### PR TITLE
feat(batch): BatchMetadata dataclass + run_experiment CLI flags (Arc C PR-01)

### DIFF
--- a/experiments/run_experiment.py
+++ b/experiments/run_experiment.py
@@ -50,6 +50,7 @@ from bid_euchre.datasets.bidless_outcomes import (
     emit_bidless_outcomes_dataset,
 )
 from bid_euchre.experiments import load_config
+from bid_euchre.experiments.batch import BatchMetadata
 from bid_euchre.experiments.meta import get_git_sha, sha256_file, utc_now_iso
 from bid_euchre.logging import GameLogger, LogLevel
 from bid_euchre.sim import simulation
@@ -200,6 +201,23 @@ def parse_args():
         action="store_true",
         help="Override work budget limits (use with caution)"
     )
+    parser.add_argument(
+        "--batch-id",
+        default=None,
+        help="Batch identifier (requires --batch-role and --batch-purpose)"
+    )
+    parser.add_argument(
+        "--batch-role",
+        default=None,
+        choices=["dataset", "baseline", "challenger", "gate"],
+        help="Role within batch (requires --batch-id and --batch-purpose)"
+    )
+    parser.add_argument(
+        "--batch-purpose",
+        default=None,
+        choices=["promotion", "exploration", "regression"],
+        help="Batch intent (requires --batch-id and --batch-role)"
+    )
     return parser.parse_args()
 
 
@@ -236,7 +254,10 @@ def format_duration(seconds: float) -> str:
 
 def main():
     args = parse_args()
-    
+
+    # Validate batch metadata (all-or-nothing)
+    batch = BatchMetadata.from_cli_args(args.batch_id, args.batch_role, args.batch_purpose)
+
     # Load configuration
     print(f"📄 Loading configuration: {args.config}")
     config = load_config(args.config)
@@ -913,7 +934,11 @@ def main():
         "pair_deals": pair_deals,  # True = same physical deals across all scenarios
         "total_hands": total_hands,
     }
-    
+
+    # Add batch metadata only when provided (backward compatible)
+    if batch is not None:
+        meta["batch"] = batch.to_dict()
+
     with open(os.path.join(run_dir, "meta.json"), "w") as f:
         json.dump(meta, f, indent=2, sort_keys=True)
     

--- a/src/bid_euchre/experiments/batch.py
+++ b/src/bid_euchre/experiments/batch.py
@@ -1,0 +1,59 @@
+"""Batch metadata for experiment runs.
+
+Provides optional batch context (batch_id, batch_role, batch_purpose)
+that can be attached to individual experiment runs via CLI flags.
+"""
+
+from dataclasses import asdict, dataclass
+from typing import Optional
+
+VALID_BATCH_ROLES = {"dataset", "baseline", "challenger", "gate"}
+VALID_BATCH_PURPOSES = {"promotion", "exploration", "regression"}
+
+
+@dataclass(frozen=True)
+class BatchMetadata:
+    """Immutable batch context for a single experiment run."""
+
+    batch_id: str
+    batch_role: str
+    batch_purpose: str
+
+    def __post_init__(self):
+        if not self.batch_id:
+            raise ValueError("batch_id must be non-empty")
+        if self.batch_role not in VALID_BATCH_ROLES:
+            raise ValueError(
+                f"batch_role must be one of {sorted(VALID_BATCH_ROLES)}"
+            )
+        if self.batch_purpose not in VALID_BATCH_PURPOSES:
+            raise ValueError(
+                f"batch_purpose must be one of {sorted(VALID_BATCH_PURPOSES)}"
+            )
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_cli_args(
+        cls,
+        batch_id: Optional[str],
+        batch_role: Optional[str],
+        batch_purpose: Optional[str],
+    ) -> Optional["BatchMetadata"]:
+        """Create from CLI args. Returns None if all are None.
+
+        Raises ValueError if only some flags are provided (all-or-nothing).
+        """
+        args = [batch_id, batch_role, batch_purpose]
+        if all(a is None for a in args):
+            return None
+        if any(a is None for a in args):
+            names = ["--batch-id", "--batch-role", "--batch-purpose"]
+            provided = {n for n, v in zip(names, args) if v is not None}
+            missing = set(names) - provided
+            raise ValueError(
+                f"Batch flags are all-or-nothing. "
+                f"Provided: {sorted(provided)}, missing: {sorted(missing)}"
+            )
+        return cls(batch_id=batch_id, batch_role=batch_role, batch_purpose=batch_purpose)

--- a/tests/unit/test_batch_metadata.py
+++ b/tests/unit/test_batch_metadata.py
@@ -1,0 +1,106 @@
+"""Tests for BatchMetadata dataclass and CLI factory."""
+
+import pytest
+
+from bid_euchre.experiments.batch import BatchMetadata
+
+
+class TestBatchMetadata:
+    """Tests for BatchMetadata construction and validation."""
+
+    def test_valid_construction(self):
+        bm = BatchMetadata(
+            batch_id="test_001",
+            batch_role="dataset",
+            batch_purpose="exploration",
+        )
+        assert bm.batch_id == "test_001"
+        assert bm.batch_role == "dataset"
+        assert bm.batch_purpose == "exploration"
+
+    def test_to_dict_roundtrip(self):
+        bm = BatchMetadata(
+            batch_id="test_001",
+            batch_role="baseline",
+            batch_purpose="promotion",
+        )
+        d = bm.to_dict()
+        assert d == {
+            "batch_id": "test_001",
+            "batch_role": "baseline",
+            "batch_purpose": "promotion",
+        }
+
+    def test_invalid_role_rejected(self):
+        with pytest.raises(ValueError, match="batch_role must be one of"):
+            BatchMetadata(
+                batch_id="test_001",
+                batch_role="unknown",
+                batch_purpose="exploration",
+            )
+
+    def test_invalid_purpose_rejected(self):
+        with pytest.raises(ValueError, match="batch_purpose must be one of"):
+            BatchMetadata(
+                batch_id="test_001",
+                batch_role="dataset",
+                batch_purpose="unknown",
+            )
+
+    def test_empty_batch_id_rejected(self):
+        with pytest.raises(ValueError, match="batch_id must be non-empty"):
+            BatchMetadata(
+                batch_id="",
+                batch_role="dataset",
+                batch_purpose="exploration",
+            )
+
+    def test_frozen(self):
+        bm = BatchMetadata(
+            batch_id="test_001",
+            batch_role="dataset",
+            batch_purpose="exploration",
+        )
+        with pytest.raises(AttributeError):
+            bm.batch_id = "modified"
+
+    def test_all_valid_roles(self):
+        for role in ["dataset", "baseline", "challenger", "gate"]:
+            bm = BatchMetadata(
+                batch_id="test", batch_role=role, batch_purpose="exploration"
+            )
+            assert bm.batch_role == role
+
+    def test_all_valid_purposes(self):
+        for purpose in ["promotion", "exploration", "regression"]:
+            bm = BatchMetadata(
+                batch_id="test", batch_role="dataset", batch_purpose=purpose
+            )
+            assert bm.batch_purpose == purpose
+
+
+class TestFromCliArgs:
+    """Tests for BatchMetadata.from_cli_args factory."""
+
+    def test_all_none_returns_none(self):
+        result = BatchMetadata.from_cli_args(None, None, None)
+        assert result is None
+
+    def test_partial_raises(self):
+        with pytest.raises(ValueError, match="all-or-nothing"):
+            BatchMetadata.from_cli_args("test_001", None, None)
+
+    def test_partial_raises_two_of_three(self):
+        with pytest.raises(ValueError, match="all-or-nothing"):
+            BatchMetadata.from_cli_args("test_001", "dataset", None)
+
+    def test_all_provided(self):
+        result = BatchMetadata.from_cli_args("test_001", "dataset", "exploration")
+        assert result is not None
+        assert result.batch_id == "test_001"
+        assert result.batch_role == "dataset"
+        assert result.batch_purpose == "exploration"
+
+    def test_all_provided_validates_role(self):
+        with pytest.raises(ValueError, match="batch_role must be one of"):
+            BatchMetadata.from_cli_args("test_001", "bad_role", "exploration")


### PR DESCRIPTION
## Summary
- Add `BatchMetadata` frozen dataclass in `src/bid_euchre/experiments/batch.py`
- Add `--batch-id`, `--batch-role`, `--batch-purpose` CLI flags to `run_experiment.py`
- Write `batch` field to meta.json only when all three flags are provided

## Why
Batch metadata enables downstream tools (suite rollup, eligibility engine) to
identify run context (role, purpose) for promotion workflows.

## Repro / Validation
```bash
# Without batch flags (backward compat):
uv run python experiments/run_experiment.py --config experiments/configs/quick_test.yaml --seed 42 --n_per 5
# Verify no "batch" key in meta.json

# With batch flags:
uv run python experiments/run_experiment.py --config experiments/configs/quick_test.yaml --seed 42 --n_per 5 \
  --batch-id test_001 --batch-role dataset --batch-purpose exploration
# Verify "batch" key present in meta.json

# Partial flags should fail:
uv run python experiments/run_experiment.py --config experiments/configs/quick_test.yaml --seed 42 --n_per 5 \
  --batch-id test_001
# Should error: "Batch flags are all-or-nothing"
```

## Tests
- [x] `make check` passes
- [x] `uv run python -m pytest tests/unit/test_batch_metadata.py -v` — 13 passed

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (additive CLI flags, backward compatible)

## Worktree proof
`pwd`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-arc-c-pr01`
`git rev-parse --show-toplevel`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-arc-c-pr01`

## Checklist
- [x] No generated artifacts committed
- [x] Behavior changes have matching tests
- [x] PR is focused (one concept)

**Stacked on:** #311 (PR-00)