### PR TITLE
fix(config): Add pythonpath to pytest.ini for standalone test runs

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+pythonpath = . src
 testpaths = tests
 python_files = test_*.py
 python_classes = Test*

--- a/src/bid_euchre/reporting/__init__.py
+++ b/src/bid_euchre/reporting/__init__.py
@@ -68,6 +68,8 @@ __all__ = [
     "OutcomeStats",
     "compute_outcome_stats",
     "outcome_rates_with_ci",
+    # Charts — import directly: from bid_euchre.reporting.charts import ...
+    # (not re-exported here to avoid circular import with diagnostics.charts)
     # Validation
     "generate_validation_plots",
     "plot_feature_distributions",


### PR DESCRIPTION
## Summary
- Add `pythonpath = . src` to `pytest.ini` so standalone `uv run pytest` resolves `scripts.*` imports
- Document in `reporting/__init__.py` why chart generators can't be re-exported (circular import)

## Why
Bare `uv run pytest tests/unit/test_auction_comparator.py` failed because `.` wasn't on `sys.path`. The Makefile sets `PYTHONPATH=.:src` but standalone pytest doesn't get that. Adding `pythonpath` to `pytest.ini` fixes all 4 affected test files (`test_auction_comparator.py`, `test_validate_teacher_roster.py`, `test_repo_linter.py`, `test_suite_aggregation.py`).

The plan originally included re-exporting chart generators from `reporting/__init__.py`, but this triggers a circular import: `reporting/__init__` → `reporting.charts` → `diagnostics.charts` → `reporting.style` (via `reporting.__init__`). Added a comment documenting this constraint instead.

## Repro / Validation
```bash
# Previously failed, now passes:
uv run pytest tests/unit/test_auction_comparator.py -v

# Full gate:
make check
```

## Tests
- [x] `make check` passes (914 tests, ruff clean, notebook-check clean)
- [x] Standalone `uv run pytest tests/unit/test_auction_comparator.py` passes

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (config/docs only)

## Worktree proof
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-import-hygiene
```
`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-import-hygiene
```
`git branch --show-current`:
```
codex/import-export-hygiene
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)