### PR TITLE
docs: fix SCORING.md and DATA_CONTRACT.md ambiguity and brittle references

### DIFF
--- a/docs/01_core/DATA_CONTRACT.md
+++ b/docs/01_core/DATA_CONTRACT.md
@@ -34,14 +34,14 @@ data/
 - ✅ **Allowed**: `data/fixtures/**` only (tiny, intentional; referenced by tests/docs)
 - ❌ **Forbidden**: Any generated outputs (runs, logs, models, training data, dashboards)
 
-**Legacy paths** (present today; to be removed from git in PR #14):
+**Legacy paths** (may exist locally; no longer tracked):
 - `data/_deprecated/` - Old dashboard PNGs
 - `data/hand_logs/` - Loose experiment logs
 - `data/training/` - Training CSVs
 - `data/models/` - Model binaries / legacy models
 - `data/reports/` - Top-level aggregated reports
 
-These are now ignored for new writes, but contain tracked artifacts that will be cleaned up in a future PR.
+These paths are now ignored by git. Do not write new outputs to these locations.
 
 ### Migration note
 

--- a/docs/01_core/SCORING.md
+++ b/docs/01_core/SCORING.md
@@ -16,8 +16,8 @@ Results JSON includes the following scoring/points-related fields:
 
 ### bidding_points Object (Always Present)
 
-- **`enabled`** (boolean): `true` if any hands in the scenario involved bidding, `false` otherwise
-- **`hands_with_bids`** (integer): Count of hands where bidding occurred
+- **`enabled`** (boolean): `true` if any hands had actual bidding activity (`hands_with_bids > 0`), `false` otherwise. Note: Auction mode can be configured but still result in `enabled: false` if all players pass in every hand.
+- **`hands_with_bids`** (integer): Count of hands where at least one player placed a bid (did not pass)
 
 #### Conditional Subfields (Present Only When `hands_with_bids > 0`)
 
@@ -30,25 +30,30 @@ Results JSON includes the following scoring/points-related fields:
 
 Point calculations follow euchre scoring rules as implemented in `src/bid_euchre/scoring.py`:
 
-- **No bidding case**: Both teams receive their trick count as points
-- **Bid made case**: Both teams receive their trick count as points (bid team gets reward for making contract)
-- **Bid set case**: Bid team receives negative bid amount (penalty), non-bid team receives their trick count
+**Scenario types:**
+- **Fixed contract** (no auction): `contract_type` is a fixed value ("suit", "high", or "low") specified in configuration. All hands play with this predetermined contract.
+- **Auction mode**: `contract_type` is `null` in configuration. Each hand runs a bidding phase to determine the contract and bidder.
+
+**Scoring rules (from `src/bid_euchre/scoring.py::compute_points`):**
+- **Fixed contract case**: Both teams receive their trick count as points
+- **Bid made case**: Bid team receives their trick count; non-bid team receives their trick count
+- **Bid set case**: Bid team receives negative bid amount (penalty); non-bid team receives their trick count
 
 Sign conventions:
 - Positive points: Tricks taken (both teams) or successful bid completion
-- Negative points: Failed bid penalty (only applied to bidding team when set)
+- Negative points: Failed bid penalty (only applied to bid team when set)
 - Zero points: Possible but rare (team takes 0 tricks)
 
 ## Where Computed/Emitted
 
-- **Point calculation per hand**: `src/bid_euchre/scoring.py` `compute_points()` function
-- **Aggregation and distribution tracking**: `src/bid_euchre/sim/simulation.py` `run_scenario()` function (lines 354-440)
-- **bidding_points object assembly**: `src/bid_euchre/sim/simulation.py` `run_scenario()` function (lines 411-422)
-- **Results JSON emission**: `src/bid_euchre/sim/simulation.py` `run_scenario()` function return statement (lines 424-445)
+- **Point calculation per hand**: `src/bid_euchre/scoring.py::compute_points`
+- **Aggregation and distribution tracking**: `src/bid_euchre/sim/simulation.py::run_scenario`
+- **bidding_points object assembly**: `src/bid_euchre/sim/simulation.py::run_scenario`
+- **Results JSON emission**: `src/bid_euchre/sim/simulation.py::run_scenario` (return statement)
 
 ## Notes on Determinism/Stability
 
 - **Per-hand scoring**: Deterministic given fixed seed (same hand always produces same point outcome)
 - **Aggregate statistics** (`avg_points_*`, `distribution_points_*`): Vary with sample size but converge to true distribution as `n_per` increases
-- **Bidding metrics**: Present/absent based on scenario configuration (`contract_type: null` enables bidding)
+- **Bidding metrics**: Conditional subfields appear only when `hands_with_bids > 0`. Auction mode (`contract_type: null`) enables bidding opportunity, but actual bidding activity determines metric presence.
 - **Backward compatibility**: All fields follow existing JSON schema contracts in `docs/01_core/DATA_CONTRACT.md`


### PR DESCRIPTION
## Summary
Fix documentation ambiguity and brittle references in SCORING.md and DATA_CONTRACT.md that were missed in PR #34.

## Why
PR #34 was merged before commit fc2356b (with these fixes) was included. This PR completes the original documentation cleanup task:
- Remove ambiguity about fixed contract vs auction mode
- Clarify bidding_points.enabled semantics
- Remove brittle line-number references
- Remove outdated PR references

## Repro / Validation
**Command(s) run:**
- `make check` (repo-lint passed)
- `grep -n "lines [0-9]" docs/01_core/SCORING.md` → no matches ✓
- `grep -n "PR #14" docs/01_core/DATA_CONTRACT.md` → no matches ✓
- `git diff --name-only main` → only 2 files (SCORING.md, DATA_CONTRACT.md) ✓

**Config (if applicable):**
N/A (docs-only)

**Seed (if applicable):**
N/A

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/` (via make check)
- [ ] Integration (if engine/rules changed): N/A
- [x] Other: `make check` (repo-lint, ruff, tests)

## Expected impact
- Metrics impact (if any): None (docs-only)
- Runtime impact (if any): None (docs-only)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it (N/A - docs-only)
- [x] PR is focused (one concept)

