### PR TITLE
docs: fix C33 schema and gate-threshold loading docs

### DIFF
--- a/docs/01_core/schemas/c33_ablation_v1.md
+++ b/docs/01_core/schemas/c33_ablation_v1.md
@@ -1,4 +1,4 @@
-# Schema: c33_ablation_v1
+# Schema: c33_ablation (h2h_battery_v1 subset)
 
 C33 mini-H2H ablation results comparing HybridOLSaBidder (Gaussian EV) vs
 OLSaBidder (floor-based) using identical regression coefficients.
@@ -8,57 +8,71 @@ OLSaBidder (floor-based) using identical regression coefficients.
 Isolates the wrapper effect: both bidders use the same constrained-arm
 coefficients from `hybrid_r0.json`. The only difference is the decision layer.
 
+## Schema
+
+The C33 ablation artifact reuses the `h2h_battery_v1` schema (see
+`h2h_battery_v1.md`) with a 2-bidder roster producing 4 cells:
+
+- `hybrid_olsa_self_play` -- self-play baseline
+- `olsa_self_play` -- self-play baseline
+- `hybrid_olsa_vs_olsa` -- directional matchup
+- `olsa_vs_hybrid_olsa` -- seat-swapped matchup
+
 ## Structure
 
 ```json
 {
-  "schema": "c33_ablation_v1",
+  "schema": "h2h_battery_v1",
   "generated_at": "<ISO-8601>",
+  "mode": "QUICK",
   "seed": 42,
   "n_per": 10000,
-  "constrained_artifact": "data/artifacts/arc_d/r0/hybrid_r0.json",
-  "matchups": {
+  "roster": ["hybrid_olsa", "olsa"],
+  "cells": {
     "hybrid_olsa_self_play": {
       "bidder_a": "hybrid_olsa",
       "bidder_b": "hybrid_olsa",
       "net_eppd_a": 0.0,
       "net_eppd_b": 0.0,
-      "deals_total": 10000
+      "net_eppd_delta": 0.0,
+      "ci_low": 0.0,
+      "ci_high": 0.0,
+      "win_rate_a": 0.5,
+      "deals_total": 10000,
+      "cvar_5": 0.0
     },
     "olsa_self_play": { "..." : "..." },
     "hybrid_olsa_vs_olsa": {
       "bidder_a": "hybrid_olsa",
       "bidder_b": "olsa",
-      "net_eppd_a": 0.0,
-      "net_eppd_b": 0.0,
       "net_eppd_delta": 0.0,
-      "delta_ci_low": 0.0,
-      "delta_ci_high": 0.0,
-      "deals_total": 10000
+      "ci_low": 0.0,
+      "ci_high": 0.0,
+      "deals_total": 10000,
+      "cvar_5": 0.0
     },
     "olsa_vs_hybrid_olsa": { "..." : "..." }
   },
-  "summary": {
-    "wrapper_effect_delta": 0.0,
-    "wrapper_effect_ci": [0.0, 0.0],
-    "wrapper_effect_significant": false
+  "quick_source": null,
+  "provenance": {
+    "script": "scripts/internal/run_arc_d_h2h_battery.py",
+    "git_sha": "<commit-sha>"
   }
 }
 ```
 
-## Required Fields
+## Interpreting the Wrapper Effect
 
-| Field | Type | Description |
-|-------|------|-------------|
-| schema | string | Must be "c33_ablation_v1" |
-| seed | int | RNG seed for reproducibility |
-| n_per | int | Deals per matchup cell |
-| constrained_artifact | string | Path to shared artifact |
-| matchups | dict | Per-matchup results keyed by matchup_id |
-| summary.wrapper_effect_delta | float | Pooled hybrid-olsa advantage |
-| summary.wrapper_effect_ci | [float, float] | 95% bootstrap CI |
+The wrapper effect is derived from the cross-matchup cells:
+
+- **wrapper_effect_delta** = average of `hybrid_olsa_vs_olsa.net_eppd_delta`
+  and `-olsa_vs_hybrid_olsa.net_eppd_delta` (pooled across seat rotations).
+- **Significant** if the CI on both cross-matchup cells excludes zero
+  (i.e., `ci_low > 0` for `hybrid_olsa_vs_olsa` AND `ci_high < 0` for
+  `olsa_vs_hybrid_olsa`).
 
 ## Provenance
 
 Produced by `experiments/configs/arc_d_r0_c33_ablation.yaml` run via
-`experiments/run_experiment.py`. Results parsed from JSONL game logs.
+`experiments/run_experiment.py`. Results parsed from JSONL game logs via
+scripts/internal/run_arc_d_h2h_battery.py `--parse-run`.

--- a/docs/01_core/schemas/gate_thresholds_v1.md
+++ b/docs/01_core/schemas/gate_thresholds_v1.md
@@ -84,5 +84,5 @@ cvar5_tolerance     = max(0.05, 2.0 * std(cvar5_pairwise_residuals))
 
 - **R0:** Gate always uses hardcoded defaults (no artifact needed).
 - **R1+:** Gate loads from `gate_thresholds_r1.json` (auto-discovered or explicit path).
-  Falls back to hardcoded defaults with a warning if artifact is not found.
-  Hard fails if an explicit `thresholds_path` argument points to a missing file.
+  Hard fails if artifact is not found (either auto-discovered or explicit path).
+  Run `calibrate_arc_d_thresholds.py` to produce the artifact before R1+ gate runs.


### PR DESCRIPTION
## Summary
- Update `c33_ablation_v1.md` to document that C33 artifacts use `h2h_battery_v1` schema (not a custom `c33_ablation_v1` schema)
- Fix `gate_thresholds_v1.md` loading behavior: R1+ hard-fails on missing thresholds (no fallback to defaults)

## Why
Reviewer flagged two P1 doc-contract mismatches during R0→R1 handoff validation:
1. C33 ablation doc described a `c33_ablation_v1` schema with `matchups` + `summary` keys, but the actual artifact produced by the H2H battery parser uses `h2h_battery_v1` with `cells` + `roster` keys
2. Gate thresholds doc said missing artifact "falls back to hardcoded defaults with a warning" but implementation hard-fails with `FileNotFoundError` (correct D23 contract)

## Repro / Validation
**Command(s) run:**
- `make check-quiet` — all checks pass

**Config (if applicable):**
- N/A (docs only)

**Seed (if applicable):**
- N/A

## Tests
- [x] `make check-quiet` (docs-check passes)
- [ ] Other: docs-only change, no code modifications

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-doc-contracts
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-doc-contracts
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                       7765901 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-doc-contracts     7765901 [fix/doc-contract-mismatches]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)