### PR TITLE
feat(gate): Add notebook gate artifact emission

### DIFF
--- a/scripts/run_notebooks.py
+++ b/scripts/run_notebooks.py
@@ -21,10 +21,17 @@ load_or_generate_features() will pick up the injected MODE automatically.
 
 import argparse
 import glob
+import json
+import os
 import sys
 import tempfile
 import time
 from pathlib import Path
+
+# Ensure src is importable for meta helpers
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from bid_euchre.experiments.meta import get_git_sha, utc_now_iso
 
 
 def discover_notebooks(pattern: str = "notebooks/phase0_bidless/*.ipynb") -> list[Path]:
@@ -93,6 +100,96 @@ def execute_notebook(
         return False, str(e)[:200], duration
 
 
+def build_gate_json(
+    results: list[tuple[str, bool, str, float]],
+    mode: str,
+) -> dict:
+    """Build the notebook_gate.json structure from execution results.
+
+    Args:
+        results: List of (notebook_name, success, message, duration) tuples.
+        mode: Execution mode ("smoke" or "quick").
+
+    Returns:
+        Dict suitable for JSON serialization.
+    """
+    notebooks = []
+    for name, success, message, duration in results:
+        notebooks.append({
+            "name": name,
+            "status": "PASS" if success else "FAIL",
+            "duration_sec": round(duration, 2),
+            "error": None if success else message,
+        })
+
+    pass_count = sum(1 for _, s, _, _ in results if s)
+    fail_count = sum(1 for _, s, _, _ in results if not s)
+
+    return {
+        "gate_type": "notebook_execution",
+        "gate_version": 1,
+        "mode": mode,
+        "timestamp_utc": utc_now_iso(),
+        "git_sha": get_git_sha(),
+        "notebooks": notebooks,
+        "overall_status": "PASS" if fail_count == 0 else "FAIL",
+        "pass_count": pass_count,
+        "fail_count": fail_count,
+    }
+
+
+def build_gate_markdown(gate: dict) -> str:
+    """Build NOTEBOOK_GATE.md content from the gate JSON structure."""
+    lines = [
+        f"# Notebook Gate — {gate['mode'].upper()} mode",
+        "",
+        f"**Status**: {gate['overall_status']}",
+        f"**Timestamp**: {gate['timestamp_utc']}",
+        f"**Git SHA**: `{gate['git_sha']}`",
+        f"**Pass**: {gate['pass_count']}  |  **Fail**: {gate['fail_count']}",
+        "",
+        "## Results",
+        "",
+        "| Notebook | Status | Duration |",
+        "|----------|--------|----------|",
+    ]
+
+    for nb in gate["notebooks"]:
+        status_icon = "PASS" if nb["status"] == "PASS" else "FAIL"
+        lines.append(f"| {nb['name']} | {status_icon} | {nb['duration_sec']:.1f}s |")
+
+    # Show errors if any
+    failures = [nb for nb in gate["notebooks"] if nb["status"] == "FAIL"]
+    if failures:
+        lines.extend(["", "## Errors", ""])
+        for nb in failures:
+            lines.append(f"- **{nb['name']}**: {nb['error']}")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_gate_artifacts(
+    results: list[tuple[str, bool, str, float]],
+    mode: str,
+    gate_output_dir: str,
+) -> None:
+    """Write notebook_gate.json and NOTEBOOK_GATE.md to the gate output dir."""
+    gate_dir = Path(gate_output_dir)
+    gate_dir.mkdir(parents=True, exist_ok=True)
+
+    gate = build_gate_json(results, mode)
+
+    gate_json_path = gate_dir / "notebook_gate.json"
+    with gate_json_path.open("w") as f:
+        json.dump(gate, f, indent=2)
+    print(f"\nGate JSON: {gate_json_path}")
+
+    gate_md_path = gate_dir / "NOTEBOOK_GATE.md"
+    gate_md_path.write_text(build_gate_markdown(gate))
+    print(f"Gate MD:   {gate_md_path}")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Execute notebooks for validation",
@@ -114,6 +211,12 @@ def main():
         "--keep-outputs",
         action="store_true",
         help="Keep executed notebook outputs (default: use temp dir)",
+    )
+    parser.add_argument(
+        "--gate-output-dir",
+        type=str,
+        default=None,
+        help="Directory to write notebook_gate.json and NOTEBOOK_GATE.md (e.g. <run_dir>/reports/notebook_review/)",
     )
     args = parser.parse_args()
 
@@ -172,6 +275,10 @@ def main():
         print(f"Output notebooks: {output_dir} (temp)")
     else:
         print(f"Output notebooks: {output_dir}")
+
+    # Write gate artifacts if --gate-output-dir given
+    if args.gate_output_dir:
+        write_gate_artifacts(results, args.mode, args.gate_output_dir)
 
     # Exit with error if any failed
     sys.exit(0 if failed == 0 else 1)

--- a/tests/unit/test_notebook_gate.py
+++ b/tests/unit/test_notebook_gate.py
@@ -1,0 +1,157 @@
+"""
+Unit tests for notebook gate artifact generation.
+
+Tests:
+- Gate JSON structure and fields
+- Pass/fail counting
+- Markdown generation
+- Backward compat (no --gate-output-dir = no artifacts)
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+from run_notebooks import build_gate_json, build_gate_markdown, write_gate_artifacts
+
+
+class TestBuildGateJson:
+    """Test build_gate_json structure and counting."""
+
+    def test_all_pass(self) -> None:
+        results = [
+            ("10_health.ipynb", True, "OK", 3.2),
+            ("20_outcome.ipynb", True, "OK", 5.1),
+        ]
+        gate = build_gate_json(results, "smoke")
+
+        assert gate["gate_type"] == "notebook_execution"
+        assert gate["gate_version"] == 1
+        assert gate["mode"] == "smoke"
+        assert gate["overall_status"] == "PASS"
+        assert gate["pass_count"] == 2
+        assert gate["fail_count"] == 0
+        assert len(gate["notebooks"]) == 2
+        assert gate["notebooks"][0]["name"] == "10_health.ipynb"
+        assert gate["notebooks"][0]["status"] == "PASS"
+        assert gate["notebooks"][0]["error"] is None
+        assert "timestamp_utc" in gate
+        assert "git_sha" in gate
+
+    def test_one_failure(self) -> None:
+        results = [
+            ("10_health.ipynb", True, "OK", 3.0),
+            ("20_outcome.ipynb", False, "AssertionError: bad", 1.5),
+        ]
+        gate = build_gate_json(results, "quick")
+
+        assert gate["overall_status"] == "FAIL"
+        assert gate["pass_count"] == 1
+        assert gate["fail_count"] == 1
+        assert gate["notebooks"][1]["status"] == "FAIL"
+        assert gate["notebooks"][1]["error"] == "AssertionError: bad"
+
+    def test_all_fail(self) -> None:
+        results = [
+            ("10_health.ipynb", False, "Error 1", 0.5),
+            ("20_outcome.ipynb", False, "Error 2", 0.3),
+        ]
+        gate = build_gate_json(results, "smoke")
+
+        assert gate["overall_status"] == "FAIL"
+        assert gate["pass_count"] == 0
+        assert gate["fail_count"] == 2
+
+    def test_empty_results(self) -> None:
+        gate = build_gate_json([], "smoke")
+
+        assert gate["overall_status"] == "PASS"
+        assert gate["pass_count"] == 0
+        assert gate["fail_count"] == 0
+        assert gate["notebooks"] == []
+
+    def test_duration_rounded(self) -> None:
+        results = [("nb.ipynb", True, "OK", 3.14159)]
+        gate = build_gate_json(results, "smoke")
+        assert gate["notebooks"][0]["duration_sec"] == 3.14
+
+    def test_mode_preserved(self) -> None:
+        gate = build_gate_json([], "quick")
+        assert gate["mode"] == "quick"
+
+
+class TestBuildGateMarkdown:
+    """Test NOTEBOOK_GATE.md generation."""
+
+    def test_contains_header_and_status(self) -> None:
+        gate = build_gate_json(
+            [("nb.ipynb", True, "OK", 1.0)], "smoke"
+        )
+        md = build_gate_markdown(gate)
+        assert "# Notebook Gate" in md
+        assert "SMOKE" in md
+        assert "**Status**: PASS" in md
+
+    def test_contains_table(self) -> None:
+        gate = build_gate_json(
+            [("10_health.ipynb", True, "OK", 3.0)], "smoke"
+        )
+        md = build_gate_markdown(gate)
+        assert "| 10_health.ipynb | PASS | 3.0s |" in md
+
+    def test_failure_shows_errors_section(self) -> None:
+        gate = build_gate_json(
+            [("nb.ipynb", False, "ImportError: no pandas", 0.5)], "quick"
+        )
+        md = build_gate_markdown(gate)
+        assert "## Errors" in md
+        assert "ImportError: no pandas" in md
+
+    def test_no_errors_section_when_all_pass(self) -> None:
+        gate = build_gate_json(
+            [("nb.ipynb", True, "OK", 1.0)], "smoke"
+        )
+        md = build_gate_markdown(gate)
+        assert "## Errors" not in md
+
+
+class TestWriteGateArtifacts:
+    """Test file writing."""
+
+    def test_creates_files(self, tmp_path: Path) -> None:
+        results = [("nb.ipynb", True, "OK", 1.0)]
+        write_gate_artifacts(results, "smoke", str(tmp_path))
+
+        json_path = tmp_path / "notebook_gate.json"
+        md_path = tmp_path / "NOTEBOOK_GATE.md"
+
+        assert json_path.exists()
+        assert md_path.exists()
+
+        gate = json.loads(json_path.read_text())
+        assert gate["gate_type"] == "notebook_execution"
+        assert gate["overall_status"] == "PASS"
+
+        md = md_path.read_text()
+        assert "# Notebook Gate" in md
+
+    def test_creates_missing_directory(self, tmp_path: Path) -> None:
+        nested_dir = tmp_path / "a" / "b" / "c"
+        results = [("nb.ipynb", True, "OK", 1.0)]
+        write_gate_artifacts(results, "smoke", str(nested_dir))
+
+        assert (nested_dir / "notebook_gate.json").exists()
+        assert (nested_dir / "NOTEBOOK_GATE.md").exists()
+
+    def test_json_is_valid(self, tmp_path: Path) -> None:
+        results = [
+            ("10.ipynb", True, "OK", 2.5),
+            ("20.ipynb", False, "Error", 1.0),
+        ]
+        write_gate_artifacts(results, "quick", str(tmp_path))
+
+        gate = json.loads((tmp_path / "notebook_gate.json").read_text())
+        assert gate["pass_count"] == 1
+        assert gate["fail_count"] == 1
+        assert gate["overall_status"] == "FAIL"


### PR DESCRIPTION
## Summary
- Add `--gate-output-dir` flag to `scripts/run_notebooks.py`
- When given, emits `notebook_gate.json` (machine-readable) and `NOTEBOOK_GATE.md` (human-readable) with per-notebook pass/fail status, duration, and overall gate verdict
- Backward compatible: no flag = existing behavior unchanged

## Why
Foundation for promotion workflow. Notebook execution results need to be durable and machine-readable for batch gate evaluation.

## Repro / Validation
```bash
# Run with gate output
PYTHONPATH=src uv run python scripts/run_notebooks.py --mode smoke \
  --gate-output-dir /tmp/notebook_review/
cat /tmp/notebook_review/notebook_gate.json
cat /tmp/notebook_review/NOTEBOOK_GATE.md
```

## Tests
```bash
make check  # All pass
uv run python -m pytest tests/unit/test_notebook_gate.py -v  # 13 tests
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-notebook-gate
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-notebook-gate
```

## Scope
- New: `tests/unit/test_notebook_gate.py`
- Modified: `scripts/run_notebooks.py`