### PR TITLE
chore: fix report generator command printed by runner

### DIFF
--- a/experiments/run_experiment.py
+++ b/experiments/run_experiment.py
@@ -536,8 +536,8 @@ def main():
     print(f"📊 Generated {plan_count * len(scenarios)} result files")
     
     print("\n🎯 Next steps:")
-    print(f"   # Generate all reports:")
-    print(f"   PYTHONPATH=src python experiments/generate_all_reports.py \\")
+    print(f"   # Generate reports:")
+    print(f"   PYTHONPATH=src python scripts/generate_report.py \\")
     print(f"       --run-dir {run_dir}")
     print()
     
@@ -547,7 +547,7 @@ def main():
         try:
             import subprocess
             result = subprocess.run(
-                ["python", "experiments/generate_all_reports.py", "--run-dir", run_dir],
+                ["python", "scripts/generate_report.py", "--run-dir", run_dir],
                 env={**os.environ, "PYTHONPATH": "src"},
                 capture_output=True,
                 text=True
@@ -558,7 +558,7 @@ def main():
                 print("⚠️  Report generation encountered issues (run manually)")
         except Exception as e:
             print(f"⚠️  Could not auto-generate reports: {e}")
-            print(f"   Run manually: PYTHONPATH=src python experiments/generate_all_reports.py --run-dir {run_dir}")
+            print(f"   Run manually: PYTHONPATH=src python scripts/generate_report.py --run-dir {run_dir}")
         print()
 
 

--- a/scripts/run_suite.py
+++ b/scripts/run_suite.py
@@ -184,7 +184,7 @@ def run_experiment(
             text=True,
             check=True
         )
-        # Note: run_experiment.py may print deprecated generate_all_reports commands
+        # Note: run_experiment.py prints canonical report generation commands
         # These can be ignored; we use scripts/generate_report.py
     except subprocess.CalledProcessError as e:
         print(f"\n❌ Experiment failed: {config_path}", file=sys.stderr)


### PR DESCRIPTION
## Summary

Fixes a user-facing footgun where the experiment runner printed and attempted to call a deprecated/non-existent report generator script.

## Changes

**Updated in `experiments/run_experiment.py`**:
- Printed "next steps" guidance now shows `scripts/generate_report.py` (not `experiments/generate_all_reports.py`)
- Auto-generation subprocess call now uses `scripts/generate_report.py`
- Error message fallback now shows correct command

**Updated in `scripts/run_suite.py`**:
- Comment updated to reflect that runner now prints correct commands

## What Did NOT Change

- ✅ No simulation logic changes
- ✅ No metrics or output contract changes
- ✅ No changes to run directory layout
- ✅ No changes to report generator implementation

This is purely a messaging fix to prevent agents/users from copying broken commands.

## Validation

```bash
make check  # ✅ 229 passed, 3 skipped, 2 xfailed, 1 xpassed
```

**Grep verification**:
```bash
grep -r "generate_all_reports" --include="*.py" --exclude-dir=".git" .
# Returns: only references in _deprecated/ folder (expected)
```

**Visual check**:
Runner now prints:
```
🎯 Next steps:
   # Generate reports:
   PYTHONPATH=src python scripts/generate_report.py \
       --run-dir <RUN_DIR>
```

## Files Changed

- `experiments/run_experiment.py` (3 locations updated)
- `scripts/run_suite.py` (1 comment updated)