### PR TITLE
feat(diagnostics): Add tricks-model evaluation + feature-outcome join

### DIFF
--- a/docs/02_agent/DIAGNOSTIC_TRICKS_EVALUATION.md
+++ b/docs/02_agent/DIAGNOSTIC_TRICKS_EVALUATION.md
@@ -1,0 +1,145 @@
+# Diagnostic Tricks-Model Evaluation
+
+> **Purpose:** Full-feature Ridge regression on `tricks_won` from canonical bidless data.
+> Coefficients are standardized and exploratory. Correlated features share variance.
+> This diagnostic is separate from the B0 hand-value regression in `train_b0.py`.
+
+## Methodology
+
+- **Model:** Ridge regression (alpha=1.0) with standardized features (z-scored)
+- **Target:** `tricks_won` (per-seat, derived from team trick counts)
+- **Split:** Grouped by `hand_id` (80/20 train/test) to prevent leakage across 4 seat rows
+- **Features:** All 41 hand features from `get_hand_features()`
+
+## Greedy Play Policy
+
+- **Training:** 240,000 hands (960,000 seat-rows)
+- **Test:** 60,000 hands (240,000 seat-rows)
+- **R² (train):** 0.2070
+- **R² (test):** 0.2088
+- **MAE (train):** 1.3714
+- **MAE (test):** 1.3777
+- **Intercept:** 5.0000
+
+### Top 10 Standardized Coefficients
+
+| Rank | Feature | Coefficient |
+|------|---------|-------------|
+| 1 | `highest_trump_rank` | -0.4468 |
+| 2 | `rank_sum` | +0.4115 |
+| 3 | `trump_rb_count` | +0.3632 |
+| 4 | `trump_power_avg` | -0.3610 |
+| 5 | `second_highest_trump_rank` | -0.3419 |
+| 6 | `trump_count_x_void_count` | +0.3050 |
+| 7 | `bowers` | +0.2695 |
+| 8 | `hand_value` | +0.2679 |
+| 9 | `offsuit_tens_count` | +0.2415 |
+| 10 | `max_suit_len` | -0.1870 |
+
+## Glutton Play Policy
+
+- **Training:** 240,000 hands (960,000 seat-rows)
+- **Test:** 60,000 hands (240,000 seat-rows)
+- **R² (train):** 0.1917
+- **R² (test):** 0.1928
+- **MAE (train):** 1.2809
+- **MAE (test):** 1.2867
+- **Intercept:** 5.0000
+
+### Top 10 Standardized Coefficients
+
+| Rank | Feature | Coefficient |
+|------|---------|-------------|
+| 1 | `trump_power_avg` | -0.6148 |
+| 2 | `rank_sum` | +0.3992 |
+| 3 | `trump_count_x_void_count` | +0.2562 |
+| 4 | `offsuit_tens_count` | +0.2277 |
+| 5 | `trump_rb_count` | +0.2157 |
+| 6 | `fourth_suit_len` | +0.1902 |
+| 7 | `hand_value` | +0.1868 |
+| 8 | `bowers` | +0.1826 |
+| 9 | `trump_count_x_offsuit_ace` | -0.1774 |
+| 10 | `void_count` | +0.1591 |
+
+## Per-Contract Breakdown: Greedy
+
+| Contract | R² (test) | MAE (test) | N (test rows) | OLSa Feature Validation |
+|----------|-----------|------------|---------------|------------------------|
+| high | 0.2043 | 1.2807 | 40,000 | OK: {'offsuit_aces'} all in top 10 |
+| low | 0.2133 | 1.2881 | 40,000 | OK: {'offsuit_tens_count'} all in top 10 |
+| suit | 0.2295 | 1.4033 | 160,000 | WARN: {'trump_count', 'offsuit_aces'} not in top 10 |
+
+### Greedy — contract=high top 5
+
+| Rank | Feature | Coefficient |
+|------|---------|-------------|
+| 1 | `high_offsuit` | -0.1764 |
+| 2 | `offsuit_aces` | +0.1764 |
+| 3 | `offsuit_suits_with_ace` | +0.1610 |
+| 4 | `offsuit_king_count_total` | -0.1092 |
+| 5 | `offsuit_suits_with_double_ace` | +0.1041 |
+
+### Greedy — contract=low top 5
+
+| Rank | Feature | Coefficient |
+|------|---------|-------------|
+| 1 | `offsuit_tens_count` | +0.6255 |
+| 2 | `rank_sum` | +0.1244 |
+| 3 | `hand_value` | +0.1244 |
+| 4 | `offsuit_secondbest_rank_sum` | +0.1100 |
+| 5 | `offsuit_best_rank_sum` | +0.0949 |
+
+### Greedy — contract=suit top 5
+
+| Rank | Feature | Coefficient |
+|------|---------|-------------|
+| 1 | `trump_rb_count` | +0.3050 |
+| 2 | `second_highest_trump_rank` | -0.2984 |
+| 3 | `highest_trump_rank` | -0.2936 |
+| 4 | `trump_count_x_void_count` | +0.2792 |
+| 5 | `bowers` | +0.2082 |
+
+## Per-Contract Breakdown: Glutton
+
+| Contract | R² (test) | MAE (test) | N (test rows) | OLSa Feature Validation |
+|----------|-----------|------------|---------------|------------------------|
+| high | 0.1893 | 1.3426 | 40,000 | OK: {'offsuit_aces'} all in top 10 |
+| low | 0.1949 | 1.3511 | 40,000 | OK: {'offsuit_tens_count'} all in top 10 |
+| suit | 0.2353 | 1.2189 | 160,000 | WARN: {'trump_count', 'offsuit_aces'} not in top 10 |
+
+### Glutton — contract=high top 5
+
+| Rank | Feature | Coefficient |
+|------|---------|-------------|
+| 1 | `offsuit_aces` | +0.1642 |
+| 2 | `high_offsuit` | -0.1642 |
+| 3 | `offsuit_best_rank_sum` | +0.1436 |
+| 4 | `offsuit_suits_with_ace` | +0.1394 |
+| 5 | `offsuit_secondbest_rank_sum` | +0.1186 |
+
+### Glutton — contract=low top 5
+
+| Rank | Feature | Coefficient |
+|------|---------|-------------|
+| 1 | `offsuit_tens_count` | +0.5753 |
+| 2 | `offsuit_best_rank_sum` | +0.1726 |
+| 3 | `offsuit_secondbest_rank_sum` | +0.1488 |
+| 4 | `rank_sum` | +0.1142 |
+| 5 | `hand_value` | +0.1142 |
+
+### Glutton — contract=suit top 5
+
+| Rank | Feature | Coefficient |
+|------|---------|-------------|
+| 1 | `void_count` | +0.2022 |
+| 2 | `trump_rb_count` | +0.1615 |
+| 3 | `bowers` | +0.1296 |
+| 4 | `offsuit_length_3plus_count` | -0.1130 |
+| 5 | `num_singletons` | +0.1129 |
+
+## Caveats
+
+- Coefficients are standardized (z-scored features) and exploratory only
+- Correlated features share variance; coefficients do not imply causal importance
+- This diagnostic is separate from the B0 hand-value regression pipeline
+- Use Ridge (not raw OLS) for 40+ correlated features to avoid numerical instability

--- a/scripts/evaluate_diagnostic_tricks.py
+++ b/scripts/evaluate_diagnostic_tricks.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python
+"""
+Diagnostic Ridge regression on tricks_won from canonical bidless data.
+
+Trains a full-feature Ridge model (41 features) on tricks_won using
+standardized features. Reports overall and per-contract R²/MAE plus
+top-10 standardized coefficients.
+
+This is a DIAGNOSTIC evaluation — separate from the B0 hand-value
+regression in train_b0.py. Coefficient ranking is exploratory only,
+not definitive feature importance.
+
+Usage:
+    uv run python scripts/evaluate_diagnostic_tricks.py \
+        --greedy-dir data/runs/canonical_bidless_dataset_greedy_42_20260204_221121 \
+        --glutton-dir data/runs/canonical_bidless_dataset_glutton_42_20260204_222713 \
+        --seed 42 --output docs/02_agent/DIAGNOSTIC_TRICKS_EVALUATION.md
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+# Allow running from repo root
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from bid_euchre.analysis.models import SimpleRidge  # noqa: E402
+from bid_euchre.datasets.join import join_features_outcomes  # noqa: E402
+
+# Features to exclude from the feature matrix (metadata, not predictive)
+EXCLUDE_COLS = {
+    "hand_id",
+    "seat",
+    "dealer_seat",
+    "deal_id",
+    "hand_cards",
+    "hand_feature_schema_version",
+    "contract_type",
+    "trump_suit",
+    "tricks_won",
+}
+
+# OLSa candidate features to validate
+OLSA_SUIT_FEATURES = {"bowers", "trump_count", "offsuit_aces"}
+OLSA_HIGH_FEATURES = {"offsuit_aces"}
+OLSA_LOW_FEATURES = {"offsuit_tens_count"}
+
+
+def get_feature_columns(df: pd.DataFrame) -> list[str]:
+    """Get feature column names (all numeric columns except excluded)."""
+    return [
+        c
+        for c in df.columns
+        if c not in EXCLUDE_COLS and pd.api.types.is_numeric_dtype(df[c])
+    ]
+
+
+def grouped_train_test_split(
+    df: pd.DataFrame, seed: int, train_frac: float = 0.8
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """
+    Split by hand_id to prevent leakage across 4 seat rows per hand.
+
+    Returns (train_df, test_df).
+    """
+    unique_ids = df["hand_id"].unique()
+    rng = np.random.RandomState(seed)
+    rng.shuffle(unique_ids)
+    split_idx = int(len(unique_ids) * train_frac)
+    train_ids = set(unique_ids[:split_idx])
+    train_mask = df["hand_id"].isin(train_ids)
+    return df[train_mask].copy(), df[~train_mask].copy()
+
+
+def train_and_evaluate(
+    df: pd.DataFrame,
+    feature_cols: list[str],
+    seed: int,
+    label: str,
+) -> dict:
+    """
+    Train standardized Ridge on tricks_won. Return metrics + coefficients.
+
+    Features are z-scored before fitting so coefficients are comparable.
+    """
+    train_df, test_df = grouped_train_test_split(df, seed)
+
+    X_train = train_df[feature_cols].values.astype(np.float64)
+    y_train = train_df["tricks_won"].values.astype(np.float64)
+    X_test = test_df[feature_cols].values.astype(np.float64)
+    y_test = test_df["tricks_won"].values.astype(np.float64)
+
+    # Standardize features (z-score)
+    means = X_train.mean(axis=0)
+    stds = X_train.std(axis=0)
+    # Avoid division by zero for constant columns
+    stds[stds == 0] = 1.0
+
+    X_train_std = (X_train - means) / stds
+    X_test_std = (X_test - means) / stds
+
+    # Fit Ridge
+    model = SimpleRidge(alpha=1.0)
+    model.fit(X_train_std, y_train)
+
+    # Evaluate
+    y_pred_train = model.predict(X_train_std)
+    y_pred_test = model.predict(X_test_std)
+
+    ss_res_train = np.sum((y_train - y_pred_train) ** 2)
+    ss_tot_train = np.sum((y_train - y_train.mean()) ** 2)
+    r2_train = 1 - ss_res_train / ss_tot_train
+
+    ss_res_test = np.sum((y_test - y_pred_test) ** 2)
+    ss_tot_test = np.sum((y_test - y_test.mean()) ** 2)
+    r2_test = 1 - ss_res_test / ss_tot_test
+
+    mae_train = np.mean(np.abs(y_train - y_pred_train))
+    mae_test = np.mean(np.abs(y_test - y_pred_test))
+
+    # Coefficient ranking (standardized)
+    coef_ranking = sorted(
+        zip(feature_cols, model.coef_),
+        key=lambda x: abs(x[1]),
+        reverse=True,
+    )
+
+    return {
+        "label": label,
+        "n_train_hands": len(train_df["hand_id"].unique()),
+        "n_test_hands": len(test_df["hand_id"].unique()),
+        "n_train_rows": len(train_df),
+        "n_test_rows": len(test_df),
+        "r2_train": r2_train,
+        "r2_test": r2_test,
+        "mae_train": mae_train,
+        "mae_test": mae_test,
+        "coef_ranking": coef_ranking,
+        "intercept": model.intercept_,
+    }
+
+
+def per_contract_metrics(
+    df: pd.DataFrame,
+    feature_cols: list[str],
+    seed: int,
+) -> list[dict]:
+    """Train and evaluate per contract_type."""
+    results = []
+    for ct in sorted(df["contract_type"].unique()):
+        sub = df[df["contract_type"] == ct]
+        if len(sub) < 100:
+            continue
+        result = train_and_evaluate(sub, feature_cols, seed, f"contract={ct}")
+        result["contract_type"] = ct
+        results.append(result)
+    return results
+
+
+def validate_olsa_features(coef_ranking: list, contract_type: str) -> str:
+    """Check if OLSa candidate features rank in top 10."""
+    top10_features = {name for name, _ in coef_ranking[:10]}
+
+    if contract_type == "suit":
+        target = OLSA_SUIT_FEATURES
+    elif contract_type == "high":
+        target = OLSA_HIGH_FEATURES
+    elif contract_type == "low":
+        target = OLSA_LOW_FEATURES
+    else:
+        return "N/A"
+
+    found = target & top10_features
+    missing = target - top10_features
+    if missing:
+        return f"WARN: {missing} not in top 10"
+    return f"OK: {found} all in top 10"
+
+
+def format_report(
+    overall_results: list[dict],
+    per_contract_results: dict[str, list[dict]],
+) -> str:
+    """Format results as markdown."""
+    lines = [
+        "# Diagnostic Tricks-Model Evaluation",
+        "",
+        "> **Purpose:** Full-feature Ridge regression on `tricks_won` from canonical bidless data.",
+        "> Coefficients are standardized and exploratory. Correlated features share variance.",
+        "> This diagnostic is separate from the B0 hand-value regression in `train_b0.py`.",
+        "",
+        "## Methodology",
+        "",
+        "- **Model:** Ridge regression (alpha=1.0) with standardized features (z-scored)",
+        "- **Target:** `tricks_won` (per-seat, derived from team trick counts)",
+        "- **Split:** Grouped by `hand_id` (80/20 train/test) to prevent leakage across 4 seat rows",
+        "- **Features:** All 41 hand features from `get_hand_features()`",
+        "",
+    ]
+
+    for result in overall_results:
+        lines.extend([
+            f"## {result['label']}",
+            "",
+            f"- **Training:** {result['n_train_hands']:,} hands ({result['n_train_rows']:,} seat-rows)",
+            f"- **Test:** {result['n_test_hands']:,} hands ({result['n_test_rows']:,} seat-rows)",
+            f"- **R² (train):** {result['r2_train']:.4f}",
+            f"- **R² (test):** {result['r2_test']:.4f}",
+            f"- **MAE (train):** {result['mae_train']:.4f}",
+            f"- **MAE (test):** {result['mae_test']:.4f}",
+            f"- **Intercept:** {result['intercept']:.4f}",
+            "",
+            "### Top 10 Standardized Coefficients",
+            "",
+            "| Rank | Feature | Coefficient |",
+            "|------|---------|-------------|",
+        ])
+        for rank, (feat, coef) in enumerate(result["coef_ranking"][:10], 1):
+            lines.append(f"| {rank} | `{feat}` | {coef:+.4f} |")
+        lines.append("")
+
+    # Per-contract results
+    for dataset_label, contract_results in per_contract_results.items():
+        lines.extend([
+            f"## Per-Contract Breakdown: {dataset_label}",
+            "",
+            "| Contract | R² (test) | MAE (test) | N (test rows) | OLSa Feature Validation |",
+            "|----------|-----------|------------|---------------|------------------------|",
+        ])
+        for cr in contract_results:
+            olsa_status = validate_olsa_features(
+                cr["coef_ranking"], cr["contract_type"]
+            )
+            lines.append(
+                f"| {cr['contract_type']} | {cr['r2_test']:.4f} | "
+                f"{cr['mae_test']:.4f} | {cr['n_test_rows']:,} | {olsa_status} |"
+            )
+        lines.append("")
+
+        # Show top 5 coefficients per contract
+        for cr in contract_results:
+            lines.extend([
+                f"### {dataset_label} — contract={cr['contract_type']} top 5",
+                "",
+                "| Rank | Feature | Coefficient |",
+                "|------|---------|-------------|",
+            ])
+            for rank, (feat, coef) in enumerate(cr["coef_ranking"][:5], 1):
+                lines.append(f"| {rank} | `{feat}` | {coef:+.4f} |")
+            lines.append("")
+
+    lines.extend([
+        "## Caveats",
+        "",
+        "- Coefficients are standardized (z-scored features) and exploratory only",
+        "- Correlated features share variance; coefficients do not imply causal importance",
+        "- This diagnostic is separate from the B0 hand-value regression pipeline",
+        "- Use Ridge (not raw OLS) for 40+ correlated features to avoid numerical instability",
+        "",
+    ])
+
+    return "\n".join(lines)
+
+
+def process_dataset(run_dir: str, seed: int, label: str) -> tuple[dict, list[dict]]:
+    """Load one dataset, train overall + per-contract, return results."""
+    bidless_path = os.path.join(run_dir, "datasets", "bidless.parquet")
+    outcomes_path = os.path.join(run_dir, "datasets", "bidless_outcomes.parquet")
+
+    if not os.path.exists(bidless_path):
+        raise FileNotFoundError(f"Missing: {bidless_path}")
+    if not os.path.exists(outcomes_path):
+        raise FileNotFoundError(f"Missing: {outcomes_path}")
+
+    print(f"Loading {label} data...")
+    df = join_features_outcomes(bidless_path, outcomes_path)
+    feature_cols = get_feature_columns(df)
+    print(f"  Joined: {len(df):,} rows, {len(feature_cols)} features")
+
+    print("  Training overall model...")
+    overall = train_and_evaluate(df, feature_cols, seed, label)
+
+    print("  Training per-contract models...")
+    per_contract = per_contract_metrics(df, feature_cols, seed)
+
+    # Free memory before returning
+    del df
+
+    return overall, per_contract
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Diagnostic tricks-model evaluation"
+    )
+    parser.add_argument("--greedy-dir", required=True, help="Path to greedy canonical run")
+    parser.add_argument("--glutton-dir", required=True, help="Path to glutton canonical run")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed")
+    parser.add_argument("--output", required=True, help="Output markdown path")
+    args = parser.parse_args()
+
+    overall_results = []
+    per_contract_results = {}
+
+    # Process greedy dataset
+    overall, per_contract = process_dataset(args.greedy_dir, args.seed, "Greedy Play Policy")
+    overall_results.append(overall)
+    per_contract_results["Greedy"] = per_contract
+
+    # Process glutton dataset
+    overall, per_contract = process_dataset(args.glutton_dir, args.seed, "Glutton Play Policy")
+    overall_results.append(overall)
+    per_contract_results["Glutton"] = per_contract
+
+    # Generate report
+    report = format_report(overall_results, per_contract_results)
+
+    os.makedirs(os.path.dirname(args.output), exist_ok=True)
+    with open(args.output, "w") as f:
+        f.write(report)
+
+    print(f"\nReport written to {args.output}")
+    print(f"Overall R² — Greedy: {overall_results[0]['r2_test']:.4f}, Glutton: {overall_results[1]['r2_test']:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bid_euchre/datasets/__init__.py
+++ b/src/bid_euchre/datasets/__init__.py
@@ -1,1 +1,5 @@
 # Dataset collection and emission utilities
+
+from .join import join_features_outcomes
+
+__all__ = ["join_features_outcomes"]

--- a/src/bid_euchre/datasets/join.py
+++ b/src/bid_euchre/datasets/join.py
@@ -1,0 +1,72 @@
+"""
+Join bidless features and outcomes for analysis.
+
+Provides the canonical join between per-seat feature rows (bidless.parquet)
+and per-hand outcome rows (bidless_outcomes.parquet).
+"""
+
+import pandas as pd
+
+
+def join_features_outcomes(
+    bidless_path: str,
+    outcomes_path: str,
+) -> pd.DataFrame:
+    """
+    Join bidless feature data with outcome data.
+
+    Bidless has per-seat rows (hand_id, seat, hand_features struct).
+    Outcomes has per-hand rows (hand_id, tricks_team0, tricks_team1).
+
+    The join assigns each seat its team's tricks_won:
+      - Seats 0, 2 → team 0 → tricks_team0
+      - Seats 1, 3 → team 1 → tricks_team1
+
+    Args:
+        bidless_path: Path to bidless.parquet
+        outcomes_path: Path to bidless_outcomes.parquet
+
+    Returns:
+        DataFrame with columns: hand_id, seat, contract_type, trump_suit,
+        <41 feature columns>, tricks_won
+    """
+    features_df = pd.read_parquet(bidless_path)
+    outcomes_df = pd.read_parquet(outcomes_path)
+
+    # Flatten the hand_features struct into individual columns
+    if "hand_features" in features_df.columns:
+        hf = pd.json_normalize(features_df["hand_features"])
+        features_df = pd.concat(
+            [features_df.drop(columns=["hand_features"]), hf], axis=1
+        )
+
+    # Keep only the columns we need from outcomes
+    outcomes_subset = outcomes_df[
+        ["hand_id", "contract_type", "trump_suit", "tricks_team0", "tricks_team1"]
+    ].copy()
+
+    # Join on hand_id + contract_type + trump_suit (outcomes may have
+    # multiple strategy matchups; deduplicate by taking the first)
+    outcomes_dedup = outcomes_subset.drop_duplicates(
+        subset=["hand_id", "contract_type", "trump_suit"], keep="first"
+    )
+
+    merged = features_df.merge(
+        outcomes_dedup,
+        on=["hand_id", "contract_type", "trump_suit"],
+        how="inner",
+    )
+
+    # Assign tricks_won based on team membership
+    import numpy as np
+
+    merged["tricks_won"] = np.where(
+        merged["seat"].isin([0, 2]),
+        merged["tricks_team0"],
+        merged["tricks_team1"],
+    )
+
+    # Drop intermediate columns
+    merged = merged.drop(columns=["tricks_team0", "tricks_team1"])
+
+    return merged

--- a/tests/unit/test_evaluate_diagnostic_tricks.py
+++ b/tests/unit/test_evaluate_diagnostic_tricks.py
@@ -1,0 +1,43 @@
+"""
+Smoke test for the diagnostic tricks evaluation script.
+"""
+
+import subprocess
+import sys
+
+
+class TestEvaluateDiagnosticTricks:
+    """Smoke tests for the evaluate script."""
+
+    def test_script_has_help(self):
+        """Test that the script prints help without errors."""
+        result = subprocess.run(
+            [sys.executable, "scripts/evaluate_diagnostic_tricks.py", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "--greedy-dir" in result.stdout
+        assert "--glutton-dir" in result.stdout
+        assert "--seed" in result.stdout
+
+    def test_script_fails_on_missing_dirs(self, tmp_path):
+        """Test that the script fails gracefully with missing data dirs."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "scripts/evaluate_diagnostic_tricks.py",
+                "--greedy-dir",
+                str(tmp_path / "nonexistent_greedy"),
+                "--glutton-dir",
+                str(tmp_path / "nonexistent_glutton"),
+                "--seed",
+                "42",
+                "--output",
+                str(tmp_path / "output.md"),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "Missing" in result.stderr or "FileNotFoundError" in result.stderr

--- a/tests/unit/test_join_features_outcomes.py
+++ b/tests/unit/test_join_features_outcomes.py
@@ -1,0 +1,168 @@
+"""
+Unit tests for join_features_outcomes utility.
+"""
+
+import pandas as pd
+
+from bid_euchre.datasets.join import join_features_outcomes
+
+
+def _make_bidless_parquet(path, hand_ids, contract_types, trump_suits):
+    """Create a minimal bidless.parquet for testing."""
+    rows = []
+    for hand_id in hand_ids:
+        for ct, ts in zip(contract_types, trump_suits):
+            for seat in range(4):
+                rows.append(
+                    {
+                        "hand_id": hand_id,
+                        "seat": seat,
+                        "dealer_seat": 0,
+                        "deal_id": hand_id,
+                        "hand_cards": ["SA", "HA"],
+                        "hand_features": {
+                            "bowers": seat % 2,
+                            "trump_count": 3 + seat,
+                            "offsuit_aces": 1,
+                            "offsuit_tens_count": 2,
+                        },
+                        "hand_feature_schema_version": 1,
+                        "contract_type": ct,
+                        "trump_suit": ts,
+                    }
+                )
+    df = pd.DataFrame(rows)
+    df.to_parquet(path)
+
+
+def _make_outcomes_parquet(path, hand_ids, contract_types, trump_suits):
+    """Create a minimal bidless_outcomes.parquet for testing."""
+    rows = []
+    for hand_id in hand_ids:
+        for ct, ts in zip(contract_types, trump_suits):
+            rows.append(
+                {
+                    "hand_id": hand_id,
+                    "deal_id": hand_id,
+                    "dealer_seat": 0,
+                    "contract_type": ct,
+                    "trump_suit": ts,
+                    "strategy_id": "test",
+                    "matchup_id": "test",
+                    "team0_strategy": "greedy",
+                    "team1_strategy": "greedy",
+                    "tricks_team0": 6,
+                    "tricks_team1": 4,
+                    "team0_win": True,
+                }
+            )
+    df = pd.DataFrame(rows)
+    df.to_parquet(path)
+
+
+class TestJoinFeaturesOutcomes:
+    """Test the join utility."""
+
+    def test_basic_join(self, tmp_path):
+        """Test basic join produces correct shape and columns."""
+        bidless_path = tmp_path / "bidless.parquet"
+        outcomes_path = tmp_path / "outcomes.parquet"
+
+        hand_ids = [1, 2, 3]
+        cts = ["suit"]
+        tss = ["H"]
+
+        _make_bidless_parquet(bidless_path, hand_ids, cts, tss)
+        _make_outcomes_parquet(outcomes_path, hand_ids, cts, tss)
+
+        result = join_features_outcomes(str(bidless_path), str(outcomes_path))
+
+        # 3 hands × 4 seats × 1 contract = 12 rows
+        assert len(result) == 12
+        assert "tricks_won" in result.columns
+        assert "hand_id" in result.columns
+        assert "seat" in result.columns
+        # Struct features should be flattened
+        assert "bowers" in result.columns
+        assert "trump_count" in result.columns
+
+    def test_team_assignment(self, tmp_path):
+        """Test that tricks_won is correctly assigned by team."""
+        bidless_path = tmp_path / "bidless.parquet"
+        outcomes_path = tmp_path / "outcomes.parquet"
+
+        _make_bidless_parquet(bidless_path, [1], ["suit"], ["H"])
+        _make_outcomes_parquet(outcomes_path, [1], ["suit"], ["H"])
+
+        result = join_features_outcomes(str(bidless_path), str(outcomes_path))
+
+        # Seats 0, 2 → team 0 → tricks_team0 = 6
+        team0_rows = result[result["seat"].isin([0, 2])]
+        assert (team0_rows["tricks_won"] == 6).all()
+
+        # Seats 1, 3 → team 1 → tricks_team1 = 4
+        team1_rows = result[result["seat"].isin([1, 3])]
+        assert (team1_rows["tricks_won"] == 4).all()
+
+    def test_struct_flattening(self, tmp_path):
+        """Test that hand_features struct is properly flattened."""
+        bidless_path = tmp_path / "bidless.parquet"
+        outcomes_path = tmp_path / "outcomes.parquet"
+
+        _make_bidless_parquet(bidless_path, [1], ["suit"], ["H"])
+        _make_outcomes_parquet(outcomes_path, [1], ["suit"], ["H"])
+
+        result = join_features_outcomes(str(bidless_path), str(outcomes_path))
+
+        # hand_features struct should be gone
+        assert "hand_features" not in result.columns
+        # Individual features should be present
+        assert "bowers" in result.columns
+        assert "offsuit_aces" in result.columns
+        assert "offsuit_tens_count" in result.columns
+
+    def test_no_intermediate_columns(self, tmp_path):
+        """Test that tricks_team0/tricks_team1 are dropped."""
+        bidless_path = tmp_path / "bidless.parquet"
+        outcomes_path = tmp_path / "outcomes.parquet"
+
+        _make_bidless_parquet(bidless_path, [1], ["suit"], ["H"])
+        _make_outcomes_parquet(outcomes_path, [1], ["suit"], ["H"])
+
+        result = join_features_outcomes(str(bidless_path), str(outcomes_path))
+
+        assert "tricks_team0" not in result.columns
+        assert "tricks_team1" not in result.columns
+
+    def test_multiple_contracts(self, tmp_path):
+        """Test join with multiple contract types."""
+        bidless_path = tmp_path / "bidless.parquet"
+        outcomes_path = tmp_path / "outcomes.parquet"
+
+        hand_ids = [1, 2]
+        cts = ["suit", "high"]
+        tss = ["H", None]
+
+        _make_bidless_parquet(bidless_path, hand_ids, cts, tss)
+        _make_outcomes_parquet(outcomes_path, hand_ids, cts, tss)
+
+        result = join_features_outcomes(str(bidless_path), str(outcomes_path))
+
+        # 2 hands × 4 seats × 2 contracts = 16 rows
+        assert len(result) == 16
+
+    def test_hand_id_grouping_preserved(self, tmp_path):
+        """Test that all 4 seats per hand are present after join."""
+        bidless_path = tmp_path / "bidless.parquet"
+        outcomes_path = tmp_path / "outcomes.parquet"
+
+        _make_bidless_parquet(bidless_path, [10, 20, 30], ["suit"], ["S"])
+        _make_outcomes_parquet(outcomes_path, [10, 20, 30], ["suit"], ["S"])
+
+        result = join_features_outcomes(str(bidless_path), str(outcomes_path))
+
+        # Each hand_id should have exactly 4 rows (one per seat)
+        for hid in [10, 20, 30]:
+            hand_rows = result[result["hand_id"] == hid]
+            assert len(hand_rows) == 4
+            assert set(hand_rows["seat"]) == {0, 1, 2, 3}


### PR DESCRIPTION
## Summary
- Add `join_features_outcomes()` utility in `src/bid_euchre/datasets/join.py` — joins per-seat features with per-hand outcomes
- Add `scripts/evaluate_diagnostic_tricks.py` — full-feature Ridge regression on `tricks_won`
- Generate `docs/02_agent/DIAGNOSTIC_TRICKS_EVALUATION.md` with results from canonical data

## Why
This diagnostic informs OLSa sparse feature selection (PR6). By training a full-feature Ridge on `tricks_won` with standardized coefficients, we validate that the planned OLSa features (`bowers`, `trump_count`, `offsuit_aces`, `offsuit_tens_count`) are among the most predictive for their respective contracts.

Key findings:
- Overall R² (test): Greedy=0.2088, Glutton=0.1928
- HIGH/LOW: OLSa candidate features rank in top 10 (validated)
- Suit: `bowers` ranks in top 10; `trump_count`/`offsuit_aces` spread across correlated proxies (expected — exploratory only)

## Repro / Validation
```bash
cd /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr1-diagnostic

# Run the diagnostic (requires canonical data in main checkout)
uv run python scripts/evaluate_diagnostic_tricks.py \
    --greedy-dir /path/to/canonical_bidless_dataset_greedy_42_20260204_221121 \
    --glutton-dir /path/to/canonical_bidless_dataset_glutton_42_20260204_222713 \
    --seed 42 --output docs/02_agent/DIAGNOSTIC_TRICKS_EVALUATION.md

make check   # all 885 tests pass, ruff clean, repo-lint clean
```

## Tests
- `make check` — full suite (repo-lint + ruff + pytest)
- `tests/unit/test_join_features_outcomes.py` — 6 tests (join, team assignment, struct flattening, hand_id grouping)
- `tests/unit/test_evaluate_diagnostic_tricks.py` — 2 smoke tests (help, missing dirs)

## Statistical Rigor
- **Grouped split by `hand_id`** — prevents leakage across 4 seat rows per hand
- **Standardized features (z-scored)** — coefficients comparable across different-scale features
- **Ridge regression (alpha=1.0)** — avoids numerical instability with 41 correlated features
- **Explicit caveats** — coefficient ranking is exploratory, not causal

## Files Changed
| File | Change |
|------|--------|
| `src/bid_euchre/datasets/join.py` | NEW: `join_features_outcomes()` |
| `src/bid_euchre/datasets/__init__.py` | Export join function |
| `scripts/evaluate_diagnostic_tricks.py` | NEW: diagnostic evaluation script |
| `docs/02_agent/DIAGNOSTIC_TRICKS_EVALUATION.md` | NEW: generated results |
| `tests/unit/test_join_features_outcomes.py` | NEW: 6 unit tests |
| `tests/unit/test_evaluate_diagnostic_tricks.py` | NEW: 2 smoke tests |

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr1-diagnostic
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr1-diagnostic
branch: codex/b0-evaluation-diagnostic
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)