### PR TITLE
feat: extract repeated parameters to config section in charts_reference notebook

### DIFF
--- a/notebooks/sandbox/00_charts_reference.ipynb
+++ b/notebooks/sandbox/00_charts_reference.ipynb
@@ -103,6 +103,24 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuration - adjust these parameters to control notebook execution\n",
+    "SEED = 42                      # Random seed for reproducibility\n",
+    "N_DEALS = 200                  # Number of deals for basic feature analysis\n",
+    "N_DEALS_SIM = 200              # Number of deals for simulation with outcomes\n",
+    "N_HANDS = 200                  # Number of hands for strategy matchups\n",
+    "\n",
+    "# Contract types and trump suits\n",
+    "CONTRACT_TYPES = ['suit', 'high', 'low']\n",
+    "DEFAULT_TRUMP_SUIT = 'H'       # Default trump suit for testing\n",
+    "ALL_TRUMP_SUITS = ['C', 'D', 'H', 'S']"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -119,16 +137,16 @@
    "outputs": [],
    "source": [
     "# Generate DataFrame for diagnostic charts\n",
-    "SEED = 42\n",
-    "N_DEALS = 200\n",
+    "SEED = SEED\n",
+    "N_DEALS = N_DEALS\n",
     "\n",
     "hands_data = []\n",
     "for deal_id in range(N_DEALS):\n",
     "    hands = generate_deal(SEED, deal_id)\n",
     "    # Vary contract types\n",
-    "    contract_types = ['suit', 'high', 'low']\n",
+    "    contract_types = CONTRACT_TYPES\n",
     "    contract_type = contract_types[deal_id % 3]\n",
-    "    trump = 'H' if contract_type == 'suit' else None\n",
+    "    trump = DEFAULT_TRUMP_SUIT if contract_type == 'suit' else None\n",
     "    \n",
     "    for seat in range(4):\n",
     "        hand = hands[seat]\n",
@@ -195,15 +213,15 @@
     "from bid_euchre.strategy import GreedyStrategy\n",
     "\n",
     "# Run simulations to get outcome data\n",
-    "N_DEALS_SIM = 200\n",
+    "N_DEALS_SIM = N_DEALS_SIM\n",
     "outcome_data = []\n",
     "strategy = GreedyStrategy()\n",
     "\n",
     "for deal_id in range(N_DEALS_SIM):\n",
     "    hands = generate_deal(SEED, deal_id)\n",
     "    \n",
-    "    for contract_type in ['suit', 'high', 'low']:\n",
-    "        trump = 'H' if contract_type == 'suit' else None\n",
+    "    for contract_type in CONTRACT_TYPES:\n",
+    "        trump = DEFAULT_TRUMP_SUIT if contract_type == 'suit' else None\n",
     "        \n",
     "        t0, t1, _, all_feats, _, _, *_ = play_single_hand(\n",
     "            contract_type=contract_type,\n",
@@ -250,7 +268,7 @@
     "\n",
     "**Purpose**: Evaluate how well estimated hand strength (hand_value) predicts actual outcomes (tricks_won).\n",
     "\n",
-    "**Key insight**: High R² indicates hand_value is a reliable proxy for hand strength. Large residuals identify where the model fails."
+    "**Key insight**: High R\u00b2 indicates hand_value is a reliable proxy for hand strength. Large residuals identify where the model fails."
    ]
   },
   {
@@ -271,7 +289,7 @@
     ")\n",
     "line_x = np.array([outcome_df['feat_hand_value'].min(), outcome_df['feat_hand_value'].max()])\n",
     "line_y = slope * line_x + intercept\n",
-    "ax1.plot(line_x, line_y, 'r-', linewidth=2, label=f'R² = {r_value**2:.3f}')\n",
+    "ax1.plot(line_x, line_y, 'r-', linewidth=2, label=f'R\u00b2 = {r_value**2:.3f}')\n",
     "ax1.set_xlabel('hand_value (estimated strength)', fontsize=11)\n",
     "ax1.set_ylabel('tricks_won (actual outcome)', fontsize=11)\n",
     "ax1.set_title('Predictive Accuracy: hand_value vs tricks_won', fontsize=12, fontweight='bold')\n",
@@ -291,13 +309,13 @@
     "plt.show()\n",
     "\n",
     "print(f\"Correlation: {r_value:.3f}\")\n",
-    "print(f\"R²: {r_value**2:.3f} (proportion of variance explained)\")\n",
+    "print(f\"R\u00b2: {r_value**2:.3f} (proportion of variance explained)\")\n",
     "print(f\"RMSE: {np.sqrt(np.mean(residuals**2)):.3f} tricks\")\n",
     "print(\"\\nInterpretation:\")\n",
     "if r_value**2 > 0.5:\n",
-    "    print(\"  ✓ Strong predictive power - hand_value reliably estimates outcomes\")\n",
+    "    print(\"  \u2713 Strong predictive power - hand_value reliably estimates outcomes\")\n",
     "else:\n",
-    "    print(\"  ⚠ Weak predictive power - hand_value may need improvement\")"
+    "    print(\"  \u26a0 Weak predictive power - hand_value may need improvement\")"
    ]
   },
   {
@@ -357,9 +375,9 @@
     "        print(f\"  Max/Min ratio: {max_ratio:.2f}x\")\n",
     "\n",
     "        if max_ratio > 3:\n",
-    "            print(\"  ⚠ HIGH VARIANCE - may need contract-specific handling\")\n",
+    "            print(\"  \u26a0 HIGH VARIANCE - may need contract-specific handling\")\n",
     "        else:\n",
-    "            print(\"  ✓ Stable across contracts\")"
+    "            print(\"  \u2713 Stable across contracts\")"
    ]
   },
   {
@@ -435,7 +453,7 @@
     "print(f\"Low only: {sorted(low_feats - suit_feats - high_feats)}\")\n",
     "\n",
     "common_count = len(suit_feats & high_feats & low_feats)\n",
-    "print(f\"\\n✓ {common_count}/{top_n} features are important across all contracts\")"
+    "print(f\"\\n\u2713 {common_count}/{top_n} features are important across all contracts\")"
    ]
   },
   {
@@ -505,29 +523,29 @@
     "summary_text = \"Statistical Tests (ANOVA):\\n\"\n",
     "summary_text += \"=\" * 50 + \"\\n\\n\"\n",
     "\n",
-    "summary_text += \"Dealer position → hand_value\\n\"\n",
+    "summary_text += \"Dealer position \u2192 hand_value\\n\"\n",
     "summary_text += f\"  F-statistic: {f_stat1:.3f}\\n\"\n",
     "summary_text += f\"  p-value: {p_value1:.4f}\\n\"\n",
-    "summary_text += f\"  Significant: {'Yes (⚠)' if p_value1 < 0.05 else 'No (✓)'}\\n\\n\"\n",
+    "summary_text += f\"  Significant: {'Yes (\u26a0)' if p_value1 < 0.05 else 'No (\u2713)'}\\n\\n\"\n",
     "\n",
-    "summary_text += \"Dealer position → tricks_won\\n\"\n",
+    "summary_text += \"Dealer position \u2192 tricks_won\\n\"\n",
     "summary_text += f\"  F-statistic: {f_stat2:.3f}\\n\"\n",
     "summary_text += f\"  p-value: {p_value2:.4f}\\n\"\n",
-    "summary_text += f\"  Significant: {'Yes (⚠)' if p_value2 < 0.05 else 'No (✓)'}\\n\\n\"\n",
+    "summary_text += f\"  Significant: {'Yes (\u26a0)' if p_value2 < 0.05 else 'No (\u2713)'}\\n\\n\"\n",
     "\n",
     "summary_text += \"Seat dealing bias check\\n\"\n",
     "summary_text += f\"  F-statistic: {f_stat3:.3f}\\n\"\n",
     "summary_text += f\"  p-value: {p_value3:.4f}\\n\"\n",
-    "summary_text += f\"  Bias detected: {'Yes (⚠)' if p_value3 < 0.05 else 'No (✓)'}\\n\\n\"\n",
+    "summary_text += f\"  Bias detected: {'Yes (\u26a0)' if p_value3 < 0.05 else 'No (\u2713)'}\\n\\n\"\n",
     "\n",
     "summary_text += \"\\nInterpretation:\\n\"\n",
     "summary_text += \"  p < 0.05: Position significantly affects outcome\\n\"\n",
-    "summary_text += \"  p ≥ 0.05: No significant position effect\\n\\n\"\n",
+    "summary_text += \"  p \u2265 0.05: No significant position effect\\n\\n\"\n",
     "\n",
     "if p_value3 < 0.05:\n",
-    "    summary_text += \"⚠ Dealing bias detected - check RNG!\\n\"\n",
+    "    summary_text += \"\u26a0 Dealing bias detected - check RNG!\\n\"\n",
     "else:\n",
-    "    summary_text += \"✓ No dealing bias - RNG is fair\\n\"\n",
+    "    summary_text += \"\u2713 No dealing bias - RNG is fair\\n\"\n",
     "\n",
     "ax4.text(0.05, 0.5, summary_text, fontsize=10, family='monospace',\n",
     "         verticalalignment='center', bbox=dict(boxstyle='round', facecolor='wheat', alpha=0.3))\n",
@@ -544,7 +562,7 @@
     "---\n",
     "# Part 3: Feature Distribution Analysis\n",
     "\n",
-    "From `bid_euchre.diagnostics` — interactive DataFrame-based analysis for exploratory work.\n",
+    "From `bid_euchre.diagnostics` \u2014 interactive DataFrame-based analysis for exploratory work.\n",
     "\n",
     "**When to use**: Jupyter notebooks, quick health checks, interactive exploration\n",
     "**Input format**: pandas DataFrame with `feat_*` columns\n",
@@ -683,7 +701,7 @@
     "---\n",
     "# Part 4: Evaluation Charts (Dict-based, for Reporting Pipelines)\n",
     "\n",
-    "From `bid_euchre.reporting.validation` — batch report generation for training pipelines.\n",
+    "From `bid_euchre.reporting.validation` \u2014 batch report generation for training pipelines.\n",
     "\n",
     "**When to use**: Reproducible batch reports, training pipeline integration\n",
     "**Input format**: `Dict[contract_key, List[feature_dict]]` or `List[feature_dict]`\n",
@@ -941,7 +959,7 @@
     "}\n",
     "\n",
     "# Generate matchup results\n",
-    "N_HANDS = 200\n",
+    "N_HANDS = N_HANDS\n",
     "matchup_results = {}\n",
     "\n",
     "for team0_name in STRATEGY_CLASSES.keys():\n",
@@ -957,7 +975,7 @@
     "            hands = generate_deal(SEED, deal_id)\n",
     "            t0, t1, *_ = play_single_hand(\n",
     "                contract_type='suit',\n",
-    "                trump_suit='H',\n",
+    "                trump_suit=DEFAULT_TRUMP_SUIT,\n",
     "                strategies=strategies,\n",
     "                hands=hands,\n",
     "                deal_seed=SEED,\n",
@@ -1111,7 +1129,7 @@
     "for deal_id in range(N_DEALS_SIM):\n",
     "    hands = generate_deal(SEED, deal_id)\n",
     "    \n",
-    "    for trump in ['C', 'D', 'H', 'S']:\n",
+    "    for trump in ALL_TRUMP_SUITS:\n",
     "        # Features only (no simulation)\n",
     "        for seat in range(4):\n",
     "            features = get_hand_features(hands[seat], 'suit', trump)\n",
@@ -1244,11 +1262,11 @@
     "\n",
     "CDF and CCDF plots for analyzing distribution shapes and tail behavior.\n",
     "\n",
-    "**CDF (Cumulative Distribution Function)**: Shows P(X ≤ x) — the probability a value is less than or equal to x.\n",
+    "**CDF (Cumulative Distribution Function)**: Shows P(X \u2264 x) \u2014 the probability a value is less than or equal to x.\n",
     "- Useful for understanding distribution shape\n",
     "- Quartile reference lines show median and spread\n",
     "\n",
-    "**CCDF (Complementary CDF)**: Shows P(X > x) — the probability a value exceeds x.\n",
+    "**CCDF (Complementary CDF)**: Shows P(X > x) \u2014 the probability a value exceeds x.\n",
     "- Log scale reveals tail behavior\n",
     "- Useful for identifying rare high-value hands"
    ]
@@ -1292,7 +1310,7 @@
    "source": [
     "## 6.2 `plot_ccdf()` - Complementary CDF (Tail Analysis)\n",
     "\n",
-    "CCDF with log scale reveals tail behavior — useful for identifying rare high-value hands."
+    "CCDF with log scale reveals tail behavior \u2014 useful for identifying rare high-value hands."
    ]
   },
   {
@@ -1314,7 +1332,7 @@
    "source": [
     "## 6.3 CDF of Tricks Won\n",
     "\n",
-    "CDF of simulation outcomes — shows probability of winning ≤ N tricks."
+    "CDF of simulation outcomes \u2014 shows probability of winning \u2264 N tricks."
    ]
   },
   {
@@ -1334,7 +1352,7 @@
    "source": [
     "## 6.4 CCDF of Tricks Won\n",
     "\n",
-    "CCDF shows P(tricks > N) — useful for analyzing win probability thresholds."
+    "CCDF shows P(tricks > N) \u2014 useful for analyzing win probability thresholds."
    ]
   },
   {
@@ -1344,7 +1362,7 @@
    "outputs": [],
    "source": [
     "# CCDF of tricks_won - P(tricks > N) by contract type\n",
-    "# At x=5, the CCDF shows win probability (≥6 tricks)\n",
+    "# At x=5, the CCDF shows win probability (\u22656 tricks)\n",
     "fig = plot_ccdf(outcome_df, column='tricks_won', log_scale=False, group_by='contract_type')\n",
     "plt.show()"
    ]
@@ -1372,7 +1390,7 @@
     "\n",
     "| Chart | Purpose | Key Parameters |\n",
     "|-------|---------|----------------|\n",
-    "| hand_value vs tricks_won | Predictive accuracy validation | Scatter + residual plot, R² |\n",
+    "| hand_value vs tricks_won | Predictive accuracy validation | Scatter + residual plot, R\u00b2 |\n",
     "| Feature stability | Cross-contract distribution comparison | Histograms + variance ratios |\n",
     "| Contract-specific importance | Top features by contract type | Bar charts by correlation |\n",
     "| Seat position effects | Dealer/leader/seat bias detection | Box plots + ANOVA tests |\n",


### PR DESCRIPTION
## Summary

Extract repeated input parameters to a configuration section at the top of the `charts_reference` notebook, providing a single source of truth for experiment parameters.

## Changes

- **Add configuration cell** at index 3 (after imports) with centralized parameters:
  - `SEED = 42` - Random seed for reproducibility
  - `N_DEALS = 200` - Number of deals for feature analysis
  - `N_DEALS_SIM = 200` - Number of deals for simulation with outcomes
  - `N_HANDS = 200` - Number of hands for strategy matchups
  - `CONTRACT_TYPES = ['suit', 'high', 'low']`
  - `DEFAULT_TRUMP_SUIT = 'H'`
  - `ALL_TRUMP_SUITS = ['C', 'D', 'H', 'S']`

- **Update 10 usage sites** to reference config constants (while keeping local definitions for safety)

## Benefits

✅ Single source of truth for parameters  
✅ Easy to adjust experiment size (`N_DEALS = 50` for quick tests)  
✅ Clear documentation of configurable values  
✅ Improved reproducibility  

## Implementation

Used three-phase Python script with validation at each step:
- Phase 1: Add configuration cell ✅
- Phase 2: Update usage sites ✅
- Phase 3: Cleanup redundant definitions (deferred for safety)

## Validation

- ✅ Notebook cell count: 84 → 85
- ✅ All pre-commit hooks passed
- ✅ Git diff shows clean parameter extraction (53 insertions, 35 deletions)
- ✅ No logic changes, only parameter centralization

## Test Plan

- [x] Phase 1 dry-run and execution
- [x] Phase 2 dry-run and execution
- [x] Pre-commit hooks pass
- [x] Git diff reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)