### PR TITLE
fix: Add flush calls to BiddingDatasetWriter JSONL methods

### DIFF
--- a/src/bid_euchre/datasets/bidding.py
+++ b/src/bid_euchre/datasets/bidding.py
@@ -426,6 +426,7 @@ class BiddingDatasetWriter:
             row_with_run_id = {"run_id": self.run_id, **row}
             json.dump(row_with_run_id, self._jsonl_file, sort_keys=True)
             self._jsonl_file.write("\n")
+        self._jsonl_file.flush()
 
     def _write_jsonl_primary_chunk(self, rows: List[Dict[str, Any]]) -> None:
         """Append rows to primary JSONL file WITHOUT run_id (jsonl mode)."""
@@ -436,6 +437,7 @@ class BiddingDatasetWriter:
         for row in rows:
             json.dump(row, self._jsonl_file, sort_keys=True)
             self._jsonl_file.write("\n")
+        self._jsonl_file.flush()
 
     def finalize(self) -> str:
         """Flush remaining rows, close files, write metadata."""


### PR DESCRIPTION
## Summary
- Add `.flush()` after JSONL writes in `_write_jsonl_debug_chunk()` and `_write_jsonl_primary_chunk()`

## Why
Without `.flush()`, JSONL data stays in Python's file buffer until `finalize()` is called. If the process crashes mid-run, buffered rows are lost. This matches the pattern already used in `BidlessDatasetWriter`.

## Repro / Validation
```bash
make check
```

## Tests
- `make check` passes (861 tests)

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-bidding-jsonl-flush
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-bidding-jsonl-flush
git worktree list:
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                    67e65f7 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-bidding-jsonl-flush 55c1cde [fix/bidding-jsonl-flush]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)