### PR TITLE
fix: replace broken §6d cross-contract table with per-contract tables

### DIFF
--- a/docs/04_reports/phase0_bidless_20260207_r5.md
+++ b/docs/04_reports/phase0_bidless_20260207_r5.md
@@ -261,35 +261,62 @@ HIGH contracts show strong strategy stability — the top features are ace/offsu
 
 LOW contracts are dominated by `offsuit_tens_count` (coefficient +0.63/+0.58 — by far the strongest single feature in any contract type). Tens are the highest-ranked cards in LOW contracts, so this is expected. Both strategies agree on this and on most other rankings. Note the positive sign on `rank_sum` and `hand_value` — these are positively correlated with tens holdings despite LOW being a "worst cards win" contract, because the hand evaluator's scoring reflects relative card strength.
 
-### 6d. Cross-Contract Feature Ranking
+### 6d. Per-Contract Correlation Ranking
 
-This table inverts the §6c perspective: instead of per-contract top-10 lists, it ranks features by their average |Pearson r| with tricks_won across all three contract types (suit, high, low). Features that appear here are strong predictors regardless of contract type, while those absent may be powerful in one contract but irrelevant in others.
+The §6c tables rank features by Ridge coefficient magnitude. This complementary view ranks by Pearson correlation with tricks_won — a simpler measure that doesn't account for feature interactions but is easier to interpret.
 
-*Note: Pearson r and Ridge coefficients can disagree — correlated features share variance in Ridge, so a feature with high correlation may have a modest Ridge coefficient if its signal is captured by related features.*
+*Note: Pearson r measures linear association between a single feature and tricks_won. Ridge coefficients account for all features simultaneously, so rankings can differ — a feature with high correlation may have a modest coefficient if correlated features capture its signal.*
 
-| Rank | Feature | Avg |r| | Suit Coeff | High Coeff | Low Coeff |
-|------|---------|---------|------------|------------|-----------|
-| 1 | `hand_value` | 0.363 | +0.1555 | +0.0548 | +0.1244 |
-| 2 | `trump_power_sum` | 0.354 | +0.1642 | +0.0000 | +0.0000 |
-| 3 | `high_offsuit` | 0.333 | -0.1539 | -0.1764 | -0.0410 |
-| 4 | `trump_count_x_offsuit_ace` | 0.331 | +0.0800 | +0.0000 | +0.0000 |
-| 5 | `trump_count` | 0.316 | +0.0694 | +0.0000 | +0.0000 |
-| 6 | `third_highest_trump_rank` | 0.310 | -0.1606 | +0.0000 | +0.0000 |
-| 7 | `top_trump_count` | 0.305 | +0.1393 | +0.0000 | +0.0000 |
-| 8 | `top_trump_sum` | 0.305 | +0.1393 | +0.0000 | +0.0000 |
-| 9 | `bowers` | 0.298 | +0.2082 | +0.0000 | +0.0000 |
-| 10 | `trump_count_x_void_count` | 0.282 | +0.2792 | +0.0000 | +0.0000 |
-| 11 | `second_highest_trump_rank` | 0.277 | -0.2984 | +0.0000 | +0.0000 |
-| 12 | `rank_sum` | 0.271 | +0.0262 | +0.0548 | +0.1244 |
-| 13 | `trump_rb_count` | 0.267 | +0.3050 | +0.0000 | +0.0000 |
-| 14 | `offsuit_aces` | 0.253 | +0.1254 | +0.1764 | +0.0410 |
-| 15 | `offsuit_tens_count` | 0.248 | +0.0357 | +0.0564 | +0.6255 |
+**Suit Contracts — Top 10 by Pearson Correlation:**
 
-Notable patterns:
-- **`hand_value`** ranks #1 by average correlation — it's a strong predictor across all contract types, which makes sense since it aggregates multiple card-strength signals.
-- **Trump features** (ranks 2, 4–11, 13) dominate the top 15 by Pearson r but show +0.0000 coefficients in HIGH/LOW contracts (these features are constant in no-trump deals). Their high average correlation comes entirely from suit contracts.
-- **`offsuit_tens_count`** (rank 15) has a modest average correlation but a massive LOW coefficient (+0.6255) — it's the single most important feature for LOW contracts while being minor elsewhere.
-- **Cross-contract features** like `hand_value`, `rank_sum`, `offsuit_aces`, and `high_offsuit` carry non-zero coefficients across all three contract types, making them strong candidates for any pooled model.
+| Feature | Pearson r | Greedy Coeff | Glutton Coeff |
+|---------|-----------|--------------|---------------|
+| `high_offsuit` | -0.4212 | -0.1539 | -0.0985 |
+| `hand_value` | +0.3996 | +0.1555 | +0.0991 |
+| `trump_power_sum` | +0.3544 | +0.1642 | +0.1019 |
+| `trump_count_x_offsuit_ace` | +0.3312 | +0.0800 | +0.0773 |
+| `trump_count` | +0.3158 | +0.0694 | +0.0517 |
+| `third_highest_trump_rank` | +0.3098 | -0.1606 | -0.0350 |
+| `top_trump_count` | +0.3048 | +0.1393 | +0.0854 |
+| `top_trump_sum` | +0.3048 | +0.1393 | +0.0854 |
+| `bowers` | +0.2980 | +0.2082 | +0.1296 |
+| `trump_count_x_void_count` | +0.2823 | +0.2792 | +0.0474 |
+
+`high_offsuit` has the strongest correlation (r = -0.42) — more offsuit high cards means fewer trump, reducing trick-taking in suit contracts. Trump features dominate the list, consistent with §6c. Note `third_highest_trump_rank` has a positive correlation but a negative Ridge coefficient — it correlates with having many trump cards (positive for tricks) but conditional on trump count, a higher third-trump rank means the trump holding is top-heavy, which the Ridge model penalizes.
+
+**High Contracts — Top 10 by Pearson Correlation:**
+
+| Feature | Pearson r | Greedy Coeff | Glutton Coeff |
+|---------|-----------|--------------|---------------|
+| `high_offsuit` | -0.4459 | -0.1764 | -0.1642 |
+| `offsuit_aces` | +0.4459 | +0.1764 | +0.1642 |
+| `offsuit_suits_with_ace` | +0.4029 | +0.1610 | +0.1394 |
+| `hand_value` | +0.3443 | +0.0548 | +0.0535 |
+| `rank_sum` | +0.3443 | +0.0548 | +0.0535 |
+| `high_card_count` | +0.3130 | +0.0549 | +0.0555 |
+| `offsuit_suits_with_double_ace` | +0.2716 | +0.1041 | +0.1184 |
+| `offsuit_secondbest_rank_sum` | +0.2355 | +0.1013 | +0.1186 |
+| `offsuit_suits_with_ace_and_king` | +0.2246 | +0.0583 | +0.0608 |
+| `low_card_count` | -0.2116 | -0.0057 | -0.0146 |
+
+Correlation and Ridge rankings align closely here — ace-related features dominate both. `offsuit_aces` and `high_offsuit` are mirror images (r = +0.45 and -0.45), reflecting that in no-trump HIGH contracts, aces are the primary trick-winning mechanism. Strategy agreement is strong: greedy and glutton coefficients track each other closely.
+
+**Low Contracts — Top 10 by Pearson Correlation:**
+
+| Feature | Pearson r | Greedy Coeff | Glutton Coeff |
+|---------|-----------|--------------|---------------|
+| `offsuit_tens_count` | +0.4490 | +0.6255 | +0.5753 |
+| `hand_value` | +0.3448 | +0.1244 | +0.1142 |
+| `rank_sum` | +0.3448 | +0.1244 | +0.1142 |
+| `low_card_count` | +0.3131 | -0.0515 | -0.0464 |
+| `offsuit_secondbest_rank_sum` | +0.2322 | +0.1100 | +0.1488 |
+| `high_card_count` | -0.2095 | +0.0660 | +0.0600 |
+| `offsuit_best_rank_sum` | +0.1952 | +0.0949 | +0.1726 |
+| `double_ten_jack_count` | +0.1915 | +0.0695 | +0.0475 |
+| `offsuit_suits_with_ace_and_king` | -0.1411 | -0.0188 | -0.0207 |
+| `high_offsuit` | +0.1311 | -0.0410 | -0.0407 |
+
+`offsuit_tens_count` dominates both by correlation (r = +0.45) and by Ridge coefficient (+0.63/+0.58), confirming it as the single most important feature for LOW contracts. `low_card_count` shows an interesting divergence: high positive correlation (r = +0.31) but a small *negative* Ridge coefficient — its signal is absorbed by `offsuit_tens_count` and `rank_sum` in the multivariate model. `high_offsuit` flips sign from §6c's suit contracts (negative there, positive here), reflecting that in LOW contracts, having more high-ranked offsuit cards paradoxically helps because the hand evaluator's `high_offsuit` feature captures suit distribution properties that matter differently when 10s beat aces.
 
 ### 6e. Caveats
 

--- a/docs/04_reports/phase0_bidless_20260207_r5_provenance.json
+++ b/docs/04_reports/phase0_bidless_20260207_r5_provenance.json
@@ -17,7 +17,7 @@
     "change_1": "Seat balance chart: swapped axes (contract group → x-axis, seat → legend)",
     "change_2": "Greedy strategy color changed from #2ecc71 (green) to #e67e22 (orange) for contrast with glutton",
     "change_3": "New all-strategy hand value calibration chart (greedy, glutton, random_legal from mixed_play)",
-    "change_4": "Cross-contract feature ranking table (§6d) — features ranked by avg |Pearson r|",
+    "change_4": "Per-contract correlation ranking tables (§6d) — 3 tables (suit/high/low), each top 10 by |Pearson r| with greedy + glutton coefficients",
     "change_5": "Strategy descriptions added to §8 intro"
   },
   "charts": {
@@ -180,14 +180,15 @@
       "changed_in_r5": true,
       "change_note": "Rank columns renamed from 'Greedy Rank'/'Glutton Rank' to 'Greedy Coeff Rank'/'Glutton Coeff Rank'"
     },
-    "cross_contract_ranking": {
+    "per_contract_correlation_ranking": {
       "section": "6d",
       "source_runs": [
         "canonical_bidless_dataset_greedy_42_20260204_221121",
         "canonical_bidless_dataset_glutton_42_20260204_222713"
       ],
-      "computed_from": "generate_cross_contract_table() from per-contract JSON",
-      "new_in_r5": true
+      "computed_from": "generate_cross_contract_table() — 3 per-contract tables (suit/high/low), each top 10 by |Pearson r|, with greedy + glutton Ridge coefficients",
+      "new_in_r5": true,
+      "changed_note": "Replaced single cross-contract table (broken Avg |r| header) with 3 separate per-contract tables"
     },
     "strategy_vs_random": {
       "section": "7a",

--- a/scripts/internal/evaluate_diagnostic_tricks.py
+++ b/scripts/internal/evaluate_diagnostic_tricks.py
@@ -337,21 +337,20 @@ def process_dataset(
 
 def generate_cross_contract_table(
     json_path: str,
-    strategy: str = "greedy",
-    top_n: int = 15,
+    top_n: int = 10,
 ) -> str:
-    """Generate a cross-contract feature ranking table from per-contract JSON.
+    """Generate per-contract feature correlation tables from per-contract JSON.
 
-    Ranks features by average |Pearson r| across suit, high, low contract types.
-    Shows Ridge coefficients for each contract type alongside the correlation.
+    Produces 3 separate tables (suit, high, low), each ranking features by
+    |Pearson r| with tricks_won. Shows both greedy and glutton Ridge
+    coefficients alongside the signed Pearson r.
 
     Args:
         json_path: Path to per-contract JSON (from --per-contract-json)
-        strategy: Which strategy's Ridge coefficients to show
-        top_n: Number of top features to include
+        top_n: Number of top features per contract type
 
     Returns:
-        Markdown table string
+        Markdown string with 3 tables separated by blank lines
     """
     with open(json_path) as f:
         data = json.load(f)
@@ -359,7 +358,11 @@ def generate_cross_contract_table(
     correlations = data.get("correlations", {})
 
     # Map contract types to groups: collapse suit_* into "suit"
-    contract_groups = {"suit": [], "high": [], "low": []}
+    contract_groups: dict[str, list[tuple[str, list[dict]]]] = {
+        "suit": [],
+        "high": [],
+        "low": [],
+    }
     for ct, corr_list in correlations.items():
         if ct == "suit" or ct.startswith("suit_"):
             group = "suit"
@@ -369,80 +372,85 @@ def generate_cross_contract_table(
             continue
         contract_groups[group].append((ct, corr_list))
 
-    # Build per-feature data: collect Pearson r and Ridge coeff per group
-    feature_data: dict[str, dict] = {}
+    group_labels = {
+        "suit": "Suit Contracts",
+        "high": "High Contracts",
+        "low": "Low Contracts",
+    }
 
-    for group, ct_entries in contract_groups.items():
+    sections = []
+    for group in ("suit", "high", "low"):
+        ct_entries = contract_groups[group]
+
+        # Collect per-feature data for this group
+        feature_data: dict[str, dict] = {}
         for _ct, corr_list in ct_entries:
             for entry in corr_list:
                 feat = entry["feature"]
                 if feat not in feature_data:
                     feature_data[feat] = {
-                        "pearson_rs": {"suit": [], "high": [], "low": []},
-                        "coeffs": {"suit": [], "high": [], "low": []},
+                        "pearson_rs": [],
+                        "greedy_coeffs": [],
+                        "glutton_coeffs": [],
                     }
                 r_val = entry["pearson_r"]
-                # Skip NaN correlations (constant features in some contracts)
                 if r_val is not None and not math.isnan(r_val):
-                    feature_data[feat]["pearson_rs"][group].append(abs(r_val))
-                coeff_key = f"{strategy}_ridge_coeff"
-                coeff = entry.get(coeff_key)
-                if coeff is not None:
-                    feature_data[feat]["coeffs"][group].append(coeff)
+                    feature_data[feat]["pearson_rs"].append(r_val)
+                for strategy in ("greedy", "glutton"):
+                    coeff = entry.get(f"{strategy}_ridge_coeff")
+                    if coeff is not None:
+                        feature_data[feat][f"{strategy}_coeffs"].append(coeff)
 
-    # Compute avg |Pearson r| across the 3 groups
-    ranked_features = []
-    for feat, data_dict in feature_data.items():
-        group_means = []
-        for group in ("suit", "high", "low"):
-            rs = data_dict["pearson_rs"][group]
-            if rs:
-                group_means.append(sum(rs) / len(rs))
-        if not group_means:
-            continue
-        avg_abs_r = sum(group_means) / len(group_means)
+        # Rank by average |Pearson r| within this group
+        ranked = []
+        for feat, fd in feature_data.items():
+            rs = fd["pearson_rs"]
+            if not rs:
+                continue
+            avg_r = sum(rs) / len(rs)
+            avg_abs_r = sum(abs(r) for r in rs) / len(rs)
+            greedy_cs = fd["greedy_coeffs"]
+            glutton_cs = fd["glutton_coeffs"]
+            ranked.append(
+                {
+                    "feature": feat,
+                    "pearson_r": avg_r,
+                    "abs_r": avg_abs_r,
+                    "greedy_coeff": (
+                        sum(greedy_cs) / len(greedy_cs) if greedy_cs else None
+                    ),
+                    "glutton_coeff": (
+                        sum(glutton_cs) / len(glutton_cs) if glutton_cs else None
+                    ),
+                }
+            )
 
-        # Average coefficient per group
-        group_coeffs = {}
-        for group in ("suit", "high", "low"):
-            cs = data_dict["coeffs"][group]
-            if cs:
-                group_coeffs[group] = sum(cs) / len(cs)
-            else:
-                group_coeffs[group] = None
+        ranked.sort(key=lambda x: x["abs_r"], reverse=True)
+        top = ranked[:top_n]
 
-        ranked_features.append(
-            {
-                "feature": feat,
-                "avg_abs_r": avg_abs_r,
-                "suit_coeff": group_coeffs["suit"],
-                "high_coeff": group_coeffs["high"],
-                "low_coeff": group_coeffs["low"],
-            }
-        )
+        lines = [
+            f"**{group_labels[group]} — Top {top_n} by Pearson Correlation:**",
+            "",
+            "| Feature | Pearson r | Greedy Coeff | Glutton Coeff |",
+            "|---------|-----------|--------------|---------------|",
+        ]
+        for entry in top:
+            r_s = f"{entry['pearson_r']:+.4f}"
+            g_s = (
+                f"{entry['greedy_coeff']:+.4f}"
+                if entry["greedy_coeff"] is not None
+                else "—"
+            )
+            gl_s = (
+                f"{entry['glutton_coeff']:+.4f}"
+                if entry["glutton_coeff"] is not None
+                else "—"
+            )
+            lines.append(f"| `{entry['feature']}` | {r_s} | {g_s} | {gl_s} |")
 
-    ranked_features.sort(key=lambda x: x["avg_abs_r"], reverse=True)
-    top = ranked_features[:top_n]
+        sections.append("\n".join(lines))
 
-    # Format as markdown
-    lines = [
-        "| Rank | Feature | Avg |r| | Suit Coeff | High Coeff | Low Coeff |",
-        "|------|---------|---------|------------|------------|-----------|",
-    ]
-    for rank, entry in enumerate(top, 1):
-        suit_s = (
-            f"{entry['suit_coeff']:+.4f}" if entry["suit_coeff"] is not None else "—"
-        )
-        high_s = (
-            f"{entry['high_coeff']:+.4f}" if entry["high_coeff"] is not None else "—"
-        )
-        low_s = f"{entry['low_coeff']:+.4f}" if entry["low_coeff"] is not None else "—"
-        lines.append(
-            f"| {rank} | `{entry['feature']}` | {entry['avg_abs_r']:.3f} "
-            f"| {suit_s} | {high_s} | {low_s} |"
-        )
-
-    return "\n".join(lines)
+    return "\n\n".join(sections)
 
 
 def main():


### PR DESCRIPTION
## Summary
- Rewrote `generate_cross_contract_table()` to produce 3 separate per-contract tables (suit/high/low) instead of one combined table
- Replaced §6d in Phase 0 report r5 with regenerated per-contract correlation rankings and narratives
- Updated provenance JSON to reflect the new table structure

## Why
The original §6d table had an `Avg |r|` header containing pipe characters that broke markdown table rendering. Additionally, a single averaged-across-contracts table obscured contract-specific patterns. The new per-contract format matches the §6c structure and eliminates the rendering bug.

## Repro / Validation
**Command(s) run:**
```bash
cd /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-6d
PYTHONPATH=src uv run python scripts/internal/evaluate_diagnostic_tricks.py \
  --greedy-dir ../Bid-Euchre/data/runs/canonical_bidless_dataset_greedy_42_20260204_221121 \
  --glutton-dir ../Bid-Euchre/data/runs/canonical_bidless_dataset_glutton_42_20260204_222713 \
  --seed 42 --output /tmp/phase0_r5_fix/diagnostic_tricks.md \
  --per-contract-json /tmp/phase0_r5_fix/coefficients.json \
  --cross-contract-table /tmp/phase0_r5_fix/cross_contract_table.md
```

**Seed:** 42

## Tests
- [x] `make check` — repo-lint + ruff + pytest (1288 passed, 5 skipped)
- [x] Visual inspection: tables render correctly without pipe-in-header issues

## Expected impact
- Metrics impact: None (report text only)
- Runtime impact: None

## Risk level
- [x] Low (docs/scripts only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-6d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-6d
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre       d515ed2 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-6d e68288a [fix/report-6d-tables]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] PR is focused (one concept)
- [x] `make check` passes