### PR TITLE
feat: Add batch template, config validation & workflow docs

### DIFF
--- a/docs/02_agent/CANONICAL_BIDLESS_RUNS.md
+++ b/docs/02_agent/CANONICAL_BIDLESS_RUNS.md
@@ -81,3 +81,7 @@ A run is eligible for promotion when:
 ## Related Reports
 
 - [Phase 0 Bidless Report](../04_reports/phase0_bidless_20260207.md) — Consolidated findings with embedded charts and provenance
+
+## Batch Promotion Workflow
+
+For the automated batch promotion workflow, see [PROMOTION_WORKFLOW.md](PROMOTION_WORKFLOW.md).

--- a/docs/02_agent/PROMOTION_WORKFLOW.md
+++ b/docs/02_agent/PROMOTION_WORKFLOW.md
@@ -1,0 +1,65 @@
+# Promotion Workflow
+
+Step-by-step workflow for promoting experiment runs to canonical status.
+
+## Prerequisites
+
+- Active batch pointer set in `experiments/promotion/ACTIVE_BATCH.yaml`
+- Suite config defined in `experiments/suites/canonical_promotion.yaml`
+
+## Steps
+
+### 1. Set Active Batch
+
+Edit `experiments/promotion/ACTIVE_BATCH.yaml`:
+```yaml
+batch_id: "promotion_YYYYMMDD"
+suite_path: experiments/suites/canonical_promotion.yaml
+created_at: "YYYY-MM-DDTHH:MM:SSZ"
+```
+
+### 2. Run Suite
+
+```bash
+uv run python scripts/run_suite.py \
+  --suite experiments/suites/canonical_promotion.yaml \
+  --seed 42 --batch-purpose promotion
+```
+
+### 3. Generate Per-Run Reports
+
+For each member run discovered from rollup.json:
+```bash
+PYTHONPATH=src uv run python scripts/generate_report.py \
+  --run-dir <run_dir> --fail-on-sanity-failures
+```
+
+### 4. Run Notebook Gate
+
+```bash
+PYTHONPATH=src uv run python scripts/run_notebooks.py \
+  --mode quick --gate-output-dir <run_dir>/reports/notebook_review/
+```
+
+### 5. Generate Batch Report
+
+```bash
+PYTHONPATH=src uv run python scripts/generate_report.py \
+  --batch-dir <rollup_dir>
+```
+
+### 6. Review
+
+- Review `BATCH_REPORT.md` and `batch_gate.json`
+- Check eligibility: eligible=true means all gates passed
+
+### 7. Promote or Reject
+
+If promoted:
+1. Update `notebooks/phase0_bidless/canonical_runs.py` with new run IDs
+2. Update `docs/02_agent/CANONICAL_BIDLESS_RUNS.md` with new run details
+3. Clear `experiments/promotion/ACTIVE_BATCH.yaml` (set batch_id back to null)
+
+If rejected:
+1. Document reason in PR or issue
+2. Clear `experiments/promotion/ACTIVE_BATCH.yaml`

--- a/experiments/suites/canonical_promotion.yaml
+++ b/experiments/suites/canonical_promotion.yaml
@@ -1,0 +1,29 @@
+# Canonical Promotion Suite
+# Batch template for promoting experiment runs to canonical status.
+# Used by: scripts/run_suite.py --batch-purpose promotion
+
+suite_name: canonical_promotion
+batch_purpose: promotion
+
+parameters:
+  seed: 42
+  n_per: 50000
+  log_level: none
+
+configs:
+  - experiments/configs/canonical_bidless_dataset_greedy.yaml
+  - experiments/configs/canonical_bidless_dataset_glutton.yaml
+  - experiments/configs/canonical_bidless_outcomes_matrix_shallow.yaml
+  - experiments/configs/canonical_bidless_outcomes_zoom.yaml
+
+batch_roles:
+  canonical_bidless_dataset_greedy.yaml: dataset_greedy
+  canonical_bidless_dataset_glutton.yaml: dataset_glutton
+  canonical_bidless_outcomes_matrix_shallow.yaml: outcomes_shallow
+  canonical_bidless_outcomes_zoom.yaml: outcomes_zoom
+
+run_flags:
+  canonical_bidless_dataset_greedy.yaml:
+    extra_args: ["--emit-bidless-dataset", "--emit-bidless-outcomes-dataset"]
+  canonical_bidless_dataset_glutton.yaml:
+    extra_args: ["--emit-bidless-dataset", "--emit-bidless-outcomes-dataset"]

--- a/scripts/validate_configs.py
+++ b/scripts/validate_configs.py
@@ -107,6 +107,45 @@ def validate_suite_file(path: Path) -> list[str]:
             if not isinstance(data["parameters"], dict):
                 errors.append(f"{path}: 'parameters' must be a dict")
 
+        # Validate batch-specific fields (optional, backward compat)
+        if "batch_purpose" in data:
+            valid_purposes = {"promotion", "regression", "exploration"}
+            if data["batch_purpose"] not in valid_purposes:
+                errors.append(
+                    f"{path}: batch_purpose must be one of {valid_purposes}, "
+                    f"got '{data['batch_purpose']}'"
+                )
+
+        if "batch_roles" in data:
+            if not isinstance(data["batch_roles"], dict):
+                errors.append(f"{path}: 'batch_roles' must be a dict")
+            elif isinstance(data.get("configs"), list):
+                config_filenames = {Path(c).name for c in data["configs"]}
+                for key in data["batch_roles"]:
+                    if key not in config_filenames:
+                        errors.append(
+                            f"{path}: batch_roles key '{key}' "
+                            f"not found in configs list"
+                        )
+
+        if "run_flags" in data:
+            if not isinstance(data["run_flags"], dict):
+                errors.append(f"{path}: 'run_flags' must be a dict")
+            elif isinstance(data.get("configs"), list):
+                config_filenames = {Path(c).name for c in data["configs"]}
+                for key, flags in data["run_flags"].items():
+                    if key not in config_filenames:
+                        errors.append(
+                            f"{path}: run_flags key '{key}' "
+                            f"not found in configs list"
+                        )
+                    if isinstance(flags, dict) and "extra_args" in flags:
+                        if not isinstance(flags["extra_args"], list):
+                            errors.append(
+                                f"{path}: run_flags['{key}'].extra_args "
+                                f"must be a list"
+                            )
+
     except FileNotFoundError as e:
         errors.append(f"{path}: {e}")
     except yaml.YAMLError as e:

--- a/tests/unit/test_validate_batch_config.py
+++ b/tests/unit/test_validate_batch_config.py
@@ -1,0 +1,150 @@
+"""Tests for batch-specific suite validation fields.
+
+Validates the batch_purpose, batch_roles, and run_flags fields
+added to validate_suite_file() in scripts/validate_configs.py.
+"""
+
+from pathlib import Path
+
+import yaml
+from validate_configs import validate_suite_file
+
+
+def _write_suite(tmp_path: Path, data: dict) -> Path:
+    """Write a suite YAML to a temp file and return the path."""
+    suite_path = tmp_path / "test_suite.yaml"
+    with open(suite_path, "w") as f:
+        yaml.safe_dump(data, f)
+    return suite_path
+
+
+class TestBatchFieldValidation:
+    """Tests for batch-specific suite validation fields."""
+
+    def _base_suite(self, tmp_path: Path) -> dict:
+        """Return a minimal valid suite with batch fields.
+
+        Uses config paths that exist under tmp_path so file-existence
+        checks don't pollute the batch-field tests.
+        """
+        # Create stub config files so file-existence validation passes
+        configs_dir = tmp_path / "experiments" / "configs"
+        configs_dir.mkdir(parents=True, exist_ok=True)
+        (configs_dir / "alpha.yaml").touch()
+        (configs_dir / "beta.yaml").touch()
+
+        return {
+            "suite_name": "test_batch",
+            "parameters": {"seed": 42, "n_per": 100},
+            "configs": [
+                str(configs_dir / "alpha.yaml"),
+                str(configs_dir / "beta.yaml"),
+            ],
+            "batch_purpose": "promotion",
+            "batch_roles": {
+                "alpha.yaml": "role_a",
+                "beta.yaml": "role_b",
+            },
+            "run_flags": {
+                "alpha.yaml": {
+                    "extra_args": ["--emit-bidless-dataset"],
+                },
+            },
+        }
+
+    def test_valid_batch_suite(self, tmp_path):
+        """Suite with all batch fields valid produces no errors."""
+        data = self._base_suite(tmp_path)
+        path = _write_suite(tmp_path, data)
+        errors = validate_suite_file(path)
+        assert errors == [], f"Expected no errors, got: {errors}"
+
+    def test_missing_batch_roles_key_allowed(self, tmp_path):
+        """Old-style suite without batch fields passes (backward compat)."""
+        data = self._base_suite(tmp_path)
+        del data["batch_purpose"]
+        del data["batch_roles"]
+        del data["run_flags"]
+        path = _write_suite(tmp_path, data)
+        errors = validate_suite_file(path)
+        assert errors == [], f"Expected no errors, got: {errors}"
+
+    def test_batch_roles_key_not_in_configs(self, tmp_path):
+        """batch_roles key references config not in configs list -> error."""
+        data = self._base_suite(tmp_path)
+        data["batch_roles"]["nonexistent.yaml"] = "bad_role"
+        path = _write_suite(tmp_path, data)
+        errors = validate_suite_file(path)
+        assert any(
+            "batch_roles key 'nonexistent.yaml'" in e and "not found" in e
+            for e in errors
+        ), f"Expected batch_roles key error, got: {errors}"
+
+    def test_run_flags_key_not_in_configs(self, tmp_path):
+        """run_flags key references config not in configs list -> error."""
+        data = self._base_suite(tmp_path)
+        data["run_flags"]["nonexistent.yaml"] = {
+            "extra_args": ["--some-flag"],
+        }
+        path = _write_suite(tmp_path, data)
+        errors = validate_suite_file(path)
+        assert any(
+            "run_flags key 'nonexistent.yaml'" in e and "not found" in e
+            for e in errors
+        ), f"Expected run_flags key error, got: {errors}"
+
+    def test_invalid_batch_purpose(self, tmp_path):
+        """batch_purpose not in {promotion, regression, exploration} -> error."""
+        data = self._base_suite(tmp_path)
+        data["batch_purpose"] = "invalid_purpose"
+        path = _write_suite(tmp_path, data)
+        errors = validate_suite_file(path)
+        assert any(
+            "batch_purpose" in e and "invalid_purpose" in e
+            for e in errors
+        ), f"Expected batch_purpose error, got: {errors}"
+
+    def test_extra_args_not_list(self, tmp_path):
+        """run_flags.*.extra_args not a list -> error."""
+        data = self._base_suite(tmp_path)
+        data["run_flags"]["alpha.yaml"]["extra_args"] = "--not-a-list"
+        path = _write_suite(tmp_path, data)
+        errors = validate_suite_file(path)
+        assert any(
+            "extra_args" in e and "must be a list" in e
+            for e in errors
+        ), f"Expected extra_args list error, got: {errors}"
+
+    def test_batch_roles_not_dict(self, tmp_path):
+        """batch_roles that is not a dict -> error."""
+        data = self._base_suite(tmp_path)
+        data["batch_roles"] = ["not", "a", "dict"]
+        path = _write_suite(tmp_path, data)
+        errors = validate_suite_file(path)
+        assert any(
+            "'batch_roles' must be a dict" in e
+            for e in errors
+        ), f"Expected batch_roles dict error, got: {errors}"
+
+    def test_run_flags_not_dict(self, tmp_path):
+        """run_flags that is not a dict -> error."""
+        data = self._base_suite(tmp_path)
+        data["run_flags"] = "not_a_dict"
+        path = _write_suite(tmp_path, data)
+        errors = validate_suite_file(path)
+        assert any(
+            "'run_flags' must be a dict" in e
+            for e in errors
+        ), f"Expected run_flags dict error, got: {errors}"
+
+    def test_valid_batch_purposes(self, tmp_path):
+        """All three valid batch_purpose values pass validation."""
+        for purpose in ("promotion", "regression", "exploration"):
+            data = self._base_suite(tmp_path)
+            data["batch_purpose"] = purpose
+            path = _write_suite(tmp_path, data)
+            errors = validate_suite_file(path)
+            batch_errors = [e for e in errors if "batch_purpose" in e]
+            assert batch_errors == [], (
+                f"Purpose '{purpose}' should be valid, got: {batch_errors}"
+            )


### PR DESCRIPTION
## Summary
- Add `experiments/suites/canonical_promotion.yaml` batch template for promotion runs
- Extend `scripts/validate_configs.py` with validation for `batch_purpose`, `batch_roles`, and `run_flags` fields
- Add `docs/02_agent/PROMOTION_WORKFLOW.md` step-by-step promotion guide
- Link promotion workflow from `docs/02_agent/CANONICAL_BIDLESS_RUNS.md`

## Why
The batch promotion workflow needs a canonical suite template and validated configuration fields. This PR provides the template, validation logic, and documentation to support automated batch promotions.

## Repro / Validation
**Command(s) run:**
```bash
make check
uv run python -m pytest tests/unit/test_validate_batch_config.py -v
```

**Config (if applicable):** experiments/suites/canonical_promotion.yaml

**Seed (if applicable):** N/A (config validation only)

## Tests
- [x] `uv run python -m pytest -m "not slow" tests/` (953 passed)
- [x] `uv run python -m pytest tests/unit/test_validate_batch_config.py -v` (9 passed)
- [x] `make check` (repo-lint + ruff + pytest all pass)

## Expected impact
- Metrics impact: None
- Runtime impact: None (validation-only changes)

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr-a4
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr-a4
```

`git worktree list` (relevant line):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr-a4  ce54c1f [codex/pr-a4-batch-template]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)