### PR TITLE
docs: add glutton feature isolation experiment report

### DIFF
--- a/experiments/reports/glutton_feature_isolation.md
+++ b/experiments/reports/glutton_feature_isolation.md
@@ -109,9 +109,7 @@ Per repo rigor requirements (`docs/02_agent/05_rigor.md`):
 
 ```bash
 cd /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-feat-glutton-feature-isolation
-PYTHONPATH=src uv run python experiments/run_experiment.py \
-  --config experiments/configs/glutton_feature_isolation.yaml \
-  --seed 42 --n_per 100000 --force
+PYTHONPATH=src uv run python experiments/run_experiment.py --config experiments/configs/glutton_feature_isolation.yaml --seed 42 --n_per 100000 --force
 ```
 
 ---
@@ -317,10 +315,8 @@ cd ../Bid-Euchre-feat-glutton-feature-isolation
 # Install dependencies
 uv sync --all-extras
 
-# Run experiment (takes ~45 minutes)
-PYTHONPATH=src uv run python experiments/run_experiment.py \
-  --config experiments/configs/glutton_feature_isolation.yaml \
-  --seed 42 --n_per 100000 --force
+# Run experiment
+PYTHONPATH=src uv run python experiments/run_experiment.py --config experiments/configs/glutton_feature_isolation.yaml --seed 42 --n_per 100000 --force
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Add `experiments/reports/` directory for experiment analysis summaries
- Add `glutton_feature_isolation.md` documenting the feature isolation experiment

## Why
Preserve the analysis from the feature isolation experiment (7.2M hands) that measured individual GluttonStrategy improvements. Key findings:
- Smart Leads = 95% of improvement
- Smart Discards hurts when isolated
- PR#227/PR#228 show no incremental benefit

## Repro / Validation
Report is documentation only. To reproduce the experiment:
```bash
PYTHONPATH=src uv run python experiments/run_experiment.py \
  --config experiments/configs/glutton_feature_isolation.yaml \
  --seed 42 --n_per 100000 --force
```

## Tests
N/A - documentation only

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-feat-experiment-reports
Branch: feat/experiment-reports
```

🤖 Generated with [Claude Code](https://claude.ai/code)