### PR TITLE
docs: tighten archive guardrails

### DIFF
--- a/docs/archive/ARCHIVED.md
+++ b/docs/archive/ARCHIVED.md
@@ -1,0 +1,1 @@
+ARCHIVED — `docs/archive/` is historical and not authoritative; start with `docs/README.md`, `docs/01_core/`, `docs/02_agent/`, and `experiments/README.md` instead.

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,11 +1,21 @@
-> **⚠️ ARCHIVED — This folder contains historical documentation that may be outdated.**
+> # ⚠️ ARCHIVED — not authoritative
 >
-> These docs reflect earlier project structure and conventions. For current documentation, see:
-> - `docs/01_core/` — Authoritative architecture and contracts
-> - `docs/02_agent/` — Agent operating guidelines
-> - `experiments/README.md` — Current experiment structure
+> **You’re in `docs/archive/`.** This folder is intentionally **not canonical** and may be stale or contradictory.
 >
-> Do not treat these files as current truth.
+> For current, authoritative docs, start here:
+> - `docs/README.md`
+> - `docs/01_core/`
+> - `docs/02_agent/`
+> - `experiments/README.md`
+>
+> ## Canonical docs map (top 5)
+> 1. `docs/README.md` — docs entrypoint + navigation
+> 2. `docs/01_core/ARCHITECTURE.md` — architecture + contracts overview
+> 3. `docs/01_core/RULES.md` — game rules / definitions used by the code
+> 4. `docs/02_agent/AGENTS.md` — how to work in this repo (agents/automation)
+> 5. `experiments/README.md` — experiments layout + how to run them
+>
+> If you’re unsure, **do not cite `docs/archive/`**—cite the canonical paths above.
 
 ---
 


### PR DESCRIPTION
## Summary
Tighten guardrails around `docs/archive/` to prevent accidental use as canonical documentation. Added prominent "ARCHIVED" banners and canonical doc pointers to `docs/archive/README.md` and new `docs/archive/ARCHIVED.md`.

## Why
Archive docs may be outdated and should not be treated as authoritative. This change makes it clear when users are in the archive and provides quick links to current documentation.

## Repro / Validation
**Command(s) run:**
- `make repo-lint && make lint`

**Config (if applicable):**
- N/A

**Seed (if applicable):**
- N/A

## Tests
- [ ] `PYTHONPATH=src python -m pytest -m "not slow" tests/` (docs-only change, no behavior impact)
- [ ] Integration (if engine/rules changed): `PYTHONPATH=src python -m pytest tests/integration/` (docs-only change)
- [ ] Other: Repo lint + ruff pass

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [ ] If behavior changed, tests updated/added to lock it (docs-only change)
- [x] PR is focused (one concept)