### PR TITLE
fix: allow model invocation of /reviewing-changes skill

### DIFF
--- a/.claude/skills/reviewing-changes/SKILL.md
+++ b/.claude/skills/reviewing-changes/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: reviewing-changes
 description: Reviews changed code for quality, repo conventions, and correctness after PR creation. Auto-fixes simple issues (pushed as follow-up commit), flags convention violations, and generates an agent-ready handoff summary for /copy. Triggered automatically by PostToolUse hook after gh pr create.
-disable-model-invocation: true
 ---
 
 # /reviewing-changes — Post-PR Code Review & Handoff


### PR DESCRIPTION
## Summary
- Remove `disable-model-invocation: true` from the `/reviewing-changes` skill frontmatter

## Why
- The PostToolUse hook that auto-triggers `/reviewing-changes` after `gh pr create` was failing with: `Error: Skill reviewing-changes cannot be used with Skill tool due to disable-model-invocation`
- This flag prevented programmatic (model) invocation, breaking the automated post-PR review workflow

## Repro / Validation
**Command(s) run:**
- `make check-quiet` — 1834 passed, 1 pre-existing failure (unrelated `test_r1_progression_report_file_checked`)

**Config (if applicable):**
- N/A

**Seed (if applicable):**
- N/A

## Tests
- [x] `make check-quiet` — all passing except pre-existing failure on main
- [ ] Integration (if engine/rules changed): N/A — config-only change
- [x] Other: verified same test fails on main checkout

## Expected impact
- Metrics impact (if any): none
- Runtime impact (if any): none — enables existing hook to work as designed

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/fix-skill-invocation
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/fix-skill-invocation
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                                         721ceb9 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/fix-skill-invocation  c88e2db [worktree-fix-skill-invocation]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)