### PR TITLE
fix: reject trump_suit for high/low (no-trump) contracts

### DIFF
--- a/src/bid_euchre/sim/simulation.py
+++ b/src/bid_euchre/sim/simulation.py
@@ -397,6 +397,10 @@ def play_single_hand(
     # Validation (now that contract is decided)
     if contract_type == "suit" and trump_suit is None:
         raise ValueError("trump_suit must be provided or decided for 'suit' contracts")
+    if contract_type in ("high", "low") and trump_suit is not None:
+        raise ValueError(
+            "trump_suit must be None for 'high'/'low' (no-trump) contracts"
+        )
 
     # Extract features for ALL 4 players
     all_player_scores: List[int] = []

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -256,9 +256,6 @@ class TestErrorHandling:
         with pytest.raises(ValueError):
             simulation.simulate_many_hands(10, "suit", None)
 
-    @pytest.mark.xfail(
-        reason="Trump suit validation for high/low contracts not yet implemented"
-    )
     def test_trump_provided_for_no_trump_contract(self):
         """Test error when trump suit provided for no-trump contracts."""
         with pytest.raises(ValueError):

--- a/tests/integration/test_simulation_validation.py
+++ b/tests/integration/test_simulation_validation.py
@@ -177,9 +177,6 @@ class TestSimulationEdgeCases:
         with pytest.raises(ValueError):
             simulation.simulate_many_hands(10, "suit", None)
 
-    @pytest.mark.xfail(
-        reason="Trump suit validation for high/low contracts not yet implemented"
-    )
     def test_simulation_no_trump_contracts_with_trump(self):
         """Test that high/low contracts reject trump suit."""
         with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- Add defensive validation in `play_single_hand()` rejecting `trump_suit` for high/low contracts
- Remove 2 `xfail` test markers that were waiting for this validation

## Why
RULES.md §3.2.1 requires `trump=null` for high/low (no-trump) contracts. The existing validation enforces that suit contracts *require* `trump_suit`, but the complementary check — that high/low contracts *reject* `trump_suit` — was missing. Two xfail tests explicitly documented this gap.

No game results were affected (all core rule functions gate trump logic on `contract_type == "suit"`), but the missing guard allowed invalid configurations to silently pass.

## Repro / Validation
```bash
make check  # All 1306 fast tests pass (was 1304 passing + 2 xfail)
uv run python -m pytest -k "test_simulation_no_trump_contracts_with_trump or test_trump_provided_for_no_trump_contract" -v
```

## Tests
- [x] `make check` passes (repo-lint + ruff + pytest + docs-freshness)
- [x] 2 formerly-xfail integration tests now pass normally:
  - `tests/integration/test_simulation_validation.py::TestSimulationEdgeCases::test_simulation_no_trump_contracts_with_trump`
  - `tests/integration/test_integration.py::TestErrorHandling::test_trump_provided_for_no_trump_contract`

## Expected impact
- Metrics impact: None (no production code passes trump_suit to high/low contracts)
- Runtime impact: None (single conditional check)

## Risk level
- [x] High (core rules/sim/scoring) — but blast radius is minimal (defensive assertion only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-high-low-validation
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-high-low-validation
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                              c5a346e [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-high-low-validation          ed66999 [fix/high-low-trump-validation]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)