### PR TITLE
feat: OLSaBidder dual-format loading + C33 ablation config

### DIFF
--- a/docs/01_core/schemas/c33_ablation_v1.md
+++ b/docs/01_core/schemas/c33_ablation_v1.md
@@ -1,0 +1,64 @@
+# Schema: c33_ablation_v1
+
+C33 mini-H2H ablation results comparing HybridOLSaBidder (Gaussian EV) vs
+OLSaBidder (floor-based) using identical regression coefficients.
+
+## Purpose
+
+Isolates the wrapper effect: both bidders use the same constrained-arm
+coefficients from `hybrid_r0.json`. The only difference is the decision layer.
+
+## Structure
+
+```json
+{
+  "schema": "c33_ablation_v1",
+  "generated_at": "<ISO-8601>",
+  "seed": 42,
+  "n_per": 10000,
+  "constrained_artifact": "data/artifacts/arc_d/r0/hybrid_r0.json",
+  "matchups": {
+    "hybrid_olsa_self_play": {
+      "bidder_a": "hybrid_olsa",
+      "bidder_b": "hybrid_olsa",
+      "net_eppd_a": 0.0,
+      "net_eppd_b": 0.0,
+      "deals_total": 10000
+    },
+    "olsa_self_play": { "..." : "..." },
+    "hybrid_olsa_vs_olsa": {
+      "bidder_a": "hybrid_olsa",
+      "bidder_b": "olsa",
+      "net_eppd_a": 0.0,
+      "net_eppd_b": 0.0,
+      "net_eppd_delta": 0.0,
+      "delta_ci_low": 0.0,
+      "delta_ci_high": 0.0,
+      "deals_total": 10000
+    },
+    "olsa_vs_hybrid_olsa": { "..." : "..." }
+  },
+  "summary": {
+    "wrapper_effect_delta": 0.0,
+    "wrapper_effect_ci": [0.0, 0.0],
+    "wrapper_effect_significant": false
+  }
+}
+```
+
+## Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| schema | string | Must be "c33_ablation_v1" |
+| seed | int | RNG seed for reproducibility |
+| n_per | int | Deals per matchup cell |
+| constrained_artifact | string | Path to shared artifact |
+| matchups | dict | Per-matchup results keyed by matchup_id |
+| summary.wrapper_effect_delta | float | Pooled hybrid-olsa advantage |
+| summary.wrapper_effect_ci | [float, float] | 95% bootstrap CI |
+
+## Provenance
+
+Produced by `experiments/configs/arc_d_r0_c33_ablation.yaml` run via
+`experiments/run_experiment.py`. Results parsed from JSONL game logs.

--- a/experiments/configs/arc_d_r0_c33_ablation.yaml
+++ b/experiments/configs/arc_d_r0_c33_ablation.yaml
@@ -1,0 +1,62 @@
+# C33 Ablation: hybrid_olsa vs olsa mini-H2H
+#
+# Tests whether the Gaussian EV decision layer (HybridOLSaBidder) adds value
+# over the simple floor-based decision layer (OLSaBidder) when both use
+# identical regression coefficients from hybrid_r0.json (constrained arm).
+#
+# 4 matchups: self-play for each + both seat rotations of cross-matchup.
+# All trick play uses GluttonStrategy; only bidding policies vary.
+#
+# 4 matchups × 1 scenario × 10,000 hands = 40,000 hands.
+
+experiment_name: arc_d_r0_c33_ablation
+
+parameters:
+  seed: 42
+  n_per: 10000
+  log_level: hand
+  mode: head_to_head_matrix
+  pair_deals: true
+
+strategies:
+  - name: glutton
+    class_name: GluttonStrategy
+
+bidding_policies:
+  - name: hybrid_olsa
+    class_name: HybridOLSaBidder
+    params:
+      artifact_path: data/artifacts/arc_d/r0/hybrid_r0.json
+
+  - name: olsa
+    class_name: OLSaBidder
+    params:
+      artifact_path: data/artifacts/arc_d/r0/hybrid_r0.json
+
+matchups:
+  # hybrid_olsa self-play
+  - matchup_id: hybrid_olsa_self_play
+    team0: glutton
+    team1: glutton
+    seat_bidding_policies: [hybrid_olsa, hybrid_olsa, hybrid_olsa, hybrid_olsa]
+
+  # olsa self-play
+  - matchup_id: olsa_self_play
+    team0: glutton
+    team1: glutton
+    seat_bidding_policies: [olsa, olsa, olsa, olsa]
+
+  # hybrid_olsa vs olsa (hybrid as seats 0,2)
+  - matchup_id: hybrid_olsa_vs_olsa
+    team0: glutton
+    team1: glutton
+    seat_bidding_policies: [hybrid_olsa, olsa, hybrid_olsa, olsa]
+
+  # olsa vs hybrid_olsa (olsa as seats 0,2)
+  - matchup_id: olsa_vs_hybrid_olsa
+    team0: glutton
+    team1: glutton
+    seat_bidding_policies: [olsa, hybrid_olsa, olsa, hybrid_olsa]
+
+scenarios:
+  - contract_type: null   # Auction mode — bidders actually bid

--- a/experiments/configs/auction_comparator.yaml
+++ b/experiments/configs/auction_comparator.yaml
@@ -1,13 +1,15 @@
 # Auction Comparator: compare bidders in auction mode
 #
-# Primary metric: expected_points over bid-hands only
+# Primary metric: net_eppd (expected net differential per deal)
 # Gate: bid_rate > 0 for every comparator
 #
 # Usage:
 #   uv run python scripts/run_auction_comparator.py \
 #     --config experiments/configs/auction_comparator.yaml \
 #     --seed 42 \
-#     --olsa-artifact /path/to/olsa_v1.json
+#     --olsa-artifact data/artifacts/arc_d/r0/hybrid_r0.json \
+#     --bidder-class HybridOLSaBidder \
+#     --bidder-name hybrid_olsa
 
 experiment_name: auction_comparator
 
@@ -25,8 +27,20 @@ bidding_policies:
   - name: modeloespecifico
     class_name: ModeloEspecifico
 
-  # OLSa is added dynamically by run_auction_comparator.py
-  # if --olsa-artifact is provided
+  # OLSa floor-based bidder using constrained-arm coefficients
+  - name: olsa
+    class_name: OLSaBidder
+    params:
+      artifact_path: data/artifacts/arc_d/r0/hybrid_r0.json
+
+  # OLSa floor-based bidder using full-arm coefficients
+  - name: olsa_full
+    class_name: OLSaBidder
+    params:
+      artifact_path: data/artifacts/arc_d/r0/hybrid_r0_full.json
+
+  # hybrid_olsa is added dynamically by run_auction_comparator.py
+  # if --olsa-artifact is provided with --bidder-class HybridOLSaBidder
 
 scenarios:
   - contract_type: null  # Auction mode

--- a/scripts/internal/extract_comparator_cis.py
+++ b/scripts/internal/extract_comparator_cis.py
@@ -195,6 +195,11 @@ def main():
         help="Output JSON path",
     )
     parser.add_argument(
+        "--battery-file",
+        default="comparator_battery_r0.json",
+        help="Battery JSON filename within artifacts-dir (default: comparator_battery_r0.json)",
+    )
+    parser.add_argument(
         "--force",
         action="store_true",
         help="Write output even if JSONL-vs-battery validation fails",
@@ -205,7 +210,7 @@ def main():
     runs_dir = Path(args.runs_dir)
 
     # Load comparator battery to get bidder list
-    battery_path = artifacts_dir / "comparator_battery_r0.json"
+    battery_path = artifacts_dir / args.battery_file
     if not battery_path.exists():
         print(f"ERROR: {battery_path} not found", file=sys.stderr)
         sys.exit(1)

--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -686,7 +686,9 @@ class OLSaBidder(BiddingPolicy):
     each using the corresponding sparse OLS model, floors to get bid amount,
     and picks the best candidate.
 
-    Artifact format: olsa_v1.json with models for "suit", "high", "low".
+    Artifact format: accepts both olsa_v1 and hybrid_olsa_v1 artifacts.
+    For hybrid_olsa_v1, uses the offensive sub-model (bidder's perspective)
+    and ignores residual_variance / risk_lambda fields.
     """
 
     def __init__(self, artifact_path: str, name: str = "olsa"):
@@ -695,13 +697,24 @@ class OLSaBidder(BiddingPolicy):
         with open(artifact_path) as f:
             artifact = json.load(f)
 
-        if artifact.get("artifact_type") != "olsa_v1":
+        artifact_type = artifact.get("artifact_type")
+        if artifact_type == "olsa_v1":
+            raw_models = artifact["models"]
+        elif artifact_type == "hybrid_olsa_v1":
+            raw_models = {}
+            for cf, model_data in artifact["payoff_model"].items():
+                if "offensive" in model_data:
+                    raw_models[cf] = model_data["offensive"]
+                else:
+                    raw_models[cf] = model_data
+        else:
             raise ValueError(
-                f"Expected artifact_type 'olsa_v1', got '{artifact.get('artifact_type')}'"
+                f"Expected artifact_type 'olsa_v1' or 'hybrid_olsa_v1', "
+                f"got '{artifact_type}'"
             )
 
         self.models = {}
-        for contract_family, model_data in artifact["models"].items():
+        for contract_family, model_data in raw_models.items():
             self.models[contract_family] = {
                 "weights": np.array(model_data["weights"], dtype=np.float64),
                 "bias": float(model_data["bias"]),

--- a/tests/unit/test_olsa_bidder.py
+++ b/tests/unit/test_olsa_bidder.py
@@ -4,9 +4,13 @@ Unit tests for OLSaBidder.
 
 import json
 
+import numpy as np
+import pytest
+
 from bid_euchre.core.cards import Card
 from bid_euchre.strategy.bidding import (
     BiddingObservation,
+    HybridOLSaBidder,
     OLSaBidder,
 )
 
@@ -50,6 +54,97 @@ def _make_artifact(tmp_path, models=None):
     return str(path)
 
 
+def _make_hybrid_artifact_flat(tmp_path, filename="hybrid_flat.json"):
+    """Create a hybrid_olsa_v1 artifact with flat (no off/def) structure."""
+    artifact = {
+        "artifact_type": "hybrid_olsa_v1",
+        "schema_version": 1,
+        "rung_id": "r0",
+        "payoff_model": {
+            "suit": {
+                "weights": [1.0, 0.5, 0.5],
+                "bias": 0.0,
+                "feature_names": ["bowers", "trump_count", "offsuit_aces"],
+            },
+            "high": {
+                "weights": [1.0],
+                "bias": 0.0,
+                "feature_names": ["offsuit_aces"],
+            },
+            "low": {
+                "weights": [1.0],
+                "bias": 0.0,
+                "feature_names": ["offsuit_tens_count"],
+            },
+        },
+        "residual_variance": {"suit": 2.5, "high": 1.8, "low": 1.9},
+        "risk_lambda": 0.0,
+        "context_features": [],
+    }
+    path = tmp_path / filename
+    with open(path, "w") as f:
+        json.dump(artifact, f)
+    return str(path)
+
+
+def _make_hybrid_artifact_offdef(tmp_path, filename="hybrid_offdef.json"):
+    """Create a hybrid_olsa_v1 artifact with offensive/defensive sub-models."""
+    artifact = {
+        "artifact_type": "hybrid_olsa_v1",
+        "schema_version": 1,
+        "rung_id": "r0",
+        "payoff_model": {
+            "suit": {
+                "offensive": {
+                    "weights": [1.0, 0.5, 0.5],
+                    "bias": 0.0,
+                    "feature_names": ["bowers", "trump_count", "offsuit_aces"],
+                },
+                "defensive": {
+                    "weights": [0.3, 0.2, 0.1],
+                    "bias": 1.0,
+                    "feature_names": ["bowers", "trump_count", "offsuit_aces"],
+                },
+            },
+            "high": {
+                "offensive": {
+                    "weights": [1.0],
+                    "bias": 0.0,
+                    "feature_names": ["offsuit_aces"],
+                },
+                "defensive": {
+                    "weights": [0.5],
+                    "bias": 0.5,
+                    "feature_names": ["offsuit_aces"],
+                },
+            },
+            "low": {
+                "offensive": {
+                    "weights": [1.0],
+                    "bias": 0.0,
+                    "feature_names": ["offsuit_tens_count"],
+                },
+                "defensive": {
+                    "weights": [0.4],
+                    "bias": 0.3,
+                    "feature_names": ["offsuit_tens_count"],
+                },
+            },
+        },
+        "residual_variance": {
+            "suit": {"offensive": 2.5, "defensive": 3.0},
+            "high": {"offensive": 1.8, "defensive": 2.0},
+            "low": {"offensive": 1.9, "defensive": 2.1},
+        },
+        "risk_lambda": 0.0,
+        "context_features": [],
+    }
+    path = tmp_path / filename
+    with open(path, "w") as f:
+        json.dump(artifact, f)
+    return str(path)
+
+
 class TestOLSaBidder:
     """Test OLSaBidder."""
 
@@ -77,9 +172,7 @@ class TestOLSaBidder:
             Card("S", "A"),  # Offsuit ace
         ]
 
-        obs = BiddingObservation(
-            hand=hand, seat=0, dealer_seat=3, current_high_bid=0
-        )
+        obs = BiddingObservation(hand=hand, seat=0, dealer_seat=3, current_high_bid=0)
         action = bidder.choose_bid(obs)
         assert not action.is_pass()
         assert action.n == 4
@@ -100,9 +193,7 @@ class TestOLSaBidder:
             Card("C", "T"),
         ]
 
-        obs = BiddingObservation(
-            hand=hand, seat=0, dealer_seat=3, current_high_bid=0
-        )
+        obs = BiddingObservation(hand=hand, seat=0, dealer_seat=3, current_high_bid=0)
         action = bidder.choose_bid(obs)
         assert action.is_pass()
 
@@ -125,9 +216,7 @@ class TestOLSaBidder:
             Card("H", "Q"),
         ]
 
-        obs = BiddingObservation(
-            hand=hand, seat=0, dealer_seat=3, current_high_bid=0
-        )
+        obs = BiddingObservation(hand=hand, seat=0, dealer_seat=3, current_high_bid=0)
         action = bidder.choose_bid(obs)
         assert not action.is_pass()
         # With 4 aces, HIGH should be a strong candidate
@@ -170,9 +259,7 @@ class TestOLSaBidder:
             Card("H", "Q"),
         ]
 
-        obs = BiddingObservation(
-            hand=hand, seat=0, dealer_seat=3, current_high_bid=0
-        )
+        obs = BiddingObservation(hand=hand, seat=0, dealer_seat=3, current_high_bid=0)
         action = bidder.choose_bid(obs)
         assert not action.is_pass()
         assert action.contract == "LOW"
@@ -193,9 +280,7 @@ class TestOLSaBidder:
         ]
 
         # Current high bid is 4, must bid higher or pass
-        obs = BiddingObservation(
-            hand=hand, seat=0, dealer_seat=3, current_high_bid=4
-        )
+        obs = BiddingObservation(hand=hand, seat=0, dealer_seat=3, current_high_bid=4)
         action = bidder.choose_bid(obs)
         # predicted=4.5, floor=4, but 4 not > 4, so pass
         assert action.is_pass()
@@ -231,3 +316,121 @@ class TestOLSaBidder:
         bidder = config.create_bidding_policy()
         assert isinstance(bidder, OLSaBidder)
         assert bidder.name == "test_olsa"
+
+
+class TestOLSaBidderDualFormat:
+    """Test OLSaBidder loading hybrid_olsa_v1 artifacts."""
+
+    def test_loads_hybrid_flat(self, tmp_path):
+        """OLSaBidder loads flat hybrid_olsa_v1 artifact."""
+        path = _make_hybrid_artifact_flat(tmp_path)
+        bidder = OLSaBidder(path)
+        assert "suit" in bidder.models
+        assert "high" in bidder.models
+        assert "low" in bidder.models
+
+    def test_loads_hybrid_offdef(self, tmp_path):
+        """OLSaBidder loads off/def hybrid_olsa_v1, using offensive sub-model."""
+        path = _make_hybrid_artifact_offdef(tmp_path)
+        bidder = OLSaBidder(path)
+        assert "suit" in bidder.models
+        # Verify it used offensive weights (1.0, 0.5, 0.5), not defensive (0.3, 0.2, 0.1)
+        np.testing.assert_array_almost_equal(
+            bidder.models["suit"]["weights"], [1.0, 0.5, 0.5]
+        )
+        assert bidder.models["suit"]["bias"] == 0.0
+
+    def test_hybrid_flat_matches_olsa_v1_predictions(self, tmp_path):
+        """Flat hybrid and olsa_v1 produce identical predictions for same coefficients."""
+        olsa_path = _make_artifact(tmp_path)
+        hybrid_path = _make_hybrid_artifact_flat(tmp_path)
+        olsa_bidder = OLSaBidder(olsa_path)
+        hybrid_bidder = OLSaBidder(hybrid_path, name="olsa_from_hybrid")
+
+        features = {"bowers": 2.0, "trump_count": 4.0, "offsuit_aces": 1.0}
+        olsa_pred = olsa_bidder._predict("suit", features)
+        hybrid_pred = hybrid_bidder._predict("suit", features)
+        assert abs(olsa_pred - hybrid_pred) <= 1e-12
+
+    def test_offdef_uses_offensive_predictions(self, tmp_path):
+        """Off/def hybrid uses offensive sub-model for predictions."""
+        path = _make_hybrid_artifact_offdef(tmp_path)
+        bidder = OLSaBidder(path)
+        # offensive: weights=[1.0, 0.5, 0.5], bias=0.0
+        features = {"bowers": 2.0, "trump_count": 3.0, "offsuit_aces": 1.0}
+        predicted = bidder._predict("suit", features)
+        expected = 2.0 * 1.0 + 3.0 * 0.5 + 1.0 * 0.5  # = 4.0
+        assert abs(predicted - expected) <= 1e-12
+
+    def test_coefficient_parity_with_hybrid_bidder(self, tmp_path):
+        """OLSaBidder._predict matches HybridOLSaBidder._predict for declaring=True.
+
+        This is the core C33 ablation invariant: same coefficients, same linear
+        prediction. The only difference is the decision layer (floor vs Gaussian EV).
+        """
+        # Use flat hybrid artifact (no off/def) for direct comparison
+        path = _make_hybrid_artifact_flat(tmp_path)
+        olsa_bidder = OLSaBidder(path)
+        hybrid_bidder = HybridOLSaBidder(path)
+
+        # Per-contract-family feature dicts (each model has different feature_names)
+        features_by_cf = {
+            "suit": {"bowers": 1.0, "trump_count": 5.0, "offsuit_aces": 2.0},
+            "high": {"offsuit_aces": 3.0},
+            "low": {"offsuit_tens_count": 4.0},
+        }
+        for cf, features in features_by_cf.items():
+            olsa_pred = olsa_bidder._predict(cf, features)
+            hybrid_pred = hybrid_bidder._predict(cf, features, declaring=True)
+            assert abs(olsa_pred - hybrid_pred) <= 1e-12, (
+                f"Coefficient parity broken for {cf}: "
+                f"OLSa={olsa_pred}, Hybrid={hybrid_pred}"
+            )
+
+    def test_coefficient_parity_offdef_with_hybrid_bidder(self, tmp_path):
+        """Parity holds for off/def artifacts: OLSa uses offensive, Hybrid uses declaring=True."""
+        path = _make_hybrid_artifact_offdef(tmp_path)
+        olsa_bidder = OLSaBidder(path)
+        hybrid_bidder = HybridOLSaBidder(path)
+
+        features_by_cf = {
+            "suit": {"bowers": 1.0, "trump_count": 5.0, "offsuit_aces": 2.0},
+            "high": {"offsuit_aces": 3.0},
+            "low": {"offsuit_tens_count": 4.0},
+        }
+        for cf, features in features_by_cf.items():
+            olsa_pred = olsa_bidder._predict(cf, features)
+            hybrid_pred = hybrid_bidder._predict(cf, features, declaring=True)
+            assert abs(olsa_pred - hybrid_pred) <= 1e-12, (
+                f"Coefficient parity broken for {cf}: "
+                f"OLSa={olsa_pred}, Hybrid={hybrid_pred}"
+            )
+
+    def test_strong_hand_bids_from_hybrid(self, tmp_path):
+        """OLSaBidder loaded from hybrid_olsa_v1 bids correctly on strong hands."""
+        path = _make_hybrid_artifact_offdef(tmp_path)
+        bidder = OLSaBidder(path)
+
+        # 2 bowers + 4 trump + 1 offsuit ace
+        # offensive: 1.0*2 + 0.5*4 + 0.5*1 = 4.5 → bid 4
+        hand = [
+            Card("H", "J"),
+            Card("D", "J"),
+            Card("H", "A"),
+            Card("H", "K"),
+            Card("S", "A"),
+        ]
+        obs = BiddingObservation(hand=hand, seat=0, dealer_seat=3, current_high_bid=0)
+        action = bidder.choose_bid(obs)
+        assert not action.is_pass()
+        assert action.n == 4
+
+    def test_error_message_includes_both_formats(self, tmp_path):
+        """Error message mentions both accepted artifact types."""
+        artifact = {"artifact_type": "unknown_v9", "models": {}}
+        path = tmp_path / "bad.json"
+        with open(path, "w") as f:
+            json.dump(artifact, f)
+
+        with pytest.raises(ValueError, match="olsa_v1.*hybrid_olsa_v1"):
+            OLSaBidder(str(path))


### PR DESCRIPTION
## Summary
- Extend OLSaBidder to accept `hybrid_olsa_v1` artifacts (both flat and off/def sub-model structures)
- Add `olsa` and `olsa_full` entries to comparator battery config
- Add `--battery-file` flag to `extract_comparator_cis.py`
- New C33 mini-H2H ablation experiment config (4 matchups)
- New `c33_ablation_v1` schema doc

## Why
C33 ablation requires comparing HybridOLSaBidder (Gaussian EV decision layer) vs OLSaBidder (floor-based) using *identical* regression coefficients from `hybrid_r0.json`. Extending OLSaBidder to load `hybrid_olsa_v1` artifacts avoids retraining drift and enables true apples-to-apples comparison.

This is the first PR in the R0→R1 transition chain (C33 → C50, D23).

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/test_olsa_bidder.py tests/unit/test_hybrid_bidder.py -v`
- `make check-quiet`

**Config (if applicable):**
- `experiments/configs/arc_d_r0_c33_ablation.yaml` (new, 4 matchups)
- `experiments/configs/auction_comparator.yaml` (updated with olsa/olsa_full)

**Seed (if applicable):**
- N/A (code changes only, no experiment runs in this PR)

## Tests
- [x] `uv run python -m pytest -m "not slow" tests/` — all 1666 passed
- [x] `make check-quiet` — all checks passed
- [x] 8 new tests for dual-format loading + coefficient parity verification

## Expected impact
- Metrics impact: None (no behavior changes to existing bidders)
- Runtime impact: None (loading path adds negligible overhead)

## Risk level
- [x] Medium (strategy/experiments)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-c33
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-c33
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre       706185b [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-c33   a0f1091 [codex/c33-olsa-ablation]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)