### PR TITLE
docs: Update REPO_REVIEW_PROMPT config count (24→25)

### DIFF
--- a/docs/02_agent/REPO_REVIEW_PROMPT.md
+++ b/docs/02_agent/REPO_REVIEW_PROMPT.md
@@ -824,7 +824,7 @@ bid-euchre/
 │   └── utils/                   # Generic helpers
 ├── experiments/                 # Experiment configs + runner
 │   ├── run_experiment.py        # THE canonical runner
-│   ├── configs/                 # YAML experiment definitions (24)
+│   ├── configs/                 # YAML experiment definitions (25)
 │   ├── suites/                  # Suite definitions (4)
 │   ├── comparisons/             # Frozen (head-to-head scripts)
 │   ├── training/                # Frozen (training scripts)
@@ -890,7 +890,7 @@ bid-euchre/
 ```bash
 # Verify structure
 find src/bid_euchre -type d -maxdepth 1 | grep -v __pycache__ | sort
-ls experiments/configs/*.yaml | wc -l  # Expected: 24
+ls experiments/configs/*.yaml | wc -l  # Expected: 25
 ls experiments/suites/*.yaml | wc -l   # Expected: 4
 ls scripts/*.py | wc -l                # Expected: 12
 ```


### PR DESCRIPTION
## Summary
- Updates REPO_REVIEW_PROMPT.md config count from 24 to 25

## Why
The repo review identified documentation drift: the REPO_REVIEW_PROMPT.md file states there are 24 experiment configs, but there are actually 25.

## Repro / Validation
```bash
ls experiments/configs/*.yaml | wc -l  # Returns 25
make check  # Passes
```

## Tests
```bash
make check
```
All 876 tests pass.

## Worktree proof
```
pwd
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-config-count

git rev-parse --show-toplevel
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-config-count

git worktree list
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                  79a30bf [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-config-count 9779787 [fix/config-count]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)