### PR TITLE
fix: fail fast on linear_regression bidding artifacts (reserved)

### DIFF
--- a/data/fixtures/bidding_artifact_v1_tiny.json
+++ b/data/fixtures/bidding_artifact_v1_tiny.json
@@ -5,18 +5,11 @@
     "description": "Example bidding model artifact for hearts contract"
   },
   "model_params": {
-    "coefficients": [
-      0.1,
-      0.2,
-      -0.05
-    ],
-    "features": [
-      "trump_count",
-      "high_card_points",
-      "suit_length"
-    ],
-    "intercept": 0.5
+    "initial_bid": {"n": 3, "contract": "H"},
+    "raise_increment": 1,
+    "max_bid": 10,
+    "contract": "H"
   },
-  "model_type": "linear_regression",
+  "model_type": "strict_raiser_imitation_v1",
   "schema_version": "1"
 }

--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -419,7 +419,10 @@ class ArtifactBidder(BiddingPolicy):
         # Initialize model-specific state
         self.model_type = self.artifact["model_type"]
         if self.model_type == "linear_regression":
-            self._init_linear_regression()
+            raise NotImplementedError(
+                "linear_regression artifacts are reserved for future work. This runtime path is not implemented and would silently pass. "
+                "Use strict_raiser_imitation_v1 or heuristics_imitation_v1 instead."
+            )
         elif self.model_type == "strict_raiser_imitation_v1":
             self._init_strict_raiser_imitation()
         elif self.model_type == "heuristics_imitation_v1":

--- a/tests/unit/test_artifact_bidder_linear_regression_reserved.py
+++ b/tests/unit/test_artifact_bidder_linear_regression_reserved.py
@@ -1,0 +1,78 @@
+"""
+Tests for linear_regression bidding artifacts fail-fast behavior.
+
+Ensures that linear_regression artifacts raise NotImplementedError instead
+of silently passing, preventing accidental benchmarking of placeholder models.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from bid_euchre.models.bidding_artifact import dump_artifact
+from bid_euchre.strategy.bidding import ArtifactBidder
+
+
+class TestLinearRegressionReserved:
+    """Test that linear_regression artifacts fail fast with clear error."""
+
+    def test_linear_regression_artifact_fails_at_init(self):
+        """Test that instantiating ArtifactBidder with linear_regression raises NotImplementedError."""
+        # Create a linear_regression artifact
+        artifact = {
+            "schema_version": "1",
+            "model_type": "linear_regression",
+            "contract": "H",
+            "model_params": {
+                "coefficients": [0.1, 0.2, -0.05],
+                "features": ["trump_count", "high_card_points", "suit_length"],
+                "intercept": 0.5
+            },
+            "metadata": {
+                "description": "Test linear regression artifact"
+            }
+        }
+
+        # Write to temp file
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            temp_path = f.name
+
+        try:
+            dump_artifact(artifact, temp_path)
+
+            # Should raise NotImplementedError
+            with pytest.raises(NotImplementedError, match="linear_regression artifacts are reserved for future work"):
+                ArtifactBidder(temp_path)
+
+        finally:
+            Path(temp_path).unlink()
+
+    def test_error_message_mentions_supported_alternatives(self):
+        """Test that the error message suggests supported alternatives."""
+        artifact = {
+            "schema_version": "1",
+            "model_type": "linear_regression",
+            "contract": "H",
+            "model_params": {
+                "coefficients": [0.1],
+                "intercept": 0.0
+            }
+        }
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            temp_path = f.name
+
+        try:
+            dump_artifact(artifact, temp_path)
+
+            with pytest.raises(NotImplementedError) as exc_info:
+                ArtifactBidder(temp_path)
+
+            error_msg = str(exc_info.value)
+            assert "strict_raiser_imitation_v1" in error_msg
+            assert "heuristics_imitation_v1" in error_msg
+            assert "silently pass" in error_msg
+
+        finally:
+            Path(temp_path).unlink()

--- a/tests/unit/test_artifact_strategy.py
+++ b/tests/unit/test_artifact_strategy.py
@@ -6,6 +6,8 @@ artifacts (strict_raiser_imitation_v1, heuristics_imitation_v1) deterministicall
 """
 
 
+import pytest
+
 from bid_euchre.core.cards import Card
 from bid_euchre.models.bidding_artifact import dump_artifact
 from bid_euchre.strategy.artifact_strategy import ArtifactGreedyStrategy
@@ -226,8 +228,8 @@ class TestArtifactGreedyStrategyTeacherArtifacts:
         else:
             assert suit is None  # HIGH/LOW don't specify suit
 
-    def test_linear_regression_still_works(self, tmp_path):
-        """Test that linear_regression artifacts still work (backward compatibility)."""
+    def test_linear_regression_fails_fast(self, tmp_path):
+        """Test that linear_regression artifacts fail fast with clear error message."""
         artifact = {
             "schema_version": "1",
             "model_type": "linear_regression",
@@ -245,29 +247,12 @@ class TestArtifactGreedyStrategyTeacherArtifacts:
         artifact_path = tmp_path / "linear.json"
         dump_artifact(artifact, str(artifact_path))
 
-        # Should load without error
-        strategy = ArtifactGreedyStrategy(
-            name="test_linear",
-            artifact_path=str(artifact_path)
-        )
-
-        assert strategy.name == "test_linear"
-        assert strategy._contract_token == "H"
-
-        # Test bidding (should delegate to ArtifactBidder's linear logic)
-        hand = [Card("H", "A"), Card("H", "K"), Card("S", "Q"), Card("D", "J"), Card("C", "T")]
-
-        # Just verify it doesn't crash - linear_regression in ArtifactBidder passes for now
-        bid_amount, contract_type, suit = strategy.decide_bid(
-            hand=hand,
-            current_high_bid=0,
-            current_winner_index=None,
-            partner_index=2,
-            player_index=0
-        )
-
-        # ArtifactBidder._choose_bid_linear currently always passes (TODO in implementation)
-        assert bid_amount == 0
+        # Should fail at initialization with clear error message
+        with pytest.raises(NotImplementedError, match="linear_regression artifacts are reserved for future work"):
+            ArtifactGreedyStrategy(
+                name="test_linear",
+                artifact_path=str(artifact_path)
+            )
 
     def test_determinism_strict_raiser(self, tmp_path):
         """Test that strict_raiser artifact produces deterministic results."""

--- a/tests/unit/test_bidding_artifact_schema.py
+++ b/tests/unit/test_bidding_artifact_schema.py
@@ -37,7 +37,7 @@ class TestBiddingArtifactSchema:
 
         # Check required fields are present
         assert artifact["schema_version"] == "1"
-        assert artifact["model_type"] == "linear_regression"
+        assert artifact["model_type"] == "strict_raiser_imitation_v1"
         assert artifact["contract"] == "H"
         assert isinstance(artifact["model_params"], dict)
         assert "metadata" in artifact


### PR DESCRIPTION
## Summary
- Implement fail-fast behavior for `linear_regression` bidding artifacts to prevent silent always-pass behavior
- Raise `NotImplementedError` with clear message when attempting to load linear_regression artifacts
- Update fixture to use supported `strict_raiser_imitation_v1` model type
- Add comprehensive unit tests for the fail-fast behavior

## Why
- `linear_regression` artifacts were placeholder implementations that always returned `pass_bid()`
- This could lead to silent failures in benchmarking suites where users accidentally use placeholder models
- The goal is to prevent "silent always-pass" behavior by failing fast with a clear error message

## Repro / Validation
**Command(s) run:**
- `make check` (passes all tests including new unit tests)
- `PYTHONPATH=src python -m pytest tests/unit/test_artifact_bidder_linear_regression_reserved.py -v`

**Config (if applicable):**
- Updated `data/fixtures/bidding_artifact_v1_tiny.json` to use `strict_raiser_imitation_v1` instead of `linear_regression`
- This ensures `bid_eval_tiny` integration test continues to pass

**Seed (if applicable):**
- N/A (deterministic implementation change)

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/`
- [x] Integration (if engine/rules changed): `PYTHONPATH=src python -m pytest tests/integration/`
- [x] Other: New unit test `test_artifact_bidder_linear_regression_reserved.py`

## Expected impact
- Metrics impact (if any): Prevents invalid benchmarking results from placeholder models
- Runtime impact (if any): Fail-fast prevents wasted computation on placeholder models

## Risk level
- [x] Low (strategy/experiments)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/Quentin/Projects/bid-euchre
```

`git rev-parse --show-toplevel`:
```
/Users/Quentin/Projects/bid-euchre
```

`git worktree list`:
```
/Users/Quentin/Projects/bid-euchre               34a704a [fix/linear-regression-artifact-failfast]
/Users/Quentin/.cursor/worktrees/bid-euchre/eap  ed99a47 [fix/bidding-dataset-illegal-raise]
/Users/Quentin/.cursor/worktrees/bid-euchre/krk  c5b760f [feat/artifact-backed-bidder]
/Users/Quentin/.cursor/worktrees/bid-euchre/ocm  ceb0629 [feat/bid-eval-tiny]
/Users/Quentin/.cursor/worktrees/bid-euchre/qmv  9a314b4 [feat/bid-eval-tiny-baseline-matrix]
/Users/Quentin/.cursor/worktrees/bid-euchre/rgw  4e2a692 [fix/pyarrow-lazy-import-bidding-dataset]
/Users/Quentin/.cursor/worktrees/bid-euchre/wou  f2d43fc [pr-119-bid-eval]
/Users/Quentin/.cursor/worktrees/bid-euchre/xfg  a5719c7 (detached HEAD)
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)