### PR TITLE
fix: correct artifact filenames and bundle keys in docs

### DIFF
--- a/docs/01_core/DATA_CONTRACT.md
+++ b/docs/01_core/DATA_CONTRACT.md
@@ -101,10 +101,11 @@ The hybrid OLSa training pipeline produces per-arm artifacts conforming to the
 **Artifact directory structure:**
 ```
 data/artifacts/arc_d/r{N}/
-  olsa_constrained.json      # OLSa arm (locked 3/1/1 features)
-  olsa_full.json              # OLSa_Full arm (forward-selected features)
-  split_manifest.json         # Shared train/val/test split
-  training_report.json        # Training metrics and metadata
+  hybrid_r{N}.json                  # OLSa arm (locked 3/1/1 features)
+  hybrid_r{N}_full.json             # OLSa_Full arm (forward-selected features)
+  split_manifest_r{N}_{ct}.json     # Per-contract split manifests (ct = suit/high/low)
+  training_report_r{N}.json         # Training metrics and metadata
+  rung_bundle_r{N}.json             # Rung bundle packaging both arms
 ```
 
 ### Rung Bundle Schema

--- a/docs/01_core/schemas/hybrid_olsa_v1.md
+++ b/docs/01_core/schemas/hybrid_olsa_v1.md
@@ -75,11 +75,20 @@ When both arms are trained, a `rung_bundle_r{N}.json` packages them:
 
 ```json
 {
-  "bundle_type": "arc_d_rung_bundle_v1",
+  "bundle_schema": "arc_d_rung_bundle_v1",
   "rung_id": "r0",
-  "constrained_artifact": "hybrid_r0.json",
-  "full_artifact": "hybrid_r0_full.json",
-  "split_manifest": "split_manifest_r0.json",
+  "arc": "arc_d",
+  "olsa": {
+    "artifact_path": "hybrid_r0.json",
+    "artifact_sha256": "...",
+    "selected_features": {"suit": [...], "high": [...], "low": [...]}
+  },
+  "olsa_full": {
+    "artifact_path": "hybrid_r0_full.json",
+    "artifact_sha256": "...",
+    "selected_features": {"suit": [...], "high": [...], "low": [...]}
+  },
+  "split_manifest": "split_manifest_r0_suit.json",
   "training_report": "training_report_r0.json"
 }
 ```


### PR DESCRIPTION
## Summary
- Fix artifact filenames in DATA_CONTRACT.md to match `train_hybrid_olsa.py` output
- Fix rung bundle example in hybrid_olsa_v1.md to match actual bundle schema

## Why
Post-merge review of #394 found two doc-code mismatches:
1. DATA_CONTRACT.md listed `olsa_constrained.json` / `olsa_full.json` but the trainer produces `hybrid_r{N}.json` / `hybrid_r{N}_full.json`
2. hybrid_olsa_v1.md used `bundle_type` and flat keys (`constrained_artifact`, `full_artifact`) but code uses `bundle_schema` with nested `olsa`/`olsa_full` blocks

## Repro / Validation
**Command(s) run:**
- `make repo-lint && make docs-check`

## Tests
- [x] `make repo-lint` passes
- [x] `make docs-check` passes

## Expected impact
- Metrics impact: None (doc-only)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-doc-contract
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-doc-contract
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                        5c30bc4 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-doc-contract       487dfba [fix/doc-contract-mismatch]
```

## Checklist
- [x] No generated artifacts committed
- [x] PR is focused (one concept)