### PR TITLE
docs: provenance derivation comments for mathematical formulas

### DIFF
--- a/src/bid_euchre/features/hand_eval.py
+++ b/src/bid_euchre/features/hand_eval.py
@@ -494,6 +494,16 @@ def get_hand_features(
 # ===========================
 
 
+# ── Derivation: scalar hand score (uniform weighting) ──
+# Source: hand-crafted heuristic for monotonic hand-strength ordering, not learned
+# Formula:
+#   Suit: right bower=120, left bower=110, trump A=100..T=60, offsuit A=50..T=10
+#   HIGH/LOW: (rank_strength + 1) × 10  (rank_strength is 0..4)
+# Assumptions: uniform 10-point spacing gives adequate separation for
+#   threshold-based bidders; not calibrated to expected tricks
+# See also: RanktheTank in strategy/bidding.py, get_hand_features() hand_value
+
+
 def score_hand_scalar(
     hand: List[Card],
     contract_type: str,

--- a/src/bid_euchre/models/train_hybrid_olsa.py
+++ b/src/bid_euchre/models/train_hybrid_olsa.py
@@ -8,6 +8,19 @@ Supports two arms:
   - OLSa (constrained): locked 3/1/1 features matching CONTRACT_FEATURES
   - OLSa_Full: forward-selected from all 39 features
 
+Dual-arm rationale:
+  - OLSa provides an attribution-stable baseline with fixed feature sets
+    (3 suit, 1 high, 1 low) for consistent rung-to-rung comparison.
+  - OLSa_Full is the promotional arm; forward selection via GroupKFold
+    cross-validation (grouped by hand_id to prevent 4-row leakage) finds
+    the best feature subset from all 39 features per contract.
+
+Design choices:
+  - OLS over ridge/regularized: interpretability is primary for Arc D
+    evaluation; regularization was tested but not needed given feature count.
+  - Artifact schema: hybrid_olsa_v1 with per-contract sub-models (weights,
+    bias, feature_names), residual_variance, and risk_lambda fields.
+
 CLI usage (preferred):
     PYTHONPATH=src python scripts/train_hybrid_olsa.py \\
         --run-dir data/runs/<run_id> --seed 42 --output /tmp/hybrid/

--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -318,6 +318,15 @@ class HighLowHeuristicBidder(BiddingPolicy):
             return BidAction.pass_bid()
 
 
+# ── Derivation: RanktheTank threshold-to-bid mapping ──
+# Source: hand-crafted heuristic baseline, not learned from data
+# Formula: score_hand_scalar() → ~10-point spacing thresholds → bid_n
+#   Suit: 100→1, 150→2, 200→3, 250→4, 300→5, 350→6, 450→7, 550→8, 650→9, 750→10
+#   HIGH/LOW: 100→1, 150→2, 200→3, 280→4, 350→5, 400→6, 450→7, 500→8
+# Assumptions: score_hand_scalar provides monotonic ordering of hand strength
+# See also: score_hand_scalar() in features/hand_eval.py
+
+
 class RanktheTank(BiddingPolicy):
     """
     Rank-sum based bidder (v1 baseline) that evaluates all contract options.
@@ -860,6 +869,17 @@ _CVAR_DRAWS = 1000
 _CVAR_TAIL = 0.05
 
 
+# ── Derivation: truncated normal EV ──
+# Source: standard truncated normal distribution theory
+# Formula:
+#   Payoff: make (t >= bid) → net = 2t - 10; set (t < bid) → net = t - b - 10
+#   Continuity correction: threshold = bid_n - 0.5 (half-integer boundary)
+#   Conditional expectations: E[X|X≥k] = μ + σ·φ(z)/Φ̄(z)  (inverse Mills ratio)
+#   Z_CAP = 6.0 prevents numerical overflow in extreme CDF/PDF tails
+# Assumptions: tricks ~ N(μ, σ²), residual variance from OLS training
+# See also: compute_ev_vectorized in nb56, analysis/sweep.py
+
+
 def _compute_ev_static(mu: float, sigma: float, bid_n: int) -> float:
     """Compute expected net-differential value using Gaussian model.
 
@@ -893,6 +913,18 @@ def _compute_ev_static(mu: float, sigma: float, bid_n: int) -> float:
     set_ev = e_tricks_set - bid_n - 10.0
 
     return p_make * make_ev + p_set * set_ev
+
+
+# ── Derivation: CVaR risk penalty (Monte Carlo) ──
+# Source: Conditional Value-at-Risk (CVaR) via simulation
+# Formula:
+#   1. Draw 1000 samples from N(μ, σ²), compute net payoff for each
+#   2. Sort nets ascending, take bottom 5% (tail_size = max(1, 50))
+#   3. CVaR = mean of that tail
+#   4. Penalty = max(0, -CVaR) × λ  (only penalizes downside risk)
+# Assumptions: 1000 draws gives adequate precision for bid selection;
+#   Monte Carlo avoids complex analytical truncated-normal CVaR formulas
+# See also: plans/r0_v2_lambda_tuning_protocol.md
 
 
 def _compute_risk_penalty_static(


### PR DESCRIPTION
## Summary
- Added `# ── Derivation: ... ──` comments to 5 mathematical formula blocks across 3 source files
- Documents payoff models, truncated normal EV, CVaR Monte Carlo, threshold-to-bid heuristics, scalar scoring weights, and dual-arm training rationale

## Why
- Mathematical formulas in the codebase lacked derivation provenance — assumptions, references, and cross-references to related code were implicit
- These comments make it easier to audit, extend, or debug the bidding/evaluation pipeline without re-deriving formulas from scratch

## Repro / Validation
**Command(s) run:**
- `uv run ruff check src/bid_euchre/strategy/bidding.py src/bid_euchre/features/hand_eval.py src/bid_euchre/models/train_hybrid_olsa.py`
- `uv run ruff format src/bid_euchre/strategy/bidding.py src/bid_euchre/features/hand_eval.py src/bid_euchre/models/train_hybrid_olsa.py` (3 files unchanged)
- `make check-quiet` — all checks passed
- `git diff --stat` — 3 files changed, 55 insertions(+), 0 deletions

**Config (if applicable):**
- N/A (documentation-only PR)

**Seed (if applicable):**
- N/A

## Tests
- [x] `make check-quiet` — full validation suite passed
- No new tests needed (comments only, no behavioral changes)

## Expected impact
- Metrics impact (if any): None — no code logic changes
- Runtime impact (if any): None — comments only

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Derivation comments added

| File | Block | Key formula |
|------|-------|-------------|
| `strategy/bidding.py` | `RanktheTank` | score_hand_scalar → threshold → bid_n mapping |
| `strategy/bidding.py` | `_compute_ev_static` | Truncated normal EV with continuity correction |
| `strategy/bidding.py` | `_compute_risk_penalty_static` | CVaR Monte Carlo: 1000 draws, 5% tail |
| `features/hand_eval.py` | `score_hand_scalar` | Uniform 10-point weight scheme |
| `models/train_hybrid_olsa.py` | Module docstring | Dual-arm rationale, OLS design choice, artifact schema |

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr-h
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr-h
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre       acdc00b [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-pr-h  b288cc0 [pr-h/provenance-docs]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it (N/A — no behavior change)
- [x] PR is focused (one concept)