### PR TITLE
docs: note retrain + H2H re-run after regression investigation

### DIFF
--- a/docs/04_reports/r1/h2h_suit_regression_diagnostic.md
+++ b/docs/04_reports/r1/h2h_suit_regression_diagnostic.md
@@ -8,7 +8,7 @@
 
 ## Quick Context
 
-R1 added 4 **partner bidding context features** (extracted from auction transcripts)
+R1 added **partner bidding context features** (extracted from auction transcripts)
 to the OLSa hybrid bidder. These features describe what the partner bid during
 the auction (bid level, whether they passed, whether they bid the same contract
 family). Training R² improved dramatically (+0.40 for suit), but H2H game
@@ -16,6 +16,11 @@ performance **regressed** by -0.76 pts/deal for suit contracts.
 
 This report documents the regression, proposes hypotheses for why it happened,
 and lays out a concrete investigation plan with reproduction commands.
+
+> **Note:** The H2H battery that produced these results used models trained with
+> 4 partner features (including `partner_bid_confidence`, removed in PR #538 as
+> redundant with `partner_bid_level`). After investigation completes, models will
+> be retrained with 3 partner features and the H2H battery re-run.
 
 **Key files:**
 - Training pipeline: `src/bid_euchre/models/train_hybrid_olsa.py`

--- a/plans/r1_training_plan.md
+++ b/plans/r1_training_plan.md
@@ -3,7 +3,7 @@
 **Date:** 2026-03-04
 **Governing doc:** `plans/r1_master_plan.md` §3
 **Predecessor:** R0 v2 (`r0-canonical-v2` tag at `4e26d44`)
-**Status:** Step 3c (retrain constrained arm with partner features)
+**Status:** Gate X3 STOP — regression investigation in progress (see diagnostic report)
 
 ---
 
@@ -244,6 +244,26 @@ print('X2 PASS: Both arms suit R² not regressed')
 **Finding:** High/low selected only `partner_suit_match` in both arms. Confounded
 by sample size (4k high, 5.5k low vs 32k suit). Not gate-blocking; deferred to R2.
 See `docs/04_reports/r1/partner_feature_selection_diagnostic.md`.
+
+> **Stale note:** Step 3c trained with 4 partner features including
+> `partner_bid_confidence`, which was removed in PR #538 (linearly redundant
+> with `partner_bid_level`). The full arm results above include this feature.
+
+### 3d. Retrain with 3 partner features (post-investigation)
+
+**Status:** BLOCKED — waiting on regression investigation
+(see `docs/04_reports/r1/h2h_suit_regression_diagnostic.md`)
+
+After the regression investigation (Investigations F–I) identifies root cause:
+
+1. **Retrain both arms** with 3 partner features (`partner_bid_level`,
+   `partner_passed`, `partner_suit_match`) using the same command as 3c
+2. **Re-run Gate X2** to verify R² is not degraded
+3. **Proceed to Step 4 → Step 5** (3-seed eval → H2H battery re-run)
+4. **Re-evaluate Gate X3** with the corrected models
+
+Any fixes from the investigation (e.g., bug fixes, training data changes,
+feature extraction corrections) should be applied **before** retraining.
 
 ---
 


### PR DESCRIPTION
## Summary
- Update R1 training plan status to Gate X3 STOP, add Step 3d (retrain with 3 partner features post-investigation)
- Update diagnostic report to note current H2H results used 4-feature models (pre-PR #538)

## Why
PR #538 removed `partner_bid_confidence` from the codebase, but the R1 artifacts were trained with 4 features. The plan needs to explicitly track that retraining + H2H re-run is required after the regression investigation completes.

## Repro / Validation
Docs-only change. No code modified.

## Tests
```
make check-quiet  # not required for docs-only
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/docs-retrain-plan
branch: docs/retrain-plan-after-investigation
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)