### PR TITLE
feat: add typed Arc D v2 package with schemas, paths, and config

### DIFF
--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -19,6 +19,7 @@ Submodules:
 - `models/` — Model training/inference
 - `diagnostics/` — Visualization and analysis tools
 - `validation/` — Schema validation
+- `arc_d_v2/` — Arc D v2 lineage: typed schemas, paths, configuration (orchestration and reporting scripts import from here)
 - `reporting/`, `logging/`, `analysis/` — Supporting utilities
 - `scoring.py` — Top-level scoring module (compute_points)
 
@@ -65,7 +66,9 @@ Shell scripts:
 - `run_r0b.sh` — R0 baseline lock reproduction commands (Arc D Wave 3)
 
 ### `scripts/internal/`
-**Research and internal tooling.** Not part of the canonical workflow.
+**Research and internal tooling.** Not part of the canonical experiment workflow.
+Arc D v2 lineage scripts (orchestrator, reporting) are canonical execution tools
+that import typed schemas and paths from `bid_euchre.arc_d_v2`.
 
 - `audit_analysis.py` — Review pipeline audit (follow-up rates, corrective PRs, per-PR trail)
 - `evaluate_diagnostic_tricks.py` — Diagnostic Ridge evaluation

--- a/src/bid_euchre/arc_d_v2/__init__.py
+++ b/src/bid_euchre/arc_d_v2/__init__.py
@@ -1,0 +1,1 @@
+"""Arc D v2 lineage package — typed schemas, paths, and configuration."""

--- a/src/bid_euchre/arc_d_v2/config.py
+++ b/src/bid_euchre/arc_d_v2/config.py
@@ -1,0 +1,169 @@
+"""Configuration types for Arc D v2 lineage.
+
+Typed representations for the roster (model definitions), mode contracts
+(seed/deal counts), and per-rung runtime configuration.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class RosterModel:
+    """A single model entry in the lineage roster."""
+
+    name: str
+    class_name: str  # Python class name (e.g., "GBTActionValueBidder")
+    trainable: bool
+    model_class: str = ""  # ols, gbt, two-stage, or "" for heuristics
+    feature_set: str = ""  # r0, constrained, full, or "" for heuristics
+    selection: str = "none"  # none, forward
+    category: str = ""  # heuristic, legacy_baseline, or "" for trained models
+    status: str = "active"  # active, excluded, experimental
+
+
+@dataclass
+class AnchorModel:
+    """The fixed anchor model used as the comparator baseline."""
+
+    name: str
+    artifact: str
+    class_name: str
+
+
+@dataclass
+class Roster:
+    """Model roster for the lineage.
+
+    Lives at ``plans/arc_d_v2/roster.json``.
+    """
+
+    schema_version: str = "roster_v1"
+    lineage_id: str = "arc_d_v2"
+    models: list[RosterModel] = field(default_factory=list)
+    anchor: AnchorModel = field(default_factory=lambda: AnchorModel("", "", ""))
+
+    def trainable_models(self) -> list[RosterModel]:
+        """Return only trainable, active models."""
+        return [m for m in self.models if m.trainable and m.status == "active"]
+
+    def all_active_models(self) -> list[RosterModel]:
+        """Return all active models (trainable and heuristic)."""
+        return [m for m in self.models if m.status == "active"]
+
+    @classmethod
+    def load(cls, path: Path) -> Roster:
+        """Load roster from a JSON file."""
+        data = json.loads(path.read_text())
+        models = [
+            RosterModel(
+                name=m["name"],
+                class_name=m["class"],
+                trainable=m["trainable"],
+                model_class=m.get("model_class", ""),
+                feature_set=m.get("feature_set", ""),
+                selection=m.get("selection", "none"),
+                category=m.get("category", ""),
+                status=m.get("status", "active"),
+            )
+            for m in data.get("models", [])
+        ]
+
+        anchor_data = data.get("anchor", {})
+        anchor = AnchorModel(
+            name=anchor_data.get("name", ""),
+            artifact=anchor_data.get("artifact", ""),
+            class_name=anchor_data.get("class", ""),
+        )
+
+        return cls(
+            schema_version=data.get("schema_version", "roster_v1"),
+            lineage_id=data.get("lineage_id", "arc_d_v2"),
+            models=models,
+            anchor=anchor,
+        )
+
+    def save(self, path: Path) -> None:
+        """Serialize roster to a JSON file."""
+        data: dict = {
+            "schema_version": self.schema_version,
+            "lineage_id": self.lineage_id,
+            "models": [
+                {
+                    "name": m.name,
+                    "class": m.class_name,
+                    "trainable": m.trainable,
+                    **({"model_class": m.model_class} if m.model_class else {}),
+                    **({"feature_set": m.feature_set} if m.feature_set else {}),
+                    **({"selection": m.selection} if m.selection != "none" else {}),
+                    **({"category": m.category} if m.category else {}),
+                    **({"status": m.status} if m.status != "active" else {}),
+                }
+                for m in self.models
+            ],
+            "anchor": {
+                "name": self.anchor.name,
+                "artifact": self.anchor.artifact,
+                "class": self.anchor.class_name,
+            },
+        }
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+# ── Seed and Mode Contracts ──────────────────────────────────────────────────
+
+MODES: dict[str, dict] = {
+    "smoke": {"deals": 50, "seeds": [42]},
+    "quick": {"deals": 2500, "seeds": [42]},
+    "full": {"deals": 50000, "seeds": [42, 123, 456]},
+}
+
+
+@dataclass
+class RungConfig:
+    """Runtime configuration for a rung execution."""
+
+    rung: str
+    mode: str
+    seeds: list[int]
+    deals: int
+    roster: Roster
+    continuation_artifact: Path
+
+    @classmethod
+    def create(
+        cls,
+        rung: str,
+        mode: str,
+        roster: Roster,
+        seeds: list[int] | None = None,
+    ) -> RungConfig:
+        """Create a rung config from mode defaults.
+
+        Parameters
+        ----------
+        rung : str
+            Rung identifier (e.g., "r2.0").
+        mode : str
+            Execution mode: "smoke", "quick", or "full".
+        roster : Roster
+            The model roster.
+        seeds : list[int] | None
+            Override default seeds for the mode.
+        """
+        if mode not in MODES:
+            msg = f"Unknown mode {mode!r}; expected one of {sorted(MODES)}"
+            raise ValueError(msg)
+        mode_spec = MODES[mode]
+        return cls(
+            rung=rung,
+            mode=mode,
+            seeds=seeds if seeds is not None else mode_spec["seeds"],
+            deals=mode_spec["deals"],
+            roster=roster,
+            continuation_artifact=Path("data/artifacts/arc_d/r0/hybrid_r0_full.json"),
+        )

--- a/src/bid_euchre/arc_d_v2/paths.py
+++ b/src/bid_euchre/arc_d_v2/paths.py
@@ -1,0 +1,142 @@
+"""Canonical path construction for Arc D v2 lineage.
+
+All path logic in one place.  No more string interpolation scattered across
+scripts.  Every function returns a ``pathlib.Path`` that is *repo-root-relative*
+(consistent with the rest of the codebase).
+"""
+
+from pathlib import Path
+
+# ── Lineage root paths ──────────────────────────────────────────────────────
+
+PLANS_ROOT = Path("plans/arc_d_v2")
+REPORTS_ROOT = Path("docs/04_reports/arc_d_v2")
+RUNS_ROOT = Path("data/runs/arc_d_v2")
+
+# ── Lineage-level files ─────────────────────────────────────────────────────
+
+LINEAGE_PLAN = PLANS_ROOT / "lineage_plan.md"
+LINEAGE_ROSTER = PLANS_ROOT / "roster.json"
+LINEAGE_AMENDMENTS = PLANS_ROOT / "amendments.md"
+SUB_PLAN_REGISTRY = PLANS_ROOT / "sub_plan_registry.md"
+CROSS_RUNG_DELTAS = REPORTS_ROOT / "cross_rung_deltas.csv"
+
+# ── Anchor model (fixed for the lineage) ────────────────────────────────────
+
+ANCHOR_ARTIFACT = Path("data/artifacts/arc_d/r0/hybrid_r0_full.json")
+
+
+# ── Rung-level plan paths ───────────────────────────────────────────────────
+
+
+def rung_plan_dir(rung: str) -> Path:
+    """Plans directory for a rung: ``plans/arc_d_v2/<rung>/``."""
+    return PLANS_ROOT / rung
+
+
+def rung_plan(rung: str) -> Path:
+    """Rung plan file: ``plans/arc_d_v2/<rung>/plan.md``."""
+    return rung_plan_dir(rung) / "plan.md"
+
+
+def rung_hypotheses(rung: str) -> Path:
+    """Hypotheses file: ``plans/arc_d_v2/<rung>/hypotheses.json``."""
+    return rung_plan_dir(rung) / "hypotheses.json"
+
+
+def rung_checkpoints(rung: str) -> Path:
+    """Checkpoints file: ``plans/arc_d_v2/<rung>/checkpoints.md``."""
+    return rung_plan_dir(rung) / "checkpoints.md"
+
+
+def rung_state(rung: str) -> Path:
+    """State file: ``plans/arc_d_v2/<rung>/state.json``."""
+    return rung_plan_dir(rung) / "state.json"
+
+
+def rung_execution_log(rung: str) -> Path:
+    """Execution log: ``plans/arc_d_v2/<rung>/execution_log.jsonl``."""
+    return rung_plan_dir(rung) / "execution_log.jsonl"
+
+
+# ── Rung-level run paths ────────────────────────────────────────────────────
+
+
+def rung_run_dir(rung: str) -> Path:
+    """Run artifacts root: ``data/runs/arc_d_v2/<rung>/``."""
+    return RUNS_ROOT / rung
+
+
+def seed_dir(rung: str, mode: str, seed: int) -> Path:
+    """Per-seed output: ``data/runs/arc_d_v2/<rung>/<mode>/seed_<N>/``."""
+    return rung_run_dir(rung) / mode / f"seed_{seed}"
+
+
+def seed_dataset(rung: str, mode: str, seed: int) -> Path:
+    """Action-value dataset for a seed."""
+    return seed_dir(rung, mode, seed) / "datasets" / "action_value.parquet"
+
+
+def seed_artifacts_dir(rung: str, mode: str, seed: int) -> Path:
+    """Artifacts directory for a seed."""
+    return seed_dir(rung, mode, seed) / "artifacts"
+
+
+def model_artifact(rung: str, mode: str, seed: int, model_name: str) -> Path:
+    """Model artifact JSON for a specific model within a seed."""
+    return seed_artifacts_dir(rung, mode, seed) / model_name / "artifact.json"
+
+
+def seed_h2h_dir(rung: str, mode: str, seed: int) -> Path:
+    """Head-to-head results directory for a seed."""
+    return seed_dir(rung, mode, seed) / "h2h"
+
+
+def seed_comparator_dir(rung: str, mode: str, seed: int) -> Path:
+    """Comparator battery results directory for a seed."""
+    return seed_dir(rung, mode, seed) / "comparator"
+
+
+# ── Rung-level report paths ─────────────────────────────────────────────────
+
+
+def rung_report_dir(rung: str) -> Path:
+    """Report output: ``docs/04_reports/arc_d_v2/<rung>/``."""
+    return REPORTS_ROOT / rung
+
+
+def rung_tables_dir(rung: str) -> Path:
+    """Report tables directory."""
+    return rung_report_dir(rung) / "tables"
+
+
+def rung_charts_dir(rung: str) -> Path:
+    """Report charts directory."""
+    return rung_report_dir(rung) / "charts"
+
+
+def rung_chart_data_dir(rung: str) -> Path:
+    """Chart backing data directory."""
+    return rung_report_dir(rung) / "chart_data"
+
+
+# ── Advance / evidence paths ────────────────────────────────────────────────
+
+
+def advance_check_path(rung: str, mode: str) -> Path:
+    """``advance_check_<mode>.json`` in rung run dir."""
+    return rung_run_dir(rung) / f"advance_check_{mode}.json"
+
+
+def evidence_manifest_path(rung: str) -> Path:
+    """Evidence manifest: ``docs/04_reports/arc_d_v2/<rung>/evidence_manifest.json``."""
+    return rung_report_dir(rung) / "evidence_manifest.json"
+
+
+# ── Step logs ────────────────────────────────────────────────────────────────
+
+
+def step_log_path(rung: str, step: str, detail: str = "") -> Path:
+    """Per-step subprocess log in the rung plan directory."""
+    suffix = f"_{detail}" if detail else ""
+    return rung_plan_dir(rung) / "logs" / f"step_{step}{suffix}.log"

--- a/src/bid_euchre/arc_d_v2/schemas.py
+++ b/src/bid_euchre/arc_d_v2/schemas.py
@@ -1,0 +1,433 @@
+"""Typed schemas for Arc D v2 machine-readable artifacts.
+
+All JSON artifacts produced by the orchestrator and reporting scripts have
+typed dataclass representations here.  This enforces structure and prevents
+schema drift between plan, orchestrator, and reporting.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+# ── Step and Model Status Constants ──────────────────────────────────────────
+
+VALID_STEP_STATUSES = frozenset(
+    {
+        "pending",
+        "in_progress",
+        "complete",
+        "partial",
+        "failed_retryable",
+        "failed_blocking",
+        "skipped",
+    }
+)
+
+VALID_ADVANCE_DECISIONS = frozenset({"PROCEED", "INVESTIGATE", "PAUSE"})
+
+
+# ── State Schema ─────────────────────────────────────────────────────────────
+
+
+@dataclass
+class ModelStatus:
+    """Status of a single model within a seed step."""
+
+    status: str  # one of VALID_STEP_STATUSES
+    output: str = ""
+    detail: str = ""
+
+
+@dataclass
+class SeedStepStatus:
+    """Status of a pipeline step for a single seed."""
+
+    status: str  # one of VALID_STEP_STATUSES
+    outputs: list[str] = field(default_factory=list)
+    models: dict[str, ModelStatus] = field(default_factory=dict)
+    detail: str = ""
+
+
+@dataclass
+class AggregationStepStatus:
+    """Status of an aggregation step (cross-seed)."""
+
+    status: str = "pending"
+    outputs: list[str] = field(default_factory=list)
+    detail: str = ""
+
+
+@dataclass
+class Fingerprint:
+    """Reproducibility fingerprint for a run artifact."""
+
+    roster_hash: str = ""
+    seed: int = 0
+    mode: str = ""
+    feature_set: str = ""
+    plan_sha: str = ""
+    script_mtime: float = 0.0
+
+
+@dataclass
+class RunState:
+    """Machine-readable execution state for a rung.
+
+    Lives at ``plans/arc_d_v2/<rung>/state.json``.
+    """
+
+    schema_version: str = "rung_state_v1"
+    rung: str = ""
+    mode: str = ""  # smoke, quick, full
+    seeds: list[int] = field(default_factory=list)
+    current_step: str = ""
+    step_status: str = "pending"
+    status_detail: str = ""
+    retries: int = 0
+    max_retries: int = 3
+    blocker: str | None = None
+    active_investigation: str | None = None
+    supersession: dict[str, Any] | None = None
+    per_seed: dict[int, dict[str, SeedStepStatus]] = field(default_factory=dict)
+    aggregation: dict[str, AggregationStepStatus] = field(default_factory=dict)
+    fingerprints: dict[str, Fingerprint] = field(default_factory=dict)
+    last_updated: str = ""
+
+    # Per-seed pipeline steps
+    _PER_SEED_STEPS: list[str] = field(
+        default_factory=lambda: ["1", "2", "3", "3b", "4", "5"],
+        init=False,
+        repr=False,
+    )
+    # Aggregation steps
+    _AGGREGATION_STEPS: list[str] = field(
+        default_factory=lambda: ["6", "7", "8", "9"],
+        init=False,
+        repr=False,
+    )
+
+    @classmethod
+    def create_fresh(cls, rung: str, mode: str, seeds: list[int]) -> RunState:
+        """Create a fresh state for a new rung execution."""
+        per_seed_steps = ["1", "2", "3", "3b", "4", "5"]
+        aggregation_steps = ["6", "7", "8", "9"]
+
+        per_seed: dict[int, dict[str, SeedStepStatus]] = {}
+        for seed in seeds:
+            per_seed[seed] = {
+                step: SeedStepStatus(status="pending") for step in per_seed_steps
+            }
+
+        aggregation = {
+            step: AggregationStepStatus(status="pending") for step in aggregation_steps
+        }
+
+        return cls(
+            rung=rung,
+            mode=mode,
+            seeds=seeds,
+            current_step="0",
+            step_status="pending",
+            per_seed=per_seed,
+            aggregation=aggregation,
+        )
+
+    def save(self, path: Path) -> None:
+        """Serialize to JSON file."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = asdict(self)
+        # Remove private fields
+        data.pop("_PER_SEED_STEPS", None)
+        data.pop("_AGGREGATION_STEPS", None)
+        path.write_text(json.dumps(data, indent=2, default=str) + "\n")
+
+    @classmethod
+    def load(cls, path: Path) -> RunState:
+        """Deserialize from JSON file, reconstructing nested dataclasses."""
+        data = json.loads(path.read_text())
+
+        per_seed: dict[int, dict[str, SeedStepStatus]] = {}
+        for seed_str, steps in data.get("per_seed", {}).items():
+            seed = int(seed_str)
+            per_seed[seed] = {}
+            for step, step_data in steps.items():
+                models: dict[str, ModelStatus] = {}
+                for m_name, m_data in step_data.get("models", {}).items():
+                    models[m_name] = ModelStatus(**m_data)
+                per_seed[seed][step] = SeedStepStatus(
+                    status=step_data["status"],
+                    outputs=step_data.get("outputs", []),
+                    models=models,
+                    detail=step_data.get("detail", ""),
+                )
+
+        aggregation: dict[str, AggregationStepStatus] = {}
+        for step, step_data in data.get("aggregation", {}).items():
+            aggregation[step] = AggregationStepStatus(**step_data)
+
+        fingerprints: dict[str, Fingerprint] = {}
+        for key, fp_data in data.get("fingerprints", {}).items():
+            fingerprints[key] = Fingerprint(**fp_data)
+
+        return cls(
+            schema_version=data.get("schema_version", "rung_state_v1"),
+            rung=data["rung"],
+            mode=data["mode"],
+            seeds=data["seeds"],
+            current_step=data.get("current_step", ""),
+            step_status=data.get("step_status", "pending"),
+            status_detail=data.get("status_detail", ""),
+            retries=data.get("retries", 0),
+            max_retries=data.get("max_retries", 3),
+            blocker=data.get("blocker"),
+            active_investigation=data.get("active_investigation"),
+            supersession=data.get("supersession"),
+            per_seed=per_seed,
+            aggregation=aggregation,
+            fingerprints=fingerprints,
+            last_updated=data.get("last_updated", ""),
+        )
+
+
+# ── Hypothesis Schema ────────────────────────────────────────────────────────
+
+
+@dataclass
+class HypothesisBound:
+    """A directional bound for hypothesis evaluation."""
+
+    op: str  # ">", "<", ">=", "<="
+    value: float
+
+
+@dataclass
+class Hypothesis:
+    """A single testable hypothesis with metric source and bounds."""
+
+    id: str
+    description: str
+    metric: str
+    source_table: str
+    source_column: str
+    source_filter: dict[str, str]
+    anchor_filter: dict[str, str] = field(default_factory=dict)
+    computation: str = "value - anchor_value"
+    expected_bound: HypothesisBound = field(
+        default_factory=lambda: HypothesisBound(">", 0.0)
+    )
+    surprise_if: HypothesisBound = field(
+        default_factory=lambda: HypothesisBound("<", 0.0)
+    )
+
+
+@dataclass
+class HypothesesFile:
+    """Container for a rung's hypothesis definitions.
+
+    Lives at ``plans/arc_d_v2/<rung>/hypotheses.json``.
+    """
+
+    schema_version: str = "hypotheses_v1"
+    rung: str = ""
+    hypotheses: list[Hypothesis] = field(default_factory=list)
+
+    def save(self, path: Path) -> None:
+        """Serialize to JSON file."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(asdict(self), indent=2) + "\n")
+
+    @classmethod
+    def load(cls, path: Path) -> HypothesesFile:
+        """Deserialize from JSON file."""
+        data = json.loads(path.read_text())
+        hypotheses = []
+        for h in data.get("hypotheses", []):
+            hypotheses.append(
+                Hypothesis(
+                    id=h["id"],
+                    description=h["description"],
+                    metric=h["metric"],
+                    source_table=h["source_table"],
+                    source_column=h["source_column"],
+                    source_filter=h["source_filter"],
+                    anchor_filter=h.get("anchor_filter", {}),
+                    computation=h.get("computation", "value - anchor_value"),
+                    expected_bound=HypothesisBound(
+                        **h.get("expected_bound", {"op": ">", "value": 0.0})
+                    ),
+                    surprise_if=HypothesisBound(
+                        **h.get("surprise_if", {"op": "<", "value": 0.0})
+                    ),
+                )
+            )
+        return cls(
+            schema_version=data.get("schema_version", "hypotheses_v1"),
+            rung=data.get("rung", ""),
+            hypotheses=hypotheses,
+        )
+
+
+# ── Advance Check Schema ─────────────────────────────────────────────────────
+
+
+@dataclass
+class CheckResult:
+    """Result of a single sufficiency or canary check."""
+
+    id: str
+    pass_: bool  # ``pass`` is a Python keyword
+    value: str = ""
+    detail: str = ""
+    level: str = "GATE"  # GATE or WARNING
+
+
+@dataclass
+class HypothesisCheckResult:
+    """Result of evaluating a single hypothesis against observed data."""
+
+    id: str
+    description: str
+    expected_bound: str
+    observed: float
+    pass_: bool
+    surprise_threshold: str
+    surprise_hit: bool
+
+
+@dataclass
+class BestInLineage:
+    """Tracks the best model seen so far across the lineage."""
+
+    model: str
+    pooled_net_eppd: float
+    updated: bool = False
+
+
+@dataclass
+class NextAction:
+    """Recommended next action after an advance check."""
+
+    command: str
+    prerequisite: str = ""
+
+
+@dataclass
+class AdvanceCheck:
+    """Machine-readable advance decision.
+
+    Lives at ``data/runs/arc_d_v2/<rung>/advance_check_<mode>.json``.
+    """
+
+    schema_version: str = "advance_check_v1"
+    rung: str = ""
+    mode: str = ""
+    advance_decision: str = ""  # PROCEED, INVESTIGATE, PAUSE
+    reason: str = ""
+    timestamp: str = ""
+    next_action: NextAction = field(default_factory=lambda: NextAction(""))
+    hypothesis_checks: list[HypothesisCheckResult] = field(default_factory=list)
+    sufficiency_checks: list[CheckResult] = field(default_factory=list)
+    canary_checks: list[CheckResult] = field(default_factory=list)
+    best_in_lineage: BestInLineage | None = None
+    failed_checks_summary: list[str] = field(default_factory=list)
+    warnings_summary: list[str] = field(default_factory=list)
+
+    def save(self, path: Path) -> None:
+        """Serialize to JSON, renaming ``pass_`` back to ``pass``."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = asdict(self)
+        _rename_pass_fields(data)
+        path.write_text(json.dumps(data, indent=2) + "\n")
+
+    @classmethod
+    def load(cls, path: Path) -> AdvanceCheck:
+        """Deserialize from JSON file."""
+        data = json.loads(path.read_text())
+
+        hypothesis_checks = []
+        for h in data.get("hypothesis_checks", []):
+            hypothesis_checks.append(
+                HypothesisCheckResult(
+                    id=h["id"],
+                    description=h["description"],
+                    expected_bound=h["expected_bound"],
+                    observed=h["observed"],
+                    pass_=h.get("pass", h.get("pass_", True)),
+                    surprise_threshold=h["surprise_threshold"],
+                    surprise_hit=h["surprise_hit"],
+                )
+            )
+
+        sufficiency_checks = []
+        for s in data.get("sufficiency_checks", []):
+            sufficiency_checks.append(
+                CheckResult(
+                    id=s["id"],
+                    pass_=s.get("pass", s.get("pass_", True)),
+                    value=s.get("value", ""),
+                    detail=s.get("detail", ""),
+                    level=s.get("level", "GATE"),
+                )
+            )
+
+        canary_checks = []
+        for c in data.get("canary_checks", []):
+            canary_checks.append(
+                CheckResult(
+                    id=c["id"],
+                    pass_=c.get("pass", c.get("pass_", True)),
+                    value=c.get("value", ""),
+                    detail=c.get("detail", ""),
+                    level=c.get("level", "WARNING"),
+                )
+            )
+
+        best_data = data.get("best_in_lineage")
+        best_in_lineage = BestInLineage(**best_data) if best_data is not None else None
+
+        next_data = data.get("next_action", {})
+        next_action = NextAction(
+            command=next_data.get("command", ""),
+            prerequisite=next_data.get("prerequisite", ""),
+        )
+
+        return cls(
+            schema_version=data.get("schema_version", "advance_check_v1"),
+            rung=data.get("rung", ""),
+            mode=data.get("mode", ""),
+            advance_decision=data.get("advance_decision", ""),
+            reason=data.get("reason", ""),
+            timestamp=data.get("timestamp", ""),
+            next_action=next_action,
+            hypothesis_checks=hypothesis_checks,
+            sufficiency_checks=sufficiency_checks,
+            canary_checks=canary_checks,
+            best_in_lineage=best_in_lineage,
+            failed_checks_summary=data.get("failed_checks_summary", []),
+            warnings_summary=data.get("warnings_summary", []),
+        )
+
+    @property
+    def all_pass(self) -> bool:
+        """True if all gating checks pass (canary warnings don't block)."""
+        return (
+            all(h.pass_ for h in self.hypothesis_checks)
+            and all(s.pass_ for s in self.sufficiency_checks)
+            and not any(h.surprise_hit for h in self.hypothesis_checks)
+        )
+
+
+def _rename_pass_fields(d: dict[str, Any]) -> None:
+    """Recursively rename ``pass_`` to ``pass`` in a dict for JSON serialization."""
+    if "pass_" in d:
+        d["pass"] = d.pop("pass_")
+    for v in d.values():
+        if isinstance(v, dict):
+            _rename_pass_fields(v)
+        elif isinstance(v, list):
+            for item in v:
+                if isinstance(item, dict):
+                    _rename_pass_fields(item)

--- a/tests/unit/test_arc_d_v2_schemas.py
+++ b/tests/unit/test_arc_d_v2_schemas.py
@@ -1,0 +1,619 @@
+"""Unit tests for the Arc D v2 package: schemas, paths, and config.
+
+Tests are fixture-based — no real experiment runs or files required.
+All file I/O uses tmp_path.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bid_euchre.arc_d_v2 import paths
+from bid_euchre.arc_d_v2.config import (
+    MODES,
+    AnchorModel,
+    Roster,
+    RosterModel,
+    RungConfig,
+)
+from bid_euchre.arc_d_v2.schemas import (
+    VALID_ADVANCE_DECISIONS,
+    VALID_STEP_STATUSES,
+    AdvanceCheck,
+    BestInLineage,
+    CheckResult,
+    Fingerprint,
+    HypothesesFile,
+    Hypothesis,
+    HypothesisBound,
+    HypothesisCheckResult,
+    ModelStatus,
+    NextAction,
+    RunState,
+)
+
+# =============================================================================
+# Path tests
+# =============================================================================
+
+
+class TestPaths:
+    """Verify path construction returns expected structures."""
+
+    def test_lineage_root_paths(self):
+        assert paths.PLANS_ROOT == Path("plans/arc_d_v2")
+        assert paths.REPORTS_ROOT == Path("docs/04_reports/arc_d_v2")
+        assert paths.RUNS_ROOT == Path("data/runs/arc_d_v2")
+
+    def test_lineage_level_files(self):
+        assert paths.LINEAGE_PLAN == Path("plans/arc_d_v2/lineage_plan.md")
+        assert paths.LINEAGE_ROSTER == Path("plans/arc_d_v2/roster.json")
+        assert paths.LINEAGE_AMENDMENTS == Path("plans/arc_d_v2/amendments.md")
+        assert paths.SUB_PLAN_REGISTRY == Path("plans/arc_d_v2/sub_plan_registry.md")
+        assert paths.CROSS_RUNG_DELTAS == Path(
+            "docs/04_reports/arc_d_v2/cross_rung_deltas.csv"
+        )
+
+    def test_anchor_artifact(self):
+        assert paths.ANCHOR_ARTIFACT == Path(
+            "data/artifacts/arc_d/r0/hybrid_r0_full.json"
+        )
+
+    def test_rung_plan_dir(self):
+        assert paths.rung_plan_dir("r2.0") == Path("plans/arc_d_v2/r2.0")
+
+    def test_rung_plan(self):
+        assert paths.rung_plan("r2.0") == Path("plans/arc_d_v2/r2.0/plan.md")
+
+    def test_rung_hypotheses(self):
+        assert paths.rung_hypotheses("r2.0") == Path(
+            "plans/arc_d_v2/r2.0/hypotheses.json"
+        )
+
+    def test_rung_checkpoints(self):
+        assert paths.rung_checkpoints("r2.0") == Path(
+            "plans/arc_d_v2/r2.0/checkpoints.md"
+        )
+
+    def test_rung_state(self):
+        assert paths.rung_state("r2.0") == Path("plans/arc_d_v2/r2.0/state.json")
+
+    def test_rung_execution_log(self):
+        assert paths.rung_execution_log("r2.0") == Path(
+            "plans/arc_d_v2/r2.0/execution_log.jsonl"
+        )
+
+    def test_rung_run_dir(self):
+        assert paths.rung_run_dir("r2.0") == Path("data/runs/arc_d_v2/r2.0")
+
+    def test_seed_dir(self):
+        result = paths.seed_dir("r2.0", "quick", 42)
+        assert result == Path("data/runs/arc_d_v2/r2.0/quick/seed_42")
+
+    def test_seed_dataset(self):
+        result = paths.seed_dataset("r2.0", "smoke", 42)
+        assert result == Path(
+            "data/runs/arc_d_v2/r2.0/smoke/seed_42/datasets/action_value.parquet"
+        )
+
+    def test_seed_artifacts_dir(self):
+        result = paths.seed_artifacts_dir("r2.0", "full", 123)
+        assert result == Path("data/runs/arc_d_v2/r2.0/full/seed_123/artifacts")
+
+    def test_model_artifact(self):
+        result = paths.model_artifact("r2.0", "quick", 42, "gbt_full")
+        assert result == Path(
+            "data/runs/arc_d_v2/r2.0/quick/seed_42/artifacts/gbt_full/artifact.json"
+        )
+
+    def test_seed_h2h_dir(self):
+        result = paths.seed_h2h_dir("r2.0", "full", 456)
+        assert result == Path("data/runs/arc_d_v2/r2.0/full/seed_456/h2h")
+
+    def test_seed_comparator_dir(self):
+        result = paths.seed_comparator_dir("r2.0", "quick", 42)
+        assert result == Path("data/runs/arc_d_v2/r2.0/quick/seed_42/comparator")
+
+    def test_rung_report_dir(self):
+        assert paths.rung_report_dir("r2.0") == Path("docs/04_reports/arc_d_v2/r2.0")
+
+    def test_rung_tables_dir(self):
+        assert paths.rung_tables_dir("r2.0") == Path(
+            "docs/04_reports/arc_d_v2/r2.0/tables"
+        )
+
+    def test_rung_charts_dir(self):
+        assert paths.rung_charts_dir("r2.0") == Path(
+            "docs/04_reports/arc_d_v2/r2.0/charts"
+        )
+
+    def test_rung_chart_data_dir(self):
+        assert paths.rung_chart_data_dir("r2.0") == Path(
+            "docs/04_reports/arc_d_v2/r2.0/chart_data"
+        )
+
+    def test_advance_check_path(self):
+        result = paths.advance_check_path("r2.0", "quick")
+        assert result == Path("data/runs/arc_d_v2/r2.0/advance_check_quick.json")
+
+    def test_evidence_manifest_path(self):
+        result = paths.evidence_manifest_path("r2.0")
+        assert result == Path("docs/04_reports/arc_d_v2/r2.0/evidence_manifest.json")
+
+    def test_step_log_path_no_detail(self):
+        result = paths.step_log_path("r2.0", "3")
+        assert result == Path("plans/arc_d_v2/r2.0/logs/step_3.log")
+
+    def test_step_log_path_with_detail(self):
+        result = paths.step_log_path("r2.0", "3", "gbt_full")
+        assert result == Path("plans/arc_d_v2/r2.0/logs/step_3_gbt_full.log")
+
+
+# =============================================================================
+# RunState tests
+# =============================================================================
+
+
+class TestRunState:
+    """Test RunState creation, save, and load roundtrip."""
+
+    def test_create_fresh(self):
+        state = RunState.create_fresh("r2.0", "quick", [42])
+        assert state.rung == "r2.0"
+        assert state.mode == "quick"
+        assert state.seeds == [42]
+        assert state.current_step == "0"
+        assert state.step_status == "pending"
+        assert 42 in state.per_seed
+        assert set(state.per_seed[42].keys()) == {"1", "2", "3", "3b", "4", "5"}
+        for step_status in state.per_seed[42].values():
+            assert step_status.status == "pending"
+        assert set(state.aggregation.keys()) == {"6", "7", "8", "9"}
+
+    def test_create_fresh_multi_seed(self):
+        state = RunState.create_fresh("r2.0", "full", [42, 123, 456])
+        assert state.seeds == [42, 123, 456]
+        assert set(state.per_seed.keys()) == {42, 123, 456}
+
+    def test_save_load_roundtrip(self, tmp_path: Path):
+        state = RunState.create_fresh("r2.0", "quick", [42])
+        state.current_step = "2"
+        state.step_status = "in_progress"
+        state.status_detail = "Training models"
+        state.last_updated = "2026-03-13T10:00:00Z"
+
+        # Set a model status
+        state.per_seed[42]["2"].status = "in_progress"
+        state.per_seed[42]["2"].models["gbt_full"] = ModelStatus(
+            status="complete",
+            output="artifacts/gbt_full/artifact.json",
+            detail="R2=0.45",
+        )
+
+        # Set a fingerprint
+        state.fingerprints["seed_42"] = Fingerprint(
+            roster_hash="abc123",
+            seed=42,
+            mode="quick",
+        )
+
+        path = tmp_path / "state.json"
+        state.save(path)
+
+        loaded = RunState.load(path)
+        assert loaded.rung == "r2.0"
+        assert loaded.mode == "quick"
+        assert loaded.current_step == "2"
+        assert loaded.step_status == "in_progress"
+        assert loaded.status_detail == "Training models"
+        assert loaded.last_updated == "2026-03-13T10:00:00Z"
+        assert loaded.per_seed[42]["2"].status == "in_progress"
+
+        model = loaded.per_seed[42]["2"].models["gbt_full"]
+        assert model.status == "complete"
+        assert model.output == "artifacts/gbt_full/artifact.json"
+
+        fp = loaded.fingerprints["seed_42"]
+        assert fp.roster_hash == "abc123"
+        assert fp.seed == 42
+
+    def test_save_load_with_blocker(self, tmp_path: Path):
+        state = RunState.create_fresh("r2.0", "smoke", [42])
+        state.blocker = "make check failed"
+        state.active_investigation = "ruff format issue"
+
+        path = tmp_path / "state.json"
+        state.save(path)
+
+        loaded = RunState.load(path)
+        assert loaded.blocker == "make check failed"
+        assert loaded.active_investigation == "ruff format issue"
+
+    def test_save_creates_parent_dirs(self, tmp_path: Path):
+        state = RunState.create_fresh("r2.0", "smoke", [42])
+        path = tmp_path / "nested" / "dir" / "state.json"
+        state.save(path)
+        assert path.exists()
+
+    def test_per_seed_tracking(self):
+        state = RunState.create_fresh("r2.0", "quick", [42, 123])
+        # Update one seed step
+        state.per_seed[42]["1"].status = "complete"
+        state.per_seed[42]["1"].outputs = ["datasets/action_value.parquet"]
+        # Other seed untouched
+        assert state.per_seed[123]["1"].status == "pending"
+        assert state.per_seed[42]["1"].status == "complete"
+
+
+# =============================================================================
+# Hypothesis tests
+# =============================================================================
+
+
+class TestHypotheses:
+    """Test hypothesis file save/load roundtrip."""
+
+    def _sample_hypotheses(self) -> HypothesesFile:
+        return HypothesesFile(
+            rung="r2.0",
+            hypotheses=[
+                Hypothesis(
+                    id="H1",
+                    description="GBT pooled delta > 0",
+                    metric="net_eppd",
+                    source_table="h2h_summary",
+                    source_column="pooled_net_eppd",
+                    source_filter={"model": "gbt_full"},
+                    anchor_filter={"model": "hybrid_r0"},
+                    computation="value - anchor_value",
+                    expected_bound=HypothesisBound(">", 0.0),
+                    surprise_if=HypothesisBound("<", -0.5),
+                ),
+                Hypothesis(
+                    id="H2",
+                    description="Suit delta positive",
+                    metric="suit_net_eppd",
+                    source_table="h2h_by_contract",
+                    source_column="net_eppd",
+                    source_filter={"model": "gbt_full", "contract_type": "suit"},
+                    expected_bound=HypothesisBound(">", 0.0),
+                    surprise_if=HypothesisBound("<", -1.0),
+                ),
+            ],
+        )
+
+    def test_save_load_roundtrip(self, tmp_path: Path):
+        original = self._sample_hypotheses()
+        path = tmp_path / "hypotheses.json"
+        original.save(path)
+
+        loaded = HypothesesFile.load(path)
+        assert loaded.schema_version == "hypotheses_v1"
+        assert loaded.rung == "r2.0"
+        assert len(loaded.hypotheses) == 2
+
+        h1 = loaded.hypotheses[0]
+        assert h1.id == "H1"
+        assert h1.metric == "net_eppd"
+        assert h1.expected_bound.op == ">"
+        assert h1.expected_bound.value == 0.0
+        assert h1.surprise_if.op == "<"
+        assert h1.surprise_if.value == -0.5
+        assert h1.anchor_filter == {"model": "hybrid_r0"}
+
+    def test_empty_hypotheses(self, tmp_path: Path):
+        empty = HypothesesFile(rung="r2.0")
+        path = tmp_path / "empty.json"
+        empty.save(path)
+        loaded = HypothesesFile.load(path)
+        assert loaded.hypotheses == []
+
+
+# =============================================================================
+# AdvanceCheck tests
+# =============================================================================
+
+
+class TestAdvanceCheck:
+    """Test AdvanceCheck, especially pass_/pass renaming and all_pass."""
+
+    def _make_check(self, *, all_passing: bool = True) -> AdvanceCheck:
+        return AdvanceCheck(
+            rung="r2.0",
+            mode="quick",
+            advance_decision="PROCEED",
+            reason="All gates pass",
+            timestamp="2026-03-13T10:00:00Z",
+            next_action=NextAction(command="run full", prerequisite="quick complete"),
+            hypothesis_checks=[
+                HypothesisCheckResult(
+                    id="H1",
+                    description="Pooled delta > 0",
+                    expected_bound="> 0.0",
+                    observed=0.57,
+                    pass_=all_passing,
+                    surprise_threshold="< -0.5",
+                    surprise_hit=False,
+                ),
+            ],
+            sufficiency_checks=[
+                CheckResult(
+                    id="S1",
+                    pass_=all_passing,
+                    value="50000",
+                    detail="n_deals sufficient",
+                    level="GATE",
+                ),
+            ],
+            canary_checks=[
+                CheckResult(
+                    id="CAN1",
+                    pass_=True,
+                    value="0.03",
+                    detail="self-play bias",
+                    level="WARNING",
+                ),
+            ],
+            best_in_lineage=BestInLineage(
+                model="gbt_full", pooled_net_eppd=0.57, updated=True
+            ),
+        )
+
+    def test_all_pass_true(self):
+        check = self._make_check(all_passing=True)
+        assert check.all_pass is True
+
+    def test_all_pass_false_hypothesis(self):
+        check = self._make_check(all_passing=False)
+        assert check.all_pass is False
+
+    def test_all_pass_false_surprise(self):
+        check = self._make_check(all_passing=True)
+        check.hypothesis_checks[0].surprise_hit = True
+        assert check.all_pass is False
+
+    def test_all_pass_false_sufficiency(self):
+        check = self._make_check(all_passing=True)
+        check.sufficiency_checks[0].pass_ = False
+        assert check.all_pass is False
+
+    def test_all_pass_empty_checks(self):
+        check = AdvanceCheck()
+        assert check.all_pass is True  # vacuously true
+
+    def test_save_load_roundtrip(self, tmp_path: Path):
+        original = self._make_check()
+        path = tmp_path / "advance_check.json"
+        original.save(path)
+
+        # Verify JSON uses "pass" not "pass_"
+        raw = json.loads(path.read_text())
+        assert "pass" in raw["hypothesis_checks"][0]
+        assert "pass_" not in raw["hypothesis_checks"][0]
+        assert "pass" in raw["sufficiency_checks"][0]
+
+        loaded = AdvanceCheck.load(path)
+        assert loaded.rung == "r2.0"
+        assert loaded.mode == "quick"
+        assert loaded.advance_decision == "PROCEED"
+        assert loaded.hypothesis_checks[0].pass_ is True
+        assert loaded.hypothesis_checks[0].observed == 0.57
+        assert loaded.sufficiency_checks[0].pass_ is True
+        assert loaded.canary_checks[0].level == "WARNING"
+        assert loaded.best_in_lineage is not None
+        assert loaded.best_in_lineage.model == "gbt_full"
+        assert loaded.next_action.command == "run full"
+        assert loaded.all_pass is True
+
+    def test_load_without_best_in_lineage(self, tmp_path: Path):
+        check = self._make_check()
+        check.best_in_lineage = None
+        path = tmp_path / "no_best.json"
+        check.save(path)
+
+        loaded = AdvanceCheck.load(path)
+        assert loaded.best_in_lineage is None
+
+
+# =============================================================================
+# Roster tests
+# =============================================================================
+
+
+class TestRoster:
+    """Test roster load, save, and filtering methods."""
+
+    def _sample_roster_json(self) -> dict:
+        return {
+            "schema_version": "roster_v1",
+            "lineage_id": "arc_d_v2",
+            "models": [
+                {
+                    "name": "gbt_full",
+                    "class": "GBTActionValueBidder",
+                    "trainable": True,
+                    "model_class": "gbt",
+                    "feature_set": "full",
+                    "selection": "forward",
+                },
+                {
+                    "name": "ols_constrained",
+                    "class": "OLSActionValueBidder",
+                    "trainable": True,
+                    "model_class": "ols",
+                    "feature_set": "constrained",
+                },
+                {
+                    "name": "strict_hellraiser",
+                    "class": "StrictHellraiserBidder",
+                    "trainable": False,
+                    "category": "heuristic",
+                },
+                {
+                    "name": "excluded_model",
+                    "class": "SomeExcluded",
+                    "trainable": True,
+                    "status": "excluded",
+                },
+            ],
+            "anchor": {
+                "name": "hybrid_r0",
+                "artifact": "data/artifacts/arc_d/r0/hybrid_r0_full.json",
+                "class": "HybridOLSaBidder",
+            },
+        }
+
+    def test_load_from_json(self, tmp_path: Path):
+        path = tmp_path / "roster.json"
+        path.write_text(json.dumps(self._sample_roster_json()))
+
+        roster = Roster.load(path)
+        assert roster.schema_version == "roster_v1"
+        assert roster.lineage_id == "arc_d_v2"
+        assert len(roster.models) == 4
+        assert roster.anchor.name == "hybrid_r0"
+        assert roster.anchor.class_name == "HybridOLSaBidder"
+
+    def test_trainable_models(self, tmp_path: Path):
+        path = tmp_path / "roster.json"
+        path.write_text(json.dumps(self._sample_roster_json()))
+
+        roster = Roster.load(path)
+        trainable = roster.trainable_models()
+        assert len(trainable) == 2
+        names = {m.name for m in trainable}
+        assert names == {"gbt_full", "ols_constrained"}
+
+    def test_all_active_models(self, tmp_path: Path):
+        path = tmp_path / "roster.json"
+        path.write_text(json.dumps(self._sample_roster_json()))
+
+        roster = Roster.load(path)
+        active = roster.all_active_models()
+        assert len(active) == 3
+        names = {m.name for m in active}
+        assert "excluded_model" not in names
+        assert "strict_hellraiser" in names
+
+    def test_save_load_roundtrip(self, tmp_path: Path):
+        path = tmp_path / "roster.json"
+        path.write_text(json.dumps(self._sample_roster_json()))
+
+        roster = Roster.load(path)
+        out_path = tmp_path / "roster_out.json"
+        roster.save(out_path)
+
+        reloaded = Roster.load(out_path)
+        assert len(reloaded.models) == 4
+        assert reloaded.anchor.name == "hybrid_r0"
+
+        # Verify trainable filtering is preserved
+        assert len(reloaded.trainable_models()) == 2
+
+    def test_save_creates_parent_dirs(self, tmp_path: Path):
+        roster = Roster(
+            models=[
+                RosterModel(
+                    name="test_model",
+                    class_name="TestBidder",
+                    trainable=True,
+                )
+            ],
+            anchor=AnchorModel(name="anchor", artifact="a.json", class_name="A"),
+        )
+        path = tmp_path / "nested" / "dir" / "roster.json"
+        roster.save(path)
+        assert path.exists()
+
+    def test_default_fields(self):
+        m = RosterModel(name="x", class_name="X", trainable=True)
+        assert m.model_class == ""
+        assert m.feature_set == ""
+        assert m.selection == "none"
+        assert m.category == ""
+        assert m.status == "active"
+
+
+# =============================================================================
+# RungConfig tests
+# =============================================================================
+
+
+class TestRungConfig:
+    """Test RungConfig creation for each mode."""
+
+    def _minimal_roster(self) -> Roster:
+        return Roster(
+            models=[
+                RosterModel(name="m1", class_name="M1", trainable=True),
+            ],
+            anchor=AnchorModel(name="a", artifact="a.json", class_name="A"),
+        )
+
+    def test_smoke_mode(self):
+        cfg = RungConfig.create("r2.0", "smoke", self._minimal_roster())
+        assert cfg.rung == "r2.0"
+        assert cfg.mode == "smoke"
+        assert cfg.seeds == [42]
+        assert cfg.deals == 50
+
+    def test_quick_mode(self):
+        cfg = RungConfig.create("r2.0", "quick", self._minimal_roster())
+        assert cfg.seeds == [42]
+        assert cfg.deals == 2500
+
+    def test_full_mode(self):
+        cfg = RungConfig.create("r2.0", "full", self._minimal_roster())
+        assert cfg.seeds == [42, 123, 456]
+        assert cfg.deals == 50000
+
+    def test_custom_seeds(self):
+        cfg = RungConfig.create(
+            "r2.0", "quick", self._minimal_roster(), seeds=[7, 8, 9]
+        )
+        assert cfg.seeds == [7, 8, 9]
+        # deals still come from mode default
+        assert cfg.deals == 2500
+
+    def test_continuation_artifact(self):
+        cfg = RungConfig.create("r2.0", "smoke", self._minimal_roster())
+        assert cfg.continuation_artifact == Path(
+            "data/artifacts/arc_d/r0/hybrid_r0_full.json"
+        )
+
+    def test_invalid_mode(self):
+        with pytest.raises(ValueError, match="Unknown mode"):
+            RungConfig.create("r2.0", "invalid", self._minimal_roster())
+
+
+# =============================================================================
+# Constants tests
+# =============================================================================
+
+
+class TestConstants:
+    """Verify status and decision constants."""
+
+    def test_valid_step_statuses(self):
+        expected = {
+            "pending",
+            "in_progress",
+            "complete",
+            "partial",
+            "failed_retryable",
+            "failed_blocking",
+            "skipped",
+        }
+        assert VALID_STEP_STATUSES == expected
+
+    def test_valid_advance_decisions(self):
+        assert VALID_ADVANCE_DECISIONS == {"PROCEED", "INVESTIGATE", "PAUSE"}
+
+    def test_modes_contract(self):
+        assert set(MODES.keys()) == {"smoke", "quick", "full"}
+        for mode_name, spec in MODES.items():
+            assert "deals" in spec, f"{mode_name} missing deals"
+            assert "seeds" in spec, f"{mode_name} missing seeds"
+            assert isinstance(spec["deals"], int)
+            assert isinstance(spec["seeds"], list)


### PR DESCRIPTION
## Plan
plans/arc_d_v2/lineage_plan.md — PR 2 (typed foundation package)

## Summary
- Create `src/bid_euchre/arc_d_v2/` package with typed dataclasses for all JSON schemas (RunState, HypothesesFile, AdvanceCheck), centralized path construction, and configuration types (Roster, RungConfig)
- 54 unit tests covering save/load roundtrips, filtering, `all_pass` logic, `pass_`/`pass` JSON field renaming, and path structure verification
- Update `ARCHITECTURE.md` to document the new module and clarify Arc D v2 lineage script status

## Why
The Arc D v2 lineage rebuild needs a typed importable foundation that orchestration scripts (PR 4) and reporting scripts (PR 3a) can import. Centralizing schemas, paths, and config types prevents schema drift and eliminates scattered string interpolation across scripts.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_arc_d_v2_schemas.py -v  # 54 passed
make repo-lint  # Passed
make lint       # Passed
make test       # 2590 passed, 38 skipped
```

**Config (if applicable):** N/A

**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_arc_d_v2_schemas.py` — 54 tests
- [x] `uv run python -m pytest -m "not slow" tests/` — 2590 passed
- [x] Other: `make repo-lint`, `make lint` — all passed

## Expected impact
- Metrics impact: None (library code only, no behavior changes)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/feat-arc-d-v2-package
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/feat-arc-d-v2-package
```

`git worktree list` (abbreviated):
```
.../Bid-Euchre                          d3b0623 [main]
.../worktrees/feat-arc-d-v2-package     9e8be76 [feat/arc-d-v2-package]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

**Note:** `make check-quiet` fails on docs-check due to pre-existing broken path references (35 issues on main). All other checks (repo-lint, ruff, pytest, notebook-check) pass.