### PR TITLE
chore: add Make targets for teacher baseline loop (train + bid_eval_tiny)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,29 @@
-.PHONY: help repo-lint lint test check
+.PHONY: help repo-lint lint test check bid-train-teachers bid-eval-tiny bid-teacher-loop
 .DEFAULT_GOAL := help
 
 PYTHON ?= python
 REPO_LINT_BASE ?= origin/main
 REPO_LINT_HEAD ?= HEAD
 
+# Teacher baseline loop configuration
+TEACHERS ?= strict_raiser heuristics
+CONTRACTS ?= C D H S HIGH LOW
+RUN_BASE ?= data/runs
+SEED ?= 42
+N_PER ?= 20
+
 help:
 	@echo ""
 	@echo "Gold path targets:"
-	@echo "  make check      - repo-lint + ruff + tests"
-	@echo "  make repo-lint  - repo linter (diff vs origin/main)"
-	@echo "  make lint       - ruff check ."
-	@echo "  make test       - pytest fast suite"
+	@echo "  make check              - repo-lint + ruff + tests"
+	@echo "  make repo-lint          - repo linter (diff vs origin/main)"
+	@echo "  make lint               - ruff check ."
+	@echo "  make test               - pytest fast suite"
+	@echo ""
+	@echo "Teacher baseline targets:"
+	@echo "  make bid-train-teachers - train teacher artifacts (all contracts)"
+	@echo "  make bid-eval-tiny      - run bid_eval_tiny suite"
+	@echo "  make bid-teacher-loop   - train teachers then eval tiny"
 	@echo ""
 
 repo-lint:
@@ -28,3 +40,41 @@ test:
 
 check: repo-lint lint test
 	@echo "✓ All checks passed"
+
+# Generate unique run ID for teacher training
+TEACHER_RUN_ID = teacher_baseline_$(shell date -u +%Y%m%d_%H%M%S)_$(shell printf "%04x" $$RANDOM)
+
+bid-train-teachers:
+	@echo ">>> Training teacher artifacts"
+	@echo "Run ID: $(TEACHER_RUN_ID)"
+	@echo "Teachers: $(TEACHERS)"
+	@echo "Contracts: $(CONTRACTS)"
+	@echo "Output base: $(RUN_BASE)/$(TEACHER_RUN_ID)/artifacts/"
+	@mkdir -p $(RUN_BASE)/$(TEACHER_RUN_ID)/artifacts
+	@for teacher in $(TEACHERS); do \
+		for contract in $(CONTRACTS); do \
+			echo "Training $$teacher/$$contract..."; \
+			PYTHONPATH=src $(PYTHON) scripts/train_bidder.py \
+				--teacher $$teacher \
+				--contract $$contract \
+				--output $(RUN_BASE)/$(TEACHER_RUN_ID)/artifacts/$$teacher-$$contract.json \
+				--seed $(SEED); \
+		done; \
+	done
+	@echo "✅ Teacher training complete"
+	@echo "Artifacts written to: $(RUN_BASE)/$(TEACHER_RUN_ID)/artifacts/"
+
+bid-eval-tiny:
+	@echo ">>> Running bid_eval_tiny suite"
+	@echo "Suite: experiments/suites/bid_eval_tiny.yaml"
+	@echo "Seed: $(SEED)"
+	@echo "N_PER: $(N_PER)"
+	PYTHONPATH=src $(PYTHON) scripts/run_suite.py \
+		--suite experiments/suites/bid_eval_tiny.yaml \
+		--seed $(SEED) \
+		--n-per $(N_PER)
+	@echo "✅ bid_eval_tiny complete"
+	@echo "Find latest run in: $(RUN_BASE)/"
+
+bid-teacher-loop: bid-train-teachers bid-eval-tiny
+	@echo "✅ Teacher baseline loop complete"


### PR DESCRIPTION
## Summary
- Add Make targets for training teacher artifacts and running bid_eval_tiny
- Provide deterministic defaults (SEED/N_PER) and clear output paths
- No behavior changes outside developer ergonomics

## Why
Provide a "gold path" set of Make targets that:
1) trains teacher artifacts deterministically into a run directory (NOT committed),
2) runs bid_eval_tiny suite against a selected roster include set,
3) (optionally) prints the most recent run directory path for convenience.

## Repro / Validation
**Command(s) run:**
```bash
make bid-teacher-loop
# or individually:
make bid-train-teachers
make bid-eval-tiny
```

**Config (if applicable):**
- experiments/suites/bid_eval_tiny.yaml

**Seed (if applicable):**
- Default: 42 (overridable via SEED=123 make ...)

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/`
- [ ] Integration (if engine/rules changed): `PYTHONPATH=src python -m pytest tests/integration/`
- [ ] Other:

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/Quentin/.cursor/worktrees/bid-euchre/lpi
```

`git rev-parse --show-toplevel`:
```
/Users/Quentin/.cursor/worktrees/bid-euchre/lpi
```

`git worktree list`:
```
/Users/Quentin/Projects/bid-euchre               a1ae3aa [fix/linear-regression-artifact-failfast]
/Users/Quentin/.cursor/worktrees/bid-euchre/bod  2700213 [feat/bid-eval-tiny-roster-consumption]
/Users/Quentin/.cursor/worktrees/bid-euchre/chm  3c50a8a [feat/teacher-roster-manifest-v1]
/Users/Quentin/.cursor/worktrees/bid-euchre/eap  ed99a47 [fix/bidding-dataset-illegal-raise]
/Users/Quentin/.cursor/worktrees/bid-euchre/evj  34a704a [docs/teacher-baseline-loop-pause-point]
/Users/Quentin/.cursor/worktrees/bid-euchre/iaq  7caf571 [test/migrate-off-pickle-regressionbidder]
/Users/Quentin/.cursor/worktrees/bid-euchre/jsd  6df4a4b [chore/remove-pickle-regressionbidder]
/Users/Quentin/.cursor/worktrees/bid-euchre/krk  c5b760f [feat/artifact-backed-bidder]
/Users/Quentin/.cursor/worktrees/bid-euchre/lgk  4fb4f16 [chore/consolidate-train-bidder-cli]
/Users/Quentin/.cursor/worktrees/bid-euchre/lpi  6b6d8dd [chore/make-teacher-baseline-loop]
/Users/Quentin/.cursor/worktrees/bid-euchre/ocm  ceb0629 [feat/bid-eval-tiny]
/Users/Quentin/.cursor/worktrees/bid-euchre/qmv  9a314b4 [feat/bid-eval-tiny-baseline-matrix]
/Users/Quentin/.cursor/worktrees/bid-euchre/rgw  4e2a692 [fix/pyarrow-lazy-import-bidding-dataset]
/Users/Quentin/.cursor/worktrees/bid-euchre/vif  34a704a [ci/validate-teacher-roster-manifest]
/Users/Quentin/.cursor/worktrees/bid-euchre/wou  f2d43fc [pr-119-bid-eval]
/Users/Quentin/.cursor/worktrees/bid-euchre/xfg  a5719c7 (detached HEAD)
/Users/Quentin/.cursor/worktrees/bid-euchre/zbe  34a704a (detached HEAD)
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
