### PR TITLE
fix: backward-compat shim for partner_bid_confidence in old R1 artifacts

### DIFF
--- a/plans/r1_training_plan.md
+++ b/plans/r1_training_plan.md
@@ -31,25 +31,24 @@ uv run python scripts/internal/generate_auction_context_dataset.py \
     --bidder-artifact data/artifacts/arc_d/r0/hybrid_r0_full.json \
     --seed 42 \
     --n-deals 50000 \
-    --output data/training/r1/canonical_auction_context_42.parquet
+    --output-dir data/runs/canonical_auction_r1_42
 ```
 
 > **Note:** `generate_auction_context_dataset.py` is a new script created in PR-R1a.
 > It runs the simulation with the R0 model in all bidding seats, logging
-> `auction_transcript` for each hand, then extracts the 4 partner features.
+> `auction_transcript` for each hand, then extracts the 3 partner features.
 >
-> **Data contract (Step 1 → Step 3):** This script must produce a **run directory**
-> (e.g., `data/runs/<canonical_auction_run_id>/`) containing
+> **Data contract (Step 1 → Step 3):** This script produces a **run directory**
+> (e.g., `data/runs/canonical_auction_r1_42/`) containing
 > `datasets/bidless.parquet` and `datasets/bidless_outcomes.parquet`.
-> `train_hybrid_olsa` expects this directory structure, not a bare parquet path.
-> The `--output` path above is the parquet location within that directory.
+> `train_hybrid_olsa` expects this directory structure.
 
 **Gate X1 — Feature Smoke Test:**
 
 ```bash
 uv run python -c "
 import pandas as pd
-df = pd.read_parquet('data/training/r1/canonical_auction_context_42.parquet')
+df = pd.read_parquet('data/runs/canonical_auction_r1_42/datasets/bidless.parquet')
 # Check partner features exist and are non-trivial
 for col in ['partner_bid_level', 'partner_passed', 'partner_suit_match']:
     assert col in df.columns, f'Missing column: {col}'

--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -1244,6 +1244,17 @@ class HybridOLSaBidder(BiddingPolicy):
                     )
                     features = {**features, **partner_feats}
 
+                    # Backward compat: old artifacts may expect
+                    # partner_bid_confidence (removed PR #538).
+                    # Derive from partner_bid_level / 10.
+                    if (
+                        "partner_bid_confidence" not in features
+                        and "partner_bid_confidence" in self.context_features
+                    ):
+                        features["partner_bid_confidence"] = (
+                            features.get("partner_bid_level", 0) / 10.0
+                        )
+
                 mu = self._predict(contract_family, features, declaring=True)
 
                 result = compute_best_bid(

--- a/tests/unit/test_bidding.py
+++ b/tests/unit/test_bidding.py
@@ -1208,6 +1208,68 @@ class TestHybridOLSaBidFloor:
         assert action.n == 7
 
 
+class TestHybridOLSaPartnerBidConfidenceCompat:
+    """Backward compat: old artifacts with partner_bid_confidence still work."""
+
+    def test_old_artifact_with_partner_bid_confidence(self, tmp_path):
+        """Artifact expecting partner_bid_confidence doesn't crash at runtime."""
+        import json
+
+        artifact = {
+            "artifact_type": "hybrid_olsa_v1",
+            "context_features": [
+                "partner_bid_level",
+                "partner_bid_confidence",
+                "partner_passed",
+                "partner_suit_match",
+            ],
+            "payoff_model": {
+                "suit": {
+                    "weights": [0.0, 0.0, 0.0, 0.0, 0.0],
+                    "bias": 7.0,
+                    "feature_names": [
+                        "trump_count",
+                        "partner_bid_level",
+                        "partner_bid_confidence",
+                        "partner_passed",
+                        "partner_suit_match",
+                    ],
+                }
+            },
+            "residual_variance": {"suit": 0.0},
+            "risk_lambda": 0.0,
+        }
+        artifact_path = tmp_path / "old_r1_full.json"
+        artifact_path.write_text(json.dumps(artifact))
+
+        bidder = HybridOLSaBidder(str(artifact_path), name="test_compat")
+
+        hand = [
+            Card("H", "A"),
+            Card("H", "K"),
+            Card("H", "Q"),
+            Card("H", "T"),
+            Card("S", "A"),
+            Card("S", "K"),
+            Card("D", "A"),
+            Card("D", "K"),
+            Card("C", "A"),
+            Card("C", "K"),
+        ]
+        obs = BiddingObservation(
+            hand=hand,
+            seat=0,
+            dealer_seat=3,
+            current_high_bid=0,
+            auction_transcript=[
+                {"seat": 2, "action": "BID", "tricks_bid": 6, "contract_type": "suit"},
+            ],
+        )
+        # Must not raise KeyError
+        action = bidder.choose_bid(obs)
+        assert action is not None
+
+
 class TestModeloEspecificoBidFloorRemoval:
     """Test ModeloEspecifico bid floor lowered from 3 to 1 (comparator v5)."""
 


### PR DESCRIPTION
## Summary
- Add backward-compat shim in `HybridOLSaBidder.choose_bid()` to derive `partner_bid_confidence` from `partner_bid_level / 10` when artifact expects it but extractor no longer provides it
- Fix training plan CLI flag (`--output` → `--output-dir`), stale parquet path, and "4 partner features" → "3"
- Add regression test for old-artifact compatibility

## Why
PR #538 removed `partner_bid_confidence` from the extractor but didn't account for existing R1 artifacts that still reference it in `feature_names`. Loading `hybrid_r1_full.json` and calling `choose_bid()` raises `KeyError: 'partner_bid_confidence'`. This shim ensures old artifacts remain functional until models are retrained.

## Repro / Validation
```bash
# Before fix: KeyError
# After fix: works
uv run python -c "
from bid_euchre.strategy.bidding import HybridOLSaBidder
b = HybridOLSaBidder('data/artifacts/arc_d/r1/hybrid_r1_full.json', name='test')
print('Loaded OK, context_features:', b.context_features)
"
```

## Tests
```bash
uv run python -m pytest tests/unit/test_bidding.py::TestHybridOLSaPartnerBidConfidenceCompat -xvs
make check-quiet  # all passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/fix-compat
branch: fix/partner-bid-confidence-compat
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)