### PR TITLE
feat: 3-player loner trick play (R3 Phase A, PR 3/6)

### DIFF
--- a/src/bid_euchre/sim/simulation.py
+++ b/src/bid_euchre/sim/simulation.py
@@ -95,6 +95,8 @@ def play_single_hand(
     dealer_index = None  # Track dealer position (0-3 or None if no bidding)
     bidder_position = None  # Track auction winner (0-3 or None)
     _transcript: Optional[List[Dict[str, Any]]] = None  # Auction transcript (schema v7)
+    winning_bid_action: Optional[BidAction] = None  # Track full winning bid
+    winning_bidder: Optional[int] = None  # Track auction winner seat
 
     if contract_type is None:
         # Determine dealer
@@ -113,8 +115,6 @@ def play_single_hand(
                     dealer_index = random.Random().randrange(4)
 
         current_high_bid = 0
-        winning_bid_action: Optional[BidAction] = None  # Track full winning bid
-        winning_bidder = None
         final_contract = None
         final_trump = None
         _transcript = []  # Accumulate per-seat bid actions (schema v7)
@@ -505,6 +505,17 @@ def play_single_hand(
                 initial_leader = random.Random().randrange(4)
     leader = initial_leader
 
+    # Determine active seats for trick play (loner bids exclude declarer's partner)
+    sitting_out_seat: Optional[int] = None
+    if (
+        winning_bid_action is not None
+        and winning_bid_action.bid_type == "loner"
+        and winning_bidder is not None
+    ):
+        # Partner sits out: partnerships are (0,2) and (1,3)
+        sitting_out_seat = (winning_bidder + 2) % 4
+    players_per_trick = 3 if sitting_out_seat is not None else 4
+
     # Fire on_hand_start hooks for strategies that implement them
     # CRITICAL: De-duplicate by instance identity to avoid calling hooks multiple times
     # when a single strategy instance is shared across seats (common in self-play)
@@ -547,9 +558,19 @@ def play_single_hand(
         plays = []
         trick_leader = leader
 
-        # Players act in order starting from leader
-        for offset in range(4):
-            player = (leader + offset) % 4
+        # Build play order for this trick (skipping sitting-out seat for loners)
+        if sitting_out_seat is not None:
+            play_order = []
+            p = leader
+            for _ in range(players_per_trick):
+                while p == sitting_out_seat:
+                    p = (p + 1) % 4
+                play_order.append(p)
+                p = (p + 1) % 4
+        else:
+            play_order = [(leader + offset) % 4 for offset in range(4)]
+
+        for player in play_order:
             hand = hands[player]
 
             # Engine-level guardrail: enforce legal plays (not just in strategies).

--- a/tests/integration/test_loner_game.py
+++ b/tests/integration/test_loner_game.py
@@ -1,0 +1,429 @@
+"""Integration tests for loner trick play (3-player games).
+
+Validates that when a loner bid wins the auction, the declarer's partner
+sits out of trick play, each trick has 3 cards, lead rotation skips the
+sitting-out player, and regular/moon games remain unaffected.
+"""
+
+import random
+from collections import defaultdict
+from typing import Dict, List
+
+import pytest
+
+from bid_euchre.core.cards import create_deck, deal_hands, shuffle_deck
+from bid_euchre.sim.simulation import play_single_hand
+from bid_euchre.strategy import GreedyStrategy
+from bid_euchre.strategy.bidding import BidAction, BiddingObservation, BiddingPolicy
+
+
+class AlwaysLonerPolicy(BiddingPolicy):
+    """A bidding policy that always bids loner with a fixed contract.
+
+    Used for testing loner trick play mechanics. The first player to bid
+    wins the auction since loner overcalls everything.
+    """
+
+    def __init__(self, contract: str = "H", seat_to_bid: int = 0):
+        self.contract = contract
+        self.seat_to_bid = seat_to_bid
+
+    @property
+    def strategy_id(self) -> str:
+        return "always_loner"
+
+    def choose_bid(self, obs: BiddingObservation) -> BidAction:
+        if obs.seat == self.seat_to_bid:
+            return BidAction.loner(self.contract)
+        return BidAction.pass_bid()
+
+
+class AlwaysMoonPolicy(BiddingPolicy):
+    """A bidding policy that always bids moon with a fixed contract."""
+
+    def __init__(self, contract: str = "H", seat_to_bid: int = 0):
+        self.contract = contract
+        self.seat_to_bid = seat_to_bid
+
+    @property
+    def strategy_id(self) -> str:
+        return "always_moon"
+
+    def choose_bid(self, obs: BiddingObservation) -> BidAction:
+        if obs.seat == self.seat_to_bid:
+            return BidAction.moon(self.contract)
+        return BidAction.pass_bid()
+
+
+class AlwaysRegularPolicy(BiddingPolicy):
+    """A bidding policy that always bids a regular bid."""
+
+    def __init__(self, contract: str = "H", bid_n: int = 6, seat_to_bid: int = 0):
+        self.contract = contract
+        self.bid_n = bid_n
+        self.seat_to_bid = seat_to_bid
+
+    @property
+    def strategy_id(self) -> str:
+        return "always_regular"
+
+    def choose_bid(self, obs: BiddingObservation) -> BidAction:
+        if obs.seat == self.seat_to_bid:
+            return BidAction.bid(self.bid_n, self.contract)
+        return BidAction.pass_bid()
+
+
+class TrackingStrategy(GreedyStrategy):
+    """GreedyStrategy that tracks which seats play cards and trick sizes."""
+
+    def __init__(self):
+        super().__init__()
+        self.plays_by_seat: Dict[int, int] = defaultdict(int)
+        self.trick_sizes: List[int] = []
+        self._current_trick_plays: int = 0
+        self._last_trick_num: int = -1
+
+    def choose_card(self, hand, plays_so_far, contract_type, trump_suit, player_index):
+        self.plays_by_seat[player_index] += 1
+
+        # Track trick sizes: when plays_so_far is empty, a new trick started
+        if len(plays_so_far) == 0:
+            if self._current_trick_plays > 0:
+                self.trick_sizes.append(self._current_trick_plays)
+            self._current_trick_plays = 1
+        else:
+            self._current_trick_plays += 1
+
+        return super().choose_card(
+            hand=hand,
+            plays_so_far=plays_so_far,
+            contract_type=contract_type,
+            trump_suit=trump_suit,
+            player_index=player_index,
+        )
+
+    def finalize_trick_tracking(self):
+        """Call after the game to record the last trick."""
+        if self._current_trick_plays > 0:
+            self.trick_sizes.append(self._current_trick_plays)
+            self._current_trick_plays = 0
+
+
+# Partnership map: seat -> partner seat
+_PARTNER = {0: 2, 1: 3, 2: 0, 3: 1}
+
+
+class TestLonerTrickPlay:
+    """Test that loner bids produce 3-player trick play."""
+
+    @pytest.mark.parametrize("declarer_seat", [0, 1, 2, 3])
+    def test_loner_game_completes(self, declarer_seat):
+        """A full loner game completes with 10 tricks of 3 cards each."""
+        rng = random.Random(42 + declarer_seat)
+        deck = create_deck()
+        shuffle_deck(deck, rng=rng)
+        hands = deal_hands(deck, num_players=4, hand_size=10)
+
+        result = play_single_hand(
+            contract_type=None,
+            bidding_policies=[
+                AlwaysLonerPolicy(contract="H", seat_to_bid=declarer_seat)
+            ]
+            * 4,
+            hands=hands,
+            initial_leader=declarer_seat,
+            deal_id=0,
+            rng=rng,
+        )
+
+        t0, t1 = result[0], result[1]
+        # Total tricks must still sum to 10
+        assert t0 + t1 == 10, f"Expected 10 total tricks, got {t0 + t1}"
+
+    @pytest.mark.parametrize("declarer_seat", [0, 1, 2, 3])
+    def test_partner_never_plays_in_loner(self, declarer_seat):
+        """The declarer's partner should not play any cards during loner."""
+        rng = random.Random(100 + declarer_seat)
+        deck = create_deck()
+        shuffle_deck(deck, rng=rng)
+        hands = deal_hands(deck, num_players=4, hand_size=10)
+
+        partner_seat = _PARTNER[declarer_seat]
+        tracker = TrackingStrategy()
+
+        play_single_hand(
+            contract_type=None,
+            bidding_policies=[
+                AlwaysLonerPolicy(contract="H", seat_to_bid=declarer_seat)
+            ]
+            * 4,
+            strategy=tracker,
+            hands=hands,
+            initial_leader=declarer_seat,
+            deal_id=0,
+            rng=rng,
+        )
+
+        # Partner should never have played
+        assert tracker.plays_by_seat[partner_seat] == 0, (
+            f"Partner (seat {partner_seat}) played {tracker.plays_by_seat[partner_seat]} "
+            f"cards, expected 0"
+        )
+
+    @pytest.mark.parametrize("declarer_seat", [0, 1, 2, 3])
+    def test_active_players_play_10_cards_each(self, declarer_seat):
+        """Each active player (non-sitting-out) should play exactly 10 cards."""
+        rng = random.Random(200 + declarer_seat)
+        deck = create_deck()
+        shuffle_deck(deck, rng=rng)
+        hands = deal_hands(deck, num_players=4, hand_size=10)
+
+        partner_seat = _PARTNER[declarer_seat]
+        tracker = TrackingStrategy()
+
+        play_single_hand(
+            contract_type=None,
+            bidding_policies=[
+                AlwaysLonerPolicy(contract="H", seat_to_bid=declarer_seat)
+            ]
+            * 4,
+            strategy=tracker,
+            hands=hands,
+            initial_leader=declarer_seat,
+            deal_id=0,
+            rng=rng,
+        )
+
+        # Active players should have played 10 cards each
+        for seat in range(4):
+            if seat == partner_seat:
+                assert (
+                    tracker.plays_by_seat[seat] == 0
+                ), f"Sitting-out seat {seat} played {tracker.plays_by_seat[seat]} cards"
+            else:
+                assert tracker.plays_by_seat[seat] == 10, (
+                    f"Active seat {seat} played {tracker.plays_by_seat[seat]} cards, "
+                    f"expected 10"
+                )
+
+    @pytest.mark.parametrize("declarer_seat", [0, 1, 2, 3])
+    def test_loner_tricks_have_3_cards(self, declarer_seat):
+        """Each trick in a loner game should have exactly 3 cards."""
+        rng = random.Random(400 + declarer_seat)
+        deck = create_deck()
+        shuffle_deck(deck, rng=rng)
+        hands = deal_hands(deck, num_players=4, hand_size=10)
+
+        tracker = TrackingStrategy()
+
+        play_single_hand(
+            contract_type=None,
+            bidding_policies=[
+                AlwaysLonerPolicy(contract="H", seat_to_bid=declarer_seat)
+            ]
+            * 4,
+            strategy=tracker,
+            hands=hands,
+            initial_leader=declarer_seat,
+            deal_id=0,
+            rng=rng,
+        )
+
+        tracker.finalize_trick_tracking()
+
+        assert (
+            len(tracker.trick_sizes) == 10
+        ), f"Expected 10 tricks, got {len(tracker.trick_sizes)}"
+        for i, size in enumerate(tracker.trick_sizes):
+            assert size == 3, f"Trick {i} had {size} cards, expected 3"
+
+    def test_regular_game_still_works(self):
+        """Regular (non-loner) games are unaffected by loner logic."""
+        rng = random.Random(42)
+        deck = create_deck()
+        shuffle_deck(deck, rng=rng)
+        hands = deal_hands(deck, num_players=4, hand_size=10)
+
+        tracker = TrackingStrategy()
+
+        result = play_single_hand(
+            contract_type=None,
+            bidding_policies=[AlwaysRegularPolicy(contract="H", bid_n=6)] * 4,
+            strategy=tracker,
+            hands=hands,
+            initial_leader=0,
+            deal_id=0,
+            rng=rng,
+        )
+
+        t0, t1 = result[0], result[1]
+        assert t0 + t1 == 10
+
+        # All players should have played 10 cards each
+        for seat in range(4):
+            assert (
+                tracker.plays_by_seat[seat] == 10
+            ), f"Seat {seat} played {tracker.plays_by_seat[seat]} cards, expected 10"
+
+    def test_moon_game_still_4_players(self):
+        """Moon bids should still use 4-player trick play."""
+        rng = random.Random(42)
+        deck = create_deck()
+        shuffle_deck(deck, rng=rng)
+        hands = deal_hands(deck, num_players=4, hand_size=10)
+
+        tracker = TrackingStrategy()
+
+        result = play_single_hand(
+            contract_type=None,
+            bidding_policies=[AlwaysMoonPolicy(contract="H")] * 4,
+            strategy=tracker,
+            hands=hands,
+            initial_leader=0,
+            deal_id=0,
+            rng=rng,
+        )
+
+        t0, t1 = result[0], result[1]
+        assert t0 + t1 == 10
+
+        # All 4 players should have played 10 cards each
+        for seat in range(4):
+            assert (
+                tracker.plays_by_seat[seat] == 10
+            ), f"Seat {seat} played {tracker.plays_by_seat[seat]} cards, expected 10"
+
+    def test_fixed_contract_still_4_players(self):
+        """Fixed-contract mode (no auction) should still use 4-player tricks."""
+        rng = random.Random(42)
+        deck = create_deck()
+        shuffle_deck(deck, rng=rng)
+        hands = deal_hands(deck, num_players=4, hand_size=10)
+
+        tracker = TrackingStrategy()
+
+        result = play_single_hand(
+            contract_type="suit",
+            trump_suit="H",
+            strategy=tracker,
+            hands=hands,
+            initial_leader=0,
+            deal_id=0,
+            rng=rng,
+        )
+
+        t0, t1 = result[0], result[1]
+        assert t0 + t1 == 10
+
+        for seat in range(4):
+            assert (
+                tracker.plays_by_seat[seat] == 10
+            ), f"Seat {seat} played {tracker.plays_by_seat[seat]} cards, expected 10"
+
+    def test_loner_determinism(self):
+        """Same seed + config should produce identical loner results."""
+        results = []
+        for _ in range(2):
+            rng = random.Random(42)
+            deck = create_deck()
+            shuffle_deck(deck, rng=rng)
+            hands = deal_hands(deck, num_players=4, hand_size=10)
+
+            result = play_single_hand(
+                contract_type=None,
+                bidding_policies=[AlwaysLonerPolicy(contract="H", seat_to_bid=0)] * 4,
+                hands=hands,
+                initial_leader=0,
+                deal_id=0,
+                rng=rng,
+            )
+            results.append((result[0], result[1]))
+
+        assert results[0] == results[1], "Loner games should be deterministic"
+
+    @pytest.mark.parametrize("declarer_seat", [0, 1, 2, 3])
+    def test_loner_trick_count_correct(self, declarer_seat):
+        """Tricks won should be valid for 3-player games."""
+        rng = random.Random(300 + declarer_seat)
+        deck = create_deck()
+        shuffle_deck(deck, rng=rng)
+        hands = deal_hands(deck, num_players=4, hand_size=10)
+
+        result = play_single_hand(
+            contract_type=None,
+            bidding_policies=[
+                AlwaysLonerPolicy(contract="H", seat_to_bid=declarer_seat)
+            ]
+            * 4,
+            hands=hands,
+            initial_leader=declarer_seat,
+            deal_id=0,
+            rng=rng,
+        )
+
+        t0, t1 = result[0], result[1]
+        # Total must be 10 (10 tricks played)
+        assert t0 + t1 == 10
+        # Both teams should get at least 0 tricks
+        assert t0 >= 0
+        assert t1 >= 0
+
+    def test_loner_with_no_trump_contract(self):
+        """Loner works with high no-trump contract."""
+        rng = random.Random(42)
+        deck = create_deck()
+        shuffle_deck(deck, rng=rng)
+        hands = deal_hands(deck, num_players=4, hand_size=10)
+
+        tracker = TrackingStrategy()
+
+        result = play_single_hand(
+            contract_type=None,
+            bidding_policies=[AlwaysLonerPolicy(contract="HIGH", seat_to_bid=0)] * 4,
+            strategy=tracker,
+            hands=hands,
+            initial_leader=0,
+            deal_id=0,
+            rng=rng,
+        )
+
+        t0, t1 = result[0], result[1]
+        assert t0 + t1 == 10
+
+        # Partner (seat 2) should not have played
+        assert (
+            tracker.plays_by_seat[2] == 0
+        ), f"Partner played {tracker.plays_by_seat[2]} cards, expected 0"
+
+    @pytest.mark.parametrize("declarer_seat", [0, 1, 2, 3])
+    def test_lead_rotation_skips_sitting_out(self, declarer_seat):
+        """The lead rotation should never assign the sitting-out player as leader."""
+        rng = random.Random(500 + declarer_seat)
+        deck = create_deck()
+        shuffle_deck(deck, rng=rng)
+        hands = deal_hands(deck, num_players=4, hand_size=10)
+
+        partner_seat = _PARTNER[declarer_seat]
+        tracker = TrackingStrategy()
+
+        play_single_hand(
+            contract_type=None,
+            bidding_policies=[
+                AlwaysLonerPolicy(contract="H", seat_to_bid=declarer_seat)
+            ]
+            * 4,
+            strategy=tracker,
+            hands=hands,
+            initial_leader=declarer_seat,
+            deal_id=0,
+            rng=rng,
+        )
+
+        # Sitting-out partner should never have played (which means they never led)
+        assert (
+            tracker.plays_by_seat[partner_seat] == 0
+        ), f"Partner (seat {partner_seat}) should never play or lead in loner"
+
+        # Total plays should be 30 (3 players x 10 tricks)
+        total_plays = sum(tracker.plays_by_seat.values())
+        assert total_plays == 30, f"Expected 30 total plays, got {total_plays}"

--- a/tests/unit/test_rules.py
+++ b/tests/unit/test_rules.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from bid_euchre.core.cards import Card
@@ -73,7 +72,10 @@ class TestTrickWinner:
         plays = [
             (0, Card("H", "A")),  # Player 0: Ace of hearts (led suit)
             (1, Card("H", "K")),  # Player 1: King of hearts
-            (2, Card("H", "J")),  # Player 2: Jack of hearts (RIGHT bower when hearts trump)
+            (
+                2,
+                Card("H", "J"),
+            ),  # Player 2: Jack of hearts (RIGHT bower when hearts trump)
             (3, Card("S", "A")),  # Player 3: Ace of spades
         ]
 
@@ -85,7 +87,10 @@ class TestTrickWinner:
         plays = [
             (0, Card("H", "A")),  # Player 0: Ace of hearts (led suit)
             (1, Card("H", "K")),  # Player 1: King of hearts
-            (2, Card("D", "J")),  # Player 2: Jack of diamonds (LEFT bower when hearts trump)
+            (
+                2,
+                Card("D", "J"),
+            ),  # Player 2: Jack of diamonds (LEFT bower when hearts trump)
             (3, Card("S", "A")),  # Player 3: Ace of spades
         ]
 
@@ -103,6 +108,60 @@ class TestTrickWinner:
 
         winner = trick_winner(plays, "suit", "H")
         assert winner == 1  # Right bower beats left bower
+
+
+class TestTrickWinner3Cards:
+    """Test trick_winner with 3-card tricks (loner games)."""
+
+    def test_trick_winner_3_cards_suit_contract(self):
+        """Trick winner works correctly with only 3 cards played."""
+        plays = [
+            (0, Card("H", "T")),  # Player 0: 10 of hearts (led)
+            (1, Card("H", "K")),  # Player 1: King of hearts
+            (3, Card("H", "Q")),  # Player 3: Queen of hearts (player 2 sitting out)
+        ]
+        winner = trick_winner(plays, "suit", "S")
+        assert winner == 1  # King is highest heart
+
+    def test_trick_winner_3_cards_with_trump(self):
+        """Trump wins in 3-card trick."""
+        plays = [
+            (0, Card("H", "T")),  # Player 0: 10 of hearts (led)
+            (1, Card("S", "Q")),  # Player 1: Queen of spades (trump)
+            (3, Card("H", "A")),  # Player 3: Ace of hearts
+        ]
+        winner = trick_winner(plays, "suit", "S")
+        assert winner == 1  # Trump wins
+
+    def test_trick_winner_3_cards_high_contract(self):
+        """High no-trump works with 3 cards."""
+        plays = [
+            (1, Card("D", "K")),  # Player 1: King of diamonds (led)
+            (2, Card("D", "A")),  # Player 2: Ace of diamonds
+            (3, Card("S", "A")),  # Player 3: Ace of spades (offsuit)
+        ]
+        winner = trick_winner(plays, "high", None)
+        assert winner == 2  # Ace of diamonds wins
+
+    def test_trick_winner_3_cards_low_contract(self):
+        """Low no-trump works with 3 cards."""
+        plays = [
+            (0, Card("C", "A")),  # Player 0: Ace of clubs (led, lowest in low)
+            (1, Card("C", "T")),  # Player 1: 10 of clubs (highest in low)
+            (3, Card("C", "K")),  # Player 3: King of clubs
+        ]
+        winner = trick_winner(plays, "low", None)
+        assert winner == 1  # 10 is highest in low contract
+
+    def test_trick_winner_3_cards_bower_wins(self):
+        """Right bower wins in 3-card trick."""
+        plays = [
+            (0, Card("H", "A")),  # Player 0: Ace of hearts
+            (1, Card("H", "J")),  # Player 1: Right bower (hearts trump)
+            (3, Card("D", "J")),  # Player 3: Left bower
+        ]
+        winner = trick_winner(plays, "suit", "H")
+        assert winner == 1  # Right bower wins
 
 
 class TestHighestTrump:
@@ -198,7 +257,11 @@ class TestGetLegalIndices:
 
     def test_left_bower_is_trump_suit(self):
         """Left bower should be treated as trump suit for follow-suit."""
-        hand = [Card("D", "J"), Card("S", "K"), Card("C", "Q")]  # D-J is left bower when H is trump
+        hand = [
+            Card("D", "J"),
+            Card("S", "K"),
+            Card("C", "Q"),
+        ]  # D-J is left bower when H is trump
         plays_so_far = [(0, Card("H", "T"))]  # Hearts led
         legal = get_legal_indices(hand, plays_so_far, "suit", "H")
         # D-J has effective suit of Hearts (left bower), so it's the only legal play
@@ -220,7 +283,11 @@ class TestGetLegalIndices:
 
     def test_trump_led_must_follow_trump(self):
         """When trump is led, must follow with trump if possible."""
-        hand = [Card("H", "A"), Card("S", "K"), Card("D", "Q")]  # S-K is only trump (spades trump)
+        hand = [
+            Card("H", "A"),
+            Card("S", "K"),
+            Card("D", "Q"),
+        ]  # S-K is only trump (spades trump)
         plays_so_far = [(0, Card("S", "T"))]  # Spades (trump) led
         legal = get_legal_indices(hand, plays_so_far, "suit", "S")
         # Only S-K follows spades


### PR DESCRIPTION
## Summary

- Modify trick play loop in `simulation.py` to support 3-player loner games
- Partner (declarer's teammate) sits out — 3-card tricks, 10 tricks total
- Lead rotation skips sitting-out player
- `trick_winner()` already handles variable-length plays — no changes needed
- 34 new tests (5 unit + 29 integration)

## Why

R3 Phase A (lineage plan §6.4): loner = declarer plays solo against 2 opponents, partner sits out.

## Repro / Validation

```bash
make check-quiet
uv run python -m pytest tests/unit/test_rules.py tests/integration/test_loner_game.py -v --seed 42
```

## R3 Phase A PR Chain

- PR 1/6: Bid types + auction (#717, merged)
- PR 2/6: Card exchange (#721, open)
- **PR 3/6: Loner trick play** (this PR)
- PR 4/6: Scoring + logging (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>