### PR TITLE
docs: add worktree-only workflow enforcement

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -41,6 +41,43 @@ make help     # see all targets
 - No commits to `data/runs/`, `data/reports/`, `data/models/`
 - One concept per PR; use PR template
 
+## Worktree-Only Workflow (MANDATORY)
+
+**CRITICAL:** All code changes MUST happen in dedicated git worktrees, never in the main checkout at `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre`.
+
+### Before Making Any Changes
+
+1. **Check current location:**
+   ```bash
+   git rev-parse --show-toplevel
+   git branch --show-current
+   ```
+
+2. **If on `main` branch in main checkout → STOP:**
+   - The user-prompt-submit hook will block you
+   - Create a worktree first: `git worktree add ../Bid-Euchre-<branch-name> <branch-name>`
+
+3. **Worktree creation pattern:**
+   ```bash
+   # From main checkout
+   git worktree add ../Bid-Euchre-<descriptive-name> <branch-name>
+   cd ../Bid-Euchre-<descriptive-name>
+   # Now work here
+   ```
+
+### Enforcement Rules
+
+- ❌ NEVER work from main checkout when on `main` branch
+- ❌ NEVER commit from main checkout
+- ✅ ALWAYS verify worktree location before starting
+- ✅ ALWAYS include worktree proof in PR descriptions
+
+Violations trigger:
+1. User-prompt-submit hook → blocks immediately
+2. Pre-commit hook → blocks at commit time
+
+See `docs/02_agent/AGENTS.md` for full workflow details.
+
 ## Compaction Instructions
 
 When compacting conversation context, preserve:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,11 @@ repos:
         language: system
         files: ^experiments/(configs|suites)/.*\.yaml$
         pass_filenames: false
+
+      - id: no-commits-from-main-checkout
+        name: Block commits from main checkout
+        entry: bash -c 'MAIN_DIR="/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre"; CURRENT_DIR="$(git rev-parse --show-toplevel)"; CURRENT_BRANCH="$(git branch --show-current)"; if [ "$CURRENT_DIR" = "$MAIN_DIR" ] && [ "$CURRENT_BRANCH" = "main" ]; then echo ""; echo "⛔ ERROR: Commits from main checkout are not allowed."; echo ""; echo "This repository requires worktree-only workflow."; echo "Create a worktree: git worktree add ../Bid-Euchre-<branch> <branch>"; echo ""; exit 1; fi'
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [commit]


### PR DESCRIPTION
## Summary
- Add worktree-only workflow documentation to `.claude/CLAUDE.md`
- Add pre-commit hook to block commits from main checkout on `main` branch

## Why
Establishes mandatory worktree workflow to prevent accidental commits to main checkout, enforcing the pattern referenced in `docs/02_agent/AGENTS.md`.

## Validation
```bash
# Changes made in main checkout (bootstrap exception)
pwd  # /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre
git rev-parse --show-toplevel  # /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre
git branch --show-current  # docs/worktree-workflow-enforcement
```

## Tests
N/A - documentation and hook configuration only

## Worktree proof
```bash
$ pwd
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre
$ git rev-parse --show-toplevel
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre
$ git worktree list
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre  784ef25 [docs/worktree-workflow-enforcement]
```

Note: This is a bootstrap commit establishing the worktree policy itself. Future changes will follow the worktree-only workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)