### PR TITLE
feat: add bidless diagnostics CLI script and Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help sync repo-lint lint test check bid-train-teachers bid-eval-tiny bid-loop
+.PHONY: help sync repo-lint lint test check bid-train-teachers bid-eval-tiny bid-loop bidless-diagnostics
 .DEFAULT_GOAL := help
 
 PYTHON ?= uv run python
@@ -27,6 +27,9 @@ help:
 	@echo "  make bid-train-teachers - train teacher artifacts (all contracts)"
 	@echo "  make bid-eval-tiny      - run bid_eval_tiny suite"
 	@echo "  make bid-loop           - train teachers then eval tiny"
+	@echo ""
+	@echo "Diagnostics:"
+	@echo "  make bidless-diagnostics DATASET_DIR=path/to/datasets"
 	@echo ""
 
 sync:
@@ -85,3 +88,11 @@ bid-eval-tiny:
 
 bid-loop: bid-train-teachers bid-eval-tiny
 	@echo "✅ Teacher baseline loop complete"
+
+# Bidless diagnostics
+DATASET_DIR ?= data/runs/latest/datasets
+
+bidless-diagnostics:
+	@echo ">>> Running bidless diagnostics"
+	@echo "Dataset: $(DATASET_DIR)"
+	PYTHONPATH=src $(PYTHON) scripts/run_bidless_diagnostics.py --dataset $(DATASET_DIR)

--- a/scripts/run_bidless_diagnostics.py
+++ b/scripts/run_bidless_diagnostics.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+"""Run bidless dataset diagnostics from the command line.
+
+Usage:
+    PYTHONPATH=src python scripts/run_bidless_diagnostics.py --dataset /path/to/datasets
+    PYTHONPATH=src python scripts/run_bidless_diagnostics.py --dataset /path/to/datasets --charts /tmp/charts
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from bid_euchre.diagnostics import (
+    compare_first_last_batch,
+    compute_health_scorecard,
+    compute_seat_balance,
+    display_scorecard,
+    load_bidless_dataset,
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run bidless diagnostics")
+    parser.add_argument("--dataset", required=True, help="Path to dataset directory")
+    parser.add_argument("--charts", help="Output dir for charts (optional)")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    # Load dataset
+    df = load_bidless_dataset(args.dataset)
+    print(f"Loaded {len(df):,} rows from {args.dataset}")
+
+    # Run health scorecard
+    scorecard = compute_health_scorecard(df)
+    print("\n" + display_scorecard(scorecard))
+
+    # Additional stats
+    balance = compute_seat_balance(df)
+    drift = compare_first_last_batch(df)
+    print(f"\nSeat balance: {balance.interpretation}")
+    print(f"Drift check: {drift.interpretation}")
+
+    # Optional charts
+    if args.charts:
+        _save_charts(df, args.charts)
+
+    # Exit code
+    summary = scorecard.summary()
+    if summary["FAIL"] > 0:
+        print(f"\n❌ {summary['FAIL']} check(s) FAILED")
+        return 1
+    elif summary["WARN"] > 0:
+        print(f"\n⚠️ {summary['WARN']} warning(s), {summary['PASS']} passed")
+        return 0
+    else:
+        print(f"\n✅ All {summary['PASS']} checks passed")
+        return 0
+
+
+def _save_charts(df, output_dir):
+    """Save diagnostic charts to output directory."""
+    import matplotlib
+
+    matplotlib.use("Agg")  # Non-interactive backend
+    import matplotlib.pyplot as plt
+
+    from bid_euchre.diagnostics import (
+        plot_feature_distributions,
+        plot_hand_value_by_contract,
+        plot_hand_value_by_seat,
+        plot_rolling_mean,
+    )
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    charts = [
+        ("hand_value_by_seat.png", plot_hand_value_by_seat),
+        ("hand_value_by_contract.png", plot_hand_value_by_contract),
+        ("feature_distributions.png", plot_feature_distributions),
+        ("rolling_mean.png", lambda d: plot_rolling_mean(d, "feat_hand_value")),
+    ]
+
+    print("\nSaving charts:")
+    for filename, plot_fn in charts:
+        fig = plot_fn(df)
+        fig.savefig(output_dir / filename, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        print(f"  Saved {filename}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add `scripts/run_bidless_diagnostics.py` CLI script for running bidless dataset diagnostics
- Add `make bidless-diagnostics` Makefile target for easy invocation
- Includes exit code semantics (0=pass/warn, 1=fail) for CI integration

## Why
Phase 4 of the diagnostic visualization plan. Enables running diagnostics without Jupyter, useful for:
- CI integration (`make bidless-diagnostics || exit 1`)
- Quick command-line validation of datasets
- Automated chart generation

## Repro / Validation
```bash
# After generating a bidless dataset:
make bidless-diagnostics DATASET_DIR=/path/to/datasets

# Or directly:
PYTHONPATH=src python scripts/run_bidless_diagnostics.py --dataset /path/to/datasets

# With charts:
PYTHONPATH=src python scripts/run_bidless_diagnostics.py --dataset /path/to/datasets --charts /tmp/charts
```

## Tests
```bash
make check  # 682 passed, 4 skipped, 2 xfailed, 2 xpassed
```

## Worktree proof
```
pwd: /Users/Quentin/Projects/bid-euchre
git rev-parse --show-toplevel: /Users/Quentin/Projects/bid-euchre
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)