### PR TITLE
feat: add reviewer agent handoff to /summarize skill

### DIFF
--- a/.claude/skills/summarize/SKILL.md
+++ b/.claude/skills/summarize/SKILL.md
@@ -1,10 +1,10 @@
-# Summarize — PR Session Summary & Lessons Learned
+# Summarize — PR Session Summary, Lessons Learned & Review
 
-Generate a structured summary of PRs completed in this session, then commit lessons learned to auto memory.
+Generate a structured summary of PRs completed in this session, commit lessons learned to auto memory, then launch a reviewer agent to verify the work.
 
 ## When to Use
 
-Invoke `/summarize` at the end of a session after PRs have been created, merged, or completed. Produces a consistent, scannable report and persists lessons for future sessions.
+Invoke `/summarize` at the end of a session after PRs have been created, merged, or completed. Produces a consistent, scannable report, persists lessons for future sessions, and kicks off an automated review.
 
 ## Workflow
 
@@ -28,7 +28,7 @@ Output the following **exact template** (fill in values, omit sections that don'
 
 | PR | Title | Files | Tests | Status |
 |----|-------|-------|-------|--------|
-| #NNN | short title | N files | N new | make check passing |
+| #NNN | short title | N files | N new | merged / open |
 
 ### What Was Done
 - [Bullet per PR: what it adds/changes, key implementation detail]
@@ -62,6 +62,84 @@ After generating the summary, **automatically** update auto memory:
 4. **Deduplicate**: Don't add lessons that are already recorded
 5. **Confirm** to the user which lessons were persisted and where
 
+### 4. Launch Review Agent
+
+After the summary is generated and lessons are committed, spawn a **reviewer agent** using the Task tool (`subagent_type: general-purpose`) to verify the session's work. Pass the full summary text as context.
+
+**Agent prompt template** (fill in the `{...}` placeholders from the summary):
+
+```
+You are a code reviewer for the Bid Euchre project. Verify that the following
+session work was completed correctly. Do NOT make any code changes — this is
+a read-only review.
+
+## Session Summary to Review
+{paste the full summary from Step 2 here}
+
+## Review Checklist
+
+For EACH PR listed above, perform these checks:
+
+### A. Merge State Verification
+- Run: `gh pr view {PR_NUMBER} --json state,mergeCommit,title`
+- Confirm state matches what the summary claims (merged/open)
+- If merged, confirm merge commit exists on main
+
+### B. Code Presence on Main
+- Run: `git log --oneline -20` to see recent commits
+- For each PR, verify the squash-merge commit message appears
+- Spot-check 1-2 key files per PR to confirm the code is present:
+  - Read the file and verify the new function/class/change exists
+  - Check that imports are wired correctly
+
+### C. Test Coverage
+- Run: `uv run python -m pytest tests/unit/test_chart_generators.py -v --tb=short 2>&1 | tail -30`
+  (or the relevant test file for the PR)
+- Confirm the new tests listed in the summary actually exist and pass
+- Verify test count matches what the summary claims
+
+### D. Integration Sanity
+- Run: `make check` from the project root
+- Confirm all checks pass (repo-lint, ruff, pytest, notebook-check)
+- If any failures, report them with full error output
+
+### E. Review Checklist (from docs/02_agent/REVIEW_CHECKLIST.md)
+For each PR, verify:
+- [ ] No generated artifacts committed under data/runs/ or data/reports/
+- [ ] Scope is focused (one concept per PR)
+- [ ] New behavior has matching tests
+- [ ] No import boundary violations (src/ must not import experiments/)
+
+### F. MEMORY.md Consistency
+- Read the auto memory file at:
+  /Users/claude_runner/.claude/projects/-Users-claude-runner-Projects-Bid-Euchre-meta-Bid-Euchre/memory/MEMORY.md
+- Confirm PR numbers and status match what was actually merged
+- Check that lessons learned were persisted (not just claimed)
+
+## Output Format
+
+Produce a review report with this structure:
+
+### Review Results
+
+| PR | Merge | Code | Tests | Checklist | Verdict |
+|----|-------|------|-------|-----------|---------|
+| #NNN | pass/fail | pass/fail | pass/fail | pass/fail | PASS/FAIL |
+
+### Issues Found
+- [List any discrepancies, missing code, failing tests, or summary inaccuracies]
+- If none: "No issues found."
+
+### make check Result
+- [PASS/FAIL with summary line count: "N tests passed, 0 failed"]
+```
+
+**Agent configuration:**
+- Use `subagent_type: general-purpose`
+- Do NOT run in background — wait for the review result
+- The reviewer must work from the main checkout (read-only, no edits)
+- If the reviewer finds issues, present them to the user for action
+
 ## Notes
 
 - The summary is output as chat text (not written to a file) unless the user requests it saved
@@ -69,3 +147,6 @@ After generating the summary, **automatically** update auto memory:
 - If no lessons were learned, say so explicitly rather than inventing filler
 - Keep lessons concrete and actionable — "use PATH=$(pwd)/.venv/bin:$PATH for commits in worktrees" not "remember to set up PATH"
 - When multiple PRs touch the same file, note potential merge conflicts in Follow-Up Work
+- The reviewer agent is read-only — it must NEVER edit files, create commits, or push code
+- If `make check` is already known to pass from the session, the reviewer can skip re-running it and note "verified earlier in session" — but should still run it if any doubt exists
+- For large sessions (5+ PRs), the reviewer may spot-check a subset rather than exhaustively verifying every file, but must check all merge states and test counts


### PR DESCRIPTION
## Summary
- Extend `/summarize` skill with Step 4: automated reviewer agent handoff
- After generating the session summary and committing lessons, the skill spawns a read-only reviewer agent that verifies the work was done correctly
- Reviewer checks: merge states, code presence on main, test counts, `make check`, review checklist compliance, MEMORY.md consistency

## Why
Session summaries claim work was completed, but there was no verification step. The reviewer agent cross-checks claims against reality — confirming PRs are actually merged, code is on main, tests exist and pass, and memory was updated.

## Repro / Validation
```bash
make check  # all checks pass (markdown-only change)
```

## Tests
N/A — skill is markdown instructions, not executable code

## Worktree proof
- Branch: `codex/summarize-skill-v2`
- Worktree: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-summarize-v2`

## What the reviewer agent checks

| Check | What it verifies |
|-------|-----------------|
| A. Merge State | `gh pr view` confirms PR state matches summary |
| B. Code Presence | Key files/functions exist on main after merge |
| C. Test Coverage | New tests listed in summary actually exist and pass |
| D. Integration | `make check` passes on main |
| E. Review Checklist | No artifacts committed, scope focused, tests match behavior |
| F. Memory Consistency | MEMORY.md PR numbers and lessons match reality |

## Files changed
- `.claude/skills/summarize/SKILL.md` — added Step 4 (reviewer agent), updated notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)