### PR TITLE
feat: add ModeloEspecifico bidder

### DIFF
--- a/src/bid_euchre/strategy/__init__.py
+++ b/src/bid_euchre/strategy/__init__.py
@@ -30,6 +30,7 @@ from .bidding import (
     FixedBidder,
     HeuristicSuitBidder,
     HighLowHeuristicBidder,
+    ModeloEspecifico,
     RanktheTank,
     StrictRaiserBidder,
 )
@@ -57,8 +58,9 @@ __all__ = [
     "ArtifactBidder",
     "FixedBidder",
     "HeuristicSuitBidder",
-    "RanktheTank",
     "HighLowHeuristicBidder",
+    "ModeloEspecifico",
+    "RanktheTank",
     "StrictRaiserBidder",
     # Baselines
     "BasicStrategy",

--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -379,6 +379,54 @@ class RanktheTank(BiddingPolicy):
         return BidAction.bid(bid_n, contract)
 
 
+class ModeloEspecifico(BiddingPolicy):
+    """
+    Feature-weighted bidder using hand-coded weights.
+
+    BidScore = 1.0 × bowers + 0.5 × trump_count + 0.5 × offsuit_aces
+
+    The score maps directly to bid amount (floored).
+    Named after the blog post's "specific model" baseline.
+    """
+
+    def __init__(self, name: str = "modelo_especifico"):
+        super().__init__(name)
+
+    def choose_bid(self, obs: BiddingObservation) -> BidAction:
+        from ..features.hand_eval import get_hand_features
+
+        candidates = []
+
+        # Evaluate suit contracts
+        for suit in ["C", "D", "H", "S"]:
+            features = get_hand_features(obs.hand, "suit", suit)
+            score = (
+                1.0 * features["bowers"]
+                + 0.5 * features["trump_count"]
+                + 0.5 * features["offsuit_aces"]
+            )
+            bid_n = int(score)  # floor
+            if 3 <= bid_n <= 6 and bid_n > obs.current_high_bid:
+                candidates.append((score, bid_n, suit))
+
+        # Evaluate HIGH/LOW contracts
+        # For HIGH/LOW, no bowers exist, so score is based on aces only
+        for contract in ["HIGH", "LOW"]:
+            features = get_hand_features(obs.hand, contract.lower(), None)
+            # No bowers in HIGH/LOW, trump_count = 0
+            score = 0.5 * features["offsuit_aces"]
+            bid_n = int(score)
+            if 3 <= bid_n <= 6 and bid_n > obs.current_high_bid:
+                candidates.append((score, bid_n, contract))
+
+        if not candidates:
+            return BidAction.pass_bid()
+
+        # Pick best: highest score, break ties by bid amount, then alphabetically
+        best = max(candidates, key=lambda x: (x[0], x[1], x[2]))
+        return BidAction.bid(best[1], best[2])
+
+
 class ArtifactBidder(BiddingPolicy):
     """
     Bidding policy that loads and executes a trained model from a bidding artifact file.

--- a/tests/unit/test_bidding.py
+++ b/tests/unit/test_bidding.py
@@ -11,6 +11,7 @@ from bid_euchre.strategy.bidding import (
     ArtifactBidder,
     BidAction,
     BiddingObservation,
+    ModeloEspecifico,
     StrictRaiserBidder,
 )
 
@@ -590,3 +591,147 @@ class TestBiddingPolicyConfig:
 
         with pytest.raises(ValueError, match="Unknown bidding policy class"):
             config.create_bidding_policy()
+
+
+class TestModeloEspecifico:
+    """Test ModeloEspecifico feature-weighted bidder."""
+
+    def test_strong_hand_bids_correctly(self):
+        """Test a strong hand: 2 bowers + 2 trump + 1 offsuit ace = score 4.5 → bid 4."""
+        bidder = ModeloEspecifico()
+
+        # Hand: RB(H), LB(H), AH, KH, AS
+        # In Hearts trump: 2 bowers, 4 trump total (RB, LB, A, K), 1 offsuit ace (AS)
+        # Score = 1.0 * 2 + 0.5 * 4 + 0.5 * 1 = 2 + 2 + 0.5 = 4.5 → bid 4
+        hand = [
+            Card("H", "J"),  # Right bower
+            Card("D", "J"),  # Left bower (Jack of same-color suit)
+            Card("H", "A"),  # Trump Ace
+            Card("H", "K"),  # Trump King
+            Card("S", "A"),  # Offsuit Ace
+        ]
+
+        obs = BiddingObservation(
+            hand=hand,
+            seat=0,
+            dealer_seat=3,
+            current_high_bid=0
+        )
+
+        action = bidder.choose_bid(obs)
+        assert not action.is_pass()
+        assert action.n == 4
+        assert action.contract == "H"  # Hearts should score highest
+
+    def test_weak_hand_passes(self):
+        """Test a weak hand (score < 3) passes."""
+        bidder = ModeloEspecifico()
+
+        # Hand with no bowers, 2 trump, no offsuit aces
+        # Score = 0 + 0.5 * 2 + 0 = 1.0 → pass
+        hand = [
+            Card("S", "K"),  # Trump King
+            Card("S", "Q"),  # Trump Queen
+            Card("H", "K"),  # Offsuit (not ace)
+            Card("D", "Q"),  # Offsuit (not ace)
+            Card("C", "T"),  # Offsuit (not ace)
+        ]
+
+        obs = BiddingObservation(
+            hand=hand,
+            seat=0,
+            dealer_seat=3,
+            current_high_bid=0
+        )
+
+        action = bidder.choose_bid(obs)
+        assert action.is_pass()
+
+    def test_contract_selection_highest_score(self):
+        """Test that the contract with highest score is selected."""
+        bidder = ModeloEspecifico()
+
+        # Hand heavily favoring Spades trump
+        # In Spades: RB, LB, A (3 trump, 2 bowers) + 1 offsuit ace
+        # Score = 2 + 1.5 + 0.5 = 4.0 → bid 4
+        hand = [
+            Card("S", "J"),  # Right bower in Spades
+            Card("C", "J"),  # Left bower in Spades (Club J)
+            Card("S", "A"),  # Trump Ace
+            Card("H", "A"),  # Offsuit Ace
+            Card("D", "K"),  # Offsuit
+        ]
+
+        obs = BiddingObservation(
+            hand=hand,
+            seat=0,
+            dealer_seat=3,
+            current_high_bid=0
+        )
+
+        action = bidder.choose_bid(obs)
+        assert not action.is_pass()
+        assert action.contract == "S"  # Spades should be chosen
+
+    def test_strict_increasing_compliance(self):
+        """Test that bids comply with strict-increasing rule."""
+        bidder = ModeloEspecifico()
+
+        # Strong hand that would normally bid 4
+        hand = [
+            Card("H", "J"),
+            Card("D", "J"),
+            Card("H", "A"),
+            Card("H", "K"),
+            Card("S", "A"),
+        ]
+
+        # Current high bid is 4, so must bid higher or pass
+        obs = BiddingObservation(
+            hand=hand,
+            seat=0,
+            dealer_seat=3,
+            current_high_bid=4
+        )
+
+        action = bidder.choose_bid(obs)
+        # Score is 4.5 → floor to 4, but 4 is not > 4, so must pass
+        assert action.is_pass()
+
+    def test_borderline_bid_3(self):
+        """Test a hand that scores exactly 3 bids 3."""
+        bidder = ModeloEspecifico()
+
+        # Need score of exactly 3.0-3.99 for bid 3
+        # 0 bowers + 6 trump + 0 offsuit aces = 0 + 3 + 0 = 3.0 → bid 3
+        hand = [
+            Card("H", "A"),
+            Card("H", "K"),
+            Card("H", "Q"),
+            Card("H", "T"),
+            Card("C", "A"),  # This would be offsuit ace, so let's use non-ace
+        ]
+        # Actually, let's construct it differently:
+        # 0 bowers, 6 trump, 0 offsuit aces → 0.5 * 6 = 3.0
+        # But we only have 5 cards in test hands sometimes...
+        # Let's do: 1 bower (1.0) + 4 trump (2.0) + 0 aces = 3.0
+        hand = [
+            Card("H", "J"),  # Right bower (1 bower, 1 trump)
+            Card("H", "K"),  # Trump
+            Card("H", "Q"),  # Trump
+            Card("H", "T"),  # Trump → total 4 trump, 1 bower
+            Card("D", "K"),  # Offsuit non-ace
+        ]
+        # Score = 1.0 * 1 + 0.5 * 4 + 0.5 * 0 = 1 + 2 + 0 = 3.0 → bid 3
+
+        obs = BiddingObservation(
+            hand=hand,
+            seat=0,
+            dealer_seat=3,
+            current_high_bid=0
+        )
+
+        action = bidder.choose_bid(obs)
+        assert not action.is_pass()
+        assert action.n == 3
+        assert action.contract == "H"


### PR DESCRIPTION
## Summary
- Add `ModeloEspecifico` bidder using hand-coded feature weights
- Formula: `BidScore = 1.0 × bowers + 0.5 × trump_count + 0.5 × offsuit_aces`
- Score maps directly to bid amount (floored, clamped to 3-6)

## Why
Aligns codebase with blog post "Bid Euchre, Part 4" which describes this baseline bidder.

## Repro / Validation
```bash
make check  # 560 passed
```

## Tests
- `test_strong_hand_bids_correctly` - 2 bowers + 4 trump + 1 offsuit ace → bid 4
- `test_weak_hand_passes` - score < 3 → pass
- `test_contract_selection_highest_score` - picks best contract
- `test_strict_increasing_compliance` - respects bid rules
- `test_borderline_bid_3` - score 3.0 → bid 3

## Worktree proof
```
pwd: /Users/Quentin/Projects/bid-euchre
git rev-parse --show-toplevel: /Users/Quentin/Projects/bid-euchre
```

🤖 Generated with [Claude Code](https://claude.ai/code)