### PR TITLE
feat: add review commit status infrastructure

### DIFF
--- a/.claude/rules/60_review_gate.md
+++ b/.claude/rules/60_review_gate.md
@@ -57,13 +57,17 @@ Aligned with `/reviewing-changes` CHECKLIST.md check IDs:
 Use `scripts/internal/set_review_status.sh`:
 
 ```bash
-# Pre-merge code review
+# Pre-merge code review (local Claude session — HEAD is correct)
 scripts/internal/set_review_status.sh pending "Review in progress"
 scripts/internal/set_review_status.sh success "Review passed — 0 blockers, N warnings"
 scripts/internal/set_review_status.sh failure "Review blocked — N blockers found"
 
-# Plan review (advisory)
-scripts/internal/set_review_status.sh success "Plan approved" "" "codex-plan-review"
+# Plan review from GitHub Actions — pass PR head SHA explicitly
+# (actions/checkout checks out merge commit, not PR head)
+scripts/internal/set_review_status.sh success "Plan approved" "" "codex-plan-review" "$PR_HEAD_SHA"
+
+# Or via environment variable
+REVIEW_STATUS_SHA="$PR_HEAD_SHA" scripts/internal/set_review_status.sh pending "Review starting"
 
 # Manual override (admin recovery for stuck pending)
 scripts/internal/set_review_status.sh success "Manual override"

--- a/scripts/internal/set_review_status.sh
+++ b/scripts/internal/set_review_status.sh
@@ -1,26 +1,37 @@
 #!/bin/bash
 # Publish a GitHub commit status for a review gate.
 #
-# Usage: set_review_status.sh <state> <description> [target_url] [context]
+# Usage: set_review_status.sh <state> <description> [target_url] [context] [sha]
 #   state:       pending | success | failure | error
 #   description: short text (max 140 chars)
 #   target_url:  optional link to review details (pass "" to skip)
 #   context:     status context name (default: "reviewing-changes")
 #                Use "codex-plan-review" for plan review status
+#   sha:         commit SHA to attach status to (default: git rev-parse HEAD)
+#                Override with REVIEW_STATUS_SHA env var or positional arg.
+#                In GitHub Actions pull_request workflows, pass the PR head SHA
+#                (e.g., ${{ github.event.pull_request.head.sha }}) since HEAD
+#                may be the synthetic merge commit, not the PR head.
 #
 # Examples:
+#   # Local (Claude session) — HEAD is the PR branch tip
 #   set_review_status.sh pending "Review in progress"
 #   set_review_status.sh success "Review passed — 0 blockers, 3 warnings"
 #   set_review_status.sh failure "Review blocked — 2 blockers found"
-#   set_review_status.sh success "Plan approved by Codex" "" "codex-plan-review"
 #   set_review_status.sh success "Manual override"
+#
+#   # GitHub Actions — pass explicit PR head SHA
+#   set_review_status.sh success "Plan approved" "" "codex-plan-review" "$PR_HEAD_SHA"
+#
+#   # Or via environment variable
+#   REVIEW_STATUS_SHA="$PR_HEAD_SHA" set_review_status.sh pending "Review starting"
 set -euo pipefail
 
 STATE="$1"
 DESCRIPTION="$2"
 TARGET_URL="${3:-}"
 CONTEXT="${4:-reviewing-changes}"
-SHA=$(git rev-parse HEAD)
+SHA="${5:-${REVIEW_STATUS_SHA:-$(git rev-parse HEAD)}}"
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 
 # Validate state


### PR DESCRIPTION
## Summary
- Add `scripts/internal/set_review_status.sh` — publish GitHub commit statuses for review gates
- Add `.claude/rules/60_review_gate.md` — documents review gate contract, severity definitions, recovery procedures
- Supports configurable context: `reviewing-changes` (code PRs) and `codex-plan-review` (plan PRs)

## Why
Part of the workflow redesign (PR 2/8). See `plans/sessions/2026-03-06_workflow-redesign.md`.

The `/reviewing-changes` skill currently outputs its verdict only to chat — it has no GitHub-visible signal. This PR adds the infrastructure to publish a GitHub commit status that branch protection can enforce. PR 3 will modify the skill to call this script; PR 5 will configure branch protection to require it.

**Dependency:** PR 3 (modified `/reviewing-changes` skill) depends on this PR.

## Repro / Validation
**Command(s) run:**
- `make repo-lint` — passed
- `make lint` — passed
- `make test` — 2178 passed, 6 skipped
- Pre-existing `make docs-check` failure on main — not introduced by this PR

**Usage examples:**
```bash
# Set pending status (review starting)
scripts/internal/set_review_status.sh pending "Review in progress"

# Set success (review passed)
scripts/internal/set_review_status.sh success "Review passed — 0 blockers, 3 warnings"

# Set failure (blockers found)
scripts/internal/set_review_status.sh failure "Review blocked — 2 blockers found"

# Plan review context
scripts/internal/set_review_status.sh success "Plan approved" "" "codex-plan-review"

# Manual override (admin recovery)
scripts/internal/set_review_status.sh success "Manual override"
```

**Seed (if applicable):** N/A

## Tests
- [x] `make repo-lint` — passed
- [x] `make lint` — passed
- [x] `make test` (2178 passed, 6 skipped)

No new Python tests needed — this PR adds a shell script and a documentation file.
The script will be integration-tested when PR 3 wires it into the `/reviewing-changes` skill.

## Expected impact
- Metrics impact: None
- Runtime impact: None (script is called manually by the review skill)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-review-status
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-review-status
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                   c141973 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-governance-check   5fbcbf2 [feat/governance-check]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-review-status      106f3f5 [feat/review-status-infra]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)