### PR TITLE
feat: add demo mode to health checks notebook

### DIFF
--- a/notebooks/phase0_bidless/10_health_checks.ipynb
+++ b/notebooks/phase0_bidless/10_health_checks.ipynb
@@ -38,18 +38,7 @@
    "id": "config",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# === CONFIGURATION ===\n",
-    "# Option 1: Point to datasets subfolder directly\n",
-    "DATASET_DIR = \"../../data/runs/YOUR_RUN_ID/datasets\"\n",
-    "\n",
-    "# Option 2: Point to run root (will auto-append /datasets)\n",
-    "# DATASET_DIR = \"../../data/runs/YOUR_RUN_ID\"\n",
-    "\n",
-    "# Optional: Customize analysis\n",
-    "ROLLING_WINDOW = 100  # Window size for rolling mean plots\n",
-    "TOP_FEATURES = 9      # Number of features to show in distribution grid"
-   ]
+   "source": "# === CONFIGURATION ===\n\n# --- Data Source Mode ---\nDEMO_MODE = False  # If True, generates synthetic data; if False, loads from RUN_DIR\n\n# If DEMO_MODE=False, set this path:\nRUN_DIR = \"../../data/runs/YOUR_RUN_ID\"  # Will load from RUN_DIR/datasets/\n\n# --- Demo Mode Parameters (used when DEMO_MODE=True) ---\nDEMO_SEED = 42\nDEMO_N_DEALS = 2000  # Minimum for bias detection per rigor standards\n\n# --- Analysis Parameters ---\nROLLING_WINDOW = 100  # Window size for rolling mean plots\nTOP_FEATURES = 9      # Number of features to show in distribution grid"
   },
   {
    "cell_type": "markdown",
@@ -78,52 +67,29 @@
    "id": "imports",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Standard imports\n",
-    "import sys\n",
-    "from pathlib import Path\n",
-    "\n",
-    "# Add src to path for local development\n",
-    "project_root = Path.cwd().parent.parent\n",
-    "if str(project_root / \"src\") not in sys.path:\n",
-    "    sys.path.insert(0, str(project_root / \"src\"))\n",
-    "\n",
-    "# Diagnostic utilities\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "from bid_euchre.diagnostics import (\n",
-    "    compare_first_last_batch,\n",
-    "    compute_health_scorecard,\n",
-    "    compute_seat_balance,\n",
-    "    display_scorecard,\n",
-    "    load_bidless_dataset,\n",
-    "    load_meta,\n",
-    "    plot_feature_correlation,\n",
-    "    plot_feature_distributions,\n",
-    "    plot_hand_value_by_contract,\n",
-    "    plot_hand_value_by_seat,\n",
-    "    plot_rolling_mean,\n",
-    ")\n",
-    "from bid_euchre.diagnostics.charts import plot_feature_vs_label\n",
-    "from bid_euchre.diagnostics.loaders import get_dataset_summary\n",
-    "from bid_euchre.diagnostics.stats import (\n",
-    "    compute_correlation_with_label,\n",
-    "    compute_feature_stats,\n",
-    ")\n",
-    "\n",
-    "# Optional: seaborn for enhanced visualizations\n",
-    "try:\n",
-    "    import seaborn as sns\n",
-    "    sns.set_theme(style=\"whitegrid\")\n",
-    "except ImportError:\n",
-    "    print(\"seaborn not available, using matplotlib defaults\")\n",
-    "\n",
-    "# Configure matplotlib\n",
-    "plt.rcParams['figure.figsize'] = (12, 6)\n",
-    "plt.rcParams['figure.dpi'] = 100\n",
-    "\n",
-    "print(\"Imports successful!\")"
-   ]
+   "source": "# Standard imports\nimport sys\nfrom pathlib import Path\n\nimport pandas as pd\n\n# Add src to path for local development\nproject_root = Path.cwd().parent.parent\nif str(project_root / \"src\") not in sys.path:\n    sys.path.insert(0, str(project_root / \"src\"))\n\n# Diagnostic utilities\nimport matplotlib.pyplot as plt\n\nfrom bid_euchre.diagnostics import (\n    compare_first_last_batch,\n    compute_health_scorecard,\n    compute_seat_balance,\n    display_scorecard,\n    load_bidless_dataset,\n    load_meta,\n    plot_feature_correlation,\n    plot_feature_distributions,\n    plot_hand_value_by_contract,\n    plot_hand_value_by_seat,\n    plot_rolling_mean,\n)\nfrom bid_euchre.diagnostics.charts import plot_feature_vs_label\nfrom bid_euchre.diagnostics.loaders import get_dataset_summary\nfrom bid_euchre.diagnostics.stats import (\n    compute_correlation_with_label,\n    compute_feature_stats,\n)\n\n# Optional: seaborn for enhanced visualizations\ntry:\n    import seaborn as sns\n    sns.set_theme(style=\"whitegrid\")\nexcept ImportError:\n    print(\"seaborn not available, using matplotlib defaults\")\n\n# Configure matplotlib\nplt.rcParams['figure.figsize'] = (12, 6)\nplt.rcParams['figure.dpi'] = 100\n\nprint(\"Imports successful!\")"
+  },
+  {
+   "cell_type": "code",
+   "id": "pu043yg0haj",
+   "source": "# ============================================================================\n# DATA GENERATION FACTORY (for demo mode)\n# ============================================================================\n\ndef build_demo_dataset(seed: int, n_deals: int) -> pd.DataFrame:\n    \"\"\"Build demo bidless dataset with features only (no simulation).\n\n    Generates data for all 6 Phase 0 scenarios: 4 suit contracts + high + low.\n\n    Args:\n        seed: Random seed for reproducibility\n        n_deals: Number of deals per scenario\n\n    Returns:\n        DataFrame with hand_id, seat, contract_type, trump_suit, feat_* columns\n    \"\"\"\n    from bid_euchre.features.hand_eval import get_hand_features\n    from bid_euchre.sim.deals import generate_deal\n\n    contract_types = ['suit', 'suit', 'suit', 'suit', 'high', 'low']\n    trumps = ['C', 'D', 'H', 'S', None, None]  # Aligned with contract_types\n\n    hands_data = []\n    for deal_id in range(n_deals):\n        hands = generate_deal(seed, deal_id)\n\n        for contract_type, trump in zip(contract_types, trumps):\n            for seat in range(4):\n                hand = hands[seat]\n                features = get_hand_features(hand, contract_type, trump)\n                hands_data.append({\n                    'hand_id': f\"{deal_id}_{contract_type}_{trump}\",\n                    'seat': seat,\n                    'contract_type': contract_type,\n                    'trump_suit': trump if contract_type == 'suit' else None,\n                    **{f'feat_{k}': v for k, v in features.items()}\n                })\n\n    return pd.DataFrame(hands_data)\n\n\nprint(\"✅ Demo data factory loaded\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ny5b46k891m",
+   "source": "**Data Source Options:**\n\n1. **Production mode** (`DEMO_MODE=False`):\n   - Point `RUN_DIR` to an existing experiment run\n   - Generate production dataset with:\n     ```bash\n     PYTHONPATH=src python experiments/run_experiment.py \\\n       --config experiments/configs/bidless_dataset_collection.yaml \\\n       --seed 42 \\\n       --n_per 2000\n     ```\n   - Then set `RUN_DIR = \"../../data/runs/<your_run_id>\"`\n\n2. **Demo mode** (`DEMO_MODE=True`):\n   - Generates synthetic data in-memory\n   - Uses `DEMO_N_DEALS=2000` (meets rigor standards for bias detection)\n   - Useful for testing, development, or when no pre-existing dataset available",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "8vgvim0lu7c",
+   "source": "# ============================================================================\n# Data Loading / Generation\n# ============================================================================\n\nif not DEMO_MODE:\n    print(\"📂 Loading existing dataset from RUN_DIR...\")\n    from pathlib import Path\n\n    dataset_path = Path(RUN_DIR) / \"datasets\"\n    if not dataset_path.exists():\n        raise FileNotFoundError(\n            f\"Dataset not found: {dataset_path}\\n\"\n            f\"Set RUN_DIR to your run directory, or use DEMO_MODE=True\"\n        )\n\n    df = load_bidless_dataset(dataset_path)\n    print(f\"✅ Loaded {len(df):,} rows from {dataset_path}\")\n\nelse:\n    print(\"🎭 DEMO_MODE=True: Generating synthetic data...\")\n    print(f\"   Seed: {DEMO_SEED}\")\n    print(f\"   Deals per scenario: {DEMO_N_DEALS}\")\n    print(\"   Scenarios: 6 (4 suit + high + low)\")\n\n    df = build_demo_dataset(seed=DEMO_SEED, n_deals=DEMO_N_DEALS)\n    dataset_path = None  # No disk path for demo data\n\n    print(f\"\\n✅ Generated {len(df):,} rows (synthetic demo data)\")\n    print(f\"   Expected: {DEMO_N_DEALS * 6 * 4:,} rows (n_deals × scenarios × seats)\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -134,32 +100,6 @@
     "## Section 0: Health Scorecard\n",
     "\n",
     "Quick pass/warn/fail summary of dataset health."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "load-data",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Validation helper: adjust path if user pointed to run root\n",
-    "dataset_path = Path(DATASET_DIR)\n",
-    "if dataset_path.name != \"datasets\" and (dataset_path / \"datasets\").exists():\n",
-    "    # User pointed to run root, adjust to datasets subfolder\n",
-    "    dataset_path = dataset_path / \"datasets\"\n",
-    "    print(f\"📁 Adjusted path to: {dataset_path}\")\n",
-    "else:\n",
-    "    dataset_path = Path(DATASET_DIR)\n",
-    "\n",
-    "# Load the dataset\n",
-    "if not dataset_path.exists():\n",
-    "    print(f\"\\n⚠️  Dataset directory not found: {dataset_path}\")\n",
-    "    print(\"Please update DATASET_DIR in the Configuration cell above.\")\n",
-    "    print(\"\\nExample: DATASET_DIR = '../../data/runs/bidless_dataset_collection_20260130_143022/datasets'\")\n",
-    "else:\n",
-    "    df = load_bidless_dataset(dataset_path)\n",
-    "    print(f\"✅ Loaded {len(df):,} rows from {dataset_path}\")"
    ]
   },
   {
@@ -191,29 +131,7 @@
    "id": "run-summary",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Load metadata if available\n",
-    "try:\n",
-    "    meta = load_meta(dataset_path)\n",
-    "    print(\"=== Metadata ===\")\n",
-    "    for key, value in meta.items():\n",
-    "        print(f\"  {key}: {value}\")\n",
-    "except FileNotFoundError:\n",
-    "    print(\"No metadata file found (bidless_meta.json)\")\n",
-    "\n",
-    "# Dataset summary\n",
-    "print(\"\\n=== Dataset Summary ===\")\n",
-    "summary = get_dataset_summary(df)\n",
-    "for key, value in summary.items():\n",
-    "    if key != 'feature_columns':\n",
-    "        print(f\"  {key}: {value}\")\n",
-    "\n",
-    "print(f\"\\n  Feature columns ({len(summary['feature_columns'])}):\")  \n",
-    "for col in summary['feature_columns'][:10]:\n",
-    "    print(f\"    - {col}\")\n",
-    "if len(summary['feature_columns']) > 10:\n",
-    "    print(f\"    ... and {len(summary['feature_columns']) - 10} more\")"
-   ]
+   "source": "# Load metadata if available\nif dataset_path is not None:\n    try:\n        meta = load_meta(dataset_path)\n        print(\"=== Metadata ===\")\n        for key, value in meta.items():\n            print(f\"  {key}: {value}\")\n    except FileNotFoundError:\n        print(\"No metadata file found (bidless_meta.json)\")\nelse:\n    print(\"=== Metadata ===\")\n    print(\"  No metadata (demo mode)\")\n\n# Dataset summary\nprint(\"\\n=== Dataset Summary ===\")\nsummary = get_dataset_summary(df)\nfor key, value in summary.items():\n    if key != 'feature_columns':\n        print(f\"  {key}: {value}\")\n\nprint(f\"\\n  Feature columns ({len(summary['feature_columns'])}):\")  \nfor col in summary['feature_columns'][:10]:\n    print(f\"    - {col}\")\nif len(summary['feature_columns']) > 10:\n    print(f\"    ... and {len(summary['feature_columns']) - 10} more\")"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary

- Add DEMO_MODE flag to `10_health_checks.ipynb` following pattern from `20_charts_reference.ipynb`
- Enable in-memory synthetic data generation for health check validation
- Update data loading logic to handle both demo and production modes

## Why

The health checks notebook previously required users to generate a full bidless dataset before running any validation. This adds friction for:
- Quick iteration during notebook development
- Testing health check logic without external dependencies
- Learning/exploring the health checks without setup overhead

Demo mode generates synthetic data on-the-fly, matching the pattern already established in `20_charts_reference.ipynb`.

## Repro / Validation

**Demo mode test:**
```bash
# Open notebook: notebooks/phase0_bidless/10_health_checks.ipynb
# Set DEMO_MODE=True, DEMO_N_DEALS=2000 in config cell
# Run all cells
# Expected: 48,000 rows generated, health scorecard shows 1 WARN (missing hand_cards)
```

**Production mode test (optional):**
```bash
PYTHONPATH=src python experiments/run_experiment.py \
  --config experiments/configs/bidless_dataset_collection.yaml \
  --seed 42 \
  --n_per 2000
# Set DEMO_MODE=False and RUN_DIR to generated path in notebook
# Run all cells
# Expected: Loads from disk, all sections work identically
```

## Tests

```bash
make check  # PASSED
```

All linting (ruff, repo-lint) and pytest tests pass.

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre/Bid-Euchre-health-checks-demo
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre/Bid-Euchre-health-checks-demo
git worktree list:
/Users/claude_runner/Projects/Bid-Euchre                                5e52123 [main]
/Users/claude_runner/Projects/Bid-Euchre/Bid-Euchre-health-checks-demo  ac05fca [feat/health-checks-demo-mode]
```

## Technical Notes

- Sample size: `DEMO_N_DEALS=2000` meets rigor standards (≥2,000 deals for bias detection per `.claude/rules/05_rigor.md`)
- Demo data is features-only (no simulation), matching production bidless workflow
- Health scorecard shows expected WARN for missing `hand_cards` column (demo mode omits raw card data for simplicity)
- Schema compatible: demo generates minimal schema (hand_id, seat, contract_type, trump_suit, feat_*) sufficient for all health check analyses

🤖 Generated with [Claude Code](https://claude.com/claude-code)