### PR TITLE
feat: add heuristic baseline bidding policies (v1)

### DIFF
--- a/src/bid_euchre/strategy/__init__.py
+++ b/src/bid_euchre/strategy/__init__.py
@@ -26,6 +26,9 @@ from .bidding import (
     BidAction,
     BiddingObservation,
     BiddingPolicy,
+    FixedBidder,
+    HeuristicSuitBidder,
+    HighLowHeuristicBidder,
     StrictRaiserBidder,
 )
 
@@ -50,6 +53,9 @@ __all__ = [
     "BiddingObservation",
     "BiddingPolicy",
     "AlwaysPassBidder",
+    "FixedBidder",
+    "HeuristicSuitBidder",
+    "HighLowHeuristicBidder",
     "StrictRaiserBidder",
     # Baselines
     "BasicStrategy",

--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -163,3 +163,128 @@ class StrictRaiserBidder(BiddingPolicy):
         else:
             # current >= 10, cannot raise further
             return BidAction.pass_bid()
+
+
+class FixedBidder(BiddingPolicy):
+    """
+    Baseline bidder that bids a fixed amount and contract.
+
+    If the fixed bid is higher than current_high_bid, bids it.
+    Otherwise, passes.
+    """
+
+    def __init__(self, n: int, contract: str, name: str = "fixed_bidder"):
+        super().__init__(name)
+        if n < 1 or n > 10:
+            raise ValueError(f"Fixed bid n must be 1-10, got {n}")
+        if contract not in {"C", "D", "H", "S", "HIGH", "LOW"}:
+            raise ValueError(f"Invalid contract: {contract}")
+        self.n = n
+        self.contract = contract
+
+    def choose_bid(self, obs: BiddingObservation) -> BidAction:
+        if self.n > obs.current_high_bid:
+            return BidAction.bid(self.n, self.contract)
+        else:
+            return BidAction.pass_bid()
+
+
+class HeuristicSuitBidder(BiddingPolicy):
+    """
+    Heuristic bidder that uses hand strength to choose suit contract.
+
+    - Evaluates hand strength for each suit (C, D, H, S)
+    - Picks the strongest suit deterministically
+    - Bids based on strength thresholds:
+      - strength >= 350: bid 6
+      - strength >= 300: bid 5
+      - strength >= 250: bid 4
+      - strength >= 200: bid 3
+      - else: pass
+    - Complies with strict-increasing rule (only bids if > current_high_bid)
+    """
+
+    def __init__(self, name: str = "heuristic_suit"):
+        super().__init__(name)
+
+    def choose_bid(self, obs: BiddingObservation) -> BidAction:
+        from ..features.hand_eval import score_hand_scalar
+
+        # Evaluate hand strength for each suit
+        suit_scores = {}
+        for suit in ["C", "D", "H", "S"]:
+            suit_scores[suit] = score_hand_scalar(obs.hand, "suit", suit)
+
+        # Pick strongest suit deterministically (ties broken alphabetically)
+        best_suit = max(suit_scores, key=lambda s: (suit_scores[s], s))
+        strength = suit_scores[best_suit]
+
+        # Determine bid amount based on strength thresholds
+        if strength >= 350:
+            bid_n = 6
+        elif strength >= 300:
+            bid_n = 5
+        elif strength >= 250:
+            bid_n = 4
+        elif strength >= 200:
+            bid_n = 3
+        else:
+            # Too weak, pass
+            return BidAction.pass_bid()
+
+        # Comply with strict-increasing rule
+        if bid_n > obs.current_high_bid:
+            return BidAction.bid(bid_n, best_suit)
+        else:
+            return BidAction.pass_bid()
+
+
+class HighLowHeuristicBidder(BiddingPolicy):
+    """
+    Heuristic bidder that chooses HIGH or LOW based on hand composition.
+
+    - Counts high cards (A, K, Q) vs low cards (J, T)
+    - If more high cards: bid HIGH
+    - If more low cards: bid LOW
+    - Ties: bid HIGH (deterministic)
+    - Bid amount based on strength:
+      - strength >= 40: bid 5
+      - strength >= 30: bid 4
+      - strength >= 20: bid 3
+      - else: pass
+    - Complies with strict-increasing rule
+    """
+
+    def __init__(self, name: str = "high_low_heuristic"):
+        super().__init__(name)
+
+    def choose_bid(self, obs: BiddingObservation) -> BidAction:
+        from ..features.hand_eval import score_hand_scalar
+
+        # Count high vs low cards
+        high_cards = sum(1 for card in obs.hand if card.rank in {"A", "K", "Q"})
+        low_cards = sum(1 for card in obs.hand if card.rank in {"J", "T"})
+
+        # Choose contract (HIGH if tied or more high cards)
+        if high_cards >= low_cards:
+            contract = "HIGH"
+            strength = score_hand_scalar(obs.hand, "high", None)
+        else:
+            contract = "LOW"
+            strength = score_hand_scalar(obs.hand, "low", None)
+
+        # Determine bid amount based on strength
+        if strength >= 40:
+            bid_n = 5
+        elif strength >= 30:
+            bid_n = 4
+        elif strength >= 20:
+            bid_n = 3
+        else:
+            return BidAction.pass_bid()
+
+        # Comply with strict-increasing rule
+        if bid_n > obs.current_high_bid:
+            return BidAction.bid(bid_n, contract)
+        else:
+            return BidAction.pass_bid()

--- a/tests/unit/test_heuristic_bidders.py
+++ b/tests/unit/test_heuristic_bidders.py
@@ -1,0 +1,245 @@
+"""
+Unit tests for heuristic baseline bidding policies.
+
+Tests determinism and strict-increasing compliance for:
+- FixedBidder
+- HeuristicSuitBidder
+- HighLowHeuristicBidder
+"""
+
+from bid_euchre.core.cards import Card
+from bid_euchre.strategy.bidding import (
+    BiddingObservation,
+    FixedBidder,
+    HeuristicSuitBidder,
+    HighLowHeuristicBidder,
+)
+
+
+class TestFixedBidder:
+    """Tests for FixedBidder."""
+
+    def test_bids_when_allowed(self):
+        """Fixed bidder bids its fixed amount when higher than current bid."""
+        bidder = FixedBidder(n=5, contract="H")
+        obs = BiddingObservation(
+            hand=[Card("H", "A"), Card("H", "K")],
+            seat=0,
+            dealer_seat=3,
+            current_high_bid=3,
+        )
+        action = bidder.choose_bid(obs)
+        assert action.n == 5
+        assert action.contract == "H"
+        assert not action.is_pass()
+
+    def test_passes_when_not_allowed(self):
+        """Fixed bidder passes when its fixed bid is not higher than current."""
+        bidder = FixedBidder(n=5, contract="H")
+        obs = BiddingObservation(
+            hand=[Card("H", "A"), Card("H", "K")],
+            seat=0,
+            dealer_seat=3,
+            current_high_bid=6,
+        )
+        action = bidder.choose_bid(obs)
+        assert action.is_pass()
+
+    def test_passes_when_equal(self):
+        """Fixed bidder passes when its fixed bid equals current (strict increasing)."""
+        bidder = FixedBidder(n=5, contract="H")
+        obs = BiddingObservation(
+            hand=[Card("H", "A"), Card("H", "K")],
+            seat=0,
+            dealer_seat=3,
+            current_high_bid=5,
+        )
+        action = bidder.choose_bid(obs)
+        assert action.is_pass()
+
+    def test_validates_n_range(self):
+        """FixedBidder validates n is 1-10."""
+        try:
+            FixedBidder(n=0, contract="H")
+            assert False, "Should have raised ValueError"
+        except ValueError as e:
+            assert "1-10" in str(e)
+
+        try:
+            FixedBidder(n=11, contract="H")
+            assert False, "Should have raised ValueError"
+        except ValueError as e:
+            assert "1-10" in str(e)
+
+    def test_validates_contract(self):
+        """FixedBidder validates contract is valid."""
+        try:
+            FixedBidder(n=5, contract="INVALID")
+            assert False, "Should have raised ValueError"
+        except ValueError as e:
+            assert "Invalid contract" in str(e)
+
+
+class TestHeuristicSuitBidder:
+    """Tests for HeuristicSuitBidder."""
+
+    def test_determinism_same_hand_same_bid(self):
+        """Same hand produces same bid."""
+        bidder = HeuristicSuitBidder()
+        hand = [
+            Card("H", "A"), Card("H", "K"), Card("H", "Q"),
+            Card("C", "A"), Card("C", "K")
+        ]
+        obs = BiddingObservation(
+            hand=hand,
+            seat=0,
+            dealer_seat=3,
+            current_high_bid=0,
+        )
+
+        # Call multiple times
+        action1 = bidder.choose_bid(obs)
+        action2 = bidder.choose_bid(obs)
+        action3 = bidder.choose_bid(obs)
+
+        # All should be identical
+        assert action1.n == action2.n == action3.n
+        assert action1.contract == action2.contract == action3.contract
+
+    def test_picks_strongest_suit(self):
+        """Heuristic bidder picks the strongest suit."""
+        bidder = HeuristicSuitBidder()
+        # Strong hearts hand (right bower, left bower, A, K, Q - 5 cards total)
+        hand = [
+            Card("H", "J"), Card("D", "J"), Card("H", "A"),
+            Card("H", "K"), Card("H", "Q")
+        ]
+        obs = BiddingObservation(
+            hand=hand,
+            seat=0,
+            dealer_seat=3,
+            current_high_bid=0,
+        )
+
+        action = bidder.choose_bid(obs)
+        assert not action.is_pass()
+        # Should choose H (hearts) as it has the strongest cards
+        assert action.contract == "H"
+
+    def test_passes_weak_hand(self):
+        """Heuristic bidder passes if hand is too weak."""
+        bidder = HeuristicSuitBidder()
+        # Very weak hand (all tens)
+        hand = [Card("C", "T"), Card("D", "T"), Card("H", "T"), Card("S", "T"), Card("C", "T")]
+        obs = BiddingObservation(
+            hand=hand,
+            seat=0,
+            dealer_seat=3,
+            current_high_bid=0,
+        )
+
+        action = bidder.choose_bid(obs)
+        assert action.is_pass()
+
+    def test_complies_with_strict_increasing(self):
+        """Heuristic bidder passes if computed bid not higher than current."""
+        bidder = HeuristicSuitBidder()
+        # Medium strength hand that would bid 3
+        hand = [Card("H", "A"), Card("C", "K"), Card("D", "Q"), Card("S", "T"), Card("H", "T")]
+        obs = BiddingObservation(
+            hand=hand,
+            seat=0,
+            dealer_seat=3,
+            current_high_bid=5,  # Already higher than what we'd bid
+        )
+
+        action = bidder.choose_bid(obs)
+        assert action.is_pass()
+
+
+class TestHighLowHeuristicBidder:
+    """Tests for HighLowHeuristicBidder."""
+
+    def test_determinism_same_hand_same_bid(self):
+        """Same hand produces same bid."""
+        bidder = HighLowHeuristicBidder()
+        hand = [Card("H", "A"), Card("C", "K"), Card("D", "Q"), Card("S", "J"), Card("H", "T")]
+        obs = BiddingObservation(
+            hand=hand,
+            seat=0,
+            dealer_seat=3,
+            current_high_bid=0,
+        )
+
+        # Call multiple times
+        action1 = bidder.choose_bid(obs)
+        action2 = bidder.choose_bid(obs)
+        action3 = bidder.choose_bid(obs)
+
+        # All should be identical
+        assert action1.n == action2.n == action3.n
+        assert action1.contract == action2.contract == action3.contract
+
+    def test_chooses_high_for_high_cards(self):
+        """Chooses HIGH when hand has more high cards."""
+        bidder = HighLowHeuristicBidder()
+        # 4 high cards (A, K, Q, Q) vs 1 low card (T)
+        hand = [Card("H", "A"), Card("C", "K"), Card("D", "Q"), Card("S", "Q"), Card("H", "T")]
+        obs = BiddingObservation(
+            hand=hand,
+            seat=0,
+            dealer_seat=3,
+            current_high_bid=0,
+        )
+
+        action = bidder.choose_bid(obs)
+        assert not action.is_pass()
+        assert action.contract == "HIGH"
+
+    def test_chooses_low_for_low_cards(self):
+        """Chooses LOW when hand has more low cards."""
+        bidder = HighLowHeuristicBidder()
+        # 1 high card (A) vs 4 low cards (J, J, T, T)
+        hand = [Card("H", "A"), Card("C", "J"), Card("D", "J"), Card("S", "T"), Card("H", "T")]
+        obs = BiddingObservation(
+            hand=hand,
+            seat=0,
+            dealer_seat=3,
+            current_high_bid=0,
+        )
+
+        action = bidder.choose_bid(obs)
+        assert not action.is_pass()
+        assert action.contract == "LOW"
+
+    def test_chooses_high_on_tie(self):
+        """Chooses HIGH deterministically when high/low counts are tied."""
+        bidder = HighLowHeuristicBidder()
+        # 3 high cards (A, K, Q) vs 2 low cards (J, T)
+        hand = [Card("H", "A"), Card("C", "K"), Card("D", "J"), Card("S", "T"), Card("H", "Q")]
+        obs = BiddingObservation(
+            hand=hand,
+            seat=0,
+            dealer_seat=3,
+            current_high_bid=0,
+        )
+
+        action = bidder.choose_bid(obs)
+        # Should choose HIGH (more high cards)
+        if not action.is_pass():
+            assert action.contract == "HIGH"
+
+    def test_complies_with_strict_increasing(self):
+        """Passes if computed bid not higher than current."""
+        bidder = HighLowHeuristicBidder()
+        # Medium strength hand
+        hand = [Card("H", "A"), Card("C", "K"), Card("D", "Q"), Card("S", "J"), Card("H", "T")]
+        obs = BiddingObservation(
+            hand=hand,
+            seat=0,
+            dealer_seat=3,
+            current_high_bid=6,  # Higher than what we'd bid
+        )
+
+        action = bidder.choose_bid(obs)
+        assert action.is_pass()


### PR DESCRIPTION
## Summary
- Add 3 deterministic heuristic bidders (`FixedBidder`, `HeuristicSuitBidder`, `HighLowHeuristicBidder`)
- All comply with strict-increasing bidding rules and are fully deterministic
- Include comprehensive unit tests for each bidder

## Why
Provides baseline bidding policies to beat in offline/online evaluation. These complement the existing `AlwaysPassBidder` and `StrictRaiserBidder`.

## Repro / Validation
**Command(s) run:**
- `make lint`
- `PYTHONPATH=src python -m pytest tests/unit/test_heuristic_bidders.py -v`
- `PYTHONPATH=src python -m pytest tests/unit/ -q`

**Config (if applicable):**
N/A (no experiment config changes)

**Seed (if applicable):**
N/A (bidders are deterministic)

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/`
- [ ] Integration (if engine/rules changed): N/A - no engine changes
- [x] Unit tests for new bidders: `tests/unit/test_heuristic_bidders.py`

## Expected impact
- Metrics impact (if any): None - new bidders, not used in existing experiments
- Runtime impact (if any): None

## Risk level
- [ ] Low (docs/tests only)
- [x] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/Quentin/Projects/wt-feat-heuristic-bidders-v1
```

`git rev-parse --show-toplevel`:
```
/Users/Quentin/Projects/wt-feat-heuristic-bidders-v1
```

`git worktree list`:
```
/Users/Quentin/Projects/bid-euchre                               4b47404 [docs/gh-auth-sandbox-workflow]
/Users/Quentin/Projects/wt-feat-heuristic-bidders-v1             a594b99 [feat/heuristic-bidders-v1]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)