### PR TITLE
docs: fix experiments README stale refs

### DIFF
--- a/experiments/README.md
+++ b/experiments/README.md
@@ -11,13 +11,10 @@ This directory contains all experiment scripts for Bid Euchre simulation and ana
 
 ```
 experiments/
-├── analysis/          (7 scripts)  - Analyze simulation results
-├── comparisons/       (9 scripts)  - Head-to-head strategy comparisons
-├── dashboards/        (9 scripts)  - Multi-panel dashboard generators
-├── data_generation/   (3 scripts)  - Training data generation
-├── plotting/          (5 scripts)  - Individual plot generators
+├── comparisons/       (1 script)   - Head-to-head strategy comparisons
 ├── training/          (1 script)   - Model training
-├── configs/           (10 YAML)    - Experiment configurations
+├── configs/           (12 YAML)    - Experiment configurations
+├── suites/            (1 YAML)     - Experiment suite definitions
 ├── _deprecated/       (15 scripts) - Superseded experiments
 ├── __init__.py                     - Auto-setup (no sys.path needed!)
 ├── REGISTRY.yaml                   - Complete experiment catalog (includes active, stable, and deprecated)
@@ -30,113 +27,33 @@ experiments/
 
 ## 🎯 Quick Start
 
-### Running an Experiment
-
-**Option 1: Use Unified Runner** (Preferred)
+### Single Experiment
 ```bash
-PYTHONPATH=src python experiments/run_experiment.py \
-  --config experiments/configs/strategy_comparison.yaml
+PYTHONPATH=src python experiments/run_experiment.py --config experiments/configs/baseline_greedy.yaml
 ```
 
-**Option 2: Run Specific Script**
+### Experiment Suite
 ```bash
-PYTHONPATH=src python experiments/dashboards/generate_bidder_models_dashboard.py
+PYTHONPATH=src python scripts/run_suite.py experiments/suites/baseline_tiny.yaml
 ```
 
-**Option 3: Find in Registry**
+### Generate Report
 ```bash
-# Check configs/ for current experiment configurations
-ls experiments/configs/
+PYTHONPATH=src python scripts/generate_report.py --experiment baseline_greedy
 ```
 
 ---
 
 ## 📁 Subdirectory Guide
 
-### `analysis/` - Analysis Scripts
-
-**Purpose:** Analyze simulation outputs, extract insights
-
-**Scripts:**
-- `analyze_bid_winners.py` - Which position wins bids?
-- `analyze_bidding_distributions.py` - Bid amount distributions
-- `analyze_position_impact.py` - Impact of bidder position
-- `analyze_predicted_vs_actual.py` - Model calibration
-- `analyze_suit_trick_distribution.py` - Trick distributions
-- `evaluate_bidding_performance.py` - Bidding metrics
-- `run_position_test.py` - Position validation test
-
-**When to add here:** Scripts that process existing simulation results
-
----
-
 ### `comparisons/` - Head-to-Head Comparisons
 
 **Purpose:** Compare strategies against each other
 
 **Scripts:**
-- `compare_top_four.py` - Top 4 strategies
-- `compare_top_three.py` - Top 3 strategies
-- `generate_paired_comparison.py` - Paired statistical comparison
-- `run_bidding_comparison.py` - Three-horse race
-- `run_full_head_to_head.py` - All-pairs comparison
-- `run_head_to_head.py` - Simple head-to-head
-- `run_olsa_policy_comparison.py` - Compare rounding policies
-- `run_olsa_vs_ccrider.py` - Specific matchup
-- `run_six_way_head_to_head.py` - Six-way comparison
+- `run_head_to_head.py` - Backward-compatibility wrapper (use configs instead)
 
-**When to add here:** Scripts that run strategy vs strategy simulations
-
----
-
-### `dashboards/` - Dashboard Generators
-
-**Purpose:** Create multi-panel visualizations
-
-**Scripts:**
-- `generate_advanced_visualizations.py` - Hexbin, violin plots
-- `generate_auction_points_heatmaps.py` - Auction analysis
-- `generate_bidder_models_dashboard.py` - Model comparison
-- `generate_hand_eval_dashboard.py` - Feature analysis
-- `generate_head_to_head_report.py` - H2H results
-- `generate_reports_from_split.py` - Split-specific reports
-- `generate_strategy_comparison_dashboard.py` - Strategy overview
-- `generate_top_four_metrics_heatmap.py` - Top 4 heatmap
-- `generate_trick_strategy_dashboard.py` - Trick analysis
-
-**When to add here:** Scripts that create comprehensive multi-panel figures
-
-**Note:** Consider consolidating these using a base `DashboardGenerator` class
-
----
-
-### `data_generation/` - Training Data Pipelines
-
-**Purpose:** Generate and prepare training datasets
-
-**Scripts:**
-- `generate_bidder_training_data.py` - Run simulations for training
-- `split_train_val_test.py` - Split JSONL into train/val/test
-- `convert_splits_to_csv.py` - JSONL → CSV conversion
-
-**When to add here:** Scripts that create or transform training data
-
----
-
-### `plotting/` - Individual Plot Generators
-
-**Purpose:** Create focused single plots
-
-**Scripts:**
-- `plot_all_feature_correlations.py` - All 40 features
-- `plot_correlations_by_contract.py` - By contract type
-- `plot_predicted_vs_actual.py` - Model calibration
-- `plot_top_features_improved.py` - Hexbin/violin for top 9
-- `plot_top_features_scatter.py` - Scatter with regression
-
-**When to add here:** Scripts that create single-purpose visualizations
-
-**vs dashboards/:** Use `plotting/` for single plots, `dashboards/` for multi-panel
+**When to add here:** Only backward-compatibility wrappers. Use configs + unified runner for new comparisons.
 
 ---
 
@@ -186,6 +103,17 @@ parameters:
 
 ---
 
+### `suites/` - Experiment Suite Definitions
+
+**Purpose:** Define collections of experiments to run together
+
+**Current suites:**
+- `baseline_tiny.yaml` - Small test suite for validation
+
+**When to add here:** YAML files defining multiple experiments to run as a batch
+
+---
+
 ### `_deprecated/` - Superseded Experiments
 
 **Purpose:** Historical experiments no longer used
@@ -211,12 +139,8 @@ Follow these steps (from `CONTRIBUTING.md`):
    - `experiments/configs/my_experiment.yaml`
 
 3. **Choose subdirectory**
-   - Analysis → `analysis/`
-   - Dashboard → `dashboards/`
-   - Comparison → `comparisons/`
-   - Training data → `data_generation/`
-   - Plot → `plotting/`
-   - Model training → `training/`
+   - Comparison → `comparisons/` (wrappers only)
+   - Model training → `training/` (legacy scripts only)
 
 4. **Write script**
    - Accept `--config` argument
@@ -239,15 +163,13 @@ Follow these steps (from `CONTRIBUTING.md`):
 ## 📊 Statistics
 
 **Script counts:**
-- analysis/: 7
-- comparisons/: 9
-- dashboards/: 9
-- data_generation/: 3
-- plotting/: 5
+- comparisons/: 1
 - training/: 1
-- **Total active:** 34
+- **Total active:** 2
 
-**Config files:** 10
+**Config files:** 12
+
+**Suite files:** 1
 
 **Deprecated:** 15
 


### PR DESCRIPTION
## Summary
- Update experiments/README.md to match current folder structure
- Remove references to non-existent folders (analysis/, dashboards/, data_generation/, plotting/)
- Add canonical copy/paste commands for single experiment, suite, and report generation

## Why
The experiments/README.md contained outdated references to directories that no longer exist, making the documentation confusing for new contributors. This PR brings the documentation in sync with the actual codebase structure.

## Repro / Validation
**Command(s) run:**
```bash
PYTHONPATH=src python experiments/run_experiment.py --config experiments/configs/baseline_greedy.yaml
PYTHONPATH=src python scripts/run_suite.py experiments/suites/baseline_tiny.yaml
PYTHONPATH=src python scripts/generate_report.py --experiment baseline_greedy
```

**Config (if applicable):**
baseline_greedy.yaml

**Seed (if applicable):**
42 (default)

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/` (relies on CI - pytest not installed locally)
- [ ] Integration (if engine/rules changed): `PYTHONPATH=src python -m pytest tests/integration/`
- [ ] Other:

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [ ] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
