### PR TITLE
fix(reporting): Fix strategy matchup chart signatures + add CLI suite

### DIFF
--- a/src/bid_euchre/reporting/chart_runner.py
+++ b/src/bid_euchre/reporting/chart_runner.py
@@ -18,9 +18,10 @@ from .charts import (
     generate_distribution_charts,
     generate_feature_health_charts,
     generate_feature_outcome_charts,
+    generate_strategy_matchup_charts,
 )
 
-AVAILABLE_SUITES = ["feature_health", "feature_outcome", "distribution", "all"]
+AVAILABLE_SUITES = ["feature_health", "feature_outcome", "distribution", "strategy_matchup", "all"]
 
 
 def _load_bidless_features(run_dir: Path) -> pd.DataFrame:
@@ -44,6 +45,73 @@ def _load_features_with_outcomes(run_dir: Path) -> pd.DataFrame:
         raise FileNotFoundError(f"Missing: {outcomes_path}")
 
     return join_features_outcomes(bidless_path, outcomes_path)
+
+
+def _load_matchup_results(run_dir: Path) -> dict:
+    """Load strategy matchup results from a matrix run directory.
+
+    Reads results/<team0>_vs_<team1>/*.json and aggregates into
+    Dict[(team0, team1), Dict] suitable for generate_strategy_matchup_charts.
+
+    Returns empty dict if the run is not a matrix run.
+    """
+    results_dir = run_dir / "results"
+    if not results_dir.exists():
+        return {}
+
+    matchup_results = {}
+    for matchup_dir in sorted(results_dir.iterdir()):
+        if not matchup_dir.is_dir():
+            continue
+        name = matchup_dir.name
+        if "_vs_" not in name:
+            continue
+
+        team0, team1 = name.split("_vs_", maxsplit=1)
+
+        # Aggregate scenario JSONs in this matchup directory
+        scenario_files = sorted(matchup_dir.glob("*.json"))
+        if not scenario_files:
+            continue
+
+        total_deals = 0
+        weighted_win_rate = 0.0
+        weighted_mean_t0 = 0.0
+        weighted_mean_t1 = 0.0
+        all_tricks_t0 = []
+
+        for sf in scenario_files:
+            with open(sf) as f:
+                data = json.load(f)
+            n = data.get("deals", data.get("hands", 0))
+            if n == 0:
+                continue
+            total_deals += n
+            weighted_win_rate += data.get("win_rate_team0", 0) * n
+            weighted_mean_t0 += data.get("avg_team0", data.get("mean_tricks_team0", 0)) * n
+            weighted_mean_t1 += data.get("avg_team1", data.get("mean_tricks_team1", 0)) * n
+
+            # Reconstruct trick list from distribution histogram if available
+            dist = data.get("distribution_team0", {})
+            for k_str, count in dist.items():
+                all_tricks_t0.extend([int(k_str)] * count)
+
+        if total_deals == 0:
+            continue
+
+        result = {
+            "win_rate": weighted_win_rate / total_deals,
+            "mean_tricks_team0": weighted_mean_t0 / total_deals,
+            "mean_tricks_team1": weighted_mean_t1 / total_deals,
+            "mean_tricks": weighted_mean_t0 / total_deals,
+            "deals": total_deals,
+        }
+        if all_tricks_t0:
+            result["tricks_team0"] = all_tricks_t0
+
+        matchup_results[(team0, team1)] = result
+
+    return matchup_results
 
 
 def main():
@@ -91,6 +159,14 @@ def main():
             df = _load_features_with_outcomes(run_dir)
             suite_dir = str(output_dir / suite)
             paths = generate_distribution_charts(df, suite_dir, dpi=args.dpi)
+
+        elif suite == "strategy_matchup":
+            matchup_results = _load_matchup_results(run_dir)
+            if not matchup_results:
+                print("  Skipping strategy_matchup: no matchup data found in results/")
+                continue
+            suite_dir = str(output_dir / suite)
+            paths = generate_strategy_matchup_charts(matchup_results, suite_dir, dpi=args.dpi)
 
         else:
             print(f"  Unknown suite: {suite}")

--- a/src/bid_euchre/reporting/charts.py
+++ b/src/bid_euchre/reporting/charts.py
@@ -94,6 +94,7 @@ def generate_feature_health_charts(
 def generate_strategy_matchup_charts(
     matchup_results: Dict[Tuple[str, str], Dict[str, Any]],
     output_dir: str,
+    baseline_name: Optional[str] = None,
     dpi: int = 150,
 ) -> List[str]:
     """Generate strategy comparison charts.
@@ -102,13 +103,15 @@ def generate_strategy_matchup_charts(
     - win_rate_heatmap.png
     - tricks_distribution.png
     - matchup_summary.png
-    - strategy_delta_bars.png
-    - self_play_control.png
+    - strategy_delta_bars.png (if baseline available)
+    - self_play_control.png (if self-play data available)
 
     Args:
         matchup_results: Dict mapping (team0, team1) to result dicts.
             Each result dict should have 'win_rate', 'mean_tricks_team0', etc.
         output_dir: Directory to save PNGs.
+        baseline_name: Strategy name to use as baseline for delta bars.
+            If None, auto-detects first strategy with self-play entry.
         dpi: Output resolution.
 
     Returns:
@@ -127,11 +130,35 @@ def generate_strategy_matchup_charts(
     fig = plot_matchup_summary(matchup_results)
     paths.append(_save_figure(fig, out, "matchup_summary", dpi))
 
-    fig = plot_strategy_delta_bars(matchup_results)
-    paths.append(_save_figure(fig, out, "strategy_delta_bars", dpi))
+    # Extract self-play entries: {strategy_name: result}
+    self_play = {
+        team0: result
+        for (team0, team1), result in matchup_results.items()
+        if team0 == team1
+    }
 
-    fig = plot_self_play_control(matchup_results)
-    paths.append(_save_figure(fig, out, "self_play_control", dpi))
+    # Delta bars: need a baseline strategy and cross-play comparison results
+    if baseline_name is None:
+        # Auto-detect: use first strategy that has a self-play entry
+        baseline_name = next(iter(self_play), None)
+
+    if baseline_name and baseline_name in self_play:
+        baseline_results = self_play[baseline_name]
+        comparison_results = {
+            team0: result
+            for (team0, team1), result in matchup_results.items()
+            if team1 == baseline_name and team0 != baseline_name
+        }
+        if comparison_results:
+            fig = plot_strategy_delta_bars(
+                baseline_results, comparison_results, baseline_name=baseline_name,
+            )
+            paths.append(_save_figure(fig, out, "strategy_delta_bars", dpi))
+
+    # Self-play control chart
+    if self_play:
+        fig = plot_self_play_control(self_play)
+        paths.append(_save_figure(fig, out, "self_play_control", dpi))
 
     return paths
 

--- a/tests/unit/test_chart_generators.py
+++ b/tests/unit/test_chart_generators.py
@@ -13,6 +13,7 @@ from bid_euchre.reporting.charts import (
     generate_distribution_charts,
     generate_feature_health_charts,
     generate_feature_outcome_charts,
+    generate_strategy_matchup_charts,
 )
 
 
@@ -95,6 +96,65 @@ class TestDistributionCharts:
         with tempfile.TemporaryDirectory() as tmpdir:
             paths = generate_distribution_charts(df, tmpdir)
             assert len(paths) == 0
+
+
+@pytest.fixture
+def matchup_results():
+    """Minimal matchup results dict for strategy charts."""
+    rng = np.random.RandomState(42)
+    strategies = ["greedy", "random"]
+    results = {}
+    for t0 in strategies:
+        for t1 in strategies:
+            tricks = rng.randint(0, 11, 50).tolist()
+            results[(t0, t1)] = {
+                "win_rate": rng.uniform(0.3, 0.7),
+                "mean_tricks_team0": np.mean(tricks),
+                "mean_tricks_team1": 10 - np.mean(tricks),
+                "mean_tricks": np.mean(tricks),
+                "tricks_team0": tricks,
+                "deals": 50,
+            }
+    return results
+
+
+class TestStrategyMatchupCharts:
+    """Test strategy matchup chart generation."""
+
+    def test_generates_pngs(self, matchup_results):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = generate_strategy_matchup_charts(matchup_results, tmpdir)
+            assert len(paths) >= 3  # heatmap + tricks_distribution + matchup_summary
+            for p in paths:
+                assert Path(p).exists()
+                assert p.endswith(".png")
+
+    def test_includes_delta_bars_and_self_play(self, matchup_results):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = generate_strategy_matchup_charts(
+                matchup_results, tmpdir, baseline_name="random",
+            )
+            names = [Path(p).stem for p in paths]
+            assert "win_rate_heatmap" in names
+            assert "matchup_summary" in names
+            assert "self_play_control" in names
+            assert "strategy_delta_bars" in names
+
+    def test_no_self_play_skips_gracefully(self):
+        """Handles matchup results with no self-play entries."""
+        results = {
+            ("greedy", "random"): {
+                "win_rate": 0.6,
+                "mean_tricks_team0": 5.5,
+                "mean_tricks_team1": 4.5,
+                "mean_tricks": 5.5,
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = generate_strategy_matchup_charts(results, tmpdir)
+            assert len(paths) >= 2  # heatmap + tricks_distribution at minimum
+            names = [Path(p).stem for p in paths]
+            assert "self_play_control" not in names
 
 
 class TestChartRunnerCLI:


### PR DESCRIPTION
## Summary
- Fix `generate_strategy_matchup_charts` to correctly call `plot_strategy_delta_bars` and `plot_self_play_control` with proper signatures
- Add optional `baseline_name` parameter for delta bar baseline selection
- Add `strategy_matchup` suite to `chart_runner.py` CLI with `_load_matchup_results` loader
- Add 3 new tests for strategy matchup chart generation

## Why
Post-review finding #3: `generate_strategy_matchup_charts` had broken calls:
- `plot_strategy_delta_bars(matchup_results)` — wrong signature (needs `baseline_results, comparison_results, baseline_name`)
- `plot_self_play_control(matchup_results)` — wrong type (`Dict[Tuple, Dict]` but needs `Dict[str, Dict]`)

The chart runner also lacked a `strategy_matchup` suite entry.

## Repro / Validation
```bash
make check
uv run python -m pytest tests/unit/test_chart_generators.py -v
```

## Tests
- `make lint` — passes
- `make test` — 912 passed (3 new), 5 skipped

## Expected impact
- No metrics impact
- Fixes previously broken chart generation path

## Risk level
- [x] Medium (reporting module)

## Worktree proof
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-charts
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-charts
```

`git worktree list` (relevant entry):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-charts  codex/chart-runner-strategy-suite
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] Behavior changes have matching tests
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)