### PR TITLE
docs: define bidding contract (v1)

### DIFF
--- a/docs/01_core/BIDDING.md
+++ b/docs/01_core/BIDDING.md
@@ -1,0 +1,42 @@
+# Bidding Contract (v1)
+
+## Overview
+
+Bid Euchre bidding mechanics define how players select contracts for each hand. This document specifies the bidding protocol, observation contract, and default behaviors.
+
+## Bidding Protocol
+
+### Round Structure
+- **Single round**: One bidding round starting left of dealer
+- **Simultaneous action**: All players bid `(n, contract)` simultaneously
+- **Bid values**: `n` ranges from 0–10 where `0` = pass
+- **Strictly increasing**: `n` must be `> current_high_bid` else treated as pass
+- **Redeal condition**: All players pass (bid 0) → redeal
+
+### Contracts
+- **Suit contracts**: `C`, `D`, `H`, `S` (Clubs, Diamonds, Hearts, Spades)
+- **Special contracts**: `HIGH`, `LOW`
+  - No trump suit applies
+  - Only rank order determines winners (A > K > Q > J > 10)
+
+## Observation Contract (v1)
+
+Bidding observations provide minimal context for decision-making:
+
+- **Hand**: Player's 5 cards
+- **Seat**: Player's position (0-3)
+- **Dealer seat**: Dealer's position (0-3)
+- **Current high bid**: Highest `n` bid so far in this round
+
+**Note**: Bidding history not included (planned for v2)
+
+## Default Behavior
+
+### Auction Configurations
+- **Required**: Bidding policy must be specified
+- **Fail fast**: Missing bidding policy → immediate error
+
+### Non-Auction Configurations
+- **No bidding**: Skip bidding phase entirely
+- **Deterministic selection**: Use existing non-auction contract selection path
+- **Randomness**: Via repo's seeded RNG sources (deterministic by default)


### PR DESCRIPTION
## Summary
Add operational documentation for bidding mechanics (v1) including protocol, observation contract, and default behaviors.

## Why
Define bidding rules that match implementation and prevent future drift.

## Repro / Validation
**Command(s) run:**
```bash
ls docs/01_core/
```

**Config (if applicable):**
N/A

**Seed (if applicable):**
N/A

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/` (docs only, no code changes)
- [ ] Integration (if engine/rules changed): `PYTHONPATH=src python -m pytest tests/integration/`
- [ ] Other:

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [ ] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)