### PR TITLE
feat(arch): Add docs freshness gate to make check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help sync repo-lint lint test check notebook-sync notebook-check notebook-run notebook-run-full bid-train-teachers bid-eval-tiny bid-loop bidless-diagnostics
+.PHONY: help sync repo-lint lint test check notebook-sync notebook-check notebook-run notebook-run-full bid-train-teachers bid-eval-tiny bid-loop bidless-diagnostics docs-check
 .DEFAULT_GOAL := help
 
 PYTHON ?= uv run python
@@ -26,6 +26,7 @@ help:
 	@echo "  make notebook-check     - verify sync + outputs cleared"
 	@echo "  make notebook-run       - execute notebooks (SMOKE mode, ~10s)"
 	@echo "  make notebook-run-full  - execute notebooks (QUICK mode, ~2-5min)"
+	@echo "  make docs-check         - docs freshness gate (path refs + script list)"
 	@echo ""
 	@echo "Teacher baseline targets:"
 	@echo "  make bid-train-teachers - train teacher artifacts (all contracts)"
@@ -52,7 +53,7 @@ test:
 	@echo ">>> Pytest (fast suite)"
 	PYTHONPATH=.:src $(PYTHON) -m pytest -m "not slow" tests/
 
-check: repo-lint lint test notebook-check
+check: repo-lint lint test notebook-check docs-check
 	@echo "✓ All checks passed"
 
 notebook-sync:
@@ -71,6 +72,10 @@ notebook-run:
 notebook-run-full:
 	@echo ">>> Executing notebooks (QUICK mode)"
 	PYTHONPATH=src $(PYTHON) scripts/run_notebooks.py --mode quick
+
+docs-check:
+	@echo ">>> Docs freshness check"
+	$(PYTHON) scripts/check_docs_freshness.py
 
 # Generate unique run ID for teacher training
 TEACHER_RUN_ID = teacher_baseline_$(shell date -u +%Y%m%d_%H%M%S)_$(shell printf "%04x" $$RANDOM)

--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -38,6 +38,7 @@ Structure:
 **Blessed tooling entrypoints.**
 
 Canonical scripts:
+- `check_docs_freshness.py` — Docs freshness gate (path refs + script list completeness)
 - `compare_rollup.py` — Drift detection (compares rollup against baseline fixture)
 - `compare_runs.py` — Run comparison utility with bootstrap statistics
 - `generate_report.py` — Per-run report generator
@@ -157,6 +158,7 @@ Every experiment run creates a standardized directory under `data/runs/<run_id>/
 
 | Command | Purpose |
 |---------|---------|
+| `scripts/check_docs_freshness.py` | Docs freshness gate (path refs + script list) |
 | `scripts/compare_runs.py` | Compare two runs with bootstrap statistics |
 | `scripts/compare_rollup.py` | Drift detection against baseline fixture |
 | `scripts/lint_repo.py` | Repository linter |

--- a/docs/01_core/TEACHER_ROSTER_MANIFEST.md
+++ b/docs/01_core/TEACHER_ROSTER_MANIFEST.md
@@ -70,7 +70,7 @@ This ensures reproducible comparisons across runs and environments.
 - Test import paths manually before adding
 - Include meaningful `notes` for future maintainers
 - Use `params` dict for configuration instead of hardcoding
-- Validate with `scripts/validate_teacher_roster_manifest.py` before committing
+- Validate with `scripts/validate_teacher_roster.py` before committing
 
 ### Don'ts
 - Don't change existing IDs (breaks experiment reproducibility)

--- a/scripts/check_docs_freshness.py
+++ b/scripts/check_docs_freshness.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+"""Docs freshness gate: validate path references and script list completeness."""
+import re
+import sys
+from pathlib import Path
+
+
+def check_path_references(docs_dir: Path, repo_root: Path) -> list[str]:
+    """Find markdown path references that don't resolve.
+
+    Checks backtick paths containing a slash: `path/to/file.ext`
+
+    Skips:
+    - Archive/legacy directories (historical docs with known stale refs)
+    - Paths relative to run directories (artifacts/, reports/, datasets/, etc.)
+    - Paths under data/runs/ (gitignored generated outputs)
+    - Wildcard patterns, Python module refs, URLs
+    """
+    errors = []
+    backtick_re = re.compile(r'`([a-zA-Z0-9_./\-]+/[a-zA-Z0-9_.*\-]+)`')
+
+    # Directories to skip entirely (historical docs with many stale refs)
+    skip_dirs = {"archive", "legacy"}
+
+    # Path prefixes that are relative to run directories, not repo root
+    run_relative_prefixes = (
+        "artifacts/",
+        "reports/",
+        "datasets/",
+        "splits/",
+        "logs/",
+    )
+
+    # src/bid_euchre/ submodule names — paths starting with these are
+    # module-relative shorthand, not repo-root paths
+    src_pkg_dir = repo_root / "src" / "bid_euchre"
+    src_submodules: set[str] = set()
+    if src_pkg_dir.is_dir():
+        src_submodules = {
+            d.name
+            for d in src_pkg_dir.iterdir()
+            if d.is_dir() and not d.name.startswith("__")
+        }
+
+    for md_file in sorted(docs_dir.rglob("*.md")):
+        # Skip files in archive/legacy directories
+        if any(part in skip_dirs for part in md_file.relative_to(docs_dir).parts):
+            continue
+
+        text = md_file.read_text(encoding="utf-8")
+        rel = md_file.relative_to(repo_root)
+
+        for match in backtick_re.finditer(text):
+            ref = match.group(1).strip()
+            # Skip patterns with wildcards, Python module refs, URLs
+            if "*" in ref or ref.startswith("http") or ref.startswith("<"):
+                continue
+            # Skip known non-path patterns
+            if ref.startswith("random.") or ref.startswith("bid_euchre."):
+                continue
+            # Skip run-relative paths (not repo-root paths)
+            if ref.startswith(run_relative_prefixes):
+                continue
+            # Skip data/runs/ paths (gitignored generated outputs)
+            if ref.startswith("data/runs/"):
+                continue
+            # Skip src/bid_euchre/ submodule-relative shorthand paths
+            first_segment = ref.split("/")[0]
+            if first_segment in src_submodules:
+                continue
+            # Skip generic/template paths (e.g., _deprecated/README.md)
+            if ref.startswith("_"):
+                continue
+            # Skip docs-relative schema paths (schemas/)
+            if ref.startswith("schemas/"):
+                continue
+            # Skip paths that look like Python import paths (no extension, dots)
+            if "." not in ref.split("/")[-1] and not ref.endswith("/"):
+                # Could be a directory — check
+                if not (repo_root / ref).exists() and not (repo_root / ref).is_dir():
+                    continue  # Probably not a file path
+            if not (repo_root / ref).exists():
+                lineno = text[:match.start()].count('\n') + 1
+                errors.append(f"{rel}:{lineno}: path not found: `{ref}`")
+    return errors
+
+
+def check_scripts_list_complete(arch_doc: Path, scripts_dir: Path) -> list[str]:
+    """Verify ARCHITECTURE.md lists all non-internal, non-private scripts."""
+    errors = []
+    if not arch_doc.exists():
+        return [f"ARCHITECTURE.md not found at {arch_doc}"]
+    text = arch_doc.read_text(encoding="utf-8")
+    for py_file in sorted(scripts_dir.glob("*.py")):
+        if py_file.name.startswith("_"):
+            continue
+        if py_file.name not in text:
+            errors.append(f"ARCHITECTURE.md missing script: {py_file.name}")
+    return errors
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    docs_dir = repo_root / "docs"
+    scripts_dir = repo_root / "scripts"
+    arch_doc = docs_dir / "01_core" / "ARCHITECTURE.md"
+
+    all_errors: list[str] = []
+
+    print("Checking path references in docs/...")
+    path_errors = check_path_references(docs_dir, repo_root)
+    all_errors.extend(path_errors)
+
+    print("Checking script list completeness...")
+    script_errors = check_scripts_list_complete(arch_doc, scripts_dir)
+    all_errors.extend(script_errors)
+
+    if all_errors:
+        print(f"\nDocs freshness check FAILED ({len(all_errors)} issues):\n")
+        for e in all_errors:
+            print(f"  - {e}")
+        return 1
+
+    print("Docs freshness check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_docs_freshness.py
+++ b/tests/unit/test_docs_freshness.py
@@ -1,0 +1,70 @@
+"""Tests for docs freshness gate."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from check_docs_freshness import check_path_references, check_scripts_list_complete
+
+
+def test_valid_path_reference(tmp_path):
+    """Valid backtick path references pass."""
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (tmp_path / "src" / "foo.py").parent.mkdir(parents=True)
+    (tmp_path / "src" / "foo.py").touch()
+    (docs_dir / "test.md").write_text("See `src/foo.py` for details.\n")
+
+    errors = check_path_references(docs_dir, tmp_path)
+    assert len(errors) == 0
+
+
+def test_broken_path_reference(tmp_path):
+    """Broken backtick path references are flagged."""
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "test.md").write_text("See `src/nonexistent.py` for details.\n")
+
+    errors = check_path_references(docs_dir, tmp_path)
+    assert len(errors) == 1
+    assert "nonexistent.py" in errors[0]
+
+
+def test_scripts_list_complete(tmp_path):
+    """All scripts should be listed in ARCHITECTURE.md."""
+    arch_doc = tmp_path / "ARCHITECTURE.md"
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "foo.py").touch()
+    (scripts_dir / "bar.py").touch()
+    (scripts_dir / "_private.py").touch()
+    arch_doc.write_text("Scripts: foo.py and bar.py\n")
+
+    errors = check_scripts_list_complete(arch_doc, scripts_dir)
+    assert len(errors) == 0
+
+
+def test_missing_script_in_docs(tmp_path):
+    """Missing script in ARCHITECTURE.md is flagged."""
+    arch_doc = tmp_path / "ARCHITECTURE.md"
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "foo.py").touch()
+    (scripts_dir / "missing.py").touch()
+    arch_doc.write_text("Scripts: foo.py\n")
+
+    errors = check_scripts_list_complete(arch_doc, scripts_dir)
+    assert len(errors) == 1
+    assert "missing.py" in errors[0]
+
+
+def test_private_scripts_ignored(tmp_path):
+    """Scripts starting with _ are ignored."""
+    arch_doc = tmp_path / "ARCHITECTURE.md"
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "_internal.py").touch()
+    arch_doc.write_text("No scripts here\n")
+
+    errors = check_scripts_list_complete(arch_doc, scripts_dir)
+    assert len(errors) == 0


### PR DESCRIPTION
## Summary
- Add `scripts/check_docs_freshness.py` to verify docs path references and script lists stay current
- Wire into `make check` as a new validation step

## Why
Docs drift silently when scripts are moved/renamed. This gate catches stale path references automatically.

## Tests
- `make check` passes (includes the new docs freshness check)

Replaces #285 (auto-closed when parent branch deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)