### PR TITLE
docs: agent reliability constraints for autonomous execution

### DIFF
--- a/.claude/rules/70_agent_reliability.md
+++ b/.claude/rules/70_agent_reliability.md
@@ -1,0 +1,38 @@
+# Agent Reliability — Context Window Constraints
+
+> Spawned agents silently die when they exhaust their context window.
+> This is a platform constraint, not a bug. Mitigate operationally.
+
+## Failure Pattern
+
+| Agent Duration | Output Size | Reliability |
+|---------------|-------------|-------------|
+| < 10 min, < 500KB | — | Reliable |
+| 10-15 min, 500-700KB | — | Moderate risk |
+| > 15 min or > 700KB | — | High risk of silent death |
+
+## Rules
+
+1. **One concept per agent.** Never combine unrelated tasks.
+2. **Never include experiment/SMOKE runs in fix agents.** Run validation separately.
+3. **Cap file reads.** Use offset/limit for large files. Avoid reading >5 large files.
+4. **Prefer small sequential agents over large combined agents.**
+5. **Keep prompts focused.** Don't include full code implementations in prompts.
+
+## Detection
+
+```bash
+wc -c < /path/to/agent.output && sleep 5 && wc -c < /path/to/agent.output
+# If identical = agent is dead
+```
+
+## Recovery
+
+state.json + fingerprinting enables idempotent respawn. Respawn with tighter scope.
+
+## Anti-Patterns
+
+- "Fix bug AND run SMOKE AND update docs" in one agent
+- Reading entire governing plan (2800 lines) into agent context
+- Combining two independent PRs into one agent
+- Waiting indefinitely without checking output growth

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,6 +334,11 @@ file every 60 seconds. Check with `run_rung.py --rung <rung> --check-alive`.
 If stale (>5 min), the agent has died and should be respawned -- `state.json`
 enables idempotent resume.
 
+**Agent reliability:** Spawned agents silently die when they exhaust their
+context window (~15 min or ~700KB output). Keep agent tasks small and focused
+(one concept per agent). Never combine fix + validation in one agent. See
+`.claude/rules/70_agent_reliability.md` for constraints.
+
 ### When to Create a Sub-Plan
 
 Create a sub-plan when a governing plan step requires significant


### PR DESCRIPTION
## Summary
- Add `.claude/rules/70_agent_reliability.md` documenting context window constraints for spawned agents
- Add agent reliability paragraph to CLAUDE.md Agent Execution Protocol section

## Why
Spawned agents silently die when they exhaust their context window (~15 min or ~700KB output). This is a platform constraint that has caused failed autonomous executions. Documenting the failure pattern, mitigation rules, detection technique, and anti-patterns prevents recurring agent deaths.

## Repro / Validation
Docs-only change. No code modifications.

## Tests
N/A — docs only.

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/worktree-agent-reliability
branch: docs/agent-reliability-constraints
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)