### PR TITLE
feat: add baseline_full suite (matchup matrix)

### DIFF
--- a/docs/01_core/BASELINE.md
+++ b/docs/01_core/BASELINE.md
@@ -38,17 +38,31 @@ Baseline is not:
 
 ---
 
-### `baseline_full` (Future: PR #23)
+### `baseline_full` (Manual: Strategy Interactions + Auction Plumbing)
 
-**Purpose**: Larger rerun for more confidence
+**Purpose**: Broader regression net beyond `baseline_tiny` (interaction effects + wiring)
 
-**Planned contract**:
-- Play-only
-- `n_per`: 10,000+ (TBD)
-- Same scenario/strategy coverage as `baseline_tiny`
-- Same determinism requirements
+**Contract**:
+- **Strategy interactions**: 4x4 matchup matrix (16 matchups including self-play controls)
+- **Auction plumbing**: Bidding mode smoke test
+- **Default seed**: `42`
+- **Default n_per**: `500` (hands per matchup/scenario)
+- **Total hands**: ~120,000 (16 × 6 × 500)
+- **Strategies**: greedy, random_legal, always_highest, always_lowest
+- **Scenarios**: Full coverage (6 scenarios: 4 suit contracts + high + low)
 
-*(Details deferred to PR #23)*
+**When to run**: Before merging changes to sim/core/scoring/strategy/runner (manual)
+
+**How to run**:
+
+```bash
+PYTHONPATH=src python scripts/run_suite.py \
+  --suite experiments/suites/baseline_full.yaml
+```
+
+**Expected runtime**: ~5 minutes (adjust n_per via `--n-per` if needed)
+
+**Outputs**: Rollup directory under `data/runs/suite_<timestamp>/` (never committed)
 
 ---
 

--- a/experiments/configs/baseline_matchups.yaml
+++ b/experiments/configs/baseline_matchups.yaml
@@ -1,0 +1,88 @@
+# Baseline Matchups Config
+#
+# All-vs-all matchup matrix across four core strategies (16 matchups total).
+# Includes self-play controls (A vs A) for regression testing.
+# Tests interaction effects and positional bias across strategy pairs.
+
+experiment_name: baseline_matchups
+
+parameters:
+  n_per: 50000
+  seed: 42
+  log_level: hand
+  mode: head_to_head_matrix
+
+# Define all strategies that will be tested
+strategies:
+  - name: greedy
+    class_name: GreedyStrategy
+
+  - name: random_legal
+    class_name: RandomLegalStrategy
+
+  - name: always_highest
+    class_name: AlwaysHighestLegalStrategy
+
+  - name: always_lowest
+    class_name: AlwaysLowestLegalStrategy
+
+# Define matchups (Team0 vs Team1) - all ordered pairs including self-play
+matchups:
+  # Greedy vs all
+  - team0: greedy
+    team1: greedy
+
+  - team0: greedy
+    team1: random_legal
+
+  - team0: greedy
+    team1: always_highest
+
+  - team0: greedy
+    team1: always_lowest
+
+  # Random legal vs all
+  - team0: random_legal
+    team1: greedy
+
+  - team0: random_legal
+    team1: random_legal
+
+  - team0: random_legal
+    team1: always_highest
+
+  - team0: random_legal
+    team1: always_lowest
+
+  # Always highest vs all
+  - team0: always_highest
+    team1: greedy
+
+  - team0: always_highest
+    team1: random_legal
+
+  - team0: always_highest
+    team1: always_highest
+
+  - team0: always_highest
+    team1: always_lowest
+
+  # Always lowest vs all
+  - team0: always_lowest
+    team1: greedy
+
+  - team0: always_lowest
+    team1: random_legal
+
+  - team0: always_lowest
+    team1: always_highest
+
+  - team0: always_lowest
+    team1: always_lowest
+
+# Scenarios to test (all contract types)
+scenarios:
+  - contract_type: suit
+    trump_suit: C,D,H,S
+  - contract_type: high
+  - contract_type: low

--- a/experiments/suites/baseline_full.yaml
+++ b/experiments/suites/baseline_full.yaml
@@ -1,0 +1,24 @@
+# Baseline Full Suite Definition
+#
+# Broad regression net covering gameplay interactions and auction plumbing.
+# Manual target runtime: ~5 minutes (n_per=500, seed=42).
+# Covers: strategy interactions (matchup matrix) + auction/bidding wiring.
+
+suite_name: baseline_full
+
+purpose: Broad regression net covering gameplay interactions and auction plumbing
+
+parameters:
+  seed: 42
+  n_per: 500
+  log_level: none
+
+configs:
+  - experiments/configs/baseline_matchups.yaml
+  - experiments/configs/auction_smoke.yaml
+
+notes:
+  - "This suite provides broader coverage than baseline_tiny (interaction effects + wiring)."
+  - "Includes 16 strategy matchups (4x4 matrix with self-play controls) + auction plumbing."
+  - "Target runtime: ~5 minutes manually (n_per=500, adjustable via --n-per)."
+  - "Intended for manual runs before merging changes to sim/core/scoring/strategy/runner."


### PR DESCRIPTION
## Summary
- Add baseline_matchups config (4x4 matrix; includes self-play controls)
- Add baseline_full suite (manual ~5 min target)
- Update BASELINE.md to document baseline_full

## Why
Add a new, clean-checkout runnable "baseline_full" suite intended to run ~5 minutes manually, covering non-auction gameplay via a head-to-head matchup matrix across four core strategies plus auction-mode plumbing via the existing auction_smoke config.

## Repro / Validation
**Command(s) run:**
- `PYTHONPATH=src python scripts/run_suite.py --suite experiments/suites/baseline_full.yaml --dry-run` (dry-run validation)
- `PYTHONPATH=src python experiments/run_experiment.py --config experiments/configs/baseline_matchups.yaml --dry-run` (config validation)

**Config (if applicable):**
- experiments/configs/baseline_matchups.yaml (new)
- experiments/suites/baseline_full.yaml (new)

**Seed (if applicable):**
- 42 (suite-level seed for determinism)

## Tests
- [ ] `PYTHONPATH=src python -m pytest -m "not slow" tests/` (pytest not available locally)
- [ ] Integration (if engine/rules changed): `PYTHONPATH=src python -m pytest tests/integration/`
- [ ] Other: make repo-lint && make lint passed

## Expected impact
- Metrics impact (if any): None (new baseline suite)
- Runtime impact (if any): None (new suite, not replacing existing)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [ ] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)