### PR TITLE
feat: add bidding model artifact schema v1 (json) + validation

### DIFF
--- a/data/fixtures/bidding_artifact_v1_tiny.json
+++ b/data/fixtures/bidding_artifact_v1_tiny.json
@@ -1,0 +1,22 @@
+{
+  "contract": "H",
+  "metadata": {
+    "created_at": "2024-01-01T00:00:00Z",
+    "description": "Example bidding model artifact for hearts contract"
+  },
+  "model_params": {
+    "coefficients": [
+      0.1,
+      0.2,
+      -0.05
+    ],
+    "features": [
+      "trump_count",
+      "high_card_points",
+      "suit_length"
+    ],
+    "intercept": 0.5
+  },
+  "model_type": "linear_regression",
+  "schema_version": "1"
+}

--- a/docs/01_core/BIDDING_MODEL.md
+++ b/docs/01_core/BIDDING_MODEL.md
@@ -1,0 +1,129 @@
+# Bidding Model Artifact Schema (v1)
+
+## Overview
+
+Bidding model artifacts define a deterministic, JSON-serializable format for storing trained bidding models. This schema enables stable model persistence and interchange across different training runs and environments.
+
+## Schema Definition
+
+### Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `schema_version` | string | Must be `"1"` (current schema version) |
+| `model_type` | string | Model type identifier (e.g., `"linear_regression"`, `"random_forest"`) |
+| `contract` | string | Target contract: `"C"`, `"D"`, `"H"`, `"S"`, `"HIGH"`, `"LOW"` |
+| `model_params` | object | JSON-serializable model parameters |
+
+### Optional Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `metadata` | object | JSON-serializable metadata (creation time, description, etc.) |
+
+## Contract Types
+
+Contracts are represented as single strings matching the bidding protocol:
+
+- `"C"`, `"D"`, `"H"`, `"S"`: Suit contracts (Clubs, Diamonds, Hearts, Spades)
+- `"HIGH"`, `"LOW"`: Special contracts (no trump suit)
+
+## JSON Requirements
+
+All fields must be JSON-serializable:
+- No Python objects, sets, or custom classes
+- No `numpy` arrays (convert to lists)
+- No `datetime` objects (use ISO strings)
+
+## Example Artifact
+
+```json
+{
+  "schema_version": "1",
+  "model_type": "linear_regression",
+  "contract": "H",
+  "model_params": {
+    "coefficients": [0.1, 0.2, -0.05],
+    "features": ["trump_count", "high_card_points", "suit_length"],
+    "intercept": 0.5
+  },
+  "metadata": {
+    "created_at": "2024-01-01T00:00:00Z",
+    "description": "Example bidding model for hearts contract",
+    "training_data_size": 10000
+  }
+}
+```
+
+## API Reference
+
+### `validate_artifact(obj: Dict[str, Any]) -> None`
+
+Validates an artifact dictionary against the schema.
+
+**Raises**: `ValueError` with descriptive message on validation failure.
+
+### `load_artifact(path: str) -> Dict[str, Any]`
+
+Loads and validates an artifact from a JSON file.
+
+**Returns**: Validated artifact dictionary
+
+**Raises**:
+- `FileNotFoundError`: File doesn't exist
+- `ValueError`: Invalid JSON or schema validation failure
+
+### `dump_artifact(obj: Dict[str, Any], path: str) -> None`
+
+Saves an artifact to a JSON file with stable formatting.
+
+- Validates artifact before writing
+- Uses `sort_keys=True, indent=2` for deterministic output
+- Creates parent directories as needed
+
+**Raises**:
+- `ValueError`: Invalid artifact
+- `OSError`: File system errors
+
+## Validation Rules
+
+1. **Required fields**: All fields in "Required Fields" must be present
+2. **Schema version**: Must exactly equal `"1"`
+3. **Model type**: Non-empty string
+4. **Contract**: Must be one of the valid contract strings
+5. **JSON serializable**: `model_params` and `metadata` must pass `json.dumps()`
+
+## File Format
+
+Artifacts are stored as UTF-8 encoded JSON files with:
+- Sorted keys for deterministic output
+- 2-space indentation
+- Trailing newline
+- ASCII-compatible encoding (`ensure_ascii=False`)
+
+## Usage in Training Pipeline
+
+```python
+from bid_euchre.models.bidding_artifact import dump_artifact, load_artifact
+
+# After training
+artifact = {
+    "schema_version": "1",
+    "model_type": "linear_regression",
+    "contract": "H",
+    "model_params": trained_model_params,
+    "metadata": {"accuracy": 0.85, "created_at": "2024-01-01T00:00:00Z"}
+}
+
+dump_artifact(artifact, "models/hearts_v1.json")
+
+# Later, in inference
+model_artifact = load_artifact("models/hearts_v1.json")
+# Use model_artifact["model_params"] for inference
+```
+
+## Migration Notes
+
+- **v1 is initial schema**: No migration path from earlier versions
+- **Stability guarantee**: v1 artifacts will remain loadable in future versions
+- **Extension strategy**: New fields may be added as optional in future versions

--- a/src/bid_euchre/models/__init__.py
+++ b/src/bid_euchre/models/__init__.py
@@ -1,0 +1,1 @@
+# Bidding model artifacts

--- a/src/bid_euchre/models/bidding_artifact.py
+++ b/src/bid_euchre/models/bidding_artifact.py
@@ -1,0 +1,112 @@
+"""
+Bidding model artifact schema v1 - JSON-serializable bidding models.
+
+This module provides a deterministic, JSON-serializable format for bidding model artifacts.
+Artifacts are stable across runs and can be used to represent trained bidding policies.
+"""
+
+import json
+import os
+from typing import Any, Dict
+
+# Valid contract strings (must match core bidding system)
+VALID_CONTRACTS = {"C", "D", "H", "S", "HIGH", "LOW"}
+
+
+def validate_artifact(obj: Dict[str, Any]) -> None:
+    """
+    Validate a bidding model artifact dictionary.
+
+    Args:
+        obj: The artifact dictionary to validate
+
+    Raises:
+        ValueError: If the artifact is invalid with a clear error message
+    """
+    if not isinstance(obj, dict):
+        raise ValueError("Artifact must be a dictionary")
+
+    # Required fields
+    required_fields = {"schema_version", "model_type", "contract", "model_params"}
+    missing = required_fields - set(obj.keys())
+    if missing:
+        raise ValueError(f"Missing required fields: {sorted(missing)}")
+
+    # Schema version
+    if obj["schema_version"] != "1":
+        raise ValueError(f"Unsupported schema version: {obj['schema_version']}, expected '1'")
+
+    # Model type
+    if not isinstance(obj["model_type"], str):
+        raise ValueError("model_type must be a string")
+    if not obj["model_type"].strip():
+        raise ValueError("model_type cannot be empty")
+
+    # Contract
+    if obj["contract"] not in VALID_CONTRACTS:
+        raise ValueError(f"Invalid contract '{obj['contract']}', must be one of: {sorted(VALID_CONTRACTS)}")
+
+    # Model params - must be JSON-serializable
+    try:
+        json.dumps(obj["model_params"])
+    except (TypeError, ValueError) as e:
+        raise ValueError(f"model_params must be JSON-serializable: {e}")
+
+    # Optional metadata validation
+    if "metadata" in obj:
+        try:
+            json.dumps(obj["metadata"])
+        except (TypeError, ValueError) as e:
+            raise ValueError(f"metadata must be JSON-serializable: {e}")
+
+
+def load_artifact(path: str) -> Dict[str, Any]:
+    """
+    Load and validate a bidding model artifact from JSON file.
+
+    Args:
+        path: Path to the JSON artifact file
+
+    Returns:
+        The validated artifact dictionary
+
+    Raises:
+        FileNotFoundError: If the file doesn't exist
+        ValueError: If the JSON is invalid or artifact fails validation
+    """
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Artifact file not found: {path}")
+
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            obj = json.load(f)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON in artifact file {path}: {e}")
+
+    validate_artifact(obj)
+    return obj
+
+
+def dump_artifact(obj: Dict[str, Any], path: str) -> None:
+    """
+    Dump a validated bidding model artifact to a JSON file.
+
+    Creates stable JSON output with sorted keys and consistent formatting.
+
+    Args:
+        path: Path where to save the artifact
+        obj: The artifact dictionary (will be validated first)
+
+    Raises:
+        ValueError: If the artifact is invalid
+        OSError: If the directory doesn't exist or file cannot be written
+    """
+    validate_artifact(obj)
+
+    # Ensure directory exists
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+
+    # Write with stable formatting
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(obj, f, sort_keys=True, indent=2, ensure_ascii=False)
+        f.write('\n')  # Add trailing newline

--- a/tests/unit/test_bidding_artifact_schema.py
+++ b/tests/unit/test_bidding_artifact_schema.py
@@ -1,0 +1,198 @@
+"""
+Schema validation tests for bidding model artifact v1.
+
+These tests ensure the bidding artifact schema is correctly validated
+and catches invalid artifacts appropriately.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from bid_euchre.models.bidding_artifact import (
+    VALID_CONTRACTS,
+    dump_artifact,
+    load_artifact,
+    validate_artifact,
+)
+
+
+class TestBiddingArtifactSchema:
+    """Test bidding artifact schema validation."""
+
+    FIXTURE_PATH = Path("data/fixtures/bidding_artifact_v1_tiny.json")
+
+    def test_fixture_exists(self):
+        """Ensure the tiny fixture file exists."""
+        assert self.FIXTURE_PATH.exists(), f"Fixture file not found: {self.FIXTURE_PATH}"
+
+    def test_valid_fixture_loads_and_validates(self):
+        """Test that the fixture artifact loads and validates successfully."""
+        artifact = load_artifact(str(self.FIXTURE_PATH))
+
+        # Should not raise an exception
+        validate_artifact(artifact)
+
+        # Check required fields are present
+        assert artifact["schema_version"] == "1"
+        assert artifact["model_type"] == "linear_regression"
+        assert artifact["contract"] == "H"
+        assert isinstance(artifact["model_params"], dict)
+        assert "metadata" in artifact
+
+    def test_rejects_missing_required_keys(self):
+        """Test that artifacts with missing required keys are rejected."""
+        valid_artifact = {
+            "schema_version": "1",
+            "model_type": "test",
+            "contract": "H",
+            "model_params": {"test": "value"}
+        }
+
+        # Test missing each required field
+        for field in ["schema_version", "model_type", "contract", "model_params"]:
+            invalid_artifact = {k: v for k, v in valid_artifact.items() if k != field}
+            with pytest.raises(ValueError, match=f"Missing required fields.*{field}"):
+                validate_artifact(invalid_artifact)
+
+    def test_rejects_invalid_schema_version(self):
+        """Test that artifacts with wrong schema version are rejected."""
+        artifact = {
+            "schema_version": "2",  # Wrong version
+            "model_type": "test",
+            "contract": "H",
+            "model_params": {"test": "value"}
+        }
+        with pytest.raises(ValueError, match="Unsupported schema version: 2"):
+            validate_artifact(artifact)
+
+    def test_rejects_invalid_contract(self):
+        """Test that artifacts with invalid contracts are rejected."""
+        artifact = {
+            "schema_version": "1",
+            "model_type": "test",
+            "contract": "INVALID",  # Invalid contract
+            "model_params": {"test": "value"}
+        }
+        with pytest.raises(ValueError, match="Invalid contract 'INVALID'"):
+            validate_artifact(artifact)
+
+    def test_accepts_all_valid_contracts(self):
+        """Test that all valid contracts are accepted."""
+        for contract in VALID_CONTRACTS:
+            artifact = {
+                "schema_version": "1",
+                "model_type": "test",
+                "contract": contract,
+                "model_params": {"test": "value"}
+            }
+            # Should not raise
+            validate_artifact(artifact)
+
+    def test_rejects_non_json_serializable_model_params(self):
+        """Test that non-JSON-serializable model_params are rejected."""
+        # Test with a set (not JSON-serializable)
+        artifact = {
+            "schema_version": "1",
+            "model_type": "test",
+            "contract": "H",
+            "model_params": {"invalid": {1, 2, 3}}  # set is not JSON-serializable
+        }
+        with pytest.raises(ValueError, match="model_params must be JSON-serializable"):
+            validate_artifact(artifact)
+
+    def test_rejects_non_json_serializable_metadata(self):
+        """Test that non-JSON-serializable metadata is rejected."""
+        artifact = {
+            "schema_version": "1",
+            "model_type": "test",
+            "contract": "H",
+            "model_params": {"test": "value"},
+            "metadata": {"invalid": {1, 2, 3}}  # set is not JSON-serializable
+        }
+        with pytest.raises(ValueError, match="metadata must be JSON-serializable"):
+            validate_artifact(artifact)
+
+    def test_load_artifact_file_not_found(self):
+        """Test that load_artifact raises FileNotFoundError for missing files."""
+        with pytest.raises(FileNotFoundError, match="Artifact file not found"):
+            load_artifact("nonexistent_file.json")
+
+    def test_load_artifact_invalid_json(self):
+        """Test that load_artifact raises ValueError for invalid JSON."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            f.write("invalid json content {")
+            temp_path = f.name
+
+        try:
+            with pytest.raises(ValueError, match="Invalid JSON"):
+                load_artifact(temp_path)
+        finally:
+            Path(temp_path).unlink()
+
+    def test_dump_artifact_creates_valid_file(self):
+        """Test that dump_artifact creates a valid, loadable file."""
+        artifact = {
+            "schema_version": "1",
+            "model_type": "test_model",
+            "contract": "S",
+            "model_params": {"param1": 1, "param2": [1, 2, 3]},
+            "metadata": {"created": "test"}
+        }
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            temp_path = f.name
+
+        try:
+            dump_artifact(artifact, temp_path)
+
+            # File should exist
+            assert Path(temp_path).exists()
+
+            # Should be loadable and valid
+            loaded = load_artifact(temp_path)
+            assert loaded == artifact
+
+        finally:
+            Path(temp_path).unlink()
+
+    def test_dump_artifact_rejects_invalid_artifact(self):
+        """Test that dump_artifact validates before writing."""
+        invalid_artifact = {"missing": "fields"}
+
+        with pytest.raises(ValueError):
+            dump_artifact(invalid_artifact, "dummy_path.json")
+
+    def test_dump_artifact_stable_formatting(self):
+        """Test that dump_artifact produces stable, sorted JSON output."""
+        artifact = {
+            "schema_version": "1",
+            "model_type": "test",
+            "contract": "C",
+            "model_params": {"z_param": 1, "a_param": 2},
+            "metadata": {"z_meta": "last", "a_meta": "first"}
+        }
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            temp_path = f.name
+
+        try:
+            dump_artifact(artifact, temp_path)
+
+            with open(temp_path, 'r') as f:
+                content = f.read()
+
+            # Parse and check it's valid JSON
+            parsed = json.loads(content)
+            assert parsed == artifact
+
+            # Check formatting (sorted keys, indent=2)
+            lines = content.strip().split('\n')
+            assert lines[0] == '{'
+            assert lines[1].startswith('  "contract":')
+            # Keys should be in sorted order at top level
+
+        finally:
+            Path(temp_path).unlink()


### PR DESCRIPTION
## Summary
- Define JSON-serializable bidding model artifact schema v1
- Add validation helpers for loading/saving artifacts
- Include comprehensive unit tests and fixture
- Document schema in core docs

## Why
- Enable Phase 2 training by providing a deterministic JSON artifact format for bidding models
- Ensure stable serialization across runs with validation
- Unblock training pipeline with standardized model persistence

## Repro / Validation
**Command(s) run:**
- `PYTHONPATH=.:src python -m pytest tests/unit/test_bidding_artifact_schema.py -v`
- `PYTHONPATH=.:src python -c "from bid_euchre.models.bidding_artifact import load_artifact; print('✅ Load works:', load_artifact('data/fixtures/bidding_artifact_v1_tiny.json')['model_type'])"`

**Config (if applicable):**
- N/A

**Seed (if applicable):**
- N/A

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/`
- [ ] Integration (if engine/rules changed): `PYTHONPATH=src python -m pytest tests/integration/`
- [x] Other: `PYTHONPATH=.:src python -m pytest tests/unit/test_bidding_artifact_schema.py -v` (13 tests)

## Expected impact
- Metrics impact (if any): None (new schema only)
- Runtime impact (if any): None (validation adds minimal overhead)

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/Quentin/Projects/.worktrees/feat/add-bidding-model-artifact-schema-v1
```

`git rev-parse --show-toplevel`:
```
/Users/Quentin/Projects/.worktrees/feat/add-bidding-model-artifact-schema-v1
```

`git worktree list`:
```
/Users/Quentin/Projects/bid-euchre                                            997067a [main]
/Users/Quentin/Projects/.worktrees/feat/add-bidding-model-artifact-schema-v1  cbf009d [feat/add-bidding-model-artifact-schema-v1]
/Users/Quentin/Projects/bid-euchre-fix-nightly-workflow                       ae76ceb [fix/nightly-workflow-yaml-syntax]
/Users/Quentin/Projects/wt-bid-pr-05-parquet-canonical                        d6e35ce [bid-pr-05-parquet-canonical]
/Users/Quentin/Projects/wt-bid-pr-05-parquet-canonical-v2                     dcbaba4 [bid-pr-05-parquet-canonical-v2]
/Users/Quentin/Projects/wt-docs-bidding-dataset-contract-v1-pr3               97940e9 [docs/bidding-dataset-contract-v1-pr3]
/Users/Quentin/Projects/wt-feat-emit-bidding-dataset-v1                       78770b1 [feat/emit-bidding-dataset-v1]
/Users/Quentin/Projects/wt-feat-heuristic-bidders-v1                          a594b99 [feat/heuristic-bidders-v1]
/Users/Quentin/Projects/wt-fix-wire-emit-bidding-dataset-v1                   0f10a86 [fix/wire-emit-bidding-dataset-v1]
/Users/Quentin/Projects/wt-modular-pr-prompts                                 a076428 [docs/modular-pr-prompt-templates]
/Users/Quentin/Projects/wt-pr-prompt-template-hardening                       70976df [docs/pr-prompt-template-hardening]
/Users/Quentin/Projects/wt-test-bidding-dataset-schema-guard                  a89eca2 [test/bidding-dataset-schema-guard]
/Users/Quentin/Projects/wt-verify-pr6-heuristic-bidders-present               828374e [verify/pr6-heuristic-bidders-present]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
