### PR TITLE
fix: align CVaR continuity correction with EV threshold in hybrid OLSa

### DIFF
--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -962,9 +962,10 @@ class HybridOLSaBidder(BiddingPolicy):
         rng = np.random.RandomState(self._CVAR_SEED)
         draws = rng.normal(mu, sigma, self._CVAR_DRAWS)
 
-        # Compute net differential for each draw
+        # Compute net differential for each draw (continuity-corrected to match EV)
+        threshold = bid_n - 0.5
         nets = np.where(
-            draws >= bid_n,
+            draws >= threshold,
             2.0 * draws - 10.0,
             draws - bid_n - 10.0,
         )

--- a/tests/unit/test_hybrid_bidder.py
+++ b/tests/unit/test_hybrid_bidder.py
@@ -262,6 +262,45 @@ def test_config_registration():
     assert "artifact_path" in BIDDING_REQUIRED_PARAMS["HybridOLSaBidder"]
 
 
+def test_cvar_uses_continuity_corrected_threshold(tmp_path: Path):
+    """CVaR make/set threshold matches EV's continuity correction (bid_n - 0.5).
+
+    We pick mu well above bid_n so the 5th-percentile tail straddles the
+    correction zone [bid_n - 0.5, bid_n). Draws in that region are classified
+    as "make" (net = 2x - 10) with the correction but "set" (net = x - bid_n - 10)
+    without it — a ~11-point swing per draw that materially changes CVaR.
+    """
+    path = _make_artifact(tmp_path, risk_lambda=1.0)
+    bidder = HybridOLSaBidder(path)
+
+    # mu=8, sigma=1.5, bid_n=6 → 5th pctile ≈ 5.53, right in [5.5, 6.0)
+    mu, sigma, bid_n = 8.0, 1.5, 6
+
+    # Compute penalty with the corrected threshold (bid_n - 0.5 = 5.5)
+    penalty_corrected = bidder._compute_risk_penalty(mu, sigma, bid_n)
+
+    # Manually compute what penalty would be WITHOUT the correction
+    # (using bid_n as threshold instead of bid_n - 0.5)
+    rng = np.random.RandomState(bidder._CVAR_SEED)
+    draws = rng.normal(mu, sigma, bidder._CVAR_DRAWS)
+    nets_uncorrected = np.where(
+        draws >= bid_n,  # no continuity correction
+        2.0 * draws - 10.0,
+        draws - bid_n - 10.0,
+    )
+    tail_size = max(1, int(bidder._CVAR_DRAWS * bidder._CVAR_TAIL))
+    sorted_nets = np.sort(nets_uncorrected)
+    cvar_uncorrected = float(sorted_nets[:tail_size].mean())
+    penalty_uncorrected = max(0.0, -cvar_uncorrected) * bidder.risk_lambda
+
+    # Corrected threshold is more lenient (more draws classified as "make"),
+    # so the penalty should be strictly lower than the uncorrected version
+    assert penalty_corrected < penalty_uncorrected, (
+        f"Corrected penalty {penalty_corrected:.4f} should be less than "
+        f"uncorrected {penalty_uncorrected:.4f}"
+    )
+
+
 def test_risk_lambda_override(tmp_path: Path):
     """risk_lambda parameter overrides artifact value."""
     path = _make_artifact(tmp_path, risk_lambda=0.5)


### PR DESCRIPTION
## Summary
- Apply continuity correction (`bid_n - 0.5`) to CVaR threshold in `_compute_risk_penalty`, matching `_compute_ev`
- Add test verifying both components use the same make/set threshold

## Why
The EV and CVaR components of the hybrid OLSa utility function used inconsistent thresholds: EV classified draws ≥ `bid_n - 0.5` as "make" (continuity-corrected), while CVaR classified draws ≥ `bid_n` as "make". Draws in `[bid_n - 0.5, bid_n)` were "make" in EV but "set" in CVaR — a ~11-point net-differential swing per draw — creating an inconsistency in how the two utility components model the same decision.

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/test_hybrid_bidder.py tests/unit/test_olsa_bidder.py -v`
- `make check-quiet`

**Config:** N/A (one-line logic fix)
**Seed:** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_hybrid_bidder.py tests/unit/test_olsa_bidder.py` — 30/30 pass
- [x] `make check-quiet` — all checks pass
- New test: `test_cvar_uses_continuity_corrected_threshold` — verifies corrected threshold produces strictly lower penalty than uncorrected

## Expected impact
- Metrics impact: Slightly lower risk penalty for near-threshold outcomes (penalty decreases because more marginal draws are correctly classified as "make")
- Runtime impact: None (same number of operations)

## Risk level
- [x] Medium (strategy/experiments)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-cvar-threshold
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-cvar-threshold
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                       ea7163c [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-cvar-threshold    2f903bb [fix/cvar-continuity-correction]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)