### PR TITLE
chore: move deprecated Phase 0 notebooks to archive instead of deleting

### DIFF
--- a/notebooks/.archive/00_charts_reference.ipynb
+++ b/notebooks/.archive/00_charts_reference.ipynb
@@ -1,0 +1,54 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Bidless Dataset Diagnostics - Reference Implementation - MOVED\n",
+    "\n",
+    "\u26a0\ufe0f **This notebook has been reorganized into the Phase 0 bidless analysis suite.**\n",
+    "\n",
+    "**New location:** `notebooks/phase0_bidless/20_charts_reference.ipynb`\n",
+    "\n",
+    "## Migration Guide\n",
+    "\n",
+    "| Old Location | New Location | Purpose |\n",
+    "|--------------|--------------|---------||\n",
+    "| `notebooks/diagnostics/bidless_diagnostics.ipynb` | `notebooks/phase0_bidless/10_health_checks.ipynb` | Quick dataset validation |\n",
+    "| `notebooks/sandbox/00_charts_reference.ipynb` | `notebooks/phase0_bidless/20_charts_reference.ipynb` | Comprehensive reference |\n",
+    "| `notebooks/sandbox/00_starter_b0_exploration.ipynb` | `notebooks/phase0_bidless/30_model_dev_and_eval.ipynb` | Exploratory template |\n",
+    "\n",
+    "See the [Phase 0 README](../phase0_bidless/README.md) for the full suite.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Deprecation timeline:** This stub will be removed after 2026-03-01."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raise RuntimeError(\n",
+    "    \"This notebook has been moved to notebooks/phase0_bidless/.\\n\"\n",
+    "    \"See the markdown cell above for the new location.\"\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.8.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/.archive/00_starter_b0_exploration.ipynb
+++ b/notebooks/.archive/00_starter_b0_exploration.ipynb
@@ -1,0 +1,54 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# B0 Feature Exploration Starter - MOVED\n",
+    "\n",
+    "\u26a0\ufe0f **This notebook has been reorganized into the Phase 0 bidless analysis suite.**\n",
+    "\n",
+    "**New location:** `notebooks/phase0_bidless/30_model_dev_and_eval.ipynb`\n",
+    "\n",
+    "## Migration Guide\n",
+    "\n",
+    "| Old Location | New Location | Purpose |\n",
+    "|--------------|--------------|---------||\n",
+    "| `notebooks/diagnostics/bidless_diagnostics.ipynb` | `notebooks/phase0_bidless/10_health_checks.ipynb` | Quick dataset validation |\n",
+    "| `notebooks/sandbox/00_charts_reference.ipynb` | `notebooks/phase0_bidless/20_charts_reference.ipynb` | Comprehensive reference |\n",
+    "| `notebooks/sandbox/00_starter_b0_exploration.ipynb` | `notebooks/phase0_bidless/30_model_dev_and_eval.ipynb` | Exploratory template |\n",
+    "\n",
+    "See the [Phase 0 README](../phase0_bidless/README.md) for the full suite.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Deprecation timeline:** This stub will be removed after 2026-03-01."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raise RuntimeError(\n",
+    "    \"This notebook has been moved to notebooks/phase0_bidless/.\\n\"\n",
+    "    \"See the markdown cell above for the new location.\"\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.8.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/.archive/README.md
+++ b/notebooks/.archive/README.md
@@ -1,0 +1,28 @@
+# Archived Notebooks
+
+This directory contains deprecated Phase 0 notebook stubs that were replaced by the consolidated `notebooks/phase0_bidless/` structure.
+
+## Archived Files
+
+**From diagnostics/ (deprecated stubs):**
+- `diagnostics/bidless_diagnostics.ipynb` - Stub pointing to `phase0_bidless/10_health_checks.ipynb`
+- `diagnostics/README.md` - Deprecation notice
+
+**From sandbox/ (deprecated stubs):**
+- `00_charts_reference.ipynb` - Stub pointing to `phase0_bidless/20_charts_reference.ipynb`
+- `00_starter_b0_exploration.ipynb` - Stub pointing to `phase0_bidless/30_model_dev_and_eval.ipynb`
+
+## Why Archived?
+
+These notebooks were replaced as part of the Phase 0 reorganization (PR #173). The stubs were kept briefly for backward compatibility but have now been archived for reference.
+
+## Current Phase 0 Notebooks
+
+For current Phase 0 (bidless) analysis, use:
+- **`notebooks/phase0_bidless/`** - Canonical Phase 0 location
+
+See [Phase 0 README](../phase0_bidless/README.md) for details.
+
+## Archive Date
+
+Archived: 2026-01-30

--- a/notebooks/.archive/diagnostics/README.md
+++ b/notebooks/.archive/diagnostics/README.md
@@ -1,0 +1,17 @@
+# Diagnostics Notebooks - MOVED
+
+⚠️ **Bidless diagnostics have moved to `notebooks/phase0_bidless/`**
+
+## New Location
+
+All Phase 0 (bidless hand analysis) notebooks are now in:
+- **`notebooks/phase0_bidless/`**
+
+See [Phase 0 README](../phase0_bidless/README.md) for:
+- Quick health checks (`10_health_checks.ipynb`)
+- Comprehensive analysis (`20_charts_reference.ipynb`)
+- Exploratory template (`30_model_dev_and_eval.ipynb`)
+
+---
+
+**Deprecation timeline:** This directory will be removed after 2026-03-01.

--- a/notebooks/.archive/diagnostics/bidless_diagnostics.ipynb
+++ b/notebooks/.archive/diagnostics/bidless_diagnostics.ipynb
@@ -1,0 +1,54 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Bidless Simulation Diagnostics - MOVED\n",
+    "\n",
+    "\u26a0\ufe0f **This notebook has been reorganized into the Phase 0 bidless analysis suite.**\n",
+    "\n",
+    "**New location:** `notebooks/phase0_bidless/10_health_checks.ipynb`\n",
+    "\n",
+    "## Migration Guide\n",
+    "\n",
+    "| Old Location | New Location | Purpose |\n",
+    "|--------------|--------------|---------||\n",
+    "| `notebooks/diagnostics/bidless_diagnostics.ipynb` | `notebooks/phase0_bidless/10_health_checks.ipynb` | Quick dataset validation |\n",
+    "| `notebooks/sandbox/00_charts_reference.ipynb` | `notebooks/phase0_bidless/20_charts_reference.ipynb` | Comprehensive reference |\n",
+    "| `notebooks/sandbox/00_starter_b0_exploration.ipynb` | `notebooks/phase0_bidless/30_model_dev_and_eval.ipynb` | Exploratory template |\n",
+    "\n",
+    "See the [Phase 0 README](../phase0_bidless/README.md) for the full suite.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Deprecation timeline:** This stub will be removed after 2026-03-01."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raise RuntimeError(\n",
+    "    \"This notebook has been moved to notebooks/phase0_bidless/.\\n\"\n",
+    "    \"See the markdown cell above for the new location.\"\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.8.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -15,9 +15,12 @@ notebooks/
 │   └── 30_model_dev_and_eval.ipynb    # Exploratory template
 ├── sandbox/         - Exploratory notebooks (dated, ad-hoc)
 │   └── YYYY_MM_DD_*.ipynb             # Individual explorations
+├── .archive/        - Archived/deprecated notebooks (for reference)
 ├── README.md        - This file
 └── .gitignore
 ```
+
+**Note:** Old Phase 0 notebook stubs have been archived in `.archive/` for reference.
 
 ---
 


### PR DESCRIPTION
## Summary
- Restore deprecated notebook stubs from deletion
- Move them to `notebooks/.archive/` for preservation
- Add archive README explaining purpose and contents

## Why
Better approach than deletion - preserves old notebook locations for reference while keeping them out of active use.

**Supersedes PR #174** (which deleted the files - this restores and archives them instead)

## Repro / Validation
**Commands run:**
```bash
# Verify archive exists
ls -la notebooks/.archive/
ls -la notebooks/.archive/diagnostics/

# Verify archive README exists
cat notebooks/.archive/README.md

# Verify notebooks README updated
grep ".archive" notebooks/README.md
```

**Validation:** Files are preserved in archive, not deleted

## Tests
- [x] `make check` - Passes (documentation changes only)
- [ ] Integration: N/A (archive preservation)
- [x] Other: Verified archive structure is correct

## Expected impact
- **Metrics impact:** None (archival only)
- **Runtime impact:** None (notebooks not in runtime)

## Risk level
- [x] Low (docs/tests only) - Archiving instead of deleting

## Worktree proof

`pwd`:
```
/Users/claude_runner/Projects/wt-archive-v2
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/wt-archive-v2
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre     4fb260f [main]
/Users/claude_runner/Projects/wt-archive-v2  1111cc7 [chore/archive-old-notebooks-v2]
```

## Checklist
- [x] No generated artifacts committed
- [x] If behavior changed, tests updated/added (N/A - archival only)
- [x] PR is focused (one concept: archive instead of delete)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)