### PR TITLE
fix: handle variable SHAP value shapes in interpretability pipeline

### DIFF
--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -226,6 +226,8 @@ Every experiment run creates a standardized directory under `data/runs/<run_id>/
 | `scripts/internal/generate_rung_tables.py` | Canonical CSV table generation for Arc D v2 rung reports |
 | `scripts/internal/generate_rung_report.py` | Markdown rung report renderer from CSV tables and chart PNGs |
 | `scripts/internal/generate_evidence_manifest.py` | Evidence manifest generator (JSON + markdown) for Arc D v2 |
+| `scripts/internal/generate_interpretability.py` | SHAP feature analysis, selection paths, and decision comparison for Arc D v2 |
+| `scripts/internal/generate_interpretability_charts.py` | PNG chart generation from interpretability CSV data |
 | `scripts/internal/manage_artifacts.py` | Artifact lifecycle CLI (status, supersession, quarantine, prune) |
 | `scripts/internal/play_policy_gate.py` | Play policy stability gate |
 | `scripts/internal/review_driver.py` | Autonomous review loop orchestrator (state machine) |

--- a/scripts/internal/generate_interpretability.py
+++ b/scripts/internal/generate_interpretability.py
@@ -127,6 +127,50 @@ def _get_feature_names(artifact: dict, family: str) -> list[str]:
     return []
 
 
+# ── SHAP shape normalization ───────────────────────────────
+
+
+def normalize_shap_values(shap_values: Any) -> np.ndarray:
+    """Normalize SHAP values to 2D array (n_samples, n_features).
+
+    ``shap.TreeExplainer.shap_values()`` returns variable shapes depending
+    on model type and sklearn version:
+
+    - **Regression:** 2D ``(n_samples, n_features)`` — the common case.
+    - **Binary classification:** list of two 2D arrays ``[class0, class1]``;
+      we take the positive-class (last) array.
+    - **Multi-output:** 3D ``(n_samples, n_features, n_outputs)``; we take
+      the first output slice.
+    - **Single feature edge case:** 1D ``(n_samples,)``; reshaped to
+      ``(n_samples, 1)``.
+
+    Returns:
+        2D numpy array of shape ``(n_samples, n_features)``.
+
+    Raises:
+        ValueError: If the shape cannot be normalized (e.g. 0-d or >3-d).
+    """
+    # Handle list-of-arrays (binary/multi-class classification)
+    if isinstance(shap_values, list):
+        shap_values = np.array(shap_values[-1])
+
+    shap_values = np.asarray(shap_values)
+
+    if shap_values.ndim == 2:
+        return shap_values
+    elif shap_values.ndim == 1:
+        # Single feature edge case
+        return shap_values.reshape(-1, 1)
+    elif shap_values.ndim == 3:
+        # Multi-output: take first output
+        return shap_values[:, :, 0]
+    else:
+        raise ValueError(
+            f"Cannot normalize SHAP values with {shap_values.ndim} dimensions "
+            f"(shape={shap_values.shape}); expected 1-3 dimensions"
+        )
+
+
 # ── SHAP analysis ───────────────────────────────────────────
 
 
@@ -202,7 +246,8 @@ def generate_shap_analysis(
         # TreeExplainer
         try:
             explainer = shap.TreeExplainer(model)
-            shap_values = explainer.shap_values(X)
+            raw_shap = explainer.shap_values(X)
+            shap_values = normalize_shap_values(raw_shap)
         except Exception as e:
             logger.warning("SHAP failed for %s/%s: %s", model_name, family, e)
             continue
@@ -246,6 +291,10 @@ def generate_shap_analysis(
             interaction_values = explainer.shap_interaction_values(
                 X[: min(500, len(X))]
             )
+            # Normalize list output (classification models)
+            if isinstance(interaction_values, list):
+                interaction_values = np.array(interaction_values[-1])
+            interaction_values = np.asarray(interaction_values)
             n_features = interaction_values.shape[2]
             # Sum absolute interaction strengths across samples
             mean_interactions = np.abs(interaction_values).mean(axis=0)

--- a/scripts/internal/generate_interpretability_charts.py
+++ b/scripts/internal/generate_interpretability_charts.py
@@ -11,6 +11,7 @@ CLI:
 Charts produced:
   - shap_summary.png          — horizontal bar of mean |SHAP| per feature, faceted by contract
   - shap_dependence_top5.png  — scatter plots of top-5 features vs SHAP values
+  - shap_interactions.png     — heatmap of pairwise SHAP interaction strengths
   - selection_path.png        — line chart of R² vs features added
   - decision_agreement.png    — bar chart of pairwise agreement rates
   - disagreement_outcomes.png — bar chart of who wins in disagreements
@@ -115,6 +116,78 @@ def generate_shap_dependence(dependence_df: pd.DataFrame, output_dir: Path) -> N
     # Combine into single output
     if contracts:
         _save_chart(fig, output_dir, "shap_dependence_top5.png")
+
+
+def generate_shap_interactions_chart(
+    interactions_df: pd.DataFrame, output_dir: Path
+) -> None:
+    """Heatmap of pairwise SHAP interaction strengths, faceted by contract.
+
+    Each cell shows the mean absolute interaction strength between two features.
+    Only the top feature pairs (those present in the CSV) are shown.
+    """
+    contracts = sorted(interactions_df["contract"].unique())
+    n_contracts = len(contracts)
+    if n_contracts == 0:
+        return
+
+    fig, axes = plt.subplots(
+        1,
+        n_contracts,
+        figsize=(6 * n_contracts, 5),
+        squeeze=False,
+    )
+
+    for col_idx, contract in enumerate(contracts):
+        ax = axes[0, col_idx]
+        cdf = interactions_df[interactions_df["contract"] == contract]
+        if cdf.empty:
+            ax.set_title(f"{contract} (no data)")
+            ax.axis("off")
+            continue
+
+        # Collect all unique features mentioned in pairs
+        all_features = sorted(
+            set(cdf["feature_1"].tolist() + cdf["feature_2"].tolist())
+        )
+        n_feat = len(all_features)
+        feat_to_idx = {f: i for i, f in enumerate(all_features)}
+
+        # Build symmetric matrix
+        matrix = np.zeros((n_feat, n_feat))
+        for _, row in cdf.iterrows():
+            i = feat_to_idx[row["feature_1"]]
+            j = feat_to_idx[row["feature_2"]]
+            matrix[i, j] = row["interaction_strength"]
+            matrix[j, i] = row["interaction_strength"]
+
+        im = ax.imshow(matrix, cmap="YlOrRd", aspect="auto")
+        ax.set_xticks(range(n_feat))
+        ax.set_yticks(range(n_feat))
+        ax.set_xticklabels(all_features, rotation=45, ha="right", fontsize=7)
+        ax.set_yticklabels(all_features, fontsize=7)
+        ax.set_title(f"{contract}")
+
+        # Annotate cells with values
+        for i in range(n_feat):
+            for j in range(n_feat):
+                val = matrix[i, j]
+                if val > 0:
+                    ax.text(
+                        j,
+                        i,
+                        f"{val:.3f}",
+                        ha="center",
+                        va="center",
+                        fontsize=6,
+                        color="black" if val < matrix.max() * 0.7 else "white",
+                    )
+
+        fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+
+    fig.suptitle("SHAP Feature Interaction Strengths", fontsize=14, y=1.02)
+    fig.tight_layout()
+    _save_chart(fig, output_dir, "shap_interactions.png")
 
 
 def generate_selection_path_chart(selection_df: pd.DataFrame, output_dir: Path) -> None:
@@ -281,6 +354,12 @@ def run(chart_data_dir: Path, output_dir: Path) -> list[str]:
     if dep_df is not None:
         generate_shap_dependence(dep_df, output_dir)
         generated.append("shap_dependence_top5.png")
+
+    # SHAP interactions
+    interactions_df = _read_csv_safe(chart_data_dir / "shap_interactions.csv")
+    if interactions_df is not None:
+        generate_shap_interactions_chart(interactions_df, output_dir)
+        generated.append("shap_interactions.png")
 
     # Selection paths
     sel_df = _read_csv_safe(chart_data_dir / "selection_paths.csv")

--- a/tests/unit/test_interpretability.py
+++ b/tests/unit/test_interpretability.py
@@ -301,6 +301,19 @@ def two_gbt_artifacts(tmp_path: Path, synthetic_eval_df: pd.DataFrame) -> list[d
     return results
 
 
+# ── Availability checks ─────────────────────────────────────
+
+
+def _shap_available() -> bool:
+    """Check if the shap package is importable."""
+    try:
+        import shap  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
 # ── Import helper ───────────────────────────────────────────
 
 # The scripts live outside src/ so we import via path manipulation in tests.
@@ -335,9 +348,75 @@ def _import_generate_interpretability_charts():
     return mod
 
 
+# ── SHAP shape normalization tests ──────────────────────────
+
+
+class TestNormalizeShapValues:
+    """Tests for normalize_shap_values shape handling."""
+
+    def test_2d_passthrough(self):
+        """2D array passes through unchanged."""
+        mod = _import_generate_interpretability()
+        arr = np.random.RandomState(42).rand(10, 5)
+        result = mod.normalize_shap_values(arr)
+        assert result.shape == (10, 5)
+        np.testing.assert_array_equal(result, arr)
+
+    def test_list_of_2d_takes_last(self):
+        """List of 2D arrays (binary classification) takes the last element."""
+        mod = _import_generate_interpretability()
+        rng = np.random.RandomState(42)
+        class0 = rng.rand(10, 5)
+        class1 = rng.rand(10, 5)
+        result = mod.normalize_shap_values([class0, class1])
+        assert result.shape == (10, 5)
+        np.testing.assert_array_equal(result, class1)
+
+    def test_1d_reshaped(self):
+        """1D array (single feature) is reshaped to (n, 1)."""
+        mod = _import_generate_interpretability()
+        arr = np.random.RandomState(42).rand(10)
+        result = mod.normalize_shap_values(arr)
+        assert result.shape == (10, 1)
+        np.testing.assert_array_equal(result[:, 0], arr)
+
+    def test_3d_takes_first_output(self):
+        """3D array (multi-output) takes first output slice."""
+        mod = _import_generate_interpretability()
+        arr = np.random.RandomState(42).rand(10, 5, 3)
+        result = mod.normalize_shap_values(arr)
+        assert result.shape == (10, 5)
+        np.testing.assert_array_equal(result, arr[:, :, 0])
+
+    def test_list_of_single_array(self):
+        """List with one element (single-class edge case)."""
+        mod = _import_generate_interpretability()
+        arr = np.random.RandomState(42).rand(10, 5)
+        result = mod.normalize_shap_values([arr])
+        assert result.shape == (10, 5)
+        np.testing.assert_array_equal(result, arr)
+
+    def test_invalid_ndim_raises(self):
+        """0D or 4D+ arrays raise ValueError."""
+        mod = _import_generate_interpretability()
+        with pytest.raises(ValueError, match="Cannot normalize"):
+            mod.normalize_shap_values(np.array(1.0))
+
+    def test_4d_raises(self):
+        """4D array raises ValueError."""
+        mod = _import_generate_interpretability()
+        arr = np.random.RandomState(42).rand(2, 3, 4, 5)
+        with pytest.raises(ValueError, match="Cannot normalize"):
+            mod.normalize_shap_values(arr)
+
+
 # ── SHAP analysis tests ────────────────────────────────────
 
 
+@pytest.mark.skipif(
+    not _shap_available(),
+    reason="shap not installed",
+)
 class TestShapAnalysis:
     """Tests for SHAP-based feature analysis."""
 
@@ -750,6 +829,7 @@ class TestArtifactDiscovery:
 class TestEndToEnd:
     """Integration-style tests for the full pipeline."""
 
+    @pytest.mark.skipif(not _shap_available(), reason="shap not installed")
     def test_run_produces_csvs(
         self,
         tmp_path: Path,
@@ -875,3 +955,61 @@ class TestChartGeneration:
 
         assert "shap_summary.png" in generated
         assert (output_dir / "shap_summary.png").exists()
+
+    def test_shap_interactions_chart(self, tmp_path: Path):
+        """SHAP interactions heatmap chart generates without error."""
+        mod = _import_generate_interpretability_charts()
+
+        interactions_df = pd.DataFrame(
+            [
+                {
+                    "model": "m1",
+                    "contract": "suit",
+                    "feature_1": "trump_count",
+                    "feature_2": "bower_count",
+                    "interaction_strength": 0.15,
+                },
+                {
+                    "model": "m1",
+                    "contract": "suit",
+                    "feature_1": "trump_count",
+                    "feature_2": "ace_count",
+                    "interaction_strength": 0.08,
+                },
+                {
+                    "model": "m1",
+                    "contract": "suit",
+                    "feature_1": "bower_count",
+                    "feature_2": "ace_count",
+                    "interaction_strength": 0.05,
+                },
+            ]
+        )
+        mod.generate_shap_interactions_chart(interactions_df, tmp_path)
+        assert (tmp_path / "shap_interactions.png").exists()
+
+    def test_run_charts_includes_interactions(self, tmp_path: Path):
+        """Full chart run picks up shap_interactions.csv and generates PNG."""
+        mod = _import_generate_interpretability_charts()
+
+        chart_data_dir = tmp_path / "chart_data"
+        chart_data_dir.mkdir()
+
+        interactions_df = pd.DataFrame(
+            [
+                {
+                    "model": "m1",
+                    "contract": "suit",
+                    "feature_1": "f1",
+                    "feature_2": "f2",
+                    "interaction_strength": 0.1,
+                },
+            ]
+        )
+        interactions_df.to_csv(chart_data_dir / "shap_interactions.csv", index=False)
+
+        output_dir = tmp_path / "charts"
+        generated = mod.run(chart_data_dir, output_dir)
+
+        assert "shap_interactions.png" in generated
+        assert (output_dir / "shap_interactions.png").exists()


### PR DESCRIPTION
## Summary
- Add `normalize_shap_values()` to handle variable SHAP output shapes (list-of-arrays for classification, 1D for single feature, 3D for multi-output)
- Normalize interaction values from classification models (list output)
- Add `shap_interactions.png` heatmap chart to `generate_interpretability_charts.py`
- Add `pytest.importorskip` guards so SHAP-dependent tests skip cleanly when shap is not installed
- Register new scripts in ARCHITECTURE.md for docs-check compliance

## Why
`shap.TreeExplainer.shap_values()` returns variable shapes depending on model type and sklearn version. The existing code assumed 2D `(n_samples, n_features)` arrays, which crashes for binary classification (list of 2D arrays) or multi-output models (3D arrays). The `shap_interactions.csv` was generated but had no corresponding chart.

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_interpretability.py -v -k "TestNormalizeShapValues or test_shap_interactions_chart or test_run_charts_includes_interactions"
make check-quiet
```

## Tests
```bash
uv run python -m pytest tests/unit/test_interpretability.py -v  # 34 passed, 5 skipped (shap not installed)
make check-quiet  # All checks passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/fix-shap-value-indexing
show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/fix-shap-value-indexing
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)