### PR TITLE
ci: lint canonical runner and scripts (ruff exclude fix)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
-        exclude: ^(data/.*|experiments/.*|scripts/.*)
+        exclude: ^(data/.*|experiments/_deprecated/.*)
 
   - repo: local
     hooks:


### PR DESCRIPTION
## Summary
Fix ruff configuration to ensure the highest-risk entrypoints (experiments/run_experiment.py and scripts/*.py) are linted by both direct ruff commands and pre-commit hooks.

## Why
The pre-commit ruff configuration was excluding experiments/ and scripts/ directories entirely, preventing linting of critical entrypoints. While pyproject.toml correctly excluded only data/ and experiments/_deprecated/, the pre-commit config was overly broad.

## Repro / Validation
**Command(s) run:**
- `python -m ruff check experiments/run_experiment.py scripts/` - passes
- `make lint` - passes  
- `make repo-lint` - passes
- `make check` - repo-lint + lint pass (pytest not installed locally, relying on CI)

**Config (if applicable):**
- pyproject.toml ruff config unchanged (correctly excludes only data/ and experiments/_deprecated/)
- .pre-commit-config.yaml ruff exclude updated from `^(data/.*|experiments/.*|scripts/.*)` to `^(data/.*|experiments/_deprecated/.*)`

**Seed (if applicable):**
- N/A

## Tests
- [ ] `PYTHONPATH=src python -m pytest -m "not slow" tests/` (CI validates)
- [ ] Integration (if engine/rules changed): `PYTHONPATH=src python -m pytest tests/integration/` (CI validates)
- [ ] Other: pre-commit hooks now lint experiments/run_experiment.py and scripts/

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None (only affects linting, not runtime)

## Risk level
- [x] Low (CI/linting config only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [ ] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)