### PR TITLE
fix: improve markdown legibility in 20_outcome_health_checks

### DIFF
--- a/notebooks/phase0_bidless/20_outcome_health_checks.ipynb
+++ b/notebooks/phase0_bidless/20_outcome_health_checks.ipynb
@@ -5,7 +5,24 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Phase 0: Outcome Health ChecksThis notebook validates simulation **outcomes** (tricks_won) for the bidless Euchre dataset.**Scope:**- Outcome validity (range, contract-type breakdown)- Reproducibility checks- Outcome distributions by contract type, seat, trump- Strategy matchup analysis- CDF/CCDF tail analysis**Counterpart:**- See `10_feature_health_checks.ipynb` for feature validation**Quick start:**1. Set `MODE = \"QUICK\"` or `MODE = \"FULL\"`2. Run all cells3. Review fail-fast assertions and summary"
+    "# Phase 0: Outcome Health Checks\n",
+    "\n",
+    "This notebook validates simulation **outcomes** (tricks_won) for the bidless Euchre dataset.\n",
+    "\n",
+    "**Scope:**\n",
+    "- Outcome validity (range, contract-type breakdown)\n",
+    "- Reproducibility checks\n",
+    "- Outcome distributions by contract type, seat, trump\n",
+    "- Strategy matchup analysis\n",
+    "- CDF/CCDF tail analysis\n",
+    "\n",
+    "**Counterpart:**\n",
+    "- See `10_feature_health_checks.ipynb` for feature validation\n",
+    "\n",
+    "**Quick start:**\n",
+    "1. Set `MODE = \"QUICK\"` or `MODE = \"FULL\"`\n",
+    "2. Run all cells\n",
+    "3. Review fail-fast assertions and summary"
    ]
   },
   {
@@ -13,7 +30,11 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "---## Section 0: Configuration & SetupSet experiment parameters and import utilities."
+    "---\n",
+    "\n",
+    "## Section 0: Configuration & Setup\n",
+    "\n",
+    "Set experiment parameters and import utilities."
    ]
   },
   {
@@ -157,7 +178,11 @@
    "id": "7",
    "metadata": {},
    "source": [
-    "---## Section 2: Fail-Fast Validation TestsCritical assertions that must pass before proceeding with analysis."
+    "---\n",
+    "\n",
+    "## Section 2: Fail-Fast Validation Tests\n",
+    "\n",
+    "Critical assertions that must pass before proceeding with analysis."
    ]
   },
   {
@@ -165,7 +190,9 @@
    "id": "8",
    "metadata": {},
    "source": [
-    "### Test 3: Outcome Validity (with Contract-Type Breakdown)**Enhancement:** This test now breaks down outcome statistics by contract type to detect contract-specific simulation bugs."
+    "### Test 3: Outcome Validity (with Contract-Type Breakdown)\n",
+    "\n",
+    "**Enhancement:** This test now breaks down outcome statistics by contract type to detect contract-specific simulation bugs."
    ]
   },
   {
@@ -251,7 +278,9 @@
    "id": "10",
    "metadata": {},
    "source": [
-    "### Test 4: Reproducibility Check (Outcome Portion)Verify that running with the same seed produces identical outcomes."
+    "### Test 4: Reproducibility Check (Outcome Portion)\n",
+    "\n",
+    "Verify that running with the same seed produces identical outcomes."
    ]
   },
   {
@@ -319,7 +348,11 @@
    "id": "12",
    "metadata": {},
    "source": [
-    "---## Section 3: Outcome Distributions by Contract TypeVisualize outcome distributions segregated by contract type using violin plots."
+    "---\n",
+    "\n",
+    "## Section 3: Outcome Distributions by Contract Type\n",
+    "\n",
+    "Visualize outcome distributions segregated by contract type using violin plots."
    ]
   },
   {
@@ -409,7 +442,11 @@
    "id": "15",
    "metadata": {},
    "source": [
-    "---## Section 4: Strategy Matchup AnalysisCompare outcomes across different strategy pairings (if applicable)."
+    "---\n",
+    "\n",
+    "## Section 4: Strategy Matchup Analysis\n",
+    "\n",
+    "Compare outcomes across different strategy pairings (if applicable)."
    ]
   },
   {
@@ -532,7 +569,11 @@
    "id": "19",
    "metadata": {},
    "source": [
-    "---## Section 5: Trump Suit Analysis (Suit Contracts Only)Examine outcome variation by trump suit for suit contracts."
+    "---\n",
+    "\n",
+    "## Section 5: Trump Suit Analysis (Suit Contracts Only)\n",
+    "\n",
+    "Examine outcome variation by trump suit for suit contracts."
    ]
   },
   {
@@ -600,7 +641,11 @@
    "id": "21",
    "metadata": {},
    "source": [
-    "---## Section 6: Distribution Analysis (CDF/CCDF)Cumulative distribution functions to examine tail behavior."
+    "---\n",
+    "\n",
+    "## Section 6: Distribution Analysis (CDF/CCDF)\n",
+    "\n",
+    "Cumulative distribution functions to examine tail behavior."
    ]
   },
   {
@@ -685,7 +730,11 @@
    "id": "24",
    "metadata": {},
    "source": [
-    "---## Section 7: SummaryFinal health scorecard for outcome validation."
+    "---\n",
+    "\n",
+    "## Section 7: Summary\n",
+    "\n",
+    "Final health scorecard for outcome validation."
    ]
   },
   {
@@ -774,7 +823,15 @@
    "id": "26",
    "metadata": {},
    "source": [
-    "---## End of Notebook**Next steps:**- If failures detected, investigate simulation logic- If warnings present, consider increasing sample size (use MODE=\"FULL\")- See `10_feature_health_checks.ipynb` for feature validation- See `30_feature_outcome_eval.ipynb` for feature-label relationships"
+    "---\n",
+    "\n",
+    "## End of Notebook\n",
+    "\n",
+    "**Next steps:**\n",
+    "- If failures detected, investigate simulation logic\n",
+    "- If warnings present, consider increasing sample size (use MODE=\"FULL\")\n",
+    "- See `10_feature_health_checks.ipynb` for feature validation\n",
+    "- See `30_feature_outcome_eval.ipynb` for feature-label relationships"
    ]
   }
  ],

--- a/notebooks/phase0_bidless/20_outcome_health_checks.py
+++ b/notebooks/phase0_bidless/20_outcome_health_checks.py
@@ -25,10 +25,31 @@
 # ---
 
 # %% [markdown]
-# # Phase 0: Outcome Health ChecksThis notebook validates simulation **outcomes** (tricks_won) for the bidless Euchre dataset.**Scope:**- Outcome validity (range, contract-type breakdown)- Reproducibility checks- Outcome distributions by contract type, seat, trump- Strategy matchup analysis- CDF/CCDF tail analysis**Counterpart:**- See `10_feature_health_checks.ipynb` for feature validation**Quick start:**1. Set `MODE = "QUICK"` or `MODE = "FULL"`2. Run all cells3. Review fail-fast assertions and summary
+# # Phase 0: Outcome Health Checks
+#
+# This notebook validates simulation **outcomes** (tricks_won) for the bidless Euchre dataset.
+#
+# **Scope:**
+# - Outcome validity (range, contract-type breakdown)
+# - Reproducibility checks
+# - Outcome distributions by contract type, seat, trump
+# - Strategy matchup analysis
+# - CDF/CCDF tail analysis
+#
+# **Counterpart:**
+# - See `10_feature_health_checks.ipynb` for feature validation
+#
+# **Quick start:**
+# 1. Set `MODE = "QUICK"` or `MODE = "FULL"`
+# 2. Run all cells
+# 3. Review fail-fast assertions and summary
 
 # %% [markdown]
-# ---## Section 0: Configuration & SetupSet experiment parameters and import utilities.
+# ---
+#
+# ## Section 0: Configuration & Setup
+#
+# Set experiment parameters and import utilities.
 
 # %%
 # ============================================================================
@@ -132,10 +153,16 @@ if 'strategy_id' in outcome_df.columns:
 print("=" * 70)
 
 # %% [markdown]
-# ---## Section 2: Fail-Fast Validation TestsCritical assertions that must pass before proceeding with analysis.
+# ---
+#
+# ## Section 2: Fail-Fast Validation Tests
+#
+# Critical assertions that must pass before proceeding with analysis.
 
 # %% [markdown]
-# ### Test 3: Outcome Validity (with Contract-Type Breakdown)**Enhancement:** This test now breaks down outcome statistics by contract type to detect contract-specific simulation bugs.
+# ### Test 3: Outcome Validity (with Contract-Type Breakdown)
+#
+# **Enhancement:** This test now breaks down outcome statistics by contract type to detect contract-specific simulation bugs.
 
 # %%
 # ============================================================================
@@ -209,7 +236,9 @@ else:
     print("\n⚠️  SKIPPED: outcome_df does not have tricks_won column")
 
 # %% [markdown]
-# ### Test 4: Reproducibility Check (Outcome Portion)Verify that running with the same seed produces identical outcomes.
+# ### Test 4: Reproducibility Check (Outcome Portion)
+#
+# Verify that running with the same seed produces identical outcomes.
 
 # %%
 # ============================================================================
@@ -265,7 +294,11 @@ print("✅ Reproducibility check PASSED")
 print("=" * 70)
 
 # %% [markdown]
-# ---## Section 3: Outcome Distributions by Contract TypeVisualize outcome distributions segregated by contract type using violin plots.
+# ---
+#
+# ## Section 3: Outcome Distributions by Contract Type
+#
+# Visualize outcome distributions segregated by contract type using violin plots.
 
 # %%
 # ============================================================================
@@ -336,7 +369,11 @@ plt.show()
 print("✓ Seat-level outcome distributions plotted")
 
 # %% [markdown]
-# ---## Section 4: Strategy Matchup AnalysisCompare outcomes across different strategy pairings (if applicable).
+# ---
+#
+# ## Section 4: Strategy Matchup Analysis
+#
+# Compare outcomes across different strategy pairings (if applicable).
 
 # %%
 # ============================================================================
@@ -433,7 +470,11 @@ else:
     print("  (Skipped - no strategy variation)")
 
 # %% [markdown]
-# ---## Section 5: Trump Suit Analysis (Suit Contracts Only)Examine outcome variation by trump suit for suit contracts.
+# ---
+#
+# ## Section 5: Trump Suit Analysis (Suit Contracts Only)
+#
+# Examine outcome variation by trump suit for suit contracts.
 
 # %%
 # ============================================================================
@@ -489,7 +530,11 @@ else:
     print("\n⚠️  No trump column - skipping trump analysis")
 
 # %% [markdown]
-# ---## Section 6: Distribution Analysis (CDF/CCDF)Cumulative distribution functions to examine tail behavior.
+# ---
+#
+# ## Section 6: Distribution Analysis (CDF/CCDF)
+#
+# Cumulative distribution functions to examine tail behavior.
 
 # %%
 # ============================================================================
@@ -555,7 +600,11 @@ plt.show()
 print("✓ CCDF plotted")
 
 # %% [markdown]
-# ---## Section 7: SummaryFinal health scorecard for outcome validation.
+# ---
+#
+# ## Section 7: Summary
+#
+# Final health scorecard for outcome validation.
 
 # %%
 # ============================================================================
@@ -632,4 +681,12 @@ else:
 print("=" * 70)
 
 # %% [markdown]
-# ---## End of Notebook**Next steps:**- If failures detected, investigate simulation logic- If warnings present, consider increasing sample size (use MODE="FULL")- See `10_feature_health_checks.ipynb` for feature validation- See `30_feature_outcome_eval.ipynb` for feature-label relationships
+# ---
+#
+# ## End of Notebook
+#
+# **Next steps:**
+# - If failures detected, investigate simulation logic
+# - If warnings present, consider increasing sample size (use MODE="FULL")
+# - See `10_feature_health_checks.ipynb` for feature validation
+# - See `30_feature_outcome_eval.ipynb` for feature-label relationships


### PR DESCRIPTION
## Summary
- Add proper line breaks between sections in markdown cells in `20_outcome_health_checks.ipynb`
- Fix 11 markdown cells that had text concatenated on single lines without formatting
- Update paired `.py` file to maintain jupytext sync

## Why
The markdown cells in `20_outcome_health_checks.ipynb` had all text run together on single lines (e.g., `# Phase 0: Outcome Health ChecksThis notebook validates...`), making them difficult to read when rendered.

## Repro / Validation
```bash
cd /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-markdown-legibility
make notebook-sync  # Confirms files are in sync
make check          # All tests pass
```

## Tests
- `make repo-lint` - Passed
- `make lint` (ruff) - Passed  
- `make test` - 759 tests passed
- `make notebook-sync` - Files in sync

## Worktree Proof
```
$ pwd
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-markdown-legibility

$ git rev-parse --show-toplevel
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-markdown-legibility

$ git worktree list
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                          9fcba92 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-markdown-legibility  eada42a [fix-markdown-legibility]
```

🤖 Generated with [Claude Code](https://claude.ai/code)