### PR TITLE
docs: Promote canonical bidless runs (2026-02-04)

### DIFF
--- a/docs/02_agent/CANONICAL_BIDLESS_RUNS.md
+++ b/docs/02_agent/CANONICAL_BIDLESS_RUNS.md
@@ -19,10 +19,11 @@ This file is the **single source of truth** for blessed canonical run IDs and th
 
 | experiment_name | run_id | date | git_sha | seed | n_per | total_hands | PASS | WARN | FAIL | SKIP | canonical_summary_json_path | notes |
 |-----------------|--------|------|---------|------|-------|-------------|------|------|------|------|------------------------------|-------|
-| canonical_bidless_dataset_greedy | TBD | - | - | 42 | 50000 | 300K | - | - | - | - | artifacts/canonical_summary.json | - |
-| canonical_bidless_dataset_glutton | TBD | - | - | 42 | 50000 | 300K | - | - | - | - | artifacts/canonical_summary.json | Only if gate PASS |
-| canonical_bidless_outcomes_matrix_shallow | TBD | - | - | 42 | 2000 | 300K | - | - | - | - | artifacts/canonical_summary.json | - |
-| canonical_bidless_outcomes_zoom | TBD | - | - | 42 | 50000 | 3.3M | - | - | - | - | artifacts/canonical_summary.json | - |
+| canonical_bidless_dataset_greedy | canonical_bidless_dataset_greedy_42_20260204_221121 | 2026-02-04 | ea55269 | 42 | 50000 | 300K | 1 | 0 | 0 | 3 | artifacts/canonical_summary.json | - |
+| canonical_bidless_dataset_glutton | canonical_bidless_dataset_glutton_42_20260204_222713 | 2026-02-04 | ea55269 | 42 | 50000 | 300K | 1 | 0 | 0 | 3 | artifacts/canonical_summary.json | Gate PASS |
+| canonical_bidless_dataset_mixed_play | canonical_bidless_dataset_mixed_play_42_20260204_221115 | 2026-02-04 | ea55269 | 42 | 50000 | 900K | 3 | 0 | 0 | 1 | artifacts/canonical_summary.json | - |
+| canonical_bidless_outcomes_matrix_shallow | canonical_bidless_outcomes_matrix_shallow_42_20260204_220920 | 2026-02-04 | ea55269 | 42 | 2000 | 300K | 4 | 0 | 0 | 0 | artifacts/canonical_summary.json | - |
+| canonical_bidless_outcomes_zoom | canonical_bidless_outcomes_zoom_42_20260204_222712 | 2026-02-04 | ea55269 | 42 | 50000 | 3.3M | 4 | 0 | 0 | 0 | artifacts/canonical_summary.json | - |
 
 ## Policy Freeze Record
 
@@ -30,12 +31,12 @@ Documents the frozen play policy decision for bidding model training.
 
 | Field | Value |
 |-------|-------|
-| **Chosen policy** | TBD (greedy or glutton) |
-| **Decision date** | TBD |
-| **Gate run_id(s)** | TBD |
-| **Gate output path** | `data/runs/<run_id>/artifacts/play_policy_gate.json` |
-| **Gate result** | TBD (PASS/WARN/FAIL) |
-| **Rationale** | TBD (1-2 sentences) |
+| **Chosen policy** | glutton |
+| **Decision date** | 2026-02-04 |
+| **Gate run_id(s)** | glutton_vs_greedy_head_to_head_42_20260204_221117, glutton_vs_greedy_head_to_head_43_20260204_221311, glutton_vs_greedy_head_to_head_44_20260204_221504 |
+| **Gate output path** | `data/runs/play_policy_gate_aggregate_20260204_221656.json` |
+| **Gate result** | PASS |
+| **Rationale** | Glutton consistently beats greedy with +0.19 to +0.21 mean trick advantage across all 3 seeds; 95% CI excludes 0 in all 6 direction/seed combinations. |
 
 ### Update Process
 


### PR DESCRIPTION
## Summary

- Populate registry table with 5 canonical bidless runs
- Record glutton policy freeze decision (PASS)
- Add canonical_bidless_dataset_mixed_play row (was missing)

## Why

Execute the [Promotion Checklist](docs/02_agent/CANONICAL_BIDLESS.md#promotion-checklist) to establish baseline canonical runs for bidless dataset generation and model training.

## Promoted Runs

| experiment_name | run_id | hands | PASS | WARN | FAIL | SKIP |
|-----------------|--------|-------|------|------|------|------|
| canonical_bidless_outcomes_matrix_shallow | canonical_bidless_outcomes_matrix_shallow_42_20260204_220920 | 300K | 4 | 0 | 0 | 0 |
| canonical_bidless_dataset_greedy | canonical_bidless_dataset_greedy_42_20260204_221121 | 300K | 1 | 0 | 0 | 3 |
| canonical_bidless_dataset_mixed_play | canonical_bidless_dataset_mixed_play_42_20260204_221115 | 900K | 3 | 0 | 0 | 1 |
| canonical_bidless_outcomes_zoom | canonical_bidless_outcomes_zoom_42_20260204_222712 | 3.3M | 4 | 0 | 0 | 0 |
| canonical_bidless_dataset_glutton | canonical_bidless_dataset_glutton_42_20260204_222713 | 300K | 1 | 0 | 0 | 3 |

## Glutton Gate Results

| Seed | Direction | Adv Mean | 95% CI | Status |
|------|-----------|----------|--------|--------|
| 42 | glutton_vs_greedy | +0.21 | [+0.19, +0.23] | PASS |
| 42 | greedy_vs_glutton | +0.19 | [+0.16, +0.21] | PASS |
| 43 | glutton_vs_greedy | +0.19 | [+0.17, +0.22] | PASS |
| 43 | greedy_vs_glutton | +0.21 | [+0.19, +0.23] | PASS |
| 44 | glutton_vs_greedy | +0.20 | [+0.17, +0.22] | PASS |
| 44 | greedy_vs_glutton | +0.21 | [+0.19, +0.23] | PASS |

Gate run_ids:
- glutton_vs_greedy_head_to_head_42_20260204_221117
- glutton_vs_greedy_head_to_head_43_20260204_221311
- glutton_vs_greedy_head_to_head_44_20260204_221504

## Repro / Validation

All runs executed with git SHA `ea55269`, seed 42:

```bash
# Sanity gate (blocking)
uv run python experiments/run_experiment.py --config experiments/configs/canonical_bidless_outcomes_matrix_shallow.yaml --seed 42
uv run python scripts/generate_report.py --run-dir data/runs/canonical_bidless_outcomes_matrix_shallow_42_20260204_220920 --fail-on-sanity-failures

# Dataset runs
uv run python experiments/run_experiment.py --config experiments/configs/canonical_bidless_dataset_greedy.yaml --seed 42 --emit-bidless-dataset --emit-bidless-outcomes-dataset
uv run python experiments/run_experiment.py --config experiments/configs/canonical_bidless_dataset_mixed_play.yaml --seed 42 --emit-bidless-dataset --emit-bidless-outcomes-dataset
uv run python experiments/run_experiment.py --config experiments/configs/canonical_bidless_dataset_glutton.yaml --seed 42 --emit-bidless-dataset --emit-bidless-outcomes-dataset

# Zoom (only after shallow passed)
uv run python experiments/run_experiment.py --config experiments/configs/canonical_bidless_outcomes_zoom.yaml --seed 42
uv run python scripts/generate_report.py --run-dir data/runs/canonical_bidless_outcomes_zoom_42_20260204_222712 --fail-on-sanity-failures

# Glutton gate
uv run python scripts/play_policy_gate.py --config experiments/configs/glutton_vs_greedy_head_to_head.yaml --seeds 42,43,44 --n-per 20000
```

## Tests

Docs-only change. All sanity gates passed during run execution.

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-canonical-runs-2026-02-04
toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-canonical-runs-2026-02-04
branch: canonical-runs-2026-02-04
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)