### PR TITLE
Fix repo-lint to handle multi-line experiment invocations

### DIFF
--- a/scripts/lint_repo.py
+++ b/scripts/lint_repo.py
@@ -422,8 +422,8 @@ def check_experiments_without_seed(changed: list[str], repo_root: Path) -> list[
 
     violations: list[Violation] = []
 
-    # Pattern matches experiment invocations
-    experiment_pattern = re.compile(r'python experiments/run_experiment\.py[^\n]*')
+    # Pattern matches experiment invocations (including multi-line with backslash continuations)
+    experiment_pattern = re.compile(r'python experiments/run_experiment\.py(?:[^\n]*\\\n)*[^\n]*')
 
     # Files to check
     paths_to_check: list[Path] = []


### PR DESCRIPTION
## Summary
- Updated `experiments-require-seed` regex pattern to match multi-line shell commands with backslash continuations
- Unblocks PR #242 which was failing due to multi-line invocation in `docs/01_core/EXPERIMENTS.md`

## Why
The repo linter's regex for detecting experiment invocations only matched up to the first newline:
```python
experiment_pattern = re.compile(r'python experiments/run_experiment\.py[^\n]*')
```

This caused false positives for properly-seeded multi-line invocations like:
```bash
python experiments/run_experiment.py \
  --config ... \
  --seed 42
```

## Repro / Validation
```bash
cd /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-repo-lint-multiline
make check  # passes
```

## Tests
- `make check` passes (repo-lint, ruff, pytest)

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-repo-lint-multiline
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-repo-lint-multiline
git worktree list:
  /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                        bc5a93d [main]
  /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-repo-lint-multiline 82dc9f6 [fix/repo-lint-multiline]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)