### PR TITLE
feat: add points scoring aggregates to simulation results

### DIFF
--- a/src/bid_euchre/scoring.py
+++ b/src/bid_euchre/scoring.py
@@ -1,0 +1,57 @@
+"""
+Points-based scoring utilities for Bid Euchre.
+
+This module provides deterministic scoring calculations for bid euchre games.
+"""
+
+from typing import Optional
+
+
+def compute_points(
+    winning_bid: Optional[int],
+    bidder_position: Optional[int],
+    tricks_team0: int,
+    tricks_team1: int,
+) -> tuple[int, int]:
+    """
+    Compute points for both teams based on euchre scoring rules.
+
+    Args:
+        winning_bid: The winning bid amount, or None if no bidding occurred
+        bidder_position: The seat position (0-3) of the winning bidder, or None if no bidding
+        tricks_team0: Number of tricks taken by team 0 (seats 0, 2)
+        tricks_team1: Number of tricks taken by team 1 (seats 1, 3)
+
+    Returns:
+        Tuple of (points_team0, points_team1)
+
+    Scoring rules:
+    - If no bidding occurred (winning_bid or bidder_position is None):
+      Both teams get their tricks taken as points
+    - If bid team makes the bid (bid_team_tricks >= winning_bid):
+      Bid team gets their tricks taken, non-bid team gets their tricks taken
+    - If bid team gets set (bid_team_tricks < winning_bid):
+      Bid team gets -winning_bid, non-bid team gets their tricks taken
+    """
+    # No bidding case: both teams get their tricks
+    if winning_bid is None or bidder_position is None:
+        return tricks_team0, tricks_team1
+
+    # Determine which team made the bid
+    bid_team_is_team0 = bidder_position in (0, 2)
+    bid_team_tricks = tricks_team0 if bid_team_is_team0 else tricks_team1
+    non_bid_team_tricks = tricks_team1 if bid_team_is_team0 else tricks_team0
+
+    if bid_team_tricks >= winning_bid:
+        # Bid made: bid team gets their tricks, non-bid team gets their tricks
+        if bid_team_is_team0:
+            return bid_team_tricks, non_bid_team_tricks
+        else:
+            return non_bid_team_tricks, bid_team_tricks
+    else:
+        # Bid set: bid team gets -winning_bid, non-bid team gets their tricks
+        negative_bid = -winning_bid
+        if bid_team_is_team0:
+            return negative_bid, non_bid_team_tricks
+        else:
+            return non_bid_team_tricks, negative_bid

--- a/src/bid_euchre/sim/simulation.py
+++ b/src/bid_euchre/sim/simulation.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 from ..core.cards import Card, create_deck, deal_hands, shuffle_deck
 from ..core.rules import get_legal_indices, trick_winner
 from ..features.hand_eval import get_hand_features, score_hand
+from ..scoring import compute_points
 from ..strategy import GreedyStrategy, Strategy
 from .deals import generate_deal, generate_initial_leader
 
@@ -283,6 +284,19 @@ def simulate_many_hands(
     total1 = 0
     total_score_all = 0  # sum across all 4 players
 
+    # Points-based scoring aggregates
+    total_points_team0 = 0
+    total_points_team1 = 0
+    # Points distributions allow negative values (for sets), so we use dicts
+    dist_points_team0: Dict[int, int] = {}
+    dist_points_team1: Dict[int, int] = {}
+
+    # Bidding-related tracking (only when bidding occurred)
+    hands_with_bids = 0
+    bid_values: List[int] = []
+    made_count = 0
+    set_count = 0
+
     # score -> stats dict (aggregated across all players)
     score_buckets: Dict[int, Dict[str, float]] = {}
 
@@ -336,6 +350,23 @@ def simulate_many_hands(
         total1 += t1
         dist_team0[t0] += 1
 
+        # Compute and track points-based scoring
+        points_team0, points_team1 = compute_points(winning_bid, bidder_pos, t0, t1)
+        total_points_team0 += points_team0
+        total_points_team1 += points_team1
+        dist_points_team0[points_team0] = dist_points_team0.get(points_team0, 0) + 1
+        dist_points_team1[points_team1] = dist_points_team1.get(points_team1, 0) + 1
+
+        # Track bidding-related stats only when bidding occurred
+        if winning_bid is not None and bidder_pos is not None:
+            hands_with_bids += 1
+            bid_values.append(winning_bid)
+            bid_team_tricks = t0 if bidder_pos in (0, 2) else t1
+            if bid_team_tricks >= winning_bid:
+                made_count += 1
+            else:
+                set_count += 1
+
         # Process ALL 4 players' features
         for player_idx in range(4):
             # Determine this player's team's tricks
@@ -377,6 +408,19 @@ def simulate_many_hands(
             else:
                 stats["avg_tricks"] = 0.0
 
+    # Build bidding_points object
+    bidding_points = {
+        "enabled": hands_with_bids > 0,
+        "hands_with_bids": hands_with_bids,
+    }
+    if hands_with_bids > 0:
+        bidding_points.update({
+            "avg_bid": sum(bid_values) / len(bid_values),
+            "bid_distribution": {bid: bid_values.count(bid) for bid in set(bid_values)},
+            "make_rate": made_count / hands_with_bids,
+            "set_rate": set_count / hands_with_bids,
+        })
+
     return {
         "hands": n,
         "contract_type": contract_type,
@@ -388,6 +432,12 @@ def simulate_many_hands(
         "score_buckets": score_buckets,
         "feature_buckets": feature_buckets,
         "player_samples": player_samples,
+        # New points-based scoring aggregates
+        "avg_points_team0": total_points_team0 / n,
+        "avg_points_team1": total_points_team1 / n,
+        "distribution_points_team0": dist_points_team0,
+        "distribution_points_team1": dist_points_team1,
+        "bidding_points": bidding_points,
         # Backward compatibility aliases
         "avg_score_player0": total_score_all / player_samples if player_samples > 0 else 0,
         "score_buckets_player0": score_buckets,

--- a/tests/integration/test_simulation_validation.py
+++ b/tests/integration/test_simulation_validation.py
@@ -29,7 +29,9 @@ class TestSimulationStatistics:
             # Backward compatibility aliases
             "avg_score_player0", "score_buckets_player0", "feature_buckets_player0"
         }
-        assert set(results.keys()) == expected_keys
+        # Results schema is additive; tests should not fail on new keys.
+        missing = expected_keys - set(results.keys())
+        assert not missing, f"Missing expected keys: {sorted(missing)}"
         # Verify player_samples is 4x hands (all 4 players tracked)
         assert results["player_samples"] == results["hands"] * 4
 

--- a/tests/unit/test_scoring_points.py
+++ b/tests/unit/test_scoring_points.py
@@ -1,0 +1,87 @@
+"""
+Unit tests for points-based scoring in Bid Euchre.
+
+Tests the compute_points() function with exact integer results.
+"""
+
+from bid_euchre.scoring import compute_points
+
+
+class TestComputePoints:
+    """Test compute_points() function with exact test cases."""
+
+    def test_no_bid_case(self):
+        """Test case with no bidding: both teams get their tricks."""
+        points_team0, points_team1 = compute_points(None, None, 6, 4)
+        assert points_team0 == 6
+        assert points_team1 == 4
+        assert isinstance(points_team0, int)
+        assert isinstance(points_team1, int)
+
+    def test_team0_makes_bid(self):
+        """Test case where team 0 makes their bid."""
+        points_team0, points_team1 = compute_points(6, 0, 8, 2)
+        assert points_team0 == 8
+        assert points_team1 == 2
+        assert isinstance(points_team0, int)
+        assert isinstance(points_team1, int)
+
+    def test_team0_gets_set(self):
+        """Test case where team 0 gets set."""
+        points_team0, points_team1 = compute_points(6, 2, 5, 5)
+        assert points_team0 == -6
+        assert points_team1 == 5
+        assert isinstance(points_team0, int)
+        assert isinstance(points_team1, int)
+
+    def test_team1_makes_bid(self):
+        """Test case where team 1 makes their bid."""
+        points_team0, points_team1 = compute_points(7, 1, 3, 7)
+        assert points_team0 == 3
+        assert points_team1 == 7
+        assert isinstance(points_team0, int)
+        assert isinstance(points_team1, int)
+
+    def test_team1_gets_set(self):
+        """Test case where team 1 gets set."""
+        points_team0, points_team1 = compute_points(8, 3, 6, 4)
+        assert points_team0 == 6
+        assert points_team1 == -8
+        assert isinstance(points_team0, int)
+        assert isinstance(points_team1, int)
+
+    def test_no_bidder_position_none(self):
+        """Test case with winning_bid but bidder_position None (should treat as no bid)."""
+        points_team0, points_team1 = compute_points(6, None, 8, 2)
+        assert points_team0 == 8
+        assert points_team1 == 2
+
+    def test_winning_bid_none_with_bidder(self):
+        """Test case with bidder_position but winning_bid None (should treat as no bid)."""
+        points_team0, points_team1 = compute_points(None, 0, 8, 2)
+        assert points_team0 == 8
+        assert points_team1 == 2
+
+    def test_edge_case_minimum_bid(self):
+        """Test edge case with minimum bid of 6."""
+        # Team 0 makes minimum bid
+        points_team0, points_team1 = compute_points(6, 0, 6, 4)
+        assert points_team0 == 6
+        assert points_team1 == 4
+
+        # Team 0 gets set on minimum bid
+        points_team0, points_team1 = compute_points(6, 2, 5, 5)
+        assert points_team0 == -6
+        assert points_team1 == 5
+
+    def test_edge_case_maximum_tricks(self):
+        """Test edge case with maximum tricks (10 total)."""
+        # Team 0 makes bid with 10 tricks
+        points_team0, points_team1 = compute_points(6, 0, 10, 0)
+        assert points_team0 == 10
+        assert points_team1 == 0
+
+        # No bid case with 10 tricks
+        points_team0, points_team1 = compute_points(None, None, 10, 0)
+        assert points_team0 == 10
+        assert points_team1 == 0


### PR DESCRIPTION
## Summary
- Add deterministic points-based scoring aggregates to `simulate_many_hands()` results
- New JSON keys: `avg_points_team0`, `avg_points_team1`, `distribution_points_team0`, `distribution_points_team1`, `bidding_points`
- Implement scoring rules: bid team gets tricks if made, negative bid if set; non-bid team always gets tricks

## Scope
**Intended files/areas touched (be explicit):**
- `src/bid_euchre/scoring.py` (new `compute_points()`)
- `src/bid_euchre/sim/simulation.py` (points tracking + aggregates)
- `tests/integration/test_simulation_validation.py` (allow additive keys)
- `tests/unit/test_scoring_points.py` (unit tests)

**Non-goals / explicitly not touched:**
- No changes to gameplay, dealing, trick resolution, RNG, or existing metrics
- No new CLI tools, reports, or experiment runners
- Backward compatible: only additive JSON keys

## Repro / Validation
**Command(s) run:**
- `make check`
- `PYTHONPATH=src python experiments/run_experiment.py --config experiments/configs/quick_test.yaml --seed 42 --n_per 1 --log-level none --run-dir /tmp/pr29_check`

**Config (if applicable):**
- `experiments/configs/quick_test.yaml`

**Seed (if applicable):**
- `42`

## Tests
- [x] `PYTHONPATH=.:src python -m pytest -m "not slow" tests/`
- [x] Integration: `PYTHONPATH=.:src python -m pytest tests/integration/`

## Branch & Diff Hygiene (Required)
- [x] Branch created from `origin/main`
- [x] Diff vs `origin/main` matches Scope (4 files only)
- [x] No unrelated changes

## Expected impact
- Metrics impact: adds points-based aggregates to results JSON
- Runtime impact: minimal (extra counters/means only)

## Risk level
- [x] High (core sim/scoring surface area)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] Behavior change locked with tests
- [x] PR is focused (one concept)
