### PR TITLE
feat(eval): Add auction comparator gate stack

### DIFF
--- a/experiments/configs/auction_comparator.yaml
+++ b/experiments/configs/auction_comparator.yaml
@@ -1,0 +1,37 @@
+# Auction Comparator: compare bidders in auction mode
+#
+# Primary metric: expected_points over bid-hands only
+# Gate: bid_rate > 0 for every comparator
+#
+# Usage:
+#   uv run python scripts/run_auction_comparator.py \
+#     --config experiments/configs/auction_comparator.yaml \
+#     --seed 42 \
+#     --olsa-artifact /path/to/olsa_v1.json
+
+experiment_name: auction_comparator
+
+bidding_policies:
+  - name: fiveheadfred
+    class_name: FixedBidder
+    params: {n: 5, contract: "S"}
+
+  - name: stricthellraiser
+    class_name: StrictRaiserBidder
+
+  - name: rankthetank
+    class_name: RanktheTank
+
+  - name: modeloespecifico
+    class_name: ModeloEspecifico
+
+  # OLSa is added dynamically by run_auction_comparator.py
+  # if --olsa-artifact is provided
+
+scenarios:
+  - contract_type: null  # Auction mode
+
+parameters:
+  n_per: 10000
+  seed: 42
+  log_level: hand

--- a/scripts/run_auction_comparator.py
+++ b/scripts/run_auction_comparator.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python
+"""
+Auction Comparator: run all bidders in auction mode and compare metrics.
+
+Orchestrates the experiment runner per bidder, then applies gate checks
+and generates a comparison report.
+
+Usage:
+    uv run python scripts/run_auction_comparator.py \
+        --config experiments/configs/auction_comparator.yaml \
+        --seed 42 \
+        --olsa-artifact /tmp/olsa_artifacts/olsa_v1.json
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+
+def run_experiment(config_path, seed, run_id, extra_args=None):
+    """Run a single experiment via the canonical runner."""
+    cmd = [
+        sys.executable, "experiments/run_experiment.py",
+        "--config", config_path,
+        "--seed", str(seed),
+        "--run-id", run_id,
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"FAILED: {run_id}")
+        print(result.stderr)
+        return False
+    return True
+
+
+def generate_evaluation(run_dir):
+    """Generate evaluator report for a run."""
+    cmd = [
+        sys.executable, "scripts/generate_report.py",
+        "--run-dir", run_dir,
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return result.returncode == 0
+
+
+def load_evaluation(run_dir):
+    """Load the evaluator JSON output."""
+    eval_path = Path(run_dir) / "reports" / "bidding_strategy" / "evaluation.json"
+    if not eval_path.exists():
+        return None
+    with open(eval_path) as f:
+        return json.load(f)
+
+
+def load_auction_results(run_dir, policy_name):
+    """Load the per-policy auction results."""
+    results_path = Path(run_dir) / "results" / policy_name / "auction.json"
+    if not results_path.exists():
+        return None
+    with open(results_path) as f:
+        return json.load(f)
+
+
+def gate_check(metrics_by_bidder):
+    """
+    Apply gate checks:
+    1. No bidder has bid_rate == 0 (degenerate)
+    2. Report overall coverage
+    """
+    failures = []
+
+    for name, metrics in metrics_by_bidder.items():
+        bid_rate = metrics.get("bid_rate", 0)
+        if bid_rate == 0:
+            failures.append(f"GATE FAIL: {name} has bid_rate=0 (never bids)")
+
+    return failures
+
+
+def format_report(metrics_by_bidder, gate_failures, seed):
+    """Generate markdown comparison report."""
+    lines = [
+        "# Auction Comparator Gate Report",
+        "",
+        f"- **Seed:** {seed}",
+        f"- **Generated:** {datetime.now(timezone.utc).isoformat()}",
+        f"- **Bidders:** {len(metrics_by_bidder)}",
+        "",
+    ]
+
+    # Gate results
+    if gate_failures:
+        lines.extend([
+            "## Gate Status: FAIL",
+            "",
+        ])
+        for f in gate_failures:
+            lines.append(f"- {f}")
+        lines.append("")
+    else:
+        lines.extend([
+            "## Gate Status: PASS",
+            "",
+        ])
+
+    # Comparison table
+    lines.extend([
+        "## Bidder Comparison",
+        "",
+        "| Bidder | Expected Points | Make Rate | Bid Rate | CVaR-5% | N (bid hands) |",
+        "|--------|----------------|-----------|----------|---------|---------------|",
+    ])
+
+    # Sort by expected_points descending
+    sorted_bidders = sorted(
+        metrics_by_bidder.items(),
+        key=lambda x: x[1].get("expected_points", 0),
+        reverse=True,
+    )
+
+    for name, m in sorted_bidders:
+        ep = m.get("expected_points", 0)
+        mr = m.get("make_rate", 0)
+        br = m.get("bid_rate", 0)
+        cvar = m.get("cvar_5")
+        n_bids = m.get("hands_with_bids", 0)
+        cvar_str = f"{cvar:.2f}" if cvar is not None else "N/A"
+        lines.append(
+            f"| {name} | {ep:.4f} | {mr:.4f} | {br:.4f} | {cvar_str} | {n_bids:,} |"
+        )
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Auction Comparator")
+    parser.add_argument("--config", required=True, help="YAML config path")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--olsa-artifact", default=None, help="Path to OLSa artifact")
+    parser.add_argument("--output", default=None, help="Output report path")
+    parser.add_argument("--skip-run", action="store_true", help="Skip experiment run, just analyze")
+    args = parser.parse_args()
+
+    # Load config
+    with open(args.config) as f:
+        config = yaml.safe_load(f)
+
+    policies = config.get("bidding_policies", [])
+    n_per = config.get("parameters", {}).get("n_per", 10000)
+
+    # Add OLSa if artifact provided
+    if args.olsa_artifact:
+        if not os.path.exists(args.olsa_artifact):
+            print(f"ERROR: OLSa artifact not found: {args.olsa_artifact}")
+            sys.exit(1)
+        policies.append({
+            "name": "olsa",
+            "class_name": "OLSaBidder",
+            "params": {"artifact_path": args.olsa_artifact},
+        })
+
+    experiment_name = config.get("experiment_name", "auction_comparator")
+
+    if not args.skip_run:
+        # Run experiment for each bidder individually
+        print(f"Running auction comparator with {len(policies)} bidders, n_per={n_per}...")
+        for policy in policies:
+            policy_name = policy["name"]
+            run_id = f"{experiment_name}_{policy_name}_{args.seed}"
+
+            # Create a per-policy config
+            per_policy_config = {
+                "experiment_name": f"{experiment_name}_{policy_name}",
+                "bidding_policies": [policy],
+                "scenarios": config.get("scenarios", [{"contract_type": None}]),
+                "parameters": config.get("parameters", {}),
+            }
+
+            config_path = f"/tmp/auction_comparator_{policy_name}.yaml"
+            with open(config_path, "w") as f:
+                yaml.dump(per_policy_config, f)
+
+            print(f"  Running {policy_name}...")
+            if not run_experiment(config_path, args.seed, run_id):
+                print(f"  FAILED: {policy_name}")
+                continue
+
+            # Generate evaluation
+            run_dir = f"data/runs/{run_id}"
+            generate_evaluation(run_dir)
+
+    # Collect metrics
+    metrics_by_bidder = {}
+    for policy in policies:
+        policy_name = policy["name"]
+        run_id = f"{experiment_name}_{policy_name}_{args.seed}"
+        run_dir = f"data/runs/{run_id}"
+
+        evaluation = load_evaluation(run_dir)
+        if evaluation and evaluation.get("strategies"):
+            strat = evaluation["strategies"][0]
+            metrics_by_bidder[policy_name] = {
+                "expected_points": strat.get("expected_points", 0),
+                "expected_points_per_deal": strat.get("expected_points_per_deal", 0),
+                "make_rate": strat.get("make_rate", 0),
+                "bid_rate": strat.get("bid_rate", 0),
+                "cvar_5": strat.get("cvar_5"),
+                "hands_with_bids": strat.get("hands_with_bids", 0),
+                "deals_total": strat.get("deals_total", 0),
+            }
+        else:
+            # Try loading from auction results
+            auction = load_auction_results(run_dir, policy_name)
+            if auction:
+                bp = auction.get("bidding_points", {})
+                metrics_by_bidder[policy_name] = {
+                    "expected_points": auction.get("avg_points_team0", 0),
+                    "make_rate": bp.get("make_rate", 0),
+                    "bid_rate": bp.get("hands_with_bids", 0) / max(auction.get("hands", 1), 1),
+                    "cvar_5": None,
+                    "hands_with_bids": bp.get("hands_with_bids", 0),
+                    "deals_total": auction.get("hands", 0),
+                }
+
+    if not metrics_by_bidder:
+        print("ERROR: No metrics collected. Check experiment runs.")
+        sys.exit(1)
+
+    # Gate check
+    gate_failures = gate_check(metrics_by_bidder)
+
+    # Generate report
+    report = format_report(metrics_by_bidder, gate_failures, args.seed)
+
+    if args.output:
+        os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+        with open(args.output, "w") as f:
+            f.write(report)
+        print(f"\nReport written to {args.output}")
+    else:
+        print(report)
+
+    if gate_failures:
+        print("\nGATE STATUS: FAIL")
+        for f in gate_failures:
+            print(f"  {f}")
+        sys.exit(1)
+    else:
+        print("\nGATE STATUS: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_auction_comparator.py
+++ b/tests/unit/test_auction_comparator.py
@@ -1,0 +1,104 @@
+"""
+Unit tests for the auction comparator gate logic.
+"""
+
+import subprocess
+import sys
+
+from scripts.run_auction_comparator import format_report, gate_check
+
+
+class TestGateCheck:
+    """Test gate check logic."""
+
+    def test_all_bidders_have_bids_passes(self):
+        """Gate passes when all bidders have bid_rate > 0."""
+        metrics = {
+            "bidder_a": {"bid_rate": 0.5, "expected_points": 3.0},
+            "bidder_b": {"bid_rate": 0.3, "expected_points": 2.0},
+        }
+        failures = gate_check(metrics)
+        assert len(failures) == 0
+
+    def test_zero_bid_rate_fails(self):
+        """Gate fails when any bidder has bid_rate == 0."""
+        metrics = {
+            "bidder_a": {"bid_rate": 0.5, "expected_points": 3.0},
+            "bidder_b": {"bid_rate": 0, "expected_points": 0},
+        }
+        failures = gate_check(metrics)
+        assert len(failures) == 1
+        assert "bidder_b" in failures[0]
+
+    def test_multiple_zero_bid_rates(self):
+        """Gate reports all zero-bid-rate bidders."""
+        metrics = {
+            "bidder_a": {"bid_rate": 0},
+            "bidder_b": {"bid_rate": 0},
+            "bidder_c": {"bid_rate": 0.8},
+        }
+        failures = gate_check(metrics)
+        assert len(failures) == 2
+
+
+class TestFormatReport:
+    """Test report formatting."""
+
+    def test_report_contains_all_bidders(self):
+        """Report includes all bidders in comparison table."""
+        metrics = {
+            "alice": {
+                "expected_points": 3.5,
+                "make_rate": 0.7,
+                "bid_rate": 0.5,
+                "cvar_5": -2.0,
+                "hands_with_bids": 5000,
+            },
+            "bob": {
+                "expected_points": 2.0,
+                "make_rate": 0.6,
+                "bid_rate": 0.3,
+                "cvar_5": -3.0,
+                "hands_with_bids": 3000,
+            },
+        }
+        report = format_report(metrics, [], seed=42)
+        assert "alice" in report
+        assert "bob" in report
+        assert "PASS" in report
+
+    def test_report_shows_failures(self):
+        """Report shows gate failures."""
+        metrics = {"x": {"expected_points": 0, "bid_rate": 0}}
+        failures = ["GATE FAIL: x has bid_rate=0"]
+        report = format_report(metrics, failures, seed=42)
+        assert "FAIL" in report
+        assert "bid_rate=0" in report
+
+    def test_report_sorted_by_expected_points(self):
+        """Report sorts bidders by expected_points descending."""
+        metrics = {
+            "low": {"expected_points": 1.0, "make_rate": 0.5, "bid_rate": 0.5, "cvar_5": None, "hands_with_bids": 100},
+            "high": {"expected_points": 5.0, "make_rate": 0.8, "bid_rate": 0.9, "cvar_5": -1.0, "hands_with_bids": 900},
+        }
+        report = format_report(metrics, [], seed=42)
+        lines = report.split("\n")
+        # Find the data rows (after header)
+        data_rows = [l for l in lines if l.startswith("| ") and "Bidder" not in l and "---" not in l]
+        assert "high" in data_rows[0]
+        assert "low" in data_rows[1]
+
+
+class TestScriptHelp:
+    """Smoke test for the comparator script."""
+
+    def test_help_flag(self):
+        """Test that the script prints help without errors."""
+        result = subprocess.run(
+            [sys.executable, "scripts/run_auction_comparator.py", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "--config" in result.stdout
+        assert "--olsa-artifact" in result.stdout


### PR DESCRIPTION
## Summary
- Add `experiments/configs/auction_comparator.yaml` — 4 built-in bidders + optional OLSa
- Add `scripts/run_auction_comparator.py` — orchestrates per-bidder auction runs, collects metrics, applies gates, generates comparison report
- Gate check: `bid_rate > 0` for every comparator (catches degenerate strategies)

## Why
Provides the evaluation framework for comparing bidders head-to-head in auction mode. The gate ensures no degenerate bidders (zero bid rate) slip through. Primary metric is `expected_points` over bid-hands only.

### Comparator Lineup
| Bidder | Class | Notes |
|--------|-------|-------|
| FiveHeadFred | `FixedBidder(n=5, contract="S")` | Always bids 5S |
| StrictHellRaiser | `StrictRaiserBidder` | Always raises |
| RanktheTank | `RanktheTank` | Heuristic evaluator |
| ModeloEspecifico | `ModeloEspecifico` | Hand-coded weights |
| OLSa | `OLSaBidder` | Trained sparse OLS (optional, via `--olsa-artifact`) |

## Repro / Validation
```bash
cd /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr7-auction

# Full run (requires experiment runner + canonical data)
uv run python scripts/run_auction_comparator.py \
    --config experiments/configs/auction_comparator.yaml \
    --seed 42 \
    --olsa-artifact /path/to/olsa_v1.json

make check   # all 905 tests pass, ruff clean, repo-lint clean
```

## Tests
- `make check` — full suite
- `tests/unit/test_auction_comparator.py` — 7 tests (gate logic, report format, script help)

## Depends On
- PR #265 (`codex/olsa-core-implementation`) — OLSaBidder, FixedBidder, ModeloEspecifico registration

## Files Changed
| File | Change |
|------|--------|
| `experiments/configs/auction_comparator.yaml` | NEW: comparator config |
| `scripts/run_auction_comparator.py` | NEW: comparator orchestrator |
| `tests/unit/test_auction_comparator.py` | NEW: 7 tests |

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr7-auction
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr7-auction
branch: codex/auction-comparator-gates
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)