### PR TITLE
docs: remove conflicting single-agent branch-only mode from PR templates

### DIFF
--- a/docs/02_agent/PR_PROMPT_TEMPLATES.md
+++ b/docs/02_agent/PR_PROMPT_TEMPLATES.md
@@ -625,14 +625,7 @@ Run and PASTE outputs verbatim:
 - git fetch origin (if blocked, say “fetch blocked” and continue)
 
 Then:
-- Single-agent / non-parallel mode:
-  - You MUST be on main before branching:
-    - cd out of worktree (cd - or cd ..)
-    - git status -sb
-  - Create/switch to branch:
-    - git checkout -b <branch-name>
-
-- Parallel Mode (worktrees; REQUIRED for multi-agent runs):
+- Worktree creation (MANDATORY for all runs, including single-agent):
   - Do NOT branch-switch the shared checkout.
   - Worktree creation (from the main repo root):
     - BRANCH="<branch-name>"


### PR DESCRIPTION
## Summary
- Remove conflicting single-agent branch-only mode section from PR templates
- Fix internal inconsistency where worktrees were claimed as mandatory but branch-only workflows were still documented
- Ensure all PR agents use worktrees exclusively for parallel safety

## Why
The PR prompt templates contained contradictory instructions: the worktree enforcement section stated that worktrees are MANDATORY for ALL runs including single-agent, but the templates still showed single-agent branch-only workflows with `git checkout -b`. This created confusion and potential for agents to violate the mandatory worktree requirement.

## Repro / Validation
**Command(s) run:**
- `make check` (passed all tests)
- Verified internal consistency across both SHORT and LONG PR templates

**Config (if applicable):**
- N/A

**Seed (if applicable):**
- N/A

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/` (passed)
- [ ] Integration (if engine/rules changed): N/A
- [ ] Other: Repo linter passed

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/Quentin/Projects/.worktrees/docs-fix-template-consistency-v2-20260112-145057-21970
```

`git rev-parse --show-toplevel`:
```
/Users/Quentin/Projects/.worktrees/docs-fix-template-consistency-v2-20260112-145057-21970
```

`git worktree list`:
```
/Users/Quentin/Projects/bid-euchre                                                                                   12de893 [main]
/Users/Quentin/Projects/.worktrees/.worktrees/feat-bidding-model-artifact-v1-schema-emit-load-20260112-145507-24648  b433dbe [feat/bidding-model-artifact-v1-schema-emit-load]
/Users/Quentin/Projects/.worktrees/docs-fix-template-consistency-v2-20260112-145057-21970                            f152bee [docs/fix-template-consistency-v2]
/Users/Quentin/Projects/.worktrees/docs-pr-templates-parallel-safety-20260112-141450-8753                            7dd6847 [docs/pr-templates-parallel-safety]
/Users/Quentin/Projects/.worktrees/feat-bidding-model-artifact-v1-complete-20260112-145044-21483                     b433dbe [feat/bidding-model-artifact-v1-complete]
/Users/Quentin/Projects/bid-euchre-fix-nightly-workflow                                                              ae76ceb [fix/nightly-workflow-yaml-syntax]
/Users/Quentin/Projects/wt-bid-pr-05-parquet-canonical                                                               d6e35ce [bid-pr-05-parquet-canonical]
/Users/Quentin/Projects/wt-bid-pr-05-parquet-canonical-v2                                                            dcbaba4 [bid-pr-05-parquet-canonical-v2]
/Users/Quentin/Projects/wt-docs-bidding-dataset-contract-v1-pr3                                                      97940e9 [docs/bidding-dataset-contract-v1-pr3]
/Users/Quentin/Projects/wt-feat-emit-bidding-dataset-v1                                                              78770b1 [feat/emit-bidding-dataset-v1]
/Users/Quentin/Projects/wt-feat-heuristic-bidders-v1                                                                 a594b99 [feat/heuristic-bidders-v1]
/Users/Quentin/Projects/wt-fix-wire-emit-bidding-dataset-v1                                                          0f10a86 [fix/wire-emit-bidding-dataset-v1]
/Users/Quentin/Projects/wt-modular-pr-prompts                                                                        a076428 [docs/modular-pr-prompt-templates]
/Users/Quentin/Projects/wt-pr-prompt-template-hardening                                                              70976df [docs/pr-prompt-template-hardening]
/Users/Quentin/Projects/wt-test-bidding-dataset-schema-guard                                                         a89eca2 [test/bidding-dataset-schema-guard]
/Users/Quentin/Projects/wt-verify-pr6-heuristic-bidders-present                                                      828374e [verify/pr6-heuristic-bidders-present]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [ ] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
