### PR TITLE
feat: configurable Codex launcher and review loop docs (PR 3/3)

### DIFF
--- a/docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md
+++ b/docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md
@@ -76,10 +76,23 @@ as its first step before invoking Codex CLI. Checks include:
 - N3: Inference claim without statistical test (P2, notebooks only)
 - X2: Core/scoring/logging changes without doc update (P2, diff-level)
 
+### Plan Validation
+
+Plan validation checks run in `_step_pr_open()` before deterministic
+prechecks. They verify that PRs reference a governing or session plan and
+that the declared plan file exists with content. Checks:
+
+- **PV1:** Plan reference present in PR description (P2 — non-blocking)
+- **PV2:** Referenced plan file exists on disk (P1 — blocking)
+- **PV3:** Plan file has non-trivial content (P2 — non-blocking)
+- **SD1:** Scope drift — files changed but not declared in plan (P2 — non-blocking)
+
+Plan validation is advisory for doc/plan-only PRs and enforced for code PRs.
+
 ### Codex CLI Adapter
 
-Invokes `codex review --base main` (prefers installed binary, falls back to
-`npx @openai/codex`). Parses two output formats:
+Invokes `codex review --base main` with a configurable binary resolution
+chain. Parses two output formats:
 
 1. Standard: `[P1] file:line — message (C1)`
 2. Alternative: `[CRITICAL][C1] file:line — message`
@@ -87,6 +100,23 @@ Invokes `codex review --base main` (prefers installed binary, falls back to
 Findings are normalized into `CodexFinding` dataclass with severity, file,
 line, category, check_id, and message. Results saved to
 round_N/codex_review.json.
+
+**Binary preference order:**
+
+1. `CODEX_REVIEW_CMD` env var (custom launcher, split by whitespace)
+2. `codex` in PATH (fastest — no npx overhead)
+3. macOS app bundle at /Applications/Codex.app/Contents/Resources/codex
+4. `npx @openai/codex` fallback (downloads if needed)
+
+The `CODEX_REVIEW_CMD` env var allows running Codex in alternative
+environments (e.g., Docker containers, remote hosts). Example:
+
+```bash
+CODEX_REVIEW_CMD="docker exec codex codex" python scripts/internal/review_driver.py --pr 42 --trigger manual
+```
+
+If set but empty or whitespace-only, the env var is ignored and the
+existing preference chain applies.
 
 Retry logic: up to 3 attempts before `stopped_review_failure`.
 Stagnation detection: same findings hash on consecutive rounds →
@@ -128,6 +158,19 @@ The loop publishes GitHub commit status at key transitions:
 At `ready_to_merge`, the loop creates GitHub issues for non-blocking (P2)
 findings, grouped by category. Issues are labeled with `follow-up` plus
 the appropriate category label (`fix:bug`, `fix:convention`, etc.).
+
+### Blocker PR Comments
+
+On terminal states, the review loop posts a structured PR comment
+summarizing the outcome. Comments use a `<!-- review-loop-comment -->`
+HTML marker for idempotent upsert (existing comment is updated rather
+than duplicated on rerun).
+
+Comment contents:
+- **Status header** — pass/fail with emoji indicator
+- **Stop reason** — why the loop terminated (e.g., blockers found, max iterations)
+- **Findings table** — severity, file, check ID, and message for each finding
+- **Recovery command** — exact command to rerun the review loop manually
 
 ## Usage
 

--- a/docs/02_agent/CODEX_GITHUB_REVIEW.md
+++ b/docs/02_agent/CODEX_GITHUB_REVIEW.md
@@ -27,6 +27,14 @@ The review loop:
 | Usage pool | ChatGPT subscription (no API billing) |
 | Latency | ~60s per invocation |
 | Retry policy | Up to 3 attempts before `stopped_review_failure` |
+| Custom launcher | `CODEX_REVIEW_CMD` env var (optional) |
+
+## PR Comments
+
+The review loop posts structured PR comments on terminal states (not just
+commit statuses). Comments use an HTML marker for idempotent upsert and
+include the stop reason, findings table, and a recovery command. See
+`docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md` for details.
 
 ## Relationship to Other Gates
 

--- a/scripts/internal/codex_review_adapter.py
+++ b/scripts/internal/codex_review_adapter.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import shutil
 import subprocess
@@ -270,10 +271,16 @@ def _resolve_codex_binary() -> list[str]:
     """Return the command prefix for invoking Codex CLI.
 
     Preference order:
-    1. ``codex`` in PATH (fastest — no npx overhead)
-    2. macOS app bundle binary at known path
-    3. ``npx @openai/codex`` fallback (downloads if needed)
+    1. ``CODEX_REVIEW_CMD`` env var (custom launcher, e.g. Docker wrapper)
+    2. ``codex`` in PATH (fastest — no npx overhead)
+    3. macOS app bundle binary at known path
+    4. ``npx @openai/codex`` fallback (downloads if needed)
     """
+    custom_cmd = os.environ.get("CODEX_REVIEW_CMD", "").strip()
+    if custom_cmd:
+        parts = custom_cmd.split()
+        logger.info("Using custom Codex launcher from CODEX_REVIEW_CMD: %s", parts)
+        return parts
     if shutil.which("codex"):
         return ["codex"]
     if _CODEX_APP_PATH.is_file():

--- a/tests/unit/test_codex_review_adapter.py
+++ b/tests/unit/test_codex_review_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -434,3 +435,73 @@ class TestCodexReviewResultErrorType:
         )
         d = result.to_dict()
         assert d["error_type"] is None
+
+
+class TestEnvVarLauncher:
+    """Test CODEX_REVIEW_CMD env var configurable launcher."""
+
+    def test_env_var_takes_priority(self):
+        """CODEX_REVIEW_CMD overrides all other resolution paths."""
+        with patch.dict(os.environ, {"CODEX_REVIEW_CMD": "my-codex"}):
+            result = _resolve_codex_binary()
+            assert result == ["my-codex"]
+
+    def test_env_var_multi_word_split(self):
+        """Multi-word commands are split by whitespace."""
+        with patch.dict(
+            os.environ,
+            {"CODEX_REVIEW_CMD": "docker exec codex-container codex"},
+        ):
+            result = _resolve_codex_binary()
+            assert result == ["docker", "exec", "codex-container", "codex"]
+
+    @patch("codex_review_adapter.shutil.which", return_value="/usr/local/bin/codex")
+    def test_env_var_overrides_path_binary(self, mock_which):
+        """Env var wins even when codex is in PATH."""
+        with patch.dict(os.environ, {"CODEX_REVIEW_CMD": "custom-codex"}):
+            result = _resolve_codex_binary()
+            assert result == ["custom-codex"]
+
+    @patch("codex_review_adapter.shutil.which", return_value="/usr/local/bin/codex")
+    def test_empty_env_var_falls_through(self, mock_which):
+        """Empty env var is ignored, falls through to PATH binary."""
+        with patch.dict(os.environ, {"CODEX_REVIEW_CMD": ""}):
+            result = _resolve_codex_binary()
+            assert result == ["codex"]
+
+    @patch("codex_review_adapter.shutil.which", return_value="/usr/local/bin/codex")
+    def test_whitespace_only_env_var_falls_through(self, mock_which):
+        """Whitespace-only env var is ignored, falls through to PATH binary."""
+        with patch.dict(os.environ, {"CODEX_REVIEW_CMD": "   "}):
+            result = _resolve_codex_binary()
+            assert result == ["codex"]
+
+    @patch("codex_review_adapter.shutil.which", return_value=None)
+    def test_unset_env_var_uses_existing_chain(self, mock_which):
+        """When env var is not set, existing preference chain applies."""
+        env = os.environ.copy()
+        env.pop("CODEX_REVIEW_CMD", None)
+        with patch.dict(os.environ, env, clear=True):
+            with patch.object(Path, "is_file", return_value=False):
+                result = _resolve_codex_binary()
+                assert result == ["npx", "@openai/codex"]
+
+    @patch("codex_review_adapter.subprocess.run")
+    def test_env_var_in_invoke_command(self, mock_run):
+        """Env-configured command appears in invoke_codex_cli() command."""
+        mock_run.return_value = Mock(returncode=0, stdout="LGTM", stderr="")
+        with patch.dict(
+            os.environ,
+            {"CODEX_REVIEW_CMD": "docker exec codex-container codex"},
+        ):
+            invoke_codex_cli(base="main")
+            cmd = mock_run.call_args[0][0]
+            assert cmd == [
+                "docker",
+                "exec",
+                "codex-container",
+                "codex",
+                "review",
+                "--base",
+                "main",
+            ]


### PR DESCRIPTION
## Summary

- Add `CODEX_REVIEW_CMD` environment variable to `_resolve_codex_binary()` for configurable Codex CLI launcher
- Extend unit tests with 7 new tests covering env var priority, multi-word splitting, empty/whitespace fallthrough, and end-to-end command construction
- Document plan validation checks (PV1/PV2/PV3/SD1), configurable launcher, and blocker PR comments in review loop docs

## Why

PR 3 of a 3-PR series for plan-aware autonomous review. This PR adds the configurable launcher to support alternative execution environments (Docker, remote hosts) and aligns documentation with the new plan validation and PR comment features being added in PRs 1 and 2.

## Plan

`plans/sessions/2026-03-14_plan-aware-autonomous-review.md`

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_codex_review_adapter.py -v
# 55 passed (48 existing + 7 new)
```

## Tests

```bash
uv run python -m pytest tests/unit/test_codex_review_adapter.py -v  # All 55 pass
uv run python -m pytest -m "not slow" tests/  # 2932 passed, 39 skipped
make check-quiet  # Pre-existing docs-check failures only (stale path refs on main)
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/plan-aware-review-pr3
toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/plan-aware-review-pr3
```

## Files changed

- `scripts/internal/codex_review_adapter.py` — add `os` import, `CODEX_REVIEW_CMD` check in `_resolve_codex_binary()`
- `tests/unit/test_codex_review_adapter.py` — 7 new tests in `TestEnvVarLauncher` class
- `docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md` — plan validation, configurable launcher, blocker PR comments sections
- `docs/02_agent/CODEX_GITHUB_REVIEW.md` — custom launcher row in properties table, PR comments section

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)