### PR TITLE
fix: add pr_open → stopped_ci_failure state transition

### DIFF
--- a/scripts/internal/review_state.py
+++ b/scripts/internal/review_state.py
@@ -46,7 +46,10 @@ class ReviewMode(str, enum.Enum):
 VALID_TRANSITIONS: dict[ReviewState, list[ReviewState]] = {
     ReviewState.INITIALIZED: [ReviewState.PR_OPEN],
     ReviewState.AUTHORING: [ReviewState.PR_OPEN],
-    ReviewState.PR_OPEN: [ReviewState.WAITING_FOR_CI],
+    ReviewState.PR_OPEN: [
+        ReviewState.WAITING_FOR_CI,
+        ReviewState.STOPPED_CI_FAILURE,
+    ],
     ReviewState.WAITING_FOR_CI: [
         ReviewState.WAITING_FOR_CODEX,
         ReviewState.STOPPED_CI_FAILURE,

--- a/tests/unit/test_review_state.py
+++ b/tests/unit/test_review_state.py
@@ -259,6 +259,18 @@ class TestTransitionChains:
         assert state.is_terminal
         assert state.current_state == ReviewState.STOPPED_CI_FAILURE
 
+    def test_pr_open_to_stopped_ci_failure(self) -> None:
+        """Regression: pr_open must allow direct transition to stopped_ci_failure.
+
+        The review driver transitions pr_open → stopped_ci_failure when
+        deterministic prechecks find blocking issues before CI starts.
+        """
+        state = ReviewLoopState(pr_number=1, branch="b")
+        state.transition(ReviewState.PR_OPEN)
+        state.transition(ReviewState.STOPPED_CI_FAILURE)
+        assert state.is_terminal
+        assert state.current_state == ReviewState.STOPPED_CI_FAILURE
+
     def test_review_failure_stops(self) -> None:
         state = ReviewLoopState(pr_number=1, branch="b")
         state.transition(ReviewState.PR_OPEN)


### PR DESCRIPTION
## Plan
- plans/sessions/2026-03-08_autonomous-review-loop.md (Task #10 e2e validation)

## Summary
- Add `STOPPED_CI_FAILURE` to `PR_OPEN`'s valid transitions in `VALID_TRANSITIONS`
- Add regression test `test_pr_open_to_stopped_ci_failure`

## Why
The review driver transitions `pr_open → stopped_ci_failure` when deterministic prechecks find blocking issues before CI starts. This transition was missing from `VALID_TRANSITIONS`, causing `InvalidTransitionError`. Found during Task #10 e2e validation with seeded bugs (PR #593).

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/test_review_state.py -v` — 28 passed
- `make check-quiet` — all checks passed

## Tests
- [x] `uv run python -m pytest tests/unit/test_review_state.py` — 28 passed (including new regression test)
- [x] `make check-quiet` — full validation passed

## Expected impact
- Metrics impact: None
- Runtime impact: None — fixes a crash path in the review loop

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-transition
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-transition
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                       88d25bc [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-transition        f4add51 [fix/review-state-transition-table]
```

## Codex Review
- [ ] Codex auto-review received (or N/A if not yet enabled)
- [ ] Blocking Codex comments addressed
- [ ] Non-blocking Codex findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)