### PR TITLE
feat: add points_won column and fix recursive notebook discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ notebook-run-arc-d:
 ifdef NOTEBOOK
 	PYTHONPATH=src $(PYTHON) scripts/run_notebooks.py --mode smoke --pattern "$(NOTEBOOK)"
 else
-	PYTHONPATH=src $(PYTHON) scripts/run_notebooks.py --mode smoke --pattern "notebooks/arc_d/*.ipynb"
+	PYTHONPATH=src $(PYTHON) scripts/run_notebooks.py --mode smoke --pattern "notebooks/arc_d/**/*.ipynb"
 endif
 
 docs-check:

--- a/scripts/run_notebooks.py
+++ b/scripts/run_notebooks.py
@@ -56,7 +56,7 @@ def discover_notebooks(pattern: str = "notebooks/phase0_bidless/*.ipynb") -> lis
     Excludes archive/ subdirectory.
     """
     repo_root = Path(__file__).parent.parent
-    all_notebooks = sorted(glob.glob(str(repo_root / pattern)))
+    all_notebooks = sorted(glob.glob(str(repo_root / pattern), recursive=True))
     # Exclude archived notebooks
     notebooks = [Path(nb) for nb in all_notebooks if "archive" not in Path(nb).parts]
     return notebooks

--- a/src/bid_euchre/datasets/eval_dataset.py
+++ b/src/bid_euchre/datasets/eval_dataset.py
@@ -28,6 +28,8 @@ from typing import Dict, Iterable, List
 
 import pandas as pd
 
+from bid_euchre.scoring import compute_points
+
 logger = logging.getLogger(__name__)
 
 
@@ -107,6 +109,10 @@ def _expand_record(record: Dict) -> List[Dict]:
             "n_passes": n_passes,
             "auction_rounds": auction_rounds,
         }
+
+        # Compute points_won using scoring rules
+        pts_t0, pts_t1 = compute_points(winning_bid, bidder_position, t0, t1)
+        row["points_won"] = pts_t0 if team == 0 else pts_t1
 
         # Flatten features with feat_ prefix
         seat_features = features_list[seat] if seat < len(features_list) else {}

--- a/tests/unit/test_eval_dataset.py
+++ b/tests/unit/test_eval_dataset.py
@@ -404,6 +404,72 @@ class TestMalformedJson:
         assert set(df["deal_id"]) == {0, 1}
 
 
+class TestPointsWon:
+    """Tests for points_won column derived from compute_points."""
+
+    def test_made_bid_declaring_team(self, tmp_path: Path) -> None:
+        """Declaring team (team 0) made the bid → gets tricks won."""
+        log = tmp_path / "test.jsonl"
+        # Team 0 bids 6, wins 7 tricks
+        _write_jsonl(
+            log,
+            [_make_hand_end(winning_bid=6, bidder_position=0, t0=7, t1=3)],
+        )
+
+        df = build_eval_dataset(log)
+
+        # Seats 0,2 (team 0, declaring) → 7 points (made bid, get tricks)
+        for seat in (0, 2):
+            assert df.loc[df["seat"] == seat, "points_won"].iloc[0] == 7
+
+    def test_made_bid_defending_team(self, tmp_path: Path) -> None:
+        """Defending team (team 1) when bid is made → gets their tricks."""
+        log = tmp_path / "test.jsonl"
+        _write_jsonl(
+            log,
+            [_make_hand_end(winning_bid=6, bidder_position=0, t0=7, t1=3)],
+        )
+
+        df = build_eval_dataset(log)
+
+        # Seats 1,3 (team 1, defending) → 3 points (their tricks)
+        for seat in (1, 3):
+            assert df.loc[df["seat"] == seat, "points_won"].iloc[0] == 3
+
+    def test_set_bid_declaring_team(self, tmp_path: Path) -> None:
+        """Declaring team set → gets -bid."""
+        log = tmp_path / "test.jsonl"
+        # Team 0 bids 8, only wins 5 tricks → set
+        _write_jsonl(
+            log,
+            [_make_hand_end(winning_bid=8, bidder_position=0, t0=5, t1=5)],
+        )
+
+        df = build_eval_dataset(log)
+
+        # Seats 0,2 (team 0, declaring, set) → -8 points
+        for seat in (0, 2):
+            assert df.loc[df["seat"] == seat, "points_won"].iloc[0] == -8
+        # Seats 1,3 (team 1, defending) → 5 points
+        for seat in (1, 3):
+            assert df.loc[df["seat"] == seat, "points_won"].iloc[0] == 5
+
+    def test_no_bidder(self, tmp_path: Path) -> None:
+        """No bidder → both teams get their tricks as points."""
+        log = tmp_path / "test.jsonl"
+        _write_jsonl(
+            log,
+            [_make_hand_end(winning_bid=None, bidder_position=None, t0=6, t1=4)],
+        )
+
+        df = build_eval_dataset(log)
+
+        for seat in (0, 2):
+            assert df.loc[df["seat"] == seat, "points_won"].iloc[0] == 6
+        for seat in (1, 3):
+            assert df.loc[df["seat"] == seat, "points_won"].iloc[0] == 4
+
+
 # ---------------------------------------------------------------------------
 # Tests: resolve_eval_log_from_bundle
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `points_won` column to `eval_dataset._expand_record()` using `compute_points()` from `scoring.py`
- Fix `scripts/run_notebooks.py` to use `recursive=True` in `glob.glob()` so `**` patterns work
- Fix `Makefile` `notebook-run-arc-d` default pattern from `notebooks/arc_d/*.ipynb` → `notebooks/arc_d/**/*.ipynb`

## Why
PR-0 in the R0 notebook execution plan (v2, #428). This is the Phase 0 blocker:
- All 5 Phase 1 notebook PRs depend on the `points_won` column for scoring analysis
- Without `recursive=True`, `make notebook-run-arc-d` cannot discover R0 notebooks in `notebooks/arc_d/r0/`

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/test_eval_dataset.py -x -q` — 25 passed (21 existing + 4 new)
- `make check-quiet` — all checks passed

**Config (if applicable):** N/A

**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_eval_dataset.py -x -q` (25 passed)
- [x] `make check-quiet` (full validation)
- [ ] Other: 4 new test cases in `TestPointsWon` class:
  - `test_made_bid_declaring_team` — team 0 bids 6, wins 7 → points_won=7
  - `test_made_bid_defending_team` — same deal, defending → points_won=3
  - `test_set_bid_declaring_team` — team 0 bids 8, wins 5 → points_won=-8
  - `test_no_bidder` — no bidder → both teams get tricks as points

## Expected impact
- Metrics impact (if any): None (new column only, no existing columns changed)
- Runtime impact (if any): Negligible (one `compute_points()` call per record)

## Risk level
- [ ] Low (docs/tests only)
- [x] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-points-infra
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-points-infra
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                29e40d7 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-points-infra   1132710 [feat/r0-nb-0-points-infra]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)