### PR TITLE
feat: add compact issue display for health checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,8 @@ repos:
 
       - id: no-commits-from-main-checkout
         name: Block commits from main checkout
-        entry: bash -c 'MAIN_DIR="/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre"; CURRENT_DIR="$(git rev-parse --show-toplevel)"; CURRENT_BRANCH="$(git branch --show-current)"; if [ "$CURRENT_DIR" = "$MAIN_DIR" ] && [ "$CURRENT_BRANCH" = "main" ]; then echo ""; echo "⛔ ERROR: Commits from main checkout are not allowed."; echo ""; echo "This repository requires worktree-only workflow."; echo "Create a worktree: git worktree add ../Bid-Euchre-<branch> <branch>"; echo ""; exit 1; fi'
+        entry: |
+          bash -c 'MAIN_DIR="/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre"; CURRENT_DIR="$(git rev-parse --show-toplevel)"; CURRENT_BRANCH="$(git branch --show-current)"; if [ "$CURRENT_DIR" = "$MAIN_DIR" ] && [ "$CURRENT_BRANCH" = "main" ]; then echo ""; echo "⛔ ERROR: Commits from main checkout are not allowed."; echo ""; echo "This repository requires worktree-only workflow."; echo "Create a worktree: git worktree add ../Bid-Euchre-<branch> <branch>"; echo ""; exit 1; fi'
         language: system
         pass_filenames: false
         always_run: true

--- a/notebooks/phase0_bidless/10_feature_health_checks.ipynb
+++ b/notebooks/phase0_bidless/10_feature_health_checks.ipynb
@@ -83,7 +83,7 @@
    "id": "imports",
    "metadata": {},
    "outputs": [],
-   "source": "# Standard imports\nimport sys\nfrom pathlib import Path\n\nimport pandas as pd\n\n# Add src to path for local development\nproject_root = Path.cwd().parent.parent\nif str(project_root / \"src\") not in sys.path:\n    sys.path.insert(0, str(project_root / \"src\"))\n\n# Diagnostic utilities\nimport matplotlib.pyplot as plt\n\nfrom bid_euchre.diagnostics import (\n    compute_health_scorecard,\n    compute_seat_balance,\n    display_scorecard,\n    load_bidless_dataset,\n    load_meta,\n    plot_hand_value_by_contract,\n)\nfrom bid_euchre.diagnostics.loaders import get_dataset_summary\n\n# Optional: seaborn for enhanced visualizations\ntry:\n    import seaborn as sns\n    sns.set_theme(style=\"whitegrid\")\nexcept ImportError:\n    print(\"seaborn not available, using matplotlib defaults\")\n\n# Configure matplotlib\nplt.rcParams['figure.figsize'] = (12, 6)\nplt.rcParams['figure.dpi'] = 100\n\nprint(\"Imports successful!\")"
+   "source": "# Standard imports\nimport sys\nfrom pathlib import Path\n\nimport pandas as pd\n\n# Add src to path for local development\nproject_root = Path.cwd().parent.parent\nif str(project_root / \"src\") not in sys.path:\n    sys.path.insert(0, str(project_root / \"src\"))\n\n# Diagnostic utilities\nimport matplotlib.pyplot as plt\n\nfrom bid_euchre.diagnostics import (\n    compute_health_scorecard,\n    compute_seat_balance,\n    display_issues,\n    display_scorecard,\n    load_bidless_dataset,\n    load_meta,\n    plot_hand_value_by_contract,\n)\nfrom bid_euchre.diagnostics.loaders import get_dataset_summary\n\n# Optional: seaborn for enhanced visualizations\ntry:\n    import seaborn as sns\n    sns.set_theme(style=\"whitegrid\")\nexcept ImportError:\n    print(\"seaborn not available, using matplotlib defaults\")\n\n# Configure matplotlib\nplt.rcParams['figure.figsize'] = (12, 6)\nplt.rcParams['figure.dpi'] = 100\n\nprint(\"Imports successful!\")"
   },
   {
    "cell_type": "code",
@@ -949,25 +949,7 @@
    "id": "final-summary",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "print(\"=\" * 60)\n",
-    "print(\"FINAL HEALTH SUMMARY\")\n",
-    "print(\"=\" * 60)\n",
-    "\n",
-    "summary = scorecard.summary()\n",
-    "if summary['FAIL'] == 0 and summary['WARN'] == 0:\n",
-    "    print(\"\\n\\u2705 ALL CHECKS PASSED - Dataset looks healthy!\")\n",
-    "elif summary['FAIL'] == 0:\n",
-    "    print(f\"\\n\\u26a0\\ufe0f  {summary['WARN']} WARNING(S) - Review warnings above\")\n",
-    "else:\n",
-    "    print(f\"\\n\\u274c {summary['FAIL']} FAILURE(S) - Fix issues before proceeding\")\n",
-    "\n",
-    "print(f\"\\n  Passed: {summary['PASS']}\")\n",
-    "print(f\"  Warnings: {summary['WARN']}\")\n",
-    "print(f\"  Failures: {summary['FAIL']}\")\n",
-    "\n",
-    "print(\"\\n\" + \"=\" * 60)"
-   ]
+   "source": "print(\"=\" * 60)\nprint(\"FINAL HEALTH SUMMARY\")\nprint(\"=\" * 60)\n\nsummary = scorecard.summary()\nif summary['FAIL'] == 0 and summary['WARN'] == 0:\n    print(\"\\n✅ ALL CHECKS PASSED - Dataset looks healthy!\")\nelif summary['FAIL'] == 0:\n    print(f\"\\n⚠️  {summary['WARN']} WARNING(S)\")\nelse:\n    print(f\"\\n❌ {summary['FAIL']} FAILURE(S)\")\n\n# Show compact issue list for quick reference\nif summary['FAIL'] > 0 or summary['WARN'] > 0:\n    print(\"\\n\" + display_issues(scorecard))\n\nprint(f\"\\n  Passed: {summary['PASS']}\")\nprint(f\"  Warnings: {summary['WARN']}\")\nprint(f\"  Failures: {summary['FAIL']}\")\n\nprint(\"\\n\" + \"=\" * 60)"
   }
  ],
  "metadata": {

--- a/scripts/run_bidless_diagnostics.py
+++ b/scripts/run_bidless_diagnostics.py
@@ -14,6 +14,7 @@ from bid_euchre.diagnostics import (
     compare_first_last_batch,
     compute_health_scorecard,
     compute_seat_balance,
+    display_issues,
     display_scorecard,
     load_bidless_dataset,
 )
@@ -32,7 +33,8 @@ def main():
 
     # Run health scorecard
     scorecard = compute_health_scorecard(df)
-    print("\n" + display_scorecard(scorecard))
+    if args.verbose:
+        print("\n" + display_scorecard(scorecard))
 
     # Additional stats
     balance = compute_seat_balance(df)
@@ -48,9 +50,17 @@ def main():
     summary = scorecard.summary()
     if summary["FAIL"] > 0:
         print(f"\n❌ {summary['FAIL']} check(s) FAILED")
+        if not args.verbose:
+            issues = display_issues(scorecard)
+            if issues:
+                print("\n" + issues)
         return 1
     elif summary["WARN"] > 0:
         print(f"\n⚠️ {summary['WARN']} warning(s), {summary['PASS']} passed")
+        if not args.verbose:
+            issues = display_issues(scorecard)
+            if issues:
+                print("\n" + issues)
         return 0
     else:
         print(f"\n✅ All {summary['PASS']} checks passed")

--- a/src/bid_euchre/diagnostics/__init__.py
+++ b/src/bid_euchre/diagnostics/__init__.py
@@ -26,7 +26,7 @@ from .charts import (
     plot_rolling_mean,
     plot_suit_variance_summary,
 )
-from .health_checks import compute_health_scorecard, display_scorecard
+from .health_checks import compute_health_scorecard, display_issues, display_scorecard
 from .loaders import load_bidless_dataset, load_meta
 from .notebook_data import load_or_generate_features, load_or_generate_outcomes
 from .stats import compare_first_last_batch, compute_seat_balance
@@ -49,6 +49,7 @@ __all__ = [
     # Health checks
     "compute_health_scorecard",
     "display_scorecard",
+    "display_issues",
     # Charts - Feature Analysis
     "plot_hand_value_by_seat",
     "plot_hand_value_by_contract",

--- a/src/bid_euchre/diagnostics/health_checks.py
+++ b/src/bid_euchre/diagnostics/health_checks.py
@@ -44,6 +44,14 @@ class HealthScorecard:
             counts[check.status] += 1
         return counts
 
+    def get_warnings(self) -> List[CheckResult]:
+        """Return all checks with WARN status."""
+        return [c for c in self.checks if c.status == "WARN"]
+
+    def get_failures(self) -> List[CheckResult]:
+        """Return all checks with FAIL status."""
+        return [c for c in self.checks if c.status == "FAIL"]
+
 
 def compute_health_scorecard(df: pd.DataFrame) -> HealthScorecard:
     """Compute health scorecard for a bidless dataset.
@@ -316,6 +324,37 @@ def display_scorecard(scorecard: HealthScorecard) -> str:
 
     for check in scorecard.checks:
         badge = {"PASS": "✅", "WARN": "⚠️", "FAIL": "❌"}[check.status]
+        lines.append(f"{badge} {check.name}: {check.message}")
+
+    return "\n".join(lines)
+
+
+def display_issues(scorecard: HealthScorecard) -> str:
+    """Format warnings and failures as compact list.
+
+    Returns empty string if no issues. Shows failures first, then warnings.
+
+    Example:
+        Issues found:
+        ❌ row_uniqueness: Found 3 duplicate pairs
+        ⚠️  feature_variance: 2 features have zero variance
+
+    Args:
+        scorecard: HealthScorecard to display issues from
+
+    Returns:
+        Formatted string with compact issue list, or empty string if no issues
+    """
+    failures = scorecard.get_failures()
+    warnings = scorecard.get_warnings()
+    issues = failures + warnings
+
+    if not issues:
+        return ""
+
+    lines = ["Issues found:"]
+    for check in issues:
+        badge = "❌" if check.status == "FAIL" else "⚠️ "
         lines.append(f"{badge} {check.name}: {check.message}")
 
     return "\n".join(lines)

--- a/tests/unit/test_health_checks.py
+++ b/tests/unit/test_health_checks.py
@@ -1,0 +1,105 @@
+"""Unit tests for health check filtering and display functions."""
+
+from bid_euchre.diagnostics.health_checks import (
+    CheckResult,
+    HealthScorecard,
+    display_issues,
+)
+
+
+def test_get_warnings_filters_correctly():
+    """Test that get_warnings returns only WARN status checks."""
+    scorecard = HealthScorecard(
+        checks=[
+            CheckResult(name="check1", status="PASS", message="All good"),
+            CheckResult(name="check2", status="WARN", message="Minor issue"),
+            CheckResult(name="check3", status="FAIL", message="Critical error"),
+            CheckResult(name="check4", status="WARN", message="Another warning"),
+        ]
+    )
+
+    warnings = scorecard.get_warnings()
+
+    assert len(warnings) == 2
+    assert all(c.status == "WARN" for c in warnings)
+    assert warnings[0].name == "check2"
+    assert warnings[1].name == "check4"
+
+
+def test_get_failures_filters_correctly():
+    """Test that get_failures returns only FAIL status checks."""
+    scorecard = HealthScorecard(
+        checks=[
+            CheckResult(name="check1", status="PASS", message="All good"),
+            CheckResult(name="check2", status="WARN", message="Minor issue"),
+            CheckResult(name="check3", status="FAIL", message="Critical error"),
+            CheckResult(name="check4", status="FAIL", message="Another failure"),
+        ]
+    )
+
+    failures = scorecard.get_failures()
+
+    assert len(failures) == 2
+    assert all(c.status == "FAIL" for c in failures)
+    assert failures[0].name == "check3"
+    assert failures[1].name == "check4"
+
+
+def test_display_issues_empty_when_no_issues():
+    """Test that display_issues returns empty string when all checks pass."""
+    scorecard = HealthScorecard(
+        checks=[
+            CheckResult(name="check1", status="PASS", message="All good"),
+            CheckResult(name="check2", status="PASS", message="Also good"),
+        ]
+    )
+
+    result = display_issues(scorecard)
+
+    assert result == ""
+
+
+def test_display_issues_shows_failures_before_warnings():
+    """Test that failures appear before warnings in display_issues output."""
+    scorecard = HealthScorecard(
+        checks=[
+            CheckResult(name="check1", status="PASS", message="All good"),
+            CheckResult(name="check2", status="WARN", message="Minor issue"),
+            CheckResult(name="check3", status="FAIL", message="Critical error"),
+            CheckResult(name="check4", status="WARN", message="Another warning"),
+        ]
+    )
+
+    result = display_issues(scorecard)
+
+    assert result != ""
+    lines = result.split("\n")
+    assert lines[0] == "Issues found:"
+
+    # Check that failures appear before warnings in the output
+    # Find indices of failure and warning lines
+    fail_indices = [i for i, line in enumerate(lines) if "❌" in line]
+    warn_indices = [i for i, line in enumerate(lines) if "⚠️" in line]
+
+    assert len(fail_indices) == 1
+    assert len(warn_indices) == 2
+    assert all(f_idx < w_idx for f_idx in fail_indices for w_idx in warn_indices)
+
+
+def test_display_issues_includes_check_names_and_messages():
+    """Test that display_issues includes both check name and message."""
+    scorecard = HealthScorecard(
+        checks=[
+            CheckResult(
+                name="feature_variance",
+                status="WARN",
+                message="2 feature(s) have zero variance",
+            ),
+        ]
+    )
+
+    result = display_issues(scorecard)
+
+    assert "feature_variance" in result
+    assert "2 feature(s) have zero variance" in result
+    assert "⚠️" in result


### PR DESCRIPTION
## Summary
- Add compact `display_issues()` function to show warnings/failures without scrolling
- CLI defaults to compact mode; `--verbose` flag provides full details
- Add filtering methods `get_warnings()` and `get_failures()` to HealthScorecard
- Update notebook final summary to show compact issue list
- Fix YAML syntax error in `.pre-commit-config.yaml`

## Why
- Health check system showed detailed results early but final summaries only showed counts
- Users had to scroll up to find which specific check warned/failed
- Poor UX in long outputs, especially in CI/CD logs

## Repro / Validation
**Command(s) run:**
- `PYTHONPATH=.:src uv run python -m pytest tests/unit/test_health_checks.py -v`
- `make test` (all tests pass)
- Manual testing with mock scorecard data

**Config (if applicable):**
- N/A

**Seed (if applicable):**
- N/A

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/`
- [x] New unit tests: `tests/unit/test_health_checks.py` (5 tests, all passing)
- [x] Other: Tested display_issues() function manually with mock data

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None (display function only)

## Risk level
- [x] Low (diagnostics display only, no core logic changes)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-health-check-issues-display
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-health-check-issues-display
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                              014d88f [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-architecture-drift           87cf4d9 [fix/architecture-drift]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-health-check-issues-display  30abe45 [health-check-issues-display]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-notebook-warning             9e7f79b [fix/archive-notebook-warning]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-repo-review-update           9c8d45b [fix/repo-review-prompt]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-visual-language              d778140 [fix/visual-only-language]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)