### PR TITLE
feat: plan-aware validation in review loop (PR 1/3)

### DIFF
--- a/plans/sessions/2026-03-14_plan-aware-autonomous-review.md
+++ b/plans/sessions/2026-03-14_plan-aware-autonomous-review.md
@@ -1,0 +1,69 @@
+# Plan-Aware Autonomous Review Enforcement
+**Date:** 2026-03-14
+**Goal:** Tighten the existing autonomous PR review loop so it validates the PR's declared plan, detects scope drift against that plan, and leaves durable blocker feedback on the PR. Keep the core architecture local-first and status-driven; do not build repo-critical behavior around auth-file hacks.
+
+## Review Amendments (2026-03-14)
+
+Changes from the original plan based on code review of the existing infrastructure:
+
+1. **Scope-drift severity downgraded to P2 (non-blocking).** Plans in this repo use `## Files` as aspirational, not contractual. Actual PRs routinely touch files beyond the plan (exports, conftest, transitive deps). Blocking on drift would produce excessive false positives. Scope drift is reported as a P2 warning with a PR comment; upgrade to P1 only after false-positive rate data proves it's reliable.
+
+2. **"Minimum execution contract" replaced with concrete checks.** Three checks: (a) plan reference present in PR body (P2 if missing — some PRs are trivially N/A), (b) referenced plan file exists on disk (P1 if broken reference), (c) plan file has non-trivial content beyond template boilerplate (P2 if empty/skeleton). No section-structure enforcement.
+
+3. **Plan/scope checks live in `review_driver.py`, not `deterministic_prechecks.py`.** Plan checks need PR body context (fetched from GitHub API), which doesn't fit the `check_file()`/`check_diff()` interface that operates on file content and changed-file lists. The driver gets a new `_validate_plan()` step called in `_step_pr_open()` before prechecks.
+
+4. **New `get_pr_changed_files()` helper in `github_pr_state.py`.** Scope-drift needs the changed file list. Currently the driver gets this from `git diff` in `main()`. Centralizing it in the PR state module makes it reusable and testable.
+
+## Plan
+- Extend `PRMetadata` with `body` field and add `get_pr_body()` to retrieve it. Add `get_pr_changed_files()` helper.
+- Add plan-reference parsing: extract the plan path from the PR body's `## Plan` section.
+- Add plan validation in the driver (`_validate_plan()`): check plan reference present, file exists, file has content. Results stored as findings with appropriate severity (P1/P2).
+- Add idempotent PR comment upsert (`upsert_review_comment()`) using a machine-owned marker and head SHA for deduplication.
+- Add scope-drift check: compare changed files against the plan's `## Files` section. Report undeclared files as P2 warning in the PR comment.
+- Add structured review summaries: format deterministic precheck failures and Codex findings into the PR comment body.
+- Wire blocker comment posting into all terminal-failure paths in the driver.
+- Make Codex CLI invocation configurable via `CODEX_REVIEW_CMD` env var, preserving the current preference chain as fallback.
+- Back all new behavior with focused unit tests.
+- Update `AUTONOMOUS_REVIEW_LOOP.md` and `CODEX_GITHUB_REVIEW.md`.
+
+## Files
+- `scripts/internal/github_pr_state.py` — add `body` to `PRMetadata`, add `get_pr_body()`, `get_pr_changed_files()`, `upsert_review_comment()`.
+- `scripts/internal/review_driver.py` — add `_validate_plan()`, `_parse_plan_reference()`, `_check_scope_drift()`, wire into `_step_pr_open()`. Post blocker comments on stop paths.
+- `scripts/internal/review_state.py` — add `plan_path` and `plan_findings` fields to `ReviewLoopState` if needed for persistence.
+- `scripts/internal/codex_review_adapter.py` — add `CODEX_REVIEW_CMD` env-var support in `_resolve_codex_binary()`.
+- `tests/unit/test_github_pr_state.py` (new) — PR body retrieval, changed files, comment upsert.
+- `tests/unit/test_review_driver.py` (new) — plan validation, scope-drift, blocker comment publishing.
+- `tests/unit/test_codex_review_adapter.py` — configurable launcher tests.
+- `docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md` — document plan-aware enforcement, blocker comments, launcher contract.
+- `docs/02_agent/CODEX_GITHUB_REVIEW.md` — align with new plan-enforcement and comment behavior.
+
+## Validation
+- `uv run python -m pytest tests/unit/test_github_pr_state.py`
+- `uv run python -m pytest tests/unit/test_review_driver.py`
+- `uv run python -m pytest tests/unit/test_codex_review_adapter.py`
+- `uv run python -m pytest tests/unit/test_review_state.py`
+- `uv run python -m pytest tests/unit/test_deterministic_prechecks.py`
+- `make check-quiet`
+
+## Sequencing
+- PR 1: PR metadata enrichment + plan parsing + plan validation + unit tests.
+- PR 2: Scope-drift detection + blocker comment upsert + review summary formatting + unit tests.
+- PR 3: Configurable Codex launcher + documentation alignment.
+
+## Non-Goals
+- Do not move the review loop into GitHub Actions as the primary reviewer.
+- Do not commit `.codex.json`, token refresh logic, or any machine-local auth artifacts.
+- Do not rely on prompt wording alone for plan adherence when deterministic checks can enforce the contract.
+- Do not expand the auto-fixer beyond safe mechanical edits as part of this change.
+- Do not enforce specific plan section structure (e.g., requiring `## Validation` or `## Sequencing`).
+
+## Risks
+- Scope-drift detection can be noisy if the plan file format is too loose; this is mitigated by making it P2 (non-blocking) initially.
+- PR comment upsert logic can spam if deduplication is weak; the implementation keys on a stable marker (`<!-- review-loop-comment -->`) plus head SHA.
+- A configurable launcher can make failures less obvious if misconfigured; preserve clear error reporting when the custom command is absent or exits non-zero.
+- Plan validation adds a GitHub API call to `_step_pr_open()` which could slow the loop or fail if `gh` auth is misconfigured; failures should be non-blocking (log + continue).
+
+## Outcome
+<!-- Filled after implementation -->
+- PR:
+- Notes:

--- a/scripts/internal/github_pr_state.py
+++ b/scripts/internal/github_pr_state.py
@@ -22,6 +22,7 @@ class PRMetadata:
     state: str  # "OPEN", "CLOSED", "MERGED"
     head_sha: str
     url: str
+    body: str = ""
 
 
 def get_pr_metadata(pr_number: int) -> PRMetadata:
@@ -33,7 +34,7 @@ def get_pr_metadata(pr_number: int) -> PRMetadata:
             "view",
             str(pr_number),
             "--json",
-            "number,title,headRefName,state,headRefOid,url",
+            "number,title,headRefName,state,headRefOid,url,body",
         ],
         capture_output=True,
         text=True,
@@ -49,7 +50,69 @@ def get_pr_metadata(pr_number: int) -> PRMetadata:
         state=data["state"],
         head_sha=data["headRefOid"],
         url=data["url"],
+        body=data.get("body", ""),
     )
+
+
+def get_pr_body(pr_number: int) -> str:
+    """Get the body (description) of a PR.
+
+    Args:
+        pr_number: PR number.
+
+    Returns:
+        PR body text.
+
+    Raises:
+        RuntimeError: If the gh CLI call fails.
+    """
+    result = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(pr_number),
+            "--json",
+            "body",
+            "--jq",
+            ".body",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to get PR #{pr_number} body: {result.stderr}")
+    return result.stdout.strip()
+
+
+def get_pr_changed_files(pr_number: int) -> list[str]:
+    """Get the list of files changed in a PR.
+
+    Args:
+        pr_number: PR number.
+
+    Returns:
+        List of relative file paths changed in the PR.
+
+    Raises:
+        RuntimeError: If the gh CLI call fails.
+    """
+    result = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "diff",
+            str(pr_number),
+            "--name-only",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Failed to get PR #{pr_number} changed files: {result.stderr}"
+        )
+    return [f.strip() for f in result.stdout.strip().split("\n") if f.strip()]
 
 
 def get_pr_head_sha(pr_number: int) -> str:

--- a/scripts/internal/review_driver.py
+++ b/scripts/internal/review_driver.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import re
 import subprocess
 import sys
 import time
@@ -293,39 +294,214 @@ def _step_initialized(
     return loop_state
 
 
+# Regex for explicit plan opt-out markers (N/A, none, dash, em-dash)
+_PLAN_OPTOUT_RE = re.compile(r"^(?:N/?A|none|-)$", re.IGNORECASE)
+
+# Minimum content length (after stripping headers/comments) for a non-trivial plan
+_PLAN_MIN_CONTENT_LEN = 50
+
+
+def parse_plan_reference(pr_body: str) -> tuple[str | None, bool]:
+    """Extract plan file path from PR body's ``## Plan`` section.
+
+    Handles:
+    - Plain path: ``plans/sessions/2026-03-14_foo.md``
+    - Backtick-quoted: ```plans/sessions/2026-03-14_foo.md```
+    - Markdown link: ``[Plan](plans/sessions/2026-03-14_foo.md)``
+    - List item prefix: ``- plans/sessions/...``
+    - Explicit opt-out: ``N/A``, ``none``, ``-``
+
+    Args:
+        pr_body: Full PR description text.
+
+    Returns:
+        Tuple of (path or None, opted_out). If opted_out is True,
+        the author explicitly marked the plan as N/A.
+    """
+    # Find ## Plan section (up to next ## heading or end of body)
+    plan_match = re.search(
+        r"^## Plan\s*\n(.*?)(?=^## |\Z)",
+        pr_body,
+        re.MULTILINE | re.DOTALL,
+    )
+    if not plan_match:
+        return None, False
+
+    section = plan_match.group(1)
+    # Strip HTML comments
+    section = re.sub(r"<!--.*?-->", "", section, flags=re.DOTALL).strip()
+
+    if not section:
+        return None, False
+
+    # Check for explicit opt-out BEFORE stripping list markers
+    # (a bare "-" is the unfilled template placeholder, not a list prefix)
+    clean_for_optout = re.sub(r"^[-*]\s*", "", section).strip()
+    if _PLAN_OPTOUT_RE.match(section) or (not clean_for_optout):
+        return None, True
+
+    # Strip leading list marker for path extraction
+    section = clean_for_optout
+
+    # Try backtick-quoted path
+    backtick_match = re.search(r"`([^`]+\.md)`", section)
+    if backtick_match:
+        return backtick_match.group(1), False
+
+    # Try markdown link
+    link_match = re.search(r"\[.*?\]\(([^)]+\.md)\)", section)
+    if link_match:
+        return link_match.group(1), False
+
+    # Try plain path (looks like a relative file path ending in .md)
+    path_match = re.search(r"((?:plans|docs)/\S+\.md)", section)
+    if path_match:
+        return path_match.group(1), False
+
+    return None, False
+
+
+def validate_plan(
+    pr_number: int,
+    *,
+    repo_root: Path | None = None,
+) -> tuple[str | None, list[dict]]:
+    """Validate the plan reference declared in a PR's body.
+
+    Checks:
+    1. Plan reference is present in the PR body (P2 if missing).
+    2. Referenced plan file exists on disk (P1 if broken reference).
+    3. Plan file has non-trivial content (P2 if empty/boilerplate).
+
+    Failures in fetching the PR body are non-blocking (logged and skipped).
+
+    Args:
+        pr_number: PR number to validate.
+        repo_root: Repository root for file existence checks.
+
+    Returns:
+        Tuple of (plan_path or None, list of finding dicts).
+    """
+    from github_pr_state import get_pr_body
+
+    if repo_root is None:
+        repo_root = Path.cwd()
+
+    findings: list[dict] = []
+
+    try:
+        body = get_pr_body(pr_number)
+    except Exception:
+        logger.warning(
+            "PR #%d: failed to fetch PR body — skipping plan validation",
+            pr_number,
+        )
+        return None, []
+
+    plan_path, opted_out = parse_plan_reference(body)
+
+    if opted_out:
+        # Explicit N/A — no finding
+        return None, []
+
+    if plan_path is None:
+        findings.append(
+            {
+                "severity": "P2",
+                "file": "<PR body>",
+                "line": 0,
+                "category": "process",
+                "check_id": "PV1",
+                "message": "No plan reference in PR body — add a plan path or N/A",
+                "raw_source": "plan_validation",
+            }
+        )
+        return None, findings
+
+    # Check if plan file exists
+    full_path = repo_root / plan_path
+    if not full_path.exists():
+        findings.append(
+            {
+                "severity": "P1",
+                "file": plan_path,
+                "line": 0,
+                "category": "process",
+                "check_id": "PV2",
+                "message": f"Plan file does not exist: {plan_path}",
+                "raw_source": "plan_validation",
+            }
+        )
+        return plan_path, findings
+
+    # Check if plan file has non-trivial content
+    content = full_path.read_text()
+    # Strip markdown headers and HTML comments to measure real content
+    stripped = re.sub(r"<!--.*?-->", "", content, flags=re.DOTALL)
+    stripped = re.sub(r"^#+\s.*$", "", stripped, flags=re.MULTILINE)
+    stripped = re.sub(r"^\*\*.*?\*\*:?", "", stripped, flags=re.MULTILINE)
+    stripped = stripped.strip()
+
+    if len(stripped) < _PLAN_MIN_CONTENT_LEN:
+        findings.append(
+            {
+                "severity": "P2",
+                "file": plan_path,
+                "line": 0,
+                "category": "process",
+                "check_id": "PV3",
+                "message": "Plan file appears to be empty or boilerplate only",
+                "raw_source": "plan_validation",
+            }
+        )
+
+    return plan_path, findings
+
+
 def _step_pr_open(
     loop_state: ReviewLoopState,
     base_dir: Path | None,
 ) -> ReviewLoopState:
-    """PR_OPEN → WAITING_FOR_CI: Run prechecks + make check, then wait for CI."""
+    """PR_OPEN → WAITING_FOR_CI: Run plan validation + prechecks + make check."""
     from deterministic_prechecks import check_diff, get_blocking_findings
+
+    # 0. Validate plan reference (non-blocking on fetch failures)
+    plan_path, plan_findings = validate_plan(loop_state.pr_number)
+    if plan_path:
+        loop_state.plan_path = plan_path
 
     # 1. Run deterministic prechecks
     findings = check_diff(mode=loop_state.mode)
     blocking = get_blocking_findings(findings)
 
-    # Save precheck results for this round
+    # Merge plan validation findings (already dicts) with precheck Finding objects
+    # Plan findings with P1 severity count as blocking
+    plan_blocking = [f for f in plan_findings if f.get("severity") in ("P0", "P1")]
+
+    # Save all precheck + plan validation results for this round
     rdir = round_dir(loop_state.pr_number, loop_state.iteration_count + 1, base_dir)
     rdir.mkdir(parents=True, exist_ok=True)
+    all_findings_dicts = [f.to_dict() for f in findings] + plan_findings
     with open(rdir / "prechecks.json", "w") as f:
-        json.dump([f.to_dict() for f in findings], f, indent=2)
+        json.dump(all_findings_dicts, f, indent=2)
 
-    if blocking:
-        # Blocking prechecks -> stop (these are deterministic, unfixable by Codex)
+    all_blocking = list(blocking) + plan_blocking
+    if all_blocking:
+        # Blocking prechecks/plan issues -> stop
         _publish_status(
             loop_state.pr_number,
             "failure",
-            f"Blocking prechecks: {len(blocking)} findings",
+            f"Blocking prechecks: {len(all_blocking)} findings",
         )
         loop_state.transition(ReviewState.STOPPED_CI_FAILURE)
         loop_state.stop_reason = (
-            f"Blocking deterministic precheck failures: {len(blocking)} findings"
+            f"Blocking precheck/plan failures: {len(all_blocking)} findings"
         )
         save_state(loop_state, base_dir)
         logger.warning(
             "PR #%d: blocking prechecks (%d findings) -- stopped",
             loop_state.pr_number,
-            len(blocking),
+            len(all_blocking),
         )
         return loop_state
 

--- a/scripts/internal/review_state.py
+++ b/scripts/internal/review_state.py
@@ -159,6 +159,8 @@ class ReviewLoopState:
     initial_head_sha: str | None = None  # SHA when loop started
     current_head_sha: str | None = None  # tracks pushes (auto-fix commits)
     run_id: str | None = None  # unique ID: f"pr_{pr_number}_{head_sha[:7]}"
+    # Plan tracking
+    plan_path: str | None = None  # declared plan file from PR body
 
     @property
     def current_state(self) -> ReviewState:

--- a/tests/unit/test_github_pr_state.py
+++ b/tests/unit/test_github_pr_state.py
@@ -1,0 +1,174 @@
+"""Tests for github_pr_state.py — PR metadata, body retrieval, changed files."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+# Add scripts/internal to path for direct imports
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "internal"))
+
+from github_pr_state import (
+    PRMetadata,
+    get_pr_body,
+    get_pr_changed_files,
+    get_pr_metadata,
+)
+
+
+class TestPRMetadata:
+    """Test PRMetadata dataclass."""
+
+    def test_body_field_default(self) -> None:
+        """body field defaults to empty string for backward compatibility."""
+        meta = PRMetadata(
+            number=1,
+            title="test",
+            branch="main",
+            state="OPEN",
+            head_sha="abc123",
+            url="https://example.com",
+        )
+        assert meta.body == ""
+
+    def test_body_field_set(self) -> None:
+        meta = PRMetadata(
+            number=1,
+            title="test",
+            branch="main",
+            state="OPEN",
+            head_sha="abc123",
+            url="https://example.com",
+            body="## Plan\nN/A",
+        )
+        assert meta.body == "## Plan\nN/A"
+
+
+class TestGetPRMetadata:
+    """Test get_pr_metadata includes body."""
+
+    @patch("github_pr_state.subprocess.run")
+    def test_includes_body_in_request(self, mock_run: Mock) -> None:
+        mock_run.return_value = Mock(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "number": 42,
+                    "title": "test PR",
+                    "headRefName": "feature-branch",
+                    "state": "OPEN",
+                    "headRefOid": "abc1234567890",
+                    "url": "https://github.com/org/repo/pull/42",
+                    "body": "## Plan\nplans/sessions/test.md",
+                }
+            ),
+        )
+        meta = get_pr_metadata(42)
+        # Verify body field in gh CLI request
+        cmd = mock_run.call_args[0][0]
+        assert "body" in cmd[5]  # The --json fields string
+        assert meta.body == "## Plan\nplans/sessions/test.md"
+
+    @patch("github_pr_state.subprocess.run")
+    def test_body_defaults_on_missing(self, mock_run: Mock) -> None:
+        """If body is missing from API response, default to empty string."""
+        mock_run.return_value = Mock(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "number": 42,
+                    "title": "test PR",
+                    "headRefName": "feature-branch",
+                    "state": "OPEN",
+                    "headRefOid": "abc1234567890",
+                    "url": "https://github.com/org/repo/pull/42",
+                    # No body key
+                }
+            ),
+        )
+        meta = get_pr_metadata(42)
+        assert meta.body == ""
+
+
+class TestGetPRBody:
+    """Test get_pr_body standalone function."""
+
+    @patch("github_pr_state.subprocess.run")
+    def test_returns_body_text(self, mock_run: Mock) -> None:
+        mock_run.return_value = Mock(
+            returncode=0,
+            stdout="## Plan\nplans/sessions/test.md\n\n## Summary\n- Added feature\n",
+        )
+        body = get_pr_body(42)
+        assert "## Plan" in body
+        assert "plans/sessions/test.md" in body
+
+    @patch("github_pr_state.subprocess.run")
+    def test_strips_trailing_whitespace(self, mock_run: Mock) -> None:
+        mock_run.return_value = Mock(returncode=0, stdout="body text\n\n")
+        assert get_pr_body(1) == "body text"
+
+    @patch("github_pr_state.subprocess.run")
+    def test_raises_on_failure(self, mock_run: Mock) -> None:
+        mock_run.return_value = Mock(returncode=1, stderr="not found")
+        with pytest.raises(RuntimeError, match="Failed to get PR #99 body"):
+            get_pr_body(99)
+
+    @patch("github_pr_state.subprocess.run")
+    def test_uses_jq_for_body(self, mock_run: Mock) -> None:
+        """Verify the gh CLI command uses --jq .body for efficient extraction."""
+        mock_run.return_value = Mock(returncode=0, stdout="body text")
+        get_pr_body(42)
+        cmd = mock_run.call_args[0][0]
+        assert "--jq" in cmd
+        assert ".body" in cmd
+
+
+class TestGetPRChangedFiles:
+    """Test get_pr_changed_files function."""
+
+    @patch("github_pr_state.subprocess.run")
+    def test_returns_file_list(self, mock_run: Mock) -> None:
+        mock_run.return_value = Mock(
+            returncode=0,
+            stdout="scripts/internal/review_driver.py\ntests/unit/test_review.py\n",
+        )
+        files = get_pr_changed_files(42)
+        assert files == [
+            "scripts/internal/review_driver.py",
+            "tests/unit/test_review.py",
+        ]
+
+    @patch("github_pr_state.subprocess.run")
+    def test_strips_whitespace(self, mock_run: Mock) -> None:
+        mock_run.return_value = Mock(
+            returncode=0,
+            stdout="  src/foo.py  \n  src/bar.py  \n",
+        )
+        files = get_pr_changed_files(1)
+        assert files == ["src/foo.py", "src/bar.py"]
+
+    @patch("github_pr_state.subprocess.run")
+    def test_skips_empty_lines(self, mock_run: Mock) -> None:
+        mock_run.return_value = Mock(
+            returncode=0,
+            stdout="src/foo.py\n\nsrc/bar.py\n\n",
+        )
+        files = get_pr_changed_files(1)
+        assert files == ["src/foo.py", "src/bar.py"]
+
+    @patch("github_pr_state.subprocess.run")
+    def test_raises_on_failure(self, mock_run: Mock) -> None:
+        mock_run.return_value = Mock(returncode=1, stderr="not found")
+        with pytest.raises(RuntimeError, match="Failed to get PR #99"):
+            get_pr_changed_files(99)
+
+    @patch("github_pr_state.subprocess.run")
+    def test_empty_diff_returns_empty_list(self, mock_run: Mock) -> None:
+        mock_run.return_value = Mock(returncode=0, stdout="")
+        files = get_pr_changed_files(1)
+        assert files == []

--- a/tests/unit/test_review_driver.py
+++ b/tests/unit/test_review_driver.py
@@ -1,0 +1,322 @@
+"""Tests for review_driver.py — plan parsing, plan validation, and driver logic."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# Add scripts/internal to path for direct imports
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "internal"))
+
+from review_driver import (
+    classify_review_mode,
+    parse_plan_reference,
+    validate_plan,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures: PR body samples
+# ---------------------------------------------------------------------------
+
+BODY_WITH_PLAN_PATH = """\
+## Plan
+plans/sessions/2026-03-14_plan-aware-autonomous-review.md
+
+## Summary
+- Added plan validation
+"""
+
+BODY_WITH_BACKTICK_PATH = """\
+## Plan
+`plans/sessions/2026-03-14_plan-aware-autonomous-review.md`
+
+## Summary
+- Added plan validation
+"""
+
+BODY_WITH_MARKDOWN_LINK = """\
+## Plan
+[Plan file](plans/sessions/2026-03-14_plan-aware-autonomous-review.md)
+
+## Summary
+- Added plan validation
+"""
+
+BODY_WITH_LIST_ITEM = """\
+## Plan
+- plans/sessions/2026-03-14_plan-aware-autonomous-review.md
+
+## Summary
+- Added plan validation
+"""
+
+BODY_WITH_NA = """\
+## Plan
+<!-- Link to the plan file that authorized this PR, or N/A for trivial changes -->
+N/A
+
+## Summary
+- Trivial fix
+"""
+
+BODY_WITH_NONE = """\
+## Plan
+none
+
+## Summary
+- Trivial fix
+"""
+
+BODY_WITH_DASH = """\
+## Plan
+<!-- Link to the plan file that authorized this PR, or N/A for trivial changes -->
+-
+
+## Summary
+- Empty template
+"""
+
+BODY_EMPTY_PLAN = """\
+## Plan
+
+## Summary
+- Missing plan reference
+"""
+
+BODY_NO_PLAN_SECTION = """\
+## Summary
+- No plan section at all
+"""
+
+BODY_WITH_COMMENT_ONLY = """\
+## Plan
+<!-- Link to the plan file that authorized this PR, or N/A for trivial changes -->
+
+## Summary
+- Only comment in plan section
+"""
+
+BODY_DOCS_PLAN_PATH = """\
+## Plan
+docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md
+
+## Summary
+- Updated docs
+"""
+
+BODY_WITH_BACKTICK_LIST = """\
+## Plan
+- `plans/sessions/2026-03-14_foo.md`
+
+## Summary
+- path in backticks with list prefix
+"""
+
+
+# ---------------------------------------------------------------------------
+# parse_plan_reference tests
+# ---------------------------------------------------------------------------
+
+
+class TestParsePlanReference:
+    """Test plan reference extraction from PR body text."""
+
+    def test_plain_path(self) -> None:
+        path, opted_out = parse_plan_reference(BODY_WITH_PLAN_PATH)
+        assert path == "plans/sessions/2026-03-14_plan-aware-autonomous-review.md"
+        assert not opted_out
+
+    def test_backtick_path(self) -> None:
+        path, opted_out = parse_plan_reference(BODY_WITH_BACKTICK_PATH)
+        assert path == "plans/sessions/2026-03-14_plan-aware-autonomous-review.md"
+        assert not opted_out
+
+    def test_markdown_link(self) -> None:
+        path, opted_out = parse_plan_reference(BODY_WITH_MARKDOWN_LINK)
+        assert path == "plans/sessions/2026-03-14_plan-aware-autonomous-review.md"
+        assert not opted_out
+
+    def test_list_item_path(self) -> None:
+        path, opted_out = parse_plan_reference(BODY_WITH_LIST_ITEM)
+        assert path == "plans/sessions/2026-03-14_plan-aware-autonomous-review.md"
+        assert not opted_out
+
+    def test_backtick_with_list(self) -> None:
+        path, opted_out = parse_plan_reference(BODY_WITH_BACKTICK_LIST)
+        assert path == "plans/sessions/2026-03-14_foo.md"
+        assert not opted_out
+
+    def test_docs_path(self) -> None:
+        path, opted_out = parse_plan_reference(BODY_DOCS_PLAN_PATH)
+        assert path == "docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md"
+        assert not opted_out
+
+    def test_na_explicit_optout(self) -> None:
+        path, opted_out = parse_plan_reference(BODY_WITH_NA)
+        assert path is None
+        assert opted_out
+
+    def test_none_explicit_optout(self) -> None:
+        path, opted_out = parse_plan_reference(BODY_WITH_NONE)
+        assert path is None
+        assert opted_out
+
+    def test_dash_explicit_optout(self) -> None:
+        path, opted_out = parse_plan_reference(BODY_WITH_DASH)
+        assert path is None
+        assert opted_out
+
+    def test_empty_plan_section(self) -> None:
+        path, opted_out = parse_plan_reference(BODY_EMPTY_PLAN)
+        assert path is None
+        assert not opted_out
+
+    def test_no_plan_section(self) -> None:
+        path, opted_out = parse_plan_reference(BODY_NO_PLAN_SECTION)
+        assert path is None
+        assert not opted_out
+
+    def test_comment_only_section(self) -> None:
+        path, opted_out = parse_plan_reference(BODY_WITH_COMMENT_ONLY)
+        assert path is None
+        assert not opted_out
+
+    def test_empty_body(self) -> None:
+        path, opted_out = parse_plan_reference("")
+        assert path is None
+        assert not opted_out
+
+
+# ---------------------------------------------------------------------------
+# validate_plan tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePlan:
+    """Test plan validation logic."""
+
+    @patch("github_pr_state.get_pr_body")
+    def test_na_produces_no_findings(self, mock_body) -> None:
+        mock_body.return_value = BODY_WITH_NA
+        plan_path, findings = validate_plan(1)
+        assert plan_path is None
+        assert findings == []
+
+    @patch("github_pr_state.get_pr_body")
+    def test_missing_plan_produces_p2(self, mock_body) -> None:
+        mock_body.return_value = BODY_EMPTY_PLAN
+        plan_path, findings = validate_plan(1)
+        assert plan_path is None
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "P2"
+        assert findings[0]["check_id"] == "PV1"
+
+    @patch("github_pr_state.get_pr_body")
+    def test_no_plan_section_produces_p2(self, mock_body) -> None:
+        mock_body.return_value = BODY_NO_PLAN_SECTION
+        plan_path, findings = validate_plan(1)
+        assert plan_path is None
+        assert len(findings) == 1
+        assert findings[0]["check_id"] == "PV1"
+
+    @patch("github_pr_state.get_pr_body")
+    def test_broken_reference_produces_p1(self, mock_body, tmp_path) -> None:
+        mock_body.return_value = (
+            "## Plan\nplans/sessions/nonexistent.md\n\n## Summary\n- test\n"
+        )
+        plan_path, findings = validate_plan(1, repo_root=tmp_path)
+        assert plan_path == "plans/sessions/nonexistent.md"
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "P1"
+        assert findings[0]["check_id"] == "PV2"
+
+    @patch("github_pr_state.get_pr_body")
+    def test_valid_plan_no_findings(self, mock_body, tmp_path) -> None:
+        # Create a plan file with real content
+        plan_dir = tmp_path / "plans" / "sessions"
+        plan_dir.mkdir(parents=True)
+        plan_file = plan_dir / "test.md"
+        plan_file.write_text(
+            "# Test Plan\n\n"
+            "## Plan\n"
+            "This plan implements the foo feature with bar approach. "
+            "It modifies several files and adds comprehensive tests. "
+            "The validation strategy uses targeted pytest runs.\n"
+        )
+        mock_body.return_value = "## Plan\nplans/sessions/test.md\n\n## Summary\n"
+        plan_path, findings = validate_plan(1, repo_root=tmp_path)
+        assert plan_path == "plans/sessions/test.md"
+        assert findings == []
+
+    @patch("github_pr_state.get_pr_body")
+    def test_empty_plan_file_produces_p2(self, mock_body, tmp_path) -> None:
+        plan_dir = tmp_path / "plans" / "sessions"
+        plan_dir.mkdir(parents=True)
+        plan_file = plan_dir / "empty.md"
+        plan_file.write_text("# Empty Plan\n")
+        mock_body.return_value = "## Plan\nplans/sessions/empty.md\n\n## Summary\n"
+        plan_path, findings = validate_plan(1, repo_root=tmp_path)
+        assert plan_path == "plans/sessions/empty.md"
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "P2"
+        assert findings[0]["check_id"] == "PV3"
+
+    @patch("github_pr_state.get_pr_body")
+    def test_body_fetch_failure_is_non_blocking(self, mock_body) -> None:
+        mock_body.side_effect = RuntimeError("gh CLI failed")
+        plan_path, findings = validate_plan(1)
+        assert plan_path is None
+        assert findings == []
+
+    @patch("github_pr_state.get_pr_body")
+    def test_plan_path_stored_in_result(self, mock_body, tmp_path) -> None:
+        plan_dir = tmp_path / "plans" / "sessions"
+        plan_dir.mkdir(parents=True)
+        plan_file = plan_dir / "real.md"
+        plan_file.write_text(
+            "# Real Plan\n\n"
+            "## Plan\n"
+            "Detailed implementation plan with enough content "
+            "to pass the minimum content length check easily.\n"
+        )
+        mock_body.return_value = "## Plan\nplans/sessions/real.md\n\n## Summary\n"
+        plan_path, _ = validate_plan(1, repo_root=tmp_path)
+        assert plan_path == "plans/sessions/real.md"
+
+
+# ---------------------------------------------------------------------------
+# classify_review_mode tests (existing function, extended coverage)
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyReviewMode:
+    """Test review mode classification from changed files."""
+
+    def test_standard_mode(self) -> None:
+        from review_state import ReviewMode
+
+        mode = classify_review_mode(["src/bid_euchre/core/rules.py"])
+        assert mode == ReviewMode.STANDARD
+
+    def test_report_audit_mode(self) -> None:
+        from review_state import ReviewMode
+
+        mode = classify_review_mode(
+            ["docs/04_reports/r0/report.md", "src/bid_euchre/core/rules.py"]
+        )
+        assert mode == ReviewMode.REPORT_AUDIT
+
+    def test_plan_audit_mode(self) -> None:
+        from review_state import ReviewMode
+
+        mode = classify_review_mode(["plans/sessions/2026-03-14_test.md"])
+        assert mode == ReviewMode.PLAN_AUDIT
+
+    def test_report_takes_precedence_over_plan(self) -> None:
+        from review_state import ReviewMode
+
+        mode = classify_review_mode(
+            ["docs/04_reports/r0/report.md", "plans/sessions/test.md"]
+        )
+        assert mode == ReviewMode.REPORT_AUDIT


### PR DESCRIPTION
## Plan
plans/sessions/2026-03-14_plan-aware-autonomous-review.md

## Summary
- Extend `PRMetadata` with `body` field; add `get_pr_body()` and `get_pr_changed_files()` helpers
- Add `parse_plan_reference()` to extract plan paths from PR body (handles plain paths, backtick-quoted, markdown links, N/A opt-out)
- Add `validate_plan()` with three checks: reference present (PV1/P2), file exists (PV2/P1), content non-trivial (PV3/P2)
- Wire plan validation into `_step_pr_open()` before deterministic prechecks
- 38 new unit tests across two test files

## Why
The autonomous review loop currently has no awareness of the plan that authorized a PR. This is PR 1/3 in a series that adds plan-aware validation:
1. **(this PR)** PR metadata + plan parsing + validation
2. Scope-drift detection + blocker PR comments
3. Configurable Codex launcher + docs

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_github_pr_state.py tests/unit/test_review_driver.py -v
uv run python -m pytest tests/unit/test_review_state.py tests/unit/test_codex_review_adapter.py tests/unit/test_deterministic_prechecks.py -v
make check-quiet
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_github_pr_state.py` (13 tests)
- [x] `uv run python -m pytest tests/unit/test_review_driver.py` (12 tests)
- [x] `uv run python -m pytest tests/unit/test_review_state.py` (34 tests — no regressions)
- [x] `uv run python -m pytest tests/unit/test_codex_review_adapter.py` (30 tests — no regressions)
- [x] `uv run python -m pytest tests/unit/test_deterministic_prechecks.py` (38 tests — no regressions)
- [x] `make check-quiet` — all passed

## Expected impact
- Metrics impact: None (tooling only)
- Runtime impact: One additional `gh pr view` call in `_step_pr_open()` (~1s)

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-plan-aware-review
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-plan-aware-review
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                    4521545 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-plan-aware-review  a65bc35 [plan-aware-review]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)