### PR TITLE
docs: add Arc D gate model and hybrid artifact schemas

### DIFF
--- a/docs/01_core/DATA_CONTRACT.md
+++ b/docs/01_core/DATA_CONTRACT.md
@@ -89,6 +89,52 @@ If you have local files in legacy paths (`data/models/`, `data/training/`, etc.)
 
 Going forward, runner outputs must land under `data/runs/<run_id>/`.
 
+## Model Artifacts
+
+Model artifacts follow the same commit policy as run data: never committed, gitignored under `data/`.
+
+### Hybrid OLSa Artifact Schema
+
+The hybrid OLSa training pipeline produces per-arm artifacts conforming to the
+`hybrid_olsa_v1` schema documented in `docs/01_core/schemas/hybrid_olsa_v1.md`.
+
+**Artifact directory structure:**
+```
+data/artifacts/arc_d/r{N}/
+  olsa_constrained.json      # OLSa arm (locked 3/1/1 features)
+  olsa_full.json              # OLSa_Full arm (forward-selected features)
+  split_manifest.json         # Shared train/val/test split
+  training_report.json        # Training metrics and metadata
+```
+
+### Rung Bundle Schema
+
+Each rung is tracked by an `arc_d_rung_bundle_v1` bundle with these key fields:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `bundle_schema` | str | Always `"arc_d_rung_bundle_v1"` |
+| `rung_id` | str | e.g., `"r0"`, `"r1"` |
+| `arc` | str | Always `"arc_d"` |
+| `olsa` | dict | Constrained arm block (artifact path, eval path, feature set) |
+| `olsa_full` | dict | Promotional arm block (artifact path, eval path, feature set) |
+| `split_manifest` | str | Path to shared split manifest |
+| `training_report` | str | Path to training report |
+
+### Promotion Decision Schema (v3)
+
+Gate decisions are emitted as JSON with:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `decision` | str | `"PROMOTED"`, `"ADVANCED"`, or `"HALT"` |
+| `reasons` | list[str] | Human-readable explanation of the decision |
+| `rung_id` | str | Rung that was evaluated |
+| `timestamp` | str | ISO-8601 decision timestamp |
+
+See `src/bid_euchre/validation/arc_d_gate.py` for the gate runner implementation
+and `src/bid_euchre/validation/arc_d_bundle.py` for bundle schema validation.
+
 ## Notes
 - Keep schemas small and versioned.
 - Prefer adding new fields over deleting/renaming existing ones (backward compatibility).

--- a/docs/02_agent/PROMOTION_WORKFLOW.md
+++ b/docs/02_agent/PROMOTION_WORKFLOW.md
@@ -163,6 +163,44 @@ Semantic gate JSON files (`semantic_gate*.json`) must have full schema: 11 top-l
 ### `split-manifest-schema`
 Split manifest JSON files (`split_manifest*.json`) must have valid schema (required fields: `schema_version`, `split_type`, `split_seed`, `total_hand_ids`, `partition_hashes`) and `split_type` must be `two_way` or `three_way`.
 
+## Arc D Gate Model
+
+Arc D uses an **always-advance** gate model for iterative model improvement.
+The gate runner evaluates a candidate model against the current incumbent and
+returns one of three outcomes:
+
+| Outcome | Meaning |
+|---------|---------|
+| **PROMOTED** | Model advances to the next rung AND becomes the new incumbent (replaces current best) |
+| **ADVANCED** | Model advances to the next rung but does NOT become incumbent (insufficient improvement over current best) |
+| **HALT** | Model fails health or quality checks; advancement is blocked |
+
+### Dual-Arm Convention
+
+Arc D trains two model arms per rung:
+
+- **OLSa** (constrained) — locked 3/1/1 feature set per contract type; used for attribution and interpretability
+- **OLSa_Full** (promotional) — forward-selected from all 39 features; used for promotional gate evaluation
+
+The promotional arm (OLSa_Full) determines whether the candidate advances or halts.
+The constrained arm (OLSa) provides stable attribution baselines across rungs.
+
+### Artifact Validation
+
+- **Hybrid OLSa schema:** `docs/01_core/schemas/hybrid_olsa_v1.md`
+- **Bundle validation:** `src/bid_euchre/validation/arc_d_bundle.py` validates rung bundle structure (both arms, split manifest, training report)
+- **Gate runner:** `src/bid_euchre/validation/arc_d_gate.py` implements the promotion gate logic (metric normalization, threshold comparison, decision emission)
+- **CLI entry point:** `scripts/internal/run_arc_d_gate.py`
+- **Artifact integrity:** Both arms must pass `verify_frozen()` from `src/bid_euchre/models/freeze.py` before gate evaluation
+
+### Gate Flow
+
+1. Train both arms (OLSa + OLSa_Full) with shared split manifest
+2. Freeze both artifacts
+3. Evaluate both arms on held-out test split
+4. Run gate: compare OLSa_Full metrics against incumbent thresholds
+5. Emit promotion decision (PROMOTED / ADVANCED / HALT) with reasons
+
 ## Reviewer Checklist
 
 When reviewing a promotion-track PR, verify:


### PR DESCRIPTION
## Summary
- Add Arc D gate model section to PROMOTION_WORKFLOW.md (PROMOTED/ADVANCED/HALT outcomes, dual-arm convention, gate runner reference)
- Add model artifacts section to DATA_CONTRACT.md (hybrid_olsa_v1 schema, rung bundle, promotion decision schema)

## Why
Arc D Wave 2 introduced the hybrid OLSa bidder, gate runner, and bundle validator (PRs #389-#393). Documentation needs to reflect these new schemas and the always-advance gate model.

## Repro / Validation
**Command(s) run:**
```bash
make repo-lint && make docs-check
```
Both pass with no errors.

## Tests
- [x] `make repo-lint` passes (backtick path validation)
- [x] `make docs-check` passes (doc freshness)

## Expected impact
- Metrics impact: None (doc-only)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)
```
$ pwd
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-arc-d-i3

$ git rev-parse --show-toplevel
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-arc-d-i3

$ git worktree list
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                       a086fd1 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-arc-d-i3              83f19ac [feat/arc-d-i3]
```

## Checklist
- [x] No generated artifacts committed
- [x] PR is focused (one concept)