### PR TITLE
feat: switch primary metric to net_eppd

### DIFF
--- a/src/bid_euchre/reporting/evaluator.py
+++ b/src/bid_euchre/reporting/evaluator.py
@@ -36,7 +36,8 @@ def _iter_hand_end_records(log_path: Path) -> Iterable[Dict]:
                 yield record
 
 
-def _bidder_team_points(record: Dict) -> Optional[int]:
+def _parse_record_fields(record: Dict) -> Optional[tuple[int, int, int, int]]:
+    """Extract and validate (winning_bid, bidder_position, t0, t1) from a hand_end record."""
     winning_bid = record.get("winning_bid")
     bidder_position = record.get("bidder_position")
     if winning_bid is None or bidder_position is None:
@@ -48,17 +49,38 @@ def _bidder_team_points(record: Dict) -> Optional[int]:
         return None
 
     try:
-        t0 = int(t0)
-        t1 = int(t1)
-        winning_bid = int(winning_bid)
-        bidder_position = int(bidder_position)
+        return int(winning_bid), int(bidder_position), int(t0), int(t1)
     except (TypeError, ValueError):
         return None
 
+
+def _bidder_team_points(record: Dict) -> Optional[int]:
+    parsed = _parse_record_fields(record)
+    if parsed is None:
+        return None
+
+    winning_bid, bidder_position, t0, t1 = parsed
     pts0, pts1 = compute_points(winning_bid, bidder_position, t0, t1)
     if bidder_position in (0, 2):
         return pts0
     return pts1
+
+
+def _net_differential_points(record: Dict) -> Optional[int]:
+    """Compute net differential: bidder_team_points - opponent_team_points.
+
+    Make (tricks >= bid_n): net = 2 * tricks_won - 10
+    Set  (tricks < bid_n):  net = tricks_won - bid_n - 10
+    """
+    parsed = _parse_record_fields(record)
+    if parsed is None:
+        return None
+
+    winning_bid, bidder_position, t0, t1 = parsed
+    pts0, pts1 = compute_points(winning_bid, bidder_position, t0, t1)
+    if bidder_position in (0, 2):
+        return pts0 - pts1
+    return pts1 - pts0
 
 
 def compute_cvar(values: List[int], tail_fraction: float = 0.05) -> Optional[float]:
@@ -70,7 +92,9 @@ def compute_cvar(values: List[int], tail_fraction: float = 0.05) -> Optional[flo
     return sum(tail) / len(tail)
 
 
-def compute_downside_variance(values: List[int], target: float = 0.0) -> Optional[float]:
+def compute_downside_variance(
+    values: List[int], target: float = 0.0
+) -> Optional[float]:
     negatives = [v for v in values if v < target]
     if not negatives:
         return None
@@ -95,57 +119,83 @@ def _generate_comparison_report(run_dir: Path, strategy_metrics: List[Dict]) -> 
     output_dir.mkdir(parents=True, exist_ok=True)
     output_path = output_dir / "RISK_METRICS_COMPARISON.md"
 
-    # Sort strategies by expected_points for consistent ordering
+    # Sort strategies by net_expected_points for consistent ordering
     sorted_strategies = sorted(
         strategy_metrics,
-        key=lambda s: s.get("expected_points", 0) or 0,
-        reverse=True
+        key=lambda s: s.get("net_expected_points", 0) or 0,
+        reverse=True,
     )
 
     with output_path.open("w") as f:
         f.write("# Risk Metrics Comparison\n\n")
         f.write("**Run ID:** `{}`\n\n".format(Path(run_dir).name))
-        f.write("**Primary Series:** `bidder_team_points` (team points from successful bids)\n\n")
+        f.write(
+            "**Primary Series:** `net_bidder_team_points` (net differential: bidder - opponent)\n\n"
+        )
         f.write("**Metric Definitions:**\n")
-        f.write("- **EV (Expected Value)**: Average points across hands where an auction winner exists\n")
-        f.write("- **EV/Deal**: EV with `0` assigned to all-pass redeals (no auction winner)\n")
+        f.write(
+            "- **Net EV**: Average net differential (bidder - opponent) across hands with bids\n"
+        )
+        f.write("- **Net EV/Deal**: Net EV with `0` assigned to all-pass redeals\n")
+        f.write("- **EV (Expected Value)**: Average bidder team points (secondary)\n")
+        f.write("- **EV/Deal**: EV with `0` assigned to all-pass redeals (secondary)\n")
         f.write("- **Bid Rate**: Fraction of deals with an auction winner\n")
-        f.write("- **CVaR-5%**: Average of worst 5% of outcomes (tail risk)\n")
-        f.write("- **Downside Variance**: Variance of outcomes below zero\n\n")
+        f.write("- **Net CVaR-5%**: Average of worst 5% of net differential outcomes\n")
+        f.write(
+            "- **Downside Variance**: Variance of net differential outcomes below zero\n\n"
+        )
 
         f.write("## Comparative Analysis\n\n")
-        f.write("| Strategy | Deals | Bid Hands | Bid Rate | EV | EV/Deal | CVaR-5% | Downside Var | Make Rate |\n")
-        f.write("|----------|------:|----------:|---------:|---:|--------:|--------:|-------------:|----------:|\n")
+        f.write(
+            "| Strategy | Deals | Bid Hands | Bid Rate | Net EV | Net EV/Deal | EV/Deal | Net CVaR-5% | Downside Var | Make Rate |\n"
+        )
+        f.write(
+            "|----------|------:|----------:|---------:|-------:|------------:|--------:|------------:|-------------:|----------:|\n"
+        )
 
         for strategy in sorted_strategies:
             strategy_id = strategy["strategy_id"]
             deals = strategy.get("deals_total", 0)
             hands = strategy["hands_with_bids"]
             bid_rate = strategy.get("bid_rate")
-            ev = strategy.get("expected_points")
+            net_ev = strategy.get("net_expected_points")
+            net_ev_per_deal = strategy.get("net_expected_points_per_deal")
             ev_per_deal = strategy.get("expected_points_per_deal")
-            cvar = strategy.get("cvar_5")
-            downside_var = strategy.get("downside_variance")
+            net_cvar = strategy.get("net_cvar_5")
+            net_downside_var = strategy.get("net_downside_variance")
             make_rate = strategy.get("make_rate")
 
             # Format values
             bid_rate_str = f"{bid_rate:.1%}" if bid_rate is not None else "N/A"
-            ev_str = f"{ev:.3f}" if ev is not None else "N/A"
+            net_ev_str = f"{net_ev:.3f}" if net_ev is not None else "N/A"
+            net_ev_deal_str = (
+                f"{net_ev_per_deal:.3f}" if net_ev_per_deal is not None else "N/A"
+            )
             ev_deal_str = f"{ev_per_deal:.3f}" if ev_per_deal is not None else "N/A"
-            cvar_str = f"{cvar:.3f}" if cvar is not None else "N/A"
-            downside_str = f"{downside_var:.3f}" if downside_var is not None else "N/A"
+            net_cvar_str = f"{net_cvar:.3f}" if net_cvar is not None else "N/A"
+            net_downside_str = (
+                f"{net_downside_var:.3f}" if net_downside_var is not None else "N/A"
+            )
             make_rate_str = f"{make_rate:.1%}" if make_rate is not None else "N/A"
 
             f.write(
-                f"| {strategy_id} | {deals} | {hands} | {bid_rate_str} | {ev_str} | {ev_deal_str} | {cvar_str} | {downside_str} | {make_rate_str} |\n"
+                f"| {strategy_id} | {deals} | {hands} | {bid_rate_str} | {net_ev_str} | {net_ev_deal_str} | {ev_deal_str} | {net_cvar_str} | {net_downside_str} | {make_rate_str} |\n"
             )
 
         f.write("\n")
-        f.write("**Note:** Higher EV and Make Rate are better. Lower CVaR-5% and Downside Variance indicate lower risk.\n\n")
-        f.write("*Generated: {}*\n".format(datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")))
+        f.write(
+            "**Note:** Higher Net EV and Make Rate are better. Lower Net CVaR-5% and Downside Variance indicate lower risk.\n\n"
+        )
+        f.write(
+            "*Generated: {}*\n".format(
+                datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+            )
+        )
 
 
-def _generate_baseline_matrix_report(run_dir: Path, strategy_metrics: List[Dict]) -> None:
+def _generate_baseline_matrix_report(
+    run_dir: Path, strategy_metrics: List[Dict]
+) -> None:
     """
     Generate a baseline matrix JSON report with metrics per strategy.
 
@@ -166,11 +216,17 @@ def _generate_baseline_matrix_report(run_dir: Path, strategy_metrics: List[Dict]
             "strategy_id": strategy["strategy_id"],
             "expected_points": strategy.get("expected_points"),
             "expected_points_per_deal": strategy.get("expected_points_per_deal"),
+            "net_expected_points": strategy.get("net_expected_points"),
+            "net_expected_points_per_deal": strategy.get(
+                "net_expected_points_per_deal"
+            ),
             "make_rate": strategy.get("make_rate"),
             "bid_rate": strategy.get("bid_rate"),
             "pass_rate": strategy.get("pass_rate"),
             "cvar_5": strategy.get("cvar_5"),
             "downside_variance": strategy.get("downside_variance"),
+            "net_cvar_5": strategy.get("net_cvar_5"),
+            "net_downside_variance": strategy.get("net_downside_variance"),
             "n_hands": strategy.get("hands_with_bids", 0),
             "n_deals": strategy.get("deals_total", 0),
         }
@@ -180,7 +236,7 @@ def _generate_baseline_matrix_report(run_dir: Path, strategy_metrics: List[Dict]
         "run_id": Path(run_dir).name,
         "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "description": "Baseline matrix report with deterministic strategy ordering",
-        "strategies": matrix
+        "strategies": matrix,
     }
 
     with output_path.open("w") as stream:
@@ -192,9 +248,10 @@ def generate_bidder_evaluation(run_dir: Path) -> Optional[Path]:
     """
     Generate evaluation JSON and markdown report summarizing metrics per bidder strategy.
 
-    The primary series is always `bidder_team_points`. CVaR-5% is defined as
-    the average of the worst 5% of outcomes. Downside variance is the variance
-    of returns that fall below zero.
+    The primary series is `net_bidder_team_points` (net differential: bidder - opponent).
+    Secondary series `bidder_team_points` is retained for backward compatibility.
+    CVaR-5% is defined as the average of the worst 5% of outcomes.
+    Downside variance is the variance of returns that fall below zero.
     """
     logs_path, _ = get_data_paths(str(run_dir))
     logs_dir = Path(logs_path)
@@ -221,6 +278,7 @@ def generate_bidder_evaluation(run_dir: Path) -> Optional[Path]:
         )
         deals_total = len(records)
         bidder_points: List[int] = []
+        net_points: List[int] = []
         made_count = 0
         for record in records:
             points = _bidder_team_points(record)
@@ -230,6 +288,10 @@ def generate_bidder_evaluation(run_dir: Path) -> Optional[Path]:
             if points >= 0:
                 made_count += 1
 
+            net = _net_differential_points(record)
+            if net is not None:
+                net_points.append(net)
+
         hands_with_bids = len(bidder_points)
         expected = sum(bidder_points) / hands_with_bids if hands_with_bids else None
         expected_per_deal = sum(bidder_points) / deals_total if deals_total else None
@@ -237,18 +299,28 @@ def generate_bidder_evaluation(run_dir: Path) -> Optional[Path]:
         bid_rate = hands_with_bids / deals_total if deals_total else None
         pass_rate = (1.0 - bid_rate) if bid_rate is not None else None
 
+        # Net-differential metrics
+        net_hands = len(net_points)
+        net_expected = sum(net_points) / net_hands if net_hands else None
+        net_expected_per_deal = sum(net_points) / deals_total if deals_total else None
+
         entry = {
             "strategy_id": strategy_id,
             "deals_total": deals_total,
             "hands_with_bids": hands_with_bids,
             "bidder_team_points": bidder_points,
+            "net_bidder_team_points": net_points,
             "expected_points": _round(expected),
             "expected_points_per_deal": _round(expected_per_deal),
+            "net_expected_points": _round(net_expected),
+            "net_expected_points_per_deal": _round(net_expected_per_deal),
             "make_rate": _round(make_rate),
             "bid_rate": _round(bid_rate),
             "pass_rate": _round(pass_rate),
             "cvar_5": _round(compute_cvar(bidder_points)),
             "downside_variance": _round(compute_downside_variance(bidder_points)),
+            "net_cvar_5": _round(compute_cvar(net_points)),
+            "net_downside_variance": _round(compute_downside_variance(net_points)),
         }
         strategy_metrics.append(entry)
 
@@ -259,14 +331,18 @@ def generate_bidder_evaluation(run_dir: Path) -> Optional[Path]:
     payload = {
         "run_id": Path(run_dir).name,
         "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-        "primary_series": "bidder_team_points",
+        "primary_series": "net_bidder_team_points",
         "source_logs": [str(p.relative_to(run_dir)) for p in used_log_files],
         "strategies": strategy_metrics,
         "metric_definitions": {
-            "cvar_5": "avg of worst 5% bidder_team_points",
-            "downside_variance": "variance of bidder_team_points below 0",
-            "expected_points": "EV over hands with an auction winner (no-bid hands excluded)",
-            "expected_points_per_deal": "EV per deal with 0 for all-pass redeals",
+            "net_expected_points": "net EV (bidder - opponent) over hands with bids",
+            "net_expected_points_per_deal": "net EV per deal with 0 for all-pass redeals",
+            "net_cvar_5": "avg of worst 5% net_bidder_team_points",
+            "net_downside_variance": "variance of net_bidder_team_points below 0",
+            "cvar_5": "avg of worst 5% bidder_team_points (secondary)",
+            "downside_variance": "variance of bidder_team_points below 0 (secondary)",
+            "expected_points": "EV over hands with an auction winner (secondary)",
+            "expected_points_per_deal": "EV per deal with 0 for all-pass redeals (secondary)",
             "bid_rate": "fraction of deals with an auction winner",
             "pass_rate": "fraction of deals that are all-pass redeals",
         },

--- a/tests/integration/test_bid_eval_tiny_suite.py
+++ b/tests/integration/test_bid_eval_tiny_suite.py
@@ -38,7 +38,9 @@ def test_bid_eval_tiny_emits_evaluator(tmp_path: Path) -> None:
 
     dirs_after = set(run_base.iterdir())
     new_dirs = dirs_after - dirs_before
-    assert len(new_dirs) == 2, f"Expected 2 directories (1 run + 1 rollup), found {len(new_dirs)}"
+    assert (
+        len(new_dirs) == 2
+    ), f"Expected 2 directories (1 run + 1 rollup), found {len(new_dirs)}"
 
     rollup_dir = next(d for d in new_dirs if (d / "rollup.json").exists())
     assert (rollup_dir / "rollup.json").exists()
@@ -59,18 +61,27 @@ def test_bid_eval_tiny_emits_evaluator(tmp_path: Path) -> None:
         with eval_path.open() as ef:
             data = json.load(ef)
 
-        assert data["primary_series"] == "bidder_team_points"
+        assert data["primary_series"] == "net_bidder_team_points"
         assert isinstance(data["strategies"], list)
         for strategy in data["strategies"]:
             assert "strategy_id" in strategy
             assert isinstance(strategy["bidder_team_points"], list)
+            assert isinstance(strategy["net_bidder_team_points"], list)
+            # Original metrics (backward compat)
             assert "expected_points" in strategy
             assert "make_rate" in strategy
             assert "cvar_5" in strategy
             assert "downside_variance" in strategy
+            # Net-differential metrics
+            assert "net_expected_points" in strategy
+            assert "net_expected_points_per_deal" in strategy
+            assert "net_cvar_5" in strategy
+            assert "net_downside_variance" in strategy
 
         # Check that baseline matrix report exists
-        matrix_path = member_run / "reports" / "bidding_strategy" / "baseline_matrix.json"
+        matrix_path = (
+            member_run / "reports" / "bidding_strategy" / "baseline_matrix.json"
+        )
         assert matrix_path.exists(), f"Missing baseline matrix report: {matrix_path}"
 
         with matrix_path.open() as mf:
@@ -83,7 +94,9 @@ def test_bid_eval_tiny_emits_evaluator(tmp_path: Path) -> None:
         # Verify deterministic ordering (sorted by strategy_id)
         matrix_ids = [s["strategy_id"] for s in matrix_data["strategies"]]
         sorted_ids = sorted(matrix_ids)
-        assert matrix_ids == sorted_ids, f"Matrix not deterministically ordered: {matrix_ids} != {sorted_ids}"
+        assert (
+            matrix_ids == sorted_ids
+        ), f"Matrix not deterministically ordered: {matrix_ids} != {sorted_ids}"
 
         # Verify required fields are present in each strategy
         for strategy in matrix_data["strategies"]:
@@ -92,4 +105,8 @@ def test_bid_eval_tiny_emits_evaluator(tmp_path: Path) -> None:
             assert "make_rate" in strategy
             assert "cvar_5" in strategy
             assert "downside_variance" in strategy
+            assert "net_expected_points" in strategy
+            assert "net_expected_points_per_deal" in strategy
+            assert "net_cvar_5" in strategy
+            assert "net_downside_variance" in strategy
             assert "n_hands" in strategy

--- a/tests/unit/test_net_eppd.py
+++ b/tests/unit/test_net_eppd.py
@@ -1,0 +1,225 @@
+"""
+Unit tests for net-differential expected points per deal (net_eppd).
+
+Tests the _net_differential_points function and verifies net metrics
+appear correctly in evaluator output.
+"""
+
+import json
+from pathlib import Path
+
+from bid_euchre.reporting.evaluator import (
+    _net_differential_points,
+    compute_cvar,
+    compute_downside_variance,
+    generate_bidder_evaluation,
+)
+
+
+def _make_hand_end_record(
+    winning_bid: int,
+    bidder_position: int,
+    t0: int,
+    t1: int,
+    deal_id: int = 1,
+    strategy_id: str = "test_strategy",
+) -> dict:
+    """Create a minimal hand_end record for testing."""
+    return {
+        "event": "hand_end",
+        "deal_id": deal_id,
+        "strategy_id": strategy_id,
+        "winning_bid": winning_bid,
+        "bidder_position": bidder_position,
+        "t0": t0,
+        "t1": t1,
+        "timestamp": f"2026-01-01T00:00:{deal_id:02d}Z",
+    }
+
+
+def test_net_differential_make():
+    """bid_n=5, tricks=7 (team0 bidder) → net = 2*7 - 10 = 4."""
+    record = _make_hand_end_record(winning_bid=5, bidder_position=0, t0=7, t1=3)
+    assert _net_differential_points(record) == 4
+
+
+def test_net_differential_set():
+    """bid_n=6, tricks=3 (team0 bidder) → net = 3 - 6 - 10 = -13."""
+    # Set: bidder gets -6 (= -bid), opponent gets 7 (their tricks = t1)
+    # net = -6 - 7 = -13
+    record = _make_hand_end_record(winning_bid=6, bidder_position=0, t0=3, t1=7)
+    assert _net_differential_points(record) == -13
+
+
+def test_net_differential_team1_bidder_make():
+    """Bidder on team1 (seat 1), makes bid: bid_n=4, t0=3, t1=7 → net = 2*7 - 10 = 4."""
+    record = _make_hand_end_record(winning_bid=4, bidder_position=1, t0=3, t1=7)
+    assert _net_differential_points(record) == 4
+
+
+def test_net_differential_team1_bidder_set():
+    """Bidder on team1 (seat 3), set: bid_n=6, t0=7, t1=3 → net = 3 - 6 - 10 = -13."""
+    record = _make_hand_end_record(winning_bid=6, bidder_position=3, t0=7, t1=3)
+    assert _net_differential_points(record) == -13
+
+
+def test_net_differential_no_bid():
+    """Returns None for all-pass (no winning_bid)."""
+    record = {
+        "event": "hand_end",
+        "deal_id": 1,
+        "strategy_id": "test",
+        "winning_bid": None,
+        "bidder_position": None,
+        "t0": 5,
+        "t1": 5,
+    }
+    assert _net_differential_points(record) is None
+
+
+def test_net_differential_exact_make():
+    """bid_n=5, tricks=5 (exactly make) → net = 2*5 - 10 = 0."""
+    record = _make_hand_end_record(winning_bid=5, bidder_position=0, t0=5, t1=5)
+    assert _net_differential_points(record) == 0
+
+
+def test_net_differential_slam():
+    """bid_n=10, tricks=10 (all tricks) → net = 2*10 - 10 = 10."""
+    record = _make_hand_end_record(winning_bid=10, bidder_position=0, t0=10, t1=0)
+    assert _net_differential_points(record) == 10
+
+
+def test_net_eppd_in_eval_output(tmp_path: Path):
+    """Verify net_expected_points and related keys appear in evaluator output."""
+    # Create a minimal JSONL log directory
+    run_dir = tmp_path / "test_run"
+    logs_dir = run_dir / "logs"
+    logs_dir.mkdir(parents=True)
+    datasets_dir = run_dir / "datasets"
+    datasets_dir.mkdir()
+    meta_path = run_dir / "meta.json"
+    meta_path.write_text(
+        json.dumps({"data_dir": str(datasets_dir), "logs_dir": str(logs_dir)})
+    )
+
+    # Write some hand_end records
+    log_file = logs_dir / "game_001.jsonl"
+    records = [
+        _make_hand_end_record(winning_bid=5, bidder_position=0, t0=7, t1=3, deal_id=1),
+        _make_hand_end_record(winning_bid=6, bidder_position=0, t0=3, t1=7, deal_id=2),
+        _make_hand_end_record(winning_bid=4, bidder_position=2, t0=6, t1=4, deal_id=3),
+    ]
+    log_file.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+    result = generate_bidder_evaluation(run_dir)
+    assert result is not None
+
+    with result.open() as f:
+        data = json.load(f)
+
+    assert data["primary_series"] == "net_bidder_team_points"
+    assert len(data["strategies"]) == 1
+
+    strategy = data["strategies"][0]
+    assert "net_expected_points" in strategy
+    assert "net_expected_points_per_deal" in strategy
+    assert "net_cvar_5" in strategy
+    assert "net_downside_variance" in strategy
+    assert "net_bidder_team_points" in strategy
+    assert isinstance(strategy["net_bidder_team_points"], list)
+    assert len(strategy["net_bidder_team_points"]) == 3
+
+
+def test_eppd_still_present(tmp_path: Path):
+    """Old expected_points (eppd) keys must still be present for backward compat."""
+    run_dir = tmp_path / "test_run"
+    logs_dir = run_dir / "logs"
+    logs_dir.mkdir(parents=True)
+    datasets_dir = run_dir / "datasets"
+    datasets_dir.mkdir()
+    meta_path = run_dir / "meta.json"
+    meta_path.write_text(
+        json.dumps({"data_dir": str(datasets_dir), "logs_dir": str(logs_dir)})
+    )
+
+    log_file = logs_dir / "game_001.jsonl"
+    records = [
+        _make_hand_end_record(winning_bid=5, bidder_position=0, t0=7, t1=3, deal_id=1),
+    ]
+    log_file.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+    result = generate_bidder_evaluation(run_dir)
+    assert result is not None
+
+    with result.open() as f:
+        data = json.load(f)
+
+    strategy = data["strategies"][0]
+    # Old keys still present
+    assert "expected_points" in strategy
+    assert "expected_points_per_deal" in strategy
+    assert "cvar_5" in strategy
+    assert "downside_variance" in strategy
+    assert "bidder_team_points" in strategy
+
+
+def test_net_cvar_computed_on_net_series():
+    """CVaR should be computed on net differential values, not bidder-only values."""
+    # Make case: bid=5, tricks=7 → bidder_pts=7, net=4
+    # Set case: bid=6, tricks=3 → bidder_pts=-6, net=-13
+    # CVaR on net series uses net values, not bidder team values
+    net_values = [4, -13, 0, 2, -8]
+    bidder_values = [7, -6, 5, 6, -5]
+
+    net_cvar = compute_cvar(net_values)
+    bidder_cvar = compute_cvar(bidder_values)
+
+    # These must differ since the series are different
+    assert net_cvar != bidder_cvar
+    # Net CVaR should be based on worst net values
+    assert net_cvar == -13.0  # worst 5% of 5 values = 1 value = -13
+
+
+def test_net_downside_variance_computed_on_net_series():
+    """Downside variance should be computed on net differential values."""
+    net_values = [4, -13, 0, 2, -8]
+    bidder_values = [7, -6, 5, 6, -5]
+
+    net_dv = compute_downside_variance(net_values)
+    bidder_dv = compute_downside_variance(bidder_values)
+
+    assert net_dv != bidder_dv
+    assert net_dv is not None
+    assert bidder_dv is not None
+
+
+def test_metric_definitions_include_net_keys(tmp_path: Path):
+    """Metric definitions should document net-differential metrics."""
+    run_dir = tmp_path / "test_run"
+    logs_dir = run_dir / "logs"
+    logs_dir.mkdir(parents=True)
+    datasets_dir = run_dir / "datasets"
+    datasets_dir.mkdir()
+    meta_path = run_dir / "meta.json"
+    meta_path.write_text(
+        json.dumps({"data_dir": str(datasets_dir), "logs_dir": str(logs_dir)})
+    )
+
+    log_file = logs_dir / "game_001.jsonl"
+    records = [
+        _make_hand_end_record(winning_bid=5, bidder_position=0, t0=7, t1=3, deal_id=1),
+    ]
+    log_file.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+    result = generate_bidder_evaluation(run_dir)
+    with result.open() as f:
+        data = json.load(f)
+
+    defs = data["metric_definitions"]
+    assert "net_expected_points" in defs
+    assert "net_expected_points_per_deal" in defs
+    assert "net_cvar_5" in defs
+    assert "net_downside_variance" in defs
+    # Old definitions still present
+    assert "expected_points" in defs
+    assert "cvar_5" in defs


### PR DESCRIPTION
## Summary
- Add net-differential scoring (bidder_pts - opponent_pts) as the primary evaluation metric
- Keep original eppd metrics as secondary diagnostics for backward compatibility
- Add 12 unit tests covering all net-differential scenarios

## Why
Arc D execution plan v3 designates **net_eppd** as the primary metric (not eppd). Net differential
captures the asymmetric payoff structure where bidder team points and opponent points are coupled:
- Make: net = 2*tricks - 10
- Set: net = tricks - bid - 10

This is PR-P0 in the Arc D Wave 0 critical path.

## Repro / Validation
**Command(s) run:**
- `make check` — full suite (repo-lint + ruff + pytest + notebook-check + docs-check)
- `uv run python -m pytest tests/unit/test_net_eppd.py -v`

**Seed (if applicable):** N/A (unit tests)

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/`
- [x] Integration: `test_bid_eval_tiny_suite.py` updated for new primary_series
- [x] 12 new unit tests in `test_net_eppd.py`

## Expected impact
- Metrics impact: `primary_series` now `net_bidder_team_points`; all existing keys unchanged
- Runtime impact: Negligible (one extra subtraction per record)

## Risk level
- [x] Medium (strategy/experiments)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-p0
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-p0
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre      0be8c4d [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-p0   cd409f7 [feat/arc-d-p0]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)