### PR TITLE
feat(batch): Suite batch propagation + per-config extra args (Arc C PR-02)

### DIFF
--- a/scripts/run_suite.py
+++ b/scripts/run_suite.py
@@ -63,6 +63,17 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Print commands without executing"
     )
+    parser.add_argument(
+        "--batch-id",
+        default=None,
+        help="Override batch ID (default: auto-generated from suite name + seed + timestamp)"
+    )
+    parser.add_argument(
+        "--batch-purpose",
+        default=None,
+        choices=["promotion", "exploration", "regression"],
+        help="Override batch purpose"
+    )
     return parser.parse_args()
 
 
@@ -226,22 +237,52 @@ def discover_new_run_dir(run_base: Path, dirs_before: set) -> Path:
     return run_base / list(new_dirs)[0]
 
 
-def run_experiment(
+def resolve_batch_context(
+    suite: Dict,
+    args: argparse.Namespace,
+    suite_name: str,
+    seed: int,
+) -> tuple:
+    """Resolve batch metadata from suite YAML + CLI overrides.
+
+    Returns:
+        (batch_id, batch_purpose, config_overrides) tuple.
+        batch_id and batch_purpose are None when batch is inactive.
+    """
+    suite_batch = suite.get("batch", {})
+    config_overrides = suite.get("config_overrides", {})
+
+    # CLI precedence over YAML
+    batch_id = args.batch_id or suite_batch.get("batch_id")
+    batch_purpose = args.batch_purpose or suite_batch.get("batch_purpose")
+
+    # All-or-nothing: batch_id without purpose is an error
+    if batch_id and not batch_purpose:
+        raise ValueError(
+            "batch_id provided without batch_purpose. "
+            "Batch metadata requires at least batch_purpose."
+        )
+
+    # Auto-generate batch_id when purpose is set but id is not
+    if batch_purpose and not batch_id:
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        batch_id = f"{suite_name}_{seed}_{timestamp}"
+
+    return batch_id, batch_purpose, config_overrides
+
+
+def build_experiment_cmd(
     config_path: str,
     seed: int,
     n_per: int,
     log_level: str,
-    run_base: Path
-) -> Path:
-    """
-    Run a single experiment config and return the created run directory.
-    
-    Returns:
-        Path to the created run directory
-    """
-    # Snapshot existing directories
-    dirs_before = set(d.name for d in run_base.iterdir() if d.is_dir())
-    
+    run_base: str,
+    batch_id: str | None,
+    batch_role: str | None,
+    batch_purpose: str | None,
+    extra_args: list[str] | None,
+) -> list[str]:
+    """Build the command list for a single experiment run."""
     cmd = [
         "python",
         "experiments/run_experiment.py",
@@ -249,13 +290,45 @@ def run_experiment(
         "--seed", str(seed),
         "--n_per", str(n_per),
         "--log-level", log_level,
-        "--run-dir", str(run_base)
+        "--run-dir", run_base,
     ]
-    
+    if batch_purpose:
+        cmd += ["--batch-id", batch_id, "--batch-role", batch_role,
+                "--batch-purpose", batch_purpose]
+    if extra_args:
+        cmd += extra_args
+    return cmd
+
+
+def run_experiment(
+    config_path: str,
+    seed: int,
+    n_per: int,
+    log_level: str,
+    run_base: Path,
+    batch_id: str | None = None,
+    batch_role: str | None = None,
+    batch_purpose: str | None = None,
+    extra_args: list[str] | None = None,
+) -> Path:
+    """
+    Run a single experiment config and return the created run directory.
+
+    Returns:
+        Path to the created run directory
+    """
+    # Snapshot existing directories
+    dirs_before = set(d.name for d in run_base.iterdir() if d.is_dir())
+
+    cmd = build_experiment_cmd(
+        config_path, seed, n_per, log_level, str(run_base),
+        batch_id, batch_role, batch_purpose, extra_args,
+    )
+
     env = {**os.environ, "PYTHONPATH": "src"}
-    
+
     print(f"  Running: {config_path}")
-    
+
     try:
         subprocess.run(
             cmd,
@@ -272,11 +345,11 @@ def run_experiment(
         print(f"Stdout:\n{e.stdout}", file=sys.stderr)
         print(f"Stderr:\n{e.stderr}", file=sys.stderr)
         raise
-    
+
     # Discover the created run directory
     run_dir = discover_new_run_dir(run_base, dirs_before)
     print(f"  ✓ Run completed: {run_dir.name}")
-    
+
     return run_dir
 
 
@@ -315,7 +388,10 @@ def create_suite_rollup(
     suite_path: str,
     effective_params: Dict,
     member_runs: List[Dict],
-    run_base: Path
+    run_base: Path,
+    batch_id: str | None = None,
+    batch_purpose: str | None = None,
+    config_overrides: Dict | None = None,
 ) -> Path:
     """
     Create suite rollup run directory with metadata.
@@ -401,8 +477,20 @@ def create_suite_rollup(
         "suite_n_per": effective_params["n_per"],
         "created_at_utc": created_at_utc,
         "configs": member_runs,
-        "summary": summary
+        "summary": summary,
     }
+
+    # Add batch section only when batch is active
+    if batch_purpose:
+        overrides = config_overrides or {}
+        rollup["batch"] = {
+            "batch_id": batch_id,
+            "batch_purpose": batch_purpose,
+            "config_roles": {
+                Path(c).name: overrides.get(Path(c).name, {}).get("batch_role", "baseline")
+                for c in suite["configs"]
+            },
+        }
 
     with (rollup_dir / "rollup.json").open("w") as f:
         json.dump(rollup, f, indent=2, sort_keys=True)
@@ -448,7 +536,12 @@ def main():
     
     # Resolve parameters
     effective_params = resolve_parameters(suite, args)
-    
+
+    # Resolve batch context
+    batch_id, batch_purpose, config_overrides = resolve_batch_context(
+        suite, args, suite_name, effective_params["seed"]
+    )
+
     print("======================================================================")
     print(f"🚀 Suite: {suite_name}")
     print("======================================================================")
@@ -457,17 +550,24 @@ def main():
     print(f"n_per: {effective_params['n_per']}")
     print(f"log_level: {effective_params['log_level']}")
     print(f"Generate reports: {not args.no_reports}")
+    if batch_purpose:
+        print(f"Batch ID: {batch_id}")
+        print(f"Batch purpose: {batch_purpose}")
     print("======================================================================\n")
-    
+
     if args.dry_run:
         print("🔍 Dry run - commands that would be executed:\n")
         for config_path in suite["configs"]:
-            print("  python experiments/run_experiment.py \\")
-            print(f"    --config {config_path} \\")
-            print(f"    --seed {effective_params['seed']} \\")
-            print(f"    --n-per {effective_params['n_per']} \\")
-            print(f"    --log-level {effective_params['log_level']} \\")
-            print(f"    --run-dir {args.run_dir}\n")
+            config_name = Path(config_path).name
+            overrides = config_overrides.get(config_name, {})
+            batch_role = overrides.get("batch_role", "baseline")
+            extra_args = overrides.get("extra_args", [])
+            cmd = build_experiment_cmd(
+                config_path, effective_params["seed"], effective_params["n_per"],
+                effective_params["log_level"], args.run_dir,
+                batch_id, batch_role, batch_purpose, extra_args,
+            )
+            print("  " + " \\\n    ".join(cmd) + "\n")
         print("Rollup would be created after all runs complete.")
         return 0
     
@@ -480,14 +580,23 @@ def main():
     
     for i, config_path in enumerate(suite["configs"], 1):
         print(f"[{i}/{len(suite['configs'])}] {config_path}")
-        
+
+        config_name = Path(config_path).name
+        overrides = config_overrides.get(config_name, {})
+        batch_role = overrides.get("batch_role", "baseline") if batch_purpose else None
+        extra_args = overrides.get("extra_args", [])
+
         try:
             run_dir = run_experiment(
                 config_path,
                 effective_params["seed"],
                 effective_params["n_per"],
                 effective_params["log_level"],
-                run_base
+                run_base,
+                batch_id=batch_id,
+                batch_role=batch_role,
+                batch_purpose=batch_purpose,
+                extra_args=extra_args or None,
             )
             
             # Load meta.json to get git_sha
@@ -532,7 +641,10 @@ def main():
         args.suite,
         effective_params,
         member_runs,
-        run_base
+        run_base,
+        batch_id=batch_id,
+        batch_purpose=batch_purpose,
+        config_overrides=config_overrides,
     )
     
     print("======================================================================")

--- a/scripts/validate_configs.py
+++ b/scripts/validate_configs.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 import yaml
 
+from bid_euchre.experiments.batch import VALID_BATCH_PURPOSES, VALID_BATCH_ROLES
 from bid_euchre.experiments.config import ExperimentConfig
 
 
@@ -106,6 +107,49 @@ def validate_suite_file(path: Path) -> list[str]:
         if "parameters" in data:
             if not isinstance(data["parameters"], dict):
                 errors.append(f"{path}: 'parameters' must be a dict")
+
+        # Validate optional batch section
+        if "batch" in data:
+            batch = data["batch"]
+            if not isinstance(batch, dict):
+                errors.append(f"{path}: 'batch' must be a dict")
+            else:
+                bp = batch.get("batch_purpose")
+                if bp is None:
+                    errors.append(
+                        f"{path}: batch.batch_purpose is required when batch section is present"
+                    )
+                elif bp not in VALID_BATCH_PURPOSES:
+                    errors.append(
+                        f"{path}: batch.batch_purpose must be one of {sorted(VALID_BATCH_PURPOSES)}, got '{bp}'"
+                    )
+                bi = batch.get("batch_id")
+                if bi is not None and not isinstance(bi, str):
+                    errors.append(f"{path}: batch.batch_id must be a string or null")
+
+        # Validate optional config_overrides section
+        if "config_overrides" in data:
+            co = data["config_overrides"]
+            if not isinstance(co, dict):
+                errors.append(f"{path}: 'config_overrides' must be a dict")
+            else:
+                for config_key, overrides in co.items():
+                    if not isinstance(overrides, dict):
+                        errors.append(
+                            f"{path}: config_overrides.{config_key} must be a dict"
+                        )
+                        continue
+                    role = overrides.get("batch_role")
+                    if role is not None and role not in VALID_BATCH_ROLES:
+                        errors.append(
+                            f"{path}: config_overrides.{config_key}.batch_role "
+                            f"must be one of {sorted(VALID_BATCH_ROLES)}, got '{role}'"
+                        )
+                    ea = overrides.get("extra_args")
+                    if ea is not None and not isinstance(ea, list):
+                        errors.append(
+                            f"{path}: config_overrides.{config_key}.extra_args must be a list"
+                        )
 
     except FileNotFoundError as e:
         errors.append(f"{path}: {e}")

--- a/tests/unit/test_suite_batch.py
+++ b/tests/unit/test_suite_batch.py
@@ -1,0 +1,276 @@
+"""Tests for suite batch propagation and per-config overrides."""
+
+import argparse
+from unittest.mock import patch
+
+import pytest
+
+from scripts.run_suite import (
+    build_experiment_cmd,
+    create_suite_rollup,
+    resolve_batch_context,
+)
+from scripts.validate_configs import validate_suite_file
+
+
+def _make_args(**overrides):
+    """Create a minimal argparse.Namespace for tests."""
+    defaults = {
+        "batch_id": None,
+        "batch_purpose": None,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def _make_suite(**overrides):
+    """Create a minimal suite dict for tests."""
+    base = {
+        "suite_name": "test_suite",
+        "parameters": {"seed": 42, "n_per": 20, "log_level": "none"},
+        "configs": [
+            "experiments/configs/quick_test.yaml",
+            "experiments/configs/baseline_greedy.yaml",
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+class TestResolveBatchContext:
+    """Tests for resolve_batch_context."""
+
+    def test_no_batch_returns_none(self):
+        suite = _make_suite()
+        args = _make_args()
+        batch_id, batch_purpose, config_overrides = resolve_batch_context(
+            suite, args, "test_suite", 42
+        )
+        assert batch_id is None
+        assert batch_purpose is None
+        assert config_overrides == {}
+
+    def test_suite_yaml_batch_purpose(self):
+        suite = _make_suite(batch={"batch_purpose": "promotion"})
+        args = _make_args()
+        batch_id, batch_purpose, _ = resolve_batch_context(
+            suite, args, "test_suite", 42
+        )
+        assert batch_purpose == "promotion"
+        assert batch_id is not None  # auto-generated
+        assert batch_id.startswith("test_suite_42_")
+
+    def test_suite_yaml_batch_id_and_purpose(self):
+        suite = _make_suite(
+            batch={"batch_id": "manual_123", "batch_purpose": "exploration"}
+        )
+        args = _make_args()
+        batch_id, batch_purpose, _ = resolve_batch_context(
+            suite, args, "test_suite", 42
+        )
+        assert batch_id == "manual_123"
+        assert batch_purpose == "exploration"
+
+    def test_cli_override_precedence(self):
+        suite = _make_suite(
+            batch={"batch_id": "yaml_id", "batch_purpose": "exploration"}
+        )
+        args = _make_args(batch_id="cli_id", batch_purpose="promotion")
+        batch_id, batch_purpose, _ = resolve_batch_context(
+            suite, args, "test_suite", 42
+        )
+        assert batch_id == "cli_id"
+        assert batch_purpose == "promotion"
+
+    def test_batch_id_without_purpose_fails(self):
+        suite = _make_suite()
+        args = _make_args(batch_id="orphan_id")
+        with pytest.raises(ValueError, match="batch_id provided without batch_purpose"):
+            resolve_batch_context(suite, args, "test_suite", 42)
+
+    def test_batch_purpose_auto_generates_id(self):
+        suite = _make_suite()
+        args = _make_args(batch_purpose="regression")
+        batch_id, batch_purpose, _ = resolve_batch_context(
+            suite, args, "test_suite", 42
+        )
+        assert batch_purpose == "regression"
+        assert batch_id.startswith("test_suite_42_")
+
+    def test_config_overrides_passed_through(self):
+        overrides = {
+            "quick_test.yaml": {"batch_role": "dataset", "extra_args": ["--emit-bidless-dataset"]},
+        }
+        suite = _make_suite(config_overrides=overrides)
+        args = _make_args()
+        _, _, config_overrides = resolve_batch_context(
+            suite, args, "test_suite", 42
+        )
+        assert config_overrides == overrides
+
+
+class TestBuildExperimentCmd:
+    """Tests for build_experiment_cmd."""
+
+    def test_without_batch(self):
+        cmd = build_experiment_cmd(
+            "experiments/configs/quick_test.yaml", 42, 20, "none", "data/runs",
+            None, None, None, None,
+        )
+        assert "--batch-id" not in cmd
+        assert "--batch-role" not in cmd
+        assert "--batch-purpose" not in cmd
+        assert "--config" in cmd
+
+    def test_with_batch(self):
+        cmd = build_experiment_cmd(
+            "experiments/configs/quick_test.yaml", 42, 20, "none", "data/runs",
+            "batch_001", "dataset", "promotion", None,
+        )
+        assert "--batch-id" in cmd
+        idx = cmd.index("--batch-id")
+        assert cmd[idx + 1] == "batch_001"
+        assert "--batch-role" in cmd
+        assert "--batch-purpose" in cmd
+
+    def test_with_extra_args(self):
+        cmd = build_experiment_cmd(
+            "experiments/configs/quick_test.yaml", 42, 20, "none", "data/runs",
+            "batch_001", "dataset", "promotion",
+            ["--emit-bidless-dataset", "--emit-bidless-outcomes-dataset"],
+        )
+        assert "--emit-bidless-dataset" in cmd
+        assert "--emit-bidless-outcomes-dataset" in cmd
+
+    def test_extra_args_without_batch(self):
+        cmd = build_experiment_cmd(
+            "experiments/configs/quick_test.yaml", 42, 20, "none", "data/runs",
+            None, None, None, ["--force"],
+        )
+        assert "--force" in cmd
+        assert "--batch-id" not in cmd
+
+
+class TestRollupBatchMetadata:
+    """Tests for batch metadata in rollup.json."""
+
+    def test_rollup_without_batch(self, tmp_path):
+        suite = _make_suite()
+        member_runs = [
+            {"config_path": "experiments/configs/quick_test.yaml",
+             "run_id": "quick_test_42_20260210", "run_dir": "quick_test_42_20260210",
+             "status": "ok", "git_sha": "abc1234"},
+        ]
+        # Create a fake run dir with results
+        run_dir = tmp_path / "quick_test_42_20260210"
+        run_dir.mkdir()
+        (run_dir / "results").mkdir()
+
+        with patch("scripts.run_suite.get_git_sha", return_value="abc1234"), \
+             patch("scripts.run_suite.compute_file_sha256", return_value="deadbeef"):
+            rollup_dir = create_suite_rollup(
+                suite, "experiments/suites/test.yaml",
+                {"seed": 42, "n_per": 20, "log_level": "none"},
+                member_runs, tmp_path,
+            )
+
+        import json
+        rollup = json.loads((rollup_dir / "rollup.json").read_text())
+        assert "batch" not in rollup
+
+    def test_rollup_with_batch(self, tmp_path):
+        suite = _make_suite(
+            config_overrides={
+                "quick_test.yaml": {"batch_role": "dataset"},
+            }
+        )
+        member_runs = [
+            {"config_path": "experiments/configs/quick_test.yaml",
+             "run_id": "quick_test_42_20260210", "run_dir": "quick_test_42_20260210",
+             "status": "ok", "git_sha": "abc1234"},
+            {"config_path": "experiments/configs/baseline_greedy.yaml",
+             "run_id": "baseline_greedy_42_20260210", "run_dir": "baseline_greedy_42_20260210",
+             "status": "ok", "git_sha": "abc1234"},
+        ]
+        for run in member_runs:
+            d = tmp_path / run["run_dir"]
+            d.mkdir()
+            (d / "results").mkdir()
+
+        with patch("scripts.run_suite.get_git_sha", return_value="abc1234"), \
+             patch("scripts.run_suite.compute_file_sha256", return_value="deadbeef"):
+            rollup_dir = create_suite_rollup(
+                suite, "experiments/suites/test.yaml",
+                {"seed": 42, "n_per": 20, "log_level": "none"},
+                member_runs, tmp_path,
+                batch_id="batch_001", batch_purpose="promotion",
+                config_overrides=suite.get("config_overrides", {}),
+            )
+
+        import json
+        rollup = json.loads((rollup_dir / "rollup.json").read_text())
+        assert "batch" in rollup
+        assert rollup["batch"]["batch_id"] == "batch_001"
+        assert rollup["batch"]["batch_purpose"] == "promotion"
+        assert rollup["batch"]["config_roles"]["quick_test.yaml"] == "dataset"
+        assert rollup["batch"]["config_roles"]["baseline_greedy.yaml"] == "baseline"
+
+
+class TestValidateSuiteWithBatch:
+    """Tests for validate_configs.py suite validation with batch fields."""
+
+    def test_valid_suite_with_batch(self, tmp_path):
+        suite_yaml = tmp_path / "test.yaml"
+        suite_yaml.write_text(
+            "suite_name: test\n"
+            "parameters:\n  seed: 42\n  n_per: 20\n"
+            "batch:\n  batch_purpose: promotion\n"
+            "configs:\n  - experiments/configs/quick_test.yaml\n"
+        )
+        errors = validate_suite_file(suite_yaml)
+        assert errors == []
+
+    def test_invalid_batch_role_in_overrides(self, tmp_path):
+        suite_yaml = tmp_path / "test.yaml"
+        suite_yaml.write_text(
+            "suite_name: test\n"
+            "parameters:\n  seed: 42\n  n_per: 20\n"
+            "config_overrides:\n"
+            "  quick_test.yaml:\n"
+            "    batch_role: invalid_role\n"
+            "configs:\n  - experiments/configs/quick_test.yaml\n"
+        )
+        errors = validate_suite_file(suite_yaml)
+        assert any("batch_role" in e for e in errors)
+
+    def test_missing_batch_purpose(self, tmp_path):
+        suite_yaml = tmp_path / "test.yaml"
+        suite_yaml.write_text(
+            "suite_name: test\n"
+            "parameters:\n  seed: 42\n  n_per: 20\n"
+            "batch:\n  batch_id: some_id\n"
+            "configs:\n  - experiments/configs/quick_test.yaml\n"
+        )
+        errors = validate_suite_file(suite_yaml)
+        assert any("batch_purpose is required" in e for e in errors)
+
+    def test_invalid_batch_purpose(self, tmp_path):
+        suite_yaml = tmp_path / "test.yaml"
+        suite_yaml.write_text(
+            "suite_name: test\n"
+            "parameters:\n  seed: 42\n  n_per: 20\n"
+            "batch:\n  batch_purpose: invalid\n"
+            "configs:\n  - experiments/configs/quick_test.yaml\n"
+        )
+        errors = validate_suite_file(suite_yaml)
+        assert any("batch_purpose must be one of" in e for e in errors)
+
+    def test_suite_without_batch_unchanged(self, tmp_path):
+        suite_yaml = tmp_path / "test.yaml"
+        suite_yaml.write_text(
+            "suite_name: test\n"
+            "parameters:\n  seed: 42\n  n_per: 20\n"
+            "configs:\n  - experiments/configs/quick_test.yaml\n"
+        )
+        errors = validate_suite_file(suite_yaml)
+        assert errors == []


### PR DESCRIPTION
## Summary
- Add batch context resolution to `run_suite.py`: YAML `batch` section + CLI overrides
- Add `config_overrides` section for per-config `batch_role` and `extra_args`
- Add batch section to `rollup.json` when batch is active
- Extend `validate_configs.py` to validate new suite YAML fields

## Why
Suite-level batch propagation enables the promotion workflow to tag all member
runs with consistent batch_id/batch_purpose, while per-config overrides allow
assigning different roles (dataset vs baseline vs challenger) to different configs.

## Repro / Validation
```bash
make check
# Dry run without batch (backward compat):
uv run python scripts/run_suite.py --suite experiments/suites/baseline_tiny.yaml --seed 42 --dry-run

# batch_id without purpose should fail:
uv run python scripts/run_suite.py --suite experiments/suites/baseline_tiny.yaml --seed 42 --dry-run --batch-id manual_test
```

## Tests
- [x] `make check` passes
- [x] `uv run python -m pytest tests/unit/test_suite_batch.py -v` — 18 passed

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Medium (modifies suite runner, but backward compatible)

## Worktree proof
`pwd`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-arc-c-pr02`
`git rev-parse --show-toplevel`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-arc-c-pr02`

## Checklist
- [x] No generated artifacts committed
- [x] Behavior changes have matching tests
- [x] PR is focused (one concept)

**Stacked on:** #312 (PR-01)