### PR TITLE
test: V2 Codex validation — style-only issues

### DIFF
--- a/scripts/internal/codex_v2_test_fixture.py
+++ b/scripts/internal/codex_v2_test_fixture.py
@@ -1,0 +1,26 @@
+"""V2 validation test fixture — style-only issues.
+
+This file contains intentional style violations to test whether
+Codex correctly assigns WARNING/NIT severity (not CRITICAL).
+"""
+
+
+def analyze_hand(cards: list[str], trump: str) -> dict:
+    """Analyze a hand of cards."""
+    breakpoint()  # Debug artifact left in
+
+    result = {"trump": trump, "count": len(cards)}
+
+    if result["count"] == 0:
+        return result
+    else:  # Redundant else after return
+        high_cards = [c for c in cards if c[0] == "A"]
+        result["aces"] = len(high_cards)
+
+    if trump == None:  # noqa: E711 — intentional style violation for test
+        result["no_trump"] = True
+
+    if result.get("no_trump") == True:  # Should use truthiness
+        result["contract"] = "high"
+
+    return result


### PR DESCRIPTION
## Plan
- plans/sessions/2026-03-08_codex-review-quality.md — Workstream 2, V2

## Summary
- Test fixture with style-only violations (breakpoint, redundant else, == None, == True)
- Expected: Codex flags as WARNING/NIT, not CRITICAL

## Why
Validation test V2 — verify Codex does not inflate severity on non-correctness issues.

## Risk level
- [x] Low (docs/tests only)

## Checklist
- [x] Temporary test PR — will be closed without merge