### PR TITLE
fix(arch): Fix comparator --run-id bug + document canonical CLI contract

### DIFF
--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -38,9 +38,13 @@ Structure:
 Current scripts:
 - `compare_rollup.py` — Drift detection (compares rollup against baseline fixture)
 - `compare_runs.py` — Run comparison utility with bootstrap statistics
+- `evaluate_diagnostic_tricks.py` — Diagnostic Ridge evaluation
 - `generate_report.py` — Per-run report generator
 - `lint_repo.py` — Repository linter (enforces boundaries and data policy)
+- `play_policy_gate.py` — Play policy stability gate
+- `run_auction_comparator.py` — Auction comparator orchestrator
 - `run_bidless_diagnostics.py` — Bidless feature dataset diagnostics
+- `run_notebooks.py` — Notebook execution via papermill (CI tooling)
 - `run_suite.py` — Suite runner (batches experiments with rollup generation)
 - `run_tests.py` — Test runner utility
 - `train_bidder.py` — Bidder model training
@@ -125,6 +129,39 @@ Every experiment run creates a standardized directory under `data/runs/<run_id>/
 - `artifacts/` — Model binaries and intermediates (if generated)
 
 **Full details**: See `EXPERIMENTS.md` for complete run output structure and reproduction instructions.
+
+---
+
+## Canonical CLI Contract
+
+### Primary commands (production workflows)
+
+| Command | Purpose |
+|---------|---------|
+| `experiments/run_experiment.py` | Run experiments (seed required) |
+| `scripts/generate_report.py` | Generate per-run reports |
+| `scripts/run_suite.py` | Batch experiment runner |
+
+### Supporting tooling
+
+| Command | Purpose |
+|---------|---------|
+| `scripts/compare_runs.py` | Compare two runs with bootstrap statistics |
+| `scripts/compare_rollup.py` | Drift detection against baseline fixture |
+| `scripts/lint_repo.py` | Repository linter |
+| `scripts/run_notebooks.py` | Notebook execution via papermill (CI) |
+| `scripts/validate_configs.py` | Config validation |
+| `scripts/validate_teacher_roster.py` | Teacher roster validation |
+
+### Research/internal tooling
+
+| Command | Purpose |
+|---------|---------|
+| `scripts/run_auction_comparator.py` | Auction comparator orchestrator |
+| `scripts/evaluate_diagnostic_tricks.py` | Diagnostic Ridge evaluation |
+| `scripts/play_policy_gate.py` | Play policy stability gate |
+| `scripts/run_bidless_diagnostics.py` | Bidless diagnostics |
+| `scripts/train_bidder.py` | Bidder model training |
 
 ---
 

--- a/docs/02_agent/AI_BOUNDARIES.md
+++ b/docs/02_agent/AI_BOUNDARIES.md
@@ -84,6 +84,31 @@ make check  # Runs: repo-lint + ruff + pytest (fast suite)
 
 ---
 
+## Canonical Commands for AI Agents
+
+When running experiments and generating reports, use these exact invocation patterns:
+
+```bash
+# Run an experiment (always include --seed)
+PYTHONPATH=src python experiments/run_experiment.py \
+  --config experiments/configs/<config>.yaml --seed 42
+
+# Generate a report for a completed run
+PYTHONPATH=src python scripts/generate_report.py --run-dir data/runs/<run_id>
+
+# Run a suite of experiments
+PYTHONPATH=src python scripts/run_suite.py \
+  --suite experiments/suites/<suite>.yaml --seed 42
+
+# Compare two runs
+PYTHONPATH=src python scripts/compare_runs.py \
+  --baseline data/runs/<baseline> --candidate data/runs/<candidate> --seed 42
+```
+
+**Do not** invoke `run_experiment.py` with flags it does not support (e.g., `--run-id`). The runner auto-generates run IDs with timestamps.
+
+---
+
 ## References
 
 - **Workflow guidance**: [docs/02_agent/AGENTS.md](AGENTS.md)

--- a/scripts/run_auction_comparator.py
+++ b/scripts/run_auction_comparator.py
@@ -23,23 +23,67 @@ from pathlib import Path
 import yaml
 
 
-def run_experiment(config_path, seed, run_id, extra_args=None):
-    """Run a single experiment via the canonical runner."""
+def _detect_new_run_dir(runs_base, before_snapshot):
+    """Detect the new run directory by diffing data/runs/ before/after.
+
+    Returns the new directory path, or None if no new directory was created.
+    """
+    runs_path = Path(runs_base)
+    if not runs_path.is_dir():
+        return None
+    after_snapshot = {p.name for p in runs_path.iterdir() if p.is_dir()}
+    new_dirs = after_snapshot - before_snapshot
+    if len(new_dirs) == 1:
+        return str(runs_path / new_dirs.pop())
+    return None
+
+
+def _snapshot_runs_dir(runs_base="data/runs"):
+    """Snapshot current run directory names for before/after diffing."""
+    runs_path = Path(runs_base)
+    if not runs_path.is_dir():
+        return set()
+    return {p.name for p in runs_path.iterdir() if p.is_dir()}
+
+
+def run_experiment(config_path, seed, runs_base="data/runs", extra_args=None):
+    """Run a single experiment via the canonical runner.
+
+    Returns the detected run directory path, or None on failure.
+    The runner auto-generates run IDs with timestamps, so we detect the
+    new directory by snapshotting data/runs/ before/after.
+    """
+    before = _snapshot_runs_dir(runs_base)
+
     cmd = [
         sys.executable, "experiments/run_experiment.py",
         "--config", config_path,
         "--seed", str(seed),
-        "--run-id", run_id,
     ]
     if extra_args:
         cmd.extend(extra_args)
 
     result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:
-        print(f"FAILED: {run_id}")
+        print(f"FAILED: experiment with config {config_path}")
         print(result.stderr)
-        return False
-    return True
+        return None
+
+    # Primary: parse stdout for "Run directory: <path>"
+    for line in result.stdout.splitlines():
+        if "Run directory:" in line:
+            # Line format: "📁 Run directory: data/runs/<run_id>"
+            run_dir = line.split("Run directory:")[-1].strip()
+            if run_dir and Path(run_dir).is_dir():
+                return run_dir
+
+    # Fallback: diff data/runs/ before/after
+    detected = _detect_new_run_dir(runs_base, before)
+    if detected:
+        return detected
+
+    print("WARNING: Could not detect run directory from stdout or filesystem diff")
+    return None
 
 
 def generate_evaluation(run_dir):
@@ -163,12 +207,14 @@ def main():
 
     experiment_name = config.get("experiment_name", "auction_comparator")
 
+    # Track run directories per policy (populated during run or from --skip-run lookup)
+    run_dirs_by_policy = {}
+
     if not args.skip_run:
         # Run experiment for each bidder individually
         print(f"Running auction comparator with {len(policies)} bidders, n_per={n_per}...")
         for policy in policies:
             policy_name = policy["name"]
-            run_id = f"{experiment_name}_{policy_name}_{args.seed}"
 
             # Create a per-policy config
             per_policy_config = {
@@ -183,21 +229,38 @@ def main():
                 yaml.dump(per_policy_config, f)
 
             print(f"  Running {policy_name}...")
-            if not run_experiment(config_path, args.seed, run_id):
+            run_dir = run_experiment(config_path, args.seed)
+            if run_dir is None:
                 print(f"  FAILED: {policy_name}")
                 continue
 
-            # Generate evaluation
-            run_dir = f"data/runs/{run_id}"
+            run_dirs_by_policy[policy_name] = run_dir
             generate_evaluation(run_dir)
+    else:
+        # In --skip-run mode, scan data/runs/ for matching directories
+        runs_path = Path("data/runs")
+        if runs_path.is_dir():
+            for policy in policies:
+                policy_name = policy["name"]
+                prefix = f"{experiment_name}_{policy_name}_"
+                matches = sorted(
+                    (p for p in runs_path.iterdir() if p.is_dir() and p.name.startswith(prefix)),
+                    key=lambda p: p.name,
+                    reverse=True,
+                )
+                if matches:
+                    run_dirs_by_policy[policy_name] = str(matches[0])
 
     # Collect metrics (require evaluation.json — no silent fallback)
     metrics_by_bidder = {}
     missing_evaluations = []
     for policy in policies:
         policy_name = policy["name"]
-        run_id = f"{experiment_name}_{policy_name}_{args.seed}"
-        run_dir = f"data/runs/{run_id}"
+        run_dir = run_dirs_by_policy.get(policy_name)
+
+        if not run_dir:
+            missing_evaluations.append(policy_name)
+            continue
 
         evaluation = load_evaluation(run_dir)
         if evaluation and evaluation.get("strategies"):
@@ -217,8 +280,8 @@ def main():
     if missing_evaluations:
         print("ERROR: Missing evaluation data for the following bidders:")
         for name in missing_evaluations:
-            run_id = f"{experiment_name}_{name}_{args.seed}"
-            print(f"  - {name}  (expected at data/runs/{run_id}/reports/bidding_strategy/evaluation.json)")
+            run_dir = run_dirs_by_policy.get(name, "<no run directory found>")
+            print(f"  - {name}  (run_dir: {run_dir})")
         print("\nTo generate evaluation data, re-run without --skip-run:")
         print(f"  uv run python scripts/run_auction_comparator.py --config {args.config} --seed {args.seed}")
         sys.exit(1)

--- a/tests/unit/test_comparator_contract.py
+++ b/tests/unit/test_comparator_contract.py
@@ -1,0 +1,134 @@
+"""Tests for auction comparator contract compliance.
+
+Validates that run_auction_comparator.py:
+1. Does not pass unsupported flags to run_experiment.py
+2. Can detect new run directories via before/after snapshot diffing
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+from run_auction_comparator import (
+    _detect_new_run_dir,
+    _snapshot_runs_dir,
+    run_experiment,
+)
+
+
+def test_run_experiment_cmd_has_no_run_id_flag(tmp_path):
+    """run_experiment() must not pass --run-id to experiments/run_experiment.py."""
+    captured_cmd = []
+
+    def fake_run(cmd, **kwargs):
+        captured_cmd.extend(cmd)
+
+        class FakeResult:
+            returncode = 1
+            stderr = "fake"
+            stdout = ""
+
+        return FakeResult()
+
+    with patch("run_auction_comparator.subprocess.run", side_effect=fake_run):
+        run_experiment(str(tmp_path / "config.yaml"), 42)
+
+    assert "--run-id" not in captured_cmd, (
+        "run_experiment() must not pass --run-id to experiments/run_experiment.py. "
+        "The runner auto-generates run IDs with timestamps."
+    )
+
+
+def test_run_experiment_cmd_includes_seed(tmp_path):
+    """run_experiment() must pass --seed to experiments/run_experiment.py."""
+    captured_cmd = []
+
+    def fake_run(cmd, **kwargs):
+        captured_cmd.extend(cmd)
+
+        class FakeResult:
+            returncode = 1
+            stderr = "fake"
+            stdout = ""
+
+        return FakeResult()
+
+    with patch("run_auction_comparator.subprocess.run", side_effect=fake_run):
+        run_experiment(str(tmp_path / "config.yaml"), 42)
+
+    assert "--seed" in captured_cmd
+    seed_idx = captured_cmd.index("--seed")
+    assert captured_cmd[seed_idx + 1] == "42"
+
+
+def test_detect_new_run_dir_single_new(tmp_path):
+    """_detect_new_run_dir detects exactly one new directory."""
+    before = {"existing_run_1", "existing_run_2"}
+    # Create the "new" directory
+    (tmp_path / "new_run_abc").mkdir()
+    (tmp_path / "existing_run_1").mkdir()
+    (tmp_path / "existing_run_2").mkdir()
+
+    result = _detect_new_run_dir(str(tmp_path), before)
+    assert result == str(tmp_path / "new_run_abc")
+
+
+def test_detect_new_run_dir_no_change(tmp_path):
+    """_detect_new_run_dir returns None when no new dirs appear."""
+    (tmp_path / "existing_run").mkdir()
+    before = {"existing_run"}
+
+    result = _detect_new_run_dir(str(tmp_path), before)
+    assert result is None
+
+
+def test_detect_new_run_dir_multiple_new(tmp_path):
+    """_detect_new_run_dir returns None when multiple new dirs appear (ambiguous)."""
+    before = set()
+    (tmp_path / "run_a").mkdir()
+    (tmp_path / "run_b").mkdir()
+
+    result = _detect_new_run_dir(str(tmp_path), before)
+    assert result is None
+
+
+def test_detect_new_run_dir_nonexistent_base():
+    """_detect_new_run_dir returns None for nonexistent base directory."""
+    result = _detect_new_run_dir("/nonexistent/path", set())
+    assert result is None
+
+
+def test_snapshot_runs_dir(tmp_path):
+    """_snapshot_runs_dir captures directory names."""
+    (tmp_path / "run_1").mkdir()
+    (tmp_path / "run_2").mkdir()
+    (tmp_path / "some_file.txt").touch()  # Files should be ignored
+
+    snapshot = _snapshot_runs_dir(str(tmp_path))
+    assert snapshot == {"run_1", "run_2"}
+
+
+def test_snapshot_runs_dir_nonexistent():
+    """_snapshot_runs_dir returns empty set for nonexistent directory."""
+    snapshot = _snapshot_runs_dir("/nonexistent/path")
+    assert snapshot == set()
+
+
+def test_run_experiment_parses_stdout_for_run_dir(tmp_path):
+    """run_experiment() parses 'Run directory:' from stdout."""
+    run_dir = tmp_path / "data" / "runs" / "test_run_42_20260206"
+    run_dir.mkdir(parents=True)
+
+    def fake_run(cmd, **kwargs):
+        class FakeResult:
+            returncode = 0
+            stderr = ""
+            stdout = f"\n📁 Run directory: {run_dir}\n"
+
+        return FakeResult()
+
+    with patch("run_auction_comparator.subprocess.run", side_effect=fake_run):
+        result = run_experiment(str(tmp_path / "config.yaml"), 42)
+
+    assert result == str(run_dir)


### PR DESCRIPTION
## Summary
- Fix `scripts/run_auction_comparator.py`: remove unsupported `--run-id` flag passed to `run_experiment.py`
- Add run directory detection via stdout parsing + filesystem snapshot diffing
- Add 4 missing scripts to ARCHITECTURE.md script list
- Document canonical CLI contract (primary + supporting + research tiers) in ARCHITECTURE.md
- Add canonical command patterns for AI agents in AI_BOUNDARIES.md

## Why
The auction comparator passed `--run-id` to `run_experiment.py`, which has no such argument — causing argparse to hard-fail on every invocation. The runner auto-generates run IDs with timestamps, so callers must detect the generated directory instead of controlling it.

## Repro / Validation
```bash
make check
uv run python -m pytest tests/unit/test_comparator_contract.py -v
```

## Tests
- `make check` — full suite passes (929 passed)
- `tests/unit/test_comparator_contract.py` — 9 tests covering command construction, run dir detection, and snapshot diffing

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-arch-pr1
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-arch-pr1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)