### PR TITLE
feat: split_guard runtime enforcement for HITL workflow

### DIFF
--- a/src/bid_euchre/diagnostics/split_guard.py
+++ b/src/bid_euchre/diagnostics/split_guard.py
@@ -1,0 +1,135 @@
+"""Runtime split-access enforcement for HITL notebook workflow.
+
+Provides ``require_split()`` which filters a DataFrame to a requested
+partition while enforcing visibility rules:
+
+- During HITL review (``active_split="val"``), test-split access is blocked.
+- During blind test (``active_split="test"``), test-split access is allowed.
+- Partition hashes are re-derived and verified against the manifest.
+
+This module is the *runtime* complement to the *static* split manifest
+validation in ``models.splits.verify_split_manifest``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from bid_euchre.models.splits import SplitManifest, _hash_hand_ids
+
+# Valid split names by manifest type
+_VALID_SPLITS_THREE_WAY = frozenset({"train", "val", "test"})
+_VALID_SPLITS_TWO_WAY = frozenset({"train", "test"})
+
+
+def _partition_hand_ids(
+    df: pd.DataFrame,
+    manifest: SplitManifest,
+    seed: int,
+) -> dict[str, np.ndarray]:
+    """Re-derive partition boundaries from manifest metadata.
+
+    Returns a dict mapping split name -> array of hand_ids.
+    """
+    unique_ids = df["hand_id"].unique()
+    rng = np.random.RandomState(seed)
+    rng.shuffle(unique_ids)
+
+    n_total = len(unique_ids)
+
+    if manifest.split_type == "two_way":
+        split_idx = int(n_total * manifest.train_fraction)
+        return {
+            "train": unique_ids[:split_idx],
+            "test": unique_ids[split_idx:],
+        }
+    else:  # three_way
+        train_end = int(n_total * manifest.train_fraction)
+        val_end = train_end + int(n_total * (manifest.val_fraction or 0))
+        return {
+            "train": unique_ids[:train_end],
+            "val": unique_ids[train_end:val_end],
+            "test": unique_ids[val_end:],
+        }
+
+
+def require_split(
+    df: pd.DataFrame,
+    manifest: SplitManifest,
+    allowed_split: str,
+    seed: int,
+    *,
+    active_split: str = "val",
+) -> pd.DataFrame:
+    """Filter *df* to the requested split with access-control enforcement.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Full dataset with ``hand_id`` column.
+    manifest : SplitManifest
+        Split manifest defining partition boundaries and hashes.
+    allowed_split : str
+        Which partition to return: ``"train"``, ``"val"``, or ``"test"``.
+    seed : int
+        The split seed (must match ``manifest.split_seed``).
+    active_split : str, default ``"val"``
+        Current notebook context. When ``"val"`` (HITL mode), requesting
+        ``"test"`` raises ``ValueError``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Rows belonging to the requested partition.
+
+    Raises
+    ------
+    ValueError
+        If *allowed_split* is invalid, test access is blocked, or
+        partition hashes don't match the manifest.
+    """
+    # Determine valid splits for this manifest type
+    if manifest.split_type == "three_way":
+        valid_splits = _VALID_SPLITS_THREE_WAY
+    else:
+        valid_splits = _VALID_SPLITS_TWO_WAY
+
+    # Validate split name
+    if allowed_split not in valid_splits:
+        if allowed_split == "val" and manifest.split_type == "two_way":
+            raise ValueError(
+                f"Split 'val' is not available in a two_way manifest. "
+                f"Valid splits: {sorted(valid_splits)}"
+            )
+        raise ValueError(
+            f"Unknown split name {allowed_split!r}. "
+            f"Valid splits for {manifest.split_type}: {sorted(valid_splits)}"
+        )
+
+    # Enforce test-split access control
+    if allowed_split == "test" and active_split == "val":
+        raise ValueError(
+            "Test split access blocked during HITL review. "
+            "Set active_split='test' for blind test evaluation."
+        )
+
+    # Re-derive partitions
+    partitions = _partition_hand_ids(df, manifest, seed)
+
+    # Verify partition hash matches manifest
+    requested_ids = partitions[allowed_split]
+    computed_hash = _hash_hand_ids(requested_ids)
+    expected_hash = manifest.partition_hashes.get(allowed_split)
+
+    if computed_hash != expected_hash:
+        raise ValueError(
+            f"Partition hash mismatch for split {allowed_split!r}. "
+            f"Computed: {computed_hash[:16]}..., "
+            f"Expected: {(expected_hash or 'None')[:16]}... "
+            f"Data may have changed since the manifest was created."
+        )
+
+    # Filter and return
+    id_set = set(requested_ids)
+    return df[df["hand_id"].isin(id_set)].copy()

--- a/tests/unit/test_split_guard.py
+++ b/tests/unit/test_split_guard.py
@@ -1,0 +1,161 @@
+"""Tests for split-access enforcement via split_guard.
+
+Tests cover:
+- Correct DataFrame filtering for train/val/test splits
+- Test-split blocking during HITL (active_split="val")
+- Test-split access during blind evaluation (active_split="test")
+- Partition hash verification (pass and mismatch)
+- Unknown split name rejection
+- Two-way manifest handling (no val split)
+"""
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from bid_euchre.diagnostics.split_guard import require_split
+from bid_euchre.models.splits import create_grouped_split
+
+
+@pytest.fixture
+def sample_parquet(tmp_path: Path) -> Path:
+    """Create a small parquet file for testing (100 hands, 4 seats each)."""
+    rows = []
+    for hand_id in range(100):
+        for seat in range(4):
+            rows.append({"hand_id": hand_id, "seat": seat, "tricks_won": 5.0})
+    df = pd.DataFrame(rows)
+    parquet_path = tmp_path / "bidless.parquet"
+    df.to_parquet(parquet_path)
+    return parquet_path
+
+
+@pytest.fixture
+def sample_df(sample_parquet: Path) -> pd.DataFrame:
+    return pd.read_parquet(sample_parquet)
+
+
+@pytest.fixture
+def three_way_split(sample_df, sample_parquet):
+    """Create a three-way split and return (df, manifest)."""
+    _train, _val, _test, manifest = create_grouped_split(
+        sample_df,
+        seed=42,
+        source_run_id="test_run",
+        source_parquet_path=str(sample_parquet),
+        split_type="three_way",
+    )
+    return sample_df, manifest
+
+
+@pytest.fixture
+def two_way_split(sample_df, sample_parquet):
+    """Create a two-way split and return (df, manifest)."""
+    _train, _val, _test, manifest = create_grouped_split(
+        sample_df,
+        seed=42,
+        source_run_id="test_run",
+        source_parquet_path=str(sample_parquet),
+        split_type="two_way",
+    )
+    return sample_df, manifest
+
+
+class TestRequireSplitReturnsCorrectData:
+    """Verify require_split filters to the correct partition."""
+
+    def test_require_val_split_returns_val_data(self, three_way_split):
+        df, manifest = three_way_split
+        result = require_split(df, manifest, "val", seed=42, active_split="val")
+        assert len(result) > 0
+        # Val should be roughly 10% of 100 hands * 4 seats = ~40 rows
+        assert len(result) < len(df)
+
+    def test_require_train_split_returns_train_data(self, three_way_split):
+        df, manifest = three_way_split
+        result = require_split(df, manifest, "train", seed=42, active_split="val")
+        assert len(result) > 0
+        # Train should be the largest partition
+        val = require_split(df, manifest, "val", seed=42, active_split="val")
+        assert len(result) > len(val)
+
+    def test_splits_are_disjoint(self, three_way_split):
+        df, manifest = three_way_split
+        train = require_split(df, manifest, "train", seed=42, active_split="test")
+        val = require_split(df, manifest, "val", seed=42, active_split="test")
+        test = require_split(df, manifest, "test", seed=42, active_split="test")
+
+        train_ids = set(train["hand_id"].unique())
+        val_ids = set(val["hand_id"].unique())
+        test_ids = set(test["hand_id"].unique())
+
+        assert train_ids.isdisjoint(val_ids)
+        assert train_ids.isdisjoint(test_ids)
+        assert val_ids.isdisjoint(test_ids)
+
+    def test_splits_cover_all_data(self, three_way_split):
+        df, manifest = three_way_split
+        train = require_split(df, manifest, "train", seed=42, active_split="test")
+        val = require_split(df, manifest, "val", seed=42, active_split="test")
+        test = require_split(df, manifest, "test", seed=42, active_split="test")
+
+        assert len(train) + len(val) + len(test) == len(df)
+
+
+class TestTestSplitAccessControl:
+    """Verify test-split blocking during HITL and access during blind test."""
+
+    def test_require_test_blocked_during_hitl(self, three_way_split):
+        df, manifest = three_way_split
+        with pytest.raises(ValueError, match="Test split access blocked"):
+            require_split(df, manifest, "test", seed=42, active_split="val")
+
+    def test_require_test_allowed_during_blind(self, three_way_split):
+        df, manifest = three_way_split
+        result = require_split(df, manifest, "test", seed=42, active_split="test")
+        assert len(result) > 0
+
+
+class TestPartitionHashVerification:
+    """Verify partition hash checks catch corruption."""
+
+    def test_partition_hash_matches(self, three_way_split):
+        df, manifest = three_way_split
+        # Should not raise
+        require_split(df, manifest, "val", seed=42, active_split="val")
+
+    def test_partition_hash_mismatch_detected(self, three_way_split):
+        """Wrong seed produces different partitions -> hash mismatch."""
+        df, manifest = three_way_split
+        with pytest.raises(ValueError, match="Partition hash mismatch"):
+            require_split(df, manifest, "val", seed=99, active_split="val")
+
+
+class TestEdgeCases:
+    """Test error handling for invalid inputs."""
+
+    def test_unknown_split_name_raises(self, three_way_split):
+        df, manifest = three_way_split
+        with pytest.raises(ValueError, match="Unknown split name"):
+            require_split(df, manifest, "foo", seed=42, active_split="val")
+
+    def test_two_way_manifest_no_val(self, two_way_split):
+        df, manifest = two_way_split
+        with pytest.raises(ValueError, match="not available in a two_way"):
+            require_split(df, manifest, "val", seed=42, active_split="val")
+
+    def test_two_way_train_works(self, two_way_split):
+        df, manifest = two_way_split
+        result = require_split(df, manifest, "train", seed=42, active_split="val")
+        assert len(result) > 0
+
+    def test_two_way_test_blocked_during_hitl(self, two_way_split):
+        df, manifest = two_way_split
+        with pytest.raises(ValueError, match="Test split access blocked"):
+            require_split(df, manifest, "test", seed=42, active_split="val")
+
+    def test_two_way_test_allowed_during_blind(self, two_way_split):
+        df, manifest = two_way_split
+        result = require_split(df, manifest, "test", seed=42, active_split="test")
+        assert len(result) > 0


### PR DESCRIPTION
## Summary
- Add `split_guard.py` module with `require_split()` function for runtime split-access enforcement
- Add 13 unit tests covering access control, hash verification, and edge cases

## Why
Phase 1 model development requires enforcing that HITL review notebooks can only access the validation split — the test split must be physically inaccessible during tuning to prevent data leakage. This is the first MVP PR for the HITL Notebook Gates framework (plan: `plans/hitl_notebook_gates_plan.md`).

## Repro / Validation
**Command(s) run:**
```bash
make check  # 1,302 passed, 5 skipped, 1 xpassed
uv run python -m pytest tests/unit/test_split_guard.py -v  # 13 passed
```

## Tests
- [x] `make check` — full suite passes (1,302 tests)
- [x] `tests/unit/test_split_guard.py` — 13 new tests

## Expected impact
- Metrics impact: None (new module, no behavior changes)
- Runtime impact: None (not called by existing code)

## Risk level
- [x] Low (new module + tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-split-guard
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-split-guard
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre              f10b9f9 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-split-guard  e12a1a3 [feat/split-guard]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] Behavior changes have matching tests (13 new tests)
- [x] PR is focused (one concept: split access enforcement)