### PR TITLE
feat(lint): Add promotion contract lint rules

### DIFF
--- a/scripts/lint_repo.py
+++ b/scripts/lint_repo.py
@@ -588,6 +588,118 @@ def check_no_import_experiments_package(changed: list[str], repo_root: Path) -> 
     return violations
 
 
+# --- Promotion contract lint rules ---
+
+# Promotion registry: files that constitute the canonical results registry.
+PROMOTION_REGISTRY_PREFIXES = [
+    "docs/04_reports/",
+]
+
+# Explicit allowlist for additional registry files outside the prefix dirs.
+PROMOTION_REGISTRY_ALLOWLIST: set[str] = set()
+
+GATE_EVIDENCE_PATTERNS = [
+    "batch_gate.json",
+    "notebook_gate.json",
+    "canonical_summary.json",
+    "gate_status",
+]
+
+CODE_REGISTRY_PATH = "src/bid_euchre/datasets/canonical_runs.py"
+
+
+def check_registry_requires_gate_reference(
+    changed: list[str], repo_root: Path,
+) -> list[Violation]:
+    """If a promotion registry doc changes, require gate evidence reference in content."""
+    violations: list[Violation] = []
+    for p in changed:
+        # Only check .md files
+        if not p.endswith(".md"):
+            continue
+        # Skip README.md (index/navigation only)
+        if Path(p).name == "README.md":
+            continue
+        # Check if under registry prefixes or in allowlist
+        in_registry = any(is_under(p, prefix) for prefix in PROMOTION_REGISTRY_PREFIXES)
+        if not in_registry and p not in PROMOTION_REGISTRY_ALLOWLIST:
+            continue
+
+        abs_path = repo_root / p
+        if not abs_path.exists():
+            continue
+
+        text = abs_path.read_text(encoding="utf-8")
+
+        # Check if any gate evidence pattern appears in content
+        has_gate_ref = any(pattern in text for pattern in GATE_EVIDENCE_PATTERNS)
+        if not has_gate_ref:
+            violations.append(
+                Violation(
+                    rule="registry-requires-gate-reference",
+                    path=p,
+                    message=(
+                        "Promotion registry doc must reference gate evidence "
+                        f"(one of: {', '.join(GATE_EVIDENCE_PATTERNS)})"
+                    ),
+                )
+            )
+    return violations
+
+
+def check_canonical_runs_registry_consistency(
+    changed: list[str], repo_root: Path,
+) -> list[Violation]:
+    """If code registry exists AND doc registry changes, require synchronized update."""
+    violations: list[Violation] = []
+
+    # Check if code registry exists on disk
+    code_registry = repo_root / CODE_REGISTRY_PATH
+    if not code_registry.exists():
+        # Post-#305 reality: code registry deleted, no-op
+        return violations
+
+    # Identify doc registry files in changed set
+    doc_registry_changed = [
+        p for p in changed
+        if (
+            any(is_under(p, prefix) for prefix in PROMOTION_REGISTRY_PREFIXES)
+            or p in PROMOTION_REGISTRY_ALLOWLIST
+        )
+    ]
+
+    code_registry_changed = CODE_REGISTRY_PATH in changed
+
+    # If doc changed but code not changed → violation
+    if doc_registry_changed and not code_registry_changed:
+        for p in doc_registry_changed:
+            violations.append(
+                Violation(
+                    rule="canonical-runs-registry-consistency",
+                    path=p,
+                    message=(
+                        f"Doc registry changed but {CODE_REGISTRY_PATH} was not updated. "
+                        "Keep code and doc registries in sync."
+                    ),
+                )
+            )
+
+    # If code changed but no doc changed → violation
+    if code_registry_changed and not doc_registry_changed:
+        violations.append(
+            Violation(
+                rule="canonical-runs-registry-consistency",
+                path=CODE_REGISTRY_PATH,
+                message=(
+                    "Code registry changed but no doc registry files were updated. "
+                    "Keep code and doc registries in sync."
+                ),
+            )
+        )
+
+    return violations
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--base", default="origin/main")
@@ -614,6 +726,8 @@ def main() -> int:
     violations += check_no_sys_path_insert(changed, repo_root)
     violations += check_no_cli_in_src(changed, repo_root)
     violations += check_no_import_experiments_package(changed, repo_root)
+    violations += check_registry_requires_gate_reference(changed, repo_root)
+    violations += check_canonical_runs_registry_consistency(changed, repo_root)
 
     if violations:
         print("Repo linter failed:\n")

--- a/tests/unit/test_repo_linter.py
+++ b/tests/unit/test_repo_linter.py
@@ -1,9 +1,11 @@
 from pathlib import Path
 
 from scripts.lint_repo import (
+    check_canonical_runs_registry_consistency,
     check_data_fixtures_allowlist,
     check_no_deprecated_changes,
     check_no_generated_artifacts,
+    check_registry_requires_gate_reference,
     check_src_no_experiments_or_tests_imports,
 )
 
@@ -152,4 +154,121 @@ def test_data_allowlist_handles_deleted_files(tmp_path: Path):
     changed = ["data/fixtures/deleted.json"]
     v = check_data_fixtures_allowlist(changed, tmp_path)
     # Should pass because file doesn't exist (no size to check)
+    assert v == []
+
+
+# --- Promotion contract lint rule tests ---
+
+
+def test_registry_gate_reference_present_passes(tmp_path: Path):
+    """Report with gate evidence reference passes."""
+    repo_root = tmp_path
+    reports_dir = repo_root / "docs" / "04_reports"
+    reports_dir.mkdir(parents=True)
+    report = reports_dir / "phase1_report.md"
+    report.write_text("# Report\nSee notebook_gate.json for details.\n", encoding="utf-8")
+
+    v = check_registry_requires_gate_reference(
+        ["docs/04_reports/phase1_report.md"], repo_root,
+    )
+    assert v == []
+
+
+def test_registry_gate_reference_missing_fails(tmp_path: Path):
+    """Report without gate evidence reference fails."""
+    repo_root = tmp_path
+    reports_dir = repo_root / "docs" / "04_reports"
+    reports_dir.mkdir(parents=True)
+    report = reports_dir / "phase1_report.md"
+    report.write_text("# Report\nNo gate evidence here.\n", encoding="utf-8")
+
+    v = check_registry_requires_gate_reference(
+        ["docs/04_reports/phase1_report.md"], repo_root,
+    )
+    assert len(v) == 1
+    assert v[0].rule == "registry-requires-gate-reference"
+
+
+def test_registry_unrelated_doc_ignored(tmp_path: Path):
+    """Doc outside registry patterns is not checked."""
+    repo_root = tmp_path
+    docs_dir = repo_root / "docs" / "01_core"
+    docs_dir.mkdir(parents=True)
+    doc = docs_dir / "RULES.md"
+    doc.write_text("# Rules\nNo gate evidence.\n", encoding="utf-8")
+
+    v = check_registry_requires_gate_reference(
+        ["docs/01_core/RULES.md"], repo_root,
+    )
+    assert v == []
+
+
+def test_registry_readme_skipped(tmp_path: Path):
+    """README.md in reports dir is not checked."""
+    repo_root = tmp_path
+    reports_dir = repo_root / "docs" / "04_reports"
+    reports_dir.mkdir(parents=True)
+    readme = reports_dir / "README.md"
+    readme.write_text("# Reports Index\nNo gate evidence.\n", encoding="utf-8")
+
+    v = check_registry_requires_gate_reference(
+        ["docs/04_reports/README.md"], repo_root,
+    )
+    assert v == []
+
+
+def test_consistency_no_code_registry_noop(tmp_path: Path):
+    """Code registry absent (post-#305) -> no violation."""
+    repo_root = tmp_path
+    # Don't create CODE_REGISTRY_PATH file
+    v = check_canonical_runs_registry_consistency(
+        ["docs/04_reports/report.md"], repo_root,
+    )
+    assert v == []
+
+
+def test_consistency_both_changed_passes(tmp_path: Path):
+    """Both code+doc changed -> no violation."""
+    repo_root = tmp_path
+    # Create code registry file
+    code_path = repo_root / "src" / "bid_euchre" / "datasets"
+    code_path.mkdir(parents=True)
+    (code_path / "canonical_runs.py").write_text("# registry\n", encoding="utf-8")
+
+    v = check_canonical_runs_registry_consistency(
+        [
+            "src/bid_euchre/datasets/canonical_runs.py",
+            "docs/04_reports/report.md",
+        ],
+        repo_root,
+    )
+    assert v == []
+
+
+def test_consistency_code_only_changed_fails(tmp_path: Path):
+    """Code changed but not doc -> violation."""
+    repo_root = tmp_path
+    code_path = repo_root / "src" / "bid_euchre" / "datasets"
+    code_path.mkdir(parents=True)
+    (code_path / "canonical_runs.py").write_text("# registry\n", encoding="utf-8")
+
+    v = check_canonical_runs_registry_consistency(
+        ["src/bid_euchre/datasets/canonical_runs.py"],
+        repo_root,
+    )
+    assert len(v) == 1
+    assert v[0].rule == "canonical-runs-registry-consistency"
+
+
+def test_non_md_files_ignored(tmp_path: Path):
+    """Non-.md file in reports dir is not checked by gate reference rule."""
+    repo_root = tmp_path
+    reports_dir = repo_root / "docs" / "04_reports"
+    reports_dir.mkdir(parents=True)
+    png = reports_dir / "chart.png"
+    png.write_bytes(b"\x89PNG")
+
+    v = check_registry_requires_gate_reference(
+        ["docs/04_reports/chart.png"], repo_root,
+    )
     assert v == []


### PR DESCRIPTION
## Summary
- Add `registry-requires-gate-reference` lint rule: promotion registry docs (under `docs/04_reports/`) must reference gate evidence (e.g. `notebook_gate.json`, `batch_gate.json`)
- Add `canonical-runs-registry-consistency` lint rule: if code registry (`canonical_runs.py`) exists, require synchronized doc registry updates (no-op post-#305)
- Add 8 test cases covering both rules

## Why
Promotion workflow requires that reports cite gate evidence for traceability. These lint rules enforce that contract at commit time.

## Repro / Validation
```bash
make check
PYTHONPATH=.:src uv run python -m pytest tests/unit/test_repo_linter.py -v
```

## Tests
- [x] `make check` passes
- [x] `PYTHONPATH=.:src uv run python -m pytest tests/unit/test_repo_linter.py -v` — 23 passed

## Expected impact
- No metrics impact
- No runtime impact on existing lint checks

## Risk level
- [x] Low (docs/tests only)

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr07
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr07
```

## Checklist
- [x] No generated artifacts committed
- [x] Behavior changes have matching tests
- [x] PR is focused (one concept)