### PR TITLE
docs: replace stale DEMO_MODE with MODE parameter

### DIFF
--- a/docs/02_agent/CANONICAL_BIDLESS.md
+++ b/docs/02_agent/CANONICAL_BIDLESS.md
@@ -206,17 +206,27 @@ Checks for transitivity violations (A>B, B>C implies A>C).
 
 ## Notebook Usage
 
-For analyzing canonical runs in notebooks:
-
-1. Set `DEMO_MODE = False` to use real data
-2. Set `RUN_DIR` to point to your run directory:
+Notebooks are controlled by the `MODE` parameter, injected by `scripts/run_notebooks.py`:
 
 ```python
-DEMO_MODE = False
-RUN_DIR = "../../data/runs/<canonical_run_id>"
+# MODE controls notebook execution scale:
+#   SMOKE (~30 deals) — CI smoke tests
+#   QUICK (~2,000 deals) — development iteration
+#   FULL  (~50,000 deals) — production analysis
+MODE = "QUICK"
 ```
 
-Diagnostics loaders prefer `bidless_outcomes.parquet` when present, so notebooks work without hand-level logs.
+Run notebooks via the canonical runner:
+
+```bash
+# SMOKE mode (CI, ~10s)
+uv run python scripts/run_notebooks.py --mode SMOKE
+
+# QUICK mode (development, ~2-5min)
+uv run python scripts/run_notebooks.py --mode QUICK
+```
+
+Notebooks generate data on-the-fly via `load_or_generate_*()` helpers — no pre-existing run directory needed.
 
 ### Loading Outcomes Data
 


### PR DESCRIPTION
## Summary
- Replaced stale `DEMO_MODE`/`RUN_DIR` guidance in `docs/02_agent/CANONICAL_BIDLESS.md` with current `MODE` parameter documentation
- Documents the three execution scales (SMOKE/QUICK/FULL) and the canonical notebook runner (`scripts/run_notebooks.py`)
- Notes that notebooks generate data on-the-fly via `load_or_generate_*()` helpers, no pre-existing run directory needed

## Why
The old "Notebook Usage" section referenced `DEMO_MODE = False` and manual `RUN_DIR` paths, which no longer exist. Since the canonical runs registry was removed (#305) and notebooks switched to on-the-fly generation with `MODE` injection, this section was stale and misleading.

## Validation
```bash
make check  # All checks passed (repo-lint, ruff, pytest 1262 tests, notebook-check, docs freshness)
```

## Worktree proof
- Branch: `codex/report-charts-demomode-cleanup`
- Worktree: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-demomode-cleanup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)