### PR TITLE
fix: use rung-aware feature set in Step 2 training

### DIFF
--- a/src/bid_euchre/arc_d_v2/orchestration.py
+++ b/src/bid_euchre/arc_d_v2/orchestration.py
@@ -781,7 +781,12 @@ def execute_step_2(state: RunState, seed: int, dry_run: bool = False) -> bool:
         if model_class != "ols":
             cmd.extend(["--model-class", model_class])
 
+        # Rung-aware feature set: at R1+ rungs, upgrade "r0" to "full"
+        # so models get partner/position context features.
+        # "constrained" stays locked (attribution arm, per §5.1).
         feature_set = model.feature_set or "full"
+        if feature_set == "r0" and rung != "r0":
+            feature_set = "full"
         if feature_set != "full":
             cmd.extend(["--feature-set", feature_set])
 


### PR DESCRIPTION
## Summary
- Override feature_set "r0" → "full" at R1+ rungs so models consume partner/position features
- Constrained arm stays locked (attribution, per §5.1)

## Why
R1 QUICK trained all models on hand-only features (39) despite R1 dataset having
partner+position columns (57 total). GBT H2H delta dropped from +1.061 (R0) to
+0.325 (R1) — a configuration error, not a real context effect.

## Tests
```bash
uv run python -m pytest tests/unit/test_rung_orchestrator.py -v  # 100 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)