### PR TITLE
fix: 4 review findings from PRs #500-#512

### DIFF
--- a/docs/04_reports/README.md
+++ b/docs/04_reports/README.md
@@ -43,15 +43,15 @@ docs/04_reports/
 | [model_arc_d_dashboard.md](model_arc_d_dashboard.md) | 2026-02-22 | Cross-rung progression dashboard (snapshot) |
 | [r0/model_arc_r0.md](r0/model_arc_r0.md) | 2026-03-01 | R0 rung report (narrative refactor, 12 sections) |
 | [r0/r0_promotion_report.md](r0/r0_promotion_report.md) | 2026-02-22 | R0 promotion decision + gate threshold calibration |
-| [r0/comparator_rankings.md](r0/comparator_rankings.md) | 2026-02-28 | Comparator battery rankings (v4, single-seat, GluttonStrategy, 7 bidders) |
-| [r0/c33_ablation_report.md](r0/c33_ablation_report.md) | 2026-02-25 | C33 ablation: Gaussian EV wrapper effect (+0.21 net_eppd) |
-| [r0/h2h_battery_analysis.md](r0/h2h_battery_analysis.md) | 2026-02-25 | H2H battery analysis + gate threshold calibration |
+| [r0/comparator_rankings.md](r0/comparator_rankings.md) | 2026-03-03 | Comparator battery rankings (v6, single-seat, GluttonStrategy, 8 bidders) |
+| [r0/c33_ablation_report.md](r0/c33_ablation_report.md) | 2026-03-03 | C33 ablation: Gaussian EV wrapper + bid-level search (+0.13 H2H pooled, +2.36 comparator gap) |
+| [r0/h2h_battery_analysis.md](r0/h2h_battery_analysis.md) | 2026-03-03 | H2H battery analysis + gate threshold calibration |
 | [r0/contract_selection_oracle.md](r0/contract_selection_oracle.md) | 2026-03-01 | Contract selection oracle: regret decomposition, pass-threshold dominance |
 | [r0/pass_threshold_decision.md](r0/pass_threshold_decision.md) | 2026-03-02 | B0 threshold sweep decision: RETAIN t=0 (monotonic decline) |
 | [r0/lambda_decision.md](r0/lambda_decision.md) | 2026-03-03 | D0 lambda tuning decision: RETAIN lambda=0.0 (self-play gain reversed in H2H) |
-| [r0/measurement_integrity_r0.md](r0/measurement_integrity_r0.md) | 2026-02-26 | Methodology limitations + deferral costs (L1-L3 resolved/partially resolved) |
+| [r0/measurement_integrity_r0.md](r0/measurement_integrity_r0.md) | 2026-03-03 | Methodology limitations + deferral costs (L1-L3 resolved/partially resolved) |
 | [r0/phase0_to_r0_progression.md](r0/phase0_to_r0_progression.md) | 2026-03-01 | Phase 0→R0 progression: variance direction check, contract mix shift, role asymmetry |
-| [r0/dual_track_analysis.md](r0/dual_track_analysis.md) | 2026-03-01 | Dual-track rankings, archetype classification, roster scatter plots |
+| [r0/dual_track_analysis.md](r0/dual_track_analysis.md) | 2026-03-03 | Dual-track rankings, archetype classification, roster scatter plots |
 | [r0/r0_retrospective.md](r0/r0_retrospective.md) | 2026-03-02 | R0 development retrospective: process lessons, course corrections, R1 recommendations |
 | [r0/normalizer_offline_screen.md](r0/normalizer_offline_screen.md) | 2026-03-03 | Track E normalizer pre-screen: NO_GO_DEFER_R1 (accuracy +4% but net_eppd -0.269) |
 

--- a/docs/04_reports/r0/h2h_battery_analysis.md
+++ b/docs/04_reports/r0/h2h_battery_analysis.md
@@ -19,18 +19,23 @@ added), bid-level search in HybridOLSa, QUICK/FULL both at v4, comparator at v6.
 Seven experiment campaigns were run to complete the R0-to-R1 transition,
 producing the data needed to calibrate promotion gates and train the R1 model.
 All runs used seed=42 for deterministic reproducibility. Total simulation
-budget: ~808,000 deals across all campaigns.
+budget: ~888,000 deals across all campaigns.
 
 ### 1.2 Campaign Inventory
 
 | Campaign | Deals | Bidders | Purpose |
 |----------|-------|---------|---------|
-| C33 Ablation (v2) | 40,000 | 2 (hybrid_olsa, olsa) | Isolate combined wrapper + search effect |
+| C33 Ablation (v2) | 40,000* | 2 (hybrid_olsa, olsa) | Isolate combined wrapper + search effect |
 | Comparator Battery (v6) | 160,000 | 8 (all) | Rank bidders in self-play vs Glutton |
 | C50 QUICK (v4) | 128,000 | 8 (all, 64 matchups) | Full H2H matrix at survey resolution |
 | C50 FULL (v4) | 520,000 | 8 (all, 52 matchups) | Targeted rerun at publication resolution |
+| Lambda H2H Confirmation | 40,000 | 2 (lambda=0.0, lambda=0.5) | H2H confirmation of self-play lambda selection |
 | Threshold Calibration | N/A | N/A | Derive gate thresholds from null signal |
 | Drift Check | N/A | N/A | Validate QUICK thresholds against FULL |
+
+*C33 v2 deals are a 4-cell subset analyzed from the C50 FULL run, not a separate simulation.
+Unique simulated deals: 160,000 + 128,000 + 520,000 + 40,000 = 848,000 (plus 90,000 from the
+dedicated C33 v1 run = 938,000 total including v1 source data).
 
 ### 1.3 Simulation Design
 

--- a/docs/04_reports/r0/normalizer_offline_screen.md
+++ b/docs/04_reports/r0/normalizer_offline_screen.md
@@ -1,5 +1,7 @@
 # Normalizer Offline Screen — Track E Pre-Screen
 
+> **Version:** v2 (PR #508) | New in v2
+
 **Arc:** D (OLSa-Hybrid Bidder)
 **Rung:** R0
 **Date:** 2026-03-03

--- a/src/bid_euchre/analysis/sweep.py
+++ b/src/bid_euchre/analysis/sweep.py
@@ -141,7 +141,7 @@ def bid_level_search_vectorized(
                 best_utility[i] = -np.inf
         return best_bid_n, best_utility
 
-    # Original vectorized path for lambda=0 (unchanged).
+    # Original vectorized path for lambda=0.
     # Iterate ascending; use >= so last (highest n) with max utility wins.
     # This matches compute_best_bid() tie-break: prefer higher n on equal utility.
     for bid_n in range(1, 11):
@@ -150,6 +150,13 @@ def bid_level_search_vectorized(
         better_or_tie = utility >= best_utility
         best_utility = np.where(better_or_tie, utility, best_utility)
         best_bid_n = np.where(better_or_tie, bid_n, best_bid_n)
+
+    # Apply pass threshold: hands where best utility < threshold should pass.
+    # This mirrors the scalar path where compute_best_bid() returns None
+    # (mapped to bid_n=0) when the best utility is below pass_threshold.
+    pass_mask = best_utility < pass_threshold
+    best_bid_n = np.where(pass_mask, 0, best_bid_n)
+    best_utility = np.where(pass_mask, -np.inf, best_utility)
 
     return best_bid_n, best_utility
 

--- a/tests/unit/test_sweep.py
+++ b/tests/unit/test_sweep.py
@@ -119,11 +119,11 @@ class TestComputeEV:
 
 class TestBidLevelSearch:
     def test_basic(self):
-        """Returns valid bid_n in [1, 10]."""
+        """Returns valid bid_n in [0, 10] (0=pass, 1-10=bid)."""
         mu = np.array([5.0, 7.0, 3.0])
         best_n, best_util = bid_level_search_vectorized(mu, sigma=1.5)
         assert best_n.shape == (3,)
-        assert np.all(best_n >= 1)
+        assert np.all(best_n >= 0)
         assert np.all(best_n <= 10)
 
     def test_high_mu_positive_utility(self):
@@ -138,11 +138,12 @@ class TestBidLevelSearch:
         ), f"Expected high utility for mu=9, got {best_util[0]:.4f}"
         assert best_n[0] >= 1
 
-    def test_low_mu_bids_low(self):
-        """Very low mu should result in lowest bid level."""
+    def test_low_mu_passes(self):
+        """Very low mu with negative max-EV should pass (bid_n=0)."""
         mu = np.array([0.5])
-        best_n, _ = bid_level_search_vectorized(mu, sigma=1.0)
-        assert best_n[0] == 1, f"Expected bid_n=1 for mu=0.5, got {best_n[0]}"
+        best_n, best_util = bid_level_search_vectorized(mu, sigma=1.0)
+        assert best_n[0] == 0, f"Expected bid_n=0 (pass) for mu=0.5, got {best_n[0]}"
+        assert best_util[0] == -np.inf
 
     def test_scalar_fallback_produces_results(self):
         """Non-zero risk_lambda triggers scalar fallback with valid results."""
@@ -216,7 +217,7 @@ class TestBidLevelSearch:
 
     def test_new_params_accepted_on_lambda_zero(self):
         """pass_threshold and seed accepted on vectorized path (lambda=0)."""
-        mu = np.array([5.0, 7.0])
+        mu = np.array([7.0, 9.0])
         # Should not raise — new params are accepted even on lambda=0 path
         best_n, best_util = bid_level_search_vectorized(
             mu, sigma=1.5, risk_lambda=0.0, pass_threshold=0.0, seed=99
@@ -231,6 +232,119 @@ class TestBidLevelSearch:
         r2 = bid_level_search_vectorized(mu, sigma=1.5, risk_lambda=0.5, seed=42)
         np.testing.assert_array_equal(r1[0], r2[0])
         np.testing.assert_array_equal(r1[1], r2[1])
+
+    def test_vectorized_pass_threshold_filters_negative_ev(self):
+        """Vectorized path (lambda=0) returns bid_n=0 for negative max-EV hands.
+
+        Regression test for pass_threshold being ignored on the vectorized path.
+        With very low mu values (e.g., 2.0 with sigma=1.5), the best possible
+        EV across all bid levels is negative. These hands must get bid_n=0
+        when pass_threshold=0.0.
+        """
+        # mu=2.0 with sigma=1.5: max EV across all levels is negative.
+        # mu=9.0 with sigma=1.5: clearly positive EV.
+        mu = np.array([2.0, 9.0, 1.5, 0.5, 8.0])
+        sigma = 1.5
+        best_n, best_util = bid_level_search_vectorized(
+            mu, sigma=sigma, risk_lambda=0.0, pass_threshold=0.0
+        )
+
+        # Verify low-mu hands that have negative max-EV get bid_n=0
+        for i in range(len(mu)):
+            # Compute max EV across all levels for this hand
+            max_ev = max(
+                float(
+                    compute_ev_vectorized(np.array([mu[i]]), sigma, np.array([bid_n]))[
+                        0
+                    ]
+                )
+                for bid_n in range(1, 11)
+            )
+            if max_ev < 0.0:
+                assert best_n[i] == 0, (
+                    f"Hand with mu={mu[i]}, max_ev={max_ev:.4f} should pass "
+                    f"(bid_n=0) but got bid_n={best_n[i]}"
+                )
+                assert best_util[i] == -np.inf
+            else:
+                assert best_n[i] >= 1, (
+                    f"Hand with mu={mu[i]}, max_ev={max_ev:.4f} should bid "
+                    f"but got bid_n={best_n[i]}"
+                )
+
+    def test_vectorized_parity_with_scalar_at_lambda_zero(self):
+        """Vectorized path (lambda=0) matches scalar compute_best_bid() results.
+
+        For pass_threshold=0.0 and lambda=0.0, the vectorized path should
+        agree with the scalar compute_best_bid() on which hands pass vs bid,
+        and on the selected bid levels.
+        """
+        rng = np.random.RandomState(42)
+        mu_vals = rng.uniform(0.5, 9.5, size=100)
+        sigma = 1.5
+
+        best_n_vec, best_util_vec = bid_level_search_vectorized(
+            mu_vals, sigma=sigma, risk_lambda=0.0, pass_threshold=0.0
+        )
+
+        for i, mu in enumerate(mu_vals):
+            result = compute_best_bid(
+                mu=float(mu),
+                sigma=sigma,
+                current_high_bid=0,
+                pass_threshold=0.0,
+                bid_level_search=True,
+                risk_lambda=0.0,
+                seed=42,
+            )
+            if result is not None:
+                assert best_n_vec[i] == result[0], (
+                    f"bid_n mismatch at mu={mu:.3f}: "
+                    f"vectorized={best_n_vec[i]}, scalar={result[0]}"
+                )
+                np.testing.assert_allclose(
+                    best_util_vec[i],
+                    result[1],
+                    atol=1e-12,
+                    err_msg=f"utility mismatch at mu={mu:.3f}",
+                )
+            else:
+                assert (
+                    best_n_vec[i] == 0
+                ), f"Expected pass (0) at mu={mu:.3f}, got bid_n={best_n_vec[i]}"
+                assert best_util_vec[i] == -np.inf
+
+    def test_vectorized_custom_pass_threshold(self):
+        """Vectorized path respects non-zero pass_threshold values.
+
+        With a higher pass_threshold, more hands should be filtered to pass.
+        """
+        mu = np.array([5.0, 7.0, 3.0, 9.0, 4.0])
+        sigma = 1.5
+
+        # With threshold=0.0
+        n_t0, u_t0 = bid_level_search_vectorized(
+            mu, sigma=sigma, risk_lambda=0.0, pass_threshold=0.0
+        )
+        # With threshold=2.0 (stricter)
+        n_t2, u_t2 = bid_level_search_vectorized(
+            mu, sigma=sigma, risk_lambda=0.0, pass_threshold=2.0
+        )
+
+        # Higher threshold should produce at least as many passes
+        passes_t0 = np.sum(n_t0 == 0)
+        passes_t2 = np.sum(n_t2 == 0)
+        assert passes_t2 >= passes_t0, (
+            f"Higher threshold should cause more passes: "
+            f"t=0.0 passes={passes_t0}, t=2.0 passes={passes_t2}"
+        )
+
+        # Hands that pass under t=0 should also pass under t=2
+        for i in range(len(mu)):
+            if n_t0[i] == 0:
+                assert (
+                    n_t2[i] == 0
+                ), f"Hand {i} (mu={mu[i]}) passes at t=0.0 but bids at t=2.0"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **BLOCK fix:** `bid_level_search_vectorized()` now correctly applies `pass_threshold` on the lambda=0 vectorized path, filtering hands with negative max-EV to bid_n=0 (pass)
- **Doc fixes:** Updated stale report index descriptions, corrected H2H campaign arithmetic, added missing version header to normalizer screen report

## Why
Post-merge review of PRs #500-#512 identified 4 findings (1 BLOCK, 3 WARN). The BLOCK finding caused hands with negative expected value to still receive bid_n=1 instead of pass (bid_n=0) on the vectorized code path.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_sweep.py -v  # 40 passed
uv run python -m pytest tests/unit/test_normalizer_offline_screen.py -v  # 26 passed
make check-quiet  # All checks passed
```

**Seed (if applicable):** N/A (code fix + doc fixes)

## Tests
- [x] `uv run python -m pytest -m "not slow" tests/`
- [x] Other: `tests/unit/test_sweep.py` (40 tests including 3 new regression tests)

## Expected impact
- Metrics impact: `bid_level_search_vectorized()` will now return bid_n=0 for hands where all bid levels have negative EV (at lambda=0). This affects:
  - `scripts/internal/run_normalizer_offline_screen.py` (uses bid_n > 0 for oracle eligibility)
  - Notebooks 55 and 56 have **inline copies** of the function (NOT affected by this fix)
  - Existing artifacts were generated with the buggy code; re-running is a separate decision
- Runtime impact: Negligible (3 numpy operations added after the loop)

## Risk level
- [x] Low (docs/tests only)
- [x] Medium (strategy/experiments) — code fix in analysis/sweep.py

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-review-fixes
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-review-fixes
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                 edd487b [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-review-fixes    8bb717e [fix-review-findings-509-512]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept — review findings batch)

## Detailed Changes

### Finding 1 (BLOCK): pass_threshold ignored in vectorized bid search
**File:** `src/bid_euchre/analysis/sweep.py`

The lambda=0 vectorized path iterated bid_n from 1 to 10 and picked the best utility, but never checked `pass_threshold`. Hands where the best possible bid had negative EV got bid_n=1 instead of bid_n=0 (pass). The scalar fallback (lambda!=0) correctly passed `pass_threshold` to `compute_best_bid()`.

**Fix:** After the for loop, apply pass_threshold filter:
```python
pass_mask = best_utility < pass_threshold
best_bid_n = np.where(pass_mask, 0, best_bid_n)
best_utility = np.where(pass_mask, -np.inf, best_utility)
```

**Tests added (3):**
- `test_vectorized_pass_threshold_filters_negative_ev` — regression test for the exact bug
- `test_vectorized_parity_with_scalar_at_lambda_zero` — 100-hand parity check vs `compute_best_bid()`
- `test_vectorized_custom_pass_threshold` — monotonicity: higher threshold => more passes

**Existing tests updated:**
- `test_basic` — bid_n range now includes 0 (pass)
- `test_low_mu_bids_low` → `test_low_mu_passes` — mu=0.5 correctly passes
- `test_new_params_accepted_on_lambda_zero` — uses mu values with positive EV

### Finding 2 (WARN): Reports index stale descriptions
**File:** `docs/04_reports/README.md`
- Comparator: "v4, 7 bidders" → "v6, 8 bidders"
- C33: "+0.21 net_eppd" → "+0.13 H2H pooled, +2.36 comparator gap"
- Updated stale dates on 4 reports to match v2 update dates

### Finding 3 (WARN): H2H campaign total arithmetic
**File:** `docs/04_reports/r0/h2h_battery_analysis.md`
- Added missing Lambda H2H Confirmation row (40,000 deals)
- Fixed total from ~808,000 to ~888,000
- Added footnote clarifying C33 v2 is a FULL subset, not a separate sim
- "Seven campaigns" now matches 7 table rows

### Finding 4 (WARN): Missing version header
**File:** `docs/04_reports/r0/normalizer_offline_screen.md`
- Added `> **Version:** v2 (PR #508) | New in v2` banner matching other v2 reports