### PR TITLE
feat: add bid_eval_tiny suite and risk-metric evaluator output

### DIFF
--- a/experiments/configs/bid_eval_tiny.yaml
+++ b/experiments/configs/bid_eval_tiny.yaml
@@ -1,0 +1,15 @@
+experiment_name: bid_eval_tiny
+
+strategies:
+  - name: artifact_bidder
+    class_name: ArtifactGreedyStrategy
+    params:
+      artifact_path: data/fixtures/bidding_artifact_v1_tiny.json
+
+scenarios:
+  - contract_type: null
+
+parameters:
+  n_per: 40
+  seed: 42
+  log_level: hand

--- a/experiments/suites/bid_eval_tiny.yaml
+++ b/experiments/suites/bid_eval_tiny.yaml
@@ -1,0 +1,19 @@
+# Tiny evaluation suite for artifact-backed bidders.
+# Uses auction mode with hand-level logging so risk metrics can be computed.
+
+suite_name: bid_eval_tiny
+
+purpose: Evaluate artifact-backed bidders with risk-aware metrics (CVaR & downside variance).
+
+parameters:
+  seed: 42
+  n_per: 20
+  log_level: hand
+
+configs:
+  - experiments/configs/bid_eval_tiny.yaml
+
+notes:
+  - "Designed for quick evaluation of linear-regression artifact bidders."
+  - "Uses auction mode (contract_type: null) to measure bidding outcomes."
+  - "Logging level 'hand' enables structured evaluator output."

--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -21,6 +21,8 @@ from typing import Dict, List
 
 import yaml
 
+from bid_euchre.reporting.evaluator import generate_bidder_evaluation
+
 
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
@@ -278,6 +280,14 @@ def main() -> int:
     if args.verbose:
         print("📝 Generating ANALYSIS_SUMMARY.md...")
     generate_analysis_summary(run_dir, metadata, result_files, chart_files, args.verbose)
+    
+    evaluation_path = generate_bidder_evaluation(run_dir)
+    if evaluation_path:
+        rel_path = evaluation_path.relative_to(run_dir)
+        if args.verbose:
+            print(f"🧮 Generated bidder evaluation: {rel_path}")
+        else:
+            print(f"🧮 Bidder evaluation: {rel_path}")
     
     if args.verbose:
         print("✅ Report generation complete!")

--- a/src/bid_euchre/experiments/config.py
+++ b/src/bid_euchre/experiments/config.py
@@ -19,6 +19,7 @@ from ..strategy import (
     RandomLegalStrategy,
     Strategy,
 )
+from ..strategy.artifact_strategy import ArtifactGreedyStrategy
 
 
 @dataclass
@@ -44,6 +45,13 @@ class StrategyConfig:
             return AlwaysLowestLegalStrategy(name=self.name)
         elif self.class_name == "AlwaysHighestLegalStrategy":
             return AlwaysHighestLegalStrategy(name=self.name)
+        elif self.class_name == "ArtifactGreedyStrategy":
+            artifact_path = self.params.get("artifact_path")
+            if not artifact_path:
+                raise ValueError(
+                    "ArtifactGreedyStrategy requires 'artifact_path' parameter"
+                )
+            return ArtifactGreedyStrategy(name=self.name, artifact_path=artifact_path)
         else:
             raise ValueError(f"Unknown strategy class: {self.class_name}")
 

--- a/src/bid_euchre/reporting/evaluator.py
+++ b/src/bid_euchre/reporting/evaluator.py
@@ -1,0 +1,164 @@
+"""
+Deterministic evaluator for auction-mode bidders.
+
+This module parses hand-level logs and summarizes bidder risk metrics,
+ensuring outputs are stable given the same run.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from datetime import datetime, timezone
+from math import ceil
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from ..scoring import compute_points
+from .paths import get_data_paths
+
+
+def _iter_hand_end_records(log_path: Path) -> Iterable[Dict]:
+    if not log_path.exists():
+        return
+
+    with log_path.open() as stream:
+        for line in stream:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            if record.get("event") == "hand_end":
+                yield record
+
+
+def _bidder_team_points(record: Dict) -> Optional[int]:
+    winning_bid = record.get("winning_bid")
+    bidder_position = record.get("bidder_position")
+    if winning_bid is None or bidder_position is None:
+        return None
+
+    t0 = record.get("t0")
+    t1 = record.get("t1")
+    if t0 is None or t1 is None:
+        return None
+
+    try:
+        t0 = int(t0)
+        t1 = int(t1)
+        winning_bid = int(winning_bid)
+        bidder_position = int(bidder_position)
+    except (TypeError, ValueError):
+        return None
+
+    pts0, pts1 = compute_points(winning_bid, bidder_position, t0, t1)
+    if bidder_position in (0, 2):
+        return pts0
+    return pts1
+
+
+def compute_cvar(values: List[int], tail_fraction: float = 0.05) -> Optional[float]:
+    if not values:
+        return None
+    sorted_values = sorted(values)
+    tail_size = max(1, ceil(len(sorted_values) * tail_fraction))
+    tail = sorted_values[:tail_size]
+    return sum(tail) / len(tail)
+
+
+def compute_downside_variance(values: List[int], target: float = 0.0) -> Optional[float]:
+    negatives = [v for v in values if v < target]
+    if not negatives:
+        return None
+    mean_negative = sum(negatives) / len(negatives)
+    variance = sum((value - mean_negative) ** 2 for value in negatives) / len(negatives)
+    return variance
+
+
+def _round(value: Optional[float]) -> Optional[float]:
+    if value is None:
+        return None
+    return round(value, 5)
+
+
+def generate_bidder_evaluation(run_dir: Path) -> Optional[Path]:
+    """
+    Generate evaluation JSON summarizing metrics per bidder strategy.
+
+    The primary series is always `bidder_team_points`. CVaR-5% is defined as
+    the average of the worst 5% of outcomes. Downside variance is the variance
+    of returns that fall below zero.
+    """
+    logs_path, _ = get_data_paths(str(run_dir))
+    logs_dir = Path(logs_path)
+    records_by_strategy: Dict[str, List[Dict]] = defaultdict(list)
+    used_log_files: List[Path] = []
+
+    for log_file in sorted(logs_dir.glob("*.jsonl")):
+        seen = False
+        for record in _iter_hand_end_records(log_file):
+            strategy_id = record.get("strategy_id") or "unknown"
+            records_by_strategy[strategy_id].append(record)
+            seen = True
+        if seen:
+            used_log_files.append(log_file)
+
+    if not records_by_strategy:
+        return None
+
+    strategy_metrics = []
+    for strategy_id in sorted(records_by_strategy.keys()):
+        records = sorted(
+            records_by_strategy[strategy_id],
+            key=lambda r: (int(r.get("deal_id", 0)), r.get("timestamp", "")),
+        )
+        bidder_points: List[int] = []
+        made_count = 0
+        for record in records:
+            points = _bidder_team_points(record)
+            if points is None:
+                continue
+            bidder_points.append(points)
+            if points >= 0:
+                made_count += 1
+
+        hands_with_bids = len(bidder_points)
+        expected = sum(bidder_points) / hands_with_bids if hands_with_bids else None
+        make_rate = made_count / hands_with_bids if hands_with_bids else None
+
+        entry = {
+            "strategy_id": strategy_id,
+            "hands_with_bids": hands_with_bids,
+            "bidder_team_points": bidder_points,
+            "expected_points": _round(expected),
+            "make_rate": _round(make_rate),
+            "cvar_5": _round(compute_cvar(bidder_points)),
+            "downside_variance": _round(compute_downside_variance(bidder_points)),
+        }
+        strategy_metrics.append(entry)
+
+    output_dir = Path(run_dir) / "reports" / "bidding_strategy"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / "evaluation.json"
+
+    payload = {
+        "run_id": Path(run_dir).name,
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "primary_series": "bidder_team_points",
+        "source_logs": [str(p.relative_to(run_dir)) for p in used_log_files],
+        "strategies": strategy_metrics,
+        "metric_definitions": {
+            "cvar_5": "avg of worst 5% bidder_team_points",
+            "downside_variance": "variance of bidder_team_points below 0",
+        },
+    }
+
+    with output_path.open("w") as stream:
+        json.dump(payload, stream, indent=2, sort_keys=True)
+        stream.write("\n")
+
+    return output_path

--- a/src/bid_euchre/strategy/artifact_strategy.py
+++ b/src/bid_euchre/strategy/artifact_strategy.py
@@ -1,0 +1,125 @@
+"""
+Artifact-backed strategy for Auction mode.
+
+This module provides a strategy that reuses an existing playable card policy
+but delegates bidding to a deterministic artifact (v1 schema) that predicts
+how aggressively to bid for a fixed contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ..core.cards import Card
+from ..features.hand_eval import get_hand_features
+from ..models.bidding_artifact import load_artifact
+from ..strategy.greedy import ImprovedGreedyStrategy
+
+HIGH_CARD_WEIGHTS: Dict[str, int] = {
+    "A": 4,
+    "K": 3,
+    "Q": 2,
+    "J": 1,
+    "T": 0,
+}
+
+
+class ArtifactGreedyStrategy(ImprovedGreedyStrategy):
+    """
+    Greedy card-play logic with artifact-backed bidding decisions.
+
+    The artifact controls bidding for a single contract (suit/HIGH/LOW). Card
+    play defers to :class:`ImprovedGreedyStrategy`.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        artifact_path: str,
+    ):
+        super().__init__(name=name)
+        artifact = load_artifact(artifact_path)
+        model_params = artifact["model_params"]
+
+        if artifact["model_type"] != "linear_regression":
+            raise ValueError(
+                "ArtifactGreedyStrategy only supports linear_regression artifacts"
+            )
+
+        self._artifact = artifact
+        self._feature_names: List[str] = list(model_params["features"])
+        self._coefficients: List[float] = [float(v) for v in model_params["coefficients"]]
+        self._intercept: float = float(model_params.get("intercept", 0.0))
+        self._contract_token = artifact["contract"]
+        self._contract_type, self._trump_suit = self._resolve_contract(artifact["contract"])
+
+        if len(self._feature_names) != len(self._coefficients):
+            raise ValueError(
+                "Mismatch between artifact feature list and coefficient length"
+            )
+
+    def _resolve_contract(self, contract: str) -> tuple[str, Any]:
+        if contract in {"C", "D", "H", "S"}:
+            return "suit", contract
+        if contract == "HIGH":
+            return "high", None
+        if contract == "LOW":
+            return "low", None
+        raise ValueError(f"Unsupported artifact contract: {contract}")
+
+    def _derivable_features(self, hand: List[Card]) -> Dict[str, float]:
+        suit_lengths: Dict[str, int] = {}
+        for card in hand:
+            suit_lengths[card.suit] = suit_lengths.get(card.suit, 0) + 1
+
+        max_suit_len = max(suit_lengths.values()) if suit_lengths else 0
+        high_card_points = sum(HIGH_CARD_WEIGHTS.get(card.rank, 0) for card in hand)
+
+        return {
+            "suit_length": float(max_suit_len),
+            "high_card_points": float(high_card_points),
+        }
+
+    def _hand_feature_vector(self, hand: List[Card]) -> List[float]:
+        core_features = get_hand_features(
+            hand,
+            contract_type=self._contract_type,
+            trump_suit=self._trump_suit,
+        )
+        derived = self._derivable_features(hand)
+        combined = {**core_features, **derived}
+
+        values = []
+        for name in self._feature_names:
+            value = combined.get(name, 0.0)
+            values.append(float(value))
+        return values
+
+    def _predict_bid_value(self, hand: List[Card]) -> float:
+        vector = self._hand_feature_vector(hand)
+        total = self._intercept
+        for coef, value in zip(self._coefficients, vector):
+            total += coef * value
+        return total
+
+    def decide_bid(
+        self,
+        hand: List[Card],
+        current_high_bid: int,
+        current_winner_index: Any,
+        partner_index: int,
+        player_index: int,
+    ) -> tuple[int, Any, Any]:
+        """
+        Override bidding decision to consult the artifact (linear regression).
+        """
+        bid_value = self._predict_bid_value(hand)
+        bid_amount = int(round(bid_value))
+        bid_amount = max(0, min(10, bid_amount))
+
+        if bid_amount <= current_high_bid:
+            return 0, None, None
+
+        if self._contract_type == "suit":
+            return bid_amount, "suit", self._trump_suit
+        return bid_amount, self._contract_type, None

--- a/tests/integration/test_bid_eval_tiny_suite.py
+++ b/tests/integration/test_bid_eval_tiny_suite.py
@@ -1,0 +1,70 @@
+"""
+Integration test for the bid_eval_tiny suite.
+
+Ensures the evaluator output (bidder risk metrics) is produced deterministically.
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+SUITE_PATH = "experiments/suites/bid_eval_tiny.yaml"
+SEED = 42
+N_PER = 5
+
+
+def test_bid_eval_tiny_emits_evaluator(tmp_path: Path) -> None:
+    run_base = tmp_path / "runs"
+    run_base.mkdir(parents=True, exist_ok=True)
+    dirs_before = set(run_base.iterdir()) if run_base.exists() else set()
+
+    cmd = [
+        "python",
+        "scripts/run_suite.py",
+        "--suite",
+        SUITE_PATH,
+        "--seed",
+        str(SEED),
+        "--n-per",
+        str(N_PER),
+        "--run-dir",
+        str(run_base),
+    ]
+
+    env = {**os.environ, "PYTHONPATH": "src"}
+
+    subprocess.run(cmd, check=True, capture_output=True, text=True, env=env)
+
+    dirs_after = set(run_base.iterdir())
+    new_dirs = dirs_after - dirs_before
+    assert len(new_dirs) == 2, f"Expected 2 directories (run + rollup), found {len(new_dirs)}"
+
+    rollup_dir = next(d for d in new_dirs if (d / "rollup.json").exists())
+    assert (rollup_dir / "rollup.json").exists()
+
+    with (rollup_dir / "rollup.json").open() as f:
+        rollup = json.load(f)
+
+    assert rollup["suite_name"] == "bid_eval_tiny"
+    assert rollup["configs"], "Expected at least one config"
+
+    run_dir_names = {entry["run_dir"] for entry in rollup["configs"]}
+
+    for run_dir_name in run_dir_names:
+        member_run = rollup_dir.parent / run_dir_name
+        eval_path = member_run / "reports" / "bidding_strategy" / "evaluation.json"
+        assert eval_path.exists(), f"Missing evaluator output: {eval_path}"
+
+        with eval_path.open() as ef:
+            data = json.load(ef)
+
+        assert data["primary_series"] == "bidder_team_points"
+        assert isinstance(data["strategies"], list)
+        for strategy in data["strategies"]:
+            assert "strategy_id" in strategy
+            assert isinstance(strategy["bidder_team_points"], list)
+            assert "expected_points" in strategy
+            assert "make_rate" in strategy
+            assert "cvar_5" in strategy
+            assert "downside_variance" in strategy

--- a/tests/unit/test_bid_evaluator_metrics.py
+++ b/tests/unit/test_bid_evaluator_metrics.py
@@ -1,0 +1,27 @@
+import math
+
+from bid_euchre.reporting.evaluator import compute_cvar, compute_downside_variance
+
+
+def test_compute_cvar_worst_percentile():
+    values = [10, 5, 0, -5, -10, 20]
+    # len=6 -> tail_size = ceil(6*0.05)=1, so CVaR is worst value.
+    assert compute_cvar(values) == -10
+
+
+def test_compute_cvar_multiple_tail_items():
+    values = list(range(-10, 30))  # 40 values
+    tail_size = math.ceil(len(values) * 0.05)
+    assert tail_size == 2
+    expected = sum(sorted(values)[:tail_size]) / tail_size
+    assert math.isclose(compute_cvar(values), expected)
+
+
+def test_downside_variance_definition():
+    values = [5, -1, -3, -5, 2]
+    expected = ((-1 + 3) ** 2 + (-3 + 3) ** 2 + (-5 + 3) ** 2) / 3
+    assert math.isclose(compute_downside_variance(values), expected)
+
+
+def test_downside_variance_no_negatives():
+    assert compute_downside_variance([1, 2, 3]) is None


### PR DESCRIPTION
## Summary
- add artifact-backed bidder evaluation + risk metrics
- add tiny suite that runs auction logging + the deterministic evaluator

## Why
- to capture EV/make rate/CVaR/downside variance for artifact bidders in a stable JSON output

## Repro / Validation
**Command(s) run:**
- `PYTHONPATH=src python -m pytest tests/unit/test_bid_evaluator_metrics.py tests/integration/test_bid_eval_tiny_suite.py`

**Config (if applicable):**
- `experiments/configs/bid_eval_tiny.yaml`

**Seed (if applicable):**
- 42

## Tests
- [ ] `PYTHONPATH=src python -m pytest -m "not slow" tests/`
- [ ] Integration (if engine/rules changed): `PYTHONPATH=src python -m pytest tests/integration/`
- [x] Other: `PYTHONPATH=src python -m pytest tests/unit/test_bid_evaluator_metrics.py tests/integration/test_bid_eval_tiny_suite.py`

## Expected impact
- Metrics impact (if any): N/A
- Runtime impact (if any): Tiny new suite and evaluator JSON

## Risk level
- [ ] Low (docs/tests only)
- [x] Medium (strategy/experiments)
- [ ] High (core rules/scoring)

## Worktree proof (required)
`pwd`:
```
/Users/Quentin/.cursor/worktrees/bid-euchre/ocm
```

`git rev-parse --show-toplevel`:
```
/Users/Quentin/.cursor/worktrees/bid-euchre/ocm
```

`git worktree list`:
```
/Users/Quentin/Projects/bid-euchre               a5719c7 [main]
/Users/Quentin/.cursor/worktrees/bid-euchre/krk  c5b760f [feat/artifact-backed-bidder]
/Users/Quentin/.cursor/worktrees/bid-euchre/ocm  ceb0629 [feat/bid-eval-tiny]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
