### PR TITLE
fix(notebook): Move CANONICAL_MODE guard to own cell in notebook 20

### DIFF
--- a/notebooks/phase0_bidless/20_outcome_health_checks.ipynb
+++ b/notebooks/phase0_bidless/20_outcome_health_checks.ipynb
@@ -95,9 +95,19 @@
     "print(f\"  Trumps (suit contracts): {TRUMPS_FOR_SUIT_CONTRACTS}\")\n",
     "print(f\"  Seats: {SEATS}\")\n",
     "print(f\"  Strategies: {[s['name'] for s in STRATEGIES]}\")\n",
-    "print(f\"  Plot downsampling: {DOWNSAMPLE_PLOTS} (max {PLOT_MAX_ROWS} rows)\")\n",
-    "\n",
+    "print(f\"  Plot downsampling: {DOWNSAMPLE_PLOTS} (max {PLOT_MAX_ROWS} rows)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# --- Hard-fail guard for CANONICAL_MODE ---\n",
+    "# This MUST be in its own cell (not the parameters cell) so that papermill's\n",
+    "# injected parameter overrides take effect before this guard runs.\n",
     "# N×N strategy matchups are NOT part of canonical run data.\n",
     "if CANONICAL_MODE:\n",
     "    raise ValueError(\n",
@@ -111,7 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -152,7 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -308,7 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +369,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -402,7 +412,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,7 +443,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "source": [
     "---\n",
@@ -447,7 +457,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -512,7 +522,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -550,7 +560,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -617,7 +627,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "source": [
     "---\n",
@@ -636,7 +646,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "### 2.1 By Contract_Type\n",
@@ -648,7 +658,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -704,7 +714,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "### 2.1.1 By Suit (suit contracts only)\n",
@@ -715,7 +725,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -778,7 +788,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "source": [
     "### 2.1.2 By High/Low\n",
@@ -789,7 +799,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -856,7 +866,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "source": [
     "### 2.2 By Team\n",
@@ -870,7 +880,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -929,7 +939,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "### 2.3 By Seat\n",
@@ -952,7 +962,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1001,7 +1011,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "### 2.4 By Contract_Type and Team\n",
@@ -1012,7 +1022,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1078,7 +1088,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "source": [
     "---\n",
@@ -1091,7 +1101,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1117,7 +1127,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "source": [
     "### 3.1 Win Rate Heatmap\n",
@@ -1128,7 +1138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1163,7 +1173,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "source": [
     "### 3.2 Mean Delta Heatmap\n",
@@ -1174,7 +1184,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1218,7 +1228,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "source": [
     "### 3.3 Distribution Grid: Team 0 Tricks\n",
@@ -1229,7 +1239,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1278,7 +1288,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "source": [
     "### 3.4 Distribution Grid: Delta Tricks\n",
@@ -1289,7 +1299,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1337,7 +1347,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "source": [
     "### 3.5 Tabular Summary"
@@ -1346,7 +1356,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1374,7 +1384,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "source": [
     "### 3.6 Strategy Sanity Tests\n",
@@ -1390,7 +1400,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1408,7 +1418,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1461,7 +1471,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1517,7 +1527,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1571,7 +1581,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1620,7 +1630,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1695,7 +1705,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1732,7 +1742,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "source": [
     "---\n",
@@ -1747,7 +1757,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "source": [
     "### 4.1 CDF by Contract Type"
@@ -1756,7 +1766,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1795,7 +1805,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "source": [
     "### 4.2 CDF by Strategy"
@@ -1804,7 +1814,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1841,7 +1851,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "source": [
     "### 4.3 CDF by Contract Type × Strategy"
@@ -1850,7 +1860,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1895,7 +1905,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "source": [
     "### 4.4 KDE Overall Distribution"
@@ -1904,7 +1914,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1954,7 +1964,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "source": [
     "### 4.5 PMF: Probability Mass Function (Percentile Plot)"
@@ -1963,7 +1973,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2085,7 +2095,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "source": [
     "### 4.6 CDF by Team (Symmetry Check)"
@@ -2094,7 +2104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2143,7 +2153,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "source": [
     "### 4.7 CCDF: Discrete Survival Function"
@@ -2152,7 +2162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2214,7 +2224,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "source": [
     "---\n",
@@ -2227,7 +2237,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2331,7 +2341,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "source": [
     "---\n",

--- a/notebooks/phase0_bidless/20_outcome_health_checks.py
+++ b/notebooks/phase0_bidless/20_outcome_health_checks.py
@@ -102,7 +102,10 @@ print(f"  Seats: {SEATS}")
 print(f"  Strategies: {[s['name'] for s in STRATEGIES]}")
 print(f"  Plot downsampling: {DOWNSAMPLE_PLOTS} (max {PLOT_MAX_ROWS} rows)")
 
+# %%
 # --- Hard-fail guard for CANONICAL_MODE ---
+# This MUST be in its own cell (not the parameters cell) so that papermill's
+# injected parameter overrides take effect before this guard runs.
 # N×N strategy matchups are NOT part of canonical run data.
 if CANONICAL_MODE:
     raise ValueError(


### PR DESCRIPTION
## Summary

- Move the `CANONICAL_MODE` hard-fail guard from inside the papermill parameters cell to its own separate cell in notebook 20

## Why

The guard was inside the `tags=["parameters"]` cell. Papermill injects parameter overrides in a **new cell after** the parameters cell, so the guard ran with the default `CANONICAL_MODE=True` before the injected `CANONICAL_MODE=False` could take effect. This caused `make notebook-run` to always fail on notebook 20.

## Repro / Validation

```bash
# Before: notebook 20 always failed
make notebook-run  # 20_outcome_health_checks FAIL

# After: all 3 notebooks pass
cd ../Bid-Euchre-fix-nb20-guard
make notebook-run  # 3 passed, 0 failed (77.3s)
make check         # 917 passed, all clean
```

## Tests

```
make check → 917 passed, 5 skipped, 1 deselected, 2 xfailed, 1 xpassed
make notebook-run → 3 passed, 0 failed
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-nb20-guard
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-nb20-guard
branch: codex/fix-nb20-guard-cell
```

## Files changed

- `notebooks/phase0_bidless/20_outcome_health_checks.py` — Move guard to own `# %%` cell
- `notebooks/phase0_bidless/20_outcome_health_checks.ipynb` — Jupytext sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)