### PR TITLE
fix: correct lambda sweep guardrail to seat-level propensity

### DIFF
--- a/scripts/internal/run_lambda_sweep.py
+++ b/scripts/internal/run_lambda_sweep.py
@@ -234,6 +234,52 @@ def load_per_deal_nets(run_dir):
 
 
 # ---------------------------------------------------------------------------
+# Seat-level bid propensity
+# ---------------------------------------------------------------------------
+
+
+def extract_seat_bid_propensity(run_dir):
+    """Extract per-seat bid propensity from auction transcripts in JSONL logs.
+
+    In self-play, each hand_end record has auction_transcript with 4 entries
+    (one per seat). Each entry has action: "BID" or "PASS".
+
+    Returns float: fraction of seat-opportunities where action was "BID".
+    Returns None if no auction_transcript data found.
+    """
+    logs_dir = Path(run_dir) / "logs"
+    if not logs_dir.is_dir():
+        return None
+
+    total_bids = 0
+    total_opportunities = 0
+
+    for log_file in sorted(logs_dir.glob("*.jsonl")):
+        with open(log_file) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if record.get("event") != "hand_end":
+                    continue
+                transcript = record.get("auction_transcript")
+                if not transcript:
+                    continue
+                for entry in transcript:
+                    total_opportunities += 1
+                    if entry.get("action") == "BID":
+                        total_bids += 1
+
+    if total_opportunities == 0:
+        return None
+    return total_bids / total_opportunities
+
+
+# ---------------------------------------------------------------------------
 # Deal pairing validation
 # ---------------------------------------------------------------------------
 
@@ -304,14 +350,22 @@ def paired_bootstrap_ci(
 
 
 def apply_guardrails(
-    metrics, bid_rate_floor=0.05, bid_rate_cap=0.95, make_rate_floor=0.45
+    metrics,
+    bid_rate_floor=0.05,
+    bid_rate_cap=0.95,
+    make_rate_floor=0.45,
+    bid_rate_key="bid_rate",
 ):
     """Apply guardrail checks to a metrics dict.
+
+    Args:
+        bid_rate_key: Key for bid rate metric. Use "seat_bid_propensity" for
+            self-play contexts where deal-level bid_rate inflates.
 
     Returns dict with guardrail results: {pass_bid_rate_floor, pass_bid_rate_cap,
     pass_make_rate, all_pass}.
     """
-    bid_rate = metrics.get("bid_rate")
+    bid_rate = metrics.get(bid_rate_key)
     make_rate = metrics.get("make_rate")
 
     result = {
@@ -490,6 +544,8 @@ def format_sweep_summary(
             "make_rate": r["make_rate"],
             "guardrails": r.get("guardrails", {}),
         }
+        if "seat_bid_propensity" in r:
+            entry["seat_bid_propensity"] = r["seat_bid_propensity"]
         lam = r["risk_lambda"]
         if bootstrap_results and lam in bootstrap_results:
             delta, ci_lo, ci_hi = bootstrap_results[lam]
@@ -656,8 +712,16 @@ def main():
             "hands_with_bids": strat.get("hands_with_bids", 0),
         }
 
-        # Apply guardrails
-        metrics["guardrails"] = apply_guardrails(metrics)
+        # Extract seat-level bid propensity from auction transcripts
+        seat_prop = extract_seat_bid_propensity(run_dir)
+        if seat_prop is not None:
+            metrics["seat_bid_propensity"] = round(seat_prop, 4)
+
+        # Use seat-level propensity for guardrails if available (self-play context)
+        guardrail_key = (
+            "seat_bid_propensity" if "seat_bid_propensity" in metrics else "bid_rate"
+        )
+        metrics["guardrails"] = apply_guardrails(metrics, bid_rate_key=guardrail_key)
         sweep_results.append(metrics)
 
         # Load per-deal nets for bootstrap

--- a/src/bid_euchre/analysis/sweep.py
+++ b/src/bid_euchre/analysis/sweep.py
@@ -140,21 +140,25 @@ def check_guardrails(
     bid_rate_floor: float = 0.05,
     bid_rate_cap: float = 0.95,
     make_rate_floor: float = 0.45,
+    bid_rate_key: str = "bid_rate",
 ) -> tuple[bool, list[str]]:
     """Check bid_rate and make_rate against guardrail bounds.
 
     Args:
-        metrics: Dict containing ``"bid_rate"`` and/or ``"make_rate"`` keys.
+        metrics: Dict containing bid rate and/or ``"make_rate"`` keys.
         bid_rate_floor: Minimum acceptable bid rate.
         bid_rate_cap: Maximum acceptable bid rate.
         make_rate_floor: Minimum acceptable make rate.
+        bid_rate_key: Key to use for bid rate (default ``"bid_rate"``). Use
+            ``"seat_bid_propensity"`` for self-play contexts where deal-level
+            bid_rate inflates.
 
     Returns:
         ``(all_pass, violation_messages)`` where *all_pass* is True when
         every checked guardrail is satisfied.
     """
     violations: list[str] = []
-    bid_rate = metrics.get("bid_rate")
+    bid_rate = metrics.get(bid_rate_key)
     make_rate = metrics.get("make_rate")
     if bid_rate is not None and bid_rate < bid_rate_floor:
         violations.append(f"bid_rate {bid_rate:.4f} < floor {bid_rate_floor}")

--- a/tests/unit/test_lambda_sweep.py
+++ b/tests/unit/test_lambda_sweep.py
@@ -1,0 +1,348 @@
+"""Tests for scripts/internal/run_lambda_sweep.py — lambda sweep tooling."""
+
+# run_lambda_sweep is a script, not a library module. Import via path manipulation.
+# The canonical approach in this repo is PYTHONPATH=src, so we add scripts/internal
+# to get the module.
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Insert scripts/internal onto sys.path so we can import run_lambda_sweep
+_SCRIPTS_DIR = str(Path(__file__).resolve().parents[2] / "scripts" / "internal")
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import run_lambda_sweep  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# extract_seat_bid_propensity
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSeatBidPropensity:
+    def _write_jsonl(self, logs_dir, records):
+        """Helper to write JSONL records to a log file."""
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        log_file = logs_dir / "test_run.jsonl"
+        with open(log_file, "w") as f:
+            for record in records:
+                f.write(json.dumps(record) + "\n")
+
+    def test_basic_counting(self, tmp_path):
+        """Counts BID and PASS actions correctly across seats."""
+        run_dir = tmp_path / "test_run"
+        logs_dir = run_dir / "logs"
+        records = [
+            {"event": "run_start"},
+            {
+                "event": "hand_end",
+                "deal_id": 0,
+                "auction_transcript": [
+                    {"seat": 0, "action": "BID"},
+                    {"seat": 1, "action": "PASS"},
+                    {"seat": 2, "action": "BID"},
+                    {"seat": 3, "action": "PASS"},
+                ],
+            },
+            {
+                "event": "hand_end",
+                "deal_id": 1,
+                "auction_transcript": [
+                    {"seat": 0, "action": "BID"},
+                    {"seat": 1, "action": "BID"},
+                    {"seat": 2, "action": "BID"},
+                    {"seat": 3, "action": "BID"},
+                ],
+            },
+        ]
+        self._write_jsonl(logs_dir, records)
+
+        result = run_lambda_sweep.extract_seat_bid_propensity(str(run_dir))
+        # 6 BIDs out of 8 total opportunities
+        assert result == pytest.approx(6 / 8)
+
+    def test_all_pass(self, tmp_path):
+        """All-pass deals yield propensity 0."""
+        run_dir = tmp_path / "test_run"
+        logs_dir = run_dir / "logs"
+        records = [
+            {
+                "event": "hand_end",
+                "deal_id": 0,
+                "auction_transcript": [
+                    {"seat": 0, "action": "PASS"},
+                    {"seat": 1, "action": "PASS"},
+                    {"seat": 2, "action": "PASS"},
+                    {"seat": 3, "action": "PASS"},
+                ],
+            },
+        ]
+        self._write_jsonl(logs_dir, records)
+        result = run_lambda_sweep.extract_seat_bid_propensity(str(run_dir))
+        assert result == 0.0
+
+    def test_all_bid(self, tmp_path):
+        """All-bid deals yield propensity 1."""
+        run_dir = tmp_path / "test_run"
+        logs_dir = run_dir / "logs"
+        records = [
+            {
+                "event": "hand_end",
+                "deal_id": 0,
+                "auction_transcript": [
+                    {"seat": 0, "action": "BID"},
+                    {"seat": 1, "action": "BID"},
+                    {"seat": 2, "action": "BID"},
+                    {"seat": 3, "action": "BID"},
+                ],
+            },
+        ]
+        self._write_jsonl(logs_dir, records)
+        result = run_lambda_sweep.extract_seat_bid_propensity(str(run_dir))
+        assert result == 1.0
+
+    def test_no_logs_dir(self, tmp_path):
+        """Returns None when logs directory does not exist."""
+        run_dir = tmp_path / "test_run"
+        run_dir.mkdir()
+        result = run_lambda_sweep.extract_seat_bid_propensity(str(run_dir))
+        assert result is None
+
+    def test_no_auction_transcripts(self, tmp_path):
+        """Returns None when no hand_end records have auction_transcript."""
+        run_dir = tmp_path / "test_run"
+        logs_dir = run_dir / "logs"
+        records = [
+            {"event": "run_start"},
+            {"event": "hand_end", "deal_id": 0},
+        ]
+        self._write_jsonl(logs_dir, records)
+        result = run_lambda_sweep.extract_seat_bid_propensity(str(run_dir))
+        assert result is None
+
+    def test_skips_non_hand_end_events(self, tmp_path):
+        """Only counts auction_transcript from hand_end events."""
+        run_dir = tmp_path / "test_run"
+        logs_dir = run_dir / "logs"
+        records = [
+            {"event": "run_start"},
+            {
+                "event": "hand_end",
+                "deal_id": 0,
+                "auction_transcript": [
+                    {"seat": 0, "action": "BID"},
+                    {"seat": 1, "action": "PASS"},
+                    {"seat": 2, "action": "PASS"},
+                    {"seat": 3, "action": "PASS"},
+                ],
+            },
+        ]
+        self._write_jsonl(logs_dir, records)
+        result = run_lambda_sweep.extract_seat_bid_propensity(str(run_dir))
+        assert result == pytest.approx(1 / 4)
+
+
+# ---------------------------------------------------------------------------
+# apply_guardrails with bid_rate_key
+# ---------------------------------------------------------------------------
+
+
+class TestApplyGuardrailsBidRateKey:
+    def test_default_uses_bid_rate(self):
+        """Default bid_rate_key='bid_rate' uses deal-level bid_rate."""
+        metrics = {"bid_rate": 0.5, "make_rate": 0.7}
+        result = run_lambda_sweep.apply_guardrails(metrics)
+        assert result["all_pass"] is True
+
+    def test_custom_key_seat_propensity(self):
+        """Using seat_bid_propensity key reads from that field."""
+        metrics = {
+            "bid_rate": 0.99,  # deal-level (would fail cap)
+            "seat_bid_propensity": 0.5,  # seat-level (passes)
+            "make_rate": 0.7,
+        }
+        result = run_lambda_sweep.apply_guardrails(
+            metrics, bid_rate_key="seat_bid_propensity"
+        )
+        assert result["all_pass"] is True
+        assert result["pass_bid_rate_cap"] is True
+
+    def test_seat_propensity_below_floor(self):
+        """Seat propensity below floor triggers guardrail failure."""
+        metrics = {
+            "bid_rate": 0.13,  # deal-level (would pass floor)
+            "seat_bid_propensity": 0.034,  # seat-level (below 0.05 floor)
+            "make_rate": 1.0,
+        }
+        result = run_lambda_sweep.apply_guardrails(
+            metrics, bid_rate_key="seat_bid_propensity"
+        )
+        assert result["all_pass"] is False
+        assert result["pass_bid_rate_floor"] is False
+
+    def test_missing_key_defaults_to_pass(self):
+        """If the specified key is missing, guardrail passes (None treated as ok)."""
+        metrics = {"make_rate": 0.7}
+        result = run_lambda_sweep.apply_guardrails(
+            metrics, bid_rate_key="seat_bid_propensity"
+        )
+        assert result["pass_bid_rate_floor"] is True
+        assert result["pass_bid_rate_cap"] is True
+
+
+# ---------------------------------------------------------------------------
+# select_lambda_star with seat-level guardrails
+# ---------------------------------------------------------------------------
+
+
+class TestSelectLambdaStarSeatLevel:
+    def test_selects_lambda_0_5_with_seat_propensity(self):
+        """With seat-level propensity, lambda=0.5 is selected (best net_eppd that passes).
+
+        This mirrors the corrected real-world scenario:
+        - lambda=0.0 through 0.5 pass (seat propensity in [0.05, 0.95])
+        - lambda=0.5 has best net_eppd
+        - lambda=2.0 fails (seat propensity < 0.05)
+        """
+        sweep_results = [
+            {
+                "risk_lambda": 0.0,
+                "net_eppd": 2.238,
+                "guardrails": {"all_pass": True},
+            },
+            {
+                "risk_lambda": 0.05,
+                "net_eppd": 2.270,
+                "guardrails": {"all_pass": True},
+            },
+            {
+                "risk_lambda": 0.1,
+                "net_eppd": 2.685,
+                "guardrails": {"all_pass": True},
+            },
+            {
+                "risk_lambda": 0.2,
+                "net_eppd": 2.905,
+                "guardrails": {"all_pass": True},
+            },
+            {
+                "risk_lambda": 0.5,
+                "net_eppd": 3.122,
+                "guardrails": {"all_pass": True},
+            },
+            {
+                "risk_lambda": 1.0,
+                "net_eppd": 2.216,
+                "guardrails": {"all_pass": True},
+            },
+            {
+                "risk_lambda": 2.0,
+                "net_eppd": 0.696,
+                "guardrails": {"all_pass": False},
+            },
+        ]
+        result = run_lambda_sweep.select_lambda_star(sweep_results, epsilon=0.02)
+        assert result == 0.5
+
+    def test_old_behavior_would_select_lambda_1(self):
+        """Demonstrates the old (incorrect) behavior: only lambda=1.0 and 2.0 pass
+        because deal-level bid_rate was used for cap (all others > 0.95).
+        """
+        # This is the old behavior: deal-level bid_rate > 0.95 for lambda 0-0.5
+        sweep_results = [
+            {
+                "risk_lambda": 0.0,
+                "net_eppd": 2.238,
+                "guardrails": {"all_pass": False},
+            },
+            {
+                "risk_lambda": 0.05,
+                "net_eppd": 2.270,
+                "guardrails": {"all_pass": False},
+            },
+            {
+                "risk_lambda": 0.1,
+                "net_eppd": 2.685,
+                "guardrails": {"all_pass": False},
+            },
+            {
+                "risk_lambda": 0.2,
+                "net_eppd": 2.905,
+                "guardrails": {"all_pass": False},
+            },
+            {
+                "risk_lambda": 0.5,
+                "net_eppd": 3.122,
+                "guardrails": {"all_pass": False},
+            },
+            {
+                "risk_lambda": 1.0,
+                "net_eppd": 2.216,
+                "guardrails": {"all_pass": True},
+            },
+            {
+                "risk_lambda": 2.0,
+                "net_eppd": 0.696,
+                "guardrails": {"all_pass": True},
+            },
+        ]
+        result = run_lambda_sweep.select_lambda_star(sweep_results, epsilon=0.02)
+        # Old behavior: selects 1.0 (best net_eppd among 1.0 and 2.0)
+        assert result == 1.0
+
+
+# ---------------------------------------------------------------------------
+# format_sweep_summary includes seat_bid_propensity
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSweepSummaryPropensity:
+    def test_includes_seat_bid_propensity(self):
+        """format_sweep_summary includes seat_bid_propensity when present."""
+        sweep_results = [
+            {
+                "risk_lambda": 0.0,
+                "net_eppd": 2.0,
+                "bid_rate": 1.0,
+                "make_rate": 0.97,
+                "seat_bid_propensity": 0.468,
+                "guardrails": {"all_pass": True},
+            },
+        ]
+        summary = run_lambda_sweep.format_sweep_summary(
+            grid=[0.0],
+            sweep_results=sweep_results,
+            lambda_star=0.0,
+            seed=42,
+            n_per=100,
+            pass_threshold=0.0,
+            artifact_path="test.json",
+            epsilon=0.02,
+        )
+        assert "seat_bid_propensity" in summary["results"][0]
+        assert summary["results"][0]["seat_bid_propensity"] == 0.468
+
+    def test_omits_seat_bid_propensity_when_absent(self):
+        """format_sweep_summary omits seat_bid_propensity when not present."""
+        sweep_results = [
+            {
+                "risk_lambda": 0.0,
+                "net_eppd": 2.0,
+                "bid_rate": 0.5,
+                "make_rate": 0.7,
+                "guardrails": {"all_pass": True},
+            },
+        ]
+        summary = run_lambda_sweep.format_sweep_summary(
+            grid=[0.0],
+            sweep_results=sweep_results,
+            lambda_star=0.0,
+            seed=42,
+            n_per=100,
+            pass_threshold=0.0,
+            artifact_path="test.json",
+            epsilon=0.02,
+        )
+        assert "seat_bid_propensity" not in summary["results"][0]

--- a/tests/unit/test_sweep.py
+++ b/tests/unit/test_sweep.py
@@ -220,6 +220,37 @@ class TestGuardrails:
         assert passed is False
         assert len(violations) == 1
 
+    def test_bid_rate_key_custom(self):
+        """check_guardrails uses bid_rate_key to select the bid rate metric."""
+        # deal-level bid_rate would fail cap, but seat_bid_propensity passes
+        metrics = {
+            "bid_rate": 0.99,
+            "seat_bid_propensity": 0.5,
+            "make_rate": 0.7,
+        }
+        ok, violations = check_guardrails(metrics, bid_rate_key="seat_bid_propensity")
+        assert ok is True
+        assert violations == []
+
+    def test_bid_rate_key_below_floor(self):
+        """check_guardrails detects violation using custom bid_rate_key."""
+        metrics = {
+            "bid_rate": 0.13,
+            "seat_bid_propensity": 0.034,
+            "make_rate": 1.0,
+        }
+        ok, violations = check_guardrails(metrics, bid_rate_key="seat_bid_propensity")
+        assert ok is False
+        assert any("floor" in v for v in violations)
+
+    def test_bid_rate_key_missing(self):
+        """When custom bid_rate_key is absent from metrics, no bid rate violation."""
+        ok, violations = check_guardrails(
+            {"make_rate": 0.7}, bid_rate_key="seat_bid_propensity"
+        )
+        assert ok is True
+        assert violations == []
+
 
 # ---------------------------------------------------------------------------
 # bootstrap_paired_delta


### PR DESCRIPTION
## Summary
- Add `extract_seat_bid_propensity()` to parse auction transcripts from JSONL logs and compute per-seat BID fraction
- Add `bid_rate_key` parameter to `apply_guardrails()` (run_lambda_sweep.py) and `check_guardrails()` (analysis/sweep.py) to select between deal-level and seat-level bid rate metrics
- Use `seat_bid_propensity` for guardrail evaluation in self-play context, include it in sweep summary output

## Why
The lambda sweep (PR #500) computed `bid_rate` using the evaluator's deal-level metric (fraction of deals with an auction winner). In 4-seat self-play this inflates: `deal_bid_rate ≈ 1-(1-p)^4` where `p` = per-seat propensity. The guardrail bounds [0.05, 0.95] were designed for seat-level propensity, not deal-level rate. This caused `lambda_star=1.0` to be selected (only 1.0 and 2.0 passed the 0.95 cap at deal-level), when the correct answer is `lambda_star=0.5` (net_eppd=3.122, seat_propensity=46.8%).

## Repro / Validation
**Command(s) run:**
```bash
uv run python scripts/internal/run_lambda_sweep.py \
  --artifact-path data/artifacts/arc_d/r0/hybrid_r0.json \
  --output data/artifacts/arc_d/r0/lambda_sweep_selfplay_v1.json \
  --seed 42 --n-per 10000 \
  --skip-run --manifest data/runs/lambda_sweep_manifest_42_20260303_051939.json
```

**Seed:** 42

**Verified:**
- `lambda_star: 0.5` (was 1.0)
- Each result entry has `seat_bid_propensity` field
- lambda=2.0 fails guardrails (seat propensity 3.4% < floor 5%)
- lambda=0.0 through 1.0 pass guardrails

## Tests
- [x] `uv run python -m pytest tests/unit/test_lambda_sweep.py tests/unit/test_sweep.py -v` (47 passed)
- [x] `make check-quiet` (all checks passed)

New tests:
- `TestExtractSeatBidPropensity` — 6 tests for JSONL parsing (basic counting, all pass, all bid, no logs, no transcripts, event filtering)
- `TestApplyGuardrailsBidRateKey` — 4 tests for `bid_rate_key` parameter in script guardrails
- `TestSelectLambdaStarSeatLevel` — 2 tests demonstrating corrected vs old behavior
- `TestFormatSweepSummaryPropensity` — 2 tests for inclusion/omission of seat_bid_propensity
- `TestGuardrails.test_bid_rate_key_*` — 3 tests for `bid_rate_key` parameter in sweep.py

## Expected impact
- Metrics impact: lambda_star changes from 1.0 to 0.5 (higher net_eppd by +0.88)
- Runtime impact: None (analysis-only change, no new experiment runs)

## Risk level
- [x] Medium (strategy/experiments)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a322124e
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a322124e
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                                   40712f3 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a322124e  225cfa3 [fix-lambda-guardrail-metric]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)