### PR TITLE
feat: redesign /reviewing-changes for audit-first workflow

### DIFF
--- a/.claude/skills/reviewing-changes/HANDOFF_TEMPLATE.md
+++ b/.claude/skills/reviewing-changes/HANDOFF_TEMPLATE.md
@@ -24,9 +24,11 @@ The user can `/copy` this into a new Claude Code session to resume work.
 (or "None.")
 
 ### Review Findings
-- Auto-fixes: [N applied / pushed as commit `<sha>`] (or "none needed")
 - Blockers: [N] ([list each with file:line and rule ID])
 - Warnings: [N] ([list each briefly])
+- Follow-up issues: [N created] (or "none needed")
+  - [issue URL] — [category]
+  - ...
 
 ### Needs Human Decision
 - [Each BLOCK item with context on why it needs judgment]
@@ -37,6 +39,8 @@ The user can `/copy` this into a new Claude Code session to resume work.
 - Worktree: `[worktree-path]`
 - Branch: `[branch]` → PR #[number]
 - make check: [PASSED / FAILED]
+- Commit status: [`success` / `failure` / `not published`]
+- Auto-merge: [ARMED / NOT ARMED]
 - Verdict: [READY TO MERGE / NEEDS ATTENTION]
 
 ### Context for Next Agent

--- a/.claude/skills/reviewing-changes/SKILL.md
+++ b/.claude/skills/reviewing-changes/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: reviewing-changes
-description: Reviews changed code for quality, repo conventions, and correctness after PR creation. Auto-fixes simple issues (pushed as follow-up commit), flags convention violations, and generates an agent-ready handoff summary for /copy. Triggered automatically by PostToolUse hook after gh pr create.
+description: Reviews changed code for quality, repo conventions, and correctness after PR creation. Publishes a GitHub commit status, creates follow-up issues for warnings, and arms auto-merge when clean. Triggered automatically by PostToolUse hook after gh pr create.
 ---
 
 # /reviewing-changes — Post-PR Code Review & Handoff
 
-You are reviewing code changes on the current branch before merge. Follow each phase in order. Be thorough but conservative — only auto-fix patterns you are certain about.
+You are reviewing code changes on the current branch before merge. Follow each phase in order. Do NOT modify any files in the PR — all findings are recorded, not fixed.
 
 ## Phase 0 — Pre-flight
 
@@ -16,13 +16,19 @@ You are reviewing code changes on the current branch before merge. Follow each p
    ```
    If on `main`, stop and warn: "Cannot review from main checkout. Switch to a worktree."
 
-2. Get the diff scope:
+2. Set the commit status to `pending`:
+   ```bash
+   scripts/internal/set_review_status.sh pending "Review in progress"
+   ```
+   If the script is not found (e.g., not yet merged), skip status publishing and note it in the report.
+
+3. Get the diff scope:
    ```bash
    git diff --name-only origin/main...HEAD
    git diff --stat origin/main...HEAD
    ```
 
-3. Classify each changed file into categories:
+4. Classify each changed file into categories:
    - **library**: `src/bid_euchre/**/*.py`
    - **test**: `tests/**/*.py`
    - **notebook**: `notebooks/**/*.py` or `*.ipynb`
@@ -30,47 +36,31 @@ You are reviewing code changes on the current branch before merge. Follow each p
    - **doc**: `docs/**`, `*.md`
    - **other**: everything else
 
-4. Identify the PR number and title:
+5. Identify the PR number and title:
    ```bash
    gh pr view --json number,title,url
    ```
    If no PR exists, note "No PR found — review is pre-PR."
 
-5. If no changed files: report "Nothing to review" and stop.
+6. If no changed files: report "Nothing to review" and stop.
 
-## Phase 1 — Simplification Pass (Auto-Fix)
+## Phase 1 — Finding Collection (Read-Only)
 
-Read each changed `.py` file (library and test). Apply **only** these conservative auto-fixes:
+Read each changed `.py` file (library and test). Scan for the patterns below but **do NOT edit any files**. Record each match as a finding for the Phase 2 report.
 
-### Auto-Fix Rules
+### Patterns to Flag
 
-| Pattern | Fix | Safe? |
-|---------|-----|-------|
-| `print(f"DEBUG` / `print(">>>` / `breakpoint()` | Remove the line | Yes — debug artifacts |
-| `if x == True:` | `if x:` | Yes — PEP 8 |
-| `if x == False:` | `if not x:` | Yes — PEP 8 |
-| `if x == None:` / `if x != None:` | `if x is None:` / `if x is not None:` | Yes — PEP 8 |
-| `else:` block after `return`/`raise`/`continue`/`break` that is the only `else` | Remove `else:`, dedent body | Yes — redundant |
-| `pass` as sole statement in non-empty body | Remove | Yes — redundant |
-| `type(x) == T` | `isinstance(x, T)` | Yes — Pythonic |
+| Pattern | Category | Severity |
+|---------|----------|----------|
+| `print(f"DEBUG` / `print(">>>` / `breakpoint()` | `fix:convention` | WARN |
+| `if x == True:` / `if x == False:` | `fix:convention` | WARN |
+| `if x == None:` / `if x != None:` | `fix:convention` | WARN |
+| `type(x) == T` | `fix:convention` | WARN |
+| Redundant `else:` after `return`/`raise` | `fix:convention` | WARN |
+| Redundant `pass` in non-empty body | `fix:convention` | WARN |
 
-**Do NOT auto-fix:**
-- Anything involving logic changes
-- String formatting preferences
-- Import ordering (ruff handles this)
-- Type annotations
-- Comment wording
-
-### Auto-Fix Workflow
-
-If any fixes are applied:
-1. Stage the changes: `git add -u`
-2. Run `ruff check --fix` and `ruff format` on changed files
-3. Commit: `git commit -m "fix: auto-fix quality issues from /reviewing-changes"`
-4. Push: `git push`
-5. Record the commit SHA for the report
-
-If no fixes needed, skip to Phase 2.
+These patterns were previously auto-fixed. They are now recorded as WARN findings
+and addressed in follow-up issues post-merge.
 
 ## Phase 2 — Convention & Correctness Review
 
@@ -80,33 +70,33 @@ Check each changed file against the rule matrix below. Full definitions with cod
 
 These are correctness or convention violations that would cause problems:
 
-| ID | Scope | What to Check |
-|----|-------|---------------|
-| **C1** | Library (`src/`) | Unseeded `random.Random()` or new global RNG state (`random.choice`, `random.shuffle` without local RNG) |
-| **C2** | Library (`src/`) | `x = x or fallback` on numeric metric — `0.0` is falsy, silently replaces valid zeros |
-| **N1** | Notebooks | Aggregation/visualization without `contract_type` facet (or explicit justification for pooling) |
-| **N2** | Notebooks | Matchup summary table collapsing team0/team1 into a single row |
-| **X3** | Any | Merge conflict markers (`<<<<<<<`), `TODO: remove before merge`, large commented-out blocks (>10 lines) |
+| ID | Scope | What to Check | Category |
+|----|-------|---------------|----------|
+| **C1** | Library (`src/`) | Unseeded `random.Random()` or new global RNG state (`random.choice`, `random.shuffle` without local RNG) | `fix:bug` |
+| **C2** | Library (`src/`) | `x = x or fallback` on numeric metric — `0.0` is falsy, silently replaces valid zeros | `fix:bug` |
+| **N1** | Notebooks | Aggregation/visualization without `contract_type` facet (or explicit justification for pooling) | `fix:process` |
+| **N2** | Notebooks | Matchup summary table collapsing team0/team1 into a single row | `fix:process` |
+| **X3** | Any | Merge conflict markers (`<<<<<<<`), `TODO: remove before merge`, large commented-out blocks (>10 lines) | `fix:process` |
 
 ### WARN (recommend fixing, non-blocking)
 
-| ID | Scope | What to Check |
-|----|-------|---------------|
-| **C3** | Library (`validation/`, `diagnostics/`) | Gate check ordering: most-restrictive first? SKIP vs FAIL semantics correct? |
-| **C4** | Library | Functions >50 lines or nesting depth >4 levels |
-| **N3** | Notebooks | Inference claim without accompanying statistical test (p-value, CI, effect size) |
-| **T1** | Tests | Behavior change in `src/` without corresponding test change in `tests/` |
-| **X1** | Cross-cut | Changes span 3+ unrelated modules (possible scope drift) |
-| **X2** | Cross-cut | Core/scoring/logging changed without corresponding doc update |
+| ID | Scope | What to Check | Category |
+|----|-------|---------------|----------|
+| **C3** | Library (`validation/`, `diagnostics/`) | Gate check ordering: most-restrictive first? SKIP vs FAIL semantics correct? | `fix:convention` |
+| **C4** | Library | Functions >50 lines or nesting depth >4 levels | `fix:convention` |
+| **N3** | Notebooks | Inference claim without accompanying statistical test (p-value, CI, effect size) | `fix:process` |
+| **T1** | Tests | Behavior change in `src/` without corresponding test change in `tests/` | `fix:test` |
+| **X1** | Cross-cut | Changes span 3+ unrelated modules (possible scope drift) | `fix:process` |
+| **X2** | Cross-cut | Core/scoring/logging changed without corresponding doc update | `fix:docs` |
 
 ### How to Check
 
 For each changed file:
 1. Read the file content
 2. Apply the relevant checks based on file category
-3. For each finding, record: check ID, file path, line number(s), description
+3. For each finding, record: check ID, file path, line number(s), description, category
 
-## Phase 3 — Validation & Report
+## Phase 3 — Validation & Status
 
 ### Step 1: Run make check
 
@@ -120,7 +110,25 @@ If it fails:
 3. If fixed: stage, commit as `"fix: resolve make check failures from /reviewing-changes"`, push
 4. If still failing after 3 attempts: note as FAILED in report
 
-### Step 2: Generate Review Report
+### Step 2: Publish commit status and arm auto-merge
+
+Based on findings from Phases 1-2 and make check result:
+
+**If zero BLOCKs and make check passes:**
+```bash
+scripts/internal/set_review_status.sh success "Review passed — 0 blockers, N warnings"
+gh pr merge --auto --squash
+```
+
+**If any BLOCKs or make check fails:**
+```bash
+scripts/internal/set_review_status.sh failure "Review blocked — N blockers found"
+```
+Do NOT arm auto-merge. List blockers in report.
+
+If `set_review_status.sh` is not available, skip status publishing and note in report.
+
+### Step 3: Generate Review Report
 
 Output the review report to chat in this format:
 
@@ -132,30 +140,67 @@ Output the review report to chat in this format:
 - Branch: `<branch>`
 - Files changed: N (M library, K tests, J notebooks, ...)
 
-### Auto-Fixes Applied
-| File | Line | Fix |
-|------|------|-----|
-(table rows, or "No auto-fixes needed.")
-(If applied: "Pushed as follow-up commit `<sha>`.")
-
 ### Findings
 #### BLOCK (fix before merging)
-| ID | File | Finding | Rule |
-|----|------|---------|------|
+| ID | File | Finding | Category |
+|----|------|---------|----------|
 (table rows, or "No blockers.")
 
-#### WARN (recommend fixing)
-| ID | File | Finding | Rule |
-|----|------|---------|------|
+#### WARN (follow-up issue post-merge)
+| ID | File | Finding | Category |
+|----|------|---------|----------|
 (table rows, or "No warnings.")
 
-### make check: PASSED / FAILED
+### Status
+- make check: PASSED / FAILED
+- Commit status: `success` / `failure` / `not published`
+- Auto-merge: ARMED / NOT ARMED
 
 ### Verdict: READY TO MERGE / NEEDS ATTENTION
 READY if zero BLOCKs and make check passes.
 ```
 
-### Step 3: Generate Handoff Summary
+## Phase 4 — Follow-up Issue Creation
+
+For WARN findings, create follow-up issues to track corrective work post-merge.
+
+**Skip this phase if:**
+- There are zero WARN findings
+- The PR has BLOCK findings (fix those first; follow-up issues are for clean merges)
+
+**Process:**
+1. Group findings by category label (`fix:bug`, `fix:convention`, `fix:test`, `fix:docs`, `fix:process`)
+2. For each category with findings, create ONE GitHub issue:
+   ```bash
+   gh issue create \
+     --title "fix(<category>): follow-up for PR #NNN" \
+     --label "<category>,follow-up" \
+     --body "<structured body>"
+   ```
+3. Issue body format:
+   ```markdown
+   ## Follow-up: PR #NNN — [title]
+
+   Findings from `/reviewing-changes` that should be addressed post-merge.
+
+   ### Findings
+   | ID | File | Line | Description |
+   |----|------|------|-------------|
+   | C4 | src/foo.py | 42 | Function exceeds 50 lines |
+
+   ### Suggested fixes
+   - [specific fix suggestions for each finding]
+
+   ---
+   *Auto-generated by `/reviewing-changes`. Original PR: #NNN*
+   ```
+
+4. If label creation fails (labels don't exist yet), create the issue without labels
+   and note in the report.
+
+5. Record all created issue URLs for the handoff.
+
+## Phase 5 — Handoff Summary
 
 Generate the handoff block using the template from [HANDOFF_TEMPLATE.md](HANDOFF_TEMPLATE.md). This block should be ready for the user to `/copy` into a new Claude Code session.
 
@@ -163,8 +208,10 @@ Output it after the review report, separated by a horizontal rule.
 
 ## Important Notes
 
-- **Conservative fixes only.** When in doubt, WARN instead of auto-fixing.
+- **Read-only review.** Do NOT edit files, commit, or push to the PR branch (except for make check fixes in Phase 3 Step 1). All quality findings are recorded as WARN and tracked via follow-up issues.
 - **Read before checking.** Always read the actual file content — don't guess from filenames.
 - **Context matters.** A `print()` in a CLI script is fine; in library code it's a debug artifact.
 - **Scope awareness.** If changes touch only docs or configs, skip the library checks.
 - **Don't expand scope.** If you find issues in unchanged files, note them but don't fix them. This review covers only the PR diff.
+- **Status publishing is best-effort.** If `set_review_status.sh` is not found, the review still completes — just without the GitHub-visible signal.
+- **Follow-up issues, not PRs.** Corrective PRs are opened only after the original PR merges, referencing the follow-up issue. This keeps the audit trail clean.


### PR DESCRIPTION
## Summary
- Rewrite `/reviewing-changes` skill: read-only review (no auto-fix commits), commit status publishing, auto-merge arming, follow-up issue creation
- Add category labels to all findings (`fix:bug`, `fix:convention`, `fix:test`, `fix:docs`, `fix:process`)
- Update handoff template to track follow-up issues instead of auto-fixes

## Why
Part of the workflow redesign (PR 3/8). See `plans/sessions/2026-03-06_workflow-redesign.md`.

The current skill mixes reviewing and fixing — it pushes auto-fix commits to the PR branch, which obscures the audit trail between "original work" and "corrections." The new skill is purely a reviewer: it reads, categorizes findings, publishes a GitHub commit status, and creates follow-up issues for post-merge correction.

**Depends on:** PR #561 (review commit status infrastructure) — merged.

**Key behavioral changes:**
| Before | After |
|--------|-------|
| Auto-fixes pushed to PR branch | No files modified (read-only review) |
| Verdict in chat only | Commit status published to GitHub |
| Manual merge | Auto-merge armed on success |
| No follow-up tracking | Follow-up issues created per category |

## Repro / Validation
**Command(s) run:**
- `make repo-lint` — passed
- `make lint` — passed
- `make test` — 2178 passed, 6 skipped

**Live test:** This PR's own `/reviewing-changes` run will exercise the new skill behavior (status publishing, no auto-fixes).

## Tests
- [x] `make repo-lint` — passed
- [x] `make lint` — passed
- [x] `make test` (2178 passed, 6 skipped)

No new Python tests — this modifies a Claude Code skill (markdown instructions), not library code.

## Expected impact
- Metrics impact: None
- Runtime impact: Review takes slightly longer (issue creation), but no auto-fix commit/push cycle

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-review-skill
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-review-skill
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                 88f28aa [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-review-skill    ee7712e [feat/review-skill-v2]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)