### PR TITLE
ci: block new scripts in experiments comparisons and training folders

### DIFF
--- a/experiments/comparisons/README.md
+++ b/experiments/comparisons/README.md
@@ -2,6 +2,8 @@
 
 **Status**: This folder contains backward-compatibility wrappers that forward to the unified runner.
 
+⚠️ **Do not add new scripts to this folder.** Use configs + the canonical runner instead.
+
 ## Current Contents
 
 - **`run_head_to_head.py`** - Deprecated wrapper for head-to-head matchups
@@ -12,11 +14,18 @@
 
 For reproducible experiments, always use:
 
+**Single run:**
 ```bash
 PYTHONPATH=src python experiments/run_experiment.py \
   --config experiments/configs/<config>.yaml \
   --seed 42 \
   --n_per 100
+```
+
+**Suite run (coming soon):**
+```bash
+PYTHONPATH=src python scripts/run_suite.py \
+  --suite experiments/suites/<suite>.yaml
 ```
 
 ## Output Contract

--- a/experiments/training/README.md
+++ b/experiments/training/README.md
@@ -2,11 +2,14 @@
 
 **Status**: This folder contains current, blessed training scripts.
 
+⚠️ **Do not add new scripts to this folder.** Future training should be config-driven with a single blessed entrypoint.
+
 ## Current Contents
 
 - **`train_bidder_aware_models.py`** - Train bidder-aware regression models (OLSa_v2, OLSa_SR_v2)
   - Includes `is_bidder` feature for positional awareness
   - Supersedes all legacy training scripts in `_deprecated/training/`
+  - **Note**: This is a legacy script; future training workflows should write to `data/runs/<run_id>/`
 
 ## Usage
 
@@ -15,6 +18,24 @@ Train models with explicit configuration:
 ```bash
 PYTHONPATH=src python experiments/training/train_bidder_aware_models.py \
   --config experiments/configs/train_bidder_models.yaml
+```
+
+## Canonical Workflow (Future)
+
+Future training should follow the same pattern as experiments:
+
+**Single run:**
+```bash
+PYTHONPATH=src python experiments/run_experiment.py \
+  --config experiments/configs/<config>.yaml \
+  --seed 42 \
+  --n_per 100
+```
+
+**Suite run (coming soon):**
+```bash
+PYTHONPATH=src python scripts/run_suite.py \
+  --suite experiments/suites/<suite>.yaml
 ```
 
 ## Output Contract

--- a/scripts/lint_repo.py
+++ b/scripts/lint_repo.py
@@ -212,6 +212,71 @@ def check_data_fixtures_allowlist(changed: list[str], repo_root: Path) -> list[V
     return violations
 
 
+def check_no_new_scripts_in_frozen_folders(changed: list[str]) -> list[Violation]:
+    """
+    Block new Python scripts in experiments/comparisons/ and experiments/training/.
+    These folders are frozen to prevent workflow sprawl.
+    
+    Allowlist:
+    - experiments/comparisons/run_head_to_head.py (existing wrapper)
+    - experiments/training/train_bidder_aware_models.py (existing training script)
+    - Any README.md files (documentation)
+    - Any __init__.py files (package markers)
+    """
+    FROZEN_FOLDERS = [
+        "experiments/comparisons/",
+        "experiments/training/",
+    ]
+    
+    ALLOWLIST = {
+        "experiments/comparisons/run_head_to_head.py",
+        "experiments/training/train_bidder_aware_models.py",
+    }
+    
+    violations: list[Violation] = []
+    for p in changed:
+        # Check if under frozen folders
+        in_frozen_folder = any(is_under(p, folder) for folder in FROZEN_FOLDERS)
+        if not in_frozen_folder:
+            continue
+        
+        # Allow README.md files
+        if p.endswith("README.md"):
+            continue
+        
+        # Allow __init__.py files
+        if p.endswith("__init__.py"):
+            continue
+        
+        # Allow allowlisted scripts
+        if p in ALLOWLIST:
+            continue
+        
+        # Check if this is a new Python file (added or renamed into folder)
+        if not p.endswith(".py"):
+            continue
+        
+        # Check git status to see if this is a new file
+        status = subprocess.run(
+            ["git", "diff", "--name-status", "origin/main...HEAD", "--", p],
+            capture_output=True,
+            text=True
+        ).stdout.strip()
+        
+        # Block additions (A) and renames (R) into frozen folders
+        if status.startswith(("A", "R")):
+            folder_name = "comparisons" if "comparisons" in p else "training"
+            violations.append(
+                Violation(
+                    rule="no-frozen-folder-sprawl",
+                    path=p,
+                    message=f"Do not add new scripts to experiments/{folder_name}/. Use configs + experiments/run_experiment.py (or suites) instead.",
+                )
+            )
+    
+    return violations
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--base", default="origin/main")
@@ -230,6 +295,7 @@ def main() -> int:
     violations += check_no_deprecated_changes(changed)
     violations += check_src_no_experiments_or_tests_imports(changed, repo_root)
     violations += check_data_fixtures_allowlist(changed, repo_root)
+    violations += check_no_new_scripts_in_frozen_folders(changed)
 
     if violations:
         print("Repo linter failed:\n")


### PR DESCRIPTION
## Roadmap Context

**This is Roadmap PR D** — Block new scripts in frozen folders to prevent sprawl

**Roadmap sequence**: PR A (docs, #20) → PR B (quarantine, #21) → PR B2 (delete, #22) → **PR D (this)** → PR C (determinism test) → PRs #19-21 (baseline suite)

---

## Summary

Add repo-linter rule to prevent workflow sprawl while we ship determinism + baseline suites. The rule blocks new Python scripts from being added to `experiments/comparisons/` and `experiments/training/`, keeping a single canonical workflow.

**Result**: Anti-sprawl guardrails in place, canonical runner remains `experiments/run_experiment.py`.

---

## Linter Rule Added

**New check**: `check_no_new_scripts_in_frozen_folders()`

**Blocks**: New Python scripts (git status `A` or `R`) in:
- `experiments/comparisons/`
- `experiments/training/`

**Allowlist** (existing scripts that are OK):
- `experiments/comparisons/run_head_to_head.py` (deprecated wrapper)
- `experiments/training/train_bidder_aware_models.py` (legacy training script)
- Any `README.md` files (documentation allowed)
- Any `__init__.py` files (package markers allowed)

**Violation message**: `Do not add new scripts to experiments/{folder}/. Use configs + experiments/run_experiment.py (or suites) instead.`

---

## README Updates (Minimal)

Both READMEs existed from PR B. Added minimal "do not add scripts" warnings:

**`experiments/comparisons/README.md`**:
- Added: ⚠️ "Do not add new scripts to this folder" warning
- Added: Reference to upcoming suites workflow
- Kept: Existing wrapper documentation and canonical workflow

**`experiments/training/README.md`**:
- Added: ⚠️ "Do not add new scripts to this folder" warning
- Added: Note that existing script is legacy (future should be config-driven)
- Added: Reference to canonical workflow and upcoming suites

---

## Why This Rule

**Problem**: Without enforcement, agents and contributors might:
- Add one-off comparison scripts to `experiments/comparisons/`
- Add new training scripts to `experiments/training/`
- Bypass the canonical `run_experiment.py` + configs workflow

**Solution**: Linter blocks new scripts in these folders, forcing use of:
- Configs: `experiments/configs/*.yaml`
- Canonical runner: `experiments/run_experiment.py`
- Suites (coming soon): `scripts/run_suite.py` + `experiments/suites/*.yaml`

**Allowlist**: Existing wrapper and training script are grandfathered in (already deprecated/legacy).

---

## Verification

✅ **make check**: PASSED

```
>>> Repo linter: ✓ Passed
>>> Ruff: All checks passed!
>>> Pytest: 226 passed, 3 skipped, 1 deselected, 2 xfailed, 1 xpassed
✓ All checks passed
```

✅ **Canonical workflows unchanged**

✅ **No runtime behavior changes** — Policy-only change

---

## Canonical Workflow (Now Referenced in READMEs)

**Single run:**
```bash
PYTHONPATH=src python experiments/run_experiment.py \
  --config experiments/configs/<config>.yaml \
  --seed 42 \
  --n_per 100
```

**Suite run (coming soon):**
```bash
PYTHONPATH=src python scripts/run_suite.py \
  --suite experiments/suites/<suite>.yaml
```

---

## Changes Summary

- **Linter rule added**: 1 new check function (`check_no_new_scripts_in_frozen_folders`)
- **Frozen folders**: 2 (`experiments/comparisons/`, `experiments/training/`)
- **Allowlisted scripts**: 2 (wrapper + training)
- **READMEs updated**: 2 (minimal additions only)
- **No code changes**: Zero functional changes to canonical workflows