### PR TITLE
fix(lint): robust JSON shapes, schema-based detection, sha256 alignment

### DIFF
--- a/scripts/lint_repo.py
+++ b/scripts/lint_repo.py
@@ -724,8 +724,15 @@ def check_canonical_runs_registry_consistency(
 
 
 # --- Artifact discovery lint rules ---
+#
+# This is a supplemental commit-time check. The canonical promotion-path
+# enforcement lives in reporting.eligibility.check_artifacts_frozen() which
+# uses models.freeze.verify_frozen() at runtime. The lint rule mirrors that
+# logic (checks both frozen_at and artifact_sha256) for early feedback.
 
 # Filename substrings that indicate model artifacts (case-insensitive match).
+# Used as a path-based pre-filter; schema confirmation via
+# _has_model_artifact_schema() prevents false positives on unrelated JSON.
 ARTIFACT_NAME_PATTERNS = ["olsa", "b0", "teacher"]
 
 # Infrastructure JSON files that live under data/ but are NOT model artifacts.
@@ -733,7 +740,12 @@ FREEZE_EXEMPT_NAMES = {"meta.json", "rollup.json", "canonical_summary.json"}
 
 
 def _is_model_artifact(path: str) -> bool:
-    """Return True if *path* looks like a model artifact JSON under data/."""
+    """Path-based pre-filter: True if *path* is a candidate model artifact.
+
+    Checks: under data/, .json extension, not exempt, filename matches a
+    known pattern. Callers should confirm with _has_model_artifact_schema()
+    after reading the file content.
+    """
     if not is_under(path, "data/"):
         return False
     name = Path(path).name
@@ -745,11 +757,36 @@ def _is_model_artifact(path: str) -> bool:
     return any(pattern in name_lower for pattern in ARTIFACT_NAME_PATTERNS)
 
 
+def _has_model_artifact_schema(data: dict) -> bool:
+    """Schema-based confirmation: True if *data* looks like a model artifact.
+
+    Checks for known model artifact keys produced by the training pipeline:
+    - ``artifact_type``: explicitly tags the file as a model artifact
+    - ``frozen_at``: freeze field (present even when null in training output)
+    - ``models`` + ``metadata``: OLSa artifact structure
+    """
+    if "artifact_type" in data:
+        return True
+    if "frozen_at" in data:
+        return True
+    if "models" in data and "metadata" in data:
+        return True
+    return False
+
+
 def check_artifacts_require_freeze(
     changed: list[str],
     repo_root: Path,
 ) -> list[Violation]:
-    """Model artifact JSON files must have a non-null ``frozen_at`` field."""
+    """Model artifact JSON must be properly frozen (frozen_at + artifact_sha256).
+
+    Detection uses two-phase filtering: path pre-filter (_is_model_artifact)
+    then schema confirmation (_has_model_artifact_schema). This prevents
+    false positives on unrelated JSON that happens to match filename patterns.
+
+    Freeze check mirrors models.freeze.verify_frozen(): requires both
+    frozen_at and artifact_sha256 to be non-null.
+    """
     violations: list[Violation] = []
     for p in changed:
         if not _is_model_artifact(p):
@@ -771,6 +808,23 @@ def check_artifacts_require_freeze(
             )
             continue
 
+        if not isinstance(metadata, dict):
+            violations.append(
+                Violation(
+                    rule="artifact-requires-freeze",
+                    path=p,
+                    message=(
+                        "Model artifact JSON must be an object (got "
+                        f"{type(metadata).__name__})."
+                    ),
+                )
+            )
+            continue
+
+        # Schema confirmation: skip files that don't look like model artifacts
+        if not _has_model_artifact_schema(metadata):
+            continue
+
         if metadata.get("frozen_at") is None:
             violations.append(
                 Violation(
@@ -779,6 +833,17 @@ def check_artifacts_require_freeze(
                     message=(
                         "Model artifact must be frozen before commit "
                         "(frozen_at is null). Run freeze_artifact() first."
+                    ),
+                )
+            )
+        elif metadata.get("artifact_sha256") is None:
+            violations.append(
+                Violation(
+                    rule="artifact-requires-freeze",
+                    path=p,
+                    message=(
+                        "Model artifact has frozen_at but missing artifact_sha256. "
+                        "Run freeze_artifact() to set both fields."
                     ),
                 )
             )
@@ -839,6 +904,19 @@ def check_gate_artifacts_schema(
             )
             continue
 
+        if not isinstance(data, dict):
+            violations.append(
+                Violation(
+                    rule="gate-artifact-schema",
+                    path=p,
+                    message=(
+                        "Gate artifact JSON must be an object (got "
+                        f"{type(data).__name__})."
+                    ),
+                )
+            )
+            continue
+
         missing = GATE_REQUIRED_FIELDS - set(data.keys())
         if missing:
             violations.append(
@@ -886,6 +964,19 @@ def check_split_manifest_schema(
                     rule="split-manifest-schema",
                     path=p,
                     message="Split manifest is not valid JSON.",
+                )
+            )
+            continue
+
+        if not isinstance(data, dict):
+            violations.append(
+                Violation(
+                    rule="split-manifest-schema",
+                    path=p,
+                    message=(
+                        "Split manifest JSON must be an object (got "
+                        f"{type(data).__name__})."
+                    ),
                 )
             )
             continue

--- a/tests/unit/test_lint_repo.py
+++ b/tests/unit/test_lint_repo.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 from scripts.lint_repo import (
+    _has_model_artifact_schema,
     _is_gate_artifact,
     _is_model_artifact,
     _is_split_manifest,
@@ -85,7 +86,8 @@ class TestCheckArtifactsRequireFreeze:
             "data/models/olsa_v1.json",
             {
                 "frozen_at": "2026-01-15T00:00:00Z",
-                "version": "1.0",
+                "artifact_sha256": "abc123def456",
+                "artifact_type": "olsa_v1",
             },
         )
         violations = check_artifacts_require_freeze(
@@ -100,7 +102,7 @@ class TestCheckArtifactsRequireFreeze:
             "data/models/olsa_v1.json",
             {
                 "frozen_at": None,
-                "version": "1.0",
+                "artifact_type": "olsa_v1",
             },
         )
         violations = check_artifacts_require_freeze(
@@ -116,7 +118,8 @@ class TestCheckArtifactsRequireFreeze:
             tmp_path,
             "data/models/b0_weights.json",
             {
-                "version": "1.0",
+                "artifact_type": "b0_v1",
+                "models": {},
             },
         )
         violations = check_artifacts_require_freeze(
@@ -125,6 +128,7 @@ class TestCheckArtifactsRequireFreeze:
         )
         assert len(violations) == 1
         assert violations[0].rule == "artifact-requires-freeze"
+        assert "frozen_at is null" in violations[0].message
 
     def test_exempt_files_pass(self, tmp_path: Path):
         _write_json(tmp_path, "data/runs/abc/meta.json", {"some": "data"})
@@ -167,13 +171,16 @@ class TestCheckArtifactsRequireFreeze:
             "data/models/olsa_frozen.json",
             {
                 "frozen_at": "2026-01-15T00:00:00Z",
+                "artifact_sha256": "abc123",
+                "artifact_type": "olsa_v1",
             },
         )
         _write_json(
             tmp_path,
             "data/models/b0_unfrozen.json",
             {
-                "version": "1.0",
+                "artifact_type": "b0_v1",
+                "frozen_at": None,
             },
         )
         violations = check_artifacts_require_freeze(
@@ -440,3 +447,221 @@ class TestCheckSplitManifestSchema:
             tmp_path,
         )
         assert violations == []
+
+
+# -- _has_model_artifact_schema tests -----------------------------------------
+
+
+class TestHasModelArtifactSchema:
+    """Tests for the _has_model_artifact_schema helper."""
+
+    def test_artifact_type_key(self):
+        assert _has_model_artifact_schema({"artifact_type": "olsa_v1"}) is True
+
+    def test_frozen_at_key_null(self):
+        assert _has_model_artifact_schema({"frozen_at": None}) is True
+
+    def test_frozen_at_key_set(self):
+        assert _has_model_artifact_schema({"frozen_at": "2026-01-15T00:00:00Z"}) is True
+
+    def test_models_and_metadata_keys(self):
+        assert _has_model_artifact_schema({"models": {}, "metadata": {}}) is True
+
+    def test_unrelated_config_json(self):
+        assert (
+            _has_model_artifact_schema({"learning_rate": 0.01, "epochs": 10}) is False
+        )
+
+    def test_empty_dict(self):
+        assert _has_model_artifact_schema({}) is False
+
+    def test_version_only(self):
+        assert _has_model_artifact_schema({"version": "1.0"}) is False
+
+
+# -- Non-dict JSON root tests (Fix 1) ----------------------------------------
+
+
+class TestNonDictJsonRoots:
+    """Verify all three lint rules handle non-dict JSON roots without crashing."""
+
+    def test_artifact_json_array_root(self, tmp_path: Path):
+        _write_json(tmp_path, "data/models/olsa_v1.json", [1, 2, 3])
+        violations = check_artifacts_require_freeze(
+            ["data/models/olsa_v1.json"], tmp_path
+        )
+        assert len(violations) == 1
+        assert violations[0].rule == "artifact-requires-freeze"
+        assert "must be an object" in violations[0].message
+        assert "list" in violations[0].message
+
+    def test_artifact_json_string_root(self, tmp_path: Path):
+        _write_json(tmp_path, "data/models/olsa_v1.json", "just a string")
+        violations = check_artifacts_require_freeze(
+            ["data/models/olsa_v1.json"], tmp_path
+        )
+        assert len(violations) == 1
+        assert "must be an object" in violations[0].message
+        assert "str" in violations[0].message
+
+    def test_artifact_json_number_root(self, tmp_path: Path):
+        _write_json(tmp_path, "data/models/olsa_v1.json", 42)
+        violations = check_artifacts_require_freeze(
+            ["data/models/olsa_v1.json"], tmp_path
+        )
+        assert len(violations) == 1
+        assert "must be an object" in violations[0].message
+        assert "int" in violations[0].message
+
+    def test_gate_json_array_root(self, tmp_path: Path):
+        _write_json(tmp_path, "data/runs/abc/notebook_gate.json", [1, 2])
+        violations = check_gate_artifacts_schema(
+            ["data/runs/abc/notebook_gate.json"], tmp_path
+        )
+        assert len(violations) == 1
+        assert violations[0].rule == "gate-artifact-schema"
+        assert "must be an object" in violations[0].message
+
+    def test_gate_json_string_root(self, tmp_path: Path):
+        _write_json(tmp_path, "data/runs/abc/notebook_gate.json", "hello")
+        violations = check_gate_artifacts_schema(
+            ["data/runs/abc/notebook_gate.json"], tmp_path
+        )
+        assert len(violations) == 1
+        assert "must be an object" in violations[0].message
+
+    def test_split_json_array_root(self, tmp_path: Path):
+        _write_json(tmp_path, "data/runs/abc/split_manifest.json", [1, 2])
+        violations = check_split_manifest_schema(
+            ["data/runs/abc/split_manifest.json"], tmp_path
+        )
+        assert len(violations) == 1
+        assert violations[0].rule == "split-manifest-schema"
+        assert "must be an object" in violations[0].message
+
+    def test_split_json_number_root(self, tmp_path: Path):
+        _write_json(tmp_path, "data/runs/abc/split_manifest.json", 3.14)
+        violations = check_split_manifest_schema(
+            ["data/runs/abc/split_manifest.json"], tmp_path
+        )
+        assert len(violations) == 1
+        assert "must be an object" in violations[0].message
+
+
+# -- Schema confirmation tests (Fix 2) ----------------------------------------
+
+
+class TestSchemaConfirmation:
+    """Verify that schema confirmation prevents false positives."""
+
+    def test_config_with_olsa_in_name_not_flagged(self, tmp_path: Path):
+        """JSON with 'olsa' in filename but no artifact schema is skipped."""
+        _write_json(
+            tmp_path,
+            "data/configs/olsa_config.json",
+            {"learning_rate": 0.01, "batch_size": 32},
+        )
+        violations = check_artifacts_require_freeze(
+            ["data/configs/olsa_config.json"], tmp_path
+        )
+        assert violations == []
+
+    def test_real_olsa_artifact_detected(self, tmp_path: Path):
+        """Realistic OLSa artifact (with artifact_type) is detected and flagged."""
+        _write_json(
+            tmp_path,
+            "data/models/olsa_v1.json",
+            {
+                "schema_version": "1",
+                "artifact_type": "olsa_v1",
+                "frozen_at": None,
+                "models": {"suit": {"weights": [1.0], "bias": 0.5}},
+                "metadata": {"training_seed": 42},
+            },
+        )
+        violations = check_artifacts_require_freeze(
+            ["data/models/olsa_v1.json"], tmp_path
+        )
+        assert len(violations) == 1
+        assert violations[0].rule == "artifact-requires-freeze"
+
+    def test_b0_name_no_schema_skipped(self, tmp_path: Path):
+        """File named b0_*.json but without artifact schema is not flagged."""
+        _write_json(
+            tmp_path,
+            "data/logs/b0_experiment_log.json",
+            {"timestamp": "2026-01-15", "events": []},
+        )
+        violations = check_artifacts_require_freeze(
+            ["data/logs/b0_experiment_log.json"], tmp_path
+        )
+        assert violations == []
+
+    def test_teacher_name_no_schema_skipped(self, tmp_path: Path):
+        """File named teacher_*.json but without artifact schema is not flagged."""
+        _write_json(
+            tmp_path,
+            "data/reports/teacher_eval_report.json",
+            {"accuracy": 0.95, "loss": 0.1},
+        )
+        violations = check_artifacts_require_freeze(
+            ["data/reports/teacher_eval_report.json"], tmp_path
+        )
+        assert violations == []
+
+
+# -- artifact_sha256 alignment tests (Fix 3) -----------------------------------
+
+
+class TestArtifactSha256Check:
+    """Verify freeze check requires both frozen_at and artifact_sha256."""
+
+    def test_frozen_at_set_but_no_sha256_flagged(self, tmp_path: Path):
+        """Artifact with frozen_at but missing artifact_sha256 is flagged."""
+        _write_json(
+            tmp_path,
+            "data/models/olsa_v1.json",
+            {
+                "artifact_type": "olsa_v1",
+                "frozen_at": "2026-01-15T00:00:00Z",
+            },
+        )
+        violations = check_artifacts_require_freeze(
+            ["data/models/olsa_v1.json"], tmp_path
+        )
+        assert len(violations) == 1
+        assert violations[0].rule == "artifact-requires-freeze"
+        assert "artifact_sha256" in violations[0].message
+
+    def test_both_fields_set_passes(self, tmp_path: Path):
+        """Artifact with both frozen_at and artifact_sha256 passes."""
+        _write_json(
+            tmp_path,
+            "data/models/olsa_v1.json",
+            {
+                "artifact_type": "olsa_v1",
+                "frozen_at": "2026-01-15T00:00:00Z",
+                "artifact_sha256": "abc123def456",
+            },
+        )
+        violations = check_artifacts_require_freeze(
+            ["data/models/olsa_v1.json"], tmp_path
+        )
+        assert violations == []
+
+    def test_sha256_null_flagged(self, tmp_path: Path):
+        """Artifact with artifact_sha256=null is flagged."""
+        _write_json(
+            tmp_path,
+            "data/models/olsa_v1.json",
+            {
+                "artifact_type": "olsa_v1",
+                "frozen_at": "2026-01-15T00:00:00Z",
+                "artifact_sha256": None,
+            },
+        )
+        violations = check_artifacts_require_freeze(
+            ["data/models/olsa_v1.json"], tmp_path
+        )
+        assert len(violations) == 1
+        assert "artifact_sha256" in violations[0].message


### PR DESCRIPTION
## Summary

- **Fix 1**: All three lint rules (`artifact-requires-freeze`, `gate-artifact-schema`, `split-manifest-schema`) now handle non-dict JSON roots (arrays, strings, numbers) with a clear violation instead of crashing on `.get()`/`.keys()`.
- **Fix 2**: Artifact detection uses two-phase filtering: path pre-filter (`_is_model_artifact`) then schema confirmation (`_has_model_artifact_schema`). Config/log JSON that happens to match filename patterns (`olsa`, `b0`, `teacher`) is no longer falsely required to be frozen.
- **Fix 3**: `artifact-requires-freeze` now checks both `frozen_at` AND `artifact_sha256`, mirroring `models.freeze.verify_frozen()` logic. Added comments documenting the lint as supplemental to the canonical eligibility engine.

## Why

Track 3 lint rules (#327, #328) had three problems:
1. Valid JSON that isn't an object (e.g. `[1,2,3]`) would crash the linter with `AttributeError`.
2. Filename-only heuristic could false-positive on config/log files with `olsa`/`b0`/`teacher` in the name.
3. Lint only checked `frozen_at` but `verify_frozen()` requires both `frozen_at` + `artifact_sha256`; the gap meant the lint was weaker than runtime promotion checks.

## Changes

| File | Change |
|------|--------|
| `scripts/lint_repo.py` | `isinstance(data, dict)` guards in all 3 rules; new `_has_model_artifact_schema()` helper; `artifact_sha256` check; documenting comments |
| `tests/unit/test_lint_repo.py` | 21 new tests (7 schema helper, 7 non-dict roots, 4 schema confirmation, 3 sha256 alignment); updated 4 existing fixtures with realistic schemas |

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| `olsa_v1.json` containing `[1,2,3]` | `AttributeError` crash | Violation: "must be an object (got list)" |
| `olsa_config.json` with `{"learning_rate": 0.01}` | Violation (false positive) | Skipped (no artifact schema) |
| Frozen artifact missing `artifact_sha256` | Passes lint | Violation: "missing artifact_sha256" |
| Gate/split manifest containing a JSON array | `AttributeError` crash | Violation: "must be an object" |

## Repro / Validation

```bash
# Targeted tests
uv run pytest -q tests/unit/test_lint_repo.py   # 66 passed
uv run pytest -q tests/unit/test_eligibility.py  # 40 passed (unchanged)

# Full suite
make check  # 1231 passed, repo-lint + ruff + docs all green
```

## Tests

- `make check` — 1231 passed (21 new + 4 updated + 1206 existing)
- `tests/unit/test_lint_repo.py` — 66 passed (45→66)
- `tests/unit/test_eligibility.py` — 40 passed (unchanged)

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-lint-fixes
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-lint-fixes
branch: codex/lint-robustness-fixes
```

## Residual limitations

- `_is_model_artifact()` path pre-filter still uses filename substring matching. Schema confirmation catches false positives, but files outside `data/` with artifact schemas won't be caught (acceptable: lint scope is `data/` only).
- The lint rule does not verify SHA-256 integrity (just checks the field is non-null). Full integrity verification is done by `verify_frozen()` in the eligibility engine at runtime.
- No changes to `eligibility.py` or `generate_batch_report.py` — they already use `verify_frozen()` which is the canonical promotion-path check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)