### PR TITLE
feat(strategy): add GluttonIsolatedStrategy for feature isolation testing

### DIFF
--- a/experiments/configs/glutton_feature_isolation.yaml
+++ b/experiments/configs/glutton_feature_isolation.yaml
@@ -1,0 +1,168 @@
+# Glutton Feature Isolation Experiments
+#
+# Tests each Glutton improvement individually against Greedy baseline.
+# Each feature is isolated to measure its individual contribution.
+#
+# Run with:
+#   cd /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-feat-glutton-feature-isolation
+#   PYTHONPATH=src uv run python experiments/run_experiment.py \
+#     --config experiments/configs/glutton_feature_isolation.yaml \
+#     --seed 42 --n_per 100000
+
+experiment_name: glutton_feature_isolation
+
+parameters:
+  n_per: 100000
+  seed: 42
+  log_level: none
+  mode: head_to_head_matrix
+
+# Define strategies - each tests one feature in isolation
+strategies:
+  # Baseline: Greedy (no improvements)
+  - name: greedy
+    class_name: GreedyStrategy
+
+  # Feature 1: Smart Leads only
+  - name: f1_smart_leads
+    class_name: GluttonIsolatedStrategy
+    params:
+      smart_leads: true
+
+  # Feature 2: Smart Discards only
+  - name: f2_smart_discards
+    class_name: GluttonIsolatedStrategy
+    params:
+      smart_discards: true
+
+  # Feature 3: 3rd Seat Aggression only
+  - name: f3_third_seat_aggression
+    class_name: GluttonIsolatedStrategy
+    params:
+      third_seat_aggression: true
+
+  # Feature 4: Partner Awareness only
+  - name: f4_partner_awareness
+    class_name: GluttonIsolatedStrategy
+    params:
+      partner_awareness: true
+
+  # Feature 5: Sure Winner Cover only (requires partner_awareness)
+  - name: f5_sure_winner_cover
+    class_name: GluttonIsolatedStrategy
+    params:
+      partner_awareness: true
+      sure_winner_cover: true
+
+  # Feature 6: Partner Check (requires third_seat_aggression)
+  - name: f6_partner_check
+    class_name: GluttonIsolatedStrategy
+    params:
+      third_seat_aggression: true
+      partner_check: true
+
+  # Feature 7: Trump Gating (requires third_seat_aggression)
+  - name: f7_trump_gating
+    class_name: GluttonIsolatedStrategy
+    params:
+      third_seat_aggression: true
+      trump_gating: true
+
+  # Feature 8: Probabilistic Trump-In (requires partner_awareness + sure_winner_cover)
+  - name: f8_probabilistic_trump_in
+    class_name: GluttonIsolatedStrategy
+    params:
+      partner_awareness: true
+      sure_winner_cover: true
+      probabilistic_trump_in: true
+
+  # Cumulative: V1 (PR#226 features)
+  - name: v1_pr226_all
+    class_name: GluttonIsolatedStrategy
+    params:
+      smart_leads: true
+      smart_discards: true
+      third_seat_aggression: true
+      partner_awareness: true
+      sure_winner_cover: true
+
+  # Cumulative: V2 (PR#226 + PR#227 features)
+  - name: v2_pr227_all
+    class_name: GluttonIsolatedStrategy
+    params:
+      smart_leads: true
+      smart_discards: true
+      third_seat_aggression: true
+      partner_awareness: true
+      sure_winner_cover: true
+      partner_check: true
+      trump_gating: true
+
+  # Cumulative: V3 (PR#226 + PR#227 + PR#228 features) - Full Glutton
+  - name: v3_pr228_all
+    class_name: GluttonIsolatedStrategy
+    params:
+      smart_leads: true
+      smart_discards: true
+      third_seat_aggression: true
+      partner_awareness: true
+      sure_winner_cover: true
+      partner_check: true
+      trump_gating: true
+      probabilistic_trump_in: true
+
+# Head-to-head matchups: each strategy vs Greedy
+matchups:
+  # Feature isolations vs Greedy
+  - team0: f1_smart_leads
+    team1: greedy
+  - team0: f2_smart_discards
+    team1: greedy
+  - team0: f3_third_seat_aggression
+    team1: greedy
+  - team0: f4_partner_awareness
+    team1: greedy
+  - team0: f5_sure_winner_cover
+    team1: greedy
+  - team0: f6_partner_check
+    team1: greedy
+  - team0: f7_trump_gating
+    team1: greedy
+  - team0: f8_probabilistic_trump_in
+    team1: greedy
+
+  # Cumulative versions vs Greedy
+  - team0: v1_pr226_all
+    team1: greedy
+  - team0: v2_pr227_all
+    team1: greedy
+  - team0: v3_pr228_all
+    team1: greedy
+
+  # Greedy self-play baseline (sanity check)
+  - team0: greedy
+    team1: greedy
+
+# All bidless scenarios
+scenarios:
+  - name: suit_C
+    contract_type: suit
+    trump_suit: C
+
+  - name: suit_D
+    contract_type: suit
+    trump_suit: D
+
+  - name: suit_H
+    contract_type: suit
+    trump_suit: H
+
+  - name: suit_S
+    contract_type: suit
+    trump_suit: S
+
+  - name: high
+    contract_type: high
+
+  - name: low
+    contract_type: low

--- a/src/bid_euchre/experiments/config.py
+++ b/src/bid_euchre/experiments/config.py
@@ -17,6 +17,7 @@ from ..strategy import (
     ArtifactBidder,
     BasicStrategy,
     BiddingPolicy,
+    GluttonIsolatedStrategy,
     GluttonStrategy,
     GreedyStrategy,
     RandomLegalStrategy,
@@ -44,6 +45,19 @@ class StrategyConfig:
         elif self.class_name == "GluttonStrategy":
             debug = self.params.get("debug", False)
             return GluttonStrategy(name=self.name, debug=debug)
+        elif self.class_name == "GluttonIsolatedStrategy":
+            return GluttonIsolatedStrategy(
+                name=self.name,
+                debug=self.params.get("debug", False),
+                smart_leads=self.params.get("smart_leads", False),
+                smart_discards=self.params.get("smart_discards", False),
+                third_seat_aggression=self.params.get("third_seat_aggression", False),
+                partner_awareness=self.params.get("partner_awareness", False),
+                sure_winner_cover=self.params.get("sure_winner_cover", False),
+                partner_check=self.params.get("partner_check", False),
+                trump_gating=self.params.get("trump_gating", False),
+                probabilistic_trump_in=self.params.get("probabilistic_trump_in", False),
+            )
         elif self.class_name == "RandomLegalStrategy":
             seed = self.params.get("seed", None)
             return RandomLegalStrategy(name=self.name, seed=seed)

--- a/src/bid_euchre/strategy/__init__.py
+++ b/src/bid_euchre/strategy/__init__.py
@@ -37,6 +37,7 @@ from .bidding import (
 
 # Greedy strategies
 from .greedy import (
+    GluttonIsolatedStrategy,
     GluttonStrategy,
     GreedyStrategy,
     # Legacy functions for backwards compatibility
@@ -70,6 +71,7 @@ __all__ = [
     # Greedy
     "GreedyStrategy",
     "GluttonStrategy",
+    "GluttonIsolatedStrategy",
     # Regression - REMOVED: RegressionBidder (legacy pickle path)
     # Legacy functions
     "choose_card_basic",

--- a/src/bid_euchre/strategy/greedy.py
+++ b/src/bid_euchre/strategy/greedy.py
@@ -461,6 +461,396 @@ class GluttonStrategy(Strategy):
         return choice
 
 
+class GluttonIsolatedStrategy(Strategy):
+    """
+    Feature-isolated Glutton strategy for A/B testing individual improvements.
+
+    Each feature can be enabled/disabled independently to measure its impact:
+    - smart_leads: Use heuristic lead selection (Aces, draw trump, longest suit)
+    - smart_discards: Prefer shortest suit to create voids
+    - third_seat_aggression: Take tricks in 3rd seat when threat count ≤1
+    - partner_awareness: Don't overkill partner's winning card
+    - sure_winner_cover: Cover vulnerable partner with guaranteed winner
+    - partner_check: Skip 3rd-seat aggression when partner winning (PR#227)
+    - trump_gating: Only aggressive trump if hand ≤6 or trump ≥3 (PR#227)
+    - probabilistic_trump_in: Trump to protect partner from void 4th seat (PR#228)
+
+    With all features disabled, this behaves identically to GreedyStrategy.
+    """
+
+    def __init__(
+        self,
+        name: str = "glutton_isolated",
+        debug: bool = False,
+        # Feature flags - all default to False for isolation testing
+        smart_leads: bool = False,
+        smart_discards: bool = False,
+        third_seat_aggression: bool = False,
+        partner_awareness: bool = False,
+        sure_winner_cover: bool = False,
+        partner_check: bool = False,
+        trump_gating: bool = False,
+        probabilistic_trump_in: bool = False,
+    ):
+        super().__init__(name)
+        self.debug = debug
+        self.decision_log: List[dict] = []
+
+        # Feature flags
+        self._smart_leads = smart_leads
+        self._smart_discards = smart_discards
+        self._third_seat_aggression = third_seat_aggression
+        self._partner_awareness = partner_awareness
+        self._sure_winner_cover = sure_winner_cover
+        self._partner_check = partner_check
+        self._trump_gating = trump_gating
+        self._probabilistic_trump_in = probabilistic_trump_in
+
+        # Double-deck aware tracking (each card exists 0-2 times)
+        self._seen_counts: Dict[Card, int] = {}
+        # Void inference: which seats are void in which effective suits
+        self._void_suits_by_seat: Dict[int, Set[str]] = {0: set(), 1: set(), 2: set(), 3: set()}
+        # Contract context (set by on_hand_start)
+        self._contract_type: str = "high"
+        self._trump_suit: Optional[str] = None
+        self._player_index: int = 0
+
+    def on_hand_start(
+        self,
+        starting_hand: List[Card],
+        contract_type: str,
+        trump_suit: Optional[str],
+        player_index: int,
+    ) -> None:
+        """Reset per-hand state at the start of each hand."""
+        self._seen_counts = {}
+        self._void_suits_by_seat = {0: set(), 1: set(), 2: set(), 3: set()}
+        self._contract_type = contract_type
+        self._trump_suit = trump_suit
+        self._player_index = player_index
+        if self.debug:
+            self.decision_log = []
+
+    def observe_play(
+        self,
+        player_index: int,
+        card: Card,
+        trick_plays: List[Tuple[int, Card]],
+        contract_type: str,
+        trump_suit: Optional[str],
+    ) -> None:
+        """Track played cards and infer voids from play patterns."""
+        # Increment seen count (clamp at 2 for double deck)
+        self._seen_counts[card] = min(2, self._seen_counts.get(card, 0) + 1)
+
+        # Infer voids: if a player didn't follow suit, they're void in led suit
+        if len(trick_plays) >= 1:
+            led_suit = effective_suit(trick_plays[0][1], trump_suit, contract_type)
+            played_eff = effective_suit(card, trump_suit, contract_type)
+            if played_eff != led_suit:
+                self._void_suits_by_seat[player_index].add(led_suit)
+
+    def _threat_copies_remaining(
+        self,
+        card: Card,
+        led_suit: str,
+        hand: List[Card],
+    ) -> int:
+        """Count how many copies of cards that beat `card` are still unaccounted for."""
+        beating = cards_that_beat(card, led_suit, self._trump_suit, self._contract_type)
+        hand_counter = Counter(hand)
+        total = 0
+        for threat in beating:
+            seen = self._seen_counts.get(threat, 0)
+            in_hand = hand_counter.get(threat, 0)
+            remaining = max(0, 2 - seen - in_hand)
+            total += remaining
+        return total
+
+    def _is_sure_winner(
+        self,
+        candidate: Card,
+        plays_so_far: List[Tuple[int, Card]],
+        hand: List[Card],
+    ) -> bool:
+        """Returns True if candidate cannot be beaten by any remaining card."""
+        if plays_so_far:
+            led_suit = effective_suit(plays_so_far[0][1], self._trump_suit, self._contract_type)
+        else:
+            led_suit = effective_suit(candidate, self._trump_suit, self._contract_type)
+
+        beating_cards = cards_that_beat(candidate, led_suit, self._trump_suit, self._contract_type)
+        hand_counter = Counter(hand)
+        for threat in beating_cards:
+            seen = self._seen_counts.get(threat, 0)
+            in_hand = hand_counter.get(threat, 0)
+            remaining = 2 - seen - in_hand
+            if remaining > 0:
+                return False
+        return True
+
+    def _count_effective_suit(self, hand: List[Card], suit: str) -> int:
+        """Count cards in hand that belong to the given effective suit."""
+        return sum(
+            1 for c in hand
+            if effective_suit(c, self._trump_suit, self._contract_type) == suit
+        )
+
+    def _get_suit_counts(self, hand: List[Card]) -> Dict[str, int]:
+        """Get count of cards by effective suit in hand."""
+        counts: Dict[str, int] = {}
+        for c in hand:
+            eff = effective_suit(c, self._trump_suit, self._contract_type)
+            counts[eff] = counts.get(eff, 0) + 1
+        return counts
+
+    def _choose_lead_smart(
+        self,
+        hand: List[Card],
+        legal_indices: List[int],
+    ) -> int:
+        """Choose which card to lead with human-like heuristics."""
+
+        def card_value(idx: int) -> int:
+            return card_value_for_dump(hand[idx], self._contract_type, self._trump_suit)
+
+        suit_counts = self._get_suit_counts(hand)
+
+        if self._contract_type == "suit" and self._trump_suit is not None:
+            # 1. Look for non-trump Aces
+            non_trump_aces = [
+                idx for idx in legal_indices
+                if hand[idx].rank == "A"
+                and effective_suit(hand[idx], self._trump_suit, self._contract_type) != self._trump_suit
+            ]
+            if non_trump_aces:
+                def ace_priority(idx: int) -> Tuple[int, int]:
+                    eff = effective_suit(hand[idx], self._trump_suit, self._contract_type)
+                    return (suit_counts.get(eff, 0), -card_value(idx))
+                return min(non_trump_aces, key=ace_priority)
+
+            # 2. Draw trump if holding >= 4 trumps and NOT holding both bowers
+            trump_count = self._count_effective_suit(hand, self._trump_suit)
+            trump_indices = [
+                idx for idx in legal_indices
+                if effective_suit(hand[idx], self._trump_suit, self._contract_type) == self._trump_suit
+            ]
+            if trump_count >= 4 and trump_indices:
+                from ..core.cards import is_left_bower, is_right_bower
+                has_right = any(is_right_bower(hand[idx], self._trump_suit) for idx in trump_indices)
+                has_left = any(is_left_bower(hand[idx], self._trump_suit) for idx in trump_indices)
+                if not (has_right and has_left):
+                    return min(trump_indices, key=card_value)
+
+            # 3. Lead from longest non-trump suit
+            non_trump_suits = [s for s in suit_counts if s != self._trump_suit]
+            if non_trump_suits:
+                longest_suit = max(non_trump_suits, key=lambda s: suit_counts.get(s, 0))
+                longest_suit_indices = [
+                    idx for idx in legal_indices
+                    if effective_suit(hand[idx], self._trump_suit, self._contract_type) == longest_suit
+                ]
+                if longest_suit_indices:
+                    return max(longest_suit_indices, key=card_value)
+
+            return max(legal_indices, key=card_value)
+
+        else:
+            # HIGH / LOW CONTRACT LEADS
+            if suit_counts:
+                longest_suit = max(suit_counts.keys(), key=lambda s: suit_counts.get(s, 0))
+                longest_suit_indices = [
+                    idx for idx in legal_indices
+                    if hand[idx].suit == longest_suit
+                ]
+                if longest_suit_indices:
+                    return max(longest_suit_indices, key=card_value)
+            return max(legal_indices, key=card_value)
+
+    def _choose_discard_smart(
+        self,
+        hand: List[Card],
+        legal_indices: List[int],
+    ) -> int:
+        """Choose which card to discard with smart void-creation logic."""
+
+        def card_value(idx: int) -> int:
+            return card_value_for_dump(hand[idx], self._contract_type, self._trump_suit)
+
+        suit_counts = self._get_suit_counts(hand)
+
+        if self._contract_type == "suit" and self._trump_suit is not None:
+            non_trump_indices = [
+                idx for idx in legal_indices
+                if effective_suit(hand[idx], self._trump_suit, self._contract_type) != self._trump_suit
+            ]
+
+            if non_trump_indices:
+                def discard_priority(idx: int) -> Tuple[int, int]:
+                    eff = effective_suit(hand[idx], self._trump_suit, self._contract_type)
+                    return (suit_counts.get(eff, 0), card_value(idx))
+                return min(non_trump_indices, key=discard_priority)
+
+            return min(legal_indices, key=card_value)
+
+        else:
+            return min(legal_indices, key=card_value)
+
+    def _should_trump_in(
+        self,
+        hand: List[Card],
+        plays_so_far: List[Tuple[int, Card]],
+        player_index: int,
+    ) -> bool:
+        """Returns True if we should consider trumping in to protect partner."""
+        if self._contract_type != "suit" or self._trump_suit is None:
+            return False
+        if not plays_so_far:
+            return False
+
+        led_suit = effective_suit(plays_so_far[0][1], self._trump_suit, self._contract_type)
+
+        can_follow = any(
+            effective_suit(hand[idx], self._trump_suit, self._contract_type) == led_suit
+            for idx in range(len(hand))
+        )
+        if can_follow:
+            return False
+
+        trump_in_hand = any(
+            effective_suit(c, self._trump_suit, self._contract_type) == self._trump_suit
+            for c in hand
+        )
+        if not trump_in_hand:
+            return False
+
+        pos = len(plays_so_far)
+        if pos != 2:
+            return False
+
+        fourth_seat = (player_index + 1) % 4
+        fourth_void_in_led = led_suit in self._void_suits_by_seat[fourth_seat]
+        fourth_might_have_trump = self._trump_suit not in self._void_suits_by_seat[fourth_seat]
+
+        return fourth_void_in_led and fourth_might_have_trump
+
+    def choose_card(
+        self,
+        hand: List[Card],
+        plays_so_far: List[Tuple[int, Card]],
+        contract_type: str,
+        trump_suit: Optional[str],
+        player_index: int,
+    ) -> int:
+        """Choose card with configurable feature flags."""
+        # Fallback reset if on_hand_start wasn't called
+        if len(hand) == 10 and not plays_so_far:
+            self._seen_counts = {}
+            self._void_suits_by_seat = {0: set(), 1: set(), 2: set(), 3: set()}
+            self._contract_type = contract_type
+            self._trump_suit = trump_suit
+            self._player_index = player_index
+
+        legal_indices = get_legal_indices(hand, plays_so_far, contract_type, trump_suit)
+
+        def card_value(idx: int) -> int:
+            return card_value_for_dump(hand[idx], contract_type, trump_suit)
+
+        # LEADING
+        if not plays_so_far:
+            if self._smart_leads:
+                return self._choose_lead_smart(hand, legal_indices)
+            else:
+                # Greedy: highest value card
+                return max(legal_indices, key=card_value)
+
+        # FOLLOWING: Find winning candidates
+        winning_candidates = []
+        for idx in legal_indices:
+            card = hand[idx]
+            provisional_plays = plays_so_far + [(player_index, card)]
+            winner = trick_winner(
+                provisional_plays,
+                contract_type=contract_type,
+                trump_suit=trump_suit,
+            )
+            if winner == player_index:
+                winning_candidates.append(idx)
+
+        # Calculate partner status (needed for multiple features)
+        partner_index = (player_index + 2) % 4
+        current_winner = trick_winner(
+            plays_so_far,
+            contract_type=contract_type,
+            trump_suit=trump_suit,
+        )
+        partner_winning = (current_winner == partner_index)
+
+        pos = len(plays_so_far)  # 0=lead, 1=2nd, 2=3rd, 3=4th
+
+        # 3RD SEAT AGGRESSION
+        if self._third_seat_aggression and pos == 2 and winning_candidates:
+            # Partner check: skip if partner is winning (PR#227)
+            skip_for_partner = self._partner_check and partner_winning
+
+            if not skip_for_partner:
+                best_winner_idx = min(winning_candidates, key=card_value)
+                best_winner = hand[best_winner_idx]
+                led_suit = effective_suit(plays_so_far[0][1], trump_suit, contract_type)
+                threats = self._threat_copies_remaining(best_winner, led_suit, hand)
+
+                if threats <= 1:
+                    # Trump gating check (PR#227)
+                    if self._trump_gating:
+                        is_trump_winner = (
+                            contract_type == "suit" and trump_suit is not None
+                            and effective_suit(best_winner, trump_suit, contract_type) == trump_suit
+                        )
+                        can_gate = len(hand) <= 6 or self._count_effective_suit(hand, trump_suit or "") >= 3
+                        if is_trump_winner and not can_gate:
+                            pass  # Skip this aggression
+                        else:
+                            return best_winner_idx
+                    else:
+                        return best_winner_idx
+
+        # PARTNER AWARENESS
+        if self._partner_awareness and partner_winning:
+            # Sure winner cover
+            if self._sure_winner_cover and pos == 2:
+                sure_winners = [
+                    idx for idx in winning_candidates
+                    if self._is_sure_winner(hand[idx], plays_so_far, hand)
+                ]
+                if sure_winners:
+                    return min(sure_winners, key=card_value)
+
+                # Probabilistic trump-in (PR#228)
+                if self._probabilistic_trump_in and self._should_trump_in(hand, plays_so_far, player_index):
+                    trump_winners = [
+                        idx for idx in winning_candidates
+                        if effective_suit(hand[idx], trump_suit, contract_type) == trump_suit
+                    ]
+                    if trump_winners:
+                        return min(trump_winners, key=card_value)
+
+            # Smart discard when partner winning
+            if self._smart_discards:
+                return self._choose_discard_smart(hand, legal_indices)
+            else:
+                return min(legal_indices, key=card_value)
+
+        # Standard winning logic
+        if winning_candidates:
+            return min(winning_candidates, key=card_value)
+
+        # Discard
+        if self._smart_discards:
+            return self._choose_discard_smart(hand, legal_indices)
+        else:
+            return min(legal_indices, key=card_value)
+
+
 # Legacy function interface (for backwards compatibility)
 def choose_card_basic(
     hand: List[Card],


### PR DESCRIPTION
## Summary
- Add `GluttonIsolatedStrategy` class with feature flags to enable/disable individual improvements
- Add experiment config `glutton_feature_isolation.yaml` for head-to-head testing
- Register new strategy in config parser

## Why
To measure the individual contribution of each GluttonStrategy improvement. Experiment results show:
- **Smart Leads** accounts for ~95% of improvement (+0.16 tricks, 54.5% win rate)
- **Smart Discards** is harmful when isolated (-0.13 tricks, 47.9% win rate)
- PR#227/PR#228 features show no incremental benefit over PR#226

Full analysis in `data/runs/glutton_feature_isolation_42_20260203_222922/EXPERIMENT_SUMMARY.md` (not committed, run locally to reproduce).

## Repro / Validation
```bash
cd Bid-Euchre-feat-glutton-feature-isolation
PYTHONPATH=src uv run python experiments/run_experiment.py \
  --config experiments/configs/glutton_feature_isolation.yaml \
  --seed 42 --n_per 100000 --force
```

## Tests
```bash
make check  # All pass
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-feat-glutton-feature-isolation
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-feat-glutton-feature-isolation
Branch: feat/glutton-feature-isolation
```

🤖 Generated with [Claude Code](https://claude.ai/code)