### PR TITLE
fix: KeyError in r0 baseline notebook groupby apply

### DIFF
--- a/notebooks/arc_d/r0/40_r0_baseline.ipynb
+++ b/notebooks/arc_d/r0/40_r0_baseline.ipynb
@@ -1374,7 +1374,7 @@
     "            n=(\"made_bid\", \"count\"),\n",
     "        )\n",
     "        wr_by_bid[\"mean_surplus\"] = decl_bidder.groupby(\"winning_bid\").apply(\n",
-    "            lambda g: (g[\"tricks_won\"] - g[\"winning_bid\"]).mean(),\n",
+    "            lambda g: (g[\"tricks_won\"] - g.name).mean(),\n",
     "            include_groups=False,\n",
     "        )\n",
     "        print(\"\\n=== Win Rate by Bid Value (Declaring Bidder) ===\")\n",

--- a/notebooks/arc_d/r0/40_r0_baseline.py
+++ b/notebooks/arc_d/r0/40_r0_baseline.py
@@ -1196,7 +1196,7 @@ if not df.empty and "is_declaring_team" in df.columns and "winning_bid" in df.co
             n=("made_bid", "count"),
         )
         wr_by_bid["mean_surplus"] = decl_bidder.groupby("winning_bid").apply(
-            lambda g: (g["tricks_won"] - g["winning_bid"]).mean(),
+            lambda g: (g["tricks_won"] - g.name).mean(),
             include_groups=False,
         )
         print("\n=== Win Rate by Bid Value (Declaring Bidder) ===")


### PR DESCRIPTION
## Summary
- Fix `KeyError: 'winning_bid'` in `40_r0_baseline.ipynb` cell 17
- Changed `g["winning_bid"]` to `g.name` inside `groupby("winning_bid").apply()` with `include_groups=False`

## Why
The notebook used `include_groups=False` (to suppress pandas FutureWarning) but the lambda still referenced the excluded group column. `g.name` provides the group key value, which is the correct way to access it.

## Repro / Validation
```bash
# Before fix: KeyError on notebook execution
PYTHONPATH=src uv run python scripts/run_notebooks.py \
  --mode smoke --pattern "notebooks/arc_d/r0/40_r0_baseline.ipynb"
# After fix: PASS
```

## Tests
```bash
make check-quiet  # ✓ All checks passed
```

## Worktree Proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-notebook
worktree: Bid-Euchre-fix-notebook [fix/r0-baseline-notebook-groupby]
```