### PR TITLE
docs: R3 Phase B plan, hypotheses, and checkpoints

### DIFF
--- a/plans/arc_d_v2/r3/checkpoints.md
+++ b/plans/arc_d_v2/r3/checkpoints.md
@@ -1,0 +1,44 @@
+# R3 Checkpoints
+
+**Governing plan:** `plans/arc_d_v2/lineage_plan.md`
+**Phase/Rung:** R3 (moon/loner action space expansion)
+**Last updated:** 2026-03-15 by plan creation session
+
+---
+
+## Step Progress
+
+| Step | Status | Date | Agent/Session | Notes |
+|------|--------|------|---------------|-------|
+| Step 0: Plan & Hypothesize | COMPLETE | 2026-03-15 | Plan creation | 9 hypotheses |
+| Step 1: Generate Training Data | PENDING | | | `--include-moon-loner` flag required |
+| Step 2: Train All Roster Models | PENDING | | | 59 state + 4 action features |
+| Step 3: Offline Evaluation + Data Sanity | PENDING | | | |
+| Step 3b: Model Interpretability | PENDING | | | SHAP analysis of is_moon, is_loner features |
+| Step 4: H2H Battery | PENDING | | | |
+| Step 5: Comparator Battery | PENDING | | | |
+| Step 6: Sanity Bounds Check | PENDING | | | |
+| Step 7: Generate Reports | PENDING | | | |
+| Step 8: Advance Decision + Narrative | PENDING | | | |
+| Step 9: Archive & Advance | PENDING | | | |
+
+## Prerequisites
+
+- [x] R0 QUICK canonical -- 8/9 PASS
+- [x] R1 QUICK canonical -- 7/9 PASS (H2 FAIL, H7 SURPRISE)
+- [x] R2 QUICK canonical -- 8/9 PASS (H2 FAIL, non-blocking)
+- [x] R3 Phase A engine expansion -- 6 PRs merged
+
+## Blockers
+
+_None._
+
+## Session Log
+
+### 2026-03-15 -- Plan creation
+
+- R2 baselines: GBT +1.302 H2H, 0.603 suit R-squared, 2.255 comparator, 57.2% win rate
+- R3 is unique: action space expansion, not feature addition
+- 9 hypotheses focused on: action space doesn't hurt (H1-H4, H7), models remain sane (H6, H8), model ordering preserved (H5, H9)
+- Key R3 research questions from lineage plan section 6.4.6: do models learn moon vs loner selectivity, does GBT exploit card exchange better than OLS, dealer takeover risk
+- Moon/loner-specific metrics (bid rates by action type, make rates by action type) not yet in canonical CSV schema -- will need game log analysis or table schema extension

--- a/plans/arc_d_v2/r3/hypotheses.json
+++ b/plans/arc_d_v2/r3/hypotheses.json
@@ -1,0 +1,116 @@
+{
+  "schema_version": "hypotheses_v1",
+  "rung": "r3",
+  "hypotheses": [
+    {
+      "id": "H1",
+      "description": "GBT pooled H2H delta vs anchor remains positive with expanded action space",
+      "metric": "gbt_pooled_delta_vs_anchor",
+      "source_table": "h2h_delta_matrix.csv",
+      "source_column": "net_eppd_delta",
+      "source_filter": {"model_a": "gbt_av", "model_b": "anchor_hybrid_r0_full", "facet": "pooled"},
+      "computation": "value",
+      "expected_bound": {"op": ">", "value": 0.3},
+      "surprise_if": {"op": "<", "value": 0.0},
+      "_note": "R0: +1.061, R1: +0.490, R2: +1.302. Moon/loner expand options -- should not hurt pooled performance if models learn when NOT to use them."
+    },
+    {
+      "id": "H2",
+      "description": "GBT comparator net_eppd maintains above 2.0 with expanded action space",
+      "metric": "gbt_comparator",
+      "source_table": "comparator_rankings.csv",
+      "source_column": "net_eppd",
+      "source_filter": {"model": "gbt_av", "facet": "pooled"},
+      "computation": "value",
+      "expected_bound": {"op": ">", "value": 2.0},
+      "surprise_if": {"op": "<", "value": 1.5},
+      "_note": "R0: 2.201, R1: 2.114, R2: 2.255. Expanded action space should not degrade single-seat quality."
+    },
+    {
+      "id": "H3",
+      "description": "GBT bids (does not pass) at least 40% of the time in comparator",
+      "metric": "gbt_bid_rate",
+      "source_table": "comparator_rankings.csv",
+      "source_column": "bid_rate",
+      "source_filter": {"model": "gbt_av", "facet": "pooled"},
+      "computation": "value",
+      "expected_bound": {"op": ">", "value": 0.40},
+      "surprise_if": {"op": "<", "value": 0.20},
+      "_note": "Moon/loner add more action options. Models should still bid regularly -- the expanded space should not cause pathological passing. Lowered from 50% to 40% since more options may shift the pass/bid boundary slightly."
+    },
+    {
+      "id": "H4",
+      "description": "GBT R3 suit R-squared does not collapse below R0 baseline",
+      "metric": "gbt_suit_r2",
+      "source_table": "model_performance.csv",
+      "source_column": "r_squared",
+      "source_filter": {"model": "gbt_av", "contract": "suit"},
+      "computation": "value",
+      "expected_bound": {"op": ">", "value": 0.55},
+      "surprise_if": {"op": "<", "value": 0.45},
+      "_note": "R0: 0.588, R1: 0.621, R2: 0.603. Moon/loner add complexity to suit predictions. Lowered threshold -- the question is whether models can still predict regular suit outcomes well while also handling moon/loner."
+    },
+    {
+      "id": "H5",
+      "description": "Two-stage model gap vs GBT is within 1.0 net_eppd in comparator",
+      "metric": "two_stage_vs_gbt",
+      "source_table": "comparator_rankings.csv",
+      "source_column": "net_eppd",
+      "source_filter": {"model": "selected_two_stage_av", "facet": "pooled"},
+      "comparator_filter": {"model": "gbt_av", "facet": "pooled"},
+      "computation": "value - comparator_value",
+      "expected_bound": {"op": ">", "value": -1.0},
+      "surprise_if": {"op": "<", "value": -1.5},
+      "_note": "R0: -0.322, R1: -0.341, R2: gap TBD. Two-stage P(make) must generalize to level-10 moon/loner -- may struggle or may benefit from cleaner P(make)=1 vs 0 signals."
+    },
+    {
+      "id": "H6",
+      "description": "All models bid at least half the time",
+      "metric": "min_bid_rate",
+      "source_table": "comparator_rankings.csv",
+      "source_column": "bid_rate",
+      "source_filter": {"facet": "pooled"},
+      "computation": "min",
+      "expected_bound": {"op": ">", "value": 0.5},
+      "surprise_if": {"op": "<", "value": 0.2},
+      "_note": "Same sanity check as R0-R2. Expanded action space should not cause any model to pass pathologically."
+    },
+    {
+      "id": "H7",
+      "description": "GBT H2H win rate vs anchor exceeds 45%",
+      "metric": "h2h_win_rate_vs_anchor",
+      "source_table": "h2h_delta_matrix.csv",
+      "source_column": "win_rate_a",
+      "source_filter": {"model_a": "gbt_av", "model_b": "anchor_hybrid_r0_full", "facet": "pooled"},
+      "computation": "value",
+      "expected_bound": {"op": ">", "value": 0.45},
+      "surprise_if": {"op": "<", "value": 0.40},
+      "_note": "R0: 53.2%, R1: 44.0%, R2: 57.2%. Action space expansion should maintain competitive win rate. The anchor cannot bid moon/loner, so R3 models have strictly more options."
+    },
+    {
+      "id": "H8",
+      "description": "GBT make rate stays above 50% in comparator",
+      "metric": "gbt_make_rate",
+      "source_table": "comparator_rankings.csv",
+      "source_column": "make_rate",
+      "source_filter": {"model": "gbt_av", "facet": "pooled"},
+      "computation": "value",
+      "expected_bound": {"op": ">", "value": 0.50},
+      "surprise_if": {"op": "<", "value": 0.35},
+      "_note": "Moon and loner require winning ALL 10 tricks. If models bid moon/loner too aggressively, overall make rate will drop. This tests whether models learn selectivity."
+    },
+    {
+      "id": "H9",
+      "description": "ModeloEspecifico heuristic is worst among trained models in comparator",
+      "metric": "heuristic_vs_gbt",
+      "source_table": "comparator_rankings.csv",
+      "source_column": "net_eppd",
+      "source_filter": {"model": "modeloespecifico", "facet": "pooled"},
+      "comparator_filter": {"model": "gbt_av", "facet": "pooled"},
+      "computation": "value - comparator_value",
+      "expected_bound": {"op": "<", "value": 0.0},
+      "surprise_if": {"op": ">", "value": 0.5},
+      "_note": "ModeloEspecifico is a hand-coded heuristic. It may not bid moon/loner at all (or uses fixed rules). Trained models should exploit the expanded action space better."
+    }
+  ]
+}

--- a/plans/arc_d_v2/r3/plan.md
+++ b/plans/arc_d_v2/r3/plan.md
@@ -1,0 +1,113 @@
+# Arc D v2 — R3 Rung Plan (Phase B)
+
+**Status:** PROPOSED
+**Lineage:** arc_d_v2
+**Rung:** r3 (moon/loner action space expansion)
+
+## 1. Objective
+
+Expand the action space to include moon and loner bid types alongside regular
+bids. Test whether models learn when the fixed +/-20 (moon) or +/-40 (loner)
+payoff is worth the risk vs a regular bid at a lower level.
+
+R3 is fundamentally different from R0*-R2: it does not add state features --
+it expands the **action space**. The 59 state features from R2 are unchanged.
+Two new action features (`is_moon`, `is_loner`) join the existing `bid_n` and
+`bid_n_sq`.
+
+Phase A (engine expansion) is complete. This plan covers Phase B only:
+standard rung execution (Steps 0-9).
+
+## 2. Model Roster
+
+Same as R0/R1/R2 -- see `plans/arc_d_v2/roster.json`.
+Per LA-4, FULL mode uses the trimmed roster: gbt_av, selected_two_stage_av,
+full_ols_av, modeloespecifico.
+
+## 3. Context Bundle
+
+R3 context: hand + partner + position + opponent (unchanged from R2).
+- 39 hand features (frozen)
+- 6 partner features (v2 suit-relative, from R1)
+- 2 position features (LA-1: auction_position, is_dealer)
+- 12 opponent features (6 left + 6 right, from R2)
+- Total: 59 state features (unchanged from R2)
+
+R3 action features (expanded):
+- `bid_n` -- bid level (1-10)
+- `bid_n_sq` -- bid level squared
+- `is_moon` -- 1 if evaluating a moon bid, 0 otherwise
+- `is_loner` -- 1 if evaluating a loner bid, 0 otherwise
+
+Uses `--feature-set full` (same as R2).
+
+## 4. Hypotheses
+
+See `plans/arc_d_v2/r3/hypotheses.json`.
+
+## 5. Execution
+
+Managed by `scripts/internal/run_rung.py --rung r3`.
+Per Amendment LA-3, R3 runs at QUICK scale first.
+
+### 5.1 Dataset Generation
+
+```bash
+uv run python scripts/internal/generate_action_value_dataset.py \
+  --seed 42 \
+  --mode <SMOKE|QUICK|FULL> \
+  --continuation-artifact data/artifacts/arc_d/r0/hybrid_r0_full.json \
+  --output-dir data/runs/arc_d_v2/r3/datasets/ \
+  --include-moon-loner
+```
+
+The `--include-moon-loner` flag enables counterfactual evaluation of moon and
+loner actions. The card exchange uses deterministic heuristic policies (see
+lineage plan section 6.4.4).
+
+### 5.2 Training
+
+All models train on the same expanded action-value dataset. The action feature
+vector now includes `is_moon` and `is_loner` indicators. Moon and loner
+actions always have `bid_n=10` and `bid_n_sq=100`.
+
+### 5.3 Evaluation Batteries
+
+H2H and comparator batteries run as normal. Models may bid moon or loner
+during simulation if their EV estimate exceeds regular bids. The existing
+battery infrastructure handles any legal action selected by the bidder.
+
+## 6. Implementation Notes
+
+- Card exchange simulation during counterfactual dataset generation follows
+  the fixed heuristic policies defined in lineage plan section 6.4.4.
+- Loner trick play uses 3-player trick resolution (partner sits out).
+- Scoring: moon make = +20, fail = -20; loner make = +40, fail = -40.
+  Defending team always scores their tricks won.
+- The anchor (hybrid_r0_full) does NOT bid moon/loner -- it predates the
+  action space expansion. This means H2H comparisons vs anchor test whether
+  the expanded action space helps or hurts overall bidding quality.
+
+## 7. R3-Specific Analysis
+
+Beyond the standard report suite, R3 analysis should examine:
+1. **Moon/loner bid rates** -- how often each model chooses moon vs loner vs
+   regular-10 (requires new behavior_summary columns or SHAP analysis)
+2. **Moon/loner make rates** -- when models bid moon/loner, how often do they
+   make it (from game logs)
+3. **Decision comparison** -- how often does GBT choose moon where OLS chooses
+   regular? (Step 3b SHAP + game log analysis)
+4. **Dealer position effect** -- do models learn the dealer takeover risk?
+   (`is_dealer` feature importance for moon/loner actions)
+
+Note: Some R3-specific metrics (moon_rate, loner_rate, moon_make_rate) are
+not yet in the canonical CSV table schema. These will need to be extracted
+from game log JSONL data during Step 7 or via supplementary analysis.
+Hypotheses H3, H4, and H8 are flagged as potentially requiring table schema
+extensions. If the pipeline does not produce these columns by execution time,
+they should be evaluated manually from game logs and recorded in the decision
+report.
+
+## Outcome
+
+_To be filled after execution._


### PR DESCRIPTION
## Summary

- Create R3 Phase B rung evaluation plan (Steps 0-9 with moon/loner action space)
- Create 9 hypotheses using existing CSV table schema
- Create checkpoints with Step 0 COMPLETE, Steps 1-9 PENDING

## Why

R3 Phase A (engine expansion) is complete. Phase B runs the standard rung evaluation pipeline with the expanded action space to test whether models learn when moon/loner bids are worth the risk.

## Key design note

Hypotheses use existing table columns only. Moon/loner-specific metrics (moon bid rate, moon make rate) would require schema extensions. The hypotheses capture these concerns indirectly through overall bid_rate and make_rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>