### PR TITLE
docs: tiered plan review rubric and plan-reviewer agent definition

### DIFF
--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -1,0 +1,79 @@
+---
+name: plan-reviewer
+description: Reviews plan files against tiered rubric (small/medium/governing). Used as failsafe when Codex CLI is unavailable.
+model: sonnet
+color: blue
+---
+
+You are a plan reviewer. You review plan files against the tiered rubric
+defined in `docs/02_agent/PLAN_REVIEW_TIERS.md`.
+
+## Process
+
+1. **Read the plan file** provided as input.
+2. **Detect the tier** using the classification rules (in order):
+   a. Check the first 10 lines for a frontmatter override: `<!-- review-tier: small|medium|governing -->`
+   b. Check the file path: `plans/<initiative>/` (non-session, non-template) defaults to governing.
+   c. Check content for governing escalation: `## Governing Plan` header, OR (>300 lines AND strong research signals: `## Hypotheses` section, `rung`/`R0`/`R1`/`rung ladder`, `promotion gate`/`ADVANCE`/`HALT`).
+   d. Check content for medium escalation: 4+ file references, multi-PR chain, or >80 lines.
+   e. Default to small.
+3. **Apply the appropriate rubric checks** for the detected tier.
+4. **Return findings** as a JSON array.
+
+## Tier Quick Reference
+
+- **Small** (7 checks): P1, P2, P3, P5, P6, P9, R4
+- **Medium** (15 checks): all Small + P4, P7, P8, P10, P11, P15, R1-R5
+- **Governing** (all Medium + P12, P13, P14 + full 16-dimension weighted rubric + 8 hard gates)
+
+For P8 (sample size) and P11 (hypotheses): auto-detect research intent via
+keywords (`hypothesis`, `statistical`, `bootstrap`, `p-value`, `confidence
+interval`, `sample size`, `n_deals`, `SMOKE`, `QUICK`, `FULL`). SKIP these
+checks for non-research plans.
+
+## Verification Rules
+
+- For **P1 (real paths)**: Use Glob or Read to verify each referenced path exists.
+  New files being created by the plan are exempt — look for language like
+  "create", "new file", or "to be created".
+- For **P2 (real signatures)**: Use Grep to verify referenced function names,
+  class names, and parameter signatures exist in the codebase.
+- For **P3 (seeds)**: Check that any `run_experiment.py`, `run_suite.py`, or
+  data generation commands include `--seed <int>`.
+- For **P8/P11**: First check for research keywords. If none found, mark SKIP
+  and move on. Do not flag non-research plans for missing sample sizes or
+  hypotheses.
+
+## Output Format
+
+Return a JSON-parseable list of findings:
+
+```json
+[
+  {
+    "severity": "CRITICAL|WARNING|INFO",
+    "category": "convention|risk|research",
+    "file": "plans/path/to/plan.md",
+    "line": 42,
+    "description": "Brief description of the issue",
+    "check_id": "P1|P2|P3|P4|P5|P6|P7|P8|P9|P10|P11|P12|P13|P14|P15|R1|R2|R3|R4|R5"
+  }
+]
+```
+
+If no issues found, return: `[]`
+
+## What NOT to Flag
+
+- File paths marked as "new" or "to be created" — these do not exist yet by design.
+- Outcome sections that say "to be filled" — these are completed post-implementation.
+- Plan scope decisions — these are the author's prerogative.
+- Template files in `plans/_templates/` — these contain placeholder values by design.
+- Non-research plans missing P8 (sample size) or P11 (hypotheses) — these are SKIP.
+
+## Context Efficiency
+
+- Read only the plan file and files needed for verification (paths, signatures).
+- Do not read the full governing plan rubric unless the tier is governing.
+- For small plans, limit verification to P1 and P2 spot checks (first 5 paths).
+- Keep total file reads under 10 for small/medium tiers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,8 +79,11 @@ These are **reviewable artifacts**, not "docs-only" PRs. Apply these checks:
 
 Applies to: PRs touching `plans/**`
 
-Use the checks from `/reviewing-plans` (P1-P10, R1-R5). Focus on scope,
-real paths, execution risk, and testing strategy.
+Use the tiered plan review rubric from `docs/02_agent/PLAN_REVIEW_TIERS.md`.
+Classify the plan as small, medium, or governing and apply the corresponding
+checks. For quick reference, the minimum checks (small tier) are: P1 (real
+paths), P2 (real signatures), P3 (seeds), P5 (scope), P6 (testing), P9
+(template), R4 (scope creep).
 
 ## Review Output Format
 

--- a/docs/02_agent/PLAN_REVIEW_RUBRIC.md
+++ b/docs/02_agent/PLAN_REVIEW_RUBRIC.md
@@ -15,6 +15,10 @@ plans.
 - Bugfix or small feature plans
 - Plans with no experimental evaluation component
 
+**Tiered rubric system:** For automated plan review with tier detection
+(small/medium/governing), see `docs/02_agent/PLAN_REVIEW_TIERS.md`.
+The governing tier applies the full rubric from this document.
+
 ## Scoring Model
 
 Score each dimension `0–5`. Multiply by the dimension weight. Normalize to 0–100:

--- a/docs/02_agent/PLAN_REVIEW_TIERS.md
+++ b/docs/02_agent/PLAN_REVIEW_TIERS.md
@@ -1,0 +1,137 @@
+# Tiered Plan Review Rubric
+
+Three-tier rubric for automated plan review. Each plan is classified into a
+tier that determines which checks are applied. Higher tiers include all checks
+from lower tiers.
+
+**Cross-reference:** The governing tier applies the full weighted rubric and
+hard gates from `docs/02_agent/PLAN_REVIEW_RUBRIC.md`.
+
+## Tier Classification
+
+Tiers are determined by the first matching rule (evaluated in order):
+
+1. **Frontmatter override** — `<!-- review-tier: small|medium|governing -->`
+   in the first 10 lines of the file always wins.
+2. **Initiative path** — Files under `plans/<initiative>/` (excluding
+   `plans/sessions/` and `plans/_templates/`) default to **governing**.
+3. **Content escalation to governing** — Plans with a `## Governing Plan`
+   header, OR plans that are both >300 lines AND contain strong research
+   signals, escalate to **governing**. Strong research signals are:
+   - `## Hypotheses` section header
+   - Keywords: `rung`, `R0`, `R1`, `rung ladder`
+   - Keywords: `promotion gate`, `ADVANCE`, `HALT`
+   - Weak signals (`gate`, `SMOKE`, `QUICK`, `FULL` alone) are NOT sufficient.
+4. **Content escalation to medium** — Plans that reference 4+ files, describe
+   a multi-PR chain, or exceed 80 lines escalate to **medium**.
+5. **Default** — Everything else is **small**.
+
+## Small Tier (7 checks)
+
+Applies to: session plans, single-PR bugfixes, small feature plans.
+
+| ID | Check | Category |
+|----|-------|----------|
+| P1 | **Real paths** — All referenced file paths exist on disk (new files being created are exempt) | convention |
+| P2 | **Real signatures** — Referenced function/class names and parameter signatures match the codebase | convention |
+| P3 | **Seeds specified** — Any experiment or data-generation command includes `--seed <int>` | convention |
+| P5 | **Single-concept** — Plan addresses one coherent change (no mixed refactor + feature) | convention |
+| P6 | **Testing strategy** — Plan specifies which tests to run or create | convention |
+| P9 | **Template completeness** — Required template sections are present (Summary, Outcome placeholder) | convention |
+| R4 | **Scope creep** — Plan scope matches the stated goal; no undeclared side-work | risk |
+
+## Medium Tier (15 checks)
+
+Applies to: multi-file changes, multi-PR chains, plans 80-300 lines.
+
+Includes all Small checks plus:
+
+| ID | Check | Category |
+|----|-------|----------|
+| P4 | **Import boundary** — Plan does not introduce `src/` imports from `experiments/` or `tests/` | convention |
+| P7 | **Data contract** — Changes to logging, metrics, or schemas reference the appropriate contract docs | convention |
+| P8 | **Sample size** — Research plans specify sample sizes that meet repo minimums (>=2000 for bias detection, >=50000 for production). **SKIP** for non-research plans. Auto-detect research intent via keywords: `hypothesis`, `statistical`, `bootstrap`, `p-value`, `confidence interval`, `sample size`, `n_deals`, `SMOKE`, `QUICK`, `FULL`. | convention |
+| P10 | **Jupytext** — Notebook changes reference `.py` files (not `.ipynb` directly) and note `make notebook-sync` | convention |
+| P11 | **Hypotheses** — Research plans state testable hypotheses with measurable success criteria. **SKIP** for non-research plans. Auto-detect research intent via the same keywords as P8. | convention |
+| P15 | **Step dependencies** — Multi-step plans annotate what each step requires and produces; independent steps are not unnecessarily serialized | convention |
+| R1 | **Execution risk** — High-risk steps (schema changes, data regeneration, multi-rung experiments) are identified | risk |
+| R2 | **Rollback plan** — Plan describes how to recover if a step fails or produces bad results | risk |
+| R3 | **Dependency chain** — External dependencies (other PRs, data artifacts, model artifacts) are listed | risk |
+| R4 | **Scope creep** — (inherited from Small) | risk |
+| R5 | **Timeline risk** — Plan estimates are realistic given the scope; multi-day work is acknowledged | risk |
+
+## Governing Tier (full rubric)
+
+Applies to: multi-rung research plans, lineage rebuilds, governing plans.
+
+Includes all Medium checks plus:
+
+| ID | Check | Category |
+|----|-------|----------|
+| P12 | **Evaluation economics** — Plan distinguishes SMOKE/QUICK/FULL evidence requirements and justifies expensive runs | research |
+| P13 | **Knowledge transfer** — Plan is self-contained enough for a new agent to execute without repo-wide archaeology | research |
+| P14 | **Failure containment** — Plan defines quarantine/rerun/invalidation rules for bad runs or broken artifacts | research |
+
+Additionally, the governing tier applies:
+
+- **16-dimension weighted rubric** from `docs/02_agent/PLAN_REVIEW_RUBRIC.md`
+  (research validity, agent executability, reporting traceability, etc.)
+- **8 hard gates** from `docs/02_agent/PLAN_REVIEW_RUBRIC.md` (R0* definition,
+  canonical rung definition, executable runbook, fixed metric/table schema,
+  evidence/provenance contract, stable data-generation policy, tooling
+  existence, contract consistency)
+
+A hard gate FAIL overrides the weighted score and produces a **Not Ready**
+verdict regardless of the total.
+
+## Output Schema
+
+All tiers produce findings in a common JSON schema:
+
+```json
+[
+  {
+    "severity": "CRITICAL|WARNING|INFO",
+    "category": "convention|risk|research",
+    "file": "plans/sessions/2026-03-15_example.md",
+    "line": 42,
+    "description": "Referenced path src/bid_euchre/foo/bar.py does not exist",
+    "check_id": "P1"
+  }
+]
+```
+
+If no issues are found, return `[]`.
+
+### Severity Mapping
+
+| Severity | Meaning | Action |
+|----------|---------|--------|
+| **CRITICAL** | Blocks execution or produces incorrect results | Must fix before proceeding |
+| **WARNING** | Risk factor or gap worth addressing | Should fix; may defer with justification |
+| **INFO** | Minor improvement or observation | Note only |
+
+### Check ID to Default Severity
+
+| Check | Default Severity | Override Conditions |
+|-------|-----------------|---------------------|
+| P1 (real paths) | CRITICAL | — |
+| P2 (real signatures) | CRITICAL | — |
+| P3 (seeds) | WARNING | CRITICAL if plan includes experiment comparisons |
+| P4 (import boundary) | CRITICAL | — |
+| P5 (single-concept) | WARNING | — |
+| P6 (testing strategy) | WARNING | CRITICAL for code PRs with no tests mentioned |
+| P7 (data contract) | WARNING | CRITICAL if touching core/ or logging/ |
+| P8 (sample size) | WARNING | SKIP for non-research plans |
+| P9 (template) | INFO | — |
+| P10 (jupytext) | INFO | WARNING if plan creates new notebooks |
+| P11 (hypotheses) | WARNING | SKIP for non-research plans |
+| P12 (eval economics) | WARNING | — |
+| P13 (knowledge transfer) | INFO | — |
+| P14 (failure containment) | WARNING | CRITICAL for multi-rung plans |
+| P15 (step dependencies) | WARNING | — |
+| R1 (execution risk) | WARNING | — |
+| R2 (rollback plan) | INFO | WARNING for irreversible operations |
+| R3 (dependency chain) | WARNING | CRITICAL if dependencies are unmerged PRs |
+| R4 (scope creep) | WARNING | — |
+| R5 (timeline risk) | INFO | — |

--- a/plans/AGENTS.md
+++ b/plans/AGENTS.md
@@ -21,6 +21,21 @@ Codex: when reviewing PRs that touch this directory, apply these checks.
 - Plan scope decisions — these are the author's prerogative, not a review target.
 - Template files in `_templates/` — these contain placeholder values by design.
 
+## Tiered Plan Review
+
+Plans are reviewed at three tiers based on complexity and scope.
+See `docs/02_agent/PLAN_REVIEW_TIERS.md` for the full specification.
+
+| Tier | Scope | Checks |
+|------|-------|--------|
+| Small | <=3 files, single-PR, <80 lines | 7 convention checks (P1,P2,P3,P5,P6,P9,R4) |
+| Medium | 4-10 files, multi-PR, 80-300 lines | 15 convention + 5 risk flags |
+| Governing | Multi-rung/phase, research plans | Full 16-dimension rubric + 8 hard gates |
+
+Codex: when reviewing plan files, classify the plan tier and apply the
+appropriate depth. Default to the existing Plan Audit Checks above for
+any plan that doesn't clearly fit a tier.
+
 ## Plan Hierarchy
 
 For the governing plan framework (governing plans, sub-plans, registries,


### PR DESCRIPTION
## Summary
- Added `docs/02_agent/PLAN_REVIEW_TIERS.md`: three-tier rubric specification (small/medium/governing) with classification heuristics, escalation rules, check tables, output schema, and severity mapping
- Added `.claude/agents/plan-reviewer.md`: Claude agent definition for failsafe plan review when Codex CLI is unavailable
- Updated cross-references in `AGENTS.md`, `plans/AGENTS.md`, and `docs/02_agent/PLAN_REVIEW_RUBRIC.md` to point to the tiered rubric

## Why
Codex needs tier-aware guidance for the new plan review loop. Small session plans should not be evaluated against the full 16-dimension governing rubric. This PR establishes the classification system and check sets for each tier, plus a failsafe agent that can apply the rubric when Codex CLI is unavailable.

## Repro / Validation
```bash
cat docs/02_agent/PLAN_REVIEW_TIERS.md
```

## Tests
```bash
make docs-check   # Passes — no broken path references
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-plan-review-pr1
show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-plan-review-pr1
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)