### PR TITLE
feat: add quiet output shaping to Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help sync repo-lint lint test check notebook-sync notebook-check notebook-run notebook-run-full notebook-run-arc-d promotion-gate bid-train-teachers bid-eval-tiny bid-loop bidless-diagnostics docs-check
+.PHONY: help sync repo-lint lint test check check-quiet notebook-sync notebook-check notebook-run notebook-run-full notebook-run-arc-d promotion-gate bid-train-teachers bid-eval-tiny bid-loop bidless-diagnostics docs-check
 .DEFAULT_GOAL := help
 
 PYTHON ?= uv run python
@@ -19,6 +19,7 @@ help:
 	@echo ""
 	@echo "Gold path targets:"
 	@echo "  make check              - repo-lint + ruff + tests"
+	@echo "  make check-quiet        - full check, minimal output (logs to tmpfile)"
 	@echo "  make repo-lint          - repo linter (diff vs origin/main)"
 	@echo "  make lint               - ruff check ."
 	@echo "  make test               - pytest fast suite"
@@ -49,14 +50,26 @@ repo-lint:
 
 lint:
 	@echo ">>> Ruff"
-	$(PYTHON) -m ruff check .
+	$(PYTHON) -m ruff check -q .
 
 test:
 	@echo ">>> Pytest (fast suite)"
-	PYTHONPATH=.:src $(PYTHON) -m pytest -m "not slow" tests/
+	PYTHONPATH=.:src $(PYTHON) -m pytest -q -m "not slow" tests/
 
 check: repo-lint lint test notebook-check docs-check
 	@echo "✓ All checks passed"
+
+check-quiet:
+	@CHECK_LOG=$$(mktemp /tmp/make-check-XXXXXX); \
+	echo ">>> Running full check (logs → $$CHECK_LOG)"; \
+	if $(MAKE) check > "$$CHECK_LOG" 2>&1; then \
+		echo "✓ All checks passed (details: $$CHECK_LOG)"; \
+	else \
+		echo "✗ Checks FAILED (full log: $$CHECK_LOG)"; \
+		echo "--- Failure extract ---"; \
+		grep -n -i -A 3 'FAILED\|ERROR\|error:\|failed' "$$CHECK_LOG" | head -40; \
+		exit 1; \
+	fi
 
 notebook-sync:
 	@echo ">>> Jupytext sync (notebooks)"


### PR DESCRIPTION
## Summary
- Add `-q` flag to `make test` (pytest) and `make lint` (ruff) for reduced output in Makefile invocations (~88% token reduction)
- Add new `check-quiet` target that runs full check with output redirected to a `mktemp` log file, showing only pass/fail + failure extract on error
- Add `check-quiet` to `.PHONY` and `help` target

## Why
`make check` produces ~173KB (~42K tokens) of output, with pytest `--verbose` accounting for ~90%. This floods agent context windows with noise. By adding `-q` to Makefile targets (not `pytest.ini`), we reduce default Makefile output by ~88% while preserving verbose output for direct pytest invocations and CI.

**PR-2** (`docs/context-efficiency-workflow`) depends on this PR to document the new targets.

## Repro / Validation
**Command(s) run:**
- `make check` — all checks pass with quiet flags
- `make check-quiet` — success path shows 2-line output + log path
- `make test 2>&1 | wc -c` — ~16KB (was ~150KB with --verbose)

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `make check` passes (includes pytest fast suite, ruff, repo-lint, notebook-check, docs-check)
- [x] `make check-quiet` success path verified

## Expected impact
- Metrics impact: None (output shaping only)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-output-shaping
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-output-shaping
```

`git worktree list` (trimmed):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                 150c906 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-output-shaping  619cd48 [feat/context-efficiency-output-shaping]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)