### PR TITLE
chore: remove dead utils/ module and consolidate utc_now_iso

### DIFF
--- a/scripts/internal/run_arc_d_gate.py
+++ b/scripts/internal/run_arc_d_gate.py
@@ -17,14 +17,10 @@ Exit codes:
 import argparse
 import json
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
 
+from bid_euchre.core.time import utc_now_iso
 from bid_euchre.validation.arc_d_gate import promotion_gate
-
-
-def _utc_now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def main():
@@ -83,7 +79,7 @@ def main():
         "decision": decision,
         "reasons": reasons,
         "bundle_path": bundle_path,
-        "timestamp": _utc_now_iso(),
+        "timestamp": utc_now_iso(),
     }
 
     decision_path = Path(bundle_path).parent / f"promotion_decision_{rung_id}.json"

--- a/src/bid_euchre/core/time.py
+++ b/src/bid_euchre/core/time.py
@@ -1,0 +1,8 @@
+"""Time utilities for the Bid Euchre framework."""
+
+from datetime import datetime, timezone
+
+
+def utc_now_iso() -> str:
+    """UTC time in ISO8601 with Z suffix."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/src/bid_euchre/diagnostics/semantic_gate.py
+++ b/src/bid_euchre/diagnostics/semantic_gate.py
@@ -29,13 +29,14 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
 import numpy as np
 import pandas as pd
 from scipy import stats
+
+from bid_euchre.core.time import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -99,10 +100,6 @@ _SIGN_CHECK_FEATURES = {
     "high": "offsuit_aces",
     "low": "offsuit_tens_count",
 }
-
-
-def _utc_now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def _make_check(
@@ -1216,7 +1213,7 @@ def compute_semantic_gate(
     gate: dict[str, Any] = {
         "schema_version": SEMANTIC_GATE_SCHEMA_VERSION,
         "gate_status": gate_status,
-        "created_at_utc": _utc_now_iso(),
+        "created_at_utc": utc_now_iso(),
         "active_split": active_split,
         "mode": mode,
         "seed": seed,

--- a/src/bid_euchre/models/freeze.py
+++ b/src/bid_euchre/models/freeze.py
@@ -13,15 +13,11 @@ import hashlib
 import json
 import logging
 import warnings
-from datetime import datetime, timezone
 from pathlib import Path
 
+from bid_euchre.core.time import utc_now_iso
+
 logger = logging.getLogger(__name__)
-
-
-def _utc_now_iso() -> str:
-    """UTC time in ISO8601 with Z suffix."""
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def _sha256_file(path: str | Path) -> str:
@@ -81,7 +77,7 @@ def freeze_artifact(artifact_path: str | Path) -> dict:
 
     content_hash = _content_hash(metadata)
 
-    metadata["frozen_at"] = _utc_now_iso()
+    metadata["frozen_at"] = utc_now_iso()
     metadata["artifact_sha256"] = content_hash
 
     with open(path, "w") as f:

--- a/src/bid_euchre/models/splits.py
+++ b/src/bid_euchre/models/splits.py
@@ -14,16 +14,12 @@ from __future__ import annotations
 import dataclasses
 import hashlib
 import json
-from datetime import datetime, timezone
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 
-
-def _utc_now_iso() -> str:
-    """UTC time in ISO8601 with Z suffix."""
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+from bid_euchre.core.time import utc_now_iso
 
 
 def _sha256_file(path: str) -> str:
@@ -76,7 +72,13 @@ class SplitManifest:
 
     @classmethod
     def from_dict(cls, d: dict) -> SplitManifest:
-        return cls(**{k: v for k, v in d.items() if k in {f.name for f in dataclasses.fields(cls)}})
+        return cls(
+            **{
+                k: v
+                for k, v in d.items()
+                if k in {f.name for f in dataclasses.fields(cls)}
+            }
+        )
 
     def save(self, path: str | Path) -> None:
         """Write manifest to JSON file."""
@@ -126,7 +128,9 @@ def create_grouped_split(
         (train_df, val_df_or_None, test_df, manifest)
     """
     if split_type not in ("two_way", "three_way"):
-        raise ValueError(f"split_type must be 'two_way' or 'three_way', got {split_type!r}")
+        raise ValueError(
+            f"split_type must be 'two_way' or 'three_way', got {split_type!r}"
+        )
 
     unique_ids = df["hand_id"].unique()
     rng = np.random.RandomState(seed)
@@ -162,7 +166,7 @@ def create_grouped_split(
             source_run_id=source_run_id,
             source_parquet_sha256=_sha256_file(source_parquet_path),
             partition_hashes=partition_hashes,
-            created_at_utc=_utc_now_iso(),
+            created_at_utc=utc_now_iso(),
         )
 
     else:  # three_way
@@ -203,7 +207,7 @@ def create_grouped_split(
             source_run_id=source_run_id,
             source_parquet_sha256=_sha256_file(source_parquet_path),
             partition_hashes=partition_hashes,
-            created_at_utc=_utc_now_iso(),
+            created_at_utc=utc_now_iso(),
         )
 
     return train_df, val_df, test_df, manifest
@@ -228,10 +232,9 @@ def verify_split_manifest(manifest: SplitManifest, df: pd.DataFrame, seed: int) 
         train_ids = unique_ids[:split_idx]
         test_ids = unique_ids[split_idx:]
 
-        return (
-            _hash_hand_ids(train_ids) == manifest.partition_hashes.get("train")
-            and _hash_hand_ids(test_ids) == manifest.partition_hashes.get("test")
-        )
+        return _hash_hand_ids(train_ids) == manifest.partition_hashes.get(
+            "train"
+        ) and _hash_hand_ids(test_ids) == manifest.partition_hashes.get("test")
     else:
         train_end = int(n_total * manifest.train_fraction)
         val_end = train_end + int(n_total * (manifest.val_fraction or 0))

--- a/src/bid_euchre/reporting/eligibility.py
+++ b/src/bid_euchre/reporting/eligibility.py
@@ -12,7 +12,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Optional
 
-from bid_euchre.experiments.meta import utc_now_iso
+from bid_euchre.core.time import utc_now_iso
 from bid_euchre.models.freeze import verify_frozen
 
 logger = logging.getLogger(__name__)

--- a/src/bid_euchre/utils/__init__.py
+++ b/src/bid_euchre/utils/__init__.py
@@ -1,9 +1,0 @@
-"""Utility modules for Bid Euchre project.
-
-This package contains shared utility functions used across the codebase:
-- validation: Configuration and data validation helpers
-
-REMOVED: model_io (was for legacy pickle model I/O)
-"""
-
-__all__ = []


### PR DESCRIPTION
## Summary
- Delete dead `src/bid_euchre/utils/` module (`__all__ = []`, 0 exports, 0 consumers)
- Create `src/bid_euchre/core/time.py` as canonical location for `utc_now_iso()`
- Replace 4 local `_utc_now_iso()` copies with import from `core.time`
- Fix import boundary violation in `eligibility.py` (was importing from `bid_euchre.experiments.meta`)

## Why
- `utils/` was dead code: empty `__all__`, no functions, no consumers
- `eligibility.py` violated the `src/` must-not-import-from-`experiments/` boundary by importing `utc_now_iso` from `bid_euchre.experiments.meta`
- 4 identical `_utc_now_iso()` copies existed across the codebase (DRY violation)
- New canonical location `core/time.py` is within the library boundary and accessible to all modules

## Repro / Validation
**Command(s) run:**
```bash
uv run python -c "from bid_euchre.core.time import utc_now_iso; print(utc_now_iso())"
uv run python -m pytest tests/unit/ -k "freeze or split or semantic_gate or eligib" -x -q
make check-quiet
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/ -k "freeze or split or semantic_gate or eligib"` (189 passed)
- [x] `make check-quiet` (all checks passed)

## Expected impact
- Metrics impact (if any): None (pure refactor)
- Runtime impact (if any): None

## Risk level
- [x] Low (dead code removal + import consolidation)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-cleanup-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-cleanup-b
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre           ea7163c [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-cleanup-b 32510ab [cleanup/dead-code-boundary-fix]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)