### PR TITLE
feat(reporting): Promote diagnostic charts to production generators

### DIFF
--- a/src/bid_euchre/reporting/chart_runner.py
+++ b/src/bid_euchre/reporting/chart_runner.py
@@ -1,0 +1,112 @@
+"""CLI for generating production charts from run data.
+
+Usage:
+    uv run python -m bid_euchre.reporting.chart_runner \
+        --run-dir data/runs/<run_id> \
+        --output-dir /tmp/charts/ \
+        --suite feature_health
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+from .charts import (
+    generate_distribution_charts,
+    generate_feature_health_charts,
+    generate_feature_outcome_charts,
+)
+
+AVAILABLE_SUITES = ["feature_health", "feature_outcome", "distribution", "all"]
+
+
+def _load_bidless_features(run_dir: Path) -> pd.DataFrame:
+    """Load bidless features from a run directory."""
+    parquet_path = run_dir / "datasets" / "bidless.parquet"
+    if not parquet_path.exists():
+        raise FileNotFoundError(f"No bidless.parquet found in {run_dir / 'datasets'}")
+    return pd.read_parquet(parquet_path)
+
+
+def _load_features_with_outcomes(run_dir: Path) -> pd.DataFrame:
+    """Load features joined with outcomes from a run directory."""
+    from ..datasets.join import join_features_outcomes
+
+    bidless_path = str(run_dir / "datasets" / "bidless.parquet")
+    outcomes_path = str(run_dir / "datasets" / "bidless_outcomes.parquet")
+
+    if not Path(bidless_path).exists():
+        raise FileNotFoundError(f"Missing: {bidless_path}")
+    if not Path(outcomes_path).exists():
+        raise FileNotFoundError(f"Missing: {outcomes_path}")
+
+    return join_features_outcomes(bidless_path, outcomes_path)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate production charts from run data")
+    parser.add_argument("--run-dir", required=True, help="Path to experiment run directory")
+    parser.add_argument("--output-dir", required=True, help="Output directory for PNGs")
+    parser.add_argument(
+        "--suite",
+        choices=AVAILABLE_SUITES,
+        default="all",
+        help="Which chart suite to generate (default: all)",
+    )
+    parser.add_argument("--dpi", type=int, default=150, help="Output resolution (default: 150)")
+    args = parser.parse_args()
+
+    run_dir = Path(args.run_dir)
+    if not run_dir.exists():
+        print(f"ERROR: Run directory not found: {run_dir}")
+        sys.exit(1)
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    all_paths = []
+    suites = AVAILABLE_SUITES[:-1] if args.suite == "all" else [args.suite]
+
+    for suite in suites:
+        print(f"Generating {suite} charts...")
+
+        if suite == "feature_health":
+            df = _load_bidless_features(run_dir)
+            # Flatten struct columns if present
+            if "hand_features" in df.columns:
+                features = pd.json_normalize(df["hand_features"].tolist())
+                df = pd.concat([df.drop(columns=["hand_features"]), features], axis=1)
+            suite_dir = str(output_dir / suite)
+            paths = generate_feature_health_charts(df, suite_dir, dpi=args.dpi)
+
+        elif suite == "feature_outcome":
+            df = _load_features_with_outcomes(run_dir)
+            suite_dir = str(output_dir / suite)
+            paths = generate_feature_outcome_charts(df, suite_dir, dpi=args.dpi)
+
+        elif suite == "distribution":
+            df = _load_features_with_outcomes(run_dir)
+            suite_dir = str(output_dir / suite)
+            paths = generate_distribution_charts(df, suite_dir, dpi=args.dpi)
+
+        else:
+            print(f"  Unknown suite: {suite}")
+            continue
+
+        all_paths.extend(paths)
+        print(f"  Generated {len(paths)} chart(s)")
+
+    # Write manifest
+    manifest_path = output_dir / "manifest.json"
+    with open(manifest_path, "w") as f:
+        json.dump({"charts": all_paths, "run_dir": str(run_dir)}, f, indent=2)
+
+    print(f"\nTotal: {len(all_paths)} chart(s) generated")
+    print(f"Manifest: {manifest_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bid_euchre/reporting/charts.py
+++ b/src/bid_euchre/reporting/charts.py
@@ -1,0 +1,230 @@
+"""Production chart generators for reporting.
+
+Wraps diagnostic chart functions to save PNGs and return manifests.
+Each generator takes a run directory, saves charts to output_dir,
+and returns a list of generated file paths.
+
+Boundary:
+- diagnostics/ = exploratory, returns Figure objects, notebook-facing
+- reporting/ = production, saves PNGs, returns manifests, CLI-runnable
+"""
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from ..diagnostics.charts import (
+    plot_ccdf,
+    plot_cdf,
+    plot_feature_correlation,
+    plot_feature_distributions,
+    plot_feature_outcome_correlation,
+    plot_feature_vs_outcome,
+    plot_hand_value_by_contract,
+    plot_hand_value_by_seat,
+    plot_outcome_distributions,
+)
+from ..diagnostics.strategy_charts import (
+    plot_matchup_summary,
+    plot_self_play_control,
+    plot_strategy_delta_bars,
+    plot_tricks_distribution_comparison,
+    plot_win_rate_heatmap,
+)
+
+
+def _save_figure(fig: plt.Figure, output_dir: Path, name: str, dpi: int = 150) -> str:
+    """Save a figure and close it. Returns the output path."""
+    path = output_dir / f"{name}.png"
+    fig.savefig(str(path), dpi=dpi, bbox_inches="tight")
+    plt.close(fig)
+    return str(path)
+
+
+def generate_feature_health_charts(
+    df: pd.DataFrame,
+    output_dir: str,
+    top_features: int = 9,
+    dpi: int = 150,
+) -> List[str]:
+    """Generate feature health check charts.
+
+    Produces:
+    - hand_value_by_seat.png
+    - hand_value_by_contract.png
+    - feature_distributions.png
+    - feature_correlation.png
+
+    Args:
+        df: DataFrame with hand features (from bidless.parquet).
+        output_dir: Directory to save PNGs.
+        top_features: Number of features for distribution grid.
+        dpi: Output resolution.
+
+    Returns:
+        List of generated file paths.
+    """
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    paths = []
+
+    fig = plot_hand_value_by_seat(df)
+    paths.append(_save_figure(fig, out, "hand_value_by_seat", dpi))
+
+    fig = plot_hand_value_by_contract(df)
+    paths.append(_save_figure(fig, out, "hand_value_by_contract", dpi))
+
+    # Select top features by variance for distributions
+    numeric_cols = df.select_dtypes(include="number").columns.tolist()
+    feature_cols = [c for c in numeric_cols if c not in ("seat", "deal_id", "hand_id")]
+    if feature_cols:
+        variances = df[feature_cols].var().sort_values(ascending=False)
+        top = variances.head(top_features).index.tolist()
+        fig = plot_feature_distributions(df, features=top)
+        paths.append(_save_figure(fig, out, "feature_distributions", dpi))
+
+        fig = plot_feature_correlation(df, features=top)
+        paths.append(_save_figure(fig, out, "feature_correlation", dpi))
+
+    return paths
+
+
+def generate_strategy_matchup_charts(
+    matchup_results: Dict[Tuple[str, str], Dict[str, Any]],
+    output_dir: str,
+    dpi: int = 150,
+) -> List[str]:
+    """Generate strategy comparison charts.
+
+    Produces:
+    - win_rate_heatmap.png
+    - tricks_distribution.png
+    - matchup_summary.png
+    - strategy_delta_bars.png
+    - self_play_control.png
+
+    Args:
+        matchup_results: Dict mapping (team0, team1) to result dicts.
+            Each result dict should have 'win_rate', 'mean_tricks_team0', etc.
+        output_dir: Directory to save PNGs.
+        dpi: Output resolution.
+
+    Returns:
+        List of generated file paths.
+    """
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    paths = []
+
+    fig = plot_win_rate_heatmap(matchup_results)
+    paths.append(_save_figure(fig, out, "win_rate_heatmap", dpi))
+
+    fig = plot_tricks_distribution_comparison(matchup_results)
+    paths.append(_save_figure(fig, out, "tricks_distribution", dpi))
+
+    fig = plot_matchup_summary(matchup_results)
+    paths.append(_save_figure(fig, out, "matchup_summary", dpi))
+
+    fig = plot_strategy_delta_bars(matchup_results)
+    paths.append(_save_figure(fig, out, "strategy_delta_bars", dpi))
+
+    fig = plot_self_play_control(matchup_results)
+    paths.append(_save_figure(fig, out, "self_play_control", dpi))
+
+    return paths
+
+
+def generate_feature_outcome_charts(
+    df: pd.DataFrame,
+    output_dir: str,
+    outcome_col: str = "tricks_won",
+    top_n: int = 10,
+    dpi: int = 150,
+) -> List[str]:
+    """Generate feature-outcome relationship charts.
+
+    Produces:
+    - feature_vs_outcome.png (top feature scatter)
+    - feature_outcome_correlation.png
+    - outcome_distributions.png
+
+    Args:
+        df: DataFrame with features and outcome column.
+        output_dir: Directory to save PNGs.
+        outcome_col: Name of the outcome column.
+        top_n: Number of top features for correlation chart.
+        dpi: Output resolution.
+
+    Returns:
+        List of generated file paths.
+    """
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    paths = []
+
+    # Identify feature columns
+    feature_cols = [c for c in df.columns if c.startswith("feat_") or c == "hand_value"]
+    if not feature_cols:
+        # Try numeric columns excluding metadata
+        skip = {"seat", "deal_id", "hand_id", outcome_col, "contract_type", "trump", "trump_suit"}
+        feature_cols = [c for c in df.select_dtypes(include="number").columns if c not in skip]
+
+    if feature_cols and outcome_col in df.columns:
+        # Correlation bar chart
+        fig = plot_feature_outcome_correlation(
+            df, outcome=outcome_col, features=feature_cols, top_n=top_n,
+        )
+        paths.append(_save_figure(fig, out, "feature_outcome_correlation", dpi))
+
+        # Top feature scatter
+        correlations = df[feature_cols].corrwith(df[outcome_col]).abs().sort_values(ascending=False)
+        top_feature = correlations.index[0] if len(correlations) > 0 else feature_cols[0]
+        fig = plot_feature_vs_outcome(df, feature=top_feature, outcome=outcome_col)
+        paths.append(_save_figure(fig, out, "feature_vs_outcome", dpi))
+
+    if outcome_col in df.columns and "contract_type" in df.columns:
+        fig = plot_outcome_distributions(df, outcome=outcome_col, group_by="contract_type")
+        paths.append(_save_figure(fig, out, "outcome_distributions", dpi))
+
+    return paths
+
+
+def generate_distribution_charts(
+    df: pd.DataFrame,
+    output_dir: str,
+    value_col: str = "tricks_won",
+    group_col: Optional[str] = "contract_type",
+    dpi: int = 150,
+) -> List[str]:
+    """Generate distribution analysis charts (CDF/CCDF).
+
+    Produces:
+    - cdf.png
+    - ccdf.png
+
+    Args:
+        df: DataFrame with value column.
+        output_dir: Directory to save PNGs.
+        value_col: Column to plot distributions for.
+        group_col: Optional grouping column.
+        dpi: Output resolution.
+
+    Returns:
+        List of generated file paths.
+    """
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    paths = []
+
+    if value_col not in df.columns:
+        return paths
+
+    fig = plot_cdf(df, column=value_col, group_by=group_col)
+    paths.append(_save_figure(fig, out, "cdf", dpi))
+
+    fig = plot_ccdf(df, column=value_col, group_by=group_col)
+    paths.append(_save_figure(fig, out, "ccdf", dpi))
+
+    return paths

--- a/tests/unit/test_chart_generators.py
+++ b/tests/unit/test_chart_generators.py
@@ -1,0 +1,121 @@
+"""Unit tests for production chart generators."""
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from bid_euchre.reporting.charts import (
+    generate_distribution_charts,
+    generate_feature_health_charts,
+    generate_feature_outcome_charts,
+)
+
+
+@pytest.fixture
+def feature_df():
+    """Minimal DataFrame with hand features."""
+    rng = np.random.RandomState(42)
+    n = 200
+    return pd.DataFrame({
+        "hand_value": rng.uniform(0, 10, n),
+        "seat": np.tile([0, 1, 2, 3], n // 4),
+        "contract_type": np.tile(["suit", "high"], n // 2),
+        "trump_count": rng.randint(0, 6, n),
+        "bowers": rng.randint(0, 3, n),
+        "offsuit_aces": rng.randint(0, 5, n),
+        "offsuit_tens_count": rng.randint(0, 5, n),
+    })
+
+
+@pytest.fixture
+def feature_outcome_df(feature_df):
+    """DataFrame with features and tricks_won outcome."""
+    rng = np.random.RandomState(42)
+    df = feature_df.copy()
+    df["tricks_won"] = rng.randint(0, 11, len(df))
+    return df
+
+
+class TestFeatureHealthCharts:
+    """Test feature health chart generation."""
+
+    def test_generates_pngs(self, feature_df):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = generate_feature_health_charts(feature_df, tmpdir)
+            assert len(paths) >= 2  # At minimum seat + contract charts
+            for p in paths:
+                assert Path(p).exists()
+                assert p.endswith(".png")
+
+    def test_creates_output_dir(self, feature_df):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nested = str(Path(tmpdir) / "sub" / "charts")
+            paths = generate_feature_health_charts(feature_df, nested)
+            assert len(paths) >= 2
+            assert Path(nested).exists()
+
+
+class TestFeatureOutcomeCharts:
+    """Test feature-outcome chart generation."""
+
+    def test_generates_pngs(self, feature_outcome_df):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = generate_feature_outcome_charts(feature_outcome_df, tmpdir)
+            assert len(paths) >= 1
+            for p in paths:
+                assert Path(p).exists()
+
+    def test_empty_features(self):
+        """Handles DataFrames with no feature columns gracefully."""
+        df = pd.DataFrame({"tricks_won": [5, 6, 7], "contract_type": ["suit"] * 3})
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = generate_feature_outcome_charts(df, tmpdir)
+            # Should still generate outcome_distributions at minimum
+            assert len(paths) >= 1
+
+
+class TestDistributionCharts:
+    """Test CDF/CCDF chart generation."""
+
+    def test_generates_cdf_ccdf(self, feature_outcome_df):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = generate_distribution_charts(feature_outcome_df, tmpdir)
+            assert len(paths) == 2
+            names = [Path(p).stem for p in paths]
+            assert "cdf" in names
+            assert "ccdf" in names
+
+    def test_missing_column_returns_empty(self):
+        df = pd.DataFrame({"other": [1, 2, 3]})
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = generate_distribution_charts(df, tmpdir)
+            assert len(paths) == 0
+
+
+class TestChartRunnerCLI:
+    """Smoke tests for the chart_runner CLI."""
+
+    def test_help_flag(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "bid_euchre.reporting.chart_runner", "--help"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert "--run-dir" in result.stdout
+        assert "--suite" in result.stdout
+
+    def test_missing_run_dir(self):
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "bid_euchre.reporting.chart_runner",
+                "--run-dir", "/nonexistent/path",
+                "--output-dir", "/tmp/test_charts",
+            ],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 1


### PR DESCRIPTION
## Summary

- Add `reporting/charts.py` with 4 production chart generators wrapping diagnostic chart functions
- Add `reporting/chart_runner.py` CLI for batch chart generation from run directories
- 8 new tests covering all generators + CLI smoke tests

## Why

Diagnostic chart functions (in `diagnostics/`) return Figure objects for notebook use. Production reporting needs PNG-saving wrappers with manifests. This promotes the chart pipeline to first-class CLI-runnable status.

## Chart Generators

| Generator | Charts | Source |
|-----------|--------|--------|
| `generate_feature_health_charts` | seat, contract, distributions, correlation | `diagnostics/charts.py` |
| `generate_strategy_matchup_charts` | heatmap, tricks, summary, delta, control | `diagnostics/strategy_charts.py` |
| `generate_feature_outcome_charts` | correlation bar, scatter, outcome dist | `diagnostics/charts.py` |
| `generate_distribution_charts` | CDF, CCDF | `diagnostics/charts.py` |

## Design Decision: No `__init__.py` re-export

Charts are imported from `bid_euchre.reporting.charts` directly (not re-exported from `reporting/__init__.py`) to avoid circular import: `reporting.__init__` → `reporting.charts` → `diagnostics.charts` → `reporting.style` → back to `reporting.__init__`.

## Repro / Validation

```bash
# Generate charts from canonical data
uv run python -m bid_euchre.reporting.chart_runner \
    --run-dir data/runs/canonical_bidless_dataset_greedy_42_20260204_221121 \
    --output-dir /tmp/charts/ --suite feature_health

make check  # 909 passed
```

## Tests

```bash
make check  # repo-lint + ruff + pytest + notebook-check all pass
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr3-charts
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr3-charts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)