### PR TITLE
feat(experiments): implement play-strategy for auction mode

### DIFF
--- a/docs/01_core/EXPERIMENTS.md
+++ b/docs/01_core/EXPERIMENTS.md
@@ -308,15 +308,39 @@ PYTHONPATH=src python experiments/run_experiment.py \
   --n_per 20
 ```
 
+### Choosing a Play Strategy (Auction Mode)
+
+In auction mode, the contract is chosen by the bidding policy, and the hand is then played out by a
+**play strategy** (card-play policy).
+
+By default, auction runs that iterate `bidding_policies` use `GreedyStrategy` for trick play.
+
+To override trick play for bidder evaluation, define the play strategy under `strategies:` and set it via:
+- `parameters.play_strategy: <strategy_name>` in YAML, or
+- `--play-strategy <strategy_name>` on the CLI.
+
+Example:
+
+```yaml
+strategies:
+  - name: glutton
+    class_name: GluttonStrategy
+
+parameters:
+  play_strategy: glutton
+```
+
 ### Output Structure
 
 Auction mode results include bidding-specific metrics:
 
-- **`bidding_points.enabled`**: Always `true` for auction scenarios
-- **`bidding_points.hands_with_bids`**: Count of hands where bidding occurred
+- **`bidding_points.enabled`**: `true` iff at least one hand had an auction winner (non-all-pass)
+- **`bidding_points.hands_with_bids`**: Count of hands with an auction winner
 - Standard team scoring and trick distribution metrics
 
-Results are written to `results/<strategy>/auction.json` (filenames use "auction" for `contract_type: null`).
+Results are written to `results/<id>/auction.json` (filenames use "auction" for `contract_type: null`), where `<id>` is:
+- the strategy name (strategy evaluations), or
+- the bidding policy name (bidder evaluations that iterate `bidding_policies`).
 
 ---
 

--- a/experiments/run_experiment.py
+++ b/experiments/run_experiment.py
@@ -188,6 +188,16 @@ def parse_args():
         help="For head_to_head: name of strategy to use for Team 1 (players 1 & 3). Must be one of the strategies in the config."
     )
     parser.add_argument(
+        "--play-strategy",
+        type=str,
+        help=(
+            "For auction-mode bidder evaluation (contract_type: null with bidding_policies): "
+            "name of the play strategy to use for trick play. "
+            "Can also be set via parameters.play_strategy in YAML. "
+            "Default is GreedyStrategy (current behavior) when omitted."
+        ),
+    )
+    parser.add_argument(
         "--force",
         action="store_true",
         help="Override work budget limits (use with caution)"
@@ -247,6 +257,7 @@ def main():
     log_level_str = args.log_level if args.log_level else config.parameters.get("log_level", "none")
     mode = args.mode if args.mode else (getattr(config, "mode", None) or config.parameters.get("mode", "self_play"))
     team1_strategy_name = args.team1_strategy if args.team1_strategy else config.parameters.get("team1_strategy")
+    play_strategy_name = args.play_strategy if args.play_strategy else config.parameters.get("play_strategy")
     pair_deals = config.parameters.get("pair_deals", False)
     
     # Get strategies and bidding policies
@@ -313,7 +324,28 @@ def main():
             _clone(team0_cfg, 2),
             _clone(team1_cfg, 3),
         ]
-    
+
+    def _make_self_play_strategies(cfg):
+        """Create distinct instances of a single strategy config for all 4 seats."""
+        cfg_params = dict(cfg.params or {})
+
+        # RandomLegal gets per-seat seed offsets to avoid identical RNG streams.
+        if cfg.class_name == "RandomLegalStrategy":
+            base_seed = cfg_params.get("seed", seed)
+            seat_strategies = []
+            for seat_idx in range(4):
+                seat_params = dict(cfg_params)
+                seat_params["seed"] = (base_seed + seat_idx) if base_seed is not None else None
+                seat_strategies.append(
+                    cfg.__class__(name=cfg.name, class_name=cfg.class_name, params=seat_params).create_strategy()
+                )
+            return seat_strategies
+
+        return [
+            cfg.__class__(name=cfg.name, class_name=cfg.class_name, params=cfg_params).create_strategy()
+            for _ in range(4)
+        ]
+
     # Determine what we're running
     has_auction_scenarios = any(s.contract_type is None for s in scenarios)
 
@@ -345,6 +377,8 @@ def main():
     print(f"Mode: {mode}")
     if mode == "head_to_head":
         print(f"Team1 strategy: {team1_strategy_name}")
+    if mode != "head_to_head_matrix" and has_auction_scenarios and bidding_policies:
+        print(f"Auction play strategy: {play_strategy_name or 'greedy (default)'}")
     print("=" * 70)
 
     # Enforce work budget before starting simulation
@@ -379,6 +413,7 @@ def main():
             "seed": seed,
             "log_level": log_level_str,
             "pair_deals": pair_deals,
+            "play_strategy": play_strategy_name,
         },
         "mode": mode,
         "strategies": [{"name": s.name, "class_name": getattr(s, "class_name", s.__class__.__name__)} for s in strategy_cfgs],
@@ -684,6 +719,20 @@ def main():
             policies_to_run = strategies
             policy_type = "strategy"
 
+        auction_seat_strategies = None
+        if policy_type == "bidding_policy" and play_strategy_name:
+            if not strategy_cfgs:
+                raise ValueError(
+                    f"play_strategy='{play_strategy_name}' requires a 'strategies' section in {args.config}."
+                )
+            play_cfg = next((sc for sc in strategy_cfgs if sc.name == play_strategy_name), None)
+            if play_cfg is None:
+                raise ValueError(
+                    f"Unknown play_strategy '{play_strategy_name}'. Must be one of: "
+                    f"{', '.join(sc.name for sc in strategy_cfgs)}"
+                )
+            auction_seat_strategies = _make_self_play_strategies(play_cfg)
+
         for policy_idx, policy in enumerate(policies_to_run):
             print("-" * 70)
             print(f"{policy_type.title()}: {policy.name}")
@@ -747,7 +796,7 @@ def main():
                             seed=None,
                             deal_seed=scenario_seed,
                             strategy=None,
-                            strategies=None,  # No strategies for auction mode
+                            strategies=auction_seat_strategies,
                             bidding_policy=policy,
                             logger=logger,
                             bidding_dataset_run_id=run_id if args.emit_bidding_dataset else None,
@@ -830,6 +879,7 @@ def main():
         "log_level": log_level_str,
         "mode": mode,
         "team1_strategy": team1_strategy_name if mode == "head_to_head" else None,
+        "play_strategy": play_strategy_name if has_auction_scenarios else None,
         "scenarios": [
             {"contract_type": s.contract_type, "trump_suit": s.trump_suit}
             for s in scenarios

--- a/src/bid_euchre/reporting/evaluator.py
+++ b/src/bid_euchre/reporting/evaluator.py
@@ -107,29 +107,38 @@ def _generate_comparison_report(run_dir: Path, strategy_metrics: List[Dict]) -> 
         f.write("**Run ID:** `{}`\n\n".format(Path(run_dir).name))
         f.write("**Primary Series:** `bidder_team_points` (team points from successful bids)\n\n")
         f.write("**Metric Definitions:**\n")
-        f.write("- **EV (Expected Value)**: Average points across all bidding hands\n")
+        f.write("- **EV (Expected Value)**: Average points across hands where an auction winner exists\n")
+        f.write("- **EV/Deal**: EV with `0` assigned to all-pass redeals (no auction winner)\n")
+        f.write("- **Bid Rate**: Fraction of deals with an auction winner\n")
         f.write("- **CVaR-5%**: Average of worst 5% of outcomes (tail risk)\n")
         f.write("- **Downside Variance**: Variance of outcomes below zero\n\n")
 
         f.write("## Comparative Analysis\n\n")
-        f.write("| Strategy | Hands | EV | CVaR-5% | Downside Var | Make Rate |\n")
-        f.write("|----------|------:|---:|--------:|-------------:|-----------:|\n")
+        f.write("| Strategy | Deals | Bid Hands | Bid Rate | EV | EV/Deal | CVaR-5% | Downside Var | Make Rate |\n")
+        f.write("|----------|------:|----------:|---------:|---:|--------:|--------:|-------------:|----------:|\n")
 
         for strategy in sorted_strategies:
             strategy_id = strategy["strategy_id"]
+            deals = strategy.get("deals_total", 0)
             hands = strategy["hands_with_bids"]
+            bid_rate = strategy.get("bid_rate")
             ev = strategy.get("expected_points")
+            ev_per_deal = strategy.get("expected_points_per_deal")
             cvar = strategy.get("cvar_5")
             downside_var = strategy.get("downside_variance")
             make_rate = strategy.get("make_rate")
 
             # Format values
+            bid_rate_str = f"{bid_rate:.1%}" if bid_rate is not None else "N/A"
             ev_str = f"{ev:.3f}" if ev is not None else "N/A"
+            ev_deal_str = f"{ev_per_deal:.3f}" if ev_per_deal is not None else "N/A"
             cvar_str = f"{cvar:.3f}" if cvar is not None else "N/A"
             downside_str = f"{downside_var:.3f}" if downside_var is not None else "N/A"
             make_rate_str = f"{make_rate:.1%}" if make_rate is not None else "N/A"
 
-            f.write(f"| {strategy_id} | {hands} | {ev_str} | {cvar_str} | {downside_str} | {make_rate_str} |\n")
+            f.write(
+                f"| {strategy_id} | {deals} | {hands} | {bid_rate_str} | {ev_str} | {ev_deal_str} | {cvar_str} | {downside_str} | {make_rate_str} |\n"
+            )
 
         f.write("\n")
         f.write("**Note:** Higher EV and Make Rate are better. Lower CVaR-5% and Downside Variance indicate lower risk.\n\n")
@@ -156,10 +165,14 @@ def _generate_baseline_matrix_report(run_dir: Path, strategy_metrics: List[Dict]
         entry = {
             "strategy_id": strategy["strategy_id"],
             "expected_points": strategy.get("expected_points"),
+            "expected_points_per_deal": strategy.get("expected_points_per_deal"),
             "make_rate": strategy.get("make_rate"),
+            "bid_rate": strategy.get("bid_rate"),
+            "pass_rate": strategy.get("pass_rate"),
             "cvar_5": strategy.get("cvar_5"),
             "downside_variance": strategy.get("downside_variance"),
-            "n_hands": strategy.get("hands_with_bids", 0)
+            "n_hands": strategy.get("hands_with_bids", 0),
+            "n_deals": strategy.get("deals_total", 0),
         }
         matrix.append(entry)
 
@@ -206,6 +219,7 @@ def generate_bidder_evaluation(run_dir: Path) -> Optional[Path]:
             records_by_strategy[strategy_id],
             key=lambda r: (int(r.get("deal_id", 0)), r.get("timestamp", "")),
         )
+        deals_total = len(records)
         bidder_points: List[int] = []
         made_count = 0
         for record in records:
@@ -218,14 +232,21 @@ def generate_bidder_evaluation(run_dir: Path) -> Optional[Path]:
 
         hands_with_bids = len(bidder_points)
         expected = sum(bidder_points) / hands_with_bids if hands_with_bids else None
+        expected_per_deal = sum(bidder_points) / deals_total if deals_total else None
         make_rate = made_count / hands_with_bids if hands_with_bids else None
+        bid_rate = hands_with_bids / deals_total if deals_total else None
+        pass_rate = (1.0 - bid_rate) if bid_rate is not None else None
 
         entry = {
             "strategy_id": strategy_id,
+            "deals_total": deals_total,
             "hands_with_bids": hands_with_bids,
             "bidder_team_points": bidder_points,
             "expected_points": _round(expected),
+            "expected_points_per_deal": _round(expected_per_deal),
             "make_rate": _round(make_rate),
+            "bid_rate": _round(bid_rate),
+            "pass_rate": _round(pass_rate),
             "cvar_5": _round(compute_cvar(bidder_points)),
             "downside_variance": _round(compute_downside_variance(bidder_points)),
         }
@@ -244,6 +265,10 @@ def generate_bidder_evaluation(run_dir: Path) -> Optional[Path]:
         "metric_definitions": {
             "cvar_5": "avg of worst 5% bidder_team_points",
             "downside_variance": "variance of bidder_team_points below 0",
+            "expected_points": "EV over hands with an auction winner (no-bid hands excluded)",
+            "expected_points_per_deal": "EV per deal with 0 for all-pass redeals",
+            "bid_rate": "fraction of deals with an auction winner",
+            "pass_rate": "fraction of deals that are all-pass redeals",
         },
     }
 


### PR DESCRIPTION
## Summary

- Add `--play-strategy` CLI arg and `parameters.play_strategy` YAML option for specifying the card-play strategy in auction mode bidder evaluations
- Add `_make_self_play_strategies()` helper to create 4-seat strategy instances for the play strategy
- Add `bid_rate`, `pass_rate`, and `EV/deal` metrics to the evaluator reports

## Why

Configs on `origin/main` reference `parameters.play_strategy` (e.g., `bid_eval_with_frozen_play.yaml`), but the code to handle this parameter was never merged. This PR completes the feature.

## Repro / Validation

```bash
cd /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-play-strategy-impl
make check
PYTHONPATH=src python experiments/run_experiment.py \
  --config experiments/configs/bid_eval_with_frozen_play.yaml \
  --seed 42 --n_per 100
```

Output shows:
```
Auction play strategy: f1_f4
```

## Tests

- `make check` passes (1 unrelated flaky test failure in `test_different_seeds_give_different_results`)
- Smoke test confirms `play_strategy` parameter is honored

## Worktree proof

```
$ pwd
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-play-strategy-impl

$ git rev-parse --show-toplevel
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-play-strategy-impl

$ git worktree list
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                   b44c069 [weighted-win-rate]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-play-strategy-impl 0a46d61 [feat/play-strategy-impl]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)