### PR TITLE
feat: interpretability pipeline — SHAP, selection paths, decision comparison

### DIFF
--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -226,6 +226,8 @@ Every experiment run creates a standardized directory under `data/runs/<run_id>/
 | `scripts/internal/generate_rung_tables.py` | Canonical CSV table generation for Arc D v2 rung reports |
 | `scripts/internal/generate_rung_report.py` | Markdown rung report renderer from CSV tables and chart PNGs |
 | `scripts/internal/generate_evidence_manifest.py` | Evidence manifest generator (JSON + markdown) for Arc D v2 |
+| `scripts/internal/generate_interpretability.py` | Interpretability pipeline (SHAP, selection paths, decision comparison) |
+| `scripts/internal/generate_interpretability_charts.py` | Interpretability chart generation from CSV data |
 | `scripts/internal/manage_artifacts.py` | Artifact lifecycle CLI (status, supersession, quarantine, prune) |
 | `scripts/internal/play_policy_gate.py` | Play policy stability gate |
 | `scripts/internal/review_driver.py` | Autonomous review loop orchestrator (state machine) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "scipy>=1.7.0",
   "pyyaml>=6.0.0",
   "pyarrow>=10.0.0",
+  "shap>=0.49.1",
 ]
 
 [project.optional-dependencies]
@@ -49,4 +50,3 @@ ignore = ["E501", "E402", "E712", "E741"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["bid_euchre"]
-

--- a/scripts/internal/generate_interpretability.py
+++ b/scripts/internal/generate_interpretability.py
@@ -1,0 +1,750 @@
+#!/usr/bin/env python
+"""Generate interpretability artifacts for Arc D v2 rung analysis.
+
+Produces SHAP feature analysis, selection path traces, and pairwise
+decision comparison CSVs from trained action-value model artifacts.
+
+CLI:
+    uv run python scripts/internal/generate_interpretability.py \\
+        --rung-dir data/runs/r0_smoke_42 \\
+        --report-dir /tmp/interpretability_report \\
+        --eval-sample 5000
+
+Outputs (CSVs in <report-dir>/chart_data/):
+  - shap_feature_ranking.csv
+  - shap_dependence.csv
+  - shap_interactions.csv
+  - selection_paths.csv
+  - decision_comparison.csv
+  - disagreement_outcomes.csv
+  - context_feature_usage.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+# ── Context feature classification ──────────────────────────
+
+# Features that come from auction context (partner signals), not hand evaluation.
+# This list is the canonical source for context vs hand feature tagging.
+CONTEXT_FEATURE_NAMES = frozenset(
+    [
+        "partner_bid_level",
+        "partner_passed",
+        "partner_suit_match",
+        "partner_bid_confidence",
+        "auction_position",
+        "is_dealer",
+    ]
+)
+
+# Action features injected by the action-value pipeline
+ACTION_FEATURE_NAMES = frozenset(["bid_n", "bid_n_sq"])
+
+# Contract families
+CONTRACT_FAMILIES = ("suit", "high", "low", "pass")
+
+
+# ── Artifact loading ────────────────────────────────────────
+
+
+def _discover_artifacts(rung_dir: Path) -> list[dict]:
+    """Find all action-value JSON artifacts in a rung directory.
+
+    Searches for files matching known schema patterns in artifacts/.
+    Returns list of dicts with 'path', 'name', 'schema', 'artifact' keys.
+    """
+    artifacts_dir = rung_dir / "artifacts"
+    if not artifacts_dir.exists():
+        logger.warning("No artifacts/ directory in %s", rung_dir)
+        return []
+
+    results = []
+    for json_path in sorted(artifacts_dir.glob("*.json")):
+        try:
+            with open(json_path) as f:
+                artifact = json.load(f)
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning("Skipping %s: %s", json_path, e)
+            continue
+
+        schema = artifact.get("schema_version", "")
+        if schema in ("action_value_gbt_v1", "action_value_olsa_v1"):
+            results.append(
+                {
+                    "path": json_path,
+                    "name": json_path.stem,
+                    "schema": schema,
+                    "artifact": artifact,
+                }
+            )
+    return results
+
+
+def _load_gbt_models(artifact: dict, artifact_dir: Path) -> dict[str, Any] | None:
+    """Load GBT sklearn models from joblib files referenced in artifact.
+
+    Returns dict mapping contract family -> sklearn model, or None on failure.
+    """
+    try:
+        import joblib
+    except ImportError:
+        logger.warning("joblib not available; cannot load GBT models")
+        return None
+
+    models = {}
+    models_meta = artifact["models"]
+    for family in CONTRACT_FAMILIES:
+        if family not in models_meta:
+            continue
+        meta = models_meta[family]
+        if "model_file" not in meta:
+            continue
+        model_path = artifact_dir / meta["model_file"]
+        if not model_path.exists():
+            logger.warning("Model file not found: %s", model_path)
+            return None
+        models[family] = joblib.load(model_path)
+    return models
+
+
+def _get_feature_names(artifact: dict, family: str) -> list[str]:
+    """Extract feature names for a model family from artifact metadata."""
+    models = artifact.get("models", {})
+    if family in models and "feature_names" in models[family]:
+        return list(models[family]["feature_names"])
+    return []
+
+
+# ── SHAP analysis ───────────────────────────────────────────
+
+
+def generate_shap_analysis(
+    artifact_info: dict,
+    eval_df: pd.DataFrame,
+    eval_sample: int,
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Run SHAP TreeExplainer on GBT models and produce ranking/dependence/interaction CSVs.
+
+    Args:
+        artifact_info: Dict with 'name', 'artifact', 'path', 'schema' keys.
+        eval_df: Evaluation dataset (parquet-loaded).
+        eval_sample: Max rows to subsample for SHAP computation.
+
+    Returns:
+        (ranking_df, dependence_df, interactions_df)
+    """
+    try:
+        import shap
+    except ImportError:
+        logger.warning("shap not installed; skipping SHAP analysis")
+        return pd.DataFrame(), pd.DataFrame(), pd.DataFrame()
+
+    artifact = artifact_info["artifact"]
+    artifact_dir = artifact_info["path"].parent
+    model_name = artifact_info["name"]
+
+    gbt_models = _load_gbt_models(artifact, artifact_dir)
+    if gbt_models is None:
+        logger.warning("Could not load GBT models for %s; skipping SHAP", model_name)
+        return pd.DataFrame(), pd.DataFrame(), pd.DataFrame()
+
+    ranking_rows: list[dict] = []
+    dependence_rows: list[dict] = []
+    interaction_rows: list[dict] = []
+
+    for family in CONTRACT_FAMILIES:
+        if family not in gbt_models:
+            continue
+
+        model = gbt_models[family]
+        feature_names = _get_feature_names(artifact, family)
+        if not feature_names:
+            logger.warning("No feature_names for %s/%s; skipping", model_name, family)
+            continue
+
+        # Filter eval data to this contract family
+        if family == "pass":
+            family_df = eval_df[eval_df["action_type"] == "pass"]
+        else:
+            family_df = eval_df[eval_df["contract_family"] == family]
+
+        if len(family_df) == 0:
+            logger.warning("No eval data for %s/%s", model_name, family)
+            continue
+
+        # Subsample
+        if len(family_df) > eval_sample:
+            family_df = family_df.sample(n=eval_sample, random_state=42)
+
+        # Build feature matrix
+        available_features = [f for f in feature_names if f in family_df.columns]
+        if len(available_features) < len(feature_names):
+            missing = set(feature_names) - set(available_features)
+            logger.warning(
+                "Missing features for %s/%s: %s", model_name, family, missing
+            )
+            continue
+
+        X = family_df[available_features].values
+
+        # TreeExplainer
+        try:
+            explainer = shap.TreeExplainer(model)
+            shap_values = explainer.shap_values(X)
+        except Exception as e:
+            logger.warning("SHAP failed for %s/%s: %s", model_name, family, e)
+            continue
+
+        mean_abs_shap = np.abs(shap_values).mean(axis=0)
+        mean_shap = shap_values.mean(axis=0)
+
+        # Ranking
+        sorted_indices = np.argsort(-mean_abs_shap)
+        for rank, idx in enumerate(sorted_indices, 1):
+            direction = "positive" if mean_shap[idx] > 0 else "negative"
+            ranking_rows.append(
+                {
+                    "model": model_name,
+                    "contract": family,
+                    "feature": available_features[idx],
+                    "rank": rank,
+                    "mean_abs_shap": round(float(mean_abs_shap[idx]), 6),
+                    "direction": direction,
+                }
+            )
+
+        # Dependence (top 5 features)
+        top_5_indices = sorted_indices[:5]
+        for idx in top_5_indices:
+            feat_name = available_features[idx]
+            for i in range(len(X)):
+                dependence_rows.append(
+                    {
+                        "model": model_name,
+                        "contract": family,
+                        "feature": feat_name,
+                        "feature_value": round(float(X[i, idx]), 6),
+                        "shap_value": round(float(shap_values[i, idx]), 6),
+                    }
+                )
+
+        # Interactions (top 3 pairs by absolute interaction strength)
+        # Use SHAP interaction values if available, otherwise approximate
+        try:
+            interaction_values = explainer.shap_interaction_values(
+                X[: min(500, len(X))]
+            )
+            n_features = interaction_values.shape[2]
+            # Sum absolute interaction strengths across samples
+            mean_interactions = np.abs(interaction_values).mean(axis=0)
+            # Get off-diagonal elements
+            pairs = []
+            for i in range(n_features):
+                for j in range(i + 1, n_features):
+                    pairs.append((i, j, float(mean_interactions[i, j])))
+            pairs.sort(key=lambda x: x[2], reverse=True)
+            for i, j, strength in pairs[:3]:
+                interaction_rows.append(
+                    {
+                        "model": model_name,
+                        "contract": family,
+                        "feature_1": available_features[i],
+                        "feature_2": available_features[j],
+                        "interaction_strength": round(strength, 6),
+                    }
+                )
+        except Exception as e:
+            logger.info(
+                "Interaction values not available for %s/%s: %s", model_name, family, e
+            )
+
+    ranking_df = pd.DataFrame(ranking_rows)
+    dependence_df = pd.DataFrame(dependence_rows)
+    interactions_df = pd.DataFrame(interaction_rows)
+
+    return ranking_df, dependence_df, interactions_df
+
+
+# ── Selection paths ─────────────────────────────────────────
+
+
+def extract_selection_paths(artifact_info: dict) -> pd.DataFrame:
+    """Extract forward selection path from artifact metadata.
+
+    The selection log is stored in artifact['metadata']['selection_logs']
+    when the model was trained with --selection forward.
+
+    Returns DataFrame with columns: model, contract, step, feature_added, oof_r2, delta_r2
+    """
+    artifact = artifact_info["artifact"]
+    model_name = artifact_info["name"]
+    metadata = artifact.get("metadata", {})
+    selection_logs = metadata.get("selection_logs")
+
+    if selection_logs is None:
+        logger.info(
+            "No selection_logs in %s metadata; skipping selection paths", model_name
+        )
+        return pd.DataFrame()
+
+    rows: list[dict] = []
+    for contract, log in selection_logs.items():
+        steps = log.get("steps", [])
+        for step_info in steps:
+            step_num = step_info["step"]
+            feature = step_info["feature"]
+            r2 = step_info["r2"]
+            delta = step_info["improvement"]
+
+            rows.append(
+                {
+                    "model": model_name,
+                    "contract": contract,
+                    "step": step_num,
+                    "feature_added": feature,
+                    "oof_r2": round(r2, 6),
+                    "delta_r2": round(delta, 6),
+                }
+            )
+
+    return pd.DataFrame(rows)
+
+
+# ── Decision comparison ─────────────────────────────────────
+
+
+def _predict_best_action(
+    model: Any,
+    feature_names: list[str],
+    X_base: np.ndarray,
+    max_bid: int = 10,
+) -> np.ndarray:
+    """Predict the best bid level for each sample using a GBT model.
+
+    For each hand, evaluate bid_n from 1..max_bid and pick the level
+    with the highest predicted value. Returns array of best bid levels.
+
+    Args:
+        model: Trained sklearn GBT model.
+        feature_names: Feature names the model expects.
+        X_base: Base feature matrix (n_samples, n_state_features) without action features.
+        max_bid: Maximum bid level to evaluate.
+
+    Returns:
+        Array of best bid levels (n_samples,).
+    """
+    # Determine which columns are action features
+    bid_n_idx = None
+    bid_n_sq_idx = None
+    for i, name in enumerate(feature_names):
+        if name == "bid_n":
+            bid_n_idx = i
+        elif name == "bid_n_sq":
+            bid_n_sq_idx = i
+
+    if bid_n_idx is None:
+        # No action features — model predicts value directly
+        preds = model.predict(X_base)
+        # Return dummy bid levels
+        return np.ones(len(X_base), dtype=int)
+
+    n_samples = X_base.shape[0]
+    best_bids = np.ones(n_samples, dtype=int)
+    best_values = np.full(n_samples, -np.inf)
+
+    for bid_n in range(1, max_bid + 1):
+        X_trial = X_base.copy()
+        X_trial[:, bid_n_idx] = bid_n
+        if bid_n_sq_idx is not None:
+            X_trial[:, bid_n_sq_idx] = bid_n * bid_n
+
+        preds = model.predict(X_trial)
+        better = preds > best_values
+        best_values[better] = preds[better]
+        best_bids[better] = bid_n
+
+    return best_bids
+
+
+def generate_decision_comparison(
+    artifact_infos: list[dict],
+    eval_df: pd.DataFrame,
+    eval_sample: int,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Compare decisions between pairs of models.
+
+    For each pair of GBT models, predicts best action for the same eval set
+    and computes agreement rate and outcome differences.
+
+    Returns:
+        (comparison_df, disagreement_outcomes_df)
+    """
+    try:
+        import joblib  # noqa: F401
+    except ImportError:
+        logger.warning("joblib not available; skipping decision comparison")
+        return pd.DataFrame(), pd.DataFrame()
+
+    # Load all GBT models and their predictions
+    model_predictions: dict[str, dict[str, np.ndarray]] = {}
+    model_features: dict[str, dict[str, list[str]]] = {}
+
+    for info in artifact_infos:
+        artifact = info["artifact"]
+        if info["schema"] != "action_value_gbt_v1":
+            continue
+
+        gbt_models = _load_gbt_models(artifact, info["path"].parent)
+        if gbt_models is None:
+            continue
+
+        model_name = info["name"]
+        model_predictions[model_name] = {}
+        model_features[model_name] = {}
+
+        for family in ("suit", "high", "low"):
+            if family not in gbt_models:
+                continue
+
+            feature_names = _get_feature_names(artifact, family)
+            if not feature_names:
+                continue
+
+            # Filter to contract family
+            family_df = eval_df[eval_df["contract_family"] == family]
+            if len(family_df) == 0:
+                continue
+
+            if len(family_df) > eval_sample:
+                family_df = family_df.sample(n=eval_sample, random_state=42)
+
+            available = [f for f in feature_names if f in family_df.columns]
+            if len(available) != len(feature_names):
+                continue
+
+            X = family_df[available].values.astype(float)
+
+            best_bids = _predict_best_action(gbt_models[family], feature_names, X)
+            model_predictions[model_name][family] = best_bids
+            model_features[model_name][family] = available
+
+    # Pairwise comparison
+    comparison_rows: list[dict] = []
+    disagreement_rows: list[dict] = []
+    model_names = sorted(model_predictions.keys())
+
+    for i, model_a in enumerate(model_names):
+        for model_b in model_names[i + 1 :]:
+            for family in ("suit", "high", "low"):
+                if family not in model_predictions[model_a]:
+                    continue
+                if family not in model_predictions[model_b]:
+                    continue
+
+                preds_a = model_predictions[model_a][family]
+                preds_b = model_predictions[model_b][family]
+
+                # Align lengths (use min since sampling may differ)
+                n = min(len(preds_a), len(preds_b))
+                preds_a = preds_a[:n]
+                preds_b = preds_b[:n]
+
+                agree = (preds_a == preds_b).sum()
+                n_disagree = n - agree
+                agreement_rate = agree / n if n > 0 else 0.0
+
+                comparison_rows.append(
+                    {
+                        "model_a": model_a,
+                        "model_b": model_b,
+                        "contract": family,
+                        "agreement_rate": round(float(agreement_rate), 4),
+                        "n_disagree": int(n_disagree),
+                    }
+                )
+
+                # Disagreement outcomes: who bid higher? (proxy for "better")
+                if n_disagree > 0:
+                    disagree_mask = preds_a != preds_b
+                    a_higher = (preds_a[disagree_mask] > preds_b[disagree_mask]).sum()
+                    b_higher = (preds_b[disagree_mask] > preds_a[disagree_mask]).sum()
+                    a_higher_pct = a_higher / n_disagree
+                    b_higher_pct = b_higher / n_disagree
+                    tie_pct = 1.0 - a_higher_pct - b_higher_pct
+                else:
+                    a_higher_pct = 0.0
+                    b_higher_pct = 0.0
+                    tie_pct = 1.0
+
+                disagreement_rows.append(
+                    {
+                        "model_a": model_a,
+                        "model_b": model_b,
+                        "contract": family,
+                        "a_better_pct": round(float(a_higher_pct), 4),
+                        "b_better_pct": round(float(b_higher_pct), 4),
+                        "tie_pct": round(float(tie_pct), 4),
+                    }
+                )
+
+    return pd.DataFrame(comparison_rows), pd.DataFrame(disagreement_rows)
+
+
+# ── Context feature usage ───────────────────────────────────
+
+
+def generate_context_feature_usage(
+    shap_ranking_df: pd.DataFrame,
+) -> pd.DataFrame:
+    """Tag features as hand vs context and check top-10 entry.
+
+    Uses the SHAP ranking to determine whether context features
+    (partner signals, auction position) entered the top 10.
+
+    Returns DataFrame with columns:
+        model, contract, feature, rank, mean_abs_shap, is_context_feature, entered_top_10
+    """
+    if shap_ranking_df.empty:
+        return pd.DataFrame()
+
+    rows: list[dict] = []
+    for _, row in shap_ranking_df.iterrows():
+        is_context = row["feature"] in CONTEXT_FEATURE_NAMES
+        entered_top_10 = row["rank"] <= 10
+        rows.append(
+            {
+                "model": row["model"],
+                "contract": row["contract"],
+                "feature": row["feature"],
+                "rank": int(row["rank"]),
+                "mean_abs_shap": float(row["mean_abs_shap"]),
+                "is_context_feature": is_context,
+                "entered_top_10": entered_top_10,
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+# ── Main orchestrator ───────────────────────────────────────
+
+
+def _find_eval_dataset(rung_dir: Path) -> Path | None:
+    """Find the eval dataset (parquet) in the rung directory."""
+    # Check datasets/ subdirectory first
+    datasets_dir = rung_dir / "datasets"
+    if datasets_dir.exists():
+        for p in sorted(datasets_dir.glob("*.parquet")):
+            return p
+
+    # Check for action_value dataset
+    for p in sorted(rung_dir.glob("**/*.parquet")):
+        if "action_value" in p.name:
+            return p
+
+    return None
+
+
+def run(
+    rung_dir: Path,
+    report_dir: Path,
+    eval_sample: int = 5000,
+) -> dict[str, Path]:
+    """Run the full interpretability pipeline.
+
+    Args:
+        rung_dir: Path to rung directory containing artifacts/ and datasets/.
+        report_dir: Output directory for CSVs.
+        eval_sample: Max samples for SHAP computation.
+
+    Returns:
+        Dict mapping output name -> file path.
+    """
+    chart_data_dir = report_dir / "chart_data"
+    chart_data_dir.mkdir(parents=True, exist_ok=True)
+
+    outputs: dict[str, Path] = {}
+
+    # Discover artifacts
+    artifact_infos = _discover_artifacts(rung_dir)
+    if not artifact_infos:
+        logger.warning("No action-value artifacts found in %s", rung_dir)
+        return outputs
+
+    logger.info(
+        "Found %d artifacts: %s",
+        len(artifact_infos),
+        [a["name"] for a in artifact_infos],
+    )
+
+    # Load eval dataset
+    eval_path = _find_eval_dataset(rung_dir)
+    eval_df = pd.DataFrame()
+    if eval_path is not None:
+        logger.info("Loading eval dataset: %s", eval_path)
+        eval_df = pd.read_parquet(eval_path)
+        logger.info(
+            "Eval dataset: %d rows, %d columns", len(eval_df), len(eval_df.columns)
+        )
+    else:
+        logger.warning("No eval dataset found in %s", rung_dir)
+
+    # ── SHAP analysis ──
+    all_ranking = []
+    all_dependence = []
+    all_interactions = []
+
+    for info in artifact_infos:
+        if info["schema"] != "action_value_gbt_v1":
+            logger.info("Skipping SHAP for non-GBT artifact: %s", info["name"])
+            continue
+
+        if eval_df.empty:
+            logger.warning("No eval data; skipping SHAP for %s", info["name"])
+            continue
+
+        ranking, dependence, interactions = generate_shap_analysis(
+            info, eval_df, eval_sample
+        )
+        all_ranking.append(ranking)
+        all_dependence.append(dependence)
+        all_interactions.append(interactions)
+
+    if all_ranking:
+        ranking_df = pd.concat(all_ranking, ignore_index=True)
+        if not ranking_df.empty:
+            path = chart_data_dir / "shap_feature_ranking.csv"
+            ranking_df.to_csv(path, index=False)
+            outputs["shap_feature_ranking"] = path
+            logger.info("Wrote %s (%d rows)", path, len(ranking_df))
+
+            # Context feature usage
+            context_df = generate_context_feature_usage(ranking_df)
+            if not context_df.empty:
+                path = chart_data_dir / "context_feature_usage.csv"
+                context_df.to_csv(path, index=False)
+                outputs["context_feature_usage"] = path
+                logger.info("Wrote %s (%d rows)", path, len(context_df))
+
+    if all_dependence:
+        dep_df = pd.concat(all_dependence, ignore_index=True)
+        if not dep_df.empty:
+            path = chart_data_dir / "shap_dependence.csv"
+            dep_df.to_csv(path, index=False)
+            outputs["shap_dependence"] = path
+            logger.info("Wrote %s (%d rows)", path, len(dep_df))
+
+    if all_interactions:
+        int_df = pd.concat(all_interactions, ignore_index=True)
+        if not int_df.empty:
+            path = chart_data_dir / "shap_interactions.csv"
+            int_df.to_csv(path, index=False)
+            outputs["shap_interactions"] = path
+            logger.info("Wrote %s (%d rows)", path, len(int_df))
+
+    # ── Selection paths ──
+    all_selection = []
+    for info in artifact_infos:
+        sel_df = extract_selection_paths(info)
+        if not sel_df.empty:
+            all_selection.append(sel_df)
+
+    if all_selection:
+        selection_df = pd.concat(all_selection, ignore_index=True)
+        path = chart_data_dir / "selection_paths.csv"
+        selection_df.to_csv(path, index=False)
+        outputs["selection_paths"] = path
+        logger.info("Wrote %s (%d rows)", path, len(selection_df))
+
+    # ── Decision comparison ──
+    gbt_infos = [i for i in artifact_infos if i["schema"] == "action_value_gbt_v1"]
+    if len(gbt_infos) >= 2 and not eval_df.empty:
+        comparison_df, disagreement_df = generate_decision_comparison(
+            gbt_infos, eval_df, eval_sample
+        )
+        if not comparison_df.empty:
+            path = chart_data_dir / "decision_comparison.csv"
+            comparison_df.to_csv(path, index=False)
+            outputs["decision_comparison"] = path
+            logger.info("Wrote %s (%d rows)", path, len(comparison_df))
+
+        if not disagreement_df.empty:
+            path = chart_data_dir / "disagreement_outcomes.csv"
+            disagreement_df.to_csv(path, index=False)
+            outputs["disagreement_outcomes"] = path
+            logger.info("Wrote %s (%d rows)", path, len(disagreement_df))
+    elif len(gbt_infos) < 2:
+        logger.info(
+            "Need >=2 GBT artifacts for decision comparison; found %d", len(gbt_infos)
+        )
+
+    return outputs
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate interpretability artifacts for Arc D v2 rung analysis"
+    )
+    parser.add_argument(
+        "--rung-dir",
+        type=Path,
+        required=True,
+        help="Path to rung directory containing artifacts/ and datasets/",
+    )
+    parser.add_argument(
+        "--report-dir",
+        type=Path,
+        required=True,
+        help="Output directory for interpretability CSVs",
+    )
+    parser.add_argument(
+        "--eval-sample",
+        type=int,
+        default=5000,
+        help="Max rows to subsample for SHAP computation (default: 5000)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s: %(message)s",
+    )
+
+    if not args.rung_dir.exists():
+        logger.error("Rung directory does not exist: %s", args.rung_dir)
+        sys.exit(1)
+
+    outputs = run(
+        rung_dir=args.rung_dir,
+        report_dir=args.report_dir,
+        eval_sample=args.eval_sample,
+    )
+
+    if outputs:
+        print(f"\nGenerated {len(outputs)} output files:")
+        for name, path in sorted(outputs.items()):
+            print(f"  {name}: {path}")
+    else:
+        print("\nNo output files generated (missing artifacts or eval data)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/internal/generate_interpretability_charts.py
+++ b/scripts/internal/generate_interpretability_charts.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python
+"""Generate interpretability charts from CSV data.
+
+Reads interpretability CSVs from chart_data/ and produces PNG charts.
+
+CLI:
+    uv run python scripts/internal/generate_interpretability_charts.py \\
+        --chart-data-dir /tmp/report/chart_data \\
+        --output-dir /tmp/report/charts
+
+Charts produced:
+  - shap_summary.png          — horizontal bar of mean |SHAP| per feature, faceted by contract
+  - shap_dependence_top5.png  — scatter plots of top-5 features vs SHAP values
+  - selection_path.png        — line chart of R² vs features added
+  - decision_agreement.png    — bar chart of pairwise agreement rates
+  - disagreement_outcomes.png — bar chart of who wins in disagreements
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")  # Non-interactive backend
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def _save_chart(fig: plt.Figure, output_dir: Path, name: str, dpi: int = 150) -> None:
+    """Save a chart and close the figure."""
+    path = output_dir / name
+    fig.savefig(path, dpi=dpi, bbox_inches="tight")
+    plt.close(fig)
+    logger.info("Saved: %s", path)
+
+
+def _read_csv_safe(path: Path) -> pd.DataFrame | None:
+    """Read CSV, returning None if missing or empty."""
+    if not path.exists():
+        logger.info("CSV not found: %s", path)
+        return None
+    try:
+        df = pd.read_csv(path)
+        return df if len(df) > 0 else None
+    except Exception as e:
+        logger.warning("Failed to read %s: %s", path, e)
+        return None
+
+
+def generate_shap_summary(ranking_df: pd.DataFrame, output_dir: Path) -> None:
+    """Horizontal bar chart of mean |SHAP| per feature, faceted by contract."""
+    contracts = sorted(ranking_df["contract"].unique())
+    n_contracts = len(contracts)
+    if n_contracts == 0:
+        return
+
+    fig, axes = plt.subplots(1, n_contracts, figsize=(5 * n_contracts, 8), sharey=False)
+    if n_contracts == 1:
+        axes = [axes]
+
+    for ax, contract in zip(axes, contracts):
+        cdf = ranking_df[ranking_df["contract"] == contract].copy()
+        # Take top 15 features
+        cdf = cdf.nsmallest(15, "rank")
+        cdf = cdf.sort_values("mean_abs_shap", ascending=True)
+
+        colors = ["#d73027" if d == "negative" else "#4575b4" for d in cdf["direction"]]
+        ax.barh(cdf["feature"], cdf["mean_abs_shap"], color=colors)
+        ax.set_xlabel("Mean |SHAP value|")
+        ax.set_title(f"{contract}")
+
+    fig.suptitle("SHAP Feature Importance by Contract", fontsize=14, y=1.02)
+    fig.tight_layout()
+    _save_chart(fig, output_dir, "shap_summary.png")
+
+
+def generate_shap_dependence(dependence_df: pd.DataFrame, output_dir: Path) -> None:
+    """Scatter plots of top-5 features vs SHAP values, faceted by contract."""
+    contracts = sorted(dependence_df["contract"].unique())
+
+    for contract in contracts:
+        cdf = dependence_df[dependence_df["contract"] == contract]
+        features = cdf["feature"].unique()[:5]
+        n_features = len(features)
+        if n_features == 0:
+            continue
+
+        fig, axes = plt.subplots(
+            1, n_features, figsize=(4 * n_features, 4), squeeze=False
+        )
+
+        for i, feat in enumerate(features):
+            ax = axes[0, i]
+            fdf = cdf[cdf["feature"] == feat]
+            ax.scatter(
+                fdf["feature_value"],
+                fdf["shap_value"],
+                alpha=0.3,
+                s=5,
+                c="#4575b4",
+            )
+            ax.set_xlabel(feat)
+            ax.set_ylabel("SHAP value" if i == 0 else "")
+            ax.axhline(0, color="gray", linewidth=0.5, linestyle="--")
+
+        fig.suptitle(f"SHAP Dependence: {contract}", fontsize=12)
+        fig.tight_layout()
+
+    # Combine into single output
+    if contracts:
+        _save_chart(fig, output_dir, "shap_dependence_top5.png")
+
+
+def generate_selection_path_chart(selection_df: pd.DataFrame, output_dir: Path) -> None:
+    """Line chart of R² vs features added, one line per contract."""
+    models = sorted(selection_df["model"].unique())
+    n_models = len(models)
+
+    fig, axes = plt.subplots(
+        1, max(n_models, 1), figsize=(6 * max(n_models, 1), 5), squeeze=False
+    )
+
+    for i, model in enumerate(models):
+        ax = axes[0, i]
+        mdf = selection_df[selection_df["model"] == model]
+        contracts = sorted(mdf["contract"].unique())
+
+        for contract in contracts:
+            cdf = mdf[mdf["contract"] == contract].sort_values("step")
+            ax.plot(
+                cdf["step"], cdf["oof_r2"], marker="o", label=contract, markersize=4
+            )
+
+        ax.set_xlabel("Features Added")
+        ax.set_ylabel("OOF R²")
+        ax.set_title(f"Selection Path: {model}")
+        ax.legend(loc="lower right")
+        ax.grid(True, alpha=0.3)
+
+    fig.tight_layout()
+    _save_chart(fig, output_dir, "selection_path.png")
+
+
+def generate_decision_agreement_chart(
+    comparison_df: pd.DataFrame, output_dir: Path
+) -> None:
+    """Bar chart of pairwise agreement rates by contract."""
+    if comparison_df.empty:
+        return
+
+    contracts = sorted(comparison_df["contract"].unique())
+
+    fig, ax = plt.subplots(
+        figsize=(max(6, 3 * len(comparison_df["model_a"].unique())), 5)
+    )
+
+    colors = {"suit": "#d73027", "high": "#4575b4", "low": "#91bfdb"}
+
+    # Group by pair
+    unique_pairs = comparison_df.apply(
+        lambda r: f"{r['model_a']} vs {r['model_b']}", axis=1
+    ).unique()
+
+    bar_positions = []
+    bar_values = []
+    bar_colors = []
+    bar_labels = []
+    tick_positions = []
+    tick_labels_list = []
+
+    pos = 0
+    for pair_name in unique_pairs:
+        pair_start = pos
+        for contract in contracts:
+            mask = (
+                comparison_df.apply(
+                    lambda r: f"{r['model_a']} vs {r['model_b']}", axis=1
+                )
+                == pair_name
+            ) & (comparison_df["contract"] == contract)
+            rows = comparison_df[mask]
+            if len(rows) > 0:
+                bar_positions.append(pos)
+                bar_values.append(rows.iloc[0]["agreement_rate"])
+                bar_colors.append(colors.get(contract, "#999999"))
+                bar_labels.append(contract)
+                pos += 1
+        tick_positions.append((pair_start + pos - 1) / 2)
+        tick_labels_list.append(pair_name.replace(" vs ", "\nvs\n"))
+        pos += 0.5
+
+    ax.bar(bar_positions, bar_values, color=bar_colors, width=0.7)
+    ax.set_ylabel("Agreement Rate")
+    ax.set_title("Decision Agreement Between Models")
+    ax.set_ylim(0, 1.05)
+
+    if tick_positions:
+        ax.set_xticks(tick_positions)
+        ax.set_xticklabels(tick_labels_list, fontsize=8)
+
+    # Legend for contracts
+    from matplotlib.patches import Patch
+
+    legend_elements = [
+        Patch(facecolor=colors.get(c, "#999999"), label=c) for c in contracts
+    ]
+    ax.legend(handles=legend_elements, loc="lower left")
+
+    fig.tight_layout()
+    _save_chart(fig, output_dir, "decision_agreement.png")
+
+
+def generate_disagreement_outcomes_chart(
+    disagreement_df: pd.DataFrame, output_dir: Path
+) -> None:
+    """Stacked bar chart showing who wins in disagreements."""
+    if disagreement_df.empty:
+        return
+
+    fig, ax = plt.subplots(figsize=(max(6, 2 * len(disagreement_df)), 5))
+
+    labels = disagreement_df.apply(
+        lambda r: f"{r['model_a']}\nvs {r['model_b']}\n({r['contract']})", axis=1
+    )
+    x = np.arange(len(labels))
+
+    ax.bar(
+        x,
+        disagreement_df["a_better_pct"],
+        label="Model A higher bid",
+        color="#d73027",
+    )
+    ax.bar(
+        x,
+        disagreement_df["tie_pct"],
+        bottom=disagreement_df["a_better_pct"],
+        label="Tie",
+        color="#ffffbf",
+    )
+    ax.bar(
+        x,
+        disagreement_df["b_better_pct"],
+        bottom=disagreement_df["a_better_pct"] + disagreement_df["tie_pct"],
+        label="Model B higher bid",
+        color="#4575b4",
+    )
+
+    ax.set_ylabel("Proportion")
+    ax.set_title("Disagreement Outcomes")
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels, fontsize=7, rotation=0)
+    ax.legend(loc="upper right")
+    ax.set_ylim(0, 1.05)
+
+    fig.tight_layout()
+    _save_chart(fig, output_dir, "disagreement_outcomes.png")
+
+
+def run(chart_data_dir: Path, output_dir: Path) -> list[str]:
+    """Generate all interpretability charts from CSV data.
+
+    Returns list of chart filenames generated.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    generated: list[str] = []
+
+    # SHAP summary
+    ranking_df = _read_csv_safe(chart_data_dir / "shap_feature_ranking.csv")
+    if ranking_df is not None:
+        generate_shap_summary(ranking_df, output_dir)
+        generated.append("shap_summary.png")
+
+    # SHAP dependence
+    dep_df = _read_csv_safe(chart_data_dir / "shap_dependence.csv")
+    if dep_df is not None:
+        generate_shap_dependence(dep_df, output_dir)
+        generated.append("shap_dependence_top5.png")
+
+    # Selection paths
+    sel_df = _read_csv_safe(chart_data_dir / "selection_paths.csv")
+    if sel_df is not None:
+        generate_selection_path_chart(sel_df, output_dir)
+        generated.append("selection_path.png")
+
+    # Decision agreement
+    comp_df = _read_csv_safe(chart_data_dir / "decision_comparison.csv")
+    if comp_df is not None:
+        generate_decision_agreement_chart(comp_df, output_dir)
+        generated.append("decision_agreement.png")
+
+    # Disagreement outcomes
+    disagree_df = _read_csv_safe(chart_data_dir / "disagreement_outcomes.csv")
+    if disagree_df is not None:
+        generate_disagreement_outcomes_chart(disagree_df, output_dir)
+        generated.append("disagreement_outcomes.png")
+
+    return generated
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate interpretability charts from CSV data"
+    )
+    parser.add_argument(
+        "--chart-data-dir",
+        type=Path,
+        required=True,
+        help="Directory containing interpretability CSVs",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Output directory for chart PNGs",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s: %(message)s",
+    )
+
+    charts = run(args.chart_data_dir, args.output_dir)
+    if charts:
+        print(f"\nGenerated {len(charts)} charts:")
+        for name in charts:
+            print(f"  {name}")
+    else:
+        print("\nNo charts generated (missing CSV data)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_interpretability.py
+++ b/tests/unit/test_interpretability.py
@@ -1,0 +1,877 @@
+"""Tests for the interpretability pipeline.
+
+Tests CSV schema correctness, decision comparison logic, context feature tagging,
+and graceful skip behaviors using synthetic/fixture data only.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# ── Fixtures ────────────────────────────────────────────────
+
+
+@pytest.fixture
+def synthetic_eval_df() -> pd.DataFrame:
+    """Synthetic evaluation dataset mimicking action-value parquet schema."""
+    rng = np.random.RandomState(42)
+    n = 200
+    contracts = ["suit", "high", "low"]
+    rows = []
+    for i in range(n):
+        contract = contracts[i % 3]
+        rows.append(
+            {
+                "hand_id": i // 4,
+                "contract_family": contract,
+                "action_type": "bid" if i % 5 != 0 else "pass",
+                "bid_n": rng.randint(1, 11),
+                "bid_n_sq": 0,  # filled below
+                "trump_count": rng.randint(0, 8),
+                "bower_count": rng.randint(0, 3),
+                "ace_count": rng.randint(0, 5),
+                "void_count": rng.randint(0, 4),
+                "singleton_count": rng.randint(0, 4),
+                "doubleton_count": rng.randint(0, 4),
+                "partner_bid_level": rng.randint(0, 6),
+                "partner_passed": rng.choice([0, 1]),
+                "partner_suit_match": rng.choice([0, 1]),
+                "net_points": rng.normal(0, 3),
+            }
+        )
+    df = pd.DataFrame(rows)
+    df["bid_n_sq"] = df["bid_n"] ** 2
+    return df
+
+
+@pytest.fixture
+def sample_gbt_artifact(tmp_path: Path) -> dict:
+    """Create a minimal GBT artifact JSON + mock joblib files."""
+    import joblib
+    from sklearn.ensemble import GradientBoostingRegressor
+
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+
+    feature_names = [
+        "trump_count",
+        "bower_count",
+        "ace_count",
+        "void_count",
+        "singleton_count",
+        "doubleton_count",
+        "partner_bid_level",
+        "partner_passed",
+        "partner_suit_match",
+        "bid_n",
+        "bid_n_sq",
+    ]
+
+    models = {}
+    for family in ("suit", "high", "low", "pass"):
+        model = GradientBoostingRegressor(n_estimators=5, max_depth=2, random_state=42)
+        # Train on tiny random data
+        rng = np.random.RandomState(42)
+        X = rng.rand(50, len(feature_names))
+        y = rng.normal(0, 1, 50)
+        model.fit(X, y)
+
+        model_file = f"gbt_{family}.joblib"
+        joblib.dump(model, artifacts_dir / model_file)
+        models[family] = {
+            "model_file": model_file,
+            "r_squared": 0.5,
+            "feature_names": feature_names,
+        }
+
+    artifact = {
+        "schema_version": "action_value_gbt_v1",
+        "target": "net_points",
+        "risk_mode": "neutral",
+        "continuation_policy": "hybrid_r0_full",
+        "action_features": ["bid_n", "bid_n_sq"],
+        "feature_set": "full",
+        "models": models,
+        "metadata": {
+            "n_deals": 100,
+            "training_seed": 42,
+            "arm": "full",
+            "context_features": [],
+            "model_class": "gbt",
+        },
+    }
+
+    artifact_path = artifacts_dir / "gbt_model_a.json"
+    with open(artifact_path, "w") as f:
+        json.dump(artifact, f)
+
+    return {
+        "path": artifact_path,
+        "name": "gbt_model_a",
+        "schema": "action_value_gbt_v1",
+        "artifact": artifact,
+    }
+
+
+@pytest.fixture
+def sample_ols_artifact(tmp_path: Path) -> dict:
+    """Create a minimal OLS artifact JSON (no SHAP support)."""
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir(exist_ok=True)
+
+    feature_names = [
+        "trump_count",
+        "bower_count",
+        "ace_count",
+        "bid_n",
+        "bid_n_sq",
+    ]
+
+    models = {}
+    for family in ("suit", "high", "low", "pass"):
+        models[family] = {
+            "coefficients": [0.1, 0.2, 0.3, 0.4, 0.5],
+            "intercept": 1.0,
+            "r_squared": 0.45,
+            "feature_names": feature_names,
+        }
+
+    artifact = {
+        "schema_version": "action_value_olsa_v1",
+        "target": "net_points",
+        "risk_mode": "neutral",
+        "continuation_policy": "hybrid_r0_full",
+        "action_features": ["bid_n", "bid_n_sq"],
+        "feature_set": "full",
+        "models": models,
+        "metadata": {
+            "n_deals": 100,
+            "training_seed": 42,
+            "arm": "full",
+            "context_features": [],
+            "model_class": "ols",
+            "selection": "forward",
+            "selection_logs": {
+                "suit": {
+                    "steps": [
+                        {
+                            "step": 1,
+                            "feature": "trump_count",
+                            "feature_index": 0,
+                            "r2": 0.35,
+                            "improvement": 0.35,
+                        },
+                        {
+                            "step": 2,
+                            "feature": "bower_count",
+                            "feature_index": 1,
+                            "r2": 0.42,
+                            "improvement": 0.07,
+                        },
+                        {
+                            "step": 3,
+                            "feature": "ace_count",
+                            "feature_index": 2,
+                            "r2": 0.45,
+                            "improvement": 0.03,
+                        },
+                    ],
+                    "final_r2": 0.45,
+                    "n_selected": 3,
+                    "locked_base": [],
+                },
+                "high": {
+                    "steps": [
+                        {
+                            "step": 1,
+                            "feature": "ace_count",
+                            "feature_index": 2,
+                            "r2": 0.30,
+                            "improvement": 0.30,
+                        },
+                        {
+                            "step": 2,
+                            "feature": "trump_count",
+                            "feature_index": 0,
+                            "r2": 0.38,
+                            "improvement": 0.08,
+                        },
+                    ],
+                    "final_r2": 0.38,
+                    "n_selected": 2,
+                    "locked_base": [],
+                },
+            },
+        },
+    }
+
+    artifact_path = artifacts_dir / "ols_model.json"
+    with open(artifact_path, "w") as f:
+        json.dump(artifact, f)
+
+    return {
+        "path": artifact_path,
+        "name": "ols_model",
+        "schema": "action_value_olsa_v1",
+        "artifact": artifact,
+    }
+
+
+@pytest.fixture
+def two_gbt_artifacts(tmp_path: Path, synthetic_eval_df: pd.DataFrame) -> list[dict]:
+    """Create two GBT artifacts for pairwise comparison tests."""
+    import joblib
+    from sklearn.ensemble import GradientBoostingRegressor
+
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir(exist_ok=True)
+
+    feature_names = [
+        "trump_count",
+        "bower_count",
+        "ace_count",
+        "void_count",
+        "singleton_count",
+        "doubleton_count",
+        "partner_bid_level",
+        "partner_passed",
+        "partner_suit_match",
+        "bid_n",
+        "bid_n_sq",
+    ]
+
+    results = []
+    for model_id in ("model_a", "model_b"):
+        seed = 42 if model_id == "model_a" else 99
+        models_section = {}
+        for family in ("suit", "high", "low", "pass"):
+            model = GradientBoostingRegressor(
+                n_estimators=5, max_depth=2, random_state=seed
+            )
+            rng = np.random.RandomState(seed)
+            X = rng.rand(50, len(feature_names))
+            y = rng.normal(0, 1, 50)
+            model.fit(X, y)
+
+            model_file = f"gbt_{family}_{model_id}.joblib"
+            joblib.dump(model, artifacts_dir / model_file)
+            models_section[family] = {
+                "model_file": model_file,
+                "r_squared": 0.5,
+                "feature_names": feature_names,
+            }
+
+        artifact = {
+            "schema_version": "action_value_gbt_v1",
+            "target": "net_points",
+            "risk_mode": "neutral",
+            "continuation_policy": "hybrid_r0_full",
+            "action_features": ["bid_n", "bid_n_sq"],
+            "feature_set": "full",
+            "models": models_section,
+            "metadata": {
+                "n_deals": 100,
+                "training_seed": seed,
+                "arm": "full",
+                "context_features": [],
+                "model_class": "gbt",
+            },
+        }
+
+        artifact_path = artifacts_dir / f"{model_id}.json"
+        with open(artifact_path, "w") as f:
+            json.dump(artifact, f)
+
+        results.append(
+            {
+                "path": artifact_path,
+                "name": model_id,
+                "schema": "action_value_gbt_v1",
+                "artifact": artifact,
+            }
+        )
+
+    return results
+
+
+# ── Import helper ───────────────────────────────────────────
+
+# The scripts live outside src/ so we import via path manipulation in tests.
+# This mirrors how other test files import internal scripts.
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts" / "internal"
+
+
+def _import_generate_interpretability():
+    """Import the generate_interpretability module."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "generate_interpretability",
+        SCRIPTS_DIR / "generate_interpretability.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _import_generate_interpretability_charts():
+    """Import the generate_interpretability_charts module."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "generate_interpretability_charts",
+        SCRIPTS_DIR / "generate_interpretability_charts.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ── SHAP analysis tests ────────────────────────────────────
+
+
+class TestShapAnalysis:
+    """Tests for SHAP-based feature analysis."""
+
+    def test_shap_ranking_csv_schema(
+        self, sample_gbt_artifact: dict, synthetic_eval_df: pd.DataFrame
+    ):
+        """SHAP ranking CSV has correct columns."""
+        mod = _import_generate_interpretability()
+        ranking, _, _ = mod.generate_shap_analysis(
+            sample_gbt_artifact, synthetic_eval_df, eval_sample=100
+        )
+        assert not ranking.empty
+        expected_cols = {
+            "model",
+            "contract",
+            "feature",
+            "rank",
+            "mean_abs_shap",
+            "direction",
+        }
+        assert set(ranking.columns) == expected_cols
+
+    def test_shap_ranking_direction_values(
+        self, sample_gbt_artifact: dict, synthetic_eval_df: pd.DataFrame
+    ):
+        """Direction is either 'positive' or 'negative'."""
+        mod = _import_generate_interpretability()
+        ranking, _, _ = mod.generate_shap_analysis(
+            sample_gbt_artifact, synthetic_eval_df, eval_sample=100
+        )
+        assert ranking["direction"].isin(["positive", "negative"]).all()
+
+    def test_shap_ranking_has_all_contracts(
+        self, sample_gbt_artifact: dict, synthetic_eval_df: pd.DataFrame
+    ):
+        """SHAP ranking includes rows for each contract family with data."""
+        mod = _import_generate_interpretability()
+        ranking, _, _ = mod.generate_shap_analysis(
+            sample_gbt_artifact, synthetic_eval_df, eval_sample=100
+        )
+        contracts = set(ranking["contract"].unique())
+        # Should have suit, high, low (pass may or may not be present)
+        assert "suit" in contracts
+        assert "high" in contracts
+        assert "low" in contracts
+
+    def test_shap_dependence_csv_schema(
+        self, sample_gbt_artifact: dict, synthetic_eval_df: pd.DataFrame
+    ):
+        """SHAP dependence CSV has correct columns."""
+        mod = _import_generate_interpretability()
+        _, dependence, _ = mod.generate_shap_analysis(
+            sample_gbt_artifact, synthetic_eval_df, eval_sample=100
+        )
+        assert not dependence.empty
+        expected_cols = {"model", "contract", "feature", "feature_value", "shap_value"}
+        assert set(dependence.columns) == expected_cols
+
+    def test_shap_interactions_csv_schema(
+        self, sample_gbt_artifact: dict, synthetic_eval_df: pd.DataFrame
+    ):
+        """SHAP interactions CSV has correct columns when interactions available."""
+        mod = _import_generate_interpretability()
+        _, _, interactions = mod.generate_shap_analysis(
+            sample_gbt_artifact, synthetic_eval_df, eval_sample=50
+        )
+        if not interactions.empty:
+            expected_cols = {
+                "model",
+                "contract",
+                "feature_1",
+                "feature_2",
+                "interaction_strength",
+            }
+            assert set(interactions.columns) == expected_cols
+
+    def test_shap_graceful_skip_when_unavailable(
+        self, sample_gbt_artifact: dict, synthetic_eval_df: pd.DataFrame
+    ):
+        """SHAP analysis returns empty DataFrames when shap is not importable."""
+        mod = _import_generate_interpretability()
+        with patch.dict(sys.modules, {"shap": None}):
+            # Force re-import check
+            ranking, dep, inter = mod.generate_shap_analysis(
+                sample_gbt_artifact, synthetic_eval_df, eval_sample=100
+            )
+        # The function catches ImportError internally, so we test the guard path
+        # by checking it doesn't crash
+
+    def test_shap_skips_ols_artifacts(
+        self, sample_ols_artifact: dict, synthetic_eval_df: pd.DataFrame
+    ):
+        """SHAP analysis returns empty DataFrames for non-GBT artifacts."""
+        mod = _import_generate_interpretability()
+        # OLS artifacts have no joblib models, so _load_gbt_models returns None
+        ranking, dep, inter = mod.generate_shap_analysis(
+            sample_ols_artifact, synthetic_eval_df, eval_sample=100
+        )
+        assert ranking.empty
+        assert dep.empty
+        assert inter.empty
+
+
+# ── Selection path tests ────────────────────────────────────
+
+
+class TestSelectionPaths:
+    """Tests for forward selection path extraction."""
+
+    def test_selection_paths_csv_schema(self, sample_ols_artifact: dict):
+        """Selection paths CSV has correct columns."""
+        mod = _import_generate_interpretability()
+        df = mod.extract_selection_paths(sample_ols_artifact)
+        assert not df.empty
+        expected_cols = {
+            "model",
+            "contract",
+            "step",
+            "feature_added",
+            "oof_r2",
+            "delta_r2",
+        }
+        assert set(df.columns) == expected_cols
+
+    def test_selection_paths_values(self, sample_ols_artifact: dict):
+        """Selection paths contain correct values from fixture."""
+        mod = _import_generate_interpretability()
+        df = mod.extract_selection_paths(sample_ols_artifact)
+
+        # Check suit path
+        suit_df = df[df["contract"] == "suit"].sort_values("step")
+        assert len(suit_df) == 3
+        assert list(suit_df["feature_added"]) == [
+            "trump_count",
+            "bower_count",
+            "ace_count",
+        ]
+        assert suit_df.iloc[0]["oof_r2"] == pytest.approx(0.35)
+        assert suit_df.iloc[1]["delta_r2"] == pytest.approx(0.07)
+
+    def test_selection_paths_r2_monotonic(self, sample_ols_artifact: dict):
+        """OOF R² should be monotonically increasing along the selection path."""
+        mod = _import_generate_interpretability()
+        df = mod.extract_selection_paths(sample_ols_artifact)
+
+        for contract in df["contract"].unique():
+            cdf = df[df["contract"] == contract].sort_values("step")
+            r2_values = cdf["oof_r2"].values
+            # Each step's R² should be >= previous (monotonic in forward selection)
+            for i in range(1, len(r2_values)):
+                assert (
+                    r2_values[i] >= r2_values[i - 1]
+                ), f"R² decreased at step {i + 1} for {contract}"
+
+    def test_selection_paths_skip_when_missing(self, sample_gbt_artifact: dict):
+        """Returns empty DataFrame when no selection_logs in metadata."""
+        mod = _import_generate_interpretability()
+        df = mod.extract_selection_paths(sample_gbt_artifact)
+        assert df.empty
+
+
+# ── Decision comparison tests ───────────────────────────────
+
+
+class TestDecisionComparison:
+    """Tests for pairwise model decision comparison."""
+
+    def test_comparison_csv_schema(
+        self, two_gbt_artifacts: list, synthetic_eval_df: pd.DataFrame
+    ):
+        """Decision comparison CSV has correct columns."""
+        mod = _import_generate_interpretability()
+        comp_df, _ = mod.generate_decision_comparison(
+            two_gbt_artifacts, synthetic_eval_df, eval_sample=100
+        )
+        assert not comp_df.empty
+        expected_cols = {
+            "model_a",
+            "model_b",
+            "contract",
+            "agreement_rate",
+            "n_disagree",
+        }
+        assert set(comp_df.columns) == expected_cols
+
+    def test_disagreement_outcomes_csv_schema(
+        self, two_gbt_artifacts: list, synthetic_eval_df: pd.DataFrame
+    ):
+        """Disagreement outcomes CSV has correct columns."""
+        mod = _import_generate_interpretability()
+        _, disagree_df = mod.generate_decision_comparison(
+            two_gbt_artifacts, synthetic_eval_df, eval_sample=100
+        )
+        assert not disagree_df.empty
+        expected_cols = {
+            "model_a",
+            "model_b",
+            "contract",
+            "a_better_pct",
+            "b_better_pct",
+            "tie_pct",
+        }
+        assert set(disagree_df.columns) == expected_cols
+
+    def test_agreement_rate_bounds(
+        self, two_gbt_artifacts: list, synthetic_eval_df: pd.DataFrame
+    ):
+        """Agreement rate is between 0 and 1."""
+        mod = _import_generate_interpretability()
+        comp_df, _ = mod.generate_decision_comparison(
+            two_gbt_artifacts, synthetic_eval_df, eval_sample=100
+        )
+        assert (comp_df["agreement_rate"] >= 0).all()
+        assert (comp_df["agreement_rate"] <= 1).all()
+
+    def test_disagreement_pcts_sum_to_one(
+        self, two_gbt_artifacts: list, synthetic_eval_df: pd.DataFrame
+    ):
+        """a_better + b_better + tie should sum to ~1.0."""
+        mod = _import_generate_interpretability()
+        _, disagree_df = mod.generate_decision_comparison(
+            two_gbt_artifacts, synthetic_eval_df, eval_sample=100
+        )
+        totals = (
+            disagree_df["a_better_pct"]
+            + disagree_df["b_better_pct"]
+            + disagree_df["tie_pct"]
+        )
+        np.testing.assert_allclose(totals, 1.0, atol=0.01)
+
+    def test_identical_models_full_agreement(
+        self, sample_gbt_artifact: dict, synthetic_eval_df: pd.DataFrame
+    ):
+        """Two copies of the same model should have 100% agreement."""
+        mod = _import_generate_interpretability()
+        # Create two identical artifact infos
+        info_b = dict(sample_gbt_artifact)
+        info_b = {**info_b, "name": "gbt_model_b"}
+        comp_df, _ = mod.generate_decision_comparison(
+            [sample_gbt_artifact, info_b], synthetic_eval_df, eval_sample=100
+        )
+        assert (comp_df["agreement_rate"] == 1.0).all()
+
+    def test_comparison_with_synthetic_predictions(self):
+        """Decision comparison works correctly with known synthetic predictions."""
+        # Create predictable predictions
+        preds_a = np.array([3, 4, 5, 6, 7])
+        preds_b = np.array([3, 4, 6, 6, 8])
+
+        agree = (preds_a == preds_b).sum()
+        n_disagree = len(preds_a) - agree
+        agreement_rate = agree / len(preds_a)
+
+        assert agreement_rate == pytest.approx(0.6)  # 3/5 agree
+        assert n_disagree == 2
+
+        disagree_mask = preds_a != preds_b
+        a_higher = (preds_a[disagree_mask] > preds_b[disagree_mask]).sum()
+        b_higher = (preds_b[disagree_mask] > preds_a[disagree_mask]).sum()
+        assert a_higher == 0  # model_a never bids higher
+        assert b_higher == 2  # model_b bids higher in both disagreements
+
+
+# ── Context feature usage tests ─────────────────────────────
+
+
+class TestContextFeatureUsage:
+    """Tests for context vs hand feature classification."""
+
+    def test_context_feature_tagging(self):
+        """Known context features are correctly tagged."""
+        mod = _import_generate_interpretability()
+
+        ranking_df = pd.DataFrame(
+            [
+                {
+                    "model": "test",
+                    "contract": "suit",
+                    "feature": "trump_count",
+                    "rank": 1,
+                    "mean_abs_shap": 0.5,
+                    "direction": "positive",
+                },
+                {
+                    "model": "test",
+                    "contract": "suit",
+                    "feature": "partner_bid_level",
+                    "rank": 2,
+                    "mean_abs_shap": 0.3,
+                    "direction": "positive",
+                },
+                {
+                    "model": "test",
+                    "contract": "suit",
+                    "feature": "ace_count",
+                    "rank": 11,
+                    "mean_abs_shap": 0.01,
+                    "direction": "negative",
+                },
+            ]
+        )
+
+        result = mod.generate_context_feature_usage(ranking_df)
+        assert len(result) == 3
+
+        # trump_count is a hand feature
+        hand_row = result[result["feature"] == "trump_count"].iloc[0]
+        assert bool(hand_row["is_context_feature"]) is False
+        assert bool(hand_row["entered_top_10"]) is True
+
+        # partner_bid_level is a context feature
+        ctx_row = result[result["feature"] == "partner_bid_level"].iloc[0]
+        assert bool(ctx_row["is_context_feature"]) is True
+        assert bool(ctx_row["entered_top_10"]) is True
+
+        # ace_count is rank 11 so NOT in top 10
+        low_row = result[result["feature"] == "ace_count"].iloc[0]
+        assert bool(low_row["is_context_feature"]) is False
+        assert bool(low_row["entered_top_10"]) is False
+
+    def test_context_feature_usage_csv_schema(self):
+        """Context feature usage CSV has correct columns."""
+        mod = _import_generate_interpretability()
+
+        ranking_df = pd.DataFrame(
+            [
+                {
+                    "model": "test",
+                    "contract": "suit",
+                    "feature": "trump_count",
+                    "rank": 1,
+                    "mean_abs_shap": 0.5,
+                    "direction": "positive",
+                },
+            ]
+        )
+
+        result = mod.generate_context_feature_usage(ranking_df)
+        expected_cols = {
+            "model",
+            "contract",
+            "feature",
+            "rank",
+            "mean_abs_shap",
+            "is_context_feature",
+            "entered_top_10",
+        }
+        assert set(result.columns) == expected_cols
+
+    def test_context_feature_constants(self):
+        """CONTEXT_FEATURE_NAMES includes known partner/auction features."""
+        mod = _import_generate_interpretability()
+        assert "partner_bid_level" in mod.CONTEXT_FEATURE_NAMES
+        assert "partner_passed" in mod.CONTEXT_FEATURE_NAMES
+        assert "partner_suit_match" in mod.CONTEXT_FEATURE_NAMES
+        # Hand features should not be in context set
+        assert "trump_count" not in mod.CONTEXT_FEATURE_NAMES
+        assert "ace_count" not in mod.CONTEXT_FEATURE_NAMES
+
+    def test_empty_ranking_returns_empty(self):
+        """Empty ranking DF produces empty context usage DF."""
+        mod = _import_generate_interpretability()
+        result = mod.generate_context_feature_usage(pd.DataFrame())
+        assert result.empty
+
+
+# ── Artifact discovery tests ────────────────────────────────
+
+
+class TestArtifactDiscovery:
+    """Tests for artifact discovery in rung directories."""
+
+    def test_discover_gbt_artifacts(self, sample_gbt_artifact: dict):
+        """Discovers GBT artifacts from artifacts/ directory."""
+        mod = _import_generate_interpretability()
+        rung_dir = sample_gbt_artifact["path"].parent.parent
+        results = mod._discover_artifacts(rung_dir)
+        assert len(results) == 1
+        assert results[0]["schema"] == "action_value_gbt_v1"
+
+    def test_discover_ols_artifacts(self, sample_ols_artifact: dict):
+        """Discovers OLS artifacts from artifacts/ directory."""
+        mod = _import_generate_interpretability()
+        rung_dir = sample_ols_artifact["path"].parent.parent
+        results = mod._discover_artifacts(rung_dir)
+        assert len(results) == 1
+        assert results[0]["schema"] == "action_value_olsa_v1"
+
+    def test_discover_no_artifacts(self, tmp_path: Path):
+        """Returns empty list when no artifacts directory."""
+        mod = _import_generate_interpretability()
+        results = mod._discover_artifacts(tmp_path)
+        assert results == []
+
+    def test_discover_ignores_non_action_value(self, tmp_path: Path):
+        """Ignores JSON files with other schema versions."""
+        artifacts_dir = tmp_path / "artifacts"
+        artifacts_dir.mkdir()
+        with open(artifacts_dir / "other.json", "w") as f:
+            json.dump({"schema_version": "other_v1"}, f)
+
+        mod = _import_generate_interpretability()
+        results = mod._discover_artifacts(tmp_path)
+        assert results == []
+
+
+# ── End-to-end pipeline test ────────────────────────────────
+
+
+class TestEndToEnd:
+    """Integration-style tests for the full pipeline."""
+
+    def test_run_produces_csvs(
+        self,
+        tmp_path: Path,
+        sample_gbt_artifact: dict,
+        synthetic_eval_df: pd.DataFrame,
+    ):
+        """Full run produces at least SHAP ranking and context usage CSVs."""
+        mod = _import_generate_interpretability()
+
+        # Set up rung dir with artifact and eval data
+        rung_dir = sample_gbt_artifact["path"].parent.parent
+        datasets_dir = rung_dir / "datasets"
+        datasets_dir.mkdir(exist_ok=True)
+        synthetic_eval_df.to_parquet(datasets_dir / "action_value.parquet")
+
+        report_dir = tmp_path / "report"
+        outputs = mod.run(rung_dir, report_dir, eval_sample=50)
+
+        assert "shap_feature_ranking" in outputs
+        assert "context_feature_usage" in outputs
+
+        # Verify files exist and are valid CSVs
+        for name, path in outputs.items():
+            assert path.exists(), f"{name} file does not exist"
+            df = pd.read_csv(path)
+            assert len(df) > 0, f"{name} CSV is empty"
+
+    def test_run_with_selection_logs(
+        self,
+        tmp_path: Path,
+        sample_ols_artifact: dict,
+    ):
+        """Run produces selection paths CSV from OLS artifact with selection logs."""
+        mod = _import_generate_interpretability()
+        rung_dir = sample_ols_artifact["path"].parent.parent
+
+        report_dir = tmp_path / "report"
+        outputs = mod.run(rung_dir, report_dir, eval_sample=50)
+
+        assert "selection_paths" in outputs
+        df = pd.read_csv(outputs["selection_paths"])
+        assert len(df) > 0
+
+
+# ── Chart generation tests ──────────────────────────────────
+
+
+class TestChartGeneration:
+    """Tests for interpretability chart generation."""
+
+    def test_shap_summary_chart(self, tmp_path: Path):
+        """SHAP summary chart generates without error."""
+        mod = _import_generate_interpretability_charts()
+
+        ranking_df = pd.DataFrame(
+            [
+                {
+                    "model": "m1",
+                    "contract": "suit",
+                    "feature": f"f{i}",
+                    "rank": i,
+                    "mean_abs_shap": 1.0 / i,
+                    "direction": "positive",
+                }
+                for i in range(1, 6)
+            ]
+        )
+        mod.generate_shap_summary(ranking_df, tmp_path)
+        assert (tmp_path / "shap_summary.png").exists()
+
+    def test_selection_path_chart(self, tmp_path: Path):
+        """Selection path chart generates without error."""
+        mod = _import_generate_interpretability_charts()
+
+        sel_df = pd.DataFrame(
+            [
+                {
+                    "model": "m1",
+                    "contract": "suit",
+                    "step": 1,
+                    "feature_added": "f1",
+                    "oof_r2": 0.3,
+                    "delta_r2": 0.3,
+                },
+                {
+                    "model": "m1",
+                    "contract": "suit",
+                    "step": 2,
+                    "feature_added": "f2",
+                    "oof_r2": 0.4,
+                    "delta_r2": 0.1,
+                },
+            ]
+        )
+        mod.generate_selection_path_chart(sel_df, tmp_path)
+        assert (tmp_path / "selection_path.png").exists()
+
+    def test_run_charts_from_csvs(self, tmp_path: Path):
+        """Full chart run from CSV files."""
+        mod = _import_generate_interpretability_charts()
+
+        chart_data_dir = tmp_path / "chart_data"
+        chart_data_dir.mkdir()
+
+        # Write a minimal ranking CSV
+        ranking_df = pd.DataFrame(
+            [
+                {
+                    "model": "m1",
+                    "contract": "suit",
+                    "feature": f"f{i}",
+                    "rank": i,
+                    "mean_abs_shap": 1.0 / i,
+                    "direction": "positive",
+                }
+                for i in range(1, 4)
+            ]
+        )
+        ranking_df.to_csv(chart_data_dir / "shap_feature_ranking.csv", index=False)
+
+        output_dir = tmp_path / "charts"
+        generated = mod.run(chart_data_dir, output_dir)
+
+        assert "shap_summary.png" in generated
+        assert (output_dir / "shap_summary.png").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -4,13 +4,16 @@ requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "(python_full_version == '3.11.*' and sys_platform == 'win32') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "(python_full_version == '3.11.*' and sys_platform == 'emscripten') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "(python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "(python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin')",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version < '3.11'",
 ]
 
@@ -312,6 +315,8 @@ dependencies = [
     { name = "pyyaml" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "shap", version = "0.49.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "shap", version = "0.51.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [package.optional-dependencies]
@@ -354,6 +359,7 @@ requires-dist = [
     { name = "scikit-learn", marker = "extra == 'dev'", specifier = ">=1.4.0" },
     { name = "scipy", specifier = ">=1.7.0" },
     { name = "seaborn", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+    { name = "shap", specifier = ">=0.49.1" },
     { name = "statsmodels", marker = "extra == 'dev'", specifier = ">=0.14.0" },
 ]
 provides-extras = ["dev"]
@@ -577,6 +583,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -671,13 +686,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "(python_full_version == '3.11.*' and sys_platform == 'win32') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "(python_full_version == '3.11.*' and sys_platform == 'emscripten') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "(python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "(python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin')",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -1295,13 +1313,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "(python_full_version == '3.11.*' and sys_platform == 'win32') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "(python_full_version == '3.11.*' and sys_platform == 'emscripten') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "(python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "(python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin')",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
     { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
@@ -1513,7 +1534,7 @@ dependencies = [
     { name = "overrides", marker = "python_full_version < '3.12'" },
     { name = "packaging" },
     { name = "prometheus-client" },
-    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "pywinpty", marker = "(python_full_version < '3.11' and os_name == 'nt') or (os_name == 'nt' and platform_machine != 'x86_64') or (os_name == 'nt' and sys_platform != 'darwin')" },
     { name = "pyzmq" },
     { name = "send2trash" },
     { name = "terminado" },
@@ -1531,7 +1552,7 @@ name = "jupyter-server-terminals"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "pywinpty", marker = "(python_full_version < '3.11' and os_name == 'nt') or (os_name == 'nt' and platform_machine != 'x86_64') or (os_name == 'nt' and sys_platform != 'darwin')" },
     { name = "terminado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f4/a7/bcd0a9b0cbba88986fe944aaaf91bfda603e5a50bda8ed15123f381a3b2f/jupyter_server_terminals-0.5.4.tar.gz", hash = "sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5", size = 31770, upload-time = "2026-01-14T16:53:20.213Z" }
@@ -1723,6 +1744,57 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
+]
+
+[[package]]
+name = "llvmlite"
+version = "0.36.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin')",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/66/6b2c49c7c68da48d17059882fdb9ad9ac9e5ac3f22b00874d7996e3c44a8/llvmlite-0.36.0.tar.gz", hash = "sha256:765128fdf5f149ed0b889ffbe2b05eb1717f8e20a5c87fa2b4018fbcce0fcfc9", size = 126219, upload-time = "2021-03-12T13:41:52.064Z" }
+
+[[package]]
+name = "llvmlite"
+version = "0.46.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "(python_full_version == '3.11.*' and sys_platform == 'win32') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "(python_full_version == '3.11.*' and sys_platform == 'emscripten') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/cd/08ae687ba099c7e3d21fe2ea536500563ef1943c5105bf6ab4ee3829f68e/llvmlite-0.46.0.tar.gz", hash = "sha256:227c9fd6d09dce2783c18b754b7cd9d9b3b3515210c46acc2d3c5badd9870ceb", size = 193456, upload-time = "2025-12-08T18:15:36.295Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/a4/3959e1c61c5ca9db7921e5fd115b344c29b9d57a5dadd87bef97963ca1a5/llvmlite-0.46.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4323177e936d61ae0f73e653e2e614284d97d14d5dd12579adc92b6c2b0597b0", size = 37232766, upload-time = "2025-12-08T18:14:34.765Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a5/a4d916f1015106e1da876028606a8e87fd5d5c840f98c87bc2d5153b6a2f/llvmlite-0.46.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0a2d461cb89537b7c20feb04c46c32e12d5ad4f0896c9dfc0f60336219ff248e", size = 56275176, upload-time = "2025-12-08T18:14:37.944Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7f/a7f2028805dac8c1a6fae7bda4e739b7ebbcd45b29e15bf6d21556fcd3d5/llvmlite-0.46.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b1f6595a35b7b39c3518b85a28bf18f45e075264e4b2dce3f0c2a4f232b4a910", size = 55128629, upload-time = "2025-12-08T18:14:41.674Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/bc/4689e1ba0c073c196b594471eb21be0aa51d9e64b911728aa13cd85ef0ae/llvmlite-0.46.0-cp310-cp310-win_amd64.whl", hash = "sha256:e7a34d4aa6f9a97ee006b504be6d2b8cb7f755b80ab2f344dda1ef992f828559", size = 38138651, upload-time = "2025-12-08T18:14:45.845Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/a1/2ad4b2367915faeebe8447f0a057861f646dbf5fbbb3561db42c65659cf3/llvmlite-0.46.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:82f3d39b16f19aa1a56d5fe625883a6ab600d5cc9ea8906cca70ce94cabba067", size = 37232766, upload-time = "2025-12-08T18:14:48.836Z" },
+    { url = "https://files.pythonhosted.org/packages/12/b5/99cf8772fdd846c07da4fd70f07812a3c8fd17ea2409522c946bb0f2b277/llvmlite-0.46.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a3df43900119803bbc52720e758c76f316a9a0f34612a886862dfe0a5591a17e", size = 56275175, upload-time = "2025-12-08T18:14:51.604Z" },
+    { url = "https://files.pythonhosted.org/packages/38/f2/ed806f9c003563732da156139c45d970ee435bd0bfa5ed8de87ba972b452/llvmlite-0.46.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de183fefc8022d21b0aa37fc3e90410bc3524aed8617f0ff76732fc6c3af5361", size = 55128630, upload-time = "2025-12-08T18:14:55.107Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0c/8f5a37a65fc9b7b17408508145edd5f86263ad69c19d3574e818f533a0eb/llvmlite-0.46.0-cp311-cp311-win_amd64.whl", hash = "sha256:e8b10bc585c58bdffec9e0c309bb7d51be1f2f15e169a4b4d42f2389e431eb93", size = 38138652, upload-time = "2025-12-08T18:14:58.171Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f8/4db016a5e547d4e054ff2f3b99203d63a497465f81ab78ec8eb2ff7b2304/llvmlite-0.46.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b9588ad4c63b4f0175a3984b85494f0c927c6b001e3a246a3a7fb3920d9a137", size = 37232767, upload-time = "2025-12-08T18:15:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/85/4890a7c14b4fa54400945cb52ac3cd88545bbdb973c440f98ca41591cdc5/llvmlite-0.46.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3535bd2bb6a2d7ae4012681ac228e5132cdb75fefb1bcb24e33f2f3e0c865ed4", size = 56275176, upload-time = "2025-12-08T18:15:03.936Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/07/3d31d39c1a1a08cd5337e78299fca77e6aebc07c059fbd0033e3edfab45c/llvmlite-0.46.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4cbfd366e60ff87ea6cc62f50bc4cd800ebb13ed4c149466f50cf2163a473d1e", size = 55128630, upload-time = "2025-12-08T18:15:07.196Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/6b/d139535d7590a1bba1ceb68751bef22fadaa5b815bbdf0e858e3875726b2/llvmlite-0.46.0-cp312-cp312-win_amd64.whl", hash = "sha256:398b39db462c39563a97b912d4f2866cd37cba60537975a09679b28fbbc0fb38", size = 38138940, upload-time = "2025-12-08T18:15:10.162Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ff/3eba7eb0aed4b6fca37125387cd417e8c458e750621fce56d2c541f67fa8/llvmlite-0.46.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:30b60892d034bc560e0ec6654737aaa74e5ca327bd8114d82136aa071d611172", size = 37232767, upload-time = "2025-12-08T18:15:13.22Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/54/737755c0a91558364b9200702c3c9c15d70ed63f9b98a2c32f1c2aa1f3ba/llvmlite-0.46.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6cc19b051753368a9c9f31dc041299059ee91aceec81bd57b0e385e5d5bf1a54", size = 56275176, upload-time = "2025-12-08T18:15:16.339Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/91/14f32e1d70905c1c0aa4e6609ab5d705c3183116ca02ac6df2091868413a/llvmlite-0.46.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bca185892908f9ede48c0acd547fe4dc1bafefb8a4967d47db6cf664f9332d12", size = 55128629, upload-time = "2025-12-08T18:15:19.493Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/a7/d526ae86708cea531935ae777b6dbcabe7db52718e6401e0fb9c5edea80e/llvmlite-0.46.0-cp313-cp313-win_amd64.whl", hash = "sha256:67438fd30e12349ebb054d86a5a1a57fd5e87d264d2451bcfafbbbaa25b82a35", size = 38138941, upload-time = "2025-12-08T18:15:22.536Z" },
+    { url = "https://files.pythonhosted.org/packages/95/ae/af0ffb724814cc2ea64445acad05f71cff5f799bb7efb22e47ee99340dbc/llvmlite-0.46.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:d252edfb9f4ac1fcf20652258e3f102b26b03eef738dc8a6ffdab7d7d341d547", size = 37232768, upload-time = "2025-12-08T18:15:25.055Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/19/5018e5352019be753b7b07f7759cdabb69ca5779fea2494be8839270df4c/llvmlite-0.46.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:379fdd1c59badeff8982cb47e4694a6143bec3bb49aa10a466e095410522064d", size = 56275173, upload-time = "2025-12-08T18:15:28.109Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c9/d57877759d707e84c082163c543853245f91b70c804115a5010532890f18/llvmlite-0.46.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e8cbfff7f6db0fa2c771ad24154e2a7e457c2444d7673e6de06b8b698c3b269", size = 55128628, upload-time = "2025-12-08T18:15:31.098Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a8/e61a8c2b3cc7a597073d9cde1fcbb567e9d827f1db30c93cf80422eac70d/llvmlite-0.46.0-cp314-cp314-win_amd64.whl", hash = "sha256:7821eda3ec1f18050f981819756631d60b6d7ab1a6cf806d9efefbe3f4082d61", size = 39153056, upload-time = "2025-12-08T18:15:33.938Z" },
 ]
 
 [[package]]
@@ -2175,6 +2247,67 @@ wheels = [
 ]
 
 [[package]]
+name = "numba"
+version = "0.53.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin')",
+]
+dependencies = [
+    { name = "llvmlite", version = "0.36.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "setuptools", marker = "python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/7d/3d61160836e49f40913741c464f119551c15ed371c1d91ea50308495b93b/numba-0.53.1.tar.gz", hash = "sha256:9cd4e5216acdc66c4e9dab2dfd22ddb5bef151185c070d4a3cd8e78638aff5b0", size = 2213956, upload-time = "2021-03-26T09:15:50.402Z" }
+
+[[package]]
+name = "numba"
+version = "0.64.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "(python_full_version == '3.11.*' and sys_platform == 'win32') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "(python_full_version == '3.11.*' and sys_platform == 'emscripten') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "llvmlite", version = "0.46.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/c9/a0fb41787d01d621046138da30f6c2100d80857bf34b3390dd68040f27a3/numba-0.64.0.tar.gz", hash = "sha256:95e7300af648baa3308127b1955b52ce6d11889d16e8cfe637b4f85d2fca52b1", size = 2765679, upload-time = "2026-02-18T18:41:20.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/5e/604fed821cd7e3426bb3bc99a7ed6ac0bcb489f4cd93052256437d082f95/numba-0.64.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cc09b79440952e3098eeebea4bf6e8d2355fb7f12734fcd9fc5039f0dca90727", size = 2683250, upload-time = "2026-02-18T18:40:45.829Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/9f/9275a723d050b5f1a9b1c7fb7dbfce324fef301a8e50c5f88338569db06c/numba-0.64.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1afe3a80b8c2f376b211fb7a49e536ef9eafc92436afc95a2f41ea5392f8cc65", size = 3742168, upload-time = "2026-02-18T18:40:48.066Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d1/97ca7dddaa36b16f4c46319bdb6b4913ba15d0245317d0d8ccde7b2d7d92/numba-0.64.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23804194b93b8cd416c6444b5fbc4956082a45fed2d25436ef49c594666e7f7e", size = 3449103, upload-time = "2026-02-18T18:40:49.905Z" },
+    { url = "https://files.pythonhosted.org/packages/52/0a/b9e137ad78415373e3353564500e8bf29dbce3c0d73633bb384d4e5d7537/numba-0.64.0-cp310-cp310-win_amd64.whl", hash = "sha256:e2a9fe998bb2cf848960b34db02c2c3b5e02cf82c07a26d9eef3494069740278", size = 2749950, upload-time = "2026-02-18T18:40:51.536Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a3/1a4286a1c16136c8896d8e2090d950e79b3ec626d3a8dc9620f6234d5a38/numba-0.64.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:766156ee4b8afeeb2b2e23c81307c5d19031f18d5ce76ae2c5fb1429e72fa92b", size = 2682938, upload-time = "2026-02-18T18:40:52.897Z" },
+    { url = "https://files.pythonhosted.org/packages/19/16/aa6e3ba3cd45435c117d1101b278b646444ed05b7c712af631b91353f573/numba-0.64.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d17071b4ffc9d39b75d8e6c101a36f0c81b646123859898c9799cb31807c8f78", size = 3747376, upload-time = "2026-02-18T18:40:54.925Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/f1/dd2f25e18d75fdf897f730b78c5a7b00cc4450f2405564dbebfaf359f21f/numba-0.64.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4ead5630434133bac87fa67526eacb264535e4e9a2d5ec780e0b4fc381a7d275", size = 3453292, upload-time = "2026-02-18T18:40:56.818Z" },
+    { url = "https://files.pythonhosted.org/packages/31/29/e09d5630578a50a2b3fa154990b6b839cf95327aa0709e2d50d0b6816cd1/numba-0.64.0-cp311-cp311-win_amd64.whl", hash = "sha256:f2b1fd93e7aaac07d6fbaed059c00679f591f2423885c206d8c1b55d65ca3f2d", size = 2749824, upload-time = "2026-02-18T18:40:58.392Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a6/9fc52cb4f0d5e6d8b5f4d81615bc01012e3cf24e1052a60f17a68deb8092/numba-0.64.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:69440a8e8bc1a81028446f06b363e28635aa67bd51b1e498023f03b812e0ce68", size = 2683418, upload-time = "2026-02-18T18:40:59.886Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/89/1a74ea99b180b7a5587b0301ed1b183a2937c4b4b67f7994689b5d36fc34/numba-0.64.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f13721011f693ba558b8dd4e4db7f2640462bba1b855bdc804be45bbeb55031a", size = 3804087, upload-time = "2026-02-18T18:41:01.699Z" },
+    { url = "https://files.pythonhosted.org/packages/91/e1/583c647404b15f807410510fec1eb9b80cb8474165940b7749f026f21cbc/numba-0.64.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0b180b1133f2b5d8b3f09d96b6d7a9e51a7da5dda3c09e998b5bcfac85d222c", size = 3504309, upload-time = "2026-02-18T18:41:03.252Z" },
+    { url = "https://files.pythonhosted.org/packages/85/23/0fce5789b8a5035e7ace21216a468143f3144e02013252116616c58339aa/numba-0.64.0-cp312-cp312-win_amd64.whl", hash = "sha256:e63dc94023b47894849b8b106db28ccb98b49d5498b98878fac1a38f83ac007a", size = 2752740, upload-time = "2026-02-18T18:41:05.097Z" },
+    { url = "https://files.pythonhosted.org/packages/52/80/2734de90f9300a6e2503b35ee50d9599926b90cbb7ac54f9e40074cd07f1/numba-0.64.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3bab2c872194dcd985f1153b70782ec0fbbe348fffef340264eacd3a76d59fd6", size = 2683392, upload-time = "2026-02-18T18:41:06.563Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e8/14b5853ebefd5b37723ef365c5318a30ce0702d39057eaa8d7d76392859d/numba-0.64.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:703a246c60832cad231d2e73c1182f25bf3cc8b699759ec8fe58a2dbc689a70c", size = 3812245, upload-time = "2026-02-18T18:41:07.963Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a2/f60dc6c96d19b7185144265a5fbf01c14993d37ff4cd324b09d0212aa7ce/numba-0.64.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7e2e49a7900ee971d32af7609adc0cfe6aa7477c6f6cccdf6d8138538cf7756f", size = 3511328, upload-time = "2026-02-18T18:41:09.504Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/2a/fe7003ea7e7237ee7014f8eaeeb7b0d228a2db22572ca85bab2648cf52cb/numba-0.64.0-cp313-cp313-win_amd64.whl", hash = "sha256:396f43c3f77e78d7ec84cdfc6b04969c78f8f169351b3c4db814b97e7acf4245", size = 2752668, upload-time = "2026-02-18T18:41:11.455Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8a/77d26afe0988c592dd97cb8d4e80bfb3dfc7dbdacfca7d74a7c5c81dd8c2/numba-0.64.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:f565d55eaeff382cbc86c63c8c610347453af3d1e7afb2b6569aac1c9b5c93ce", size = 2683590, upload-time = "2026-02-18T18:41:12.897Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/4b/600b8b7cdbc7f9cebee9ea3d13bb70052a79baf28944024ffcb59f0712e3/numba-0.64.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9b55169b18892c783f85e9ad9e6f5297a6d12967e4414e6b71361086025ff0bb", size = 3781163, upload-time = "2026-02-18T18:41:15.377Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/73/53f2d32bfa45b7175e9944f6b816d8c32840178c3eee9325033db5bf838e/numba-0.64.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:196bcafa02c9dd1707e068434f6d5cedde0feb787e3432f7f1f0e993cc336c4c", size = 3481172, upload-time = "2026-02-18T18:41:17.281Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/00/aebd2f7f1e11e38814bb96e95a27580817a7b340608d3ac085fdbab83174/numba-0.64.0-cp314-cp314-win_amd64.whl", hash = "sha256:213e9acbe7f1c05090592e79020315c1749dd52517b90e94c517dca3f014d4a1", size = 2754700, upload-time = "2026-02-18T18:41:19.277Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
@@ -2246,13 +2379,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "(python_full_version == '3.11.*' and sys_platform == 'win32') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "(python_full_version == '3.11.*' and sys_platform == 'emscripten') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "(python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "(python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin')",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/24/62/ae72ff66c0f1fd959925b4c11f8c2dea61f47f6acaea75a08512cdfe3fed/numpy-2.4.1.tar.gz", hash = "sha256:a1ceafc5042451a858231588a104093474c6a5c57dcc724841f5c888d237d690", size = 20721320, upload-time = "2026-01-10T06:44:59.619Z" }
 wheels = [
@@ -2418,13 +2554,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "(python_full_version == '3.11.*' and sys_platform == 'win32') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "(python_full_version == '3.11.*' and sys_platform == 'emscripten') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "(python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "(python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin')",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -3420,13 +3559,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "(python_full_version == '3.11.*' and sys_platform == 'win32') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "(python_full_version == '3.11.*' and sys_platform == 'emscripten') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "(python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "(python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin')",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
     { name = "joblib", marker = "python_full_version >= '3.11'" },
@@ -3540,13 +3682,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "(python_full_version == '3.11.*' and sys_platform == 'win32') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "(python_full_version == '3.11.*' and sys_platform == 'emscripten') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "(python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "(python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin')",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -3650,12 +3795,136 @@ wheels = [
 ]
 
 [[package]]
+name = "shap"
+version = "0.49.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "cloudpickle", marker = "python_full_version < '3.11'" },
+    { name = "numba", version = "0.64.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "slicer", marker = "python_full_version < '3.11'" },
+    { name = "tqdm", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/c6/9823a7f483aa9f3179fc359c10d22da9e418b1a7a3fc99a42b705d05e82a/shap-0.49.1.tar.gz", hash = "sha256:1114ecd804fff29f50d522ce6031082fcf42fe4a32fb1b5da233b2415d784c8c", size = 4084725, upload-time = "2025-10-14T10:04:49.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/a1/66b4f04995ee23ff8638c21294f1a3a6dc87397af54c87aeeb037500f71f/shap-0.49.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:40140ec5d306719f89daee1df27805a71bcc1ac39630832455d316d0306d1283", size = 558950, upload-time = "2025-10-14T10:04:08.441Z" },
+    { url = "https://files.pythonhosted.org/packages/06/76/2142615fa5cc745fd66beb066d00db123cc86d614a31ca8029b29537a959/shap-0.49.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6e9977f1e0b6bba57967de600e8e6047b3e4643d06a4671f2dba1a97c1b5ab3e", size = 556605, upload-time = "2025-10-14T10:04:10.049Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3a/e28014ffc23f386da3d69abd978838e653fff5641831e5a34aade3f4dfe7/shap-0.49.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54ad4c38e6af56eaa1c892bb3af550a35df15ca0d27d2d41c1d1619ca6a2ba75", size = 1000329, upload-time = "2025-10-14T10:04:11.359Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/09/734325f0a9ab9d3dfa5c0908a927027b3d95b3f6929bb62d88e840b85abf/shap-0.49.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fcd832e97038648ba89f659863322d5cd3ea0815e18c36dd48cd7ae1ca9f264b", size = 1000713, upload-time = "2025-10-14T10:04:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a2/0518acabb104e21fecda65b0202e41edd06637c44dac15e2197e7d13a002/shap-0.49.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7fc2e864908277dca2b1d9c59a18b3f31576b985bd024f39b0c3cb7e2c7441db", size = 2065477, upload-time = "2025-10-14T10:04:13.874Z" },
+    { url = "https://files.pythonhosted.org/packages/af/e1/3d52717b617b9ad1e4d0c9634d3b7c52a913540fde27c4b4663a7ee76b87/shap-0.49.1-cp310-cp310-win_amd64.whl", hash = "sha256:4f5bec3d061b4f4889e1ac4e9b676aede2875778ff44b9d5f5a844cbe6788fd2", size = 547034, upload-time = "2025-10-14T10:04:16.17Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/08/d433b7d18a8b51a7d10477120f78877d806d2eb86283cb1661318d865f3d/shap-0.49.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1e208a0129c721bd0eba6268a9ffac4610dbc8a833d07d2ad9f39541bb737f06", size = 558742, upload-time = "2025-10-14T10:04:17.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/35/72929fdad25e055aff9dfbeb48c044682fc3b815d90cee4036b90bd65f4c/shap-0.49.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0b878470bdf6800069c25d2a8598eb0548aa1e6826becd39cca253521cc14866", size = 556486, upload-time = "2025-10-14T10:04:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/02/be/d92623be2c584784e99a8eb9a6cd02263b4eb363c9e49fa14c20f824bcbb/shap-0.49.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:118577d40c53f005268024e59f6a10cbcafbb6d03b3d97dce7c0c7510190ebaa", size = 1025978, upload-time = "2025-10-14T10:04:20.096Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e9/e4079b5de26a8269121ce38125e130c147dac7b59611e0bd94be10f9444e/shap-0.49.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f424465699aa2dda8057656c6b6d3cb927cf29b054c5bb01cfffcb9efa5dbf98", size = 1027831, upload-time = "2025-10-14T10:04:21.666Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ff/e22e1d899ed56384a2395d6121d6e21833c518c01c5b6c52fce3c0b0cbab/shap-0.49.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d505834fdf2a159e88b1dcdeddfd79f101fd789ba89d589faf0aaec060c0bad9", size = 2092627, upload-time = "2025-10-14T10:04:22.894Z" },
+    { url = "https://files.pythonhosted.org/packages/17/48/bbcd638a391ac0fb30033398a3cca60ba5c36941d962dd74958e67069108/shap-0.49.1-cp311-cp311-win_amd64.whl", hash = "sha256:897c7e6fa98d66482282c8f898c97ade181d714ecaf581da0dab5c49adb9f62c", size = 546845, upload-time = "2025-10-14T10:04:24.238Z" },
+    { url = "https://files.pythonhosted.org/packages/92/7a/ccecf7a9158baa10bdc5146907c72dd5f85c762cb5f16cdc74d15cebb8a1/shap-0.49.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c652dc77f1fffe73f5a3def3356c5090e2e6401c261e4fe5329d83cb6251e772", size = 559663, upload-time = "2025-10-14T10:04:25.412Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/c6/c43382d6c891fcf067d0a9f6d954351e3c7d330f4328c5816769b796aa27/shap-0.49.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c23f1493205e648634680c8974e82e7f4b2e96ae3a7eca2251680172bd197ae9", size = 556265, upload-time = "2025-10-14T10:04:27.098Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/71/f7db7a5a2cedaa3ac52f58f453172d613be041bedd9509ce5b5cba2096a6/shap-0.49.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41147740c42821023e1b60185ce8be989656ccac266cc9490d7a8e3ad53c556a", size = 1022419, upload-time = "2025-10-14T10:04:28.793Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a4/96ca9a69dd669ff835ddef875c5dd8e07599103769417d3e9051fd97d470/shap-0.49.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef9952929d4a7e6763d2716938067bdad762217e3afb46cabfc15a62c012b364", size = 1027074, upload-time = "2025-10-14T10:04:30.2Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/9a/89ed1ac8beffe8ff8e09c12cb351bc3c79ddaadcc47ca6ee434d76e464d7/shap-0.49.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e823417eb0a01947cd9bd763bef2e534c5aef7a7c2952b1badfa969c7d59d3b3", size = 2088172, upload-time = "2025-10-14T10:04:31.725Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/28/11422c1c3aa022a06e76cbfa3267e1750cedc00c1e02ef1ccae9c88cd6f4/shap-0.49.1-cp312-cp312-win_amd64.whl", hash = "sha256:cb28043decfec3f35f795421eb5a81545f629b7f60bbf7449cd2843a7f1c8cc6", size = 548036, upload-time = "2025-10-14T10:04:33.087Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5c/030bbfa19605ca4ad66a753d55e76aee5093be6748a6d33eda89e5613995/shap-0.49.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:333cd8e8c427badda92d5ada9e7aad1e3e1e8e7e0398da51a18b7ffb03514e45", size = 558604, upload-time = "2025-10-14T10:04:34.298Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/7f/7e7b78e9fac6f891096fb6a59a6d4db23243b0af2369ae54e161f513c485/shap-0.49.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4faf61560f73a66f4f26bc027c91f8939201979c4db24949dca305ba0a2ad36", size = 555311, upload-time = "2025-10-14T10:04:35.582Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/be/25283a0f8c30deaf897b89a0dbfd490d330f6fc68caa6f19db6e130832e9/shap-0.49.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b440da658d9aee7711bf642c9b4826d81f588fb478cd9e90c068646e90f56669", size = 1016897, upload-time = "2025-10-14T10:04:36.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/91/a63e563f3dc8e134db12dd155a1a6ed5e0649f79fc8ac651aac1088e8652/shap-0.49.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d8dfa5654eccf4d13dcb262a10314a4e0eb1060db842b2ef31e9fb0038168bc1", size = 1022476, upload-time = "2025-10-14T10:04:38.171Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a2/89303c1f7eb206658bf9ec974dc6e69b0a6bd309cf5de0cfa8f92f5a8eb3/shap-0.49.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ed3080030a6000d3737841c5770ed555b8a922b794fa0ba5aae1e45655eda1fa", size = 2087940, upload-time = "2025-10-14T10:04:39.497Z" },
+    { url = "https://files.pythonhosted.org/packages/84/bd/0b9b3e19b9b8cda51463f8a749dc354eb9c87f42eddcbfdf742dceb3746b/shap-0.49.1-cp313-cp313-win_amd64.whl", hash = "sha256:6af779344c23b12a47063aab7fc135fefbdb5849233c1813f11dd8cf2fc73bea", size = 547806, upload-time = "2025-10-14T10:04:40.712Z" },
+]
+
+[[package]]
+name = "shap"
+version = "0.51.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "(python_full_version == '3.11.*' and sys_platform == 'win32') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "(python_full_version == '3.11.*' and sys_platform == 'emscripten') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "(python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin')",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+]
+dependencies = [
+    { name = "cloudpickle", marker = "python_full_version >= '3.11'" },
+    { name = "llvmlite", version = "0.36.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "llvmlite", version = "0.46.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+    { name = "numba", version = "0.53.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "numba", version = "0.64.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pandas", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "slicer", marker = "python_full_version >= '3.11'" },
+    { name = "tqdm", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/0a/4a3ee4b1a3654f2a9ae038a64bb3e91a42af3da07577d69b65241f010970/shap-0.51.0.tar.gz", hash = "sha256:cfa17ff213657c9d50285aa923d79b0037a62e2ee1a31bc3eec7e196b00bdb59", size = 4108336, upload-time = "2026-03-04T09:18:19.985Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/4f/513ffc1c27242488be2269d5704c7bd8e82c6b28a04c297533d616003948/shap-0.51.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4b4b81d7401bc821490148a694a9f149f8ef488fa973b49fdc8a7916a572750f", size = 565103, upload-time = "2026-03-04T09:17:24.11Z" },
+    { url = "https://files.pythonhosted.org/packages/14/bf/bafa92ae6606f1ee38f14e866045fbcae21412a3a5766fb493b951a6e6e1/shap-0.51.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9b92f7371644c4a19660f734e0b0fe299d0eff273102230c9cf191e310576619", size = 562798, upload-time = "2026-03-04T09:17:25.909Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/09/a952ef8a1fe64b8a7bb909b2d3ab614d33cff7fdf646d62c3bd35d84de02/shap-0.51.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ddd314c9dc766f72027b3b6d9a8b975c7df67f1a27af7f857267c716b7d3dd8", size = 1052516, upload-time = "2026-03-04T09:17:27.816Z" },
+    { url = "https://files.pythonhosted.org/packages/42/48/541bd5b7f068804f33fac459274c06a46deb8f0e1edf3a9b176c00137629/shap-0.51.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a909d6e306d4083e4862b6d097d53f3b4aa4d5cdf2ef4dbac5e8245160d9abd", size = 1060070, upload-time = "2026-03-04T09:17:29.751Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f9/02269c83b3056c5fbaa13911e59b844146ed80c97a6f78aa0d374a9e8368/shap-0.51.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ff5534e92f5876c74975b53cc6b251126bbe092e5032f81e1fe8583c4a74d58c", size = 2023431, upload-time = "2026-03-04T09:17:31.97Z" },
+    { url = "https://files.pythonhosted.org/packages/72/ac/751f3070be48c4b365f565ca5b4ba4c93b0a371d8ee595859c62eab9885b/shap-0.51.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6f3a83f28d2304f81645392a1d346154d9d992705e762fb949fa5371925399b2", size = 2092764, upload-time = "2026-03-04T09:17:33.991Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8e/cee1ee136a4e54fe2fbb63a60d72d7c25e21a4ffe6aa05779cab7669cb31/shap-0.51.0-cp311-cp311-win_amd64.whl", hash = "sha256:ca2a9171e6c5b9a700d585982d7fd8336856ad818e24264420c56f9d8f02a961", size = 554870, upload-time = "2026-03-04T09:17:35.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ba/8c8fac8506327febada7dc58f90dc459287995bb7b8aadbc44506e61be55/shap-0.51.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:07b0367408b1b9fc51556f2ddac5ee4209cc51be592099e6d51d0834c9b037d8", size = 565741, upload-time = "2026-03-04T09:17:37.286Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/07f7c454ff5dff455576e5bb08cdb2cab05a4c1eb5e1b9959ef2ac28366d/shap-0.51.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e412bb475c9074ffd6684abb88d86d93275729b344cbfb37b4e4db37db759fbf", size = 562281, upload-time = "2026-03-04T09:17:39.006Z" },
+    { url = "https://files.pythonhosted.org/packages/93/a1/37e7229be000cf608ece024dcd76edae4cc618b22b402ea78270849cac3f/shap-0.51.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1aa9f659d2028e26ac7ec34cafbc14585fdc14d0c8973e9442c65af1af1ff781", size = 1051009, upload-time = "2026-03-04T09:17:40.989Z" },
+    { url = "https://files.pythonhosted.org/packages/af/c1/a9152876b04f9a05ca18bd3e8bc4bc72468ae32429bfbb30a9cbd4ad35b9/shap-0.51.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0b1f9e62d6a3fa28765d7b61abda7caf76aba21e769423fbf3ce8a7a5e498243", size = 1062849, upload-time = "2026-03-04T09:17:42.587Z" },
+    { url = "https://files.pythonhosted.org/packages/80/89/38c903c438b33063b006f41d00684af8b424bb95f0fcfd8963d1501bf427/shap-0.51.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:dee16e81082dec5ce2a37c41c2b9cbebcb4bf7de79133a72d84a4093b7d4158c", size = 2014842, upload-time = "2026-03-04T09:17:44.212Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/fd/9b295ad15420566dca713b792d9beb65692804b96c69cc99ffec5e31db58/shap-0.51.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c3b878f6414213a12247faa00d609957fdfbcc33cfd48a6751500c4708b5666d", size = 2090611, upload-time = "2026-03-04T09:17:46.728Z" },
+    { url = "https://files.pythonhosted.org/packages/20/0e/6f581645b66efff6bf091953f474eb16e64da499cfac0c552dd77559f205/shap-0.51.0-cp312-cp312-win_amd64.whl", hash = "sha256:ee76aa705927ac64acd4f506722f52596e77d3ced87078bc86bfcb4571c7b976", size = 556117, upload-time = "2026-03-04T09:17:48.68Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4a/77f8dc2c6874d8a27123afffcb79f540a80ed3ccfd640604e4d8beb9cc5e/shap-0.51.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f3efeef8a76e2ee735fad50f82e5a8e56ba8639f42e2fa50dc1997caed77c488", size = 564931, upload-time = "2026-03-04T09:17:51.022Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/5e/5c6d37992e93b3fa44509d8544281cd5ae357c8946bc0e756e78139b4baf/shap-0.51.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:724cdd8298450ae22b08ca40e07136c73e4e75dbdf8e3f07d741a291bf636dad", size = 561686, upload-time = "2026-03-04T09:17:52.462Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b7/76dbca9c4b83602841c016fec7201e4146c5e6347a8b0428e7c0617ba424/shap-0.51.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:13eb21626ea671604769c847ac0604871a03df0842522087ffc00181683780a4", size = 1050719, upload-time = "2026-03-04T09:17:54.252Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b1/472ca0adf25215dfdbca9f398d853536413091fe47dd69bb3f67dbd445f4/shap-0.51.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f32d006680708513efff07f67dcbe44a531b242ae042dee99b7024e210391ac2", size = 1063794, upload-time = "2026-03-04T09:17:56.154Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8e/9072acfcbe6abc79fbfe87360c7dcfe16d7498cdb13dc560820912eb5dd5/shap-0.51.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:33540a7e3c70bd1a742a4d0576c19b5e000165038de953d3ebf31a7bb53d01f4", size = 2012838, upload-time = "2026-03-04T09:17:57.835Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/65/b95588a1f48eb9e98aa61e6db31cf63a388970e4c11341d40ddece3b54f8/shap-0.51.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f461e5a1d6b0cae3fd9c6bd00c95111ed95b9e0020ec71f14291429ed17d49f4", size = 2090245, upload-time = "2026-03-04T09:17:59.501Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d5/1ec3120f461f31a03d1d2f1d339f5058f12c7a542d22bfcc350511eccc8a/shap-0.51.0-cp313-cp313-win_amd64.whl", hash = "sha256:5f51ca55bda10b3fa2125f2b8e08e9d6a6edcbb0e752c67050e87a6d3ca7d53b", size = 555927, upload-time = "2026-03-04T09:18:01.274Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/57/f48dd00ac0d9f75a1f34f5ae47ed3269e8acd541189555f39e49e6f126f4/shap-0.51.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d0c33498ed7042f7259ff207bd3aa1cc814fb759240e5f1500e018660b597c17", size = 562390, upload-time = "2026-03-04T09:18:02.722Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c8/c3b067d10c7a792fd1a32ea93f218b2c217fa99d125f79f26d31376ae246/shap-0.51.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6afaeac1fdd7883a058fb071c7044aff6c44699377a35a5d73e75b68564d0d47", size = 1050124, upload-time = "2026-03-04T09:18:04.172Z" },
+    { url = "https://files.pythonhosted.org/packages/31/81/cf180b20ac0c1323b78386667a24dfc2f6d827baa0b223d84bfd5818aa03/shap-0.51.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da930d73fa23d7a296660431f01726ae47ef2e7d9fee7e1632fb674be7b150b9", size = 1059129, upload-time = "2026-03-04T09:18:05.815Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c3/45ab3242f055980938671d568540ff1dbd84eb9bf4fe0d3235432f7bad35/shap-0.51.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:331d80a993e32404dd76254f5a82cb481453b4d9e58c0e7da13a3b700a381b03", size = 2012487, upload-time = "2026-03-04T09:18:07.919Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/38/a25863c3c8d344e3e322b8dcbac41929b9d00cfb9df3166ac9c350d89c53/shap-0.51.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c52aa8fb311502d5d25e8d631806326656318ab4094459ddbf1410837aaeb139", size = 2086328, upload-time = "2026-03-04T09:18:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5e/60fbf1ffe0c150c4db0e80e31b3f9428e633d33ccf072e1e75227679cbfc/shap-0.51.0-cp314-cp314-win_amd64.whl", hash = "sha256:86f24dab2c64d78f38170d490a03ff6fb1b48cf3bd0a1527e9bed23e74ad5d2c", size = 559185, upload-time = "2026-03-04T09:18:11.64Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/56/8c5f94ae86590e612487c77b9b9bef3fd2f3c91969b3c6e8743ce06440f3/shap-0.51.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:80132eca5679e7e8da7a0d9bfee58d0a3979be25630fd6598ef608bbcefce784", size = 568928, upload-time = "2026-03-04T09:18:13.2Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/04467bf7b8430c3a5c709401ab065022a72340bc50dfaf67a1cc117ce15e/shap-0.51.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18828bc4f78adb644ae35c50e79a246d262fa6cf17143c78cca091796b21c27b", size = 1082574, upload-time = "2026-03-04T09:18:14.899Z" },
+    { url = "https://files.pythonhosted.org/packages/12/d1/3f7b841dd943a1cbb9c693ed65366c6afc1ac54c70065e0281fa82b57075/shap-0.51.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:71e18a6850af4cdeece1a3f9d4b633a421885fcfda079125e3d35ea08433d3eb", size = 2034618, upload-time = "2026-03-04T09:18:16.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/42/3668db63cb38e9648e97087d60a0d4ce569c2e8c2b8828124e6da433026f/shap-0.51.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:23c33eae29f887153ef952846ec3bff6abc0aed3aa01594e4ae66cd94a227a49", size = 2096224, upload-time = "2026-03-04T09:18:18.094Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "slicer"
+version = "0.0.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/f9/b4bce2825b39b57760b361e6131a3dacee3d8951c58cb97ad120abb90317/slicer-0.0.8.tar.gz", hash = "sha256:2e7553af73f0c0c2d355f4afcc3ecf97c6f2156fcf4593955c3f56cf6c4d6eb7", size = 14894, upload-time = "2024-03-09T23:35:26.826Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/81/9ef641ff4e12cbcca30e54e72fb0951a2ba195d0cda0ba4100e532d929db/slicer-0.0.8-py3-none-any.whl", hash = "sha256:6c206258543aecd010d497dc2eca9d2805860a0b3758673903456b7df7934dc3", size = 15251, upload-time = "2024-03-09T07:03:07.708Z" },
 ]
 
 [[package]]
@@ -3753,7 +4022,7 @@ version = "0.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ptyprocess", marker = "os_name != 'nt'" },
-    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "pywinpty", marker = "(python_full_version < '3.11' and os_name == 'nt') or (os_name == 'nt' and platform_machine != 'x86_64') or (os_name == 'nt' and sys_platform != 'darwin')" },
     { name = "tornado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }


### PR DESCRIPTION
## Plan
- Arc D v2 lineage plan, PR 3b (interpretability scripts)

## Summary
- Add `generate_interpretability.py` script: SHAP analysis for GBT models, forward selection path extraction, pairwise decision comparison, context feature usage tagging — produces 7 CSV outputs
- Add `generate_interpretability_charts.py` script: PNG chart generation from interpretability CSVs (SHAP summary, dependence, selection paths, agreement, disagreement outcomes)
- Add 30-test test suite covering CSV schemas, decision comparison logic, context feature tagging, graceful skips, and chart generation
- Add `shap` dependency and update ARCHITECTURE.md

## Why
Interpretability is a core requirement for Arc D v2 rung analysis. These scripts enable automated SHAP feature ranking, selection path visualization, and pairwise model decision comparison — all producing machine-readable CSVs that feed into rung reports.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_interpretability.py -v  # 30 passed
make check-quiet  # All checks passed
```

**Config (if applicable):**
- N/A (scripts consume existing rung artifacts)

**Seed (if applicable):**
- Synthetic test data uses seed=42

## Tests
- [x] `uv run python -m pytest tests/unit/test_interpretability.py -v` — 30 tests pass
- [x] `make check-quiet` — all checks pass

## Expected impact
- Metrics impact: None (new tooling only)
- Runtime impact: None (offline analysis scripts)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/interpretability
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/interpretability
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre  b9d3de7 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/interpretability  198df4d [feat/interpretability-pipeline]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)