### PR TITLE
docs: comprehensive rewrite of REPO_REVIEW_PROMPT.md

### DIFF
--- a/docs/02_agent/REPO_REVIEW_PROMPT.md
+++ b/docs/02_agent/REPO_REVIEW_PROMPT.md
@@ -276,7 +276,7 @@ For each contract doc, verify claims against reality:
 grep -h "^python\|^make\|^PYTHONPATH" docs/01_core/*.md docs/02_agent/*.md | head -10
 
 # Test sample commands (dry-run safe)
-PYTHONPATH=src python experiments/run_experiment.py --config experiments/configs/quick_test.yaml --dry-run
+PYTHONPATH=src python experiments/run_experiment.py --config experiments/configs/quick_test.yaml --seed 42 --dry-run
 ```
 
 **Deliverable:** Documentation accuracy table with drift details.
@@ -330,7 +330,7 @@ grep -rn "def test_.*:.*pass$" tests/
 
 ```bash
 # Find experiment invocations in docs without --seed
-grep -rn "python experiments/run_experiment.py" docs/ | grep -v "\-\-seed\|\-\-allow-nondeterministic" | head -10
+grep -rn "python experiments/run_experiment.py" docs/ | grep -v -- "--seed\|--allow-nondeterministic" | head -10
 ```
 
 **Stale Reference Detection:**
@@ -805,21 +805,13 @@ make test       # Pytest fast suite
 
 ```bash
 # Seeded experiment (production)
-PYTHONPATH=src python experiments/run_experiment.py \
-  --config experiments/configs/strategy_comparison.yaml \
-  --seed 42 \
-  --n_per 2000
+PYTHONPATH=src python experiments/run_experiment.py --config experiments/configs/strategy_comparison.yaml --seed 42 --n_per 2000
 
 # Quick smoke test (exploratory only, not for inference)
-PYTHONPATH=src python experiments/run_experiment.py \
-  --config experiments/configs/quick_test.yaml \
-  --seed 42 \
-  --n_per 200
+PYTHONPATH=src python experiments/run_experiment.py --config experiments/configs/quick_test.yaml --seed 42 --n_per 200
 
 # Dry-run validation (no simulation)
-PYTHONPATH=src python experiments/run_experiment.py \
-  --config experiments/configs/strategy_comparison.yaml \
-  --dry-run
+PYTHONPATH=src python experiments/run_experiment.py --config experiments/configs/strategy_comparison.yaml --seed 42 --dry-run
 ```
 
 ### Report Generation


### PR DESCRIPTION
## Summary

Comprehensive rewrite of `docs/02_agent/REPO_REVIEW_PROMPT.md` to create an AI agent-optimized prompt for performing comprehensive repo reviews.

- Rewrote entire document with 5-phase systematic workflow structure
- Added dedicated rigor validation sections (PHASE 2.2, PHASE 3.4, OUTPUT 5.5)
- Updated all content to reflect PR #186 state (was last updated at PR #155)
- Integrated .claude/ references and rigor philosophy
- Expanded from 431 to 1,113 lines with comprehensive verification commands

## Why

The REPO_REVIEW_PROMPT serves as instructions for AI agents to review the repo. Since last update (PR #155), significant changes occurred:
- New modules: `validation/`, `diagnostics/notebook_data.py`
- New scripts: `compare_runs.py`, `validate_configs.py`
- Enhanced repo-linter: 9+ rules (was ~5)
- Rigor enforcement: `.claude/rules/05_rigor.md` philosophy now central
- New docs: `FLOW_DIAGRAM.md`, `.claude/CLAUDE.md` entrypoint

Needed to transform from loose guide into precision instrument for agent execution.

## Repro / Validation

```bash
# Document exists and has correct structure
wc -l docs/02_agent/REPO_REVIEW_PROMPT.md  # Should be ~1113 lines
grep -E "^## PHASE [1-5]:" docs/02_agent/REPO_REVIEW_PROMPT.md | wc -l  # Should be 5

# New sections present
grep "PHASE 2.2: Rigor Validation" docs/02_agent/REPO_REVIEW_PROMPT.md
grep "PHASE 3.4: Rigor Gaps" docs/02_agent/REPO_REVIEW_PROMPT.md
grep "5.5 Rigor Assessment" docs/02_agent/REPO_REVIEW_PROMPT.md

# Updated references
grep "13" docs/02_agent/REPO_REVIEW_PROMPT.md | grep -i module  # 13 modules, not 14
grep "compare_runs.py" docs/02_agent/REPO_REVIEW_PROMPT.md
grep "validate_configs.py" docs/02_agent/REPO_REVIEW_PROMPT.md
grep ".claude/CLAUDE.md" docs/02_agent/REPO_REVIEW_PROMPT.md
grep "Validation & Rigor" docs/02_agent/REPO_REVIEW_PROMPT.md
```

## Tests

```bash
# Repo-linter passes
make repo-lint

# Full validation (lint may need worktree venv setup)
make check
```

## Worktree Proof

```bash
pwd
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-update-repo-review-prompt

git rev-parse --show-toplevel
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-update-repo-review-prompt

git worktree list
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                               aab8027 [main]
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-update-repo-review-prompt     448eb87 [docs/update-repo-review-prompt]
```

## Checklist

- [x] Branch based on main
- [x] Scope lock — only touched `docs/02_agent/REPO_REVIEW_PROMPT.md`
- [x] `make repo-lint` passes
- [x] No artifacts committed
- [x] Documentation-only change (no code modifications)
- [x] Exact repro commands in PR description
- [x] Contract compliance (doc update, no schema changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)