### PR TITLE
fix: remove local make check from review loop

### DIFF
--- a/.claude/rules/deferred/60_review_gate.md
+++ b/.claude/rules/deferred/60_review_gate.md
@@ -36,7 +36,7 @@ Codex CLI is the sole reviewer — local, ~60s latency, uses ChatGPT subscriptio
 |--------|-------------------|----------------------|------|
 | PENDING | `pending` | "Review loop starting" | Dispatcher publishes immediately |
 | IN_PROGRESS | `pending` | "Codex CLI review in progress (round N)" | Each Codex invocation |
-| FAIL | `failure` | "Review blocked — N blockers" | Blocking prechecks, make check fail, loop crash |
+| FAIL | `failure` | "Review blocked — N blockers" | Blocking prechecks, CI failure, loop crash |
 | WARN | `success` | "Review passed — N warnings (follow-up issues created)" | Non-blocking findings only |
 | READY | `success` | "Review passed — clean" | No findings |
 
@@ -47,7 +47,7 @@ Codex CLI is the sole reviewer — local, ~60s latency, uses ChatGPT subscriptio
 3. Dispatcher publishes `pending` status and generates handoff summary (~5s)
 4. `post-pr-review-loop.sh` hook launches `review_driver.py` asynchronously
 5. Loop runs deterministic prechecks (C1/C2/N1/N2/N3/X2/X3)
-6. Loop runs `make check-quiet`
+6. Loop waits for GitHub CI to pass (polls `gh pr checks`)
 7. Loop invokes Codex CLI (`codex review --base main`)
 8. Codex CLI findings are parsed into normalized schema (P0/P1/P2)
 9. Auto-fixable findings (convention patterns) are applied and committed

--- a/docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md
+++ b/docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md
@@ -40,11 +40,17 @@ The dispatcher and the loop hook both fire on `gh pr create`:
 
 ```
 initialized → pr_open → waiting_for_ci → waiting_for_codex → scoring_findings
-                                                                   ↓
-                                              applying_fixes → retesting → waiting_for_ci
-                                                                   ↓
-                                              ready_to_merge → merged (auto-merge enabled)
+                                 ↑                                  ↓
+                                 └── retesting ← applying_fixes
+                                                      ↓
+                                 ready_to_merge → merged (auto-merge enabled)
 ```
+
+**Note:** `pr_open` runs deterministic prechecks (diff-based, no build needed)
+then transitions to `waiting_for_ci`. Local `make check` was removed because
+the review loop runs in the main checkout, not the PR worktree — GitHub CI
+validates on a clean checkout and is the authoritative build gate. Similarly,
+`retesting` (after fixes pushed) transitions directly to `waiting_for_ci`.
 
 The `scoring_findings` state runs confidence-based filtering on P2 findings
 before deciding whether to apply fixes or proceed to merge. Low-confidence

--- a/plans/sessions/2026-03-15_review-loop-skip-local-make-check.md
+++ b/plans/sessions/2026-03-15_review-loop-skip-local-make-check.md
@@ -1,0 +1,45 @@
+# Fix: Review Loop Skip Local `make check`
+
+## Problem
+
+The autonomous review loop (`review_driver.py`) fails at `make check` for all
+recent PRs (#704-#709), never reaching Codex CLI review. State files show
+`stopped_ci_failure` with reason "make check failed in initial validation".
+
+### Root Cause
+
+Two issues combine:
+
+1. **Design flaw:** The review loop runs in the main checkout (triggered by
+   PostToolUse hook), but PRs are created from worktrees. `run_make_check()`
+   uses `Path.cwd()` = main checkout, which has dirty state (untracked files,
+   modified plans, stale fixtures).
+
+2. **Stale fixture (separate bug):** Recent PRs (#703-#707) added 19 new
+   required columns to the action-value dataset schema but never regenerated
+   `data/fixtures/smoke_action_value.parquet`. This causes test failures in
+   any checkout.
+
+## Fix
+
+Remove local `make check` from the review loop. It's redundant with GitHub CI
+(which runs on a clean checkout) and runs in the wrong directory.
+
+### Changes
+
+- `scripts/internal/review_driver.py` — Remove `make check` from `_step_pr_open()`
+  and `_step_retesting()`. Both now transition directly to `WAITING_FOR_CI`.
+- `docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md` — Update state machine diagram and
+  add note explaining why local `make check` was removed.
+- `.claude/rules/deferred/60_review_gate.md` — Update merge protocol steps and
+  status table to reflect CI-only validation.
+
+### Not Changed
+
+- `run_make_check()` in `claude_fix_adapter.py` — Left in place as a utility
+  function (no callers but may be useful for manual invocations).
+- Stale fixture — Separate issue, should be fixed in a follow-up PR.
+
+## Outcome
+
+PR #TBD

--- a/scripts/internal/review_driver.py
+++ b/scripts/internal/review_driver.py
@@ -679,7 +679,7 @@ def _step_pr_open(
     loop_state: ReviewLoopState,
     base_dir: Path | None,
 ) -> ReviewLoopState:
-    """PR_OPEN → WAITING_FOR_CI: Run plan validation + prechecks + make check."""
+    """PR_OPEN → WAITING_FOR_CI: Run plan validation + prechecks."""
     from deterministic_prechecks import check_diff, get_blocking_findings
 
     # 0. Validate plan reference (non-blocking on fetch failures)
@@ -746,22 +746,11 @@ def _step_pr_open(
         )
         return loop_state
 
-    # 2. Run make check (initial validation before CI)
-    from claude_fix_adapter import run_make_check
-
-    if not run_make_check():
-        _publish_status(loop_state.pr_number, "failure", "make check failed")
-        loop_state.transition(ReviewState.STOPPED_CI_FAILURE)
-        loop_state.stop_reason = "make check failed in initial validation"
-        _post_review_comment(loop_state, all_findings_dicts, "blocked")
-        save_state(loop_state, base_dir)
-        logger.warning(
-            "PR #%d: make check failed -- stopped",
-            loop_state.pr_number,
-        )
-        return loop_state
-
-    # 3. Prechecks + make check passed -> wait for CI (remote)
+    # 2. Prechecks passed -> wait for CI (remote)
+    # NOTE: Local `make check` was removed because the review loop runs in the
+    # main checkout (not the PR worktree), so local validation hits dirty state
+    # and stale fixtures unrelated to the PR.  GitHub CI runs on a clean checkout
+    # and is the authoritative build gate — the WAITING_FOR_CI step polls it.
     loop_state.transition(ReviewState.WAITING_FOR_CI)
     save_state(loop_state, base_dir)
     logger.info("PR #%d: pr_open -> waiting_for_ci", loop_state.pr_number)
@@ -1105,44 +1094,19 @@ def _step_retesting(
     loop_state: ReviewLoopState,
     base_dir: Path | None,
 ) -> ReviewLoopState:
-    """RETESTING → WAITING_FOR_CI or STOPPED_CI_FAILURE.
+    """RETESTING → WAITING_FOR_CI: transition to CI polling after fixes pushed.
 
-    Runs make check locally. On success, transitions to WAITING_FOR_CI
-    (CI will re-run on the pushed commit). On failure after 3 retries,
-    stops with STOPPED_CI_FAILURE.
+    Local `make check` was removed — the review loop runs in the main checkout,
+    not the PR worktree, so local validation is unreliable.  The pushed commit
+    triggers GitHub CI which validates on a clean checkout.
     """
-    from claude_fix_adapter import run_make_check
-
-    if run_make_check():
-        loop_state.ci_retry_count = 0
-        loop_state.transition(ReviewState.WAITING_FOR_CI)
-        save_state(loop_state, base_dir)
-        logger.info("PR #%d: make check passed → waiting_for_ci", loop_state.pr_number)
-        return loop_state
-
-    loop_state.ci_retry_count += 1
-    if loop_state.ci_retry_count >= 3:
-        _publish_status(
-            loop_state.pr_number,
-            "failure",
-            f"make check failed {loop_state.ci_retry_count} times",
-        )
-        loop_state.transition(ReviewState.STOPPED_CI_FAILURE)
-        loop_state.stop_reason = f"make check failed {loop_state.ci_retry_count} times"
-        _post_review_comment(loop_state, [], "blocked")
-        save_state(loop_state, base_dir)
-        logger.warning(
-            "PR #%d: make check failed %d times -- stopped",
-            loop_state.pr_number,
-            loop_state.ci_retry_count,
-        )
-    else:
-        save_state(loop_state, base_dir)
-        logger.info(
-            "PR #%d: make check failed (attempt %d/3) — will retry",
-            loop_state.pr_number,
-            loop_state.ci_retry_count,
-        )
+    loop_state.ci_retry_count = 0
+    loop_state.transition(ReviewState.WAITING_FOR_CI)
+    save_state(loop_state, base_dir)
+    logger.info(
+        "PR #%d: retesting → waiting_for_ci (CI validates pushed fixes)",
+        loop_state.pr_number,
+    )
     return loop_state
 
 


### PR DESCRIPTION
## Plan
plans/sessions/2026-03-15_review-loop-skip-local-make-check.md

## Summary
- Remove local `make check` from `_step_pr_open()` and `_step_retesting()` in the review loop driver
- Both steps now transition directly to `WAITING_FOR_CI`, relying on GitHub CI (clean checkout) instead
- Update design doc and review gate rules to reflect CI-only validation

## Why
The review loop runs in the main checkout (triggered by PostToolUse hook), but PRs are created from worktrees. `run_make_check()` uses `Path.cwd()` = main checkout, which has dirty state (untracked files, modified plans, stale fixtures). This caused all recent PRs (#704-#709) to stop at `stopped_ci_failure` with "make check failed in initial validation" — never reaching Codex CLI review.

The loop already has a `WAITING_FOR_CI` state that polls GitHub CI, making the local `make check` redundant.

## Repro / Validation
```bash
# Verify tests pass
uv run python -m pytest tests/unit/test_review_driver.py -v  # 47 passed

# Confirm no references to run_make_check in driver
grep -n run_make_check scripts/internal/review_driver.py  # no matches

# Evidence of the problem (from state files)
cat .claude/runtime/review_loops/pr_707/state.json | jq '.state, .stop_reason'
# "stopped_ci_failure"
# "make check failed in initial validation"
```

## Tests
```bash
uv run python -m pytest tests/unit/test_review_driver.py -v  # 47 passed
uv run ruff check scripts/internal/review_driver.py  # clean
uv run ruff format --check scripts/internal/review_driver.py  # clean
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-review-loop
branch: fix/review-loop-skip-local-make-check
```

## Follow-up
- [ ] Regenerate `data/fixtures/smoke_action_value.parquet` to include new R2 columns (separate issue — causes `test_train_action_value.py` failures in any checkout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)