### PR TITLE
feat: R1 partner context infrastructure + locked base expansion

### DIFF
--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -70,6 +70,7 @@ Shell scripts:
 - `evaluate_diagnostic_tricks.py` — Diagnostic Ridge evaluation
 - `extract_comparator_cis.py` — Bootstrap CIs for comparator battery metrics
 - `generate_arc_dashboard.py` — Cross-rung Arc D progression dashboard
+- `generate_auction_context_dataset.py` — Auction-context dataset generator (R1 partner features)
 - `generate_batch_report.py` — Batch report + eligibility gate
 - `generate_r4_charts.py` — One-off report chart regeneration utility
 - `play_policy_gate.py` — Play policy stability gate
@@ -79,6 +80,7 @@ Shell scripts:
 - `run_auction_comparator.py` — Auction comparator orchestrator
 - `run_lambda_sweep.py` — Simulation-based risk_lambda tuning sweep
 - `run_normalizer_offline_screen.py` — Normalizer go/no-go offline screening pipeline
+- `run_threshold_sweep.py` — Grid search over pass_threshold values (R1 threshold tuning)
 - `train_unified_model.py` — Unified cross-contract OLS training (Track F OneModel)
 - `update_arc_registry.py` — Arc D registry updater (MODEL_ARC_RUNS.md)
 - `validate_arc_d_rung_contract.py` — Arc D rung bundle validator
@@ -198,6 +200,7 @@ Every experiment run creates a standardized directory under `data/runs/<run_id>/
 | `scripts/internal/evaluate_diagnostic_tricks.py` | Diagnostic Ridge evaluation |
 | `scripts/internal/extract_comparator_cis.py` | Bootstrap CIs for comparator battery metrics |
 | `scripts/internal/generate_arc_dashboard.py` | Cross-rung Arc D progression dashboard |
+| `scripts/internal/generate_auction_context_dataset.py` | Auction-context dataset generator (R1 partner features) |
 | `scripts/internal/generate_batch_report.py` | Batch report + eligibility gate |
 | `scripts/internal/generate_r4_charts.py` | One-off report chart regeneration utility |
 | `scripts/internal/generate_rung_charts.py` | Rung report chart generation from eval data + model artifacts |
@@ -208,6 +211,7 @@ Every experiment run creates a standardized directory under `data/runs/<run_id>/
 | `scripts/internal/run_auction_comparator.py` | Auction comparator orchestrator |
 | `scripts/internal/run_lambda_sweep.py` | Simulation-based risk_lambda tuning sweep |
 | `scripts/internal/run_normalizer_offline_screen.py` | Normalizer go/no-go offline screening pipeline |
+| `scripts/internal/run_threshold_sweep.py` | Grid search over pass_threshold values (R1 threshold tuning) |
 | `scripts/internal/train_unified_model.py` | Unified cross-contract OLS training (Track F OneModel) |
 | `scripts/internal/update_arc_registry.py` | Arc D registry updater (MODEL_ARC_RUNS.md) |
 | `scripts/internal/validate_arc_d_rung_contract.py` | Arc D rung bundle validator |

--- a/experiments/configs/auction_comparator_r1_dual.yaml
+++ b/experiments/configs/auction_comparator_r1_dual.yaml
@@ -1,0 +1,88 @@
+# R1 Dual-Seat Auction Comparator — 6-bidder canonical roster (§3.7.1)
+#
+# PRIMARY evaluation instrument for R1: both partnership seats use the same
+# bidder, so partner features receive real signal from a bidding partner.
+#
+# Usage:
+#   uv run python scripts/internal/run_auction_comparator.py \
+#     --config experiments/configs/auction_comparator_r1_dual.yaml \
+#     --dual-seat --seed 42 --n-per 5000 \
+#     --output-format json \
+#     --output data/artifacts/arc_d/r1/comparator_battery_r1_dual.json
+
+experiment_name: auction_comparator_r1_dual
+
+bidding_policies:
+  # --- R1 variants (partner-aware) ---
+
+  # Hybrid OLSa Full R1 — forward-selected from all 43 features
+  - name: hybrid_olsa_full_r1
+    class_name: HybridOLSaBidder
+    params:
+      artifact_path: data/artifacts/arc_d/r1/hybrid_r1_full.json
+      bid_level_search: true
+      risk_lambda: 0.0
+
+  # Hybrid OLSa R1 — constrained arm (locked base 3/2/2 + partner features)
+  - name: hybrid_olsa_r1
+    class_name: HybridOLSaBidder
+    params:
+      artifact_path: data/artifacts/arc_d/r1/hybrid_r1.json
+      bid_level_search: true
+      risk_lambda: 0.0
+
+  # ModeloEspecifico R1 — hand-coded baseline with R1 feature enrichment (§3.2.1)
+  - name: modeloespecifico_r1
+    class_name: ModeloEspecifico
+    params:
+      feature_weights:
+        suit:
+          bowers: 1.0
+          trump_count: 0.5
+          offsuit_aces: 0.5
+        high:
+          offsuit_aces: 1.0
+          quick_tricks: 1.0
+        low:
+          offsuit_tens_count: 1.0
+          quick_tricks: 1.0
+      partner_weights:
+        partner_bid_level: 1.0
+        partner_passed: 1.0
+        partner_suit_match: 1.0
+        partner_bid_confidence: 1.0
+
+  # --- R0 variants (partner-unaware, continuity baselines) ---
+
+  # Hybrid OLSa Full R0
+  - name: hybrid_olsa_full_r0
+    class_name: HybridOLSaBidder
+    params:
+      artifact_path: data/artifacts/arc_d/r0/hybrid_r0_full.json
+      bid_level_search: true
+      risk_lambda: 0.0
+
+  # Hybrid OLSa R0
+  - name: hybrid_olsa_r0
+    class_name: HybridOLSaBidder
+    params:
+      artifact_path: data/artifacts/arc_d/r0/hybrid_r0.json
+      bid_level_search: true
+      risk_lambda: 0.0
+
+  # ModeloEspecifico R0 (default weights = identical to R0 behavior)
+  - name: modeloespecifico_r0
+    class_name: ModeloEspecifico
+
+strategies:
+  - name: glutton
+    class_name: GluttonStrategy
+
+scenarios:
+  - contract_type: null  # Auction mode
+
+parameters:
+  play_strategy: glutton
+  n_per: 10000
+  seed: 42
+  log_level: hand

--- a/experiments/configs/auction_comparator_r1_legacy.yaml
+++ b/experiments/configs/auction_comparator_r1_legacy.yaml
@@ -1,0 +1,83 @@
+# R1 Single-Seat Auction Comparator — 6-bidder canonical roster (§3.7.1)
+#
+# CONTINUITY diagnostic: single-seat mode (R0-comparable). Partner seats use
+# AlwaysPassBidder, so partner features see no real signal. This produces
+# rankings comparable to R0 single-seat results for drift detection.
+#
+# Usage:
+#   uv run python scripts/internal/run_auction_comparator.py \
+#     --config experiments/configs/auction_comparator_r1_legacy.yaml \
+#     --single-seat --seed 42 --n-per 5000 \
+#     --output-format json \
+#     --output data/artifacts/arc_d/r1/comparator_battery_r1_legacy.json
+
+experiment_name: auction_comparator_r1_legacy
+
+bidding_policies:
+  # --- R1 variants ---
+
+  - name: hybrid_olsa_full_r1
+    class_name: HybridOLSaBidder
+    params:
+      artifact_path: data/artifacts/arc_d/r1/hybrid_r1_full.json
+      bid_level_search: true
+      risk_lambda: 0.0
+
+  - name: hybrid_olsa_r1
+    class_name: HybridOLSaBidder
+    params:
+      artifact_path: data/artifacts/arc_d/r1/hybrid_r1.json
+      bid_level_search: true
+      risk_lambda: 0.0
+
+  - name: modeloespecifico_r1
+    class_name: ModeloEspecifico
+    params:
+      feature_weights:
+        suit:
+          bowers: 1.0
+          trump_count: 0.5
+          offsuit_aces: 0.5
+        high:
+          offsuit_aces: 1.0
+          quick_tricks: 1.0
+        low:
+          offsuit_tens_count: 1.0
+          quick_tricks: 1.0
+      partner_weights:
+        partner_bid_level: 1.0
+        partner_passed: 1.0
+        partner_suit_match: 1.0
+        partner_bid_confidence: 1.0
+
+  # --- R0 variants ---
+
+  - name: hybrid_olsa_full_r0
+    class_name: HybridOLSaBidder
+    params:
+      artifact_path: data/artifacts/arc_d/r0/hybrid_r0_full.json
+      bid_level_search: true
+      risk_lambda: 0.0
+
+  - name: hybrid_olsa_r0
+    class_name: HybridOLSaBidder
+    params:
+      artifact_path: data/artifacts/arc_d/r0/hybrid_r0.json
+      bid_level_search: true
+      risk_lambda: 0.0
+
+  - name: modeloespecifico_r0
+    class_name: ModeloEspecifico
+
+strategies:
+  - name: glutton
+    class_name: GluttonStrategy
+
+scenarios:
+  - contract_type: null  # Auction mode
+
+parameters:
+  play_strategy: glutton
+  n_per: 10000
+  seed: 42
+  log_level: hand

--- a/experiments/configs/r1_eval_full.yaml
+++ b/experiments/configs/r1_eval_full.yaml
@@ -1,0 +1,73 @@
+# R1 Evaluation — FULL mode (50k deals × 3 seeds)
+#
+# Self-play evaluation for all 6 canonical R1 bidders.
+# FULL mode for production reports and promotion gate inputs.
+#
+# Usage:
+#   for seed in 42 43 44; do
+#     uv run python experiments/run_experiment.py \
+#       --config experiments/configs/r1_eval_full.yaml \
+#       --seed $seed --n_per 50000
+#   done
+
+experiment_name: r1_eval_full
+
+bidding_policies:
+  - name: hybrid_olsa_full_r1
+    class_name: HybridOLSaBidder
+    params:
+      artifact_path: data/artifacts/arc_d/r1/hybrid_r1_full.json
+      bid_level_search: true
+      risk_lambda: 0.0
+
+  - name: hybrid_olsa_r1
+    class_name: HybridOLSaBidder
+    params:
+      artifact_path: data/artifacts/arc_d/r1/hybrid_r1.json
+      bid_level_search: true
+      risk_lambda: 0.0
+
+  - name: modeloespecifico_r1
+    class_name: ModeloEspecifico
+    params:
+      feature_weights:
+        suit:
+          bowers: 1.0
+          trump_count: 0.5
+          offsuit_aces: 0.5
+        high:
+          offsuit_aces: 1.0
+          quick_tricks: 1.0
+        low:
+          offsuit_tens_count: 1.0
+          quick_tricks: 1.0
+      partner_weights:
+        partner_bid_level: 1.0
+        partner_passed: 1.0
+        partner_suit_match: 1.0
+        partner_bid_confidence: 1.0
+
+  - name: hybrid_olsa_full_r0
+    class_name: HybridOLSaBidder
+    params:
+      artifact_path: data/artifacts/arc_d/r0/hybrid_r0_full.json
+      bid_level_search: true
+      risk_lambda: 0.0
+
+  - name: hybrid_olsa_r0
+    class_name: HybridOLSaBidder
+    params:
+      artifact_path: data/artifacts/arc_d/r0/hybrid_r0.json
+      bid_level_search: true
+      risk_lambda: 0.0
+
+  - name: modeloespecifico_r0
+    class_name: ModeloEspecifico
+
+scenarios:
+  - contract_type: null  # Auction mode
+
+parameters:
+  n_per: 50000
+  seed: 42
+  log_level: hand

--- a/experiments/configs/r1_eval_quick.yaml
+++ b/experiments/configs/r1_eval_quick.yaml
@@ -1,0 +1,73 @@
+# R1 Evaluation — QUICK mode (2k deals × 3 seeds)
+#
+# Self-play evaluation for all 6 canonical R1 bidders.
+# QUICK mode for fast iteration; switch to r1_eval_full.yaml for production.
+#
+# Usage:
+#   for seed in 42 43 44; do
+#     uv run python experiments/run_experiment.py \
+#       --config experiments/configs/r1_eval_quick.yaml \
+#       --seed $seed --n_per 2000
+#   done
+
+experiment_name: r1_eval_quick
+
+bidding_policies:
+  - name: hybrid_olsa_full_r1
+    class_name: HybridOLSaBidder
+    params:
+      artifact_path: data/artifacts/arc_d/r1/hybrid_r1_full.json
+      bid_level_search: true
+      risk_lambda: 0.0
+
+  - name: hybrid_olsa_r1
+    class_name: HybridOLSaBidder
+    params:
+      artifact_path: data/artifacts/arc_d/r1/hybrid_r1.json
+      bid_level_search: true
+      risk_lambda: 0.0
+
+  - name: modeloespecifico_r1
+    class_name: ModeloEspecifico
+    params:
+      feature_weights:
+        suit:
+          bowers: 1.0
+          trump_count: 0.5
+          offsuit_aces: 0.5
+        high:
+          offsuit_aces: 1.0
+          quick_tricks: 1.0
+        low:
+          offsuit_tens_count: 1.0
+          quick_tricks: 1.0
+      partner_weights:
+        partner_bid_level: 1.0
+        partner_passed: 1.0
+        partner_suit_match: 1.0
+        partner_bid_confidence: 1.0
+
+  - name: hybrid_olsa_full_r0
+    class_name: HybridOLSaBidder
+    params:
+      artifact_path: data/artifacts/arc_d/r0/hybrid_r0_full.json
+      bid_level_search: true
+      risk_lambda: 0.0
+
+  - name: hybrid_olsa_r0
+    class_name: HybridOLSaBidder
+    params:
+      artifact_path: data/artifacts/arc_d/r0/hybrid_r0.json
+      bid_level_search: true
+      risk_lambda: 0.0
+
+  - name: modeloespecifico_r0
+    class_name: ModeloEspecifico
+
+scenarios:
+  - contract_type: null  # Auction mode
+
+parameters:
+  n_per: 2000
+  seed: 42
+  log_level: hand

--- a/experiments/configs/r1_h2h_roster.json
+++ b/experiments/configs/r1_h2h_roster.json
@@ -1,0 +1,73 @@
+{
+  "schema": "h2h_roster_v1",
+  "description": "R1 canonical 6-bidder H2H roster (r1_master_plan.md §3.7.1). All-vs-all matrix: 36 cells (30 cross + 6 self-play) per decision round.",
+  "bidders": [
+    {
+      "name": "hybrid_olsa_full_r1",
+      "class_name": "HybridOLSaBidder",
+      "params": {
+        "artifact_path": "data/artifacts/arc_d/r1/hybrid_r1_full.json",
+        "bid_level_search": true,
+        "risk_lambda": 0.0
+      }
+    },
+    {
+      "name": "hybrid_olsa_r1",
+      "class_name": "HybridOLSaBidder",
+      "params": {
+        "artifact_path": "data/artifacts/arc_d/r1/hybrid_r1.json",
+        "bid_level_search": true,
+        "risk_lambda": 0.0
+      }
+    },
+    {
+      "name": "modeloespecifico_r1",
+      "class_name": "ModeloEspecifico",
+      "params": {
+        "feature_weights": {
+          "suit": {"bowers": 1.0, "trump_count": 0.5, "offsuit_aces": 0.5},
+          "high": {"offsuit_aces": 1.0, "quick_tricks": 1.0},
+          "low": {"offsuit_tens_count": 1.0, "quick_tricks": 1.0}
+        },
+        "partner_weights": {
+          "partner_bid_level": 1.0,
+          "partner_passed": 1.0,
+          "partner_suit_match": 1.0,
+          "partner_bid_confidence": 1.0
+        }
+      }
+    },
+    {
+      "name": "hybrid_olsa_full_r0",
+      "class_name": "HybridOLSaBidder",
+      "params": {
+        "artifact_path": "data/artifacts/arc_d/r0/hybrid_r0_full.json",
+        "bid_level_search": true,
+        "risk_lambda": 0.0
+      }
+    },
+    {
+      "name": "hybrid_olsa_r0",
+      "class_name": "HybridOLSaBidder",
+      "params": {
+        "artifact_path": "data/artifacts/arc_d/r0/hybrid_r0.json",
+        "bid_level_search": true,
+        "risk_lambda": 0.0
+      }
+    },
+    {
+      "name": "modeloespecifico_r0",
+      "class_name": "ModeloEspecifico",
+      "params": {}
+    }
+  ],
+  "play_strategy": "glutton",
+  "gate_critical_matchups": [
+    {"a": "hybrid_olsa_full_r1", "b": "hybrid_olsa_full_r0", "purpose": "Primary class-local promotion signal (hybrid_full)"},
+    {"a": "hybrid_olsa_r1", "b": "hybrid_olsa_r0", "purpose": "Constrained class-local rung-over-rung"},
+    {"a": "modeloespecifico_r1", "b": "modeloespecifico_r0", "purpose": "Baseline class-local rung-over-rung"},
+    {"a": "hybrid_olsa_full_r1", "b": "hybrid_olsa_r1", "purpose": "Within-rung full vs constrained"},
+    {"a": "hybrid_olsa_full_r1", "b": "modeloespecifico_r1", "purpose": "External pressure check (learned vs hand-coded)"},
+    {"a": "hybrid_olsa_full_r1", "b": "modeloespecifico_r0", "purpose": "Cross-class cross-rung sanity"}
+  ]
+}

--- a/scripts/internal/generate_auction_context_dataset.py
+++ b/scripts/internal/generate_auction_context_dataset.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python
+"""
+Generate auction-context dataset with partner bidding features.
+
+Runs an auction-mode experiment (all 4 seats bidding with the same artifact),
+then post-processes JSONL logs to produce a bidless-format parquet dataset
+augmented with 4 partner auction features per row.
+
+Output: standard run directory with datasets/bidless.parquet (43-feature
+hand_features struct) and datasets/bidless_outcomes.parquet.
+
+Usage:
+    uv run python scripts/internal/generate_auction_context_dataset.py \
+        --bidder-artifact data/artifacts/arc_d/r0/hybrid_r0_full.json \
+        --seed 42 --n-deals 50000 \
+        --output-dir data/runs/canonical_auction_r1_42
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+from bid_euchre.core.cards import Card
+from bid_euchre.features.auction_context import (
+    PARTNER_FEATURE_NAMES,
+    extract_partner_features,
+)
+from bid_euchre.features.hand_eval import get_hand_features
+
+
+def _find_jsonl_log(run_dir):
+    """Find the JSONL log file in a run directory."""
+    logs_dir = Path(run_dir) / "logs"
+    if not logs_dir.is_dir():
+        return None
+    jsonl_files = list(logs_dir.glob("*.jsonl"))
+    if len(jsonl_files) == 1:
+        return str(jsonl_files[0])
+    # Multiple files: pick the largest (most likely the main log)
+    if jsonl_files:
+        return str(max(jsonl_files, key=lambda p: p.stat().st_size))
+    return None
+
+
+def _parse_contract(contract_str, trump_str):
+    """Map JSONL contract/trump fields to (contract_type, trump_suit)."""
+    if contract_str in ("HIGH", "high"):
+        return "high", None
+    elif contract_str in ("LOW", "low"):
+        return "low", None
+    else:
+        # Suit contract: trump field has the suit letter
+        return "suit", trump_str
+
+
+def _parse_hand(hand_data):
+    """Parse JSONL hand data ([suit, rank] pairs) into Card objects."""
+    return [Card(c[0], c[1]) for c in hand_data]
+
+
+def build_dataset_from_jsonl(jsonl_path):
+    """Build bidless-format DataFrames from JSONL auction logs.
+
+    Parses hand_end records, recomputes hand features from cards,
+    and adds partner auction context features.
+
+    Returns (bidless_rows, outcomes_rows).
+    """
+    bidless_rows = []
+    outcomes_rows = []
+
+    hand_id = 0
+    with open(jsonl_path) as f:
+        for line in f:
+            record = json.loads(line)
+            if record.get("event") != "hand_end":
+                continue
+
+            # Skip redeals (all-pass hands with no contract)
+            if record.get("redeal_flag"):
+                continue
+
+            contract_type, trump_suit = _parse_contract(
+                record["contract"], record.get("trump")
+            )
+            t0 = record["t0"]
+            t1 = record["t1"]
+            dealer = record.get("dealer_position", 0)
+            deal_id = record.get("deal_id", hand_id)
+            hands_data = record.get("hands")
+            auction_transcript = record.get("auction_transcript") or []
+
+            if not hands_data or len(hands_data) != 4:
+                print(
+                    f"  WARNING: Skipping hand {hand_id} — no hands data logged",
+                    file=sys.stderr,
+                )
+                continue
+
+            # Outcomes row (one per hand)
+            outcomes_rows.append(
+                {
+                    "hand_id": hand_id,
+                    "deal_id": deal_id,
+                    "dealer_seat": dealer,
+                    "contract_type": contract_type,
+                    "trump_suit": trump_suit,
+                    "strategy_id": "auction",
+                    "matchup_id": "auction",
+                    "team0_strategy": "auction",
+                    "team1_strategy": "auction",
+                    "tricks_team0": t0,
+                    "tricks_team1": t1,
+                    "team0_win": t0 > t1,
+                }
+            )
+
+            # Bidless rows (one per seat)
+            for seat in range(4):
+                hand_cards = _parse_hand(hands_data[seat])
+
+                # 39 hand features
+                features = get_hand_features(hand_cards, contract_type, trump_suit)
+
+                # 4 partner features
+                partner_feats = extract_partner_features(
+                    seat, auction_transcript, observer_best_contract=contract_type
+                )
+
+                # Merge into single dict (43 features)
+                merged_features = {**features, **partner_feats}
+
+                bidless_rows.append(
+                    {
+                        "hand_id": hand_id,
+                        "seat": seat,
+                        "dealer_seat": dealer,
+                        "deal_id": deal_id,
+                        "hand_cards": [str(c) for c in hand_cards],
+                        "hand_features": merged_features,
+                        "hand_feature_schema_version": 1,
+                        "contract_type": contract_type,
+                        "trump_suit": trump_suit,
+                    }
+                )
+
+            hand_id += 1
+
+    return bidless_rows, outcomes_rows
+
+
+def validate_dataset(bidless_df, outcomes_df):
+    """Run gate X1 validation on the generated dataset.
+
+    Raises AssertionError on any validation failure.
+    """
+    # Assert 4 rows per hand
+    rows_per_hand = bidless_df.groupby("hand_id").size()
+    assert (
+        rows_per_hand == 4
+    ).all(), f"Expected 4 rows per hand, got: {rows_per_hand.value_counts().to_dict()}"
+
+    # Assert partner features present and non-null
+    sample_features = bidless_df["hand_features"].iloc[0]
+    for fname in PARTNER_FEATURE_NAMES:
+        assert fname in sample_features, f"Missing partner feature: {fname}"
+        assert sample_features[fname] is not None, f"Null partner feature: {fname}"
+
+    # Assert feature dict has 43 keys (39 hand + 4 partner)
+    n_features = len(sample_features)
+    assert n_features == 43, f"Expected 43 features, got {n_features}"
+
+    # Assert outcomes match hands
+    n_hands_bidless = bidless_df["hand_id"].nunique()
+    n_hands_outcomes = len(outcomes_df)
+    assert (
+        n_hands_bidless == n_hands_outcomes
+    ), f"Hand count mismatch: bidless={n_hands_bidless}, outcomes={n_hands_outcomes}"
+
+    print(f"  Gate X1 PASS: {n_hands_bidless} hands, 43 features, 4 rows/hand")
+
+
+def print_partner_feature_stats(bidless_df):
+    """Print summary statistics for partner features."""
+    # Flatten hand_features to get partner columns
+    features_flat = pd.json_normalize(bidless_df["hand_features"])
+    print("\n  Partner feature summary:")
+    for fname in PARTNER_FEATURE_NAMES:
+        col = features_flat[fname]
+        print(
+            f"    {fname}: mean={col.mean():.3f}, "
+            f"std={col.std():.3f}, "
+            f"min={col.min():.1f}, max={col.max():.1f}"
+        )
+
+
+def run_auction_experiment(
+    bidder_artifact,
+    seed,
+    n_deals,
+    bidder_class="HybridOLSaBidder",
+    play_strategy="glutton",
+):
+    """Run an auction-mode experiment and return the run directory path."""
+    # Create temporary config
+    config = {
+        "experiment_name": "auction_context_gen",
+        "bidding_policies": [
+            {
+                "name": "target_bidder",
+                "class_name": bidder_class,
+                "params": {"artifact_path": bidder_artifact},
+            }
+        ],
+        "strategies": [{"name": play_strategy, "class_name": "GluttonStrategy"}],
+        "scenarios": [{"contract_type": None}],
+        "parameters": {
+            "n_per": n_deals,
+            "play_strategy": play_strategy,
+            "mode": "auction",
+        },
+    }
+
+    config_path = f"/tmp/auction_context_gen_{seed}.yaml"
+    with open(config_path, "w") as f:
+        yaml.dump(config, f)
+
+    print(f"  Config: {config_path}")
+    print(f"  Running {n_deals} deals with seed={seed}...")
+
+    # Snapshot data/runs before
+    runs_path = Path("data/runs")
+    runs_path.mkdir(parents=True, exist_ok=True)
+    before = {p.name for p in runs_path.iterdir() if p.is_dir()}
+
+    # Run experiment
+    cmd = [
+        sys.executable,
+        "experiments/run_experiment.py",
+        "--config",
+        config_path,
+        "--seed",
+        str(seed),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=1800)
+    if result.returncode != 0:
+        print(f"  ERROR: Experiment failed:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    # Find new run directory
+    after = {p.name for p in runs_path.iterdir() if p.is_dir()}
+    new_dirs = after - before
+    if len(new_dirs) != 1:
+        print(
+            f"  ERROR: Expected 1 new run directory, found {len(new_dirs)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    run_dir = str(runs_path / new_dirs.pop())
+    print(f"  Run directory: {run_dir}")
+    return run_dir
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate auction-context dataset with partner features"
+    )
+    parser.add_argument(
+        "--bidder-artifact",
+        required=True,
+        help="Path to bidder artifact JSON (all seats use this)",
+    )
+    parser.add_argument("--seed", type=int, required=True)
+    parser.add_argument("--n-deals", type=int, default=50000)
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Output directory for datasets (standard run directory structure)",
+    )
+    parser.add_argument(
+        "--bidder-class",
+        default="HybridOLSaBidder",
+        help="Bidder class name (default: HybridOLSaBidder)",
+    )
+    parser.add_argument(
+        "--play-strategy",
+        default="glutton",
+        help="Play strategy name (default: glutton)",
+    )
+    parser.add_argument(
+        "--skip-run",
+        default=None,
+        help="Skip experiment run, use existing run directory for JSONL parsing",
+    )
+    args = parser.parse_args()
+
+    print("=== Auction Context Dataset Generator ===")
+
+    # Step 1: Run experiment (or use existing)
+    if args.skip_run:
+        run_dir = args.skip_run
+        print(f"  Using existing run: {run_dir}")
+    else:
+        run_dir = run_auction_experiment(
+            args.bidder_artifact,
+            args.seed,
+            args.n_deals,
+            args.bidder_class,
+            args.play_strategy,
+        )
+
+    # Step 2: Find JSONL log
+    jsonl_path = _find_jsonl_log(run_dir)
+    if not jsonl_path:
+        print(f"  ERROR: No JSONL log found in {run_dir}/logs/", file=sys.stderr)
+        sys.exit(1)
+    print(f"  JSONL log: {jsonl_path}")
+
+    # Step 3: Build dataset
+    print("  Building dataset from JSONL...")
+    bidless_rows, outcomes_rows = build_dataset_from_jsonl(jsonl_path)
+
+    if not bidless_rows:
+        print("  ERROR: No valid hand records found in JSONL", file=sys.stderr)
+        sys.exit(1)
+
+    bidless_df = pd.DataFrame(bidless_rows)
+    outcomes_df = pd.DataFrame(outcomes_rows)
+
+    print(f"  Rows: {len(bidless_df)} bidless, {len(outcomes_df)} outcomes")
+
+    # Step 4: Validate (gate X1)
+    validate_dataset(bidless_df, outcomes_df)
+    print_partner_feature_stats(bidless_df)
+
+    # Step 5: Write to output directory
+    output_dir = Path(args.output_dir)
+    datasets_dir = output_dir / "datasets"
+    datasets_dir.mkdir(parents=True, exist_ok=True)
+
+    bidless_path = datasets_dir / "bidless.parquet"
+    outcomes_path = datasets_dir / "bidless_outcomes.parquet"
+
+    bidless_df.to_parquet(bidless_path)
+    outcomes_df.to_parquet(outcomes_path)
+
+    print(f"\n  Output: {bidless_path}")
+    print(f"  Output: {outcomes_path}")
+    print(f"  Hands: {outcomes_df.shape[0]}")
+    print("  Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/internal/run_auction_comparator.py
+++ b/scripts/internal/run_auction_comparator.py
@@ -112,6 +112,126 @@ def _write_batch_manifest(
     return str(manifest_path), batch_id
 
 
+def _write_dual_seat_manifest(
+    runs_dir, experiment_name, seed, n_per, policies, run_dirs_by_policy
+):
+    """Write a batch manifest after a complete dual-seat battery run.
+
+    Dual-seat: 2 sub-experiments per bidder (team0 = seats 0+2, team1 = seats 1+3).
+    Returns (manifest_path, batch_id) on success, (None, None) on failure.
+    """
+    expected_keys = []
+    for policy in policies:
+        for team in range(2):
+            expected_keys.append(f"{policy['name']}_team{team}")
+
+    # Completeness gate
+    missing = [k for k in expected_keys if k not in run_dirs_by_policy]
+    if missing:
+        print(
+            f"ERROR: Incomplete batch — missing {len(missing)} members: "
+            + ", ".join(missing),
+            file=sys.stderr,
+        )
+        return None, None
+
+    # Validate evaluation.json exists for each member
+    members = {}
+    for key in expected_keys:
+        run_dir = run_dirs_by_policy[key]
+        eval_path = Path(run_dir) / "reports" / "bidding_strategy" / "evaluation.json"
+        if not eval_path.exists():
+            print(
+                f"ERROR: Missing evaluation.json in {run_dir}",
+                file=sys.stderr,
+            )
+            return None, None
+        members[key] = Path(run_dir).name
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    batch_id = f"{experiment_name}_{seed}_{timestamp}"
+    manifest = {
+        "schema": "batch_manifest_v1",
+        "batch_id": batch_id,
+        "created_at_utc": datetime.now(timezone.utc).isoformat(),
+        "experiment_name": experiment_name,
+        "seed": seed,
+        "n_per": n_per,
+        "mode": "dual_seat",
+        "expected_policies": [p["name"] for p in policies],
+        "expected_teams": 2,
+        "members": members,
+    }
+
+    runs_path = Path(runs_dir)
+    manifest_path = runs_path / f"batch_manifest_{batch_id}.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    return str(manifest_path), batch_id
+
+
+def _merge_dual_seat_evaluations(run_dirs_by_policy, policies, load_fn=None):
+    """Merge evaluation.json across 2 teams per bidder (dual-seat mode).
+
+    Returns (metrics_by_bidder, missing_evaluations).
+    The load_fn parameter enables test injection; defaults to load_evaluation.
+    """
+    if load_fn is None:
+        load_fn = load_evaluation
+
+    metrics_by_bidder = {}
+    missing_evaluations = []
+
+    for policy in policies:
+        policy_name = policy["name"]
+        merged_deals = 0
+        merged_bid_hands = 0
+        merged_bidder_pts_sum = 0.0
+        merged_net_pts_sum = 0.0
+        merged_make_count = 0
+        missing_team = False
+
+        for team in range(2):
+            key = f"{policy_name}_team{team}"
+            run_dir = run_dirs_by_policy.get(key)
+            if not run_dir:
+                missing_team = True
+                continue
+            evaluation = load_fn(run_dir)
+            if evaluation and evaluation.get("strategies"):
+                strat = evaluation["strategies"][0]
+                dt = strat.get("deals_total", 0)
+                hwb = strat.get("hands_with_bids", 0)
+                merged_deals += dt
+                merged_bid_hands += hwb
+                ep = strat.get("expected_points_per_deal", 0)
+                nep = strat.get("net_expected_points_per_deal", 0)
+                merged_bidder_pts_sum += ep * dt
+                merged_net_pts_sum += nep * dt
+                mr = strat.get("make_rate", 0)
+                merged_make_count += int(round(mr * hwb))
+            else:
+                missing_team = True
+
+        if missing_team or merged_deals == 0:
+            missing_evaluations.append(policy_name)
+        else:
+            metrics_by_bidder[policy_name] = {
+                "expected_points": merged_bidder_pts_sum / merged_deals,
+                "expected_points_per_deal": merged_bidder_pts_sum / merged_deals,
+                "net_expected_points_per_deal": merged_net_pts_sum / merged_deals,
+                "make_rate": merged_make_count / merged_bid_hands
+                if merged_bid_hands > 0
+                else 0.0,
+                "bid_rate": merged_bid_hands / merged_deals,
+                "cvar_5": None,
+                "net_cvar_5": None,
+                "hands_with_bids": merged_bid_hands,
+                "deals_total": merged_deals,
+            }
+
+    return metrics_by_bidder, missing_evaluations
+
+
 def _load_batch_manifest(manifest_path, runs_dir):
     """Load and validate a batch manifest, returning resolved run dirs.
 
@@ -296,7 +416,13 @@ def gate_check(metrics_by_bidder):
 
 
 def format_json(
-    metrics_by_bidder, gate_failures, seed, n_per, single_seat=False, batch_id=None
+    metrics_by_bidder,
+    gate_failures,
+    seed,
+    n_per,
+    single_seat=False,
+    dual_seat=False,
+    batch_id=None,
 ):
     """Generate JSON comparison output with arc_d_comparator_v1 schema."""
     bidders = {}
@@ -316,7 +442,9 @@ def format_json(
         "gate_status": "FAIL" if gate_failures else "PASS",
         "bidders": bidders,
     }
-    if single_seat:
+    if dual_seat:
+        result["mode"] = "dual_seat"
+    elif single_seat:
         result["mode"] = "single_seat"
     if batch_id is not None:
         result["batch_id"] = batch_id
@@ -407,6 +535,11 @@ def main():
         help="Run single-seat mode: each bidder evaluated one seat at a time",
     )
     parser.add_argument(
+        "--dual-seat",
+        action="store_true",
+        help="Run dual-seat mode: both partnership seats use the same bidder",
+    )
+    parser.add_argument(
         "--n-per",
         type=int,
         default=None,
@@ -433,6 +566,9 @@ def main():
         help="Allow heuristic 'latest per seat' discovery when no manifest exists (unsafe)",
     )
     args = parser.parse_args()
+
+    if args.single_seat and args.dual_seat:
+        parser.error("--single-seat and --dual-seat are mutually exclusive")
 
     # Load config
     with open(args.config) as f:
@@ -466,7 +602,89 @@ def main():
     batch_id = None  # Set when a manifest is written or loaded
 
     if not args.skip_run:
-        if args.single_seat:
+        if args.dual_seat:
+            # Dual-seat mode: 2 sub-experiments per bidder (team0=seats 0+2, team1=seats 1+3)
+            print(
+                f"Running dual-seat comparator with {len(policies)} bidders, "
+                f"n_per={n_per_effective}..."
+            )
+            base_per_team = n_per_effective // 2
+            remainder = n_per_effective % 2
+
+            for policy in policies:
+                policy_name = policy["name"]
+
+                for team in range(2):
+                    team_n = base_per_team + (1 if team < remainder else 0)
+                    # Team 0 = seats 0+2, Team 1 = seats 1+3
+                    team_seats = [team, team + 2]
+
+                    seat_bp = ["always_pass"] * 4
+                    for s in team_seats:
+                        seat_bp[s] = policy_name
+
+                    per_team_config = {
+                        "experiment_name": f"{experiment_name}_{policy_name}_team{team}",
+                        "bidding_policies": [
+                            policy,
+                            {"name": "always_pass", "class_name": "AlwaysPassBidder"},
+                        ],
+                        "seat_bidding_policies": seat_bp,
+                        "strategies": config.get("strategies", []),
+                        "scenarios": config.get("scenarios", [{"contract_type": None}]),
+                        "parameters": {
+                            **config.get("parameters", {}),
+                            "n_per": team_n,
+                        },
+                    }
+
+                    config_path = (
+                        f"/tmp/auction_comparator_{policy_name}_team{team}.yaml"
+                    )
+                    with open(config_path, "w") as f:
+                        yaml.dump(per_team_config, f)
+
+                    # Validate play strategy passed through to generated config
+                    with open(config_path) as _f:
+                        _written = yaml.safe_load(_f)
+                    if not _written.get("strategies"):
+                        raise ValueError(
+                            f"Generated config {config_path} is missing 'strategies' section. "
+                            f"Ensure the source config includes a strategies list "
+                            f"(e.g., strategies: [{{name: glutton, class_name: GluttonStrategy}}])."
+                        )
+                    if not _written.get("parameters", {}).get("play_strategy"):
+                        raise ValueError(
+                            f"Generated config {config_path} is missing 'parameters.play_strategy'. "
+                            f"Ensure the source config includes play_strategy in parameters."
+                        )
+
+                    print(f"  Running {policy_name} team {team} ({team_n} deals)...")
+                    run_dir = run_experiment(config_path, args.seed)
+                    if run_dir is None:
+                        print(f"  FAILED: {policy_name} team {team}")
+                        continue
+
+                    run_dirs_by_policy[f"{policy_name}_team{team}"] = run_dir
+                    generate_evaluation(run_dir)
+
+            # Write batch manifest
+            manifest_path, batch_id = _write_dual_seat_manifest(
+                "data/runs",
+                experiment_name,
+                args.seed,
+                n_per_effective,
+                policies,
+                run_dirs_by_policy,
+            )
+            if manifest_path:
+                print(f"  Batch manifest: {manifest_path}")
+            else:
+                print(
+                    "  WARNING: Incomplete batch — no manifest written",
+                    file=sys.stderr,
+                )
+        elif args.single_seat:
             # Single-seat mode: 4 sub-experiments per bidder
             print(
                 f"Running single-seat comparator with {len(policies)} bidders, "
@@ -599,7 +817,25 @@ def main():
         # In --skip-run mode, discover run directories
         runs_path = Path("data/runs")
         if runs_path.is_dir():
-            if args.single_seat:
+            if args.dual_seat:
+                # Dual-seat: manifest-based discovery (no legacy heuristic)
+                if args.manifest:
+                    run_dirs_by_policy = _load_batch_manifest(
+                        args.manifest, "data/runs"
+                    )
+                    manifest_data = json.loads(Path(args.manifest).read_text())
+                    batch_id = manifest_data.get("batch_id")
+                    print(f"  Using manifest: {args.manifest} (batch_id={batch_id})")
+                else:
+                    print(
+                        f"ERROR: No batch manifest provided for "
+                        f"{experiment_name} seed={args.seed}.\n"
+                        f"Run the battery first (without --skip-run), "
+                        f"or provide --manifest <path>.",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
+            elif args.single_seat:
                 # Single-seat: manifest-based discovery with hard-fail default
                 if args.manifest:
                     # Priority 1: explicit --manifest
@@ -665,7 +901,11 @@ def main():
     metrics_by_bidder = {}
     missing_evaluations = []
 
-    if args.single_seat:
+    if args.dual_seat:
+        metrics_by_bidder, missing_evaluations = _merge_dual_seat_evaluations(
+            run_dirs_by_policy, policies
+        )
+    elif args.single_seat:
         metrics_by_bidder, missing_evaluations = _merge_single_seat_evaluations(
             run_dirs_by_policy, policies
         )
@@ -726,6 +966,7 @@ def main():
             args.seed,
             n_per_effective,
             single_seat=args.single_seat,
+            dual_seat=getattr(args, "dual_seat", False),
             batch_id=batch_id,
         )
         output_str = json.dumps(output_data, indent=2)

--- a/scripts/internal/run_threshold_sweep.py
+++ b/scripts/internal/run_threshold_sweep.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python
+"""
+Threshold sweep CLI: grid search over pass_threshold values.
+
+Loads a model artifact and evaluation dataset, applies deal_partition
+for train/val split, evaluates each threshold on the grid, selects
+the best threshold from train, and validates on val.
+
+Output: JSON artifact with grid results + selected threshold + validation metrics.
+
+Usage:
+    uv run python scripts/internal/run_threshold_sweep.py \
+        --artifact-path data/artifacts/arc_d/r1/hybrid_r1_full.json \
+        --data data/runs/canonical_auction_r1_42 \
+        --grid "0.0,0.1,0.2,0.5,1.0,2.0,5.0" \
+        --seed 42 \
+        --output data/artifacts/arc_d/r1/threshold_sweep_r1.json
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+
+from bid_euchre.analysis.sweep import compute_ev_vectorized, deal_partition
+from bid_euchre.datasets.join import join_features_outcomes
+
+
+def load_model_artifact(artifact_path):
+    """Load and validate an OLSa/Hybrid model artifact."""
+    with open(artifact_path) as f:
+        artifact = json.load(f)
+
+    artifact_type = artifact.get("artifact_type", "")
+    if artifact_type not in ("olsa_v1", "hybrid_olsa_v1"):
+        print(f"WARNING: Unexpected artifact_type={artifact_type!r}", file=sys.stderr)
+
+    return artifact
+
+
+def predict_tricks(model, feature_names, df):
+    """Predict tricks for a contract family using OLS weights.
+
+    Returns mu (predicted tricks) as numpy array.
+    """
+    weights = np.array(model["weights"], dtype=np.float64)
+    bias = float(model["bias"])
+    X = df[feature_names].values.astype(np.float64)
+    return X @ weights + bias
+
+
+def evaluate_threshold(df, mu, sigma, threshold):
+    """Evaluate a threshold value on the dataset.
+
+    For each row, compute best_bid EV and check if EV > -threshold.
+    Returns dict with net_eppd, bid_rate, make_rate, n_bid_hands.
+    """
+    # Bid level search: for each hand, find the best bid_n where EV > -threshold
+    bid_n_best = np.zeros(len(mu), dtype=int)
+    ev_best = np.full(len(mu), -np.inf)
+
+    current_high_bid = 0  # Self-play: no prior bids
+    for n in range(max(1, current_high_bid + 1), 11):
+        ev_n = compute_ev_vectorized(mu, sigma, np.full(len(mu), n))
+        better = ev_n > ev_best
+        bid_n_best = np.where(better, n, bid_n_best)
+        ev_best = np.where(better, ev_n, ev_best)
+
+    # Apply threshold: bid if EV > -threshold
+    would_bid = ev_best > -threshold
+    n_total = len(df)
+    n_bid = int(would_bid.sum())
+
+    if n_bid == 0:
+        return {
+            "net_eppd": 0.0,
+            "bid_rate": 0.0,
+            "make_rate": 0.0,
+            "n_bid_hands": 0,
+            "n_total": n_total,
+        }
+
+    # For bidding hands, compute outcomes
+    tricks_won = df["tricks_won"].values
+    bid_levels = bid_n_best[would_bid]
+    tricks_bid = tricks_won[would_bid]
+    made = tricks_bid >= bid_levels
+
+    # Bidder points: tricks_won if made, -bid if set
+    bidder_pts = np.where(made, tricks_bid, -bid_levels.astype(float))
+    # Opponent always gets their tricks (10 - tricks_won for bidder's team)
+    opponent_tricks = 10.0 - tricks_bid
+    net_pts = bidder_pts - opponent_tricks
+
+    # Non-bidding hands: both teams get their tricks, net = tricks - (10 - tricks) = 2*tricks - 10
+    no_bid_tricks = tricks_won[~would_bid]
+    no_bid_net = 2.0 * no_bid_tricks - 10.0
+
+    # Overall net_eppd: weighted average across all deals
+    total_net = float(net_pts.sum() + no_bid_net.sum())
+    net_eppd = total_net / n_total
+
+    return {
+        "net_eppd": net_eppd,
+        "bid_rate": n_bid / n_total,
+        "make_rate": float(made.mean()),
+        "n_bid_hands": n_bid,
+        "n_total": n_total,
+    }
+
+
+def run_sweep(artifact, df, grid, seed):
+    """Run threshold sweep on train/val split.
+
+    Returns (selected_threshold, train_results, val_result).
+    """
+    # Add partition column
+    df = df.copy()
+    df["_partition"] = df["deal_id"].apply(lambda d: deal_partition(str(d), seed))
+
+    train_df = df[df["_partition"] == "train"]
+    val_df = df[df["_partition"] == "val"]
+
+    print(f"  Train: {len(train_df)} rows, Val: {len(val_df)} rows")
+
+    # Determine which models to use (hybrid has 'suit', 'high', 'low')
+    models = artifact.get("models", {})
+
+    # Evaluate per contract family, then merge
+    train_results = {}
+    val_results = {}
+
+    for threshold in grid:
+        train_metrics_parts = []
+        val_metrics_parts = []
+
+        for cf, model in models.items():
+            feature_names = model["feature_names"]
+            sigma = model.get("sigma", 1.0)  # Default sigma if not in artifact
+
+            for split_name, split_df, result_list in [
+                ("train", train_df, train_metrics_parts),
+                ("val", val_df, val_metrics_parts),
+            ]:
+                cf_df = split_df[split_df["contract_type"] == cf]
+                if len(cf_df) == 0:
+                    continue
+                mu = predict_tricks(model, feature_names, cf_df)
+                metrics = evaluate_threshold(cf_df, mu, sigma, threshold)
+                result_list.append(
+                    {"contract_type": cf, "n": len(cf_df), "metrics": metrics}
+                )
+
+        # Aggregate train results across contract families
+        train_results[threshold] = _aggregate_metrics(train_metrics_parts)
+        val_results[threshold] = _aggregate_metrics(val_metrics_parts)
+
+    # Select best threshold from train (highest net_eppd)
+    selected = max(train_results, key=lambda t: train_results[t].get("net_eppd", -999))
+
+    return selected, train_results, val_results
+
+
+def _aggregate_metrics(parts):
+    """Aggregate metrics across contract families weighted by deal count."""
+    if not parts:
+        return {"net_eppd": 0.0, "bid_rate": 0.0, "make_rate": 0.0, "n_total": 0}
+
+    total_n = sum(p["n"] for p in parts)
+    if total_n == 0:
+        return {"net_eppd": 0.0, "bid_rate": 0.0, "make_rate": 0.0, "n_total": 0}
+
+    net_eppd = sum(p["metrics"]["net_eppd"] * p["n"] for p in parts) / total_n
+    bid_rate = sum(p["metrics"]["bid_rate"] * p["n"] for p in parts) / total_n
+    total_bids = sum(p["metrics"]["n_bid_hands"] for p in parts)
+    total_made = sum(
+        p["metrics"]["make_rate"] * p["metrics"]["n_bid_hands"] for p in parts
+    )
+    make_rate = total_made / total_bids if total_bids > 0 else 0.0
+
+    return {
+        "net_eppd": net_eppd,
+        "bid_rate": bid_rate,
+        "make_rate": make_rate,
+        "n_total": total_n,
+        "n_bid_hands": total_bids,
+    }
+
+
+def format_output(artifact_path, seed, grid, selected, train_results, val_results):
+    """Format sweep results as JSON artifact."""
+    grid_detail = {}
+    for t in grid:
+        grid_detail[str(t)] = {
+            "train": train_results[t],
+            "val": val_results.get(t, {}),
+        }
+
+    return {
+        "schema": "threshold_sweep_v1",
+        "artifact_path": str(artifact_path),
+        "seed": seed,
+        "grid": grid,
+        "selected_threshold": selected,
+        "selected_train_metrics": train_results[selected],
+        "selected_val_metrics": val_results.get(selected, {}),
+        "grid_results": grid_detail,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Threshold sweep for pass_threshold")
+    parser.add_argument(
+        "--artifact-path",
+        required=True,
+        help="Path to model artifact JSON",
+    )
+    parser.add_argument(
+        "--data",
+        required=True,
+        help="Run directory or path to bidless parquet",
+    )
+    parser.add_argument(
+        "--grid",
+        default="0.0,0.1,0.2,0.5,1.0,2.0,5.0",
+        help="Comma-separated threshold grid (default: 0.0,...,5.0)",
+    )
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Output JSON path for sweep results",
+    )
+    args = parser.parse_args()
+
+    grid = [float(x.strip()) for x in args.grid.split(",")]
+
+    print("=== Threshold Sweep ===")
+    print(f"  Artifact: {args.artifact_path}")
+    print(f"  Grid: {grid}")
+    print(f"  Seed: {args.seed}")
+
+    # Load artifact
+    artifact = load_model_artifact(args.artifact_path)
+
+    # Load dataset
+    data_path = Path(args.data)
+    if data_path.is_dir():
+        bidless_path = str(data_path / "datasets" / "bidless.parquet")
+        outcomes_path = str(data_path / "datasets" / "bidless_outcomes.parquet")
+    else:
+        print("ERROR: --data must be a run directory", file=sys.stderr)
+        sys.exit(1)
+
+    df = join_features_outcomes(bidless_path, outcomes_path)
+    print(f"  Dataset: {len(df)} rows")
+
+    # Run sweep
+    selected, train_results, val_results = run_sweep(artifact, df, grid, args.seed)
+
+    print(f"\n  Selected threshold: {selected}")
+    print(f"  Train net_eppd:    {train_results[selected]['net_eppd']:.4f}")
+    if selected in val_results:
+        print(f"  Val net_eppd:      {val_results[selected]['net_eppd']:.4f}")
+
+    # Write output
+    output = format_output(
+        args.artifact_path, args.seed, grid, selected, train_results, val_results
+    )
+    os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+    with open(args.output, "w") as f:
+        json.dump(output, f, indent=2)
+
+    print(f"\n  Output: {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bid_euchre/features/auction_context.py
+++ b/src/bid_euchre/features/auction_context.py
@@ -1,0 +1,81 @@
+"""
+Partner bidding context features extracted from auction_transcript.
+
+These features capture information about the partner's bidding behavior
+during the auction phase. They are separate from hand evaluation features
+(hand_eval.py) because they depend on auction state, not just cards.
+
+Features:
+    partner_bid_level: Highest bid level partner made (0 if passed/no action)
+    partner_passed: 1 if partner explicitly passed, 0 otherwise
+    partner_suit_match: 1 if partner bid same contract family as observer context
+    partner_bid_confidence: partner_bid_level / 10 (normalized to [0, 1])
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def extract_partner_features(
+    seat: int,
+    auction_transcript: tuple[dict, ...] | list[dict],
+    observer_best_contract: str | None = None,
+) -> dict[str, Any]:
+    """Extract partner bidding context features from auction transcript.
+
+    Args:
+        seat: Observer's seat index (0-3).
+        auction_transcript: Sequence of auction entry dicts, each with keys:
+            seat (int), action (str: "BID" or "PASS"),
+            tricks_bid (int), contract_type (str|None), trump (str|None).
+        observer_best_contract: Contract family the observer is evaluating
+            ("suit", "high", or "low"). Used for partner_suit_match.
+            If None, partner_suit_match defaults to 0.
+
+    Returns:
+        Dict with 4 features:
+            partner_bid_level (int): 0-10, highest bid partner made
+            partner_passed (int): 0 or 1
+            partner_suit_match (int): 0 or 1
+            partner_bid_confidence (float): 0.0-1.0
+    """
+    partner_seat = (seat + 2) % 4
+
+    partner_bid_level = 0
+    partner_passed = 0
+    partner_contract_type = None
+
+    for entry in auction_transcript:
+        if entry["seat"] != partner_seat:
+            continue
+        if entry["action"] == "PASS":
+            partner_passed = 1
+        elif entry["action"] == "BID":
+            bid_level = entry.get("tricks_bid", 0)
+            if bid_level > partner_bid_level:
+                partner_bid_level = bid_level
+                partner_contract_type = entry.get("contract_type")
+
+    # Suit match: did partner bid the same contract family as observer?
+    partner_suit_match = 0
+    if observer_best_contract is not None and partner_contract_type is not None:
+        partner_suit_match = int(partner_contract_type == observer_best_contract)
+
+    partner_bid_confidence = partner_bid_level / 10.0
+
+    return {
+        "partner_bid_level": partner_bid_level,
+        "partner_passed": partner_passed,
+        "partner_suit_match": partner_suit_match,
+        "partner_bid_confidence": partner_bid_confidence,
+    }
+
+
+# Canonical feature names for schema validation and filtering
+PARTNER_FEATURE_NAMES = [
+    "partner_bid_level",
+    "partner_passed",
+    "partner_suit_match",
+    "partner_bid_confidence",
+]

--- a/src/bid_euchre/models/train_olsa.py
+++ b/src/bid_euchre/models/train_olsa.py
@@ -30,9 +30,9 @@ logger = logging.getLogger(__name__)
 
 # Per-contract feature specs
 CONTRACT_FEATURES = {
-    "suit": ["bowers", "trump_count", "offsuit_aces"],
-    "high": ["offsuit_aces"],
-    "low": ["offsuit_tens_count"],
+    "suit": ["bowers", "trump_count", "offsuit_aces"],  # 3 (unchanged)
+    "high": ["offsuit_aces", "quick_tricks"],  # 2 (R1: +quick_tricks)
+    "low": ["offsuit_tens_count", "quick_tricks"],  # 2 (R1: +quick_tricks)
 }
 
 
@@ -113,7 +113,8 @@ def train_olsa(run_dir, seed, split_manifest_dir=None, split_type="two_way"):
             continue
 
         train_df, val_df, test_df, manifest = create_grouped_split(
-            sub, seed,
+            sub,
+            seed,
             source_run_id=source_run_id,
             source_parquet_path=bidless_path,
             split_type=split_type,
@@ -252,9 +253,13 @@ if __name__ == "__main__":
     )
 
     parser = argparse.ArgumentParser(description="Train OLSa models")
-    parser.add_argument("--run-dir", required=True, help="Canonical bidless run directory")
+    parser.add_argument(
+        "--run-dir", required=True, help="Canonical bidless run directory"
+    )
     parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--output", required=True, help="Output directory for artifacts")
+    parser.add_argument(
+        "--output", required=True, help="Output directory for artifacts"
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")

--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -443,19 +443,44 @@ class RanktheTank(BiddingPolicy):
 
 class ModeloEspecifico(BiddingPolicy):
     """
-    Feature-weighted bidder using hand-coded weights.
+    Feature-weighted bidder with configurable weights.
 
-    Formulas (locked):
+    Default formulas (R0, locked):
       suit: 1.0 * bowers + 0.5 * trump_count + 0.5 * offsuit_aces
       HIGH: 1.0 * offsuit_aces
       LOW:  1.0 * offsuit_tens_count
 
+    R1 adds optional partner_weights for auction context features.
     The score maps directly to bid amount (floored).
     Named after the blog post's "specific model" baseline.
     """
 
-    def __init__(self, name: str = "modelo_especifico"):
+    _DEFAULT_FEATURE_WEIGHTS = {
+        "suit": {"bowers": 1.0, "trump_count": 0.5, "offsuit_aces": 0.5},
+        "high": {"offsuit_aces": 1.0},
+        "low": {"offsuit_tens_count": 1.0},
+    }
+
+    def __init__(
+        self,
+        name: str = "modelo_especifico",
+        feature_weights: dict | None = None,
+        partner_weights: dict | None = None,
+    ):
         super().__init__(name)
+        self.feature_weights = feature_weights or self._DEFAULT_FEATURE_WEIGHTS
+        self.partner_weights = partner_weights
+
+    def _compute_partner_score(self, obs, contract_family):
+        """Compute partner feature contribution to score."""
+        if not self.partner_weights or not obs.auction_transcript:
+            return 0.0
+        from ..features.auction_context import extract_partner_features
+
+        partner_feats = extract_partner_features(
+            obs.seat, obs.auction_transcript, observer_best_contract=contract_family
+        )
+        return sum(w * partner_feats[f] for f, w in self.partner_weights.items())
 
     def choose_bid(self, obs: BiddingObservation) -> BidAction:
         from ..features.hand_eval import get_hand_features
@@ -463,27 +488,30 @@ class ModeloEspecifico(BiddingPolicy):
         candidates = []
 
         # Evaluate suit contracts
+        partner_score_suit = self._compute_partner_score(obs, "suit")
         for suit in ["C", "D", "H", "S"]:
             features = get_hand_features(obs.hand, "suit", suit)
-            score = (
-                1.0 * features["bowers"]
-                + 0.5 * features["trump_count"]
-                + 0.5 * features["offsuit_aces"]
-            )
+            weights = self.feature_weights.get("suit", {})
+            score = sum(w * features[f] for f, w in weights.items())
+            score += partner_score_suit
             bid_n = int(score)  # floor
             if 1 <= bid_n <= 10 and bid_n > obs.current_high_bid:
                 candidates.append((score, bid_n, suit))
 
-        # Evaluate HIGH contract: score = 1.0 * offsuit_aces
+        # Evaluate HIGH contract
         features_high = get_hand_features(obs.hand, "high", None)
-        score_high = 1.0 * features_high["offsuit_aces"]
+        weights_high = self.feature_weights.get("high", {})
+        score_high = sum(w * features_high[f] for f, w in weights_high.items())
+        score_high += self._compute_partner_score(obs, "high")
         bid_n_high = int(score_high)
         if 1 <= bid_n_high <= 10 and bid_n_high > obs.current_high_bid:
             candidates.append((score_high, bid_n_high, "HIGH"))
 
-        # Evaluate LOW contract: score = 1.0 * offsuit_tens_count
+        # Evaluate LOW contract
         features_low = get_hand_features(obs.hand, "low", None)
-        score_low = 1.0 * features_low["offsuit_tens_count"]
+        weights_low = self.feature_weights.get("low", {})
+        score_low = sum(w * features_low[f] for f, w in weights_low.items())
+        score_low += self._compute_partner_score(obs, "low")
         bid_n_low = int(score_low)
         if 1 <= bid_n_low <= 10 and bid_n_low > obs.current_high_bid:
             candidates.append((score_low, bid_n_low, "LOW"))

--- a/tests/unit/test_auction_context.py
+++ b/tests/unit/test_auction_context.py
@@ -1,0 +1,117 @@
+"""Tests for partner bidding context feature extraction."""
+
+import pytest
+
+from bid_euchre.features.auction_context import (
+    PARTNER_FEATURE_NAMES,
+    extract_partner_features,
+)
+
+
+def _bid_entry(seat: int, tricks: int, contract_type: str, trump: str | None = None):
+    return {
+        "seat": seat,
+        "action": "BID",
+        "tricks_bid": tricks,
+        "contract_type": contract_type,
+        "trump": trump,
+    }
+
+
+def _pass_entry(seat: int):
+    return {
+        "seat": seat,
+        "action": "PASS",
+        "tricks_bid": 0,
+        "contract_type": None,
+        "trump": None,
+    }
+
+
+class TestExtractPartnerFeatures:
+    def test_partner_bid_extracts_level(self):
+        # Seat 0's partner is seat 2; seat 2 bids 5 suit
+        transcript = [_bid_entry(2, 5, "suit", "H")]
+        result = extract_partner_features(0, transcript)
+        assert result["partner_bid_level"] == 5
+
+    def test_partner_passed_flag(self):
+        transcript = [_pass_entry(2)]
+        result = extract_partner_features(0, transcript)
+        assert result["partner_passed"] == 1
+        assert result["partner_bid_level"] == 0
+
+    def test_empty_transcript_all_zeros(self):
+        result = extract_partner_features(0, ())
+        assert result["partner_bid_level"] == 0
+        assert result["partner_passed"] == 0
+        assert result["partner_suit_match"] == 0
+        assert result["partner_bid_confidence"] == 0.0
+
+    def test_partner_suit_match(self):
+        transcript = [_bid_entry(2, 4, "suit", "S")]
+        result = extract_partner_features(0, transcript, observer_best_contract="suit")
+        assert result["partner_suit_match"] == 1
+
+    def test_partner_suit_mismatch(self):
+        transcript = [_bid_entry(2, 3, "high")]
+        result = extract_partner_features(0, transcript, observer_best_contract="suit")
+        assert result["partner_suit_match"] == 0
+
+    def test_partner_bid_confidence_normalized(self):
+        transcript = [_bid_entry(2, 7, "suit", "D")]
+        result = extract_partner_features(0, transcript)
+        assert result["partner_bid_confidence"] == pytest.approx(0.7)
+
+    def test_multiple_entries_takes_highest(self):
+        transcript = [
+            _bid_entry(2, 3, "suit", "H"),
+            _bid_entry(2, 5, "suit", "S"),
+        ]
+        result = extract_partner_features(0, transcript)
+        assert result["partner_bid_level"] == 5
+
+    def test_ignores_non_partner_seats(self):
+        # Seat 0's partner is seat 2; bids from seat 1 and 3 should be ignored
+        transcript = [
+            _bid_entry(1, 6, "suit", "H"),
+            _bid_entry(3, 8, "high"),
+        ]
+        result = extract_partner_features(0, transcript)
+        assert result["partner_bid_level"] == 0
+        assert result["partner_passed"] == 0
+
+    def test_no_observer_contract_defaults_suit_match_zero(self):
+        transcript = [_bid_entry(2, 4, "suit", "D")]
+        result = extract_partner_features(0, transcript, observer_best_contract=None)
+        assert result["partner_suit_match"] == 0
+
+    def test_partner_seat_wraps_correctly(self):
+        # Seat 1's partner is seat 3
+        transcript = [_bid_entry(3, 4, "low")]
+        result = extract_partner_features(1, transcript)
+        assert result["partner_bid_level"] == 4
+
+        # Seat 3's partner is seat 1
+        transcript = [_bid_entry(1, 6, "high")]
+        result = extract_partner_features(3, transcript)
+        assert result["partner_bid_level"] == 6
+
+    def test_pass_then_bid_captures_both(self):
+        transcript = [
+            _pass_entry(2),
+            _bid_entry(2, 4, "suit", "H"),
+        ]
+        result = extract_partner_features(0, transcript)
+        assert result["partner_passed"] == 1
+        assert result["partner_bid_level"] == 4
+
+    def test_feature_names_constant_matches_output(self):
+        result = extract_partner_features(0, ())
+        assert set(result.keys()) == set(PARTNER_FEATURE_NAMES)
+
+    def test_accepts_list_transcript(self):
+        """Transcript can be list (from JSONL) or tuple (from BiddingObservation)."""
+        transcript = [_bid_entry(2, 3, "suit", "H")]
+        result = extract_partner_features(0, transcript)
+        assert result["partner_bid_level"] == 3

--- a/tests/unit/test_bidding.py
+++ b/tests/unit/test_bidding.py
@@ -1265,6 +1265,111 @@ class TestModeloEspecificoBidFloorRemoval:
         assert action.is_pass()
 
 
+class TestModeloEspecificoR1:
+    """Test ModeloEspecifico R1 parameterization (feature_weights + partner_weights)."""
+
+    def test_default_weights_constant(self):
+        """Default feature_weights matches the R0 locked formulas."""
+        expected = {
+            "suit": {"bowers": 1.0, "trump_count": 0.5, "offsuit_aces": 0.5},
+            "high": {"offsuit_aces": 1.0},
+            "low": {"offsuit_tens_count": 1.0},
+        }
+        assert ModeloEspecifico._DEFAULT_FEATURE_WEIGHTS == expected
+
+    def test_custom_suit_weights_change_bid(self):
+        """Custom suit weights produce different bids than default."""
+        # Double the bower weight → scores increase for suit contracts
+        custom_weights = {
+            "suit": {"bowers": 2.0, "trump_count": 0.5, "offsuit_aces": 0.5},
+            "high": {"offsuit_aces": 1.0},
+            "low": {"offsuit_tens_count": 1.0},
+        }
+        bidder = ModeloEspecifico(feature_weights=custom_weights)
+
+        # 2 bowers + 4 trump + 1 offsuit ace
+        # Default: 1.0*2 + 0.5*4 + 0.5*1 = 4.5 → bid 4
+        # Custom:  2.0*2 + 0.5*4 + 0.5*1 = 6.5 → bid 6
+        hand = [
+            Card("H", "J"),
+            Card("D", "J"),
+            Card("H", "A"),
+            Card("H", "K"),
+            Card("S", "A"),
+        ]
+
+        obs = BiddingObservation(hand=hand, seat=0, dealer_seat=3, current_high_bid=0)
+
+        default_bidder = ModeloEspecifico()
+        default_action = default_bidder.choose_bid(obs)
+        assert default_action.n == 4  # Baseline
+
+        custom_action = bidder.choose_bid(obs)
+        assert custom_action.n == 6  # Higher due to doubled bower weight
+
+    def test_partner_weights_increase_bid(self):
+        """Partner weights add to score when transcript shows partner bid."""
+        partner_weights = {
+            "partner_bid_level": 0.5,
+            "partner_passed": 0.0,
+            "partner_suit_match": 0.0,
+            "partner_bid_confidence": 0.0,
+        }
+        bidder = ModeloEspecifico(partner_weights=partner_weights)
+
+        # Hand: 2 bowers + 4 trump + 1 offsuit ace → default score 4.5 → bid 4
+        hand = [
+            Card("H", "J"),
+            Card("D", "J"),
+            Card("H", "A"),
+            Card("H", "K"),
+            Card("S", "A"),
+        ]
+
+        # Partner (seat 2) bid suit level 4 → partner_bid_level=4
+        # Partner contribution: 0.5 * 4 = 2.0
+        # Total score: 4.5 + 2.0 = 6.5 → bid 6
+        transcript = (
+            {"seat": 2, "action": "BID", "tricks_bid": 4, "contract_type": "suit"},
+        )
+        obs = BiddingObservation(
+            hand=hand,
+            seat=0,
+            dealer_seat=3,
+            current_high_bid=0,
+            auction_transcript=transcript,
+        )
+        action = bidder.choose_bid(obs)
+        assert action.n == 6
+        assert action.contract == "H"
+
+    def test_empty_transcript_no_partner_contribution(self):
+        """Empty transcript → zero partner contribution even with weights set."""
+        partner_weights = {
+            "partner_bid_level": 10.0,
+            "partner_passed": 10.0,
+            "partner_suit_match": 10.0,
+            "partner_bid_confidence": 10.0,
+        }
+        bidder = ModeloEspecifico(partner_weights=partner_weights)
+        default_bidder = ModeloEspecifico()
+
+        hand = [
+            Card("H", "J"),
+            Card("D", "J"),
+            Card("H", "A"),
+            Card("H", "K"),
+            Card("S", "A"),
+        ]
+
+        obs = BiddingObservation(hand=hand, seat=0, dealer_seat=3, current_high_bid=0)
+
+        assert bidder.choose_bid(obs).n == default_bidder.choose_bid(obs).n
+        assert (
+            bidder.choose_bid(obs).contract == default_bidder.choose_bid(obs).contract
+        )
+
+
 class TestRanktheTankFloorExtension:
     """Test RanktheTank suit bid_1/bid_2 tiers and HIGH/LOW floor extension."""
 

--- a/tests/unit/test_comparator_dual_seat.py
+++ b/tests/unit/test_comparator_dual_seat.py
@@ -1,0 +1,211 @@
+"""
+Unit tests for dual-seat comparator mode.
+
+Tests cover: config generation, merge logic, manifest schema, format_json mode.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+# Import via importlib to avoid sys.path.insert anti-pattern.
+_COMPARATOR_SCRIPT = (
+    Path(__file__).parent.parent.parent
+    / "scripts"
+    / "internal"
+    / "run_auction_comparator.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "run_auction_comparator", _COMPARATOR_SCRIPT
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+format_json = _mod.format_json
+_merge_dual_seat_evaluations = _mod._merge_dual_seat_evaluations
+_write_dual_seat_manifest = _mod._write_dual_seat_manifest
+
+
+def _make_fake_eval(deals_total, hands_with_bids, eppd, net_eppd, make_rate):
+    """Create a minimal evaluation.json-like dict for test injection."""
+    return {
+        "strategies": [
+            {
+                "deals_total": deals_total,
+                "hands_with_bids": hands_with_bids,
+                "expected_points_per_deal": eppd,
+                "net_expected_points_per_deal": net_eppd,
+                "make_rate": make_rate,
+                "bid_rate": hands_with_bids / deals_total if deals_total > 0 else 0,
+            }
+        ]
+    }
+
+
+class TestMergeDualSeatEvaluations:
+    """Test dual-seat evaluation merging across 2 teams."""
+
+    def test_two_teams_merge_correctly(self):
+        """Merge 2 team evaluations into a single bidder metric."""
+        policies = [{"name": "test_bidder"}]
+        run_dirs = {
+            "test_bidder_team0": "/fake/team0",
+            "test_bidder_team1": "/fake/team1",
+        }
+
+        # Team 0: 100 deals, 50 bids, eppd=2.0, net_eppd=1.0, make_rate=0.8
+        # Team 1: 100 deals, 60 bids, eppd=3.0, net_eppd=1.5, make_rate=0.6
+        fake_evals = {
+            "/fake/team0": _make_fake_eval(100, 50, 2.0, 1.0, 0.8),
+            "/fake/team1": _make_fake_eval(100, 60, 3.0, 1.5, 0.6),
+        }
+
+        metrics, missing = _merge_dual_seat_evaluations(
+            run_dirs, policies, load_fn=lambda d: fake_evals[d]
+        )
+
+        assert len(missing) == 0
+        assert "test_bidder" in metrics
+        m = metrics["test_bidder"]
+
+        # Merged: 200 deals, 110 bid hands
+        assert m["deals_total"] == 200
+        assert m["hands_with_bids"] == 110
+
+        # eppd = (2.0*100 + 3.0*100) / 200 = 2.5
+        assert abs(m["expected_points_per_deal"] - 2.5) < 1e-9
+
+        # net_eppd = (1.0*100 + 1.5*100) / 200 = 1.25
+        assert abs(m["net_expected_points_per_deal"] - 1.25) < 1e-9
+
+        # bid_rate = 110 / 200 = 0.55
+        assert abs(m["bid_rate"] - 0.55) < 1e-9
+
+        # make_count = round(0.8*50) + round(0.6*60) = 40 + 36 = 76
+        # make_rate = 76 / 110
+        assert abs(m["make_rate"] - 76 / 110) < 1e-9
+
+    def test_missing_team_reports_missing(self):
+        """Missing team sub-run reports the bidder as missing."""
+        policies = [{"name": "bidder_x"}]
+        run_dirs = {
+            "bidder_x_team0": "/fake/team0",
+            # team1 missing
+        }
+
+        fake_evals = {
+            "/fake/team0": _make_fake_eval(100, 50, 2.0, 1.0, 0.8),
+        }
+
+        metrics, missing = _merge_dual_seat_evaluations(
+            run_dirs, policies, load_fn=lambda d: fake_evals.get(d)
+        )
+
+        assert "bidder_x" in missing
+        assert "bidder_x" not in metrics
+
+    def test_multiple_bidders_merge_independently(self):
+        """Each bidder's teams are merged independently."""
+        policies = [{"name": "alpha"}, {"name": "beta"}]
+        run_dirs = {
+            "alpha_team0": "/fake/a0",
+            "alpha_team1": "/fake/a1",
+            "beta_team0": "/fake/b0",
+            "beta_team1": "/fake/b1",
+        }
+
+        fake_evals = {
+            "/fake/a0": _make_fake_eval(100, 40, 1.0, 0.5, 0.7),
+            "/fake/a1": _make_fake_eval(100, 40, 1.0, 0.5, 0.7),
+            "/fake/b0": _make_fake_eval(200, 80, 3.0, 2.0, 0.9),
+            "/fake/b1": _make_fake_eval(200, 80, 3.0, 2.0, 0.9),
+        }
+
+        metrics, missing = _merge_dual_seat_evaluations(
+            run_dirs, policies, load_fn=lambda d: fake_evals[d]
+        )
+
+        assert len(missing) == 0
+        assert len(metrics) == 2
+
+        # Alpha: identical teams → same metrics
+        assert abs(metrics["alpha"]["expected_points_per_deal"] - 1.0) < 1e-9
+        assert metrics["alpha"]["deals_total"] == 200
+
+        # Beta: identical teams → same metrics
+        assert abs(metrics["beta"]["expected_points_per_deal"] - 3.0) < 1e-9
+        assert metrics["beta"]["deals_total"] == 400
+
+
+class TestWriteDualSeatManifest:
+    """Test dual-seat batch manifest writing."""
+
+    def test_writes_valid_manifest(self, tmp_path):
+        """Manifest is written with correct schema fields."""
+        # Create fake run dirs with evaluation.json
+        for suffix in ["team0", "team1"]:
+            run_dir = tmp_path / f"test_bidder_{suffix}"
+            eval_dir = run_dir / "reports" / "bidding_strategy"
+            eval_dir.mkdir(parents=True)
+            (eval_dir / "evaluation.json").write_text("{}")
+
+        run_dirs = {
+            "test_bidder_team0": str(tmp_path / "test_bidder_team0"),
+            "test_bidder_team1": str(tmp_path / "test_bidder_team1"),
+        }
+        policies = [{"name": "test_bidder"}]
+
+        manifest_path, batch_id = _write_dual_seat_manifest(
+            str(tmp_path), "test_exp", 42, 1000, policies, run_dirs
+        )
+
+        assert manifest_path is not None
+        assert batch_id is not None
+
+        manifest = json.loads(Path(manifest_path).read_text())
+        assert manifest["schema"] == "batch_manifest_v1"
+        assert manifest["mode"] == "dual_seat"
+        assert manifest["expected_teams"] == 2
+        assert manifest["seed"] == 42
+        assert manifest["n_per"] == 1000
+        assert "test_bidder_team0" in manifest["members"]
+        assert "test_bidder_team1" in manifest["members"]
+
+    def test_incomplete_batch_returns_none(self, tmp_path):
+        """Missing team sub-run → no manifest written."""
+        # Only team0
+        run_dir = tmp_path / "test_bidder_team0"
+        eval_dir = run_dir / "reports" / "bidding_strategy"
+        eval_dir.mkdir(parents=True)
+        (eval_dir / "evaluation.json").write_text("{}")
+
+        run_dirs = {"test_bidder_team0": str(run_dir)}
+        policies = [{"name": "test_bidder"}]
+
+        manifest_path, batch_id = _write_dual_seat_manifest(
+            str(tmp_path), "test_exp", 42, 1000, policies, run_dirs
+        )
+
+        assert manifest_path is None
+        assert batch_id is None
+
+
+class TestFormatJsonDualSeat:
+    """Test format_json includes dual_seat mode."""
+
+    def test_dual_seat_mode_in_output(self):
+        """format_json with dual_seat=True includes mode field."""
+        metrics = {"bidder": {"net_expected_points_per_deal": 1.0, "bid_rate": 0.5}}
+        result = format_json(metrics, [], 42, 1000, dual_seat=True)
+        assert result["mode"] == "dual_seat"
+
+    def test_single_seat_mode_unchanged(self):
+        """format_json with single_seat=True still works."""
+        metrics = {"bidder": {"net_expected_points_per_deal": 1.0, "bid_rate": 0.5}}
+        result = format_json(metrics, [], 42, 1000, single_seat=True)
+        assert result["mode"] == "single_seat"
+
+    def test_no_mode_by_default(self):
+        """format_json with neither flag omits mode field."""
+        metrics = {"bidder": {"net_expected_points_per_deal": 1.0, "bid_rate": 0.5}}
+        result = format_json(metrics, [], 42, 1000)
+        assert "mode" not in result

--- a/tests/unit/test_generate_auction_context.py
+++ b/tests/unit/test_generate_auction_context.py
@@ -1,0 +1,265 @@
+"""
+Unit tests for auction-context dataset generator.
+
+Tests the JSONL parsing and dataset building logic (not the experiment runner).
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from bid_euchre.features.auction_context import PARTNER_FEATURE_NAMES
+
+# Import script via importlib (no sys.path manipulation)
+_SCRIPT = (
+    Path(__file__).parent.parent.parent
+    / "scripts"
+    / "internal"
+    / "generate_auction_context_dataset.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "generate_auction_context_dataset", _SCRIPT
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+build_dataset_from_jsonl = _mod.build_dataset_from_jsonl
+validate_dataset = _mod.validate_dataset
+_parse_contract = _mod._parse_contract
+
+
+def _make_hand_end_record(
+    hand_id=0,
+    contract="H",
+    trump="H",
+    t0=6,
+    t1=4,
+    dealer=0,
+    hands=None,
+    auction_transcript=None,
+):
+    """Create a minimal hand_end JSONL record for testing."""
+    if hands is None:
+        # 4 hands of 10 cards each (simplified — just enough to extract features)
+        default_hand = [
+            ["H", "A"],
+            ["H", "K"],
+            ["H", "Q"],
+            ["S", "A"],
+            ["S", "K"],
+            ["D", "A"],
+            ["D", "K"],
+            ["C", "A"],
+            ["C", "K"],
+            ["C", "Q"],
+        ]
+        hands = [default_hand] * 4
+
+    if auction_transcript is None:
+        auction_transcript = [
+            {"seat": 0, "action": "BID", "tricks_bid": 6, "contract_type": "suit"},
+            {"seat": 1, "action": "PASS"},
+            {"seat": 2, "action": "BID", "tricks_bid": 4, "contract_type": "suit"},
+            {"seat": 3, "action": "PASS"},
+        ]
+
+    return {
+        "schema_version": 7,
+        "event": "hand_end",
+        "run_id": "test_run",
+        "strategy_id": "test",
+        "deal_id": hand_id,
+        "seed": 42,
+        "contract": contract,
+        "trump": trump,
+        "leader": 0,
+        "t0": t0,
+        "t1": t1,
+        "features": [{}, {}, {}, {}],
+        "scores": [0, 0, 0, 0],
+        "hands": hands,
+        "dealer_position": dealer,
+        "auction_transcript": auction_transcript,
+    }
+
+
+def _write_jsonl(records, path):
+    """Write records to a JSONL file."""
+    with open(path, "w") as f:
+        for r in records:
+            f.write(json.dumps(r, sort_keys=True) + "\n")
+
+
+class TestBuildDataset:
+    """Test JSONL parsing and dataset building."""
+
+    def test_single_hand_produces_4_bidless_rows(self, tmp_path):
+        """One hand_end record produces 4 bidless rows (one per seat)."""
+        jsonl_path = str(tmp_path / "test.jsonl")
+        records = [
+            {"event": "run_start", "schema_version": 7, "run_id": "test"},
+            _make_hand_end_record(hand_id=0),
+            {"event": "run_end", "schema_version": 7, "run_id": "test"},
+        ]
+        _write_jsonl(records, jsonl_path)
+
+        bidless, outcomes = build_dataset_from_jsonl(jsonl_path)
+
+        assert len(bidless) == 4
+        assert len(outcomes) == 1
+        assert {r["seat"] for r in bidless} == {0, 1, 2, 3}
+
+    def test_partner_features_present(self, tmp_path):
+        """All 4 partner features are present in hand_features dict."""
+        jsonl_path = str(tmp_path / "test.jsonl")
+        _write_jsonl([_make_hand_end_record()], jsonl_path)
+
+        bidless, _ = build_dataset_from_jsonl(jsonl_path)
+
+        for row in bidless:
+            features = row["hand_features"]
+            for fname in PARTNER_FEATURE_NAMES:
+                assert fname in features, f"Missing: {fname}"
+                assert features[fname] is not None
+
+    def test_43_features_per_row(self, tmp_path):
+        """Each row has 43 features (39 hand + 4 partner)."""
+        jsonl_path = str(tmp_path / "test.jsonl")
+        _write_jsonl([_make_hand_end_record()], jsonl_path)
+
+        bidless, _ = build_dataset_from_jsonl(jsonl_path)
+
+        for row in bidless:
+            assert len(row["hand_features"]) == 43
+
+    def test_outcomes_schema_matches_bidless_format(self, tmp_path):
+        """Outcomes DataFrame has the expected columns."""
+        jsonl_path = str(tmp_path / "test.jsonl")
+        _write_jsonl([_make_hand_end_record()], jsonl_path)
+
+        _, outcomes = build_dataset_from_jsonl(jsonl_path)
+        outcomes_df = pd.DataFrame(outcomes)
+
+        required_cols = {
+            "hand_id",
+            "deal_id",
+            "dealer_seat",
+            "contract_type",
+            "trump_suit",
+            "tricks_team0",
+            "tricks_team1",
+            "team0_win",
+        }
+        assert required_cols.issubset(set(outcomes_df.columns))
+
+    def test_high_contract_parsing(self, tmp_path):
+        """HIGH contract maps to contract_type='high', trump_suit=None."""
+        jsonl_path = str(tmp_path / "test.jsonl")
+        record = _make_hand_end_record(contract="HIGH", trump=None)
+        _write_jsonl([record], jsonl_path)
+
+        bidless, outcomes = build_dataset_from_jsonl(jsonl_path)
+
+        assert outcomes[0]["contract_type"] == "high"
+        assert outcomes[0]["trump_suit"] is None
+        assert bidless[0]["contract_type"] == "high"
+
+    def test_low_contract_parsing(self, tmp_path):
+        """LOW contract maps to contract_type='low', trump_suit=None."""
+        jsonl_path = str(tmp_path / "test.jsonl")
+        record = _make_hand_end_record(contract="LOW", trump=None)
+        _write_jsonl([record], jsonl_path)
+
+        _, outcomes = build_dataset_from_jsonl(jsonl_path)
+        assert outcomes[0]["contract_type"] == "low"
+
+    def test_multiple_hands(self, tmp_path):
+        """Multiple hand_end records produce correct row counts."""
+        jsonl_path = str(tmp_path / "test.jsonl")
+        records = [
+            _make_hand_end_record(hand_id=0),
+            _make_hand_end_record(hand_id=1, contract="HIGH", trump=None),
+            _make_hand_end_record(hand_id=2, contract="LOW", trump=None),
+        ]
+        _write_jsonl(records, jsonl_path)
+
+        bidless, outcomes = build_dataset_from_jsonl(jsonl_path)
+
+        assert len(bidless) == 12  # 3 hands × 4 seats
+        assert len(outcomes) == 3
+
+    def test_redeal_hands_skipped(self, tmp_path):
+        """Hands with redeal_flag=True are skipped."""
+        jsonl_path = str(tmp_path / "test.jsonl")
+        record = _make_hand_end_record(hand_id=0)
+        record["redeal_flag"] = True
+        _write_jsonl([record], jsonl_path)
+
+        bidless, outcomes = build_dataset_from_jsonl(jsonl_path)
+
+        assert len(bidless) == 0
+        assert len(outcomes) == 0
+
+    def test_compatible_with_join_features_outcomes(self, tmp_path):
+        """Output parquet is compatible with join_features_outcomes()."""
+        from bid_euchre.datasets.join import join_features_outcomes
+
+        jsonl_path = str(tmp_path / "test.jsonl")
+        records = [
+            _make_hand_end_record(hand_id=0),
+            _make_hand_end_record(hand_id=1),
+        ]
+        _write_jsonl(records, jsonl_path)
+
+        bidless_rows, outcomes_rows = build_dataset_from_jsonl(jsonl_path)
+
+        bidless_df = pd.DataFrame(bidless_rows)
+        outcomes_df = pd.DataFrame(outcomes_rows)
+
+        bidless_path = str(tmp_path / "bidless.parquet")
+        outcomes_path = str(tmp_path / "bidless_outcomes.parquet")
+        bidless_df.to_parquet(bidless_path)
+        outcomes_df.to_parquet(outcomes_path)
+
+        # join_features_outcomes should work without error
+        joined = join_features_outcomes(bidless_path, outcomes_path)
+
+        assert len(joined) > 0
+        assert "tricks_won" in joined.columns
+
+        # Partner features should be flattened into columns
+        for fname in PARTNER_FEATURE_NAMES:
+            assert fname in joined.columns
+
+
+class TestValidateDataset:
+    """Test the gate X1 validation function."""
+
+    def test_valid_dataset_passes(self, tmp_path):
+        """Valid dataset passes validation without error."""
+        jsonl_path = str(tmp_path / "test.jsonl")
+        _write_jsonl([_make_hand_end_record()], jsonl_path)
+
+        bidless_rows, outcomes_rows = build_dataset_from_jsonl(jsonl_path)
+        bidless_df = pd.DataFrame(bidless_rows)
+        outcomes_df = pd.DataFrame(outcomes_rows)
+
+        # Should not raise
+        validate_dataset(bidless_df, outcomes_df)
+
+
+class TestParseContract:
+    """Test contract string parsing."""
+
+    def test_suit_contract(self):
+        assert _parse_contract("H", "H") == ("suit", "H")
+        assert _parse_contract("S", "S") == ("suit", "S")
+
+    def test_high_contract(self):
+        assert _parse_contract("HIGH", None) == ("high", None)
+        assert _parse_contract("high", None) == ("high", None)
+
+    def test_low_contract(self):
+        assert _parse_contract("LOW", None) == ("low", None)
+        assert _parse_contract("low", None) == ("low", None)


### PR DESCRIPTION
## Summary
- Add 4 partner bidding context features from auction transcript (`auction_context.py`)
- Parameterize ModeloEspecifico with R1 weights (feature_weights + partner_weights), expand locked base 3/1/1 → 3/2/2
- Add dual-seat comparator mode, auction-context dataset generator, threshold sweep CLI, and 6-bidder R1 config files

## Why
First code PR for the R1 training cycle (Step 1 of `r1_training_plan.md`). Provides all infrastructure that subsequent R1 steps depend on: partner feature extraction, dataset generation, evaluation instruments, and config files for the canonical 6-bidder roster (§3.7.1).

## Repro / Validation
**Command(s) run:**
```bash
# Tier 2 full validation
make check-quiet  # ✓ All checks passed

# Targeted tests during implementation (Tier 1)
uv run python -m pytest tests/unit/test_auction_context.py -v      # 13/13 pass
uv run python -m pytest tests/unit/test_bidding.py -v              # 18/18 pass (14 existing + 4 new)
uv run python -m pytest tests/unit/test_comparator_dual_seat.py -v # 8/8 pass
uv run python -m pytest tests/unit/test_generate_auction_context.py -v # 13/13 pass
uv run python -m pytest tests/unit/test_train_olsa.py -v           # 8/8 pass
```

**Seed (if applicable):** N/A (infrastructure PR, no experiments)

## Tests
- [x] `make check-quiet` (full validation: repo-lint + ruff + pytest + notebook-check + docs-check)
- [x] Unit tests for all new modules (38 new tests + all existing pass)
- [x] Backward compatibility: ModeloEspecifico default constructor = identical R0 behavior

## Expected impact
- Metrics impact: None (infrastructure only; R1 models created in PR-R1b)
- Runtime impact: None (new features only activated when partner_weights are configured)

## Risk level
- [x] Medium (strategy/experiments)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-r1a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-r1a
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre      e8e85b7 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-r1a  91552dc [r1a-partner-context]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

## Implementation Waves

| Wave | Deliverable | Files |
|------|------------|-------|
| 1 | Partner feature extraction | `src/bid_euchre/features/auction_context.py`, `tests/unit/test_auction_context.py` |
| 2 | Locked base expansion (3/2/2) | `src/bid_euchre/models/train_olsa.py` |
| 3 | ModeloEspecifico parameterization | `src/bid_euchre/strategy/bidding.py`, `tests/unit/test_bidding.py` |
| 4 | Dual-seat comparator mode | `scripts/internal/run_auction_comparator.py`, `tests/unit/test_comparator_dual_seat.py` |
| 5 | Auction-context dataset generator | `scripts/internal/generate_auction_context_dataset.py`, `tests/unit/test_generate_auction_context.py` |
| 6 | Threshold sweep CLI | `scripts/internal/run_threshold_sweep.py` |
| 7 | R1 config files | `experiments/configs/auction_comparator_r1_dual.yaml`, `auction_comparator_r1_legacy.yaml`, `r1_h2h_roster.json`, `r1_eval_quick.yaml`, `r1_eval_full.yaml` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)