### PR TITLE
feat(models): Add deterministic split manifests

### DIFF
--- a/scripts/train_olsa.py
+++ b/scripts/train_olsa.py
@@ -22,11 +22,21 @@ def main() -> None:
     parser.add_argument("--run-dir", required=True, help="Canonical bidless run directory")
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--output", required=True, help="Output directory for artifacts")
+    parser.add_argument(
+        "--split-type",
+        choices=["two_way", "three_way"],
+        default="two_way",
+        help="Split type (three_way required for promotion)",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
 
-    artifact, metrics = train_olsa(args.run_dir, args.seed)
+    artifact, metrics = train_olsa(
+        args.run_dir, args.seed,
+        split_manifest_dir=args.output,
+        split_type=args.split_type,
+    )
     artifact_path = save_artifacts(artifact, metrics, args.output)
     print(f"\nOLSa artifact: {artifact_path}")
 

--- a/src/bid_euchre/models/splits.py
+++ b/src/bid_euchre/models/splits.py
@@ -1,0 +1,248 @@
+"""
+Deterministic split manifests for train/val/test partitioning.
+
+Provides grouped-by-hand_id splitting with persistent manifests that
+record partition hashes for reproducibility and corruption detection.
+
+Split policy:
+  - Promotion-track: 3-way (train/val/test) required
+  - Exploratory: 2-way (train/test) allowed
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+def _utc_now_iso() -> str:
+    """UTC time in ISO8601 with Z suffix."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _sha256_file(path: str) -> str:
+    """SHA256 of file contents."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+@dataclasses.dataclass(frozen=True)
+class SplitManifest:
+    """Persistent record of a train/val/test split.
+
+    Attributes:
+        schema_version: Always 1.
+        split_seed: Random seed used for partitioning.
+        split_type: "two_way" or "three_way".
+        train_fraction: Fraction of hand_ids in train set.
+        val_fraction: Fraction of hand_ids in val set (None for two_way).
+        test_fraction: Fraction of hand_ids in test set.
+        total_hand_ids: Number of unique hand_ids before split.
+        train_hand_ids: Number of unique hand_ids in train set.
+        val_hand_ids: Number of unique hand_ids in val set (None for two_way).
+        test_hand_ids: Number of unique hand_ids in test set.
+        source_run_id: Run identifier the data came from.
+        source_parquet_sha256: SHA256 of the source parquet file.
+        partition_hashes: SHA256 of sorted hand_id lists per partition.
+        created_at_utc: ISO8601 timestamp.
+    """
+
+    schema_version: int
+    split_seed: int
+    split_type: str
+    train_fraction: float
+    val_fraction: float | None
+    test_fraction: float
+    total_hand_ids: int
+    train_hand_ids: int
+    val_hand_ids: int | None
+    test_hand_ids: int
+    source_run_id: str
+    source_parquet_sha256: str
+    partition_hashes: dict[str, str]
+    created_at_utc: str
+
+    def to_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> SplitManifest:
+        return cls(**{k: v for k, v in d.items() if k in {f.name for f in dataclasses.fields(cls)}})
+
+    def save(self, path: str | Path) -> None:
+        """Write manifest to JSON file."""
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(self.to_dict(), indent=2))
+
+    @classmethod
+    def load(cls, path: str | Path) -> SplitManifest:
+        """Load manifest from JSON file."""
+        d = json.loads(Path(path).read_text())
+        return cls.from_dict(d)
+
+
+def _hash_hand_ids(hand_ids: np.ndarray) -> str:
+    """SHA256 of sorted hand_id values as a stable fingerprint."""
+    sorted_ids = np.sort(hand_ids)
+    h = hashlib.sha256()
+    for hid in sorted_ids:
+        h.update(str(int(hid)).encode())
+    return h.hexdigest()
+
+
+def create_grouped_split(
+    df: pd.DataFrame,
+    seed: int,
+    source_run_id: str,
+    source_parquet_path: str,
+    split_type: str = "two_way",
+    train_frac: float = 0.8,
+    val_frac: float = 0.1,
+    test_frac: float = 0.1,
+) -> tuple[pd.DataFrame, pd.DataFrame | None, pd.DataFrame, SplitManifest]:
+    """Split DataFrame by hand_id groups and return partitions + manifest.
+
+    Args:
+        df: DataFrame with 'hand_id' column.
+        seed: Random seed for reproducible partitioning.
+        source_run_id: Run identifier for provenance.
+        source_parquet_path: Path to source parquet (for SHA256).
+        split_type: "two_way" or "three_way".
+        train_frac: Fraction for training (used in both modes).
+        val_frac: Fraction for validation (three_way only).
+        test_frac: Fraction for test.
+
+    Returns:
+        (train_df, val_df_or_None, test_df, manifest)
+    """
+    if split_type not in ("two_way", "three_way"):
+        raise ValueError(f"split_type must be 'two_way' or 'three_way', got {split_type!r}")
+
+    unique_ids = df["hand_id"].unique()
+    rng = np.random.RandomState(seed)
+    rng.shuffle(unique_ids)
+
+    n_total = len(unique_ids)
+
+    if split_type == "two_way":
+        split_idx = int(n_total * train_frac)
+        train_ids = unique_ids[:split_idx]
+        test_ids = unique_ids[split_idx:]
+        val_ids = None
+
+        train_df = df[df["hand_id"].isin(set(train_ids))]
+        test_df = df[df["hand_id"].isin(set(test_ids))]
+        val_df = None
+
+        partition_hashes = {
+            "train": _hash_hand_ids(train_ids),
+            "test": _hash_hand_ids(test_ids),
+        }
+
+        manifest = SplitManifest(
+            schema_version=1,
+            split_seed=seed,
+            split_type="two_way",
+            train_fraction=round(len(train_ids) / n_total, 4),
+            val_fraction=None,
+            test_fraction=round(len(test_ids) / n_total, 4),
+            total_hand_ids=n_total,
+            train_hand_ids=len(train_ids),
+            val_hand_ids=None,
+            test_hand_ids=len(test_ids),
+            source_run_id=source_run_id,
+            source_parquet_sha256=_sha256_file(source_parquet_path),
+            partition_hashes=partition_hashes,
+            created_at_utc=_utc_now_iso(),
+        )
+
+    else:  # three_way
+        # Validate fractions sum to ~1.0
+        total_frac = train_frac + val_frac + test_frac
+        if abs(total_frac - 1.0) > 0.01:
+            raise ValueError(
+                f"Fractions must sum to ~1.0 for three_way split, "
+                f"got {train_frac}+{val_frac}+{test_frac}={total_frac}"
+            )
+
+        train_end = int(n_total * train_frac)
+        val_end = train_end + int(n_total * val_frac)
+        train_ids = unique_ids[:train_end]
+        val_ids = unique_ids[train_end:val_end]
+        test_ids = unique_ids[val_end:]
+
+        train_df = df[df["hand_id"].isin(set(train_ids))]
+        val_df = df[df["hand_id"].isin(set(val_ids))]
+        test_df = df[df["hand_id"].isin(set(test_ids))]
+
+        partition_hashes = {
+            "train": _hash_hand_ids(train_ids),
+            "val": _hash_hand_ids(val_ids),
+            "test": _hash_hand_ids(test_ids),
+        }
+
+        manifest = SplitManifest(
+            schema_version=1,
+            split_seed=seed,
+            split_type="three_way",
+            train_fraction=round(len(train_ids) / n_total, 4),
+            val_fraction=round(len(val_ids) / n_total, 4),
+            test_fraction=round(len(test_ids) / n_total, 4),
+            total_hand_ids=n_total,
+            train_hand_ids=len(train_ids),
+            val_hand_ids=len(val_ids),
+            test_hand_ids=len(test_ids),
+            source_run_id=source_run_id,
+            source_parquet_sha256=_sha256_file(source_parquet_path),
+            partition_hashes=partition_hashes,
+            created_at_utc=_utc_now_iso(),
+        )
+
+    return train_df, val_df, test_df, manifest
+
+
+def verify_split_manifest(manifest: SplitManifest, df: pd.DataFrame, seed: int) -> bool:
+    """Verify a manifest matches a DataFrame by re-computing partition hashes.
+
+    Re-runs the split with the same seed and checks that partition hashes match.
+
+    Returns:
+        True if manifest is consistent with the data.
+    """
+    unique_ids = df["hand_id"].unique()
+    rng = np.random.RandomState(seed)
+    rng.shuffle(unique_ids)
+
+    n_total = len(unique_ids)
+
+    if manifest.split_type == "two_way":
+        split_idx = int(n_total * manifest.train_fraction)
+        train_ids = unique_ids[:split_idx]
+        test_ids = unique_ids[split_idx:]
+
+        return (
+            _hash_hand_ids(train_ids) == manifest.partition_hashes.get("train")
+            and _hash_hand_ids(test_ids) == manifest.partition_hashes.get("test")
+        )
+    else:
+        train_end = int(n_total * manifest.train_fraction)
+        val_end = train_end + int(n_total * (manifest.val_fraction or 0))
+        train_ids = unique_ids[:train_end]
+        val_ids = unique_ids[train_end:val_end]
+        test_ids = unique_ids[val_end:]
+
+        return (
+            _hash_hand_ids(train_ids) == manifest.partition_hashes.get("train")
+            and _hash_hand_ids(val_ids) == manifest.partition_hashes.get("val")
+            and _hash_hand_ids(test_ids) == manifest.partition_hashes.get("test")
+        )

--- a/src/bid_euchre/models/train_olsa.py
+++ b/src/bid_euchre/models/train_olsa.py
@@ -24,6 +24,7 @@ from datetime import datetime, timezone
 import numpy as np
 
 from ..datasets.join import join_features_outcomes
+from .splits import create_grouped_split
 
 logger = logging.getLogger(__name__)
 
@@ -75,9 +76,15 @@ def _compute_metrics(y_true, y_pred):
     return {"r2": float(r2), "mae": float(mae)}
 
 
-def train_olsa(run_dir, seed):
+def train_olsa(run_dir, seed, split_manifest_dir=None, split_type="two_way"):
     """
     Train OLSa models from a canonical bidless run directory.
+
+    Args:
+        run_dir: Path to canonical bidless run.
+        seed: Random seed for splitting and reproducibility.
+        split_manifest_dir: If given, write split_manifest.json per contract here.
+        split_type: "two_way" or "three_way" (three_way required for promotion).
 
     Returns the artifact dict and per-contract metrics.
     """
@@ -93,6 +100,8 @@ def train_olsa(run_dir, seed):
     df = join_features_outcomes(bidless_path, outcomes_path)
     logger.info("Joined: %d rows", len(df))
 
+    source_run_id = os.path.basename(run_dir)
+
     models = {}
     training_metrics = {}
 
@@ -103,7 +112,20 @@ def train_olsa(run_dir, seed):
             logger.warning("No data for contract_type=%s, skipping", contract_family)
             continue
 
-        train_df, test_df = _grouped_train_test_split(sub, seed)
+        train_df, val_df, test_df, manifest = create_grouped_split(
+            sub, seed,
+            source_run_id=source_run_id,
+            source_parquet_path=bidless_path,
+            split_type=split_type,
+        )
+
+        # Persist manifest if requested
+        if split_manifest_dir:
+            manifest_path = os.path.join(
+                split_manifest_dir, f"split_manifest_{contract_family}.json"
+            )
+            manifest.save(manifest_path)
+            logger.info("  Split manifest: %s", manifest_path)
 
         X_train = train_df[feature_names].values.astype(np.float64)
         y_train = train_df["tricks_won"].values.astype(np.float64)
@@ -232,10 +254,21 @@ if __name__ == "__main__":
     parser.add_argument("--run-dir", required=True, help="Canonical bidless run directory")
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--output", required=True, help="Output directory for artifacts")
+    parser.add_argument(
+        "--split-type",
+        choices=["two_way", "three_way"],
+        default="two_way",
+        help="Split type (three_way required for promotion)",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
 
-    artifact, metrics = train_olsa(args.run_dir, args.seed)
+    # Emit split manifests into output dir
+    artifact, metrics = train_olsa(
+        args.run_dir, args.seed,
+        split_manifest_dir=args.output,
+        split_type=args.split_type,
+    )
     artifact_path = save_artifacts(artifact, metrics, args.output)
     print(f"\nOLSa artifact: {artifact_path}")

--- a/tests/unit/test_split_manifest.py
+++ b/tests/unit/test_split_manifest.py
@@ -1,0 +1,232 @@
+"""
+Unit tests for deterministic split manifests.
+
+Tests:
+- Determinism (same seed = same partition hashes)
+- Two-way vs three-way modes
+- Manifest round-trip (save/load)
+- Verification of manifest against data
+- Corruption detection
+"""
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from bid_euchre.models.splits import (
+    SplitManifest,
+    _hash_hand_ids,
+    create_grouped_split,
+    verify_split_manifest,
+)
+
+
+@pytest.fixture
+def sample_parquet(tmp_path: Path) -> Path:
+    """Create a small parquet file for testing."""
+    n_hands = 100
+    rows = []
+    for hand_id in range(n_hands):
+        for seat in range(4):
+            rows.append({"hand_id": hand_id, "seat": seat, "tricks_won": 5.0})
+
+    df = pd.DataFrame(rows)
+    parquet_path = tmp_path / "bidless.parquet"
+    df.to_parquet(parquet_path)
+    return parquet_path
+
+
+@pytest.fixture
+def sample_df(sample_parquet: Path) -> pd.DataFrame:
+    return pd.read_parquet(sample_parquet)
+
+
+class TestCreateGroupedSplit:
+    """Test create_grouped_split function."""
+
+    def test_two_way_basic(self, sample_df: pd.DataFrame, sample_parquet: Path) -> None:
+        train, val, test, manifest = create_grouped_split(
+            sample_df, seed=42,
+            source_run_id="test_run",
+            source_parquet_path=str(sample_parquet),
+            split_type="two_way",
+        )
+        assert val is None
+        assert len(train) > 0
+        assert len(test) > 0
+        assert len(train) + len(test) == len(sample_df)
+        assert manifest.split_type == "two_way"
+        assert manifest.val_hand_ids is None
+        assert manifest.val_fraction is None
+
+    def test_three_way_basic(self, sample_df: pd.DataFrame, sample_parquet: Path) -> None:
+        train, val, test, manifest = create_grouped_split(
+            sample_df, seed=42,
+            source_run_id="test_run",
+            source_parquet_path=str(sample_parquet),
+            split_type="three_way",
+        )
+        assert val is not None
+        assert len(train) > 0
+        assert len(val) > 0
+        assert len(test) > 0
+        assert len(train) + len(val) + len(test) == len(sample_df)
+        assert manifest.split_type == "three_way"
+        assert manifest.val_hand_ids is not None
+        assert manifest.val_fraction is not None
+
+    def test_determinism(self, sample_df: pd.DataFrame, sample_parquet: Path) -> None:
+        """Same seed produces identical partition hashes."""
+        _, _, _, m1 = create_grouped_split(
+            sample_df, seed=42,
+            source_run_id="test_run",
+            source_parquet_path=str(sample_parquet),
+        )
+        _, _, _, m2 = create_grouped_split(
+            sample_df, seed=42,
+            source_run_id="test_run",
+            source_parquet_path=str(sample_parquet),
+        )
+        assert m1.partition_hashes == m2.partition_hashes
+
+    def test_different_seed_different_hashes(
+        self, sample_df: pd.DataFrame, sample_parquet: Path
+    ) -> None:
+        _, _, _, m1 = create_grouped_split(
+            sample_df, seed=42,
+            source_run_id="run",
+            source_parquet_path=str(sample_parquet),
+        )
+        _, _, _, m2 = create_grouped_split(
+            sample_df, seed=99,
+            source_run_id="run",
+            source_parquet_path=str(sample_parquet),
+        )
+        assert m1.partition_hashes != m2.partition_hashes
+
+    def test_no_hand_id_overlap(self, sample_df: pd.DataFrame, sample_parquet: Path) -> None:
+        train, val, test, _ = create_grouped_split(
+            sample_df, seed=42,
+            source_run_id="run",
+            source_parquet_path=str(sample_parquet),
+            split_type="three_way",
+        )
+        train_ids = set(train["hand_id"].unique())
+        val_ids = set(val["hand_id"].unique())
+        test_ids = set(test["hand_id"].unique())
+
+        assert train_ids.isdisjoint(val_ids)
+        assert train_ids.isdisjoint(test_ids)
+        assert val_ids.isdisjoint(test_ids)
+
+    def test_invalid_split_type(self, sample_df: pd.DataFrame, sample_parquet: Path) -> None:
+        with pytest.raises(ValueError, match="split_type must be"):
+            create_grouped_split(
+                sample_df, seed=42,
+                source_run_id="run",
+                source_parquet_path=str(sample_parquet),
+                split_type="four_way",
+            )
+
+    def test_bad_fractions_rejected(
+        self, sample_df: pd.DataFrame, sample_parquet: Path
+    ) -> None:
+        with pytest.raises(ValueError, match="Fractions must sum"):
+            create_grouped_split(
+                sample_df, seed=42,
+                source_run_id="run",
+                source_parquet_path=str(sample_parquet),
+                split_type="three_way",
+                train_frac=0.5,
+                val_frac=0.5,
+                test_frac=0.5,
+            )
+
+    def test_manifest_metadata(self, sample_df: pd.DataFrame, sample_parquet: Path) -> None:
+        _, _, _, manifest = create_grouped_split(
+            sample_df, seed=42,
+            source_run_id="my_run",
+            source_parquet_path=str(sample_parquet),
+        )
+        assert manifest.schema_version == 1
+        assert manifest.split_seed == 42
+        assert manifest.source_run_id == "my_run"
+        assert manifest.source_parquet_sha256  # non-empty
+        assert manifest.created_at_utc  # non-empty
+        assert manifest.total_hand_ids == 100
+
+
+class TestSplitManifestSerialization:
+    """Test SplitManifest save/load round-trip."""
+
+    def test_round_trip(self, sample_df: pd.DataFrame, sample_parquet: Path, tmp_path: Path) -> None:
+        _, _, _, original = create_grouped_split(
+            sample_df, seed=42,
+            source_run_id="run",
+            source_parquet_path=str(sample_parquet),
+        )
+        manifest_path = tmp_path / "manifest.json"
+        original.save(manifest_path)
+        loaded = SplitManifest.load(manifest_path)
+        assert loaded == original
+
+    def test_to_dict_json_serializable(
+        self, sample_df: pd.DataFrame, sample_parquet: Path
+    ) -> None:
+        _, _, _, manifest = create_grouped_split(
+            sample_df, seed=42,
+            source_run_id="run",
+            source_parquet_path=str(sample_parquet),
+        )
+        # Should not raise
+        json.dumps(manifest.to_dict())
+
+
+class TestVerifySplitManifest:
+    """Test manifest verification."""
+
+    def test_valid_manifest(self, sample_df: pd.DataFrame, sample_parquet: Path) -> None:
+        _, _, _, manifest = create_grouped_split(
+            sample_df, seed=42,
+            source_run_id="run",
+            source_parquet_path=str(sample_parquet),
+        )
+        assert verify_split_manifest(manifest, sample_df, seed=42) is True
+
+    def test_wrong_seed_fails(self, sample_df: pd.DataFrame, sample_parquet: Path) -> None:
+        _, _, _, manifest = create_grouped_split(
+            sample_df, seed=42,
+            source_run_id="run",
+            source_parquet_path=str(sample_parquet),
+        )
+        assert verify_split_manifest(manifest, sample_df, seed=99) is False
+
+    def test_three_way_verification(
+        self, sample_df: pd.DataFrame, sample_parquet: Path
+    ) -> None:
+        _, _, _, manifest = create_grouped_split(
+            sample_df, seed=42,
+            source_run_id="run",
+            source_parquet_path=str(sample_parquet),
+            split_type="three_way",
+        )
+        assert verify_split_manifest(manifest, sample_df, seed=42) is True
+        assert verify_split_manifest(manifest, sample_df, seed=99) is False
+
+
+class TestHashHandIds:
+    """Test _hash_hand_ids determinism."""
+
+    def test_deterministic(self) -> None:
+        ids = np.array([3, 1, 2])
+        assert _hash_hand_ids(ids) == _hash_hand_ids(ids)
+
+    def test_order_independent(self) -> None:
+        """Hash of [3,1,2] equals hash of [2,1,3] (sorted internally)."""
+        assert _hash_hand_ids(np.array([3, 1, 2])) == _hash_hand_ids(np.array([2, 1, 3]))
+
+    def test_different_ids_different_hash(self) -> None:
+        assert _hash_hand_ids(np.array([1, 2, 3])) != _hash_hand_ids(np.array([4, 5, 6]))


### PR DESCRIPTION
## Summary
- Add `SplitManifest` dataclass in `src/bid_euchre/models/splits.py` with grouped-by-hand_id splitting and SHA256 partition hashing
- Support 2-way (train/test) and 3-way (train/val/test) splits with deterministic reproducibility
- Wire into `train_olsa.py` and `scripts/train_olsa.py` with `--split-type` flag and per-contract manifest emission
- Add `verify_split_manifest()` for corruption detection

## Why
Foundation for promotion enforcement. Split policy: promotion-track requires 3-way; exploratory allows 2-way. Manifests make splits auditable and reproducible.

## Repro / Validation
```bash
# Run tests
uv run python -m pytest tests/unit/test_split_manifest.py -v

# Verify determinism
python3 -c "
import pandas as pd, numpy as np
from bid_euchre.models.splits import create_grouped_split
df = pd.DataFrame({'hand_id': list(range(100)) * 4, 'tricks_won': [5.0] * 400})
df.to_parquet('/tmp/test.parquet')
_, _, _, m1 = create_grouped_split(df, 42, 'r', '/tmp/test.parquet')
_, _, _, m2 = create_grouped_split(df, 42, 'r', '/tmp/test.parquet')
assert m1.partition_hashes == m2.partition_hashes
print('Determinism verified')
"
```

## Tests
```bash
make check  # All pass
uv run python -m pytest tests/unit/test_split_manifest.py -v  # 16 tests
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-split-manifests
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-split-manifests
```

## Scope
- New: `src/bid_euchre/models/splits.py`, `tests/unit/test_split_manifest.py`
- Modified: `src/bid_euchre/models/train_olsa.py`, `scripts/train_olsa.py`