### PR TITLE
feat: codex plan review adapter with tier detection and Claude failsafe

### DIFF
--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -211,6 +211,7 @@ Every experiment run creates a standardized directory under `data/runs/<run_id>/
 | `scripts/internal/audit_analysis.py` | Review pipeline audit (follow-up rates, corrective PRs) |
 | `scripts/internal/blind_strategy_comparison.py` | Blind strategy comparison for Arc D evaluation (anonymize, rubric, unblind) |
 | `scripts/internal/claude_fix_adapter.py` | Deterministic fix application from Codex findings (auto-fix + commit) |
+| `scripts/internal/codex_plan_review_adapter.py` | Codex CLI plan review adapter (tier detection, plan-scoped invocation, Claude failsafe) |
 | `scripts/internal/codex_review_adapter.py` | Codex CLI invocation and output parsing (review findings extraction) |
 | `scripts/internal/confidence_scorer.py` | Deterministic confidence scoring for P2 review findings (heuristic filtering) |
 | `scripts/internal/deterministic_prechecks.py` | Fast deterministic code checks (merge markers, RNG, imports) |

--- a/scripts/internal/codex_plan_review_adapter.py
+++ b/scripts/internal/codex_plan_review_adapter.py
@@ -1,0 +1,527 @@
+"""Codex CLI plan review adapter -- tier detection and plan-scoped invocation.
+
+Extends the code review adapter for plan file review with:
+- Tier detection (frontmatter override -> heuristic classification)
+- Path-isolated Codex invocation (temp index seeded from main)
+- Claude failsafe (CLAUDE_REVIEW_CMD env var for testing)
+- Plan-specific finding schema (PlanReviewFinding)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import subprocess
+import tempfile
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+logger = logging.getLogger("codex_plan_review_adapter")
+
+# --- Tier Detection ---
+
+# Frontmatter override pattern: <!-- review-tier: small|medium|governing -->
+_TIER_OVERRIDE_RE = re.compile(r"<!--\s*review-tier:\s*(small|medium|governing)\s*-->")
+
+# Strong research signals for governing escalation (rule 3)
+_GOVERNING_SIGNALS = [
+    re.compile(r"^##\s+Hypotheses", re.MULTILINE),  # Section header
+    re.compile(r"\brung\s+ladder\b", re.IGNORECASE),
+    re.compile(r"\b[Rr][0-3]\*?\b"),  # R0, R1, R2, R3, R0*
+    re.compile(r"\bpromotion\s+gate\b", re.IGNORECASE),
+    re.compile(r"\bADVANCE\b"),
+    re.compile(r"\bHALT\b"),
+]
+
+VALID_TIERS = ("small", "medium", "governing")
+
+# Pattern to detect backtick-quoted file paths
+_FILE_REF_RE = re.compile(r"`[a-zA-Z_./][a-zA-Z0-9_./]+\.\w+`")
+
+# Pattern to detect multi-PR references
+_MULTI_PR_RE = re.compile(r"\bmulti-PR\b|\bPR-\d+\b", re.IGNORECASE)
+
+
+@dataclass
+class PlanReviewFinding:
+    """A single finding from plan review (Codex or Claude failsafe)."""
+
+    severity: str  # "CRITICAL", "WARNING", "INFO"
+    category: str  # "convention", "risk", "research"
+    file: str
+    line: int
+    description: str
+    check_id: str | None  # "P1", "P2", "R4", etc.
+    source: str = "codex_cli"  # or "claude_failsafe"
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> PlanReviewFinding:
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+
+@dataclass
+class PlanReviewResult:
+    """Result of a plan review invocation."""
+
+    success: bool
+    findings: list[PlanReviewFinding]
+    tier: str
+    reviewer: str  # "codex_cli" or "claude_failsafe"
+    raw_output: str
+    latency_seconds: float
+    error: str | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "success": self.success,
+            "findings": [f.to_dict() for f in self.findings],
+            "tier": self.tier,
+            "reviewer": self.reviewer,
+            "raw_output": self.raw_output,
+            "latency_seconds": self.latency_seconds,
+            "error": self.error,
+        }
+
+
+def detect_plan_tier(plan_path: Path) -> str:
+    """Classify a plan file into small, medium, or governing tier.
+
+    Tier detection follows the rules in PLAN_REVIEW_TIERS.md:
+    1. Frontmatter override (first 10 lines)
+    2. Initiative path (plans/<initiative>/, not sessions or _templates)
+    3. Content escalation to governing (>300 lines + research signals,
+       or ## Governing Plan header)
+    4. Content escalation to medium (4+ file refs, multi-PR, or >80 lines)
+    5. Default: small
+    """
+    try:
+        content = plan_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        logger.warning("Cannot read plan file %s, defaulting to small", plan_path)
+        return "small"
+
+    lines = content.split("\n")
+
+    # Rule 1: Frontmatter override in first 10 lines
+    header = "\n".join(lines[:10])
+    override_match = _TIER_OVERRIDE_RE.search(header)
+    if override_match:
+        return override_match.group(1)
+
+    # Rule 2: Initiative path detection
+    path_str = str(plan_path)
+    # Normalize to forward slashes for matching
+    path_str_normalized = path_str.replace("\\", "/")
+    # Check if under plans/<initiative>/ but NOT plans/sessions/ or plans/_templates/
+    if "/plans/" in path_str_normalized:
+        # Extract the segment after plans/
+        parts_after_plans = path_str_normalized.split("/plans/", 1)[1]
+        first_segment = (
+            parts_after_plans.split("/")[0] if "/" in parts_after_plans else ""
+        )
+        if first_segment and first_segment not in ("sessions", "_templates"):
+            return "governing"
+
+    # Rule 3: Content escalation to governing
+    line_count = len(lines)
+
+    # Check for ## Governing Plan header
+    if re.search(r"^##\s+Governing\s+Plan\b", content, re.MULTILINE):
+        return "governing"
+
+    # >300 lines AND any strong research signal
+    if line_count > 300:
+        for pattern in _GOVERNING_SIGNALS:
+            if pattern.search(content):
+                return "governing"
+
+    # Rule 4: Content escalation to medium
+    file_refs = _FILE_REF_RE.findall(content)
+    has_multi_pr = bool(_MULTI_PR_RE.search(content))
+
+    if len(file_refs) >= 4 or has_multi_pr or line_count > 80:
+        return "medium"
+
+    # Rule 5: Default
+    return "small"
+
+
+def plan_state_key(plan_path: Path) -> str:
+    """Compute a stable key from the repo-relative path using hashlib.
+
+    Uses SHA-256 of the string path, truncated to 12 hex chars.
+    This ensures different directories with the same basename get different keys.
+    """
+    rel = str(plan_path)  # already repo-relative
+    return hashlib.sha256(rel.encode()).hexdigest()[:12]
+
+
+def invoke_codex_plan_review(
+    plan_path: Path,
+    tier: str,
+    *,
+    base: str = "main",
+    timeout: int = 300,
+    cwd: Path | None = None,
+) -> PlanReviewResult:
+    """Invoke Codex CLI for plan-specific review with path isolation.
+
+    Creates a temp git index seeded from the base branch with only the plan
+    file staged, then invokes ``codex review --base <base>`` against it.
+
+    Args:
+        plan_path: Path to the plan file (repo-relative).
+        tier: Detected plan tier ("small", "medium", "governing").
+        base: Git base ref for the review.
+        timeout: Maximum wait time in seconds.
+        cwd: Working directory (defaults to cwd).
+
+    Returns:
+        PlanReviewResult with parsed findings or error info.
+    """
+    # Lazy import to avoid circular dependency / missing module at import time
+    from codex_review_adapter import (
+        _CLEAN_REVIEW_PATTERNS,
+        _classify_error,
+        _resolve_codex_binary,
+        parse_codex_output,
+    )
+
+    work_dir = cwd or Path.cwd()
+    start = time.monotonic()
+    tmp_index = None
+
+    try:
+        # Create a temp index file seeded from the base branch
+        tmp_fd, tmp_index = tempfile.mkstemp(prefix="plan_review_idx_", suffix=".idx")
+        os.close(tmp_fd)
+
+        env = {**os.environ, "GIT_INDEX_FILE": tmp_index}
+
+        # Seed from base branch
+        subprocess.run(
+            ["git", "read-tree", base],
+            env=env,
+            cwd=work_dir,
+            capture_output=True,
+            check=True,
+            timeout=30,
+        )
+
+        # Stage only the plan file
+        subprocess.run(
+            ["git", "add", str(plan_path)],
+            env=env,
+            cwd=work_dir,
+            capture_output=True,
+            check=True,
+            timeout=30,
+        )
+
+        # Invoke Codex CLI with the isolated index
+        cmd = [*_resolve_codex_binary(), "review", "--base", base]
+        logger.info(
+            "Invoking Codex CLI for plan review (tier=%s, base=%s, file=%s)",
+            tier,
+            base,
+            plan_path,
+        )
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=work_dir,
+            env=env,
+        )
+        elapsed = time.monotonic() - start
+
+        if result.returncode != 0:
+            error_type = _classify_error(result.stderr)
+            logger.warning(
+                "Codex CLI plan review failed (exit %d, %.1fs, %s): %s",
+                result.returncode,
+                elapsed,
+                error_type,
+                result.stderr[:200],
+            )
+            return PlanReviewResult(
+                success=False,
+                findings=[],
+                tier=tier,
+                reviewer="codex_cli",
+                raw_output=result.stdout + result.stderr,
+                latency_seconds=elapsed,
+                error=f"Exit code {result.returncode}: {result.stderr[:200]}",
+            )
+
+        # Parse findings using the shared parser
+        codex_findings = parse_codex_output(result.stdout)
+        plan_findings = _convert_codex_findings(codex_findings, str(plan_path))
+
+        # Fail-safe: unparseable non-empty output
+        if not codex_findings and result.stdout.strip():
+            if not _CLEAN_REVIEW_PATTERNS.search(result.stdout):
+                logger.warning(
+                    "Codex CLI plan review returned unparseable output (%.1fs, %d chars)",
+                    elapsed,
+                    len(result.stdout),
+                )
+                return PlanReviewResult(
+                    success=False,
+                    findings=[],
+                    tier=tier,
+                    reviewer="codex_cli",
+                    raw_output=result.stdout,
+                    latency_seconds=elapsed,
+                    error="Unparseable output: no findings matched and no clean-review signal",
+                )
+
+        logger.info(
+            "Codex CLI plan review completed (%.1fs): %d findings",
+            elapsed,
+            len(plan_findings),
+        )
+        return PlanReviewResult(
+            success=True,
+            findings=plan_findings,
+            tier=tier,
+            reviewer="codex_cli",
+            raw_output=result.stdout,
+            latency_seconds=elapsed,
+        )
+
+    except subprocess.TimeoutExpired:
+        elapsed = time.monotonic() - start
+        logger.warning("Codex CLI plan review timed out after %.1fs", elapsed)
+        return PlanReviewResult(
+            success=False,
+            findings=[],
+            tier=tier,
+            reviewer="codex_cli",
+            raw_output="",
+            latency_seconds=elapsed,
+            error=f"Timeout after {timeout}s",
+        )
+
+    except FileNotFoundError:
+        elapsed = time.monotonic() - start
+        logger.error("Codex CLI not found for plan review")
+        return PlanReviewResult(
+            success=False,
+            findings=[],
+            tier=tier,
+            reviewer="codex_cli",
+            raw_output="",
+            latency_seconds=elapsed,
+            error="Codex CLI not found (codex not in PATH, npx unavailable)",
+        )
+
+    except subprocess.CalledProcessError as exc:
+        elapsed = time.monotonic() - start
+        logger.error("Git command failed during plan review setup: %s", exc)
+        return PlanReviewResult(
+            success=False,
+            findings=[],
+            tier=tier,
+            reviewer="codex_cli",
+            raw_output=str(exc),
+            latency_seconds=elapsed,
+            error=f"Git setup failed: {exc}",
+        )
+
+    finally:
+        if tmp_index and os.path.exists(tmp_index):
+            try:
+                os.unlink(tmp_index)
+            except OSError:
+                pass
+
+
+def invoke_claude_failsafe(
+    plan_path: Path,
+    tier: str,
+    *,
+    timeout: int = 120,
+) -> PlanReviewResult:
+    """Invoke Claude failsafe reviewer when Codex CLI is unavailable.
+
+    Checks ``CLAUDE_REVIEW_CMD`` env var for a test seam. If set, runs
+    that command with plan_path and tier as arguments and parses JSON output.
+    If not set, returns a minimal result indicating no live session available.
+
+    Args:
+        plan_path: Path to the plan file.
+        tier: Detected plan tier.
+        timeout: Maximum wait time in seconds.
+
+    Returns:
+        PlanReviewResult with findings from Claude or a placeholder.
+    """
+    start = time.monotonic()
+    claude_cmd = os.environ.get("CLAUDE_REVIEW_CMD", "").strip()
+
+    if not claude_cmd:
+        elapsed = time.monotonic() - start
+        return PlanReviewResult(
+            success=False,
+            findings=[],
+            tier=tier,
+            reviewer="claude_failsafe",
+            raw_output="",
+            latency_seconds=elapsed,
+            error="CLAUDE_REVIEW_CMD not set -- Claude failsafe requires a live session",
+        )
+
+    try:
+        cmd = [*claude_cmd.split(), str(plan_path), tier]
+        logger.info(
+            "Invoking Claude failsafe (cmd=%s, tier=%s, file=%s)",
+            cmd,
+            tier,
+            plan_path,
+        )
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        elapsed = time.monotonic() - start
+
+        if result.returncode != 0:
+            return PlanReviewResult(
+                success=False,
+                findings=[],
+                tier=tier,
+                reviewer="claude_failsafe",
+                raw_output=result.stdout + result.stderr,
+                latency_seconds=elapsed,
+                error=f"Claude failsafe exited with code {result.returncode}",
+            )
+
+        # Parse JSON output as list of PlanReviewFinding dicts
+        findings = _parse_claude_json_output(result.stdout)
+
+        return PlanReviewResult(
+            success=True,
+            findings=findings,
+            tier=tier,
+            reviewer="claude_failsafe",
+            raw_output=result.stdout,
+            latency_seconds=elapsed,
+        )
+
+    except subprocess.TimeoutExpired:
+        elapsed = time.monotonic() - start
+        return PlanReviewResult(
+            success=False,
+            findings=[],
+            tier=tier,
+            reviewer="claude_failsafe",
+            raw_output="",
+            latency_seconds=elapsed,
+            error=f"Claude failsafe timed out after {timeout}s",
+        )
+
+    except (FileNotFoundError, OSError) as exc:
+        elapsed = time.monotonic() - start
+        return PlanReviewResult(
+            success=False,
+            findings=[],
+            tier=tier,
+            reviewer="claude_failsafe",
+            raw_output="",
+            latency_seconds=elapsed,
+            error=f"Claude failsafe command failed: {exc}",
+        )
+
+
+def parse_plan_findings(
+    raw_output: str,
+    source: str = "codex_cli",
+) -> list[PlanReviewFinding]:
+    """Parse raw Codex CLI output into PlanReviewFinding objects.
+
+    Reuses ``parse_codex_output`` from the code review adapter, then
+    converts each ``CodexFinding`` to a ``PlanReviewFinding``.
+
+    Args:
+        raw_output: Raw stdout from Codex CLI.
+        source: Source label for the findings.
+
+    Returns:
+        List of PlanReviewFinding objects.
+    """
+    from codex_review_adapter import parse_codex_output
+
+    codex_findings = parse_codex_output(raw_output)
+    return _convert_codex_findings(codex_findings, source=source)
+
+
+# --- Internal helpers ---
+
+# Severity mapping from Codex P-levels to plan review severity
+_CODEX_TO_PLAN_SEVERITY = {
+    "P0": "CRITICAL",
+    "P1": "WARNING",
+    "P2": "INFO",
+}
+
+
+def _convert_codex_findings(
+    codex_findings: list,
+    plan_file: str = "",
+    *,
+    source: str = "codex_cli",
+) -> list[PlanReviewFinding]:
+    """Convert CodexFinding objects to PlanReviewFinding objects."""
+    results = []
+    for cf in codex_findings:
+        results.append(
+            PlanReviewFinding(
+                severity=_CODEX_TO_PLAN_SEVERITY.get(cf.severity, "INFO"),
+                category=cf.category,
+                file=cf.file or plan_file,
+                line=cf.line,
+                description=cf.message,
+                check_id=cf.check_id,
+                source=source,
+            )
+        )
+    return results
+
+
+def _parse_claude_json_output(raw_output: str) -> list[PlanReviewFinding]:
+    """Parse JSON output from Claude failsafe command.
+
+    Expects a JSON array of objects matching the PlanReviewFinding schema.
+    """
+    try:
+        data = json.loads(raw_output.strip())
+    except (json.JSONDecodeError, ValueError):
+        logger.warning("Claude failsafe output is not valid JSON")
+        return []
+
+    if not isinstance(data, list):
+        logger.warning("Claude failsafe output is not a JSON array")
+        return []
+
+    findings = []
+    for item in data:
+        if isinstance(item, dict):
+            try:
+                item.setdefault("source", "claude_failsafe")
+                findings.append(PlanReviewFinding.from_dict(item))
+            except (TypeError, KeyError) as exc:
+                logger.warning("Skipping malformed finding: %s (%s)", item, exc)
+    return findings

--- a/scripts/internal/review_state.py
+++ b/scripts/internal/review_state.py
@@ -277,3 +277,129 @@ def save_state(loop_state: ReviewLoopState, base: Path | None = None) -> Path:
     with open(path, "w") as f:
         json.dump(loop_state.to_dict(), f, indent=2)
     return path
+
+
+# --- Plan Review State ---
+
+
+class PlanReviewState(str, enum.Enum):
+    """States in the plan review loop state machine."""
+
+    INITIALIZED = "initialized"
+    CODEX_REVIEWING = "codex_reviewing"
+    FINDINGS_RECEIVED = "findings_received"
+    CLAUDE_FIXING = "claude_fixing"
+    CODEX_FALLBACK = "codex_fallback"
+    CLAUDE_FALLBACK_REVIEWING = "claude_fallback_reviewing"
+    REVIEW_COMPLETE = "review_complete"
+    REVIEW_COMPLETE_WITH_ISSUES = "review_complete_with_issues"
+
+
+PLAN_REVIEW_VALID_TRANSITIONS: dict[PlanReviewState, list[PlanReviewState]] = {
+    PlanReviewState.INITIALIZED: [PlanReviewState.CODEX_REVIEWING],
+    PlanReviewState.CODEX_REVIEWING: [
+        PlanReviewState.FINDINGS_RECEIVED,
+        PlanReviewState.CODEX_FALLBACK,
+    ],
+    PlanReviewState.FINDINGS_RECEIVED: [
+        PlanReviewState.CLAUDE_FIXING,
+        PlanReviewState.REVIEW_COMPLETE,
+        PlanReviewState.REVIEW_COMPLETE_WITH_ISSUES,
+    ],
+    PlanReviewState.CLAUDE_FIXING: [
+        PlanReviewState.CODEX_REVIEWING,  # re-review after fix
+    ],
+    PlanReviewState.CODEX_FALLBACK: [
+        PlanReviewState.CLAUDE_FALLBACK_REVIEWING,
+    ],
+    PlanReviewState.CLAUDE_FALLBACK_REVIEWING: [
+        PlanReviewState.FINDINGS_RECEIVED,
+    ],
+    PlanReviewState.REVIEW_COMPLETE: [],
+    PlanReviewState.REVIEW_COMPLETE_WITH_ISSUES: [],
+}
+
+PLAN_REVIEW_TERMINAL_STATES = frozenset(
+    s for s, targets in PLAN_REVIEW_VALID_TRANSITIONS.items() if not targets
+)
+
+
+@dataclass
+class PlanReviewLoopState:
+    """Persisted state for one plan's review loop."""
+
+    plan_path: str
+    state_key: str  # hash of plan_path for directory naming
+    tier: str  # "small", "medium", "governing"
+    state: str = PlanReviewState.INITIALIZED.value
+    iteration_count: int = 0
+    max_iterations: int = 5
+    last_findings_hash: str | None = None
+    fallback_used: bool = False
+    fallback_reason: str | None = None
+    started_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+    stop_reason: str | None = None
+
+    @property
+    def current_state(self) -> PlanReviewState:
+        return PlanReviewState(self.state)
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.current_state in PLAN_REVIEW_TERMINAL_STATES
+
+    def transition(self, new_state: PlanReviewState) -> None:
+        """Advance to a new state, validating the transition."""
+        current = self.current_state
+        if current in PLAN_REVIEW_TERMINAL_STATES:
+            raise InvalidTransitionError(
+                f"Cannot transition from terminal state {current.value}"
+            )
+        valid = set(PLAN_REVIEW_VALID_TRANSITIONS.get(current, []))
+        # Global: any non-terminal can go to terminal
+        valid |= PLAN_REVIEW_TERMINAL_STATES
+        if new_state not in valid:
+            raise InvalidTransitionError(
+                f"Invalid plan review transition: {current.value} -> {new_state.value}. "
+                f"Valid targets: {sorted(s.value for s in valid)}"
+            )
+        self.state = new_state.value
+        self.updated_at = time.time()
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PlanReviewLoopState:
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+
+def plan_review_state_dir(state_key: str, base: Path | None = None) -> Path:
+    """Return the state directory for a plan's review loop."""
+    if base is None:
+        base = Path(".claude/runtime/plan_reviews")
+    return base / state_key
+
+
+def load_plan_review_state(
+    state_key: str, base: Path | None = None
+) -> PlanReviewLoopState | None:
+    """Load persisted plan review state from disk."""
+    path = plan_review_state_dir(state_key, base) / "state.json"
+    if not path.exists():
+        return None
+    with open(path) as f:
+        return PlanReviewLoopState.from_dict(json.load(f))
+
+
+def save_plan_review_state(
+    loop_state: PlanReviewLoopState, base: Path | None = None
+) -> Path:
+    """Save plan review state to disk, creating directories as needed."""
+    directory = plan_review_state_dir(loop_state.state_key, base)
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / "state.json"
+    with open(path, "w") as f:
+        json.dump(loop_state.to_dict(), f, indent=2)
+    return path

--- a/tests/unit/test_codex_plan_review_adapter.py
+++ b/tests/unit/test_codex_plan_review_adapter.py
@@ -1,0 +1,312 @@
+"""Tests for codex plan review adapter -- tier detection, output parsing, and failsafe."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Add scripts/internal to path for imports
+sys.path.insert(
+    0, str(Path(__file__).resolve().parent.parent.parent / "scripts" / "internal")
+)
+
+from codex_plan_review_adapter import (
+    PlanReviewFinding,
+    detect_plan_tier,
+    parse_plan_findings,
+    plan_state_key,
+)
+
+# --- Tier Detection Tests ---
+
+
+class TestTierOverrideFrontmatter:
+    """Test that frontmatter override always wins."""
+
+    def test_tier_override_frontmatter_small(self, tmp_path: Path) -> None:
+        plan = tmp_path / "test.md"
+        plan.write_text("<!-- review-tier: small -->\n# Big Plan\n" + "x\n" * 500)
+        assert detect_plan_tier(plan) == "small"
+
+    def test_tier_override_frontmatter_governing(self, tmp_path: Path) -> None:
+        plan = tmp_path / "test.md"
+        plan.write_text("<!-- review-tier: governing -->\n# Tiny Plan\n")
+        assert detect_plan_tier(plan) == "governing"
+
+    def test_tier_override_frontmatter_medium(self, tmp_path: Path) -> None:
+        plan = tmp_path / "test.md"
+        plan.write_text("# Header\n<!-- review-tier: medium -->\nShort plan.\n")
+        assert detect_plan_tier(plan) == "medium"
+
+    def test_override_not_in_first_10_lines_ignored(self, tmp_path: Path) -> None:
+        """Override past line 10 is not detected; file is >80 lines so medium."""
+        plan = tmp_path / "test.md"
+        content = "\n".join([f"Line {i}" for i in range(85)])
+        content += "\n<!-- review-tier: governing -->\n"
+        plan.write_text(content)
+        # Should NOT be governing since override is past line 10
+        # But >80 lines triggers medium
+        assert detect_plan_tier(plan) == "medium"
+
+
+class TestTierInitiativePath:
+    """Test initiative path detection."""
+
+    def test_tier_initiative_path(self, tmp_path: Path) -> None:
+        initiative_dir = tmp_path / "plans" / "arc_d_v2"
+        initiative_dir.mkdir(parents=True)
+        plan = initiative_dir / "foo.md"
+        plan.write_text("# Some plan\n")
+        assert detect_plan_tier(plan) == "governing"
+
+    def test_tier_templates_excluded(self, tmp_path: Path) -> None:
+        """plans/_templates/ should NOT be treated as governing."""
+        template_dir = tmp_path / "plans" / "_templates"
+        template_dir.mkdir(parents=True)
+        plan = template_dir / "foo.md"
+        plan.write_text("# Template\n")
+        assert detect_plan_tier(plan) == "small"
+
+    def test_tier_sessions_not_governing(self, tmp_path: Path) -> None:
+        """plans/sessions/ should NOT be treated as governing."""
+        session_dir = tmp_path / "plans" / "sessions"
+        session_dir.mkdir(parents=True)
+        plan = session_dir / "2026-03-15_test.md"
+        plan.write_text("# Short session plan\n")
+        assert detect_plan_tier(plan) == "small"
+
+
+class TestTierContentEscalation:
+    """Test content-based tier escalation."""
+
+    def test_tier_session_short(self, tmp_path: Path) -> None:
+        """Short (<80 lines) plan in sessions/ -> small."""
+        session_dir = tmp_path / "plans" / "sessions"
+        session_dir.mkdir(parents=True)
+        plan = session_dir / "short.md"
+        plan.write_text("# Short Plan\n\nJust a few lines.\n")
+        assert detect_plan_tier(plan) == "small"
+
+    def test_tier_session_medium(self, tmp_path: Path) -> None:
+        """100 lines with 5 file references -> medium."""
+        session_dir = tmp_path / "plans" / "sessions"
+        session_dir.mkdir(parents=True)
+        plan = session_dir / "medium.md"
+        content = "# Medium Plan\n\n"
+        content += (
+            "Files: `src/a.py`, `src/b.py`, `src/c.py`, `src/d.py`, `src/e.py`\n\n"
+        )
+        content += "x\n" * 100
+        plan.write_text(content)
+        assert detect_plan_tier(plan) == "medium"
+
+    def test_tier_session_large_no_research(self, tmp_path: Path) -> None:
+        """350 lines, no research signals -> medium (NOT governing)."""
+        session_dir = tmp_path / "plans" / "sessions"
+        session_dir.mkdir(parents=True)
+        plan = session_dir / "large.md"
+        content = "# Large Refactor Plan\n\n"
+        content += "This plan covers a large refactoring effort.\n"
+        content += "x\n" * 350
+        plan.write_text(content)
+        assert detect_plan_tier(plan) == "medium"
+
+    def test_tier_session_large_with_research(self, tmp_path: Path) -> None:
+        """350 lines + '## Hypotheses' section -> governing."""
+        session_dir = tmp_path / "plans" / "sessions"
+        session_dir.mkdir(parents=True)
+        plan = session_dir / "research.md"
+        content = "# Research Plan\n\n"
+        content += "## Hypotheses\n\n"
+        content += "H1: Model capacity matters more than label quality.\n"
+        content += "x\n" * 350
+        plan.write_text(content)
+        assert detect_plan_tier(plan) == "governing"
+
+    def test_tier_governing_header(self, tmp_path: Path) -> None:
+        """Plan with ## Governing Plan header -> governing."""
+        plan = tmp_path / "test.md"
+        plan.write_text("# Arc E\n\n## Governing Plan\n\nPhase 1...\n")
+        assert detect_plan_tier(plan) == "governing"
+
+    def test_tier_rung_ladder_signal(self, tmp_path: Path) -> None:
+        """>300 lines + 'rung ladder' keyword -> governing."""
+        plan = tmp_path / "test.md"
+        content = "# Plan\n\nThe rung ladder defines progression.\n"
+        content += "x\n" * 310
+        plan.write_text(content)
+        assert detect_plan_tier(plan) == "governing"
+
+    def test_tier_promotion_gate_signal(self, tmp_path: Path) -> None:
+        """>300 lines + 'promotion gate' keyword -> governing."""
+        plan = tmp_path / "test.md"
+        content = "# Plan\n\nThe promotion gate checks quality.\n"
+        content += "x\n" * 310
+        plan.write_text(content)
+        assert detect_plan_tier(plan) == "governing"
+
+    def test_tier_multi_pr_medium(self, tmp_path: Path) -> None:
+        """Short plan with PR-1, PR-2 references -> medium."""
+        plan = tmp_path / "test.md"
+        plan.write_text("# Plan\n\nPR-1 adds adapter. PR-2 adds tests.\n")
+        assert detect_plan_tier(plan) == "medium"
+
+    def test_tier_over_80_lines_medium(self, tmp_path: Path) -> None:
+        """Plan with >80 lines but no research signals -> medium."""
+        plan = tmp_path / "test.md"
+        content = "# Plan\n" + "x\n" * 85
+        plan.write_text(content)
+        assert detect_plan_tier(plan) == "medium"
+
+    def test_tier_unreadable_file(self, tmp_path: Path) -> None:
+        """Unreadable file defaults to small."""
+        plan = tmp_path / "nonexistent.md"
+        assert detect_plan_tier(plan) == "small"
+
+
+# --- State Key Tests ---
+
+
+class TestPlanStateKey:
+    """Test plan_state_key for stability and uniqueness."""
+
+    def test_state_key_different_paths(self) -> None:
+        k1 = plan_state_key(Path("plans/arc_d_v2/plan.md"))
+        k2 = plan_state_key(Path("plans/browser_game/plan.md"))
+        assert k1 != k2
+
+    def test_state_key_same_path_stable(self) -> None:
+        p = Path("plans/sessions/2026-03-15_test.md")
+        k1 = plan_state_key(p)
+        k2 = plan_state_key(p)
+        assert k1 == k2
+
+    def test_state_key_same_basename_different_dirs(self) -> None:
+        k1 = plan_state_key(Path("plans/arc_d_v2/amendments.md"))
+        k2 = plan_state_key(Path("plans/browser_game/amendments.md"))
+        assert k1 != k2
+
+    def test_state_key_length(self) -> None:
+        """Key should be exactly 12 hex chars."""
+        k = plan_state_key(Path("plans/test.md"))
+        assert len(k) == 12
+        assert all(c in "0123456789abcdef" for c in k)
+
+
+# --- Output Parsing Tests ---
+
+
+class TestParsePlanFindings:
+    """Test parse_plan_findings with standard Codex output."""
+
+    def test_parse_standard_findings(self) -> None:
+        output = (
+            "[P1] plans/test.md:42 -- Missing seed in experiment command (P3)\n"
+            "[P0] plans/test.md:10 -- Referenced path does not exist (P1)\n"
+        )
+        findings = parse_plan_findings(output)
+        assert len(findings) == 2
+        assert findings[0].severity == "WARNING"  # P1 -> WARNING
+        assert findings[1].severity == "CRITICAL"  # P0 -> CRITICAL
+
+    def test_parse_clean_review(self) -> None:
+        findings = parse_plan_findings("No issues found.")
+        assert findings == []
+
+    def test_parse_empty_output(self) -> None:
+        findings = parse_plan_findings("")
+        assert findings == []
+
+    def test_parsed_findings_have_source(self) -> None:
+        output = "[P2] plans/test.md:5 -- Convention issue\n"
+        findings = parse_plan_findings(output, source="test_source")
+        assert len(findings) == 1
+        assert findings[0].source == "test_source"
+
+
+# --- Finding Dataclass Tests ---
+
+
+class TestPlanReviewFinding:
+    """Test PlanReviewFinding serialization."""
+
+    def test_finding_to_dict_roundtrip(self) -> None:
+        original = PlanReviewFinding(
+            severity="WARNING",
+            category="convention",
+            file="plans/test.md",
+            line=42,
+            description="Missing seed in experiment command",
+            check_id="P3",
+            source="codex_cli",
+        )
+        d = original.to_dict()
+        restored = PlanReviewFinding.from_dict(d)
+        assert restored.severity == original.severity
+        assert restored.category == original.category
+        assert restored.file == original.file
+        assert restored.line == original.line
+        assert restored.description == original.description
+        assert restored.check_id == original.check_id
+        assert restored.source == original.source
+
+    def test_finding_from_dict_ignores_unknown(self) -> None:
+        data = {
+            "severity": "INFO",
+            "category": "risk",
+            "file": "test.md",
+            "line": 1,
+            "description": "test",
+            "check_id": None,
+            "source": "test",
+            "unknown_field": "ignored",
+        }
+        finding = PlanReviewFinding.from_dict(data)
+        assert finding.description == "test"
+
+    def test_finding_default_source(self) -> None:
+        finding = PlanReviewFinding(
+            severity="INFO",
+            category="convention",
+            file="test.md",
+            line=1,
+            description="test",
+            check_id=None,
+        )
+        assert finding.source == "codex_cli"
+
+    def test_finding_to_dict_all_fields(self) -> None:
+        finding = PlanReviewFinding(
+            severity="CRITICAL",
+            category="research",
+            file="plans/foo.md",
+            line=99,
+            description="Sample size below minimum",
+            check_id="P8",
+            source="claude_failsafe",
+        )
+        d = finding.to_dict()
+        assert d["severity"] == "CRITICAL"
+        assert d["category"] == "research"
+        assert d["file"] == "plans/foo.md"
+        assert d["line"] == 99
+        assert d["description"] == "Sample size below minimum"
+        assert d["check_id"] == "P8"
+        assert d["source"] == "claude_failsafe"
+
+    def test_finding_json_roundtrip(self) -> None:
+        """Verify JSON serialization roundtrip."""
+        original = PlanReviewFinding(
+            severity="WARNING",
+            category="risk",
+            file="plans/test.md",
+            line=10,
+            description="Rollback plan missing",
+            check_id="R2",
+            source="codex_cli",
+        )
+        json_str = json.dumps(original.to_dict())
+        restored = PlanReviewFinding.from_dict(json.loads(json_str))
+        assert restored.severity == original.severity
+        assert restored.check_id == original.check_id


### PR DESCRIPTION
## Summary
- Add `scripts/internal/codex_plan_review_adapter.py` — plan-specific Codex CLI adapter with tier detection (frontmatter override, initiative path, content heuristics), path-isolated invocation via temp git index, Claude failsafe via `CLAUDE_REVIEW_CMD` env var, and `PlanReviewFinding`/`PlanReviewResult` dataclasses
- Extend `scripts/internal/review_state.py` with `PlanReviewState` enum, `PlanReviewLoopState` dataclass, valid transition map, and plan review state persistence (`load_plan_review_state`/`save_plan_review_state`)
- Add 30 unit tests in `tests/unit/test_codex_plan_review_adapter.py` covering tier detection (11 tests), state keys (4 tests), output parsing (4 tests), and finding serialization (5 tests)

## Why
Needed for the plan review loop (PR-3). This PR provides the adapter layer that detects plan tiers per `docs/02_agent/PLAN_REVIEW_TIERS.md`, invokes Codex CLI with path isolation, falls back to Claude when Codex is unavailable, and manages plan review state.

## Dependency
Builds on PR #695 (merged) which added `PLAN_REVIEW_TIERS.md` and `.claude/agents/plan-reviewer.md`.

## Repro / Validation
```bash
cd .claude/worktrees/agent-plan-review-pr2
uv run python -m pytest tests/unit/test_codex_plan_review_adapter.py -v
# 30 passed in 0.11s

uv run python -m pytest tests/unit/test_review_state.py tests/unit/test_codex_review_adapter.py -v
# 77 passed (47 existing review_state + 30 existing codex_review_adapter) in 0.12s

make check-quiet
# ✓ All checks passed
```

## Tests
- `uv run python -m pytest tests/unit/test_codex_plan_review_adapter.py -v` — 30 tests
- `uv run python -m pytest tests/unit/test_review_state.py -v` — 47 tests (no regressions)
- `uv run python -m pytest tests/unit/test_codex_review_adapter.py -v` — 30 tests (no regressions)
- `make check-quiet` — all checks passed

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-plan-review-pr2
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-plan-review-pr2
Branch: plan-review-pr2-adapter
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)