### PR TITLE
feat: Add deterministic split manifests for train/val/test partitioning

### DIFF
--- a/src/bid_euchre/models/splits.py
+++ b/src/bid_euchre/models/splits.py
@@ -1,0 +1,208 @@
+"""
+Deterministic split manifests for reproducible train/val/test partitioning.
+
+Split policy:
+- Promotion-track: mandatory 3-way (train/val/test)
+- Exploratory: 2-way (train/test) allowed
+
+All splits are grouped by hand_id to prevent data leakage.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+from ..experiments.meta import sha256_file, utc_now_iso
+
+
+@dataclass(frozen=True)
+class SplitManifest:
+    """Manifest recording deterministic dataset split parameters and hashes."""
+
+    schema_version: int
+    split_seed: int
+    split_type: str  # "two_way" | "three_way"
+    train_fraction: float
+    val_fraction: Optional[float]
+    test_fraction: float
+    total_hand_ids: int
+    train_hand_ids: int
+    val_hand_ids: Optional[int]
+    test_hand_ids: int
+    source_run_id: str
+    source_parquet_sha256: str
+    partition_hashes: dict  # {"train": sha256, "val": sha256, "test": sha256}
+    created_at_utc: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> SplitManifest:
+        return cls(**d)
+
+    def save(self, path: str | Path) -> None:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as f:
+            json.dump(self.to_dict(), f, indent=2)
+
+    @classmethod
+    def load(cls, path: str | Path) -> SplitManifest:
+        with open(path) as f:
+            return cls.from_dict(json.load(f))
+
+
+def _hash_hand_ids(hand_ids: np.ndarray) -> str:
+    """SHA256 of sorted hand_id array for partition identity."""
+    sorted_ids = np.sort(hand_ids)
+    return hashlib.sha256(sorted_ids.tobytes()).hexdigest()
+
+
+def create_split(
+    df: pd.DataFrame,
+    seed: int,
+    source_run_id: str,
+    source_parquet_path: str,
+    split_type: str = "two_way",
+    train_frac: float = 0.8,
+    val_frac: float = 0.1,
+    test_frac: float = 0.1,
+) -> tuple[pd.DataFrame, Optional[pd.DataFrame], pd.DataFrame, SplitManifest]:
+    """Split dataframe by hand_id and return partitions with manifest.
+
+    Args:
+        df: DataFrame with 'hand_id' column.
+        seed: Random seed for reproducibility.
+        source_run_id: Run ID for provenance.
+        source_parquet_path: Path to source parquet for SHA256.
+        split_type: "two_way" or "three_way".
+        train_frac: Training fraction.
+        val_frac: Validation fraction (three_way only).
+        test_frac: Test fraction.
+
+    Returns:
+        (train_df, val_df_or_None, test_df, manifest)
+    """
+    if split_type not in ("two_way", "three_way"):
+        raise ValueError(f"split_type must be 'two_way' or 'three_way', got {split_type!r}")
+
+    unique_ids = df["hand_id"].unique()
+    rng = np.random.RandomState(seed)
+    rng.shuffle(unique_ids)
+
+    if split_type == "two_way":
+        split_idx = int(len(unique_ids) * train_frac)
+        train_ids = unique_ids[:split_idx]
+        test_ids = unique_ids[split_idx:]
+
+        train_mask = df["hand_id"].isin(set(train_ids))
+        train_df = df[train_mask].copy()
+        test_df = df[~train_mask].copy()
+        val_df = None
+
+        partition_hashes = {
+            "train": _hash_hand_ids(train_ids),
+            "test": _hash_hand_ids(test_ids),
+        }
+
+        manifest = SplitManifest(
+            schema_version=1,
+            split_seed=seed,
+            split_type="two_way",
+            train_fraction=train_frac,
+            val_fraction=None,
+            test_fraction=round(1.0 - train_frac, 4),
+            total_hand_ids=len(unique_ids),
+            train_hand_ids=len(train_ids),
+            val_hand_ids=None,
+            test_hand_ids=len(test_ids),
+            source_run_id=source_run_id,
+            source_parquet_sha256=sha256_file(source_parquet_path),
+            partition_hashes=partition_hashes,
+            created_at_utc=utc_now_iso(),
+        )
+
+    else:  # three_way
+        n = len(unique_ids)
+        train_end = int(n * train_frac)
+        val_end = train_end + int(n * val_frac)
+
+        train_ids = unique_ids[:train_end]
+        val_ids = unique_ids[train_end:val_end]
+        test_ids = unique_ids[val_end:]
+
+        train_set = set(train_ids)
+        val_set = set(val_ids)
+
+        train_df = df[df["hand_id"].isin(train_set)].copy()
+        val_df = df[df["hand_id"].isin(val_set)].copy()
+        test_df = df[~df["hand_id"].isin(train_set | val_set)].copy()
+
+        partition_hashes = {
+            "train": _hash_hand_ids(train_ids),
+            "val": _hash_hand_ids(val_ids),
+            "test": _hash_hand_ids(test_ids),
+        }
+
+        manifest = SplitManifest(
+            schema_version=1,
+            split_seed=seed,
+            split_type="three_way",
+            train_fraction=train_frac,
+            val_fraction=val_frac,
+            test_fraction=round(1.0 - train_frac - val_frac, 4),
+            total_hand_ids=len(unique_ids),
+            train_hand_ids=len(train_ids),
+            val_hand_ids=len(val_ids),
+            test_hand_ids=len(test_ids),
+            source_run_id=source_run_id,
+            source_parquet_sha256=sha256_file(source_parquet_path),
+            partition_hashes=partition_hashes,
+            created_at_utc=utc_now_iso(),
+        )
+
+    return train_df, val_df, test_df, manifest
+
+
+def verify_split_manifest(manifest_path: str | Path, df: pd.DataFrame, seed: int) -> bool:
+    """Verify a saved manifest matches the current data and seed.
+
+    Returns True if partition hashes match, False otherwise.
+    """
+    manifest = SplitManifest.load(manifest_path)
+
+    if manifest.split_seed != seed:
+        return False
+
+    unique_ids = df["hand_id"].unique()
+    rng = np.random.RandomState(seed)
+    rng.shuffle(unique_ids)
+
+    if manifest.split_type == "two_way":
+        split_idx = int(len(unique_ids) * manifest.train_fraction)
+        train_ids = unique_ids[:split_idx]
+        test_ids = unique_ids[split_idx:]
+        return (
+            _hash_hand_ids(train_ids) == manifest.partition_hashes["train"]
+            and _hash_hand_ids(test_ids) == manifest.partition_hashes["test"]
+        )
+    else:
+        n = len(unique_ids)
+        train_end = int(n * manifest.train_fraction)
+        val_end = train_end + int(n * manifest.val_fraction)
+        train_ids = unique_ids[:train_end]
+        val_ids = unique_ids[train_end:val_end]
+        test_ids = unique_ids[val_end:]
+        return (
+            _hash_hand_ids(train_ids) == manifest.partition_hashes["train"]
+            and _hash_hand_ids(val_ids) == manifest.partition_hashes["val"]
+            and _hash_hand_ids(test_ids) == manifest.partition_hashes["test"]
+        )

--- a/src/bid_euchre/models/train_b0.py
+++ b/src/bid_euchre/models/train_b0.py
@@ -100,6 +100,7 @@ class B0Model:
                 "description": "B0 hand value regression model (Arc B Stage 0)",
                 "training_seed": seed,
                 "n_features": len(self.feature_names),
+                "frozen_at": None,  # Set by freeze workflow
             },
         }
 

--- a/src/bid_euchre/models/train_olsa.py
+++ b/src/bid_euchre/models/train_olsa.py
@@ -161,6 +161,7 @@ def train_olsa(run_dir, seed):
             "git_sha": git_sha,
             "training_timestamp": datetime.now(timezone.utc).isoformat(),
             "training_metrics": training_metrics,
+            "frozen_at": None,  # Set by freeze workflow
         },
     }
 

--- a/tests/unit/test_split_manifest.py
+++ b/tests/unit/test_split_manifest.py
@@ -1,0 +1,187 @@
+"""Tests for deterministic split manifests."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from bid_euchre.models.splits import SplitManifest, create_split, verify_split_manifest
+
+
+@pytest.fixture
+def sample_df():
+    """Create a sample DataFrame with hand_id for testing splits."""
+    # 100 unique hand_ids, 4 rows per hand (simulating seat-level data)
+    hand_ids = np.repeat(np.arange(100), 4)
+    return pd.DataFrame(
+        {
+            "hand_id": hand_ids,
+            "tricks_won": np.random.RandomState(0).randint(0, 11, len(hand_ids)),
+            "feature_a": np.random.RandomState(1).randn(len(hand_ids)),
+        }
+    )
+
+
+@pytest.fixture
+def parquet_path(tmp_path, sample_df):
+    """Save sample data as parquet and return path."""
+    path = tmp_path / "test.parquet"
+    sample_df.to_parquet(path)
+    return str(path)
+
+
+def test_two_way_split_determinism(sample_df, parquet_path):
+    """Same seed produces identical partition hashes."""
+    train1, _, test1, m1 = create_split(
+        sample_df,
+        seed=42,
+        source_run_id="run1",
+        source_parquet_path=parquet_path,
+        split_type="two_way",
+    )
+    train2, _, test2, m2 = create_split(
+        sample_df,
+        seed=42,
+        source_run_id="run1",
+        source_parquet_path=parquet_path,
+        split_type="two_way",
+    )
+    assert m1.partition_hashes["train"] == m2.partition_hashes["train"]
+    assert m1.partition_hashes["test"] == m2.partition_hashes["test"]
+
+
+def test_three_way_split_determinism(sample_df, parquet_path):
+    """Same seed produces identical partition hashes for 3-way."""
+    _, val1, _, m1 = create_split(
+        sample_df,
+        seed=42,
+        source_run_id="run1",
+        source_parquet_path=parquet_path,
+        split_type="three_way",
+    )
+    _, val2, _, m2 = create_split(
+        sample_df,
+        seed=42,
+        source_run_id="run1",
+        source_parquet_path=parquet_path,
+        split_type="three_way",
+    )
+    assert m1.partition_hashes == m2.partition_hashes
+
+
+def test_two_way_split_sizes(sample_df, parquet_path):
+    """Two-way split has correct approximate sizes."""
+    train, val, test, manifest = create_split(
+        sample_df,
+        seed=42,
+        source_run_id="run1",
+        source_parquet_path=parquet_path,
+        split_type="two_way",
+    )
+    assert val is None
+    assert manifest.val_hand_ids is None
+    assert manifest.split_type == "two_way"
+    assert manifest.train_hand_ids + manifest.test_hand_ids == manifest.total_hand_ids
+    assert manifest.train_hand_ids == 80  # 80% of 100
+    assert manifest.test_hand_ids == 20
+
+
+def test_three_way_split_sizes(sample_df, parquet_path):
+    """Three-way split has correct approximate sizes."""
+    train, val, test, manifest = create_split(
+        sample_df,
+        seed=42,
+        source_run_id="run1",
+        source_parquet_path=parquet_path,
+        split_type="three_way",
+    )
+    assert val is not None
+    assert manifest.val_hand_ids is not None
+    assert manifest.split_type == "three_way"
+    total = manifest.train_hand_ids + manifest.val_hand_ids + manifest.test_hand_ids
+    assert total == manifest.total_hand_ids
+
+
+def test_manifest_roundtrip(tmp_path, sample_df, parquet_path):
+    """Save and load manifest preserves all fields."""
+    _, _, _, manifest = create_split(
+        sample_df,
+        seed=42,
+        source_run_id="run1",
+        source_parquet_path=parquet_path,
+        split_type="three_way",
+    )
+    path = tmp_path / "manifest.json"
+    manifest.save(path)
+    loaded = SplitManifest.load(path)
+    assert loaded == manifest
+
+
+def test_verify_manifest_correct(tmp_path, sample_df, parquet_path):
+    """Verify returns True for matching data and seed."""
+    _, _, _, manifest = create_split(
+        sample_df,
+        seed=42,
+        source_run_id="run1",
+        source_parquet_path=parquet_path,
+        split_type="two_way",
+    )
+    path = tmp_path / "manifest.json"
+    manifest.save(path)
+    assert verify_split_manifest(path, sample_df, seed=42) is True
+
+
+def test_verify_manifest_wrong_seed(tmp_path, sample_df, parquet_path):
+    """Verify returns False for different seed."""
+    _, _, _, manifest = create_split(
+        sample_df,
+        seed=42,
+        source_run_id="run1",
+        source_parquet_path=parquet_path,
+        split_type="two_way",
+    )
+    path = tmp_path / "manifest.json"
+    manifest.save(path)
+    assert verify_split_manifest(path, sample_df, seed=99) is False
+
+
+def test_invalid_split_type(sample_df, parquet_path):
+    """Invalid split_type raises ValueError."""
+    with pytest.raises(ValueError, match="split_type"):
+        create_split(
+            sample_df,
+            seed=42,
+            source_run_id="run1",
+            source_parquet_path=parquet_path,
+            split_type="invalid",
+        )
+
+
+def test_no_hand_id_leakage(sample_df, parquet_path):
+    """Train and test hand_ids are completely disjoint."""
+    train, _, test, _ = create_split(
+        sample_df,
+        seed=42,
+        source_run_id="run1",
+        source_parquet_path=parquet_path,
+        split_type="two_way",
+    )
+    train_ids = set(train["hand_id"].unique())
+    test_ids = set(test["hand_id"].unique())
+    assert train_ids.isdisjoint(test_ids)
+
+
+def test_three_way_no_leakage(sample_df, parquet_path):
+    """All three partitions have disjoint hand_ids."""
+    train, val, test, _ = create_split(
+        sample_df,
+        seed=42,
+        source_run_id="run1",
+        source_parquet_path=parquet_path,
+        split_type="three_way",
+    )
+    train_ids = set(train["hand_id"].unique())
+    val_ids = set(val["hand_id"].unique())
+    test_ids = set(test["hand_id"].unique())
+    assert train_ids.isdisjoint(val_ids)
+    assert train_ids.isdisjoint(test_ids)
+    assert val_ids.isdisjoint(test_ids)


### PR DESCRIPTION
## Summary
- Add `SplitManifest` dataclass and `create_split()` in `src/bid_euchre/models/splits.py`
- Supports two_way (train/test) and three_way (train/val/test) split modes
- All splits grouped by `hand_id` to prevent data leakage
- Partition identity tracked via SHA256 hashes for corruption detection
- Add `frozen_at: null` to OLSa and B0 artifact metadata (freeze workflow prep)

## Why
Enable reproducible, verifiable dataset splits for promotion-track training. Three-way splits are mandatory for promotion; two-way allowed for exploration. Partition hashes allow detecting data corruption or inadvertent reprocessing.

## Repro / Validation
```bash
uv run pytest tests/unit/test_split_manifest.py -v  # 10 new tests
make check
```

## Tests
```bash
make check  # 938 tests pass
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr-b1
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr-b1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)