### PR TITLE
docs: add roadmap sequencing for autonomous-ops and browser-game

### DIFF
--- a/plans/browser_game/governing_plan.md
+++ b/plans/browser_game/governing_plan.md
@@ -158,6 +158,22 @@ To maximize the chance of a working product in a couple of days:
 - Prefer idempotent HTTP actions over websockets
 - Treat Phase 4 exports as launch support, not a reason to delay the playable product
 
+## 6.5 Relationship to Autonomous-Ops Redesign
+
+> **Reference:** `plans/sessions/2026-03-15_autonomous-agent-ops-workflow.md`
+
+The autonomous-ops redesign is **foundational infrastructure for browser-game execution** but **not a blocker**. The browser-game initiative involves more parallel tracks than Arc D (domain engine, backend API, frontend product, replay/export, deployment), which creates real multi-agent coordination pressure that the ops redesign is designed to address.
+
+**Sequencing relative to this initiative:**
+
+| Browser-game phase | Ops infrastructure available | Benefit |
+|--------------------|------------------------------|---------|
+| Phase 0-2 (foundation → backend API) | Ops PRs 1-2 (workflow scaffold, tmux, VS Code audit) | Role-based worktrees and audit surface for parallel domain + API work |
+| Phase 3 (frontend product) | Ops PRs 3-4 landing (operator CLI, health checks, memory/index) | `ops.py status` for monitoring parallel backend + frontend agents |
+| Phase 5 (deployment and launch) | Ops PR-5 (rollout, safety, recovery) | Recovery templates and context safety before external exposure |
+
+The ops PRs are not prerequisites for starting browser-game work. Phases 0-2 can proceed with the informal workflow improvements (Ghostty, tmux, role worktrees) already adopted. The heavier ops infrastructure lands progressively as coordination complexity grows.
+
 ## 7. Execution Structure
 
 ### 7.1 Phases / Milestones

--- a/plans/sessions/2026-03-15_autonomous-agent-ops-workflow.md
+++ b/plans/sessions/2026-03-15_autonomous-agent-ops-workflow.md
@@ -11,6 +11,56 @@
 - PR-4: Add a two-layer memory system: small curated memory for stable operator facts plus a local audit index over execution logs, review artifacts, checkpoints, and manifests for searchable history.
 - PR-5: Roll out the autonomous workflow in stages, validate that it works for real tasks, add skill-promotion and context-safety workflows, and retire ad hoc “multiple terminals in one checkout” usage.
 
+## Sequencing — Roadmap Position
+
+> **Decision date:** 2026-03-15
+> **Context:** Arc D v2 R0-R2 QUICK complete, R3 engine in progress, FULL backfill running. Browser-game initiative ACTIVE but not yet started.
+
+This plan is a **staged enabling track**, not a monolithic blocker. It should not pause Arc D and should not be deferred until after everything else. The thin slice lands right after R3 QUICK; the heavier infrastructure lands as browser-game creates real multi-agent coordination pressure.
+
+### Immediate (now, during Arc D sprint)
+
+Adopt **user-side workflow changes only** — no repo PRs required:
+- Ghostty (or equivalent) as primary terminal host
+- `tmux` for persistent sessions
+- Role-based worktrees (informal adoption of `author`/`review`/`ops` convention)
+- VS Code as audit surface for diffs, plans, and runtime artifacts
+
+These reduce operational pain immediately and require no shared-repo changes.
+
+### After R3 QUICK first stable pass → PRs 1-2
+
+Land the **lightweight workflow scaffolding**:
+- **PR-1:** Worktree/bootstrap contract, role conventions, session/task metadata
+- **PR-2:** tmux launcher, VS Code audit workspace and tasks
+
+These are low-risk (mostly tooling/docs) but change shared repo behavior, so they should not land in the middle of the active research loop.
+
+### Before browser-game backend/frontend parallelism → PRs 3-4
+
+Land the **operator CLI and memory/index layer**:
+- **PR-3:** `ops.py` CLI, health checks, recovery templates
+- **PR-4:** Curated memory, audit index, session compaction/archive
+
+These are cross-cutting and will be easier to design once Arc D runtime artifacts and operational pain points are stable. The browser-game initiative is exactly the kind of work that benefits most — it involves parallel tracks (domain engine, backend API, frontend product, replay/export, deployment) that create real multi-agent coordination pressure.
+
+### Before hosted-play becomes externally exposed → PR-5
+
+Land the **higher-autonomy safeguards**:
+- **PR-5:** Rollout validation, agent profiles, context safety, shadow snapshots
+
+This must be in place before the hosted product is operationally important or externally exposed.
+
+### Summary Sequence
+
+| Step | Trigger | Deliverables |
+|------|---------|-------------|
+| 1 | Now | User-side workflow (Ghostty, tmux, role worktrees, VS Code) |
+| 2 | R3 QUICK stable pass | PRs 1-2 (scaffold) |
+| 3 | Browser-game Phase 0/1/2 starts | Browser-game benefits from improved agent workflow |
+| 4 | Browser-game enters backend/frontend parallelism | PRs 3-4 (operator CLI, memory/index) |
+| 5 | Before hosted-play external exposure | PR-5 (rollout, safety, recovery) |
+
 ## Decisions
 
 ### Target Workflow


### PR DESCRIPTION
## Plan
- N/A (roadmap/sequencing decision, not implementation)

## Summary
- Adds a "Sequencing — Roadmap Position" section to `plans/sessions/2026-03-15_autonomous-agent-ops-workflow.md` defining when each ops PR should land relative to Arc D v2 and browser-game
- Adds §6.5 to `plans/browser_game/governing_plan.md` documenting the relationship between ops infrastructure and browser-game phases

## Why
The autonomous-ops redesign needs a clear place on the roadmap to avoid either blocking Arc D or being indefinitely deferred. This PR establishes it as a staged enabling track: user-side workflow now, lightweight scaffolding after R3 QUICK, heavier infra as browser-game parallelism creates real pressure, and safety safeguards before external exposure.

## Repro / Validation
**Command(s) run:**
- Docs-only PR, no code changes

**Config (if applicable):**
- N/A

**Seed (if applicable):**
- N/A

## Tests
- [x] Other: Docs-only change, pre-commit hooks pass

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-roadmap-sequencing
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-roadmap-sequencing
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                   8e68111 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-roadmap-sequencing e8257b5 [roadmap-sequencing]
(+ others)
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)