### PR TITLE
docs: add execution modes (Cursor-managed worktrees) to PR templates

### DIFF
--- a/docs/02_agent/PR_PROMPT_TEMPLATES.md
+++ b/docs/02_agent/PR_PROMPT_TEMPLATES.md
@@ -280,11 +280,27 @@ Run + paste outputs verbatim:
 - git branch --show-current
 - git fetch origin (or “fetch blocked”)
 
-Then:
-- Worktree creation (MANDATORY; branch-only workflows are forbidden):
-  - Do NOT branch-switch from the shared checkout.
-  - Worktree creation (from the main repo root):
-    - BRANCH="<branch-name>"
+Then determine execution mode and proceed:
+
+### Mode A — Cursor-managed worktree
+Hard rules:
+- DO NOT run `git worktree add`.
+- If you are on `main` in this worktree, create a feature branch *inside this worktree*:
+  - git switch -c <branch-name>
+
+Paste proofs:
+- pwd
+- git rev-parse --show-toplevel
+- git worktree list
+- git status -sb
+
+Base proof:
+- git merge-base --is-ancestor main HEAD && echo "based on main ✅" || echo "NOT based on main ❌"
+
+### Mode B — Manual worktree creation (ONLY if you are in the shared checkout and NOT already in an isolated worktree)
+From the shared repo root:
+```bash
+BRANCH="<branch-name>"
     - SUFFIX="$(date +%Y%m%d-%H%M%S)-$$"
     - WT_DIR="../.worktrees/${BRANCH//\//-}-$SUFFIX"
     - mkdir -p ../.worktrees


### PR DESCRIPTION
## Summary
- Clarify Cursor-managed vs manual worktree flows in PR templates
- Make branch-creation rules correct (forbidden only in shared checkout)
- Reduce parallel agent overlap/confusion

## Why
- Agents were trying to create worktrees when Cursor already provided one
- Branch creation rules were confusing - `git switch -c` should be allowed in worktrees
- Need clear separation between execution modes for parallel safety

## Repro / Validation
**Command(s) run:**
- `make check`

**Config (if applicable):**
- N/A

**Seed (if applicable):**
- N/A

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/`
- [ ] Integration (if engine/rules changed): `PYTHONPATH=src python -m pytest tests/integration/`
- [ ] Other:

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/Quentin/.cursor/worktrees/bid-euchre/vys
```

`git rev-parse --show-toplevel`:
```
/Users/Quentin/.cursor/worktrees/bid-euchre/vys
```

`git worktree list`:
```
/Users/Quentin/Projects/bid-euchre                                                                                   7eb9146 [main]
/Users/Quentin/.cursor/worktrees/bid-euchre/vys                                                                      ba63f9d (docs/execution-modes-pr-templates)
/Users/Quentin/Projects/.worktrees/.worktrees/feat-bidding-model-artifact-v1-schema-emit-load-20260112-145507-24648  b433dbe [feat/bidding-model-artifact-v1-schema-emit-load]
/Users/Quentin/Projects/.worktrees/docs-pr-templates-parallel-safety-20260112-141450-8753                            7dd6847 [docs/pr-templates-parallel-safety]
/Users/Quentin/Projects/.worktrees/feat-bid-pr-09b-heuristics-training-20260112-151941-32088                         7eb9146 [feat/bid-pr-09b-heuristics-training]
/Users/Quentin/Projects/.worktrees/feat-bidding-model-artifact-v1-complete-20260112-145044-21483                     b433dbe [feat/bidding-model-artifact-v1-complete]
/Users/Quentin/Projects/bid-euchre-fix-nightly-workflow                                                              ae76ceb [fix/nightly-workflow-yaml-syntax]
/Users/Quentin/Projects/wt-bid-pr-05-parquet-canonical                                                               d6e35ce [bid-pr-05-parquet-canonical]
/Users/Quentin/Projects/wt-bid-pr-05-parquet-canonical-v2                                                            dcbaba4 [bid-pr-05-parquet-canonical-v2]
/Users/Quentin/Projects/wt-docs-bidding-dataset-contract-v1-pr3                                                      97940e9 [docs/bidding-dataset-contract-v1-pr3]
/Users/Quentin/Projects/wt-feat-emit-bidding-dataset-v1                                                              78770b1 [feat/emit-bidding-dataset-v1]
/Users/Quentin/Projects/wt-feat-heuristic-bidders-v1                                                                 a594b99 [feat/heuristic-bidders-v1]
/Users/Quentin/Projects/wt-fix-wire-emit-bidding-dataset-v1                                                          0f10a86 [fix/wire-emit-bidding-dataset-v1]
/Users/Quentin/Projects/wt-modular-pr-prompts                                                                        a076428 [docs/modular-pr-prompt-templates]
/Users/Quentin/Projects/wt-pr-prompt-template-hardening                                                              70976df [docs/pr-prompt-template-hardening]
/Users/Quentin/Projects/wt-test-bidding-dataset-schema-guard                                                         a89eca2 [test/bidding-dataset-schema-guard]
/Users/Quentin/Projects/wt-verify-pr6-heuristic-bidders-present                                                      828374e [verify/pr6-heuristic-bidders-present]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [ ] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)