### PR TITLE
refactor(arch): Extract CLI entrypoints from src/ to scripts/

### DIFF
--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -44,10 +44,13 @@ Current scripts:
 - `play_policy_gate.py` — Play policy stability gate
 - `run_auction_comparator.py` — Auction comparator orchestrator
 - `run_bidless_diagnostics.py` — Bidless feature dataset diagnostics
+- `run_charts.py` — Production chart generation (extracted from `reporting.chart_runner`)
 - `run_notebooks.py` — Notebook execution via papermill (CI tooling)
 - `run_suite.py` — Suite runner (batches experiments with rollup generation)
 - `run_tests.py` — Test runner utility
+- `train_b0.py` — B0 hand value model training (extracted from `models.train_b0`)
 - `train_bidder.py` — Bidder model training
+- `train_olsa.py` — OLSa model training (extracted from `models.train_olsa`)
 - `validate_configs.py` — Config validation utility
 - `validate_teacher_roster.py` — Teacher roster validation
 
@@ -158,10 +161,13 @@ Every experiment run creates a standardized directory under `data/runs/<run_id>/
 | Command | Purpose |
 |---------|---------|
 | `scripts/run_auction_comparator.py` | Auction comparator orchestrator |
+| `scripts/run_charts.py` | Production chart generation |
 | `scripts/evaluate_diagnostic_tricks.py` | Diagnostic Ridge evaluation |
 | `scripts/play_policy_gate.py` | Play policy stability gate |
 | `scripts/run_bidless_diagnostics.py` | Bidless diagnostics |
+| `scripts/train_b0.py` | B0 hand value model training |
 | `scripts/train_bidder.py` | Bidder model training |
+| `scripts/train_olsa.py` | OLSa model training |
 
 ---
 

--- a/scripts/lint_repo.py
+++ b/scripts/lint_repo.py
@@ -24,6 +24,14 @@ RANDOM_ALLOWED_MODULES = {
     "src/bid_euchre/sim/deals.py",  # Designated RNG module
 }
 
+# src/ files with deprecation shims that contain `import argparse` inside
+# `if __name__ == "__main__":` blocks — excluded from the no-cli-in-src check.
+CLI_SHIM_ALLOWLIST = {
+    "src/bid_euchre/reporting/chart_runner.py",
+    "src/bid_euchre/models/train_olsa.py",
+    "src/bid_euchre/models/train_b0.py",
+}
+
 
 @dataclass(frozen=True)
 class Violation:
@@ -486,6 +494,65 @@ def check_no_sys_path_insert(changed: list[str], repo_root: Path) -> list[Violat
     return violations
 
 
+def check_no_cli_in_src(changed: list[str], repo_root: Path) -> list[Violation]:
+    """Block module-level ``import argparse`` in src/ Python files.
+
+    CLI entrypoints belong in scripts/, not in library code.  Files in
+    CLI_SHIM_ALLOWLIST are expected to contain ``import argparse`` only
+    inside their ``if __name__ == "__main__":`` deprecation shim and are
+    therefore excluded from this check.
+
+    Uses ast.parse to inspect only *module-level* statements so that
+    argparse imports inside ``if __name__`` guards are not flagged.
+    """
+    violations: list[Violation] = []
+    for p in changed:
+        if not (p.startswith("src/") and p.endswith(".py")):
+            continue
+        if p in CLI_SHIM_ALLOWLIST:
+            continue
+
+        abs_path = repo_root / p
+        if not abs_path.exists():
+            continue
+
+        text = abs_path.read_text(encoding="utf-8")
+        try:
+            tree = ast.parse(text, filename=p)
+        except SyntaxError:
+            continue
+
+        # Only inspect top-level statements (not nested in if/def/class)
+        for node in tree.body:
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "argparse":
+                        violations.append(
+                            Violation(
+                                rule="no-cli-in-src",
+                                path=f"{p}:{node.lineno}",
+                                message=(
+                                    "Module-level `import argparse` in src/ is forbidden. "
+                                    "Move CLI logic to scripts/."
+                                ),
+                            )
+                        )
+            elif isinstance(node, ast.ImportFrom):
+                if node.module == "argparse":
+                    violations.append(
+                        Violation(
+                            rule="no-cli-in-src",
+                            path=f"{p}:{node.lineno}",
+                            message=(
+                                "Module-level `from argparse import ...` in src/ is forbidden. "
+                                "Move CLI logic to scripts/."
+                            ),
+                        )
+                    )
+
+    return violations
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--base", default="origin/main")
@@ -510,6 +577,7 @@ def main() -> int:
     violations += check_empty_test_functions(changed, repo_root)
     violations += check_experiments_without_seed(changed, repo_root)
     violations += check_no_sys_path_insert(changed, repo_root)
+    violations += check_no_cli_in_src(changed, repo_root)
 
     if violations:
         print("Repo linter failed:\n")

--- a/scripts/run_charts.py
+++ b/scripts/run_charts.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Generate production charts from run data.
+
+Thin CLI wrapper around bid_euchre.reporting.chart_runner.
+
+Usage:
+    PYTHONPATH=src python scripts/run_charts.py \
+        --run-dir data/runs/<run_id> \
+        --output-dir /tmp/charts/ \
+        --suite feature_health
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+from bid_euchre.reporting.chart_runner import (
+    AVAILABLE_SUITES,
+    _load_bidless_features,
+    _load_features_with_outcomes,
+    _load_matchup_results,
+)
+from bid_euchre.reporting.charts import (
+    generate_distribution_charts,
+    generate_feature_health_charts,
+    generate_feature_outcome_charts,
+    generate_strategy_matchup_charts,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate production charts from run data")
+    parser.add_argument("--run-dir", required=True, help="Path to experiment run directory")
+    parser.add_argument("--output-dir", required=True, help="Output directory for PNGs")
+    parser.add_argument(
+        "--suite",
+        choices=AVAILABLE_SUITES,
+        default="all",
+        help="Which chart suite to generate (default: all)",
+    )
+    parser.add_argument("--dpi", type=int, default=150, help="Output resolution (default: 150)")
+    args = parser.parse_args()
+
+    run_dir = Path(args.run_dir)
+    if not run_dir.exists():
+        print(f"ERROR: Run directory not found: {run_dir}")
+        sys.exit(1)
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    all_paths: list[str] = []
+    suites = AVAILABLE_SUITES[:-1] if args.suite == "all" else [args.suite]
+
+    for suite in suites:
+        print(f"Generating {suite} charts...")
+
+        if suite == "feature_health":
+            df = _load_bidless_features(run_dir)
+            # Flatten struct columns if present
+            if "hand_features" in df.columns:
+                features = pd.json_normalize(df["hand_features"].tolist())
+                df = pd.concat([df.drop(columns=["hand_features"]), features], axis=1)
+            suite_dir = str(output_dir / suite)
+            paths = generate_feature_health_charts(df, suite_dir, dpi=args.dpi)
+
+        elif suite == "feature_outcome":
+            df = _load_features_with_outcomes(run_dir)
+            suite_dir = str(output_dir / suite)
+            paths = generate_feature_outcome_charts(df, suite_dir, dpi=args.dpi)
+
+        elif suite == "distribution":
+            df = _load_features_with_outcomes(run_dir)
+            suite_dir = str(output_dir / suite)
+            paths = generate_distribution_charts(df, suite_dir, dpi=args.dpi)
+
+        elif suite == "strategy_matchup":
+            matchup_results = _load_matchup_results(run_dir)
+            if not matchup_results:
+                print("  Skipping strategy_matchup: no matchup data found in results/")
+                continue
+            suite_dir = str(output_dir / suite)
+            paths = generate_strategy_matchup_charts(matchup_results, suite_dir, dpi=args.dpi)
+
+        else:
+            print(f"  Unknown suite: {suite}")
+            continue
+
+        all_paths.extend(paths)
+        print(f"  Generated {len(paths)} chart(s)")
+
+    # Write manifest
+    manifest_path = output_dir / "manifest.json"
+    with open(manifest_path, "w") as f:
+        json.dump({"charts": all_paths, "run_dir": str(run_dir)}, f, indent=2)
+
+    print(f"\nTotal: {len(all_paths)} chart(s) generated")
+    print(f"Manifest: {manifest_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_b0.py
+++ b/scripts/train_b0.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Train B0 hand value regression model from bidless dataset.
+
+Thin CLI wrapper around bid_euchre.models.train_b0.
+
+Usage:
+    PYTHONPATH=src python scripts/train_b0.py \
+        --dataset data/bidless_dataset.jsonl \
+        --output data/models/b0_v1.json \
+        --seed 42
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from bid_euchre.models.train_b0 import B0TrainingConfig, save_b0_model, train_b0_model
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Train B0 hand value regression model",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--dataset",
+        required=True,
+        help="Path to bidless dataset JSONL file",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Output path for trained model JSON",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed (default: 42)",
+    )
+    parser.add_argument(
+        "--model-type",
+        choices=["ols", "ridge"],
+        default="ridge",
+        help="Model type (default: ridge)",
+    )
+    parser.add_argument(
+        "--alpha",
+        type=float,
+        default=1.0,
+        help="Ridge regularization parameter (default: 1.0)",
+    )
+    parser.add_argument(
+        "--test-split",
+        type=float,
+        default=0.2,
+        help="Test set fraction (default: 0.2)",
+    )
+
+    args = parser.parse_args()
+
+    config = B0TrainingConfig(
+        dataset_path=args.dataset,
+        output_path=args.output,
+        seed=args.seed,
+        model_type=args.model_type,
+        alpha=args.alpha,
+        test_split=args.test_split,
+    )
+
+    print(f"Training B0 model from {config.dataset_path}...")
+    model, metrics = train_b0_model(config)
+
+    print(f"Train metrics: MSE={metrics['train']['mse']:.4f}, R²={metrics['train']['r2']:.4f}")
+    print(f"Test metrics:  MSE={metrics['test']['mse']:.4f}, R²={metrics['test']['r2']:.4f}")
+
+    save_b0_model(model, config.output_path, config.seed)
+    print(f"Model saved to {config.output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_olsa.py
+++ b/scripts/train_olsa.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Train OLSa models from canonical bidless run data.
+
+Thin CLI wrapper around bid_euchre.models.train_olsa.
+
+Usage:
+    PYTHONPATH=src python scripts/train_olsa.py \
+        --run-dir data/runs/canonical_bidless_dataset_glutton_42_20260204_222713 \
+        --seed 42 --output /tmp/olsa_artifacts/
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+from bid_euchre.models.train_olsa import save_artifacts, train_olsa
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train OLSa models")
+    parser.add_argument("--run-dir", required=True, help="Canonical bidless run directory")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output", required=True, help="Output directory for artifacts")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    artifact, metrics = train_olsa(args.run_dir, args.seed)
+    artifact_path = save_artifacts(artifact, metrics, args.output)
+    print(f"\nOLSa artifact: {artifact_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bid_euchre/models/train_b0.py
+++ b/src/bid_euchre/models/train_b0.py
@@ -5,12 +5,12 @@ Trains a regression model to predict expected hand value from hand features.
 This is the first stage of the Arc B curriculum: learning to evaluate hands
 without auction awareness.
 
-B0 Model: (hand_features, contract_type) → expected_value
+B0 Model: (hand_features, contract_type) -> expected_value
 
-Usage:
-    PYTHONPATH=src python -m bid_euchre.models.train_b0 \\
-        --dataset data/bidless_dataset.jsonl \\
-        --output data/models/b0_v1.json \\
+CLI usage (preferred):
+    PYTHONPATH=src python scripts/train_b0.py \
+        --dataset data/bidless_dataset.jsonl \
+        --output data/models/b0_v1.json \
         --seed 42
 """
 
@@ -258,8 +258,8 @@ def train_b0_model(config: B0TrainingConfig) -> Tuple[B0Model, Dict[str, Any]]:
     Returns:
         (model, metrics) tuple
     """
-    # Set random seed
-    np.random.seed(config.seed)
+    # Local RNG for reproducibility (avoids global np.random state)
+    rng = np.random.default_rng(config.seed)
 
     # Load dataset
     rows = load_bidless_dataset(config.dataset_path)
@@ -271,7 +271,7 @@ def train_b0_model(config: B0TrainingConfig) -> Tuple[B0Model, Dict[str, Any]]:
 
     # Shuffle and split
     n_samples = len(rows)
-    indices = np.random.permutation(n_samples)
+    indices = rng.permutation(n_samples)
     n_test = int(n_samples * config.test_split)
     test_indices = indices[:n_test]
     train_indices = indices[n_test:]
@@ -349,9 +349,16 @@ def load_b0_model(path: str) -> B0Model:
     )
 
 
-def main() -> None:
-    """Command-line entry point."""
+if __name__ == "__main__":
     import argparse
+    import warnings
+
+    warnings.warn(
+        "Direct execution of this module is deprecated. "
+        "Use: PYTHONPATH=src python scripts/train_b0.py",
+        DeprecationWarning,
+        stacklevel=1,
+    )
 
     parser = argparse.ArgumentParser(
         description="Train B0 hand value regression model",
@@ -412,7 +419,3 @@ def main() -> None:
 
     save_b0_model(model, config.output_path, config.seed)
     print(f"Model saved to {config.output_path}")
-
-
-if __name__ == "__main__":
-    main()

--- a/src/bid_euchre/models/train_olsa.py
+++ b/src/bid_euchre/models/train_olsa.py
@@ -9,13 +9,12 @@ Trains 3 separate OLS models with sparse features:
 
 Uses normal equation with lstsq fallback for robustness.
 
-Usage:
-    uv run python -m bid_euchre.models.train_olsa \
+CLI usage (preferred):
+    PYTHONPATH=src python scripts/train_olsa.py \
         --run-dir data/runs/canonical_bidless_dataset_glutton_42_20260204_222713 \
         --seed 42 --output /tmp/olsa_artifacts/
 """
 
-import argparse
 import json
 import logging
 import os
@@ -218,7 +217,17 @@ def save_artifacts(artifact, training_metrics, output_dir):
     return artifact_path
 
 
-def main():
+if __name__ == "__main__":
+    import argparse
+    import warnings
+
+    warnings.warn(
+        "Direct execution of this module is deprecated. "
+        "Use: PYTHONPATH=src python scripts/train_olsa.py",
+        DeprecationWarning,
+        stacklevel=1,
+    )
+
     parser = argparse.ArgumentParser(description="Train OLSa models")
     parser.add_argument("--run-dir", required=True, help="Canonical bidless run directory")
     parser.add_argument("--seed", type=int, default=42)
@@ -230,7 +239,3 @@ def main():
     artifact, metrics = train_olsa(args.run_dir, args.seed)
     artifact_path = save_artifacts(artifact, metrics, args.output)
     print(f"\nOLSa artifact: {artifact_path}")
-
-
-if __name__ == "__main__":
-    main()

--- a/src/bid_euchre/reporting/chart_runner.py
+++ b/src/bid_euchre/reporting/chart_runner.py
@@ -1,15 +1,13 @@
-"""CLI for generating production charts from run data.
+"""Library functions for generating production charts from run data.
 
-Usage:
-    uv run python -m bid_euchre.reporting.chart_runner \
+CLI usage (preferred):
+    PYTHONPATH=src python scripts/run_charts.py \
         --run-dir data/runs/<run_id> \
         --output-dir /tmp/charts/ \
         --suite feature_health
 """
 
-import argparse
 import json
-import sys
 from pathlib import Path
 
 import pandas as pd
@@ -114,7 +112,18 @@ def _load_matchup_results(run_dir: Path) -> dict:
     return matchup_results
 
 
-def main():
+if __name__ == "__main__":
+    import argparse
+    import sys
+    import warnings
+
+    warnings.warn(
+        "Direct execution of this module is deprecated. "
+        "Use: PYTHONPATH=src python scripts/run_charts.py",
+        DeprecationWarning,
+        stacklevel=1,
+    )
+
     parser = argparse.ArgumentParser(description="Generate production charts from run data")
     parser.add_argument("--run-dir", required=True, help="Path to experiment run directory")
     parser.add_argument("--output-dir", required=True, help="Output directory for PNGs")
@@ -143,7 +152,6 @@ def main():
 
         if suite == "feature_health":
             df = _load_bidless_features(run_dir)
-            # Flatten struct columns if present
             if "hand_features" in df.columns:
                 features = pd.json_normalize(df["hand_features"].tolist())
                 df = pd.concat([df.drop(columns=["hand_features"]), features], axis=1)
@@ -175,14 +183,9 @@ def main():
         all_paths.extend(paths)
         print(f"  Generated {len(paths)} chart(s)")
 
-    # Write manifest
     manifest_path = output_dir / "manifest.json"
     with open(manifest_path, "w") as f:
         json.dump({"charts": all_paths, "run_dir": str(run_dir)}, f, indent=2)
 
     print(f"\nTotal: {len(all_paths)} chart(s) generated")
     print(f"Manifest: {manifest_path}")
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
## Summary
- Move CLI `main()` entrypoints from `train_b0.py`, `train_olsa.py`, and `chart_runner.py` to new scripts under `scripts/`
- Replace `np.random.seed`/`np.random.permutation` with local `np.random.default_rng` in `train_b0.py`
- Source modules remain importable libraries; scripts handle CLI concerns

## Why
Library code in `src/` should not contain CLI entrypoints. Separating them follows the repo's architecture boundary (`src/` = library, `scripts/` = CLI).

## Tests
- `make check` passes

Replaces #286 (auto-closed when parent branch deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)