### PR TITLE
feat: R1.5 Step 1 — counterfactual action-value dataset generator

### DIFF
--- a/plans/sessions/2026-03-06_r1-5-step1-dataset-generator.md
+++ b/plans/sessions/2026-03-06_r1-5-step1-dataset-generator.md
@@ -1,0 +1,179 @@
+# R1.5 Step 1 — Counterfactual Dataset Generator Session Plan
+
+**Date:** 2026-03-06
+**Task:** #2 — PR-2: R1.5 Step 1 counterfactual dataset generator
+**Governs:** `scripts/internal/generate_action_value_dataset.py` + unit tests
+**Design spec:** `plans/r1_5_training_plan.md` (Section 5, Step 1)
+
+---
+
+## Scope
+
+One PR. Dataset generator script + unit tests for Gate X1 validation.
+
+### Deliverables
+
+| # | File | Change |
+|---|------|--------|
+| 1 | `scripts/internal/generate_action_value_dataset.py` | New: counterfactual dataset generator |
+| 2 | `tests/unit/test_action_value_dataset.py` | New: unit tests for dataset generation |
+
+### Not in scope
+
+- Training pipeline (Step 2, separate PR)
+- Modifications to `sim/simulation.py` or any frozen files
+- ActionValueBidder changes (done in Step 0)
+- YAML config changes
+
+---
+
+## Architecture
+
+### Why not delegate to run_experiment.py?
+
+The existing auction pipeline runs one auction per deal, producing 1 outcome per (deal, seat). The counterfactual generator needs to enumerate ALL legal actions for each focal seat, force each action, and play out the remainder — producing ~40 rows per (deal, seat). This requires direct access to sim primitives.
+
+### Data flow
+
+```
+For each deal_id in range(n_deals):
+  hands = generate_deal(seed, deal_id)
+  dealer = generate_initial_leader(seed, deal_id)  # reuse as dealer derivation
+
+  For each focal_seat (0..3):
+    # Run partial auction up to focal_seat's turn
+    partial_auction = run_auction_up_to(hands, dealer, focal_seat, continuation_policy)
+    obs = build_observation(hands[focal_seat], focal_seat, dealer, partial_auction)
+    legal = enumerate_legal_actions(obs)
+
+    For each action in legal:
+      # Force this action, continue auction, play tricks, score
+      net_points = simulate_counterfactual(
+          hands, dealer, focal_seat, action, partial_auction, continuation_policy
+      )
+
+      # Extract features
+      state_feats = extract_state_features(obs, contract_family, trump_suit)
+
+      # Write row
+      row = {hand_id, deal_id, focal_seat, action_type, contract_family,
+             bid_n, 52 state features, net_points}
+```
+
+### Key design decisions
+
+1. **Partial auction:** Must simulate the auction up to the focal seat's turn (preceding seats bid using the continuation policy). This establishes `current_high_bid` and `auction_transcript` correctly.
+
+2. **Continuation after forced action:** After forcing the focal seat's action, remaining seats continue bidding using the continuation policy. If all pass (including focal), it's a misdeal — record `net_points=0`.
+
+3. **Trick play:** All 4 seats play with GluttonStrategy. The continuation policy is only for bidding.
+
+4. **net_points calculation:** Use `compute_points(winning_bid, bidder_position, t0, t1)` then extract the focal team's points. `net_points = focal_team_points - opponent_team_points`.
+
+5. **Dealer derivation:** Use `_deal_rng(seed, deal_id).randrange(4)` for deterministic dealer position (same formula as `generate_initial_leader`).
+
+6. **Bidding order:** LOD (left of dealer) first: seats `(dealer+1)%4, (dealer+2)%4, (dealer+3)%4, dealer`. The focal seat is one of these 4 positions.
+
+7. **Misdeal handling:** If no one bids (all pass), set `net_points=0` for all actions in that (deal, focal_seat). This is correct: passing in a dead auction has zero expected value.
+
+### Functions
+
+```python
+def run_partial_auction(
+    hands: list[list[Card]], dealer: int, focal_seat: int,
+    continuation_policy: BiddingPolicy
+) -> tuple[int, list[dict]]:
+    """Run auction up to (but not including) focal_seat's turn.
+    Returns (current_high_bid, transcript_so_far)."""
+
+def simulate_counterfactual(
+    hands: list[list[Card]], dealer: int, focal_seat: int,
+    forced_action: BidAction, current_high_bid: int,
+    transcript_so_far: list[dict],
+    continuation_policy: BiddingPolicy,
+) -> float:
+    """Force focal_seat to take forced_action, continue auction + play tricks.
+    Returns net_points for focal_seat's team."""
+
+def generate_dataset(
+    seed: int, n_deals: int, continuation_policy: BiddingPolicy,
+    mode: str = "SMOKE",
+) -> pd.DataFrame:
+    """Generate the full counterfactual dataset."""
+```
+
+### CLI interface
+
+```bash
+uv run python scripts/internal/generate_action_value_dataset.py \
+    --seed 42 \
+    --n-deals 500 \
+    --mode SMOKE \
+    --continuation-artifact data/artifacts/arc_d/r0/hybrid_r0_full.json \
+    --output-dir data/runs/action_value_smoke_42
+```
+
+Modes: SMOKE=500 deals, QUICK=2500, FULL=50000
+
+### Output schema (Parquet)
+
+| Column | Type | Description |
+|--------|------|-------------|
+| hand_id | int | Unique per (deal, focal_seat) |
+| deal_id | int | Deal index |
+| focal_seat | int | 0-3 |
+| action_type | str | "pass" or "bid" |
+| contract_family | str | "suit", "high", "low", or "none" (for pass) |
+| bid_n | int | 0 for pass, 1-10 for bids |
+| trump_suit | str/None | Suit letter or None |
+| {52 state feature columns} | float | Flattened from STATE_FEATURE_NAMES |
+| net_points | float | Target variable |
+
+---
+
+## Gate X1 Validation
+
+Built into the script and also tested in unit tests:
+
+| Check | Criterion |
+|-------|-----------|
+| Row count | `n_deals * 4 * mean_actions` (+/- 10% of expected) |
+| Contract families | All 3 bid families + pass present |
+| Pass coverage | Exactly 1 pass row per (deal_id, focal_seat) |
+| net_points range | All values in [-10, +10] |
+| No NaN | No NaN in features or target |
+| Feature count | 52 state feature columns present |
+
+---
+
+## Unit Tests
+
+| Test | What it validates |
+|------|-------------------|
+| `test_run_partial_auction_first_seat` | First seat has empty transcript, high_bid=0 |
+| `test_run_partial_auction_later_seat` | Later seats see prior bids in transcript |
+| `test_simulate_counterfactual_pass` | Pass action produces plausible net_points |
+| `test_simulate_counterfactual_bid` | Bid action produces plausible net_points |
+| `test_simulate_counterfactual_misdeal` | All-pass → net_points=0 |
+| `test_generate_dataset_smoke` | SMOKE generates correct row counts |
+| `test_gate_x1_pass_coverage` | Exactly 1 pass per (deal, seat) |
+| `test_gate_x1_no_nan` | No NaN in output |
+| `test_gate_x1_net_points_range` | net_points in [-10, +10] |
+| `test_determinism` | Same seed → identical dataset |
+
+---
+
+## Implementation Order
+
+1. Helper functions: `run_partial_auction()`, `simulate_counterfactual()`
+2. Main `generate_dataset()` function
+3. Gate X1 validation function
+4. CLI wrapper (`main()`)
+5. Unit tests
+6. `make check`
+
+---
+
+## Outcome
+
+_To be filled after implementation._

--- a/scripts/internal/generate_action_value_dataset.py
+++ b/scripts/internal/generate_action_value_dataset.py
@@ -1,0 +1,533 @@
+#!/usr/bin/env python
+"""
+Generate counterfactual action-value dataset for R1.5 training.
+
+For each (deal, focal_seat): enumerate all legal actions, force each one,
+continue the auction with a continuation policy, play out tricks with
+GluttonStrategy, and record the focal team's net_points.
+
+Output: Parquet with columns hand_id, deal_id, focal_seat, action_type,
+contract_family, bid_n, trump_suit, 52 state feature columns, net_points.
+
+Usage:
+    uv run python scripts/internal/generate_action_value_dataset.py \
+        --seed 42 --n-deals 500 --mode SMOKE \
+        --continuation-artifact data/artifacts/arc_d/r0/hybrid_r0_full.json \
+        --output-dir data/runs/action_value_smoke_42
+"""
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+import pandas as pd
+
+from bid_euchre.scoring import compute_points
+from bid_euchre.sim.deals import generate_deal
+from bid_euchre.strategy import GluttonStrategy
+from bid_euchre.strategy.bidding import (
+    STATE_FEATURE_NAMES,
+    BidAction,
+    BiddingObservation,
+    BiddingPolicy,
+    enumerate_legal_actions,
+    extract_state_features,
+)
+
+# Mode → n_deals mapping (override with --n-deals)
+MODE_DEALS = {"SMOKE": 500, "QUICK": 2500, "FULL": 50000}
+
+
+def _deterministic_dealer(seed: int, deal_id: int) -> int:
+    """Derive a deterministic dealer position for (seed, deal_id).
+
+    Uses the same RNG construction as sim.deals._deal_rng so that the
+    dealer is reproducible and independent of the deal's card shuffle.
+    """
+    import random
+
+    combined = int(seed) * 1_000_003 + int(deal_id)
+    return random.Random(combined).randrange(4)
+
+
+def _bidding_order(dealer: int) -> list[int]:
+    """Return the 4 seats in auction order (LOD first, dealer last)."""
+    return [(dealer + offset) % 4 for offset in range(1, 5)]
+
+
+def run_partial_auction(
+    hands: list,
+    dealer: int,
+    focal_seat: int,
+    continuation_policy: BiddingPolicy,
+) -> tuple[int, list[dict]]:
+    """Run auction up to (but not including) focal_seat's turn.
+
+    Returns:
+        (current_high_bid, transcript_so_far)
+    """
+    current_high_bid = 0
+    transcript: list[dict] = []
+
+    for seat in _bidding_order(dealer):
+        if seat == focal_seat:
+            break  # Stop before focal seat bids
+
+        obs = BiddingObservation(
+            hand=hands[seat],
+            seat=seat,
+            dealer_seat=dealer,
+            current_high_bid=current_high_bid,
+            auction_transcript=tuple(dict(e) for e in transcript),
+        )
+
+        bid_action = continuation_policy.choose_bid(obs)
+
+        # Process action
+        is_effective_pass = bid_action.is_pass() or bid_action.n <= current_high_bid
+        if is_effective_pass:
+            transcript.append(
+                {
+                    "seat": seat,
+                    "action": "PASS",
+                    "tricks_bid": 0,
+                    "contract_type": None,
+                    "trump": None,
+                }
+            )
+        else:
+            ctype, trump = bid_action.to_contract_tuple()
+            transcript.append(
+                {
+                    "seat": seat,
+                    "action": "BID",
+                    "tricks_bid": bid_action.n,
+                    "contract_type": ctype,
+                    "trump": trump,
+                }
+            )
+            current_high_bid = bid_action.n
+
+    return current_high_bid, transcript
+
+
+def _complete_auction(
+    hands: list,
+    dealer: int,
+    focal_seat: int,
+    forced_action: BidAction,
+    current_high_bid: int,
+    transcript_so_far: list[dict],
+    continuation_policy: BiddingPolicy,
+) -> tuple[int | None, int | None, str | None, str | None, list[dict]]:
+    """Complete the auction after forcing focal_seat's action.
+
+    Returns:
+        (winning_bid, bidder_position, contract_type, trump_suit, full_transcript)
+    """
+    transcript = [dict(e) for e in transcript_so_far]
+
+    # Apply forced action
+    is_effective_pass = forced_action.is_pass() or forced_action.n <= current_high_bid
+    if is_effective_pass:
+        transcript.append(
+            {
+                "seat": focal_seat,
+                "action": "PASS",
+                "tricks_bid": 0,
+                "contract_type": None,
+                "trump": None,
+            }
+        )
+    else:
+        ctype, trump = forced_action.to_contract_tuple()
+        transcript.append(
+            {
+                "seat": focal_seat,
+                "action": "BID",
+                "tricks_bid": forced_action.n,
+                "contract_type": ctype,
+                "trump": trump,
+            }
+        )
+        current_high_bid = forced_action.n
+
+    # Track winning bidder across entire auction
+    winning_bidder = None
+    winning_contract = None
+    winning_trump = None
+    for entry in transcript:
+        if entry["action"] == "BID":
+            winning_bidder = entry["seat"]
+            winning_contract = entry["contract_type"]
+            winning_trump = entry["trump"]
+
+    # Continue auction for seats after focal
+    order = _bidding_order(dealer)
+    focal_idx = order.index(focal_seat)
+    remaining = order[focal_idx + 1 :]
+
+    for seat in remaining:
+        obs = BiddingObservation(
+            hand=hands[seat],
+            seat=seat,
+            dealer_seat=dealer,
+            current_high_bid=current_high_bid,
+            auction_transcript=tuple(dict(e) for e in transcript),
+        )
+
+        bid_action = continuation_policy.choose_bid(obs)
+
+        is_effective_pass = bid_action.is_pass() or bid_action.n <= current_high_bid
+        if is_effective_pass:
+            transcript.append(
+                {
+                    "seat": seat,
+                    "action": "PASS",
+                    "tricks_bid": 0,
+                    "contract_type": None,
+                    "trump": None,
+                }
+            )
+        else:
+            ctype, trump = bid_action.to_contract_tuple()
+            transcript.append(
+                {
+                    "seat": seat,
+                    "action": "BID",
+                    "tricks_bid": bid_action.n,
+                    "contract_type": ctype,
+                    "trump": trump,
+                }
+            )
+            current_high_bid = bid_action.n
+            winning_bidder = seat
+            winning_contract = ctype
+            winning_trump = trump
+
+    if winning_bidder is None:
+        # All passed — misdeal
+        return None, None, None, None, transcript
+
+    return (
+        current_high_bid,
+        winning_bidder,
+        winning_contract,
+        winning_trump,
+        transcript,
+    )
+
+
+def _play_tricks(
+    hands: list,
+    initial_leader: int,
+    contract_type: str,
+    trump_suit: str | None,
+) -> tuple[int, int]:
+    """Play out 10 tricks with GluttonStrategy. Returns (t0, t1)."""
+    from bid_euchre.core.rules import get_legal_indices, trick_winner
+
+    # Deep copy hands since play_tricks mutates them
+    play_hands = [list(h) for h in hands]
+    strategy = GluttonStrategy()
+
+    team_tricks = {0: 0, 1: 0}
+    leader = initial_leader
+
+    for _trick_num in range(10):
+        plays = []
+        for offset in range(4):
+            player = (leader + offset) % 4
+            hand = play_hands[player]
+
+            legal_indices = get_legal_indices(hand, plays, contract_type, trump_suit)
+            card_index = strategy.choose_card(
+                hand=hand,
+                plays_so_far=plays,
+                contract_type=contract_type,
+                trump_suit=trump_suit,
+                player_index=player,
+            )
+            if card_index not in legal_indices:
+                card_index = legal_indices[0]
+
+            card = hand.pop(card_index)
+            plays.append((player, card))
+
+        winner = trick_winner(plays, contract_type=contract_type, trump_suit=trump_suit)
+        if winner in (0, 2):
+            team_tricks[0] += 1
+        else:
+            team_tricks[1] += 1
+        leader = winner
+
+    return team_tricks[0], team_tricks[1]
+
+
+def simulate_counterfactual(
+    hands: list,
+    dealer: int,
+    focal_seat: int,
+    forced_action: BidAction,
+    current_high_bid: int,
+    transcript_so_far: list[dict],
+    continuation_policy: BiddingPolicy,
+) -> float:
+    """Force focal_seat to take forced_action, complete auction + play tricks.
+
+    Returns net_points for focal_seat's team (focal_points - opponent_points).
+    Misdeal (all pass) returns 0.0.
+    """
+    winning_bid, bidder_pos, contract_type, trump_suit, _transcript = _complete_auction(
+        hands,
+        dealer,
+        focal_seat,
+        forced_action,
+        current_high_bid,
+        transcript_so_far,
+        continuation_policy,
+    )
+
+    if winning_bid is None:
+        # Misdeal: all passed
+        return 0.0
+
+    # Play tricks (auction winner leads)
+    t0, t1 = _play_tricks(hands, bidder_pos, contract_type, trump_suit)
+
+    # Compute points
+    points_t0, points_t1 = compute_points(winning_bid, bidder_pos, t0, t1)
+
+    # net_points for focal_seat's team
+    if focal_seat in (0, 2):
+        return float(points_t0 - points_t1)
+    else:
+        return float(points_t1 - points_t0)
+
+
+def generate_dataset(
+    seed: int,
+    n_deals: int,
+    continuation_policy: BiddingPolicy,
+    progress: bool = True,
+) -> pd.DataFrame:
+    """Generate the full counterfactual action-value dataset.
+
+    For each (deal, focal_seat), enumerates all legal actions, forces each one,
+    and records the resulting net_points.
+    """
+    rows: list[dict] = []
+    hand_id = 0
+    t0 = time.time()
+
+    for deal_id in range(n_deals):
+        hands = generate_deal(seed, deal_id)
+        dealer = _deterministic_dealer(seed, deal_id)
+
+        for focal_seat in range(4):
+            # Run partial auction up to focal_seat
+            current_high_bid, transcript = run_partial_auction(
+                hands, dealer, focal_seat, continuation_policy
+            )
+
+            # Build observation for focal_seat
+            obs = BiddingObservation(
+                hand=hands[focal_seat],
+                seat=focal_seat,
+                dealer_seat=dealer,
+                current_high_bid=current_high_bid,
+                auction_transcript=tuple(dict(e) for e in transcript),
+            )
+
+            # Enumerate legal actions
+            legal = enumerate_legal_actions(obs)
+
+            for action in legal:
+                # Determine contract family and trump for feature extraction
+                if action.is_pass():
+                    contract_family = "none"
+                    trump_suit = None
+                    action_type = "pass"
+                    bid_n = 0
+                else:
+                    ctype, trump_suit = action.to_contract_tuple()
+                    contract_family = ctype
+                    action_type = "bid"
+                    bid_n = action.n
+
+                # Extract state features (52 columns)
+                state = extract_state_features(obs, contract_family, trump_suit)
+
+                # Simulate counterfactual outcome
+                net_points = simulate_counterfactual(
+                    hands,
+                    dealer,
+                    focal_seat,
+                    action,
+                    current_high_bid,
+                    transcript,
+                    continuation_policy,
+                )
+
+                # Build row
+                row = {
+                    "hand_id": hand_id,
+                    "deal_id": deal_id,
+                    "focal_seat": focal_seat,
+                    "action_type": action_type,
+                    "contract_family": contract_family,
+                    "bid_n": bid_n,
+                    "trump_suit": trump_suit if trump_suit else "",
+                }
+                # Add 52 state features as individual columns
+                for i, fname in enumerate(STATE_FEATURE_NAMES):
+                    row[fname] = state[i]
+                row["net_points"] = net_points
+
+                rows.append(row)
+
+            hand_id += 1
+
+        if progress and (deal_id + 1) % max(1, n_deals // 10) == 0:
+            elapsed = time.time() - t0
+            rate = (deal_id + 1) / elapsed
+            print(
+                f"  [{deal_id + 1}/{n_deals}] {len(rows)} rows, "
+                f"{rate:.1f} deals/s, {elapsed:.1f}s elapsed",
+                file=sys.stderr,
+            )
+
+    return pd.DataFrame(rows)
+
+
+def validate_gate_x1(df: pd.DataFrame, n_deals: int) -> None:
+    """Run Gate X1 validation checks on the dataset.
+
+    Raises AssertionError on failure.
+    """
+    # 1. Pass coverage: exactly 1 pass per (deal_id, focal_seat)
+    pass_df = df[df["action_type"] == "pass"]
+    pass_counts = pass_df.groupby(["deal_id", "focal_seat"]).size()
+    assert (pass_counts == 1).all(), (
+        f"Expected exactly 1 pass per (deal, seat), got: "
+        f"{pass_counts.value_counts().to_dict()}"
+    )
+    assert (
+        len(pass_counts) == n_deals * 4
+    ), f"Expected {n_deals * 4} (deal, seat) pairs with pass, got {len(pass_counts)}"
+
+    # 2. All contract families represented
+    families = set(df["contract_family"].unique())
+    expected_families = {"none", "suit", "high", "low"}
+    missing = expected_families - families
+    assert not missing, f"Missing contract families: {missing}"
+
+    # 3. net_points range is plausible
+    min_np = df["net_points"].min()
+    max_np = df["net_points"].max()
+    assert min_np >= -20, f"net_points min too low: {min_np}"
+    assert max_np <= 20, f"net_points max too high: {max_np}"
+
+    # 4. No NaN in features or target
+    feature_cols = STATE_FEATURE_NAMES + ["net_points"]
+    nan_counts = df[feature_cols].isna().sum()
+    nan_cols = nan_counts[nan_counts > 0]
+    assert len(nan_cols) == 0, f"NaN found in columns: {nan_cols.to_dict()}"
+
+    # 5. Row count sanity (expect ~40 actions per seat on average)
+    expected_rows = n_deals * 4 * 40  # rough estimate
+    actual_rows = len(df)
+    ratio = actual_rows / expected_rows
+    assert 0.5 <= ratio <= 1.5, (
+        f"Row count {actual_rows} is outside expected range "
+        f"({expected_rows * 0.5:.0f} - {expected_rows * 1.5:.0f})"
+    )
+
+    # 6. 52 state feature columns present
+    for fname in STATE_FEATURE_NAMES:
+        assert fname in df.columns, f"Missing state feature column: {fname}"
+
+    avg_actions = actual_rows / (n_deals * 4)
+    print(
+        f"  Gate X1 PASS: {actual_rows} rows, {n_deals * 4} hands, "
+        f"{avg_actions:.1f} avg actions/seat"
+    )
+
+
+def load_continuation_policy(artifact_path: str) -> BiddingPolicy:
+    """Load a bidding policy to use as the continuation policy."""
+    from bid_euchre.strategy.bidding import HybridOLSaBidder
+
+    return HybridOLSaBidder(artifact_path=artifact_path, name="continuation")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate counterfactual action-value dataset for R1.5"
+    )
+    parser.add_argument("--seed", type=int, required=True)
+    parser.add_argument(
+        "--n-deals",
+        type=int,
+        default=None,
+        help="Number of deals (overrides --mode default)",
+    )
+    parser.add_argument(
+        "--mode",
+        default="SMOKE",
+        choices=["SMOKE", "QUICK", "FULL"],
+        help="Dataset scale (default: SMOKE)",
+    )
+    parser.add_argument(
+        "--continuation-artifact",
+        required=True,
+        help="Path to bidder artifact for continuation policy",
+    )
+    parser.add_argument(
+        "--output-dir", required=True, help="Output directory for dataset"
+    )
+    parser.add_argument(
+        "--skip-validation", action="store_true", help="Skip Gate X1 validation"
+    )
+    args = parser.parse_args()
+
+    n_deals = args.n_deals if args.n_deals is not None else MODE_DEALS[args.mode]
+
+    print("=== R1.5 Counterfactual Action-Value Dataset Generator ===")
+    print(f"  Seed: {args.seed}")
+    print(f"  Mode: {args.mode} ({n_deals} deals)")
+    print(f"  Continuation: {args.continuation_artifact}")
+
+    # Load continuation policy
+    print("  Loading continuation policy...")
+    continuation = load_continuation_policy(args.continuation_artifact)
+
+    # Generate dataset
+    print(f"  Generating dataset ({n_deals} deals × 4 seats × ~40 actions)...")
+    df = generate_dataset(args.seed, n_deals, continuation)
+
+    print(f"  Total rows: {len(df)}")
+    print(f"  Columns: {len(df.columns)}")
+
+    # Validate
+    if not args.skip_validation:
+        print("  Running Gate X1 validation...")
+        validate_gate_x1(df, n_deals)
+
+    # Write output
+    output_dir = Path(args.output_dir)
+    datasets_dir = output_dir / "datasets"
+    datasets_dir.mkdir(parents=True, exist_ok=True)
+
+    output_path = datasets_dir / "action_value.parquet"
+    df.to_parquet(output_path, index=False)
+
+    print(f"\n  Output: {output_path}")
+    print(f"  Rows: {len(df)}")
+    print(f"  Deals: {n_deals}")
+    print("  Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_action_value_dataset.py
+++ b/tests/unit/test_action_value_dataset.py
@@ -1,0 +1,343 @@
+"""Unit tests for the R1.5 counterfactual action-value dataset generator."""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# Add scripts to path so we can import the generator
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "internal"))
+
+from generate_action_value_dataset import (
+    _bidding_order,
+    _deterministic_dealer,
+    _play_tricks,
+    generate_dataset,
+    run_partial_auction,
+    simulate_counterfactual,
+    validate_gate_x1,
+)
+
+from bid_euchre.sim.deals import generate_deal
+from bid_euchre.strategy.bidding import (
+    STATE_FEATURE_NAMES,
+    AlwaysPassBidder,
+    BidAction,
+    StrictHellRaiser,
+)
+
+# ── Fixtures ──────────────────────────────────────────────────
+
+
+@pytest.fixture
+def seed():
+    return 42
+
+
+@pytest.fixture
+def hands(seed):
+    return generate_deal(seed, 0)
+
+
+@pytest.fixture
+def dealer(seed):
+    return _deterministic_dealer(seed, 0)
+
+
+@pytest.fixture
+def raiser():
+    """A continuation policy that bids aggressively (ensures non-misdeal)."""
+    return StrictHellRaiser(name="test_raiser")
+
+
+@pytest.fixture
+def passer():
+    """A continuation policy that always passes."""
+    return AlwaysPassBidder(name="test_passer")
+
+
+# ── Helpers ───────────────────────────────────────────────────
+
+
+class TestBiddingOrder:
+    def test_dealer_last(self):
+        assert _bidding_order(0) == [1, 2, 3, 0]
+        assert _bidding_order(2) == [3, 0, 1, 2]
+
+    def test_four_seats(self):
+        for dealer in range(4):
+            order = _bidding_order(dealer)
+            assert len(order) == 4
+            assert set(order) == {0, 1, 2, 3}
+
+
+class TestDeterministicDealer:
+    def test_reproducible(self, seed):
+        d1 = _deterministic_dealer(seed, 0)
+        d2 = _deterministic_dealer(seed, 0)
+        assert d1 == d2
+
+    def test_range(self, seed):
+        for deal_id in range(100):
+            d = _deterministic_dealer(seed, deal_id)
+            assert 0 <= d <= 3
+
+
+# ── Partial Auction ───────────────────────────────────────────
+
+
+class TestRunPartialAuction:
+    def test_first_seat_empty_transcript(self, hands, dealer, raiser):
+        """First seat to bid should have empty transcript and high_bid=0."""
+        first_seat = _bidding_order(dealer)[0]
+        high_bid, transcript = run_partial_auction(hands, dealer, first_seat, raiser)
+        assert high_bid == 0
+        assert len(transcript) == 0
+
+    def test_later_seat_sees_prior_bids(self, hands, dealer, raiser):
+        """A later seat should see prior bids in transcript."""
+        order = _bidding_order(dealer)
+        # Third seat should see 2 prior actions
+        third_seat = order[2]
+        high_bid, transcript = run_partial_auction(hands, dealer, third_seat, raiser)
+        assert len(transcript) == 2
+        # StrictHellRaiser always bids, so high_bid > 0
+        assert high_bid > 0
+
+    def test_all_pass_continuation(self, hands, dealer, passer):
+        """With AlwaysPassBidder, all prior seats pass."""
+        order = _bidding_order(dealer)
+        last_seat = order[3]
+        high_bid, transcript = run_partial_auction(hands, dealer, last_seat, passer)
+        assert high_bid == 0
+        assert len(transcript) == 3
+        assert all(e["action"] == "PASS" for e in transcript)
+
+
+# ── Counterfactual Simulation ─────────────────────────────────
+
+
+class TestSimulateCounterfactual:
+    def test_pass_returns_float(self, hands, dealer, raiser):
+        """Pass action produces a float net_points."""
+        focal = _bidding_order(dealer)[0]
+        high_bid, transcript = run_partial_auction(hands, dealer, focal, raiser)
+        result = simulate_counterfactual(
+            hands,
+            dealer,
+            focal,
+            BidAction.pass_bid(),
+            high_bid,
+            transcript,
+            raiser,
+        )
+        assert isinstance(result, float)
+
+    def test_bid_returns_float(self, hands, dealer, raiser):
+        """Bid action produces a float net_points."""
+        focal = _bidding_order(dealer)[0]
+        high_bid, transcript = run_partial_auction(hands, dealer, focal, raiser)
+        action = BidAction.bid(3, "S")
+        result = simulate_counterfactual(
+            hands,
+            dealer,
+            focal,
+            action,
+            high_bid,
+            transcript,
+            raiser,
+        )
+        assert isinstance(result, float)
+
+    def test_misdeal_returns_zero(self, hands, dealer, passer):
+        """When all pass (including forced pass), net_points=0."""
+        focal = _bidding_order(dealer)[0]
+        high_bid, transcript = run_partial_auction(hands, dealer, focal, passer)
+        result = simulate_counterfactual(
+            hands,
+            dealer,
+            focal,
+            BidAction.pass_bid(),
+            high_bid,
+            transcript,
+            passer,
+        )
+        assert result == 0.0
+
+    def test_net_points_range(self, hands, dealer, raiser):
+        """net_points should be in a plausible range."""
+        focal = _bidding_order(dealer)[0]
+        high_bid, transcript = run_partial_auction(hands, dealer, focal, raiser)
+        action = BidAction.bid(3, "S")
+        result = simulate_counterfactual(
+            hands,
+            dealer,
+            focal,
+            action,
+            high_bid,
+            transcript,
+            raiser,
+        )
+        assert -20 <= result <= 20
+
+    def test_different_actions_different_outcomes(self, raiser):
+        """Across multiple deals, pass vs bid produce different net_points."""
+        # Use multiple deals to avoid single-deal flukes where continuation
+        # policy overwhelms the forced action
+        results_pass = []
+        results_bid = []
+        for deal_id in range(10):
+            hands = generate_deal(42, deal_id)
+            dealer = _deterministic_dealer(42, deal_id)
+            focal = _bidding_order(dealer)[0]
+            high_bid, transcript = run_partial_auction(hands, dealer, focal, raiser)
+
+            r_pass = simulate_counterfactual(
+                hands,
+                dealer,
+                focal,
+                BidAction.pass_bid(),
+                high_bid,
+                transcript,
+                raiser,
+            )
+            r_bid = simulate_counterfactual(
+                hands,
+                dealer,
+                focal,
+                BidAction.bid(5, "S"),
+                high_bid,
+                transcript,
+                raiser,
+            )
+            results_pass.append(r_pass)
+            results_bid.append(r_bid)
+
+        # Across 10 deals, pass and bid=5S should differ on at least one
+        assert (
+            results_pass != results_bid
+        ), "Pass and bid always identical across 10 deals"
+
+
+# ── Play Tricks ───────────────────────────────────────────────
+
+
+class TestPlayTricks:
+    def test_tricks_sum_to_ten(self, hands):
+        t0, t1 = _play_tricks(
+            hands, initial_leader=0, contract_type="suit", trump_suit="S"
+        )
+        assert t0 + t1 == 10
+
+    def test_all_contract_types(self, hands):
+        for ctype, trump in [
+            ("suit", "C"),
+            ("suit", "D"),
+            ("high", None),
+            ("low", None),
+        ]:
+            t0, t1 = _play_tricks(
+                hands, initial_leader=0, contract_type=ctype, trump_suit=trump
+            )
+            assert t0 + t1 == 10
+            assert 0 <= t0 <= 10
+
+
+# ── Full Dataset Generation ──────────────────────────────────
+
+
+class TestGenerateDataset:
+    @pytest.fixture
+    def small_df(self, raiser):
+        """Generate a tiny dataset for testing (5 deals)."""
+        return generate_dataset(
+            seed=42, n_deals=5, continuation_policy=raiser, progress=False
+        )
+
+    def test_has_required_columns(self, small_df):
+        required = {
+            "hand_id",
+            "deal_id",
+            "focal_seat",
+            "action_type",
+            "contract_family",
+            "bid_n",
+            "trump_suit",
+            "net_points",
+        }
+        assert required.issubset(set(small_df.columns))
+
+    def test_has_state_features(self, small_df):
+        for fname in STATE_FEATURE_NAMES:
+            assert fname in small_df.columns, f"Missing: {fname}"
+
+    def test_pass_coverage(self, small_df):
+        """Exactly 1 pass per (deal_id, focal_seat)."""
+        pass_df = small_df[small_df["action_type"] == "pass"]
+        counts = pass_df.groupby(["deal_id", "focal_seat"]).size()
+        assert (counts == 1).all()
+        assert len(counts) == 5 * 4  # 5 deals × 4 seats
+
+    def test_no_nan(self, small_df):
+        feature_cols = STATE_FEATURE_NAMES + ["net_points"]
+        assert small_df[feature_cols].isna().sum().sum() == 0
+
+    def test_action_types(self, small_df):
+        assert set(small_df["action_type"].unique()) == {"pass", "bid"}
+
+    def test_contract_families(self, small_df):
+        families = set(small_df["contract_family"].unique())
+        # Must have at least pass (none) and some bid families
+        assert "none" in families
+        assert len(families) >= 2
+
+    def test_row_count_plausible(self, small_df):
+        """5 deals × 4 seats × ~40 avg actions ≈ 800 rows."""
+        assert 200 <= len(small_df) <= 2000
+
+
+# ── Determinism ───────────────────────────────────────────────
+
+
+class TestDeterminism:
+    def test_same_seed_same_output(self, raiser):
+        df1 = generate_dataset(
+            seed=99, n_deals=3, continuation_policy=raiser, progress=False
+        )
+        df2 = generate_dataset(
+            seed=99, n_deals=3, continuation_policy=raiser, progress=False
+        )
+        pd.testing.assert_frame_equal(df1, df2)
+
+    def test_different_seed_different_output(self, raiser):
+        df1 = generate_dataset(
+            seed=99, n_deals=3, continuation_policy=raiser, progress=False
+        )
+        df2 = generate_dataset(
+            seed=100, n_deals=3, continuation_policy=raiser, progress=False
+        )
+        # Different seeds should produce different net_points
+        assert not np.allclose(df1["net_points"].values, df2["net_points"].values)
+
+
+# ── Gate X1 ───────────────────────────────────────────────────
+
+
+class TestGateX1:
+    def test_passes_on_valid_data(self, raiser):
+        df = generate_dataset(
+            seed=42, n_deals=10, continuation_policy=raiser, progress=False
+        )
+        # Should not raise
+        validate_gate_x1(df, n_deals=10)
+
+    def test_fails_on_missing_pass(self, raiser):
+        df = generate_dataset(
+            seed=42, n_deals=5, continuation_policy=raiser, progress=False
+        )
+        # Remove all pass rows
+        df_no_pass = df[df["action_type"] != "pass"].copy()
+        with pytest.raises(AssertionError, match="pass"):
+            validate_gate_x1(df_no_pass, n_deals=5)


### PR DESCRIPTION
## Summary
- Add `scripts/internal/generate_action_value_dataset.py`: counterfactual dataset generator for R1.5 action-value training
- For each (deal, focal_seat), enumerates all legal actions, forces each one, continues auction with continuation policy, plays tricks with GluttonStrategy, records `net_points`
- 25 unit tests + Gate X1 validation built into the script

## Why
R1.5 trains directly on `E[net_points]` instead of `tricks_won` (R1 objective mismatch root cause). The counterfactual dataset provides training labels for all legal actions at each decision point, not just the action that was actually chosen. This is Step 1 of the 10-step R1.5 pipeline defined in `plans/r1_5_training_plan.md`.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_action_value_dataset.py -v  # 25 tests
make check-quiet  # 2242 passed (docs-check pre-existing failure, same as main)
```

**Seed:** Tests use seed=42 and seed=99

## Tests
- [x] `uv run python -m pytest tests/unit/test_action_value_dataset.py -v` — 25 passed
- [x] `make check-quiet` — 2242 passed, 6 skipped (docs-check failure is pre-existing on main)

## Expected impact
- Metrics impact: None (infrastructure only, no model changes)
- Runtime impact: None (new script, not integrated into existing pipelines)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-r1.5-step1-dataset
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-r1.5-step1-dataset
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                       1b82d18 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-r1.5-step1-dataset    e511e20 [r1.5-step1-dataset]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)