### PR TITLE
docs: expand CLAUDE.md with additional core docs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,17 +4,25 @@ This file is the entrypoint for Claude Code sessions. It imports the authoritati
 
 ## Imported Docs (Authoritative Sources)
 
-### Agent Workflow & Boundaries
-@docs/02_agent/AGENTS.md
-@docs/02_agent/AI_BOUNDARIES.md
-@docs/02_agent/QUALITY_BAR.md
-@docs/02_agent/REVIEW_CHECKLIST.md
+### Architecture & Execution
+@docs/01_core/ARCHITECTURE.md
+@docs/01_core/EXPERIMENTS.md
 
 ### Core Contracts
+@docs/01_core/RULES.md
 @docs/01_core/REPRODUCIBILITY.md
 @docs/01_core/DATA_CONTRACT.md
 @docs/01_core/METRICS.md
-@docs/01_core/RULES.md
+@docs/01_core/SCORING.md
+
+### Validation & Quality
+@docs/01_core/DRIFT.md
+@docs/02_agent/QUALITY_BAR.md
+@docs/02_agent/REVIEW_CHECKLIST.md
+
+### Agent Workflow
+@docs/02_agent/AGENTS.md
+@docs/02_agent/AI_BOUNDARIES.md
 
 ### PR Requirements
 @.github/pull_request_template.md
@@ -29,6 +37,7 @@ make help     # see all targets
 
 **Key constraints:**
 - Seed required for experiments: `--seed <int>`
+- Canonical runner: `experiments/run_experiment.py` (see @docs/01_core/EXPERIMENTS.md)
 - No commits to `data/runs/`, `data/reports/`, `data/models/`
 - One concept per PR; use PR template
 


### PR DESCRIPTION
## Summary
- Added ARCHITECTURE.md and EXPERIMENTS.md references for codebase structure guidance
- Added SCORING.md and DRIFT.md as core contract documents
- Reorganized imported docs into clearer sections (Architecture & Execution, Core Contracts, Validation & Quality, Agent Workflow)
- Added canonical runner reference in Quick Reference section

## Why
The repo review (REPO_REVIEW_2026_01_27.md) identified documentation drift as a gap. Several important documents exist but weren't referenced in CLAUDE.md:
- ARCHITECTURE.md defines critical module boundaries (e.g., "src/ must NOT import from experiments/")
- SCORING.md is a contract specification alongside RULES.md and DATA_CONTRACT.md
- DRIFT.md and EXPERIMENTS.md provide essential context for validation and execution

This update ensures AI assistants have access to all authoritative sources.

## Repro / Validation
Documentation-only change. Verified file references exist:
```bash
ls docs/01_core/ARCHITECTURE.md docs/01_core/EXPERIMENTS.md docs/01_core/SCORING.md docs/01_core/DRIFT.md
```

## Tests
- Repo linter: ✅ Passed
- Ruff: ✅ Passed
- Pre-commit hooks: ✅ Passed

## Worktree proof
```
pwd: /Users/Quentin/Projects/bid-euchre-update-claude-md
git rev-parse --show-toplevel: /Users/Quentin/Projects/bid-euchre-update-claude-md
git worktree list:
  /Users/Quentin/Projects/bid-euchre                   146ac63 [main]
  /Users/Quentin/Projects/bid-euchre-update-claude-md  900402c [docs/update-claude-md]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)