### PR TITLE
fix(arc-c): Fix eligibility artifacts path/schema + tighten suite validation

### DIFF
--- a/scripts/validate_configs.py
+++ b/scripts/validate_configs.py
@@ -133,23 +133,47 @@ def validate_suite_file(path: Path) -> list[str]:
             if not isinstance(co, dict):
                 errors.append(f"{path}: 'config_overrides' must be a dict")
             else:
+                # Get list of config basenames for override key validation
+                if isinstance(data.get("configs"), list):
+                    config_basenames = {Path(cfg).name for cfg in data["configs"] if isinstance(cfg, str)}
+                else:
+                    config_basenames = set()
+
                 for config_key, overrides in co.items():
+                    # Validate override key references an actual config
+                    if config_basenames and config_key not in config_basenames:
+                        errors.append(
+                            f"{path}: config_overrides.{config_key} does not match "
+                            f"any config in suite. Valid configs: {sorted(config_basenames)}"
+                        )
+
                     if not isinstance(overrides, dict):
                         errors.append(
                             f"{path}: config_overrides.{config_key} must be a dict"
                         )
                         continue
+
                     role = overrides.get("batch_role")
                     if role is not None and role not in VALID_BATCH_ROLES:
                         errors.append(
                             f"{path}: config_overrides.{config_key}.batch_role "
                             f"must be one of {sorted(VALID_BATCH_ROLES)}, got '{role}'"
                         )
+
                     ea = overrides.get("extra_args")
-                    if ea is not None and not isinstance(ea, list):
-                        errors.append(
-                            f"{path}: config_overrides.{config_key}.extra_args must be a list"
-                        )
+                    if ea is not None:
+                        if not isinstance(ea, list):
+                            errors.append(
+                                f"{path}: config_overrides.{config_key}.extra_args must be a list"
+                            )
+                        else:
+                            # Validate each element is a string
+                            for i, arg in enumerate(ea):
+                                if not isinstance(arg, str):
+                                    errors.append(
+                                        f"{path}: config_overrides.{config_key}.extra_args[{i}] "
+                                        f"must be a string, got {type(arg).__name__}: {arg!r}"
+                                    )
 
     except FileNotFoundError as e:
         errors.append(f"{path}: {e}")

--- a/src/bid_euchre/reporting/eligibility.py
+++ b/src/bid_euchre/reporting/eligibility.py
@@ -104,14 +104,30 @@ def check_canonical_summaries(
         if config.get("status") != "ok":
             continue
         run_dir = config.get("run_dir", "")
-        summary_path = base / run_dir / "reports" / "canonical_summary.json"
+
+        # Try artifacts/ first (canonical path), then reports/ (legacy fallback)
+        summary_path = base / run_dir / "artifacts" / "canonical_summary.json"
         if not summary_path.exists():
-            failures.append(f"{run_dir}: missing canonical_summary.json")
-            continue
+            legacy_path = base / run_dir / "reports" / "canonical_summary.json"
+            if legacy_path.exists():
+                summary_path = legacy_path
+            else:
+                failures.append(
+                    f"{run_dir}: missing canonical_summary.json "
+                    f"(tried artifacts/ and reports/)"
+                )
+                continue
+
         try:
             with summary_path.open() as f:
                 summary = json.load(f)
-            fail_count = summary.get("fail_count", -1)
+
+            # Try nested schema first (production), then flat schema (legacy)
+            fail_count = summary.get("sanity", {}).get("fail_count")
+            if fail_count is None:
+                # Legacy flat schema
+                fail_count = summary.get("fail_count", -1)
+
             if fail_count != 0:
                 failures.append(f"{run_dir}: fail_count={fail_count}")
         except (json.JSONDecodeError, KeyError) as e:

--- a/tests/unit/test_eligibility.py
+++ b/tests/unit/test_eligibility.py
@@ -49,7 +49,17 @@ def _make_rollup(**overrides):
 
 
 def _make_canonical_summary(fail_count=0):
-    return {"fail_count": fail_count, "pass_count": 5}
+    """Create canonical summary with production nested schema."""
+    return {
+        "sanity": {
+            "fail_count": fail_count,
+            "pass_count": 5,
+            "warn_count": 0,
+            "skip_count": 0,
+            "failing_tests": [],
+            "all_passed": fail_count == 0
+        }
+    }
 
 
 def _make_notebook_gate(gate_status="PASS", total=3, passed=3, failed=0):
@@ -104,7 +114,7 @@ class TestCheckCanonicalSummaries:
     def test_all_clean(self, tmp_path):
         rollup = _make_rollup()
         for config in rollup["configs"]:
-            run_dir = tmp_path / config["run_dir"] / "reports"
+            run_dir = tmp_path / config["run_dir"] / "artifacts"
             run_dir.mkdir(parents=True)
             with (run_dir / "canonical_summary.json").open("w") as f:
                 json.dump(_make_canonical_summary(fail_count=0), f)
@@ -115,7 +125,7 @@ class TestCheckCanonicalSummaries:
     def test_fail_count_nonzero(self, tmp_path):
         rollup = _make_rollup()
         for i, config in enumerate(rollup["configs"]):
-            run_dir = tmp_path / config["run_dir"] / "reports"
+            run_dir = tmp_path / config["run_dir"] / "artifacts"
             run_dir.mkdir(parents=True)
             fc = 1 if i == 0 else 0
             with (run_dir / "canonical_summary.json").open("w") as f:
@@ -127,14 +137,53 @@ class TestCheckCanonicalSummaries:
 
     def test_missing_canonical_summary(self, tmp_path):
         rollup = _make_rollup()
-        # Don't create any summary files
+        # Don't create any summary files (neither artifacts/ nor reports/)
         for config in rollup["configs"]:
-            run_dir = tmp_path / config["run_dir"] / "reports"
+            run_dir = tmp_path / config["run_dir"]
             run_dir.mkdir(parents=True)
 
         result = check_canonical_summaries(rollup, str(tmp_path))
         assert result.status == "FAIL"
         assert "missing" in result.detail
+
+    def test_legacy_flat_schema(self, tmp_path):
+        """Test backward compatibility with old flat fail_count schema."""
+        rollup = _make_rollup()
+        # Use only first config for simplicity
+        rollup["configs"] = rollup["configs"][:1]
+
+        run_dir = tmp_path / rollup["configs"][0]["run_dir"] / "artifacts"
+        run_dir.mkdir(parents=True)
+        summary_path = run_dir / "canonical_summary.json"
+        # Legacy flat schema (no nested sanity object)
+        summary_path.write_text(json.dumps({"fail_count": 0, "pass_count": 5}))
+
+        result = check_canonical_summaries(rollup, str(tmp_path))
+        assert result.status == "PASS"
+
+    def test_legacy_path_fallback(self, tmp_path):
+        """Test backward compatibility with old reports/ path."""
+        rollup = _make_rollup()
+        rollup["configs"] = rollup["configs"][:1]
+
+        # Create file in old reports/ location (not artifacts/)
+        run_dir = tmp_path / rollup["configs"][0]["run_dir"] / "reports"
+        run_dir.mkdir(parents=True)
+        summary_path = run_dir / "canonical_summary.json"
+        summary_path.write_text(json.dumps({
+            "sanity": {
+                "fail_count": 0,
+                "pass_count": 5,
+                "warn_count": 0,
+                "skip_count": 0,
+                "failing_tests": [],
+                "all_passed": True
+            }
+        }))
+
+        # Should find file in legacy reports/ location
+        result = check_canonical_summaries(rollup, str(tmp_path))
+        assert result.status == "PASS"
 
 
 class TestCheckNotebookGate:
@@ -202,7 +251,7 @@ class TestComputeEligibility:
         rollup = _make_rollup()
         # Create canonical summaries
         for config in rollup["configs"]:
-            run_dir = tmp_path / config["run_dir"] / "reports"
+            run_dir = tmp_path / config["run_dir"] / "artifacts"
             run_dir.mkdir(parents=True)
             with (run_dir / "canonical_summary.json").open("w") as f:
                 json.dump(_make_canonical_summary(fail_count=0), f)
@@ -221,9 +270,9 @@ class TestComputeEligibility:
 
     def test_any_fail_ineligible(self, tmp_path):
         rollup = _make_rollup()
-        # Missing canonical summaries will cause FAIL
+        # Missing canonical summaries will cause FAIL (neither artifacts/ nor reports/)
         for config in rollup["configs"]:
-            run_dir = tmp_path / config["run_dir"] / "reports"
+            run_dir = tmp_path / config["run_dir"]
             run_dir.mkdir(parents=True)
 
         gate = compute_eligibility(
@@ -234,7 +283,7 @@ class TestComputeEligibility:
     def test_gate_to_dict(self, tmp_path):
         rollup = _make_rollup()
         for config in rollup["configs"]:
-            run_dir = tmp_path / config["run_dir"] / "reports"
+            run_dir = tmp_path / config["run_dir"] / "artifacts"
             run_dir.mkdir(parents=True)
             with (run_dir / "canonical_summary.json").open("w") as f:
                 json.dump(_make_canonical_summary(fail_count=0), f)
@@ -253,3 +302,77 @@ class TestComputeEligibility:
         assert "reasons" in d
         assert isinstance(d["reasons"], list)
         assert all("rule" in r and "status" in r and "detail" in r for r in d["reasons"])
+
+
+def test_eligibility_with_realistic_artifacts(tmp_path):
+    """Integration-like test with realistic run directory structure using new schema."""
+    # Setup: Create realistic run directory matching production
+    run_id = "test_run_42_20260206_120000"
+    run_dir_path = tmp_path / run_id
+    artifacts_dir = run_dir_path / "artifacts"
+    artifacts_dir.mkdir(parents=True)
+
+    # Create canonical_summary.json with production schema (nested sanity object)
+    summary_path = artifacts_dir / "canonical_summary.json"
+    summary_data = {
+        "run_id": run_id,
+        "experiment_name": "test_run",
+        "seed": 42,
+        "n_per": 100,
+        "git_sha": "abc123",
+        "total_hands": 600,
+        "sanity": {
+            "pass_count": 5,
+            "warn_count": 0,
+            "fail_count": 0,
+            "skip_count": 0,
+            "failing_tests": [],
+            "all_passed": True
+        },
+        "discovered": {
+            "results_files": ["results_high_2_pairs.jsonl"],
+            "datasets_present": False,
+            "bidless_parquet": False,
+            "bidless_outcomes_parquet": False
+        },
+        "generated_at_utc": "2026-02-06T12:00:00Z"
+    }
+    summary_path.write_text(json.dumps(summary_data, indent=2))
+
+    # Create rollup dict (not meta.json - use rollup directly)
+    rollup = {
+        "schema_version": 1,
+        "suite_name": "test_suite",
+        "suite_seed": 42,
+        "suite_n_per": 100,
+        "created_at_utc": "2026-02-06T12:00:00Z",
+        "configs": [
+            {
+                "config_path": "experiments/configs/test.yaml",
+                "run_id": run_id,
+                "run_dir": run_id,
+                "status": "ok",
+                "git_sha": "abc123",
+            }
+        ],
+        "summary": [],
+        "batch": {
+            "batch_id": "test_batch_001",
+            "batch_purpose": "promotion",
+        },
+    }
+
+    # Test: Compute eligibility (no notebook gate for simplicity)
+    gate = compute_eligibility(
+        rollup=rollup,
+        run_base_dir=str(tmp_path),
+        batch_purpose="promotion",
+        notebook_gate_path=None,  # Omit gate, should FAIL for promotion
+    )
+
+    # Assert: Should fail (promotion requires notebook gate)
+    assert gate.eligible is False
+    gate_reasons = {r.rule: r for r in gate.reasons}
+    assert gate_reasons["notebook_gate"].status == "FAIL"
+    # But canonical summary check should PASS with new artifacts/ path
+    assert gate_reasons["canonical_summary_clean"].status == "PASS"

--- a/tests/unit/test_suite_batch.py
+++ b/tests/unit/test_suite_batch.py
@@ -274,3 +274,70 @@ class TestValidateSuiteWithBatch:
         )
         errors = validate_suite_file(suite_yaml)
         assert errors == []
+
+    def test_config_override_invalid_key(self, tmp_path):
+        """Test validation fails when override key doesn't match any config."""
+        suite_path = tmp_path / "suite.yaml"
+        config_path = tmp_path / "quick_test.yaml"
+        config_path.write_text("strategies: []\nparameters: {}")
+
+        suite_path.write_text(
+            "suite_name: test\n"
+            "configs:\n"
+            "  - quick_test.yaml\n"
+            "parameters: {}\n"
+            "batch:\n"
+            "  batch_purpose: promotion\n"
+            "config_overrides:\n"
+            "  nonexistent.yaml:\n"  # Does not match quick_test.yaml
+            "    batch_role: dataset\n"
+        )
+
+        # validate_suite_file returns list[str] of errors, does NOT raise
+        errors = validate_suite_file(suite_path)
+        assert len(errors) > 0
+        assert any("does not match any config" in err for err in errors)
+
+    def test_extra_args_non_string_element(self, tmp_path):
+        """Test validation fails when extra_args contains non-string."""
+        suite_path = tmp_path / "suite.yaml"
+        config_path = tmp_path / "quick_test.yaml"
+        config_path.write_text("strategies: []\nparameters: {}")
+
+        suite_path.write_text(
+            "suite_name: test\n"
+            "configs:\n"
+            "  - quick_test.yaml\n"
+            "parameters: {}\n"
+            "batch:\n"
+            "  batch_purpose: promotion\n"
+            "config_overrides:\n"
+            "  quick_test.yaml:\n"
+            "    extra_args: [42, '--flag']\n"  # 42 is not a string
+        )
+
+        errors = validate_suite_file(suite_path)
+        assert len(errors) > 0
+        assert any("must be a string" in err for err in errors)
+
+    def test_config_override_valid(self, tmp_path):
+        """Test validation passes with valid override."""
+        suite_path = tmp_path / "suite.yaml"
+        config_path = tmp_path / "quick_test.yaml"
+        config_path.write_text("strategies: []\nparameters: {}")
+
+        suite_path.write_text(
+            "suite_name: test\n"
+            "configs:\n"
+            "  - quick_test.yaml\n"
+            "parameters: {}\n"
+            "batch:\n"
+            "  batch_purpose: exploration\n"
+            "config_overrides:\n"
+            "  quick_test.yaml:\n"
+            "    batch_role: dataset\n"
+            "    extra_args: ['--some-flag', '--another-flag']\n"
+        )
+
+        errors = validate_suite_file(suite_path)
+        assert len(errors) == 0  # Should return empty error list


### PR DESCRIPTION
## Summary

Fixes critical review findings from PRs #311-#315 (Arc C: Promotion Workflow & Batch Infrastructure):

1. **Eligibility artifact path/schema mismatch** - Checker read from wrong path (`reports/`) and used wrong schema (flat `fail_count`)
2. **Insufficient suite validation** - Validator didn't check `config_overrides` keys or `extra_args` element types

## Why

Production writes to `artifacts/canonical_summary.json` with nested schema `{"sanity": {"fail_count": ...}}`, but eligibility checker looked in `reports/` and expected flat schema. This would cause all eligibility checks to fail once real data flows through the promotion pipeline.

Suite validation allowed invalid configs to pass (typos in override keys, non-string extra_args) that would fail at runtime.

## Changes

### 1. Eligibility Path + Schema (eligibility.py)
- ✅ Change primary path to `artifacts/canonical_summary.json`
- ✅ Add backward-compat fallback to `reports/` for legacy runs
- ✅ Read nested `sanity.fail_count` first, fallback to flat `fail_count`
- ✅ Improve error messages (show both paths attempted)

### 2. Eligibility Tests (test_eligibility.py)
- ✅ Update fixtures to use production nested schema + artifacts/ path
- ✅ Add `test_legacy_flat_schema()` - validates backward compatibility
- ✅ Add `test_legacy_path_fallback()` - validates backward compatibility
- ✅ Add `test_eligibility_with_realistic_artifacts()` - integration test

### 3. Suite Validation (validate_configs.py)
- ✅ Validate `config_overrides` keys match actual config basenames
- ✅ Validate `extra_args` elements are all strings (not just list type)
- ✅ Improve error messages with context

### 4. Suite Validation Tests (test_suite_batch.py)
- ✅ Add `test_config_override_invalid_key()` - invalid key fails
- ✅ Add `test_extra_args_non_string_element()` - non-string fails
- ✅ Add `test_config_override_valid()` - valid config passes

## Repro / Validation

```bash
# Test eligibility fixes
uv run pytest -xvs tests/unit/test_eligibility.py
# Result: 22/22 passed (includes 3 new tests)

# Test suite validation fixes
uv run pytest -xvs tests/unit/test_suite_batch.py::TestValidateSuiteWithBatch
# Result: 8/8 passed (includes 3 new tests)

# Verify no Arc C regressions
uv run pytest -xvs tests/unit/test_meta_schema.py tests/unit/test_batch_metadata.py \
  tests/unit/test_notebook_gate.py tests/unit/test_repo_linter.py
# Result: 52/52 passed

# Full validation
make check
# Result: ✅ All checks passed (1048 tests)
```

## Tests

- ✅ Unit tests: 22 eligibility + 8 suite validation = 30 tests pass
- ✅ Arc C tests: 52/52 pass (no regressions)
- ✅ Full suite: 1048/1048 pass
- ✅ make check: All checks passed

## Backward Compatibility

**Preserved:**
- ✅ Legacy runs with `reports/canonical_summary.json` still work (fallback)
- ✅ Legacy runs with flat `fail_count` schema still work (fallback)
- ✅ No breaking changes to public APIs or CLI interfaces

**New restrictions (intentional):**
- ❌ Suite files with invalid `config_overrides` keys now fail validation (was silently ignored)
- ❌ Suite files with non-string `extra_args` now fail validation (would fail at runtime)

## Worktree Proof

```bash
pwd
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-arc-c-fixes

git rev-parse --show-toplevel
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-arc-c-fixes

git worktree list
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre      8ced9b8 [main]
# /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-arc-c-fixes  536829d [codex/arc-c-review-fixes]
```

## Risk Assessment

**Low risk:**
- Changes are additive (fallback logic preserves backward compat)
- Tests lock in both new and legacy behavior
- No changes to meta.json/rollup.json/batch metadata schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)