### PR TITLE
fix: accept partner/position features in artifact validation

### DIFF
--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -1732,15 +1732,23 @@ def _validate_artifact_features(
             )
     else:
         # R0/constrained/selected: state features should be a subset of
-        # known hand features (forward selection or constrained arms may
-        # use fewer than 39)
-        hand_set = set(_HAND_FEATURE_NAMES)
-        unknown = [f for f in state_names if f not in hand_set]
+        # known hand features, partner v2 features, and position features.
+        # Forward selection from the full 57-feature set may keep partner
+        # or position features while dropping all positional (legality)
+        # features, so we accept all three categories as valid.
+        from ..features.auction_context import PARTNER_FEATURE_NAMES_V2
+
+        valid_set = (
+            set(_HAND_FEATURE_NAMES)
+            | set(PARTNER_FEATURE_NAMES_V2)
+            | _POSITION_FEATURE_SET
+        )
+        unknown = [f for f in state_names if f not in valid_set]
         if unknown:
             raise ValueError(
                 f"Artifact feature_names structural mismatch. "
                 f"Non-positional model contains unknown state features "
-                f"(not in hand feature set): {unknown}"
+                f"(not in hand/partner/position feature set): {unknown}"
             )
 
         # Verify action features are at the expected positions
@@ -1797,14 +1805,24 @@ def _validate_pass_model_features(
                 f"got {len(pass_feature_names)} features."
             )
     else:
-        # R0/constrained/selected: pass features should be subset of hand
-        hand_set = set(_HAND_FEATURE_NAMES)
-        unknown = [f for f in pass_feature_names if f not in hand_set]
+        # R0/constrained/selected: pass features should be subset of
+        # known hand features, partner v2 features, and position features.
+        # Forward selection from the full feature set may keep partner
+        # or position features while dropping all positional (legality)
+        # features.
+        from ..features.auction_context import PARTNER_FEATURE_NAMES_V2
+
+        valid_set = (
+            set(_HAND_FEATURE_NAMES)
+            | set(PARTNER_FEATURE_NAMES_V2)
+            | _POSITION_FEATURE_SET
+        )
+        unknown = [f for f in pass_feature_names if f not in valid_set]
         if unknown:
             raise ValueError(
                 f"Artifact pass model feature_names mismatch. "
                 f"Non-positional pass model contains unknown features "
-                f"(not in hand feature set): {unknown}"
+                f"(not in hand/partner/position feature set): {unknown}"
             )
 
 

--- a/tests/unit/test_train_action_value.py
+++ b/tests/unit/test_train_action_value.py
@@ -891,3 +891,64 @@ class TestR0HandOnlyFeatureInference:
         bad_features = ["bowers", "UNKNOWN_FEATURE"] + list(ACTION_FEATURE_NAMES)
         with pytest.raises(ValueError, match="unknown state features"):
             _validate_artifact_features(bad_features, has_interactions=False)
+
+    def test_validate_artifact_features_selected_with_partner_v2(self):
+        """Forward-selected model with partner v2 features but no positional validates."""
+        # Simulate forward selection keeping some hand + partner_passed (no positional)
+        selected = ["bowers", "trump_count", "partner_passed"]
+        model_features = selected + list(ACTION_FEATURE_NAMES)
+        partner_names, has_positional = _validate_artifact_features(
+            model_features, has_interactions=False
+        )
+        assert has_positional is False
+        # partner_names inferred as empty because _infer_partner_features
+        # only detects partners when positional features are present
+        assert partner_names == []
+
+    def test_validate_artifact_features_selected_with_position(self):
+        """Forward-selected model with position features but no positional validates."""
+        # Simulate forward selection keeping hand + auction_position (no positional)
+        selected = ["bowers", "trump_count", "auction_position"]
+        model_features = selected + list(ACTION_FEATURE_NAMES)
+        partner_names, has_positional = _validate_artifact_features(
+            model_features, has_interactions=False
+        )
+        assert has_positional is False
+        assert partner_names == []
+
+    def test_validate_artifact_features_selected_with_partner_and_position(self):
+        """Forward-selected model with partner v2 + position features validates."""
+        selected = [
+            "bowers",
+            "trump_count",
+            "partner_passed",
+            "partner_level_high",
+            "auction_position",
+            "is_dealer",
+        ]
+        model_features = selected + list(ACTION_FEATURE_NAMES)
+        partner_names, has_positional = _validate_artifact_features(
+            model_features, has_interactions=False
+        )
+        assert has_positional is False
+        assert partner_names == []
+
+    def test_validate_pass_model_selected_with_partner_v2(self):
+        """Forward-selected pass model with partner v2 features validates."""
+        selected = ["bowers", "trump_count", "partner_passed"]
+        _validate_pass_model_features(
+            selected,
+            partner_feature_names=[],
+            has_interactions=False,
+            has_positional=False,
+        )
+
+    def test_validate_pass_model_selected_with_position(self):
+        """Forward-selected pass model with position features validates."""
+        selected = ["bowers", "auction_position", "is_dealer"]
+        _validate_pass_model_features(
+            selected,
+            partner_feature_names=[],
+            has_interactions=False,
+            has_positional=False,
+        )


### PR DESCRIPTION
## Summary

- Expand valid feature set in `_validate_artifact_features()` and `_validate_pass_model_features()` non-positional paths to include `PARTNER_FEATURE_NAMES_V2` and `_POSITION_FEATURE_SET` alongside `_HAND_FEATURE_NAMES`
- Add 5 new tests covering forward-selected models with partner v2 features, position features, and both combined

## Why

When R1 models train with `--feature-set full` (57 features) and forward selection reduces the feature set, the resulting artifact may contain partner v2 features (e.g., `partner_passed`) or position features (e.g., `auction_position`) without positional/legality features (because forward selection dropped `current_high_bid` and friends). The validation classified these as "non-positional" models and then rejected the partner/position features as unknown, raising `ValueError`.

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_train_action_value.py::TestR0HandOnlyFeatureInference -v -x
```

All 17 tests pass (12 existing + 5 new).

## Tests

```bash
make check-quiet  # All checks pass
uv run python -m pytest tests/unit/test_train_action_value.py tests/unit/test_action_value_bidder.py tests/unit/test_auction_context.py -v -x
# 118 passed, 32 skipped
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-validate-fix
toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-validate-fix
```

## Changed files

- `src/bid_euchre/strategy/bidding.py` — `_validate_artifact_features()` and `_validate_pass_model_features()` non-positional paths
- `tests/unit/test_train_action_value.py` — 5 new tests in `TestR0HandOnlyFeatureInference`