### PR TITLE
docs: define data layout and commit policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,10 @@ data/raw/
 data/reports/
 data/processed/
 data/runs/
+data/_deprecated/
+data/hand_logs/
+data/training/
+data/models/
 
 # Experiment outputs (keep experiment scripts tracked)
 experiments/output/

--- a/data/fixtures/README.md
+++ b/data/fixtures/README.md
@@ -1,0 +1,41 @@
+# Fixtures Policy
+
+This directory contains **tiny, intentional test fixtures** that are committed to the repository.
+
+## Rules
+
+1. **Fixtures must be referenced by tests or docs**
+   - Each fixture must have a clear purpose
+   - Document where it's used (test file path or doc reference)
+
+2. **Keep fixtures small**
+   - Recommend: <100KB per file
+   - Total: <1MB for all fixtures
+   - If a fixture exceeds these limits, it probably doesn't belong here
+
+3. **Good examples** (what belongs here):
+   - Tiny deterministic deal samples (for deterministic tests)
+   - Tiny expected-summary JSON files (for output validation)
+   - Expected test outputs (small JSON/text files)
+   - Minimal config examples referenced by docs
+
+4. **Bad examples** (what does NOT belong here):
+   - Training CSVs (use `data/runs/<run_id>/` instead)
+   - Dashboards or PNGs (generated outputs)
+   - JSONL logs (generated outputs)
+   - Full run outputs (use `data/runs/<run_id>/` instead)
+   - Model binaries or pickles (generated artifacts)
+
+## Adding a new fixture
+
+When adding a fixture:
+1. Ensure it's truly needed (can't generate it in the test?)
+2. Keep it as small as possible
+3. Document its purpose here:
+
+### Current fixtures
+
+*No fixtures yet. Add entries here as fixtures are added.*
+
+**Format**:
+- `filename.ext` - Brief description, used by `path/to/test_file.py::test_name`

--- a/docs/01_core/DATA_CONTRACT.md
+++ b/docs/01_core/DATA_CONTRACT.md
@@ -7,6 +7,50 @@ If you change a schema, update the relevant doc and bump schema versions where a
 
 - **meta.json (schema v2):** see `docs/01_core/schemas/meta_json.md`
 
+## Directory Layout and Commit Policy
+
+### Target layout (end-state)
+
+```
+data/
+  fixtures/          # Committed: tiny, intentional test/doc fixtures
+  runs/              # Ignored: all experiment outputs
+    <run_id>/
+      results/       # Machine-readable outputs (json/jsonl/csv/parquet)
+      logs/          # JSONL hand logs / structured logs
+      reports/       # Charts, dashboards, analyses
+      splits/        # Train/test/val splits (if generated)
+      artifacts/     # Model binaries, intermediate artifacts (if generated)
+      meta.json      # Run metadata (schema v2)
+      perf.json      # Performance metrics (optional)
+```
+
+### Policy
+
+**The golden rule**: No generated outputs may be written outside `data/runs/<run_id>/...`
+
+**Commit policy:**
+- ✅ **Allowed**: `data/fixtures/**` only (tiny, intentional; referenced by tests/docs)
+- ❌ **Forbidden**: Any generated outputs (runs, logs, models, training data, dashboards)
+
+**Legacy paths** (present today; to be removed from git in PR #14):
+- `data/_deprecated/` - Old dashboard PNGs
+- `data/hand_logs/` - Loose experiment logs
+- `data/training/` - Training CSVs
+- `data/models/` - Model binaries / legacy models
+- `data/reports/` - Top-level aggregated reports
+
+These are now ignored for new writes, but contain tracked artifacts that will be cleaned up in a future PR.
+
+### Migration note
+
+If you have local files in legacy paths (`data/models/`, `data/training/`, etc.), they are now ignored by git. You can:
+- Keep them locally (ignored)
+- Delete them manually if no longer needed
+- Archive them externally if important
+
+Going forward, runner outputs must land under `data/runs/<run_id>/`.
+
 ## Notes
 - Keep schemas small and versioned.
 - Prefer adding new fields over deleting/renaming existing ones (backward compatibility).


### PR DESCRIPTION
## Summary

Establishes data policy to prevent future artifact leaks. Defines target end-state: only `data/fixtures/` (committed) and `data/runs/<run_id>/` (ignored). Legacy tracked artifacts will be cleaned up in PR #14.

## Changes

**1. Updated .gitignore**
Added ignore patterns for legacy output paths:
- `data/_deprecated/`
- `data/hand_logs/`
- `data/training/`
- `data/models/`

**2. Updated DATA_CONTRACT.md**
Added "Directory Layout and Commit Policy" section defining:
- Target layout (fixtures + runs only)
- Golden rule: no generated outputs outside `data/runs/<run_id>/`
- Commit policy (fixtures allowed, all generated outputs forbidden)
- Legacy paths documentation (to be cleaned in PR #14)

**3. Created data/fixtures/**
- Created `data/fixtures/README.md` with fixtures policy
- Size limits: <100KB/file, <1MB total
- Each fixture must be referenced by tests/docs

## Acceptance Criteria

✅ **make check**: PASSED
```
195 passed, 3 skipped, 1 deselected, 2 xfailed, 1 xpassed in 13.04s
✓ All checks passed
```

✅ **Tiny experiment**: PASSED
```bash
PYTHONPATH=src python experiments/run_experiment.py \
  --config experiments/configs/quick_test.yaml \
  --seed 42 \
  --n_per 50
```
Created run: `data/runs/quick_test_42_20260105_185420/`

✅ **Ignore verification**: PASSED
```bash
git status --porcelain | grep "^??" | grep "data/runs" && echo "FAIL" || echo "PASS"
# Output: PASS: Ignores working
```

New run outputs are correctly ignored. Tracked legacy files remain in git history (will be cleaned in PR #14).

## Related

- Sets foundation for PR #14 (artifact cleanup)
- Prevents new data leaks immediately
- Does NOT remove existing tracked artifacts (policy only)