### PR TITLE
fix: resolve YAML syntax error in nightly_baseline_full workflow

### DIFF
--- a/.github/workflows/nightly_baseline_full.yml
+++ b/.github/workflows/nightly_baseline_full.yml
@@ -68,20 +68,28 @@ jobs:
         script: |
           const runUrl = `${context.payload.repository.html_url}/actions/runs/${context.runId}`;
 
+          const issueBody = [
+            '## Nightly Baseline Full Failure',
+            '',
+            'The scheduled baseline_full suite has failed.',
+            '',
+            '| Field | Value |',
+            '|-------|-------|',
+            '| **Workflow Run** | [View Run](' + runUrl + ') |',
+            '| **Date** | ' + new Date().toISOString() + ' |',
+            '| **Branch** | `' + context.ref + '` |',
+            '',
+            '### Next Steps',
+            '',
+            '1. Check the workflow run logs above',
+            '2. Review the nightly-baseline-full-runs artifact',
+            '3. Investigate any test failures or runner issues',
+          ].join('\n');
+
           await github.rest.issues.create({
             owner: context.repo.owner,
             repo: context.repo.repo,
             title: `🚨 Nightly baseline_full failure - ${new Date().toISOString().split('T')[0]}`,
-            body: `## Nightly Baseline Full Failure
-
-The scheduled baseline_full suite has failed.
-
-**Workflow Run:** ${runUrl}
-
-**Date:** ${new Date().toISOString()}
-
-**Branch:** ${context.ref}
-
-Please investigate the failure and fix any issues.`,
+            body: issueBody,
             labels: ['bug', 'ci-failure']
           });


### PR DESCRIPTION
## Summary

- Fixed YAML syntax error in `.github/workflows/nightly_baseline_full.yml` that prevented the workflow from loading correctly
- Changed GitHub script to use string concatenation instead of template literals with markdown
- Improved issue body formatting with a table layout

## Why

The workflow had a YAML parsing error on lines 75-85 where a JavaScript template literal contained markdown with colons (e.g., `**Workflow Run:**`) that confused the YAML parser. This caused:

- GitHub Actions to register the workflow name as the file path instead of the proper name
- Immediate workflow failures with 0s duration on every push
- No actual workflow execution or logs

The root cause was using template literals for multi-line strings with YAML-special characters. The fix follows the pattern from `baseline_full_drift.yml` which uses string array concatenation with `.join('\n')`.

## Validation

**Local checks:**
```bash
make check
```
✅ All checks passed

**YAML validation:**
```bash
python -c "import yaml; yaml.safe_load(open('.github/workflows/nightly_baseline_full.yml'))"
```
✅ YAML is valid

**Test suite run:**
```bash
PYTHONPATH=src python scripts/run_suite.py \
  --suite experiments/suites/baseline_full.yaml \
  --seed 42 \
  --n-per 50 \
  --run-dir /tmp/test_nightly \
  --no-reports
```
✅ Suite completed successfully

## Expected Impact

- The `nightly-baseline-full` workflow will now load and execute properly
- No changes to workflow behavior or logic
- No metrics impact (workflow configuration fix only)

## Notes

This is a CI infrastructure fix with no changes to core logic, tests, or experiment code.