### PR TITLE
docs: add master plan and sub-plans for R0→R1 execution

### DIFF
--- a/plans/MASTER_PLAN.md
+++ b/plans/MASTER_PLAN.md
@@ -1,0 +1,531 @@
+# Master Plan — Bid Euchre R0 Finalization & R1 Readiness
+
+**Date:** 2026-02-28
+**Status:** ACTIVE
+**Scope:** All outstanding work from R0 finalization through R1 readiness, including
+contract selection analysis, report pipeline infrastructure, R0 report updates, and
+R1 training cycle.
+
+**Last updated by:** Human + Claude review session (2026-02-28)
+
+---
+
+## How to Use This Plan
+
+This is the **governing document** for all project work. When starting a new session:
+
+1. Read this file first to understand what's in flight
+2. Check the Phase Status table (§2) for current progress
+3. Find your assigned work stream and read its sub-plan
+4. Update this file when work items complete
+
+Sub-plans contain implementation detail (file paths, function signatures, commands).
+This plan contains sequencing, dependencies, and rationale.
+
+---
+
+## 1. Executive Summary
+
+R0 is functionally complete — code, experiments, and notebooks are done. But R0 reports
+are not finalized, and a critical analysis (contract selection) may require R0 experiment
+re-runs before reports can be locked. Meanwhile, report pipeline infrastructure (skills,
+chart runner, conventions) can be built in parallel since it's model-agnostic.
+
+**The critical path to R1 runs through the contract selection decision:**
+
+```
+Contract Selection Step 0 (oracle analysis)
+  │
+  ├── Gap small → finalize R0 reports with current data → begin R1
+  │
+  └── Gap large → build calibrator → re-run R0 experiments → finalize R0 reports → begin R1
+```
+
+**Three parallel tracks can proceed immediately:**
+1. Contract selection oracle analysis (determines the critical path)
+2. Report pipeline infrastructure (needed regardless of calibrator outcome)
+3. C33 ablation report refactor (R0-only, independent)
+
+---
+
+## 2. Phase Status
+
+| Phase | Description | Status | Blocker |
+|-------|-------------|--------|---------|
+| **A1** | Contract selection Step 0 (oracle) | NOT STARTED | None — start immediately |
+| **A2** | Report pipeline infrastructure | NOT STARTED | None — start immediately |
+| **A3** | C33 ablation report refactor | NOT STARTED | None — start immediately |
+| **B1** | Contract selection Steps 1–2 (calibrator) | CONDITIONAL | A1 result |
+| **B2** | R0 experiment re-runs | CONDITIONAL | B1 (if calibrator adopted) |
+| **B3** | R0 report finalization | BLOCKED | A1; also B2 if calibrator adopted |
+| **B4** | Skills testing on R0 data | BLOCKED | A2 + B3 |
+| **C1** | Dual-track + archetype analysis (C6) | BLOCKED | B3 |
+| **C2** | R1 training cycle (PR-R1a) | BLOCKED | B3 |
+| **D1** | R1 experiments + reports | BLOCKED | C2 + B4 (reports require validated skills) |
+
+---
+
+## 3. Work Streams
+
+### Stream 1: Contract Selection Analysis (R0 Ablation)
+
+**Why this matters:** The OLSa bidder selects suit 98.3% of the time. If a calibrator
+can improve contract selection, it must be measured at R0 to preserve the ablation —
+otherwise the calibrator effect is confounded with R1 changes (new features, opponent
+context, more training data). Same logic as the C33 Gaussian wrapper ablation.
+
+**Sub-plan:** `plans/contract_selection_analysis.md` (v3)
+
+| Step | Work | Estimated Effort | Output |
+|------|------|-----------------|--------|
+| **Step 0** | Oracle/regret analysis | 1 PR (offline analysis notebook) | Oracle contract mix, regret distribution |
+| **Step 1** | Calibrator prototype | 1–2 PRs (if Step 0 triggers) | Calibrator model + offline validation |
+| **Step 2** | H2H validation | 1 PR (experiment run) | Calibrated vs uncalibrated H2H results |
+| **Re-runs** | R0 experiment suite | Run-only (if calibrator adopted) | Updated eval, comparator, H2H data |
+| **Report** | Calibrator ablation report | 1 PR (analogous to c33_ablation) | R0 ablation documented |
+
+**Decision gate:** Step 0 result determines whether Steps 1–2 happen.
+Two indicators, evaluated together:
+- Oracle HIGH/LOW contract share (how often non-suit is optimal)
+- Mean regret in utility space (how much utility is lost by current selection)
+
+**Precedence rule:** Regret is the primary decision driver (it directly measures
+utility loss). Contract mix is diagnostic context. Specifically:
+- Mean regret > 0.1 utility → calibrator worth pursuing → Steps 1–2 → B2 re-runs
+  (regardless of contract mix — regret could come from wrong-suit selection too)
+- Mean regret ≤ 0.1 utility AND HIGH/LOW < 3% → calibrator not needed → proceed
+  to B3 with current data
+- Mean regret ≤ 0.1 utility AND HIGH/LOW ≥ 3% → contract selection matters but
+  current model captures it adequately → proceed to B3 with current data, document
+  the oracle mix for future reference
+
+**Key context for cold-start:**
+- Paired outcome data already exists: `canonical_bidless_dataset_glutton_42_20260221_175752`
+- Construction path (4 steps — direct join is NOT possible, tables have different granularity):
+  1. **Filter** to canonical single-policy glutton run (eliminates strategy ambiguity)
+  2. **Join** via existing `join_features_outcomes()` from `datasets/join.py` — bridges
+     per-seat bidless ↔ per-hand outcomes on `(hand_id, contract_type, trump_suit)`
+  3. **Pivot** wide on `(contract_type, trump_suit)` → 6 outcome columns per `(deal_id, seat)`
+  4. **Validate** 6 rows per group pre-pivot, drop incomplete groups
+- See `contract_selection_analysis.md` §Step 0 Construction Path for full detail
+- Regret must be computed in **utility space** (EV − CVaR_penalty), NOT raw tricks
+- The `HybridOLSaBidder._compute_ev()` formula is in `bidding.py:900–942`
+- Pass is a valid action: `utility <= 0 → pass` (`bidding.py:1043`)
+
+---
+
+### Stream 2: Report Pipeline Infrastructure
+
+**Why this matters:** R1+ reports need systematic production — the four-stage pipeline
+(data → charts → report → narrative) replaces ad-hoc report writing. This infrastructure
+is model-agnostic and should be built now regardless of the calibrator decision.
+
+**Sub-plan:** `plans/report_narrative_overlay.md` (684 lines) — Phases 0, 3, 4, 5
+
+| PR | Work | Estimated Effort | Depends On |
+|----|------|-----------------|------------|
+| **PR-N0a** | Generator data fixes (G1–G3) | Small code PR | None |
+| **PR-N0b** | Chart runner script | Medium code PR | Resolve open items 4-5 |
+| **PR-N3** | Report conventions + template registry | Doc PR | None |
+| **PR-N4** | `/narrate-report` skill | Skill PR | PR-N3 |
+| **PR-N5** | `/draft-rung-reports` skill | Skill PR | PR-N3 |
+
+**Key context for cold-start:**
+- Generator (`arc_d_report.py`) already supports `chart_dir` parameter — 10 PNG filenames
+  are hardcoded in `_render_*()` functions but no script produces them yet
+- Chart manifest: 11 charts mapped to existing `plot_*` functions in `diagnostics/`
+- G1: Bundle comparator pointer stale (v1 → v4)
+- G2: Bundle has no H2H battery reference
+- G3: Report §8 (Semantic Gate) doesn't read gate checks from `promotion_decision_r0.json`
+- Skill pattern: see `.claude/skills/reviewing-changes/SKILL.md` for the multi-phase template
+- Five-question exec summary: What is this? What did we do? What did we find? Caveats? Decision?
+
+---
+
+### Stream 3: R0 Report Finalization
+
+**Why this matters:** R0 reports carry stale v2 comparator data, lack narrative, have no
+charts, and may need calibrator ablation data. They must be finalized before R1 begins
+because R0 reports are the baseline comparison point.
+
+**Sub-plan:** `plans/report_narrative_overlay.md` — Phases 1, 2
+
+**Blocked on:** Stream 1 Step 0 result (determines whether data changes before finalization)
+
+| PR | Work | Estimated Effort | Depends On |
+|----|------|-----------------|------------|
+| **PR-N1** | R0 rung report refactor | Large doc PR | PR-N0a, PR-N0b, Step 0 |
+| **PR-N2** | Companion report consistency (= C2b-2) | Medium doc PR | PR-N1 |
+
+**Reports to update (Phase 2 = C2b-2):**
+
+| Report | Key Changes |
+|--------|-------------|
+| `h2h_battery_analysis.md` §3 | v2→v4 comparator data, field terminology fixes |
+| `r0_promotion_report.md` | v2→v4 exec summary + comparator table, gate descriptions |
+| `comparator_rankings.md` §4, §8 | Resolve placeholder sections (populate from FULL data or defer with rationale) |
+| `measurement_integrity_r0.md` | Play strategy context (GluttonStrategy), L3 resolved |
+| `docs/04_reports/README.md` | Stale directory listing, missing entries |
+
+**Key context for cold-start:**
+- v2 comparator: 4-way mode, GreedyStrategy, different numbers (e.g., modeloespecifico +2.291)
+- v4 comparator: single-seat, GluttonStrategy, current numbers (e.g., modeloespecifico +1.587)
+- The v2→v4 gap nearly doubled (0.624 → 1.132) — methodology change, not just data refresh
+- **H2H field semantics (CRITICAL):** In H2H battery data, `bid_rate_a/b` = team auction-win
+  frequency (NOT per-bidder bid propensity); `make_rate_a/b` = conditional on team winning bid.
+  In single-seat comparator data, `bid_rate` = per-hand propensity. These are different estimands
+  sharing similar names — do not conflate them in reports. See `report_narrative_overlay.md` P2-1.
+- User's per-section notes for rung report are in `report_narrative_overlay.md` P1-2
+- Econometric-style tables: borrow from `docs/04_reports/phase0/phase0_bidless_20260207.md`
+
+---
+
+### Stream 4: C33 Ablation Report Refactor
+
+**Why this matters:** The C33 ablation report documents the Gaussian wrapper validation.
+It's well-structured but the "selective restraint" mechanism needs empirical grounding.
+R0-specific — no persistence to other rungs.
+
+**Sub-plan:** `plans/c33_ablation_refactor_plan.md` (1,040 lines)
+
+| Work | Estimated Effort | Depends On |
+|------|-----------------|------------|
+| Refactor report with replay diagnostics | 1–2 PRs | None |
+
+**Key context for cold-start:**
+- C33 ablation result: hybrid_olsa > olsa by +0.21 net_eppd (significant, CI excludes 0)
+- Decision trace data NOT logged — requires replay through model artifact
+- Replay: parse JSONL `hands` field → `get_hand_features()` → run both decision layers
+- Must reconstruct: mu, sigma, P(make), EV, bid/pass for each hand × all 6 contracts
+- The EV formula is in `bidding.py:900–942` (asymmetric payoff, continuity correction)
+
+---
+
+### Stream 5: Dual-Track & Roster Meta-Analysis (C6)
+
+**Why this matters:** Side-by-side presentation of decision-quality (single-seat comparator)
+and full-game (H2H self-play) rankings, with archetype segmentation and roster scatter plots.
+Extends the comparator analysis to answer "do the two instruments agree?"
+
+**Sub-plan:** `plans/report_narrative_overlay.md` — Phase 6
+**Background:** `plans/comparator_dual_track_plan.md` (absorbed into Phase 6)
+
+| PR | Work | Estimated Effort | Depends On |
+|----|------|-----------------|------------|
+| **PR-N7** | Dual-track report + archetype + scatter | Large report+viz PR | PR-N2 |
+
+**Key context for cold-start:**
+- Two estimands: decision-quality (declaring-only, every bid) vs full-game (declaring+defending, auction winners only)
+- Both now use GluttonStrategy (confound resolved by C2c/#466)
+- Archetype labels from single-seat data only (bid_rate = per-hand propensity)
+  - AGGRESSIVE: bid_rate > 0.95 AND make_rate < 0.65 (fiveheadfred, rankthetank)
+  - SELECTIVE: bid_rate < 0.50 (hybrid_olsa, modeloespecifico)
+  - NEUTRAL: bid_rate > 0.95 AND make_rate ≥ 0.65 (stricthellraiser, olsa, olsa_full)
+- **H2H field semantics differ:** `bid_rate_a/b` in H2H = team auction-win frequency (see Stream 3)
+- Three scatter plots: bid_rate×make_rate, bid_rate×net_eppd, make_rate×net_eppd
+- H2H absolute metrics available since #468 (schema v2): `abs_net_eppd_team0/team1`
+- Completed prerequisites: C2c (#466), C3 (reruns), C4 (#468), C5 (#467), C2b-1 (#470)
+
+---
+
+### Stream 6: R1 Training Cycle (PR-R1a)
+
+**Why this matters:** R1 is the first improvement rung — new training data, new model,
+new features. All the pipeline infrastructure and R0 baselines must be locked before
+R1 begins.
+
+**Sub-plan:** `plans/arc_d_execution_plan.md` (v3) — Wave 3+
+**Gap:** PR-R1a needs a concrete execution checklist (file paths, commands, validation
+gates). The arc_d_execution_plan covers R1 at a high level but was written before the
+calibrator question arose. **Create a detailed PR-R1a sub-plan when R0 is finalized.**
+
+| Work | Estimated Effort | Depends On |
+|------|-----------------|------------|
+| R1 training data generation | Run-only | B3 (R0 finalized) |
+| R1 model training (dual-arm) | Code + run | Training data |
+| R1 bundle + gate | Code PR | Model artifacts |
+| R1 eval runs (3 seeds, 50k deals) | Run-only | Bundle |
+| R1 report production (using skills) | Pipeline run | PR-N4, PR-N5 |
+
+**Key context for cold-start:**
+- Dual-arm: OLSa_Full (promotional, forward-selected) + OLSa (attribution, locked 3/1/1)
+- Primary metric: net_eppd; eppd is secondary diagnostic
+- Gate thresholds (FULL-calibrated): delta_floor=0.180, regression=0.184
+- R1 challenger must improve by +0.18 net_eppd over R0 incumbent in paired H2H
+- If calibrator adopted, R1 model includes calibrator (R0+calibrator is the baseline)
+- PR-R2a (opponent context features via auction_transcript) can parallel — off critical path
+
+---
+
+## 4. Dependency Graph
+
+```
+PHASE A — UNBLOCKED (start immediately, all parallel)
+──────────────────────────────────────────────────────
+A1: Contract Selection Step 0        A2: Pipeline Infrastructure       A3: C33 Ablation
+   (oracle analysis)                    PR-N0a (generator fixes)          Report Refactor
+                                        PR-N0b (chart runner)
+                                        PR-N3  (conventions)
+                                        PR-N4  (narrate skill)
+                                        PR-N5  (draft skill)
+
+PHASE B — BLOCKED ON A1
+──────────────────────────────────────────────────────
+              A1 result
+                │
+    ┌───────────┴───────────┐
+    │                       │
+Gap small               Gap large
+    │                       │
+    │                  B1: Calibrator
+    │                  (Steps 1–2)
+    │                       │
+    │                  B2: R0 Re-runs
+    │                  (eval, comparator,
+    │                   H2H, thresholds)
+    │                       │
+    └───────────┬───────────┘
+                │
+           B3: R0 Report Finalization
+               PR-N1 (rung report)
+               PR-N2 (companion reports)
+                │
+           B4: Skills Testing
+               PR-N6 (test on R0 data)
+
+PHASE C — BLOCKED ON B3
+──────────────────────────────────────────────────────
+           B3 complete
+                │
+    ┌───────────┴───────────┐
+    │                       │
+C1: Dual-Track (C6)    C2: R1 Training
+    PR-N7                   (PR-R1a)
+    (report + viz)          │
+                       R1 experiments
+                            │
+                       D1: R1 Reports ← also requires B4 (validated skills)
+                       (uses A2 skills)
+```
+
+---
+
+## 5. Execution Phases — Detailed Sequencing
+
+### Phase A: Immediate Parallel Work (no blockers)
+
+All three streams can start immediately and run in parallel. Assign to separate agents
+or work sequentially — no dependencies between them.
+
+**A1 — Contract Selection Oracle Analysis**
+- Effort: ~1 session (notebook + offline analysis)
+- Uses existing paired data (`canonical_bidless_dataset_glutton_42_20260221_175752`)
+- Deliverable: Oracle contract mix, regret distribution, go/no-go decision
+- Sub-plan: `plans/contract_selection_analysis.md` §Acceptance Gates, Step 0
+
+**A2 — Report Pipeline Infrastructure**
+- Effort: ~5 PRs across multiple sessions
+- Order: PR-N0a ∥ PR-N0b ∥ PR-N3 → PR-N4 ∥ PR-N5
+- Deliverable: Chart runner, generator fixes, conventions doc, two skills
+- Sub-plan: `plans/report_narrative_overlay.md` Phases 0, 3, 4, 5
+
+**A3 — C33 Ablation Report Refactor**
+- Effort: 1–2 PRs
+- Deliverable: Empirically grounded ablation report with replay diagnostics
+- Sub-plan: `plans/c33_ablation_refactor_plan.md`
+
+### Phase B: Calibrator Decision & R0 Finalization (blocked on A1)
+
+**B1 — Calibrator Build (CONDITIONAL)**
+- Only if A1 shows oracle gap is meaningful (regret > 0.1 utility)
+- Effort: 1–2 PRs for prototype + validation
+- Sub-plan: `plans/contract_selection_analysis.md` §Steps 1–2
+- **Gap:** If triggered, create `plans/calibrator_implementation.md` with detailed design
+  decisions (tie-handling, pass integration, bid-level coupling, auction context)
+
+**B2 — R0 Experiment Re-runs (CONDITIONAL)**
+- Only if B1 produces a validated calibrator
+- Effort: Run-only (compute time, no code changes)
+- Scope: eval runs (3 seeds × 50k), comparator battery (7 × 4 × 20k), H2H (49 × 2-10k)
+- Also produce: calibrator ablation report (new companion report for R0)
+
+**B3 — R0 Report Finalization**
+- Blocked on A1 (all paths), AND on B2 (calibrator path only)
+- Uses data from B2 if calibrator adopted, otherwise current data
+- Effort: 2 PRs (PR-N1 rung report refactor, PR-N2 companion consistency)
+- Sub-plan: `plans/report_narrative_overlay.md` Phases 1, 2
+
+**B4 — Skills Testing**
+- Run `/narrate-report` on the finalized R0 rung report (validates the skill)
+- Run `/draft-rung-reports r0` and compare against actual R0 reports
+- Effort: 1 PR (PR-N6)
+- Sub-plan: `plans/report_narrative_overlay.md` P4-2, P5-3
+
+### Phase C: Post-R0 Finalization (blocked on B3)
+
+**C1 — Dual-Track + Archetype (C6)**
+- Side-by-side comparator vs H2H analysis
+- Effort: 1 large PR (PR-N7)
+- Sub-plan: `plans/report_narrative_overlay.md` Phase 6
+
+**C2 — R1 Training Cycle**
+- New training data, model, bundle, gate
+- Effort: multiple PRs
+- Sub-plan: `plans/arc_d_execution_plan.md` (Wave 3+)
+- **Gap:** Create `plans/r1_training_plan.md` before starting — concrete commands,
+  validation gates, file paths. Must account for calibrator if adopted.
+
+### Phase D: R1 Reports (blocked on C2 + B4)
+
+- Run the four-stage pipeline on R1 data
+- Use `/narrate-report` and `/draft-rung-reports` skills from A2
+- **Requires B4 complete** — skills must be validated on R0 data before using for R1
+- Effort: Pipeline runs + review
+- No separate sub-plan needed — skills + conventions handle this
+
+---
+
+## 6. Sub-Plan Registry
+
+| Plan File | Governs | Status | Streams |
+|-----------|---------|--------|---------|
+| **`plans/MASTER_PLAN.md`** | All work sequencing | ACTIVE | All |
+| **`plans/contract_selection_analysis.md`** | Oracle analysis + calibrator | ACTIVE (v3) | 1 |
+| **`plans/report_narrative_overlay.md`** | Pipeline, reports, skills, C6 | ACTIVE (684 lines) | 2, 3, 5 |
+| **`plans/c33_ablation_refactor_plan.md`** | C33 report refactor | ACTIVE (1,040 lines) | 4 |
+| **`plans/arc_d_execution_plan.md`** | Full Arc D (R0 done, R1+ remaining) | ACTIVE (v3) | 6 |
+| `plans/comparator_dual_track_plan.md` | C6 background (absorbed into report_narrative_overlay P6) | REFERENCE | 5 |
+| `plans/bidder_correctness_fixes.md` | Fixes A/B/C | COMPLETE (#463–#465) | — |
+| `plans/comparator_rankings_refactor_plan.md` | Rankings report v4 | COMPLETE (#470) | — |
+| `plans/comparator_single_seat.md` | Single-seat methodology | COMPLETE (#464) | — |
+| `plans/comparator_experiment_redesign.md` | Comparator redesign | COMPLETE (#464) | — |
+| `plans/comparator_rankings_review_notes.md` | Review notes | REFERENCE | — |
+| `plans/c33_ablation_review_notes.md` | Review notes | REFERENCE (consumed) | — |
+| `plans/c33_ablation_plan_prompt.md` | Agent handoff | REFERENCE (consumed) | — |
+
+**Plans to create (when triggered):**
+- `plans/calibrator_implementation.md` — if Step 0 triggers calibrator work (B1)
+- `plans/r1_training_plan.md` — before starting R1 training cycle (C2)
+
+---
+
+## 7. Key Project State (for cold-start recovery)
+
+### What's Done
+
+- **R0 code:** All merged (#389–#396, #439–#441)
+- **R0 experiments:** All complete (eval, comparator v4, H2H v2 QUICK+FULL)
+- **R0 notebooks:** 6/6 passing (#428–#438)
+- **Comparator overhaul:** Wave 1 (#463–#465), dual-track code (#466–#468), rankings (#470)
+- **R0 reports:** 6 exist, all need updating (stale v2 data, no narrative, no charts)
+
+### Key Results (R0)
+
+| Metric | OLSa (attribution) | OLSa_Full (promotional) |
+|--------|--------------------|-----------------------|
+| net_eppd (seed 42) | +1.627 | +1.484 |
+| bid_rate | 63.2% | 82.8% |
+| make_rate | 87.3% | 83.3% |
+| R² | 0.18–0.22 | 0.24–0.29 |
+
+- **Attribution gap:** −0.143 (constrained arm slightly outperforms — benign at R0)
+- **C33 ablation:** +0.21 net_eppd (Gaussian wrapper, significant)
+- **Comparator rank:** 2nd/7 (modeloespecifico +1.587, hybrid_olsa +0.455, gap 1.132)
+- **Gate thresholds:** delta_floor=0.180, regression=0.184 (FULL-calibrated)
+- **Contract mix:** 98.3% suit / 0.9% low / 0.8% high (under investigation)
+
+### Key Artifacts
+
+| Artifact | Path |
+|----------|------|
+| R0 eval run | `data/runs/arc_d_eval_r0_42_20260221_180253/` |
+| R0 bundle | `data/artifacts/arc_d/r0/rung_bundle_r0.json` |
+| R0 promotion decision | `data/artifacts/arc_d/r0/promotion_decision_r0.json` |
+| Comparator battery v4 | `data/artifacts/arc_d/r0/comparator_battery_r0_v4.json` |
+| Comparator CIs v4 | `data/artifacts/arc_d/r0/comparator_cis_r0_v4.json` |
+| H2H battery (QUICK) | `data/artifacts/arc_d/r0/h2h_battery_quick_v2.json` |
+| H2H battery (FULL) | `data/artifacts/arc_d/r0/h2h_battery_full_v2.json` |
+| Gate thresholds (R1) | `data/artifacts/arc_d/r0/gate_thresholds_r1.json` |
+| Training data | `canonical_bidless_dataset_glutton_42_20260221_175752` |
+| OLSa model | `data/artifacts/arc_d/r0/hybrid_r0.json` |
+| OLSa_Full model | `data/artifacts/arc_d/r0/hybrid_r0_full.json` |
+
+### Key Files (for implementation)
+
+| Area | Files |
+|------|-------|
+| Bidding policies | `src/bid_euchre/strategy/bidding.py` (OLSaBidder L691, HybridOLSaBidder L778) |
+| Feature extraction | `src/bid_euchre/features/hand_eval.py` (39 features) |
+| Report generator | `src/bid_euchre/reporting/arc_d_report.py` (1,244 lines, 11 sections) |
+| Chart library | `src/bid_euchre/diagnostics/charts.py`, `model_charts.py`, `auction_charts.py`, `strategy_charts.py` |
+| Eval dataset parser | `src/bid_euchre/datasets/eval_dataset.py` |
+| Bundle validator | `src/bid_euchre/validation/arc_d_bundle.py` |
+| Gate runner | `src/bid_euchre/validation/arc_d_gate.py` |
+| Semantic gate | `src/bid_euchre/diagnostics/semantic_gate.py` (12+3 checks) |
+| Feature-outcome join | `src/bid_euchre/datasets/join.py` |
+| Comparator runner | `scripts/internal/run_auction_comparator.py` |
+| H2H battery runner | `scripts/internal/run_arc_d_h2h_battery.py` |
+| CI extractor | `scripts/internal/extract_comparator_cis.py` |
+| Threshold calibrator | `scripts/internal/calibrate_arc_d_thresholds.py` |
+
+### Repo Conventions (critical for agents)
+
+- **Worktree-only:** All code changes in `git worktree add ../Bid-Euchre-<branch> -b <branch>`
+- **Runner:** Always `uv run` (never raw `python` or `pip`)
+- **Validation:** `make check-quiet` before PRs (repo-lint + ruff + pytest + notebook-check + docs-check)
+- **Determinism:** `--seed <int>` required for all experiments
+- **Data policy:** Never commit `data/runs/`, `data/reports/`, `data/models/`
+- **One concept per PR**, use `.github/pull_request_template.md`
+- **Contract-type faceting:** Every chart/table MUST facet by contract_type or justify pooling
+- **Team breakout:** Matchup tables MUST show team0/team1 separately
+
+---
+
+## 8. Completion Checklist
+
+### Phase A (parallel, no blockers)
+- [ ] A1: Oracle contract mix computed, regret distribution reported, go/no-go decision made
+- [ ] A2-a: PR-N0a merged (generator data fixes G1–G3)
+- [ ] A2-b: PR-N0b merged (chart runner script)
+- [ ] A2-c: PR-N3 merged (report conventions + template registry)
+- [ ] A2-d: PR-N4 merged (`/narrate-report` skill)
+- [ ] A2-e: PR-N5 merged (`/draft-rung-reports` skill)
+- [ ] A3: C33 ablation report refactored with replay diagnostics
+
+### Phase B (blocked on A1)
+- [ ] B1: Calibrator decision documented (adopted / not needed)
+- [ ] B1-a: (if adopted) Calibrator prototype built and validated offline
+- [ ] B1-b: (if adopted) Calibrator H2H validation passed
+- [ ] B2: (if adopted) R0 experiments re-run with calibrated model
+- [ ] B2-a: (if adopted) Calibrator ablation report written
+- [ ] B3-a: PR-N1 merged (R0 rung report refactor with charts + narrative)
+- [ ] B3-b: PR-N2 merged (companion report consistency = C2b-2)
+- [ ] B4: PR-N6 merged (skills tested on R0 data)
+
+### Phase C (blocked on B3)
+- [ ] C1: PR-N7 merged (dual-track + archetype + scatter = C6)
+- [ ] C2-a: R1 training plan created (`plans/r1_training_plan.md`)
+- [ ] C2-b: R1 training data generated
+- [ ] C2-c: R1 model trained (dual-arm)
+- [ ] C2-d: R1 bundle + gate created
+- [ ] C2-e: R1 eval runs complete (3 seeds)
+
+### Phase D (blocked on C2 + B4)
+- [ ] D1-a: R1 charts generated (chart runner)
+- [ ] D1-b: R1 rung report generated + narrated (`/narrate-report`)
+- [ ] D1-c: R1 companion reports drafted (`/draft-rung-reports`)
+- [ ] D1-d: R1 reports reviewed and finalized
+
+---
+
+## 9. Plan Maintenance
+
+Update this file when:
+- A work item completes (check the box, add PR number)
+- A phase transitions (update Phase Status table)
+- A conditional branch resolves (B1 calibrator decision)
+- A new sub-plan is created (add to Sub-Plan Registry)
+- A blocking issue is discovered (add to Phase Status blocker column)
+
+**MEMORY.md** should reference this file and track PR numbers. This file tracks
+sequencing and status. Sub-plans track implementation detail.

--- a/plans/arc_d_execution_plan.md
+++ b/plans/arc_d_execution_plan.md
@@ -5,6 +5,15 @@
 **Date:** 2026-02-20 (v3 update)
 **Target path:** `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/plans/arc_d_execution_plan.md`
 
+## ⚠️ STALENESS WARNING (2026-02-28)
+
+**This plan is partially stale.** Waves 0–2 + R0b are COMPLETE. The plan still
+references provisional thresholds (delta_floor=0.01) — actual FULL-calibrated
+values are delta_floor=0.180, regression=0.184 (see MASTER_PLAN.md Stream 6).
+The prerequisites table in §10 is also stale (P0 is merged; all R0 work is done).
+For current project state, consult `plans/MASTER_PLAN.md` first. This plan
+remains the authoritative source for R1+ wave structure and PR sequencing.
+
 ## v3 Changes (2026-02-20)
 
 Applies 31 review decisions from `plans/archive/arc_d_gap_analysis.md`. Key changes:
@@ -783,7 +792,7 @@ def promotion_gate(bundle_path, rung_id):
     /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/src/bid_euchre/reporting/eligibility.py.
     It adds Arc D-specific Tier 2 gates on top of the central eligibility engine.
     """
-    delta_floor = 0.01  # fixed floor, not configurable
+    delta_floor = 0.01  # ⚠️ SUPERSEDED: FULL-calibrated value is 0.180 (see MASTER_PLAN.md)
 
     # --- Pre-Gate: Bundle validation ---
     bundle = load_and_validate_bundle(bundle_path)
@@ -881,18 +890,23 @@ def promotion_gate(bundle_path, rung_id):
 
 ### Threshold Summary
 
+> **⚠️ SUPERSEDED:** The `0.01` values below are provisional pre-R0 estimates.
+> FULL-calibrated thresholds from R0 actuals: **delta_floor=0.180, regression=0.184**.
+> See `MASTER_PLAN.md` Stream 6 and `src/bid_euchre/validation/arc_d_gate.py` for
+> the implemented values. The table below is retained for historical context only.
+
 | Rung | Gate Type | Primary Condition | Additional | Sensitivity |
 |------|-----------|-------------------|------------|-------------|
 | R0 | Auto-promote | All 7 metrics finite (both arms) | None | None |
-| R1 | Improvement | net_eppd > control + max(0.01, 1.5\*SE) | Standard guardrails | Both 43+44 < 0 -> HALT |
-| R2 | Improvement | net_eppd > control + max(0.01, 1.5\*SE) | Standard guardrails | Both 43+44 < 0 -> HALT |
-| R3 | Improvement | net_eppd > control + max(0.01, 1.5\*SE) | Standard guardrails | Both 43+44 < 0 -> HALT |
-| R4 | Improvement | net_eppd > control + max(0.01, 1.5\*SE) | Standard guardrails | Both 43+44 < 0 -> HALT |
-| R5 | Improvement | net_eppd > control + max(0.01, 1.5\*SE) | **Strict cvar_5 improvement** | Both 43+44 < 0 -> HALT |
+| R1 | Improvement | net_eppd > control + max(~~0.01~~ 0.180, 1.5\*SE) | Standard guardrails | Both 43+44 < 0 -> HALT |
+| R2 | Improvement | net_eppd > control + max(~~0.01~~ 0.180, 1.5\*SE) | Standard guardrails | Both 43+44 < 0 -> HALT |
+| R3 | Improvement | net_eppd > control + max(~~0.01~~ 0.180, 1.5\*SE) | Standard guardrails | Both 43+44 < 0 -> HALT |
+| R4 | Improvement | net_eppd > control + max(~~0.01~~ 0.180, 1.5\*SE) | Standard guardrails | Both 43+44 < 0 -> HALT |
+| R5 | Improvement | net_eppd > control + max(~~0.01~~ 0.180, 1.5\*SE) | **Strict cvar_5 improvement** | Both 43+44 < 0 -> HALT |
 
-**Note on provisional thresholds:** The thresholds above (delta_floor=0.01,
-cvar_5 tolerance=0.10, etc.) were originally calibrated for `eppd`. Since `net_eppd`
-values are systematically lower (net differential is harsher), these thresholds are
+**Note on provisional thresholds:** The thresholds above were originally calibrated
+for `eppd` at delta_floor=0.01. They have been **recalibrated from FULL-mode R0
+actuals** to delta_floor=0.180, regression=0.184. The original values are
 **provisional**. R0 establishes the net_eppd baseline; thresholds are recalibrated
 from R0 actuals before R1 promotion.
 
@@ -1925,7 +1939,7 @@ Verify: make repo-lint passes.
 
 | # | Action | Status |
 |---|--------|--------|
-| P0 | Merge PR-P0: switch primary metric to `net_eppd` | **Pending** |
+| P0 | Merge PR-P0: switch primary metric to `net_eppd` | **DONE** (merged, part of R0 completion) |
 | P1 | Merge HITL PR-1 (#370): `require_split()` | **DONE** (merged 2026-02-19) |
 | P2 | Merge HITL PR-2 (#372): `compute_semantic_gate()` | **DONE** (merged 2026-02-19) |
 | P3 | Merge HITL PR-3 (#374): model-rung notebook template | **DONE** (merged) |

--- a/plans/bidder_correctness_fixes.md
+++ b/plans/bidder_correctness_fixes.md
@@ -1,0 +1,358 @@
+# Bidder Correctness Fixes
+
+> **Status:** Plan — ready for review
+> **Scope:** Code correctness for 3 heuristic/trained bidders. No experiment design
+> changes. Tests + behavior changes only.
+> **Relationship to comparator redesign:** These fixes MUST land before the
+> comparator battery is re-run under any methodology (single-seat or 4-way).
+> See `plans/comparator_single_seat.md` for the methodology change.
+> **Extracted from:** `plans/comparator_experiment_redesign.md` (Fixes A, B, C)
+
+---
+
+## Fix A: Remove ModeloEspecifico bid ceiling (P0 — correctness bug)
+
+### Problem
+
+`ModeloEspecifico.choose_bid()` (`bidding.py:438,445,452`) caps bids at `<= 6`:
+
+```python
+# Line 438 (suit)
+if 3 <= bid_n <= 6 and bid_n > obs.current_high_bid:
+# Line 445 (HIGH)
+if 3 <= bid_n_high <= 6 and bid_n_high > obs.current_high_bid:
+# Line 452 (LOW)
+if 3 <= bid_n_low <= 6 and bid_n_low > obs.current_high_bid:
+```
+
+The game rules (RULES.md §3.2, line 115) allow bids 1–10. OLSaBidder and
+HybridOLSaBidder correctly use `<= 10`. The `<= 6` cap has no documented
+rationale — it was present from the initial implementation (PR #154) and was
+never revisited.
+
+### Effect
+
+Hands scoring > 6 in the formula (e.g., `1.0 * bowers + 0.5 * trump_count +
+0.5 * offsuit_aces` → 7.0 for 2 bowers + 6 trump + 2 aces) get **no bid at
+all** in that contract type, rather than bidding the max of 6. The `int(score)`
+floors the result, so `score = 7.2 → bid_n = 7`, and `7 <= 6` is false → the
+entire candidate is skipped.
+
+This silently suppresses the **strongest** hands and artificially deflates
+bid_rate while inflating make_rate (only medium-strength hands that pass the
+guard actually bid).
+
+### Fix
+
+Change `<= 6` to `<= 10` on all three guard lines:
+
+```python
+# Line 438: 3 <= bid_n <= 6 → 3 <= bid_n <= 10
+# Line 445: 3 <= bid_n_high <= 6 → 3 <= bid_n_high <= 10
+# Line 452: 3 <= bid_n_low <= 6 → 3 <= bid_n_low <= 10
+```
+
+The formula's practical maximum for suit is ~9 (4 bowers × 1.0 + 10 trump ×
+0.5 + 0 aces = 9.0), so bids of 7–9 become possible for very strong hands.
+For HIGH, the formula is `1.0 * offsuit_aces`; with a maximum of 8 aces
+(double deck, 4 suits × 2), bids up to 8 become possible. For LOW,
+`offsuit_tens_count` caps at 8, so bids up to 8.
+
+### Impact
+
+- ModeloEspecifico's bid_rate will increase slightly (more hands qualify).
+- net_eppd could change in either direction (strong hands now bid, likely
+  make at high rates, but the bid amount is also higher).
+- **Rankings may shift.** ModeloEspecifico is currently #1 — this is a
+  correctness fix; the current #1 ranking is based on a bugged bidder.
+
+### Tests
+
+1. **Unit test:** Construct a hand with `score > 6` (e.g., 2 bowers + 6
+   trump + 2 aces in hearts). Verify `choose_bid()` returns a bid (not pass).
+2. **Regression test:** Verify that hands scoring 3–6 still bid correctly
+   (no change in behavior for the existing range).
+3. **Edge case:** Hand with `score = 10.5` → `bid_n = 10` → valid.
+   Hand with `score = 11.0` → `bid_n = 11` → filtered by `<= 10` → correct.
+   (Practically unreachable, but the guard is correct.)
+
+### Files changed
+
+- `src/bid_euchre/strategy/bidding.py` (3 lines)
+- `tests/unit/test_bidding.py` (new test cases)
+
+---
+
+## Fix B: Remove bid floor from OLSa-family bidders (P2 — minor constraint removal)
+
+### Problem
+
+OLSaBidder (`bidding.py:741,749,757`) and HybridOLSaBidder (`bidding.py:1010`)
+enforce `bid_n >= 3`:
+
+```python
+# OLSaBidder, line 741:
+if 3 <= bid_n <= 10 and bid_n > obs.current_high_bid:
+
+# HybridOLSaBidder, line 1010:
+if bid_n < 3 or bid_n > 10:
+    continue
+```
+
+The game rules (RULES.md §3.2, line 115) explicitly state: "the first
+non-pass bid may be as low as **1**."
+
+For OLSaBidder: if the model predicts `mu = 1.7`, flooring to `bid_n = 1`
+is a legal bid that reflects the model's assessment.
+
+For HybridOLSaBidder: the `>= 3` floor is even less defensible — the
+Gaussian EV wrapper already gates on `utility > 0`. If the model says
+bidding 1 is positive-utility, the floor overrides that judgment.
+
+### Fix
+
+```python
+# OLSaBidder lines 741, 749, 757:
+# 3 <= bid_n <= 10 → 1 <= bid_n <= 10
+
+# HybridOLSaBidder line 1010:
+# bid_n < 3 → bid_n < 1
+```
+
+**Leave heuristic bidders unchanged:** For ModeloEspecifico and RanktheTank,
+the `>= 3` floor may be an intentional design choice since their formulas
+are hand-tuned. Document the rationale in their docstrings.
+
+### Impact
+
+Likely minimal for trained models (OLS predictions of < 3 are rare for
+hands worth bidding), but removes an artificial constraint that could mask
+model behavior at the margins. Specifically:
+- Bids of 1 or 2 become possible when the model thinks a hand is marginal.
+- For HybridOLSaBidder, the EV wrapper should already reject most bids of
+  1–2 as negative-utility (the scoring formula gives `tricks_won - 10`
+  from the defender's perspective, so bidding 1 and making it yields only
+  1 point for declarer vs 9 for defender).
+
+### Tests
+
+1. **Unit test:** Mock model with weights that predict `mu = 1.5` for a hand.
+   Verify `choose_bid()` returns `BidAction.bid(1, ...)` (not pass).
+2. **Unit test (HybridOLSa):** Mock model where `bid_n = 2` has
+   `utility > 0`. Verify it bids 2.
+3. **Regression test:** Verify bids of 3–10 still work correctly.
+
+### Files changed
+
+- `src/bid_euchre/strategy/bidding.py` (4 lines: OLSa ×3, HybridOLSa ×1)
+- `tests/unit/test_bidding.py` (new test cases)
+- Docstring updates for ModeloEspecifico, RanktheTank (document `>= 3`
+  as intentional for heuristic bidders)
+
+---
+
+## Fix C: Recalibrate RanktheTank thresholds (P1 — two bugs)
+
+### Bug 1: Suit ceiling at 6
+
+The threshold table (`bidding.py:348–357`) only maps up to `350 → 6`:
+
+```python
+if strength >= 350:
+    bid_n = 6
+elif strength >= 300:
+    bid_n = 5
+elif strength >= 250:
+    bid_n = 4
+elif strength >= 200:
+    bid_n = 3
+```
+
+`score_hand_scalar` for suit contracts returns 60–120 per card (trump: 60–100,
+offsuit: 10–50, bowers: 110–120). With 10 cards, the range is roughly
+100–1000. Hands scoring 400–1000 still bid only 6. Bids of 7–10 are
+unreachable.
+
+### Bug 2: HIGH/LOW thresholds are miscalibrated (dead code)
+
+`score_hand_scalar` for HIGH/LOW returns `(rank_strength + 1) * 10` per
+card, where `rank_strength ∈ {0,1,2,3,4}`. So each card contributes 10–50
+points. With 10 cards:
+- **Minimum possible score:** 10 × 10 = 100
+- **Maximum possible score:** 10 × 50 = 500
+
+The thresholds (`bidding.py:370–377, 385–392`) are:
+
+```python
+if strength_high >= 40:    # Always true (min score = 100)
+    bid_n = 5
+elif strength_high >= 30:  # Dead code
+    bid_n = 4
+elif strength_high >= 20:  # Dead code
+    bid_n = 3
+```
+
+**Every** HIGH/LOW hand hits the first branch and bids 5. The `elif` and
+`else` branches never execute. This means RanktheTank has no discrimination
+for HIGH/LOW — it always bids 5.
+
+### Bug 3: HIGH/LOW mutual exclusion
+
+Lines 368 and 383 use a card-count heuristic (`high_cards >= low_cards` vs
+`low_cards > high_cards`) to choose between HIGH and LOW. This means:
+- Only one of HIGH/LOW is ever evaluated per hand.
+- The choice is based on card count, not `score_hand_scalar`.
+- A hand could score better in LOW than HIGH but never be evaluated.
+
+### Fix approach
+
+**Option A (Minimal): Fix thresholds + ceiling only**
+- Extend suit threshold table to cover bids 7–10.
+- Replace HIGH/LOW thresholds with values in the 100–500 range.
+- Evaluate BOTH HIGH and LOW, pick the higher-scoring candidate.
+- Derive thresholds by inspection of `score_hand_scalar` ranges.
+
+**Option B (Empirical): Derive from canonical bidless dataset**
+- Join `canonical_bidless_dataset_glutton_42_20260221_175752` (features +
+  outcomes) on `hand_id`.
+- For each contract type, compute the `hand_value` → `mean(tricks_won)`
+  mapping.
+- Set threshold for bid level N = the `hand_value` where
+  `mean(tricks_won) ≈ N`.
+- This grounds thresholds in actual trick-taking outcomes under the same
+  play policy used in the comparator.
+
+**Recommendation: Option A.** The empirical approach is sound but adds
+complexity (data dependency, calibration script) for a mid-tier heuristic
+bidder that ranks 5th of 7. Option A is sufficient to fix the bugs.
+Document Option B as a future improvement.
+
+### Approximate thresholds (Option A)
+
+**Suit** (score range ~100–1000):
+| Strength | Bid | Rationale |
+|----------|-----|-----------|
+| ≥ 200 | 3 | Keep existing |
+| ≥ 250 | 4 | Keep existing |
+| ≥ 300 | 5 | Keep existing |
+| ≥ 350 | 6 | Keep existing |
+| ≥ 450 | 7 | Extrapolate ~100-point spacing |
+| ≥ 550 | 8 | Extrapolate |
+| ≥ 650 | 9 | Extrapolate |
+| ≥ 750 | 10 | Extrapolate |
+
+**HIGH/LOW** (score range 100–500):
+| Strength | Bid | Rationale |
+|----------|-----|-----------|
+| ≥ 150 | 3 | ~30th percentile |
+| ≥ 200 | 4 | ~50th percentile |
+| ≥ 280 | 5 | ~70th percentile |
+| ≥ 350 | 6 | ~85th percentile |
+| ≥ 400 | 7 | ~92nd percentile |
+| ≥ 450 | 8 | Near ceiling |
+
+Note: These are rough approximations. Exact values should be verified
+against the score distribution from a sample of hands. A quick smoke test
+(100–200 hands) can confirm the thresholds produce reasonable bid
+distributions.
+
+### Mutual exclusion fix
+
+```python
+# BEFORE (lines 368, 383):
+if high_cards >= low_cards:
+    # evaluate HIGH only
+if low_cards > high_cards:
+    # evaluate LOW only
+
+# AFTER:
+# Evaluate BOTH HIGH and LOW, add both to candidates list.
+# The existing max(candidates, key=...) picks the best one.
+strength_high = score_hand_scalar(obs.hand, "high", None)
+# ... threshold → bid_n_high ...
+if bid_n_high > obs.current_high_bid:
+    candidates.append((strength_high, bid_n_high, "HIGH"))
+
+strength_low = score_hand_scalar(obs.hand, "low", None)
+# ... threshold → bid_n_low ...
+if bid_n_low > obs.current_high_bid:
+    candidates.append((strength_low, bid_n_low, "LOW"))
+```
+
+### Impact
+
+- RanktheTank's HIGH/LOW behavior changes significantly (from "always bid 5"
+  to discriminating by hand strength).
+- Suit behavior gains bids of 7–10 for very strong hands.
+- Rankings will likely shift. RanktheTank is currently #5 of 7.
+
+### Tests
+
+1. **Unit test (suit):** Hand with `score_hand_scalar ≥ 450` → bids 7+.
+2. **Unit test (HIGH/LOW):** Hand with `score_hand_scalar = 150` → bids 3
+   (not 5).
+3. **Unit test (mutual exclusion):** Hand where LOW score > HIGH score →
+   LOW candidate is evaluated and selected.
+4. **Regression test:** Existing suit thresholds (200–350) → same bids as
+   before.
+
+### Files changed
+
+- `src/bid_euchre/strategy/bidding.py` (RanktheTank.choose_bid: threshold
+  table + mutual exclusion logic, ~20 lines)
+- `src/bid_euchre/features/hand_eval.py` (update `score_hand_scalar`
+  docstring: "not used for bidding" is stale — it IS used by RanktheTank)
+- `tests/unit/test_bidding.py` (new test cases)
+
+---
+
+## Implementation Plan
+
+### PR structure (2 PRs)
+
+**PR-B1: Fix A + Fix B** (small, low-risk)
+- 3 lines for ModeloEspecifico ceiling
+- 4 lines for OLSa floor
+- Docstring updates
+- New unit tests
+- Can merge independently
+
+**PR-B2: Fix C** (medium, behavioral change)
+- RanktheTank threshold table rewrite
+- Mutual exclusion fix
+- Docstring fix in `hand_eval.py`
+- New unit tests
+- Depends on: nothing (can parallel with PR-B1)
+
+### Sequencing
+
+Both PRs can be developed in parallel. Neither depends on the other.
+Both must merge before the comparator battery is re-run.
+
+### Validation
+
+Per-PR:
+- `make check-quiet` passes
+- New unit tests cover the changed behavior
+- Smoke experiment: `uv run python experiments/run_experiment.py --config experiments/configs/quick_test.yaml --seed 42`
+
+Post-merge (both PRs):
+- Run the comparator battery once to verify all 7 bidders still produce
+  valid results (this is the comparator methodology plan's job, not this
+  plan's).
+
+---
+
+## Dependency Note
+
+The comparator methodology plan (`plans/comparator_single_seat.md`) depends
+on these fixes being merged first. The comparator battery results will
+reflect both the bidder corrections AND the methodology change. By landing
+bidder fixes first, we establish a clean baseline:
+
+1. **Merge PR-B1 + PR-B2** (bidder fixes)
+2. **Run comparator battery** (under new methodology)
+3. **Result deltas** are attributable to methodology, not bidder bugs
+
+If the comparator plan is implemented without these fixes, the results will
+be based on bugged bidders, defeating the purpose of a cleaner measurement.

--- a/plans/c33_ablation_plan_prompt.md
+++ b/plans/c33_ablation_plan_prompt.md
@@ -1,0 +1,156 @@
+# Agent Handoff: C33 Ablation Report Refactor — Plan Development
+
+## Your Task
+
+Review the notes in `plans/c33_ablation_review_notes.md` and develop a detailed
+implementation plan for refactoring the C33 ablation report and creating/modifying
+supporting notebooks. The plan should be ready for a coding agent to execute.
+
+**Output:** A written plan saved to `plans/c33_ablation_refactor_plan.md`.
+Do NOT begin implementation.
+
+---
+
+## Context
+
+### What is the C33 ablation?
+
+The C33 ablation is an experiment that isolates the value of the Gaussian CDF
+decision layer ("wrapper") in the hybrid_olsa bidder vs a simpler floor-based
+threshold (olsa). Both bidders use identical OLS regression coefficients — the
+only difference is how they decide whether to bid. The result: the wrapper adds
++0.21 net_eppd via "selective restraint" (avoiding bad bids, not finding better
+ones).
+
+### What's wrong with the current report?
+
+The report (`docs/04_reports/r0/c33_ablation_report.md`) presents correct
+results but:
+1. Doesn't explain the architecture being ablated (reader must look elsewhere)
+2. Results are point estimates only — no distributional detail
+3. Matchup tables collapse team0/team1 into single rows
+4. The 16.2% bid rate is confusingly low without explaining it's a competitive
+   (not intrinsic) rate
+5. The central claim ("selective restraint") is asserted but not demonstrated
+   with evidence
+
+### What are we building?
+
+Three deliverables (see `plans/c33_ablation_review_notes.md` for full detail):
+- **D1:** Refactored ablation report with new sections and expanded results
+- **D2:** Violin plot addition to existing `notebooks/arc_d/r0/50_r0_matchups.py`
+- **D3:** New notebook `notebooks/arc_d/r0/55_c33_ablation_deep_dive.py`
+
+---
+
+## Instructions for Plan Development
+
+### Phase 1: Resolve open questions
+
+Before planning, investigate these three questions (answers determine scope):
+
+1. **Decision trace data availability:** Check whether the existing C33 ablation
+   eval logs (JSONL in `data/runs/`) capture per-hand mu, sigma, P(make), and EV.
+   Relevant files to check:
+   - `src/bid_euchre/strategy/bidding.py` — look at `HybridOLSaBidder` and
+     `OLSaBidder` classes for what gets logged during bid decisions
+   - `src/bid_euchre/logging/` — JSONL log schema
+   - `docs/01_core/DATA_CONTRACT.md` — logged fields
+
+   If per-hand decision traces are NOT logged, the notebook (D3) will need to
+   replay hands through both decision layers using the saved model artifact
+   (`data/artifacts/arc_d/r0/hybrid_r0.json`). This changes the notebook
+   complexity significantly.
+
+2. **EV formula:** Read the exact EV computation in `HybridOLSaBidder` in
+   `src/bid_euchre/strategy/bidding.py`. Capture the precise reward/penalty
+   terms (are they trick-based? point-based? bid-dependent?). This is needed
+   for the overlaid histograms in D3.
+
+3. **Intrinsic bid rate provenance:** The notes reference hybrid_olsa intrinsic
+   bid rates of ~62.5% and ~82.8% from different contexts. Check:
+   - `docs/04_reports/r0/comparator_rankings.md`
+   - `docs/04_reports/r0/h2h_battery_analysis.md`
+   - `docs/04_reports/r0/r0_promotion_report.md`
+
+   Determine which run/seed/context produced each number so the report can
+   cite them accurately.
+
+### Phase 2: Develop the plan
+
+Structure the plan with:
+
+1. **PR strategy** — How many PRs? What goes in each? Suggested:
+   - PR 1: Report refactor (D1-a architecture section + D1-b results expansion
+     + bid rate clarification) — pure writing, no data dependency
+   - PR 2: New notebook (D3) + report evidence section (D1-c) + violin plot (D2)
+
+   But adjust based on what you learn in Phase 1 (if replay is needed, D3 may
+   be larger and warrant its own PR).
+
+2. **Per-deliverable spec** — For each deliverable:
+   - Exact files to create/modify (full paths)
+   - What changes in each file (section-level for report, cell-level for notebooks)
+   - Dependencies on other deliverables
+   - Acceptance criteria (what does "done" look like?)
+
+3. **Notebook D3 detailed spec** — This is the most complex deliverable:
+   - Data loading strategy (existing logs vs replay)
+   - Required imports and library functions to use
+   - Each section's inputs, computation, and outputs
+   - Chart specifications (axes, faceting, colors, expected visual pattern)
+   - Assert-style gates (what sanity checks should the notebook enforce?)
+
+4. **Report D1 section drafts** — For new sections (§3 Architecture Comparison,
+   §5 Decision Divergence Evidence), provide draft outlines with placeholder
+   references to notebook outputs. Don't write final prose, but specify:
+   - Section heading
+   - Subsection structure
+   - What each paragraph covers
+   - Where notebook figures/tables are referenced
+
+5. **Validation checklist** — What to verify before the PR:
+   - `make check` passes
+   - `make notebook-check` passes (Jupytext sync, outputs cleared)
+   - All charts faceted by contract_type
+   - All matchup tables show team0/team1
+   - Report cross-references are valid
+   - No data artifacts committed
+
+---
+
+## Key Files to Read
+
+Read these files during plan development (in priority order):
+
+### Must-read
+- `plans/c33_ablation_review_notes.md` — the review notes driving this plan
+- `docs/04_reports/r0/c33_ablation_report.md` — the report being refactored
+- `src/bid_euchre/strategy/bidding.py` — HybridOLSaBidder and OLSaBidder classes
+  (decision logic, EV formula, what gets logged)
+- `src/bid_euchre/reporting/evaluator.py` — bid_rate formula, metric computation
+
+### Should-read
+- `notebooks/arc_d/r0/50_r0_matchups.py` — existing matchup notebook (D2 target)
+- `notebooks/arc_d/r0/30_feature_outcome_eval.py` — example of notebook structure,
+  assert gates, chart patterns to follow
+- `docs/04_reports/r0/h2h_battery_analysis.md` — bid rate numbers in context
+
+### Reference
+- `CLAUDE.md` — project conventions (worktree workflow, `uv run`, ruff, etc.)
+- `.claude/rules/05_rigor.md` — statistical rigor requirements
+- `docs/01_core/DATA_CONTRACT.md` — logging schema
+- `.github/pull_request_template.md` — PR template
+
+---
+
+## Conventions
+
+- All charts/tables MUST be faceted by contract_type or justify pooling
+- All matchup tables MUST show team0 and team1 separately
+- Always distinguish competitive (H2H) bid rate from intrinsic (comparator) bid rate
+- Notebooks: edit .py files (Jupytext), not .ipynb
+- Notebook naming: 55_ prefix (between existing 50_ and future 60_)
+- All code changes in worktrees, never on main
+- Run `make check-quiet` before claiming done
+- Use `uv run` for all Python commands

--- a/plans/c33_ablation_refactor_plan.md
+++ b/plans/c33_ablation_refactor_plan.md
@@ -65,13 +65,13 @@ exceeds current high bid. No sigma, no P(make), no EV check.
 
 | Rate | Bidder Arm | Context | Source |
 |------|-----------|---------|--------|
-| **62.5%** | hybrid_olsa (constrained, 3 features, Gaussian CDF) | Comparator self-play (uncontested, vs Glutton) | `comparator_rankings.md` v2 (10k deals, seed=42) |
+| **(see v4)** | hybrid_olsa (constrained, 3 features, Gaussian CDF) | Comparator self-play (uncontested, vs Glutton) | Pull from current `comparator_rankings.md` v4 (single-seat mode) |
 | **82.8%** | OLSa_Full (full, 39 features, floor-based) | R0 promotion eval (uncontested, vs Glutton) | `r0_promotion_report.md` (seed=42) |
 | **16.2%** | hybrid_olsa (constrained, 3 features, Gaussian CDF) | C33 ablation H2H (contested auction, vs olsa) | `c33_ablation_report.md` (10k deals, seed=42) |
 
-**Key distinction:** 62.5% and 82.8% are from *different model arms*, not the
+**Key distinction:** The comparator and promotion rates are from *different model arms*, not the
 same model in different contexts. The 16.2% competitive rate reflects auction
-interaction: hybrid_olsa yields 84% of auctions to olsa because olsa always
+interaction: hybrid_olsa yields most auctions to olsa because olsa always
 outbids it when both would bid (olsa has no EV threshold).
 
 ---
@@ -168,7 +168,7 @@ sigma from training. For each candidate bid:
 | Decision rule | floor(mu) >= 3 | EV > 0 |
 | Uses sigma? | No | Yes (per-contract residual variance) |
 | Accounts for uncertainty? | No | Yes (Gaussian model) |
-| Bid rate (comparator, uncontested) | ~100% | ~62.5% |
+| Bid rate (comparator, uncontested) | ~100% | See current `comparator_rankings.md` v4 |
 | Parameters beyond OLS | None | residual_variance, risk_lambda |
 
 ### 3.2 Risk Quantification (Analytical CVaR)
@@ -202,7 +202,7 @@ the intrinsic bid rate, which measures how often the bidder would bid in
 uncontested self-play.
 
 For context:
-- hybrid_olsa intrinsic bid rate: 62.5% (comparator_rankings.md v2, 10k deals)
+- hybrid_olsa intrinsic bid rate: pull from current `comparator_rankings.md` v4 at write time
 - hybrid_olsa competitive bid rate vs olsa: 16.2% (this report)
 - The 46pp gap reflects auction interaction: olsa outbids hybrid_olsa in most
   deals because olsa has no EV threshold and bids more aggressively.

--- a/plans/c33_ablation_review_notes.md
+++ b/plans/c33_ablation_review_notes.md
@@ -1,0 +1,202 @@
+# C33 Ablation Report — Review Notes (Agent Handoff)
+
+> **Goal:** Refactor the C33 ablation report and supporting notebooks to make the
+> "selective restraint" mechanism empirically grounded rather than asserted.
+>
+> **Source report:** `docs/04_reports/r0/c33_ablation_report.md`
+> **Scope:** R0 only. Changes do not persist to other rungs.
+
+---
+
+## Current Report Structure
+
+The report has 8 sections:
+1. Motivation
+2. Methodology
+3. Results (self-play sanity + cross-matchup tables + behavioral profile)
+4. Interpretation
+5. Impact & Decisions
+6. Arc Context
+7. Provenance
+8. Reproduction
+
+---
+
+## Deliverables
+
+### D1. Refactored ablation report (`docs/04_reports/r0/c33_ablation_report.md`)
+
+The report needs structural changes. Proposed new section order:
+
+| # | Section | Status | Notes |
+|---|---------|--------|-------|
+| 1 | Motivation | Keep as-is | |
+| 2 | Methodology | Minor edits | Add bid_rate formula, clarify competitive vs intrinsic bid rate |
+| **3** | **Architecture Comparison** | **NEW** | Consolidates all hybrid_olsa vs olsa differences |
+| 4 | Results | Expand | Add distributional detail, team0/team1 breakout |
+| **5** | **Decision Divergence Evidence** | **NEW** | References notebook 55; summarizes key findings |
+| 6 | Interpretation | Revise | Currently §4; update to reference new evidence sections |
+| 7 | Impact & Decisions | Keep as-is | Currently §5 |
+| 8 | Arc Context | Keep as-is | Currently §6 |
+| 9 | Provenance | Keep as-is | Currently §7 |
+| 10 | Reproduction | Keep as-is | Currently §8 |
+
+#### D1-a. New §3: Architecture Comparison (hybrid_olsa vs olsa)
+
+**Purpose:** Make the ablation self-contained — the reader fully understands the
+independent variable before seeing outcomes.
+
+**Two subsections:**
+
+**A. Bid/Pass Decision Mechanism (Gaussian EV wrapper)**
+- Mechanics: Both bidders share identical OLS coefficients (`hybrid_r0.json`).
+  OLS predicts mu (expected tricks). Difference is the decision layer:
+  - hybrid_olsa: models full distribution via residual variance (sigma).
+    P(make) = P(tricks >= bid) via normal CDF. Bids if EV > 0.
+  - olsa: bids if mu >= bid - margin (floor-based). No distributional model.
+- Benefits: accounts for prediction uncertainty, principled EV threshold (not
+  hand-tuned margin), adapts per-contract via differing residual variance.
+- Drawbacks: Gaussian assumption on discrete/bounded [0,10] data. Global sigma
+  per contract (no heteroscedasticity). Misestimating sigma has directional
+  consequences (overestimate → excessive passivity, observed at 16.2% competitive
+  bid rate).
+
+**B. Risk Quantification (analytical CVaR)**
+- Mechanics: Gaussian model enables analytical CVaR-5% from left tail
+  (mu - sigma * phi(z_0.05) / 0.05). Per-hand downside risk before play.
+  Floor-based olsa can only measure CVaR empirically from realized outcomes.
+- Benefits: risk-aware bid decisions pre-play, penalizes high-variance hands
+  even when EV is positive, relevant given asymmetric set penalties.
+- Drawbacks: inherits Gaussian assumptions, likely underestimates tail risk
+  near boundaries, doesn't account for opponent strategy or trick dynamics.
+
+#### D1-b. Expand §4 (new numbering) Results
+
+Three additions to the results section:
+
+1. **Distributional detail** — add to existing results tables:
+   - Spread metrics: std, IQR, P5/P95 per matchup
+   - Win/draw/loss breakdown per matchup
+   - Contract-type faceting on all delta distributions
+
+2. **Team0/team1 breakout** — all matchup summary tables must show team0 and
+   team1 separately, not collapsed into a single matchup row. (Repo-wide
+   convention, now in MEMORY.md Key Rules.)
+
+3. **Bid rate clarification** — in the behavioral profile table:
+   - Add formula: `bid_rate = hands_with_bids / deals_total` (from `evaluator.py:326`)
+   - Clarify this is competitive (H2H) bid rate, not intrinsic bid rate
+   - Show intrinsic bid rate from comparator runs alongside (~63-83%) so the
+     reader sees the interaction effect
+
+#### D1-c. New §5: Decision Divergence Evidence
+
+Summarizes findings from notebook D3 (55_c33_ablation_deep_dive). Should include:
+- Reference to the EV distribution charts (5a)
+- Decision divergence counts table (5b)
+- Worked example hand summary (5c)
+- Narrative connecting evidence to the "selective restraint" interpretation
+
+---
+
+### D2. Violin plot addition to `notebooks/arc_d/r0/50_r0_matchups.py`
+
+**Scope:** ~10-15 lines. matplotlib already imported, per-deal data already loaded.
+
+**Change:** Add a 4-panel violin plot of per-deal net_eppd_delta for all 4
+matchups. Self-play violins (centered on zero) serve as visual null reference;
+cross-matchup violins show the distributional shift. Faceted by contract_type.
+
+Referenced from the ablation report's results section.
+
+---
+
+### D3. New notebook: `notebooks/arc_d/r0/55_c33_ablation_deep_dive.py`
+
+**Purpose:** Produces all evidence for the "selective restraint" claim. R0-only,
+does not persist to other rungs. Keeps `50_r0_matchups.py` focused on competitive
+ranking; this notebook goes deep on *how and why* the wrapper works.
+
+**Sections:**
+
+**S1: Setup & data loading**
+- Load C33 ablation run data (40k deals)
+- Load model artifact (`hybrid_r0.json`) for replay
+
+**S2: Decision replay**
+- For each deal in the cross-matchups, replay through both decision layers
+  (Gaussian EV wrapper and floor-based threshold) to capture per-hand:
+  mu, sigma, P(make), EV, bid/pass decision
+- This may require checking whether eval logs already capture these traces
+  or if hands must be replayed through the model artifact
+
+**S3: Aggregate EV distribution (note 5a)**
+- **Overlaid histograms** (faceted by contract_type): X = EV of bid decision,
+  two distributions (olsa vs hybrid_olsa). Shows olsa's negative-EV tail that
+  hybrid_olsa truncates.
+- **2x2 decision scatterplot** (faceted by contract_type): X = olsa's predicted
+  EV, Y = hybrid_olsa's P(make). Color by decision outcome (both bid, both pass,
+  olsa-only bid, hybrid-only bid). Shows decision boundary geometrically.
+
+**S4: Decision divergence table (note 5b)**
+- Counts: both bid / both pass / olsa-only bid / hybrid-only bid
+- Per-category: mean EV, mean tricks_won, mean net_eppd
+- Expected: "olsa-only bid" (restraint zone) dominates divergence and has
+  negative or marginal EV
+
+**S5: Worked example hand (note 5c)**
+- 1 illustrative deal from the restraint zone (olsa bids, hybrid passes)
+- Show: hand features, mu, sigma, P(make), EV calculation step-by-step
+- Show actual outcome (did olsa make or get set?) to close the narrative
+
+**S6: Summary**
+- Key counts and findings for reference from the ablation report
+
+---
+
+## Dependencies
+
+```
+D3 (new notebook) ──produces evidence──> D1-c (new report section §5)
+D2 (violin in 50_) ──referenced by────> D1-b (report results §4)
+D1-a (architecture section) ────────────> no dependency, can go first
+D1-b (results expansion) ──────────────> partially depends on D2, D3
+```
+
+**Suggested execution order:**
+1. D1-a (architecture section) — standalone, no data dependency
+2. D3 (new notebook) — data exploration, produces evidence
+3. D2 (violin plot in 50_) — small addition
+4. D1-b + D1-c (results expansion + evidence summary) — references D2 and D3
+5. D1 final pass — renumber sections, update cross-references, revise interpretation
+
+---
+
+## Open Questions (resolve before planning)
+
+1. **Decision trace data:** Do the existing C33 ablation eval logs capture
+   per-hand mu/sigma/P(make)/EV, or will the notebook need to replay hands
+   through the model artifact? Check JSONL log schema and the bidding policy's
+   logging behavior.
+
+2. **EV formula confirmation:** Verify the exact EV formula used by the Gaussian
+   wrapper in `src/bid_euchre/strategy/bidding.py` — need the precise
+   reward/penalty terms to compute EV for the histograms.
+
+3. **Bid rate in comparator context:** The intrinsic bid rate numbers (~62.5%
+   and ~82.8%) appear in different reports. Confirm which run/seed/context
+   produced each number for accurate citation.
+
+---
+
+## Conventions to Follow
+
+- **Contract-type faceting:** ALL charts and tables MUST be faceted by
+  contract_type or justify pooling
+- **Matchup team breakout:** ALL matchup summary tables MUST show team0 and
+  team1 separately
+- **Bid rate clarity:** Always distinguish competitive (H2H) bid rate from
+  intrinsic (comparator/self-play) bid rate
+- **Jupytext:** Edit .py files, not .ipynb. Use `jupytext --sync` for pairing.
+- **Notebook naming:** 55_ prefix slots between existing 50_ (matchups) and
+  any future 60_ notebooks

--- a/plans/comparator_dual_track_plan.md
+++ b/plans/comparator_dual_track_plan.md
@@ -1,0 +1,375 @@
+# Comparator Dual-Track & Roster Meta-Analysis Plan
+
+> **Status:** Plan — ready for review.
+> **Date:** 2026-02-28
+> **Depends on:** PR-C2 (v3 battery complete), Wave 1 bugfixes (#463, #464, #465 merged)
+> **Context:** Discussion session analyzing comparator vs H2H relationship, context
+> feature readiness, and reporting enhancements.
+
+---
+
+## Background
+
+### Key Findings from Analysis Session
+
+1. **The old comparator (v1/v2) and H2H self-play diagonal were mechanically
+   identical.** Both put the same bidding policy in all 4 seats with a sequential
+   auction. The only difference was metric extraction: the comparator computed
+   absolute net_eppd, the H2H computed team deltas (≈0 for self-play).
+
+2. **Single-seat mode (#464) was the actual innovation.** It replaced the 4-way
+   auction with 1-bidder + 3-always_pass, giving every bid decision a direct
+   outcome with no survivorship bias.
+
+3. **The two instruments measure fundamentally different things:**
+
+   | | Single-Seat Comparator | H2H Battery |
+   |---|---|---|
+   | Measures | Individual bid decision quality | Game performance (bid + defend) |
+   | Every decision evaluated? | Yes | Only auction winner's |
+   | Survivorship bias? | None | Yes — losing bids unobserved |
+   | Context features work? | No (always_pass neighbors) | Yes (real auction dynamics) |
+   | Absolute ranking? | Yes (net_eppd) | Not currently extracted (only deltas) |
+
+4. **No third instrument needed.** The contextual comparator proposal was
+   evaluated and deferred — the H2H cross-cells already provide context
+   robustness signal when sliced by opponent archetype. A dedicated contextual
+   comparator would become relevant at R2+ when bidders actually consume context
+   features; building it now would require committing to archetype choices before
+   we know which contexts differentiate good bidders from bad ones.
+
+5. **The H2H battery data is stale.** Generated 2026-02-26, before bugfix PRs
+   #463/#464/#465 merged on 2026-02-27.
+
+6. **The H2H parser doesn't extract absolute net_eppd.** `_compute_team_points()`
+   returns absolute `(t0_pts, t1_pts)` but the parser immediately collapses to
+   `delta = t0_pts - t1_pts`. The field `net_eppd_a` is misleadingly named — it
+   is the delta, not an absolute per-team metric.
+
+### Design Decisions
+
+- **Dual-track evaluation:** Always report both single-seat (decision quality)
+  and H2H self-play absolute (game performance). Neither substitutes for the
+  other.
+- **Archetype segmentation:** Tag bidders by behavioral archetype
+  (AGGRESSIVE/NEUTRAL/SELECTIVE) derived from bid_rate × make_rate. Slice H2H
+  cross-cells by opponent archetype for context robustness signal.
+- **Roster meta-analysis:** Scatter plots decomposing rankings into behavioral
+  components (selectivity, accuracy, efficiency).
+- **Context features deferred to R2:** `BiddingObservation.auction_transcript`
+  is the prerequisite; no context-aware bidders exist at R0-R1.
+
+---
+
+## Work Items
+
+### W1. C2b — Comparator Report Updates
+
+**Scope:** Consume v3 single-seat artifacts (already produced by PR-C2) to
+update existing reports.
+
+**Files to modify:**
+- `docs/04_reports/r0/comparator_rankings.md` — v3 numbers, methodology note
+- `docs/04_reports/r0/h2h_battery_analysis.md` — Remove §3 duplication, fix
+  terminology, update v2 provenance
+- `docs/04_reports/r0/r0_promotion_report.md` — Update comparator context table
+- `docs/04_reports/r0/model_arc_r0_20260224.md` — Update 5-bidder → 7-bidder v3
+- `docs/04_reports/r0/measurement_integrity_r0.md` — Update to reflect GluttonStrategy
+  as canonical comparator play strategy (post-C2c/#466 state)
+
+**Artifacts consumed:**
+- `data/artifacts/arc_d/r0/comparator_battery_r0_v3.json`
+- `data/artifacts/arc_d/r0/comparator_cis_r0_v3.json`
+
+**Blockers:** None — artifacts exist.
+
+---
+
+### W2. Rerun H2H Battery Post-Bugfix
+
+**Scope:** Run-only. Existing H2H data predates #463/#464/#465. Rerun with
+corrected bidders.
+
+**Command:**
+```bash
+PYTHONPATH=src .venv/bin/python scripts/internal/run_arc_d_h2h_battery.py \
+    --mode QUICK --seed 42 --n-per 2000 \
+    --output data/artifacts/arc_d/r0/h2h_battery_quick_v2.json
+
+# Then FULL subset:
+PYTHONPATH=src .venv/bin/python scripts/internal/run_arc_d_h2h_battery.py \
+    --mode FULL --seed 42 --n-per 10000 \
+    --quick-summary data/artifacts/arc_d/r0/h2h_battery_quick_v2.json \
+    --output data/artifacts/arc_d/r0/h2h_battery_full_v2.json
+```
+
+**Expected:** 49 matchups (QUICK), subset at higher N (FULL). Same 7 bidders.
+
+**Artifacts produced (NOT committed):**
+- `data/artifacts/arc_d/r0/h2h_battery_quick_v2.json`
+- `data/artifacts/arc_d/r0/h2h_battery_full_v2.json`
+
+**Validation:**
+- All 49 cells populated (QUICK)
+- Self-play diagonal deltas ≈ 0 (sanity)
+- Behavioral shifts consistent with bugfixes (ModeloEspecifico, RanktheTank, OLSa)
+
+**Blockers:** None — run-only, no code changes.
+
+---
+
+### W3. Extract Absolute Per-Team net_eppd from H2H
+
+**Scope:** Code change to `scripts/internal/run_arc_d_h2h_battery.py` parser.
+
+**Problem:** `_compute_team_points()` returns absolute `(t0_pts, t1_pts)` but
+the parser at lines 519-520 immediately collapses:
+```python
+t0_pts, t1_pts = _compute_team_points(rec)
+delta = t0_pts - t1_pts   # absolute values discarded
+```
+
+**Change:** Accumulate absolute per-team totals alongside deltas:
+```python
+t0_pts, t1_pts = _compute_team_points(rec)
+delta = t0_pts - t1_pts
+deltas.append(delta)
+team0_points_abs.append(t0_pts)   # NEW
+team1_points_abs.append(t1_pts)   # NEW
+```
+
+Then add to cell output:
+```python
+cell["abs_net_eppd_team0"] = round(float(np.mean(team0_points_abs)), 6)
+cell["abs_net_eppd_team1"] = round(float(np.mean(team1_points_abs)), 6)
+```
+
+For self-play cells, both teams use the same bidder, so
+`(abs_team0 + abs_team1) / 2` gives the bidder's absolute net_eppd under full
+auction dynamics.
+
+**Files to modify:**
+- `scripts/internal/run_arc_d_h2h_battery.py` — parser section (~10 lines)
+
+**Tests:**
+- Verify `abs_net_eppd_team0 - abs_net_eppd_team1 ≈ net_eppd_delta` (consistency)
+- Self-play: `abs_team0 ≈ abs_team1` (symmetry)
+
+**Blockers:** None (but logically pairs with W2).
+
+---
+
+### W4. Self-Play Absolute Ranking Extraction
+
+**Scope:** New extraction path that reads H2H self-play cells and produces a
+rankings artifact parallel to the single-seat one.
+
+**Output format:** Same schema as `comparator_cis_r0_v3.json` but sourced from
+H2H self-play. Per bidder:
+- `abs_net_eppd` (average of team0 + team1 absolute from W3)
+- `bid_rate`, `make_rate` (already in H2H cells as `bid_rate_a`/`bid_rate_b`)
+- `cvar_5` (already extracted)
+- Bootstrap CIs on absolute metric
+
+**Implementation options:**
+- Extend `extract_comparator_cis.py` with `--source h2h-self-play` flag, or
+- Add extraction logic to `run_arc_d_h2h_battery.py` summary output
+
+**Files to modify:** TBD based on approach choice.
+
+**Depends on:** W3 (absolute metrics in H2H cells).
+
+---
+
+### W5. Extend BiddingObservation with auction_transcript
+
+**Scope:** Foundation for R2 context features. No bidders consume it yet.
+
+**Change to `src/bid_euchre/strategy/bidding.py`:**
+```python
+@dataclass(frozen=True)
+class BiddingObservation:
+    hand: List[Card]
+    seat: int
+    dealer_seat: int
+    current_high_bid: int
+    auction_transcript: Tuple[dict, ...] = ()  # NEW: prior actions in bid order
+    allowed_contracts: Tuple[str, ...] = (...)
+```
+
+**Change to `src/bid_euchre/sim/simulation.py`:**
+In the auction loop (lines 122-182 for seat_bidding_policies path, lines
+189-203 for single-policy path), pass accumulated `_transcript` entries into
+each `BiddingObservation`:
+```python
+obs = BiddingObservation(
+    hand=starting_hands[player_idx],
+    seat=player_idx,
+    dealer_seat=dealer_index,
+    current_high_bid=current_high_bid,
+    auction_transcript=tuple(_transcript),  # NEW
+)
+```
+
+**Backward compatible:** Default `()` means existing bidders ignore it.
+
+**Files to modify:**
+- `src/bid_euchre/strategy/bidding.py` — dataclass field
+- `src/bid_euchre/sim/simulation.py` — pass transcript in both auction paths
+
+**Tests:**
+- Existing tests pass unchanged (default `()`)
+- New test: verify transcript accumulates correctly across seats
+
+**Blockers:** None — independent of all other items.
+
+---
+
+### W6. Dual-Track Comparator Report
+
+**Scope:** Present both ranking tracks side-by-side in the comparator report.
+
+**Content:**
+- Single-seat rankings (decision quality track) — from v3 artifacts
+- H2H self-play absolute rankings (game performance track) — from W3/W4
+- Agreement/disagreement analysis between tracks
+- Documentation of what each track measures and why both matter
+
+**Depends on:** W1, W2, W3, W4.
+
+---
+
+### W6b. Archetype-Segmented H2H Performance Summary
+
+**Scope:** Tag bidders by behavioral archetype and slice H2H cross-cells.
+
+**Archetype definitions (derived from bid_rate × make_rate):**
+
+| Category | Criterion | R0 Bidders |
+|---|---|---|
+| AGGRESSIVE | bid_rate=1.0 AND make_rate < 0.6 | fiveheadfred, rankthetank |
+| SELECTIVE | bid_rate < 1.0 | hybrid_olsa, modeloespecifico |
+| NEUTRAL | bid_rate=1.0 AND make_rate ≥ 0.6 | stricthellraiser, olsa, olsa_full |
+
+**Implementation:**
+- Add `archetype` field to bidder roster config or a lookup dict in the report
+  extractor
+- Group H2H cross-cell deltas by opponent archetype
+- Per-bidder summary table: mean delta vs AGGRESSIVE / NEUTRAL / SELECTIVE
+
+**Output example:**
+```
+Bidder              vs AGGRESSIVE    vs NEUTRAL    vs SELECTIVE
+hybrid_olsa            +2.17           +0.58            —
+modeloespecifico       +1.82           -0.03          +0.64
+...
+```
+
+**Files to modify:**
+- H2H report extractor or report template (TBD)
+- Bidder roster config (add archetype tags)
+
+**Depends on:** W2 (post-bugfix H2H data).
+
+---
+
+### W6c. Bidder Roster Meta-Analysis Scatter Plots
+
+**Scope:** Three scatter plots decomposing the rankings into behavioral
+components.
+
+**Plot 1: bid_rate × make_rate (Calibration)**
+- X: bid_rate (selectivity), Y: make_rate (accuracy)
+- Shows who is overbidding (high bid_rate, low make_rate) vs well-calibrated
+- A "perfect" bidder would be top-left (selective) or top-right (bids often,
+  still makes)
+
+**Plot 2: bid_rate × net_eppd (Efficiency)**
+- X: bid_rate, Y: net_eppd
+- Shows the payoff curve of selectivity
+- Key question: is it better to bid rarely and make most, or bid always and
+  accept sets?
+- The efficient frontier would be visible
+
+**Plot 3: make_rate × net_eppd (Conversion)**
+- X: make_rate, Y: net_eppd
+- Two bidders with same make_rate can have different net_eppd if bid levels
+  differ
+- Shows who converts makes into points efficiently
+
+**For all plots:**
+- Points labeled by bidder name
+- Colored by archetype (AGGRESSIVE=red, NEUTRAL=blue, SELECTIVE=green)
+- Tracked longitudinally across rungs (R0, R1, R2, ...)
+
+**Data source:** Single-seat comparator artifacts (v3 for R0) — absolute
+metrics, every bid evaluated, no survivorship filtering.
+
+**Files to create/modify:**
+- New visualization in `src/bid_euchre/diagnostics/` or a notebook in
+  `notebooks/arc_d/`
+- Report template update to embed or reference plots
+
+**Depends on:** v3 artifacts exist (PR-C2 complete). Can be done independently
+of W2-W4.
+
+---
+
+## Dependency Graph
+
+```
+W1 (C2b report)        ─── no blockers, uses existing v3 artifacts
+W2 (H2H rerun)         ─── no blockers, run-only
+W5 (auction_transcript) ── no blockers, independent foundation
+
+W3 (absolute extraction) ─ logically pairs with W2 but no hard dependency
+W4 (self-play rankings)  ─ depends on W3
+
+W6 (dual-track report)  ─── depends on W1 + W2 + W3 + W4
+W6b (archetype summary)  ── depends on W2
+W6c (scatter plots)      ── depends on v3 artifacts (already exist)
+```
+
+**Parallelism opportunities:**
+- W1, W2, W5, W6c can all proceed in parallel immediately
+- W3 can start immediately (code change) and be validated against W2 output
+- W4 depends on W3
+- W6 and W6b are the final integration steps
+
+---
+
+## Scope Boundaries
+
+**In scope:**
+- Report updates consuming existing v3 artifacts (W1)
+- H2H battery rerun with post-bugfix bidders (W2)
+- H2H parser enhancement for absolute metrics (W3)
+- Self-play absolute ranking extraction (W4)
+- BiddingObservation.auction_transcript foundation (W5)
+- Dual-track report format with archetype segmentation and scatter plots (W6/6b/6c)
+
+**Deferred to R2:**
+- Context-aware bidder implementation (consumes auction_transcript)
+- Contextual comparator instrument (reassess when context features exist)
+- Context feature ablation analysis (single-seat vs self-play delta)
+
+**Deferred to later:**
+- Contract-type faceted breakdowns (notebook 45_comparator_deep_dive.py)
+- 4-way sensitivity panel comparison
+- Promotion gate changes based on dual-track rankings
+
+---
+
+## PR Structure (Tentative)
+
+| PR | Work Items | Type | Blockers |
+|----|-----------|------|----------|
+| C2b | W1 | Report edits | None |
+| C3 | W2 | Run-only | None |
+| C4 | W3 + W4 | Code + extraction | W2 for validation |
+| C5 | W5 | Code (foundation) | None |
+| C6 | W6 + W6b + W6c | Report + viz | C2b, C3, C4 |
+
+One concept per PR. C2b and C3 can proceed in parallel. C5 is independent.
+C4 needs C3 data for validation but code can be written first. C6 is the
+integration PR that ties everything together.

--- a/plans/comparator_experiment_redesign.md
+++ b/plans/comparator_experiment_redesign.md
@@ -1,0 +1,398 @@
+# Comparator Experiment Redesign: Single-Seat Evaluation
+
+> **Status:** Review notes — ready for external agent review and plan development.
+> **Scope:** Comparator battery experimental design. R0 re-run + methodology
+> change. Does NOT cover report quality improvements (see
+> `plans/comparator_rankings_review_notes.md` for report-level changes).
+> **Relationship to report:** The report improvements (Notes 1-10 in review
+> notes) can proceed in parallel on existing data. This redesign would produce
+> new data that the report then consumes. The two workstreams merge when the
+> report is updated with new numbers.
+
+---
+
+## Problem Statement
+
+The current comparator battery runs a 4-way self-auction where all 4 seats use
+the same bidding policy. This design produces three interpretive artifacts that
+complicate what should be a simple "how good is this policy?" measurement:
+
+1. **Best-of-4 selection effect** — the auction winner always has the strongest
+   hand at the table, inflating make_rate and net_eppd
+2. **LOD positional bias** — the first bidder bids against `current_high_bid=0`
+   while the dealer must beat all previous bids
+3. **bid_rate conflation** — reported bid_rate reflects "probability at least 1
+   of 4 seats bids," not the policy's per-hand selectivity
+
+These artifacts don't invalidate the rank ordering (all policies face the same
+design), but they make absolute metrics (net_eppd, bid_rate, make_rate) harder
+to interpret and not directly comparable to H2H metrics.
+
+---
+
+## Current Design: How It Works
+
+### Code path
+
+1. `scripts/internal/run_auction_comparator.py` runs each bidder individually.
+   For each bidder, it creates a per-policy config and calls the experiment
+   runner.
+
+2. The runner calls `simulate_many_hands()` with `bidding_policy=policy`
+   (singular, not per-seat).
+
+3. In `src/bid_euchre/sim/simulation.py` `play_single_hand()` (line 189-203),
+   when a singular `bidding_policy` is provided, ALL 4 seats call
+   `bidding_policy.choose_bid()` with their own hand and the current auction
+   state.
+
+4. The auction is sequential (LOD order: left of dealer → clockwise → dealer).
+   Each bid must be **strictly** greater than `current_high_bid`. Both the
+   policies themselves and the simulation enforce this:
+   - `OLSaBidder.choose_bid()` line 741: `bid_n > obs.current_high_bid`
+   - `HybridOLSaBidder.choose_bid()` line 1014: `bid_n <= obs.current_high_bid: continue`
+   - Simulation line 160-161: `bid_action.n <= current_high_bid` → treated as pass
+
+5. Dealer position is pseudo-random per deal: `Random(deal_seed + deal_id)`
+   (line 109).
+
+6. GluttonStrategy handles all card play for all 4 seats.
+
+### Metric computation
+
+The extraction script (`scripts/internal/extract_comparator_cis.py`) computes:
+- `net_eppd = sum(declaring_pts - defending_pts) / total_deals`
+- Always from the **declaring team's perspective**
+- Pass deals (all 4 seats pass) contribute 0 to numerator, 1 to denominator
+
+This means net_eppd is NOT zero-centered in self-play. Declaring is
+structurally advantageous when you make your bid: net = `2 * tricks - 10`.
+A policy that makes 90% of bids (modeloespecifico) gets +2.291 net_eppd.
+A policy that overbids (stricthellraiser) gets -6.114. Both are self-play.
+
+### Positional bias example
+
+With identical OLSa policies on all 4 seats:
+- Seat 1 (LOD): predicts `floor(mu) = 6`, sees `current_high_bid=0` → **bids 6**
+- Seat 3: predicts `floor(mu) = 6`, sees `current_high_bid=6` → 6 is not > 6 →
+  **forced to pass**
+
+Two equally good hands get different outcomes based solely on auction position.
+
+### bid_rate interpretation
+
+- hybrid_olsa bid_rate = 62.5% means: on 62.5% of deals, **at least 1 of 4
+  seats** had a hand good enough to bid. The per-hand selectivity rate is
+  lower.
+- For always-bid policies: bid_rate = 100% because at least 1 seat always bids
+  (4 chances).
+
+---
+
+## Proposed Design: Single-Seat Evaluation
+
+For each deal, randomly select 1 seat. That seat evaluates its hand with
+`current_high_bid=0` and either bids its best contract or passes. If it bids,
+play the hand with GluttonStrategy (all 4 seats). If it passes, count as a
+pass deal (numerator += 0, denominator += 1).
+
+### Pros
+
+1. **Cleaner intrinsic measurement.** Directly answers "given a random hand,
+   how well does this policy bid?" No best-of-4 inflation.
+
+2. **No positional bias.** Every hand is evaluated with `current_high_bid=0`.
+   No LOD advantage, no dealer disadvantage.
+
+3. **bid_rate is directly interpretable.** Measures the policy's per-hand
+   selectivity. hybrid_olsa's bid_rate would report how often the policy bids
+   on an average hand, not the compound probability across 4 seats.
+
+4. **Simpler to explain.** "Each bidder evaluates 10,000 random hands" vs
+   "Each bidder runs a 4-way self-auction on each deal."
+
+5. **Cheaper to run.** 1 policy evaluation per deal instead of 4.
+
+6. **net_eppd interpretation improves.** Still measured from declarer's
+   perspective (positive = profitable contracts), but without best-of-4
+   inflation. Makes absolute values more meaningful for cross-rung tracking.
+
+### Cons
+
+1. **Higher pass rate → fewer bid-hands → wider CIs.** For selective bidders
+   like hybrid_olsa, the per-hand pass rate will be much higher than the
+   current best-of-4 rate. Fewer bid-hands means wider CIs on make_rate and
+   CVaR. **Mitigation:** Increase deal count (e.g., 20k or 50k instead of
+   10k). Compute is cheap.
+
+2. **Rankings might shift.** The best-of-4 effect could differentially benefit
+   some policies. If rankings change, downstream reports need updating.
+   **Counter:** If rankings change, the current ones are misleading — better
+   to know.
+
+3. **Doesn't test `current_high_bid` interaction.** Future policies with
+   opponent modeling may behave differently based on auction context. Single-
+   seat with `current_high_bid=0` doesn't test this. **Counter:** The current
+   4-way design doesn't test this either — all 4 seats use the same policy,
+   so there's no meaningful strategic interaction. H2H is the right place to
+   test auction dynamics.
+
+4. **Less "realistic."** In a real game, you face an auction. **Counter:**
+   The 4-way self-auction isn't realistic either — real opponents use different
+   policies. Neither design simulates a real auction; single-seat is at least
+   honest about what it measures.
+
+---
+
+## Why R0 Is the Ideal Time
+
+1. **No backward compatibility cost.** R0 is rung zero — there's no prior
+   rung to crosswalk against. At R1+, we'd need dual runs to maintain
+   comparability.
+
+2. **R1 hasn't started.** The R0→R1 transition is complete but no R1
+   experiments have run. Cleanest possible transition point.
+
+3. **Compute is cheap.** 7 bidders × 10-50k deals = minutes of wall time.
+
+4. **Reports need updates anyway.** The comparator rankings report has 10
+   improvement notes pending. Changing the underlying numbers is incremental.
+
+---
+
+## What's NOT Affected
+
+Regardless of which comparator design is used:
+
+- **H2H battery** is unaffected (separate design, separate data)
+- **Gate thresholds** are calibrated from H2H null signal, not comparator
+- **C33 ablation** uses H2H matchups, not comparator
+- **Promotion decisions** use H2H + semantic gate, not comparator rankings
+- **Pairwise significance** tests are valid within any consistent methodology
+
+The comparator is used for *absolute benchmarking* and *progress tracking*, not
+for promotion decisions. Changing its design doesn't affect the gate.
+
+---
+
+## Pre-Requisite Fixes (before re-running)
+
+### Fix A: Remove ModeloEspecifico bid ceiling
+
+`ModeloEspecifico.choose_bid()` (bidding.py lines 438, 445, 452) caps bids at
+`<= 6`. The game rules allow bids 1-10 (RULES.md §3.2, line 111). OLSaBidder
+and HybridOLSaBidder correctly use `<= 10`. The `<= 6` cap has no documented
+rationale — it was present from the initial implementation (PR #154) and was
+never revisited.
+
+**Effect of the bug:** Hands scoring > 6 in the formula (e.g., 2 bowers + 6
+trump + 2 offsuit aces = 7.0) get **no bid at all** in that contract type,
+rather than bidding 6. This silently suppresses strong hands and artificially
+deflates bid_rate while inflating make_rate.
+
+**Fix:** Change `<= 6` to `<= 10` on all three guard lines (suit, HIGH, LOW).
+The formula's practical maximum for suit is ~9 (4 bowers + 10 trump + 0 aces),
+so bids of 7-9 become possible for very strong hands.
+
+**Impact on comparator results:** ModeloEspecifico's bid_rate may increase
+slightly (more hands qualify) and its net_eppd could change. Rankings may shift.
+This is a correctness fix — the current results are based on a bugged bidder.
+
+### Fix B: Remove bid floor from OLSa-family bidders
+
+OLSaBidder (line 741) and HybridOLSaBidder use `3 <= bid_n` as a minimum bid.
+The game rules (RULES.md §3.2, line 115) explicitly state: "the first non-pass
+bid may be as low as **1**." There is no documented rationale for the `>= 3`
+floor.
+
+For OLSaBidder, if the model predicts `mu = 1.7`, flooring to `bid_n = 1` is
+a legal bid that reflects the model's assessment. Whether it's profitable is
+the model's problem, not the guard clause's.
+
+For HybridOLSaBidder, the `>= 3` floor is even less defensible: the Gaussian
+EV wrapper already gates on `EV > 0`. If the model says bidding 1 is positive
+EV, the floor overrides that judgment.
+
+**Fix:** Change `3 <= bid_n <= 10` to `1 <= bid_n <= 10` in OLSaBidder and
+HybridOLSaBidder. For heuristic bidders (ModeloEspecifico, RanktheTank, etc.),
+the `>= 3` floor may be an intentional design choice since their formulas are
+hand-tuned — leave as-is but document the rationale in their docstrings.
+
+**Impact:** Likely minimal for trained models (OLS predictions of < 3 are
+rare for hands worth bidding), but removes an artificial constraint that could
+mask model behavior at the margins.
+
+### Fix C: Recalibrate RanktheTank thresholds from empirical data
+
+RanktheTank uses `score_hand_scalar()` (exposed as `hand_value` in the feature
+set) with fixed thresholds to map strength → bid level:
+- Suit: 200→3, 250→4, 300→5, 350→6 (max bid 6, range covers ~200-350 of a
+  100-1000 scale)
+- HIGH/LOW: 20→3, 30→4, 40→5 (max bid 5)
+
+**Two bugs:**
+1. **Suit ceiling at 6.** The threshold table only goes up to 350→6. Hands
+   scoring 400-1000 still bid 6. Bids of 7-10 are unreachable.
+2. **HIGH/LOW thresholds are miscalibrated.** `score_hand_scalar` for HIGH/LOW
+   returns 100-500 (10 cards × 10-50 per card). The thresholds (20, 30, 40)
+   are far below the minimum possible score of 100. Every hand that gets
+   evaluated for HIGH/LOW hits the top threshold (40) and bids 5. The
+   `elif` and `else` branches are dead code.
+
+**Fix: Derive thresholds empirically from the canonical bidless dataset.**
+
+**Data source:** `canonical_bidless_dataset_glutton_42_20260221_175752`
+- ~1.2M rows (50k deals × 4 seats × 6 scenarios)
+- Each row has `hand_value` (= `score_hand_scalar`), `contract_type`, `seat`
+- Outcomes dataset has `tricks_team0`/`tricks_team1` per `hand_id`
+- Join: seats 0,2 → `tricks_team0`, seats 1,3 → `tricks_team1`
+
+**Approach:**
+1. Join features + outcomes on `hand_id` to get per-seat `tricks_won`.
+2. For each contract type (suit, high, low), compute `hand_value` →
+   `mean(tricks_won)` empirically.
+3. Set threshold for bid level N = the `hand_value` where
+   `mean(tricks_won) ≈ N`. This produces a mapping grounded in actual
+   trick-taking outcomes under Glutton play (the same play policy used in
+   the comparator).
+4. If the mapping doesn't cover all bid levels (e.g., no hands have
+   `mean(tricks_won) ≈ 1`), that's fine — those thresholds just produce
+   very low bids on very weak hands, which is the correct behavior.
+
+**Why Glutton play is the right reference:** The comparator battery uses
+Glutton (or Greedy) for all card play. Calibrating thresholds against tricks
+won under the same play policy ensures the bid level approximates actual
+expected tricks in the comparator context.
+
+**Deliverable:** A small calibration script or notebook cell that reads the
+bidless parquet, computes the threshold table, and outputs the values to
+hard-code into `RanktheTank.choose_bid()`. The thresholds are static —
+they don't need to be computed at runtime.
+
+**Also fix:**
+- HIGH/LOW mutual exclusion (line 368/383): evaluate BOTH and pick the
+  higher-scoring contract, rather than choosing based on card count alone.
+- Update `score_hand_scalar` docstring ("not used for bidding" is stale).
+
+---
+
+## Implementation Path
+
+### Step 1: Fix ModeloEspecifico bid ceiling (Fix A above)
+
+### Step 1b: Recalibrate RanktheTank thresholds (Fix C above)
+
+### Step 2: Modify comparator runner
+
+Add single-seat mode to `scripts/internal/run_auction_comparator.py` (or
+create a new script). Key change in the simulation call:
+
+- Instead of `bidding_policy=policy` (all 4 seats), pass
+  `bidding_policies=[policy, None, None, None]` with a randomly selected
+  seat, or add a new parameter to `simulate_many_hands`.
+- Alternatively, call `play_single_hand` directly with a wrapper that
+  assigns the policy to one random seat per deal and uses a pass-always
+  policy for the other 3.
+
+**Design decision needed:** How to handle the non-bidding seats. Options:
+- A. Only 1 seat has the policy; other 3 always pass → the selected seat
+  always wins the auction if it bids (true single-seat, simplest)
+- B. Use `play_single_hand` with a custom "single evaluator" mode that
+  bypasses the auction entirely → cleaner but requires simulation changes
+
+Recommend Option A — minimal code change, same effect.
+
+### Step 3: Re-run battery
+
+```bash
+# Re-run with single-seat mode (exact flag TBD)
+PYTHONPATH=src uv run python scripts/internal/run_auction_comparator.py \
+  --config experiments/configs/auction_comparator.yaml \
+  --seed 42 --single-seat \
+  --olsa-artifact data/artifacts/arc_d/r0/hybrid_r0.json \
+  --bidder-class HybridOLSaBidder --bidder-name hybrid_olsa
+```
+
+Consider increasing deal count to 20k-50k to compensate for higher pass rates
+(especially for hybrid_olsa).
+
+### Step 4: Re-run extraction
+
+```bash
+PYTHONPATH=src uv run python scripts/internal/extract_comparator_cis.py \
+  --artifacts-dir data/artifacts/arc_d/r0 --runs-dir data/runs --seed 42 \
+  --n-bootstrap 10000 --output data/artifacts/arc_d/r0/comparator_cis_r0_v3.json \
+  --battery-file comparator_battery_r0_v3.json
+```
+
+Note: v3 to distinguish from v2 (current 7-bidder, 4-way auction).
+
+### Step 5: Verify rankings
+
+Compare v2 (4-way) and v3 (single-seat) rankings. Document any rank changes
+and explain why they occurred. This crosswalk is optional but good practice.
+
+### Step 6: Update downstream
+
+- `docs/04_reports/r0/comparator_rankings.md` — new numbers + methodology
+  (merge with Notes 1-10 report improvements)
+- `docs/04_reports/r0/h2h_battery_analysis.md` §3 — update or cross-reference
+- `docs/04_reports/r0/r0_promotion_report.md` — update comparator context
+- `notebooks/arc_d/r0/40_r0_baseline.py` §11 — update comparator charts
+
+---
+
+## Decision: Dual-Mode with Single-Seat Primary (2026-02-26)
+
+**Decided:** Make single-seat the canonical (primary) comparator methodology.
+Retain the 4-way auction as a secondary diagnostic panel.
+
+**Rationale:** Cost and churn are not constraints at R0 (zero backward-
+compatibility cost, reports need updates anyway). The deciding criterion is
+measurement validity: single-seat is the cleaner estimate of intrinsic bidding
+quality per random hand.
+
+**What you give up:** The primary metric no longer reflects behavior under
+contested `current_high_bid` pressure.
+
+**Mitigation:** Run one 4-way battery alongside as an explicit
+"auction-pressure sensitivity" panel. This preserves the signal without
+conflating it with the intrinsic measurement.
+
+**Updated implementation path:**
+1. Implement `--single-seat` mode in the comparator runner.
+2. Re-run all 7 bidders at seed 42 / n=10,000 in single-seat mode and
+   regenerate CIs → this becomes the **primary ranking**.
+3. Also run one 4-way battery as a **sensitivity panel** (existing v2 data
+   may suffice, or re-run for consistency).
+4. Update the report so primary rankings are single-seat and 4-way is
+   explicitly labeled "auction-pressure sensitivity."
+
+---
+
+## Open Questions for Reviewing Agent
+
+1. **Deal count for single-seat mode.** 10k deals may produce too few
+   bid-hands for selective bidders (hybrid_olsa). Should we increase to 20k
+   or 50k? What's the minimum for stable CIs on CVaR-5%?
+
+2. **Non-bidding seat handling.** Option A (3 seats always pass) vs Option B
+   (bypass auction entirely). Is there a reason to prefer one over the other?
+
+3. **v3 artifact naming.** The current battery is v2 (superseded v1's 5-bidder
+   roster). Should the single-seat battery be v3, or a separate artifact name
+   (e.g., `comparator_single_seat_r0.json`)?
+
+---
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `scripts/internal/run_auction_comparator.py` | Comparator orchestrator (modify) |
+| `scripts/internal/extract_comparator_cis.py` | CI extraction (may need minor changes) |
+| `src/bid_euchre/sim/simulation.py` | `play_single_hand` / `simulate_many_hands` |
+| `src/bid_euchre/strategy/bidding.py` | `OLSaBidder`, `HybridOLSaBidder` |
+| `src/bid_euchre/scoring.py` | `compute_points` (scoring formula) |
+| `experiments/configs/auction_comparator.yaml` | Battery config |
+| `docs/04_reports/r0/comparator_rankings.md` | Report (update with new data) |

--- a/plans/comparator_rankings_refactor_plan.md
+++ b/plans/comparator_rankings_refactor_plan.md
@@ -1,0 +1,595 @@
+# Comparator Rankings Report — Refactor Plan
+
+> **Goal:** Refactor `docs/04_reports/r0/comparator_rankings.md` to be
+> self-contained, convention-compliant, and empirically grounded.
+>
+> **Scope:** Report refactor + supporting notebook. No code changes, no
+> experiment runs — this plan assumes all prerequisites are complete.
+>
+> **Source notes:** `plans/comparator_rankings_review_notes.md` (12 notes)
+>
+> **Output:** Refactored report + new notebook `45_comparator_deep_dive.py`
+
+---
+
+## Prerequisites (assumed complete)
+
+Before executing this plan, the following must be done:
+
+1. **Bidder fixes merged** — ModeloEspecifico ceiling removed (`<= 6` → `<= 10`),
+   OLSa-family floor lowered (`3 <=` → `1 <=`), RanktheTank thresholds
+   recalibrated from empirical data. See `plans/comparator_experiment_redesign.md`
+   Fixes A, B, C.
+
+2. **Comparator battery re-run** — Single-seat mode (v3) as primary. 10k+ deals
+   per bidder, seed=42, 10k bootstrap resamples. Artifact at
+   data/artifacts/arc_d/r0/comparator_cis_r0_v3.json.
+
+3. **4-way battery available** — Either re-run for consistency or use existing v2
+   data as the auction-pressure sensitivity panel.
+
+4. **Raw JSONL logs available** — Per-deal game logs in `data/runs/` for each
+   bidder's single-seat run. Required for the notebook's per-deal and
+   per-contract-type analysis.
+
+---
+
+## PR Strategy
+
+**Single PR.** The report refactor and notebook are one concept ("comparator
+rankings v3 report"). The notebook exists solely to support the report with
+charts and faceted data. Splitting them would leave the report with dangling
+cross-references.
+
+**PR title:** `docs: refactor comparator rankings report (v3, single-seat)`
+
+---
+
+## Target Report Structure
+
+The refactored report has 9 sections. This is the authoritative specification —
+each section below includes what it covers, what changed from the current
+report, and acceptance criteria.
+
+---
+
+### Header
+
+```markdown
+# R0 Comparator Rankings (v3, Single-Seat, 7 Bidders)
+
+**Arc:** D (OLSa-Hybrid Bidder)
+**Rung:** R0
+**Date:** <date of v3 battery run>
+**Methodology:** Single-seat evaluation · <N> deals per bidder · seed=42 · 10,000 bootstrap resamples
+```
+
+**Changes:** Update version to v3, add "Single-Seat" to title, update
+methodology one-liner with actual deal count.
+
+---
+
+### §1. Summary
+
+> **Status:** NEW. The current report has no introductory section.
+
+**Purpose:** Make the report self-contained. A reader unfamiliar with Arc D
+should understand what this is, why it was run, and what it tells us before
+hitting any numbers.
+
+**Content (5 paragraphs, ~15 lines total):**
+
+1. **What this is.** A self-play benchmark where each bidder evaluates random
+   hands uncontested (`current_high_bid=0`) and plays declared contracts with
+   GluttonStrategy handling all card play. Measures intrinsic bidding quality
+   in isolation.
+
+2. **Why it's run this way.** Provides an absolute benchmark ("is this model
+   any good?") without requiring O(n²) pairwise matchups. Enables rung-over-rung
+   progress tracking against a fixed reference point.
+
+3. **What it tells us.** Ranks 7 bidders on net_eppd. State the top-line result:
+   which bidder leads, how many tiers emerge, what the dominant differentiator
+   is (selective bidding vs always-bid).
+
+4. **How to use it.** Baseline for rung-over-rung tracking. Self-play rankings
+   can diverge from competitive ordering — use H2H battery for promotion
+   decisions. Cross-reference `h2h_battery_analysis.md`.
+
+5. **Arc context.** Where this fits in the R0 evaluation stack (alongside H2H
+   battery, C33 ablation, and threshold calibration).
+
+**Acceptance criteria:**
+- [ ] A reader with no prior context can understand the report's purpose
+- [ ] Cross-references H2H battery and C33 ablation reports
+- [ ] No numbers — this is framing, not results
+
+---
+
+### §2. Methodology
+
+> **Status:** MOVED from current §5. Expanded for v3 single-seat design.
+
+**Purpose:** Reader understands the experimental design before seeing numbers.
+
+**Subsections:**
+
+#### §2.1 Experimental Design
+
+- Single-seat evaluation (v3): one random seat per deal, `current_high_bid=0`,
+  bid-or-pass. GluttonStrategy handles all card play for all 4 seats.
+- Parameters: deal count, seed, bootstrap config.
+- Key distinction from H2H: no contested auction, no opponent bidding strategy.
+  This measures intrinsic policy quality, not competitive performance.
+
+#### §2.2 Metric Definitions
+
+- **net_eppd:** `sum(declaring_pts − defending_pts) / total_deals`. Pass deals
+  contribute 0 to numerator, 1 to denominator. Positive = the bidder picks
+  profitable contracts on average.
+- **eppd:** `sum(declaring_pts) / total_deals`. Always positive if any bids are
+  made; ignores the opponent's points.
+- **bid_rate:** `hands_with_bids / total_deals`. In single-seat mode, this is
+  the per-hand selectivity rate — the fraction of random hands the policy
+  considers worth bidding on.
+- **make_rate:** `contracts_made / contracts_bid`. Fraction of bid contracts
+  where `tricks_won >= bid_n`.
+- **CVaR-5%:** Mean of the worst 5% of per-hand outcomes (by `bidder_team_points`).
+  A tail-risk metric: lower (more negative) = worse downside.
+
+#### §2.3 Version History
+
+> Merged from current §5a + §5b. Single subsection.
+
+- **v1** (5 bidders, 4-way auction): Initial battery.
+  `hybrid_olsa` referred to OLSa_Full promotional arm.
+- **v2** (7 bidders, 4-way auction): Added `olsa_full` and `olsa` as separate
+  entries. `hybrid_olsa` redefined to constrained arm with Gaussian CDF wrapper.
+- **v3** (7 bidders, single-seat): Current. Replaces 4-way auction with
+  single-seat evaluation. Bidder bug fixes applied (see §6a). Numbers are
+  not directly comparable to v1/v2 due to methodology change.
+
+#### §2.4 What This Methodology Measures (and What It Does Not)
+
+> Preserved from current §5c. The strongest section in the current report.
+
+**Rewrite guidance:** Under v3 single-seat, "uncontested" is now factually
+correct. Rewrite to match:
+
+- **Strengths:** Absolute scale, progress tracking, reproducible exam. Keep
+  current language (it's accurate for v3).
+- **Limitations:**
+  - Confounded by GluttonStrategy (keep as-is).
+  - "No auction interaction" — now accurate. State clearly: single-seat mode
+    with `current_high_bid=0`, no auction mechanics. For auction-pressure
+    analysis, see §8.
+  - Self-play vs competitive divergence (keep as-is, with H2H cross-ref).
+- **Bottom line:** Keep the current closing paragraph.
+
+**Acceptance criteria:**
+- [ ] Every claim about the methodology is factually correct for v3
+- [ ] "Uncontested" language is present AND justified (single-seat, no auction)
+- [ ] bid_rate formula is stated explicitly
+- [ ] Version history covers v1→v2→v3 with bidder identity clarification
+- [ ] Metric definitions match actual computation in extraction script
+
+---
+
+### §3. Rankings Table
+
+> **Status:** EXPANDED from current §1. New columns, footnotes, notebook ref.
+
+**Content:** All 7 bidders ranked by net_eppd descending. Same table structure
+as current but with additions:
+
+**New columns (from review Note 2):**
+- `std` or `IQR` for net_eppd (spread metric)
+
+**New footnotes (from review Note 6):**
+- Explain zero-width CVaR CIs: "Zero-width CVaR CIs indicate that the worst
+  5% of outcomes for these bidders all incur the same set penalty (−bid_n),
+  reflecting their narrow bid-level distribution."
+
+**Notebook reference (from review Note 10):**
+- "See notebook `45_comparator_deep_dive`, Figure 1 for per-deal net_eppd
+  distributions (violin plot)."
+
+**Data source:** v3 single-seat data from
+data/artifacts/arc_d/r0/comparator_cis_r0_v3.json.
+
+**Acceptance criteria:**
+- [ ] All numbers are from v3 single-seat data
+- [ ] At least one spread metric (std or IQR) is included
+- [ ] CVaR footnote explains zero-width CIs
+- [ ] Cross-references notebook violin plot
+- [ ] bid_rate and make_rate have bootstrap 95% CIs (review Note 3)
+
+---
+
+### §4. Rankings by Contract Type
+
+> **Status:** NEW. Satisfies repo-wide contract-type faceting convention.
+
+**Content:** Per-contract-type breakdown table showing net_eppd, bid_rate, and
+make_rate for each bidder, faceted by contract_type (suit / high / low).
+
+**Format:**
+
+```markdown
+| Bidder | Contract | net_eppd [95% CI] | bid_rate | make_rate |
+|--------|----------|-------------------|----------|-----------|
+| modeloespecifico | suit | ... | ... | ... |
+| modeloespecifico | high | ... | ... | ... |
+| modeloespecifico | low  | ... | ... | ... |
+| hybrid_olsa | suit | ... | ... | ... |
+| ... | ... | ... | ... | ... |
+```
+
+**Narrative (2-3 sentences):** Are rankings preserved within each contract type?
+Does hybrid_olsa's selectivity concentrate in certain contract types?
+
+**Data source:** New notebook `45_comparator_deep_dive.py` computes per-contract
+metrics from raw JSONL logs.
+
+**Justification:** If faceted rankings match pooled rankings, state it
+explicitly: "The pooled ranking order is preserved within each contract type."
+If they diverge, explain why.
+
+**Acceptance criteria:**
+- [ ] Table shows all 7 bidders × 3 contract types
+- [ ] Narrative explains whether rankings are preserved or diverge
+- [ ] Data sourced from notebook (not manual computation)
+
+---
+
+### §5. Pairwise Significance
+
+> **Status:** KEEP from current §2. Update numbers only.
+
+**Content:** Bootstrap permutation test results for adjacent-ranked bidders.
+Same format as current.
+
+**Changes:** Update all numbers to v3 single-seat data. Significance levels
+may change; update the narrative accordingly.
+
+**Acceptance criteria:**
+- [ ] All numbers from v3 data
+- [ ] Narrative accurately reflects which pairs are significant
+
+---
+
+### §6. Behavioral Profiles
+
+> **Status:** RESTRUCTURED into §6a and §6b. This is the most substantive
+> change in the refactor.
+
+The current §3 blends description and results in a single narrative per bidder.
+The refactored version separates them to make the reader's mental model explicit:
+first understand what each model IS, then compare predictions to results.
+
+#### §6a. Bidder Descriptions
+
+> What each model IS. Decision logic, algorithm, bid range. Written as if the
+> reader has not seen the results yet.
+
+For each of the 7 bidders, provide:
+
+1. **Algorithm** (1-2 sentences): What class of model, what inputs.
+2. **Decision logic** (2-3 sentences): How it chooses whether/what to bid.
+3. **Bid range**: What bid levels are reachable.
+4. **Expected behavior** (1-2 sentences): What we'd predict about bid_rate,
+   make_rate, and net_eppd before seeing the data.
+
+**Draft sketches for each bidder** (implementing agent should refine based on
+post-fix code):
+
+**modeloespecifico** — Hand-coded feature-weighted formula. Computes a score
+per contract: suit = `1.0*bowers + 0.5*trump_count + 0.5*offsuit_aces`,
+HIGH = `offsuit_aces`, LOW = `offsuit_tens_count`. Score is floored to a bid
+level (1-10). Picks the highest-scoring contract across all candidates.
+*Expected:* High bid_rate (formula is simple, most hands produce a score ≥ 1),
+high make_rate (formula tracks real trick-taking ability from domain expertise).
+
+**hybrid_olsa** — OLS regression (3 constrained features from `hybrid_r0.json`)
+predicts expected tricks (mu). Gaussian CDF wrapper models the full distribution
+via residual variance (sigma) to compute P(make) and expected value (EV). Bids
+only when EV > 0 — the only bidder with an analytical pass threshold. Bid
+range 1-10.
+*Expected:* Lower bid_rate than always-bid models (passes on negative-EV hands),
+higher make_rate when it does bid (self-selected for profitability), strong
+net_eppd from avoiding costly sets.
+
+**olsa_full** — OLS regression with all 39 forward-selected features
+(`hybrid_r0_full.json`). Floor-based threshold: bids `floor(mu)` if ≥ 1.
+No distributional model — no P(make) or EV computation. Bid range 1-10.
+*Expected:* Always bids (floor ≥ 1 is easy to reach with 39 features), higher
+eppd than constrained models (more features = better predictions), but lower
+net_eppd than hybrid_olsa (no selectivity filter).
+
+**olsa** — OLS regression with 3 constrained features (`hybrid_r0.json`).
+Same floor-based threshold as olsa_full. Identical OLS coefficients to
+hybrid_olsa but without the Gaussian CDF wrapper. Bid range 1-10.
+*Expected:* Similar to olsa_full but slightly worse predictions (fewer features).
+Serves as the attribution baseline: the difference between olsa and hybrid_olsa
+isolates the wrapper effect (see C33 ablation).
+
+**rankthetank** — Rank-sum heuristic using `score_hand_scalar()` (composite
+hand strength score). Maps strength to bid level via empirically calibrated
+thresholds derived from the canonical bidless dataset. Evaluates all 6 contract
+types (4 suits + HIGH + LOW) and picks the strongest. Bid range 1-10.
+*Expected:* High bid_rate (rank-sum is generous), moderate make_rate (thresholds
+approximate expected tricks but don't account for hand composition nuances),
+negative net_eppd (overbids on marginal hands).
+
+**fiveheadfred** — Fixed bidder: always bids 5 Spades if able. No hand
+evaluation — completely ignores the dealt cards. Bid range: exactly 5.
+*Expected:* Always bids (by definition), moderate make_rate (5 tricks is
+achievable on many hands by chance), negative net_eppd (bidding without hand
+evaluation guarantees overbidding on weak hands and underbidding on strong ones).
+
+**stricthellraiser** — Escalation bidder: bids `current_high_bid + 1` (or 3
+if no prior bid), always Spades. In single-seat mode (`current_high_bid=0`),
+always bids 3 Spades. No hand evaluation. Bid range: 3 (in single-seat).
+*Expected:* Always bids, low make_rate (bid level has no relationship to hand
+strength), worst net_eppd (systematic overbidding is heavily penalized).
+
+**Note on stricthellraiser in single-seat mode:** In single-seat mode with
+`current_high_bid=0`, StrictHellRaiser always bids 3 Spades. This is a
+degenerate but interpretable baseline: it measures "what happens when you
+always bid 3 regardless of your hand." Its escalation logic (bid higher when
+outbid) is inert in single-seat mode.
+
+#### §6b. Expected vs Observed
+
+> Compare predictions from §6a to actual results. Frame as "surprises."
+
+**Format:** For each bidder, a short paragraph covering:
+1. Did the results match predictions? (Usually yes for heuristic bidders.)
+2. Any surprises? (e.g., hybrid_olsa's bid_rate in single-seat mode, the
+   magnitude of the olsa_full vs olsa gap, rankthetank's post-calibration
+   behavior.)
+3. What the result tells us about the bidder's design.
+
+**Key narratives to include:**
+
+- **hybrid_olsa's bid_rate** will be notably different from v2 (was 62.5% under
+  4-way best-of-4). The single-seat rate is the true per-hand selectivity.
+  Explain what this means for the "selective bidding" interpretation.
+
+- **modeloespecifico's bid_rate** may change after removing the `<= 6` ceiling.
+  Previously, strong suit hands (score > 6) were silently dropped. Post-fix,
+  these hands now produce bids of 7-9.
+
+- **rankthetank's behavior** after threshold recalibration. The v2 battery had
+  miscalibrated HIGH/LOW thresholds (dead code). Post-fix, rankthetank should
+  show meaningful HIGH/LOW bid differentiation for the first time.
+
+- **stricthellraiser's single-seat behavior** — always bids 3 Spades, so its
+  make_rate reflects "how often can you make 3 tricks with a random hand playing
+  Spades as trump?" This is an interesting empirical baseline.
+
+**Acceptance criteria:**
+- [ ] §6a descriptions match the post-fix code (not the bugged versions)
+- [ ] §6a is written as predictions (before seeing data)
+- [ ] §6b explicitly compares predictions to results
+- [ ] §6b calls out any surprises or notable findings
+- [ ] hybrid_olsa bid_rate change from v2 is explained
+- [ ] StrictHellRaiser single-seat degeneracy is noted
+
+---
+
+### §7. Key Observations
+
+> **Status:** KEEP from current §4. Update numbers, re-evaluate claims.
+
+**Content:** High-level takeaways. Same structure as current (numbered list).
+
+**Updates needed:**
+- Update all numbers to v3 data.
+- Re-evaluate tier boundaries (they may shift with new data).
+- "Selective bidding pays off" (observation 2) — the magnitude may change.
+  Update the hybrid_olsa vs olsa_full gap.
+- "Gap to close" (observation 4) — update the modeloespecifico vs hybrid_olsa
+  gap.
+- Consider adding an observation about the bidder bug fixes if they changed
+  rankings (e.g., "rankthetank improved after threshold recalibration").
+
+**Acceptance criteria:**
+- [ ] All numbers from v3 data
+- [ ] Tier boundaries re-evaluated and accurate
+- [ ] No stale references to v2 numbers
+
+---
+
+### §8. Auction-Pressure Sensitivity
+
+> **Status:** NEW. Secondary diagnostic panel showing 4-way auction results.
+
+**Purpose:** Preserve the auction-interaction signal without conflating it with
+the primary (single-seat) ranking. Explicitly labeled as supplementary.
+
+**Content:**
+
+1. **Brief explanation** (2-3 sentences): What the 4-way design is, how it
+   differs from single-seat (best-of-4 selection, positional bias, bid_rate
+   inflation).
+
+2. **Summary table:** 4-way rankings (v2 data or re-run). Same columns as §3
+   but labeled "4-way auction" with a note that these are NOT the primary
+   rankings.
+
+3. **Comparison narrative** (3-5 sentences): Do rankings change between
+   single-seat and 4-way? If so, why? Expected explanations: best-of-4
+   effect benefits selective bidders less (they already pass on weak hands),
+   bid_rate inflation makes always-bid policies look comparable.
+
+4. **What the 4-way signal adds:** The `current_high_bid` interaction signal
+   that single-seat misses. Note that this is more relevant for future policies
+   with opponent modeling.
+
+**Length target:** Compact — ~20-30 lines total. This is a diagnostic appendix.
+
+**Acceptance criteria:**
+- [ ] Explicitly labeled as secondary/supplementary
+- [ ] 4-way table has different column header or label from §3
+- [ ] Comparison narrative explains any ranking differences
+- [ ] Does NOT undermine the primary single-seat rankings
+
+---
+
+### §9. Provenance
+
+> **Status:** EXTRACTED from current §5. Standard provenance table.
+
+**Content:** Machine-readable traceability table following the experiment report
+template convention.
+
+```markdown
+| Item | Value |
+|------|-------|
+| gate_status | PROMOTED (see r0_promotion_report.md) |
+| Artifact (primary) | data/artifacts/arc_d/r0/comparator_cis_r0_v3.json |
+| Artifact (4-way) | data/artifacts/arc_d/r0/comparator_cis_r0_v2.json |
+| Extraction script | scripts/internal/extract_comparator_cis.py |
+| Battery metadata | data/artifacts/arc_d/r0/comparator_battery_r0_v3.json |
+| Git SHA | <commit hash> |
+| Seed | 42 |
+| n_deals | <per bidder> |
+| Schema | comparator_v3 |
+```
+
+Note: Use plain text for artifact paths (not backticks) to avoid docs-check
+lint failures on gitignored paths.
+
+**Acceptance criteria:**
+- [ ] `gate_status` present (lint requirement)
+- [ ] Both v3 and v2 artifact paths listed
+- [ ] Artifact paths in plain text, not backticks
+
+---
+
+## Notebook Specification: `45_comparator_deep_dive.py`
+
+> **Location:** `notebooks/arc_d/r0/45_comparator_deep_dive.py`
+> **Format:** Jupytext percent-format (.py), paired with .ipynb
+> **Purpose:** Produce all per-deal and per-contract-type analysis that the
+> report cross-references.
+
+### S1: Setup & Data Loading
+
+- Load raw JSONL game logs from each bidder's single-seat run
+  (`data/runs/auction_comparator_{name}_{seed}_*/logs/*.jsonl`)
+- Parse into a per-deal DataFrame with columns:
+  `bidder_name`, `deal_id`, `contract_type`, `trump_suit`, `bid_n`,
+  `tricks_won`, `declaring_pts`, `defending_pts`, `net_pts`, `made`
+- Handle pass deals (no bid → exclude from bid-conditional metrics,
+  include in per-deal metrics with 0 contribution)
+- **Assert gate:** verify expected bidder count (7), deal count per bidder
+
+**Key implementation note:** The extraction script `extract_comparator_cis.py`
+already has JSONL parsing logic at lines 41-96 (`_parse_jsonl_points`), but it
+does NOT extract `contract_type`. The notebook must parse the JSONL directly.
+Reuse the log-parsing pattern from the H2H notebook
+(`50_r0_matchups.py`) if applicable.
+
+### S2: Per-Deal Distributions (Figure 1 — referenced from report §3)
+
+**Violin plot of per-deal net_eppd for each bidder.**
+
+- Y-axis: 7 bidders in ranked order (matching §3 table)
+- X-axis: per-deal net points (declaring_pts − defending_pts)
+- One violin per bidder
+- Annotate with mean ± CI marker overlaid on each violin
+- **Faceted by contract_type** (3 panels: suit / high / low)
+- Self-play zero-reference line (dashed at x=0)
+
+**Assert gate:** Self-play consistency — mean net_pts for pass deals is 0.
+
+### S3: Contract-Type Breakdown (Table — referenced from report §4)
+
+**Per-contract-type metrics table.**
+
+- Compute net_eppd, bid_rate, make_rate per bidder per contract_type
+- Bootstrap 95% CIs on net_eppd
+- Output as formatted markdown table for copy-paste into report
+- **Assert gate:** bid_rate × 3 contract types ≈ overall bid_rate
+  (within rounding)
+
+### S4: Bid-Level Distribution
+
+**Histogram of bid levels by bidder.**
+
+- X-axis: bid level (1-10)
+- Y-axis: count or proportion
+- One panel per bidder (or stacked/grouped)
+- **Faceted by contract_type**
+- Highlights: stricthellraiser should show a spike at 3 (single-seat),
+  modeloespecifico should now show bids above 6 (post-fix),
+  rankthetank should show full 1-10 range (post-calibration)
+
+**Assert gate:** No bids outside [1, 10]. fiveheadfred has only bid=5.
+
+### S5: Summary Statistics
+
+- Print key summary numbers for easy reference from the report
+- Per-bidder: n_deals, n_bids, bid_rate, make_rate, net_eppd, std, CVaR-5%
+- Per-contract-type aggregated across all bidders
+
+### Notebook Conventions
+
+- All charts faceted by contract_type (or justify pooling)
+- `MODE` parameter for SMOKE/QUICK/FULL (default SMOKE for fast iteration)
+- Assert gates at each section boundary
+- No data artifacts committed — notebook reads from `data/runs/`
+
+---
+
+## Files to Create / Modify
+
+| File | Action | What Changes |
+|------|--------|--------------|
+| `docs/04_reports/r0/comparator_rankings.md` | **Rewrite** | Full refactor per section specs above |
+| `notebooks/arc_d/r0/45_comparator_deep_dive.py` | **Create** | New notebook per spec above |
+| `notebooks/arc_d/r0/45_comparator_deep_dive.ipynb` | **Create** | Jupytext-paired ipynb (auto-generated) |
+| `docs/04_reports/r0/h2h_battery_analysis.md` | **Minor edit** | Update §3 comparator cross-reference to note v3 methodology |
+| `docs/04_reports/README.md` | **Minor edit** | Update comparator_rankings entry with v3 date |
+
+---
+
+## Validation Checklist
+
+Before opening the PR:
+
+- [ ] `make check-quiet` passes (repo-lint + ruff + pytest + notebook-check + docs-check)
+- [ ] `make notebook-check` passes (Jupytext sync, outputs cleared)
+- [ ] All charts in notebook faceted by contract_type
+- [ ] All matchup/summary tables show appropriate breakdowns
+- [ ] Report cross-references to notebook are valid (correct figure numbers)
+- [ ] Report cross-references to other reports are valid relative links
+- [ ] `gate_status` present in §9 Provenance
+- [ ] No data artifacts committed (data/runs/, data/reports/)
+- [ ] No backtick-quoted artifact paths (docs-check lint)
+- [ ] Worktree workflow used (not main checkout)
+
+---
+
+## Key Files to Read Before Implementing
+
+### Must-read
+- `plans/comparator_rankings_review_notes.md` — the review notes driving changes
+- `plans/comparator_experiment_redesign.md` — experiment redesign + bidder fixes
+- `docs/04_reports/r0/comparator_rankings.md` — the report being refactored
+- `src/bid_euchre/strategy/bidding.py` — all 7 bidder classes (post-fix versions)
+- `scripts/internal/extract_comparator_cis.py` — CI extraction, metric computation
+
+### Should-read
+- `docs/04_reports/r0/c33_ablation_report.md` — reference for report quality/structure
+- `docs/04_reports/r0/h2h_battery_analysis.md` — cross-referenced report
+- `notebooks/arc_d/r0/50_r0_matchups.py` — reference for notebook patterns
+- `docs/02_agent/EXPERIMENT_REPORTS.md` — 8-section template convention
+
+### Reference
+- `CLAUDE.md` — project conventions
+- `.claude/rules/05_rigor.md` — statistical rigor requirements
+- `.github/pull_request_template.md` — PR template
+- `docs/01_core/DATA_CONTRACT.md` — logging schema (for JSONL parsing)

--- a/plans/comparator_rankings_review_notes.md
+++ b/plans/comparator_rankings_review_notes.md
@@ -1,0 +1,647 @@
+# Comparator Rankings Report — Review Notes
+
+> **Report under review:** `docs/04_reports/r0/comparator_rankings.md`
+> **Scope:** R0 only. Notes for potential future refactoring.
+> **Status:** Running log — no modifications yet.
+
+---
+
+## Current Report Section Map
+
+For reference, the report's current structure with line numbers:
+
+| § | Heading | Lines | Status |
+|---|---------|-------|--------|
+| — | Header (Arc/Rung/Date/Methodology) | 1-6 | Keep |
+| 1 | Rankings Table | 8-21 | Expand (Notes 1, 2, 3) |
+| 2 | Pairwise Significance | 23-40 | Keep as-is |
+| 3 | Behavioral Profiles | 42-80 | Minor edits |
+| 4 | Key Observations | 82-106 | Keep as-is |
+| 5 | Methodology | 108-119 | Reposition (Note 4) |
+| 5a | — Supersession Note | 121-128 | Merge (Note 5) |
+| 5b | — Bidder Identity Note | 130-136 | Merge (Note 5) |
+| 5c | — What This Methodology Measures | 138-172 | **FIX (Note 12: "uncontested" is wrong)** |
+
+---
+
+## Proposed Refactored Section Outline
+
+Below is the target structure for the refactored report. Each section includes
+its header, a brief description of what it covers, the source (existing or new),
+and which notes drive the change.
+
+---
+
+### Header (keep, minor update)
+
+```
+# R0 Comparator Rankings (v3, Single-Seat, 7 Bidders)
+
+**Arc:** D (OLSa-Hybrid Bidder)
+**Rung:** R0
+**Date:** 2026-02-XX (v3; supersedes v2 4-way auction rankings)
+**Methodology:** Single-seat evaluation · 10,000 deals per bidder · seed=42 · 10,000 bootstrap resamples
+```
+
+Update version to v3, add "Single-Seat" to title, update methodology one-liner.
+Date TBD when experiment is re-run.
+
+---
+
+### §1. Summary (NEW — Note 9)
+
+> Brief executive overview making the report self-contained for a reader
+> unfamiliar with Arc D.
+
+**Covers:**
+- **What this is:** A self-play benchmark where each bidder evaluates random
+  hands and plays declared contracts against GluttonStrategy. Measures
+  intrinsic bidding quality in isolation.
+- **Why it's run this way:** Provides an absolute benchmark ("is this model
+  any good?") without requiring O(n²) pairwise matchups. Enables
+  rung-over-rung progress tracking against a fixed reference point.
+- **What it tells us:** Ranks 7 bidders on net_eppd. Three tiers emerge
+  (competitive / weak / degenerate). hybrid_olsa ranks #2 behind the
+  domain-expert modeloespecifico, with selective bidding as the dominant
+  differentiator among trained models.
+- **How to use it going forward:** Baseline for rung-over-rung tracking. Each
+  new rung runs the same battery to measure absolute progress. Self-play
+  rankings can diverge from competitive ordering — use H2H for promotion.
+- **Arc context:** Where this fits in the R0 evaluation stack (alongside H2H
+  battery, C33 ablation, and threshold calibration).
+
+**Length target:** ~10-15 lines of prose.
+
+---
+
+### §2. Methodology (MOVED from current §5 — Note 4)
+
+> Describes the experimental design so the reader understands the evaluation
+> before seeing numbers.
+
+**Covers:**
+- Experimental design: single-seat evaluation (v3). One random seat per deal,
+  `current_high_bid=0`, bid-or-pass, GluttonStrategy card play.
+- Parameters: deal count, seed, bootstrap configuration.
+- Metric definitions: net_eppd, eppd, bid_rate, make_rate, CVaR-5%.
+- Extraction script and source data references.
+- Auction-pressure sensitivity panel: notes that a secondary 4-way auction
+  battery is available (v2 data) for readers interested in the contested-
+  auction signal. Cross-references the sensitivity panel section (§8).
+- **bid_rate formula** (Note 3): `bid_rate = hands_with_bids / deals_total`.
+  In single-seat mode, this is the per-hand selectivity rate.
+
+**Subsections:**
+
+#### §2.1 What This Methodology Measures (and What It Does Not)
+
+> Preserved from current §5c (lines 138-172). This is the strongest section
+> in the current report — keep as-is with minor updates to reflect v3
+> single-seat design.
+
+**Updates needed:**
+- **Factual correction (Note 12):** The current report says "no competing
+  bidder in the auction" and "evaluates uncontested bidding" — this is wrong
+  for the v2 4-way design (there IS a contested 4-seat auction). Under the
+  v3 single-seat design, "uncontested" becomes accurate. Rewrite to match
+  the actual methodology of whichever version the report describes.
+- Clarify that net_eppd is measured from the declaring team's perspective
+  (positive values are expected when the policy picks profitable contracts).
+
+#### §2.2 Version History
+
+> Merged from current §5a + §5b (Note 5). Single subsection covering
+> v1→v2→v3 progression.
+
+**Covers:**
+- v1 (5 bidders, 4-way auction), v2 (7 bidders, 4-way auction),
+  v3 (7 bidders, single-seat).
+- Bidder identity changes: v1 `hybrid_olsa` = OLSa_Full promotional arm;
+  v2+ `hybrid_olsa` = constrained arm with Gaussian CDF wrapper.
+
+---
+
+### §3. Rankings Table (EXPANDED from current §1 — Notes 1, 2, 3, 6)
+
+> Primary results table ranked by net_eppd. This is the headline output.
+
+**Changes from current:**
+- **Add spread metrics (Note 2):** std or IQR column for net_eppd.
+- **Add CIs to bid_rate and make_rate (Note 3):** Bootstrap CIs for
+  consistency with other metrics.
+- **Add CVaR footnote (Note 6):** Explain zero-width CVaR CIs for heuristic
+  bidders (set penalty floors at `-bid_n`).
+- **Reference violin plot:** "See Figure 1 in notebook
+  `45_comparator_deep_dive` for per-deal distributions."
+
+**Numbers will change** when single-seat experiment runs. bid_rate in
+particular will shift significantly (currently inflated by best-of-4 effect
+in 4-way design).
+
+---
+
+### §4. Rankings by Contract Type (NEW — Note 1)
+
+> Per-contract-type breakdown of key metrics, satisfying the repo-wide
+> faceting convention.
+
+**Covers:**
+- Table: net_eppd, bid_rate, make_rate faceted by contract_type
+  (suit / high / low) for each bidder.
+- Brief narrative: are rankings preserved within each contract type?
+  Does the Gaussian wrapper's selectivity concentrate in certain contract
+  types (different sigma per contract)?
+
+**Data source:** New notebook `45_comparator_deep_dive.py` parses raw JSONL
+logs and computes per-contract-type metrics. Report cross-references the
+notebook for detailed charts.
+
+**Justification:** If faceted rankings are identical to pooled rankings, a
+brief note saying so is sufficient — but the data must be shown.
+
+---
+
+### §5. Pairwise Significance (KEEP — current §2)
+
+> Bootstrap permutation tests for net_eppd differences between
+> adjacent-ranked bidders. No structural changes needed.
+
+**Updates:** Re-run with v3 single-seat data. Numbers and possibly
+significance levels will change.
+
+---
+
+### §6. Behavioral Profiles (KEEP — current §3)
+
+> Per-bidder narrative descriptions explaining strategy and performance.
+
+**Updates:**
+- Update numbers to match v3 single-seat results.
+- Clarify that bid_rate now reflects per-hand selectivity (not best-of-4
+  probability). hybrid_olsa's bid_rate will decrease from 62.5%.
+- Minor wording adjustments for accuracy.
+
+---
+
+### §7. Key Observations (KEEP — current §4)
+
+> High-level takeaways from the rankings.
+
+**Updates:**
+- Update numbers to match v3 data.
+- May need to adjust observation 2 ("selective bidding pays off") since the
+  magnitude of the selectivity advantage may change in single-seat mode.
+- Tier boundaries may shift slightly.
+
+---
+
+### §8. Auction-Pressure Sensitivity (NEW — from Workstream B)
+
+> Secondary diagnostic showing the 4-way auction results for comparison.
+> NOT the primary ranking — explicitly labeled as sensitivity analysis.
+
+**Covers:**
+- Brief explanation of the 4-way design and how it differs from single-seat.
+- Summary table of 4-way rankings (v2 data, or re-run for consistency).
+- Comparison: do rankings change? If so, why? (Best-of-4 selection,
+  positional bias, bid_rate inflation.)
+- Narrative: what the 4-way signal adds that single-seat misses
+  (`current_high_bid` interaction, auction pressure).
+
+**Length:** Compact — this is a diagnostic appendix, not the main event.
+
+---
+
+### §9. Provenance (KEEP — currently embedded in §5)
+
+> Source data paths, gate status, extraction script references.
+
+**Covers:**
+- Extraction script path, source data path, battery metadata path.
+- `gate_status: PROMOTED` cross-reference to promotion report.
+- v3 artifact naming (TBD from Workstream B).
+
+---
+
+### Section Map: Current → Proposed
+
+| Current | Proposed | Notes |
+|---------|----------|-------|
+| Header | Header | Update version/methodology |
+| *(none)* | **§1. Summary** | NEW (Note 9) |
+| §5 Methodology | **§2. Methodology** | MOVED up (Note 4) |
+| §5a Supersession Note | §2.2 Version History | MERGED (Note 5) |
+| §5b Bidder Identity Note | §2.2 Version History | MERGED (Note 5) |
+| §5c What This Measures | §2.1 What This Measures | MOVED into §2 |
+| §1 Rankings Table | **§3. Rankings Table** | EXPANDED (Notes 1,2,3,6) |
+| *(none)* | **§4. Rankings by Contract Type** | NEW (Note 1) |
+| §2 Pairwise Significance | **§5. Pairwise Significance** | KEEP (renumbered) |
+| §3 Behavioral Profiles | **§6. Behavioral Profiles** | KEEP (renumbered) |
+| §4 Key Observations | **§7. Key Observations** | KEEP (renumbered) |
+| *(none)* | **§8. Auction-Pressure Sensitivity** | NEW (Workstream B) |
+| *(embedded in §5)* | **§9. Provenance** | EXTRACTED |
+
+---
+
+## Report Strengths
+
+Before listing improvement areas, what's working well:
+
+- **§5c "What This Methodology Measures"** is excellent — clearly explains
+  confounding with GluttonStrategy, lack of auction interaction, and when to
+  use H2H instead. This is the gold standard for methodology caveats.
+- **§2 Pairwise Significance** with bootstrap permutation tests gives
+  statistical rigor beyond just rankings.
+- **§3 Behavioral Profiles** provides per-bidder narrative context that
+  makes the raw numbers interpretable.
+- **§5a Supersession Note** documents v1→v2 history transparently.
+
+---
+
+## Observations & Potential Changes
+
+### Note 1: Contract-type faceting missing (§1 Rankings Table)
+
+**Convention violation.** The §1 rankings table pools all contract types (suit,
+high, low) into single aggregate metrics. The repo-wide convention requires all
+tables/charts to be faceted by contract_type or explicitly justify pooling.
+
+This matters because:
+- Bidders may perform very differently by contract type (suit contracts have
+  bowers/trump; high/low are no-trump)
+- hybrid_olsa's selective bidding (62.5% bid rate) may be concentrated in
+  certain contract types
+- The Gaussian wrapper's residual variance (sigma) differs per contract type,
+  so its selectivity effect varies
+
+**Proposed change:** Add a contract-type breakdown table (either in §1
+directly or referenced from a notebook). At minimum, show net_eppd, bid_rate,
+and make_rate faceted by contract_type for each bidder.
+
+**Justification for pooling (if kept):** If adding a full faceted table is too
+heavy, the report should at least include a sentence justifying why pooled
+metrics are sufficient here (e.g., "Contract-type breakdowns are available in
+notebook 50_r0_matchups; the pooled ranking order is preserved within each
+contract type.").
+
+---
+
+### Note 2: No distributional detail in results (§1 Rankings Table)
+
+The §1 rankings table shows point estimates + CIs for net_eppd and eppd, but no
+spread or shape metrics. Same issue identified in the C33 ablation review.
+
+**Missing:**
+- Spread: std, IQR, or P5/P95 per bidder
+- Shape: any indication of skewness (the CVaR-5% gives left-tail info, but
+  nothing about the right tail or overall distribution)
+- Per-deal outcome distributions (histograms or violin plots)
+
+**Why it matters:** Two bidders could have the same mean net_eppd but very
+different variance profiles. The CVaR-5% column partially addresses this, but
+it's a single tail quantile, not a full distributional picture.
+
+**Proposed change:** Add spread metrics to the §1 table (at least std or
+IQR) and reference a notebook with per-deal distribution visualizations.
+
+---
+
+### Note 3: bid_rate and make_rate lack confidence intervals (§1 Rankings Table)
+
+Every other metric in the §1 rankings table has bootstrap 95% CIs, but bid_rate
+and make_rate are bare point estimates. This is inconsistent.
+
+**Why it matters:** bid_rate for hybrid_olsa (0.625) is the single most
+important behavioral distinction in the table. Without a CI, the reader can't
+tell if this is 0.625 +/- 0.001 or +/- 0.05.
+
+**Proposed change:** Add CIs to bid_rate and make_rate, or add a footnote
+explaining their omission (see Open Question 2 resolution below).
+
+---
+
+### Note 4: Methodology section placement (§5 → move before §1)
+
+The report's current flow is:
+1. §1 Rankings Table
+2. §2 Pairwise Significance
+3. §3 Behavioral Profiles
+4. §4 Key Observations
+5. §5 Methodology (including sub-notes)
+
+The §5 methodology section appears *after* the results and observations. The
+standard experiment report template (`docs/02_agent/EXPERIMENT_REPORTS.md`) puts
+methodology before results.
+
+**Proposed change:** Move §5 (including all subsections) to appear after the
+header/intro, before §1 Rankings Table. This lets the reader understand the
+evaluation design before interpreting numbers.
+
+**Counter-argument:** Some readers prefer results-first for quick reference.
+If so, the header already has a one-line methodology summary
+("10,000 deals per bidder, seed=42, 10,000 bootstrap resamples"). This could
+be expanded slightly as a sufficient upfront summary, keeping detailed
+methodology at the bottom as reference.
+
+---
+
+### Note 5: Redundant v1→v2 naming notes (§5a + §5b)
+
+Two subsections both explain the v1→v2 naming change:
+- §5a "Supersession Note" (lines 121-128)
+- §5b "Bidder Identity Note" (lines 130-136)
+
+These cover substantially the same ground (v1 had 5 bidders, v2 has 7;
+`hybrid_olsa` identity changed between versions).
+
+**Proposed change:** Merge into a single "Version History" or "Naming Note"
+subsection that covers both the supersession and the identity change.
+
+---
+
+### Note 6: CVaR-5% floor values unexplained (§1 Rankings Table)
+
+Three heuristic bidders show CVaR-5% values with zero-width CIs:
+- rankthetank: -6.000 [-6.000, -6.000]
+- fiveheadfred: -5.000 [-5.000, -5.000]
+- stricthellraiser: -6.000 [-6.000, -6.000]
+
+The report doesn't explain why these CIs have zero width.
+
+**Why it matters:** A metric with zero variance is hitting a boundary condition
+in the scoring formula. The reader may wonder if this is a bug or an artifact.
+
+**Proposed change:** Add a brief footnote to the §1 table explaining the floor
+(see Open Question 3 resolution below for the exact mechanism).
+
+---
+
+### Note 7: Duplication with H2H battery analysis report (cross-report)
+
+The H2H battery analysis report (`h2h_battery_analysis.md` §3) contains a
+near-complete copy of the comparator rankings:
+- Same rankings table (H2H §3.2 ≈ this report's §1)
+- Same pairwise significance table (H2H §3.3 ≈ this report's §2)
+- Same observations (H2H §3.4 ≈ this report's §4)
+
+This creates maintenance burden — any update to the comparator rankings must
+be mirrored in the H2H report.
+
+**Options:**
+- A. **Keep duplication, add cross-reference warning** — note in both reports
+  that they duplicate content and must be updated together
+- B. **Remove from H2H report, cross-reference only** — the H2H report's §3
+  becomes a summary + link to this report
+- C. **Status quo** — accept duplication as the cost of self-contained reports
+
+**Recommendation:** Option B. The H2H report is already long (500+ lines).
+Moving the comparator section to a cross-reference reduces its scope to what
+it uniquely covers (H2H matchups, thresholds). The comparator_rankings.md
+report is the authoritative source for self-play rankings.
+
+---
+
+### Note 9: Missing summary / executive overview (top of report)
+
+The report has no introductory section. It goes directly from the header
+metadata (Arc/Rung/Date/Methodology one-liner) into the rankings table. A
+reader unfamiliar with the Arc D context has no way to understand:
+
+1. **What this is:** A self-play evaluation where each bidder plays
+   independently against GluttonStrategy (the card-playing policy). No
+   contested auction — each bidder declares uncontested.
+2. **Why it was run this way:** Provides an absolute benchmark ("is this
+   model any good?") rather than a relative comparison ("which is better?").
+   Enables rung-over-rung progress tracking against a fixed reference point
+   without requiring O(n²) pairwise matchups.
+3. **What it tells us:** Ranks 7 bidders on net_eppd. hybrid_olsa ranks #2
+   behind the domain-expert modeloespecifico, with a 0.624 gap that R1+ aims
+   to close. Three tiers emerge (competitive / weak / degenerate). Selective
+   bidding via the Gaussian wrapper is the dominant differentiator among
+   trained models.
+4. **How to use it going forward:** Baseline for rung-over-rung tracking.
+   Each new rung runs the same battery to measure absolute progress. But
+   self-play rankings can diverge from competitive ordering (see H2H
+   battery) — use this for benchmarking, H2H for promotion decisions.
+5. **Arc context:** Where this fits in the R0 evaluation stack (alongside
+   H2H battery, C33 ablation, and threshold calibration).
+
+The information for all 5 points *exists* in the report — it's scattered
+across §3 Behavioral Profiles, §4 Key Observations, and §5c What This
+Methodology Measures. But none of it appears before the reader hits the
+rankings table.
+
+**Proposed change:** Add a new section immediately after the header
+(before §1 Rankings Table) that covers these 5 points in ~10-15 lines.
+This would subsume the motivation currently implied across §4 and §5c
+without removing those sections (they provide detail the summary doesn't).
+
+This is related to Note 4 (methodology placement) — if a summary section
+is added, it partially addresses the "methodology comes after results"
+issue by putting the design rationale upfront. The detailed §5 methodology
+can stay at the bottom as reference.
+
+---
+
+### Note 10: Violin plot of per-deal distributions (§1 Rankings Table)
+
+The rankings table shows only summary statistics. A violin plot showing the
+per-deal net_eppd distribution for each bidder would make the table's numbers
+tangible — the reader could see the shape, spread, and tails at a glance.
+
+**What it should show:**
+- Y-axis: 7 bidders (ranked order, matching the table)
+- X-axis: per-deal net_eppd (or bidder_team_points)
+- One violin per bidder showing the full distribution
+- Faceted by contract_type (convention requirement)
+- Annotated with mean + CI markers overlaid on each violin
+
+**Data source challenge:** The existing comparator battery artifacts only
+contain summary-level metrics (per-bidder aggregates). The violin plot needs
+per-deal outcome arrays, which requires reading the raw JSONL game logs from
+`data/runs/auction_comparator_{name}_{seed}_*/logs/*.jsonl`. The extraction
+script (`extract_comparator_cis.py`) already parses these into per-deal arrays
+(lines 41-96) but doesn't expose them at notebook-friendly granularity.
+
+**Where to build this:** Two options:
+- **Option A:** Add to existing `40_r0_baseline.py` §11 (Comparator Battery).
+  Pro: keeps comparator visuals in one place. Con: that notebook already uses
+  summary data, not per-deal data; adding JSONL parsing changes its character.
+- **Option B:** New dedicated notebook (e.g., `45_comparator_deep_dive.py`).
+  Pro: clean separation, room for faceted charts + distribution analysis.
+  Con: another notebook to maintain.
+
+**Recommendation:** Option B. The per-deal JSONL loading + contract-type
+faceting + violin plots + potential distributional analysis is substantial
+enough to warrant its own notebook. This also provides the natural home for
+Note 1 (contract-type faceted table) and Note 2 (distributional detail).
+
+**Connection to other notes:**
+- Subsumes Note 8 (visual cross-reference) — the report would reference this
+  notebook
+- Provides the data infrastructure for Note 1 (contract-type faceting) and
+  Note 2 (distributional detail)
+- If built, the report's §1 would reference the violin plot figure from this
+  notebook
+
+---
+
+### Note 12: "Uncontested bidding" claim is factually incorrect (§5c)
+
+**Correctness issue.** The current §5c (lines 140-143) states:
+
+> "There is no competing bidder in the auction — the bidder under test declares
+> contracts uncontested"
+
+and
+
+> "No auction interaction. Real games have contested auctions where one bidder's
+> bid changes which contracts the opponent gets to play. This battery evaluates
+> uncontested bidding — a fundamentally different task."
+
+This is **wrong** for the v2 4-way design. The code runs a real sequential
+auction where all 4 seats call `choose_bid()` with strictly increasing bids
+enforced. There IS mechanical auction interaction: `current_high_bid` rises
+as seats bid, later seats are forced to pass or bid higher, and the winner is
+whichever seat can outbid the others.
+
+What's true is that there's no *strategic* interaction — all 4 copies use the
+same policy, so there's no opponent modeling or adaptive behavior. But the
+auction mechanics are fully contested.
+
+**Under the v3 single-seat design, "uncontested" becomes accurate** — the
+single seat evaluates with `current_high_bid=0` and no other seat participates.
+So the current report's language accidentally describes the *proposed* design
+rather than the *current* one.
+
+**Proposed change (P1):** Fix this immediately regardless of which design the
+report ultimately describes:
+- If the report stays on v2 data temporarily: rewrite to accurately describe
+  the 4-way contested auction with identical policies.
+- When the report moves to v3 data: "uncontested" language becomes correct, but
+  should clarify *why* (single-seat, no auction, `current_high_bid=0`).
+
+The H2H battery report (`h2h_battery_analysis.md` §1.4) also describes the
+comparator as "uncontested" — same correction needed there.
+
+---
+
+### Note 8: No visual cross-reference (whole report)
+
+*Subsumed by Note 10.* If a comparator deep-dive notebook is created (Note 10),
+the report would reference it for visualizations, resolving this gap.
+
+---
+
+### Note 11: Comparator experimental design — single-seat redesign
+
+**Status:** Extracted to standalone plan.
+
+See `plans/comparator_experiment_redesign.md` for the full analysis of
+4-way auction vs single-seat evaluation design, including code path traces,
+three identified artifacts (best-of-4 selection, LOD positional bias,
+non-zero-centered net_eppd), pros/cons of single-seat alternative, and
+implementation path.
+
+**Decision (2026-02-26):** Make single-seat the **primary** comparator
+methodology; retain 4-way auction as a **secondary diagnostic** ("auction-
+pressure sensitivity"). Re-run at R0 — zero backward-compatibility cost.
+The report quality improvements (Notes 1-10 above) can proceed in parallel
+on existing data.
+
+---
+
+## Open Questions — RESOLVED
+
+### Q1: Contract-type data availability → NOT AVAILABLE
+
+**Finding:** The extraction script (`scripts/internal/extract_comparator_cis.py`)
+does **not** facet by contract_type. It parses JSONL logs at the hand level and
+computes pooled aggregates only (lines 41-96). The function `_parse_jsonl_points`
+collects `bidder_team_points` and `net_bidder_team_points` arrays without
+recording which contract type each hand used.
+
+**Implication for Note 1:** Adding contract-type faceting to the report requires
+one of:
+- **Option A:** Modify the extraction script to parse contract_type from the
+  JSONL `hand_end` records and compute per-contract-type metrics. Then re-run
+  on existing logs (no new simulation needed).
+- **Option B:** Build the faceting in a notebook that reads the raw JSONL logs
+  directly, and cross-reference from the report.
+
+Option B is lower-risk (no script modification) and follows the pattern used
+in the H2H report (notebook produces charts, report references them).
+
+### Q2: bid_rate variance → DETERMINISTIC (with caveat)
+
+**Finding:** Both `OLSaBidder.choose_bid()` (line 730) and
+`HybridOLSaBidder.choose_bid()` (line 980) are **purely deterministic** given
+the same hand, model artifact, and auction state. There is no randomness in the
+bid decision — it's a function of:
+- Hand features (deterministic from dealt cards)
+- OLS weights + bias (fixed in artifact)
+- Residual variance / sigma (fixed in artifact)
+- `current_high_bid` from auction state (deterministic given other bids)
+
+However, bid_rate **does** have sampling variance from the deal sequence. The
+10,000 deals are a sample from the deal distribution. A different seed would
+produce different deals and potentially a different bid_rate. So bid_rate has
+variance from the deal-sampling process, not from the decision function.
+
+**Implication for Note 3:** CIs on bid_rate **are** appropriate — they capture
+deal-sampling uncertainty ("if we drew a different 10k deals, how much would
+bid_rate change?"). The bootstrap already handles this if bid_rate is computed
+per-resample. However, the current extraction script computes bid_rate as a
+simple fraction (line 117), not as a bootstrapped statistic.
+
+Adding bid_rate CIs would require modifying the bootstrap to resample
+per-deal indicator variables. This is low-effort but touches the extraction
+script.
+
+### Q3: CVaR floor explanation → SCORING FORMULA FLOORS
+
+**Finding:** The CVaR-5% is the mean of the worst 5% of per-hand
+`bidder_team_points` (line 99-102 of extraction script, line 128). From
+`scoring.py`, the scoring rules are:
+
+- **Made bid:** bid team gets `tricks_won` (ranges 3-10 since bid ≥ 3)
+- **Set bid:** bid team gets `-winning_bid` (ranges -3 to -10)
+
+For the worst 5% of outcomes, the bidder was set. The set penalty is
+`-winning_bid`. So:
+- A bidder that bids 5 and gets set → **-5 points**
+- A bidder that bids 6 and gets set → **-6 points**
+
+The zero-width CIs mean that the worst 5% of hands for these bidders
+**all** get set at the same bid level:
+- **fiveheadfred:** worst 5% all get set at bid=5 → CVaR-5% = -5.000
+- **rankthetank:** worst 5% all get set at bid=6 → CVaR-5% = -6.000
+- **stricthellraiser:** worst 5% all get set at bid=6 → CVaR-5% = -6.000
+
+This makes sense: these heuristic bidders have simple, formulaic bid levels.
+Their worst outcomes cluster at a single set penalty because they consistently
+bid the same amount on hands they can't make.
+
+**Implication for Note 6:** The report should add a brief footnote:
+"Zero-width CVaR CIs indicate that the worst 5% of outcomes for these bidders
+all incur the same set penalty (-bid_n), reflecting their narrow bid-level
+distribution."
+
+---
+
+## Priority Assessment
+
+| Note | Section | Impact | Effort | Priority |
+|------|---------|--------|--------|----------|
+| 12. "Uncontested bidding" is wrong | §5c | High (correctness) | Low | P0 |
+| 11. Experimental design (single-seat) | → `comparator_experiment_redesign.md` | High (correctness) | Medium | SEPARATE PLAN |
+| 9. Summary / executive overview | NEW (top) | High (readability) | Low | P1 |
+| 1. Contract-type faceting | §1 | High (convention) | Medium | P1 |
+| 10. Violin plot (per-deal dist.) | §1 / notebook | High (evidence) | Medium | P1 |
+| 2. Distributional detail | §1 | Medium | Medium | P2 |
+| 6. CVaR floor explanation | §1 | Medium | Low | P2 |
+| 7. H2H duplication | cross-report | Medium | Medium | P2 |
+| 3. bid/make rate CIs | §1 | Low | Low | P3 |
+| 4. Methodology placement | §5→top | Low | Low | P3 |
+| 5. Redundant naming notes | §5a+§5b | Low | Low | P3 |
+| 8. Visual cross-reference | whole report | — | — | Subsumed by 10 |

--- a/plans/comparator_single_seat.md
+++ b/plans/comparator_single_seat.md
@@ -1,0 +1,348 @@
+# Comparator Methodology: Single-Seat Evaluation
+
+> **Status:** Plan — ready for review
+> **Scope:** Comparator battery experimental design change. Single-seat mode
+> implementation, re-run protocol, artifact versioning, report updates.
+> **Dependency:** `plans/bidder_correctness_fixes.md` — all bidder fixes
+> (PR-B1 + PR-B2) must merge before the battery is re-run.
+> **Extracted from:** `plans/comparator_experiment_redesign.md`
+> **Companion doc:** `plans/comparator_rankings_review_notes.md` (report-level
+> improvements, proceeds in parallel on existing data)
+
+---
+
+## Problem Statement
+
+The current comparator battery runs a 4-way self-auction where all 4 seats
+use the same bidding policy. This produces three interpretive artifacts:
+
+1. **Best-of-4 selection effect** — the auction winner always has the
+   strongest hand at the table, inflating make_rate and net_eppd.
+2. **LOD positional bias** — seat 1 (left of dealer) bids against
+   `current_high_bid=0`; the dealer must beat all previous bids.
+3. **bid_rate conflation** — reported bid_rate is "probability at least 1
+   of 4 seats bids," not the policy's per-hand selectivity.
+
+These artifacts don't invalidate rank ordering (all policies face the same
+design), but they make absolute metrics harder to interpret and not
+comparable to H2H metrics.
+
+**Decision (2026-02-26):** Single-seat becomes the primary comparator
+methodology. The 4-way auction is retained as an optional sensitivity panel.
+
+---
+
+## Design: Single-Seat Evaluation
+
+For each deal:
+1. Randomly select 1 seat (using the deal's deterministic RNG).
+2. That seat evaluates its hand with `current_high_bid=0`.
+3. If it bids, play the hand with GreedyStrategy (all 4 seats).
+4. If it passes, count as a pass deal (`numerator += 0, denominator += 1`).
+
+### Metric computation (unchanged)
+
+- `net_eppd = sum(declaring_pts - defending_pts) / total_deals`
+- Pass deals contribute 0 to numerator, 1 to denominator.
+- All metrics from the declaring team's perspective.
+
+### What changes
+
+| Metric | 4-way (v2) | Single-seat (v3) |
+|--------|-----------|-----------------|
+| bid_rate | P(≥1 of 4 seats bids) | P(this seat bids) |
+| make_rate | Conditional on best-of-4 winner | Conditional on this seat's bid |
+| net_eppd | Inflated by selection | Unbiased per-hand estimate |
+| CVaR-5% | Worst 5% of best-of-4 | Worst 5% of single-seat |
+
+### What stays the same
+
+- **H2H battery** — unaffected (separate design, separate data)
+- **Gate thresholds** — calibrated from H2H null signal, not comparator
+- **C33 ablation** — uses H2H matchups, not comparator
+- **Promotion decisions** — use H2H + semantic gate, not comparator
+- **Pairwise significance** — valid within any consistent methodology
+
+---
+
+## Implementation
+
+### Step 1: Add `AlwaysPassBidder` as sentinel for non-bidding seats
+
+The simulation's `bidding_policies` parameter (`simulation.py:75–82`)
+accepts a list of 4 policies. Passing `None` crashes at line 136 (no null
+guard). Instead, use the existing `AlwaysPassBidder` (`bidding.py:154–163`)
+for non-bidding seats:
+
+```python
+from bid_euchre.strategy.bidding import AlwaysPassBidder
+
+# Single-seat: seat 2 bids, others always pass
+pass_policy = AlwaysPassBidder()
+policies = [pass_policy, pass_policy, target_policy, pass_policy]
+```
+
+**Seat randomization:** For each deal, pick the bidding seat using the
+existing deterministic RNG: `seat = rng.randrange(4)` where `rng` is
+`Random(deal_seed + deal_id)`. This is the same RNG source the simulation
+already uses for dealer selection (`simulation.py:109`), ensuring
+reproducibility.
+
+**Important:** The bidding seat's `current_high_bid` will always be 0
+because the other 3 seats always pass. The auction order (LOD) still runs,
+but pass actions don't raise the bid. This gives Option A behavior (true
+single-seat) with zero simulation changes.
+
+### Step 2: Play policy clarification
+
+**Current state:** The comparator config (`auction_comparator.yaml`) does
+not set `play_strategy`. The simulation defaults to `GreedyStrategy`
+(`simulation.py:70–72`):
+
+```python
+if strategy is None:
+    strategy = GreedyStrategy()
+```
+
+The original `comparator_experiment_redesign.md` and some report text refer
+to "GluttonStrategy" for card play, but the actual code uses
+**GreedyStrategy**. This plan preserves the existing default (Greedy).
+
+**Action:** Add an explicit comment to the comparator config or runner
+documenting that the play policy is GreedyStrategy (the simulation default).
+No code change needed.
+
+### Step 3: Modify comparator runner
+
+Add `--single-seat` flag to `scripts/internal/run_auction_comparator.py`.
+
+When `--single-seat` is set:
+- For each bidder, build a per-deal policy assignment that places the
+  target bidder on one randomly-selected seat and `AlwaysPassBidder` on
+  the other three.
+- The simplest approach: wrap the existing per-bidder experiment in a
+  loop or modify the config to use `bidding_policies` (list of 4) instead
+  of `bidding_policy` (singular).
+
+**Design detail — per-deal vs per-run seat assignment:**
+
+Option 1: **Per-run fixed seat** — assign the bidder to seat 0 for all
+10k deals. Simpler, but introduces seat bias (always bidding from the
+same position relative to dealer).
+
+Option 2: **Per-deal random seat** — for each deal, randomly assign the
+bidder to one of 4 seats. Eliminates seat bias. Requires passing
+`bidding_policies` per-deal rather than once per-run.
+
+**Recommendation: Option 2.** The simulation already supports per-deal
+dealer randomization. Extending to per-deal bidder-seat randomization is
+a small change and eliminates a confounder.
+
+**Implementation approach for Option 2:**
+- The comparator runner cannot currently vary `bidding_policies` per-deal
+  because `simulate_many_hands` takes a single `bidding_policies` list.
+- **Simplest fix:** Add a new `SingleSeatBiddingPolicy` wrapper that
+  internally randomizes which seat is "active" per deal:
+
+```python
+class SingleSeatBiddingPolicy(BiddingPolicy):
+    """Wrapper that activates the inner policy only for a designated seat."""
+    def __init__(self, inner: BiddingPolicy, active_seat: int):
+        self.inner = inner
+        self.active_seat = active_seat
+
+    def choose_bid(self, obs: BiddingObservation) -> BidAction:
+        if obs.seat == self.active_seat:
+            return self.inner.choose_bid(obs)
+        return BidAction.pass_bid()
+```
+
+Then pass `bidding_policy=SingleSeatBiddingPolicy(target, seat=deal_rng.randrange(4))`
+as the singular policy for all 4 seats. Wait — this doesn't work because
+the policy is shared across all seats in the same deal.
+
+**Better approach:** Use the existing `bidding_policies` (list of 4) and
+create a custom `simulate_many_hands` wrapper or modify the simulation to
+accept a callback that varies the policy list per deal. But this is more
+invasive.
+
+**Simplest viable approach:** Use `bidding_policies` with a
+`SeatAwareBiddingPolicy` that checks `obs.seat`:
+
+```python
+class SeatAwareBiddingPolicy(BiddingPolicy):
+    """Routes to inner policy only for a randomly-selected seat per deal."""
+    def __init__(self, inner: BiddingPolicy, seed: int):
+        self.inner = inner
+        self.seed = seed
+        self._deal_seats = {}  # Cache: deal_id → active_seat
+
+    def choose_bid(self, obs: BiddingObservation) -> BidAction:
+        # Problem: obs doesn't carry deal_id, so we can't vary per-deal.
+```
+
+**Problem:** `BiddingObservation` does not include `deal_id`. Without it,
+a policy wrapper can't determine which seat is active for this deal.
+
+**Resolution — two viable paths:**
+
+**Path A (Minimal code change):** Run 4 separate sub-experiments, one per
+seat. Each sub-experiment places the bidder on seat K and AlwaysPassBidder
+on the other 3. Each runs N/4 deals. Merge results. This is clean,
+deterministic, and requires no simulation changes.
+
+```
+Seat 0: [target, pass, pass, pass] × 2,500 deals
+Seat 1: [pass, target, pass, pass] × 2,500 deals
+Seat 2: [pass, pass, target, pass] × 2,500 deals
+Seat 3: [pass, pass, pass, target] × 2,500 deals
+Total: 10,000 deals, perfectly balanced across seats
+```
+
+**Path B (Simulation change):** Add `deal_id` to `BiddingObservation`, then
+use the `SeatAwareBiddingPolicy` wrapper.
+
+**Recommendation: Path A.** No simulation changes needed. Perfect seat
+balance (exactly 25% per seat). Deterministic with seed. The comparator
+runner already knows how to create per-policy configs — extending to
+per-seat configs is straightforward.
+
+### Step 4: Deal count and power
+
+**Problem:** Single-seat mode has a higher pass rate than 4-way mode.
+For selective bidders like hybrid_olsa (currently 62.5% bid_rate in 4-way
+mode), the per-hand bid rate will be lower, yielding fewer bid-hands and
+wider CIs.
+
+**Minimum bid-hand target:** For stable CIs on CVaR-5%, we need at least
+~500 bid-hands in the 5th percentile tail. If a bidder bids 30% of hands:
+- 10k deals → 3,000 bid-hands → 150 in 5th percentile → thin but viable
+- 20k deals → 6,000 bid-hands → 300 in 5th percentile → adequate
+- 50k deals → 15,000 bid-hands → 750 in 5th percentile → comfortable
+
+**Decision needed:** What is the minimum acceptable CI width on CVaR-5%?
+
+**Recommendation:** Start with **20,000 deals** (5,000 per seat × 4 seats).
+This is a 2× increase from the current 10k, costs minutes of wall time,
+and provides adequate power for all current bidders. If CIs are still too
+wide for the most selective bidder, increase to 50k in a follow-up.
+
+### Step 5: Re-run battery
+
+After bidder fixes (PR-B1 + PR-B2) are merged:
+
+```bash
+PYTHONPATH=src uv run python scripts/internal/run_auction_comparator.py \
+  --config experiments/configs/auction_comparator.yaml \
+  --seed 42 --single-seat --n-per 20000 \
+  --olsa-artifact data/artifacts/arc_d/r0/hybrid_r0.json \
+  --bidder-class HybridOLSaBidder --bidder-name hybrid_olsa
+```
+
+(Exact flags TBD based on implementation.)
+
+### Step 6: Re-run CI extraction
+
+```bash
+PYTHONPATH=src uv run python scripts/internal/extract_comparator_cis.py \
+  --artifacts-dir data/artifacts/arc_d/r0 --runs-dir data/runs --seed 42 \
+  --n-bootstrap 10000 \
+  --output data/artifacts/arc_d/r0/comparator_cis_r0_v3.json \
+  --battery-file comparator_battery_r0_v3.json
+```
+
+Version tag: **v3** (v1 = 5-bidder 4-way, v2 = 7-bidder 4-way,
+v3 = 7-bidder single-seat).
+
+### Step 7: Verify and crosswalk
+
+- Compare v2 (4-way) and v3 (single-seat) rankings side by side.
+- Document any rank changes and explain why (best-of-4 removal, ceiling/
+  floor fixes, threshold recalibration).
+- This crosswalk is diagnostic — it goes in the report's sensitivity
+  section, not the primary results.
+
+### Step 8: Update downstream reports
+
+Merge with the report improvements from `comparator_rankings_review_notes.md`:
+
+| File | Update |
+|------|--------|
+| `docs/04_reports/r0/comparator_rankings.md` | New numbers + methodology (v3) |
+| `docs/04_reports/r0/h2h_battery_analysis.md` §3 | Cross-reference only (Note 7: remove duplication) |
+| `docs/04_reports/r0/r0_promotion_report.md` | Update comparator context |
+
+---
+
+## Sensitivity Panel (Optional — Lower Priority)
+
+Retain one 4-way battery run as an "auction-pressure sensitivity" panel.
+
+**Purpose:** Show whether rank ordering changes under contested-auction
+conditions. This answers "does the best-of-4 selection effect favor certain
+policies?" without conflating it with the primary measurement.
+
+**Implementation:** Re-use existing v2 data OR re-run with fixed bidders
+for consistency. Label explicitly as "sensitivity analysis" in the report.
+
+**Recommendation:** Defer to after the primary single-seat battery is
+complete and reviewed. The v2 data already exists and can be referenced
+without a new run. Only re-run if bidder fixes change results enough
+that the v2 data is no longer representative.
+
+---
+
+## PR Structure
+
+**PR-C1: Single-seat mode implementation**
+- Comparator runner: `--single-seat` flag + per-seat sub-experiment logic
+- Config updates (if needed)
+- Tests for the new mode
+- Does NOT include experiment results or report updates
+
+**PR-C2: Battery re-run + report updates**
+- New v3 artifacts (not committed — data policy)
+- Updated `comparator_rankings.md` with v3 numbers
+- v2 → v3 crosswalk in sensitivity section
+- Report improvements from review notes (merged)
+
+### Sequencing
+
+```
+PR-B1 (Fix A+B) ──┐
+                   ├──→ PR-C1 (single-seat mode) → PR-C2 (rerun + report)
+PR-B2 (Fix C) ────┘
+```
+
+PR-B1 and PR-B2 can parallel. PR-C1 can parallel with PR-B1/B2 (code
+doesn't depend on bidder fixes). PR-C2 must wait for all three to merge.
+
+---
+
+## Open Questions
+
+1. **Deal count:** 20k recommended. Is this sufficient, or should we go
+   straight to 50k? Compute is cheap; the only cost is slightly larger
+   JSONL logs.
+
+2. **Artifact naming:** `comparator_cis_r0_v3.json` vs
+   `comparator_single_seat_r0.json`. v3 maintains the version sequence;
+   the descriptive name is more self-documenting. Recommend v3 for
+   consistency with existing v1/v2 naming.
+
+3. **Sensitivity panel timing:** Run alongside v3, or defer to a later PR?
+   Recommend defer — the v2 data is already available for comparison.
+
+---
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `scripts/internal/run_auction_comparator.py` | Runner (modify: add --single-seat) |
+| `scripts/internal/extract_comparator_cis.py` | CI extraction (minor: version tag) |
+| `src/bid_euchre/sim/simulation.py` | Simulation (NO changes needed with Path A) |
+| `src/bid_euchre/strategy/bidding.py` | `AlwaysPassBidder` (existing, used as sentinel) |
+| `experiments/configs/auction_comparator.yaml` | Config (document play policy) |
+| `docs/04_reports/r0/comparator_rankings.md` | Report (update with v3 data) |
+| `plans/comparator_rankings_review_notes.md` | Report improvements (merge into PR-C2) |

--- a/plans/contract_selection_analysis.md
+++ b/plans/contract_selection_analysis.md
@@ -1,0 +1,249 @@
+# Contract Selection Analysis: HIGH/LOW Under-Selection in OLSa
+
+**Date:** 2026-02-28
+**Status:** Plan document complete (v3), Step 0 execution NOT STARTED
+**Context:** R0 eval data shows 98.3% suit / 0.9% low / 0.8% high contract selection.
+
+---
+
+## Problem Statement
+
+The OLSa and HybridOLSa bidders almost never select HIGH or LOW contracts. The R0 eval report (`docs/04_reports/r0/model_arc_r0_20260224.md`) shows:
+
+| Contract | Deals | Pct |
+|----------|-------|-----|
+| suit | 31,070 | 98.3% |
+| low | 281 | 0.9% |
+| high | 261 | 0.8% |
+
+Whether this is a problem — and how large — depends on the **oracle contract mix**: the contract distribution that maximizes net EPPD when the same hand is evaluated under all 6 contracts. The oracle mix is currently unknown and must be measured empirically from paired data before setting a target. The 98.3/0.9/0.8 split may or may not be close to optimal; the goal is to measure the gap, not to assume one.
+
+## Root Cause Hypotheses
+
+Four potential compounding causes, ordered by estimated severity. **All require empirical validation** via the regret analysis in the next steps.
+
+### 1. Multi-Candidate Selection Advantage for Suit (Structural — Hypothesized HIGH)
+
+The bidder evaluates 6 candidates: C, D, H, S, HIGH, LOW, and picks the best. Suit contracts get **4 correlated-but-distinct evaluations** from a shared OLS model with different feature vectors (each suit produces different trump/bower/offsuit splits). HIGH and LOW each get **1 evaluation**. The max of 4 correlated draws tends to exceed the max of 1 draw, creating a structural advantage for suit selection.
+
+**Caveat:** The 4 suit draws are highly correlated (same model, overlapping features), so the effect is weaker than 4 independent draws. The magnitude of this bias is unknown without measurement.
+
+### 2. Feature Poverty in HIGH/LOW Models (Model Capacity — Hypothesized HIGH)
+
+Forward feature selection (`feature_selection.py`, `min_improvement=0.005`) selected only:
+
+| Contract | OLSa features | OLSa_Full features |
+|----------|--------------|-------------------|
+| suit | 3 (bowers, trump_count, offsuit_aces) | 3 (hand_value, quick_tricks, low_card_count) |
+| high | 1 (offsuit_aces) | 2 (offsuit_non_ace_count, offsuit_best_rank_sum) |
+| low | 1 (offsuit_tens_count) | 2 (offsuit_tens_count, offsuit_best_rank_sum) |
+
+The HIGH model produces ~9 discrete μ values (one per ace count). It cannot distinguish "4 aces spread across 4 suits" (excellent for HIGH) from "4 aces concentrated in 1 suit" (better as suit). The suit model, with 3 features, produces a richer prediction surface and can spike higher for strong hands.
+
+### 3. Higher Outcome Variance Penalizes HIGH/LOW (HybridOLSa — Hypothesized MEDIUM)
+
+Outcome standard deviations from the R0 report:
+
+| Contract | σ(tricks_won) |
+|----------|--------------|
+| suit | 2.50 |
+| high | 3.14 |
+| low | 3.21 |
+
+For HybridOLSa specifically, this creates a **double penalty**:
+- Larger residual σ → more probability mass below the make threshold → lower Gaussian EV
+- Larger downside tail → higher CVaR₅% penalty × risk_lambda
+
+Two contracts with identical μ and bid_n will produce different utilities, systematically favoring suit.
+
+### 4. No Cross-Contract Calibration (Model Design — Hypothesized MEDIUM)
+
+Each contract family's OLS model is trained independently on its own data. A μ=5.5 prediction from the suit model and μ=5.5 from the HIGH model are not trained to be comparable — they're predictions on different scales from models that never saw each other's data. The cross-contract comparison assumes commensurability that doesn't exist.
+
+## Decision Objective Alignment
+
+**Critical constraint:** Any contract selection improvement must align with the HybridOLSa runtime decision objective, which is **not** raw tricks but:
+
+```
+utility = EV(mu, sigma, bid_n) - CVaR_penalty(mu, sigma, bid_n)
+```
+
+Where EV uses the asymmetric net-differential payoff:
+- **Make** (tricks >= bid): `net = 2 * tricks - 10`
+- **Set** (tricks < bid): `net = tricks - bid - 10`
+
+And the bidder **passes** if `best_utility <= 0` (`bidding.py:1043`).
+
+This means:
+- Maximizing "most tricks" can **hurt** net EPPD if it increases set frequency
+- The calibrator/regret analysis must target **utility** (or net EPPD), not raw tricks
+- "Pass" must be a valid action in the selection model — not just "which contract" but "should we bid at all under this contract"
+
+## Possible Solutions
+
+Three architectural options were evaluated:
+
+### Option A: Best-Contract Classifier
+
+- **Approach:** Single classifier predicting `P(best_contract | hand)` from contract-agnostic features
+- **Training label:** Which contract maximizes utility (requires paired data + utility computation)
+- **Pros:** Directly optimizes contract selection; eliminates multi-candidate bias
+- **Cons:** Loses trick-count prediction (can't determine bid amount); doesn't capture margin of advantage; must handle "pass" as an action class
+- **Invasiveness:** Full rewrite of bidding pipeline
+
+### Option B: Unified Regression (Contract as Feature)
+
+- **Approach:** Single OLS model with contract type encoded as input features + interaction terms
+- **Called 6 times** per hand (once per candidate contract), outputs comparable μ values
+- **Pros:** Inherently calibrated; one model learns when HIGH/LOW beats suit; still outputs tricks
+- **Cons:** Single linear model may lack capacity for 3 very different contract dynamics (bowers/ruffing vs no-trump)
+- **Invasiveness:** Moderate rewrite of training + bidding
+
+### Option C: Per-Contract Models + Calibration Layer
+
+- **Approach:** Keep existing 3 OLS models, add a learned calibration layer that transforms 6 raw μ values (+ σ, bid_n) into comparable utility scores
+- **Training data:** Paired outcomes from canonical single-policy runs (same hand under all 6 contracts)
+- **Pros:** Preserves existing models (proven, interpretable); calibration layer handles cross-contract comparison
+- **Cons:** Two-stage training; calibrator limited by what per-contract models provide; requires decisions on tie-handling, pass action, and bid-level coupling (see Open Design Questions below)
+- **Invasiveness:** Additive new component, but non-trivial integration with existing `choose_bid()` logic
+
+## Recommendation
+
+**Start with the regret/oracle analysis (Step 0), then evaluate Option C.**
+
+The analysis is prerequisite because:
+1. We don't know the oracle contract mix — the problem may be smaller (or larger) than assumed
+2. Regret faceted by `(chosen, oracle_best)` quantifies exactly where tricks are lost
+3. The regret distribution informs whether a calibrator has enough signal to improve on argmax
+
+## Data Scope and Join Specification
+
+Paired data must come from **canonical single-policy runs only** to avoid confounding play quality with contract selection.
+
+- **Source config:** `canonical_bidless_dataset_glutton.yaml` (single-policy, `pair_deals: true`)
+- **NOT** mixed-play configs (`canonical_bidless_dataset_mixed_play.yaml`), which carry multiple `strategy_id`/`matchup_id` values per deal
+
+### Schema Reality
+
+The two dataset tables have **complementary but non-overlapping key columns:**
+
+| Column | `bidless.parquet` | `bidless_outcomes.parquet` |
+|--------|:-:|:-:|
+| `hand_id` | yes | yes |
+| `deal_id` | yes | yes |
+| `seat` | yes | **no** |
+| `strategy_id` | **no** | yes |
+| `contract_type` | yes | yes |
+| `trump_suit` | yes | yes |
+| `tricks_team0/1` | **no** | yes |
+| `hand_features` | yes | **no** |
+
+This means a single direct join on `(deal_id, seat, strategy_id)` is **not possible**. The construction path must be:
+
+### Step 0 Construction Path
+
+```
+1. FILTER: Use only the canonical single-policy glutton run directory.
+   This ensures a single strategy_id, eliminating mixed-policy ambiguity
+   without needing strategy_id as a join key.
+
+2. JOIN (existing): Use join_features_outcomes() from datasets/join.py.
+   This joins bidless (per-seat) ↔ outcomes (per-hand) on
+   (hand_id, contract_type, trump_suit), deduplicates outcomes,
+   and derives per-seat tricks_won from team membership:
+     seats 0,2 → tricks_team0
+     seats 1,3 → tricks_team1
+   Output: one row per (hand_id, seat) with contract_type, features, tricks_won.
+
+3. PIVOT: Widen the joined table on (contract_type, trump_suit).
+   Group by (deal_id, seat), pivot tricks_won into 6 columns:
+     tricks_suit_C, tricks_suit_D, tricks_suit_H, tricks_suit_S,
+     tricks_HIGH, tricks_LOW
+   This produces one row per (deal_id, seat) with all 6 outcomes.
+
+4. VALIDATE: Assert each (deal_id, seat) group has exactly 6 rows
+   pre-pivot (one per scenario). Drop incomplete groups with a warning.
+```
+
+**Why this works:** The canonical glutton config is single-policy, so the `join.py` dedup on `(hand_id, contract_type, trump_suit)` is unambiguous — there's only one strategy producing outcomes. The `pair_deals: true` setting ensures deal_id 0 across all 6 scenarios received identical physical hands, making the pivot semantically valid.
+
+## Open Design Questions
+
+These must be resolved before prototyping a calibrator:
+
+1. **Tie-handling for oracle best_contract:** When two contracts yield the same tricks_won, which is "best"? Options: (a) any is acceptable (multi-label), (b) prefer suit (conservative), (c) prefer higher utility after EV computation.
+
+2. **Pass as an action:** The calibrator must integrate with the `utility <= 0 → pass` gate. Should the calibrator output a utility that feeds into the existing pass gate, or should it have its own pass decision?
+
+3. **Bid-level coupling:** The calibrator sees μ values, but bid_n = floor(μ) and utility depends on bid_n. If the calibrator re-ranks contracts, the bid amount must be re-derived. A contract switch from suit (μ=5.8, bid 5) to HIGH (μ=5.5, bid 5) has different EV profiles.
+
+4. **Auction context:** `current_high_bid` constrains which contracts can even be selected (bid_n must exceed it). The calibrator must respect this filter, not override it.
+
+## Acceptance Gates
+
+### Step 0: Oracle/Regret Analysis (offline)
+
+**Pass criteria:**
+- Oracle contract mix computed from ≥50,000 paired hands
+- Regret distribution reported: mean, P50, P95, faceted by `(chosen, oracle_best)`
+- If oracle mix shows HIGH/LOW < 3% combined, the problem is smaller than hypothesized — document and reassess
+
+### Step 1: Calibrator Prototype (offline)
+
+**Pass criteria:**
+- Calibrator trained on 80% of paired data, evaluated on held-out 20%
+- **Non-regression:** calibrator-selected contracts must achieve net EPPD ≥ current argmax net EPPD on held-out data (within bootstrap 95% CI)
+- **Contract mix shift:** calibrator must produce a measurably different contract distribution (chi-squared test, p < 0.05)
+- **Pass rate stability:** pass rate within ±2pp of current OLSa pass rate
+- Unit tests for tie-handling, pass integration, and auction-context filtering
+
+### Step 2: H2H Validation (online)
+
+**Pass criteria:**
+- H2H battery: calibrated bidder vs uncalibrated bidder, ≥2,000 deals per matchup
+- Net EPPD delta ≥ 0 (non-negative, bootstrap 95% CI excludes large negative values)
+- Make rate within ±3pp of baseline
+- Contract mix reported alongside net EPPD for interpretability
+
+## Suggested Next Steps
+
+1. **Oracle/regret analysis (Step 0)** — Follow the construction path in §Data Scope: filter to canonical glutton run, join via `join_features_outcomes()`, pivot wide on contract_type. Compute oracle `best_contract` per hand (by utility, not raw tricks). Measure regret. Report oracle contract mix. This determines whether the problem warrants further investment.
+
+2. **Feature selection review** — If Step 0 confirms a meaningful gap, consider lowering `min_improvement` threshold for HIGH/LOW, or using AIC/BIC instead of R² delta, to allow more features into those models. This is independent of and complementary to a calibrator.
+
+3. **Calibrator prototype (Step 1)** — If Step 0 shows mean regret > 0.1 utility (NOT tricks — see §Decision Objective Alignment), train a calibrator on paired outcomes using μ-values + σ + bid_n as input, targeting utility-maximizing contract. Resolve open design questions first.
+
+4. **H2H validation (Step 2)** — Wire calibrator into `HybridOLSaBidder.choose_bid()` and run H2H battery against uncalibrated baseline.
+
+## Key Files
+
+| File | Relevance |
+|------|-----------|
+| `src/bid_euchre/strategy/bidding.py` | All bidder implementations; `OLSaBidder` (L691), `HybridOLSaBidder` (L778), utility/pass logic (L1027–1046) |
+| `src/bid_euchre/features/hand_eval.py` | Feature extraction (`get_hand_features`, 39 features) |
+| `src/bid_euchre/models/feature_selection.py` | Forward selection with GroupKFold, `min_improvement=0.005` |
+| `src/bid_euchre/models/train_hybrid_olsa.py` | OLSa training pipeline, per-contract split |
+| `src/bid_euchre/datasets/bidless_outcomes.py` | Outcome dataset with `strategy_id`/`matchup_id` columns (L85–88) |
+| `src/bid_euchre/datasets/join.py` | Feature-outcome join with dedup logic (L48–52) |
+| `experiments/configs/canonical_bidless_dataset_glutton.yaml` | Training data config, `pair_deals: true`, single-policy |
+| `experiments/run_experiment.py` | Deal pairing logic (L755–760) |
+| `src/bid_euchre/sim/deals.py` | Deterministic deal generation (`seed * 1_000_003 + deal_id`) |
+| `docs/04_reports/r0/model_arc_r0_20260224.md` | R0 report with contract selection frequencies |
+
+## Review Log
+
+| Date | Reviewer | Findings | Resolution |
+|------|----------|----------|------------|
+| 2026-02-28 | Agent review | 6 findings (2×P1, 4×P2) | v2: all addressed — see below |
+| 2026-02-28 | Human review | 1 finding: join key spec not realizable | v3: construction path rewritten — see below |
+
+**v2 changes (addressing review findings):**
+- **[P1-1] Decision objective mismatch:** Added "Decision Objective Alignment" section. Reframed regret/calibration target from raw tricks to utility (`EV - CVaR_penalty`). Pass action explicitly included.
+- **[P1-2] Join spec under-constrained:** Added "Data Scope and Join Specification" section. Locked to canonical single-policy runs. Required join keys include `strategy_id`. Referenced existing dedup logic in `join.py`.
+- **[P2-1] "Independent draws" overstated:** Reworded root cause #1 to "correlated-but-distinct evaluations" with explicit caveat that magnitude is unknown without measurement.
+- **[P2-2] 10–20% target ungrounded:** Removed the asserted target. Reframed problem statement around measuring the oracle mix empirically. Step 0 must establish the baseline before claiming a gap.
+- **[P2-3] Option C complexity understated:** Added "Open Design Questions" section covering tie-handling, pass integration, bid-level coupling, and auction context. Removed "least invasive" and "no training pipeline changes" language.
+- **[P2-4] Missing acceptance gates:** Added "Acceptance Gates" section with quantified pass/fail criteria for each step (oracle analysis, calibrator prototype, H2H validation). Includes non-regression thresholds, statistical tests, and test plan requirements.
+
+**v3 changes (addressing human review):**
+- **Join key spec not realizable:** `bidless_outcomes` has no `seat` column; `bidless` has no `strategy_id`. Replaced the impossible `(deal_id, seat, strategy_id)` join spec with a concrete 4-step construction path: (1) filter to single-policy run, (2) use existing `join_features_outcomes()` to get per-seat tricks_won, (3) pivot wide on contract_type, (4) validate 6-row completeness per group. Added schema comparison table showing which columns live where.

--- a/plans/report_narrative_overlay.md
+++ b/plans/report_narrative_overlay.md
@@ -1,0 +1,699 @@
+# Report Pipeline — Comprehensive Implementation Plan
+
+**Date:** 2026-02-28
+**Scope:** Four-stage report pipeline (data → charts → report → narrative), template-based drafting for recurring reports, R0 exemplar, consistency fixes
+**Status:** DECISIONS RESOLVED — ready for implementation (open items 4-5 at EOF block PR-N0b)
+
+---
+
+## Background
+
+The R0 report ecosystem has two quality tiers. Auto-generated reports (rung report, dashboard) lack
+narrative interpretation — they're tables without story. Hand-crafted reports (comparator rankings,
+H2H battery, promotion, C33 ablation) are excellent, but were shaped over 10+ PRs of iteration that
+would need to be re-derived from scratch at each rung.
+
+This plan introduces a **four-stage pipeline** and two complementary agent skills:
+
+**Pipeline stages:**
+1. **Data preparation** — JSON artifacts, eval datasets, bundles (existing)
+2. **Chart generation** — dedicated script produces PNGs from existing `plot_*` library (NEW)
+3. **Report generation** — Python generator emits markdown with embedded charts (existing `arc_d_report.py`)
+4. **Narrative overlay** — agent adds interpretation within each section (NEW `/narrate-report` skill)
+
+**Agent skills:**
+- **`/narrate-report`** — adds interpretation to auto-generated reports (stage 4)
+- **`/draft-rung-reports`** — produces first drafts of recurring hand-crafted reports from JSON artifacts + previous rung exemplars
+
+Together, these ensure that R1+ reports inherit R0's quality without re-discovering the format.
+
+### Plan Consolidation (2026-02-28)
+
+This plan consolidates remaining scope from `~/.claude/plans/kind-nibbling-sphinx.md`
+(Comparator Battery & H2H Refactor v2) and `plans/comparator_dual_track_plan.md`.
+
+**Completed items (not in this plan):**
+- C2c (#466) — comparator play strategy harmonization to GluttonStrategy
+- C3 — H2H battery rerun (QUICK+FULL), post-bugfix
+- C4 (#468) — H2H absolute per-team metrics + schema v2
+- C5 (#467) — BiddingObservation.auction_transcript
+- C2b-1 (#470) — comparator rankings refactor (v4, 9-section report)
+
+**Remaining items absorbed into this plan:**
+- C2b-2 → Phase 2 (companion report consistency: h2h_battery, promotion report,
+  measurement_integrity, README)
+- C6 → Phase 6 (dual-track report, archetype segmentation, roster scatter plots)
+
+### Design Decisions (from review session 2026-02-28)
+
+1. **Agent adds commentary within data sections** — not just dedicated narrative blocks. Each section
+   gets a summary of what was done and key takeaways.
+2. **Summarize-and-link** for companion reports — the main report carries compact tables + 2-3 sentences
+   + cross-link, rather than duplicating or just linking.
+3. **Keep generator as-is initially** — Stage 4 agent rewrites sections of the current markdown output.
+   Refactor the generator to emit JSON sidecar later, once we know exactly what the sidecar needs.
+4. **Start with manual skill invocation**, graduate to PostToolUse hook later.
+5. **R0 reports serve as seed exemplars** — manually refactored once to establish standards.
+   Future rungs use them as "previous rung context."
+
+### Resolved Questions (2026-02-28)
+
+1. **Regenerate first** — run current generator (picks up #450, #452 improvements), then overlay.
+2. **Drop date from filename** — use `model_arc_r0.md` (stable, no link churn). Archive previous
+   versions with versioning label: `archive/model_arc_r0_v1_20260224.md`. Generation timestamp
+   lives in the report header.
+3. **Show all 7 bidders** in the main report's comparator summary table (compact format: net_eppd + CI).
+4. **Key pairwise matchups** (4-5 rows) in the main report's H2H summary — shows trained-bidder
+   dominance order with delta + CI + verdict, plus the dominance diagram.
+5. **`_DRAFT` suffix** for `/draft-rung-reports` output — rename to final after review.
+6. **Skill names:** `/narrate-report` + `/draft-rung-reports`.
+
+---
+
+## Report Inventory: What Gets Produced at Each Rung
+
+### Auto-Generated (Python → Markdown)
+
+| # | Report | Generator | Narrative Value |
+|---|--------|-----------|-----------------|
+| A1 | **Rung report** | `arc_d_report.py` | **HIGH** — primary `/narrate-report` target |
+| A2 | **Cross-rung dashboard** | `generate_arc_dashboard.py` | **MEDIUM** — trend narrative |
+| A3 | Per-run analysis | `generate_report.py` | LOW — ephemeral, in `data/runs/` |
+| A4 | Batch report | `generate_batch_report.py` | LOW — ephemeral, in `data/runs/` |
+
+### Auto-Generated Data Artifacts (Python → JSON, feeds hand-crafted reports)
+
+| # | Artifact | Generator | Consumed By |
+|---|----------|-----------|-------------|
+| D1 | `promotion_decision_r{N}.json` | `write_r0_promotion.py` / `run_arc_d_gate.py` | Promotion report |
+| D2 | `comparator_battery_r{N}.json` | `run_auction_comparator.py` | Comparator rankings |
+| D3 | `comparator_cis_r{N}.json` | `extract_comparator_cis.py` | Comparator rankings |
+| D4 | `h2h_battery_quick.json` | `run_arc_d_h2h_battery.py` | H2H analysis |
+| D5 | `h2h_battery_full.json` | `run_arc_d_h2h_battery.py` | H2H analysis |
+| D6 | `gate_thresholds_r{N+1}.json` | `calibrate_arc_d_thresholds.py` | H2H analysis, Promotion report |
+| D7 | `rung_bundle_r{N}.json` | Training pipeline | Rung report, Promotion report |
+
+### Hand-Crafted, Recurring (agent/human → Markdown)
+
+| # | Report | Recurs? | Exemplar | JSON Sources | Template Value |
+|---|--------|---------|----------|--------------|----------------|
+| H1 | **Promotion report** | Every rung | `r0_promotion_report.md` | D1, D7, eval files | **HIGH** — gate results, multi-seed, attribution gap |
+| H2 | **Comparator rankings** | Every rung | `comparator_rankings.md` | D2, D3 | **HIGH** — 9 sections, behavioral profiles, methodology |
+| H3 | **H2H battery analysis** | Every rung | `h2h_battery_analysis.md` | D4, D5, D6 | **HIGH** — campaign inventory, dominance, thresholds |
+| H4 | **Measurement integrity** | Every rung | `measurement_integrity_r0.md` | All artifacts | **MEDIUM** — checklist, less structural |
+| H5 | C33 ablation | R0 only | `c33_ablation_report.md` | — | NONE — one-time |
+
+---
+
+## Work Items
+
+### Phase 0: Prerequisites
+
+Infrastructure and data fixes required before the rung report refactor.
+
+#### P0-1: Generator Data Fixes (G1–G3)
+
+Three data issues in the current generator pipeline need fixing before regeneration:
+
+| ID | Issue | Fix |
+|----|-------|-----|
+| **G1** | `rung_bundle_r0.json` `comparator_battery` points to v1 (5 bidders) | Update pointer to v4 comparator data |
+| **G2** | Bundle has no `h2h_battery` reference | Add `h2h_battery_quick` + `h2h_battery_full` references |
+| **G3** | Report §8 (Semantic Gate) shows only "PROMOTED" | Read gate checks from `promotion_decision_r0.json` and render pass/fail table |
+
+- G1/G2 are bundle schema changes → update `arc_d_bundle.py` validation
+- G3 is a generator logic change → update `_render_semantic_gate()` in `arc_d_report.py`
+- **Files:** `src/bid_euchre/validation/arc_d_bundle.py`, `src/bid_euchre/reporting/arc_d_report.py`,
+  `data/artifacts/arc_d/r0/rung_bundle_r0.json`
+
+#### P0-2: Chart Runner Script
+
+Create `scripts/internal/generate_rung_charts.py` — a dedicated script that produces all PNGs
+needed by the rung report generator, using the existing `plot_*` diagnostics library.
+
+**Rationale:** Separates chart generation from notebook execution. Notebooks remain exploratory;
+the chart runner produces the curated subset that gets embedded in formal reports. The generator
+already supports `chart_dir` parameter but currently no script produces the expected PNGs.
+
+**Chart manifest** — the generator (`arc_d_report.py`) already looks for these 10 filenames:
+
+| # | PNG Filename | Source Function | Report Section |
+|---|-------------|-----------------|----------------|
+| 1 | `seat_balance_boxplot.png` | `charts.plot_hand_value_by_seat()` | S2: Feature Health |
+| 2 | `hand_value_by_contract.png` | `charts.plot_hand_value_by_contract()` | S2: Feature Health |
+| 3 | `tricks_won_histogram.png` | `charts.plot_outcome_distributions()` | S3: Outcome Health |
+| 4 | `cdf_by_contract.png` | `charts.plot_cdf()` | S3: Outcome Health |
+| 5 | `auction_health.png` | `auction_charts.plot_auction_health()` | S4: Auction Analysis |
+| 6 | `bidder_performance.png` | `auction_charts.plot_bidder_performance()` | S4: Auction Analysis |
+| 7 | `coefficient_heatmap.png` | `charts.plot_coefficient_heatmap()` | S5: Model Specification |
+| 8 | `pred_vs_actual_scatter.png` | `model_charts.plot_model_diagnostics()` | S6: Model Performance |
+| 9 | `residual_distribution.png` | `model_charts.plot_model_diagnostics()` | S6: Model Performance |
+| 10 | `dual_arm_comparison.png` | `model_charts.plot_dual_arm_comparison()` | S7: Dual-Arm |
+
+**Additional charts** from user review (not yet in generator — add embedding support):
+
+| # | PNG Filename | Source Function | Report Section | Notes |
+|---|-------------|-----------------|----------------|-------|
+| 11 | `calibration_curve.png` | `model_charts.plot_calibration_curve()` | S6: Model Performance | S3.5 Gaussian diagnostics |
+
+**Script interface:**
+```bash
+uv run python scripts/internal/generate_rung_charts.py \
+  --rung r0 \
+  --eval-dir data/runs/arc_d_eval_r0_42_20260221_180253 \
+  --bundle data/artifacts/arc_d/r0/rung_bundle_r0.json \
+  --output-dir data/reports/arc_d/r0/charts/
+```
+
+**Output directory:** `data/reports/arc_d/r{N}/charts/` (gitignored, same as other generated data)
+
+**Implementation notes:**
+- Each chart function returns a `matplotlib.figure.Figure` — call `fig.savefig(output_dir / name)`
+- Load eval data via `build_eval_dataset()` (same as report generator)
+- Load model artifacts from bundle for coefficient/calibration charts
+- Script should be idempotent (overwrite existing PNGs)
+- Add `--chart` flag for selective chart generation (optional, for development)
+
+**Files:** `scripts/internal/generate_rung_charts.py` (new), `Makefile` (optional target)
+
+---
+
+### Phase 1: R0 Rung Report Refactor (exemplar for A1)
+
+Create the narrative exemplar that defines the standard for all future auto-generated rung reports.
+
+#### P1-0: Generate Charts, Regenerate Report, and Rename
+- Archive current report: `model_arc_r0_20260224.md` → `archive/model_arc_r0_v1_20260224.md`
+- Generate charts first (stage 2 of pipeline):
+  ```bash
+  uv run python scripts/internal/generate_rung_charts.py \
+    --rung r0 \
+    --eval-dir data/runs/arc_d_eval_r0_42_20260221_180253 \
+    --bundle data/artifacts/arc_d/r0/rung_bundle_r0.json \
+    --output-dir data/reports/arc_d/r0/charts/
+  ```
+- Regenerate report with charts (stage 3 of pipeline):
+  ```bash
+  PYTHONPATH=src uv run python -c "
+  from bid_euchre.datasets.eval_dataset import build_eval_dataset
+  from bid_euchre.reporting.arc_d_report import generate_arc_d_rung_report
+  df = build_eval_dataset('data/runs/arc_d_eval_r0_42_20260221_180253/logs/*.jsonl')
+  generate_arc_d_rung_report(
+      'data/artifacts/arc_d/r0/rung_bundle_r0.json',
+      decision_path='data/artifacts/arc_d/r0/promotion_decision_r0.json',
+      eval_df=df,
+      chart_dir='data/reports/arc_d/r0/charts/',
+      output_path='docs/04_reports/r0/model_arc_r0.md',
+  )
+  "
+  ```
+- This picks up generator improvements from #450 (eval methodology) and #452 (residual variance)
+- Charts are now embedded inline (using `chart_dir` parameter)
+- Stable filename `model_arc_r0.md` — no date in filename, timestamp in header
+- Update cross-links in companion reports and README to use new filename
+
+#### P1-1: Refactor Executive Summary
+- Replace bullet-point metadata dump with narrative structure:
+  - **What is this?** R0 purpose (baseline establishment)
+  - **What did we do?** Brief campaign inventory (~580k deals, 6 campaigns)
+  - **What did we find?** Both arms positive, ranks 2nd/7, wrapper adds +0.21
+  - **What are the caveats?** Negative attribution gap explained, high/low sample sizes
+  - **What's the decision?** PROMOTED with rationale
+- Add compact key metrics table (OLSa vs OLSa_Full side-by-side)
+- Add companion reports cross-link block
+- **File:** `docs/04_reports/r0/model_arc_r0.md`
+
+#### P1-2: Add Section Commentary (per-section notes from review)
+
+For each data section, add interpretation, charting, and borrowed analysis patterns.
+Notes below from user review session (2026-02-28), organized by report section.
+
+**S2 — Feature Health:**
+- Add pass/fail counts: how many of the N features pass each sanity check (balance, range, etc.)
+- Summary: "N features, M contract types evaluated, K deals, no anomalies detected"
+- Charts (from chart runner): seat balance boxplot, hand value by contract
+- Key insight: what the feature health tells us about data quality
+
+**S3 — Outcome Health:**
+- Add key assumptions and design: what outcomes we're measuring, what "health" means
+- Summarize distribution shape — center, spread, skew
+- Charts: tricks histogram, CDF by contract
+- Borrow pattern from `30_feature_outcome_eval.py` (S3.5 Gaussian diagnostics — Q-Q, residuals)
+
+**S4 — Auction Analysis:**
+- Add experimental design: what auction data we're analyzing, how it relates to bidding policy
+- Summarize auction behavior: bid rates, common contracts, seat effects
+- Charts: auction health (multi-panel), bidder performance
+- Reference dealer position bid analysis from `25_auction_health.py` notebooks
+
+**S5 — Model Specification:**
+- **Econometric-style consolidated table** (borrow from phase0 report pattern):
+  Side-by-side OLSa vs OLSa_Full, with rows for key parameters:
+  n_features, training set size, feature selection method, regularization, etc.
+- Chart: coefficient heatmap
+- Summarize model design choices: why OLS, why these features, what each arm tests
+- Borrow coefficient comparison analysis from `30_feature_outcome_eval.py`
+
+**S6 — Model Performance:**
+- **Econometric-style metrics table** (borrow from phase0 report):
+  Side-by-side R², RMSE, MAE with bootstrap CIs and status column (PASS/WARN/FAIL)
+- Charts: pred-vs-actual scatter, residual distribution, calibration curve (new)
+- Summarize what R²=0.24-0.29 means in context: ~75% unexplained variance is expected
+  for R0 linear models; trick outcomes have inherent randomness
+- Flag rigor concerns: sample-size warnings for high/low contracts (n<300)
+
+**S7 — Dual-Arm & Attribution Gap:**
+- Keep attribution gap analysis (own content, important narrative)
+- Summarize-and-link comparator battery: compact 7-bidder table (net_eppd + CI) + link
+  to comparator_rankings.md
+- Summarize-and-link H2H results: key pairwise matchups (4-5 rows, delta + CI + verdict)
+  + dominance diagram + link to h2h_battery_analysis.md
+- Chart: dual-arm comparison
+- Update data from 5-bidder v1 to 7-bidder v4 numbers (requires G1 fix)
+
+**S8 — Semantic Gate:**
+- Populate with pass/fail table from `promotion_decision_r0.json` (requires G3 fix)
+- Note R0 uses Tier 1 only (artifact integrity — 4 checks)
+- Cross-link to promotion report for full gate analysis + multi-seed stability
+
+**S9 — Known Limitations:**
+- Make R0-specific rather than generic boilerplate
+- Include concrete items: high/low sample sizes, single-seed eval, R² ceiling,
+  attribution gap direction, comparator sensitivity to play strategy
+- Cross-reference measurement_integrity_r0.md for methodology limitations
+- Borrow limitation framing from existing companion reports
+
+#### P1-3: Fix Reproduction Commands
+- Replace `<EVAL_RUN_DIR>`, `<LOG>`, `<RUNG>` placeholders with actual values
+- Include the full four-stage pipeline command sequence:
+  1. Chart generation (`generate_rung_charts.py`)
+  2. Report generation (`arc_d_report.py` with `chart_dir`)
+  3. Narrative overlay (`/narrate-report`)
+
+#### P1-4: Add Companion Reports Section
+New section linking all 5 companion reports with one-line descriptions:
+- r0_promotion_report.md — Gate decision + multi-seed stability
+- comparator_rankings.md — Absolute benchmarking (v4, 7 bidders)
+- h2h_battery_analysis.md — Competitive ordering + threshold calibration
+- c33_ablation_report.md — Gaussian EV wrapper validation
+- measurement_integrity_r0.md — Methodology limitations + deferral costs
+
+### Phase 2: Companion Report Consistency (= C2b-2)
+
+Fix v2→v4 data staleness in companion reports. This phase consolidates the remaining
+C2b-2 scope from `~/.claude/plans/kind-nibbling-sphinx.md` (Comparator Battery & H2H
+Refactor v2). Completed items from that plan: C2c (#466), C3 (reruns), C4 (#468),
+C5 (#467), C2b-1 (#470).
+
+#### P2-1: Update h2h_battery_analysis.md §3
+- Section 3 ("Comparator Rankings") carries v2 data (GreedyStrategy, 4-way mode)
+- Replace with v4 summary table + "see [comparator_rankings.md] for full analysis"
+- v2 data is no longer authoritative; the standalone comparator_rankings.md owns this
+- Fix H2H field terminology (from C2b scope): `bid_rate_a/b` = team auction-win
+  frequency (not per-bidder bid propensity), `make_rate_a/b` = conditional on team
+  winning bid
+- Update provenance to reference v2 H2H data (post-bugfix reruns)
+
+#### P2-2: Update r0_promotion_report.md (section-by-section from review 2026-02-28)
+
+**§1 — Executive Summary:**
+- Lines 26-28 cite v2 comparator numbers (modeloespecifico +2.291, gap 0.624)
+- Update to v4: modeloespecifico +1.587, hybrid_olsa +0.455, gap 1.132
+- Note methodology change: "single-seat comparator with GluttonStrategy card play"
+
+**§2 — Gate Results:**
+- Add brief explanation of what each gate check does (currently just names + PASS/FAIL)
+- Example: "artifact_integrity_olsa — verifies model JSON is loadable and schema-valid"
+- Note what Tier 2 checks will add at R1+ (calibration, fairness, stability)
+
+**§5 — Comparator Context:**
+- **Primary staleness issue.** Full table is v2 data (4-way mode, GreedyStrategy)
+- Replace with v4 table (single-seat, GluttonStrategy, 7 bidders with bootstrap CIs)
+- Update all v2 references in text: rankings, gap size, methodology description
+- Note the v2→v4 methodology change matters: gap nearly doubled (0.624 → 1.132)
+
+**§8 — Exclusions:**
+- H2H and C33 are no longer exclusions — they're available as companion reports
+- Rename section to "Companion Reports" or "Related Reports" with summarize-and-link
+- Convert "now available" notes into proper cross-links with one-line summaries
+
+#### P2-2b: Resolve comparator_rankings.md placeholder sections
+
+PR #470 left two placeholder sections in `comparator_rankings.md`:
+- **§4 (Contract-Type Rankings)** — "pending FULL-mode notebook run" of `45_comparator_deep_dive.py`
+- **§8 (Auction-Pressure Sensitivity)** — "pending post-fix 4-way rerun"
+
+Action: Either populate from FULL-mode data (§4: ~20 min compute via `45_comparator_deep_dive.py`
+in FULL mode), or replace both placeholders with explicit "Deferred to R1" notes explaining:
+- §4: Why FULL-mode hasn't been run yet (compute budget / prioritization)
+- §8: Whether 4-way mode is worth preserving given single-seat superiority
+
+Decision point: The 4-way rerun (§8) is a design question — if single-seat mode is the
+canonical instrument going forward, §8 may be permanently deferred or removed.
+
+#### P2-3: Update measurement_integrity_r0.md
+- Update play strategy context: comparator now uses GluttonStrategy (v4), consistent
+  with H2H battery (from C2b scope)
+- Note that play strategy confound (L3 in original review) is resolved by C2c (#466)
+
+#### P2-4: Update docs/04_reports/README.md
+- Directory structure section is stale (shows 3 files, actually 6+)
+- Add measurement_integrity_r0.md to index
+- Update descriptions to reflect v4 comparator
+
+### Phase 3: Report Conventions Documentation
+
+Codify the patterns from R0 so agents can follow them systematically.
+
+#### P3-1: Create report narrative conventions doc
+- **File:** `docs/02_agent/REPORT_NARRATIVE_CONVENTIONS.md`
+- Sections:
+  - **Exec summary convention**: Five-question structure (what, did, found, caveats, decision)
+  - **Section commentary convention**: 2-4 sentences after data tables, interpretation + caveats
+  - **Summarize-and-link convention**: When to summarize vs link, table sizing guidance
+  - **Rigor annotations**: When to flag sample sizes, missing CIs, low R²
+  - **Cross-linking convention**: How to reference companion reports, previous rungs
+  - **Exemplar references**: Points to R0 reports as the canonical examples
+
+#### P3-2: Create report template registry
+- **File:** `docs/02_agent/REPORT_TEMPLATES.md`
+- Documents the structure of each recurring report type:
+  - Promotion report: sections, required fields, JSON sources
+  - Comparator rankings: 9-section structure, what each section covers
+  - H2H battery analysis: 8-section structure, what each section covers
+  - Measurement integrity: checklist structure, classification scheme
+- For each report type: which JSON artifacts it reads, what sections are structural vs
+  rung-specific, what sections need interpretation vs data extraction
+
+### Phase 4: `/narrate-report` Skill (auto-generated reports)
+
+Agent skill that adds narrative overlay to auto-generated reports (A1, A2).
+
+#### P4-1: Create skill template
+- **File:** `.claude/skills/narrating-reports/SKILL.md`
+- Phased template:
+  - **Phase 0 — Context loading**
+    - Read the auto-generated report (stage 3 output — markdown with embedded charts)
+    - Read companion reports in same rung directory
+    - Read previous rung's final report (if exists) for tone/structure continuity
+    - Read `docs/02_agent/REPORT_NARRATIVE_CONVENTIONS.md` for style guide
+  - **Phase 1 — Executive summary**
+    - Replace bullet-point format with five-question narrative
+    - Add key metrics table (dual-arm side-by-side)
+    - Add companion reports cross-link block
+  - **Phase 2 — Section commentary**
+    - For each data section: add 2-4 sentence interpretation
+    - Flag rigor concerns inline (sample sizes, missing CIs)
+    - Add summarize-and-link blocks for topics covered by companion reports
+  - **Phase 3 — Specialized sections**
+    - Populate semantic gate with check breakdown
+    - Revise known limitations to be rung-specific
+    - Fix reproduction commands (resolve placeholders)
+    - Add companion reports section
+  - **Phase 4 — Validation checklist**
+    - [ ] All companion reports cross-linked?
+    - [ ] Sample-size warnings for n < 2000?
+    - [ ] Attribution gap explained (not left as TODO)?
+    - [ ] Gate decision has rationale?
+    - [ ] Reproduction commands have real paths?
+    - [ ] No stale v-N data (comparator, H2H versions match latest)?
+
+#### P4-2: Dashboard variant
+- Extend or create sibling skill for dashboard narrative
+- Adds trend interpretation across rungs ("R1 closed X% of the gap to modeloespecifico")
+- Lower priority — dashboard is a single table today
+
+### Phase 5: `/draft-rung-reports` Skill (recurring hand-crafted reports)
+
+Agent skill that produces first drafts of recurring reports (H1-H4) from JSON artifacts
+and previous-rung exemplars.
+
+#### P5-1: Create skill template
+- **File:** `.claude/skills/drafting-rung-reports/SKILL.md`
+- Input: rung identifier (e.g., "r1"), artifact directory path
+- Phased template:
+  - **Phase 0 — Discovery**
+    - Scan `data/artifacts/arc_d/r{N}/` for available JSON artifacts
+    - Read previous rung's reports from `docs/04_reports/r{N-1}/`
+    - Read `docs/02_agent/REPORT_TEMPLATES.md` for structural requirements
+    - Determine which reports can be drafted (based on available artifacts)
+  - **Phase 1 — Promotion report draft**
+    - Read `promotion_decision_r{N}.json` + `rung_bundle_r{N}.json`
+    - Read eval metric files for multi-seed stability table
+    - Follow R0 promotion report structure:
+      - Exec summary (narrative), Gate results (table), Evaluation metrics (multi-seed),
+        Attribution gap (narrative), Comparator context (summarize-and-link),
+        Gate thresholds (if recalibrated), Provenance (table)
+    - Adapt narrative: "R1 was PROMOTED/ADVANCED/HALTED because..."
+    - Flag sections needing human interpretation (e.g., attribution gap direction change)
+  - **Phase 2 — Comparator rankings draft**
+    - Read `comparator_cis_r{N}.json` + `comparator_battery_r{N}.json`
+    - Follow R0 comparator_rankings.md 9-section structure:
+      - Summary, Methodology, Rankings table, Contract-type breakdown,
+        Pairwise significance, Behavioral profiles, Key observations,
+        Auction-pressure sensitivity, Provenance & reproduction
+    - Populate data tables from JSON artifacts
+    - Draft behavioral profiles using R0 descriptions as base, noting any changes
+    - Draft key observations by comparing R{N} rankings to R{N-1}
+    - Flag: new bidders, rank changes, tier changes
+  - **Phase 3 — H2H battery analysis draft**
+    - Read `h2h_battery_quick.json` + `h2h_battery_full.json` + `gate_thresholds_r{N+1}.json`
+    - Follow R0 h2h_battery_analysis.md 8-section structure:
+      - What was done, C33 ablation (if applicable), Comparator summary,
+        H2H full matrix, Gate threshold calibration, Artifact inventory,
+        Conclusions, Reproduction
+    - Populate dominance tables, pairwise matchups, threshold tables from JSON
+    - Draft interpretation: which matchups changed from R{N-1}, new findings
+    - Flag: any self-play cells failing sanity, drift in thresholds
+  - **Phase 4 — Measurement integrity draft**
+    - Read all artifacts, enumerate evaluation batteries
+    - Follow R0 measurement_integrity_r0.md checklist structure
+    - Carry forward any unresolved (b)-class items from R{N-1}
+    - Flag new limitations introduced by R{N} changes
+  - **Phase 5 — Output and status**
+    - Write drafts to `docs/04_reports/r{N}/` with `_DRAFT` suffix
+    - Output summary: which reports were drafted, which artifacts were missing,
+      which sections need human review
+
+#### P5-2: Define artifact-to-report mapping
+- Machine-readable mapping (JSON or in the skill template) that specifies:
+  - Which artifacts each report type requires
+  - Which sections can be auto-populated vs need interpretation
+  - Which fields from each artifact map to which report sections
+- This enables the skill to gracefully degrade: if h2h_battery_full.json doesn't exist yet,
+  it can draft partial reports with "FULL data pending" placeholders
+
+#### P5-3: Test on R0 artifacts
+- Run `/draft-rung-reports r0` using the existing R0 JSON artifacts
+- Compare output against the actual R0 hand-crafted reports
+- Iterate on skill template until draft quality is useful as a starting point
+- "Useful" = agent or human can review and finalize in <30 min, not rewrite from scratch
+
+### Phase 6: Dual-Track Report & Roster Meta-Analysis (= C6)
+
+Consolidated from `~/.claude/plans/kind-nibbling-sphinx.md` (W6 + W6b + W6c).
+Prerequisites: C2b-2 (Phase 2), C3 (H2H reruns, DONE), C4 (#468, DONE).
+
+#### P6-1: Dual-track comparator report (W6)
+- Side-by-side presentation of both ranking tracks with explicit estimand labeling:
+
+| Track | Estimand | Source | Key Metrics |
+|-------|----------|--------|-------------|
+| Decision quality | Declaring-only, every bid evaluated | Single-seat v4 | net_eppd, bid_rate (propensity), make_rate (unconditional) |
+| Full-game | Declaring + defending, auction winners only | H2H self-play absolute | fullgame_eppd, team_bid_win_rate, team_make_rate |
+
+- Both tracks now use GluttonStrategy (confound resolved by C2c/#466)
+- Track disagreements are primarily estimand-driven (residual: `pair_deals` design difference)
+- Analysis of agreement/disagreement between tracks
+- **File:** New section in `comparator_rankings.md` or standalone `dual_track_analysis.md`
+
+#### P6-2: Archetype-segmented H2H performance (W6b)
+- Tag bidders by behavioral archetype derived from **single-seat comparator** metrics:
+
+| Archetype | Criterion (single-seat) | R0 Bidders |
+|-----------|------------------------|------------|
+| AGGRESSIVE | bid_rate > 0.95 AND make_rate < 0.65 | fiveheadfred, rankthetank |
+| SELECTIVE | bid_rate < 0.50 | hybrid_olsa, modeloespecifico |
+| NEUTRAL | bid_rate > 0.95 AND make_rate ≥ 0.65 | stricthellraiser, olsa, olsa_full |
+
+- Use tolerance bands (not exact thresholds) — flag edge cases for manual review
+- Per-bidder table: mean H2H delta vs AGGRESSIVE / NEUTRAL / SELECTIVE opponents
+- Archetype labels derived from single-seat data only (bid_rate = per-hand propensity);
+  do NOT derive from H2H fields (different semantics: team auction-win frequency)
+
+#### P6-3: Roster meta-analysis scatter plots (W6c)
+- Three scatter plots decomposing rankings into behavioral components:
+  1. **bid_rate × make_rate** — calibration (who overbids?)
+  2. **bid_rate × net_eppd** — efficiency (payoff of selectivity)
+  3. **make_rate × net_eppd** — conversion (who turns makes into points?)
+- All from single-seat comparator v4 data (decision-quality estimand)
+- Points labeled by bidder name, colored by archetype
+- Track longitudinally across rungs (R0, R1, R2, ...)
+- Add to `diagnostics/strategy_charts.py` or new `diagnostics/roster_charts.py`
+
+---
+
+## PR Strategy
+
+| PR | Phase | Items | Depends On | Type |
+|----|-------|-------|------------|------|
+| **PR-N0a** | P0 | P0-1 (G1–G3) | — | Code: Generator data fixes |
+| **PR-N0b** | P0 | P0-2 | Resolve open items 4-5 | Code: Chart runner script |
+| **PR-N1** | P1 | P1-0 through P1-4 | PR-N0a, PR-N0b, Step 0 | Doc: R0 rung report refactor |
+| **PR-N2** | P2 | P2-1 through P2-4 (incl. P2-2b) | PR-N1 | Doc: Companion report consistency (= C2b-2) |
+| **PR-N3** | P3 | P3-1, P3-2 | — | Doc: Conventions + template registry |
+| **PR-N4** | P4 | P4-1 | PR-N3 | Skill: `/narrate-report` |
+| **PR-N5** | P5 | P5-1, P5-2 | PR-N3 | Skill: `/draft-rung-reports` |
+| **PR-N6** | P4+P5 | P4-2, P5-3 | PR-N4, PR-N5 | Testing + dashboard variant |
+| **PR-N7** | P6 | P6-1 through P6-3 | PR-N2 | Report+viz: Dual-track + archetype + scatter (= C6) |
+
+**Dependency notes:**
+- PR-N0a and PR-N3 have no blockers — start immediately (parallel).
+- PR-N0b requires resolving open items 4-5 (calibration curve embedding, model artifact loading).
+- PR-N1 (R0 report refactor) is blocked on Step 0 of the contract selection analysis.
+  If calibrator is adopted, R0 experiments re-run first, then PR-N1 uses new data.
+  If calibrator is not needed, PR-N1 proceeds with current data.
+- PR-N3 (conventions) is decoupled from PR-N1 — conventions are model-agnostic.
+  PR-N4 and PR-N5 (skills) can be built while waiting for Step 0.
+- PR-N7 depends on PR-N2 (needs consistency fixes in companion reports first).
+
+### Critical Path
+
+```
+                                    Contract Selection Step 0 (oracle analysis)
+                                      │
+PR-N0a (generator data fixes)  ─┐    │   (if calibrator: re-run R0 experiments)
+                                 ├────┴──→ PR-N1 (R0 exemplar)
+PR-N0b (chart runner script)   ─┘              │
+                                                ├──→ PR-N2 (C2b-2 consistency) ──→ PR-N7 (C6 dual-track)
+                                                │
+PR-N3 (conventions docs)  ─────────────────────(parallel, no blockers)
+  ├──→ PR-N4 (/narrate-report)     ─┐
+  └──→ PR-N5 (/draft-rung-reports)  ─┤──→ PR-N6 (testing)
+                                      │
+                                 (parallel)
+```
+
+**Two independent tracks can proceed in parallel:**
+- **Infrastructure track:** PR-N0a → PR-N0b → (ready for PR-N1 when Step 0 resolves)
+- **Skills track:** PR-N3 → PR-N4/N5 → PR-N6 (fully independent of Step 0)
+
+---
+
+## Contract Selection Analysis — R0 Ablation Dependency
+
+The contract selection investigation (`plans/contract_selection_analysis.md` v3) may add
+a calibration layer for cross-contract utility comparison. **This must be measured at R0**
+to preserve the ablation — the same logic as the C33 Gaussian wrapper ablation.
+
+### Why R0, Not R1
+
+If the calibrator is adopted only at R1 alongside other changes (new features, opponent
+context, more training data), the calibrator's effect cannot be isolated. The ablation is:
+
+```
+R0-without-calibrator  →  R0-with-calibrator     (isolates calibrator effect)
+R0-with-calibrator     →  R1                      (isolates R1-specific changes)
+```
+
+Deferring the calibrator to R1 collapses both into a single R0→R1 delta where the
+calibrator's contribution is confounded with everything else.
+
+### Sequencing: Step 0 Gates R0 Report Finalization
+
+```
+Step 0: Oracle analysis (offline, uses existing paired data)
+  │
+  ├─ Oracle gap small (HIGH/LOW < 3% combined)
+  │    → Contract selection is near-optimal
+  │    → Document finding in R0 reports
+  │    → Finalize R0 reports (Phases 1–2)
+  │    → R1 proceeds without calibrator
+  │
+  └─ Oracle gap meaningful (regret > 0.1 utility)
+       → Step 1: Build calibrator prototype
+       → Step 2: H2H validation (calibrated vs uncalibrated R0)
+       → Re-run R0 experiments with calibrated model
+       → Update R0 reports with calibrator ablation results
+       → Finalize R0 reports (Phases 1–2)
+       → R1 builds on calibrated R0 baseline
+```
+
+### Impact on This Plan
+
+**Unaffected (build now, model-agnostic infrastructure):**
+- Phase 0: Chart runner script + generator data fixes
+- Phase 3: Report conventions + template registry
+- Phase 4: `/narrate-report` skill
+- Phase 5: `/draft-rung-reports` skill
+
+**Blocked until Step 0 completes:**
+- Phase 1: R0 rung report refactor — may need calibrator ablation data
+- Phase 2: Companion report consistency — comparator/H2H data may change
+- Phase 6: Dual-track + archetype analysis — rankings may shift
+
+**Conditionally blocked (if calibrator adopted):**
+
+| R0 Re-run | Why | Estimated Scale |
+|---|---|---|
+| R0 eval runs (3 seeds) | New contract mix → different net_eppd, bid_rate, make_rate | 50k deals × 3 seeds |
+| R0 comparator battery | Calibrated hybrid_olsa entry replaces uncalibrated | 7+ bidders × 4 seats × 20k deals |
+| R0 H2H battery (QUICK+FULL) | New pairwise matchups with calibrated bidder | 49+ cells × 2k-10k deals |
+| R0 gate threshold recalibration | Null distribution may shift with new model | Depends on H2H results |
+| R0 rung bundle | Updated model artifact, new eval metrics | Bundle rebuild |
+| All R0 reports | Produced from new data via four-stage pipeline | Full pipeline run |
+
+### Recommended Execution Order
+
+1. **Build pipeline infrastructure now** (Phases 0, 3, 4, 5) — needed regardless of
+   calibrator outcome. This is the critical path for R1 readiness.
+2. **Run Step 0 in parallel** — oracle analysis is offline, uses existing paired data,
+   fast to execute. The answer determines whether Phases 1–2 proceed as-is or wait.
+3. **If calibrator adopted:**
+   a. Build calibrator (Step 1) + validate (Step 2) — ~1-2 PRs
+   b. Re-run R0 experiment suite with calibrated model
+   c. Run four-stage pipeline on new R0 data to produce updated reports
+   d. Document calibrator ablation (analogous to `c33_ablation_report.md`)
+4. **If calibrator not needed:**
+   a. Document oracle analysis finding in R0 reports (contract selection is near-optimal)
+   b. Finalize R0 reports (Phases 1–2) with current data
+5. **Proceed to R1** once R0 reports are finalized under either branch.
+
+## Future Scope (not in this plan)
+
+- **Makefile pipeline target** — single `make rung-report RUNG=r0` that chains all four stages
+  (data prep → chart generation → report generation → narrative overlay prompt)
+- **Generator JSON sidecar** — refactor `arc_d_report.py` to emit structured data alongside markdown
+  (cleaner stage 3→stage 4 contract, eliminates markdown parsing in `/narrate-report`)
+- **PostToolUse hook** — auto-trigger `/narrate-report` after `generate_arc_d_rung_report` calls
+- **PostToolUse hook** — auto-trigger `/draft-rung-reports` after gate runner completes
+- **Chart runner extensions** — add comparator/H2H charts for companion reports
+  (currently only produces rung-report charts)
+- **Per-run ANALYSIS_SUMMARY overlay** — narrative for experiment-level reports (low priority)
+- **Notebook narrative** — auto-generate markdown cells summarizing notebook outputs
+
+---
+
+## Resolved Questions
+
+All 6 open questions were resolved on 2026-02-28. See "Resolved Questions" in Design Decisions above.
+
+## Remaining Open Items
+
+1. **Archive versioning label format.** Proposed: `model_arc_r0_v1_20260224.md` (vN + original date).
+   Confirm this pattern works for cases where a report has multiple revisions within the same day.
+
+2. **Cross-link update scope.** Renaming `model_arc_r0_20260224.md` → `model_arc_r0.md` requires
+   updating links in README.md, dashboard, and any companion reports that reference the old filename.
+   Need to grep for all references.
+
+3. **Eval data glob pattern.** The regeneration command uses `*.jsonl` — need to verify the exact
+   log file path in the eval run directory before running.
+
+4. **Calibration curve embedding.** The generator doesn't currently look for `calibration_curve.png`.
+   Need to add embedding support in `_render_model_performance()` (small addition to P0-1 or P0-2).
+
+5. **Chart runner model artifact loading.** Charts #7-10 (coefficient heatmap, pred-vs-actual,
+   residuals, dual-arm comparison) require model artifacts (coefficients, predictions). Need to
+   determine whether these are loaded from the bundle, from the eval run, or need separate loading
+   logic in the chart runner script.


### PR DESCRIPTION
## Summary
- Add MASTER_PLAN.md and 10 referenced sub-plans to version control
- Fix two internal consistency issues identified during final review:
  - PR-N0b dependency: `None` → `Resolve open items 4-5` (line 128)
  - Phase D checklist header: `blocked on C2` → `blocked on C2 + B4` (line 513)
- Update arc_d_execution_plan.md and c33_ablation_refactor_plan.md with review fixes

## Why
The master plan governs all remaining work for the R0→R1 transition and beyond.
Committing it and all sub-plans ensures cold-start context is available for any
session and enables traceability of planning decisions. The two fixes ensure the
summary table and checklist are consistent with the Phase Status table and sub-plan
dependency declarations.

## Repro / Validation
**Command(s) run:**
- Verified consistency: `grep -n "PR-N0b" plans/MASTER_PLAN.md` (shows `Resolve open items 4-5`)
- Verified consistency: `grep -n "Phase D" plans/MASTER_PLAN.md` (shows `blocked on C2 + B4`)
- Cross-referenced with `report_narrative_overlay.md` line 541 and Phase Status table line 64

**Config (if applicable):**
- N/A (docs only)

**Seed (if applicable):**
- N/A

## Tests
- [x] N/A — docs-only PR (no code changes)

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-master-plan-fixes
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-master-plan-fixes
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                       fe075ad [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-master-plan-fixes     c348a76 [master-plan-fixes]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)