### PR TITLE
feat: add teacher baseline roster manifest v1 (machine-readable)

### DIFF
--- a/experiments/baselines/teacher_roster_v1.yaml
+++ b/experiments/baselines/teacher_roster_v1.yaml
@@ -1,0 +1,28 @@
+roster_version: "1"
+created: "2026-01-13"
+description: "Teacher baseline bidders (v1)"
+baselines:
+  - id: always_pass
+    display_name: "Always Pass"
+    kind: "policy"
+    import_path: "src.bid_euchre.strategy.bidding.AlwaysPassBidder"
+    params: {}
+    notes: "Always passes in auctions"
+  - id: strict_raiser
+    display_name: "Strict Raiser"
+    kind: "policy"
+    import_path: "src.bid_euchre.strategy.bidding.StrictRaiserBidder"
+    params: {}
+    notes: "Bids 3S initially, raises by 1 each time"
+  - id: heuristics
+    display_name: "Heuristics"
+    kind: "policy"
+    import_path: "src.bid_euchre.strategy.bidding.HeuristicsBidder"
+    params: {}
+    notes: "Rule-based bidding using hand evaluation heuristics"
+  - id: fixed_bidder
+    display_name: "Fixed Bid (FiveHeadFred)"
+    kind: "policy"
+    import_path: "src.bid_euchre.strategy.bidding.FixedBidder"
+    params: {}
+    notes: "Fixed-bid baseline for controlled experiments"

--- a/src/bid_euchre/experiments/teacher_roster.py
+++ b/src/bid_euchre/experiments/teacher_roster.py
@@ -1,0 +1,114 @@
+"""
+Teacher baseline roster validation utilities.
+
+This module provides utilities for loading and validating the teacher baseline
+roster manifest (v1), ensuring that all referenced baselines are available and
+properly configured.
+"""
+
+import importlib
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+def load_teacher_roster(path: str | Path) -> Dict[str, Any]:
+    """
+    Load and validate a teacher baseline roster from YAML file.
+
+    Args:
+        path: Path to the roster YAML file
+
+    Returns:
+        Validated roster dictionary
+
+    Raises:
+        ValueError: If roster validation fails
+        FileNotFoundError: If roster file doesn't exist
+        yaml.YAMLError: If YAML parsing fails
+    """
+    path = Path(path)
+
+    # Load YAML
+    with open(path, 'r', encoding='utf-8') as f:
+        roster = yaml.safe_load(f)
+
+    if roster is None:
+        raise ValueError("Empty roster file")
+
+    # Validate roster structure
+    _validate_roster_structure(roster)
+
+    # Validate each baseline
+    for baseline in roster['baselines']:
+        _validate_baseline(baseline, roster_path=path.parent)
+
+    return roster
+
+
+def _validate_roster_structure(roster: Dict[str, Any]) -> None:
+    """Validate the top-level roster structure."""
+    required_keys = {'roster_version', 'created', 'description', 'baselines'}
+
+    missing_keys = required_keys - set(roster.keys())
+    if missing_keys:
+        raise ValueError(f"Roster missing required keys: {missing_keys}")
+
+    if roster['roster_version'] != "1":
+        raise ValueError(f"Unsupported roster version: {roster['roster_version']}")
+
+    if not isinstance(roster['baselines'], list):
+        raise ValueError("baselines must be a list")
+
+    if not roster['baselines']:
+        raise ValueError("baselines list cannot be empty")
+
+    # Check for duplicate IDs
+    ids = []
+    for b in roster['baselines']:
+        if 'id' not in b:
+            raise ValueError(f"Baseline missing required 'id' key: {b}")
+        ids.append(b['id'])
+
+    if len(ids) != len(set(ids)):
+        duplicates = [id for id in ids if ids.count(id) > 1]
+        raise ValueError(f"Duplicate baseline IDs found: {duplicates}")
+
+
+def _validate_baseline(baseline: Dict[str, Any], roster_path: Path) -> None:
+    """Validate a single baseline entry."""
+    required_keys = {'id', 'display_name', 'kind', 'import_path'}
+
+    missing_keys = required_keys - set(baseline.keys())
+    if missing_keys:
+        raise ValueError(f"Baseline '{baseline.get('id', 'unknown')}' missing required keys: {missing_keys}")
+
+    if baseline['kind'] not in {'policy', 'artifact_policy'}:
+        raise ValueError(f"Baseline '{baseline['id']}' has invalid kind '{baseline['kind']}', must be 'policy' or 'artifact_policy'")
+
+    # Validate import path can be imported
+    try:
+        module_path, class_name = baseline['import_path'].rsplit('.', 1)
+        module = importlib.import_module(module_path)
+        cls = getattr(module, class_name)
+        if not callable(cls):
+            raise ValueError(f"Import path '{baseline['import_path']}' does not point to a callable class")
+    except (ImportError, AttributeError, ValueError) as e:
+        raise ValueError(f"Cannot import baseline '{baseline['id']}': {e}")
+
+    # Validate artifact_policy specifics
+    if baseline['kind'] == 'artifact_policy':
+        if 'params' not in baseline:
+            raise ValueError(f"artifact_policy baseline '{baseline['id']}' missing required 'params' key")
+
+        params = baseline['params']
+        if not isinstance(params, dict):
+            raise ValueError(f"artifact_policy baseline '{baseline['id']}' params must be a dict")
+
+        if 'artifact_path' not in params:
+            raise ValueError(f"artifact_policy baseline '{baseline['id']}' missing required 'artifact_path' in params")
+
+        artifact_path = Path(params['artifact_path'])
+        if not artifact_path.exists():
+            raise ValueError(f"artifact_policy baseline '{baseline['id']}' artifact_path does not exist: {artifact_path}")

--- a/tests/unit/test_teacher_roster_v1.py
+++ b/tests/unit/test_teacher_roster_v1.py
@@ -1,0 +1,190 @@
+"""
+Unit tests for teacher baseline roster validation (v1).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from src.bid_euchre.experiments.teacher_roster import load_teacher_roster
+
+
+class TestTeacherRosterV1:
+    """Test teacher roster loading and validation."""
+
+    def test_load_valid_roster(self, tmp_path):
+        """Test loading a valid roster file."""
+        roster_content = """
+roster_version: "1"
+created: "2026-01-13"
+description: "Test roster"
+baselines:
+  - id: test_policy
+    display_name: "Test Policy"
+    kind: "policy"
+    import_path: "src.bid_euchre.strategy.bidding.AlwaysPassBidder"
+    params: {}
+"""
+        roster_file = tmp_path / "test_roster.yaml"
+        roster_file.write_text(roster_content)
+
+        roster = load_teacher_roster(roster_file)
+
+        assert roster['roster_version'] == "1"
+        assert len(roster['baselines']) == 1
+        assert roster['baselines'][0]['id'] == "test_policy"
+
+    def test_duplicate_ids_fail(self, tmp_path):
+        """Test that duplicate baseline IDs are rejected."""
+        roster_content = """
+roster_version: "1"
+created: "2026-01-13"
+description: "Test roster"
+baselines:
+  - id: duplicate
+    display_name: "First"
+    kind: "policy"
+    import_path: "src.bid_euchre.strategy.bidding.AlwaysPassBidder"
+    params: {}
+  - id: duplicate
+    display_name: "Second"
+    kind: "policy"
+    import_path: "src.bid_euchre.strategy.bidding.StrictRaiserBidder"
+    params: {}
+"""
+        roster_file = tmp_path / "test_roster.yaml"
+        roster_file.write_text(roster_content)
+
+        with pytest.raises(ValueError, match="Duplicate baseline IDs found"):
+            load_teacher_roster(roster_file)
+
+    def test_invalid_kind_fails(self, tmp_path):
+        """Test that invalid baseline kinds are rejected."""
+        roster_content = """
+roster_version: "1"
+created: "2026-01-13"
+description: "Test roster"
+baselines:
+  - id: invalid_kind
+    display_name: "Invalid"
+    kind: "invalid_type"
+    import_path: "src.bid_euchre.strategy.bidding.AlwaysPassBidder"
+    params: {}
+"""
+        roster_file = tmp_path / "test_roster.yaml"
+        roster_file.write_text(roster_content)
+
+        with pytest.raises(ValueError, match="has invalid kind 'invalid_type'"):
+            load_teacher_roster(roster_file)
+
+    def test_missing_required_keys_fail(self, tmp_path):
+        """Test that missing required keys are rejected."""
+        roster_content = """
+roster_version: "1"
+created: "2026-01-13"
+description: "Test roster"
+baselines:
+  - display_name: "Missing ID"
+    kind: "policy"
+    import_path: "src.bid_euchre.strategy.bidding.AlwaysPassBidder"
+"""
+        roster_file = tmp_path / "test_roster.yaml"
+        roster_file.write_text(roster_content)
+
+        with pytest.raises(ValueError, match="Baseline missing required 'id' key"):
+            load_teacher_roster(roster_file)
+
+    def test_invalid_import_path_fails(self, tmp_path):
+        """Test that invalid import paths are rejected."""
+        roster_content = """
+roster_version: "1"
+created: "2026-01-13"
+description: "Test roster"
+baselines:
+  - id: invalid_import
+    display_name: "Invalid Import"
+    kind: "policy"
+    import_path: "nonexistent.module.NonexistentClass"
+    params: {}
+"""
+        roster_file = tmp_path / "test_roster.yaml"
+        roster_file.write_text(roster_content)
+
+        with pytest.raises(ValueError, match="Cannot import baseline"):
+            load_teacher_roster(roster_file)
+
+    def test_artifact_policy_missing_params_fails(self, tmp_path):
+        """Test that artifact_policy without params fails."""
+        roster_content = """
+roster_version: "1"
+created: "2026-01-13"
+description: "Test roster"
+baselines:
+  - id: missing_params
+    display_name: "Missing Params"
+    kind: "artifact_policy"
+    import_path: "src.bid_euchre.strategy.bidding.ArtifactBidder"
+"""
+        roster_file = tmp_path / "test_roster.yaml"
+        roster_file.write_text(roster_content)
+
+        with pytest.raises(ValueError, match="missing required 'params' key"):
+            load_teacher_roster(roster_file)
+
+    def test_artifact_policy_missing_artifact_path_fails(self, tmp_path):
+        """Test that artifact_policy without artifact_path fails."""
+        roster_content = """
+roster_version: "1"
+created: "2026-01-13"
+description: "Test roster"
+baselines:
+  - id: missing_artifact_path
+    display_name: "Missing Artifact Path"
+    kind: "artifact_policy"
+    import_path: "src.bid_euchre.strategy.bidding.ArtifactBidder"
+    params: {}
+"""
+        roster_file = tmp_path / "test_roster.yaml"
+        roster_file.write_text(roster_content)
+
+        with pytest.raises(ValueError, match="missing required 'artifact_path' in params"):
+            load_teacher_roster(roster_file)
+
+    def test_artifact_policy_nonexistent_artifact_fails(self, tmp_path):
+        """Test that artifact_policy with nonexistent artifact path fails."""
+        roster_content = """
+roster_version: "1"
+created: "2026-01-13"
+description: "Test roster"
+baselines:
+  - id: nonexistent_artifact
+    display_name: "Nonexistent Artifact"
+    kind: "artifact_policy"
+    import_path: "src.bid_euchre.strategy.bidding.ArtifactBidder"
+    params:
+      artifact_path: "nonexistent/path.json"
+"""
+        roster_file = tmp_path / "test_roster.yaml"
+        roster_file.write_text(roster_content)
+
+        with pytest.raises(ValueError, match="artifact_path does not exist"):
+            load_teacher_roster(roster_file)
+
+    def test_load_shipped_roster(self):
+        """Test loading the actual shipped roster file."""
+        roster_path = Path("experiments/baselines/teacher_roster_v1.yaml")
+
+        # This should not raise an exception if the roster is valid
+        roster = load_teacher_roster(roster_path)
+
+        assert roster['roster_version'] == "1"
+        assert len(roster['baselines']) >= 3  # Should have at least 3 baselines
+
+        # Check that all baselines have unique IDs
+        ids = [b['id'] for b in roster['baselines']]
+        assert len(ids) == len(set(ids))
+
+        # Check that all required keys are present
+        for baseline in roster['baselines']:
+            required_keys = {'id', 'display_name', 'kind', 'import_path'}
+            assert required_keys.issubset(set(baseline.keys()))


### PR DESCRIPTION
## Summary
- Introduce a single canonical, machine-readable roster file that enumerates the "teacher baselines" used for bidding evaluation
- Add validator helper to ensure roster integrity and safe consumption by tooling
- Include comprehensive unit tests

## Why
- Future tooling (like bid_eval_tiny) can consume this roster safely without hardcoding baseline definitions
- Provides a single source of truth for teacher baselines
- Enables validation to catch configuration errors early

## Repro / Validation
**Command(s) run:**
- `make check` (passes)
- `PYTHONPATH=src python -m pytest tests/unit/test_teacher_roster_v1.py -v` (9 tests pass)

**Config (if applicable):**
- N/A

**Seed (if applicable):**
- N/A

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/` (passes)
- [x] Integration (if engine/rules changed): N/A (no rules changed)
- [x] Other: Unit tests for roster validation (9 tests pass)

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None (data-only change)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/Quentin/.cursor/worktrees/bid-euchre/chm
```

`git rev-parse --show-toplevel`:
```
/Users/Quentin/.cursor/worktrees/bid-euchre/chm
```

`git worktree list`:
```
/Users/Quentin/Projects/bid-euchre               a1ae3aa [fix/linear-regression-artifact-failfast]
/Users/Quentin/.cursor/worktrees/bid-euchre/bod  34a704a (detached HEAD)
/Users/Quentin/.cursor/worktrees/bid-euchre/chm  3c50a8a [feat/teacher-roster-manifest-v1]
/Users/Quentin/.cursor/worktrees/bid-euchre/eap  ed99a47 [fix/bidding-dataset-illegal-raise]
/Users/Quentin/.cursor/worktrees/bid-euchre/iaq  7caf571 [test/migrate-off-pickle-regressionbidder]
/Users/Quentin/.cursor/worktrees/bid-euchre/jsd  6df4a4b [chore/remove-pickle-regressionbidder]
/Users/Quentin/.cursor/worktrees/bid-euchre/krk  c5b760f [feat/artifact-backed-bidder]
/Users/Quentin/.cursor/worktrees/bid-euchre/lgk  4fb4f16 [chore/consolidate-train-bidder-cli]
/Users/Quentin/.cursor/worktrees/bid-euchre/ocm  ceb0629 [feat/bid-eval-tiny]
/Users/Quentin/.cursor/worktrees/bid-euchre/qmv  9a314b4 [feat/bid-eval-tiny-baseline-matrix]
/Users/Quentin/.cursor/worktrees/bid-euchre/rgw  4fb4f16 [fix/pyarrow-lazy-import-bidding-dataset]
/Users/Quentin/.cursor/worktrees/bid-euchre/wou  f2d43fc [pr-119-bid-eval]
/Users/Quentin/.cursor/worktrees/bid-euchre/xfg  a5719c7 (detached HEAD)
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it (no behavior changed, tests added for new functionality)
- [x] PR is focused (one concept)