### PR TITLE
feat(reports): Add canonical summary artifacts and sanity gate flag

### DIFF
--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -5,7 +5,7 @@ Generate reports for a single experiment run.
 Strict I/O Contract:
 - READS: <run_dir>/results/**, <run_dir>/meta.json, <run_dir>/config_effective.yaml,
          <run_dir>/datasets/** (bidless_outcomes.parquet if present)
-- WRITES: <run_dir>/reports/** ONLY
+- WRITES: <run_dir>/reports/** and <run_dir>/artifacts/**
 
 Report Types:
 - ANALYSIS_SUMMARY.md: Overview of run with links to results
@@ -21,13 +21,17 @@ import argparse
 import json
 import shutil
 import sys
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
 
-from bid_euchre.diagnostics.sanity_tests import run_sanity_tests, write_sanity_report
+from bid_euchre.diagnostics.sanity_tests import (
+    SanityTestResult,
+    run_sanity_tests,
+    write_sanity_report,
+)
 from bid_euchre.reporting.evaluator import generate_bidder_evaluation
 
 
@@ -52,6 +56,11 @@ def parse_args() -> argparse.Namespace:
         "--verbose", "-v",
         action="store_true",
         help="Print progress messages (default: quiet unless errors)"
+    )
+    parser.add_argument(
+        "--fail-on-sanity-failures",
+        action="store_true",
+        help="Exit non-zero if any sanity test has status FAIL (and also fail if sanity cannot run)"
     )
     return parser.parse_args()
 
@@ -127,7 +136,7 @@ def discover_result_files(run_dir: Path, verbose: bool) -> List[str]:
 def load_metadata(run_dir: Path, verbose: bool) -> Dict:
     """
     Load run metadata from meta.json and config_effective.yaml.
-    
+
     Returns dict with available fields (may be incomplete if files missing).
     """
     metadata = {
@@ -136,8 +145,10 @@ def load_metadata(run_dir: Path, verbose: bool) -> Dict:
         "n_per": "unknown",
         "mode": "unknown",
         "experiment_name": "unknown",
+        "git_sha": None,
+        "total_hands": None,
     }
-    
+
     # Try meta.json
     meta_path = run_dir / "meta.json"
     if meta_path.exists():
@@ -146,12 +157,14 @@ def load_metadata(run_dir: Path, verbose: bool) -> Dict:
                 meta = json.load(f)
                 metadata["seed"] = meta.get("seed", "unknown")
                 metadata["n_per"] = meta.get("n_per", "unknown")
+                metadata["git_sha"] = meta.get("git_sha")
+                metadata["total_hands"] = meta.get("total_hands")
                 if verbose:
                     print("  ℹ️  Loaded meta.json")
         except Exception as e:
             if verbose:
                 print(f"  ⚠️  Warning: Could not parse meta.json: {e}")
-    
+
     # Try config_effective.yaml
     config_path = run_dir / "config_effective.yaml"
     if config_path.exists():
@@ -170,7 +183,7 @@ def load_metadata(run_dir: Path, verbose: bool) -> Dict:
         except Exception as e:
             if verbose:
                 print(f"  ⚠️  Warning: Could not parse config_effective.yaml: {e}")
-    
+
     return metadata
 
 
@@ -242,14 +255,143 @@ def generate_analysis_summary(
 def generate_charts(run_dir: Path, metadata: Dict, verbose: bool) -> List[str]:
     """
     Generate charts into run_dir/reports/.
-    
+
     Returns list of chart filenames (relative to reports/).
-    
+
     For this minimal PR: no charts yet. Future PRs can add chart generation here.
     """
     # Placeholder: no chart generation in this PR
     # Future: call existing plotting utilities from src/bid_euchre/reporting/
     return []
+
+
+def summarize_sanity_results(
+    results: Dict[str, SanityTestResult],
+) -> Dict[str, Any]:
+    """
+    Summarize sanity test results for canonical summary and gating.
+
+    Returns dict with:
+    - pass_count, warn_count, fail_count, skip_count
+    - failing_tests: list of test names with FAIL status
+    - all_passed: bool (True iff fail_count == 0)
+    """
+    if not results:
+        return {
+            "pass_count": 0,
+            "warn_count": 0,
+            "fail_count": 0,
+            "skip_count": 0,
+            "failing_tests": [],
+            "all_passed": True,
+        }
+
+    statuses = [r.status for r in results.values()]
+    pass_count = statuses.count("PASS")
+    warn_count = statuses.count("WARN")
+    fail_count = statuses.count("FAIL")
+    skip_count = statuses.count("SKIP")
+
+    failing_tests = [name for name, r in results.items() if r.status == "FAIL"]
+
+    return {
+        "pass_count": pass_count,
+        "warn_count": warn_count,
+        "fail_count": fail_count,
+        "skip_count": skip_count,
+        "failing_tests": failing_tests,
+        "all_passed": fail_count == 0,
+    }
+
+
+def write_canonical_summary(
+    run_dir: Path,
+    metadata: Dict,
+    sanity_summary: Dict[str, Any],
+    result_files: List[str],
+) -> Tuple[Path, Path]:
+    """
+    Write canonical_summary.json and canonical_summary.md to artifacts/.
+
+    Creates artifacts/ directory if needed.
+
+    Returns:
+        Tuple of (json_path, md_path)
+    """
+    artifacts_dir = run_dir / "artifacts"
+    artifacts_dir.mkdir(exist_ok=True)
+
+    # Detect dataset presence
+    datasets_dir = run_dir / "datasets"
+    datasets_present = datasets_dir.exists() and any(datasets_dir.iterdir()) if datasets_dir.exists() else False
+    bidless_parquet = (datasets_dir / "bidless.parquet").exists() if datasets_dir.exists() else False
+    bidless_outcomes_parquet = (datasets_dir / "bidless_outcomes.parquet").exists() if datasets_dir.exists() else False
+
+    # Build JSON content
+    summary_data = {
+        "run_id": metadata.get("run_id", "unknown"),
+        "experiment_name": metadata.get("experiment_name", "unknown"),
+        "seed": metadata.get("seed", "unknown"),
+        "n_per": metadata.get("n_per", "unknown"),
+        "git_sha": metadata.get("git_sha"),
+        "total_hands": metadata.get("total_hands"),
+        "sanity": sanity_summary,
+        "discovered": {
+            "results_files": result_files,
+            "datasets_present": datasets_present,
+            "bidless_parquet": bidless_parquet,
+            "bidless_outcomes_parquet": bidless_outcomes_parquet,
+        },
+        "generated_at_utc": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+    # Write JSON
+    json_path = artifacts_dir / "canonical_summary.json"
+    with open(json_path, "w") as f:
+        json.dump(summary_data, f, indent=2)
+
+    # Write Markdown
+    md_path = artifacts_dir / "canonical_summary.md"
+    sanity_status = "PASS" if sanity_summary["all_passed"] else "FAIL"
+    failing_str = ", ".join(sanity_summary["failing_tests"]) if sanity_summary["failing_tests"] else "None"
+
+    md_content = f"""# Canonical Summary
+
+**Run ID:** `{summary_data['run_id']}`
+**Experiment:** {summary_data['experiment_name']}
+**Seed:** {summary_data['seed']}
+**N Per:** {summary_data['n_per']}
+**Git SHA:** {summary_data['git_sha'] or 'N/A'}
+**Total Hands:** {summary_data['total_hands'] or 'N/A'}
+
+## Sanity Tests
+
+**Status:** {sanity_status}
+
+| Metric | Count |
+|--------|-------|
+| PASS | {sanity_summary['pass_count']} |
+| WARN | {sanity_summary['warn_count']} |
+| FAIL | {sanity_summary['fail_count']} |
+| SKIP | {sanity_summary['skip_count']} |
+
+**Failing Tests:** {failing_str}
+
+## Discovered Files
+
+- **Results files:** {len(result_files)}
+- **Datasets present:** {datasets_present}
+- **bidless.parquet:** {bidless_parquet}
+- **bidless_outcomes.parquet:** {bidless_outcomes_parquet}
+
+---
+*Generated: {summary_data['generated_at_utc']}*
+"""
+
+    with open(md_path, "w") as f:
+        f.write(md_content)
+
+    return json_path, md_path
 
 
 def main() -> int:
@@ -299,45 +441,67 @@ def main() -> int:
     # Run sanity tests for bidless experiments
     if args.verbose:
         print("🔬 Running strategy sanity tests...")
+
+    sanity_results: Optional[Dict[str, SanityTestResult]] = None
+    sanity_ran = False
+
     try:
         sanity_results = run_sanity_tests(str(run_dir))
         if sanity_results and "error" not in sanity_results:
-            json_path, md_path = write_sanity_report(str(run_dir), sanity_results)
-
-            # Count results by status
-            statuses = [r.status for r in sanity_results.values()]
-            pass_count = statuses.count("PASS")
-            warn_count = statuses.count("WARN")
-            fail_count = statuses.count("FAIL")
-            skip_count = statuses.count("SKIP")
-
-            status_summary = []
-            if pass_count:
-                status_summary.append(f"{pass_count} PASS")
-            if warn_count:
-                status_summary.append(f"{warn_count} WARN")
-            if fail_count:
-                status_summary.append(f"{fail_count} FAIL")
-            if skip_count:
-                status_summary.append(f"{skip_count} SKIP")
-
-            if args.verbose:
-                print(f"🔬 Sanity tests: {', '.join(status_summary)}")
-                print(f"   Results: {md_path.relative_to(run_dir)}")
-            else:
-                print(f"🔬 Sanity tests: {', '.join(status_summary)}")
+            sanity_ran = True
+            write_sanity_report(str(run_dir), sanity_results)
         elif args.verbose:
             print("🔬 Sanity tests: skipped (no outcomes data)")
     except Exception as e:
         if args.verbose:
             print(f"⚠️  Sanity tests failed: {e}")
 
+    # Compute sanity summary (works even if sanity didn't run)
+    if sanity_ran and sanity_results:
+        sanity_summary = summarize_sanity_results(sanity_results)
+    else:
+        sanity_summary = summarize_sanity_results({})
+
+    # Print sanity status summary
+    if sanity_ran:
+        status_parts = []
+        if sanity_summary["pass_count"]:
+            status_parts.append(f"{sanity_summary['pass_count']} PASS")
+        if sanity_summary["warn_count"]:
+            status_parts.append(f"{sanity_summary['warn_count']} WARN")
+        if sanity_summary["fail_count"]:
+            status_parts.append(f"{sanity_summary['fail_count']} FAIL")
+        if sanity_summary["skip_count"]:
+            status_parts.append(f"{sanity_summary['skip_count']} SKIP")
+        print(f"🔬 Sanity tests: {', '.join(status_parts)}")
+
+    # Write canonical summary (always, regardless of verbose mode)
+    if args.verbose:
+        print("📄 Writing canonical summary...")
+    json_path, md_path = write_canonical_summary(
+        run_dir, metadata, sanity_summary, result_files
+    )
+    if args.verbose:
+        print(f"   Artifacts: {json_path.relative_to(run_dir)}, {md_path.relative_to(run_dir)}")
+
     if args.verbose:
         print("✅ Report generation complete!")
     else:
         # Always print success message even in quiet mode
         print(f"✅ Report generated: {run_dir / 'reports'}")
-    
+
+    # Handle --fail-on-sanity-failures gate
+    if args.fail_on_sanity_failures:
+        if sanity_summary["fail_count"] > 0:
+            failing = sanity_summary["failing_tests"]
+            print(f"❌ Sanity gate failed: {failing}")
+            return 1
+        if not sanity_ran:
+            print("❌ Sanity gate failed: sanity tests could not run (no outcomes)")
+            return 2
+        # All passed
+        return 0
+
     return 0
 
 

--- a/tests/integration/test_report_generator.py
+++ b/tests/integration/test_report_generator.py
@@ -204,8 +204,8 @@ def test_report_generator_succeeds_with_overwrite():
         assert run_dir.name in second_content, "Regenerated summary should contain run_id"
 
 
-def test_report_generator_writes_only_under_reports():
-    """Test strict I/O contract: writes only under run_dir/reports/."""
+def test_report_generator_writes_only_under_reports_and_artifacts():
+    """Test strict I/O contract: writes only under run_dir/reports/ and run_dir/artifacts/."""
     with tempfile.TemporaryDirectory() as tmpdir:
         # Run experiment
         result = run_experiment(
@@ -231,9 +231,12 @@ def test_report_generator_writes_only_under_reports():
         # Find new files
         new_files = files_after - files_before
 
-        # All new files should be under reports/
+        # All new files should be under reports/ or artifacts/
         reports_dir = run_dir / "reports"
+        artifacts_dir = run_dir / "artifacts"
         for new_file in new_files:
             if new_file.is_file():
-                assert new_file.is_relative_to(reports_dir), \
-                    f"New file should be under reports/: {new_file.relative_to(run_dir)}"
+                is_under_reports = new_file.is_relative_to(reports_dir)
+                is_under_artifacts = new_file.is_relative_to(artifacts_dir)
+                assert is_under_reports or is_under_artifacts, \
+                    f"New file should be under reports/ or artifacts/: {new_file.relative_to(run_dir)}"

--- a/tests/unit/test_generate_report_sanity_gate.py
+++ b/tests/unit/test_generate_report_sanity_gate.py
@@ -1,0 +1,159 @@
+"""
+Tests for generate_report.py sanity gate functionality.
+
+Tests the summarize_sanity_results helper function that powers:
+1. Status counting for console output
+2. Canonical summary JSON/MD generation
+3. --fail-on-sanity-failures gate logic
+"""
+
+import sys
+
+# Import from scripts directory
+sys.path.insert(0, "scripts")
+from generate_report import summarize_sanity_results
+
+# We need to import SanityTestResult from the actual module
+from bid_euchre.diagnostics.sanity_tests import SanityTestResult
+
+
+class TestSummarizeSanityResults:
+    """Tests for summarize_sanity_results helper."""
+
+    def test_counts_all_statuses(self):
+        """Correctly counts PASS, WARN, FAIL, SKIP."""
+        results = {
+            "test_pass_1": SanityTestResult(
+                name="test_pass_1", status="PASS", message="ok", details={}
+            ),
+            "test_pass_2": SanityTestResult(
+                name="test_pass_2", status="PASS", message="ok", details={}
+            ),
+            "test_warn": SanityTestResult(
+                name="test_warn", status="WARN", message="warning", details={}
+            ),
+            "test_fail": SanityTestResult(
+                name="test_fail", status="FAIL", message="failed", details={}
+            ),
+            "test_skip_1": SanityTestResult(
+                name="test_skip_1", status="SKIP", message="skipped", details={}
+            ),
+            "test_skip_2": SanityTestResult(
+                name="test_skip_2", status="SKIP", message="skipped", details={}
+            ),
+        }
+
+        summary = summarize_sanity_results(results)
+
+        assert summary["pass_count"] == 2
+        assert summary["warn_count"] == 1
+        assert summary["fail_count"] == 1
+        assert summary["skip_count"] == 2
+
+    def test_identifies_failing_tests(self):
+        """Lists names of tests with FAIL status."""
+        results = {
+            "test_ok": SanityTestResult(
+                name="test_ok", status="PASS", message="ok", details={}
+            ),
+            "test_fail_one": SanityTestResult(
+                name="test_fail_one", status="FAIL", message="failed", details={}
+            ),
+            "test_fail_two": SanityTestResult(
+                name="test_fail_two", status="FAIL", message="also failed", details={}
+            ),
+        }
+
+        summary = summarize_sanity_results(results)
+
+        assert len(summary["failing_tests"]) == 2
+        assert "test_fail_one" in summary["failing_tests"]
+        assert "test_fail_two" in summary["failing_tests"]
+        assert "test_ok" not in summary["failing_tests"]
+
+    def test_all_passed_true_when_no_fails(self):
+        """all_passed=True when fail_count == 0."""
+        results = {
+            "test_pass": SanityTestResult(
+                name="test_pass", status="PASS", message="ok", details={}
+            ),
+            "test_warn": SanityTestResult(
+                name="test_warn", status="WARN", message="warning", details={}
+            ),
+            "test_skip": SanityTestResult(
+                name="test_skip", status="SKIP", message="skipped", details={}
+            ),
+        }
+
+        summary = summarize_sanity_results(results)
+
+        assert summary["all_passed"] is True
+        assert summary["fail_count"] == 0
+
+    def test_all_passed_false_when_fails(self):
+        """all_passed=False when fail_count > 0."""
+        results = {
+            "test_pass": SanityTestResult(
+                name="test_pass", status="PASS", message="ok", details={}
+            ),
+            "test_fail": SanityTestResult(
+                name="test_fail", status="FAIL", message="failed", details={}
+            ),
+        }
+
+        summary = summarize_sanity_results(results)
+
+        assert summary["all_passed"] is False
+        assert summary["fail_count"] == 1
+
+    def test_empty_results(self):
+        """Handles empty results dict (all counts 0, all_passed=True)."""
+        summary = summarize_sanity_results({})
+
+        assert summary["pass_count"] == 0
+        assert summary["warn_count"] == 0
+        assert summary["fail_count"] == 0
+        assert summary["skip_count"] == 0
+        assert summary["failing_tests"] == []
+        assert summary["all_passed"] is True
+
+    def test_only_passes(self):
+        """All PASS results yields all_passed=True."""
+        results = {
+            "test_1": SanityTestResult(
+                name="test_1", status="PASS", message="ok", details={}
+            ),
+            "test_2": SanityTestResult(
+                name="test_2", status="PASS", message="ok", details={}
+            ),
+            "test_3": SanityTestResult(
+                name="test_3", status="PASS", message="ok", details={}
+            ),
+        }
+
+        summary = summarize_sanity_results(results)
+
+        assert summary["pass_count"] == 3
+        assert summary["warn_count"] == 0
+        assert summary["fail_count"] == 0
+        assert summary["skip_count"] == 0
+        assert summary["all_passed"] is True
+        assert summary["failing_tests"] == []
+
+    def test_only_fails(self):
+        """All FAIL results yields all_passed=False with all tests in failing_tests."""
+        results = {
+            "test_fail_a": SanityTestResult(
+                name="test_fail_a", status="FAIL", message="failed", details={}
+            ),
+            "test_fail_b": SanityTestResult(
+                name="test_fail_b", status="FAIL", message="failed", details={}
+            ),
+        }
+
+        summary = summarize_sanity_results(results)
+
+        assert summary["pass_count"] == 0
+        assert summary["fail_count"] == 2
+        assert summary["all_passed"] is False
+        assert len(summary["failing_tests"]) == 2


### PR DESCRIPTION
## Summary

- Add `--fail-on-sanity-failures` flag to `generate_report.py` for shallow→zoom workflow gating
- Write `canonical_summary.json` and `canonical_summary.md` to `<run_dir>/artifacts/`
- Update I/O contract to allow writes to both `reports/` and `artifacts/`

## Why

This PR enables the shallow→zoom workflow pattern where:
1. A shallow experiment runs quickly to validate sanity
2. The report generator checks sanity test status with `--fail-on-sanity-failures`
3. Only if sanity passes (exit 0) does the more expensive zoom experiment proceed

The canonical summary artifacts provide a machine-readable summary of run metadata, sanity test results, and discovered files for downstream tooling.

## Repro / Validation

```bash
# Run a tiny experiment with outcomes
uv run python experiments/run_experiment.py \
  --config experiments/configs/quick_test.yaml \
  --seed 42 --n_per 5 \
  --run-dir /tmp/test_run \
  --emit-bidless-outcomes-dataset

# Generate report with gate flag
uv run python scripts/generate_report.py \
  --run-dir /tmp/test_run/quick_test_42_* \
  --fail-on-sanity-failures --verbose
echo "Exit code: $?"

# Verify artifacts
ls /tmp/test_run/quick_test_42_*/artifacts/
cat /tmp/test_run/quick_test_42_*/artifacts/canonical_summary.json
```

**Exit codes:**
- `0`: All sanity tests passed
- `1`: At least one sanity test failed
- `2`: Sanity tests could not run (no outcomes data)

## Tests

```bash
# Unit tests for summarize_sanity_results helper
uv run python -m pytest tests/unit/test_generate_report_sanity_gate.py -v

# Full test suite
make check
```

All 866 tests pass, 5 skipped.

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr8-canonical-artifacts
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr8-canonical-artifacts
git branch: pr8-canonical-artifacts
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)