### PR TITLE
docs: Add blessed canonical runs registry

### DIFF
--- a/docs/02_agent/CANONICAL_BIDLESS.md
+++ b/docs/02_agent/CANONICAL_BIDLESS.md
@@ -5,6 +5,22 @@ This document describes the canonical bidless experiment workflow for producing 
 ## Overview
 
 Canonical bidless experiments provide deterministic, paired-deals runs for:
+
+## Blessed Runs Registry
+
+See [CANONICAL_BIDLESS_RUNS.md](CANONICAL_BIDLESS_RUNS.md) for the authoritative registry of promoted canonical runs.
+
+**Promotion artifacts** (in each blessed run):
+- `artifacts/canonical_summary.json` — Machine-readable promotion record with PASS/WARN/FAIL/SKIP counts
+- `artifacts/canonical_summary.md` — Human-readable summary
+
+**Supporting evidence** (for troubleshooting):
+- `reports/ANALYSIS_SUMMARY.md` — Detailed run analysis
+- `reports/sanity_tests/strategy_sanity.json` — Full sanity test results
+
+---
+
+Canonical bidless experiments provide deterministic, paired-deals runs for:
 - **ML Training Data**: Features and outcome labels for bidding model development
 - **Strategy Comparison**: Head-to-head matchups with statistical validation
 - **Sanity Checking**: Automated tests to validate strategy behavior

--- a/docs/02_agent/CANONICAL_BIDLESS_RUNS.md
+++ b/docs/02_agent/CANONICAL_BIDLESS_RUNS.md
@@ -1,0 +1,56 @@
+# Canonical Bidless Runs Registry
+
+This file is the **single source of truth** for blessed canonical run IDs and their validation summaries.
+
+## Promotion Rules
+
+1. **Update only on intentional promotion** — Do not add runs speculatively
+2. **Require full provenance** — Every promoted run must include:
+   - Run ID (directory name in `data/runs/`)
+   - Git SHA at time of run
+   - Seed and n_per values
+   - PASS/WARN/FAIL/SKIP counts from `artifacts/canonical_summary.json`
+3. **Reference promotion artifacts** — The canonical artifacts are:
+   - `artifacts/canonical_summary.json` (machine-readable)
+   - `artifacts/canonical_summary.md` (human-readable)
+4. **One row per config** — Each config has exactly one blessed run at a time
+
+## Registry Table
+
+| experiment_name | run_id | date | git_sha | seed | n_per | total_hands | PASS | WARN | FAIL | SKIP | canonical_summary_json_path | notes |
+|-----------------|--------|------|---------|------|-------|-------------|------|------|------|------|------------------------------|-------|
+| canonical_bidless_dataset_greedy | TBD | - | - | 42 | 50000 | 300K | - | - | - | - | artifacts/canonical_summary.json | - |
+| canonical_bidless_outcomes_matrix_shallow | TBD | - | - | 42 | 2000 | 300K | - | - | - | - | artifacts/canonical_summary.json | - |
+| canonical_bidless_outcomes_zoom | TBD | - | - | 42 | 50000 | 3.3M | - | - | - | - | artifacts/canonical_summary.json | - |
+
+## How to Regenerate
+
+Run the canonical experiments with these commands:
+
+```bash
+uv run python experiments/run_experiment.py --seed 42 --config experiments/configs/canonical_bidless_dataset_greedy.yaml --emit-bidless-dataset --emit-bidless-outcomes-dataset
+
+uv run python experiments/run_experiment.py --seed 42 --config experiments/configs/canonical_bidless_outcomes_matrix_shallow.yaml
+
+uv run python experiments/run_experiment.py --seed 42 --config experiments/configs/canonical_bidless_outcomes_zoom.yaml
+```
+
+## How to Promote
+
+1. **Run the canonical experiment** using one of the commands above
+2. **Generate report**:
+   ```bash
+   uv run python scripts/generate_report.py --run-dir data/runs/<run_id>
+   ```
+3. **Verify `artifacts/canonical_summary.json`** exists and shows expected PASS/WARN/FAIL/SKIP counts
+4. **Update registry table** with run metadata:
+   - Replace TBD with actual run_id
+   - Fill in date, git_sha, and validation counts
+5. **Commit registry update** with PR linking to run provenance
+
+## Validation Criteria
+
+A run is eligible for promotion when:
+- **FAIL = 0** — No failing sanity tests
+- **WARN ≤ 2** — At most minor warnings (e.g., marginal thresholds)
+- **Determinism verified** — Same seed + config reproduces identical results


### PR DESCRIPTION
## Summary
- Create `docs/02_agent/CANONICAL_BIDLESS_RUNS.md` as single source of truth for blessed run IDs
- Add promotion rules requiring full provenance (run_id, git_sha, seed, validation counts)
- Registry table with TBD placeholders for 3 canonical configs
- Link from `CANONICAL_BIDLESS.md` to new registry

## Why
Need a single authoritative place to record blessed canonical run IDs and summaries, updated only on intentional promotion. This addresses PR9 in the canonical bidless workflow series.

## Test plan
- [x] `make check` passes (repo-lint + ruff + pytest)
- [x] Pre-commit hooks pass

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre
branch: pr9-canonical-runs-registry
```

🤖 Generated with [Claude Code](https://claude.ai/code)