### PR TITLE
feat(lint): Add promotion contract lint rules

### DIFF
--- a/scripts/lint_repo.py
+++ b/scripts/lint_repo.py
@@ -588,6 +588,90 @@ def check_no_import_experiments_package(changed: list[str], repo_root: Path) -> 
     return violations
 
 
+CANONICAL_RUNS_REGISTRY = "notebooks/phase0_bidless/canonical_runs.py"
+CANONICAL_RUNS_DOC = "docs/02_agent/CANONICAL_BIDLESS_RUNS.md"
+
+
+def check_canonical_runs_consistency(changed: list[str], repo_root: Path) -> list[Violation]:
+    """Require canonical_runs.py and CANONICAL_BIDLESS_RUNS.md to change together.
+
+    If one changes without the other, the code registry and documentation
+    can silently diverge.  Only enforced when the code registry file exists
+    (it was removed in PR #305; the rule remains for future registries).
+    """
+    violations: list[Violation] = []
+
+    # Skip if code registry file doesn't exist in the repo
+    if not (repo_root / CANONICAL_RUNS_REGISTRY).exists():
+        return violations
+
+    has_code = CANONICAL_RUNS_REGISTRY in changed
+    has_doc = CANONICAL_RUNS_DOC in changed
+
+    if has_code and not has_doc:
+        violations.append(
+            Violation(
+                rule="canonical-runs-registry-consistency",
+                path=CANONICAL_RUNS_REGISTRY,
+                message=(
+                    f"{CANONICAL_RUNS_REGISTRY} changed but {CANONICAL_RUNS_DOC} did not. "
+                    "Both must be updated together to keep registry and docs in sync."
+                ),
+            )
+        )
+    elif has_doc and not has_code:
+        violations.append(
+            Violation(
+                rule="canonical-runs-registry-consistency",
+                path=CANONICAL_RUNS_DOC,
+                message=(
+                    f"{CANONICAL_RUNS_DOC} changed but {CANONICAL_RUNS_REGISTRY} did not. "
+                    "Both must be updated together to keep registry and docs in sync."
+                ),
+            )
+        )
+
+    return violations
+
+
+def check_registry_requires_gate_reference(
+    changed: list[str], repo_root: Path
+) -> list[Violation]:
+    """If CANONICAL_BIDLESS_RUNS.md changes, the diff must reference a gate artifact.
+
+    Prevents registry updates without backing evidence from batch_gate.json,
+    notebook_gate.json, or canonical_summary.json.
+    """
+    violations: list[Violation] = []
+    if CANONICAL_RUNS_DOC not in changed:
+        return violations
+
+    abs_path = repo_root / CANONICAL_RUNS_DOC
+    if not abs_path.exists():
+        return violations
+
+    text = abs_path.read_text(encoding="utf-8")
+
+    # Check for any gate/summary artifact reference in the file content
+    gate_patterns = ["_gate.json", "canonical_summary.json", "batch_gate.json", "notebook_gate.json"]
+    has_gate_ref = any(pat in text for pat in gate_patterns)
+
+    if not has_gate_ref:
+        violations.append(
+            Violation(
+                rule="registry-requires-gate-reference",
+                path=CANONICAL_RUNS_DOC,
+                message=(
+                    "Registry update must reference a gate artifact "
+                    "(*_gate.json or canonical_summary.json). "
+                    "Add a reference to the evidence backing this promotion."
+                ),
+            )
+        )
+
+    return violations
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--base", default="origin/main")
@@ -614,6 +698,8 @@ def main() -> int:
     violations += check_no_sys_path_insert(changed, repo_root)
     violations += check_no_cli_in_src(changed, repo_root)
     violations += check_no_import_experiments_package(changed, repo_root)
+    violations += check_canonical_runs_consistency(changed, repo_root)
+    violations += check_registry_requires_gate_reference(changed, repo_root)
 
     if violations:
         print("Repo linter failed:\n")

--- a/tests/unit/test_repo_linter.py
+++ b/tests/unit/test_repo_linter.py
@@ -1,9 +1,11 @@
 from pathlib import Path
 
 from scripts.lint_repo import (
+    check_canonical_runs_consistency,
     check_data_fixtures_allowlist,
     check_no_deprecated_changes,
     check_no_generated_artifacts,
+    check_registry_requires_gate_reference,
     check_src_no_experiments_or_tests_imports,
 )
 
@@ -152,4 +154,113 @@ def test_data_allowlist_handles_deleted_files(tmp_path: Path):
     changed = ["data/fixtures/deleted.json"]
     v = check_data_fixtures_allowlist(changed, tmp_path)
     # Should pass because file doesn't exist (no size to check)
+    assert v == []
+
+
+# --- canonical-runs-registry-consistency tests ---
+
+
+def _create_registry_file(tmp_path: Path) -> None:
+    """Helper: create canonical_runs.py so the consistency rule activates."""
+    registry = tmp_path / "notebooks" / "phase0_bidless"
+    registry.mkdir(parents=True, exist_ok=True)
+    (registry / "canonical_runs.py").write_text("RUNS = {}\n")
+
+
+def test_canonical_runs_both_changed(tmp_path: Path):
+    """No violation when both registry files change together."""
+    _create_registry_file(tmp_path)
+    changed = [
+        "notebooks/phase0_bidless/canonical_runs.py",
+        "docs/02_agent/CANONICAL_BIDLESS_RUNS.md",
+    ]
+    v = check_canonical_runs_consistency(changed, tmp_path)
+    assert v == []
+
+
+def test_canonical_runs_code_only(tmp_path: Path):
+    """Violation when canonical_runs.py changes but doc does not."""
+    _create_registry_file(tmp_path)
+    changed = ["notebooks/phase0_bidless/canonical_runs.py"]
+    v = check_canonical_runs_consistency(changed, tmp_path)
+    assert len(v) == 1
+    assert v[0].rule == "canonical-runs-registry-consistency"
+    assert "canonical_runs.py" in v[0].message
+
+
+def test_canonical_runs_doc_only(tmp_path: Path):
+    """Violation when doc changes but canonical_runs.py does not."""
+    _create_registry_file(tmp_path)
+    changed = ["docs/02_agent/CANONICAL_BIDLESS_RUNS.md"]
+    v = check_canonical_runs_consistency(changed, tmp_path)
+    assert len(v) == 1
+    assert v[0].rule == "canonical-runs-registry-consistency"
+    assert "CANONICAL_BIDLESS_RUNS.md" in v[0].message
+
+
+def test_canonical_runs_neither_changed(tmp_path: Path):
+    """No violation when neither registry file changes."""
+    _create_registry_file(tmp_path)
+    changed = ["src/bid_euchre/core/cards.py"]
+    v = check_canonical_runs_consistency(changed, tmp_path)
+    assert v == []
+
+
+def test_canonical_runs_skipped_when_registry_missing(tmp_path: Path):
+    """Rule is skipped when canonical_runs.py doesn't exist (deleted in #305)."""
+    changed = ["docs/02_agent/CANONICAL_BIDLESS_RUNS.md"]
+    v = check_canonical_runs_consistency(changed, tmp_path)
+    assert v == []
+
+
+# --- registry-requires-gate-reference tests ---
+
+
+def test_registry_gate_ref_present(tmp_path: Path):
+    """No violation when doc references a gate artifact."""
+    doc_dir = tmp_path / "docs" / "02_agent"
+    doc_dir.mkdir(parents=True)
+    doc_path = doc_dir / "CANONICAL_BIDLESS_RUNS.md"
+    doc_path.write_text(
+        "# Registry\nPromoted via batch_gate.json evidence.\n",
+        encoding="utf-8",
+    )
+    changed = ["docs/02_agent/CANONICAL_BIDLESS_RUNS.md"]
+    v = check_registry_requires_gate_reference(changed, tmp_path)
+    assert v == []
+
+
+def test_registry_gate_ref_missing(tmp_path: Path):
+    """Violation when doc changes without gate artifact reference."""
+    doc_dir = tmp_path / "docs" / "02_agent"
+    doc_dir.mkdir(parents=True)
+    doc_path = doc_dir / "CANONICAL_BIDLESS_RUNS.md"
+    doc_path.write_text(
+        "# Registry\nUpdated run IDs.\n",
+        encoding="utf-8",
+    )
+    changed = ["docs/02_agent/CANONICAL_BIDLESS_RUNS.md"]
+    v = check_registry_requires_gate_reference(changed, tmp_path)
+    assert len(v) == 1
+    assert v[0].rule == "registry-requires-gate-reference"
+
+
+def test_registry_gate_ref_canonical_summary(tmp_path: Path):
+    """canonical_summary.json reference is acceptable."""
+    doc_dir = tmp_path / "docs" / "02_agent"
+    doc_dir.mkdir(parents=True)
+    doc_path = doc_dir / "CANONICAL_BIDLESS_RUNS.md"
+    doc_path.write_text(
+        "# Registry\nBacked by canonical_summary.json.\n",
+        encoding="utf-8",
+    )
+    changed = ["docs/02_agent/CANONICAL_BIDLESS_RUNS.md"]
+    v = check_registry_requires_gate_reference(changed, tmp_path)
+    assert v == []
+
+
+def test_registry_gate_ref_not_triggered_without_doc_change(tmp_path: Path):
+    """No violation when doc is not in changed files."""
+    changed = ["src/bid_euchre/core/cards.py"]
+    v = check_registry_requires_gate_reference(changed, tmp_path)
     assert v == []


### PR DESCRIPTION
## Summary
- Add `canonical-runs-registry-consistency` lint rule: requires code registry and doc registry to change together (gracefully skips when canonical_runs.py is absent per PR #305)
- Add `registry-requires-gate-reference` lint rule: requires gate artifact references when updating CANONICAL_BIDLESS_RUNS.md

## Why
Prevent promotion registry updates without backing evidence. These rules enforce that:
1. Code and documentation registries stay in sync
2. Registry updates are backed by machine-readable gate artifacts

## Repro / Validation
```bash
cd $(git rev-parse --show-toplevel)
uv run python -m pytest tests/unit/test_repo_linter.py -v
make check
```

## Tests
- `make check` passes (repo-lint + ruff + pytest)
- 24 tests in test_repo_linter.py (9 new: 5 consistency + 4 gate-reference)

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr-b3
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr-b3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>