### PR TITLE
feat: auto-invoke /reviewing-changes via PostToolUse additionalContext

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -60,6 +60,23 @@ Then restart your Claude session in that directory.
      cd ../Bid-Euchre-<branch-name>
 ```
 
+### `post-pr-review.sh` (PostToolUse)
+
+**Trigger:** After any Bash tool call
+
+**Purpose:** Auto-invokes `/reviewing-changes` skill after successful `gh pr create`
+
+**Behavior:**
+1. Checks if the Bash command contained `gh pr create` and exit code was 0
+2. If yes: emits structured JSON with `additionalContext` directive
+3. Claude reads the injected context and auto-invokes the `/reviewing-changes` skill
+4. The skill reviews code quality, convention compliance, and generates a handoff summary
+
+**How it works:**
+- PostToolUse hooks can return JSON with a `hookSpecificOutput.additionalContext` field
+- This text is injected into Claude's conversation context on the next turn
+- The directive instructs Claude to invoke the skill without waiting for user input
+
 ## Helper Script
 
 ### `../scripts/claude-worktree.sh`

--- a/.claude/hooks/post-pr-review.sh
+++ b/.claude/hooks/post-pr-review.sh
@@ -12,10 +12,16 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
 EXIT_CODE=$(echo "$INPUT" | jq -r '.tool_response.exit_code // 0')
 
 if [[ "$COMMAND" == *"gh pr create"* ]] && [[ "$EXIT_CODE" == "0" ]]; then
-  echo ""
-  echo "PR created successfully."
-  echo "Now run /reviewing-changes to review the code and generate a handoff summary."
-  echo "This will check for quality issues, convention compliance, and produce a copyable context block."
+  # Emit structured JSON so additionalContext is injected into Claude's
+  # conversation context, making it auto-invoke /reviewing-changes.
+  cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "A PR was just created successfully. You MUST now invoke the /reviewing-changes skill immediately — do not wait for the user to ask. This skill reviews the PR for quality issues, convention compliance, and generates a handoff summary."
+  }
+}
+EOF
 fi
 
 exit 0


### PR DESCRIPTION
## Summary
- Switch `post-pr-review.sh` from plain-text `echo` to structured JSON with `additionalContext`
- Claude now auto-invokes `/reviewing-changes` after `gh pr create` succeeds (no user action needed)
- Document the `post-pr-review.sh` hook in the hooks README

## Why
The previous plain-text output was only a user-visible notification — Claude didn't act on it.
By emitting structured JSON with `hookSpecificOutput.additionalContext`, the directive gets
injected into Claude's conversation context, making it auto-invoke the skill.

## Repro / Validation
**Command(s) run:**
- `make check-quiet` — all checks pass

**Config (if applicable):**
- N/A

**Seed (if applicable):**
- N/A

## Tests
- [x] `make check-quiet` passes
- [ ] Manual: create a PR in a future session and verify `/reviewing-changes` auto-triggers

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None — hook is <5s

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-hook-auto-review
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-hook-auto-review
```

`git worktree list` (relevant line):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-hook-auto-review      0e39298 [hook-auto-review]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)