### PR TITLE
feat: add /reviewing-changes skill and PostToolUse hook

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -13,3 +13,9 @@ When compacting conversation context, preserve:
 4. **Blocking issues** — any unresolved errors or decisions needed
 
 Discard: exploration tangents, superseded plans, verbose file contents already summarized.
+
+## Post-PR Review
+- `/reviewing-changes` auto-triggers after `gh pr create` via PostToolUse hook
+- Reviews code quality, conventions, generates handoff summary
+- Auto-fixes are pushed as follow-up commits to the PR branch
+- Handoff summary is designed for `/copy` into a new session

--- a/.claude/hooks/post-pr-review.sh
+++ b/.claude/hooks/post-pr-review.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# PostToolUse hook — triggers /reviewing-changes after gh pr create
+set -euo pipefail
+
+# Read JSON input from stdin
+INPUT=$(cat)
+
+# Extract the bash command (if this was a Bash tool call)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+
+# Only trigger for gh pr create commands that succeeded
+EXIT_CODE=$(echo "$INPUT" | jq -r '.tool_response.exit_code // 0')
+
+if [[ "$COMMAND" == *"gh pr create"* ]] && [[ "$EXIT_CODE" == "0" ]]; then
+  echo ""
+  echo "PR created successfully."
+  echo "Now run /reviewing-changes to review the code and generate a handoff summary."
+  echo "This will check for quality issues, convention compliance, and produce a copyable context block."
+fi
+
+exit 0

--- a/.claude/skills/reviewing-changes/CHECKLIST.md
+++ b/.claude/skills/reviewing-changes/CHECKLIST.md
@@ -1,0 +1,222 @@
+# Review Checklist — Rule Reference
+
+Each check ID used in the `/reviewing-changes` skill is defined here with anti-patterns, correct patterns, and source rules.
+
+---
+
+## BLOCK Rules (must fix)
+
+### C1 — Unseeded Randomness
+
+**Source:** `.claude/rules/20_determinism.md`, `docs/01_core/REPRODUCIBILITY.md`
+
+**Anti-pattern:**
+```python
+# Global RNG — breaks determinism
+import random
+random.shuffle(cards)
+
+# Unseeded local RNG — non-reproducible
+rng = random.Random()
+```
+
+**Correct:**
+```python
+# Seeded local RNG — deterministic
+rng = random.Random(seed)
+rng.shuffle(cards)
+```
+
+**Why it blocks:** Same seed + same config must produce identical results. Global or unseeded RNG breaks this invariant.
+
+---
+
+### C2 — Falsy Numeric Guard
+
+**Source:** MEMORY.md "Key Patterns → Code"
+
+**Anti-pattern:**
+```python
+# 0.0 is falsy — this silently replaces valid zeros with the fallback
+x = x or 0.0
+score = score or default_score
+```
+
+**Correct:**
+```python
+# Explicit None check preserves valid zero values
+x = x if x is not None else 0.0
+score = score if score is not None else default_score
+```
+
+**Why it blocks:** Metrics like `net_eppd` can legitimately be `0.0`. The `or` pattern silently replaces them, producing incorrect results.
+
+---
+
+### N1 — Missing Contract-Type Facet
+
+**Source:** MEMORY.md "Key Rules → Contract-Type Faceting"
+
+**Anti-pattern:**
+```python
+# Pooling all contract types into one chart
+df.groupby('strategy')['tricks_won'].mean().plot(kind='bar')
+```
+
+**Correct:**
+```python
+# Faceted by contract_type
+fig, axes = plt.subplots(1, 3, figsize=(15, 5))
+for ax, ct in zip(axes, ['suit', 'high', 'low']):
+    subset = df[df['contract_type'] == ct]
+    subset.groupby('strategy')['tricks_won'].mean().plot(kind='bar', ax=ax)
+    ax.set_title(ct)
+```
+
+**Why it blocks:** Suit, high, and low contracts have fundamentally different dynamics. Pooling hides confounders.
+
+---
+
+### N2 — Collapsed Matchup Table
+
+**Source:** MEMORY.md "Key Rules → Matchup Team Breakout"
+
+**Anti-pattern:**
+```python
+# Single row per matchup — hides team asymmetry
+matchup_summary = df.groupby('matchup')['tricks_won'].mean()
+```
+
+**Correct:**
+```python
+# Separate rows for team0 and team1
+matchup_summary = df.groupby(['matchup', 'team'])['tricks_won'].mean()
+```
+
+**Why it blocks:** In comparator (self-play) runs, only one team bids. Collapsing teams hides this asymmetry.
+
+---
+
+### X3 — Merge Artifacts
+
+**Source:** General quality
+
+**Anti-pattern:**
+```python
+<<<<<<< HEAD
+old_code()
+=======
+new_code()
+>>>>>>> feature-branch
+
+# TODO: remove before merge
+debug_dump(state)
+
+# Old approach (keeping for reference)
+# def old_function():
+#     ... 15 lines of commented-out code ...
+```
+
+**Correct:** Remove all merge markers, TODO-remove comments, and large commented-out blocks before merging.
+
+**Why it blocks:** These are accidental artifacts that should never reach main.
+
+---
+
+## WARN Rules (recommend fixing)
+
+### C3 — Gate Check Ordering
+
+**Source:** MEMORY.md "Key Patterns → Gate Design"
+
+**Anti-pattern:**
+```python
+# PASS before checking failure conditions — wrong order
+def check(data):
+    if data.is_valid:
+        return GateResult.PASS
+    if data.is_missing:
+        return GateResult.SKIP  # Should have been checked first
+    return GateResult.FAIL
+```
+
+**Correct:**
+```python
+# Most-restrictive first: SKIP (can't evaluate) → FAIL (violation) → PASS
+def check(data):
+    if data.is_missing:
+        return GateResult.SKIP
+    if not data.is_valid:
+        return GateResult.FAIL
+    return GateResult.PASS
+```
+
+**Why it warns:** SKIP means "can't evaluate" (non-blocking). FAIL means "found violation" (blocks). Returning PASS before checking for SKIP/FAIL can miss violations.
+
+---
+
+### C4 — Function Complexity
+
+**Source:** General code quality
+
+**Threshold:** Functions >50 lines or nesting depth >4 levels.
+
+**Why it warns:** Long or deeply nested functions are harder to test, review, and maintain. Consider extracting helper functions.
+
+---
+
+### N3 — Claim Without Statistical Test
+
+**Source:** `.claude/rules/05_rigor.md`
+
+**Anti-pattern:**
+```python
+# "Strategy A is better" based on visual inspection only
+plt.boxplot([strategy_a_data, strategy_b_data])
+plt.title("Strategy A outperforms B")
+```
+
+**Correct:**
+```python
+# Statistical test accompanies the visual
+t_stat, p_value = ttest_ind(strategy_a_data, strategy_b_data)
+plt.boxplot([strategy_a_data, strategy_b_data])
+plt.title(f"A vs B (t={t_stat:.2f}, p={p_value:.3f})")
+```
+
+**Why it warns:** Rigor policy requires hypothesis tests with p-values, not just visual inspection.
+
+---
+
+### T1 — Untested Behavior Change
+
+**Source:** `.claude/rules/40_prs.md`
+
+**Check:** If files in `src/bid_euchre/` have behavior changes (not just refactoring), there should be corresponding changes in `tests/`.
+
+**Why it warns:** Behavior changes without tests can silently regress.
+
+---
+
+### X1 — Scope Drift
+
+**Source:** `.claude/rules/40_prs.md` ("one concept per PR")
+
+**Check:** Changes span 3+ unrelated modules (e.g., `core/` + `reporting/` + `notebooks/` with no clear connection).
+
+**Why it warns:** May indicate scope drift — the PR might be doing too many things.
+
+---
+
+### X2 — Undocumented Contract Change
+
+**Source:** `.claude/rules/30_data_contract.md`
+
+**Check:** Changes to core rules, scoring, logging schema, or metrics without corresponding doc updates.
+
+**Affected docs:**
+- `docs/01_core/RULES.md` — game rules, trick resolution
+- `docs/01_core/DATA_CONTRACT.md` — logging fields, schemas
+- `docs/01_core/METRICS.md` — metrics, aggregation
+
+**Why it warns:** Contract changes without doc updates cause drift between code and documentation.

--- a/.claude/skills/reviewing-changes/HANDOFF_TEMPLATE.md
+++ b/.claude/skills/reviewing-changes/HANDOFF_TEMPLATE.md
@@ -1,0 +1,46 @@
+# Handoff Template
+
+Generate this block at the end of every `/reviewing-changes` run. Replace all `[bracketed]` placeholders with actual values from the review.
+
+The user can `/copy` this into a new Claude Code session to resume work.
+
+---
+
+```markdown
+---
+## Session Handoff — [branch-name]
+
+**PR:** #[number] — [title] — [url]
+
+### What Was Done
+- [1-3 bullet summary derived from diff and commit messages]
+
+### Files Changed
+- `[path/to/file.py]` — [one-line description]
+- ...
+
+### Issues Encountered
+- [Any test failures, lint issues, or complications during implementation]
+(or "None.")
+
+### Review Findings
+- Auto-fixes: [N applied / pushed as commit `<sha>`] (or "none needed")
+- Blockers: [N] ([list each with file:line and rule ID])
+- Warnings: [N] ([list each briefly])
+
+### Needs Human Decision
+- [Each BLOCK item with context on why it needs judgment]
+- [Each WARN item the agent couldn't resolve]
+(or "None — ready to merge.")
+
+### Current State
+- Worktree: `[worktree-path]`
+- Branch: `[branch]` → PR #[number]
+- make check: [PASSED / FAILED]
+- Verdict: [READY TO MERGE / NEEDS ATTENTION]
+
+### Context for Next Agent
+[2-3 sentences: What this PR does, any gotchas from the review,
+what the next agent needs to know.]
+---
+```

--- a/.claude/skills/reviewing-changes/SKILL.md
+++ b/.claude/skills/reviewing-changes/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: reviewing-changes
+description: Reviews changed code for quality, repo conventions, and correctness after PR creation. Auto-fixes simple issues (pushed as follow-up commit), flags convention violations, and generates an agent-ready handoff summary for /copy. Triggered automatically by PostToolUse hook after gh pr create.
+disable-model-invocation: true
+---
+
+# /reviewing-changes — Post-PR Code Review & Handoff
+
+You are reviewing code changes on the current branch before merge. Follow each phase in order. Be thorough but conservative — only auto-fix patterns you are certain about.
+
+## Phase 0 — Pre-flight
+
+1. Verify you are in a worktree (not main checkout):
+   ```bash
+   git rev-parse --show-toplevel
+   git branch --show-current
+   ```
+   If on `main`, stop and warn: "Cannot review from main checkout. Switch to a worktree."
+
+2. Get the diff scope:
+   ```bash
+   git diff --name-only origin/main...HEAD
+   git diff --stat origin/main...HEAD
+   ```
+
+3. Classify each changed file into categories:
+   - **library**: `src/bid_euchre/**/*.py`
+   - **test**: `tests/**/*.py`
+   - **notebook**: `notebooks/**/*.py` or `*.ipynb`
+   - **config**: `experiments/configs/**`, `experiments/suites/**`, `*.yaml`, `*.json`
+   - **doc**: `docs/**`, `*.md`
+   - **other**: everything else
+
+4. Identify the PR number and title:
+   ```bash
+   gh pr view --json number,title,url
+   ```
+   If no PR exists, note "No PR found — review is pre-PR."
+
+5. If no changed files: report "Nothing to review" and stop.
+
+## Phase 1 — Simplification Pass (Auto-Fix)
+
+Read each changed `.py` file (library and test). Apply **only** these conservative auto-fixes:
+
+### Auto-Fix Rules
+
+| Pattern | Fix | Safe? |
+|---------|-----|-------|
+| `print(f"DEBUG` / `print(">>>` / `breakpoint()` | Remove the line | Yes — debug artifacts |
+| `if x == True:` | `if x:` | Yes — PEP 8 |
+| `if x == False:` | `if not x:` | Yes — PEP 8 |
+| `if x == None:` / `if x != None:` | `if x is None:` / `if x is not None:` | Yes — PEP 8 |
+| `else:` block after `return`/`raise`/`continue`/`break` that is the only `else` | Remove `else:`, dedent body | Yes — redundant |
+| `pass` as sole statement in non-empty body | Remove | Yes — redundant |
+| `type(x) == T` | `isinstance(x, T)` | Yes — Pythonic |
+
+**Do NOT auto-fix:**
+- Anything involving logic changes
+- String formatting preferences
+- Import ordering (ruff handles this)
+- Type annotations
+- Comment wording
+
+### Auto-Fix Workflow
+
+If any fixes are applied:
+1. Stage the changes: `git add -u`
+2. Run `ruff check --fix` and `ruff format` on changed files
+3. Commit: `git commit -m "fix: auto-fix quality issues from /reviewing-changes"`
+4. Push: `git push`
+5. Record the commit SHA for the report
+
+If no fixes needed, skip to Phase 2.
+
+## Phase 2 — Convention & Correctness Review
+
+Check each changed file against the rule matrix below. Full definitions with code examples are in [CHECKLIST.md](CHECKLIST.md).
+
+### BLOCK (must fix before merging)
+
+These are correctness or convention violations that would cause problems:
+
+| ID | Scope | What to Check |
+|----|-------|---------------|
+| **C1** | Library (`src/`) | Unseeded `random.Random()` or new global RNG state (`random.choice`, `random.shuffle` without local RNG) |
+| **C2** | Library (`src/`) | `x = x or fallback` on numeric metric — `0.0` is falsy, silently replaces valid zeros |
+| **N1** | Notebooks | Aggregation/visualization without `contract_type` facet (or explicit justification for pooling) |
+| **N2** | Notebooks | Matchup summary table collapsing team0/team1 into a single row |
+| **X3** | Any | Merge conflict markers (`<<<<<<<`), `TODO: remove before merge`, large commented-out blocks (>10 lines) |
+
+### WARN (recommend fixing, non-blocking)
+
+| ID | Scope | What to Check |
+|----|-------|---------------|
+| **C3** | Library (`validation/`, `diagnostics/`) | Gate check ordering: most-restrictive first? SKIP vs FAIL semantics correct? |
+| **C4** | Library | Functions >50 lines or nesting depth >4 levels |
+| **N3** | Notebooks | Inference claim without accompanying statistical test (p-value, CI, effect size) |
+| **T1** | Tests | Behavior change in `src/` without corresponding test change in `tests/` |
+| **X1** | Cross-cut | Changes span 3+ unrelated modules (possible scope drift) |
+| **X2** | Cross-cut | Core/scoring/logging changed without corresponding doc update |
+
+### How to Check
+
+For each changed file:
+1. Read the file content
+2. Apply the relevant checks based on file category
+3. For each finding, record: check ID, file path, line number(s), description
+
+## Phase 3 — Validation & Report
+
+### Step 1: Run make check
+
+```bash
+make check-quiet
+```
+
+If it fails:
+1. Read the error output
+2. Attempt to fix (up to 3 iterations)
+3. If fixed: stage, commit as `"fix: resolve make check failures from /reviewing-changes"`, push
+4. If still failing after 3 attempts: note as FAILED in report
+
+### Step 2: Generate Review Report
+
+Output the review report to chat in this format:
+
+```markdown
+## Review Complete
+
+### Diff Summary
+- PR: #NNN — [title]
+- Branch: `<branch>`
+- Files changed: N (M library, K tests, J notebooks, ...)
+
+### Auto-Fixes Applied
+| File | Line | Fix |
+|------|------|-----|
+(table rows, or "No auto-fixes needed.")
+(If applied: "Pushed as follow-up commit `<sha>`.")
+
+### Findings
+#### BLOCK (fix before merging)
+| ID | File | Finding | Rule |
+|----|------|---------|------|
+(table rows, or "No blockers.")
+
+#### WARN (recommend fixing)
+| ID | File | Finding | Rule |
+|----|------|---------|------|
+(table rows, or "No warnings.")
+
+### make check: PASSED / FAILED
+
+### Verdict: READY TO MERGE / NEEDS ATTENTION
+READY if zero BLOCKs and make check passes.
+```
+
+### Step 3: Generate Handoff Summary
+
+Generate the handoff block using the template from [HANDOFF_TEMPLATE.md](HANDOFF_TEMPLATE.md). This block should be ready for the user to `/copy` into a new Claude Code session.
+
+Output it after the review report, separated by a horizontal rule.
+
+## Important Notes
+
+- **Conservative fixes only.** When in doubt, WARN instead of auto-fixing.
+- **Read before checking.** Always read the actual file content — don't guess from filenames.
+- **Context matters.** A `print()` in a CLI script is fine; in library code it's a debug artifact.
+- **Scope awareness.** If changes touch only docs or configs, skip the library checks.
+- **Don't expand scope.** If you find issues in unchanged files, note them but don't fix them. This review covers only the PR diff.


### PR DESCRIPTION
## Summary
- Add `/reviewing-changes` skill: 4-phase post-PR code review (pre-flight, auto-fix, convention check, handoff summary)
- Add PostToolUse hook that auto-triggers the skill after `gh pr create` succeeds
- Add CHECKLIST.md rule reference and HANDOFF_TEMPLATE.md for session continuity

## Why
No structured quality gate exists after PR creation. `make check` catches syntax/lint but not semantic conventions (contract-type faceting, unseeded RNG, falsy numeric guards, matchup table collapsing). This skill fills that gap and generates a `/copy`-ready handoff summary for cross-session continuity.

## Repro / Validation
**Command(s) run:**
- `make check-quiet` — all checks passed
- `bash -n .claude/hooks/post-pr-review.sh` — syntax valid
- `python3 -c "import json; json.load(open('.claude/settings.local.json'))"` — JSON valid
- `which jq` — `/usr/bin/jq` available

**Config (if applicable):**
- N/A (no experiment config)

**Seed (if applicable):**
- N/A

## Tests
- [x] `make check-quiet` — PASSED (all sub-targets)
- [ ] Integration (if engine/rules changed): N/A (no engine changes)
- [x] Other: Hook syntax validation, JSON validation, jq availability

## Expected impact
- Metrics impact (if any): None — workflow tooling only
- Runtime impact (if any): Negligible (hook runs jq on stdin for every Bash tool call, ~5ms)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-post-pr-review
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-post-pr-review
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                  5b9dd06 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-post-pr-review   588e059 [feat/post-pr-review-skill]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it (N/A — no behavior change)
- [x] PR is focused (one concept)

## Files Changed

| File | Purpose |
|------|---------|
| `.claude/hooks/post-pr-review.sh` | PostToolUse hook — fires after `gh pr create`, prints reminder to run `/reviewing-changes` |
| `.claude/skills/reviewing-changes/SKILL.md` | Skill definition — 4-phase review workflow |
| `.claude/skills/reviewing-changes/CHECKLIST.md` | Rule reference — anti-patterns, correct patterns, sources for all check IDs |
| `.claude/skills/reviewing-changes/HANDOFF_TEMPLATE.md` | `/copy`-ready handoff format |
| `.claude/CLAUDE.md` | Document the post-PR review workflow |
| `.claude/settings.local.json` | Register PostToolUse hook (gitignored, local only) |

## Note on settings.local.json
`settings.local.json` is gitignored and not tracked. The PostToolUse hook registration must be applied manually to each checkout. The hook script itself (`.claude/hooks/post-pr-review.sh`) is tracked and will be available in all worktrees.