### PR TITLE
docs: add ARCHIVED banner to docs/archive/

### DIFF
--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,3 +1,14 @@
+> **⚠️ ARCHIVED — This folder contains historical documentation that may be outdated.**
+>
+> These docs reflect earlier project structure and conventions. For current documentation, see:
+> - `docs/01_core/` — Authoritative architecture and contracts
+> - `docs/02_agent/` — Agent operating guidelines
+> - `experiments/README.md` — Current experiment structure
+>
+> Do not treat these files as current truth.
+
+---
+
 # BUD EUCHRE — Bid Euchre Simulation + Strategy Lab
 
 This repo is a simulation and analysis environment for **Bid Euchre**. The goal is to:


### PR DESCRIPTION
## Summary
- Add clear ARCHIVED warning banner to docs/archive/README.md
- Points agents to authoritative documentation locations
- Prevents treating historical docs as current truth

## Test Plan
- [x] No code changes, docs only
- [x] Banner clearly visible at top of file

## Checklist
- [x] `make check` passes (pre-commit ran)
- [x] No generated artifacts committed