### PR TITLE
feat: add moon and loner bid types with overcall hierarchy (R3 Phase A, PR 1/6)

### DIFF
--- a/src/bid_euchre/sim/simulation.py
+++ b/src/bid_euchre/sim/simulation.py
@@ -113,6 +113,7 @@ def play_single_hand(
                     dealer_index = random.Random().randrange(4)
 
         current_high_bid = 0
+        winning_bid_action: Optional[BidAction] = None  # Track full winning bid
         winning_bidder = None
         final_contract = None
         final_trump = None
@@ -139,9 +140,25 @@ def play_single_hand(
                 if bidding_collector is not None:
                     bidding_collector.record_decision(obs, bid_action, deal_id)
 
+                # Determine legality using overcall hierarchy
+                is_dealer = player_idx == dealer_index
+                if bid_action.is_pass():
+                    _is_legal = True
+                elif winning_bid_action is None:
+                    _is_legal = True  # First bid is always legal
+                elif bid_action.overcalls(winning_bid_action):
+                    _is_legal = True
+                elif (
+                    is_dealer
+                    and bid_action.bid_type in {"moon", "loner"}
+                    and winning_bid_action.bid_type == bid_action.bid_type
+                ):
+                    _is_legal = True  # Dealer takeover
+                else:
+                    _is_legal = False
+
                 # Fire bidding decision event if handler registered
                 if on_bidding_decision is not None:
-                    is_legal = bid_action.is_pass() or bid_action.n > current_high_bid
                     on_bidding_decision(
                         BiddingDecisionEvent(
                             deal_id=deal_id,
@@ -153,14 +170,26 @@ def play_single_hand(
                             current_high_bid=current_high_bid,
                             bid_amount=bid_action.n,
                             bid_contract=bid_action.contract,
-                            is_legal=is_legal,
+                            is_legal=_is_legal,
                         )
                     )
 
-                # If bid is pass or <= current high bid, treat as pass
-                is_effective_pass = (
-                    bid_action.is_pass() or bid_action.n <= current_high_bid
-                )
+                # Determine if this bid is an effective pass
+                if bid_action.is_pass():
+                    is_effective_pass = True
+                elif winning_bid_action is None:
+                    is_effective_pass = False  # First bid always accepted
+                elif bid_action.overcalls(winning_bid_action):
+                    is_effective_pass = False
+                elif (
+                    is_dealer
+                    and bid_action.bid_type in {"moon", "loner"}
+                    and winning_bid_action.bid_type == bid_action.bid_type
+                ):
+                    is_effective_pass = False  # Dealer takeover
+                else:
+                    is_effective_pass = True  # Does not overcall
+
                 if is_effective_pass:
                     _transcript.append(
                         {
@@ -182,9 +211,12 @@ def play_single_hand(
                         "tricks_bid": bid_action.n,
                         "contract_type": _ctype,
                         "trump": _trump,
+                        "bid_type": bid_action.bid_type,
                     }
                 )
                 current_high_bid = bid_action.n
+
+                winning_bid_action = bid_action
                 winning_bidder = player_idx
                 final_contract, final_trump = _ctype, _trump
         elif bidding_policy is not None:
@@ -207,9 +239,25 @@ def play_single_hand(
                 if bidding_collector is not None:
                     bidding_collector.record_decision(obs, bid_action, deal_id)
 
+                # Determine legality using overcall hierarchy
+                is_dealer = player_idx == dealer_index
+                if bid_action.is_pass():
+                    _is_legal = True
+                elif winning_bid_action is None:
+                    _is_legal = True
+                elif bid_action.overcalls(winning_bid_action):
+                    _is_legal = True
+                elif (
+                    is_dealer
+                    and bid_action.bid_type in {"moon", "loner"}
+                    and winning_bid_action.bid_type == bid_action.bid_type
+                ):
+                    _is_legal = True  # Dealer takeover
+                else:
+                    _is_legal = False
+
                 # Fire bidding decision event if handler registered
                 if on_bidding_decision is not None:
-                    is_legal = bid_action.is_pass() or bid_action.n > current_high_bid
                     on_bidding_decision(
                         BiddingDecisionEvent(
                             deal_id=deal_id,
@@ -221,14 +269,26 @@ def play_single_hand(
                             current_high_bid=current_high_bid,
                             bid_amount=bid_action.n,
                             bid_contract=bid_action.contract,
-                            is_legal=is_legal,
+                            is_legal=_is_legal,
                         )
                     )
 
-                # If bid is pass or <= current high bid, treat as pass
-                is_effective_pass = (
-                    bid_action.is_pass() or bid_action.n <= current_high_bid
-                )
+                # Determine if this bid is an effective pass
+                if bid_action.is_pass():
+                    is_effective_pass = True
+                elif winning_bid_action is None:
+                    is_effective_pass = False
+                elif bid_action.overcalls(winning_bid_action):
+                    is_effective_pass = False
+                elif (
+                    is_dealer
+                    and bid_action.bid_type in {"moon", "loner"}
+                    and winning_bid_action.bid_type == bid_action.bid_type
+                ):
+                    is_effective_pass = False  # Dealer takeover
+                else:
+                    is_effective_pass = True
+
                 if is_effective_pass:
                     _transcript.append(
                         {
@@ -250,9 +310,12 @@ def play_single_hand(
                         "tricks_bid": bid_action.n,
                         "contract_type": _ctype,
                         "trump": _trump,
+                        "bid_type": bid_action.bid_type,
                     }
                 )
                 current_high_bid = bid_action.n
+
+                winning_bid_action = bid_action
                 winning_bidder = player_idx
                 final_contract, final_trump = _ctype, _trump
         else:

--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -34,16 +34,30 @@ class BidAction:
 
     Either a pass (n=0) or a bid for n tricks with a specific contract.
     For suit contracts, trump_suit must be specified.
+
+    bid_type controls the auction hierarchy:
+    - "regular": Standard bid (levels 1-10)
+    - "moon": All 10 tricks, overcalls any regular bid
+    - "loner": All 10 tricks solo (partner sits out), overcalls moon
     """
 
     n: int  # 0 = pass, 1-10 = bid amount
     contract: Optional[str] = None  # contract type or None for passes
     trump_suit: Optional[str] = None  # trump suit for "suit" contracts
+    bid_type: str = "regular"  # "regular" | "moon" | "loner"
+
+    # Numeric rank for overcall hierarchy comparisons
+    _BID_TYPE_RANK = {"regular": 0, "moon": 1, "loner": 2}
 
     def __post_init__(self):
         """Validate bid action constraints."""
         if self.n < 0 or self.n > 10:
             raise ValueError(f"Bid amount n must be 0-10, got {self.n}")
+
+        if self.bid_type not in {"regular", "moon", "loner"}:
+            raise ValueError(
+                f"bid_type must be 'regular', 'moon', or 'loner', got '{self.bid_type}'"
+            )
 
         if self.n == 0:
             # Pass: contract and trump must be None
@@ -54,6 +68,10 @@ class BidAction:
             if self.trump_suit is not None:
                 raise ValueError(
                     f"Pass (n=0) must have trump_suit=None, got {self.trump_suit}"
+                )
+            if self.bid_type != "regular":
+                raise ValueError(
+                    f"Pass (n=0) must have bid_type='regular', got '{self.bid_type}'"
                 )
         else:
             # Bid: contract must be specified and valid
@@ -71,19 +89,63 @@ class BidAction:
                     f"trump_suit must be None for v1 contracts, got {self.trump_suit}"
                 )
 
+            # Moon and loner are always level 10
+            if self.bid_type in {"moon", "loner"} and self.n != 10:
+                raise ValueError(
+                    f"{self.bid_type} bids must be level 10, got n={self.n}"
+                )
+
     @classmethod
     def pass_bid(cls) -> "BidAction":
         """Create a pass action."""
-        return cls(n=0, contract=None, trump_suit=None)
+        return cls(n=0, contract=None, trump_suit=None, bid_type="regular")
 
     @classmethod
     def bid(cls, n: int, contract: str) -> "BidAction":
-        """Create a bid action."""
-        return cls(n=n, contract=contract, trump_suit=None)
+        """Create a regular bid action."""
+        return cls(n=n, contract=contract, trump_suit=None, bid_type="regular")
+
+    @classmethod
+    def moon(cls, contract: str) -> "BidAction":
+        """Create a moon bid action (always level 10)."""
+        return cls(n=10, contract=contract, trump_suit=None, bid_type="moon")
+
+    @classmethod
+    def loner(cls, contract: str) -> "BidAction":
+        """Create a loner bid action (always level 10)."""
+        return cls(n=10, contract=contract, trump_suit=None, bid_type="loner")
 
     def is_pass(self) -> bool:
         """Return True if this is a pass."""
         return self.n == 0
+
+    def bid_rank(self) -> int:
+        """Return numeric rank for overcall comparisons.
+
+        Hierarchy: regular bids by level < moon < loner.
+        Pass returns -1 (below all bids).
+        """
+        if self.is_pass():
+            return -1
+        type_rank = self._BID_TYPE_RANK[self.bid_type]
+        if self.bid_type == "regular":
+            # Regular bids ranked by level (1-10)
+            return self.n
+        else:
+            # Moon = 11, Loner = 12 (above any regular bid including 10)
+            return 10 + type_rank
+
+    def overcalls(self, other: "BidAction") -> bool:
+        """Return True if this bid strictly overcalls the other bid.
+
+        Overcall hierarchy: regular N < regular N+1 < ... < regular 10 < moon < loner.
+        A pass never overcalls anything. A bid always overcalls a pass.
+        """
+        if self.is_pass():
+            return False
+        if other.is_pass():
+            return True
+        return self.bid_rank() > other.bid_rank()
 
     def to_contract_tuple(self) -> Tuple[Optional[str], Optional[str]]:
         """
@@ -108,19 +170,56 @@ class BidAction:
             raise ValueError(f"Unknown contract: {self.contract}")
 
 
-def enumerate_legal_actions(obs: "BiddingObservation") -> List[BidAction]:
+def enumerate_legal_actions(
+    obs: "BiddingObservation",
+    *,
+    include_moon_loner: bool = False,
+    current_bid_type: str = "regular",
+    is_dealer: bool = False,
+) -> List[BidAction]:
     """Enumerate all legal bidding actions for the current auction state.
 
     Returns actions in canonical order: PASS first, then ascending by
     (bid_level, contract) where contract order follows obs.allowed_contracts.
+    When include_moon_loner=True, moon and loner bids are appended after
+    regular bids.
+
+    Args:
+        obs: Current bidding observation.
+        include_moon_loner: If True, include moon/loner actions when legal.
+        current_bid_type: The bid_type of the current high bid
+            ("regular", "moon", or "loner"). Only relevant when
+            include_moon_loner=True.
+        is_dealer: Whether the current player is the dealer. Dealers can
+            "take away" (match) a moon or loner bid. Only relevant when
+            include_moon_loner=True.
 
     Used by both ActionValueBidder.choose_bid() and the counterfactual
     dataset generator to ensure consistent action enumeration.
     """
     actions: List[BidAction] = [BidAction.pass_bid()]
-    for n in range(obs.current_high_bid + 1, 11):
-        for contract in obs.allowed_contracts:
-            actions.append(BidAction.bid(n, contract))
+
+    # Regular bids: only legal if current high bid is a regular bid
+    if current_bid_type == "regular":
+        for n in range(obs.current_high_bid + 1, 11):
+            for contract in obs.allowed_contracts:
+                actions.append(BidAction.bid(n, contract))
+
+    if include_moon_loner:
+        # Moon bids: legal if current high bid is regular (overcalls it)
+        # or if dealer is taking away a moon
+        if current_bid_type == "regular" or (current_bid_type == "moon" and is_dealer):
+            for contract in obs.allowed_contracts:
+                actions.append(BidAction.moon(contract))
+
+        # Loner bids: legal if current high bid is regular or moon
+        # (overcalls both), or if dealer is taking away a loner
+        if current_bid_type in {"regular", "moon"} or (
+            current_bid_type == "loner" and is_dealer
+        ):
+            for contract in obs.allowed_contracts:
+                actions.append(BidAction.loner(contract))
+
     return actions
 
 

--- a/tests/unit/test_auction_bidding_rules.py
+++ b/tests/unit/test_auction_bidding_rules.py
@@ -1,5 +1,5 @@
 """
-Unit tests for auction bidding rules correctness (v1).
+Unit tests for auction bidding rules correctness (v1 + v2 moon/loner).
 
 These tests lock the v1 auction bidding behavior:
 - One round, starting left of dealer (sequential bidding in LOD order)
@@ -7,7 +7,15 @@ These tests lock the v1 auction bidding behavior:
 - Winner is highest accepted bid (unique)
 - All pass => redeal
 - Contract choices include suit + HIGH + LOW
+
+And v2 moon/loner extensions:
+- Moon and loner BidActions
+- Overcall hierarchy: regular < moon < loner
+- Dealer takeover for moon/loner
+- enumerate_legal_actions with moon/loner support
 """
+
+import pytest
 
 from bid_euchre.core.cards import Card
 from bid_euchre.sim.simulation import play_single_hand
@@ -16,6 +24,7 @@ from bid_euchre.strategy.bidding import (
     BidAction,
     BiddingObservation,
     BiddingPolicy,
+    enumerate_legal_actions,
 )
 
 
@@ -444,3 +453,579 @@ class TestAuctionBiddingRules:
         assert leader == 1, f"Expected leader to be 1 (auction winner), got {leader}"
         assert bid == 6, f"Expected bid to be 6, got {bid}"
         assert bidder_pos == 1, f"Expected bidder position to be 1, got {bidder_pos}"
+
+
+class TestBidActionMoonLoner:
+    """Test BidAction construction and validation for moon/loner bid types."""
+
+    def test_moon_bid_creation(self):
+        """Moon bids can be created via classmethod."""
+        action = BidAction.moon("S")
+        assert action.n == 10
+        assert action.contract == "S"
+        assert action.bid_type == "moon"
+        assert not action.is_pass()
+
+    def test_loner_bid_creation(self):
+        """Loner bids can be created via classmethod."""
+        action = BidAction.loner("HIGH")
+        assert action.n == 10
+        assert action.contract == "HIGH"
+        assert action.bid_type == "loner"
+        assert not action.is_pass()
+
+    def test_moon_all_contracts(self):
+        """Moon bids work for all contract types (suit + HIGH + LOW)."""
+        for contract in ["C", "D", "H", "S", "HIGH", "LOW"]:
+            action = BidAction.moon(contract)
+            assert action.n == 10
+            assert action.contract == contract
+            assert action.bid_type == "moon"
+
+    def test_loner_all_contracts(self):
+        """Loner bids work for all contract types."""
+        for contract in ["C", "D", "H", "S", "HIGH", "LOW"]:
+            action = BidAction.loner(contract)
+            assert action.n == 10
+            assert action.contract == contract
+            assert action.bid_type == "loner"
+
+    def test_moon_must_be_level_10(self):
+        """Moon bids must be level 10."""
+        with pytest.raises(ValueError, match="moon bids must be level 10"):
+            BidAction(n=5, contract="S", bid_type="moon")
+
+    def test_loner_must_be_level_10(self):
+        """Loner bids must be level 10."""
+        with pytest.raises(ValueError, match="loner bids must be level 10"):
+            BidAction(n=8, contract="H", bid_type="loner")
+
+    def test_pass_must_be_regular(self):
+        """Pass bids cannot have moon/loner type."""
+        with pytest.raises(ValueError, match="Pass.*must have bid_type='regular'"):
+            BidAction(n=0, contract=None, bid_type="moon")
+
+    def test_invalid_bid_type(self):
+        """Invalid bid_type raises ValueError."""
+        with pytest.raises(ValueError, match="bid_type must be"):
+            BidAction(n=10, contract="S", bid_type="invalid")
+
+    def test_regular_bid_backward_compat(self):
+        """Regular bids default to bid_type='regular' for backward compatibility."""
+        action = BidAction.bid(5, "S")
+        assert action.bid_type == "regular"
+        action2 = BidAction.pass_bid()
+        assert action2.bid_type == "regular"
+
+    def test_moon_to_contract_tuple(self):
+        """Moon bids convert to contract tuples correctly."""
+        assert BidAction.moon("S").to_contract_tuple() == ("suit", "S")
+        assert BidAction.moon("HIGH").to_contract_tuple() == ("high", None)
+        assert BidAction.moon("LOW").to_contract_tuple() == ("low", None)
+
+    def test_loner_to_contract_tuple(self):
+        """Loner bids convert to contract tuples correctly."""
+        assert BidAction.loner("H").to_contract_tuple() == ("suit", "H")
+        assert BidAction.loner("HIGH").to_contract_tuple() == ("high", None)
+
+    def test_moon_loner_frozen(self):
+        """Moon and loner BidActions are frozen dataclasses."""
+        moon = BidAction.moon("S")
+        with pytest.raises(AttributeError):
+            moon.n = 5  # type: ignore[misc]
+        loner = BidAction.loner("S")
+        with pytest.raises(AttributeError):
+            loner.bid_type = "regular"  # type: ignore[misc]
+
+
+class TestOvercallHierarchy:
+    """Test the overcall hierarchy: regular < moon < loner."""
+
+    def test_regular_overcalls_lower_regular(self):
+        """A regular bid overcalls a lower regular bid."""
+        bid5 = BidAction.bid(5, "S")
+        bid6 = BidAction.bid(6, "H")
+        assert bid6.overcalls(bid5)
+        assert not bid5.overcalls(bid6)
+
+    def test_regular_does_not_overcall_equal(self):
+        """A regular bid does not overcall an equal regular bid."""
+        bid5a = BidAction.bid(5, "S")
+        bid5b = BidAction.bid(5, "H")
+        assert not bid5a.overcalls(bid5b)
+        assert not bid5b.overcalls(bid5a)
+
+    def test_moon_overcalls_any_regular(self):
+        """Moon overcalls any regular bid, including regular 10."""
+        regular10 = BidAction.bid(10, "S")
+        moon = BidAction.moon("S")
+        assert moon.overcalls(regular10)
+        assert not regular10.overcalls(moon)
+
+    def test_moon_overcalls_lower_regular(self):
+        """Moon overcalls lower regular bids."""
+        regular5 = BidAction.bid(5, "S")
+        moon = BidAction.moon("H")
+        assert moon.overcalls(regular5)
+
+    def test_loner_overcalls_moon(self):
+        """Loner overcalls moon."""
+        moon = BidAction.moon("S")
+        loner = BidAction.loner("H")
+        assert loner.overcalls(moon)
+        assert not moon.overcalls(loner)
+
+    def test_loner_overcalls_any_regular(self):
+        """Loner overcalls any regular bid."""
+        regular10 = BidAction.bid(10, "S")
+        loner = BidAction.loner("S")
+        assert loner.overcalls(regular10)
+
+    def test_moon_does_not_overcall_moon(self):
+        """Moon does not overcall another moon (same rank)."""
+        moon_s = BidAction.moon("S")
+        moon_h = BidAction.moon("H")
+        assert not moon_s.overcalls(moon_h)
+        assert not moon_h.overcalls(moon_s)
+
+    def test_loner_does_not_overcall_loner(self):
+        """Loner does not overcall another loner (same rank)."""
+        loner_s = BidAction.loner("S")
+        loner_h = BidAction.loner("H")
+        assert not loner_s.overcalls(loner_h)
+
+    def test_pass_never_overcalls(self):
+        """Pass never overcalls anything."""
+        pass_bid = BidAction.pass_bid()
+        assert not pass_bid.overcalls(BidAction.bid(1, "S"))
+        assert not pass_bid.overcalls(BidAction.moon("S"))
+        assert not pass_bid.overcalls(BidAction.loner("S"))
+        assert not pass_bid.overcalls(BidAction.pass_bid())
+
+    def test_any_bid_overcalls_pass(self):
+        """Any bid overcalls a pass."""
+        pass_bid = BidAction.pass_bid()
+        assert BidAction.bid(1, "S").overcalls(pass_bid)
+        assert BidAction.moon("S").overcalls(pass_bid)
+        assert BidAction.loner("S").overcalls(pass_bid)
+
+    def test_bid_rank_ordering(self):
+        """bid_rank() returns correct ordering for the full hierarchy."""
+        pass_bid = BidAction.pass_bid()
+        regular1 = BidAction.bid(1, "S")
+        regular5 = BidAction.bid(5, "S")
+        regular10 = BidAction.bid(10, "S")
+        moon = BidAction.moon("S")
+        loner = BidAction.loner("S")
+
+        assert pass_bid.bid_rank() < regular1.bid_rank()
+        assert regular1.bid_rank() < regular5.bid_rank()
+        assert regular5.bid_rank() < regular10.bid_rank()
+        assert regular10.bid_rank() < moon.bid_rank()
+        assert moon.bid_rank() < loner.bid_rank()
+
+    def test_regular_cannot_overcall_moon(self):
+        """A regular bid (even level 10) cannot overcall moon."""
+        regular10 = BidAction.bid(10, "S")
+        moon = BidAction.moon("S")
+        assert not regular10.overcalls(moon)
+
+
+class TestEnumerateLegalActionsWithMoonLoner:
+    """Test enumerate_legal_actions with include_moon_loner=True."""
+
+    def _make_obs(self, current_high_bid=0, seat=0, dealer_seat=3):
+        """Helper to create a minimal BiddingObservation."""
+        hand = [Card("S", "A")] * 10  # Dummy hand
+        return BiddingObservation(
+            hand=hand,
+            seat=seat,
+            dealer_seat=dealer_seat,
+            current_high_bid=current_high_bid,
+        )
+
+    def test_without_flag_no_moon_loner(self):
+        """Without include_moon_loner, no moon/loner actions are returned."""
+        obs = self._make_obs(current_high_bid=0)
+        actions = enumerate_legal_actions(obs)
+        for a in actions:
+            assert a.bid_type == "regular" or a.is_pass()
+
+    def test_with_flag_includes_moon_loner(self):
+        """With include_moon_loner=True, moon and loner actions are included."""
+        obs = self._make_obs(current_high_bid=0)
+        actions = enumerate_legal_actions(obs, include_moon_loner=True)
+        moon_actions = [a for a in actions if a.bid_type == "moon"]
+        loner_actions = [a for a in actions if a.bid_type == "loner"]
+        assert len(moon_actions) == 6  # 4 suits + HIGH + LOW
+        assert len(loner_actions) == 6
+
+    def test_moon_blocks_regular_bids(self):
+        """When current high bid is a moon, no regular bids are legal."""
+        obs = self._make_obs(current_high_bid=10)
+        actions = enumerate_legal_actions(
+            obs,
+            include_moon_loner=True,
+            current_bid_type="moon",
+        )
+        regular_bids = [
+            a for a in actions if a.bid_type == "regular" and not a.is_pass()
+        ]
+        assert len(regular_bids) == 0
+
+    def test_moon_allows_loner(self):
+        """When current high bid is a moon, loner overcalls are available."""
+        obs = self._make_obs(current_high_bid=10)
+        actions = enumerate_legal_actions(
+            obs,
+            include_moon_loner=True,
+            current_bid_type="moon",
+        )
+        loner_actions = [a for a in actions if a.bid_type == "loner"]
+        assert len(loner_actions) == 6
+
+    def test_moon_no_moon_for_non_dealer(self):
+        """Non-dealer cannot match a moon (no moon actions when current is moon)."""
+        obs = self._make_obs(current_high_bid=10, seat=0, dealer_seat=3)
+        actions = enumerate_legal_actions(
+            obs,
+            include_moon_loner=True,
+            current_bid_type="moon",
+            is_dealer=False,
+        )
+        moon_actions = [a for a in actions if a.bid_type == "moon"]
+        assert len(moon_actions) == 0
+
+    def test_moon_dealer_can_take_away(self):
+        """Dealer can match a moon bid (takeover)."""
+        obs = self._make_obs(current_high_bid=10, seat=3, dealer_seat=3)
+        actions = enumerate_legal_actions(
+            obs,
+            include_moon_loner=True,
+            current_bid_type="moon",
+            is_dealer=True,
+        )
+        moon_actions = [a for a in actions if a.bid_type == "moon"]
+        assert len(moon_actions) == 6
+
+    def test_loner_blocks_all_except_dealer_loner(self):
+        """When current is loner, only dealer can match with another loner."""
+        obs = self._make_obs(current_high_bid=10, seat=0, dealer_seat=3)
+        actions = enumerate_legal_actions(
+            obs,
+            include_moon_loner=True,
+            current_bid_type="loner",
+            is_dealer=False,
+        )
+        # Only pass should be available for non-dealer
+        non_pass = [a for a in actions if not a.is_pass()]
+        assert len(non_pass) == 0
+
+    def test_loner_dealer_can_take_away(self):
+        """Dealer can match a loner bid."""
+        obs = self._make_obs(current_high_bid=10, seat=3, dealer_seat=3)
+        actions = enumerate_legal_actions(
+            obs,
+            include_moon_loner=True,
+            current_bid_type="loner",
+            is_dealer=True,
+        )
+        loner_actions = [a for a in actions if a.bid_type == "loner"]
+        assert len(loner_actions) == 6
+
+    def test_backward_compat_default_args(self):
+        """Default arguments produce same results as before (no moon/loner)."""
+        obs = self._make_obs(current_high_bid=5)
+        actions_default = enumerate_legal_actions(obs)
+        actions_explicit = enumerate_legal_actions(obs, include_moon_loner=False)
+        assert actions_default == actions_explicit
+
+    def test_pass_always_available(self):
+        """Pass is always available regardless of moon/loner state."""
+        for bid_type in ["regular", "moon", "loner"]:
+            obs = self._make_obs(current_high_bid=10)
+            actions = enumerate_legal_actions(
+                obs,
+                include_moon_loner=True,
+                current_bid_type=bid_type,
+            )
+            assert BidAction.pass_bid() in actions
+
+
+class TestAuctionMoonLonerIntegration:
+    """Integration tests for moon/loner in the auction simulation."""
+
+    def _fixed_hands(self):
+        """Return fixed hands for deterministic auction tests."""
+        hand = [
+            Card("S", "A"),
+            Card("H", "K"),
+            Card("D", "Q"),
+            Card("C", "J"),
+            Card("S", "T"),
+            Card("H", "A"),
+            Card("D", "K"),
+            Card("C", "Q"),
+            Card("S", "J"),
+            Card("H", "T"),
+        ]
+        return [hand.copy() for _ in range(4)]
+
+    def test_moon_wins_over_regular_bid(self):
+        """A moon bid wins over a regular bid 10."""
+
+        class MoonBidder(BiddingPolicy):
+            def choose_bid(self, obs: BiddingObservation) -> BidAction:
+                if obs.seat == 0:
+                    return BidAction.bid(10, "S")  # Regular 10
+                elif obs.seat == 1:
+                    return BidAction.moon("H")  # Moon overcalls
+                return BidAction.pass_bid()
+
+        policy = MoonBidder()
+        hands = self._fixed_hands()
+
+        _, _, _, _, leader, _, bid, _, bidder_pos, contract, trump, transcript = (
+            play_single_hand(
+                contract_type=None,
+                bidding_policy=policy,
+                hands=hands,
+                initial_leader=3,  # dealer=2, LOD order: [3, 0, 1, 2]
+            )
+        )
+
+        assert bidder_pos == 1, f"Moon bidder (seat 1) should win, got {bidder_pos}"
+        assert bid == 10
+        assert contract == "suit"
+        assert trump == "H"
+
+    def test_loner_wins_over_moon(self):
+        """A loner bid wins over a moon bid."""
+
+        class LonerBidder(BiddingPolicy):
+            def choose_bid(self, obs: BiddingObservation) -> BidAction:
+                if obs.seat == 0:
+                    return BidAction.moon("S")  # Moon
+                elif obs.seat == 1:
+                    return BidAction.loner("D")  # Loner overcalls moon
+                return BidAction.pass_bid()
+
+        policy = LonerBidder()
+        hands = self._fixed_hands()
+
+        _, _, _, _, leader, _, bid, _, bidder_pos, contract, trump, _ = (
+            play_single_hand(
+                contract_type=None,
+                bidding_policy=policy,
+                hands=hands,
+                initial_leader=3,
+            )
+        )
+
+        assert bidder_pos == 1, f"Loner bidder (seat 1) should win, got {bidder_pos}"
+        assert contract == "suit"
+        assert trump == "D"
+
+    def test_regular_cannot_overcall_moon(self):
+        """A regular bid after a moon is treated as pass."""
+
+        class RegularAfterMoon(BiddingPolicy):
+            def choose_bid(self, obs: BiddingObservation) -> BidAction:
+                if obs.seat == 0:
+                    return BidAction.moon("S")
+                elif obs.seat == 1:
+                    return BidAction.bid(10, "H")  # Regular 10 cannot beat moon
+                return BidAction.pass_bid()
+
+        policy = RegularAfterMoon()
+        hands = self._fixed_hands()
+
+        _, _, _, _, _, _, _, _, bidder_pos, contract, trump, transcript = (
+            play_single_hand(
+                contract_type=None,
+                bidding_policy=policy,
+                hands=hands,
+                initial_leader=3,
+            )
+        )
+
+        # Moon bidder (seat 0) should still be the winner
+        assert bidder_pos == 0, f"Moon bidder (seat 0) should win, got {bidder_pos}"
+        assert trump == "S"
+
+        # Verify transcript shows seat 1 as PASS
+        seat_1_entry = [e for e in transcript if e["seat"] == 1][0]
+        assert seat_1_entry["action"] == "PASS"
+
+    def test_dealer_takeover_moon(self):
+        """Dealer can take away a moon bid by bidding moon."""
+
+        class DealerTakeoverMoon(BiddingPolicy):
+            def choose_bid(self, obs: BiddingObservation) -> BidAction:
+                if obs.seat == 0:
+                    return BidAction.moon("S")  # Non-dealer bids moon
+                elif obs.seat == 2:
+                    return BidAction.moon("H")  # Dealer takes it away
+                return BidAction.pass_bid()
+
+        policy = DealerTakeoverMoon()
+        hands = self._fixed_hands()
+
+        # Dealer is seat 2, LOD order: [3, 0, 1, 2]
+        _, _, _, _, _, _, _, _, bidder_pos, contract, trump, _ = play_single_hand(
+            contract_type=None,
+            bidding_policy=policy,
+            hands=hands,
+            initial_leader=3,  # dealer = (3-1)%4 = 2
+        )
+
+        # Dealer (seat 2) should take away the moon
+        assert bidder_pos == 2, f"Dealer (seat 2) should take moon, got {bidder_pos}"
+        assert trump == "H"
+
+    def test_dealer_takeover_loner(self):
+        """Dealer can take away a loner bid by bidding loner."""
+
+        class DealerTakeoverLoner(BiddingPolicy):
+            def choose_bid(self, obs: BiddingObservation) -> BidAction:
+                if obs.seat == 0:
+                    return BidAction.loner("S")  # Non-dealer bids loner
+                elif obs.seat == 2:
+                    return BidAction.loner("D")  # Dealer takes it away
+                return BidAction.pass_bid()
+
+        policy = DealerTakeoverLoner()
+        hands = self._fixed_hands()
+
+        _, _, _, _, _, _, _, _, bidder_pos, contract, trump, _ = play_single_hand(
+            contract_type=None,
+            bidding_policy=policy,
+            hands=hands,
+            initial_leader=3,
+        )
+
+        assert bidder_pos == 2, f"Dealer (seat 2) should take loner, got {bidder_pos}"
+        assert trump == "D"
+
+    def test_non_dealer_cannot_takeover_moon(self):
+        """Non-dealer cannot match a moon bid (treated as pass)."""
+
+        class NonDealerMoonMatch(BiddingPolicy):
+            def choose_bid(self, obs: BiddingObservation) -> BidAction:
+                if obs.seat == 0:
+                    return BidAction.moon("S")  # First moon
+                elif obs.seat == 1:
+                    return BidAction.moon("H")  # Non-dealer tries to match
+                return BidAction.pass_bid()
+
+        policy = NonDealerMoonMatch()
+        hands = self._fixed_hands()
+
+        _, _, _, _, _, _, _, _, bidder_pos, _, trump, transcript = play_single_hand(
+            contract_type=None,
+            bidding_policy=policy,
+            hands=hands,
+            initial_leader=3,
+        )
+
+        # Seat 0 should still win (seat 1's moon treated as pass)
+        assert bidder_pos == 0, f"Seat 0 should win, got {bidder_pos}"
+        assert trump == "S"
+
+        seat_1_entry = [e for e in transcript if e["seat"] == 1][0]
+        assert seat_1_entry["action"] == "PASS"
+
+    def test_moon_with_per_seat_policies(self):
+        """Moon/loner work with per-seat bidding policies too."""
+
+        class MoonBidder(BiddingPolicy):
+            def choose_bid(self, obs: BiddingObservation) -> BidAction:
+                return BidAction.moon("S")
+
+        class PassBidder(BiddingPolicy):
+            def choose_bid(self, obs: BiddingObservation) -> BidAction:
+                return BidAction.pass_bid()
+
+        policies = [MoonBidder(), PassBidder(), PassBidder(), PassBidder()]
+        hands = self._fixed_hands()
+
+        _, _, _, _, _, _, bid, _, bidder_pos, contract, trump, _ = play_single_hand(
+            contract_type=None,
+            bidding_policies=policies,
+            hands=hands,
+            initial_leader=3,
+        )
+
+        assert bidder_pos == 0
+        assert bid == 10
+        assert trump == "S"
+
+    def test_transcript_records_bid_type(self):
+        """Auction transcript records bid_type for moon/loner bids."""
+
+        class MoonBidder(BiddingPolicy):
+            def choose_bid(self, obs: BiddingObservation) -> BidAction:
+                if obs.seat == 0:
+                    return BidAction.moon("S")
+                return BidAction.pass_bid()
+
+        policy = MoonBidder()
+        hands = self._fixed_hands()
+
+        *_, transcript = play_single_hand(
+            contract_type=None,
+            bidding_policy=policy,
+            hands=hands,
+            initial_leader=3,
+        )
+
+        # Find the BID entry in the transcript
+        bid_entries = [e for e in transcript if e["action"] == "BID"]
+        assert len(bid_entries) == 1
+        assert bid_entries[0]["bid_type"] == "moon"
+
+    def test_moon_high_contract(self):
+        """Moon with HIGH contract works correctly."""
+
+        class MoonHighBidder(BiddingPolicy):
+            def choose_bid(self, obs: BiddingObservation) -> BidAction:
+                if obs.seat == 0:
+                    return BidAction.moon("HIGH")
+                return BidAction.pass_bid()
+
+        policy = MoonHighBidder()
+        hands = self._fixed_hands()
+
+        _, _, _, _, _, _, bid, _, bidder_pos, contract, trump, _ = play_single_hand(
+            contract_type=None,
+            bidding_policy=policy,
+            hands=hands,
+            initial_leader=3,
+        )
+
+        assert bidder_pos == 0
+        assert contract == "high"
+        assert trump is None
+
+    def test_moon_low_contract(self):
+        """Moon with LOW contract works correctly."""
+
+        class MoonLowBidder(BiddingPolicy):
+            def choose_bid(self, obs: BiddingObservation) -> BidAction:
+                if obs.seat == 0:
+                    return BidAction.moon("LOW")
+                return BidAction.pass_bid()
+
+        policy = MoonLowBidder()
+        hands = self._fixed_hands()
+
+        _, _, _, _, _, _, bid, _, bidder_pos, contract, trump, _ = play_single_hand(
+            contract_type=None,
+            bidding_policy=policy,
+            hands=hands,
+            initial_leader=3,
+        )
+
+        assert bidder_pos == 0
+        assert contract == "low"
+        assert trump is None


### PR DESCRIPTION
## Summary

- Add `bid_type` field to `BidAction`: `"regular"` (default), `"moon"`, `"loner"`
- Add `BidAction.moon()` and `BidAction.loner()` factory methods (always level 10)
- Add `bid_rank()` and `overcalls()` methods for hierarchy comparison
- Update `enumerate_legal_actions()` with opt-in `include_moon_loner` flag
- Implement dealer takeover logic in auction resolution (`simulation.py`)
- 44 new tests covering bid construction, overcall hierarchy, legal action enumeration, and end-to-end auction integration

## Why

R3 Phase A (lineage plan §6.4) requires engine support for moon (±20, 2-card partner exchange) and loner (±40, partner sits out) bid types. This is the first of 6 PRs — it adds the bid types and auction resolution only. Scoring, trick play, card exchange, and logging are separate PRs.

## Design

- **Overcall hierarchy:** `regular(1-10) < moon(11) < loner(12)`
- **Dealer takeover:** Dealer can match a moon/loner bid to "steal" it. Non-dealers cannot match.
- **Backward compatible:** All new parameters default to existing behavior. `enumerate_legal_actions()` without `include_moon_loner=True` returns exactly the same actions as before. Regular bid behavior is unchanged.

## Repro / Validation

```bash
make check-quiet  # all green
uv run python -m pytest tests/unit/test_auction_bidding_rules.py -v --seed 42  # 51 tests (7 existing + 44 new)
```

## Tests

```bash
uv run python -m pytest tests/unit/test_auction_bidding_rules.py -v
# TestBidActionMoonLoner (12 tests)
# TestOvercallHierarchy (12 tests)
# TestEnumerateLegalActionsWithMoonLoner (10 tests)
# TestAuctionMoonLonerIntegration (10 tests)
```

## Worktree proof

Branch: `r3/moon-loner-bid-types` (worktree-based)

## R3 Phase A PR Chain

- **PR 1/6: Bid types + auction** (this PR)
- PR 2/6: Card exchange phase
- PR 3/6: 3-player trick play (loner)
- PR 4/6: Scoring + logging
- PR 5/6: Dataset generator + action features
- PR 6/6: SMOKE validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>