### PR TITLE
docs: add R0 process lessons checklist to R1 follow-ups

### DIFF
--- a/plans/MASTER_PLAN.md
+++ b/plans/MASTER_PLAN.md
@@ -308,7 +308,8 @@ calibrator question arose. **Create a detailed PR-R1a sub-plan when R0 is finali
 
 **R1 design priorities from A1 oracle analysis:**
 See `plans/r1_follow_ups.md` for the complete prioritized list of follow-ups,
-including experimental designs, ablation protocols, and deferred report items.
+including experimental designs, ablation protocols, deferred report items, and
+R0 process lessons (W1–W6) from `docs/04_reports/r0/r0_retrospective.md`.
 
 Summary (details + rationale in follow-ups file):
 - **HIGH/LOW feature enrichment** — #1 priority, addresses 82% of oracle regret

--- a/plans/r1_follow_ups.md
+++ b/plans/r1_follow_ups.md
@@ -302,6 +302,27 @@ R1→R2+ comparisons are cleaner than Phase 0→R0 because:
 
 ---
 
+## R0 Process Lessons — Checklist
+
+**Source:** `docs/04_reports/r0/r0_retrospective.md` §5
+**Status:** Review before starting R1 execution (C2)
+
+These are development process recommendations from the R0 retrospective. They do not
+block promotion but should be reviewed and dispositioned before R1 execution begins.
+
+| # | Process Item | Disposition | Notes |
+|---|-------------|-------------|-------|
+| W1 | Pre-register calibration protocols before battery runs | — | Comparator v1→v4 required 4 iterations; define config, controls, and metrics upfront |
+| W2 | Run integration smoke test before large experiment runs | — | Parser bugs (#442, #443, #453) surfaced during battery execution, forcing reruns |
+| W3 | Review notebooks incrementally (per-notebook, not batch) | — | 72 items accumulated across 5 notebooks at R0; fix-forward, not fix-later |
+| W4 | Preserve design-first pattern, reduce plan iterations | — | R0 had 3 plan versions; target 1–2 by leveraging existing conventions |
+| W5 | Automate progression reports | — | = P7 above; implement early in R1 to reduce per-rung overhead |
+| W6 | Expand fail-fast gates into battery orchestration scripts | — | Validate deal counts, schema compatibility, metric completeness before aggregation |
+
+**Disposition values:** DONE / ADOPTED (with evidence) / DEFERRED (with rationale) / NOT APPLICABLE
+
+---
+
 ## Cross-Reference
 
 | Follow-Up | Master Plan Phase | Sub-Plan | Report |
@@ -313,3 +334,4 @@ R1→R2+ comparisons are cleaner than Phase 0→R0 because:
 | Deferred report sections | B3/D1 | `report_narrative_overlay.md` | `comparator_rankings.md` §4, §8 |
 | H2H bid_rate caveat | All | `measurement_integrity_r0.md` L3 | All H2H reports |
 | Rung-to-rung pipeline | Post-A2 | — | `phase0_to_r0_progression.md` (template) |
+| Process lessons (W1–W6) | Pre-C2 | `r0_retrospective.md` §5 | — |


### PR DESCRIPTION
## Summary
- Add W1–W6 process lessons checklist to `plans/r1_follow_ups.md` (from R0 retrospective §5)
- Add cross-reference from `plans/MASTER_PLAN.md` Stream 6

## Why
PR #485 documented R0 development process lessons, but the recommendations weren't linked into the R1 planning documents that get reviewed before execution. This ensures the process items (calibration protocols, integration smoke tests, incremental review, fail-fast gates) are visible alongside the P1–P7 model methodology follow-ups.

## Repro / Validation
**Command(s) run:**
- `make docs-check` — passes

**Config (if applicable):** N/A

**Seed (if applicable):** N/A

## Tests
- [x] `make docs-check` — passes
- [x] No Python files changed — pytest not applicable

## Expected impact
- Metrics impact: None (plans/docs only)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-r1-process
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-r1-process
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre            721ceb9 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-r1-process 72870b0 [r1-process-lessons]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)