### PR TITLE
feat(gate): Notebook gate artifact emission + frozen schema (Arc C PR-03)

### DIFF
--- a/scripts/run_notebooks.py
+++ b/scripts/run_notebooks.py
@@ -21,10 +21,33 @@ load_or_generate_features() will pick up the injected MODE automatically.
 
 import argparse
 import glob
+import json
 import sys
 import tempfile
 import time
+from datetime import datetime, timezone
 from pathlib import Path
+
+# Frozen schema contract for notebook_gate.json v1
+NOTEBOOK_GATE_SCHEMA_VERSION = 1
+
+NOTEBOOK_GATE_REQUIRED_FIELDS = {
+    "schema_version",
+    "gate_status",
+    "created_at_utc",
+    "mode",
+    "total",
+    "passed",
+    "failed",
+    "notebooks",
+}
+
+NOTEBOOK_RESULT_REQUIRED_FIELDS = {
+    "name",
+    "status",
+    "duration_seconds",
+    "message",
+}
 
 
 def discover_notebooks(pattern: str = "notebooks/phase0_bidless/*.ipynb") -> list[Path]:
@@ -91,6 +114,60 @@ def execute_notebook(
         return False, str(e)[:200], duration
 
 
+def build_gate_artifact(results: list[tuple], mode: str) -> dict:
+    """Build notebook gate JSON from execution results.
+
+    Args:
+        results: List of (name, success, message, duration) tuples
+        mode: Execution mode ("smoke" or "quick")
+
+    Returns:
+        Gate artifact dict conforming to NOTEBOOK_GATE_SCHEMA_VERSION 1
+    """
+    passed = sum(1 for _, success, _, _ in results if success)
+    failed = len(results) - passed
+    return {
+        "schema_version": NOTEBOOK_GATE_SCHEMA_VERSION,
+        "gate_status": "PASS" if failed == 0 else "FAIL",
+        "created_at_utc": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "mode": mode,
+        "total": len(results),
+        "passed": passed,
+        "failed": failed,
+        "notebooks": [
+            {
+                "name": name,
+                "status": "PASS" if success else "FAIL",
+                "duration_seconds": round(duration, 2),
+                "message": message,
+            }
+            for name, success, message, duration in results
+        ],
+    }
+
+
+def build_gate_markdown(gate: dict) -> str:
+    """Build NOTEBOOK_GATE.md from gate artifact dict."""
+    lines = [
+        f"# Notebook Gate: {gate['gate_status']}",
+        "",
+        f"**Mode**: {gate['mode']}",
+        f"**Total**: {gate['total']} | **Passed**: {gate['passed']} | **Failed**: {gate['failed']}",
+        f"**Created**: {gate['created_at_utc']}",
+        "",
+        "## Results",
+        "",
+        "| Notebook | Status | Duration (s) | Message |",
+        "|----------|--------|-------------:|---------|",
+    ]
+    for nb in gate["notebooks"]:
+        lines.append(
+            f"| {nb['name']} | {nb['status']} | {nb['duration_seconds']:.2f} | {nb['message']} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Execute notebooks for validation",
@@ -112,6 +189,11 @@ def main():
         "--keep-outputs",
         action="store_true",
         help="Keep executed notebook outputs (default: use temp dir)",
+    )
+    parser.add_argument(
+        "--gate-output-dir",
+        default=None,
+        help="Directory for gate artifacts (notebook_gate.json + NOTEBOOK_GATE.md)",
     )
     args = parser.parse_args()
 
@@ -170,6 +252,17 @@ def main():
         print(f"Output notebooks: {output_dir} (temp)")
     else:
         print(f"Output notebooks: {output_dir}")
+
+    # Emit gate artifacts if requested
+    if args.gate_output_dir:
+        gate_dir = Path(args.gate_output_dir)
+        gate_dir.mkdir(parents=True, exist_ok=True)
+        gate = build_gate_artifact(results, args.mode)
+        with open(gate_dir / "notebook_gate.json", "w") as f:
+            json.dump(gate, f, indent=2, sort_keys=True)
+        with open(gate_dir / "NOTEBOOK_GATE.md", "w") as f:
+            f.write(build_gate_markdown(gate))
+        print(f"Gate artifacts: {gate_dir}/")
 
     # Exit with error if any failed
     sys.exit(0 if failed == 0 else 1)

--- a/tests/unit/test_notebook_gate.py
+++ b/tests/unit/test_notebook_gate.py
@@ -1,0 +1,106 @@
+"""Tests for notebook gate artifact generation."""
+
+from scripts.run_notebooks import (
+    NOTEBOOK_GATE_REQUIRED_FIELDS,
+    NOTEBOOK_GATE_SCHEMA_VERSION,
+    NOTEBOOK_RESULT_REQUIRED_FIELDS,
+    build_gate_artifact,
+    build_gate_markdown,
+)
+
+
+def _make_results(*specs):
+    """Create results list from (name, success) pairs."""
+    return [
+        (name, success, "OK" if success else "Error: test", 1.5)
+        for name, success in specs
+    ]
+
+
+class TestBuildGateArtifact:
+    """Tests for build_gate_artifact."""
+
+    def test_gate_pass_all_notebooks(self):
+        results = _make_results(
+            ("10_seat_balance.ipynb", True),
+            ("20_outcome_health.ipynb", True),
+        )
+        gate = build_gate_artifact(results, "smoke")
+        assert gate["gate_status"] == "PASS"
+        assert gate["passed"] == 2
+        assert gate["failed"] == 0
+
+    def test_gate_fail_any_notebook(self):
+        results = _make_results(
+            ("10_seat_balance.ipynb", True),
+            ("20_outcome_health.ipynb", False),
+        )
+        gate = build_gate_artifact(results, "smoke")
+        assert gate["gate_status"] == "FAIL"
+        assert gate["passed"] == 1
+        assert gate["failed"] == 1
+
+    def test_gate_empty_results(self):
+        gate = build_gate_artifact([], "smoke")
+        assert gate["gate_status"] == "PASS"
+        assert gate["total"] == 0
+        assert gate["passed"] == 0
+        assert gate["failed"] == 0
+        assert gate["notebooks"] == []
+
+    def test_gate_schema_version(self):
+        gate = build_gate_artifact([], "smoke")
+        assert gate["schema_version"] == NOTEBOOK_GATE_SCHEMA_VERSION
+
+    def test_gate_has_all_required_fields(self):
+        results = _make_results(("10_test.ipynb", True))
+        gate = build_gate_artifact(results, "smoke")
+        assert NOTEBOOK_GATE_REQUIRED_FIELDS <= set(gate.keys())
+
+    def test_notebook_results_have_required_fields(self):
+        results = _make_results(
+            ("10_test.ipynb", True),
+            ("20_test.ipynb", False),
+        )
+        gate = build_gate_artifact(results, "quick")
+        for nb in gate["notebooks"]:
+            assert NOTEBOOK_RESULT_REQUIRED_FIELDS <= set(nb.keys()), (
+                f"Missing: {NOTEBOOK_RESULT_REQUIRED_FIELDS - set(nb.keys())}"
+            )
+
+    def test_gate_mode_propagated(self):
+        gate = build_gate_artifact([], "quick")
+        assert gate["mode"] == "quick"
+
+    def test_gate_created_at_utc_has_z_suffix(self):
+        gate = build_gate_artifact([], "smoke")
+        assert gate["created_at_utc"].endswith("Z")
+
+    def test_gate_duration_rounded(self):
+        results = [("test.ipynb", True, "OK", 1.23456)]
+        gate = build_gate_artifact(results, "smoke")
+        assert gate["notebooks"][0]["duration_seconds"] == 1.23
+
+
+class TestBuildGateMarkdown:
+    """Tests for build_gate_markdown."""
+
+    def test_gate_markdown_format(self):
+        results = _make_results(("10_test.ipynb", True))
+        gate = build_gate_artifact(results, "smoke")
+        md = build_gate_markdown(gate)
+        assert "# Notebook Gate: PASS" in md
+        assert "| Notebook | Status |" in md
+        assert "10_test.ipynb" in md
+
+    def test_gate_markdown_fail_status(self):
+        results = _make_results(("10_test.ipynb", False))
+        gate = build_gate_artifact(results, "smoke")
+        md = build_gate_markdown(gate)
+        assert "# Notebook Gate: FAIL" in md
+        assert "FAIL" in md
+
+    def test_gate_markdown_contains_mode(self):
+        gate = build_gate_artifact([], "quick")
+        md = build_gate_markdown(gate)
+        assert "quick" in md


### PR DESCRIPTION
## Summary
- Add `--gate-output-dir` flag to `run_notebooks.py` for gate artifact emission
- Emit `notebook_gate.json` (schema v1) and `NOTEBOOK_GATE.md`
- Frozen schema contract with `NOTEBOOK_GATE_SCHEMA_VERSION = 1` and required field sets

## Why
Promotion eligibility (PR-04) needs a machine-readable notebook gate artifact
to verify notebooks passed before promoting a batch. This PR provides the
artifact emission; PR-04 will consume it.

## Repro / Validation
```bash
make check
PYTHONPATH=src uv run python scripts/run_notebooks.py --mode smoke \
  --gate-output-dir /tmp/gate_test
cat /tmp/gate_test/notebook_gate.json
cat /tmp/gate_test/NOTEBOOK_GATE.md
```

## Tests
- [x] `make check` passes
- [x] `uv run python -m pytest tests/unit/test_notebook_gate.py -v` — 12 passed

## Expected impact
- Metrics impact: None
- Runtime impact: None (no artifacts without --gate-output-dir)

## Risk level
- [x] Low (additive CLI flag, no behavior change without flag)

## Worktree proof
`pwd`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-arc-c-pr03`
`git rev-parse --show-toplevel`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-arc-c-pr03`

## Checklist
- [x] No generated artifacts committed
- [x] Behavior changes have matching tests
- [x] PR is focused (one concept)

**Stacked on:** #313 (PR-02)