### PR TITLE
fix: notebook gate validation alignment, strict MODE checks, path-robust archive filter

### DIFF
--- a/scripts/run_notebooks.py
+++ b/scripts/run_notebooks.py
@@ -58,7 +58,7 @@ def discover_notebooks(pattern: str = "notebooks/phase0_bidless/*.ipynb") -> lis
     repo_root = Path(__file__).parent.parent
     all_notebooks = sorted(glob.glob(str(repo_root / pattern)))
     # Exclude archived notebooks
-    notebooks = [Path(nb) for nb in all_notebooks if "/archive/" not in nb]
+    notebooks = [Path(nb) for nb in all_notebooks if "archive" not in Path(nb).parts]
     return notebooks
 
 
@@ -114,18 +114,40 @@ def execute_notebook(
         return False, str(e)[:200], duration
 
 
-def build_gate_artifact(results: list[tuple], mode: str) -> dict:
-    """Build notebook gate JSON from execution results.
+def build_gate_artifact(
+    results: list[tuple],
+    mode: str,
+    validation_results: dict[str, dict] | None = None,
+) -> dict:
+    """Build notebook gate JSON from execution and validation results.
 
     Args:
         results: List of (name, success, message, duration) tuples
         mode: Execution mode ("smoke" or "quick")
+        validation_results: Optional dict mapping notebook name to
+            {"ok": bool, "errors": list[str]} from post-execution validation
 
     Returns:
         Gate artifact dict conforming to NOTEBOOK_GATE_SCHEMA_VERSION 1
     """
-    passed = sum(1 for _, success, _, _ in results if success)
-    failed = len(results) - passed
+    notebooks = []
+    for name, success, message, duration in results:
+        entry = {
+            "name": name,
+            "status": "PASS" if success else "FAIL",
+            "duration_seconds": round(duration, 2),
+            "message": message,
+        }
+        if validation_results and name in validation_results:
+            vr = validation_results[name]
+            entry["validation_status"] = "PASS" if vr["ok"] else "FAIL"
+            if not vr["ok"]:
+                entry["validation_message"] = "; ".join(vr["errors"])
+                entry["status"] = "FAIL"
+        notebooks.append(entry)
+
+    passed = sum(1 for nb in notebooks if nb["status"] == "PASS")
+    failed = len(notebooks) - passed
     return {
         "schema_version": NOTEBOOK_GATE_SCHEMA_VERSION,
         "gate_status": "PASS" if failed == 0 else "FAIL",
@@ -134,15 +156,7 @@ def build_gate_artifact(results: list[tuple], mode: str) -> dict:
         "total": len(results),
         "passed": passed,
         "failed": failed,
-        "notebooks": [
-            {
-                "name": name,
-                "status": "PASS" if success else "FAIL",
-                "duration_seconds": round(duration, 2),
-                "message": message,
-            }
-            for name, success, message, duration in results
-        ],
+        "notebooks": notebooks,
     }
 
 
@@ -259,6 +273,7 @@ def main():
         print(f"Output notebooks: {output_dir}")
 
     # Validate executed notebooks if requested
+    validation_map: dict[str, dict] | None = None
     if args.validate:
         from bid_euchre.diagnostics.notebook_validation import validate_notebook
 
@@ -270,6 +285,7 @@ def main():
         print("VALIDATION")
         print("=" * 60)
 
+        validation_map = {}
         validation_failures = 0
         for name, success, _, _ in results:
             if not success:
@@ -280,17 +296,20 @@ def main():
             result = validate_notebook(output_path, expected_mode=expected_mode)
 
             if result.ok:
+                validation_map[name] = {"ok": True, "errors": []}
                 print(f"  [PASS] {name}")
             else:
                 validation_failures += 1
-                print(f"  [FAIL] {name}")
-                for err in result.errors:
-                    print(f"    - {err}")
+                errors = list(result.errors)
                 for cell_err in result.cell_errors:
-                    print(
-                        f"    - Cell {cell_err.cell_index}: "
+                    errors.append(
+                        f"Cell {cell_err.cell_index}: "
                         f"{cell_err.ename}: {cell_err.evalue}"
                     )
+                validation_map[name] = {"ok": False, "errors": errors}
+                print(f"  [FAIL] {name}")
+                for err in errors:
+                    print(f"    - {err}")
 
         if validation_failures > 0:
             failed += validation_failures
@@ -300,7 +319,9 @@ def main():
     if args.gate_output_dir:
         gate_dir = Path(args.gate_output_dir)
         gate_dir.mkdir(parents=True, exist_ok=True)
-        gate = build_gate_artifact(results, args.mode)
+        gate = build_gate_artifact(
+            results, args.mode, validation_results=validation_map
+        )
         with open(gate_dir / "notebook_gate.json", "w") as f:
             json.dump(gate, f, indent=2, sort_keys=True)
         with open(gate_dir / "NOTEBOOK_GATE.md", "w") as f:

--- a/src/bid_euchre/diagnostics/notebook_validation.py
+++ b/src/bid_euchre/diagnostics/notebook_validation.py
@@ -104,6 +104,11 @@ def check_mode_parameter(nb: dict, expected_mode: str | None = None) -> list[str
             f"No 'injected-parameters' cell found (expected MODE={expected_mode})"
         )
 
+    if expected_mode and has_injected_cell and injected_mode is None:
+        errors.append(
+            "injected-parameters cell exists but MODE assignment not found or unparseable"
+        )
+
     if expected_mode and injected_mode and injected_mode != expected_mode:
         errors.append(f"Injected MODE={injected_mode!r}, expected {expected_mode!r}")
 

--- a/tests/unit/test_notebook_gate.py
+++ b/tests/unit/test_notebook_gate.py
@@ -64,9 +64,9 @@ class TestBuildGateArtifact:
         )
         gate = build_gate_artifact(results, "quick")
         for nb in gate["notebooks"]:
-            assert NOTEBOOK_RESULT_REQUIRED_FIELDS <= set(nb.keys()), (
-                f"Missing: {NOTEBOOK_RESULT_REQUIRED_FIELDS - set(nb.keys())}"
-            )
+            assert NOTEBOOK_RESULT_REQUIRED_FIELDS <= set(
+                nb.keys()
+            ), f"Missing: {NOTEBOOK_RESULT_REQUIRED_FIELDS - set(nb.keys())}"
 
     def test_gate_mode_propagated(self):
         gate = build_gate_artifact([], "quick")
@@ -80,6 +80,67 @@ class TestBuildGateArtifact:
         results = [("test.ipynb", True, "OK", 1.23456)]
         gate = build_gate_artifact(results, "smoke")
         assert gate["notebooks"][0]["duration_seconds"] == 1.23
+
+    def test_gate_fail_on_validation_failure(self):
+        """Gate should be FAIL when execution passes but validation fails."""
+        results = _make_results(("10_test.ipynb", True))
+        validation_results = {
+            "10_test.ipynb": {
+                "ok": False,
+                "errors": ["Cell 2: ZeroDivisionError: division by zero"],
+            }
+        }
+        gate = build_gate_artifact(
+            results, "smoke", validation_results=validation_results
+        )
+        assert gate["gate_status"] == "FAIL"
+        assert gate["failed"] == 1
+        assert gate["passed"] == 0
+        nb_entry = gate["notebooks"][0]
+        assert nb_entry["status"] == "FAIL"
+        assert nb_entry["validation_status"] == "FAIL"
+        assert "ZeroDivisionError" in nb_entry["validation_message"]
+
+    def test_gate_pass_with_validation_pass(self):
+        """Gate should be PASS when both execution and validation pass."""
+        results = _make_results(("10_test.ipynb", True))
+        validation_results = {
+            "10_test.ipynb": {"ok": True, "errors": []},
+        }
+        gate = build_gate_artifact(
+            results, "smoke", validation_results=validation_results
+        )
+        assert gate["gate_status"] == "PASS"
+        assert gate["passed"] == 1
+        nb_entry = gate["notebooks"][0]
+        assert nb_entry["status"] == "PASS"
+        assert nb_entry["validation_status"] == "PASS"
+
+    def test_gate_no_validation_results_backward_compat(self):
+        """Gate without validation_results should work as before (no validation_status key)."""
+        results = _make_results(("10_test.ipynb", True))
+        gate = build_gate_artifact(results, "smoke")
+        nb_entry = gate["notebooks"][0]
+        assert nb_entry["status"] == "PASS"
+        assert "validation_status" not in nb_entry
+
+    def test_gate_mixed_execution_and_validation_failures(self):
+        """Gate counts both execution and validation failures correctly."""
+        results = _make_results(
+            ("10_test.ipynb", False),  # execution fail
+            ("20_test.ipynb", True),  # execution pass, validation fail
+            ("30_test.ipynb", True),  # all pass
+        )
+        validation_results = {
+            "20_test.ipynb": {"ok": False, "errors": ["MODE mismatch"]},
+            "30_test.ipynb": {"ok": True, "errors": []},
+        }
+        gate = build_gate_artifact(
+            results, "smoke", validation_results=validation_results
+        )
+        assert gate["gate_status"] == "FAIL"
+        assert gate["failed"] == 2
+        assert gate["passed"] == 1
 
 
 class TestBuildGateMarkdown:

--- a/tests/unit/test_notebook_validation.py
+++ b/tests/unit/test_notebook_validation.py
@@ -125,6 +125,38 @@ class TestCheckModeParameter:
         errors = check_mode_parameter(nb, expected_mode="SMOKE")
         assert any("injected-parameters" in e for e in errors)
 
+    def test_injected_cell_no_mode_assignment(self):
+        """injected-parameters cell with no MODE line should fail when expected_mode set."""
+        cells = [
+            _make_code_cell('MODE = "QUICK"', tags=["parameters"]),
+            _make_code_cell("SEED = 42", tags=["injected-parameters"]),
+        ]
+        nb = _make_notebook(cells=cells)
+        errors = check_mode_parameter(nb, expected_mode="SMOKE")
+        assert any("not found or unparseable" in e for e in errors)
+
+    def test_injected_cell_malformed_mode(self):
+        """injected-parameters cell with malformed MODE should fail when expected_mode set."""
+        cells = [
+            _make_code_cell('MODE = "QUICK"', tags=["parameters"]),
+            # MODE without = is not parseable
+            _make_code_cell("SOMETHING_ELSE = 1", tags=["injected-parameters"]),
+        ]
+        nb = _make_notebook(cells=cells)
+        errors = check_mode_parameter(nb, expected_mode="SMOKE")
+        assert any("not found or unparseable" in e for e in errors)
+
+    def test_injected_cell_no_mode_no_expected(self):
+        """injected-parameters cell with no MODE should pass when no expected_mode."""
+        cells = [
+            _make_code_cell('MODE = "QUICK"', tags=["parameters"]),
+            _make_code_cell("SEED = 42", tags=["injected-parameters"]),
+        ]
+        nb = _make_notebook(cells=cells)
+        # No expected_mode → no strict check on injected cell content
+        errors = check_mode_parameter(nb)
+        assert errors == []
+
 
 # ---------------------------------------------------------------------------
 # extract_cell_errors

--- a/tests/unit/test_run_notebooks.py
+++ b/tests/unit/test_run_notebooks.py
@@ -42,6 +42,21 @@ class TestDiscoverNotebooks:
         assert "20_test.ipynb" in names
         assert "old_test.ipynb" not in names
 
+    def test_archive_exclusion_uses_path_parts(self):
+        """Archive exclusion should use Path.parts, not substring matching."""
+        fake_glob_results = [
+            "/repo/notebooks/phase0_bidless/10_archive_notes.ipynb",  # not in archive dir
+            "/repo/notebooks/phase0_bidless/archive/old_test.ipynb",  # in archive dir
+        ]
+        with patch("scripts.run_notebooks.glob.glob", return_value=fake_glob_results):
+            notebooks = discover_notebooks("notebooks/phase0_bidless/*.ipynb")
+
+        names = [nb.name for nb in notebooks]
+        # File with "archive" in name but not in archive/ dir should be included
+        assert "10_archive_notes.ipynb" in names
+        # File actually in archive/ dir should be excluded
+        assert "old_test.ipynb" not in names
+
     def test_returns_sorted_paths(self):
         """Discovered notebooks should be sorted by path."""
         notebooks = discover_notebooks("notebooks/phase0_bidless/*.ipynb")
@@ -426,3 +441,42 @@ class TestValidateFlag:
                 main()
             # Exit 1 because execution failed, not validation
             assert exc_info.value.code == 1
+
+    @patch("scripts.run_notebooks.execute_notebook")
+    @patch("scripts.run_notebooks.discover_notebooks")
+    def test_validate_failure_reflected_in_gate_artifact(
+        self, mock_discover, mock_execute, tmp_path
+    ):
+        """Gate artifact should be FAIL when execution passes but validation fails."""
+        nb_name = "10_test.ipynb"
+        mock_discover.return_value = [Path(f"notebooks/{nb_name}")]
+
+        def fake_execute(nb_path, mode, output_dir):
+            _write_error_notebook(output_dir / nb_path.name)
+            return True, "OK", 1.0
+
+        mock_execute.side_effect = fake_execute
+
+        gate_dir = tmp_path / "gate"
+        with patch(
+            "sys.argv",
+            [
+                "run_notebooks.py",
+                "--mode",
+                "smoke",
+                "--validate",
+                "--gate-output-dir",
+                str(gate_dir),
+            ],
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                from scripts.run_notebooks import main
+
+                main()
+            assert exc_info.value.code == 1
+
+        gate = json.loads((gate_dir / "notebook_gate.json").read_text())
+        assert gate["gate_status"] == "FAIL"
+        nb_entry = gate["notebooks"][0]
+        assert nb_entry["status"] == "FAIL"
+        assert nb_entry["validation_status"] == "FAIL"


### PR DESCRIPTION
## Summary
- Gate artifact (`notebook_gate.json`) now reflects `--validate` failures, not just execution results
- MODE injection validation is strict: fails when `injected-parameters` cell has no parseable MODE
- Archive exclusion uses `Path.parts` instead of substring matching for cross-platform safety

## Why
PR #325 introduced notebook testing infrastructure but had three gaps:
1. Gate artifact could report PASS even when `--validate` found cell errors
2. MODE injection check silently passed when `injected-parameters` cell existed without a MODE assignment
3. Archive filtering used `"/archive/" not in path_str` which could false-positive on filenames containing "archive"

## Changes by file

| File | Change |
|------|--------|
| `scripts/run_notebooks.py` | `build_gate_artifact()` accepts `validation_results` param; `main()` collects validation map; archive filter uses `Path.parts` |
| `src/bid_euchre/diagnostics/notebook_validation.py` | `check_mode_parameter()` fails when injected-parameters cell has no parseable MODE and `expected_mode` is set |
| `tests/unit/test_notebook_gate.py` | +4 tests: validation FAIL in gate, validation PASS, backward compat, mixed failures |
| `tests/unit/test_notebook_validation.py` | +3 tests: missing MODE in injected cell, malformed MODE, no-expected-mode passthrough |
| `tests/unit/test_run_notebooks.py` | +2 tests: path-parts archive exclusion, validate failure reflected in gate JSON |

## Repro / Validation
```bash
# Unit tests (67 pass)
uv run python -m pytest -q tests/unit/test_run_notebooks.py tests/unit/test_notebook_validation.py tests/unit/test_notebook_gate.py

# Integration smoke tests (3 pass)
uv run python -m pytest -q tests/integration/test_notebook_smoke.py -m slow

# Full suite (1170 pass)
make check
```

## Tests
- `make check` — 1170 passed, 5 skipped, 2 xfailed, 1 xpassed
- Integration smoke tests — 3/3 passed

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-notebook-fixes
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-notebook-fixes
branch: codex/notebook-testing-fixes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)