### PR TITLE
fix(datasets): compute globally unique hand_id across strategies/scenarios

### DIFF
--- a/experiments/run_experiment.py
+++ b/experiments/run_experiment.py
@@ -39,7 +39,7 @@ import os
 import sys
 import time
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List
 
 import yaml
 
@@ -384,15 +384,22 @@ def main():
     all_bidding_collectors: List[Any] = []
     all_bidless_collectors: List[BidlessDatasetCollector] = []
 
+    # Track plan/scenario indices for globally unique hand_id computation
+    # Use a dict to make values mutable from within closures
+    num_scenarios = len(scenarios)
+    bidless_context: Dict[str, int] = {
+        "plan_id": 0,
+        "scenario_id": 0,
+    }
+
     # Create hooks for bidless dataset collection if requested
     def create_bidless_hooks() -> SimulationHooks | None:
         """Create hooks for bidless dataset collection."""
         if not args.emit_bidless_dataset:
             return None
 
-        # Collector indexed by (deal_id, contract_type, trump_suit) to avoid collisions
-        # when the same deal is played under different scenarios (e.g., pair_deals=True)
-        hand_collectors: Dict[Tuple[int, str, Optional[str]], BidlessDatasetCollector] = {}
+        # Collector indexed by globally unique hand_id to ensure uniqueness
+        hand_collectors: Dict[int, BidlessDatasetCollector] = {}
 
         def on_hand_end(event: HandEndEvent) -> None:
             """Record hand data when each hand completes."""
@@ -401,14 +408,18 @@ def main():
             if event.contract_type is None:
                 return
 
-            # Key by (deal_id, contract_type, trump_suit) to handle paired deals
-            collector_key = (event.deal_id, event.contract_type, event.trump_suit)
+            # Compute globally unique hand_id:
+            # hand_id = ((plan_id * num_scenarios + scenario_id) * n_per) + deal_id
+            # This ensures (hand_id, seat) is unique across the entire run
+            plan_id = bidless_context["plan_id"]
+            scenario_id = bidless_context["scenario_id"]
+            hand_id = ((plan_id * num_scenarios + scenario_id) * n_per) + event.deal_id
 
             # Create collector for this hand if needed
-            if collector_key not in hand_collectors:
-                hand_collectors[collector_key] = BidlessDatasetCollector(run_id, event.deal_id)
+            if hand_id not in hand_collectors:
+                hand_collectors[hand_id] = BidlessDatasetCollector(run_id, hand_id)
 
-            collector = hand_collectors[collector_key]
+            collector = hand_collectors[hand_id]
 
             # Record all 4 seats
             for seat in range(4):
@@ -443,7 +454,7 @@ def main():
         policy_cfg_by_name = {pc.name: pc for pc in bidding_policy_cfgs}
 
         # Each matchup: results/<team0>_vs_<team1>/..., logs/<run_id>_<matchup>.jsonl
-        for m in matchups:
+        for matchup_idx, m in enumerate(matchups):
             team0_name = m.get("team0")
             team1_name = m.get("team1")
             seat_strategy_names = m.get("seat_strategies")
@@ -532,6 +543,10 @@ def main():
                     ]
 
                 for i, scenario in enumerate(scenarios, 1):
+                    # Update bidless context for unique hand_id computation
+                    bidless_context["plan_id"] = matchup_idx
+                    bidless_context["scenario_id"] = i - 1  # 0-indexed
+
                     # When pair_deals=True, use the same seed for all scenarios
                     # so the same physical deals are played under different contracts
                     if pair_deals and seed is not None:
@@ -617,7 +632,7 @@ def main():
             policies_to_run = strategies
             policy_type = "strategy"
 
-        for policy in policies_to_run:
+        for policy_idx, policy in enumerate(policies_to_run):
             print("-" * 70)
             print(f"{policy_type.title()}: {policy.name}")
             print("-" * 70)
@@ -637,6 +652,10 @@ def main():
 
             try:
                 for i, scenario in enumerate(scenarios, 1):
+                    # Update bidless context for unique hand_id computation
+                    bidless_context["plan_id"] = policy_idx
+                    bidless_context["scenario_id"] = i - 1  # 0-indexed
+
                     # When pair_deals=True, use the same seed for all scenarios
                     # so the same physical deals are played under different contracts
                     if pair_deals and seed is not None:

--- a/tests/integration/test_bidless_workflow.py
+++ b/tests/integration/test_bidless_workflow.py
@@ -197,3 +197,58 @@ class TestBidlessDatasetWorkflow:
             files = os.listdir(datasets_dir)
             bidless_files = [f for f in files if f.startswith("bidless")]
             assert len(bidless_files) == 0, f"Found bidless files without flag: {bidless_files}"
+
+    def test_hand_id_uniqueness_across_strategies_and_scenarios(self, temp_run_dir):
+        """hand_id is globally unique across all strategies and scenarios.
+
+        This tests the fix for the hand_id collision bug where deal_id was used
+        as hand_id, causing collisions when multiple strategies or scenarios
+        share the same deal_id values (0..n_per-1).
+
+        The fix computes: hand_id = ((plan_id * num_scenarios + scenario_id) * n_per) + deal_id
+        """
+        # Use strategy_comparison.yaml which has 5 strategies
+        result = subprocess.run(
+            [
+                "python", "experiments/run_experiment.py",
+                "--config", "experiments/configs/strategy_comparison.yaml",
+                "--seed", "42",
+                "--n_per", "10",
+                "--run-dir", temp_run_dir,
+                "--emit-bidless-dataset",
+            ],
+            env={**os.environ, "PYTHONPATH": "src"},
+            capture_output=True,
+            text=True,
+            cwd=os.getcwd(),
+        )
+
+        assert result.returncode == 0, f"run_experiment.py failed:\n{result.stderr}"
+
+        run_dirs = [d for d in os.listdir(temp_run_dir) if d.startswith("strategy_comparison_42_")]
+        run_dir = os.path.join(temp_run_dir, run_dirs[0])
+        datasets_dir = os.path.join(run_dir, "datasets")
+
+        from bid_euchre.diagnostics import load_bidless_dataset
+
+        df = load_bidless_dataset(datasets_dir)
+
+        # Verify (hand_id, seat) uniqueness
+        # strategy_comparison.yaml: 5 strategies × 6 scenarios × 10 hands × 4 seats = 1200 rows
+        # Each unique hand_id should appear exactly 4 times (once per seat)
+        hand_id_counts = df.groupby("hand_id").size()
+        assert (hand_id_counts == 4).all(), "Some hand_ids don't have exactly 4 rows (one per seat)"
+
+        # Verify total unique hand_ids matches expected
+        num_strategies = 5  # greedy, glutton, random_legal, always_lowest, always_highest
+        num_scenarios = 6  # suit-C, suit-D, suit-H, suit-S, high, low
+        n_per = 10
+        expected_unique_hands = num_strategies * num_scenarios * n_per
+        assert df["hand_id"].nunique() == expected_unique_hands, (
+            f"Expected {expected_unique_hands} unique hand_ids, "
+            f"got {df['hand_id'].nunique()}"
+        )
+
+        # Verify (hand_id, seat) is truly unique (no duplicates)
+        duplicates = df.groupby(["hand_id", "seat"]).size()
+        assert (duplicates == 1).all(), "Found duplicate (hand_id, seat) pairs"


### PR DESCRIPTION
## Summary
- Fix hand_id computation to be globally unique across strategies and scenarios
- Add integration test verifying (hand_id, seat) uniqueness

## Why
The bidless dataset previously used `deal_id` directly as `hand_id`, which caused collisions when:
- Multiple strategies ran with the same `deal_id` values (0..n_per-1)
- Multiple scenarios ran with `pair_deals=True` (same physical deals)

This broke the assumption that `(hand_id, seat)` is unique across the entire run.

## Fix
Compute globally unique hand_id:
```python
hand_id = ((plan_id * num_scenarios + scenario_id) * n_per) + deal_id
```

Where:
- `plan_id` = matchup index (matrix mode) or strategy index (self_play mode)
- `scenario_id` = scenario index (0-indexed)
- `deal_id` = physical deal index (0..n_per-1), preserved for pairing

This ensures `(hand_id, seat)` is globally unique while preserving `deal_id` for pairing via `(deal_id, contract_type, trump_suit)`.

## Repro / Validation

```bash
# Run multi-strategy config and verify uniqueness
PYTHONPATH=src python experiments/run_experiment.py \
    --config experiments/configs/strategy_comparison.yaml \
    --seed 42 --n_per 10 --emit-bidless-dataset

# Verify in Python
python -c "
import pandas as pd
df = pd.read_parquet('data/runs/strategy_comparison_42_*/datasets/bidless.parquet')
print('Unique hand_ids:', df['hand_id'].nunique())
print('Expected:', 5 * 6 * 10)  # 5 strategies × 6 scenarios × 10 hands
print('Duplicates:', (df.groupby(['hand_id', 'seat']).size() > 1).sum())
"
```

## Tests
- [x] `make check` passes
- [x] New test: `test_hand_id_uniqueness_across_strategies_and_scenarios`
- [x] All existing bidless workflow tests pass

## Worktree Proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-canonical-bidless-pr2
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-canonical-bidless-pr2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)