### PR TITLE
docs: add plan review rubric + extend /reviewing-plans with research checks

### DIFF
--- a/.claude/skills/reviewing-plans/SKILL.md
+++ b/.claude/skills/reviewing-plans/SKILL.md
@@ -32,6 +32,10 @@ Check each item. Use Glob/Grep/Read to verify against actual repo state.
 | P8 | Experiment plans specify sample size and success criteria | Check for N=, threshold, CI requirements | `05_rigor.md` |
 | P9 | Template completeness: Goal, Plan/Steps, Files, Outcome | Check for required section headers | New convention |
 | P10 | Notebook changes note jupytext sync requirement | Check if plan touches `notebooks/` | `45_notebook_boundary.md` |
+| P11 | Research plans state testable hypotheses with expected bounds | Check for measurable success/failure criteria (thresholds, CIs, effect sizes) — not just "improve X" | `PLAN_REVIEW_RUBRIC.md` §1 |
+| P12 | Multi-step plans isolate one variable per step | Check that each step/rung changes one factor (architecture, objective, data, or evaluation) — flag confounded comparisons | `PLAN_REVIEW_RUBRIC.md` §5 |
+| P13 | Report-producing plans specify artifact provenance | Check that claims trace to committed artifacts (JSON/CSV) with run IDs and generating scripts — not just notebook outputs | `PLAN_REVIEW_RUBRIC.md` §3, `45_notebook_boundary.md` |
+| P14 | Multi-mode plans define per-tier evidence contracts | Check that SMOKE/QUICK/FULL tiers each specify what evidence is produced and what decisions each tier supports | `PLAN_REVIEW_RUBRIC.md` §12 |
 
 **Scoring:**
 - **PASS** — check satisfied
@@ -90,5 +94,7 @@ NEEDS ATTENTION = any FLAG or critical WARN found.
 - **Read-only review.** Do not edit the plan file or any other file.
 - **Verify against disk.** Always Glob/Read to check claims — don't trust path references without verification.
 - **New files are exempt from P1.** If the plan says "Create `foo.py`", don't flag it as missing.
-- **SKIP generously.** If a check category doesn't apply (e.g., no experiments → skip P3/P8), mark SKIP and move on.
+- **SKIP generously.** If a check category doesn't apply (e.g., no experiments → skip P3/P8, single-step plan → skip P12), mark SKIP and move on.
+- **P11–P14 are research-plan checks.** SKIP all four for pure code/bugfix/refactor plans. They apply when the plan involves experiments, multi-rung evaluation, or report generation.
 - **Don't expand scope.** Review only what the plan describes. Don't suggest additional features or improvements.
+- **For governing plans**, recommend the full rubric review from `docs/02_agent/PLAN_REVIEW_RUBRIC.md` in addition to this tactical checklist.

--- a/docs/02_agent/PLAN_REVIEW_RUBRIC.md
+++ b/docs/02_agent/PLAN_REVIEW_RUBRIC.md
@@ -1,0 +1,257 @@
+# Plan Review Rubric
+
+Weighted rubric for evaluating governing plans (multi-rung research designs,
+lineage rebuilds, canonical plan revisions). Complements the tactical
+`/reviewing-plans` skill, which handles convention compliance for session-scoped
+plans.
+
+**When to use this rubric:**
+- Governing plans that span multiple rungs or PRs
+- Lineage rebuild plans
+- Any plan that defines a multi-step research program with promotion gates
+
+**When `/reviewing-plans` is sufficient:**
+- Session-scoped plans (single PR)
+- Bugfix or small feature plans
+- Plans with no experimental evaluation component
+
+## Scoring Model
+
+Score each dimension `0–5`. Multiply by the dimension weight. Normalize to 0–100:
+
+```
+Total = Σ(weight_i × score_i) / (5 × 100) × 100
+```
+
+Since weights sum to 100, this simplifies to:
+
+```
+Total = Σ(weight_i × score_i) / 5
+```
+
+Suggested scale:
+- `5`: fully specified, low ambiguity, directly usable
+- `4`: strong, small gaps, low execution risk
+- `3`: adequate but materially underspecified
+- `2`: weak, high agent guesswork required
+- `1`: major gaps, not reliable
+- `0`: absent or contradictory
+
+Suggested thresholds:
+- `90–100`: governing-plan ready
+- `75–89`: strong, needs targeted fixes
+- `60–74`: directionally right, still underspecified
+- `<60`: not safe for agent execution
+
+## Weighted Dimensions
+
+| Dimension | Weight |
+|---|---:|
+| Research validity | 14 |
+| Agent executability | 13 |
+| Reporting traceability | 10 |
+| Reporting communication quality | 10 |
+| Ablation integrity | 9 |
+| Tooling alignment | 8 |
+| Metric contract quality | 7 |
+| Data-generation consistency | 7 |
+| Roster and lineage governance | 4 |
+| Decision usefulness | 3 |
+| Human review ergonomics | 3 |
+| Evaluation economics | 3 |
+| Knowledge transfer | 3 |
+| Operational sustainability | 2 |
+| Historical continuity | 2 |
+| Failure containment | 2 |
+| **Total** | **100** |
+
+## Rubric Questions
+
+### 1. Research validity — 14%
+- Does the plan produce evidence that answers the actual research questions?
+- Are the core hypotheses measurable and tied to the decisions the lineage is supposed to support?
+- Does the plan avoid confounding model class, objective, context, label-generation policy, and evaluation setup?
+- Would a reviewer trust the conclusions the plan is designed to produce?
+- Does the plan pre-specify what evidence would trigger ADVANCE vs HALT vs INVESTIGATE at each rung boundary?
+
+### 2. Agent executability — 13%
+- Can a future agent execute a rung end to end from the plan alone?
+- Are commands, inputs, outputs, schemas, directories, and artifact contracts concrete?
+- Are sample sizes, seeds, validation checks, and rerun rules explicit?
+- Is there a clear fallback or blocking rule when required infrastructure is not yet implemented?
+
+### 3. Reporting traceability — 10%
+- Can every major claim trace to a table/chart ID?
+- Can every table/chart trace to a CSV/JSON artifact?
+- Can every artifact trace to a run ID, config, and generating script?
+- Does the plan prohibit hand-maintained metrics in canonical reports?
+
+### 4. Reporting communication quality — 10%
+
+*Scope: narrative content, findings clarity, story structure.*
+
+- Do the reports make the story of the rung understandable quickly?
+- Are main findings, surprises, decisions, and risks surfaced clearly?
+- Are charts and tables complementary rather than redundant?
+- Can HITL or a future agent understand what mattered from the report narrative alone, without cross-referencing artifacts?
+
+### 5. Ablation integrity — 9%
+- Does each rung isolate a small enough change to support interpretation?
+- Are rung-to-rung comparisons clean and consistent?
+- Are independent experimental factors (architecture, objective, data, evaluation) varied one at a time across rungs?
+- Can the plan support a defensible "what changed and why?" narrative?
+
+### 6. Tooling alignment — 8%
+- Does the plan match the repo's current scripts, CLIs, artifact formats, and model interfaces?
+- Are unsupported workflows explicitly marked as required implementation work?
+- Are file paths, config patterns, and command shapes consistent with the codebase?
+- Would a future agent avoid inventing missing flags or unsupported execution paths?
+
+### 7. Metric contract quality — 7%
+- Are the canonical metrics fixed and consistently defined?
+- Are offline, gameplay, behavioral, and decision metrics separated clearly?
+- Are required contract-type facets fixed across all reports?
+- Are table schemas precise enough that different agents would generate the same outputs?
+
+### 8. Data-generation consistency — 7%
+- Is the training/eval data contract stable across rungs?
+- Are continuation policy, feature extraction, context bundles, and label generation clearly defined?
+- Are seed and sample-size policies fixed by mode?
+- Would rerunning the same rung under the same config reproduce the same evidence package?
+
+### 9. Roster and lineage governance — 4%
+- Is the active roster clearly defined?
+- Are frozen references, active models, legacy baselines, and exploratory entrants distinguished cleanly?
+- Are amendment rules for adding/removing models explicit?
+- Are exclusions and status labels defined well enough to prevent silent drift?
+
+### 10. Decision usefulness — 3%
+- Does each rung end with a clear decision artifact?
+- Does the plan require explicit hypotheses, expected bounds, and observed outcomes?
+- Is it easy to tell whether the next action is proceed, investigate, pause, or redirect?
+- Does the plan help guide the next rung rather than only record the last one?
+
+### 11. Human review ergonomics — 3%
+
+*Scope: file layout, directory structure, artifact naming, navigation.*
+
+- Can a human reviewer audit a rung quickly without opening raw logs or notebooks?
+- Are the most important tables, charts, and summaries surfaced at the top level of the evidence package?
+- Is the directory/artifact structure easy to navigate without a guide?
+- Does the plan minimize the number of files a reviewer must open to form a judgment?
+
+### 12. Evaluation economics — 3%
+- Is the cost of QUICK and FULL evaluations proportionate to the decision value they provide?
+- Does the plan clearly distinguish what evidence is required at SMOKE, QUICK, and FULL?
+- Are expensive artifacts justified by the research questions?
+- Is there a clear way to screen cheaply before paying for full evidence?
+
+### 13. Knowledge transfer — 3%
+- Could a new agent understand the lineage's operating model from this plan?
+- Are naming conventions, artifact semantics, and execution expectations explained clearly?
+- Does the plan reduce dependence on legacy tribal knowledge?
+- Could the next agent avoid rereading the entire repo to operate correctly?
+
+### 14. Operational sustainability — 2%
+- Is the reporting and artifact burden realistic to maintain?
+- Are runtime, storage, and regeneration costs manageable across multiple rungs?
+- Can the process survive repeated use without collapsing into overhead?
+- Does the plan avoid unnecessary report/file sprawl?
+
+### 15. Historical continuity — 2%
+- Does the new lineage remain interpretable relative to legacy `R0` work?
+- Are frozen legacy references used thoughtfully for continuity?
+- Can reviewers answer "better than old R0?" from the canonical reports?
+- Does the rebuild preserve useful comparability without inheriting old confusion?
+
+### 16. Failure containment — 2%
+- Does the plan define how to quarantine bad runs or broken artifacts?
+- Are rerun, supersession, and invalidation rules explicit?
+- Can a bad rung be isolated without contaminating later ones?
+- Is canonical vs exploratory failure handling clear?
+
+## Hard Gates
+
+Override checks — if any gate FAILs, the verdict is **Not Ready** regardless of
+the weighted score.
+
+| Gate | What It Checks |
+|---|---|
+| R0* definition | Concrete frozen baseline exists and is referenced |
+| Canonical rung definition | Each rung/context bundle has a singular canonical specification |
+| Executable runbook | At least one rung has step-by-step executable instructions |
+| Fixed metric/table schema | Canonical metrics and report table schemas are pinned |
+| Evidence/provenance contract | Artifact → run ID → config traceability chain is defined |
+| Stable data-generation policy | Continuation policy, labels, and seeds are fixed across rungs |
+| Tooling existence | Any required tooling that doesn't exist is marked as implementation work with block/fallback behavior |
+| Contract consistency | Canonical report contract does not contradict the evidence contract |
+
+## Output Template
+
+```markdown
+# Plan Rubric Review
+
+## Summary
+- Plan: <path>
+- Reviewer: <agent/human>
+- Date: <YYYY-MM-DD>
+- Total Score: <0–100>
+- Verdict: <Ready / Needs Targeted Fixes / Underspecified / Not Ready>
+
+## Hard Gate Check
+
+| Gate | Status | Notes |
+|---|---|---|
+| R0* definition | PASS/FAIL | ... |
+| Canonical rung definition | PASS/FAIL | ... |
+| Executable runbook | PASS/FAIL | ... |
+| Fixed metric/table schema | PASS/FAIL | ... |
+| Evidence/provenance contract | PASS/FAIL | ... |
+| Stable data-generation policy | PASS/FAIL | ... |
+| Tooling existence | PASS/FAIL | ... |
+| Contract consistency | PASS/FAIL | ... |
+
+> Hard gate FAIL → verdict is "Not Ready" regardless of total score.
+
+## Findings
+
+| Severity | Dimension | Finding |
+|---|---|---|
+| CRITICAL | <dimension name> | <finding> |
+| WARNING | <dimension name> | <finding> |
+
+## Dimension Scores
+
+| Dimension | Weight | Score (0–5) | Weighted | Notes |
+|---|---:|---:|---:|---|
+| Research validity | 14 |  |  |  |
+| Agent executability | 13 |  |  |  |
+| Reporting traceability | 10 |  |  |  |
+| Reporting communication quality | 10 |  |  |  |
+| Ablation integrity | 9 |  |  |  |
+| Tooling alignment | 8 |  |  |  |
+| Metric contract quality | 7 |  |  |  |
+| Data-generation consistency | 7 |  |  |  |
+| Roster and lineage governance | 4 |  |  |  |
+| Decision usefulness | 3 |  |  |  |
+| Human review ergonomics | 3 |  |  |  |
+| Evaluation economics | 3 |  |  |  |
+| Knowledge transfer | 3 |  |  |  |
+| Operational sustainability | 2 |  |  |  |
+| Historical continuity | 2 |  |  |  |
+| Failure containment | 2 |  |  |  |
+| **Total** | **100** |  | **<sum>** |  |
+
+> Total Score = sum of weighted column / 5
+
+## Strengths
+- <bullet>
+
+## Gaps
+- <bullet>
+
+## Priority Fixes
+1. <highest-value fix>
+2. <next fix>
+3. <next fix>
+```


### PR DESCRIPTION
## Plan
- N/A (process improvement, not code change)

## Summary
- Add `docs/02_agent/PLAN_REVIEW_RUBRIC.md` — 16-dimension weighted rubric for evaluating governing plans (multi-rung research designs, lineage rebuilds)
- Extend `/reviewing-plans` skill with 4 new checks (P11–P14) drawn from the rubric's highest-weight uncovered dimensions

## Why
The existing `/reviewing-plans` skill is a **tactical checklist** (real paths, seeds, import boundaries, testing strategy) optimized for session-scoped plans. It doesn't evaluate whether a plan will produce trustworthy research evidence — are hypotheses measurable? Are variables isolated across rungs? Can claims trace to artifacts? The rubric fills this gap for governing plans, and P11–P14 bring the most impactful checks into the tactical flow.

## Changes

### New: `docs/02_agent/PLAN_REVIEW_RUBRIC.md`
- 16 weighted dimensions summing to 100 (research validity 14%, agent executability 13%, down to failure containment 2%)
- Explicit normalization formula: `Total = Σ(weight × score) / 5`
- 8 hard gates that override the weighted score (e.g., no R0* definition → Not Ready regardless of score)
- Structured output template with hard gate check, severity-linked findings table, and dimension scores
- Threshold bands: 90–100 (ready), 75–89 (targeted fixes), 60–74 (underspecified), <60 (not safe)

### Updated: `.claude/skills/reviewing-plans/SKILL.md`
- **P11** — Research plans state testable hypotheses with expected bounds (from rubric §1: research validity)
- **P12** — Multi-step plans isolate one variable per step (from rubric §5: ablation integrity)
- **P13** — Report-producing plans specify artifact provenance (from rubric §3: reporting traceability)
- **P14** — Multi-mode plans define per-tier evidence contracts (from rubric §12: evaluation economics)
- All four SKIP for pure code/bugfix/refactor plans
- Added note recommending full rubric review for governing plans

## Repro / Validation
**Command(s) run:**
- `make check-quiet` — all checks passed

**Config (if applicable):**
- N/A (docs + skill only)

**Seed (if applicable):**
- N/A

## Tests
- [x] `make check-quiet` passes (docs-only PR, no Python changes)
- [ ] Other: N/A

## Expected impact
- Metrics impact (if any): none
- Runtime impact (if any): none

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-plan-rubric
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-plan-rubric
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre              4f622ee [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-plan-rubric  8ee5ade [plan-review-rubric]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)