### PR TITLE
docs: align ARCHITECTURE.md and README.md with current codebase

### DIFF
--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -59,6 +59,7 @@ Canonical scripts:
 
 - `evaluate_diagnostic_tricks.py` — Diagnostic Ridge evaluation
 - `generate_batch_report.py` — Batch report + eligibility gate
+- `generate_r4_charts.py` — One-off report chart regeneration utility
 - `play_policy_gate.py` — Play policy stability gate
 - `run_auction_comparator.py` — Auction comparator orchestrator
 
@@ -173,6 +174,7 @@ Every experiment run creates a standardized directory under `data/runs/<run_id>/
 |---------|---------|
 | `scripts/internal/evaluate_diagnostic_tricks.py` | Diagnostic Ridge evaluation |
 | `scripts/internal/generate_batch_report.py` | Batch report + eligibility gate |
+| `scripts/internal/generate_r4_charts.py` | One-off report chart regeneration utility |
 | `scripts/internal/play_policy_gate.py` | Play policy stability gate |
 | `scripts/internal/run_auction_comparator.py` | Auction comparator orchestrator |
 
@@ -218,12 +220,6 @@ Promotion-track PRs (labeled `promotion`) must pass the promotion CI gate:
 
 See `docs/02_agent/PROMOTION_WORKFLOW.md` for the full end-to-end workflow including
 split manifests, artifact freeze, notebook gates, and reviewer checklist.
-
----
-
-## Promotion Workflow
-
-Model artifacts follow a promotion pipeline from exploration to production. See `docs/02_agent/PROMOTION_WORKFLOW.md` for the full workflow including split manifests, artifact freeze, notebook gate, and CI enforcement.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,12 +30,12 @@ This framework provides a complete research platform for developing and testing 
 
 ### Installation
 ```bash
-# Clone the repository
-git clone <repository-url>
-cd bid-euchre
+uv sync
 
-# Install dependencies
-pip install -r requirements.txt
+# or (pip alternative)
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
 ```
 
 ### Basic Usage
@@ -55,6 +55,7 @@ print(f"Team 0 average tricks: {result['avg_team0']:.2f}")
 ```bash
 PYTHONPATH=src python experiments/run_experiment.py \
   --config experiments/configs/head_to_head_vs_random.yaml \
+  --seed 42 \
   --mode head_to_head_matrix
 
 PYTHONPATH=src python scripts/generate_report.py \
@@ -64,27 +65,31 @@ PYTHONPATH=src python scripts/generate_report.py \
 **Unified Runner** (recommended):
 ```bash
 # Run experiment from YAML config
-PYTHONPATH=src python experiments/run_experiment.py \\
-    --config experiments/configs/strategy_comparison.yaml
+PYTHONPATH=src python experiments/run_experiment.py \
+    --config experiments/configs/strategy_comparison.yaml \
+    --seed 42
 
 # Quick test (1k hands, 2 strategies, 2 scenarios, ~1 second)
-PYTHONPATH=src python experiments/run_experiment.py \\
-    --config experiments/configs/quick_test.yaml
+PYTHONPATH=src python experiments/run_experiment.py \
+    --config experiments/configs/quick_test.yaml \
+    --seed 42
 
 # Override config parameters
-PYTHONPATH=src python experiments/run_experiment.py \\
-    --config experiments/configs/baseline_greedy.yaml \\
+PYTHONPATH=src python experiments/run_experiment.py \
+    --config experiments/configs/baseline_greedy.yaml \
     --n_per 10000 --seed 99 --log-level none
 
 # Generate report for a run
-PYTHONPATH=src python scripts/generate_report.py \\
+PYTHONPATH=src python scripts/generate_report.py \
     --run-dir data/runs/<run_id>
 ```
 
 **Suite Runner** (recommended for production):
 ```bash
 # Run full experiment suite
-PYTHONPATH=src python scripts/run_suite.py --suite experiments/suites/baseline_tiny.yaml
+PYTHONPATH=src python scripts/run_suite.py \
+  --suite experiments/suites/baseline_tiny.yaml \
+  --seed 42
 
 # Generate comprehensive report
 PYTHONPATH=src python scripts/generate_report.py --run-dir data/runs/<run_id>
@@ -102,7 +107,7 @@ bid-euchre/
 │   └── experiments/           # Configuration system
 ├── experiments/               # Research scripts & configs
 ├── tests/                     # Comprehensive test suite
-└── data/                      # Simulation results & reports
+└── data/                      # Fixtures + generated runs (do not commit runs)
 ```
 
 ## 🤖 Available Strategies
@@ -141,11 +146,11 @@ parameters:
 ## 🧪 Testing
 
 ```bash
-# Run the full test suite
-PYTHONPATH=src pytest -q
+# Fast local test suite
+make test
 
-# Verbose
-PYTHONPATH=src pytest -v
+# Full pre-PR gate
+make check
 
 # Coverage (optional)
 PYTHONPATH=src pytest --cov=src/bid_euchre --cov-report=term-missing
@@ -179,10 +184,6 @@ PYTHONPATH=src pytest --cov=src/bid_euchre --cov-report=term-missing
 3. Add tests for new functionality
 4. Run the full test suite
 5. Submit a pull request
-
-## 📄 License
-
-[Add license information here]
 
 ## 🙏 Acknowledgments
 


### PR DESCRIPTION
## Summary
- Add `generate_r4_charts.py` to ARCHITECTURE.md internal script listings (bullet list + table)
- Remove duplicate `## Promotion Workflow` H2 heading in ARCHITECTURE.md
- Update README.md: install instructions (`uv sync`), `--seed 42` on all examples, backslash continuations, `make test`/`make check`, data/ description, remove placeholder license

## Why
ARCHITECTURE.md was missing a script added in #344 and had a duplicate H2 heading. README.md still referenced `pip install -r requirements.txt`, lacked `--seed` on experiment commands (violating determinism policy), and had stale testing instructions.

## Repro / Validation
```bash
make check   # passes in worktree
```

No runtime changes — docs only.

## Tests
- [x] `make check` passes (1282 tests)

## Risk level
- [x] Low (docs only)

## Worktree proof
`pwd`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-docs-alignment`
`git rev-parse --show-toplevel`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-docs-alignment`
`git branch --show-current`: `docs/alignment`

## Checklist
- [x] No generated artifacts committed
- [x] PR is focused (one concept — docs alignment)
- [x] No behavior changes