### PR TITLE
docs: add CLAUDE.md rules from insights friction analysis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,8 @@ Bid Euchre AI Research Framework — a Python framework for deterministic simula
 
 - Always create a **plan** before implementing. Never start coding without an explicit written plan unless the user says otherwise.
 - When the user asks for a "plan", produce ONLY a written plan document — do NOT begin implementation.
+- When asked to discuss, analyze, or explore, stay in discussion mode — do not start writing code unless explicitly asked.
+- Before claiming data, files, or APIs don't exist, verify with Grep and Read. Never assume absence — always check the actual codebase.
 - Always ask clarifying questions about scope before starting multi-PR plans.
 - Save plans as markdown files in a `plans/` directory.
 - Do not use EnterPlanMode as a substitute for file-based planning — always write plans as markdown files. Users may still invoke `/plan` for interactive exploration.
@@ -42,6 +44,8 @@ Bid Euchre AI Research Framework — a Python framework for deterministic simula
 - When creating plans, read the actual source code and API signatures first — never guess.
 - Plans must reference real file paths, real function names, and real parameter signatures from the codebase.
 - If the user provides their own plan structure, adopt it rather than proposing an alternative.
+- Before presenting a plan, verify ALL outstanding items (DoD, blockers, open work items) against the plan document. Never skip items that are explicitly listed.
+- After drafting a plan, self-audit for internal contradictions (e.g., mandating something in one section while exempting it in another) and verify all file paths and output paths against the actual repo before presenting.
 
 ## Python
 


### PR DESCRIPTION
## Plan
N/A — trivial docs change driven by Claude Code `/insights` report.

## Summary
- Add 4 CLAUDE.md rules targeting the top friction source (59 wrong-approach events) identified by usage insights

## Why
Claude Code usage insights (260 sessions analyzed) identified recurring friction patterns:
1. Claude jumping to implementation during discussion/exploration (not just "plan" requests)
2. Claude claiming files/APIs don't exist without verifying
3. Plans missing outstanding DoD items that were explicitly listed
4. Plans containing internal contradictions (mandating + exempting the same thing)

Existing rules partially covered #1 and #3 but weren't specific enough to prevent the behavior in practice.

## Repro / Validation
**Command(s) run:**
- `git diff main` — verified 4 new lines, no other changes

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] Docs-only change, no code affected

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-insights-claude-rules
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-insights-claude-rules
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                        4f622ee [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-insights-claude-rules  245389b [insights-claude-rules]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)