### PR TITLE
feat: add compaction hook to re-inject critical context

### DIFF
--- a/.claude/hooks/compact-context.sh
+++ b/.claude/hooks/compact-context.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Re-inject critical constraints after context compaction.
+# Triggered by SessionStart hook with "compact" matcher.
+
+cat <<'CONTEXT'
+## Critical Context (re-injected after compaction)
+
+1. **Worktree-only workflow**: All code changes MUST happen in git worktrees, never on main in the shared checkout. Pre-commit hooks enforce this.
+2. **make check composition**: repo-lint + ruff + pytest + notebook-check + docs-check (all 5 must pass before PRs)
+3. **Python runner**: Always use `uv run` (not raw `python` or `pip`)
+4. **Seed required**: Experiments need `--seed <int>` for determinism
+5. **Data policy**: Never commit `data/runs/`, `data/reports/`, `data/models/`
+6. **One concept per PR**: Use the PR template from `.github/pull_request_template.md`
+CONTEXT

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/compact-context.sh",
+            "statusMessage": "Re-injecting critical context..."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Create `.claude/hooks/compact-context.sh` — outputs 6 critical constraints when compaction occurs
- Create `.claude/settings.json` (shared/committed) with SessionStart compact matcher

## Why
- Official best practice: SessionStart with compact matcher preserves critical context
- Without it, compaction can lose key constraints (worktree-only, make check composition, uv run, seed requirement, data policy, one-concept-per-PR)
- The hook is lightweight (~10 lines) and only fires during compaction events

## Repro / Validation
**Command(s) run:**
- `make check` — all tests pass

## Tests
- [x] `make check` passes

## Expected impact
- Metrics impact: None
- Runtime impact: Critical constraints preserved across compaction

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)
`git rev-parse --show-toplevel`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-compaction-hook`

## Checklist
- [x] No generated artifacts committed
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)