### PR TITLE
fix: false READY verdict on double reviewer failure and resume crash

### DIFF
--- a/scripts/internal/plan_review_driver.py
+++ b/scripts/internal/plan_review_driver.py
@@ -291,6 +291,17 @@ def run_plan_review_loop(
     # Step 2: Create or load state
     key = plan_state_key(plan_path)
     loop_state = load_plan_review_state(key, base_dir)
+    if loop_state is not None and not loop_state.is_terminal:
+        # Resuming from a non-terminal state. Reset to INITIALIZED so the
+        # loop can cleanly transition to CODEX_REVIEWING. Without this,
+        # restarting from states like CODEX_REVIEWING would raise
+        # InvalidTransitionError because self-transitions are not allowed.
+        logger.info(
+            "Resuming plan review from state %s — resetting to INITIALIZED",
+            loop_state.state,
+        )
+        loop_state.state = PlanReviewState.INITIALIZED.value
+        loop_state.updated_at = time.time()
     if loop_state is None or loop_state.is_terminal:
         loop_state = PlanReviewLoopState(
             plan_path=str(plan_path),
@@ -347,7 +358,24 @@ def run_plan_review_loop(
                 loop_state.transition(PlanReviewState.FINDINGS_RECEIVED)
                 all_findings.append((iteration, current_findings))
             else:
-                # Fallback also produced nothing useful -> complete with issues
+                # Both reviewers failed — this is NOT a clean review.
+                # Inject a synthetic CRITICAL finding so the verdict is NOT_READY
+                # instead of falsely reporting READY.
+                no_review_finding = PlanReviewFinding(
+                    severity="CRITICAL",
+                    category="process",
+                    file=str(plan_path),
+                    line=0,
+                    description=(
+                        "No review completed: both Codex CLI and Claude fallback "
+                        "failed to produce findings. Plan has not been reviewed."
+                    ),
+                    check_id=None,
+                    source="plan_review_driver",
+                )
+                current_findings = [no_review_finding]
+                loop_state.transition(PlanReviewState.FINDINGS_RECEIVED)
+                all_findings.append((iteration, current_findings))
                 loop_state.transition(PlanReviewState.REVIEW_COMPLETE_WITH_ISSUES)
                 loop_state.stop_reason = "Codex and Claude fallback both unavailable"
             save_plan_review_state(loop_state, base_dir)

--- a/tests/unit/test_plan_review_driver.py
+++ b/tests/unit/test_plan_review_driver.py
@@ -366,9 +366,8 @@ class TestCodexFallback:
         result = run_plan_review_loop(plan_file, base_dir=tmp_path)
 
         assert result.fallback_used is True
-        assert (
-            result.verdict == "READY"
-        )  # No findings -> READY (both failed to produce any)
+        assert result.verdict == "NOT_READY"  # Both failed → synthetic CRITICAL finding
+        assert result.total_findings == 1  # Synthetic "no review completed" finding
         assert result.iterations == 1
 
 
@@ -479,6 +478,40 @@ class TestStatePersistence:
     def test_load_nonexistent_returns_none(self, tmp_path: Path) -> None:
         result = load_plan_review_state("nonexistent_key", tmp_path)
         assert result is None
+
+    def test_resume_from_codex_reviewing_resets_to_initialized(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Resuming from CODEX_REVIEWING should not raise InvalidTransitionError.
+
+        The driver resets non-terminal states to INITIALIZED before entering
+        the loop, so a restart from any mid-loop state is safe.
+        """
+        # Pre-save state in CODEX_REVIEWING (simulates interrupted run)
+        key = "resume_test_key"
+        pre_state = PlanReviewLoopState(
+            plan_path="plans/sessions/test.md",
+            state_key=key,
+            tier="small",
+            state=PlanReviewState.CODEX_REVIEWING.value,
+            iteration_count=1,
+        )
+        save_plan_review_state(pre_state, tmp_path)
+
+        plan_file = tmp_path / "plans" / "sessions" / "test.md"
+        plan_file.parent.mkdir(parents=True, exist_ok=True)
+        plan_file.write_text("# Test Plan\n")
+
+        monkeypatch.setattr(
+            "plan_review_driver.invoke_codex_plan_review",
+            lambda *a, **kw: _make_result(success=True, findings=[]),
+        )
+        monkeypatch.setattr("plan_review_driver.detect_plan_tier", lambda p: "small")
+        monkeypatch.setattr("plan_review_driver.plan_state_key", lambda p: key)
+
+        # Should NOT raise InvalidTransitionError
+        result = run_plan_review_loop(plan_file, base_dir=tmp_path)
+        assert result.verdict == "READY"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **P0 fix:** When both Codex CLI and Claude fallback fail, verdict was falsely `READY` (empty findings). Now injects synthetic CRITICAL finding → verdict `NOT_READY`.
- **P1 fix:** Resuming from persisted `CODEX_REVIEWING` state raised `InvalidTransitionError`. Now resets to `INITIALIZED` on resume.
- Updated test to assert `NOT_READY` instead of `READY` on double failure; added resume test.

## Why
Codex post-merge review identified both bugs. The P0 is a safety issue — an unreviewed plan would be reported as clean. The P1 would crash on any interrupted review loop restart.

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_plan_review_driver.py -v --seed 42
uv run python -m pytest tests/integration/test_plan_review_loop.py -v
```

## Tests
- 25 unit tests pass (including 2 new: `test_codex_and_fallback_both_fail` updated, `test_resume_from_codex_reviewing_resets_to_initialized` added)
- 14 integration tests pass

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-plan-review
branch: fix/plan-review-driver-bugs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)