### PR TITLE
docs: fix documentation drift from repo review

### DIFF
--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -15,6 +15,9 @@ Submodules:
 - `features/` — Hand evaluation
 - `sim/` — Simulation engines
 - `experiments/` — Configuration system (StrategyConfig, ExperimentConfig)
+- `datasets/` — Dataset collectors (bidding, bidless)
+- `models/` — Model training/inference
+- `diagnostics/` — Visualization and analysis tools
 - `reporting/`, `logging/`, `analysis/`, `utils/` — Supporting utilities
 
 ### `experiments/`
@@ -36,7 +39,9 @@ Current scripts:
 - `lint_repo.py` — Repository linter (enforces boundaries and data policy)
 - `run_suite.py` — Suite runner (batches experiments with rollup generation)
 - `compare_rollup.py` — Drift detection (compares rollup against baseline fixture)
-- `run_tests.py`, `validate_tests.py` — Test utilities
+- `run_tests.py`, `validate_teacher_roster.py` — Test utilities
+- `collect_bidless_dataset.py` — Bidless feature dataset collector
+- `train_bidder.py` — Bidder model training
 
 ### `tests/`
 **Test suite only.**

--- a/docs/02_agent/REPO_REVIEW_PROMPT.md
+++ b/docs/02_agent/REPO_REVIEW_PROMPT.md
@@ -85,8 +85,8 @@ ls -d src/bid_euchre/*/
 
 ```bash
 # 5. Verify core modules import correctly
-PYTHONPATH=src python -c "from bid_euchre.core import Card, Deck; print('core OK')"
-PYTHONPATH=src python -c "from bid_euchre.sim import Simulation; print('sim OK')"
+PYTHONPATH=src python -c "from bid_euchre.core import Card, create_deck; print('core OK')"
+PYTHONPATH=src python -c "from bid_euchre.sim.simulation import play_single_hand; print('sim OK')"
 PYTHONPATH=src python -c "from bid_euchre.strategy import GreedyStrategy; print('strategy OK')"
 
 # 6. Verify newer modules (Arc B)

--- a/docs/03_TODO/CODEBASE_CONSISTENCY.md
+++ b/docs/03_TODO/CODEBASE_CONSISTENCY.md
@@ -1,7 +1,7 @@
 # CODEBASE_CONSISTENCY — doc/code gap tracker (RULES.md + METRICS.md)
 
 **Created:** 2026-01-04
-**Last verified on main:** 2026-01-11 (commit `b811119`)
+**Last verified on main:** 2026-01-27 (commit `279417d`)
 **Status:** Active
 
 ## How to read this file
@@ -133,6 +133,7 @@
 
 ## Done/Archived (verified in repo)
 
+- **Arc B bidding infrastructure complete:** `datasets/`, `models/`, and `diagnostics/` modules implemented; `train_bidder.py` and `collect_bidless_dataset.py` scripts operational; ModeloEspecifico and ArtifactBidder policies working.
 - **Scoring system implemented:** `src/bid_euchre/scoring.py::compute_points()` exists, simulation calls it, and unit tests cover exact scoring cases.
 - **`hand_id` vs `deal_id` clarification no longer needed:** `docs/01_core/METRICS.md` no longer references `hand_id`.
 - **Core docs populated:** `docs/01_core/EXPERIMENTS.md` exists and documents `meta.json` (schema v2) and reproducibility workflow.


### PR DESCRIPTION
## Summary
- **ARCHITECTURE.md**: Add missing modules (`datasets/`, `models/`, `diagnostics/`), fix script name (`validate_teacher_roster.py`), add new scripts (`collect_bidless_dataset.py`, `train_bidder.py`)
- **REPO_REVIEW_PROMPT.md**: Fix verification commands (`Deck`→`create_deck`, `Simulation`→`play_single_hand`)
- **CODEBASE_CONSISTENCY.md**: Update verification date to 2026-01-27, add Arc B infrastructure completion to Done/Archived

## Why
These documentation files had drifted from the actual codebase state:
- Module list was missing 3 modules added during Arc B development
- Verification commands referenced non-existent exports
- Consistency tracker hadn't been refreshed since Jan 11

## Repro / Validation
```bash
# Verify updated verification commands work
PYTHONPATH=src python -c "from bid_euchre.core import Card, create_deck; print('core OK')"
PYTHONPATH=src python -c "from bid_euchre.sim.simulation import play_single_hand; print('sim OK')"
PYTHONPATH=src python -c "from bid_euchre.strategy import GreedyStrategy; print('strategy OK')"
```

## Tests
```bash
make check  # 682 passed ✅
```

## Worktree proof
```
pwd: /Users/Quentin/Projects/bid-euchre
branch: docs/fix-doc-drift-post-review
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)