### PR TITLE
feat: Add notebook gate artifacts to run_notebooks.py

### DIFF
--- a/scripts/run_notebooks.py
+++ b/scripts/run_notebooks.py
@@ -21,10 +21,16 @@ load_or_generate_features() will pick up the injected MODE automatically.
 
 import argparse
 import glob
+import json
+import os
 import sys
 import tempfile
 import time
 from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from bid_euchre.experiments.meta import get_git_sha, utc_now_iso
 
 
 def discover_notebooks(pattern: str = "notebooks/phase0_bidless/*.ipynb") -> list[Path]:
@@ -93,6 +99,74 @@ def execute_notebook(
         return False, str(e)[:200], duration
 
 
+def write_gate_artifacts(
+    gate_dir: Path,
+    mode: str,
+    results: list[tuple[str, bool, str, float]],
+) -> dict:
+    """Write notebook gate JSON and markdown artifacts.
+
+    Args:
+        gate_dir: Directory to write artifacts to.
+        mode: Execution mode ("smoke" or "quick").
+        results: List of (name, success, message, duration) tuples.
+
+    Returns:
+        The gate dict that was written.
+    """
+    gate_dir.mkdir(parents=True, exist_ok=True)
+
+    passed = sum(1 for _, success, _, _ in results if success)
+    failed = sum(1 for _, success, _, _ in results if not success)
+
+    notebooks_data = []
+    for name, success, message, duration in results:
+        notebooks_data.append({
+            "name": name,
+            "status": "PASS" if success else "FAIL",
+            "duration_sec": round(duration, 2),
+            "error": None if success else message,
+        })
+
+    overall_status = "PASS" if failed == 0 else "FAIL"
+
+    gate = {
+        "gate_type": "notebook_execution",
+        "gate_version": 1,
+        "mode": mode,
+        "timestamp_utc": utc_now_iso(),
+        "git_sha": get_git_sha(),
+        "notebooks": notebooks_data,
+        "overall_status": overall_status,
+        "pass_count": passed,
+        "fail_count": failed,
+    }
+
+    gate_path = gate_dir / "notebook_gate.json"
+    with gate_path.open("w") as f:
+        json.dump(gate, f, indent=2)
+
+    md_path = gate_dir / "NOTEBOOK_GATE.md"
+    with md_path.open("w") as f:
+        f.write("# Notebook Execution Gate\n\n")
+        f.write(f"**Mode**: {mode.upper()}\n\n")
+        f.write(f"**Overall**: {overall_status}\n\n")
+        f.write(f"**Timestamp**: {gate['timestamp_utc']}\n\n")
+        f.write(f"**Git SHA**: {gate['git_sha']}\n\n")
+        f.write("## Results\n\n")
+        f.write("| Notebook | Status | Duration | Error |\n")
+        f.write("|----------|--------|----------|-------|\n")
+        for nb in notebooks_data:
+            error_str = (nb["error"] or "").replace("|", "\\|").replace("\n", " ")
+            f.write(
+                f"| {nb['name']} | {nb['status']} "
+                f"| {nb['duration_sec']:.1f}s | {error_str} |\n"
+            )
+        f.write(f"\n**Total**: {passed} passed, {failed} failed\n")
+
+    return gate
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Execute notebooks for validation",
@@ -114,6 +188,11 @@ def main():
         "--keep-outputs",
         action="store_true",
         help="Keep executed notebook outputs (default: use temp dir)",
+    )
+    parser.add_argument(
+        "--gate-output-dir",
+        type=str,
+        help="Directory to write notebook_gate.json and NOTEBOOK_GATE.md artifacts",
     )
     args = parser.parse_args()
 
@@ -172,6 +251,14 @@ def main():
         print(f"Output notebooks: {output_dir} (temp)")
     else:
         print(f"Output notebooks: {output_dir}")
+
+    # Write gate artifacts if requested
+    if args.gate_output_dir:
+        write_gate_artifacts(
+            Path(args.gate_output_dir), args.mode, results
+        )
+        print(f"\nGate artifact: {args.gate_output_dir}/notebook_gate.json")
+        print(f"Gate markdown: {args.gate_output_dir}/NOTEBOOK_GATE.md")
 
     # Exit with error if any failed
     sys.exit(0 if failed == 0 else 1)

--- a/tests/unit/test_notebook_gate.py
+++ b/tests/unit/test_notebook_gate.py
@@ -1,0 +1,108 @@
+"""Tests for notebook gate artifact generation."""
+
+import importlib.util
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def run_notebooks_mod():
+    """Import run_notebooks.py as a module."""
+    script_path = os.path.join(
+        os.path.dirname(__file__), "..", "..", "scripts", "run_notebooks.py"
+    )
+    spec = importlib.util.spec_from_file_location("run_notebooks", script_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_gate_json_all_pass(tmp_path, run_notebooks_mod):
+    """Gate JSON has correct structure when all notebooks pass."""
+    results = [
+        ("nb1.ipynb", True, "OK", 1.5),
+        ("nb2.ipynb", True, "OK", 2.3),
+    ]
+
+    with patch.object(run_notebooks_mod, "utc_now_iso", return_value="2026-02-10T12:00:00Z"), \
+         patch.object(run_notebooks_mod, "get_git_sha", return_value="abc1234"):
+        gate = run_notebooks_mod.write_gate_artifacts(tmp_path, "smoke", results)
+
+    assert gate["gate_type"] == "notebook_execution"
+    assert gate["gate_version"] == 1
+    assert gate["mode"] == "smoke"
+    assert gate["overall_status"] == "PASS"
+    assert gate["pass_count"] == 2
+    assert gate["fail_count"] == 0
+    assert len(gate["notebooks"]) == 2
+    assert gate["notebooks"][0]["status"] == "PASS"
+    assert gate["notebooks"][0]["error"] is None
+
+    # Verify file was written correctly
+    loaded = json.loads((tmp_path / "notebook_gate.json").read_text())
+    assert loaded == gate
+
+
+def test_gate_json_with_failure(tmp_path, run_notebooks_mod):
+    """Gate JSON correctly records failures."""
+    results = [
+        ("nb1.ipynb", True, "OK", 1.5),
+        ("nb2.ipynb", False, "NameError: foo", 0.8),
+    ]
+
+    with patch.object(run_notebooks_mod, "utc_now_iso", return_value="2026-02-10T12:00:00Z"), \
+         patch.object(run_notebooks_mod, "get_git_sha", return_value="abc1234"):
+        gate = run_notebooks_mod.write_gate_artifacts(tmp_path, "quick", results)
+
+    assert gate["overall_status"] == "FAIL"
+    assert gate["pass_count"] == 1
+    assert gate["fail_count"] == 1
+    assert gate["notebooks"][1]["status"] == "FAIL"
+    assert gate["notebooks"][1]["error"] == "NameError: foo"
+
+
+def test_gate_markdown_content(tmp_path, run_notebooks_mod):
+    """NOTEBOOK_GATE.md has expected content."""
+    results = [
+        ("nb1.ipynb", True, "OK", 1.5),
+        ("nb2.ipynb", False, "Error msg", 0.8),
+    ]
+
+    with patch.object(run_notebooks_mod, "utc_now_iso", return_value="2026-02-10T12:00:00Z"), \
+         patch.object(run_notebooks_mod, "get_git_sha", return_value="abc1234"):
+        run_notebooks_mod.write_gate_artifacts(tmp_path, "smoke", results)
+
+    content = (tmp_path / "NOTEBOOK_GATE.md").read_text()
+    assert "# Notebook Execution Gate" in content
+    assert "SMOKE" in content
+    assert "nb1.ipynb" in content
+    assert "nb2.ipynb" in content
+    assert "1 passed, 1 failed" in content
+
+
+def test_gate_creates_nested_directory(tmp_path, run_notebooks_mod):
+    """Gate writing creates nested output directory."""
+    nested = tmp_path / "a" / "b"
+    results = [("nb1.ipynb", True, "OK", 1.0)]
+
+    with patch.object(run_notebooks_mod, "utc_now_iso", return_value="2026-02-10T12:00:00Z"), \
+         patch.object(run_notebooks_mod, "get_git_sha", return_value="abc1234"):
+        run_notebooks_mod.write_gate_artifacts(nested, "smoke", results)
+
+    assert (nested / "notebook_gate.json").exists()
+    assert (nested / "NOTEBOOK_GATE.md").exists()
+
+
+def test_gate_empty_results(tmp_path, run_notebooks_mod):
+    """Gate handles empty results list."""
+    with patch.object(run_notebooks_mod, "utc_now_iso", return_value="2026-02-10T12:00:00Z"), \
+         patch.object(run_notebooks_mod, "get_git_sha", return_value="abc1234"):
+        gate = run_notebooks_mod.write_gate_artifacts(tmp_path, "smoke", [])
+
+    assert gate["overall_status"] == "PASS"
+    assert gate["pass_count"] == 0
+    assert gate["fail_count"] == 0
+    assert gate["notebooks"] == []


### PR DESCRIPTION
## Summary
- Add `--gate-output-dir` flag to `scripts/run_notebooks.py`
- Emit `notebook_gate.json` (machine-readable) and `NOTEBOOK_GATE.md` (human-readable) gate artifacts
- Extract `write_gate_artifacts()` function for testability

## Why
Enable durable, per-run notebook execution gate artifacts that can be consumed by batch promotion validation. Currently notebook execution results are ephemeral (printed to stdout only).

## Repro / Validation
```bash
# Run with gate output
PYTHONPATH=src uv run python scripts/run_notebooks.py --mode smoke \
  --gate-output-dir /tmp/notebook_review/
cat /tmp/notebook_review/notebook_gate.json
cat /tmp/notebook_review/NOTEBOOK_GATE.md

# Backward compat — no flag = no artifacts, behavior unchanged
PYTHONPATH=src uv run python scripts/run_notebooks.py --mode smoke
```

## Tests
```bash
make check  # All tests pass
uv run pytest tests/unit/test_notebook_gate.py -v  # 5 new tests
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr-a2
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr-a2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)