### PR TITLE
feat: docs-freshness hardening — 3 new checks + CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Validate configs
         run: uv run python scripts/validate_configs.py
 
+      - name: Docs freshness
+        run: make docs-check
+
       - name: Ruff (lint)
         run: make lint
 

--- a/scripts/check_docs_freshness.py
+++ b/scripts/check_docs_freshness.py
@@ -172,6 +172,158 @@ def check_scripts_list_complete(arch_doc: Path, scripts_dir: Path) -> list[str]:
     return errors
 
 
+def check_internal_scripts_listed(
+    arch_doc: Path, internal_scripts_dir: Path
+) -> list[str]:
+    """Verify ARCHITECTURE.md lists all non-private scripts in scripts/internal/.
+
+    Checks by full path (``scripts/internal/{name}``) to avoid false positives
+    from deprecation wrappers at ``scripts/`` that share the same basename.
+    """
+    errors = []
+    if not arch_doc.exists():
+        return [f"ARCHITECTURE.md not found at {arch_doc}"]
+    if not internal_scripts_dir.is_dir():
+        return []
+    text = arch_doc.read_text(encoding="utf-8")
+    for py_file in sorted(internal_scripts_dir.glob("*.py")):
+        if py_file.name.startswith("_"):
+            continue
+        expected_token = f"scripts/internal/{py_file.name}"
+        if expected_token not in text:
+            errors.append(f"ARCHITECTURE.md missing internal script: {expected_token}")
+    return errors
+
+
+def check_no_duplicate_headings(doc_path: Path) -> list[str]:
+    """Flag duplicate ``## `` (H2) headings within a single markdown doc.
+
+    Only checks H2 — duplicate H3 under different H2 parents is valid.
+    Reports both line numbers for each duplicate.
+    """
+    errors = []
+    if not doc_path.exists():
+        return []
+    text = doc_path.read_text(encoding="utf-8")
+    heading_re = re.compile(r"^## (.+)$", re.MULTILINE)
+    seen: dict[str, int] = {}
+    for match in heading_re.finditer(text):
+        heading = match.group(1).strip()
+        lineno = text[: match.start()].count("\n") + 1
+        if heading in seen:
+            errors.append(
+                f"{doc_path.name}:{lineno}: duplicate H2 '## {heading}' "
+                f"(first at line {seen[heading]})"
+            )
+        else:
+            seen[heading] = lineno
+    return errors
+
+
+def check_command_contracts(docs_dir: Path, repo_root: Path) -> list[str]:
+    """Scan bash/sh/untagged fenced code blocks for command contract violations.
+
+    Checks:
+    1. ``run_experiment.py`` without ``--seed`` or ``--allow-nondeterministic``
+    2. ``pip install -r requirements.txt`` (stale install method)
+
+    Only scans ``bash``, ``sh``, or untagged (no language) fenced blocks.
+    Skips mermaid, yaml, python, json, etc. to prevent false positives.
+    Skips template commands containing ``<placeholder>`` angle brackets.
+    Follows backslash continuations for multi-line commands.
+    Skips archive/legacy directories.
+    """
+    errors = []
+    skip_dirs = {"archive", "legacy"}
+    # Languages we consider "shell-like" (check commands in these blocks)
+    shell_langs = {"bash", "sh", ""}
+    fence_open_re = re.compile(r"^```(\w*)\s*$")
+    # Match run_experiment.py only when used as a command (preceded by python
+    # or at the start of a command line with PYTHONPATH=), not file tree listings
+    run_exp_re = re.compile(r"python\s+\S*run_experiment\.py")
+    seed_re = re.compile(r"--seed\b|--allow-nondeterministic\b")
+    template_re = re.compile(r"<\w+")
+    requirements_re = re.compile(r"pip install\s+-r\s+requirements\.txt")
+
+    for md_file in sorted(docs_dir.rglob("*.md")):
+        if any(part in skip_dirs for part in md_file.relative_to(docs_dir).parts):
+            continue
+        text = md_file.read_text(encoding="utf-8")
+        rel = md_file.relative_to(repo_root)
+        lines = text.splitlines()
+
+        # Parse fenced blocks with a simple state machine
+        in_block = False
+        block_lang = ""
+        block_lines: list[tuple[int, str]] = []  # (lineno, text)
+
+        for lineno_0, line in enumerate(lines):
+            lineno = lineno_0 + 1
+            stripped = line.strip()
+
+            if not in_block:
+                m = fence_open_re.match(stripped)
+                if m:
+                    in_block = True
+                    block_lang = m.group(1)
+                    block_lines = []
+                continue
+
+            # Inside a block — check for closing fence
+            if stripped == "```":
+                # Block closed — check if it was a shell-like block
+                if block_lang in shell_langs:
+                    _check_block_commands(
+                        block_lines,
+                        rel,
+                        errors,
+                        run_exp_re,
+                        seed_re,
+                        template_re,
+                        requirements_re,
+                    )
+                in_block = False
+                continue
+
+            block_lines.append((lineno, line))
+
+    return errors
+
+
+def _check_block_commands(
+    block_lines: list[tuple[int, str]],
+    rel: Path,
+    errors: list[str],
+    run_exp_re: re.Pattern,
+    seed_re: re.Pattern,
+    template_re: re.Pattern,
+    requirements_re: re.Pattern,
+) -> None:
+    """Check a single shell code block for command contract violations."""
+    for idx, (lineno, line) in enumerate(block_lines):
+        if run_exp_re.search(line):
+            if template_re.search(line):
+                continue
+            # Collect continuation lines
+            cmd_parts = [line]
+            j = idx + 1
+            while j < len(block_lines) and cmd_parts[-1].rstrip().endswith("\\"):
+                cmd_parts.append(block_lines[j][1])
+                j += 1
+            full_cmd = " ".join(cmd_parts)
+            if not seed_re.search(full_cmd):
+                errors.append(
+                    f"{rel}:{lineno}: run_experiment.py without "
+                    f"--seed or --allow-nondeterministic"
+                )
+
+        if requirements_re.search(line):
+            errors.append(
+                f"{rel}:{lineno}: stale 'pip install -r requirements.txt' "
+                f"(use 'uv sync' or 'pip install -e \".[dev]\"')"
+            )
+
+
 def main() -> int:
     repo_root = Path(__file__).resolve().parent.parent
     docs_dir = repo_root / "docs"
@@ -191,6 +343,18 @@ def main() -> int:
     print("Checking script list completeness...")
     script_errors = check_scripts_list_complete(arch_doc, scripts_dir)
     all_errors.extend(script_errors)
+
+    print("Checking internal script list completeness...")
+    internal_errors = check_internal_scripts_listed(arch_doc, scripts_dir / "internal")
+    all_errors.extend(internal_errors)
+
+    print("Checking for duplicate headings...")
+    heading_errors = check_no_duplicate_headings(arch_doc)
+    all_errors.extend(heading_errors)
+
+    print("Checking command contracts in docs/...")
+    contract_errors = check_command_contracts(docs_dir, repo_root)
+    all_errors.extend(contract_errors)
 
     if all_errors:
         print(f"\nDocs freshness check FAILED ({len(all_errors)} issues):\n")

--- a/tests/unit/test_docs_freshness.py
+++ b/tests/unit/test_docs_freshness.py
@@ -6,7 +6,10 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 
 from check_docs_freshness import (
+    check_command_contracts,
     check_image_references,
+    check_internal_scripts_listed,
+    check_no_duplicate_headings,
     check_path_references,
     check_scripts_list_complete,
 )
@@ -152,4 +155,179 @@ def test_non_png_image_not_decoded(tmp_path):
     (docs_dir / "report.md").write_text("![Photo](photo.jpg)\n![Icon](icon.svg)\n")
 
     errors = check_image_references(docs_dir, tmp_path)
+    assert len(errors) == 0
+
+
+# --- Internal scripts tests ---
+
+
+def test_internal_scripts_all_listed(tmp_path):
+    """All internal scripts listed in ARCHITECTURE.md pass."""
+    arch_doc = tmp_path / "ARCHITECTURE.md"
+    internal_dir = tmp_path / "scripts" / "internal"
+    internal_dir.mkdir(parents=True)
+    (internal_dir / "foo.py").touch()
+    (internal_dir / "bar.py").touch()
+    arch_doc.write_text("scripts/internal/foo.py and scripts/internal/bar.py\n")
+
+    errors = check_internal_scripts_listed(arch_doc, internal_dir)
+    assert len(errors) == 0
+
+
+def test_internal_script_missing_flagged(tmp_path):
+    """Missing internal script flagged with full path."""
+    arch_doc = tmp_path / "ARCHITECTURE.md"
+    internal_dir = tmp_path / "scripts" / "internal"
+    internal_dir.mkdir(parents=True)
+    (internal_dir / "foo.py").touch()
+    (internal_dir / "missing.py").touch()
+    arch_doc.write_text("scripts/internal/foo.py only\n")
+
+    errors = check_internal_scripts_listed(arch_doc, internal_dir)
+    assert len(errors) == 1
+    assert "scripts/internal/missing.py" in errors[0]
+
+
+def test_internal_scripts_private_ignored(tmp_path):
+    """Private (_-prefixed) internal scripts are skipped."""
+    arch_doc = tmp_path / "ARCHITECTURE.md"
+    internal_dir = tmp_path / "scripts" / "internal"
+    internal_dir.mkdir(parents=True)
+    (internal_dir / "_helper.py").touch()
+    arch_doc.write_text("No scripts listed\n")
+
+    errors = check_internal_scripts_listed(arch_doc, internal_dir)
+    assert len(errors) == 0
+
+
+def test_internal_scripts_dir_missing_ok(tmp_path):
+    """Missing internal dir returns no errors (not all repos have it)."""
+    arch_doc = tmp_path / "ARCHITECTURE.md"
+    arch_doc.write_text("No scripts\n")
+
+    errors = check_internal_scripts_listed(arch_doc, tmp_path / "scripts" / "internal")
+    assert len(errors) == 0
+
+
+# --- Duplicate headings tests ---
+
+
+def test_no_duplicate_headings_clean(tmp_path):
+    """Unique H2 headings pass."""
+    doc = tmp_path / "test.md"
+    doc.write_text("## Alpha\ntext\n## Beta\ntext\n## Gamma\ntext\n")
+
+    errors = check_no_duplicate_headings(doc)
+    assert len(errors) == 0
+
+
+def test_duplicate_heading_flagged(tmp_path):
+    """Duplicate H2 heading is flagged with both line numbers."""
+    doc = tmp_path / "test.md"
+    doc.write_text("## Foo\ntext\n## Bar\ntext\n## Foo\nmore text\n")
+
+    errors = check_no_duplicate_headings(doc)
+    assert len(errors) == 1
+    assert "Foo" in errors[0]
+    assert "line 1" in errors[0]
+    assert "5" in errors[0]  # duplicate at line 5
+
+
+def test_duplicate_heading_h3_ignored(tmp_path):
+    """Duplicate H3 headings are not flagged (only H2 checked)."""
+    doc = tmp_path / "test.md"
+    doc.write_text("## A\n### Sub\ntext\n## B\n### Sub\ntext\n")
+
+    errors = check_no_duplicate_headings(doc)
+    assert len(errors) == 0
+
+
+# --- Command contracts tests ---
+
+
+def test_command_with_seed_passes(tmp_path):
+    """run_experiment.py with --seed passes."""
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "test.md").write_text(
+        "```bash\npython experiments/run_experiment.py --seed 42\n```\n"
+    )
+
+    errors = check_command_contracts(docs_dir, tmp_path)
+    assert len(errors) == 0
+
+
+def test_command_without_seed_flagged(tmp_path):
+    """run_experiment.py without --seed is flagged."""
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "test.md").write_text(
+        "```bash\npython experiments/run_experiment.py --config foo.yaml\n```\n"
+    )
+
+    errors = check_command_contracts(docs_dir, tmp_path)
+    assert len(errors) == 1
+    assert "run_experiment.py" in errors[0]
+    assert "--seed" in errors[0]
+
+
+def test_command_with_allow_nondeterministic_passes(tmp_path):
+    """run_experiment.py with --allow-nondeterministic passes."""
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "test.md").write_text(
+        "```bash\npython experiments/run_experiment.py "
+        "--allow-nondeterministic\n```\n"
+    )
+
+    errors = check_command_contracts(docs_dir, tmp_path)
+    assert len(errors) == 0
+
+
+def test_template_command_skipped(tmp_path):
+    """Commands with <placeholder> angle brackets are skipped."""
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "test.md").write_text(
+        "```bash\npython experiments/run_experiment.py --config <config>\n```\n"
+    )
+
+    errors = check_command_contracts(docs_dir, tmp_path)
+    assert len(errors) == 0
+
+
+def test_requirements_txt_flagged(tmp_path):
+    """pip install -r requirements.txt is flagged."""
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "test.md").write_text("```bash\npip install -r requirements.txt\n```\n")
+
+    errors = check_command_contracts(docs_dir, tmp_path)
+    assert len(errors) == 1
+    assert "requirements.txt" in errors[0]
+
+
+def test_multiline_command_with_seed_passes(tmp_path):
+    """Backslash-continued command with --seed on continuation line passes."""
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "test.md").write_text(
+        "```bash\npython experiments/run_experiment.py \\\n"
+        "  --config foo.yaml \\\n"
+        "  --seed 42\n```\n"
+    )
+
+    errors = check_command_contracts(docs_dir, tmp_path)
+    assert len(errors) == 0
+
+
+def test_mermaid_block_not_checked(tmp_path):
+    """run_experiment.py inside mermaid blocks is not flagged."""
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "test.md").write_text(
+        "```mermaid\nStart([python experiments/run_experiment.py])\n```\n"
+    )
+
+    errors = check_command_contracts(docs_dir, tmp_path)
     assert len(errors) == 0


### PR DESCRIPTION
## Summary
- Add `check_internal_scripts_listed()` — verifies `scripts/internal/*.py` listed in ARCHITECTURE.md by full path
- Add `check_no_duplicate_headings()` — flags duplicate H2 headings with line numbers
- Add `check_command_contracts()` — scans bash/sh code blocks for `run_experiment.py` without `--seed` and stale `pip install -r requirements.txt`
- Add `docs-check` step to GitHub Actions CI pipeline (`.github/workflows/ci.yml`)
- 14 new unit tests (25 total in `test_docs_freshness.py`)

## Why
PR #347 fixed 10 docs drift issues. These guardrails prevent recurrence by catching:
- Missing internal scripts in ARCHITECTURE.md (generate_r4_charts.py was missed until #347)
- Duplicate H2 headings (duplicate `## Promotion Workflow` was caught in #347)
- Determinism violations in code examples (missing `--seed` on `run_experiment.py`)
- Stale install instructions (`pip install -r requirements.txt`)

The CI step is the most impactful change — without it, docs-check only runs locally via `make check`.

## Technical Design
- **State machine parser** for fenced code blocks (not regex): correctly handles opening/closing fence ambiguity that caused false positives with the initial regex approach
- **Shell-only scoping**: only checks `bash`, `sh`, and untagged blocks; skips `mermaid`, `yaml`, `python`, etc. — verified against `FLOW_DIAGRAM.md` mermaid blocks
- **Command invocation detection**: matches `python ... run_experiment.py` pattern, not bare filename mentions in tree listings or prose
- **Template exclusion**: commands with `<placeholder>` angle brackets are skipped (REPRODUCIBILITY.md patterns)
- **Backslash continuation**: follows `\` line continuations to find `--seed` on subsequent lines

## Repro / Validation
```bash
make check                                                    # all 1296 tests pass
uv run python scripts/check_docs_freshness.py                # standalone gate passes
uv run python -m pytest tests/unit/test_docs_freshness.py -v  # 25 tests pass
```

## Tests
- [x] `make check` passes (1296 tests, +14 new)

## Risk level
- [x] Low (docs tooling + CI config only — no runtime code changes)

## Worktree proof
`pwd`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-docs-hardening`
`git rev-parse --show-toplevel`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-docs-hardening`
`git branch --show-current`: `docs/freshness-hardening`

## Checklist
- [x] No generated artifacts committed
- [x] PR is focused (one concept — docs guardrail hardening)
- [x] Behavior changes have matching tests (14 new)