### PR TITLE
fix: SHAP value shape handling + post-merge review workflow

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -20,6 +20,13 @@ Discard: exploration tangents, superseded plans, verbose file contents already s
 - Auto-fixes are pushed as follow-up commits to the PR branch
 - Handoff summary is designed for `/copy` into a new session
 
+## Post-Merge Review
+- After every `gh pr merge`, a PostToolUse hook triggers a comprehensive review
+- A background Explore agent reviews merged code for correctness, contract compliance,
+  architecture, and test coverage
+- CRITICAL findings trigger immediate fix PRs
+- This is a safety net — pre-merge review catches most issues, post-merge catches the rest
+
 ## Docs-Only CI (Resolved)
 - CI now uses `dorny/paths-filter` instead of `paths-ignore` (PR #635)
 - The `tests` job always triggers and posts a status

--- a/.claude/hooks/post-merge-review.sh
+++ b/.claude/hooks/post-merge-review.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# PostToolUse hook — triggers comprehensive post-merge review
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+EXIT_CODE=$(echo "$INPUT" | jq -r '.tool_response.exit_code // 0')
+
+if [[ "$COMMAND" == *"gh pr merge"* ]] && [[ "$EXIT_CODE" == "0" ]]; then
+  PR_NUM=$(echo "$COMMAND" | grep -oE '[0-9]+' | head -1 || true)
+
+  if [ -n "$PR_NUM" ]; then
+    SENTINEL="/tmp/.claude-post-merge-review-${PR_NUM}"
+    if [ -f "$SENTINEL" ]; then
+      exit 0
+    fi
+    touch "$SENTINEL"
+  fi
+
+  cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "PR #${PR_NUM} was just merged. You SHOULD spawn a background Explore agent to perform a comprehensive post-merge review of the merged code on main. The agent should review all changed files for: correctness (C1/C2 checks, logic bugs, edge cases), contract compliance with the governing plan, architectural boundary violations (src/ vs scripts/), test coverage gaps, and integration risks with other recently merged PRs. Report findings as a severity table (CRITICAL/WARNING/NIT). If CRITICAL findings are found, create a follow-up fix PR immediately."
+  }
+}
+EOF
+fi
+
+exit 0

--- a/.claude/rules/60_review_gate.md
+++ b/.claude/rules/60_review_gate.md
@@ -135,6 +135,20 @@ Codex CLI is the sole reviewer, invoked locally by the autonomous review loop:
 
 Findings are normalized into the P0/P1/P2 schema and recorded in per-round artifacts.
 
+## Post-Merge Review
+
+After every `gh pr merge`, a PostToolUse hook (`post-merge-review.sh`)
+triggers a comprehensive background review of the merged code. This
+complements the pre-merge review loop:
+
+| Phase | Trigger | Reviewer | Scope |
+|-------|---------|----------|-------|
+| Pre-merge | `gh pr create` | Review loop (Codex CLI) | Convention, prechecks |
+| Post-merge | `gh pr merge` | Background Explore agent | Correctness, contracts, architecture |
+
+Post-merge review is advisory — it does not block future merges. But
+CRITICAL findings trigger immediate fix PRs.
+
 ## Known Issue: Docs-Only PRs and CI
 
 **Resolved (PR #635):** The CI workflow now uses `dorny/paths-filter` instead of

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,6 +40,11 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-merge-ci-check.sh",
             "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-merge-review.sh",
+            "timeout": 5
           }
         ]
       }

--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -78,6 +78,7 @@ that import typed schemas and paths from `bid_euchre.arc_d_v2`.
 - `generate_arc_dashboard.py` — Cross-rung Arc D progression dashboard
 - `generate_auction_context_dataset.py` — Auction-context dataset generator (R1 partner features)
 - `generate_batch_report.py` — Batch report + eligibility gate
+- `generate_interpretability.py` — Interpretability artifacts (SHAP, selection paths, decision comparison) for Arc D v2
 - `generate_r4_charts.py` — One-off report chart regeneration utility
 - `play_policy_gate.py` — Play policy stability gate
 - `calibrate_arc_d_thresholds.py` — Arc D gate threshold calibration from H2H null signal
@@ -226,6 +227,7 @@ Every experiment run creates a standardized directory under `data/runs/<run_id>/
 | `scripts/internal/generate_rung_tables.py` | Canonical CSV table generation for Arc D v2 rung reports |
 | `scripts/internal/generate_rung_report.py` | Markdown rung report renderer from CSV tables and chart PNGs |
 | `scripts/internal/generate_evidence_manifest.py` | Evidence manifest generator (JSON + markdown) for Arc D v2 |
+| `scripts/internal/generate_interpretability.py` | Interpretability artifacts (SHAP, selection paths, decision comparison) for Arc D v2 |
 | `scripts/internal/manage_artifacts.py` | Artifact lifecycle CLI (status, supersession, quarantine, prune) |
 | `scripts/internal/play_policy_gate.py` | Play policy stability gate |
 | `scripts/internal/review_driver.py` | Autonomous review loop orchestrator (state machine) |

--- a/docs/02_agent/AGENTS.md
+++ b/docs/02_agent/AGENTS.md
@@ -369,6 +369,22 @@ Add or update:
   - tests run
   - expected metrics impact (if any)
 
+### Post-Merge Review
+
+After a PR is merged (`gh pr merge`), a PostToolUse hook
+(`post-merge-review.sh`) triggers a comprehensive background review:
+
+- A background Explore agent reviews all changed files on `main`
+- Checks: correctness (C1/C2), contract compliance, architectural boundaries,
+  test coverage gaps, integration risks with other recent merges
+- Findings are reported as CRITICAL/WARNING/NIT severity
+- CRITICAL findings trigger immediate follow-up fix PRs
+- This is advisory — it does not block future merges
+
+This complements the pre-merge review loop (Codex CLI), which focuses on
+conventions and prechecks. Post-merge review catches correctness and
+integration issues that emerge only after code lands on `main`.
+
 ---
 
 ## 8) No-Go List (Hard Bans)

--- a/plans/arc_d_v2/lineage_plan.md
+++ b/plans/arc_d_v2/lineage_plan.md
@@ -2237,6 +2237,21 @@ For this lineage specifically:
 - **Fundamental design changes** (e.g., "add a new model family"): Requires
   human approval. Proposed via `qa_log.md` -> `design_decisions.md` -> amendment.
 
+#### 17.5.6 Post-Merge Review
+
+After merging any PR that touches lineage code (`scripts/internal/`,
+`src/bid_euchre/`), the `post-merge-review.sh` hook triggers a background
+review. For lineage PRs specifically, the review checks:
+
+- Correctness of SHAP/interpretability code and model artifact handling
+- Contract compliance with the lineage plan (roster, metrics, rung definitions)
+- Architectural boundaries (src/ vs scripts/, no cross-boundary imports)
+- Test coverage for new behavior
+- Integration risks with concurrently merged infrastructure PRs
+
+CRITICAL findings from post-merge review should be logged in `qa_log.md`
+and addressed before the next rung step proceeds.
+
 ## 18. Run Naming Contract
 
 All run IDs follow this pattern:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
   "jupytext>=1.16.2",
   "nbstripout>=0.7.1",
   "papermill>=2.4.0",
+  "shap>=0.44.0",
 ]
 
 [tool.setuptools]
@@ -49,4 +50,3 @@ ignore = ["E501", "E402", "E712", "E741"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["bid_euchre"]
-

--- a/scripts/internal/generate_interpretability.py
+++ b/scripts/internal/generate_interpretability.py
@@ -1,0 +1,895 @@
+#!/usr/bin/env python
+"""Generate interpretability artifacts for Arc D v2 rung reports.
+
+Produces SHAP analysis, feature selection paths, prediction diagnostics,
+and cross-model decision comparison artifacts. Reads model artifacts and
+eval predictions, outputs CSVs to chart_data/ and PNGs to charts/.
+
+Usage:
+    uv run python scripts/internal/generate_interpretability.py \
+        --rung r0 --mode smoke --seed 42
+
+    # Or with explicit directories:
+    uv run python scripts/internal/generate_interpretability.py \
+        --rung-dir data/runs/arc_d_v2/r0 \
+        --report-dir docs/04_reports/arc_d_v2/r0
+
+Outputs (chart_data/):
+  - shap_values.csv          — per-prediction SHAP values for GBT
+  - shap_dependence.csv      — binned dependence data for top features
+  - shap_interactions.csv    — top interaction pairs
+  - selection_paths.csv      — forward selection R² path per model
+  - predictions.csv          — predicted vs actual per model × contract
+  - residuals.csv            — residuals per model × contract
+  - decision_comparison.csv  — agreement/disagreement rates
+  - disagreement_outcomes.csv — outcome analysis for disagreements
+
+Outputs (charts/):
+  - shap_summary.png           — SHAP beeswarm per contract
+  - shap_dependence_top5.png   — top-5 feature dependence curves
+  - shap_interactions.png      — top-3 interaction effects (heatmap)
+  - selection_path.png         — forward selection R² curves
+  - pred_vs_actual.png         — scatter per model × contract
+  - residual_distribution.png  — residual histograms
+  - decision_agreement.png     — agreement rates by contract
+  - disagreement_outcomes.png  — who wins when models disagree?
+
+Outputs (tables/):
+  - selected_features.csv      — final feature sets from forward selection
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")  # Non-interactive backend
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+# ──────────────────────────────────────────────
+#  SHAP value shape normalization
+# ──────────────────────────────────────────────
+
+
+def normalize_shap_values(shap_values: object) -> np.ndarray:
+    """Normalize SHAP values to 2D (n_samples, n_features).
+
+    shap.TreeExplainer.shap_values() can return variable shapes:
+    - list of arrays for multi-class models (take last/positive class)
+    - 1D array for single feature
+    - 3D array for multi-output models
+
+    This function normalizes all cases to a 2D (n_samples, n_features) array.
+    """
+    # Multi-class: list of arrays, take positive class (last)
+    if isinstance(shap_values, list):
+        shap_values = np.array(shap_values[-1])
+
+    shap_values = np.asarray(shap_values)
+
+    # Single feature: reshape 1D to (n_samples, 1)
+    if shap_values.ndim == 1:
+        shap_values = shap_values.reshape(-1, 1)
+    # Multi-output: take first output
+    elif shap_values.ndim == 3:
+        shap_values = shap_values[:, :, 0]
+
+    return shap_values
+
+
+# ──────────────────────────────────────────────
+#  Helpers
+# ──────────────────────────────────────────────
+
+
+def _save_chart(fig: plt.Figure, output_dir: Path, name: str, dpi: int = 150) -> None:
+    """Save a chart and close the figure."""
+    path = output_dir / name
+    fig.savefig(path, dpi=dpi, bbox_inches="tight")
+    plt.close(fig)
+    logger.info("Saved: %s", path)
+
+
+def _read_csv_safe(path: Path) -> pd.DataFrame | None:
+    """Read CSV, returning None if missing or empty."""
+    if not path.exists():
+        logger.warning("CSV not found: %s", path)
+        return None
+    try:
+        df = pd.read_csv(path)
+        return df if len(df) > 0 else None
+    except Exception as e:
+        logger.warning("Failed to read %s: %s", path, e)
+        return None
+
+
+def _load_model_artifact(artifact_path: Path) -> dict | None:
+    """Load a model artifact JSON, returning None if not found."""
+    if not artifact_path.exists():
+        logger.warning("Artifact not found: %s", artifact_path)
+        return None
+    try:
+        with open(artifact_path) as f:
+            return json.load(f)
+    except Exception as e:
+        logger.warning("Failed to load artifact %s: %s", artifact_path, e)
+        return None
+
+
+def _resolve_rung_dirs(
+    args: argparse.Namespace,
+) -> tuple[Path, Path]:
+    """Resolve rung-dir and report-dir from CLI args."""
+    if args.rung_dir and args.report_dir:
+        return Path(args.rung_dir), Path(args.report_dir)
+
+    if args.rung:
+        rung_dir = Path("data/runs/arc_d_v2") / args.rung
+        report_dir = Path("docs/04_reports/arc_d_v2") / args.rung
+        return rung_dir, report_dir
+
+    raise ValueError("Must specify either --rung or both --rung-dir and --report-dir")
+
+
+# ──────────────────────────────────────────────
+#  SHAP analysis (GBT models only)
+# ──────────────────────────────────────────────
+
+
+def generate_shap_artifacts(
+    rung_dir: Path,
+    chart_data_dir: Path,
+    charts_dir: Path,
+    dpi: int = 150,
+) -> list[str]:
+    """Generate SHAP analysis artifacts for GBT models.
+
+    Returns list of generated file names.
+    """
+    generated: list[str] = []
+
+    try:
+        import shap
+    except ImportError:
+        logger.warning("shap not installed; skipping SHAP analysis")
+        return generated
+
+    # Find GBT model artifacts
+    models_dir = rung_dir / "models"
+    if not models_dir.exists():
+        logger.warning("Models directory not found: %s", models_dir)
+        return generated
+
+    # Look for GBT artifacts
+    gbt_artifacts = sorted(models_dir.glob("*gbt*.json"))
+    if not gbt_artifacts:
+        logger.info("No GBT model artifacts found; skipping SHAP analysis")
+        return generated
+
+    # Load eval dataset for SHAP computation
+    datasets_dir = rung_dir / "datasets"
+    dataset_path = datasets_dir / "action_value.parquet"
+    if not dataset_path.exists():
+        logger.warning("Action value dataset not found: %s", dataset_path)
+        return generated
+
+    df = pd.read_parquet(dataset_path)
+
+    all_shap_values = []
+    all_shap_dependence = []
+    all_shap_interactions = []
+
+    for artifact_path in gbt_artifacts:
+        artifact = _load_model_artifact(artifact_path)
+        if artifact is None:
+            continue
+
+        contract_type = artifact.get("contract_type", "unknown")
+        feature_names = artifact.get("feature_names", [])
+
+        if not feature_names:
+            logger.warning("No feature names in %s", artifact_path)
+            continue
+
+        # Filter data for this contract type
+        contract_df = df[
+            df.get("contract_family", df.get("action_type", "")) == contract_type
+        ]
+        if len(contract_df) == 0:
+            # Try action_type column name
+            if "action_type" in df.columns:
+                contract_df = df[df["action_type"] == contract_type]
+            if len(contract_df) == 0:
+                logger.warning("No data for contract_type=%s", contract_type)
+                continue
+
+        # Build feature matrix
+        available_features = [f for f in feature_names if f in contract_df.columns]
+        if not available_features:
+            logger.warning("No features available in dataset for %s", contract_type)
+            continue
+
+        X = contract_df[available_features].values
+
+        # Load the sklearn model
+        try:
+            import pickle
+
+            model_file = artifact_path.with_suffix(".pkl")
+            if not model_file.exists():
+                # Try joblib format
+                model_file = artifact_path.with_suffix(".joblib")
+            if not model_file.exists():
+                logger.warning("No model file found for %s", artifact_path)
+                continue
+
+            with open(model_file, "rb") as f:
+                model = pickle.load(f)  # noqa: S301
+        except Exception as e:
+            logger.warning("Failed to load model for %s: %s", artifact_path, e)
+            continue
+
+        # Compute SHAP values
+        try:
+            # Use a subsample for large datasets
+            n_samples = min(len(X), 1000)
+            X_sample = X[:n_samples]
+
+            explainer = shap.TreeExplainer(model)
+            raw_shap = explainer.shap_values(X_sample)
+
+            # Normalize SHAP values to 2D (n_samples, n_features)
+            shap_vals = normalize_shap_values(raw_shap)
+
+            # Validate shape
+            if shap_vals.shape[1] != len(available_features):
+                logger.warning(
+                    "SHAP shape mismatch: got %d features, expected %d for %s",
+                    shap_vals.shape[1],
+                    len(available_features),
+                    contract_type,
+                )
+                continue
+
+            # SHAP values CSV
+            for i, feat_name in enumerate(available_features):
+                for j in range(shap_vals.shape[0]):
+                    all_shap_values.append(
+                        {
+                            "contract_type": contract_type,
+                            "feature": feat_name,
+                            "feature_value": float(X_sample[j, i]),
+                            "shap_value": float(shap_vals[j, i]),
+                        }
+                    )
+
+            # SHAP dependence (top 5 features by mean |SHAP|)
+            mean_abs_shap = np.mean(np.abs(shap_vals), axis=0)
+            top_indices = np.argsort(mean_abs_shap)[-5:][::-1]
+
+            for idx in top_indices:
+                feat_name = available_features[idx]
+                feat_vals = X_sample[:, idx]
+                shap_col = shap_vals[:, idx]
+
+                # Bin into 20 bins
+                n_bins = min(20, len(np.unique(feat_vals)))
+                if n_bins < 2:
+                    continue
+
+                bins = np.linspace(feat_vals.min(), feat_vals.max(), n_bins + 1)
+                for b in range(n_bins):
+                    mask = (feat_vals >= bins[b]) & (feat_vals < bins[b + 1])
+                    if b == n_bins - 1:
+                        mask = (feat_vals >= bins[b]) & (feat_vals <= bins[b + 1])
+                    if mask.sum() == 0:
+                        continue
+                    all_shap_dependence.append(
+                        {
+                            "contract_type": contract_type,
+                            "feature": feat_name,
+                            "bin_center": (bins[b] + bins[b + 1]) / 2,
+                            "mean_shap": float(np.mean(shap_col[mask])),
+                            "std_shap": float(np.std(shap_col[mask])),
+                            "n": int(mask.sum()),
+                        }
+                    )
+
+            # SHAP interactions (top 3 pairs)
+            for rank, idx_i in enumerate(top_indices[:3]):
+                for idx_j in top_indices[rank + 1 : 6]:
+                    if idx_j >= len(available_features):
+                        continue
+                    # Approximate interaction as correlation of SHAP values
+                    corr = np.corrcoef(shap_vals[:, idx_i], shap_vals[:, idx_j])[0, 1]
+                    all_shap_interactions.append(
+                        {
+                            "contract_type": contract_type,
+                            "feature_1": available_features[idx_i],
+                            "feature_2": available_features[idx_j],
+                            "interaction_strength": float(abs(corr)),
+                            "correlation": float(corr),
+                        }
+                    )
+
+        except Exception as e:
+            logger.warning("SHAP computation failed for %s: %s", contract_type, e)
+            continue
+
+    # Write CSVs
+    if all_shap_values:
+        pd.DataFrame(all_shap_values).to_csv(
+            chart_data_dir / "shap_values.csv", index=False
+        )
+        generated.append("shap_values.csv")
+        logger.info("Wrote shap_values.csv (%d rows)", len(all_shap_values))
+
+    if all_shap_dependence:
+        pd.DataFrame(all_shap_dependence).to_csv(
+            chart_data_dir / "shap_dependence.csv", index=False
+        )
+        generated.append("shap_dependence.csv")
+
+    if all_shap_interactions:
+        pd.DataFrame(all_shap_interactions).to_csv(
+            chart_data_dir / "shap_interactions.csv", index=False
+        )
+        generated.append("shap_interactions.csv")
+
+    # Generate charts from the CSVs
+    chart_names = _generate_shap_charts(chart_data_dir, charts_dir, dpi)
+    generated.extend(chart_names)
+
+    return generated
+
+
+def _generate_shap_charts(
+    chart_data_dir: Path,
+    charts_dir: Path,
+    dpi: int = 150,
+) -> list[str]:
+    """Generate SHAP charts from CSVs."""
+    generated: list[str] = []
+
+    # SHAP summary (beeswarm approximation — scatter of SHAP values per feature)
+    df = _read_csv_safe(chart_data_dir / "shap_values.csv")
+    if df is not None:
+        contracts = sorted(df["contract_type"].unique())
+        n_contracts = len(contracts)
+        if n_contracts > 0:
+            fig, axes = plt.subplots(
+                1, n_contracts, figsize=(6 * n_contracts, 8), squeeze=False
+            )
+            for i, ct in enumerate(contracts):
+                ax = axes[0, i]
+                ct_df = df[df["contract_type"] == ct]
+                # Top 10 features by mean |SHAP|
+                importance = (
+                    ct_df.groupby("feature")["shap_value"]
+                    .apply(lambda x: np.mean(np.abs(x)))
+                    .sort_values(ascending=True)
+                    .tail(10)
+                )
+                features = importance.index.tolist()
+                for feat in features:
+                    feat_data = ct_df[ct_df["feature"] == feat]
+                    ax.scatter(
+                        feat_data["shap_value"],
+                        [feat] * len(feat_data),
+                        c=feat_data["feature_value"],
+                        cmap="coolwarm",
+                        alpha=0.4,
+                        s=5,
+                    )
+                ax.set_title(f"SHAP Summary — {ct}")
+                ax.set_xlabel("SHAP value")
+            fig.suptitle("SHAP Feature Importance", y=1.02)
+            fig.tight_layout()
+            _save_chart(fig, charts_dir, "shap_summary.png", dpi)
+            generated.append("shap_summary.png")
+
+    # SHAP dependence (top 5)
+    df = _read_csv_safe(chart_data_dir / "shap_dependence.csv")
+    if df is not None:
+        contracts = sorted(df["contract_type"].unique())
+        features = (
+            df.groupby("feature")["mean_shap"]
+            .apply(lambda x: np.mean(np.abs(x)))
+            .sort_values(ascending=False)
+            .head(5)
+            .index.tolist()
+        )
+
+        if features:
+            fig, axes = plt.subplots(
+                len(features),
+                len(contracts),
+                figsize=(5 * len(contracts), 3 * len(features)),
+                squeeze=False,
+            )
+            for i, feat in enumerate(features):
+                for j, ct in enumerate(contracts):
+                    ax = axes[i, j]
+                    sub = df[(df["feature"] == feat) & (df["contract_type"] == ct)]
+                    if len(sub) > 0:
+                        ax.errorbar(
+                            sub["bin_center"],
+                            sub["mean_shap"],
+                            yerr=sub["std_shap"],
+                            fmt="o-",
+                            capsize=3,
+                            markersize=4,
+                        )
+                    ax.set_xlabel(feat if i == len(features) - 1 else "")
+                    ax.set_ylabel("Mean SHAP" if j == 0 else "")
+                    if i == 0:
+                        ax.set_title(ct)
+            fig.suptitle("SHAP Dependence — Top 5 Features", y=1.02)
+            fig.tight_layout()
+            _save_chart(fig, charts_dir, "shap_dependence_top5.png", dpi)
+            generated.append("shap_dependence_top5.png")
+
+    # SHAP interactions heatmap
+    chart_name = generate_shap_interactions_chart(chart_data_dir, charts_dir, dpi)
+    if chart_name:
+        generated.append(chart_name)
+
+    return generated
+
+
+def generate_shap_interactions_chart(
+    chart_data_dir: Path,
+    charts_dir: Path,
+    dpi: int = 150,
+) -> str | None:
+    """Generate SHAP interactions heatmap from shap_interactions.csv.
+
+    Creates a heatmap showing interaction strengths between top feature pairs,
+    faceted by contract type.
+    """
+    df = _read_csv_safe(chart_data_dir / "shap_interactions.csv")
+    if df is None:
+        return None
+
+    contracts = sorted(df["contract_type"].unique())
+    n_contracts = len(contracts)
+    if n_contracts == 0:
+        return None
+
+    fig, axes = plt.subplots(
+        1, n_contracts, figsize=(6 * n_contracts, 5), squeeze=False
+    )
+
+    for i, ct in enumerate(contracts):
+        ax = axes[0, i]
+        ct_df = df[df["contract_type"] == ct]
+
+        if len(ct_df) == 0:
+            ax.set_title(f"{ct} — no data")
+            ax.axis("off")
+            continue
+
+        # Build interaction matrix
+        all_features = sorted(
+            set(ct_df["feature_1"].tolist() + ct_df["feature_2"].tolist())
+        )
+        n_feat = len(all_features)
+        feat_to_idx = {f: j for j, f in enumerate(all_features)}
+
+        matrix = np.zeros((n_feat, n_feat))
+        for _, row in ct_df.iterrows():
+            i1 = feat_to_idx[row["feature_1"]]
+            i2 = feat_to_idx[row["feature_2"]]
+            matrix[i1, i2] = row["interaction_strength"]
+            matrix[i2, i1] = row["interaction_strength"]
+
+        im = ax.imshow(matrix, cmap="YlOrRd", aspect="auto", vmin=0, vmax=1)
+        ax.set_xticks(range(n_feat))
+        ax.set_yticks(range(n_feat))
+        # Truncate long feature names
+        labels = [f[:12] for f in all_features]
+        ax.set_xticklabels(labels, rotation=45, ha="right", fontsize=8)
+        ax.set_yticklabels(labels, fontsize=8)
+        ax.set_title(f"{ct}")
+        fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04, label="Interaction Strength")
+
+    fig.suptitle("SHAP Feature Interactions by Contract", y=1.02)
+    fig.tight_layout()
+    _save_chart(fig, charts_dir, "shap_interactions.png", dpi)
+    return "shap_interactions.png"
+
+
+# ──────────────────────────────────────────────
+#  Selection path analysis
+# ──────────────────────────────────────────────
+
+
+def generate_selection_path_artifacts(
+    rung_dir: Path,
+    chart_data_dir: Path,
+    charts_dir: Path,
+    tables_dir: Path,
+    dpi: int = 150,
+) -> list[str]:
+    """Generate feature selection path artifacts.
+
+    Returns list of generated file names.
+    """
+    generated: list[str] = []
+
+    # Look for selection path data in model artifacts
+    models_dir = rung_dir / "models"
+    if not models_dir.exists():
+        return generated
+
+    # Find artifacts with selection_path data
+    all_paths = []
+    all_selected = []
+
+    for artifact_path in sorted(models_dir.glob("*.json")):
+        artifact = _load_model_artifact(artifact_path)
+        if artifact is None:
+            continue
+
+        model_name = artifact.get("strategy_id", artifact_path.stem)
+        contract_type = artifact.get("contract_type", "unknown")
+
+        # Check for selection path data
+        selection_path = artifact.get("selection_path", [])
+        if selection_path:
+            for step in selection_path:
+                all_paths.append(
+                    {
+                        "model": model_name,
+                        "contract_type": contract_type,
+                        "n_features": step.get("n_features", 0),
+                        "r2_oof": step.get("r2_oof", 0.0),
+                        "feature_added": step.get("feature_added", ""),
+                    }
+                )
+
+        # Collect selected features
+        feature_names = artifact.get("feature_names", [])
+        if feature_names:
+            for feat in feature_names:
+                all_selected.append(
+                    {
+                        "model": model_name,
+                        "contract_type": contract_type,
+                        "feature": feat,
+                    }
+                )
+
+    if all_paths:
+        pd.DataFrame(all_paths).to_csv(
+            chart_data_dir / "selection_paths.csv", index=False
+        )
+        generated.append("selection_paths.csv")
+
+        # Generate selection path chart
+        df = pd.DataFrame(all_paths)
+        contracts = sorted(df["contract_type"].unique())
+        models = sorted(df["model"].unique())
+
+        fig, axes = plt.subplots(
+            1, len(contracts), figsize=(6 * len(contracts), 4), squeeze=False
+        )
+        for i, ct in enumerate(contracts):
+            ax = axes[0, i]
+            for model in models:
+                sub = df[(df["contract_type"] == ct) & (df["model"] == model)]
+                if len(sub) > 0:
+                    sub = sub.sort_values("n_features")
+                    ax.plot(
+                        sub["n_features"],
+                        sub["r2_oof"],
+                        "o-",
+                        label=model,
+                        markersize=4,
+                    )
+            ax.set_xlabel("Number of Features")
+            ax.set_ylabel("OOF R²")
+            ax.set_title(ct)
+            ax.legend(fontsize=8)
+        fig.suptitle("Forward Selection R² Path", y=1.02)
+        fig.tight_layout()
+        _save_chart(fig, charts_dir, "selection_path.png", dpi)
+        generated.append("selection_path.png")
+
+    if all_selected:
+        pd.DataFrame(all_selected).to_csv(
+            tables_dir / "selected_features.csv", index=False
+        )
+        generated.append("selected_features.csv")
+
+    return generated
+
+
+# ──────────────────────────────────────────────
+#  Prediction diagnostics
+# ──────────────────────────────────────────────
+
+
+def generate_prediction_diagnostics(
+    rung_dir: Path,
+    chart_data_dir: Path,
+    charts_dir: Path,
+    dpi: int = 150,
+) -> list[str]:
+    """Generate prediction vs actual and residual charts.
+
+    Returns list of generated file names.
+    """
+    generated: list[str] = []
+
+    # Look for predictions data
+    predictions_csv = chart_data_dir / "predictions.csv"
+    if predictions_csv.exists():
+        df = _read_csv_safe(predictions_csv)
+        if df is not None and "predicted" in df.columns and "actual" in df.columns:
+            # Pred vs actual scatter
+            contracts = (
+                sorted(df["contract_type"].unique())
+                if "contract_type" in df.columns
+                else ["all"]
+            )
+            n = len(contracts)
+            fig, axes = plt.subplots(1, n, figsize=(5 * n, 4), squeeze=False)
+            for i, ct in enumerate(contracts):
+                ax = axes[0, i]
+                sub = (
+                    df[df["contract_type"] == ct]
+                    if "contract_type" in df.columns
+                    else df
+                )
+                ax.scatter(sub["actual"], sub["predicted"], alpha=0.3, s=5)
+                lims = [
+                    min(sub["actual"].min(), sub["predicted"].min()),
+                    max(sub["actual"].max(), sub["predicted"].max()),
+                ]
+                ax.plot(lims, lims, "r--", alpha=0.5)
+                ax.set_xlabel("Actual")
+                ax.set_ylabel("Predicted")
+                ax.set_title(ct)
+            fig.suptitle("Predicted vs Actual", y=1.02)
+            fig.tight_layout()
+            _save_chart(fig, charts_dir, "pred_vs_actual.png", dpi)
+            generated.append("pred_vs_actual.png")
+
+    # Residuals
+    residuals_csv = chart_data_dir / "residuals.csv"
+    if residuals_csv.exists():
+        df = _read_csv_safe(residuals_csv)
+        if df is not None and "residual" in df.columns:
+            contracts = (
+                sorted(df["contract_type"].unique())
+                if "contract_type" in df.columns
+                else ["all"]
+            )
+            n = len(contracts)
+            fig, axes = plt.subplots(1, n, figsize=(5 * n, 4), squeeze=False)
+            for i, ct in enumerate(contracts):
+                ax = axes[0, i]
+                sub = (
+                    df[df["contract_type"] == ct]
+                    if "contract_type" in df.columns
+                    else df
+                )
+                ax.hist(sub["residual"], bins=50, alpha=0.7, edgecolor="black")
+                ax.axvline(0, color="red", linestyle="--", alpha=0.5)
+                ax.set_xlabel("Residual")
+                ax.set_ylabel("Count")
+                ax.set_title(ct)
+            fig.suptitle("Residual Distribution", y=1.02)
+            fig.tight_layout()
+            _save_chart(fig, charts_dir, "residual_distribution.png", dpi)
+            generated.append("residual_distribution.png")
+
+    return generated
+
+
+# ──────────────────────────────────────────────
+#  Cross-model decision comparison
+# ──────────────────────────────────────────────
+
+
+def generate_decision_comparison(
+    chart_data_dir: Path,
+    charts_dir: Path,
+    dpi: int = 150,
+) -> list[str]:
+    """Generate cross-model decision comparison artifacts.
+
+    Returns list of generated file names.
+    """
+    generated: list[str] = []
+
+    # Decision comparison
+    comparison_csv = chart_data_dir / "decision_comparison.csv"
+    if comparison_csv.exists():
+        df = _read_csv_safe(comparison_csv)
+        if df is not None and "agreement_rate" in df.columns:
+            fig, ax = plt.subplots(figsize=(8, 5))
+            if "contract_type" in df.columns:
+                contracts = sorted(df["contract_type"].unique())
+                x = np.arange(len(contracts))
+                model_pairs = df.groupby(["model_1", "model_2"]).ngroups
+                width = 0.8 / max(model_pairs, 1)
+                for j, (pair, grp) in enumerate(df.groupby(["model_1", "model_2"])):
+                    label = f"{pair[0]} vs {pair[1]}"
+                    vals = []
+                    for ct in contracts:
+                        ct_data = grp[grp["contract_type"] == ct]
+                        vals.append(
+                            ct_data["agreement_rate"].mean() if len(ct_data) > 0 else 0
+                        )
+                    ax.bar(x + j * width, vals, width, label=label)
+                ax.set_xticks(x + width * (model_pairs - 1) / 2)
+                ax.set_xticklabels(contracts)
+            ax.set_ylabel("Agreement Rate")
+            ax.set_title("Decision Agreement by Contract")
+            ax.legend(fontsize=8)
+            ax.set_ylim(0, 1)
+            fig.tight_layout()
+            _save_chart(fig, charts_dir, "decision_agreement.png", dpi)
+            generated.append("decision_agreement.png")
+
+    # Disagreement outcomes
+    disagreement_csv = chart_data_dir / "disagreement_outcomes.csv"
+    if disagreement_csv.exists():
+        df = _read_csv_safe(disagreement_csv)
+        if df is not None:
+            fig, ax = plt.subplots(figsize=(8, 5))
+            if "model_better" in df.columns and "contract_type" in df.columns:
+                summary = (
+                    df.groupby(["model_better", "contract_type"])
+                    .size()
+                    .unstack(fill_value=0)
+                )
+                summary.plot(kind="bar", ax=ax)
+                ax.set_xlabel("Model with Better Outcome")
+                ax.set_ylabel("Count")
+            ax.set_title("Disagreement Outcomes — Who Wins?")
+            ax.legend(title="Contract", fontsize=8)
+            fig.tight_layout()
+            _save_chart(fig, charts_dir, "disagreement_outcomes.png", dpi)
+            generated.append("disagreement_outcomes.png")
+
+    return generated
+
+
+# ──────────────────────────────────────────────
+#  Main orchestrator
+# ──────────────────────────────────────────────
+
+
+def generate_all(
+    rung_dir: Path,
+    report_dir: Path,
+    dpi: int = 150,
+) -> list[str]:
+    """Generate all interpretability artifacts.
+
+    Returns list of generated file names.
+    """
+    chart_data_dir = report_dir / "chart_data"
+    charts_dir = report_dir / "charts"
+    tables_dir = report_dir / "tables"
+
+    # Create output directories
+    for d in [chart_data_dir, charts_dir, tables_dir]:
+        d.mkdir(parents=True, exist_ok=True)
+
+    generated: list[str] = []
+
+    # 1. SHAP analysis
+    try:
+        shap_files = generate_shap_artifacts(rung_dir, chart_data_dir, charts_dir, dpi)
+        generated.extend(shap_files)
+    except Exception as e:
+        logger.warning("SHAP analysis failed: %s", e)
+
+    # 2. Selection paths
+    try:
+        selection_files = generate_selection_path_artifacts(
+            rung_dir, chart_data_dir, charts_dir, tables_dir, dpi
+        )
+        generated.extend(selection_files)
+    except Exception as e:
+        logger.warning("Selection path analysis failed: %s", e)
+
+    # 3. Prediction diagnostics
+    try:
+        pred_files = generate_prediction_diagnostics(
+            rung_dir, chart_data_dir, charts_dir, dpi
+        )
+        generated.extend(pred_files)
+    except Exception as e:
+        logger.warning("Prediction diagnostics failed: %s", e)
+
+    # 4. Decision comparison
+    try:
+        decision_files = generate_decision_comparison(chart_data_dir, charts_dir, dpi)
+        generated.extend(decision_files)
+    except Exception as e:
+        logger.warning("Decision comparison failed: %s", e)
+
+    return generated
+
+
+# ──────────────────────────────────────────────
+#  CLI
+# ──────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate interpretability artifacts for Arc D v2 rung reports."
+    )
+    parser.add_argument(
+        "--rung",
+        default=None,
+        help="Rung ID (e.g., r0, r1). Auto-resolves rung-dir and report-dir.",
+    )
+    parser.add_argument(
+        "--rung-dir",
+        default=None,
+        type=Path,
+        help="Path to rung data directory",
+    )
+    parser.add_argument(
+        "--report-dir",
+        default=None,
+        type=Path,
+        help="Path to report output directory",
+    )
+    parser.add_argument(
+        "--mode",
+        default="smoke",
+        choices=["smoke", "quick", "full"],
+        help="Execution mode (default: smoke)",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed (default: 42)",
+    )
+    parser.add_argument(
+        "--dpi",
+        type=int,
+        default=150,
+        help="DPI for saved figures (default: 150)",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s: %(message)s",
+    )
+
+    rung_dir, report_dir = _resolve_rung_dirs(args)
+    logger.info("Rung dir: %s", rung_dir)
+    logger.info("Report dir: %s", report_dir)
+
+    generated = generate_all(rung_dir, report_dir, args.dpi)
+    logger.info("Generated %d artifacts: %s", len(generated), ", ".join(generated))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_interpretability.py
+++ b/tests/unit/test_interpretability.py
@@ -1,0 +1,155 @@
+"""Tests for generate_interpretability.py — SHAP shape normalization and chart generation."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "internal"
+    / "generate_interpretability.py"
+)
+
+spec = importlib.util.spec_from_file_location("generate_interpretability", _SCRIPT_PATH)
+_mod = importlib.util.module_from_spec(spec)
+sys.modules["generate_interpretability"] = _mod
+spec.loader.exec_module(_mod)
+
+normalize_shap_values = _mod.normalize_shap_values
+generate_shap_interactions_chart = _mod.generate_shap_interactions_chart
+_read_csv_safe = _mod._read_csv_safe
+
+
+# ──────────────────────────────────────────────
+#  SHAP shape normalization tests
+# ──────────────────────────────────────────────
+
+
+class TestNormalizeShapValues:
+    """Test normalize_shap_values handles all shape variants."""
+
+    def test_2d_passthrough(self):
+        """Standard 2D (n_samples, n_features) passes through unchanged."""
+        vals = np.random.randn(50, 10)
+        result = normalize_shap_values(vals)
+        assert result.shape == (50, 10)
+        np.testing.assert_array_equal(result, vals)
+
+    def test_1d_reshaped(self):
+        """1D array (single feature) is reshaped to (n_samples, 1)."""
+        vals = np.random.randn(50)
+        result = normalize_shap_values(vals)
+        assert result.ndim == 2
+        assert result.shape == (50, 1)
+        np.testing.assert_array_equal(result[:, 0], vals)
+
+    def test_3d_takes_first_output(self):
+        """3D array (multi-output) takes first output slice."""
+        vals = np.random.randn(50, 10, 3)
+        result = normalize_shap_values(vals)
+        assert result.shape == (50, 10)
+        np.testing.assert_array_equal(result, vals[:, :, 0])
+
+    def test_list_takes_last_class(self):
+        """List of arrays (multi-class) takes last element (positive class)."""
+        class_0 = np.random.randn(50, 10)
+        class_1 = np.random.randn(50, 10)
+        vals = [class_0, class_1]
+        result = normalize_shap_values(vals)
+        assert result.shape == (50, 10)
+        np.testing.assert_array_equal(result, class_1)
+
+    def test_list_single_element(self):
+        """List with single element still works."""
+        single = np.random.randn(50, 10)
+        result = normalize_shap_values([single])
+        assert result.shape == (50, 10)
+        np.testing.assert_array_equal(result, single)
+
+    def test_list_of_1d(self):
+        """List containing 1D arrays — take last, reshape to (n, 1)."""
+        vals = [np.random.randn(50), np.random.randn(50)]
+        result = normalize_shap_values(vals)
+        assert result.ndim == 2
+        assert result.shape == (50, 1)
+        np.testing.assert_array_equal(result[:, 0], vals[-1])
+
+    def test_list_of_3d(self):
+        """List containing 3D arrays — take last element, then first output."""
+        vals = [np.random.randn(50, 10, 2), np.random.randn(50, 10, 2)]
+        result = normalize_shap_values(vals)
+        assert result.shape == (50, 10)
+        np.testing.assert_array_equal(result, vals[-1][:, :, 0])
+
+    def test_preserves_values(self):
+        """Verify no data corruption during normalization."""
+        original = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        result = normalize_shap_values(original)
+        np.testing.assert_array_equal(result, original)
+
+    def test_empty_2d(self):
+        """Empty 2D array passes through."""
+        vals = np.zeros((0, 5))
+        result = normalize_shap_values(vals)
+        assert result.shape == (0, 5)
+
+
+# ──────────────────────────────────────────────
+#  SHAP interactions chart test
+# ──────────────────────────────────────────────
+
+
+class TestShapInteractionsChart:
+    """Test shap_interactions.png generation from CSV."""
+
+    def test_generates_chart_from_csv(self, tmp_path):
+        """Verify chart is created when interaction CSV exists."""
+        chart_data_dir = tmp_path / "chart_data"
+        charts_dir = tmp_path / "charts"
+        chart_data_dir.mkdir()
+        charts_dir.mkdir()
+
+        # Create test interaction data
+        interactions = pd.DataFrame(
+            {
+                "contract_type": ["suit", "suit", "high", "high"],
+                "feature_1": ["trump_count", "trump_count", "ace_count", "ace_count"],
+                "feature_2": ["void_count", "ace_count", "king_count", "void_count"],
+                "interaction_strength": [0.45, 0.30, 0.55, 0.20],
+                "correlation": [0.45, -0.30, 0.55, -0.20],
+            }
+        )
+        interactions.to_csv(chart_data_dir / "shap_interactions.csv", index=False)
+
+        result = generate_shap_interactions_chart(chart_data_dir, charts_dir, dpi=72)
+        assert result == "shap_interactions.png"
+        assert (charts_dir / "shap_interactions.png").exists()
+
+    def test_returns_none_when_no_csv(self, tmp_path):
+        """Returns None when CSV is missing."""
+        result = generate_shap_interactions_chart(tmp_path, tmp_path, dpi=72)
+        assert result is None
+
+    def test_returns_none_for_empty_csv(self, tmp_path):
+        """Returns None when CSV is empty."""
+        chart_data_dir = tmp_path / "chart_data"
+        chart_data_dir.mkdir()
+        # Write empty CSV with just headers
+        pd.DataFrame(
+            columns=[
+                "contract_type",
+                "feature_1",
+                "feature_2",
+                "interaction_strength",
+                "correlation",
+            ]
+        ).to_csv(chart_data_dir / "shap_interactions.csv", index=False)
+
+        result = generate_shap_interactions_chart(chart_data_dir, tmp_path, dpi=72)
+        assert result is None

--- a/uv.lock
+++ b/uv.lock
@@ -4,13 +4,16 @@ requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "(python_full_version == '3.11.*' and sys_platform == 'win32') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "(python_full_version == '3.11.*' and sys_platform == 'emscripten') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "(python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "(python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin')",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version < '3.11'",
 ]
 
@@ -331,6 +334,8 @@ dev = [
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "seaborn" },
+    { name = "shap", version = "0.49.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "shap", version = "0.51.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "statsmodels" },
 ]
 
@@ -354,6 +359,7 @@ requires-dist = [
     { name = "scikit-learn", marker = "extra == 'dev'", specifier = ">=1.4.0" },
     { name = "scipy", specifier = ">=1.7.0" },
     { name = "seaborn", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+    { name = "shap", marker = "extra == 'dev'", specifier = ">=0.44.0" },
     { name = "statsmodels", marker = "extra == 'dev'", specifier = ">=0.14.0" },
 ]
 provides-extras = ["dev"]
@@ -577,6 +583,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -671,13 +686,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "(python_full_version == '3.11.*' and sys_platform == 'win32') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "(python_full_version == '3.11.*' and sys_platform == 'emscripten') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "(python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "(python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin')",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -1295,13 +1313,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "(python_full_version == '3.11.*' and sys_platform == 'win32') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "(python_full_version == '3.11.*' and sys_platform == 'emscripten') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "(python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "(python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin')",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
     { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
@@ -1513,7 +1534,7 @@ dependencies = [
     { name = "overrides", marker = "python_full_version < '3.12'" },
     { name = "packaging" },
     { name = "prometheus-client" },
-    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "pywinpty", marker = "(python_full_version < '3.11' and os_name == 'nt') or (os_name == 'nt' and platform_machine != 'x86_64') or (os_name == 'nt' and sys_platform != 'darwin')" },
     { name = "pyzmq" },
     { name = "send2trash" },
     { name = "terminado" },
@@ -1531,7 +1552,7 @@ name = "jupyter-server-terminals"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "pywinpty", marker = "(python_full_version < '3.11' and os_name == 'nt') or (os_name == 'nt' and platform_machine != 'x86_64') or (os_name == 'nt' and sys_platform != 'darwin')" },
     { name = "terminado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f4/a7/bcd0a9b0cbba88986fe944aaaf91bfda603e5a50bda8ed15123f381a3b2f/jupyter_server_terminals-0.5.4.tar.gz", hash = "sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5", size = 31770, upload-time = "2026-01-14T16:53:20.213Z" }
@@ -1723,6 +1744,57 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
+]
+
+[[package]]
+name = "llvmlite"
+version = "0.36.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin')",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/66/6b2c49c7c68da48d17059882fdb9ad9ac9e5ac3f22b00874d7996e3c44a8/llvmlite-0.36.0.tar.gz", hash = "sha256:765128fdf5f149ed0b889ffbe2b05eb1717f8e20a5c87fa2b4018fbcce0fcfc9", size = 126219, upload-time = "2021-03-12T13:41:52.064Z" }
+
+[[package]]
+name = "llvmlite"
+version = "0.46.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "(python_full_version == '3.11.*' and sys_platform == 'win32') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "(python_full_version == '3.11.*' and sys_platform == 'emscripten') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/cd/08ae687ba099c7e3d21fe2ea536500563ef1943c5105bf6ab4ee3829f68e/llvmlite-0.46.0.tar.gz", hash = "sha256:227c9fd6d09dce2783c18b754b7cd9d9b3b3515210c46acc2d3c5badd9870ceb", size = 193456, upload-time = "2025-12-08T18:15:36.295Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/a4/3959e1c61c5ca9db7921e5fd115b344c29b9d57a5dadd87bef97963ca1a5/llvmlite-0.46.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4323177e936d61ae0f73e653e2e614284d97d14d5dd12579adc92b6c2b0597b0", size = 37232766, upload-time = "2025-12-08T18:14:34.765Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a5/a4d916f1015106e1da876028606a8e87fd5d5c840f98c87bc2d5153b6a2f/llvmlite-0.46.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0a2d461cb89537b7c20feb04c46c32e12d5ad4f0896c9dfc0f60336219ff248e", size = 56275176, upload-time = "2025-12-08T18:14:37.944Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7f/a7f2028805dac8c1a6fae7bda4e739b7ebbcd45b29e15bf6d21556fcd3d5/llvmlite-0.46.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b1f6595a35b7b39c3518b85a28bf18f45e075264e4b2dce3f0c2a4f232b4a910", size = 55128629, upload-time = "2025-12-08T18:14:41.674Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/bc/4689e1ba0c073c196b594471eb21be0aa51d9e64b911728aa13cd85ef0ae/llvmlite-0.46.0-cp310-cp310-win_amd64.whl", hash = "sha256:e7a34d4aa6f9a97ee006b504be6d2b8cb7f755b80ab2f344dda1ef992f828559", size = 38138651, upload-time = "2025-12-08T18:14:45.845Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/a1/2ad4b2367915faeebe8447f0a057861f646dbf5fbbb3561db42c65659cf3/llvmlite-0.46.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:82f3d39b16f19aa1a56d5fe625883a6ab600d5cc9ea8906cca70ce94cabba067", size = 37232766, upload-time = "2025-12-08T18:14:48.836Z" },
+    { url = "https://files.pythonhosted.org/packages/12/b5/99cf8772fdd846c07da4fd70f07812a3c8fd17ea2409522c946bb0f2b277/llvmlite-0.46.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a3df43900119803bbc52720e758c76f316a9a0f34612a886862dfe0a5591a17e", size = 56275175, upload-time = "2025-12-08T18:14:51.604Z" },
+    { url = "https://files.pythonhosted.org/packages/38/f2/ed806f9c003563732da156139c45d970ee435bd0bfa5ed8de87ba972b452/llvmlite-0.46.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de183fefc8022d21b0aa37fc3e90410bc3524aed8617f0ff76732fc6c3af5361", size = 55128630, upload-time = "2025-12-08T18:14:55.107Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0c/8f5a37a65fc9b7b17408508145edd5f86263ad69c19d3574e818f533a0eb/llvmlite-0.46.0-cp311-cp311-win_amd64.whl", hash = "sha256:e8b10bc585c58bdffec9e0c309bb7d51be1f2f15e169a4b4d42f2389e431eb93", size = 38138652, upload-time = "2025-12-08T18:14:58.171Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f8/4db016a5e547d4e054ff2f3b99203d63a497465f81ab78ec8eb2ff7b2304/llvmlite-0.46.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b9588ad4c63b4f0175a3984b85494f0c927c6b001e3a246a3a7fb3920d9a137", size = 37232767, upload-time = "2025-12-08T18:15:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/85/4890a7c14b4fa54400945cb52ac3cd88545bbdb973c440f98ca41591cdc5/llvmlite-0.46.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3535bd2bb6a2d7ae4012681ac228e5132cdb75fefb1bcb24e33f2f3e0c865ed4", size = 56275176, upload-time = "2025-12-08T18:15:03.936Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/07/3d31d39c1a1a08cd5337e78299fca77e6aebc07c059fbd0033e3edfab45c/llvmlite-0.46.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4cbfd366e60ff87ea6cc62f50bc4cd800ebb13ed4c149466f50cf2163a473d1e", size = 55128630, upload-time = "2025-12-08T18:15:07.196Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/6b/d139535d7590a1bba1ceb68751bef22fadaa5b815bbdf0e858e3875726b2/llvmlite-0.46.0-cp312-cp312-win_amd64.whl", hash = "sha256:398b39db462c39563a97b912d4f2866cd37cba60537975a09679b28fbbc0fb38", size = 38138940, upload-time = "2025-12-08T18:15:10.162Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ff/3eba7eb0aed4b6fca37125387cd417e8c458e750621fce56d2c541f67fa8/llvmlite-0.46.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:30b60892d034bc560e0ec6654737aaa74e5ca327bd8114d82136aa071d611172", size = 37232767, upload-time = "2025-12-08T18:15:13.22Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/54/737755c0a91558364b9200702c3c9c15d70ed63f9b98a2c32f1c2aa1f3ba/llvmlite-0.46.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6cc19b051753368a9c9f31dc041299059ee91aceec81bd57b0e385e5d5bf1a54", size = 56275176, upload-time = "2025-12-08T18:15:16.339Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/91/14f32e1d70905c1c0aa4e6609ab5d705c3183116ca02ac6df2091868413a/llvmlite-0.46.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bca185892908f9ede48c0acd547fe4dc1bafefb8a4967d47db6cf664f9332d12", size = 55128629, upload-time = "2025-12-08T18:15:19.493Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/a7/d526ae86708cea531935ae777b6dbcabe7db52718e6401e0fb9c5edea80e/llvmlite-0.46.0-cp313-cp313-win_amd64.whl", hash = "sha256:67438fd30e12349ebb054d86a5a1a57fd5e87d264d2451bcfafbbbaa25b82a35", size = 38138941, upload-time = "2025-12-08T18:15:22.536Z" },
+    { url = "https://files.pythonhosted.org/packages/95/ae/af0ffb724814cc2ea64445acad05f71cff5f799bb7efb22e47ee99340dbc/llvmlite-0.46.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:d252edfb9f4ac1fcf20652258e3f102b26b03eef738dc8a6ffdab7d7d341d547", size = 37232768, upload-time = "2025-12-08T18:15:25.055Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/19/5018e5352019be753b7b07f7759cdabb69ca5779fea2494be8839270df4c/llvmlite-0.46.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:379fdd1c59badeff8982cb47e4694a6143bec3bb49aa10a466e095410522064d", size = 56275173, upload-time = "2025-12-08T18:15:28.109Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c9/d57877759d707e84c082163c543853245f91b70c804115a5010532890f18/llvmlite-0.46.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e8cbfff7f6db0fa2c771ad24154e2a7e457c2444d7673e6de06b8b698c3b269", size = 55128628, upload-time = "2025-12-08T18:15:31.098Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a8/e61a8c2b3cc7a597073d9cde1fcbb567e9d827f1db30c93cf80422eac70d/llvmlite-0.46.0-cp314-cp314-win_amd64.whl", hash = "sha256:7821eda3ec1f18050f981819756631d60b6d7ab1a6cf806d9efefbe3f4082d61", size = 39153056, upload-time = "2025-12-08T18:15:33.938Z" },
 ]
 
 [[package]]
@@ -2175,6 +2247,67 @@ wheels = [
 ]
 
 [[package]]
+name = "numba"
+version = "0.53.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin')",
+]
+dependencies = [
+    { name = "llvmlite", version = "0.36.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "setuptools", marker = "python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/7d/3d61160836e49f40913741c464f119551c15ed371c1d91ea50308495b93b/numba-0.53.1.tar.gz", hash = "sha256:9cd4e5216acdc66c4e9dab2dfd22ddb5bef151185c070d4a3cd8e78638aff5b0", size = 2213956, upload-time = "2021-03-26T09:15:50.402Z" }
+
+[[package]]
+name = "numba"
+version = "0.64.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "(python_full_version == '3.11.*' and sys_platform == 'win32') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "(python_full_version == '3.11.*' and sys_platform == 'emscripten') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "llvmlite", version = "0.46.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/c9/a0fb41787d01d621046138da30f6c2100d80857bf34b3390dd68040f27a3/numba-0.64.0.tar.gz", hash = "sha256:95e7300af648baa3308127b1955b52ce6d11889d16e8cfe637b4f85d2fca52b1", size = 2765679, upload-time = "2026-02-18T18:41:20.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/5e/604fed821cd7e3426bb3bc99a7ed6ac0bcb489f4cd93052256437d082f95/numba-0.64.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cc09b79440952e3098eeebea4bf6e8d2355fb7f12734fcd9fc5039f0dca90727", size = 2683250, upload-time = "2026-02-18T18:40:45.829Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/9f/9275a723d050b5f1a9b1c7fb7dbfce324fef301a8e50c5f88338569db06c/numba-0.64.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1afe3a80b8c2f376b211fb7a49e536ef9eafc92436afc95a2f41ea5392f8cc65", size = 3742168, upload-time = "2026-02-18T18:40:48.066Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d1/97ca7dddaa36b16f4c46319bdb6b4913ba15d0245317d0d8ccde7b2d7d92/numba-0.64.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23804194b93b8cd416c6444b5fbc4956082a45fed2d25436ef49c594666e7f7e", size = 3449103, upload-time = "2026-02-18T18:40:49.905Z" },
+    { url = "https://files.pythonhosted.org/packages/52/0a/b9e137ad78415373e3353564500e8bf29dbce3c0d73633bb384d4e5d7537/numba-0.64.0-cp310-cp310-win_amd64.whl", hash = "sha256:e2a9fe998bb2cf848960b34db02c2c3b5e02cf82c07a26d9eef3494069740278", size = 2749950, upload-time = "2026-02-18T18:40:51.536Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a3/1a4286a1c16136c8896d8e2090d950e79b3ec626d3a8dc9620f6234d5a38/numba-0.64.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:766156ee4b8afeeb2b2e23c81307c5d19031f18d5ce76ae2c5fb1429e72fa92b", size = 2682938, upload-time = "2026-02-18T18:40:52.897Z" },
+    { url = "https://files.pythonhosted.org/packages/19/16/aa6e3ba3cd45435c117d1101b278b646444ed05b7c712af631b91353f573/numba-0.64.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d17071b4ffc9d39b75d8e6c101a36f0c81b646123859898c9799cb31807c8f78", size = 3747376, upload-time = "2026-02-18T18:40:54.925Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/f1/dd2f25e18d75fdf897f730b78c5a7b00cc4450f2405564dbebfaf359f21f/numba-0.64.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4ead5630434133bac87fa67526eacb264535e4e9a2d5ec780e0b4fc381a7d275", size = 3453292, upload-time = "2026-02-18T18:40:56.818Z" },
+    { url = "https://files.pythonhosted.org/packages/31/29/e09d5630578a50a2b3fa154990b6b839cf95327aa0709e2d50d0b6816cd1/numba-0.64.0-cp311-cp311-win_amd64.whl", hash = "sha256:f2b1fd93e7aaac07d6fbaed059c00679f591f2423885c206d8c1b55d65ca3f2d", size = 2749824, upload-time = "2026-02-18T18:40:58.392Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a6/9fc52cb4f0d5e6d8b5f4d81615bc01012e3cf24e1052a60f17a68deb8092/numba-0.64.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:69440a8e8bc1a81028446f06b363e28635aa67bd51b1e498023f03b812e0ce68", size = 2683418, upload-time = "2026-02-18T18:40:59.886Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/89/1a74ea99b180b7a5587b0301ed1b183a2937c4b4b67f7994689b5d36fc34/numba-0.64.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f13721011f693ba558b8dd4e4db7f2640462bba1b855bdc804be45bbeb55031a", size = 3804087, upload-time = "2026-02-18T18:41:01.699Z" },
+    { url = "https://files.pythonhosted.org/packages/91/e1/583c647404b15f807410510fec1eb9b80cb8474165940b7749f026f21cbc/numba-0.64.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0b180b1133f2b5d8b3f09d96b6d7a9e51a7da5dda3c09e998b5bcfac85d222c", size = 3504309, upload-time = "2026-02-18T18:41:03.252Z" },
+    { url = "https://files.pythonhosted.org/packages/85/23/0fce5789b8a5035e7ace21216a468143f3144e02013252116616c58339aa/numba-0.64.0-cp312-cp312-win_amd64.whl", hash = "sha256:e63dc94023b47894849b8b106db28ccb98b49d5498b98878fac1a38f83ac007a", size = 2752740, upload-time = "2026-02-18T18:41:05.097Z" },
+    { url = "https://files.pythonhosted.org/packages/52/80/2734de90f9300a6e2503b35ee50d9599926b90cbb7ac54f9e40074cd07f1/numba-0.64.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3bab2c872194dcd985f1153b70782ec0fbbe348fffef340264eacd3a76d59fd6", size = 2683392, upload-time = "2026-02-18T18:41:06.563Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e8/14b5853ebefd5b37723ef365c5318a30ce0702d39057eaa8d7d76392859d/numba-0.64.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:703a246c60832cad231d2e73c1182f25bf3cc8b699759ec8fe58a2dbc689a70c", size = 3812245, upload-time = "2026-02-18T18:41:07.963Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a2/f60dc6c96d19b7185144265a5fbf01c14993d37ff4cd324b09d0212aa7ce/numba-0.64.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7e2e49a7900ee971d32af7609adc0cfe6aa7477c6f6cccdf6d8138538cf7756f", size = 3511328, upload-time = "2026-02-18T18:41:09.504Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/2a/fe7003ea7e7237ee7014f8eaeeb7b0d228a2db22572ca85bab2648cf52cb/numba-0.64.0-cp313-cp313-win_amd64.whl", hash = "sha256:396f43c3f77e78d7ec84cdfc6b04969c78f8f169351b3c4db814b97e7acf4245", size = 2752668, upload-time = "2026-02-18T18:41:11.455Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8a/77d26afe0988c592dd97cb8d4e80bfb3dfc7dbdacfca7d74a7c5c81dd8c2/numba-0.64.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:f565d55eaeff382cbc86c63c8c610347453af3d1e7afb2b6569aac1c9b5c93ce", size = 2683590, upload-time = "2026-02-18T18:41:12.897Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/4b/600b8b7cdbc7f9cebee9ea3d13bb70052a79baf28944024ffcb59f0712e3/numba-0.64.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9b55169b18892c783f85e9ad9e6f5297a6d12967e4414e6b71361086025ff0bb", size = 3781163, upload-time = "2026-02-18T18:41:15.377Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/73/53f2d32bfa45b7175e9944f6b816d8c32840178c3eee9325033db5bf838e/numba-0.64.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:196bcafa02c9dd1707e068434f6d5cedde0feb787e3432f7f1f0e993cc336c4c", size = 3481172, upload-time = "2026-02-18T18:41:17.281Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/00/aebd2f7f1e11e38814bb96e95a27580817a7b340608d3ac085fdbab83174/numba-0.64.0-cp314-cp314-win_amd64.whl", hash = "sha256:213e9acbe7f1c05090592e79020315c1749dd52517b90e94c517dca3f014d4a1", size = 2754700, upload-time = "2026-02-18T18:41:19.277Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
@@ -2246,13 +2379,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "(python_full_version == '3.11.*' and sys_platform == 'win32') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "(python_full_version == '3.11.*' and sys_platform == 'emscripten') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "(python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "(python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin')",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/24/62/ae72ff66c0f1fd959925b4c11f8c2dea61f47f6acaea75a08512cdfe3fed/numpy-2.4.1.tar.gz", hash = "sha256:a1ceafc5042451a858231588a104093474c6a5c57dcc724841f5c888d237d690", size = 20721320, upload-time = "2026-01-10T06:44:59.619Z" }
 wheels = [
@@ -2418,13 +2554,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "(python_full_version == '3.11.*' and sys_platform == 'win32') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "(python_full_version == '3.11.*' and sys_platform == 'emscripten') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "(python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "(python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin')",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -3420,13 +3559,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "(python_full_version == '3.11.*' and sys_platform == 'win32') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "(python_full_version == '3.11.*' and sys_platform == 'emscripten') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "(python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "(python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin')",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
     { name = "joblib", marker = "python_full_version >= '3.11'" },
@@ -3540,13 +3682,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "(python_full_version == '3.11.*' and sys_platform == 'win32') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "(python_full_version == '3.11.*' and sys_platform == 'emscripten') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "(python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "(python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin')",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -3650,12 +3795,136 @@ wheels = [
 ]
 
 [[package]]
+name = "shap"
+version = "0.49.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "cloudpickle", marker = "python_full_version < '3.11'" },
+    { name = "numba", version = "0.64.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "slicer", marker = "python_full_version < '3.11'" },
+    { name = "tqdm", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/c6/9823a7f483aa9f3179fc359c10d22da9e418b1a7a3fc99a42b705d05e82a/shap-0.49.1.tar.gz", hash = "sha256:1114ecd804fff29f50d522ce6031082fcf42fe4a32fb1b5da233b2415d784c8c", size = 4084725, upload-time = "2025-10-14T10:04:49.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/a1/66b4f04995ee23ff8638c21294f1a3a6dc87397af54c87aeeb037500f71f/shap-0.49.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:40140ec5d306719f89daee1df27805a71bcc1ac39630832455d316d0306d1283", size = 558950, upload-time = "2025-10-14T10:04:08.441Z" },
+    { url = "https://files.pythonhosted.org/packages/06/76/2142615fa5cc745fd66beb066d00db123cc86d614a31ca8029b29537a959/shap-0.49.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6e9977f1e0b6bba57967de600e8e6047b3e4643d06a4671f2dba1a97c1b5ab3e", size = 556605, upload-time = "2025-10-14T10:04:10.049Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3a/e28014ffc23f386da3d69abd978838e653fff5641831e5a34aade3f4dfe7/shap-0.49.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54ad4c38e6af56eaa1c892bb3af550a35df15ca0d27d2d41c1d1619ca6a2ba75", size = 1000329, upload-time = "2025-10-14T10:04:11.359Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/09/734325f0a9ab9d3dfa5c0908a927027b3d95b3f6929bb62d88e840b85abf/shap-0.49.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fcd832e97038648ba89f659863322d5cd3ea0815e18c36dd48cd7ae1ca9f264b", size = 1000713, upload-time = "2025-10-14T10:04:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a2/0518acabb104e21fecda65b0202e41edd06637c44dac15e2197e7d13a002/shap-0.49.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7fc2e864908277dca2b1d9c59a18b3f31576b985bd024f39b0c3cb7e2c7441db", size = 2065477, upload-time = "2025-10-14T10:04:13.874Z" },
+    { url = "https://files.pythonhosted.org/packages/af/e1/3d52717b617b9ad1e4d0c9634d3b7c52a913540fde27c4b4663a7ee76b87/shap-0.49.1-cp310-cp310-win_amd64.whl", hash = "sha256:4f5bec3d061b4f4889e1ac4e9b676aede2875778ff44b9d5f5a844cbe6788fd2", size = 547034, upload-time = "2025-10-14T10:04:16.17Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/08/d433b7d18a8b51a7d10477120f78877d806d2eb86283cb1661318d865f3d/shap-0.49.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1e208a0129c721bd0eba6268a9ffac4610dbc8a833d07d2ad9f39541bb737f06", size = 558742, upload-time = "2025-10-14T10:04:17.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/35/72929fdad25e055aff9dfbeb48c044682fc3b815d90cee4036b90bd65f4c/shap-0.49.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0b878470bdf6800069c25d2a8598eb0548aa1e6826becd39cca253521cc14866", size = 556486, upload-time = "2025-10-14T10:04:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/02/be/d92623be2c584784e99a8eb9a6cd02263b4eb363c9e49fa14c20f824bcbb/shap-0.49.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:118577d40c53f005268024e59f6a10cbcafbb6d03b3d97dce7c0c7510190ebaa", size = 1025978, upload-time = "2025-10-14T10:04:20.096Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e9/e4079b5de26a8269121ce38125e130c147dac7b59611e0bd94be10f9444e/shap-0.49.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f424465699aa2dda8057656c6b6d3cb927cf29b054c5bb01cfffcb9efa5dbf98", size = 1027831, upload-time = "2025-10-14T10:04:21.666Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ff/e22e1d899ed56384a2395d6121d6e21833c518c01c5b6c52fce3c0b0cbab/shap-0.49.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d505834fdf2a159e88b1dcdeddfd79f101fd789ba89d589faf0aaec060c0bad9", size = 2092627, upload-time = "2025-10-14T10:04:22.894Z" },
+    { url = "https://files.pythonhosted.org/packages/17/48/bbcd638a391ac0fb30033398a3cca60ba5c36941d962dd74958e67069108/shap-0.49.1-cp311-cp311-win_amd64.whl", hash = "sha256:897c7e6fa98d66482282c8f898c97ade181d714ecaf581da0dab5c49adb9f62c", size = 546845, upload-time = "2025-10-14T10:04:24.238Z" },
+    { url = "https://files.pythonhosted.org/packages/92/7a/ccecf7a9158baa10bdc5146907c72dd5f85c762cb5f16cdc74d15cebb8a1/shap-0.49.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c652dc77f1fffe73f5a3def3356c5090e2e6401c261e4fe5329d83cb6251e772", size = 559663, upload-time = "2025-10-14T10:04:25.412Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/c6/c43382d6c891fcf067d0a9f6d954351e3c7d330f4328c5816769b796aa27/shap-0.49.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c23f1493205e648634680c8974e82e7f4b2e96ae3a7eca2251680172bd197ae9", size = 556265, upload-time = "2025-10-14T10:04:27.098Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/71/f7db7a5a2cedaa3ac52f58f453172d613be041bedd9509ce5b5cba2096a6/shap-0.49.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41147740c42821023e1b60185ce8be989656ccac266cc9490d7a8e3ad53c556a", size = 1022419, upload-time = "2025-10-14T10:04:28.793Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a4/96ca9a69dd669ff835ddef875c5dd8e07599103769417d3e9051fd97d470/shap-0.49.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef9952929d4a7e6763d2716938067bdad762217e3afb46cabfc15a62c012b364", size = 1027074, upload-time = "2025-10-14T10:04:30.2Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/9a/89ed1ac8beffe8ff8e09c12cb351bc3c79ddaadcc47ca6ee434d76e464d7/shap-0.49.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e823417eb0a01947cd9bd763bef2e534c5aef7a7c2952b1badfa969c7d59d3b3", size = 2088172, upload-time = "2025-10-14T10:04:31.725Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/28/11422c1c3aa022a06e76cbfa3267e1750cedc00c1e02ef1ccae9c88cd6f4/shap-0.49.1-cp312-cp312-win_amd64.whl", hash = "sha256:cb28043decfec3f35f795421eb5a81545f629b7f60bbf7449cd2843a7f1c8cc6", size = 548036, upload-time = "2025-10-14T10:04:33.087Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5c/030bbfa19605ca4ad66a753d55e76aee5093be6748a6d33eda89e5613995/shap-0.49.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:333cd8e8c427badda92d5ada9e7aad1e3e1e8e7e0398da51a18b7ffb03514e45", size = 558604, upload-time = "2025-10-14T10:04:34.298Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/7f/7e7b78e9fac6f891096fb6a59a6d4db23243b0af2369ae54e161f513c485/shap-0.49.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4faf61560f73a66f4f26bc027c91f8939201979c4db24949dca305ba0a2ad36", size = 555311, upload-time = "2025-10-14T10:04:35.582Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/be/25283a0f8c30deaf897b89a0dbfd490d330f6fc68caa6f19db6e130832e9/shap-0.49.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b440da658d9aee7711bf642c9b4826d81f588fb478cd9e90c068646e90f56669", size = 1016897, upload-time = "2025-10-14T10:04:36.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/91/a63e563f3dc8e134db12dd155a1a6ed5e0649f79fc8ac651aac1088e8652/shap-0.49.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d8dfa5654eccf4d13dcb262a10314a4e0eb1060db842b2ef31e9fb0038168bc1", size = 1022476, upload-time = "2025-10-14T10:04:38.171Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a2/89303c1f7eb206658bf9ec974dc6e69b0a6bd309cf5de0cfa8f92f5a8eb3/shap-0.49.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ed3080030a6000d3737841c5770ed555b8a922b794fa0ba5aae1e45655eda1fa", size = 2087940, upload-time = "2025-10-14T10:04:39.497Z" },
+    { url = "https://files.pythonhosted.org/packages/84/bd/0b9b3e19b9b8cda51463f8a749dc354eb9c87f42eddcbfdf742dceb3746b/shap-0.49.1-cp313-cp313-win_amd64.whl", hash = "sha256:6af779344c23b12a47063aab7fc135fefbdb5849233c1813f11dd8cf2fc73bea", size = 547806, upload-time = "2025-10-14T10:04:40.712Z" },
+]
+
+[[package]]
+name = "shap"
+version = "0.51.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "(python_full_version == '3.11.*' and sys_platform == 'win32') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "(python_full_version == '3.11.*' and sys_platform == 'emscripten') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "(python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin')",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+]
+dependencies = [
+    { name = "cloudpickle", marker = "python_full_version >= '3.11'" },
+    { name = "llvmlite", version = "0.36.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "llvmlite", version = "0.46.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+    { name = "numba", version = "0.53.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "numba", version = "0.64.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pandas", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "slicer", marker = "python_full_version >= '3.11'" },
+    { name = "tqdm", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/0a/4a3ee4b1a3654f2a9ae038a64bb3e91a42af3da07577d69b65241f010970/shap-0.51.0.tar.gz", hash = "sha256:cfa17ff213657c9d50285aa923d79b0037a62e2ee1a31bc3eec7e196b00bdb59", size = 4108336, upload-time = "2026-03-04T09:18:19.985Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/4f/513ffc1c27242488be2269d5704c7bd8e82c6b28a04c297533d616003948/shap-0.51.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4b4b81d7401bc821490148a694a9f149f8ef488fa973b49fdc8a7916a572750f", size = 565103, upload-time = "2026-03-04T09:17:24.11Z" },
+    { url = "https://files.pythonhosted.org/packages/14/bf/bafa92ae6606f1ee38f14e866045fbcae21412a3a5766fb493b951a6e6e1/shap-0.51.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9b92f7371644c4a19660f734e0b0fe299d0eff273102230c9cf191e310576619", size = 562798, upload-time = "2026-03-04T09:17:25.909Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/09/a952ef8a1fe64b8a7bb909b2d3ab614d33cff7fdf646d62c3bd35d84de02/shap-0.51.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ddd314c9dc766f72027b3b6d9a8b975c7df67f1a27af7f857267c716b7d3dd8", size = 1052516, upload-time = "2026-03-04T09:17:27.816Z" },
+    { url = "https://files.pythonhosted.org/packages/42/48/541bd5b7f068804f33fac459274c06a46deb8f0e1edf3a9b176c00137629/shap-0.51.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a909d6e306d4083e4862b6d097d53f3b4aa4d5cdf2ef4dbac5e8245160d9abd", size = 1060070, upload-time = "2026-03-04T09:17:29.751Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f9/02269c83b3056c5fbaa13911e59b844146ed80c97a6f78aa0d374a9e8368/shap-0.51.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ff5534e92f5876c74975b53cc6b251126bbe092e5032f81e1fe8583c4a74d58c", size = 2023431, upload-time = "2026-03-04T09:17:31.97Z" },
+    { url = "https://files.pythonhosted.org/packages/72/ac/751f3070be48c4b365f565ca5b4ba4c93b0a371d8ee595859c62eab9885b/shap-0.51.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6f3a83f28d2304f81645392a1d346154d9d992705e762fb949fa5371925399b2", size = 2092764, upload-time = "2026-03-04T09:17:33.991Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8e/cee1ee136a4e54fe2fbb63a60d72d7c25e21a4ffe6aa05779cab7669cb31/shap-0.51.0-cp311-cp311-win_amd64.whl", hash = "sha256:ca2a9171e6c5b9a700d585982d7fd8336856ad818e24264420c56f9d8f02a961", size = 554870, upload-time = "2026-03-04T09:17:35.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ba/8c8fac8506327febada7dc58f90dc459287995bb7b8aadbc44506e61be55/shap-0.51.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:07b0367408b1b9fc51556f2ddac5ee4209cc51be592099e6d51d0834c9b037d8", size = 565741, upload-time = "2026-03-04T09:17:37.286Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/07f7c454ff5dff455576e5bb08cdb2cab05a4c1eb5e1b9959ef2ac28366d/shap-0.51.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e412bb475c9074ffd6684abb88d86d93275729b344cbfb37b4e4db37db759fbf", size = 562281, upload-time = "2026-03-04T09:17:39.006Z" },
+    { url = "https://files.pythonhosted.org/packages/93/a1/37e7229be000cf608ece024dcd76edae4cc618b22b402ea78270849cac3f/shap-0.51.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1aa9f659d2028e26ac7ec34cafbc14585fdc14d0c8973e9442c65af1af1ff781", size = 1051009, upload-time = "2026-03-04T09:17:40.989Z" },
+    { url = "https://files.pythonhosted.org/packages/af/c1/a9152876b04f9a05ca18bd3e8bc4bc72468ae32429bfbb30a9cbd4ad35b9/shap-0.51.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0b1f9e62d6a3fa28765d7b61abda7caf76aba21e769423fbf3ce8a7a5e498243", size = 1062849, upload-time = "2026-03-04T09:17:42.587Z" },
+    { url = "https://files.pythonhosted.org/packages/80/89/38c903c438b33063b006f41d00684af8b424bb95f0fcfd8963d1501bf427/shap-0.51.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:dee16e81082dec5ce2a37c41c2b9cbebcb4bf7de79133a72d84a4093b7d4158c", size = 2014842, upload-time = "2026-03-04T09:17:44.212Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/fd/9b295ad15420566dca713b792d9beb65692804b96c69cc99ffec5e31db58/shap-0.51.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c3b878f6414213a12247faa00d609957fdfbcc33cfd48a6751500c4708b5666d", size = 2090611, upload-time = "2026-03-04T09:17:46.728Z" },
+    { url = "https://files.pythonhosted.org/packages/20/0e/6f581645b66efff6bf091953f474eb16e64da499cfac0c552dd77559f205/shap-0.51.0-cp312-cp312-win_amd64.whl", hash = "sha256:ee76aa705927ac64acd4f506722f52596e77d3ced87078bc86bfcb4571c7b976", size = 556117, upload-time = "2026-03-04T09:17:48.68Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4a/77f8dc2c6874d8a27123afffcb79f540a80ed3ccfd640604e4d8beb9cc5e/shap-0.51.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f3efeef8a76e2ee735fad50f82e5a8e56ba8639f42e2fa50dc1997caed77c488", size = 564931, upload-time = "2026-03-04T09:17:51.022Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/5e/5c6d37992e93b3fa44509d8544281cd5ae357c8946bc0e756e78139b4baf/shap-0.51.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:724cdd8298450ae22b08ca40e07136c73e4e75dbdf8e3f07d741a291bf636dad", size = 561686, upload-time = "2026-03-04T09:17:52.462Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b7/76dbca9c4b83602841c016fec7201e4146c5e6347a8b0428e7c0617ba424/shap-0.51.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:13eb21626ea671604769c847ac0604871a03df0842522087ffc00181683780a4", size = 1050719, upload-time = "2026-03-04T09:17:54.252Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b1/472ca0adf25215dfdbca9f398d853536413091fe47dd69bb3f67dbd445f4/shap-0.51.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f32d006680708513efff07f67dcbe44a531b242ae042dee99b7024e210391ac2", size = 1063794, upload-time = "2026-03-04T09:17:56.154Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8e/9072acfcbe6abc79fbfe87360c7dcfe16d7498cdb13dc560820912eb5dd5/shap-0.51.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:33540a7e3c70bd1a742a4d0576c19b5e000165038de953d3ebf31a7bb53d01f4", size = 2012838, upload-time = "2026-03-04T09:17:57.835Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/65/b95588a1f48eb9e98aa61e6db31cf63a388970e4c11341d40ddece3b54f8/shap-0.51.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f461e5a1d6b0cae3fd9c6bd00c95111ed95b9e0020ec71f14291429ed17d49f4", size = 2090245, upload-time = "2026-03-04T09:17:59.501Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d5/1ec3120f461f31a03d1d2f1d339f5058f12c7a542d22bfcc350511eccc8a/shap-0.51.0-cp313-cp313-win_amd64.whl", hash = "sha256:5f51ca55bda10b3fa2125f2b8e08e9d6a6edcbb0e752c67050e87a6d3ca7d53b", size = 555927, upload-time = "2026-03-04T09:18:01.274Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/57/f48dd00ac0d9f75a1f34f5ae47ed3269e8acd541189555f39e49e6f126f4/shap-0.51.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d0c33498ed7042f7259ff207bd3aa1cc814fb759240e5f1500e018660b597c17", size = 562390, upload-time = "2026-03-04T09:18:02.722Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c8/c3b067d10c7a792fd1a32ea93f218b2c217fa99d125f79f26d31376ae246/shap-0.51.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6afaeac1fdd7883a058fb071c7044aff6c44699377a35a5d73e75b68564d0d47", size = 1050124, upload-time = "2026-03-04T09:18:04.172Z" },
+    { url = "https://files.pythonhosted.org/packages/31/81/cf180b20ac0c1323b78386667a24dfc2f6d827baa0b223d84bfd5818aa03/shap-0.51.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da930d73fa23d7a296660431f01726ae47ef2e7d9fee7e1632fb674be7b150b9", size = 1059129, upload-time = "2026-03-04T09:18:05.815Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c3/45ab3242f055980938671d568540ff1dbd84eb9bf4fe0d3235432f7bad35/shap-0.51.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:331d80a993e32404dd76254f5a82cb481453b4d9e58c0e7da13a3b700a381b03", size = 2012487, upload-time = "2026-03-04T09:18:07.919Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/38/a25863c3c8d344e3e322b8dcbac41929b9d00cfb9df3166ac9c350d89c53/shap-0.51.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c52aa8fb311502d5d25e8d631806326656318ab4094459ddbf1410837aaeb139", size = 2086328, upload-time = "2026-03-04T09:18:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5e/60fbf1ffe0c150c4db0e80e31b3f9428e633d33ccf072e1e75227679cbfc/shap-0.51.0-cp314-cp314-win_amd64.whl", hash = "sha256:86f24dab2c64d78f38170d490a03ff6fb1b48cf3bd0a1527e9bed23e74ad5d2c", size = 559185, upload-time = "2026-03-04T09:18:11.64Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/56/8c5f94ae86590e612487c77b9b9bef3fd2f3c91969b3c6e8743ce06440f3/shap-0.51.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:80132eca5679e7e8da7a0d9bfee58d0a3979be25630fd6598ef608bbcefce784", size = 568928, upload-time = "2026-03-04T09:18:13.2Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/04467bf7b8430c3a5c709401ab065022a72340bc50dfaf67a1cc117ce15e/shap-0.51.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18828bc4f78adb644ae35c50e79a246d262fa6cf17143c78cca091796b21c27b", size = 1082574, upload-time = "2026-03-04T09:18:14.899Z" },
+    { url = "https://files.pythonhosted.org/packages/12/d1/3f7b841dd943a1cbb9c693ed65366c6afc1ac54c70065e0281fa82b57075/shap-0.51.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:71e18a6850af4cdeece1a3f9d4b633a421885fcfda079125e3d35ea08433d3eb", size = 2034618, upload-time = "2026-03-04T09:18:16.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/42/3668db63cb38e9648e97087d60a0d4ce569c2e8c2b8828124e6da433026f/shap-0.51.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:23c33eae29f887153ef952846ec3bff6abc0aed3aa01594e4ae66cd94a227a49", size = 2096224, upload-time = "2026-03-04T09:18:18.094Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "slicer"
+version = "0.0.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/f9/b4bce2825b39b57760b361e6131a3dacee3d8951c58cb97ad120abb90317/slicer-0.0.8.tar.gz", hash = "sha256:2e7553af73f0c0c2d355f4afcc3ecf97c6f2156fcf4593955c3f56cf6c4d6eb7", size = 14894, upload-time = "2024-03-09T23:35:26.826Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/81/9ef641ff4e12cbcca30e54e72fb0951a2ba195d0cda0ba4100e532d929db/slicer-0.0.8-py3-none-any.whl", hash = "sha256:6c206258543aecd010d497dc2eca9d2805860a0b3758673903456b7df7934dc3", size = 15251, upload-time = "2024-03-09T07:03:07.708Z" },
 ]
 
 [[package]]
@@ -3753,7 +4022,7 @@ version = "0.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ptyprocess", marker = "os_name != 'nt'" },
-    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "pywinpty", marker = "(python_full_version < '3.11' and os_name == 'nt') or (os_name == 'nt' and platform_machine != 'x86_64') or (os_name == 'nt' and sys_platform != 'darwin')" },
     { name = "tornado" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }


### PR DESCRIPTION
## Plan
N/A — two small combined changes to avoid agent resource issues.

## Summary
- Add `generate_interpretability.py` with SHAP value shape normalization (`normalize_shap_values()`) that handles list (multi-class), 1D (single feature), and 3D (multi-output) shapes from `shap.TreeExplainer.shap_values()`. Includes full interpretability artifact generation (SHAP values/dependence/interactions CSVs, selection paths, prediction diagnostics, decision comparison) and chart rendering including `shap_interactions.png` heatmap.
- Add post-merge review hook (`post-merge-review.sh`) that triggers a comprehensive background Explore agent review after every `gh pr merge`, checking correctness, contract compliance, architecture, and test coverage.

## Why
1. **SHAP fix:** `shap.TreeExplainer.shap_values()` returns variable shapes depending on model type. The interpretability script (Step 3b in the rung orchestrator) needs shape normalization before any 2D indexing (`[i, idx]`) to avoid runtime crashes.
2. **Post-merge review:** Complements the pre-merge review loop (Codex CLI) with a post-merge safety net that catches correctness and integration issues after code lands on main.

## Repro / Validation
**Command(s) run:**
```bash
bash -n .claude/hooks/post-merge-review.sh
python3 -c "import json; json.load(open('.claude/settings.json'))"
uv run python -m pytest tests/unit/test_interpretability.py -v  # 12 tests pass
make check-quiet  # All checks pass
```

**Config (if applicable):** N/A

**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_interpretability.py -v` — 12 tests (9 shape normalization + 3 chart generation)
- [x] `make check-quiet` — Full validation suite passes

## Expected impact
- Metrics impact: None (new script, not yet invoked in production)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/fix-shap-post-merge
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/fix-shap-post-merge
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre  b9d3de7 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/fix-shap-post-merge  593d779 [fix/shap-and-post-merge-review]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)