### PR TITLE
feat: moon/loner scoring and hand-end logging v8 (R3 Phase A, PR 4/6)

### DIFF
--- a/docs/01_core/RULES.md
+++ b/docs/01_core/RULES.md
@@ -356,14 +356,39 @@ Points are awarded per hand as follows:
   - `points_declaring_team = -bid_tricks`
   - `points_defending_team = tricks_defending`
 
-### 6.4 All-pass redeal events
+### 6.4 Moon and loner bid scoring
+
+Moon and loner bids are special bid types that require winning **all 10 tricks** to make.
+The `bid_type` field on a bid action distinguishes these from regular bids.
+
+#### 6.4.1 Moon bid (`bid_type="moon"`)
+
+- **Make** (`tricks_declaring == 10`): `points_declaring_team = +20`
+- **Fail** (`tricks_declaring < 10`): `points_declaring_team = -20`
+- **Defending team** always scores `tricks_defending` (same as regular bids)
+
+#### 6.4.2 Loner bid (`bid_type="loner"`)
+
+- **Make** (`tricks_declaring == 10`): `points_declaring_team = +40`
+- **Fail** (`tricks_declaring < 10`): `points_declaring_team = -40`
+- **Defending team** always scores `tricks_defending` (same as regular bids)
+
+#### 6.4.3 Summary table
+
+| Bid type | Make condition | Make points | Fail points | Defending points |
+|----------|---------------|-------------|-------------|------------------|
+| regular  | tricks >= bid | tricks won  | -bid        | tricks won       |
+| moon     | tricks == 10  | +20         | -20         | tricks won       |
+| loner    | tricks == 10  | +40         | -40         | tricks won       |
+
+### 6.5 All-pass redeal events
 
 If the auction results in an all-pass redeal event (Section 3.5):
 - No tricks are played
 - No points are awarded
 - Declarer/contract fields are null
 
-### 6.5 Placeholder: match scoring (future)
+### 6.6 Placeholder: match scoring (future)
 
 A future experiment mode may aggregate per-hand points into a running match score (e.g., first to target points, fixed number of hands). This is intentionally out of scope for the current phase.
 

--- a/src/bid_euchre/logging/game_logger.py
+++ b/src/bid_euchre/logging/game_logger.py
@@ -30,7 +30,9 @@ from typing import Any, Dict, List, Optional, Tuple
 # v5 adds `dealer_position` and `bidder_position` to hand_end records.
 # v6 adds `redeal_flag` and `made_bid` to hand_end records.
 # v7 adds `auction_transcript` to hand_end records.
-SCHEMA_VERSION = 7
+# v8 adds `bid_type`, `exchange_cards_given`, `exchange_cards_received`,
+#    and `sitting_out_seat` to hand_end records.
+SCHEMA_VERSION = 8
 
 
 class LogLevel(Enum):
@@ -70,6 +72,16 @@ class HandEndRecord:
     made_bid: Optional[bool] = None  # True if declaring team made their bid (schema v6)
     auction_transcript: Optional[List[Dict[str, Any]]] = (
         None  # 4-entry list or null (schema v7)
+    )
+    bid_type: Optional[str] = None  # "regular" | "moon" | "loner" or null (schema v8)
+    exchange_cards_given: Optional[List[List[str]]] = (
+        None  # Cards given during moon exchange, each as [suit, rank] (schema v8)
+    )
+    exchange_cards_received: Optional[List[List[str]]] = (
+        None  # Cards received during moon exchange, each as [suit, rank] (schema v8)
+    )
+    sitting_out_seat: Optional[int] = (
+        None  # Seat number sitting out during loner (schema v8)
     )
     timestamp: str = ""
 
@@ -209,6 +221,10 @@ class GameLogger:
         redeal_flag: Optional[bool] = None,
         made_bid: Optional[bool] = None,
         auction_transcript: Optional[List[Dict[str, Any]]] = None,
+        bid_type: Optional[str] = None,
+        exchange_cards_given: Optional[List[Any]] = None,
+        exchange_cards_received: Optional[List[Any]] = None,
+        sitting_out_seat: Optional[int] = None,
     ) -> None:
         """
         Log the completion of a hand.
@@ -230,6 +246,10 @@ class GameLogger:
             redeal_flag: True if all players passed (all-pass redeal) (schema v6+)
             made_bid: True if declaring team made their bid (schema v6+)
             auction_transcript: 4-entry list of per-seat bid actions (schema v7+)
+            bid_type: "regular", "moon", or "loner" (schema v8+)
+            exchange_cards_given: Cards given during moon exchange (schema v8+)
+            exchange_cards_received: Cards received during moon exchange (schema v8+)
+            sitting_out_seat: Seat sitting out during loner (schema v8+)
         """
         if not self.is_enabled:
             return
@@ -238,6 +258,18 @@ class GameLogger:
         hands_json: Optional[List[List[List[str]]]] = None
         if hands is not None:
             hands_json = [[[card.suit, card.rank] for card in hand] for hand in hands]
+
+        # Convert exchange Card objects to [suit, rank] lists
+        exchange_given_json: Optional[List[List[str]]] = None
+        if exchange_cards_given is not None:
+            exchange_given_json = [
+                [card.suit, card.rank] for card in exchange_cards_given
+            ]
+        exchange_received_json: Optional[List[List[str]]] = None
+        if exchange_cards_received is not None:
+            exchange_received_json = [
+                [card.suit, card.rank] for card in exchange_cards_received
+            ]
 
         record = HandEndRecord(
             schema_version=SCHEMA_VERSION,
@@ -260,6 +292,10 @@ class GameLogger:
             redeal_flag=redeal_flag,
             made_bid=made_bid,
             auction_transcript=auction_transcript,
+            bid_type=bid_type,
+            exchange_cards_given=exchange_given_json,
+            exchange_cards_received=exchange_received_json,
+            sitting_out_seat=sitting_out_seat,
             timestamp=self._timestamp(),
         )
         self._write_record(asdict(record))

--- a/src/bid_euchre/scoring.py
+++ b/src/bid_euchre/scoring.py
@@ -12,6 +12,7 @@ def compute_points(
     bidder_position: Optional[int],
     tricks_team0: int,
     tricks_team1: int,
+    bid_type: str = "regular",
 ) -> tuple[int, int]:
     """
     Compute points for both teams based on euchre scoring rules.
@@ -21,6 +22,7 @@ def compute_points(
         bidder_position: The seat position (0-3) of the winning bidder, or None if no bidding
         tricks_team0: Number of tricks taken by team 0 (seats 0, 2)
         tricks_team1: Number of tricks taken by team 1 (seats 1, 3)
+        bid_type: Type of bid — "regular", "moon", or "loner" (default "regular")
 
     Returns:
         Tuple of (points_team0, points_team1)
@@ -28,10 +30,17 @@ def compute_points(
     Scoring rules:
     - If no bidding occurred (winning_bid or bidder_position is None):
       Both teams get their tricks taken as points
-    - If bid team makes the bid (bid_team_tricks >= winning_bid):
-      Bid team gets their tricks taken, non-bid team gets their tricks taken
-    - If bid team gets set (bid_team_tricks < winning_bid):
-      Bid team gets -winning_bid, non-bid team gets their tricks taken
+    - bid_type="regular":
+      - Make (bid_team_tricks >= winning_bid): bid team gets tricks, defending gets tricks
+      - Set (bid_team_tricks < winning_bid): bid team gets -winning_bid, defending gets tricks
+    - bid_type="moon":
+      - Make (bid_team_tricks == 10): declaring team gets +20
+      - Fail (bid_team_tricks < 10): declaring team gets -20
+      - Defending team always gets their tricks won
+    - bid_type="loner":
+      - Make (bid_team_tricks == 10): declaring team gets +40
+      - Fail (bid_team_tricks < 10): declaring team gets -40
+      - Defending team always gets their tricks won
     """
     # No bidding case: both teams get their tricks
     if winning_bid is None or bidder_position is None:
@@ -42,6 +51,29 @@ def compute_points(
     bid_team_tricks = tricks_team0 if bid_team_is_team0 else tricks_team1
     non_bid_team_tricks = tricks_team1 if bid_team_is_team0 else tricks_team0
 
+    if bid_type == "moon":
+        # Moon: must win all 10 tricks for +20, else -20
+        if bid_team_tricks == 10:
+            bid_team_points = 20
+        else:
+            bid_team_points = -20
+        if bid_team_is_team0:
+            return bid_team_points, non_bid_team_tricks
+        else:
+            return non_bid_team_tricks, bid_team_points
+
+    if bid_type == "loner":
+        # Loner: must win all 10 tricks for +40, else -40
+        if bid_team_tricks == 10:
+            bid_team_points = 40
+        else:
+            bid_team_points = -40
+        if bid_team_is_team0:
+            return bid_team_points, non_bid_team_tricks
+        else:
+            return non_bid_team_tricks, bid_team_points
+
+    # Regular bid scoring
     if bid_team_tricks >= winning_bid:
         # Bid made: bid team gets their tricks, non-bid team gets their tricks
         if bid_team_is_team0:

--- a/src/bid_euchre/sim/simulation.py
+++ b/src/bid_euchre/sim/simulation.py
@@ -52,6 +52,7 @@ def play_single_hand(
     str,
     Optional[str],
     Optional[List[Dict[str, Any]]],
+    str,
 ]:
     """
     Play one full 10-trick hand.
@@ -60,7 +61,7 @@ def play_single_hand(
     The winner of the bid chooses the contract and leads the first trick.
 
     Returns:
-        (t0, t1, scores, features, leader, hands, bid, dealer_pos, bidder_pos, final_contract, final_trump, auction_transcript)
+        (t0, t1, scores, features, leader, hands, bid, dealer_pos, bidder_pos, final_contract, final_trump, auction_transcript, bid_type)
     """
     # Resolve strategy-per-seat.
     if strategies is not None:
@@ -439,6 +440,7 @@ def play_single_hand(
                 dummy_ctype,
                 None,
                 _transcript,
+                "regular",
             )
 
         contract_type = final_contract
@@ -464,6 +466,10 @@ def play_single_hand(
                 contract_type=contract_type,
                 trump_suit=trump_suit,
             )
+        # Extract bid_type from winning bid action (if available)
+        _bid_type = (
+            winning_bid_action.bid_type if winning_bid_action is not None else "regular"
+        )
     else:
         # Contract was fixed, no bid was made
         current_high_bid = None
@@ -471,6 +477,7 @@ def play_single_hand(
         dealer_index = None
         bidder_position = None
         _transcript = None  # null distinguishes "no bidding mode" from "all passed"
+        _bid_type = "regular"
 
     # Validation (now that contract is decided)
     if contract_type == "suit" and trump_suit is None:
@@ -655,6 +662,7 @@ def play_single_hand(
         contract_type,
         trump_suit,
         _transcript,
+        _bid_type,
     )
 
 
@@ -781,6 +789,7 @@ def simulate_many_hands(
                 actual_contract,
                 actual_trump,
                 auction_transcript,
+                bid_type,
             ) = play_single_hand(
                 contract_type=contract_type,
                 trump_suit=trump_suit,
@@ -809,6 +818,7 @@ def simulate_many_hands(
                 actual_contract,
                 actual_trump,
                 auction_transcript,
+                bid_type,
             ) = play_single_hand(
                 contract_type=contract_type,
                 trump_suit=trump_suit,
@@ -854,6 +864,7 @@ def simulate_many_hands(
                 redeal_flag=redeal_flag,
                 made_bid=made_bid,
                 auction_transcript=auction_transcript,
+                bid_type=bid_type,
             )
 
         # Fire HandEndEvent if hooks registered
@@ -895,7 +906,9 @@ def simulate_many_hands(
             ties += 1
 
         # Compute and track points-based scoring
-        points_team0, points_team1 = compute_points(winning_bid, bidder_pos, t0, t1)
+        points_team0, points_team1 = compute_points(
+            winning_bid, bidder_pos, t0, t1, bid_type=bid_type
+        )
         total_points_team0 += points_team0
         total_points_team1 += points_team1
         dist_points_team0[points_team0] = dist_points_team0.get(points_team0, 0) + 1

--- a/tests/integration/test_bidding_logic.py
+++ b/tests/integration/test_bidding_logic.py
@@ -64,7 +64,7 @@ def test_misdeal_logic():
     # RandomLegalStrategy always returns 0 for decide_bid (default)
     strategies = [RandomLegalStrategy() for _ in range(4)]
 
-    t0, t1, scores, feats, leader, hands, bid, _, _, _, _, _ = play_single_hand(
+    t0, t1, scores, feats, leader, hands, bid, _, _, _, _, _, _ = play_single_hand(
         contract_type=None, strategies=strategies
     )
 
@@ -87,7 +87,7 @@ def test_artifact_bidder_initial_bid():
     ]
 
     # Play hand with contract_type=None to trigger bidding
-    t0, t1, _, _, leader, _, bid, _, _, _, _, _ = play_single_hand(
+    t0, t1, _, _, leader, _, bid, _, _, _, _, _, _ = play_single_hand(
         contract_type=None, strategies=strategies, initial_leader=0
     )
 
@@ -108,7 +108,7 @@ def test_bid_winner_leads():
         RandomLegalStrategy(),
     ]
 
-    t0, t1, _, _, leader, _, bid, _, _, _, _, _ = play_single_hand(
+    t0, t1, _, _, leader, _, bid, _, _, _, _, _, _ = play_single_hand(
         contract_type=None,
         strategies=strategies,
         initial_leader=1,  # make someone else dealer so Seat 0 is LOD

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -33,6 +33,7 @@ class TestEndToEndSimulation:
             _,
             _,
             _,
+            _,
         ) = result
 
         # Basic validation

--- a/tests/integration/test_model_integration.py
+++ b/tests/integration/test_model_integration.py
@@ -39,7 +39,7 @@ def test_artifact_strategy_plays_single_hand():
     strategies = [strategy, strategy, strategy, strategy]
 
     try:
-        t0, t1, _, _, leader, _, bid, dealer, bidder, contract, trump, _ = (
+        t0, t1, _, _, leader, _, bid, dealer, bidder, contract, trump, _, _ = (
             play_single_hand(
                 contract_type=None,  # Trigger bidding
                 strategies=strategies,
@@ -76,7 +76,7 @@ def test_artifact_strategy_plays_multiple_hands():
 
     for i in range(n_hands):
         try:
-            t0, t1, _, _, leader, _, bid, dealer, bidder, contract, trump, _ = (
+            t0, t1, _, _, leader, _, bid, dealer, bidder, contract, trump, _, _ = (
                 play_single_hand(
                     contract_type=None, strategies=strategies, deal_seed=42 + i
                 )
@@ -111,7 +111,7 @@ def test_artifact_strategy_different_contracts():
     ]
 
     try:
-        t0, t1, _, _, leader, _, bid, dealer, bidder, contract, trump, _ = (
+        t0, t1, _, _, leader, _, bid, dealer, bidder, contract, trump, _, _ = (
             play_single_hand(contract_type=None, strategies=strategies, deal_seed=42)
         )
 
@@ -142,7 +142,7 @@ def test_artifact_strategy_vs_random():
     team1_wins = 0
 
     for i in range(50):
-        t0, t1, _, _, _, _, _, _, _, _, _, _ = play_single_hand(
+        t0, t1, _, _, _, _, _, _, _, _, _, _, _ = play_single_hand(
             contract_type=None, strategies=strategies, deal_seed=100 + i
         )
 
@@ -171,7 +171,7 @@ def test_artifact_strategy_bidding_behavior():
 
     bids = []
     for i in range(100):
-        t0, t1, _, _, _, _, bid, _, _, _, _, _ = play_single_hand(
+        t0, t1, _, _, _, _, bid, _, _, _, _, _, _ = play_single_hand(
             contract_type=None, strategies=strategies, deal_seed=200 + i
         )
         if bid is not None and bid > 0:  # Valid bid
@@ -205,7 +205,7 @@ def test_artifact_strategy_make_bid_rate():
     total_count = 0
 
     for i in range(100):
-        t0, t1, _, _, _, _, bid, dealer, bidder, _, _, _ = play_single_hand(
+        t0, t1, _, _, _, _, bid, dealer, bidder, _, _, _, _ = play_single_hand(
             contract_type=None, strategies=strategies, deal_seed=300 + i
         )
 
@@ -240,11 +240,11 @@ def test_no_crashes_with_edge_cases():
     # Test many random seeds to hit edge cases
     for i in range(50):
         try:
-            t0, t1, _, _, _, _, _, _, _, _, _, _ = play_single_hand(
+            t0, t1, _, _, _, _, _, _, _, _, _, _, _ = play_single_hand(
                 contract_type=None, strategies=strategies, deal_seed=1000 + i
             )
         except Exception as e:
-            print(f"❌ Crashed on seed {1000+i}: {e}")
+            print(f"❌ Crashed on seed {1000 + i}: {e}")
             raise
 
     print("✅ No crashes on 50 random edge case hands")

--- a/tests/unit/test_auction_bidding_rules.py
+++ b/tests/unit/test_auction_bidding_rules.py
@@ -50,6 +50,7 @@ class TestAuctionBiddingRules:
             final_contract,
             final_trump,
             _,
+            _,
         ) = play_single_hand(
             contract_type=None,
             bidding_policy=bidding_policy,
@@ -108,6 +109,7 @@ class TestAuctionBiddingRules:
             bidder_pos,
             final_contract,
             final_trump,
+            _,
             _,
         ) = play_single_hand(
             contract_type=None,
@@ -170,6 +172,7 @@ class TestAuctionBiddingRules:
             bidder_pos,
             final_contract,
             final_trump,
+            _,
             _,
         ) = play_single_hand(
             contract_type=None,
@@ -295,6 +298,7 @@ class TestAuctionBiddingRules:
             final_contract,
             final_trump,
             _,
+            _,
         ) = play_single_hand(
             contract_type=None,
             bidding_policy=bidding_policy,
@@ -383,6 +387,7 @@ class TestAuctionBiddingRules:
                 final_contract,
                 final_trump,
                 _,
+                _,
             ) = play_single_hand(
                 contract_type=None,
                 bidding_policy=bidding_policy,
@@ -441,6 +446,7 @@ class TestAuctionBiddingRules:
             bidder_pos,
             final_contract,
             final_trump,
+            _,
             _,
         ) = play_single_hand(
             contract_type=None,
@@ -785,7 +791,7 @@ class TestAuctionMoonLonerIntegration:
         policy = MoonBidder()
         hands = self._fixed_hands()
 
-        _, _, _, _, leader, _, bid, _, bidder_pos, contract, trump, transcript = (
+        _, _, _, _, leader, _, bid, _, bidder_pos, contract, trump, transcript, _ = (
             play_single_hand(
                 contract_type=None,
                 bidding_policy=policy,
@@ -813,7 +819,7 @@ class TestAuctionMoonLonerIntegration:
         policy = LonerBidder()
         hands = self._fixed_hands()
 
-        _, _, _, _, leader, _, bid, _, bidder_pos, contract, trump, _ = (
+        _, _, _, _, leader, _, bid, _, bidder_pos, contract, trump, _, _ = (
             play_single_hand(
                 contract_type=None,
                 bidding_policy=policy,
@@ -840,7 +846,7 @@ class TestAuctionMoonLonerIntegration:
         policy = RegularAfterMoon()
         hands = self._fixed_hands()
 
-        _, _, _, _, _, _, _, _, bidder_pos, contract, trump, transcript = (
+        _, _, _, _, _, _, _, _, bidder_pos, contract, trump, transcript, _ = (
             play_single_hand(
                 contract_type=None,
                 bidding_policy=policy,
@@ -872,7 +878,7 @@ class TestAuctionMoonLonerIntegration:
         hands = self._fixed_hands()
 
         # Dealer is seat 2, LOD order: [3, 0, 1, 2]
-        _, _, _, _, _, _, _, _, bidder_pos, contract, trump, _ = play_single_hand(
+        _, _, _, _, _, _, _, _, bidder_pos, contract, trump, _, _ = play_single_hand(
             contract_type=None,
             bidding_policy=policy,
             hands=hands,
@@ -897,7 +903,7 @@ class TestAuctionMoonLonerIntegration:
         policy = DealerTakeoverLoner()
         hands = self._fixed_hands()
 
-        _, _, _, _, _, _, _, _, bidder_pos, contract, trump, _ = play_single_hand(
+        _, _, _, _, _, _, _, _, bidder_pos, contract, trump, _, _ = play_single_hand(
             contract_type=None,
             bidding_policy=policy,
             hands=hands,
@@ -921,7 +927,7 @@ class TestAuctionMoonLonerIntegration:
         policy = NonDealerMoonMatch()
         hands = self._fixed_hands()
 
-        _, _, _, _, _, _, _, _, bidder_pos, _, trump, transcript = play_single_hand(
+        _, _, _, _, _, _, _, _, bidder_pos, _, trump, transcript, _ = play_single_hand(
             contract_type=None,
             bidding_policy=policy,
             hands=hands,
@@ -949,7 +955,7 @@ class TestAuctionMoonLonerIntegration:
         policies = [MoonBidder(), PassBidder(), PassBidder(), PassBidder()]
         hands = self._fixed_hands()
 
-        _, _, _, _, _, _, bid, _, bidder_pos, contract, trump, _ = play_single_hand(
+        _, _, _, _, _, _, bid, _, bidder_pos, contract, trump, _, _ = play_single_hand(
             contract_type=None,
             bidding_policies=policies,
             hands=hands,
@@ -972,7 +978,7 @@ class TestAuctionMoonLonerIntegration:
         policy = MoonBidder()
         hands = self._fixed_hands()
 
-        *_, transcript = play_single_hand(
+        *_, transcript, _bid_type = play_single_hand(
             contract_type=None,
             bidding_policy=policy,
             hands=hands,
@@ -996,7 +1002,7 @@ class TestAuctionMoonLonerIntegration:
         policy = MoonHighBidder()
         hands = self._fixed_hands()
 
-        _, _, _, _, _, _, bid, _, bidder_pos, contract, trump, _ = play_single_hand(
+        _, _, _, _, _, _, bid, _, bidder_pos, contract, trump, _, _ = play_single_hand(
             contract_type=None,
             bidding_policy=policy,
             hands=hands,
@@ -1019,7 +1025,7 @@ class TestAuctionMoonLonerIntegration:
         policy = MoonLowBidder()
         hands = self._fixed_hands()
 
-        _, _, _, _, _, _, bid, _, bidder_pos, contract, trump, _ = play_single_hand(
+        _, _, _, _, _, _, bid, _, bidder_pos, contract, trump, _, _ = play_single_hand(
             contract_type=None,
             bidding_policy=policy,
             hands=hands,

--- a/tests/unit/test_bidding_sequential_semantics.py
+++ b/tests/unit/test_bidding_sequential_semantics.py
@@ -114,6 +114,7 @@ class TestBiddingSequentialSemantics:
             final_contract,
             final_trump,
             _,
+            _,
         ) = play_single_hand(
             contract_type=None,
             bidding_policy=policy,

--- a/tests/unit/test_game_logger.py
+++ b/tests/unit/test_game_logger.py
@@ -15,9 +15,9 @@ from bid_euchre.logging.game_logger import (
 )
 
 
-def test_schema_version_is_7():
-    """Schema version must be 7 after PR B-2 auction_transcript addition."""
-    assert SCHEMA_VERSION == 7
+def test_schema_version_is_8():
+    """Schema version must be 8 after v8 moon/loner fields addition."""
+    assert SCHEMA_VERSION == 8
 
 
 def test_hand_end_record_has_v6_fields():
@@ -65,7 +65,7 @@ def test_log_hand_end_writes_v6_fields(tmp_path):
 
     records = [json.loads(line) for line in open(log_path)]
     hand_end = next(r for r in records if r.get("event") == "hand_end")
-    assert hand_end["schema_version"] == 7
+    assert hand_end["schema_version"] == 8
     assert hand_end["redeal_flag"] is False
     assert hand_end["made_bid"] is True
 
@@ -89,7 +89,7 @@ def test_log_hand_end_null_v6_fields_when_not_provided(tmp_path):
 
     records = [json.loads(line) for line in open(log_path)]
     hand_end = next(r for r in records if r.get("event") == "hand_end")
-    assert hand_end["schema_version"] == 7
+    assert hand_end["schema_version"] == 8
     assert hand_end["redeal_flag"] is None
     assert hand_end["made_bid"] is None
 
@@ -199,7 +199,7 @@ def test_log_hand_end_writes_auction_transcript(tmp_path):
 
     records = [json.loads(line) for line in open(log_path)]
     hand_end = next(r for r in records if r.get("event") == "hand_end")
-    assert hand_end["schema_version"] == 7
+    assert hand_end["schema_version"] == 8
     assert hand_end["auction_transcript"] == transcript
 
 

--- a/tests/unit/test_scoring_points.py
+++ b/tests/unit/test_scoring_points.py
@@ -85,3 +85,118 @@ class TestComputePoints:
         points_team0, points_team1 = compute_points(None, None, 10, 0)
         assert points_team0 == 10
         assert points_team1 == 0
+
+    def test_regular_bid_type_default(self):
+        """Regular bid_type (default) leaves existing logic unchanged."""
+        # Explicit "regular" should match default
+        p0, p1 = compute_points(6, 0, 8, 2, bid_type="regular")
+        assert p0 == 8
+        assert p1 == 2
+
+        p0, p1 = compute_points(6, 2, 5, 5, bid_type="regular")
+        assert p0 == -6
+        assert p1 == 5
+
+
+class TestMoonScoring:
+    """Tests for moon bid scoring (bid_type='moon')."""
+
+    def test_moon_make_team0(self):
+        """Moon make: team 0 declares and wins all 10 tricks -> +20."""
+        p0, p1 = compute_points(10, 0, 10, 0, bid_type="moon")
+        assert p0 == 20
+        assert p1 == 0
+
+    def test_moon_make_team1(self):
+        """Moon make: team 1 declares and wins all 10 tricks -> +20."""
+        p0, p1 = compute_points(10, 1, 0, 10, bid_type="moon")
+        assert p0 == 0
+        assert p1 == 20
+
+    def test_moon_fail_team0(self):
+        """Moon fail: team 0 declares but doesn't win all 10 -> -20."""
+        p0, p1 = compute_points(10, 0, 9, 1, bid_type="moon")
+        assert p0 == -20
+        assert p1 == 1
+
+    def test_moon_fail_team1(self):
+        """Moon fail: team 1 declares but doesn't win all 10 -> -20."""
+        p0, p1 = compute_points(10, 3, 3, 7, bid_type="moon")
+        assert p0 == 3
+        assert p1 == -20
+
+    def test_moon_fail_defending_gets_tricks(self):
+        """Moon fail: defending team always gets their tricks won."""
+        p0, p1 = compute_points(10, 2, 5, 5, bid_type="moon")
+        assert p0 == -20
+        assert p1 == 5
+
+    def test_moon_make_defending_zero_tricks(self):
+        """Moon make: defending team gets 0 tricks (since declaring won all 10)."""
+        p0, p1 = compute_points(10, 0, 10, 0, bid_type="moon")
+        assert p0 == 20
+        assert p1 == 0
+
+    def test_moon_bidder_seat2(self):
+        """Moon with bidder on seat 2 (team 0)."""
+        p0, p1 = compute_points(10, 2, 10, 0, bid_type="moon")
+        assert p0 == 20
+        assert p1 == 0
+
+    def test_moon_bidder_seat3(self):
+        """Moon with bidder on seat 3 (team 1)."""
+        p0, p1 = compute_points(10, 3, 2, 8, bid_type="moon")
+        assert p0 == 2
+        assert p1 == -20
+
+
+class TestLonerScoring:
+    """Tests for loner bid scoring (bid_type='loner')."""
+
+    def test_loner_make_team0(self):
+        """Loner make: team 0 declares and wins all 10 tricks -> +40."""
+        p0, p1 = compute_points(10, 0, 10, 0, bid_type="loner")
+        assert p0 == 40
+        assert p1 == 0
+
+    def test_loner_make_team1(self):
+        """Loner make: team 1 declares and wins all 10 tricks -> +40."""
+        p0, p1 = compute_points(10, 1, 0, 10, bid_type="loner")
+        assert p0 == 0
+        assert p1 == 40
+
+    def test_loner_fail_team0(self):
+        """Loner fail: team 0 declares but doesn't win all 10 -> -40."""
+        p0, p1 = compute_points(10, 0, 9, 1, bid_type="loner")
+        assert p0 == -40
+        assert p1 == 1
+
+    def test_loner_fail_team1(self):
+        """Loner fail: team 1 declares but doesn't win all 10 -> -40."""
+        p0, p1 = compute_points(10, 3, 4, 6, bid_type="loner")
+        assert p0 == 4
+        assert p1 == -40
+
+    def test_loner_fail_defending_gets_tricks(self):
+        """Loner fail: defending team always gets their tricks won."""
+        p0, p1 = compute_points(10, 2, 5, 5, bid_type="loner")
+        assert p0 == -40
+        assert p1 == 5
+
+    def test_loner_make_defending_zero_tricks(self):
+        """Loner make: defending team gets 0 tricks."""
+        p0, p1 = compute_points(10, 1, 0, 10, bid_type="loner")
+        assert p0 == 0
+        assert p1 == 40
+
+    def test_loner_bidder_seat2(self):
+        """Loner with bidder on seat 2 (team 0)."""
+        p0, p1 = compute_points(10, 2, 10, 0, bid_type="loner")
+        assert p0 == 40
+        assert p1 == 0
+
+    def test_loner_bidder_seat3(self):
+        """Loner with bidder on seat 3 (team 1)."""
+        p0, p1 = compute_points(10, 3, 3, 7, bid_type="loner")
+        assert p0 == 3
+        assert p1 == -40


### PR DESCRIPTION
## Summary

- Add `bid_type` parameter to `compute_points()` (default "regular" — backward compatible)
- Moon: +20 make / -20 fail (all 10 tricks). Loner: +40 make / -40 fail
- Defending team always scores their tricks won
- Bump logging schema v7→v8: `bid_type`, `exchange_cards_given/received`, `sitting_out_seat`
- Extended `play_single_hand()` return tuple (12→13 elements)
- Updated RULES.md §6.4, 6 test files for tuple unpacking, 17 new scoring tests

## Repro / Validation

```bash
make check-quiet  # 3216 passed
uv run python -m pytest tests/unit/test_scoring_points.py -v --seed 42
```

## R3 Phase A PR Chain

- PR 1/6: #717 (merged) | PR 2/6: #721 (open) | PR 3/6: #723 (open)
- **PR 4/6: Scoring + logging** (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>