### PR TITLE
fix: include positional features in non-positional validation branch

### DIFF
--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -1775,9 +1775,10 @@ def _validate_artifact_features(
     else:
         # R0/constrained/selected: state features should be a subset of
         # known hand features, partner v2 features, position features,
-        # and opponent features. Forward selection from the full state
-        # feature set may keep any of these while dropping positional
-        # (legality) features, so we accept all categories as valid.
+        # opponent features, and positional/legality features. Forward
+        # selection from the full state feature set may keep any subset
+        # of these (e.g. seat_rel_2 without current_high_bid), so we
+        # accept all categories as valid.
         from ..features.auction_context import PARTNER_FEATURE_NAMES_V2
 
         valid_set = (
@@ -1785,13 +1786,14 @@ def _validate_artifact_features(
             | set(PARTNER_FEATURE_NAMES_V2)
             | _POSITION_FEATURE_SET
             | _OPPONENT_FEATURE_SET
+            | set(_POSITIONAL_FEATURE_NAMES)
         )
         unknown = [f for f in state_names if f not in valid_set]
         if unknown:
             raise ValueError(
                 f"Artifact feature_names structural mismatch. "
                 f"Non-positional model contains unknown state features "
-                f"(not in hand/partner/position/opponent feature set): {unknown}"
+                f"(not in hand/partner/position/opponent/positional feature set): {unknown}"
             )
 
         # Verify action features are at the expected positions
@@ -1849,8 +1851,9 @@ def _validate_pass_model_features(
     else:
         # R0/constrained/selected: pass features should be subset of
         # known hand features, partner v2 features, position features,
-        # and opponent features. Forward selection from the full feature
-        # set may keep any of these while dropping positional features.
+        # opponent features, and positional/legality features. Forward
+        # selection from the full feature set may keep any subset of
+        # these (e.g. seat_rel_2 without current_high_bid).
         from ..features.auction_context import PARTNER_FEATURE_NAMES_V2
 
         valid_set = (
@@ -1858,13 +1861,14 @@ def _validate_pass_model_features(
             | set(PARTNER_FEATURE_NAMES_V2)
             | _POSITION_FEATURE_SET
             | _OPPONENT_FEATURE_SET
+            | set(_POSITIONAL_FEATURE_NAMES)
         )
         unknown = [f for f in pass_feature_names if f not in valid_set]
         if unknown:
             raise ValueError(
                 f"Artifact pass model feature_names mismatch. "
                 f"Non-positional pass model contains unknown features "
-                f"(not in hand/partner/position/opponent feature set): {unknown}"
+                f"(not in hand/partner/position/opponent/positional feature set): {unknown}"
             )
 
 

--- a/tests/unit/test_train_action_value.py
+++ b/tests/unit/test_train_action_value.py
@@ -855,16 +855,38 @@ class TestR0HandOnlyFeatureInference:
             has_positional=True,
         )
 
-    def test_validate_pass_model_r0_with_positional_raises(self):
-        """R0 pass model with positional features but has_positional=False raises."""
-        bad_features = list(_HAND_FEATURE_NAMES) + list(_POSITIONAL_FEATURE_NAMES)
-        with pytest.raises(ValueError, match="mismatch"):
-            _validate_pass_model_features(
-                bad_features,
-                partner_feature_names=[],
-                has_interactions=False,
-                has_positional=False,
-            )
+    def test_validate_pass_model_r0_with_positional_accepted(self):
+        """Pass model with positional features but has_positional=False validates.
+
+        Forward selection may keep positional features (e.g. seat_rel_2) while
+        dropping current_high_bid, resulting in has_positional=False. All
+        positional features should be accepted in the non-positional branch.
+        """
+        features_with_positional = list(_HAND_FEATURE_NAMES) + list(
+            _POSITIONAL_FEATURE_NAMES
+        )
+        # Should not raise
+        _validate_pass_model_features(
+            features_with_positional,
+            partner_feature_names=[],
+            has_interactions=False,
+            has_positional=False,
+        )
+
+    def test_validate_pass_model_selected_positional_subset(self):
+        """Pass model with forward-selected positional subset validates.
+
+        Regression test: forward selection keeps seat_rel_2 but drops
+        current_high_bid. The validator must accept this.
+        """
+        selected = list(_HAND_FEATURE_NAMES) + ["seat_rel_2"]
+        # Should not raise
+        _validate_pass_model_features(
+            selected,
+            partner_feature_names=[],
+            has_interactions=False,
+            has_positional=False,
+        )
 
     def test_validate_artifact_features_r0_selected_subset(self):
         """Forward-selected R0 artifact with 3 hand features validates."""
@@ -891,6 +913,21 @@ class TestR0HandOnlyFeatureInference:
         bad_features = ["bowers", "UNKNOWN_FEATURE"] + list(ACTION_FEATURE_NAMES)
         with pytest.raises(ValueError, match="unknown state features"):
             _validate_artifact_features(bad_features, has_interactions=False)
+
+    def test_validate_artifact_features_selected_with_positional_subset(self):
+        """Forward-selected model with seat_rel_2 but no current_high_bid validates.
+
+        Regression test: forward selection from the full 69-feature set may
+        keep positional features (e.g. seat_rel_2) while dropping
+        current_high_bid. The validator must accept this.
+        """
+        selected = ["bowers", "trump_count", "seat_rel_2"]
+        model_features = selected + list(ACTION_FEATURE_NAMES)
+        partner_names, has_positional = _validate_artifact_features(
+            model_features, has_interactions=False
+        )
+        assert has_positional is False
+        assert partner_names == []
 
     def test_validate_artifact_features_selected_with_partner_v2(self):
         """Forward-selected model with partner v2 features but no positional validates."""


### PR DESCRIPTION
## Plan
N/A — targeted bugfix

## Summary
- Add `_POSITIONAL_FEATURE_NAMES` to the valid feature set in the non-positional branches of `_validate_artifact_features()` and `_validate_pass_model_features()`
- Update test `test_validate_pass_model_r0_with_positional_raises` to expect acceptance instead of rejection
- Add regression tests for forward-selected models that keep positional features without `current_high_bid`

## Why
R2 two-stage models trained with `--feature-set full` (69 features) use forward selection that may keep positional features like `seat_rel_2` while dropping `current_high_bid`. The validator classifies these models as "non-positional" (no `current_high_bid`) and then rejects `seat_rel_2` because the valid feature set only included hand/partner/position/opponent — not positional/legality features. This produces:
```
ValueError: Artifact pass model feature_names mismatch. Non-positional pass model contains unknown features (not in hand/partner/position/opponent feature set): ['seat_rel_2']
```

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_train_action_value.py tests/unit/test_action_value_bidder.py tests/unit/test_two_stage_bidder.py -v -x
make check-quiet
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_train_action_value.py tests/unit/test_action_value_bidder.py tests/unit/test_two_stage_bidder.py -v -x` (120 passed)
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None — validation-only change
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-validate-fix2
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-validate-fix2
```

`git worktree list` (abbreviated):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre               aae5781 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-validate-fix2  2d793b2 [fix/validate-positional-features]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)