### PR TITLE
feat(batch): Eligibility engine + internal batch report CLI (Arc C PR-04)

### DIFF
--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -58,6 +58,7 @@ Canonical scripts:
 **Research and internal tooling.** Not part of the canonical workflow.
 
 - `evaluate_diagnostic_tricks.py` — Diagnostic Ridge evaluation
+- `generate_batch_report.py` — Batch report + eligibility gate
 - `play_policy_gate.py` — Play policy stability gate
 - `run_auction_comparator.py` — Auction comparator orchestrator
 
@@ -170,9 +171,10 @@ Every experiment run creates a standardized directory under `data/runs/<run_id>/
 
 | Command | Purpose |
 |---------|---------|
-| `scripts/internal/run_auction_comparator.py` | Auction comparator orchestrator |
 | `scripts/internal/evaluate_diagnostic_tricks.py` | Diagnostic Ridge evaluation |
+| `scripts/internal/generate_batch_report.py` | Batch report + eligibility gate |
 | `scripts/internal/play_policy_gate.py` | Play policy stability gate |
+| `scripts/internal/run_auction_comparator.py` | Auction comparator orchestrator |
 
 ### Research tooling (canonical path)
 

--- a/scripts/internal/generate_batch_report.py
+++ b/scripts/internal/generate_batch_report.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+"""Generate batch report with eligibility gate from suite rollup.
+
+Aggregates run artifacts into a single batch report with machine-readable
+eligibility gate (batch_gate.json) and human-readable report (BATCH_REPORT.md).
+
+Usage:
+    PYTHONPATH=src python scripts/internal/generate_batch_report.py \
+        --rollup data/runs/suite_<id>/rollup.json \
+        --output /tmp/batch_report
+
+    PYTHONPATH=src python scripts/internal/generate_batch_report.py \
+        --rollup data/runs/suite_<id>/rollup.json \
+        --notebook-gate data/runs/suite_<id>/notebook_gate.json \
+        --output /tmp/batch_report \
+        --expected-configs config_a.yaml,config_b.yaml
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from bid_euchre.reporting.eligibility import compute_eligibility
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate batch report with eligibility gate",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--rollup",
+        required=True,
+        help="Path to suite rollup.json",
+    )
+    parser.add_argument(
+        "--run-dir",
+        default="data/runs",
+        help="Base run directory (default: data/runs)",
+    )
+    parser.add_argument(
+        "--notebook-gate",
+        default=None,
+        help="Path to notebook_gate.json (optional)",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Output directory for batch_gate.json and BATCH_REPORT.md",
+    )
+    parser.add_argument(
+        "--expected-configs",
+        default=None,
+        help="Comma-separated config filenames for membership check (optional)",
+    )
+    return parser.parse_args()
+
+
+def build_batch_report_markdown(rollup: dict, gate_dict: dict) -> str:
+    """Build human-readable BATCH_REPORT.md."""
+    lines = []
+
+    # Header
+    batch = rollup.get("batch", {})
+    batch_id = batch.get("batch_id", gate_dict.get("batch_id", "unknown"))
+    batch_purpose = batch.get("batch_purpose", gate_dict.get("batch_purpose", "unknown"))
+    eligible = gate_dict.get("eligible", False)
+    status_str = "ELIGIBLE" if eligible else "NOT ELIGIBLE"
+
+    lines.append(f"# Batch Report: {batch_id}")
+    lines.append("")
+    lines.append(f"**Status**: {status_str}")
+    lines.append(f"**Purpose**: {batch_purpose}")
+    lines.append(f"**Suite**: {rollup.get('suite_name', 'unknown')}")
+    lines.append(f"**Seed**: {rollup.get('suite_seed', 'unknown')}")
+    lines.append(f"**Created**: {gate_dict.get('created_at_utc', 'unknown')}")
+    lines.append("")
+
+    # Member runs
+    lines.append("## Member Runs")
+    lines.append("")
+    lines.append("| Config | Run ID | Status | Git SHA |")
+    lines.append("|--------|--------|--------|---------|")
+    for config in rollup.get("configs", []):
+        config_name = Path(config.get("config_path", "")).name
+        status_icon = "PASS" if config.get("status") == "ok" else "FAIL"
+        lines.append(
+            f"| {config_name} | {config.get('run_id', 'N/A')} "
+            f"| {status_icon} | {config.get('git_sha', 'N/A')} |"
+        )
+    lines.append("")
+
+    # Eligibility gate
+    lines.append("## Eligibility Gate")
+    lines.append("")
+    lines.append("| Rule | Status | Detail |")
+    lines.append("|------|--------|--------|")
+    for reason in gate_dict.get("reasons", []):
+        lines.append(
+            f"| {reason['rule']} | {reason['status']} | {reason['detail']} |"
+        )
+    lines.append("")
+
+    # Repro
+    lines.append("## Repro Commands")
+    lines.append("")
+    lines.append("```bash")
+    lines.append("# Re-run eligibility check:")
+    lines.append(
+        "PYTHONPATH=src python scripts/internal/generate_batch_report.py \\"
+    )
+    lines.append("    --rollup <rollup_path> --output <output_dir>")
+    lines.append("```")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def main():
+    args = parse_args()
+
+    # Load rollup
+    rollup_path = Path(args.rollup)
+    if not rollup_path.exists():
+        print(f"Error: rollup not found: {args.rollup}", file=sys.stderr)
+        sys.exit(1)
+
+    with rollup_path.open() as f:
+        rollup = json.load(f)
+
+    # Resolve batch purpose from rollup or default
+    batch = rollup.get("batch", {})
+    batch_purpose = batch.get("batch_purpose", "exploration")
+
+    # Parse expected configs
+    expected_configs = None
+    if args.expected_configs:
+        expected_configs = set(args.expected_configs.split(","))
+
+    # Compute eligibility
+    gate = compute_eligibility(
+        rollup=rollup,
+        run_base_dir=args.run_dir,
+        batch_purpose=batch_purpose,
+        notebook_gate_path=args.notebook_gate,
+        expected_configs=expected_configs,
+    )
+
+    gate_dict = gate.to_dict()
+
+    # Write outputs
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    with (output_dir / "batch_gate.json").open("w") as f:
+        json.dump(gate_dict, f, indent=2, sort_keys=True)
+
+    report_md = build_batch_report_markdown(rollup, gate_dict)
+    with (output_dir / "BATCH_REPORT.md").open("w") as f:
+        f.write(report_md)
+
+    # Print summary
+    status = "ELIGIBLE" if gate.eligible else "NOT ELIGIBLE"
+    print(f"Batch {gate.batch_id}: {status}")
+    for r in gate.reasons:
+        print(f"  [{r.status}] {r.rule}: {r.detail}")
+    print(f"\nArtifacts: {output_dir}/")
+
+    sys.exit(0 if gate.eligible else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bid_euchre/reporting/eligibility.py
+++ b/src/bid_euchre/reporting/eligibility.py
@@ -1,0 +1,242 @@
+"""Batch eligibility engine for promotion workflow.
+
+Evaluates whether a batch of experiment runs meets promotion criteria
+based on config membership, canonical summary health, notebook gate
+status, and git SHA consistency.
+"""
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Optional
+
+from bid_euchre.experiments.meta import utc_now_iso
+
+
+@dataclass(frozen=True)
+class EligibilityResult:
+    """Result of a single eligibility check."""
+
+    rule: str
+    status: str  # "PASS" or "FAIL"
+    detail: str
+
+
+@dataclass
+class BatchGate:
+    """Aggregated eligibility gate for a batch of runs."""
+
+    eligible: bool
+    reasons: list[EligibilityResult]
+    batch_id: str
+    batch_purpose: str
+    created_at_utc: str
+
+    def to_dict(self) -> dict:
+        return {
+            "schema_version": 1,
+            "eligible": self.eligible,
+            "batch_id": self.batch_id,
+            "batch_purpose": self.batch_purpose,
+            "created_at_utc": self.created_at_utc,
+            "reasons": [asdict(r) for r in self.reasons],
+        }
+
+
+def check_config_membership(
+    rollup: dict,
+    expected_configs: Optional[set[str]] = None,
+) -> EligibilityResult:
+    """Verify all expected configs completed successfully in rollup.
+
+    If expected_configs is None, verify all configs in rollup have status=ok.
+    """
+    configs = rollup.get("configs", [])
+
+    if expected_configs is not None:
+        completed = {
+            Path(c["config_path"]).name
+            for c in configs
+            if c.get("status") == "ok"
+        }
+        missing = expected_configs - completed
+        if missing:
+            return EligibilityResult(
+                rule="config_membership",
+                status="FAIL",
+                detail=f"Missing configs: {sorted(missing)}",
+            )
+        return EligibilityResult(
+            rule="config_membership",
+            status="PASS",
+            detail=f"All {len(expected_configs)} expected configs completed",
+        )
+
+    # No expected set: verify all configs in rollup have status=ok
+    failed = [
+        Path(c["config_path"]).name
+        for c in configs
+        if c.get("status") != "ok"
+    ]
+    if failed:
+        return EligibilityResult(
+            rule="config_membership",
+            status="FAIL",
+            detail=f"Configs with non-ok status: {sorted(failed)}",
+        )
+    return EligibilityResult(
+        rule="config_membership",
+        status="PASS",
+        detail=f"All {len(configs)} configs completed",
+    )
+
+
+def check_canonical_summaries(
+    rollup: dict,
+    run_base_dir: str,
+) -> EligibilityResult:
+    """Verify all member runs have canonical_summary.json with fail_count==0."""
+    configs = rollup.get("configs", [])
+    base = Path(run_base_dir)
+    failures = []
+
+    for config in configs:
+        if config.get("status") != "ok":
+            continue
+        run_dir = config.get("run_dir", "")
+        summary_path = base / run_dir / "reports" / "canonical_summary.json"
+        if not summary_path.exists():
+            failures.append(f"{run_dir}: missing canonical_summary.json")
+            continue
+        try:
+            with summary_path.open() as f:
+                summary = json.load(f)
+            fail_count = summary.get("fail_count", -1)
+            if fail_count != 0:
+                failures.append(f"{run_dir}: fail_count={fail_count}")
+        except (json.JSONDecodeError, KeyError) as e:
+            failures.append(f"{run_dir}: parse error: {e}")
+
+    if failures:
+        return EligibilityResult(
+            rule="canonical_summary_clean",
+            status="FAIL",
+            detail="; ".join(failures[:3]),
+        )
+    return EligibilityResult(
+        rule="canonical_summary_clean",
+        status="PASS",
+        detail="All member runs have clean canonical summaries",
+    )
+
+
+def check_notebook_gate(
+    gate_path: Optional[str],
+    batch_purpose: str,
+) -> EligibilityResult:
+    """Check notebook gate JSON.
+
+    - batch_purpose='promotion' + missing gate -> FAIL (gate required)
+    - batch_purpose='promotion' + gate FAIL -> FAIL
+    - batch_purpose!='promotion' + missing gate -> PASS (optional)
+    - batch_purpose!='promotion' + gate FAIL -> FAIL
+    """
+    if gate_path is None or not Path(gate_path).exists():
+        if batch_purpose == "promotion":
+            return EligibilityResult(
+                rule="notebook_gate",
+                status="FAIL",
+                detail="No notebook gate artifact found (required for promotion)",
+            )
+        return EligibilityResult(
+            rule="notebook_gate",
+            status="PASS",
+            detail="No notebook gate artifact (optional for non-promotion)",
+        )
+
+    try:
+        with open(gate_path) as f:
+            gate = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        return EligibilityResult(
+            rule="notebook_gate",
+            status="FAIL",
+            detail=f"Failed to read gate artifact: {e}",
+        )
+
+    gate_status = gate.get("gate_status", "FAIL")
+    if gate_status != "PASS":
+        failed_nbs = [
+            nb["name"]
+            for nb in gate.get("notebooks", [])
+            if nb.get("status") != "PASS"
+        ]
+        return EligibilityResult(
+            rule="notebook_gate",
+            status="FAIL",
+            detail=f"Notebook gate FAIL: {failed_nbs}",
+        )
+    return EligibilityResult(
+        rule="notebook_gate",
+        status="PASS",
+        detail=f"Notebook gate PASS ({gate.get('passed', 0)}/{gate.get('total', 0)})",
+    )
+
+
+def check_git_sha_consistency(
+    rollup: dict,
+) -> EligibilityResult:
+    """Verify all member runs have matching git_sha."""
+    configs = rollup.get("configs", [])
+    shas = {
+        c.get("git_sha", "unknown")
+        for c in configs
+        if c.get("status") == "ok"
+    }
+    shas.discard("unknown")
+
+    if len(shas) == 0:
+        return EligibilityResult(
+            rule="git_sha_consistency",
+            status="PASS",
+            detail="No git SHAs to compare",
+        )
+    if len(shas) == 1:
+        return EligibilityResult(
+            rule="git_sha_consistency",
+            status="PASS",
+            detail=f"All runs: {shas.pop()}",
+        )
+    return EligibilityResult(
+        rule="git_sha_consistency",
+        status="FAIL",
+        detail=f"Inconsistent git SHAs: {sorted(shas)}",
+    )
+
+
+def compute_eligibility(
+    rollup: dict,
+    run_base_dir: str,
+    batch_purpose: str,
+    notebook_gate_path: Optional[str] = None,
+    expected_configs: Optional[set[str]] = None,
+) -> BatchGate:
+    """Run all eligibility checks. eligible=True only if ALL checks PASS."""
+    batch_id = rollup.get("batch", {}).get("batch_id", "unknown")
+
+    results = [
+        check_config_membership(rollup, expected_configs),
+        check_canonical_summaries(rollup, run_base_dir),
+        check_notebook_gate(notebook_gate_path, batch_purpose),
+        check_git_sha_consistency(rollup),
+    ]
+
+    eligible = all(r.status == "PASS" for r in results)
+
+    return BatchGate(
+        eligible=eligible,
+        reasons=results,
+        batch_id=batch_id,
+        batch_purpose=batch_purpose,
+        created_at_utc=utc_now_iso(),
+    )

--- a/tests/unit/test_eligibility.py
+++ b/tests/unit/test_eligibility.py
@@ -1,0 +1,255 @@
+"""Tests for batch eligibility engine.
+
+All tests are fixture-based — no real experiment runs required.
+"""
+
+import json
+
+from bid_euchre.reporting.eligibility import (
+    check_canonical_summaries,
+    check_config_membership,
+    check_git_sha_consistency,
+    check_notebook_gate,
+    compute_eligibility,
+)
+
+
+def _make_rollup(**overrides):
+    """Create a minimal rollup fixture."""
+    base = {
+        "schema_version": 1,
+        "suite_name": "test_suite",
+        "suite_seed": 42,
+        "suite_n_per": 20,
+        "created_at_utc": "2026-02-10T12:00:00Z",
+        "configs": [
+            {
+                "config_path": "experiments/configs/quick_test.yaml",
+                "run_id": "quick_test_42_20260210",
+                "run_dir": "quick_test_42_20260210",
+                "status": "ok",
+                "git_sha": "abc1234",
+            },
+            {
+                "config_path": "experiments/configs/baseline_greedy.yaml",
+                "run_id": "baseline_greedy_42_20260210",
+                "run_dir": "baseline_greedy_42_20260210",
+                "status": "ok",
+                "git_sha": "abc1234",
+            },
+        ],
+        "summary": [],
+        "batch": {
+            "batch_id": "test_batch_001",
+            "batch_purpose": "promotion",
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_canonical_summary(fail_count=0):
+    return {"fail_count": fail_count, "pass_count": 5}
+
+
+def _make_notebook_gate(gate_status="PASS", total=3, passed=3, failed=0):
+    return {
+        "schema_version": 1,
+        "gate_status": gate_status,
+        "created_at_utc": "2026-02-10T12:00:00Z",
+        "mode": "smoke",
+        "total": total,
+        "passed": passed,
+        "failed": failed,
+        "notebooks": [
+            {"name": f"nb_{i}.ipynb", "status": "PASS" if i < passed else "FAIL",
+             "duration_seconds": 1.0, "message": "OK" if i < passed else "Error"}
+            for i in range(total)
+        ],
+    }
+
+
+class TestCheckConfigMembership:
+
+    def test_all_configs_ok(self):
+        rollup = _make_rollup()
+        result = check_config_membership(rollup)
+        assert result.status == "PASS"
+
+    def test_config_failed_status(self):
+        rollup = _make_rollup()
+        rollup["configs"][1]["status"] = "failed"
+        result = check_config_membership(rollup)
+        assert result.status == "FAIL"
+        assert "baseline_greedy.yaml" in result.detail
+
+    def test_expected_config_missing(self):
+        rollup = _make_rollup()
+        result = check_config_membership(
+            rollup, expected_configs={"quick_test.yaml", "missing_config.yaml"}
+        )
+        assert result.status == "FAIL"
+        assert "missing_config.yaml" in result.detail
+
+    def test_expected_configs_all_present(self):
+        rollup = _make_rollup()
+        result = check_config_membership(
+            rollup, expected_configs={"quick_test.yaml", "baseline_greedy.yaml"}
+        )
+        assert result.status == "PASS"
+
+
+class TestCheckCanonicalSummaries:
+
+    def test_all_clean(self, tmp_path):
+        rollup = _make_rollup()
+        for config in rollup["configs"]:
+            run_dir = tmp_path / config["run_dir"] / "reports"
+            run_dir.mkdir(parents=True)
+            with (run_dir / "canonical_summary.json").open("w") as f:
+                json.dump(_make_canonical_summary(fail_count=0), f)
+
+        result = check_canonical_summaries(rollup, str(tmp_path))
+        assert result.status == "PASS"
+
+    def test_fail_count_nonzero(self, tmp_path):
+        rollup = _make_rollup()
+        for i, config in enumerate(rollup["configs"]):
+            run_dir = tmp_path / config["run_dir"] / "reports"
+            run_dir.mkdir(parents=True)
+            fc = 1 if i == 0 else 0
+            with (run_dir / "canonical_summary.json").open("w") as f:
+                json.dump(_make_canonical_summary(fail_count=fc), f)
+
+        result = check_canonical_summaries(rollup, str(tmp_path))
+        assert result.status == "FAIL"
+        assert "fail_count=1" in result.detail
+
+    def test_missing_canonical_summary(self, tmp_path):
+        rollup = _make_rollup()
+        # Don't create any summary files
+        for config in rollup["configs"]:
+            run_dir = tmp_path / config["run_dir"] / "reports"
+            run_dir.mkdir(parents=True)
+
+        result = check_canonical_summaries(rollup, str(tmp_path))
+        assert result.status == "FAIL"
+        assert "missing" in result.detail
+
+
+class TestCheckNotebookGate:
+
+    def test_promotion_gate_required_missing(self):
+        result = check_notebook_gate(None, "promotion")
+        assert result.status == "FAIL"
+        assert "required for promotion" in result.detail
+
+    def test_promotion_gate_pass(self, tmp_path):
+        gate_path = tmp_path / "notebook_gate.json"
+        with gate_path.open("w") as f:
+            json.dump(_make_notebook_gate(gate_status="PASS"), f)
+        result = check_notebook_gate(str(gate_path), "promotion")
+        assert result.status == "PASS"
+
+    def test_promotion_gate_fail(self, tmp_path):
+        gate_path = tmp_path / "notebook_gate.json"
+        with gate_path.open("w") as f:
+            json.dump(_make_notebook_gate(gate_status="FAIL", passed=2, failed=1), f)
+        result = check_notebook_gate(str(gate_path), "promotion")
+        assert result.status == "FAIL"
+
+    def test_exploration_gate_optional_missing(self):
+        result = check_notebook_gate(None, "exploration")
+        assert result.status == "PASS"
+        assert "optional" in result.detail
+
+    def test_exploration_gate_fail(self, tmp_path):
+        gate_path = tmp_path / "notebook_gate.json"
+        with gate_path.open("w") as f:
+            json.dump(_make_notebook_gate(gate_status="FAIL", passed=2, failed=1), f)
+        result = check_notebook_gate(str(gate_path), "exploration")
+        assert result.status == "FAIL"
+
+    def test_nonexistent_path(self):
+        result = check_notebook_gate("/nonexistent/path.json", "promotion")
+        assert result.status == "FAIL"
+
+
+class TestCheckGitShaConsistency:
+
+    def test_all_same_sha(self):
+        rollup = _make_rollup()
+        result = check_git_sha_consistency(rollup)
+        assert result.status == "PASS"
+        assert "abc1234" in result.detail
+
+    def test_different_shas(self):
+        rollup = _make_rollup()
+        rollup["configs"][1]["git_sha"] = "def5678"
+        result = check_git_sha_consistency(rollup)
+        assert result.status == "FAIL"
+        assert "Inconsistent" in result.detail
+
+    def test_no_shas(self):
+        rollup = _make_rollup(configs=[])
+        result = check_git_sha_consistency(rollup)
+        assert result.status == "PASS"
+
+
+class TestComputeEligibility:
+
+    def test_eligible_all_pass(self, tmp_path):
+        rollup = _make_rollup()
+        # Create canonical summaries
+        for config in rollup["configs"]:
+            run_dir = tmp_path / config["run_dir"] / "reports"
+            run_dir.mkdir(parents=True)
+            with (run_dir / "canonical_summary.json").open("w") as f:
+                json.dump(_make_canonical_summary(fail_count=0), f)
+
+        # Create gate
+        gate_path = tmp_path / "notebook_gate.json"
+        with gate_path.open("w") as f:
+            json.dump(_make_notebook_gate(gate_status="PASS"), f)
+
+        gate = compute_eligibility(
+            rollup, str(tmp_path), "promotion",
+            notebook_gate_path=str(gate_path),
+        )
+        assert gate.eligible is True
+        assert all(r.status == "PASS" for r in gate.reasons)
+
+    def test_any_fail_ineligible(self, tmp_path):
+        rollup = _make_rollup()
+        # Missing canonical summaries will cause FAIL
+        for config in rollup["configs"]:
+            run_dir = tmp_path / config["run_dir"] / "reports"
+            run_dir.mkdir(parents=True)
+
+        gate = compute_eligibility(
+            rollup, str(tmp_path), "promotion",
+        )
+        assert gate.eligible is False
+
+    def test_gate_to_dict(self, tmp_path):
+        rollup = _make_rollup()
+        for config in rollup["configs"]:
+            run_dir = tmp_path / config["run_dir"] / "reports"
+            run_dir.mkdir(parents=True)
+            with (run_dir / "canonical_summary.json").open("w") as f:
+                json.dump(_make_canonical_summary(fail_count=0), f)
+
+        gate_path = tmp_path / "notebook_gate.json"
+        with gate_path.open("w") as f:
+            json.dump(_make_notebook_gate(gate_status="PASS"), f)
+
+        gate = compute_eligibility(
+            rollup, str(tmp_path), "promotion",
+            notebook_gate_path=str(gate_path),
+        )
+        d = gate.to_dict()
+        assert d["schema_version"] == 1
+        assert "eligible" in d
+        assert "reasons" in d
+        assert isinstance(d["reasons"], list)
+        assert all("rule" in r and "status" in r and "detail" in r for r in d["reasons"])


### PR DESCRIPTION
## Summary
- Add `src/bid_euchre/reporting/eligibility.py` with 4 eligibility checks:
  - `config_membership`: All expected configs completed with status=ok
  - `canonical_summary_clean`: All member runs have fail_count==0
  - `notebook_gate`: Promotion-aware gate (required for promotion, optional otherwise)
  - `git_sha_consistency`: All member runs built from same commit
- Add `scripts/internal/generate_batch_report.py` CLI producing `batch_gate.json` + `BATCH_REPORT.md`
- Update ARCHITECTURE.md with new internal script

## Why
The eligibility engine is the core decision point for the promotion workflow.
It aggregates multiple signal sources into a single PASS/FAIL gate that can
be consumed by CI or human reviewers.

## Repro / Validation
```bash
make check
uv run python -m pytest tests/unit/test_eligibility.py -v
```

## Tests
- [x] `make check` passes
- [x] `uv run python -m pytest tests/unit/test_eligibility.py -v` — 19 passed

## Expected impact
- Metrics impact: None
- Runtime impact: None (new code, not wired into existing paths)

## Risk level
- [x] Low (new files only, no existing behavior changes)

## Worktree proof
`pwd`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-arc-c-pr04`
`git rev-parse --show-toplevel`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-arc-c-pr04`

## Checklist
- [x] No generated artifacts committed
- [x] Behavior changes have matching tests
- [x] PR is focused (one concept)

**Stacked on:** #314 (PR-03)