### PR TITLE
feat: scalar fallback for non-zero lambda in bid_level_search_vectorized

### DIFF
--- a/src/bid_euchre/analysis/sweep.py
+++ b/src/bid_euchre/analysis/sweep.py
@@ -88,7 +88,11 @@ def compute_ev_vectorized(
 
 
 def bid_level_search_vectorized(
-    mu_vals: np.ndarray, sigma: float, risk_lambda: float = 0.0
+    mu_vals: np.ndarray,
+    sigma: float,
+    risk_lambda: float = 0.0,
+    pass_threshold: float = 0.0,
+    seed: int = 42,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Vectorized bid-level search across all legal levels (1-10).
 
@@ -96,28 +100,48 @@ def bid_level_search_vectorized(
     level with highest utility. Tie-break: prefer higher bid level (matches
     ``compute_best_bid()`` in ``bidding.py``).
 
+    For non-zero ``risk_lambda``, falls back to a scalar loop calling
+    production ``compute_best_bid()`` (vectorized CVaR deferred to R1).
+
     Args:
         mu_vals: Predicted tricks array.
         sigma: Residual standard deviation (scalar).
-        risk_lambda: Risk penalty weight.  Must be 0.0 — non-zero lambda
-            requires CVaR penalty which is not yet vectorized.
+        risk_lambda: Risk penalty weight. Non-zero triggers scalar fallback.
+        pass_threshold: Minimum utility for non-pass bid (default 0.0).
+        seed: RNG seed for CVaR Monte Carlo (only used when risk_lambda > 0).
 
     Returns:
         ``(best_bid_n, best_utility)`` arrays of shape ``(n_hands,)``.
-
-    Raises:
-        AssertionError: If *risk_lambda* is not 0.0.
+        ``best_bid_n[i] = 0`` means the model passes that hand.
     """
     n = len(mu_vals)
     best_bid_n = np.ones(n, dtype=int)
     best_utility = np.full(n, -np.inf)
 
-    assert risk_lambda == 0.0, (
-        f"risk_lambda={risk_lambda} but CVaR penalty not implemented in "
-        "vectorized helper. Use compute_best_bid() from bidding.py for "
-        "non-zero lambda."
-    )
+    if risk_lambda != 0.0:
+        # Scalar fallback: production compute_best_bid() for non-zero lambda.
+        # Vectorized CVaR deferred to R1.
+        from bid_euchre.strategy.bidding import compute_best_bid
 
+        for i in range(n):
+            result = compute_best_bid(
+                mu=float(mu_vals[i]),
+                sigma=sigma,
+                current_high_bid=0,
+                pass_threshold=pass_threshold,
+                bid_level_search=True,
+                risk_lambda=risk_lambda,
+                seed=seed,
+            )
+            if result is not None:
+                best_bid_n[i] = result[0]
+                best_utility[i] = result[1]
+            else:
+                best_bid_n[i] = 0
+                best_utility[i] = -np.inf
+        return best_bid_n, best_utility
+
+    # Original vectorized path for lambda=0 (unchanged).
     # Iterate ascending; use >= so last (highest n) with max utility wins.
     # This matches compute_best_bid() tie-break: prefer higher n on equal utility.
     for bid_n in range(1, 11):

--- a/tests/unit/test_sweep.py
+++ b/tests/unit/test_sweep.py
@@ -16,7 +16,7 @@ from bid_euchre.analysis.sweep import (
     compute_ev_vectorized,
     deal_partition,
 )
-from bid_euchre.strategy.bidding import _compute_ev_static
+from bid_euchre.strategy.bidding import _compute_ev_static, compute_best_bid
 
 # ---------------------------------------------------------------------------
 # deal_partition
@@ -144,11 +144,93 @@ class TestBidLevelSearch:
         best_n, _ = bid_level_search_vectorized(mu, sigma=1.0)
         assert best_n[0] == 1, f"Expected bid_n=1 for mu=0.5, got {best_n[0]}"
 
-    def test_lambda_nonzero_raises(self):
-        """Non-zero risk_lambda should raise AssertionError."""
-        mu = np.array([5.0])
-        with pytest.raises(AssertionError, match="risk_lambda"):
-            bid_level_search_vectorized(mu, sigma=1.5, risk_lambda=0.5)
+    def test_scalar_fallback_produces_results(self):
+        """Non-zero risk_lambda triggers scalar fallback with valid results."""
+        mu = np.array([5.0, 7.0, 3.0, 9.0])
+        best_n, best_util = bid_level_search_vectorized(mu, sigma=1.5, risk_lambda=0.5)
+        assert best_n.shape == (4,)
+        assert best_util.shape == (4,)
+        # bid_n in [0, 10]: 0 = pass, 1-10 = valid bid
+        assert np.all(best_n >= 0)
+        assert np.all(best_n <= 10)
+        # Hands that bid should have finite utility; passes get -inf
+        for i in range(len(mu)):
+            if best_n[i] > 0:
+                assert np.isfinite(
+                    best_util[i]
+                ), f"Expected finite utility for bid at mu={mu[i]}"
+            else:
+                assert best_util[i] == -np.inf
+
+    def test_scalar_fallback_parity_with_compute_best_bid(self):
+        """Scalar fallback agrees with direct compute_best_bid() calls."""
+        mu_vals = np.array([4.0, 6.0, 8.0, 2.0, 5.5])
+        sigma = 1.5
+        risk_lambda = 0.3
+        seed = 42
+
+        best_n, best_util = bid_level_search_vectorized(
+            mu_vals, sigma=sigma, risk_lambda=risk_lambda, seed=seed
+        )
+
+        for i, mu in enumerate(mu_vals):
+            result = compute_best_bid(
+                mu=float(mu),
+                sigma=sigma,
+                current_high_bid=0,
+                pass_threshold=0.0,
+                bid_level_search=True,
+                risk_lambda=risk_lambda,
+                seed=seed,
+            )
+            if result is not None:
+                assert best_n[i] == result[0], (
+                    f"bid_n mismatch at mu={mu}: "
+                    f"vectorized={best_n[i]}, scalar={result[0]}"
+                )
+                np.testing.assert_allclose(
+                    best_util[i],
+                    result[1],
+                    atol=1e-12,
+                    err_msg=f"utility mismatch at mu={mu}",
+                )
+            else:
+                assert best_n[i] == 0, f"Expected pass (0) at mu={mu}"
+                assert best_util[i] == -np.inf
+
+    def test_scalar_fallback_with_pass(self):
+        """Low mu + risk penalty causes all hands to pass (bid_n=0).
+
+        pass_threshold semantics: pass when utility <= -pass_threshold.
+        With pass_threshold=0.0, pass when utility <= 0. Low mu values
+        produce negative utility, so compute_best_bid returns None.
+        """
+        mu = np.array([0.5, 1.0, 2.0])
+        best_n, best_util = bid_level_search_vectorized(
+            mu, sigma=1.5, risk_lambda=0.5, pass_threshold=0.0
+        )
+        assert np.all(best_n == 0), f"Expected all passes, got {best_n}"
+        assert np.all(
+            best_util == -np.inf
+        ), f"Expected -inf utility for passes, got {best_util}"
+
+    def test_new_params_accepted_on_lambda_zero(self):
+        """pass_threshold and seed accepted on vectorized path (lambda=0)."""
+        mu = np.array([5.0, 7.0])
+        # Should not raise — new params are accepted even on lambda=0 path
+        best_n, best_util = bid_level_search_vectorized(
+            mu, sigma=1.5, risk_lambda=0.0, pass_threshold=0.0, seed=99
+        )
+        assert best_n.shape == (2,)
+        assert np.all(best_n >= 1)
+
+    def test_scalar_fallback_deterministic(self):
+        """Scalar fallback produces identical results with same seed."""
+        mu = np.array([5.0, 7.0, 3.0])
+        r1 = bid_level_search_vectorized(mu, sigma=1.5, risk_lambda=0.5, seed=42)
+        r2 = bid_level_search_vectorized(mu, sigma=1.5, risk_lambda=0.5, seed=42)
+        np.testing.assert_array_equal(r1[0], r2[0])
+        np.testing.assert_array_equal(r1[1], r2[1])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace `assert risk_lambda == 0.0` in `bid_level_search_vectorized()` with a scalar fallback that delegates to production `compute_best_bid()` from `bidding.py`
- Add `pass_threshold` and `seed` parameters to the function signature
- Add 5 new tests covering: fallback shape/validity, parity with `compute_best_bid()`, pass behavior, new-params-accepted, determinism

## Why
The lambda sweep (PR #500) selects `lambda* != 0`. Notebooks 55 and 56 use `bid_level_search_vectorized()` which previously asserted `risk_lambda == 0.0`. This PR enables those notebooks to work with non-zero lambda by falling back to the scalar production function. Vectorized CVaR is deferred to R1.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_sweep.py -v
```

**Spot-check:**
```python
import numpy as np
from bid_euchre.analysis.sweep import bid_level_search_vectorized
mu = np.array([5.0, 7.0, 3.0, 9.0])
bid_n, util = bid_level_search_vectorized(mu, sigma=1.5, risk_lambda=0.5)
print(f"bid_n={bid_n}, util={util}")
# bid_n=[0 1 0 1], util=[-inf 3.10949361 -inf 7.99999999]
```

**Seed (if applicable):**
seed=42 (default in function, used in tests)

## Tests
- [x] `uv run python -m pytest tests/unit/test_sweep.py -v` — 34 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact (if any): None — new code path only activated when `risk_lambda != 0`
- Runtime impact (if any): Scalar fallback is O(n) slower than vectorized for non-zero lambda; acceptable for notebook analysis use

## Risk level
- [ ] Low (docs/tests only)
- [x] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-aa246cc7
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-aa246cc7
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                                   40712f3 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-aa246cc7  2d0d6db [feat-sweep-scalar-fallback]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)