### PR TITLE
feat: add self-play by contract chart

### DIFF
--- a/src/bid_euchre/diagnostics/strategy_charts.py
+++ b/src/bid_euchre/diagnostics/strategy_charts.py
@@ -138,10 +138,12 @@ def plot_win_rate_heatmap(
             for j in range(n):
                 val = matrix[i, j]
                 if not np.isnan(val):
-                    color = "white" if (vmax and (val < 0.3 * vmax or val > 0.7 * vmax)) else "black"
-                    ax.text(
-                        j, i, f"{val:{fmt}}", ha="center", va="center", color=color
+                    color = (
+                        "white"
+                        if (vmax and (val < 0.3 * vmax or val > 0.7 * vmax))
+                        else "black"
                     )
+                    ax.text(j, i, f"{val:{fmt}}", ha="center", va="center", color=color)
 
     ax.set_xlabel("Team 1 Strategy")
     ax.set_ylabel("Team 0 Strategy")
@@ -187,7 +189,13 @@ def plot_tricks_distribution_comparison(
 
     if not trick_data:
         fig, ax = plt.subplots(figsize=figsize)
-        ax.text(0.5, 0.5, f"No trick data found (key: {tricks_key})", ha="center", va="center")
+        ax.text(
+            0.5,
+            0.5,
+            f"No trick data found (key: {tricks_key})",
+            ha="center",
+            va="center",
+        )
         return fig
 
     fig, ax = plt.subplots(figsize=figsize)
@@ -533,5 +541,96 @@ def plot_matchup_summary(
         )
 
     fig.suptitle("Strategy Matchup Summary", fontsize=14, y=1.02)
+    plt.tight_layout()
+    return fig
+
+
+def plot_self_play_by_contract(
+    matchup_results: Dict[Tuple[str, str], Dict[str, Any]],
+    expected_mean: float = 5.0,
+    figsize: Tuple[int, int] = (14, 8),
+    title: Optional[str] = None,
+) -> Optional[plt.Figure]:
+    """Plot self-play mean tricks broken down by contract/scenario.
+
+    Creates a grouped bar chart showing mean tricks per scenario for each
+    self-play strategy, with a control band around expected_mean.
+
+    Args:
+        matchup_results: Dict mapping (team0, team1) to result dicts.
+            Self-play entries (team0 == team1) with 'scenarios' key are used.
+        expected_mean: Expected mean tricks for fair self-play (default 5.0)
+        figsize: Figure size tuple
+        title: Optional title override
+
+    Returns:
+        matplotlib Figure, or None if no self-play entries have scenario data
+    """
+    _apply_style()
+
+    # Extract self-play entries with scenarios
+    self_play = {}
+    for (team0, team1), result in matchup_results.items():
+        if team0 == team1 and "scenarios" in result:
+            self_play[team0] = result["scenarios"]
+
+    if not self_play:
+        return None
+
+    # Collect all scenario names across all strategies
+    all_scenarios = sorted(
+        set(s for scenarios in self_play.values() for s in scenarios.keys())
+    )
+
+    if not all_scenarios:
+        return None
+
+    fig, ax = plt.subplots(figsize=figsize)
+
+    # Grouped bar chart
+    strategies = sorted(self_play.keys())
+    n_strategies = len(strategies)
+    n_scenarios = len(all_scenarios)
+
+    bar_width = 0.8 / n_strategies
+    x = np.arange(n_scenarios)
+
+    for i, strategy in enumerate(strategies):
+        scenarios = self_play[strategy]
+        means = []
+        for scenario in all_scenarios:
+            data = scenarios.get(scenario, {})
+            # Use avg_team0 or mean_tricks_team0
+            mean = data.get("avg_team0", data.get("mean_tricks_team0", np.nan))
+            means.append(mean)
+
+        offset = (i - n_strategies / 2 + 0.5) * bar_width
+        color = get_strategy_color(strategy)
+        label = get_strategy_name(strategy)
+        ax.bar(x + offset, means, bar_width, color=color, alpha=0.8, label=label)
+
+    # Control band
+    ax.axhline(expected_mean, color="green", linestyle="-", linewidth=2)
+    ax.axhspan(expected_mean - 0.25, expected_mean + 0.25, color="green", alpha=0.1)
+
+    # Labels
+    from ..reporting.style import get_contract_label
+
+    scenario_labels = []
+    for s in all_scenarios:
+        # Parse scenario name: "suit_C" -> get_contract_label("suit", "C")
+        if s.startswith("suit_") and len(s) == 6:
+            scenario_labels.append(get_contract_label("suit", s[-1]))
+        else:
+            scenario_labels.append(get_contract_label(s))
+
+    ax.set_xticks(x)
+    ax.set_xticklabels(scenario_labels, rotation=45, ha="right")
+    ax.set_xlabel("Contract / Scenario")
+    ax.set_ylabel("Mean Tricks (Team 0)")
+    ax.set_title(title or "Self-Play Mean Tricks by Contract")
+    ax.legend(loc="upper right")
+    ax.grid(True, axis="y", alpha=0.3)
+
     plt.tight_layout()
     return fig

--- a/src/bid_euchre/reporting/chart_runner.py
+++ b/src/bid_euchre/reporting/chart_runner.py
@@ -119,6 +119,15 @@ def _load_matchup_results(run_dir: Path) -> dict:
         if all_tricks_t0:
             result["tricks_team0"] = all_tricks_t0
 
+        # Per-scenario breakdown (backward-compatible extension)
+        scenario_data = {}
+        for sf in scenario_files:
+            scenario_name = sf.stem  # e.g., "suit_C", "high", "low"
+            with open(sf) as f:
+                sdata = json.load(f)
+            scenario_data[scenario_name] = sdata
+        result["scenarios"] = scenario_data
+
         matchup_results[(team0, team1)] = result
 
     return matchup_results

--- a/src/bid_euchre/reporting/charts.py
+++ b/src/bid_euchre/reporting/charts.py
@@ -33,6 +33,7 @@ from ..diagnostics.charts import (
 )
 from ..diagnostics.strategy_charts import (
     plot_matchup_summary,
+    plot_self_play_by_contract,
     plot_self_play_control,
     plot_strategy_delta_bars,
     plot_tricks_distribution_comparison,
@@ -194,6 +195,11 @@ def generate_strategy_matchup_charts(
     if self_play:
         fig = plot_self_play_control(self_play)
         paths.append(_save_figure(fig, out, "self_play_control", dpi))
+
+    # Per-contract self-play breakdown (skip if no scenario data)
+    fig = plot_self_play_by_contract(matchup_results)
+    if fig is not None:
+        paths.append(_save_figure(fig, out, "self_play_by_contract", dpi))
 
     return paths
 

--- a/tests/unit/test_chart_generators.py
+++ b/tests/unit/test_chart_generators.py
@@ -184,6 +184,33 @@ class TestStrategyMatchupCharts:
             names = [Path(p).stem for p in paths]
             assert "self_play_control" not in names
 
+    def test_self_play_by_contract_with_scenarios(self, matchup_results):
+        """Generates per-contract self-play chart when scenarios present."""
+        # Add scenarios to self-play entries
+        for key in list(matchup_results.keys()):
+            team0, team1 = key
+            if team0 == team1:
+                matchup_results[key]["scenarios"] = {
+                    "suit_C": {"avg_team0": 5.1, "deals": 50},
+                    "suit_D": {"avg_team0": 4.9, "deals": 50},
+                    "suit_H": {"avg_team0": 5.0, "deals": 50},
+                    "suit_S": {"avg_team0": 5.2, "deals": 50},
+                    "high": {"avg_team0": 4.8, "deals": 50},
+                    "low": {"avg_team0": 5.3, "deals": 50},
+                }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = generate_strategy_matchup_charts(matchup_results, tmpdir)
+            names = [Path(p).stem for p in paths]
+            assert "self_play_by_contract" in names
+
+    def test_self_play_by_contract_skips_without_scenarios(self, matchup_results):
+        """No error when matchup results lack scenarios key."""
+        # matchup_results fixture doesn't have scenarios by default
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = generate_strategy_matchup_charts(matchup_results, tmpdir)
+            names = [Path(p).stem for p in paths]
+            assert "self_play_by_contract" not in names
+
 
 @pytest.fixture
 def feature_outcome_with_trump_df(feature_outcome_df):


### PR DESCRIPTION
## Summary
- Add `plot_self_play_by_contract()` to `strategy_charts.py` — grouped bar chart showing mean tricks per scenario (contract type) for each self-play strategy, with a control band around the expected 5.0 mean
- Extend `_load_matchup_results()` in `chart_runner.py` to store per-scenario JSON data in a backward-compatible `scenarios` key on each matchup result dict
- Wire the new chart into `generate_strategy_matchup_charts()` so it is auto-generated when scenario data is present, gracefully skipped otherwise

## Why
Self-play aggregate mean tricks can mask per-contract imbalances. A strategy might average 5.0 overall but show significant bias on specific contracts (e.g., suit vs high vs low). This chart makes per-contract fairness visible at a glance.

## Files Changed
- `src/bid_euchre/diagnostics/strategy_charts.py` — new `plot_self_play_by_contract()` function
- `src/bid_euchre/reporting/chart_runner.py` — per-scenario data storage in `_load_matchup_results()`
- `src/bid_euchre/reporting/charts.py` — import + call new chart in `generate_strategy_matchup_charts()`
- `tests/unit/test_chart_generators.py` — 2 new tests (with/without scenarios)

## Repro / Validation
```bash
make check  # All 1264 tests pass, ruff clean, repo-lint clean
```

## Tests
- `test_self_play_by_contract_with_scenarios` — verifies chart is generated when scenarios present
- `test_self_play_by_contract_skips_without_scenarios` — verifies no error when scenarios absent

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-selfplay-faceted
branch: codex/report-charts-selfplay-faceted
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)