### PR TITLE
docs: log H10 bid-level search degeneracy finding

### DIFF
--- a/docs/04_reports/r1/h2h_suit_regression_diagnostic.md
+++ b/docs/04_reports/r1/h2h_suit_regression_diagnostic.md
@@ -1,11 +1,11 @@
 # R1 H2H Suit Regression Diagnostic
 
 **Date:** 2026-03-05
-**Status:** INVESTIGATION COMPLETE — Root cause confirmed: H7 (weight instability)
+**Status:** INVESTIGATION ONGOING — H7 contributing, H10 (bid-level search degeneracy) identified as structural cause
 **Blocking:** Gate X3 (STOP), Steps 6–12 of R1 training plan
-**gate_status:** X3 STOP — primary delta -0.348, suit delta -0.76
-**Root cause:** H7 (weight instability) — CONFIRMED by Investigation C ablation
-**Decisive test result:** Investigation C (zero-out ablation) shows partner features are net-positive (+1.3 eppd); regression comes from depressed base weights
+**gate_status:** X3 STOP — primary delta -0.348 (persists after two-stage remediation)
+**Root cause:** H10 (bid-level search degeneracy) — structural; H7 (weight instability) contributing but not primary
+**Decisive test result:** Two-stage training (PRs #548/#549) preserved base weights but did NOT fix regression. ME_R1 (hand-coded weights, no OLS) regresses by -9.5 eppd — proves problem is upstream of weight fitting. `compute_best_bid()` always selects minimum legal bid level because payoff `2t - 10` is bid-independent.
 **Provenance:** H2H battery run `arc_d_r0_h2h_battery_42_20260304_210528`, seed 42, 2k deals/matchup
 **Ablation run:** `arc_d_r0_h2h_battery_42_20260305_131433`, seed 42, 2k deals/matchup
 
@@ -342,6 +342,60 @@ quasi-randomly (only one seat bids in bidless runs).
   fraction of the total +0.40 improvement
 
 **Test:** See Investigation I.
+
+### H10: Bid-Level Search Degeneracy (Structural)
+
+**Claim:** `compute_best_bid()` with `bid_level_search=True` always selects the
+minimum legal bid level because the payoff function for making a contract
+(`net = 2t - 10`) is independent of bid level. Higher bids only increase the set
+penalty (`net = t - bid - 10`). This creates a degenerate auction where every seat
+bids `current_high + 1` or passes — nobody voluntarily bids above the minimum.
+
+**Mechanism:**
+- For any predicted mu and sigma, the EV curve is monotonically decreasing in bid
+  level: bid=1 always has the highest (or tied-highest) expected utility
+- With 4 seats in a single auction round, max winning bid = 4 (each seat bids +1)
+- R0 masks this: all 4 seats bid (~96% rate), winning bid = 3-4, looks normal
+- R1 exposes this: partner features cause 1-2 seats to pass, winning bid drops to
+  1-2, declaring team bids at artificially low levels
+- The regression is not from bad predictions — it's from the auction mechanism
+  rewarding "always bid 1" and partner features reducing the number of competing
+  bidders
+
+**Evidence (2026-03-05 two-stage retrain + H2H battery):**
+- Two-stage training preserved R0 base weights: suit R² = 0.596 (vs joint 0.618),
+  Gate X2 PASS (+0.38 vs R0). But H2H delta = -0.348, identical to joint R1.
+- ME_R1 (hand-coded partner weights, no OLS at all) regresses by -9.475 eppd.
+  This rules out weight fitting as the cause.
+- R1_full individual bid rate: 49.3%. R0_full: 95.9%.
+- R1 team passes 26.7% of hands; R0 passes 0.1%.
+- Self-play mean bid level: R1_full = 2.00, R0_full = 3.76, R1_constrained = 1.25.
+- EV table confirms: for mu ∈ [1, 8], bid=1 always maximizes utility at sigma=1.32.
+
+**Relationship to other hypotheses:**
+- **Subsumes H7:** Weight instability was real but not the primary cause. Even with
+  stable weights (two-stage), the regression persists.
+- **Subsumes H8:** "R² doesn't imply better bidding" is correct, but the mechanism
+  is more specific — bid-level search makes bid level a pure function of auction
+  competition, not prediction quality.
+- **Connects to H1:** Partner features change who bids, which changes bid levels,
+  which changes outcomes. This is a game-theoretic distribution shift, not a
+  statistical one.
+
+**Structural status:** This is not a bug in `compute_best_bid()` — the function
+correctly maximizes expected utility. The issue is that the payoff function doesn't
+reward higher bids, so the auction degenerates. Present in R0 (masked by 4-way
+competition) and R1 (exposed by asymmetric passing).
+
+**Known prior documentation:** The pass-threshold decision report
+(`docs/04_reports/r0/11_pass_threshold_decision.md`) documented that bid-level
+search causes ~96% bid rate and "resolves the pass-threshold problem." The
+degeneracy of always selecting the minimum legal bid was not flagged.
+
+**Fix required:** The payoff model must be revised so that bid level affects the
+make payoff, or the auction mechanism must be changed. This is a structural
+prerequisite — feature engineering (R1.5) and hyperparameter tuning cannot fix
+a degenerate auction.
 
 ### H1 vs H3: How to Distinguish
 
@@ -1090,30 +1144,44 @@ is confounded (H3) and destabilizes the base model (H7).
 | H4: Feature fragility | PLAUSIBLE | Full arm weight (12.85) explains full > constrained gap |
 | **H5: Implementation bug** | **ELIMINATED** | Investigation F: all 5 checks clean |
 | **H6: Training sparsity** | **CONTRIBUTING** | Investigation G: 71% zeros for partner_bid_level |
-| **H7: Weight instability** | **CONFIRMED (ROOT CAUSE)** | Investigation H: bias Δ=-8.77, locked weights -28 to -78%. Investigation C: ablation confirms base weights are depressed — R1 model never bids suit without partner signal |
+| **H7: Weight instability** | **CONFIRMED (CONTRIBUTING)** | Investigation H + C confirmed mechanism, but two-stage fix did not resolve regression — H7 is real but not primary |
 | **H8: Overbidding** | **WEAKENED** | Investigation B: R1 bids LOWER (1.80 vs 3.74) |
 | **H9: Data artifact** | **WEAKENED** | Investigation I: variance higher, data effect only 12% |
+| **H10: Bid-level search degeneracy** | **CONFIRMED (STRUCTURAL)** | Two-stage remediation failed (delta unchanged at -0.348); ME_R1 regresses -9.5 (no OLS); EV monotonically decreasing in bid level |
 
-**Confirmed causal chain:**
-1. Locked base expands from 3/1/1 to 3/2/2. OLS re-estimates all weights jointly.
-2. Partner features enter OLS and dominate fit (+0.374 R², 85% of improvement).
-3. OLS redistributes weight: intercept collapses +2.75 → -6.02, locked base
-   weights drop 28-78%.
-4. At inference, the depressed base weights produce systematically low mu
-   predictions. Even with partner features adding positive signal, the net
-   prediction is lower than R0.
-5. **Without partner features (ablation), R1 never bids suit at all.** With
-   partner features, R1 bids at reduced rate (40% vs R0's 60%), causing
-   the -0.76 suit regression.
-6. Partner features are **masking** the weight instability problem, not causing it.
+**Revised causal chain (2026-03-05):**
 
-**Root cause declaration:** H7 (weight instability) is confirmed. The regression
-originates from OLS weight redistribution during retraining with the expanded
-3/2/2 locked base + partner features. The remedy must stabilize base weights.
+The original H7 causal chain (weight instability) was confirmed as a real mechanism
+but NOT the primary cause. Two-stage training (PR #548/#549) stabilized base weights
+but produced identical regression (delta = -0.348). The structural cause is H10:
+
+1. `compute_best_bid()` with `bid_level_search=True` always selects the minimum
+   legal bid level because `make_payoff = 2t - 10` is independent of bid level.
+2. In R0, all 4 seats bid (~96%), so the winning bid reaches 3-4 (looks normal).
+3. R1 partner features cause some seats to pass (bid rate ~49%), reducing auction
+   competition. Winning bids drop to 1-2.
+4. The regression comes from the asymmetry: R1 passes more, lets R0 declare at
+   low levels where set penalty is minimal.
+5. H7 (weight instability) amplifies this by depressing base predictions, but
+   fixing H7 alone does not resolve the regression.
+6. ME_R1 (hand-coded weights, no OLS) shows the same pattern at -9.5 eppd,
+   confirming the problem is upstream of weight fitting.
+
+**Root cause declaration (revised):** H10 (bid-level search degeneracy) is the
+structural cause. The `compute_best_bid()` payoff model must be revised before
+partner features can show their value in H2H play. H7 is a real contributing
+factor but not primary.
 
 ---
 
 ## 5. Decision Framework
+
+> **2026-03-05 update:** The recommended remediation options below were based on H7
+> as root cause. Two-stage training (Option 1) was implemented in PRs #548/#549 and
+> tested: it did NOT fix the regression (delta unchanged at -0.348). The structural
+> cause is now identified as H10 (bid-level search degeneracy). Remediation must
+> address the payoff model in `compute_best_bid()` before further feature or weight
+> work can show impact. See H10 hypothesis for details.
 
 Based on Investigation C results: **partner features are net-positive** (+1.3 eppd).
 The regression is caused by base weight instability during OLS retraining, not by

--- a/plans/r1_training_plan.md
+++ b/plans/r1_training_plan.md
@@ -3,7 +3,7 @@
 **Date:** 2026-03-04 (updated 2026-03-05)
 **Governing doc:** `plans/r1_master_plan.md` §3 and §10
 **Predecessor:** R0 v2 (`r0-canonical-v2` tag at `4e26d44`)
-**Status:** Gate X3 STOP — regression investigation in progress (see diagnostic report)
+**Status:** Gate X3 STOP — H10 (bid-level search degeneracy) identified as structural cause. Payoff model revision required.
 
 > **Document role:** This is the **R1 operational execution checklist** — CLI
 > commands, gate results, artifact paths. For strategic governance (feature
@@ -266,26 +266,24 @@ See `docs/04_reports/r1/partner_feature_selection_diagnostic.md`.
 > Step 3d will retrain both arms from scratch with the corrected 3-feature set,
 > making 3c artifacts historical only.
 
-### 3d. Retrain with 3 partner features (post-investigation)
+### 3d. Retrain with 3 partner features + two-stage (post-investigation)
 
-**Status:** BLOCKED — waiting on regression investigation
-(see `docs/04_reports/r1/h2h_suit_regression_diagnostic.md`)
+**Status:** COMPLETED (two-stage) — regression NOT resolved
 
-> **Blocking chain:** Steps 4–12 are blocked until 3d completes. Step 3e
-> (feature-effect testing) runs immediately after 3d, before Step 4. The
-> full dependency is: regression investigation → 3d retrain → 3e counterfactual
-> → Step 4 eval → Step 5 H2H → Steps 6–12.
+Two-stage training (PRs #548/#549) was implemented and tested:
+- Training data regenerated as `canonical_auction_r1_42_v2` (3 partner features,
+  no stale `partner_bid_confidence`)
+- Two-stage constrained arm: suit R² = 0.596, Gate X2 PASS
+- H2H battery: primary delta = -0.348, identical to joint R1. Gate X3 STOP.
+- ME_R1 regresses by -9.475 eppd (hand-coded weights, no OLS)
 
-After the regression investigation (Investigations F–I) identifies root cause:
+**Finding:** H7 (weight instability) was real but not the primary cause. The
+structural cause is H10 (bid-level search degeneracy) — `compute_best_bid()`
+always selects the minimum legal bid because `make_payoff = 2t - 10` is
+bid-independent. This affects R0 and R1 equally but is masked in R0 by
+4-way auction competition. See diagnostic report §2 H10 for details.
 
-1. **Retrain both arms** with 3 partner features (`partner_bid_level`,
-   `partner_passed`, `partner_suit_match`) using the same command as 3c
-2. **Re-run Gate X2** to verify R² is not degraded
-3. **Proceed to Step 4 → Step 5** (3-seed eval → H2H battery re-run)
-4. **Re-evaluate Gate X3** with the corrected models
-
-Any fixes from the investigation (e.g., bug fixes, training data changes,
-feature extraction corrections) should be applied **before** retraining.
+**Blocking:** Steps 4-12 remain blocked until the payoff model is revised.
 
 ### 3e. Partner-Off Counterfactual / Feature-Effect Testing (Required)
 


### PR DESCRIPTION
## Summary
- Add H10 hypothesis (bid-level search degeneracy) to diagnostic report as structural root cause
- Revise causal chain from H7→H10, downgrade H7 from ROOT CAUSE to CONTRIBUTING
- Update training plan Step 3d as COMPLETED (two-stage), note regression persists

## Why
Two-stage training (PRs #548/#549) preserved R0 base weights but did NOT fix the H2H regression (delta unchanged at -0.348). ME_R1 (hand-coded weights, no OLS) regresses by -9.5 eppd, proving the problem is upstream of weight fitting. The structural cause is that `compute_best_bid()` always selects the minimum legal bid level because `make_payoff = 2t - 10` is bid-independent.

## Repro / Validation
**Command(s) run:** N/A — docs-only change

## Tests
- [x] `make check-quiet` — docs-only, no code changes
- [x] Other: verified diagnostic report markdown renders correctly

## Expected impact
- Metrics impact: None (docs-only)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/log-h10-finding
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/log-h10-finding
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre        26ef1fc [main]
.../.claude/worktrees/log-h10-finding                            93b7dc5 [log-h10-finding]
```

## Checklist
- [x] No generated artifacts committed
- [x] PR is focused (one concept)