### PR TITLE
feat: add reference-docs skill for on-demand doc access

### DIFF
--- a/.claude/skills/reference-docs/SKILL.md
+++ b/.claude/skills/reference-docs/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: reference-docs
+description: Project reference documentation catalog. Use when you need authoritative details about game rules, architecture, data contracts, metrics, scoring, reproducibility, drift, quality bar, review checklist, agent workflow, or promotion workflow.
+---
+
+# Reference Documentation Catalog
+
+Read these docs on-demand when working in the relevant area. Do NOT load all at once.
+
+## Core Documentation (docs/01_core/)
+
+| Doc | When to read |
+|-----|-------------|
+| `docs/01_core/ARCHITECTURE.md` | System design, module boundaries, import rules |
+| `docs/01_core/EXPERIMENTS.md` | Experiment runner, configs, output structure |
+| `docs/01_core/RULES.md` | Authoritative game rules (cards, tricks, bowers, scoring) |
+| `docs/01_core/REPRODUCIBILITY.md` | Seeding, determinism, `--allow-nondeterministic` |
+| `docs/01_core/DATA_CONTRACT.md` | Output schemas, JSONL fields, parquet contracts |
+| `docs/01_core/METRICS.md` | Metric definitions, statistical requirements |
+| `docs/01_core/SCORING.md` | Scoring rules, trick counting, set penalties |
+| `docs/01_core/DRIFT.md` | Drift detection, golden seeds, version pinning |
+
+## Agent & Workflow Documentation (docs/02_agent/)
+
+| Doc | When to read |
+|-----|-------------|
+| `docs/02_agent/QUALITY_BAR.md` | Quality gates, review standards, merge criteria |
+| `docs/02_agent/REVIEW_CHECKLIST.md` | PR review checklist items |
+| `docs/02_agent/AGENTS.md` | Agent development workflow, worktree process |
+| `docs/02_agent/AI_BOUNDARIES.md` | What agents may/may not do autonomously |
+| `docs/02_agent/PROMOTION_WORKFLOW.md` | Model promotion pipeline and validation |
+
+## PR Template
+
+| Doc | When to read |
+|-----|-------------|
+| `.github/pull_request_template.md` | Creating or reviewing pull requests |


### PR DESCRIPTION
## Summary
- Create `.claude/skills/reference-docs/SKILL.md` cataloging all 13 project docs removed from `.claude/CLAUDE.md`
- Claude reads individual docs on-demand when working in relevant areas

## Why
- Companion to PR #379 (slim .claude/CLAUDE.md)
- Preserves access to all docs without loading ~2,485 lines every session
- Aligns with best practice: "Move reference material to skills, which load on-demand"

## Repro / Validation
**Command(s) run:**
- `make check` — all tests pass, lint clean

## Tests
- [x] `make check` passes

## Expected impact
- Metrics impact: None
- Runtime impact: Docs loaded on-demand instead of every session

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)
`git rev-parse --show-toplevel`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-reference-docs-skill`

## Checklist
- [x] No generated artifacts committed
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)