### PR TITLE
feat: promotion hardening — content-hash freeze, rollup binding, split coherence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,11 @@ jobs:
         if: contains(github.event.pull_request.labels.*.name, 'promotion')
         env:
           ARTIFACT_DIR: ${{ vars.ARTIFACT_DIR || '' }}
+          ROLLUP_JSON: ${{ vars.ROLLUP_JSON || '' }}
+          SPLIT_MANIFEST_DIR: ${{ vars.SPLIT_MANIFEST_DIR || '' }}
         run: |
-          if [ -z "$ARTIFACT_DIR" ]; then
-            echo "::error::Promotion gate requires ARTIFACT_DIR. Set the ARTIFACT_DIR repository variable or remove the 'promotion' label."
+          if [ -z "$ARTIFACT_DIR" ] || [ -z "$ROLLUP_JSON" ]; then
+            echo "::error::Promotion gate requires ARTIFACT_DIR and ROLLUP_JSON. Set these repository variables or remove the 'promotion' label."
             exit 1
           fi
-          make promotion-gate ARTIFACT_DIR="$ARTIFACT_DIR"
+          make promotion-gate ARTIFACT_DIR="$ARTIFACT_DIR" ROLLUP_JSON="$ROLLUP_JSON" SPLIT_MANIFEST_DIR="${SPLIT_MANIFEST_DIR:-}"

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ help:
 	@echo "  make notebook-run       - execute notebooks (SMOKE mode, ~10s)"
 	@echo "  make notebook-run-full  - execute notebooks (QUICK mode, ~2-5min)"
 	@echo "  make docs-check         - docs freshness gate (path refs + script list)"
-	@echo "  make promotion-gate     - promotion CI gate (repo-lint + notebook gate)"
+	@echo "  make promotion-gate     - promotion CI gate (requires ARTIFACT_DIR + ROLLUP_JSON)"
 	@echo ""
 	@echo "Teacher baseline targets:"
 	@echo "  make bid-train-teachers - train teacher artifacts (all contracts)"
@@ -80,6 +80,8 @@ docs-check:
 
 GATE_OUTPUT_DIR ?= /tmp/promotion-gate-artifacts
 ARTIFACT_DIR ?=
+ROLLUP_JSON ?=
+SPLIT_MANIFEST_DIR ?=
 
 promotion-gate: repo-lint
 	@echo ">>> Promotion gate"
@@ -87,8 +89,31 @@ promotion-gate: repo-lint
 	PYTHONPATH=src $(PYTHON) scripts/run_notebooks.py --mode smoke --gate-output-dir $(GATE_OUTPUT_DIR)
 	@echo "Step 2: Assert notebook gate PASS"
 	$(PYTHON) -c "import json, sys; g=json.load(open('$(GATE_OUTPUT_DIR)/notebook_gate.json')); sys.exit(0 if g['gate_status']=='PASS' else 1)"
-	@echo "Step 3: Verify artifact freeze"
-	@if [ -z "$(ARTIFACT_DIR)" ]; then 		echo "ERROR: ARTIFACT_DIR is required for promotion gate."; 		echo "Usage: make promotion-gate ARTIFACT_DIR=/path/to/artifacts"; 		exit 1; 	elif [ ! -d "$(ARTIFACT_DIR)" ]; then 		echo "ERROR: ARTIFACT_DIR not found: $(ARTIFACT_DIR)"; 		exit 1; 	else 		echo "  Checking frozen status in $(ARTIFACT_DIR)..."; 		PYTHONPATH=src $(PYTHON) -c "from bid_euchre.models.freeze import verify_frozen; import pathlib, sys; exempt={'meta.json','rollup.json','canonical_summary.json','training_metrics.json'}; artifacts=[p for p in pathlib.Path('$(ARTIFACT_DIR)').glob('*.json') if p.name not in exempt and not p.name.startswith('split_manifest')]; failed=[p.name for p in artifacts if not verify_frozen(p)]; print(f'  Checked {len(artifacts)} artifacts, {len(failed)} not verified'); sys.exit(1) if failed else sys.exit(0)"; 	fi
+	@echo "Step 3: Verify artifact freeze and rollup binding"
+	@if [ -z "$(ARTIFACT_DIR)" ] || [ -z "$(ROLLUP_JSON)" ]; then \
+		echo "ERROR: ARTIFACT_DIR and ROLLUP_JSON are required for promotion gate."; \
+		echo "Usage: make promotion-gate ARTIFACT_DIR=/path/to/artifacts ROLLUP_JSON=/path/to/rollup.json"; \
+		exit 1; \
+	elif [ ! -d "$(ARTIFACT_DIR)" ]; then \
+		echo "ERROR: ARTIFACT_DIR not found: $(ARTIFACT_DIR)"; \
+		exit 1; \
+	elif [ ! -f "$(ROLLUP_JSON)" ]; then \
+		echo "ERROR: ROLLUP_JSON not found: $(ROLLUP_JSON)"; \
+		exit 1; \
+	else \
+		echo "  Validating rollup: $(ROLLUP_JSON)..."; \
+		PYTHONPATH=src $(PYTHON) -c "import json, sys; r=json.load(open('$(ROLLUP_JSON)')); bp=r.get('batch',{}).get('batch_purpose',''); print(f'  Rollup batch_purpose={bp}'); sys.exit(0) if bp=='promotion' else (print('  WARNING: batch_purpose is not promotion'), sys.exit(0))[1]"; \
+		echo "  Checking frozen status in $(ARTIFACT_DIR)..."; \
+		PYTHONPATH=src $(PYTHON) -c "from bid_euchre.models.freeze import verify_frozen; import pathlib, sys; exempt={'meta.json','rollup.json','canonical_summary.json','training_metrics.json'}; artifacts=[p for p in pathlib.Path('$(ARTIFACT_DIR)').glob('*.json') if p.name not in exempt and not p.name.startswith('split_manifest')]; failed=[p.name for p in artifacts if not verify_frozen(p)]; print(f'  Checked {len(artifacts)} artifacts, {len(failed)} not verified'); sys.exit(1) if failed else sys.exit(0)"; \
+	fi
+	@if [ -n "$(SPLIT_MANIFEST_DIR)" ]; then \
+		echo "Step 4: Validate split manifests in $(SPLIT_MANIFEST_DIR)"; \
+		if [ ! -d "$(SPLIT_MANIFEST_DIR)" ]; then \
+			echo "ERROR: SPLIT_MANIFEST_DIR not found: $(SPLIT_MANIFEST_DIR)"; \
+			exit 1; \
+		fi; \
+		PYTHONPATH=src $(PYTHON) -c "import json, pathlib, sys; manifests=list(pathlib.Path('$(SPLIT_MANIFEST_DIR)').glob('split_manifest*.json')); bad=[m.name for m in manifests if json.load(open(m)).get('split_type')!='three_way']; print(f'  Checked {len(manifests)} manifests, {len(bad)} not three_way'); sys.exit(1) if bad else sys.exit(0)"; \
+	fi
 	@echo "Promotion gate passed"
 
 # Generate unique run ID for teacher training

--- a/docs/02_agent/PROMOTION_WORKFLOW.md
+++ b/docs/02_agent/PROMOTION_WORKFLOW.md
@@ -29,6 +29,8 @@ Split manifests ensure reproducible and leakage-free train/test partitions.
 - Partition hashes (SHA256 of sorted hand_ids) recorded for verification
 - Two-way splits (`train`/`test`) for exploration; three-way (`train`/`val`/`test`) for promotion-track
 
+**Default behavior:** Training defaults to `two_way` (exploration is the common workflow). Promotion-track training must explicitly pass `--split-type three_way`. The eligibility engine enforces this at gate time.
+
 **Key files:**
 - `src/bid_euchre/models/splits.py` — `SplitManifest`, `create_grouped_split()`, `verify_split_manifest()`
 
@@ -45,10 +47,12 @@ Artifact freeze prevents accidental modification between training and evaluation
 
 **Requirements:**
 - Artifact must be frozen before any promotion evaluation
-- Frozen artifacts contain `frozen_at` (ISO timestamp) and `artifact_sha256` (integrity hash)
-- `verify_frozen()` checks that both `frozen_at` and `artifact_sha256` are present (not None)
+- Frozen artifacts contain `frozen_at` (ISO timestamp) and `artifact_sha256` (content-based integrity hash)
+- `artifact_sha256` is computed from a canonical JSON serialization of the artifact content (excluding `frozen_at` and `artifact_sha256` fields themselves), using `sort_keys=True` and compact separators
+- `verify_frozen()` recomputes the content hash and compares it to the stored `artifact_sha256` — detecting any post-freeze tampering
 - The eligibility engine uses `verify_frozen()` for integrity verification (not raw field checks)
 - Re-freezing an already-frozen artifact raises `ValueError`
+- Artifacts frozen before content-based hashing must be re-frozen to pass verification
 
 **Key files:**
 - `src/bid_euchre/models/freeze.py` — `freeze_artifact()`, `verify_frozen()`, `require_frozen()`
@@ -96,15 +100,20 @@ The CI workflow enforces promotion checks on PRs labeled `promotion`.
 1. `make repo-lint` — repository boundary linter (includes promotion registry lint rules)
 2. `make notebook-run` (SMOKE mode with `--gate-output-dir`) — notebook preflight
 3. Notebook gate assertion — verifies `gate_status == PASS`
-4. Artifact freeze check — verifies all model artifacts in ARTIFACT_DIR pass `verify_frozen()` (required, not opt-in)
+4. Artifact freeze check — verifies all model artifacts in ARTIFACT_DIR pass `verify_frozen()` with content-based hash validation (required, not opt-in)
+5. Rollup validation — verifies ROLLUP_JSON is readable and warns if `batch_purpose != "promotion"`
+6. Split manifest validation (optional) — if SPLIT_MANIFEST_DIR is provided, verifies manifests have `three_way` split_type
 
 **Makefile target:**
 ```bash
-# ARTIFACT_DIR is required for promotion gate
-make promotion-gate ARTIFACT_DIR=/path/to/artifacts
+# ARTIFACT_DIR and ROLLUP_JSON are required for promotion gate
+make promotion-gate ARTIFACT_DIR=/path/to/artifacts ROLLUP_JSON=/path/to/rollup.json
+
+# Optionally include split manifest validation
+make promotion-gate ARTIFACT_DIR=/path/to/artifacts ROLLUP_JSON=/path/to/rollup.json SPLIT_MANIFEST_DIR=/path/to/splits
 ```
 
-**CI behavior:** The promotion gate step runs only on PRs with the `promotion` label. It is a hard-fail gate — a failing promotion gate blocks the PR from merging. `ARTIFACT_DIR` must be set as a repository variable for promotion PRs to pass CI.
+**CI behavior:** The promotion gate step runs only on PRs with the `promotion` label. It is a hard-fail gate — a failing promotion gate blocks the PR from merging. Both `ARTIFACT_DIR` and `ROLLUP_JSON` must be set as repository variables for promotion PRs to pass CI. `SPLIT_MANIFEST_DIR` is optional.
 
 ## Lint Rules
 

--- a/scripts/train_olsa.py
+++ b/scripts/train_olsa.py
@@ -31,7 +31,7 @@ def main() -> None:
         "--split-type",
         choices=["two_way", "three_way"],
         default="two_way",
-        help="Split type (three_way required for promotion)",
+        help="Split type: two_way for exploration (default), three_way required for promotion-track batches",
     )
     parser.add_argument(
         "--freeze",

--- a/src/bid_euchre/models/freeze.py
+++ b/src/bid_euchre/models/freeze.py
@@ -6,6 +6,7 @@ Provides:
 - verify_frozen(): Check that artifact is frozen and unmodified
 - require_frozen(): Gate that raises (strict=True) or warns (strict=False)
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -32,13 +33,30 @@ def _sha256_file(path: str | Path) -> str:
     return h.hexdigest()
 
 
+def _content_hash(metadata: dict) -> str:
+    """Compute SHA-256 of artifact content, excluding freeze-specific fields.
+
+    Strips ``frozen_at`` and ``artifact_sha256`` from a copy of *metadata*,
+    serializes with deterministic key ordering (``sort_keys=True``,
+    compact separators), and returns the hex digest of the UTF-8 bytes.
+
+    Both ``freeze_artifact`` and ``verify_frozen`` use this function so that
+    the stored hash is always reproducible from the artifact's logical content.
+    """
+    content = {
+        k: v for k, v in metadata.items() if k not in ("frozen_at", "artifact_sha256")
+    }
+    canonical = json.dumps(content, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
 def freeze_artifact(artifact_path: str | Path) -> dict:
     """Freeze an artifact by recording frozen_at and artifact_sha256 in its JSON metadata.
 
     The artifact must be a JSON file with a top-level dict. This function:
-    1. Computes the SHA-256 of the artifact in its current state
+    1. Computes the content-based SHA-256 (excluding freeze fields)
     2. Sets frozen_at timestamp and artifact_sha256
-    3. Writes the updated metadata back
+    3. Writes the updated metadata back with deterministic key ordering
     4. Returns the updated metadata dict
 
     Args:
@@ -61,28 +79,31 @@ def freeze_artifact(artifact_path: str | Path) -> dict:
     if metadata.get("frozen_at") is not None:
         raise ValueError(f"Artifact already frozen at {metadata['frozen_at']}: {path}")
 
-    # Compute hash of the current file content
-    content_hash = _sha256_file(path)
+    content_hash = _content_hash(metadata)
 
     metadata["frozen_at"] = _utc_now_iso()
     metadata["artifact_sha256"] = content_hash
 
     with open(path, "w") as f:
-        json.dump(metadata, f, indent=2)
+        json.dump(metadata, f, indent=2, sort_keys=True)
 
     logger.info("Froze artifact: %s (sha256=%s)", path, content_hash[:12])
     return metadata
 
 
 def verify_frozen(artifact_path: str | Path) -> bool:
-    """Check that an artifact is frozen and has not been modified since freezing.
+    """Check that an artifact is frozen and its content hash is valid.
 
     Verification checks:
     1. frozen_at is set (not None)
     2. artifact_sha256 is set
+    3. Recomputed content hash matches stored artifact_sha256
+
+    Artifacts frozen before content-based hashing will fail verification
+    and must be re-frozen.
 
     Returns:
-        True if artifact is frozen and valid, False otherwise.
+        True if artifact is frozen and content hash matches, False otherwise.
     """
     path = Path(artifact_path)
     if not path.exists():
@@ -97,10 +118,11 @@ def verify_frozen(artifact_path: str | Path) -> bool:
     if metadata.get("frozen_at") is None:
         return False
 
-    if metadata.get("artifact_sha256") is None:
+    stored_hash = metadata.get("artifact_sha256")
+    if stored_hash is None:
         return False
 
-    return True
+    return _content_hash(metadata) == stored_hash
 
 
 def require_frozen(artifact_path: str | Path, strict: bool = True) -> None:
@@ -128,7 +150,9 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Freeze a model artifact")
     parser.add_argument("--artifact", required=True, help="Path to artifact JSON file")
-    parser.add_argument("--verify", action="store_true", help="Verify instead of freeze")
+    parser.add_argument(
+        "--verify", action="store_true", help="Verify instead of freeze"
+    )
     args = parser.parse_args()
 
     if args.verify:

--- a/tests/unit/test_batch_report.py
+++ b/tests/unit/test_batch_report.py
@@ -4,6 +4,8 @@ import json
 import subprocess
 import sys
 
+from bid_euchre.models.freeze import freeze_artifact
+
 
 def _make_rollup(batch_purpose="promotion"):
     return {
@@ -87,11 +89,9 @@ class TestBatchReportCLI:
         # Provide artifact-dir but not split-manifest-dir
         artifact_dir = tmp_path / "artifacts"
         artifact_dir.mkdir()
-        (artifact_dir / "olsa_v1.json").write_text(
-            json.dumps(
-                {"frozen_at": "2026-02-07T12:00:00Z", "artifact_sha256": "abc123"}
-            )
-        )
+        artifact_path = artifact_dir / "olsa_v1.json"
+        artifact_path.write_text(json.dumps({"frozen_at": None}))
+        freeze_artifact(artifact_path)
 
         exit_code, stdout, _ = _run_batch_report(
             tmp_path, ["--artifact-dir", str(artifact_dir)]
@@ -108,11 +108,9 @@ class TestBatchReportCLI:
         # Create frozen artifact
         artifact_dir = tmp_path / "artifacts"
         artifact_dir.mkdir()
-        (artifact_dir / "olsa_v1.json").write_text(
-            json.dumps(
-                {"frozen_at": "2026-02-07T12:00:00Z", "artifact_sha256": "abc123"}
-            )
-        )
+        artifact_path = artifact_dir / "olsa_v1.json"
+        artifact_path.write_text(json.dumps({"frozen_at": None}))
+        freeze_artifact(artifact_path)
 
         # Create three_way split manifest
         split_dir = tmp_path / "splits"

--- a/tests/unit/test_eligibility.py
+++ b/tests/unit/test_eligibility.py
@@ -5,6 +5,7 @@ All tests are fixture-based — no real experiment runs required.
 
 import json
 
+from bid_euchre.models.freeze import freeze_artifact
 from bid_euchre.reporting.eligibility import (
     check_artifacts_frozen,
     check_canonical_summaries,
@@ -269,15 +270,8 @@ class TestCheckArtifactsFrozen:
 
     def test_promotion_frozen_passes(self, tmp_path):
         artifact = tmp_path / "olsa_v1.json"
-        artifact.write_text(
-            json.dumps(
-                {
-                    "frozen_at": "2026-02-07T12:00:00Z",
-                    "artifact_sha256": "abc123",
-                    "artifact_type": "olsa_v1",
-                }
-            )
-        )
+        artifact.write_text(json.dumps({"frozen_at": None, "artifact_type": "olsa_v1"}))
+        freeze_artifact(artifact)
         result = check_artifacts_frozen(str(tmp_path), "promotion")
         assert result.status == "PASS"
 
@@ -313,14 +307,9 @@ class TestCheckArtifactsFrozen:
         (tmp_path / "split_manifest_suit.json").write_text(
             json.dumps({"schema_version": 1, "split_type": "three_way"})
         )
-        (tmp_path / "olsa_v1.json").write_text(
-            json.dumps(
-                {
-                    "frozen_at": "2026-02-07T12:00:00Z",
-                    "artifact_sha256": "abc123",
-                }
-            )
-        )
+        artifact = tmp_path / "olsa_v1.json"
+        artifact.write_text(json.dumps({"frozen_at": None}))
+        freeze_artifact(artifact)
         result = check_artifacts_frozen(str(tmp_path), "promotion")
         assert result.status == "PASS"
         assert "1 model artifacts frozen" in result.detail
@@ -437,14 +426,9 @@ class TestComputeEligibility:
         # Create frozen artifact
         artifact_dir = tmp_path / "model_artifacts"
         artifact_dir.mkdir()
-        (artifact_dir / "olsa_v1.json").write_text(
-            json.dumps(
-                {
-                    "frozen_at": "2026-02-07T12:00:00Z",
-                    "artifact_sha256": "abc123",
-                }
-            )
-        )
+        artifact_path = artifact_dir / "olsa_v1.json"
+        artifact_path.write_text(json.dumps({"frozen_at": None}))
+        freeze_artifact(artifact_path)
 
         # Create three_way split manifest
         split_dir = tmp_path / "splits"

--- a/tests/unit/test_freeze.py
+++ b/tests/unit/test_freeze.py
@@ -1,9 +1,15 @@
 """Tests for model artifact freeze/verify utilities."""
+
 import json
 
 import pytest
 
-from bid_euchre.models.freeze import freeze_artifact, require_frozen, verify_frozen
+from bid_euchre.models.freeze import (
+    _content_hash,
+    freeze_artifact,
+    require_frozen,
+    verify_frozen,
+)
 
 
 @pytest.fixture
@@ -47,6 +53,14 @@ class TestFreezeArtifact:
         assert result["model_type"] == "olsa"
         assert result["contracts"]["suit"]["coef"] == [1, 2, 3]
 
+    def test_freeze_writes_sort_keys(self, artifact_file):
+        """Frozen file must have deterministic key ordering."""
+        freeze_artifact(artifact_file)
+        text = artifact_file.read_text()
+        data = json.loads(text)
+        keys = list(data.keys())
+        assert keys == sorted(keys)
+
 
 class TestVerifyFrozen:
     def test_verify_unfrozen(self, artifact_file):
@@ -71,6 +85,47 @@ class TestVerifyFrozen:
         del data["artifact_sha256"]
         artifact_file.write_text(json.dumps(data))
         assert verify_frozen(artifact_file) is False
+
+    def test_verify_detects_tampered_coefficient(self, artifact_file):
+        """Modifying content after freeze must cause verify to fail."""
+        freeze_artifact(artifact_file)
+        data = json.loads(artifact_file.read_text())
+        data["contracts"]["suit"]["coef"] = [99, 99, 99]
+        artifact_file.write_text(json.dumps(data, indent=2, sort_keys=True))
+        assert verify_frozen(artifact_file) is False
+
+    def test_verify_detects_wrong_hash(self, artifact_file):
+        """Replacing artifact_sha256 with a bogus value must fail."""
+        freeze_artifact(artifact_file)
+        data = json.loads(artifact_file.read_text())
+        data["artifact_sha256"] = "0" * 64
+        artifact_file.write_text(json.dumps(data, indent=2, sort_keys=True))
+        assert verify_frozen(artifact_file) is False
+
+    def test_verify_stable_across_reloads(self, artifact_file):
+        """Verification must be idempotent across multiple reads."""
+        freeze_artifact(artifact_file)
+        assert verify_frozen(artifact_file) is True
+        assert verify_frozen(artifact_file) is True
+        assert verify_frozen(artifact_file) is True
+
+
+class TestContentHash:
+    def test_excludes_freeze_fields(self):
+        """Hash must be identical with and without freeze fields."""
+        base = {"model_type": "olsa", "contracts": {"suit": {"coef": [1, 2]}}}
+        with_freeze = {
+            **base,
+            "frozen_at": "2026-01-01T00:00:00Z",
+            "artifact_sha256": "abc",
+        }
+        assert _content_hash(base) == _content_hash(with_freeze)
+
+    def test_detects_content_change(self):
+        """Hash must differ when content changes."""
+        original = {"model_type": "olsa", "contracts": {"suit": {"coef": [1, 2]}}}
+        modified = {"model_type": "olsa", "contracts": {"suit": {"coef": [1, 3]}}}
+        assert _content_hash(original) != _content_hash(modified)
 
 
 class TestRequireFrozen:


### PR DESCRIPTION
## Summary

- **Gap A:** `freeze_artifact()` now uses content-based SHA-256 (excludes freeze fields, deterministic `sort_keys=True` serialization). `verify_frozen()` recomputes and validates the hash, detecting post-freeze tampering.
- **Gap B:** Enhanced `--split-type` help text and added split policy coherence note to `PROMOTION_WORKFLOW.md`.
- **Gap C:** Makefile `promotion-gate` now requires `ROLLUP_JSON` alongside `ARTIFACT_DIR`, validates rollup readability/batch_purpose, and optionally validates `SPLIT_MANIFEST_DIR` split_type. CI workflow updated.

## Why

The freeze/verify system had three gaps: (A) `artifact_sha256` was never validated against file content, (B) split policy defaults were underdocumented, (C) the CI promotion gate had no rollup binding or split manifest validation.

## Repro / Validation

```bash
# Unit tests
uv run python -m pytest -q tests/unit/test_freeze.py tests/unit/test_eligibility.py tests/unit/test_batch_report.py --seed 42

# Full suite
make check
```

## Tests

- `make check` — 1229 passed, 0 failed
- 6 new tests in `test_freeze.py` (tamper, wrong hash, stable reload, sort_keys, content hash exclusion/change)
- 5 cascade fixes in `test_eligibility.py` (3) and `test_batch_report.py` (2): replaced fake `"artifact_sha256": "abc123"` with `freeze_artifact()` calls

## Files Modified (8)

| File | Change |
|------|--------|
| `src/bid_euchre/models/freeze.py` | `_content_hash()`, content-based freeze/verify, `sort_keys=True` |
| `tests/unit/test_freeze.py` | 6 new tests |
| `tests/unit/test_eligibility.py` | 3 tests fixed (fake hashes → freeze_artifact) |
| `tests/unit/test_batch_report.py` | 2 tests fixed (fake hashes → freeze_artifact) |
| `scripts/train_olsa.py` | Enhanced `--split-type` help string |
| `Makefile` | ROLLUP_JSON + SPLIT_MANIFEST_DIR validation in promotion-gate |
| `.github/workflows/ci.yml` | ROLLUP_JSON + SPLIT_MANIFEST_DIR env vars |
| `docs/02_agent/PROMOTION_WORKFLOW.md` | Content hash docs, split coherence note, CI gate update |

## Backward Compatibility

Old artifacts will fail `verify_frozen()` and must be re-frozen. This is correct — old hashes were never validated anyway. The eligibility engine and Makefile gate both call `verify_frozen()`, so stale artifacts are correctly rejected.

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-promotion-hardening
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-promotion-hardening
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)