### PR TITLE
fix: prevent feature overwrite in bidless dataset emission

### DIFF
--- a/src/bid_euchre/datasets/bidless.py
+++ b/src/bid_euchre/datasets/bidless.py
@@ -251,6 +251,7 @@ def emit_bidless_dataset(
     # Create collector with combined data for writing
     combined_collector = BidlessDatasetCollector(run_id, "combined")
     combined_collector.rows = all_rows_sorted
+    combined_collector._features_computed = True  # Features already computed in individual collectors
 
     # Always write primary format (parquet by default)
     if format == "parquet":


### PR DESCRIPTION
## Summary

- Fix bug in `emit_bidless_dataset()` that was overwriting feature values with zeros
- Mark combined collector as having features already computed to skip recomputation

## Why

When combining bidless collectors for dataset emission, the code was creating a new combined collector and copying rows, but not copying the `_hands_by_seat` mapping. When writing the dataset, `get_rows_sorted()` calls `_ensure_hand_features()`, which couldn't find any hands and defaulted all features to zeros, overwriting the correctly computed features.

This caused notebook feature correlation analysis (30_feature_outcome_eval.ipynb) to fail with all features showing zero variance.

## Repro / Validation

**Before fix:**
```python
# In notebooks/phase0_bidless/30_feature_outcome_eval.ipynb
# All features showed mean=0.000, std=0.000
```

**After fix:**
```bash
# Clear cache
rm -rf /private/tmp/claude-503/-Users-claude-runner-Projects-Bid-Euchre-meta-Bid-Euchre/*/scratchpad/notebook_cache

# Run notebook cell 6 to regenerate data
# Features now show proper variance and correlations
```

## Tests

```bash
make check  # All tests pass
```

Existing integration tests in `tests/integration/test_bidless_workflow.py` cover the dataset emission workflow and continue to pass.

## Worktree proof

```bash
pwd
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-bidless-feature-zero-bug

git rev-parse --show-toplevel
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-bidless-feature-zero-bug

git worktree list
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                                     aab8027 [main]
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-bidless-feature-zero-bug        6ea2679 [fix/bidless-feature-zero-bug]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)