### PR TITLE
test(arch): Enforce reporting/diagnostics import contract

### DIFF
--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -173,6 +173,21 @@ Every experiment run creates a standardized directory under `data/runs/<run_id>/
 
 ---
 
+## Module Dependency Contract
+
+The following import edges are explicitly allowed between `reporting/` and `diagnostics/`:
+
+| Edge | Status | Reason |
+|------|--------|--------|
+| `diagnostics/*.py` → `reporting.style` | Allowed | Shared styling constants |
+| `reporting.charts` → `diagnostics.charts` | Allowed | Direct import for chart composition |
+| `reporting.__init__` → `reporting.charts` | **Forbidden** | Would trigger circular import |
+| `reporting.style` → `diagnostics.*` | **Forbidden** | Back-edge would create cycle |
+
+These constraints are enforced by `tests/unit/test_import_contract.py`.
+
+---
+
 ## Design Principles
 
 1. **Single source of truth**: One canonical runner (`run_experiment.py`), one report generator (`generate_report.py`)

--- a/tests/unit/test_import_contract.py
+++ b/tests/unit/test_import_contract.py
@@ -1,0 +1,47 @@
+"""Test architectural import contracts between reporting and diagnostics."""
+import ast
+from pathlib import Path
+
+SRC = Path(__file__).parent.parent.parent / "src" / "bid_euchre"
+
+
+def _get_imports(filepath: Path) -> set[str]:
+    """Extract all import module paths from a Python file."""
+    tree = ast.parse(filepath.read_text())
+    imports = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+    return imports
+
+
+def test_diagnostics_only_imports_reporting_style():
+    """diagnostics/ may only depend on reporting.style, not broader reporting."""
+    diag_dir = SRC / "diagnostics"
+    for py_file in diag_dir.glob("*.py"):
+        imports = _get_imports(py_file)
+        for imp in imports:
+            if "reporting" in imp:
+                assert imp.endswith(".style") or imp.endswith("reporting.style"), (
+                    f"{py_file.name} imports {imp} — diagnostics may only import reporting.style"
+                )
+
+
+def test_reporting_init_does_not_import_charts():
+    """reporting/__init__.py must not import reporting.charts (circular import risk)."""
+    init_file = SRC / "reporting" / "__init__.py"
+    imports = _get_imports(init_file)
+    for imp in imports:
+        assert "charts" not in imp, (
+            f"reporting/__init__.py imports {imp} — this would cause circular import"
+        )
+
+
+def test_reporting_style_has_no_back_imports():
+    """reporting/style.py must not import from diagnostics."""
+    style_file = SRC / "reporting" / "style.py"
+    imports = _get_imports(style_file)
+    for imp in imports:
+        assert "diagnostics" not in imp, (
+            f"reporting/style.py imports {imp} — back-edge to diagnostics forbidden"
+        )


### PR DESCRIPTION
## Summary
- Add tests enforcing the import boundary between reporting/ and diagnostics/
- Prevent circular import regressions

## Tests
- `make check` passes

Replaces #281 (auto-closed when parent branch deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)