### PR TITLE
feat: expand behavior tables + chart_data extraction (reporting Phase 1)

### DIFF
--- a/src/bid_euchre/arc_d_v2/tables.py
+++ b/src/bid_euchre/arc_d_v2/tables.py
@@ -254,28 +254,101 @@ def generate_model_performance(
     return pd.DataFrame(rows)
 
 
+def _compute_contract_mix(
+    comparator_cis: dict | None, h2h_battery: dict | None
+) -> dict[str, dict[str, float | None]]:
+    """Compute contract-type mix fractions per model from available sources.
+
+    Uses H2H self-play by_contract deal counts when available,
+    falls back to comparator bidders_by_contract if present.
+
+    Returns:
+        dict mapping model name to {"mix_suit": float|None, "mix_high": ..., "mix_low": ...}
+    """
+    result: dict[str, dict[str, float | None]] = {}
+
+    # Prefer H2H self-play by_contract (always has deal counts per contract)
+    if h2h_battery:
+        for _mid, cell in h2h_battery.get("cells", {}).items():
+            if cell.get("bidder_a") != cell.get("bidder_b"):
+                continue  # Only self-play
+            model = cell["bidder_a"]
+            by_contract = cell.get("by_contract", {})
+            if not by_contract:
+                continue
+            total = sum(ct.get("deals_total", 0) for ct in by_contract.values())
+            if total > 0:
+                result[model] = {
+                    "mix_suit": _safe_round(
+                        by_contract.get("suit", {}).get("deals_total", 0) / total
+                    ),
+                    "mix_high": _safe_round(
+                        by_contract.get("high", {}).get("deals_total", 0) / total
+                    ),
+                    "mix_low": _safe_round(
+                        by_contract.get("low", {}).get("deals_total", 0) / total
+                    ),
+                }
+
+    # Fall back to comparator bidders_by_contract if available
+    if comparator_cis and not result:
+        bidders_by_contract = comparator_cis.get("bidders_by_contract", {})
+        if bidders_by_contract:
+            # Collect all models across contract types
+            models = set()
+            for ct_data in bidders_by_contract.values():
+                models.update(ct_data.keys())
+            for model in models:
+                counts = {}
+                for ct in ("suit", "high", "low"):
+                    ct_data = bidders_by_contract.get(ct, {}).get(model, {})
+                    counts[ct] = ct_data.get("deals_total", 0)
+                total = sum(counts.values())
+                if total > 0:
+                    result[model] = {
+                        "mix_suit": _safe_round(counts["suit"] / total),
+                        "mix_high": _safe_round(counts["high"] / total),
+                        "mix_low": _safe_round(counts["low"] / total),
+                    }
+
+    return result
+
+
 def generate_behavior_summary(
     comparator_cis: dict | None = None,
     h2h_battery: dict | None = None,
 ) -> pd.DataFrame:
     """Generate behavior_summary.csv -- pooled behavioral metrics per model.
 
-    Columns: model, net_eppd, eppd, bid_rate, make_rate, cvar_5, net_cvar_5,
-             source
+    Columns: model, net_eppd, eppd, bid_rate, pass_rate, make_rate, cvar_5,
+             net_cvar_5, mix_suit, mix_high, mix_low, source
+
+    Note: avg_bid, bid_std, bid_min, bid_max, and redeal_rate are defined in
+    the reporting contract but are not currently available in comparator_cis or
+    H2H battery artifacts. They are omitted until the source data supports them.
     """
+    contract_mix = _compute_contract_mix(comparator_cis, h2h_battery)
     rows = []
 
     if comparator_cis:
         for name, b in comparator_cis.get("bidders", {}).items():
+            bid_rate = b.get("bid_rate")
+            mix = contract_mix.get(name, {})
             rows.append(
                 {
                     "model": name,
                     "net_eppd": _safe_round(b.get("net_eppd")),
                     "eppd": _safe_round(b.get("eppd")),
-                    "bid_rate": _safe_round(b.get("bid_rate")),
+                    "bid_rate": _safe_round(bid_rate),
+                    "pass_rate": _safe_round(1.0 - bid_rate)
+                    if bid_rate is not None
+                    else None,
                     "make_rate": _safe_round(b.get("make_rate")),
                     "cvar_5": _safe_round(b.get("cvar_5")),
                     "net_cvar_5": _safe_round(b.get("net_cvar_5")),
+                    "mix_suit": mix.get("mix_suit"),
+                    "mix_high": mix.get("mix_high"),
+                    "mix_low": mix.get("mix_low"),
                     "source": "comparator",
                 }
             )
@@ -284,15 +357,24 @@ def generate_behavior_summary(
         for _mid, cell in h2h_battery.get("cells", {}).items():
             if cell.get("bidder_a") != cell.get("bidder_b"):
                 continue  # Only self-play
+            bid_rate = cell.get("bid_rate_a")
+            model = cell["bidder_a"]
+            mix = contract_mix.get(model, {})
             rows.append(
                 {
-                    "model": cell["bidder_a"],
+                    "model": model,
                     "net_eppd": _safe_round(cell.get("fullgame_eppd")),
                     "eppd": None,
-                    "bid_rate": _safe_round(cell.get("bid_rate_a")),
+                    "bid_rate": _safe_round(bid_rate),
+                    "pass_rate": _safe_round(1.0 - bid_rate)
+                    if bid_rate is not None
+                    else None,
                     "make_rate": _safe_round(cell.get("make_rate_a")),
                     "cvar_5": _safe_round(cell.get("fullgame_cvar_5")),
                     "net_cvar_5": None,
+                    "mix_suit": mix.get("mix_suit"),
+                    "mix_high": mix.get("mix_high"),
+                    "mix_low": mix.get("mix_low"),
                     "source": "h2h_self_play",
                 }
             )
@@ -305,7 +387,11 @@ def generate_behavior_by_contract(
 ) -> pd.DataFrame:
     """Generate behavior_by_contract.csv -- faceted behavioral metrics.
 
-    Columns: model, contract, net_eppd, bid_rate, make_rate, source
+    Columns: model, contract, net_eppd, bid_rate, pass_rate, make_rate, source
+
+    Note: avg_bid, bid_std, bid_min, bid_max are defined in the reporting
+    contract but are not currently available in comparator_cis per-contract
+    artifacts. They are omitted until the source data supports them.
     """
     rows = []
     if comparator_cis:
@@ -314,12 +400,16 @@ def generate_behavior_by_contract(
         for contract in ["suit", "high", "low"]:
             contract_data = bidders_by_contract.get(contract, {})
             for name, b in contract_data.items():
+                bid_rate = b.get("bid_rate")
                 rows.append(
                     {
                         "model": name,
                         "contract": contract,
                         "net_eppd": _safe_round(b.get("net_eppd")),
-                        "bid_rate": _safe_round(b.get("bid_rate")),
+                        "bid_rate": _safe_round(bid_rate),
+                        "pass_rate": _safe_round(1.0 - bid_rate)
+                        if bid_rate is not None
+                        else None,
                         "make_rate": _safe_round(b.get("make_rate")),
                         "source": "comparator",
                     }
@@ -327,12 +417,16 @@ def generate_behavior_by_contract(
 
         # Pooled rows (always available)
         for name, b in comparator_cis.get("bidders", {}).items():
+            bid_rate = b.get("bid_rate")
             rows.append(
                 {
                     "model": name,
                     "contract": "pooled",
                     "net_eppd": _safe_round(b.get("net_eppd")),
-                    "bid_rate": _safe_round(b.get("bid_rate")),
+                    "bid_rate": _safe_round(bid_rate),
+                    "pass_rate": _safe_round(1.0 - bid_rate)
+                    if bid_rate is not None
+                    else None,
                     "make_rate": _safe_round(b.get("make_rate")),
                     "source": "comparator",
                 }
@@ -482,19 +576,55 @@ def generate_sanity_bounds_check(
     return pd.DataFrame(rows)
 
 
-def generate_hypothesis_outcomes() -> pd.DataFrame:
-    """Generate hypothesis_outcomes.csv -- stub with columns.
+def generate_hypothesis_outcomes(
+    advance_check: dict | None = None,
+) -> pd.DataFrame:
+    """Generate hypothesis_outcomes.csv from advance_check data.
 
     Columns: hypothesis_id, description, status, evidence, notes
+
+    If advance_check is provided, populates from its hypothesis_checks.
+    Otherwise returns an empty DataFrame with the correct schema.
     """
+    rows: list[dict] = []
+
+    if advance_check:
+        for h in advance_check.get("hypothesis_checks", []):
+            passed = h.get("pass", False)
+            observed = h.get("observed")
+            expected_bound = h.get("expected_bound", "")
+            surprise = h.get("surprise_hit", False)
+
+            status = "PASS" if passed else "FAIL"
+            evidence = f"observed={observed}"
+            if expected_bound:
+                evidence += f", bound={expected_bound}"
+
+            notes_parts = []
+            if surprise:
+                notes_parts.append("SURPRISE")
+            if h.get("error"):
+                notes_parts.append(f"error: {h['error']}")
+
+            rows.append(
+                {
+                    "hypothesis_id": h.get("id", ""),
+                    "description": h.get("description", ""),
+                    "status": status,
+                    "evidence": evidence,
+                    "notes": "; ".join(notes_parts) if notes_parts else "",
+                }
+            )
+
     return pd.DataFrame(
+        rows,
         columns=[
             "hypothesis_id",
             "description",
             "status",
             "evidence",
             "notes",
-        ]
+        ],
     )
 
 
@@ -780,6 +910,116 @@ def generate_h2h_tier_summary(
             )
 
     return pd.DataFrame(rows)
+
+
+# ──────────────────────────────────────────────
+#  Chart data extraction
+# ──────────────────────────────────────────────
+
+
+def generate_chart_data(
+    h2h_battery: dict | None = None,
+    comparator_cis: dict | None = None,
+    output_dir: Path | None = None,
+) -> list[str]:
+    """Generate chart_data CSVs from existing artifacts.
+
+    Produces auditable source-data CSVs for chart generation (Phase 2).
+    Only creates CSVs where sufficient source data exists.
+
+    Args:
+        h2h_battery: Merged H2H battery JSON.
+        comparator_cis: Merged comparator CIs JSON.
+        output_dir: Path to write chart_data CSVs.
+
+    Returns:
+        List of generated CSV filenames.
+
+    Note: The following chart_data CSVs require model artifacts not available
+    in battery/comparator JSONs and are deferred:
+    - predictions.csv (requires model prediction outputs)
+    - residuals.csv (requires model prediction outputs)
+    - calibration_bins.csv (requires model prediction outputs)
+    - selection_paths.csv (requires feature selection logs)
+    - decision_comparison.csv (requires model decision traces)
+    - disagreement_outcomes.csv (requires multi-model decision traces)
+    - cross_rung_progression.csv (requires multi-rung data)
+    """
+    if output_dir is None:
+        return []
+    output_dir.mkdir(parents=True, exist_ok=True)
+    generated = []
+
+    # 1. outcome_distributions.csv — from H2H self-play by_contract
+    if h2h_battery:
+        rows = []
+        for _mid, cell in h2h_battery.get("cells", {}).items():
+            if cell.get("bidder_a") != cell.get("bidder_b"):
+                continue  # Self-play only
+            model = cell["bidder_a"]
+            # Pooled outcome
+            fullgame_eppd = cell.get("fullgame_eppd")
+            if fullgame_eppd is not None:
+                rows.append(
+                    {
+                        "model": model,
+                        "contract": "pooled",
+                        "value": _safe_round(fullgame_eppd),
+                        "metric": "fullgame_eppd",
+                    }
+                )
+            # Per-contract outcomes
+            by_contract = cell.get("by_contract", {})
+            for ct in ("suit", "high", "low"):
+                ct_data = by_contract.get(ct)
+                if ct_data and ct_data.get("net_eppd_delta") is not None:
+                    rows.append(
+                        {
+                            "model": model,
+                            "contract": ct,
+                            "value": _safe_round(ct_data["net_eppd_delta"]),
+                            "metric": "net_eppd_delta",
+                        }
+                    )
+        if rows:
+            df = pd.DataFrame(rows)
+            df.to_csv(output_dir / "outcome_distributions.csv", index=False)
+            generated.append("outcome_distributions.csv")
+
+    # 2. contract_mix.csv — deal counts by contract from H2H self-play
+    if h2h_battery:
+        rows = []
+        for _mid, cell in h2h_battery.get("cells", {}).items():
+            if cell.get("bidder_a") != cell.get("bidder_b"):
+                continue
+            model = cell["bidder_a"]
+            by_contract = cell.get("by_contract", {})
+            if not by_contract:
+                continue
+            total = sum(ct.get("deals_total", 0) for ct in by_contract.values())
+            for ct in ("suit", "high", "low"):
+                ct_data = by_contract.get(ct, {})
+                deals = ct_data.get("deals_total", 0)
+                rows.append(
+                    {
+                        "model": model,
+                        "contract": ct,
+                        "deals": deals,
+                        "fraction": _safe_round(deals / total) if total > 0 else None,
+                    }
+                )
+        if rows:
+            df = pd.DataFrame(rows)
+            df.to_csv(output_dir / "contract_mix.csv", index=False)
+            generated.append("contract_mix.csv")
+
+    # 3. seat_balance.csv — not available in battery JSONs (no per-seat data)
+    # Deferred: requires per-seat JSONL data not present in battery summaries.
+
+    # 4. bid_levels.csv — not available (no bid-level distribution data)
+    # Deferred: requires per-hand bid level data not present in battery summaries.
+
+    return generated
 
 
 # ──────────────────────────────────────────────
@@ -1288,10 +1528,24 @@ def generate_all_tables(
         df.to_csv(output_dir / "sanity_bounds_check.csv", index=False)
         generated.append("sanity_bounds_check.csv")
 
-    # 7. hypothesis_outcomes.csv (stub)
-    df = generate_hypothesis_outcomes()
-    df.to_csv(output_dir / "hypothesis_outcomes.csv", index=False)
-    generated.append("hypothesis_outcomes.csv")
+    # 7. hypothesis_outcomes.csv — populate from advance_check.json if available
+    #    Skip writing if a populated CSV already exists (e.g., from advance_check
+    #    pipeline) to avoid overwriting real data with an empty stub.
+    existing_ho = output_dir / "hypothesis_outcomes.csv"
+    advance_check = _load_json(rung_dir / "advance_check.json")
+    df = generate_hypothesis_outcomes(advance_check)
+    if len(df) > 0:
+        # We have real data — always write it
+        df.to_csv(existing_ho, index=False)
+        generated.append("hypothesis_outcomes.csv")
+    elif existing_ho.exists() and existing_ho.stat().st_size > 0:
+        # A populated CSV already exists — do not overwrite with empty stub
+        logger.info("hypothesis_outcomes.csv already populated; skipping empty stub.")
+        generated.append("hypothesis_outcomes.csv")
+    else:
+        # No data available — write empty schema stub
+        df.to_csv(existing_ho, index=False)
+        generated.append("hypothesis_outcomes.csv")
 
     # 8. rung_model_spec.csv
     df = generate_rung_model_spec(roster)
@@ -1332,5 +1586,15 @@ def generate_all_tables(
                 "Per-seed sanity: %d warnings detected. See seed_sanity.csv.",
                 len(df),
             )
+
+    # 14. chart_data CSVs (outcome_distributions, contract_mix, etc.)
+    chart_data_dir = output_dir.parent / "chart_data"
+    chart_data_csvs = generate_chart_data(
+        h2h_battery=h2h_battery,
+        comparator_cis=comparator_cis,
+        output_dir=chart_data_dir,
+    )
+    for csv_name in chart_data_csvs:
+        generated.append(f"chart_data/{csv_name}")
 
     return generated

--- a/tests/unit/test_reporting_pipeline_smoke.py
+++ b/tests/unit/test_reporting_pipeline_smoke.py
@@ -53,7 +53,11 @@ class TestFullPipelineSmoke:
 
         # Verify all table CSVs exist and are non-empty
         for csv_name in generated_tables:
-            csv_path = tables_dir / csv_name
+            if csv_name.startswith("chart_data/"):
+                # chart_data CSVs are written to report_dir/chart_data/
+                csv_path = report_dir / csv_name
+            else:
+                csv_path = tables_dir / csv_name
             assert csv_path.exists(), f"Table missing: {csv_name}"
             assert csv_path.stat().st_size > 0, f"Table empty: {csv_name}"
 

--- a/tests/unit/test_rung_tables.py
+++ b/tests/unit/test_rung_tables.py
@@ -31,6 +31,7 @@ from bid_euchre.arc_d_v2.tables import (
     generate_behavior_by_bid_type,
     generate_behavior_by_contract,
     generate_behavior_summary,
+    generate_chart_data,
     generate_comparator_rankings,
     generate_cross_rung_deltas,
     generate_data_sanity,
@@ -97,9 +98,13 @@ EXPECTED_SCHEMAS = {
         "net_eppd",
         "eppd",
         "bid_rate",
+        "pass_rate",
         "make_rate",
         "cvar_5",
         "net_cvar_5",
+        "mix_suit",
+        "mix_high",
+        "mix_low",
         "source",
     ],
     "behavior_by_contract": [
@@ -107,6 +112,7 @@ EXPECTED_SCHEMAS = {
         "contract",
         "net_eppd",
         "bid_rate",
+        "pass_rate",
         "make_rate",
         "source",
     ],
@@ -302,13 +308,62 @@ class TestSanityBoundsCheck:
 
 
 class TestHypothesisOutcomes:
-    def test_schema(self):
+    def test_schema_empty(self):
         df = generate_hypothesis_outcomes()
         assert list(df.columns) == EXPECTED_SCHEMAS["hypothesis_outcomes"]
-
-    def test_empty(self):
-        df = generate_hypothesis_outcomes()
         assert len(df) == 0
+
+    def test_schema_with_advance_check(self):
+        advance_check = {
+            "hypothesis_checks": [
+                {
+                    "id": "H1",
+                    "description": "Test hypothesis",
+                    "pass": True,
+                    "observed": 1.5,
+                    "expected_bound": "> 0.5",
+                    "surprise_hit": False,
+                    "error": None,
+                },
+                {
+                    "id": "H2",
+                    "description": "Failed hypothesis",
+                    "pass": False,
+                    "observed": -0.3,
+                    "expected_bound": ">= 0.0",
+                    "surprise_hit": True,
+                    "error": None,
+                },
+            ],
+        }
+        df = generate_hypothesis_outcomes(advance_check)
+        assert list(df.columns) == EXPECTED_SCHEMAS["hypothesis_outcomes"]
+        assert len(df) == 2
+        assert df.iloc[0]["hypothesis_id"] == "H1"
+        assert df.iloc[0]["status"] == "PASS"
+        assert "1.5" in df.iloc[0]["evidence"]
+        assert df.iloc[1]["status"] == "FAIL"
+        assert "SURPRISE" in df.iloc[1]["notes"]
+
+    def test_no_overwrite_populated_csv(self, tmp_path):
+        """generate_all_tables does not overwrite populated hypothesis_outcomes."""
+        output_dir = tmp_path / "tables"
+        output_dir.mkdir()
+
+        # Pre-populate hypothesis_outcomes.csv with real data
+        populated = output_dir / "hypothesis_outcomes.csv"
+        populated.write_text(
+            "hypothesis_id,description,status,evidence,notes\n"
+            "H1,Test,PASS,observed=1.0,\n"
+        )
+        original_size = populated.stat().st_size
+
+        # Run generate_all_tables with no advance_check available
+        generate_all_tables(FIXTURES_DIR, output_dir)
+
+        # Should NOT have been overwritten with empty stub
+        assert populated.stat().st_size >= original_size
+        assert "H1" in populated.read_text()
 
 
 class TestRungModelSpec:
@@ -585,7 +640,11 @@ class TestFullPipeline:
         ), f"Generated only {len(generated)} tables: {generated}"
 
         for csv_name in generated:
-            csv_path = output_dir / csv_name
+            if csv_name.startswith("chart_data/"):
+                # chart_data CSVs live at output_dir.parent / chart_data/
+                csv_path = output_dir.parent / csv_name
+            else:
+                csv_path = output_dir / csv_name
             assert csv_path.exists(), f"Missing: {csv_path}"
             assert csv_path.stat().st_size > 0, f"Empty: {csv_path}"
 
@@ -1190,3 +1249,152 @@ class TestH2HDeltaMatrixBidType:
         df = generate_h2h_delta_matrix(h2h)
         assert len(df) == 1
         assert df.iloc[0]["facet"] == "pooled"
+
+
+# ──────────────────────────────────────────────
+#  Expanded behavior column tests
+# ──────────────────────────────────────────────
+
+
+class TestBehaviorSummaryExpanded:
+    """Tests for expanded behavior_summary columns (pass_rate, mix_*)."""
+
+    def test_pass_rate_computed(self, comparator_cis, h2h_battery):
+        """pass_rate = 1 - bid_rate is present and correct."""
+        df = generate_behavior_summary(comparator_cis, h2h_battery)
+        assert "pass_rate" in df.columns
+        comp_rows = df[df["source"] == "comparator"]
+        for _, row in comp_rows.iterrows():
+            if row["bid_rate"] is not None and not pd.isna(row["bid_rate"]):
+                expected = round(1.0 - row["bid_rate"], 4)
+                assert row["pass_rate"] == pytest.approx(expected, abs=1e-4)
+
+    def test_mix_columns_present(self, comparator_cis, h2h_battery):
+        """mix_suit, mix_high, mix_low columns are present."""
+        df = generate_behavior_summary(comparator_cis, h2h_battery)
+        for col in ("mix_suit", "mix_high", "mix_low"):
+            assert col in df.columns
+
+    def test_mix_from_h2h_self_play(self):
+        """Contract mix computed from H2H self-play by_contract deal counts."""
+        h2h = {
+            "cells": {
+                "a_self": {
+                    "bidder_a": "model_a",
+                    "bidder_b": "model_a",
+                    "fullgame_eppd": 3.5,
+                    "bid_rate_a": 0.4,
+                    "make_rate_a": 0.6,
+                    "fullgame_cvar_5": -2.0,
+                    "deals_total": 100,
+                    "by_contract": {
+                        "suit": {"deals_total": 70, "net_eppd_delta": 0.5},
+                        "high": {"deals_total": 20, "net_eppd_delta": 0.3},
+                        "low": {"deals_total": 10, "net_eppd_delta": 0.1},
+                    },
+                },
+            },
+        }
+        df = generate_behavior_summary(None, h2h)
+        row = df.iloc[0]
+        assert row["mix_suit"] == pytest.approx(0.7, abs=1e-3)
+        assert row["mix_high"] == pytest.approx(0.2, abs=1e-3)
+        assert row["mix_low"] == pytest.approx(0.1, abs=1e-3)
+
+    def test_graceful_without_contract_data(self, comparator_cis):
+        """mix_* columns are None when no by_contract data is available."""
+        df = generate_behavior_summary(comparator_cis, None)
+        for col in ("mix_suit", "mix_high", "mix_low"):
+            # All should be None since fixture comparator_cis has no
+            # bidders_by_contract and we passed no h2h_battery
+            assert df[col].isna().all()
+
+
+class TestBehaviorByContractExpanded:
+    """Tests for expanded behavior_by_contract columns (pass_rate)."""
+
+    def test_pass_rate_present(self, comparator_cis):
+        """pass_rate column is present in behavior_by_contract."""
+        df = generate_behavior_by_contract(comparator_cis)
+        assert "pass_rate" in df.columns
+
+    def test_pass_rate_computed(self, comparator_cis):
+        """pass_rate = 1 - bid_rate for all rows."""
+        df = generate_behavior_by_contract(comparator_cis)
+        for _, row in df.iterrows():
+            if row["bid_rate"] is not None and not pd.isna(row["bid_rate"]):
+                expected = round(1.0 - row["bid_rate"], 4)
+                assert row["pass_rate"] == pytest.approx(expected, abs=1e-4)
+
+
+# ──────────────────────────────────────────────
+#  Chart data extraction tests
+# ──────────────────────────────────────────────
+
+
+class TestChartData:
+    """Tests for chart_data CSV generation."""
+
+    def test_outcome_distributions_from_h2h(self, h2h_battery, tmp_path):
+        """outcome_distributions.csv generated from H2H self-play data."""
+        generated = generate_chart_data(h2h_battery=h2h_battery, output_dir=tmp_path)
+        assert "outcome_distributions.csv" in generated
+        df = pd.read_csv(tmp_path / "outcome_distributions.csv")
+        assert "model" in df.columns
+        assert "contract" in df.columns
+        assert "value" in df.columns
+        assert len(df) > 0
+
+    def test_contract_mix_from_h2h(self, tmp_path):
+        """contract_mix.csv generated from H2H self-play by_contract."""
+        h2h = {
+            "cells": {
+                "a_self": {
+                    "bidder_a": "model_a",
+                    "bidder_b": "model_a",
+                    "deals_total": 100,
+                    "by_contract": {
+                        "suit": {"deals_total": 60, "net_eppd_delta": 0.5},
+                        "high": {"deals_total": 25, "net_eppd_delta": 0.3},
+                        "low": {"deals_total": 15, "net_eppd_delta": 0.1},
+                    },
+                },
+            },
+        }
+        generated = generate_chart_data(h2h_battery=h2h, output_dir=tmp_path)
+        assert "contract_mix.csv" in generated
+        df = pd.read_csv(tmp_path / "contract_mix.csv")
+        assert set(df.columns) == {"model", "contract", "deals", "fraction"}
+        assert len(df) == 3
+        suit_row = df[df["contract"] == "suit"].iloc[0]
+        assert suit_row["deals"] == 60
+        assert suit_row["fraction"] == pytest.approx(0.6, abs=1e-3)
+
+    def test_no_data_no_csvs(self, tmp_path):
+        """No chart_data CSVs generated when no source data exists."""
+        generated = generate_chart_data(output_dir=tmp_path)
+        assert len(generated) == 0
+
+    def test_graceful_without_by_contract(self, tmp_path):
+        """No contract_mix.csv when H2H has no by_contract data."""
+        h2h = {
+            "cells": {
+                "a_self": {
+                    "bidder_a": "model_a",
+                    "bidder_b": "model_a",
+                    "deals_total": 100,
+                    "fullgame_eppd": 3.5,
+                },
+            },
+        }
+        generated = generate_chart_data(h2h_battery=h2h, output_dir=tmp_path)
+        assert "contract_mix.csv" not in generated
+
+    def test_chart_data_in_full_pipeline(self, tmp_path):
+        """generate_all_tables produces chart_data CSVs."""
+        output_dir = tmp_path / "tables"
+        generated = generate_all_tables(FIXTURES_DIR, output_dir)
+        chart_data_items = [g for g in generated if g.startswith("chart_data/")]
+        # Fixture h2h_battery has self-play cells with fullgame_eppd,
+        # so outcome_distributions should be present
+        assert len(chart_data_items) > 0


### PR DESCRIPTION
## Summary

- Expand behavior_summary.csv: pass_rate, mix_suit/high/low columns
- Expand behavior_by_contract.csv: pass_rate column  
- Fix hypothesis_outcomes dual-writer (populate from advance_check.json)
- New chart_data extraction: outcome_distributions.csv, contract_mix.csv
- 11 new tests

Phase 1 of Reporting Suite Compaction Plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)