### PR TITLE
feat: Codex CLI fallback when GitHub Codex hits usage limits

### DIFF
--- a/.claude/rules/60_review_gate.md
+++ b/.claude/rules/60_review_gate.md
@@ -100,6 +100,23 @@ and branch protection blocks the PR. Recovery options:
 2. Admin override: `scripts/internal/set_review_status.sh success "Manual override"`
 3. Fallback workflow (`review_status_fallback.yml`) posts a comment after 1 hour
 
+## Codex Review Channels
+
+Two independent Codex review paths exist, with separate usage pools:
+
+| Channel | How invoked | Usage pool | Response time | Status values |
+|---------|-------------|------------|---------------|---------------|
+| **GitHub Codex** | `@codex review` PR comment | GitHub Codex quota | ~60-254s | COMPLETE, PENDING, UNAVAILABLE_LIMIT |
+| **Codex CLI** | `npx @openai/codex review --base main` (local) | ChatGPT subscription | ~60s | COMPLETE, FAILED |
+
+**Fallback behavior:** When GitHub Codex returns `UNAVAILABLE_LIMIT`, the
+`/reviewing-changes` skill automatically falls back to local Codex CLI. CLI
+findings are recorded under `channel=codex_cli` and appear in a separate report
+section — they are never collapsed with GitHub Codex results.
+
+Both channels are **observe-only** — findings do not affect commit status,
+merge eligibility, or follow-up issue creation.
+
 ## Known Issue: Docs-Only PRs and CI
 
 The CI workflow (`ci.yml`) has `paths-ignore: ['plans/**', 'docs/**', '*.md']`.

--- a/.claude/skills/reviewing-changes/HANDOFF_TEMPLATE.md
+++ b/.claude/skills/reviewing-changes/HANDOFF_TEMPLATE.md
@@ -40,7 +40,9 @@ The user can `/copy` this into a new Claude Code session to resume work.
 - Finding counts: [CRITICAL: N, WARNING: N, NIT: N / unparseable / N/A]
 - Checks reported: [list of check IDs / none]
 - Error message: [verbatim error if UNAVAILABLE_LIMIT, omit otherwise]
-- Summary: [1-3 sentence summary of Codex findings, or "Awaiting response" / "Usage limit — no review performed"]
+- CLI fallback used: [yes / no / failed]
+- CLI fallback findings: [P0: N, P1: N, P2: N / N/A]
+- Summary: [1-3 sentence summary of Codex findings, or "Awaiting response" / "Usage limit — CLI fallback used"]
 
 ### Needs Human Decision
 - [Each BLOCK item with context on why it needs judgment]

--- a/.claude/skills/reviewing-changes/SKILL.md
+++ b/.claude/skills/reviewing-changes/SKILL.md
@@ -230,6 +230,40 @@ error messages. If a Codex comment matches any of these patterns (case-insensiti
 Do NOT continue polling after detecting a limit error — the review will never
 arrive. Record the error message verbatim in the report.
 
+**Step 3b: Codex CLI fallback (when GitHub Codex is unavailable)**
+
+If GitHub Codex status is `UNAVAILABLE_LIMIT`, fall back to local Codex CLI
+review. This uses a separate usage pool (ChatGPT subscription) and provides
+review coverage when the GitHub integration is unavailable.
+
+1. Invoke the Codex CLI adapter:
+   ```bash
+   uv run python -c "
+   import sys, json; sys.path.insert(0, 'scripts/internal')
+   from codex_review_adapter import invoke_codex_cli
+   result = invoke_codex_cli(mode='<review_mode>', base='main')
+   print(json.dumps(result.to_dict(), indent=2))
+   "
+   ```
+
+2. If the CLI invocation succeeds (`result.success == True`):
+   - Parse findings from the result
+   - Record as `codex_cli_fallback_used: yes`
+   - Record channel as `codex_cli` (NOT `inline_review` or `comment`)
+   - Include findings in the report under a separate **Codex CLI Fallback** section
+
+3. If the CLI invocation fails:
+   - Record as `codex_cli_fallback_used: failed`
+   - Include the error in the report
+   - Do NOT retry — proceed with the review using only precheck findings
+
+**Important:** CLI fallback findings are recorded **separately** from GitHub
+Codex findings. They use a different channel (`codex_cli`) and appear in their
+own report section. They are never treated as equivalent to GitHub Codex coverage.
+
+CLI fallback findings are **observe-only** — same as GitHub Codex findings, they
+do NOT affect commit status, merge eligibility, or follow-up issue creation.
+
 ### Step 4: Log Codex response metadata
 
 After polling completes (response received or timeout), log these fields
@@ -244,6 +278,9 @@ in the review report's Codex Review section:
 | `codex_findings_parseable` | yes / no — file paths, line numbers, and severity tags are extractable |
 | `codex_finding_counts` | CRITICAL: N, WARNING: N, NIT: N (or `unparseable`) |
 | `codex_checks_reported` | list of check IDs found in findings (or `none`) |
+| `codex_cli_fallback_used` | yes / no / failed — whether local CLI was invoked as fallback |
+| `codex_cli_latency_seconds` | seconds for CLI invocation (if fallback used) |
+| `codex_cli_finding_counts` | P0: N, P1: N, P2: N (if fallback used, or `N/A`) |
 
 **Format compliance check:** Codex may use either format:
 
@@ -314,6 +351,17 @@ Output the review report to chat in this format:
 | Severity | File | Line | Check | Finding |
 |----------|------|------|-------|---------|
 (parsed from inline review comments or table format — include all Codex findings here)
+
+### Codex CLI Fallback
+(Include this section only when CLI fallback was invoked)
+- Fallback used: yes / failed
+- Latency: N seconds
+- Finding counts: P0: N, P1: N, P2: N
+- CLI findings:
+
+| Severity | File | Line | Check | Finding |
+|----------|------|------|-------|---------|
+(parsed from local CLI output — these are separate from GitHub Codex findings)
 
 ### Status
 - make check: PASSED / FAILED


### PR DESCRIPTION
## Plan
- plans/sessions/2026-03-10_codex-limit-fallback.md (PR 2 of 2)

## Summary
- Add Codex CLI fallback step (Step 3b) in /reviewing-changes when GitHub Codex returns UNAVAILABLE_LIMIT
- CLI findings recorded under `channel=codex_cli` in separate report section
- Document two Codex channels and fallback behavior in review gate rules

## Why
When GitHub Codex usage limits are hit, we get zero external review signal. The local Codex CLI uses a separate usage pool (ChatGPT subscription) and still works. This provides continued review coverage while maintaining distinct audit statuses — GitHub Codex and CLI findings are never collapsed.

## Repro / Validation
**Command(s) run:**
- `make check-quiet` — all checks passed

## Tests
- [x] `make check-quiet` — full validation passed
- Changes are procedural SKILL.md instructions + rule documentation, not executable code

## Expected impact
- Metrics impact: None
- Runtime impact: Adds ~60s CLI invocation when GitHub Codex limits are hit (vs 10 min wasted polling before PR #597)

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-codex-fallback
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-codex-fallback
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                     1e773ad [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-codex-fallback      1bbde7f [feat/codex-cli-fallback]
```

## Codex Review
- [ ] Codex auto-review: N/A (usage limits exhausted — this PR fixes that gap)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] PR is focused (one concept)