### PR TITLE
feat: Phase 0→R0 progression report + bundle gate

### DIFF
--- a/docs/01_core/DATA_CONTRACT.md
+++ b/docs/01_core/DATA_CONTRACT.md
@@ -121,6 +121,7 @@ Each rung is tracked by an `arc_d_rung_bundle_v1` bundle with these key fields:
 | `olsa_full` | dict | Promotional arm block (artifact path, eval path, feature set) |
 | `split_manifest` | str | Path to shared split manifest |
 | `training_report` | str | Path to training report |
+| `progression_report` | str | R1+ only. Path to rung-to-rung progression report. |
 
 ### Promotion Decision Schema (v3)
 

--- a/docs/01_core/schemas/hybrid_olsa_v1.md
+++ b/docs/01_core/schemas/hybrid_olsa_v1.md
@@ -89,8 +89,18 @@ When both arms are trained, a `rung_bundle_r{N}.json` packages them:
     "selected_features": {"suit": [...], "high": [...], "low": [...]}
   },
   "split_manifest": "split_manifest_r0_suit.json",
-  "training_report": "training_report_r0.json"
+  "training_report": "training_report_r0.json",
+  "progression_report": "docs/04_reports/r1/r0_to_r1_progression.md"
 }
+```
+
+Note: `progression_report` is required for R1+ bundles. It points to the
+rung-to-rung progression report documenting what changed between the prior
+and current rung. R0 bundles are exempt (no prior rung to compare against).
+
+```text
+R0: progression_report absent (exempted)
+R1+: progression_report = "docs/04_reports/r1/r0_to_r1_progression.md" (required)
 ```
 
 ## R5 Extension: Offensive/Defensive Sub-Models

--- a/docs/04_reports/README.md
+++ b/docs/04_reports/README.md
@@ -25,6 +25,7 @@ docs/04_reports/
     contract_selection_oracle.md (oracle regret analysis)
     pass_threshold_decision.md   (B0 threshold sweep)
     measurement_integrity_r0.md  (methodology review)
+    phase0_to_r0_progression.md  (Phase 0→R0 progression)
     archive/                     (superseded revisions)
   r1/                      Arc D R1 rung report + companions
     30_feature_outcome_eval.md   (feature-outcome eval template)
@@ -46,6 +47,7 @@ docs/04_reports/
 | [r0/contract_selection_oracle.md](r0/contract_selection_oracle.md) | 2026-03-01 | Contract selection oracle: regret decomposition, pass-threshold dominance |
 | [r0/pass_threshold_decision.md](r0/pass_threshold_decision.md) | 2026-03-02 | B0 threshold sweep decision: RETAIN t=0 (monotonic decline) |
 | [r0/measurement_integrity_r0.md](r0/measurement_integrity_r0.md) | 2026-02-26 | Methodology limitations + deferral costs (L1-L3 resolved/partially resolved) |
+| [r0/phase0_to_r0_progression.md](r0/phase0_to_r0_progression.md) | 2026-03-01 | Phase 0→R0 progression: variance direction check, contract mix shift, role asymmetry |
 
 Superseded revisions in `r0/archive/`.
 

--- a/docs/04_reports/r0/phase0_to_r0_progression.md
+++ b/docs/04_reports/r0/phase0_to_r0_progression.md
@@ -1,0 +1,276 @@
+# Phase 0 → R0 Progression Report
+
+**Arc:** D — OLSa-Hybrid Bidder
+**Rung:** R0
+**Date:** 2026-03-01
+**Purpose:** Post-hoc cross-phase comparison documenting the transition from bidless
+baseline (Phase 0) to first bidding model (R0)
+
+---
+
+## Executive Summary
+
+Phase 0 (forced random contracts, n=300,000 hands × 3 contracts = 1,200,000 rows)
+and R0 (auction-selected contracts, n=31,612 deals = 126,448 rows) show the expected
+divergence in contract selection and outcome distributions:
+
+- **Contract mix shift:** Phase 0 forced ~33/33/33 suit/high/low → R0 auctions
+  produce 98.3% suit / 0.8% high / 0.9% low, driven by R0's 1-feature HIGH/LOW
+  models that rarely find profitable non-suit contracts.
+- **Variance direction (suit, declaring-side):** Phase 0 std(tricks_won) = 1.72 →
+  R0 declaring-side std = 1.60. The 7% reduction is directionally consistent with
+  auction selection filtering weak hands, though the comparison is confounded by the
+  forced-vs-selected contract asymmetry.
+- **Mean stability:** mean(tricks_won) = 5.00 in both phases across all contract types,
+  confirming simulation fairness (symmetric self-play).
+- **R0 role asymmetry:** R0 declaring teams average 6.92 tricks (suit), reflecting
+  the auction's selection of strong hands. The overall R0 suit std (2.50) is higher
+  than Phase 0's (1.72) due to pooling across roles with different means — this is a
+  Simpson's paradox artifact, not a real variance increase.
+
+R0 is already PROMOTED. This report validates retroactively and establishes the
+progression report pattern for future rung transitions.
+
+---
+
+## 1. Motivation
+
+The project lacked any cross-phase comparison between Phase 0 (bidless baseline) and
+R0 (first bidding model). Phase 0 established ground-truth outcome distributions
+under forced contracts — every hand plays every contract regardless of suitability.
+R0 introduced auction-selected contracts where the bidding model filters hands based
+on predicted payoff.
+
+The core hypothesis: auction selection should reduce declaring-side outcome variance
+within contract types, because the bidder avoids playing weak hands. This report
+tests that hypothesis with appropriate caveats about comparability.
+
+**Prior work:**
+- Phase 0 baseline: [phase0_bidless_20260207.md](../phase0/phase0_bidless_20260207.md)
+- R0 rung report: [model_arc_r0.md](model_arc_r0.md)
+- R0 promotion decision: [r0_promotion_report.md](r0_promotion_report.md)
+
+---
+
+## 2. Methodology
+
+### Data Sources
+
+| Source | Dataset | Hands | Rows | Contracts | Mode |
+|--------|---------|-------|------|-----------|------|
+| Phase 0 | canonical_bidless_dataset_glutton_42_20260221_175752 | 300,000 | 1,200,000 | Forced (suit × 4 trumps + high + low) | Symmetric self-play, no auction |
+| R0 | arc_d_eval_r0_42_20260221_180253 | 31,612 | 126,448 | Auction-selected | Symmetric self-play with OLSa_Full R0 bidder |
+
+**Phase 0 loader:** `join_features_outcomes()` from `src/bid_euchre/datasets/join.py`
+(same loader used by oracle notebook `55_contract_selection_oracle.py`).
+
+**R0 loader:** `build_eval_dataset()` from `src/bid_euchre/datasets/eval_dataset.py`
+applied to the R0 evaluation JSONL log.
+
+### Statistics
+
+- **Primary metric:** std(tricks_won) per contract_type, stratified by role where applicable
+- **Contract mix:** proportion of deals per contract_type
+- **Role stratification:** R0 is split by declaring/defending team; Phase 0 has no
+  roles (all hands play all contracts, no auction)
+
+### Comparability Caveat
+
+Phase 0 forces every hand into every contract regardless of hand strength. R0
+self-selects via auction. The variance comparison is a hypothesis with confounds,
+not a controlled experiment. Differences could reflect:
+
+1. **Selection effects** — auction filters weak hands (expected direction: lower declaring variance)
+2. **Model imperfections** — R0's 1-feature HIGH/LOW models rarely bid non-suit contracts
+3. **Role asymmetry** — R0 has declaring/defending teams; Phase 0 is symmetric
+4. **Sample size imbalance** — Phase 0 has 800,000 suit rows vs R0's 124,280
+
+---
+
+## 3. Results
+
+### Table 1: Per-Contract Tricks Won Statistics
+
+| Contract | Phase | Mean | Std | P5 | P25 | P50 | P75 | P95 | n |
+|----------|-------|------|-----|-----|-----|-----|-----|-----|---|
+| suit | Phase 0 | 5.00 | 1.72 | 2.00 | 4.00 | 5.00 | 6.00 | 8.00 | 800,000 |
+| suit | R0 (all) | 5.00 | 2.50 | 1.00 | 3.00 | 5.00 | 7.00 | 9.00 | 124,280 |
+| suit | R0 declaring | 6.92 | 1.60 | 4.00 | 6.00 | 7.00 | 8.00 | 9.00 | 62,140 |
+| suit | R0 defending | 3.08 | 1.60 | 1.00 | 2.00 | 3.00 | 4.00 | 6.00 | 62,140 |
+| high | Phase 0 | 5.00 | 1.87 | 2.00 | 4.00 | 5.00 | 6.00 | 8.00 | 200,000 |
+| high | R0 (all) | 5.00 | 3.14 | 0.00 | 2.00 | 5.00 | 8.00 | 10.00 | 1,044 |
+| high | R0 declaring | 7.82 | 1.38 | — | — | — | — | — | 522 |
+| high | R0 defending | 2.18 | 1.38 | — | — | — | — | — | 522 |
+| low | Phase 0 | 5.00 | 1.88 | 2.00 | 4.00 | 5.00 | 6.00 | 8.00 | 200,000 |
+| low | R0 (all) | 5.00 | 3.21 | 0.00 | 2.00 | 5.00 | 8.00 | 10.00 | 1,124 |
+| low | R0 declaring | 7.88 | 1.42 | — | — | — | — | — | 562 |
+| low | R0 defending | 2.12 | 1.42 | — | — | — | — | — | 562 |
+
+Percentiles omitted for R0 high/low declaring/defending due to small samples (n<600).
+
+### Table 2: Contract Mix Comparison
+
+| Contract | Phase 0 | R0 |
+|----------|---------|-----|
+| suit | 66.7% (forced: 4 trumps × 2 = 8 of 12 slots) | 98.3% (121,280 / 126,448) |
+| high | 16.7% (1 of 6 contract types) | 0.8% (1,044 / 126,448) |
+| low | 16.7% (1 of 6 contract types) | 0.9% (1,124 / 126,448) |
+
+Note: Phase 0 percentages reflect the bidless dataset structure where each hand
+plays each contract type. Suit has 4 trump variants per hand while high and low have
+1 each, giving a natural 4:1:1 ratio (66.7/16.7/16.7).
+
+### Table 3: Variance Ratio (R0 Declaring / Phase 0)
+
+| Contract | Phase 0 Std | R0 Declaring Std | Ratio | Direction |
+|----------|-------------|-------------------|-------|-----------|
+| suit | 1.72 | 1.60 | 0.93 | Lower (expected) |
+| high | 1.87 | 1.38 | 0.74 | Lower (expected) |
+| low | 1.88 | 1.42 | 0.75 | Lower (expected) |
+
+All three contract types show reduced declaring-side variance in R0 compared to the
+Phase 0 forced-contract baseline.
+
+**Chart references:**
+- Phase 0 outcome distributions: Phase 0 report §5b
+- R0 outcome health: R0 notebook `20_outcome_health` S2
+
+---
+
+## 4. Interpretation
+
+### Variance Direction Check: Confirmed
+
+The directional hypothesis holds: R0 declaring-side std(tricks_won) is lower than
+Phase 0 std in all three contract types. The suit contract ratio (0.93) represents a
+modest 7% reduction; high and low show larger reductions (26% and 25%) but with
+much smaller R0 samples (n~500 each).
+
+### Why Overall R0 Variance Is Higher
+
+The R0 overall (all-seats) suit std of 2.50 exceeds Phase 0's 1.72. This is expected
+and is *not* evidence against the hypothesis. The inflation comes from pooling two
+subpopulations with different means:
+
+- R0 declaring: mean=6.92, std=1.60
+- R0 defending: mean=3.08, std=1.60
+
+Pooling these into a single distribution produces a bimodal-like spread with inflated
+standard deviation (Simpson's paradox in variance). Phase 0 has no declaring/defending
+distinction — all seats are symmetric.
+
+### Contract Mix Concentration
+
+R0 produces 98.3% suit contracts because the R0 model uses only 1 feature each for
+HIGH (offsuit_aces) and LOW (offsuit_tens_count). These sparse specifications rarely
+produce positive expected value, so the bidder almost always selects suit contracts
+where the 3-feature model provides better discrimination. This is a known R0 limitation
+documented in the [model specification](model_arc_r0.md) and motivating R1's
+HIGH/LOW feature enrichment.
+
+### Confound Analysis
+
+1. **Forced vs selected contracts:** Phase 0 includes all hands regardless of strength;
+   R0's auction self-selects. The declaring-side variance reduction could reflect
+   genuine filtering (weak hands pass) or mean-shift mechanics (declaring teams always
+   have stronger hands by construction).
+2. **Symmetric vs asymmetric play:** Phase 0 uses GluttonStrategy for all 4 seats
+   (pure play, no bidding). R0 uses OLSa_Full R0 for all 4 seats (self-play with
+   auction). The introduction of an auction changes both hand selection and play dynamics.
+3. **Sample size:** R0 high/low have <600 declaring observations each. The variance
+   ratios for these contracts are suggestive but not statistically robust.
+
+### Mean Stability
+
+mean(tricks_won) = 5.00 in both phases across all contract types and roles. This
+confirms the simulation's zero-sum property: in self-play, average tricks per seat
+must equal 10/4 = 2.5, and per team must equal 10/2 = 5.0. This is a structural
+property, not a coincidence.
+
+---
+
+## 5. Impact & Decisions
+
+- **R0 is PROMOTED** — already decided via the [R0 promotion gate](r0_promotion_report.md).
+  This report validates retroactively and does not change any decision.
+- **Variance results inform R1 priorities:** The extreme contract mix concentration
+  (98.3% suit) and sparse HIGH/LOW models confirm that HIGH/LOW feature enrichment
+  is the correct R1 priority (see P1 in R1 follow-ups).
+- **Progression report pattern:** This report establishes the template for future
+  rung-to-rung comparisons. Starting at R1, a `progression_report` is a required
+  bundle artifact enforced by the rung bundle validator.
+
+---
+
+## 6. Arc Context
+
+```
+Phase 0 (bidless baseline)
+  ↓  [this report]
+R0 (first bidding model, OLSa-Hybrid with 3/1/1 features)
+  ↓  [R1 follow-ups: HIGH/LOW enrichment, 2×2 factorial design]
+R1 (enriched features, auction-trained data)
+  ↓
+R2+ (context features, risk adjustment)
+```
+
+Phase 0 provides the unconditional baseline — what outcomes look like when every hand
+plays every contract. R0 introduces selection via auction, reducing declaring-side
+variance and concentrating contracts. R1 will address the HIGH/LOW feature gap and
+train on auction-generated data for the first time.
+
+---
+
+## 7. Provenance
+
+| Field | Value |
+|-------|-------|
+| gate_status | N/A (post-hoc retroactive report, not a gate input) |
+| Phase 0 dataset | `data/runs/canonical_bidless_dataset_glutton_42_20260221_175752/datasets/bidless.parquet` + `bidless_outcomes.parquet` |
+| R0 eval run | `data/runs/arc_d_eval_r0_42_20260221_180253/logs/arc_d_eval_r0_42_20260221_180253_hybrid_olsa_r0.jsonl` |
+| Phase 0 seed | 42 |
+| R0 seed | 42 |
+| Phase 0 sample | 300,000 hands × 4 seats = 1,200,000 rows |
+| R0 sample | 31,612 deals × 4 seats = 126,448 rows |
+| R0 promotion decision | PROMOTED (see r0_promotion_report.md) |
+
+---
+
+## 8. Reproduction
+
+### Phase 0 Statistics
+
+```bash
+PYTHONPATH=src uv run python -c "
+from bid_euchre.datasets.join import join_features_outcomes
+df = join_features_outcomes(
+    'data/runs/canonical_bidless_dataset_glutton_42_20260221_175752/datasets/bidless.parquet',
+    'data/runs/canonical_bidless_dataset_glutton_42_20260221_175752/datasets/bidless_outcomes.parquet',
+)
+print(df.groupby('contract_type')['tricks_won'].agg(['mean','std','count']))
+for ct in ['suit', 'high', 'low']:
+    sub = df[df['contract_type'] == ct]['tricks_won']
+    print(f'{ct}: P5={sub.quantile(0.05):.1f}, P25={sub.quantile(0.25):.1f}, '
+          f'P75={sub.quantile(0.75):.1f}, P95={sub.quantile(0.95):.1f}')
+"
+```
+
+### R0 Statistics
+
+```bash
+PYTHONPATH=src uv run python -c "
+from bid_euchre.datasets.eval_dataset import build_eval_dataset
+df = build_eval_dataset(
+    'data/runs/arc_d_eval_r0_42_20260221_180253/logs/'
+    'arc_d_eval_r0_42_20260221_180253_hybrid_olsa_r0.jsonl'
+)
+print(df.groupby('contract_type')['tricks_won'].agg(['mean','std','count']))
+for ct in ['suit', 'high', 'low']:
+    for role in [True, False]:
+        sub = df[(df['is_declaring_team'] == role) & (df['contract_type'] == ct)]
+        label = 'declaring' if role else 'defending'
+        if len(sub) > 0:
+            print(f'{ct} {label}: mean={sub[\"tricks_won\"].mean():.3f}, '
+                  f'std={sub[\"tricks_won\"].std():.3f}, n={len(sub)}')
+"
+```

--- a/plans/arc_d_execution_plan.md
+++ b/plans/arc_d_execution_plan.md
@@ -1103,6 +1103,11 @@ promotion gate:
 }
 ```
 
+**Required R1+ key (v3.2):**
+- `progression_report` (string): R1+ only — path to rung-to-rung progression report
+  (e.g., `docs/04_reports/r1/r0_to_r1_progression.md`). Enforced by bundle validator
+  as an artifact existence gate. R0 bundles are exempt (no prior rung).
+
 **Optional comparator keys (v3.1):**
 - `comparator_battery` (string | null): R0 only — path to heuristic battery JSON.
   Null at R1–R5 (R0-only artifact) or if battery script failed at R0.

--- a/plans/r1_follow_ups.md
+++ b/plans/r1_follow_ups.md
@@ -24,6 +24,7 @@ See `arc_d_execution_plan.md` §Phase R1 for the gate definition.
 | P4 | Pass-threshold re-tuning | **Yes** | — | Re-run B0 protocol |
 | P5 | Deferred report sections | No (deferrable) | — | |
 | P6 | H2H bid_rate caveat | No (deferrable) | — | Verify terminology |
+| P7 | Rung-to-rung report pipeline | No (deferrable) | — | Automate progression reports |
 
 **Disposition values:** DONE / DEFERRED (with rationale + target rung) / NOT APPLICABLE (with evidence)
 
@@ -267,6 +268,40 @@ causes persistent confusion.
 
 ---
 
+## Priority 7: Rung-to-Rung Report Pipeline
+
+**Status:** Planned (deferrable)
+**Origin:** Phase 0→R0 progression report (hand-written), bundle gate requirement
+
+### What
+
+The Phase 0→R0 progression report (`docs/04_reports/r0/phase0_to_r0_progression.md`)
+was manually authored. Starting at R1, `progression_report` is a required bundle
+artifact enforced by the rung bundle validator. Future rung transitions should have
+automated or semi-automated report generation.
+
+### Proposed Approach
+
+Either:
+- **Skill:** `/generate-progression-report` that takes prior + current bundle paths
+  and populates the 8-section template from `EXPERIMENT_REPORTS.md`
+- **Script:** `scripts/internal/generate_progression_report.py` with CLI args for
+  prior bundle, current bundle, and output path
+
+### Why R1→R2+ Is Cleaner
+
+R1→R2+ comparisons are cleaner than Phase 0→R0 because:
+1. Both rungs use the same game mode (auction-selected contracts)
+2. Both have standard bundle JSONs with comparable eval metrics
+3. The forced-vs-selected confound that complicated Phase 0→R0 does not apply
+
+### Dependencies
+
+- A2 pipeline infrastructure
+- R1 bundle available (eval runs complete)
+
+---
+
 ## Cross-Reference
 
 | Follow-Up | Master Plan Phase | Sub-Plan | Report |
@@ -277,3 +312,4 @@ causes persistent confusion.
 | Pass-threshold re-tune | Post-C2 | `r0_pass_threshold_protocol.md` (template) | `pass_threshold_decision.md` §6 |
 | Deferred report sections | B3/D1 | `report_narrative_overlay.md` | `comparator_rankings.md` §4, §8 |
 | H2H bid_rate caveat | All | `measurement_integrity_r0.md` L3 | All H2H reports |
+| Rung-to-rung pipeline | Post-A2 | — | `phase0_to_r0_progression.md` (template) |

--- a/src/bid_euchre/validation/arc_d_bundle.py
+++ b/src/bid_euchre/validation/arc_d_bundle.py
@@ -44,6 +44,7 @@ REQUIRED_R1_PLUS_KEYS = {
     "h2h_summary",
     "h2h_challenger_vs_incumbent",
     "gate_thresholds",
+    "progression_report",
 }
 
 # Required sub-keys for h2h_challenger_vs_incumbent inline data
@@ -169,7 +170,7 @@ def validate_bundle(bundle: dict) -> tuple[bool, list[str]]:
                         )
 
         # Type-validate h2h_summary and gate_thresholds as strings (paths)
-        for path_key in ("h2h_summary", "gate_thresholds"):
+        for path_key in ("h2h_summary", "gate_thresholds", "progression_report"):
             path_val = bundle.get(path_key)
             if path_val is not None and not isinstance(path_val, str):
                 errors.append(
@@ -229,11 +230,12 @@ def validate_bundle_files_exist(bundle: dict, base_dir: str) -> tuple[bool, list
         if comp_path:
             file_paths.append(comp_path)
 
-    # R1+ path keys (h2h_summary, gate_thresholds are paths; h2h_challenger_vs_incumbent is inline)
-    for h2h_key in ("h2h_summary", "gate_thresholds"):
-        h2h_path = bundle.get(h2h_key)
-        if h2h_path and isinstance(h2h_path, str):
-            file_paths.append(h2h_path)
+    # R1+ path keys (h2h_summary, gate_thresholds, progression_report are paths;
+    # h2h_challenger_vs_incumbent is inline)
+    for path_key in ("h2h_summary", "gate_thresholds", "progression_report"):
+        path_val = bundle.get(path_key)
+        if path_val and isinstance(path_val, str):
+            file_paths.append(path_val)
 
     for fp in file_paths:
         full_path = base / fp

--- a/tests/fixtures/arc_d/rung_bundle_r1_synthetic.json
+++ b/tests/fixtures/arc_d/rung_bundle_r1_synthetic.json
@@ -36,5 +36,6 @@
     "ci_method": "paired_bootstrap",
     "seat_directions": ["challenger_01", "challenger_23"]
   },
-  "gate_thresholds": "data/artifacts/arc_d/r0/gate_thresholds_r1.json"
+  "gate_thresholds": "data/artifacts/arc_d/r0/gate_thresholds_r1.json",
+  "progression_report": "docs/04_reports/r1/r0_to_r1_progression.md"
 }

--- a/tests/unit/test_arc_d_gate.py
+++ b/tests/unit/test_arc_d_gate.py
@@ -67,7 +67,7 @@ def _make_bundle(**overrides) -> dict:
     """Create a minimal valid arc_d_rung_bundle_v1 fixture.
 
     Includes R1+ keys (h2h_summary, h2h_challenger_vs_incumbent,
-    gate_thresholds) by default since the default rung_id is "r1".
+    gate_thresholds, progression_report) by default since the default rung_id is "r1".
     """
     base = {
         "bundle_schema": BUNDLE_SCHEMA,
@@ -100,11 +100,17 @@ def _make_bundle(**overrides) -> dict:
         "h2h_summary": "data/artifacts/arc_d/r0/h2h_battery_full.json",
         "h2h_challenger_vs_incumbent": _make_h2h_inline(),
         "gate_thresholds": "data/artifacts/arc_d/r0/gate_thresholds_r1.json",
+        "progression_report": "docs/04_reports/r1/r0_to_r1_progression.md",
     }
     base.update(overrides)
     # R0 bundles don't have R1+ keys
     if base.get("rung_id") == "r0":
-        for key in ("h2h_summary", "h2h_challenger_vs_incumbent", "gate_thresholds"):
+        for key in (
+            "h2h_summary",
+            "h2h_challenger_vs_incumbent",
+            "gate_thresholds",
+            "progression_report",
+        ):
             base.pop(key, None)
     return base
 
@@ -298,6 +304,13 @@ def _setup_gate_files(
     h2h_summary_path = bundle.get("h2h_summary")
     if h2h_summary_path:
         _write_json(tmp_path / h2h_summary_path, {"cells": {}})
+
+    # Write progression report file (R1+ bundles) -- plain text, not JSON
+    progression_report_path = bundle.get("progression_report")
+    if progression_report_path:
+        fp = tmp_path / progression_report_path
+        fp.parent.mkdir(parents=True, exist_ok=True)
+        fp.write_text("# Placeholder progression report\ngate_status: N/A\n")
 
     # Write split manifest file
     split_manifest = bundle.get("split_manifest")
@@ -494,6 +507,11 @@ class TestBundleFilesExist:
             _write_json(tmp_path / bundle["h2h_summary"], {})
         if bundle.get("gate_thresholds"):
             _write_json(tmp_path / bundle["gate_thresholds"], {})
+        progression_report_path = bundle.get("progression_report")
+        if progression_report_path:
+            fp = tmp_path / progression_report_path
+            fp.parent.mkdir(parents=True, exist_ok=True)
+            fp.write_text("# Placeholder\ngate_status: N/A\n")
 
         valid, errors = validate_bundle_files_exist(bundle, str(tmp_path))
         assert valid, f"Expected valid, got errors: {errors}"
@@ -1453,6 +1471,39 @@ class TestR1BundleValidation:
         # Verify inline H2H has all required sub-keys
         for key in REQUIRED_H2H_INLINE_KEYS:
             assert key in bundle["h2h_challenger_vs_incumbent"]
+
+    def test_r1_progression_report_non_string_fails(self):
+        """R1 progression_report must be a string path."""
+        bundle = _make_bundle(progression_report=42)
+        valid, errors = validate_bundle(bundle)
+        assert not valid
+        assert any("progression_report must be a string" in e for e in errors)
+
+    def test_r1_progression_report_file_checked(self, tmp_path):
+        """validate_bundle_files_exist checks progression_report path."""
+        bundle = _make_bundle()
+        # Create all files except progression_report
+        for arm in ("olsa", "olsa_full"):
+            for key in ("artifact_path", "eval_seed42", "eval_seed43", "eval_seed44"):
+                path = bundle[arm].get(key)
+                if path:
+                    _write_json(tmp_path / path, {})
+        _write_json(tmp_path / bundle["incumbent"]["artifact_path"], {})
+        _write_json(tmp_path / bundle["split_manifest"], {})
+        _write_json(tmp_path / bundle["h2h_summary"], {"cells": {}})
+        _write_json(tmp_path / bundle["gate_thresholds"], {})
+        # Don't write progression_report
+
+        valid, errors = validate_bundle_files_exist(bundle, str(tmp_path))
+        assert not valid
+        assert any("r0_to_r1_progression.md" in e for e in errors)
+
+    def test_r0_bundle_no_progression_report(self):
+        """R0 bundle passes without progression_report (R0 exempted)."""
+        bundle = _make_bundle(rung_id="r0")
+        assert "progression_report" not in bundle
+        valid, errors = validate_bundle(bundle)
+        assert valid, f"Expected valid, got errors: {errors}"
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Post-hoc Phase 0→R0 progression report documenting transition from bidless baseline to first bidding model
- `progression_report` added as required R1+ bundle key (artifact existence gate)
- P7 rung-to-rung report pipeline follow-up added to `plans/r1_follow_ups.md`

## Why
No cross-phase comparison existed between Phase 0 (bidless) and R0 (first bidding model).
Auction dynamics were expected to reduce declaring-side outcome variance within contract types,
but this had never been verified. Additionally, no gate existed requiring a rung-to-rung summary
before promotion, meaning future rungs could be promoted without documenting what changed.

## Repro / Validation
**Command(s) run:**

Phase 0 data extraction:
```bash
PYTHONPATH=src uv run python -c "
from bid_euchre.datasets.join import join_features_outcomes
df = join_features_outcomes(
    'data/runs/canonical_bidless_dataset_glutton_42_20260221_175752/datasets/bidless.parquet',
    'data/runs/canonical_bidless_dataset_glutton_42_20260221_175752/datasets/bidless_outcomes.parquet',
)
print(df.groupby('contract_type')['tricks_won'].agg(['mean','std','count']))
"
```

R0 data extraction:
```bash
PYTHONPATH=src uv run python -c "
from bid_euchre.datasets.eval_dataset import build_eval_dataset
df = build_eval_dataset(
    'data/runs/arc_d_eval_r0_42_20260221_180253/logs/'
    'arc_d_eval_r0_42_20260221_180253_hybrid_olsa_r0.jsonl'
)
print(df.groupby('contract_type')['tricks_won'].agg(['mean','std','count']))
"
```

**Seed:** 42 (both datasets)

## Tests
- [x] `uv run python -m pytest tests/unit/test_arc_d_gate.py -v` — 98 passed (3 new)
- [x] `make check-quiet` — all checks passed

New tests:
- `test_r1_progression_report_non_string_fails` — non-string type → error
- `test_r1_progression_report_file_checked` — file existence validated
- `test_r0_bundle_no_progression_report` — R0 exempted

## Expected impact
- Metrics impact: none (post-hoc report, artifact gate only)
- Runtime impact: none (bundle validation adds one more string key check)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-progression
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-progression
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre               054a6b1 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-progression   3679098 [feat/phase0-r0-progression]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)