### PR TITLE
ci: polish drift workflow with actionable issue output

### DIFF
--- a/.github/workflows/baseline_full_drift.yml
+++ b/.github/workflows/baseline_full_drift.yml
@@ -52,11 +52,14 @@ jobs:
       run: |
         ROLLUP_FILE="${{ steps.find_rollup.outputs.rollup_file }}"
         echo "Running comparator on: $ROLLUP_FILE"
+        # Capture output to file for inclusion in issue body
         PYTHONPATH=src python scripts/compare_rollup.py \
           --rollup "$ROLLUP_FILE" \
-          --fixture data/fixtures/baseline_full_expected.json
+          --fixture data/fixtures/baseline_full_expected.json 2>&1 | tee comparator_output.txt
+        # Preserve exit code from comparator (not tee)
+        exit ${PIPESTATUS[0]}
 
-    - name: Upload artifacts (rollup + runs)
+    - name: Upload artifacts (rollup + logs + comparator output)
       uses: actions/upload-artifact@v4
       if: always()
       with:
@@ -64,7 +67,23 @@ jobs:
         path: |
           ${{ steps.find_rollup.outputs.rollup_file }}
           nightly_runs/
+          comparator_output.txt
         retention-days: 14
+
+    - name: Read comparator output
+      if: steps.drift_check.outcome == 'failure'
+      id: comparator_output
+      run: |
+        if [ -f comparator_output.txt ]; then
+          # Read output and escape for GitHub Actions
+          OUTPUT=$(cat comparator_output.txt)
+          # Use heredoc to preserve multiline output
+          echo "output<<EOF" >> $GITHUB_OUTPUT
+          echo "$OUTPUT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+        else
+          echo "output=Comparator output not available" >> $GITHUB_OUTPUT
+        fi
 
     - name: Create or update GitHub Issue on drift
       if: steps.drift_check.outcome == 'failure'
@@ -74,11 +93,16 @@ jobs:
         script: |
           const titlePrefix = '[drift] baseline_full metrics drifted';
           const runUrl = context.payload.repository.html_url + '/actions/runs/' + context.runId;
+          const artifactUrl = runUrl + '#artifacts';
           const commitSha = context.sha;
+          const shortSha = commitSha.substring(0, 7);
           const timestamp = new Date().toISOString();
+          const comparatorOutput = process.env.COMPARATOR_OUTPUT || 'Output not available';
 
-          // Determine drift reason
-          let driftReason = 'Drift comparator detected metric changes (tricks-only)';
+          // Run metadata
+          const suiteName = 'baseline_full';
+          const seed = 42;
+          const nPer = 500;
 
           // Search for existing open issue with the title prefix
           const issues = await github.rest.issues.listForRepo({
@@ -92,24 +116,68 @@ jobs:
             issue.title.startsWith(titlePrefix)
           );
 
-          const issueBody = '## Baseline Full Drift Detected\n\n' +
-            'The scheduled baseline_full suite completed successfully, but metrics have drifted from expected values.\n\n' +
-            '**Drift Reason:** ' + driftReason + '\n\n' +
-            '**Workflow Run:** ' + runUrl + '\n\n' +
-            '**Commit SHA:** ' + commitSha + '\n\n' +
-            '**Timestamp:** ' + timestamp + '\n\n' +
-            '**Artifact:** `baseline-full-drift-results` (includes rollup.json and full run data)\n\n' +
-            'Please investigate the drift and determine if this is expected or requires fixing.';
+          // Build issue body with string concatenation (YAML-safe)
+          const issueBody = [
+            '## Baseline Full Drift Detected',
+            '',
+            'The scheduled baseline_full suite completed successfully, but metrics have drifted from expected values.',
+            '',
+            '### Run Details',
+            '',
+            '| Field | Value |',
+            '|-------|-------|',
+            '| **Suite** | `' + suiteName + '` |',
+            '| **Seed** | `' + seed + '` |',
+            '| **n_per** | `' + nPer + '` |',
+            '| **Commit** | `' + shortSha + '` |',
+            '| **Timestamp** | ' + timestamp + ' |',
+            '| **Workflow Run** | [View Run](' + runUrl + ') |',
+            '| **Artifacts** | [Download](' + artifactUrl + ') |',
+            '',
+            '### Comparator Output',
+            '',
+            '<details>',
+            '<summary>Click to expand comparison table</summary>',
+            '',
+            '```',
+            comparatorOutput,
+            '```',
+            '',
+            '</details>',
+            '',
+            '### Next Steps',
+            '',
+            '1. Download the `baseline-full-drift-results` artifact',
+            '2. Review the comparison table above to identify which configs drifted',
+            '3. Determine if this is an expected change (update fixture) or a regression (fix code)',
+          ].join('\n');
+
+          // Build comment body for existing issues
+          const commentBody = [
+            '## New Drift Detected',
+            '',
+            '| Field | Value |',
+            '|-------|-------|',
+            '| **Suite** | `' + suiteName + '` |',
+            '| **Seed** | `' + seed + '` |',
+            '| **n_per** | `' + nPer + '` |',
+            '| **Commit** | `' + shortSha + '` |',
+            '| **Timestamp** | ' + timestamp + ' |',
+            '| **Workflow Run** | [View Run](' + runUrl + ') |',
+            '| **Artifacts** | [Download](' + artifactUrl + ') |',
+            '',
+            '<details>',
+            '<summary>Comparator Output</summary>',
+            '',
+            '```',
+            comparatorOutput,
+            '```',
+            '',
+            '</details>',
+          ].join('\n');
 
           if (existingIssue) {
             // Update existing issue with new comment
-            const commentBody = '## New Drift Detected\n\n' +
-              '**Drift Reason:** ' + driftReason + '\n\n' +
-              '**Workflow Run:** ' + runUrl + '\n\n' +
-              '**Commit SHA:** ' + commitSha + '\n\n' +
-              '**Timestamp:** ' + timestamp + '\n\n' +
-              '**Artifact:** `baseline-full-drift-results` (includes rollup.json and full run data)';
-
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -126,3 +194,5 @@ jobs:
               labels: ['drift']
             });
           }
+      env:
+        COMPARATOR_OUTPUT: ${{ steps.comparator_output.outputs.output }}


### PR DESCRIPTION
## Summary
- Capture comparator output to file during drift detection
- Include comprehensive run metadata in GitHub issues (suite, seed, n_per, commit SHA, workflow link, artifact link)
- Format issue body with structured sections: run details table, collapsible comparator output, and actionable next steps
- Preserve existing issue deduplication behavior (comments on existing open drift issues)

## Why
When drift is detected in the nightly baseline_full run, developers need to immediately see **what** drifted without downloading artifacts. Previously, issues only contained minimal metadata. This change makes drift issues immediately actionable by embedding the full comparator output (the comparison table showing expected vs actual values) directly in the issue body.

## Repro / Validation
**Command(s) run:**
- `make check` (passed)
- YAML validation via pre-commit hooks (passed)

**Config (if applicable):**
- N/A (workflow-only change)

**Seed (if applicable):**
- N/A (workflow-only change)

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/` (passed)
- [x] Pre-commit hooks (passed, including check-yaml)
- [ ] Integration: Will be tested when next drift occurs in CI (workflow cannot be easily tested locally)

## Expected impact
- Metrics impact (if any): None (workflow-only)
- Runtime impact (if any): None (comparator already runs; we just capture its output)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it (N/A - workflow only)
- [x] PR is focused (one concept)