### PR TITLE
docs: add context-efficiency improvements for AI assistants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# AI Assistant Quick Start
+
+## Repository Purpose
+Bid Euchre simulator + strategy framework + ML training pipeline.
+
+## Essential Commands
+```bash
+make check    # Run before any PR (repo-lint + ruff + pytest)
+make help     # See all available targets
+```
+
+## Do NOT Read (outdated/irrelevant)
+- `docs/archive/` — Historical, may contradict current docs
+- `experiments/_deprecated/` — Legacy, frozen code
+- `data/runs/` — Generated outputs (gitignored)
+
+## Read By Task Type
+
+| Task | Start Here |
+|------|-----------|
+| Any code changes | [docs/02_agent/AGENTS.md](docs/02_agent/AGENTS.md) |
+| Understanding game rules | [docs/01_core/RULES.md](docs/01_core/RULES.md) |
+| Running experiments | [experiments/README.md](experiments/README.md) |
+| Adding strategies | [src/bid_euchre/strategy/](src/bid_euchre/strategy/) |
+| Training models | [docs/01_core/BIDDING_MODEL.md](docs/01_core/BIDDING_MODEL.md) |
+| Known issues/gaps | [docs/03_TODO/CODEBASE_CONSISTENCY.md](docs/03_TODO/CODEBASE_CONSISTENCY.md) |
+
+## Module Quick Reference (src/bid_euchre/)
+
+| Module | Purpose |
+|--------|---------|
+| `core/` | Card primitives, rules, trick resolution (DO NOT modify without tests) |
+| `sim/` | Simulation loop, deterministic deal generation |
+| `strategy/` | Bot policies — bidding + play strategies |
+| `features/` | Hand feature extraction for ML |
+| `models/` | ML model implementations |
+| `datasets/` | Dataset collectors (bidding, bidless) |
+| `analysis/` | Statistical analysis utilities |
+| `reporting/` | Report generation and metrics |
+| `logging/` | JSONL game event logging |
+| `experiments/` | Config parsing and structures |
+
+## Config Locations
+
+| Path | Contents |
+|------|----------|
+| `experiments/configs/` | Individual experiment YAML files |
+| `experiments/suites/` | Batched experiment definitions |
+| `experiments/configs/INDEX.md` | Config directory index |
+
+## Key Contracts (docs/01_core/)
+- **RULES.md** — Game rules, scoring, legality
+- **ARCHITECTURE.md** — System design, module boundaries
+- **REPRODUCIBILITY.md** — Seeding, determinism requirements
+- **DATA_CONTRACT.md** — Logging schema, field definitions

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,19 @@
 # Bid Euchre AI Research Framework
 
+## Quick Navigation
+
+| You want to... | Read this |
+|----------------|-----------|
+| Make code changes (AI/human) | [02_agent/AGENTS.md](02_agent/AGENTS.md) |
+| Understand game rules | [01_core/RULES.md](01_core/RULES.md) |
+| Run experiments | [../experiments/README.md](../experiments/README.md) |
+| See known issues | [03_TODO/CODEBASE_CONSISTENCY.md](03_TODO/CODEBASE_CONSISTENCY.md) |
+| Train models | [01_core/BIDDING_MODEL.md](01_core/BIDDING_MODEL.md) |
+
+> **AI Assistants**: Start with [../CLAUDE.md](../CLAUDE.md) for task-based routing.
+
+---
+
 A comprehensive framework for simulating and analyzing the card game Bid Euchre with various AI strategies and experimental configurations.
 
 ## 🎯 Overview

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,3 +1,5 @@
+<!-- AI-SKIP: This entire directory contains outdated documentation. Return to docs/02_agent/AGENTS.md -->
+
 > # ⚠️ ARCHIVED — not authoritative
 >
 > **You’re in `docs/archive/`.** This folder is intentionally **not canonical** and may be stale or contradictory.

--- a/experiments/configs/INDEX.md
+++ b/experiments/configs/INDEX.md
@@ -1,0 +1,53 @@
+# Experiment Config Index
+
+Quick reference for finding the right experiment configuration.
+
+## Quick Validation (smoke tests)
+
+| Config | Purpose | Duration |
+|--------|---------|----------|
+| `quick_test.yaml` | Fast validation (~1k hands, 2 strategies) | ~seconds |
+| `quick_test_random.yaml` | Random strategy variant | ~seconds |
+| `auction_smoke.yaml` | Auction/bidding smoke test | ~seconds |
+
+## Baseline Evaluations
+
+| Config | Purpose |
+|--------|---------|
+| `baseline_greedy.yaml` | Greedy strategy vs scenarios |
+| `baseline_matchups.yaml` | 4x4 strategy matrix comparison |
+| `strategy_comparison.yaml` | General strategy comparison |
+
+## Head-to-Head
+
+| Config | Purpose |
+|--------|---------|
+| `head_to_head_vs_random.yaml` | Strategy vs random baseline |
+
+## Bidding Evaluation (bid_eval_*)
+
+| Config | Purpose |
+|--------|---------|
+| `bid_eval_tiny.yaml` | Tiny bidder evaluation suite |
+| `bid_eval_strict.yaml` | StrictRaiserBidder evaluation |
+| `bid_eval_heuristics.yaml` | HeuristicsBidder evaluation |
+| `bid_eval_artifact.yaml` | Artifact-based bidder evaluation |
+| `artifact_bidder_test.yaml` | Artifact bidder integration test |
+
+## Hand Evaluation
+
+| Config | Purpose |
+|--------|---------|
+| `hand_eval_test_greedy.yaml` | Hand eval with greedy strategy |
+| `hand_eval_test_random.yaml` | Hand eval with random strategy |
+| `prelim_hand_eval.yaml` | Preliminary hand evaluation |
+
+## Training Data Collection
+
+| Config | Purpose |
+|--------|---------|
+| `bidless_dataset_collection.yaml` | Collect bidless training data |
+
+---
+
+**See also:** [experiments/suites/](../suites/) for batched experiment definitions

--- a/src/bid_euchre/core/README.md
+++ b/src/bid_euchre/core/README.md
@@ -1,0 +1,25 @@
+# core/ — Game Mechanics
+
+Card primitives, rules, and trick resolution. This is the **source of truth** for game logic.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `cards.py` | `Card` class, deck creation, suit/rank logic, `effective_suit()` |
+| `rules.py` | `get_legal_indices()`, `trick_winner()` |
+
+## Exports (via `__init__.py`)
+```python
+Card, create_deck, shuffle_deck, deal_hands
+effective_suit, rank_strength
+trick_winner, get_legal_indices
+```
+
+## Dependencies
+**None** — This is a leaf module. Does not import from other `bid_euchre` modules.
+
+## Contract
+- Changes here require unit tests in `tests/unit/test_cards.py`, `tests/unit/test_rules.py`
+- See [docs/01_core/RULES.md](../../../docs/01_core/RULES.md) for game rule specifications
+- Bower handling (left/right jack) is critical — test thoroughly

--- a/src/bid_euchre/features/README.md
+++ b/src/bid_euchre/features/README.md
@@ -1,0 +1,19 @@
+# features/ — Feature Extraction
+
+Extract features from hands for ML training and analysis.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `hand_eval.py` | Hand evaluation features — strength scoring |
+| `bidless_hand_features.py` | Features for bidless dataset (v1 deterministic extractor) |
+
+## Dependencies
+- Imports from: `core/` (cards)
+- Used by: `datasets/`, `models/`
+
+## Contract
+- Features must be **deterministic** — same hand always produces same features
+- See [docs/01_core/BIDLESS_FEATURES.md](../../../docs/01_core/BIDLESS_FEATURES.md) for feature specification
+- See [docs/01_core/BIDLESS_DATASET.md](../../../docs/01_core/BIDLESS_DATASET.md) for dataset context

--- a/src/bid_euchre/sim/README.md
+++ b/src/bid_euchre/sim/README.md
@@ -1,0 +1,21 @@
+# sim/ — Simulation Engine
+
+Game loop orchestration and deterministic deal generation.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `simulation.py` | `simulate_many_hands()` — core game loop, runs hands with strategies |
+| `deals.py` | Deterministic deal generation with seeding |
+
+## Usage
+Called by `experiments/run_experiment.py`. For experiments, use the unified runner rather than calling `sim` directly.
+
+## Dependencies
+- Imports from: `core/` (cards, rules)
+- Used by: `experiments/`, `datasets/`
+
+## Contract
+- Deals must be reproducible given the same seed
+- See [docs/01_core/REPRODUCIBILITY.md](../../../docs/01_core/REPRODUCIBILITY.md) for seeding requirements

--- a/src/bid_euchre/strategy/README.md
+++ b/src/bid_euchre/strategy/README.md
@@ -1,0 +1,34 @@
+# strategy/ — Bot Policies
+
+Bidding and play strategies for AI players.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `base.py` | `Strategy` ABC, shared utilities (`card_value_for_dump`) |
+| `baselines.py` | Simple strategies: `BasicStrategy`, `RandomLegalStrategy`, `AlwaysLowest/HighestLegalStrategy` |
+| `greedy.py` | `GreedyStrategy`, `ImprovedGreedyStrategy` — 1-trick lookahead |
+| `bidding.py` | Bidding policies: `HeuristicsBidder`, `StrictRaiserBidder`, `ArtifactBidder`, etc. |
+| `artifact_strategy.py` | Artifact-based strategy loading |
+
+## Available Strategies
+
+**Play Strategies:**
+- `BasicStrategy` — Simple rule-based
+- `RandomLegalStrategy` — Random legal card
+- `GreedyStrategy` / `ImprovedGreedyStrategy` — 1-trick lookahead
+
+**Bidding Policies:**
+- `AlwaysPassBidder`, `FixedBidder` — Testing/baseline
+- `HeuristicsBidder`, `StrictRaiserBidder` — Rule-based
+- `ArtifactBidder` — ML model-based
+
+## Adding a New Strategy
+1. Implement in new file or extend existing (inherit from `Strategy` or `BiddingPolicy`)
+2. Export in `__init__.py`
+3. Register in `src/bid_euchre/experiments/config.py` (`StrategyConfig.create_strategy`)
+4. Add tests in `tests/unit/`
+
+## Contract
+- See [docs/02_agent/AGENTS.md](../../../docs/02_agent/AGENTS.md) Section 10 for recipes


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` at repo root as single entry point for AI assistants
- Add lightweight READMEs to key source modules (`core/`, `sim/`, `strategy/`, `features/`)
- Add `experiments/configs/INDEX.md` as config file directory
- Enhance `docs/README.md` with quick navigation table
- Add `AI-SKIP` marker to `docs/archive/README.md`

## Why
Reduces AI assistant orientation from 4-6 file reads to 2-3 file reads. The new `CLAUDE.md` provides immediate task-based routing so AI knows exactly which doc to read for any task type.

## Test plan
- [ ] Verify `CLAUDE.md` links resolve correctly
- [ ] Verify module README links resolve correctly
- [ ] Start new AI session and confirm orientation is faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)