### PR TITLE
docs: clarify config precedence and effective-config snapshot

### DIFF
--- a/docs/01_core/EXPERIMENTS.md
+++ b/docs/01_core/EXPERIMENTS.md
@@ -76,6 +76,43 @@ strategies:
   name: greedy
 ```
 
+## Config precedence and effective config snapshot
+
+### Precedence (as implemented)
+
+- `--seed` / `--s`: overrides `parameters.seed`; required unless `--allow-nondeterministic` is passed.
+- `--n_per` / `--n`: overrides `parameters.n_per`.
+- `--log-level`: overrides `parameters.log_level` (default: `none`).
+- `--mode`: overrides `mode` (falls back to `parameters.mode` or `self_play` from the YAML).
+- `--team1-strategy`: overrides `parameters.team1_strategy` when `mode=head_to_head`.
+- All other fields (strategies, scenarios, matchups, custom parameters, etc.) come straight from the YAML and are never changed by CLI flags.
+
+The `experiments/run_experiment.py` runner merges CLI values on top of `ExperimentConfig.parameters`/`mode`, so the effective config reflects whichever source had the highest precedence.
+
+### Effective config snapshot: `config_effective.yaml`
+
+- Located at `<run_dir>/config_effective.yaml` (run_dir is `--run-dir`/`data/runs` + `<experiment_name>_<seed>_<timestamp>`).
+- Contains the merged values after precedence resolution: `experiment_name`, `parameters` (`n_per`, `seed`, `log_level`, plus `team1_strategy` when applicable), `mode`, the strategy metadata, and the expanded scenario list that actually ran.
+- Written with `yaml.dump(..., sort_keys=True)` so the file ordering is deterministic.
+- The existing integration test `tests/integration/test_run_output_contract.py` asserts this file exists and demonstrates that the CLI overrides for `seed`/`n_per` propagate into it.
+
+### Scenario expansion (“what actually ran”)
+
+- `ExperimentConfig.__post_init__` expands every YAML scenario entry with multiple `trump_suit` values into one `ScenarioConfig` per suit, ensuring each result file corresponds to a concrete contract/trump pair.
+- The runner enumerates the resulting `scenarios` list (without any additional CLI filtering) and writes per-strategy results under `results/<strategy>/<contract>.json` (with auction contracts named `auction.json` via `scenario_filename`).
+- Therefore the effective config and the output files together represent the exact contracts and trump suits that executed.
+
+### Path resolution rules
+
+- The `--config` path is used verbatim; it is resolved relative to the current working directory with no additional normalization or relative-to-config-file logic.
+- `--run-dir` (default `data/runs`) is likewise resolved relative to the current working directory and then joined with `<run_id>` to create the actual run path. All artifacts are written inside that directory.
+
+### Error messaging conventions
+
+- Missing seed exits with a `SystemExit` whose message begins `Error: --seed is required...` (the only manual `Error:` prefix today).
+- YAML load issues or nonexistent files raise `FileNotFoundError` and Python truthfully prints the stack/exception text.
+- Invalid modes, missing scenarios, or unknown strategies/team1-strategy values raise `ValueError` with their standard message. There is no additional custom prefix beyond what the exception provides.
+
 ## Reproducing a Run
 
 To reproduce a run from its metadata:


### PR DESCRIPTION
Summary
- Document CLI vs YAML config precedence for the canonical runner
- Document config_effective.yaml location/contents + scenario expansion + path resolution
- Link to the existing integration test that asserts effective config usefulness

## Summary
- Clarify which CLI flags override `ExperimentConfig` parameters/mode and what stays in the YAML so readers know which values actually ran.

## Why
- Keeps the docs grounded in current runner behavior and removes ambiguity about which inputs win, which paths are resolved, and how to audit the effective config.

## Repro / Validation
**Command(s) run:**
- `make check` *(fails locally because `ruff` is not installed; CI covers it)*

**Config (if applicable):**
- n/a

**Seed (if applicable):**
- n/a

## Tests
- [ ] `PYTHONPATH=src python -m pytest -m "not slow" tests/`
- [ ] Integration (if engine/rules changed): `PYTHONPATH=src python -m pytest tests/integration/`
- [ ] Other:

## Expected impact
- Metrics impact (if any): none
- Runtime impact (if any): none

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
