### PR TITLE
feat: add random strategy baseline and improve heatmap formatting

### DIFF
--- a/notebooks/phase0_bidless/20_outcome_health_checks.ipynb
+++ b/notebooks/phase0_bidless/20_outcome_health_checks.ipynb
@@ -71,6 +71,7 @@
     "STRATEGIES = [\n",
     "    {\"name\": \"greedy\", \"class_name\": \"GreedyStrategy\"},\n",
     "    {\"name\": \"glutton\", \"class_name\": \"GluttonStrategy\"},\n",
+    "    {\"name\": \"random\", \"class_name\": \"RandomLegalStrategy\"},\n",
     "    {\"name\": \"always_highest\", \"class_name\": \"AlwaysHighestLegalStrategy\"},\n",
     "    {\"name\": \"always_lowest\", \"class_name\": \"AlwaysLowestLegalStrategy\"},\n",
     "]\n",

--- a/notebooks/phase0_bidless/20_outcome_health_checks.py
+++ b/notebooks/phase0_bidless/20_outcome_health_checks.py
@@ -75,6 +75,7 @@ SEATS = [0, 1, 2, 3]
 STRATEGIES = [
     {"name": "greedy", "class_name": "GreedyStrategy"},
     {"name": "glutton", "class_name": "GluttonStrategy"},
+    {"name": "random", "class_name": "RandomLegalStrategy"},
     {"name": "always_highest", "class_name": "AlwaysHighestLegalStrategy"},
     {"name": "always_lowest", "class_name": "AlwaysLowestLegalStrategy"},
 ]

--- a/notebooks/phase0_bidless/30_feature_outcome_eval.ipynb
+++ b/notebooks/phase0_bidless/30_feature_outcome_eval.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Feature-Outcome Relationship Analysis\n",
@@ -44,6 +45,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2",
    "metadata": {},
    "source": [
     "---\n",
@@ -53,6 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "3",
    "metadata": {
     "tags": [
      "parameters"
@@ -73,6 +76,7 @@
     "STRATEGIES = [\n",
     "    {\"name\": \"greedy\", \"class_name\": \"GreedyStrategy\"},\n",
     "    {\"name\": \"glutton\", \"class_name\": \"GluttonStrategy\"},\n",
+    "    {\"name\": \"random\", \"class_name\": \"RandomLegalStrategy\"},\n",
     "    {\"name\": \"always_highest\", \"class_name\": \"AlwaysHighestLegalStrategy\"},\n",
     "    {\"name\": \"always_lowest\", \"class_name\": \"AlwaysLowestLegalStrategy\"},\n",
     "]\n",
@@ -99,6 +103,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4",
    "metadata": {},
    "source": [
     "### Imports"
@@ -107,6 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,6 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -219,6 +226,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7",
    "metadata": {},
    "source": [
     "---\n",
@@ -228,6 +236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,6 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,6 +289,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "10",
    "metadata": {},
    "source": [
     "---\n",
@@ -300,6 +311,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -413,6 +425,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -463,6 +476,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -533,6 +547,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "16",
    "metadata": {},
    "source": [
     "### 2.3 Matchup Summary Table"
@@ -541,6 +556,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -566,6 +582,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -664,6 +681,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -765,6 +783,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -872,6 +891,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "24",
    "metadata": {},
    "source": [
     "### 2.7 Strategy Performance by Seat (B pattern)\n",
@@ -1025,6 +1045,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1082,6 +1103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1117,6 +1139,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "31",
    "metadata": {},
    "source": [
     "---\n",
@@ -1128,6 +1151,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1198,6 +1222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1218,6 +1243,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1259,6 +1285,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "35",
    "metadata": {},
    "source": [
     "---\n",
@@ -1270,6 +1297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1374,5 +1402,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/notebooks/phase0_bidless/30_feature_outcome_eval.py
+++ b/notebooks/phase0_bidless/30_feature_outcome_eval.py
@@ -68,6 +68,7 @@ SEATS = [0, 1, 2, 3]
 STRATEGIES = [
     {"name": "greedy", "class_name": "GreedyStrategy"},
     {"name": "glutton", "class_name": "GluttonStrategy"},
+    {"name": "random", "class_name": "RandomLegalStrategy"},
     {"name": "always_highest", "class_name": "AlwaysHighestLegalStrategy"},
     {"name": "always_lowest", "class_name": "AlwaysLowestLegalStrategy"},
 ]

--- a/src/bid_euchre/diagnostics/strategy_charts.py
+++ b/src/bid_euchre/diagnostics/strategy_charts.py
@@ -40,6 +40,7 @@ def plot_win_rate_heatmap(
     metric: str = "win_rate",
     figsize: Tuple[int, int] = FIGSIZE_MATRIX,
     title: Optional[str] = None,
+    fmt: Optional[str] = None,
 ) -> plt.Figure:
     """Plot heatmap of win rates for all strategy matchups.
 
@@ -52,6 +53,7 @@ def plot_win_rate_heatmap(
         metric: Key in result dict to plot (default "win_rate" for Team 0)
         figsize: Figure size tuple
         title: Optional title override
+        fmt: Format string for annotations. Default: ".1%" for win_rate, ".1f" otherwise
 
     Returns:
         matplotlib Figure
@@ -90,28 +92,39 @@ def plot_win_rate_heatmap(
     # Create figure
     fig, ax = plt.subplots(figsize=figsize)
 
+    # Determine format string
+    if fmt is None:
+        fmt = ".1%" if metric == "win_rate" else ".1f"
+
+    # Determine colorbar label and value range
+    is_win_rate = metric == "win_rate"
+    vmin = 0 if is_win_rate else None
+    vmax = 1 if is_win_rate else None
+    center = 0.5 if is_win_rate else None
+    cbar_label = "Win Rate (Team 0)" if is_win_rate else metric
+
     # Plot heatmap
     if HAS_SEABORN:
         labels = [get_strategy_name(s) for s in strategies]
         annot = np.array(
-            [[f"{v:.1%}" if not np.isnan(v) else "" for v in row] for row in matrix]
+            [[f"{v:{fmt}}" if not np.isnan(v) else "" for v in row] for row in matrix]
         )
         sns.heatmap(
             matrix,
             annot=annot,
             fmt="",
             cmap="RdYlGn",
-            center=0.5,
-            vmin=0,
-            vmax=1,
+            center=center,
+            vmin=vmin,
+            vmax=vmax,
             ax=ax,
             xticklabels=labels,
             yticklabels=labels,
-            cbar_kws={"label": "Win Rate (Team 0)"},
+            cbar_kws={"label": cbar_label},
         )
     else:
-        im = ax.imshow(matrix, cmap="RdYlGn", vmin=0, vmax=1, aspect="auto")
-        fig.colorbar(im, ax=ax, label="Win Rate (Team 0)")
+        im = ax.imshow(matrix, cmap="RdYlGn", vmin=vmin, vmax=vmax, aspect="auto")
+        fig.colorbar(im, ax=ax, label=cbar_label)
 
         # Labels
         labels = [get_strategy_name(s) for s in strategies]
@@ -125,9 +138,9 @@ def plot_win_rate_heatmap(
             for j in range(n):
                 val = matrix[i, j]
                 if not np.isnan(val):
-                    color = "white" if val < 0.3 or val > 0.7 else "black"
+                    color = "white" if (vmax and (val < 0.3 * vmax or val > 0.7 * vmax)) else "black"
                     ax.text(
-                        j, i, f"{val:.1%}", ha="center", va="center", color=color
+                        j, i, f"{val:{fmt}}", ha="center", va="center", color=color
                     )
 
     ax.set_xlabel("Team 1 Strategy")

--- a/src/bid_euchre/reporting/style.py
+++ b/src/bid_euchre/reporting/style.py
@@ -39,6 +39,7 @@ CONTRACT_COLORS = {
 STRATEGY_NAMES = {
     "greedy": "Greedy",
     "glutton": "Glutton",
+    "random": "Random",
     "random_legal": "Random Legal",
     "always_lowest": "Always Lowest",
     "always_highest": "Always Highest",
@@ -48,6 +49,7 @@ STRATEGY_NAMES = {
 STRATEGY_COLORS = {
     "greedy": "#2ecc71",
     "glutton": "#27ae60",
+    "random": "#7f8c8d",
     "random_legal": "#95a5a6",
     "always_lowest": "#3498db",
     "always_highest": "#e74c3c",


### PR DESCRIPTION
## Summary
- Add "random" strategy entry to `STRATEGY_NAMES` and `STRATEGY_COLORS` for consistent styling
- Add `fmt` parameter to `plot_win_rate_heatmap` for custom number formatting
- Add random strategy (`RandomLegalStrategy`) to both phase0 notebook configs
- Heatmap auto-detects formatting based on metric type (`.1%` for win_rate, `.1f` otherwise)

## Why
The random strategy baseline enables meaningful comparison between "smart" strategies (greedy, glutton) and a random baseline. The `fmt` parameter allows proper integer display for mean_tricks metrics instead of showing them as percentages.

## Repro / Validation
```bash
make check  # All tests pass (750 passed)
```

## Tests
- `make repo-lint` - passed
- `make lint` - passed
- `make test` - passed (750 tests)
- Notebooks synced and stripped

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre
Branch: feat/enhance-30-feature-outcome-eval-v2 (from main)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)