### PR TITLE
feat: per-contract H2H faceting and multi-seed FULL aggregation

### DIFF
--- a/scripts/internal/generate_rung_tables.py
+++ b/scripts/internal/generate_rung_tables.py
@@ -46,9 +46,9 @@ def main() -> None:
     )
     parser.add_argument(
         "--seed",
-        type=int,
         default=None,
-        help="RNG seed for deterministic artifact selection",
+        help="RNG seed(s) for deterministic artifact selection. "
+        "Comma-separated for multi-seed FULL (e.g., '42,123,456')",
     )
     parser.add_argument(
         "--verbose",
@@ -64,8 +64,13 @@ def main() -> None:
         format="%(levelname)s: %(message)s",
     )
 
+    # Parse seed(s) — supports single int or comma-separated list
+    seeds = None
+    if args.seed:
+        seeds = [int(s.strip()) for s in args.seed.split(",")]
+
     generated = generate_all_tables(
-        args.rung_dir, args.output_dir, mode=args.mode, seed=args.seed
+        args.rung_dir, args.output_dir, mode=args.mode, seeds=seeds
     )
     logger.info("Generated %d tables: %s", len(generated), ", ".join(generated))
 

--- a/scripts/internal/run_arc_d_h2h_battery.py
+++ b/scripts/internal/run_arc_d_h2h_battery.py
@@ -712,6 +712,41 @@ def parse_run_results(run_dir, summary, seed=42):
         cell["deals_total"] = n_deals
         cell["run_id"] = run_path.name
 
+        # Per-contract faceting: group records by contract type and compute
+        # core metrics (delta, CI, win_rate) for suit/high/low.
+        contract_groups: dict[str, list] = {}
+        for rec in records:
+            ct = rec.get("contract")
+            if ct and isinstance(ct, str) and ct in ("suit", "high", "low"):
+                contract_groups.setdefault(ct, []).append(rec)
+
+        by_contract = {}
+        for ct, ct_records in contract_groups.items():
+            ct_deltas = []
+            ct_wins = 0
+            for rec in ct_records:
+                bp = rec.get("bidder_position")
+                if bp is None:
+                    continue  # all-pass: no contract, skip
+                t0_pts, t1_pts = _compute_team_points(rec)
+                ct_deltas.append(t0_pts - t1_pts)
+                if t0_pts > t1_pts:
+                    ct_wins += 1
+            ct_n = len(ct_deltas)
+            if ct_n == 0:
+                continue
+            ct_delta = float(np.mean(ct_deltas))
+            ct_ci_low, ct_ci_high = _bootstrap_ci(ct_deltas, seed=seed)
+            by_contract[ct] = {
+                "net_eppd_delta": round(ct_delta, 6),
+                "ci_low": round(ct_ci_low, 6),
+                "ci_high": round(ct_ci_high, 6),
+                "win_rate_a": round(ct_wins / ct_n, 4),
+                "deals_total": ct_n,
+            }
+        if by_contract:
+            cell["by_contract"] = by_contract
+
     return summary
 
 

--- a/src/bid_euchre/arc_d_v2/orchestration.py
+++ b/src/bid_euchre/arc_d_v2/orchestration.py
@@ -1345,7 +1345,7 @@ def execute_step_6(state: RunState, dry_run: bool = False) -> bool:
         "--mode",
         state.mode,
         "--seed",
-        str(state.seeds[0] if state.seeds else 42),
+        ",".join(str(s) for s in state.seeds) if state.seeds else "42",
     ]
 
     if dry_run:

--- a/src/bid_euchre/arc_d_v2/tables.py
+++ b/src/bid_euchre/arc_d_v2/tables.py
@@ -165,12 +165,12 @@ def generate_h2h_delta_matrix(h2h_battery: dict) -> pd.DataFrame:
         bidder_a = cell.get("bidder_a", "")
         bidder_b = cell.get("bidder_b", "")
 
-        facet = "pooled"  # H2H battery is pooled by default
+        # Pooled row (always present)
         rows.append(
             {
                 "model_a": bidder_a,
                 "model_b": bidder_b,
-                "facet": facet,
+                "facet": "pooled",
                 "net_eppd_delta": _safe_round(cell.get("net_eppd_delta")),
                 "ci_low": _safe_round(cell.get("ci_low")),
                 "ci_high": _safe_round(cell.get("ci_high")),
@@ -178,6 +178,24 @@ def generate_h2h_delta_matrix(h2h_battery: dict) -> pd.DataFrame:
                 "deals_total": cell.get("deals_total"),
             }
         )
+
+        # Per-contract rows (if by_contract data is available)
+        by_contract = cell.get("by_contract", {})
+        for ct in ("suit", "high", "low"):
+            ct_data = by_contract.get(ct)
+            if ct_data:
+                rows.append(
+                    {
+                        "model_a": bidder_a,
+                        "model_b": bidder_b,
+                        "facet": ct,
+                        "net_eppd_delta": _safe_round(ct_data.get("net_eppd_delta")),
+                        "ci_low": _safe_round(ct_data.get("ci_low")),
+                        "ci_high": _safe_round(ct_data.get("ci_high")),
+                        "win_rate_a": _safe_round(ct_data.get("win_rate_a")),
+                        "deals_total": ct_data.get("deals_total"),
+                    }
+                )
 
     return pd.DataFrame(rows)
 
@@ -572,11 +590,93 @@ def generate_data_sanity(
 # ──────────────────────────────────────────────
 
 
+def _merge_h2h_batteries(batteries: list[dict]) -> dict:
+    """Merge multiple H2H battery JSONs by averaging per-cell metrics across seeds."""
+    if len(batteries) == 1:
+        return batteries[0]
+
+    merged = dict(batteries[0])  # Copy structure from first
+    merged_cells = {}
+
+    # Collect all cells by matchup_id
+    for battery in batteries:
+        for mid, cell in battery.get("cells", {}).items():
+            merged_cells.setdefault(mid, []).append(cell)
+
+    result_cells = {}
+    for mid, cell_list in merged_cells.items():
+        base = dict(cell_list[0])
+        # Average numeric fields across seeds
+        for key in (
+            "net_eppd_delta",
+            "net_eppd_a",
+            "net_eppd_b",
+            "ci_low",
+            "ci_high",
+            "win_rate_a",
+            "abs_net_eppd_team0",
+            "abs_net_eppd_team1",
+            "cvar_5",
+            "fullgame_eppd",
+        ):
+            vals = [c.get(key) for c in cell_list if c.get(key) is not None]
+            base[key] = round(sum(vals) / len(vals), 6) if vals else None
+        # Sum deal counts
+        deal_counts = [c.get("deals_total", 0) for c in cell_list]
+        base["deals_total"] = sum(deal_counts)
+        # Merge per-contract data if present
+        all_contracts: dict[str, list[dict]] = {}
+        for c in cell_list:
+            for ct, ct_data in c.get("by_contract", {}).items():
+                all_contracts.setdefault(ct, []).append(ct_data)
+        if all_contracts:
+            merged_bc = {}
+            for ct, ct_list in all_contracts.items():
+                merged_ct: dict = {}
+                for key in ("net_eppd_delta", "ci_low", "ci_high", "win_rate_a"):
+                    vals = [d.get(key) for d in ct_list if d.get(key) is not None]
+                    merged_ct[key] = round(sum(vals) / len(vals), 6) if vals else None
+                merged_ct["deals_total"] = sum(d.get("deals_total", 0) for d in ct_list)
+                merged_bc[ct] = merged_ct
+            base["by_contract"] = merged_bc
+        result_cells[mid] = base
+
+    merged["cells"] = result_cells
+    merged["seeds_merged"] = len(batteries)
+    return merged
+
+
+def _merge_comparator_cis(cis_list: list[dict]) -> dict:
+    """Merge multiple comparator CI JSONs by averaging per-bidder metrics."""
+    if len(cis_list) == 1:
+        return cis_list[0]
+
+    merged = dict(cis_list[0])
+    # Average bidder metrics across seeds
+    all_bidders: dict[str, list[dict]] = {}
+    for cis in cis_list:
+        for name, b in cis.get("bidders", {}).items():
+            all_bidders.setdefault(name, []).append(b)
+
+    result_bidders = {}
+    for name, b_list in all_bidders.items():
+        base = dict(b_list[0])
+        for key in ("net_eppd", "eppd", "bid_rate", "make_rate"):
+            vals = [b.get(key) for b in b_list if b.get(key) is not None]
+            base[key] = round(sum(vals) / len(vals), 6) if vals else None
+        result_bidders[name] = base
+
+    merged["bidders"] = result_bidders
+    merged["seeds_merged"] = len(cis_list)
+    return merged
+
+
 def generate_all_tables(
     rung_dir: Path,
     output_dir: Path,
     mode: str | None = None,
     seed: int | None = None,
+    seeds: list[int] | None = None,
 ) -> list[str]:
     """Generate all 11 canonical CSVs from rung directory artifacts.
 
@@ -584,7 +684,9 @@ def generate_all_tables(
         rung_dir: Path to directory containing run artifacts.
         output_dir: Path to write CSV files.
         mode: Execution mode (smoke/quick/full) for deterministic artifact selection.
-        seed: RNG seed for deterministic artifact selection.
+        seed: Single RNG seed (for backward compatibility).
+        seeds: List of RNG seeds for multi-seed FULL aggregation.
+            If provided, overrides ``seed``.
 
     Returns:
         List of generated CSV filenames.
@@ -592,13 +694,24 @@ def generate_all_tables(
     output_dir.mkdir(parents=True, exist_ok=True)
     generated = []
 
-    # Load available artifacts (deterministic when mode/seed provided)
-    # H2H uses {prefix}_{mode}_{seed}.json naming
-    h2h_battery = _load_json_glob(rung_dir, "h2h_battery", mode=mode, seed=seed)
-    # Comparator CIs use {prefix}_{rung}_{seed}.json naming — extract rung from dir
+    # Resolve seed list
+    seed_list = seeds or ([seed] if seed is not None else [None])
     rung_id = rung_dir.name  # e.g., "r0"
-    comparator_cis = _load_json_glob(
-        rung_dir, "comparator_cis", mode=rung_id, seed=seed
+
+    # Load artifacts for all seeds, then merge
+    h2h_batteries = []
+    comparator_cis_list = []
+    for s in seed_list:
+        h2h = _load_json_glob(rung_dir, "h2h_battery", mode=mode, seed=s)
+        if h2h:
+            h2h_batteries.append(h2h)
+        cis = _load_json_glob(rung_dir, "comparator_cis", mode=rung_id, seed=s)
+        if cis:
+            comparator_cis_list.append(cis)
+
+    h2h_battery = _merge_h2h_batteries(h2h_batteries) if h2h_batteries else None
+    comparator_cis = (
+        _merge_comparator_cis(comparator_cis_list) if comparator_cis_list else None
     )
     roster = _load_json(rung_dir / "roster.json")
 


### PR DESCRIPTION
## Summary
- H2H battery parse now computes per-contract (suit/high/low) metrics alongside pooled
- Table generator emits per-contract rows in h2h_delta_matrix.csv — unblocks H1/H3/H4 hypothesis evaluation
- Table generation supports multi-seed artifact aggregation for FULL mode (seeds via comma-separated CLI arg)
- Orchestrator Step 6 passes all seeds to table generator

## Why
Two features needed before R0 FULL:
1. H1/H3/H4 hypotheses require per-contract H2H faceting (suit/high/low deltas vs anchor)
2. FULL mode runs 3 seeds (42, 123, 456) — table generation must merge artifacts across seeds

## Repro / Validation
```bash
# Tests
uv run python -m pytest tests/unit/test_rung_tables.py tests/unit/test_rung_orchestrator.py -v

# Full validation
make check-quiet

# Post-merge: re-parse existing H2H results to populate per-contract data
uv run python scripts/internal/run_arc_d_h2h_battery.py \
  --mode QUICK --seed 42 --n-per 2500 \
  --output data/artifacts/arc_d_v2/r0/h2h_battery_quick_42.json \
  --roster plans/arc_d_v2/r0/logs/h2h_roster_seed_42.json \
  --parse-run data/runs/arc_d_r0_h2h_battery_42_*/

# Then re-run table generation + advance check
uv run python scripts/internal/generate_rung_tables.py \
  --rung-dir data/artifacts/arc_d_v2/r0 \
  --output-dir docs/04_reports/arc_d_v2/r0/canonical/tables \
  --mode quick --seed 42
```

## Tests
```bash
uv run python -m pytest tests/unit/test_rung_tables.py tests/unit/test_rung_orchestrator.py -v  # 125 passed, 1 skipped
make check-quiet  # All checks passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-h2h-faceting
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-h2h-faceting
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)