### PR TITLE
feat: add /review skill for repo health checks

### DIFF
--- a/.claude/skills/reviewing-repo/DISCOVERY_TEMPLATE.md
+++ b/.claude/skills/reviewing-repo/DISCOVERY_TEMPLATE.md
@@ -1,0 +1,83 @@
+# Phase 1: Discovery — Sub-Agent Prompt Template
+
+Read the template below and pass it to a `general-purpose` sub-agent. The `{REPO_ROOT}` placeholder should be replaced with the actual repo root path.
+
+```
+You are performing Phase 1 (Discovery) of a comprehensive repo review for the
+Bid Euchre project. Your job is to build an accurate, quantitative map of the
+current repository state.
+
+**Working directory:** {REPO_ROOT}
+**Constraint:** Read-only. Do NOT edit any files.
+
+## Instructions
+
+Read `docs/02_agent/REPO_REVIEW_PROMPT.md` sections 1.1, 1.2, and 1.3 for the
+full list of discovery commands. Execute all of them.
+
+## Summary of What to Discover
+
+### 1.1 Structure Discovery (run in parallel)
+
+- Module count and listing: `ls -d src/bid_euchre/*/ | grep -v __pycache__`
+- Config count: `ls experiments/configs/*.yaml | wc -l`
+- Suite count: `ls experiments/suites/*.yaml | wc -l`
+- Script counts (top-level + internal): `ls scripts/*.py`, `ls scripts/internal/*.py`
+- Test structure: `ls -d tests/*/`, test file count
+- Documentation structure: doc counts per subdirectory
+- Notebook count (active only, exclude archives)
+
+### 1.2 Version Context (run in parallel)
+
+- Latest merged PR number (via `gh pr list`)
+- Recent commits (last 10)
+- Total commit count
+- Repo age (first commit date)
+
+### 1.3 Module Health (run sequentially)
+
+Run all the `uv run python -c "from ..."` import checks listed in the protocol.
+Test every module directory found in 1.1 — if a module exists but has no import
+check in the protocol, attempt a basic import and note it.
+
+## Output Format
+
+Return your results as structured markdown with these 3 sections:
+
+### Structure Table
+
+| Component | Count | Details |
+|-----------|-------|---------|
+| Modules | <N> | <comma-separated list> |
+| Configs | <N> | |
+| Suites | <N> | |
+| Scripts (top-level) | <N> | <comma-separated list> |
+| Scripts (internal) | <N> | <comma-separated list> |
+| Test directories | <N> | <list> |
+| Test files | <N> | |
+| Docs (total) | <N> | |
+| Docs (01_core) | <N> | |
+| Docs (02_agent) | <N> | |
+| Docs (03_TODO) | <N> | |
+| Docs (04_reports) | <N> | |
+| Notebooks (active) | <N> | |
+
+### Version Context
+
+| Metric | Value |
+|--------|-------|
+| Latest merged PR | #<N> |
+| Recent commits | <last 5 one-liners> |
+| Total commits | <N> |
+| Repo age | <first commit date> |
+
+### Module Health
+
+| Module | Import Test | Status |
+|--------|-------------|--------|
+| core | `from bid_euchre.core import Card, create_deck` | OK / FAIL |
+| sim | `from bid_euchre.sim.simulation import play_single_hand` | OK / FAIL |
+| ... | ... | ... |
+
+List ALL modules found in 1.1 with their import status.
+```

--- a/.claude/skills/reviewing-repo/ISSUES_TEMPLATE.md
+++ b/.claude/skills/reviewing-repo/ISSUES_TEMPLATE.md
@@ -1,0 +1,112 @@
+# Phase 3: Issue Discovery — Sub-Agent Prompt Template
+
+Read the template below and pass it to a `general-purpose` sub-agent. The `{REPO_ROOT}` placeholder should be replaced with the actual repo root path.
+
+```
+You are performing Phase 3 (Issue Discovery) of a comprehensive repo review
+for the Bid Euchre project. Your job is to identify all issues, gaps, and
+improvement opportunities using automated detection.
+
+**Working directory:** {REPO_ROOT}
+**Constraint:** Read-only. Do NOT edit any files.
+
+## Instructions
+
+Read `docs/02_agent/REPO_REVIEW_PROMPT.md` sections 3.1 through 3.4 for the
+full list of issue detection commands. Execute all of them.
+
+## Summary of What to Detect
+
+### 3.1 Known Issues Review
+- List TODO tracker files: `ls docs/03_TODO/*.md`
+- Check for previous review outputs: `ls docs/03_TODO/REPO_REVIEW_*.md`
+- Read `docs/03_TODO/CODEBASE_CONSISTENCY.md` for ongoing gaps
+
+### 3.2 Automated Detection
+- TODO/FIXME/HACK/XXX scanning in source and docs (counts + samples)
+- Empty test detection: `grep -rn "def test_.*:.*pass$" tests/`
+- Unseeded experiment detection in docs
+- Stale reference detection (config paths, script paths referenced in docs
+  that no longer exist on disk)
+
+### 3.3 Drift Detection
+- Module count drift: compare ARCHITECTURE.md module list to actual `ls`
+- Config count drift: compare EXPERIMENTS.md claims to actual count
+- Script list drift: compare ARCHITECTURE.md script list to actual `ls`
+
+### 3.4 Rigor Gaps
+- Visual-only validation: notebooks with "looks balanced/good" claims
+- Missing statistical tests: notebooks with plots but no f_oneway/ttest/bootstrap
+- Inadequate sample sizes: configs with n_per < 2000
+- Hardcoded configuration: seat=0, trump='H' patterns
+- Missing confidence intervals: mean/median reporting without CI
+
+## Output Format
+
+Return your results as structured markdown with these sections:
+
+### Known Issues
+
+- Previous reviews found: <list or "none">
+- Existing TODO trackers: <list>
+- Key ongoing gaps from CODEBASE_CONSISTENCY.md: <summary>
+
+### TODO/FIXME Scan
+
+| Location | Count | Sample Issues |
+|----------|-------|---------------|
+| src/ | <N> | <top 3 examples with file:line> |
+| scripts/ | <N> | <top 3 examples> |
+| docs/ | <N> | <top 3 examples> |
+| Total | <N> | |
+
+### Empty Tests
+
+| File | Function | Status |
+|------|----------|--------|
+| <file> | <test_name> | empty/stub |
+
+(If none found, state "No empty tests detected.")
+
+### Unseeded Experiments
+
+| Location | Command | Issue |
+|----------|---------|-------|
+| <file:line> | <command text> | missing --seed |
+
+(If none found, state "No unseeded experiments detected.")
+
+### Stale References
+
+| Referenced Path | Referenced In | Exists? |
+|-----------------|---------------|---------|
+| <path> | <doc file> | yes/no |
+
+### Drift Detection
+
+| Item | Documented | Actual | Status |
+|------|-----------|--------|--------|
+| Module count | <doc claim> | <actual> | match/drift |
+| Config count | <doc claim> | <actual> | match/drift |
+| Script list | <doc claim> | <actual> | match/drift |
+
+### Rigor Gaps
+
+| Category | Count | Examples |
+|----------|-------|----------|
+| Visual-only validation | <N> | <top 3 file:line> |
+| Missing stat tests | <N> notebooks | <list> |
+| Inadequate sample sizes | <N> configs | <list> |
+| Hardcoded values | <N> | <top 3 file:line> |
+| Missing CIs | <N> | <top 3 file:line> |
+
+### Issue Summary
+
+Total issues found: <N>
+- Critical: <N>
+- High: <N>
+- Medium: <N>
+- Low: <N>
+
+(Preliminary severity classification — final classification happens in Phase 4.)
+```

--- a/.claude/skills/reviewing-repo/SKILL.md
+++ b/.claude/skills/reviewing-repo/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: reviewing-repo
+description: Performs a comprehensive 5-phase repository review following docs/02_agent/REPO_REVIEW_PROMPT.md. Spawns parallel agents for discovery, verification, and issue detection, then synthesizes a scored report. Use when the user wants a full repo health check.
+---
+
+# Repo Review — 5-Phase Protocol
+
+Comprehensive repo health check following the protocol in `docs/02_agent/REPO_REVIEW_PROMPT.md`.
+
+## Pre-flight
+
+1. **Verify branch**: Confirm you are on `main` at HEAD. Reviews should assess the current canonical state.
+   ```bash
+   git branch --show-current
+   git log --oneline -1
+   ```
+2. **Warn if not on main**: If on a feature branch, warn the user that the review will cover that branch's state, not the canonical repo.
+3. **Read the protocol**: Read `docs/02_agent/REPO_REVIEW_PROMPT.md` to confirm it exists and note its version.
+
+## Wave 1 — Parallel Data Gathering (Phases 1-3)
+
+Spawn **3 sub-agents in parallel** using the Task tool (`subagent_type: general-purpose`). Each agent works from the repo root and is **read-only** (no file edits).
+
+**Important:** Launch all 3 in a single message so they run concurrently.
+
+### Agent 1: Discovery (Phase 1)
+
+Use the prompt template from [DISCOVERY_TEMPLATE.md](DISCOVERY_TEMPLATE.md).
+
+Set `max_turns` to 30.
+
+### Agent 2: Verification (Phase 2)
+
+Use the prompt template from [VERIFICATION_TEMPLATE.md](VERIFICATION_TEMPLATE.md).
+
+Set `max_turns` to 40.
+
+### Agent 3: Issue Discovery (Phase 3)
+
+Use the prompt template from [ISSUES_TEMPLATE.md](ISSUES_TEMPLATE.md).
+
+Set `max_turns` to 35.
+
+## Gate Check
+
+After all 3 agents return:
+
+1. **Check Phase 2 result for `make check` status**
+2. **If `make check` FAILED**: Stop the review. Output a failure summary with the error details from Agent 2. Do not proceed to synthesis.
+3. **If any agent failed to return**: Mark that phase as "NOT COMPLETED" and continue with available data.
+
+## Phase 4 — Analysis (Main Thread)
+
+Using the combined output from all 3 agents:
+
+1. **Classify issues by severity**:
+   - **CRITICAL**: Breaks functionality, violates hard gates, introduces nondeterminism
+   - **HIGH**: Documentation drift causing confusion, missing rigor validation
+   - **MEDIUM**: TODOs in production code, stale references, incomplete tests
+   - **LOW**: Cosmetic issues, informational gaps, minor doc improvements
+
+2. **Assess each issue**:
+   - Affected workflows (CI, experiments, analysis, onboarding)
+   - Risk (high/medium/low)
+   - Effort (trivial/small/medium/large)
+
+3. **Rank by impact**: Top 5 issues by default (expand only if user requests).
+
+## Phase 5 — Output (Main Thread)
+
+Assemble the **7-section report** per the protocol's output format:
+
+1. **Executive Summary** — Health score table (X/100 per component), key achievements, blockers, top 5 issues
+2. **Verification Evidence** — Command/Output/Status table from Phase 2
+3. **Issue Registry** — ID/Severity/Location/Issue/Evidence/Recommendation table (top 5 by impact)
+4. **Cleanup Plan** (optional) — Only if issues warrant PR sequencing
+5. **Rigor Assessment** — Sample sizes, statistical test coverage, fail-fast gates, anti-patterns
+6. **Documentation Roadmap** (optional) — Only if critical doc drift found
+7. **Development Roadmap** (optional) — Only if requested or critical issues need sequencing
+
+### Write Report
+
+Save the full report to: `docs/03_TODO/REPO_REVIEW_<YYYY-MM-DD>.md`
+
+**Important:** This is the one write operation in the review. Create a worktree if needed:
+```bash
+git worktree add ../Bid-Euchre-review -b codex/review-<date>
+```
+
+### Chat Summary
+
+After writing the report, output to chat:
+- The executive summary (health score table + top 5 issues)
+- The file path where the full report was saved
+- Offer follow-up options
+
+### Follow-Up
+
+Ask the user:
+1. **Commit as PR** — commit the report and open a PR
+2. **Dive deeper** — investigate specific issues in more detail
+3. **Generate cleanup plan** — create a prioritized PR sequence for fixes
+4. **Done** — end the review
+
+## Error Handling
+
+- **Sub-agent failure**: Mark the phase as "NOT COMPLETED — agent failed to return". Continue with available data. Note the gap in the executive summary.
+- **`make check` failure**: Abort review. Output failure summary with error details. Do not proceed to synthesis.
+- **Unrunnable commands**: Mark as "NOT RUN" with reason in verification evidence table.
+- **Stale protocol references**: If a command from the protocol fails, note it as a prompt staleness issue in the issue registry.
+
+## Anti-Patterns to Avoid
+
+- Embedding the full 40KB protocol text in sub-agent prompts (agents read it at runtime)
+- Hardcoding counts, PR numbers, or file lists (use discovery)
+- Making code changes during the review (read-only, except the final report write)
+- Skipping `make check` or proceeding after it fails
+- Inventing issues not backed by evidence (every claim needs a command output or file quote)
+- Running the review from a feature branch without warning the user
+
+## Notes
+
+- Total estimated tool calls across all agents: 60-90
+- The review is read-only — only the final report file is written
+- Sub-agents use `general-purpose` type because they need Bash for `make check`, `uv run`, and `gh`
+- The protocol version is in `docs/02_agent/REPO_REVIEW_PROMPT.md` — check it at runtime

--- a/.claude/skills/reviewing-repo/VERIFICATION_TEMPLATE.md
+++ b/.claude/skills/reviewing-repo/VERIFICATION_TEMPLATE.md
@@ -1,0 +1,126 @@
+# Phase 2: Verification — Sub-Agent Prompt Template
+
+Read the template below and pass it to a `general-purpose` sub-agent. The `{REPO_ROOT}` placeholder should be replaced with the actual repo root path.
+
+```
+You are performing Phase 2 (Verification) of a comprehensive repo review for
+the Bid Euchre project. Your job is to validate that the repo complies with all
+hard gates, contracts, and rigor standards.
+
+**Working directory:** {REPO_ROOT}
+**Constraint:** Read-only. Do NOT edit any files.
+
+## Instructions
+
+Read `docs/02_agent/REPO_REVIEW_PROMPT.md` sections 2.1 through 2.5 for the
+full list of verification commands. Execute all of them.
+
+## Critical: make check First
+
+Run `make check` FIRST. This is mandatory.
+
+- If `make check` PASSES: continue with all remaining verification steps.
+- If `make check` FAILS: run the individual sub-targets (`make repo-lint`,
+  `make lint`, `make test`, `make notebook-check`, `make docs-check`) to
+  identify which step failed. Return the failure details immediately. Mark
+  the overall result as FAILED.
+
+## Summary of What to Verify
+
+### 2.1 CI Gates
+- Run `make check` and record pass/fail
+- If failed, run individual targets to pinpoint failure
+- Count repo-linter rules: `grep -c "^def check_" scripts/lint_repo.py`
+- List all rule names: `grep "^def check_" scripts/lint_repo.py`
+
+### 2.2 Rigor Validation
+- Sample size validation: check n_per values across configs
+- Statistical test presence in notebooks
+- Fail-fast gate verification (assert-style checks)
+- Hardcoded value detection (seat=0, trump='H')
+- Confidence interval usage
+
+### 2.3 Boundary Compliance
+- Import hygiene: no forbidden imports in src/
+- Frozen folder check: no modifications to _deprecated/
+- Artifact leakage: no uncommitted artifacts in data/
+
+### 2.4 Documentation Accuracy
+- Verify ARCHITECTURE.md module list matches reality
+- Verify EXPERIMENTS.md config count matches reality
+- Check DATA_CONTRACT.md schema versions
+- Test sample commands from docs (dry-run safe only)
+
+### 2.5 Promotion Workflow Verification
+- Check promotion-gate target exists
+- Verify freeze/splits/eligibility/promotion imports
+- Verify promotion lint rules exist in repo-linter
+
+## Output Format
+
+Return your results as structured markdown with these sections:
+
+### make check Result
+
+**Status:** PASSED / FAILED
+**Output summary:** <key lines from output>
+
+If FAILED:
+| Sub-target | Status | Error |
+|------------|--------|-------|
+| repo-lint | PASS/FAIL | <error if failed> |
+| lint | PASS/FAIL | <error if failed> |
+| test | PASS/FAIL | <error if failed> |
+| notebook-check | PASS/FAIL | <error if failed> |
+| docs-check | PASS/FAIL | <error if failed> |
+
+### Repo-Linter Rules
+
+- Rule count: <N>
+- Rule names: <list>
+
+### Verification Evidence
+
+| Verification | Command | Result | Status |
+|--------------|---------|--------|--------|
+| CI gates | `make check` | <PASSED/FAILED> | pass/fail |
+| Module count | `ls -d src/bid_euchre/*/` | <N> | pass/fail |
+| Config count | `ls experiments/configs/*.yaml` | <N> | pass/fail |
+| Import hygiene | `grep -r "from experiments" src/` | <result> | pass/fail |
+| Artifact leakage | `find data/runs -type f` | <result> | pass/fail |
+| ... | ... | ... | ... |
+
+### Rigor Compliance
+
+| Metric | Value | Threshold | Status |
+|--------|-------|-----------|--------|
+| Min config n_per | <N> | 2000 (inference) | pass/warn |
+| Notebooks with stat tests | <X>/<Y> | - | info |
+| Notebooks with CIs | <X>/<Y> | - | info |
+| Hardcoded values found | <N> | 0 | pass/warn |
+| Fail-fast gates found | <N> | - | info |
+
+### Boundary Compliance
+
+| Check | Result | Status |
+|-------|--------|--------|
+| No forbidden imports in src/ | <result> | pass/fail |
+| Frozen folders intact | <result> | pass/fail |
+| No artifact leakage | <result> | pass/fail |
+
+### Documentation Accuracy
+
+| Doc | Claim | Reality | Status |
+|-----|-------|---------|--------|
+| ARCHITECTURE.md | <module list claim> | <actual modules> | match/drift |
+| EXPERIMENTS.md | <config count claim> | <actual count> | match/drift |
+| ... | ... | ... | ... |
+
+### Promotion Workflow
+
+| Check | Result | Status |
+|-------|--------|--------|
+| promotion-gate target | exists/missing | pass/fail |
+| Promotion imports | OK/FAIL | pass/fail |
+| Promotion lint rules | <count> found | pass/fail |
+```


### PR DESCRIPTION
## Summary
- Add `/review` skill that performs a comprehensive 5-phase repo health check
- Spawns 3 parallel sub-agents for Phases 1-3 (discovery, verification, issue detection)
- Synthesizes results in main thread for Phases 4-5 (analysis, output generation)
- Produces a scored 7-section report following `docs/02_agent/REPO_REVIEW_PROMPT.md`

## Why
- The repo review protocol (`REPO_REVIEW_PROMPT.md`) is 40KB and ~60-90 tool calls
- A single agent hits context pressure by Phase 4, degrading synthesis quality
- Parallel sub-agents keep each phase's context lean and maximize throughput
- Saves the user from manually orchestrating the review process

## Repro / Validation
**Command(s) run:**
- `make check` — all checks pass (repo-lint, ruff, 1296 tests, notebook-check, docs-check)

**Config:** N/A (skill files only, no Python code)

## Tests
- [x] `make check` passes
- No new Python code to test — skill is a set of markdown instruction files

## Expected impact
- Metrics impact: None (read-only skill)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-review-skill
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-review-skill
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre         d515ed2 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-review-skill  7bcd916 [codex/review-skill]
```

## Files Created
```
.claude/skills/reviewing-repo/
  SKILL.md                  # Main skill (frontmatter + 5-phase workflow)
  DISCOVERY_TEMPLATE.md     # Phase 1 sub-agent prompt
  VERIFICATION_TEMPLATE.md  # Phase 2 sub-agent prompt
  ISSUES_TEMPLATE.md        # Phase 3 sub-agent prompt
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] PR is focused (one concept)
- [x] `make check` passes