### PR TITLE
fix: normalize SHAP value shapes for variable TreeExplainer output

### DIFF
--- a/scripts/internal/generate_interpretability.py
+++ b/scripts/internal/generate_interpretability.py
@@ -130,6 +130,49 @@ def _get_feature_names(artifact: dict, family: str) -> list[str]:
 # ── SHAP analysis ───────────────────────────────────────────
 
 
+def normalize_shap_values(shap_values):
+    """Normalize SHAP values to 2D (n_samples, n_features).
+
+    TreeExplainer returns variable shapes:
+    - Regression: 2D (n_samples, n_features) — pass through
+    - Binary classification: list of 2D arrays — take positive class
+    - Single feature: 1D (n_samples,) — reshape to (n_samples, 1)
+    - Multi-output: 3D (n_samples, n_features, n_outputs) — take first output
+    """
+    if isinstance(shap_values, list):
+        shap_values = np.array(shap_values[-1])
+    if not isinstance(shap_values, np.ndarray):
+        shap_values = np.array(shap_values)
+    if shap_values.ndim == 1:
+        shap_values = shap_values.reshape(-1, 1)
+    elif shap_values.ndim == 3:
+        shap_values = shap_values[:, :, 0]
+    elif shap_values.ndim not in (1, 2):
+        raise ValueError(f"Unexpected SHAP values shape: {shap_values.shape}")
+    return shap_values
+
+
+def normalize_shap_interaction_values(interaction_values):
+    """Normalize SHAP interaction values to 3D (n_samples, n_features, n_features).
+
+    TreeExplainer.shap_interaction_values() can return:
+    - 3D (n_samples, n_features, n_features) — pass through
+    - List of 3D arrays (binary classification) — take positive class
+    - 4D (n_samples, n_features, n_features, n_outputs) — take first output
+    """
+    if isinstance(interaction_values, list):
+        interaction_values = np.array(interaction_values[-1])
+    if not isinstance(interaction_values, np.ndarray):
+        interaction_values = np.array(interaction_values)
+    if interaction_values.ndim == 4:
+        interaction_values = interaction_values[:, :, :, 0]
+    elif interaction_values.ndim != 3:
+        raise ValueError(
+            f"Unexpected SHAP interaction values shape: {interaction_values.shape}"
+        )
+    return interaction_values
+
+
 def generate_shap_analysis(
     artifact_info: dict,
     eval_df: pd.DataFrame,
@@ -202,7 +245,7 @@ def generate_shap_analysis(
         # TreeExplainer
         try:
             explainer = shap.TreeExplainer(model)
-            shap_values = explainer.shap_values(X)
+            shap_values = normalize_shap_values(explainer.shap_values(X))
         except Exception as e:
             logger.warning("SHAP failed for %s/%s: %s", model_name, family, e)
             continue
@@ -243,8 +286,8 @@ def generate_shap_analysis(
         # Interactions (top 3 pairs by absolute interaction strength)
         # Use SHAP interaction values if available, otherwise approximate
         try:
-            interaction_values = explainer.shap_interaction_values(
-                X[: min(500, len(X))]
+            interaction_values = normalize_shap_interaction_values(
+                explainer.shap_interaction_values(X[: min(500, len(X))])
             )
             n_features = interaction_values.shape[2]
             # Sum absolute interaction strengths across samples

--- a/tests/unit/test_interpretability.py
+++ b/tests/unit/test_interpretability.py
@@ -335,6 +335,108 @@ def _import_generate_interpretability_charts():
     return mod
 
 
+# ── SHAP value normalization tests ─────────────────────────
+
+
+class TestNormalizeShapValues:
+    """Tests for normalize_shap_values handling variable TreeExplainer output shapes."""
+
+    def test_2d_passthrough(self):
+        """2D regression output (n_samples, n_features) passes through unchanged."""
+        mod = _import_generate_interpretability()
+        vals = np.random.RandomState(42).randn(10, 5)
+        result = mod.normalize_shap_values(vals)
+        assert result.shape == (10, 5)
+        np.testing.assert_array_equal(result, vals)
+
+    def test_list_takes_last_element(self):
+        """List of arrays (binary classification) takes the last (positive class)."""
+        mod = _import_generate_interpretability()
+        neg = np.zeros((10, 5))
+        pos = np.ones((10, 5))
+        result = mod.normalize_shap_values([neg, pos])
+        assert result.shape == (10, 5)
+        np.testing.assert_array_equal(result, pos)
+
+    def test_1d_reshaped_to_column(self):
+        """1D array (single feature) is reshaped to (n_samples, 1)."""
+        mod = _import_generate_interpretability()
+        vals = np.array([1.0, 2.0, 3.0])
+        result = mod.normalize_shap_values(vals)
+        assert result.shape == (3, 1)
+        np.testing.assert_array_equal(result.ravel(), vals)
+
+    def test_3d_takes_first_output(self):
+        """3D array (multi-output) takes first output slice."""
+        mod = _import_generate_interpretability()
+        vals = np.random.RandomState(42).randn(10, 5, 3)
+        result = mod.normalize_shap_values(vals)
+        assert result.shape == (10, 5)
+        np.testing.assert_array_equal(result, vals[:, :, 0])
+
+    def test_list_binary_classification_selects_positive(self):
+        """Binary classification list: negative class zeros, positive class ones."""
+        mod = _import_generate_interpretability()
+        neg = np.zeros((5, 3))
+        pos = np.full((5, 3), 0.42)
+        result = mod.normalize_shap_values([neg, pos])
+        assert result.shape == (5, 3)
+        np.testing.assert_allclose(result, 0.42)
+
+    def test_4d_raises_value_error(self):
+        """4D array raises ValueError (unexpected shape)."""
+        mod = _import_generate_interpretability()
+        vals = np.zeros((2, 3, 4, 5))
+        with pytest.raises(ValueError, match="Unexpected SHAP values shape"):
+            mod.normalize_shap_values(vals)
+
+    def test_list_of_single_array(self):
+        """List with single element (single-class) takes that element."""
+        mod = _import_generate_interpretability()
+        arr = np.ones((8, 4))
+        result = mod.normalize_shap_values([arr])
+        assert result.shape == (8, 4)
+        np.testing.assert_array_equal(result, arr)
+
+
+class TestNormalizeShapInteractionValues:
+    """Tests for normalize_shap_interaction_values."""
+
+    def test_3d_passthrough(self):
+        """3D interaction values (n_samples, n_features, n_features) pass through."""
+        mod = _import_generate_interpretability()
+        vals = np.random.RandomState(42).randn(10, 5, 5)
+        result = mod.normalize_shap_interaction_values(vals)
+        assert result.shape == (10, 5, 5)
+        np.testing.assert_array_equal(result, vals)
+
+    def test_list_takes_last_element(self):
+        """List of 3D arrays (binary classification) takes the last."""
+        mod = _import_generate_interpretability()
+        neg = np.zeros((10, 5, 5))
+        pos = np.ones((10, 5, 5))
+        result = mod.normalize_shap_interaction_values([neg, pos])
+        assert result.shape == (10, 5, 5)
+        np.testing.assert_array_equal(result, pos)
+
+    def test_4d_takes_first_output(self):
+        """4D array (multi-output) takes first output slice."""
+        mod = _import_generate_interpretability()
+        vals = np.random.RandomState(42).randn(10, 5, 5, 3)
+        result = mod.normalize_shap_interaction_values(vals)
+        assert result.shape == (10, 5, 5)
+        np.testing.assert_array_equal(result, vals[:, :, :, 0])
+
+    def test_2d_raises_value_error(self):
+        """2D array raises ValueError (unexpected shape for interactions)."""
+        mod = _import_generate_interpretability()
+        vals = np.zeros((10, 5))
+        with pytest.raises(
+            ValueError, match="Unexpected SHAP interaction values shape"
+        ):
+            mod.normalize_shap_interaction_values(vals)
+
+
 # ── SHAP analysis tests ────────────────────────────────────
 
 


### PR DESCRIPTION
## Plan
N/A — targeted bugfix

## Summary
- Add `normalize_shap_values()` to handle variable `TreeExplainer.shap_values()` output shapes (list, 1D, 2D, 3D)
- Add `normalize_shap_interaction_values()` for interaction value shape normalization (list, 3D, 4D)
- Apply normalization at both call sites in `generate_shap_analysis()`
- Add 11 unit tests covering all shape variants and error cases

## Why
`shap.TreeExplainer.shap_values()` returns variable shapes depending on the model type:
- Regression: 2D `(n_samples, n_features)` — works today
- Binary classification: list of 2D arrays — would fail with raw indexing
- Single feature: 1D `(n_samples,)` — would fail at `mean(axis=0)`
- Multi-output: 3D `(n_samples, n_features, n_outputs)` — would silently produce wrong results

The existing code assumed 2D output and would crash or produce incorrect SHAP rankings for non-regression models.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_interpretability.py -v
make check-quiet
```

**Config:** N/A
**Seed:** N/A (unit tests only, no experiment runs)

## Tests
- [x] `uv run python -m pytest tests/unit/test_interpretability.py -v` — 41 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None (normalization preserves values, just ensures correct shape)
- Runtime impact: Negligible (single reshape per SHAP call)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/fix-shap-shape
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/fix-shap-shape
```

`git worktree list` (abbreviated):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                        2066ddf [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/fix-shap-shape  8418bef [fix/shap-shape-normalization]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)