### PR TITLE
feat: slim reviewing-changes to dispatcher, enable autonomous review loop

### DIFF
--- a/.claude/hooks/post-pr-review-loop.sh
+++ b/.claude/hooks/post-pr-review-loop.sh
@@ -4,13 +4,7 @@
 # This hook complements post-pr-review.sh (which triggers /reviewing-changes).
 # The review loop driver runs asynchronously in the background and manages
 # the full Codex CLI review → fix → retest cycle.
-#
-# NOTE: Currently disabled (exit 0 early) during rollout. Enable by
-# removing the early exit below once end-to-end validation is complete.
 set -euo pipefail
-
-# ROLLOUT GUARD: disabled until end-to-end validation passes
-exit 0
 
 # Read JSON input from stdin
 INPUT=$(cat)

--- a/.claude/rules/60_review_gate.md
+++ b/.claude/rules/60_review_gate.md
@@ -5,11 +5,13 @@
 ## Operating Model
 
 Claude is the default authoring agent. GitHub is the system of record for merge gates
-and review artifacts. Two review systems operate in parallel:
+and review artifacts. Two systems coordinate on every PR:
 
-1. **`/reviewing-changes` skill** — Manual pre-merge gate (publishes commit status)
-2. **Autonomous review loop** — State machine that orchestrates Codex CLI review,
-   auto-fix, and retesting cycles (`scripts/internal/review_driver.py`)
+1. **`/reviewing-changes` skill** — Fast dispatcher (~5s): publishes `pending` status,
+   generates handoff summary. No file reading, no Codex polling, no follow-up issues.
+2. **Autonomous review loop** — State machine (`scripts/internal/review_driver.py`)
+   that runs asynchronously: deterministic prechecks, `make check`, Codex CLI review,
+   auto-fix, retesting, status publishing, and follow-up issue creation.
 
 Codex CLI is the primary reviewer in the autonomous loop — local, ~60s latency,
 uses ChatGPT subscription (no API billing). GitHub Codex remains as a passive
@@ -19,23 +21,34 @@ overlay (auto-fires on PR open, not orchestrated).
 
 | Context | Publisher | Required by branch protection? | Purpose |
 |---------|-----------|-------------------------------|---------|
-| `reviewing-changes` | Claude (local, via `/reviewing-changes` skill) | Yes | Pre-merge code review gate |
+| `reviewing-changes` | Review loop (`review_driver.py`), initial `pending` from dispatcher | Yes | Pre-merge code review gate |
 
-## Merge Protocol (Observe Phase)
+### Status Values
 
-1. Claude opens PR, `/reviewing-changes` runs automatically
-2. `reviewing-changes` publishes commit status (`success` or `failure`)
-3. Autonomous review loop invokes Codex CLI (`codex review --base main`)
-4. Codex CLI findings are parsed into normalized schema (P0/P1/P2)
-5. Auto-fixable findings (convention patterns) are applied and committed
-6. Non-auto-fixable findings are recorded for human review
-7. Loop iterates (max 5 rounds) until clean or stopped
-8. Human verifies review report, addresses any remaining findings
-9. Human merges manually (no auto-merge during rollout)
+| Status | GitHub API `state` | `description` pattern | When |
+|--------|-------------------|----------------------|------|
+| PENDING | `pending` | "Review loop starting" | Dispatcher publishes immediately |
+| IN_PROGRESS | `pending` | "Codex CLI review in progress (round N)" | Each Codex invocation |
+| FAIL | `failure` | "Review blocked — N blockers" | Blocking prechecks, make check fail, loop crash |
+| WARN | `success` | "Review passed — N warnings (follow-up issues created)" | Non-blocking findings only |
+| READY | `success` | "Review passed — clean" | No findings |
 
-**Rollout phase:** The autonomous review loop hook is disabled by default.
-Enable after end-to-end validation passes. Auto-merge is gated on promotion
-criteria in `docs/04_reports/codex_validation/`.
+## Merge Protocol
+
+1. Claude opens PR
+2. `post-pr-review.sh` hook triggers `/reviewing-changes` dispatcher
+3. Dispatcher publishes `pending` status and generates handoff summary (~5s)
+4. `post-pr-review-loop.sh` hook launches `review_driver.py` asynchronously
+5. Loop runs deterministic prechecks (C1/C2/N1/N2/N3/X2/X3)
+6. Loop runs `make check-quiet`
+7. Loop invokes Codex CLI (`codex review --base main`)
+8. Codex CLI findings are parsed into normalized schema (P0/P1/P2)
+9. Auto-fixable findings (convention patterns) are applied and committed
+10. Non-auto-fixable findings are recorded
+11. Loop iterates (max 5 rounds) until clean or stopped
+12. Loop publishes final status (`success` or `failure`)
+13. Loop creates follow-up issues for non-blocking (P2) findings
+14. Human merges when status is `success` (no auto-merge)
 
 See `docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md` for the full state machine design.
 
@@ -82,8 +95,10 @@ Aligned with `/reviewing-changes` CHECKLIST.md check IDs:
 Use `scripts/internal/set_review_status.sh`:
 
 ```bash
-# Pre-merge code review (local Claude session — HEAD is correct)
-scripts/internal/set_review_status.sh pending "Review in progress"
+# Initial pending (from dispatcher)
+scripts/internal/set_review_status.sh pending "Review loop starting"
+
+# Final statuses (from review loop)
 scripts/internal/set_review_status.sh success "Review passed — 0 blockers, N warnings"
 scripts/internal/set_review_status.sh failure "Review blocked — N blockers found"
 
@@ -91,14 +106,14 @@ scripts/internal/set_review_status.sh failure "Review blocked — N blockers fou
 scripts/internal/set_review_status.sh success "Manual override"
 ```
 
-## Recovery: Stuck Pending Status
+## Recovery
 
-If a Claude session crashes mid-review, `reviewing-changes` stays `pending`
-and branch protection blocks the PR. Recovery options:
+If the review loop crashes or gets stuck:
 
-1. Start a new Claude session and run `/reviewing-changes` manually
-2. Admin override: `scripts/internal/set_review_status.sh success "Manual override"`
-3. Fallback workflow (`review_status_fallback.yml`) posts a comment after 1 hour
+1. Check state: `cat .claude/runtime/review_loops/pr_<N>/state.json`
+2. Manual rerun: `python scripts/internal/review_driver.py --pr <N> --trigger manual`
+3. Admin override: `scripts/internal/set_review_status.sh success "Manual override"`
+4. Fallback workflow (`review_status_fallback.yml`) posts a comment after 1 hour
 
 ## Codex Review Channels
 
@@ -109,13 +124,12 @@ Two independent Codex review paths exist, with separate usage pools:
 | **GitHub Codex** | `@codex review` PR comment | GitHub Codex quota | ~60-254s | COMPLETE, PENDING, UNAVAILABLE_LIMIT |
 | **Codex CLI** | `codex review --base main` (local) | ChatGPT subscription | ~60s | COMPLETE, FAILED |
 
-**Fallback behavior:** When GitHub Codex returns `UNAVAILABLE_LIMIT`, the
-`/reviewing-changes` skill automatically falls back to local Codex CLI. CLI
-findings are recorded under `channel=codex_cli` and appear in a separate report
-section — they are never collapsed with GitHub Codex results.
+The autonomous review loop uses **Codex CLI** as its primary reviewer.
+GitHub Codex fires independently as a passive overlay — visible on the PR
+page for humans, not orchestrated by the loop.
 
-Both channels are **observe-only** — findings do not affect commit status,
-merge eligibility, or follow-up issue creation.
+Both channels' findings feed into the normalized finding schema (P0/P1/P2)
+and are recorded in the loop's per-round artifacts.
 
 ## Known Issue: Docs-Only PRs and CI
 

--- a/.claude/skills/reviewing-changes/HANDOFF_TEMPLATE.md
+++ b/.claude/skills/reviewing-changes/HANDOFF_TEMPLATE.md
@@ -20,45 +20,28 @@ The user can `/copy` this into a new Claude Code session to resume work.
 - ...
 
 ### Issues Encountered
-- [Any test failures, lint issues, or complications during implementation]
+- [Any complications during implementation]
 (or "None.")
 
-### Review Findings
-- Blockers: [N] ([list each with file:line and rule ID])
-- Warnings: [N] ([list each briefly])
-- Follow-up issues: [N created] (or "none needed")
-  - [issue URL] — [category]
-  - ...
-
-### Codex Review Metadata
-- Status: [COMPLETE / PENDING / NOT AVAILABLE / UNAVAILABLE_LIMIT]
-- Response channel: [inline_review / comment / codex_cli / none]
-- Responded: [yes/no]
-- Latency: [N seconds / timeout / early_exit]
-- Format compliant: [yes/no / N/A]
-- Findings parseable: [yes/no / N/A]
-- Finding counts: [CRITICAL: N, WARNING: N, NIT: N / unparseable / N/A]
-- Checks reported: [list of check IDs / none]
-- Error message: [verbatim error if UNAVAILABLE_LIMIT, omit otherwise]
-- CLI fallback used: [yes / no / failed]
-- CLI fallback findings: [P0: N, P1: N, P2: N / N/A]
-- Summary: [1-3 sentence summary of Codex findings, or "Awaiting response" / "Usage limit — CLI fallback used"]
+### Review Loop
+- Run ID: [pr_<number>_<sha[:7]>]
+- State dir: `.claude/runtime/review_loops/pr_<number>/`
+- Initial SHA: [head_sha]
+- Status: SPAWNED (async — check GitHub commit status for final result)
+- Recovery: `python scripts/internal/review_driver.py --pr <number> --trigger manual`
 
 ### Needs Human Decision
-- [Each BLOCK item with context on why it needs judgment]
-- [Each WARN item the agent couldn't resolve]
-(or "None — ready to merge.")
+- [Any items requiring judgment before merge]
+(or "None — review loop will publish final status.")
 
 ### Current State
 - Worktree: `[worktree-path]`
 - Branch: `[branch]` → PR #[number]
-- make check: [PASSED / FAILED]
-- Commit status: [`success` / `failure` / `not published`]
-- Codex review: [PENDING / COMPLETE / NOT AVAILABLE / UNAVAILABLE_LIMIT]
-- Verdict: [READY FOR CODEX/HUMAN REVIEW / NEEDS ATTENTION]
+- Commit status: `pending` (review loop in progress)
+- Verdict: DISPATCHED — review loop running asynchronously
 
 ### Context for Next Agent
-[2-3 sentences: What this PR does, any gotchas from the review,
+[2-3 sentences: What this PR does, what the review loop will check,
 what the next agent needs to know.]
 ---
 ```

--- a/.claude/skills/reviewing-changes/SKILL.md
+++ b/.claude/skills/reviewing-changes/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: reviewing-changes
-description: Reviews changed code for quality, repo conventions, and correctness after PR creation. Publishes a GitHub commit status and creates follow-up issues for warnings. Triggered automatically by PostToolUse hook after gh pr create.
+description: Dispatches the post-PR review by publishing pending status and generating a handoff summary. The autonomous review loop handles all quality checks asynchronously.
 ---
 
-# /reviewing-changes — Post-PR Code Review & Handoff
+# /reviewing-changes — Post-PR Review Dispatcher
 
-You are reviewing code changes on the current branch before merge. Follow each phase in order. Do NOT modify any files in the PR — all findings are recorded, not fixed.
+You are dispatching the post-PR review. This skill is fast (~5s).
+All quality review happens asynchronously via the autonomous review loop (`review_driver.py`).
 
 ## Phase 0 — Pre-flight
 
@@ -16,19 +17,13 @@ You are reviewing code changes on the current branch before merge. Follow each p
    ```
    If on `main`, stop and warn: "Cannot review from main checkout. Switch to a worktree."
 
-2. Set the commit status to `pending`:
-   ```bash
-   scripts/internal/set_review_status.sh pending "Review in progress"
-   ```
-   If the script is not found (e.g., not yet merged), skip status publishing and note it in the report.
-
-3. Get the diff scope:
+2. Get the diff scope:
    ```bash
    git diff --name-only origin/main...HEAD
    git diff --stat origin/main...HEAD
    ```
 
-4. Classify each changed file into categories:
+3. Classify changed files into categories:
    - **library**: `src/bid_euchre/**/*.py`
    - **test**: `tests/**/*.py`
    - **notebook**: `notebooks/**/*.py` or `*.ipynb`
@@ -36,410 +31,53 @@ You are reviewing code changes on the current branch before merge. Follow each p
    - **doc**: `docs/**`, `*.md`
    - **other**: everything else
 
-5. Identify the PR number and title:
+4. Identify the PR:
    ```bash
    gh pr view --json number,title,url
    ```
-   If no PR exists, note "No PR found — review is pre-PR."
 
-6. If no changed files: report "Nothing to review" and stop.
-
-## Phase 1 — Automated Finding Collection
-
-Run deterministic prechecks on the diff. This module detects convention patterns
-(breakpoint, == None, == True, debug prints, type() ==) and correctness issues
-(C1 unseeded RNG, C2 falsy guards, X3 merge markers/TODO/comment blocks,
-import boundary violations). Do NOT edit any files.
-
-```bash
-uv run python -c "
-import sys; sys.path.insert(0, 'scripts/internal')
-from deterministic_prechecks import check_diff
-import json
-findings = check_diff()
-print(json.dumps([f.to_dict() for f in findings], indent=2))
-"
-```
-
-Record each finding for the Phase 2 report:
-- **P0** findings → BLOCK severity
-- **P1** findings → BLOCK severity (C1, C2, X3 violations)
-- **P2** findings → WARN severity (convention patterns)
-
-If the command fails (e.g., module not found), fall back to manual file scanning
-for the patterns listed in [CHECKLIST.md](CHECKLIST.md).
-
-## Phase 2 — Manual Review (Checks Not Covered by Prechecks)
-
-Phase 1 covers C1, C2, and X3 checks automatically **for Python files only**.
-This phase adds checks that require code comprehension, semantic understanding,
-or apply to non-Python files.
-
-Full definitions with code examples are in [CHECKLIST.md](CHECKLIST.md).
-
-### BLOCK (must fix before merging) — Manual checks only
-
-| ID | Scope | What to Check | Category |
-|----|-------|---------------|----------|
-| **N1** | Notebooks | Aggregation/visualization without `contract_type` facet (or explicit justification for pooling) | `fix:process` |
-| **N2** | Notebooks | Matchup summary table collapsing team0/team1 into a single row | `fix:process` |
-| **X3** | Non-Python files | Merge conflict markers (`<<<<<<<`), `TODO: remove before merge` in `.md`, `.yaml`, `.json`, etc. | `fix:process` |
-
-C1, C2, and X3-in-Python are detected automatically by Phase 1 prechecks — do
-not duplicate them here. However, **X3 for non-Python files must still be checked
-manually** since the prechecks module only scans `.py` files. If Phase 1 reported
-any P0/P1 findings for these checks, include them in the BLOCK section of the report.
-
-### WARN (recommend fixing, non-blocking)
-
-| ID | Scope | What to Check | Category |
-|----|-------|---------------|----------|
-| **C3** | Library (`validation/`, `diagnostics/`) | Gate check ordering: most-restrictive first? SKIP vs FAIL semantics correct? | `fix:convention` |
-| **C4** | Library | Functions >50 lines or nesting depth >4 levels | `fix:convention` |
-| **N3** | Notebooks | Inference claim without accompanying statistical test (p-value, CI, effect size) | `fix:process` |
-| **T1** | Tests | Behavior change in `src/` without corresponding test change in `tests/` | `fix:test` |
-| **X1** | Cross-cut | Changes span 3+ unrelated modules (possible scope drift) | `fix:process` |
-| **X2** | Cross-cut | Core/scoring/logging changed without corresponding doc update | `fix:docs` |
-
-Redundant `else:` after `return`/`raise` and redundant `pass` in non-empty body
-are also WARN-level convention issues — flag them if spotted during manual review.
-
-### How to Check
-
-For each changed file:
-1. Read the file content
-2. Apply the relevant manual checks based on file category (N1/N2 for notebooks, C3/C4 for library, etc.)
-3. Combine with Phase 1 automated findings for the complete report
-
-## Phase 3 — Validation & Status
-
-### Step 1: Run make check
-
-```bash
-make check-quiet
-```
-
-If it fails:
-1. Read the error output
-2. Attempt to fix (up to 3 iterations)
-3. If fixed: stage, commit as `"fix: resolve make check failures from /reviewing-changes"`, push
-4. If still failing after 3 attempts: note as FAILED in report
-
-### Step 2: Publish commit status
-
-Based on findings from Phases 1-2 and make check result:
-
-**If zero BLOCKs and make check passes:**
-```bash
-scripts/internal/set_review_status.sh success "Review passed — 0 blockers, N warnings"
-```
-
-**If any BLOCKs or make check fails:**
-```bash
-scripts/internal/set_review_status.sh failure "Review blocked — N blockers found"
-```
-
-If `set_review_status.sh` is not available, skip status publishing and note in report.
-
-Do NOT arm auto-merge (`gh pr merge --auto`). During rollout, merge happens
-manually after Codex pre-merge review is visible on the PR.
-
-### Step 3: Request Codex review (observe-only)
-
-Post a comment on the PR to trigger Codex review with a **review-mode-specific
-prompt**. Determine the review mode from the file classification in Phase 0 Step 4:
-
-| Changed files include | Review mode |
-|----------------------|-------------|
-| `docs/04_reports/**`, gate/promotion reports | `report-audit` |
-| `plans/**` | `plan-audit` |
-| Everything else (default) | `standard` |
-
-If a PR has mixed file types, use the most restrictive mode that applies.
-
-**Standard mode prompt:**
-
-```bash
-gh pr comment <PR_NUMBER> --body "@codex review for P0/P1 correctness regressions, syntax breakage, merge markers, determinism violations, and import-boundary violations. Ignore stylistic nits.
-
-PR scope: M files changed (K library, J test, ...)
-
-See AGENTS.md at the repo root for repo-specific check IDs (C1, C2, X3, etc.)."
-```
-
-**Report-audit mode prompt:**
-
-```bash
-gh pr comment <PR_NUMBER> --body "@codex review for provenance errors, irreproducible published metrics, missing generator scripts, and gate-result/adjudication mismatches. Treat each as P1.
-
-PR scope: M files changed (report/docs files)
-
-See docs/04_reports/AGENTS.md for report-audit guidance."
-```
-
-**Plan-audit mode prompt:**
-
-```bash
-gh pr comment <PR_NUMBER> --body "@codex review for nonexistent file references, contradictory rollout steps, and unenforceable or deadlocking gates. Treat each as P1.
-
-PR scope: M files changed (plan files)
-
-See plans/AGENTS.md for plan-audit guidance."
-```
-
-Record the timestamp when the `@codex review` comment was posted as
-`CODEX_REQUEST_TS` (ISO 8601 format, e.g. `2026-03-10T14:30:00Z`). This
-timestamp is used to scope channel 3 polling — see "Early exit on usage limits"
-below.
-
-Then poll for the Codex response (up to 10 minutes, checking every 30 seconds).
-
-**Important:** Codex responds via **three channels** — check all:
-
-1. **PR review comments** (inline, on specific lines) — this is the primary channel:
+5. Get HEAD SHA:
    ```bash
-   # Check for inline review comments from Codex
-   gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments --paginate \
-     --jq '[.[] | select(.user.login == "chatgpt-codex-connector[bot]") | {path: .path, line: .line, body: .body}]'
+   git rev-parse HEAD
    ```
 
-2. **PR reviews** (top-level review body):
-   ```bash
-   # Check for PR review from Codex
-   gh pr view <PR_NUMBER> --json reviews \
-     --jq '.reviews[] | select(.author.login == "chatgpt-codex-connector") | .body'
-   ```
+## Phase 1 — Publish Pending Status
 
-3. **Regular comments** (used for setup messages, errors, or usage limit notices):
-   ```bash
-   # Filter to comments from Codex created AFTER the current @codex review request.
-   # This prevents stale error comments from prior review attempts triggering
-   # a false UNAVAILABLE_LIMIT on the current attempt.
-   gh pr view <PR_NUMBER> --json comments \
-     --jq '.comments[] | select(.author.login == "chatgpt-codex-connector" and .createdAt > "'"$CODEX_REQUEST_TS"'") | .body'
-   ```
-
-**Polling exit conditions:**
-
-A Codex review is **COMPLETE** when either channel 1 or 2 returns content.
-Channel 1 (inline comments) contains the actual findings; channel 2 is typically
-a summary header.
-
-**Early exit on usage limits:** On each poll cycle, also check channel 3 for
-error messages. **Only check comments created after `CODEX_REQUEST_TS`** — older
-comments from prior review attempts must be ignored to avoid false early exits.
-If a Codex comment (newer than `CODEX_REQUEST_TS`) matches any of these patterns
-(case-insensitive), **stop polling immediately** and set status to `UNAVAILABLE_LIMIT`:
-
-- "reached your Codex usage limits"
-- "usage limit"
-- "temporarily unavailable"
-
-Do NOT continue polling after detecting a limit error — the review will never
-arrive. Record the error message verbatim in the report.
-
-**Why timestamp scoping matters:** A PR may be reviewed multiple times (e.g.,
-after pushing fixes). Without filtering by `CODEX_REQUEST_TS`, a stale usage-limit
-comment from an earlier review attempt would immediately trigger `UNAVAILABLE_LIMIT`
-on the new attempt, even if Codex has recovered capacity.
-
-**Step 3b: Codex CLI fallback (when GitHub Codex is unavailable)**
-
-If GitHub Codex status is `UNAVAILABLE_LIMIT`, fall back to local Codex CLI
-review. This uses a separate usage pool (ChatGPT subscription) and provides
-review coverage when the GitHub integration is unavailable.
-
-1. Invoke the Codex CLI adapter:
-   ```bash
-   uv run python -c "
-   import sys, json; sys.path.insert(0, 'scripts/internal')
-   from codex_review_adapter import invoke_codex_cli
-   result = invoke_codex_cli(mode='<review_mode>', base='main')
-   print(json.dumps(result.to_dict(), indent=2))
-   "
-   ```
-
-2. If the CLI invocation succeeds (`result.success == True`):
-   - Parse findings from the result
-   - Record as `codex_cli_fallback_used: yes`
-   - Record channel as `codex_cli` (NOT `inline_review` or `comment`)
-   - Include findings in the report under a separate **Codex CLI Fallback** section
-
-3. If the CLI invocation fails:
-   - Record as `codex_cli_fallback_used: failed`
-   - Include the error in the report
-   - Do NOT retry — proceed with the review using only precheck findings
-
-**Important:** CLI fallback findings are recorded **separately** from GitHub
-Codex findings. They use a different channel (`codex_cli`) and appear in their
-own report section. They are never treated as equivalent to GitHub Codex coverage.
-
-CLI fallback findings are **observe-only** — same as GitHub Codex findings, they
-do NOT affect commit status, merge eligibility, or follow-up issue creation.
-
-### Step 4: Log Codex response metadata
-
-After polling completes (response received or timeout), log these fields
-in the review report's Codex Review section:
-
-| Field | Value |
-|-------|-------|
-| `codex_responded` | yes / no |
-| `codex_response_channel` | `inline_review` / `comment` / `codex_cli` / `none` |
-| `codex_latency_seconds` | seconds from `@codex review` comment to response (or `timeout`) |
-| `codex_format_compliant` | yes / no — findings use severity tags and check IDs |
-| `codex_findings_parseable` | yes / no — file paths, line numbers, and severity tags are extractable |
-| `codex_finding_counts` | CRITICAL: N, WARNING: N, NIT: N (or `unparseable`) |
-| `codex_checks_reported` | list of check IDs found in findings (or `none`) |
-| `codex_cli_fallback_used` | yes / no / failed — whether local CLI was invoked as fallback |
-| `codex_cli_latency_seconds` | seconds for CLI invocation (if fallback used) |
-| `codex_cli_finding_counts` | P0: N, P1: N, P2: N (if fallback used, or `N/A`) |
-
-**Format compliance check:** Codex may use either format:
-
-1. **Our requested format** (table in AGENTS.md):
-   - `### Summary` with severity counts
-   - `### Findings` table with Severity/File/Line/Check/Finding columns
-   - `### Checks Performed` checklist
-
-2. **Codex native format** (inline review comments):
-   - `[CRITICAL][C1]` or `[WARNING][T1]` severity+check tags in comment title
-   - File path and line number from the inline comment metadata
-   - `P0`/`P1`/`P2` priority badges
-
-Both formats are parseable. For native format, extract:
-- Severity from `[CRITICAL]`/`[WARNING]`/`[NIT]` tags (or map P0→CRITICAL, P1→CRITICAL, P2→WARNING)
-- Check ID from `[C1]`/`[C2]`/`[X3]` etc.
-- File and line from the inline comment's `path` and `line` fields
-
-If the response uses neither format, set `codex_format_compliant: no` and include
-the raw response body in the report for human review.
-
-Record the Codex review result:
-- **COMPLETE** — Codex responded with review content. Include parsed findings in the report.
-- **PENDING** — Codex did not respond within 10 minutes. Note in report; human should check before merging.
-- **NOT AVAILABLE** — `gh pr comment` failed or PR doesn't exist.
-- **UNAVAILABLE_LIMIT** — Codex responded with a usage limit error. No review was performed. Record the error message.
-
-**Observe-only:** Codex findings are informational in this phase. They do NOT
-affect commit status, merge eligibility, or follow-up issue creation. They are
-reported for human review only. Do NOT auto-fix Codex findings.
-
-### Step 5: Generate Review Report
-
-Output the review report to chat in this format:
-
-```markdown
-## Review Complete
-
-### Diff Summary
-- PR: #NNN — [title]
-- Branch: `<branch>`
-- Files changed: N (M library, K tests, J notebooks, ...)
-
-### Findings
-#### BLOCK (fix before merging)
-| ID | File | Finding | Category |
-|----|------|---------|----------|
-(table rows, or "No blockers.")
-
-#### WARN (follow-up issue post-merge)
-| ID | File | Finding | Category |
-|----|------|---------|----------|
-(table rows, or "No warnings.")
-
-### Codex Review
-- Status: COMPLETE / PENDING / NOT AVAILABLE / UNAVAILABLE_LIMIT
-- Response channel: inline_review / comment / codex_cli / none
-- Responded: yes / no
-- Latency: N seconds / timeout / early_exit
-- Format compliant: yes / no / N/A (if unavailable)
-- Findings parseable: yes / no / N/A (if unavailable)
-- Finding counts: CRITICAL: N, WARNING: N, NIT: N (or "unparseable" / "N/A")
-- Checks reported: [list of check IDs] (or "none")
-- Error message: [verbatim Codex error, if UNAVAILABLE_LIMIT] (omit if not applicable)
-- Summary: [1-3 sentence summary of Codex findings, or "No issues found" / "Awaiting response" / "Usage limit — no review performed"]
-- Codex findings (if parseable):
-
-| Severity | File | Line | Check | Finding |
-|----------|------|------|-------|---------|
-(parsed from inline review comments or table format — include all Codex findings here)
-
-### Codex CLI Fallback
-(Include this section only when CLI fallback was invoked)
-- Fallback used: yes / failed
-- Latency: N seconds
-- Finding counts: P0: N, P1: N, P2: N
-- CLI findings:
-
-| Severity | File | Line | Check | Finding |
-|----------|------|------|-------|---------|
-(parsed from local CLI output — these are separate from GitHub Codex findings)
-
-### Status
-- make check: PASSED / FAILED
-- Commit status: `success` / `failure` / `not published`
-- Codex review: COMPLETE / PENDING / NOT AVAILABLE / UNAVAILABLE_LIMIT
-
-### Verdict: READY TO MERGE / NEEDS ATTENTION
-READY if zero BLOCKs and make check passes.
-NEEDS ATTENTION if any BLOCKs or make check fails.
-Codex findings are observe-only — they do not affect the verdict.
-Note Codex format compliance for validation tracking.
+Publish the review status as pending:
+```bash
+scripts/internal/set_review_status.sh pending "Review loop starting"
 ```
 
-## Phase 4 — Follow-up Issue Creation
+If the script is not found, skip and note in the handoff.
 
-For WARN findings, create follow-up issues to track corrective work post-merge.
+The autonomous review loop is triggered by the PostToolUse hook (`post-pr-review-loop.sh`).
+It runs asynchronously and handles:
+- Deterministic prechecks (C1/C2/N1/N2/N3/X2/X3)
+- `make check-quiet`
+- Codex CLI review + auto-fix loop (max 5 iterations)
+- Final status publishing (success/failure)
+- Follow-up issue creation for P2 findings
 
-**Skip this phase if:**
-- There are zero WARN findings
-- The PR has BLOCK findings (fix those first; follow-up issues are for clean merges)
+If the loop hook did not fire (check `.claude/runtime/review_loops/` for state),
+invoke manually:
+```bash
+python scripts/internal/review_driver.py --pr <N> --branch <branch> --trigger pr_created
+```
 
-**Process:**
-1. Group findings by category label (`fix:bug`, `fix:convention`, `fix:test`, `fix:docs`, `fix:process`)
-2. For each category with findings, create ONE GitHub issue:
-   ```bash
-   gh issue create \
-     --title "fix(<category>): follow-up for PR #NNN" \
-     --label "<category>,follow-up" \
-     --body "<structured body>"
-   ```
-3. Issue body format:
-   ```markdown
-   ## Follow-up: PR #NNN — [title]
+## Phase 2 — Handoff Summary
 
-   Findings from `/reviewing-changes` that should be addressed post-merge.
+Generate the handoff block using [HANDOFF_TEMPLATE.md](HANDOFF_TEMPLATE.md).
+Populate with pre-flight data from Phase 0.
+Mark the review loop as **SPAWNED** (not COMPLETE — it runs asynchronously).
 
-   ### Findings
-   | ID | File | Line | Description |
-   |----|------|------|-------------|
-   | C4 | src/foo.py | 42 | Function exceeds 50 lines |
-
-   ### Suggested fixes
-   - [specific fix suggestions for each finding]
-
-   ---
-   *Auto-generated by `/reviewing-changes`. Original PR: #NNN*
-   ```
-
-4. If label creation fails (labels don't exist yet), create the issue without labels
-   and note in the report.
-
-5. Record all created issue URLs for the handoff.
-
-## Phase 5 — Handoff Summary
-
-Generate the handoff block using the template from [HANDOFF_TEMPLATE.md](HANDOFF_TEMPLATE.md). This block should be ready for the user to `/copy` into a new Claude Code session.
-
-Output it after the review report, separated by a horizontal rule.
+Output the handoff after a horizontal rule.
 
 ## Important Notes
 
-- **Read-only review.** Do NOT edit files, commit, or push to the PR branch (except for make check fixes in Phase 3 Step 1). All quality findings are recorded as WARN and tracked via follow-up issues.
-- **Read before checking.** Always read the actual file content — don't guess from filenames.
-- **Context matters.** A `print()` in a CLI script is fine; in library code it's a debug artifact.
-- **Scope awareness.** If changes touch only docs or configs, skip the library checks.
-- **Don't expand scope.** If you find issues in unchanged files, note them but don't fix them. This review covers only the PR diff.
-- **Status publishing is best-effort.** If `set_review_status.sh` is not found, the review still completes — just without the GitHub-visible signal.
-- **Follow-up issues, not PRs.** Corrective PRs are opened only after the original PR merges, referencing the follow-up issue. This keeps the audit trail clean.
+- **Do NOT read changed files** or apply manual review checks — the loop handles this.
+- **Do NOT poll for Codex response** — the loop handles this.
+- **Do NOT create follow-up issues** — the loop handles this.
+- **Do NOT run make check** — the loop handles this.
+- If the loop fails, it publishes a failure status with a recovery command.
+- The CHECKLIST.md file is retained as the authoritative reference for check definitions.
+  The loop's `deterministic_prechecks.py` module implements these checks programmatically.

--- a/docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md
+++ b/docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md
@@ -6,7 +6,10 @@ The autonomous review loop is a local state machine where Claude (author)
 writes/fixes code and Codex CLI (reviewer) reviews it. The loop is persisted
 to disk, resumable after restarts, and bounded (max 5 iterations).
 
-During rollout, the loop stops at `ready_to_merge` — it does not auto-merge.
+The loop is the primary review mechanism for all PRs. It runs asynchronously
+after PR creation, triggered by the `post-pr-review-loop.sh` PostToolUse hook.
+The loop stops at `ready_to_merge` — it does not auto-merge. Human merges
+when the final status is `success`.
 
 ## Architecture
 
@@ -14,12 +17,23 @@ During rollout, the loop stops at `ready_to_merge` — it does not auto-merge.
 
 | Module | Purpose |
 |--------|---------|
-| `scripts/internal/review_state.py` | State schema, persistence, state enum |
-| `scripts/internal/review_driver.py` | Main orchestrator (state transitions, dispatch) |
-| `scripts/internal/deterministic_prechecks.py` | Fast local checks (merge markers, RNG, imports) |
-| `scripts/internal/github_pr_state.py` | GitHub CLI wrappers (CI status, PR metadata) |
+| `scripts/internal/review_state.py` | State schema, persistence, state enum, SHA tracking |
+| `scripts/internal/review_driver.py` | Main orchestrator (state transitions, dispatch, status publishing, crash recovery) |
+| `scripts/internal/deterministic_prechecks.py` | Fast local checks (merge markers, RNG, imports, N1/N2/N3/X2 heuristics) |
+| `scripts/internal/github_pr_state.py` | GitHub CLI wrappers (CI status, PR metadata, status publishing) |
 | `scripts/internal/codex_review_adapter.py` | Codex CLI invocation + output parsing |
 | `scripts/internal/claude_fix_adapter.py` | Deterministic fix application from Codex findings |
+
+### Dispatcher Integration
+
+The `/reviewing-changes` skill acts as a fast dispatcher (~5s):
+1. Publishes `pending` status immediately
+2. Generates a handoff summary for the session
+3. Does NOT read files, run checks, or poll for Codex — the loop handles all of that
+
+The dispatcher and the loop hook both fire on `gh pr create`:
+- `post-pr-review.sh` triggers `/reviewing-changes` (in-session dispatcher)
+- `post-pr-review-loop.sh` launches `review_driver.py` (async background)
 
 ### State Machine
 
@@ -49,9 +63,8 @@ evidence is committed under `docs/04_reports/codex_validation/`.
 
 ### Deterministic Prechecks
 
-Extracted from `/reviewing-changes` Phases 0-2 into a standalone module.
-Both the skill and the state machine call `deterministic_prechecks.py`
-independently. Checks include:
+Implemented in `deterministic_prechecks.py`. The loop runs these
+as its first step before invoking Codex CLI. Checks include:
 
 - Merge conflict markers (P0)
 - `TODO: remove before merge` (P1)
@@ -60,6 +73,10 @@ independently. Checks include:
 - Falsy numeric guard `x = x or fallback` (P1, library only)
 - Import boundary violations (P1, library only)
 - Convention patterns: `== None`, `== True`, `breakpoint()` (P2)
+- N1: Missing contract-type facet in notebook groupby/plot (P1, notebooks only)
+- N2: Collapsed matchup table without team breakout (P1, notebooks only)
+- N3: Inference claim without statistical test (P2, notebooks only)
+- X2: Core/scoring/logging changes without doc update (P2, diff-level)
 
 ### Codex CLI Adapter
 
@@ -94,20 +111,69 @@ Applies deterministic, pattern-based fixes only:
 Skipped findings are recorded with reason in round_N/fix_summary.json
 and round_N/claude_fix_summary.md.
 
+### Status Publishing
+
+The loop publishes GitHub commit status at key transitions:
+
+| Transition | Status | Description |
+|------------|--------|-------------|
+| Loop starts | `pending` | "Review loop starting" |
+| Codex invoked | `pending` | "Codex CLI review in progress (round N)" |
+| Clean pass | `success` | "Review passed — clean" |
+| Warnings only | `success` | "Review passed — N warnings (follow-up issues created)" |
+| Blockers found | `failure` | "Review blocked — N blockers" |
+| Loop crash | `failure` | "Review loop crashed: {error}. Rerun: ..." |
+
+### Follow-up Issues
+
+At `ready_to_merge`, the loop creates GitHub issues for non-blocking (P2)
+findings, grouped by category. Issues are labeled with `follow-up` plus
+the appropriate category label (`fix:bug`, `fix:convention`, etc.).
+
 ## Usage
 
 ```bash
-# Start a review loop for a PR
-python scripts/internal/review_driver.py --pr 42 --branch feature-branch
+# Start a review loop for a PR (normally triggered by hook)
+python scripts/internal/review_driver.py --pr 42 --branch feature-branch --trigger pr_created
 
 # Resume after CI completes
 python scripts/internal/review_driver.py --pr 42 --trigger ci_complete
+
+# Manual trigger (recovery)
+python scripts/internal/review_driver.py --pr 42 --trigger manual
 
 # Check state
 cat .claude/runtime/review_loops/pr_42/state.json
 ```
 
+## Recovery
+
+If the loop crashes or gets stuck:
+
+1. **Check state:**
+   ```bash
+   cat .claude/runtime/review_loops/pr_<N>/state.json
+   ```
+
+2. **Manual rerun:**
+   ```bash
+   python scripts/internal/review_driver.py --pr <N> --trigger manual
+   ```
+
+3. **Admin override** (skip review, unblock merge):
+   ```bash
+   scripts/internal/set_review_status.sh success "Manual override"
+   ```
+
+4. **Fallback workflow:** `review_status_fallback.yml` posts a comment after
+   1 hour if status remains `pending`.
+
+The loop's crash recovery publishes a `failure` status with a recovery
+command in the description, so the PR is never silently stuck.
+
 ## Governing Plan
 
 See `plans/archive/2026-03-08_autonomous-review-loop.md` for the full
 design, state transitions, stop conditions, and implementation sequence.
+
+Activation plan: plans/sessions/2026-03-11_autonomous-review-loop-activation.md


### PR DESCRIPTION
## Summary
- Rewrite `/reviewing-changes` from 446-line HITL skill to ~80-line fast dispatcher
- Enable autonomous review loop by removing rollout guard from `post-pr-review-loop.sh`
- Update handoff template for loop-based workflow (run ID, state dir, recovery command)
- Update `60_review_gate.md` and `AUTONOMOUS_REVIEW_LOOP.md` to reflect activated state

## Why
Completes the autonomous review loop activation. Post-PR review now takes ~5s in-session (dispatcher publishes pending + generates handoff). All quality review happens asynchronously via `review_driver.py` — prechecks, make check, Codex CLI, auto-fix, status publishing, and follow-up issues.

## Repro / Validation
```bash
make check-quiet
```

## Tests
No new Python tests — this PR modifies skill definitions, hooks, and documentation only.
Existing review infrastructure tests cover the loop driver behavior:
```bash
uv run python -m pytest tests/unit/test_review_state.py tests/unit/test_codex_review_adapter.py tests/unit/test_deterministic_prechecks.py -v
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/slim-reviewing-changes
show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/slim-reviewing-changes
branch: feat/slim-reviewing-changes
worktree list (relevant):
  .../Bid-Euchre [main]
  .../.claude/worktrees/slim-reviewing-changes [feat/slim-reviewing-changes]
```

Part 3/3 of the autonomous review loop activation plan.
See plans/sessions/2026-03-11_autonomous-review-loop-activation.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)