### PR TITLE
feat: schema v7 — auction_transcript + wire redeal_flag/made_bid (PR B-2)

### DIFF
--- a/docs/01_core/DATA_CONTRACT.md
+++ b/docs/01_core/DATA_CONTRACT.md
@@ -7,7 +7,7 @@ If you change a schema, update the relevant doc and bump schema versions where a
 
 - **meta.json (schema v2):** see `docs/01_core/schemas/meta_json.md`
 - **results JSON**: Strategy performance metrics including scoring/points aggregates; see `docs/01_core/SCORING.md`
-- **JSONL game log (schema v6):** see below
+- **JSONL game log (schema v7):** see below
 
 ## JSONL Game Log Schema
 
@@ -17,7 +17,7 @@ Each `hand_end` record contains:
 
 | Field | Type | Since | Notes |
 |-------|------|-------|-------|
-| `schema_version` | int | v1 | Always present; current = 6 |
+| `schema_version` | int | v1 | Always present; current = 7 |
 | `event` | str | v1 | Always `"hand_end"` |
 | `run_id` | str | v1 | Run identifier |
 | `strategy_id` | str | v1 | Strategy name |
@@ -36,11 +36,14 @@ Each `hand_end` record contains:
 | `bidder_position` | int\|null | v5 | Auction winner seat; null on pre-v5 logs |
 | `redeal_flag` | bool\|null | v6 | True if all players passed (all-pass redeal); null on pre-v6 logs |
 | `made_bid` | bool\|null | v6 | True if declaring team made their bid; null on pre-v6 logs |
+| `auction_transcript` | list\|null | v7 | 4-entry list `[{seat, action, tricks_bid, contract_type, trump}]`; null if no auction or pre-v7 |
 | `timestamp` | str | v1 | ISO-8601 timestamp |
 
 **Backward compatibility:** All versioned fields have `null` defaults. Old logs can be read safely using `.get(field)`.
 
 **Filtering note:** `redeal_flag=true` records have `t0=0, t1=0` (no play occurred). Exclude them when computing comparative metrics.
+
+**auction_transcript entry format:** Each entry is `{"seat": int, "action": "PASS"|"BID", "tricks_bid": int, "contract_type": str|null, "trump": str|null}`. PASS entries have `tricks_bid=0`, `contract_type=null`, `trump=null`. The list is always exactly 4 entries (one per seat in bid order) when bidding occurred; `null` when no auction ran (fixed-contract mode).
 
 ## Directory Layout and Commit Policy
 

--- a/docs/03_TODO/CODEBASE_CONSISTENCY.md
+++ b/docs/03_TODO/CODEBASE_CONSISTENCY.md
@@ -16,40 +16,28 @@
 
 ### 1) Add auction transcript logging (RULES.md §8.2)
 
-**Status:** Open
-**Why it matters:** We can’t audit/replay bidding decisions without per-seat bid actions.
+**Status:** Resolved in PR B-2 (schema v7, 2026-02-18)
+**Why it matters:** We can't audit/replay bidding decisions without per-seat bid actions.
 
-**Next action:**
-- Add a per-action auction log record (one event per seat action; always 4 actions).
-- Emit these records from the auction loop (including “all-pass redeal” hands).
-- Update/extend tests to lock the log contract.
-
-**Notes (from RULES.md):**
-- Must log all 4 bids/passes (“single-round auction transcript”).
-- A redeal should be explicit (see item 2).
+**Resolution:** `auction_transcript` field added to `hand_end` records (schema v7). 4-entry list `[{seat, action, tricks_bid, contract_type, trump}]` accumulated across all 3 auction code paths in `play_single_hand()`. `null` when no auction ran (fixed-contract mode).
 
 ---
 
 ### 2) Add `redeal_flag` to hand-level logs (RULES.md §8.2)
 
-**Status:** Open
-**Why it matters:** RULES.md requires an explicit redeal signal; today it’s implicit/derivable at best.
+**Status:** Resolved in PR B-1 (schema v6) + PR B-2 callsite wiring (2026-02-18)
+**Why it matters:** RULES.md requires an explicit redeal signal; today it's implicit/derivable at best.
 
-**Next action:**
-- Add `redeal_flag: bool` to the hand-end record/schema and set it `True` for all-pass redeals.
-- Update any record-writing paths and contract tests accordingly.
+**Resolution:** `redeal_flag` added to `HandEndRecord` in schema v6 (PR #361). Callsite wired in PR B-2: computed as `(winning_bid == 0 and bidder_pos is None)` in `simulate_many_hands()`.
 
 ---
 
 ### 3) Add `made_bid` to hand-level logs (RULES.md §8.2 / METRICS.md required field)
 
-**Status:** Open
+**Status:** Resolved in PR B-1 (schema v6) + PR B-2 callsite wiring (2026-02-18)
 **Why it matters:** `made_bid` is a required analysis field; deriving it downstream is easy but brittle and obscures intent.
 
-**Next action:**
-- Add `made_bid: bool` to the hand-end record/schema.
-- Compute it in simulation once tricks are known: `decl_tricks >= contract_tricks`.
-- Update tests that validate log/metrics fields.
+**Resolution:** `made_bid` added to `HandEndRecord` in schema v6 (PR #361). Callsite wired in PR B-2: computed from `t0/t1 >= winning_bid` by team in `simulate_many_hands()`.
 
 ---
 

--- a/src/bid_euchre/logging/game_logger.py
+++ b/src/bid_euchre/logging/game_logger.py
@@ -29,7 +29,8 @@ from typing import Any, Dict, List, Optional, Tuple
 # v4 adds `winning_bid` to hand_end records.
 # v5 adds `dealer_position` and `bidder_position` to hand_end records.
 # v6 adds `redeal_flag` and `made_bid` to hand_end records.
-SCHEMA_VERSION = 6
+# v7 adds `auction_transcript` to hand_end records.
+SCHEMA_VERSION = 7
 
 
 class LogLevel(Enum):
@@ -67,6 +68,9 @@ class HandEndRecord:
         None  # True if all players passed (all-pass redeal) (schema v6)
     )
     made_bid: Optional[bool] = None  # True if declaring team made their bid (schema v6)
+    auction_transcript: Optional[List[Dict[str, Any]]] = (
+        None  # 4-entry list or null (schema v7)
+    )
     timestamp: str = ""
 
 
@@ -204,6 +208,7 @@ class GameLogger:
         bidder_position: Optional[int] = None,
         redeal_flag: Optional[bool] = None,
         made_bid: Optional[bool] = None,
+        auction_transcript: Optional[List[Dict[str, Any]]] = None,
     ) -> None:
         """
         Log the completion of a hand.
@@ -224,6 +229,7 @@ class GameLogger:
             bidder_position: Auction winner seat (0-3) (schema v5+)
             redeal_flag: True if all players passed (all-pass redeal) (schema v6+)
             made_bid: True if declaring team made their bid (schema v6+)
+            auction_transcript: 4-entry list of per-seat bid actions (schema v7+)
         """
         if not self.is_enabled:
             return
@@ -253,6 +259,7 @@ class GameLogger:
             bidder_position=bidder_position,
             redeal_flag=redeal_flag,
             made_bid=made_bid,
+            auction_transcript=auction_transcript,
             timestamp=self._timestamp(),
         )
         self._write_record(asdict(record))

--- a/src/bid_euchre/sim/simulation.py
+++ b/src/bid_euchre/sim/simulation.py
@@ -7,7 +7,7 @@ This module is library code (no CLI). It supports:
 """
 
 import random
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 from ..core.cards import Card, create_deck, deal_hands, shuffle_deck
 from ..core.rules import get_legal_indices, trick_winner
@@ -38,7 +38,20 @@ def play_single_hand(
     rng: Optional[random.Random] = None,
     bidding_collector: Optional[BiddingDatasetCollector] = None,
     on_bidding_decision: Optional[Callable[[BiddingDecisionEvent], None]] = None,
-) -> Tuple[int, int, List[int], List[Dict[str, int]], int, List[List[Card]], Optional[int], Optional[int], Optional[int], str, Optional[str]]:
+) -> Tuple[
+    int,
+    int,
+    List[int],
+    List[Dict[str, int]],
+    int,
+    List[List[Card]],
+    Optional[int],
+    Optional[int],
+    Optional[int],
+    str,
+    Optional[str],
+    Optional[List[Dict[str, Any]]],
+]:
     """
     Play one full 10-trick hand.
 
@@ -46,7 +59,7 @@ def play_single_hand(
     The winner of the bid chooses the contract and leads the first trick.
 
     Returns:
-        (t0, t1, scores, features, leader, hands, bid, dealer_pos, bidder_pos, final_contract, final_trump)
+        (t0, t1, scores, features, leader, hands, bid, dealer_pos, bidder_pos, final_contract, final_trump, auction_transcript)
     """
     # Resolve strategy-per-seat.
     if strategies is not None:
@@ -81,6 +94,7 @@ def play_single_hand(
     bidding_data = None
     dealer_index = None  # Track dealer position (0-3 or None if no bidding)
     bidder_position = None  # Track auction winner (0-3 or None)
+    _transcript: Optional[List[Dict[str, Any]]] = None  # Auction transcript (schema v7)
 
     if contract_type is None:
         # Determine dealer
@@ -102,6 +116,7 @@ def play_single_hand(
         winning_bidder = None
         final_contract = None
         final_trump = None
+        _transcript = []  # Accumulate per-seat bid actions (schema v7)
 
         # Use new bidding policy interface if provided, otherwise fall back to old interface
         if seat_bidding_policies is not None:
@@ -114,7 +129,7 @@ def play_single_hand(
                     hand=starting_hands[player_idx],
                     seat=player_idx,
                     dealer_seat=dealer_index,
-                    current_high_bid=current_high_bid
+                    current_high_bid=current_high_bid,
                 )
 
                 # Get bid from policy
@@ -126,25 +141,51 @@ def play_single_hand(
                 # Fire bidding decision event if handler registered
                 if on_bidding_decision is not None:
                     is_legal = bid_action.is_pass() or bid_action.n > current_high_bid
-                    on_bidding_decision(BiddingDecisionEvent(
-                        deal_id=deal_id,
-                        seat=player_idx,
-                        hand=list(starting_hands[player_idx]),  # Copy to avoid aliasing
-                        dealer_seat=dealer_index,
-                        current_high_bid=current_high_bid,
-                        bid_amount=bid_action.n,
-                        bid_contract=bid_action.contract,
-                        is_legal=is_legal,
-                    ))
+                    on_bidding_decision(
+                        BiddingDecisionEvent(
+                            deal_id=deal_id,
+                            seat=player_idx,
+                            hand=list(
+                                starting_hands[player_idx]
+                            ),  # Copy to avoid aliasing
+                            dealer_seat=dealer_index,
+                            current_high_bid=current_high_bid,
+                            bid_amount=bid_action.n,
+                            bid_contract=bid_action.contract,
+                            is_legal=is_legal,
+                        )
+                    )
 
                 # If bid is pass or <= current high bid, treat as pass
-                if bid_action.is_pass() or bid_action.n <= current_high_bid:
+                is_effective_pass = (
+                    bid_action.is_pass() or bid_action.n <= current_high_bid
+                )
+                if is_effective_pass:
+                    _transcript.append(
+                        {
+                            "seat": player_idx,
+                            "action": "PASS",
+                            "tricks_bid": 0,
+                            "contract_type": None,
+                            "trump": None,
+                        }
+                    )
                     continue
 
                 # Valid higher bid - accept it
+                _ctype, _trump = bid_action.to_contract_tuple()
+                _transcript.append(
+                    {
+                        "seat": player_idx,
+                        "action": "BID",
+                        "tricks_bid": bid_action.n,
+                        "contract_type": _ctype,
+                        "trump": _trump,
+                    }
+                )
                 current_high_bid = bid_action.n
                 winning_bidder = player_idx
-                final_contract, final_trump = bid_action.to_contract_tuple()
+                final_contract, final_trump = _ctype, _trump
         elif bidding_policy is not None:
             # New interface: sequential bidding (LOD order) using BiddingPolicy
             for offset in range(1, 5):
@@ -155,7 +196,7 @@ def play_single_hand(
                     hand=starting_hands[player_idx],
                     seat=player_idx,
                     dealer_seat=dealer_index,
-                    current_high_bid=current_high_bid
+                    current_high_bid=current_high_bid,
                 )
 
                 # Get bid from policy
@@ -167,25 +208,51 @@ def play_single_hand(
                 # Fire bidding decision event if handler registered
                 if on_bidding_decision is not None:
                     is_legal = bid_action.is_pass() or bid_action.n > current_high_bid
-                    on_bidding_decision(BiddingDecisionEvent(
-                        deal_id=deal_id,
-                        seat=player_idx,
-                        hand=list(starting_hands[player_idx]),  # Copy to avoid aliasing
-                        dealer_seat=dealer_index,
-                        current_high_bid=current_high_bid,
-                        bid_amount=bid_action.n,
-                        bid_contract=bid_action.contract,
-                        is_legal=is_legal,
-                    ))
+                    on_bidding_decision(
+                        BiddingDecisionEvent(
+                            deal_id=deal_id,
+                            seat=player_idx,
+                            hand=list(
+                                starting_hands[player_idx]
+                            ),  # Copy to avoid aliasing
+                            dealer_seat=dealer_index,
+                            current_high_bid=current_high_bid,
+                            bid_amount=bid_action.n,
+                            bid_contract=bid_action.contract,
+                            is_legal=is_legal,
+                        )
+                    )
 
                 # If bid is pass or <= current high bid, treat as pass
-                if bid_action.is_pass() or bid_action.n <= current_high_bid:
+                is_effective_pass = (
+                    bid_action.is_pass() or bid_action.n <= current_high_bid
+                )
+                if is_effective_pass:
+                    _transcript.append(
+                        {
+                            "seat": player_idx,
+                            "action": "PASS",
+                            "tricks_bid": 0,
+                            "contract_type": None,
+                            "trump": None,
+                        }
+                    )
                     continue
 
                 # Valid higher bid - accept it
+                _ctype, _trump = bid_action.to_contract_tuple()
+                _transcript.append(
+                    {
+                        "seat": player_idx,
+                        "action": "BID",
+                        "tricks_bid": bid_action.n,
+                        "contract_type": _ctype,
+                        "trump": _trump,
+                    }
+                )
                 current_high_bid = bid_action.n
                 winning_bidder = player_idx
-                final_contract, final_trump = bid_action.to_contract_tuple()
+                final_contract, final_trump = _ctype, _trump
         else:
             # Old interface: sequential bidding using Strategy.decide_bid
             # Bidding order: LOD, Partner of LOD, ROD, Dealer
@@ -199,7 +266,7 @@ def play_single_hand(
                     current_high_bid=current_high_bid,
                     current_winner_index=winning_bidder,
                     partner_index=partner_idx,
-                    player_index=player_idx
+                    player_index=player_idx,
                 )
 
                 obs = BiddingObservation(
@@ -215,7 +282,9 @@ def play_single_hand(
                     if ctype == "suit":
                         contract_for_action = trump
                     else:
-                        contract_for_action = ctype.upper() if isinstance(ctype, str) else ctype
+                        contract_for_action = (
+                            ctype.upper() if isinstance(ctype, str) else ctype
+                        )
                     bid_action = BidAction.bid(bid, contract_for_action)
                 if bidding_collector is not None and bid_action is not None:
                     bidding_collector.record_decision(obs, bid_action, deal_id)
@@ -223,22 +292,55 @@ def play_single_hand(
                 # Fire bidding decision event if handler registered
                 if on_bidding_decision is not None and bid_action is not None:
                     is_legal = bid_action.is_pass() or bid_action.n > current_high_bid
-                    on_bidding_decision(BiddingDecisionEvent(
-                        deal_id=deal_id,
-                        seat=player_idx,
-                        hand=list(starting_hands[player_idx]),  # Copy to avoid aliasing
-                        dealer_seat=dealer_index,
-                        current_high_bid=current_high_bid,
-                        bid_amount=bid_action.n,
-                        bid_contract=bid_action.contract,
-                        is_legal=is_legal,
-                    ))
+                    on_bidding_decision(
+                        BiddingDecisionEvent(
+                            deal_id=deal_id,
+                            seat=player_idx,
+                            hand=list(
+                                starting_hands[player_idx]
+                            ),  # Copy to avoid aliasing
+                            dealer_seat=dealer_index,
+                            current_high_bid=current_high_bid,
+                            bid_amount=bid_action.n,
+                            bid_contract=bid_action.contract,
+                            is_legal=is_legal,
+                        )
+                    )
 
                 # Dealer-partner pass rule: dealer passes if partner has the high bid
                 if player_idx == dealer_index and winning_bidder == partner_idx:
+                    _transcript.append(
+                        {
+                            "seat": player_idx,
+                            "action": "PASS",
+                            "tricks_bid": 0,
+                            "contract_type": None,
+                            "trump": None,
+                        }
+                    )
                     continue
 
-                if bid > current_high_bid:
+                is_effective_pass = bid == 0 or bid <= current_high_bid
+                if is_effective_pass:
+                    _transcript.append(
+                        {
+                            "seat": player_idx,
+                            "action": "PASS",
+                            "tricks_bid": 0,
+                            "contract_type": None,
+                            "trump": None,
+                        }
+                    )
+                else:
+                    _transcript.append(
+                        {
+                            "seat": player_idx,
+                            "action": "BID",
+                            "tricks_bid": bid,
+                            "contract_type": ctype,
+                            "trump": trump,
+                        }
+                    )
                     current_high_bid = bid
                     winning_bidder = player_idx
                     final_contract = ctype
@@ -248,12 +350,29 @@ def play_single_hand(
             # Misdeal: everyone passed or no valid bids
             # Return zeros but still need scores/features (use dummy contract for logging)
             dummy_ctype = "high"
-            all_player_scores = [score_hand(h, dummy_ctype, None) for h in starting_hands]
-            all_player_features = [get_hand_features(h, dummy_ctype, None) for h in starting_hands]
+            all_player_scores = [
+                score_hand(h, dummy_ctype, None) for h in starting_hands
+            ]
+            all_player_features = [
+                get_hand_features(h, dummy_ctype, None) for h in starting_hands
+            ]
             # dealer_index is known, bidder_position is None (misdeal)
             if bidding_collector is not None:
                 bidding_collector.set_final_contract(dummy_ctype, None)
-            return 0, 0, all_player_scores, all_player_features, -1, starting_hands, 0, dealer_index, None, dummy_ctype, None
+            return (
+                0,
+                0,
+                all_player_scores,
+                all_player_features,
+                -1,
+                starting_hands,
+                0,
+                dealer_index,
+                None,
+                dummy_ctype,
+                None,
+                _transcript,
+            )
 
         contract_type = final_contract
         trump_suit = final_trump
@@ -265,7 +384,7 @@ def play_single_hand(
             "winner": winning_bidder,
             "bid": current_high_bid,
             "contract": contract_type,
-            "trump": trump_suit
+            "trump": trump_suit,
         }
     else:
         # Contract was fixed, no bid was made
@@ -273,6 +392,7 @@ def play_single_hand(
         # No bidding phase: dealer and bidder are unknown
         dealer_index = None
         bidder_position = None
+        _transcript = None  # null distinguishes "no bidding mode" from "all passed"
 
     # Validation (now that contract is decided)
     if contract_type == "suit" and trump_suit is None:
@@ -327,7 +447,8 @@ def play_single_hand(
 
     # Filter to strategies that override on_hand_start (not default no-op)
     hand_start_targets = [
-        s for s in unique_strategies
+        s
+        for s in unique_strategies
         if type(s).on_hand_start is not Strategy.on_hand_start
     ]
     for s in hand_start_targets:
@@ -335,7 +456,9 @@ def play_single_hand(
         for seat_idx, seat_strat in enumerate(seat_strategies):
             if seat_strat is s:
                 s.on_hand_start(
-                    starting_hand=list(starting_hands[seat_idx]),  # Copy to avoid aliasing
+                    starting_hand=list(
+                        starting_hands[seat_idx]
+                    ),  # Copy to avoid aliasing
                     contract_type=contract_type,
                     trump_suit=trump_suit,
                     player_index=seat_idx,
@@ -344,7 +467,8 @@ def play_single_hand(
 
     # Filter to strategies that override observe_play (not default no-op)
     observe_play_targets = [
-        s for s in unique_strategies
+        s
+        for s in unique_strategies
         if type(s).observe_play is not Strategy.observe_play
     ]
 
@@ -373,7 +497,7 @@ def play_single_hand(
                     f"Illegal play from strategy={getattr(strat, 'name', type(strat).__name__)} "
                     f"player={player} contract={contract_type} trump={trump_suit} "
                     f"chosen_index={card_index} legal_indices={legal_indices} hand_size={len(hand)}"
-            )
+                )
 
             # Index integrity check: verify strategy returns valid index into actual hand
             # (catches bugs where strategy sorts/filters hand and returns wrong index)
@@ -415,7 +539,20 @@ def play_single_hand(
 
         leader = winner  # winner leads next trick
 
-    return team_tricks[0], team_tricks[1], all_player_scores, all_player_features, initial_leader, starting_hands, current_high_bid, dealer_index, bidder_position, contract_type, trump_suit
+    return (
+        team_tricks[0],
+        team_tricks[1],
+        all_player_scores,
+        all_player_features,
+        initial_leader,
+        starting_hands,
+        current_high_bid,
+        dealer_index,
+        bidder_position,
+        contract_type,
+        trump_suit,
+        _transcript,
+    )
 
 
 def simulate_many_hands(
@@ -515,7 +652,9 @@ def simulate_many_hands(
     collectors: List[BiddingDatasetCollector] = []
     if bidding_dataset_run_id is not None and contract_type is None:
         collectors = [
-            BiddingDatasetCollector(bidding_dataset_run_id, bidding_hand_id_offset + hand_id)
+            BiddingDatasetCollector(
+                bidding_dataset_run_id, bidding_hand_id_offset + hand_id
+            )
             for hand_id in range(n)
         ]
 
@@ -526,7 +665,20 @@ def simulate_many_hands(
 
         if deal_seed is not None:
             deal_hands_ = generate_deal(deal_seed, deal_id, deal_method=deal_method)
-            t0, t1, all_scores, all_feats, initial_leader, starting_hands, winning_bid, dealer_pos, bidder_pos, actual_contract, actual_trump = play_single_hand(
+            (
+                t0,
+                t1,
+                all_scores,
+                all_feats,
+                initial_leader,
+                starting_hands,
+                winning_bid,
+                dealer_pos,
+                bidder_pos,
+                actual_contract,
+                actual_trump,
+                auction_transcript,
+            ) = play_single_hand(
                 contract_type=contract_type,
                 trump_suit=trump_suit,
                 strategy=strategy,
@@ -541,7 +693,20 @@ def simulate_many_hands(
                 on_bidding_decision=on_bidding_decision,
             )
         else:
-            t0, t1, all_scores, all_feats, initial_leader, starting_hands, winning_bid, dealer_pos, bidder_pos, actual_contract, actual_trump = play_single_hand(
+            (
+                t0,
+                t1,
+                all_scores,
+                all_feats,
+                initial_leader,
+                starting_hands,
+                winning_bid,
+                dealer_pos,
+                bidder_pos,
+                actual_contract,
+                actual_trump,
+                auction_transcript,
+            ) = play_single_hand(
                 contract_type=contract_type,
                 trump_suit=trump_suit,
                 strategy=strategy,
@@ -557,6 +722,18 @@ def simulate_many_hands(
 
         # Log hand completion (if logger enabled)
         if logger and logger.is_enabled:
+            # Compute v6 fields: redeal when all passed (winning_bid==0, no bidder)
+            redeal_flag = (
+                (winning_bid == 0 and bidder_pos is None)
+                if winning_bid is not None
+                else None
+            )
+            if bidder_pos is None or winning_bid == 0 or winning_bid is None:
+                made_bid = None
+            elif bidder_pos in (0, 2):
+                made_bid = t0 >= winning_bid
+            else:
+                made_bid = t1 >= winning_bid
             logger.log_hand_end(
                 deal_id=deal_id,
                 seed=seed,
@@ -571,25 +748,34 @@ def simulate_many_hands(
                 winning_bid=winning_bid,
                 dealer_position=dealer_pos,
                 bidder_position=bidder_pos,
+                redeal_flag=redeal_flag,
+                made_bid=made_bid,
+                auction_transcript=auction_transcript,
             )
 
         # Fire HandEndEvent if hooks registered
         if hooks is not None:
-            hooks.fire_hand_end(HandEndEvent(
-                deal_id=deal_id,
-                seed=seed,
-                hands=[list(h) for h in starting_hands],  # Deep copy to avoid aliasing
-                dealer_seat=dealer_pos,
-                contract_type=actual_contract,
-                trump_suit=actual_trump,
-                initial_leader=initial_leader,
-                tricks_team0=t0,
-                tricks_team1=t1,
-                scores=list(all_scores),
-                features=[dict(f) for f in all_feats],  # Copy dicts to avoid aliasing
-                winning_bid=winning_bid,
-                bidder_seat=bidder_pos,
-            ))
+            hooks.fire_hand_end(
+                HandEndEvent(
+                    deal_id=deal_id,
+                    seed=seed,
+                    hands=[
+                        list(h) for h in starting_hands
+                    ],  # Deep copy to avoid aliasing
+                    dealer_seat=dealer_pos,
+                    contract_type=actual_contract,
+                    trump_suit=actual_trump,
+                    initial_leader=initial_leader,
+                    tricks_team0=t0,
+                    tricks_team1=t1,
+                    scores=list(all_scores),
+                    features=[
+                        dict(f) for f in all_feats
+                    ],  # Copy dicts to avoid aliasing
+                    winning_bid=winning_bid,
+                    bidder_seat=bidder_pos,
+                )
+            )
 
         total0 += t0
         total1 += t1
@@ -679,12 +865,16 @@ def simulate_many_hands(
         "hands_with_bids": hands_with_bids,
     }
     if hands_with_bids > 0:
-        bidding_points.update({
-            "avg_bid": sum(bid_values) / len(bid_values),
-            "bid_distribution": {bid: bid_values.count(bid) for bid in set(bid_values)},
-            "make_rate": made_count / hands_with_bids,
-            "set_rate": set_count / hands_with_bids,
-        })
+        bidding_points.update(
+            {
+                "avg_bid": sum(bid_values) / len(bid_values),
+                "bid_distribution": {
+                    bid: bid_values.count(bid) for bid in set(bid_values)
+                },
+                "make_rate": made_count / hands_with_bids,
+                "set_rate": set_count / hands_with_bids,
+            }
+        )
 
     bidding_collectors = [c for c in collectors if c.rows] if collectors else []
 
@@ -709,7 +899,9 @@ def simulate_many_hands(
         "distribution_points_team1": dist_points_team1,
         "bidding_points": bidding_points,
         # Backward compatibility aliases
-        "avg_score_player0": total_score_all / player_samples if player_samples > 0 else 0,
+        "avg_score_player0": total_score_all / player_samples
+        if player_samples > 0
+        else 0,
         "score_buckets_player0": score_buckets,
         "feature_buckets_player0": feature_buckets,
         "bidding_collectors": bidding_collectors,
@@ -767,8 +959,9 @@ def run_all_scenarios(
         print("Avg score:        ", f"{results['avg_score']:.2f}")
         print("Avg tricks Team 0:", f"{results['avg_team0']:.3f}")
         print("Avg tricks Team 1:", f"{results['avg_team1']:.3f}")
-        print("Sum of avgs (≈10):",
-              f"{results['avg_team0'] + results['avg_team1']:.3f}")
+        print(
+            "Sum of avgs (≈10):", f"{results['avg_team0'] + results['avg_team1']:.3f}"
+        )
 
         print("\nDistribution of Team 0 tricks:")
         dist = results["distribution_team0"]
@@ -784,5 +977,7 @@ def run_all_scenarios(
             print("\nSample of score buckets (hand score → avg tricks for team):")
             for score in sorted(buckets.keys())[:8]:
                 b = buckets[score]
-                print(f"  Score {score:3d}: "
-                      f"n={b['count']:4d}, avg_tricks={b['avg_tricks']:.3f}")
+                print(
+                    f"  Score {score:3d}: "
+                    f"n={b['count']:4d}, avg_tricks={b['avg_tricks']:.3f}"
+                )

--- a/tests/integration/test_bidding_logic.py
+++ b/tests/integration/test_bidding_logic.py
@@ -10,26 +10,27 @@ from bid_euchre.strategy.baselines import RandomLegalStrategy
 def dummy_strategies():
     """Create dummy strategies using artifact fixtures for testing."""
     return {
-        'suit': ArtifactGreedyStrategy(
+        "suit": ArtifactGreedyStrategy(
             name="dummy_suit",
-            artifact_path="data/fixtures/bidding_artifact_v1_dummy_suit.json"
+            artifact_path="data/fixtures/bidding_artifact_v1_dummy_suit.json",
         ),
-        'high': ArtifactGreedyStrategy(
+        "high": ArtifactGreedyStrategy(
             name="dummy_high",
-            artifact_path="data/fixtures/bidding_artifact_v1_dummy_high.json"
+            artifact_path="data/fixtures/bidding_artifact_v1_dummy_high.json",
         ),
-        'low': ArtifactGreedyStrategy(
+        "low": ArtifactGreedyStrategy(
             name="dummy_low",
-            artifact_path="data/fixtures/bidding_artifact_v1_dummy_low.json"
-        )
+            artifact_path="data/fixtures/bidding_artifact_v1_dummy_low.json",
+        ),
     }
+
 
 def test_artifact_bidder_bidding_rules(dummy_strategies):
     """Test artifact bidder follows strict raiser imitation rules."""
     # Test initial bidding
     hand = [Card("H", "A")] * 5 + [Card("H", "T")] * 5
 
-    bidder = dummy_strategies['suit']
+    bidder = dummy_strategies["suit"]
     bid, ctype, trump = bidder.decide_bid(hand, 0, None, 2, 0)
     assert bid == 3  # initial_bid from artifact
     assert ctype == "suit"
@@ -40,29 +41,31 @@ def test_artifact_bidder_bidding_rules(dummy_strategies):
     assert bid == 4  # 3 + raise_increment = 4
 
     # Test max bid limit - should pass when at max
-    bid, ctype, trump = bidder.decide_bid(hand, 10, None, 2, 0)  # current high bid = 10 (max)
+    bid, ctype, trump = bidder.decide_bid(
+        hand, 10, None, 2, 0
+    )  # current high bid = 10 (max)
     assert bid == 0  # pass when cannot raise further
     # Wait, np.round(3.5) is 4.0.
+
 
 def test_fixed_bid_fred():
     """Test that fixed bid strategies always bid the fixed amount."""
     hand = [Card("H", "A")] * 10
 
     fred = ArtifactGreedyStrategy(
-        name="fred",
-        artifact_path="data/fixtures/bidding_artifact_v1_dummy_fixed5.json"
+        name="fred", artifact_path="data/fixtures/bidding_artifact_v1_dummy_fixed5.json"
     )
     bid, _, _ = fred.decide_bid(hand, 0, None, 2, 0)
     assert bid == 5
+
 
 def test_misdeal_logic():
     """Verify that if all players pass, it's a misdeal."""
     # RandomLegalStrategy always returns 0 for decide_bid (default)
     strategies = [RandomLegalStrategy() for _ in range(4)]
 
-    t0, t1, scores, feats, leader, hands, bid, _, _, _, _ = play_single_hand(
-        contract_type=None,
-        strategies=strategies
+    t0, t1, scores, feats, leader, hands, bid, _, _, _, _, _ = play_single_hand(
+        contract_type=None, strategies=strategies
     )
 
     assert t0 == 0
@@ -70,65 +73,66 @@ def test_misdeal_logic():
     assert leader == -1
     assert bid == 0
 
+
 def test_artifact_bidder_initial_bid():
     """Test that artifact bidder makes its initial bid."""
     strategies = [
-        RandomLegalStrategy(), # Seat 0
-        RandomLegalStrategy(), # Seat 1
-        RandomLegalStrategy(), # Seat 2
+        RandomLegalStrategy(),  # Seat 0
+        RandomLegalStrategy(),  # Seat 1
+        RandomLegalStrategy(),  # Seat 2
         ArtifactGreedyStrategy(
             name="bidder",
-            artifact_path="data/fixtures/bidding_artifact_v1_dummy_fixed12.json"
-        ) # Seat 3 bids 10 initially
+            artifact_path="data/fixtures/bidding_artifact_v1_dummy_fixed12.json",
+        ),  # Seat 3 bids 10 initially
     ]
 
     # Play hand with contract_type=None to trigger bidding
-    t0, t1, _, _, leader, _, bid, _, _, _, _ = play_single_hand(
-        contract_type=None,
-        strategies=strategies,
-        initial_leader=0
+    t0, t1, _, _, leader, _, bid, _, _, _, _, _ = play_single_hand(
+        contract_type=None, strategies=strategies, initial_leader=0
     )
 
     # Seat 3 should win with initial bid of 10
     assert leader == 3
     assert bid == 10
 
+
 def test_bid_winner_leads():
     """The person who wins the bid must lead the first trick."""
     strategies = [
         ArtifactGreedyStrategy(
             name="bidder",
-            artifact_path="data/fixtures/bidding_artifact_v1_dummy_fixed6.json"
-        ), # wants to bid 6
+            artifact_path="data/fixtures/bidding_artifact_v1_dummy_fixed6.json",
+        ),  # wants to bid 6
         RandomLegalStrategy(),
         RandomLegalStrategy(),
-        RandomLegalStrategy()
+        RandomLegalStrategy(),
     ]
 
-    t0, t1, _, _, leader, _, bid, _, _, _, _ = play_single_hand(
+    t0, t1, _, _, leader, _, bid, _, _, _, _, _ = play_single_hand(
         contract_type=None,
         strategies=strategies,
-        initial_leader=1 # make someone else dealer so Seat 0 is LOD
+        initial_leader=1,  # make someone else dealer so Seat 0 is LOD
     )
 
     assert leader == 0
     assert bid == 6
 
+
 if __name__ == "__main__":
     # Setup dummy strategies
     dummy_strategies = {
-        'suit': ArtifactGreedyStrategy(
+        "suit": ArtifactGreedyStrategy(
             name="dummy_suit",
-            artifact_path="data/fixtures/bidding_artifact_v1_dummy_suit.json"
+            artifact_path="data/fixtures/bidding_artifact_v1_dummy_suit.json",
         ),
-        'high': ArtifactGreedyStrategy(
+        "high": ArtifactGreedyStrategy(
             name="dummy_high",
-            artifact_path="data/fixtures/bidding_artifact_v1_dummy_high.json"
+            artifact_path="data/fixtures/bidding_artifact_v1_dummy_high.json",
         ),
-        'low': ArtifactGreedyStrategy(
+        "low": ArtifactGreedyStrategy(
             name="dummy_low",
-            artifact_path="data/fixtures/bidding_artifact_v1_dummy_low.json"
-        )
+            artifact_path="data/fixtures/bidding_artifact_v1_dummy_low.json",
+        ),
     }
 
     print("Running tests manually...")
@@ -152,5 +156,6 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"\n❌ TEST FAILED: {e}")
         import traceback
+
         traceback.print_exc()
         exit(1)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -32,6 +32,7 @@ class TestEndToEndSimulation:
             _,
             _,
             _,
+            _,
         ) = result
 
         # Basic validation

--- a/tests/integration/test_model_integration.py
+++ b/tests/integration/test_model_integration.py
@@ -15,9 +15,9 @@ from bid_euchre.strategy.baselines import RandomLegalStrategy
 def test_artifact_strategies_load_successfully():
     """Test that artifact-based strategies can be loaded."""
     artifact_paths = {
-        'suit': 'data/fixtures/bidding_artifact_v1_dummy_suit.json',
-        'high': 'data/fixtures/bidding_artifact_v1_dummy_high.json',
-        'low': 'data/fixtures/bidding_artifact_v1_dummy_low.json',
+        "suit": "data/fixtures/bidding_artifact_v1_dummy_suit.json",
+        "high": "data/fixtures/bidding_artifact_v1_dummy_high.json",
+        "low": "data/fixtures/bidding_artifact_v1_dummy_low.json",
     }
 
     for contract, path in artifact_paths.items():
@@ -32,17 +32,19 @@ def test_artifact_strategy_plays_single_hand():
     """Test that artifact strategy can complete a single hand without crashing."""
     strategy = ArtifactGreedyStrategy(
         name="test_strategy",
-        artifact_path='data/fixtures/bidding_artifact_v1_dummy_suit.json'
+        artifact_path="data/fixtures/bidding_artifact_v1_dummy_suit.json",
     )
 
     # Play a single hand with bidding
     strategies = [strategy, strategy, strategy, strategy]
 
     try:
-        t0, t1, _, _, leader, _, bid, dealer, bidder, contract, trump = play_single_hand(
-            contract_type=None,  # Trigger bidding
-            strategies=strategies,
-            deal_seed=42
+        t0, t1, _, _, leader, _, bid, dealer, bidder, contract, trump, _ = (
+            play_single_hand(
+                contract_type=None,  # Trigger bidding
+                strategies=strategies,
+                deal_seed=42,
+            )
         )
 
         # Check results are valid
@@ -52,7 +54,9 @@ def test_artifact_strategy_plays_single_hand():
         assert bid is not None, "Bid should not be None"
         assert isinstance(bid, int), f"Bid should be int: {bid}"
 
-        print(f"✅ Artifact strategy played single hand: {t0}-{t1}, bid={bid}, contract={contract}")
+        print(
+            f"✅ Artifact strategy played single hand: {t0}-{t1}, bid={bid}, contract={contract}"
+        )
 
     except Exception as e:
         print(f"❌ Artifact strategy failed to play hand: {e}")
@@ -63,7 +67,7 @@ def test_artifact_strategy_plays_multiple_hands():
     """Test that artifact strategy can play multiple hands consistently."""
     strategy = ArtifactGreedyStrategy(
         name="test_strategy",
-        artifact_path='data/fixtures/bidding_artifact_v1_dummy_suit.json'
+        artifact_path="data/fixtures/bidding_artifact_v1_dummy_suit.json",
     )
 
     # Play 10 hands
@@ -72,10 +76,10 @@ def test_artifact_strategy_plays_multiple_hands():
 
     for i in range(n_hands):
         try:
-            t0, t1, _, _, leader, _, bid, dealer, bidder, contract, trump = play_single_hand(
-                contract_type=None,
-                strategies=strategies,
-                deal_seed=42 + i
+            t0, t1, _, _, leader, _, bid, dealer, bidder, contract, trump, _ = (
+                play_single_hand(
+                    contract_type=None, strategies=strategies, deal_seed=42 + i
+                )
             )
 
             assert 0 <= t0 <= 10, f"Hand {i}: Team 0 tricks out of range"
@@ -92,17 +96,23 @@ def test_artifact_strategy_plays_multiple_hands():
 def test_artifact_strategy_different_contracts():
     """Test artifact strategies for different contract types."""
     strategies = [
-        ArtifactGreedyStrategy("suit", 'data/fixtures/bidding_artifact_v1_dummy_suit.json'),
-        ArtifactGreedyStrategy("high", 'data/fixtures/bidding_artifact_v1_dummy_high.json'),
-        ArtifactGreedyStrategy("low", 'data/fixtures/bidding_artifact_v1_dummy_low.json'),
-        ArtifactGreedyStrategy("suit", 'data/fixtures/bidding_artifact_v1_dummy_suit.json'),
+        ArtifactGreedyStrategy(
+            "suit", "data/fixtures/bidding_artifact_v1_dummy_suit.json"
+        ),
+        ArtifactGreedyStrategy(
+            "high", "data/fixtures/bidding_artifact_v1_dummy_high.json"
+        ),
+        ArtifactGreedyStrategy(
+            "low", "data/fixtures/bidding_artifact_v1_dummy_low.json"
+        ),
+        ArtifactGreedyStrategy(
+            "suit", "data/fixtures/bidding_artifact_v1_dummy_suit.json"
+        ),
     ]
 
     try:
-        t0, t1, _, _, leader, _, bid, dealer, bidder, contract, trump = play_single_hand(
-            contract_type=None,
-            strategies=strategies,
-            deal_seed=42
+        t0, t1, _, _, leader, _, bid, dealer, bidder, contract, trump, _ = (
+            play_single_hand(contract_type=None, strategies=strategies, deal_seed=42)
         )
 
         assert 0 <= t0 <= 10, f"Team 0 tricks out of range: {t0}"
@@ -120,7 +130,7 @@ def test_artifact_strategy_vs_random():
     """Test artifact strategy vs random baseline (sanity check)."""
     artifact_strat = ArtifactGreedyStrategy(
         name="artifact",
-        artifact_path='data/fixtures/bidding_artifact_v1_dummy_suit.json'
+        artifact_path="data/fixtures/bidding_artifact_v1_dummy_suit.json",
     )
     random_strat = RandomLegalStrategy(seed=42)
 
@@ -132,10 +142,8 @@ def test_artifact_strategy_vs_random():
     team1_wins = 0
 
     for i in range(50):
-        t0, t1, _, _, _, _, _, _, _, _, _ = play_single_hand(
-            contract_type=None,
-            strategies=strategies,
-            deal_seed=100 + i
+        t0, t1, _, _, _, _, _, _, _, _, _, _ = play_single_hand(
+            contract_type=None, strategies=strategies, deal_seed=100 + i
         )
 
         if t0 > t1:
@@ -146,7 +154,9 @@ def test_artifact_strategy_vs_random():
     # Artifact should perform reasonably vs random
     win_rate = team0_wins / 50
 
-    print(f"✅ Artifact vs Random: {team0_wins}-{team1_wins} (win rate: {win_rate:.2%})")
+    print(
+        f"✅ Artifact vs Random: {team0_wins}-{team1_wins} (win rate: {win_rate:.2%})"
+    )
     print("   (Note: with bidding, win rates are complex due to points scoring)")
 
 
@@ -154,17 +164,15 @@ def test_artifact_strategy_bidding_behavior():
     """Test that artifact strategy makes reasonable bids."""
     strategy = ArtifactGreedyStrategy(
         name="artifact",
-        artifact_path='data/fixtures/bidding_artifact_v1_dummy_suit.json'
+        artifact_path="data/fixtures/bidding_artifact_v1_dummy_suit.json",
     )
 
     strategies = [strategy, strategy, strategy, strategy]
 
     bids = []
     for i in range(100):
-        t0, t1, _, _, _, _, bid, _, _, _, _ = play_single_hand(
-            contract_type=None,
-            strategies=strategies,
-            deal_seed=200 + i
+        t0, t1, _, _, _, _, bid, _, _, _, _, _ = play_single_hand(
+            contract_type=None, strategies=strategies, deal_seed=200 + i
         )
         if bid is not None and bid > 0:  # Valid bid
             bids.append(bid)
@@ -178,7 +186,9 @@ def test_artifact_strategy_bidding_behavior():
     assert min_bid >= 0, f"Min bid out of range: {min_bid}"
     assert max_bid <= 10, f"Max bid out of range: {max_bid}"
 
-    print(f"✅ Artifact bidding behavior: avg={avg_bid:.2f}, range=[{min_bid}, {max_bid}]")
+    print(
+        f"✅ Artifact bidding behavior: avg={avg_bid:.2f}, range=[{min_bid}, {max_bid}]"
+    )
     print(f"   Bid distribution: {sorted(set(bids))} (unique bids)")
 
 
@@ -186,7 +196,7 @@ def test_artifact_strategy_make_bid_rate():
     """Test that artifact strategy makes its bid at a reasonable rate."""
     strategy = ArtifactGreedyStrategy(
         name="artifact",
-        artifact_path='data/fixtures/bidding_artifact_v1_dummy_suit.json'
+        artifact_path="data/fixtures/bidding_artifact_v1_dummy_suit.json",
     )
 
     strategies = [strategy, strategy, strategy, strategy]
@@ -195,10 +205,8 @@ def test_artifact_strategy_make_bid_rate():
     total_count = 0
 
     for i in range(100):
-        t0, t1, _, _, _, _, bid, dealer, bidder, _, _ = play_single_hand(
-            contract_type=None,
-            strategies=strategies,
-            deal_seed=300 + i
+        t0, t1, _, _, _, _, bid, dealer, bidder, _, _, _ = play_single_hand(
+            contract_type=None, strategies=strategies, deal_seed=300 + i
         )
 
         if bid is None or bidder is None or bid == 0:
@@ -224,7 +232,7 @@ def test_no_crashes_with_edge_cases():
     """Test that artifact strategies don't crash on edge case hands."""
     strategy = ArtifactGreedyStrategy(
         name="artifact",
-        artifact_path='data/fixtures/bidding_artifact_v1_dummy_suit.json'
+        artifact_path="data/fixtures/bidding_artifact_v1_dummy_suit.json",
     )
 
     strategies = [strategy, strategy, strategy, strategy]
@@ -232,10 +240,8 @@ def test_no_crashes_with_edge_cases():
     # Test many random seeds to hit edge cases
     for i in range(50):
         try:
-            t0, t1, _, _, _, _, _, _, _, _, _ = play_single_hand(
-                contract_type=None,
-                strategies=strategies,
-                deal_seed=1000 + i
+            t0, t1, _, _, _, _, _, _, _, _, _, _ = play_single_hand(
+                contract_type=None, strategies=strategies, deal_seed=1000 + i
             )
         except Exception as e:
             print(f"❌ Crashed on seed {1000+i}: {e}")
@@ -257,9 +263,9 @@ def run_all_tests():
         test_no_crashes_with_edge_cases,
     ]
 
-    print("="*80)
+    print("=" * 80)
     print("Running Model Integration Tests")
-    print("="*80)
+    print("=" * 80)
 
     passed = 0
     failed = 0
@@ -276,9 +282,9 @@ def run_all_tests():
             print(f"⚠️  {test.__name__} ERROR: {e}")
             skipped += 1
 
-    print("\n" + "="*80)
+    print("\n" + "=" * 80)
     print(f"Test Summary: {passed} passed, {failed} failed, {skipped} skipped/errors")
-    print("="*80)
+    print("=" * 80)
 
     if failed > 0:
         sys.exit(1)

--- a/tests/unit/test_auction_bidding_rules.py
+++ b/tests/unit/test_auction_bidding_rules.py
@@ -28,7 +28,20 @@ class TestAuctionBiddingRules:
         bidding_policy = AlwaysPassBidder()
 
         # Play hand with auction mode (contract_type=None)
-        t0, t1, scores, features, leader, hands, bid, dealer_pos, bidder_pos, final_contract, final_trump = play_single_hand(
+        (
+            t0,
+            t1,
+            scores,
+            features,
+            leader,
+            hands,
+            bid,
+            dealer_pos,
+            bidder_pos,
+            final_contract,
+            final_trump,
+            _,
+        ) = play_single_hand(
             contract_type=None,
             bidding_policy=bidding_policy,
         )
@@ -45,6 +58,7 @@ class TestAuctionBiddingRules:
 
         class SeatBasedBidder(BiddingPolicy):
             """Bids differently based on seat."""
+
             def choose_bid(self, obs: BiddingObservation) -> BidAction:
                 if obs.seat == 0:
                     return BidAction.bid(8, "S")  # High bid first
@@ -56,13 +70,37 @@ class TestAuctionBiddingRules:
         bidding_policy = SeatBasedBidder()
 
         # Use a fixed hand and dealer to ensure determinism
-        fixed_hand = [Card("S", "A"), Card("H", "K"), Card("D", "Q"), Card("C", "J"),
-                      Card("S", "T"), Card("H", "A"), Card("D", "K"), Card("C", "Q"),
-                      Card("S", "J"), Card("H", "T")]
+        fixed_hand = [
+            Card("S", "A"),
+            Card("H", "K"),
+            Card("D", "Q"),
+            Card("C", "J"),
+            Card("S", "T"),
+            Card("H", "A"),
+            Card("D", "K"),
+            Card("C", "Q"),
+            Card("S", "J"),
+            Card("H", "T"),
+        ]
 
-        hands = [fixed_hand.copy() for _ in range(4)]  # Same hand for all for simplicity
+        hands = [
+            fixed_hand.copy() for _ in range(4)
+        ]  # Same hand for all for simplicity
 
-        t0, t1, scores, features, leader, hands, bid, dealer_pos, bidder_pos, final_contract, final_trump = play_single_hand(
+        (
+            t0,
+            t1,
+            scores,
+            features,
+            leader,
+            hands,
+            bid,
+            dealer_pos,
+            bidder_pos,
+            final_contract,
+            final_trump,
+            _,
+        ) = play_single_hand(
             contract_type=None,
             bidding_policy=bidding_policy,
             hands=hands,
@@ -72,7 +110,9 @@ class TestAuctionBiddingRules:
         # Seat 0 should win with bid 8 (seat 1's bid 3 was ignored as <= 8)
         assert leader == 0, f"Expected leader to be 0 (high bidder), got {leader}"
         assert bid == 8, f"Expected bid to be 8, got {bid}"
-        assert final_contract == "suit", f"Expected contract 'suit', got {final_contract}"
+        assert (
+            final_contract == "suit"
+        ), f"Expected contract 'suit', got {final_contract}"
         assert final_trump == "S", f"Expected trump 'S', got {final_trump}"
 
     def test_highest_valid_bid_wins(self):
@@ -80,6 +120,7 @@ class TestAuctionBiddingRules:
 
         class SeatBasedBidder(BiddingPolicy):
             """Bids differently based on seat."""
+
             def choose_bid(self, obs: BiddingObservation) -> BidAction:
                 if obs.seat == 0:
                     return BidAction.bid(5, "HIGH")
@@ -93,13 +134,35 @@ class TestAuctionBiddingRules:
 
         bidding_policy = SeatBasedBidder()
 
-        fixed_hand = [Card("S", "A"), Card("H", "K"), Card("D", "Q"), Card("C", "J"),
-                      Card("S", "T"), Card("H", "A"), Card("D", "K"), Card("C", "Q"),
-                      Card("S", "J"), Card("H", "T")]
+        fixed_hand = [
+            Card("S", "A"),
+            Card("H", "K"),
+            Card("D", "Q"),
+            Card("C", "J"),
+            Card("S", "T"),
+            Card("H", "A"),
+            Card("D", "K"),
+            Card("C", "Q"),
+            Card("S", "J"),
+            Card("H", "T"),
+        ]
 
         hands = [fixed_hand.copy() for _ in range(4)]
 
-        t0, t1, scores, features, leader, hands, bid, dealer_pos, bidder_pos, final_contract, final_trump = play_single_hand(
+        (
+            t0,
+            t1,
+            scores,
+            features,
+            leader,
+            hands,
+            bid,
+            dealer_pos,
+            bidder_pos,
+            final_contract,
+            final_trump,
+            _,
+        ) = play_single_hand(
             contract_type=None,
             bidding_policy=bidding_policy,
             hands=hands,
@@ -107,16 +170,21 @@ class TestAuctionBiddingRules:
         )
 
         # Seat 1 should win with the highest bid (7 LOW)
-        assert leader == 1, f"Expected leader to be 1 (highest bidder with 7), got {leader}"
+        assert (
+            leader == 1
+        ), f"Expected leader to be 1 (highest bidder with 7), got {leader}"
         assert bid == 7, f"Expected bid to be 7, got {bid}"
         assert final_contract == "low", f"Expected contract 'low', got {final_contract}"
-        assert final_trump is None, f"Expected trump None for LOW contract, got {final_trump}"
+        assert (
+            final_trump is None
+        ), f"Expected trump None for LOW contract, got {final_trump}"
 
     def test_sequential_bidding_lod_order(self):
         """Bidding proceeds sequentially in LOD order: left of dealer first, then clockwise, dealer last."""
 
         class CallOrderTracker(BiddingPolicy):
             """Tracks the order in which seats are called."""
+
             call_order = []  # Class variable to track order of calls
 
             def choose_bid(self, obs: BiddingObservation) -> BidAction:
@@ -128,9 +196,18 @@ class TestAuctionBiddingRules:
 
         bidding_policy = CallOrderTracker()
 
-        fixed_hand = [Card("S", "A"), Card("H", "K"), Card("D", "Q"), Card("C", "J"),
-                      Card("S", "T"), Card("H", "A"), Card("D", "K"), Card("C", "Q"),
-                      Card("S", "J"), Card("H", "T")]
+        fixed_hand = [
+            Card("S", "A"),
+            Card("H", "K"),
+            Card("D", "Q"),
+            Card("C", "J"),
+            Card("S", "T"),
+            Card("H", "A"),
+            Card("D", "K"),
+            Card("C", "Q"),
+            Card("S", "J"),
+            Card("H", "T"),
+        ]
 
         hands = [fixed_hand.copy() for _ in range(4)]
 
@@ -145,18 +222,21 @@ class TestAuctionBiddingRules:
 
         # Verify sequential LOD order: [3, 0, 1, 2]
         expected_order = [3, 0, 1, 2]
-        assert CallOrderTracker.call_order == expected_order, \
-            f"Expected LOD order {expected_order}, got {CallOrderTracker.call_order}"
+        assert (
+            CallOrderTracker.call_order == expected_order
+        ), f"Expected LOD order {expected_order}, got {CallOrderTracker.call_order}"
 
         # Verify each seat called exactly once
-        assert len(CallOrderTracker.call_order) == 4, \
-            f"Expected 4 calls (one round), got {len(CallOrderTracker.call_order)}"
+        assert (
+            len(CallOrderTracker.call_order) == 4
+        ), f"Expected 4 calls (one round), got {len(CallOrderTracker.call_order)}"
 
     def test_current_high_bid_progresses_sequentially(self):
         """Verify that current_high_bid visible to each bidder reflects the sequential progression."""
 
         class ObservationTracker(BiddingPolicy):
             """Tracks the current_high_bid each seat observes and bids according to seat."""
+
             observed_high_bids = {}  # seat -> current_high_bid at time of bidding
 
             def choose_bid(self, obs: BiddingObservation) -> BidAction:
@@ -177,14 +257,36 @@ class TestAuctionBiddingRules:
 
         bidding_policy = ObservationTracker()
 
-        fixed_hand = [Card("S", "A"), Card("H", "K"), Card("D", "Q"), Card("C", "J"),
-                      Card("S", "T"), Card("H", "A"), Card("D", "K"), Card("C", "Q"),
-                      Card("S", "J"), Card("H", "T")]
+        fixed_hand = [
+            Card("S", "A"),
+            Card("H", "K"),
+            Card("D", "Q"),
+            Card("C", "J"),
+            Card("S", "T"),
+            Card("H", "A"),
+            Card("D", "K"),
+            Card("C", "Q"),
+            Card("S", "J"),
+            Card("H", "T"),
+        ]
 
         hands = [fixed_hand.copy() for _ in range(4)]
 
         # Dealer is seat 2, LOD order: [3, 0, 1, 2]
-        t0, t1, scores, features, leader, hands, bid, dealer_pos, bidder_pos, final_contract, final_trump = play_single_hand(
+        (
+            t0,
+            t1,
+            scores,
+            features,
+            leader,
+            hands,
+            bid,
+            dealer_pos,
+            bidder_pos,
+            final_contract,
+            final_trump,
+            _,
+        ) = play_single_hand(
             contract_type=None,
             bidding_policy=bidding_policy,
             hands=hands,
@@ -192,9 +294,13 @@ class TestAuctionBiddingRules:
         )
 
         # Verify the winner is seat 1 (who bid 6)
-        assert bidder_pos == 1, f"Expected winner to be seat 1 (bid 6), got {bidder_pos}"
+        assert (
+            bidder_pos == 1
+        ), f"Expected winner to be seat 1 (bid 6), got {bidder_pos}"
         assert bid == 6, f"Expected winning bid to be 6, got {bid}"
-        assert final_contract == "suit", f"Expected contract 'suit', got {final_contract}"
+        assert (
+            final_contract == "suit"
+        ), f"Expected contract 'suit', got {final_contract}"
         assert final_trump == "H", f"Expected trump 'H', got {final_trump}"
 
         # Verify current_high_bid progression:
@@ -202,14 +308,18 @@ class TestAuctionBiddingRules:
         # - Seat 0 should see current_high_bid = 5 (seat 3's bid)
         # - Seat 1 should see current_high_bid = 5 (seat 0's bid was ignored)
         # - Seat 2 should see current_high_bid = 6 (seat 1's bid)
-        assert ObservationTracker.observed_high_bids[3] == 0, \
-            f"Seat 3 (LOD) should see current_high_bid=0, got {ObservationTracker.observed_high_bids[3]}"
-        assert ObservationTracker.observed_high_bids[0] == 5, \
-            f"Seat 0 should see current_high_bid=5 (from seat 3), got {ObservationTracker.observed_high_bids[0]}"
-        assert ObservationTracker.observed_high_bids[1] == 5, \
-            f"Seat 1 should see current_high_bid=5 (seat 0's bid ignored), got {ObservationTracker.observed_high_bids[1]}"
-        assert ObservationTracker.observed_high_bids[2] == 6, \
-            f"Seat 2 (dealer) should see current_high_bid=6 (from seat 1), got {ObservationTracker.observed_high_bids[2]}"
+        assert (
+            ObservationTracker.observed_high_bids[3] == 0
+        ), f"Seat 3 (LOD) should see current_high_bid=0, got {ObservationTracker.observed_high_bids[3]}"
+        assert (
+            ObservationTracker.observed_high_bids[0] == 5
+        ), f"Seat 0 should see current_high_bid=5 (from seat 3), got {ObservationTracker.observed_high_bids[0]}"
+        assert (
+            ObservationTracker.observed_high_bids[1] == 5
+        ), f"Seat 1 should see current_high_bid=5 (seat 0's bid ignored), got {ObservationTracker.observed_high_bids[1]}"
+        assert (
+            ObservationTracker.observed_high_bids[2] == 6
+        ), f"Seat 2 (dealer) should see current_high_bid=6 (from seat 1), got {ObservationTracker.observed_high_bids[2]}"
 
     def test_contract_types_supported(self):
         """Auction supports suit contracts (S,H,D,C) and HIGH/LOW contracts."""
@@ -228,6 +338,7 @@ class TestAuctionBiddingRules:
 
             class ContractBidder(BiddingPolicy):
                 """Bids with a specific contract type."""
+
                 def choose_bid(self, obs: BiddingObservation) -> BidAction:
                     if obs.seat == 0:  # Only seat 0 bids
                         return BidAction.bid(5, contract_input)
@@ -235,43 +346,94 @@ class TestAuctionBiddingRules:
 
             bidding_policy = ContractBidder()
 
-            fixed_hand = [Card("S", "A"), Card("H", "K"), Card("D", "Q"), Card("C", "J"),
-                          Card("S", "T"), Card("H", "A"), Card("D", "K"), Card("C", "Q"),
-                          Card("S", "J"), Card("H", "T")]
+            fixed_hand = [
+                Card("S", "A"),
+                Card("H", "K"),
+                Card("D", "Q"),
+                Card("C", "J"),
+                Card("S", "T"),
+                Card("H", "A"),
+                Card("D", "K"),
+                Card("C", "Q"),
+                Card("S", "J"),
+                Card("H", "T"),
+            ]
 
             hands = [fixed_hand.copy() for _ in range(4)]
 
-            t0, t1, scores, features, leader, hands, bid, dealer_pos, bidder_pos, final_contract, final_trump = play_single_hand(
+            (
+                t0,
+                t1,
+                scores,
+                features,
+                leader,
+                hands,
+                bid,
+                dealer_pos,
+                bidder_pos,
+                final_contract,
+                final_trump,
+                _,
+            ) = play_single_hand(
                 contract_type=None,
                 bidding_policy=bidding_policy,
                 hands=hands,
                 initial_leader=3,  # Seat 0 is left of dealer
             )
 
-            assert leader == 0, f"Expected leader 0 for contract {contract_input}, got {leader}"
+            assert (
+                leader == 0
+            ), f"Expected leader 0 for contract {contract_input}, got {leader}"
             assert bid == 5, f"Expected bid 5 for contract {contract_input}, got {bid}"
-            assert final_contract == expected_contract, f"Expected contract '{expected_contract}' for {contract_input}, got '{final_contract}'"
-            assert final_trump == expected_trump, f"Expected trump '{expected_trump}' for {contract_input}, got '{final_trump}'"
+            assert (
+                final_contract == expected_contract
+            ), f"Expected contract '{expected_contract}' for {contract_input}, got '{final_contract}'"
+            assert (
+                final_trump == expected_trump
+            ), f"Expected trump '{expected_trump}' for {contract_input}, got '{final_trump}'"
 
     def test_bidder_wins_and_leads(self):
         """The auction winner must lead the first trick."""
 
         class SeatBasedBidder(BiddingPolicy):
             """Only seat 1 bids."""
+
             def choose_bid(self, obs: BiddingObservation) -> BidAction:
                 if obs.seat == 1:
                     return BidAction.bid(6, "S")  # Seat 1 bids 6
-                return BidAction.pass_bid()       # Others pass
+                return BidAction.pass_bid()  # Others pass
 
         bidding_policy = SeatBasedBidder()
 
-        fixed_hand = [Card("S", "A"), Card("H", "K"), Card("D", "Q"), Card("C", "J"),
-                      Card("S", "T"), Card("H", "A"), Card("D", "K"), Card("C", "Q"),
-                      Card("S", "J"), Card("H", "T")]
+        fixed_hand = [
+            Card("S", "A"),
+            Card("H", "K"),
+            Card("D", "Q"),
+            Card("C", "J"),
+            Card("S", "T"),
+            Card("H", "A"),
+            Card("D", "K"),
+            Card("C", "Q"),
+            Card("S", "J"),
+            Card("H", "T"),
+        ]
 
         hands = [fixed_hand.copy() for _ in range(4)]
 
-        t0, t1, scores, features, leader, hands, bid, dealer_pos, bidder_pos, final_contract, final_trump = play_single_hand(
+        (
+            t0,
+            t1,
+            scores,
+            features,
+            leader,
+            hands,
+            bid,
+            dealer_pos,
+            bidder_pos,
+            final_contract,
+            final_trump,
+            _,
+        ) = play_single_hand(
             contract_type=None,
             bidding_policy=bidding_policy,
             hands=hands,

--- a/tests/unit/test_bidding_sequential_semantics.py
+++ b/tests/unit/test_bidding_sequential_semantics.py
@@ -22,6 +22,7 @@ class TestBiddingSequentialSemantics:
 
         class OrderTracker(BiddingPolicy):
             """Records the order in which seats are called to bid."""
+
             call_order = []
 
             def choose_bid(self, obs: BiddingObservation) -> BidAction:
@@ -32,9 +33,18 @@ class TestBiddingSequentialSemantics:
         OrderTracker.call_order = []
 
         policy = OrderTracker()
-        fixed_hand = [Card("S", "A"), Card("H", "K"), Card("D", "Q"), Card("C", "J"),
-                      Card("S", "T"), Card("H", "A"), Card("D", "K"), Card("C", "Q"),
-                      Card("S", "J"), Card("H", "T")]
+        fixed_hand = [
+            Card("S", "A"),
+            Card("H", "K"),
+            Card("D", "Q"),
+            Card("C", "J"),
+            Card("S", "T"),
+            Card("H", "A"),
+            Card("D", "K"),
+            Card("C", "Q"),
+            Card("S", "J"),
+            Card("H", "T"),
+        ]
         hands = [fixed_hand.copy() for _ in range(4)]
 
         # Dealer is seat 2 (initial_leader=3 means dealer = (3-1)%4 = 2)
@@ -47,8 +57,9 @@ class TestBiddingSequentialSemantics:
         )
 
         expected_order = [3, 0, 1, 2]  # LOD → partner → ROD → dealer
-        assert OrderTracker.call_order == expected_order, \
-            f"Expected LOD order {expected_order}, got {OrderTracker.call_order}"
+        assert (
+            OrderTracker.call_order == expected_order
+        ), f"Expected LOD order {expected_order}, got {OrderTracker.call_order}"
 
     def test_strict_raise_legality_enforced(self):
         """Bids <= current_high_bid are treated as pass (illegal bids coerced to pass)."""
@@ -66,20 +77,44 @@ class TestBiddingSequentialSemantics:
         # Seat 1: bid 3 (illegal, <= 5, should be treated as pass)
         # Seat 2: bid 7 (legal, > 5)
         # Seat 3: pass
-        policy = ScriptedBidder({
-            0: BidAction.bid(5, "S"),  # LOD bids 5
-            1: BidAction.bid(3, "H"),  # Partner tries 3 (<= 5, illegal)
-            2: BidAction.bid(7, "D"),  # ROD bids 7 (> 5, legal)
-            3: BidAction.pass_bid(),   # Dealer passes
-        })
+        policy = ScriptedBidder(
+            {
+                0: BidAction.bid(5, "S"),  # LOD bids 5
+                1: BidAction.bid(3, "H"),  # Partner tries 3 (<= 5, illegal)
+                2: BidAction.bid(7, "D"),  # ROD bids 7 (> 5, legal)
+                3: BidAction.pass_bid(),  # Dealer passes
+            }
+        )
 
-        fixed_hand = [Card("S", "A"), Card("H", "K"), Card("D", "Q"), Card("C", "J"),
-                      Card("S", "T"), Card("H", "A"), Card("D", "K"), Card("C", "Q"),
-                      Card("S", "J"), Card("H", "T")]
+        fixed_hand = [
+            Card("S", "A"),
+            Card("H", "K"),
+            Card("D", "Q"),
+            Card("C", "J"),
+            Card("S", "T"),
+            Card("H", "A"),
+            Card("D", "K"),
+            Card("C", "Q"),
+            Card("S", "J"),
+            Card("H", "T"),
+        ]
         hands = [fixed_hand.copy() for _ in range(4)]
 
         # Dealer is seat 2 (initial_leader=3)
-        t0, t1, scores, features, leader, hands, bid, dealer_pos, bidder_pos, final_contract, final_trump = play_single_hand(
+        (
+            t0,
+            t1,
+            scores,
+            features,
+            leader,
+            hands,
+            bid,
+            dealer_pos,
+            bidder_pos,
+            final_contract,
+            final_trump,
+            _,
+        ) = play_single_hand(
             contract_type=None,
             bidding_policy=policy,
             hands=hands,
@@ -87,7 +122,11 @@ class TestBiddingSequentialSemantics:
         )
 
         # Seat 2 (ROD) should win with bid 7 (seat 1's bid 3 was ignored as illegal)
-        assert leader == 2, f"Expected leader to be 2 (ROD with highest valid bid), got {leader}"
+        assert (
+            leader == 2
+        ), f"Expected leader to be 2 (ROD with highest valid bid), got {leader}"
         assert bid == 7, f"Expected bid to be 7, got {bid}"
-        assert final_contract == "suit", f"Expected contract 'suit', got {final_contract}"
+        assert (
+            final_contract == "suit"
+        ), f"Expected contract 'suit', got {final_contract}"
         assert final_trump == "D", f"Expected trump 'D', got {final_trump}"

--- a/tests/unit/test_game_logger.py
+++ b/tests/unit/test_game_logger.py
@@ -1,7 +1,8 @@
 """
 Unit tests for GameLogger and HandEndRecord schema versioning.
 
-Focuses on schema version correctness and the v6 fields (redeal_flag, made_bid).
+Focuses on schema version correctness and the v6 fields (redeal_flag, made_bid)
+and the v7 field (auction_transcript).
 """
 
 import json
@@ -14,15 +15,15 @@ from bid_euchre.logging.game_logger import (
 )
 
 
-def test_schema_version_is_6():
-    """Schema version must be 6 after PR B-1 additions."""
-    assert SCHEMA_VERSION == 6
+def test_schema_version_is_7():
+    """Schema version must be 7 after PR B-2 auction_transcript addition."""
+    assert SCHEMA_VERSION == 7
 
 
 def test_hand_end_record_has_v6_fields():
     """HandEndRecord dataclass must have redeal_flag and made_bid fields."""
     record = HandEndRecord(
-        schema_version=6,
+        schema_version=7,
         event="hand_end",
         run_id="test",
         strategy_id="greedy",
@@ -64,7 +65,7 @@ def test_log_hand_end_writes_v6_fields(tmp_path):
 
     records = [json.loads(line) for line in open(log_path)]
     hand_end = next(r for r in records if r.get("event") == "hand_end")
-    assert hand_end["schema_version"] == 6
+    assert hand_end["schema_version"] == 7
     assert hand_end["redeal_flag"] is False
     assert hand_end["made_bid"] is True
 
@@ -88,7 +89,7 @@ def test_log_hand_end_null_v6_fields_when_not_provided(tmp_path):
 
     records = [json.loads(line) for line in open(log_path)]
     hand_end = next(r for r in records if r.get("event") == "hand_end")
-    assert hand_end["schema_version"] == 6
+    assert hand_end["schema_version"] == 7
     assert hand_end["redeal_flag"] is None
     assert hand_end["made_bid"] is None
 
@@ -117,3 +118,227 @@ def test_redeal_flag_true_for_all_pass_hand(tmp_path):
     assert hand_end["redeal_flag"] is True
     assert hand_end["t0"] == 0
     assert hand_end["t1"] == 0
+
+
+# ---------------------------------------------------------------------------
+# v7 tests — auction_transcript
+# ---------------------------------------------------------------------------
+
+
+def test_hand_end_record_has_auction_transcript_field():
+    """HandEndRecord dataclass must have auction_transcript field defaulting to None."""
+    record = HandEndRecord(
+        schema_version=7,
+        event="hand_end",
+        run_id="test",
+        strategy_id="greedy",
+        deal_id=0,
+        seed=42,
+        contract="suit",
+        trump="H",
+        leader=0,
+        t0=6,
+        t1=4,
+        features=[{}, {}, {}, {}],
+        scores=None,
+        hands=None,
+    )
+    assert hasattr(record, "auction_transcript")
+    assert record.auction_transcript is None  # default
+
+
+def test_log_hand_end_writes_auction_transcript(tmp_path):
+    """log_hand_end writes auction_transcript entries to JSONL output."""
+    log_path = str(tmp_path / "test_v7.jsonl")
+    transcript = [
+        {
+            "seat": 1,
+            "action": "PASS",
+            "tricks_bid": 0,
+            "contract_type": None,
+            "trump": None,
+        },
+        {
+            "seat": 2,
+            "action": "BID",
+            "tricks_bid": 3,
+            "contract_type": "suit",
+            "trump": "H",
+        },
+        {
+            "seat": 3,
+            "action": "PASS",
+            "tricks_bid": 0,
+            "contract_type": None,
+            "trump": None,
+        },
+        {
+            "seat": 0,
+            "action": "PASS",
+            "tricks_bid": 0,
+            "contract_type": None,
+            "trump": None,
+        },
+    ]
+    logger = GameLogger(run_id="test_v7", strategy_id="greedy", level=LogLevel.HAND)
+    logger.open(log_path)
+    logger.log_hand_end(
+        deal_id=0,
+        seed=42,
+        contract="suit",
+        trump="H",
+        leader=2,
+        t0=7,
+        t1=3,
+        features=[{}, {}, {}, {}],
+        redeal_flag=False,
+        made_bid=True,
+        auction_transcript=transcript,
+    )
+    logger.close()
+
+    records = [json.loads(line) for line in open(log_path)]
+    hand_end = next(r for r in records if r.get("event") == "hand_end")
+    assert hand_end["schema_version"] == 7
+    assert hand_end["auction_transcript"] == transcript
+
+
+def test_auction_transcript_null_when_not_provided(tmp_path):
+    """auction_transcript defaults to null in JSONL when not passed."""
+    log_path = str(tmp_path / "test_no_transcript.jsonl")
+    logger = GameLogger(run_id="test_no_tr", strategy_id="greedy", level=LogLevel.HAND)
+    logger.open(log_path)
+    logger.log_hand_end(
+        deal_id=0,
+        seed=42,
+        contract="high",
+        trump=None,
+        leader=0,
+        t0=5,
+        t1=5,
+        features=[{}, {}, {}, {}],
+    )
+    logger.close()
+
+    records = [json.loads(line) for line in open(log_path)]
+    hand_end = next(r for r in records if r.get("event") == "hand_end")
+    assert hand_end["auction_transcript"] is None
+
+
+def test_all_pass_transcript_has_four_passes(tmp_path):
+    """All-pass redeal: transcript has 4 PASS entries alongside redeal_flag=True."""
+    log_path = str(tmp_path / "test_all_pass.jsonl")
+    all_pass_transcript = [
+        {
+            "seat": 1,
+            "action": "PASS",
+            "tricks_bid": 0,
+            "contract_type": None,
+            "trump": None,
+        },
+        {
+            "seat": 2,
+            "action": "PASS",
+            "tricks_bid": 0,
+            "contract_type": None,
+            "trump": None,
+        },
+        {
+            "seat": 3,
+            "action": "PASS",
+            "tricks_bid": 0,
+            "contract_type": None,
+            "trump": None,
+        },
+        {
+            "seat": 0,
+            "action": "PASS",
+            "tricks_bid": 0,
+            "contract_type": None,
+            "trump": None,
+        },
+    ]
+    logger = GameLogger(run_id="test_ap", strategy_id="greedy", level=LogLevel.HAND)
+    logger.open(log_path)
+    logger.log_hand_end(
+        deal_id=0,
+        seed=42,
+        contract="high",
+        trump=None,
+        leader=-1,
+        t0=0,
+        t1=0,
+        features=[{}, {}, {}, {}],
+        redeal_flag=True,
+        made_bid=None,
+        auction_transcript=all_pass_transcript,
+    )
+    logger.close()
+
+    records = [json.loads(line) for line in open(log_path)]
+    hand_end = next(r for r in records if r.get("event") == "hand_end")
+    assert hand_end["redeal_flag"] is True
+    tr = hand_end["auction_transcript"]
+    assert len(tr) == 4
+    assert all(entry["action"] == "PASS" for entry in tr)
+    assert all(entry["tricks_bid"] == 0 for entry in tr)
+
+
+def test_auction_transcript_bid_entry_format(tmp_path):
+    """BID entries in the transcript have correct structure."""
+    log_path = str(tmp_path / "test_bid_entry.jsonl")
+    transcript = [
+        {
+            "seat": 1,
+            "action": "PASS",
+            "tricks_bid": 0,
+            "contract_type": None,
+            "trump": None,
+        },
+        {
+            "seat": 2,
+            "action": "BID",
+            "tricks_bid": 4,
+            "contract_type": "high",
+            "trump": None,
+        },
+        {
+            "seat": 3,
+            "action": "PASS",
+            "tricks_bid": 0,
+            "contract_type": None,
+            "trump": None,
+        },
+        {
+            "seat": 0,
+            "action": "PASS",
+            "tricks_bid": 0,
+            "contract_type": None,
+            "trump": None,
+        },
+    ]
+    logger = GameLogger(run_id="test_bid", strategy_id="greedy", level=LogLevel.HAND)
+    logger.open(log_path)
+    logger.log_hand_end(
+        deal_id=0,
+        seed=42,
+        contract="high",
+        trump=None,
+        leader=2,
+        t0=3,
+        t1=7,
+        features=[{}, {}, {}, {}],
+        winning_bid=4,
+        bidder_position=2,
+        made_bid=False,
+        auction_transcript=transcript,
+    )
+    logger.close()
+
+    records = [json.loads(line) for line in open(log_path)]
+    hand_end = next(r for r in records if r.get("event") == "hand_end")
+    bid_entry = next(e for e in hand_end["auction_transcript"] if e["action"] == "BID")
+    assert bid_entry["seat"] == 2
+    assert bid_entry["tricks_bid"] == 4
+    assert bid_entry["contract_type"] == "high"
+    assert bid_entry["trump"] is None


### PR DESCRIPTION
## Summary
- Add `auction_transcript` field to `hand_end` JSONL records (schema v7): 4-entry list `[{seat, action, tricks_bid, contract_type, trump}]` accumulated from all 3 auction code paths
- Wire `redeal_flag` and `made_bid` at the callsite — both existed in schema v6 (PR #361) but were never computed; now computed in `simulate_many_hands()` and passed to `log_hand_end()`
- Close all 3 open `CODEBASE_CONSISTENCY.md` items (auction_transcript, redeal_flag, made_bid)

## Why
- Without per-seat bid records, we can't audit or replay bidding decisions
- `redeal_flag` and `made_bid` were always `null` at runtime despite being in the schema — this PR closes the gap
- CODEBASE_CONSISTENCY items 1, 2, 3 have been open since 2026-01-04

## Repro / Validation
**Command(s) run:**
- `make check` — 1,298 passed, 0 failed

**Config (if applicable):**
- N/A (schema/logging change; no experiment config)

**Seed (if applicable):**
- N/A

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/` — 1,298 passed
- [x] Other: 5 new tests in `test_game_logger.py` for v7 schema; updated 6 existing test files with 12-element unpack

## Expected impact
- Metrics impact: none (new optional fields with null defaults)
- Runtime impact: negligible (4-entry list append per hand during bidding)

## Risk level
- [x] Medium (strategy/experiments) — changes simulation.py return tuple (backward-compatible for existing callers that only call `simulate_many_hands`)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-schema-v7
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-schema-v7
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre          46da8e3 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-schema-v7  9c7d8eb [codex/schema-v7-auction-transcript]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

## PR URL
- (paste after creation)