### PR TITLE
fix: use default partner names when _needs_full_state is True

### DIFF
--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -2114,7 +2114,9 @@ class ActionValueBidder(BiddingPolicy):
             obs,
             contract_family,
             trump_suit,
-            partner_feature_names=self._partner_feature_names,
+            partner_feature_names=(
+                None if self._needs_full_state else self._partner_feature_names
+            ),
             include_positional=self._has_positional or self._needs_full_state,
         )
         if not self._has_positional and family in self._hand_indices:
@@ -2298,7 +2300,9 @@ class GBTActionValueBidder(BiddingPolicy):
             obs,
             contract_family,
             trump_suit,
-            partner_feature_names=self._partner_feature_names,
+            partner_feature_names=(
+                None if self._needs_full_state else self._partner_feature_names
+            ),
             include_positional=self._has_positional or self._needs_full_state,
         )
         if not self._has_positional and family in self._hand_indices:
@@ -2498,7 +2502,9 @@ class TwoStageActionValueBidder(BiddingPolicy):
             obs,
             contract_family,
             trump_suit,
-            partner_feature_names=self._partner_feature_names,
+            partner_feature_names=(
+                None if self._needs_full_state else self._partner_feature_names
+            ),
             include_positional=self._has_positional or self._needs_full_state,
         )
         if not self._has_positional and family in self._hand_indices:


### PR DESCRIPTION
## Summary
- Pass None for partner_feature_names in _select_state() when _needs_full_state=True
- Ensures extract_state_features() returns full 69-feature vector

## Why
R2 QUICK fails with IndexError: forward selection drops partner features but keeps
opponent/positional ones. Inferred partner names are [] → 63 features instead of 69.

## Tests
85 bidder tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)