### PR TITLE
chore: add Claude Code project memory and rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,43 @@
+# Claude Code Project Memory — Bid Euchre
+
+This file is the entrypoint for Claude Code sessions. It imports the authoritative docs.
+
+## Imported Docs (Authoritative Sources)
+
+### Agent Workflow & Boundaries
+@docs/02_agent/AGENTS.md
+@docs/02_agent/AI_BOUNDARIES.md
+@docs/02_agent/QUALITY_BAR.md
+@docs/02_agent/REVIEW_CHECKLIST.md
+
+### Core Contracts
+@docs/01_core/REPRODUCIBILITY.md
+@docs/01_core/DATA_CONTRACT.md
+@docs/01_core/METRICS.md
+@docs/01_core/RULES.md
+
+### PR Requirements
+@.github/pull_request_template.md
+
+## Quick Reference
+
+**Essential commands:**
+```bash
+make check    # repo-lint + ruff + pytest (run before PRs)
+make help     # see all targets
+```
+
+**Key constraints:**
+- Seed required for experiments: `--seed <int>`
+- No commits to `data/runs/`, `data/reports/`, `data/models/`
+- One concept per PR; use PR template
+
+## Compaction Instructions
+
+When compacting conversation context, preserve:
+1. **Modified files list** — all files created/edited this session
+2. **Goal + acceptance criteria** — what we're trying to achieve and how to verify
+3. **Exact commands + outputs** — reproduction commands with seeds, test results, error messages
+4. **Blocking issues** — any unresolved errors or decisions needed
+
+Discard: exploration tangents, superseded plans, verbose file contents already summarized.

--- a/.claude/rules/10_workflow.md
+++ b/.claude/rules/10_workflow.md
@@ -1,0 +1,35 @@
+# Workflow Rules
+
+> **Authoritative source:** @docs/02_agent/AGENTS.md
+
+## Gold Path Commands
+
+Run before any PR:
+```bash
+make check          # Full validation: repo-lint + ruff + pytest
+```
+
+Individual checks:
+```bash
+make repo-lint      # Repo linter only
+make lint           # Ruff only
+make test           # Pytest fast suite only
+```
+
+## Smoke Experiment (Optional)
+
+Validate changes with a seeded run:
+```bash
+PYTHONPATH=src python experiments/run_experiment.py \
+  --config experiments/configs/quick_test.yaml \
+  --seed 42
+```
+
+## Key Rules
+
+1. **Use canonical runner only** — `experiments/run_experiment.py` + YAML configs
+2. **Do not create new top-level directories** without explicit instruction
+3. **Library code in `src/`** — CLI scripts go in `scripts/` or `experiments/`
+4. **Run `make check` before claiming PR is done**
+
+See @docs/02_agent/AGENTS.md for full workflow details.

--- a/.claude/rules/20_determinism.md
+++ b/.claude/rules/20_determinism.md
@@ -1,0 +1,30 @@
+# Determinism Rules
+
+> **Authoritative source:** @docs/01_core/REPRODUCIBILITY.md
+
+## Default: Seed Required
+
+All experiments require explicit seed:
+```bash
+python experiments/run_experiment.py --config <path> --seed 42 --n_per 100
+```
+
+Opt-out for exploration only:
+```bash
+python experiments/run_experiment.py --config <path> --allow-nondeterministic
+```
+
+## Key Invariants
+
+1. **Same seed + same config → identical results**
+2. **No global randomness** — strategies use local `random.Random(seed)`
+3. **Deal derivation is stable** — `deal_seed = seed * 1_000_003 + deal_id`
+4. **Unseeded runs are debug-only** — not valid for comparisons
+
+## Run Metadata
+
+Every run writes `data/runs/<run_id>/meta.json` with:
+- Git SHA, config hash, seed, timestamp
+- `is_deterministic: true/false` flag
+
+See @docs/01_core/REPRODUCIBILITY.md for full specification.

--- a/.claude/rules/30_data_contract.md
+++ b/.claude/rules/30_data_contract.md
@@ -1,0 +1,33 @@
+# Data Contract Rules
+
+> **Authoritative sources:**
+> - @docs/01_core/DATA_CONTRACT.md
+> - @docs/01_core/METRICS.md
+> - @docs/01_core/RULES.md
+
+## Output Policy
+
+**Golden rule:** No generated outputs outside `data/runs/<run_id>/...`
+
+**Commit policy:**
+- ✅ `data/fixtures/**` only (tiny test fixtures)
+- ❌ `data/runs/`, `data/reports/`, `data/models/`, `data/training/`
+
+## What Counts as Contract Change
+
+Changes to any of these require doc updates + tests:
+
+| Area | Contract Doc | Required Action |
+|------|--------------|-----------------|
+| Game rules, trick resolution | RULES.md | Unit + integration tests |
+| Logging fields, schemas | DATA_CONTRACT.md | Schema version bump |
+| Metrics, aggregation | METRICS.md | Verify rollup compatibility |
+| Scoring logic | RULES.md §6 | Scoring tests |
+
+## Testing Requirements
+
+- **Rules/scoring changes:** unit tests + integration tests
+- **Logging schema changes:** update `docs/01_core/schemas/`
+- **Metrics changes:** verify drift detection still works
+
+See @docs/01_core/DATA_CONTRACT.md for full schema details.

--- a/.claude/rules/40_prs.md
+++ b/.claude/rules/40_prs.md
@@ -1,0 +1,36 @@
+# PR Rules
+
+> **Authoritative sources:**
+> - @docs/02_agent/REVIEW_CHECKLIST.md
+> - @.github/pull_request_template.md
+
+## PR Template Required
+
+Every PR must use the template from `.github/pull_request_template.md`.
+
+Required sections:
+- **Summary** — what changed (1-3 bullets)
+- **Why** — motivation
+- **Repro / Validation** — exact command with seed/config
+- **Tests** — which test commands were run
+- **Worktree proof** — `pwd`, `git rev-parse --show-toplevel`, `git worktree list`
+
+## Hard Gates (Pre-PR Checklist)
+
+From @docs/02_agent/REVIEW_CHECKLIST.md:
+
+- [ ] Branch based on main
+- [ ] Scope lock — only touched declared files
+- [ ] `make check` passes
+- [ ] No artifacts in `data/runs/` or `data/reports/`
+- [ ] Exact repro command in PR description
+- [ ] Contract compliance (if touching rules/logging/metrics)
+
+## Key Constraints
+
+1. **One concept per PR** — no mixed refactor + feature
+2. **Worktree-only workflow** — never commit from main checkout
+3. **PR URL required** — don't claim PR exists without citing URL
+4. **Tests must lock behavior** — if you changed outcomes, add tests
+
+See @docs/02_agent/AGENTS.md §2 for Definition of Done.

--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,7 @@ docs/build/
 config.local.*
 secrets.*
 .env.local
+CLAUDE.local.md
 
 # =============================================================================
 # Backup and temporary files


### PR DESCRIPTION
## Summary
- Add `.claude/CLAUDE.md` as main entrypoint for Claude Code sessions
- Add `.claude/rules/` with 4 operational rule modules (workflow, determinism, data contracts, PRs)
- Add `CLAUDE.local.md` template to .gitignore

## Why
Wire Claude Code project memory so future sessions auto-load existing agent/core docs without duplicating them. Uses @path pointers to authoritative docs rather than copying content.

## Repro / Validation
**Command(s) run:**
```bash
make check
```

**Tests:** All pass (516 passed, 4 skipped)

## Files Created

| File | Lines | Purpose |
|------|-------|---------|
| `.claude/CLAUDE.md` | 43 | Main entrypoint with @imports |
| `.claude/rules/10_workflow.md` | 35 | Gold path commands |
| `.claude/rules/20_determinism.md` | 30 | Seed requirements |
| `.claude/rules/30_data_contract.md` | 33 | Contract change rules |
| `.claude/rules/40_prs.md` | 36 | PR template gates |

All files under 120 lines as specified.

## Expected impact
- Metrics impact: None (docs only)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)