### PR TITLE
fix: H2H battery parser strategy_id fallback + config overwrite guard

### DIFF
--- a/scripts/internal/run_arc_d_h2h_battery.py
+++ b/scripts/internal/run_arc_d_h2h_battery.py
@@ -484,7 +484,7 @@ def parse_run_results(run_dir, summary, seed=42):
                 if record.get("event") != "hand_end":
                     continue
 
-                mid = record.get("matchup_id", "")
+                mid = record.get("matchup_id") or record.get("strategy_id", "")
                 if mid not in matchup_records:
                     matchup_records[mid] = []
                 matchup_records[mid].append(record)
@@ -654,13 +654,17 @@ def main():
     # Generate experiment config
     config = generate_h2h_config(roster, matchups, args.seed, args.n_per)
 
-    # Write YAML config
+    # Write YAML config (skip when parsing existing run to avoid overwriting)
     output_path = Path(args.output)
-    config_path = output_path.parent / f"h2h_battery_{args.mode.lower()}_config.yaml"
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(config_path, "w") as f:
-        yaml.dump(config, f, default_flow_style=False, sort_keys=False)
-    print(f"Config written to: {config_path}", file=sys.stderr)
+
+    if not args.parse_run:
+        config_path = (
+            output_path.parent / f"h2h_battery_{args.mode.lower()}_config.yaml"
+        )
+        with open(config_path, "w") as f:
+            yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+        print(f"Config written to: {config_path}", file=sys.stderr)
 
     if args.config_only:
         print(


### PR DESCRIPTION
## Summary
- Fix `parse_run_results()` to use `strategy_id` as fallback when `matchup_id` is not present in JSONL records (the logging schema uses `strategy_id`)
- Guard config file write in parse mode to avoid overwriting experiment configs from prior runs

## Why
During R0→R1 experiment execution, the H2H battery parser returned 0/4 populated cells because it looked for `matchup_id` in hand_end records, but the experiment runner logs this as `strategy_id`. Additionally, running parse mode with `--mode QUICK` overwrote the 49-matchup QUICK config with a 2-bidder config.

## Repro / Validation
```bash
# Before fix: 0/4 cells populated
PYTHONPATH=src uv run python scripts/internal/run_arc_d_h2h_battery.py \
  --mode QUICK --seed 42 --n-per 10000 \
  --roster /tmp/c33_roster.json \
  --parse-run data/runs/arc_d_r0_c33_ablation_42_20260225_170036 \
  --output data/artifacts/arc_d/r0/c33_ablation_results.json

# After fix: 4/4 cells populated
```

## Tests
```bash
make check-quiet  # ✓ All checks passed
```

## Worktree Proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-h2h-parser
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-h2h-parser
worktree: Bid-Euchre-fix-h2h-parser  502bca1 [fix/h2h-battery-parser-bugs]
```