### PR TITLE
feat: update notebook parameters for v2 battery data

### DIFF
--- a/notebooks/arc_d/r0/45_comparator_deep_dive.ipynb
+++ b/notebooks/arc_d/r0/45_comparator_deep_dive.ipynb
@@ -40,8 +40,8 @@
    "source": [
     "MODE = \"SMOKE\"  # SMOKE | QUICK | FULL\n",
     "SEED = 42\n",
-    "ARTIFACT_PATH = \"data/artifacts/arc_d/r0/comparator_cis_r0_v4.json\"\n",
-    "BATTERY_PATH = \"data/artifacts/arc_d/r0/comparator_battery_r0_v4.json\"\n",
+    "ARTIFACT_PATH = \"data/artifacts/arc_d/r0/comparator_cis_r0_v6.json\"\n",
+    "BATTERY_PATH = \"data/artifacts/arc_d/r0/comparator_battery_r0_v6.json\"\n",
     "RUNS_DIR = \"data/runs\""
    ]
   },

--- a/notebooks/arc_d/r0/45_comparator_deep_dive.py
+++ b/notebooks/arc_d/r0/45_comparator_deep_dive.py
@@ -42,8 +42,8 @@
 # %% tags=["parameters"]
 MODE = "SMOKE"  # SMOKE | QUICK | FULL
 SEED = 42
-ARTIFACT_PATH = "data/artifacts/arc_d/r0/comparator_cis_r0_v4.json"
-BATTERY_PATH = "data/artifacts/arc_d/r0/comparator_battery_r0_v4.json"
+ARTIFACT_PATH = "data/artifacts/arc_d/r0/comparator_cis_r0_v6.json"
+BATTERY_PATH = "data/artifacts/arc_d/r0/comparator_battery_r0_v6.json"
 RUNS_DIR = "data/runs"
 
 # %% [markdown]

--- a/notebooks/arc_d/r0/50_r0_matchups.ipynb
+++ b/notebooks/arc_d/r0/50_r0_matchups.ipynb
@@ -39,7 +39,7 @@
    "source": [
     "MODE = \"SMOKE\"  # SMOKE | QUICK | FULL\n",
     "SEED = 42  # RNG seed\n",
-    "MATCHUP_RUN_DIR = \"\"  # Path to h2h run (empty = skip matchup analysis, show demo)\n",
+    "MATCHUP_RUN_DIR = \"data/runs/arc_d_r0_h2h_battery_42_20260302_231835\"\n",
     "MODEL_NAME = \"hybrid_olsa_r0\"  # Model name in matchup_id strings"
    ]
   },

--- a/notebooks/arc_d/r0/50_r0_matchups.py
+++ b/notebooks/arc_d/r0/50_r0_matchups.py
@@ -41,7 +41,7 @@
 # %% tags=["parameters"]
 MODE = "SMOKE"  # SMOKE | QUICK | FULL
 SEED = 42  # RNG seed
-MATCHUP_RUN_DIR = ""  # Path to h2h run (empty = skip matchup analysis, show demo)
+MATCHUP_RUN_DIR = "data/runs/arc_d_r0_h2h_battery_42_20260302_231835"
 MODEL_NAME = "hybrid_olsa_r0"  # Model name in matchup_id strings
 
 # %% [markdown]

--- a/notebooks/arc_d/r0/55_contract_selection_oracle.ipynb
+++ b/notebooks/arc_d/r0/55_contract_selection_oracle.ipynb
@@ -936,7 +936,7 @@
     "\n",
     "NORMALIZER_TRIGGER_THRESHOLD = 0.25  # 25% of total regret\n",
     "\n",
-    "normalizer_triggered = cs_regret_share >= NORMALIZER_TRIGGER_THRESHOLD\n",
+    "normalizer_triggered = bool(cs_regret_share >= NORMALIZER_TRIGGER_THRESHOLD)\n",
     "\n",
     "print(f\"\\n{'=' * 70}\")\n",
     "print(\"v2 NORMALIZER TRIGGER CHECK\")\n",

--- a/notebooks/arc_d/r0/55_contract_selection_oracle.py
+++ b/notebooks/arc_d/r0/55_contract_selection_oracle.py
@@ -741,7 +741,7 @@ else:
 
 NORMALIZER_TRIGGER_THRESHOLD = 0.25  # 25% of total regret
 
-normalizer_triggered = cs_regret_share >= NORMALIZER_TRIGGER_THRESHOLD
+normalizer_triggered = bool(cs_regret_share >= NORMALIZER_TRIGGER_THRESHOLD)
 
 print(f"\n{'=' * 70}")
 print("v2 NORMALIZER TRIGGER CHECK")

--- a/notebooks/arc_d/r0/57_c33_ablation_deep_dive.ipynb
+++ b/notebooks/arc_d/r0/57_c33_ablation_deep_dive.ipynb
@@ -39,7 +39,7 @@
    "source": [
     "MODE = \"SMOKE\"  # SMOKE | QUICK | FULL\n",
     "SEED = 42  # RNG seed\n",
-    "C33_RUN_DIR = \"\"  # Path to C33 ablation run (empty = synthetic fallback)\n",
+    "C33_RUN_DIR = \"data/runs/arc_d_r0_c33_ablation_42_20260302_230400\"\n",
     "ARTIFACT_PATH = \"data/artifacts/arc_d/r0/hybrid_r0.json\""
    ]
   },

--- a/notebooks/arc_d/r0/57_c33_ablation_deep_dive.py
+++ b/notebooks/arc_d/r0/57_c33_ablation_deep_dive.py
@@ -41,7 +41,7 @@
 # %% tags=["parameters"]
 MODE = "SMOKE"  # SMOKE | QUICK | FULL
 SEED = 42  # RNG seed
-C33_RUN_DIR = ""  # Path to C33 ablation run (empty = synthetic fallback)
+C33_RUN_DIR = "data/runs/arc_d_r0_c33_ablation_42_20260302_230400"
 ARTIFACT_PATH = "data/artifacts/arc_d/r0/hybrid_r0.json"
 
 # %% [markdown]


### PR DESCRIPTION
## Summary
- Update 4 notebook parameter defaults to point at v2 battery artifacts
- nb45: comparator CIs v4→v6, battery v4→v6
- nb50: set MATCHUP_RUN_DIR to FULL H2H v4 run dir
- nb55: fix numpy bool JSON serialization in normalizer trigger gate
- nb57: set C33_RUN_DIR to v2 ablation run dir

## Why
Phase 2 batteries completed (comparator v6, H2H v4, C33 v2). Notebooks need
parameter updates to read the new artifacts. Part of R0 Canonical v2 execution
(Task #8 in overnight plan).

## Repro / Validation
**Command(s) run:**
- All 8 notebooks validated via SMOKE papermill execution:
  ```bash
  uv run jupytext --to ipynb --output /tmp/nbXX.ipynb notebooks/arc_d/r0/XX.py
  uv run papermill /tmp/nbXX.ipynb /tmp/nbXX_out.ipynb -p MODE SMOKE
  ```
- nb40 ✓, nb45 ✓, nb50 ✓, nb55 ✓, nb56 ✓, nb57 ✓, nb58 ✓, nb59 ✓

**Seed (if applicable):** 42

## Tests
- [x] `make check-quiet` — all checks passed
- [x] Notebook SMOKE execution via papermill (all 8 pass)

## Expected impact
- Metrics impact: None (parameter defaults only, no code logic changes)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-v2-batteries
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-v2-batteries
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre               ee5f9c2 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-v2-batteries  2f6353e [feat-v2-batteries-notebooks]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

## Battery Artifacts (on-disk, gitignored)
| Track | Artifact | Deals |
|-------|----------|-------|
| A: Comparator v6 | `comparator_battery_r0_v6.json`, `comparator_cis_r0_v6.json` | 8×4×5k = 160k |
| B: H2H v4 QUICK | `h2h_battery_quick_v4.json` | 64×2k = 128k |
| B: H2H v4 FULL | `h2h_battery_full_v4.json` | 52×10k = 520k |
| C: C33 ablation | run dir `arc_d_r0_c33_ablation_42_20260302_230400` | 9×10k = 90k |
| Bundle | `rung_bundle_r0.json` updated to v6/v4 pointers | — |