### PR TITLE
docs: harden PR prompt templates (pre-commit, expected outcomes)

### DIFF
--- a/docs/02_agent/PR_PROMPT_TEMPLATES.md
+++ b/docs/02_agent/PR_PROMPT_TEMPLATES.md
@@ -155,6 +155,17 @@ To make PR creation reliable:
 
 ---
 
+## Comprehension plan (no user confirmation required)
+
+**Before editing any files, the agent must write:**
+- 2–3 sentences describing what the PR will change
+- the exact file list it expects to touch
+- how it will verify (commands/tests)
+
+Explicitly state: **do not ask the user to confirm; proceed after writing the plan.**
+
+---
+
 # REPO PR AGENT PROMPT TEMPLATE (ROBUST SHORT TEMPLATE FOR CHEAPER AGENTS — PARALLEL-SAFE)
 
 ROLE
@@ -176,6 +187,14 @@ PARALLEL-SAFE RULES
 - If you discover required changes outside scope that touch shared files: STOP and report.
 - Do not “fix” nearby lint/docs unless it is strictly required for the scoped change.
 
+## Dependency ordering / parallelism
+
+If PR B depends on PR A, the prompt must say **"A must land before B starts"**
+
+If PRs can be parallelized, the prompt must include:
+- a non-overlapping file/area split
+- explicit warning about conflict risk when touching the same emitter/runner/core file
+
 GIT HYGIENE (required)
 - Never work or commit on main.
 - **Worktrees required; prove with commands before any edits.**
@@ -183,6 +202,20 @@ GIT HYGIENE (required)
 - Stage explicitly (no `git add .`).
 - Single commit per PR.
 - Clean up worktree at the end (see worktree cleanup section).
+
+## Pre-commit hook recovery protocol
+
+Recommended: run `pre-commit run -a` before commit if available.
+
+If a commit fails because hooks modified files:
+```bash
+git status
+git add -A
+git commit -m "<same message>"
+```
+
+**Never use `--no-verify`** unless explicitly instructed.
+Mention typical auto-fixers (EOF/whitespace, YAML, ruff) briefly.
 
 PERMISSIONS / GH ACCESS (critical)
 - Run GitHub + git-remote checks early (Step 0.2).
@@ -214,6 +247,14 @@ Hard Gates / Acceptance
 - baseline/invariant tests pass unless explicitly listed
 - PR body MUST include EVERY “##” section header from .github/pull_request_template.md
 - Final response MUST include proof snippets (see below)
+
+## Expected outcomes checksum
+
+Expected files changed (explicit list)
+Expected tests changed (approx: "+2 tests", "no removals")
+Expected behavior changes (1–2 bullets)
+
+This is for self-audit; not a hard guarantee.
 
 DOC COMMAND VALIDATION (required for docs changes that add/modify commands)
 For every command you add or change, include proof for at least one of:
@@ -374,6 +415,8 @@ PROOF REQUIRED:
 ────────────────────────────────────────
 Create PR (gh preferred)
 
+Agents can run directly in the terminal (outside sandbox) now, so `gh` should usually work. Still include a fallback if `gh api` fails TLS: use `scripts/create_pr_curl.sh` (if present) or instruct to create PR via curl only if `gh` fails with TLS verification error.
+
 Branch context gate (required):
 - test "$(git branch --show-current)" != "main" && echo "On feature branch ✅" || (echo "On main ❌" && exit 1)
 
@@ -448,6 +491,14 @@ PARALLEL-SAFE RULES
 - Do not edit central/index files unless explicitly scoped (README, docs/README.md, AGENTS.md, pyproject.toml, Makefile).
 - If required change touches shared files outside scope: STOP and report.
 
+## Dependency ordering / parallelism
+
+If PR B depends on PR A, the prompt must say **"A must land before B starts"**
+
+If PRs can be parallelized, the prompt must include:
+- a non-overlapping file/area split
+- explicit warning about conflict risk when touching the same emitter/runner/core file
+
 GIT HYGIENE (required)
 - Do not work or commit on main.
 - **Worktrees required; prove with commands before any edits.**
@@ -458,6 +509,20 @@ GIT HYGIENE (required)
 - PR body MUST use .github/pull_request_template.md (prepend summary bullets).
 - Default to creating the PR automatically via gh.
 - Clean up worktree at the end (see worktree cleanup section).
+
+## Pre-commit hook recovery protocol
+
+Recommended: run `pre-commit run -a` before commit if available.
+
+If a commit fails because hooks modified files:
+```bash
+git status
+git add -A
+git commit -m "<same message>"
+```
+
+**Never use `--no-verify`** unless explicitly instructed.
+Mention typical auto-fixers (EOF/whitespace, YAML, ruff) briefly.
 
 PERMISSIONS / ENV / GH ACCESS (critical)
 - You MUST run an early GitHub + git-remote capability check (Step 0.2).
@@ -494,6 +559,14 @@ Hard Gates / Acceptance Criteria
 - Deterministic behavior preserved.
 - PR body MUST include EVERY “##” section header from .github/pull_request_template.md (no omissions).
 - Final response MUST include proof snippets (validation + clean workspace) and header validation confirmation.
+
+## Expected outcomes checksum
+
+Expected files changed (explicit list)
+Expected tests changed (approx: "+2 tests", "no removals")
+Expected behavior changes (1–2 bullets)
+
+This is for self-audit; not a hard guarantee.
 
 Inputs / Ground Truth
 - Repo is authoritative: prefer what exists in code/docs over assumptions.
@@ -696,6 +769,8 @@ PROOF REQUIRED (final response):
 
 ──────────────────────────────────────────────────────────────────────────────
 CREATE PR (gh preferred)
+
+Agents can run directly in the terminal (outside sandbox) now, so `gh` should usually work. Still include a fallback if `gh api` fails TLS: use `scripts/create_pr_curl.sh` (if present) or instruct to create PR via curl only if `gh` fails with TLS verification error.
 
 Branch context gate (required):
 - test "$(git branch --show-current)" != "main" && echo "On feature branch ✅" || (echo "On main ❌" && exit 1)


### PR DESCRIPTION
## Summary
- Harden PR prompt templates with lessons learned from PR #98/#99 execution
- Add pre-commit hook recovery protocol for auto-fixer commits
- Add expected outcomes checksum for self-audit
- Add dependency ordering guidance for parallel PRs
- Update GitHub PR creation guidance for Cursor direct CLI access

## Why
- Pre-commit hook failures caused commits to fail when auto-fixers (EOF/whitespace, YAML, ruff) modified files after staging
- Need explicit dependency ordering for coupled PRs to prevent conflicts
- Expected outcomes provide self-audit mechanism for file/test changes
- Cursor agents can now run directly at command line, improving `gh` reliability
- These improvements will make future AI PRs execute more reliably

## Repro / Validation
**Command(s) run:**
- `make check`

**Config (if applicable):**
- N/A

**Seed (if applicable):**
- N/A

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/`
- [ ] Integration (if engine/rules changed): `PYTHONPATH=src python -m pytest tests/integration/`
- [ ] Other:

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/Quentin/Projects/wt-pr-prompt-template-hardening
```

`git rev-parse --show-toplevel`:
```
/Users/Quentin/Projects/wt-pr-prompt-template-hardening
```

`git worktree list`:
```
/Users/Quentin/Projects/bid-euchre                                  edf7dbc [main]
/Users/Quentin/Projects/wt-docs-bidding-dataset-contract-v1-pr3     97940e9 [docs/bidding-dataset-contract-v1-pr3]
/Users/Quentin/Projects/wt-docs-bidding-v1-sequential-redeal-debug  edf7dbc [docs/bidding-v1-sequential-redeal-debug]
/Users/Quentin/Projects/wt-feat-emit-bidding-dataset-v1             78770b1 [feat/emit-bidding-dataset-v1]
/Users/Quentin/Projects/wt-feat-heuristic-bidders-v1                a594b99 [feat/heuristic-bidders-v1]
/Users/Quentin/Projects/wt-fix-wire-emit-bidding-dataset-v1         0f10a86 [fix/wire-emit-bidding-dataset-v1]
/Users/Quentin/Projects/wt-pr-prompt-template-hardening             70976df [docs/pr-prompt-template-hardening]
/Users/Quentin/Projects/wt-test-bidding-dataset-schema-guard        a89eca2 [test/bidding-dataset-schema-guard]
/Users/Quentin/Projects/wt-verify-pr6-heuristic-bidders-present     828374e [verify/pr6-heuristic-bidders-present]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [ ] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)