### PR TITLE
feat(lint): Add gate artifact + split manifest schema lint rules

### DIFF
--- a/docs/02_agent/PROMOTION_WORKFLOW.md
+++ b/docs/02_agent/PROMOTION_WORKFLOW.md
@@ -114,6 +114,15 @@ Reports under `docs/04_reports/` (excluding `README.md`) must reference gate evi
 ### `canonical-runs-registry-consistency`
 If a code registry file exists and a doc registry file changes, both must be updated together (and vice versa). Currently no-op since the code registry was removed in #305.
 
+### `artifact-requires-freeze`
+Model artifact JSON files (matching `olsa`, `b0`, `teacher` patterns) under `data/` must have a non-null `frozen_at` field.
+
+### `gate-artifact-schema`
+Gate artifact JSON files (`*gate*.json`) under `data/` must have valid schema (required fields: `schema_version`, `gate_status`, `created_at_utc`) and `gate_status` must be `PASS`.
+
+### `split-manifest-schema`
+Split manifest JSON files (`split_manifest*.json`) must have valid schema (required fields: `schema_version`, `split_type`, `split_seed`, `total_hand_ids`, `partition_hashes`) and `split_type` must be `two_way` or `three_way`.
+
 ## Reviewer Checklist
 
 When reviewing a promotion-track PR, verify:

--- a/scripts/lint_repo.py
+++ b/scripts/lint_repo.py
@@ -785,6 +785,136 @@ def check_artifacts_require_freeze(
     return violations
 
 
+# --- Gate artifact and split manifest schema lint rules ---
+
+GATE_REQUIRED_FIELDS = {"schema_version", "gate_status", "created_at_utc"}
+
+SPLIT_MANIFEST_REQUIRED_FIELDS = {
+    "schema_version",
+    "split_type",
+    "split_seed",
+    "total_hand_ids",
+    "partition_hashes",
+}
+VALID_SPLIT_TYPES = {"two_way", "three_way"}
+
+
+def _is_gate_artifact(path: str) -> bool:
+    """Return True if *path* looks like a gate artifact JSON under data/."""
+    if not is_under(path, "data/"):
+        return False
+    name = Path(path).name
+    return name.endswith(".json") and "gate" in name.lower()
+
+
+def _is_split_manifest(path: str) -> bool:
+    """Return True if *path* looks like a split manifest JSON."""
+    name = Path(path).name
+    return name.startswith("split_manifest") and name.endswith(".json")
+
+
+def check_gate_artifacts_schema(
+    changed: list[str],
+    repo_root: Path,
+) -> list[Violation]:
+    """Gate artifact JSON files must have required fields and gate_status == PASS."""
+    violations: list[Violation] = []
+    for p in changed:
+        if not _is_gate_artifact(p):
+            continue
+
+        abs_path = repo_root / p
+        if not abs_path.exists():
+            continue
+
+        try:
+            data = json.loads(abs_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, ValueError):
+            violations.append(
+                Violation(
+                    rule="gate-artifact-schema",
+                    path=p,
+                    message="Gate artifact is not valid JSON.",
+                )
+            )
+            continue
+
+        missing = GATE_REQUIRED_FIELDS - set(data.keys())
+        if missing:
+            violations.append(
+                Violation(
+                    rule="gate-artifact-schema",
+                    path=p,
+                    message=f"Gate artifact missing required fields: {sorted(missing)}",
+                )
+            )
+            continue
+
+        if data["gate_status"] != "PASS":
+            violations.append(
+                Violation(
+                    rule="gate-artifact-schema",
+                    path=p,
+                    message=(
+                        f"Gate artifact has gate_status={data['gate_status']!r} "
+                        "(must be 'PASS' to commit)."
+                    ),
+                )
+            )
+    return violations
+
+
+def check_split_manifest_schema(
+    changed: list[str],
+    repo_root: Path,
+) -> list[Violation]:
+    """Split manifest JSON files must have required fields and valid split_type."""
+    violations: list[Violation] = []
+    for p in changed:
+        if not _is_split_manifest(p):
+            continue
+
+        abs_path = repo_root / p
+        if not abs_path.exists():
+            continue
+
+        try:
+            data = json.loads(abs_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, ValueError):
+            violations.append(
+                Violation(
+                    rule="split-manifest-schema",
+                    path=p,
+                    message="Split manifest is not valid JSON.",
+                )
+            )
+            continue
+
+        missing = SPLIT_MANIFEST_REQUIRED_FIELDS - set(data.keys())
+        if missing:
+            violations.append(
+                Violation(
+                    rule="split-manifest-schema",
+                    path=p,
+                    message=f"Split manifest missing required fields: {sorted(missing)}",
+                )
+            )
+            continue
+
+        if data["split_type"] not in VALID_SPLIT_TYPES:
+            violations.append(
+                Violation(
+                    rule="split-manifest-schema",
+                    path=p,
+                    message=(
+                        f"Split manifest has split_type={data['split_type']!r} "
+                        f"(must be one of: {sorted(VALID_SPLIT_TYPES)})."
+                    ),
+                )
+            )
+    return violations
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--base", default="origin/main")
@@ -814,6 +944,8 @@ def main() -> int:
     violations += check_registry_requires_gate_reference(changed, repo_root)
     violations += check_canonical_runs_registry_consistency(changed, repo_root)
     violations += check_artifacts_require_freeze(changed, repo_root)
+    violations += check_gate_artifacts_schema(changed, repo_root)
+    violations += check_split_manifest_schema(changed, repo_root)
 
     if violations:
         print("Repo linter failed:\n")

--- a/tests/unit/test_lint_repo.py
+++ b/tests/unit/test_lint_repo.py
@@ -1,4 +1,4 @@
-"""Tests for artifact discovery lint rules in scripts/lint_repo.py."""
+"""Tests for artifact discovery and schema lint rules in scripts/lint_repo.py."""
 
 from __future__ import annotations
 
@@ -6,8 +6,12 @@ import json
 from pathlib import Path
 
 from scripts.lint_repo import (
+    _is_gate_artifact,
     _is_model_artifact,
+    _is_split_manifest,
     check_artifacts_require_freeze,
+    check_gate_artifacts_schema,
+    check_split_manifest_schema,
 )
 
 
@@ -184,6 +188,255 @@ class TestCheckArtifactsRequireFreeze:
         _write_json(tmp_path, "data/models/settings.json", {"frozen_at": None})
         violations = check_artifacts_require_freeze(
             ["data/models/settings.json"],
+            tmp_path,
+        )
+        assert violations == []
+
+
+# -- _is_gate_artifact tests --------------------------------------------------
+
+
+class TestIsGateArtifact:
+    """Tests for the _is_gate_artifact helper."""
+
+    def test_notebook_gate_matches(self):
+        assert _is_gate_artifact("data/runs/abc/notebook_gate.json") is True
+
+    def test_batch_gate_matches(self):
+        assert _is_gate_artifact("data/runs/abc/batch_gate.json") is True
+
+    def test_gate_substring_matches(self):
+        assert (
+            _is_gate_artifact("data/runs/abc/play_policy_gate_aggregate.json") is True
+        )
+
+    def test_non_gate_json_ignored(self):
+        assert _is_gate_artifact("data/runs/abc/meta.json") is False
+        assert _is_gate_artifact("data/runs/abc/rollup.json") is False
+
+    def test_non_data_path_ignored(self):
+        assert _is_gate_artifact("src/configs/notebook_gate.json") is False
+
+    def test_non_json_ignored(self):
+        assert _is_gate_artifact("data/runs/abc/gate_results.txt") is False
+
+
+# -- check_gate_artifacts_schema tests ----------------------------------------
+
+
+class TestCheckGateArtifactsSchema:
+    """Tests for the check_gate_artifacts_schema lint rule."""
+
+    def test_valid_pass_gate_passes(self, tmp_path: Path):
+        _write_json(
+            tmp_path,
+            "data/runs/abc/notebook_gate.json",
+            {
+                "schema_version": 1,
+                "gate_status": "PASS",
+                "created_at_utc": "2026-01-15T00:00:00Z",
+            },
+        )
+        violations = check_gate_artifacts_schema(
+            ["data/runs/abc/notebook_gate.json"],
+            tmp_path,
+        )
+        assert violations == []
+
+    def test_fail_gate_flagged(self, tmp_path: Path):
+        _write_json(
+            tmp_path,
+            "data/runs/abc/notebook_gate.json",
+            {
+                "schema_version": 1,
+                "gate_status": "FAIL",
+                "created_at_utc": "2026-01-15T00:00:00Z",
+            },
+        )
+        violations = check_gate_artifacts_schema(
+            ["data/runs/abc/notebook_gate.json"],
+            tmp_path,
+        )
+        assert len(violations) == 1
+        assert violations[0].rule == "gate-artifact-schema"
+        assert "FAIL" in violations[0].message
+
+    def test_missing_fields_flagged(self, tmp_path: Path):
+        _write_json(
+            tmp_path,
+            "data/runs/abc/batch_gate.json",
+            {"schema_version": 1},
+        )
+        violations = check_gate_artifacts_schema(
+            ["data/runs/abc/batch_gate.json"],
+            tmp_path,
+        )
+        assert len(violations) == 1
+        assert violations[0].rule == "gate-artifact-schema"
+        assert "missing required fields" in violations[0].message
+
+    def test_invalid_json_flagged(self, tmp_path: Path):
+        _write_file(tmp_path, "data/runs/abc/notebook_gate.json", "not json {{{")
+        violations = check_gate_artifacts_schema(
+            ["data/runs/abc/notebook_gate.json"],
+            tmp_path,
+        )
+        assert len(violations) == 1
+        assert violations[0].rule == "gate-artifact-schema"
+        assert "not valid JSON" in violations[0].message
+
+    def test_non_gate_files_ignored(self, tmp_path: Path):
+        _write_json(tmp_path, "data/runs/abc/meta.json", {"some": "data"})
+        violations = check_gate_artifacts_schema(
+            ["data/runs/abc/meta.json"],
+            tmp_path,
+        )
+        assert violations == []
+
+    def test_nonexistent_file_skipped(self, tmp_path: Path):
+        violations = check_gate_artifacts_schema(
+            ["data/runs/abc/notebook_gate.json"],
+            tmp_path,
+        )
+        assert violations == []
+
+    def test_non_data_path_ignored(self, tmp_path: Path):
+        _write_json(
+            tmp_path,
+            "src/notebook_gate.json",
+            {"gate_status": "FAIL"},
+        )
+        violations = check_gate_artifacts_schema(
+            ["src/notebook_gate.json"],
+            tmp_path,
+        )
+        assert violations == []
+
+
+# -- _is_split_manifest tests -------------------------------------------------
+
+
+class TestIsSplitManifest:
+    """Tests for the _is_split_manifest helper."""
+
+    def test_split_manifest_json_matches(self):
+        assert _is_split_manifest("data/runs/abc/split_manifest.json") is True
+
+    def test_split_manifest_v2_matches(self):
+        assert _is_split_manifest("data/runs/abc/split_manifest_v2.json") is True
+
+    def test_split_manifest_with_suffix_matches(self):
+        assert _is_split_manifest("some/path/split_manifest_train_test.json") is True
+
+    def test_other_json_ignored(self):
+        assert _is_split_manifest("data/runs/abc/meta.json") is False
+        assert _is_split_manifest("data/runs/abc/manifest.json") is False
+
+    def test_non_json_ignored(self):
+        assert _is_split_manifest("data/runs/abc/split_manifest.txt") is False
+
+
+# -- check_split_manifest_schema tests ----------------------------------------
+
+
+class TestCheckSplitManifestSchema:
+    """Tests for the check_split_manifest_schema lint rule."""
+
+    def test_valid_two_way_passes(self, tmp_path: Path):
+        _write_json(
+            tmp_path,
+            "data/runs/abc/split_manifest.json",
+            {
+                "schema_version": 1,
+                "split_type": "two_way",
+                "split_seed": 42,
+                "total_hand_ids": 1000,
+                "partition_hashes": {"train": "abc123", "test": "def456"},
+            },
+        )
+        violations = check_split_manifest_schema(
+            ["data/runs/abc/split_manifest.json"],
+            tmp_path,
+        )
+        assert violations == []
+
+    def test_valid_three_way_passes(self, tmp_path: Path):
+        _write_json(
+            tmp_path,
+            "data/runs/abc/split_manifest.json",
+            {
+                "schema_version": 1,
+                "split_type": "three_way",
+                "split_seed": 42,
+                "total_hand_ids": 1000,
+                "partition_hashes": {
+                    "train": "abc",
+                    "val": "def",
+                    "test": "ghi",
+                },
+            },
+        )
+        violations = check_split_manifest_schema(
+            ["data/runs/abc/split_manifest.json"],
+            tmp_path,
+        )
+        assert violations == []
+
+    def test_invalid_split_type_flagged(self, tmp_path: Path):
+        _write_json(
+            tmp_path,
+            "data/runs/abc/split_manifest.json",
+            {
+                "schema_version": 1,
+                "split_type": "four_way",
+                "split_seed": 42,
+                "total_hand_ids": 1000,
+                "partition_hashes": {},
+            },
+        )
+        violations = check_split_manifest_schema(
+            ["data/runs/abc/split_manifest.json"],
+            tmp_path,
+        )
+        assert len(violations) == 1
+        assert violations[0].rule == "split-manifest-schema"
+        assert "four_way" in violations[0].message
+
+    def test_missing_fields_flagged(self, tmp_path: Path):
+        _write_json(
+            tmp_path,
+            "data/runs/abc/split_manifest.json",
+            {"schema_version": 1, "split_type": "two_way"},
+        )
+        violations = check_split_manifest_schema(
+            ["data/runs/abc/split_manifest.json"],
+            tmp_path,
+        )
+        assert len(violations) == 1
+        assert violations[0].rule == "split-manifest-schema"
+        assert "missing required fields" in violations[0].message
+
+    def test_invalid_json_flagged(self, tmp_path: Path):
+        _write_file(tmp_path, "data/runs/abc/split_manifest.json", "not json")
+        violations = check_split_manifest_schema(
+            ["data/runs/abc/split_manifest.json"],
+            tmp_path,
+        )
+        assert len(violations) == 1
+        assert violations[0].rule == "split-manifest-schema"
+        assert "not valid JSON" in violations[0].message
+
+    def test_non_manifest_files_ignored(self, tmp_path: Path):
+        _write_json(tmp_path, "data/runs/abc/meta.json", {"some": "data"})
+        violations = check_split_manifest_schema(
+            ["data/runs/abc/meta.json"],
+            tmp_path,
+        )
+        assert violations == []
+
+    def test_nonexistent_file_skipped(self, tmp_path: Path):
+        violations = check_split_manifest_schema(
+            ["data/runs/abc/split_manifest.json"],
             tmp_path,
         )
         assert violations == []


### PR DESCRIPTION
## Summary
- Add `gate-artifact-schema` lint rule: validates gate JSON files under `data/` have required fields (`schema_version`, `gate_status`, `created_at_utc`) and `gate_status == PASS`
- Add `split-manifest-schema` lint rule: validates split manifest JSON files have required fields (`schema_version`, `split_type`, `split_seed`, `total_hand_ids`, `partition_hashes`) and valid `split_type` (`two_way` or `three_way`)
- Document all Track 3 lint rules (`artifact-requires-freeze`, `gate-artifact-schema`, `split-manifest-schema`) in `PROMOTION_WORKFLOW.md`

## Why
Completes Track 3 (Registry Lint) of the Promotion Workflow Gaps plan. These rules prevent committing malformed or failing gate artifacts and invalid split manifests, catching schema violations at PR time rather than downstream in the promotion pipeline.

## Repro / Validation
```bash
cd ../Bid-Euchre-track3-schema-lint
make check                                        # Full suite passes (1186 tests)
uv run python -m pytest tests/unit/test_lint_repo.py -v  # 45 tests pass (20 new)
```

## Tests
- `make check` — 1186 passed, 0 failures
- `tests/unit/test_lint_repo.py` — 45 tests total (20 new: 6 gate helper, 7 gate schema, 5 split helper, 7 split schema)

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-track3-schema-lint
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-track3-schema-lint
```

## Files changed
| File | Change |
|------|--------|
| `scripts/lint_repo.py` | +2 rules, +2 helpers, +constants (~130 LOC) |
| `tests/unit/test_lint_repo.py` | +20 tests (~250 LOC) |
| `docs/02_agent/PROMOTION_WORKFLOW.md` | +3 lint rule docs (~9 LOC) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)