### PR TITLE
feat: add always-on governance check workflow

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -1,0 +1,54 @@
+name: Governance
+
+on:
+  pull_request:
+    branches: [main]
+    # No paths-ignore — runs on ALL PRs including plan/docs-only
+
+concurrency:
+  group: governance-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  governance:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: PR metadata check
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          BODY_LENGTH=$(echo "$PR_BODY" | wc -c)
+          if [ "$BODY_LENGTH" -lt 20 ]; then
+            echo "::warning::PR description is very short. Use the PR template from .github/pull_request_template.md"
+          fi
+
+      - name: Plan file lint
+        run: |
+          PLAN_FILES=$(git diff --name-only origin/main...HEAD -- 'plans/*.md' 'plans/**/*.md' 2>/dev/null || true)
+          if [ -n "$PLAN_FILES" ]; then
+            echo "Plan files changed:"
+            echo "$PLAN_FILES"
+            FAIL=0
+            for f in $PLAN_FILES; do
+              if [ -f "$f" ]; then
+                echo "  Checking: $f"
+                if ! grep -q "^## Goal" "$f"; then
+                  echo "::warning file=$f::Missing '## Goal' section"
+                fi
+                if ! grep -q "^## Outcome" "$f"; then
+                  echo "::warning file=$f::Missing '## Outcome' section"
+                fi
+              fi
+            done
+          else
+            echo "No plan files changed — skipping plan lint"
+          fi
+
+      - name: Governance passed
+        run: echo "All governance checks passed"


### PR DESCRIPTION
## Summary
- Add lightweight GitHub Actions workflow (`governance.yml`) that runs on ALL PRs (no `paths-ignore`)
- Checks PR body length (warns if <20 chars) and plan file lint (warns if missing `## Goal` or `## Outcome`)
- Ensures plan/docs-only PRs have at least one required check for branch protection

## Why
Part of the workflow redesign (PR 1/8). See `plans/sessions/2026-03-06_workflow-redesign.md`.

Currently, CI (`ci.yml`) ignores `plans/**`, `docs/**`, and `*.md`. This means plan/docs-only PRs have zero GitHub checks, which makes it impossible to require checks via branch protection for those PRs. The governance workflow fills this gap.

## Repro / Validation
**Command(s) run:**
- `make repo-lint && make lint && make test && make notebook-check` — all pass (2178 tests, 6 skipped)
- Pre-existing `make docs-check` failure on main (R1 reports reference uncommitted data artifacts) — not introduced by this PR

**Config (if applicable):** N/A

**Seed (if applicable):** N/A

## Tests
- [x] `make repo-lint` — passed
- [x] `make lint` — passed
- [x] `make test` (2178 passed, 6 skipped)
- [x] `make notebook-check` — passed
- [ ] `make docs-check` — pre-existing failure on main, not related to this PR

## Expected impact
- Metrics impact: None
- Runtime impact: Adds ~10s workflow to every PR

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-governance-check
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-governance-check
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                   c141973 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-governance-check   5fbcbf2 [feat/governance-check]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)