### PR TITLE
feat(batch): Add batch intent metadata to experiment runs

### DIFF
--- a/experiments/promotion/ACTIVE_BATCH.yaml
+++ b/experiments/promotion/ACTIVE_BATCH.yaml
@@ -1,0 +1,13 @@
+# Active promotion batch pointer.
+# Only one batch may be active at a time.
+# Set batch_id to null when no batch is active.
+#
+# To start a new promotion batch:
+#   1. Set batch_id, suite_path, and created_at below
+#   2. Run the suite: scripts/run_suite.py --suite <suite_path> --batch-purpose promotion
+#   3. After promotion decision, clear batch_id back to null
+
+batch_id: null
+# batch_id: "promotion_20260210"
+# suite_path: experiments/suites/canonical_promotion.yaml
+# created_at: "2026-02-10T12:00:00Z"

--- a/experiments/run_experiment.py
+++ b/experiments/run_experiment.py
@@ -53,6 +53,7 @@ from bid_euchre.datasets.bidless_outcomes import (
     emit_bidless_outcomes_dataset,
 )
 from bid_euchre.experiments import load_config
+from bid_euchre.experiments.batch import VALID_BATCH_PURPOSES, BatchIntent
 from bid_euchre.experiments.meta import get_git_sha, sha256_file, utc_now_iso
 from bid_euchre.logging import GameLogger, LogLevel
 from bid_euchre.sim import simulation
@@ -203,6 +204,22 @@ def parse_args():
         action="store_true",
         help="Override work budget limits (use with caution)"
     )
+    parser.add_argument(
+        "--batch-id",
+        type=str,
+        help="Batch identifier (e.g. 'promotion_20260210'). Enables batch metadata in meta.json."
+    )
+    parser.add_argument(
+        "--batch-role",
+        type=str,
+        help="Role within the batch (e.g. 'dataset_greedy'). Required when --batch-id is given."
+    )
+    parser.add_argument(
+        "--batch-purpose",
+        type=str,
+        choices=sorted(VALID_BATCH_PURPOSES),
+        help="Batch purpose: promotion, regression, or exploration. Required when --batch-id is given."
+    )
     return parser.parse_args()
 
 
@@ -239,7 +256,22 @@ def format_duration(seconds: float) -> str:
 
 def main():
     args = parse_args()
-    
+
+    # Build BatchIntent if --batch-id is given
+    batch_intent: BatchIntent | None = None
+    if args.batch_id:
+        if not args.batch_role:
+            raise SystemExit("Error: --batch-role is required when --batch-id is given")
+        if not args.batch_purpose:
+            raise SystemExit("Error: --batch-purpose is required when --batch-id is given")
+        batch_intent = BatchIntent(
+            batch_id=args.batch_id,
+            batch_role=args.batch_role,
+            batch_purpose=args.batch_purpose,
+        )
+    elif args.batch_role or args.batch_purpose:
+        raise SystemExit("Error: --batch-id is required when --batch-role or --batch-purpose is given")
+
     # Load configuration
     print(f"📄 Loading configuration: {args.config}")
     config = load_config(args.config)
@@ -916,7 +948,12 @@ def main():
         "pair_deals": pair_deals,  # True = same physical deals across all scenarios
         "total_hands": total_hands,
     }
-    
+
+    # Add batch metadata when present (additive — schema stays v2)
+    if batch_intent is not None:
+        meta["intent"] = batch_intent.batch_purpose
+        meta["batch"] = batch_intent.to_dict()
+
     with open(os.path.join(run_dir, "meta.json"), "w") as f:
         json.dump(meta, f, indent=2, sort_keys=True)
     

--- a/scripts/run_suite.py
+++ b/scripts/run_suite.py
@@ -63,6 +63,17 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Print commands without executing"
     )
+    parser.add_argument(
+        "--batch-id",
+        type=str,
+        help="Batch identifier to pass to each member run"
+    )
+    parser.add_argument(
+        "--batch-purpose",
+        type=str,
+        choices=["exploration", "promotion", "regression"],
+        help="Batch purpose to pass to each member run"
+    )
     return parser.parse_args()
 
 
@@ -231,17 +242,21 @@ def run_experiment(
     seed: int,
     n_per: int,
     log_level: str,
-    run_base: Path
+    run_base: Path,
+    batch_id: str | None = None,
+    batch_role: str | None = None,
+    batch_purpose: str | None = None,
+    extra_args: list[str] | None = None,
 ) -> Path:
     """
     Run a single experiment config and return the created run directory.
-    
+
     Returns:
         Path to the created run directory
     """
     # Snapshot existing directories
     dirs_before = set(d.name for d in run_base.iterdir() if d.is_dir())
-    
+
     cmd = [
         "python",
         "experiments/run_experiment.py",
@@ -251,6 +266,16 @@ def run_experiment(
         "--log-level", log_level,
         "--run-dir", str(run_base)
     ]
+
+    # Pass batch metadata through to run_experiment
+    if batch_id:
+        cmd.extend(["--batch-id", batch_id])
+    if batch_role:
+        cmd.extend(["--batch-role", batch_role])
+    if batch_purpose:
+        cmd.extend(["--batch-purpose", batch_purpose])
+    if extra_args:
+        cmd.extend(extra_args)
     
     env = {**os.environ, "PYTHONPATH": "src"}
     
@@ -315,7 +340,9 @@ def create_suite_rollup(
     suite_path: str,
     effective_params: Dict,
     member_runs: List[Dict],
-    run_base: Path
+    run_base: Path,
+    batch_id: str | None = None,
+    batch_purpose: str | None = None,
 ) -> Path:
     """
     Create suite rollup run directory with metadata.
@@ -401,8 +428,15 @@ def create_suite_rollup(
         "suite_n_per": effective_params["n_per"],
         "created_at_utc": created_at_utc,
         "configs": member_runs,
-        "summary": summary
+        "summary": summary,
     }
+
+    # Add batch metadata to rollup when present
+    if batch_id:
+        rollup["batch"] = {
+            "batch_id": batch_id,
+            "batch_purpose": batch_purpose,
+        }
 
     with (rollup_dir / "rollup.json").open("w") as f:
         json.dump(rollup, f, indent=2, sort_keys=True)
@@ -475,19 +509,37 @@ def main():
     run_base = Path(args.run_dir)
     run_base.mkdir(parents=True, exist_ok=True)
     
+    # Resolve batch metadata
+    batch_id = args.batch_id or suite.get("batch_id")
+    batch_purpose = args.batch_purpose or suite.get("batch_purpose")
+    batch_roles = suite.get("batch_roles", {})
+    run_flags = suite.get("run_flags", {})
+
     # Run each config
     member_runs = []
-    
+
     for i, config_path in enumerate(suite["configs"], 1):
         print(f"[{i}/{len(suite['configs'])}] {config_path}")
-        
+
+        # Derive batch_role from suite's batch_roles mapping, or config filename
+        config_filename = Path(config_path).name
+        batch_role = batch_roles.get(config_filename) if batch_id else None
+
+        # Get per-config extra_args from run_flags
+        per_config_flags = run_flags.get(config_filename, {})
+        extra_args = per_config_flags.get("extra_args")
+
         try:
             run_dir = run_experiment(
                 config_path,
                 effective_params["seed"],
                 effective_params["n_per"],
                 effective_params["log_level"],
-                run_base
+                run_base,
+                batch_id=batch_id,
+                batch_role=batch_role,
+                batch_purpose=batch_purpose,
+                extra_args=extra_args,
             )
             
             # Load meta.json to get git_sha
@@ -532,7 +584,9 @@ def main():
         args.suite,
         effective_params,
         member_runs,
-        run_base
+        run_base,
+        batch_id=batch_id,
+        batch_purpose=batch_purpose,
     )
     
     print("======================================================================")

--- a/src/bid_euchre/experiments/batch.py
+++ b/src/bid_euchre/experiments/batch.py
@@ -1,0 +1,56 @@
+"""
+Batch intent metadata for promotion-track experiment runs.
+
+Provides the BatchIntent dataclass for tagging runs with batch membership,
+role, and purpose. Written into meta.json when --batch-id is given.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+VALID_BATCH_PURPOSES = frozenset({"promotion", "regression", "exploration"})
+
+
+@dataclasses.dataclass(frozen=True)
+class BatchIntent:
+    """Batch membership metadata for an experiment run.
+
+    Attributes:
+        batch_id: Unique identifier for the batch (e.g. "promotion_20260210").
+        batch_role: Role within the batch (e.g. "dataset_greedy", "outcomes_zoom").
+        batch_purpose: Purpose category: "promotion", "regression", or "exploration".
+    """
+
+    batch_id: str
+    batch_role: str
+    batch_purpose: str
+
+    def __post_init__(self) -> None:
+        if not self.batch_id:
+            raise ValueError("batch_id must be non-empty")
+        if not self.batch_role:
+            raise ValueError("batch_role must be non-empty")
+        if self.batch_purpose not in VALID_BATCH_PURPOSES:
+            raise ValueError(
+                f"batch_purpose must be one of {sorted(VALID_BATCH_PURPOSES)}, "
+                f"got {self.batch_purpose!r}"
+            )
+
+    def to_dict(self) -> dict[str, str]:
+        """Serialize to dict for inclusion in meta.json."""
+        return {
+            "batch_id": self.batch_id,
+            "batch_role": self.batch_role,
+            "batch_purpose": self.batch_purpose,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> BatchIntent:
+        """Deserialize from dict (e.g. from meta.json)."""
+        return cls(
+            batch_id=d["batch_id"],
+            batch_role=d["batch_role"],
+            batch_purpose=d["batch_purpose"],
+        )

--- a/tests/unit/test_batch_intent.py
+++ b/tests/unit/test_batch_intent.py
@@ -1,0 +1,95 @@
+"""
+Unit tests for BatchIntent dataclass and serialization.
+
+Tests:
+- Construction and validation
+- Serialization round-trip (to_dict / from_dict)
+- Backward compatibility (no batch field when flags absent)
+- Invalid purpose rejection
+"""
+
+import pytest
+
+from bid_euchre.experiments.batch import VALID_BATCH_PURPOSES, BatchIntent
+
+
+class TestBatchIntentConstruction:
+    """Test BatchIntent construction and validation."""
+
+    def test_valid_construction(self) -> None:
+        bi = BatchIntent(
+            batch_id="promotion_20260210",
+            batch_role="dataset_greedy",
+            batch_purpose="promotion",
+        )
+        assert bi.batch_id == "promotion_20260210"
+        assert bi.batch_role == "dataset_greedy"
+        assert bi.batch_purpose == "promotion"
+
+    def test_all_valid_purposes(self) -> None:
+        for purpose in VALID_BATCH_PURPOSES:
+            bi = BatchIntent(batch_id="test", batch_role="role", batch_purpose=purpose)
+            assert bi.batch_purpose == purpose
+
+    def test_empty_batch_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match="batch_id must be non-empty"):
+            BatchIntent(batch_id="", batch_role="role", batch_purpose="promotion")
+
+    def test_empty_batch_role_rejected(self) -> None:
+        with pytest.raises(ValueError, match="batch_role must be non-empty"):
+            BatchIntent(batch_id="test", batch_role="", batch_purpose="promotion")
+
+    def test_invalid_purpose_rejected(self) -> None:
+        with pytest.raises(ValueError, match="batch_purpose must be one of"):
+            BatchIntent(batch_id="test", batch_role="role", batch_purpose="invalid")
+
+    def test_frozen(self) -> None:
+        bi = BatchIntent(batch_id="test", batch_role="role", batch_purpose="promotion")
+        with pytest.raises(AttributeError):
+            bi.batch_id = "changed"  # type: ignore[misc]
+
+
+class TestBatchIntentSerialization:
+    """Test to_dict / from_dict round-trip."""
+
+    def test_round_trip(self) -> None:
+        original = BatchIntent(
+            batch_id="promo_42",
+            batch_role="dataset_glutton",
+            batch_purpose="regression",
+        )
+        d = original.to_dict()
+        restored = BatchIntent.from_dict(d)
+        assert restored == original
+
+    def test_to_dict_keys(self) -> None:
+        bi = BatchIntent(
+            batch_id="test", batch_role="role", batch_purpose="exploration"
+        )
+        d = bi.to_dict()
+        assert set(d.keys()) == {"batch_id", "batch_role", "batch_purpose"}
+
+    def test_from_dict_with_extra_keys(self) -> None:
+        """Extra keys in dict should be ignored (forward compat)."""
+        d = {
+            "batch_id": "test",
+            "batch_role": "role",
+            "batch_purpose": "promotion",
+            "extra_field": "ignored",
+        }
+        bi = BatchIntent.from_dict(d)
+        assert bi.batch_id == "test"
+
+    def test_from_dict_missing_key(self) -> None:
+        with pytest.raises(KeyError):
+            BatchIntent.from_dict({"batch_id": "test", "batch_role": "role"})
+
+
+class TestValidBatchPurposes:
+    """Test the VALID_BATCH_PURPOSES constant."""
+
+    def test_expected_values(self) -> None:
+        assert VALID_BATCH_PURPOSES == {"promotion", "regression", "exploration"}
+
+    def test_is_frozenset(self) -> None:
+        assert isinstance(VALID_BATCH_PURPOSES, frozenset)


### PR DESCRIPTION
## Summary
- Add `BatchIntent` dataclass in `src/bid_euchre/experiments/batch.py` for tagging runs with batch membership, role, and purpose
- Add `--batch-id`, `--batch-role`, `--batch-purpose` CLI flags to `run_experiment.py`; writes `batch` + `intent` fields into `meta.json` when present
- Add `--batch-id`, `--batch-purpose` to `run_suite.py`; passes batch metadata through to member runs and includes in `rollup.json`
- Create `experiments/promotion/ACTIVE_BATCH.yaml` as the active batch pointer (initially null)

## Why
Foundation for hardened canonical promotion workflow. Makes batch membership machine-readable from artifacts alone.

## Repro / Validation
```bash
# Dry-run with batch flags
PYTHONPATH=src uv run python experiments/run_experiment.py \
  --seed 42 --config experiments/configs/quick_test.yaml --n_per 10 \
  --batch-id test --batch-role quick --batch-purpose exploration --dry-run

# Full run to verify meta.json
PYTHONPATH=src uv run python experiments/run_experiment.py \
  --seed 42 --config experiments/configs/quick_test.yaml --n_per 10 \
  --batch-id test --batch-role quick --batch-purpose exploration \
  --run-dir /tmp/batch_test
# Check: cat /tmp/batch_test/*/meta.json | python -c "import json,sys; m=json.load(sys.stdin); print(m['batch'], m['intent'])"
```

## Tests
```bash
make check  # All pass
uv run python -m pytest tests/unit/test_batch_intent.py -v  # 12 tests
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-batch-intent
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-batch-intent
```

## Scope
- New: `src/bid_euchre/experiments/batch.py`, `experiments/promotion/ACTIVE_BATCH.yaml`, `tests/unit/test_batch_intent.py`
- Modified: `experiments/run_experiment.py`, `scripts/run_suite.py`
- Backward compatible: no batch fields emitted unless CLI flags are given; schema stays v2