### PR TITLE
fix: Codex CLI review invocation — remove mutually exclusive prompt arg

### DIFF
--- a/.claude/rules/60_review_gate.md
+++ b/.claude/rules/60_review_gate.md
@@ -107,7 +107,7 @@ Two independent Codex review paths exist, with separate usage pools:
 | Channel | How invoked | Usage pool | Response time | Status values |
 |---------|-------------|------------|---------------|---------------|
 | **GitHub Codex** | `@codex review` PR comment | GitHub Codex quota | ~60-254s | COMPLETE, PENDING, UNAVAILABLE_LIMIT |
-| **Codex CLI** | `npx @openai/codex review --base main` (local) | ChatGPT subscription | ~60s | COMPLETE, FAILED |
+| **Codex CLI** | `codex review --base main` (local) | ChatGPT subscription | ~60s | COMPLETE, FAILED |
 
 **Fallback behavior:** When GitHub Codex returns `UNAVAILABLE_LIMIT`, the
 `/reviewing-changes` skill automatically falls back to local Codex CLI. CLI

--- a/docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md
+++ b/docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md
@@ -42,7 +42,7 @@ evidence is committed under `docs/04_reports/codex_validation/`.
 
 ### Backends
 
-- **Codex CLI** (primary): `npx @openai/codex review --base main`, local,
+- **Codex CLI** (primary): `codex review --base main`, local,
   ~60s latency, uses ChatGPT subscription (no API billing)
 - **GitHub Codex** (passive overlay): Auto-fires on PR open, visible on PR
   page for humans, not orchestrated by the state machine
@@ -63,8 +63,8 @@ independently. Checks include:
 
 ### Codex CLI Adapter
 
-Invokes `npx @openai/codex review --base main` with a mode-specific prompt.
-Parses two output formats:
+Invokes `codex review --base main` (prefers installed binary, falls back to
+`npx @openai/codex`). Parses two output formats:
 
 1. Standard: `[P1] file:line — message (C1)`
 2. Alternative: `[CRITICAL][C1] file:line — message`

--- a/scripts/internal/codex_review_adapter.py
+++ b/scripts/internal/codex_review_adapter.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import shutil
 import subprocess
 import time
 from dataclasses import asdict, dataclass
@@ -24,6 +25,18 @@ DEFAULT_TIMEOUT_SECONDS = 300
 
 # Max retries before giving up
 MAX_RETRIES = 3
+
+# Known path for macOS Codex app bundle binary
+_CODEX_APP_PATH = Path("/Applications/Codex.app/Contents/Resources/codex")
+
+# Patterns in stderr that indicate a CLI argument/invocation error
+# (as opposed to a review-time error like auth failure or network issue)
+_CLI_ARG_ERROR_PATTERNS = [
+    "cannot be used with",
+    "unexpected argument",
+    "invalid value",
+    "usage: codex review",
+]
 
 # Mode-specific review prompts (aligned with AGENTS.md guidance)
 _PROMPTS = {
@@ -114,6 +127,7 @@ class CodexReviewResult:
     latency_seconds: float
     error: str | None = None
     exit_code: int | None = None
+    error_type: str | None = None  # "cli_invocation_error" or "cli_review_error"
 
     def to_dict(self) -> dict:
         return {
@@ -123,6 +137,7 @@ class CodexReviewResult:
             "latency_seconds": self.latency_seconds,
             "error": self.error,
             "exit_code": self.exit_code,
+            "error_type": self.error_type,
         }
 
 
@@ -237,6 +252,34 @@ def _parse_alt_format(line: str) -> CodexFinding | None:
     )
 
 
+def _resolve_codex_binary() -> list[str]:
+    """Return the command prefix for invoking Codex CLI.
+
+    Preference order:
+    1. ``codex`` in PATH (fastest — no npx overhead)
+    2. macOS app bundle binary at known path
+    3. ``npx @openai/codex`` fallback (downloads if needed)
+    """
+    if shutil.which("codex"):
+        return ["codex"]
+    if _CODEX_APP_PATH.is_file():
+        return [str(_CODEX_APP_PATH)]
+    return ["npx", "@openai/codex"]
+
+
+def _classify_error(stderr: str) -> str:
+    """Classify a CLI error as invocation vs. runtime.
+
+    Returns ``"cli_invocation_error"`` for argument parsing failures
+    (bad flags, mutually exclusive args) or ``"cli_review_error"`` for
+    runtime issues (auth, network, model errors).
+    """
+    stderr_lower = stderr.lower()
+    if any(p in stderr_lower for p in _CLI_ARG_ERROR_PATTERNS):
+        return "cli_invocation_error"
+    return "cli_review_error"
+
+
 def invoke_codex_cli(
     *,
     mode: str = "standard",
@@ -248,6 +291,9 @@ def invoke_codex_cli(
 
     Args:
         mode: Review mode ("standard", "report-audit", "plan-audit").
+            Currently logged for diagnostics only — the CLI relies on
+            repo-level AGENTS.md for review guidance rather than a
+            positional prompt (which is mutually exclusive with --base).
         base: Git base ref for the review.
         timeout: Maximum wait time in seconds.
         cwd: Working directory (defaults to cwd).
@@ -255,19 +301,14 @@ def invoke_codex_cli(
     Returns:
         CodexReviewResult with parsed findings or error info.
     """
-    prompt = _PROMPTS.get(mode, _PROMPTS["standard"])
-
-    cmd = [
-        "npx",
-        "@openai/codex",
-        "review",
-        "--base",
-        base,
-        prompt,
-    ]
+    cmd = [*_resolve_codex_binary(), "review", "--base", base]
 
     logger.info(
-        "Invoking Codex CLI (mode=%s, base=%s, timeout=%ds)", mode, base, timeout
+        "Invoking Codex CLI (mode=%s, base=%s, timeout=%ds, cmd=%s)",
+        mode,
+        base,
+        timeout,
+        cmd,
     )
     start = time.monotonic()
 
@@ -282,10 +323,12 @@ def invoke_codex_cli(
         elapsed = time.monotonic() - start
 
         if result.returncode != 0:
+            error_type = _classify_error(result.stderr)
             logger.warning(
-                "Codex CLI returned exit code %d (%.1fs): %s",
+                "Codex CLI returned exit code %d (%.1fs, %s): %s",
                 result.returncode,
                 elapsed,
+                error_type,
                 result.stderr[:200],
             )
             return CodexReviewResult(
@@ -295,6 +338,7 @@ def invoke_codex_cli(
                 latency_seconds=elapsed,
                 error=f"Exit code {result.returncode}: {result.stderr[:200]}",
                 exit_code=result.returncode,
+                error_type=error_type,
             )
 
         findings = parse_codex_output(result.stdout)
@@ -346,13 +390,13 @@ def invoke_codex_cli(
 
     except FileNotFoundError:
         elapsed = time.monotonic() - start
-        logger.error("Codex CLI not found (npx not in PATH?)")
+        logger.error("Codex CLI not found — codex not in PATH and npx unavailable")
         return CodexReviewResult(
             success=False,
             findings=[],
             raw_output="",
             latency_seconds=elapsed,
-            error="Codex CLI not found (npx not in PATH)",
+            error="Codex CLI not found (codex not in PATH, npx unavailable)",
         )
 
 

--- a/tests/unit/test_codex_review_adapter.py
+++ b/tests/unit/test_codex_review_adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from unittest.mock import Mock, patch
 
 # Add scripts/internal to path for imports
 sys.path.insert(
@@ -12,9 +13,13 @@ sys.path.insert(
 
 from codex_review_adapter import (
     _CLEAN_REVIEW_PATTERNS,
+    _CODEX_APP_PATH,
     CodexFinding,
     CodexReviewResult,
+    _classify_error,
+    _resolve_codex_binary,
     get_blocking_findings,
+    invoke_codex_cli,
     parse_codex_output,
 )
 
@@ -282,3 +287,150 @@ class TestCleanReviewDetection:
 
     def test_no_problems_found_matches(self):
         assert _CLEAN_REVIEW_PATTERNS.search("No problems found.") is not None
+
+
+# --- Tests for command construction (the bug that prompted this PR) ---
+
+
+class TestBinaryResolution:
+    """Test _resolve_codex_binary preference order."""
+
+    @patch("codex_review_adapter.shutil.which", return_value="/usr/local/bin/codex")
+    def test_prefers_path_binary(self, mock_which):
+        assert _resolve_codex_binary() == ["codex"]
+
+    @patch("codex_review_adapter.shutil.which", return_value=None)
+    def test_falls_back_to_app_bundle(self, mock_which):
+        with patch.object(Path, "is_file", return_value=True):
+            result = _resolve_codex_binary()
+            assert result == [str(_CODEX_APP_PATH)]
+
+    @patch("codex_review_adapter.shutil.which", return_value=None)
+    def test_falls_back_to_npx(self, mock_which):
+        with patch.object(Path, "is_file", return_value=False):
+            assert _resolve_codex_binary() == ["npx", "@openai/codex"]
+
+
+class TestCommandConstruction:
+    """Test that invoke_codex_cli builds valid CLI commands.
+
+    The original bug was passing both --base and a positional prompt,
+    which codex-cli v0.114.0 treats as mutually exclusive. These tests
+    ensure the prompt is never included in the command.
+    """
+
+    @patch("codex_review_adapter.subprocess.run")
+    @patch("codex_review_adapter._resolve_codex_binary", return_value=["codex"])
+    def test_no_prompt_in_review_command(self, mock_resolve, mock_run):
+        """The review command must not include a positional prompt."""
+        mock_run.return_value = Mock(returncode=0, stdout="No issues found.", stderr="")
+        invoke_codex_cli(mode="standard", base="main")
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["codex", "review", "--base", "main"]
+
+    @patch("codex_review_adapter.subprocess.run")
+    @patch("codex_review_adapter._resolve_codex_binary", return_value=["codex"])
+    def test_mode_does_not_affect_command(self, mock_resolve, mock_run):
+        """Different modes must not change the command (prompt removed)."""
+        mock_run.return_value = Mock(returncode=0, stdout="LGTM", stderr="")
+        for mode in ("standard", "report-audit", "plan-audit"):
+            invoke_codex_cli(mode=mode, base="main")
+            cmd = mock_run.call_args[0][0]
+            assert cmd == ["codex", "review", "--base", "main"]
+
+    @patch("codex_review_adapter.subprocess.run")
+    @patch(
+        "codex_review_adapter._resolve_codex_binary",
+        return_value=["npx", "@openai/codex"],
+    )
+    def test_npx_fallback_command(self, mock_resolve, mock_run):
+        """When codex binary not found, falls back to npx."""
+        mock_run.return_value = Mock(returncode=0, stdout="LGTM", stderr="")
+        invoke_codex_cli(base="main")
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["npx", "@openai/codex", "review", "--base", "main"]
+
+    @patch("codex_review_adapter.subprocess.run")
+    @patch("codex_review_adapter._resolve_codex_binary", return_value=["codex"])
+    def test_custom_base_branch(self, mock_resolve, mock_run):
+        """Base branch argument is correctly passed."""
+        mock_run.return_value = Mock(returncode=0, stdout="LGTM", stderr="")
+        invoke_codex_cli(base="develop")
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["codex", "review", "--base", "develop"]
+
+
+class TestErrorClassification:
+    """Test that CLI errors are classified correctly."""
+
+    def test_argument_conflict_is_invocation_error(self):
+        stderr = "error: the argument '--base <BRANCH>' cannot be used with '[PROMPT]'"
+        assert _classify_error(stderr) == "cli_invocation_error"
+
+    def test_unexpected_argument_is_invocation_error(self):
+        stderr = "error: unexpected argument '--foo' found"
+        assert _classify_error(stderr) == "cli_invocation_error"
+
+    def test_usage_line_is_invocation_error(self):
+        stderr = "Usage: codex review --base <BRANCH>"
+        assert _classify_error(stderr) == "cli_invocation_error"
+
+    def test_auth_failure_is_review_error(self):
+        stderr = "Error: authentication failed"
+        assert _classify_error(stderr) == "cli_review_error"
+
+    def test_network_error_is_review_error(self):
+        stderr = "Error: network timeout connecting to API"
+        assert _classify_error(stderr) == "cli_review_error"
+
+    def test_empty_stderr_is_review_error(self):
+        assert _classify_error("") == "cli_review_error"
+
+    @patch("codex_review_adapter.subprocess.run")
+    @patch("codex_review_adapter._resolve_codex_binary", return_value=["codex"])
+    def test_error_type_in_result(self, mock_resolve, mock_run):
+        """error_type must be set on failed results."""
+        mock_run.return_value = Mock(
+            returncode=2,
+            stdout="",
+            stderr="error: the argument '--base <BRANCH>' cannot be used with '[PROMPT]'",
+        )
+        result = invoke_codex_cli(base="main")
+        assert not result.success
+        assert result.error_type == "cli_invocation_error"
+
+    @patch("codex_review_adapter.subprocess.run")
+    @patch("codex_review_adapter._resolve_codex_binary", return_value=["codex"])
+    def test_success_has_no_error_type(self, mock_resolve, mock_run):
+        """Successful results have no error_type."""
+        mock_run.return_value = Mock(returncode=0, stdout="LGTM", stderr="")
+        result = invoke_codex_cli(base="main")
+        assert result.success
+        assert result.error_type is None
+
+
+class TestCodexReviewResultErrorType:
+    """Test error_type field in serialization."""
+
+    def test_error_type_in_to_dict(self):
+        result = CodexReviewResult(
+            success=False,
+            findings=[],
+            raw_output="",
+            latency_seconds=3.0,
+            error="Exit code 2",
+            exit_code=2,
+            error_type="cli_invocation_error",
+        )
+        d = result.to_dict()
+        assert d["error_type"] == "cli_invocation_error"
+
+    def test_none_error_type_in_to_dict(self):
+        result = CodexReviewResult(
+            success=True,
+            findings=[],
+            raw_output="LGTM",
+            latency_seconds=60.0,
+        )
+        d = result.to_dict()
+        assert d["error_type"] is None


### PR DESCRIPTION
## Plan
`plans/sessions/2026-03-11_codex-cli-argument-fix.md`

## Summary
- Fix Codex CLI fallback that fails immediately with `error: the argument '--base <BRANCH>' cannot be used with '[PROMPT]'`
- Prefer installed `codex` binary over `npx` (eliminates 2-3s startup overhead)
- Add `error_type` classification to `CodexReviewResult` for faster debugging

## Why
The CLI fallback (PRs #597-#600) was DOA — every invocation failed in ~3s due to
`codex review` v0.114.0 treating `--base` and positional `[PROMPT]` as mutually
exclusive. This meant zero external review coverage when GitHub Codex hit usage limits.

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/test_codex_review_adapter.py -v` (48 tests, 17 new)
- `make check-quiet` (all checks passed)
- Manual verification: `npx @openai/codex review --base main "prompt"` → exit 2; `codex review --base main` → exit 0

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_codex_review_adapter.py -v`
- [x] `make check-quiet`
- [ ] Manual smoke test with real CLI fallback (post-merge — requires active PR + GitHub Codex limit)

## Expected impact
- Metrics impact: None (review infra only)
- Runtime impact: CLI fallback now works; ~2-3s faster per invocation (codex binary vs npx)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-codex-cli-args
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-codex-cli-args
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                       74479f7 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-codex-cli-args    305ae39 [fix-codex-cli-args]
```

## Codex Review
- [ ] Codex auto-review received (or N/A if not yet enabled)
- [ ] Blocking Codex comments addressed
- [ ] Non-blocking Codex findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)