### PR TITLE
fix: add log_level to auction dataset generator

### DIFF
--- a/scripts/internal/generate_auction_context_dataset.py
+++ b/scripts/internal/generate_auction_context_dataset.py
@@ -223,6 +223,7 @@ def run_auction_experiment(
             "n_per": n_deals,
             "play_strategy": play_strategy,
             "mode": "auction",
+            "log_level": "hand",
         },
     }
 


### PR DESCRIPTION
## Summary
- Add `log_level: "hand"` to the experiment config generated by `generate_auction_context_dataset.py`

## Why
The generated config omitted `log_level`, which defaults to `"none"` in the experiment runner. Without JSONL hand logging, the dataset generator has no records to parse and fails with "No JSONL log found."

## Repro / Validation
```bash
# Before fix: fails with "No JSONL log found"
# After fix: generates dataset successfully
uv run python scripts/internal/generate_auction_context_dataset.py \
    --bidder-artifact data/artifacts/arc_d/r0/hybrid_r0_full.json \
    --seed 42 --n-deals 500 \
    --output-dir /tmp/r1_smoke_auction_42
```

Full smoke test (dataset generation + training + Gate X1):
- Dataset: 416 hands from 500 deals, 43 features, 4 rows/hand
- Gate X1: All 4 partner features have |r| > 0.02 for suit (r ≈ 0.41–0.43)
- Training: Both arms (constrained + full) trained successfully, rung_id=r1
- Forward selection auto-discovered partner features as top predictors

## Tests
```bash
uv run python -m pytest tests/unit/test_generate_auction_context.py -v  # 13 passed
make check-quiet  # All checks passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-smoke
branch: fix-smoke-test-pipeline
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)