### PR TITLE
docs: rewrite Arc D execution plan v2 with 15 review fixes

### DIFF
--- a/plans/arc_d_execution_plan.md
+++ b/plans/arc_d_execution_plan.md
@@ -548,14 +548,22 @@ def should_promote(challenger, control, rung_id):
 
     # --- Pre-Gates: delegate to compute_eligibility() ---
     # The gate runner calls compute_eligibility() which checks:
-    #   - artifact freeze (via check_artifacts_frozen)
-    #   - split manifest integrity
-    #   - semantic gate on val partition (semantic_gate_val.json)
-    #   - semantic gate on test partition (semantic_gate_test.json)
-    # compute_eligibility() must return ELIGIBLE for promotion to proceed.
-    eligibility = compute_eligibility(challenger.artifact_path, challenger.gates)
-    if eligibility.decision != "ELIGIBLE":
-        return ("REJECT", [f"Eligibility FAIL: {eligibility.reasons}"])
+    #   - config membership, canonical summaries, notebook gate
+    #   - semantic gate on val + test partitions (via check_semantic_gate)
+    #   - git SHA consistency, artifact freeze, split manifests
+    # Signature: compute_eligibility(rollup, run_base_dir, batch_purpose, ...)
+    # Returns BatchGate with .eligible (bool) and .reasons (list of CheckResult)
+    eligibility = compute_eligibility(
+        rollup=challenger.rollup,
+        run_base_dir=challenger.run_base_dir,
+        batch_purpose=challenger.batch_purpose,
+        artifact_dir=challenger.artifact_dir,
+        split_manifest_dir=challenger.split_manifest_dir,
+        semantic_gate_dir=challenger.semantic_gate_dir,
+    )
+    if not eligibility.eligible:
+        failed = [r for r in eligibility.reasons if r.status != "PASS"]
+        return ("REJECT", [f"Eligibility FAIL: {[r.detail for r in failed]}"])
 
     # --- Tier 2: Model Quality ---
     c = challenger.metrics_seed42


### PR DESCRIPTION
## Summary
- Rewrites `plans/arc_d_execution_plan.md` incorporating 8 non-negotiable review fixes + 7 additional review findings
- Transforms from 9-PR model-complexity ladder to 16-PR bidding-context ladder (R0→R5)
- New `hybrid_olsa_v1` artifact schema with two-stage architecture from R0 onward

## Why
The v1 plan (PR #373) had structural issues identified during review:
rungs conflated model complexity with information gain, thresholds were
too loose, the gate runner was standalone instead of adapting the central
eligibility engine, and several PRs violated one-concept-per-PR.

## Key Changes (15 fixes applied)

**8 Non-Negotiable Fixes:**
1. R0→R5 bidding context ladder (not model complexity)
2. `hybrid_olsa_v1` schema with `stage1_win_model` + `stage2_payoff_model`
3. Tighter thresholds: delta 0.01, bid_rate [0.05,0.95], make_rate≥0.45, cvar_5 tol 0.10, dv 1.10x
4. Output paths: `docs/02_agent/MODEL_ARC_RUNS.md`, `docs/04_reports/model_arc_*`
5. Semantic gate naming: `semantic_gate_val.json`, `semantic_gate_test.json`
6. Risk sign fix: `risk_penalty = max(0, -CVaR_5)` → always ≥ 0
7. Strict split discipline: train-only fit, val-only tune, test-only blind eval
8. Gate runner as adapter wrapping `compute_eligibility()`

**7 Additional Findings:**
1. One concept per PR enforced (16 PRs, R2-R4 split into a/b)
2. Dependency gate reflects pipeline reality (no `compute_eligibility()` yet)
3. Absolute paths everywhere
4. Schema doc + validator contracts (`hybrid_olsa_v1.md` + linter rule)
5. Promotion delta with confidence: `max(0.01, 1.5*SE)`
6. Doc-sync PR (I3) for PROMOTION_WORKFLOW.md + DATA_CONTRACT.md
7. `make repo-lint` required for all PRs including doc-only

## Repro / Validation
```
make repo-lint  # passes
```

## Tests
- [x] `make repo-lint` passes
- [x] No TBD/TBC/open-question markers
- [x] All thresholds concrete numbers
- [x] 10-section document structure (§1-§10)

## Expected impact
- Metrics impact: None (documentation only)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-arc-d-plan-v2
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-arc-d-plan-v2
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre              9db8a22 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-arc-d-plan-v2 e06a3b1 [docs/arc-d-plan-v2]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] PR is focused (one concept: plan rewrite)
- [x] Documentation only — no behavior changes