### PR TITLE
docs: clarify OLSa/hybrid naming convention across R0 reports

### DIFF
--- a/docs/04_reports/r0/01_r0_promotion_report.md
+++ b/docs/04_reports/r0/01_r0_promotion_report.md
@@ -8,38 +8,50 @@
 **Date:** 2026-02-22 (v1 decision); 2026-03-04 (v2 eval refresh)
 **Methodology Review:** [20_measurement_integrity_r0.md](20_measurement_integrity_r0.md)
 
+> **Naming convention:** Each model arm has two names — a **model name** used in
+> self-play evaluation and a **strategy name** used in comparator/H2H batteries:
+>
+> | Model Name | Strategy Name | Arm | Artifact |
+> |------------|---------------|-----|----------|
+> | OLSa | hybrid_olsa | Constrained (attribution) | `hybrid_r0.json` |
+> | OLSa_Full | hybrid_olsa_full | Promotional | `hybrid_r0_full.json` |
+>
+> Self-play sections use model names; comparator and H2H sections use strategy
+> names. The "hybrid" prefix denotes the Gaussian EV wrapper + bid-level search;
+> non-prefixed variants (olsa, olsa_full) use floor-based thresholds without search.
+
 ## Executive Summary
 
 The R0 rung of Arc D's OLSa-Hybrid bidder was **PROMOTED** after passing all
 Tier 1 artifact integrity checks and demonstrating positive net expected points
 per deal across three independent evaluation seeds.
 
-**Self-play evaluation** (OLSa_Full promotional arm, seed 42):
+**Self-play evaluation** (seed 42, both arms):
 
-| Metric | Value | Definition |
-|--------|-------|------------|
-| `net_eppd` | +1.932 | Net expected points per deal (bidder − opponent). **Differential.** |
-| `eppd` | +5.795 | Expected points per deal (bidder only). **Absolute.** |
-| `bid_rate` | 100.0% | Fraction of deals with an auction winner. v2 bid-level search bids every deal. |
-| `make_rate` | 94.9% | Fraction of won auctions where declaring team makes contract. |
-| `net_CVaR-5%` | −11.230 | Average of worst 5% of net point outcomes. **Differential tail risk.** Higher = less risky. |
+| Metric | OLSa_Full (promotional) | OLSa (constrained) | Definition |
+|--------|-------------------------|---------------------|------------|
+| `net_eppd` | +1.932 | +1.953 | Net expected points per deal (bidder − opponent). **Differential.** |
+| `eppd` | +5.795 | +5.815 | Expected points per deal (bidder only). **Absolute.** |
+| `bid_rate` | 100.0% | 100.0% | Fraction of deals with an auction winner. v2 bid-level search bids every deal. |
+| `make_rate` | 94.9% | 95.2% | Fraction of won auctions where declaring team makes contract. |
+| `net_CVaR-5%` | −11.230 | −10.998 | Average of worst 5% of net point outcomes. **Differential tail risk.** Higher = less risky. |
 
-**Comparator context** (hybrid_olsa, single-seat vs GluttonStrategy, seed 42):
+**Comparator context** (single-seat vs GluttonStrategy, seed 42, both arms):
 
-| Metric | Value | Definition |
-|--------|-------|------------|
-| `net_eppd` | +2.131 | Net expected points per deal. **Differential** vs always-pass sentinels. |
-| `bid_rate` | 0.961 | Fraction of deals bid on. |
-| `make_rate` | 1.000 | Fraction of bids that make contract. |
-| Rank | 2 of 8 | Tied with hybrid_olsa_full (p=0.5457). |
+| Metric | hybrid_olsa_full (OLSa_Full) | hybrid_olsa (OLSa) | Definition |
+|--------|------------------------------|---------------------|------------|
+| `net_eppd` | +2.170 | +2.131 | Net expected points per deal. **Differential** vs always-pass sentinels. |
+| `bid_rate` | 0.968 | 0.961 | Fraction of deals bid on. |
+| `make_rate` | 1.000 | 1.000 | Fraction of bids that make contract. |
+| Rank | 1 of 8 | 2 of 8 | Statistically tied (delta=+0.038, p=0.5457). |
 
-The model ranks 1-2 among 8 comparator bidders by net_eppd (v6 single-seat
-comparator with GluttonStrategy, seed=42), tied with hybrid_olsa_full (+2.170,
-p=0.5457) and leading `modeloespecifico` (+1.604) by +0.527 points/deal
-(p < 0.001). The v2 bid-level search transformed bidding behavior across both
-self-play and comparator: self-play bid_rate rose from ~63-83% (v1) to 100%
-(v2), while make_rate shifted from ~83-87% (v1) to ~95% (v2) as the model now
-bids on every deal at the optimal level rather than passing marginal hands.
+Both arms rank 1-2 among 8 comparator bidders by net_eppd (v6 single-seat
+comparator with GluttonStrategy, seed=42), statistically tied (p=0.5457) and
+leading `modeloespecifico` (+1.604) by +0.5-0.6 points/deal (p < 0.001). The
+v2 bid-level search transformed bidding behavior across both self-play and
+comparator: self-play bid_rate rose from ~63-83% (v1) to 100% (v2), while
+make_rate shifted from ~83-87% (v1) to ~95% (v2) as the model now bids on
+every deal at the optimal level rather than passing marginal hands.
 
 ## Gate Results
 
@@ -198,8 +210,8 @@ expected points per deal (**differential** vs always-pass sentinels):
 
 | Rank | Bidder | net_eppd | 95% CI |
 |------|--------|----------|--------|
-| 1 | **hybrid_olsa_full** | **+2.170** | **[+2.081, +2.257]** |
-| 2 | **hybrid_olsa (R0)** | **+2.131** | **[+2.042, +2.216]** |
+| 1 | **hybrid_olsa_full** (OLSa_Full) | **+2.170** | **[+2.081, +2.257]** |
+| 2 | **hybrid_olsa** (OLSa) | **+2.131** | **[+2.042, +2.216]** |
 | 3 | modeloespecifico | +1.604 | [+1.489, +1.720] |
 | 4 | stricthellraiser | +0.085 | [−0.027, +0.197] |
 | 5 | olsa_full | −0.012 | [−0.193, +0.173] |

--- a/docs/04_reports/r0/02_model_arc_r0.md
+++ b/docs/04_reports/r0/02_model_arc_r0.md
@@ -12,7 +12,10 @@
 ## Executive Summary
 
 **What is this?** The R0 baseline establishment for Arc D's OLSa-Hybrid bidder
-— the first trainable bidding model in the Bid Euchre framework.
+— the first trainable bidding model in the Bid Euchre framework. See
+[01_r0_promotion_report.md](01_r0_promotion_report.md) for the naming convention
+mapping model names (OLSa, OLSa_Full) to strategy names (hybrid_olsa,
+hybrid_olsa_full) used in comparator/H2H batteries.
 
 **What did we do?** Six experiment campaigns totaling ~650,000 deals evaluated
 two model arms (OLSa constrained + OLSa_Full promotional) across self-play,
@@ -30,9 +33,9 @@ the top bidders in the framework:
 | make_rate | 95.2% | 94.9% |
 
 In the v6 single-seat comparator (GluttonStrategy, 20k deals/bidder, 8
-bidders), hybrid_olsa ranks 1-2 (tied with hybrid_olsa_full) among 8 bidders at
-net_eppd +2.131 (comparator), leading modeloespecifico (+1.604, comparator) by
-+0.527 points/deal (p < 0.001). The bid-level search (v2) dramatically changed
+bidders), both arms rank 1-2: hybrid_olsa_full (OLSa_Full) at +2.170 and
+hybrid_olsa (OLSa) at +2.131, statistically tied (p=0.5457) and leading
+modeloespecifico (+1.604, comparator) by +0.5-0.6 points/deal (p < 0.001). The bid-level search (v2) dramatically changed
 bidding behavior: bid_rate rose from 19.7% to 96.1%, make_rate from 88.6% to
 100%, driving the net_eppd improvement from +0.455 to +2.131. The C33 ablation
 shows a combined search effect (+0.43) and wrapper effect (+0.75).
@@ -415,8 +418,8 @@ behavioral analysis.
 
 | Rank | Bidder | net_eppd (comparator) | 95% CI | bid_rate | make_rate |
 |------|--------|----------------------|--------|----------|-----------|
-| 1 | **hybrid_olsa_full** | **+2.170** | **[+2.081, +2.257]** | 96.8% | 100% |
-| 2 | **hybrid_olsa** | **+2.131** | **[+2.042, +2.216]** | 96.1% | 100% |
+| 1 | **hybrid_olsa_full** (OLSa_Full) | **+2.170** | **[+2.081, +2.257]** | 96.8% | 100% |
+| 2 | **hybrid_olsa** (OLSa) | **+2.131** | **[+2.042, +2.216]** | 96.1% | 100% |
 | 3 | modeloespecifico | +1.604 | [+1.489, +1.720] | 100% | 94.7% |
 | 4 | stricthellraiser | +0.085 | [−0.027, +0.197] | 100% | 94.5% |
 | 5 | olsa_full | −0.012 | [−0.193, +0.173] | 100% | 77.2% |
@@ -430,12 +433,14 @@ p=0.5457). hybrid_olsa now leads modeloespecifico by +0.527 points/deal
 is driven by bid-level search (v2): hybrid_olsa bid_rate rose from 19.7% to
 96.1% and make_rate from 88.6% to 100%.
 
-**Instrument note:** Eval net_eppd (+1.953 for OLSa, eval) and comparator
-net_eppd (+2.131 for hybrid_olsa, comparator v6 single-seat) measure different
-estimands. Eval uses self-play where both teams bid; the comparator uses
-single-seat mode where only the test bidder bids against always-pass sentinels,
-with GluttonStrategy card play. The eval figure reflects competitive bidding
-dynamics while the comparator isolates bidding quality in a controlled setting.
+**Instrument note:** Eval net_eppd (OLSa +1.953, OLSa_Full +1.932) and
+comparator net_eppd (hybrid_olsa +2.131, hybrid_olsa_full +2.170) measure
+different estimands. Eval uses self-play where both teams bid; the comparator
+uses single-seat mode where only the test bidder bids against always-pass
+sentinels, with GluttonStrategy card play. The eval figure reflects competitive
+bidding dynamics while the comparator isolates bidding quality in a controlled
+setting. OLSa = hybrid_olsa, OLSa_Full = hybrid_olsa_full (see
+[01_r0_promotion_report.md](01_r0_promotion_report.md) naming convention).
 
 **Source:** comparator_cis_r0_v6.json
 

--- a/docs/04_reports/r0/06_dual_track_analysis.md
+++ b/docs/04_reports/r0/06_dual_track_analysis.md
@@ -8,6 +8,10 @@
 **Purpose:** Side-by-side analysis of two complementary evaluation tracks,
 archetype classification, and roster meta-analysis
 
+> **Naming:** `hybrid_olsa` = constrained arm (OLSa, 3 features, `hybrid_r0.json`);
+> `hybrid_olsa_full` = promotional arm (OLSa_Full, 7 features, `hybrid_r0_full.json`).
+> See [01_r0_promotion_report.md](01_r0_promotion_report.md) for full naming convention.
+
 ---
 
 ## 1. Summary


### PR DESCRIPTION
## Summary
- Add naming glossary to promotion report (01) mapping model names to strategy names
- Show both arms side by side in executive summary tables (self-play + comparator)
- Add naming cross-references to model spec (02) and dual-track analysis (06)

## Why
The R0 reports use two naming conventions: **model names** (OLSa, OLSa_Full)
in self-play contexts and **strategy names** (hybrid_olsa, hybrid_olsa_full) in
comparator/H2H batteries. The promotion report's executive summary showed
OLSa_Full for self-play but hybrid_olsa (the *other* arm) for comparator,
creating confusion about which arm was being discussed.

An audit of all 13 R0 reports found three needing fixes (01, 02, 06) with the
rest already clear through explicit roster tables or single-arm scope.

## Repro / Validation
```bash
# Verify naming consistency
grep -n "hybrid_olsa" docs/04_reports/r0/01_r0_promotion_report.md | head -5
grep -n "Naming convention" docs/04_reports/r0/01_r0_promotion_report.md
```

**Seed (if applicable):** N/A (documentation only)

## Tests
- [x] `make check-quiet` — all checks pass
- [x] No code changes — docs only

## Expected impact
- Metrics impact: None (documentation only)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-naming-clarity
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-naming-clarity
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                       66f2b27 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-naming-clarity        42927c8 [naming-clarity]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)