### PR TITLE
fix: add missing strategies/matchups params to reproducibility test

### DIFF
--- a/notebooks/phase0_bidless/20_outcome_health_checks.ipynb
+++ b/notebooks/phase0_bidless/20_outcome_health_checks.ipynb
@@ -390,6 +390,8 @@
     "    contracts=CONTRACT_TYPES,\n",
     "    trumps=TRUMPS_FOR_SUIT_CONTRACTS,\n",
     "    seats=SEATS,\n",
+    "    strategies=STRATEGIES,\n",
+    "    matchups=MATCHUPS,\n",
     ")\n",
     "\n",
     "# Compare\n",

--- a/notebooks/phase0_bidless/20_outcome_health_checks.py
+++ b/notebooks/phase0_bidless/20_outcome_health_checks.py
@@ -336,6 +336,8 @@ outcome_df2 = load_or_generate_outcomes(
     contracts=CONTRACT_TYPES,
     trumps=TRUMPS_FOR_SUIT_CONTRACTS,
     seats=SEATS,
+    strategies=STRATEGIES,
+    matchups=MATCHUPS,
 )
 
 # Compare


### PR DESCRIPTION
## Summary
- Added missing `strategies=STRATEGIES` and `matchups=MATCHUPS` parameters to the second `load_or_generate_outcomes()` call in Test 4 (Reproducibility Check)

## Why
The reproducibility test was failing with "Shape mismatch" because the second dataset generation used default parameters instead of matching the first call's parameters. Without `strategies` and `matchups`, it defaulted to:
- 1 strategy (greedy only) instead of 4 strategies
- Self-play mode instead of 12 matchups

This produced far fewer rows than the first dataset, causing the shape comparison assertion to fail.

## Repro / Validation
```bash
cd /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-outcome-health-check
make notebook-sync
make check
```

## Tests
- `make check` passes (750 tests pass)
- Notebook sync verified with `make notebook-sync` and `make notebook-check`

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-outcome-health-check
toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-outcome-health-check
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                              85ae0fe [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-outcome-health-check     82e7dce [fix/outcome-health-check-shape-mismatch]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)