### PR TITLE
ci: add repo linter (artifacts, boundaries, deprecated)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -23,6 +25,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
+
+      - name: Repo linter
+        run: |
+          python scripts/lint_repo.py --base origin/main --head HEAD
 
       - name: Ruff (lint + import sort)
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: ^(data/|experiments/|scripts/)
+      - id: end-of-file-fixer
+        exclude: ^(data/|experiments/|scripts/)
+      - id: check-yaml
+        exclude: ^(data/|experiments/|scripts/)
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.0
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+        exclude: ^(data/.*|experiments/.*|scripts/.*)
+
+  - repo: local
+    hooks:
+      - id: repo-linter
+        name: repo-linter
+        entry: python scripts/lint_repo.py --base origin/main --head HEAD
+        language: system
+        pass_filenames: false

--- a/docs/02_agent/AGENTS.md
+++ b/docs/02_agent/AGENTS.md
@@ -246,6 +246,16 @@ Add or update:
 - Do not write new work into `_deprecated/` (historical only).
 - Do not change core rules without adding tests.
 
+### Automated enforcement (repo linter)
+
+`scripts/lint_repo.py` enforces in CI + pre-commit:
+
+1. **No generated artifacts** under `data/runs/` or `data/reports/` (except `.gitkeep`).
+2. **Import boundaries:** `src/` must not import from `experiments/` or `tests/`.
+3. **No deprecated edits:** do not modify `experiments/_deprecated/`.
+
+If the linter blocks your commit, fix the violation or discuss with maintainers if you believe the rule should be adjusted.
+
 ---
 
 ## 9) Debug / Failure Playbook

--- a/scripts/lint_repo.py
+++ b/scripts/lint_repo.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""
+Repo linter: enforce project-specific rules that Ruff can't.
+
+Usage:
+  python scripts/lint_repo.py --base origin/main --head HEAD
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ALLOWED_ARTIFACT_FILENAMES = {".gitkeep"}
+
+
+@dataclass(frozen=True)
+class Violation:
+    rule: str
+    path: str
+    message: str
+
+
+def run_git(*args: str) -> str:
+    return subprocess.check_output(["git", *args], text=True).strip()
+
+
+def ensure_ref_exists(ref: str) -> None:
+    try:
+        subprocess.check_output(["git", "rev-parse", "--verify", ref], stderr=subprocess.DEVNULL)
+    except Exception:
+        raise SystemExit(
+            f"ERROR: git ref '{ref}' not found. "
+            f"Run: git fetch origin main (or adjust --base)."
+        )
+
+
+def list_changed_files(base: str, head: str) -> list[str]:
+    """
+    Return changed files between base..head (added/modified/renamed), excluding deletions.
+    """
+    out = run_git("diff", "--name-status", f"{base}..{head}")
+    files: list[str] = []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split(maxsplit=2)
+        status = parts[0]
+        if status.startswith("D"):
+            continue
+        # Handle rename lines: R100 old new -> take last token (new path)
+        path = parts[-1]
+        files.append(path)
+    return files
+
+
+def is_under(path: str, prefix: str) -> bool:
+    return path == prefix or path.startswith(prefix.rstrip("/") + "/")
+
+
+def check_no_generated_artifacts(changed: list[str]) -> list[Violation]:
+    violations: list[Violation] = []
+    blocked_prefixes = ["data/runs/", "data/reports/"]
+    for p in changed:
+        for pref in blocked_prefixes:
+            if is_under(p, pref):
+                name = Path(p).name
+                if name not in ALLOWED_ARTIFACT_FILENAMES:
+                    violations.append(
+                        Violation(
+                            rule="no-generated-artifacts",
+                            path=p,
+                            message=f"Do not commit generated artifacts under {pref} (except .gitkeep).",
+                        )
+                    )
+    return violations
+
+
+def _imports_from_tree(tree: ast.AST) -> set[str]:
+    mods: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                if n.name:
+                    mods.add(n.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                mods.add(node.module.split(".")[0])
+    return mods
+
+
+def check_src_no_experiments_or_tests_imports(changed: list[str], repo_root: Path) -> list[Violation]:
+    violations: list[Violation] = []
+    for p in changed:
+        if not (p.startswith("src/") and p.endswith(".py")):
+            continue
+
+        abs_path = repo_root / p
+        if not abs_path.exists():
+            # In unusual cases, a rename/move could produce a path not present in workspace.
+            continue
+
+        text = abs_path.read_text(encoding="utf-8")
+        try:
+            tree = ast.parse(text, filename=p)
+        except SyntaxError as e:
+            violations.append(
+                Violation(
+                    rule="src-import-boundary",
+                    path=p,
+                    message=f"SyntaxError while parsing imports: {e}",
+                )
+            )
+            continue
+
+        imports = _imports_from_tree(tree)
+        bad = sorted(set(imports) & {"experiments", "tests"})
+        if bad:
+            violations.append(
+                Violation(
+                    rule="src-import-boundary",
+                    path=p,
+                    message=f"src/ must not import from {bad}. Move shared code into src/ proper.",
+                )
+            )
+    return violations
+
+
+def check_no_deprecated_changes(changed: list[str]) -> list[Violation]:
+    violations: list[Violation] = []
+    for p in changed:
+        if is_under(p, "experiments/_deprecated/"):
+            violations.append(
+                Violation(
+                    rule="no-deprecated-changes",
+                    path=p,
+                    message="Do not modify experiments/_deprecated/. Create new code outside _deprecated instead.",
+                )
+            )
+    return violations
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", default="origin/main")
+    ap.add_argument("--head", default="HEAD")
+    args = ap.parse_args()
+
+    repo_root = Path(run_git("rev-parse", "--show-toplevel"))
+    os.chdir(repo_root)
+
+    ensure_ref_exists(args.base)
+
+    changed = list_changed_files(args.base, args.head)
+
+    violations: list[Violation] = []
+    violations += check_no_generated_artifacts(changed)
+    violations += check_no_deprecated_changes(changed)
+    violations += check_src_no_experiments_or_tests_imports(changed, repo_root)
+
+    if violations:
+        print("Repo linter failed:\n")
+        for v in violations:
+            print(f"- [{v.rule}] {v.path}: {v.message}")
+        print("\nFix the violations or adjust the change to comply with repo rules.")
+        return 1
+
+    print("Repo linter passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_repo_linter.py
+++ b/tests/unit/test_repo_linter.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+from scripts.lint_repo import (
+    check_no_deprecated_changes,
+    check_no_generated_artifacts,
+    check_src_no_experiments_or_tests_imports,
+)
+
+
+def test_blocks_generated_artifacts():
+    changed = ["data/runs/abc/meta.json", "data/reports/x.png"]
+    v = check_no_generated_artifacts(changed)
+    assert len(v) == 2
+
+
+def test_allows_gitkeep_in_artifact_dirs():
+    changed = ["data/runs/.gitkeep", "data/reports/.gitkeep"]
+    v = check_no_generated_artifacts(changed)
+    assert v == []
+
+
+def test_blocks_deprecated_changes():
+    changed = ["experiments/_deprecated/old_runner.py"]
+    v = check_no_deprecated_changes(changed)
+    assert len(v) == 1
+
+
+def test_blocks_src_importing_experiments(tmp_path: Path):
+    # Create a fake repo root with a src file
+    repo_root = tmp_path
+    p = repo_root / "src" / "bid_euchre" / "core"
+    p.mkdir(parents=True)
+    target = p / "cards.py"
+    target.write_text("import experiments\n", encoding="utf-8")
+
+    v = check_src_no_experiments_or_tests_imports(
+        ["src/bid_euchre/core/cards.py"],
+        repo_root,
+    )
+    assert len(v) == 1
+    assert "experiments" in v[0].message
+
+
+def test_allows_src_without_bad_imports(tmp_path: Path):
+    repo_root = tmp_path
+    p = repo_root / "src" / "bid_euchre" / "core"
+    p.mkdir(parents=True)
+    target = p / "cards.py"
+    target.write_text("import os\nfrom bid_euchre.core.cards import Card\n", encoding="utf-8")
+
+    v = check_src_no_experiments_or_tests_imports(
+        ["src/bid_euchre/core/cards.py"],
+        repo_root,
+    )
+    assert v == []


### PR DESCRIPTION
## Summary

Adds automated enforcement of key project rules via scripts/lint_repo.py, running in both CI and pre-commit hooks.

## Rules Enforced

1. **No generated artifacts**: Block commits under data/runs/ and data/reports/ (except .gitkeep)
2. **Import boundaries**: src/ must not import from experiments/ or tests/
3. **No deprecated edits**: Block changes under experiments/_deprecated/

## Changes

- Add scripts/lint_repo.py with AST-based import detection
- Add CI step with fetch-depth: 0 for origin/main access
- Add pre-commit hook for local enforcement
- Add 5 comprehensive unit tests (100% rule coverage)
- Document in AGENTS.md Section 8 (automated enforcement)

## Test Results

Repo linter: PASSED
Unit tests: 5/5 PASSED
Full suite: 197 passed, 3 xfailed

## Acceptance Criteria

- CI runs repo linter and fails on violations
- Pre-commit hook enforces locally
- Unit tests pass (all 3 rules covered)
- Documentation added to AGENTS.md
- No unrelated changes