### PR TITLE
fix: apply PTY fix to PR review adapter and reduce max iterations

### DIFF
--- a/.claude/rules/deferred/60_review_gate.md
+++ b/.claude/rules/deferred/60_review_gate.md
@@ -52,7 +52,7 @@ Codex CLI is the sole reviewer — local, ~60s latency, uses ChatGPT subscriptio
 8. Codex CLI findings are parsed into normalized schema (P0/P1/P2)
 9. Auto-fixable findings (convention patterns) are applied and committed
 10. Non-auto-fixable findings are recorded
-11. Loop iterates (max 5 rounds) until clean or stopped
+11. Loop iterates (max 3 rounds) until clean or stopped
 12. Loop publishes final status (`success` or `failure`)
 13. Loop creates follow-up issues for non-blocking (P2) findings
 14. Loop enables auto-merge (squash) — GitHub merges when CI + branch protection pass

--- a/.claude/skills/review-plan/SKILL.md
+++ b/.claude/skills/review-plan/SKILL.md
@@ -6,7 +6,7 @@ description: Runs independent plan review loop with Codex CLI primary reviewer a
 # /review-plan -- Independent Plan Review
 
 Reviews a plan file using the Codex CLI (primary) with Claude agent fallback.
-Runs up to 5 review iterations with automated fixes between rounds.
+Runs up to 3 review iterations with automated fixes between rounds.
 
 ## Usage
 

--- a/.claude/skills/reviewing-changes/SKILL.md
+++ b/.claude/skills/reviewing-changes/SKILL.md
@@ -54,7 +54,7 @@ The autonomous review loop is triggered by the PostToolUse hook (`post-pr-review
 It runs asynchronously and handles:
 - Deterministic prechecks (C1/C2/N1/N2/N3/X2/X3)
 - `make check-quiet`
-- Codex CLI review + auto-fix loop (max 5 iterations)
+- Codex CLI review + auto-fix loop (max 3 iterations)
 - Final status publishing (success/failure)
 - Follow-up issue creation for P2 findings
 

--- a/docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md
+++ b/docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md
@@ -4,7 +4,7 @@
 
 The autonomous review loop is a local state machine where Claude (author)
 writes/fixes code and Codex CLI (reviewer) reviews it. The loop is persisted
-to disk, resumable after restarts, and bounded (max 5 iterations).
+to disk, resumable after restarts, and bounded (max 3 iterations).
 
 The loop is the sole review mechanism for all PRs. It runs asynchronously
 after PR creation, triggered by the `post-pr-review-loop.sh` PostToolUse hook.

--- a/docs/02_agent/CODEX_GITHUB_REVIEW.md
+++ b/docs/02_agent/CODEX_GITHUB_REVIEW.md
@@ -14,7 +14,7 @@ The review loop:
 2. Runs `make check-quiet`
 3. Invokes Codex CLI for code review
 4. Auto-fixes safe patterns (convention fixes)
-5. Iterates (max 5 rounds) until clean or stopped
+5. Iterates (max 3 rounds) until clean or stopped
 6. Publishes `reviewing-changes` commit status
 7. Enables auto-merge (squash) when review passes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ package-dir = {"" = "src"}
 where = ["src"]
 
 [tool.ruff]
-extend-exclude = ["data/", "experiments/_deprecated/"]
+extend-exclude = ["data/", "experiments/_deprecated/", ".claude/worktrees/"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]

--- a/scripts/internal/codex_plan_review_adapter.py
+++ b/scripts/internal/codex_plan_review_adapter.py
@@ -14,7 +14,9 @@ import hashlib
 import json
 import logging
 import os
+import pty
 import re
+import select
 import subprocess
 import time
 from dataclasses import asdict, dataclass
@@ -163,6 +165,103 @@ def plan_state_key(plan_path: Path) -> str:
     return hashlib.sha256(rel.encode()).hexdigest()[:12]
 
 
+def _run_with_pty(
+    cmd: list[str],
+    *,
+    timeout: float = 300,
+    cwd: Path | None = None,
+) -> tuple[int | None, str]:
+    """Run a command with a pseudo-TTY and capture output.
+
+    Codex CLI requires a TTY to function — ``subprocess.run(capture_output=True)``
+    provides no TTY, causing the CLI to hang. This function allocates a PTY so
+    Codex can detect a terminal and produce output normally.
+
+    Args:
+        cmd: Command and arguments.
+        timeout: Maximum wall-clock seconds before killing the process.
+        cwd: Working directory for the child process.
+
+    Returns:
+        Tuple of (return_code, captured_output). Return code is ``None``
+        if the process was killed due to timeout.
+    """
+    master_fd, slave_fd = pty.openpty()
+    proc = subprocess.Popen(
+        cmd,
+        stdin=slave_fd,
+        stdout=slave_fd,
+        stderr=slave_fd,
+        close_fds=True,
+        cwd=cwd,
+    )
+    os.close(slave_fd)
+
+    output_chunks: list[str] = []
+    start = time.monotonic()
+    timed_out = False
+
+    try:
+        while True:
+            elapsed = time.monotonic() - start
+            if elapsed > timeout:
+                proc.kill()
+                timed_out = True
+                break
+
+            remaining = timeout - elapsed
+            ready, _, _ = select.select([master_fd], [], [], min(remaining, 1.0))
+            if ready:
+                try:
+                    data = os.read(master_fd, 8192)
+                    if not data:
+                        break
+                    output_chunks.append(data.decode("utf-8", errors="replace"))
+                except OSError:
+                    break
+
+            if proc.poll() is not None:
+                # Process finished — drain remaining output with retries.
+                # The PTY buffer may not be fully flushed when poll() first
+                # returns, so retry a few times with short sleeps.
+                empty_polls = 0
+                while empty_polls < 5:
+                    ready, _, _ = select.select([master_fd], [], [], 0.2)
+                    if not ready:
+                        empty_polls += 1
+                        continue
+                    empty_polls = 0
+                    try:
+                        data = os.read(master_fd, 8192)
+                        if not data:
+                            break
+                        output_chunks.append(data.decode("utf-8", errors="replace"))
+                    except OSError:
+                        break
+                break
+    finally:
+        os.close(master_fd)
+        if proc.poll() is None:
+            proc.kill()
+        proc.wait()
+
+    raw = "".join(output_chunks)
+    # Strip ANSI escape codes from terminal output
+    clean = re.sub(r"\x1b\[[0-9;]*[a-zA-Z]", "", raw)
+    clean = re.sub(r"[\x00-\x08\x0e-\x1f]", "", clean)
+    # Extract the review section from PTY output. Codex CLI emits verbose
+    # exec traces followed by a "codex" marker and the actual review text.
+    # Only the last "codex" block contains the review conclusion.
+    # Use \r?\n to handle both Unix and PTY line endings.
+    parts = re.split(r"\r?\ncodex\r?\n", clean)
+    if len(parts) > 1:
+        clean = parts[-1].strip()
+
+    if timed_out:
+        return None, clean
+    return proc.returncode, clean
+
+
 def _check_codex_auth(auth_path: Path | None = None) -> str | None:
     """Check whether Codex CLI credentials are present.
 
@@ -230,8 +329,10 @@ def invoke_codex_plan_review(
     work_dir = cwd or Path.cwd()
     start = time.monotonic()
 
-    # Pre-flight auth check
-    auth_error = _check_codex_auth()
+    # Pre-flight auth check (skip when using a custom launcher, which
+    # may supply its own credentials independently of ~/.codex/auth.json)
+    custom_cmd = os.environ.get("CODEX_REVIEW_CMD", "").strip()
+    auth_error = None if custom_cmd else _check_codex_auth()
     if auth_error:
         elapsed = time.monotonic() - start
         logger.warning("Codex auth check failed: %s", auth_error)
@@ -245,92 +346,16 @@ def invoke_codex_plan_review(
             error=auth_error,
         )
 
+    cmd = [*_resolve_codex_binary(), "review", "--base", base]
+    logger.info(
+        "Invoking Codex CLI for plan review (tier=%s, base=%s, file=%s)",
+        tier,
+        base,
+        plan_path,
+    )
+
     try:
-        cmd = [*_resolve_codex_binary(), "review", "--base", base]
-        logger.info(
-            "Invoking Codex CLI for plan review (tier=%s, base=%s, file=%s)",
-            tier,
-            base,
-            plan_path,
-        )
-
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            cwd=work_dir,
-        )
-        elapsed = time.monotonic() - start
-
-        if result.returncode != 0:
-            error_type = _classify_error(result.stderr)
-            logger.warning(
-                "Codex CLI plan review failed (exit %d, %.1fs, %s): %s",
-                result.returncode,
-                elapsed,
-                error_type,
-                result.stderr[:200],
-            )
-            return PlanReviewResult(
-                success=False,
-                findings=[],
-                tier=tier,
-                reviewer="codex_cli",
-                raw_output=result.stdout + result.stderr,
-                latency_seconds=elapsed,
-                error=f"Exit code {result.returncode}: {result.stderr[:200]}",
-            )
-
-        # Parse findings using the shared parser
-        codex_findings = parse_codex_output(result.stdout)
-        plan_findings = _convert_codex_findings(codex_findings, str(plan_path))
-
-        # Fail-safe: unparseable non-empty output
-        if not codex_findings and result.stdout.strip():
-            if not _CLEAN_REVIEW_PATTERNS.search(result.stdout):
-                logger.warning(
-                    "Codex CLI plan review returned unparseable output (%.1fs, %d chars)",
-                    elapsed,
-                    len(result.stdout),
-                )
-                return PlanReviewResult(
-                    success=False,
-                    findings=[],
-                    tier=tier,
-                    reviewer="codex_cli",
-                    raw_output=result.stdout,
-                    latency_seconds=elapsed,
-                    error="Unparseable output: no findings matched and no clean-review signal",
-                )
-
-        logger.info(
-            "Codex CLI plan review completed (%.1fs): %d findings",
-            elapsed,
-            len(plan_findings),
-        )
-        return PlanReviewResult(
-            success=True,
-            findings=plan_findings,
-            tier=tier,
-            reviewer="codex_cli",
-            raw_output=result.stdout,
-            latency_seconds=elapsed,
-        )
-
-    except subprocess.TimeoutExpired:
-        elapsed = time.monotonic() - start
-        logger.warning("Codex CLI plan review timed out after %.1fs", elapsed)
-        return PlanReviewResult(
-            success=False,
-            findings=[],
-            tier=tier,
-            reviewer="codex_cli",
-            raw_output="",
-            latency_seconds=elapsed,
-            error=f"Timeout after {timeout}s",
-        )
-
+        returncode, output = _run_with_pty(cmd, timeout=timeout, cwd=work_dir)
     except FileNotFoundError:
         elapsed = time.monotonic() - start
         logger.error("Codex CLI not found for plan review")
@@ -343,6 +368,75 @@ def invoke_codex_plan_review(
             latency_seconds=elapsed,
             error="Codex CLI not found (codex not in PATH, npx unavailable)",
         )
+
+    elapsed = time.monotonic() - start
+
+    if returncode is None:
+        logger.warning("Codex CLI plan review timed out after %.1fs", elapsed)
+        return PlanReviewResult(
+            success=False,
+            findings=[],
+            tier=tier,
+            reviewer="codex_cli",
+            raw_output=output,
+            latency_seconds=elapsed,
+            error=f"Timeout after {timeout}s",
+        )
+
+    if returncode != 0:
+        error_type = _classify_error(output)
+        logger.warning(
+            "Codex CLI plan review failed (exit %d, %.1fs, %s): %s",
+            returncode,
+            elapsed,
+            error_type,
+            output[:200],
+        )
+        return PlanReviewResult(
+            success=False,
+            findings=[],
+            tier=tier,
+            reviewer="codex_cli",
+            raw_output=output,
+            latency_seconds=elapsed,
+            error=f"Exit code {returncode}: {output[:200]}",
+        )
+
+    # Parse findings using the shared parser
+    codex_findings = parse_codex_output(output)
+    plan_findings = _convert_codex_findings(codex_findings, str(plan_path))
+
+    # Fail-safe: unparseable non-empty output
+    if not codex_findings and output.strip():
+        if not _CLEAN_REVIEW_PATTERNS.search(output):
+            logger.warning(
+                "Codex CLI plan review returned unparseable output (%.1fs, %d chars)",
+                elapsed,
+                len(output),
+            )
+            return PlanReviewResult(
+                success=False,
+                findings=[],
+                tier=tier,
+                reviewer="codex_cli",
+                raw_output=output,
+                latency_seconds=elapsed,
+                error="Unparseable output: no findings matched and no clean-review signal",
+            )
+
+    logger.info(
+        "Codex CLI plan review completed (%.1fs): %d findings",
+        elapsed,
+        len(plan_findings),
+    )
+    return PlanReviewResult(
+        success=True,
+        findings=plan_findings,
+        tier=tier,
+        reviewer="codex_cli",
+        raw_output=output,
+        latency_seconds=elapsed,
+    )
 
 
 def invoke_claude_failsafe(

--- a/scripts/internal/codex_review_adapter.py
+++ b/scripts/internal/codex_review_adapter.py
@@ -14,7 +14,6 @@ import logging
 import os
 import re
 import shutil
-import subprocess
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -322,6 +321,8 @@ def invoke_codex_cli(
     Returns:
         CodexReviewResult with parsed findings or error info.
     """
+    from codex_plan_review_adapter import _run_with_pty
+
     cmd = [*_resolve_codex_binary(), "review", "--base", base]
 
     logger.info(
@@ -334,81 +335,7 @@ def invoke_codex_cli(
     start = time.monotonic()
 
     try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            cwd=cwd,
-        )
-        elapsed = time.monotonic() - start
-
-        if result.returncode != 0:
-            error_type = _classify_error(result.stderr)
-            logger.warning(
-                "Codex CLI returned exit code %d (%.1fs, %s): %s",
-                result.returncode,
-                elapsed,
-                error_type,
-                result.stderr[:200],
-            )
-            return CodexReviewResult(
-                success=False,
-                findings=[],
-                raw_output=result.stdout + result.stderr,
-                latency_seconds=elapsed,
-                error=f"Exit code {result.returncode}: {result.stderr[:200]}",
-                exit_code=result.returncode,
-                error_type=error_type,
-            )
-
-        findings = parse_codex_output(result.stdout)
-
-        # Fail-safe: if zero findings parsed from non-trivial output
-        # and no recognizable "clean review" signal, treat as unparseable.
-        # This prevents format drift from silently bypassing review.
-        if not findings and result.stdout.strip():
-            if not _CLEAN_REVIEW_PATTERNS.search(result.stdout):
-                logger.warning(
-                    "Codex CLI returned output (%.1fs, %d chars) but no findings "
-                    "were parsed and no clean-review signal detected — treating "
-                    "as unparseable",
-                    elapsed,
-                    len(result.stdout),
-                )
-                return CodexReviewResult(
-                    success=False,
-                    findings=[],
-                    raw_output=result.stdout,
-                    latency_seconds=elapsed,
-                    error="Unparseable output: no findings matched and no clean-review signal",
-                    exit_code=0,
-                )
-
-        logger.info(
-            "Codex CLI completed (%.1fs): %d findings",
-            elapsed,
-            len(findings),
-        )
-        return CodexReviewResult(
-            success=True,
-            findings=findings,
-            raw_output=result.stdout,
-            latency_seconds=elapsed,
-            exit_code=0,
-        )
-
-    except subprocess.TimeoutExpired:
-        elapsed = time.monotonic() - start
-        logger.warning("Codex CLI timed out after %.1fs", elapsed)
-        return CodexReviewResult(
-            success=False,
-            findings=[],
-            raw_output="",
-            latency_seconds=elapsed,
-            error=f"Timeout after {timeout}s",
-        )
-
+        returncode, output = _run_with_pty(cmd, timeout=timeout, cwd=cwd)
     except FileNotFoundError:
         elapsed = time.monotonic() - start
         logger.error("Codex CLI not found — codex not in PATH and npx unavailable")
@@ -419,6 +346,73 @@ def invoke_codex_cli(
             latency_seconds=elapsed,
             error="Codex CLI not found (codex not in PATH, npx unavailable)",
         )
+
+    elapsed = time.monotonic() - start
+
+    if returncode is None:
+        logger.warning("Codex CLI timed out after %.1fs", elapsed)
+        return CodexReviewResult(
+            success=False,
+            findings=[],
+            raw_output=output,
+            latency_seconds=elapsed,
+            error=f"Timeout after {timeout}s",
+        )
+
+    if returncode != 0:
+        error_type = _classify_error(output)
+        logger.warning(
+            "Codex CLI returned exit code %d (%.1fs, %s): %s",
+            returncode,
+            elapsed,
+            error_type,
+            output[:200],
+        )
+        return CodexReviewResult(
+            success=False,
+            findings=[],
+            raw_output=output,
+            latency_seconds=elapsed,
+            error=f"Exit code {returncode}: {output[:200]}",
+            exit_code=returncode,
+            error_type=error_type,
+        )
+
+    findings = parse_codex_output(output)
+
+    # Fail-safe: if zero findings parsed from non-trivial output
+    # and no recognizable "clean review" signal, treat as unparseable.
+    # This prevents format drift from silently bypassing review.
+    if not findings and output.strip():
+        if not _CLEAN_REVIEW_PATTERNS.search(output):
+            logger.warning(
+                "Codex CLI returned output (%.1fs, %d chars) but no findings "
+                "were parsed and no clean-review signal detected — treating "
+                "as unparseable",
+                elapsed,
+                len(output),
+            )
+            return CodexReviewResult(
+                success=False,
+                findings=[],
+                raw_output=output,
+                latency_seconds=elapsed,
+                error="Unparseable output: no findings matched and no clean-review signal",
+                exit_code=0,
+            )
+
+    logger.info(
+        "Codex CLI completed (%.1fs): %d findings",
+        elapsed,
+        len(findings),
+    )
+    return CodexReviewResult(
+        success=True,
+        findings=findings,
+        raw_output=output,
+        latency_seconds=elapsed,
+        exit_code=0,
+    )
 
 
 def get_blocking_findings(findings: list[CodexFinding]) -> list[CodexFinding]:

--- a/scripts/internal/plan_review_driver.py
+++ b/scripts/internal/plan_review_driver.py
@@ -1,6 +1,6 @@
 """Plan review loop driver -- orchestrates iterative Codex -> fix -> re-review cycles.
 
-Entry point: run_plan_review_loop(plan_path, tier=None, max_iter=5)
+Entry point: run_plan_review_loop(plan_path, tier=None, max_iter=3)
 
 The loop:
 1. Detect tier (or use override)
@@ -264,7 +264,7 @@ def run_plan_review_loop(
     plan_path: Path,
     *,
     tier: str | None = None,
-    max_iter: int = 5,
+    max_iter: int = 3,
     base_dir: Path | None = None,
 ) -> PlanReviewLoopResult:
     """Run the plan review loop.

--- a/scripts/internal/review_driver.py
+++ b/scripts/internal/review_driver.py
@@ -194,7 +194,7 @@ def initialize_state(
     pr_number: int,
     branch: str,
     mode: ReviewMode,
-    max_iterations: int = 5,
+    max_iterations: int = 3,
     *,
     head_sha: str | None = None,
 ) -> ReviewLoopState:
@@ -1166,8 +1166,8 @@ def main() -> int:
     parser.add_argument(
         "--max-iterations",
         type=int,
-        default=5,
-        help="Maximum review iterations (default: 5)",
+        default=3,
+        help="Maximum review iterations (default: 3)",
     )
     args = parser.parse_args()
 

--- a/scripts/internal/test_codex_plan_review_live.py
+++ b/scripts/internal/test_codex_plan_review_live.py
@@ -27,16 +27,30 @@ import sys
 import time
 from pathlib import Path
 
-# Ensure scripts/internal is importable
-sys.path.insert(0, str(Path(__file__).resolve().parent))
+# Import sibling modules from scripts/internal/ via importlib
+_scripts_dir = str(Path(__file__).resolve().parent)
 
-from codex_plan_review_adapter import (
-    PlanReviewResult,
-    _check_codex_auth,
-    detect_plan_tier,
-    invoke_codex_plan_review,
-)
-from plan_review_driver import run_plan_review_loop
+
+def _import_sibling(module_name: str):
+    """Import a sibling module from scripts/internal/ without sys.path mutation."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        module_name, Path(_scripts_dir) / f"{module_name}.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_adapter = _import_sibling("codex_plan_review_adapter")
+_driver = _import_sibling("plan_review_driver")
+
+PlanReviewResult = _adapter.PlanReviewResult
+_check_codex_auth = _adapter._check_codex_auth
+detect_plan_tier = _adapter.detect_plan_tier
+invoke_codex_plan_review = _adapter.invoke_codex_plan_review
+run_plan_review_loop = _driver.run_plan_review_loop
 
 # --- Test Plans ---
 

--- a/tests/unit/test_codex_review_adapter.py
+++ b/tests/unit/test_codex_review_adapter.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 # Add scripts/internal to path for imports
 sys.path.insert(
@@ -320,44 +320,44 @@ class TestCommandConstruction:
     ensure the prompt is never included in the command.
     """
 
-    @patch("codex_review_adapter.subprocess.run")
+    @patch("codex_plan_review_adapter._run_with_pty")
     @patch("codex_review_adapter._resolve_codex_binary", return_value=["codex"])
-    def test_no_prompt_in_review_command(self, mock_resolve, mock_run):
+    def test_no_prompt_in_review_command(self, mock_resolve, mock_pty):
         """The review command must not include a positional prompt."""
-        mock_run.return_value = Mock(returncode=0, stdout="No issues found.", stderr="")
+        mock_pty.return_value = (0, "No issues found.")
         invoke_codex_cli(mode="standard", base="main")
-        cmd = mock_run.call_args[0][0]
+        cmd = mock_pty.call_args[0][0]
         assert cmd == ["codex", "review", "--base", "main"]
 
-    @patch("codex_review_adapter.subprocess.run")
+    @patch("codex_plan_review_adapter._run_with_pty")
     @patch("codex_review_adapter._resolve_codex_binary", return_value=["codex"])
-    def test_mode_does_not_affect_command(self, mock_resolve, mock_run):
+    def test_mode_does_not_affect_command(self, mock_resolve, mock_pty):
         """Different modes must not change the command (prompt removed)."""
-        mock_run.return_value = Mock(returncode=0, stdout="LGTM", stderr="")
+        mock_pty.return_value = (0, "LGTM")
         for mode in ("standard", "report-audit", "plan-audit"):
             invoke_codex_cli(mode=mode, base="main")
-            cmd = mock_run.call_args[0][0]
+            cmd = mock_pty.call_args[0][0]
             assert cmd == ["codex", "review", "--base", "main"]
 
-    @patch("codex_review_adapter.subprocess.run")
+    @patch("codex_plan_review_adapter._run_with_pty")
     @patch(
         "codex_review_adapter._resolve_codex_binary",
         return_value=["npx", "@openai/codex"],
     )
-    def test_npx_fallback_command(self, mock_resolve, mock_run):
+    def test_npx_fallback_command(self, mock_resolve, mock_pty):
         """When codex binary not found, falls back to npx."""
-        mock_run.return_value = Mock(returncode=0, stdout="LGTM", stderr="")
+        mock_pty.return_value = (0, "LGTM")
         invoke_codex_cli(base="main")
-        cmd = mock_run.call_args[0][0]
+        cmd = mock_pty.call_args[0][0]
         assert cmd == ["npx", "@openai/codex", "review", "--base", "main"]
 
-    @patch("codex_review_adapter.subprocess.run")
+    @patch("codex_plan_review_adapter._run_with_pty")
     @patch("codex_review_adapter._resolve_codex_binary", return_value=["codex"])
-    def test_custom_base_branch(self, mock_resolve, mock_run):
+    def test_custom_base_branch(self, mock_resolve, mock_pty):
         """Base branch argument is correctly passed."""
-        mock_run.return_value = Mock(returncode=0, stdout="LGTM", stderr="")
+        mock_pty.return_value = (0, "LGTM")
         invoke_codex_cli(base="develop")
-        cmd = mock_run.call_args[0][0]
+        cmd = mock_pty.call_args[0][0]
         assert cmd == ["codex", "review", "--base", "develop"]
 
 
@@ -387,24 +387,23 @@ class TestErrorClassification:
     def test_empty_stderr_is_review_error(self):
         assert _classify_error("") == "cli_review_error"
 
-    @patch("codex_review_adapter.subprocess.run")
+    @patch("codex_plan_review_adapter._run_with_pty")
     @patch("codex_review_adapter._resolve_codex_binary", return_value=["codex"])
-    def test_error_type_in_result(self, mock_resolve, mock_run):
+    def test_error_type_in_result(self, mock_resolve, mock_pty):
         """error_type must be set on failed results."""
-        mock_run.return_value = Mock(
-            returncode=2,
-            stdout="",
-            stderr="error: the argument '--base <BRANCH>' cannot be used with '[PROMPT]'",
+        mock_pty.return_value = (
+            2,
+            "error: the argument '--base <BRANCH>' cannot be used with '[PROMPT]'",
         )
         result = invoke_codex_cli(base="main")
         assert not result.success
         assert result.error_type == "cli_invocation_error"
 
-    @patch("codex_review_adapter.subprocess.run")
+    @patch("codex_plan_review_adapter._run_with_pty")
     @patch("codex_review_adapter._resolve_codex_binary", return_value=["codex"])
-    def test_success_has_no_error_type(self, mock_resolve, mock_run):
+    def test_success_has_no_error_type(self, mock_resolve, mock_pty):
         """Successful results have no error_type."""
-        mock_run.return_value = Mock(returncode=0, stdout="LGTM", stderr="")
+        mock_pty.return_value = (0, "LGTM")
         result = invoke_codex_cli(base="main")
         assert result.success
         assert result.error_type is None
@@ -486,16 +485,16 @@ class TestEnvVarLauncher:
                 result = _resolve_codex_binary()
                 assert result == ["npx", "@openai/codex"]
 
-    @patch("codex_review_adapter.subprocess.run")
-    def test_env_var_in_invoke_command(self, mock_run):
+    @patch("codex_plan_review_adapter._run_with_pty")
+    def test_env_var_in_invoke_command(self, mock_pty):
         """Env-configured command appears in invoke_codex_cli() command."""
-        mock_run.return_value = Mock(returncode=0, stdout="LGTM", stderr="")
+        mock_pty.return_value = (0, "LGTM")
         with patch.dict(
             os.environ,
             {"CODEX_REVIEW_CMD": "docker exec codex-container codex"},
         ):
             invoke_codex_cli(base="main")
-            cmd = mock_run.call_args[0][0]
+            cmd = mock_pty.call_args[0][0]
             assert cmd == [
                 "docker",
                 "exec",


### PR DESCRIPTION
## Plan
`plans/sessions/2026-03-15_review-loop-pty-completion.md`

## Summary
- Apply `_run_with_pty()` to `codex_review_adapter.py` `invoke_codex_cli()`, fixing the same TTY hang that affected plan reviews (#722)
- Reduce max review iterations from 5 to 3 in both `plan_review_driver` and `review_driver`
- Exclude `.claude/worktrees/` from ruff scanning to prevent stale agent worktrees from failing lint
- Update 7 tests in `test_codex_review_adapter.py` to mock `_run_with_pty`
- Update docs and skills referencing "5 review iterations" to 3

## Why
PR #722 fixed the plan review adapter's TTY hang but the PR review adapter (`codex_review_adapter.py`) had the identical `subprocess.run(capture_output=True)` problem. With #719 fixing `make check`, the PR review loop would now reach Codex invocation and hit the same hang. Additionally, stale agent worktrees under `.claude/worktrees/` with broken code (merge conflicts, etc.) were causing ruff to fail on otherwise clean checkouts.

Closes #730

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_codex_review_adapter.py tests/unit/test_codex_plan_review_adapter.py tests/unit/test_plan_review_driver.py -v
# 114 passed
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_codex_review_adapter.py tests/unit/test_codex_plan_review_adapter.py tests/unit/test_plan_review_driver.py` — 114 passed
- [x] Pre-commit hooks pass (ruff, repo-linter)

## Expected impact
- Metrics impact: None
- Runtime impact: PR reviews will complete in ~130s instead of hanging indefinitely

## Risk level
- [x] Medium (strategy/experiments)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-review-loop-pty
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-review-loop-pty
```

`git worktree list` (abbreviated):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                   63e029d [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-review-loop-pty   3d9f820 [fix/review-loop-pty-completion]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)