### PR TITLE
Fix null-safe comparison in parquet join consistency check

### DIFF
--- a/src/bid_euchre/diagnostics/notebook_data.py
+++ b/src/bid_euchre/diagnostics/notebook_data.py
@@ -659,7 +659,7 @@ def load_features_and_outcomes_from_run_dir(
     run_dir: str,
     prefer_parquet: bool = True,
 ) -> pd.DataFrame:
-    """Load features from datasets/ and outcomes, joined by deal_id + seat.
+    """Load features from datasets/ and outcomes, joined appropriately by source.
 
     Prefers outcomes parquet when present (from --emit-bidless-outcomes-dataset),
     falls back to parsing JSONL logs when parquet is not available.
@@ -668,7 +668,7 @@ def load_features_and_outcomes_from_run_dir(
     1. Validates the run directory structure
     2. Loads feature data from run_dir/datasets/bidless.parquet
     3. Loads outcome data (prefers parquet, falls back to logs)
-    4. Joins on deal_id + seat + contract_type + trump
+    4. Joins on ['hand_id', 'seat'] (parquet) or ['deal_id', 'seat', 'contract_type', 'trump'] (logs)
 
     Args:
         run_dir: Path to run directory containing datasets/ (and optionally logs/)
@@ -696,8 +696,10 @@ def load_features_and_outcomes_from_run_dir(
         ValueError: If no data found or join fails
 
     Note:
-        The join is on [deal_id, seat, contract_type, trump] to ensure proper
-        alignment even when features and outcomes have different data coverage.
+        Join strategy depends on data source:
+        - Parquet path (hand_id present): merge on ['hand_id', 'seat'] for globally
+          unique joins that handle multi-strategy runs correctly.
+        - Log fallback (no hand_id): merge on ['deal_id', 'seat', 'contract_type', 'trump'].
     """
     run_path = Path(run_dir)
 
@@ -755,6 +757,9 @@ def load_features_and_outcomes_from_run_dir(
         ]
 
         # Verify consistency before dropping
+        # Note: This consistency check adds an extra merge pass. We accept this cost
+        # for correctness validation. For very large runs, consider gating behind
+        # a debug_validate parameter if performance becomes an issue.
         if cols_to_drop:
             check_df = features_df[['hand_id', 'seat'] + cols_to_drop].merge(
                 outcome_df[['hand_id', 'seat'] + cols_to_drop],
@@ -763,7 +768,11 @@ def load_features_and_outcomes_from_run_dir(
                 how='inner'
             )
             for col in cols_to_drop:
-                mismatches = check_df[check_df[f'{col}_feat'] != check_df[f'{col}_out']]
+                feat_vals = check_df[f'{col}_feat']
+                out_vals = check_df[f'{col}_out']
+                # Null-safe: treat (both null) as equal; covers None, NaN, pd.NA
+                both_null = feat_vals.isna() & out_vals.isna()
+                mismatches = check_df[feat_vals.ne(out_vals) & ~both_null]
                 if len(mismatches) > 0:
                     raise ValueError(
                         f"Inconsistent {col} values between features and outcomes for "

--- a/tests/unit/diagnostics/test_outcomes_loader.py
+++ b/tests/unit/diagnostics/test_outcomes_loader.py
@@ -507,3 +507,60 @@ class TestFeaturesAndOutcomesLoaderPreference:
         # Should fail with MergeError due to validate='one_to_one'
         with pytest.raises(pd.errors.MergeError):
             load_features_and_outcomes_from_run_dir(temp_run_dir)
+
+    def test_parquet_join_allows_null_trump_high_low(self, temp_run_dir):
+        """Parquet join succeeds when trump is null (high/low contracts).
+
+        Regression test: the consistency check for redundant columns must handle
+        None/NaN values correctly. Previously, None != None evaluated to True,
+        causing false 'Inconsistent trump' errors.
+        """
+        from bid_euchre.diagnostics.notebook_data import (
+            load_features_and_outcomes_from_run_dir,
+        )
+
+        # Features: 1 hand × 4 seats, contract_type="high", trump=None
+        features_rows = [
+            {
+                "hand_id": 0,
+                "deal_id": 0,
+                "seat": seat,
+                "contract_type": "high",
+                "trump_suit": None,  # high contract has no trump
+                "hand_cards": ["AH", "KH"],
+                "hand_features": {"offsuit_aces": 2},
+                "hand_feature_schema_version": 1,
+                "dealer_seat": 0,
+            }
+            for seat in range(4)
+        ]
+        self._create_features_parquet(temp_run_dir, features_rows)
+
+        # Outcomes: 1 hand, contract_type="high", trump=None
+        outcomes_rows = [
+            {
+                "hand_id": 0,
+                "deal_id": 0,
+                "dealer_seat": 0,
+                "contract_type": "high",
+                "trump_suit": None,  # must match features
+                "strategy_id": "greedy",
+                "matchup_id": "greedy_vs_greedy",
+                "team0_strategy": "greedy",
+                "team1_strategy": "greedy",
+                "tricks_team0": 6,
+                "tricks_team1": 4,
+                "team0_win": 1.0,
+            },
+        ]
+        self._create_outcomes_parquet(temp_run_dir, outcomes_rows)
+
+        # Should succeed without ValueError
+        df = load_features_and_outcomes_from_run_dir(temp_run_dir)
+
+        # Verify join produced correct results
+        assert len(df) == 4, f"Expected 4 rows (1 hand × 4 seats), got {len(df)}"
+        assert df["contract_type"].eq("high").all()
+        assert df["trump"].isna().all(), "trump should be None for high contracts"
+        assert "tricks_won" in df.columns, "Join should include outcome columns"
+        assert df["tricks_won"].notna().all(), "tricks_won should be populated"


### PR DESCRIPTION
## Summary

- Fix null-unsafe comparison in `load_features_and_outcomes_from_run_dir()` consistency check
- Add regression test for null trump values (high/low contracts)
- Update docstring to accurately reflect merge behavior for parquet vs log sources

## Why

The consistency check for redundant columns (deal_id, contract_type, trump) used `!=` comparison which fails for null values. In pandas, `None != None` evaluates to `True` for object-dtype columns, causing false "Inconsistent trump" errors for high/low contracts where trump is intentionally `None`.

## Repro / Validation

```bash
# Run the specific regression test
cd /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-parquet-null-trump
uv run pytest tests/unit/diagnostics/test_outcomes_loader.py::TestFeaturesAndOutcomesLoaderPreference::test_parquet_join_allows_null_trump_high_low -v

# Run all tests in the file
uv run pytest tests/unit/diagnostics/test_outcomes_loader.py -v
```

## Tests

```bash
make check  # All 859 tests pass
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-parquet-null-trump
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-parquet-null-trump
git worktree list:
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                       3b7218f [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-parquet-null-trump 1112f5a [fix-parquet-null-trump]
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)