### PR TITLE
docs: add intent-reflection communication rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Bid Euchre AI Research Framework — a Python framework for deterministic simulation and strategy evaluation of the card game Bid Euchre (double-deck, 10-A variant with bowers).
 
+## Communication
+
+- For non-trivial requests (multi-step tasks, ambiguous scope, architectural decisions), start your response with a brief **Intent:** line restating what you understand the user's goal and intent to be (1-2 sentences). Then proceed with the work.
+- Skip the intent restatement for single-step tasks, simple questions, and follow-up confirmations.
+- If the intent restatement reveals uncertainty, ask before acting.
+
 ## Git & PR Workflow
 
 - Always use `git worktree` for PR branches — never work directly on main.


### PR DESCRIPTION
## Summary
- Add `## Communication` section to CLAUDE.md with intent-reflection rule
- Non-trivial requests get a 1-2 sentence **Intent:** restatement before action
- Trivial/single-step tasks skip the restatement

## Why
`/insights` analysis showed 45 "wrong approach" events across 137 sessions — Claude frequently misunderstood intent on ambiguous requests. A lightweight intent check catches misalignment before work begins.

## Repro / Validation
**Command(s) run:**
- `make check` — all checks pass

## Tests
- [x] `make check`
- Other: N/A (doc-only)

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-communication
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-communication
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                af153f9 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-communication  a877b38 [docs/claude-md-communication]
```

## Checklist
- [x] No generated artifacts committed
- [x] PR is focused (one concept)