### PR TITLE
ci: enforce data fixtures allowlist and size limits

### DIFF
--- a/scripts/lint_repo.py
+++ b/scripts/lint_repo.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 
 ALLOWED_ARTIFACT_FILENAMES = {".gitkeep"}
+FIXTURE_SIZE_LIMIT_BYTES = 102400  # 100KB
 
 
 @dataclass(frozen=True)
@@ -146,6 +147,49 @@ def check_no_deprecated_changes(changed: list[str]) -> list[Violation]:
     return violations
 
 
+def check_data_fixtures_allowlist(changed: list[str], repo_root: Path) -> list[Violation]:
+    """
+    Enforce that only data/fixtures/** and data/.gitkeep may be committed under data/.
+    Also enforce 100KB size limit on fixtures.
+    """
+    violations: list[Violation] = []
+    for p in changed:
+        if not is_under(p, "data/"):
+            continue
+
+        # Check if allowlisted
+        is_gitkeep = p == "data/.gitkeep"
+        is_fixture = is_under(p, "data/fixtures/")
+
+        if not (is_gitkeep or is_fixture):
+            # Block everything else under data/
+            violations.append(
+                Violation(
+                    rule="data-fixtures-allowlist",
+                    path=p,
+                    message=f"{p} is not allowed (only data/fixtures/** and data/.gitkeep may be committed)",
+                )
+            )
+            continue
+
+        # Check fixture size limit
+        if is_fixture:
+            abs_path = repo_root / p
+            if abs_path.exists():
+                size_bytes = abs_path.stat().st_size
+                if size_bytes > FIXTURE_SIZE_LIMIT_BYTES:
+                    size_kb = (size_bytes + 1023) // 1024  # Round up
+                    violations.append(
+                        Violation(
+                            rule="data-fixtures-allowlist",
+                            path=p,
+                            message=f"data/fixtures/{Path(p).name} exceeds 100KB limit (size: {size_kb}KB, limit: 100KB)",
+                        )
+                    )
+
+    return violations
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--base", default="origin/main")
@@ -163,6 +207,7 @@ def main() -> int:
     violations += check_no_generated_artifacts(changed)
     violations += check_no_deprecated_changes(changed)
     violations += check_src_no_experiments_or_tests_imports(changed, repo_root)
+    violations += check_data_fixtures_allowlist(changed, repo_root)
 
     if violations:
         print("Repo linter failed:\n")

--- a/tests/unit/test_repo_linter.py
+++ b/tests/unit/test_repo_linter.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from scripts.lint_repo import (
+    check_data_fixtures_allowlist,
     check_no_deprecated_changes,
     check_no_generated_artifacts,
     check_src_no_experiments_or_tests_imports,
@@ -52,4 +53,103 @@ def test_allows_src_without_bad_imports(tmp_path: Path):
         ["src/bid_euchre/core/cards.py"],
         repo_root,
     )
+    assert v == []
+
+
+def test_data_allowlist_blocks_runs(tmp_path: Path):
+    """Block files under data/runs/"""
+    changed = ["data/runs/example/meta.json"]
+    v = check_data_fixtures_allowlist(changed, tmp_path)
+    assert len(v) == 1
+    assert "not allowed" in v[0].message
+    assert "data/fixtures/**" in v[0].message
+
+
+def test_data_allowlist_blocks_training(tmp_path: Path):
+    """Block files under data/training/"""
+    changed = ["data/training/foo.csv"]
+    v = check_data_fixtures_allowlist(changed, tmp_path)
+    assert len(v) == 1
+    assert "not allowed" in v[0].message
+
+
+def test_data_allowlist_blocks_reports(tmp_path: Path):
+    """Block files under data/reports/"""
+    changed = ["data/reports/foo.png"]
+    v = check_data_fixtures_allowlist(changed, tmp_path)
+    assert len(v) == 1
+    assert "not allowed" in v[0].message
+
+
+def test_data_allowlist_blocks_deprecated(tmp_path: Path):
+    """Block files under data/_deprecated/"""
+    changed = ["data/_deprecated/foo.png"]
+    v = check_data_fixtures_allowlist(changed, tmp_path)
+    assert len(v) == 1
+    assert "not allowed" in v[0].message
+
+
+def test_data_allowlist_allows_small_fixture(tmp_path: Path):
+    """Allow small fixtures under data/fixtures/"""
+    repo_root = tmp_path
+    fixture_dir = repo_root / "data" / "fixtures"
+    fixture_dir.mkdir(parents=True)
+    fixture_file = fixture_dir / "example.json"
+    fixture_file.write_text('{"test": "data"}', encoding="utf-8")  # ~16 bytes
+
+    v = check_data_fixtures_allowlist(["data/fixtures/example.json"], repo_root)
+    assert v == []
+
+
+def test_data_allowlist_blocks_oversized_fixture(tmp_path: Path):
+    """Block fixtures exceeding 100KB"""
+    repo_root = tmp_path
+    fixture_dir = repo_root / "data" / "fixtures"
+    fixture_dir.mkdir(parents=True)
+    fixture_file = fixture_dir / "oversize.bin"
+    fixture_file.write_bytes(b"x" * 150000)  # 150KB
+
+    v = check_data_fixtures_allowlist(["data/fixtures/oversize.bin"], repo_root)
+    assert len(v) == 1
+    assert "exceeds 100KB limit" in v[0].message
+    assert "147KB" in v[0].message  # 150000 / 1024 = 146.48, rounds up to 147
+
+
+def test_data_allowlist_allows_empty_fixture(tmp_path: Path):
+    """Allow empty fixture files (0 bytes)"""
+    repo_root = tmp_path
+    fixture_dir = repo_root / "data" / "fixtures"
+    fixture_dir.mkdir(parents=True)
+    fixture_file = fixture_dir / "empty.json"
+    fixture_file.write_text("", encoding="utf-8")  # 0 bytes
+
+    v = check_data_fixtures_allowlist(["data/fixtures/empty.json"], repo_root)
+    assert v == []
+
+
+def test_data_allowlist_allows_gitkeep(tmp_path: Path):
+    """Allow data/.gitkeep"""
+    changed = ["data/.gitkeep"]
+    v = check_data_fixtures_allowlist(changed, tmp_path)
+    assert v == []
+
+
+def test_data_allowlist_allows_subdirectory_fixtures(tmp_path: Path):
+    """Allow fixtures in subdirectories under data/fixtures/"""
+    repo_root = tmp_path
+    fixture_dir = repo_root / "data" / "fixtures" / "deals"
+    fixture_dir.mkdir(parents=True)
+    fixture_file = fixture_dir / "example.json"
+    fixture_file.write_text('{"deal": "data"}', encoding="utf-8")
+
+    v = check_data_fixtures_allowlist(["data/fixtures/deals/example.json"], repo_root)
+    assert v == []
+
+
+def test_data_allowlist_handles_deleted_files(tmp_path: Path):
+    """Deleted files don't exist in working tree, should not fail size check"""
+    # Simulate a changed file that doesn't exist (deleted or not yet created)
+    changed = ["data/fixtures/deleted.json"]
+    v = check_data_fixtures_allowlist(changed, tmp_path)
+    # Should pass because file doesn't exist (no size to check)
     assert v == []


### PR DESCRIPTION
## Summary

This PR adds a new repo-linter rule to prevent accidental commits of generated artifacts under `data/`. Only `data/fixtures/**` (with size limits) and `data/.gitkeep` are allowed to be committed.

## Changes

**New repo-linter rule: `data-fixtures-allowlist`**
- Blocks any ADDED or MODIFIED file under `data/**` except:
  - `data/fixtures/**` - Allowed fixtures directory
  - `data/.gitkeep` - Repository placeholder
- Enforces **100KB size limit** on fixture files (matching `data/fixtures/README.md` policy)
- Deletions are always allowed (no blocking)

**Error messages:**
- Blocked path: `"<path> is not allowed (only data/fixtures/** and data/.gitkeep may be committed)"`
- Oversized fixture: `"<path> exceeds 100KB limit (size: <actual>KB, limit: 100KB)"`

## Tests Added

Added 10 new tests in `tests/unit/test_repo_linter.py`:
- ✅ Block files under `data/runs/`, `data/training/`, `data/reports/`, `data/_deprecated/`
- ✅ Allow small fixtures under `data/fixtures/`
- ✅ Block oversized fixtures (>100KB)
- ✅ Allow empty fixtures (0 bytes)
- ✅ Allow `data/.gitkeep`
- ✅ Allow fixtures in subdirectories (`data/fixtures/deals/example.json`)
- ✅ Handle deleted files correctly

## Verification

**Commands run:**
```bash
make repo-lint  # ✅ PASSED (on clean tree)
make check      # ✅ PASSED (205 passed, 3 skipped)
```

**Manual verification:**
- ✅ Created file under `data/test_manual/` → repo-lint correctly blocked it
- ✅ Created 150KB file under `data/fixtures/` → repo-lint correctly blocked it with size error

## Impact

This makes it impossible to accidentally commit generated artifacts under `data/`, completing the data policy enforcement started in PRs #13 and #14.

- CI will fail if any PR attempts to commit files outside `data/fixtures/**` and `data/.gitkeep`
- Fixtures exceeding 100KB will be rejected
- Works in both CI and local pre-commit hooks