### PR TITLE
feat: add bidless hand feature extractor v1 (deterministic)

### DIFF
--- a/docs/01_core/BIDLESS_FEATURES.md
+++ b/docs/01_core/BIDLESS_FEATURES.md
@@ -1,0 +1,402 @@
+# Bidless Hand Features (v1)
+
+## Overview
+
+The **Bidless Hand Feature Extractor** transforms a 10-card hand (after bidding has concluded) into a fixed-order numeric feature vector for value model training. This extractor is deterministic and designed for predicting trick outcomes based on hand composition, trump strength, and positional context.
+
+**Module**: `src/bid_euchre/features/bidless_hand_features.py`
+
+**Schema Version**: v1
+
+---
+
+## Key Requirements
+
+1. **Deterministic**: Same input always produces same output
+2. **Stable Ordering**: Features always appear in the same order (no dict iteration randomness)
+3. **Schema Versioned**: Includes version marker for forward compatibility
+4. **Pure Function**: No side effects, no external state
+
+---
+
+## API
+
+### Main Functions
+
+#### `extract_bidless_hand_features(hand, contract_type, trump_suit, dealer_seat, leader_seat)`
+
+Extracts features as a dictionary with stable key ordering.
+
+**Args:**
+- `hand` (List[Card]): The 10-card hand
+- `contract_type` (str): "suit", "high", or "low"
+- `trump_suit` (Optional[str]): Trump suit for suit contracts (e.g., "H"), None for high/low
+- `dealer_seat` (Optional[int]): Dealer's seat index (0-3), or None if unknown
+- `leader_seat` (Optional[int]): Leader's seat index (0-3), or None if unknown
+
+**Returns:**
+- `Dict[str, float]`: Feature dictionary with 31 features in stable order
+
+**Raises:**
+- `ValueError`: If `contract_type` is "suit" but `trump_suit` is None
+
+---
+
+#### `extract_feature_vector(hand, contract_type, trump_suit, dealer_seat, leader_seat)`
+
+Convenience wrapper that returns features as a list instead of a dict, for direct use in ML frameworks.
+
+**Returns:**
+- `Tuple[List[float], List[str]]`: (feature_values, feature_names)
+
+---
+
+#### `get_feature_names()`
+
+Returns the stable, ordered list of all 31 feature names.
+
+**Returns:**
+- `List[str]`: Feature names in extraction order
+
+---
+
+## Feature Schema (v1)
+
+Total features: **31**
+
+### 1. Schema Marker (1 feature)
+
+| Feature | Type | Description |
+|---------|------|-------------|
+| `schema_version_marker` | float | Version identifier (v1 = 1.0) |
+
+---
+
+### 2. Hand Composition by Rank (5 features)
+
+Counts of each rank in the hand, regardless of suit or trump status.
+
+| Feature | Type | Description |
+|---------|------|-------------|
+| `count_aces` | float | Number of Aces in hand (0-10) |
+| `count_kings` | float | Number of Kings in hand (0-10) |
+| `count_queens` | float | Number of Queens in hand (0-10) |
+| `count_jacks` | float | Number of Jacks in hand (0-10) |
+| `count_tens` | float | Number of Tens in hand (0-10) |
+
+---
+
+### 3. Trump Features (7 features)
+
+Trump strength indicators for suit contracts. For high/low contracts, all trump features are set to 0.
+
+| Feature | Type | Description |
+|---------|------|-------------|
+| `trump_count` | float | Total trump cards (including bowers) (0-10) |
+| `has_right_bower` | float | 1.0 if right bower present, else 0.0 |
+| `has_left_bower` | float | 1.0 if left bower present, else 0.0 |
+| `trump_aces` | float | Number of trump Aces (0-2) |
+| `trump_kings` | float | Number of trump Kings (0-2) |
+| `trump_queens` | float | Number of trump Queens (0-2) |
+| `trump_tens` | float | Number of trump Tens (0-2) |
+
+**Note**: In suit contracts:
+- Right bower = Jack of trump suit
+- Left bower = Jack of same-color suit (becomes trump)
+- Trump cards are counted by their effective suit, not printed suit
+
+---
+
+### 4. Offsuit Distribution (6 features)
+
+Suit length distribution, sorted longest to shortest for stability. In suit contracts, trump cards are excluded from offsuit counts.
+
+| Feature | Type | Description |
+|---------|------|-------------|
+| `longest_offsuit_length` | float | Length of longest suit (0-10) |
+| `second_longest_offsuit_length` | float | Length of 2nd longest suit (0-10) |
+| `third_longest_offsuit_length` | float | Length of 3rd longest suit (0-10) |
+| `shortest_offsuit_length` | float | Length of shortest suit (0-10) |
+| `void_count` | float | Number of suits with 0 cards (0-4) |
+| `singleton_count` | float | Number of suits with 1 card (0-4) |
+
+**Suit vs High/Low difference:**
+- **Suit contracts**: Offsuit = non-trump suits (4 suits minus trump)
+- **High/Low contracts**: Offsuit = all 4 suits (no trump concept)
+
+---
+
+### 5. Offsuit Control (2 features)
+
+High-value offsuit cards that may control tricks.
+
+| Feature | Type | Description |
+|---------|------|-------------|
+| `offsuit_aces` | float | Number of offsuit Aces (0-8) |
+| `offsuit_kings` | float | Number of offsuit Kings (0-8) |
+
+**Suit vs High/Low difference:**
+- **Suit contracts**: Only non-trump Aces/Kings count
+- **High/Low contracts**: All Aces/Kings count (no trump distinction)
+
+---
+
+### 6. Seat Context - Dealer (5 features)
+
+One-hot encoding of dealer position. Exactly one feature is 1.0, others are 0.0.
+
+| Feature | Type | Description |
+|---------|------|-------------|
+| `is_dealer_seat_0` | float | 1.0 if dealer at seat 0, else 0.0 |
+| `is_dealer_seat_1` | float | 1.0 if dealer at seat 1, else 0.0 |
+| `is_dealer_seat_2` | float | 1.0 if dealer at seat 2, else 0.0 |
+| `is_dealer_seat_3` | float | 1.0 if dealer at seat 3, else 0.0 |
+| `dealer_seat_unknown` | float | 1.0 if dealer unknown, else 0.0 |
+
+---
+
+### 7. Seat Context - Leader (5 features)
+
+One-hot encoding of leader (first to play) position. Exactly one feature is 1.0, others are 0.0.
+
+| Feature | Type | Description |
+|---------|------|-------------|
+| `is_leader_seat_0` | float | 1.0 if leader at seat 0, else 0.0 |
+| `is_leader_seat_1` | float | 1.0 if leader at seat 1, else 0.0 |
+| `is_leader_seat_2` | float | 1.0 if leader at seat 2, else 0.0 |
+| `is_leader_seat_3` | float | 1.0 if leader at seat 3, else 0.0 |
+| `leader_seat_unknown` | float | 1.0 if leader unknown, else 0.0 |
+
+---
+
+## Feature Ordering Guarantee
+
+Features are always extracted in the order listed above. This is enforced by:
+
+1. **Explicit insertion order** in `extract_bidless_hand_features()` (Python 3.7+ dicts maintain insertion order)
+2. **Canonical name list** provided by `get_feature_names()`
+3. **Unit tests** verifying order stability across calls
+
+**Do not rely on dict iteration order from external code.** Always use `get_feature_names()` or `extract_feature_vector()` to ensure correct ordering.
+
+---
+
+## Contract Type Behavior
+
+### Suit Contracts
+
+- `trump_suit` must be specified (e.g., "H", "D", "C", "S")
+- Bowers (right/left) are identified and counted as trump
+- Offsuit features exclude trump cards
+- Trump features are populated based on effective suit
+
+**Example:**
+```python
+hand = [Card("H", "J"), Card("D", "J"), Card("H", "A"), ...]
+features = extract_bidless_hand_features(
+    hand, contract_type="suit", trump_suit="H"
+)
+# Result:
+# - has_right_bower = 1.0 (HJ is right bower)
+# - has_left_bower = 1.0 (DJ is left bower for H trump)
+# - trump_count = 3.0 (HJ + DJ + HA)
+```
+
+---
+
+### High Contracts
+
+- No trump suit (set `trump_suit=None`)
+- All trump features are 0.0
+- All cards are treated as "offsuit"
+- Ace is highest rank
+
+**Example:**
+```python
+features = extract_bidless_hand_features(
+    hand, contract_type="high"
+)
+# Result:
+# - trump_count = 0.0
+# - has_right_bower = 0.0
+# - has_left_bower = 0.0
+# - offsuit_aces = (all aces in hand)
+```
+
+---
+
+### Low Contracts
+
+- No trump suit (set `trump_suit=None`)
+- All trump features are 0.0
+- All cards are treated as "offsuit"
+- Ten is highest rank, Ace is lowest
+
+**Example:**
+```python
+features = extract_bidless_hand_features(
+    hand, contract_type="low"
+)
+# Result:
+# - trump_count = 0.0
+# - has_right_bower = 0.0
+# - has_left_bower = 0.0
+# - offsuit_aces = (all aces in hand)
+```
+
+---
+
+## Usage Examples
+
+### Basic Extraction (Dict)
+
+```python
+from bid_euchre.core.cards import Card
+from bid_euchre.features.bidless_hand_features import extract_bidless_hand_features
+
+hand = [
+    Card("H", "J"),  # Right bower
+    Card("H", "A"),
+    Card("H", "K"),
+    Card("C", "A"),
+    Card("C", "K"),
+    Card("D", "A"),
+    Card("D", "T"),
+    Card("S", "Q"),
+    Card("S", "T"),
+    Card("S", "T"),
+]
+
+features = extract_bidless_hand_features(
+    hand,
+    contract_type="suit",
+    trump_suit="H",
+    dealer_seat=0,
+    leader_seat=1,
+)
+
+print(features["trump_count"])        # 3.0 (RB, HA, HK)
+print(features["has_right_bower"])    # 1.0
+print(features["offsuit_aces"])       # 2.0 (CA, DA)
+```
+
+---
+
+### Feature Vector (List)
+
+```python
+from bid_euchre.features.bidless_hand_features import extract_feature_vector
+
+values, names = extract_feature_vector(
+    hand,
+    contract_type="suit",
+    trump_suit="H",
+    dealer_seat=0,
+    leader_seat=1,
+)
+
+# Use in scikit-learn, PyTorch, etc.
+import numpy as np
+X = np.array([values])  # Shape: (1, 31)
+
+# Check feature names
+print(names[0])   # "schema_version_marker"
+print(names[1])   # "count_aces"
+print(len(names)) # 31
+```
+
+---
+
+### Get Feature Names Only
+
+```python
+from bid_euchre.features.bidless_hand_features import get_feature_names
+
+names = get_feature_names()
+print(len(names))  # 31
+print(names[:5])   # ["schema_version_marker", "count_aces", "count_kings", ...]
+```
+
+---
+
+## Testing
+
+Comprehensive unit tests are provided in `tests/unit/test_bidless_hand_features.py`.
+
+**Test coverage includes:**
+- Feature name stability and ordering
+- Deterministic output for same input
+- Schema version marker presence
+- All contract types (suit, high, low)
+- Bower identification
+- Rank counting
+- Trump feature calculation
+- Offsuit distribution (voids, singletons, sorted lengths)
+- Offsuit control (aces, kings)
+- Seat context encoding (dealer, leader, unknown)
+- Feature vector consistency with dict
+- Edge cases (empty hand, all trump, all jacks, etc.)
+
+**Run tests:**
+```bash
+pytest tests/unit/test_bidless_hand_features.py -v
+```
+
+---
+
+## Design Rationale
+
+### Why Stable Ordering?
+
+Dictionary iteration order became stable in Python 3.7+, but relying on insertion order makes the code fragile to refactoring. By providing `get_feature_names()` as the canonical ordering, we ensure:
+- Features can be extracted as numpy arrays with consistent column meaning
+- Training and inference use the same feature order
+- Feature importance analysis maps correctly to feature names
+
+---
+
+### Why One-Hot Encoding for Seats?
+
+Seat position is categorical, not ordinal. One-hot encoding prevents the model from learning spurious ordinal relationships (e.g., "seat 3 is 3x more important than seat 1").
+
+---
+
+### Why Schema Version Marker?
+
+As models evolve, feature definitions may change (new features added, old ones removed, semantics adjusted). The schema version marker allows:
+- Training scripts to validate feature compatibility
+- Models to reject incompatible feature vectors
+- Forward compatibility planning (e.g., v1 vs v2 extractors)
+
+---
+
+## Future Extensions (Not in v1)
+
+Potential future additions (would require schema v2):
+- Trick-by-trick state features (cards played so far)
+- Partner's bid information
+- Opponent modeling features
+- Hand evaluation scores (from `hand_eval.py`)
+- Interaction terms (e.g., trump_count × offsuit_aces)
+
+**For v1, we keep it simple and deterministic.**
+
+---
+
+## Related Documentation
+
+- **Hand Evaluation**: `src/bid_euchre/features/hand_eval.py` (bidding-phase features)
+- **Card Primitives**: `src/bid_euchre/core/cards.py` (Card, effective_suit, bowers)
+- **Rules**: `docs/01_core/RULES.md` (game rules and trump mechanics)
+- **Bidding Dataset**: `docs/01_core/BIDDING_DATASET.md` (pre-bidding features)
+
+---
+
+## Changelog
+
+### v1 (Initial Release)
+- 31 features covering hand composition, trump strength, offsuit distribution, and seat context
+- Deterministic, stable-order extraction
+- Support for suit, high, and low contracts
+- One-hot encoding for dealer and leader seats
+- Schema version marker for forward compatibility

--- a/src/bid_euchre/features/bidless_hand_features.py
+++ b/src/bid_euchre/features/bidless_hand_features.py
@@ -1,0 +1,272 @@
+"""
+Bidless Hand Feature Extractor v1 (Deterministic)
+
+Extracts features from a 10-card hand AFTER the bidding phase (contract is known).
+Used for value model training to predict trick outcomes.
+
+Key requirements:
+- Deterministic: same input always produces same output
+- Stable ordering: features always appear in the same order
+- Schema versioned: includes version marker for forward compatibility
+
+Feature categories:
+- Hand composition (by rank)
+- Trump strength (suit contracts only)
+- Offsuit control and distribution
+- Seat context (dealer, leader positions)
+"""
+
+from typing import Dict, List, Optional, Tuple
+
+from ..core.cards import Card, effective_suit, is_left_bower, is_right_bower
+
+# Schema version for feature compatibility tracking
+BIDLESS_FEATURES_SCHEMA_VERSION = "v1"
+
+
+def extract_bidless_hand_features(
+    hand: List[Card],
+    contract_type: str,
+    trump_suit: Optional[str] = None,
+    dealer_seat: Optional[int] = None,
+    leader_seat: Optional[int] = None,
+) -> Dict[str, float]:
+    """
+    Extract features from a bidless hand for value model training.
+
+    Args:
+        hand: List of 10 cards in the player's hand
+        contract_type: "suit", "high", or "low"
+        trump_suit: Trump suit (required for "suit" contracts, None otherwise)
+        dealer_seat: Seat index of the dealer (0-3), or None if unknown
+        leader_seat: Seat index of the leader (0-3), or None if unknown
+
+    Returns:
+        Dictionary mapping feature names to numeric values, in stable order.
+        Includes schema_version marker for compatibility tracking.
+
+    Raises:
+        ValueError: if contract_type is "suit" but trump_suit is None
+    """
+    if contract_type == "suit" and trump_suit is None:
+        raise ValueError("trump_suit must be provided for 'suit' contracts")
+
+    # Initialize feature dict with explicit ordering (Python 3.7+ dicts maintain insertion order)
+    features: Dict[str, float] = {}
+
+    # Schema version (for compatibility tracking)
+    features["schema_version_marker"] = 1.0  # v1 = 1.0
+
+    # ===========================
+    # Hand Composition Features
+    # ===========================
+    # Count cards by rank (explicit order: A, K, Q, J, T)
+    features["count_aces"] = float(sum(1 for c in hand if c.rank == "A"))
+    features["count_kings"] = float(sum(1 for c in hand if c.rank == "K"))
+    features["count_queens"] = float(sum(1 for c in hand if c.rank == "Q"))
+    features["count_jacks"] = float(sum(1 for c in hand if c.rank == "J"))
+    features["count_tens"] = float(sum(1 for c in hand if c.rank == "T"))
+
+    # ===========================
+    # Trump Features (Suit Contracts Only)
+    # ===========================
+    if contract_type == "suit":
+        trump_count = 0
+        has_right_bower = 0.0
+        has_left_bower = 0.0
+        trump_aces = 0
+        trump_kings = 0
+        trump_queens = 0
+        trump_tens = 0
+
+        for card in hand:
+            eff_suit = effective_suit(card, trump_suit, contract_type)
+            if eff_suit == trump_suit:
+                trump_count += 1
+                if is_right_bower(card, trump_suit):
+                    has_right_bower = 1.0
+                elif is_left_bower(card, trump_suit):
+                    has_left_bower = 1.0
+                elif card.rank == "A":
+                    trump_aces += 1
+                elif card.rank == "K":
+                    trump_kings += 1
+                elif card.rank == "Q":
+                    trump_queens += 1
+                elif card.rank == "T":
+                    trump_tens += 1
+
+        features["trump_count"] = float(trump_count)
+        features["has_right_bower"] = has_right_bower
+        features["has_left_bower"] = has_left_bower
+        features["trump_aces"] = float(trump_aces)
+        features["trump_kings"] = float(trump_kings)
+        features["trump_queens"] = float(trump_queens)
+        features["trump_tens"] = float(trump_tens)
+    else:
+        # High/Low contracts: no trump, set all to 0
+        features["trump_count"] = 0.0
+        features["has_right_bower"] = 0.0
+        features["has_left_bower"] = 0.0
+        features["trump_aces"] = 0.0
+        features["trump_kings"] = 0.0
+        features["trump_queens"] = 0.0
+        features["trump_tens"] = 0.0
+
+    # ===========================
+    # Offsuit Distribution Features
+    # ===========================
+    # Group cards by suit (effective suit for suit contracts, literal suit for high/low)
+    suit_lengths: Dict[str, int] = {"C": 0, "D": 0, "H": 0, "S": 0}
+
+    for card in hand:
+        if contract_type == "suit":
+            eff_suit = effective_suit(card, trump_suit, contract_type)
+            # Don't count trump cards in offsuit distribution
+            if eff_suit != trump_suit:
+                suit_lengths[card.suit] += 1
+        else:
+            # High/Low: use literal suit
+            suit_lengths[card.suit] += 1
+
+    # Sort suit lengths for stable feature ordering (longest to shortest)
+    sorted_lengths = sorted(suit_lengths.values(), reverse=True)
+
+    features["longest_offsuit_length"] = float(sorted_lengths[0])
+    features["second_longest_offsuit_length"] = float(sorted_lengths[1])
+    features["third_longest_offsuit_length"] = float(sorted_lengths[2])
+    features["shortest_offsuit_length"] = float(sorted_lengths[3])
+
+    # Count voids and singletons
+    features["void_count"] = float(sum(1 for length in suit_lengths.values() if length == 0))
+    features["singleton_count"] = float(sum(1 for length in suit_lengths.values() if length == 1))
+
+    # ===========================
+    # Offsuit Control Features
+    # ===========================
+    # Count offsuit aces (for suit contracts) or all aces (for high/low)
+    if contract_type == "suit":
+        offsuit_aces = 0
+        offsuit_kings = 0
+        for card in hand:
+            eff_suit = effective_suit(card, trump_suit, contract_type)
+            if eff_suit != trump_suit:
+                if card.rank == "A":
+                    offsuit_aces += 1
+                elif card.rank == "K":
+                    offsuit_kings += 1
+        features["offsuit_aces"] = float(offsuit_aces)
+        features["offsuit_kings"] = float(offsuit_kings)
+    else:
+        # High/Low: all cards are "offsuit"
+        features["offsuit_aces"] = float(features["count_aces"])
+        features["offsuit_kings"] = float(features["count_kings"])
+
+    # ===========================
+    # Seat Context Features
+    # ===========================
+    # One-hot encode dealer position (0-3, or -1 if unknown)
+    # This helps model learn positional advantages
+    features["is_dealer_seat_0"] = 1.0 if dealer_seat == 0 else 0.0
+    features["is_dealer_seat_1"] = 1.0 if dealer_seat == 1 else 0.0
+    features["is_dealer_seat_2"] = 1.0 if dealer_seat == 2 else 0.0
+    features["is_dealer_seat_3"] = 1.0 if dealer_seat == 3 else 0.0
+    features["dealer_seat_unknown"] = 1.0 if dealer_seat is None else 0.0
+
+    # One-hot encode leader position (0-3, or -1 if unknown)
+    features["is_leader_seat_0"] = 1.0 if leader_seat == 0 else 0.0
+    features["is_leader_seat_1"] = 1.0 if leader_seat == 1 else 0.0
+    features["is_leader_seat_2"] = 1.0 if leader_seat == 2 else 0.0
+    features["is_leader_seat_3"] = 1.0 if leader_seat == 3 else 0.0
+    features["leader_seat_unknown"] = 1.0 if leader_seat is None else 0.0
+
+    return features
+
+
+def get_feature_names() -> List[str]:
+    """
+    Return the stable, ordered list of feature names.
+
+    This list is deterministic and matches the order of features
+    returned by extract_bidless_hand_features().
+
+    Returns:
+        List of feature names in extraction order
+    """
+    return [
+        # Schema version
+        "schema_version_marker",
+        # Hand composition (by rank)
+        "count_aces",
+        "count_kings",
+        "count_queens",
+        "count_jacks",
+        "count_tens",
+        # Trump features (suit contracts)
+        "trump_count",
+        "has_right_bower",
+        "has_left_bower",
+        "trump_aces",
+        "trump_kings",
+        "trump_queens",
+        "trump_tens",
+        # Offsuit distribution
+        "longest_offsuit_length",
+        "second_longest_offsuit_length",
+        "third_longest_offsuit_length",
+        "shortest_offsuit_length",
+        "void_count",
+        "singleton_count",
+        # Offsuit control
+        "offsuit_aces",
+        "offsuit_kings",
+        # Seat context (dealer)
+        "is_dealer_seat_0",
+        "is_dealer_seat_1",
+        "is_dealer_seat_2",
+        "is_dealer_seat_3",
+        "dealer_seat_unknown",
+        # Seat context (leader)
+        "is_leader_seat_0",
+        "is_leader_seat_1",
+        "is_leader_seat_2",
+        "is_leader_seat_3",
+        "leader_seat_unknown",
+    ]
+
+
+def extract_feature_vector(
+    hand: List[Card],
+    contract_type: str,
+    trump_suit: Optional[str] = None,
+    dealer_seat: Optional[int] = None,
+    leader_seat: Optional[int] = None,
+) -> Tuple[List[float], List[str]]:
+    """
+    Extract features as a fixed-order numeric vector.
+
+    This is a convenience wrapper around extract_bidless_hand_features()
+    that returns features as a list instead of a dict, for direct use
+    in ML frameworks.
+
+    Args:
+        hand: List of 10 cards
+        contract_type: "suit", "high", or "low"
+        trump_suit: Trump suit (required for "suit")
+        dealer_seat: Dealer position (0-3 or None)
+        leader_seat: Leader position (0-3 or None)
+
+    Returns:
+        Tuple of (feature_values, feature_names)
+        - feature_values: List of numeric feature values in stable order
+        - feature_names: List of feature names matching the values
+    """
+    features_dict = extract_bidless_hand_features(
+        hand, contract_type, trump_suit, dealer_seat, leader_seat
+    )
+    feature_names = get_feature_names()
+
+    # Extract values in the stable order defined by get_feature_names()
+    feature_values = [features_dict[name] for name in feature_names]
+
+    return feature_values, feature_names

--- a/tests/unit/test_bidless_hand_features.py
+++ b/tests/unit/test_bidless_hand_features.py
@@ -1,0 +1,651 @@
+"""
+Unit tests for bidless hand feature extraction (v1).
+
+Tests cover:
+- Deterministic output for same input
+- Schema version marker presence
+- Feature name stability
+- All contract types (suit, high, low)
+- Seat context encoding
+- Edge cases (empty hands, all trump, etc.)
+"""
+
+import pytest
+
+from bid_euchre.core.cards import Card
+from bid_euchre.features.bidless_hand_features import (
+    BIDLESS_FEATURES_SCHEMA_VERSION,
+    extract_bidless_hand_features,
+    extract_feature_vector,
+    get_feature_names,
+)
+
+# ============================================================================
+# Feature Name Stability Tests
+# ============================================================================
+
+
+def test_get_feature_names_returns_stable_list():
+    """Feature names list should be deterministic and stable."""
+    names1 = get_feature_names()
+    names2 = get_feature_names()
+
+    # Same call returns same list
+    assert names1 == names2
+
+    # Schema version marker should be first
+    assert names1[0] == "schema_version_marker"
+
+    # No duplicates
+    assert len(names1) == len(set(names1))
+
+
+def test_feature_names_expected_count():
+    """We expect 31 features in v1."""
+    names = get_feature_names()
+    # 1 schema + 5 rank counts + 7 trump + 6 offsuit dist + 2 offsuit control + 5 dealer + 5 leader = 31
+    assert len(names) == 31
+
+
+def test_feature_names_order_stability():
+    """Feature names should appear in documented order."""
+    names = get_feature_names()
+
+    # Schema first
+    assert names[0] == "schema_version_marker"
+
+    # Rank counts next (A, K, Q, J, T)
+    assert names[1:6] == [
+        "count_aces",
+        "count_kings",
+        "count_queens",
+        "count_jacks",
+        "count_tens",
+    ]
+
+    # Trump features
+    assert names[6:13] == [
+        "trump_count",
+        "has_right_bower",
+        "has_left_bower",
+        "trump_aces",
+        "trump_kings",
+        "trump_queens",
+        "trump_tens",
+    ]
+
+    # Offsuit distribution
+    assert names[13:19] == [
+        "longest_offsuit_length",
+        "second_longest_offsuit_length",
+        "third_longest_offsuit_length",
+        "shortest_offsuit_length",
+        "void_count",
+        "singleton_count",
+    ]
+
+    # Offsuit control
+    assert names[19:21] == [
+        "offsuit_aces",
+        "offsuit_kings",
+    ]
+
+    # Dealer seat context
+    assert names[21:26] == [
+        "is_dealer_seat_0",
+        "is_dealer_seat_1",
+        "is_dealer_seat_2",
+        "is_dealer_seat_3",
+        "dealer_seat_unknown",
+    ]
+
+    # Leader seat context
+    assert names[26:31] == [
+        "is_leader_seat_0",
+        "is_leader_seat_1",
+        "is_leader_seat_2",
+        "is_leader_seat_3",
+        "leader_seat_unknown",
+    ]
+
+
+# ============================================================================
+# Determinism Tests
+# ============================================================================
+
+
+def test_same_hand_produces_same_features():
+    """Calling the function twice with the same input should produce identical output."""
+    hand = [
+        Card("H", "J"),  # Right bower
+        Card("H", "A"),
+        Card("H", "K"),
+        Card("C", "A"),
+        Card("C", "K"),
+        Card("D", "A"),
+        Card("D", "T"),
+        Card("S", "Q"),
+        Card("S", "T"),
+        Card("S", "T"),
+    ]
+
+    features1 = extract_bidless_hand_features(
+        hand, contract_type="suit", trump_suit="H", dealer_seat=0, leader_seat=1
+    )
+    features2 = extract_bidless_hand_features(
+        hand, contract_type="suit", trump_suit="H", dealer_seat=0, leader_seat=1
+    )
+
+    assert features1 == features2
+
+
+def test_feature_dict_order_is_stable():
+    """Feature dict keys should maintain insertion order (Python 3.7+)."""
+    hand = [Card("H", "A")] * 10
+
+    features = extract_bidless_hand_features(hand, contract_type="high")
+
+    # Extract keys as list
+    keys = list(features.keys())
+
+    # Should match get_feature_names() order
+    assert keys == get_feature_names()
+
+
+# ============================================================================
+# Schema Version Tests
+# ============================================================================
+
+
+def test_schema_version_marker_present():
+    """All feature dicts should include schema version marker."""
+    hand = [Card("H", "A")] * 10
+
+    features = extract_bidless_hand_features(hand, contract_type="high")
+
+    assert "schema_version_marker" in features
+    assert features["schema_version_marker"] == 1.0  # v1
+
+
+def test_schema_version_constant_defined():
+    """Schema version constant should be defined at module level."""
+    assert BIDLESS_FEATURES_SCHEMA_VERSION == "v1"
+
+
+# ============================================================================
+# Contract Type Tests
+# ============================================================================
+
+
+def test_suit_contract_requires_trump_suit():
+    """Suit contracts must specify trump_suit."""
+    hand = [Card("H", "A")] * 10
+
+    with pytest.raises(ValueError, match="trump_suit must be provided"):
+        extract_bidless_hand_features(hand, contract_type="suit")
+
+
+def test_high_contract_no_trump():
+    """High contracts should have zero trump features."""
+    hand = [Card("H", "J"), Card("D", "J")] + [Card("H", "A")] * 8
+
+    features = extract_bidless_hand_features(hand, contract_type="high")
+
+    assert features["trump_count"] == 0.0
+    assert features["has_right_bower"] == 0.0
+    assert features["has_left_bower"] == 0.0
+    assert features["trump_aces"] == 0.0
+
+
+def test_low_contract_no_trump():
+    """Low contracts should have zero trump features."""
+    hand = [Card("H", "J"), Card("D", "J")] + [Card("H", "A")] * 8
+
+    features = extract_bidless_hand_features(hand, contract_type="low")
+
+    assert features["trump_count"] == 0.0
+    assert features["has_right_bower"] == 0.0
+    assert features["has_left_bower"] == 0.0
+
+
+def test_suit_contract_with_bowers():
+    """Suit contracts should correctly identify bowers."""
+    hand = [
+        Card("H", "J"),  # Right bower (trump=H)
+        Card("D", "J"),  # Left bower (same color)
+        Card("H", "A"),
+        Card("C", "A"),
+        Card("C", "K"),
+        Card("C", "Q"),
+        Card("S", "A"),
+        Card("S", "K"),
+        Card("S", "Q"),
+        Card("S", "T"),
+    ]
+
+    features = extract_bidless_hand_features(hand, contract_type="suit", trump_suit="H")
+
+    assert features["trump_count"] == 3.0  # RB + LB + HA
+    assert features["has_right_bower"] == 1.0
+    assert features["has_left_bower"] == 1.0
+    assert features["trump_aces"] == 1.0  # HA
+    assert features["trump_kings"] == 0.0
+    assert features["trump_queens"] == 0.0
+
+
+# ============================================================================
+# Hand Composition Tests
+# ============================================================================
+
+
+def test_rank_counts_basic():
+    """Test basic rank counting."""
+    hand = [
+        Card("H", "A"),
+        Card("D", "A"),
+        Card("C", "K"),
+        Card("S", "Q"),
+        Card("H", "J"),
+        Card("D", "T"),
+        Card("C", "T"),
+        Card("S", "T"),
+        Card("H", "T"),
+        Card("D", "T"),
+    ]
+
+    features = extract_bidless_hand_features(hand, contract_type="high")
+
+    assert features["count_aces"] == 2.0
+    assert features["count_kings"] == 1.0
+    assert features["count_queens"] == 1.0
+    assert features["count_jacks"] == 1.0
+    assert features["count_tens"] == 5.0
+
+
+def test_all_same_rank():
+    """Test hand with all cards of same rank."""
+    hand = [Card("H", "A")] * 10
+
+    features = extract_bidless_hand_features(hand, contract_type="high")
+
+    assert features["count_aces"] == 10.0
+    assert features["count_kings"] == 0.0
+    assert features["count_queens"] == 0.0
+    assert features["count_jacks"] == 0.0
+    assert features["count_tens"] == 0.0
+
+
+# ============================================================================
+# Trump Features Tests (Suit Contracts)
+# ============================================================================
+
+
+def test_all_trump_hand():
+    """Test hand with maximum trump cards."""
+    hand = [
+        Card("H", "J"),  # Right bower
+        Card("D", "J"),  # Left bower
+        Card("H", "A"),
+        Card("H", "A"),  # Duplicate
+        Card("H", "K"),
+        Card("H", "Q"),
+        Card("H", "T"),
+        Card("H", "T"),
+        Card("H", "T"),
+        Card("H", "T"),
+    ]
+
+    features = extract_bidless_hand_features(hand, contract_type="suit", trump_suit="H")
+
+    assert features["trump_count"] == 10.0
+    assert features["has_right_bower"] == 1.0
+    assert features["has_left_bower"] == 1.0
+    assert features["trump_aces"] == 2.0
+    assert features["trump_kings"] == 1.0
+    assert features["trump_queens"] == 1.0
+    assert features["trump_tens"] == 4.0
+
+
+def test_no_trump_cards_in_suit_contract():
+    """Test suit contract with no trump cards (all offsuit)."""
+    hand = [
+        Card("C", "A"),
+        Card("C", "K"),
+        Card("D", "A"),
+        Card("D", "K"),
+        Card("S", "A"),
+        Card("S", "K"),
+        Card("S", "Q"),
+        Card("S", "J"),  # Not left bower (different color)
+        Card("C", "T"),
+        Card("D", "T"),
+    ]
+
+    features = extract_bidless_hand_features(hand, contract_type="suit", trump_suit="H")
+
+    assert features["trump_count"] == 0.0
+    assert features["has_right_bower"] == 0.0
+    assert features["has_left_bower"] == 0.0
+    assert features["trump_aces"] == 0.0
+
+
+# ============================================================================
+# Offsuit Distribution Tests
+# ============================================================================
+
+
+def test_void_counting():
+    """Test void (zero-length suit) counting."""
+    # All hearts (in high contract, no trump adjustment)
+    hand = [Card("H", "A")] * 10
+
+    features = extract_bidless_hand_features(hand, contract_type="high")
+
+    # 3 suits have zero cards
+    assert features["void_count"] == 3.0
+    assert features["singleton_count"] == 0.0
+    assert features["longest_offsuit_length"] == 10.0
+    assert features["shortest_offsuit_length"] == 0.0
+
+
+def test_singleton_counting():
+    """Test singleton (one-card suit) counting."""
+    hand = [
+        Card("H", "A"),  # 1 heart
+        Card("D", "A"),  # 1 diamond
+        Card("C", "A"),  # 1 club
+        Card("S", "A"),
+        Card("S", "K"),
+        Card("S", "Q"),
+        Card("S", "J"),
+        Card("S", "T"),
+        Card("S", "T"),
+        Card("S", "T"),  # 7 spades
+    ]
+
+    features = extract_bidless_hand_features(hand, contract_type="high")
+
+    assert features["void_count"] == 0.0
+    assert features["singleton_count"] == 3.0  # H, D, C
+    assert features["longest_offsuit_length"] == 7.0  # Spades
+    assert features["shortest_offsuit_length"] == 1.0
+
+
+def test_suit_distribution_sorted():
+    """Test that suit lengths are sorted longest to shortest."""
+    hand = [
+        Card("H", "A"),
+        Card("H", "K"),  # 2 hearts
+        Card("D", "A"),
+        Card("D", "K"),
+        Card("D", "Q"),
+        Card("D", "J"),  # 4 diamonds
+        Card("C", "A"),  # 1 club
+        Card("S", "A"),
+        Card("S", "K"),
+        Card("S", "Q"),  # 3 spades
+    ]
+
+    features = extract_bidless_hand_features(hand, contract_type="high")
+
+    # Sorted: [4, 3, 2, 1]
+    assert features["longest_offsuit_length"] == 4.0
+    assert features["second_longest_offsuit_length"] == 3.0
+    assert features["third_longest_offsuit_length"] == 2.0
+    assert features["shortest_offsuit_length"] == 1.0
+
+
+def test_offsuit_distribution_excludes_trump():
+    """In suit contracts, trump cards should not count in offsuit distribution."""
+    hand = [
+        Card("H", "J"),  # Right bower (trump)
+        Card("H", "A"),  # Trump
+        Card("H", "K"),  # Trump
+        Card("C", "A"),
+        Card("C", "K"),
+        Card("C", "Q"),  # 3 clubs
+        Card("D", "A"),
+        Card("D", "K"),  # 2 diamonds
+        Card("S", "A"),
+        Card("S", "K"),  # 2 spades
+    ]
+
+    features = extract_bidless_hand_features(hand, contract_type="suit", trump_suit="H")
+
+    # Trump count = 3, offsuit lengths = [3, 2, 2, 0] (H is excluded from offsuit)
+    assert features["trump_count"] == 3.0
+    assert features["longest_offsuit_length"] == 3.0
+    assert features["void_count"] == 1.0  # Hearts (all trump)
+
+
+# ============================================================================
+# Offsuit Control Tests
+# ============================================================================
+
+
+def test_offsuit_aces_in_suit_contract():
+    """Test offsuit ace counting in suit contracts."""
+    hand = [
+        Card("H", "J"),  # Right bower (trump)
+        Card("H", "A"),  # Trump ace (not offsuit)
+        Card("C", "A"),  # Offsuit ace
+        Card("D", "A"),  # Offsuit ace
+        Card("S", "A"),  # Offsuit ace
+        Card("C", "K"),
+        Card("D", "K"),
+        Card("S", "K"),
+        Card("S", "Q"),
+        Card("S", "T"),
+    ]
+
+    features = extract_bidless_hand_features(hand, contract_type="suit", trump_suit="H")
+
+    assert features["offsuit_aces"] == 3.0  # CDA, DDA, SA (not HA)
+    assert features["offsuit_kings"] == 3.0
+
+
+def test_offsuit_control_in_high_contract():
+    """In high/low contracts, all aces are 'offsuit'."""
+    hand = [
+        Card("H", "A"),
+        Card("D", "A"),
+        Card("C", "A"),
+        Card("S", "K"),
+        Card("S", "K"),
+        Card("S", "Q"),
+        Card("S", "J"),
+        Card("S", "T"),
+        Card("C", "T"),
+        Card("D", "T"),
+    ]
+
+    features = extract_bidless_hand_features(hand, contract_type="high")
+
+    # All aces count as offsuit in high/low
+    assert features["offsuit_aces"] == 3.0
+    assert features["offsuit_kings"] == 2.0
+
+
+# ============================================================================
+# Seat Context Tests
+# ============================================================================
+
+
+def test_dealer_seat_encoding():
+    """Test one-hot encoding of dealer seat."""
+    hand = [Card("H", "A")] * 10
+
+    # Dealer at seat 0
+    features = extract_bidless_hand_features(hand, contract_type="high", dealer_seat=0)
+    assert features["is_dealer_seat_0"] == 1.0
+    assert features["is_dealer_seat_1"] == 0.0
+    assert features["is_dealer_seat_2"] == 0.0
+    assert features["is_dealer_seat_3"] == 0.0
+    assert features["dealer_seat_unknown"] == 0.0
+
+    # Dealer at seat 2
+    features = extract_bidless_hand_features(hand, contract_type="high", dealer_seat=2)
+    assert features["is_dealer_seat_0"] == 0.0
+    assert features["is_dealer_seat_1"] == 0.0
+    assert features["is_dealer_seat_2"] == 1.0
+    assert features["is_dealer_seat_3"] == 0.0
+    assert features["dealer_seat_unknown"] == 0.0
+
+
+def test_dealer_seat_unknown():
+    """Test encoding when dealer seat is None."""
+    hand = [Card("H", "A")] * 10
+
+    features = extract_bidless_hand_features(hand, contract_type="high", dealer_seat=None)
+
+    assert features["is_dealer_seat_0"] == 0.0
+    assert features["is_dealer_seat_1"] == 0.0
+    assert features["is_dealer_seat_2"] == 0.0
+    assert features["is_dealer_seat_3"] == 0.0
+    assert features["dealer_seat_unknown"] == 1.0
+
+
+def test_leader_seat_encoding():
+    """Test one-hot encoding of leader seat."""
+    hand = [Card("H", "A")] * 10
+
+    # Leader at seat 1
+    features = extract_bidless_hand_features(hand, contract_type="high", leader_seat=1)
+    assert features["is_leader_seat_0"] == 0.0
+    assert features["is_leader_seat_1"] == 1.0
+    assert features["is_leader_seat_2"] == 0.0
+    assert features["is_leader_seat_3"] == 0.0
+    assert features["leader_seat_unknown"] == 0.0
+
+    # Leader at seat 3
+    features = extract_bidless_hand_features(hand, contract_type="high", leader_seat=3)
+    assert features["is_leader_seat_0"] == 0.0
+    assert features["is_leader_seat_1"] == 0.0
+    assert features["is_leader_seat_2"] == 0.0
+    assert features["is_leader_seat_3"] == 1.0
+    assert features["leader_seat_unknown"] == 0.0
+
+
+def test_leader_seat_unknown():
+    """Test encoding when leader seat is None."""
+    hand = [Card("H", "A")] * 10
+
+    features = extract_bidless_hand_features(hand, contract_type="high", leader_seat=None)
+
+    assert features["is_leader_seat_0"] == 0.0
+    assert features["is_leader_seat_1"] == 0.0
+    assert features["is_leader_seat_2"] == 0.0
+    assert features["is_leader_seat_3"] == 0.0
+    assert features["leader_seat_unknown"] == 1.0
+
+
+def test_both_seats_specified():
+    """Test with both dealer and leader seats specified."""
+    hand = [Card("H", "A")] * 10
+
+    features = extract_bidless_hand_features(
+        hand, contract_type="high", dealer_seat=0, leader_seat=2
+    )
+
+    # Dealer at 0
+    assert features["is_dealer_seat_0"] == 1.0
+    assert features["dealer_seat_unknown"] == 0.0
+
+    # Leader at 2
+    assert features["is_leader_seat_2"] == 1.0
+    assert features["leader_seat_unknown"] == 0.0
+
+
+# ============================================================================
+# Feature Vector Tests
+# ============================================================================
+
+
+def test_extract_feature_vector_returns_list():
+    """Test that extract_feature_vector returns list of floats."""
+    hand = [Card("H", "A")] * 10
+
+    values, names = extract_feature_vector(hand, contract_type="high")
+
+    assert isinstance(values, list)
+    assert isinstance(names, list)
+    assert len(values) == len(names)
+    assert all(isinstance(v, float) for v in values)
+    assert all(isinstance(n, str) for n in names)
+
+
+def test_feature_vector_matches_dict():
+    """Test that feature vector matches dict extraction."""
+    hand = [Card("H", "J"), Card("H", "A"), Card("C", "K")] + [Card("S", "T")] * 7
+
+    features_dict = extract_bidless_hand_features(
+        hand, contract_type="suit", trump_suit="H", dealer_seat=1
+    )
+    values, names = extract_feature_vector(
+        hand, contract_type="suit", trump_suit="H", dealer_seat=1
+    )
+
+    # Every value should match corresponding dict entry
+    for value, name in zip(values, names):
+        assert value == features_dict[name]
+
+
+def test_feature_vector_order_stability():
+    """Test that feature vector order is stable across calls."""
+    hand = [Card("H", "A")] * 10
+
+    values1, names1 = extract_feature_vector(hand, contract_type="high")
+    values2, names2 = extract_feature_vector(hand, contract_type="high")
+
+    assert values1 == values2
+    assert names1 == names2
+
+
+def test_feature_vector_names_match_get_feature_names():
+    """Test that feature vector names match get_feature_names()."""
+    hand = [Card("H", "A")] * 10
+
+    _, names = extract_feature_vector(hand, contract_type="high")
+
+    assert names == get_feature_names()
+
+
+# ============================================================================
+# Edge Cases
+# ============================================================================
+
+
+def test_empty_hand():
+    """Test with empty hand (edge case)."""
+    hand = []
+
+    features = extract_bidless_hand_features(hand, contract_type="high")
+
+    # All counts should be 0
+    assert features["count_aces"] == 0.0
+    assert features["trump_count"] == 0.0
+    assert features["void_count"] == 4.0  # All suits void
+    assert features["longest_offsuit_length"] == 0.0
+
+
+def test_hand_with_all_jacks():
+    """Test hand with all jacks (left/right bowers in suit contract)."""
+    hand = [
+        Card("H", "J"),
+        Card("H", "J"),  # 2 right bowers
+        Card("D", "J"),
+        Card("D", "J"),  # 2 left bowers
+        Card("C", "J"),
+        Card("S", "J"),  # 2 offsuit jacks
+        Card("C", "A"),
+        Card("C", "K"),
+        Card("S", "A"),
+        Card("S", "K"),
+    ]
+
+    features = extract_bidless_hand_features(hand, contract_type="suit", trump_suit="H")
+
+    assert features["count_jacks"] == 6.0
+    assert features["trump_count"] == 4.0  # 2 RB + 2 LB
+    assert features["has_right_bower"] == 1.0
+    assert features["has_left_bower"] == 1.0


### PR DESCRIPTION
Summary
- Add deterministic bidless hand feature extractor v1 for value model training
- Includes 31 features covering hand composition, trump strength, offsuit distribution, and seat context
- Comprehensive unit tests (32 tests) ensuring determinism and feature ordering stability

## Summary
- New feature extraction module for bidless hands (after contract is declared)
- Pure function mapping (hand, contract, seat context) → fixed-order numeric feature vector
- 31 features with explicit ordering and schema version marker (v1)

## Why
Support upcoming value-model training (PR 140+ series) by providing deterministic, stable-order feature extraction for hands after bidding completes. This module:
- Enables training models to predict trick outcomes based on hand composition
- Maintains strict determinism (same input → same output)
- Includes schema versioning for forward compatibility
- Provides one-hot encoded seat context (dealer, leader positions)

## Repro / Validation
**Command(s) run:**
- `PYTHONPATH=src python -m pytest tests/unit/test_bidless_hand_features.py -v` (32 tests, all pass)
- `make check` (502 total tests pass, repo linter + ruff pass)

**Config (if applicable):**
- N/A (pure feature extraction, no experiments)

**Seed (if applicable):**
- N/A (deterministic, no randomness)

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/` (502 passed, 2 skipped, 1 deselected, 2 xfailed, 2 xpassed)
- [x] Integration: No engine/rules changes (new module only)
- [x] Other: `PYTHONPATH=src python -m pytest tests/unit/test_bidless_hand_features.py -v` (32 tests, all pass)

## Expected impact
- Metrics impact: None (no runtime paths changed, no experiments modified)
- Runtime impact: None (new module, not yet integrated into any runners)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

**Justification:** New feature extraction module with no integration into existing simulation or scoring paths. Only adds new files; does not modify any existing behavior.

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/Quentin/.cursor/worktrees/bid-euchre/mjs
```

`git rev-parse --show-toplevel`:
```
/Users/Quentin/.cursor/worktrees/bid-euchre/mjs
```

`git worktree list`:
```
/Users/Quentin/Projects/bid-euchre               f458c6a [main]
/Users/Quentin/.cursor/worktrees/bid-euchre/clq  2f30b9b [build/add-make-targets-teacher-baseline-loop]
/Users/Quentin/.cursor/worktrees/bid-euchre/gyd  af2f224 [feat/add-collect-bidless-dataset-script]
/Users/Quentin/.cursor/worktrees/bid-euchre/mjs  a2c1931 [feat/add-bidless-hand-feature-extractor-v1]
/Users/Quentin/.cursor/worktrees/bid-euchre/ukd  9c8cde2 [docs-teacher-baselines-loop-pause-point]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it (32 new unit tests)
- [x] PR is focused (one concept: bidless hand feature extraction)
