### PR TITLE
chore: consolidate bidder training CLI surface (single canonical entrypoint)

### DIFF
--- a/src/bid_euchre/models/train_bidder.py
+++ b/src/bid_euchre/models/train_bidder.py
@@ -501,6 +501,27 @@ def train_heuristics_model(contract: str = "S") -> HeuristicsModel:
     return model
 
 
+def train_teacher_model(teacher: str, contract: str = "S") -> Any:
+    """
+    Train a model to imitate the specified teacher.
+
+    Args:
+        teacher: Teacher type ("strict_raiser", "heuristics", or "fiveheadfred")
+        contract: Contract to train for
+
+    Returns:
+        Trained model instance
+    """
+    if teacher == "strict_raiser":
+        return train_strict_raiser_model(contract)
+    elif teacher == "heuristics":
+        return train_heuristics_model(contract)
+    elif teacher == "fiveheadfred":
+        return train_fiveheadfred_model(contract)
+    else:
+        raise ValueError(f"Unknown teacher type: {teacher}")
+
+
 def train_and_save_model(
     contract: str = "S",
     output_path: Optional[str] = None,
@@ -519,15 +540,8 @@ def train_and_save_model(
     Returns:
         Artifact dictionary
     """
-    # Train the model based on teacher type
-    if teacher == "strict_raiser":
-        model = train_strict_raiser_model(contract)
-    elif teacher == "heuristics":
-        model = train_heuristics_model(contract)
-    elif teacher == "fiveheadfred":
-        model = train_fiveheadfred_model(contract)
-    else:
-        raise ValueError(f"Unknown teacher type: {teacher}")
+    # Train the model
+    model = train_teacher_model(teacher, contract)
 
     # Create artifact
     artifact = model.to_artifact_dict(contract, seed)


### PR DESCRIPTION
## Summary
- Consolidate bidder training logic by introducing a single train_teacher_model dispatch function
- Maintain deterministic output and existing CLI interface
- No behavioral changes to training or artifacts

## Why
Consolidate the training surface to make it more maintainable and reduce duplication in the teacher-specific training dispatch logic.

## Repro / Validation
**Command(s) run:**
```bash
PYTHONPATH=src python scripts/train_bidder.py --help
PYTHONPATH=src python scripts/train_bidder.py --teacher strict_raiser --contract S --output /tmp/test.json --seed 42
PYTHONPATH=src python scripts/train_bidder.py --teacher heuristics --contract S --output /tmp/test.json --seed 42
PYTHONPATH=src python scripts/train_bidder.py --teacher fiveheadfred --contract S --output /tmp/test.json --seed 42
```

**Config (if applicable):**
N/A

**Seed (if applicable):**
42 (used for deterministic timestamp generation)

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/` (make check passed)
- [ ] Integration (if engine/rules changed): `PYTHONPATH=src python -m pytest tests/integration/`
- [ ] Other:

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/Quentin/.cursor/worktrees/bid-euchre/lgk
```

`git rev-parse --show-toplevel`:
```
/Users/Quentin/.cursor/worktrees/bid-euchre/lgk
```

`git worktree list`:
```
/Users/Quentin/Projects/bid-euchre               a1ae3aa [fix/linear-regression-artifact-failfast]
/Users/Quentin/.cursor/worktrees/bid-euchre/bod  34a704a (detached HEAD)
/Users/Quentin/.cursor/worktrees/bid-euchre/eap  ed99a47 [fix/bidding-dataset-illegal-raise]
/Users/Quentin/.cursor/worktrees/bid-euchre/iaq  7caf571 [test/migrate-off-pickle-regressionbidder]
/Users/Quentin/.cursor/worktrees/bid-euchre/jsd  6df4a4b [chore/remove-pickle-regressionbidder]
/Users/Quentin/.cursor/worktrees/bid-euchre/krk  c5b760f [feat/artifact-backed-bidder]
/Users/Quentin/.cursor/worktrees/bid-euchre/lgk  4fb4f16 [chore/consolidate-train-bidder-cli]
/Users/Quentin/.cursor/worktrees/bid-euchre/ocm  ceb0629 [feat/bid-eval-tiny]
/Users/Quentin/.cursor/worktrees/bid-euchre/qmv  9a314b4 [feat/bid-eval-tiny-baseline-matrix]
/Users/Quentin/.cursor/worktrees/bid-euchre/rgw  4e2a692 [fix/pyarrow-lazy-import-bidding-dataset]
/Users/Quentin/.cursor/worktrees/bid-euchre/wou  f342031 [pr-119-bid-eval]
/Users/Quentin/.cursor/worktrees/bid-euchre/xfg  6df4a4b (detached HEAD)
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [ ] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)