### PR TITLE
docs+tests: align bidding semantics to sequential auction (LOD order)

### DIFF
--- a/docs/01_core/BIDDING.md
+++ b/docs/01_core/BIDDING.md
@@ -8,7 +8,7 @@ Bid Euchre bidding mechanics define how players select contracts for each hand. 
 
 ### Round Structure
 - **Single round**: One bidding round starting left of dealer
-- **Simultaneous action**: All players bid `(n, contract)` simultaneously
+- **Sequential action**: Players bid `(n, contract)` in order: LOD → partner → ROD → dealer (clockwise from dealer)
 - **Bid values**: `n` ranges from 0–10 where `0` = pass
 - **Strictly increasing**: `n` must be `> current_high_bid` else treated as pass
 - **Redeal condition**: All players pass (bid 0) → redeal

--- a/tests/unit/test_bidding_sequential_semantics.py
+++ b/tests/unit/test_bidding_sequential_semantics.py
@@ -1,0 +1,93 @@
+"""
+Unit tests for bidding sequential semantics.
+
+These tests verify that bidding follows sequential auction in LOD order
+with strict-raise legality, matching the current simulator behavior.
+"""
+
+from bid_euchre.core.cards import Card
+from bid_euchre.sim.simulation import play_single_hand
+from bid_euchre.strategy.bidding import (
+    BidAction,
+    BiddingObservation,
+    BiddingPolicy,
+)
+
+
+class TestBiddingSequentialSemantics:
+    """Test suite for sequential bidding semantics (LOD order, strict-raise legality)."""
+
+    def test_bidding_order_lod_to_dealer(self):
+        """Bidding proceeds sequentially: LOD → partner → ROD → dealer."""
+
+        class OrderTracker(BiddingPolicy):
+            """Records the order in which seats are called to bid."""
+            call_order = []
+
+            def choose_bid(self, obs: BiddingObservation) -> BidAction:
+                OrderTracker.call_order.append(obs.seat)
+                return BidAction.pass_bid()
+
+        # Reset tracker
+        OrderTracker.call_order = []
+
+        policy = OrderTracker()
+        fixed_hand = [Card("S", "A"), Card("H", "K"), Card("D", "Q"), Card("C", "J"),
+                      Card("S", "T"), Card("H", "A"), Card("D", "K"), Card("C", "Q"),
+                      Card("S", "J"), Card("H", "T")]
+        hands = [fixed_hand.copy() for _ in range(4)]
+
+        # Dealer is seat 2 (initial_leader=3 means dealer = (3-1)%4 = 2)
+        # Expected order: LOD(3) → partner(0) → ROD(1) → dealer(2)
+        play_single_hand(
+            contract_type=None,
+            bidding_policy=policy,
+            hands=hands,
+            initial_leader=3,
+        )
+
+        expected_order = [3, 0, 1, 2]  # LOD → partner → ROD → dealer
+        assert OrderTracker.call_order == expected_order, \
+            f"Expected LOD order {expected_order}, got {OrderTracker.call_order}"
+
+    def test_strict_raise_legality_enforced(self):
+        """Bids <= current_high_bid are treated as pass (illegal bids coerced to pass)."""
+
+        class ScriptedBidder(BiddingPolicy):
+            """Bids according to a predefined script per seat."""
+
+            def __init__(self, seat_bids):
+                self.seat_bids = seat_bids  # seat -> BidAction
+
+            def choose_bid(self, obs: BiddingObservation) -> BidAction:
+                return self.seat_bids.get(obs.seat, BidAction.pass_bid())
+
+        # Seat 0: bid 5 first (legal)
+        # Seat 1: bid 3 (illegal, <= 5, should be treated as pass)
+        # Seat 2: bid 7 (legal, > 5)
+        # Seat 3: pass
+        policy = ScriptedBidder({
+            0: BidAction.bid(5, "S"),  # LOD bids 5
+            1: BidAction.bid(3, "H"),  # Partner tries 3 (<= 5, illegal)
+            2: BidAction.bid(7, "D"),  # ROD bids 7 (> 5, legal)
+            3: BidAction.pass_bid(),   # Dealer passes
+        })
+
+        fixed_hand = [Card("S", "A"), Card("H", "K"), Card("D", "Q"), Card("C", "J"),
+                      Card("S", "T"), Card("H", "A"), Card("D", "K"), Card("C", "Q"),
+                      Card("S", "J"), Card("H", "T")]
+        hands = [fixed_hand.copy() for _ in range(4)]
+
+        # Dealer is seat 2 (initial_leader=3)
+        t0, t1, scores, features, leader, hands, bid, dealer_pos, bidder_pos, final_contract, final_trump = play_single_hand(
+            contract_type=None,
+            bidding_policy=policy,
+            hands=hands,
+            initial_leader=3,
+        )
+
+        # Seat 2 (ROD) should win with bid 7 (seat 1's bid 3 was ignored as illegal)
+        assert leader == 2, f"Expected leader to be 2 (ROD with highest valid bid), got {leader}"
+        assert bid == 7, f"Expected bid to be 7, got {bid}"
+        assert final_contract == "suit", f"Expected contract 'suit', got {final_contract}"
+        assert final_trump == "D", f"Expected trump 'D', got {final_trump}"


### PR DESCRIPTION
## Summary
- Updated docs/01_core/BIDDING.md to describe sequential auction in LOD order instead of simultaneous bidding
- Added tests/unit/test_bidding_sequential_semantics.py to verify sequential bidding order and strict-raise legality

## Why
The current docs incorrectly describe bidding as "simultaneous action" when the simulator actually implements sequential bidding in LOD → partner → ROD → dealer order. This PR aligns the documentation and adds tests to match the current simulator behavior.

## Repro / Validation
**Command(s) run:**
- `PYTHONPATH=src python -m pytest tests/unit/test_bidding_sequential_semantics.py -v`
- `PYTHONPATH=src python -m pytest tests/unit/test_auction_bidding_rules.py -v`
- `PYTHONPATH=src python -m pytest tests/unit/test_bidding.py -v`

**Config (if applicable):**
N/A

**Seed (if applicable):**
N/A

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/` (subset run for bidding tests)
- [ ] Integration (if engine/rules changed): N/A
- [x] Other: Added focused unit tests for sequential bidding semantics

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/Quentin/.cursor/worktrees/bid-euchre/xzf
```

`git rev-parse --show-toplevel`:
```
/Users/Quentin/.cursor/worktrees/bid-euchre/xzf
```

`git worktree list`:
```
/Users/Quentin/Projects/bid-euchre               6e544db [main]
/Users/Quentin/.cursor/worktrees/bid-euchre/krk  c5b760f [feat/artifact-backed-bidder]
/Users/Quentin/.cursor/worktrees/bid-euchre/ocm  ceb0629 [feat/bid-eval-tiny]
/Users/Quentin/.cursor/worktrees/bid-euchre/qmv  9a314b4 [feat/bid-eval-tiny-baseline-matrix]
/Users/Quentin/.cursor/worktrees/bid-euchre/wou  f2d43fc [pr-119-bid-eval]
/Users/Quentin/.cursor/worktrees/bid-euchre/xfg  a5719c7 (detached HEAD)
/Users/Quentin/.cursor/worktrees/bid-euchre/xzf  32bb488 [docs/bidding-sequential-semantics]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it (docs alignment only)
- [x] PR is focused (one concept)