### PR TITLE
chore: add PR template (repro-first)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Summary
+- 
+
+## Why
+- 
+
+## Repro / Validation
+**Command(s) run:**
+- 
+
+**Config (if applicable):**
+- 
+
+**Seed (if applicable):**
+- 
+
+## Tests
+- [ ] `PYTHONPATH=src python -m pytest -m "not slow" tests/`
+- [ ] Integration (if engine/rules changed): `PYTHONPATH=src python -m pytest tests/integration/`
+- [ ] Other:
+
+## Expected impact
+- Metrics impact (if any):
+- Runtime impact (if any):
+
+## Risk level
+- [ ] Low (docs/tests only)
+- [ ] Medium (strategy/experiments)
+- [ ] High (core rules/sim/scoring)
+
+## Checklist
+- [ ] No generated artifacts committed (`data/runs`, `data/reports`)
+- [ ] If behavior changed, tests updated/added to lock it
+- [ ] PR is focused (one concept)


### PR DESCRIPTION
## Summary
- Added GitHub PR template to standardize PR descriptions
- Template focuses on reproducibility, testing, and risk assessment

## Why
- Ensures every PR includes repro steps, tests run, and risk level
- Improves code review quality and consistency
- Documents expected impact and validation steps

## Repro / Validation
**Command(s) run:**
- Created `.github/pull_request_template.md` with standardized template

**Config (if applicable):**
- N/A

**Seed (if applicable):**
- N/A

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/` (Not needed - template only)
- [ ] Integration (if engine/rules changed): N/A
- [x] Other: Verified template file exists and content matches spec

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it (N/A - template only)
- [x] PR is focused (one concept)

## Post-merge verification
After merge, verify that new PRs auto-populate with this template.