### PR TITLE
fix: correct .UPPER() typo to .upper() in outcome health checks

### DIFF
--- a/notebooks/phase0_bidless/20_outcome_health_checks.ipynb
+++ b/notebooks/phase0_bidless/20_outcome_health_checks.ipynb
@@ -768,7 +768,7 @@
     "            contract_df = outcome_df[outcome_df['contract_type'] == contract_type]\n",
     "            mean_tricks = contract_df['tricks_won'].mean()\n",
     "            if 4.0 <= mean_tricks <= 6.0:\n",
-    "                summary['passes'].append(f\"  ✅ {contract_type.UPPER()}: mean={mean_tricks:.3f} in [4.0, 6.0]\")\n",
+    "                summary['passes'].append(f\"  ✅ {contract_type.upper()}: mean={mean_tricks:.3f} in [4.0, 6.0]\")\n",
     "            else:\n",
     "                summary['warnings'].append(f\"  ⚠️  {contract_type.upper()}: mean={mean_tricks:.3f} outside [4.0, 6.0]\")\n",
     "    else:\n",

--- a/notebooks/phase0_bidless/20_outcome_health_checks.py
+++ b/notebooks/phase0_bidless/20_outcome_health_checks.py
@@ -631,7 +631,7 @@ if 'tricks_won' in outcome_df.columns:
             contract_df = outcome_df[outcome_df['contract_type'] == contract_type]
             mean_tricks = contract_df['tricks_won'].mean()
             if 4.0 <= mean_tricks <= 6.0:
-                summary['passes'].append(f"  ✅ {contract_type.UPPER()}: mean={mean_tricks:.3f} in [4.0, 6.0]")
+                summary['passes'].append(f"  ✅ {contract_type.upper()}: mean={mean_tricks:.3f} in [4.0, 6.0]")
             else:
                 summary['warnings'].append(f"  ⚠️  {contract_type.upper()}: mean={mean_tricks:.3f} outside [4.0, 6.0]")
     else:


### PR DESCRIPTION
## Summary
- Fixed typo `.UPPER()` → `.upper()` in the final cell of `20_outcome_health_checks.ipynb`

## Why
The notebook throws an `AttributeError` because Python string methods are lowercase (`.upper()` not `.UPPER()`).

## Repro / Validation
```bash
make notebook-sync
make check
```

## Tests
- `make check` passes (repo-lint, ruff, pytest)
- Notebook sync verified via `make notebook-sync`

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre
branch: fix/outcome-health-checks-typo
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)