### PR TITLE
Fix canonical dataset join to use hand_id+seat for multi-strategy runs

### DIFF
--- a/src/bid_euchre/diagnostics/notebook_data.py
+++ b/src/bid_euchre/diagnostics/notebook_data.py
@@ -736,8 +736,49 @@ def load_features_and_outcomes_from_run_dir(
         if col in outcome_df.columns:
             outcome_cols.append(col)
 
-    # Join on deal_id + seat + contract_type + trump
-    merge_keys = ['deal_id', 'seat', 'contract_type', 'trump']
+    # Determine merge keys based on data source
+    # When hand_id is available (parquet path), use it for globally unique joins
+    # This prevents many-to-many joins in multi-strategy runs where same deal_id
+    # appears multiple times with different strategies
+    has_hand_id = 'hand_id' in features_df.columns and 'hand_id' in outcome_df.columns
+
+    if has_hand_id:
+        # Preferred: globally unique key
+        merge_keys = ['hand_id', 'seat']
+
+        # Columns that exist in both DataFrames - keep from features, drop from outcomes
+        # to prevent _x/_y suffixes in merged result
+        redundant_cols = ['deal_id', 'contract_type', 'trump']
+        cols_to_drop = [
+            c for c in redundant_cols
+            if c in outcome_df.columns and c in features_df.columns
+        ]
+
+        # Verify consistency before dropping
+        if cols_to_drop:
+            check_df = features_df[['hand_id', 'seat'] + cols_to_drop].merge(
+                outcome_df[['hand_id', 'seat'] + cols_to_drop],
+                on=['hand_id', 'seat'],
+                suffixes=('_feat', '_out'),
+                how='inner'
+            )
+            for col in cols_to_drop:
+                mismatches = check_df[check_df[f'{col}_feat'] != check_df[f'{col}_out']]
+                if len(mismatches) > 0:
+                    raise ValueError(
+                        f"Inconsistent {col} values between features and outcomes for "
+                        f"hand_id/seat. Found {len(mismatches)} mismatches."
+                    )
+
+        # Remove redundant columns from outcome_cols (keep from features side)
+        outcome_cols_present = [
+            c for c in outcome_cols
+            if c in outcome_df.columns and (c not in cols_to_drop or c in merge_keys)
+        ]
+    else:
+        # Fallback for log-based outcomes (no hand_id)
+        merge_keys = ['deal_id', 'seat', 'contract_type', 'trump']
+        outcome_cols_present = [c for c in outcome_cols if c in outcome_df.columns]
 
     # Check that merge keys exist in both dataframes
     for key in merge_keys:
@@ -746,18 +787,17 @@ def load_features_and_outcomes_from_run_dir(
         if key not in outcome_df.columns:
             raise ValueError(f"Missing merge key '{key}' in outcomes DataFrame")
 
-    # Select outcome columns that exist
-    outcome_cols_present = [c for c in outcome_cols if c in outcome_df.columns]
     merged_df = features_df.merge(
         outcome_df[outcome_cols_present],
         on=merge_keys,
-        how='inner'
+        how='inner',
+        validate='one_to_one'  # Fail loudly on duplicates
     )
 
     if len(merged_df) == 0:
         raise ValueError(
-            "Join produced empty DataFrame. Check that features and outcomes "
-            "have matching deal_id + seat + contract_type + trump values."
+            f"Join produced empty DataFrame. Check that features and outcomes "
+            f"have matching {' + '.join(merge_keys)} values."
         )
 
     return merged_df

--- a/tests/unit/diagnostics/test_outcomes_loader.py
+++ b/tests/unit/diagnostics/test_outcomes_loader.py
@@ -358,3 +358,152 @@ class TestFeaturesAndOutcomesLoaderPreference:
         assert df["strategy_id"].iloc[0] == "log_strategy"
         # Should NOT have parquet-specific columns
         assert "matchup_id" not in df.columns
+
+    def test_multi_strategy_join_uses_hand_id(self, temp_run_dir):
+        """Multi-strategy runs with same deal_id don't produce many-to-many joins.
+
+        This tests the critical fix: when the same deal_id appears multiple times
+        (different strategies playing the same deal), we must join on hand_id+seat
+        not deal_id+seat to avoid cross-product explosion.
+        """
+        from bid_euchre.diagnostics.notebook_data import (
+            load_features_and_outcomes_from_run_dir,
+        )
+
+        # Features: 2 hands × 4 seats = 8 rows, SAME deal_id=0
+        features_rows = [
+            {
+                "hand_id": hand_id,
+                "deal_id": 0,  # Same deal_id for both hands!
+                "seat": seat,
+                "contract_type": "suit",
+                "trump_suit": "H",
+                "hand_cards": ["AH", "KH"],
+                "hand_features": {"trump_count": 2},
+                "hand_feature_schema_version": 1,
+                "dealer_seat": 0,
+            }
+            for hand_id in [0, 1]
+            for seat in range(4)
+        ]
+        self._create_features_parquet(temp_run_dir, features_rows)
+
+        # Outcomes: 2 hands, SAME deal_id=0, DIFFERENT strategies
+        outcomes_rows = [
+            {
+                "hand_id": 0,
+                "deal_id": 0,
+                "dealer_seat": 0,
+                "contract_type": "suit",
+                "trump_suit": "H",
+                "strategy_id": "greedy",
+                "matchup_id": "greedy_vs_greedy",
+                "team0_strategy": "greedy",
+                "team1_strategy": "greedy",
+                "tricks_team0": 7,
+                "tricks_team1": 3,
+                "team0_win": 1.0,
+            },
+            {
+                "hand_id": 1,
+                "deal_id": 0,  # Same deal_id!
+                "dealer_seat": 0,
+                "contract_type": "suit",
+                "trump_suit": "H",
+                "strategy_id": "random",
+                "matchup_id": "random_vs_random",
+                "team0_strategy": "random",
+                "team1_strategy": "random",
+                "tricks_team0": 5,
+                "tricks_team1": 5,
+                "team0_win": 0.5,
+            },
+        ]
+        self._create_outcomes_parquet(temp_run_dir, outcomes_rows)
+
+        df = load_features_and_outcomes_from_run_dir(temp_run_dir)
+
+        # Key assertion: exactly 8 rows, not 16 from cross-product
+        assert len(df) == 8, f"Expected 8 rows, got {len(df)} (cross-product bug?)"
+
+        # hand_id=0 rows should have greedy strategy and tricks from hand 0
+        hand0_df = df[df["hand_id"] == 0]
+        assert len(hand0_df) == 4
+        assert all(hand0_df["strategy_id"] == "greedy")
+        assert hand0_df[hand0_df["seat"] == 0]["tricks_won"].iloc[0] == 7  # team0
+        assert hand0_df[hand0_df["seat"] == 1]["tricks_won"].iloc[0] == 3  # team1
+
+        # hand_id=1 rows should have random strategy and tricks from hand 1
+        hand1_df = df[df["hand_id"] == 1]
+        assert len(hand1_df) == 4
+        assert all(hand1_df["strategy_id"] == "random")
+        assert hand1_df[hand1_df["seat"] == 0]["tricks_won"].iloc[0] == 5  # team0
+        assert hand1_df[hand1_df["seat"] == 1]["tricks_won"].iloc[0] == 5  # team1
+
+        # No cross-contamination: verify each hand has correct matchup_id
+        assert all(hand0_df["matchup_id"] == "greedy_vs_greedy")
+        assert all(hand1_df["matchup_id"] == "random_vs_random")
+
+        # No _x/_y suffixes from column collisions
+        assert not any("_x" in col or "_y" in col for col in df.columns)
+
+    def test_join_validate_rejects_duplicates(self, temp_run_dir):
+        """validate='one_to_one' catches bad data that would produce duplicates."""
+        from bid_euchre.diagnostics.notebook_data import (
+            load_features_and_outcomes_from_run_dir,
+        )
+
+        # Create features (4 rows, 1 hand × 4 seats)
+        features_rows = [
+            {
+                "hand_id": 0,
+                "deal_id": 0,
+                "seat": seat,
+                "contract_type": "suit",
+                "trump_suit": "H",
+                "hand_cards": ["AH", "KH"],
+                "hand_features": {"trump_count": 2},
+                "hand_feature_schema_version": 1,
+                "dealer_seat": 0,
+            }
+            for seat in range(4)
+        ]
+        self._create_features_parquet(temp_run_dir, features_rows)
+
+        # Create outcomes with duplicate hand_id (bad data)
+        # This simulates corrupted data where the same hand appears twice
+        outcomes_rows = [
+            {
+                "hand_id": 0,
+                "deal_id": 0,
+                "dealer_seat": 0,
+                "contract_type": "suit",
+                "trump_suit": "H",
+                "strategy_id": "greedy",
+                "matchup_id": "greedy_vs_greedy",
+                "team0_strategy": "greedy",
+                "team1_strategy": "greedy",
+                "tricks_team0": 7,
+                "tricks_team1": 3,
+                "team0_win": 1.0,
+            },
+            {
+                "hand_id": 0,  # Duplicate hand_id!
+                "deal_id": 0,
+                "dealer_seat": 0,
+                "contract_type": "suit",
+                "trump_suit": "H",
+                "strategy_id": "different",  # Different strategy but same hand_id
+                "matchup_id": "different_vs_different",
+                "team0_strategy": "different",
+                "team1_strategy": "different",
+                "tricks_team0": 4,
+                "tricks_team1": 6,
+                "team0_win": 0.0,
+            },
+        ]
+        self._create_outcomes_parquet(temp_run_dir, outcomes_rows)
+
+        # Should fail with MergeError due to validate='one_to_one'
+        with pytest.raises(pd.errors.MergeError):
+            load_features_and_outcomes_from_run_dir(temp_run_dir)


### PR DESCRIPTION
## Summary
- Fix many-to-many join bug in `load_features_and_outcomes_from_run_dir()` for multi-strategy runs
- Use `hand_id+seat` as merge keys when `hand_id` is available (parquet path)
- Add `validate='one_to_one'` to catch duplicate key errors early
- Add regression tests for multi-strategy join correctness

## Why
In multi-strategy runs, the same `deal_id` appears multiple times with different strategies. The old join on `deal_id+seat+contract_type+trump` caused cross-product explosion (e.g., 8 rows → 16 rows for 2 strategies playing the same deal).

**Example failure mode:**
```
Features (8 rows: 2 hands × 4 seats):
hand_id=0, deal_id=0, seat=0..3, strategy=greedy
hand_id=1, deal_id=0, seat=0..3, strategy=random

Outcomes (8 rows after expansion):
hand_id=0, deal_id=0, seat=0..3, strategy=greedy
hand_id=1, deal_id=0, seat=0..3, strategy=random

Join on deal_id+seat+contract+trump → 16 rows (cross-product)
Join on hand_id+seat → 8 rows (correct 1:1)
```

## Repro / Validation

```bash
# Run the specific tests
PYTHONPATH=src uv run python -m pytest tests/unit/diagnostics/test_outcomes_loader.py::TestFeaturesAndOutcomesLoaderPreference::test_multi_strategy_join_uses_hand_id -v
PYTHONPATH=src uv run python -m pytest tests/unit/diagnostics/test_outcomes_loader.py::TestFeaturesAndOutcomesLoaderPreference::test_join_validate_rejects_duplicates -v

# Full test suite
make check
```

## Tests
- [x] `make check` passes (822 passed, 5 skipped)
- [x] `test_multi_strategy_join_uses_hand_id`: verifies 8 rows not 16
- [x] `test_join_validate_rejects_duplicates`: verifies MergeError on bad data

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-join-correctness
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-join-correctness
Branch: fix/canonical-join-correctness
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)