### PR TITLE
fix: register sibling modules in sys.modules for transitive imports

### DIFF
--- a/scripts/internal/test_codex_plan_review_live.py
+++ b/scripts/internal/test_codex_plan_review_live.py
@@ -32,18 +32,28 @@ _scripts_dir = str(Path(__file__).resolve().parent)
 
 
 def _import_sibling(module_name: str):
-    """Import a sibling module from scripts/internal/ without sys.path mutation."""
+    """Import a sibling module from scripts/internal/ without sys.path mutation.
+
+    Registers the module in sys.modules so that transitive imports
+    (e.g., plan_review_driver importing codex_plan_review_adapter)
+    resolve correctly through the standard import machinery.
+    """
     import importlib.util
 
     spec = importlib.util.spec_from_file_location(
         module_name, Path(_scripts_dir) / f"{module_name}.py"
     )
     mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
     spec.loader.exec_module(mod)
     return mod
 
 
+# Load order matters: plan_review_driver transitively imports both
+# codex_plan_review_adapter and review_state, so they must be registered
+# in sys.modules first.
 _adapter = _import_sibling("codex_plan_review_adapter")
+_import_sibling("review_state")
 _driver = _import_sibling("plan_review_driver")
 
 PlanReviewResult = _adapter.PlanReviewResult


### PR DESCRIPTION
## Plan
- Post-merge review finding from PR #731 (CRITICAL)

## Summary
- Add `sys.modules[module_name] = mod` to `_import_sibling()` so transitive imports resolve
- Load `review_state` before `plan_review_driver` to satisfy its import deps

## Why
PR #731 replaced `sys.path.insert` with `importlib.util` to fix a repo-lint violation, but omitted `sys.modules` registration. This breaks `plan_review_driver.py`'s bare `from codex_plan_review_adapter import ...` and `from review_state import ...` with `ModuleNotFoundError` at runtime.

## Repro / Validation
**Command(s) run:**
- Pre-commit hooks pass (ruff, repo-linter)

**Seed (if applicable):**
- N/A

## Tests
- [x] Other: repo-linter passes, ruff passes

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): Fixes broken import in live test script

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-import
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-import
```

## Checklist
- [x] No generated artifacts committed
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)