### PR TITLE
fix: support structured roster format in H2H battery script

### DIFF
--- a/scripts/internal/run_arc_d_h2h_battery.py
+++ b/scripts/internal/run_arc_d_h2h_battery.py
@@ -737,7 +737,18 @@ def main():
         if not roster_path.exists():
             print(f"ERROR: Roster file not found: {roster_path}", file=sys.stderr)
             sys.exit(1)
-        roster = json.loads(roster_path.read_text())
+        roster_data = json.loads(roster_path.read_text())
+        # Support both plain list and structured {"bidders": [...]} format
+        if isinstance(roster_data, dict) and "bidders" in roster_data:
+            roster = roster_data["bidders"]
+        elif isinstance(roster_data, list):
+            roster = roster_data
+        else:
+            print(
+                f"ERROR: Roster file must be a list or dict with 'bidders' key: {roster_path}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
     else:
         roster = DEFAULT_ROSTER
 


### PR DESCRIPTION
## Summary
- Accept both plain list and `{"bidders": [...]}` structured roster JSON in `run_arc_d_h2h_battery.py`
- Error with clear message on unrecognized format

## Why
Some roster files use a structured format with metadata alongside the bidder list. The script previously assumed a bare list, crashing on structured rosters.

## Repro / Validation
```bash
make check-quiet  # all passed
```

## Tests
Script-level CLI change — validated via `make check-quiet`.

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/fix-roster
branch: fix/h2h-roster-format
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)