### PR TITLE
chore: rename HeuristicsBidder to RanktheTank

### DIFF
--- a/docs/01_core/BIDDING_MODEL.md
+++ b/docs/01_core/BIDDING_MODEL.md
@@ -143,7 +143,7 @@ The canonical "teacher baseline" roster consists of three deterministic bidding 
 | Teacher | Description | Strategy |
 |---------|-------------|----------|
 | `strict_raiser` | StrictRaiserBidder | Simple raising strategy - bids if hand strength meets minimum threshold |
-| `heuristics` | HeuristicsBidder | Rule-based heuristics (v1 baseline) - considers position, cards, and opponents |
+| `rankthetank` | RanktheTank | Rank-sum based bidding (v1 baseline) - evaluates hand strength and maps to bid thresholds |
 | `fiveheadfred` | FiveHeadFred | Aggressive bidder - always bids 5 if legal, otherwise passes |
 
 ### Training Commands
@@ -158,11 +158,11 @@ PYTHONPATH=src python scripts/train_bidder.py \
   --output data/artifacts/bidding_strict_raiser_S.json \
   --seed 42
 
-# Train heuristics teacher
+# Train rankthetank teacher
 PYTHONPATH=src python scripts/train_bidder.py \
   --teacher heuristics \
   --contract S \
-  --output data/artifacts/bidding_heuristics_S.json \
+  --output data/artifacts/bidding_rankthetank_S.json \
   --seed 42
 
 # Train fiveheadfred teacher

--- a/docs/01_core/TEACHER_BASELINES.md
+++ b/docs/01_core/TEACHER_BASELINES.md
@@ -4,7 +4,7 @@
 
 **Teacher baselines** (defined in `experiments/baselines/teacher_roster_v1.yaml`):
 - `strict_raiser`: StrictRaiserBidder - bids 3S initially, raises by 1 each time
-- `heuristics`: HeuristicsBidder - rule-based bidding using hand evaluation heuristics
+- `rankthetank`: RanktheTank - rank-sum based bidding (v1 baseline)
 - `artifact_bidder`: ArtifactBidder - linear regression model with greedy card play (uses `data/fixtures/bidding_artifact_v1_tiny.json`)
 
 **Artifact model types supported** (schema v1):

--- a/docs/03_TODO/BIDDING_DEVELOPMENT_PLAN.md
+++ b/docs/03_TODO/BIDDING_DEVELOPMENT_PLAN.md
@@ -1,0 +1,146 @@
+# Bidding Development Plan: Blog Alignment
+
+**Last Updated:** 2026-01-27
+**Status:** Phase 0 (Pre-req complete)
+
+This document outlines the implementation plan to align the codebase with the blog post "Bid Euchre, Part 4: How Do You Teach a Computer to Bid?"
+
+---
+
+## Completed Steps
+
+### Pre-requisite: Rename HeuristicsBidder → RanktheTank ✅ DONE
+
+The pre-requisite rename has been completed:
+- Renamed `HeuristicsBidder` class to `RanktheTank` in `src/bid_euchre/strategy/bidding.py`
+- Updated all imports, exports, tests, YAML configs, and documentation
+- All tests pass (`make check`)
+
+---
+
+## Implementation Phases
+
+### Phase 0: Validate Play Strategies (NEXT)
+
+**Goal:** Confirm that Glutton is meaningfully better than simpler strategies.
+
+**Command:**
+```bash
+PYTHONPATH=src python experiments/run_experiment.py \
+  --config experiments/configs/strategy_comparison.yaml \
+  --n_per 10000 \
+  --seed 42
+```
+
+**Expected results:**
+| Strategy | Expected Avg Tricks |
+|----------|---------------------|
+| Random | ~5.0 (baseline) |
+| AlwaysLowest | ~4.5 (passive) |
+| AlwaysHighest | ~4.8 (wasteful) |
+| Greedy | ~5.5-6.0 |
+| **Glutton** | **~6.0-6.5** |
+
+**Success criteria:** Glutton > Greedy > Random with statistical significance.
+
+---
+
+### Phase 1: B0 on Tricks
+
+**Goal:** Get a working tricks-prediction model.
+
+**Steps:**
+1. Wire dataset collection (`scripts/collect_bidless_dataset.py`)
+2. Train B0 on `tricks_won` using `get_hand_features()`
+3. Create `B0TricksBidder` class
+4. Register in config system
+
+**Verification:**
+```bash
+# Collect bidless data
+PYTHONPATH=src python scripts/collect_bidless_dataset.py --n_hands 50000 --seed 42
+
+# Train B0
+PYTHONPATH=src python scripts/train_b0.py --data data/bidless/... --output data/models/b0_tricks.json
+```
+
+---
+
+### Phase 2: Generate Bid Data
+
+**Goal:** Generate hands with actual bids and points.
+
+**Steps:**
+1. Create `experiments/configs/bid_dataset_collection.yaml`
+2. Run simulation with B0TricksBidder + Glutton play
+3. Log: `hand_features, bid, contract, tricks_won, points`
+
+---
+
+### Phase 3: Train on Actual Points
+
+**Goal:** Train model predicting expected points given a bid.
+
+**Steps:**
+1. Create `scripts/train_b0_points.py`
+2. Train on `hand_features + [bid_level]` → `points_earned`
+3. Create `B0PointsBidder` class
+
+---
+
+### Phase 4: Comparison Tournament
+
+**Goal:** Validate improvement chain.
+
+**Metrics:**
+- `make_rate` - % of bids made
+- `avg_points` - average points per hand
+- `cvar_5` - worst 5% outcomes (risk metric)
+
+**Expected ordering:**
+```
+FiveHeadFred < RanktheTank ≤ B0TricksBidder < B0PointsBidder
+```
+
+---
+
+## Files to Create/Modify
+
+| Phase | File | Action |
+|-------|------|--------|
+| Pre | `src/bid_euchre/strategy/bidding.py` | ✅ Renamed to `RanktheTank` |
+| Pre | All imports/tests/configs | ✅ Updated |
+| 0 | `experiments/configs/strategy_comparison.yaml` | Verify exists, run |
+| 1 | `scripts/collect_bidless_dataset.py` | Wire collector |
+| 1 | `src/bid_euchre/strategy/bidding.py` | Add `B0TricksBidder` |
+| 2 | `experiments/configs/bid_dataset_collection.yaml` | Create |
+| 3 | `scripts/train_b0_points.py` | Create |
+| 3 | `src/bid_euchre/strategy/bidding.py` | Add `B0PointsBidder` |
+| 4 | `experiments/configs/bidder_comparison.yaml` | Create |
+
+---
+
+## Background: Why Points Sooner?
+
+The blog's progression starts with tricks, but Bid Euchre scoring creates asymmetry:
+- **Make bid:** Score = `tricks_won`
+- **Get set:** Score = `-bid_tricks` (NEGATIVE!)
+
+Example: Bid 6, win 5 tricks → **-6 points** (11-point swing vs defending!)
+
+**Solution:** Use post-hoc scoring during training:
+```python
+# For each hand with tricks_won, compute points for each possible bid:
+if tricks_won >= bid:
+    points = tricks_won  # Made
+else:
+    points = -bid  # Set
+```
+
+This creates bid-conditional targets, letting B0 predict "expected points if I bid X."
+
+---
+
+## Reference
+
+Full analysis in: `/Users/Quentin/.claude/plans/imperative-twirling-swing.md`

--- a/docs/03_experiments/BID_EVAL_TINY.md
+++ b/docs/03_experiments/BID_EVAL_TINY.md
@@ -15,7 +15,7 @@ The suite evaluates baselines defined in the teacher roster manifest (`experimen
 
 Currently evaluates:
 1. **strict_raiser**: `StrictRaiserBidder` - Rule-based bidder following strict raising rules
-2. **heuristics**: `HeuristicsBidder` - v1 baseline heuristic bidder
+2. **rankthetank**: `RanktheTank` - v1 baseline rank-sum bidder
 3. **artifact_bidder**: `ArtifactBidder` - Linear regression model bidder using trained artifacts
 
 The roster manifest supports additional baseline types (policy, artifact_policy) for future expansion.

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -92,7 +92,7 @@ ls experiments/configs/
 - `baseline_greedy.yaml` - Greedy strategy baseline
 - `baseline_matchups.yaml` - 4x4 strategy matchup matrix
 - `bid_eval_artifact.yaml` - Evaluate artifact-based bidders
-- `bid_eval_heuristics.yaml` - Evaluate heuristic bidders
+- `bid_eval_heuristics.yaml` - Evaluate RanktheTank bidder
 - `bid_eval_strict.yaml` - Strict bid evaluation
 - `bid_eval_tiny.yaml` - Fast bidder evaluation (~2 min)
 - `bidless_dataset_collection.yaml` - Collect bidless training data

--- a/experiments/baselines/teacher_roster_v1.yaml
+++ b/experiments/baselines/teacher_roster_v1.yaml
@@ -14,12 +14,12 @@ baselines:
     import_path: "bid_euchre.strategy.bidding.StrictRaiserBidder"
     params: {}
     notes: "Bids 3S initially, raises by 1 each time"
-  - id: heuristics
-    display_name: "Heuristics"
+  - id: rankthetank
+    display_name: "RanktheTank"
     kind: "policy"
-    import_path: "bid_euchre.strategy.bidding.HeuristicsBidder"
+    import_path: "bid_euchre.strategy.bidding.RanktheTank"
     params: {}
-    notes: "Rule-based bidding using hand evaluation heuristics"
+    notes: "Rank-sum based bidding (v1 baseline)"
   - id: fixed_bidder
     display_name: "Fixed Bid (FiveHeadFred)"
     kind: "policy"

--- a/experiments/configs/INDEX.md
+++ b/experiments/configs/INDEX.md
@@ -30,7 +30,7 @@ Quick reference for finding the right experiment configuration.
 |--------|---------|
 | `bid_eval_tiny.yaml` | Tiny bidder evaluation suite |
 | `bid_eval_strict.yaml` | StrictRaiserBidder evaluation |
-| `bid_eval_heuristics.yaml` | HeuristicsBidder evaluation |
+| `bid_eval_heuristics.yaml` | RanktheTank evaluation |
 | `bid_eval_artifact.yaml` | Artifact-based bidder evaluation |
 | `artifact_bidder_test.yaml` | Artifact bidder integration test |
 

--- a/experiments/configs/bid_eval_heuristics.yaml
+++ b/experiments/configs/bid_eval_heuristics.yaml
@@ -1,8 +1,8 @@
 experiment_name: bid_eval_heuristics
 
 bidding_policies:
-  - name: heuristics_bidder
-    class_name: HeuristicsBidder
+  - name: rankthetank_bidder
+    class_name: RanktheTank
     params: {}
 
 scenarios:

--- a/experiments/configs/bid_eval_tiny.yaml
+++ b/experiments/configs/bid_eval_tiny.yaml
@@ -3,7 +3,7 @@ experiment_name: bid_eval_tiny
 strategy_roster_path: experiments/baselines/teacher_roster_v1.yaml
 include_baselines:
   - strict_raiser
-  - heuristics
+  - rankthetank
   - artifact_bidder
 
 scenarios:

--- a/experiments/suites/bid_eval_tiny.yaml
+++ b/experiments/suites/bid_eval_tiny.yaml
@@ -1,6 +1,6 @@
 # Tiny evaluation suite for baseline bidders comparison.
 # Uses auction mode with hand-level logging so risk metrics can be computed.
-# Compares strict, heuristics, and artifact-backed baselines.
+# Compares strict, rankthetank, and artifact-backed baselines.
 
 suite_name: bid_eval_tiny
 

--- a/scripts/train_bidder.py
+++ b/scripts/train_bidder.py
@@ -7,7 +7,7 @@ and emit JSON artifacts conforming to the bidding model schema.
 
 Supported teachers:
 - strict_raiser: StrictRaiserBidder (simple raising strategy)
-- heuristics: HeuristicsBidder (v1 baseline heuristic bidder)
+- heuristics: RanktheTank (v1 baseline rank-sum bidder)
 - fiveheadfred: FiveHeadFred (always bids 5 if legal, else passes)
 """
 

--- a/src/bid_euchre/experiments/config.py
+++ b/src/bid_euchre/experiments/config.py
@@ -19,8 +19,8 @@ from ..strategy import (
     BiddingPolicy,
     GluttonStrategy,
     GreedyStrategy,
-    HeuristicsBidder,
     RandomLegalStrategy,
+    RanktheTank,
     Strategy,
     StrictRaiserBidder,
 )
@@ -78,8 +78,8 @@ class BiddingPolicyConfig:
             if not artifact_path:
                 raise ValueError("ArtifactBidder requires 'artifact_path' parameter")
             return ArtifactBidder(artifact_path=artifact_path, name=self.name)
-        elif self.class_name == "HeuristicsBidder":
-            return HeuristicsBidder(name=self.name)
+        elif self.class_name == "RanktheTank":
+            return RanktheTank(name=self.name)
         elif self.class_name == "StrictRaiserBidder":
             return StrictRaiserBidder(name=self.name)
         else:

--- a/src/bid_euchre/models/train_bidder.py
+++ b/src/bid_euchre/models/train_bidder.py
@@ -10,7 +10,7 @@ import os
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
-from ..strategy.bidding import BiddingObservation, HeuristicsBidder, StrictRaiserBidder
+from ..strategy.bidding import BiddingObservation, RanktheTank, StrictRaiserBidder
 from .bidding_artifact import dump_artifact, validate_artifact
 
 DETERMINISTIC_BASE_TIME = datetime(2025, 1, 1, tzinfo=timezone.utc)
@@ -284,14 +284,14 @@ def train_fiveheadfred_model(contract: str = "S") -> FiveHeadFredModel:
 
 class HeuristicsModel:
     """
-    Deterministic model that exactly replicates HeuristicsBidder logic.
+    Deterministic model that exactly replicates RanktheTank logic.
 
     This is a rule-based model that encodes the heuristic bidding strategy
     as parameters, including suit and HIGH/LOW evaluation thresholds.
     """
 
     def __init__(self):
-        """Initialize with HeuristicsBidder rules."""
+        """Initialize with RanktheTank rules."""
         # Encode the bidding rules as model parameters
         self.rules = {
             "suit_thresholds": {
@@ -407,17 +407,17 @@ class HeuristicsModel:
             "model_params": self.rules,
             "metadata": {
                 "created_at": created_at,
-                "description": "Deterministic imitation of HeuristicsBidder (v1 baseline)",
+                "description": "Deterministic imitation of RanktheTank (v1 baseline)",
                 "training_data": "synthetic observations",
                 "training_seed": seed,
-                "teacher_model": "HeuristicsBidder"
+                "teacher_model": "RanktheTank"
             }
         }
 
 
 def create_synthetic_observations_for_heuristics() -> List[BiddingObservation]:
     """
-    Create synthetic bidding observations to train HeuristicsBidder imitation.
+    Create synthetic bidding observations to train RanktheTank imitation.
 
     Creates diverse hands covering different contract preferences and strengths.
 
@@ -461,7 +461,7 @@ def create_synthetic_observations_for_heuristics() -> List[BiddingObservation]:
 
 def train_heuristics_model(contract: str = "S") -> HeuristicsModel:
     """
-    Train a deterministic model to imitate HeuristicsBidder.
+    Train a deterministic model to imitate RanktheTank.
 
     Args:
         contract: Contract to train for (nominal; heuristics evaluates all contracts)
@@ -475,8 +475,8 @@ def train_heuristics_model(contract: str = "S") -> HeuristicsModel:
     # Initialize model
     model = HeuristicsModel()
 
-    # "Train" by validating that our model matches HeuristicsBidder
-    teacher = HeuristicsBidder()
+    # "Train" by validating that our model matches RanktheTank
+    teacher = RanktheTank()
 
     for obs in observations:
         teacher_action = teacher.choose_bid(obs)

--- a/src/bid_euchre/strategy/README.md
+++ b/src/bid_euchre/strategy/README.md
@@ -9,7 +9,7 @@ Bidding and play strategies for AI players.
 | `base.py` | `Strategy` ABC, shared utilities (`card_value_for_dump`) |
 | `baselines.py` | Simple strategies: `BasicStrategy`, `RandomLegalStrategy`, `AlwaysLowest/HighestLegalStrategy` |
 | `greedy.py` | `GreedyStrategy`, `GluttonStrategy` — 1-trick lookahead |
-| `bidding.py` | Bidding policies: `HeuristicsBidder`, `StrictRaiserBidder`, `ArtifactBidder`, etc. |
+| `bidding.py` | Bidding policies: `RanktheTank`, `StrictRaiserBidder`, `ArtifactBidder`, etc. |
 | `artifact_strategy.py` | Artifact-based strategy loading |
 
 ## Available Strategies
@@ -21,7 +21,7 @@ Bidding and play strategies for AI players.
 
 **Bidding Policies:**
 - `AlwaysPassBidder`, `FixedBidder` — Testing/baseline
-- `HeuristicsBidder`, `StrictRaiserBidder` — Rule-based
+- `RanktheTank`, `StrictRaiserBidder` — Rule-based
 - `ArtifactBidder` — ML model-based
 
 ## Adding a New Strategy

--- a/src/bid_euchre/strategy/__init__.py
+++ b/src/bid_euchre/strategy/__init__.py
@@ -28,9 +28,9 @@ from .bidding import (
     BiddingObservation,
     BiddingPolicy,
     FixedBidder,
-    HeuristicsBidder,
     HeuristicSuitBidder,
     HighLowHeuristicBidder,
+    RanktheTank,
     StrictRaiserBidder,
 )
 
@@ -57,7 +57,7 @@ __all__ = [
     "ArtifactBidder",
     "FixedBidder",
     "HeuristicSuitBidder",
-    "HeuristicsBidder",
+    "RanktheTank",
     "HighLowHeuristicBidder",
     "StrictRaiserBidder",
     # Baselines

--- a/src/bid_euchre/strategy/artifact_strategy.py
+++ b/src/bid_euchre/strategy/artifact_strategy.py
@@ -26,7 +26,7 @@ class ArtifactGreedyStrategy(GluttonStrategy):
     Supports all artifact model types by delegating to ArtifactBidder:
     - linear_regression: Linear model with hand features
     - strict_raiser_imitation_v1: Rule-based StrictRaiserBidder imitation
-    - heuristics_imitation_v1: Rule-based HeuristicsBidder imitation
+    - heuristics_imitation_v1: Rule-based RanktheTank imitation
     """
 
     def __init__(

--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -291,20 +291,21 @@ class HighLowHeuristicBidder(BiddingPolicy):
             return BidAction.pass_bid()
 
 
-class HeuristicsBidder(BiddingPolicy):
+class RanktheTank(BiddingPolicy):
     """
-    Composite heuristic bidder (v1 baseline) that evaluates all contract options.
+    Rank-sum based bidder (v1 baseline) that evaluates all contract options.
 
-    This is the v1 baseline heuristic bidder that combines suit and HIGH/LOW evaluation:
+    This is the v1 baseline bidder that combines suit and HIGH/LOW evaluation:
     - Evaluates hand strength for all suit contracts (C, D, H, S)
     - Evaluates HIGH/LOW contracts based on hand composition
-    - Picks the contract+bid that gives the highest strength/bid ratio
+    - Maps strength to bid via thresholds (350→6, 300→5, 250→4, 200→3)
     - Complies with strict-increasing bid rule
 
-    This serves as the canonical "heuristics" teacher for imitation learning.
+    Named after the blog post character who bids based on "my hand looks big."
+    Serves as the canonical "rankthetank" teacher for imitation learning.
     """
 
-    def __init__(self, name: str = "heuristics"):
+    def __init__(self, name: str = "rankthetank"):
         super().__init__(name)
 
     def choose_bid(self, obs: BiddingObservation) -> BidAction:
@@ -385,7 +386,7 @@ class ArtifactBidder(BiddingPolicy):
     Supports multiple model types:
     - 'linear_regression': Linear model with hand features
     - 'strict_raiser_imitation_v1': Rule-based model replicating StrictRaiserBidder
-    - 'heuristics_imitation_v1': Rule-based model replicating HeuristicsBidder
+    - 'heuristics_imitation_v1': Rule-based model replicating RanktheTank
 
     The artifact is loaded and validated at initialization time.
     """

--- a/tests/unit/test_bidder_training_v1.py
+++ b/tests/unit/test_bidder_training_v1.py
@@ -26,7 +26,7 @@ from bid_euchre.models.train_bidder import (
 )
 from bid_euchre.strategy.bidding import (
     BiddingObservation,
-    HeuristicsBidder,
+    RanktheTank,
     StrictRaiserBidder,
 )
 
@@ -337,7 +337,7 @@ class TestHeuristicsModel:
         assert artifact["model_params"] == model.rules
         assert "metadata" in artifact
         metadata = artifact["metadata"]
-        assert metadata["teacher_model"] == "HeuristicsBidder"
+        assert metadata["teacher_model"] == "RanktheTank"
         assert metadata["training_data"] == "synthetic observations"
         assert metadata["training_seed"] == 42
 
@@ -370,8 +370,8 @@ class TestHeuristicsTrainingPipeline:
 
         assert isinstance(model, HeuristicsModel)
 
-        # Verify model matches HeuristicsBidder behavior
-        teacher = HeuristicsBidder()
+        # Verify model matches RanktheTank behavior
+        teacher = RanktheTank()
 
         # Test on synthetic observations
         observations = create_synthetic_observations_for_heuristics()
@@ -513,7 +513,7 @@ class TestHeuristicsTrainingPipeline:
         assert "description" in metadata
         assert "training_data" in metadata
         assert "teacher_model" in metadata
-        assert metadata["teacher_model"] == "HeuristicsBidder"
+        assert metadata["teacher_model"] == "RanktheTank"
 
 
 class TestTeacherParameter:
@@ -539,7 +539,7 @@ class TestTeacherParameter:
         )
 
         assert artifact["model_type"] == "heuristics_imitation_v1"
-        assert artifact["metadata"]["teacher_model"] == "HeuristicsBidder"
+        assert artifact["metadata"]["teacher_model"] == "RanktheTank"
 
     def test_unknown_teacher_raises_error(self):
         """Test that unknown teacher raises ValueError."""

--- a/tests/unit/test_bidding.py
+++ b/tests/unit/test_bidding.py
@@ -454,10 +454,10 @@ class TestArtifactBidder:
                 assert reference_action.contract == "S"
 
     def test_heuristics_bidding_behavior(self, tmp_path):
-        """Test that heuristics imitation behaves like HeuristicsBidder."""
+        """Test that heuristics imitation behaves like RanktheTank."""
         from bid_euchre.models.bidding_artifact import dump_artifact
 
-        # Create artifact that replicates HeuristicsBidder
+        # Create artifact that replicates RanktheTank
         artifact = {
             "schema_version": "1",
             "model_type": "heuristics_imitation_v1",

--- a/tests/unit/test_roster_ordering_determinism.py
+++ b/tests/unit/test_roster_ordering_determinism.py
@@ -52,7 +52,7 @@ class TestRosterOrderingDeterminism:
         expected_ids = [
             "always_pass",
             "strict_raiser",
-            "heuristics",
+            "rankthetank",
             "fixed_bidder",
             "artifact_bidder"
         ]
@@ -72,7 +72,7 @@ class TestRosterOrderingDeterminism:
         test_config = {
             "experiment_name": "test_roster_ordering",
             "strategy_roster_path": "experiments/baselines/teacher_roster_v1.yaml",
-            "include_baselines": ["strict_raiser", "heuristics", "artifact_bidder"],
+            "include_baselines": ["strict_raiser", "rankthetank", "artifact_bidder"],
             "scenarios": [{"contract_type": None}],
             "parameters": {"n_per": 10, "seed": 42}
         }
@@ -97,7 +97,7 @@ class TestRosterOrderingDeterminism:
             assert policies1 == policies2 == policies3
 
             # Should match the include_baselines order
-            expected_order = ["Strict Raiser", "Heuristics", "Artifact Bidder (Greedy Play)"]
+            expected_order = ["Strict Raiser", "RanktheTank", "Artifact Bidder (Greedy Play)"]
             assert policies1 == expected_order
 
         finally:

--- a/tests/unit/test_validate_teacher_roster.py
+++ b/tests/unit/test_validate_teacher_roster.py
@@ -60,7 +60,7 @@ class TestValidateTeacherRoster:
             "roster_version": "1",
             "baselines": [
                 {"id": "strict_raiser", "import_path": "bid_euchre.strategy.bidding.StrictRaiserBidder"},
-                {"id": "heuristics", "import_path": "bid_euchre.strategy.bidding.HeuristicsBidder", "kind": "policy"}
+                {"id": "heuristics", "import_path": "bid_euchre.strategy.bidding.RanktheTank", "kind": "policy"}
             ]
         }
         # Should not raise


### PR DESCRIPTION
## Summary
- Renamed `HeuristicsBidder` class to `RanktheTank` across 21 files
- Updated all imports, exports, tests, YAML configs, and documentation
- Added `docs/03_TODO/BIDDING_DEVELOPMENT_PLAN.md` with remaining implementation phases

## Why
Align codebase terminology with blog post "Bid Euchre, Part 4: How Do You Teach a Computer to Bid?" The `RanktheTank` name better describes the bidder's behavior: evaluating hand strength via rank-sum and mapping to bid thresholds (350→6, 300→5, 250→4, 200→3).

## Repro / Validation
```bash
make check  # All 555 tests pass
```

## Tests
```bash
make check  # repo-lint + ruff + pytest (555 passed, 4 skipped)
```

## Worktree proof
```
pwd: /Users/Quentin/Projects/bid-euchre
git worktree: main checkout (not a worktree, but branch is chore/rename-heuristics-to-rankthetank)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)