### PR TITLE
feat: lambda tuning notebook for r0-canonical-v2 (PR-C)

### DIFF
--- a/notebooks/arc_d/r0/58_lambda_tuning.ipynb
+++ b/notebooks/arc_d/r0/58_lambda_tuning.ipynb
@@ -219,7 +219,13 @@
     "1. Compute mu from OLS model for each contract\n",
     "2. Compute utility = EV - risk_penalty for each contract at each lambda\n",
     "3. Select best contract (max utility) and decide bid vs pass\n",
-    "4. Measure realized net-differential from actual tricks"
+    "4. Measure realized net-differential from actual tricks\n",
+    "\n",
+    "**Pooling justification:** Metrics (net_eppd, bid_rate, make_rate) are reported\n",
+    "pooled across contract types because lambda tunes the *cross-contract decision\n",
+    "policy* — each hand selects the single best contract among all 6 candidates.\n",
+    "Per-contract-type breakout is not meaningful here since the unit of analysis is\n",
+    "the hand-level bid/pass decision, not individual contract performance."
    ]
   },
   {
@@ -397,7 +403,16 @@
     "\n",
     "            bid_n, utility = result\n",
     "\n",
-    "            if best_utility is None or utility > best_utility:\n",
+    "            # Tie-break matches HybridOLSaBidder.choose_bid() (bidding.py:1191-1198):\n",
+    "            # on equal utility, prefer higher (bid_n, contract_key) tuple.\n",
+    "            if (\n",
+    "                best_utility is None\n",
+    "                or utility > best_utility\n",
+    "                or (\n",
+    "                    utility == best_utility\n",
+    "                    and (bid_n, ck) > (best_bid_n, best_contract)\n",
+    "                )\n",
+    "            ):\n",
     "                best_utility = utility\n",
     "                best_contract = ck\n",
     "                best_bid_n = bid_n\n",

--- a/notebooks/arc_d/r0/58_lambda_tuning.py
+++ b/notebooks/arc_d/r0/58_lambda_tuning.py
@@ -185,6 +185,12 @@ print(f"Contract keys: {sorted(actual_keys)}")
 # 2. Compute utility = EV - risk_penalty for each contract at each lambda
 # 3. Select best contract (max utility) and decide bid vs pass
 # 4. Measure realized net-differential from actual tricks
+#
+# **Pooling justification:** Metrics (net_eppd, bid_rate, make_rate) are reported
+# pooled across contract types because lambda tunes the *cross-contract decision
+# policy* — each hand selects the single best contract among all 6 candidates.
+# Per-contract-type breakout is not meaningful here since the unit of analysis is
+# the hand-level bid/pass decision, not individual contract performance.
 
 # %%
 CONTRACT_KEYS = ["suit_C", "suit_D", "suit_H", "suit_S", "high", "low"]
@@ -331,7 +337,16 @@ def evaluate_lambda(
 
             bid_n, utility = result
 
-            if best_utility is None or utility > best_utility:
+            # Tie-break matches HybridOLSaBidder.choose_bid() (bidding.py:1191-1198):
+            # on equal utility, prefer higher (bid_n, contract_key) tuple.
+            if (
+                best_utility is None
+                or utility > best_utility
+                or (
+                    utility == best_utility
+                    and (bid_n, ck) > (best_bid_n, best_contract)
+                )
+            ):
                 best_utility = utility
                 best_contract = ck
                 best_bid_n = bid_n


### PR DESCRIPTION
## Summary
- Add `notebooks/arc_d/r0/58_lambda_tuning.py` (Jupytext-paired) that sweeps `risk_lambda` values `[0.0, 0.1, 0.2, 0.5, 1.0, 2.0]` to select the optimal CVaR tail-risk penalty weight
- Uses bidless dataset with deterministic 60/40 hash-based deal partition (`deal_id hash % 5 → train {0,1,2} / val {3,4}`) per pre-registered protocol §2.2
- Selection on train partition, evaluation + deal-level grouped bootstrap 95% CIs on validation partition
- Applies guardrails (bid_rate in [0.05, 0.95], make_rate >= 0.45), selects max net_eppd among survivors

## Why
Track D of the R0 Canonical v2 plan requires a lambda tuning experiment to determine whether the CVaR risk penalty (introduced in PR-A #493) improves bidding decisions. This notebook is the primary deliverable for that track — it evaluates the decision policy without retraining the model.

## Changes (v2 — protocol compliance fixes)
Addresses 4 review blockers against `plans/r0_v2_lambda_tuning_protocol.md`:
- **B1**: Replace 5-fold CV with protocol's 60/40 hash-based deal partition
- **B2**: Add `PASS_THRESHOLD` parameter (plumbed through `evaluate_lambda()`)
- **B3**: CI now computed on validation partition only with deal-level grouped bootstrap (not hand-level, not full dataset)
- **B4**: Add timing estimate cell for full-mode runtime planning

## Repro / Validation
**Command(s) run:**
```bash
# SMOKE mode (100 deals, ~1 min):
uv run jupyter nbconvert --to notebook --execute \
  notebooks/arc_d/r0/58_lambda_tuning.ipynb \
  --output 58_lambda_tuning_executed.ipynb

# Or via make (included in notebook-run but not make check):
make notebook-run
```

**Config (if applicable):**
- Parameters cell: `MODE="SMOKE"`, `SEED=42`, `ARTIFACT_PATH="data/artifacts/arc_d/r0/hybrid_r0.json"`
- `PASS_THRESHOLD=0.0` (placeholder — Track C output feeds here)

**Seed (if applicable):**
- SEED=42 (used for deal partition hash, bootstrap resampling, and CVaR Monte Carlo draws)

## Tests
- [x] `make check-quiet` — all checks passed
- [x] `ruff check` and `ruff format` pass
- [x] `jupytext --sync` and `nbstripout` pass
- [x] All pre-commit hooks pass

## Expected impact
- Metrics impact: None (this is an analysis notebook, not a code change)
- Runtime impact: SMOKE ~1 min, QUICK ~10 min, FULL ~hours (due to per-hand loop over 6 contracts x 10 bid levels)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a326a99e
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a326a99e
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                                   7376d98 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a326a99e  3a18fdf [feat/lambda-tuning-notebook]
```