### PR TITLE
feat: standardize plotting styles and guide

### DIFF
--- a/AI_QUICKSTART.md
+++ b/AI_QUICKSTART.md
@@ -21,6 +21,7 @@ make help     # See all available targets
 | Any code changes | [docs/02_agent/AGENTS.md](docs/02_agent/AGENTS.md) |
 | Understanding game rules | [docs/01_core/RULES.md](docs/01_core/RULES.md) |
 | Running experiments | [experiments/README.md](experiments/README.md) |
+| Generating plots | [docs/plotting_style_guide.md](docs/plotting_style_guide.md) |
 | Adding strategies | [src/bid_euchre/strategy/](src/bid_euchre/strategy/) |
 | Training models | [docs/01_core/BIDDING_MODEL.md](docs/01_core/BIDDING_MODEL.md) |
 | Known issues/gaps | [docs/03_TODO/CODEBASE_CONSISTENCY.md](docs/03_TODO/CODEBASE_CONSISTENCY.md) |

--- a/docs/archive/REPORTING.md
+++ b/docs/archive/REPORTING.md
@@ -185,6 +185,7 @@ All plots use consistent styling from `bid_euchre.reporting.style`:
   - Orange (#f39c12): Push/neutral
   - Blue (#3498db): General data
 - Statistical annotations (p-values, effect sizes)
+- Current plotting standards: `docs/plotting_style_guide.md`
 
 ## Data Sources
 

--- a/docs/images/plot_style_example.svg
+++ b/docs/images/plot_style_example.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="420" viewBox="0 0 640 420">
+  <rect width="640" height="420" fill="#ffffff"/>
+  <g font-family="Arial, sans-serif" font-size="12" fill="#333333">
+    <text x="320" y="28" text-anchor="middle" font-size="16">Example: Average Tricks by Round</text>
+    <text x="320" y="404" text-anchor="middle">Round</text>
+    <text x="18" y="220" text-anchor="middle" transform="rotate(-90 18 220)">Average Tricks</text>
+  </g>
+  <g stroke="#cccccc" stroke-width="1" opacity="0.6">
+    <line x1="70" y1="320" x2="600" y2="320"/>
+    <line x1="70" y1="270" x2="600" y2="270"/>
+    <line x1="70" y1="220" x2="600" y2="220"/>
+    <line x1="70" y1="170" x2="600" y2="170"/>
+    <line x1="70" y1="120" x2="600" y2="120"/>
+  </g>
+  <g stroke="#333333" stroke-width="1.5">
+    <line x1="70" y1="350" x2="70" y2="70"/>
+    <line x1="70" y1="350" x2="600" y2="350"/>
+  </g>
+  <g fill="#333333" font-family="Arial, sans-serif" font-size="11">
+    <text x="70" y="368" text-anchor="middle">1</text>
+    <text x="202" y="368" text-anchor="middle">2</text>
+    <text x="334" y="368" text-anchor="middle">3</text>
+    <text x="466" y="368" text-anchor="middle">4</text>
+    <text x="600" y="368" text-anchor="middle">5</text>
+  </g>
+  <g stroke="#3498db" stroke-width="2" fill="#3498db">
+    <polyline fill="none" points="70,250 202,210 334,170 466,160 600,140"/>
+    <circle cx="70" cy="250" r="4"/>
+    <circle cx="202" cy="210" r="4"/>
+    <circle cx="334" cy="170" r="4"/>
+    <circle cx="466" cy="160" r="4"/>
+    <circle cx="600" cy="140" r="4"/>
+  </g>
+  <g stroke="#e74c3c" stroke-width="2" fill="#e74c3c">
+    <polyline fill="none" points="70,290 202,250 334,210 466,200 600,180"/>
+    <circle cx="70" cy="290" r="4"/>
+    <circle cx="202" cy="250" r="4"/>
+    <circle cx="334" cy="210" r="4"/>
+    <circle cx="466" cy="200" r="4"/>
+    <circle cx="600" cy="180" r="4"/>
+  </g>
+  <g font-family="Arial, sans-serif" font-size="11" fill="#333333">
+    <rect x="440" y="78" width="160" height="46" fill="#ffffff" stroke="#cccccc"/>
+    <line x1="452" y1="94" x2="472" y2="94" stroke="#3498db" stroke-width="2"/>
+    <circle cx="462" cy="94" r="3" fill="#3498db"/>
+    <text x="480" y="98">Strategy A</text>
+    <line x1="452" y1="112" x2="472" y2="112" stroke="#e74c3c" stroke-width="2"/>
+    <circle cx="462" cy="112" r="3" fill="#e74c3c"/>
+    <text x="480" y="116">Strategy B</text>
+  </g>
+</svg>

--- a/docs/plotting_style_guide.md
+++ b/docs/plotting_style_guide.md
@@ -1,0 +1,105 @@
+# Plotting Style Guide
+
+This guide standardizes plot formatting and themes across the repository.
+It applies to Matplotlib/Seaborn and Plotly and should be used for any new
+visualization or report.
+
+## Why this exists
+- Consistent formatting makes comparisons across plots faster and less error-prone.
+- Standard palettes and typography improve readability and accessibility.
+- Shared helpers reduce ad-hoc styling decisions and bugs.
+
+## Core principles (evidence-based)
+- Prefer encodings with higher perceptual accuracy (position/length over area/angle).
+  Use bar charts, dot plots, and line charts before pies or complex 3D charts.
+  Source: Cleveland and McGill on graphical perception.
+- Label directly when possible; use legends only when direct labeling would clutter.
+  Source: US Web Design System (Data Visualization Standards).
+- Choose color deliberately and use accessible contrasts; color should not be the
+  only encoding of meaning. Source: Royal Statistical Society Data Vis Guide.
+
+## Standard formatting rules
+Use the shared helpers in `src/bid_euchre/reporting/style.py`:
+- Matplotlib: `apply_report_style()`
+- Seaborn: `apply_seaborn_style()`
+- Plotly: `get_plotly_template()` and `apply_plotly_template()`
+
+Standardized typography and layout:
+- Font sizes, line widths, and grid styles are controlled by `REPORT_STYLE`.
+- Figure sizes use `FIGSIZE_*` constants.
+- Gridlines: off by default; enable per-plot where they aid reading.
+- Titles use sentence case and describe what the viewer should learn.
+
+## Color system
+Color meanings are consistent across plots:
+- Outcomes: win/lose/push from `OUTCOME_COLORS`.
+- Strategies: `STRATEGY_COLORS`.
+- Contracts: `CONTRACT_COLORS`.
+
+Rules:
+- Use the shared palette first; do not invent new colors unless required.
+- Avoid red/green-only encoding; add shape/label or order to disambiguate.
+- Keep background white and foreground dark for contrast.
+
+## Axes, labels, and legends
+- Label axes with units and meaning (e.g., "Tricks Won", "Win Rate (%)").
+- Prefer direct labels to reduce legend scanning.
+- When legends are necessary:
+  - Use descriptive legend titles (not "Legend").
+  - Order categories meaningfully (descending or logical order).
+  - Place legends outside plot area when they obscure data.
+
+## Statistical annotations
+When reporting uncertainty:
+- Use confidence intervals where appropriate.
+- Prefer compact annotations like `95% CI [low, high]`.
+- Use consistent formatting via helpers in `style.py` (e.g., `format_ci`).
+
+## File naming and outputs
+- Use descriptive, stable filenames that reflect the plot purpose.
+- Keep plots in report output folders and follow existing reporting paths.
+- Avoid overwriting historical output; use existing archive patterns.
+
+## Library-specific usage
+
+### Matplotlib
+```python
+from bid_euchre.reporting.style import apply_report_style, FIGSIZE_SINGLE_PLOT
+
+apply_report_style()
+fig, ax = plt.subplots(figsize=FIGSIZE_SINGLE_PLOT)
+```
+
+### Seaborn
+```python
+from bid_euchre.reporting.style import apply_seaborn_style, FIGSIZE_SINGLE_PLOT
+
+apply_seaborn_style()
+fig, ax = plt.subplots(figsize=FIGSIZE_SINGLE_PLOT)
+```
+
+### Plotly
+```python
+from bid_euchre.reporting.style import apply_plotly_template
+
+apply_plotly_template()
+fig = px.line(df, x="x", y="y", title="Example")
+```
+
+## Checklist
+- Apply shared style helper before plotting.
+- Use a shared color palette.
+- Ensure labels are clear and units are explicit.
+- Avoid chart junk and unnecessary 3D effects.
+- Verify accessibility (contrast, not color-only).
+
+## Example figure
+![Plot styling example](images/plot_style_example.svg)
+
+## Sources
+- US Web Design System: Data Visualization Standards (labels, legends)
+  https://xdgov.github.io/data-design-standards/
+- Royal Statistical Society Data Visualization Guide (styling, accessibility)
+  https://royal-statistical-society.github.io/datavisguide/docs/styling.html
+- Cleveland, W. S., & McGill, R. (1984/1985) Graphical Perception
+  https://www.tandfonline.com/doi/abs/10.1080/01621459.1984.10478080

--- a/src/bid_euchre/diagnostics/charts.py
+++ b/src/bid_euchre/diagnostics/charts.py
@@ -10,6 +10,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
+from ..reporting.style import CONTRACT_COLORS, apply_report_style, apply_seaborn_style
+
 # Try to import seaborn, fall back gracefully
 try:
     import seaborn as sns
@@ -20,17 +22,19 @@ except ImportError:
 
 # Color schemes
 SEAT_COLORS = ["#3498db", "#e74c3c", "#2ecc71", "#9b59b6"]  # Blue, Red, Green, Purple
-CONTRACT_COLORS = {
-    "suit": "#3498db",
-    "high": "#e74c3c",
-    "low": "#2ecc71",
-}
 TRUMP_COLORS = {
     "C": "#2c3e50",  # Clubs - dark gray
     "D": "#e67e22",  # Diamonds - orange
     "H": "#c0392b",  # Hearts - red
     "S": "#34495e",  # Spades - dark blue-gray
 }
+
+
+def _apply_style() -> None:
+    if HAS_SEABORN:
+        apply_seaborn_style()
+    else:
+        apply_report_style()
 
 
 def plot_hand_value_by_seat(
@@ -51,6 +55,7 @@ def plot_hand_value_by_seat(
     Returns:
         matplotlib Figure
     """
+    _apply_style()
     fig, ax = plt.subplots(figsize=figsize)
 
     if "feat_hand_value" not in df.columns:
@@ -101,6 +106,7 @@ def plot_hand_value_by_contract(
     Returns:
         matplotlib Figure
     """
+    _apply_style()
     fig, ax = plt.subplots(figsize=figsize)
 
     if "feat_hand_value" not in df.columns or "contract_type" not in df.columns:
@@ -150,6 +156,7 @@ def plot_feature_distributions(
     Returns:
         matplotlib Figure
     """
+    _apply_style()
     # Get feature columns
     feat_cols = [c for c in df.columns if c.startswith("feat_")]
     if not feat_cols:
@@ -212,6 +219,7 @@ def plot_feature_correlation(
     Returns:
         matplotlib Figure
     """
+    _apply_style()
     # Get feature columns
     feat_cols = [c for c in df.columns if c.startswith("feat_")]
     numeric_cols = [c for c in feat_cols if df[c].dtype in [np.float64, np.int64, np.float32, np.int32]]
@@ -290,6 +298,7 @@ def plot_rolling_mean(
     Returns:
         matplotlib Figure
     """
+    _apply_style()
     fig, ax = plt.subplots(figsize=figsize)
 
     if column not in df.columns:
@@ -332,6 +341,7 @@ def plot_feature_vs_label(
     Returns:
         matplotlib Figure
     """
+    _apply_style()
     # Normalize column names
     feat_col = feature if feature.startswith("feat_") else f"feat_{feature}"
     label_col = label if label.startswith("feat_") else f"feat_{label}"
@@ -402,6 +412,7 @@ def plot_feature_vs_outcome(
     Returns:
         matplotlib Figure with correlation coefficient in title
     """
+    _apply_style()
     # Normalize column name
     feat_col = feature if feature.startswith("feat_") else f"feat_{feature}"
 
@@ -480,6 +491,7 @@ def plot_outcome_distributions(
     Returns:
         matplotlib Figure
     """
+    _apply_style()
     fig, ax = plt.subplots(figsize=figsize)
 
     if outcome not in df.columns or group_by not in df.columns:
@@ -538,6 +550,7 @@ def plot_feature_outcome_correlation(
     Returns:
         matplotlib Figure
     """
+    _apply_style()
     fig, ax = plt.subplots(figsize=figsize)
 
     if outcome not in df.columns:
@@ -621,6 +634,7 @@ def plot_cdf(
     Returns:
         matplotlib Figure
     """
+    _apply_style()
     fig, ax = plt.subplots(figsize=figsize)
 
     if column not in df.columns:
@@ -696,6 +710,7 @@ def plot_ccdf(
     Returns:
         matplotlib Figure
     """
+    _apply_style()
     fig, ax = plt.subplots(figsize=figsize)
 
     if column not in df.columns:
@@ -767,6 +782,7 @@ def plot_hand_value_by_trump_suit(
     Returns:
         matplotlib Figure
     """
+    _apply_style()
     fig, ax = plt.subplots(figsize=figsize)
 
     if "feat_hand_value" not in df.columns:
@@ -843,6 +859,7 @@ def plot_outcome_by_trump_suit(
     Returns:
         matplotlib Figure
     """
+    _apply_style()
     fig, ax = plt.subplots(figsize=figsize)
 
     if outcome not in df.columns:
@@ -915,6 +932,7 @@ def plot_feature_heatmap_by_suit(
     Returns:
         matplotlib Figure
     """
+    _apply_style()
     fig, ax = plt.subplots(figsize=figsize)
 
     if "trump" not in df.columns:
@@ -1017,6 +1035,7 @@ def plot_suit_variance_summary(
     Returns:
         matplotlib Figure
     """
+    _apply_style()
     fig, ax = plt.subplots(figsize=figsize)
 
     if column not in df.columns:

--- a/src/bid_euchre/diagnostics/strategy_charts.py
+++ b/src/bid_euchre/diagnostics/strategy_charts.py
@@ -22,9 +22,17 @@ from ..reporting.style import (
     FIGSIZE_MATRIX,
     FIGSIZE_SINGLE_PLOT,
     apply_report_style,
+    apply_seaborn_style,
     get_strategy_color,
     get_strategy_name,
 )
+
+
+def _apply_style() -> None:
+    if HAS_SEABORN:
+        apply_seaborn_style()
+    else:
+        apply_report_style()
 
 
 def plot_win_rate_heatmap(
@@ -48,7 +56,7 @@ def plot_win_rate_heatmap(
     Returns:
         matplotlib Figure
     """
-    apply_report_style()
+    _apply_style()
 
     # Extract unique strategies (preserve order from first appearance)
     strategies = []
@@ -149,7 +157,7 @@ def plot_tricks_distribution_comparison(
     Returns:
         matplotlib Figure
     """
-    apply_report_style()
+    _apply_style()
 
     tricks_key = f"tricks_team{team}"
 
@@ -222,7 +230,7 @@ def plot_strategy_delta_bars(
     Returns:
         matplotlib Figure
     """
-    apply_report_style()
+    _apply_style()
 
     baseline_val = baseline_results.get(metric, 5.0)
 
@@ -318,7 +326,7 @@ def plot_self_play_control(
     Returns:
         matplotlib Figure
     """
-    apply_report_style()
+    _apply_style()
 
     strategies = []
     means = []
@@ -418,7 +426,7 @@ def plot_matchup_summary(
     Returns:
         matplotlib Figure with 3 subplots
     """
-    apply_report_style()
+    _apply_style()
 
     fig, axes = plt.subplots(1, 3, figsize=figsize)
 

--- a/src/bid_euchre/reporting/__init__.py
+++ b/src/bid_euchre/reporting/__init__.py
@@ -21,15 +21,19 @@ from .paths import (
     write_latest_pointer,
 )
 from .style import (
+    BASE_COLORS,
     CONTRACT_COLORS,
     CONTRACT_LABELS,
     OUTCOME_COLORS,
     OUTCOME_LABELS,
     STRATEGY_COLORS,
     STRATEGY_NAMES,
+    apply_plotly_template,
     apply_report_style,
+    apply_seaborn_style,
     format_ci,
     format_pct,
+    get_plotly_template,
 )
 from .validation import (
     generate_validation_plots,
@@ -46,7 +50,11 @@ __all__ = [
     "STRATEGY_COLORS",
     "OUTCOME_COLORS",
     "OUTCOME_LABELS",
+    "BASE_COLORS",
     "apply_report_style",
+    "apply_seaborn_style",
+    "get_plotly_template",
+    "apply_plotly_template",
     "format_pct",
     "format_ci",
     # Paths

--- a/src/bid_euchre/reporting/style.py
+++ b/src/bid_euchre/reporting/style.py
@@ -5,6 +5,8 @@ Ensures consistency across dashboards, paired comparisons, and head-to-head repo
 """
 
 
+from typing import Dict
+
 import matplotlib.pyplot as plt
 
 # ================================
@@ -84,6 +86,20 @@ REPORT_STYLE = {
     "grid.linestyle": "--",
 }
 
+# ================================
+# Shared Palette
+# ================================
+
+BASE_COLORS = [
+    "#3498db",  # Blue
+    "#e67e22",  # Orange
+    "#2ecc71",  # Green
+    "#9b59b6",  # Purple
+    "#e74c3c",  # Red
+    "#f39c12",  # Yellow/Orange
+    "#95a5a6",  # Gray
+]
+
 
 # ================================
 # Outcome Styling (Win/Push/Loss)
@@ -120,6 +136,55 @@ def apply_report_style():
     """Apply standard report styling to matplotlib."""
     plt.rcParams.update(REPORT_STYLE)
 
+
+def apply_seaborn_style():
+    """Apply standard report styling to seaborn (and matplotlib)."""
+    try:
+        import seaborn as sns
+    except ImportError as exc:
+        raise ImportError("seaborn is required for apply_seaborn_style()") from exc
+
+    sns.set_theme(style="whitegrid", rc=REPORT_STYLE, palette=BASE_COLORS)
+
+
+def get_plotly_template() -> Dict:
+    """Return a Plotly template dict matching report styling."""
+    return {
+        "layout": {
+            "font": {"size": REPORT_STYLE["font.size"]},
+            "title": {"font": {"size": REPORT_STYLE["figure.titlesize"]}},
+            "paper_bgcolor": REPORT_STYLE["figure.facecolor"],
+            "plot_bgcolor": REPORT_STYLE["axes.facecolor"],
+            "colorway": BASE_COLORS,
+            "xaxis": {
+                "showgrid": REPORT_STYLE["axes.grid"],
+                "gridcolor": REPORT_STYLE["grid.color"],
+                "gridwidth": REPORT_STYLE["grid.linewidth"],
+                "zeroline": False,
+                "linecolor": REPORT_STYLE["axes.edgecolor"],
+            },
+            "yaxis": {
+                "showgrid": REPORT_STYLE["axes.grid"],
+                "gridcolor": REPORT_STYLE["grid.color"],
+                "gridwidth": REPORT_STYLE["grid.linewidth"],
+                "zeroline": False,
+                "linecolor": REPORT_STYLE["axes.edgecolor"],
+            },
+            "legend": {"font": {"size": REPORT_STYLE["legend.fontsize"]}},
+        }
+    }
+
+
+def apply_plotly_template(template_name: str = "bid_euchre") -> str:
+    """Register and set the default Plotly template."""
+    try:
+        import plotly.io as pio
+    except ImportError as exc:
+        raise ImportError("plotly is required for apply_plotly_template()") from exc
+
+    pio.templates[template_name] = get_plotly_template()
+    pio.templates.default = template_name
+    return template_name
 
 def format_pct(value: float, decimals: int = 1) -> str:
     """Format a proportion as percentage string."""

--- a/tests/unit/test_reporting_style.py
+++ b/tests/unit/test_reporting_style.py
@@ -1,0 +1,26 @@
+import matplotlib.pyplot as plt
+import pytest
+
+from bid_euchre.reporting import style
+
+
+def test_apply_report_style_updates_rcparams():
+    style.apply_report_style()
+    assert plt.rcParams["font.size"] == style.REPORT_STYLE["font.size"]
+    assert plt.rcParams["axes.titlesize"] == style.REPORT_STYLE["axes.titlesize"]
+    assert plt.rcParams["grid.linewidth"] == style.REPORT_STYLE["grid.linewidth"]
+
+
+def test_plotly_template_matches_style():
+    try:
+        import plotly.io as pio
+    except ImportError:
+        pytest.skip("plotly not installed")
+
+    template_name = style.apply_plotly_template()
+    template = pio.templates[template_name]
+    layout = template.layout
+
+    assert layout.font.size == style.REPORT_STYLE["font.size"]
+    assert layout.title.font.size == style.REPORT_STYLE["figure.titlesize"]
+    assert list(layout.colorway) == style.BASE_COLORS


### PR DESCRIPTION
## Summary
- add a plotting style guide with an example figure and external references
- centralize Matplotlib/Seaborn/Plotly theming helpers in reporting style
- apply shared styling to diagnostics plotting functions and add tests

## Test plan
- not run (pre-commit hooks passed during commit)