### PR TITLE
feat: add post-merge comprehensive review workflow

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -20,6 +20,13 @@ Discard: exploration tangents, superseded plans, verbose file contents already s
 - Auto-fixes are pushed as follow-up commits to the PR branch
 - Handoff summary is designed for `/copy` into a new session
 
+## Post-Merge Review
+- After every `gh pr merge`, a PostToolUse hook triggers a comprehensive review
+- A background Explore agent reviews merged code for correctness, contract compliance,
+  architecture, and test coverage
+- CRITICAL findings trigger immediate fix PRs
+- This is a safety net — pre-merge review catches most issues, post-merge catches the rest
+
 ## Docs-Only CI (Resolved)
 - CI now uses `dorny/paths-filter` instead of `paths-ignore` (PR #635)
 - The `tests` job always triggers and posts a status

--- a/.claude/hooks/post-merge-review.sh
+++ b/.claude/hooks/post-merge-review.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# PostToolUse hook — triggers comprehensive post-merge review
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+EXIT_CODE=$(echo "$INPUT" | jq -r '.tool_response.exit_code // 0')
+
+if [[ "$COMMAND" == *"gh pr merge"* ]] && [[ "$EXIT_CODE" == "0" ]]; then
+  # Extract PR number
+  PR_NUM=$(echo "$COMMAND" | grep -oE '[0-9]+' | head -1 || true)
+
+  # Dedupe guard
+  if [ -n "$PR_NUM" ]; then
+    SENTINEL="/tmp/.claude-post-merge-review-${PR_NUM}"
+    if [ -f "$SENTINEL" ]; then
+      exit 0
+    fi
+    touch "$SENTINEL"
+  fi
+
+  cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "PR #${PR_NUM} was just merged. You SHOULD spawn a background Explore agent to perform a comprehensive post-merge review of the merged code on main. The agent should review all changed files for: correctness (C1/C2 checks, logic bugs, edge cases), contract compliance with the governing plan, architectural boundary violations (src/ vs scripts/), test coverage gaps, and integration risks with other recently merged PRs. Report findings as a severity table (CRITICAL/WARNING/NIT). If CRITICAL findings are found, create a follow-up fix PR immediately."
+  }
+}
+EOF
+fi
+
+exit 0

--- a/.claude/rules/60_review_gate.md
+++ b/.claude/rules/60_review_gate.md
@@ -135,6 +135,20 @@ Codex CLI is the sole reviewer, invoked locally by the autonomous review loop:
 
 Findings are normalized into the P0/P1/P2 schema and recorded in per-round artifacts.
 
+## Post-Merge Review
+
+After every `gh pr merge`, a PostToolUse hook (`post-merge-review.sh`)
+triggers a comprehensive background review of the merged code. This
+complements the pre-merge review loop:
+
+| Phase | Trigger | Reviewer | Scope |
+|-------|---------|----------|-------|
+| Pre-merge | `gh pr create` | Review loop (Codex CLI) | Convention, prechecks |
+| Post-merge | `gh pr merge` | Background Explore agent | Correctness, contracts, architecture |
+
+Post-merge review is advisory — it does not block future merges. But
+CRITICAL findings trigger immediate fix PRs.
+
 ## Known Issue: Docs-Only PRs and CI
 
 **Resolved (PR #635):** The CI workflow now uses `dorny/paths-filter` instead of

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,6 +40,11 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-merge-ci-check.sh",
             "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-merge-review.sh",
+            "timeout": 5
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,13 @@ All code changes MUST happen in dedicated git worktrees, never on `main` in the 
 - Use the PR template from `.github/pull_request_template.md`
 - After `reviewing-changes` passes, wait for Codex pre-merge review before merging (see `docs/02_agent/CODEX_GITHUB_REVIEW.md`)
 
+### Post-Merge Review
+- After every `gh pr merge`, a PostToolUse hook triggers a comprehensive review
+- A background Explore agent reviews merged code for correctness, contract compliance,
+  architecture, and test coverage
+- CRITICAL findings trigger immediate fix PRs
+- This is a safety net — pre-merge review catches most issues, post-merge catches the rest
+
 ## Game Rules Summary
 
 - **Deck:** Double-deck (40 cards), ranks 10-A, 4 suits × 2 copies

--- a/docs/02_agent/AGENTS.md
+++ b/docs/02_agent/AGENTS.md
@@ -635,3 +635,32 @@ wins unconditionally.
 
 Archived plans are useful for understanding historical decisions and rationale.
 They are not valid execution contracts.
+
+---
+
+## 13) Post-Merge Comprehensive Review
+
+After every PR merge, a comprehensive review agent is spawned to review
+the merged code on main. This is a safety net that catches issues pre-merge
+review may miss:
+
+- **Correctness:** C1/C2 checks, logic bugs, edge cases, SHAP/numeric handling
+- **Contract compliance:** Does the code match the governing plan's specs?
+- **Architecture:** Package boundary violations, import direction, dual-path risks
+- **Test coverage:** Missing tests, unrealistic fixtures, untested edge cases
+- **Integration:** Conflicts with other recently merged PRs
+
+**Findings are reported as:**
+
+| Severity | Action |
+|----------|--------|
+| CRITICAL | Fix PR created immediately |
+| WARNING | Follow-up issue created |
+| NIT | Noted in review, no action required |
+
+**Implementation:** The PostToolUse hook `.claude/hooks/post-merge-review.sh`
+triggers after a successful `gh pr merge` command. It emits `additionalContext`
+instructing Claude to spawn a background Explore agent for the review.
+
+This workflow was established after post-merge review of PR #655 caught a
+CRITICAL SHAP value indexing bug that pre-merge review missed.

--- a/plans/arc_d_v2/lineage_plan.md
+++ b/plans/arc_d_v2/lineage_plan.md
@@ -2237,6 +2237,23 @@ For this lineage specifically:
 - **Fundamental design changes** (e.g., "add a new model family"): Requires
   human approval. Proposed via `qa_log.md` -> `design_decisions.md` -> amendment.
 
+#### 17.5.6 Post-Merge Review
+
+Every PR merged to main as part of Arc D v2 receives a comprehensive
+post-merge review via a spawned background agent. This review checks:
+
+1. **Correctness** — C1/C2 violations, logic bugs, numeric edge cases
+2. **Plan compliance** — Does the implementation match the governing plan's
+   specifications (table schemas, chart specs, step contracts)?
+3. **Package boundary** — Does `src/bid_euchre/arc_d_v2/` remain the canonical
+   location for domain logic? Do scripts remain thin wrappers?
+4. **Integration** — Does the merged code work correctly with other recent merges?
+
+If CRITICAL findings are discovered, a fix PR is created immediately.
+WARNING findings are tracked as follow-up issues. This workflow was
+established after post-merge review caught a SHAP value indexing bug
+that pre-merge review missed.
+
 ## 18. Run Naming Contract
 
 All run IDs follow this pattern:


### PR DESCRIPTION
## Summary

- Add PostToolUse hook (`post-merge-review.sh`) that triggers after every successful `gh pr merge`
- Hook emits `additionalContext` instructing Claude to spawn a background Explore agent for comprehensive code review
- Documented in AGENTS.md (section 13), CLAUDE.md, `.claude/CLAUDE.md`, review gate rules, and Arc D v2 governing plan (section 17.5.6)

## Why

Pre-merge review (Codex CLI autonomous loop) catches convention and precheck issues but can miss deeper correctness bugs. Post-merge review of PR #655 caught a CRITICAL SHAP value indexing bug that pre-merge review missed. This establishes post-merge comprehensive review as a standard safety net.

## Changes

| File | Change |
|------|--------|
| `.claude/hooks/post-merge-review.sh` | New hook — detects `gh pr merge` success, emits review instructions |
| `.claude/settings.json` | Register hook in Bash PostToolUse array |
| `CLAUDE.md` | Add Post-Merge Review subsection under PR Requirements |
| `.claude/CLAUDE.md` | Add Post-Merge Review section |
| `.claude/rules/60_review_gate.md` | Add Post-Merge Review section with pre/post comparison table |
| `docs/02_agent/AGENTS.md` | Add section 13 — Post-Merge Comprehensive Review |
| `plans/arc_d_v2/lineage_plan.md` | Add section 17.5.6 — Post-Merge Review for Arc D v2 |

## Repro / Validation

```bash
# Verify bash syntax
bash -n .claude/hooks/post-merge-review.sh

# Verify JSON
python3 -c "import json; json.load(open('.claude/settings.json'))"

# Full check
make check-quiet
```

All checks pass.

## Tests

```bash
make check-quiet  # PASS — all checks green
```

No new Python code, so no new tests required. This is a hook + documentation PR.

## Worktree proof

```
pwd: .claude/worktrees/post-merge-review
branch: feat/post-merge-review-workflow
```

---

**Review findings severity table:**

| Severity | Action |
|----------|--------|
| CRITICAL | Fix PR created immediately |
| WARNING | Follow-up issue created |
| NIT | Noted in review, no action required |