### PR TITLE
fix: raise ModeloEspecifico bid ceiling to 10 and lower OLSa bid floor to 1

### DIFF
--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -449,21 +449,23 @@ class ModeloEspecifico(BiddingPolicy):
                 + 0.5 * features["offsuit_aces"]
             )
             bid_n = int(score)  # floor
-            if 3 <= bid_n <= 6 and bid_n > obs.current_high_bid:
+            # Floor of 3 is intentional: the heuristic formula (bowers + 0.5*trump
+            # + 0.5*offsuit_aces) cannot produce meaningful bids below 3.
+            if 3 <= bid_n <= 10 and bid_n > obs.current_high_bid:
                 candidates.append((score, bid_n, suit))
 
         # Evaluate HIGH contract: score = 1.0 * offsuit_aces
         features_high = get_hand_features(obs.hand, "high", None)
         score_high = 1.0 * features_high["offsuit_aces"]
         bid_n_high = int(score_high)
-        if 3 <= bid_n_high <= 6 and bid_n_high > obs.current_high_bid:
+        if 3 <= bid_n_high <= 10 and bid_n_high > obs.current_high_bid:
             candidates.append((score_high, bid_n_high, "HIGH"))
 
         # Evaluate LOW contract: score = 1.0 * offsuit_tens_count
         features_low = get_hand_features(obs.hand, "low", None)
         score_low = 1.0 * features_low["offsuit_tens_count"]
         bid_n_low = int(score_low)
-        if 3 <= bid_n_low <= 6 and bid_n_low > obs.current_high_bid:
+        if 3 <= bid_n_low <= 10 and bid_n_low > obs.current_high_bid:
             candidates.append((score_low, bid_n_low, "LOW"))
 
         if not candidates:
@@ -745,7 +747,7 @@ class OLSaBidder(BiddingPolicy):
                 features = get_hand_features(obs.hand, "suit", suit)
                 predicted_tricks = self._predict("suit", features)
                 bid_n = math.floor(predicted_tricks)
-                if 3 <= bid_n <= 10 and bid_n > obs.current_high_bid:
+                if 1 <= bid_n <= 10 and bid_n > obs.current_high_bid:
                     candidates.append((predicted_tricks, bid_n, suit))
 
         # Evaluate HIGH
@@ -753,7 +755,7 @@ class OLSaBidder(BiddingPolicy):
             features = get_hand_features(obs.hand, "high", None)
             predicted_tricks = self._predict("high", features)
             bid_n = math.floor(predicted_tricks)
-            if 3 <= bid_n <= 10 and bid_n > obs.current_high_bid:
+            if 1 <= bid_n <= 10 and bid_n > obs.current_high_bid:
                 candidates.append((predicted_tricks, bid_n, "HIGH"))
 
         # Evaluate LOW
@@ -761,7 +763,7 @@ class OLSaBidder(BiddingPolicy):
             features = get_hand_features(obs.hand, "low", None)
             predicted_tricks = self._predict("low", features)
             bid_n = math.floor(predicted_tricks)
-            if 3 <= bid_n <= 10 and bid_n > obs.current_high_bid:
+            if 1 <= bid_n <= 10 and bid_n > obs.current_high_bid:
                 candidates.append((predicted_tricks, bid_n, "LOW"))
 
         if not candidates:
@@ -1014,7 +1016,7 @@ class HybridOLSaBidder(BiddingPolicy):
                 bid_n = math.floor(mu)
 
                 # Clamp bid to valid range
-                if bid_n < 3 or bid_n > 10:
+                if bid_n < 1 or bid_n > 10:
                     continue
 
                 # Must exceed current high bid

--- a/tests/unit/test_bidding.py
+++ b/tests/unit/test_bidding.py
@@ -11,7 +11,9 @@ from bid_euchre.strategy.bidding import (
     ArtifactBidder,
     BidAction,
     BiddingObservation,
+    HybridOLSaBidder,
     ModeloEspecifico,
+    OLSaBidder,
     RanktheTank,
     StrictHellRaiser,
     StrictRaiserBidder,
@@ -954,3 +956,238 @@ class TestRanktheTankThresholds:
         mid_score = score_hand_scalar(hand_mid_high, "high", None)
         assert mid_score == 350
         # 350 <= 350 < 400 → bid 5 (was always 5 before fix due to broken thresholds)
+
+
+class TestModeloEspecificoBidCeiling:
+    """Test ModeloEspecifico correctly bids above 6 (ceiling fix)."""
+
+    def test_very_strong_hand_bids_above_6(self):
+        """Hand with score >6 should bid 7+ (not pass due to ceiling bug)."""
+        bidder = ModeloEspecifico()
+
+        # In Hearts trump: RB(HJ)=bower, LB(DJ)=bower
+        # Trump: HJ, DJ, HA, HK, HQ, HT, HA(dup), HK(dup) = 8 trump, 2 bowers
+        # Offsuit aces: SA, CA = 2
+        # Score = 1.0*2 + 0.5*8 + 0.5*2 = 2+4+1 = 7.0 → bid 7
+        hand = [
+            Card("H", "J"),
+            Card("D", "J"),
+            Card("H", "A"),
+            Card("H", "K"),
+            Card("H", "Q"),
+            Card("H", "T"),
+            Card("H", "A"),
+            Card("H", "K"),
+            Card("S", "A"),
+            Card("C", "A"),
+        ]
+
+        obs = BiddingObservation(hand=hand, seat=0, dealer_seat=3, current_high_bid=0)
+        action = bidder.choose_bid(obs)
+        assert not action.is_pass(), "Strong hand (score=7) should bid, not pass"
+        assert action.n == 7
+        assert action.contract == "H"
+
+    def test_score_exactly_6_still_bids(self):
+        """Hand with score exactly 6 should still bid 6 (regression)."""
+        bidder = ModeloEspecifico()
+
+        # 2 bowers + 6 trump total + 2 offsuit aces
+        # Score = 1.0*2 + 0.5*6 + 0.5*2 = 2+3+1 = 6.0 → bid 6
+        hand = [
+            Card("H", "J"),
+            Card("D", "J"),
+            Card("H", "A"),
+            Card("H", "K"),
+            Card("H", "Q"),
+            Card("H", "T"),
+            Card("S", "A"),
+            Card("C", "A"),
+            Card("S", "K"),
+            Card("C", "K"),
+        ]
+
+        obs = BiddingObservation(hand=hand, seat=0, dealer_seat=3, current_high_bid=0)
+        action = bidder.choose_bid(obs)
+        assert not action.is_pass()
+        assert action.n == 6
+
+    def test_existing_3_to_5_range_unchanged(self):
+        """Regression: bids in 3-5 range still work correctly."""
+        bidder = ModeloEspecifico()
+
+        # Score = 1.0*2 + 0.5*4 + 0.5*1 = 2+2+0.5 = 4.5 → bid 4
+        hand = [
+            Card("H", "J"),
+            Card("D", "J"),
+            Card("H", "A"),
+            Card("H", "K"),
+            Card("S", "A"),
+        ]
+
+        obs = BiddingObservation(hand=hand, seat=0, dealer_seat=3, current_high_bid=0)
+        action = bidder.choose_bid(obs)
+        assert action.n == 4
+
+
+class TestOLSaBidFloor:
+    """Test OLSa bidders accept bids below 3."""
+
+    def test_olsa_bids_below_3(self, tmp_path):
+        """OLSa predicting mu=1.5 should bid 1 (not pass due to floor)."""
+        import json
+
+        # Create minimal olsa_v1 artifact with bias=1.5 and zero weights
+        artifact = {
+            "artifact_type": "olsa_v1",
+            "models": {
+                "suit": {
+                    "weights": [0.0],
+                    "bias": 1.5,
+                    "feature_names": ["trump_count"],
+                }
+            },
+        }
+        artifact_path = tmp_path / "test_olsa.json"
+        artifact_path.write_text(json.dumps(artifact))
+
+        bidder = OLSaBidder(str(artifact_path), name="test_olsa")
+
+        hand = [
+            Card("H", "A"),
+            Card("H", "K"),
+            Card("S", "Q"),
+            Card("D", "T"),
+            Card("C", "K"),
+            Card("H", "Q"),
+            Card("S", "A"),
+            Card("D", "K"),
+            Card("C", "Q"),
+            Card("S", "T"),
+        ]
+        obs = BiddingObservation(hand=hand, seat=0, dealer_seat=3, current_high_bid=0)
+        action = bidder.choose_bid(obs)
+        assert not action.is_pass(), "OLSa predicting 1.5 should bid 1, not pass"
+        assert action.n == 1
+
+    def test_olsa_bids_2(self, tmp_path):
+        """OLSa predicting mu=2.5 should bid 2."""
+        import json
+
+        artifact = {
+            "artifact_type": "olsa_v1",
+            "models": {
+                "suit": {
+                    "weights": [0.0],
+                    "bias": 2.5,
+                    "feature_names": ["trump_count"],
+                }
+            },
+        }
+        artifact_path = tmp_path / "test_olsa_2.json"
+        artifact_path.write_text(json.dumps(artifact))
+
+        bidder = OLSaBidder(str(artifact_path), name="test_olsa_2")
+
+        hand = [
+            Card("H", "A"),
+            Card("H", "K"),
+            Card("S", "Q"),
+            Card("D", "T"),
+            Card("C", "K"),
+            Card("H", "Q"),
+            Card("S", "A"),
+            Card("D", "K"),
+            Card("C", "Q"),
+            Card("S", "T"),
+        ]
+        obs = BiddingObservation(hand=hand, seat=0, dealer_seat=3, current_high_bid=0)
+        action = bidder.choose_bid(obs)
+        assert not action.is_pass(), "OLSa predicting 2.5 should bid 2, not pass"
+        assert action.n == 2
+
+
+class TestHybridOLSaBidFloor:
+    """Test HybridOLSaBidder floor changed from 3 to 1."""
+
+    def test_hybrid_olsa_floor_does_not_skip_low_bids(self, tmp_path):
+        """HybridOLSa with mu=2.5 evaluates bid_n=2 (not skipped by range check).
+
+        Note: the net-differential payoff (2*tricks-10) means bids below ~5 always
+        have negative EV, so the bidder still passes. The fix ensures this is due to
+        EV, not due to the range filter rejecting bid_n < 3.
+        """
+        import json
+
+        artifact = {
+            "artifact_type": "hybrid_olsa_v1",
+            "payoff_model": {
+                "suit": {
+                    "weights": [0.0],
+                    "bias": 2.5,
+                    "feature_names": ["trump_count"],
+                }
+            },
+            "residual_variance": {"suit": 0.01},
+            "risk_lambda": 0.0,
+        }
+        artifact_path = tmp_path / "test_hybrid.json"
+        artifact_path.write_text(json.dumps(artifact))
+
+        bidder = HybridOLSaBidder(str(artifact_path), name="test_hybrid")
+
+        hand = [
+            Card("H", "A"),
+            Card("H", "K"),
+            Card("S", "Q"),
+            Card("D", "T"),
+            Card("C", "K"),
+            Card("H", "Q"),
+            Card("S", "A"),
+            Card("D", "K"),
+            Card("C", "Q"),
+            Card("S", "T"),
+        ]
+        obs = BiddingObservation(hand=hand, seat=0, dealer_seat=3, current_high_bid=0)
+        # Should not raise — bid_n=2 is evaluated, passes due to negative EV
+        action = bidder.choose_bid(obs)
+        assert action.is_pass(), "mu=2.5 should pass (negative EV), not error"
+
+    def test_hybrid_olsa_positive_ev_bid(self, tmp_path):
+        """HybridOLSa with mu=7.0, sigma=0 (deterministic) bids 7."""
+        import json
+
+        artifact = {
+            "artifact_type": "hybrid_olsa_v1",
+            "payoff_model": {
+                "suit": {
+                    "weights": [0.0],
+                    "bias": 7.0,
+                    "feature_names": ["trump_count"],
+                }
+            },
+            "residual_variance": {"suit": 0.0},
+            "risk_lambda": 0.0,
+        }
+        artifact_path = tmp_path / "test_hybrid_pos.json"
+        artifact_path.write_text(json.dumps(artifact))
+
+        bidder = HybridOLSaBidder(str(artifact_path), name="test_hybrid_pos")
+
+        hand = [
+            Card("H", "A"),
+            Card("H", "K"),
+            Card("S", "Q"),
+            Card("D", "T"),
+            Card("C", "K"),
+            Card("H", "Q"),
+            Card("S", "A"),
+            Card("D", "K"),
+            Card("C", "Q"),
+            Card("S", "T"),
+        ]
+        obs = BiddingObservation(hand=hand, seat=0, dealer_seat=3, current_high_bid=0)
+        action = bidder.choose_bid(obs)
+        # sigma=0 deterministic: mu=7 >= bid_n=7, EV = 2*7-10 = 4.0 > 0
+        assert not action.is_pass(), "mu=7.0, sigma=0 should bid (EV=4.0)"
+        assert action.n == 7

--- a/tests/unit/test_olsa_bidder.py
+++ b/tests/unit/test_olsa_bidder.py
@@ -178,13 +178,13 @@ class TestOLSaBidder:
         assert action.n == 4
         assert action.contract == "H"
 
-    def test_weak_hand_passes(self, tmp_path):
-        """Test a weak hand passes."""
+    def test_weak_hand_bids_low(self, tmp_path):
+        """Test a weak hand bids its predicted value (floor lowered to 1)."""
         path = _make_artifact(tmp_path)
         bidder = OLSaBidder(path)
 
         # No bowers, 2 trump, no offsuit aces
-        # predicted = 0 + 0.5*2 + 0 = 1.0 → bid 1 < 3, pass
+        # predicted = 0 + 0.5*2 + 0 = 1.0 → bid 1 (floor lowered from 3 to 1)
         hand = [
             Card("S", "K"),
             Card("S", "Q"),
@@ -195,7 +195,8 @@ class TestOLSaBidder:
 
         obs = BiddingObservation(hand=hand, seat=0, dealer_seat=3, current_high_bid=0)
         action = bidder.choose_bid(obs)
-        assert action.is_pass()
+        assert not action.is_pass()
+        assert action.n == 1
 
     def test_high_contract_with_aces(self, tmp_path):
         """Test HIGH contract with enough aces."""


### PR DESCRIPTION
## Summary
- Fix ModeloEspecifico bid ceiling: `3 <= bid_n <= 6` → `3 <= bid_n <= 10` (3 lines)
- Fix OLSaBidder bid floor: `3 <= bid_n` → `1 <= bid_n` (3 lines)
- Fix HybridOLSaBidder bid floor: `bid_n < 3` → `bid_n < 1` (1 line)
- Add unit tests for ceiling and floor fixes; update existing test

## Why
ModeloEspecifico silently capped bids at 6. Hands scoring >6 (e.g. 2 bowers + 8 trump + 2 offsuit aces = score 7.0) had `int(7.0)=7`, and `7 <= 6` is false, so the hand got **no bid at all**. This was the #1 ranked bidder in comparator experiments — all rankings were based on a bugged implementation.

OLSa-family bidders enforced an undocumented `>=3` floor, preventing model predictions of 1-2 tricks from generating valid bids. The floor of 3 was inherited from heuristic bidders where the formula can't produce meaningful bids below 3, but OLS models can legitimately predict any value.

Note: ModeloEspecifico retains a floor of 3 (intentional — its heuristic formula `1.0*bowers + 0.5*trump + 0.5*aces` can't produce meaningful bids below 3). A docstring comment explains this.

Part of the comparator overhaul series (PR-B1).

## Repro / Validation
**Command(s) run:**
```bash
cd /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr-b1
uv run python -m pytest tests/unit/test_bidding.py tests/unit/test_olsa_bidder.py -v
make check-quiet
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_bidding.py -v` (46 passed)
- [x] `uv run python -m pytest tests/unit/test_olsa_bidder.py -v` (16 passed)
- [x] `make check-quiet` (all checks passed)

## Expected impact
- Metrics impact: ModeloEspecifico will now bid on strong hands (score >6) that previously passed. OLSa bidders will bid on weak predictions (1-2 tricks) that previously passed. **All prior comparator rankings involving these bidders are invalidated.**
- Runtime impact: None

## Risk level
- [x] Medium (strategy/experiments)

## Worktree proof (required)
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr-b1
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr-b1
```

`git worktree list` (filtered):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre       06c72bb [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr-b1 18c79ea [pr-b1/modelo-olsa-floor-ceiling]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)