### PR TITLE
docs: add evaluation methodology notes to R0 reports

### DIFF
--- a/docs/04_reports/r0/comparator_rankings.md
+++ b/docs/04_reports/r0/comparator_rankings.md
@@ -93,3 +93,49 @@ scoring system.
 - **Source data:** data/artifacts/arc_d/r0/comparator_cis_r0.json (gitignored)
 - **Battery metadata:** data/artifacts/arc_d/r0/comparator_battery_r0.json
 - **gate_status:** PROMOTED (see [r0_promotion_report.md](r0_promotion_report.md))
+
+### Bidder Identity Note
+
+In this battery, `hybrid_olsa` refers to the **OLSa_Full promotional arm** using
+the `hybrid_r0_full.json` artifact (forward-selected features, 82.8% bid rate).
+This is the same configuration reported as "OLSa_Full (Promotional Arm)" in the
+[promotion report](r0_promotion_report.md). The 7-bidder comparator battery in
+[h2h_battery_analysis.md](h2h_battery_analysis.md) later separated the OLSa
+variants into three distinct entries (`hybrid_olsa`, `olsa_full`, `olsa`) with
+different definitions — see that report for the full naming convention.
+
+### What This Methodology Measures (and What It Does Not)
+
+**Design:** Each bidder plays independently against GluttonStrategy (the
+card-playing policy that controls all four seats). There is no competing bidder
+in the auction — the bidder under test declares contracts uncontested, and
+Glutton handles all card play for both teams.
+
+**Strengths:**
+
+- **Absolute scale.** Provides a common benchmark for answering "is this model
+  any good?" A positive net_eppd means the bidder adds value relative to a
+  no-bid baseline.
+- **Progress tracking.** Enables rung-over-rung comparison against a fixed
+  reference point without running O(n²) pairwise matchups.
+- **Reproducible exam.** Same deals, same opponent, same conditions — isolates
+  the bidding policy as the only variable.
+
+**Limitations:**
+
+- **Confounded by the common opponent.** Rankings reflect how well each bidder
+  interacts with GluttonStrategy, not intrinsic bidding quality. A bidder tuned
+  to exploit Glutton's tendencies may score well here but show no advantage in
+  direct competition.
+- **No auction interaction.** Real games have contested auctions where one
+  bidder's bid changes which contracts the opponent gets to play. This battery
+  evaluates uncontested bidding — a fundamentally different task.
+- **Self-play rankings ≠ competitive ordering.** The H2H battery
+  ([h2h_battery_analysis.md](h2h_battery_analysis.md)) shows that some self-play
+  gaps do not replicate under direct opposition. For example,
+  `modeloespecifico` leads `olsa` by +1.86 net_eppd in self-play, but the two
+  are statistically indistinguishable in head-to-head (+0.016, CI spans zero).
+
+**Bottom line:** Use these rankings for absolute benchmarking and progress
+tracking. For competitive ordering between bidders, see the
+[H2H battery analysis](h2h_battery_analysis.md).

--- a/docs/04_reports/r0/h2h_battery_analysis.md
+++ b/docs/04_reports/r0/h2h_battery_analysis.md
@@ -49,17 +49,65 @@ raw `eppd`.
 seed=42). A matchup is "significant" when the CI on `net_eppd_delta` excludes
 zero.
 
-### 1.4 The Seven Bidders
+### 1.4 What This Methodology Measures (and What It Does Not)
+
+**Design:** Two bidders compete directly on the same deals. Both bidders
+participate in a contested auction — bidder A's bid may outbid B or vice versa,
+changing which contracts each side plays. Deals are seat-swapped to control for
+positional advantage.
+
+**Strengths:**
+
+- **True competitive ordering.** Measures which bidder is actually better when
+  they face each other in a contested auction. This is the only evaluation
+  method that captures auction interaction effects.
+- **Controlled for deal luck.** Paired deals + seat-swapping isolate bidding
+  skill from card distribution variance.
+- **Used for promotion gates.** The R1 promotion gate requires the challenger
+  to beat the incumbent by a calibrated delta_floor in direct H2H, not in
+  self-play.
+
+**Limitations:**
+
+- **Relative only.** Two equally weak models produce delta ~ 0, just as two
+  equally strong models do. H2H cannot tell you whether the models are any
+  good in absolute terms — only which is better. For absolute benchmarking,
+  see the [comparator rankings](comparator_rankings.md).
+- **O(n²) cost.** 7 bidders require 49 matchups; this becomes expensive at
+  publication resolution (10k deals/cell = 490k deals). The QUICK-then-FULL
+  design mitigates this by running a survey at 2k/cell first.
+- **Opponent-specific.** A bidder's H2H performance depends on who it faces.
+  Rock-paper-scissors effects (intransitivity) are possible in theory, though
+  not observed in R0.
+
+**Comparison with self-play comparator battery:** The comparator battery
+([comparator_rankings.md](comparator_rankings.md)) evaluates each bidder
+independently against GluttonStrategy in uncontested auctions. It answers "is
+this model any good?" while H2H answers "which model is better?" The two
+methods can give different rankings — for example, `modeloespecifico` leads
+`olsa` by +1.86 net_eppd in self-play but is statistically indistinguishable
+from it in H2H (+0.016, CI spans zero). This divergence arises because
+self-play rankings are confounded by how each bidder interacts with the common
+opponent, while H2H captures the actual competitive dynamic.
+
+### 1.5 The Seven Bidders
 
 | Bidder | Type | Description |
 |--------|------|-------------|
-| **hybrid_olsa** | Trained (Gaussian EV) | R0 OLSa with analytical P(make) via normal CDF. Selective bidder (bid_rate ~0.62). Uses 3 constrained features. |
-| **olsa** | Trained (floor-based) | Same R0 regression coefficients as hybrid_olsa, but uses floor-based threshold decision. Bids on all hands. |
-| **olsa_full** | Trained (floor-based) | Full-arm OLSa with all 39 features, floor-based decision. Bids on all hands. |
+| **hybrid_olsa** | Trained (Gaussian EV) | R0 OLSa with analytical P(make) via normal CDF. Selective bidder (bid_rate ~0.62). Uses 3 constrained features from `hybrid_r0.json`. |
+| **olsa** | Trained (floor-based) | Same R0 regression coefficients as hybrid_olsa (`hybrid_r0.json`), but uses floor-based threshold decision. Bids on all hands. |
+| **olsa_full** | Trained (floor-based) | Full-arm OLSa with all 39 features from `hybrid_r0_full.json`, floor-based decision. Bids on all hands. |
 | **modeloespecifico** | Heuristic (lookup) | Domain-expert lookup table tuned for this game variant. Always bids. |
 | **rankthetank** | Heuristic | Conservative rank-based heuristic. Always bids. |
 | **fiveheadfred** | Heuristic | Aggressive heuristic emphasizing high cards. Always bids. |
 | **stricthellraiser** | Heuristic | Maximally aggressive bidder. Always bids, rarely makes. |
+
+**Naming note:** In this report, `hybrid_olsa` refers to the **constrained OLSa
+arm** with Gaussian EV wrapper (bid_rate ~62%, 3 features). This differs from
+the earlier 5-bidder comparator battery
+([comparator_rankings.md](comparator_rankings.md)), where `hybrid_olsa` referred
+to the **OLSa_Full promotional arm** (bid_rate ~83%, forward-selected features).
+The 7-bidder battery disambiguates by giving `olsa_full` its own entry.
 
 ---
 

--- a/docs/04_reports/r0/r0_promotion_report.md
+++ b/docs/04_reports/r0/r0_promotion_report.md
@@ -146,5 +146,78 @@ objective of future rungs (R1+).
 
 ## Exclusions
 
-- **H2H Matchup Report:** Deferred per C50 (not required at R0).
 - **Semantic gate Tier 2:** Not applicable at R0 (introduced at R1+).
+
+---
+
+## Addendum (2026-02-25)
+
+*Added after the H2H battery analysis was completed. The PROMOTED decision
+above is unchanged — this addendum provides additional context from subsequent
+experiments.*
+
+### Bidder Naming Clarification
+
+In the Comparator Context table above (5-bidder v1 battery), `hybrid_olsa`
+refers to the **OLSa_Full promotional arm** (`hybrid_r0_full.json`,
+forward-selected features, bid_rate = 82.8%). This is the same configuration
+reported as "OLSa_Full (Promotional Arm)" in the evaluation tables above.
+
+The later 7-bidder battery
+([h2h_battery_analysis.md](h2h_battery_analysis.md)) disambiguated the OLSa
+variants into three entries:
+
+| Name in 7-bidder battery | Artifact | Bid rate | Decision layer |
+|--------------------------|----------|----------|----------------|
+| `hybrid_olsa` | `hybrid_r0.json` (constrained, 3 features) | ~62% | Gaussian EV (P(make) via CDF) |
+| `olsa` | `hybrid_r0.json` (constrained, 3 features) | ~100% | Floor-based threshold |
+| `olsa_full` | `hybrid_r0_full.json` (full, 39 features) | ~100% | Floor-based threshold |
+
+### H2H Results (No Longer Deferred)
+
+The full H2H battery is now complete. See
+[h2h_battery_analysis.md](h2h_battery_analysis.md) for the full report.
+
+**Key H2H findings relevant to this promotion:**
+
+The H2H pairwise matchups produce a **partial dominance order** among the
+competitive bidders:
+
+```
+modeloespecifico  >  hybrid_olsa  >  olsa  ~  olsa_full
+```
+
+- modeloespecifico strictly dominates hybrid_olsa (delta +0.64–0.78, CI
+  excludes zero both directions)
+- hybrid_olsa strictly dominates olsa (+0.21 net_eppd wrapper effect, CI
+  excludes zero)
+- hybrid_olsa vs olsa_full is a draw
+- olsa vs olsa_full is a draw
+
+All four trained/heuristic-expert bidders dominate the three simple heuristics
+(rankthetank, fiveheadfred, stricthellraiser) by large, significant margins.
+
+### Evaluation Methodology Comparison
+
+The comparator battery and H2H battery measure different things:
+
+| | Comparator Battery | H2H Battery |
+|---|---|---|
+| **Design** | Each bidder plays alone vs GluttonStrategy (uncontested auction) | Two bidders compete directly (contested auction) |
+| **Measures** | Absolute performance against a common opponent | Relative performance between two bidders |
+| **Answers** | "Is this model any good?" | "Which model is better?" |
+| **Cost** | O(n) — one run per bidder | O(n²) — one run per pair |
+| **Limitation** | Rankings confounded by Glutton interaction | Cannot assess absolute quality |
+
+**Where the methods disagree:** `modeloespecifico` leads `olsa` by +1.86
+net_eppd in self-play but is a **draw** in H2H (+0.016, CI spans zero). The
+self-play gap reflects how each bidder interacts with GluttonStrategy's passive
+defense, not intrinsic bidding superiority.
+
+**Where they agree:** Both methods confirm modeloespecifico > hybrid_olsa and
+the large gap between trained bidders and simple heuristics. The PROMOTED
+decision is supported by both evaluation methods.
+
+**For promotion gates (R1+),** H2H pairwise comparison is the primary
+evaluation method. The comparator battery provides supplementary absolute
+benchmarking.


### PR DESCRIPTION
## Summary
- Add methodology strengths/limitations sections to comparator_rankings.md and h2h_battery_analysis.md
- Add addendum to r0_promotion_report.md with H2H results, methodology comparison, and bidder naming clarification
- Fix stale "H2H deferred" exclusion in promotion report (H2H data now exists)

## Why
The comparator battery (self-play vs Glutton) and H2H battery (direct pairwise competition) measure fundamentally different things, and their rankings can diverge. For example, `modeloespecifico` leads `olsa` by +1.86 net_eppd in self-play but is a statistical draw in H2H. Without explicit methodology notes, readers may treat self-play rankings as competitive ordering, which they are not.

Additionally, `hybrid_olsa` referred to different configurations across reports (OLSa_Full in the 5-bidder battery vs constrained OLSa in the 7-bidder battery), creating an apples-to-oranges naming issue.

## Repro / Validation
**Command(s) run:**
- `make check` — all checks pass (docs-only change)

**Config (if applicable):**
- N/A

**Seed (if applicable):**
- N/A

## Tests
- [x] `make check` (full validation, docs-only)
- [ ] ~~Integration (if engine/rules changed)~~ — N/A
- [x] Other: `make docs-check` passes (path validation)

## Expected impact
- Metrics impact (if any): None (docs only)
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-eval-methodology-docs
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-eval-methodology-docs
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                        99709fc [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-eval-methodology-docs  f7fd252 [docs/eval-methodology-notes]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)