### PR TITLE
build: add make targets for teacher baseline loop (train + bid_eval_tiny)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help repo-lint lint test check bid-train-teachers bid-eval-tiny bid-teacher-loop
+.PHONY: help repo-lint lint test check bid-train-teachers bid-eval-tiny bid-loop
 .DEFAULT_GOAL := help
 
 PYTHON ?= python
@@ -23,7 +23,7 @@ help:
 	@echo "Teacher baseline targets:"
 	@echo "  make bid-train-teachers - train teacher artifacts (all contracts)"
 	@echo "  make bid-eval-tiny      - run bid_eval_tiny suite"
-	@echo "  make bid-teacher-loop   - train teachers then eval tiny"
+	@echo "  make bid-loop           - train teachers then eval tiny"
 	@echo ""
 
 repo-lint:
@@ -76,5 +76,5 @@ bid-eval-tiny:
 	@echo "✅ bid_eval_tiny complete"
 	@echo "Find latest run in: $(RUN_BASE)/"
 
-bid-teacher-loop: bid-train-teachers bid-eval-tiny
+bid-loop: bid-train-teachers bid-eval-tiny
 	@echo "✅ Teacher baseline loop complete"


### PR DESCRIPTION
## Summary

Add a small set of Make targets that provide a reproducible "gold path" for:
- training teacher artifacts (strict/heuristics), and  
- running bid_eval_tiny.

## Changes

- Rename \`bid-teacher-loop\` to \`bid-loop\` for consistency with naming requirements
- All targets were already implemented and functional
- Only surgical naming change required for exact target matching

## Test plan

- \`make check\` passes (repo-lint + ruff + tests)
- \`make -n bid-loop\` shows correct command sequence without executing
- Targets use existing scripts and maintain deterministic behavior
- No generated artifacts committed

## Validation

The implementation provides the exact targets requested:
- \`bid-train-teachers\`: trains artifacts for all supported teachers/contracts
- \`bid-eval-tiny\`: runs the bid_eval_tiny suite  
- \`bid-loop\`: runs training then evaluation with proper sequencing

All commands are shell-safe and use discovered paths from existing codebase.