### PR TITLE
fix: make arc_d_report CWD-independent for bundle-referenced paths

### DIFF
--- a/src/bid_euchre/reporting/arc_d_report.py
+++ b/src/bid_euchre/reporting/arc_d_report.py
@@ -252,8 +252,7 @@ def generate_arc_d_rung_report(
         model_data = None
         model_path_key = olsa_full.get("artifact_path")
         if model_path_key:
-            # artifact_path is repo-root-relative (e.g. data/artifacts/arc_d/r0/...)
-            model_file = Path(model_path_key)
+            model_file = _resolve_bundle_ref(bundle_path, model_path_key)
             if model_file.exists():
                 try:
                     with open(model_file) as f:
@@ -353,13 +352,15 @@ def generate_arc_d_rung_report(
         full_eval_path = olsa_full.get("eval_seed42")
         if olsa_eval_path:
             try:
-                olsa_metrics = load_eval_metrics(olsa_eval_path)
+                resolved = _resolve_bundle_ref(bundle_path, olsa_eval_path)
+                olsa_metrics = load_eval_metrics(str(resolved))
                 olsa_eppd = olsa_metrics.get("net_expected_points_per_deal")
             except (FileNotFoundError, json.JSONDecodeError):
                 pass
         if full_eval_path:
             try:
-                full_metrics = load_eval_metrics(full_eval_path)
+                resolved = _resolve_bundle_ref(bundle_path, full_eval_path)
+                full_metrics = load_eval_metrics(str(resolved))
                 full_eppd = full_metrics.get("net_expected_points_per_deal")
             except (FileNotFoundError, json.JSONDecodeError):
                 pass
@@ -425,6 +426,30 @@ def generate_arc_d_rung_report(
         logger.info("Wrote rung report: %s", output_path)
 
     return report
+
+
+def _resolve_bundle_ref(bundle_path: Path, ref_path: str) -> Path:
+    """Resolve a repo-root-relative path referenced in a rung bundle.
+
+    Bundle fields like ``artifact_path`` and ``eval_seed42`` store paths
+    relative to the repo root (e.g. ``data/artifacts/arc_d/r0/foo.json``).
+    When CWD **is** the repo root, ``Path(ref_path)`` works directly.
+    When CWD is elsewhere but ``bundle_path`` is absolute, we walk up
+    the bundle's ancestors to find the repo root that makes the ref
+    resolvable.
+
+    Falls back to ``Path(ref_path)`` if no ancestor works (callers
+    handle the non-existent path gracefully).
+    """
+    direct = Path(ref_path)
+    if direct.exists():
+        return direct
+    # Walk up from the bundle's resolved directory to find repo root
+    for ancestor in bundle_path.resolve().parents:
+        candidate = ancestor / ref_path
+        if candidate.exists():
+            return candidate
+    return direct
 
 
 def _count_features(arm_data: dict) -> str:

--- a/tests/unit/test_arc_d_reporting.py
+++ b/tests/unit/test_arc_d_reporting.py
@@ -613,6 +613,108 @@ def test_rung_report_model_performance_with_artifact(tmp_path):
     assert "R²" in report or "MAE" in report
 
 
+def test_rung_report_model_performance_non_repo_cwd(tmp_path, monkeypatch):
+    """Report resolves artifact_path when CWD is NOT the repo root.
+
+    Simulates: bundle at <root>/data/artifacts/arc_d/r0/rung_bundle_r0.json
+    with artifact_path="data/artifacts/arc_d/r0/model.json" (repo-root-relative).
+    CWD is set to /tmp so the path doesn't resolve directly.
+    """
+    # Build a fake repo root under tmp_path
+    repo_root = tmp_path / "fake_repo"
+    artifact_dir = repo_root / "data" / "artifacts" / "arc_d" / "r0"
+    artifact_dir.mkdir(parents=True)
+
+    model = {
+        "artifact_type": "hybrid_olsa",
+        "payoff_model": {
+            "suit": {
+                "feature_names": ["hand_value", "trump_count"],
+                "weights": [0.5, 1.2],
+                "bias": 3.0,
+            }
+        },
+    }
+    (artifact_dir / "model.json").write_text(json.dumps(model))
+
+    # Bundle uses repo-root-relative path (same format as real bundles)
+    bundle = {
+        "bundle_schema": "arc_d_rung_bundle_v1",
+        "rung_id": "r0",
+        "arc": "arc_d",
+        "olsa": {
+            "artifact_path": "data/artifacts/arc_d/r0/other.json",
+            "net_eppd": 0.15,
+            "selected_features": {"suit": ["hand_value"]},
+        },
+        "olsa_full": {
+            "artifact_path": "data/artifacts/arc_d/r0/model.json",
+            "net_eppd": 0.22,
+            "selected_features": {"suit": ["hand_value", "trump_count"]},
+        },
+    }
+    bundle_path = artifact_dir / "rung_bundle_r0.json"
+    bundle_path.write_text(json.dumps(bundle))
+
+    # Change CWD to something that is NOT the repo root
+    monkeypatch.chdir(tmp_path)
+
+    eval_df = _make_eval_df()
+    report = generate_arc_d_rung_report(bundle_path, eval_df=eval_df)
+    assert "## Model Performance" in report, (
+        "Model Performance missing when CWD != repo root — "
+        "_resolve_bundle_ref should infer repo root from bundle_path"
+    )
+
+
+def test_rung_report_attribution_gap_non_repo_cwd(tmp_path, monkeypatch):
+    """Report resolves eval_seed42 paths when CWD is NOT the repo root."""
+    repo_root = tmp_path / "fake_repo"
+    artifact_dir = repo_root / "data" / "artifacts" / "arc_d" / "r0"
+    artifact_dir.mkdir(parents=True)
+
+    # Create eval JSON files with metrics
+    eval_data = {
+        "net_expected_points_per_deal": 1.5,
+        "expected_points_per_deal": 2.0,
+    }
+    (artifact_dir / "eval_r0.json").write_text(json.dumps(eval_data))
+    eval_full = {
+        "net_expected_points_per_deal": 1.3,
+        "expected_points_per_deal": 1.8,
+    }
+    (artifact_dir / "eval_r0_full.json").write_text(json.dumps(eval_full))
+
+    bundle = {
+        "bundle_schema": "arc_d_rung_bundle_v1",
+        "rung_id": "r0",
+        "arc": "arc_d",
+        "olsa": {
+            "artifact_path": "data/artifacts/arc_d/r0/model.json",
+            "eval_seed42": "data/artifacts/arc_d/r0/eval_r0.json",
+            "selected_features": {"suit": ["hand_value"]},
+        },
+        "olsa_full": {
+            "artifact_path": "data/artifacts/arc_d/r0/model_full.json",
+            "eval_seed42": "data/artifacts/arc_d/r0/eval_r0_full.json",
+            "selected_features": {"suit": ["hand_value", "trump_count"]},
+        },
+    }
+    bundle_path = artifact_dir / "rung_bundle_r0.json"
+    bundle_path.write_text(json.dumps(bundle))
+
+    # Change CWD away from repo root
+    monkeypatch.chdir(tmp_path)
+
+    report = generate_arc_d_rung_report(bundle_path)
+    assert "pending" not in report.lower(), (
+        "Attribution gap shows 'pending' when CWD != repo root — "
+        "_resolve_bundle_ref should resolve eval paths from bundle location"
+    )
+    assert "1.5000" in report  # OLSa net_eppd
+    assert "1.3000" in report  # Full net_eppd
+
+
 def test_rung_report_no_model_artifact_key(tmp_path):
     """Report must NOT use 'model_artifact' key (old schema)."""
     # Read the source and verify it doesn't use the wrong key


### PR DESCRIPTION
## Summary
- Add `_resolve_bundle_ref()` helper that walks up the bundle file's ancestor directories to find the repo root where bundle-referenced paths resolve
- Apply helper to 3 path resolution sites: model artifact (§7), OLSa eval metrics, and Full eval metrics (attribution gap)
- Add 2 regression tests using `monkeypatch.chdir()` to verify CWD-independence

## Why
Bundle fields like `artifact_path` and `eval_seed42` store repo-root-relative paths (e.g., `data/artifacts/arc_d/r0/hybrid_r0.json`). The report generator resolved these with bare `Path(ref)`, which silently fails when the caller's CWD is not the repo root — dropping `## Model Performance` and falling back to "Attribution gap … pending."

## Repro / Validation
**Command(s) run:**
```bash
PYTHONPATH=src uv run python -m pytest tests/unit/test_arc_d_reporting.py -v -k cwd
# 2 passed — both CWD-independence tests
make check
# 1567 passed, 6 skipped, 4 deselected — all clean
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/` — 1567 passed
- [x] Other: `pytest tests/unit/test_arc_d_reporting.py -v` — 27 passed (25 existing + 2 new)

## Expected impact
- Metrics impact (if any): None — no behavior change when CWD is repo root
- Runtime impact (if any): Negligible (at most 5-6 `Path.exists()` probes per report)

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-path-fix
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-path-fix
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre           63b243e [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-path-fix  ff68d6b [fix/report-cwd-independence]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)