### PR TITLE
fix: standardize roster format to list (match config.py Roster class)

### DIFF
--- a/plans/arc_d_v2/roster.json
+++ b/plans/arc_d_v2/roster.json
@@ -1,53 +1,66 @@
 {
   "schema_version": "roster_v1",
-  "description": "Arc D v2 lineage roster — 6 primary models + anchor",
-  "models": {
-    "modeloespecifico": {
-      "class_name": "ModeloEspecifico",
+  "lineage_id": "arc_d_v2",
+  "models": [
+    {
+      "name": "modeloespecifico",
+      "class": "ModeloEspecifico",
       "trainable": false,
-      "family": "heuristic",
-      "params": {}
+      "category": "heuristic"
     },
-    "selected_two_stage_av": {
-      "class_name": "TwoStageActionValueBidder",
+    {
+      "name": "selected_two_stage_av",
+      "class": "TwoStageActionValueBidder",
       "trainable": true,
-      "family": "two-stage",
-      "model_class": "two_stage",
-      "feature_set": "forward_select"
+      "model_class": "two-stage",
+      "feature_set": "r0",
+      "selection": "forward"
     },
-    "gbt_av": {
-      "class_name": "GBTActionValueBidder",
+    {
+      "name": "gbt_av",
+      "class": "GBTActionValueBidder",
       "trainable": true,
-      "family": "GBT",
       "model_class": "gbt",
-      "feature_set": "full"
+      "feature_set": "r0"
     },
-    "constrained_ols_av": {
-      "class_name": "ActionValueBidder",
+    {
+      "name": "constrained_ols_av",
+      "class": "ActionValueBidder",
       "trainable": true,
-      "family": "OLS",
       "model_class": "ols",
       "feature_set": "constrained"
     },
-    "selected_ols_av": {
-      "class_name": "ActionValueBidder",
+    {
+      "name": "selected_ols_av",
+      "class": "ActionValueBidder",
       "trainable": true,
-      "family": "OLS",
       "model_class": "ols",
-      "feature_set": "forward_select"
+      "feature_set": "r0",
+      "selection": "forward"
     },
-    "full_ols_av": {
-      "class_name": "ActionValueBidder",
+    {
+      "name": "full_ols_av",
+      "class": "ActionValueBidder",
       "trainable": true,
-      "family": "OLS",
       "model_class": "ols",
-      "feature_set": "full"
+      "feature_set": "r0"
+    },
+    {
+      "name": "stricthellraiser",
+      "class": "StrictHellRaiser",
+      "trainable": false,
+      "category": "legacy_baseline"
+    },
+    {
+      "name": "rankthetank",
+      "class": "RanktheTank",
+      "trainable": false,
+      "category": "legacy_baseline"
     }
-  },
+  ],
   "anchor": {
     "name": "anchor_hybrid_r0_full",
-    "class_name": "HybridOLSaBidder",
     "artifact": "data/artifacts/arc_d/r0/hybrid_r0_full.json",
-    "description": "Frozen R0 hybrid OLSa (full arm) — lineage baseline"
+    "class": "HybridOLSaBidder"
   }
 }

--- a/src/bid_euchre/arc_d_v2/orchestration.py
+++ b/src/bid_euchre/arc_d_v2/orchestration.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import yaml
 
+from bid_euchre.arc_d_v2.config import Roster, RosterModel
 from bid_euchre.arc_d_v2.heartbeat import (
     clear_heartbeat,
     write_heartbeat,
@@ -199,8 +200,10 @@ def fingerprint_matches(state: RunState, step: str, seed: int, **kwargs) -> bool
 # ---------------------------------------------------------------------------
 
 
-def load_roster(rung: str) -> dict:
+def load_roster(rung: str) -> Roster:
     """Load lineage roster with optional rung overlay.
+
+    Uses the canonical ``Roster.load()`` from ``config.py`` (list format).
 
     Roster file: plans/arc_d_v2/roster.json (lineage-level)
     Overlay file: plans/arc_d_v2/<rung>/roster_overlay.json (optional)
@@ -208,47 +211,34 @@ def load_roster(rung: str) -> dict:
     roster_path = _repo_root() / "plans" / "arc_d_v2" / "roster.json"
     if not roster_path.exists():
         logger.warning("No lineage roster found at %s", roster_path)
-        return {"models": {}}
+        return Roster()
 
-    roster = json.loads(roster_path.read_text())
+    roster = Roster.load(roster_path)
 
     overlay_path = _plans_dir(rung) / "roster_overlay.json"
     if overlay_path.exists():
         overlay = json.loads(overlay_path.read_text())
         for name in overlay.get("exclude", []):
-            if name in roster.get("models", {}):
-                roster["models"][name]["status"] = "excluded"
+            for m in roster.models:
+                if m.name == name:
+                    m.status = "excluded"
         for entry in overlay.get("add", []):
-            name = entry.get("name", entry.get("id"))
+            name = entry.get("name", entry.get("id", ""))
             if name:
-                roster["models"][name] = entry
+                roster.models.append(
+                    RosterModel(
+                        name=name,
+                        class_name=entry.get("class", entry.get("class_name", "")),
+                        trainable=entry.get("trainable", True),
+                        model_class=entry.get("model_class", ""),
+                        feature_set=entry.get("feature_set", ""),
+                        selection=entry.get("selection", "none"),
+                        category=entry.get("category", ""),
+                        status=entry.get("status", "active"),
+                    )
+                )
 
     return roster
-
-
-def get_trainable_models(roster: dict) -> list[dict]:
-    """Get list of trainable models from roster."""
-    models = []
-    for name, spec in roster.get("models", {}).items():
-        if spec.get("status") == "excluded":
-            continue
-        if spec.get("trainable", True):
-            model = dict(spec)
-            model["name"] = name
-            models.append(model)
-    return models
-
-
-def get_all_active_models(roster: dict) -> list[dict]:
-    """Get all active (non-excluded) models from roster."""
-    models = []
-    for name, spec in roster.get("models", {}).items():
-        if spec.get("status") == "excluded":
-            continue
-        model = dict(spec)
-        model["name"] = name
-        models.append(model)
-    return models
 
 
 # ---------------------------------------------------------------------------
@@ -334,43 +324,36 @@ def generate_h2h_roster(
     ]
     """
     roster = load_roster(rung)
-    all_models = get_all_active_models(roster)
     entries: list[dict] = []
 
-    for model in all_models:
-        entry: dict = {"name": model["name"], "class_name": model["class_name"]}
+    for model in roster.all_active_models():
+        entry: dict = {"name": model.name, "class_name": model.class_name}
 
-        if model.get("trainable", True):
+        if model.trainable:
             # Find the trained artifact for this model + seed
             artifact_path = find_trained_artifact(
-                model["name"], rung, mode, seed, artifacts_dir
+                model.name, rung, mode, seed, artifacts_dir
             )
             if artifact_path is not None and artifact_path.exists():
                 entry["params"] = {"artifact_path": str(artifact_path)}
             else:
                 logger.warning(
                     "No artifact found for %s seed %d, skipping from H2H roster",
-                    model["name"],
+                    model.name,
                     seed,
                 )
                 continue
-        else:
-            # Non-trainable model: use params from roster spec if present
-            params = model.get("params")
-            if params:
-                entry["params"] = dict(params)
 
         entries.append(entry)
 
     # Add anchor model if defined
-    anchor = roster.get("anchor", {})
-    anchor_name = anchor.get("name")
-    anchor_class = anchor.get("class_name")
-    anchor_artifact = anchor.get("artifact")
-    if anchor_name and anchor_class:
-        anchor_entry: dict = {"name": anchor_name, "class_name": anchor_class}
-        if anchor_artifact:
-            anchor_path = _repo_root() / anchor_artifact
+    if roster.anchor.name and roster.anchor.class_name:
+        anchor_entry: dict = {
+            "name": roster.anchor.name,
+            "class_name": roster.anchor.class_name,
+        }
+        if roster.anchor.artifact:
+            anchor_path = _repo_root() / roster.anchor.artifact
             if anchor_path.exists():
                 anchor_entry["params"] = {"artifact_path": str(anchor_path)}
             else:
@@ -397,37 +380,31 @@ def generate_comparator_config(
     - parameters (n_per, log_level, etc.)
     """
     roster = load_roster(rung)
-    all_models = get_all_active_models(roster)
 
     bidding_policies: list[dict] = []
-    for model in all_models:
-        policy: dict = {"name": model["name"], "class_name": model["class_name"]}
-        if model.get("trainable", True):
+    for model in roster.all_active_models():
+        policy: dict = {"name": model.name, "class_name": model.class_name}
+        if model.trainable:
             artifact_path = find_trained_artifact(
-                model["name"], rung, mode, seed, artifacts_dir
+                model.name, rung, mode, seed, artifacts_dir
             )
             if artifact_path is not None and artifact_path.exists():
                 policy["params"] = {"artifact_path": str(artifact_path)}
             else:
                 logger.warning(
-                    "No artifact for %s, skipping from comparator", model["name"]
+                    "No artifact for %s, skipping from comparator", model.name
                 )
                 continue
-        else:
-            params = model.get("params")
-            if params:
-                policy["params"] = dict(params)
         bidding_policies.append(policy)
 
     # Add anchor
-    anchor = roster.get("anchor", {})
-    anchor_name = anchor.get("name")
-    anchor_class = anchor.get("class_name")
-    anchor_artifact = anchor.get("artifact")
-    if anchor_name and anchor_class:
-        anchor_policy: dict = {"name": anchor_name, "class_name": anchor_class}
-        if anchor_artifact:
-            anchor_path = _repo_root() / anchor_artifact
+    if roster.anchor.name and roster.anchor.class_name:
+        anchor_policy: dict = {
+            "name": roster.anchor.name,
+            "class_name": roster.anchor.class_name,
+        }
+        if roster.anchor.artifact:
+            anchor_path = _repo_root() / roster.anchor.artifact
             if anchor_path.exists():
                 anchor_policy["params"] = {"artifact_path": str(anchor_path)}
         bidding_policies.append(anchor_policy)
@@ -675,7 +652,7 @@ def execute_step_2(state: RunState, seed: int, dry_run: bool = False) -> bool:
     """Step 2: Train all roster models for one seed."""
     rung = state.rung
     roster = load_roster(rung)
-    trainable = get_trainable_models(roster)
+    trainable = roster.trainable_models()
 
     _append_log(rung, {"event": "step_start", "step": "2", "seed": seed})
     state.mark_step_started("2", seed)
@@ -688,9 +665,25 @@ def execute_step_2(state: RunState, seed: int, dry_run: bool = False) -> bool:
     dataset_dir = _repo_root() / "data" / "runs" / f"av_{rung}_{state.mode}_{seed}"
     dataset_path = dataset_dir / "datasets" / "action_value.parquet"
 
+    # Locate continuation artifact (same logic as step 1)
+    continuation = (
+        _repo_root()
+        / "data"
+        / "artifacts"
+        / "arc_d"
+        / rung
+        / f"hybrid_{rung}_full.json"
+    )
+    if not continuation.exists():
+        alt = (
+            _repo_root() / "data" / "artifacts" / "arc_d" / "r0" / "hybrid_r0_full.json"
+        )
+        if alt.exists():
+            continuation = alt
+
     all_ok = True
     for model in trainable:
-        model_name = model["name"]
+        model_name = model.name
 
         if state.model_status(seed, "2", model_name) == "complete":
             if fingerprint_matches(
@@ -725,19 +718,21 @@ def execute_step_2(state: RunState, seed: int, dry_run: bool = False) -> bool:
             str(dataset_path),
             "--output-dir",
             str(output_dir),
+            "--continuation-artifact",
+            str(continuation),
         ]
 
-        model_class = model.get("model_class", "ols")
+        model_class = model.model_class or "ols"
         if model_class != "ols":
             cmd.extend(["--model-class", model_class])
 
-        feature_set = model.get("feature_set", "full")
+        feature_set = model.feature_set or "full"
         if feature_set != "full":
             cmd.extend(["--feature-set", feature_set])
 
-        continuation = model.get("continuation_artifact")
-        if continuation:
-            cmd.extend(["--continuation-artifact", str(_repo_root() / continuation)])
+        selection = model.selection or "none"
+        if selection != "none":
+            cmd.extend(["--selection", selection])
 
         if dry_run:
             logger.info("Step 2: would train %s: %s", model_name, " ".join(cmd))

--- a/tests/unit/test_rung_orchestrator.py
+++ b/tests/unit/test_rung_orchestrator.py
@@ -23,6 +23,7 @@ from bid_euchre.arc_d_v2.advance_check import (
     find_best_in_lineage,
     generate_advance_check,
 )
+from bid_euchre.arc_d_v2.config import AnchorModel, Roster, RosterModel
 from bid_euchre.arc_d_v2.orchestration import (
     STEP_DESCRIPTIONS,
     STEP_FUNCTIONS,
@@ -965,24 +966,25 @@ from bid_euchre.arc_d_v2.orchestration import generate_h2h_roster
 
 class TestGenerateH2HRoster:
     def _mock_roster(self):
-        return {
-            "models": {
-                "gbt_av": {
-                    "class_name": "GBTActionValueBidder",
-                    "trainable": True,
-                },
-                "modeloespecifico": {
-                    "class_name": "ModeloEspecifico",
-                    "trainable": False,
-                    "params": {},
-                },
-            },
-            "anchor": {
-                "name": "anchor_hybrid_r0_full",
-                "class_name": "HybridOLSaBidder",
-                "artifact": "data/artifacts/arc_d/r0/hybrid_r0_full.json",
-            },
-        }
+        return Roster(
+            models=[
+                RosterModel(
+                    name="gbt_av",
+                    class_name="GBTActionValueBidder",
+                    trainable=True,
+                ),
+                RosterModel(
+                    name="modeloespecifico",
+                    class_name="ModeloEspecifico",
+                    trainable=False,
+                ),
+            ],
+            anchor=AnchorModel(
+                name="anchor_hybrid_r0_full",
+                class_name="HybridOLSaBidder",
+                artifact="data/artifacts/arc_d/r0/hybrid_r0_full.json",
+            ),
+        )
 
     def test_generates_correct_format(self, tmp_path):
         """Roster entries have name, class_name, and optional params."""
@@ -1037,23 +1039,25 @@ from bid_euchre.arc_d_v2.orchestration import generate_comparator_config
 
 class TestGenerateComparatorConfig:
     def _mock_roster(self):
-        return {
-            "models": {
-                "gbt_av": {
-                    "class_name": "GBTActionValueBidder",
-                    "trainable": True,
-                },
-                "modeloespecifico": {
-                    "class_name": "ModeloEspecifico",
-                    "trainable": False,
-                },
-            },
-            "anchor": {
-                "name": "anchor_hybrid_r0_full",
-                "class_name": "HybridOLSaBidder",
-                "artifact": "data/artifacts/arc_d/r0/hybrid_r0_full.json",
-            },
-        }
+        return Roster(
+            models=[
+                RosterModel(
+                    name="gbt_av",
+                    class_name="GBTActionValueBidder",
+                    trainable=True,
+                ),
+                RosterModel(
+                    name="modeloespecifico",
+                    class_name="ModeloEspecifico",
+                    trainable=False,
+                ),
+            ],
+            anchor=AnchorModel(
+                name="anchor_hybrid_r0_full",
+                class_name="HybridOLSaBidder",
+                artifact="data/artifacts/arc_d/r0/hybrid_r0_full.json",
+            ),
+        )
 
     def test_generates_valid_yaml_structure(self, tmp_path):
         """Config has required keys for run_auction_comparator.py."""
@@ -1123,15 +1127,16 @@ class TestStep4CommandConstruction:
         art.parent.mkdir(parents=True)
         art.write_text("{}")
 
-        roster = {
-            "models": {
-                "gbt_av": {
-                    "class_name": "GBTActionValueBidder",
-                    "trainable": True,
-                },
-            },
-            "anchor": {},
-        }
+        roster = Roster(
+            models=[
+                RosterModel(
+                    name="gbt_av",
+                    class_name="GBTActionValueBidder",
+                    trainable=True,
+                ),
+            ],
+            anchor=AnchorModel(name="", artifact="", class_name=""),
+        )
 
         plan_dir = tmp_path / "plans" / "arc_d_v2" / "r0"
         plan_dir.mkdir(parents=True)
@@ -1164,7 +1169,7 @@ class TestStep4CommandConstruction:
         plan_dir = tmp_path / "plans" / "arc_d_v2" / "r0"
         plan_dir.mkdir(parents=True)
 
-        roster = {"models": {}, "anchor": {}}
+        roster = Roster()
         state = RunState.create_fresh("r0", "smoke", [42])
 
         with (
@@ -1191,15 +1196,16 @@ class TestStep5CommandConstruction:
         art.parent.mkdir(parents=True)
         art.write_text("{}")
 
-        roster = {
-            "models": {
-                "gbt_av": {
-                    "class_name": "GBTActionValueBidder",
-                    "trainable": True,
-                },
-            },
-            "anchor": {},
-        }
+        roster = Roster(
+            models=[
+                RosterModel(
+                    name="gbt_av",
+                    class_name="GBTActionValueBidder",
+                    trainable=True,
+                ),
+            ],
+            anchor=AnchorModel(name="", artifact="", class_name=""),
+        )
 
         plan_dir = tmp_path / "plans" / "arc_d_v2" / "r0"
         plan_dir.mkdir(parents=True)
@@ -1231,7 +1237,7 @@ class TestStep5CommandConstruction:
         plan_dir = tmp_path / "plans" / "arc_d_v2" / "r0"
         plan_dir.mkdir(parents=True)
 
-        roster = {"models": {}, "anchor": {}}
+        roster = Roster()
         state = RunState.create_fresh("r0", "smoke", [42])
 
         with (


### PR DESCRIPTION
## Plan
N/A — bugfix for roster format mismatch discovered during SMOKE validation.

## Summary
- Convert `plans/arc_d_v2/roster.json` from dict format to list format matching `config.py`'s `Roster.load()`
- Replace orchestration.py's custom `load_roster()`/`get_trainable_models()`/`get_all_active_models()` with the canonical `Roster` class from the typed package
- Add missing legacy baselines (stricthellraiser, rankthetank) to roster per lineage plan
- Fix `model_class: "two_stage"` -> `"two-stage"` (hyphen matches training CLI)
- Pass `--continuation-artifact` and `--selection` flags to training script in Step 2

## Why
Two roster formats existed: a dict format in `roster.json` (`{"models": {"name": {...}}}`) and a list format expected by `config.py`'s `Roster.load()` (`{"models": [{"name": "...", ...}]}`). The orchestrator's `load_roster()` read raw JSON dicts while `Roster.load()` expected list format. This mismatch caused Step 2 to fail during SMOKE runs because `roster.trainable_models()` and `.all_active_models()` couldn't be called on raw dicts.

## Repro / Validation
**Command(s) run:**
- `uv run python scripts/internal/run_rung.py --rung r0 --mode smoke --dry-run` — all steps 0-9 pass
- `uv run python -m pytest tests/unit/test_rung_orchestrator.py tests/unit/test_arc_d_v2_schemas.py -v` — 148 passed
- `make check-quiet` — all checks passed

**Seed (if applicable):** 42 (default SMOKE)

## Tests
- [x] `make check-quiet` (full validation)
- [x] `uv run python -m pytest tests/unit/test_rung_orchestrator.py tests/unit/test_arc_d_v2_schemas.py -v` — 148 passed
- [x] Dry-run SMOKE: all steps 0-9 complete without errors

## Expected impact
- Metrics impact: None (format change only, no behavioral change)
- Runtime impact: None

## Risk level
- [x] Medium (strategy/experiments) — changes orchestrator pipeline

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-roster-fix
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-roster-fix
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                   29df496 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-roster-fix        4ab7463 [fix/roster-format-standardize]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)