### PR TITLE
feat(configs): add canonical bidless experiment configs and budgets

### DIFF
--- a/experiments/configs/INDEX.md
+++ b/experiments/configs/INDEX.md
@@ -48,6 +48,14 @@ Quick reference for finding the right experiment configuration.
 |--------|---------|
 | `bidless_dataset_collection.yaml` | Collect bidless training data |
 
+## Canonical Bidless Experiments
+
+| Config | Purpose |
+|--------|---------|
+| `canonical_bidless_dataset.yaml` | Features + outcomes dataset (900k hands, 3 strategies) |
+| `canonical_bidless_outcomes_matrix_shallow.yaml` | Broad coverage 5x5 matrix (300k hands, 25 matchups) |
+| `canonical_bidless_outcomes_zoom.yaml` | High-precision zoom (3.3M hands, 11 matchups) |
+
 ---
 
 **See also:** [experiments/suites/](../suites/) for batched experiment definitions

--- a/experiments/configs/canonical_bidless_dataset.yaml
+++ b/experiments/configs/canonical_bidless_dataset.yaml
@@ -1,0 +1,50 @@
+# Canonical Bidless Dataset Configuration
+#
+# Purpose: Collect hand features AND outcome labels for ML training with strategy diversity.
+# This config runs multiple strategies in self-play mode to create a diverse training
+# dataset for bidding model development.
+#
+# Strategies:
+#   - greedy: Conservative play-to-win strategy
+#   - glutton: Aggressive trick-taking strategy
+#   - random_legal: Random baseline for variety
+#
+# Total hands: 50,000 x 6 scenarios x 3 strategies = 900,000 hands
+#
+# Usage:
+#   PYTHONPATH=src python experiments/run_experiment.py \
+#       --config experiments/configs/canonical_bidless_dataset.yaml \
+#       --seed 42 \
+#       --emit-bidless-dataset \
+#       --emit-bidless-outcomes-dataset
+#
+# Outputs (in <run_dir>/datasets/):
+#   - bidless.parquet + bidless.jsonl + bidless_meta.json (features)
+#   - bidless_outcomes.parquet + bidless_outcomes.jsonl + bidless_outcomes_meta.json (outcomes)
+
+experiment_name: canonical_bidless_dataset
+
+parameters:
+  seed: 42
+  n_per: 50000
+  log_level: none
+  mode: self_play
+  pair_deals: true
+
+strategies:
+  - name: greedy
+    class_name: GreedyStrategy
+
+  - name: glutton
+    class_name: GluttonStrategy
+
+  - name: random_legal
+    class_name: RandomLegalStrategy
+    params:
+      seed: 42
+
+scenarios:
+  - contract_type: suit
+    trump_suit: C,D,H,S
+  - contract_type: high
+  - contract_type: low

--- a/experiments/configs/canonical_bidless_outcomes_matrix_shallow.yaml
+++ b/experiments/configs/canonical_bidless_outcomes_matrix_shallow.yaml
@@ -1,0 +1,115 @@
+# Canonical Bidless Outcomes: Shallow Matrix Configuration
+#
+# Purpose: Cheap broad coverage across all 25 matchups for sanity checking.
+# This config runs a full 5x5 matrix of strategy matchups with modest sample size
+# to validate strategy interactions before committing to expensive zoom runs.
+#
+# Strategies:
+#   - greedy: Conservative play-to-win strategy
+#   - glutton: Aggressive trick-taking strategy
+#   - random_legal: Random baseline
+#   - always_highest: Always plays highest legal card
+#   - always_lowest: Always plays lowest legal card
+#
+# Total hands: 2,000 x 6 scenarios x 25 matchups = 300,000 hands
+#
+# Usage:
+#   PYTHONPATH=src python experiments/run_experiment.py \
+#       --config experiments/configs/canonical_bidless_outcomes_matrix_shallow.yaml \
+#       --seed 42
+
+experiment_name: canonical_bidless_outcomes_matrix_shallow
+
+parameters:
+  seed: 42
+  n_per: 2000
+  log_level: none
+  mode: head_to_head_matrix
+  pair_deals: true
+
+strategies:
+  - name: greedy
+    class_name: GreedyStrategy
+
+  - name: glutton
+    class_name: GluttonStrategy
+
+  - name: random_legal
+    class_name: RandomLegalStrategy
+    params:
+      seed: 42
+
+  - name: always_highest
+    class_name: AlwaysHighestLegalStrategy
+
+  - name: always_lowest
+    class_name: AlwaysLowestLegalStrategy
+
+# Full 5x5 matrix (25 matchups) in deterministic order
+# Includes all ordered pairs and self-play controls
+matchups:
+  # greedy vs all (5 matchups)
+  - team0: greedy
+    team1: greedy
+  - team0: greedy
+    team1: glutton
+  - team0: greedy
+    team1: random_legal
+  - team0: greedy
+    team1: always_highest
+  - team0: greedy
+    team1: always_lowest
+
+  # glutton vs all (5 matchups)
+  - team0: glutton
+    team1: greedy
+  - team0: glutton
+    team1: glutton
+  - team0: glutton
+    team1: random_legal
+  - team0: glutton
+    team1: always_highest
+  - team0: glutton
+    team1: always_lowest
+
+  # random_legal vs all (5 matchups)
+  - team0: random_legal
+    team1: greedy
+  - team0: random_legal
+    team1: glutton
+  - team0: random_legal
+    team1: random_legal
+  - team0: random_legal
+    team1: always_highest
+  - team0: random_legal
+    team1: always_lowest
+
+  # always_highest vs all (5 matchups)
+  - team0: always_highest
+    team1: greedy
+  - team0: always_highest
+    team1: glutton
+  - team0: always_highest
+    team1: random_legal
+  - team0: always_highest
+    team1: always_highest
+  - team0: always_highest
+    team1: always_lowest
+
+  # always_lowest vs all (5 matchups)
+  - team0: always_lowest
+    team1: greedy
+  - team0: always_lowest
+    team1: glutton
+  - team0: always_lowest
+    team1: random_legal
+  - team0: always_lowest
+    team1: always_highest
+  - team0: always_lowest
+    team1: always_lowest
+
+scenarios:
+  - contract_type: suit
+    trump_suit: C,D,H,S
+  - contract_type: high
+  - contract_type: low

--- a/experiments/configs/canonical_bidless_outcomes_zoom.yaml
+++ b/experiments/configs/canonical_bidless_outcomes_zoom.yaml
@@ -1,0 +1,86 @@
+# Canonical Bidless Outcomes: Zoom Configuration
+#
+# Purpose: High-precision data for decision-relevant matchups.
+# This config concentrates budget on:
+#   1. Self-play controls (5 matchups) - verify fairness
+#   2. Decision-relevant head-to-heads (6 matchups) - key strategy comparisons
+#
+# Strategies:
+#   - greedy: Conservative play-to-win strategy
+#   - glutton: Aggressive trick-taking strategy
+#   - random_legal: Random baseline
+#   - always_highest: Always plays highest legal card
+#   - always_lowest: Always plays lowest legal card
+#
+# Total hands: 50,000 x 6 scenarios x 11 matchups = 3,300,000 hands
+#
+# Usage:
+#   PYTHONPATH=src python experiments/run_experiment.py \
+#       --config experiments/configs/canonical_bidless_outcomes_zoom.yaml \
+#       --seed 42
+
+experiment_name: canonical_bidless_outcomes_zoom
+
+parameters:
+  seed: 42
+  n_per: 50000
+  log_level: none
+  mode: head_to_head_matrix
+  pair_deals: true
+
+strategies:
+  - name: greedy
+    class_name: GreedyStrategy
+
+  - name: glutton
+    class_name: GluttonStrategy
+
+  - name: random_legal
+    class_name: RandomLegalStrategy
+    params:
+      seed: 42
+
+  - name: always_highest
+    class_name: AlwaysHighestLegalStrategy
+
+  - name: always_lowest
+    class_name: AlwaysLowestLegalStrategy
+
+# 11 matchups: 5 self-play controls + 6 decision-relevant head-to-heads
+matchups:
+  # Self-play controls (5 matchups) - verify fairness
+  - team0: greedy
+    team1: greedy
+  - team0: glutton
+    team1: glutton
+  - team0: random_legal
+    team1: random_legal
+  - team0: always_highest
+    team1: always_highest
+  - team0: always_lowest
+    team1: always_lowest
+
+  # Decision-relevant head-to-heads with reverse matchups (6 matchups)
+  # glutton vs greedy - primary strategic comparison
+  - team0: glutton
+    team1: greedy
+  - team0: greedy
+    team1: glutton
+
+  # greedy vs random_legal - baseline comparison
+  - team0: greedy
+    team1: random_legal
+  - team0: random_legal
+    team1: greedy
+
+  # glutton vs random_legal - baseline comparison
+  - team0: glutton
+    team1: random_legal
+  - team0: random_legal
+    team1: glutton
+
+scenarios:
+  - contract_type: suit
+    trump_suit: C,D,H,S
+  - contract_type: high
+  - contract_type: low

--- a/experiments/run_experiment.py
+++ b/experiments/run_experiment.py
@@ -64,6 +64,10 @@ TOTAL_HANDS_BUDGETS = {
     "quick_test": 1_000,
     "baseline_tiny": 50_000,
     "baseline_full": 5_000_000,
+    # Canonical bidless experiment configs
+    "canonical_bidless_dataset": 1_000_000,  # 50k × 6 scenarios × 3 strategies = 900k
+    "canonical_bidless_outcomes_matrix_shallow": 500_000,  # 2k × 6 scenarios × 25 matchups = 300k
+    "canonical_bidless_outcomes_zoom": 4_000_000,  # 50k × 6 scenarios × 11 matchups = 3.3M
 }
 
 


### PR DESCRIPTION
## Summary
- Add 3 YAML configs for canonical bidless experiment baseline
- Add TOTAL_HANDS_BUDGETS entries for all three configs
- Update INDEX.md with new config documentation

## Why
Establishes canonical configurations for bidless experiment runs needed for:
- ML training dataset collection (features + outcomes)
- Strategy comparison via hybrid sampling (shallow matrix + zoom)
- Reproducible baseline experiments with paired deals

## Configs Added

| Config | Purpose | Total Hands |
|--------|---------|-------------|
| `canonical_bidless_dataset.yaml` | Features + outcomes dataset (3 strategies) | 900k |
| `canonical_bidless_outcomes_matrix_shallow.yaml` | Broad 5x5 matrix coverage (25 matchups) | 300k |
| `canonical_bidless_outcomes_zoom.yaml` | High-precision zoom (11 matchups) | 3.3M |

## Repro / Validation

Dry-run validation:
```bash
PYTHONPATH=src python experiments/run_experiment.py \
    --config experiments/configs/canonical_bidless_dataset.yaml \
    --seed 42 --n_per 100 --dry-run

PYTHONPATH=src python experiments/run_experiment.py \
    --config experiments/configs/canonical_bidless_outcomes_matrix_shallow.yaml \
    --seed 42 --n_per 100 --dry-run

PYTHONPATH=src python experiments/run_experiment.py \
    --config experiments/configs/canonical_bidless_outcomes_zoom.yaml \
    --seed 42 --n_per 100 --dry-run
```

Smoke test run:
```bash
PYTHONPATH=src python experiments/run_experiment.py \
    --config experiments/configs/canonical_bidless_dataset.yaml \
    --seed 42 --n_per 100 --emit-bidless-dataset
```

## Tests

- [x] `make check` passes
- [x] All three configs pass dry-run validation
- [x] Smoke test with n_per=100 completes successfully

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-canonical-bidless-pr1
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-canonical-bidless-pr1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)