### PR TITLE
feat: add R2 opponent features (12 features, left/right split)

### DIFF
--- a/scripts/internal/generate_action_value_dataset.py
+++ b/scripts/internal/generate_action_value_dataset.py
@@ -7,7 +7,7 @@ continue the auction with a continuation policy, play out tricks with
 GluttonStrategy, and record the focal team's net_points.
 
 Output: Parquet with columns hand_id, deal_id, focal_seat, action_type,
-contract_family, bid_n, trump_suit, 57 state feature columns, net_points,
+contract_family, bid_n, trump_suit, 69 state feature columns, net_points,
 tricks_won, focal_declared.
 
 Usage:
@@ -464,7 +464,7 @@ def generate_dataset(
                     action_type = "bid"
                     bid_n = action.n
 
-                # Extract state features (57 columns) — from ORIGINAL hands
+                # Extract state features (69 columns) — from ORIGINAL hands
                 state = extract_state_features(obs, contract_family, trump_suit)
 
                 if multi:
@@ -517,7 +517,7 @@ def generate_dataset(
                     "bid_n": bid_n,
                     "trump_suit": trump_suit if trump_suit else "",
                 }
-                # Add 57 state features as individual columns
+                # Add 69 state features as individual columns
                 for i, fname in enumerate(STATE_FEATURE_NAMES):
                     row[fname] = state[i]
                 row["net_points"] = net_points
@@ -599,7 +599,7 @@ def validate_gate_x1(df: pd.DataFrame, n_deals: int) -> None:
         f"({expected_rows * 0.5:.0f} - {expected_rows * 1.5:.0f})"
     )
 
-    # 6. 57 state feature columns present
+    # 6. 69 state feature columns present
     for fname in STATE_FEATURE_NAMES:
         assert fname in df.columns, f"Missing state feature column: {fname}"
 

--- a/scripts/internal/train_action_value.py
+++ b/scripts/internal/train_action_value.py
@@ -14,7 +14,7 @@ Four models:
   pass:  target ~ state features (no action features)
 
 Ablation parameters:
-  --feature-set: "full" (57 state features), "r0" (39 R0 hand features only),
+  --feature-set: "full" (69 state features), "r0" (39 R0 hand features only),
                  or "constrained" (per-contract locked features)
   --selection: "none" (default) or "forward" (forward feature selection)
   --target: "net_points" (default) or "tricks_won"
@@ -92,6 +92,22 @@ _PARTNER_FEATURE_NAMES = [
 # Position feature columns (positions 45-46 in STATE_FEATURE_NAMES)
 _POSITION_FEATURE_NAMES = ["auction_position", "is_dealer"]
 
+# Opponent feature columns (positions 47-58 in STATE_FEATURE_NAMES, R2)
+_OPPONENT_FEATURE_NAMES = [
+    "opp_left_level_same_suit",
+    "opp_left_level_same_color",
+    "opp_left_level_off_color",
+    "opp_left_level_high",
+    "opp_left_level_low",
+    "opp_left_passed",
+    "opp_right_level_same_suit",
+    "opp_right_level_same_color",
+    "opp_right_level_off_color",
+    "opp_right_level_high",
+    "opp_right_level_low",
+    "opp_right_passed",
+]
+
 # Interaction terms computed from existing columns (not stored in dataset).
 # Each maps to (col_a, col_b) — the feature value is col_a * col_b.
 INTERACTION_FEATURE_NAMES: list[str] = [
@@ -119,13 +135,13 @@ CONSTRAINED_FEATURES: dict[str, list[str]] = {
 # Most entries are flat lists. "constrained" is a dict[str, list[str]]
 # mapping contract_family -> features.
 FEATURE_SETS: dict[str, list[str] | dict[str, list[str]]] = {
-    "full": list(STATE_FEATURE_NAMES),  # 57 state features (R1)
+    "full": list(STATE_FEATURE_NAMES),  # 69 state features (R2)
     "r0": list(STATE_FEATURE_NAMES[:_N_R0_HAND_FEATURES]),  # 39 R0 hand features only
     "no-partner": list(
         STATE_FEATURE_NAMES
-    ),  # 57 features, partner + position cols zeroed at training
+    ),  # 69 features, partner + position + opponent cols zeroed at training
     "interaction": list(STATE_FEATURE_NAMES)
-    + INTERACTION_FEATURE_NAMES,  # 57 + 3 interaction
+    + INTERACTION_FEATURE_NAMES,  # 69 + 3 interaction
     "constrained": CONSTRAINED_FEATURES,  # per-contract locked features
 }
 
@@ -158,7 +174,9 @@ def resolve_feature_names(
 # The model artifact retains all feature names (passes ActionValueBidder validation)
 # but OLS learns zero coefficients for zeroed columns.
 _ZERO_MASK_COLUMNS: dict[str, list[str]] = {
-    "no-partner": _PARTNER_FEATURE_NAMES + _POSITION_FEATURE_NAMES,
+    "no-partner": _PARTNER_FEATURE_NAMES
+    + _POSITION_FEATURE_NAMES
+    + _OPPONENT_FEATURE_NAMES,
 }
 
 VALID_TARGETS = ("net_points", "tricks_won")
@@ -971,7 +989,7 @@ def main():
         "--feature-set",
         choices=sorted(FEATURE_SETS.keys()),
         default="full",
-        help="Feature set: 'full' (57 state), 'r0' (39 hand), 'no-partner' (57 state, partner+position cols zeroed), 'interaction' (57 + 3 interaction terms)",
+        help="Feature set: 'full' (69 state), 'r0' (39 hand), 'no-partner' (69 state, partner+position+opponent cols zeroed), 'interaction' (69 + 3 interaction terms)",
     )
     parser.add_argument(
         "--target",

--- a/src/bid_euchre/features/auction_context.py
+++ b/src/bid_euchre/features/auction_context.py
@@ -1,7 +1,7 @@
 """
-Partner bidding context features extracted from auction_transcript.
+Auction context features extracted from auction_transcript.
 
-These features capture information about the partner's bidding behavior
+These features capture information about other players' bidding behavior
 during the auction phase. They are separate from hand evaluation features
 (hand_eval.py) because they depend on auction state, not just cards.
 
@@ -17,6 +17,15 @@ v2 features (R1, suit-relative channels):
     partner_level_high: Partner's bid level for high contract (0 if none)
     partner_level_low: Partner's bid level for low contract (0 if none)
     partner_passed: 1 if partner explicitly passed, 0 otherwise
+
+R2 opponent features (suit-relative, same template as v2 partner):
+    opp_{side}_level_same_suit: Opponent's bid level in same suit (0 if none)
+    opp_{side}_level_same_color: Opponent's bid level in same-color suit (0 if none)
+    opp_{side}_level_off_color: Opponent's bid level in off-color suit (0 if none)
+    opp_{side}_level_high: Opponent's bid level for high contract (0 if none)
+    opp_{side}_level_low: Opponent's bid level for low contract (0 if none)
+    opp_{side}_passed: 1 if opponent explicitly passed, 0 otherwise
+    where {side} is "left" or "right"
 """
 
 from __future__ import annotations
@@ -85,6 +94,75 @@ PARTNER_FEATURE_NAMES = [
 ]
 
 
+def _extract_player_features(
+    target_seat: int,
+    auction_transcript: tuple[dict, ...] | list[dict],
+    observer_contract_type: str | None,
+    observer_trump_suit: str | None,
+    prefix: str,
+) -> dict[str, Any]:
+    """Extract suit-relative bidding features for a single player.
+
+    Shared helper used by both partner (v2) and opponent feature extractors.
+    Produces 6 features with the given prefix:
+        {prefix}_level_same_suit, {prefix}_level_same_color,
+        {prefix}_level_off_color, {prefix}_level_high,
+        {prefix}_level_low, {prefix}_passed.
+
+    Args:
+        target_seat: The seat index (0-3) of the player to extract features for.
+        auction_transcript: Sequence of auction entry dicts.
+        observer_contract_type: Contract family the observer is evaluating
+            ("suit", "high", "low", or None).
+        observer_trump_suit: Trump suit letter for suit contracts, None otherwise.
+        prefix: Feature name prefix (e.g., "partner", "opp_left", "opp_right").
+
+    Returns:
+        Dict with 6 features using the given prefix.
+    """
+    passed = 0
+    level_same_suit = 0
+    level_same_color = 0
+    level_off_color = 0
+    level_high = 0
+    level_low = 0
+
+    for entry in auction_transcript:
+        if entry["seat"] != target_seat:
+            continue
+        if entry["action"] == "PASS":
+            passed = 1
+        elif entry["action"] == "BID":
+            bid_level = entry.get("tricks_bid", 0)
+            bid_contract = entry.get("contract_type")
+            bid_trump = entry.get("trump")
+
+            if bid_contract == "high":
+                level_high = max(level_high, bid_level)
+            elif bid_contract == "low":
+                level_low = max(level_low, bid_level)
+            elif bid_contract == "suit" and bid_trump is not None:
+                # Classify suit relationship only when observer has a suit contract
+                if observer_contract_type == "suit" and observer_trump_suit is not None:
+                    if bid_trump == observer_trump_suit:
+                        level_same_suit = max(level_same_suit, bid_level)
+                    elif bid_trump == SAME_COLOR_SUIT.get(observer_trump_suit):
+                        level_same_color = max(level_same_color, bid_level)
+                    else:
+                        level_off_color = max(level_off_color, bid_level)
+                # For non-suit observer contracts, suit bids go nowhere
+                # (suit channels stay 0, which is correct — no suit relevance)
+
+    return {
+        f"{prefix}_level_same_suit": level_same_suit,
+        f"{prefix}_level_same_color": level_same_color,
+        f"{prefix}_level_off_color": level_off_color,
+        f"{prefix}_level_high": level_high,
+        f"{prefix}_level_low": level_low,
+        f"{prefix}_passed": passed,
+    }
+
+
 def extract_partner_features_v2(
     seat: int,
     auction_transcript: tuple[dict, ...] | list[dict],
@@ -122,49 +200,13 @@ def extract_partner_features_v2(
             partner_passed (int): 0 or 1
     """
     partner_seat = (seat + 2) % 4
-
-    partner_passed = 0
-    # Track highest bid level per channel
-    level_same_suit = 0
-    level_same_color = 0
-    level_off_color = 0
-    level_high = 0
-    level_low = 0
-
-    for entry in auction_transcript:
-        if entry["seat"] != partner_seat:
-            continue
-        if entry["action"] == "PASS":
-            partner_passed = 1
-        elif entry["action"] == "BID":
-            bid_level = entry.get("tricks_bid", 0)
-            bid_contract = entry.get("contract_type")
-            bid_trump = entry.get("trump")
-
-            if bid_contract == "high":
-                level_high = max(level_high, bid_level)
-            elif bid_contract == "low":
-                level_low = max(level_low, bid_level)
-            elif bid_contract == "suit" and bid_trump is not None:
-                # Classify suit relationship only when observer has a suit contract
-                if observer_contract_type == "suit" and observer_trump_suit is not None:
-                    if bid_trump == observer_trump_suit:
-                        level_same_suit = max(level_same_suit, bid_level)
-                    elif bid_trump == SAME_COLOR_SUIT.get(observer_trump_suit):
-                        level_same_color = max(level_same_color, bid_level)
-                    else:
-                        level_off_color = max(level_off_color, bid_level)
-                # For non-suit observer contracts, suit bids go nowhere
-                # (suit channels stay 0, which is correct — no suit relevance)
-
-    return {
-        "partner_level_same_suit": level_same_suit,
-        "partner_level_same_color": level_same_color,
-        "partner_level_off_color": level_off_color,
-        "partner_level_high": level_high,
-        "partner_level_low": level_low,
-        "partner_passed": partner_passed,
-    }
+    return _extract_player_features(
+        partner_seat,
+        auction_transcript,
+        observer_contract_type,
+        observer_trump_suit,
+        prefix="partner",
+    )
 
 
 # Canonical v2 feature names (R1, 6 features)
@@ -175,4 +217,83 @@ PARTNER_FEATURE_NAMES_V2 = [
     "partner_level_high",
     "partner_level_low",
     "partner_passed",
+]
+
+
+def extract_opponent_features(
+    seat: int,
+    auction_transcript: tuple[dict, ...] | list[dict],
+    observer_contract_type: str | None = None,
+    observer_trump_suit: str | None = None,
+) -> dict[str, Any]:
+    """Extract suit-relative opponent bidding features (R2).
+
+    Extracts 12 features (6 per opponent) using the same suit-relative
+    template as partner v2 features. Each opponent gets level channels
+    for same_suit, same_color, off_color, high, low, and a passed flag.
+
+    Left opponent: seat (observer + 1) % 4
+    Right opponent: seat (observer + 3) % 4
+
+    Args:
+        seat: Observer's seat index (0-3).
+        auction_transcript: Sequence of auction entry dicts, each with keys:
+            seat (int), action (str: "BID" or "PASS"),
+            tricks_bid (int), contract_type (str|None), trump (str|None).
+        observer_contract_type: Contract family the observer is evaluating
+            ("suit", "high", "low", or None). Controls suit-channel activation.
+        observer_trump_suit: Trump suit letter for the observer's candidate
+            contract (e.g., "H"). Only meaningful when observer_contract_type
+            is "suit". None for high/low/pass.
+
+    Returns:
+        Dict with 12 features:
+            opp_left_level_same_suit (int): 0-10
+            opp_left_level_same_color (int): 0-10
+            opp_left_level_off_color (int): 0-10
+            opp_left_level_high (int): 0-10
+            opp_left_level_low (int): 0-10
+            opp_left_passed (int): 0 or 1
+            opp_right_level_same_suit (int): 0-10
+            opp_right_level_same_color (int): 0-10
+            opp_right_level_off_color (int): 0-10
+            opp_right_level_high (int): 0-10
+            opp_right_level_low (int): 0-10
+            opp_right_passed (int): 0 or 1
+    """
+    left_seat = (seat + 1) % 4
+    right_seat = (seat + 3) % 4
+
+    left_feats = _extract_player_features(
+        left_seat,
+        auction_transcript,
+        observer_contract_type,
+        observer_trump_suit,
+        prefix="opp_left",
+    )
+    right_feats = _extract_player_features(
+        right_seat,
+        auction_transcript,
+        observer_contract_type,
+        observer_trump_suit,
+        prefix="opp_right",
+    )
+
+    return {**left_feats, **right_feats}
+
+
+# Canonical R2 opponent feature names (12 features: 6 left + 6 right)
+OPPONENT_FEATURE_NAMES = [
+    "opp_left_level_same_suit",
+    "opp_left_level_same_color",
+    "opp_left_level_off_color",
+    "opp_left_level_high",
+    "opp_left_level_low",
+    "opp_left_passed",
+    "opp_right_level_same_suit",
+    "opp_right_level_same_color",
+    "opp_right_level_off_color",
+    "opp_right_level_high",
+    "opp_right_level_low",
+    "opp_right_passed",
 ]

--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -1405,10 +1405,29 @@ _POSITION_FEATURE_NAMES: List[str] = [
 # Known position feature names for _infer_partner_features exclusion
 _POSITION_FEATURE_SET: frozenset = frozenset(_POSITION_FEATURE_NAMES)
 
-# State feature names: 39 hand + 6 partner_v2 + 2 position + 10 positional = 57
-# This is the R1 canonical default (LA-1 amendment). Artifact-driven extraction
-# may use different partner features (v7: 3 features, v2: 6 features), but hand,
-# position, and positional features are fixed across versions.
+# Opponent feature names (R2): 12 features (6 left + 6 right)
+_OPPONENT_FEATURE_NAMES: List[str] = [
+    "opp_left_level_same_suit",
+    "opp_left_level_same_color",
+    "opp_left_level_off_color",
+    "opp_left_level_high",
+    "opp_left_level_low",
+    "opp_left_passed",
+    "opp_right_level_same_suit",
+    "opp_right_level_same_color",
+    "opp_right_level_off_color",
+    "opp_right_level_high",
+    "opp_right_level_low",
+    "opp_right_passed",
+]
+
+# Known opponent feature names for _infer_partner_features exclusion
+_OPPONENT_FEATURE_SET: frozenset = frozenset(_OPPONENT_FEATURE_NAMES)
+
+# State feature names: 39 hand + 6 partner_v2 + 2 position + 12 opponent + 10 positional = 69
+# This is the R2 canonical default. Artifact-driven extraction may use different
+# partner features (v7: 3 features, v2: 6 features) and may omit opponent features
+# (R0/R1 artifacts), but hand, position, and positional features are fixed.
 STATE_FEATURE_NAMES: List[str] = (
     _HAND_FEATURE_NAMES
     + [
@@ -1420,6 +1439,7 @@ STATE_FEATURE_NAMES: List[str] = (
         "partner_passed",
     ]
     + _POSITION_FEATURE_NAMES
+    + _OPPONENT_FEATURE_NAMES
     + _POSITIONAL_FEATURE_NAMES
 )
 
@@ -1431,8 +1451,9 @@ def _infer_partner_features(feature_names: List[str]) -> List[str]:
     The hand and positional blocks are fixed across schema versions; only the
     partner block varies (v7: 3 features, v2: 6 features).
 
-    Position features (auction_position, is_dealer) may sit between partner
-    and positional blocks — they are excluded from the returned partner list.
+    Position features (auction_position, is_dealer) and opponent features
+    (opp_left_*, opp_right_*) may sit between partner and positional blocks —
+    they are excluded from the returned partner list.
 
     If no positional features are present (R0 hand-only models), there are no
     partner features either — returns an empty list.
@@ -1442,18 +1463,17 @@ def _infer_partner_features(feature_names: List[str]) -> List[str]:
 
     Returns:
         The partner feature names (the slice between hand and positional blocks,
-        excluding position features). Empty list for R0 hand-only models.
+        excluding position and opponent features). Empty list for R0 hand-only models.
     """
     hand_end = len(_HAND_FEATURE_NAMES)  # 39
     if "current_high_bid" not in feature_names:
         # No positional features = no partner features (R0 hand-only model)
         return []
     positional_start = feature_names.index("current_high_bid")
-    # Position features sit between partner and positional blocks — exclude them
+    # Position and opponent features sit between partner and positional blocks — exclude them
+    _excluded = _POSITION_FEATURE_SET | _OPPONENT_FEATURE_SET
     partner_names = [
-        n
-        for n in feature_names[hand_end:positional_start]
-        if n not in _POSITION_FEATURE_SET
+        n for n in feature_names[hand_end:positional_start] if n not in _excluded
     ]
     # partner_names can be empty (model with positional but no partner features)
     return partner_names
@@ -1502,8 +1522,9 @@ def extract_state_features(
 
     Returns:
         np.ndarray with features in order:
-        - With positional: hand (39) + partner (N) + position (2) + positional (10).
-          Default shape is (57,) for R1 schema (v2 partner, 6 features).
+        - With positional: hand (39) + partner (N) + position (2) + opponent (12)
+          + positional (10). Default shape is (69,) for R2 schema (v2 partner,
+          6 features + 12 opponent features).
         - Without positional: hand (39) only (R0 hand-only models).
 
     Note on pass ("none") encoding:
@@ -1530,7 +1551,9 @@ def extract_state_features(
         return hand_arr
 
     from ..features.auction_context import (
+        OPPONENT_FEATURE_NAMES,
         PARTNER_FEATURE_NAMES_V2,
+        extract_opponent_features,
         extract_partner_features,
         extract_partner_features_v2,
     )
@@ -1569,6 +1592,19 @@ def extract_state_features(
         dtype=np.float64,
     )
 
+    # Opponent features (12): 6 left + 6 right (R2)
+    opp_family = contract_family if contract_family != "none" else None
+    opp_feats = extract_opponent_features(
+        obs.seat,
+        obs.auction_transcript,
+        observer_contract_type=opp_family,
+        observer_trump_suit=trump_suit,
+    )
+    opp_arr = np.array(
+        [float(opp_feats[k]) for k in OPPONENT_FEATURE_NAMES],
+        dtype=np.float64,
+    )
+
     # Positional / legality features (10)
     current_high_bid = float(obs.current_high_bid)
 
@@ -1604,7 +1640,9 @@ def extract_state_features(
         dtype=np.float64,
     )
 
-    return np.concatenate([hand_arr, partner_arr, position_arr, positional_arr])
+    return np.concatenate(
+        [hand_arr, partner_arr, position_arr, opp_arr, positional_arr]
+    )
 
 
 def extract_action_features(bid_n: int) -> np.ndarray:
@@ -1675,7 +1713,8 @@ def _validate_artifact_features(
 
     Shared validation logic for all action-value bidder classes. Checks that
     the artifact's feature_names have the expected structure:
-        hand (39) + partner (N) + positional (10) [+ interaction (3)] + action (2)
+        hand (39) + partner (N) + position (0-2) + opponent (0-12)
+        + positional (10) [+ interaction (3)] + action (2)
     or for R0/constrained/selected hand-only models:
         hand_subset (M) + action (2)  where M <= 39
 
@@ -1696,13 +1735,14 @@ def _validate_artifact_features(
     partner_names = _infer_partner_features(state_names)
     has_positional = "current_high_bid" in state_names
 
-    # Detect position features between partner and positional blocks
+    # Detect position and opponent features between partner and positional blocks
     hand_end = len(_HAND_FEATURE_NAMES)
     positional_start = (
         state_names.index("current_high_bid") if has_positional else len(state_names)
     )
     middle_names = state_names[hand_end:positional_start]
     position_names = [n for n in middle_names if n in _POSITION_FEATURE_SET]
+    opponent_names = [n for n in middle_names if n in _OPPONENT_FEATURE_SET]
 
     # Rebuild expected full feature list and validate
     if has_positional:
@@ -1711,6 +1751,7 @@ def _validate_artifact_features(
             list(_HAND_FEATURE_NAMES)
             + list(partner_names)
             + list(position_names)
+            + list(opponent_names)
             + list(_POSITIONAL_FEATURE_NAMES)
         )
         if has_interactions:
@@ -1726,29 +1767,31 @@ def _validate_artifact_features(
                 f"Expected {len(expected_full)} features "
                 f"(39 hand + {len(partner_names)} partner"
                 f"{f' + {len(position_names)} position' if position_names else ''}"
+                f"{f' + {len(opponent_names)} opponent' if opponent_names else ''}"
                 f" + 10 positional"
                 f"{' + 3 interaction' if has_interactions else ''} + 2 action), "
                 f"got {len(model_feature_names)} features."
             )
     else:
         # R0/constrained/selected: state features should be a subset of
-        # known hand features, partner v2 features, and position features.
-        # Forward selection from the full 57-feature set may keep partner
-        # or position features while dropping all positional (legality)
-        # features, so we accept all three categories as valid.
+        # known hand features, partner v2 features, position features,
+        # and opponent features. Forward selection from the full state
+        # feature set may keep any of these while dropping positional
+        # (legality) features, so we accept all categories as valid.
         from ..features.auction_context import PARTNER_FEATURE_NAMES_V2
 
         valid_set = (
             set(_HAND_FEATURE_NAMES)
             | set(PARTNER_FEATURE_NAMES_V2)
             | _POSITION_FEATURE_SET
+            | _OPPONENT_FEATURE_SET
         )
         unknown = [f for f in state_names if f not in valid_set]
         if unknown:
             raise ValueError(
                 f"Artifact feature_names structural mismatch. "
                 f"Non-positional model contains unknown state features "
-                f"(not in hand/partner/position feature set): {unknown}"
+                f"(not in hand/partner/position/opponent feature set): {unknown}"
             )
 
         # Verify action features are at the expected positions
@@ -1774,23 +1817,22 @@ def _validate_pass_model_features(
     Pass models use state features only (no action features).
     """
     if has_positional:
-        # Detect position features in pass model's feature list
+        # Detect position and opponent features in pass model's feature list
         hand_end = len(_HAND_FEATURE_NAMES)
         positional_start = (
             pass_feature_names.index("current_high_bid")
             if "current_high_bid" in pass_feature_names
             else len(pass_feature_names)
         )
-        position_names = [
-            n
-            for n in pass_feature_names[hand_end:positional_start]
-            if n in _POSITION_FEATURE_SET
-        ]
+        middle_names = pass_feature_names[hand_end:positional_start]
+        position_names = [n for n in middle_names if n in _POSITION_FEATURE_SET]
+        opponent_names = [n for n in middle_names if n in _OPPONENT_FEATURE_SET]
 
         expected_state = (
             list(_HAND_FEATURE_NAMES)
             + list(partner_feature_names)
             + list(position_names)
+            + list(opponent_names)
             + list(_POSITIONAL_FEATURE_NAMES)
         )
         if has_interactions:
@@ -1806,23 +1848,23 @@ def _validate_pass_model_features(
             )
     else:
         # R0/constrained/selected: pass features should be subset of
-        # known hand features, partner v2 features, and position features.
-        # Forward selection from the full feature set may keep partner
-        # or position features while dropping all positional (legality)
-        # features.
+        # known hand features, partner v2 features, position features,
+        # and opponent features. Forward selection from the full feature
+        # set may keep any of these while dropping positional features.
         from ..features.auction_context import PARTNER_FEATURE_NAMES_V2
 
         valid_set = (
             set(_HAND_FEATURE_NAMES)
             | set(PARTNER_FEATURE_NAMES_V2)
             | _POSITION_FEATURE_SET
+            | _OPPONENT_FEATURE_SET
         )
         unknown = [f for f in pass_feature_names if f not in valid_set]
         if unknown:
             raise ValueError(
                 f"Artifact pass model feature_names mismatch. "
                 f"Non-positional pass model contains unknown features "
-                f"(not in hand/partner/position feature set): {unknown}"
+                f"(not in hand/partner/position/opponent feature set): {unknown}"
             )
 
 
@@ -2015,10 +2057,10 @@ class ActionValueBidder(BiddingPolicy):
 
         # For R0/selected models: precompute per-family hand feature indices
         # so choose_bid() can select the right subset from the full state vector.
-        # R1 forward-selected artifacts may include partner/position features
-        # (e.g., partner_passed) that are not in _HAND_FEATURE_NAMES. When this
-        # happens, map indices against STATE_FEATURE_NAMES (57 features) and
-        # extract the full state vector at inference time.
+        # R1/R2 forward-selected artifacts may include partner/position/opponent
+        # features (e.g., partner_passed) that are not in _HAND_FEATURE_NAMES.
+        # When this happens, map indices against STATE_FEATURE_NAMES (69 features)
+        # and extract the full state vector at inference time.
         self._hand_indices: dict[str, Optional[np.ndarray]] = {}
         hand_name_set = set(_HAND_FEATURE_NAMES)
         if not self._has_positional:

--- a/tests/unit/test_action_value_bidder.py
+++ b/tests/unit/test_action_value_bidder.py
@@ -201,10 +201,10 @@ class TestPredictOls:
 
 
 class TestExtractStateFeatures:
-    def test_shape_is_57(self):
+    def test_shape_is_69(self):
         obs = _make_obs()
         features = extract_state_features(obs, "suit", "H")
-        assert features.shape == (57,)
+        assert features.shape == (69,)
 
     def test_shape_matches_feature_names(self):
         obs = _make_obs()

--- a/tests/unit/test_auction_context.py
+++ b/tests/unit/test_auction_context.py
@@ -1,14 +1,18 @@
-"""Tests for partner bidding context feature extraction."""
+"""Tests for auction context feature extraction (partner + opponent)."""
 
 from bid_euchre.core.cards import Card
 from bid_euchre.features.auction_context import (
+    OPPONENT_FEATURE_NAMES,
     PARTNER_FEATURE_NAMES,
     PARTNER_FEATURE_NAMES_V2,
+    extract_opponent_features,
     extract_partner_features,
     extract_partner_features_v2,
 )
 from bid_euchre.strategy.bidding import (
+    _OPPONENT_FEATURE_NAMES,
     _POSITION_FEATURE_NAMES,
+    STATE_FEATURE_NAMES,
     BiddingObservation,
     extract_state_features,
 )
@@ -347,12 +351,219 @@ class TestPositionFeatures:
                 expected_pos
             ), f"seat={seat}: expected position {expected_pos}, got {state[pos_start]}"
 
-    def test_state_vector_length_57(self):
-        """R1 state vector is 39 hand + 6 partner + 2 position + 10 positional = 57."""
+    def test_state_vector_length_69(self):
+        """R2 state vector is 39 hand + 6 partner + 2 position + 12 opponent + 10 positional = 69."""
         obs = _make_obs(seat=0, dealer_seat=3)
         state = extract_state_features(obs, "suit", "H")
-        assert len(state) == 57
+        assert len(state) == 69
 
     def test_position_feature_names(self):
         """Position feature name list is correct."""
         assert _POSITION_FEATURE_NAMES == ["auction_position", "is_dealer"]
+
+
+class TestExtractOpponentFeatures:
+    """Tests for R2 opponent bidding feature extraction."""
+
+    def test_left_opponent_suit_same_suit(self):
+        """Left opponent (seat+1)%4 bids same suit -> left same_suit channel."""
+        # Seat 0 observer, left opponent = seat 1
+        transcript = [_bid_entry(1, 5, "suit", "H")]
+        result = extract_opponent_features(
+            seat=0,
+            auction_transcript=transcript,
+            observer_contract_type="suit",
+            observer_trump_suit="H",
+        )
+        assert result["opp_left_level_same_suit"] == 5
+        assert result["opp_left_level_same_color"] == 0
+        assert result["opp_left_level_off_color"] == 0
+        # Right opponent (seat 3) should be all zeros
+        assert result["opp_right_level_same_suit"] == 0
+
+    def test_right_opponent_suit_off_color(self):
+        """Right opponent (seat+3)%4 bids off-color suit -> right off_color channel."""
+        # Seat 0 observer, right opponent = seat 3
+        transcript = [_bid_entry(3, 4, "suit", "S")]
+        result = extract_opponent_features(
+            seat=0,
+            auction_transcript=transcript,
+            observer_contract_type="suit",
+            observer_trump_suit="H",
+        )
+        assert result["opp_right_level_off_color"] == 4
+        assert result["opp_right_level_same_suit"] == 0
+        assert result["opp_right_level_same_color"] == 0
+        # Left opponent should be all zeros
+        assert result["opp_left_level_off_color"] == 0
+
+    def test_both_opponents_with_bids(self):
+        """Both opponents bid -> both left and right channels populated."""
+        # Seat 0: left=1, right=3
+        transcript = [
+            _bid_entry(1, 5, "high"),  # left bids high
+            _bid_entry(3, 3, "low"),  # right bids low
+        ]
+        result = extract_opponent_features(
+            seat=0,
+            auction_transcript=transcript,
+            observer_contract_type="suit",
+            observer_trump_suit="H",
+        )
+        assert result["opp_left_level_high"] == 5
+        assert result["opp_left_level_low"] == 0
+        assert result["opp_right_level_low"] == 3
+        assert result["opp_right_level_high"] == 0
+
+    def test_opponent_passed(self):
+        """Opponent pass flags work correctly."""
+        # Seat 0: left=1, right=3
+        transcript = [
+            _pass_entry(1),  # left passes
+        ]
+        result = extract_opponent_features(
+            seat=0,
+            auction_transcript=transcript,
+            observer_contract_type="suit",
+            observer_trump_suit="H",
+        )
+        assert result["opp_left_passed"] == 1
+        assert result["opp_right_passed"] == 0
+
+    def test_empty_transcript_all_zeros(self):
+        """Empty transcript -> all 12 opponent features are 0."""
+        result = extract_opponent_features(
+            seat=0,
+            auction_transcript=(),
+            observer_contract_type="suit",
+            observer_trump_suit="H",
+        )
+        for key in OPPONENT_FEATURE_NAMES:
+            assert result[key] == 0, f"{key} should be 0"
+
+    def test_feature_names_constant_matches_output(self):
+        """OPPONENT_FEATURE_NAMES matches output keys."""
+        result = extract_opponent_features(
+            seat=0,
+            auction_transcript=(),
+            observer_contract_type="suit",
+            observer_trump_suit="H",
+        )
+        assert set(result.keys()) == set(OPPONENT_FEATURE_NAMES)
+
+    def test_feature_names_count(self):
+        """12 opponent feature names (6 left + 6 right)."""
+        assert len(OPPONENT_FEATURE_NAMES) == 12
+
+    def test_ignores_partner_seat(self):
+        """Opponent extraction ignores partner (seat+2)%4."""
+        # Seat 0: partner=2, left=1, right=3
+        transcript = [_bid_entry(2, 7, "suit", "H")]
+        result = extract_opponent_features(
+            seat=0,
+            auction_transcript=transcript,
+            observer_contract_type="suit",
+            observer_trump_suit="H",
+        )
+        # Partner's bid should not appear in any opponent channel
+        for key in OPPONENT_FEATURE_NAMES:
+            assert result[key] == 0, f"{key} should be 0 (partner bid ignored)"
+
+    def test_seat_wraps_correctly(self):
+        """Verify left/right opponent seats wrap around correctly."""
+        # Seat 3: left = (3+1)%4 = 0, right = (3+3)%4 = 2
+        transcript = [
+            _bid_entry(0, 4, "suit", "H"),  # left opponent (seat 0)
+            _bid_entry(2, 6, "high"),  # right opponent (seat 2)
+        ]
+        result = extract_opponent_features(
+            seat=3,
+            auction_transcript=transcript,
+            observer_contract_type="suit",
+            observer_trump_suit="H",
+        )
+        assert result["opp_left_level_same_suit"] == 4
+        assert result["opp_right_level_high"] == 6
+
+    def test_same_color_suit_classification(self):
+        """Opponent bids same-color suit (C/S are same color)."""
+        # Seat 0: left=1
+        transcript = [_bid_entry(1, 3, "suit", "C")]
+        result = extract_opponent_features(
+            seat=0,
+            auction_transcript=transcript,
+            observer_contract_type="suit",
+            observer_trump_suit="S",
+        )
+        assert result["opp_left_level_same_color"] == 3
+        assert result["opp_left_level_same_suit"] == 0
+        assert result["opp_left_level_off_color"] == 0
+
+    def test_high_contract_suit_channels_zero(self):
+        """For high observer contracts, opponent suit channels are always 0."""
+        transcript = [_bid_entry(1, 5, "suit", "H")]
+        result = extract_opponent_features(
+            seat=0,
+            auction_transcript=transcript,
+            observer_contract_type="high",
+            observer_trump_suit=None,
+        )
+        assert result["opp_left_level_same_suit"] == 0
+        assert result["opp_left_level_same_color"] == 0
+        assert result["opp_left_level_off_color"] == 0
+
+
+class TestOpponentFeaturesInStateVector:
+    """Tests for opponent features in the full state vector."""
+
+    def test_state_feature_names_length(self):
+        """STATE_FEATURE_NAMES has 69 entries."""
+        assert len(STATE_FEATURE_NAMES) == 69
+
+    def test_opponent_features_in_state_names(self):
+        """All 12 opponent feature names are in STATE_FEATURE_NAMES."""
+        for name in _OPPONENT_FEATURE_NAMES:
+            assert name in STATE_FEATURE_NAMES, f"{name} not in STATE_FEATURE_NAMES"
+
+    def test_opponent_features_position_in_state(self):
+        """Opponent features sit between position and positional blocks."""
+        # Position block ends at index 47 (39 hand + 6 partner + 2 position)
+        # Opponent block: indices 47-58
+        # Positional block starts at index 59
+        opp_start = 39 + 6 + 2  # = 47
+        for i, name in enumerate(_OPPONENT_FEATURE_NAMES):
+            assert STATE_FEATURE_NAMES[opp_start + i] == name, (
+                f"Expected {name} at index {opp_start + i}, "
+                f"got {STATE_FEATURE_NAMES[opp_start + i]}"
+            )
+        # Positional starts right after opponent
+        assert STATE_FEATURE_NAMES[opp_start + 12] == "current_high_bid"
+
+    def test_opponent_features_in_state_vector(self):
+        """State vector includes opponent features at correct position."""
+        # Left opponent (seat 1) bids 5H, right opponent (seat 3) passes
+        transcript = [
+            _bid_entry(1, 5, "suit", "H"),
+            _pass_entry(3),
+        ]
+        obs = _make_obs(seat=0, dealer_seat=0, transcript=transcript)
+        state = extract_state_features(obs, "suit", "H")
+
+        # Opponent features start at index 47
+        opp_start = 39 + 6 + 2
+        # opp_left_level_same_suit should be 5 (seat 1 bid 5H, same suit as observer)
+        assert state[opp_start] == 5.0
+        # opp_left_passed should be 0 (seat 1 didn't pass)
+        assert state[opp_start + 5] == 0.0
+        # opp_right_passed should be 1 (seat 3 passed)
+        assert state[opp_start + 11] == 1.0
+
+    def test_empty_transcript_zeros_opponent_block(self):
+        """Empty transcript -> all 12 opponent features are 0 in state vector."""
+        obs = _make_obs(seat=0, dealer_seat=0)
+        state = extract_state_features(obs, "suit", "H")
+        opp_start = 39 + 6 + 2
+        for i in range(12):
+            assert (
+                state[opp_start + i] == 0.0
+            ), f"Opponent feature at index {opp_start + i} should be 0"

--- a/tests/unit/test_train_action_value.py
+++ b/tests/unit/test_train_action_value.py
@@ -338,8 +338,8 @@ class TestFeatureSets:
         assert len(FEATURE_SETS["r0"]) == 39
 
     def test_feature_set_full_length(self):
-        """Full feature set must have exactly 57 features."""
-        assert len(FEATURE_SETS["full"]) == 57
+        """Full feature set must have exactly 69 features (R2)."""
+        assert len(FEATURE_SETS["full"]) == 69
 
     def test_feature_set_r0_matches_hand_features(self):
         """R0 features are the first 39 entries of STATE_FEATURE_NAMES."""
@@ -436,9 +436,9 @@ class TestArtifactFilename:
 
 
 class TestNoPartnerFeatureSet:
-    def test_no_partner_has_57_features(self):
-        """no-partner uses full 57 state features (zero-masked at training)."""
-        assert len(FEATURE_SETS["no-partner"]) == 57
+    def test_no_partner_has_69_features(self):
+        """no-partner uses full 69 state features (zero-masked at training)."""
+        assert len(FEATURE_SETS["no-partner"]) == 69
 
     def test_no_partner_equals_full_features(self):
         """no-partner feature list is identical to full."""
@@ -458,12 +458,12 @@ class TestNoPartnerFeatureSet:
             assert name in FEATURE_SETS["full"]
 
     def test_zero_mask_columns_maps_no_partner(self):
-        """_ZERO_MASK_COLUMNS has 'no-partner' → partner + position feature names."""
-        from train_action_value import _POSITION_FEATURE_NAMES
+        """_ZERO_MASK_COLUMNS has 'no-partner' → partner + position + opponent feature names."""
+        from train_action_value import _OPPONENT_FEATURE_NAMES, _POSITION_FEATURE_NAMES
 
         assert "no-partner" in _ZERO_MASK_COLUMNS
         assert _ZERO_MASK_COLUMNS["no-partner"] == (
-            _PARTNER_FEATURE_NAMES + _POSITION_FEATURE_NAMES
+            _PARTNER_FEATURE_NAMES + _POSITION_FEATURE_NAMES + _OPPONENT_FEATURE_NAMES
         )
 
     def test_zero_mask_produces_zero_coefficients(self, smoke_parquet_path):
@@ -527,12 +527,12 @@ class TestNoPartnerFeatureSet:
 
 
 class TestInteractionFeatureSet:
-    def test_interaction_has_60_features(self):
-        """interaction feature set = 57 state + 3 interaction terms."""
-        assert len(FEATURE_SETS["interaction"]) == 60
+    def test_interaction_has_72_features(self):
+        """interaction feature set = 69 state + 3 interaction terms."""
+        assert len(FEATURE_SETS["interaction"]) == 72
 
     def test_interaction_starts_with_state_features(self):
-        """First 57 features match STATE_FEATURE_NAMES."""
+        """First 69 features match STATE_FEATURE_NAMES."""
         n_state = len(STATE_FEATURE_NAMES)
         assert FEATURE_SETS["interaction"][:n_state] == list(STATE_FEATURE_NAMES)
 


### PR DESCRIPTION
## Summary

- Add 12 opponent bidding features (6 per opponent: left and right) using the same suit-relative template as partner v2 features
- Refactor `extract_partner_features_v2()` and new `extract_opponent_features()` to share a common `_extract_player_features()` helper
- State vector grows from 57 (R1) to 69 (R2): hand(39) + partner(6) + position(2) + opponent(12) + positional(10)

## Why

R2 of the Arc D v2 lineage adds opponent context features. Each opponent's bidding behavior is encoded in 6 suit-relative channels (same_suit, same_color, off_color, high, low, passed), mirroring the partner v2 feature template. Left opponent = `(seat + 1) % 4`, right opponent = `(seat + 3) % 4`.

## Changes

| File | Change |
|------|--------|
| `src/bid_euchre/features/auction_context.py` | Refactored shared `_extract_player_features()` helper; added `extract_opponent_features()` and `OPPONENT_FEATURE_NAMES` (12 names) |
| `src/bid_euchre/strategy/bidding.py` | Updated `STATE_FEATURE_NAMES` (57→69), `extract_state_features()`, `_infer_partner_features()`, `_validate_artifact_features()`, `_validate_pass_model_features()` to handle opponent features |
| `scripts/internal/train_action_value.py` | Added `_OPPONENT_FEATURE_NAMES`, updated `no-partner` zero-mask, updated feature count comments |
| `scripts/internal/generate_action_value_dataset.py` | Updated feature count comments (57→69) |
| `tests/unit/test_auction_context.py` | Added 16 new tests: `TestExtractOpponentFeatures` (11 tests) + `TestOpponentFeaturesInStateVector` (5 tests) |
| `tests/unit/test_action_value_bidder.py` | Updated state vector shape test (57→69) |
| `tests/unit/test_train_action_value.py` | Updated feature count assertions (57→69, 60→72) and zero-mask test |

## Backward Compatibility

- R0/R1 artifacts load correctly: `_infer_partner_features()` and `_validate_artifact_features()` now exclude opponent feature names from the partner inference, and the valid feature set for non-positional models includes opponent features
- The `_needs_full_state` index mapping uses `STATE_FEATURE_NAMES` (now 69), so forward-selected R1 artifacts that include partner/position features will map correctly against the expanded state vector

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_auction_context.py tests/unit/test_train_action_value.py tests/unit/test_action_value_bidder.py tests/unit/test_gbt_bidder.py tests/unit/test_two_stage_bidder.py tests/unit/test_suit_decision_diagnostic.py tests/unit/test_action_value_dataset.py tests/unit/test_av_constrained_selection.py -v
# 270 passed, 32 skipped
make check-quiet  # All checks passed
```

## Tests

- `make check-quiet` -- all checks pass
- 270 tests pass across 8 test files, 16 new tests added

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-r2-features
git worktree: feat/r2-opponent-features
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)