### PR TITLE
fix: correct CLAUDE.md inaccuracies in make check and architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,12 +45,13 @@ make sync               # Install dependencies (uses uv sync)
 ```
 
 ```bash
-make check              # Full validation: repo-lint + ruff + pytest (run before PRs)
+make check              # Full validation: repo-lint + ruff + pytest + notebook-check + docs-check (run before PRs)
 make test               # Pytest fast suite only
 make lint               # Ruff check only
 make repo-lint          # Repo boundary linter only
 make notebook-sync      # Sync paired .py ↔ .ipynb (Jupytext)
 make notebook-check     # Verify sync + outputs cleared
+make docs-check         # Verify docs freshness
 make help               # Show all available targets
 ```
 
@@ -117,6 +118,10 @@ uv run python -m pytest tests/unit/core/test_rules.py::test_specific  # Single t
 | `diagnostics/` | Visualization and analysis tools |
 | `reporting/` | Report generation utilities |
 | `logging/` | JSONL game logging |
+| `analysis/` | Statistical analysis (stats, paired comparisons, models) |
+| `utils/` | Shared utility functions |
+| `validation/` | Promotion validation and schemas |
+| `scoring.py` | Top-level scoring module |
 
 **Import boundary:** `src/` must NOT import from `experiments/` or `tests/`.
 


### PR DESCRIPTION
## Summary
- Fix `make check` description to include all 5 sub-targets (was missing notebook-check + docs-check)
- Add 4 missing modules to architecture table: `analysis/`, `utils/`, `validation/`, `scoring.py`
- Add `make docs-check` to Essential Commands section

## Why
- Inaccurate CLAUDE.md instructions actively mislead Claude
- The `make check` error is high-impact — Claude wouldn't investigate notebook-check or docs-check failures
- Missing modules mean Claude doesn't know they exist when planning changes

## Repro / Validation
**Command(s) run:**
- `make check` — all tests pass

## Tests
- [x] `make check` passes

## Expected impact
- Metrics impact: None
- Runtime impact: More accurate guidance for Claude

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)
`git rev-parse --show-toplevel`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-claude-md-accuracy`

## Checklist
- [x] No generated artifacts committed
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)