### PR TITLE
fix: correct pass_threshold threading and oracle eligibility in normalizer screen

### DIFF
--- a/docs/04_reports/r0/normalizer_offline_screen.md
+++ b/docs/04_reports/r0/normalizer_offline_screen.md
@@ -206,14 +206,22 @@ be even worse.
 
 ### Go/No-Go Gate
 
-| Criterion | Threshold | Result | Status |
-|-----------|-----------|--------|--------|
-| delta_net_eppd > 0 | > 0 | -0.269 | **FAIL** |
-| CI upper < +0.03 | < +0.03 for NO_GO | -0.251 | **FAIL** (NO_GO confirmed) |
-| accuracy_lift >= 0.02 | >= 0.02 for passing | +0.040 | Pass |
-| delta_net_eppd >= +0.08 | >= +0.08 for GO | -0.269 | FAIL |
-| CI excludes 0 (positive) | ci_low > 0 for GO | -0.287 | FAIL |
-| Guardrails | All pass for GO | FAIL | FAIL |
+**NO_GO criteria** (any one triggers NO_GO):
+
+| Criterion | Threshold | Result | Triggered? |
+|-----------|-----------|--------|------------|
+| delta_net_eppd <= 0 | Must be > 0 | -0.269 | **Yes** |
+| CI upper bound < +0.03 | Must be >= +0.03 | -0.251 | **Yes** |
+| accuracy_lift < 0.02 | Must be >= 0.02 | +0.040 | No |
+
+**GO criteria** (all required for GO -- not evaluated since NO_GO triggered):
+
+| Criterion | Threshold | Result | Met? |
+|-----------|-----------|--------|------|
+| delta_net_eppd >= +0.08 | >= +0.08 | -0.269 | No |
+| CI excludes 0 (positive) | ci_low > 0 | -0.287 | No |
+| Guardrails pass | All pass | FAIL | No |
+| accuracy_lift >= 0.03 | >= 0.03 | +0.040 | Yes |
 
 **Two NO_GO criteria triggered:** delta <= 0 and ci_high < +0.03. Decision:
 **NO_GO_DEFER_R1**.

--- a/scripts/internal/run_normalizer_offline_screen.py
+++ b/scripts/internal/run_normalizer_offline_screen.py
@@ -180,7 +180,7 @@ def build_hand_table(
 # ---------------------------------------------------------------------------
 
 
-def make_hand_decisions(hand_table: pd.DataFrame) -> dict:
+def make_hand_decisions(hand_table: pd.DataFrame, pass_threshold: float = 0.0) -> dict:
     """Per-hand oracle and model contract decisions.
 
     Returns dict of arrays. Scalar arrays have shape ``(n_hands,)``;
@@ -198,15 +198,23 @@ def make_hand_decisions(hand_table: pd.DataFrame) -> dict:
     deal_ids = hand_table["deal_id"].values.reshape(n_hands, N_CONTRACTS)[:, 0]
     seats = hand_table["seat"].values.reshape(n_hands, N_CONTRACTS)[:, 0]
 
-    # --- Oracle: argmax actual_net (all contracts eligible since bid_n > 0) ---
-    oracle_idx = np.argmax(actual_nets, axis=1)
+    # --- Oracle: argmax actual_net where bid_n > 0 ---
+    # Spec: oracle picks from contracts where bid_level_search found a valid bid.
+    # If all bid_n == 0, oracle passes (actual_net = 0).
+    oracle_eligible = bid_ns > 0
+    oracle_scores = np.where(oracle_eligible, actual_nets, -np.inf)
+    oracle_idx = np.argmax(oracle_scores, axis=1)
     oracle_net = np.take_along_axis(actual_nets, oracle_idx[:, None], axis=1).squeeze(
         -1
     )
+    # If all bid_n == 0 for a hand, oracle passes
+    all_oracle_pass = ~oracle_eligible.any(axis=1)
+    oracle_idx = np.where(all_oracle_pass, -1, oracle_idx)
+    oracle_net = np.where(all_oracle_pass, 0.0, oracle_net)
 
     # --- Model: argmax utility where utility > 0 ---
     # Tie-break: higher bid_n → higher contract_key index
-    model_eligible = utilities > 0
+    model_eligible = utilities > -pass_threshold
     ck_index = np.arange(N_CONTRACTS)[None, :]
     tiebreak = bid_ns * 1e-10 + ck_index * 1e-14
     model_scores = np.where(model_eligible, utilities + tiebreak, -np.inf)
@@ -328,6 +336,7 @@ def fit_normalizer(
     decisions: dict,
     train_mask: np.ndarray,
     lambda_reg: float = 1e-3,
+    pass_threshold: float = 0.0,
 ) -> dict:
     """Fit affine normalizer via softmax NLL on train split.
 
@@ -377,7 +386,7 @@ def fit_normalizer(
     alpha_per_key = alpha[FAMILY_IDX_FOR_KEY]
     beta_per_key = beta[FAMILY_IDX_FOR_KEY]
     u_norm = utilities * alpha_per_key[None, :] + beta_per_key[None, :]
-    norm_eligible = u_norm > 0
+    norm_eligible = u_norm > -pass_threshold
     norm_scores = np.where(norm_eligible, u_norm, -np.inf)
     norm_idx = np.argmax(norm_scores, axis=1)
     norm_idx = np.where(norm_eligible.any(axis=1), norm_idx, -1)
@@ -401,6 +410,7 @@ def _select_normalized_contract(
     utilities: np.ndarray,
     bid_ns: np.ndarray,
     params: dict,
+    pass_threshold: float = 0.0,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Apply normalizer and select contract.
 
@@ -413,7 +423,7 @@ def _select_normalized_contract(
 
     u_norm = utilities * alpha_per_key[None, :] + beta_per_key[None, :]
 
-    norm_eligible = u_norm > 0
+    norm_eligible = u_norm > -pass_threshold
     ck_index = np.arange(N_CONTRACTS)[None, :]
     tiebreak = bid_ns * 1e-10 + ck_index * 1e-14
     norm_scores = np.where(norm_eligible, u_norm + tiebreak, -np.inf)
@@ -430,6 +440,7 @@ def evaluate_validation(
     params: dict,
     n_bootstrap: int,
     seed: int,
+    pass_threshold: float = 0.0,
 ) -> dict:
     """Compute all validation metrics on the held-out split."""
     mask = val_mask
@@ -445,7 +456,9 @@ def evaluate_validation(
     deal_ids = decisions["deal_ids"][mask]
 
     # Apply normalizer
-    norm_idx, _ = _select_normalized_contract(utilities, bid_ns, params)
+    norm_idx, _ = _select_normalized_contract(
+        utilities, bid_ns, params, pass_threshold=pass_threshold
+    )
 
     norm_bids = norm_idx >= 0
     norm_net = np.where(
@@ -666,7 +679,7 @@ def main(argv: list[str] | None = None) -> dict:
     print(f"  Complete hands: {n_hands:,}")
 
     print("Computing oracle and model decisions...")
-    decisions = make_hand_decisions(hand_table)
+    decisions = make_hand_decisions(hand_table, pass_threshold=args.pass_threshold)
 
     # --- Step 0: Diagnostic Zero ---
     print("\n=== Step 0: Diagnostic Zero ===")
@@ -696,7 +709,9 @@ def main(argv: list[str] | None = None) -> dict:
 
     # --- Step 1: Fit ---
     print("\n=== Step 1: Normalizer Fit ===")
-    fit_result = fit_normalizer(decisions, train_mask)
+    fit_result = fit_normalizer(
+        decisions, train_mask, pass_threshold=args.pass_threshold
+    )
     print(f"  Optimizer: {fit_result['optimizer_status']}")
     if fit_result["params"]:
         print(f"  Alpha: {fit_result['params']['alpha']}")
@@ -719,7 +734,12 @@ def main(argv: list[str] | None = None) -> dict:
     # --- Step 2: Validation ---
     print(f"\n=== Step 2: Validation ({val_mask.sum():,} hands) ===")
     val_metrics = evaluate_validation(
-        decisions, val_mask, fit_result["params"], args.n_bootstrap, args.seed
+        decisions,
+        val_mask,
+        fit_result["params"],
+        args.n_bootstrap,
+        args.seed,
+        pass_threshold=args.pass_threshold,
     )
     print(
         f"  Accuracy: {val_metrics['accuracy_baseline']:.4f} → "

--- a/tests/unit/test_normalizer_offline_screen.py
+++ b/tests/unit/test_normalizer_offline_screen.py
@@ -535,6 +535,79 @@ class TestDecisionRubric:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Test: pass_threshold affects model eligibility
+# ---------------------------------------------------------------------------
+
+
+class TestPassThreshold:
+    def test_pass_threshold_zero_excludes_negative_utility(self):
+        """With pass_threshold=0, hands with utility in (-0.5, 0) do NOT bid."""
+        hand_table = _make_synthetic_hand_table(n_deals=1, n_seats=1, seed=0)
+        # Set utilities: some negative, some positive
+        hand_table["utility"] = [-0.3, -0.1, 0.5, 0.2, -0.4, 1.0]
+        hand_table["bid_n"] = 3
+        hand_table["actual_net"] = 1.0
+
+        decisions = make_hand_decisions(hand_table, pass_threshold=0.0)
+        # Model should only pick from indices where utility > 0 (indices 2, 3, 5)
+        assert decisions["model_idx"][0] in (2, 3, 5)
+        # Specifically, suit_S (idx=5, utility=1.0) should win
+        assert decisions["model_idx"][0] == 5
+
+    def test_pass_threshold_positive_includes_near_zero_utility(self):
+        """With pass_threshold=0.5, hands with utility in (-0.5, 0) SHOULD bid."""
+        hand_table = _make_synthetic_hand_table(n_deals=1, n_seats=1, seed=0)
+        # Set utilities: the "best" is at index 0 with -0.1 (above -0.5 threshold)
+        hand_table["utility"] = [-0.1, -0.6, -0.7, -0.8, -0.9, -1.0]
+        hand_table["bid_n"] = 3
+        hand_table["actual_net"] = 1.0
+
+        # With t=0.0, all utilities are negative → model passes
+        decisions_t0 = make_hand_decisions(hand_table, pass_threshold=0.0)
+        assert decisions_t0["model_idx"][0] == -1  # pass
+
+        # With t=0.5, utility > -0.5 → index 0 is eligible
+        decisions_t05 = make_hand_decisions(hand_table, pass_threshold=0.5)
+        assert decisions_t05["model_idx"][0] == 0  # bids on high
+
+
+# ---------------------------------------------------------------------------
+# Test: Oracle eligibility filters by bid_n > 0
+# ---------------------------------------------------------------------------
+
+
+class TestOracleEligibility:
+    def test_oracle_skips_bid_n_zero(self):
+        """Oracle does NOT select contracts where bid_n == 0."""
+        hand_table = _make_synthetic_hand_table(n_deals=1, n_seats=1, seed=0)
+        # Contract 0 (high) has best actual_net but bid_n=0
+        hand_table["actual_net"] = [10.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+        hand_table["bid_n"] = [0, 3, 3, 3, 3, 3]
+        hand_table["utility"] = [0.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+
+        decisions = make_hand_decisions(hand_table)
+        # Oracle should NOT pick index 0 (bid_n=0), should pick index 5 (next best)
+        assert decisions["oracle_idx"][0] != 0
+        assert decisions["oracle_idx"][0] == 5
+
+    def test_oracle_all_bid_n_zero_passes(self):
+        """When all bid_n == 0, oracle passes (idx=-1, net=0)."""
+        hand_table = _make_synthetic_hand_table(n_deals=1, n_seats=1, seed=0)
+        hand_table["actual_net"] = [10.0, 5.0, 3.0, 2.0, 1.0, 0.5]
+        hand_table["bid_n"] = 0  # all zero
+        hand_table["utility"] = -1.0
+
+        decisions = make_hand_decisions(hand_table)
+        assert decisions["oracle_idx"][0] == -1
+        assert decisions["oracle_net"][0] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Test: Diagnostic Zero
+# ---------------------------------------------------------------------------
+
+
 class TestDiagnosticZero:
     def test_no_disagreement(self):
         """When model matches oracle perfectly, no early exit."""


### PR DESCRIPTION
## Summary
- Thread `pass_threshold` through all contract selection logic in `run_normalizer_offline_screen.py` (was hardcoded to `utility > 0` in `make_hand_decisions`, `fit_normalizer`, `_select_normalized_contract`, `evaluate_validation`)
- Add `bid_n > 0` filter to oracle eligibility — oracle now only picks from contracts where `bid_level_search` found a valid bid, and passes when all `bid_n == 0`
- Fix report decision table in `normalizer_offline_screen.md` to clearly separate NO_GO vs GO criteria with distinct tables

## Why
Three semantic bugs identified during code review:
1. **P2 — pass_threshold ignored:** The `--pass-threshold` CLI arg was passed to `bid_level_search_vectorized()` but the downstream contract selection logic hardcoded `utility > 0`. With `pass_threshold=0.5`, the semantics should be "bid if utility > -0.5" (matching production), but the hardcoded check ignored this.
2. **P3 — Oracle eligibility:** Oracle was picking argmax of `actual_net` across all 6 contracts regardless of `bid_n`. Per spec, oracle should only pick from contracts where `bid_level_search` found a valid bid (`bid_n > 0`).
3. **P3 — Report clarity:** The decision table mixed NO_GO and GO criteria in a single table, making it unclear which criteria triggered the NO_GO decision.

## Repro / Validation
**Command(s) run:**
```bash
# Verify canonical run (t=0, lambda=0) produces identical results
uv run python scripts/internal/run_normalizer_offline_screen.py \
  --bidless-path data/runs/canonical_bidless_dataset_glutton_42_20260221_175752/datasets/bidless.parquet \
  --outcomes-path data/runs/canonical_bidless_dataset_glutton_42_20260221_175752/datasets/bidless_outcomes.parquet \
  --artifact-path data/artifacts/arc_d/r0/hybrid_r0.json \
  --seed 42 --pass-threshold 0.0 --risk-lambda 0.0 --n-bootstrap 10000 \
  --output /tmp/normalizer_screen_verify.json
```

**Verification:** decision, rationale, accuracy_baseline, accuracy_normalized, delta_net_eppd all match existing artifact within 0.001 tolerance.

**Seed:** 42

## Tests
- [x] `uv run python -m pytest tests/unit/test_normalizer_offline_screen.py -v` — 26 tests pass
- [x] `make check-quiet` — all checks pass
- [x] New tests added:
  - `TestPassThreshold::test_pass_threshold_zero_excludes_negative_utility`
  - `TestPassThreshold::test_pass_threshold_positive_includes_near_zero_utility`
  - `TestOracleEligibility::test_oracle_skips_bid_n_zero`
  - `TestOracleEligibility::test_oracle_all_bid_n_zero_passes`

## Expected impact
- Metrics impact: None for canonical t=0, lambda=0 run (verified identical). Fix matters for non-zero pass_threshold values.
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)
- [x] Medium (strategy/experiments) — script behavior change for non-default pass_threshold

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-normalizer-fixes
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-normalizer-fixes
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                       00731e1 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-normalizer-fixes      16c8406 [fix-normalizer-screen-semantics]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)