### PR TITLE
fix: deterministic artifact selection and aggregate hypothesis evaluation

### DIFF
--- a/plans/arc_d_v2/r0/hypotheses.json
+++ b/plans/arc_d_v2/r0/hypotheses.json
@@ -68,7 +68,7 @@
       "source_table": "comparator_rankings.csv",
       "source_column": "bid_rate",
       "source_filter": {"facet": "pooled"},
-      "computation": "value",
+      "computation": "min",
       "expected_bound": {"op": ">", "value": 0.5},
       "surprise_if": {"op": "<", "value": 0.2}
     },

--- a/scripts/internal/generate_rung_tables.py
+++ b/scripts/internal/generate_rung_tables.py
@@ -39,6 +39,18 @@ def main() -> None:
         help="Path to write CSV tables",
     )
     parser.add_argument(
+        "--mode",
+        choices=["smoke", "quick", "full"],
+        default=None,
+        help="Execution mode for deterministic artifact selection",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="RNG seed for deterministic artifact selection",
+    )
+    parser.add_argument(
         "--verbose",
         "-v",
         action="store_true",
@@ -52,7 +64,9 @@ def main() -> None:
         format="%(levelname)s: %(message)s",
     )
 
-    generated = generate_all_tables(args.rung_dir, args.output_dir)
+    generated = generate_all_tables(
+        args.rung_dir, args.output_dir, mode=args.mode, seed=args.seed
+    )
     logger.info("Generated %d tables: %s", len(generated), ", ".join(generated))
 
 

--- a/src/bid_euchre/arc_d_v2/advance_check.py
+++ b/src/bid_euchre/arc_d_v2/advance_check.py
@@ -35,7 +35,10 @@ def _read_csv_value(
     source_column: str,
     source_filter: dict,
 ) -> float | None:
-    """Read a single value from a CSV table, applying filters."""
+    """Read a single value from a CSV table, applying filters.
+
+    Returns the first matching row's value, or None if not found.
+    """
     csv_path = tables_dir / source_table
     if not csv_path.exists():
         return None
@@ -43,11 +46,7 @@ def _read_csv_value(
     with open(csv_path) as f:
         reader = csv.DictReader(f)
         for row in reader:
-            match = True
-            for key, val in source_filter.items():
-                if row.get(key) != str(val):
-                    match = False
-                    break
+            match = all(row.get(key) == str(val) for key, val in source_filter.items())
             if match:
                 raw = row.get(source_column)
                 if raw is None:
@@ -56,6 +55,47 @@ def _read_csv_value(
                     return float(raw)
                 except (ValueError, TypeError):
                     return None
+    return None
+
+
+def _read_csv_aggregate(
+    tables_dir: Path,
+    source_table: str,
+    source_column: str,
+    source_filter: dict,
+    aggregate: str,
+) -> float | None:
+    """Read an aggregate (min/max) across all matching rows in a CSV table.
+
+    Args:
+        aggregate: "min" or "max"
+
+    Returns the aggregate value, or None if no matching rows found.
+    """
+    csv_path = tables_dir / source_table
+    if not csv_path.exists():
+        return None
+
+    values = []
+    with open(csv_path) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            match = all(row.get(key) == str(val) for key, val in source_filter.items())
+            if match:
+                raw = row.get(source_column)
+                if raw is not None:
+                    try:
+                        values.append(float(raw))
+                    except (ValueError, TypeError):
+                        pass
+
+    if not values:
+        return None
+
+    if aggregate == "min":
+        return min(values)
+    elif aggregate == "max":
+        return max(values)
     return None
 
 
@@ -84,8 +124,14 @@ def evaluate_hypothesis(hyp: dict, tables_dir: Path) -> dict:
     expected_bound = hyp.get("expected_bound", {})
     surprise_if = hyp.get("surprise_if", {})
 
-    # Read primary value
-    value = _read_csv_value(tables_dir, source_table, source_column, source_filter)
+    # Read primary value — use aggregate for min/max computations
+    aggregate_computations = {"min", "max"}
+    if computation in aggregate_computations:
+        value = _read_csv_aggregate(
+            tables_dir, source_table, source_column, source_filter, computation
+        )
+    else:
+        value = _read_csv_value(tables_dir, source_table, source_column, source_filter)
     if value is None:
         result["error"] = (
             f"Could not read {source_column} from {source_table} "

--- a/src/bid_euchre/arc_d_v2/orchestration.py
+++ b/src/bid_euchre/arc_d_v2/orchestration.py
@@ -1342,6 +1342,10 @@ def execute_step_6(state: RunState, dry_run: bool = False) -> bool:
         str(rung_dir),
         "--output-dir",
         str(output_dir),
+        "--mode",
+        state.mode,
+        "--seed",
+        str(state.seeds[0] if state.seeds else 42),
     ]
 
     if dry_run:

--- a/src/bid_euchre/arc_d_v2/tables.py
+++ b/src/bid_euchre/arc_d_v2/tables.py
@@ -33,25 +33,43 @@ def _load_json(path: Path) -> dict | None:
         return json.load(f)
 
 
-def _load_json_glob(rung_dir: Path, prefix: str) -> dict | None:
-    """Load a JSON artifact, trying exact name then glob for mode/seed-suffixed variants.
+def _load_json_glob(
+    rung_dir: Path,
+    prefix: str,
+    mode: str | None = None,
+    seed: int | None = None,
+) -> dict | None:
+    """Load a JSON artifact, using deterministic naming when mode/seed are known.
 
-    The orchestrator writes mode/seed-suffixed filenames (e.g., ``h2h_battery_quick_42.json``)
-    while the table generator historically expected the bare name (``h2h_battery.json``).
-    This helper tries the bare name first, then globs for ``{prefix}_*.json`` and picks
-    the most recently modified match.
+    Resolution order:
+    1. If mode and seed given, try ``{prefix}_{mode}_{seed}.json`` (deterministic).
+    2. Try the bare ``{prefix}.json`` (legacy / symlink).
+    3. Fall back to glob ``{prefix}_*.json``, newest by mtime (last resort).
     """
+    # Deterministic path when mode/seed are known
+    if mode and seed is not None:
+        deterministic = rung_dir / f"{prefix}_{mode}_{seed}.json"
+        if deterministic.exists():
+            return _load_json(deterministic)
+
+    # Legacy bare name
     exact = rung_dir / f"{prefix}.json"
     if exact.exists():
         return _load_json(exact)
 
+    # Glob fallback (nondeterministic — warns)
     candidates = sorted(
         rung_dir.glob(f"{prefix}_*.json"),
         key=lambda p: p.stat().st_mtime,
     )
     if candidates:
         chosen = candidates[-1]
-        logger.info("Resolved %s via glob: %s", prefix, chosen.name)
+        logger.warning(
+            "Resolved %s via mtime glob (nondeterministic): %s. "
+            "Pass --mode/--seed for deterministic selection.",
+            prefix,
+            chosen.name,
+        )
         return _load_json(chosen)
 
     logger.warning("No %s artifact found in %s", prefix, rung_dir)
@@ -557,12 +575,16 @@ def generate_data_sanity(
 def generate_all_tables(
     rung_dir: Path,
     output_dir: Path,
+    mode: str | None = None,
+    seed: int | None = None,
 ) -> list[str]:
     """Generate all 11 canonical CSVs from rung directory artifacts.
 
     Args:
         rung_dir: Path to directory containing run artifacts.
         output_dir: Path to write CSV files.
+        mode: Execution mode (smoke/quick/full) for deterministic artifact selection.
+        seed: RNG seed for deterministic artifact selection.
 
     Returns:
         List of generated CSV filenames.
@@ -570,9 +592,14 @@ def generate_all_tables(
     output_dir.mkdir(parents=True, exist_ok=True)
     generated = []
 
-    # Load available artifacts (glob for mode/seed-suffixed filenames)
-    h2h_battery = _load_json_glob(rung_dir, "h2h_battery")
-    comparator_cis = _load_json_glob(rung_dir, "comparator_cis")
+    # Load available artifacts (deterministic when mode/seed provided)
+    # H2H uses {prefix}_{mode}_{seed}.json naming
+    h2h_battery = _load_json_glob(rung_dir, "h2h_battery", mode=mode, seed=seed)
+    # Comparator CIs use {prefix}_{rung}_{seed}.json naming — extract rung from dir
+    rung_id = rung_dir.name  # e.g., "r0"
+    comparator_cis = _load_json_glob(
+        rung_dir, "comparator_cis", mode=rung_id, seed=seed
+    )
     roster = _load_json(rung_dir / "roster.json")
 
     # Load training artifacts (look for training_artifact_*.json)

--- a/tests/unit/test_rung_orchestrator.py
+++ b/tests/unit/test_rung_orchestrator.py
@@ -466,6 +466,77 @@ class TestHypothesisEvaluation:
         assert result["error"] is not None
         assert result["pass"] is False
 
+    def test_min_aggregate(self, tmp_path):
+        """H6-style check: min(bid_rate) across all pooled models > 0.5."""
+        _write_csv(
+            tmp_path / "comparator_rankings.csv",
+            ["model", "facet", "bid_rate"],
+            [
+                ["gbt_av", "pooled", "0.91"],
+                ["ols_av", "pooled", "1.0"],
+                ["heuristic", "pooled", "0.85"],
+            ],
+        )
+        hyp = {
+            "id": "H6",
+            "description": "all models bid > 50%",
+            "source_table": "comparator_rankings.csv",
+            "source_column": "bid_rate",
+            "source_filter": {"facet": "pooled"},
+            "computation": "min",
+            "expected_bound": {"op": ">", "value": 0.5},
+        }
+        result = evaluate_hypothesis(hyp, tmp_path)
+        assert result["pass"] is True
+        assert result["observed"] == 0.85  # min of [0.91, 1.0, 0.85]
+
+    def test_min_aggregate_fails(self, tmp_path):
+        """Min aggregate should fail when any model is below threshold."""
+        _write_csv(
+            tmp_path / "comparator_rankings.csv",
+            ["model", "facet", "bid_rate"],
+            [
+                ["gbt_av", "pooled", "0.91"],
+                ["pathological", "pooled", "0.3"],
+            ],
+        )
+        hyp = {
+            "id": "H6",
+            "description": "all models bid > 50%",
+            "source_table": "comparator_rankings.csv",
+            "source_column": "bid_rate",
+            "source_filter": {"facet": "pooled"},
+            "computation": "min",
+            "expected_bound": {"op": ">", "value": 0.5},
+        }
+        result = evaluate_hypothesis(hyp, tmp_path)
+        assert result["pass"] is False
+        assert result["observed"] == 0.3  # pathological model
+
+    def test_comparator_filter(self, tmp_path):
+        """comparator_filter should work like anchor_filter for deltas."""
+        _write_csv(
+            tmp_path / "comparator_rankings.csv",
+            ["model", "facet", "net_eppd"],
+            [
+                ["two_stage", "pooled", "1.8"],
+                ["selected_ols", "pooled", "2.2"],
+            ],
+        )
+        hyp = {
+            "id": "H8",
+            "description": "test comparator delta",
+            "source_table": "comparator_rankings.csv",
+            "source_column": "net_eppd",
+            "source_filter": {"model": "two_stage", "facet": "pooled"},
+            "comparator_filter": {"model": "selected_ols", "facet": "pooled"},
+            "computation": "value - comparator_value",
+            "expected_bound": {"op": ">=", "value": -0.2},
+        }
+        result = evaluate_hypothesis(hyp, tmp_path)
+        assert result["pass"] is False  # -0.4 < -0.2
+        assert abs(result["observed"] - (-0.4)) < 0.001
+
 
 class TestSufficiencyChecks:
     def test_all_tables_present(self, tmp_path):
@@ -1343,6 +1414,71 @@ class TestStep4CommandConstruction:
 
         assert ok is False
         assert "No bidders" in (state.steps["4"].get("error") or "")
+
+    def test_step4_full_execution_success(self, tmp_path):
+        """Step 4 non-dry-run should run config → experiment → parse."""
+        art = tmp_path / "gbt_av" / "artifact.json"
+        art.parent.mkdir(parents=True)
+        art.write_text("{}")
+
+        # Create the artifacts dir and config file the orchestrator expects
+        artifacts_dir = tmp_path / "data" / "artifacts" / "arc_d_v2" / "r0"
+        artifacts_dir.mkdir(parents=True)
+        config_path = artifacts_dir / "h2h_battery_quick_config.yaml"
+        config_path.write_text("run_id: test_run\n")
+
+        # Create a fake run directory for parse phase to find
+        run_dir = tmp_path / "data" / "runs" / "arc_d_r0_h2h_battery_42_20260101_000000"
+        run_dir.mkdir(parents=True)
+
+        roster = Roster(
+            models=[
+                RosterModel(
+                    name="gbt_av",
+                    class_name="GBTActionValueBidder",
+                    trainable=True,
+                ),
+            ],
+            anchor=AnchorModel(name="anchor", artifact="anchor.json", class_name="X"),
+        )
+
+        plan_dir = tmp_path / "plans" / "arc_d_v2" / "r0"
+        plan_dir.mkdir(parents=True)
+
+        state = RunState.create_fresh("r0", "quick", [42])
+
+        # Track subprocess calls to verify 3-phase execution
+        subprocess_calls = []
+
+        def mock_subprocess(cmd, step, rung, log_suffix=""):
+            subprocess_calls.append(log_suffix)
+            return True, None
+
+        with (
+            patch.object(run_rung_mod, "load_roster", return_value=roster),
+            patch.object(run_rung_mod, "_repo_root", return_value=tmp_path),
+            patch.object(run_rung_mod, "_plans_dir", return_value=plan_dir),
+            patch.object(
+                run_rung_mod,
+                "_state_path",
+                return_value=plan_dir / "state.json",
+            ),
+            patch.object(
+                run_rung_mod,
+                "find_trained_artifact",
+                return_value=art,
+            ),
+            patch.object(run_rung_mod, "run_subprocess", side_effect=mock_subprocess),
+        ):
+            ok = run_rung_mod.execute_step_4(state, 42, dry_run=False)
+
+        assert ok is True
+        assert state.steps["4"]["status"] == "complete"
+        # Verify all 3 phases ran: config gen, experiment, parse
+        assert len(subprocess_calls) == 3
+        assert subprocess_calls[0] == "seed_42"  # config gen
+        assert "experiment" in subprocess_calls[1]  # experiment run
+        assert "parse" in subprocess_calls[2]  # result parse
 
 
 class TestStep5CommandConstruction:


### PR DESCRIPTION
## Summary
- Make artifact selection deterministic by constructing exact filenames from mode/seed (CRITICAL Codex finding)
- Add `min`/`max` aggregate computation support for H6-style "all models" hypotheses (CRITICAL Codex finding)
- Add positive-path test for Step 4's full 3-phase subprocess flow (WARNING Codex finding)

## Why
Codex review of PR #688 found two CRITICAL correctness issues:
1. `_load_json_glob()` picked artifacts by newest mtime — stale SMOKE artifacts could be silently used for a QUICK run
2. H6 ("all models bid > 50%") only checked the first matching CSV row, not the minimum across all models

## Repro / Validation
```bash
# Tests (125 passed)
uv run python -m pytest tests/unit/test_rung_tables.py tests/unit/test_rung_orchestrator.py -v

# Full validation
make check-quiet
```

## Tests
```bash
uv run python -m pytest tests/unit/test_rung_tables.py tests/unit/test_rung_orchestrator.py -v  # 125 passed, 1 skipped
make check-quiet  # All checks passed
```

## Key changes
- `_load_json_glob()` now tries `{prefix}_{mode}_{seed}.json` first when mode/seed provided
- `generate_all_tables()` accepts optional `mode`/`seed` params
- `generate_rung_tables.py` CLI accepts `--mode`/`--seed` flags
- Orchestrator Step 6 passes mode/seed to table generator
- `_read_csv_aggregate()` returns min/max across all matching rows
- H6 hypothesis updated to `"computation": "min"`
- Step 4 positive-path test verifies 3-phase subprocess flow

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-advance-check-fix
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-advance-check-fix
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)