### PR TITLE
docs: fix wording in H2H battery analysis report

### DIFF
--- a/docs/04_reports/r0/h2h_battery_analysis.md
+++ b/docs/04_reports/r0/h2h_battery_analysis.md
@@ -227,11 +227,13 @@ is small and does not affect cross-matchup interpretation.
 | rankthetank | 0 | 6 | 0 | 6 |
 | stricthellraiser | 0 | 6 | 0 | 6 |
 
-**Note on win counts:** modeloespecifico and hybrid_olsa are tied at the QUICK
-resolution (9W vs 7W is misleading because modeloespecifico's draws resolve
-differently at higher power). The FULL subset only reran 6 modeloespecifico
-cross-matchups vs 12 for hybrid_olsa, so raw win counts are not directly
-comparable across bidders. Use the pairwise results below instead.
+**Note on win counts:** At QUICK resolution, modeloespecifico leads with 9W-0L
+vs hybrid_olsa's 7W-2L. However, modeloespecifico has 3 draws (CIs spanning
+zero at 2k deals) that may resolve with more data, while hybrid_olsa's 2
+losses are both to modeloespecifico. The FULL subset only reran 6
+modeloespecifico cross-matchups vs 12 for hybrid_olsa, so FULL win counts
+are not directly comparable across bidders. Use the pairwise results below
+instead.
 
 ### 4.4 Key Pairwise Matchups (FULL, 10k deals)
 
@@ -390,12 +392,15 @@ Run directories (local only, `data/runs/`):
    The mechanism is selective restraint (62.5% bid rate, 87.7% make rate).
 
 2. **hybrid_olsa ranks #2 overall** behind the domain-expert modeloespecifico
-   in self-play comparators, but the H2H gap to modeloespecifico (+0.64-0.78
-   net_eppd) is smaller than the self-play gap (+0.62) would suggest.
+   in self-play comparators. The H2H gap (+0.64-0.78 net_eppd) is comparable
+   to or larger than the self-play gap (+0.62), confirming modeloespecifico's
+   advantage is robust across evaluation methods.
 
-3. **The trained-vs-heuristic gap is enormous.** All four trained bidders
-   (including the simple floor-based olsa) dominate all three heuristic
-   bidders by 1-8 net_eppd. The OLS regression coefficients provide massive
+3. **The OLS-vs-heuristic gap is enormous.** The three OLS-trained bidders
+   (hybrid_olsa, olsa_full, olsa) dominate all three simple heuristics
+   (rankthetank, fiveheadfred, stricthellraiser) by 1-8 net_eppd.
+   modeloespecifico (a hand-tuned lookup table, not OLS-trained) also
+   dominates the heuristics. The OLS regression coefficients provide massive
    value even without the Gaussian wrapper.
 
 4. **olsa vs olsa_full is a draw in H2H** despite olsa_full's advantage in


### PR DESCRIPTION
## Summary
- Fix three narrative consistency issues in `docs/04_reports/r0/h2h_battery_analysis.md` identified by reviewer

## Why
Review of #445 found:
1. **[P2]** Conclusion #2 said H2H gap "is smaller than" self-play gap (+0.62), but H2H deltas are +0.64 to +0.78 (actually larger)
2. **[P2]** Conclusion #3 said "all four trained bidders" which implicitly reclassified modeloespecifico (a heuristic lookup table) as trained
3. **[P3]** QUICK win-count note said "tied" despite table showing modeloespecifico 9W vs hybrid_olsa 7W

## Repro / Validation
**Command(s) run:**
- `make check-quiet` — all checks pass

## Tests
- [x] `make check-quiet`
- [ ] Other: docs-only, no code

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-report-fixes
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-report-fixes
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre              a8df7c4 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-report-fixes a8df7c4 [fix/h2h-report-wording]
```

## Checklist
- [x] No generated artifacts committed
- [x] PR is focused (one concept)