### PR TITLE
docs: notebook boundary audit rule + provenance fixes

### DIFF
--- a/.claude/rules/45_notebook_boundary.md
+++ b/.claude/rules/45_notebook_boundary.md
@@ -1,0 +1,42 @@
+# Notebook Boundary Rule
+
+> Notebooks are exploratory tools, not sources of truth for decisions.
+
+## Core Principle
+
+Decision-critical analysis (metrics, rankings, adoption evaluations, gate inputs)
+must be reproducible from committed artifacts + scripts alone. Notebook outputs
+(`.ipynb` cell results) are gitignored and exist only locally after execution —
+they are not valid primary sources for report claims or modeling decisions.
+
+## What Counts as Decision-Critical
+
+- Metrics cited in promotion reports, decision reports, or gate evaluations
+- Rankings used to compare bidders or strategies
+- Adoption/rejection criteria for protocol decisions (threshold, lambda, normalizer)
+- Any number that, if wrong, would change a PROMOTED/HALT/RETAIN decision
+
+## Required Traceability
+
+Every decision-critical claim in a report must trace to one of:
+
+1. **Committed JSON artifact** (e.g., `comparator_cis_r0_v6.json`)
+2. **Report provenance section** with reproduction command and seed
+3. **Script output** reproducible via `uv run python scripts/...` with documented seed
+
+A notebook may *produce* the analysis, but the result must be *captured* in one
+of the above committed forms before a report may cite it as decision evidence.
+
+## Anti-Patterns
+
+❌ Report cites a metric with no committed source — only visible in notebook output
+❌ Decision gate (e.g., normalizer trigger) computed in notebook, never written to artifact
+❌ Ephemeral config generated in notebook used for experiment but never committed
+❌ Report says "See notebook S4 for exact counts" without recording the counts anywhere
+
+## Acceptable Patterns
+
+✅ Notebook computes bootstrap CIs → script extracts them into committed JSON artifact
+✅ Report embeds the actual numbers (not just "see notebook") with a repro command
+✅ Notebook explores parameter space → decision captured in protocol with repro command
+✅ Notebook produces diagnostic charts that supplement (not replace) committed evidence

--- a/docs/04_reports/r0/10_contract_selection_oracle.md
+++ b/docs/04_reports/r0/10_contract_selection_oracle.md
@@ -418,6 +418,7 @@ R0 training (#396)
 | Sub-plan | plans/contract_selection_analysis.md (v3) |
 | PR (v1) | #472 |
 | V2 update | PR #497 (bid-level search in oracle), CS regret share 90.9% |
+| Artifact | None — gate result and regret decomposition exist only in this report and notebook output. See §8 for reproduction. R1 follow-up: extract gate result to committed JSON artifact (P9 in r1_follow_ups.md). |
 
 ## 8. Reproduction
 

--- a/plans/r1_follow_ups.md
+++ b/plans/r1_follow_ups.md
@@ -26,6 +26,7 @@ See `arc_d_execution_plan.md` §Phase R1 for the gate definition.
 | P6 | H2H bid_rate caveat | No (deferrable) | DONE | Adopted by v2 — fix terminology during report regeneration (§7.4 of r0_canonical_v2_plan.md) |
 | P7 | Rung-to-rung report pipeline | No (deferrable) | — | Automate progression reports |
 | P8 | Bid-level search in HybridOLSaBidder | **Yes** | DONE | Adopted by v2 — `compute_best_bid()` in #493, verified max-utility search |
+| P9 | Extract notebook-only gate results to artifacts | No (deferrable) | — | nb55 oracle gate result has no committed JSON; see notebook boundary audit |
 
 **Disposition values:** DONE / DEFERRED (with rationale + target rung) / NOT APPLICABLE (with evidence)
 
@@ -371,6 +372,41 @@ and other R1 changes.
 - **P4 (pass-threshold re-tune):** Bid-level search may reduce the need for threshold
   adjustment — hands that currently pass because EV < 0 at floor(mu) might bid at a
   lower level instead.
+
+---
+
+## Priority 9: Extract Notebook-Only Gate Results to Artifacts
+
+**Status:** Planned for R1
+**Origin:** Notebook boundary audit (PR #518, X-2 from HITL review)
+
+### Problem
+
+The notebook boundary audit (Task #30) found that several decision-critical outputs
+exist only in notebook cell outputs (gitignored) or report prose — not in committed
+machine-readable artifacts. The highest-severity case:
+
+**nb55 (contract selection oracle):** The normalizer trigger (`cs_regret_share 90.9%
+>= 25%`) activated Track E. The gate result, regret decomposition (CS 90.9%, pass
+threshold 5.3%, over-bidding 3.7%), and oracle contract mix exist nowhere in
+`data/artifacts/` — only in notebook output and transcribed report text.
+
+### Lower-Severity Findings (informational)
+
+| Notebook | Finding | Disposition |
+|----------|---------|-------------|
+| nb45 | Contract-type breakdown (§S3) and Source B CIs (§S5) cited by `03_comparator_rankings.md` but notebook-only | Acceptable — report acknowledges deferral; metrics are supplemental |
+| nb56 | Sweep results in report text but no JSON artifact | Acceptable — numbers are in committed report; JSON is nice-to-have |
+| nb57 | Section 6 divergence evidence is notebook-only | Acceptable — decision basis (H2H/comparator) is clean; evidence is mechanistic supplement |
+
+### What to Do at R1
+
+1. **nb55:** Add `--output` flag to write gate result JSON (regret decomposition,
+   oracle mix, trigger boolean) to `data/artifacts/arc_d/{rung}/oracle_gate_{rung}.json`.
+   Template: same pattern as `normalizer_offline_screen_v1.json`.
+2. **General:** For any new decision notebook at R1, require a committed artifact
+   capturing gate-critical outputs. The `.claude/rules/45_notebook_boundary.md` rule
+   codifies this going forward.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `.claude/rules/45_notebook_boundary.md` — codifies the anti-pattern where decision-critical analysis lives only in notebook outputs (gitignored)
- Add provenance note to `10_contract_selection_oracle.md` documenting the missing JSON artifact for nb55 gate result
- Add P9 to `r1_follow_ups.md` — extract notebook-only gate results to committed artifacts

## Why
Task #30 (notebook boundary audit) reviewed all 8 R0 notebooks against their
reports to ensure no model-impacting analysis lives only in notebook cell outputs.
Found 4 findings:
- **HIGH:** nb55 oracle gate result (cs_regret_share=90.9%, normalizer trigger) has no committed JSON artifact
- **MODERATE:** nb57 section 6 evidence exists only in notebook output
- **LOW:** nb45 supplemental metrics, nb56 threshold sweep numbers

None are blockers for v2 freeze — all have provenance notes or are documented
as R1 follow-ups. The new rule prevents this anti-pattern in future work.

## Repro / Validation
**Command(s) run:**
- `make check-quiet` — all checks pass

**Config (if applicable):**
- N/A (docs/rules only)

**Seed (if applicable):**
- N/A

## Tests
- [x] `make check-quiet` (full validation including docs-check)
- No Python code changed — no pytest needed

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-notebook-audit
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-notebook-audit
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                       5253818 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-notebook-audit        96d8c45 [notebook-boundary-audit]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)