### PR TITLE
feat: add auction/model chart modules + eval log resolver

### DIFF
--- a/src/bid_euchre/datasets/eval_dataset.py
+++ b/src/bid_euchre/datasets/eval_dataset.py
@@ -183,3 +183,86 @@ def build_eval_dataset(
     df["hand_id"] = df["deal_id"]
 
     return df
+
+
+def resolve_eval_log_from_bundle(
+    bundle_path: str | Path,
+    arm: str,
+    seed: int,
+) -> Path:
+    """Resolve the JSONL game log path for a specific arm and seed.
+
+    Deterministic lookup via the rung bundle -> eval JSON -> run_id + source_logs.
+    This avoids ambiguity when multiple eval runs exist for the same arm/seed.
+
+    Parameters
+    ----------
+    bundle_path:
+        Path to the rung bundle JSON (e.g.,
+        ``data/artifacts/arc_d/r0/rung_bundle_r0.json``).
+    arm:
+        Arm name as it appears in the bundle keys: ``"olsa"`` or ``"olsa_full"``.
+    seed:
+        Evaluation seed (e.g., 42, 43, 44).
+
+    Returns
+    -------
+    Path
+        Absolute path to the JSONL game log file.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the bundle, eval JSON, or JSONL log file does not exist.
+    KeyError
+        If the arm or seed key is not found in the bundle.
+    """
+    bundle_path = Path(bundle_path)
+    if not bundle_path.exists():
+        raise FileNotFoundError(f"Bundle not found: {bundle_path}")
+
+    with bundle_path.open() as f:
+        bundle = json.load(f)
+
+    if arm not in bundle:
+        raise KeyError(
+            f"Arm '{arm}' not found in bundle. Available: {list(bundle.keys())}"
+        )
+
+    eval_key = f"eval_seed{seed}"
+    arm_data = bundle[arm]
+    if eval_key not in arm_data:
+        raise KeyError(
+            f"Eval key '{eval_key}' not found for arm '{arm}'. "
+            f"Available: {[k for k in arm_data if k.startswith('eval_')]}"
+        )
+
+    # Resolve eval JSON path relative to repo root
+    eval_json_rel = arm_data[eval_key]
+    repo_root = bundle_path.parent
+    while repo_root.name and not (repo_root / ".git").exists():
+        repo_root = repo_root.parent
+    if not (repo_root / ".git").exists():
+        repo_root = Path.cwd()  # fallback
+
+    eval_json_path = repo_root / eval_json_rel
+    if not eval_json_path.exists():
+        raise FileNotFoundError(f"Eval JSON not found: {eval_json_path}")
+
+    with eval_json_path.open() as f:
+        eval_data = json.load(f)
+
+    run_id = eval_data["run_id"]
+    source_log = eval_data["source_logs"][0]
+
+    log_path = repo_root / "data" / "runs" / run_id / source_log
+    if not log_path.exists():
+        arm_suffix = "_full" if "full" in arm else ""
+        raise FileNotFoundError(
+            f"JSONL game log not found: {log_path}\n"
+            f"Regenerate with: uv run python experiments/run_experiment.py "
+            f"--config experiments/configs/arc_d_eval_r0{arm_suffix}.yaml "
+            f"--seed {seed}"
+        )
+
+    return log_path

--- a/src/bid_euchre/diagnostics/auction_charts.py
+++ b/src/bid_euchre/diagnostics/auction_charts.py
@@ -1,0 +1,433 @@
+"""Auction-related diagnostic charts for Arc D evaluation.
+
+Provides charts for analyzing auction behavior and bidder performance
+from eval JSONL datasets. All functions return Figure objects.
+"""
+
+from typing import List, Optional, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from ..reporting.style import (
+    BASE_COLORS,
+    FIGSIZE_COMPARISON,
+    apply_report_style,
+    apply_seaborn_style,
+    get_contract_color,
+    get_contract_label,
+)
+
+try:
+    import seaborn as sns  # noqa: F401
+
+    HAS_SEABORN = True
+except ImportError:
+    HAS_SEABORN = False
+
+
+def _cycle_base_colors(n: int) -> List[str]:
+    """Cycle through BASE_COLORS to get n colors."""
+    return [BASE_COLORS[i % len(BASE_COLORS)] for i in range(n)]
+
+
+def _apply_style() -> None:
+    if HAS_SEABORN:
+        apply_seaborn_style()
+    else:
+        apply_report_style()
+
+
+def _missing_columns_message(
+    ax: plt.Axes, required: List[str], available: pd.Index
+) -> bool:
+    """Display a text message for missing columns. Returns True if any missing."""
+    missing = [c for c in required if c not in available]
+    if missing:
+        ax.text(
+            0.5,
+            0.5,
+            f"Required columns missing:\n{', '.join(missing)}",
+            ha="center",
+            va="center",
+            transform=ax.transAxes,
+            fontsize=10,
+        )
+        return True
+    return False
+
+
+def plot_auction_health(
+    df: pd.DataFrame,
+    figsize: Optional[Tuple[int, int]] = None,
+    title: Optional[str] = None,
+) -> plt.Figure:
+    """Plot auction health diagnostics: contract selection, bid distribution, auction length.
+
+    Creates a 1x3 figure summarizing auction behavior from an eval dataset.
+
+    Parameters
+    ----------
+    df:
+        DataFrame from ``build_eval_dataset()`` with per-seat rows.
+        Expected columns: ``deal_id``, ``contract_type``, ``winning_bid``,
+        ``auction_rounds``.
+    figsize:
+        Figure size tuple. Defaults to ``FIGSIZE_COMPARISON``.
+    title:
+        Optional suptitle override.
+
+    Returns
+    -------
+    plt.Figure
+        A 1x3 figure with contract selection, bid distribution, and
+        auction length panels.
+    """
+    _apply_style()
+    figsize = figsize or FIGSIZE_COMPARISON
+
+    fig, axes = plt.subplots(1, 3, figsize=figsize)
+
+    required = ["deal_id", "contract_type", "winning_bid", "auction_rounds"]
+    if _missing_columns_message(axes[0], required, df.columns):
+        for ax in axes[1:]:
+            ax.set_visible(False)
+        plt.tight_layout()
+        return fig
+
+    # Deduplicate to deal-level (1 row per deal_id)
+    deal_df = df.drop_duplicates(subset="deal_id")
+
+    if len(deal_df) == 0:
+        axes[0].text(
+            0.5,
+            0.5,
+            "No deals found",
+            ha="center",
+            va="center",
+            transform=axes[0].transAxes,
+        )
+        for ax in axes[1:]:
+            ax.set_visible(False)
+        plt.tight_layout()
+        return fig
+
+    # ---- Panel 1: Contract selection bar chart ----
+    ax = axes[0]
+    contract_order = ["suit", "high", "low"]
+    present = [ct for ct in contract_order if ct in deal_df["contract_type"].values]
+    if not present:
+        present = sorted(deal_df["contract_type"].unique())
+
+    counts = deal_df["contract_type"].value_counts()
+    bar_counts = [counts.get(ct, 0) for ct in present]
+    colors = [get_contract_color(ct) for ct in present]
+    labels = [get_contract_label(ct) for ct in present]
+
+    ax.bar(range(len(present)), bar_counts, color=colors, alpha=0.8)
+    ax.set_xticks(range(len(present)))
+    ax.set_xticklabels(labels)
+    ax.set_xlabel("Contract Type")
+    ax.set_ylabel("Count")
+    ax.set_title("Contract Selection")
+    ax.grid(True, alpha=0.3, axis="y")
+
+    # Annotate with counts
+    for i, count in enumerate(bar_counts):
+        ax.text(i, count + 0.5, str(count), ha="center", va="bottom", fontsize=9)
+
+    # ---- Panel 2: Bid distribution histogram ----
+    ax = axes[1]
+    valid_bids = deal_df.dropna(subset=["winning_bid"])
+    if len(valid_bids) > 0:
+        bid_values = valid_bids["winning_bid"].values
+        bid_min = int(np.nanmin(bid_values))
+        bid_max = int(np.nanmax(bid_values))
+        bins = np.arange(bid_min - 0.5, bid_max + 1.5, 1)
+
+        # Color by contract type
+        for ct in present:
+            ct_bids = valid_bids[valid_bids["contract_type"] == ct][
+                "winning_bid"
+            ].values
+            if len(ct_bids) > 0:
+                ax.hist(
+                    ct_bids,
+                    bins=bins,
+                    alpha=0.6,
+                    color=get_contract_color(ct),
+                    label=get_contract_label(ct),
+                    edgecolor="black",
+                    linewidth=0.5,
+                )
+        ax.legend(fontsize=8)
+    else:
+        ax.text(
+            0.5, 0.5, "No valid bids", ha="center", va="center", transform=ax.transAxes
+        )
+
+    ax.set_xlabel("Winning Bid")
+    ax.set_ylabel("Count")
+    ax.set_title("Bid Distribution")
+    ax.grid(True, alpha=0.3, axis="y")
+
+    # ---- Panel 3: Auction length histogram ----
+    ax = axes[2]
+    rounds = deal_df["auction_rounds"].dropna().values
+    if len(rounds) > 0:
+        round_min = int(np.nanmin(rounds))
+        round_max = int(np.nanmax(rounds))
+        bins = np.arange(round_min - 0.5, round_max + 1.5, 1)
+        ax.hist(
+            rounds,
+            bins=bins,
+            color=BASE_COLORS[0],
+            alpha=0.7,
+            edgecolor="black",
+            linewidth=0.5,
+        )
+        ax.axvline(
+            np.mean(rounds),
+            color="red",
+            linestyle="--",
+            label=f"Mean: {np.mean(rounds):.1f}",
+        )
+        ax.legend(fontsize=8)
+    else:
+        ax.text(
+            0.5,
+            0.5,
+            "No auction data",
+            ha="center",
+            va="center",
+            transform=ax.transAxes,
+        )
+
+    ax.set_xlabel("Auction Rounds")
+    ax.set_ylabel("Count")
+    ax.set_title("Auction Length")
+    ax.grid(True, alpha=0.3, axis="y")
+
+    fig.suptitle(title or "Auction Health Diagnostics", fontsize=14, y=1.02)
+    plt.tight_layout()
+    return fig
+
+
+def plot_bidder_performance(
+    df: pd.DataFrame,
+    figsize: Optional[Tuple[int, int]] = None,
+    title: Optional[str] = None,
+) -> plt.Figure:
+    """Plot bidder performance: make rate by contract, make rate curve, overbid histogram.
+
+    Creates a 1x3 figure analyzing bidder accuracy and calibration.
+
+    Parameters
+    ----------
+    df:
+        DataFrame from ``build_eval_dataset()`` with per-seat rows.
+        Expected columns: ``is_bidder``, ``contract_type``, ``made_bid``,
+        ``winning_bid``, ``is_declaring_team``, ``tricks_won``.
+    figsize:
+        Figure size tuple. Defaults to ``FIGSIZE_COMPARISON``.
+    title:
+        Optional suptitle override.
+
+    Returns
+    -------
+    plt.Figure
+        A 1x3 figure with make rate by contract, make rate curve by bid value,
+        and overbid/underbid histogram.
+    """
+    _apply_style()
+    figsize = figsize or FIGSIZE_COMPARISON
+
+    fig, axes = plt.subplots(1, 3, figsize=figsize)
+
+    required = [
+        "is_bidder",
+        "contract_type",
+        "made_bid",
+        "winning_bid",
+        "is_declaring_team",
+        "tricks_won",
+    ]
+    if _missing_columns_message(axes[0], required, df.columns):
+        for ax in axes[1:]:
+            ax.set_visible(False)
+        plt.tight_layout()
+        return fig
+
+    # Filter to bidder rows only
+    bidder_df = df[df["is_bidder"] == True].copy()  # noqa: E712
+
+    if len(bidder_df) == 0:
+        axes[0].text(
+            0.5,
+            0.5,
+            "No bidder rows found\n(is_bidder == True)",
+            ha="center",
+            va="center",
+            transform=axes[0].transAxes,
+        )
+        for ax in axes[1:]:
+            ax.set_visible(False)
+        plt.tight_layout()
+        return fig
+
+    # ---- Panel 1: Make rate bar chart by contract_type ----
+    ax = axes[0]
+    contract_order = ["suit", "high", "low"]
+    present = [ct for ct in contract_order if ct in bidder_df["contract_type"].values]
+    if not present:
+        present = sorted(bidder_df["contract_type"].unique())
+
+    make_rates = []
+    for ct in present:
+        ct_df = bidder_df[bidder_df["contract_type"] == ct]
+        valid = ct_df["made_bid"].dropna()
+        rate = valid.mean() if len(valid) > 0 else 0.0
+        make_rates.append(rate)
+
+    colors = [get_contract_color(ct) for ct in present]
+    labels = [get_contract_label(ct) for ct in present]
+    bars = ax.bar(range(len(present)), make_rates, color=colors, alpha=0.8)
+    ax.set_xticks(range(len(present)))
+    ax.set_xticklabels(labels)
+    ax.set_xlabel("Contract Type")
+    ax.set_ylabel("Make Rate")
+    ax.set_title("Make Rate by Contract")
+    ax.set_ylim(0, 1.05)
+    ax.grid(True, alpha=0.3, axis="y")
+
+    # Annotate bars
+    for bar, rate in zip(bars, make_rates):
+        ax.text(
+            bar.get_x() + bar.get_width() / 2,
+            bar.get_height() + 0.02,
+            f"{rate:.1%}",
+            ha="center",
+            va="bottom",
+            fontsize=9,
+        )
+
+    # ---- Panel 2: Make rate curve by bid value ----
+    ax = axes[1]
+    valid_bids = bidder_df.dropna(subset=["winning_bid", "made_bid"])
+    if len(valid_bids) > 0:
+        grouped = valid_bids.groupby("winning_bid")["made_bid"]
+        bid_vals = sorted(valid_bids["winning_bid"].unique())
+        means = [grouped.get_group(bv).mean() for bv in bid_vals]
+        counts = [len(grouped.get_group(bv)) for bv in bid_vals]
+
+        # Binomial CI: mean +/- 1.96 * sqrt(p*(1-p)/n)
+        ci_lower = []
+        ci_upper = []
+        for m, n in zip(means, counts):
+            if n > 0:
+                se = np.sqrt(m * (1 - m) / n) if n > 1 else 0.0
+                ci_lower.append(max(0, m - 1.96 * se))
+                ci_upper.append(min(1, m + 1.96 * se))
+            else:
+                ci_lower.append(0)
+                ci_upper.append(0)
+
+        ax.plot(bid_vals, means, "o-", color=BASE_COLORS[0], linewidth=2, markersize=6)
+        ax.fill_between(
+            bid_vals,
+            ci_lower,
+            ci_upper,
+            alpha=0.2,
+            color=BASE_COLORS[0],
+            label="95% CI",
+        )
+        ax.legend(fontsize=8)
+
+        # Annotate sample sizes
+        for bv, n in zip(bid_vals, counts):
+            ax.annotate(
+                f"n={n}",
+                xy=(bv, 0.02),
+                ha="center",
+                fontsize=7,
+                alpha=0.6,
+            )
+    else:
+        ax.text(
+            0.5,
+            0.5,
+            "No valid bid data",
+            ha="center",
+            va="center",
+            transform=ax.transAxes,
+        )
+
+    ax.set_xlabel("Winning Bid")
+    ax.set_ylabel("Make Rate")
+    ax.set_title("Make Rate by Bid Value")
+    ax.set_ylim(-0.05, 1.05)
+    ax.grid(True, alpha=0.3)
+
+    # ---- Panel 3: Overbid/underbid histogram ----
+    ax = axes[2]
+    # Get declaring team tricks for each deal — use bidder rows which have
+    # is_declaring_team == True (the bidder IS on the declaring team)
+    # The bidder_df already has tricks_won for the bidder's team
+    overbid_df = bidder_df.dropna(subset=["winning_bid", "tricks_won"]).copy()
+    if len(overbid_df) > 0:
+        residuals = overbid_df["winning_bid"].values - overbid_df["tricks_won"].values
+        # Reasonable bin range
+        r_min = int(np.floor(residuals.min())) - 1
+        r_max = int(np.ceil(residuals.max())) + 1
+        bins = np.arange(r_min - 0.5, r_max + 1.5, 1)
+
+        n_vals, bin_edges, patches = ax.hist(
+            residuals,
+            bins=bins,
+            color=BASE_COLORS[2],
+            alpha=0.7,
+            edgecolor="black",
+            linewidth=0.5,
+        )
+
+        # Color overbids red, underbids green, exact blue
+        for patch, left_edge in zip(patches, bin_edges[:-1]):
+            center = left_edge + 0.5
+            if center > 0.5:
+                patch.set_facecolor("#e74c3c")  # Red = overbid
+                patch.set_alpha(0.7)
+            elif center < -0.5:
+                patch.set_facecolor("#27ae60")  # Green = underbid
+                patch.set_alpha(0.7)
+            else:
+                patch.set_facecolor("#3498db")  # Blue = exact
+                patch.set_alpha(0.7)
+
+        ax.axvline(0, color="black", linestyle="-", linewidth=1.5)
+        mean_residual = np.mean(residuals)
+        ax.axvline(
+            mean_residual,
+            color="red",
+            linestyle="--",
+            label=f"Mean: {mean_residual:+.2f}",
+        )
+        ax.legend(fontsize=8)
+    else:
+        ax.text(
+            0.5,
+            0.5,
+            "No bid/tricks data",
+            ha="center",
+            va="center",
+            transform=ax.transAxes,
+        )
+
+    ax.set_xlabel("Bid - Tricks Won (positive = overbid)")
+    ax.set_ylabel("Count")
+    ax.set_title("Overbid / Underbid")
+    ax.grid(True, alpha=0.3, axis="y")
+
+    fig.suptitle(title or "Bidder Performance Diagnostics", fontsize=14, y=1.02)
+    plt.tight_layout()
+    return fig

--- a/src/bid_euchre/diagnostics/model_charts.py
+++ b/src/bid_euchre/diagnostics/model_charts.py
@@ -1,0 +1,532 @@
+"""Model diagnostic charts for Arc D evaluation.
+
+Provides charts for analyzing model prediction quality, dual-arm comparisons,
+and calibration from evaluation results. All functions return Figure objects.
+"""
+
+from typing import Dict, List, Optional, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from ..reporting.style import (
+    BASE_COLORS,
+    FIGSIZE_COMPARISON,
+    FIGSIZE_SINGLE_PLOT,
+    apply_report_style,
+    apply_seaborn_style,
+    get_contract_color,
+    get_contract_label,
+)
+
+try:
+    import seaborn as sns  # noqa: F401
+
+    HAS_SEABORN = True
+except ImportError:
+    HAS_SEABORN = False
+
+
+def _cycle_base_colors(n: int) -> List[str]:
+    """Cycle through BASE_COLORS to get n colors."""
+    return [BASE_COLORS[i % len(BASE_COLORS)] for i in range(n)]
+
+
+def _apply_style() -> None:
+    if HAS_SEABORN:
+        apply_seaborn_style()
+    else:
+        apply_report_style()
+
+
+def plot_model_diagnostics(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    contract_types: np.ndarray,
+    figsize: Optional[Tuple[int, int]] = None,
+    title: Optional[str] = None,
+) -> plt.Figure:
+    """Plot model prediction diagnostics: scatter, residuals, heteroscedasticity.
+
+    Creates a 1x3 figure assessing prediction quality per contract type.
+
+    Parameters
+    ----------
+    y_true:
+        Array of true values (e.g., tricks_won).
+    y_pred:
+        Array of predicted values (same length as y_true).
+    contract_types:
+        Array of contract type labels (same length as y_true).
+    figsize:
+        Figure size tuple. Defaults to ``FIGSIZE_COMPARISON``.
+    title:
+        Optional suptitle override.
+
+    Returns
+    -------
+    plt.Figure
+        A 1x3 figure with predicted vs actual scatter, residual distribution,
+        and residuals vs predicted panels.
+    """
+    _apply_style()
+    figsize = figsize or FIGSIZE_COMPARISON
+
+    y_true = np.asarray(y_true)
+    y_pred = np.asarray(y_pred)
+    contract_types = np.asarray(contract_types)
+
+    fig, axes = plt.subplots(1, 3, figsize=figsize)
+
+    if len(y_true) == 0:
+        axes[0].text(
+            0.5,
+            0.5,
+            "No data provided",
+            ha="center",
+            va="center",
+            transform=axes[0].transAxes,
+        )
+        for ax in axes[1:]:
+            ax.set_visible(False)
+        plt.tight_layout()
+        return fig
+
+    residuals = y_true - y_pred
+    unique_contracts = sorted(set(contract_types))
+    contract_order = ["suit", "high", "low"]
+    present = [ct for ct in contract_order if ct in unique_contracts]
+    # Add any contract types not in the standard order
+    for ct in unique_contracts:
+        if ct not in present:
+            present.append(ct)
+
+    # ---- Panel 1: Predicted vs Actual scatter ----
+    ax = axes[0]
+    for ct in present:
+        mask = contract_types == ct
+        if not np.any(mask):
+            continue
+        color = get_contract_color(ct)
+        label_str = get_contract_label(ct)
+
+        # Compute R² for this contract
+        yt = y_true[mask]
+        yp = y_pred[mask]
+        ss_res = np.sum((yt - yp) ** 2)
+        ss_tot = np.sum((yt - np.mean(yt)) ** 2)
+        r2 = 1 - ss_res / ss_tot if ss_tot > 0 else float("nan")
+
+        ax.scatter(
+            yp,
+            yt,
+            alpha=0.3,
+            s=10,
+            c=color,
+            label=f"{label_str} (R²={r2:.3f})",
+        )
+
+    # y = x reference line
+    all_vals = np.concatenate([y_true, y_pred])
+    val_min, val_max = np.min(all_vals), np.max(all_vals)
+    margin = (val_max - val_min) * 0.05
+    ax.plot(
+        [val_min - margin, val_max + margin],
+        [val_min - margin, val_max + margin],
+        "k--",
+        linewidth=1,
+        alpha=0.5,
+        label="y = x",
+    )
+    ax.set_xlabel("Predicted")
+    ax.set_ylabel("Actual")
+    ax.set_title("Predicted vs Actual")
+    ax.legend(fontsize=7, loc="upper left")
+    ax.grid(True, alpha=0.3)
+
+    # ---- Panel 2: Residual distribution histograms ----
+    ax = axes[1]
+    for ct in present:
+        mask = contract_types == ct
+        if not np.any(mask):
+            continue
+        color = get_contract_color(ct)
+        label_str = get_contract_label(ct)
+        ct_residuals = residuals[mask]
+
+        ax.hist(
+            ct_residuals,
+            bins=30,
+            alpha=0.5,
+            color=color,
+            label=f"{label_str} (mean={np.mean(ct_residuals):.2f})",
+            edgecolor="black",
+            linewidth=0.3,
+        )
+
+    ax.axvline(0, color="black", linestyle="-", linewidth=1.5)
+    ax.set_xlabel("Residual (Actual - Predicted)")
+    ax.set_ylabel("Count")
+    ax.set_title("Residual Distribution")
+    ax.legend(fontsize=7)
+    ax.grid(True, alpha=0.3, axis="y")
+
+    # ---- Panel 3: Residuals vs Predicted ----
+    ax = axes[2]
+    for ct in present:
+        mask = contract_types == ct
+        if not np.any(mask):
+            continue
+        color = get_contract_color(ct)
+        label_str = get_contract_label(ct)
+
+        ax.scatter(
+            y_pred[mask],
+            residuals[mask],
+            alpha=0.3,
+            s=10,
+            c=color,
+            label=label_str,
+        )
+
+    ax.axhline(0, color="black", linestyle="-", linewidth=1.5)
+    ax.set_xlabel("Predicted")
+    ax.set_ylabel("Residual (Actual - Predicted)")
+    ax.set_title("Residuals vs Predicted")
+    ax.legend(fontsize=7)
+    ax.grid(True, alpha=0.3)
+
+    fig.suptitle(title or "Model Diagnostics", fontsize=14, y=1.02)
+    plt.tight_layout()
+    return fig
+
+
+def plot_dual_arm_comparison(
+    metrics_dict: Dict[str, Dict[str, float]],
+    figsize: Optional[Tuple[int, int]] = None,
+    title: Optional[str] = None,
+) -> plt.Figure:
+    """Plot dual-arm metric comparison for Arc D evaluation.
+
+    Creates a 1x2 figure comparing key metrics across arms (e.g., OLSa vs OLSa_Full).
+
+    Parameters
+    ----------
+    metrics_dict:
+        Dict mapping arm name to a metrics dict. Example::
+
+            {
+                "OLSa": {"net_eppd": 1.6, "make_rate": 0.7, "r2_by_contract": {"suit": 0.3}},
+                "OLSa_Full": {"net_eppd": 1.5, "make_rate": 0.72},
+            }
+
+        If a ``r2_by_contract`` key exists in any arm's metrics, Panel 2 shows
+        per-contract R² comparison. Otherwise Panel 2 is hidden.
+    figsize:
+        Figure size tuple. Defaults to ``FIGSIZE_COMPARISON``.
+    title:
+        Optional suptitle override.
+
+    Returns
+    -------
+    plt.Figure
+        A 1x2 figure with grouped bar chart of key metrics and optional
+        per-contract R² comparison.
+    """
+    _apply_style()
+    figsize = figsize or FIGSIZE_COMPARISON
+
+    if not metrics_dict:
+        fig, ax = plt.subplots(figsize=FIGSIZE_SINGLE_PLOT)
+        ax.text(0.5, 0.5, "No metrics provided", ha="center", va="center")
+        return fig
+
+    fig, axes = plt.subplots(1, 2, figsize=figsize)
+
+    arms = list(metrics_dict.keys())
+    arm_colors = _cycle_base_colors(len(arms))
+
+    # ---- Panel 1: Grouped bar chart of scalar metrics ----
+    ax = axes[0]
+
+    # Collect all scalar metric keys (exclude r2_by_contract)
+    all_metric_keys = set()
+    for arm_metrics in metrics_dict.values():
+        for k, v in arm_metrics.items():
+            if k != "r2_by_contract" and isinstance(v, (int, float)):
+                all_metric_keys.add(k)
+
+    metric_keys = sorted(all_metric_keys)
+
+    if metric_keys:
+        n_metrics = len(metric_keys)
+        n_arms = len(arms)
+        bar_width = 0.8 / n_arms
+        x = np.arange(n_metrics)
+
+        for i, arm in enumerate(arms):
+            arm_metrics = metrics_dict[arm]
+            values = [arm_metrics.get(k, 0.0) for k in metric_keys]
+            offset = (i - (n_arms - 1) / 2) * bar_width
+            bars = ax.bar(
+                x + offset,
+                values,
+                bar_width,
+                label=arm,
+                color=arm_colors[i],
+                alpha=0.8,
+            )
+            # Annotate
+            for bar, val in zip(bars, values):
+                ax.text(
+                    bar.get_x() + bar.get_width() / 2,
+                    bar.get_height(),
+                    f"{val:.3f}",
+                    ha="center",
+                    va="bottom",
+                    fontsize=7,
+                )
+
+        ax.set_xticks(x)
+        ax.set_xticklabels(metric_keys, rotation=45, ha="right")
+        ax.set_ylabel("Value")
+        ax.set_title("Metric Comparison")
+        ax.legend(fontsize=8)
+        ax.grid(True, alpha=0.3, axis="y")
+    else:
+        ax.text(
+            0.5,
+            0.5,
+            "No scalar metrics found",
+            ha="center",
+            va="center",
+            transform=ax.transAxes,
+        )
+
+    # ---- Panel 2: Per-contract R² comparison (if available) ----
+    ax = axes[1]
+    has_r2 = any("r2_by_contract" in m for m in metrics_dict.values())
+
+    if has_r2:
+        # Collect all contract types
+        all_contracts = set()
+        for arm_metrics in metrics_dict.values():
+            r2_dict = arm_metrics.get("r2_by_contract", {})
+            all_contracts.update(r2_dict.keys())
+
+        contract_order = ["suit", "high", "low"]
+        contracts = [ct for ct in contract_order if ct in all_contracts]
+        for ct in sorted(all_contracts):
+            if ct not in contracts:
+                contracts.append(ct)
+
+        if contracts:
+            n_contracts = len(contracts)
+            bar_width = 0.8 / len(arms)
+            x = np.arange(n_contracts)
+
+            for i, arm in enumerate(arms):
+                r2_dict = metrics_dict[arm].get("r2_by_contract", {})
+                values = [r2_dict.get(ct, 0.0) for ct in contracts]
+                offset = (i - (len(arms) - 1) / 2) * bar_width
+                bars = ax.bar(
+                    x + offset,
+                    values,
+                    bar_width,
+                    label=arm,
+                    color=arm_colors[i],
+                    alpha=0.8,
+                )
+                for bar, val in zip(bars, values):
+                    ax.text(
+                        bar.get_x() + bar.get_width() / 2,
+                        bar.get_height(),
+                        f"{val:.3f}",
+                        ha="center",
+                        va="bottom",
+                        fontsize=7,
+                    )
+
+            contract_labels = [get_contract_label(ct) for ct in contracts]
+            ax.set_xticks(x)
+            ax.set_xticklabels(contract_labels)
+            ax.set_ylabel("R²")
+            ax.set_title("R² by Contract Type")
+            ax.legend(fontsize=8)
+            ax.grid(True, alpha=0.3, axis="y")
+        else:
+            ax.set_visible(False)
+    else:
+        ax.set_visible(False)
+
+    fig.suptitle(title or "Dual-Arm Comparison", fontsize=14, y=1.02)
+    plt.tight_layout()
+    return fig
+
+
+def plot_calibration_curve(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    contract_types: np.ndarray,
+    n_bins: int = 10,
+    figsize: Optional[Tuple[int, int]] = None,
+    title: Optional[str] = None,
+) -> plt.Figure:
+    """Plot calibration curve and prediction distribution.
+
+    Creates a 1x2 figure assessing prediction calibration by comparing
+    predicted vs actual means per bin.
+
+    Parameters
+    ----------
+    y_true:
+        Array of true values.
+    y_pred:
+        Array of predicted values (same length as y_true).
+    contract_types:
+        Array of contract type labels (same length as y_true).
+    n_bins:
+        Number of bins for the calibration curve (default 10).
+    figsize:
+        Figure size tuple. Defaults to ``FIGSIZE_COMPARISON``.
+    title:
+        Optional suptitle override.
+
+    Returns
+    -------
+    plt.Figure
+        A 1x2 figure with calibration curve and prediction distribution histogram.
+    """
+    _apply_style()
+    figsize = figsize or FIGSIZE_COMPARISON
+
+    y_true = np.asarray(y_true)
+    y_pred = np.asarray(y_pred)
+    contract_types = np.asarray(contract_types)
+
+    fig, axes = plt.subplots(1, 2, figsize=figsize)
+
+    if len(y_true) == 0:
+        axes[0].text(
+            0.5,
+            0.5,
+            "No data provided",
+            ha="center",
+            va="center",
+            transform=axes[0].transAxes,
+        )
+        axes[1].set_visible(False)
+        plt.tight_layout()
+        return fig
+
+    unique_contracts = sorted(set(contract_types))
+    contract_order = ["suit", "high", "low"]
+    present = [ct for ct in contract_order if ct in unique_contracts]
+    for ct in unique_contracts:
+        if ct not in present:
+            present.append(ct)
+
+    # ---- Panel 1: Calibration curve ----
+    ax = axes[0]
+
+    for ct in present:
+        mask = contract_types == ct
+        if not np.any(mask):
+            continue
+
+        yt = y_true[mask]
+        yp = y_pred[mask]
+        color = get_contract_color(ct)
+        label_str = get_contract_label(ct)
+
+        if len(yp) < n_bins:
+            # Too few points for binning; just plot overall mean
+            ax.scatter(
+                [np.mean(yp)],
+                [np.mean(yt)],
+                color=color,
+                s=60,
+                marker="D",
+                label=label_str,
+            )
+            continue
+
+        # Bin predictions and compute mean actual per bin
+        try:
+            bin_indices = pd.qcut(yp, q=n_bins, labels=False, duplicates="drop")
+        except ValueError:
+            # All predictions identical or insufficient unique values
+            ax.scatter(
+                [np.mean(yp)],
+                [np.mean(yt)],
+                color=color,
+                s=60,
+                marker="D",
+                label=label_str,
+            )
+            continue
+
+        bin_pred_means = []
+        bin_true_means = []
+        for b in sorted(set(bin_indices)):
+            bin_mask = bin_indices == b
+            bin_pred_means.append(np.mean(yp[bin_mask]))
+            bin_true_means.append(np.mean(yt[bin_mask]))
+
+        ax.plot(
+            bin_pred_means,
+            bin_true_means,
+            "o-",
+            color=color,
+            linewidth=2,
+            markersize=5,
+            label=label_str,
+        )
+
+    # Reference line y = x
+    all_vals = np.concatenate([y_true, y_pred])
+    val_min, val_max = np.min(all_vals), np.max(all_vals)
+    margin = (val_max - val_min) * 0.05
+    ax.plot(
+        [val_min - margin, val_max + margin],
+        [val_min - margin, val_max + margin],
+        "k--",
+        linewidth=1,
+        alpha=0.5,
+        label="Perfect calibration",
+    )
+    ax.set_xlabel("Mean Predicted")
+    ax.set_ylabel("Mean Actual")
+    ax.set_title("Calibration Curve")
+    ax.legend(fontsize=7)
+    ax.grid(True, alpha=0.3)
+
+    # ---- Panel 2: Prediction distribution histogram ----
+    ax = axes[1]
+    for ct in present:
+        mask = contract_types == ct
+        if not np.any(mask):
+            continue
+        color = get_contract_color(ct)
+        label_str = get_contract_label(ct)
+
+        ax.hist(
+            y_pred[mask],
+            bins=30,
+            alpha=0.5,
+            color=color,
+            label=label_str,
+            edgecolor="black",
+            linewidth=0.3,
+        )
+
+    ax.set_xlabel("Predicted Value")
+    ax.set_ylabel("Count")
+    ax.set_title("Prediction Distribution")
+    ax.legend(fontsize=7)
+    ax.grid(True, alpha=0.3, axis="y")
+
+    fig.suptitle(title or "Calibration Diagnostics", fontsize=14, y=1.02)
+    plt.tight_layout()
+    return fig

--- a/tests/unit/test_auction_charts.py
+++ b/tests/unit/test_auction_charts.py
@@ -1,0 +1,217 @@
+"""Unit tests for auction diagnostic chart functions."""
+
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+
+matplotlib.use("Agg")  # Non-interactive backend for testing
+
+from bid_euchre.diagnostics.auction_charts import (
+    plot_auction_health,
+    plot_bidder_performance,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures: synthetic eval DataFrames
+# ---------------------------------------------------------------------------
+
+
+def _make_eval_df(n_deals: int = 50, seed: int = 42) -> pd.DataFrame:
+    """Create a synthetic eval-style DataFrame mimicking build_eval_dataset output."""
+    rng = np.random.RandomState(seed)
+    rows = []
+    contract_types = ["suit", "high", "low"]
+    for deal_id in range(n_deals):
+        ct = rng.choice(contract_types)
+        winning_bid = rng.randint(6, 11)
+        bidder_seat = rng.randint(0, 4)
+        bidder_team = 0 if bidder_seat in (0, 2) else 1
+        t0 = rng.randint(3, 8)
+        t1 = 10 - t0
+        made_bid = (t0 >= winning_bid) if bidder_team == 0 else (t1 >= winning_bid)
+        n_bids = rng.randint(1, 5)
+        n_passes = rng.randint(1, 4)
+        auction_rounds = n_bids + n_passes
+
+        for seat in range(4):
+            team = 0 if seat in (0, 2) else 1
+            tricks_won = t0 if team == 0 else t1
+            rows.append(
+                {
+                    "deal_id": deal_id,
+                    "seat": seat,
+                    "team": team,
+                    "contract_type": ct,
+                    "trump": "H" if ct == "suit" else None,
+                    "tricks_won": tricks_won,
+                    "winning_bid": winning_bid,
+                    "bidder_seat": bidder_seat,
+                    "bidder_team": bidder_team,
+                    "is_bidder": seat == bidder_seat,
+                    "is_declaring_team": team == bidder_team,
+                    "made_bid": made_bid,
+                    "n_bids": n_bids,
+                    "n_passes": n_passes,
+                    "auction_rounds": auction_rounds,
+                    "hand_id": deal_id,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Tests: plot_auction_health
+# ---------------------------------------------------------------------------
+
+
+class TestPlotAuctionHealth:
+    """Tests for plot_auction_health function."""
+
+    @pytest.fixture
+    def eval_df(self) -> pd.DataFrame:
+        return _make_eval_df()
+
+    def test_returns_figure(self, eval_df: pd.DataFrame) -> None:
+        """plot_auction_health returns a matplotlib Figure."""
+        fig = plot_auction_health(eval_df)
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_has_three_panels(self, eval_df: pd.DataFrame) -> None:
+        """Figure contains 3 axes (panels)."""
+        fig = plot_auction_health(eval_df)
+        visible_axes = [ax for ax in fig.axes if ax.get_visible()]
+        assert len(visible_axes) == 3
+        plt.close(fig)
+
+    def test_custom_title(self, eval_df: pd.DataFrame) -> None:
+        """Custom title is applied."""
+        fig = plot_auction_health(eval_df, title="Test Title")
+        assert fig._suptitle.get_text() == "Test Title"
+        plt.close(fig)
+
+    def test_custom_figsize(self, eval_df: pd.DataFrame) -> None:
+        """Custom figsize is respected."""
+        fig = plot_auction_health(eval_df, figsize=(12, 4))
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_empty_dataframe(self) -> None:
+        """Empty DataFrame handled gracefully."""
+        empty_df = pd.DataFrame(
+            columns=[
+                "deal_id",
+                "contract_type",
+                "winning_bid",
+                "auction_rounds",
+            ]
+        )
+        fig = plot_auction_health(empty_df)
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_missing_columns(self) -> None:
+        """DataFrame missing required columns handled gracefully."""
+        bad_df = pd.DataFrame({"x": [1, 2, 3]})
+        fig = plot_auction_health(bad_df)
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_single_contract_type(self) -> None:
+        """Works with only one contract type."""
+        df = _make_eval_df()
+        df = df[df["contract_type"] == "suit"].copy()
+        fig = plot_auction_health(df)
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Tests: plot_bidder_performance
+# ---------------------------------------------------------------------------
+
+
+class TestPlotBidderPerformance:
+    """Tests for plot_bidder_performance function."""
+
+    @pytest.fixture
+    def eval_df(self) -> pd.DataFrame:
+        return _make_eval_df()
+
+    def test_returns_figure(self, eval_df: pd.DataFrame) -> None:
+        """plot_bidder_performance returns a matplotlib Figure."""
+        fig = plot_bidder_performance(eval_df)
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_has_three_panels(self, eval_df: pd.DataFrame) -> None:
+        """Figure contains 3 axes (panels)."""
+        fig = plot_bidder_performance(eval_df)
+        visible_axes = [ax for ax in fig.axes if ax.get_visible()]
+        assert len(visible_axes) == 3
+        plt.close(fig)
+
+    def test_custom_title(self, eval_df: pd.DataFrame) -> None:
+        """Custom title is applied."""
+        fig = plot_bidder_performance(eval_df, title="Bidder Test")
+        assert fig._suptitle.get_text() == "Bidder Test"
+        plt.close(fig)
+
+    def test_custom_figsize(self, eval_df: pd.DataFrame) -> None:
+        """Custom figsize is respected."""
+        fig = plot_bidder_performance(eval_df, figsize=(14, 5))
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_empty_dataframe(self) -> None:
+        """Empty DataFrame handled gracefully."""
+        empty_df = pd.DataFrame(
+            columns=[
+                "is_bidder",
+                "contract_type",
+                "made_bid",
+                "winning_bid",
+                "is_declaring_team",
+                "tricks_won",
+            ]
+        )
+        fig = plot_bidder_performance(empty_df)
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_missing_columns(self) -> None:
+        """DataFrame missing required columns handled gracefully."""
+        bad_df = pd.DataFrame({"x": [1, 2, 3]})
+        fig = plot_bidder_performance(bad_df)
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_single_contract_type(self) -> None:
+        """Works with only one contract type."""
+        df = _make_eval_df()
+        df = df[df["contract_type"] == "high"].copy()
+        fig = plot_bidder_performance(df)
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_no_bidder_rows(self) -> None:
+        """Handles case where no rows have is_bidder == True."""
+        df = _make_eval_df()
+        df["is_bidder"] = False
+        fig = plot_bidder_performance(df)
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Teardown: close all figures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _close_all_figures():
+    """Close all matplotlib figures after each test to prevent leaks."""
+    yield
+    plt.close("all")

--- a/tests/unit/test_eval_dataset.py
+++ b/tests/unit/test_eval_dataset.py
@@ -12,7 +12,10 @@ from pathlib import Path
 
 import pytest
 
-from bid_euchre.datasets.eval_dataset import build_eval_dataset
+from bid_euchre.datasets.eval_dataset import (
+    build_eval_dataset,
+    resolve_eval_log_from_bundle,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures: minimal hand_end records
@@ -399,3 +402,124 @@ class TestMalformedJson:
 
         assert len(df) == 8  # 2 valid hand_end records × 4 seats
         assert set(df["deal_id"]) == {0, 1}
+
+
+# ---------------------------------------------------------------------------
+# Tests: resolve_eval_log_from_bundle
+# ---------------------------------------------------------------------------
+
+
+def _setup_bundle_tree(tmp_path: Path) -> dict:
+    """Create a synthetic bundle/eval/log file tree for testing.
+
+    Returns a dict with paths: bundle_path, eval_json_path, log_path.
+    """
+    # Create fake .git dir so repo root detection works
+    (tmp_path / ".git").mkdir()
+
+    # Create run directory with a JSONL log file
+    run_id = "test_run_abc"
+    log_name = "game_log.jsonl"
+    run_dir = tmp_path / "data" / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    log_path = run_dir / log_name
+    log_path.write_text('{"event": "hand_end"}\n')
+
+    # Create eval JSON
+    eval_dir = tmp_path / "data" / "artifacts" / "arc_d" / "r0" / "eval"
+    eval_dir.mkdir(parents=True)
+    eval_json_path = eval_dir / "eval_olsa_42.json"
+    eval_json_path.write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "source_logs": [log_name],
+                "seed": 42,
+            }
+        )
+    )
+
+    # Create bundle JSON
+    bundle_dir = tmp_path / "data" / "artifacts" / "arc_d" / "r0"
+    bundle_path = bundle_dir / "rung_bundle_r0.json"
+    # Eval path is relative to repo root
+    eval_rel = str(eval_json_path.relative_to(tmp_path))
+    bundle_path.write_text(
+        json.dumps(
+            {
+                "olsa": {
+                    "eval_seed42": eval_rel,
+                    "eval_seed43": eval_rel,
+                },
+                "olsa_full": {
+                    "eval_seed42": eval_rel,
+                },
+            }
+        )
+    )
+
+    return {
+        "bundle_path": bundle_path,
+        "eval_json_path": eval_json_path,
+        "log_path": log_path,
+    }
+
+
+class TestResolveEvalLogFromBundle:
+    """Tests for resolve_eval_log_from_bundle."""
+
+    def test_happy_path(self, tmp_path: Path) -> None:
+        """Resolves the correct JSONL log path."""
+        paths = _setup_bundle_tree(tmp_path)
+        result = resolve_eval_log_from_bundle(paths["bundle_path"], arm="olsa", seed=42)
+        assert result == paths["log_path"]
+
+    def test_missing_bundle(self, tmp_path: Path) -> None:
+        """FileNotFoundError when bundle does not exist."""
+        with pytest.raises(FileNotFoundError, match="Bundle not found"):
+            resolve_eval_log_from_bundle(
+                tmp_path / "nonexistent.json", arm="olsa", seed=42
+            )
+
+    def test_invalid_arm(self, tmp_path: Path) -> None:
+        """KeyError when arm not in bundle."""
+        paths = _setup_bundle_tree(tmp_path)
+        with pytest.raises(KeyError, match="Arm 'bogus' not found"):
+            resolve_eval_log_from_bundle(paths["bundle_path"], arm="bogus", seed=42)
+
+    def test_invalid_seed(self, tmp_path: Path) -> None:
+        """KeyError when seed not in bundle arm."""
+        paths = _setup_bundle_tree(tmp_path)
+        with pytest.raises(KeyError, match="eval_seed99"):
+            resolve_eval_log_from_bundle(paths["bundle_path"], arm="olsa", seed=99)
+
+    def test_missing_eval_json(self, tmp_path: Path) -> None:
+        """FileNotFoundError when eval JSON file does not exist."""
+        paths = _setup_bundle_tree(tmp_path)
+        # Remove the eval JSON
+        paths["eval_json_path"].unlink()
+        with pytest.raises(FileNotFoundError, match="Eval JSON not found"):
+            resolve_eval_log_from_bundle(paths["bundle_path"], arm="olsa", seed=42)
+
+    def test_missing_log_file(self, tmp_path: Path) -> None:
+        """FileNotFoundError with regeneration hint when JSONL log missing."""
+        paths = _setup_bundle_tree(tmp_path)
+        # Remove the log file
+        paths["log_path"].unlink()
+        with pytest.raises(FileNotFoundError, match="JSONL game log not found"):
+            resolve_eval_log_from_bundle(paths["bundle_path"], arm="olsa", seed=42)
+
+    def test_missing_log_regeneration_hint(self, tmp_path: Path) -> None:
+        """Error message includes regeneration command."""
+        paths = _setup_bundle_tree(tmp_path)
+        paths["log_path"].unlink()
+        with pytest.raises(FileNotFoundError, match="Regenerate with"):
+            resolve_eval_log_from_bundle(paths["bundle_path"], arm="olsa", seed=42)
+
+    def test_olsa_full_arm(self, tmp_path: Path) -> None:
+        """Works with olsa_full arm."""
+        paths = _setup_bundle_tree(tmp_path)
+        result = resolve_eval_log_from_bundle(
+            paths["bundle_path"], arm="olsa_full", seed=42
+        )
+        assert result == paths["log_path"]

--- a/tests/unit/test_model_charts.py
+++ b/tests/unit/test_model_charts.py
@@ -1,0 +1,248 @@
+"""Unit tests for model diagnostic chart functions."""
+
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+matplotlib.use("Agg")  # Non-interactive backend for testing
+
+from bid_euchre.diagnostics.model_charts import (
+    plot_calibration_curve,
+    plot_dual_arm_comparison,
+    plot_model_diagnostics,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures: synthetic model data
+# ---------------------------------------------------------------------------
+
+
+def _make_model_data(
+    n: int = 200, seed: int = 42
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Create synthetic y_true, y_pred, contract_types arrays."""
+    rng = np.random.RandomState(seed)
+    contract_types = rng.choice(["suit", "high", "low"], size=n)
+    y_true = rng.uniform(3, 8, size=n)
+    # Predictions = true + noise (correlated)
+    y_pred = y_true + rng.normal(0, 0.5, size=n)
+    return y_true, y_pred, contract_types
+
+
+# ---------------------------------------------------------------------------
+# Tests: plot_model_diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestPlotModelDiagnostics:
+    """Tests for plot_model_diagnostics function."""
+
+    def test_returns_figure(self) -> None:
+        """plot_model_diagnostics returns a matplotlib Figure."""
+        y_true, y_pred, ct = _make_model_data()
+        fig = plot_model_diagnostics(y_true, y_pred, ct)
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_has_three_panels(self) -> None:
+        """Figure contains 3 visible axes."""
+        y_true, y_pred, ct = _make_model_data()
+        fig = plot_model_diagnostics(y_true, y_pred, ct)
+        visible_axes = [ax for ax in fig.axes if ax.get_visible()]
+        assert len(visible_axes) == 3
+        plt.close(fig)
+
+    def test_custom_title(self) -> None:
+        """Custom title is applied."""
+        y_true, y_pred, ct = _make_model_data()
+        fig = plot_model_diagnostics(y_true, y_pred, ct, title="Custom Diag")
+        assert fig._suptitle.get_text() == "Custom Diag"
+        plt.close(fig)
+
+    def test_custom_figsize(self) -> None:
+        """Custom figsize is respected."""
+        y_true, y_pred, ct = _make_model_data()
+        fig = plot_model_diagnostics(y_true, y_pred, ct, figsize=(15, 5))
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_empty_arrays(self) -> None:
+        """Empty arrays handled gracefully."""
+        fig = plot_model_diagnostics(
+            np.array([]),
+            np.array([]),
+            np.array([]),
+        )
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_single_contract_type(self) -> None:
+        """Works with only one contract type."""
+        rng = np.random.RandomState(42)
+        n = 50
+        y_true = rng.uniform(3, 8, size=n)
+        y_pred = y_true + rng.normal(0, 0.5, size=n)
+        ct = np.array(["suit"] * n)
+        fig = plot_model_diagnostics(y_true, y_pred, ct)
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_small_arrays(self) -> None:
+        """Works with very small arrays."""
+        y_true = np.array([5.0, 6.0, 7.0])
+        y_pred = np.array([5.1, 5.8, 7.2])
+        ct = np.array(["suit", "high", "low"])
+        fig = plot_model_diagnostics(y_true, y_pred, ct)
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Tests: plot_dual_arm_comparison
+# ---------------------------------------------------------------------------
+
+
+class TestPlotDualArmComparison:
+    """Tests for plot_dual_arm_comparison function."""
+
+    def test_returns_figure_simple(self) -> None:
+        """Simple metrics dict produces a Figure."""
+        metrics = {
+            "OLSa": {"net_eppd": 1.6, "make_rate": 0.70},
+            "OLSa_Full": {"net_eppd": 1.5, "make_rate": 0.72},
+        }
+        fig = plot_dual_arm_comparison(metrics)
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_returns_figure_with_r2(self) -> None:
+        """Metrics with r2_by_contract shows both panels."""
+        metrics = {
+            "OLSa": {
+                "net_eppd": 1.6,
+                "make_rate": 0.70,
+                "r2_by_contract": {"suit": 0.35, "high": 0.28, "low": 0.22},
+            },
+            "OLSa_Full": {
+                "net_eppd": 1.5,
+                "make_rate": 0.72,
+                "r2_by_contract": {"suit": 0.40, "high": 0.30, "low": 0.25},
+            },
+        }
+        fig = plot_dual_arm_comparison(metrics)
+        assert isinstance(fig, plt.Figure)
+        visible_axes = [ax for ax in fig.axes if ax.get_visible()]
+        assert len(visible_axes) == 2
+        plt.close(fig)
+
+    def test_custom_title(self) -> None:
+        """Custom title is applied."""
+        metrics = {"A": {"x": 1.0}, "B": {"x": 2.0}}
+        fig = plot_dual_arm_comparison(metrics, title="Arms Test")
+        assert fig._suptitle.get_text() == "Arms Test"
+        plt.close(fig)
+
+    def test_empty_metrics(self) -> None:
+        """Empty metrics dict handled gracefully."""
+        fig = plot_dual_arm_comparison({})
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_single_arm(self) -> None:
+        """Single arm works."""
+        metrics = {"OLSa": {"net_eppd": 1.6, "make_rate": 0.7}}
+        fig = plot_dual_arm_comparison(metrics)
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_panel2_hidden_without_r2(self) -> None:
+        """Panel 2 is hidden when no r2_by_contract present."""
+        metrics = {
+            "OLSa": {"net_eppd": 1.6},
+            "OLSa_Full": {"net_eppd": 1.5},
+        }
+        fig = plot_dual_arm_comparison(metrics)
+        visible_axes = [ax for ax in fig.axes if ax.get_visible()]
+        assert len(visible_axes) == 1  # Only panel 1
+        plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Tests: plot_calibration_curve
+# ---------------------------------------------------------------------------
+
+
+class TestPlotCalibrationCurve:
+    """Tests for plot_calibration_curve function."""
+
+    def test_returns_figure(self) -> None:
+        """plot_calibration_curve returns a Figure."""
+        y_true, y_pred, ct = _make_model_data()
+        fig = plot_calibration_curve(y_true, y_pred, ct)
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_has_two_panels(self) -> None:
+        """Figure contains 2 visible axes."""
+        y_true, y_pred, ct = _make_model_data()
+        fig = plot_calibration_curve(y_true, y_pred, ct)
+        visible_axes = [ax for ax in fig.axes if ax.get_visible()]
+        assert len(visible_axes) == 2
+        plt.close(fig)
+
+    def test_custom_title(self) -> None:
+        """Custom title is applied."""
+        y_true, y_pred, ct = _make_model_data()
+        fig = plot_calibration_curve(y_true, y_pred, ct, title="Cal Test")
+        assert fig._suptitle.get_text() == "Cal Test"
+        plt.close(fig)
+
+    def test_custom_n_bins(self) -> None:
+        """Custom n_bins is accepted."""
+        y_true, y_pred, ct = _make_model_data()
+        fig = plot_calibration_curve(y_true, y_pred, ct, n_bins=5)
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_empty_arrays(self) -> None:
+        """Empty arrays handled gracefully."""
+        fig = plot_calibration_curve(
+            np.array([]),
+            np.array([]),
+            np.array([]),
+        )
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_single_contract_type(self) -> None:
+        """Works with only one contract type."""
+        rng = np.random.RandomState(42)
+        n = 100
+        y_true = rng.uniform(3, 8, size=n)
+        y_pred = y_true + rng.normal(0, 0.5, size=n)
+        ct = np.array(["suit"] * n)
+        fig = plot_calibration_curve(y_true, y_pred, ct)
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_small_arrays(self) -> None:
+        """Works with very small arrays (fewer than n_bins)."""
+        y_true = np.array([5.0, 6.0, 7.0])
+        y_pred = np.array([5.1, 5.8, 7.2])
+        ct = np.array(["suit", "suit", "suit"])
+        fig = plot_calibration_curve(y_true, y_pred, ct, n_bins=10)
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Teardown: close all figures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _close_all_figures():
+    """Close all matplotlib figures after each test to prevent leaks."""
+    yield
+    plt.close("all")


### PR DESCRIPTION
## Summary
- Add 2 new diagnostic chart modules: `auction_charts.py` (2 functions) and `model_charts.py` (3 functions) for Arc D evaluation analysis
- Add `resolve_eval_log_from_bundle()` to `eval_dataset.py` for deterministic JSONL log path resolution via bundle -> eval JSON -> run_id chain
- 43 new tests (15 auction, 20 model, 8 resolver) covering happy paths, edge cases, and graceful degradation

## Why
Arc D evaluation notebooks need standardized charts for auction health diagnostics, model prediction quality assessment, and dual-arm comparisons. The log resolver eliminates ambiguity when multiple eval runs exist by using the rung bundle as the single source of truth.

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/test_auction_charts.py tests/unit/test_model_charts.py tests/unit/test_eval_dataset.py -v` (56 passed)
- `make check` (all checks passed, 1641 tests)

**Config (if applicable):**
- N/A (chart infrastructure only, no experiment runs)

**Seed (if applicable):**
- N/A

## Tests
- [x] `PYTHONPATH=src python -m pytest -m "not slow" tests/` (1641 passed, 4 deselected)
- [ ] Integration (if engine/rules changed): N/A
- [x] Other: `make check` — full validation including repo-lint, ruff, pytest, notebook-check, docs-check

## Expected impact
- Metrics impact (if any): None (new code only, no behavior changes)
- Runtime impact (if any): None (chart functions only invoked on-demand)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-wave1-charts
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-wave1-charts
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                             d6a194a [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-wave1-charts                200c073 [feat/arc-d-chart-infra]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)