### PR TITLE
ci: fix bid_eval_tiny workflow to run bid_eval_tiny suite

### DIFF
--- a/.github/workflows/bid_eval_tiny.yml
+++ b/.github/workflows/bid_eval_tiny.yml
@@ -36,7 +36,7 @@ jobs:
           rm -rf data/runs/bid_eval_tiny
           mkdir -p data/runs
           python scripts/run_suite.py \
-            --suite experiments/suites/baseline_tiny.yaml \
+            --suite experiments/suites/bid_eval_tiny.yaml \
             --seed 42 \
             --n-per 20 \
             --run-dir data/runs/bid_eval_tiny


### PR DESCRIPTION
## Summary
Fix bid_eval_tiny workflow to run bid_eval_tiny suite (truth-in-CI). No Python/runtime behavior changes; workflow-only fix. Ensure uploaded artifacts correspond to bidding evaluation outputs.

## Why
The workflow named "bid_eval_tiny" was running baseline_tiny suite instead of bid_eval_tiny suite, causing CI results to be misleading and artifacts to correspond to baseline evaluation rather than bidding evaluation.

## Repro / Validation
**Command(s) run:**
```bash
sed -n '35,42p' .github/workflows/bid_eval_tiny.yml
```

**Before:**
```
python scripts/run_suite.py \
  --suite experiments/suites/baseline_tiny.yaml \
```

**After:**
```
python scripts/run_suite.py \
  --suite experiments/suites/bid_eval_tiny.yaml \
```

## Tests
- [x] `make check` passes (422 passed, 3 skipped, 1 deselected, 2 xfailed, 2 xpassed, 1 warning)
- [ ] Integration (if engine/rules changed): `PYTHONPATH=src python -m pytest tests/integration/`
- [ ] Other:

## Expected impact
- CI now runs bid_eval_tiny suite instead of baseline_tiny
- Artifacts uploaded will correspond to bidding evaluation results
- No runtime behavior changes

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/Quentin/Projects/.worktrees/ci-fix-bid-eval-tiny-workflow-20260113-153129-27224
```

`git rev-parse --show-toplevel`:
```
/Users/Quentin/Projects/.worktrees/ci-fix-bid-eval-tiny-workflow-20260113-153129-27224
```

`git worktree list`:
```
/Users/Quentin/Projects/bid-euchre                                                      6e544db [main]
/Users/Quentin/.cursor/worktrees/bid-euchre/krk                                         c5b760f [feat/artifact-backed-bidder]
/Users/Quentin/.cursor/worktrees/bid-euchre/ocm                                         ceb0629 [feat/bid-eval-tiny]
/Users/Quentin/.cursor/worktrees/bid-euchre/qmv                                         9a314b4 [feat/bid-eval-tiny-baseline-matrix]
/Users/Quentin/.cursor/worktrees/bid-euchre/wou                                         f2d43fc [pr-119-bid-eval]
/Users/Quentin/.cursor/worktrees/bid-euchre/xfg                                         a5719c7 (detached HEAD)
/Users/Quentin/Projects/.worktrees/ci-fix-bid-eval-tiny-workflow-20260113-153129-27224  31e42b6 [ci/fix-bid-eval-tiny-workflow]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [ ] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
