### PR TITLE
ci: fix CI concurrency to prevent cancel-restart cascade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
     branches: [ "main" ]
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Plan
N/A — trivial CI config fix.

## Summary
- Changed CI concurrency group from `ci-${{ github.ref }}` to `ci-${{ github.event.pull_request.number || github.ref }}`

## Why
With the branch-ref concurrency group, all PRs targeting the same base branch share the same group. When one PR merges and other PRs update their branches, the new CI runs cancel in-progress runs for other PRs, creating a cascade where CI never finishes.

The fix uses the PR number for pull_request events (so pushing to the *same* PR still cancels old runs, which is desired) and falls back to ref for push events (main branch pushes). Different PRs no longer share a concurrency group.

## Repro / Validation
**Command(s) run:**
- Validated YAML syntax with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
- Verified diff is a single-line change

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] No code changes — CI workflow config only
- [x] YAML syntax validated

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): CI runs for different PRs will no longer cancel each other

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/ci-fix-concurrency
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/ci-fix-concurrency
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                        76b775b [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/ci-fix-concurrency  9daa18b [ci/fix-auto-merge-concurrency]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)