### PR TITLE
fix: add evidence_tier + document R1 INVESTIGATE override

### DIFF
--- a/plans/arc_d_v2/r1/checkpoints.md
+++ b/plans/arc_d_v2/r1/checkpoints.md
@@ -36,7 +36,25 @@
 
 ## Blockers
 
-- [ ] R1 features not yet implemented — blocks Steps 1-9
+- [x] R1 features not yet implemented — RESOLVED (PR #694)
+
+## Advance Decision Override
+
+**Decision:** `INVESTIGATE` (H7 surprise: GBT win rate 44.0% vs anchor, below 45% threshold)
+
+**Human override:** PROCEED to R2 (approved 2026-03-15)
+
+**Rationale:** The H7 surprise is explained by the anchor's feature asymmetry, not
+a model deficiency. The R0 anchor (`hybrid_r0_full`) uses legacy hand-only features
+(39). R1 models trained with partner+position features (47 state) bid differently —
+they coordinate with partners and adjust for auction position. But this coordination
+provides no competitive advantage against an opponent that doesn't use the same
+information. The suit R² improvement (+0.033, from 0.588 to 0.621) confirms partner
+features add real predictive signal. The H2H regression is a measurement artifact of
+evaluating against a feature-asymmetric opponent, not evidence that partner context hurts.
+
+**Per LA-3 reversal condition:** This does not trigger revert to FULL because the
+surprise has a clear causal explanation and is not ambiguous.
 
 ## Session Log
 
@@ -48,3 +66,11 @@
   - GBT suit R²: 0.588
   - GBT comparator: 2.201
   - Best comparator: full_ols_av 2.236
+
+### 2026-03-15 — QUICK execution + override
+
+- R1 QUICK completed: 7/9 PASS (H2 FAIL suit delta, H7 SURPRISE 44% win rate)
+- GBT: +0.490 H2H, 0.621 suit R² (+0.033 vs R0), 2.114 comparator
+- Human override: PROCEED to R2 — H7 surprise explained by anchor feature asymmetry
+- R2 results subsequently confirmed the diagnosis: opponent features restored H2H
+  to +1.302 and 57.2% win rate, exceeding R0

--- a/src/bid_euchre/arc_d_v2/advance_check.py
+++ b/src/bid_euchre/arc_d_v2/advance_check.py
@@ -539,6 +539,7 @@ def generate_advance_check(
         "schema_version": "advance_check_v1",
         "rung": rung,
         "mode": mode,
+        "evidence_tier": mode,  # LA-3 provenance: "quick" or "full"
         "advance_decision": decision,
         "reason": reason,
         "timestamp": utc_now_iso(),


### PR DESCRIPTION
## Summary
- Add evidence_tier field to advance check output (LA-3 requirement)
- Document R1 INVESTIGATE override decision with rationale in checkpoints

## Why
Codex review found two provenance gaps: missing evidence_tier and
undocumented R1 override. Both are traceability issues, not scientific blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)