### PR TITLE
fix: protocol doc corrections for OneModel artifact, threshold wording, sequential ordering

### DIFF
--- a/plans/r0_v2_onemodel_protocol.md
+++ b/plans/r0_v2_onemodel_protocol.md
@@ -217,17 +217,37 @@ the residual distributions differ materially across contract types.
 
 ### 3.4 Artifact Format
 
-The unified model artifact should extend the existing `hybrid_olsa_v1` format:
+The unified model artifact must be **loader-compatible** with the existing
+`HybridOLSaBidder` loader (`bidding.py:992-1008`), which iterates
+`artifact["payoff_model"]` expecting per-contract-family keys (`suit`,
+`high`, `low`) each containing `weights`, `bias`, and `feature_names`.
+The bid loop (`bidding.py:1155`) hardcodes `contract_map = {"suit": [...],
+"high": [...], "low": [...]}` and skips unknown families.
+
+**Approach:** The training pipeline decomposes the unified model's coefficients
+into per-contract-family format by absorbing the contract indicators into
+per-family bias terms:
+
+- **suit family:** `bias = intercept` (is_high=0, is_low=0), `weights` =
+  non-indicator coefficients (interaction terms for is_high/is_low zeroed out)
+- **high family:** `bias = intercept + w_is_high` (+ any is_high interaction
+  terms absorbed into corresponding feature weights)
+- **low family:** `bias = intercept + w_is_low` (+ any is_low interaction
+  terms absorbed into corresponding feature weights)
 
 ```json
 {
   "artifact_type": "hybrid_olsa_v1",
   "model_type": "unified",
+  "training_info": {
+    "description": "Unified cross-contract OLS, decomposed to per-family format",
+    "unified_intercept": 4.82,
+    "unified_coefficients": {"feature_1": 0.31, "is_high": -0.45, "is_low": -0.52}
+  },
   "payoff_model": {
-    "unified": {
-      "intercept": ...,
-      "coefficients": {"feature_1": ..., "is_high": ..., "is_low": ..., ...}
-    }
+    "suit": {"weights": [0.31, ...], "bias": 4.82, "feature_names": ["feature_1", ...]},
+    "high": {"weights": [0.31, ...], "bias": 4.37, "feature_names": ["feature_1", ...]},
+    "low":  {"weights": [0.31, ...], "bias": 4.30, "feature_names": ["feature_1", ...]}
   },
   "residual_variance": {
     "suit": ...,
@@ -237,8 +257,23 @@ The unified model artifact should extend the existing `hybrid_olsa_v1` format:
 }
 ```
 
-The `model_type: "unified"` field signals to `HybridOLSaBidder` that a single
-model should be used with contract-type indicators, rather than separate models.
+**Key design decisions:**
+
+1. **`model_type: "unified"`** is metadata only — it signals provenance
+   (single training run) but does NOT require a loader code path change.
+   The loader sees standard per-family entries and loads them normally.
+
+2. **`training_info`** preserves the raw unified coefficients for
+   reproducibility and debugging. The loader ignores unknown top-level keys.
+
+3. **`feature_names` per family** may differ: suit includes all base features,
+   while high/low include base features plus absorbed interaction terms.
+   The decomposition is handled by the training pipeline, not the loader.
+
+4. **No loader extension required.** The existing `HybridOLSaBidder` loads
+   and uses this artifact identically to per-contract models. The only
+   difference is how the artifact was produced (single unified training
+   vs independent per-contract training).
 
 ---
 
@@ -327,3 +362,4 @@ model (simpler architecture, no additional calibration layer).
 | Version | Date | Change | Rationale |
 |---------|------|--------|-----------|
 | v1 | 2026-03-02 | Initial protocol | Pre-registered before execution |
+| v1.1 | 2026-03-02 | Fix §3.4 artifact format to match loader expectations | Protocol specified `intercept`/`coefficients` naming and `payoff_model.unified` key, but loader expects per-contract `weights`/`bias`/`feature_names`. Now uses decomposed per-family format — no loader extension needed. |

--- a/plans/r0_v2_pr_a_amendments.md
+++ b/plans/r0_v2_pr_a_amendments.md
@@ -128,6 +128,33 @@ so differences are attributable only to the decision layer, not the model.
 
 ---
 
+## Amendment D — Threshold→Lambda Sequential Ordering (Post-PR-B Review)
+
+**Context:** The R0 v2 session plan (Phase 3a/3b) initially grouped threshold
+and lambda tuning as potentially parallel. The pre-registered protocols
+(`r0_v2_threshold_protocol.md` §4, `r0_v2_lambda_tuning_protocol.md` §4)
+specify **strict sequential ordering**: threshold first, then lambda.
+
+**Governing decision:** Threshold→lambda sequential is the canonical ordering
+for R0 v2 execution. This explicitly overrides any prior "parallel" framing
+in session plans or discussion.
+
+**Rationale:** Threshold controls which hands enter the bidding pool (the
+selection boundary). Lambda controls the risk penalty applied to hands already
+in the pool. Tuning threshold with lambda=0.0 isolates the selection effect.
+Then lambda is tuned conditional on the selected threshold, preserving causal
+clarity in the 2-stage hyperparameter search.
+
+**Execution sequence:**
+1. Track C: Tune `pass_threshold` with `risk_lambda=0.0` → yields `t*`
+2. Track D: Tune `risk_lambda` with `pass_threshold=t*` → yields `lambda*`
+3. Both values applied to all canonical configs before battery runs
+
+**Status:** Documented here as governing override. Both protocol docs
+already specify this ordering.
+
+---
+
 ## Resolved Findings (No Code Changes Needed)
 
 | Finding | Severity | Resolution |

--- a/plans/r0_v2_threshold_protocol.md
+++ b/plans/r0_v2_threshold_protocol.md
@@ -189,7 +189,7 @@ retain `t = 0.0`.
 
 | Condition | Decision | Action |
 |-----------|----------|--------|
-| delta > 0 AND CI excludes 0 AND guardrails pass | **ADOPT** | Set threshold for v2 policy, record in model artifact |
+| delta > 0 AND CI excludes 0 AND guardrails pass | **ADOPT** | Set threshold for v2 policy, record in bidding policy configuration (YAML configs) |
 | delta CI includes 0 | **RETAIN** | Keep t=0.0, no change |
 | delta < 0 | **RETAIN** | Threshold tuning harmful, keep t=0.0 |
 
@@ -253,3 +253,4 @@ while `lambda` controls the risk penalty on hands already in the pool.
 | v1 | 2026-03-01 | Initial protocol | Pre-registered before execution |
 | v1-exec | 2026-03-02 | Executed; decision RETAIN (t=0 optimal for floor-only policy) | Monotonic decline in net_diff |
 | v2 | 2026-03-02 | Re-tune for `bid_level_search=True` policy | v2 policy changes utility landscape; v1 result may not transfer |
+| v2.1 | 2026-03-02 | Fix §3.3 ADOPT action: "record in model artifact" → "record in bidding policy configuration" | pass_threshold is a config/policy parameter (§1.3 line 65), not a model artifact field |


### PR DESCRIPTION
## Summary
- Fix OneModel protocol §3.4 artifact format to be loader-compatible (decomposed per-family `weights`/`bias`/`feature_names` instead of `payoff_model.unified` with `intercept`/`coefficients`)
- Fix threshold protocol §3.3 ADOPT action wording: "record in model artifact" → "record in bidding policy configuration"
- Add Amendment D: explicit governing decision that threshold→lambda is the canonical sequential ordering

## Why
Post-PR-B (#494) review identified two protocol doc issues:
1. **[HIGH]** OneModel protocol specified an artifact shape (`payoff_model.unified` with `intercept`/`coefficients`) that `HybridOLSaBidder` loader cannot load — loader expects per-contract-family keys with `weights`/`bias`/`feature_names` at `bidding.py:992-1008`
2. **[MEDIUM]** Threshold protocol ADOPT action said "record in model artifact" but `pass_threshold` is a bidding policy/config parameter per the same document's §1.3 table
3. Prior session plans had ambiguous parallel/sequential framing for threshold and lambda tuning — needed explicit override

## Repro / Validation
**Command(s) run:**
- `make check-quiet` — all checks pass

**Config (if applicable):** N/A (docs-only)

**Seed (if applicable):** N/A

## Tests
- [x] `make check-quiet` passes
- No code changes — docs only

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-protocol-fixes
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-protocol-fixes
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                fe28751 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-protocol-fixes 93a9a02 [fix/protocol-doc-fixes]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)