### PR TITLE
docs: normalize command invocations to uv run python

### DIFF
--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -122,7 +122,7 @@ uv run python experiments/run_experiment.py --config experiments/configs/quick_t
 Use the blessed report entrypoint:
 
 ```bash
-PYTHONPATH=src python scripts/generate_report.py \
+uv run python scripts/generate_report.py \
   --run-dir data/runs/<run_id>
 ```
 

--- a/docs/01_core/EXPERIMENTS.md
+++ b/docs/01_core/EXPERIMENTS.md
@@ -5,7 +5,7 @@
 Run an experiment with a configuration file:
 
 ```bash
-PYTHONPATH=src python experiments/run_experiment.py \
+uv run python experiments/run_experiment.py \
   --config experiments/configs/quick_test.yaml \
   --seed 42 \
   --n_per 10
@@ -143,7 +143,7 @@ To reproduce a run from its metadata:
 3. Run with the same parameters:
 
 ```bash
-PYTHONPATH=src python experiments/run_experiment.py \
+uv run python experiments/run_experiment.py \
   --config <config_path from meta.json> \
   --seed <seed from meta.json> \
   --n_per <n_per from meta.json>
@@ -152,7 +152,7 @@ PYTHONPATH=src python experiments/run_experiment.py \
 Or use the effective config directly:
 
 ```bash
-PYTHONPATH=src python experiments/run_experiment.py \
+uv run python experiments/run_experiment.py \
   --config data/runs/<run_id>/config_effective.yaml \
   --seed <seed>
 ```
@@ -163,13 +163,13 @@ After running an experiment, generate reports and visualizations for analysis:
 
 ```bash
 # Run an experiment first
-PYTHONPATH=src python experiments/run_experiment.py \
+uv run python experiments/run_experiment.py \
   --config experiments/configs/quick_test.yaml \
   --seed 42 \
   --n_per 10
 
 # Generate report for that run
-PYTHONPATH=src python scripts/generate_report.py \
+uv run python scripts/generate_report.py \
   --run-dir data/runs/<run_id>
 ```
 
@@ -200,16 +200,16 @@ Every report generation creates:
 
 ```bash
 # Generate report (first time or empty reports/)
-PYTHONPATH=src python scripts/generate_report.py \
+uv run python scripts/generate_report.py \
   --run-dir data/runs/quick_test_42_20260105_123456
 
 # Regenerate report (overwrite existing)
-PYTHONPATH=src python scripts/generate_report.py \
+uv run python scripts/generate_report.py \
   --run-dir data/runs/quick_test_42_20260105_123456 \
   --overwrite
 
 # Verbose mode (see discovered files and progress)
-PYTHONPATH=src python scripts/generate_report.py \
+uv run python scripts/generate_report.py \
   --run-dir data/runs/quick_test_42_20260105_123456 \
   --verbose
 ```
@@ -241,21 +241,21 @@ Run these commands in order (copy/paste):
 
 ```bash
 # 1. Quick random sanity (2 scenarios)
-PYTHONPATH=src python experiments/run_experiment.py \
+uv run python experiments/run_experiment.py \
   --config experiments/configs/quick_test_random.yaml \
   --seed 42 \
   --n_per 20 \
   --log-level none
 
 # 2. Greedy anchor (full scenario set)
-PYTHONPATH=src python experiments/run_experiment.py \
+uv run python experiments/run_experiment.py \
   --config experiments/configs/baseline_greedy.yaml \
   --seed 42 \
   --n_per 20 \
   --log-level none
 
 # 3. Multi-strategy comparison (full scenario set, common deals)
-PYTHONPATH=src python experiments/run_experiment.py \
+uv run python experiments/run_experiment.py \
   --config experiments/configs/strategy_comparison.yaml \
   --seed 42 \
   --n_per 20 \
@@ -265,7 +265,7 @@ PYTHONPATH=src python experiments/run_experiment.py \
 **Suite runner** (now available):
 
 ```bash
-PYTHONPATH=src python scripts/run_suite.py \
+uv run python scripts/run_suite.py \
   --suite experiments/suites/baseline_tiny.yaml \
   --seed 42 \
   --n-per 20
@@ -302,7 +302,7 @@ parameters:
 ### Running Auction Experiments
 
 ```bash
-PYTHONPATH=src python experiments/run_experiment.py \
+uv run python experiments/run_experiment.py \
   --config experiments/configs/auction_smoke.yaml \
   --seed 42 \
   --n_per 20
@@ -349,7 +349,7 @@ Results are written to `results/<id>/auction.json` (filenames use "auction" for 
 By default, runs are written to `data/runs/`. You can customize the output directory:
 
 ```bash
-PYTHONPATH=src python experiments/run_experiment.py \
+uv run python experiments/run_experiment.py \
   --config experiments/configs/quick_test.yaml \
   --seed 42 \
   --run-dir /path/to/custom/location

--- a/docs/01_core/REPRODUCIBILITY.md
+++ b/docs/01_core/REPRODUCIBILITY.md
@@ -9,12 +9,12 @@ All experiment runs require an explicit seed for reproducibility. This ensures:
 
 **Deterministic run (required):**
 ```bash
-python experiments/run_experiment.py --config <path> --seed 42 --n_per 100
+uv run python experiments/run_experiment.py --config <path> --seed 42 --n_per 100
 ```
 
 **Nondeterministic run (opt-in for exploration only):**
 ```bash
-python experiments/run_experiment.py --config <path> --allow-nondeterministic --n_per 100
+uv run python experiments/run_experiment.py --config <path> --allow-nondeterministic --n_per 100
 ```
 
 The seed determines all deal generation using a stable derivation rule: `deal_seed = seed * 1_000_003 + deal_id`. This ensures every deal in a run is deterministic and reproducible.
@@ -110,7 +110,7 @@ This ensures runs can be traced and reproduced.
 3. Run:
 
 ```bash
-python experiments/run_experiment.py --seed <seed from meta.json> --config <config_path from meta.json> --n_per <n_per from meta.json>
+uv run python experiments/run_experiment.py --seed <seed from meta.json> --config <config_path from meta.json> --n_per <n_per from meta.json>
 ```
 
 The results should match the original run exactly (same aggregate metrics, same deal outcomes).

--- a/docs/02_agent/AGENTS.md
+++ b/docs/02_agent/AGENTS.md
@@ -106,34 +106,34 @@ pip install -e ".[dev]"
 ~~~
 
 **Notes**
-- Repo examples often use `PYTHONPATH=src`. If you did `uv sync` or `pip install -e .`, you typically do **not** need `PYTHONPATH=src`.
+- All examples use `uv run python` which handles the virtualenv automatically. You do **not** need `PYTHONPATH=src`.
 - Dependencies live in `pyproject.toml`; use `uv sync --frozen` for reproducible installs from `uv.lock`.
 
 ### Run tests (default)
 Fast-ish suite:
 
 ~~~bash
-PYTHONPATH=src python -m pytest -m "not slow" tests/
+uv run python -m pytest -m "not slow" tests/
 ~~~
 
 Full suite:
 
 ~~~bash
-PYTHONPATH=src python -m pytest tests/
+uv run python -m pytest tests/
 ~~~
 
 Run unit / integration only:
 
 ~~~bash
-PYTHONPATH=src python -m pytest tests/unit/
-PYTHONPATH=src python -m pytest tests/integration/
+uv run python -m pytest tests/unit/
+uv run python -m pytest tests/integration/
 ~~~
 
 ### Run a deterministic smoke experiment (recommended)
 Pick a small config and pass a seed:
 
 ~~~bash
-PYTHONPATH=src python experiments/run_experiment.py --seed 42 \
+uv run python experiments/run_experiment.py --seed 42 \
   --config experiments/configs/strategy_comparison.yaml \
   --n_per 200
 ~~~
@@ -141,7 +141,7 @@ PYTHONPATH=src python experiments/run_experiment.py --seed 42 \
 Dry-run config validation:
 
 ~~~bash
-PYTHONPATH=src python experiments/run_experiment.py --seed 42 \
+uv run python experiments/run_experiment.py --seed 42 \
   --config experiments/configs/strategy_comparison.yaml \
   --dry-run
 ~~~
@@ -152,7 +152,7 @@ PYTHONPATH=src python experiments/run_experiment.py --seed 42 \
 The experiment runner supports JSONL logging:
 
 ~~~bash
-PYTHONPATH=src python experiments/run_experiment.py --seed 42 \
+uv run python experiments/run_experiment.py --seed 42 \
   --config experiments/configs/strategy_comparison.yaml \
   --n_per 50 \
   --log-level trick
@@ -166,7 +166,7 @@ By default, the runner writes under:
 You may override base output directory:
 
 ~~~bash
-PYTHONPATH=src python experiments/run_experiment.py --seed 42 \
+uv run python experiments/run_experiment.py --seed 42 \
   --config experiments/configs/strategy_comparison.yaml \
   --run-dir data/runs
 ~~~
@@ -176,7 +176,7 @@ PYTHONPATH=src python experiments/run_experiment.py --seed 42 \
 To rigorously compare two runs (e.g., baseline vs candidate strategy):
 
 ~~~bash
-python scripts/compare_runs.py \
+uv run python scripts/compare_runs.py \
   --baseline data/runs/<baseline_run_id> \
   --candidate data/runs/<candidate_run_id>
 ~~~
@@ -190,18 +190,18 @@ This computes:
 
 ~~~bash
 # Human-readable (default)
-python scripts/compare_runs.py \
+uv run python scripts/compare_runs.py \
   --baseline data/runs/run1 \
   --candidate data/runs/run2
 
 # Markdown for PR bodies
-python scripts/compare_runs.py \
+uv run python scripts/compare_runs.py \
   --baseline data/runs/run1 \
   --candidate data/runs/run2 \
   --format markdown
 
 # JSON for automation
-python scripts/compare_runs.py \
+uv run python scripts/compare_runs.py \
   --baseline data/runs/run1 \
   --candidate data/runs/run2 \
   --format json > comparison.json
@@ -211,7 +211,7 @@ python scripts/compare_runs.py \
 
 ~~~bash
 # Use more bootstrap samples for publication-quality
-python scripts/compare_runs.py \
+uv run python scripts/compare_runs.py \
   --baseline data/runs/run1 \
   --candidate data/runs/run2 \
   --n-bootstrap 10000 \
@@ -414,13 +414,13 @@ When something fails:
 2) Validate via:
 
 ~~~bash
-PYTHONPATH=src python experiments/run_experiment.py --config <file.yaml> --dry-run --seed 42
+uv run python experiments/run_experiment.py --config <file.yaml> --dry-run --seed 42
 ~~~
 
 3) Run a small seeded smoke:
 
 ~~~bash
-PYTHONPATH=src python experiments/run_experiment.py --config <file.yaml> --n_per 200 --seed 42
+uv run python experiments/run_experiment.py --config <file.yaml> --n_per 200 --seed 42
 ~~~
 
 ### Add a dashboard/report script

--- a/docs/02_agent/AI_BOUNDARIES.md
+++ b/docs/02_agent/AI_BOUNDARIES.md
@@ -46,12 +46,12 @@ For system structure, see [docs/01_core/ARCHITECTURE.md](../01_core/ARCHITECTURE
 
 **Example (correct)**:
 ```bash
-python experiments/run_experiment.py --config <config> --seed 42 --n_per 100
+uv run python experiments/run_experiment.py --config <config> --seed 42 --n_per 100
 ```
 
 **Example (exploration only)**:
 ```bash
-python experiments/run_experiment.py --config <config> --allow-nondeterministic --n_per 100
+uv run python experiments/run_experiment.py --config <config> --allow-nondeterministic --n_per 100
 ```
 
 **Rationale**: Deterministic runs enable reproducibility and regression testing.

--- a/docs/03_experiments/BID_EVAL_TINY.md
+++ b/docs/03_experiments/BID_EVAL_TINY.md
@@ -31,7 +31,7 @@ make bid-eval-tiny
 Or run manually:
 
 ```bash
-PYTHONPATH=src python scripts/run_suite.py --suite experiments/suites/bid_eval_tiny.yaml
+uv run python scripts/run_suite.py --suite experiments/suites/bid_eval_tiny.yaml
 ```
 
 This generates individual run directories for each baseline in the roster, plus a suite rollup with summary metrics.

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,46 +53,46 @@ print(f"Team 0 average tricks: {result['avg_team0']:.2f}")
 ### Head-to-Head Evaluation
 
 ```bash
-PYTHONPATH=src python experiments/run_experiment.py \
+uv run python experiments/run_experiment.py \
   --config experiments/configs/head_to_head_vs_random.yaml \
   --seed 42 \
   --mode head_to_head_matrix
 
-PYTHONPATH=src python scripts/generate_report.py \
+uv run python scripts/generate_report.py \
   --run-dir data/runs/<run_id>
 ```
 
 **Unified Runner** (recommended):
 ```bash
 # Run experiment from YAML config
-PYTHONPATH=src python experiments/run_experiment.py \
+uv run python experiments/run_experiment.py \
     --config experiments/configs/strategy_comparison.yaml \
     --seed 42
 
 # Quick test (1k hands, 2 strategies, 2 scenarios, ~1 second)
-PYTHONPATH=src python experiments/run_experiment.py \
+uv run python experiments/run_experiment.py \
     --config experiments/configs/quick_test.yaml \
     --seed 42
 
 # Override config parameters
-PYTHONPATH=src python experiments/run_experiment.py \
+uv run python experiments/run_experiment.py \
     --config experiments/configs/baseline_greedy.yaml \
     --n_per 10000 --seed 99 --log-level none
 
 # Generate report for a run
-PYTHONPATH=src python scripts/generate_report.py \
+uv run python scripts/generate_report.py \
     --run-dir data/runs/<run_id>
 ```
 
 **Suite Runner** (recommended for production):
 ```bash
 # Run full experiment suite
-PYTHONPATH=src python scripts/run_suite.py \
+uv run python scripts/run_suite.py \
   --suite experiments/suites/baseline_tiny.yaml \
   --seed 42
 
 # Generate comprehensive report
-PYTHONPATH=src python scripts/generate_report.py --run-dir data/runs/<run_id>
+uv run python scripts/generate_report.py --run-dir data/runs/<run_id>
 ```
 
 ## 🏗️ Architecture
@@ -153,7 +153,7 @@ make test
 make check
 
 # Coverage (optional)
-PYTHONPATH=src pytest --cov=src/bid_euchre --cov-report=term-missing
+uv run pytest --cov=src/bid_euchre --cov-report=term-missing
 ```
 
 


### PR DESCRIPTION
## Summary
- Replace `PYTHONPATH=src python` and bare `python` with `uv run python` across 7 high-traffic docs
- Update the AGENTS.md note about `PYTHONPATH=src` to reflect the new convention

## Why
The project standardized on `uv run python` (CLAUDE.md §Python Defaults) but 24+ docs still used old invocation patterns. Bare `python` commands in REPRODUCIBILITY.md fail immediately without the right venv; `PYTHONPATH=src python` works but is unnecessary boilerplate. This fixes the 7 highest-traffic docs that developers and agents reference daily.

## Repro / Validation
**Command(s) run:**
```bash
# Verify zero matches in target files
rg "PYTHONPATH=src python" docs/01_core/REPRODUCIBILITY.md docs/01_core/EXPERIMENTS.md \
   docs/01_core/ARCHITECTURE.md docs/02_agent/AGENTS.md docs/02_agent/AI_BOUNDARIES.md \
   docs/README.md docs/03_experiments/BID_EVAL_TINY.md
# → 0 matches

rg "^python |^  python " docs/01_core/REPRODUCIBILITY.md
# → 0 matches
```

**Config (if applicable):** N/A

**Seed (if applicable):** N/A

## Tests
- [x] `make check` — 1,382 passed, all gates pass
- [x] `make docs-check` — docs freshness check passed

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-c2
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-c2
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre      c95ecb3 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-c2   dcd7768 [docs/command-normalization]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

### Files changed (7)
| File | Changes |
|------|---------|
| `docs/01_core/REPRODUCIBILITY.md` | 3 bare `python` → `uv run python` |
| `docs/01_core/EXPERIMENTS.md` | 15 `PYTHONPATH=src python` → `uv run python` |
| `docs/02_agent/AGENTS.md` | 10 instances normalized + note updated |
| `docs/README.md` | 8 instances normalized |
| `docs/01_core/ARCHITECTURE.md` | 1 instance normalized |
| `docs/03_experiments/BID_EVAL_TINY.md` | 1 instance normalized |
| `docs/02_agent/AI_BOUNDARIES.md` | 2 bare `python` → `uv run python` |

### Deferred
~17 remaining files in `docs/01_core/`, `docs/02_agent/` with old patterns (lower-traffic or legacy docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)