### PR TITLE
docs: update diagnostics README and add CDF/CCDF charts

### DIFF
--- a/notebooks/diagnostics/README.md
+++ b/notebooks/diagnostics/README.md
@@ -6,9 +6,9 @@ Interactive diagnostic notebook for analyzing bidless simulation datasets.
 
 1. **Generate a dataset** (if you don't have one):
    ```bash
-   PYTHONPATH=src python scripts/collect_bidless_dataset.py \
+   PYTHONPATH=src python experiments/run_experiment.py \
      --config experiments/configs/bidless_dataset_collection.yaml \
-     --seed 42 --n-per 1000
+     --seed 42 --n_per 1000 --emit-bidless-dataset
    ```
 
 2. **Open the notebook**:

--- a/src/bid_euchre/diagnostics/__init__.py
+++ b/src/bid_euchre/diagnostics/__init__.py
@@ -11,6 +11,8 @@ The design philosophy is: logic lives here, notebooks are thin orchestration.
 """
 
 from .charts import (
+    plot_ccdf,
+    plot_cdf,
     plot_feature_correlation,
     plot_feature_distributions,
     plot_feature_outcome_correlation,
@@ -44,6 +46,9 @@ __all__ = [
     "plot_feature_distributions",
     "plot_feature_correlation",
     "plot_rolling_mean",
+    # Charts - Distribution Analysis
+    "plot_cdf",
+    "plot_ccdf",
     # Charts - Outcome Evaluation
     "plot_feature_vs_outcome",
     "plot_outcome_distributions",

--- a/src/bid_euchre/diagnostics/charts.py
+++ b/src/bid_euchre/diagnostics/charts.py
@@ -597,3 +597,151 @@ def plot_feature_outcome_correlation(
 
     plt.tight_layout()
     return fig
+
+
+def plot_cdf(
+    df: pd.DataFrame,
+    column: str = "feat_hand_value",
+    figsize: Tuple[int, int] = (10, 6),
+    title: Optional[str] = None,
+    group_by: Optional[str] = None,
+) -> plt.Figure:
+    """Plot empirical CDF (Cumulative Distribution Function).
+
+    Shows the probability that a value is ≤ x for each x in the data.
+    Useful for understanding distribution shape and comparing subgroups.
+
+    Args:
+        df: DataFrame with column to analyze
+        column: Column name to plot CDF for
+        figsize: Figure size tuple
+        title: Optional title override
+        group_by: Optional column to group by (creates overlaid CDFs)
+
+    Returns:
+        matplotlib Figure
+    """
+    fig, ax = plt.subplots(figsize=figsize)
+
+    if column not in df.columns:
+        ax.text(0.5, 0.5, f"Column '{column}' not found",
+                ha="center", va="center", transform=ax.transAxes)
+        return fig
+
+    if group_by is not None and group_by in df.columns:
+        # Plot CDF for each group
+        groups = sorted(df[group_by].unique())
+        colors = plt.cm.tab10(np.linspace(0, 1, len(groups)))
+
+        for group, color in zip(groups, colors):
+            values = df[df[group_by] == group][column].dropna().sort_values()
+            if len(values) == 0:
+                continue
+            y = np.arange(1, len(values) + 1) / len(values)
+            ax.plot(values, y, label=str(group), color=color, linewidth=1.5)
+
+        ax.legend(title=group_by)
+    else:
+        # Single CDF
+        values = df[column].dropna().sort_values()
+        if len(values) == 0:
+            ax.text(0.5, 0.5, "No data to plot", ha="center", va="center", transform=ax.transAxes)
+            return fig
+
+        y = np.arange(1, len(values) + 1) / len(values)
+        ax.plot(values, y, color="#3498db", linewidth=2)
+
+        # Add reference lines at quartiles
+        for q, ls in [(0.25, ":"), (0.5, "--"), (0.75, ":")]:
+            q_val = values.quantile(q)
+            ax.axhline(q, color="gray", linestyle=ls, alpha=0.5)
+            ax.axvline(q_val, color="gray", linestyle=ls, alpha=0.5)
+
+    ax.set_xlabel(column.replace("feat_", "").replace("_", " ").title())
+    ax.set_ylabel("Cumulative Probability")
+    ax.set_title(title or f"Empirical CDF of {column.replace('feat_', '')}")
+    ax.set_ylim(0, 1)
+    ax.grid(True, alpha=0.3)
+
+    plt.tight_layout()
+    return fig
+
+
+def plot_ccdf(
+    df: pd.DataFrame,
+    column: str = "feat_hand_value",
+    figsize: Tuple[int, int] = (10, 6),
+    log_scale: bool = True,
+    title: Optional[str] = None,
+    group_by: Optional[str] = None,
+) -> plt.Figure:
+    """Plot empirical CCDF (Complementary CDF) for tail risk analysis.
+
+    Shows the probability that a value is > x for each x in the data.
+    CCDF = 1 - CDF. Log scale is useful for visualizing heavy tails.
+
+    This is particularly useful for:
+    - Identifying rare but impactful high-value hands
+    - Comparing tail behavior across contract types
+    - Detecting power-law or exponential tail distributions
+
+    Args:
+        df: DataFrame with column to analyze
+        column: Column name to plot CCDF for
+        figsize: Figure size tuple
+        log_scale: Whether to use log scale for y-axis (default True)
+        title: Optional title override
+        group_by: Optional column to group by (creates overlaid CCDFs)
+
+    Returns:
+        matplotlib Figure
+    """
+    fig, ax = plt.subplots(figsize=figsize)
+
+    if column not in df.columns:
+        ax.text(0.5, 0.5, f"Column '{column}' not found",
+                ha="center", va="center", transform=ax.transAxes)
+        return fig
+
+    if group_by is not None and group_by in df.columns:
+        # Plot CCDF for each group
+        groups = sorted(df[group_by].unique())
+        colors = plt.cm.tab10(np.linspace(0, 1, len(groups)))
+
+        for group, color in zip(groups, colors):
+            values = df[df[group_by] == group][column].dropna().sort_values()
+            if len(values) == 0:
+                continue
+            # CCDF = 1 - CDF = P(X > x)
+            ccdf = 1 - np.arange(1, len(values) + 1) / len(values)
+            # Filter out zeros for log scale
+            mask = ccdf > 0
+            ax.plot(values[mask], ccdf[mask], label=str(group), color=color, linewidth=1.5)
+
+        ax.legend(title=group_by)
+    else:
+        # Single CCDF
+        values = df[column].dropna().sort_values()
+        if len(values) == 0:
+            ax.text(0.5, 0.5, "No data to plot", ha="center", va="center", transform=ax.transAxes)
+            return fig
+
+        ccdf = 1 - np.arange(1, len(values) + 1) / len(values)
+        # Filter out zeros for log scale
+        mask = ccdf > 0
+        ax.plot(values[mask], ccdf[mask], color="#e74c3c", linewidth=2)
+
+    ax.set_xlabel(column.replace("feat_", "").replace("_", " ").title())
+    ax.set_ylabel("P(X > x)")
+    ax.set_title(title or f"CCDF of {column.replace('feat_', '')} (Tail Distribution)")
+
+    if log_scale:
+        ax.set_yscale("log")
+        ax.set_ylim(1e-4, 1)
+    else:
+        ax.set_ylim(0, 1)
+
+    ax.grid(True, alpha=0.3, which="both")
+
+    plt.tight_layout()
+    return fig

--- a/tests/unit/test_diagnostics_charts.py
+++ b/tests/unit/test_diagnostics_charts.py
@@ -1,0 +1,119 @@
+"""Unit tests for diagnostics chart functions."""
+
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+
+matplotlib.use("Agg")  # Non-interactive backend for testing
+
+from bid_euchre.diagnostics import plot_ccdf, plot_cdf
+
+
+class TestPlotCdf:
+    """Tests for plot_cdf function."""
+
+    @pytest.fixture
+    def sample_df(self):
+        """Create a sample DataFrame for testing."""
+        np.random.seed(42)
+        return pd.DataFrame({
+            "feat_hand_value": np.random.randn(100) * 10 + 50,
+            "contract_type": np.random.choice(["suit", "high", "low"], 100),
+        })
+
+    def test_cdf_returns_figure(self, sample_df):
+        """plot_cdf returns a matplotlib Figure."""
+        fig = plot_cdf(sample_df, column="feat_hand_value")
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_cdf_handles_missing_column(self, sample_df):
+        """plot_cdf handles missing column gracefully."""
+        fig = plot_cdf(sample_df, column="nonexistent_column")
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_cdf_with_group_by(self, sample_df):
+        """plot_cdf works with group_by parameter."""
+        fig = plot_cdf(sample_df, column="feat_hand_value", group_by="contract_type")
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_cdf_with_custom_title(self, sample_df):
+        """plot_cdf respects custom title."""
+        custom_title = "Custom CDF Title"
+        fig = plot_cdf(sample_df, column="feat_hand_value", title=custom_title)
+        assert isinstance(fig, plt.Figure)
+        # Check that title was set
+        ax = fig.axes[0]
+        assert ax.get_title() == custom_title
+        plt.close(fig)
+
+    def test_cdf_empty_data(self):
+        """plot_cdf handles empty DataFrame."""
+        empty_df = pd.DataFrame({"feat_hand_value": []})
+        fig = plot_cdf(empty_df, column="feat_hand_value")
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+
+class TestPlotCcdf:
+    """Tests for plot_ccdf function."""
+
+    @pytest.fixture
+    def sample_df(self):
+        """Create a sample DataFrame for testing."""
+        np.random.seed(42)
+        return pd.DataFrame({
+            "feat_hand_value": np.random.randn(100) * 10 + 50,
+            "contract_type": np.random.choice(["suit", "high", "low"], 100),
+        })
+
+    def test_ccdf_returns_figure(self, sample_df):
+        """plot_ccdf returns a matplotlib Figure."""
+        fig = plot_ccdf(sample_df, column="feat_hand_value")
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_ccdf_handles_missing_column(self, sample_df):
+        """plot_ccdf handles missing column gracefully."""
+        fig = plot_ccdf(sample_df, column="nonexistent_column")
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_ccdf_with_group_by(self, sample_df):
+        """plot_ccdf works with group_by parameter."""
+        fig = plot_ccdf(sample_df, column="feat_hand_value", group_by="contract_type")
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_ccdf_log_scale_default(self, sample_df):
+        """plot_ccdf uses log scale by default."""
+        fig = plot_ccdf(sample_df, column="feat_hand_value")
+        ax = fig.axes[0]
+        assert ax.get_yscale() == "log"
+        plt.close(fig)
+
+    def test_ccdf_linear_scale(self, sample_df):
+        """plot_ccdf respects log_scale=False."""
+        fig = plot_ccdf(sample_df, column="feat_hand_value", log_scale=False)
+        ax = fig.axes[0]
+        assert ax.get_yscale() == "linear"
+        plt.close(fig)
+
+    def test_ccdf_with_custom_title(self, sample_df):
+        """plot_ccdf respects custom title."""
+        custom_title = "Custom CCDF Title"
+        fig = plot_ccdf(sample_df, column="feat_hand_value", title=custom_title)
+        ax = fig.axes[0]
+        assert ax.get_title() == custom_title
+        plt.close(fig)
+
+    def test_ccdf_empty_data(self):
+        """plot_ccdf handles empty DataFrame."""
+        empty_df = pd.DataFrame({"feat_hand_value": []})
+        fig = plot_ccdf(empty_df, column="feat_hand_value")
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)


### PR DESCRIPTION
## Summary
- Update `notebooks/diagnostics/README.md` to use `run_experiment.py --emit-bidless-dataset` instead of deleted `collect_bidless_dataset.py` script
- Add `plot_cdf()` and `plot_ccdf()` chart functions for distribution analysis
- Add 12 unit tests for new chart functions

## Why
PR 3 of the hooks architecture implementation plan. The previous PR (PR 2) deleted `scripts/collect_bidless_dataset.py`, so the diagnostics README needed updating. The CDF/CCDF charts provide useful distribution visualizations for analyzing bidless datasets.

## Changes
| File | Change |
|------|--------|
| `notebooks/diagnostics/README.md` | Fix Quick Start commands |
| `src/bid_euchre/diagnostics/charts.py` | Add `plot_cdf()`, `plot_ccdf()` |
| `src/bid_euchre/diagnostics/__init__.py` | Export new functions |
| `tests/unit/test_diagnostics_charts.py` | **NEW** — 12 unit tests |

## Repro / Validation
```bash
make check  # All 711 tests pass
```

## Tests
- `make check` — repo-lint + ruff + pytest
- 12 new unit tests in `tests/unit/test_diagnostics_charts.py`

## Worktree proof
```
pwd: /Users/Quentin/Projects/bid-euchre
git rev-parse --show-toplevel: /Users/Quentin/Projects/bid-euchre
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)