### PR TITLE
chore: slim .claude/CLAUDE.md — remove doc imports

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,85 +1,8 @@
 # Claude Code Project Memory — Bid Euchre
 
-This file is the entrypoint for Claude Code sessions. It imports the authoritative docs.
-
-## Imported Docs (Authoritative Sources)
-
-### Architecture & Execution
-@docs/01_core/ARCHITECTURE.md
-@docs/01_core/EXPERIMENTS.md
-
-### Core Contracts
-@docs/01_core/RULES.md
-@docs/01_core/REPRODUCIBILITY.md
-@docs/01_core/DATA_CONTRACT.md
-@docs/01_core/METRICS.md
-@docs/01_core/SCORING.md
-
-### Validation & Quality
-@docs/01_core/DRIFT.md
-@docs/02_agent/QUALITY_BAR.md
-@docs/02_agent/REVIEW_CHECKLIST.md
-
-### Agent Workflow
-@docs/02_agent/AGENTS.md
-@docs/02_agent/AI_BOUNDARIES.md
-@docs/02_agent/PROMOTION_WORKFLOW.md
-@docs/02_agent/PROMOTION_WORKFLOW.md
-
-### PR Requirements
-@.github/pull_request_template.md
-
-## Quick Reference
-
-**Essential commands:**
-```bash
-make check    # repo-lint + ruff + pytest (run before PRs)
-make help     # see all targets
-```
-
-**Key constraints:**
-- Seed required for experiments: `--seed <int>`
-- Canonical runner: `experiments/run_experiment.py` (see @docs/01_core/EXPERIMENTS.md)
-- No commits to `data/runs/`, `data/reports/`, `data/models/`
-- One concept per PR; use PR template
-- Notebook edits: use paired `.py` under `notebooks/`; run `make notebook-sync` + `make notebook-check`
-
-## Worktree-Only Workflow (MANDATORY)
-
-**CRITICAL:** All code changes MUST happen in dedicated git worktrees, never in the shared main checkout. Verify your checkout path with `git rev-parse --show-toplevel`.
-
-### Before Making Any Changes
-
-1. **Check current location:**
-   ```bash
-   git rev-parse --show-toplevel
-   git branch --show-current
-   ```
-
-2. **If on `main` branch in main checkout → STOP:**
-   - The user-prompt-submit hook will block you
-   - Create a worktree first: `git worktree add ../Bid-Euchre-<branch-name> <branch-name>`
-
-3. **Worktree creation pattern:**
-   ```bash
-   # From main checkout
-   git worktree add ../Bid-Euchre-<descriptive-name> <branch-name>
-   cd ../Bid-Euchre-<descriptive-name>
-   # Now work here
-   ```
-
-### Enforcement Rules
-
-- ❌ NEVER work from main checkout when on `main` branch
-- ❌ NEVER commit from main checkout
-- ✅ ALWAYS verify worktree location before starting
-- ✅ ALWAYS include worktree proof in PR descriptions
-
-Violations trigger:
-1. User-prompt-submit hook → blocks immediately
-2. Pre-commit hook → blocks at commit time
-
-See `docs/02_agent/AGENTS.md` for full workflow details.
+Project overview, commands, architecture, and constraints are in the root CLAUDE.md.
+Domain docs live in docs/ — read them on-demand when working in relevant areas.
+Skills in .claude/skills/ provide workflow guidance — invoke with /skill-name.
 
 ## Compaction Instructions
 


### PR DESCRIPTION
## Summary
- Remove all 14 `@path` import lines from `.claude/CLAUDE.md` (13 unique docs + 1 duplicate PROMOTION_WORKFLOW.md)
- Remove Quick Reference section (duplicates root CLAUDE.md lines 42-55)
- Remove Worktree-Only Workflow section (duplicates root CLAUDE.md lines 151-158 + rules/10_workflow.md)

## Why
- The 14 imports loaded ~2,485 lines of docs into every session, far exceeding the recommended ~500 line context budget
- Per-session context drops from ~2,940 lines to ~200 lines
- Official best practices: "Move reference material to skills, which load on-demand" and "CLAUDE.md files are additive — content in both root and .claude/ loads twice"

## Repro / Validation
**Command(s) run:**
- `make check` — all 1,388 tests pass, lint clean, docs-check passes

**Seed (if applicable):**
- N/A (docs-only change)

## Tests
- [x] `make check` passes (repo-lint + ruff + pytest + notebook-check + docs-check)

## Expected impact
- Metrics impact: None (docs-only)
- Runtime impact: Significantly reduced per-session context loading

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-slim-claude-md
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-slim-claude-md
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)