### PR TITLE
fix: make missing anchor artifact a blocking preflight in Step 0

### DIFF
--- a/src/bid_euchre/arc_d_v2/orchestration.py
+++ b/src/bid_euchre/arc_d_v2/orchestration.py
@@ -601,7 +601,22 @@ def execute_step_0(state: RunState, dry_run: bool = False) -> bool:
             # Not a hard failure: LA-2 allows the pipeline to proceed
             # without the anchor in the comparator.
         else:
-            logger.warning("Anchor artifact not found at %s", anchor_path)
+            # The anchor artifact doubles as the continuation policy for
+            # dataset generation (Step 1) and training (Step 2).  If the
+            # roster contains trainable models, downstream steps will fail
+            # without it, so treat a missing anchor as a blocking error.
+            if roster.trainable_models():
+                missing.append(
+                    f"anchor artifact ({anchor_path}) — required for "
+                    "continuation training. Provision from a completed R0 "
+                    "run or frozen artifact store."
+                )
+                logger.error(
+                    "Anchor artifact required for continuation training: %s",
+                    anchor_path,
+                )
+            else:
+                logger.warning("Anchor artifact not found at %s", anchor_path)
 
     if missing:
         error = f"Missing: {', '.join(missing)}"

--- a/tests/unit/test_rung_orchestrator.py
+++ b/tests/unit/test_rung_orchestrator.py
@@ -764,6 +764,142 @@ class TestDryRun:
 
 
 # ============================================================================
+# Anchor Preflight Tests
+# ============================================================================
+
+
+class TestAnchorPreflight:
+    """Step 0 must block when anchor artifact is missing and roster has trainable models."""
+
+    def _setup_plan_files(self, plan_dir: Path) -> None:
+        """Create the minimal plan files required by Step 0."""
+        plan_dir.mkdir(parents=True, exist_ok=True)
+        (plan_dir / "plan.md").write_text("# Test plan")
+        (plan_dir / "hypotheses.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "hypotheses_v1",
+                    "rung": "r0",
+                    "hypotheses": [],
+                }
+            )
+        )
+
+    def _write_roster(
+        self, tmp_path: Path, *, trainable: bool, anchor_artifact: str
+    ) -> None:
+        """Write a roster.json with optional trainable model and anchor."""
+        models = []
+        if trainable:
+            models.append(
+                {
+                    "name": "test_model",
+                    "class": "ActionValueBidder",
+                    "trainable": True,
+                    "model_class": "ols",
+                    "feature_set": "r0",
+                }
+            )
+        roster_dir = tmp_path / "plans" / "arc_d_v2"
+        roster_dir.mkdir(parents=True, exist_ok=True)
+        (roster_dir / "roster.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "roster_v1",
+                    "lineage_id": "arc_d_v2",
+                    "models": models,
+                    "anchor": {
+                        "name": "anchor_hybrid_r0_full",
+                        "artifact": anchor_artifact,
+                        "class": "HybridOLSaBidder",
+                    },
+                }
+            )
+        )
+
+    def test_step0_fails_when_anchor_missing_and_trainable(self, tmp_path):
+        """Step 0 should fail when anchor artifact is configured, file is
+        missing, and roster has trainable models."""
+        plan_dir = tmp_path / "plans" / "arc_d_v2" / "r0"
+        self._setup_plan_files(plan_dir)
+        self._write_roster(
+            tmp_path,
+            trainable=True,
+            anchor_artifact="data/artifacts/arc_d/r0/hybrid_r0_full.json",
+        )
+        # Do NOT create the anchor file — it should be missing
+
+        with (
+            patch.object(run_rung_mod, "_plans_dir", return_value=plan_dir),
+            patch.object(
+                run_rung_mod, "_state_path", return_value=plan_dir / "state.json"
+            ),
+            patch.object(run_rung_mod, "_repo_root", return_value=tmp_path),
+        ):
+            state = RunState.create_fresh("r0", "smoke", [42])
+            ok = run_rung_mod.execute_step_0(state, dry_run=True)
+            assert ok is False
+            assert state.steps["0"]["status"] == "failed"
+            # Verify the error message mentions the anchor
+            assert "anchor" in state.steps["0"].get("error", "").lower()
+
+    def test_step0_passes_when_anchor_exists(self, tmp_path):
+        """Step 0 should pass when the anchor artifact file exists."""
+        plan_dir = tmp_path / "plans" / "arc_d_v2" / "r0"
+        self._setup_plan_files(plan_dir)
+        self._write_roster(
+            tmp_path,
+            trainable=True,
+            anchor_artifact="data/artifacts/arc_d/r0/hybrid_r0_full.json",
+        )
+        # Create the anchor file so it exists
+        anchor_path = (
+            tmp_path / "data" / "artifacts" / "arc_d" / "r0" / "hybrid_r0_full.json"
+        )
+        anchor_path.parent.mkdir(parents=True)
+        anchor_path.write_text("{}")
+
+        with (
+            patch.object(run_rung_mod, "_plans_dir", return_value=plan_dir),
+            patch.object(
+                run_rung_mod, "_state_path", return_value=plan_dir / "state.json"
+            ),
+            patch.object(run_rung_mod, "_repo_root", return_value=tmp_path),
+            # Mock the anchor compatibility check to avoid loading a real model
+            patch.object(run_rung_mod, "check_anchor_compatibility", return_value=True),
+        ):
+            state = RunState.create_fresh("r0", "smoke", [42])
+            ok = run_rung_mod.execute_step_0(state, dry_run=True)
+            assert ok is True
+            assert state.steps["0"]["status"] == "complete"
+
+    def test_step0_warns_when_anchor_missing_no_trainable(self, tmp_path):
+        """Step 0 should only warn (not fail) when anchor is missing but no
+        trainable models need it for continuation."""
+        plan_dir = tmp_path / "plans" / "arc_d_v2" / "r0"
+        self._setup_plan_files(plan_dir)
+        self._write_roster(
+            tmp_path,
+            trainable=False,
+            anchor_artifact="data/artifacts/arc_d/r0/hybrid_r0_full.json",
+        )
+        # Do NOT create the anchor file
+
+        with (
+            patch.object(run_rung_mod, "_plans_dir", return_value=plan_dir),
+            patch.object(
+                run_rung_mod, "_state_path", return_value=plan_dir / "state.json"
+            ),
+            patch.object(run_rung_mod, "_repo_root", return_value=tmp_path),
+        ):
+            state = RunState.create_fresh("r0", "smoke", [42])
+            ok = run_rung_mod.execute_step_0(state, dry_run=True)
+            # Should pass — only a warning, not a blocking error
+            assert ok is True
+            assert state.steps["0"]["status"] == "complete"
+
+
+# ============================================================================
 # Status Print Test
 # ============================================================================
 


### PR DESCRIPTION
## Summary

- Step 0's anchor artifact check now **blocks** when the file is missing and the roster has trainable models (which need it as the continuation artifact for dataset generation and training)
- When no trainable models exist, the missing anchor remains a non-blocking warning
- The LA-2 anchor **compatibility** check remains a non-blocking warning (unchanged)

## Why

The governing plan hard-depends on `data/artifacts/arc_d/r0/hybrid_r0_full.json` — it serves as the `--continuation-artifact` for dataset generation (Step 1) and training (Step 2). Previously, Step 0 only logged a warning when this file was missing, causing downstream steps to fail with an unclear error instead of failing fast with a provisioning message.

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_rung_orchestrator.py -v -k "TestAnchorPreflight" --seed 42
```

## Tests

- `test_step0_fails_when_anchor_missing_and_trainable` — verifies preflight failure
- `test_step0_passes_when_anchor_exists` — verifies pass with mocked anchor
- `test_step0_warns_when_anchor_missing_no_trainable` — verifies no-trainable case stays non-blocking
- Existing `TestDryRun` tests continue to pass (empty roster = no anchor configured)
- `make check-quiet` passes

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/worktree-fix-anchor-preflight
toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/worktree-fix-anchor-preflight
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)