### PR TITLE
fix: update doc references after rules moved to deferred/

### DIFF
--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -64,7 +64,7 @@ make lint             # Check only (no auto-fix)
 - **Edit the `.py` file**, not the `.ipynb` — Jupytext handles sync
 - **Clear outputs** before committing — `make notebook-check` validates this
 - **Force sync** when needed: `jupytext --to ipynb --output <ipynb> <py>`
-- **Decision-critical analysis** must be captured in committed artifacts (JSON, scripts), not only in notebook outputs — see `.claude/rules/45_notebook_boundary.md`
+- **Decision-critical analysis** must be captured in committed artifacts (JSON, scripts), not only in notebook outputs — see `.claude/rules/deferred/45_notebook_boundary.md`
 
 ## Data and Artifact Policy
 

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -86,11 +86,11 @@ See `docs/01_core/REPRODUCIBILITY.md` for the full determinism contract includin
 - Fail-fast assertions are preferred over silent bad data
 - Statistical tests must accompany visual inspection (not visual-only)
 
-See `.claude/rules/05_rigor.md` for complete standards.
+See `.claude/rules/deferred/05_rigor.md` for complete standards.
 
 ## References
 
 - `.claude/rules/15_testing_tiers.md` — Two-tier policy (authoritative)
-- `.claude/rules/05_rigor.md` — Statistical rigor standards
+- `.claude/rules/deferred/05_rigor.md` — Statistical rigor standards
 - `docs/01_core/REPRODUCIBILITY.md` — Determinism contract
 - `docs/02_agent/AI_BOUNDARIES.md` — Agent validation requirements


### PR DESCRIPTION
## Summary
- Update 3 stale path references in `docs/STYLEGUIDE.md` and `docs/TESTING_STRATEGY.md` after PR #679 moved `.claude/rules/*.md` to `.claude/rules/deferred/`

## Why
PR #679 moved rules files but missed updating two docs that reference them. `make docs-check` now validates these paths.

## Repro / Validation
```bash
grep -rn '\.claude/rules/05_rigor\|\.claude/rules/45_notebook_boundary' docs/ --include="*.md"
# Should return 0 matches (old paths gone)

make docs-check  # Must pass
```

## Tests
```bash
make docs-check  # PASS
```

## Worktree proof
Branch: `fix/rules-path-refs`
Worktree: `.claude/worktrees/agent-fix-rules-path-refs`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>