### PR TITLE
feat: add prompt self-healing to /review skill

### DIFF
--- a/.claude/skills/reviewing-repo/PROMPT_AUDIT_TEMPLATE.md
+++ b/.claude/skills/reviewing-repo/PROMPT_AUDIT_TEMPLATE.md
@@ -1,0 +1,126 @@
+# Prompt Audit — Sub-Agent Prompt Template
+
+Read the template below and pass it to a `general-purpose` sub-agent. The `{REPO_ROOT}` placeholder should be replaced with the actual repo root path.
+
+```
+You are auditing `docs/02_agent/REPO_REVIEW_PROMPT.md` for staleness. Your job
+is to test every verifiable claim in the protocol against the current repo state
+and report what's stale.
+
+**Working directory:** {REPO_ROOT}
+**Constraint:** Read-only. Do NOT edit any files.
+
+## Instructions
+
+1. Read `docs/02_agent/REPO_REVIEW_PROMPT.md` in full.
+2. For each testable claim below, run the verification command and compare.
+3. Report ONLY items where the prompt is inaccurate. Do not report items that match.
+
+## Audit Checklist
+
+### A. Module Health Imports (§1.3)
+
+For each `uv run python -c "from ..."` line in Section 1.3, run it and record
+pass/fail. Report any that FAIL — these are stale import paths.
+
+Also: run `ls -d src/bid_euchre/*/ | grep -v __pycache__` and compare against
+the modules covered by §1.3 imports. Report any modules that EXIST on disk but
+have NO corresponding import check in the prompt.
+
+### B. Gold Path Commands
+
+For each command in the GOLD PATH COMMANDS section, verify it would work:
+- `make` targets: run `make -n <target> 2>&1 | head -3` to check existence
+- `uv run python` commands: check the referenced scripts exist on disk
+- CLI flags: check that flags mentioned in examples match the script's argparse
+
+Report any commands that reference nonexistent targets, scripts, or flags.
+
+### C. Current Structure Tree
+
+Compare the directory tree in CURRENT STRUCTURE (§) against reality:
+- Run `ls -d src/bid_euchre/*/` and compare to the tree's module list
+- Run `ls docs/*/` and compare to the tree's docs directories
+- Check that all specific files mentioned (Makefile, pyproject.toml, etc.) exist
+
+Report structural differences (missing dirs, extra dirs, renamed items).
+
+### D. Make Check Composition
+
+The prompt claims `make check` includes specific sub-targets. Verify:
+```bash
+grep -A5 "^check:" Makefile
+```
+Compare the actual composition to what the prompt claims.
+
+### E. Repo-Linter Rule Categories
+
+The prompt lists rule categories in a table. Verify:
+- Run `grep "^def check_" scripts/lint_repo.py` to get actual rules
+- Check that every rule maps to one of the documented categories
+- Report any rules that don't fit existing categories or categories with no rules
+
+### F. Script and File References
+
+Find all file paths mentioned in the prompt and verify they exist:
+```bash
+grep -oE '[a-z_/]+\.(py|yaml|md|json)' docs/02_agent/REPO_REVIEW_PROMPT.md | sort -u
+```
+For each, check if it exists on disk. Report paths that don't exist.
+
+### G. Development Milestones
+
+The milestones table references PR number ranges and themes. Verify:
+- The latest era's PR range: check if PRs in that range exist via
+  `gh pr view <last_pr_number> --json title 2>/dev/null`
+- Check the "Current state" derive commands actually work
+
+## Output Format
+
+Return your results as structured markdown:
+
+### Prompt Staleness Report
+
+**Protocol version found:** <version string from the file>
+**Total stale items:** <N>
+
+### Stale Import Paths
+
+| Line | Import | Error | Fix |
+|------|--------|-------|-----|
+| <approx line#> | `from bid_euchre.X import Y` | <error message> | <correct import or "remove"> |
+
+### Missing Module Coverage
+
+| Module | On Disk | In Prompt §1.3 |
+|--------|---------|-----------------|
+| <module> | yes | no — needs import check added |
+
+### Stale Commands
+
+| Section | Command | Issue | Fix |
+|---------|---------|-------|-----|
+| <section name> | `<command>` | <what's wrong> | <correct command> |
+
+### Structure Drift
+
+| Item | In Prompt | On Disk | Fix |
+|------|-----------|---------|-----|
+| <item> | <what prompt says> | <what exists> | <edit needed> |
+
+### Stale File References
+
+| Path in Prompt | Exists? | Fix |
+|----------------|---------|-----|
+| <path> | no | <remove or update to correct path> |
+
+### Other Staleness
+
+| Location | Issue | Fix |
+|----------|-------|-----|
+| <section/line> | <description> | <proposed edit> |
+
+If no staleness is found in a category, omit that section entirely.
+If the prompt is fully accurate, return:
+"No staleness detected. Protocol is current."
+```

--- a/.claude/skills/reviewing-repo/SKILL.md
+++ b/.claude/skills/reviewing-repo/SKILL.md
@@ -17,11 +17,11 @@ Comprehensive repo health check following the protocol in `docs/02_agent/REPO_RE
 2. **Warn if not on main**: If on a feature branch, warn the user that the review will cover that branch's state, not the canonical repo.
 3. **Read the protocol**: Read `docs/02_agent/REPO_REVIEW_PROMPT.md` to confirm it exists and note its version.
 
-## Wave 1 — Parallel Data Gathering (Phases 1-3)
+## Wave 1 — Parallel Data Gathering (Phases 1-3 + Prompt Audit)
 
-Spawn **3 sub-agents in parallel** using the Task tool (`subagent_type: general-purpose`). Each agent works from the repo root and is **read-only** (no file edits).
+Spawn **4 sub-agents in parallel** using the Task tool (`subagent_type: general-purpose`). Each agent works from the repo root and is **read-only** (no file edits).
 
-**Important:** Launch all 3 in a single message so they run concurrently.
+**Important:** Launch all 4 in a single message so they run concurrently.
 
 ### Agent 1: Discovery (Phase 1)
 
@@ -40,6 +40,12 @@ Set `max_turns` to 40.
 Use the prompt template from [ISSUES_TEMPLATE.md](ISSUES_TEMPLATE.md).
 
 Set `max_turns` to 35.
+
+### Agent 4: Prompt Audit
+
+Use the prompt template from [PROMPT_AUDIT_TEMPLATE.md](PROMPT_AUDIT_TEMPLATE.md).
+
+Set `max_turns` to 25. This agent audits `docs/02_agent/REPO_REVIEW_PROMPT.md` itself for staleness — stale imports, dead commands, structure drift, missing module coverage. Its output feeds Phase 6.
 
 ## Gate Check
 
@@ -100,14 +106,72 @@ Ask the user:
 1. **Commit as PR** — commit the report and open a PR
 2. **Dive deeper** — investigate specific issues in more detail
 3. **Generate cleanup plan** — create a prioritized PR sequence for fixes
-4. **Done** — end the review
+4. **Update review prompt** — apply prompt maintenance fixes (if staleness found)
+5. **Done** — end the review
+
+## Phase 6 — Prompt Maintenance (Conditional)
+
+**Trigger:** Run this phase if the Prompt Audit agent (Agent 4) found any staleness, OR if the user selects "Update review prompt" in the follow-up.
+
+**Skip:** If the audit returned "No staleness detected", skip this phase entirely.
+
+### 6.1 Present Staleness Summary
+
+Show the user a concise table of what's stale:
+
+```markdown
+### Review Prompt Staleness Found
+
+| Category | Count | Example |
+|----------|-------|---------|
+| Stale imports | <N> | `from bid_euchre.X import Y` → module moved |
+| Missing module coverage | <N> | `utils/` has no import check in §1.3 |
+| Dead commands | <N> | `make <target>` no longer exists |
+| Structure drift | <N> | prompt tree missing `analysis/` directory |
+| Stale file references | <N> | `scripts/foo.py` referenced but deleted |
+```
+
+### 6.2 Ask for Approval
+
+Ask the user whether to apply fixes to `docs/02_agent/REPO_REVIEW_PROMPT.md`. This is a code change, so a worktree is required.
+
+### 6.3 Apply Fixes
+
+If approved:
+
+1. **Create a worktree** (or reuse the review worktree if one was already created for the report):
+   ```bash
+   git worktree add ../Bid-Euchre-prompt-maint -b codex/review-prompt-maint-<date>
+   ```
+
+2. **Apply each fix** from the audit report using targeted edits:
+   - **Stale imports**: Update `uv run python -c "from ..."` lines with correct paths
+   - **Missing modules**: Add new import check lines to §1.3
+   - **Dead commands**: Update or remove commands in Gold Path Commands
+   - **Structure drift**: Update the CURRENT STRUCTURE tree
+   - **Stale file refs**: Update or remove file path references
+
+3. **Bump version**: Update the version string at the top of the protocol (e.g., `3.2` → `3.3`)
+
+4. **Run `make check`** in the worktree to confirm no breakage
+
+5. **Commit and offer to PR**: Stage changes, commit with message like `docs: update REPO_REVIEW_PROMPT.md — fix N stale items`, push, and create PR
+
+### 6.4 Constraints
+
+- Only edit `docs/02_agent/REPO_REVIEW_PROMPT.md` — no other files
+- Preserve the protocol's structure and section numbering
+- Do not add hardcoded counts or PR numbers (the protocol is discovery-driven by design)
+- Every edit must be backed by evidence from the audit (no speculative changes)
+- If an audit finding is ambiguous (e.g., unclear whether a command should be updated or removed), ask the user
 
 ## Error Handling
 
 - **Sub-agent failure**: Mark the phase as "NOT COMPLETED — agent failed to return". Continue with available data. Note the gap in the executive summary.
 - **`make check` failure**: Abort review. Output failure summary with error details. Do not proceed to synthesis.
 - **Unrunnable commands**: Mark as "NOT RUN" with reason in verification evidence table.
-- **Stale protocol references**: If a command from the protocol fails, note it as a prompt staleness issue in the issue registry.
+- **Stale protocol references**: If a command from the protocol fails, note it as a prompt staleness issue in the issue registry. Phase 6 will collect these and offer to fix them.
+- **Prompt audit agent failure**: If Agent 4 fails, skip Phase 6. Note in the executive summary that prompt maintenance was not performed.
 
 ## Anti-Patterns to Avoid
 
@@ -120,7 +184,8 @@ Ask the user:
 
 ## Notes
 
-- Total estimated tool calls across all agents: 60-90
-- The review is read-only — only the final report file is written
+- Total estimated tool calls across all agents: 70-110 (including prompt audit)
+- The review is read-only — only the final report file is written (Phase 6 edits require separate approval)
 - Sub-agents use `general-purpose` type because they need Bash for `make check`, `uv run`, and `gh`
 - The protocol version is in `docs/02_agent/REPO_REVIEW_PROMPT.md` — check it at runtime
+- Phase 6 creates a self-healing loop: each review fixes the prompt for the next review


### PR DESCRIPTION
## Summary
- Add `PROMPT_AUDIT_TEMPLATE.md` — a 4th parallel sub-agent that audits `REPO_REVIEW_PROMPT.md` for staleness
- Add Phase 6 (Prompt Maintenance) to `SKILL.md` — collects audit findings and offers to fix the protocol
- Update Wave 1 from 3 to 4 parallel agents; update error handling and notes

## Why
The review protocol (v3.2) was designed to be drift-resilient, but the protocol file itself can still go stale — import paths change, Make targets get renamed, modules get added. Previously, agents would note failed commands as "prompt staleness issues" in the issue registry, but nothing actually fixed them. This creates a self-healing loop where each review keeps the protocol current for the next review.

## Repro / Validation
**Command(s) run:**
- `make check` — all checks pass (repo-lint, ruff, 1296 tests, notebook-check, docs-check)

**Config:** N/A (skill markdown files only, no Python code)

## Tests
- [x] `make check` passes
- No new Python code to test — skill is a set of markdown instruction files

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-review-prompt-maint
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-review-prompt-maint
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                    d419e56 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-review-prompt-maint 5befb5c [codex/review-prompt-maintenance]
```

## Files Changed
```
.claude/skills/reviewing-repo/SKILL.md                 # +72 lines: 4th agent, Phase 6, updated notes
.claude/skills/reviewing-repo/PROMPT_AUDIT_TEMPLATE.md  # NEW: 126-line prompt audit sub-agent template
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] PR is focused (one concept)
- [x] `make check` passes