### PR TITLE
feat: add contract-faceted chart suite

### DIFF
--- a/scripts/run_charts.py
+++ b/scripts/run_charts.py
@@ -26,6 +26,7 @@ from bid_euchre.reporting.chart_runner import (
     _load_matchup_results,
 )
 from bid_euchre.reporting.charts import (
+    generate_contract_faceted_charts,
     generate_distribution_charts,
     generate_feature_health_charts,
     generate_feature_outcome_charts,
@@ -122,6 +123,11 @@ def main() -> None:
             paths = generate_strategy_matchup_charts(
                 matchup_results, suite_dir, dpi=args.dpi
             )
+
+        elif suite == "contract_faceted":
+            df = _load_features_with_outcomes(run_dir)
+            suite_dir = str(output_dir / suite)
+            paths = generate_contract_faceted_charts(df, suite_dir, dpi=args.dpi)
 
         else:
             print(f"  Unknown suite: {suite}")

--- a/src/bid_euchre/reporting/chart_runner.py
+++ b/src/bid_euchre/reporting/chart_runner.py
@@ -13,13 +13,21 @@ from pathlib import Path
 import pandas as pd
 
 from .charts import (
+    generate_contract_faceted_charts,
     generate_distribution_charts,
     generate_feature_health_charts,
     generate_feature_outcome_charts,
     generate_strategy_matchup_charts,
 )
 
-AVAILABLE_SUITES = ["feature_health", "feature_outcome", "distribution", "strategy_matchup", "all"]
+AVAILABLE_SUITES = [
+    "feature_health",
+    "feature_outcome",
+    "distribution",
+    "strategy_matchup",
+    "contract_faceted",
+    "all",
+]
 
 
 def _load_bidless_features(run_dir: Path) -> pd.DataFrame:
@@ -86,8 +94,12 @@ def _load_matchup_results(run_dir: Path) -> dict:
                 continue
             total_deals += n
             weighted_win_rate += data.get("win_rate_team0", 0) * n
-            weighted_mean_t0 += data.get("avg_team0", data.get("mean_tricks_team0", 0)) * n
-            weighted_mean_t1 += data.get("avg_team1", data.get("mean_tricks_team1", 0)) * n
+            weighted_mean_t0 += (
+                data.get("avg_team0", data.get("mean_tricks_team0", 0)) * n
+            )
+            weighted_mean_t1 += (
+                data.get("avg_team1", data.get("mean_tricks_team1", 0)) * n
+            )
 
             # Reconstruct trick list from distribution histogram if available
             dist = data.get("distribution_team0", {})
@@ -124,8 +136,12 @@ if __name__ == "__main__":
         stacklevel=1,
     )
 
-    parser = argparse.ArgumentParser(description="Generate production charts from run data")
-    parser.add_argument("--run-dir", required=True, help="Path to experiment run directory")
+    parser = argparse.ArgumentParser(
+        description="Generate production charts from run data"
+    )
+    parser.add_argument(
+        "--run-dir", required=True, help="Path to experiment run directory"
+    )
     parser.add_argument("--output-dir", required=True, help="Output directory for PNGs")
     parser.add_argument(
         "--suite",
@@ -133,7 +149,9 @@ if __name__ == "__main__":
         default="all",
         help="Which chart suite to generate (default: all)",
     )
-    parser.add_argument("--dpi", type=int, default=150, help="Output resolution (default: 150)")
+    parser.add_argument(
+        "--dpi", type=int, default=150, help="Output resolution (default: 150)"
+    )
     args = parser.parse_args()
 
     run_dir = Path(args.run_dir)
@@ -174,7 +192,14 @@ if __name__ == "__main__":
                 print("  Skipping strategy_matchup: no matchup data found in results/")
                 continue
             suite_dir = str(output_dir / suite)
-            paths = generate_strategy_matchup_charts(matchup_results, suite_dir, dpi=args.dpi)
+            paths = generate_strategy_matchup_charts(
+                matchup_results, suite_dir, dpi=args.dpi
+            )
+
+        elif suite == "contract_faceted":
+            df = _load_features_with_outcomes(run_dir)
+            suite_dir = str(output_dir / suite)
+            paths = generate_contract_faceted_charts(df, suite_dir, dpi=args.dpi)
 
         else:
             print(f"  Unknown suite: {suite}")

--- a/src/bid_euchre/reporting/charts.py
+++ b/src/bid_euchre/reporting/charts.py
@@ -20,11 +20,15 @@ from ..diagnostics.charts import (
     plot_cdf,
     plot_feature_correlation,
     plot_feature_distributions,
+    plot_feature_heatmap_by_suit,
     plot_feature_outcome_correlation,
     plot_feature_vs_outcome,
     plot_hand_value_by_contract,
     plot_hand_value_by_seat,
+    plot_hand_value_by_trump_suit,
+    plot_outcome_by_trump_suit,
     plot_outcome_distributions,
+    plot_suit_variance_summary,
 )
 from ..diagnostics.strategy_charts import (
     plot_matchup_summary,
@@ -41,6 +45,34 @@ def _save_figure(fig: plt.Figure, output_dir: Path, name: str, dpi: int = 150) -
     fig.savefig(str(path), dpi=dpi, bbox_inches="tight")
     plt.close(fig)
     return str(path)
+
+
+_EXCLUDE_FROM_FEAT_PREFIX = {
+    "hand_id",
+    "seat",
+    "tricks_won",
+    "contract_type",
+    "trump",
+    "trump_suit",
+    "deal_id",
+}
+
+
+def _normalize_for_diagnostics(df: pd.DataFrame) -> pd.DataFrame:
+    """Create a copy with column aliases expected by diagnostic chart functions."""
+    df = df.copy()
+    if "trump_suit" in df.columns and "trump" not in df.columns:
+        df["trump"] = df["trump_suit"]
+    if "hand_value" in df.columns and "feat_hand_value" not in df.columns:
+        df["feat_hand_value"] = df["hand_value"]
+    for col in list(df.columns):
+        if (
+            col not in _EXCLUDE_FROM_FEAT_PREFIX
+            and not col.startswith("feat_")
+            and df[col].dtype.kind in ("i", "f")
+        ):
+            df[f"feat_{col}"] = df[col]
+    return df
 
 
 def generate_feature_health_charts(
@@ -151,7 +183,9 @@ def generate_strategy_matchup_charts(
         }
         if comparison_results:
             fig = plot_strategy_delta_bars(
-                baseline_results, comparison_results, baseline_name=baseline_name,
+                baseline_results,
+                comparison_results,
+                baseline_name=baseline_name,
             )
             paths.append(_save_figure(fig, out, "strategy_delta_bars", dpi))
 
@@ -195,24 +229,46 @@ def generate_feature_outcome_charts(
     feature_cols = [c for c in df.columns if c.startswith("feat_") or c == "hand_value"]
     if not feature_cols:
         # Try numeric columns excluding metadata
-        skip = {"seat", "deal_id", "hand_id", outcome_col, "contract_type", "trump", "trump_suit"}
-        feature_cols = [c for c in df.select_dtypes(include="number").columns if c not in skip]
+        skip = {
+            "seat",
+            "deal_id",
+            "hand_id",
+            outcome_col,
+            "contract_type",
+            "trump",
+            "trump_suit",
+        }
+        feature_cols = [
+            c for c in df.select_dtypes(include="number").columns if c not in skip
+        ]
 
     if feature_cols and outcome_col in df.columns:
         # Correlation bar chart
         fig = plot_feature_outcome_correlation(
-            df, outcome=outcome_col, features=feature_cols, top_n=top_n,
+            df,
+            outcome=outcome_col,
+            features=feature_cols,
+            top_n=top_n,
         )
         paths.append(_save_figure(fig, out, "feature_outcome_correlation", dpi))
 
         # Top feature scatter
-        correlations = df[feature_cols].corrwith(df[outcome_col]).abs().sort_values(ascending=False)
-        top_feature = correlations.index[0] if len(correlations) > 0 else feature_cols[0]
+        correlations = (
+            df[feature_cols]
+            .corrwith(df[outcome_col])
+            .abs()
+            .sort_values(ascending=False)
+        )
+        top_feature = (
+            correlations.index[0] if len(correlations) > 0 else feature_cols[0]
+        )
         fig = plot_feature_vs_outcome(df, feature=top_feature, outcome=outcome_col)
         paths.append(_save_figure(fig, out, "feature_vs_outcome", dpi))
 
     if outcome_col in df.columns and "contract_type" in df.columns:
-        fig = plot_outcome_distributions(df, outcome=outcome_col, group_by="contract_type")
+        fig = plot_outcome_distributions(
+            df, outcome=outcome_col, group_by="contract_type"
+        )
         paths.append(_save_figure(fig, out, "outcome_distributions", dpi))
 
     return paths
@@ -253,5 +309,62 @@ def generate_distribution_charts(
 
     fig = plot_ccdf(df, column=value_col, group_by=group_col)
     paths.append(_save_figure(fig, out, "ccdf", dpi))
+
+    return paths
+
+
+def generate_contract_faceted_charts(
+    df: pd.DataFrame,
+    output_dir: str,
+    outcome_col: str = "tricks_won",
+    dpi: int = 150,
+) -> List[str]:
+    """Generate contract-faceted analysis charts.
+
+    Produces charts analyzing features and outcomes by trump suit/contract type:
+    - hand_value_by_trump.png — hand value distribution per trump suit
+    - outcome_by_trump.png — outcome distribution per trump suit
+    - feature_heatmap_by_suit.png — feature mean heatmap across suits
+    - suit_variance_summary.png — variance comparison across suits
+
+    Args:
+        df: DataFrame with features and outcomes (from join_features_outcomes).
+        output_dir: Directory to save PNGs.
+        outcome_col: Name of the outcome column.
+        dpi: Output resolution.
+
+    Returns:
+        List of generated file paths.
+    """
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    paths = []
+
+    norm_df = _normalize_for_diagnostics(df)
+
+    # Hand value by trump suit
+    if "feat_hand_value" in norm_df.columns and "trump" in norm_df.columns:
+        fig = plot_hand_value_by_trump_suit(norm_df)
+        paths.append(_save_figure(fig, out, "hand_value_by_trump", dpi))
+
+    # Outcome by trump suit
+    if outcome_col in norm_df.columns and "trump" in norm_df.columns:
+        fig = plot_outcome_by_trump_suit(norm_df, outcome=outcome_col)
+        paths.append(_save_figure(fig, out, "outcome_by_trump", dpi))
+
+    # Feature heatmap by suit
+    feat_cols = [
+        c
+        for c in norm_df.columns
+        if c.startswith("feat_") and norm_df[c].dtype.kind in ("i", "f")
+    ]
+    if feat_cols and "trump" in norm_df.columns:
+        fig = plot_feature_heatmap_by_suit(norm_df)
+        paths.append(_save_figure(fig, out, "feature_heatmap_by_suit", dpi))
+
+    # Suit variance summary
+    if "feat_hand_value" in norm_df.columns and "trump" in norm_df.columns:
+        fig = plot_suit_variance_summary(norm_df)
+        paths.append(_save_figure(fig, out, "suit_variance_summary", dpi))
 
     return paths

--- a/tests/unit/test_chart_generators.py
+++ b/tests/unit/test_chart_generators.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pytest
 
 from bid_euchre.reporting.charts import (
+    generate_contract_faceted_charts,
     generate_distribution_charts,
     generate_feature_health_charts,
     generate_feature_outcome_charts,
@@ -22,15 +23,17 @@ def feature_df():
     """Minimal DataFrame with hand features."""
     rng = np.random.RandomState(42)
     n = 200
-    return pd.DataFrame({
-        "hand_value": rng.uniform(0, 10, n),
-        "seat": np.tile([0, 1, 2, 3], n // 4),
-        "contract_type": np.tile(["suit", "high"], n // 2),
-        "trump_count": rng.randint(0, 6, n),
-        "bowers": rng.randint(0, 3, n),
-        "offsuit_aces": rng.randint(0, 5, n),
-        "offsuit_tens_count": rng.randint(0, 5, n),
-    })
+    return pd.DataFrame(
+        {
+            "hand_value": rng.uniform(0, 10, n),
+            "seat": np.tile([0, 1, 2, 3], n // 4),
+            "contract_type": np.tile(["suit", "high"], n // 2),
+            "trump_count": rng.randint(0, 6, n),
+            "bowers": rng.randint(0, 3, n),
+            "offsuit_aces": rng.randint(0, 5, n),
+            "offsuit_tens_count": rng.randint(0, 5, n),
+        }
+    )
 
 
 @pytest.fixture
@@ -132,7 +135,9 @@ class TestStrategyMatchupCharts:
     def test_includes_delta_bars_and_self_play(self, matchup_results):
         with tempfile.TemporaryDirectory() as tmpdir:
             paths = generate_strategy_matchup_charts(
-                matchup_results, tmpdir, baseline_name="random",
+                matchup_results,
+                tmpdir,
+                baseline_name="random",
             )
             names = [Path(p).stem for p in paths]
             assert "win_rate_heatmap" in names
@@ -157,13 +162,69 @@ class TestStrategyMatchupCharts:
             assert "self_play_control" not in names
 
 
+@pytest.fixture
+def feature_outcome_with_trump_df(feature_outcome_df):
+    """DataFrame with features, outcomes, and trump_suit column."""
+    df = feature_outcome_df.copy()
+    rng = np.random.RandomState(42)
+    suits = ["C", "D", "H", "S", None]  # None for no-trump contracts
+    df["trump_suit"] = rng.choice(suits, len(df))
+    return df
+
+
+class TestContractFacetedCharts:
+    """Test contract-faceted chart generation."""
+
+    def test_generates_pngs_with_full_data(self, feature_outcome_with_trump_df):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = generate_contract_faceted_charts(
+                feature_outcome_with_trump_df, tmpdir
+            )
+            assert len(paths) >= 2
+            for p in paths:
+                assert Path(p).exists()
+                assert p.endswith(".png")
+
+    def test_skips_when_no_trump_data(self):
+        """Handles DataFrames with no trump suit info."""
+        df = pd.DataFrame(
+            {
+                "hand_value": [5.0, 6.0, 7.0],
+                "contract_type": ["high", "high", "low"],
+                "tricks_won": [5, 6, 4],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Should not crash; trump-dependent charts may be skipped or show placeholder
+            paths = generate_contract_faceted_charts(df, tmpdir)
+            # Some charts may still be generated (outcome_by_trump shows placeholder)
+            # Key assertion: no crash
+            assert isinstance(paths, list)
+
+    def test_file_sizes_reasonable(self, feature_outcome_with_trump_df):
+        """Generated PNGs should not be tiny placeholders."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = generate_contract_faceted_charts(
+                feature_outcome_with_trump_df, tmpdir
+            )
+            for p in paths:
+                size = Path(p).stat().st_size
+                assert size > 1024, f"{p} is suspiciously small ({size} bytes)"
+
+    def test_contract_faceted_in_available_suites(self):
+        from bid_euchre.reporting.chart_runner import AVAILABLE_SUITES
+
+        assert "contract_faceted" in AVAILABLE_SUITES
+
+
 class TestChartRunnerCLI:
     """Smoke tests for the chart_runner CLI."""
 
     def test_help_flag(self):
         result = subprocess.run(
             [sys.executable, "-m", "bid_euchre.reporting.chart_runner", "--help"],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 0
         assert "--run-dir" in result.stdout
@@ -172,10 +233,15 @@ class TestChartRunnerCLI:
     def test_missing_run_dir(self):
         result = subprocess.run(
             [
-                sys.executable, "-m", "bid_euchre.reporting.chart_runner",
-                "--run-dir", "/nonexistent/path",
-                "--output-dir", "/tmp/test_charts",
+                sys.executable,
+                "-m",
+                "bid_euchre.reporting.chart_runner",
+                "--run-dir",
+                "/nonexistent/path",
+                "--output-dir",
+                "/tmp/test_charts",
             ],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 1


### PR DESCRIPTION
## Summary
- Add `generate_contract_faceted_charts()` to `src/bid_euchre/reporting/charts.py`, producing 4 trump-suit analysis charts: `hand_value_by_trump`, `outcome_by_trump`, `feature_heatmap_by_suit`, `suit_variance_summary`
- Add `_normalize_for_diagnostics()` helper to bridge column naming between join output DataFrames and diagnostic chart functions (maps `trump_suit` -> `trump`, `hand_value` -> `feat_hand_value`, auto-prefixes numeric columns with `feat_`)
- Register `"contract_faceted"` in `AVAILABLE_SUITES` and wire dispatch in both `chart_runner.py` and `scripts/run_charts.py`

## Why
The existing chart suites analyze features and outcomes broadly, but lack trump-suit-specific analysis. The contract-faceted suite enables visualizing how hand value, tricks won, and feature distributions vary across trump suits -- critical for detecting suit-level bias and understanding contract-type effects.

## Repro / Validation
```bash
make check   # from worktree root
```

All 1266 tests pass (4 new tests added).

## Tests
- `tests/unit/test_chart_generators.py::TestContractFacetedCharts::test_generates_pngs_with_full_data` -- verifies >=2 PNGs generated with full data
- `tests/unit/test_chart_generators.py::TestContractFacetedCharts::test_skips_when_no_trump_data` -- verifies graceful handling when no trump column
- `tests/unit/test_chart_generators.py::TestContractFacetedCharts::test_file_sizes_reasonable` -- verifies PNGs are not tiny placeholders (>1KB)
- `tests/unit/test_chart_generators.py::TestContractFacetedCharts::test_contract_faceted_in_available_suites` -- verifies suite is registered

## Usage
```bash
# Via scripts/run_charts.py
uv run python scripts/run_charts.py \
  --run-dir data/runs/<run_id> \
  --output-dir /tmp/charts/ \
  --suite contract_faceted

# Via chart_runner module
uv run python -m bid_euchre.reporting.chart_runner \
  --run-dir data/runs/<run_id> \
  --output-dir /tmp/charts/ \
  --suite contract_faceted
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-contract-faceted
toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-contract-faceted
branch: codex/report-charts-contract-faceted
```

## Files changed
- `src/bid_euchre/reporting/charts.py` -- new `_normalize_for_diagnostics()`, `generate_contract_faceted_charts()`, 4 new imports
- `src/bid_euchre/reporting/chart_runner.py` -- `AVAILABLE_SUITES` updated, dispatch case added
- `scripts/run_charts.py` -- import + dispatch case added
- `tests/unit/test_chart_generators.py` -- 4 new tests in `TestContractFacetedCharts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)