### PR TITLE
fix: bidder inference mapping for R1 forward-selected artifacts

### DIFF
--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -2014,20 +2014,40 @@ class ActionValueBidder(BiddingPolicy):
         )
 
         # For R0/selected models: precompute per-family hand feature indices
-        # so choose_bid() can select the right subset from the full 39 hand features.
+        # so choose_bid() can select the right subset from the full state vector.
+        # R1 forward-selected artifacts may include partner/position features
+        # (e.g., partner_passed) that are not in _HAND_FEATURE_NAMES. When this
+        # happens, map indices against STATE_FEATURE_NAMES (57 features) and
+        # extract the full state vector at inference time.
         self._hand_indices: dict[str, Optional[np.ndarray]] = {}
+        hand_name_set = set(_HAND_FEATURE_NAMES)
         if not self._has_positional:
-            hand_name_to_idx = {n: i for i, n in enumerate(_HAND_FEATURE_NAMES)}
             n_action = len(ACTION_FEATURE_NAMES)
+            # Collect all state feature names to detect non-hand features
+            all_state_names: list[str] = []
+            for family in ("suit", "high", "low"):
+                all_state_names.extend(
+                    self.models[family]["feature_names"][:-(n_action)]
+                )
+            all_state_names.extend(self.pass_model["feature_names"])
+            self._needs_full_state = any(
+                n not in hand_name_set for n in all_state_names
+            )
+
+            if self._needs_full_state:
+                name_to_idx = {n: i for i, n in enumerate(STATE_FEATURE_NAMES)}
+            else:
+                name_to_idx = {n: i for i, n in enumerate(_HAND_FEATURE_NAMES)}
+
             for family in ("suit", "high", "low"):
                 state_names = self.models[family]["feature_names"][:-(n_action)]
                 self._hand_indices[family] = np.array(
-                    [hand_name_to_idx[n] for n in state_names]
+                    [name_to_idx[n] for n in state_names]
                 )
             pass_names = list(self.pass_model["feature_names"])
-            self._hand_indices["pass"] = np.array(
-                [hand_name_to_idx[n] for n in pass_names]
-            )
+            self._hand_indices["pass"] = np.array([name_to_idx[n] for n in pass_names])
+        else:
+            self._needs_full_state = False
 
         if not skip_behavioral_check:
             _check_ols_predictions_sane(
@@ -2035,7 +2055,7 @@ class ActionValueBidder(BiddingPolicy):
                 self.pass_model,
                 self._partner_feature_names,
                 has_interactions=self._has_interactions,
-                include_positional=self._has_positional,
+                include_positional=self._has_positional or self._needs_full_state,
                 hand_indices=self._hand_indices if not self._has_positional else None,
             )
 
@@ -2049,7 +2069,7 @@ class ActionValueBidder(BiddingPolicy):
             contract_family,
             trump_suit,
             partner_feature_names=self._partner_feature_names,
-            include_positional=self._has_positional,
+            include_positional=self._has_positional or self._needs_full_state,
         )
         if not self._has_positional and family in self._hand_indices:
             state = state[self._hand_indices[family]]
@@ -2183,26 +2203,43 @@ class GBTActionValueBidder(BiddingPolicy):
             has_positional=self._has_positional,
         )
 
-        # For R0/selected models: precompute per-family hand feature indices
+        # For R0/selected models: precompute per-family hand feature indices.
+        # R1 forward-selected artifacts may include partner/position features
+        # that are not in _HAND_FEATURE_NAMES — use STATE_FEATURE_NAMES when needed.
         self._hand_indices: dict[str, Optional[np.ndarray]] = {}
+        hand_name_set = set(_HAND_FEATURE_NAMES)
         if not self._has_positional:
-            hand_name_to_idx = {n: i for i, n in enumerate(_HAND_FEATURE_NAMES)}
             n_action = len(ACTION_FEATURE_NAMES)
+            all_state_names: list[str] = []
+            for family in ("suit", "high", "low"):
+                all_state_names.extend(
+                    models_meta[family]["feature_names"][:-(n_action)]
+                )
+            all_state_names.extend(models_meta["pass"]["feature_names"])
+            self._needs_full_state = any(
+                n not in hand_name_set for n in all_state_names
+            )
+
+            if self._needs_full_state:
+                name_to_idx = {n: i for i, n in enumerate(STATE_FEATURE_NAMES)}
+            else:
+                name_to_idx = {n: i for i, n in enumerate(_HAND_FEATURE_NAMES)}
+
             for family in ("suit", "high", "low"):
                 state_names = models_meta[family]["feature_names"][:-(n_action)]
                 self._hand_indices[family] = np.array(
-                    [hand_name_to_idx[n] for n in state_names]
+                    [name_to_idx[n] for n in state_names]
                 )
             pass_names = list(models_meta["pass"]["feature_names"])
-            self._hand_indices["pass"] = np.array(
-                [hand_name_to_idx[n] for n in pass_names]
-            )
+            self._hand_indices["pass"] = np.array([name_to_idx[n] for n in pass_names])
+        else:
+            self._needs_full_state = False
 
         if not skip_behavioral_check:
             _check_gbt_predictions_sane(
                 self.gbt_models,
                 self._partner_feature_names,
-                include_positional=self._has_positional,
+                include_positional=self._has_positional or self._needs_full_state,
                 hand_indices=self._hand_indices if not self._has_positional else None,
             )
 
@@ -2216,7 +2253,7 @@ class GBTActionValueBidder(BiddingPolicy):
             contract_family,
             trump_suit,
             partner_feature_names=self._partner_feature_names,
-            include_positional=self._has_positional,
+            include_positional=self._has_positional or self._needs_full_state,
         )
         if not self._has_positional and family in self._hand_indices:
             state = state[self._hand_indices[family]]
@@ -2369,25 +2406,42 @@ class TwoStageActionValueBidder(BiddingPolicy):
             has_positional=self._has_positional,
         )
 
-        # For R0/selected models: precompute per-family hand feature indices
+        # For R0/selected models: precompute per-family hand feature indices.
+        # R1 forward-selected artifacts may include partner/position features
+        # that are not in _HAND_FEATURE_NAMES — use STATE_FEATURE_NAMES when needed.
         self._hand_indices: dict[str, Optional[np.ndarray]] = {}
+        hand_name_set = set(_HAND_FEATURE_NAMES)
         if not self._has_positional:
-            hand_name_to_idx = {n: i for i, n in enumerate(_HAND_FEATURE_NAMES)}
             n_action = len(ACTION_FEATURE_NAMES)
             # Suit model: feature_names at top level of suit result
+            all_state_names: list[str] = list(suit_feature_names[:-(n_action)])
+            for family in ("high", "low"):
+                all_state_names.extend(
+                    self.models[family]["feature_names"][:-(n_action)]
+                )
+            all_state_names.extend(self.pass_model["feature_names"])
+            self._needs_full_state = any(
+                n not in hand_name_set for n in all_state_names
+            )
+
+            if self._needs_full_state:
+                name_to_idx = {n: i for i, n in enumerate(STATE_FEATURE_NAMES)}
+            else:
+                name_to_idx = {n: i for i, n in enumerate(_HAND_FEATURE_NAMES)}
+
             suit_state_names = suit_feature_names[:-(n_action)]
             self._hand_indices["suit"] = np.array(
-                [hand_name_to_idx[n] for n in suit_state_names]
+                [name_to_idx[n] for n in suit_state_names]
             )
             for family in ("high", "low"):
                 state_names = self.models[family]["feature_names"][:-(n_action)]
                 self._hand_indices[family] = np.array(
-                    [hand_name_to_idx[n] for n in state_names]
+                    [name_to_idx[n] for n in state_names]
                 )
             pass_names = list(self.pass_model["feature_names"])
-            self._hand_indices["pass"] = np.array(
-                [hand_name_to_idx[n] for n in pass_names]
-            )
+            self._hand_indices["pass"] = np.array([name_to_idx[n] for n in pass_names])
+        else:
+            self._needs_full_state = False
 
     def _select_state(
         self, obs: BiddingObservation, family: str, trump_suit: Optional[str]
@@ -2399,7 +2453,7 @@ class TwoStageActionValueBidder(BiddingPolicy):
             contract_family,
             trump_suit,
             partner_feature_names=self._partner_feature_names,
-            include_positional=self._has_positional,
+            include_positional=self._has_positional or self._needs_full_state,
         )
         if not self._has_positional and family in self._hand_indices:
             state = state[self._hand_indices[family]]

--- a/tests/unit/test_action_value_bidder.py
+++ b/tests/unit/test_action_value_bidder.py
@@ -12,6 +12,7 @@ import pytest
 
 from bid_euchre.core.cards import Card
 from bid_euchre.strategy.bidding import (
+    _HAND_FEATURE_NAMES,
     ACTION_FEATURE_NAMES,
     STATE_FEATURE_NAMES,
     ActionValueBidder,
@@ -538,3 +539,150 @@ class TestArtifactGovernance:
             ActionValueBidder(str(path))
 
         assert not any("Low R²" in msg for msg in caplog.messages)
+
+
+# ── R1 forward-selected artifacts (partner features, no positional) ──
+
+
+def _make_forward_selected_features() -> list[str]:
+    """Build a forward-selected feature list: hand subset + partner feature.
+
+    Simulates what forward selection produces when it keeps some hand
+    features and a partner feature (e.g., partner_passed) but drops all
+    positional/legality features.
+    """
+    # Pick a small subset of hand features + one partner feature
+    hand_subset = list(_HAND_FEATURE_NAMES[:10])  # first 10 hand features
+    partner_subset = ["partner_passed"]
+    return hand_subset + partner_subset
+
+
+def _make_forward_selected_ols_artifact(
+    pass_bias: float = 0.0,
+    suit_bias: float = 1.0,
+    high_bias: float = 0.5,
+    low_bias: float = 0.5,
+) -> dict:
+    """Create an action_value_olsa_v1 artifact with forward-selected features.
+
+    The artifact has partner features (partner_passed) but no positional
+    features — simulating R1 forward selection that dropped all
+    positional/legality features.
+    """
+    state_names = _make_forward_selected_features()
+    n_state = len(state_names)
+    n_action = len(ACTION_FEATURE_NAMES)
+
+    def _model(with_action: bool, intercept: float) -> dict:
+        if with_action:
+            feature_names = state_names + list(ACTION_FEATURE_NAMES)
+            n_features = n_state + n_action
+        else:
+            feature_names = list(state_names)
+            n_features = n_state
+        return {
+            "coefficients": [0.0] * n_features,
+            "intercept": intercept,
+            "feature_names": feature_names,
+            "r_squared": 0.50,
+        }
+
+    return {
+        "schema_version": "action_value_olsa_v1",
+        "models": {
+            "suit": _model(True, suit_bias),
+            "high": _model(True, high_bias),
+            "low": _model(True, low_bias),
+            "pass": _model(False, pass_bias),
+        },
+        "metadata": {
+            "context_features": ["partner_passed"],
+            "arm": "full",
+        },
+    }
+
+
+class TestForwardSelectedArtifact:
+    """Test that R1 forward-selected artifacts with partner features
+    but no positional features load and run correctly."""
+
+    def test_ols_loads_with_partner_features(self, tmp_path):
+        """ActionValueBidder loads artifact with partner features, no positional."""
+        artifact = _make_forward_selected_ols_artifact()
+        path = tmp_path / "forward_selected.json"
+        path.write_text(json.dumps(artifact))
+
+        bidder = ActionValueBidder(str(path), skip_behavioral_check=True)
+        assert bidder._needs_full_state is True
+        assert bidder._has_positional is False
+
+    def test_ols_choose_bid_with_partner_features(self, tmp_path):
+        """ActionValueBidder.choose_bid works with forward-selected artifact."""
+        artifact = _make_forward_selected_ols_artifact(pass_bias=-5.0, suit_bias=2.0)
+        path = tmp_path / "forward_selected.json"
+        path.write_text(json.dumps(artifact))
+
+        bidder = ActionValueBidder(str(path), skip_behavioral_check=True)
+        obs = _make_obs(current_high_bid=0)
+        action = bidder.choose_bid(obs)
+        assert isinstance(action, BidAction)
+        # Suit has highest intercept → should pick suit
+        if not action.is_pass():
+            contract_type, _ = action.to_contract_tuple()
+            assert contract_type == "suit"
+
+    def test_ols_hand_only_backward_compat(self, tmp_path):
+        """R0 hand-only artifact still uses _HAND_FEATURE_NAMES mapping."""
+        hand_subset = list(_HAND_FEATURE_NAMES[:15])
+
+        def _model(with_action: bool, intercept: float) -> dict:
+            if with_action:
+                names = hand_subset + list(ACTION_FEATURE_NAMES)
+            else:
+                names = list(hand_subset)
+            return {
+                "coefficients": [0.0] * len(names),
+                "intercept": intercept,
+                "feature_names": names,
+                "r_squared": 0.50,
+            }
+
+        artifact = {
+            "schema_version": "action_value_olsa_v1",
+            "models": {
+                "suit": _model(True, 1.0),
+                "high": _model(True, 0.5),
+                "low": _model(True, 0.5),
+                "pass": _model(False, 0.0),
+            },
+            "metadata": {"context_features": [], "arm": "constrained"},
+        }
+        path = tmp_path / "hand_only.json"
+        path.write_text(json.dumps(artifact))
+
+        bidder = ActionValueBidder(str(path), skip_behavioral_check=True)
+        assert bidder._needs_full_state is False
+        assert bidder._has_positional is False
+
+        obs = _make_obs(current_high_bid=0)
+        action = bidder.choose_bid(obs)
+        assert isinstance(action, BidAction)
+
+    def test_ols_index_mapping_correct(self, tmp_path):
+        """Verify forward-selected indices point to correct STATE_FEATURE_NAMES positions."""
+        artifact = _make_forward_selected_ols_artifact()
+        path = tmp_path / "forward_selected.json"
+        path.write_text(json.dumps(artifact))
+
+        bidder = ActionValueBidder(str(path), skip_behavioral_check=True)
+
+        # The indices should map to positions in STATE_FEATURE_NAMES
+        state_name_to_idx = {n: i for i, n in enumerate(STATE_FEATURE_NAMES)}
+        expected_state = _make_forward_selected_features()
+        expected_indices = [state_name_to_idx[n] for n in expected_state]
+
+        # Suit model's hand_indices should match (state features = expected_state)
+        np.testing.assert_array_equal(
+            bidder._hand_indices["suit"],
+            expected_indices,
+        )

--- a/tests/unit/test_gbt_bidder.py
+++ b/tests/unit/test_gbt_bidder.py
@@ -13,6 +13,8 @@ import pytest
 
 from bid_euchre.core.cards import Card
 from bid_euchre.strategy.bidding import (
+    _HAND_FEATURE_NAMES,
+    ACTION_FEATURE_NAMES,
     STATE_FEATURE_NAMES,
     BidAction,
     BiddingObservation,
@@ -349,3 +351,72 @@ class TestGBTArtifactGovernance:
         assert bidder is not None
         assert any("Low R²" in msg for msg in caplog.messages)
         assert any("suit" in msg for msg in caplog.messages)
+
+
+# ── R1 forward-selected GBT artifact ─────────────────────
+
+
+class TestGBTForwardSelected:
+    """Test that GBTActionValueBidder works with forward-selected artifacts
+    containing partner features but no positional features."""
+
+    def test_gbt_loads_with_partner_features(self, tmp_path):
+        """GBTActionValueBidder loads forward-selected artifact with partner features."""
+        import joblib
+        from sklearn.ensemble import GradientBoostingRegressor
+
+        hand_subset = list(_HAND_FEATURE_NAMES[:10])
+        partner_subset = ["partner_passed"]
+        state_names = hand_subset + partner_subset
+        n_state = len(state_names)
+        n_action = len(ACTION_FEATURE_NAMES)
+
+        # Train tiny GBT models on random data
+        rng = np.random.RandomState(42)
+        X_bid = rng.randn(20, n_state + n_action)
+        X_pass = rng.randn(20, n_state)
+        y = rng.randn(20)
+
+        models_meta = {}
+        for family in ("suit", "high", "low"):
+            model = GradientBoostingRegressor(
+                n_estimators=5, max_depth=2, random_state=42
+            )
+            model.fit(X_bid, y)
+            model_file = f"gbt_{family}.joblib"
+            joblib.dump(model, tmp_path / model_file)
+            models_meta[family] = {
+                "model_file": model_file,
+                "feature_names": state_names + list(ACTION_FEATURE_NAMES),
+                "r_squared": 0.50,
+                "feature_importances": [0.1] * (n_state + n_action),
+            }
+
+        pass_model = GradientBoostingRegressor(
+            n_estimators=5, max_depth=2, random_state=42
+        )
+        pass_model.fit(X_pass, y)
+        joblib.dump(pass_model, tmp_path / "gbt_pass.joblib")
+        models_meta["pass"] = {
+            "model_file": "gbt_pass.joblib",
+            "feature_names": list(state_names),
+            "r_squared": 0.50,
+            "feature_importances": [0.1] * n_state,
+        }
+
+        artifact = {
+            "schema_version": "action_value_gbt_v1",
+            "models": models_meta,
+            "metadata": {"context_features": ["partner_passed"]},
+        }
+        path = tmp_path / "gbt_forward.json"
+        path.write_text(json.dumps(artifact))
+
+        bidder = GBTActionValueBidder(str(path), skip_behavioral_check=True)
+        assert bidder._needs_full_state is True
+        assert bidder._has_positional is False
+
+        # Verify choose_bid works
+        obs = _make_obs(current_high_bid=0)
+        action = bidder.choose_bid(obs)
+        assert isinstance(action, BidAction)

--- a/tests/unit/test_two_stage_bidder.py
+++ b/tests/unit/test_two_stage_bidder.py
@@ -8,9 +8,13 @@ import math
 import numpy as np
 import pytest
 
+from bid_euchre.core.cards import Card
 from bid_euchre.strategy.bidding import (
+    _HAND_FEATURE_NAMES,
     ACTION_FEATURE_NAMES,
     STATE_FEATURE_NAMES,
+    BidAction,
+    BiddingObservation,
     TwoStageActionValueBidder,
     predict_logistic,
     predict_ols,
@@ -386,3 +390,134 @@ class TestTwoStagePredictionPaths:
         # Manual: 52 features * 0.01 coef * 0.1 input + (-1.0) intercept
         expected = N_STATE * 0.01 * 0.1 + (-1.0)
         assert abs(value - expected) < 1e-10
+
+
+# ── R1 forward-selected two-stage artifact ─────────────────
+
+
+def _make_obs(
+    current_high_bid: int = 0,
+    seat: int = 1,
+    dealer_seat: int = 0,
+) -> BiddingObservation:
+    """Create a BiddingObservation for testing."""
+    suits = ["C", "D", "H", "S"]
+    ranks = ["T", "J", "Q", "K", "A"]
+    cards = []
+    for i, suit in enumerate(suits):
+        for rank in ranks[i : i + 3]:
+            cards.append(Card(rank=rank, suit=suit))
+            if len(cards) == 10:
+                break
+        if len(cards) == 10:
+            break
+    return BiddingObservation(
+        hand=cards,
+        seat=seat,
+        dealer_seat=dealer_seat,
+        current_high_bid=current_high_bid,
+        allowed_contracts=("C", "D", "H", "S", "HIGH", "LOW"),
+        auction_transcript=(),
+    )
+
+
+class TestTwoStageForwardSelected:
+    """Test TwoStageActionValueBidder with forward-selected artifacts
+    containing partner features but no positional features."""
+
+    def test_loads_with_partner_features(self, tmp_path):
+        """TwoStageActionValueBidder loads forward-selected artifact."""
+        hand_subset = list(_HAND_FEATURE_NAMES[:10])
+        partner_subset = ["partner_passed"]
+        state_names = hand_subset + partner_subset
+        n_state = len(state_names)
+        n_bid = n_state + N_ACTION
+
+        feature_names_bid = state_names + list(ACTION_FEATURE_NAMES)
+        feature_names_pass = list(state_names)
+
+        suit_model = {
+            "logistic": {
+                "coefficients": [0.0] * n_bid,
+                "intercept": 0.0,
+                "auc": 0.80,
+            },
+            "make_model": {
+                "coefficients": [0.0] * n_bid,
+                "intercept": 1.0,
+                "r_squared": 0.5,
+                "mae": 1.5,
+                "n_train": 100,
+            },
+            "set_model": {
+                "coefficients": [0.0] * n_bid,
+                "intercept": -2.0,
+                "r_squared": 0.4,
+                "mae": 2.0,
+                "n_train": 50,
+            },
+            "feature_names": feature_names_bid,
+            "composite_r_squared": 0.50,
+            "composite_mae": 1.8,
+            "auc": 0.80,
+            "make_rate": 0.70,
+            "n_train": 150,
+            "n_val": 30,
+        }
+
+        artifact = {
+            "schema_version": "two_stage_action_value_v1",
+            "target": "net_points",
+            "risk_mode": "neutral",
+            "continuation_policy": "hybrid_r0_full",
+            "action_features": list(ACTION_FEATURE_NAMES),
+            "feature_set": "full",
+            "models": {
+                "suit": suit_model,
+                "high": {
+                    "coefficients": [0.0] * n_bid,
+                    "intercept": 0.5,
+                    "feature_names": feature_names_bid,
+                    "r_squared": 0.45,
+                    "mae": 2.0,
+                    "n_train": 100,
+                    "n_val": 20,
+                },
+                "low": {
+                    "coefficients": [0.0] * n_bid,
+                    "intercept": 0.3,
+                    "feature_names": feature_names_bid,
+                    "r_squared": 0.40,
+                    "mae": 2.2,
+                    "n_train": 80,
+                    "n_val": 15,
+                },
+                "pass": {
+                    "coefficients": [0.0] * n_state,
+                    "intercept": -1.0,
+                    "feature_names": feature_names_pass,
+                    "r_squared": 0.05,
+                    "mae": 3.0,
+                    "n_train": 200,
+                    "n_val": 40,
+                },
+            },
+            "metadata": {
+                "context_features": ["partner_passed"],
+            },
+        }
+
+        path = tmp_path / "two_stage_forward.json"
+        path.write_text(json.dumps(artifact))
+
+        bidder = TwoStageActionValueBidder(
+            artifact_path=str(path),
+            skip_behavioral_check=True,
+        )
+        assert bidder._needs_full_state is True
+        assert bidder._has_positional is False
+
+        # Verify choose_bid works end-to-end
+        obs = _make_obs(current_high_bid=0)
+        action = bidder.choose_bid(obs)
+        assert isinstance(action, BidAction)


### PR DESCRIPTION
## Summary
- Fix `KeyError: 'partner_passed'` when loading R1 forward-selected artifacts in all 3 bidder classes (`ActionValueBidder`, `GBTActionValueBidder`, `TwoStageActionValueBidder`)
- When artifact state features include partner/position features (not in `_HAND_FEATURE_NAMES`), build the index mapping against `STATE_FEATURE_NAMES` (57 features) and extract the full state vector at inference time
- R0 hand-only backward compatibility preserved

## Why

R1 forward-selected artifacts may contain partner features (e.g., `partner_passed`) and position features (`auction_position`, `is_dealer`) after forward selection drops all positional/legality features. The previous code built `hand_name_to_idx` exclusively from `_HAND_FEATURE_NAMES` (39 hand features), causing a `KeyError` when looking up non-hand feature names.

## Repro / Validation

```bash
# Run targeted bidder tests (all 85 pass including 6 new forward-selected tests)
uv run python -m pytest tests/unit/test_action_value_bidder.py tests/unit/test_gbt_bidder.py tests/unit/test_two_stage_bidder.py -v

# Full validation
make check-quiet
```

## Tests

- `make check-quiet` -- all checks pass
- 6 new tests across 3 test files covering the forward-selected artifact case:
  - `TestForwardSelectedArtifact` (4 tests): OLS loads, choose_bid works, R0 backward compat, index mapping correctness
  - `TestGBTForwardSelected` (1 test): GBT loads and choose_bid works with partner features
  - `TestTwoStageForwardSelected` (1 test): Two-stage loads and choose_bid works with partner features

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-inference-fix
toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-inference-fix
branch: fix/bidder-inference-r1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)