### PR TITLE
fix: review follow-ups — docs consistency + matchup loader tests

### DIFF
--- a/docs/02_agent/CANONICAL_BIDLESS.md
+++ b/docs/02_agent/CANONICAL_BIDLESS.md
@@ -206,29 +206,37 @@ Checks for transitivity violations (A>B, B>C implies A>C).
 
 ## Notebook Usage
 
-Notebooks are controlled by the `MODE` parameter, injected by `scripts/run_notebooks.py`:
+Notebooks are controlled by the `MODE` parameter:
 
 ```python
 # MODE controls notebook execution scale:
 #   SMOKE (~30 deals) — CI smoke tests
 #   QUICK (~2,000 deals) — development iteration
-#   FULL  (~50,000 deals) — production analysis
+#   FULL  (~50,000 deals) — production analysis (manual execution only)
 MODE = "QUICK"
 ```
 
-Run notebooks via the canonical runner:
+### Via the runner CLI (SMOKE / QUICK only)
+
+`scripts/run_notebooks.py` supports `--mode smoke` and `--mode quick`. It injects the `MODE` parameter automatically:
 
 ```bash
 # SMOKE mode (CI, ~10s)
-uv run python scripts/run_notebooks.py --mode SMOKE
+uv run python scripts/run_notebooks.py --mode smoke
 
 # QUICK mode (development, ~2-5min)
-uv run python scripts/run_notebooks.py --mode QUICK
+uv run python scripts/run_notebooks.py --mode quick
 ```
 
 Notebooks generate data on-the-fly via `load_or_generate_*()` helpers — no pre-existing run directory needed.
 
-### Loading Outcomes Data
+### Direct execution (FULL mode)
+
+For production-scale analysis (`MODE = "FULL"`), execute notebooks directly (e.g., via Jupyter or `papermill`). The runner CLI does not support FULL mode.
+
+### Loading from an existing run directory (optional)
+
+If you have a pre-existing experiment run, notebooks can load data via `RUN_DIR` instead of generating on-the-fly:
 
 ```python
 from bid_euchre.diagnostics.notebook_data import load_outcomes_from_run_dir

--- a/docs/04_reports/phase0_bidless_20260207_r2.md
+++ b/docs/04_reports/phase0_bidless_20260207_r2.md
@@ -256,7 +256,7 @@ Gate evidence: each run's `canonical_summary.json` records PASS/WARN/FAIL/SKIP c
 
 ## 7. Known Limitations
 
-1. **DEMO_MODE stale reference** — `docs/02_agent/CANONICAL_BIDLESS.md` (lines 211, 215) still references `DEMO_MODE` which was renamed to `CANONICAL_MODE` in PR #268. The canonical notebooks use `CANONICAL_MODE` correctly. Cleaning up CANONICAL_BIDLESS.md is out of scope for this report.
+1. **~~DEMO_MODE stale reference~~** — Resolved in PR #334; `CANONICAL_BIDLESS.md` now uses `MODE` parameter correctly.
 
 2. **No bootstrap CIs on diagnostic R²/MAE** — The diagnostic evaluation reports point estimates only. Acceptable for exploratory analysis; production models will require bootstrapped confidence intervals.
 

--- a/tests/unit/test_chart_generators.py
+++ b/tests/unit/test_chart_generators.py
@@ -1,5 +1,6 @@
 """Unit tests for production chart generators."""
 
+import json
 import subprocess
 import sys
 import tempfile
@@ -347,6 +348,119 @@ class TestChartContentValidity:
         fig = plot_coefficient_heatmap(coefs, top_n=3)
         assert isinstance(fig, plt.Figure)
         plt.close(fig)
+
+
+class TestLoadMatchupResults:
+    """Tests for _load_matchup_results loader with scenario extension."""
+
+    def test_legacy_aggregate_keys(self, tmp_path):
+        """Legacy aggregate keys (win_rate, mean_tricks_*, deals) are populated."""
+        from bid_euchre.reporting.chart_runner import _load_matchup_results
+
+        matchup_dir = tmp_path / "results" / "greedy_vs_random"
+        matchup_dir.mkdir(parents=True)
+        scenario = {
+            "win_rate_team0": 0.65,
+            "avg_team0": 5.5,
+            "avg_team1": 4.5,
+            "deals": 100,
+            "distribution_team0": {"3": 10, "5": 60, "7": 30},
+        }
+        (matchup_dir / "suit_C.json").write_text(json.dumps(scenario))
+
+        results = _load_matchup_results(tmp_path)
+        assert ("greedy", "random") in results
+        r = results[("greedy", "random")]
+        assert r["win_rate"] == pytest.approx(0.65)
+        assert r["mean_tricks_team0"] == pytest.approx(5.5)
+        assert r["mean_tricks_team1"] == pytest.approx(4.5)
+        assert r["mean_tricks"] == pytest.approx(5.5)
+        assert r["deals"] == 100
+        assert len(r["tricks_team0"]) == 100  # 10+60+30
+
+    def test_multi_scenario_aggregation(self, tmp_path):
+        """Multiple scenario files are weighted-averaged correctly."""
+        from bid_euchre.reporting.chart_runner import _load_matchup_results
+
+        matchup_dir = tmp_path / "results" / "glutton_vs_greedy"
+        matchup_dir.mkdir(parents=True)
+
+        s1 = {
+            "win_rate_team0": 0.80,
+            "avg_team0": 6.0,
+            "avg_team1": 4.0,
+            "deals": 200,
+        }
+        s2 = {
+            "win_rate_team0": 0.60,
+            "avg_team0": 5.0,
+            "avg_team1": 5.0,
+            "deals": 100,
+        }
+        (matchup_dir / "suit_H.json").write_text(json.dumps(s1))
+        (matchup_dir / "high.json").write_text(json.dumps(s2))
+
+        results = _load_matchup_results(tmp_path)
+        r = results[("glutton", "greedy")]
+        assert r["deals"] == 300
+        # Weighted average: (0.80*200 + 0.60*100) / 300 = 220/300
+        assert r["win_rate"] == pytest.approx(220.0 / 300)
+        assert r["mean_tricks_team0"] == pytest.approx((6.0 * 200 + 5.0 * 100) / 300)
+        assert r["mean_tricks_team1"] == pytest.approx((4.0 * 200 + 5.0 * 100) / 300)
+
+    def test_scenarios_key_populated(self, tmp_path):
+        """Per-scenario breakdown is available under result['scenarios']."""
+        from bid_euchre.reporting.chart_runner import _load_matchup_results
+
+        matchup_dir = tmp_path / "results" / "greedy_vs_random"
+        matchup_dir.mkdir(parents=True)
+
+        for name in ["suit_C", "suit_D", "high", "low"]:
+            data = {
+                "win_rate_team0": 0.5,
+                "avg_team0": 5.0,
+                "avg_team1": 5.0,
+                "deals": 50,
+            }
+            (matchup_dir / f"{name}.json").write_text(json.dumps(data))
+
+        results = _load_matchup_results(tmp_path)
+        r = results[("greedy", "random")]
+        assert "scenarios" in r
+        assert set(r["scenarios"].keys()) == {"suit_C", "suit_D", "high", "low"}
+        # Each scenario preserves raw data
+        assert r["scenarios"]["suit_C"]["deals"] == 50
+        assert r["scenarios"]["high"]["avg_team0"] == 5.0
+
+    def test_empty_results_dir(self, tmp_path):
+        """Returns empty dict when results/ has no matchup subdirectories."""
+        from bid_euchre.reporting.chart_runner import _load_matchup_results
+
+        (tmp_path / "results").mkdir()
+        assert _load_matchup_results(tmp_path) == {}
+
+    def test_no_results_dir(self, tmp_path):
+        """Returns empty dict when results/ does not exist."""
+        from bid_euchre.reporting.chart_runner import _load_matchup_results
+
+        assert _load_matchup_results(tmp_path) == {}
+
+    def test_tricks_team0_absent_without_distribution(self, tmp_path):
+        """tricks_team0 key absent when scenario lacks distribution_team0."""
+        from bid_euchre.reporting.chart_runner import _load_matchup_results
+
+        matchup_dir = tmp_path / "results" / "a_vs_b"
+        matchup_dir.mkdir(parents=True)
+        data = {
+            "win_rate_team0": 0.5,
+            "avg_team0": 5.0,
+            "avg_team1": 5.0,
+            "deals": 10,
+        }
+        (matchup_dir / "high.json").write_text(json.dumps(data))
+
+        results = _load_matchup_results(tmp_path)
+        assert "tricks_team0" not in results[("a", "b")]
 
 
 class TestChartRunnerCLI:


### PR DESCRIPTION
## Summary
- Fix CANONICAL_BIDLESS.md notebook usage docs: clarify FULL is manual-only, runner supports smoke/quick only
- Separate "generate-on-the-fly" from "load existing run via RUN_DIR" usage paths
- Add 6 tests for `_load_matchup_results()` covering legacy keys, weighted aggregation, scenarios extension, and edge cases
- Update r2 report: mark DEMO_MODE limitation as resolved (PR #334)

## Why
Review follow-up fixes: docs were inaccurate about runner CLI modes and contradictory about data loading paths. The `_load_matchup_results` loader lacked direct test coverage for its scenario extension.

## Repro / Validation
**Command(s) run:**
- `make check` — 1268 passed, 5 skipped, 2 xfailed, 1 xpassed
- `uv run pytest -q tests/unit/test_chart_generators.py` — 25 passed (19 existing + 6 new)
- `uv run pytest -q tests/unit/test_docs_freshness.py` — 11 passed

## Tests
- [x] `make check` passes (full suite)
- [x] Other: `tests/unit/test_chart_generators.py` — 6 new tests in `TestLoadMatchupResults`

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-review-fixes
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-review-fixes
```

`git worktree list` (truncated):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                941cdf6 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-review-fixes   5becc3b [codex/review-fixes]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)