### PR TITLE
feat: add plan outline to /reviewing-plans output

### DIFF
--- a/.claude/skills/reviewing-plans/SKILL.md
+++ b/.claude/skills/reviewing-plans/SKILL.md
@@ -59,6 +59,11 @@ Output the review to chat in this format:
 ```markdown
 ## Plan Review: <plan-name>
 
+### Plan Outline
+- **Goal:** <1-sentence summary of what the plan aims to achieve>
+- **Approach:** <2-3 sentences describing the key steps/changes planned>
+- **Expected Result:** <1-sentence summary of the concrete deliverable or outcome>
+
 ### Convention Compliance
 | ID | Status | Finding |
 |----|--------|---------|


### PR DESCRIPTION
## Summary
- Adds a **Plan Outline** section to the `/reviewing-plans` skill output
- Shows Goal, Approach, and Expected Result before convention/risk tables

## Why
After a plan review, readers had to scan the full compliance table to understand what the plan was even about. A brief outline at the top provides immediate context.

## Repro / Validation
Create any plan file and run `/reviewing-plans` — the output will now include a Plan Outline section before Convention Compliance.

## Tests
- N/A — skill template change only (no Python code)

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-plan-outline
toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-plan-outline
worktree: Bid-Euchre-plan-outline c7b5094 [plan-review-outline]
```