### PR TITLE
refactor: move R0 notebooks into arc_d/r0/ with CWD fix

### DIFF
--- a/notebooks/arc_d/r0/40_r0_baseline.ipynb
+++ b/notebooks/arc_d/r0/40_r0_baseline.ipynb
@@ -54,9 +54,54 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Ensure CWD is repo root (Jupyter kernels start in notebook dir)\n",
+    "_cwd = Path.cwd()\n",
+    "if not (_cwd / \".git\").exists():\n",
+    "    _root = _cwd\n",
+    "    while _root != _root.parent:\n",
+    "        _root = _root.parent\n",
+    "        if (_root / \".git\").exists():\n",
+    "            os.chdir(_root)\n",
+    "            break\n",
+    "    else:\n",
+    "        print(f\"WARNING: Could not find repo root from {_cwd}\")\n",
+    "print(f\"Working directory: {Path.cwd()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "## Available eval runs\n",
+    "Run this cell to discover local eval data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import glob as _g\n",
+    "\n",
+    "for _p in sorted(_g.glob(\"data/runs/arc_d_eval*\")):\n",
+    "    print(_p)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import glob as glob_mod\n",
     "import json\n",
-    "from pathlib import Path\n",
     "\n",
     "import matplotlib\n",
     "import matplotlib.pyplot as plt\n",
@@ -111,6 +156,12 @@
     "            print(f\"  Deals: {df['deal_id'].nunique()}, Source: {_data_source}\")\n",
     "        except (FileNotFoundError, ValueError) as exc:\n",
     "            print(f\"WARNING: Could not load eval logs: {exc}\")\n",
+    "\n",
+    "if EVAL_RUN_DIR and df.empty:\n",
+    "    print(\n",
+    "        f\"WARNING: EVAL_RUN_DIR={EVAL_RUN_DIR!r} is set but no data was loaded.\\n\"\n",
+    "        \"  Check that the path exists relative to the repo root.\"\n",
+    "    )\n",
     "\n",
     "if df.empty:\n",
     "    # Synthetic demo data for CI / SMOKE fallback\n",
@@ -207,7 +258,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "7",
    "metadata": {},
    "source": [
     "# §1 Deal Health\n",
@@ -218,7 +269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,7 +317,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "9",
    "metadata": {},
    "source": [
     "# §2 Auction Health\n",
@@ -278,7 +329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -337,7 +388,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "11",
    "metadata": {},
    "source": [
     "# §3 Gameplay Health\n",
@@ -348,7 +399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -377,7 +428,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "13",
    "metadata": {},
    "source": [
     "# §4 Auction Outcomes\n",
@@ -389,7 +440,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -421,7 +472,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "15",
    "metadata": {},
    "source": [
     "# §5 Gameplay Outcomes\n",
@@ -433,7 +484,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -479,7 +530,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "17",
    "metadata": {},
    "source": [
     "# §6 Model Specs\n",
@@ -491,7 +542,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -548,7 +599,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "19",
    "metadata": {},
    "source": [
     "# §7 Model Performance\n",
@@ -560,7 +611,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -698,7 +749,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "21",
    "metadata": {},
    "source": [
     "# §7.5 Feature-Outcome Correlations\n",
@@ -710,7 +761,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -751,7 +802,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "23",
    "metadata": {},
    "source": [
     "# §7.6 Trump Suit Invariance\n",
@@ -763,7 +814,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -802,7 +853,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "25",
    "metadata": {},
    "source": [
     "# §7.7 Drift Detection\n",
@@ -814,7 +865,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -847,7 +898,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "27",
    "metadata": {},
    "source": [
     "# §8 Dual-Arm Comparison\n",
@@ -858,7 +909,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -941,7 +992,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "29",
    "metadata": {},
    "source": [
     "# §9 Seed Sensitivity\n",
@@ -952,7 +1003,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1012,7 +1063,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "31",
    "metadata": {},
    "source": [
     "# §10 Promotion Summary\n",
@@ -1023,7 +1074,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1092,7 +1143,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "33",
    "metadata": {},
    "source": [
     "# §11 Comparator Battery\n",
@@ -1105,7 +1156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/arc_d/r0/40_r0_baseline.py
+++ b/notebooks/arc_d/r0/40_r0_baseline.py
@@ -44,9 +44,35 @@ PROMOTION_DECISION_PATH = "data/artifacts/arc_d/r0/promotion_decision_r0.json"
 # # §0 Setup
 
 # %%
+import os
+from pathlib import Path
+
+# Ensure CWD is repo root (Jupyter kernels start in notebook dir)
+_cwd = Path.cwd()
+if not (_cwd / ".git").exists():
+    _root = _cwd
+    while _root != _root.parent:
+        _root = _root.parent
+        if (_root / ".git").exists():
+            os.chdir(_root)
+            break
+    else:
+        print(f"WARNING: Could not find repo root from {_cwd}")
+print(f"Working directory: {Path.cwd()}")
+
+# %% [markdown]
+# ## Available eval runs
+# Run this cell to discover local eval data:
+
+# %%
+import glob as _g
+
+for _p in sorted(_g.glob("data/runs/arc_d_eval*")):
+    print(_p)
+
+# %%
 import glob as glob_mod
 import json
-from pathlib import Path
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -101,6 +127,12 @@ if EVAL_RUN_DIR:
             print(f"  Deals: {df['deal_id'].nunique()}, Source: {_data_source}")
         except (FileNotFoundError, ValueError) as exc:
             print(f"WARNING: Could not load eval logs: {exc}")
+
+if EVAL_RUN_DIR and df.empty:
+    print(
+        f"WARNING: EVAL_RUN_DIR={EVAL_RUN_DIR!r} is set but no data was loaded.\n"
+        "  Check that the path exists relative to the repo root."
+    )
 
 if df.empty:
     # Synthetic demo data for CI / SMOKE fallback

--- a/notebooks/arc_d/r0/50_r0_matchups.ipynb
+++ b/notebooks/arc_d/r0/50_r0_matchups.ipynb
@@ -58,8 +58,53 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import glob as glob_mod\n",
+    "import os\n",
     "from pathlib import Path\n",
+    "\n",
+    "# Ensure CWD is repo root (Jupyter kernels start in notebook dir)\n",
+    "_cwd = Path.cwd()\n",
+    "if not (_cwd / \".git\").exists():\n",
+    "    _root = _cwd\n",
+    "    while _root != _root.parent:\n",
+    "        _root = _root.parent\n",
+    "        if (_root / \".git\").exists():\n",
+    "            os.chdir(_root)\n",
+    "            break\n",
+    "    else:\n",
+    "        print(f\"WARNING: Could not find repo root from {_cwd}\")\n",
+    "print(f\"Working directory: {Path.cwd()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "## Available eval runs\n",
+    "Run this cell to discover local eval data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import glob as _g\n",
+    "\n",
+    "for _p in sorted(_g.glob(\"data/runs/arc_d_eval*\")):\n",
+    "    print(_p)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import glob as glob_mod\n",
     "\n",
     "import matplotlib\n",
     "import matplotlib.pyplot as plt\n",
@@ -112,6 +157,12 @@
     "            )\n",
     "    else:\n",
     "        print(f\"Logs directory not found: {logs_dir}\")\n",
+    "\n",
+    "if MATCHUP_RUN_DIR and not _matchup_available:\n",
+    "    print(\n",
+    "        f\"WARNING: MATCHUP_RUN_DIR={MATCHUP_RUN_DIR!r} is set but no data was loaded.\\n\"\n",
+    "        \"  Check that the path exists relative to the repo root.\"\n",
+    "    )\n",
     "\n",
     "if not _matchup_available:\n",
     "    # Synthetic demo data for CI / SMOKE\n",
@@ -179,7 +230,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "7",
    "metadata": {},
    "source": [
     "# §1 Matchup Overview\n",
@@ -191,7 +242,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,7 +281,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "9",
    "metadata": {},
    "source": [
     "# §2 Tricks Distribution\n",
@@ -241,7 +292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +331,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "11",
    "metadata": {},
    "source": [
     "# §3 Self-Play Fairness\n",
@@ -291,7 +342,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -331,7 +382,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "13",
    "metadata": {},
    "source": [
     "# §4 Seat Rotation Validation\n",
@@ -343,7 +394,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,7 +448,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "15",
    "metadata": {},
    "source": [
     "# §5 Per-Opponent Analysis\n",
@@ -409,7 +460,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -471,7 +522,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "17",
    "metadata": {},
    "source": [
     "# §6 Performance by Contract\n",
@@ -482,7 +533,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -522,7 +573,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "19",
    "metadata": {},
    "source": [
     "# §7 Summary Table\n",
@@ -533,7 +584,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/arc_d/r0/50_r0_matchups.py
+++ b/notebooks/arc_d/r0/50_r0_matchups.py
@@ -48,8 +48,34 @@ MODEL_NAME = "hybrid_olsa_r0"  # Model name in matchup_id strings
 # # §0 Setup
 
 # %%
-import glob as glob_mod
+import os
 from pathlib import Path
+
+# Ensure CWD is repo root (Jupyter kernels start in notebook dir)
+_cwd = Path.cwd()
+if not (_cwd / ".git").exists():
+    _root = _cwd
+    while _root != _root.parent:
+        _root = _root.parent
+        if (_root / ".git").exists():
+            os.chdir(_root)
+            break
+    else:
+        print(f"WARNING: Could not find repo root from {_cwd}")
+print(f"Working directory: {Path.cwd()}")
+
+# %% [markdown]
+# ## Available eval runs
+# Run this cell to discover local eval data:
+
+# %%
+import glob as _g
+
+for _p in sorted(_g.glob("data/runs/arc_d_eval*")):
+    print(_p)
+
+# %%
+import glob as glob_mod
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -102,6 +128,12 @@ if MATCHUP_RUN_DIR:
             )
     else:
         print(f"Logs directory not found: {logs_dir}")
+
+if MATCHUP_RUN_DIR and not _matchup_available:
+    print(
+        f"WARNING: MATCHUP_RUN_DIR={MATCHUP_RUN_DIR!r} is set but no data was loaded.\n"
+        "  Check that the path exists relative to the repo root."
+    )
 
 if not _matchup_available:
     # Synthetic demo data for CI / SMOKE

--- a/tests/unit/test_notebook_template_contract.py
+++ b/tests/unit/test_notebook_template_contract.py
@@ -94,7 +94,8 @@ class TestNotebookTemplateContract:
             Path(__file__).resolve().parents[2]
             / "notebooks"
             / "arc_d"
-            / "02_r0_baseline.py"
+            / "r0"
+            / "40_r0_baseline.py"
         )
         source = r0_path.read_text()
         for section in REQUIRED_SECTIONS:
@@ -128,7 +129,11 @@ class TestNotebookTemplateContract:
 # ──────────────────────────────────────────────
 
 R0_PATH = (
-    Path(__file__).resolve().parents[2] / "notebooks" / "arc_d" / "02_r0_baseline.py"
+    Path(__file__).resolve().parents[2]
+    / "notebooks"
+    / "arc_d"
+    / "r0"
+    / "40_r0_baseline.py"
 )
 
 
@@ -180,14 +185,15 @@ class TestR0NotebookEnrichment:
         )
 
     def test_r0_matchup_notebook_exists(self):
-        """03_r0_matchups.py must exist with required section markers."""
+        """50_r0_matchups.py must exist with required section markers."""
         matchup_path = (
             Path(__file__).resolve().parents[2]
             / "notebooks"
             / "arc_d"
-            / "03_r0_matchups.py"
+            / "r0"
+            / "50_r0_matchups.py"
         )
-        assert matchup_path.exists(), "03_r0_matchups.py must exist"
+        assert matchup_path.exists(), "50_r0_matchups.py must exist"
         source = matchup_path.read_text()
         required_sections = [
             "§0 Setup",
@@ -208,7 +214,8 @@ class TestR0NotebookEnrichment:
             Path(__file__).resolve().parents[2]
             / "notebooks"
             / "arc_d"
-            / "03_r0_matchups.py"
+            / "r0"
+            / "50_r0_matchups.py"
         )
         source = matchup_path.read_text()
 
@@ -248,7 +255,8 @@ class TestR0NotebookEnrichment:
             Path(__file__).resolve().parents[2]
             / "notebooks"
             / "arc_d"
-            / "03_r0_matchups.py"
+            / "r0"
+            / "50_r0_matchups.py"
         )
         source = matchup_path.read_text()
 


### PR DESCRIPTION
## Summary
- Move `02_r0_baseline` and `03_r0_matchups` notebooks from `notebooks/arc_d/` into `notebooks/arc_d/r0/` (renumbered as `40_` and `50_`)
- Add CWD resolution cell, discovery cell, and unresolved-path warnings (PR #426 pattern)
- Update 5 path references in `test_notebook_template_contract.py`

## Why
All R0 notebooks should live together in `notebooks/arc_d/r0/`. The parent-level notebooks also lacked the CWD resolution fix from PR #426, which causes path resolution failures when running from notebook directory.

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/test_notebook_template_contract.py -x -q` — 35 passed
- `make check-quiet` — all checks passed

**Config (if applicable):** N/A

**Seed (if applicable):** N/A

## Tests
- [x] `make check-quiet` passes (1661 passed, 6 skipped, 4 deselected)
- [x] `uv run python -m pytest tests/unit/test_notebook_template_contract.py -x -q` — 35 passed

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-move-r0-notebooks
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-move-r0-notebooks
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                        3b79f26 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-move-r0-notebooks      d7b803a [feat/move-r0-notebooks]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)