### PR TITLE
fix: Make BidlessDatasetWriter memory-safe for jsonl format

### DIFF
--- a/src/bid_euchre/datasets/bidless.py
+++ b/src/bid_euchre/datasets/bidless.py
@@ -356,7 +356,7 @@ class BidlessDatasetWriter:
 
     def append_rows(self, rows: List[Dict[str, Any]]) -> None:
         """
-        Add rows to buffer. Flushes to parquet if buffer exceeds threshold.
+        Add rows to buffer. Flushes to disk if buffer exceeds threshold.
 
         Args:
             rows: List of row dicts to append
@@ -366,8 +366,8 @@ class BidlessDatasetWriter:
 
         self._buffer.extend(rows)
 
-        # Flush to parquet if buffer is large enough and format is parquet
-        if self.format == "parquet" and len(self._buffer) >= self.flush_rows:
+        # Flush to disk if buffer is large enough
+        if len(self._buffer) >= self.flush_rows:
             self._flush_buffer()
 
     def _flush_buffer(self) -> None:
@@ -386,12 +386,14 @@ class BidlessDatasetWriter:
                     row_with_run_id = {"run_id": self.run_id, **row}
                     json.dump(row_with_run_id, self._debug_jsonl_file, sort_keys=True)
                     self._debug_jsonl_file.write("\n")
+                self._debug_jsonl_file.flush()
         else:
             # Write to primary JSONL without run_id
             if self._jsonl_file is not None:
                 for row in sorted_rows:
                     json.dump(row, self._jsonl_file, sort_keys=True)
                     self._jsonl_file.write("\n")
+                self._jsonl_file.flush()
 
         self._total_rows += len(sorted_rows)
         self._buffer = []

--- a/tests/unit/test_bidless_dataset_writer.py
+++ b/tests/unit/test_bidless_dataset_writer.py
@@ -248,3 +248,45 @@ class TestBidlessDatasetWriter:
             with open(meta_path) as f:
                 meta = json.load(f)
             assert meta["row_count"] == 0
+
+    def test_jsonl_flush_before_finalize(self):
+        """Verify jsonl format flushes to disk before finalize() is called.
+
+        This tests the memory safety fix: format="jsonl" should flush rows to disk
+        when buffer exceeds flush_rows threshold, not buffer indefinitely until finalize().
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            run_id = "test_jsonl_flush"
+            writer = BidlessDatasetWriter(
+                run_dir=temp_dir,
+                run_id=run_id,
+                format="jsonl",
+                flush_rows=5,  # Flush after 5 rows
+            )
+
+            # Write 2 hands (8 rows total) - should trigger flush after 5
+            rows_hand1 = make_rows_for_hand(run_id, hand_id=0, contract_type="suit", trump_suit="H")
+            rows_hand2 = make_rows_for_hand(run_id, hand_id=1, contract_type="suit", trump_suit="S")
+            writer.append_rows(rows_hand1)  # 4 rows, no flush yet
+            writer.append_rows(rows_hand2)  # 8 rows total, flush triggered
+
+            # BEFORE finalize: verify file exists and has at least 5 rows
+            jsonl_path = os.path.join(temp_dir, "datasets", "bidless.jsonl")
+            assert os.path.isfile(jsonl_path), "JSONL file should exist before finalize()"
+
+            with open(jsonl_path) as f:
+                lines_before = [line.strip() for line in f if line.strip()]
+            assert len(lines_before) >= 5, (
+                f"Expected at least 5 flushed rows before finalize(), got {len(lines_before)}"
+            )
+
+            # Finalize and verify all 8 rows are present
+            primary_path = writer.finalize()
+            with open(primary_path) as f:
+                lines_after = [line.strip() for line in f if line.strip()]
+            assert len(lines_after) == 8, f"Expected 8 total rows after finalize(), got {len(lines_after)}"
+
+            # Verify ordering is (hand_id, seat)
+            parsed_rows = [json.loads(line) for line in lines_after]
+            assert [r["hand_id"] for r in parsed_rows] == [0, 0, 0, 0, 1, 1, 1, 1]
+            assert [r["seat"] for r in parsed_rows] == [0, 1, 2, 3, 0, 1, 2, 3]


### PR DESCRIPTION
## Summary

- Fixes memory leak where `format="jsonl"` would buffer rows indefinitely until `finalize()` was called
- Removes format-specific check in `append_rows()` so flushing occurs for both formats when buffer exceeds `flush_rows` threshold
- Adds `.flush()` calls after writing to JSONL files to ensure data is actually written to disk

## Why

The streaming writer was introduced in #250 to fix OOM issues for large parquet runs, but JSONL format was left unbounded. For large runs with `format="jsonl"`, rows would accumulate in memory until `finalize()`, defeating the purpose of streaming.

## Repro / Validation

```bash
# Run tests
uv run python -m pytest tests/unit/test_bidless_dataset_writer.py -v

# Full validation
make check
```

## Tests

- `make check` passes (860 tests)
- Added `test_jsonl_flush_before_finalize()` which verifies rows are written to disk before `finalize()` is called

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre
branch: fix/jsonl-streaming-memory-safety
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)