### PR TITLE
docs: add rebase-before-PR convention

### DIFF
--- a/.claude/rules/10_workflow.md
+++ b/.claude/rules/10_workflow.md
@@ -6,6 +6,7 @@
 
 Before any PR (Tier 2):
 
+    git fetch origin main && git rebase origin/main   # Avoid stale-base conflicts
     make check-quiet    # Full validation, minimal output (logs to tmpfile)
     make check          # Full validation, full output
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Bid Euchre AI Research Framework — a Python framework for deterministic simula
 
 ### Pre-Commit Checklist
 
+- Run `git fetch origin main && git rebase origin/main` before opening a PR to avoid stale-base conflicts.
 - Run full `make check` (or equivalent test suite) before creating any PR.
 - Verify no uncommitted notebook changes that would trigger git diff checks.
 - Run linter (`ruff check --fix`) and formatter (`ruff format`) on all changed files.


### PR DESCRIPTION
## Summary
- Add `git fetch origin main && git rebase origin/main` as the first step in the pre-commit checklist
- Added to both `CLAUDE.md` and `.claude/rules/10_workflow.md`

## Why
PRs #709, #711, and #715 all required manual conflict resolution because they were pushed from stale bases. This convention prevents that by ensuring branches are current before `make check` and PR creation.

## Repro / Validation
```bash
make check-quiet  # passes clean
```

## Tests
No code changes — docs only.

## Worktree proof
Branch: `docs/rebase-before-pr` (worktree at `../Bid-Euchre-rebase-convention`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)