### PR TITLE
fix(bidding): Lock ModeloEspecifico HIGH/LOW to correct formulas

### DIFF
--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -383,7 +383,10 @@ class ModeloEspecifico(BiddingPolicy):
     """
     Feature-weighted bidder using hand-coded weights.
 
-    BidScore = 1.0 × bowers + 0.5 × trump_count + 0.5 × offsuit_aces
+    Formulas (locked):
+      suit: 1.0 * bowers + 0.5 * trump_count + 0.5 * offsuit_aces
+      HIGH: 1.0 * offsuit_aces
+      LOW:  1.0 * offsuit_tens_count
 
     The score maps directly to bid amount (floored).
     Named after the blog post's "specific model" baseline.
@@ -409,15 +412,19 @@ class ModeloEspecifico(BiddingPolicy):
             if 3 <= bid_n <= 6 and bid_n > obs.current_high_bid:
                 candidates.append((score, bid_n, suit))
 
-        # Evaluate HIGH/LOW contracts
-        # For HIGH/LOW, no bowers exist, so score is based on aces only
-        for contract in ["HIGH", "LOW"]:
-            features = get_hand_features(obs.hand, contract.lower(), None)
-            # No bowers in HIGH/LOW, trump_count = 0
-            score = 0.5 * features["offsuit_aces"]
-            bid_n = int(score)
-            if 3 <= bid_n <= 6 and bid_n > obs.current_high_bid:
-                candidates.append((score, bid_n, contract))
+        # Evaluate HIGH contract: score = 1.0 * offsuit_aces
+        features_high = get_hand_features(obs.hand, "high", None)
+        score_high = 1.0 * features_high["offsuit_aces"]
+        bid_n_high = int(score_high)
+        if 3 <= bid_n_high <= 6 and bid_n_high > obs.current_high_bid:
+            candidates.append((score_high, bid_n_high, "HIGH"))
+
+        # Evaluate LOW contract: score = 1.0 * offsuit_tens_count
+        features_low = get_hand_features(obs.hand, "low", None)
+        score_low = 1.0 * features_low["offsuit_tens_count"]
+        bid_n_low = int(score_low)
+        if 3 <= bid_n_low <= 6 and bid_n_low > obs.current_high_bid:
+            candidates.append((score_low, bid_n_low, "LOW"))
 
         if not candidates:
             return BidAction.pass_bid()

--- a/tests/unit/test_bidding.py
+++ b/tests/unit/test_bidding.py
@@ -735,3 +735,107 @@ class TestModeloEspecifico:
         assert not action.is_pass()
         assert action.n == 3
         assert action.contract == "H"
+
+    def test_high_contract_bids_with_3_offsuit_aces(self):
+        """HIGH with 3+ offsuit aces → bids 3 (score = 1.0 * 3 = 3)."""
+        bidder = ModeloEspecifico()
+
+        # In HIGH mode, all cards are offsuit. 3 aces → score 3.0 → bid 3
+        hand = [
+            Card("S", "A"),
+            Card("H", "A"),
+            Card("D", "A"),
+            Card("C", "K"),
+            Card("C", "Q"),
+            Card("S", "K"),
+            Card("H", "K"),
+            Card("D", "K"),
+            Card("S", "Q"),
+            Card("H", "Q"),
+        ]
+
+        obs = BiddingObservation(
+            hand=hand, seat=0, dealer_seat=3, current_high_bid=0
+        )
+        action = bidder.choose_bid(obs)
+        assert not action.is_pass()
+        assert action.contract == "HIGH"
+        assert action.n == 3
+
+    def test_high_contract_passes_with_2_offsuit_aces(self):
+        """HIGH with 2 offsuit aces → passes (score = 2 < 3)."""
+        bidder = ModeloEspecifico()
+
+        # 2 aces → score 2.0 → floor(2.0) = 2 < 3, no suit should score 3 either
+        hand = [
+            Card("S", "A"),
+            Card("H", "A"),
+            Card("D", "K"),
+            Card("C", "K"),
+            Card("C", "Q"),
+            Card("S", "Q"),
+            Card("H", "Q"),
+            Card("D", "Q"),
+            Card("S", "T"),
+            Card("H", "T"),
+        ]
+
+        obs = BiddingObservation(
+            hand=hand, seat=0, dealer_seat=3, current_high_bid=0
+        )
+        action = bidder.choose_bid(obs)
+        # Suit contracts: no bowers, max 2 trump per suit, 1-2 offsuit aces
+        # Score for any suit: 0 + 0.5*2 + 0.5*1 = 1.5 at best → pass
+        # HIGH: 1.0 * 2 = 2 → pass
+        assert action.is_pass()
+
+    def test_low_contract_bids_with_3_offsuit_tens(self):
+        """LOW with 3+ offsuit tens → bids 3 (score = 1.0 * 3 = 3)."""
+        bidder = ModeloEspecifico()
+
+        # In LOW mode, all cards are offsuit. 3 tens → score 3.0 → bid 3
+        hand = [
+            Card("S", "T"),
+            Card("H", "T"),
+            Card("D", "T"),
+            Card("C", "Q"),
+            Card("C", "K"),
+            Card("S", "Q"),
+            Card("H", "Q"),
+            Card("D", "Q"),
+            Card("S", "K"),
+            Card("H", "K"),
+        ]
+
+        obs = BiddingObservation(
+            hand=hand, seat=0, dealer_seat=3, current_high_bid=0
+        )
+        action = bidder.choose_bid(obs)
+        assert not action.is_pass()
+        assert action.contract == "LOW"
+        assert action.n == 3
+
+    def test_low_contract_passes_with_2_offsuit_tens(self):
+        """LOW with 2 offsuit tens → passes (score = 2 < 3)."""
+        bidder = ModeloEspecifico()
+
+        # 2 tens → score 2.0 → floor(2.0) = 2 < 3
+        hand = [
+            Card("S", "T"),
+            Card("H", "T"),
+            Card("D", "Q"),
+            Card("C", "Q"),
+            Card("C", "K"),
+            Card("S", "Q"),
+            Card("H", "Q"),
+            Card("D", "K"),
+            Card("S", "K"),
+            Card("H", "K"),
+        ]
+
+        obs = BiddingObservation(
+            hand=hand, seat=0, dealer_seat=3, current_high_bid=0
+        )
+        action = bidder.choose_bid(obs)
+        # No suit should score 3 either (no bowers, max 2 trump, limited aces)
+        assert action.is_pass()


### PR DESCRIPTION
## Summary
- Fix HIGH formula: `0.5 * offsuit_aces` → `1.0 * offsuit_aces` (was impossible to reach bid=3)
- Fix LOW formula: `0.5 * offsuit_aces` → `1.0 * offsuit_tens_count` (wrong feature + wrong weight)
- Suit formula unchanged: `1.0 * bowers + 0.5 * trump_count + 0.5 * offsuit_aces`

## Why
The old HIGH/LOW formulas in ModeloEspecifico were degenerate — the maximum score for HIGH was `0.5 * 4 = 2.0` (with 4 aces), which could never reach the minimum bid of 3. LOW used the same broken formula AND the wrong feature (aces instead of tens). This locks the approved formulas so HIGH and LOW contracts are actually biddable.

## Repro / Validation
```bash
cd /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr5-modelo
make check   # all 881 tests pass (4 new), ruff clean, repo-lint clean
```

## Tests
- `make check` — full suite (repo-lint + ruff + pytest)
- 4 new tests in `TestModeloEspecifico`:
  - `test_high_contract_bids_with_3_offsuit_aces` — 3 aces → bids HIGH 3
  - `test_high_contract_passes_with_2_offsuit_aces` — 2 aces → passes
  - `test_low_contract_bids_with_3_offsuit_tens` — 3 tens → bids LOW 3
  - `test_low_contract_passes_with_2_offsuit_tens` — 2 tens → passes

## Files Changed
| File | Change |
|------|--------|
| `src/bid_euchre/strategy/bidding.py` | Fix HIGH/LOW formulas, update docstring |
| `tests/unit/test_bidding.py` | 4 new deterministic HIGH/LOW tests |

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr5-modelo
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr5-modelo
branch: codex/modeloespecifico-contract-spec
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)