### PR TITLE
feat: add outcome evaluation and strategy comparison charts

### DIFF
--- a/notebooks/sandbox/00_charts_reference.ipynb
+++ b/notebooks/sandbox/00_charts_reference.ipynb
@@ -1,0 +1,565 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Charts Reference\n",
+    "\n",
+    "Comprehensive reference for all diagnostic and evaluation charts in the bid-euchre project.\n",
+    "\n",
+    "## Two Chart Families\n",
+    "\n",
+    "| Module | Input Type | Use Case |\n",
+    "|--------|------------|----------|\n",
+    "| `bid_euchre.diagnostics` | **DataFrame** | Interactive dataset analysis, health checks |\n",
+    "| `bid_euchre.reporting` | **Dict/List** | Training pipeline reports, batch generation |\n",
+    "\n",
+    "Both have functions with the same names but different APIs — choose based on your data format."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Auto-reload for development\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "import tempfile\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "from IPython.display import Image\n",
+    "\n",
+    "from bid_euchre.diagnostics import (\n",
+    "    plot_feature_correlation,\n",
+    "    plot_feature_distributions,\n",
+    "    plot_hand_value_by_contract,\n",
+    "    plot_hand_value_by_seat,\n",
+    "    plot_rolling_mean,\n",
+    ")\n",
+    "from bid_euchre.diagnostics.charts import plot_feature_vs_label\n",
+    "from bid_euchre.features.hand_eval import get_hand_features\n",
+    "from bid_euchre.reporting.validation import (\n",
+    "    generate_validation_plots,\n",
+    ")\n",
+    "from bid_euchre.reporting.validation import (\n",
+    "    plot_feature_correlation as eval_plot_feature_correlation,\n",
+    ")\n",
+    "from bid_euchre.reporting.validation import (\n",
+    "    plot_feature_distributions as eval_plot_feature_distributions,\n",
+    ")\n",
+    "from bid_euchre.reporting.validation import (\n",
+    "    plot_hand_value_by_contract as eval_plot_hand_value_by_contract,\n",
+    ")\n",
+    "from bid_euchre.sim.deals import generate_deal\n",
+    "\n",
+    "plt.style.use(\"seaborn-v0_8-whitegrid\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Sample Data Generation\n",
+    "\n",
+    "Generate sample datasets in both formats for demonstration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate DataFrame for diagnostic charts\n",
+    "SEED = 42\n",
+    "N_DEALS = 200\n",
+    "\n",
+    "hands_data = []\n",
+    "for deal_id in range(N_DEALS):\n",
+    "    hands = generate_deal(SEED, deal_id)\n",
+    "    # Vary contract types\n",
+    "    contract_types = ['suit', 'high', 'low']\n",
+    "    contract_type = contract_types[deal_id % 3]\n",
+    "    trump = 'H' if contract_type == 'suit' else None\n",
+    "    \n",
+    "    for seat in range(4):\n",
+    "        hand = hands[seat]\n",
+    "        features = get_hand_features(hand, contract_type, trump)\n",
+    "        hands_data.append({\n",
+    "            'hand_id': f\"{deal_id}_{seat}\",\n",
+    "            'deal_id': deal_id,\n",
+    "            'seat': seat,\n",
+    "            'contract_type': contract_type,\n",
+    "            'trump': trump,\n",
+    "            # Add feat_ prefix for diagnostic charts\n",
+    "            **{f'feat_{k}': v for k, v in features.items()}\n",
+    "        })\n",
+    "\n",
+    "df = pd.DataFrame(hands_data)\n",
+    "print(f\"DataFrame shape: {df.shape}\")\n",
+    "print(f\"Columns: {list(df.columns)[:10]}...\")\n",
+    "df.head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate Dict structure for evaluation charts\n",
+    "features_by_contract = {'suit_H': [], 'high': [], 'low': []}\n",
+    "\n",
+    "for deal_id in range(N_DEALS):\n",
+    "    hands = generate_deal(SEED, deal_id)\n",
+    "    \n",
+    "    for contract_key, contract_type, trump in [\n",
+    "        ('suit_H', 'suit', 'H'),\n",
+    "        ('high', 'high', None),\n",
+    "        ('low', 'low', None),\n",
+    "    ]:\n",
+    "        # Just use seat 0 for simplicity\n",
+    "        features = get_hand_features(hands[0], contract_type, trump)\n",
+    "        features_by_contract[contract_key].append(features)\n",
+    "\n",
+    "print(f\"Dict structure: {list(features_by_contract.keys())}\")\n",
+    "print(f\"Samples per contract: {len(features_by_contract['suit_H'])}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "# Part 1: Diagnostic Charts (DataFrame-based)\n",
+    "\n",
+    "From `bid_euchre.diagnostics` — interactive analysis of bidless datasets.\n",
+    "\n",
+    "**Input:** pandas DataFrame with `feat_*` columns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1.1 `plot_hand_value_by_seat()`\n",
+    "\n",
+    "Box plots showing hand_value distribution across seats (0-3). Detects dealing bias or per-seat feature computation bugs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plot_hand_value_by_seat(df)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1.2 `plot_hand_value_by_contract()`\n",
+    "\n",
+    "Box plots comparing hand_value across contract types (suit/high/low)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plot_hand_value_by_contract(df)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1.3 `plot_feature_distributions()`\n",
+    "\n",
+    "Grid of histograms for multiple features. Shows top 9 features by variance by default."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plot_feature_distributions(df)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# With specific features\n",
+    "fig = plot_feature_distributions(df, features=['hand_value', 'trump_count', 'offsuit_aces'])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1.4 `plot_feature_correlation()`\n",
+    "\n",
+    "Heatmap of feature correlations. Top 10 features by variance by default."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plot_feature_correlation(df)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1.5 `plot_rolling_mean()`\n",
+    "\n",
+    "Time-series plot of rolling mean over hand index. Detects drift over time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plot_rolling_mean(df, column='feat_hand_value', window=50)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1.6 `plot_feature_vs_label()`\n",
+    "\n",
+    "Dual panel: scatter plot + binned box plot. Shows feature vs label relationship."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plot_feature_vs_label(df, feature='trump_count', label='hand_value')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "# Part 2: Evaluation Charts (Dict-based)\n",
+    "\n",
+    "From `bid_euchre.reporting.validation` — batch report generation for training pipelines.\n",
+    "\n",
+    "**Input:** `Dict[contract_key, List[feature_dict]]` or `List[feature_dict]`\n",
+    "\n",
+    "**Output:** Saves PNG files to disk, returns file path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create temp directory for output\n",
+    "output_dir = tempfile.mkdtemp(prefix='charts_demo_')\n",
+    "print(f\"Output directory: {output_dir}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2.1 `plot_feature_distributions()` (eval)\n",
+    "\n",
+    "Feature distributions by contract type. Overlays histograms for comparison."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path = eval_plot_feature_distributions(\n",
+    "    features_by_contract,\n",
+    "    output_dir,\n",
+    "    feature_keys=[\"trump_count\", \"hand_value\"],\n",
+    ")\n",
+    "print(f\"Saved to: {path}\")\n",
+    "\n",
+    "# Display the saved image\n",
+    "Image(filename=path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2.2 `plot_feature_correlation()` (eval)\n",
+    "\n",
+    "Correlation matrix from feature dicts. Auto-detects numeric columns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Flatten all features for correlation\n",
+    "all_features = []\n",
+    "for features_list in features_by_contract.values():\n",
+    "    all_features.extend(features_list)\n",
+    "\n",
+    "path = eval_plot_feature_correlation(all_features, output_dir)\n",
+    "print(f\"Saved to: {path}\")\n",
+    "\n",
+    "Image(filename=path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2.3 `plot_hand_value_by_contract()` (eval)\n",
+    "\n",
+    "Box plots of hand_value by contract type from Dict input."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path = eval_plot_hand_value_by_contract(features_by_contract, output_dir)\n",
+    "print(f\"Saved to: {path}\")\n",
+    "\n",
+    "Image(filename=path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2.4 `generate_validation_plots()`\n",
+    "\n",
+    "Orchestrator function that generates all evaluation plots at once."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use a separate subdirectory\n",
+    "batch_dir = os.path.join(output_dir, \"batch\")\n",
+    "\n",
+    "plots = generate_validation_plots(features_by_contract, batch_dir)\n",
+    "print(\"Generated plots:\")\n",
+    "for name, path in plots.items():\n",
+    "    print(f\"  {name}: {path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "---\n# Quick Reference\n\n## Diagnostic Charts (`bid_euchre.diagnostics`)\n\n### Feature Analysis Charts\n\n| Function | Purpose | Key Parameters |\n|----------|---------|----------------|\n| `plot_hand_value_by_seat(df)` | Seat balance check | `df` with `seat`, `feat_hand_value` |\n| `plot_hand_value_by_contract(df)` | Contract comparison | `df` with `contract_type`, `feat_hand_value` |\n| `plot_feature_distributions(df)` | Feature histograms | `features=None` for top 9 by variance |\n| `plot_feature_correlation(df)` | Correlation heatmap | `features=None` for top 10 by variance |\n| `plot_rolling_mean(df, column)` | Drift detection | `window=100` default |\n| `plot_feature_vs_label(df, feature)` | Scatter + boxplot | `label='feat_hand_value'` default |\n\n### Outcome Evaluation Charts\n\n| Function | Purpose | Key Parameters |\n|----------|---------|----------------|\n| `plot_feature_vs_outcome(df, feature)` | Feature vs outcome with correlation | `outcome='tricks_won'` |\n| `plot_outcome_distributions(df, outcome)` | Outcome by category | `group_by='contract_type'` |\n| `plot_feature_outcome_correlation(df)` | Feature importance bar chart | `outcome='tricks_won'`, `top_n=15` |\n\n### Strategy Comparison Charts\n\n| Function | Purpose | Key Parameters |\n|----------|---------|----------------|\n| `plot_win_rate_heatmap(matchup_results)` | All-vs-all win rate matrix | `metric='win_rate'` |\n| `plot_tricks_distribution_comparison(matchup_results)` | Violin plots by matchup | `team=0` |\n| `plot_strategy_delta_bars(baseline, comparisons)` | Delta vs baseline | `metric='mean_tricks'` |\n| `plot_self_play_control(self_play_results)` | Self-play sanity check | `expected_mean=5.0` |\n| `plot_matchup_summary(matchup_results)` | 3-panel summary | Heatmap + bars + control |\n\n## Evaluation Charts (`bid_euchre.reporting.validation`)\n\n| Function | Purpose | Input Format |\n|----------|---------|---------------|\n| `plot_feature_distributions(fbc, dir)` | By-contract histograms | `Dict[str, List[Dict]]` |\n| `plot_feature_correlation(features, dir)` | Correlation matrix | `List[Dict]` |\n| `plot_hand_value_by_contract(fbc, dir)` | Contract box plots | `Dict[str, List[Dict]]` |\n| `generate_validation_plots(fbc, dir)` | All of the above | `Dict[str, List[Dict]]` |"
+  },
+  {
+   "cell_type": "markdown",
+   "source": "---\n# Part 3: Outcome Evaluation Charts\n\nCharts that correlate hand features with actual outcomes (`tricks_won`) from simulation.\n\n**Key insight:** The bidless dataset only contains input features. To analyze outcomes, we must run simulations that record both starting features AND resulting trick counts.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## 3.0 Generate Simulation Data (features + tricks_won)\n\nRun simulations to create a dataset with both hand features and actual trick outcomes.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "# Generate simulation data with features + tricks_won\nfrom bid_euchre.sim.simulation import play_single_hand\nfrom bid_euchre.strategy import GreedyStrategy\n\n# Run simulations to get outcome data\nN_DEALS_SIM = 200\noutcome_data = []\nstrategy = GreedyStrategy()\n\nfor deal_id in range(N_DEALS_SIM):\n    hands = generate_deal(SEED, deal_id)\n    \n    for contract_type in ['suit', 'high', 'low']:\n        trump = 'H' if contract_type == 'suit' else None\n        \n        t0, t1, _, all_feats, _, _, *_ = play_single_hand(\n            contract_type=contract_type,\n            trump_suit=trump,\n            strategy=strategy,\n            hands=hands,\n            deal_seed=SEED,\n        )\n        \n        # Record each player's features + their team's tricks\n        for seat in range(4):\n            team_tricks = t0 if seat in (0, 2) else t1\n            features = all_feats[seat]\n            outcome_data.append({\n                'deal_id': deal_id,\n                'seat': seat,\n                'contract_type': contract_type,\n                'trump': trump,\n                'tricks_won': team_tricks,\n                **{f'feat_{k}': v for k, v in features.items()}\n            })\n\noutcome_df = pd.DataFrame(outcome_data)\nprint(f\"Simulation DataFrame shape: {outcome_df.shape}\")\nprint(f\"Tricks won range: {outcome_df['tricks_won'].min()} - {outcome_df['tricks_won'].max()}\")\noutcome_df.head(3)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## 3.1 `plot_feature_vs_outcome()` - hand_value vs tricks_won\n\nScatter plot with trend line + binned box plot. Shows correlation coefficient in title.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "from bid_euchre.diagnostics.charts import plot_feature_vs_outcome\n\n# hand_value vs tricks_won - the key relationship\nfig = plot_feature_vs_outcome(outcome_df, feature='hand_value', outcome='tricks_won')\nplt.show()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# Also check trump_count vs tricks_won for suit contracts\nsuit_df = outcome_df[outcome_df['contract_type'] == 'suit']\nfig = plot_feature_vs_outcome(suit_df, feature='trump_count', outcome='tricks_won')\nplt.show()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## 3.2 `plot_outcome_distributions()` - tricks by contract type\n\nViolin/box plots of outcome distribution grouped by category.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "from bid_euchre.diagnostics.charts import plot_outcome_distributions\n\nfig = plot_outcome_distributions(outcome_df, outcome='tricks_won', group_by='contract_type')\nplt.show()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## 3.3 `plot_feature_outcome_correlation()` - feature importance bar chart\n\nHorizontal bar chart showing correlation of each feature with tricks_won, sorted by importance.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "from bid_euchre.diagnostics.charts import plot_feature_outcome_correlation\n\nfig = plot_feature_outcome_correlation(outcome_df, outcome='tricks_won', top_n=15)\nplt.show()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# Filter to suit contracts only for more specific feature importance\nfig = plot_feature_outcome_correlation(suit_df, outcome='tricks_won', top_n=15)\nplt.show()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "---\n# Part 4: Strategy Comparison Charts\n\nCharts for comparing strategy performance in head-to-head and self-play matchups.\n\nAvailable strategies:\n- **Greedy**: 1-trick lookahead, plays cheapest winning card\n- **Glutton**: Partner-aware greedy with trump conservation\n- **Random Legal**: Uniform random among legal moves (baseline)",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## 4.0 Generate Matchup Data\n\nRun simulations with different strategy pairs to collect matchup results.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "import numpy as np\n\nfrom bid_euchre.strategy import GluttonStrategy, RandomLegalStrategy\n\n# Define strategies to compare\nSTRATEGY_CLASSES = {\n    'greedy': GreedyStrategy,\n    'glutton': GluttonStrategy,\n    'random': lambda: RandomLegalStrategy(seed=42),\n}\n\n# Generate matchup results\nN_HANDS = 200\nmatchup_results = {}\n\nfor team0_name in STRATEGY_CLASSES.keys():\n    for team1_name in STRATEGY_CLASSES.keys():\n        team0_strat = STRATEGY_CLASSES[team0_name]()\n        team1_strat = STRATEGY_CLASSES[team1_name]()\n        strategies = [team0_strat, team1_strat, team0_strat, team1_strat]\n        \n        t0_tricks = []\n        t1_tricks = []\n        \n        for deal_id in range(N_HANDS):\n            hands = generate_deal(SEED, deal_id)\n            t0, t1, *_ = play_single_hand(\n                contract_type='suit',\n                trump_suit='H',\n                strategies=strategies,\n                hands=hands,\n                deal_seed=SEED,\n            )\n            t0_tricks.append(t0)\n            t1_tricks.append(t1)\n        \n        matchup_results[(team0_name, team1_name)] = {\n            'tricks_team0': t0_tricks,\n            'tricks_team1': t1_tricks,\n            'mean_tricks': np.mean(t0_tricks),\n            'win_rate': np.mean([1 if t >= 6 else 0 for t in t0_tricks]),\n            'ci_lower': np.mean(t0_tricks) - 1.96 * np.std(t0_tricks) / np.sqrt(N_HANDS),\n            'ci_upper': np.mean(t0_tricks) + 1.96 * np.std(t0_tricks) / np.sqrt(N_HANDS),\n        }\n\nprint(f\"Generated {len(matchup_results)} matchups\")\nfor key, result in matchup_results.items():\n    print(f\"  {key[0]} vs {key[1]}: mean={result['mean_tricks']:.2f}, win_rate={result['win_rate']:.1%}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## 4.1 `plot_win_rate_heatmap()` - all-vs-all win rates\n\nHeatmap showing Team 0's win rate against each Team 1 strategy.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "from bid_euchre.diagnostics import plot_win_rate_heatmap\n\nfig = plot_win_rate_heatmap(matchup_results, metric='win_rate')\nplt.show()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## 4.2 `plot_tricks_distribution_comparison()` - violin plots by matchup\n\nViolin plots comparing trick distributions across different matchups.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "from bid_euchre.diagnostics import plot_tricks_distribution_comparison\n\n# Show a subset of interesting matchups\nsubset_matchups = {k: v for k, v in matchup_results.items() \n                   if k[0] != k[1]}  # Exclude self-play for comparison\n\nfig = plot_tricks_distribution_comparison(subset_matchups, team=0)\nplt.show()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## 4.3 `plot_strategy_delta_bars()` - delta vs baseline\n\nBar chart showing mean tricks delta relative to baseline (random).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "from bid_euchre.diagnostics import plot_strategy_delta_bars\n\n# Compare each strategy vs random baseline\nbaseline_results = matchup_results[('random', 'random')]\ncomparison_results = {\n    'greedy': matchup_results[('greedy', 'random')],\n    'glutton': matchup_results[('glutton', 'random')],\n}\n\nfig = plot_strategy_delta_bars(baseline_results, comparison_results, baseline_name='random')\nplt.show()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## 4.4 `plot_self_play_control()` - self-play sanity check\n\nControl chart showing mean tricks for self-play matchups. Should be ~5.0 for fair play.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "from bid_euchre.diagnostics import plot_self_play_control\n\n# Extract self-play matchups\nself_play_results = {k[0]: v for k, v in matchup_results.items() if k[0] == k[1]}\n\nfig = plot_self_play_control(self_play_results)\nplt.show()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Cleanup temp directory\n",
+    "shutil.rmtree(output_dir)\n",
+    "print(\"Cleaned up temp directory\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/src/bid_euchre/diagnostics/__init__.py
+++ b/src/bid_euchre/diagnostics/__init__.py
@@ -5,6 +5,7 @@ This package provides importable helpers for:
 - Computing health scorecards
 - Generating diagnostic charts
 - Running statistical tests
+- Strategy comparison visualizations
 
 The design philosophy is: logic lives here, notebooks are thin orchestration.
 """
@@ -12,13 +13,23 @@ The design philosophy is: logic lives here, notebooks are thin orchestration.
 from .charts import (
     plot_feature_correlation,
     plot_feature_distributions,
+    plot_feature_outcome_correlation,
+    plot_feature_vs_outcome,
     plot_hand_value_by_contract,
     plot_hand_value_by_seat,
+    plot_outcome_distributions,
     plot_rolling_mean,
 )
 from .health_checks import compute_health_scorecard, display_scorecard
 from .loaders import load_bidless_dataset, load_meta
 from .stats import compare_first_last_batch, compute_seat_balance
+from .strategy_charts import (
+    plot_matchup_summary,
+    plot_self_play_control,
+    plot_strategy_delta_bars,
+    plot_tricks_distribution_comparison,
+    plot_win_rate_heatmap,
+)
 
 __all__ = [
     # Loaders
@@ -27,12 +38,22 @@ __all__ = [
     # Health checks
     "compute_health_scorecard",
     "display_scorecard",
-    # Charts
+    # Charts - Feature Analysis
     "plot_hand_value_by_seat",
     "plot_hand_value_by_contract",
     "plot_feature_distributions",
     "plot_feature_correlation",
     "plot_rolling_mean",
+    # Charts - Outcome Evaluation
+    "plot_feature_vs_outcome",
+    "plot_outcome_distributions",
+    "plot_feature_outcome_correlation",
+    # Charts - Strategy Comparison
+    "plot_win_rate_heatmap",
+    "plot_tricks_distribution_comparison",
+    "plot_strategy_delta_bars",
+    "plot_self_play_control",
+    "plot_matchup_summary",
     # Stats
     "compare_first_last_batch",
     "compute_seat_balance",

--- a/src/bid_euchre/diagnostics/charts.py
+++ b/src/bid_euchre/diagnostics/charts.py
@@ -380,3 +380,220 @@ def plot_feature_vs_label(
     fig.suptitle(f"{feat_col.replace('feat_', '')} vs {label_col.replace('feat_', '')}", fontsize=12, y=1.02)
     plt.tight_layout()
     return fig
+
+
+def plot_feature_vs_outcome(
+    df: pd.DataFrame,
+    feature: str,
+    outcome: str = "tricks_won",
+    figsize: Tuple[int, int] = (12, 5),
+) -> plt.Figure:
+    """Plot scatter + binned boxplot for feature vs outcome with correlation.
+
+    Creates a two-panel figure showing the relationship between a feature
+    and an outcome variable (typically tricks_won from simulation).
+
+    Args:
+        df: DataFrame with feature columns and outcome column
+        feature: Feature column name (with or without feat_ prefix)
+        outcome: Outcome column name (default "tricks_won")
+        figsize: Figure size tuple
+
+    Returns:
+        matplotlib Figure with correlation coefficient in title
+    """
+    # Normalize column name
+    feat_col = feature if feature.startswith("feat_") else f"feat_{feature}"
+
+    fig, axes = plt.subplots(1, 2, figsize=figsize)
+
+    if feat_col not in df.columns or outcome not in df.columns:
+        axes[0].text(0.5, 0.5, f"Required columns not found\n({feat_col}, {outcome})",
+                     ha="center", va="center")
+        return fig
+
+    # Compute correlation
+    valid_mask = df[feat_col].notna() & df[outcome].notna()
+    if valid_mask.sum() > 2:
+        corr = df.loc[valid_mask, feat_col].corr(df.loc[valid_mask, outcome])
+    else:
+        corr = np.nan
+
+    # Left: Scatter plot
+    ax = axes[0]
+    ax.scatter(df[feat_col], df[outcome], alpha=0.3, s=10, c="#3498db")
+    ax.set_xlabel(feat_col.replace("feat_", ""))
+    ax.set_ylabel(outcome.replace("_", " ").title())
+    ax.set_title("Scatter Plot")
+
+    # Add trend line
+    if valid_mask.sum() > 10:
+        z = np.polyfit(df.loc[valid_mask, feat_col], df.loc[valid_mask, outcome], 1)
+        p = np.poly1d(z)
+        x_range = np.linspace(df[feat_col].min(), df[feat_col].max(), 100)
+        ax.plot(x_range, p(x_range), color="red", linestyle="--", linewidth=2, label="Trend")
+        ax.legend()
+
+    ax.grid(True, alpha=0.3)
+
+    # Right: Binned boxplot
+    ax = axes[1]
+    try:
+        df_copy = df[[feat_col, outcome]].copy()
+        df_copy["_bin"] = pd.qcut(df_copy[feat_col], q=5, duplicates="drop")
+        if HAS_SEABORN:
+            sns.boxplot(data=df_copy, x="_bin", y=outcome, ax=ax)
+        else:
+            bins = df_copy.groupby("_bin")[outcome].apply(list).tolist()
+            ax.boxplot(bins)
+    except ValueError:
+        ax.text(0.5, 0.5, "Not enough unique values for binning", ha="center", va="center")
+
+    ax.set_xlabel(feat_col.replace("feat_", "") + " (binned)")
+    ax.set_ylabel(outcome.replace("_", " ").title())
+    ax.set_title("Binned Box Plot")
+    ax.tick_params(axis="x", rotation=45)
+    ax.grid(True, axis="y", alpha=0.3)
+
+    corr_str = f"r = {corr:.3f}" if not np.isnan(corr) else "r = N/A"
+    fig.suptitle(f"{feat_col.replace('feat_', '')} vs {outcome} ({corr_str})", fontsize=12, y=1.02)
+    plt.tight_layout()
+    return fig
+
+
+def plot_outcome_distributions(
+    df: pd.DataFrame,
+    outcome: str = "tricks_won",
+    group_by: str = "contract_type",
+    figsize: Tuple[int, int] = (10, 6),
+    title: Optional[str] = None,
+) -> plt.Figure:
+    """Plot violin/box plots of outcome distribution grouped by category.
+
+    Args:
+        df: DataFrame with outcome column and grouping column
+        outcome: Outcome column name (default "tricks_won")
+        group_by: Column to group by (default "contract_type")
+        figsize: Figure size tuple
+        title: Optional title override
+
+    Returns:
+        matplotlib Figure
+    """
+    fig, ax = plt.subplots(figsize=figsize)
+
+    if outcome not in df.columns or group_by not in df.columns:
+        ax.text(0.5, 0.5, f"Required columns not found\n({outcome}, {group_by})",
+                ha="center", va="center")
+        return fig
+
+    groups = sorted(df[group_by].unique())
+
+    if HAS_SEABORN:
+        sns.violinplot(data=df, x=group_by, y=outcome, ax=ax, order=groups, inner="box")
+    else:
+        data = [df[df[group_by] == g][outcome].values for g in groups]
+        bp = ax.boxplot(data, labels=groups, patch_artist=True)
+        colors = plt.cm.tab10(np.linspace(0, 1, len(groups)))
+        for patch, color in zip(bp["boxes"], colors):
+            patch.set_facecolor(color)
+            patch.set_alpha(0.7)
+
+    ax.set_xlabel(group_by.replace("_", " ").title())
+    ax.set_ylabel(outcome.replace("_", " ").title())
+    ax.set_title(title or f"{outcome.replace('_', ' ').title()} Distribution by {group_by.replace('_', ' ').title()}")
+    ax.grid(True, axis="y", alpha=0.3)
+
+    # Add mean markers
+    means = [df[df[group_by] == g][outcome].mean() for g in groups]
+    ax.scatter(range(len(means)), means, color="red", marker="D", s=50, zorder=5, label="Mean")
+    ax.legend()
+
+    plt.tight_layout()
+    return fig
+
+
+def plot_feature_outcome_correlation(
+    df: pd.DataFrame,
+    outcome: str = "tricks_won",
+    features: Optional[List[str]] = None,
+    top_n: int = 15,
+    figsize: Tuple[int, int] = (10, 8),
+    title: Optional[str] = None,
+) -> plt.Figure:
+    """Plot horizontal bar chart of feature correlations with outcome.
+
+    Creates a bar chart sorted by absolute correlation, with colors
+    indicating positive (green) or negative (red) correlation.
+
+    Args:
+        df: DataFrame with feat_* columns and outcome column
+        outcome: Outcome column name (default "tricks_won")
+        features: Optional list of feature names to include (without feat_ prefix).
+                  If None, uses all numeric feat_* columns.
+        top_n: Maximum number of features to display (default 15)
+        figsize: Figure size tuple
+        title: Optional title override
+
+    Returns:
+        matplotlib Figure
+    """
+    fig, ax = plt.subplots(figsize=figsize)
+
+    if outcome not in df.columns:
+        ax.text(0.5, 0.5, f"Outcome column '{outcome}' not found", ha="center", va="center")
+        return fig
+
+    # Get feature columns
+    feat_cols = [c for c in df.columns if c.startswith("feat_")]
+    numeric_cols = [c for c in feat_cols if df[c].dtype in [np.float64, np.int64, np.float32, np.int32]]
+
+    if features:
+        numeric_cols = [f"feat_{f}" for f in features if f"feat_{f}" in numeric_cols]
+
+    if not numeric_cols:
+        ax.text(0.5, 0.5, "No numeric features found", ha="center", va="center")
+        return fig
+
+    # Compute correlations
+    correlations = {}
+    for col in numeric_cols:
+        valid_mask = df[col].notna() & df[outcome].notna()
+        if valid_mask.sum() > 2:
+            corr = df.loc[valid_mask, col].corr(df.loc[valid_mask, outcome])
+            if not np.isnan(corr):
+                correlations[col] = corr
+
+    if not correlations:
+        ax.text(0.5, 0.5, "Could not compute correlations", ha="center", va="center")
+        return fig
+
+    # Sort by absolute correlation and take top N
+    sorted_items = sorted(correlations.items(), key=lambda x: abs(x[1]), reverse=True)[:top_n]
+    sorted_items = list(reversed(sorted_items))  # Reverse for horizontal bar
+
+    labels = [c.replace("feat_", "") for c, _ in sorted_items]
+    values = [v for _, v in sorted_items]
+    colors = ["#27ae60" if v > 0 else "#e74c3c" for v in values]
+
+    y_pos = np.arange(len(labels))
+    bars = ax.barh(y_pos, values, color=colors, alpha=0.8)
+
+    ax.axvline(0, color="black", linestyle="-", linewidth=1)
+    ax.set_yticks(y_pos)
+    ax.set_yticklabels(labels)
+    ax.set_xlabel(f"Correlation with {outcome}")
+    ax.set_ylabel("Feature")
+    ax.set_title(title or f"Feature Correlation with {outcome.replace('_', ' ').title()}")
+    ax.grid(True, axis="x", alpha=0.3)
+    ax.set_xlim(-1.1, 1.1)
+
+    # Annotate bars with values
+    for bar, val in zip(bars, values):
+        x_pos = val + 0.02 if val >= 0 else val - 0.02
+        ha = "left" if val >= 0 else "right"
+        ax.text(x_pos, bar.get_y() + bar.get_height() / 2, f"{val:.3f}",
+                va="center", ha=ha, fontsize=8)
+
+    plt.tight_layout()
+    return fig

--- a/src/bid_euchre/diagnostics/strategy_charts.py
+++ b/src/bid_euchre/diagnostics/strategy_charts.py
@@ -1,0 +1,501 @@
+"""Strategy comparison chart functions for head-to-head analysis.
+
+Provides matplotlib-based visualizations for comparing strategy performance
+across matchups. Designed for head-to-head and self-play evaluation.
+"""
+
+from typing import Any, Dict, Optional, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+# Try to import seaborn, fall back gracefully
+try:
+    import seaborn as sns
+
+    HAS_SEABORN = True
+except ImportError:
+    HAS_SEABORN = False
+
+# Import style constants from reporting module
+from ..reporting.style import (
+    FIGSIZE_MATRIX,
+    FIGSIZE_SINGLE_PLOT,
+    apply_report_style,
+    get_strategy_color,
+    get_strategy_name,
+)
+
+
+def plot_win_rate_heatmap(
+    matchup_results: Dict[Tuple[str, str], Dict[str, Any]],
+    metric: str = "win_rate",
+    figsize: Tuple[int, int] = FIGSIZE_MATRIX,
+    title: Optional[str] = None,
+) -> plt.Figure:
+    """Plot heatmap of win rates for all strategy matchups.
+
+    Creates a square heatmap where rows are Team 0 strategies and columns
+    are Team 1 strategies. Cell values show the win rate for Team 0.
+
+    Args:
+        matchup_results: Dict mapping (team0_name, team1_name) to result dict.
+            Each result dict should contain the specified metric key.
+        metric: Key in result dict to plot (default "win_rate" for Team 0)
+        figsize: Figure size tuple
+        title: Optional title override
+
+    Returns:
+        matplotlib Figure
+    """
+    apply_report_style()
+
+    # Extract unique strategies (preserve order from first appearance)
+    strategies = []
+    seen = set()
+    for team0, team1 in matchup_results.keys():
+        if team0 not in seen:
+            strategies.append(team0)
+            seen.add(team0)
+        if team1 not in seen:
+            strategies.append(team1)
+            seen.add(team1)
+
+    n = len(strategies)
+    if n == 0:
+        fig, ax = plt.subplots(figsize=figsize)
+        ax.text(0.5, 0.5, "No matchup data provided", ha="center", va="center")
+        return fig
+
+    # Build matrix
+    matrix = np.full((n, n), np.nan)
+    strategy_idx = {s: i for i, s in enumerate(strategies)}
+
+    for (team0, team1), result in matchup_results.items():
+        i = strategy_idx.get(team0)
+        j = strategy_idx.get(team1)
+        if i is not None and j is not None:
+            val = result.get(metric)
+            if val is not None:
+                matrix[i, j] = val
+
+    # Create figure
+    fig, ax = plt.subplots(figsize=figsize)
+
+    # Plot heatmap
+    if HAS_SEABORN:
+        labels = [get_strategy_name(s) for s in strategies]
+        annot = np.array(
+            [[f"{v:.1%}" if not np.isnan(v) else "" for v in row] for row in matrix]
+        )
+        sns.heatmap(
+            matrix,
+            annot=annot,
+            fmt="",
+            cmap="RdYlGn",
+            center=0.5,
+            vmin=0,
+            vmax=1,
+            ax=ax,
+            xticklabels=labels,
+            yticklabels=labels,
+            cbar_kws={"label": "Win Rate (Team 0)"},
+        )
+    else:
+        im = ax.imshow(matrix, cmap="RdYlGn", vmin=0, vmax=1, aspect="auto")
+        fig.colorbar(im, ax=ax, label="Win Rate (Team 0)")
+
+        # Labels
+        labels = [get_strategy_name(s) for s in strategies]
+        ax.set_xticks(range(n))
+        ax.set_xticklabels(labels, rotation=45, ha="right")
+        ax.set_yticks(range(n))
+        ax.set_yticklabels(labels)
+
+        # Annotate
+        for i in range(n):
+            for j in range(n):
+                val = matrix[i, j]
+                if not np.isnan(val):
+                    color = "white" if val < 0.3 or val > 0.7 else "black"
+                    ax.text(
+                        j, i, f"{val:.1%}", ha="center", va="center", color=color
+                    )
+
+    ax.set_xlabel("Team 1 Strategy")
+    ax.set_ylabel("Team 0 Strategy")
+    ax.set_title(title or "Win Rate Heatmap (Team 0 vs Team 1)")
+
+    plt.tight_layout()
+    return fig
+
+
+def plot_tricks_distribution_comparison(
+    matchup_results: Dict[Tuple[str, str], Dict[str, Any]],
+    team: int = 0,
+    figsize: Tuple[int, int] = (14, 6),
+    title: Optional[str] = None,
+) -> plt.Figure:
+    """Plot violin/box plots comparing trick distributions across matchups.
+
+    Args:
+        matchup_results: Dict mapping (team0_name, team1_name) to result dict.
+            Each result dict should contain "tricks_team0" or "tricks_team1" key
+            with a list of trick counts.
+        team: Which team's tricks to plot (0 or 1)
+        figsize: Figure size tuple
+        title: Optional title override
+
+    Returns:
+        matplotlib Figure
+    """
+    apply_report_style()
+
+    tricks_key = f"tricks_team{team}"
+
+    # Collect data
+    matchup_labels = []
+    trick_data = []
+
+    for (team0, team1), result in matchup_results.items():
+        tricks = result.get(tricks_key, [])
+        if tricks:
+            label = f"{get_strategy_name(team0)}\nvs\n{get_strategy_name(team1)}"
+            matchup_labels.append(label)
+            trick_data.append(tricks)
+
+    if not trick_data:
+        fig, ax = plt.subplots(figsize=figsize)
+        ax.text(0.5, 0.5, f"No trick data found (key: {tricks_key})", ha="center", va="center")
+        return fig
+
+    fig, ax = plt.subplots(figsize=figsize)
+
+    if HAS_SEABORN:
+        # Flatten for seaborn
+        import pandas as pd
+
+        plot_df = []
+        for label, tricks in zip(matchup_labels, trick_data):
+            for t in tricks:
+                plot_df.append({"Matchup": label, "Tricks": t})
+        plot_df = pd.DataFrame(plot_df)
+        sns.violinplot(data=plot_df, x="Matchup", y="Tricks", ax=ax, inner="box")
+    else:
+        bp = ax.boxplot(trick_data, labels=matchup_labels, patch_artist=True)
+        colors = plt.cm.tab10(np.linspace(0, 1, len(trick_data)))
+        for patch, color in zip(bp["boxes"], colors):
+            patch.set_facecolor(color)
+            patch.set_alpha(0.7)
+
+    ax.axhline(5.0, color="red", linestyle="--", alpha=0.7, label="Expected (5.0)")
+    ax.set_xlabel("Matchup")
+    ax.set_ylabel(f"Tricks (Team {team})")
+    ax.set_title(title or f"Trick Distribution by Matchup (Team {team})")
+    ax.legend(loc="upper right")
+    ax.grid(True, axis="y", alpha=0.3)
+    ax.tick_params(axis="x", rotation=0)
+
+    plt.tight_layout()
+    return fig
+
+
+def plot_strategy_delta_bars(
+    baseline_results: Dict[str, Any],
+    comparison_results: Dict[str, Dict[str, Any]],
+    baseline_name: str = "random",
+    metric: str = "mean_tricks",
+    figsize: Tuple[int, int] = FIGSIZE_SINGLE_PLOT,
+    title: Optional[str] = None,
+) -> plt.Figure:
+    """Plot bar chart showing delta (strategy - baseline) for each strategy.
+
+    Args:
+        baseline_results: Result dict for baseline strategy (self-play)
+        comparison_results: Dict mapping strategy name to result dict.
+            Each result should be from (strategy vs baseline) matchup.
+        baseline_name: Name of baseline strategy for labeling
+        metric: Metric key to compare (default "mean_tricks")
+        figsize: Figure size tuple
+        title: Optional title override
+
+    Returns:
+        matplotlib Figure
+    """
+    apply_report_style()
+
+    baseline_val = baseline_results.get(metric, 5.0)
+
+    # Compute deltas
+    strategies = []
+    deltas = []
+    ci_lowers = []
+    ci_uppers = []
+    colors = []
+
+    for strategy_name, result in sorted(comparison_results.items()):
+        val = result.get(metric)
+        if val is None:
+            continue
+
+        delta = val - baseline_val
+        strategies.append(get_strategy_name(strategy_name))
+        deltas.append(delta)
+        colors.append(get_strategy_color(strategy_name))
+
+        # Try to get CI if available
+        ci_lower = result.get("ci_lower")
+        ci_upper = result.get("ci_upper")
+        if ci_lower is not None and ci_upper is not None:
+            ci_lowers.append(ci_lower - baseline_val)
+            ci_uppers.append(ci_upper - baseline_val)
+        else:
+            ci_lowers.append(None)
+            ci_uppers.append(None)
+
+    if not strategies:
+        fig, ax = plt.subplots(figsize=figsize)
+        ax.text(0.5, 0.5, "No comparison data provided", ha="center", va="center")
+        return fig
+
+    fig, ax = plt.subplots(figsize=figsize)
+
+    y_pos = np.arange(len(strategies))
+    bars = ax.barh(y_pos, deltas, color=colors, alpha=0.8)
+
+    # Add error bars if available
+    has_ci = all(l is not None for l in ci_lowers)
+    if has_ci:
+        xerr_lower = [d - l for d, l in zip(deltas, ci_lowers)]
+        xerr_upper = [u - d for d, u in zip(deltas, ci_uppers)]
+        ax.errorbar(
+            deltas,
+            y_pos,
+            xerr=[xerr_lower, xerr_upper],
+            fmt="none",
+            color="black",
+            capsize=3,
+        )
+
+    ax.axvline(0, color="black", linestyle="-", linewidth=1)
+    ax.set_yticks(y_pos)
+    ax.set_yticklabels(strategies)
+    ax.set_xlabel(f"Delta ({metric} - baseline)")
+    ax.set_ylabel("Strategy")
+    ax.set_title(
+        title or f"Strategy Performance vs {get_strategy_name(baseline_name)} Baseline"
+    )
+    ax.grid(True, axis="x", alpha=0.3)
+
+    # Annotate bars with values
+    for i, (bar, delta) in enumerate(zip(bars, deltas)):
+        x_pos = delta + 0.05 if delta >= 0 else delta - 0.05
+        ha = "left" if delta >= 0 else "right"
+        ax.text(x_pos, i, f"{delta:+.2f}", va="center", ha=ha, fontsize=9)
+
+    plt.tight_layout()
+    return fig
+
+
+def plot_self_play_control(
+    self_play_results: Dict[str, Dict[str, Any]],
+    expected_mean: float = 5.0,
+    figsize: Tuple[int, int] = FIGSIZE_SINGLE_PLOT,
+    title: Optional[str] = None,
+) -> plt.Figure:
+    """Plot control chart for self-play sanity check.
+
+    In self-play (strategy vs itself), each team should average ~5.0 tricks.
+    This chart flags strategies where the mean deviates significantly.
+
+    Args:
+        self_play_results: Dict mapping strategy name to result dict.
+            Each result should contain "mean_tricks" and optionally "ci_lower"/"ci_upper".
+        expected_mean: Expected mean tricks for fair self-play (default 5.0)
+        figsize: Figure size tuple
+        title: Optional title override
+
+    Returns:
+        matplotlib Figure
+    """
+    apply_report_style()
+
+    strategies = []
+    means = []
+    ci_lowers = []
+    ci_uppers = []
+    colors = []
+    warnings = []
+
+    for strategy_name, result in sorted(self_play_results.items()):
+        mean = result.get("mean_tricks")
+        if mean is None:
+            continue
+
+        strategies.append(get_strategy_name(strategy_name))
+        means.append(mean)
+        colors.append(get_strategy_color(strategy_name))
+
+        ci_lower = result.get("ci_lower", mean - 0.1)
+        ci_upper = result.get("ci_upper", mean + 0.1)
+        ci_lowers.append(ci_lower)
+        ci_uppers.append(ci_upper)
+
+        # Flag if expected mean is outside CI
+        is_warning = ci_lower > expected_mean or ci_upper < expected_mean
+        warnings.append(is_warning)
+
+    if not strategies:
+        fig, ax = plt.subplots(figsize=figsize)
+        ax.text(0.5, 0.5, "No self-play data provided", ha="center", va="center")
+        return fig
+
+    fig, ax = plt.subplots(figsize=figsize)
+
+    x_pos = np.arange(len(strategies))
+
+    # Plot points with error bars
+    for i, (x, m, lo, hi, c, warn) in enumerate(
+        zip(x_pos, means, ci_lowers, ci_uppers, colors, warnings)
+    ):
+        marker = "o" if not warn else "s"
+        edge_color = "red" if warn else c
+        ax.errorbar(
+            x,
+            m,
+            yerr=[[m - lo], [hi - m]],
+            fmt=marker,
+            color=c,
+            markeredgecolor=edge_color,
+            markeredgewidth=2 if warn else 1,
+            markersize=10,
+            capsize=5,
+            label=strategies[i] if warn else None,
+        )
+
+    # Reference line and acceptable region
+    ax.axhline(expected_mean, color="green", linestyle="-", linewidth=2, alpha=0.8)
+    ax.axhspan(expected_mean - 0.2, expected_mean + 0.2, color="green", alpha=0.1)
+
+    ax.set_xticks(x_pos)
+    ax.set_xticklabels(strategies, rotation=45, ha="right")
+    ax.set_xlabel("Strategy (Self-Play)")
+    ax.set_ylabel("Mean Tricks (Team 0)")
+    ax.set_title(title or "Self-Play Control Chart (Expected: 5.0 tricks)")
+    ax.grid(True, axis="y", alpha=0.3)
+
+    # Add warning annotation if any
+    if any(warnings):
+        warning_strats = [s for s, w in zip(strategies, warnings) if w]
+        ax.annotate(
+            f"Warning: {', '.join(warning_strats)}",
+            xy=(0.02, 0.98),
+            xycoords="axes fraction",
+            ha="left",
+            va="top",
+            fontsize=9,
+            color="red",
+            bbox=dict(boxstyle="round", facecolor="wheat", alpha=0.8),
+        )
+
+    plt.tight_layout()
+    return fig
+
+
+def plot_matchup_summary(
+    matchup_results: Dict[Tuple[str, str], Dict[str, Any]],
+    figsize: Tuple[int, int] = (16, 5),
+) -> plt.Figure:
+    """Create a 3-panel summary of matchup results.
+
+    Left: Win rate heatmap
+    Center: Trick distribution comparison
+    Right: Self-play control chart
+
+    Args:
+        matchup_results: Dict mapping (team0_name, team1_name) to result dict
+
+    Returns:
+        matplotlib Figure with 3 subplots
+    """
+    apply_report_style()
+
+    fig, axes = plt.subplots(1, 3, figsize=figsize)
+
+    # Panel 1: Win rate heatmap
+    ax = axes[0]
+    strategies = list(set(s for pair in matchup_results.keys() for s in pair))
+    n = len(strategies)
+
+    if n > 0:
+        matrix = np.full((n, n), np.nan)
+        strategy_idx = {s: i for i, s in enumerate(strategies)}
+
+        for (team0, team1), result in matchup_results.items():
+            i = strategy_idx.get(team0)
+            j = strategy_idx.get(team1)
+            if i is not None and j is not None:
+                val = result.get("win_rate")
+                if val is not None:
+                    matrix[i, j] = val
+
+        im = ax.imshow(matrix, cmap="RdYlGn", vmin=0, vmax=1, aspect="auto")
+        fig.colorbar(im, ax=ax, label="Win Rate", shrink=0.8)
+        labels = [get_strategy_name(s) for s in strategies]
+        ax.set_xticks(range(n))
+        ax.set_xticklabels(labels, rotation=45, ha="right")
+        ax.set_yticks(range(n))
+        ax.set_yticklabels(labels)
+        ax.set_title("Win Rate Heatmap")
+    else:
+        ax.text(0.5, 0.5, "No data", ha="center", va="center")
+
+    # Panel 2: Mean tricks comparison
+    ax = axes[1]
+    matchup_labels = []
+    mean_tricks = []
+
+    for (team0, team1), result in matchup_results.items():
+        label = f"{team0[:4]} v {team1[:4]}"
+        mean = result.get("mean_tricks")
+        if mean is not None:
+            matchup_labels.append(label)
+            mean_tricks.append(mean)
+
+    if mean_tricks:
+        ax.bar(range(len(mean_tricks)), mean_tricks)
+        ax.axhline(5.0, color="red", linestyle="--", label="Expected")
+        ax.set_xticks(range(len(mean_tricks)))
+        ax.set_xticklabels(matchup_labels, rotation=45, ha="right")
+        ax.set_ylabel("Mean Tricks (Team 0)")
+        ax.set_title("Mean Tricks by Matchup")
+        ax.legend()
+    else:
+        ax.text(0.5, 0.5, "No data", ha="center", va="center")
+
+    # Panel 3: Self-play subset
+    ax = axes[2]
+    self_play_data = {
+        team0: result
+        for (team0, team1), result in matchup_results.items()
+        if team0 == team1
+    }
+
+    if self_play_data:
+        strat_names = [get_strategy_name(s) for s in self_play_data.keys()]
+        means = [r.get("mean_tricks", 5.0) for r in self_play_data.values()]
+        colors = [get_strategy_color(s) for s in self_play_data.keys()]
+
+        ax.bar(range(len(means)), means, color=colors)
+        ax.axhline(5.0, color="green", linestyle="-", linewidth=2)
+        ax.axhspan(4.8, 5.2, color="green", alpha=0.1)
+        ax.set_xticks(range(len(means)))
+        ax.set_xticklabels(strat_names, rotation=45, ha="right")
+        ax.set_ylabel("Mean Tricks")
+        ax.set_title("Self-Play Control")
+    else:
+        ax.text(0.5, 0.5, "No self-play data", ha="center", va="center")
+
+    fig.suptitle("Strategy Matchup Summary", fontsize=14, y=1.02)
+    plt.tight_layout()
+    return fig


### PR DESCRIPTION
## Summary
- Add 3 outcome evaluation chart functions to `charts.py`
- Create new `strategy_charts.py` module with 5 strategy comparison charts
- Enhance charts reference notebook with Parts 3 (Outcome Evaluation) and 4 (Strategy Comparison)

## Why
The charts reference notebook needed visualization tools for:
1. Correlating hand features with actual outcomes (`tricks_won`) from simulations
2. Comparing strategy performance in head-to-head and self-play matchups

## Repro / Validation
```bash
make check  # passes (696 tests)

# Open notebook and run all cells
jupyter lab notebooks/sandbox/00_charts_reference.ipynb
```

## Tests
- [x] `make check` passes
- [x] Notebook cells execute without errors
- [x] New chart functions render correctly

## Worktree proof
```
pwd: /Users/Quentin/Projects/bid-euchre
git rev-parse --show-toplevel: /Users/Quentin/Projects/bid-euchre
git worktree list: /Users/Quentin/Projects/bid-euchre
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)