### PR TITLE
feat: blind strategy comparison for Arc D evaluation

### DIFF
--- a/.claude/agents/blind-comparator.md
+++ b/.claude/agents/blind-comparator.md
@@ -1,0 +1,30 @@
+---
+name: blind-comparator
+description: Performs blind comparison of two anonymized strategy performance profiles. Use when evaluating which strategy to promote in the Arc D lineage.
+model: sonnet
+color: purple
+---
+
+You are a blind strategy evaluator. You will receive two anonymized performance
+profiles labeled "Strategy Alpha" and "Strategy Beta". You do NOT know which
+strategy is which.
+
+## Your Task
+1. Generate a comparison rubric with 3-5 criteria relevant to the data provided
+2. Score each strategy 1-5 on each criterion
+3. Determine which strategy is superior overall
+4. Explain your reasoning
+
+## Rules
+- Do NOT try to guess which strategy is which
+- Do NOT reference strategy names, model types, or implementation details
+- Focus ONLY on the performance numbers provided
+- Be specific about which metrics drive your conclusion
+- If the comparison is close, say so -- do not manufacture a clear winner
+
+## Output
+Provide your analysis as structured JSON with:
+- rubric: list of {criterion, weight, score_alpha, score_beta, reasoning}
+- winner: "Alpha" or "Beta" or "Tie"
+- confidence: "strong" (>1.0 weighted score gap), "moderate" (0.3-1.0), "weak" (<0.3)
+- summary: 2-3 sentence explanation

--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -71,6 +71,7 @@ Arc D v2 lineage scripts (orchestrator, reporting) are canonical execution tools
 that import typed schemas and paths from `bid_euchre.arc_d_v2`.
 
 - `audit_analysis.py` — Review pipeline audit (follow-up rates, corrective PRs, per-PR trail)
+- `blind_strategy_comparison.py` — Blind strategy comparison for Arc D evaluation (anonymize, rubric, unblind)
 - `evaluate_diagnostic_tricks.py` — Diagnostic Ridge evaluation
 - `evaluate_gate_x3.py` — R1.5 Gate X3 offline ranking evaluation (action-value model vs oracle)
 - `extract_comparator_cis.py` — Bootstrap CIs for comparator battery metrics
@@ -208,6 +209,7 @@ Every experiment run creates a standardized directory under `data/runs/<run_id>/
 |---------|---------|
 | `scripts/internal/analyze_phase1a_matrix.py` | Phase 1A 2×2 model×label matrix H2H analysis (effect decomposition) |
 | `scripts/internal/audit_analysis.py` | Review pipeline audit (follow-up rates, corrective PRs) |
+| `scripts/internal/blind_strategy_comparison.py` | Blind strategy comparison for Arc D evaluation (anonymize, rubric, unblind) |
 | `scripts/internal/claude_fix_adapter.py` | Deterministic fix application from Codex findings (auto-fix + commit) |
 | `scripts/internal/codex_review_adapter.py` | Codex CLI invocation and output parsing (review findings extraction) |
 | `scripts/internal/deterministic_prechecks.py` | Fast deterministic code checks (merge markers, RNG, imports) |

--- a/scripts/internal/blind_strategy_comparison.py
+++ b/scripts/internal/blind_strategy_comparison.py
@@ -1,0 +1,914 @@
+#!/usr/bin/env python
+"""Blind strategy comparison for Arc D evaluation.
+
+Anonymizes two strategy performance profiles, generates an independent
+rubric-based comparison, then unblinds to reveal identities.
+
+Usage:
+    uv run python scripts/internal/blind_strategy_comparison.py \
+        --profile-a data/runs/<run_a>/eval_metrics.json \
+        --profile-b data/runs/<run_b>/eval_metrics.json \
+        --seed 42 \
+        --output blind_comparison.json
+
+    uv run python scripts/internal/blind_strategy_comparison.py \
+        --profile-a data/runs/<run_a>/eval_metrics.json \
+        --profile-b data/runs/<run_b>/eval_metrics.json \
+        --seed 42 \
+        --format markdown
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import statistics
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+CONTRACT_TYPES = ("suit", "high", "low")
+
+# Rubric criteria with weights (pooled gets 2x)
+RUBRIC_CRITERIA = [
+    ("pooled_net_eppd", 2.0),
+    ("worst_contract_risk", 1.0),
+    ("cross_contract_consistency", 1.0),
+    ("statistical_significance", 1.0),
+    ("seed_stability", 1.0),
+]
+
+# Keys that are safe to keep in anonymized profiles (performance-only)
+_SAFE_METRIC_KEYS = frozenset(
+    {
+        "net_eppd",
+        "net_expected_points_per_deal",
+        "eppd",
+        "expected_points_per_deal",
+        "net_eppd_delta",
+        "ci_low",
+        "ci_high",
+        "win_rate",
+        "bid_rate",
+        "make_rate",
+        "cvar_5",
+        "net_cvar_5",
+        "downside_variance",
+        "net_downside_variance",
+        "pass_rate",
+        "deals_total",
+        "n_deals",
+        "hands_with_bids",
+        # Per-contract nested keys
+        "pooled",
+        "suit",
+        "high",
+        "low",
+        # Multi-seed keys
+        "seeds",
+        "seed_deltas",
+    }
+)
+
+# Keys that indicate identifying information and must be stripped
+_IDENTIFYING_KEYS = frozenset(
+    {
+        "strategy_id",
+        "strategy_name",
+        "model_type",
+        "model_path",
+        "artifact_path",
+        "feature_count",
+        "feature_names",
+        "training_rows",
+        "class_name",
+        "params",
+        "config",
+        "run_id",
+        "source_logs",
+        "provenance",
+        "git_sha",
+    }
+)
+
+
+@dataclass
+class RubricScore:
+    """A single criterion score in the blind comparison rubric."""
+
+    criterion: str
+    weight: float
+    score_alpha: int  # 1-5
+    score_beta: int  # 1-5
+    reasoning: str
+
+
+@dataclass
+class BlindComparisonResult:
+    """Full result of a blind strategy comparison."""
+
+    seed: int
+    label_assignment: dict  # {"Alpha": "real_name_a", "Beta": "real_name_b"}
+    rubric: list[RubricScore] = field(default_factory=list)
+    alpha_total: float = 0.0
+    beta_total: float = 0.0
+    winner: str = "Tie"  # "Alpha" or "Beta" or "Tie"
+    winner_real_name: str = ""
+    confidence: str = "weak"  # "strong", "moderate", "weak"
+    summary: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Profile loading and anonymization
+# ---------------------------------------------------------------------------
+
+
+def load_profile(path: str | Path) -> dict:
+    """Load an eval metrics JSON profile.
+
+    Handles three formats:
+    1. Full evaluator output: {"strategies": [{...metrics...}]}
+    2. Nested: {"metrics": {...}}
+    3. Flat: top-level metrics dict
+
+    Args:
+        path: Path to eval metrics JSON file.
+
+    Returns:
+        Dict of metric name -> value.
+
+    Raises:
+        FileNotFoundError: If the file doesn't exist.
+        json.JSONDecodeError: If the file is invalid JSON.
+    """
+    with open(path) as f:
+        data = json.load(f)
+
+    if "strategies" in data and isinstance(data["strategies"], list):
+        return data["strategies"][0] if data["strategies"] else {}
+    if "metrics" in data:
+        return data["metrics"]
+    return data
+
+
+def _extract_strategy_name(profile: dict) -> str:
+    """Extract a human-readable strategy name from a profile.
+
+    Checks common keys where the name might be stored.
+
+    Args:
+        profile: Raw eval metrics dict.
+
+    Returns:
+        Strategy name string, or "unknown" if not found.
+    """
+    for key in ("strategy_id", "strategy_name", "name"):
+        val = profile.get(key)
+        if isinstance(val, str) and val:
+            return val
+    return "unknown"
+
+
+def anonymize_profile(profile: dict) -> dict:
+    """Strip all identifying information from a profile.
+
+    Keeps only performance metrics: net_eppd, CIs, p-values, H2H deltas,
+    win rates, and per-contract breakdowns. Removes strategy names, model
+    types, feature counts, file paths, and training details.
+
+    Args:
+        profile: Raw eval metrics dict.
+
+    Returns:
+        New dict with only safe metric keys.
+    """
+    result = {}
+    for key, value in profile.items():
+        if key in _IDENTIFYING_KEYS:
+            continue
+        if isinstance(value, dict):
+            # Recurse into nested dicts (e.g., per-contract metrics)
+            cleaned = anonymize_profile(value)
+            if cleaned:
+                result[key] = cleaned
+        elif isinstance(value, list) and value and isinstance(value[0], dict):
+            # List of dicts (e.g., per-seed results)
+            result[key] = [anonymize_profile(item) for item in value]
+        else:
+            result[key] = value
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Metric extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_metric(profile: dict, key: str, default: float = 0.0) -> float:
+    """Safely extract a float metric, handling aliases.
+
+    Args:
+        profile: Metrics dict.
+        key: Metric key.
+        default: Fallback value.
+
+    Returns:
+        Float metric value.
+    """
+    # Try direct key first
+    val = profile.get(key)
+    if val is not None:
+        try:
+            return float(val)
+        except (TypeError, ValueError):
+            pass
+
+    # Try common aliases
+    aliases = {
+        "net_eppd": "net_expected_points_per_deal",
+        "net_expected_points_per_deal": "net_eppd",
+    }
+    alias = aliases.get(key)
+    if alias:
+        val = profile.get(alias)
+        if val is not None:
+            try:
+                return float(val)
+            except (TypeError, ValueError):
+                pass
+
+    return default
+
+
+def _get_per_contract_eppd(profile: dict) -> dict[str, float]:
+    """Extract per-contract net_eppd values from a profile.
+
+    Looks for contract-type keys at top level or in nested structures.
+
+    Args:
+        profile: Metrics dict.
+
+    Returns:
+        Dict mapping contract type ("suit", "high", "low") to net_eppd.
+    """
+    result = {}
+    for ct in CONTRACT_TYPES:
+        # Try nested dict
+        ct_data = profile.get(ct)
+        if isinstance(ct_data, dict):
+            val = _get_metric(ct_data, "net_eppd")
+            result[ct] = val
+        else:
+            # Try flat key pattern: net_eppd_suit, net_eppd_high, etc.
+            val = profile.get(f"net_eppd_{ct}")
+            if val is not None:
+                try:
+                    result[ct] = float(val)
+                except (TypeError, ValueError):
+                    pass
+    return result
+
+
+def _get_seed_deltas(profile: dict) -> list[float]:
+    """Extract per-seed delta values if multi-seed data is present.
+
+    Args:
+        profile: Metrics dict.
+
+    Returns:
+        List of per-seed delta floats, or empty list if not available.
+    """
+    # Try explicit seed_deltas key
+    deltas = profile.get("seed_deltas")
+    if isinstance(deltas, list):
+        return [float(d) for d in deltas if d is not None]
+
+    # Try seeds list
+    seeds = profile.get("seeds")
+    if isinstance(seeds, list):
+        return [
+            float(s.get("net_eppd_delta", s.get("net_eppd", 0.0)))
+            for s in seeds
+            if isinstance(s, dict)
+        ]
+
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Rubric scoring
+# ---------------------------------------------------------------------------
+
+
+def _score_pooled_net_eppd(alpha: dict, beta: dict) -> tuple[int, int, str]:
+    """Score criterion 1: pooled net_eppd delta.
+
+    Higher pooled net_eppd is better. Score 1-5 based on relative position.
+
+    Args:
+        alpha: Anonymous profile for Strategy Alpha.
+        beta: Anonymous profile for Strategy Beta.
+
+    Returns:
+        (score_alpha, score_beta, reasoning)
+    """
+    a_val = _get_metric(alpha, "net_eppd")
+    b_val = _get_metric(beta, "net_eppd")
+    delta = a_val - b_val
+
+    # Score based on magnitude of difference
+    if abs(delta) < 0.01:
+        return (
+            3,
+            3,
+            f"Pooled net_eppd nearly identical (Alpha={a_val:.3f}, Beta={b_val:.3f}, delta={delta:+.3f})",
+        )
+
+    if delta > 0:
+        # Alpha better
+        if abs(delta) > 0.5:
+            return (
+                5,
+                1,
+                f"Alpha strongly superior in pooled net_eppd ({a_val:.3f} vs {b_val:.3f}, delta={delta:+.3f})",
+            )
+        if abs(delta) > 0.2:
+            return (
+                4,
+                2,
+                f"Alpha moderately better in pooled net_eppd ({a_val:.3f} vs {b_val:.3f}, delta={delta:+.3f})",
+            )
+        return (
+            4,
+            3,
+            f"Alpha slightly better in pooled net_eppd ({a_val:.3f} vs {b_val:.3f}, delta={delta:+.3f})",
+        )
+    else:
+        # Beta better
+        if abs(delta) > 0.5:
+            return (
+                1,
+                5,
+                f"Beta strongly superior in pooled net_eppd ({b_val:.3f} vs {a_val:.3f}, delta={delta:+.3f})",
+            )
+        if abs(delta) > 0.2:
+            return (
+                2,
+                4,
+                f"Beta moderately better in pooled net_eppd ({b_val:.3f} vs {a_val:.3f}, delta={delta:+.3f})",
+            )
+        return (
+            3,
+            4,
+            f"Beta slightly better in pooled net_eppd ({b_val:.3f} vs {a_val:.3f}, delta={delta:+.3f})",
+        )
+
+
+def _score_worst_contract_risk(alpha: dict, beta: dict) -> tuple[int, int, str]:
+    """Score criterion 2: worst-contract risk.
+
+    Which strategy has the least-negative worst contract? Lower downside is better.
+
+    Args:
+        alpha: Anonymous profile for Strategy Alpha.
+        beta: Anonymous profile for Strategy Beta.
+
+    Returns:
+        (score_alpha, score_beta, reasoning)
+    """
+    a_contracts = _get_per_contract_eppd(alpha)
+    b_contracts = _get_per_contract_eppd(beta)
+
+    if not a_contracts and not b_contracts:
+        return (3, 3, "No per-contract data available for either strategy")
+
+    # Use 0.0 as default if one strategy has no per-contract data
+    a_worst = min(a_contracts.values()) if a_contracts else 0.0
+    b_worst = min(b_contracts.values()) if b_contracts else 0.0
+
+    a_worst_ct = min(a_contracts, key=a_contracts.get) if a_contracts else "N/A"
+    b_worst_ct = min(b_contracts, key=b_contracts.get) if b_contracts else "N/A"
+
+    delta = a_worst - b_worst
+
+    if abs(delta) < 0.01:
+        return (
+            3,
+            3,
+            f"Similar worst-contract performance "
+            f"(Alpha worst={a_worst:.3f} [{a_worst_ct}], "
+            f"Beta worst={b_worst:.3f} [{b_worst_ct}])",
+        )
+
+    if delta > 0:
+        # Alpha's worst is less negative -> better
+        severity = 5 if delta > 0.3 else 4
+        return (
+            severity,
+            6 - severity,
+            f"Alpha has less downside risk in worst contract "
+            f"(Alpha worst={a_worst:.3f} [{a_worst_ct}], "
+            f"Beta worst={b_worst:.3f} [{b_worst_ct}])",
+        )
+    else:
+        severity = 5 if abs(delta) > 0.3 else 4
+        return (
+            6 - severity,
+            severity,
+            f"Beta has less downside risk in worst contract "
+            f"(Beta worst={b_worst:.3f} [{b_worst_ct}], "
+            f"Alpha worst={a_worst:.3f} [{a_worst_ct}])",
+        )
+
+
+def _score_cross_contract_consistency(alpha: dict, beta: dict) -> tuple[int, int, str]:
+    """Score criterion 3: consistency across contracts.
+
+    Lower variance in per-contract deltas indicates more consistent improvement.
+
+    Args:
+        alpha: Anonymous profile for Strategy Alpha.
+        beta: Anonymous profile for Strategy Beta.
+
+    Returns:
+        (score_alpha, score_beta, reasoning)
+    """
+    a_contracts = _get_per_contract_eppd(alpha)
+    b_contracts = _get_per_contract_eppd(beta)
+
+    if len(a_contracts) < 2 and len(b_contracts) < 2:
+        return (3, 3, "Insufficient per-contract data for consistency comparison")
+
+    # Compute standard deviation of per-contract values
+    a_vals = list(a_contracts.values()) if len(a_contracts) >= 2 else []
+    b_vals = list(b_contracts.values()) if len(b_contracts) >= 2 else []
+
+    a_std = statistics.stdev(a_vals) if len(a_vals) >= 2 else float("inf")
+    b_std = statistics.stdev(b_vals) if len(b_vals) >= 2 else float("inf")
+
+    if a_std == float("inf") and b_std == float("inf"):
+        return (3, 3, "Neither strategy has enough per-contract data")
+
+    # Count contracts with positive net_eppd
+    a_positive = sum(1 for v in a_vals if v > 0) if a_vals else 0
+    b_positive = sum(1 for v in b_vals if v > 0) if b_vals else 0
+
+    delta_std = a_std - b_std
+
+    if abs(delta_std) < 0.05:
+        return (
+            3,
+            3,
+            f"Similar cross-contract consistency "
+            f"(Alpha std={a_std:.3f}, {a_positive}/{len(a_vals)} positive; "
+            f"Beta std={b_std:.3f}, {b_positive}/{len(b_vals)} positive)",
+        )
+
+    if delta_std < 0:
+        # Alpha has lower std -> more consistent
+        score = 4 if abs(delta_std) < 0.2 else 5
+        return (
+            score,
+            6 - score,
+            f"Alpha more consistent across contracts "
+            f"(Alpha std={a_std:.3f}, {a_positive}/{len(a_vals)} positive; "
+            f"Beta std={b_std:.3f}, {b_positive}/{len(b_vals)} positive)",
+        )
+    else:
+        score = 4 if abs(delta_std) < 0.2 else 5
+        return (
+            6 - score,
+            score,
+            f"Beta more consistent across contracts "
+            f"(Beta std={b_std:.3f}, {b_positive}/{len(b_vals)} positive; "
+            f"Alpha std={a_std:.3f}, {a_positive}/{len(a_vals)} positive)",
+        )
+
+
+def _score_statistical_significance(alpha: dict, beta: dict) -> tuple[int, int, str]:
+    """Score criterion 4: statistical significance.
+
+    Does the CI exclude zero? Wider margin from zero -> higher confidence.
+
+    Args:
+        alpha: Anonymous profile for Strategy Alpha.
+        beta: Anonymous profile for Strategy Beta.
+
+    Returns:
+        (score_alpha, score_beta, reasoning)
+    """
+    ci_low = alpha.get("ci_low")
+    ci_high = alpha.get("ci_high")
+
+    # Also check for CIs at profile level (from H2H data)
+    if ci_low is None:
+        ci_low = beta.get("ci_low")
+    if ci_high is None:
+        ci_high = beta.get("ci_high")
+
+    if ci_low is None or ci_high is None:
+        return (3, 3, "No confidence interval data available")
+
+    try:
+        ci_low = float(ci_low)
+        ci_high = float(ci_high)
+    except (TypeError, ValueError):
+        return (3, 3, "CI values not numeric")
+
+    if ci_low > 0:
+        # CI entirely above 0 -> Alpha significantly better
+        margin = ci_low
+        if margin > 0.1:
+            return (
+                5,
+                1,
+                f"CI strongly favors Alpha: [{ci_low:.3f}, {ci_high:.3f}], CI_low > 0.1",
+            )
+        return (
+            4,
+            2,
+            f"CI favors Alpha: [{ci_low:.3f}, {ci_high:.3f}], CI excludes zero",
+        )
+    elif ci_high < 0:
+        # CI entirely below 0 -> Beta significantly better
+        margin = abs(ci_high)
+        if margin > 0.1:
+            return (
+                1,
+                5,
+                f"CI strongly favors Beta: [{ci_low:.3f}, {ci_high:.3f}], CI_high < -0.1",
+            )
+        return (
+            2,
+            4,
+            f"CI favors Beta: [{ci_low:.3f}, {ci_high:.3f}], CI excludes zero",
+        )
+    else:
+        # CI spans zero -> not significant
+        return (
+            3,
+            3,
+            f"CI spans zero: [{ci_low:.3f}, {ci_high:.3f}], result not statistically significant",
+        )
+
+
+def _score_seed_stability(alpha: dict, beta: dict) -> tuple[int, int, str]:
+    """Score criterion 5: seed stability.
+
+    If multi-seed data is available, check for consistency across seeds.
+
+    Args:
+        alpha: Anonymous profile for Strategy Alpha.
+        beta: Anonymous profile for Strategy Beta.
+
+    Returns:
+        (score_alpha, score_beta, reasoning)
+    """
+    a_deltas = _get_seed_deltas(alpha)
+    b_deltas = _get_seed_deltas(beta)
+
+    if not a_deltas and not b_deltas:
+        return (3, 3, "No multi-seed data available for either strategy")
+
+    # Check which strategy has more consistent seed results
+    a_consistent = True
+    b_consistent = True
+
+    if a_deltas:
+        a_all_positive = all(d > 0 for d in a_deltas)
+        a_all_negative = all(d < 0 for d in a_deltas)
+        a_consistent = a_all_positive or a_all_negative
+        a_std = statistics.stdev(a_deltas) if len(a_deltas) >= 2 else 0.0
+    else:
+        a_std = float("inf")
+
+    if b_deltas:
+        b_all_positive = all(d > 0 for d in b_deltas)
+        b_all_negative = all(d < 0 for d in b_deltas)
+        b_consistent = b_all_positive or b_all_negative
+        b_std = statistics.stdev(b_deltas) if len(b_deltas) >= 2 else 0.0
+    else:
+        b_std = float("inf")
+
+    # Score based on sign consistency and variance
+    if a_consistent and not b_consistent:
+        return (
+            4,
+            2,
+            f"Alpha has consistent sign across seeds "
+            f"(Alpha deltas={[f'{d:.3f}' for d in a_deltas]}, "
+            f"Beta deltas={[f'{d:.3f}' for d in b_deltas]})",
+        )
+    if b_consistent and not a_consistent:
+        return (
+            2,
+            4,
+            f"Beta has consistent sign across seeds "
+            f"(Beta deltas={[f'{d:.3f}' for d in b_deltas]}, "
+            f"Alpha deltas={[f'{d:.3f}' for d in a_deltas]})",
+        )
+
+    # Both consistent or both inconsistent; compare variance
+    if a_std == float("inf") and b_std == float("inf"):
+        return (3, 3, "Insufficient multi-seed data for comparison")
+
+    if abs(a_std - b_std) < 0.02:
+        return (
+            3,
+            3,
+            f"Similar seed stability (Alpha std={a_std:.3f}, Beta std={b_std:.3f})",
+        )
+
+    if a_std < b_std:
+        return (
+            4,
+            2,
+            f"Alpha more stable across seeds "
+            f"(Alpha std={a_std:.3f}, Beta std={b_std:.3f})",
+        )
+    return (
+        2,
+        4,
+        f"Beta more stable across seeds (Beta std={b_std:.3f}, Alpha std={a_std:.3f})",
+    )
+
+
+# Scoring function registry (criterion_name -> scoring function)
+_SCORING_FUNCTIONS = {
+    "pooled_net_eppd": _score_pooled_net_eppd,
+    "worst_contract_risk": _score_worst_contract_risk,
+    "cross_contract_consistency": _score_cross_contract_consistency,
+    "statistical_significance": _score_statistical_significance,
+    "seed_stability": _score_seed_stability,
+}
+
+
+# ---------------------------------------------------------------------------
+# Core comparison logic
+# ---------------------------------------------------------------------------
+
+
+def compare_blind(
+    profile_a: dict,
+    profile_b: dict,
+    seed: int,
+) -> BlindComparisonResult:
+    """Run blind comparison between two strategy profiles.
+
+    Randomly assigns anonymous labels, strips identifying info, scores
+    on a 5-criterion rubric, and determines a winner.
+
+    Args:
+        profile_a: Eval metrics dict for strategy A.
+        profile_b: Eval metrics dict for strategy B.
+        seed: Random seed for label assignment.
+
+    Returns:
+        BlindComparisonResult with rubric, scores, and winner.
+    """
+    # Extract real names before anonymizing
+    name_a = _extract_strategy_name(profile_a)
+    name_b = _extract_strategy_name(profile_b)
+
+    # Anonymize profiles
+    anon_a = anonymize_profile(profile_a)
+    anon_b = anonymize_profile(profile_b)
+
+    # Randomly assign labels using seeded RNG
+    rng = random.Random(seed)
+    swap = rng.choice([True, False])
+
+    if swap:
+        alpha_profile, beta_profile = anon_b, anon_a
+        alpha_name, beta_name = name_b, name_a
+    else:
+        alpha_profile, beta_profile = anon_a, anon_b
+        alpha_name, beta_name = name_a, name_b
+
+    label_assignment = {"Alpha": alpha_name, "Beta": beta_name}
+
+    # Score each criterion
+    rubric = []
+    for criterion_name, weight in RUBRIC_CRITERIA:
+        scoring_fn = _SCORING_FUNCTIONS[criterion_name]
+        score_a, score_b, reasoning = scoring_fn(alpha_profile, beta_profile)
+
+        # Clamp scores to valid range
+        score_a = max(1, min(5, score_a))
+        score_b = max(1, min(5, score_b))
+
+        rubric.append(
+            RubricScore(
+                criterion=criterion_name,
+                weight=weight,
+                score_alpha=score_a,
+                score_beta=score_b,
+                reasoning=reasoning,
+            )
+        )
+
+    # Compute weighted totals
+    total_weight = sum(r.weight for r in rubric)
+    alpha_total = sum(r.score_alpha * r.weight for r in rubric) / total_weight
+    beta_total = sum(r.score_beta * r.weight for r in rubric) / total_weight
+
+    # Determine winner
+    gap = alpha_total - beta_total
+    if abs(gap) < 0.1:
+        winner = "Tie"
+        winner_real_name = ""
+        confidence = "weak"
+    elif gap > 0:
+        winner = "Alpha"
+        winner_real_name = label_assignment["Alpha"]
+        if abs(gap) > 1.0:
+            confidence = "strong"
+        elif abs(gap) > 0.3:
+            confidence = "moderate"
+        else:
+            confidence = "weak"
+    else:
+        winner = "Beta"
+        winner_real_name = label_assignment["Beta"]
+        if abs(gap) > 1.0:
+            confidence = "strong"
+        elif abs(gap) > 0.3:
+            confidence = "moderate"
+        else:
+            confidence = "weak"
+
+    # Generate summary
+    if winner == "Tie":
+        summary = (
+            f"Strategies are statistically indistinguishable "
+            f"(Alpha={alpha_total:.2f}, Beta={beta_total:.2f}, "
+            f"gap={abs(gap):.2f})."
+        )
+    else:
+        summary = (
+            f"Strategy {winner} ({winner_real_name}) is the {confidence} "
+            f"winner with a weighted score of "
+            f"{alpha_total:.2f} vs {beta_total:.2f} (gap={abs(gap):.2f})."
+        )
+
+    return BlindComparisonResult(
+        seed=seed,
+        label_assignment=label_assignment,
+        rubric=rubric,
+        alpha_total=round(alpha_total, 4),
+        beta_total=round(beta_total, 4),
+        winner=winner,
+        winner_real_name=winner_real_name,
+        confidence=confidence,
+        summary=summary,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def result_to_dict(result: BlindComparisonResult) -> dict:
+    """Convert BlindComparisonResult to a JSON-serializable dict.
+
+    Args:
+        result: Comparison result.
+
+    Returns:
+        JSON-serializable dict.
+    """
+    d = asdict(result)
+    d["generated_at"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    d["schema"] = "blind_comparison_v1"
+    return d
+
+
+def result_to_markdown(result: BlindComparisonResult) -> str:
+    """Convert BlindComparisonResult to a markdown report.
+
+    Args:
+        result: Comparison result.
+
+    Returns:
+        Markdown string.
+    """
+    lines = [
+        "# Blind Strategy Comparison",
+        "",
+        f"**Seed:** {result.seed}",
+        f"**Winner:** {result.winner}",
+        f"**Confidence:** {result.confidence}",
+        "",
+        "## Rubric Scores",
+        "",
+        "| Criterion | Weight | Alpha | Beta | Reasoning |",
+        "|-----------|--------|-------|------|-----------|",
+    ]
+
+    for r in result.rubric:
+        lines.append(
+            f"| {r.criterion} | {r.weight:.1f} | {r.score_alpha} | "
+            f"{r.score_beta} | {r.reasoning} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            f"**Alpha weighted total:** {result.alpha_total:.2f}",
+            f"**Beta weighted total:** {result.beta_total:.2f}",
+            "",
+            "## Unblinding",
+            "",
+            f"- **Alpha** = {result.label_assignment.get('Alpha', 'unknown')}",
+            f"- **Beta** = {result.label_assignment.get('Beta', 'unknown')}",
+            "",
+            "## Summary",
+            "",
+            result.summary,
+            "",
+        ]
+    )
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """CLI entry point for blind strategy comparison."""
+    parser = argparse.ArgumentParser(
+        description="Blind strategy comparison for Arc D evaluation"
+    )
+    parser.add_argument(
+        "--profile-a",
+        required=True,
+        help="Path to eval metrics JSON for first strategy",
+    )
+    parser.add_argument(
+        "--profile-b",
+        required=True,
+        help="Path to eval metrics JSON for second strategy",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        required=True,
+        help="Random seed for label assignment",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output path for comparison result (default: stdout)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["json", "markdown"],
+        default="json",
+        help="Output format: json or markdown (default: json)",
+    )
+    args = parser.parse_args()
+
+    # Load profiles
+    try:
+        profile_a = load_profile(args.profile_a)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        print(f"ERROR: Failed to load profile A: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        profile_b = load_profile(args.profile_b)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        print(f"ERROR: Failed to load profile B: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Run blind comparison
+    result = compare_blind(profile_a, profile_b, seed=args.seed)
+
+    # Format output
+    if args.format == "markdown":
+        output = result_to_markdown(result)
+    else:
+        output = json.dumps(result_to_dict(result), indent=2) + "\n"
+
+    # Write output
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(output)
+        print(f"Written to: {output_path}", file=sys.stderr)
+    else:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_blind_comparison.py
+++ b/tests/unit/test_blind_comparison.py
@@ -1,0 +1,523 @@
+"""Unit tests for blind strategy comparison tool.
+
+Tests import the script functions via importlib.util (same pattern as
+test_h2h_battery.py) since scripts/internal/ has no __init__.py.
+"""
+
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import script module via importlib.util
+# ---------------------------------------------------------------------------
+
+_SCRIPT_PATH = (
+    Path(__file__).parent.parent.parent
+    / "scripts"
+    / "internal"
+    / "blind_strategy_comparison.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "blind_strategy_comparison", _SCRIPT_PATH
+)
+_mod = importlib.util.module_from_spec(_spec)
+# Register in sys.modules so dataclass decorator can resolve the module
+sys.modules[_spec.name] = _mod
+_spec.loader.exec_module(_mod)
+
+compare_blind = _mod.compare_blind
+load_profile = _mod.load_profile
+anonymize_profile = _mod.anonymize_profile
+result_to_dict = _mod.result_to_dict
+result_to_markdown = _mod.result_to_markdown
+BlindComparisonResult = _mod.BlindComparisonResult
+RubricScore = _mod.RubricScore
+_extract_strategy_name = _mod._extract_strategy_name
+_get_per_contract_eppd = _mod._get_per_contract_eppd
+_get_seed_deltas = _mod._get_seed_deltas
+
+# ---------------------------------------------------------------------------
+# Realistic test profiles based on R1.5.3 GBT vs Hybrid R0 results
+# (pooled +0.570, suit +0.827, high +0.333, low -0.041)
+# ---------------------------------------------------------------------------
+
+GBT_PROFILE = {
+    "strategy_id": "gbt_av_bidder_r1_5_3",
+    "strategy_name": "GBT Action-Value Bidder",
+    "model_type": "gradient_boosted_trees",
+    "artifact_path": "data/artifacts/arc_d/r1_5_3/gbt_av.json",
+    "feature_count": 42,
+    "net_expected_points_per_deal": 0.570,
+    "net_eppd": 0.570,
+    "expected_points_per_deal": 4.85,
+    "bid_rate": 0.45,
+    "make_rate": 0.72,
+    "pass_rate": 0.55,
+    "cvar_5": -3.2,
+    "net_cvar_5": -5.1,
+    "downside_variance": 12.5,
+    "net_downside_variance": 18.3,
+    "deals_total": 50000,
+    "ci_low": 0.50,
+    "ci_high": 0.64,
+    "suit": {"net_eppd": 0.827, "bid_rate": 0.35, "make_rate": 0.75},
+    "high": {"net_eppd": 0.333, "bid_rate": 0.30, "make_rate": 0.68},
+    "low": {"net_eppd": -0.041, "bid_rate": 0.15, "make_rate": 0.62},
+    "seed_deltas": [0.595, 0.557, 0.558],
+}
+
+HYBRID_R0_PROFILE = {
+    "strategy_id": "hybrid_olsa_r0",
+    "strategy_name": "Hybrid OLSa R0",
+    "model_type": "hybrid_olsa_v1",
+    "artifact_path": "data/artifacts/arc_d/r0/hybrid_r0.json",
+    "feature_count": 39,
+    "net_expected_points_per_deal": 0.0,
+    "net_eppd": 0.0,
+    "expected_points_per_deal": 4.28,
+    "bid_rate": 0.42,
+    "make_rate": 0.65,
+    "pass_rate": 0.58,
+    "cvar_5": -3.8,
+    "net_cvar_5": -5.9,
+    "downside_variance": 14.1,
+    "net_downside_variance": 20.7,
+    "deals_total": 50000,
+    "ci_low": -0.07,
+    "ci_high": 0.07,
+    "suit": {"net_eppd": 0.0, "bid_rate": 0.32, "make_rate": 0.68},
+    "high": {"net_eppd": 0.0, "bid_rate": 0.28, "make_rate": 0.60},
+    "low": {"net_eppd": 0.0, "bid_rate": 0.14, "make_rate": 0.58},
+    "seed_deltas": [0.0, 0.0, 0.0],
+}
+
+# Profiles that are nearly identical (for tie detection)
+CLOSE_PROFILE_A = {
+    "strategy_id": "strategy_a",
+    "net_eppd": 1.005,
+    "suit": {"net_eppd": 1.2},
+    "high": {"net_eppd": 0.8},
+    "low": {"net_eppd": 0.5},
+}
+
+CLOSE_PROFILE_B = {
+    "strategy_id": "strategy_b",
+    "net_eppd": 1.000,
+    "suit": {"net_eppd": 1.2},
+    "high": {"net_eppd": 0.8},
+    "low": {"net_eppd": 0.5},
+}
+
+
+# ---------------------------------------------------------------------------
+# Tests: Label randomization
+# ---------------------------------------------------------------------------
+
+
+class TestLabelRandomization:
+    def test_deterministic_with_same_seed(self):
+        """Same seed produces same label assignment."""
+        r1 = compare_blind(GBT_PROFILE, HYBRID_R0_PROFILE, seed=42)
+        r2 = compare_blind(GBT_PROFILE, HYBRID_R0_PROFILE, seed=42)
+        assert r1.label_assignment == r2.label_assignment
+        assert r1.winner == r2.winner
+        assert r1.alpha_total == r2.alpha_total
+        assert r1.beta_total == r2.beta_total
+
+    def test_different_seeds_can_differ(self):
+        """Different seeds can produce different label assignments.
+
+        We check a range of seeds to find at least one that swaps.
+        """
+        base = compare_blind(GBT_PROFILE, HYBRID_R0_PROFILE, seed=42)
+        found_different = False
+        for s in range(100):
+            other = compare_blind(GBT_PROFILE, HYBRID_R0_PROFILE, seed=s)
+            if other.label_assignment != base.label_assignment:
+                found_different = True
+                break
+        assert (
+            found_different
+        ), "Expected at least one seed to produce a different assignment"
+
+    def test_label_keys(self):
+        """Label assignment has exactly Alpha and Beta keys."""
+        result = compare_blind(GBT_PROFILE, HYBRID_R0_PROFILE, seed=42)
+        assert set(result.label_assignment.keys()) == {"Alpha", "Beta"}
+
+    def test_label_values_are_real_names(self):
+        """Label assignment values are the original strategy names."""
+        result = compare_blind(GBT_PROFILE, HYBRID_R0_PROFILE, seed=42)
+        names = set(result.label_assignment.values())
+        assert names == {"gbt_av_bidder_r1_5_3", "hybrid_olsa_r0"}
+
+
+# ---------------------------------------------------------------------------
+# Tests: Anonymization
+# ---------------------------------------------------------------------------
+
+
+class TestAnonymization:
+    def test_no_strategy_names_leak(self):
+        """Anonymized profile must not contain identifying keys."""
+        anon = anonymize_profile(GBT_PROFILE)
+        for key in (
+            "strategy_id",
+            "strategy_name",
+            "model_type",
+            "artifact_path",
+            "feature_count",
+        ):
+            assert (
+                key not in anon
+            ), f"Identifying key '{key}' leaked into anonymized profile"
+
+    def test_performance_metrics_preserved(self):
+        """Anonymized profile preserves performance metrics."""
+        anon = anonymize_profile(GBT_PROFILE)
+        assert anon["net_eppd"] == 0.570
+        assert anon["bid_rate"] == 0.45
+        assert anon["make_rate"] == 0.72
+
+    def test_nested_contract_data_preserved(self):
+        """Anonymized profile preserves per-contract data."""
+        anon = anonymize_profile(GBT_PROFILE)
+        assert "suit" in anon
+        assert anon["suit"]["net_eppd"] == 0.827
+        assert anon["high"]["net_eppd"] == 0.333
+        assert anon["low"]["net_eppd"] == -0.041
+
+    def test_seed_deltas_preserved(self):
+        """Anonymized profile preserves multi-seed data."""
+        anon = anonymize_profile(GBT_PROFILE)
+        assert anon["seed_deltas"] == [0.595, 0.557, 0.558]
+
+    def test_empty_profile(self):
+        """Anonymizing empty profile returns empty dict."""
+        assert anonymize_profile({}) == {}
+
+
+# ---------------------------------------------------------------------------
+# Tests: Rubric scoring
+# ---------------------------------------------------------------------------
+
+
+class TestRubricScoring:
+    def test_scores_in_range(self):
+        """All rubric scores must be between 1 and 5."""
+        result = compare_blind(GBT_PROFILE, HYBRID_R0_PROFILE, seed=42)
+        for r in result.rubric:
+            assert (
+                1 <= r.score_alpha <= 5
+            ), f"{r.criterion}: Alpha score {r.score_alpha} out of range"
+            assert (
+                1 <= r.score_beta <= 5
+            ), f"{r.criterion}: Beta score {r.score_beta} out of range"
+
+    def test_five_criteria(self):
+        """Rubric has exactly 5 criteria."""
+        result = compare_blind(GBT_PROFILE, HYBRID_R0_PROFILE, seed=42)
+        assert len(result.rubric) == 5
+
+    def test_criteria_names(self):
+        """Rubric criteria match expected names."""
+        result = compare_blind(GBT_PROFILE, HYBRID_R0_PROFILE, seed=42)
+        names = {r.criterion for r in result.rubric}
+        expected = {
+            "pooled_net_eppd",
+            "worst_contract_risk",
+            "cross_contract_consistency",
+            "statistical_significance",
+            "seed_stability",
+        }
+        assert names == expected
+
+    def test_weights_include_pooled_2x(self):
+        """Pooled net_eppd criterion has 2x weight."""
+        result = compare_blind(GBT_PROFILE, HYBRID_R0_PROFILE, seed=42)
+        pooled = [r for r in result.rubric if r.criterion == "pooled_net_eppd"][0]
+        assert pooled.weight == 2.0
+        for r in result.rubric:
+            if r.criterion != "pooled_net_eppd":
+                assert r.weight == 1.0
+
+    def test_reasoning_not_empty(self):
+        """Each rubric criterion has non-empty reasoning."""
+        result = compare_blind(GBT_PROFILE, HYBRID_R0_PROFILE, seed=42)
+        for r in result.rubric:
+            assert r.reasoning, f"{r.criterion}: reasoning is empty"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Winner determination
+# ---------------------------------------------------------------------------
+
+
+class TestWinnerDetermination:
+    def test_clear_winner_gbt_vs_r0(self):
+        """GBT with pooled +0.570 should win over R0 baseline."""
+        result = compare_blind(GBT_PROFILE, HYBRID_R0_PROFILE, seed=42)
+        # The winner label is "Alpha" or "Beta", but the real name should be GBT
+        assert result.winner_real_name == "gbt_av_bidder_r1_5_3"
+        assert result.winner in ("Alpha", "Beta")
+
+    def test_tie_detection_close_profiles(self):
+        """Strategies within 0.01 net_eppd delta should produce Tie or weak confidence."""
+        result = compare_blind(CLOSE_PROFILE_A, CLOSE_PROFILE_B, seed=42)
+        # With only 0.005 net_eppd gap and identical per-contract data,
+        # this should be a tie or very weak result
+        assert result.confidence == "weak" or result.winner == "Tie"
+
+    def test_confidence_levels(self):
+        """Confidence is one of strong, moderate, weak."""
+        result = compare_blind(GBT_PROFILE, HYBRID_R0_PROFILE, seed=42)
+        assert result.confidence in ("strong", "moderate", "weak")
+
+    def test_winner_matches_higher_total(self):
+        """Winner should be the strategy with the higher weighted total."""
+        result = compare_blind(GBT_PROFILE, HYBRID_R0_PROFILE, seed=42)
+        if result.winner == "Alpha":
+            assert result.alpha_total >= result.beta_total
+        elif result.winner == "Beta":
+            assert result.beta_total >= result.alpha_total
+        else:
+            # Tie
+            assert abs(result.alpha_total - result.beta_total) < 0.1
+
+
+# ---------------------------------------------------------------------------
+# Tests: Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_missing_contract_types(self):
+        """Profiles without per-contract data should not crash."""
+        profile_no_contracts = {
+            "strategy_id": "minimal",
+            "net_eppd": 0.3,
+            "bid_rate": 0.4,
+        }
+        result = compare_blind(profile_no_contracts, HYBRID_R0_PROFILE, seed=42)
+        assert result.winner in ("Alpha", "Beta", "Tie")
+        assert len(result.rubric) == 5
+
+    def test_single_seed_data(self):
+        """Profiles with no multi-seed data should still score seed_stability."""
+        profile_no_seeds = {
+            "strategy_id": "no_seeds",
+            "net_eppd": 0.5,
+        }
+        result = compare_blind(profile_no_seeds, HYBRID_R0_PROFILE, seed=42)
+        seed_criterion = [r for r in result.rubric if r.criterion == "seed_stability"][
+            0
+        ]
+        # Should get neutral score when data is absent on one side
+        assert 1 <= seed_criterion.score_alpha <= 5
+        assert 1 <= seed_criterion.score_beta <= 5
+
+    def test_minimal_profiles(self):
+        """Comparison of two minimal profiles should not crash."""
+        minimal_a = {"strategy_id": "a", "net_eppd": 0.1}
+        minimal_b = {"strategy_id": "b", "net_eppd": 0.2}
+        result = compare_blind(minimal_a, minimal_b, seed=42)
+        assert isinstance(result, BlindComparisonResult)
+        assert result.summary  # Non-empty summary
+
+    def test_missing_strategy_id(self):
+        """Profiles without strategy_id should default to 'unknown'."""
+        profile = {"net_eppd": 0.5}
+        name = _extract_strategy_name(profile)
+        assert name == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Tests: JSON output
+# ---------------------------------------------------------------------------
+
+
+class TestJsonOutput:
+    def test_valid_json(self):
+        """Output is valid, parseable JSON."""
+        result = compare_blind(GBT_PROFILE, HYBRID_R0_PROFILE, seed=42)
+        d = result_to_dict(result)
+        json_str = json.dumps(d)
+        parsed = json.loads(json_str)
+        assert "seed" in parsed
+        assert "rubric" in parsed
+        assert "winner" in parsed
+        assert "label_assignment" in parsed
+
+    def test_schema_version(self):
+        """JSON output contains schema version."""
+        result = compare_blind(GBT_PROFILE, HYBRID_R0_PROFILE, seed=42)
+        d = result_to_dict(result)
+        assert d["schema"] == "blind_comparison_v1"
+
+    def test_generated_at(self):
+        """JSON output contains timestamp."""
+        result = compare_blind(GBT_PROFILE, HYBRID_R0_PROFILE, seed=42)
+        d = result_to_dict(result)
+        assert "generated_at" in d
+        assert d["generated_at"].endswith("Z")
+
+    def test_rubric_in_json(self):
+        """JSON output contains all rubric entries as dicts."""
+        result = compare_blind(GBT_PROFILE, HYBRID_R0_PROFILE, seed=42)
+        d = result_to_dict(result)
+        assert len(d["rubric"]) == 5
+        for entry in d["rubric"]:
+            assert "criterion" in entry
+            assert "weight" in entry
+            assert "score_alpha" in entry
+            assert "score_beta" in entry
+            assert "reasoning" in entry
+
+
+# ---------------------------------------------------------------------------
+# Tests: Markdown output
+# ---------------------------------------------------------------------------
+
+
+class TestMarkdownOutput:
+    def test_contains_rubric_table(self):
+        """Markdown output contains a rubric table."""
+        result = compare_blind(GBT_PROFILE, HYBRID_R0_PROFILE, seed=42)
+        md = result_to_markdown(result)
+        assert "| Criterion | Weight | Alpha | Beta | Reasoning |" in md
+
+    def test_contains_unblinding(self):
+        """Markdown output contains unblinding section."""
+        result = compare_blind(GBT_PROFILE, HYBRID_R0_PROFILE, seed=42)
+        md = result_to_markdown(result)
+        assert "## Unblinding" in md
+        assert "Alpha" in md
+        assert "Beta" in md
+
+    def test_contains_summary(self):
+        """Markdown output contains summary."""
+        result = compare_blind(GBT_PROFILE, HYBRID_R0_PROFILE, seed=42)
+        md = result_to_markdown(result)
+        assert "## Summary" in md
+
+    def test_no_identifying_info_before_unblinding(self):
+        """Before unblinding section, no real strategy names appear.
+
+        The rubric section should use Alpha/Beta labels only.
+        """
+        result = compare_blind(GBT_PROFILE, HYBRID_R0_PROFILE, seed=42)
+        md = result_to_markdown(result)
+        # Split at unblinding section
+        parts = md.split("## Unblinding")
+        rubric_section = parts[0]
+        # Real names should not appear in the rubric section
+        assert "gbt_av_bidder_r1_5_3" not in rubric_section
+        assert "hybrid_olsa_r0" not in rubric_section
+
+
+# ---------------------------------------------------------------------------
+# Tests: Profile loading
+# ---------------------------------------------------------------------------
+
+
+class TestProfileLoading:
+    def test_load_flat_format(self):
+        """Load flat metrics dict."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"net_eppd": 0.5, "bid_rate": 0.4}, f)
+            f.flush()
+            profile = load_profile(f.name)
+        assert profile["net_eppd"] == 0.5
+
+    def test_load_strategies_format(self):
+        """Load evaluator output with strategies list."""
+        data = {"strategies": [{"strategy_id": "test", "net_eppd": 0.3}]}
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(data, f)
+            f.flush()
+            profile = load_profile(f.name)
+        assert profile["net_eppd"] == 0.3
+
+    def test_load_nested_metrics_format(self):
+        """Load nested metrics dict."""
+        data = {"metrics": {"net_eppd": 0.7}}
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(data, f)
+            f.flush()
+            profile = load_profile(f.name)
+        assert profile["net_eppd"] == 0.7
+
+    def test_file_not_found(self):
+        """Loading non-existent file raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            load_profile("/nonexistent/path/metrics.json")
+
+
+# ---------------------------------------------------------------------------
+# Tests: Helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_get_per_contract_eppd_nested(self):
+        """Extract per-contract eppd from nested format."""
+        result = _get_per_contract_eppd(GBT_PROFILE)
+        assert result["suit"] == 0.827
+        assert result["high"] == 0.333
+        assert result["low"] == -0.041
+
+    def test_get_per_contract_eppd_flat(self):
+        """Extract per-contract eppd from flat key format."""
+        profile = {
+            "net_eppd_suit": 1.0,
+            "net_eppd_high": 0.5,
+            "net_eppd_low": -0.1,
+        }
+        result = _get_per_contract_eppd(profile)
+        assert result["suit"] == 1.0
+        assert result["high"] == 0.5
+        assert result["low"] == -0.1
+
+    def test_get_per_contract_eppd_empty(self):
+        """Empty profile returns empty dict."""
+        result = _get_per_contract_eppd({})
+        assert result == {}
+
+    def test_get_seed_deltas_explicit(self):
+        """Extract seed deltas from explicit key."""
+        result = _get_seed_deltas(GBT_PROFILE)
+        assert result == [0.595, 0.557, 0.558]
+
+    def test_get_seed_deltas_from_seeds_list(self):
+        """Extract seed deltas from seeds list of dicts."""
+        profile = {
+            "seeds": [
+                {"net_eppd_delta": 0.5},
+                {"net_eppd_delta": 0.6},
+            ]
+        }
+        result = _get_seed_deltas(profile)
+        assert result == [0.5, 0.6]
+
+    def test_get_seed_deltas_empty(self):
+        """Empty profile returns empty list."""
+        result = _get_seed_deltas({})
+        assert result == []
+
+    def test_extract_strategy_name_id(self):
+        """Extract name from strategy_id."""
+        assert _extract_strategy_name({"strategy_id": "foo"}) == "foo"
+
+    def test_extract_strategy_name_name(self):
+        """Extract name from name key."""
+        assert _extract_strategy_name({"name": "bar"}) == "bar"
+
+    def test_extract_strategy_name_priority(self):
+        """strategy_id takes priority over name."""
+        profile = {"strategy_id": "primary", "name": "secondary"}
+        assert _extract_strategy_name(profile) == "primary"


### PR DESCRIPTION
## Summary
- New `scripts/internal/blind_strategy_comparison.py`: CLI tool for anonymized strategy comparison
- New `.claude/agents/blind-comparator.md`: agent definition for qualitative blind analysis
- 43 unit tests covering anonymization, rubric scoring, label randomization, output formats

## Why
Pattern transferred from `skill-creator` plugin's blind comparator. Reduces confirmation bias in strategy evaluation reports by anonymizing strategies before scoring. Generates its own rubric (avoids anchoring bias).

## Repro / Validation
```bash
uv run python scripts/internal/blind_strategy_comparison.py --help
uv run python -m pytest tests/unit/test_blind_comparison.py -v --seed 42
make check-quiet
```

## Tests
- 43 unit tests across 9 test classes
- All pass with `make check-quiet`
- `ruff check` and `ruff format` clean

## Worktree proof
```
pwd: .claude/worktrees/agent-a312585b
branch: blind-comparison
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)