### PR TITLE
fix: update doc references after plans directory restructuring

### DIFF
--- a/docs/01_core/FEATURE_REGISTRY.md
+++ b/docs/01_core/FEATURE_REGISTRY.md
@@ -154,4 +154,4 @@ partner's contract choice) and potentially positional features. These are planne
 but not yet implemented. The feature count will increase and the schema version
 will bump accordingly.
 
-See `plans/archive/r1_master_plan.md` for the R1 feature enrichment roadmap.
+See `plans/archive/pre_v1/r1_master_plan.md` for the R1 feature enrichment roadmap.

--- a/docs/01_core/HYPERPARAMETER_REGISTRY.md
+++ b/docs/01_core/HYPERPARAMETER_REGISTRY.md
@@ -53,7 +53,7 @@ Controls when the bidder passes instead of bidding. The pass rule is:
 - **Tuning:** Pre-registered sweep protocol per rung.
 - **R0 result:** RETAIN t=0 (monotonic decline in net_eppd with positive t;
   attributed to model accuracy limitations at R0 feature count).
-- **R0 tuning protocol:** See archived `plans/archive/r0_pass_threshold_protocol.md`.
+- **R0 tuning protocol:** See archived `plans/archive/pre_v1/r0_pass_threshold_protocol.md`.
 - **R1+ tuning:** Re-use protocol template with updated data source and
   potentially adjusted SESOI.
 
@@ -73,7 +73,7 @@ Controls the tradeoff between expected value and prediction uncertainty.
 - **Tuning:** Manual at R0; planned automated sweep at R3+.
 - **R0 result:** RETAIN lambda=0.0 (self-play improvement of +0.884 reversed to
   -1.15 in H2H; risk aversion not justified at current model accuracy).
-- **R0 tuning protocol:** See archived `plans/archive/r0_v2_lambda_tuning_protocol.md`.
+- **R0 tuning protocol:** See archived `plans/archive/pre_v1/r0_v2_lambda_tuning_protocol.md`.
 
 ### Feature Set (F)
 
@@ -92,7 +92,7 @@ different feature sets.
 ## Cross-Rung Evolution
 
 Parameters are re-tuned at each rung because the training data, feature set, and
-model accuracy change. The R1 master plan (`plans/archive/r1_master_plan.md`) specifies
+model accuracy change. The R1 master plan (`plans/archive/pre_v1/r1_master_plan.md`) specifies
 the tuning schedule for the next rung.
 
 Key expectation for R1: enriched features (partner context, positional) will shift

--- a/docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md
+++ b/docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md
@@ -172,7 +172,7 @@ command in the description, so the PR is never silently stuck.
 
 ## Governing Plan
 
-See `plans/archive/2026-03-08_autonomous-review-loop.md` for the full
+See `plans/archive/pre_v1/2026-03-08_autonomous-review-loop.md` for the full
 design, state transitions, stop conditions, and implementation sequence.
 
 Activation plan: plans/sessions/2026-03-11_autonomous-review-loop-activation.md

--- a/docs/04_reports/r0/10_contract_selection_oracle.md
+++ b/docs/04_reports/r0/10_contract_selection_oracle.md
@@ -350,7 +350,7 @@ prescribed remedy addressed only the minority of the problem.
 ### 5.2 Decision: Path B + B0 Threshold Tuning
 
 **Selected:** Path B (skip calibrator) + Path C sidecar (threshold tuning).
-Decision made 2026-03-01; see `plans/archive/MASTER_PLAN.md` Phase B.
+Decision made 2026-03-01; see `plans/archive/pre_v1/MASTER_PLAN.md` Phase B.
 
 **Path B — Skip calibrator, finalize R0, address in R1:**
 - Calibrator addresses only 17% of regret → disproportionate effort
@@ -360,7 +360,7 @@ Decision made 2026-03-01; see `plans/archive/MASTER_PLAN.md` Phase B.
 **B0 — Pass-threshold tuning (added as pre-registered protocol):**
 - A pre-registered sweep of the pass threshold `t` (where `utility <= -t → pass`)
   on the existing oracle data, split 60/40 by deal_id
-- Protocol: `plans/archive/r0_pass_threshold_protocol.md` (v1)
+- Protocol: `plans/archive/pre_v1/r0_pass_threshold_protocol.md` (v1)
 - Quick analysis (~1 notebook), doesn't require new models
 - If meaningful improvement found (SESOI = 0.05 net_diff), threshold is adopted
   as an R0 hyperparameter before report finalization

--- a/docs/04_reports/r0/11_pass_threshold_decision.md
+++ b/docs/04_reports/r0/11_pass_threshold_decision.md
@@ -48,7 +48,7 @@ to the pass-threshold — the model passes on hands where the oracle (with perfe
 hindsight) would profitably bid. This B0 sweep investigates whether shifting the
 pass gate from `utility ≤ 0` to `utility ≤ -t` recovers value.
 
-**Protocol:** `plans/archive/r0_pass_threshold_protocol.md` v1 (pre-registered)
+**Protocol:** `plans/archive/pre_v1/r0_pass_threshold_protocol.md` v1 (pre-registered)
 
 ## 2. Methodology
 
@@ -147,7 +147,7 @@ No code changes. The pass gate at `bidding.py:1043` remains `best_utility <= 0`.
 | Item | Value |
 |------|-------|
 | gate_status | RETAIN (B0 decision gate — no code change) |
-| Protocol | `plans/archive/r0_pass_threshold_protocol.md` v1 |
+| Protocol | `plans/archive/pre_v1/r0_pass_threshold_protocol.md` v1 |
 | Notebook | `notebooks/arc_d/r0/56_pass_threshold_sweep.py` |
 | Dataset | `canonical_bidless_dataset_glutton_42_20260221_175752` |
 | Model artifact | data/artifacts/arc_d/r0/hybrid_r0.json |

--- a/docs/04_reports/r0/12_lambda_decision.md
+++ b/docs/04_reports/r0/12_lambda_decision.md
@@ -51,7 +51,7 @@ canonical config surfaces carry explicit `risk_lambda: 0.0` entries awaiting the
 of this protocol. This Track D investigation determines whether a non-zero lambda
 improves competitive performance.
 
-**Protocol:** `plans/archive/r0_v2_lambda_tuning_protocol.md` (v1, amended to v4)
+**Protocol:** `plans/archive/pre_v1/r0_v2_lambda_tuning_protocol.md` (v1, amended to v4)
 
 **Dependency:** Track D runs sequentially after Track C (pass-threshold tuning). The
 Track C result (RETAIN t=0, see [11_pass_threshold_decision.md](11_pass_threshold_decision.md))
@@ -253,7 +253,7 @@ Since the decision is RETAIN, no config surface changes are needed. The existing
 | Item | Value |
 |------|-------|
 | gate_status | RETAIN (D0 decision gate -- no code change) |
-| Protocol | `plans/archive/r0_v2_lambda_tuning_protocol.md` v1 (amended to v4) |
+| Protocol | `plans/archive/pre_v1/r0_v2_lambda_tuning_protocol.md` v1 (amended to v4) |
 | Sweep artifact | data/artifacts/arc_d/r0/lambda_sweep_selfplay_v1.json |
 | Sweep script | `scripts/internal/run_lambda_sweep.py` |
 | Analysis notebook | `notebooks/arc_d/r0/59_lambda_simulation_sweep.py` |

--- a/docs/04_reports/r0/14_onemodel_decision.md
+++ b/docs/04_reports/r0/14_onemodel_decision.md
@@ -1,7 +1,7 @@
 # OneModel Decision Report: RETAIN Separate Models
 
 **Track:** F (Unified Cross-Contract Model)
-**Protocol:** `plans/archive/r0_v2_onemodel_protocol.md` v1
+**Protocol:** `plans/archive/pre_v1/r0_v2_onemodel_protocol.md` v1
 **Date:** 2026-03-03
 **Decision:** RETAIN separate per-contract models
 **Gate status:** FAIL (delta < 0)
@@ -213,7 +213,7 @@ Despite the negative result, this protocol execution provides:
 
 | Item | Value |
 |------|-------|
-| Protocol | `plans/archive/r0_v2_onemodel_protocol.md` v1 |
+| Protocol | `plans/archive/pre_v1/r0_v2_onemodel_protocol.md` v1 |
 | Decision | RETAIN separate per-contract models |
 | Training seed | 42 |
 | Bootstrap seed | 42 |

--- a/docs/04_reports/r0/21_r0_retrospective.md
+++ b/docs/04_reports/r0/21_r0_retrospective.md
@@ -245,7 +245,7 @@ iterations by leveraging the conventions and infrastructure already established.
 ### Automate progression reports
 
 The Phase 0→R0 progression report (#484) was manually authored. P7 in
-`plans/r1_follow_ups.md` calls for automating rung-to-rung progression reports —
+`plans/archive/v1_root/r1_follow_ups.md` calls for automating rung-to-rung progression reports —
 this should be implemented early in R1 to reduce per-rung overhead.
 
 ### Expand fail-fast gates

--- a/docs/04_reports/r1/h2h_suit_regression_diagnostic.md
+++ b/docs/04_reports/r1/h2h_suit_regression_diagnostic.md
@@ -29,8 +29,8 @@ and lays out a concrete investigation plan with reproduction commands.
 - Training pipeline: `src/bid_euchre/models/train_hybrid_olsa.py`
 - Runtime bidding: `src/bid_euchre/strategy/bidding.py` (HybridOLSaBidder)
 - Partner feature extraction: `src/bid_euchre/features/auction_context.py`
-- R1 training plan: `plans/archive/r1_training_plan.md`
-- R1 master plan: `plans/archive/r1_master_plan.md`
+- R1 training plan: `plans/archive/pre_v1/r1_training_plan.md`
+- R1 master plan: `plans/archive/pre_v1/r1_master_plan.md`
 
 **Investigation priority order:**
 
@@ -1330,7 +1330,7 @@ replace the coarse partner representation with suit-aware interaction features:
 These are candidate-contract-relative (computed per suit being evaluated) and apply
 to suit contracts only. HIGH/LOW retain simpler partner handling.
 
-See `plans/archive/r1_master_plan.md` §10.3a for full R1.6 specification.
+See `plans/archive/pre_v1/r1_master_plan.md` §10.3a for full R1.6 specification.
 
 ### Investigation K: H10 Validation Pack — Analytical Proof + `bid_bonus` Fix
 

--- a/docs/04_reports/r1/partner_feature_selection_diagnostic.md
+++ b/docs/04_reports/r1/partner_feature_selection_diagnostic.md
@@ -147,7 +147,7 @@ consistent cross-validated improvement — harder to achieve with small samples.
 **R1.6/R2:** Partner-semantics redesign happens at R1.6 (suit-aware features replacing
 coarse partner_suit_match). R1.5 is the objective-alignment rung. High/low confirmation
 with rebalanced data at R1.6 or R2 depending on data availability. See
-`plans/r1_follow_ups.md` item P10 and `plans/r2_follow_ups.md` F1 for the
+`plans/archive/v1_root/r1_follow_ups.md` item P10 and `plans/archive/v1_root/r2_follow_ups.md` F1 for the
 pre-registered protocol.
 
 ## 7. Provenance

--- a/docs/04_reports/r1_5/07_promotion_decision.md
+++ b/docs/04_reports/r1_5/07_promotion_decision.md
@@ -127,5 +127,5 @@ variance in predictions. Currently using QUICK-trained models.
 | Ablation report | [06_ablation.md](06_ablation.md) |
 | QUICK H2H report | [03_h2h_battery_quick.md](03_h2h_battery_quick.md) |
 | Risk treatment | [04_risk_treatment.md](04_risk_treatment.md) — SKIPPED |
-| Governing plan | `plans/r1_5_training_plan.md` |
+| Governing plan | `plans/archive/v1_root/r1_5_training_plan.md` |
 | analysis_base_sha | c15f7dd |

--- a/docs/04_reports/r1_5/10_model_label_matrix.md
+++ b/docs/04_reports/r1_5/10_model_label_matrix.md
@@ -4,7 +4,7 @@
 **Arc:** D — OLSa-Hybrid Bidder
 **Rung:** R1.5.3 (model-architecture exploration)
 **Predecessor:** `09_multi_rollout_diagnostic.md` (H14 CONFIRMED), `08_gbt_prototype_evaluation.md` (GBT QUICK)
-**Plan:** `plans/sessions/2026-03-12_r1-5-3-forward-plan-v2.md`, Phase 1A
+**Plan:** `plans/archive/v1_sessions/2026-03-12_r1-5-3-forward-plan-v2.md`, Phase 1A
 
 ## 1. Goal
 

--- a/docs/04_reports/r1_5/12_gbt_full_validation.md
+++ b/docs/04_reports/r1_5/12_gbt_full_validation.md
@@ -4,7 +4,7 @@
 **Rung:** R1.5.3 (model-architecture exploration)
 **Date:** 2026-03-13
 **Predecessor:** [08_gbt_prototype_evaluation.md](08_gbt_prototype_evaluation.md) (GBT QUICK — PROTOTYPE VALIDATED)
-**Plan:** `plans/sessions/2026-03-12_r1-5-3-forward-plan-v2.md`, Phase 2
+**Plan:** `plans/archive/v1_sessions/2026-03-12_r1-5-3-forward-plan-v2.md`, Phase 2
 
 ## 1. Goal
 

--- a/docs/04_reports/r1_5/13_r1_5_3_promotion_decision.md
+++ b/docs/04_reports/r1_5/13_r1_5_3_promotion_decision.md
@@ -209,7 +209,7 @@ R1.6 extends partner features from 3 → 4 with suit-relative channels:
 Schema: v7 (52 features) → v8 (53 features). PR #631 (artifact-driven feature
 extraction) enables v7/v8 coexistence in H2H batteries.
 
-Plan: `plans/sessions/2026-03-13_r1-6-partner-semantics.md`
+Plan: `plans/archive/v1_sessions/2026-03-13_r1-6-partner-semantics.md`
 
 ## 6. Timeline (R1.5.3)
 
@@ -235,7 +235,7 @@ Plan: `plans/sessions/2026-03-13_r1-6-partner-semantics.md`
 | Two-stage report | [11_two_stage_evaluation.md](11_two_stage_evaluation.md) |
 | GBT prototype report | [08_gbt_prototype_evaluation.md](08_gbt_prototype_evaluation.md) |
 | Arc retrospective | [11_r1_5_arc_retrospective.md](11_r1_5_arc_retrospective.md) |
-| R1.6 plan | `plans/sessions/2026-03-13_r1-6-partner-semantics.md` |
+| R1.6 plan | `plans/archive/v1_sessions/2026-03-13_r1-6-partner-semantics.md` |
 | PR #631 (schema infra) | artifact-driven feature extraction |
-| Governing plan | `plans/sessions/2026-03-12_r1-5-3-forward-plan-v2.md` |
+| Governing plan | `plans/archive/v1_sessions/2026-03-12_r1-5-3-forward-plan-v2.md` |
 | analysis_base_sha | 078cecc |

--- a/docs/04_reports/r1_5/diagnostic_calibration.md
+++ b/docs/04_reports/r1_5/diagnostic_calibration.md
@@ -278,7 +278,7 @@ This motivates the Phase 2 two-stage decomposition (Q14): separating
 declare/defend regimes should produce more unimodal within-regime targets.
 The OLS model would then predict within each regime rather than averaging
 across the bifurcation. Per the governing plan
-(`plans/sessions/2026-03-09_r1-5-v2-diagnostic-plan.md`), Phase 2 splits on
+(`plans/archive/v1_sessions/2026-03-09_r1-5-v2-diagnostic-plan.md`), Phase 2 splits on
 the observed declare/defend regime — not make/set — because declare/defend is
 directly observable in training data.
 

--- a/docs/04_reports/r1_5/measurement_integrity_r1_5.md
+++ b/docs/04_reports/r1_5/measurement_integrity_r1_5.md
@@ -45,7 +45,7 @@ so promotion-blocking rigor requirements are not binding.
 
 ## Plan Deviations
 
-Three formal deviations from the governing plan (`plans/r1_5_training_plan.md`):
+Three formal deviations from the governing plan (`plans/archive/v1_root/r1_5_training_plan.md`):
 
 ### PD-1: FULL Retraining Deferred
 

--- a/docs/04_reports/r1_5/post_r1_retro.md
+++ b/docs/04_reports/r1_5/post_r1_retro.md
@@ -268,6 +268,6 @@ the full phase sequencing and rung ladder.
 | R1.5 closeout | `docs/04_reports/r1_5/rung_closeout.md` |
 | R1.5.2 ablation | `docs/04_reports/r1_5/v2_ablation_analysis.md` |
 | Experiment ledger | `docs/04_reports/r1_5/appendix_experiment_ledger.md` |
-| Next experiment plan | `plans/sessions/2026-03-11_r1-5-3-alternative-approaches.md` |
-| Forward decision tree | `plans/r1_5_forward_decision_tree.md` |
+| Next experiment plan | `plans/archive/v1_sessions/2026-03-11_r1-5-3-alternative-approaches.md` |
+| Forward decision tree | `plans/archive/v1_root/r1_5_forward_decision_tree.md` |
 | analysis_base_sha | f74ff62 |

--- a/docs/04_reports/r1_5/r1_5_questions.md
+++ b/docs/04_reports/r1_5/r1_5_questions.md
@@ -1,6 +1,6 @@
 # R1.5 Open Questions & Answers
 
-**Source plan:** `plans/sessions/2026-03-09_r1-5-v2-diagnostic-plan.md`
+**Source plan:** `plans/archive/v1_sessions/2026-03-09_r1-5-v2-diagnostic-plan.md`
 **Last updated:** 2026-03-09
 
 ---

--- a/docs/04_reports/r1_5/rung_closeout.md
+++ b/docs/04_reports/r1_5/rung_closeout.md
@@ -177,7 +177,7 @@ R1.6 extends partner features with suit-relative channels:
 
 Schema: v7 (52 features) to v8 (53 features). PR #631 (artifact-driven feature
 extraction) enables v7/v8 coexistence.
-Plan: `plans/sessions/2026-03-13_r1-6-partner-semantics.md`
+Plan: `plans/archive/v1_sessions/2026-03-13_r1-6-partner-semantics.md`
 
 ## Timeline
 
@@ -208,8 +208,8 @@ Plan: `plans/sessions/2026-03-13_r1-6-partner-semantics.md`
 | OLS FULL H2H battery | `data/artifacts/arc_d/r1_5/h2h_battery_full.json` |
 | Dataset generator | `scripts/internal/generate_action_value_dataset.py` |
 | Training pipeline | `scripts/internal/train_action_value.py` |
-| Governing plan | `plans/r1_5_training_plan.md` |
-| R1.5.3 plan | `plans/sessions/2026-03-12_r1-5-3-forward-plan-v2.md` |
+| Governing plan | `plans/archive/v1_root/r1_5_training_plan.md` |
+| R1.5.3 plan | `plans/archive/v1_sessions/2026-03-12_r1-5-3-forward-plan-v2.md` |
 
 ## Companion Reports
 

--- a/docs/04_reports/r1_5/v2_ablation_analysis.md
+++ b/docs/04_reports/r1_5/v2_ablation_analysis.md
@@ -1,7 +1,7 @@
 # R1.5-v2 Ablation Analysis Report
 
 **Date:** 2026-03-10
-**Plan:** `plans/sessions/2026-03-09_r1-5-v2-diagnostic-plan.md` (Phase 1, Step 3)
+**Plan:** `plans/archive/v1_sessions/2026-03-09_r1-5-v2-diagnostic-plan.md` (Phase 1, Step 3)
 **Seed:** 42
 **Scale:** QUICK (2,500 deals per matchup for H2H; ~10,000 hands per contract for R²)
 
@@ -305,7 +305,7 @@ architecture is unlikely to close the suit gap. Progress requires either:
 | Item | Value |
 |------|-------|
 | gate_status | N/A — diagnostic ablation, no formal gate |
-| Plan | `plans/sessions/2026-03-09_r1-5-v2-diagnostic-plan.md` Phase 1 Step 3 |
+| Plan | `plans/archive/v1_sessions/2026-03-09_r1-5-v2-diagnostic-plan.md` Phase 1 Step 3 |
 | Cell A artifact | data/runs/cell_a_r0_features_42/action_value_r0_features.json |
 | Cell B' artifact | data/runs/action_value_quick_42_v2/action_value_full.json |
 | Cell C artifact | data/runs/cell_c_r0_tricks_42/ (gate X2 failed on pass, ran with --skip-validation) |


### PR DESCRIPTION
## Summary

- Updated 35 broken path references across 20 documentation files to match the plans directory restructuring from PR #642
- Three categories of path changes:
  - `plans/archive/<name>.md` -> `plans/archive/pre_v1/<name>.md`
  - `plans/sessions/<date>_*.md` -> `plans/archive/v1_sessions/<date>_*.md`
  - `plans/r1_5_*.md` / `plans/r1_follow_ups.md` / `plans/r2_follow_ups.md` -> `plans/archive/v1_root/...`

## Why

PR #642 restructured the `plans/` directory but did not update the 35 documentation references that point to the old locations. This breaks `make docs-check` and CI.

## Repro / Validation

```bash
make docs-check   # Passes with 0 issues
make check-quiet  # Full validation passes
```

## Tests

```bash
make check-quiet  # All checks passed
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/fix-doc-refs
show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/fix-doc-refs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)