### PR TITLE
test: add Arc D template contract tests (PR-C1)

### DIFF
--- a/tests/unit/test_notebook_template_contract.py
+++ b/tests/unit/test_notebook_template_contract.py
@@ -353,21 +353,13 @@ class TestArcDTemplateContract:
 
     def test_feature_health_imports(self):
         source = ARC_D_TEMPLATES["10_feature_health"].read_text()
-        has_plot = (
-            "plot_feature_distribution" in source
-            or "plot_feature_correlation" in source
-        )
-        assert has_plot, (
-            "10_feature_health must import plot functions from "
-            "bid_euchre.diagnostics.charts"
-        )
+        assert (
+            "from bid_euchre.diagnostics.charts import" in source
+        ), "10_feature_health must import from bid_euchre.diagnostics.charts"
 
     def test_outcome_health_imports(self):
         source = ARC_D_TEMPLATES["20_outcome_health"].read_text()
-        has_auction = (
-            "plot_auction_health" in source or "plot_bidder_performance" in source
-        )
-        assert has_auction, (
+        assert "from bid_euchre.diagnostics.auction_charts import" in source, (
             "20_outcome_health must import from "
             "bid_euchre.diagnostics.auction_charts"
         )


### PR DESCRIPTION
## Summary
- Adds `TestArcDTemplateContract` class with 11 static/structural contract tests for the 3 Arc D notebook templates (`10_feature_health.py`, `20_outcome_health.py`, `30_feature_outcome_eval.py`)
- Tests use parametrize across all 3 templates for shared checks (parameters, Jupytext headers, directory resolution, eval dataset import, removed parameter absence)
- Template-specific tests validate specialized imports (`diagnostics.charts`, `auction_charts`, `reporting.evaluator`), `_resolve_path` helper, and `IsADirectoryError` handling

## Why
The 3 new Arc D notebook templates (PRs #418-#420) have zero contract tests. The existing `01_model_rung_template.py` has 11+ tests in `TestNotebookTemplateContract` — this brings parity for the Arc D templates and guards against structural drift.

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_notebook_template_contract.py -v
# 35 passed (14 existing + 21 new)
```

## Tests
```bash
uv run python -m pytest tests/unit/test_notebook_template_contract.py -v  # all 35 pass
make check  # all 5 stages pass
```

## Worktree Proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-c1
show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-c1
worktree: Bid-Euchre-c1 [feat/arc-d-template-contracts]
```

## Risk
Low — tests only, no production code changes.