### PR TITLE
feat: /review-plan skill wiring, integration tests, and auto-trigger removal

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -77,23 +77,16 @@ Then restart your Claude session in that directory.
 - This text is injected into Claude's conversation context on the next turn
 - The directive instructs Claude to invoke the skill without waiting for user input
 
-### `post-plan-review.sh` (PostToolUse)
+### `post-plan-review.sh` (DEPRECATED)
 
-**Trigger:** After any Write tool call
+**Status:** Deprecated -- no longer triggers automatically.
 
-**Purpose:** Auto-invokes `/reviewing-plans` skill after plan file creation
+**Replacement:** Use `/review-plan [path]` for manual plan review with
+independent Codex CLI + Claude agent reviewers.
 
-**Behavior:**
-1. Extracts `tool_input.file_path` from the Write tool's JSON input
-2. Checks if the path matches `*/plans/*.md` (excludes `TEMPLATE.md`)
-3. If yes: emits `additionalContext` directive triggering `/reviewing-plans`
-4. The skill reviews the plan against repo conventions and flags implementation risks
-
-**Configuration:** Registered in `.claude/settings.json` under `PostToolUse` with matcher `"Write"`.
-
-**Review checks:** 10 convention checks (P1-P10) covering code-first planning, determinism, scope,
-testing strategy, and template completeness. 5 risk flags (R1-R5) for circular imports, stale data,
-missing exports, scope creep, and gate semantics. See `.claude/skills/reviewing-plans/SKILL.md`.
+**History:** Previously auto-invoked `/reviewing-plans` after plan file
+creation. Replaced by the independent plan review loop (PR-4 of the
+plan review agent chain).
 
 ## Helper Script
 
@@ -129,7 +122,7 @@ Hooks are registered across two files:
 
 **`.claude/settings.json`** (committed, shared):
 - `SessionStart` → `compact-context.sh`
-- `PostToolUse` (Write) → `post-plan-review.sh`
+- `PostToolUse` (Write) → `post-write-check.sh`
 
 **`.claude/settings.local.json`** (gitignored, per-machine):
 - `SessionStart` → `worktree-reminder.sh`

--- a/.claude/hooks/post-plan-review.sh
+++ b/.claude/hooks/post-plan-review.sh
@@ -1,28 +1,6 @@
 #!/bin/bash
-# PostToolUse hook — triggers /reviewing-plans after plan file creation
-set -euo pipefail
-
-INPUT=$(cat)
-
-# Extract the file path from Write tool input
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')
-
-# Only trigger for plan files under the repo's plans/ directory
-# Exclude TEMPLATE.md to avoid triggering on template creation/edits
-if [[ "$FILE_PATH" == */plans/*.md ]] && \
-   [[ "$FILE_PATH" != *TEMPLATE.md ]] && \
-   [[ "$FILE_PATH" != *.review.md ]]; then
-
-  PLAN_NAME=$(basename "$FILE_PATH" .md)
-
-  cat <<EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PostToolUse",
-    "additionalContext": "A plan file '${PLAN_NAME}' was just created at ${FILE_PATH}. You MUST now invoke the /reviewing-plans skill immediately -- do not wait for the user to ask. Pass the plan file path to the reviewer."
-  }
-}
-EOF
-fi
-
+# PostToolUse hook -- DEPRECATED: plan review auto-trigger removed.
+# Plan review is now manual via /review-plan skill.
+# This file is kept as a no-op to avoid hook registration errors.
+# See: plans/sessions/2026-03-15_independent-plan-review-agent.md
 exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,11 +30,6 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-plan-review.sh",
-            "timeout": 5
-          },
-          {
-            "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-write-check.sh",
             "timeout": 5
           }

--- a/.claude/skills/review-plan/SKILL.md
+++ b/.claude/skills/review-plan/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: review-plan
+description: Runs independent plan review loop with Codex CLI primary reviewer and Claude failsafe. Supports tiered rubrics (small/medium/governing). Manual invocation only.
+---
+
+# /review-plan -- Independent Plan Review
+
+Reviews a plan file using the Codex CLI (primary) with Claude agent fallback.
+Runs up to 5 review iterations with automated fixes between rounds.
+
+## Usage
+
+```
+/review-plan [path]
+/review-plan plans/sessions/2026-03-15_my-plan.md
+/review-plan  # reviews most recently modified plan file
+```
+
+## Process
+
+1. **Identify plan file:**
+   - Use the path from `$ARGUMENTS` if provided
+   - Otherwise find the most recently modified plan: `ls -t plans/sessions/*.md plans/*/*.md 2>/dev/null | grep -v TEMPLATE | grep -v '.review.md' | head -1`
+   - If no plan found, stop: "No plan file found to review."
+
+2. **Run the review loop:**
+   Use the Agent tool to spawn a background plan review agent:
+
+   ```
+   Agent(
+     description="plan review loop",
+     prompt="Run the plan review loop on <plan-path>. Execute: cd <repo-root> && PYTHONPATH=scripts/internal uv run python -c \"
+import sys; sys.path.insert(0, 'scripts/internal')
+from plan_review_driver import run_plan_review_loop
+from pathlib import Path
+result = run_plan_review_loop(Path('<plan-path>'))
+import json; print(json.dumps(result.to_dict(), indent=2))
+\"
+Report the full result back.",
+     run_in_background=true
+   )
+   ```
+
+3. **Report results:**
+   When the agent completes, present the results:
+   - Tier detected
+   - Reviewer used (codex_cli or claude_failsafe)
+   - Iteration count
+   - Verdict (READY / NEEDS_ATTENTION / NOT_READY)
+   - Findings table (if any)
+   - Sidecar file location
+
+## Important Notes
+
+- This is a **manual-only** skill. It is NOT auto-triggered by hooks.
+- The review runs as an independent agent, separate from the plan author.
+- If Codex CLI is unavailable, the Claude failsafe reviewer runs instead and a GitHub issue is created.
+- Results are written to `.claude/runtime/plan_reviews/<hash>/review.md`
+- Tier can be overridden with `<!-- review-tier: small|medium|governing -->` in the plan file.
+- See `docs/02_agent/PLAN_REVIEW_TIERS.md` for the full rubric specification.

--- a/.claude/skills/reviewing-plans/SKILL.md
+++ b/.claude/skills/reviewing-plans/SKILL.md
@@ -1,9 +1,14 @@
 ---
 name: reviewing-plans
-description: Reviews plan files against repo conventions, identifies implementation risks, and flags issues before coding begins. Auto-triggered by PostToolUse hook after plan file creation. Can also be invoked manually with /reviewing-plans <path>.
+description: Reviews plan files against repo conventions, identifies implementation risks, and flags issues before coding begins. DEPRECATED -- use /review-plan instead.
 ---
 
-# /reviewing-plans — Plan Quality Review
+> **Deprecated:** This skill has been superseded by `/review-plan`, which
+> provides independent review via Codex CLI with Claude failsafe. This skill
+> is retained for backward compatibility but is no longer auto-triggered.
+> Use `/review-plan [path]` instead.
+
+# /reviewing-plans -- Plan Quality Review
 
 You are reviewing a plan file before implementation begins. The plan file path is provided in the trigger context or as `$ARGUMENTS`.
 
@@ -12,7 +17,7 @@ You are reviewing a plan file before implementation begins. The plan file path i
 1. Read the plan file at the provided path.
 2. If no path provided, check the most recently modified file in `plans/sessions/` or `plans/`:
    ```bash
-   ls -t plans/sessions/*.md plans/*.md 2>/dev/null | head -1
+   ls -t plans/sessions/*.md plans/*/*.md 2>/dev/null | grep -v TEMPLATE | grep -v '.review.md' | head -1
    ```
 3. If no plan file found, stop: "No plan file found to review."
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Bid Euchre AI Research Framework — a Python framework for deterministic simula
 - **Governed initiatives:** Work belonging to a major initiative uses the governing plan framework. Plans live under `plans/<initiative>/`. See `docs/02_agent/AGENTS.md` section 12 for the plan hierarchy.
 - **Session-scoped work:** For standalone tasks (one-off bugfixes, small features, isolated PRs) that do NOT belong to a governed initiative, save to `plans/sessions/YYYY-MM-DD_<slug>.md`.
 - Every plan file should include an `## Outcome` section (filled after implementation) linking to resulting PR(s) or noting abandonment.
-- A PostToolUse hook auto-triggers `/reviewing-plans` after every plan file creation — see `.claude/hooks/post-plan-review.sh`.
+- Use `/review-plan [path]` for independent plan review with Codex CLI + Claude failsafe.
 
 ### Planning Rules
 

--- a/tests/integration/test_plan_review_loop.py
+++ b/tests/integration/test_plan_review_loop.py
@@ -1,0 +1,401 @@
+"""Integration tests for plan review loop -- end-to-end with mocked Codex CLI.
+
+Tests the full loop including real tier detection, real state key computation,
+and real state persistence. Codex CLI invocation is mocked at the adapter
+boundary since it requires a live git repo with a temp index.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add scripts/internal to path
+sys.path.insert(
+    0, str(Path(__file__).resolve().parent.parent.parent / "scripts" / "internal")
+)
+
+from codex_plan_review_adapter import (
+    PlanReviewFinding,
+    PlanReviewResult,
+    detect_plan_tier,
+    plan_state_key,
+)
+from plan_review_driver import run_plan_review_loop
+from review_state import load_plan_review_state
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_clean_result(tier: str = "small") -> PlanReviewResult:
+    """Create a clean (no findings) PlanReviewResult."""
+    return PlanReviewResult(
+        success=True,
+        findings=[],
+        tier=tier,
+        reviewer="codex_cli",
+        raw_output="No issues found.",
+        latency_seconds=0.1,
+    )
+
+
+def _make_findings_result(
+    findings: list[PlanReviewFinding], tier: str = "small"
+) -> PlanReviewResult:
+    """Create a PlanReviewResult with findings."""
+    return PlanReviewResult(
+        success=True,
+        findings=findings,
+        tier=tier,
+        reviewer="codex_cli",
+        raw_output="[P1] test:1 -- finding",
+        latency_seconds=0.1,
+    )
+
+
+def _make_failed_result(
+    error: str = "Codex not found", tier: str = "small"
+) -> PlanReviewResult:
+    """Create a failed PlanReviewResult."""
+    return PlanReviewResult(
+        success=False,
+        findings=[],
+        tier=tier,
+        reviewer="codex_cli",
+        raw_output="",
+        latency_seconds=0.1,
+        error=error,
+    )
+
+
+def _make_finding(
+    severity: str = "WARNING",
+    description: str = "test finding",
+    check_id: str = "P1",
+) -> PlanReviewFinding:
+    """Create a PlanReviewFinding."""
+    return PlanReviewFinding(
+        severity=severity,
+        category="convention",
+        file="plans/test.md",
+        line=1,
+        description=description,
+        check_id=check_id,
+        source="codex_cli",
+    )
+
+
+def _make_sample_plan(
+    plan_path: Path,
+    *,
+    lines: int = 30,
+    files_ref: int = 2,
+    research: bool = False,
+    tier_override: str | None = None,
+) -> Path:
+    """Create a sample plan file with controllable properties.
+
+    Args:
+        plan_path: Full path where the plan should be written.
+        lines: Approximate number of lines in the plan.
+        files_ref: Number of backtick-quoted file references to include.
+        research: If True, add research signals (## Hypotheses).
+        tier_override: If set, add a frontmatter tier override comment.
+
+    Returns:
+        Path to the created plan file.
+    """
+    plan_path.parent.mkdir(parents=True, exist_ok=True)
+
+    parts: list[str] = []
+
+    if tier_override:
+        parts.append(f"<!-- review-tier: {tier_override} -->")
+
+    parts.append("# Test Plan")
+    parts.append("")
+    parts.append("## Goal")
+    parts.append("Test the plan review system.")
+    parts.append("")
+
+    if research:
+        parts.append("## Hypotheses")
+        parts.append("")
+        parts.append("H1: Model capacity matters more than label quality.")
+        parts.append("")
+
+    # Add file references
+    if files_ref > 0:
+        parts.append("## Files")
+        for i in range(files_ref):
+            parts.append(f"- `src/module_{i}.py`")
+        parts.append("")
+
+    parts.append("## Steps")
+    parts.append("")
+    parts.append("1. Implement the feature.")
+    parts.append("2. Run tests.")
+    parts.append("")
+
+    # Pad to reach desired line count
+    current_lines = len(parts)
+    if lines > current_lines:
+        parts.append("## Details")
+        parts.append("")
+        for i in range(lines - current_lines - 2):
+            parts.append(f"Detail line {i + 1}.")
+
+    content = "\n".join(parts) + "\n"
+    plan_path.write_text(content, encoding="utf-8")
+    return plan_path
+
+
+# ---------------------------------------------------------------------------
+# Tier detection integration
+# ---------------------------------------------------------------------------
+
+
+class TestTierDetectionIntegration:
+    """Integration tests for tier detection with realistic plan structures."""
+
+    def test_small_plan_detected(self, tmp_path: Path) -> None:
+        """Short session plan -> small tier."""
+        plan = _make_sample_plan(tmp_path / "plans" / "sessions" / "test.md", lines=30)
+        assert detect_plan_tier(plan) == "small"
+
+    def test_medium_plan_detected(self, tmp_path: Path) -> None:
+        """100-line plan with 5 file refs -> medium tier."""
+        plan = _make_sample_plan(
+            tmp_path / "plans" / "sessions" / "test.md",
+            lines=100,
+            files_ref=5,
+        )
+        assert detect_plan_tier(plan) == "medium"
+
+    def test_governing_override(self, tmp_path: Path) -> None:
+        """Frontmatter override -> governing regardless of content."""
+        plan = _make_sample_plan(
+            tmp_path / "plans" / "sessions" / "test.md",
+            lines=20,
+            tier_override="governing",
+        )
+        assert detect_plan_tier(plan) == "governing"
+
+    def test_large_tooling_stays_medium(self, tmp_path: Path) -> None:
+        """350-line plan without research signals -> medium (not governing)."""
+        plan = _make_sample_plan(tmp_path / "plans" / "sessions" / "test.md", lines=350)
+        assert detect_plan_tier(plan) == "medium"
+
+    def test_large_research_escalates(self, tmp_path: Path) -> None:
+        """350-line plan with ## Hypotheses -> governing."""
+        plan = _make_sample_plan(
+            tmp_path / "plans" / "sessions" / "test.md",
+            lines=350,
+            research=True,
+        )
+        assert detect_plan_tier(plan) == "governing"
+
+    def test_initiative_path_governing(self, tmp_path: Path) -> None:
+        """plans/arc_d_v2/foo.md -> governing."""
+        plan = _make_sample_plan(tmp_path / "plans" / "arc_d_v2" / "test.md", lines=30)
+        assert detect_plan_tier(plan) == "governing"
+
+
+# ---------------------------------------------------------------------------
+# Plan review loop integration -- real tier detection + real state
+# ---------------------------------------------------------------------------
+
+
+class TestPlanReviewLoopIntegration:
+    """Integration tests for the full plan review loop.
+
+    These use real tier detection and state persistence, mocking only the
+    Codex CLI invocation boundary (invoke_codex_plan_review).
+    """
+
+    def test_clean_review_completes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Clean Codex review -> READY in 1 iteration."""
+        plan = _make_sample_plan(tmp_path / "plans" / "sessions" / "test.md")
+
+        monkeypatch.setattr(
+            "plan_review_driver.invoke_codex_plan_review",
+            lambda *a, **kw: _make_clean_result(),
+        )
+        monkeypatch.setattr(
+            "plan_review_driver.invoke_claude_failsafe",
+            lambda *a, **kw: _make_clean_result(),
+        )
+
+        result = run_plan_review_loop(plan, base_dir=tmp_path / "state")
+
+        assert result.verdict == "READY"
+        assert result.iterations == 1
+        assert result.total_findings == 0
+
+    def test_findings_trigger_stop_without_fix_cmd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Codex finds issues but no CLAUDE_FIX_CMD -> stops after 1 iteration."""
+        plan = _make_sample_plan(tmp_path / "plans" / "sessions" / "test.md")
+        finding = _make_finding(description="Missing seed in command")
+
+        monkeypatch.setattr(
+            "plan_review_driver.invoke_codex_plan_review",
+            lambda *a, **kw: _make_findings_result([finding]),
+        )
+        monkeypatch.setattr(
+            "plan_review_driver.invoke_claude_failsafe",
+            lambda *a, **kw: _make_clean_result(),
+        )
+        # Ensure CLAUDE_FIX_CMD is not set
+        monkeypatch.delenv("CLAUDE_FIX_CMD", raising=False)
+
+        result = run_plan_review_loop(plan, base_dir=tmp_path / "state", max_iter=5)
+
+        assert result.verdict in ("NEEDS_ATTENTION", "NOT_READY")
+        assert result.iterations == 1
+        assert result.total_findings >= 1
+
+    def test_codex_failure_triggers_fallback(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Codex CLI failure -> Claude fallback used."""
+        plan = _make_sample_plan(tmp_path / "plans" / "sessions" / "test.md")
+
+        monkeypatch.setattr(
+            "plan_review_driver.invoke_codex_plan_review",
+            lambda *a, **kw: _make_failed_result("Codex not found"),
+        )
+        monkeypatch.setattr(
+            "plan_review_driver.invoke_claude_failsafe",
+            lambda *a, **kw: _make_clean_result(),
+        )
+        # Mock the fallback issue creation to avoid subprocess calls
+        monkeypatch.setattr(
+            "plan_review_driver._create_fallback_issue",
+            lambda *a, **kw: "https://github.com/test/repo/issues/99",
+        )
+
+        result = run_plan_review_loop(plan, base_dir=tmp_path / "state")
+
+        assert result.fallback_used is True
+        assert result.reviewer == "claude_failsafe"
+        assert result.fallback_issue_url == "https://github.com/test/repo/issues/99"
+
+    def test_sidecar_written(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Review sidecar file is written to state dir."""
+        plan = _make_sample_plan(tmp_path / "plans" / "sessions" / "test.md")
+
+        monkeypatch.setattr(
+            "plan_review_driver.invoke_codex_plan_review",
+            lambda *a, **kw: _make_clean_result(),
+        )
+        monkeypatch.setattr(
+            "plan_review_driver.invoke_claude_failsafe",
+            lambda *a, **kw: _make_clean_result(),
+        )
+
+        result = run_plan_review_loop(plan, base_dir=tmp_path / "state")
+
+        assert result.sidecar_path is not None
+        sidecar = Path(result.sidecar_path)
+        assert sidecar.exists()
+        content = sidecar.read_text()
+        assert "# Plan Review:" in content
+        assert "READY" in content
+
+    def test_state_persisted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """State is saved to disk after loop completes."""
+        plan = _make_sample_plan(tmp_path / "plans" / "sessions" / "test.md")
+
+        monkeypatch.setattr(
+            "plan_review_driver.invoke_codex_plan_review",
+            lambda *a, **kw: _make_clean_result(),
+        )
+        monkeypatch.setattr(
+            "plan_review_driver.invoke_claude_failsafe",
+            lambda *a, **kw: _make_clean_result(),
+        )
+
+        run_plan_review_loop(plan, base_dir=tmp_path / "state")
+
+        key = plan_state_key(plan)
+        state = load_plan_review_state(key, base=tmp_path / "state")
+        assert state is not None
+        assert state.current_state.value in (
+            "review_complete",
+            "review_complete_with_issues",
+        )
+
+    def test_tier_auto_detected_for_medium(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """100-line plan -> medium tier is auto-detected and used."""
+        plan = _make_sample_plan(
+            tmp_path / "plans" / "sessions" / "test.md",
+            lines=100,
+            files_ref=5,
+        )
+
+        monkeypatch.setattr(
+            "plan_review_driver.invoke_codex_plan_review",
+            lambda *a, **kw: _make_clean_result("medium"),
+        )
+        monkeypatch.setattr(
+            "plan_review_driver.invoke_claude_failsafe",
+            lambda *a, **kw: _make_clean_result(),
+        )
+
+        result = run_plan_review_loop(plan, base_dir=tmp_path / "state")
+
+        assert result.tier == "medium"
+        assert result.verdict == "READY"
+
+    def test_tier_auto_detected_for_governing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Initiative-path plan -> governing tier is auto-detected."""
+        plan = _make_sample_plan(tmp_path / "plans" / "arc_d_v2" / "test.md", lines=30)
+
+        monkeypatch.setattr(
+            "plan_review_driver.invoke_codex_plan_review",
+            lambda *a, **kw: _make_clean_result("governing"),
+        )
+        monkeypatch.setattr(
+            "plan_review_driver.invoke_claude_failsafe",
+            lambda *a, **kw: _make_clean_result(),
+        )
+
+        result = run_plan_review_loop(plan, base_dir=tmp_path / "state")
+
+        assert result.tier == "governing"
+        assert result.verdict == "READY"
+
+
+# ---------------------------------------------------------------------------
+# State key collision
+# ---------------------------------------------------------------------------
+
+
+class TestStateKeyCollision:
+    """Test that state keys are unique across different plan paths."""
+
+    def test_different_initiatives_different_keys(self, tmp_path: Path) -> None:
+        """Same basename in different dirs -> different state keys."""
+        p1 = tmp_path / "plans" / "arc_d_v2" / "amendments.md"
+        p2 = tmp_path / "plans" / "browser_game" / "amendments.md"
+        p1.parent.mkdir(parents=True)
+        p2.parent.mkdir(parents=True)
+        p1.write_text("# Amendments A")
+        p2.write_text("# Amendments B")
+        assert plan_state_key(p1) != plan_state_key(p2)


### PR DESCRIPTION
## Plan
`plans/sessions/2026-03-15_independent-plan-review-agent.md` — PR-4 of 4-PR chain

## Summary
- Create `/review-plan` skill for manual plan review invocation with Codex CLI + Claude failsafe
- Add 14 integration tests covering tier detection, loop flow, fallback, sidecar, and state persistence
- Gut `post-plan-review.sh` to a no-op and remove its hook registration from `settings.json`
- Deprecate `/reviewing-plans` skill with notice pointing to `/review-plan`
- Update `CLAUDE.md` and hooks `README.md` to reflect the change

## Why
Completes the 4-PR independent plan review agent chain. Auto-triggering plan reviews
on every Write was noisy and tightly coupled the author agent to the reviewer. The new
`/review-plan` skill gives explicit control — invoke it when you want a review, skip it
when you don't.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/integration/test_plan_review_loop.py -v  # 14 passed
uv run python -m pytest tests/unit/test_codex_plan_review_adapter.py tests/unit/test_plan_review_driver.py -v  # 54 passed
make check-quiet  # All checks passed
```

**Seed (if applicable):** N/A (infrastructure change)

## Tests
- [x] `uv run python -m pytest tests/integration/test_plan_review_loop.py -v` — 14 passed
- [x] `uv run python -m pytest tests/unit/test_codex_plan_review_adapter.py tests/unit/test_plan_review_driver.py -v` — 54 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None (tooling only)
- Runtime impact: None (removes an auto-trigger, adds manual skill)

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a8f0ce40
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a8f0ce40
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre           [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a8f0ce40  [plan-review-pr4-wiring]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)