### PR TITLE
chore: add disable-model-invocation to side-effect skills

### DIFF
--- a/.claude/skills/chunking-prs/SKILL.md
+++ b/.claude/skills/chunking-prs/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: chunking-prs
 description: Executes multi-PR plans in manageable chunks of 3-4 PRs per session with mandatory MEMORY.md checkpoints. Use when a plan has 5+ PRs that risk context limit degradation if attempted in one session.
+disable-model-invocation: true
 ---
 
 # Batched Multi-PR Implementation

--- a/.claude/skills/executing-plans/SKILL.md
+++ b/.claude/skills/executing-plans/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: executing-plans
 description: Reads a finalized plan file, decomposes it into work units, spawns autonomous agents for each unit, coordinates dependencies, and delivers complete PRs. Use when a plan document exists and needs end-to-end implementation.
+disable-model-invocation: true
 ---
 
 # Autonomous Plan-to-Implementation Pipeline

--- a/.claude/skills/fixing-bugs/SKILL.md
+++ b/.claude/skills/fixing-bugs/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: fixing-bugs
 description: Parallelizes independent bug fixes across worktree agents for cascading test failures. Use when multiple test failures need resolution or when sequential debugging is too slow.
+disable-model-invocation: true
 ---
 
 # Parallel Test-Driven Bug Resolution

--- a/.claude/skills/merging-pr-stacks/SKILL.md
+++ b/.claude/skills/merging-pr-stacks/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: merging-pr-stacks
 description: Merges stacked/dependent PRs in dependency order with automatic conflict resolution, PR recreation, and cleanup. Use when multiple PRs form a dependency chain and need to be merged sequentially.
+disable-model-invocation: true
 ---
 
 # Autonomous Stacked PR Merge Pipeline

--- a/.claude/skills/shipping-changes/SKILL.md
+++ b/.claude/skills/shipping-changes/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: shipping-changes
 description: Ships a change from development through PR creation, CI verification, merge, and cleanup. Use when changes are ready to be committed, pushed, and merged into main.
+disable-model-invocation: true
 ---
 
 # Ship Workflow

--- a/.claude/skills/summarizing-sessions/SKILL.md
+++ b/.claude/skills/summarizing-sessions/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: summarizing-sessions
 description: Generates a structured summary of PRs completed in a session, commits lessons learned to auto memory, and launches a reviewer agent to verify the work. Use at the end of a session after PRs have been created or merged.
+disable-model-invocation: true
 ---
 
 # PR Session Summary, Lessons Learned & Review


### PR DESCRIPTION
## Summary
- Add `disable-model-invocation: true` to frontmatter of 6 skills with side effects:
  - chunking-prs, executing-plans, fixing-bugs, merging-pr-stacks, shipping-changes, summarizing-sessions

## Why
- Official best practice: "Use disable-model-invocation: true for skills with side effects"
- Prevents Claude from auto-invoking destructive workflows — they only run via explicit /skill-name
- Saves context by not loading skill descriptions into every request
- Leave planning-code-first, recovering-context, reviewing-repo, and reference-docs as auto-invocable (no side effects)

## Repro / Validation
**Command(s) run:**
- `make check` — all tests pass

## Tests
- [x] `make check` passes

## Expected impact
- Metrics impact: None
- Runtime impact: Reduced context loading, safer skill invocation

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)
`git rev-parse --show-toplevel`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-skill-frontmatter`

## Checklist
- [x] No generated artifacts committed
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)