### PR TITLE
feat: FULL roster trimming and hypothesis SKIP logic (LA-4)

### DIFF
--- a/plans/arc_d_v2/amendments.md
+++ b/plans/arc_d_v2/amendments.md
@@ -10,6 +10,7 @@
 ### LA-1 — [Auction Position Features at R1+](#lineage-amendment-la-1)
 ### LA-2 — [Anchor Compatibility Policy](#lineage-amendment-la-2)
 ### LA-3 — [Hybrid Execution Path: QUICK-First Ladder](#lineage-amendment-la-3)
+### LA-4 — [FULL Roster Trimming](#lineage-amendment-la-4)
 
 ---
 
@@ -162,5 +163,28 @@ in downstream reports or promotion decisions.
 - `run_rung.py --mode quick` remains the primary execution command per rung
 - `run_rung.py --mode all` (QUICK→FULL) is not used under LA-3
 - FULL backfill uses `run_rung.py --mode full` after QUICK results are reviewed
+
+**Approved by:** [human reviewer]
+
+---
+
+## Lineage Amendment LA-4
+
+**Date:** 2026-03-15
+**Type:** roster_trimming
+**Effective from:** FULL mode, all rungs
+**Change:** Trim FULL roster from 8 to 4 models. QUICK roster unchanged.
+
+**Rationale:**
+QUICK results across R0-R2 show three OLS variants (full, constrained, selected) cluster
+within 0.06 net_eppd on comparator and are indistinguishable in H2H. H8 (full = constrained)
+confirmed at QUICK. Legacy baselines (stricthellraiser, rankthetank) add no diagnostic value
+at FULL scale. Trimming saves ~50% compute on FULL runs.
+
+**Retained models:** gbt_av, selected_two_stage_av, full_ols_av, modeloespecifico
+**Dropped models:** constrained_ols_av, selected_ols_av, stricthellraiser, rankthetank
+
+**Impact on hypotheses:** Hypotheses referencing dropped models are automatically SKIPped
+via roster-aware logic in advance_check.py. Hypothesis files remain unchanged.
 
 **Approved by:** [human reviewer]

--- a/plans/arc_d_v2/roster_overlay_full.json
+++ b/plans/arc_d_v2/roster_overlay_full.json
@@ -1,0 +1,3 @@
+{
+  "exclude": ["constrained_ols_av", "selected_ols_av", "stricthellraiser", "rankthetank"]
+}

--- a/src/bid_euchre/arc_d_v2/advance_check.py
+++ b/src/bid_euchre/arc_d_v2/advance_check.py
@@ -99,8 +99,38 @@ def _read_csv_aggregate(
     return None
 
 
-def evaluate_hypothesis(hyp: dict, tables_dir: Path) -> dict:
+def _extract_model_refs(hyp: dict) -> set[str]:
+    """Extract model names referenced in a hypothesis's filters.
+
+    Checks ``source_filter``, ``comparator_filter``, and ``anchor_filter``
+    for a ``"model"`` key and returns the set of referenced model names.
+    """
+    refs: set[str] = set()
+    for key in ("source_filter", "comparator_filter", "anchor_filter"):
+        filt = hyp.get(key)
+        if isinstance(filt, dict) and "model" in filt:
+            refs.add(filt["model"])
+    return refs
+
+
+def evaluate_hypothesis(
+    hyp: dict,
+    tables_dir: Path,
+    active_models: set[str] | None = None,
+) -> dict:
     """Evaluate a single hypothesis against table data.
+
+    Parameters
+    ----------
+    hyp : dict
+        Hypothesis definition from ``hypotheses.json``.
+    tables_dir : Path
+        Directory containing the CSV tables to evaluate against.
+    active_models : set[str] | None
+        When provided, any hypothesis referencing a model NOT in this set
+        is automatically SKIPped (returned as ``pass=True`` with a note).
+        This supports roster trimming (LA-4) without modifying hypothesis
+        files.
 
     Returns a hypothesis check result dict.
     """
@@ -114,6 +144,17 @@ def evaluate_hypothesis(hyp: dict, tables_dir: Path) -> dict:
         "surprise_threshold": None,
         "error": None,
     }
+
+    # Roster-aware SKIP (LA-4): if a referenced model is not active, skip
+    if active_models is not None:
+        model_refs = _extract_model_refs(hyp)
+        excluded = model_refs - active_models
+        if excluded:
+            result["pass"] = True
+            result["note"] = (
+                f"SKIP: model(s) {', '.join(sorted(excluded))} not in active roster"
+            )
+            return result
 
     source_table = hyp.get("source_table")
     source_column = hyp.get("source_column")
@@ -503,14 +544,25 @@ def generate_advance_check(
     tables_dir: Path,
     mode: str,
     rung: str,
+    active_models: set[str] | None = None,
 ) -> dict:
-    """Generate the advance check JSON."""
+    """Generate the advance check JSON.
+
+    Parameters
+    ----------
+    active_models : set[str] | None
+        When provided, hypotheses referencing models outside this set are
+        automatically SKIPped (LA-4 roster trimming).
+    """
     # Load hypotheses
     hyp_data = json.loads(hypotheses_path.read_text())
     hypotheses = hyp_data.get("hypotheses", [])
 
     # Evaluate hypotheses
-    hypothesis_checks = [evaluate_hypothesis(h, tables_dir) for h in hypotheses]
+    hypothesis_checks = [
+        evaluate_hypothesis(h, tables_dir, active_models=active_models)
+        for h in hypotheses
+    ]
 
     # Sufficiency checks
     sufficiency_checks = check_sufficiency(tables_dir, rung)

--- a/src/bid_euchre/arc_d_v2/orchestration.py
+++ b/src/bid_euchre/arc_d_v2/orchestration.py
@@ -200,13 +200,23 @@ def fingerprint_matches(state: RunState, step: str, seed: int, **kwargs) -> bool
 # ---------------------------------------------------------------------------
 
 
-def load_roster(rung: str) -> Roster:
-    """Load lineage roster with optional rung overlay.
+def load_roster(rung: str, mode: str | None = None) -> Roster:
+    """Load lineage roster with optional rung and mode overlays.
 
     Uses the canonical ``Roster.load()`` from ``config.py`` (list format).
 
     Roster file: plans/arc_d_v2/roster.json (lineage-level)
-    Overlay file: plans/arc_d_v2/<rung>/roster_overlay.json (optional)
+    Overlay file: plans/arc_d_v2/<rung>/roster_overlay.json (optional, per-rung)
+    FULL overlay: plans/arc_d_v2/roster_overlay_full.json (optional, LA-4)
+
+    Parameters
+    ----------
+    rung : str
+        Rung identifier (e.g., "r0", "r1").
+    mode : str | None
+        Execution mode ("smoke", "quick", "full"). When ``"full"``, the
+        FULL roster overlay is applied after the rung overlay to trim
+        models that are redundant at FULL scale (see LA-4).
     """
     roster_path = _repo_root() / "plans" / "arc_d_v2" / "roster.json"
     if not roster_path.exists():
@@ -215,6 +225,7 @@ def load_roster(rung: str) -> Roster:
 
     roster = Roster.load(roster_path)
 
+    # Per-rung overlay
     overlay_path = _plans_dir(rung) / "roster_overlay.json"
     if overlay_path.exists():
         overlay = json.loads(overlay_path.read_text())
@@ -237,6 +248,18 @@ def load_roster(rung: str) -> Roster:
                         status=entry.get("status", "active"),
                     )
                 )
+
+    # FULL mode overlay (LA-4: trim redundant models at FULL scale)
+    if mode == "full":
+        full_overlay_path = (
+            _repo_root() / "plans" / "arc_d_v2" / "roster_overlay_full.json"
+        )
+        if full_overlay_path.exists():
+            full_overlay = json.loads(full_overlay_path.read_text())
+            for name in full_overlay.get("exclude", []):
+                for m in roster.models:
+                    if m.name == name:
+                        m.status = "excluded"
 
     return roster
 
@@ -355,7 +378,7 @@ def generate_h2h_roster(
         ...
     ]
     """
-    roster = load_roster(rung)
+    roster = load_roster(rung, mode=mode)
     entries: list[dict] = []
 
     for model in roster.all_active_models():
@@ -411,7 +434,7 @@ def generate_comparator_config(
     - scenarios
     - parameters (n_per, log_level, etc.)
     """
-    roster = load_roster(rung)
+    roster = load_roster(rung, mode=mode)
 
     bidding_policies: list[dict] = []
     for model in roster.all_active_models():
@@ -706,7 +729,7 @@ def execute_step_1(state: RunState, seed: int, dry_run: bool = False) -> bool:
 def execute_step_2(state: RunState, seed: int, dry_run: bool = False) -> bool:
     """Step 2: Train all roster models for one seed."""
     rung = state.rung
-    roster = load_roster(rung)
+    roster = load_roster(rung, mode=state.mode)
     trainable = roster.trainable_models()
 
     _append_log(rung, {"event": "step_start", "step": "2", "seed": seed})
@@ -862,7 +885,7 @@ def _collect_training_artifacts(
     """
     import shutil
 
-    roster = load_roster(state.rung)
+    roster = load_roster(state.rung, mode=state.mode)
     for model in roster.trainable_models():
         output_dir = (
             _repo_root()

--- a/tests/unit/test_rung_orchestrator.py
+++ b/tests/unit/test_rung_orchestrator.py
@@ -16,6 +16,7 @@ import pytest
 
 from bid_euchre.arc_d_v2 import orchestration as run_rung_mod
 from bid_euchre.arc_d_v2.advance_check import (
+    _extract_model_refs,
     check_canaries,
     check_sufficiency,
     compute_decision,
@@ -29,6 +30,7 @@ from bid_euchre.arc_d_v2.orchestration import (
     STEP_FUNCTIONS,
     compute_fingerprint,
     handle_rerun,
+    load_roster,
 )
 from bid_euchre.arc_d_v2.schemas import (
     DAG_DOWNSTREAM,
@@ -1748,3 +1750,282 @@ class TestH2HRosterIncludesAnchor:
 
         anchor = next(e for e in entries if e["name"] == "anchor_hybrid_r0_full")
         assert anchor["class_name"] == "HybridOLSaBidder"
+
+
+# ============================================================================
+# Roster Overlay (LA-4) Tests
+# ============================================================================
+
+
+class TestLoadRosterModeOverlay:
+    """Tests for mode-aware load_roster() with FULL roster trimming (LA-4)."""
+
+    def _setup_roster_files(self, tmp_path):
+        """Create canonical roster and FULL overlay files under tmp_path."""
+        plans_dir = tmp_path / "plans" / "arc_d_v2"
+        plans_dir.mkdir(parents=True)
+
+        roster = {
+            "schema_version": "roster_v1",
+            "lineage_id": "arc_d_v2",
+            "models": [
+                {"name": "gbt_av", "class": "GBTActionValueBidder", "trainable": True},
+                {
+                    "name": "selected_two_stage_av",
+                    "class": "TwoStageActionValueBidder",
+                    "trainable": True,
+                },
+                {
+                    "name": "full_ols_av",
+                    "class": "ActionValueBidder",
+                    "trainable": True,
+                },
+                {
+                    "name": "constrained_ols_av",
+                    "class": "ActionValueBidder",
+                    "trainable": True,
+                },
+                {
+                    "name": "selected_ols_av",
+                    "class": "ActionValueBidder",
+                    "trainable": True,
+                },
+                {
+                    "name": "modeloespecifico",
+                    "class": "ModeloEspecifico",
+                    "trainable": False,
+                    "category": "heuristic",
+                },
+                {
+                    "name": "stricthellraiser",
+                    "class": "StrictHellRaiser",
+                    "trainable": False,
+                    "category": "legacy_baseline",
+                },
+                {
+                    "name": "rankthetank",
+                    "class": "RanktheTank",
+                    "trainable": False,
+                    "category": "legacy_baseline",
+                },
+            ],
+            "anchor": {
+                "name": "anchor_hybrid_r0_full",
+                "artifact": "data/artifacts/arc_d/r0/hybrid_r0_full.json",
+                "class": "HybridOLSaBidder",
+            },
+        }
+        (plans_dir / "roster.json").write_text(json.dumps(roster))
+
+        full_overlay = {
+            "exclude": [
+                "constrained_ols_av",
+                "selected_ols_av",
+                "stricthellraiser",
+                "rankthetank",
+            ]
+        }
+        (plans_dir / "roster_overlay_full.json").write_text(json.dumps(full_overlay))
+
+        # Create rung subdir (for _plans_dir)
+        (plans_dir / "r0").mkdir()
+
+        return plans_dir
+
+    def test_load_roster_full_mode_trims_to_four(self, tmp_path):
+        """load_roster(rung, mode='full') returns only 4 active models."""
+        self._setup_roster_files(tmp_path)
+        with patch.object(run_rung_mod, "_repo_root", return_value=tmp_path):
+            roster = load_roster("r0", mode="full")
+        active = roster.all_active_models()
+        active_names = {m.name for m in active}
+        assert active_names == {
+            "gbt_av",
+            "selected_two_stage_av",
+            "full_ols_av",
+            "modeloespecifico",
+        }
+        assert len(active) == 4
+
+    def test_load_roster_quick_mode_returns_all(self, tmp_path):
+        """load_roster(rung, mode='quick') returns all 8 models."""
+        self._setup_roster_files(tmp_path)
+        with patch.object(run_rung_mod, "_repo_root", return_value=tmp_path):
+            roster = load_roster("r0", mode="quick")
+        active = roster.all_active_models()
+        assert len(active) == 8
+
+    def test_load_roster_no_mode_returns_all(self, tmp_path):
+        """load_roster(rung) with no mode returns all 8 models (backward compat)."""
+        self._setup_roster_files(tmp_path)
+        with patch.object(run_rung_mod, "_repo_root", return_value=tmp_path):
+            roster = load_roster("r0")
+        active = roster.all_active_models()
+        assert len(active) == 8
+
+    def test_load_roster_full_excluded_models_still_in_roster(self, tmp_path):
+        """Excluded models remain in roster.models but with status='excluded'."""
+        self._setup_roster_files(tmp_path)
+        with patch.object(run_rung_mod, "_repo_root", return_value=tmp_path):
+            roster = load_roster("r0", mode="full")
+        excluded_names = {m.name for m in roster.models if m.status == "excluded"}
+        assert excluded_names == {
+            "constrained_ols_av",
+            "selected_ols_av",
+            "stricthellraiser",
+            "rankthetank",
+        }
+
+
+# ============================================================================
+# Hypothesis SKIP with active_models Tests
+# ============================================================================
+
+
+class TestHypothesisSkipLogic:
+    """Tests for roster-aware SKIP logic in evaluate_hypothesis (LA-4)."""
+
+    def test_skip_when_source_model_excluded(self, tmp_path):
+        """Hypothesis referencing excluded model in source_filter is SKIPped."""
+        _write_csv(
+            tmp_path / "comparator_rankings.csv",
+            ["model", "facet", "net_eppd"],
+            [["constrained_ols_av", "pooled", "1.5"]],
+        )
+        hyp = {
+            "id": "H8",
+            "description": "constrained == full OLS",
+            "source_table": "comparator_rankings.csv",
+            "source_column": "net_eppd",
+            "source_filter": {"model": "constrained_ols_av", "facet": "pooled"},
+            "computation": "value",
+            "expected_bound": {"op": ">", "value": 0.0},
+        }
+        active = {"gbt_av", "selected_two_stage_av", "full_ols_av", "modeloespecifico"}
+        result = evaluate_hypothesis(hyp, tmp_path, active_models=active)
+        assert result["pass"] is True
+        assert "SKIP" in result.get("note", "")
+        assert "constrained_ols_av" in result.get("note", "")
+
+    def test_skip_when_comparator_model_excluded(self, tmp_path):
+        """Hypothesis referencing excluded model in comparator_filter is SKIPped."""
+        _write_csv(
+            tmp_path / "comparator_rankings.csv",
+            ["model", "facet", "net_eppd"],
+            [
+                ["full_ols_av", "pooled", "1.5"],
+                ["constrained_ols_av", "pooled", "1.4"],
+            ],
+        )
+        hyp = {
+            "id": "H8",
+            "description": "full vs constrained OLS",
+            "source_table": "comparator_rankings.csv",
+            "source_column": "net_eppd",
+            "source_filter": {"model": "full_ols_av", "facet": "pooled"},
+            "comparator_filter": {"model": "constrained_ols_av", "facet": "pooled"},
+            "computation": "value - comparator_value",
+            "expected_bound": {"op": ">=", "value": -0.2},
+        }
+        active = {"gbt_av", "selected_two_stage_av", "full_ols_av", "modeloespecifico"}
+        result = evaluate_hypothesis(hyp, tmp_path, active_models=active)
+        assert result["pass"] is True
+        assert "SKIP" in result.get("note", "")
+
+    def test_no_skip_when_all_models_active(self, tmp_path):
+        """Hypothesis with all referenced models active is evaluated normally."""
+        _write_csv(
+            tmp_path / "comparator_rankings.csv",
+            ["model", "facet", "net_eppd"],
+            [["gbt_av", "pooled", "1.5"]],
+        )
+        hyp = {
+            "id": "H1",
+            "description": "GBT comparator",
+            "source_table": "comparator_rankings.csv",
+            "source_column": "net_eppd",
+            "source_filter": {"model": "gbt_av", "facet": "pooled"},
+            "computation": "value",
+            "expected_bound": {"op": ">", "value": 1.0},
+        }
+        active = {"gbt_av", "selected_two_stage_av", "full_ols_av", "modeloespecifico"}
+        result = evaluate_hypothesis(hyp, tmp_path, active_models=active)
+        assert result["pass"] is True
+        assert result["observed"] == 1.5
+        assert "note" not in result
+
+    def test_no_skip_when_active_models_none(self, tmp_path):
+        """When active_models is None, no SKIP logic is applied (backward compat)."""
+        _write_csv(
+            tmp_path / "comparator_rankings.csv",
+            ["model", "facet", "net_eppd"],
+            [["constrained_ols_av", "pooled", "1.5"]],
+        )
+        hyp = {
+            "id": "H8",
+            "description": "constrained check",
+            "source_table": "comparator_rankings.csv",
+            "source_column": "net_eppd",
+            "source_filter": {"model": "constrained_ols_av", "facet": "pooled"},
+            "computation": "value",
+            "expected_bound": {"op": ">", "value": 1.0},
+        }
+        result = evaluate_hypothesis(hyp, tmp_path, active_models=None)
+        assert result["pass"] is True
+        assert result["observed"] == 1.5
+        assert "note" not in result
+
+    def test_skip_with_no_model_in_filter(self, tmp_path):
+        """Hypothesis without 'model' in filter is never SKIPped."""
+        _write_csv(
+            tmp_path / "comparator_rankings.csv",
+            ["model", "facet", "bid_rate"],
+            [
+                ["gbt_av", "pooled", "0.9"],
+                ["constrained_ols_av", "pooled", "0.8"],
+            ],
+        )
+        hyp = {
+            "id": "H6",
+            "description": "all models bid > 50%",
+            "source_table": "comparator_rankings.csv",
+            "source_column": "bid_rate",
+            "source_filter": {"facet": "pooled"},
+            "computation": "min",
+            "expected_bound": {"op": ">", "value": 0.5},
+        }
+        # Even with active_models set, no model key in filter -> no skip
+        active = {"gbt_av"}
+        result = evaluate_hypothesis(hyp, tmp_path, active_models=active)
+        assert result["pass"] is True
+        assert "note" not in result
+
+
+class TestExtractModelRefs:
+    """Tests for _extract_model_refs helper."""
+
+    def test_source_filter_only(self):
+        hyp = {"source_filter": {"model": "gbt_av", "facet": "pooled"}}
+        assert _extract_model_refs(hyp) == {"gbt_av"}
+
+    def test_source_and_comparator(self):
+        hyp = {
+            "source_filter": {"model": "gbt_av"},
+            "comparator_filter": {"model": "ols_av"},
+        }
+        assert _extract_model_refs(hyp) == {"gbt_av", "ols_av"}
+
+    def test_anchor_filter(self):
+        hyp = {
+            "source_filter": {"model": "gbt_av"},
+            "anchor_filter": {"model": "anchor_hybrid"},
+        }
+        assert _extract_model_refs(hyp) == {"gbt_av", "anchor_hybrid"}
+
+    def test_no_model_key(self):
+        hyp = {"source_filter": {"facet": "pooled"}}
+        assert _extract_model_refs(hyp) == set()
+
+    def test_no_filters(self):
+        hyp = {"id": "H1", "description": "test"}
+        assert _extract_model_refs(hyp) == set()


### PR DESCRIPTION
## Summary

- Add LA-4 amendment: trim FULL roster from 8 to 4 models (gbt_av, selected_two_stage_av, full_ols_av, modeloespecifico)
- Add `roster_overlay_full.json` with 4 excluded models
- Make `load_roster()` mode-aware: applies FULL overlay when `mode="full"`
- Add roster-aware SKIP logic to `evaluate_hypothesis()`: auto-SKIPs hypotheses referencing excluded models
- 14 new tests covering overlay loading, SKIP logic, and model reference extraction

## Why

QUICK results show three OLS variants cluster within 0.06 net_eppd — redundant at FULL scale. Legacy baselines add no diagnostic value. Trimming saves ~50% FULL compute while preserving all scientifically interesting comparisons (GBT dominance, two-stage comparator/H2H divergence, OLS baseline).

## Repro / Validation

```bash
make check-quiet  # all green
uv run python -m pytest tests/unit/test_rung_orchestrator.py -v  # 14 new tests pass
```

## Tests

```bash
uv run python -m pytest tests/unit/test_rung_orchestrator.py -v
# TestLoadRosterModeOverlay (4 tests)
# TestHypothesisSkipLogic (5 tests)
# TestExtractModelRefs (5 tests)
```

## Worktree proof

Branch: `roster-trim-skip-logic` (worktree-based)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>