### PR TITLE
fix: convert flaky scalability test from xfail to skip

### DIFF
--- a/docs/03_TODO/CODEBASE_CONSISTENCY.md
+++ b/docs/03_TODO/CODEBASE_CONSISTENCY.md
@@ -92,7 +92,8 @@ _All previous top-3 items resolved (see Done/Archived). Next priorities should b
 - **Log derived scoring fields:** e.g., declaring/defending tricks/points (derivable but useful).
 - **Recommended breakouts:** overtricks, set margin, volatility by contract (METRICS.md “strongly recommended”).
 - **Minimum sample thresholds:** consistently flag low-sample groups (e.g., N < 30).
-- **STYLEGUIDE.md / TESTING_STRATEGY.md:** still absent; add when there’s bandwidth (docs-only work).
+- **STYLEGUIDE.md / TESTING_STRATEGY.md:** still absent; add when there's bandwidth (docs-only work).
+- **Replace timing-based scalability test** with deterministic complexity invariant (memory/iterations).
 
 ---
 

--- a/tests/performance/test_performance.py
+++ b/tests/performance/test_performance.py
@@ -38,11 +38,10 @@ class TestPerformanceRegression:
         # If we get here without crashing, basic memory usage is OK
         # More sophisticated memory testing would require additional tools
 
-    @pytest.mark.xfail(
-        reason="Timing-based threshold is flaky in CI (variable CPU/load). "
-               "Scaling factor varies between 5x-26x depending on system state. "
-               "Needs refactor to deterministic invariant (memory/iterations). "
-               "TODO: Redesign as non-timing test - check O(1) memory, no quadratic behavior."
+    @pytest.mark.skip(
+        reason="Timing-based threshold is flaky (5x-26x scaling factor depending on "
+        "system state). Retired from gating until replaced with deterministic "
+        "complexity invariant (memory/iterations). See CODEBASE_CONSISTENCY.md."
     )
     def test_large_simulation_scalability(self):
         """Test that large simulations scale reasonably."""
@@ -80,7 +79,7 @@ class TestStatisticalStability:
         # Calculate coefficient of variation
         mean_result = sum(results) / len(results)
         variance = sum((x - mean_result) ** 2 for x in results) / len(results)
-        std_dev = variance ** 0.5
+        std_dev = variance**0.5
         cv = std_dev / mean_result if mean_result > 0 else 0
 
         # Coefficient of variation should be reasonable (< 10%)


### PR DESCRIPTION
## Summary
- Convert `test_large_simulation_scalability` from `@pytest.mark.xfail` to `@pytest.mark.skip`
- Add tracker entry to CODEBASE_CONSISTENCY.md "Later" section for deterministic replacement

## Why
The timing-based scalability test produces nondeterministic XPASS noise — the scaling factor varies between 5x-26x depending on CPU load and system state. `xfail` without `strict=True` means it sometimes passes unexpectedly, cluttering the test summary. `skip` is honest: "we're not running this until we replace it with a deterministic complexity invariant."

## Repro / Validation
**Command(s) run:**
- `make check` — 1,382 passed, 6 skipped (was 5 skipped + 1 xpassed), 0 xpassed

**Config (if applicable):** N/A

**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest -m "not slow" tests/` — 1,382 passed, 6 skipped, 0 xpassed
- [ ] Integration (if engine/rules changed): N/A
- [x] `make check` — full suite passes

## Expected impact
- Metrics impact: None
- Runtime impact: None (test was already not contributing useful signal)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-c3
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-c3
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre      c95ecb3 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-c3   b2c1250 [fix/xpass-scalability-skip]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)