### PR TITLE
refactor(arch): Remove experiments/__init__.py + add namespace lint

### DIFF
--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -32,6 +32,8 @@ Structure:
 
 **Note**: Only `run_experiment.py` is the blessed entrypoint. Other scripts in subfolders are for research exploration and must not define competing canonical paths.
 
+**Disambiguation**: `experiments/` is a filesystem directory (YAML configs + runner). `bid_euchre.experiments` (under `src/bid_euchre/experiments/`) is the library config module. Do not `import experiments` as a Python package.
+
 ### `scripts/`
 **Blessed tooling entrypoints.**
 

--- a/experiments/__init__.py
+++ b/experiments/__init__.py
@@ -1,3 +1,0 @@
-# experiments/ is a filesystem directory (configs + runner), NOT a Python package.
-# Do not import from this package. Use bid_euchre.experiments for config classes.
-# This file will be removed in a future PR.

--- a/scripts/lint_repo.py
+++ b/scripts/lint_repo.py
@@ -553,6 +553,41 @@ def check_no_cli_in_src(changed: list[str], repo_root: Path) -> list[Violation]:
     return violations
 
 
+def check_no_import_experiments_package(changed: list[str], repo_root: Path) -> list[Violation]:
+    """Block 'import experiments' or 'from experiments import' outside experiments/.
+
+    The top-level experiments/ directory is a filesystem directory (YAML configs + runner),
+    NOT a Python package. Use bid_euchre.experiments for config classes.
+    """
+    violations: list[Violation] = []
+    for p in changed:
+        if not p.endswith(".py"):
+            continue
+        if is_under(p, "experiments/"):
+            continue
+        abs_path = repo_root / p
+        if not abs_path.exists():
+            continue
+        text = abs_path.read_text(encoding="utf-8")
+        try:
+            tree = ast.parse(text, filename=p)
+        except SyntaxError:
+            continue
+        imports = _imports_from_tree(tree)
+        if "experiments" in imports:
+            violations.append(
+                Violation(
+                    rule="no-experiments-package-import",
+                    path=p,
+                    message=(
+                        "'import experiments' is forbidden outside experiments/. "
+                        "Use bid_euchre.experiments for config classes."
+                    ),
+                )
+            )
+    return violations
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--base", default="origin/main")
@@ -578,6 +613,7 @@ def main() -> int:
     violations += check_experiments_without_seed(changed, repo_root)
     violations += check_no_sys_path_insert(changed, repo_root)
     violations += check_no_cli_in_src(changed, repo_root)
+    violations += check_no_import_experiments_package(changed, repo_root)
 
     if violations:
         print("Repo linter failed:\n")

--- a/tests/unit/test_lint_rules.py
+++ b/tests/unit/test_lint_rules.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from lint_repo import check_no_sys_path_insert
+from lint_repo import check_no_import_experiments_package, check_no_sys_path_insert
 
 
 def _write_file(tmp_path: Path, rel_path: str, content: str) -> None:
@@ -65,4 +65,26 @@ def test_non_python_files_skipped(tmp_path):
     """Non-.py files are skipped."""
     _write_file(tmp_path, "README.md", "sys.path.insert(0, 'src')\n")
     violations = check_no_sys_path_insert(["README.md"], tmp_path)
+    assert len(violations) == 0
+
+
+def test_import_experiments_package_violation(tmp_path):
+    """Importing top-level experiments package is flagged."""
+    _write_file(tmp_path, "scripts/foo.py", "from experiments import run_experiment\n")
+    violations = check_no_import_experiments_package(["scripts/foo.py"], tmp_path)
+    assert len(violations) == 1
+    assert violations[0].rule == "no-experiments-package-import"
+
+
+def test_import_experiments_from_within_is_ok(tmp_path):
+    """Files inside experiments/ can import from experiments."""
+    _write_file(tmp_path, "experiments/helper.py", "from experiments import run_experiment\n")
+    violations = check_no_import_experiments_package(["experiments/helper.py"], tmp_path)
+    assert len(violations) == 0
+
+
+def test_import_bid_euchre_experiments_is_ok(tmp_path):
+    """Importing bid_euchre.experiments is fine (that's the library module)."""
+    _write_file(tmp_path, "scripts/foo.py", "from bid_euchre.experiments import config\n")
+    violations = check_no_import_experiments_package(["scripts/foo.py"], tmp_path)
     assert len(violations) == 0


### PR DESCRIPTION
## Summary
- Remove `experiments/__init__.py` to prevent `experiments` from being importable as a package
- Add lint rule to detect `src/` importing from `experiments` top-level package
- Add tests for the new import boundary lint check

## Why
`experiments/` is a CLI/config directory, not an importable package. The `__init__.py` created a false namespace that could lead to import boundary violations.

## Tests
- `make check` passes

Replaces #282 (auto-closed when parent branch deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)