### PR TITLE
feat: R3 inference fix + bid_type faceted reporting

### DIFF
--- a/scripts/internal/extract_comparator_cis.py
+++ b/scripts/internal/extract_comparator_cis.py
@@ -76,7 +76,10 @@ def _parse_jsonl_points(log_path: Path) -> dict:
             if winning_bid is None or bidder_position is None:
                 continue
 
-            pts_t0, pts_t1 = compute_points(winning_bid, bidder_position, t0, t1)
+            bid_type = record.get("bid_type", "regular")
+            pts_t0, pts_t1 = compute_points(
+                winning_bid, bidder_position, t0, t1, bid_type=bid_type
+            )
 
             # Bidder team's points
             if bidder_position in (0, 2):

--- a/scripts/internal/run_arc_d_h2h_battery.py
+++ b/scripts/internal/run_arc_d_h2h_battery.py
@@ -444,21 +444,19 @@ def _compute_team_points(record):
     """Compute team-level points from a hand_end JSONL record.
 
     Returns (team0_points, team1_points).
+
+    Uses ``compute_points()`` from the scoring module to handle regular,
+    moon, and loner bid types correctly.
     """
+    from bid_euchre.scoring import compute_points
+
     t0 = record["t0"]
     t1 = record["t1"]
     winning_bid = record["winning_bid"]
     bidder_position = record["bidder_position"]
-    made_bid = record["made_bid"]
+    bid_type = record.get("bid_type", "regular")
 
-    if bidder_position in (0, 2):  # Declarer on team 0
-        team0_points = t0 if made_bid else -winning_bid
-        team1_points = t1
-    else:  # Declarer on team 1
-        team0_points = t0
-        team1_points = t1 if made_bid else -winning_bid
-
-    return (team0_points, team1_points)
+    return compute_points(winning_bid, bidder_position, t0, t1, bid_type=bid_type)
 
 
 def _bootstrap_ci(deltas, n_bootstrap=10000, ci=0.95, seed=42):
@@ -748,6 +746,41 @@ def parse_run_results(run_dir, summary, seed=42):
             }
         if by_contract:
             cell["by_contract"] = by_contract
+
+        # Per-bid_type faceting: group records by bid_type and compute
+        # core metrics (delta, CI, win_rate) for regular/moon/loner.
+        bid_type_groups: dict[str, list] = {}
+        for rec in records:
+            bt = rec.get("bid_type", "regular")
+            if bt and isinstance(bt, str) and bt in ("regular", "moon", "loner"):
+                bid_type_groups.setdefault(bt, []).append(rec)
+
+        by_bid_type = {}
+        for bt, bt_records in bid_type_groups.items():
+            bt_deltas = []
+            bt_wins = 0
+            for rec in bt_records:
+                bp = rec.get("bidder_position")
+                if bp is None:
+                    continue  # all-pass: no bid_type, skip
+                t0_pts, t1_pts = _compute_team_points(rec)
+                bt_deltas.append(t0_pts - t1_pts)
+                if t0_pts > t1_pts:
+                    bt_wins += 1
+            bt_n = len(bt_deltas)
+            if bt_n == 0:
+                continue
+            bt_delta = float(np.mean(bt_deltas))
+            bt_ci_low, bt_ci_high = _bootstrap_ci(bt_deltas, seed=seed)
+            by_bid_type[bt] = {
+                "net_eppd_delta": round(bt_delta, 6),
+                "ci_low": round(bt_ci_low, 6),
+                "ci_high": round(bt_ci_high, 6),
+                "win_rate_a": round(bt_wins / bt_n, 4),
+                "deals_total": bt_n,
+            }
+        if by_bid_type:
+            cell["by_bid_type"] = by_bid_type
 
     return summary
 

--- a/src/bid_euchre/arc_d_v2/tables.py
+++ b/src/bid_euchre/arc_d_v2/tables.py
@@ -208,6 +208,24 @@ def generate_h2h_delta_matrix(h2h_battery: dict) -> pd.DataFrame:
                     }
                 )
 
+        # Per-bid_type rows (if by_bid_type data is available)
+        by_bid_type = cell.get("by_bid_type", {})
+        for bt in ("regular", "moon", "loner"):
+            bt_data = by_bid_type.get(bt)
+            if bt_data:
+                rows.append(
+                    {
+                        "model_a": bidder_a,
+                        "model_b": bidder_b,
+                        "facet": f"bid_type:{bt}",
+                        "net_eppd_delta": _safe_round(bt_data.get("net_eppd_delta")),
+                        "ci_low": _safe_round(bt_data.get("ci_low")),
+                        "ci_high": _safe_round(bt_data.get("ci_high")),
+                        "win_rate_a": _safe_round(bt_data.get("win_rate_a")),
+                        "deals_total": bt_data.get("deals_total"),
+                    }
+                )
+
     return pd.DataFrame(rows)
 
 
@@ -319,6 +337,93 @@ def generate_behavior_by_contract(
                     "source": "comparator",
                 }
             )
+
+    return pd.DataFrame(rows)
+
+
+def generate_behavior_by_bid_type(
+    comparator_cis: dict | None = None,
+    h2h_battery: dict | None = None,
+) -> pd.DataFrame:
+    """Generate behavior_by_bid_type.csv -- faceted behavioral metrics by bid type.
+
+    Columns: model, bid_type, count, bid_rate, make_rate, mean_net_points, source
+
+    For R0-R2 data (no bid_type field): emits only "regular" rows.
+    For R3 data: emits regular + moon + loner rows with actual frequencies.
+    """
+    rows: list[dict] = []
+
+    if comparator_cis:
+        bidders = comparator_cis.get("bidders", {})
+        bidders_by_bid_type = comparator_cis.get("bidders_by_bid_type", {})
+
+        if bidders_by_bid_type:
+            # R3+ data: per-bid_type breakdowns available
+            for bt in ("regular", "moon", "loner"):
+                bt_data = bidders_by_bid_type.get(bt, {})
+                for name, b in bt_data.items():
+                    rows.append(
+                        {
+                            "model": name,
+                            "bid_type": bt,
+                            "count": b.get("hands_with_bids", 0),
+                            "bid_rate": _safe_round(b.get("bid_rate")),
+                            "make_rate": _safe_round(b.get("make_rate")),
+                            "mean_net_points": _safe_round(b.get("net_eppd")),
+                            "source": "comparator",
+                        }
+                    )
+        else:
+            # R0-R2 data: only "regular" rows
+            for name, b in bidders.items():
+                rows.append(
+                    {
+                        "model": name,
+                        "bid_type": "regular",
+                        "count": b.get("hands_with_bids", 0),
+                        "bid_rate": _safe_round(b.get("bid_rate")),
+                        "make_rate": _safe_round(b.get("make_rate")),
+                        "mean_net_points": _safe_round(b.get("net_eppd")),
+                        "source": "comparator",
+                    }
+                )
+
+    if h2h_battery:
+        for _mid, cell in h2h_battery.get("cells", {}).items():
+            if cell.get("bidder_a") != cell.get("bidder_b"):
+                continue  # Only self-play for behavior tables
+            by_bid_type = cell.get("by_bid_type", {})
+            if by_bid_type:
+                for bt in ("regular", "moon", "loner"):
+                    bt_data = by_bid_type.get(bt)
+                    if bt_data:
+                        rows.append(
+                            {
+                                "model": cell["bidder_a"],
+                                "bid_type": bt,
+                                "count": bt_data.get("deals_total", 0),
+                                "bid_rate": None,
+                                "make_rate": _safe_round(bt_data.get("win_rate_a")),
+                                "mean_net_points": _safe_round(
+                                    bt_data.get("net_eppd_delta")
+                                ),
+                                "source": "h2h_self_play",
+                            }
+                        )
+            else:
+                # No bid_type data: emit "regular" row
+                rows.append(
+                    {
+                        "model": cell["bidder_a"],
+                        "bid_type": "regular",
+                        "count": cell.get("deals_total", 0),
+                        "bid_rate": _safe_round(cell.get("bid_rate_a")),
+                        "make_rate": _safe_round(cell.get("make_rate_a")),
+                        "mean_net_points": _safe_round(cell.get("fullgame_eppd")),
+                        "source": "h2h_self_play",
+                    }
+                )
 
     return pd.DataFrame(rows)
 
@@ -685,6 +790,30 @@ def _merge_h2h_batteries(batteries: list[dict]) -> dict:
                 merged_ct["ci_method"] = "seed_averaged"
                 merged_bc[ct] = merged_ct
             base["by_contract"] = merged_bc
+
+        # Merge per-bid_type data if present
+        all_bid_types: dict[str, list[dict]] = {}
+        for c in cell_list:
+            for bt, bt_data in c.get("by_bid_type", {}).items():
+                all_bid_types.setdefault(bt, []).append(bt_data)
+        if all_bid_types:
+            merged_bt = {}
+            for bt, bt_list in all_bid_types.items():
+                bt_deals = [d.get("deals_total", 0) for d in bt_list]
+                merged_bt_entry: dict = {}
+                for key in ("net_eppd_delta", "win_rate_a"):
+                    vals = [d.get(key) for d in bt_list]
+                    wm = _weighted_mean(vals, bt_deals)
+                    merged_bt_entry[key] = round(wm, 6) if wm is not None else None
+                for key in ("ci_low", "ci_high"):
+                    vals = [d.get(key) for d in bt_list if d.get(key) is not None]
+                    merged_bt_entry[key] = (
+                        round(sum(vals) / len(vals), 6) if vals else None
+                    )
+                merged_bt_entry["deals_total"] = sum(bt_deals)
+                merged_bt_entry["ci_method"] = "seed_averaged"
+                merged_bt[bt] = merged_bt_entry
+            base["by_bid_type"] = merged_bt
         result_cells[mid] = base
 
     merged["cells"] = result_cells
@@ -1057,6 +1186,12 @@ def generate_all_tables(
     if len(df) > 0:
         df.to_csv(output_dir / "behavior_by_contract.csv", index=False)
         generated.append("behavior_by_contract.csv")
+
+    # 5b. behavior_by_bid_type.csv
+    df = generate_behavior_by_bid_type(comparator_cis, h2h_battery)
+    if len(df) > 0:
+        df.to_csv(output_dir / "behavior_by_bid_type.csv", index=False)
+        generated.append("behavior_by_bid_type.csv")
 
     # 6. sanity_bounds_check.csv
     df = generate_sanity_bounds_check(comparator_cis, training_artifacts)

--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -1746,23 +1746,31 @@ def extract_state_features(
     )
 
 
-def extract_action_features(bid_n: int, bid_type: str = "regular") -> np.ndarray:
-    """Extract the 4-element action feature vector: [bid_n, bid_n^2, is_moon, is_loner].
+def extract_action_features(
+    bid_n: int,
+    bid_type: str = "regular",
+    *,
+    include_moon_loner: bool = True,
+) -> np.ndarray:
+    """Extract action feature vector for a bid.
 
     Args:
         bid_n: The bid level (0-10).
         bid_type: One of "regular", "moon", or "loner". Default "regular"
             for backward compatibility with R0-R2 models.
+        include_moon_loner: If True, return 4 features [bid_n, bid_n_sq,
+            is_moon, is_loner]. If False, return only 2 features
+            [bid_n, bid_n_sq] (R0-R2 backward compat).
 
     Returns:
-        np.ndarray of shape (4,): [bid_n, bid_n_sq, is_moon, is_loner].
+        np.ndarray of shape (4,) or (2,) depending on include_moon_loner.
     """
-    is_moon = 1.0 if bid_type == "moon" else 0.0
-    is_loner = 1.0 if bid_type == "loner" else 0.0
-    return np.array(
-        [float(bid_n), float(bid_n * bid_n), is_moon, is_loner],
-        dtype=np.float64,
-    )
+    base = [float(bid_n), float(bid_n * bid_n)]
+    if include_moon_loner:
+        is_moon = 1.0 if bid_type == "moon" else 0.0
+        is_loner = 1.0 if bid_type == "loner" else 0.0
+        base.extend([is_moon, is_loner])
+    return np.array(base, dtype=np.float64)
 
 
 def compute_interaction_features(state: np.ndarray) -> np.ndarray:
@@ -2034,6 +2042,7 @@ def _check_ols_predictions_sane(
     has_interactions: bool = False,
     include_positional: bool = True,
     hand_indices: Optional[dict[str, np.ndarray]] = None,
+    has_moon_loner: bool = True,
 ) -> None:
     """Quick sanity check that OLS predictions aren't degenerate.
 
@@ -2063,8 +2072,8 @@ def _check_ols_predictions_sane(
             interactions = compute_interaction_features(state)
             parts_10.append(interactions)
             parts_1.append(interactions)
-        parts_10.append(extract_action_features(10))
-        parts_1.append(extract_action_features(1))
+        parts_10.append(extract_action_features(10, include_moon_loner=has_moon_loner))
+        parts_1.append(extract_action_features(1, include_moon_loner=has_moon_loner))
         feats_10 = np.concatenate(parts_10)
         feats_1 = np.concatenate(parts_1)
         val_10 = predict_ols(models[family], feats_10)
@@ -2086,6 +2095,7 @@ def _check_gbt_predictions_sane(
     partner_feature_names: Optional[List[str]] = None,
     include_positional: bool = True,
     hand_indices: Optional[dict[str, np.ndarray]] = None,
+    has_moon_loner: bool = True,
 ) -> None:
     """Quick sanity check that GBT predictions aren't degenerate.
 
@@ -2104,8 +2114,12 @@ def _check_gbt_predictions_sane(
         )
         if hand_indices and family in hand_indices:
             state = state[hand_indices[family]]
-        feats_10 = np.concatenate([state, extract_action_features(10)])
-        feats_1 = np.concatenate([state, extract_action_features(1)])
+        feats_10 = np.concatenate(
+            [state, extract_action_features(10, include_moon_loner=has_moon_loner)]
+        )
+        feats_1 = np.concatenate(
+            [state, extract_action_features(1, include_moon_loner=has_moon_loner)]
+        )
         val_10 = float(gbt_models[family].predict(feats_10.reshape(1, -1))[0])
         val_1 = float(gbt_models[family].predict(feats_1.reshape(1, -1))[0])
         if val_10 > val_1:
@@ -2214,6 +2228,13 @@ class ActionValueBidder(BiddingPolicy):
             has_positional=self._has_positional,
         )
 
+        # Detect whether artifact uses 4 (moon/loner) or 2 (base) action features.
+        # Must be computed UNCONDITIONALLY — R3 models have positional=True AND
+        # moon/loner features.
+        self._has_moon_loner = _detect_action_feature_count(
+            list(self.models["suit"]["feature_names"])
+        ) == len(ACTION_FEATURE_NAMES)
+
         # For R0/selected models: precompute per-family hand feature indices
         # so choose_bid() can select the right subset from the full state vector.
         # R1/R2 forward-selected artifacts may include partner/position/opponent
@@ -2260,6 +2281,7 @@ class ActionValueBidder(BiddingPolicy):
                 has_interactions=self._has_interactions,
                 include_positional=self._has_positional or self._needs_full_state,
                 hand_indices=self._hand_indices if not self._has_positional else None,
+                has_moon_loner=self._has_moon_loner,
             )
 
     def _select_state(
@@ -2282,7 +2304,7 @@ class ActionValueBidder(BiddingPolicy):
 
     def choose_bid(self, obs: BiddingObservation) -> BidAction:
         """Select the legal action with highest predicted E[net_points]."""
-        legal = enumerate_legal_actions(obs)
+        legal = enumerate_legal_actions(obs, include_moon_loner=self._has_moon_loner)
 
         best_value = float("-inf")
         best_action = BidAction.pass_bid()
@@ -2302,7 +2324,11 @@ class ActionValueBidder(BiddingPolicy):
                 if self._has_interactions:
                     interactions = compute_interaction_features(state)
                     state = np.concatenate([state, interactions])
-                action_feats = extract_action_features(action.n, action.bid_type)
+                action_feats = extract_action_features(
+                    action.n,
+                    action.bid_type,
+                    include_moon_loner=self._has_moon_loner,
+                )
                 features = np.concatenate([state, action_feats])
                 value = predict_ols(self.models[family], features)
 
@@ -2408,6 +2434,13 @@ class GBTActionValueBidder(BiddingPolicy):
             has_positional=self._has_positional,
         )
 
+        # Detect whether artifact uses 4 (moon/loner) or 2 (base) action features.
+        # Must be computed UNCONDITIONALLY — R3 models have positional=True AND
+        # moon/loner features.
+        self._has_moon_loner = _detect_action_feature_count(
+            list(models_meta["suit"]["feature_names"])
+        ) == len(ACTION_FEATURE_NAMES)
+
         # For R0/selected models: precompute per-family hand feature indices.
         # R1 forward-selected artifacts may include partner/position features
         # that are not in _HAND_FEATURE_NAMES — use STATE_FEATURE_NAMES when needed.
@@ -2448,6 +2481,7 @@ class GBTActionValueBidder(BiddingPolicy):
                 self._partner_feature_names,
                 include_positional=self._has_positional or self._needs_full_state,
                 hand_indices=self._hand_indices if not self._has_positional else None,
+                has_moon_loner=self._has_moon_loner,
             )
 
     def _select_state(
@@ -2470,7 +2504,7 @@ class GBTActionValueBidder(BiddingPolicy):
 
     def choose_bid(self, obs: BiddingObservation) -> BidAction:
         """Select the legal action with highest predicted E[net_points]."""
-        legal = enumerate_legal_actions(obs)
+        legal = enumerate_legal_actions(obs, include_moon_loner=self._has_moon_loner)
 
         best_value = float("-inf")
         best_action = BidAction.pass_bid()
@@ -2489,7 +2523,11 @@ class GBTActionValueBidder(BiddingPolicy):
                 if self._has_interactions:
                     interactions = compute_interaction_features(state)
                     state = np.concatenate([state, interactions])
-                action_feats = extract_action_features(action.n, action.bid_type)
+                action_feats = extract_action_features(
+                    action.n,
+                    action.bid_type,
+                    include_moon_loner=self._has_moon_loner,
+                )
                 features = np.concatenate([state, action_feats])
                 value = float(
                     self.gbt_models[family].predict(features.reshape(1, -1))[0]
@@ -2615,6 +2653,13 @@ class TwoStageActionValueBidder(BiddingPolicy):
             has_positional=self._has_positional,
         )
 
+        # Detect whether artifact uses 4 (moon/loner) or 2 (base) action features.
+        # Must be computed UNCONDITIONALLY — R3 models have positional=True AND
+        # moon/loner features.
+        self._has_moon_loner = _detect_action_feature_count(
+            list(suit_feature_names)
+        ) == len(ACTION_FEATURE_NAMES)
+
         # For R0/selected models: precompute per-family hand feature indices.
         # R1 forward-selected artifacts may include partner/position features
         # that are not in _HAND_FEATURE_NAMES — use STATE_FEATURE_NAMES when needed.
@@ -2672,7 +2717,7 @@ class TwoStageActionValueBidder(BiddingPolicy):
 
     def choose_bid(self, obs: BiddingObservation) -> BidAction:
         """Select the legal action with highest predicted E[net_points]."""
-        legal = enumerate_legal_actions(obs)
+        legal = enumerate_legal_actions(obs, include_moon_loner=self._has_moon_loner)
 
         best_value = float("-inf")
         best_action = BidAction.pass_bid()
@@ -2692,7 +2737,11 @@ class TwoStageActionValueBidder(BiddingPolicy):
                 if self._has_interactions:
                     interactions = compute_interaction_features(state)
                     state = np.concatenate([state, interactions])
-                action_feats = extract_action_features(action.n, action.bid_type)
+                action_feats = extract_action_features(
+                    action.n,
+                    action.bid_type,
+                    include_moon_loner=self._has_moon_loner,
+                )
                 features = np.concatenate([state, action_feats])
 
                 if family == "suit":

--- a/tests/unit/test_action_value_bidder.py
+++ b/tests/unit/test_action_value_bidder.py
@@ -14,6 +14,7 @@ from bid_euchre.core.cards import Card
 from bid_euchre.strategy.bidding import (
     _HAND_FEATURE_NAMES,
     ACTION_FEATURE_NAMES,
+    ACTION_FEATURE_NAMES_BASE,
     STATE_FEATURE_NAMES,
     ActionValueBidder,
     BidAction,
@@ -97,6 +98,61 @@ def _make_mock_artifact(
             "high": _model(n_state + n_action, high_bias),
             "low": _model(n_state + n_action, low_bias),
             "pass": _model(n_state, pass_bias),
+        },
+        "metadata": {
+            "context_features": [
+                "partner_level_same_suit",
+                "partner_level_same_color",
+                "partner_level_off_color",
+                "partner_level_high",
+                "partner_level_low",
+                "partner_passed",
+            ],
+            "arm": "full",
+        },
+    }
+
+
+def _make_base_action_artifact(
+    pass_bias: float = 0.0,
+    suit_bias: float = 1.0,
+    high_bias: float = 0.5,
+    low_bias: float = 0.5,
+) -> dict:
+    """Create a mock artifact using 2-element ACTION_FEATURE_NAMES_BASE (R0-R2 style).
+
+    Uses STATE_FEATURE_NAMES (positional) + ACTION_FEATURE_NAMES_BASE (bid_n, bid_n_sq).
+    """
+    n_state = len(STATE_FEATURE_NAMES)
+    n_action = len(ACTION_FEATURE_NAMES_BASE)
+
+    def _model(n_features: int, intercept: float, feature_names: list[str]) -> dict:
+        return {
+            "coefficients": [0.0] * n_features,
+            "intercept": intercept,
+            "feature_names": feature_names,
+            "r_squared": 0.10,
+        }
+
+    return {
+        "schema_version": "action_value_olsa_v1",
+        "models": {
+            "suit": _model(
+                n_state + n_action,
+                suit_bias,
+                STATE_FEATURE_NAMES + ACTION_FEATURE_NAMES_BASE,
+            ),
+            "high": _model(
+                n_state + n_action,
+                high_bias,
+                STATE_FEATURE_NAMES + ACTION_FEATURE_NAMES_BASE,
+            ),
+            "low": _model(
+                n_state + n_action,
+                low_bias,
+                STATE_FEATURE_NAMES + ACTION_FEATURE_NAMES_BASE,
+            ),
+            "pass": _model(n_state, pass_bias, STATE_FEATURE_NAMES),
         },
         "metadata": {
             "context_features": [
@@ -389,12 +445,22 @@ class TestActionValueBidder:
         action = bidder.choose_bid(obs)
         assert action.is_pass()
 
-    def test_choose_bid_after_bid_10_must_pass(self):
-        path = self._write_artifact(_make_mock_artifact())
+    def test_choose_bid_after_bid_10_must_pass_r0(self):
+        """R0-R2 bidder (2 action features) must pass after bid 10 — no moon/loner."""
+        path = self._write_artifact(_make_base_action_artifact())
         bidder = ActionValueBidder(artifact_path=path)
         obs = _make_obs(current_high_bid=10)
         action = bidder.choose_bid(obs)
         assert action.is_pass()
+
+    def test_choose_bid_after_bid_10_with_moon_loner(self):
+        """R3 bidder (4 action features) can bid moon/loner even after regular bid 10."""
+        path = self._write_artifact(_make_mock_artifact())
+        bidder = ActionValueBidder(artifact_path=path)
+        obs = _make_obs(current_high_bid=10)
+        action = bidder.choose_bid(obs)
+        # With moon/loner enabled and positive suit_bias, should pick a moon or loner
+        assert isinstance(action, BidAction)
 
     def test_context_features_loaded(self):
         path = self._write_artifact(_make_mock_artifact())
@@ -710,3 +776,102 @@ class TestForwardSelectedArtifact:
             bidder._hand_indices["suit"],
             expected_indices,
         )
+
+
+# ── extract_action_features include_moon_loner flag ──────
+
+
+class TestExtractActionFeaturesFlag:
+    """Tests for the include_moon_loner parameter on extract_action_features."""
+
+    def test_include_moon_loner_true_returns_4(self):
+        feats = extract_action_features(5, include_moon_loner=True)
+        assert feats.shape == (4,)
+        assert feats[0] == pytest.approx(5.0)
+        assert feats[1] == pytest.approx(25.0)
+        assert feats[2] == pytest.approx(0.0)  # is_moon
+        assert feats[3] == pytest.approx(0.0)  # is_loner
+
+    def test_include_moon_loner_false_returns_2(self):
+        feats = extract_action_features(5, include_moon_loner=False)
+        assert feats.shape == (2,)
+        assert feats[0] == pytest.approx(5.0)
+        assert feats[1] == pytest.approx(25.0)
+
+    def test_moon_with_flag_true(self):
+        feats = extract_action_features(10, bid_type="moon", include_moon_loner=True)
+        assert feats.shape == (4,)
+        assert feats[2] == pytest.approx(1.0)
+        assert feats[3] == pytest.approx(0.0)
+
+    def test_moon_with_flag_false_still_2(self):
+        """Even if bid_type is moon, flag=False means 2 features (no moon/loner cols)."""
+        feats = extract_action_features(10, bid_type="moon", include_moon_loner=False)
+        assert feats.shape == (2,)
+
+    def test_default_is_true(self):
+        """Default include_moon_loner=True for backward compatibility with R3 callers."""
+        feats = extract_action_features(5)
+        assert feats.shape == (4,)
+
+
+# ── _has_moon_loner detection on bidders ─────────────────
+
+
+class TestHasMoonLonerDetection:
+    """Tests that bidders correctly detect _has_moon_loner from artifact features."""
+
+    def _write_artifact(self, artifact: dict) -> str:
+        f = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
+        json.dump(artifact, f)
+        f.close()
+        return f.name
+
+    def test_4_feature_artifact_has_moon_loner(self):
+        """Artifact with 4 action features (R3 style) sets _has_moon_loner=True."""
+        path = self._write_artifact(_make_mock_artifact())
+        bidder = ActionValueBidder(artifact_path=path)
+        assert bidder._has_moon_loner is True
+
+    def test_2_feature_artifact_no_moon_loner(self):
+        """Artifact with 2 action features (R0-R2 style) sets _has_moon_loner=False."""
+        path = self._write_artifact(_make_base_action_artifact())
+        bidder = ActionValueBidder(artifact_path=path)
+        assert bidder._has_moon_loner is False
+
+    def test_4_feature_bidder_enumerates_moon_loner(self):
+        """Bidder with 4-feature artifact enumerates moon/loner at inference time."""
+        path = self._write_artifact(_make_mock_artifact(suit_bias=10.0))
+        bidder = ActionValueBidder(artifact_path=path)
+        obs = _make_obs(current_high_bid=0)
+        action = bidder.choose_bid(obs)
+        # Just verify the bidder runs without crash and returns a valid action
+        assert isinstance(action, BidAction)
+
+    def test_2_feature_bidder_no_moon_loner(self):
+        """Bidder with 2-feature artifact does NOT enumerate moon/loner (backward compat)."""
+        path = self._write_artifact(_make_base_action_artifact(suit_bias=10.0))
+        bidder = ActionValueBidder(artifact_path=path)
+        obs = _make_obs(current_high_bid=0)
+        action = bidder.choose_bid(obs)
+        assert isinstance(action, BidAction)
+        # Regular bids only — no moon or loner
+        if not action.is_pass():
+            assert action.bid_type == "regular"
+
+    def test_2_feature_bidder_no_crash_on_predict(self):
+        """R0-R2 style bidder with 2 action features doesn't crash in predict_ols.
+
+        This is the critical regression test: extract_action_features must return
+        only 2 features to match the model's coefficient vector size.
+        """
+        artifact = _make_base_action_artifact(
+            pass_bias=-10.0, suit_bias=5.0, high_bias=3.0, low_bias=3.0
+        )
+        path = self._write_artifact(artifact)
+        bidder = ActionValueBidder(artifact_path=path)
+        obs = _make_obs(current_high_bid=0)
+        # This would crash with a dimension mismatch if extract_action_features
+        # always returned 4 features
+        action = bidder.choose_bid(obs)
+        assert not action.is_pass()  # suit_bias is highest

--- a/tests/unit/test_rung_tables.py
+++ b/tests/unit/test_rung_tables.py
@@ -24,6 +24,7 @@ from bid_euchre.arc_d_v2.tables import (
     _per_seed_sanity_h2h,
     generate_all_tables,
     generate_artifact_inventory,
+    generate_behavior_by_bid_type,
     generate_behavior_by_contract,
     generate_behavior_summary,
     generate_comparator_rankings,
@@ -752,3 +753,204 @@ class TestMultiSeedPipeline:
         output_dir = tmp_path / "tables"
         generated = generate_all_tables(FIXTURES_DIR, output_dir, seeds=[42])
         assert "seed_sanity.csv" not in generated
+
+
+# ──────────────────────────────────────────────
+#  Bid-type faceting tests
+# ──────────────────────────────────────────────
+
+
+class TestBehaviorByBidType:
+    """Tests for the behavior_by_bid_type.csv table generation."""
+
+    def test_r0_style_only_regular_rows(self):
+        """R0-R2 data (no bidders_by_bid_type) produces only 'regular' rows."""
+        comparator = {
+            "bidders": {
+                "model_a": {
+                    "net_eppd": 1.5,
+                    "bid_rate": 0.6,
+                    "make_rate": 0.7,
+                    "hands_with_bids": 120,
+                },
+                "model_b": {
+                    "net_eppd": 0.8,
+                    "bid_rate": 0.5,
+                    "make_rate": 0.6,
+                    "hands_with_bids": 100,
+                },
+            },
+        }
+        df = generate_behavior_by_bid_type(comparator_cis=comparator)
+        assert len(df) == 2
+        assert set(df["bid_type"].unique()) == {"regular"}
+        assert set(df["model"].unique()) == {"model_a", "model_b"}
+
+    def test_r3_style_has_regular_moon_loner(self):
+        """R3 data with bidders_by_bid_type produces regular + moon + loner rows."""
+        comparator = {
+            "bidders": {
+                "gbt": {"net_eppd": 2.0, "bid_rate": 0.7, "make_rate": 0.8},
+            },
+            "bidders_by_bid_type": {
+                "regular": {
+                    "gbt": {
+                        "net_eppd": 1.8,
+                        "bid_rate": 0.6,
+                        "make_rate": 0.75,
+                        "hands_with_bids": 100,
+                    },
+                },
+                "moon": {
+                    "gbt": {
+                        "net_eppd": 5.0,
+                        "bid_rate": 0.08,
+                        "make_rate": 0.5,
+                        "hands_with_bids": 12,
+                    },
+                },
+                "loner": {
+                    "gbt": {
+                        "net_eppd": 10.0,
+                        "bid_rate": 0.02,
+                        "make_rate": 0.3,
+                        "hands_with_bids": 3,
+                    },
+                },
+            },
+        }
+        df = generate_behavior_by_bid_type(comparator_cis=comparator)
+        assert len(df) == 3
+        assert set(df["bid_type"].unique()) == {"regular", "moon", "loner"}
+
+    def test_schema_columns(self):
+        """Output has expected columns."""
+        comparator = {
+            "bidders": {
+                "model_a": {
+                    "net_eppd": 1.0,
+                    "bid_rate": 0.5,
+                    "make_rate": 0.6,
+                    "hands_with_bids": 50,
+                },
+            },
+        }
+        df = generate_behavior_by_bid_type(comparator_cis=comparator)
+        expected_cols = {
+            "model",
+            "bid_type",
+            "count",
+            "bid_rate",
+            "make_rate",
+            "mean_net_points",
+            "source",
+        }
+        assert set(df.columns) == expected_cols
+
+    def test_h2h_self_play_by_bid_type(self):
+        """H2H self-play with by_bid_type data emits per-type rows."""
+        h2h = {
+            "cells": {
+                "gbt_vs_gbt": {
+                    "bidder_a": "gbt",
+                    "bidder_b": "gbt",
+                    "deals_total": 200,
+                    "by_bid_type": {
+                        "regular": {
+                            "net_eppd_delta": 0.1,
+                            "win_rate_a": 0.5,
+                            "deals_total": 180,
+                        },
+                        "moon": {
+                            "net_eppd_delta": 2.0,
+                            "win_rate_a": 0.6,
+                            "deals_total": 20,
+                        },
+                    },
+                },
+            },
+        }
+        df = generate_behavior_by_bid_type(h2h_battery=h2h)
+        assert len(df) == 2
+        assert set(df["bid_type"].unique()) == {"regular", "moon"}
+        assert all(df["source"] == "h2h_self_play")
+
+    def test_h2h_no_bid_type_data_falls_back(self):
+        """H2H self-play without by_bid_type falls back to 'regular' row."""
+        h2h = {
+            "cells": {
+                "ols_vs_ols": {
+                    "bidder_a": "ols",
+                    "bidder_b": "ols",
+                    "deals_total": 100,
+                    "bid_rate_a": 0.5,
+                    "make_rate_a": 0.6,
+                    "fullgame_eppd": 4.5,
+                },
+            },
+        }
+        df = generate_behavior_by_bid_type(h2h_battery=h2h)
+        assert len(df) == 1
+        assert df.iloc[0]["bid_type"] == "regular"
+
+
+class TestH2HDeltaMatrixBidType:
+    """Tests that h2h_delta_matrix includes bid_type facet rows."""
+
+    def test_by_bid_type_rows_present(self):
+        """H2H battery with by_bid_type produces bid_type:* facet rows."""
+        h2h = {
+            "cells": {
+                "a_vs_b": {
+                    "bidder_a": "model_a",
+                    "bidder_b": "model_b",
+                    "net_eppd_delta": 0.5,
+                    "ci_low": 0.1,
+                    "ci_high": 0.9,
+                    "win_rate_a": 0.55,
+                    "deals_total": 1000,
+                    "by_bid_type": {
+                        "regular": {
+                            "net_eppd_delta": 0.4,
+                            "ci_low": 0.05,
+                            "ci_high": 0.75,
+                            "win_rate_a": 0.54,
+                            "deals_total": 900,
+                        },
+                        "moon": {
+                            "net_eppd_delta": 2.0,
+                            "ci_low": 0.5,
+                            "ci_high": 3.5,
+                            "win_rate_a": 0.7,
+                            "deals_total": 100,
+                        },
+                    },
+                },
+            },
+        }
+        df = generate_h2h_delta_matrix(h2h)
+        # Should have: 1 pooled + 2 bid_type facets
+        assert len(df) == 3
+        facets = set(df["facet"].unique())
+        assert "pooled" in facets
+        assert "bid_type:regular" in facets
+        assert "bid_type:moon" in facets
+
+    def test_no_bid_type_no_extra_rows(self):
+        """H2H battery without by_bid_type produces only pooled row."""
+        h2h = {
+            "cells": {
+                "a_vs_b": {
+                    "bidder_a": "model_a",
+                    "bidder_b": "model_b",
+                    "net_eppd_delta": 0.5,
+                    "ci_low": 0.1,
+                    "ci_high": 0.9,
+                    "win_rate_a": 0.55,
+                    "deals_total": 1000,
+                },
+            },
+        }
+        df = generate_h2h_delta_matrix(h2h)
+        assert len(df) == 1
+        assert df.iloc[0]["facet"] == "pooled"


### PR DESCRIPTION
## Summary

- Fix bidders to enumerate moon/loner at inference time (not just training)
- Parameterize `extract_action_features()`: 2 features (R0-R2) or 4 (R3+)
- Fix scoring bugs in `extract_comparator_cis.py` and `run_arc_d_h2h_battery.py`
- Add `by_bid_type` faceting to H2H battery and tables
- New `behavior_by_bid_type.csv` table
- 17 new tests, all passing

## Why

R3 QUICK showed inflated R² (0.899) but flat H2H because models never enumerated
moon/loner at inference time. Training included moon/loner counterfactuals but
`choose_bid()` called `enumerate_legal_actions()` without `include_moon_loner=True`.

Additionally, `compute_points()` callers in comparator and H2H scripts didn't pass
`bid_type`, so moon/loner hands would be mis-scored.

## Design

- `_has_moon_loner` detected unconditionally in all 3 bidder `__init__` methods
- R0-R2 artifacts (2 action features) → regular bids only, 2-element feature vectors
- R3+ artifacts (4 action features) → moon/loner enumerated, 4-element feature vectors
- `behavior_by_bid_type.csv` shows moon/loner frequencies per model
- R0-R2 data: only "regular" rows. R3: regular + moon + loner

## Repro / Validation

```bash
make check-quiet
uv run python -m pytest tests/unit/test_action_value_bidder.py tests/unit/test_rung_tables.py -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>