### PR TITLE
chore: final cross-reference sweep after cleanup PRs

### DIFF
--- a/.claude/skills/reviewing-repo/SKILL.md
+++ b/.claude/skills/reviewing-repo/SKILL.md
@@ -125,7 +125,7 @@ Show the user a concise table of what's stale:
 | Category | Count | Example |
 |----------|-------|---------|
 | Stale imports | <N> | `from bid_euchre.X import Y` → module moved |
-| Missing module coverage | <N> | `utils/` has no import check in §1.3 |
+| Missing module coverage | <N> | `analysis/` has no import check in §1.3 |
 | Dead commands | <N> | `make <target>` no longer exists |
 | Structure drift | <N> | prompt tree missing `analysis/` directory |
 | Stale file references | <N> | `scripts/foo.py` referenced but deleted |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,6 @@ uv run python -m pytest tests/unit/core/test_rules.py::test_specific  # Single t
 | `reporting/` | Report generation utilities |
 | `logging/` | JSONL game logging |
 | `analysis/` | Statistical analysis (stats, paired comparisons, models) |
-| `utils/` | Shared utility functions |
 | `validation/` | Promotion validation and schemas |
 | `scoring.py` | Top-level scoring module |
 

--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -19,7 +19,7 @@ Submodules:
 - `models/` — Model training/inference
 - `diagnostics/` — Visualization and analysis tools
 - `validation/` — Schema validation
-- `reporting/`, `logging/`, `analysis/`, `utils/` — Supporting utilities
+- `reporting/`, `logging/`, `analysis/` — Supporting utilities
 
 ### `experiments/`
 **Experiment configurations and canonical runner.**

--- a/docs/02_agent/AGENTS.md
+++ b/docs/02_agent/AGENTS.md
@@ -304,8 +304,6 @@ Primary locations under `src/bid_euchre/`:
 - `reporting/` — report building helpers, styles, standardized paths
 - `logging/` — JSONL game logging and event schemas
 - `experiments/` — config parsing/structures used by `experiments/run_experiment.py`
-- `utils/` — generic helpers
-
 Top-level:
 
 - `experiments/` — scripts, configs, dashboards (runner lives here)

--- a/docs/02_agent/REPO_REVIEW_PROMPT.md
+++ b/docs/02_agent/REPO_REVIEW_PROMPT.md
@@ -161,7 +161,7 @@ uv run python -c "from bid_euchre.reporting.charts import generate_contract_face
 
 # Verify logging and utils
 uv run python -c "from bid_euchre.logging.game_logger import GameLogger; print('logging OK')"
-uv run python -c "import bid_euchre.utils; print('utils OK')"
+uv run python -c "from bid_euchre.core.time import format_elapsed; print('time OK')"
 
 # Verify scoring (top-level module)
 uv run python -c "from bid_euchre.scoring import compute_points; print('scoring OK')"
@@ -922,7 +922,7 @@ bid-euchre/
 │   ├── validation/              # Schema validation, promotion gates
 │   ├── analysis/                # Statistical analysis, paired comparisons
 │   ├── experiments/             # Config system, batch metadata
-│   └── utils/                   # Generic helpers
+│   └── scoring.py               # Top-level scoring module
 │   # (verify via: ls -d src/bid_euchre/*/ | grep -v __pycache__)
 ├── experiments/                 # Experiment configs + runner
 │   ├── run_experiment.py        # THE canonical runner


### PR DESCRIPTION
## Summary
- Removed stale `utils/` references from ARCHITECTURE.md, CLAUDE.md, REPO_REVIEW_PROMPT.md, AGENTS.md, and reviewing-repo SKILL.md
- Replaced `import bid_euchre.utils` verification in REPO_REVIEW_PROMPT.md with `core.time` import check (the module that replaced utils)
- Verified no remaining stale references to SCORING.md, QUALITY_BAR.md, 03_experiments, BIDLESS_FEATURES.md, or utils/

## Why
Final sweep after merging cleanup PRs #454-#457 which removed the `utils/` module (PR #454), archived plans (PR #455), merged docs (PR #456), and consolidated archives (PR #457). These PRs left behind cross-references to `utils/` in documentation that agents and developers rely on for navigation.

## Repro / Validation
**Command(s) run:**
```bash
# Verify no stale doc refs (excluding archive/)
grep -r "SCORING\.md\|QUALITY_BAR\.md\|03_experiments" \
  docs/ .claude/ CLAUDE.md src/ experiments/ \
  --include="*.md" --include="*.py" --exclude-dir=archive
# Result: CLEAN

# Verify no dead utils imports
grep -r "bid_euchre\.utils" src/ tests/ scripts/ experiments/ --include="*.py"
# Result: CLEAN

# Verify no remaining utils/ refs in non-archive docs
grep -rn "utils/" docs/ .claude/ CLAUDE.md src/ --include="*.md" --exclude-dir=archive
# Result: CLEAN

make check  # All 1773 tests pass, all gates pass
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `make check` — all 1773 passed, 6 skipped

## Expected impact
- Metrics impact: None (docs-only change)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-cleanup-e
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-cleanup-e
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                       772a41d [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-cleanup-e             c526ac9 [cleanup/cross-reference-sweep]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)