### PR TITLE
refactor(bidding): Rename StrictRaiserBidder → StrictHellRaiser

### DIFF
--- a/experiments/configs/INDEX.md
+++ b/experiments/configs/INDEX.md
@@ -29,7 +29,7 @@ Quick reference for finding the right experiment configuration.
 | Config | Purpose |
 |--------|---------|
 | `bid_eval_tiny.yaml` | Tiny bidder evaluation suite |
-| `bid_eval_strict.yaml` | StrictRaiserBidder evaluation |
+| `bid_eval_strict.yaml` | StrictHellRaiser evaluation |
 | `bid_eval_heuristics.yaml` | RanktheTank evaluation |
 | `bid_eval_artifact.yaml` | Artifact-based bidder evaluation |
 | `artifact_bidder_test.yaml` | Artifact bidder integration test |

--- a/experiments/configs/auction_play_strategy_sensitivity.yaml
+++ b/experiments/configs/auction_play_strategy_sensitivity.yaml
@@ -1,7 +1,7 @@
 # Auction Play-Strategy Sensitivity Test
 #
 # Purpose: Determine which play strategy to freeze for bidder evaluation work.
-# Uses a single baseline bidder (StrictRaiserBidder) to compare play strategies
+# Uses a single baseline bidder (StrictHellRaiser) to compare play strategies
 # in auction mode.
 #
 # Analysis approach:
@@ -42,10 +42,10 @@ strategies:
       partner_awareness: true
       sure_winner_cover: true
 
-# Use StrictRaiserBidder for all auction bidding
+# Use StrictHellRaiser for all auction bidding
 bidding_policies:
   - name: strict_raiser
-    class_name: StrictRaiserBidder
+    class_name: StrictHellRaiser
 
 scenarios:
   - contract_type: null  # Auction mode

--- a/experiments/configs/bid_eval_strict.yaml
+++ b/experiments/configs/bid_eval_strict.yaml
@@ -2,7 +2,7 @@ experiment_name: bid_eval_strict
 
 bidding_policies:
   - name: strict_bidder
-    class_name: StrictRaiserBidder
+    class_name: StrictHellRaiser
     params: {}
 
 scenarios:

--- a/src/bid_euchre/experiments/config.py
+++ b/src/bid_euchre/experiments/config.py
@@ -23,7 +23,7 @@ from ..strategy import (
     RandomLegalStrategy,
     RanktheTank,
     Strategy,
-    StrictRaiserBidder,
+    StrictHellRaiser,
 )
 from ..strategy.artifact_strategy import ArtifactGreedyStrategy
 from .teacher_roster import load_teacher_roster
@@ -94,8 +94,8 @@ class BiddingPolicyConfig:
             return ArtifactBidder(artifact_path=artifact_path, name=self.name)
         elif self.class_name == "RanktheTank":
             return RanktheTank(name=self.name)
-        elif self.class_name == "StrictRaiserBidder":
-            return StrictRaiserBidder(name=self.name)
+        elif self.class_name in ("StrictHellRaiser", "StrictRaiserBidder"):
+            return StrictHellRaiser(name=self.name)
         else:
             raise ValueError(f"Unknown bidding policy class: {self.class_name}")
 

--- a/src/bid_euchre/strategy/__init__.py
+++ b/src/bid_euchre/strategy/__init__.py
@@ -32,7 +32,8 @@ from .bidding import (
     HighLowHeuristicBidder,
     ModeloEspecifico,
     RanktheTank,
-    StrictRaiserBidder,
+    StrictHellRaiser,
+    StrictRaiserBidder,  # backward-compat alias
 )
 
 # Greedy strategies
@@ -62,6 +63,7 @@ __all__ = [
     "HighLowHeuristicBidder",
     "ModeloEspecifico",
     "RanktheTank",
+    "StrictHellRaiser",
     "StrictRaiserBidder",
     # Baselines
     "BasicStrategy",

--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -141,7 +141,7 @@ class AlwaysPassBidder(BiddingPolicy):
         return BidAction.pass_bid()
 
 
-class StrictRaiserBidder(BiddingPolicy):
+class StrictHellRaiser(BiddingPolicy):
     """
     Baseline bidder that follows strict raising rules.
 
@@ -164,6 +164,10 @@ class StrictRaiserBidder(BiddingPolicy):
         else:
             # current >= 10, cannot raise further
             return BidAction.pass_bid()
+
+
+# Backward-compatibility alias
+StrictRaiserBidder = StrictHellRaiser
 
 
 class FixedBidder(BiddingPolicy):

--- a/tests/unit/test_bidding.py
+++ b/tests/unit/test_bidding.py
@@ -12,6 +12,7 @@ from bid_euchre.strategy.bidding import (
     BidAction,
     BiddingObservation,
     ModeloEspecifico,
+    StrictHellRaiser,
     StrictRaiserBidder,
 )
 
@@ -151,12 +152,16 @@ class TestAlwaysPassBidder:
         assert action.is_pass()
 
 
-class TestStrictRaiserBidder:
-    """Test StrictRaiserBidder."""
+class TestStrictHellRaiser:
+    """Test StrictHellRaiser (formerly StrictRaiserBidder)."""
+
+    def test_backward_compat_alias(self):
+        """Test that StrictRaiserBidder is an alias for StrictHellRaiser."""
+        assert StrictRaiserBidder is StrictHellRaiser
 
     def test_initial_bid(self):
         """Test bidding 3 when no high bid exists."""
-        bidder = StrictRaiserBidder()
+        bidder = StrictHellRaiser()
         hand = [Card("S", "A"), Card("H", "K")]
 
         obs = BiddingObservation(
@@ -173,7 +178,7 @@ class TestStrictRaiserBidder:
 
     def test_raise_bid(self):
         """Test raising existing bids."""
-        bidder = StrictRaiserBidder()
+        bidder = StrictHellRaiser()
 
         # Raise from 3 to 4
         obs = BiddingObservation(
@@ -201,7 +206,7 @@ class TestStrictRaiserBidder:
 
     def test_max_bid_pass(self):
         """Test passing when at maximum bid."""
-        bidder = StrictRaiserBidder()
+        bidder = StrictHellRaiser()
 
         # Bid 10 when current is 9
         obs = BiddingObservation(
@@ -229,7 +234,7 @@ class TestStrictRaiserBidder:
 
     def test_contract_tuple_conversion(self):
         """Test that bids convert to correct contract tuples."""
-        bidder = StrictRaiserBidder()
+        bidder = StrictHellRaiser()
 
         obs = BiddingObservation(
             hand=[],
@@ -403,10 +408,10 @@ class TestArtifactBidder:
             ArtifactBidder(str(artifact_path))
 
     def test_strict_raiser_bidding_behavior(self, tmp_path):
-        """Test that strict raiser imitation behaves like StrictRaiserBidder."""
+        """Test that strict raiser imitation behaves like StrictHellRaiser."""
         from bid_euchre.models.bidding_artifact import dump_artifact
 
-        # Create artifact that replicates StrictRaiserBidder
+        # Create artifact that replicates StrictHellRaiser
         artifact = {
             "schema_version": "1",
             "model_type": "strict_raiser_imitation_v1",
@@ -423,7 +428,7 @@ class TestArtifactBidder:
         dump_artifact(artifact, str(artifact_path))
 
         artifact_bidder = ArtifactBidder(str(artifact_path))
-        reference_bidder = StrictRaiserBidder()
+        reference_bidder = StrictHellRaiser()
 
         # Test various scenarios
         test_cases = [


### PR DESCRIPTION
## Summary
- Rename `StrictRaiserBidder` class to `StrictHellRaiser` in `bidding.py`
- Add backward-compatible alias `StrictRaiserBidder = StrictHellRaiser`
- Update config registry to accept both `"StrictHellRaiser"` and `"StrictRaiserBidder"` class names

## Why
Aligning class name with the blog post character name used throughout the project. The compatibility alias ensures zero breakage for existing imports, configs, and downstream code.

## Repro / Validation
```bash
cd /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr4-rename
make check   # all 877 tests pass, ruff clean, repo-lint clean
```

## Tests
- `make check` — full suite (repo-lint + ruff + pytest)
- New test: `test_backward_compat_alias` verifies `StrictRaiserBidder is StrictHellRaiser`
- All existing StrictRaiser tests updated to use new class name

## Files Changed
| File | Change |
|------|--------|
| `src/bid_euchre/strategy/bidding.py` | Class rename + alias |
| `src/bid_euchre/strategy/__init__.py` | Export both names |
| `src/bid_euchre/experiments/config.py` | Accept both class names |
| `experiments/configs/bid_eval_strict.yaml` | Use new name |
| `experiments/configs/auction_play_strategy_sensitivity.yaml` | Use new name |
| `experiments/configs/INDEX.md` | Update reference |
| `tests/unit/test_bidding.py` | Use new name + alias test |

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr4-rename
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr4-rename
branch: codex/stricthellraiser-rename
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)