### PR TITLE
feat(strategy): add probabilistic trump-in to GluttonStrategy

### DIFF
--- a/src/bid_euchre/strategy/greedy.py
+++ b/src/bid_euchre/strategy/greedy.py
@@ -326,6 +326,65 @@ class GluttonStrategy(Strategy):
             # Just discard the cheapest card (lowest value)
             return min(legal_indices, key=card_value)
 
+    def _should_trump_in(
+        self,
+        hand: List[Card],
+        plays_so_far: List[Tuple[int, Card]],
+        player_index: int,
+    ) -> bool:
+        """
+        Returns True if we should consider trumping in to protect partner.
+
+        Conditions (ALL must be true):
+        - Suit contract with trump
+        - Not leading (plays_so_far not empty)
+        - We are void in led suit (can't follow)
+        - We have trump in hand
+        - We are 3rd seat (4th seat opponent plays after us)
+        - 4th seat is void in led suit AND might have trump
+
+        This protects partner from having their winning card trumped by 4th seat.
+        """
+        # Guard: must be suit contract with trump
+        if self._contract_type != "suit" or self._trump_suit is None:
+            return False
+
+        # Guard: must be following (not leading)
+        if not plays_so_far:
+            return False
+
+        # Get led suit
+        led_suit = effective_suit(plays_so_far[0][1], self._trump_suit, self._contract_type)
+
+        # Check if we're void in led suit (can't follow)
+        can_follow = any(
+            effective_suit(hand[idx], self._trump_suit, self._contract_type) == led_suit
+            for idx in range(len(hand))
+        )
+        if can_follow:
+            return False  # Can follow suit, not a trump-in decision
+
+        # Check if we have trump
+        trump_in_hand = any(
+            effective_suit(c, self._trump_suit, self._contract_type) == self._trump_suit
+            for c in hand
+        )
+        if not trump_in_hand:
+            return False  # No trump to play
+
+        # Position check: only 3rd seat needs to worry about 4th seat
+        pos = len(plays_so_far)
+        if pos != 2:
+            return False  # Only 3rd seat considers this logic
+
+        # Check 4th seat's void status
+        fourth_seat = (player_index + 1) % 4
+        fourth_void_in_led = led_suit in self._void_suits_by_seat[fourth_seat]
+        fourth_might_have_trump = self._trump_suit not in self._void_suits_by_seat[fourth_seat]
+
+        # If 4th seat is void in led suit and might have trump, we should trump in
+        return fourth_void_in_led and fourth_might_have_trump
+
     def choose_card(
         self,
         hand: List[Card],
@@ -438,6 +497,23 @@ class GluttonStrategy(Strategy):
                             "card": str(hand[choice]),
                         })
                     return choice
+
+                # Probabilistic trump-in: protect partner from 4th seat trump
+                if self._should_trump_in(hand, plays_so_far, player_index):
+                    # Find cheapest trump winner
+                    trump_winners = [
+                        idx for idx in winning_candidates
+                        if effective_suit(hand[idx], trump_suit, contract_type) == trump_suit
+                    ]
+                    if trump_winners:
+                        choice = min(trump_winners, key=card_value)
+                        if self.debug:
+                            self.decision_log.append({
+                                "scenario": "probabilistic_trump_cover",
+                                "action": "trump_to_protect_partner",
+                                "card": str(hand[choice]),
+                            })
+                        return choice
 
             # Partner safe or no sure winner — smart discard
             choice = self._choose_discard(hand, legal_indices)

--- a/tests/unit/test_glutton.py
+++ b/tests/unit/test_glutton.py
@@ -605,3 +605,155 @@ class TestHooksIntegration:
         )
 
         assert "S" in strategy._void_suits_by_seat[1]
+
+
+class TestProbabilisticTrumpIn:
+    """Tests for void-aware probabilistic trump-in decisions."""
+
+    def test_trump_in_when_fourth_seat_void(self):
+        """Should trump in when 4th seat is void in led suit and might have trump."""
+        glutton = GluttonStrategy(debug=True)
+
+        # Void in clubs, have trump
+        hand = [
+            Card("H", "T"),  # idx 0 - Low trump
+            Card("D", "K"),  # idx 1 - Offsuit (can't follow clubs)
+        ]
+
+        glutton.on_hand_start(hand, "suit", "H", player_index=2)
+
+        # Mark 4th seat (player 3) as void in clubs (from earlier play)
+        glutton._void_suits_by_seat[3].add("C")
+
+        # Partner is winning with clubs Ace
+        plays_so_far = [
+            (0, Card("C", "A")),  # Partner leads Ace - winning
+            (1, Card("C", "Q")),  # Opponent plays lower
+        ]
+
+        choice = glutton.choose_card(hand, plays_so_far, "suit", "H", 2)
+
+        # Should trump to protect partner from 4th seat trump
+        assert choice == 0, f"Should trump in, got {choice}"
+        assert glutton.decision_log[-1]["scenario"] == "probabilistic_trump_cover"
+
+    def test_no_trump_in_when_fourth_seat_can_follow(self):
+        """Should not trump if 4th seat can follow suit."""
+        glutton = GluttonStrategy(debug=True)
+
+        hand = [
+            Card("H", "T"),  # idx 0 - Trump
+            Card("D", "K"),  # idx 1 - Offsuit
+        ]
+
+        glutton.on_hand_start(hand, "suit", "H", player_index=2)
+
+        # 4th seat is NOT void in clubs
+        # (no entry in _void_suits_by_seat[3] for "C")
+
+        plays_so_far = [
+            (0, Card("C", "A")),  # Partner leads Ace - winning
+            (1, Card("C", "Q")),  # Opponent plays lower
+        ]
+
+        choice = glutton.choose_card(hand, plays_so_far, "suit", "H", 2)
+
+        # Should NOT trump (partner safe, 4th seat can follow suit)
+        assert choice == 1, f"Should discard, got {choice}"
+        assert glutton.decision_log[-1]["scenario"] == "partner_winning"
+
+    def test_no_trump_in_high_contract(self):
+        """Should not trigger trump-in logic in high contract."""
+        glutton = GluttonStrategy(debug=True)
+
+        hand = [
+            Card("H", "A"),  # idx 0 - Hearts Ace
+            Card("D", "K"),  # idx 1 - Offsuit
+        ]
+
+        glutton.on_hand_start(hand, "high", None, player_index=2)
+        glutton._void_suits_by_seat[3].add("C")  # Would trigger in suit contract
+
+        plays_so_far = [
+            (0, Card("C", "A")),  # Partner winning
+            (1, Card("C", "Q")),
+        ]
+
+        choice = glutton.choose_card(hand, plays_so_far, "high", None, 2)
+
+        # High contract - no trump-in logic applies
+        assert choice == 1  # Discard offsuit
+        assert glutton.decision_log[-1]["scenario"] == "partner_winning"
+
+    def test_no_trump_in_when_fourth_seat_void_in_trump(self):
+        """Should not trump if 4th seat is void in trump (can't overtrump)."""
+        glutton = GluttonStrategy(debug=True)
+
+        hand = [
+            Card("H", "T"),  # idx 0 - Trump
+            Card("D", "K"),  # idx 1 - Offsuit
+        ]
+
+        glutton.on_hand_start(hand, "suit", "H", player_index=2)
+
+        # 4th seat is void in clubs AND void in hearts (trump)
+        glutton._void_suits_by_seat[3].add("C")
+        glutton._void_suits_by_seat[3].add("H")  # No trump!
+
+        plays_so_far = [
+            (0, Card("C", "A")),  # Partner leads Ace - winning
+            (1, Card("C", "Q")),  # Opponent plays lower
+        ]
+
+        choice = glutton.choose_card(hand, plays_so_far, "suit", "H", 2)
+
+        # 4th seat is void in trump, can't overtrump partner's lead
+        assert choice == 1, f"Should discard, got {choice}"
+        assert glutton.decision_log[-1]["scenario"] == "partner_winning"
+
+    def test_no_trump_in_when_can_follow_suit(self):
+        """Should not consider trump-in if we can follow suit."""
+        glutton = GluttonStrategy(debug=True)
+
+        # Can follow clubs
+        hand = [
+            Card("H", "T"),  # idx 0 - Trump
+            Card("C", "K"),  # idx 1 - Can follow suit
+        ]
+
+        glutton.on_hand_start(hand, "suit", "H", player_index=2)
+        glutton._void_suits_by_seat[3].add("C")  # 4th seat void in clubs
+
+        plays_so_far = [
+            (0, Card("C", "A")),  # Partner leads Ace - winning
+            (1, Card("C", "Q")),  # Opponent plays lower
+        ]
+
+        choice = glutton.choose_card(hand, plays_so_far, "suit", "H", 2)
+
+        # We must follow suit with C-K
+        assert choice == 1, f"Should follow suit with C-K, got {choice}"
+        assert glutton.decision_log[-1]["scenario"] == "partner_winning"
+
+    def test_no_trump_in_not_third_seat(self):
+        """Probabilistic trump-in should only apply in 3rd seat."""
+        glutton = GluttonStrategy(debug=True)
+
+        hand = [
+            Card("H", "T"),  # idx 0 - Trump
+            Card("D", "K"),  # idx 1 - Offsuit
+        ]
+
+        glutton.on_hand_start(hand, "suit", "H", player_index=1)
+        glutton._void_suits_by_seat[2].add("C")  # Next player void
+
+        # 2nd seat position (only 1 play so far)
+        plays_so_far = [
+            (0, Card("C", "A")),  # Player 0 leads - partner is (1+2)%4=3, not 0
+        ]
+
+        glutton.choose_card(hand, plays_so_far, "suit", "H", 1)
+
+        # In 2nd seat, 4th seat protection doesn't apply
+        # Player 0 is opponent for player 1 - so we try to win
+        assert glutton.decision_log[-1]["scenario"] != "probabilistic_trump_cover"


### PR DESCRIPTION
## Summary

- Add `_should_trump_in()` helper for void-aware trump-in decisions
- Integrate probabilistic trump-in into `choose_card()` to protect partner from 4th-seat trump
- Add `TestProbabilisticTrumpIn` test class with 6 comprehensive tests

## Why

When partner is winning the trick and 4th-seat opponent is void in led suit (and might have trump), partner's winning card is vulnerable. This PR adds logic to trump in preemptively to protect partner.

This is the second part of the Glutton final state plan:
- PR1 (merged): Minimal wiring + 3rd-seat restructuring
- **PR2 (this)**: Probabilistic trump-in for partner protection

## Repro / Validation

```bash
make check
uv run pytest tests/unit/test_glutton.py -v
```

## Tests

- `make check` passes (766 tests)
- 28 glutton tests pass, including 6 new `TestProbabilisticTrumpIn` tests:
  - `test_trump_in_when_fourth_seat_void` - trumps to protect partner
  - `test_no_trump_in_when_fourth_seat_can_follow` - skips when 4th can follow
  - `test_no_trump_in_high_contract` - skips in no-trump contracts
  - `test_no_trump_in_when_fourth_seat_void_in_trump` - skips when 4th has no trump
  - `test_no_trump_in_when_can_follow_suit` - skips when we can follow suit
  - `test_no_trump_in_not_third_seat` - only applies in 3rd seat

## Worktree proof

```
pwd:
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-feat-glutton-pr2-trump-in

git rev-parse --show-toplevel:
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-feat-glutton-pr2-trump-in

git worktree list (excerpt):
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                       efa1c05 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-feat-glutton-pr2-trump-in  b5f6552 [feat-glutton-pr2-trump-in]
```