### PR TITLE
feat: expand deterministic prechecks with N1/N2/N3/X2 heuristics

### DIFF
--- a/scripts/internal/deterministic_prechecks.py
+++ b/scripts/internal/deterministic_prechecks.py
@@ -61,6 +61,36 @@ _COMMENT_BLOCK_RE = re.compile(r"((?:^[ \t]*#[^\n]*\n){11,})", re.MULTILINE)
 # Falsy numeric guard: x = x or fallback (C2)
 _FALSY_GUARD_RE = re.compile(r"\b(\w+)\s*=\s*\1\s+or\s+(?:\d+\.?\d*|default_\w+)")
 
+# --- N1: Missing contract-type facet (notebooks only) ---
+# Matches groupby(...) followed by aggregation/plot methods on the same line
+_N1_GROUPBY_RE = re.compile(
+    r"\.groupby\([^)]*\)\s*(?:\[[^\]]*\])?\s*\." r"(?:mean|sum|plot|bar|box)\b"
+)
+# Terms that indicate contract-type faceting is present
+_N1_EXEMPT_RE = re.compile(r"\bcontract_type\b|\bct\b")
+
+# --- N2: Collapsed matchup table (notebooks only) ---
+# Matches .groupby('matchup') or .groupby("matchup") without 'team' in the expression
+_N2_COLLAPSED_RE = re.compile(r"""\.groupby\(\s*['"]matchup['"]\s*\)""")
+
+# --- N3: Inference claim without statistical test (notebooks only) ---
+_N3_CLAIM_RE = re.compile(
+    r"\b(outperform(?:s|ed)?|better\s+than|significant(?:ly)?|superior)\b",
+    re.IGNORECASE,
+)
+_N3_STATS_RE = re.compile(
+    r"\b(p_value|p-value|ttest|t_test|f_oneway|bootstrap|confidence.interval|CI)\b",
+    re.IGNORECASE,
+)
+
+# --- X2: Undocumented contract change (diff-level) ---
+_X2_CONTRACT_PATHS = (
+    "src/bid_euchre/core/rules.py",
+    "src/bid_euchre/scoring.py",
+)
+_X2_CONTRACT_PREFIX = "src/bid_euchre/logging/"
+_X2_DOC_PREFIX = "docs/01_core/"
+
 
 def check_file(
     file_path: str,
@@ -193,6 +223,62 @@ def check_file(
                     )
                 )
 
+    # --- Notebook-only checks (N1, N2, N3) ---
+    is_notebook = "notebooks/" in file_path
+
+    if is_notebook:
+        # N1: Missing contract-type facet in groupby/plot
+        for i, line in enumerate(lines, 1):
+            if _N1_GROUPBY_RE.search(line):
+                # Check ±3 lines for contract_type or ct
+                window_start = max(0, i - 1 - 3)  # i is 1-indexed
+                window_end = min(len(lines), i - 1 + 4)  # +3 after current
+                window = "\n".join(lines[window_start:window_end])
+                if not _N1_EXEMPT_RE.search(window):
+                    findings.append(
+                        Finding(
+                            severity="P2",
+                            file=file_path,
+                            line=i,
+                            category="process",
+                            check_id="N1",
+                            message="Missing contract-type facet in groupby/plot",
+                        )
+                    )
+
+        # N2: Collapsed matchup table (groupby matchup without team)
+        for i, line in enumerate(lines, 1):
+            if _N2_COLLAPSED_RE.search(line) and "team" not in line:
+                findings.append(
+                    Finding(
+                        severity="P2",
+                        file=file_path,
+                        line=i,
+                        category="process",
+                        check_id="N2",
+                        message="Collapsed matchup table — groupby('matchup') without team",
+                    )
+                )
+
+        # N3: Inference claim without statistical test
+        for i, line in enumerate(lines, 1):
+            if _N3_CLAIM_RE.search(line):
+                # Check ±10 lines for stats patterns
+                window_start = max(0, i - 1 - 10)
+                window_end = min(len(lines), i - 1 + 11)
+                window = "\n".join(lines[window_start:window_end])
+                if not _N3_STATS_RE.search(window):
+                    findings.append(
+                        Finding(
+                            severity="P2",
+                            file=file_path,
+                            line=i,
+                            category="process",
+                            check_id="N3",
+                            message="Inference claim without statistical test nearby",
+                        )
+                    )
+
     # --- Convention checks (P2 — non-blocking) ---
     for i, line in enumerate(lines, 1):
         if line.strip().startswith("#"):
@@ -270,11 +356,48 @@ def check_diff(
             check_file(file_path, content, is_library=is_library, mode=mode)
         )
 
+    # X2: Undocumented contract change (diff-level)
+    all_findings.extend(_check_undocumented_contract_change(changed_files))
+
     # Plan-audit mode: check referenced file paths exist
     if mode == "plan-audit":
         all_findings.extend(_check_plan_paths(changed_files, repo_root))
 
     return all_findings
+
+
+def _check_undocumented_contract_change(
+    changed_files: list[str],
+) -> list[Finding]:
+    """X2: Flag changes to core rules/scoring/logging without doc updates."""
+    contract_files = [
+        f
+        for f in changed_files
+        if f in _X2_CONTRACT_PATHS or f.startswith(_X2_CONTRACT_PREFIX)
+    ]
+    if not contract_files:
+        return []
+
+    has_doc_update = any(
+        f.startswith(_X2_DOC_PREFIX) and f.endswith(".md") for f in changed_files
+    )
+    if has_doc_update:
+        return []
+
+    return [
+        Finding(
+            severity="P2",
+            file=cf,
+            line=0,
+            category="process",
+            check_id="X2",
+            message=(
+                "Contract file changed without docs/01_core/ update — "
+                "add documentation or confirm no contract change"
+            ),
+        )
+        for cf in contract_files
+    ]
 
 
 def _check_plan_paths(changed_files: list[str], repo_root: Path) -> list[Finding]:

--- a/tests/unit/test_deterministic_prechecks.py
+++ b/tests/unit/test_deterministic_prechecks.py
@@ -9,6 +9,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "intern
 
 from deterministic_prechecks import (
     Finding,
+    _check_undocumented_contract_change,
     check_file,
     get_blocking_findings,
 )
@@ -292,3 +293,213 @@ class TestTypeComparison:
         findings = check_file("src/foo.py", TYPE_COMPARISON)
         type_check = [f for f in findings if "isinstance" in f.message.lower()]
         assert all(f.severity == "P2" for f in type_check)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: N1/N2/N3/X2 check snippets
+# ---------------------------------------------------------------------------
+
+N1_MISSING_FACET = """\
+import pandas as pd
+
+df = pd.read_parquet("data.parquet")
+result = df.groupby('strategy')['tricks_won'].mean()
+result.plot(kind='bar')
+"""
+
+N1_WITH_FACET = """\
+import pandas as pd
+
+df = pd.read_parquet("data.parquet")
+for ct in df.contract_type.unique():
+    sub = df[df.contract_type == ct]
+    result = sub.groupby('strategy')['tricks_won'].mean()
+    result.plot(kind='bar')
+"""
+
+N2_COLLAPSED = """\
+summary = df.groupby('matchup').agg({'tricks_won': 'mean'})
+"""
+
+N2_WITH_TEAM = """\
+summary = df.groupby(['matchup', 'team']).agg({'tricks_won': 'mean'})
+"""
+
+N3_CLAIM_NO_STATS = """\
+# Analysis results
+# Strategy A significantly outperforms Strategy B
+# This confirms it is superior
+result = compare(a, b)
+"""
+
+N3_CLAIM_WITH_STATS = """\
+# Analysis results
+from scipy.stats import ttest_ind
+t_stat, p_value = ttest_ind(a_scores, b_scores)
+assert p_value < 0.05
+# Strategy A significantly outperforms Strategy B
+result = compare(a, b)
+"""
+
+
+# ---------------------------------------------------------------------------
+# N1 tests — Missing contract-type facet
+# ---------------------------------------------------------------------------
+
+
+class TestN1MissingFacet:
+    """N1: groupby/plot without contract_type in notebooks."""
+
+    def test_detects_missing_facet_in_notebook(self) -> None:
+        findings = check_file("notebooks/arc_d/r0/analysis.py", N1_MISSING_FACET)
+        n1 = [f for f in findings if f.check_id == "N1"]
+        assert len(n1) >= 1
+        assert n1[0].severity == "P2"
+
+    def test_no_finding_when_facet_present(self) -> None:
+        findings = check_file("notebooks/arc_d/r0/analysis.py", N1_WITH_FACET)
+        n1 = [f for f in findings if f.check_id == "N1"]
+        assert len(n1) == 0
+
+    def test_no_finding_outside_notebooks(self) -> None:
+        findings = check_file("scripts/analysis.py", N1_MISSING_FACET)
+        n1 = [f for f in findings if f.check_id == "N1"]
+        assert len(n1) == 0
+
+    def test_exempt_with_ct_abbreviation(self) -> None:
+        code = """\
+for ct in df.contract_type.unique():
+    sub = df[df.contract_type == ct]
+    result = sub.groupby('strategy')['tricks_won'].mean()
+"""
+        findings = check_file("notebooks/arc_d/analysis.py", code)
+        n1 = [f for f in findings if f.check_id == "N1"]
+        assert len(n1) == 0
+
+
+# ---------------------------------------------------------------------------
+# N2 tests — Collapsed matchup table
+# ---------------------------------------------------------------------------
+
+
+class TestN2CollapsedMatchup:
+    """N2: groupby('matchup') without team in notebooks."""
+
+    def test_detects_collapsed_matchup(self) -> None:
+        findings = check_file("notebooks/arc_d/r0/analysis.py", N2_COLLAPSED)
+        n2 = [f for f in findings if f.check_id == "N2"]
+        assert len(n2) == 1
+        assert n2[0].severity == "P2"
+
+    def test_no_finding_with_team(self) -> None:
+        findings = check_file("notebooks/arc_d/r0/analysis.py", N2_WITH_TEAM)
+        n2 = [f for f in findings if f.check_id == "N2"]
+        assert len(n2) == 0
+
+    def test_no_finding_outside_notebooks(self) -> None:
+        findings = check_file("scripts/analysis.py", N2_COLLAPSED)
+        n2 = [f for f in findings if f.check_id == "N2"]
+        assert len(n2) == 0
+
+    def test_no_finding_with_team_in_line(self) -> None:
+        """Ensure 'team' anywhere on the line exempts it."""
+        code = """summary = df.groupby('matchup').apply(lambda x: x.team.nunique())\n"""
+        findings = check_file("notebooks/analysis.py", code)
+        n2 = [f for f in findings if f.check_id == "N2"]
+        assert len(n2) == 0
+
+
+# ---------------------------------------------------------------------------
+# N3 tests — Inference claim without statistical test
+# ---------------------------------------------------------------------------
+
+
+class TestN3InferenceClaim:
+    """N3: inference language without stats patterns in notebooks."""
+
+    def test_detects_claim_without_stats(self) -> None:
+        findings = check_file("notebooks/arc_d/r0/analysis.py", N3_CLAIM_NO_STATS)
+        n3 = [f for f in findings if f.check_id == "N3"]
+        assert len(n3) >= 1
+        assert n3[0].severity == "P2"
+
+    def test_no_finding_with_stats_nearby(self) -> None:
+        findings = check_file("notebooks/arc_d/r0/analysis.py", N3_CLAIM_WITH_STATS)
+        n3 = [f for f in findings if f.check_id == "N3"]
+        assert len(n3) == 0
+
+    def test_no_finding_outside_notebooks(self) -> None:
+        findings = check_file("scripts/analysis.py", N3_CLAIM_NO_STATS)
+        n3 = [f for f in findings if f.check_id == "N3"]
+        assert len(n3) == 0
+
+    def test_detects_better_than(self) -> None:
+        code = "# Model X is better than Model Y\nresult = 42\n"
+        findings = check_file("notebooks/analysis.py", code)
+        n3 = [f for f in findings if f.check_id == "N3"]
+        assert len(n3) >= 1
+
+    def test_exempt_with_bootstrap(self) -> None:
+        code = """\
+# Run bootstrap analysis
+ci = bootstrap(data, n=10000)
+# Model X is better than Model Y
+result = 42
+"""
+        findings = check_file("notebooks/analysis.py", code)
+        n3 = [f for f in findings if f.check_id == "N3"]
+        assert len(n3) == 0
+
+
+# ---------------------------------------------------------------------------
+# X2 tests — Undocumented contract change
+# ---------------------------------------------------------------------------
+
+
+class TestX2UndocumentedContractChange:
+    """X2: contract file changes without docs/01_core/ update."""
+
+    def test_detects_rules_without_docs(self) -> None:
+        changed = ["src/bid_euchre/core/rules.py", "tests/unit/test_rules.py"]
+        findings = _check_undocumented_contract_change(changed)
+        x2 = [f for f in findings if f.check_id == "X2"]
+        assert len(x2) == 1
+        assert x2[0].file == "src/bid_euchre/core/rules.py"
+        assert x2[0].severity == "P2"
+
+    def test_no_finding_with_docs(self) -> None:
+        changed = [
+            "src/bid_euchre/core/rules.py",
+            "docs/01_core/RULES.md",
+        ]
+        findings = _check_undocumented_contract_change(changed)
+        x2 = [f for f in findings if f.check_id == "X2"]
+        assert len(x2) == 0
+
+    def test_detects_scoring_without_docs(self) -> None:
+        changed = ["src/bid_euchre/scoring.py"]
+        findings = _check_undocumented_contract_change(changed)
+        x2 = [f for f in findings if f.check_id == "X2"]
+        assert len(x2) == 1
+
+    def test_detects_logging_without_docs(self) -> None:
+        changed = ["src/bid_euchre/logging/game_log.py"]
+        findings = _check_undocumented_contract_change(changed)
+        x2 = [f for f in findings if f.check_id == "X2"]
+        assert len(x2) == 1
+
+    def test_no_finding_for_unrelated_files(self) -> None:
+        changed = ["src/bid_euchre/strategy/bidding.py"]
+        findings = _check_undocumented_contract_change(changed)
+        x2 = [f for f in findings if f.check_id == "X2"]
+        assert len(x2) == 0
+
+    def test_multiple_contract_files_flagged(self) -> None:
+        changed = [
+            "src/bid_euchre/core/rules.py",
+            "src/bid_euchre/scoring.py",
+            "src/bid_euchre/logging/writer.py",
+        ]
+        findings = _check_undocumented_contract_change(changed)
+        x2 = [f for f in findings if f.check_id == "X2"]
+        assert len(x2) == 3


### PR DESCRIPTION
## Plan
`plans/sessions/2026-03-11_autonomous-review-loop-activation.md` — PR 1 of 3

## Summary
- Add N1 (missing contract-type facet), N2 (collapsed matchup table), N3 (inference claim without stats test), X2 (undocumented contract change) regex heuristics to `deterministic_prechecks.py`
- All new checks start at P2 (WARN) to calibrate false positive rates before promoting to P1 (BLOCK)
- Add 19 new test cases across 4 test classes (45 total tests, all passing)

## Why
Removes HITL dependency for domain-specific review checks. These were previously only catchable by manual Phase 2 review in `/reviewing-changes`. Codifying them as deterministic prechecks enables the autonomous review loop to catch them without human intervention.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_deterministic_prechecks.py -v
make check-quiet
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_deterministic_prechecks.py -v` — 45 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None — prechecks are review infrastructure, not game logic
- Runtime impact: None — regex checks add negligible time to review loop

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/precheck-expansion
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/precheck-expansion
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                                       186c603 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/precheck-expansion  186c603 [feat/precheck-expansion]
```

## Codex Review
- [ ] Codex auto-review received (or N/A if not yet enabled)
- [ ] Blocking Codex comments addressed
- [ ] Non-blocking Codex findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

---

Part 1/3 of the autonomous review loop activation plan.
See `plans/sessions/2026-03-11_autonomous-review-loop-activation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)