### PR TITLE
feat(bidding): Add OLSa training pipeline + OLSaBidder runtime

### DIFF
--- a/src/bid_euchre/experiments/config.py
+++ b/src/bid_euchre/experiments/config.py
@@ -17,9 +17,12 @@ from ..strategy import (
     ArtifactBidder,
     BasicStrategy,
     BiddingPolicy,
+    FixedBidder,
     GluttonIsolatedStrategy,
     GluttonStrategy,
     GreedyStrategy,
+    ModeloEspecifico,
+    OLSaBidder,
     RandomLegalStrategy,
     RanktheTank,
     Strategy,
@@ -96,6 +99,19 @@ class BiddingPolicyConfig:
             return RanktheTank(name=self.name)
         elif self.class_name in ("StrictHellRaiser", "StrictRaiserBidder"):
             return StrictHellRaiser(name=self.name)
+        elif self.class_name == "ModeloEspecifico":
+            return ModeloEspecifico(name=self.name)
+        elif self.class_name == "FixedBidder":
+            n = self.params.get("n")
+            contract = self.params.get("contract")
+            if n is None or contract is None:
+                raise ValueError("FixedBidder requires 'n' and 'contract' parameters")
+            return FixedBidder(n=n, contract=contract, name=self.name)
+        elif self.class_name == "OLSaBidder":
+            artifact_path = self.params.get("artifact_path")
+            if not artifact_path:
+                raise ValueError("OLSaBidder requires 'artifact_path' parameter")
+            return OLSaBidder(artifact_path=artifact_path, name=self.name)
         else:
             raise ValueError(f"Unknown bidding policy class: {self.class_name}")
 

--- a/src/bid_euchre/models/train_olsa.py
+++ b/src/bid_euchre/models/train_olsa.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python
+"""
+OLSa training pipeline: per-contract sparse OLS on tricks_won.
+
+Trains 3 separate OLS models with sparse features:
+  suit: tricks_won ~ intercept + bowers + trump_count + offsuit_aces
+  high: tricks_won ~ intercept + offsuit_aces
+  low:  tricks_won ~ intercept + offsuit_tens_count
+
+Uses normal equation with lstsq fallback for robustness.
+
+Usage:
+    uv run python -m bid_euchre.models.train_olsa \
+        --run-dir data/runs/canonical_bidless_dataset_glutton_42_20260204_222713 \
+        --seed 42 --output /tmp/olsa_artifacts/
+"""
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+from datetime import datetime, timezone
+
+import numpy as np
+
+from ..datasets.join import join_features_outcomes
+
+logger = logging.getLogger(__name__)
+
+# Per-contract feature specs
+CONTRACT_FEATURES = {
+    "suit": ["bowers", "trump_count", "offsuit_aces"],
+    "high": ["offsuit_aces"],
+    "low": ["offsuit_tens_count"],
+}
+
+
+def _grouped_train_test_split(df, seed, train_frac=0.8):
+    """Split by hand_id to prevent leakage."""
+    unique_ids = df["hand_id"].unique()
+    rng = np.random.RandomState(seed)
+    rng.shuffle(unique_ids)
+    split_idx = int(len(unique_ids) * train_frac)
+    train_ids = set(unique_ids[:split_idx])
+    train_mask = df["hand_id"].isin(train_ids)
+    return df[train_mask], df[~train_mask]
+
+
+def _fit_ols(X, y):
+    """
+    Fit OLS with intercept using normal equation.
+
+    Falls back to lstsq on LinAlgError or ill-conditioning.
+    Returns (weights, bias) where weights excludes intercept.
+    """
+    X_with_intercept = np.column_stack([np.ones(len(X)), X])
+    XtX = X_with_intercept.T @ X_with_intercept
+    Xty = X_with_intercept.T @ y
+
+    try:
+        beta = np.linalg.solve(XtX, Xty)
+    except np.linalg.LinAlgError:
+        logger.warning("Normal equation failed, falling back to lstsq")
+        beta, _, _, _ = np.linalg.lstsq(X_with_intercept, y, rcond=None)
+
+    return beta[1:], beta[0]  # weights, bias
+
+
+def _compute_metrics(y_true, y_pred):
+    """Compute R² and MAE."""
+    ss_res = np.sum((y_true - y_pred) ** 2)
+    ss_tot = np.sum((y_true - y_true.mean()) ** 2)
+    r2 = 1 - ss_res / ss_tot if ss_tot > 0 else 0.0
+    mae = np.mean(np.abs(y_true - y_pred))
+    return {"r2": float(r2), "mae": float(mae)}
+
+
+def train_olsa(run_dir, seed):
+    """
+    Train OLSa models from a canonical bidless run directory.
+
+    Returns the artifact dict and per-contract metrics.
+    """
+    bidless_path = os.path.join(run_dir, "datasets", "bidless.parquet")
+    outcomes_path = os.path.join(run_dir, "datasets", "bidless_outcomes.parquet")
+
+    if not os.path.exists(bidless_path):
+        raise FileNotFoundError(f"Missing: {bidless_path}")
+    if not os.path.exists(outcomes_path):
+        raise FileNotFoundError(f"Missing: {outcomes_path}")
+
+    logger.info("Loading data from %s", run_dir)
+    df = join_features_outcomes(bidless_path, outcomes_path)
+    logger.info("Joined: %d rows", len(df))
+
+    models = {}
+    training_metrics = {}
+
+    for contract_family, feature_names in CONTRACT_FEATURES.items():
+        # Filter to matching contract_type
+        sub = df[df["contract_type"] == contract_family]
+        if len(sub) == 0:
+            logger.warning("No data for contract_type=%s, skipping", contract_family)
+            continue
+
+        train_df, test_df = _grouped_train_test_split(sub, seed)
+
+        X_train = train_df[feature_names].values.astype(np.float64)
+        y_train = train_df["tricks_won"].values.astype(np.float64)
+        X_test = test_df[feature_names].values.astype(np.float64)
+        y_test = test_df["tricks_won"].values.astype(np.float64)
+
+        weights, bias = _fit_ols(X_train, y_train)
+
+        # Evaluate
+        y_pred_train = X_train @ weights + bias
+        y_pred_test = X_test @ weights + bias
+
+        metrics_train = _compute_metrics(y_train, y_pred_train)
+        metrics_test = _compute_metrics(y_test, y_pred_test)
+
+        models[contract_family] = {
+            "weights": [float(w) for w in weights],
+            "bias": float(bias),
+            "feature_names": feature_names,
+        }
+
+        training_metrics[contract_family] = {
+            "r2_train": metrics_train["r2"],
+            "r2_test": metrics_test["r2"],
+            "mae_train": metrics_train["mae"],
+            "mae_test": metrics_test["mae"],
+            "n_train": len(train_df),
+            "n_test": len(test_df),
+        }
+
+        logger.info(
+            "  %s: R²=%.4f (test), MAE=%.4f, weights=%s, bias=%.4f",
+            contract_family,
+            metrics_test["r2"],
+            metrics_test["mae"],
+            [f"{w:.4f}" for w in weights],
+            bias,
+        )
+
+    # Get git SHA
+    try:
+        git_sha = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        git_sha = "unknown"
+
+    artifact = {
+        "schema_version": "1",
+        "artifact_type": "olsa_v1",
+        "models": models,
+        "metadata": {
+            "training_seed": seed,
+            "canonical_run_id": os.path.basename(run_dir),
+            "git_sha": git_sha,
+            "training_timestamp": datetime.now(timezone.utc).isoformat(),
+            "training_metrics": training_metrics,
+        },
+    }
+
+    return artifact, training_metrics
+
+
+def save_artifacts(artifact, training_metrics, output_dir):
+    """Save OLSa artifact and summary to output directory."""
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Save artifact
+    artifact_path = os.path.join(output_dir, "olsa_v1.json")
+    with open(artifact_path, "w") as f:
+        json.dump(artifact, f, indent=2)
+    logger.info("Artifact saved to %s", artifact_path)
+
+    # Save training metrics
+    metrics_path = os.path.join(output_dir, "training_metrics.json")
+    with open(metrics_path, "w") as f:
+        json.dump(training_metrics, f, indent=2)
+
+    # Save human-readable summary
+    summary_path = os.path.join(output_dir, "training_summary.md")
+    lines = [
+        "# OLSa Training Summary",
+        "",
+        f"- **Seed:** {artifact['metadata']['training_seed']}",
+        f"- **Source:** {artifact['metadata']['canonical_run_id']}",
+        f"- **Git SHA:** {artifact['metadata']['git_sha']}",
+        f"- **Timestamp:** {artifact['metadata']['training_timestamp']}",
+        "",
+        "## Per-Contract Results",
+        "",
+        "| Contract | R² (test) | MAE (test) | N (test) | Weights | Bias |",
+        "|----------|-----------|------------|----------|---------|------|",
+    ]
+    for cf, model in artifact["models"].items():
+        m = training_metrics[cf]
+        weights_str = ", ".join(f"{w:.4f}" for w in model["weights"])
+        lines.append(
+            f"| {cf} | {m['r2_test']:.4f} | {m['mae_test']:.4f} | "
+            f"{m['n_test']:,} | [{weights_str}] | {model['bias']:.4f} |"
+        )
+    lines.append("")
+    lines.append("## Feature Specs")
+    lines.append("")
+    for cf, model in artifact["models"].items():
+        lines.append(f"- **{cf}:** {', '.join(model['feature_names'])}")
+    lines.append("")
+
+    with open(summary_path, "w") as f:
+        f.write("\n".join(lines))
+
+    return artifact_path
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train OLSa models")
+    parser.add_argument("--run-dir", required=True, help="Canonical bidless run directory")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output", required=True, help="Output directory for artifacts")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    artifact, metrics = train_olsa(args.run_dir, args.seed)
+    artifact_path = save_artifacts(artifact, metrics, args.output)
+    print(f"\nOLSa artifact: {artifact_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bid_euchre/strategy/__init__.py
+++ b/src/bid_euchre/strategy/__init__.py
@@ -31,6 +31,7 @@ from .bidding import (
     HeuristicSuitBidder,
     HighLowHeuristicBidder,
     ModeloEspecifico,
+    OLSaBidder,
     RanktheTank,
     StrictHellRaiser,
     StrictRaiserBidder,  # backward-compat alias
@@ -62,6 +63,7 @@ __all__ = [
     "HeuristicSuitBidder",
     "HighLowHeuristicBidder",
     "ModeloEspecifico",
+    "OLSaBidder",
     "RanktheTank",
     "StrictHellRaiser",
     "StrictRaiserBidder",

--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -5,9 +5,13 @@ This module provides the canonical interface for bidding in auction games,
 where players bid simultaneously for the right to choose contract and trump.
 """
 
+import json
+import math
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
+
+import numpy as np
 
 from ..core.cards import Card
 from ..models.bidding_artifact import load_artifact
@@ -638,3 +642,79 @@ class ArtifactBidder(BiddingPolicy):
         _, bid_n, contract = best
 
         return BidAction.bid(bid_n, contract)
+
+
+class OLSaBidder(BiddingPolicy):
+    """
+    OLSa bidder: per-contract sparse OLS predicting tricks_won.
+
+    Evaluates all 6 contracts (4 suits + HIGH + LOW), predicts tricks for
+    each using the corresponding sparse OLS model, floors to get bid amount,
+    and picks the best candidate.
+
+    Artifact format: olsa_v1.json with models for "suit", "high", "low".
+    """
+
+    def __init__(self, artifact_path: str, name: str = "olsa"):
+        super().__init__(name)
+
+        with open(artifact_path) as f:
+            artifact = json.load(f)
+
+        if artifact.get("artifact_type") != "olsa_v1":
+            raise ValueError(
+                f"Expected artifact_type 'olsa_v1', got '{artifact.get('artifact_type')}'"
+            )
+
+        self.models = {}
+        for contract_family, model_data in artifact["models"].items():
+            self.models[contract_family] = {
+                "weights": np.array(model_data["weights"], dtype=np.float64),
+                "bias": float(model_data["bias"]),
+                "feature_names": model_data["feature_names"],
+            }
+
+    def _predict(self, contract_family: str, features: dict) -> float:
+        """Predict tricks_won for a contract family using its OLS model."""
+        model = self.models[contract_family]
+        x = np.array(
+            [features[f] for f in model["feature_names"]], dtype=np.float64
+        )
+        return float(x @ model["weights"] + model["bias"])
+
+    def choose_bid(self, obs: BiddingObservation) -> BidAction:
+        from ..features.hand_eval import get_hand_features
+
+        candidates = []
+
+        # Evaluate suit contracts (4 suits, one model)
+        if "suit" in self.models:
+            for suit in ["C", "D", "H", "S"]:
+                features = get_hand_features(obs.hand, "suit", suit)
+                predicted_tricks = self._predict("suit", features)
+                bid_n = math.floor(predicted_tricks)
+                if 3 <= bid_n <= 10 and bid_n > obs.current_high_bid:
+                    candidates.append((predicted_tricks, bid_n, suit))
+
+        # Evaluate HIGH
+        if "high" in self.models:
+            features = get_hand_features(obs.hand, "high", None)
+            predicted_tricks = self._predict("high", features)
+            bid_n = math.floor(predicted_tricks)
+            if 3 <= bid_n <= 10 and bid_n > obs.current_high_bid:
+                candidates.append((predicted_tricks, bid_n, "HIGH"))
+
+        # Evaluate LOW
+        if "low" in self.models:
+            features = get_hand_features(obs.hand, "low", None)
+            predicted_tricks = self._predict("low", features)
+            bid_n = math.floor(predicted_tricks)
+            if 3 <= bid_n <= 10 and bid_n > obs.current_high_bid:
+                candidates.append((predicted_tricks, bid_n, "LOW"))
+
+        if not candidates:
+            return BidAction.pass_bid()
+
+        # Pick best: highest predicted tricks, break ties by bid amount, then alphabetically
+        best = max(candidates, key=lambda x: (x[0], x[1], x[2]))
+        return BidAction.bid(best[1], best[2])

--- a/tests/unit/test_olsa_bidder.py
+++ b/tests/unit/test_olsa_bidder.py
@@ -1,0 +1,233 @@
+"""
+Unit tests for OLSaBidder.
+"""
+
+import json
+
+from bid_euchre.core.cards import Card
+from bid_euchre.strategy.bidding import (
+    BiddingObservation,
+    OLSaBidder,
+)
+
+
+def _make_artifact(tmp_path, models=None):
+    """Create a minimal OLSa artifact for testing."""
+    if models is None:
+        models = {
+            "suit": {
+                "weights": [1.0, 0.5, 0.5],
+                "bias": 0.0,
+                "feature_names": ["bowers", "trump_count", "offsuit_aces"],
+            },
+            "high": {
+                "weights": [1.0],
+                "bias": 0.0,
+                "feature_names": ["offsuit_aces"],
+            },
+            "low": {
+                "weights": [1.0],
+                "bias": 0.0,
+                "feature_names": ["offsuit_tens_count"],
+            },
+        }
+
+    artifact = {
+        "schema_version": "1",
+        "artifact_type": "olsa_v1",
+        "models": models,
+        "metadata": {
+            "training_seed": 42,
+            "canonical_run_id": "test",
+            "git_sha": "test",
+            "training_metrics": {},
+        },
+    }
+
+    path = tmp_path / "olsa_v1.json"
+    with open(path, "w") as f:
+        json.dump(artifact, f)
+    return str(path)
+
+
+class TestOLSaBidder:
+    """Test OLSaBidder."""
+
+    def test_loads_artifact(self, tmp_path):
+        """Test loading a valid OLSa artifact."""
+        path = _make_artifact(tmp_path)
+        bidder = OLSaBidder(path)
+        assert bidder.name == "olsa"
+        assert "suit" in bidder.models
+        assert "high" in bidder.models
+        assert "low" in bidder.models
+
+    def test_strong_suit_hand_bids(self, tmp_path):
+        """Test a strong suit hand produces a bid."""
+        path = _make_artifact(tmp_path)
+        bidder = OLSaBidder(path)
+
+        # 2 bowers + 4 trump + 1 offsuit ace
+        # predicted = 1.0*2 + 0.5*4 + 0.5*1 = 4.5 → bid 4
+        hand = [
+            Card("H", "J"),  # Right bower
+            Card("D", "J"),  # Left bower
+            Card("H", "A"),
+            Card("H", "K"),
+            Card("S", "A"),  # Offsuit ace
+        ]
+
+        obs = BiddingObservation(
+            hand=hand, seat=0, dealer_seat=3, current_high_bid=0
+        )
+        action = bidder.choose_bid(obs)
+        assert not action.is_pass()
+        assert action.n == 4
+        assert action.contract == "H"
+
+    def test_weak_hand_passes(self, tmp_path):
+        """Test a weak hand passes."""
+        path = _make_artifact(tmp_path)
+        bidder = OLSaBidder(path)
+
+        # No bowers, 2 trump, no offsuit aces
+        # predicted = 0 + 0.5*2 + 0 = 1.0 → bid 1 < 3, pass
+        hand = [
+            Card("S", "K"),
+            Card("S", "Q"),
+            Card("H", "K"),
+            Card("D", "Q"),
+            Card("C", "T"),
+        ]
+
+        obs = BiddingObservation(
+            hand=hand, seat=0, dealer_seat=3, current_high_bid=0
+        )
+        action = bidder.choose_bid(obs)
+        assert action.is_pass()
+
+    def test_high_contract_with_aces(self, tmp_path):
+        """Test HIGH contract with enough aces."""
+        path = _make_artifact(tmp_path)
+        bidder = OLSaBidder(path)
+
+        # 4 aces → predicted_high = 1.0 * 4 = 4.0 → bid 4
+        hand = [
+            Card("S", "A"),
+            Card("H", "A"),
+            Card("D", "A"),
+            Card("C", "A"),
+            Card("S", "K"),
+            Card("H", "K"),
+            Card("D", "K"),
+            Card("C", "K"),
+            Card("S", "Q"),
+            Card("H", "Q"),
+        ]
+
+        obs = BiddingObservation(
+            hand=hand, seat=0, dealer_seat=3, current_high_bid=0
+        )
+        action = bidder.choose_bid(obs)
+        assert not action.is_pass()
+        # With 4 aces, HIGH should be a strong candidate
+        # (suit contracts also evaluated — the best wins)
+
+    def test_low_contract_with_tens(self, tmp_path):
+        """Test LOW contract with enough tens."""
+        # Use weights that make LOW the only viable contract
+        models = {
+            "suit": {
+                "weights": [0.0, 0.0, 0.0],
+                "bias": 0.0,
+                "feature_names": ["bowers", "trump_count", "offsuit_aces"],
+            },
+            "high": {
+                "weights": [0.0],
+                "bias": 0.0,
+                "feature_names": ["offsuit_aces"],
+            },
+            "low": {
+                "weights": [1.0],
+                "bias": 0.0,
+                "feature_names": ["offsuit_tens_count"],
+            },
+        }
+        path = _make_artifact(tmp_path, models=models)
+        bidder = OLSaBidder(path)
+
+        # 4 tens → predicted_low = 1.0 * 4 = 4.0 → bid 4
+        hand = [
+            Card("S", "T"),
+            Card("H", "T"),
+            Card("D", "T"),
+            Card("C", "T"),
+            Card("S", "K"),
+            Card("H", "K"),
+            Card("D", "K"),
+            Card("C", "K"),
+            Card("S", "Q"),
+            Card("H", "Q"),
+        ]
+
+        obs = BiddingObservation(
+            hand=hand, seat=0, dealer_seat=3, current_high_bid=0
+        )
+        action = bidder.choose_bid(obs)
+        assert not action.is_pass()
+        assert action.contract == "LOW"
+        assert action.n == 4
+
+    def test_strict_increasing_compliance(self, tmp_path):
+        """Test that bids comply with strict-increasing rule."""
+        path = _make_artifact(tmp_path)
+        bidder = OLSaBidder(path)
+
+        # Strong hand that would normally bid 4
+        hand = [
+            Card("H", "J"),
+            Card("D", "J"),
+            Card("H", "A"),
+            Card("H", "K"),
+            Card("S", "A"),
+        ]
+
+        # Current high bid is 4, must bid higher or pass
+        obs = BiddingObservation(
+            hand=hand, seat=0, dealer_seat=3, current_high_bid=4
+        )
+        action = bidder.choose_bid(obs)
+        # predicted=4.5, floor=4, but 4 not > 4, so pass
+        assert action.is_pass()
+
+    def test_invalid_artifact_type(self, tmp_path):
+        """Test that wrong artifact type raises ValueError."""
+        artifact = {
+            "schema_version": "1",
+            "artifact_type": "wrong_type",
+            "models": {},
+            "metadata": {},
+        }
+        path = tmp_path / "wrong.json"
+        with open(path, "w") as f:
+            json.dump(artifact, f)
+
+        try:
+            OLSaBidder(str(path))
+            assert False, "Should have raised ValueError"
+        except ValueError as e:
+            assert "olsa_v1" in str(e)
+
+    def test_config_registration(self, tmp_path):
+        """Test OLSaBidder can be created via BiddingPolicyConfig."""
+        from bid_euchre.experiments.config import BiddingPolicyConfig
+
+        path = _make_artifact(tmp_path)
+        config = BiddingPolicyConfig(
+            name="test_olsa",
+            class_name="OLSaBidder",
+            params={"artifact_path": path},
+        )
+        bidder = config.create_bidding_policy()
+        assert isinstance(bidder, OLSaBidder)
+        assert bidder.name == "test_olsa"

--- a/tests/unit/test_train_olsa.py
+++ b/tests/unit/test_train_olsa.py
@@ -1,0 +1,173 @@
+"""
+Unit tests for OLSa training pipeline.
+"""
+
+import numpy as np
+import pandas as pd
+
+from bid_euchre.models.train_olsa import CONTRACT_FEATURES, train_olsa
+
+
+def _make_training_data(tmp_path, n_hands=200, seed=42):
+    """Create synthetic bidless + outcomes parquet for testing."""
+    rng = np.random.RandomState(seed)
+    run_dir = tmp_path / "test_run"
+    datasets_dir = run_dir / "datasets"
+    datasets_dir.mkdir(parents=True)
+
+    contract_types = ["suit", "suit", "suit", "suit", "high", "low"]
+    trump_suits = ["C", "D", "H", "S", None, None]
+
+    bidless_rows = []
+    outcomes_rows = []
+
+    for hand_id in range(n_hands):
+        ct_idx = hand_id % len(contract_types)
+        ct = contract_types[ct_idx]
+        ts = trump_suits[ct_idx]
+
+        tricks_team0 = rng.randint(0, 11)
+        tricks_team1 = 10 - tricks_team0
+
+        outcomes_rows.append({
+            "hand_id": hand_id,
+            "deal_id": hand_id,
+            "dealer_seat": 0,
+            "contract_type": ct,
+            "trump_suit": ts,
+            "strategy_id": "test",
+            "matchup_id": "test",
+            "team0_strategy": "greedy",
+            "team1_strategy": "greedy",
+            "tricks_team0": tricks_team0,
+            "tricks_team1": tricks_team1,
+            "team0_win": tricks_team0 > tricks_team1,
+        })
+
+        for seat in range(4):
+            bidless_rows.append({
+                "hand_id": hand_id,
+                "seat": seat,
+                "dealer_seat": 0,
+                "deal_id": hand_id,
+                "hand_cards": ["SA", "HA"],
+                "hand_features": {
+                    "bowers": rng.randint(0, 3),
+                    "trump_count": rng.randint(0, 7),
+                    "offsuit_aces": rng.randint(0, 5),
+                    "offsuit_tens_count": rng.randint(0, 5),
+                    "rank_sum": rng.randint(10, 50),
+                    "hand_value": rng.randint(100, 400),
+                    "high_offsuit": rng.randint(0, 8),
+                    "trump_rb_count": rng.randint(0, 2),
+                    "trump_lb_count": rng.randint(0, 2),
+                    "trump_ace_count": rng.randint(0, 2),
+                    "trump_king_count": rng.randint(0, 2),
+                    "trump_queen_count": rng.randint(0, 2),
+                    "trump_ten_count": rng.randint(0, 2),
+                    "trump_count_x_void_count": rng.randint(0, 10),
+                    "trump_count_x_offsuit_ace": rng.randint(0, 10),
+                    "top_trump_count": rng.randint(0, 4),
+                    "top_trump_sum": rng.randint(0, 20),
+                    "trump_power_sum": rng.randint(0, 30),
+                    "trump_power_avg": float(rng.uniform(0, 5)),
+                    "trump_duplicate_pairs": rng.randint(0, 3),
+                    "highest_trump_rank": rng.randint(0, 6),
+                    "second_highest_trump_rank": rng.randint(0, 5),
+                    "third_highest_trump_rank": rng.randint(0, 4),
+                    "void_count": rng.randint(0, 3),
+                    "num_singletons": rng.randint(0, 3),
+                    "num_doubletons": rng.randint(0, 3),
+                    "max_suit_len": rng.randint(2, 8),
+                    "second_suit_len": rng.randint(1, 5),
+                    "third_suit_len": rng.randint(0, 4),
+                    "fourth_suit_len": rng.randint(0, 3),
+                    "offsuit_king_count_total": rng.randint(0, 4),
+                    "offsuit_queen_count_total": rng.randint(0, 4),
+                    "offsuit_suits_with_ace": rng.randint(0, 4),
+                    "offsuit_suits_with_double_ace": rng.randint(0, 2),
+                    "offsuit_suits_with_ace_and_king": rng.randint(0, 3),
+                    "offsuit_length_3plus_count": rng.randint(0, 4),
+                    "offsuit_best_rank_sum": rng.randint(0, 20),
+                    "offsuit_secondbest_rank_sum": rng.randint(0, 15),
+                    "high_card_count": rng.randint(0, 8),
+                    "low_card_count": rng.randint(0, 8),
+                    "double_ten_jack_count": rng.randint(0, 3),
+                },
+                "hand_feature_schema_version": 1,
+                "contract_type": ct,
+                "trump_suit": ts,
+            })
+
+    pd.DataFrame(bidless_rows).to_parquet(datasets_dir / "bidless.parquet")
+    pd.DataFrame(outcomes_rows).to_parquet(datasets_dir / "bidless_outcomes.parquet")
+
+    return str(run_dir)
+
+
+class TestTrainOlsa:
+    """Test OLSa training pipeline."""
+
+    def test_train_produces_artifact(self, tmp_path):
+        """Test that training produces a valid artifact."""
+        run_dir = _make_training_data(tmp_path)
+        artifact, metrics = train_olsa(run_dir, seed=42)
+
+        assert artifact["artifact_type"] == "olsa_v1"
+        assert artifact["schema_version"] == "1"
+        assert "suit" in artifact["models"]
+        assert "high" in artifact["models"]
+        assert "low" in artifact["models"]
+
+    def test_artifact_model_structure(self, tmp_path):
+        """Test that each model has correct structure."""
+        run_dir = _make_training_data(tmp_path)
+        artifact, _ = train_olsa(run_dir, seed=42)
+
+        for cf, expected_features in CONTRACT_FEATURES.items():
+            model = artifact["models"][cf]
+            assert "weights" in model
+            assert "bias" in model
+            assert "feature_names" in model
+            assert model["feature_names"] == expected_features
+            assert len(model["weights"]) == len(expected_features)
+
+    def test_metrics_have_required_fields(self, tmp_path):
+        """Test that training metrics have all required fields."""
+        run_dir = _make_training_data(tmp_path)
+        _, metrics = train_olsa(run_dir, seed=42)
+
+        for cf in CONTRACT_FEATURES:
+            assert cf in metrics
+            m = metrics[cf]
+            assert "r2_train" in m
+            assert "r2_test" in m
+            assert "mae_train" in m
+            assert "mae_test" in m
+            assert "n_train" in m
+            assert "n_test" in m
+
+    def test_artifact_roundtrip(self, tmp_path):
+        """Test that artifact can be saved and loaded by OLSaBidder."""
+        from bid_euchre.models.train_olsa import save_artifacts
+        from bid_euchre.strategy.bidding import OLSaBidder
+
+        run_dir = _make_training_data(tmp_path)
+        artifact, metrics = train_olsa(run_dir, seed=42)
+
+        output_dir = str(tmp_path / "artifacts")
+        artifact_path = save_artifacts(artifact, metrics, output_dir)
+
+        # Load with OLSaBidder
+        bidder = OLSaBidder(artifact_path)
+        assert "suit" in bidder.models
+        assert "high" in bidder.models
+        assert "low" in bidder.models
+
+    def test_missing_data_raises(self, tmp_path):
+        """Test that missing data raises FileNotFoundError."""
+        try:
+            train_olsa(str(tmp_path / "nonexistent"), seed=42)
+            assert False, "Should have raised FileNotFoundError"
+        except FileNotFoundError:
+            pass


### PR DESCRIPTION
## Summary
- Add `src/bid_euchre/models/train_olsa.py` — per-contract sparse OLS training on `tricks_won`
- Add `OLSaBidder` class in `bidding.py` — loads `olsa_v1.json`, evaluates all 6 contracts
- Register `OLSaBidder`, `ModeloEspecifico`, `FixedBidder` in config.py

## Why
This is the core OLSa implementation — the trained alternative to hand-coded ModeloEspecifico weights. Per-contract sparse features keep models interpretable while learning from canonical play data.

Architecture: 3 separate OLS models:
- **suit:** `tricks_won ~ intercept + bowers + trump_count + offsuit_aces` (4 params)
- **high:** `tricks_won ~ intercept + offsuit_aces` (2 params)
- **low:** `tricks_won ~ intercept + offsuit_tens_count` (2 params)

Validated on canonical glutton data (seed=42):
- suit R²=0.2169, MAE=1.2334, weights=[0.449, 0.432, 0.340], bias=2.746
- high R²=0.1781, MAE=1.3491, weights=[0.711], bias=3.579
- low R²=0.1850, MAE=1.3562, weights=[0.715], bias=3.569

## Repro / Validation
```bash
cd /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr6-olsa

# Train OLSa
uv run python -m bid_euchre.models.train_olsa \
    --run-dir data/runs/canonical_bidless_dataset_glutton_42_20260204_222713 \
    --seed 42 --output /tmp/olsa_artifacts/

make check   # all 898 tests pass, ruff clean, repo-lint clean
```

## Tests
- `make check` — full suite (repo-lint + ruff + pytest)
- `tests/unit/test_olsa_bidder.py` — 8 tests (load, bid, pass, config registration)
- `tests/unit/test_train_olsa.py` — 5 tests (artifact structure, metrics, roundtrip)

## Depends On
- PR #264 (`codex/b0-evaluation-diagnostic`) — provides `join_features_outcomes()` utility

## Files Changed
| File | Change |
|------|--------|
| `src/bid_euchre/models/train_olsa.py` | NEW: OLSa training pipeline |
| `src/bid_euchre/strategy/bidding.py` | Add `OLSaBidder` class |
| `src/bid_euchre/strategy/__init__.py` | Export `OLSaBidder` |
| `src/bid_euchre/experiments/config.py` | Register OLSaBidder, ModeloEspecifico, FixedBidder |
| `tests/unit/test_olsa_bidder.py` | NEW: 8 unit tests |
| `tests/unit/test_train_olsa.py` | NEW: 5 unit tests |

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr6-olsa
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr6-olsa
branch: codex/olsa-core-implementation
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)