### PR TITLE
docs: add step dependency annotation to plan review rubric + P15

### DIFF
--- a/.claude/skills/reviewing-plans/SKILL.md
+++ b/.claude/skills/reviewing-plans/SKILL.md
@@ -36,6 +36,7 @@ Check each item. Use Glob/Grep/Read to verify against actual repo state.
 | P12 | Multi-step plans isolate one variable per step | Check that each step/rung changes one factor (architecture, objective, data, or evaluation) — flag confounded comparisons | `PLAN_REVIEW_RUBRIC.md` §5 |
 | P13 | Report-producing plans specify artifact provenance | Check that claims trace to committed artifacts (JSON/CSV) with run IDs and generating scripts — not just notebook outputs | `PLAN_REVIEW_RUBRIC.md` §3, `45_notebook_boundary.md` |
 | P14 | Multi-mode plans define per-tier evidence contracts | Check that SMOKE/QUICK/FULL tiers each specify what evidence is produced and what decisions each tier supports | `PLAN_REVIEW_RUBRIC.md` §12 |
+| P15 | Multi-step plans annotate step dependencies | Check that plans with 4+ artifact-producing steps declare what each step requires and produces — flag steps that consume another step's output without noting the dependency | `PLAN_REVIEW_RUBRIC.md` §2 |
 
 **Scoring:**
 - **PASS** — check satisfied
@@ -96,5 +97,6 @@ NEEDS ATTENTION = any FLAG or critical WARN found.
 - **New files are exempt from P1.** If the plan says "Create `foo.py`", don't flag it as missing.
 - **SKIP generously.** If a check category doesn't apply (e.g., no experiments → skip P3/P8, single-step plan → skip P12), mark SKIP and move on.
 - **P11–P14 are research-plan checks.** SKIP all four for pure code/bugfix/refactor plans. They apply when the plan involves experiments, multi-rung evaluation, or report generation.
+- **P15 applies to any plan with 4+ artifact-producing steps.** SKIP for plans with fewer steps or where all steps are legitimately linear (each step's input is the prior step's output). The check targets plans that serialize independent work without noting it — not plans that are inherently sequential.
 - **Don't expand scope.** Review only what the plan describes. Don't suggest additional features or improvements.
 - **For governing plans**, recommend the full rubric review from `docs/02_agent/PLAN_REVIEW_RUBRIC.md` in addition to this tactical checklist.

--- a/docs/02_agent/PLAN_REVIEW_RUBRIC.md
+++ b/docs/02_agent/PLAN_REVIEW_RUBRIC.md
@@ -79,6 +79,7 @@ Suggested thresholds:
 - Are commands, inputs, outputs, schemas, directories, and artifact contracts concrete?
 - Are sample sizes, seeds, validation checks, and rerun rules explicit?
 - Is there a clear fallback or blocking rule when required infrastructure is not yet implemented?
+- For plans with multiple artifact-producing steps: are dependencies between steps annotated (what each step requires and produces), so an agent can identify independent work and avoid unnecessary serialization?
 
 ### 3. Reporting traceability — 10%
 - Can every major claim trace to a table/chart ID?


### PR DESCRIPTION
## Plan
- Follow-up to #638 (plan review rubric)

## Summary
- Add dependency clarity question to Agent executability (§2) in the plan review rubric
- Add P15 check to `/reviewing-plans` skill for step dependency annotation

## Why
Without explicit dependency annotation, agents default to serial execution of numbered steps — even when steps are independent. This is systematically conservative and wastes wall-clock time proportional to the number of independent steps × per-step latency. Framing this as "what does each step require and produce" (not "what can run in parallel") keeps the annotation grounded in I/O contracts, with parallelism derivable from the dependency structure.

## Changes

### `docs/02_agent/PLAN_REVIEW_RUBRIC.md`
Added 5th question to Agent executability (§2):
> For plans with multiple artifact-producing steps: are dependencies between steps annotated (what each step requires and produces), so an agent can identify independent work and avoid unnecessary serialization?

This is a scored criterion, not a hard gate — governing plans that define contracts but not execution DAGs should not be penalized.

### `.claude/skills/reviewing-plans/SKILL.md`
- **P15**: Multi-step plans annotate step dependencies — flags plans with 4+ artifact-producing steps that consume another step's output without noting the dependency
- Applicability note: SKIPs for plans with fewer steps or legitimately linear workflows
- Targets plans that serialize independent work without noting it — not plans that are inherently sequential

## Repro / Validation
**Command(s) run:**
- `make check-quiet` — all checks passed

## Tests
- [x] `make check-quiet` passes (docs-only PR)

## Expected impact
- Metrics impact: none
- Runtime impact: none

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-plan-rubric
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-plan-rubric
```

`git worktree list` (abbreviated):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre              857febc [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-plan-rubric  86fc38e [plan-dependency-annotations]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)