### PR TITLE
docs: add archive warning banner to 30_model_dev_and_eval.ipynb

### DIFF
--- a/notebooks/phase0_bidless/archive/30_model_dev_and_eval.ipynb
+++ b/notebooks/phase0_bidless/archive/30_model_dev_and_eval.ipynb
@@ -2,6 +2,11 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "source": "# ⚠️ ARCHIVED EXPLORATORY ANALYSIS\n\n**Status:** This notebook contains exploratory visualizations from early model development.\n\n**Limitations:**\n- Plots are visual-only (no statistical tests)\n- No inference should be drawn from these results\n- Superseded by newer analysis in active notebooks\n\n**Use case:** Historical reference only",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Phase 0: Model Development & Evaluation\n",


### PR DESCRIPTION
## Summary
- Add prominent "⚠️ ARCHIVED EXPLORATORY ANALYSIS" warning banner
- Insert as first cell in archived notebook
- Clearly states limitations and intended use case

## Why
Comprehensive repository review identified that `notebooks/phase0_bidless/archive/30_model_dev_and_eval.ipynb` contains exploratory visualizations without statistical tests or clear archival warning.

This PR adds a warning banner to prevent misinterpretation of visual-only exploratory analysis as validated results.

## Changes

Added new markdown cell as position 0:

```markdown
# ⚠️ ARCHIVED EXPLORATORY ANALYSIS

**Status:** This notebook contains exploratory visualizations from early model development.

**Limitations:**
- Plots are visual-only (no statistical tests)
- No inference should be drawn from these results
- Superseded by newer analysis in active notebooks

**Use case:** Historical reference only
```

## Repro / Validation

**Verify warning banner exists:**
```bash
jupyter nbconvert --to script notebooks/phase0_bidless/archive/30_model_dev_and_eval.ipynb --stdout | head -20 | grep "ARCHIVED EXPLORATORY"
# Expected: Should find warning text
```

**Or inspect notebook JSON:**
```bash
jq '.cells[0].source' notebooks/phase0_bidless/archive/30_model_dev_and_eval.ipynb | grep "ARCHIVED"
# Expected: First cell contains warning
```

## Tests

```bash
make check
```

**Results:**
- repo-lint: PASSED ✅
- ruff format: PASSED ✅
- ruff lint: PASSED ✅
- pytest: 744 passed, 4 skipped, 1 deselected, 3 xfailed, 1 xpassed ✅

## Worktree Proof

```bash
pwd
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-notebook-warning

git rev-parse --show-toplevel
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-notebook-warning

git worktree list
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                       d778140 [main]
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-architecture-drift    87cf4d9 [fix/architecture-drift]
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-repo-review-update    9c8d45b [fix/repo-review-prompt]
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-notebook-warning      9e7f79b [fix/archive-notebook-warning]

git branch --show-current
# fix/archive-notebook-warning
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)