### PR TITLE
Add memory-safe streaming writer for bidding datasets and fix hand_id collisions

### DIFF
--- a/experiments/run_experiment.py
+++ b/experiments/run_experiment.py
@@ -39,14 +39,14 @@ import os
 import sys
 import time
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, Optional
 
 import yaml
 
 # Ensure src is in path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
-from bid_euchre.datasets.bidding import emit_bidding_dataset
+from bid_euchre.datasets.bidding import BiddingDatasetWriter
 from bid_euchre.datasets.bidless import BidlessDatasetCollector, BidlessDatasetWriter
 from bid_euchre.datasets.bidless_outcomes import (
     BidlessOutcomesCollector,
@@ -402,7 +402,6 @@ def main():
     # Track performance metrics
     start_time = time.time()
     scenario_metrics = []
-    all_bidding_collectors: List[Any] = []
 
     # Create streaming writer for bidless dataset if requested
     bidless_writer: BidlessDatasetWriter | None = None
@@ -412,6 +411,11 @@ def main():
             run_id=run_id,
             format=args.bidless_dataset_format,
         )
+
+    # Streaming writer for bidding dataset (replaces accumulation pattern)
+    bidding_writer: Optional[BiddingDatasetWriter] = None
+    if args.emit_bidding_dataset:
+        bidding_writer = BiddingDatasetWriter(run_dir, run_id, format=args.bidding_dataset_format)
 
     # Track plan/scenario indices for globally unique hand_id computation
     # Use a dict to make values mutable from within closures
@@ -623,6 +627,9 @@ def main():
 
                     scenario_start = time.time()
 
+                    # Compute hand_id offset: (matchup_idx * num_scenarios + scenario_idx) * n_per
+                    bidding_hand_id_offset = (matchup_idx * num_scenarios + (i - 1)) * n_per
+
                     results = simulation.simulate_many_hands(
                         n=n_per,
                         contract_type=scenario.contract_type,
@@ -635,10 +642,14 @@ def main():
                         bidding_policies=seat_bidding_policies,
                         logger=logger,
                         bidding_dataset_run_id=run_id if args.emit_bidding_dataset else None,
+                        bidding_hand_id_offset=bidding_hand_id_offset if args.emit_bidding_dataset else 0,
                         hooks=bidless_hooks,
                     )
                     bidding_collectors = results.pop("bidding_collectors", [])
-                    all_bidding_collectors.extend(bidding_collectors)
+                    # Stream write to avoid memory accumulation
+                    if bidding_writer and bidding_collectors:
+                        for collector in bidding_collectors:
+                            bidding_writer.append_rows(collector.get_rows_sorted())
 
                     scenario_duration = time.time() - scenario_start
                     hands_per_sec = n_per / scenario_duration if scenario_duration > 0 else 0
@@ -743,6 +754,9 @@ def main():
 
                     scenario_start = time.time()
 
+                    # Compute hand_id offset: (policy_idx * num_scenarios + scenario_idx) * n_per
+                    bidding_hand_id_offset = (policy_idx * num_scenarios + (i - 1)) * n_per
+
                     if policy_type == "bidding_policy":
                         # For bidding policies, use the policy directly in auction mode
                         results = simulation.simulate_many_hands(
@@ -756,6 +770,7 @@ def main():
                             bidding_policy=policy,
                             logger=logger,
                             bidding_dataset_run_id=run_id if args.emit_bidding_dataset else None,
+                            bidding_hand_id_offset=bidding_hand_id_offset if args.emit_bidding_dataset else 0,
                             hooks=bidless_hooks,
                         )
                     else:
@@ -773,10 +788,14 @@ def main():
                             bidding_policy=None,
                             logger=logger,
                             bidding_dataset_run_id=run_id if args.emit_bidding_dataset else None,
+                            bidding_hand_id_offset=bidding_hand_id_offset if args.emit_bidding_dataset else 0,
                             hooks=bidless_hooks,
                         )
                     bidding_collectors = results.pop("bidding_collectors", [])
-                    all_bidding_collectors.extend(bidding_collectors)
+                    # Stream write to avoid memory accumulation
+                    if bidding_writer and bidding_collectors:
+                        for collector in bidding_collectors:
+                            bidding_writer.append_rows(collector.get_rows_sorted())
 
                     scenario_duration = time.time() - scenario_start
                     hands_per_sec = n_per / scenario_duration if scenario_duration > 0 else 0
@@ -863,8 +882,8 @@ def main():
     with open(os.path.join(run_dir, "perf.json"), "w") as f:
         json.dump(perf, f, indent=2)
     
-    if args.emit_bidding_dataset and all_bidding_collectors:
-        dataset_path = emit_bidding_dataset(all_bidding_collectors, run_dir, format=args.bidding_dataset_format)
+    if bidding_writer:
+        dataset_path = bidding_writer.finalize()
         print(f"\n📊 Emitted bidding dataset: {dataset_path}")
 
     if args.emit_bidless_dataset and bidless_writer is not None:

--- a/src/bid_euchre/datasets/bidding.py
+++ b/src/bid_euchre/datasets/bidding.py
@@ -7,11 +7,39 @@ and emitting them as structured datasets for training ML models.
 
 import json
 import os
-from typing import Any, Dict, List, Optional
+from typing import IO, Any, Dict, List, Optional
+
+import pyarrow as pa
+import pyarrow.parquet as pq
 
 from ..core.cards import Card
 from ..features.hand_eval import get_hand_features
 from ..strategy.bidding import BidAction, BiddingObservation
+
+# Explicit schema for nullable string columns to avoid null-type inference
+# when first flush contains all-pass rows (all None values)
+BIDDING_DATASET_SCHEMA = pa.schema([
+    ("hand_id", pa.int64()),
+    ("seat", pa.int64()),
+    ("dealer_seat", pa.int64()),
+    ("deal_id", pa.int64()),
+    ("current_high_bid", pa.int64()),
+    ("hand_cards", pa.list_(pa.string())),
+    ("hand_features", pa.map_(pa.string(), pa.float64())),
+    ("hand_feature_schema_version", pa.int64()),
+    # Nullable string columns - MUST be string, not null
+    ("attempted_bid_n", pa.int64()),
+    ("attempted_bid_contract", pa.string()),      # nullable: None for pass
+    ("attempted_bid_trump_suit", pa.string()),    # nullable: None for pass/HIGH/LOW
+    ("effective_bid_n", pa.int64()),
+    ("effective_bid_contract", pa.string()),      # nullable: None for pass
+    ("effective_bid_trump_suit", pa.string()),    # nullable: None for pass/HIGH/LOW
+    ("is_legal_raise", pa.bool_()),
+    ("auction_outcome", pa.string()),             # nullable: "won" | "all_pass_redeal" | None
+    ("winning_seat", pa.int64()),                 # nullable: None for redeals
+    ("winning_bid_n", pa.int64()),                # nullable: None for redeals
+    ("winning_bid_contract", pa.string()),        # nullable: None for redeals
+])
 
 
 class BiddingDatasetCollector:
@@ -322,3 +350,117 @@ def emit_bidding_dataset(
         json.dump(meta_data, f, indent=2)
 
     return primary_path
+
+
+class BiddingDatasetWriter:
+    """Streaming writer for bidding datasets - writes incrementally to avoid memory accumulation."""
+
+    def __init__(self, run_dir: str, run_id: str, format: str = "parquet", flush_rows: int = 50_000):
+        """
+        Initialize streaming writer.
+
+        Args:
+            run_dir: Base run directory (e.g., data/runs/<run_id>)
+            run_id: Unique run identifier
+            format: Output format ("parquet" or "jsonl", default: "parquet")
+            flush_rows: Number of rows to buffer before flushing to disk
+        """
+        self.run_id = run_id
+        self.format = format
+        self.flush_rows = flush_rows
+        self.datasets_dir = os.path.join(run_dir, "datasets")
+        os.makedirs(self.datasets_dir, exist_ok=True)
+
+        # Buffer and state
+        self._buffer: List[Dict[str, Any]] = []
+        self._row_count = 0
+        self._parquet_writer: Optional[pq.ParquetWriter] = None
+        self._jsonl_file: Optional[IO[str]] = None
+
+    def append_rows(self, rows: List[Dict[str, Any]]) -> None:
+        """Append rows to buffer, flush if threshold reached."""
+        self._buffer.extend(rows)
+        if len(self._buffer) >= self.flush_rows:
+            self._flush()
+
+    def _flush(self) -> None:
+        """Sort buffer by (hand_id, seat), write to files, clear buffer."""
+        if not self._buffer:
+            return
+
+        # Sort deterministically
+        sorted_rows = sorted(self._buffer, key=lambda r: (r["hand_id"], r["seat"]))
+
+        if self.format == "parquet":
+            self._write_parquet_chunk(sorted_rows)
+            self._write_jsonl_debug_chunk(sorted_rows)  # Debug JSONL with run_id
+        else:
+            self._write_jsonl_primary_chunk(sorted_rows)  # Primary JSONL without run_id
+
+        self._row_count += len(sorted_rows)
+        self._buffer.clear()
+
+    def _write_parquet_chunk(self, rows: List[Dict[str, Any]]) -> None:
+        """Write rows as parquet row group using explicit schema."""
+        if self._parquet_writer is None:
+            # Add run_id and schema versions to parquet metadata
+            metadata = {
+                b"run_id": self.run_id.encode("utf-8"),
+                b"bidding_dataset_schema_version": b"1",
+                b"hand_feature_schema_version": b"1",
+            }
+            schema_with_meta = BIDDING_DATASET_SCHEMA.with_metadata(metadata)
+            parquet_path = os.path.join(self.datasets_dir, "bidding.parquet")
+            self._parquet_writer = pq.ParquetWriter(parquet_path, schema_with_meta)
+
+        table = pa.Table.from_pylist(rows, schema=BIDDING_DATASET_SCHEMA)
+        self._parquet_writer.write_table(table)
+
+    def _write_jsonl_debug_chunk(self, rows: List[Dict[str, Any]]) -> None:
+        """Append rows to debug JSONL file WITH run_id (parquet mode)."""
+        if self._jsonl_file is None:
+            jsonl_path = os.path.join(self.datasets_dir, "bidding.jsonl")
+            self._jsonl_file = open(jsonl_path, "w")
+
+        for row in rows:
+            row_with_run_id = {"run_id": self.run_id, **row}
+            json.dump(row_with_run_id, self._jsonl_file, sort_keys=True)
+            self._jsonl_file.write("\n")
+
+    def _write_jsonl_primary_chunk(self, rows: List[Dict[str, Any]]) -> None:
+        """Append rows to primary JSONL file WITHOUT run_id (jsonl mode)."""
+        if self._jsonl_file is None:
+            jsonl_path = os.path.join(self.datasets_dir, "bidding.jsonl")
+            self._jsonl_file = open(jsonl_path, "w")
+
+        for row in rows:
+            json.dump(row, self._jsonl_file, sort_keys=True)
+            self._jsonl_file.write("\n")
+
+    def finalize(self) -> str:
+        """Flush remaining rows, close files, write metadata."""
+        self._flush()
+
+        if self._parquet_writer:
+            self._parquet_writer.close()
+        if self._jsonl_file:
+            self._jsonl_file.close()
+
+        # Write metadata - always include both paths (matches existing behavior)
+        meta_path = os.path.join(self.datasets_dir, "bidding_meta.json")
+        meta_data = {
+            "run_id": self.run_id,
+            "bidding_dataset_schema_version": 1,
+            "hand_feature_schema_version": 1,
+            "row_count": self._row_count,
+            "parquet_path": "bidding.parquet",
+            "jsonl_path": "bidding.jsonl",
+        }
+        with open(meta_path, "w") as f:
+            json.dump(meta_data, f, indent=2)
+
+        primary_path = os.path.join(
+            self.datasets_dir,
+            "bidding.parquet" if self.format == "parquet" else "bidding.jsonl",
+        )
+        return primary_path

--- a/src/bid_euchre/sim/simulation.py
+++ b/src/bid_euchre/sim/simulation.py
@@ -430,6 +430,7 @@ def simulate_many_hands(
     logger: Optional["GameLogger"] = None,
     deal_seed: Optional[int] = None,
     bidding_dataset_run_id: Optional[str] = None,
+    bidding_hand_id_offset: int = 0,
     hooks: Optional[SimulationHooks] = None,
     deal_method: str = "round_robin",
 ) -> Dict:
@@ -446,6 +447,8 @@ def simulate_many_hands(
         bidding_policy: Optional bidding policy (single policy used for all seats)
         bidding_policies: Optional per-seat bidding policies (length 4)
         logger: Optional GameLogger for structured JSONL logging
+        bidding_dataset_run_id: Run ID for bidding dataset collection (auction mode only)
+        bidding_hand_id_offset: Offset to add to hand_id for globally unique IDs
         hooks: Optional SimulationHooks for event-based instrumentation
 
     Returns a summary dict:
@@ -512,7 +515,7 @@ def simulate_many_hands(
     collectors: List[BiddingDatasetCollector] = []
     if bidding_dataset_run_id is not None and contract_type is None:
         collectors = [
-            BiddingDatasetCollector(bidding_dataset_run_id, hand_id)
+            BiddingDatasetCollector(bidding_dataset_run_id, bidding_hand_id_offset + hand_id)
             for hand_id in range(n)
         ]
 

--- a/tests/integration/test_bidding_dataset_hand_id_uniqueness.py
+++ b/tests/integration/test_bidding_dataset_hand_id_uniqueness.py
@@ -1,0 +1,87 @@
+"""Test that hand_id values are globally unique across multi-policy auction runs."""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+
+class TestBiddingDatasetHandIdUniqueness:
+    """Verify hand_id uniqueness when running multiple bidding policies."""
+
+    def test_multi_policy_hand_id_uniqueness(self):
+        """Run bid_eval_tiny with multiple policies and verify hand_id uniqueness."""
+        env = os.environ.copy()
+        env["PYTHONPATH"] = "src"
+
+        with tempfile.TemporaryDirectory() as temp_base:
+            n_per = 5  # Small for fast test
+            cmd = [
+                sys.executable,
+                "-m",
+                "experiments.run_experiment",
+                "--config",
+                "experiments/configs/bid_eval_tiny.yaml",
+                "--run-dir",
+                temp_base,
+                "--seed",
+                "42",
+                "--n_per",
+                str(n_per),
+                "--emit-bidding-dataset",
+            ]
+            result = subprocess.run(
+                cmd, check=True, capture_output=True, text=True, cwd=os.getcwd(), env=env
+            )
+            assert result.returncode == 0, f"Runner failed: {result.stderr}"
+
+            # Find run directory
+            run_dirs = sorted(Path(temp_base).glob("bid_eval_tiny_*"))
+            assert run_dirs, f"No run directories found in {temp_base}"
+            run_dir = run_dirs[-1]
+
+            # Load effective config to get policy count
+            config_path = run_dir / "config_effective.yaml"
+            with open(config_path) as f:
+                config = yaml.safe_load(f)
+
+            num_policies = len(config["bidding_policies"])
+            num_scenarios = len(config["scenarios"])
+            expected_hands = num_policies * num_scenarios * n_per
+
+            # This test only makes sense with multiple policies
+            assert (
+                num_policies > 1
+            ), f"Need >1 policies for collision test, got {num_policies}"
+
+            # Load parquet and check uniqueness
+            try:
+                import pyarrow.parquet as pq
+
+                parquet_path = run_dir / "datasets" / "bidding.parquet"
+                table = pq.read_table(parquet_path)
+                df_hand_ids = table.column("hand_id").to_pylist()
+            except ImportError:
+                # Fallback to JSONL
+                jsonl_path = run_dir / "datasets" / "bidding.jsonl"
+                df_hand_ids = []
+                with open(jsonl_path) as f:
+                    for line in f:
+                        row = json.loads(line)
+                        df_hand_ids.append(row["hand_id"])
+
+            unique_hand_ids = sorted(set(df_hand_ids))
+
+            # Verify uniqueness and contiguous range: should be exactly [0, 1, 2, ..., expected_hands-1]
+            expected_range = list(range(expected_hands))
+            assert unique_hand_ids == expected_range, (
+                f"hand_id mismatch!\n"
+                f"Expected: {expected_range[:10]}...{expected_range[-3:]} ({len(expected_range)} values)\n"
+                f"Got: {unique_hand_ids[:10]}...{unique_hand_ids[-3:]} ({len(unique_hand_ids)} unique values)\n"
+                f"Missing: {set(expected_range) - set(unique_hand_ids)}\n"
+                f"Extra: {set(unique_hand_ids) - set(expected_range)}"
+            )


### PR DESCRIPTION
## Summary

- Add `BiddingDatasetWriter` class with streaming writes to avoid memory accumulation
- Add `bidding_hand_id_offset` parameter to `simulate_many_hands()` for globally unique IDs
- Fix hand_id collisions when multiple policies run (e.g., `bid_eval_tiny.yaml` with 3 policies)

## Why

Two issues fixed:
1. **Memory**: `emit_bidding_dataset()` accumulated all rows in memory before writing
2. **Correctness**: `hand_id` values collided when multiple policies run (each got hand_id 0..n-1)

## Repro / Validation

```bash
# Run with multiple bidding policies
uv run python experiments/run_experiment.py \
  --config experiments/configs/bid_eval_tiny.yaml \
  --seed 42 --n_per 10 --emit-bidding-dataset \
  --run-dir /tmp/pr6-test

# Verify hand_ids are contiguous 0..29 (3 policies × 1 scenario × 10 hands)
uv run python -c "
import pyarrow.parquet as pq
table = pq.read_table('/tmp/pr6-test/bid_eval_tiny_42_*/datasets/bidding.parquet')
hand_ids = sorted(set(table.column('hand_id').to_pylist()))
print(f'hand_ids: {hand_ids}')
assert hand_ids == list(range(30)), 'Expected 0..29'
"
```

## Tests

```bash
make check  # All pass (851 passed, 5 skipped, 1 deselected, 3 xfailed, 1 xpassed)
uv run python -m pytest tests/integration/test_bidding_dataset_hand_id_uniqueness.py -v  # New test passes
uv run python -m pytest tests/unit/test_bidding_dataset_schema.py -v  # Existing tests pass
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr6-bidding-streaming
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr6-bidding-streaming
git worktree list: shows feat/pr6-bidding-streaming worktree
```

## Files Changed

| File | Changes |
|------|---------|
| `src/bid_euchre/datasets/bidding.py` | Add `BiddingDatasetWriter` class + `BIDDING_DATASET_SCHEMA` |
| `src/bid_euchre/sim/simulation.py` | Add `bidding_hand_id_offset` parameter |
| `experiments/run_experiment.py` | Use streaming writer + compute hand_id offsets |
| `tests/integration/test_bidding_dataset_hand_id_uniqueness.py` | New test for collision fix |

🤖 Generated with [Claude Code](https://claude.ai/code)