### PR TITLE
docs: reconcile docs with post-schema-v7 reality

### DIFF
--- a/docs/01_core/BIDDING.md
+++ b/docs/01_core/BIDDING.md
@@ -23,12 +23,13 @@ Bid Euchre bidding mechanics define how players select contracts for each hand. 
 
 Bidding observations provide minimal context for decision-making:
 
-- **Hand**: Player's 5 cards
+- **Hand**: Player's 10 cards
 - **Seat**: Player's position (0-3)
 - **Dealer seat**: Dealer's position (0-3)
 - **Current high bid**: Highest `n` bid so far in this round
+- **Allowed contracts**: Tuple of contract types the player may bid (`C`, `D`, `H`, `S`, `HIGH`, `LOW` by default)
 
-**Note**: Bidding history not included (planned for v2)
+**Note**: Full bidding history is now captured in game logs via the `auction_transcript` field (schema v7). The observation contract itself still provides only the current high bid, not the full history.
 
 ## Default Behavior
 

--- a/docs/01_core/METRICS.md
+++ b/docs/01_core/METRICS.md
@@ -54,14 +54,21 @@ These are computed by aggregation scripts from emitted keys:
 ### Drift v1 Contract (Tricks-Only)
 Drift v1 compares the `avg_tricks_team0` field from rollup summary against expected values in `data/fixtures/baseline_full_expected.json`. This is the primary regression signal for tricks-based strategies.
 
-## Auction Metrics (Optional)
+## Auction Metrics
 
-Auction/bidding metrics are optional and clearly labeled as such until a bidding policy is implemented.
+When bidding is enabled (`contract_type: null` in scenario config), the evaluator emits the following metrics. The primary series is `bidder_team_points` from `compute_points()`.
 
-When bidding is enabled, additional metrics will include:
-- Make rate: Proportion of hands where bidding team meets or exceeds their bid
-- Set rate: Proportion of hands where bidding team falls short of their bid
-- Average bid values
+| Metric | Definition |
+|--------|-----------|
+| `expected_points` | Mean of `bidder_team_points` across hands where an auction winner exists |
+| `expected_points_per_deal` | Mean of `bidder_team_points` across all deals (0 for all-pass redeals) |
+| `make_rate` | Fraction of auction-won hands where `bidder_team_points >= 0` |
+| `bid_rate` | Fraction of deals with an auction winner (i.e., not all-pass) |
+| `pass_rate` | Fraction of deals that resulted in all-pass redeals |
+| `cvar_5` | Mean of the worst 5% of `bidder_team_points` values (conditional value at risk) |
+| `downside_variance` | Variance of negative `bidder_team_points` values (downside risk) |
+
+**Source:** `src/bid_euchre/reporting/evaluator.py`
 
 ## Where to Find These Fields
 

--- a/docs/03_TODO/CODEBASE_CONSISTENCY.md
+++ b/docs/03_TODO/CODEBASE_CONSISTENCY.md
@@ -1,7 +1,7 @@
 # CODEBASE_CONSISTENCY — doc/code gap tracker (RULES.md + METRICS.md)
 
 **Created:** 2026-01-04
-**Last verified on main:** 2026-02-16 (commit `d515ed2`)
+**Last verified on main:** 2026-02-18 (commit `c5a346e`)
 **Status:** Active
 
 ## How to read this file
@@ -14,30 +14,7 @@
 
 ## Now (top 3)
 
-### 1) Add auction transcript logging (RULES.md §8.2)
-
-**Status:** Resolved in PR B-2 (schema v7, 2026-02-18)
-**Why it matters:** We can't audit/replay bidding decisions without per-seat bid actions.
-
-**Resolution:** `auction_transcript` field added to `hand_end` records (schema v7). 4-entry list `[{seat, action, tricks_bid, contract_type, trump}]` accumulated across all 3 auction code paths in `play_single_hand()`. `null` when no auction ran (fixed-contract mode).
-
----
-
-### 2) Add `redeal_flag` to hand-level logs (RULES.md §8.2)
-
-**Status:** Resolved in PR B-1 (schema v6) + PR B-2 callsite wiring (2026-02-18)
-**Why it matters:** RULES.md requires an explicit redeal signal; today it's implicit/derivable at best.
-
-**Resolution:** `redeal_flag` added to `HandEndRecord` in schema v6 (PR #361). Callsite wired in PR B-2: computed as `(winning_bid == 0 and bidder_pos is None)` in `simulate_many_hands()`.
-
----
-
-### 3) Add `made_bid` to hand-level logs (RULES.md §8.2 / METRICS.md required field)
-
-**Status:** Resolved in PR B-1 (schema v6) + PR B-2 callsite wiring (2026-02-18)
-**Why it matters:** `made_bid` is a required analysis field; deriving it downstream is easy but brittle and obscures intent.
-
-**Resolution:** `made_bid` added to `HandEndRecord` in schema v6 (PR #361). Callsite wired in PR B-2: computed from `t0/t1 >= winning_bid` by team in `simulate_many_hands()`.
+_All previous top-3 items resolved (see Done/Archived). Next priorities should be drawn from the "Later" section below._
 
 ---
 
@@ -121,6 +98,9 @@
 
 ## Done/Archived (verified in repo)
 
+- **Auction transcript logging (RULES.md §8.2):** Resolved in PR #362 (schema v7). `auction_transcript` field on `hand_end` records captures per-seat bid actions as a 4-entry list.
+- **`redeal_flag` on hand-level logs (RULES.md §8.2):** Resolved in PRs #361 (schema v6, field) + #362 (callsite wiring). Computed as `(winning_bid == 0 and bidder_pos is None)`.
+- **`made_bid` on hand-level logs (RULES.md §8.2):** Resolved in PRs #361 (schema v6, field) + #362 (callsite wiring). Computed from team tricks vs winning bid.
 - **Arc B bidding infrastructure complete:** `datasets/`, `models/`, and `diagnostics/` modules implemented; `train_bidder.py` and `collect_bidless_dataset.py` scripts operational; ModeloEspecifico and ArtifactBidder policies working.
 - **Scoring system implemented:** `src/bid_euchre/scoring.py::compute_points()` exists, simulation calls it, and unit tests cover exact scoring cases.
 - **`hand_id` vs `deal_id` clarification no longer needed:** `docs/01_core/METRICS.md` no longer references `hand_id`.

--- a/docs/03_TODO/README.md
+++ b/docs/03_TODO/README.md
@@ -9,10 +9,10 @@ This directory contains documents tracking work that needs to be done but isn't 
 ## 📋 Current TODOs
 
 ### Active
-- **CODEBASE_CONSISTENCY.md** - Code changes needed to align with RULES.md specifications (8-12 hours estimated)
+- **CODEBASE_CONSISTENCY.md** - Remaining "Later" items: dual outcome tracking, card instance IDs, separate strategy IDs, team-randomized comparator, strategy-centric metrics, terminology standardization
 
 ### Completed
-_(None yet - move completed items here with completion date)_
+- **CODEBASE_CONSISTENCY items 1-3** (2026-02-18): auction_transcript (schema v7), redeal_flag (schema v6), made_bid (schema v6) — all wired in PRs #361/#362
 
 ---
 
@@ -43,18 +43,13 @@ _(None yet - move completed items here with completion date)_
 
 ## 🎯 Current Focus
 
-The primary TODO is **CODEBASE_CONSISTENCY.md** which tracks alignment between RULES.md and implementation:
-
-**Quick wins (< 1 hour):**
-- Add `redeal_flag` to logger (15 min)
-- Rename `contract` → `contract_type` (15 min)
-
-**High value (2-3 hours each):**
-- Auction transcript logging
-- Scoring system implementation
+The quick-wins and high-value items from CODEBASE_CONSISTENCY.md are resolved (auction transcript, redeal_flag, made_bid, scoring system). Remaining open items are in the "Later" section of CODEBASE_CONSISTENCY.md:
 
 **Can defer:**
 - Card instance IDs (complex, needed for perfect replay)
+- Dual outcome tracking (trick_win vs points_win)
+- Separate strategy IDs in logs
+- Team-randomized comparator protocol
 - Terminology standardization (polish)
 
 ---

--- a/docs/04_reports/README.md
+++ b/docs/04_reports/README.md
@@ -11,5 +11,8 @@ Each report is a point-in-time snapshot with:
 
 | Report | Date | Phase | Summary |
 |--------|------|-------|---------|
-| [phase0_bidless_20260207_r2.md](phase0_bidless_20260207_r2.md) | 2026-02-07 | Phase 0 (Bidless) | **Current** — Refactored report with chart versioning, t-test gate |
+| [phase0_bidless_20260207_r5.md](phase0_bidless_20260207_r5.md) | 2026-02-18 | Phase 0 (Bidless) | **Current** — Glutton correlations, per-contract §6d tables |
+| [phase0_bidless_20260207_r4.md](phase0_bidless_20260207_r4.md) | 2026-02-16 | Phase 0 (Bidless) | Health-first restructure, 12 sections, 8 new charts, per-contract Ridge coefficients |
+| [phase0_bidless_20260207_r3.md](phase0_bidless_20260207_r3.md) | 2026-02-08 | Phase 0 (Bidless) | Comprehensive rewrite with normalization fix, seat×contract chart, coefficient heatmap |
+| [phase0_bidless_20260207_r2.md](phase0_bidless_20260207_r2.md) | 2026-02-07 | Phase 0 (Bidless) | Refactored report with chart versioning, t-test gate |
 | [phase0_bidless_20260207.md](phase0_bidless_20260207.md) | 2026-02-07 | Phase 0 (Bidless) | Original report (immutable) |

--- a/docs/FLOW_DIAGRAM.md
+++ b/docs/FLOW_DIAGRAM.md
@@ -46,7 +46,7 @@ flowchart TB
         Scoring["scoring.py<br/>(standalone module)"]
 
         subgraph Logging["logging/"]
-            GameLogger["game_logger.py<br/>(JSONL schema v5)"]
+            GameLogger["game_logger.py<br/>(JSONL schema v7)"]
         end
 
         subgraph Reporting["reporting/"]
@@ -130,7 +130,7 @@ flowchart TD
     CreateRunDir --> SaveEffectiveConfig["Save config_effective.yaml<br/>(resolved configuration)"]
     SaveEffectiveConfig --> SaveMeta["Save meta.json<br/>(schema v2: seed, timestamp, git_hash)"]
 
-    SaveMeta --> InitLogger["Initialize GameLogger<br/>(JSONL schema v5)"]
+    SaveMeta --> InitLogger["Initialize GameLogger<br/>(JSONL schema v7)"]
     InitLogger --> InitStrategies["Instantiate strategies<br/>(GreedyStrategy, etc.)"]
 
     InitStrategies --> GenerateDeals["Generate deals<br/>(deals.derive_deal_from_index)"]
@@ -457,7 +457,7 @@ These files are only created when specific flags are provided:
 
 | Artifact | CLI Flag | When Generated | Notes |
 |----------|----------|----------------|-------|
-| `logs/*.jsonl` | `--log-level hand` or `--log-level trick` | During simulation | JSONL schema v5 event stream |
+| `logs/*.jsonl` | `--log-level hand` or `--log-level trick` | During simulation | JSONL schema v7 event stream |
 | `datasets/bidding.*` | `--emit-bidding-dataset` | After simulation | Only in auction mode (contract_type: null) |
 | `datasets/bidless.*` | `--emit-bidless-dataset` | After simulation | Only in declared contract mode |
 
@@ -636,7 +636,7 @@ flowchart TD
 
     OtherEvents --> Custom
 
-    GameLogger --> JSONL["logs/game_events.jsonl<br/>(schema v5)"]
+    GameLogger --> JSONL["logs/game_events.jsonl<br/>(schema v7)"]
     Collectors --> Parquet["datasets/*.parquet"]
 
     style Simulation fill:#e1f5ff


### PR DESCRIPTION
## Summary
- Align 6 doc files with the current codebase state after schema v6/v7 merges (PRs #361, #362)
- No code changes — docs only

## Why
Several docs were stale after the schema v6/v7 work landed:
- FLOW_DIAGRAM.md still referenced "schema v5" in 4 places
- METRICS.md described auction metrics as "optional" placeholders despite production evaluator code
- BIDDING.md had incorrect hand size (5 → 10 cards) and stale v2 note
- CODEBASE_CONSISTENCY.md top-3 items were resolved but not archived
- Report index was missing r3/r4/r5 entries
- TODO/README.md listed resolved items as current focus

## Changes by file

| File | Change |
|------|--------|
| `docs/FLOW_DIAGRAM.md` | `schema v5` → `schema v7` (4 occurrences) |
| `docs/03_TODO/CODEBASE_CONSISTENCY.md` | Move items 1-3 to Done/Archived, update verification date to `c5a346e` |
| `docs/01_core/METRICS.md` | Replace 3-bullet auction placeholder with 7 production metric definitions |
| `docs/01_core/BIDDING.md` | Fix "5 cards" → "10 cards", add `allowed_contracts`, update auction_transcript note |
| `docs/04_reports/README.md` | Add r3/r4/r5 entries, mark r5 as current |
| `docs/03_TODO/README.md` | Update current focus (quick-wins all resolved) |

## Repro / Validation
```bash
make check  # All checks pass (docs-freshness validates backtick paths, headings, command contracts)
```

## Tests
- [x] `make check` passes (repo-lint + ruff + pytest + docs-freshness)
- No code changes, so no new tests needed

## Expected impact
- Metrics impact: None (docs only)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-doc-reconciliation
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-doc-reconciliation
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                              c5a346e [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-doc-reconciliation           3b490d7 [docs/post-schema-v7-reconciliation]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)