### PR TITLE
fix: final SMOKE validation fixes

### DIFF
--- a/scripts/internal/extract_comparator_cis.py
+++ b/scripts/internal/extract_comparator_cis.py
@@ -229,13 +229,19 @@ def _load_manifest_runs(manifest_path, bidder_names, runs_dir):
     return result
 
 
-def _validate_batch_coherence(seat_run_dirs, bidder_name, strict=True):
+def _validate_batch_coherence(
+    seat_run_dirs, bidder_name, strict=True, single_seat=False
+):
     """Validate that all seat runs in a batch share consistent metadata.
 
     Checks: seed, config_sha256, n_per (within ±1 for uneven seat splits),
     and cardinality.
     If strict (manifest mode): sys.exit(1) on mismatch.
     If not strict (legacy mode): stderr warning only.
+
+    When ``single_seat=True``, the config_sha256 check is skipped because
+    each seat gets its own per-seat config YAML (different experiment_name
+    and seat_bidding_policies), making the SHA intentionally different.
     """
     seeds = []
     n_pers = []
@@ -264,20 +270,23 @@ def _validate_batch_coherence(seat_run_dirs, bidder_name, strict=True):
             f"Batch coherence violation for {bidder_name}: mixed seeds {set(seeds)}"
         )
 
-    # config_sha256: in strict mode, require all seats to have it and match
-    non_null_shas = [s for s in config_shas if s]
-    if non_null_shas:
-        if len(non_null_shas) < len(config_shas) and strict:
-            _report(
-                f"Batch coherence violation for {bidder_name}: "
-                f"{len(config_shas) - len(non_null_shas)} of {len(config_shas)} "
-                f"seats missing config_sha256"
-            )
-        if len(set(non_null_shas)) > 1:
-            _report(
-                f"Batch coherence violation for {bidder_name}: "
-                f"mixed config_sha256 {set(non_null_shas)}"
-            )
+    # config_sha256: skip in single-seat mode where each seat intentionally
+    # gets a distinct per-seat config (different experiment_name and
+    # seat_bidding_policies).
+    if not single_seat:
+        non_null_shas = [s for s in config_shas if s]
+        if non_null_shas:
+            if len(non_null_shas) < len(config_shas) and strict:
+                _report(
+                    f"Batch coherence violation for {bidder_name}: "
+                    f"{len(config_shas) - len(non_null_shas)} of {len(config_shas)} "
+                    f"seats missing config_sha256"
+                )
+            if len(set(non_null_shas)) > 1:
+                _report(
+                    f"Batch coherence violation for {bidder_name}: "
+                    f"mixed config_sha256 {set(non_null_shas)}"
+                )
 
     # n_per: allow ±1 variance for uneven seat splits (n_per % 4 != 0)
     valid_n_pers = [n for n in n_pers if n is not None]
@@ -429,7 +438,12 @@ def main():
                     seat_run_dirs.append((seat, candidates[-1]))
 
             # Validate batch coherence
-            _validate_batch_coherence(seat_run_dirs, name, strict=use_strict_coherence)
+            _validate_batch_coherence(
+                seat_run_dirs,
+                name,
+                strict=use_strict_coherence,
+                single_seat=args.single_seat,
+            )
 
             run_directories[name] = []
             for seat, run_dir in seat_run_dirs:

--- a/src/bid_euchre/arc_d_v2/orchestration.py
+++ b/src/bid_euchre/arc_d_v2/orchestration.py
@@ -830,11 +830,15 @@ def execute_step_2(state: RunState, seed: int, dry_run: bool = False) -> bool:
 def _collect_training_artifacts(
     state: RunState, seed: int, rung_artifacts_dir: Path
 ) -> None:
-    """Copy training artifact JSONs into the rung artifacts directory.
+    """Copy training artifact JSONs (and companion files) into the rung artifacts directory.
 
     Searches each trainable model's output dir for JSON artifacts and
     copies them as ``training_artifact_<model_name>.json`` so that
     ``generate_rung_tables.py`` can find them via its glob pattern.
+
+    For GBT models, the JSON artifact references ``.joblib`` files by
+    relative path.  These companion files are also copied so that the
+    ``GBTActionValueBidder`` can load them from the artifact directory.
     """
     import shutil
 
@@ -854,6 +858,14 @@ def _collect_training_artifacts(
             shutil.copy2(json_file, dest)
             logger.info("Step 3: Copied %s -> %s", json_file.name, dest.name)
             break  # Take first JSON artifact per model
+
+        # Copy companion .joblib files (GBT models store sklearn objects externally)
+        for joblib_file in sorted(output_dir.glob("*.joblib")):
+            dest = rung_artifacts_dir / joblib_file.name
+            shutil.copy2(joblib_file, dest)
+            logger.info(
+                "Step 3: Copied companion %s -> %s", joblib_file.name, dest.name
+            )
 
 
 def execute_step_3(state: RunState, seed: int, dry_run: bool = False) -> bool:
@@ -1154,6 +1166,16 @@ def execute_step_5(state: RunState, seed: int, dry_run: bool = False) -> bool:
         state.save(_state_path(rung))
         return False
 
+    # Discover the batch manifest written by run_auction_comparator.py.
+    # The manifest filename includes a timestamp, so we glob for the latest
+    # manifest matching the experiment name and seed.
+    experiment_name = comparator_config.get(
+        "experiment_name", f"arc_d_v2_{rung}_comparator_seed{seed}"
+    )
+    manifest_pattern = f"batch_manifest_{experiment_name}_{seed}_*.json"
+    manifest_candidates = sorted(runs_dir.glob(manifest_pattern))
+    manifest_path = str(manifest_candidates[-1]) if manifest_candidates else None
+
     # CI extraction needs --battery-file to locate the comparator output
     n_bootstrap = {"smoke": 1000, "quick": 5000, "full": 10000}.get(state.mode, 1000)
     cmd_cis = [
@@ -1176,6 +1198,8 @@ def execute_step_5(state: RunState, seed: int, dry_run: bool = False) -> bool:
         "--single-seat",
         "--force",
     ]
+    if manifest_path:
+        cmd_cis.extend(["--manifest", manifest_path])
 
     ok, error = run_subprocess(cmd_cis, "5", rung, f"cis_seed_{seed}")
     if ok:
@@ -1208,6 +1232,7 @@ def execute_step_6(state: RunState, dry_run: bool = False) -> bool:
         )
         return True
 
+    rung_dir = _repo_root() / "data" / "artifacts" / "arc_d_v2" / rung
     output_dir = (
         _repo_root()
         / "docs"
@@ -1217,19 +1242,14 @@ def execute_step_6(state: RunState, dry_run: bool = False) -> bool:
         / "canonical"
         / "tables"
     )
-    seeds_str = ",".join(str(s) for s in state.seeds)
 
     cmd = [
         "uv",
         "run",
         "python",
         str(script),
-        "--rung",
-        rung,
-        "--mode",
-        state.mode,
-        "--seeds",
-        seeds_str,
+        "--rung-dir",
+        str(rung_dir),
         "--output-dir",
         str(output_dir),
     ]
@@ -1292,11 +1312,7 @@ def execute_step_7(state: RunState, dry_run: bool = False) -> bool:
             "run",
             "python",
             str(report_script),
-            "--rung",
-            rung,
-            "--mode",
-            state.mode,
-            "--output-dir",
+            "--report-dir",
             str(report_dir),
         ]
         if not dry_run:
@@ -1312,16 +1328,19 @@ def execute_step_7(state: RunState, dry_run: bool = False) -> bool:
     manifest_script = (
         _repo_root() / "scripts" / "internal" / "generate_evidence_manifest.py"
     )
+    rung_artifacts_dir = _repo_root() / "data" / "artifacts" / "arc_d_v2" / rung
     if manifest_script.exists():
         cmd = [
             "uv",
             "run",
             "python",
             str(manifest_script),
-            "--rung",
+            "--rung-dir",
+            str(rung_artifacts_dir),
+            "--report-dir",
+            str(report_dir),
+            "--rung-id",
             rung,
-            "--output",
-            str(report_dir / ".." / "evidence_manifest.json"),
         ]
         if not dry_run:
             ok, error = run_subprocess(cmd, "7", rung, "manifest")


### PR DESCRIPTION
## Summary

- Fix Step 3: copy companion `.joblib` files alongside JSON training artifacts for GBT models
- Fix Step 5: pass `--manifest` to `extract_comparator_cis.py` and skip `config_sha256` coherence check in single-seat mode
- Fix Steps 6/7: correct CLI argument mismatches between orchestrator and scripts (`--rung-dir`, `--report-dir`)

## Why

Full SMOKE validation (`run_rung.py --rung r0 --mode smoke`) was blocked by three categories of integration bugs between the orchestrator and the scripts it invokes. These fixes enable clean end-to-end execution of all 9 pipeline steps.

## Repro / Validation

```bash
# Setup
mkdir -p data/artifacts/arc_d/r0/
cp <main_checkout>/data/artifacts/arc_d/r0/hybrid_r0_full.json data/artifacts/arc_d/r0/

# Run
uv run python scripts/internal/run_rung.py --rung r0 --mode smoke
```

Clean run from scratch: all 9 steps complete in ~3 minutes (183s wall time).

### Step Results
| Step | Name | Status |
|------|------|--------|
| 0 | Precondition check | PASS |
| 1 | Generate training dataset | PASS |
| 2 | Train roster models | PASS |
| 3 | Offline eval + data sanity | PASS |
| 3b | Interpretability (SHAP) | PASS |
| 4 | H2H battery | PASS |
| 5 | Comparator battery + CI extraction | PASS |
| 6 | Generate canonical tables | PASS |
| 7 | Generate charts + reports + manifest | PASS |
| 8 | Advance check | PASS |
| 9 | Narrative marker | SKIPPED (expected — human-authored) |

### Key Outputs Produced
- `state.json` with all steps complete
- 9 CSV tables, 2 charts, 1 markdown report, 1 evidence manifest
- `comparator_cis_r0_42.json`, `comparator_battery_r0_42.json`
- `h2h_battery_smoke_42.json`
- 5 training artifacts + 4 GBT `.joblib` files
- `advance_check.json` (decision: INVESTIGATE — expected for smoke)

## Tests

```bash
uv run python -m pytest tests/unit/test_rung_orchestrator.py -x -q  # 94 passed
make check-quiet  # All checks passed
```

## Worktree proof

```
pwd: .claude/worktrees/smoke-validation
git rev-parse --show-toplevel: .claude/worktrees/smoke-validation
```

## Details of Fixes

### Fix 1: GBT joblib companion files (Step 3)

`_collect_training_artifacts()` only copied JSON artifacts but GBT models store sklearn model objects in separate `.joblib` files referenced by relative path in the JSON. When the artifact JSON was copied to `data/artifacts/arc_d_v2/r0/`, the `.joblib` files were left behind in `data/runs/`, causing `FileNotFoundError` when `GBTActionValueBidder` tried to load them.

### Fix 2: Manifest + coherence (Step 5)

`extract_comparator_cis.py --single-seat` requires `--manifest <path>` for batch coherence validation. The orchestrator was not passing it. Additionally, the `config_sha256` coherence check was incorrectly failing because each per-seat sub-experiment gets its own YAML config (different `experiment_name` and `seat_bidding_policies`), making the SHA intentionally different. The SHA check is now skipped in single-seat mode.

### Fix 3: CLI argument mismatches (Steps 6/7)

The orchestrator was passing `--rung`/`--mode`/`--seeds` to `generate_rung_tables.py` which expects `--rung-dir`/`--output-dir`, and similar mismatches for `generate_rung_report.py` (`--report-dir` not `--rung`/`--mode`/`--output-dir`) and `generate_evidence_manifest.py` (`--rung-dir`/`--report-dir`/`--rung-id` not `--rung`/`--output`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)