### PR TITLE
feat(lint): Add artifact-requires-freeze discovery lint rule

### DIFF
--- a/scripts/lint_repo.py
+++ b/scripts/lint_repo.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import json
 import os
 import subprocess
 from dataclasses import dataclass
@@ -46,7 +47,9 @@ def run_git(*args: str) -> str:
 
 def ensure_ref_exists(ref: str) -> None:
     try:
-        subprocess.check_output(["git", "rev-parse", "--verify", ref], stderr=subprocess.DEVNULL)
+        subprocess.check_output(
+            ["git", "rev-parse", "--verify", ref], stderr=subprocess.DEVNULL
+        )
     except Exception:
         raise SystemExit(
             f"ERROR: git ref '{ref}' not found. "
@@ -108,7 +111,9 @@ def _imports_from_tree(tree: ast.AST) -> set[str]:
     return mods
 
 
-def check_src_no_experiments_or_tests_imports(changed: list[str], repo_root: Path) -> list[Violation]:
+def check_src_no_experiments_or_tests_imports(
+    changed: list[str], repo_root: Path
+) -> list[Violation]:
     violations: list[Violation] = []
     for p in changed:
         if not (p.startswith("src/") and p.endswith(".py")):
@@ -157,19 +162,19 @@ def check_no_deprecated_changes(changed: list[str]) -> list[Violation]:
             # Allow README updates (documenting deprecations)
             if p.endswith("README.md"):
                 continue
-            
+
             # Check if this is a new file (added, not modified)
             # Git shows renames as additions, which is what we want
             status = subprocess.run(
                 ["git", "diff", "--name-status", "origin/main...HEAD", "--", p],
                 capture_output=True,
-                text=True
+                text=True,
             ).stdout.strip()
-            
+
             # Allow additions (A) and renames (R) into _deprecated
             if status.startswith(("A", "R")):
                 continue
-            
+
             # Block modifications (M) to existing deprecated files
             violations.append(
                 Violation(
@@ -181,7 +186,9 @@ def check_no_deprecated_changes(changed: list[str]) -> list[Violation]:
     return violations
 
 
-def check_data_fixtures_allowlist(changed: list[str], repo_root: Path) -> list[Violation]:
+def check_data_fixtures_allowlist(
+    changed: list[str], repo_root: Path
+) -> list[Violation]:
     """
     Enforce that only data/fixtures/** and data/.gitkeep may be committed under data/.
     Also enforce 100KB size limit on fixtures.
@@ -228,7 +235,7 @@ def check_no_new_scripts_in_frozen_folders(changed: list[str]) -> list[Violation
     """
     Block new Python scripts in experiments/comparisons/ and experiments/training/.
     These folders are frozen to prevent workflow sprawl.
-    
+
     Allowlist:
     - experiments/comparisons/run_head_to_head.py (existing wrapper)
     - experiments/training/train_bidder_aware_models.py (existing training script)
@@ -239,42 +246,42 @@ def check_no_new_scripts_in_frozen_folders(changed: list[str]) -> list[Violation
         "experiments/comparisons/",
         "experiments/training/",
     ]
-    
+
     ALLOWLIST = {
         "experiments/comparisons/run_head_to_head.py",
         "experiments/training/train_bidder_aware_models.py",
     }
-    
+
     violations: list[Violation] = []
     for p in changed:
         # Check if under frozen folders
         in_frozen_folder = any(is_under(p, folder) for folder in FROZEN_FOLDERS)
         if not in_frozen_folder:
             continue
-        
+
         # Allow README.md files
         if p.endswith("README.md"):
             continue
-        
+
         # Allow __init__.py files
         if p.endswith("__init__.py"):
             continue
-        
+
         # Allow allowlisted scripts
         if p in ALLOWLIST:
             continue
-        
+
         # Check if this is a new Python file (added or renamed into folder)
         if not p.endswith(".py"):
             continue
-        
+
         # Check git status to see if this is a new file
         status = subprocess.run(
             ["git", "diff", "--name-status", "origin/main...HEAD", "--", p],
             capture_output=True,
-            text=True
+            text=True,
         ).stdout.strip()
-        
+
         # Block additions (A) and renames (R) into frozen folders
         if status.startswith(("A", "R")):
             folder_name = "comparisons" if "comparisons" in p else "training"
@@ -285,7 +292,7 @@ def check_no_new_scripts_in_frozen_folders(changed: list[str]) -> list[Violation
                     message=f"Do not add new scripts to experiments/{folder_name}/. Use configs + experiments/run_experiment.py (or suites) instead.",
                 )
             )
-    
+
     return violations
 
 
@@ -390,15 +397,17 @@ def check_empty_test_functions(changed: list[str], repo_root: Path) -> list[Viol
             if isinstance(node, ast.FunctionDef) and node.name.startswith("test_"):
                 # Check if function body is empty (only pass or docstring)
                 body_without_docstring = [
-                    n for n in node.body
-                    if not isinstance(n, ast.Expr) or
-                       not isinstance(n.value, ast.Constant) or
-                       not isinstance(n.value.value, str)
+                    n
+                    for n in node.body
+                    if not isinstance(n, ast.Expr)
+                    or not isinstance(n.value, ast.Constant)
+                    or not isinstance(n.value.value, str)
                 ]
 
                 # If only 'pass' statement remains, it's empty
-                if (len(body_without_docstring) == 1 and
-                    isinstance(body_without_docstring[0], ast.Pass)):
+                if len(body_without_docstring) == 1 and isinstance(
+                    body_without_docstring[0], ast.Pass
+                ):
                     violations.append(
                         Violation(
                             rule="empty-test-function",
@@ -418,7 +427,9 @@ def check_empty_test_functions(changed: list[str], repo_root: Path) -> list[Viol
     return violations
 
 
-def check_experiments_without_seed(changed: list[str], repo_root: Path) -> list[Violation]:
+def check_experiments_without_seed(
+    changed: list[str], repo_root: Path
+) -> list[Violation]:
     """
     Flag experiment invocations in docs/scripts missing --seed.
 
@@ -431,7 +442,9 @@ def check_experiments_without_seed(changed: list[str], repo_root: Path) -> list[
     violations: list[Violation] = []
 
     # Pattern matches experiment invocations (including multi-line with backslash continuations)
-    experiment_pattern = re.compile(r'python experiments/run_experiment\.py(?:[^\n]*\\\n)*[^\n]*')
+    experiment_pattern = re.compile(
+        r"python experiments/run_experiment\.py(?:[^\n]*\\\n)*[^\n]*"
+    )
 
     # Files to check
     paths_to_check: list[Path] = []
@@ -449,8 +462,11 @@ def check_experiments_without_seed(changed: list[str], repo_root: Path) -> list[
             invocation = match.group(0)
 
             # Check for --seed or --allow-nondeterministic
-            if "--seed" not in invocation and "--allow-nondeterministic" not in invocation:
-                lineno = text[:match.start()].count('\n') + 1
+            if (
+                "--seed" not in invocation
+                and "--allow-nondeterministic" not in invocation
+            ):
+                lineno = text[: match.start()].count("\n") + 1
                 violations.append(
                     Violation(
                         rule="experiments-require-seed",
@@ -486,11 +502,13 @@ def check_no_sys_path_insert(changed: list[str], repo_root: Path) -> list[Violat
             if stripped.startswith("#"):
                 continue
             if "sys.path.insert" in line or "sys.path.append" in line:
-                violations.append(Violation(
-                    rule="no-sys-path-mutation",
-                    path=f"{p}:{i}",
-                    message="sys.path.insert/append is forbidden. Use PYTHONPATH=src or uv run.",
-                ))
+                violations.append(
+                    Violation(
+                        rule="no-sys-path-mutation",
+                        path=f"{p}:{i}",
+                        message="sys.path.insert/append is forbidden. Use PYTHONPATH=src or uv run.",
+                    )
+                )
     return violations
 
 
@@ -553,7 +571,9 @@ def check_no_cli_in_src(changed: list[str], repo_root: Path) -> list[Violation]:
     return violations
 
 
-def check_no_import_experiments_package(changed: list[str], repo_root: Path) -> list[Violation]:
+def check_no_import_experiments_package(
+    changed: list[str], repo_root: Path
+) -> list[Violation]:
     """Block 'import experiments' or 'from experiments import' outside experiments/.
 
     The top-level experiments/ directory is a filesystem directory (YAML configs + runner),
@@ -609,7 +629,8 @@ CODE_REGISTRY_PATH = "src/bid_euchre/datasets/canonical_runs.py"
 
 
 def check_registry_requires_gate_reference(
-    changed: list[str], repo_root: Path,
+    changed: list[str],
+    repo_root: Path,
 ) -> list[Violation]:
     """If a promotion registry doc changes, require gate evidence reference in content."""
     violations: list[Violation] = []
@@ -648,7 +669,8 @@ def check_registry_requires_gate_reference(
 
 
 def check_canonical_runs_registry_consistency(
-    changed: list[str], repo_root: Path,
+    changed: list[str],
+    repo_root: Path,
 ) -> list[Violation]:
     """If code registry exists AND doc registry changes, require synchronized update."""
     violations: list[Violation] = []
@@ -661,7 +683,8 @@ def check_canonical_runs_registry_consistency(
 
     # Identify doc registry files in changed set
     doc_registry_changed = [
-        p for p in changed
+        p
+        for p in changed
         if (
             any(is_under(p, prefix) for prefix in PROMOTION_REGISTRY_PREFIXES)
             or p in PROMOTION_REGISTRY_ALLOWLIST
@@ -700,6 +723,68 @@ def check_canonical_runs_registry_consistency(
     return violations
 
 
+# --- Artifact discovery lint rules ---
+
+# Filename substrings that indicate model artifacts (case-insensitive match).
+ARTIFACT_NAME_PATTERNS = ["olsa", "b0", "teacher"]
+
+# Infrastructure JSON files that live under data/ but are NOT model artifacts.
+FREEZE_EXEMPT_NAMES = {"meta.json", "rollup.json", "canonical_summary.json"}
+
+
+def _is_model_artifact(path: str) -> bool:
+    """Return True if *path* looks like a model artifact JSON under data/."""
+    if not is_under(path, "data/"):
+        return False
+    name = Path(path).name
+    if not name.endswith(".json"):
+        return False
+    if name in FREEZE_EXEMPT_NAMES:
+        return False
+    name_lower = name.lower()
+    return any(pattern in name_lower for pattern in ARTIFACT_NAME_PATTERNS)
+
+
+def check_artifacts_require_freeze(
+    changed: list[str],
+    repo_root: Path,
+) -> list[Violation]:
+    """Model artifact JSON files must have a non-null ``frozen_at`` field."""
+    violations: list[Violation] = []
+    for p in changed:
+        if not _is_model_artifact(p):
+            continue
+
+        abs_path = repo_root / p
+        if not abs_path.exists():
+            continue
+
+        try:
+            metadata = json.loads(abs_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, ValueError):
+            violations.append(
+                Violation(
+                    rule="artifact-requires-freeze",
+                    path=p,
+                    message="Model artifact is not valid JSON.",
+                )
+            )
+            continue
+
+        if metadata.get("frozen_at") is None:
+            violations.append(
+                Violation(
+                    rule="artifact-requires-freeze",
+                    path=p,
+                    message=(
+                        "Model artifact must be frozen before commit "
+                        "(frozen_at is null). Run freeze_artifact() first."
+                    ),
+                )
+            )
+    return violations
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--base", default="origin/main")
@@ -728,6 +813,7 @@ def main() -> int:
     violations += check_no_import_experiments_package(changed, repo_root)
     violations += check_registry_requires_gate_reference(changed, repo_root)
     violations += check_canonical_runs_registry_consistency(changed, repo_root)
+    violations += check_artifacts_require_freeze(changed, repo_root)
 
     if violations:
         print("Repo linter failed:\n")

--- a/tests/unit/test_lint_repo.py
+++ b/tests/unit/test_lint_repo.py
@@ -1,0 +1,189 @@
+"""Tests for artifact discovery lint rules in scripts/lint_repo.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.lint_repo import (
+    _is_model_artifact,
+    check_artifacts_require_freeze,
+)
+
+
+def _write_json(tmp_path: Path, rel_path: str, obj: object) -> None:
+    """Write a JSON object at rel_path under tmp_path."""
+    p = tmp_path / rel_path
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(obj), encoding="utf-8")
+
+
+def _write_file(tmp_path: Path, rel_path: str, content: str) -> None:
+    """Write raw text at rel_path under tmp_path."""
+    p = tmp_path / rel_path
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+
+
+# -- _is_model_artifact tests -------------------------------------------------
+
+
+class TestIsModelArtifact:
+    """Tests for the _is_model_artifact helper."""
+
+    def test_olsa_artifact_under_data(self):
+        assert _is_model_artifact("data/models/olsa_v1.json") is True
+
+    def test_b0_artifact_under_data(self):
+        assert _is_model_artifact("data/models/b0_weights.json") is True
+
+    def test_teacher_artifact_under_data(self):
+        assert _is_model_artifact("data/models/teacher_config.json") is True
+
+    def test_case_insensitive_match(self):
+        assert _is_model_artifact("data/models/OLSa_V2.json") is True
+        assert _is_model_artifact("data/models/B0_FINAL.json") is True
+        assert _is_model_artifact("data/models/Teacher_Model.json") is True
+
+    def test_nested_data_path(self):
+        assert _is_model_artifact("data/runs/abc/olsa_artifact.json") is True
+
+    def test_not_under_data(self):
+        assert _is_model_artifact("src/models/olsa_v1.json") is False
+
+    def test_not_json_extension(self):
+        assert _is_model_artifact("data/models/olsa_v1.parquet") is False
+        assert _is_model_artifact("data/models/olsa_v1.pkl") is False
+
+    def test_no_pattern_match(self):
+        assert _is_model_artifact("data/models/random_config.json") is False
+        assert _is_model_artifact("data/models/settings.json") is False
+
+    def test_exempt_meta_json(self):
+        assert _is_model_artifact("data/runs/abc/meta.json") is False
+
+    def test_exempt_rollup_json(self):
+        assert _is_model_artifact("data/runs/abc/rollup.json") is False
+
+    def test_exempt_canonical_summary(self):
+        assert _is_model_artifact("data/runs/abc/canonical_summary.json") is False
+
+
+# -- check_artifacts_require_freeze tests ------------------------------------
+
+
+class TestCheckArtifactsRequireFreeze:
+    """Tests for the check_artifacts_require_freeze lint rule."""
+
+    def test_frozen_artifact_passes(self, tmp_path: Path):
+        _write_json(
+            tmp_path,
+            "data/models/olsa_v1.json",
+            {
+                "frozen_at": "2026-01-15T00:00:00Z",
+                "version": "1.0",
+            },
+        )
+        violations = check_artifacts_require_freeze(
+            ["data/models/olsa_v1.json"],
+            tmp_path,
+        )
+        assert violations == []
+
+    def test_unfrozen_artifact_fails(self, tmp_path: Path):
+        _write_json(
+            tmp_path,
+            "data/models/olsa_v1.json",
+            {
+                "frozen_at": None,
+                "version": "1.0",
+            },
+        )
+        violations = check_artifacts_require_freeze(
+            ["data/models/olsa_v1.json"],
+            tmp_path,
+        )
+        assert len(violations) == 1
+        assert violations[0].rule == "artifact-requires-freeze"
+        assert "frozen_at is null" in violations[0].message
+
+    def test_missing_frozen_at_field_fails(self, tmp_path: Path):
+        _write_json(
+            tmp_path,
+            "data/models/b0_weights.json",
+            {
+                "version": "1.0",
+            },
+        )
+        violations = check_artifacts_require_freeze(
+            ["data/models/b0_weights.json"],
+            tmp_path,
+        )
+        assert len(violations) == 1
+        assert violations[0].rule == "artifact-requires-freeze"
+
+    def test_exempt_files_pass(self, tmp_path: Path):
+        _write_json(tmp_path, "data/runs/abc/meta.json", {"some": "data"})
+        violations = check_artifacts_require_freeze(
+            ["data/runs/abc/meta.json"],
+            tmp_path,
+        )
+        assert violations == []
+
+    def test_non_data_paths_ignored(self, tmp_path: Path):
+        _write_json(tmp_path, "src/models/olsa_v1.json", {"frozen_at": None})
+        violations = check_artifacts_require_freeze(
+            ["src/models/olsa_v1.json"],
+            tmp_path,
+        )
+        assert violations == []
+
+    def test_invalid_json_flagged(self, tmp_path: Path):
+        _write_file(tmp_path, "data/models/olsa_bad.json", "not valid json {{{")
+        violations = check_artifacts_require_freeze(
+            ["data/models/olsa_bad.json"],
+            tmp_path,
+        )
+        assert len(violations) == 1
+        assert violations[0].rule == "artifact-requires-freeze"
+        assert "not valid JSON" in violations[0].message
+
+    def test_nonexistent_file_skipped(self, tmp_path: Path):
+        """A file in the changed list that doesn't exist on disk is skipped."""
+        violations = check_artifacts_require_freeze(
+            ["data/models/olsa_ghost.json"],
+            tmp_path,
+        )
+        assert violations == []
+
+    def test_multiple_artifacts_mixed(self, tmp_path: Path):
+        """Frozen and unfrozen artifacts in same batch: only unfrozen flagged."""
+        _write_json(
+            tmp_path,
+            "data/models/olsa_frozen.json",
+            {
+                "frozen_at": "2026-01-15T00:00:00Z",
+            },
+        )
+        _write_json(
+            tmp_path,
+            "data/models/b0_unfrozen.json",
+            {
+                "version": "1.0",
+            },
+        )
+        violations = check_artifacts_require_freeze(
+            ["data/models/olsa_frozen.json", "data/models/b0_unfrozen.json"],
+            tmp_path,
+        )
+        assert len(violations) == 1
+        assert violations[0].path == "data/models/b0_unfrozen.json"
+
+    def test_non_artifact_json_ignored(self, tmp_path: Path):
+        """JSON files under data/ that don't match artifact patterns are ignored."""
+        _write_json(tmp_path, "data/models/settings.json", {"frozen_at": None})
+        violations = check_artifacts_require_freeze(
+            ["data/models/settings.json"],
+            tmp_path,
+        )
+        assert violations == []


### PR DESCRIPTION
## Summary
- Add `check_artifacts_require_freeze()` lint rule to `scripts/lint_repo.py` that enforces model artifact JSON files under `data/` have a non-null `frozen_at` field
- Add `_is_model_artifact()` helper with `ARTIFACT_NAME_PATTERNS` and `FREEZE_EXEMPT_NAMES` constants
- Add 20 unit tests in `tests/unit/test_lint_repo.py` covering positive, negative, and edge cases

## Why
Model artifacts committed without being frozen can break the promotion workflow. This lint rule catches unfrozen artifacts at commit time, complementing the existing `freeze_artifact()` / `require_frozen()` utilities from #318.

## Repro / Validation
**Command(s) run:**
```bash
cd /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-track3-pr31
make check
uv run python -m pytest tests/unit/test_lint_repo.py -v
```

## Tests
- [x] `make check` passes (repo-lint + ruff + pytest)
- [x] `uv run python -m pytest tests/unit/test_lint_repo.py -v` — 20/20 pass

### Test coverage
- `TestIsModelArtifact` (11 tests): olsa/b0/teacher patterns, case-insensitive matching, non-data paths, non-JSON files, exempt files (meta.json, rollup.json, canonical_summary.json)
- `TestCheckArtifactsRequireFreeze` (9 tests): frozen passes, unfrozen fails, missing field fails, exempt files pass, non-data paths ignored, invalid JSON flagged, nonexistent file skipped, mixed batch, non-artifact JSON ignored

## Expected impact
- Metrics impact: None
- Runtime impact: None (lint-only)

## Risk level
- [x] Low (lint rule + tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-track3-pr31
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-track3-pr31
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                       00fecc2 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-track3-pr31           3ef44ea [track3/artifact-discovery]
```

---
Generated with [Claude Code](https://claude.com/claude-code)