### PR TITLE
fix: lazy-load pyarrow for bidding dataset parquet writing (optional dep)

### DIFF
--- a/src/bid_euchre/datasets/bidding.py
+++ b/src/bid_euchre/datasets/bidding.py
@@ -9,9 +9,6 @@ import json
 import os
 from typing import Any, Dict, List, Optional
 
-import pyarrow as pa
-import pyarrow.parquet as pq
-
 from ..core.cards import Card
 from ..features.hand_eval import get_hand_features
 from ..strategy.bidding import BidAction, BiddingObservation
@@ -223,6 +220,15 @@ class BiddingDatasetCollector:
             output_path: Path to write the Parquet file
             run_id: Run ID to store in metadata (defaults to self.run_id)
         """
+        try:
+            import pyarrow as pa
+            import pyarrow.parquet as pq
+        except ImportError as e:
+            raise ImportError(
+                "pyarrow is required for Parquet output. "
+                "Install with: pip install pyarrow"
+            ) from e
+
         os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
         rows = self.get_rows_sorted()

--- a/tests/unit/test_bidding_dataset_pyarrow_optional.py
+++ b/tests/unit/test_bidding_dataset_pyarrow_optional.py
@@ -1,0 +1,122 @@
+"""
+Unit tests for optional pyarrow dependency in bidding dataset.
+
+These tests ensure that:
+- Importing bid_euchre.datasets.bidding does not require pyarrow
+- Parquet writing fails gracefully with clear error when pyarrow unavailable
+- JSONL writing remains unaffected
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from bid_euchre.core.cards import Card
+from bid_euchre.strategy.bidding import BidAction, BiddingObservation
+
+
+class TestPyarrowOptionalDependency:
+    """Test that pyarrow is truly optional for bidding dataset functionality."""
+
+    def test_module_import_does_not_import_pyarrow(self):
+        """Test that importing the bidding dataset module doesn't import pyarrow."""
+        import sys
+
+        # Record pyarrow modules before import
+        pyarrow_modules_before = {
+            name: module for name, module in sys.modules.items()
+            if name.startswith('pyarrow')
+        }
+
+        # Force reimport by removing bidding module from sys.modules
+        modules_to_remove = [
+            name for name in sys.modules.keys()
+            if name.startswith('bid_euchre.datasets.bidding')
+        ]
+        for mod in modules_to_remove:
+            del sys.modules[mod]
+
+        # Import the module fresh
+        import bid_euchre.datasets.bidding  # noqa: F401
+
+        # Check that no new pyarrow modules were imported
+        pyarrow_modules_after = {
+            name: module for name, module in sys.modules.items()
+            if name.startswith('pyarrow')
+        }
+
+        # The pyarrow modules should be the same (none added during import)
+        assert pyarrow_modules_before == pyarrow_modules_after, (
+            "pyarrow should not be imported at module level. "
+            f"Pyarrow modules before: {set(pyarrow_modules_before.keys())}, "
+            f"after: {set(pyarrow_modules_after.keys())}"
+        )
+
+    def test_write_parquet_fails_gracefully_without_pyarrow(self):
+        """Test that write_parquet raises clear ImportError when pyarrow unavailable."""
+        from bid_euchre.datasets.bidding import BiddingDatasetCollector
+
+        # Create a minimal collector with some test data
+        collector = BiddingDatasetCollector("test_run", 1)
+
+        # Create a fake observation and action
+        obs = BiddingObservation(
+            hand=[Card('9', 'H'), Card('T', 'H'), Card('J', 'H'), Card('Q', 'H'), Card('K', 'H')],
+            seat=0,
+            dealer_seat=0,
+            current_high_bid=0,
+        )
+        action = BidAction.bid(3, "H")
+
+        # Record a decision
+        collector.record_decision(obs, action)
+
+        # Try to write parquet without pyarrow available
+        with patch.dict('sys.modules', {'pyarrow': None, 'pyarrow.parquet': None}):
+            with patch('builtins.__import__', side_effect=ImportError("No module named 'pyarrow'")):
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    parquet_path = Path(temp_dir) / "test.parquet"
+
+                    with pytest.raises(ImportError) as exc_info:
+                        collector.write_parquet(str(parquet_path))
+
+                    # Verify the error message is clear and actionable
+                    error_msg = str(exc_info.value)
+                    assert "pyarrow is required for Parquet output" in error_msg
+                    assert "pip install pyarrow" in error_msg
+
+    def test_write_jsonl_works_without_pyarrow(self):
+        """Test that JSONL writing works even when pyarrow is unavailable."""
+        from bid_euchre.datasets.bidding import BiddingDatasetCollector
+
+        # Create a minimal collector with some test data
+        collector = BiddingDatasetCollector("test_run", 1)
+
+        # Create a fake observation and action
+        obs = BiddingObservation(
+            hand=[Card('9', 'H'), Card('T', 'H'), Card('J', 'H'), Card('Q', 'H'), Card('K', 'H')],
+            seat=0,
+            dealer_seat=0,
+            current_high_bid=0,
+        )
+        action = BidAction.bid(3, "H")
+
+        # Record a decision
+        collector.record_decision(obs, action)
+
+        # Write JSONL without pyarrow available
+        with patch.dict('sys.modules', {'pyarrow': None, 'pyarrow.parquet': None}):
+            with patch('builtins.__import__', side_effect=ImportError("No module named 'pyarrow'")):
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    jsonl_path = Path(temp_dir) / "test.jsonl"
+
+                    # This should work without pyarrow
+                    collector.write_jsonl(str(jsonl_path))
+
+                    # Verify file was created and has content
+                    assert jsonl_path.exists()
+                    content = jsonl_path.read_text()
+                    assert len(content.strip()) > 0
+                    assert '"hand_id": 1' in content


### PR DESCRIPTION
Summary
- Lazy-load pyarrow so core imports don't require parquet deps
- Parquet writing raises a clear error when pyarrow is missing
- Add unit test covering optional dependency boundary

## Summary
Lazy-load pyarrow imports in the bidding dataset module to make pyarrow an optional dependency for core simulation imports.

## Why
Core simulation modules should not require pyarrow to be installed. Parquet writing should work when pyarrow is available but fail gracefully with a clear error message when it's not.

## Repro / Validation
**Command(s) run:**
- `make check` (passes all tests including new unit tests)

**Config (if applicable):**
- N/A

**Seed (if applicable):**
- N/A

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/`
- [ ] Integration (if engine/rules changed): `PYTHONPATH=src python -m pytest tests/integration/`
- [x] Other: Added `tests/unit/test_bidding_dataset_pyarrow_optional.py`

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None (lazy loading has negligible impact)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/Quentin/.cursor/worktrees/bid-euchre/rgw
```

`git rev-parse --show-toplevel`:
```
/Users/Quentin/.cursor/worktrees/bid-euchre/rgw
```

`git worktree list`:
```
/Users/Quentin/Projects/bid-euchre               6e544db [main]
/Users/Quentin/.cursor/worktrees/bid-euchre/eap  ed99a47 [fix/bidding-dataset-illegal-raise]
/Users/Quentin/.cursor/worktrees/bid-euchre/krk  c5b760f [feat/artifact-backed-bidder]
/Users/Quentin/.cursor/worktrees/bid-euchre/ocm  ceb0629 [feat/bid-eval-tiny]
/Users/Quentin/.cursor/worktrees/bid-euchre/qmv  9a314b4 [feat/bid-eval-tiny-baseline-matrix]
/Users/Quentin/.cursor/worktrees/bid-euchre/rgw  4e2a692 [fix/pyarrow-lazy-import-bidding-dataset]
/Users/Quentin/.cursor/worktrees/bid-euchre/wou  f2d43fc [pr-119-bid-eval]
/Users/Quentin/.cursor/worktrees/bid-euchre/xfg  a5719c7 (detached HEAD)
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
