### PR TITLE
refactor: rename high_offsuit → offsuit_non_ace_count

### DIFF
--- a/docs/02_agent/DIAGNOSTIC_TRICKS_EVALUATION.md
+++ b/docs/02_agent/DIAGNOSTIC_TRICKS_EVALUATION.md
@@ -73,7 +73,7 @@
 
 | Rank | Feature | Coefficient |
 |------|---------|-------------|
-| 1 | `high_offsuit` | -0.1764 |
+| 1 | `offsuit_non_ace_count` | -0.1764 |
 | 2 | `offsuit_aces` | +0.1764 |
 | 3 | `offsuit_suits_with_ace` | +0.1610 |
 | 4 | `offsuit_king_count_total` | -0.1092 |
@@ -112,7 +112,7 @@
 | Rank | Feature | Coefficient |
 |------|---------|-------------|
 | 1 | `offsuit_aces` | +0.1642 |
-| 2 | `high_offsuit` | -0.1642 |
+| 2 | `offsuit_non_ace_count` | -0.1642 |
 | 3 | `offsuit_best_rank_sum` | +0.1436 |
 | 4 | `offsuit_suits_with_ace` | +0.1394 |
 | 5 | `offsuit_secondbest_rank_sum` | +0.1186 |

--- a/docs/04_reports/phase0_bidless_20260207_r4.md
+++ b/docs/04_reports/phase0_bidless_20260207_r4.md
@@ -216,7 +216,7 @@ All contract types exceed the 0.10 R² threshold. Suit contracts show the strong
 | `void_count` | — | +0.2022 | — | 1 |
 | `trump_power_sum` | +0.1642 | +0.1019 | 6 | 6 |
 | `hand_value` | +0.1555 | +0.0991 | 8 | 7 |
-| `high_offsuit` | -0.1539 | -0.0985 | 9 | 8 |
+| `offsuit_non_ace_count` | -0.1539 | -0.0985 | 9 | 8 |
 | `max_suit_len` | -0.1454 | — | 10 | — |
 | `offsuit_length_3plus_count` | — | -0.1130 | — | 4 |
 | `num_singletons` | — | +0.1129 | — | 5 |
@@ -227,7 +227,7 @@ Notable: Greedy is driven by individual trump card ranks (`highest_trump_rank`, 
 
 | Feature | Greedy Coeff | Glutton Coeff | Greedy Rank | Glutton Rank |
 |---------|-------------|--------------|-------------|--------------|
-| `high_offsuit` | -0.1764 | -0.1642 | 1 | 2 |
+| `offsuit_non_ace_count` | -0.1764 | -0.1642 | 1 | 2 |
 | `offsuit_aces` | +0.1764 | +0.1642 | 2 | 1 |
 | `offsuit_suits_with_ace` | +0.1610 | +0.1394 | 3 | 4 |
 | `offsuit_king_count_total` | -0.1092 | -0.0964 | 4 | 7 |
@@ -238,7 +238,7 @@ Notable: Greedy is driven by individual trump card ranks (`highest_trump_rank`, 
 | `offsuit_suits_with_ace_and_king` | +0.0583 | +0.0608 | 9 | 9 |
 | `offsuit_tens_count` | +0.0564 | +0.0605 | 10 | 10 |
 
-HIGH contracts show strong strategy stability — the top features are ace/offsuit-dominated in both strategies. `offsuit_aces` and `high_offsuit` (inversely related by construction) dominate. Without trump, high cards in multiple suits are the primary determinant of trick-winning. Rankings are nearly identical between greedy and glutton, with minor ordering swaps.
+HIGH contracts show strong strategy stability — the top features are ace/offsuit-dominated in both strategies. `offsuit_aces` and `offsuit_non_ace_count` (inversely related by construction) dominate. Without trump, high cards in multiple suits are the primary determinant of trick-winning. Rankings are nearly identical between greedy and glutton, with minor ordering swaps.
 
 **Low Contracts — Top 10 Features:**
 

--- a/docs/04_reports/phase0_bidless_20260207_r5.md
+++ b/docs/04_reports/phase0_bidless_20260207_r5.md
@@ -220,7 +220,7 @@ All contract types exceed the 0.10 R² threshold. Suit contracts show the strong
 | `void_count` | — | +0.2022 | — | 1 |
 | `trump_power_sum` | +0.1642 | +0.1019 | 6 | 6 |
 | `hand_value` | +0.1555 | +0.0991 | 8 | 7 |
-| `high_offsuit` | -0.1539 | -0.0985 | 9 | 8 |
+| `offsuit_non_ace_count` | -0.1539 | -0.0985 | 9 | 8 |
 | `max_suit_len` | -0.1454 | — | 10 | — |
 | `offsuit_length_3plus_count` | — | -0.1130 | — | 4 |
 | `num_singletons` | — | +0.1129 | — | 5 |
@@ -231,7 +231,7 @@ Notable: Greedy is driven by individual trump card ranks (`highest_trump_rank`, 
 
 | Feature | Greedy Coeff | Glutton Coeff | Greedy Coeff Rank | Glutton Coeff Rank |
 |---------|-------------|--------------|-------------------|-------------------|
-| `high_offsuit` | -0.1764 | -0.1642 | 1 | 2 |
+| `offsuit_non_ace_count` | -0.1764 | -0.1642 | 1 | 2 |
 | `offsuit_aces` | +0.1764 | +0.1642 | 2 | 1 |
 | `offsuit_suits_with_ace` | +0.1610 | +0.1394 | 3 | 4 |
 | `offsuit_king_count_total` | -0.1092 | -0.0964 | 4 | 7 |
@@ -242,7 +242,7 @@ Notable: Greedy is driven by individual trump card ranks (`highest_trump_rank`, 
 | `offsuit_suits_with_ace_and_king` | +0.0583 | +0.0608 | 9 | 9 |
 | `offsuit_tens_count` | +0.0564 | +0.0605 | 10 | 10 |
 
-HIGH contracts show strong strategy stability — the top features are ace/offsuit-dominated in both strategies. `offsuit_aces` and `high_offsuit` (inversely related by construction) dominate. Without trump, high cards in multiple suits are the primary determinant of trick-winning. Rankings are nearly identical between greedy and glutton, with minor ordering swaps.
+HIGH contracts show strong strategy stability — the top features are ace/offsuit-dominated in both strategies. `offsuit_aces` and `offsuit_non_ace_count` (inversely related by construction) dominate. Without trump, high cards in multiple suits are the primary determinant of trick-winning. Rankings are nearly identical between greedy and glutton, with minor ordering swaps.
 
 **Low Contracts — Top 10 Features:**
 
@@ -271,7 +271,7 @@ The §6c tables rank features by Ridge coefficient magnitude. This complementary
 
 | Feature | Pearson r | Greedy Coeff | Glutton Coeff |
 |---------|-----------|--------------|---------------|
-| `high_offsuit` | -0.4212 | -0.1539 | -0.0985 |
+| `offsuit_non_ace_count` | -0.4212 | -0.1539 | -0.0985 |
 | `hand_value` | +0.3996 | +0.1555 | +0.0991 |
 | `trump_power_sum` | +0.3544 | +0.1642 | +0.1019 |
 | `trump_count_x_offsuit_ace` | +0.3312 | +0.0800 | +0.0773 |
@@ -282,13 +282,13 @@ The §6c tables rank features by Ridge coefficient magnitude. This complementary
 | `bowers` | +0.2980 | +0.2082 | +0.1296 |
 | `trump_count_x_void_count` | +0.2823 | +0.2792 | +0.0474 |
 
-`high_offsuit` has the strongest correlation (r = -0.42) — more offsuit high cards means fewer trump, reducing trick-taking in suit contracts. Trump features dominate the list, consistent with §6c. Note `third_highest_trump_rank` has a positive correlation but a negative Ridge coefficient — it correlates with having many trump cards (positive for tricks) but conditional on trump count, a higher third-trump rank means the trump holding is top-heavy, which the Ridge model penalizes.
+`offsuit_non_ace_count` has the strongest correlation (r = -0.42) — more offsuit high cards means fewer trump, reducing trick-taking in suit contracts. Trump features dominate the list, consistent with §6c. Note `third_highest_trump_rank` has a positive correlation but a negative Ridge coefficient — it correlates with having many trump cards (positive for tricks) but conditional on trump count, a higher third-trump rank means the trump holding is top-heavy, which the Ridge model penalizes.
 
 **High Contracts — Top 10 by Pearson Correlation:**
 
 | Feature | Pearson r | Greedy Coeff | Glutton Coeff |
 |---------|-----------|--------------|---------------|
-| `high_offsuit` | -0.4459 | -0.1764 | -0.1642 |
+| `offsuit_non_ace_count` | -0.4459 | -0.1764 | -0.1642 |
 | `offsuit_aces` | +0.4459 | +0.1764 | +0.1642 |
 | `offsuit_suits_with_ace` | +0.4029 | +0.1610 | +0.1394 |
 | `hand_value` | +0.3443 | +0.0548 | +0.0535 |
@@ -299,7 +299,7 @@ The §6c tables rank features by Ridge coefficient magnitude. This complementary
 | `offsuit_suits_with_ace_and_king` | +0.2246 | +0.0583 | +0.0608 |
 | `low_card_count` | -0.2116 | -0.0057 | -0.0146 |
 
-Correlation and Ridge rankings align closely here — ace-related features dominate both. `offsuit_aces` and `high_offsuit` are mirror images (r = +0.45 and -0.45), reflecting that in no-trump HIGH contracts, aces are the primary trick-winning mechanism. Strategy agreement is strong: greedy and glutton coefficients track each other closely.
+Correlation and Ridge rankings align closely here — ace-related features dominate both. `offsuit_aces` and `offsuit_non_ace_count` are mirror images (r = +0.45 and -0.45), reflecting that in no-trump HIGH contracts, aces are the primary trick-winning mechanism. Strategy agreement is strong: greedy and glutton coefficients track each other closely.
 
 **Low Contracts — Top 10 by Pearson Correlation:**
 
@@ -314,9 +314,9 @@ Correlation and Ridge rankings align closely here — ace-related features domin
 | `offsuit_best_rank_sum` | +0.1952 | +0.0949 | +0.1726 |
 | `double_ten_jack_count` | +0.1915 | +0.0695 | +0.0475 |
 | `offsuit_suits_with_ace_and_king` | -0.1411 | -0.0188 | -0.0207 |
-| `high_offsuit` | +0.1311 | -0.0410 | -0.0407 |
+| `offsuit_non_ace_count` | +0.1311 | -0.0410 | -0.0407 |
 
-`offsuit_tens_count` dominates both by correlation (r = +0.45) and by Ridge coefficient (+0.63/+0.58), confirming it as the single most important feature for LOW contracts. `low_card_count` shows an interesting divergence: high positive correlation (r = +0.31) but a small *negative* Ridge coefficient — its signal is absorbed by `offsuit_tens_count` and `rank_sum` in the multivariate model. `high_offsuit` flips sign from §6c's suit contracts (negative there, positive here), reflecting that in LOW contracts, having more high-ranked offsuit cards paradoxically helps because the hand evaluator's `high_offsuit` feature captures suit distribution properties that matter differently when 10s beat aces.
+`offsuit_tens_count` dominates both by correlation (r = +0.45) and by Ridge coefficient (+0.63/+0.58), confirming it as the single most important feature for LOW contracts. `low_card_count` shows an interesting divergence: high positive correlation (r = +0.31) but a small *negative* Ridge coefficient — its signal is absorbed by `offsuit_tens_count` and `rank_sum` in the multivariate model. `offsuit_non_ace_count` flips sign from §6c's suit contracts (negative there, positive here), reflecting that in LOW contracts, having more high-ranked offsuit cards paradoxically helps because the hand evaluator's `offsuit_non_ace_count` feature captures suit distribution properties that matter differently when 10s beat aces.
 
 ### 6e. Caveats
 

--- a/docs/archive/FEATURES.md
+++ b/docs/archive/FEATURES.md
@@ -20,7 +20,7 @@ The `get_hand_features()` function extracts 40 comprehensive features from each 
 | `bowers` | int | 0-4 | Total bowers (RB + LB) |
 | `trump_count` | int | 0-10 | Total trump cards (suit contracts only) |
 | `offsuit_aces` | int | 0-6 | Aces in non-trump suits |
-| `high_offsuit` | int | 0-10 | High offsuit cards (K, Q, J, T) |
+| `offsuit_non_ace_count` | int | 0-10 | High offsuit cards (K, Q, J, T) |
 | `rank_sum` | int | 10-50 | Sum of rank strengths (+1 each) |
 
 ---
@@ -210,7 +210,7 @@ The 5 legacy features remain unchanged:
 - `bowers`
 - `trump_count`
 - `offsuit_aces`
-- `high_offsuit`
+- `offsuit_non_ace_count`
 - `rank_sum`
 
 All existing code continues to work. New features are additive.

--- a/docs/archive/FEATURE_EXPANSION_2025.md
+++ b/docs/archive/FEATURE_EXPANSION_2025.md
@@ -16,7 +16,7 @@ Expanded hand feature extraction from 5 legacy features to **40 comprehensive fe
 ### Features Added: 35 New Features
 
 **Before**: 5 features
-- `bowers`, `trump_count`, `offsuit_aces`, `high_offsuit`, `rank_sum`
+- `bowers`, `trump_count`, `offsuit_aces`, `offsuit_non_ace_count`, `rank_sum`
 
 **After**: 40 features
 - All legacy features (backward compatible)

--- a/docs/archive/REPORTING.md
+++ b/docs/archive/REPORTING.md
@@ -299,7 +299,7 @@ PYTHONPATH=src python experiments/generate_hand_eval_dashboard.py \
 - `bowers` - Number of bowers (right + left)
 - `trump_count` - Total trump cards
 - `offsuit_aces` - Number of offsuit aces
-- `high_offsuit` - High offsuit cards (K, Q, J, T)
+- `offsuit_non_ace_count` - High offsuit cards (K, Q, J, T)
 - `rank_sum` - Sum of card ranks
 
 **Note**: The dashboard is designed to handle 40+ features from `hand_eval.py`. Currently, only 5 legacy features are logged in JSONL files. When logging is updated to include all features, the dashboard will automatically display them.

--- a/docs/archive/STRATEGY_COMPARISON_RESULTS.md
+++ b/docs/archive/STRATEGY_COMPARISON_RESULTS.md
@@ -118,7 +118,7 @@ data/runs/strategy_comparison_42_20251215_215239/dashboard/
 Each dashboard includes:
 - Trick count distribution (PMF)
 - Hand score by trick count (violin)
-- Feature vs tricks (bowers, trump_count, offsuit_aces, high_offsuit)
+- Feature vs tricks (bowers, trump_count, offsuit_aces, offsuit_non_ace_count)
 - Score vs tricks (No-Trump and Suit contracts)
 - Suit symmetry analysis
 - Win rate by contract

--- a/docs/archive/schemas/hand_record.md
+++ b/docs/archive/schemas/hand_record.md
@@ -63,10 +63,10 @@ Emitted at the end of each hand.
   "t1": 4,
   "scores": [520, 410, 600, 390],
   "features": [
-    {"bowers": 1, "trump_count": 4, "offsuit_aces": 2, "high_offsuit": 1, "rank_sum": 32},
-    {"bowers": 0, "trump_count": 3, "offsuit_aces": 1, "high_offsuit": 2, "rank_sum": 28},
-    {"bowers": 1, "trump_count": 2, "offsuit_aces": 3, "high_offsuit": 0, "rank_sum": 35},
-    {"bowers": 0, "trump_count": 1, "offsuit_aces": 0, "high_offsuit": 3, "rank_sum": 25}
+    {"bowers": 1, "trump_count": 4, "offsuit_aces": 2, "offsuit_non_ace_count": 1, "rank_sum": 32},
+    {"bowers": 0, "trump_count": 3, "offsuit_aces": 1, "offsuit_non_ace_count": 2, "rank_sum": 28},
+    {"bowers": 1, "trump_count": 2, "offsuit_aces": 3, "offsuit_non_ace_count": 0, "rank_sum": 35},
+    {"bowers": 0, "trump_count": 1, "offsuit_aces": 0, "offsuit_non_ace_count": 3, "rank_sum": 25}
   ],
   "hands": [
     [["H","J"], ["H","K"], ["H","Q"], ["H","A"], ["C","A"], ["D","A"], ["S","T"], ["S","Q"], ["C","T"], ["D","Q"]],
@@ -109,7 +109,7 @@ Emitted at the end of each hand.
 | `bowers` | int | Number of bowers (0-4 in double deck) |
 | `trump_count` | int | Number of trump cards (0-10) |
 | `offsuit_aces` | int | Number of non-trump aces (0-6) |
-| `high_offsuit` | int | Count of high non-trump cards |
+| `offsuit_non_ace_count` | int | Count of high non-trump cards |
 | `rank_sum` | int | Sum of card ranks |
 
 #### Hands Format (Schema v3+)

--- a/src/bid_euchre/features/hand_eval.py
+++ b/src/bid_euchre/features/hand_eval.py
@@ -12,6 +12,7 @@ from ..core.cards import (
 #  FEATURE EXTRACTION
 # ===========================
 
+
 def get_hand_features(
     hand: List[Card],
     contract_type: str,
@@ -44,7 +45,7 @@ def get_hand_features(
     bowers = 0
     trump_count = 0
     offsuit_aces = 0
-    high_offsuit = 0
+    offsuit_non_ace_count = 0
     rank_sum = 0
 
     # Trump features (suit contracts only)
@@ -64,7 +65,7 @@ def get_hand_features(
 
     # High/Low card counts (all contracts)
     high_card_count = 0  # Aces + Kings
-    low_card_count = 0   # Jacks + Tens
+    low_card_count = 0  # Jacks + Tens
 
     # ===========================
     # First Pass: Categorize Cards
@@ -126,14 +127,14 @@ def get_hand_features(
                     offsuit_aces += 1
                 elif card.rank == "K":
                     offsuit_king_count_total += 1
-                    high_offsuit += 1
+                    offsuit_non_ace_count += 1
                 elif card.rank == "Q":
                     offsuit_queen_count_total += 1
-                    high_offsuit += 1
+                    offsuit_non_ace_count += 1
                 elif card.rank == "J":
-                    high_offsuit += 1
+                    offsuit_non_ace_count += 1
                 elif card.rank == "T":
-                    high_offsuit += 1
+                    offsuit_non_ace_count += 1
         else:
             # HIGH / LOW contracts - all cards are "offsuit"
             offsuit_by_suit[card.suit].append(card)
@@ -142,14 +143,14 @@ def get_hand_features(
                 offsuit_aces += 1
             elif card.rank == "K":
                 offsuit_king_count_total += 1
-                high_offsuit += 1
+                offsuit_non_ace_count += 1
             elif card.rank == "Q":
                 offsuit_queen_count_total += 1
-                high_offsuit += 1
+                offsuit_non_ace_count += 1
             elif card.rank == "J":
-                high_offsuit += 1
+                offsuit_non_ace_count += 1
             elif card.rank == "T":
-                high_offsuit += 1
+                offsuit_non_ace_count += 1
 
     # ===========================
     # Trump Features (Suit Contracts)
@@ -160,8 +161,12 @@ def get_hand_features(
     # Top 3 trump ranks (sorted descending, pad with 0s)
     trump_ranks_sorted = sorted(trump_ranks, reverse=True)
     highest_trump_rank = trump_ranks_sorted[0] if len(trump_ranks_sorted) > 0 else 0
-    second_highest_trump_rank = trump_ranks_sorted[1] if len(trump_ranks_sorted) > 1 else 0
-    third_highest_trump_rank = trump_ranks_sorted[2] if len(trump_ranks_sorted) > 2 else 0
+    second_highest_trump_rank = (
+        trump_ranks_sorted[1] if len(trump_ranks_sorted) > 1 else 0
+    )
+    third_highest_trump_rank = (
+        trump_ranks_sorted[2] if len(trump_ranks_sorted) > 2 else 0
+    )
 
     # Trump power
     trump_power_sum = sum(trump_ranks)
@@ -214,8 +219,7 @@ def get_hand_features(
 
     # Offsuit tens count
     offsuit_tens_count = sum(
-        1 for cards in offsuit_by_suit.values()
-        for c in cards if c.rank == "T"
+        1 for cards in offsuit_by_suit.values() for c in cards if c.rank == "T"
     )
 
     # Best and second-best offsuit rank sums
@@ -225,8 +229,12 @@ def get_hand_features(
         offsuit_rank_sums.append(suit_rank_sum)
 
     offsuit_rank_sums_sorted = sorted(offsuit_rank_sums, reverse=True)
-    offsuit_best_rank_sum = offsuit_rank_sums_sorted[0] if len(offsuit_rank_sums_sorted) > 0 else 0
-    offsuit_secondbest_rank_sum = offsuit_rank_sums_sorted[1] if len(offsuit_rank_sums_sorted) > 1 else 0
+    offsuit_best_rank_sum = (
+        offsuit_rank_sums_sorted[0] if len(offsuit_rank_sums_sorted) > 0 else 0
+    )
+    offsuit_secondbest_rank_sum = (
+        offsuit_rank_sums_sorted[1] if len(offsuit_rank_sums_sorted) > 1 else 0
+    )
 
     # ===========================
     # High/Low Specific Features
@@ -241,8 +249,12 @@ def get_hand_features(
             double_ten_jack_count += 1
 
     # Interaction terms (only meaningful for suit contracts)
-    trump_count_x_void_count = trump_count * void_count if contract_type == "suit" else 0
-    trump_count_x_offsuit_ace = trump_count * offsuit_aces if contract_type == "suit" else 0
+    trump_count_x_void_count = (
+        trump_count * void_count if contract_type == "suit" else 0
+    )
+    trump_count_x_offsuit_ace = (
+        trump_count * offsuit_aces if contract_type == "suit" else 0
+    )
 
     # Hand Value (used for OLSa HV / OLSa SR)
     # score_hand_scalar handles all contract types correctly:
@@ -259,10 +271,9 @@ def get_hand_features(
         "bowers": bowers,
         "trump_count": trump_count,
         "offsuit_aces": offsuit_aces,
-        "high_offsuit": high_offsuit,
+        "offsuit_non_ace_count": offsuit_non_ace_count,
         "rank_sum": rank_sum,
         "hand_value": hand_value,
-
         # Trump features (suit contracts)
         "trump_rb_count": trump_rb_count,
         "trump_lb_count": trump_lb_count,
@@ -278,14 +289,12 @@ def get_hand_features(
         "trump_power_avg": trump_power_avg,
         "trump_duplicate_pairs": trump_duplicate_pairs,
         "top_trump_sum": top_trump_sum,
-
         # Offsuit control
         "offsuit_king_count_total": offsuit_king_count_total,
         "offsuit_queen_count_total": offsuit_queen_count_total,
         "offsuit_suits_with_ace": offsuit_suits_with_ace,
         "offsuit_suits_with_double_ace": offsuit_suits_with_double_ace,
         "offsuit_suits_with_ace_and_king": offsuit_suits_with_ace_and_king,
-
         # Distribution features
         "void_count": void_count,
         "max_suit_len": max_suit_len,
@@ -298,7 +307,6 @@ def get_hand_features(
         "offsuit_length_3plus_count": offsuit_length_3plus_count,
         "offsuit_best_rank_sum": offsuit_best_rank_sum,
         "offsuit_secondbest_rank_sum": offsuit_secondbest_rank_sum,
-
         # High/Low specific
         "double_ten_jack_count": double_ten_jack_count,
         "high_card_count": high_card_count,
@@ -311,6 +319,7 @@ def get_hand_features(
 # ===========================
 #  OPTION A: SCALAR SCORE
 # ===========================
+
 
 def score_hand_scalar(
     hand: List[Card],
@@ -381,6 +390,7 @@ def score_hand_scalar(
 #  OPTION B: TUPLE SCORE
 # ===========================
 
+
 def score_hand_tuple(
     hand: List[Card],
     contract_type: str,
@@ -393,14 +403,14 @@ def score_hand_tuple(
     a single scalar.
 
     Returns:
-        (bowers, trump_count, offsuit_aces, high_offsuit, rank_sum)
+        (bowers, trump_count, offsuit_aces, offsuit_non_ace_count, rank_sum)
     """
     f = get_hand_features(hand, contract_type, trump_suit)
     return (
         f["bowers"],
         f["trump_count"],
         f["offsuit_aces"],
-        f["high_offsuit"],
+        f["offsuit_non_ace_count"],
         f["rank_sum"],
     )
 
@@ -408,6 +418,7 @@ def score_hand_tuple(
 # ===========================
 #  MAIN ENTRY POINT (CHOOSE MODE)
 # ===========================
+
 
 def score_hand(
     hand: List[Card],

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -20,7 +20,19 @@ class TestEndToEndSimulation:
         # Play one complete hand
         result = simulation.play_single_hand("suit", "H", strategy=BasicStrategy())
 
-        team0_tricks, team1_tricks, all_scores, all_features, initial_leader, starting_hands, _, _, _, _, _ = result
+        (
+            team0_tricks,
+            team1_tricks,
+            all_scores,
+            all_features,
+            initial_leader,
+            starting_hands,
+            _,
+            _,
+            _,
+            _,
+            _,
+        ) = result
 
         # Basic validation
         assert isinstance(team0_tricks, int)
@@ -43,11 +55,18 @@ class TestEndToEndSimulation:
         assert isinstance(all_features, list)
         assert len(all_features) == 4
         # Check for core features (allow additional features from hand_eval evolution)
-        core_features = {"bowers", "trump_count", "offsuit_aces", "high_offsuit", "rank_sum"}
+        core_features = {
+            "bowers",
+            "trump_count",
+            "offsuit_aces",
+            "offsuit_non_ace_count",
+            "rank_sum",
+        }
         for features in all_features:
             assert isinstance(features, dict)
-            assert core_features.issubset(set(features.keys())), \
-                f"Missing core features. Expected {core_features}, got {set(features.keys())}"
+            assert core_features.issubset(
+                set(features.keys())
+            ), f"Missing core features. Expected {core_features}, got {set(features.keys())}"
 
         # Validate starting_hands
         assert isinstance(starting_hands, list)
@@ -63,23 +82,29 @@ class TestEndToEndSimulation:
         # Create temporary directory for test output
         with tempfile.TemporaryDirectory() as temp_dir:
             # Get repo root (tests/integration/../../ = repo root)
-            repo_root = os.path.join(os.path.dirname(__file__), '..', '..')
+            repo_root = os.path.join(os.path.dirname(__file__), "..", "..")
 
             # Run the experiment script with command line arguments
             cmd = [
                 sys.executable,
-                os.path.join(repo_root, 'experiments', 'run_experiment.py'),
-                '--config',
-                os.path.join(repo_root, 'experiments', 'configs', 'baseline_greedy.yaml'),
-                '--n_per', '50',
-                '--seed', '42',
-                '--run-dir', temp_dir,
-                '--log-level', 'hand',
+                os.path.join(repo_root, "experiments", "run_experiment.py"),
+                "--config",
+                os.path.join(
+                    repo_root, "experiments", "configs", "baseline_greedy.yaml"
+                ),
+                "--n_per",
+                "50",
+                "--seed",
+                "42",
+                "--run-dir",
+                temp_dir,
+                "--log-level",
+                "hand",
             ]
 
             # Set PYTHONPATH for the subprocess
             env = os.environ.copy()
-            env['PYTHONPATH'] = os.path.join(repo_root, 'src')
+            env["PYTHONPATH"] = os.path.join(repo_root, "src")
 
             result = subprocess.run(cmd, env=env, capture_output=True, text=True)
 
@@ -87,7 +112,9 @@ class TestEndToEndSimulation:
             assert result.returncode == 0, f"Command failed: {result.stderr}"
 
             # Check that a run folder was created and contains expected results
-            run_folders = [p for p in os.listdir(temp_dir) if p.startswith("baseline_greedy_")]
+            run_folders = [
+                p for p in os.listdir(temp_dir) if p.startswith("baseline_greedy_")
+            ]
             assert len(run_folders) >= 1
             run_folder = os.path.join(temp_dir, sorted(run_folders)[-1])
 
@@ -107,11 +134,14 @@ class TestEndToEndSimulation:
                 expected_file = os.path.join(results_dir, filename)
                 assert os.path.exists(expected_file), f"Missing output file: {filename}"
 
-                with open(expected_file, 'r') as f:
+                with open(expected_file, "r") as f:
                     data = json.load(f)
                     assert data["hands"] == 50
                     assert "contract_type" in data
-                    assert "trump_suit" in data or data["contract_type"] in ["high", "low"]
+                    assert "trump_suit" in data or data["contract_type"] in [
+                        "high",
+                        "low",
+                    ]
 
             # Ensure logs exist
             logs_dir = os.path.join(run_folder, "logs")
@@ -199,7 +229,6 @@ class TestDataPipeline:
         assert meta["n_per"] == 50
         assert meta["seed"] == 1
 
-
     def test_simulation_reproducibility(self):
         """Test that simulations with same seed produce same results."""
         # Note: Current implementation doesn't support seeding
@@ -226,7 +255,9 @@ class TestErrorHandling:
         with pytest.raises(ValueError):
             simulation.simulate_many_hands(10, "suit", None)
 
-    @pytest.mark.xfail(reason="Trump suit validation for high/low contracts not yet implemented")
+    @pytest.mark.xfail(
+        reason="Trump suit validation for high/low contracts not yet implemented"
+    )
     def test_trump_provided_for_no_trump_contract(self):
         """Test error when trump suit provided for no-trump contracts."""
         with pytest.raises(ValueError):

--- a/tests/integration/test_simulation_validation.py
+++ b/tests/integration/test_simulation_validation.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 pytestmark = pytest.mark.statistical
@@ -15,19 +14,28 @@ class TestSimulationStatistics:
         return simulation.simulate_many_hands(
             n=1000,  # Small sample for faster tests
             contract_type="suit",
-            trump_suit="H"
+            trump_suit="H",
         )
 
     def test_simulation_returns_expected_keys(self, small_simulation_results):
         """Test that simulation results contain all expected keys."""
         results = small_simulation_results
         expected_keys = {
-            "hands", "contract_type", "trump_suit",
-            "avg_team0", "avg_team1", "distribution_team0",
+            "hands",
+            "contract_type",
+            "trump_suit",
+            "avg_team0",
+            "avg_team1",
+            "distribution_team0",
             # New: aggregated across all 4 players
-            "avg_score", "score_buckets", "feature_buckets", "player_samples",
+            "avg_score",
+            "score_buckets",
+            "feature_buckets",
+            "player_samples",
             # Backward compatibility aliases
-            "avg_score_player0", "score_buckets_player0", "feature_buckets_player0"
+            "avg_score_player0",
+            "score_buckets_player0",
+            "feature_buckets_player0",
         }
         # Results schema is additive; tests should not fail on new keys.
         missing = expected_keys - set(results.keys())
@@ -104,9 +112,16 @@ class TestSimulationStatistics:
         feature_buckets = small_simulation_results["feature_buckets_player0"]
 
         # Should have at least the core features (may have more from hand_eval evolution)
-        core_features = {"bowers", "trump_count", "offsuit_aces", "high_offsuit", "rank_sum"}
-        assert core_features.issubset(set(feature_buckets.keys())), \
-            f"Missing core features. Expected {core_features}, got {set(feature_buckets.keys())}"
+        core_features = {
+            "bowers",
+            "trump_count",
+            "offsuit_aces",
+            "offsuit_non_ace_count",
+            "rank_sum",
+        }
+        assert core_features.issubset(
+            set(feature_buckets.keys())
+        ), f"Missing core features. Expected {core_features}, got {set(feature_buckets.keys())}"
 
         # Each feature should have some buckets
         for feature_name, buckets in feature_buckets.items():
@@ -132,7 +147,9 @@ class TestSimulationStatistics:
         difference = abs(suit_result["avg_team0"] - high_result["avg_team0"])
         # With 500 hands, we expect some variation. Use a very lenient threshold
         # since natural statistical variance can produce similar results
-        assert difference >= 0, f"Contract types gave unexpected negative difference: {difference:.3f}"
+        assert (
+            difference >= 0
+        ), f"Contract types gave unexpected negative difference: {difference:.3f}"
 
 
 class TestSimulationEdgeCases:
@@ -160,7 +177,9 @@ class TestSimulationEdgeCases:
         with pytest.raises(ValueError):
             simulation.simulate_many_hands(10, "suit", None)
 
-    @pytest.mark.xfail(reason="Trump suit validation for high/low contracts not yet implemented")
+    @pytest.mark.xfail(
+        reason="Trump suit validation for high/low contracts not yet implemented"
+    )
     def test_simulation_no_trump_contracts_with_trump(self):
         """Test that high/low contracts reject trump suit."""
         with pytest.raises(ValueError):
@@ -176,6 +195,7 @@ class TestDataValidation:
     def test_json_serializable(self):
         """Test that results can be JSON serialized."""
         import json
+
         result = simulation.simulate_many_hands(100, "suit", "H")
 
         # Should be able to serialize without errors
@@ -228,20 +248,21 @@ class TestRollupSummarySchema:
             "total_hands": 100,
             "avg_tricks": 4.23,
             "reason": None,
-            "bad_files": None
+            "bad_files": None,
         }
 
         # Drift detection requires these fields to be present and correct types
         required_fields = {
             "config": str,
             "status": str,
-            "avg_tricks": (float, type(None))
+            "avg_tricks": (float, type(None)),
         }
 
         for field, expected_type in required_fields.items():
             assert field in mock_summary_entry, f"Missing required field: {field}"
-            assert isinstance(mock_summary_entry[field], expected_type), \
-                f"Field {field} has wrong type: {type(mock_summary_entry[field])}, expected {expected_type}"
+            assert isinstance(
+                mock_summary_entry[field], expected_type
+            ), f"Field {field} has wrong type: {type(mock_summary_entry[field])}, expected {expected_type}"
 
     def test_rollup_summary_entry_success_case(self):
         """Test successful rollup summary entry structure."""
@@ -252,7 +273,7 @@ class TestRollupSummarySchema:
             "total_hands": 500,
             "avg_tricks": 5.12,
             "reason": None,
-            "bad_files": None
+            "bad_files": None,
         }
 
         # Validate required drift fields
@@ -270,7 +291,7 @@ class TestRollupSummarySchema:
             "total_hands": None,
             "avg_tricks": None,
             "reason": "Simulation crashed",
-            "bad_files": ["meta.json"]
+            "bad_files": ["meta.json"],
         }
 
         # Even failed entries should have the required drift fields
@@ -283,13 +304,19 @@ class TestRollupSummarySchema:
         test_cases = [
             "baseline_matchups.yaml",
             "auction_smoke.yaml",
-            "custom_strategy.yaml"
+            "custom_strategy.yaml",
         ]
 
         for config_name in test_cases:
-            assert "/" not in config_name, f"Config name contains path separator: {config_name}"
-            assert "\\" not in config_name, f"Config name contains path separator: {config_name}"
-            assert config_name.endswith(".yaml"), f"Config name should end with .yaml: {config_name}"
+            assert (
+                "/" not in config_name
+            ), f"Config name contains path separator: {config_name}"
+            assert (
+                "\\" not in config_name
+            ), f"Config name contains path separator: {config_name}"
+            assert config_name.endswith(
+                ".yaml"
+            ), f"Config name should end with .yaml: {config_name}"
 
     def test_rollup_summary_avg_tricks_is_numeric_when_present(self):
         """Test that avg_tricks is numeric when not None."""
@@ -302,6 +329,8 @@ class TestRollupSummarySchema:
                 "total_hands": 100,
                 "avg_tricks": value,
                 "reason": None,
-                "bad_files": None
+                "bad_files": None,
             }
-            assert isinstance(entry["avg_tricks"], (int, float)), f"avg_tricks should be numeric: {value}"
+            assert isinstance(
+                entry["avg_tricks"], (int, float)
+            ), f"avg_tricks should be numeric: {value}"

--- a/tests/unit/test_hand_eval.py
+++ b/tests/unit/test_hand_eval.py
@@ -23,6 +23,7 @@ from bid_euchre.features.hand_eval import (
 # Test Fixtures
 # ============================================================================
 
+
 @pytest.fixture
 def empty_hand():
     """Empty hand for boundary testing."""
@@ -110,6 +111,7 @@ def weak_hand():
 # Test: Basic Feature Extraction
 # ============================================================================
 
+
 class TestBasicFeatures:
     """Test basic feature extraction for all contract types."""
 
@@ -166,7 +168,7 @@ class TestBasicFeatures:
             Card("D", "J"),
             Card("C", "T"),
             Card("S", "A"),  # Weak in low
-            Card("H", "K"),   # Weak in low
+            Card("H", "K"),  # Weak in low
         ]
 
         features = get_hand_features(hand, contract_type="low", trump_suit=None)
@@ -182,6 +184,7 @@ class TestBasicFeatures:
 # ============================================================================
 # Test: Trump Strength Features (Suit Contracts Only)
 # ============================================================================
+
 
 class TestTrumpFeatures:
     """Test trump-specific features for suit contracts."""
@@ -264,7 +267,9 @@ class TestTrumpFeatures:
 
     def test_no_trump_cards(self, no_trump_hand):
         """Test hand with no trump cards."""
-        features = get_hand_features(no_trump_hand, contract_type="suit", trump_suit="H")
+        features = get_hand_features(
+            no_trump_hand, contract_type="suit", trump_suit="H"
+        )
 
         assert features["trump_count"] == 0
         assert features["trump_power_sum"] == 0
@@ -275,6 +280,7 @@ class TestTrumpFeatures:
 # ============================================================================
 # Test: Offsuit Control Features
 # ============================================================================
+
 
 class TestOffsuitControl:
     """Test offsuit control and high card features."""
@@ -306,7 +312,7 @@ class TestOffsuitControl:
 
         assert features["offsuit_king_count_total"] == 2
         assert features["offsuit_queen_count_total"] == 1
-        assert features["high_offsuit"] == 3  # 2 kings + 1 queen
+        assert features["offsuit_non_ace_count"] == 3  # 2 kings + 1 queen
 
     def test_double_ace_suit(self):
         """Test detection of suits with double aces."""
@@ -346,12 +352,15 @@ class TestOffsuitControl:
 
         features = get_hand_features(hand, contract_type="high", trump_suit=None)
 
-        assert features["offsuit_best_rank_sum"] > features["offsuit_secondbest_rank_sum"]
+        assert (
+            features["offsuit_best_rank_sum"] > features["offsuit_secondbest_rank_sum"]
+        )
 
 
 # ============================================================================
 # Test: Distribution Features
 # ============================================================================
+
 
 class TestDistribution:
     """Test hand distribution features."""
@@ -382,7 +391,9 @@ class TestDistribution:
 
     def test_suit_length_ordering(self, balanced_hand):
         """Test suit length ordering (longest to shortest)."""
-        features = get_hand_features(balanced_hand, contract_type="high", trump_suit=None)
+        features = get_hand_features(
+            balanced_hand, contract_type="high", trump_suit=None
+        )
 
         # Should be ordered longest to shortest
         assert features["max_suit_len"] >= features["second_suit_len"]
@@ -406,6 +417,7 @@ class TestDistribution:
 # ============================================================================
 # Test: High/Low Specific Features
 # ============================================================================
+
 
 class TestHighLowFeatures:
     """Test features specific to high and low contracts."""
@@ -457,6 +469,7 @@ class TestHighLowFeatures:
 # Test: Interaction Terms
 # ============================================================================
 
+
 class TestInteractionTerms:
     """Test feature interaction terms."""
 
@@ -499,6 +512,7 @@ class TestInteractionTerms:
 # Test: Edge Cases and Boundary Conditions
 # ============================================================================
 
+
 class TestEdgeCases:
     """Test edge cases and boundary conditions."""
 
@@ -515,7 +529,9 @@ class TestEdgeCases:
 
     def test_all_trump_hand_suit_contract(self, all_trump_hand):
         """Test hand with all trump cards."""
-        features = get_hand_features(all_trump_hand[:6], contract_type="suit", trump_suit="H")
+        features = get_hand_features(
+            all_trump_hand[:6], contract_type="suit", trump_suit="H"
+        )
 
         # Should have high trump count, no offsuit
         assert features["trump_count"] >= 5
@@ -547,6 +563,7 @@ class TestEdgeCases:
 # ============================================================================
 # Test: Scoring Functions
 # ============================================================================
+
 
 class TestScoringFunctions:
     """Test hand scoring functions."""
@@ -618,6 +635,7 @@ class TestScoringFunctions:
 # Test: Hand Value Feature
 # ============================================================================
 
+
 class TestHandValueFeature:
     """Test the hand_value feature added for OLSa HV."""
 
@@ -682,6 +700,7 @@ class TestHandValueFeature:
 # Test: Feature Completeness
 # ============================================================================
 
+
 class TestFeatureCompleteness:
     """Test that all expected features are present."""
 
@@ -697,30 +716,51 @@ class TestFeatureCompleteness:
 
         expected_features = {
             # Legacy
-            "bowers", "trump_count", "offsuit_aces", "high_offsuit", "rank_sum",
-
+            "bowers",
+            "trump_count",
+            "offsuit_aces",
+            "offsuit_non_ace_count",
+            "rank_sum",
             # Trump features
-            "trump_rb_count", "trump_lb_count", "trump_ace_count", "trump_king_count",
-            "trump_queen_count", "trump_ten_count", "top_trump_count",
-            "highest_trump_rank", "second_highest_trump_rank", "third_highest_trump_rank",
-            "trump_power_sum", "trump_power_avg", "trump_duplicate_pairs", "top_trump_sum",
-
+            "trump_rb_count",
+            "trump_lb_count",
+            "trump_ace_count",
+            "trump_king_count",
+            "trump_queen_count",
+            "trump_ten_count",
+            "top_trump_count",
+            "highest_trump_rank",
+            "second_highest_trump_rank",
+            "third_highest_trump_rank",
+            "trump_power_sum",
+            "trump_power_avg",
+            "trump_duplicate_pairs",
+            "top_trump_sum",
             # Offsuit control
-            "offsuit_king_count_total", "offsuit_queen_count_total",
-            "offsuit_suits_with_ace", "offsuit_suits_with_double_ace",
+            "offsuit_king_count_total",
+            "offsuit_queen_count_total",
+            "offsuit_suits_with_ace",
+            "offsuit_suits_with_double_ace",
             "offsuit_suits_with_ace_and_king",
-
             # Distribution
-            "void_count", "max_suit_len", "second_suit_len", "third_suit_len",
-            "fourth_suit_len", "num_singletons", "num_doubletons",
-            "offsuit_tens_count", "offsuit_length_3plus_count",
-            "offsuit_best_rank_sum", "offsuit_secondbest_rank_sum",
-
+            "void_count",
+            "max_suit_len",
+            "second_suit_len",
+            "third_suit_len",
+            "fourth_suit_len",
+            "num_singletons",
+            "num_doubletons",
+            "offsuit_tens_count",
+            "offsuit_length_3plus_count",
+            "offsuit_best_rank_sum",
+            "offsuit_secondbest_rank_sum",
             # High/Low specific
-            "double_ten_jack_count", "high_card_count", "low_card_count",
-
+            "double_ten_jack_count",
+            "high_card_count",
+            "low_card_count",
             # Interactions
-            "trump_count_x_void_count", "trump_count_x_offsuit_ace",
+            "trump_count_x_void_count",
+            "trump_count_x_offsuit_ace",
         }
 
         actual_features = set(features.keys())
@@ -739,8 +779,12 @@ class TestFeatureCompleteness:
         features = get_hand_features(hand, contract_type="suit", trump_suit="H")
 
         for fname, fval in features.items():
-            assert isinstance(fval, (int, float)), f"Feature {fname} has non-numeric value: {fval}"
-            assert not (isinstance(fval, float) and (fval != fval)), f"Feature {fname} is NaN"
+            assert isinstance(
+                fval, (int, float)
+            ), f"Feature {fname} has non-numeric value: {fval}"
+            assert not (
+                isinstance(fval, float) and (fval != fval)
+            ), f"Feature {fname} is NaN"
 
 
 # ============================================================================

--- a/tests/unit/test_train_olsa.py
+++ b/tests/unit/test_train_olsa.py
@@ -64,7 +64,7 @@ def _make_training_data(tmp_path, n_hands=200, seed=42):
                         "offsuit_tens_count": rng.randint(0, 5),
                         "rank_sum": rng.randint(10, 50),
                         "hand_value": rng.randint(100, 400),
-                        "high_offsuit": rng.randint(0, 8),
+                        "offsuit_non_ace_count": rng.randint(0, 8),
                         "trump_rb_count": rng.randint(0, 2),
                         "trump_lb_count": rng.randint(0, 2),
                         "trump_ace_count": rng.randint(0, 2),


### PR DESCRIPTION
## Summary
- Rename `high_offsuit` → `offsuit_non_ace_count` in source, tests, and docs (13 files)
- Clean break: no backward-compatibility shim (data is regenerable)
- Deprecated code (`experiments/_deprecated/`) intentionally unchanged

## Why
`high_offsuit` is misleading — it reads like "count of high offsuit suits" but actually counts **individual non-ace offsuit cards (K, Q, J, T)**. The new name `offsuit_non_ace_count` makes the semantics explicit and pairs naturally with `offsuit_aces`.

## Files Changed (13)

### Source (1)
- `src/bid_euchre/features/hand_eval.py` — variable, dict key, tuple docstring

### Tests (4)
- `tests/unit/test_hand_eval.py` — assertion + expected features set
- `tests/integration/test_integration.py` — core_features set
- `tests/integration/test_simulation_validation.py` — core_features set
- `tests/unit/test_train_olsa.py` — mock data dict key

### Reports & Agent Docs (3)
- `docs/04_reports/phase0_bidless_20260207_r5.md` — tables + narrative
- `docs/04_reports/phase0_bidless_20260207_r4.md` — tables + narrative
- `docs/02_agent/DIAGNOSTIC_TRICKS_EVALUATION.md` — feature ranking tables

### Archive Docs (5)
- `docs/archive/FEATURES.md` — feature definition table + legacy list
- `docs/archive/schemas/hand_record.md` — example JSON + schema table
- `docs/archive/REPORTING.md` — feature description
- `docs/archive/FEATURE_EXPANSION_2025.md` — baseline feature list
- `docs/archive/STRATEGY_COMPARISON_RESULTS.md` — dashboard feature list

## Repro / Validation
```bash
# Full validation
make check

# Verify no remaining references (except deprecated)
grep -r "high_offsuit" src/ tests/ docs/ --include="*.py" --include="*.md"
# Expected: 0 results

# Smoke experiment
uv run python experiments/run_experiment.py \
  --config experiments/configs/quick_test.yaml \
  --seed 42 --n_per 10
```

## Tests
- `make check` passes (1288 passed, 5 skipped, 2 xfailed, 1 xpassed)
- Two `make check` runs: pre-docs (source+tests only) and post-docs (full)
- Zero remaining `high_offsuit` in `src/`, `tests/`, `docs/`

## Worktree Proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-rename-feature
toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-rename-feature
worktree: 1e80e73 [codex/rename-high-offsuit]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)