### PR TITLE
docs: replace visual-only language in feature health checks notebook

### DIFF
--- a/notebooks/phase0_bidless/10_feature_health_checks.ipynb
+++ b/notebooks/phase0_bidless/10_feature_health_checks.ipynb
@@ -338,7 +338,7 @@
     "    if imbalance > expected_per_trump * 0.1:  # 10% tolerance\n",
     "        print(f\"⚠️  Imbalance detected: {imbalance} row difference across trumps\")\n",
     "    else:\n",
-    "        print(\"✅ Trump distribution looks balanced\")\n",
+    "        print(\"✅ Trump distribution shows balanced counts (within 10% tolerance)\")\n",
     "\n",
     "print(\"\\nCounts by seat:\")\n",
     "seat_counts = df.groupby('seat').size()\n",


### PR DESCRIPTION
## Summary
- Replace "looks balanced" with accurate validation description
- Reference actual check being performed (10% tolerance threshold)
- Align with rigor standards (.claude/rules/05_rigor.md)

## Why
Comprehensive repository review identified visual-only language in active notebook that doesn't reference the actual validation being performed.

Per rigor standards, assertions should reference quantitative checks rather than subjective visual assessments.

## Changes

**File:** `notebooks/phase0_bidless/10_feature_health_checks.ipynb` (line 341)

**Before:**
```python
print("✅ Trump distribution looks balanced")
```

**After:**
```python
print("✅ Trump distribution shows balanced counts (within 10% tolerance)")
```

This accurately describes the validation being performed (10% tolerance threshold check on count imbalance) rather than using subjective language.

## Repro / Validation

**Verify no "looks balanced" remains:**
```bash
grep -n "looks balanced" notebooks/phase0_bidless/10_feature_health_checks.ipynb
# Expected: No output (phrase removed)
```

**Verify replacement text:**
```bash
grep -n "shows balanced counts" notebooks/phase0_bidless/10_feature_health_checks.ipynb
# Expected: Line 341 with new text
```

## Tests

```bash
make check
```

**Results:**
- repo-lint: PASSED ✅
- ruff format: PASSED ✅
- ruff lint: PASSED ✅
- pytest: 744 passed, 4 skipped, 1 deselected, 3 xfailed, 1 xpassed ✅

## Worktree Proof

```bash
pwd
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-visual-language

git rev-parse --show-toplevel
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-visual-language

git worktree list
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                       d778140 [main]
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-architecture-drift    87cf4d9 [fix/architecture-drift]
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-repo-review-update    9c8d45b [fix/repo-review-prompt]
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-notebook-warning      9e7f79b [fix/archive-notebook-warning]
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-visual-language       74ab7f9 [fix/visual-only-language]

git branch --show-current
# fix/visual-only-language
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)