### PR TITLE
docs: add teacher baseline loop pause point + gold-path commands

### DIFF
--- a/docs/01_core/BIDDING_MODEL.md
+++ b/docs/01_core/BIDDING_MODEL.md
@@ -21,6 +21,18 @@ Bidding model artifacts define a deterministic, JSON-serializable format for sto
 |-------|------|-------------|
 | `metadata` | object | JSON-serializable metadata (creation time, description, etc.) |
 
+## Model Types
+
+Currently supported model types in schema v1:
+
+| Model Type | Status | Implementation |
+|------------|--------|----------------|
+| `linear_regression` | ✅ Implemented | Scikit-learn LinearRegression |
+| `random_forest` | 🔄 Reserved | Not yet implemented |
+| `neural_network` | 🔄 Reserved | Not yet implemented |
+
+**Loading Behavior**: Models with unsupported `model_type` values will raise `NotImplementedError` with clear messaging indicating the type is reserved for future implementation.
+
 ## Contract Types
 
 Contracts are represented as single strings matching the bidding protocol:
@@ -179,11 +191,13 @@ PYTHONPATH=src python scripts/run_suite.py \
 
 **Comparing Baselines**: Run `bid_eval_tiny` on each trained artifact to establish comparative performance. The suite generates structured logs enabling computation of risk-aware metrics (CVaR, downside variance).
 
-### Pause Point: Regression Loops Deferred
+### Pause Point: Arc A vs Arc B Decision
 
-**Regression/value modeling loops are intentionally paused after these baselines settle.**
+**Bidding model development is currently paused at the teacher baseline loop.**
 
-Further bidding model development (neural networks, advanced regression, reinforcement learning) should wait until:
+See [TEACHER_BASELINES.md](TEACHER_BASELINES.md) for the current pause point and architectural decision between Arc A (regression/value modeling) and Arc B (reinforcement learning).
+
+Further bidding model development should wait until:
 - Baseline teacher performance is well-characterized
 - `bid_eval_tiny` evaluation metrics stabilize
 - Comparative analysis between teachers is complete

--- a/docs/01_core/TEACHER_BASELINES.md
+++ b/docs/01_core/TEACHER_BASELINES.md
@@ -1,0 +1,100 @@
+# Teacher Baseline Loop
+
+This document describes the current "teacher baseline loop" - the process of training teacher artifacts and evaluating them using the bid_eval_tiny suite.
+
+## Current State
+
+The teacher baseline loop consists of three deterministic bidding strategies that serve as training targets for imitation learning:
+
+### Baseline Teachers
+
+| Teacher | Description | Strategy Type |
+|---------|-------------|---------------|
+| `strict_raiser` | StrictRaiserBidder | Simple raising strategy - bids if hand strength meets minimum threshold |
+| `heuristics` | HeuristicsBidder | Rule-based heuristics (v1 baseline) - considers position, cards, and opponents |
+| `artifact_bidder` | ArtifactBidder | Linear regression model bidder trained from teacher data |
+
+### Supported Model Types
+
+Currently supported bidding model types in artifact schema v1:
+- `linear_regression`: Scikit-learn LinearRegression models
+- Other model types (`random_forest`, `neural_network`) are reserved but not yet implemented
+
+**Note**: `linear_regression` models that fail to load will raise `NotImplementedError` with clear messaging.
+
+## Gold Path Commands
+
+### Train Teacher Artifacts
+
+Train all baseline teachers across all contracts (C, D, H, S, HIGH, LOW):
+
+```bash
+make bid-train-teachers
+```
+
+This generates artifacts in `data/runs/<run_id>/artifacts/` with filenames like `strict_raiser-H.json`.
+
+### Run Evaluation
+
+Evaluate trained artifacts using the bid_eval_tiny suite:
+
+```bash
+make bid-eval-tiny
+```
+
+This runs the suite defined in `experiments/suites/bid_eval_tiny.yaml` using the roster at `experiments/baselines/teacher_roster_v1.yaml`.
+
+### Complete Loop
+
+Run both training and evaluation in sequence:
+
+```bash
+make bid-teacher-loop
+```
+
+## Artifact Storage
+
+### What Gets Committed
+
+- **Schema definition**: Artifact format specifications
+- **Roster manifests**: `experiments/baselines/teacher_roster_v1.yaml`
+- **Suite configurations**: `experiments/suites/bid_eval_tiny.yaml`, `experiments/configs/bid_eval_tiny.yaml`
+- **Validation scripts**: `scripts/validate_teacher_roster_manifest.py`
+
+### What Doesn't Get Committed
+
+- **Generated artifacts**: `data/runs/<run_id>/artifacts/*.json` - these are training outputs
+- **Evaluation results**: `data/runs/<run_id>/results/` and `data/runs/<run_id>/reports/` - these are experimental outputs
+
+## Evaluation Outputs
+
+The bid_eval_tiny suite produces:
+
+### Per-Strategy Metrics
+- `reports/bidding_strategy/evaluation.json`: Detailed metrics including EV, CVaR-5%, downside variance
+- `reports/bidding_strategy/RISK_METRICS_COMPARISON.md`: Comparative analysis table
+
+### Suite Rollup
+- `rollup.json`: Structured summary of all baseline runs
+- `reports/ROLLUP.md`: Human-readable summary table
+
+## Pause Point: Arc A vs Arc B Decision
+
+**The teacher baseline loop is currently paused here, awaiting architectural decision between Arc A and Arc B.**
+
+### Arc A: Regression/Value Modeling
+- Extend bidding model types (random_forest, neural_network)
+- Implement advanced regression techniques
+- Focus on imitation learning from teacher baselines
+
+### Arc B: Reinforcement Learning
+- Implement RL-based bidding agents
+- Train against teacher baselines or self-play
+- Explore policy gradient methods
+
+**Decision Criteria**:
+- Stability of baseline teacher performance metrics
+- Completion of comparative analysis between strict_raiser, heuristics, and artifact_bidder
+- Clear understanding of risk-adjusted performance characteristics
+
+Resume development only after baseline characterization is complete to avoid confounding variables during architectural exploration.

--- a/docs/03_experiments/BID_EVAL_TINY.md
+++ b/docs/03_experiments/BID_EVAL_TINY.md
@@ -11,21 +11,30 @@ Compare baseline bidders across risk metrics:
 
 ## Baselines Compared
 
-The suite evaluates three baseline approaches:
+The suite evaluates baselines defined in the teacher roster manifest (`experiments/baselines/teacher_roster_v1.yaml`) with the `include_baselines` configuration:
 
-1. **strict**: `StrictRaiserBidder` - Rule-based bidder following strict raising rules
+Currently evaluates:
+1. **strict_raiser**: `StrictRaiserBidder` - Rule-based bidder following strict raising rules
 2. **heuristics**: `HeuristicsBidder` - v1 baseline heuristic bidder
-3. **artifact**: `ArtifactGreedyStrategy` - Linear regression model bidder
+3. **artifact_bidder**: `ArtifactBidder` - Linear regression model bidder using trained artifacts
+
+The roster manifest supports additional baseline types (policy, artifact_policy) for future expansion.
 
 ## Usage
 
-Run the complete baseline comparison:
+Run the complete baseline comparison using the gold path:
+
+```bash
+make bid-eval-tiny
+```
+
+Or run manually:
 
 ```bash
 PYTHONPATH=src python scripts/run_suite.py --suite experiments/suites/bid_eval_tiny.yaml
 ```
 
-This generates individual run directories for each baseline, plus a suite rollup with summary metrics.
+This generates individual run directories for each baseline in the roster, plus a suite rollup with summary metrics.
 
 ## Output Structure
 


### PR DESCRIPTION
## Summary
- Document the teacher baseline loop (train → eval → outputs).
- Add a clear pause point before Arc A vs Arc B.
- Update bid_eval_tiny + bidding model docs to match current roster + artifact support.

## Why
- Make it dead simple to understand and run the current "teacher baseline loop".
- Clearly document the intentional pause point before choosing Arc A vs Arc B.
- Ensure docs reflect the current state after PRs 129-132.

## Repro / Validation
**Command(s) run:**
- make check
- make bid-eval-tiny -n
- make bid-train-teachers -n

**Config (if applicable):**
- experiments/baselines/teacher_roster_v1.yaml
- experiments/configs/bid_eval_tiny.yaml

**Seed (if applicable):**
- 42 (default)

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/`
- [ ] Integration (if engine/rules changed): `PYTHONPATH=src python -m pytest tests/integration/`
- [ ] Other:

## Expected impact
- Metrics impact (if any): none
- Runtime impact (if any): none

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/Quentin/.cursor/worktrees/bid-euchre/eim
```

`git rev-parse --show-toplevel`:
```
/Users/Quentin/.cursor/worktrees/bid-euchre/eim
```

`git worktree list`:
```
/Users/Quentin/Projects/bid-euchre               a1ae3aa [fix/linear-regression-artifact-failfast]
/Users/Quentin/.cursor/worktrees/bid-euchre/bod  2700213 [feat/bid-eval-tiny-roster-consumption]
/Users/Quentin/.cursor/worktrees/bid-euchre/chm  3c50a8a [feat/teacher-roster-manifest-v1]
/Users/Quentin/.cursor/worktrees/bid-euchre/eap  ed99a47 [fix/bidding-dataset-illegal-raise]
/Users/Quentin/.cursor/worktrees/bid-euchre/eim  da9e5c8 [docs/teacher-baseline-loop-pause-point-v2]
/Users/Quentin/.cursor/worktrees/bid-euchre/evj  34a704a [docs/teacher-baseline-loop-pause-point]
/Users/Quentin/.cursor/worktrees/bid-euchre/iaq  7caf571 [test/migrate-off-pickle-regressionbidder]
/Users/Quentin/.cursor/worktrees/bid-euchre/jsd  6df4a4b [chore/remove-pickle-regressionbidder]
/Users/Quentin/.cursor/worktrees/bid-euchre/krk  c5b760f [feat/artifact-backed-bidder]
/Users/Quentin/.cursor/worktrees/bid-euchre/lgk  4fb4f16 [chore/consolidate-train-bidder-cli]
/Users/Quentin/.cursor/worktrees/bid-euchre/lpi  6b6d8dd [chore/make-teacher-baseline-loop]
/Users/Quentin/.cursor/worktrees/bid-euchre/ocm  ceb0629 [feat/bid-eval-tiny]
/Users/Quentin/.cursor/worktrees/bid-euchre/qmv  9a314b4 [feat/bid-eval-tiny-baseline-matrix]
/Users/Quentin/.cursor/worktrees/bid-euchre/rgw  4e2a692 [fix/pyarrow-lazy-import-bidding-dataset]
/Users/Quentin/.cursor/worktrees/bid-euchre/vif  8600631 [ci/validate-teacher-roster-manifest]
/Users/Quentin/.cursor/worktrees/bid-euchre/wou  f2d43fc [pr-119-bid-eval]
/Users/Quentin/.cursor/worktrees/bid-euchre/xfg  a5719c7 (detached HEAD)
/Users/Quentin/.cursor/worktrees/bid-euchre/zbe  34a704a (detached HEAD)
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [ ] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
