### PR TITLE
fix: resolve reporting integrity issues from Codex review

### DIFF
--- a/scripts/internal/generate_rung_charts.py
+++ b/scripts/internal/generate_rung_charts.py
@@ -19,7 +19,7 @@ Charts produced (Tier 1 + Tier 2 from §12.12):
   6.  contract_mix_bars.png          — from behavior_summary.csv
   7.  r2_by_contract.png             — from model_performance.csv
   8.  mae_by_contract.png            — from model_performance.csv
-  9.  outcome_distributions.png      — from chart_data/outcome_distributions.csv
+  9.  outcome_summary.png            — from chart_data/outcome_summary.csv
   10. seat_balance.png               — from chart_data/seat_balance.csv
 
 Dashboard pages (composite multi-panel charts):
@@ -239,29 +239,46 @@ def generate_bid_behavior_panel(
     output_dir: Path,
     dpi: int = 150,
 ) -> bool:
-    """Multi-panel behavior chart (bid_rate, make_rate by contract)."""
+    """Multi-panel behavior chart (bid_rate, make_rate by contract type).
+
+    Shows grouped bars with all contract types (suit/high/low/pooled) per model,
+    preserving the contract-type faceting required by project conventions.
+    """
     df = _read_csv_safe(tables_dir / "behavior_by_contract.csv")
     if df is None:
         return False
 
-    models = df["model"].unique()
-    fig, axes = plt.subplots(1, 2, figsize=(12, max(3, len(models) * 0.5 + 1)))
+    if "contract" not in df.columns:
+        return False
 
-    # Bid rate panel
-    ax = axes[0]
-    for model in models:
-        sub = df[df["model"] == model]
-        ax.barh(model, sub["bid_rate"].iloc[0] if len(sub) > 0 else 0)
-    ax.set_xlabel("Bid Rate")
-    ax.set_title("Bid Rate by Model")
+    models = sorted(df["model"].unique())
+    contracts = sorted(df["contract"].unique())
+    model_colors = _get_model_colors(models)
 
-    # Make rate panel
-    ax = axes[1]
-    for model in models:
-        sub = df[df["model"] == model]
-        ax.barh(model, sub["make_rate"].iloc[0] if len(sub) > 0 else 0)
-    ax.set_xlabel("Make Rate")
-    ax.set_title("Make Rate by Model")
+    fig, axes = plt.subplots(1, 2, figsize=(12, 5))
+
+    for panel_idx, (metric, title) in enumerate(
+        [("bid_rate", "Bid Rate by Contract"), ("make_rate", "Make Rate by Contract")]
+    ):
+        ax = axes[panel_idx]
+        if metric not in df.columns:
+            _unavailable_panel(ax, title)
+            continue
+        x = np.arange(len(contracts))
+        width = 0.8 / max(len(models), 1)
+        for i, model in enumerate(models):
+            vals = []
+            for contract in contracts:
+                sub = df[(df["model"] == model) & (df["contract"] == contract)]
+                vals.append(sub[metric].iloc[0] if len(sub) > 0 else 0)
+            offset = (i - len(models) / 2 + 0.5) * width
+            ax.bar(x + offset, vals, width, label=model, color=model_colors[model])
+        ax.set_xticks(x)
+        ax.set_xticklabels(contracts, fontsize=8)
+        ax.set_xlabel("Contract Type")
+        ax.set_ylabel(metric.replace("_", " ").title())
+        ax.set_title(title)
+        ax.legend(fontsize=7, loc="best")
 
     fig.tight_layout()
     _save_chart(fig, output_dir, "bid_behavior_panel.png", dpi)
@@ -271,22 +288,69 @@ def generate_bid_behavior_panel(
 def generate_contract_mix_bars(
     tables_dir: Path,
     output_dir: Path,
+    chart_data_dir: Path | None = None,
     dpi: int = 150,
 ) -> bool:
-    """Bar chart of contract mix from behavior summary."""
+    """Bar chart of contract mix.
+
+    Reads ``chart_data/contract_mix.csv`` when available (actual deal fractions
+    by contract type). Falls back to ``behavior_summary.csv`` bid_rate if the
+    dedicated contract_mix CSV is missing.
+    """
+    # Prefer contract_mix.csv from chart_data (actual mix fractions)
+    mix_df = (
+        _read_csv_safe(chart_data_dir / "contract_mix.csv") if chart_data_dir else None
+    )
+    if (
+        mix_df is not None
+        and "model" in mix_df.columns
+        and "fraction" in mix_df.columns
+    ):
+        models = sorted(mix_df["model"].unique())
+        contracts = sorted(mix_df["contract"].unique())
+        mix_colors = {"suit": "#C44E52", "high": "#4C72B0", "low": "#55A868"}
+
+        fig, ax = plt.subplots(figsize=(8, max(3, len(models) * 0.5 + 1)))
+        x = np.arange(len(models))
+        bottom = np.zeros(len(models))
+        for contract in contracts:
+            vals = []
+            for model in models:
+                sub = mix_df[
+                    (mix_df["model"] == model) & (mix_df["contract"] == contract)
+                ]
+                vals.append(sub["fraction"].iloc[0] if len(sub) > 0 else 0)
+            vals_arr = np.array(vals)
+            ax.barh(
+                x,
+                vals_arr,
+                left=bottom,
+                label=contract.title(),
+                color=mix_colors.get(contract, "#888888"),
+            )
+            bottom += vals_arr
+        ax.set_yticks(x)
+        ax.set_yticklabels(models, fontsize=8)
+        ax.set_xlabel("Fraction of Deals")
+        ax.set_title("Contract Mix by Model")
+        ax.legend(fontsize=8)
+        fig.tight_layout()
+        _save_chart(fig, output_dir, "contract_mix_bars.png", dpi)
+        return True
+
+    # Fallback: bid_rate from behavior_summary.csv
     df = _read_csv_safe(tables_dir / "behavior_summary.csv")
     if df is None:
         return False
 
-    # Use comparator-sourced data
-    comp = df[df["source"] == "comparator"]
+    comp = df[df["source"] == "comparator"] if "source" in df.columns else df
     if len(comp) == 0:
         comp = df
 
     fig, ax = plt.subplots(figsize=(8, max(3, len(comp) * 0.5 + 1)))
     ax.barh(comp["model"], comp["bid_rate"], color="#55A868", label="bid_rate")
     ax.set_xlabel("Bid Rate")
-    ax.set_title("Contract Mix / Bid Rate Summary")
+    ax.set_title("Bid Rate Summary (contract_mix.csv unavailable)")
     fig.tight_layout()
     _save_chart(fig, output_dir, "contract_mix_bars.png", dpi)
     return True
@@ -367,30 +431,52 @@ def generate_mae_by_contract(
     return True
 
 
-def generate_outcome_distributions(
+def generate_outcome_summary(
     chart_data_dir: Path,
     output_dir: Path,
     dpi: int = 150,
 ) -> bool:
-    """Outcome distribution chart from chart_data CSV."""
-    df = _read_csv_safe(chart_data_dir / "outcome_distributions.csv")
+    """Grouped bar chart of outcome summary metrics from chart_data CSV.
+
+    This shows summary-level metrics (one value per model per contract facet),
+    NOT per-deal distributions. The chart uses grouped bars with honest labeling.
+    """
+    df = _read_csv_safe(chart_data_dir / "outcome_summary.csv")
     if df is None:
         return False
 
-    fig, ax = plt.subplots(figsize=(10, 5))
-    if "contract" in df.columns and "value" in df.columns:
-        for contract in sorted(df["contract"].unique()):
-            sub = df[df["contract"] == contract]
-            ax.hist(sub["value"], bins=20, alpha=0.5, label=contract, density=True)
-        ax.legend()
-    else:
-        ax.hist(df.iloc[:, 0], bins=20, alpha=0.7)
+    if (
+        "model" not in df.columns
+        or "contract" not in df.columns
+        or "value" not in df.columns
+    ):
+        return False
 
-    ax.set_xlabel("Outcome Value")
-    ax.set_ylabel("Density")
-    ax.set_title("Outcome Distributions")
+    models = sorted(df["model"].unique())
+    contracts = sorted(df["contract"].unique())
+    model_colors = _get_model_colors(models)
+
+    x = np.arange(len(contracts))
+    width = 0.8 / max(len(models), 1)
+
+    fig, ax = plt.subplots(figsize=(10, 5))
+    for i, model in enumerate(models):
+        vals = []
+        for contract in contracts:
+            sub = df[(df["model"] == model) & (df["contract"] == contract)]
+            vals.append(sub["value"].iloc[0] if len(sub) > 0 else 0)
+        offset = (i - len(models) / 2 + 0.5) * width
+        ax.bar(x + offset, vals, width, label=model, color=model_colors[model])
+
+    ax.set_xticks(x)
+    ax.set_xticklabels(contracts, fontsize=9)
+    ax.set_xlabel("Contract Type")
+    ax.set_ylabel("Metric Value")
+    ax.set_title("Outcome Summary by Model and Contract")
+    ax.legend(fontsize=8)
+    ax.axhline(y=0, color="gray", linestyle="--", linewidth=0.5)
     fig.tight_layout()
-    _save_chart(fig, output_dir, "outcome_distributions.png", dpi)
+    _save_chart(fig, output_dir, "outcome_summary.png", dpi)
     return True
 
 
@@ -712,55 +798,81 @@ def generate_dashboard_health(
     else:
         _unavailable_panel(ax, "Contract Mix")
 
-    # Panel 3: Outcome distributions
+    # Panel 3: Outcome summary (grouped bar chart of summary metrics)
     ax = axes[1, 0]
     outcome_df = (
-        _read_csv_safe(chart_data_dir / "outcome_distributions.csv")
+        _read_csv_safe(chart_data_dir / "outcome_summary.csv")
         if chart_data_dir
         else None
     )
     if (
         outcome_df is not None
+        and "model" in outcome_df.columns
         and "contract" in outcome_df.columns
         and "value" in outcome_df.columns
     ):
-        for contract in sorted(outcome_df["contract"].unique()):
-            sub = outcome_df[outcome_df["contract"] == contract]
-            ax.hist(sub["value"], bins=20, alpha=0.5, label=contract, density=True)
-        ax.legend(fontsize=8)
-        ax.set_xlabel("Outcome Value", fontsize=9)
-        ax.set_ylabel("Density", fontsize=9)
-        ax.set_title("Outcome Distributions", fontsize=11)
-    else:
-        _unavailable_panel(ax, "Outcome Distributions")
-
-    # Panel 4: Bid-type breakdown
-    ax = axes[1, 1]
-    bid_type_df = _read_csv_safe(tables_dir / "behavior_by_bid_type.csv")
-    if bid_type_df is not None and "bid_type" in bid_type_df.columns:
-        models = sorted(bid_type_df["model"].unique())
-        bid_types = sorted(bid_type_df["bid_type"].unique())
+        models = sorted(outcome_df["model"].unique())
+        contracts = sorted(outcome_df["contract"].unique())
         model_colors = _get_model_colors(models)
-        x = np.arange(len(bid_types))
+        x = np.arange(len(contracts))
         width = 0.8 / max(len(models), 1)
         for i, model in enumerate(models):
             vals = []
-            for bt in bid_types:
-                sub = bid_type_df[
-                    (bid_type_df["model"] == model) & (bid_type_df["bid_type"] == bt)
+            for contract in contracts:
+                sub = outcome_df[
+                    (outcome_df["model"] == model)
+                    & (outcome_df["contract"] == contract)
                 ]
-                vals.append(
-                    sub["bid_rate"].iloc[0]
-                    if len(sub) > 0 and "bid_rate" in sub.columns
-                    else 0
-                )
+                vals.append(sub["value"].iloc[0] if len(sub) > 0 else 0)
             offset = (i - len(models) / 2 + 0.5) * width
             ax.bar(x + offset, vals, width, label=model, color=model_colors[model])
         ax.set_xticks(x)
-        ax.set_xticklabels(bid_types, fontsize=8)
-        ax.set_ylabel("Bid Rate", fontsize=9)
-        ax.set_title("Bid-Type Breakdown", fontsize=11)
+        ax.set_xticklabels(contracts, fontsize=8)
+        ax.set_xlabel("Contract Type", fontsize=9)
+        ax.set_ylabel("Metric Value", fontsize=9)
+        ax.set_title("Outcome Summary", fontsize=11)
         ax.legend(fontsize=7, loc="best")
+        ax.axhline(y=0, color="gray", linestyle="--", linewidth=0.5)
+    else:
+        _unavailable_panel(ax, "Outcome Summary")
+
+    # Panel 4: Bid-type breakdown
+    # Filter to source == "comparator" to exclude h2h_self_play rows where
+    # bid_rate is NaN (self-play data lacks meaningful bid_rate).
+    ax = axes[1, 1]
+    bid_type_df = _read_csv_safe(tables_dir / "behavior_by_bid_type.csv")
+    if bid_type_df is not None and "bid_type" in bid_type_df.columns:
+        if "source" in bid_type_df.columns:
+            bid_type_df = bid_type_df[bid_type_df["source"] == "comparator"]
+        if len(bid_type_df) == 0:
+            _unavailable_panel(ax, "Bid-Type Breakdown")
+        else:
+            models = sorted(bid_type_df["model"].unique())
+            bid_types = sorted(bid_type_df["bid_type"].unique())
+            model_colors = _get_model_colors(models)
+            x = np.arange(len(bid_types))
+            width = 0.8 / max(len(models), 1)
+            for i, model in enumerate(models):
+                vals = []
+                for bt in bid_types:
+                    sub = bid_type_df[
+                        (bid_type_df["model"] == model)
+                        & (bid_type_df["bid_type"] == bt)
+                    ]
+                    val = (
+                        sub["bid_rate"].iloc[0]
+                        if len(sub) > 0 and "bid_rate" in sub.columns
+                        else 0
+                    )
+                    # Handle NaN explicitly
+                    vals.append(0 if pd.isna(val) else val)
+                offset = (i - len(models) / 2 + 0.5) * width
+                ax.bar(x + offset, vals, width, label=model, color=model_colors[model])
+            ax.set_xticks(x)
+            ax.set_xticklabels(bid_types, fontsize=8)
+            ax.set_ylabel("Bid Rate", fontsize=9)
+            ax.set_title("Bid-Type Breakdown (comparator)", fontsize=11)
+            ax.legend(fontsize=7, loc="best")
     else:
         _unavailable_panel(ax, "Bid-Type Breakdown")
 
@@ -953,7 +1065,9 @@ def generate_all_charts(
         ),
         (
             "contract_mix_bars.png",
-            lambda: generate_contract_mix_bars(tables_dir, output_dir, dpi),
+            lambda: generate_contract_mix_bars(
+                tables_dir, output_dir, chart_data_dir, dpi
+            ),
         ),
         (
             "r2_by_contract.png",
@@ -976,8 +1090,8 @@ def generate_all_charts(
     if chart_data_dir:
         chart_data_generators = [
             (
-                "outcome_distributions.png",
-                lambda: generate_outcome_distributions(chart_data_dir, output_dir, dpi),
+                "outcome_summary.png",
+                lambda: generate_outcome_summary(chart_data_dir, output_dir, dpi),
             ),
             (
                 "seat_balance.png",

--- a/src/bid_euchre/arc_d_v2/orchestration.py
+++ b/src/bid_euchre/arc_d_v2/orchestration.py
@@ -106,6 +106,18 @@ def _repo_root() -> Path:
     return Path.cwd()
 
 
+def _report_subdir(mode: str) -> str:
+    """Return the report subdirectory name for the given mode.
+
+    - ``"quick"`` -> ``"quick"``
+    - ``"full"``  -> ``"full"``
+    - anything else (including ``"smoke"``) -> ``"canonical"``
+    """
+    if mode in ("quick", "full"):
+        return mode
+    return "canonical"
+
+
 def _plans_dir(rung: str) -> Path:
     return _repo_root() / "plans" / "arc_d_v2" / rung
 
@@ -954,7 +966,7 @@ def execute_step_3(state: RunState, seed: int, dry_run: bool = False) -> bool:
         / "04_reports"
         / "arc_d_v2"
         / rung
-        / "canonical"
+        / _report_subdir(state.mode)
         / "tables"
     )
     cmd = [
@@ -1008,7 +1020,14 @@ def execute_step_3b(state: RunState, seed: int, dry_run: bool = False) -> bool:
         return True
 
     rung_artifacts_dir = _repo_root() / "data" / "artifacts" / "arc_d_v2" / rung
-    report_dir = _repo_root() / "docs" / "04_reports" / "arc_d_v2" / rung / "canonical"
+    report_dir = (
+        _repo_root()
+        / "docs"
+        / "04_reports"
+        / "arc_d_v2"
+        / rung
+        / _report_subdir(state.mode)
+    )
 
     cmd = [
         "uv",
@@ -1354,7 +1373,7 @@ def execute_step_6(state: RunState, dry_run: bool = False) -> bool:
         / "04_reports"
         / "arc_d_v2"
         / rung
-        / "canonical"
+        / _report_subdir(state.mode)
         / "tables"
     )
 
@@ -1396,7 +1415,14 @@ def execute_step_7(state: RunState, dry_run: bool = False) -> bool:
     _append_log(rung, {"event": "step_start", "step": "7"})
     state.mark_step_started("7")
 
-    report_dir = _repo_root() / "docs" / "04_reports" / "arc_d_v2" / rung / "canonical"
+    report_dir = (
+        _repo_root()
+        / "docs"
+        / "04_reports"
+        / "arc_d_v2"
+        / rung
+        / _report_subdir(state.mode)
+    )
 
     # 7a: Charts
     chart_script = _repo_root() / "scripts" / "internal" / "generate_rung_charts.py"
@@ -1522,7 +1548,7 @@ def execute_step_8(state: RunState, dry_run: bool = False) -> bool:
         / "04_reports"
         / "arc_d_v2"
         / rung
-        / "canonical"
+        / _report_subdir(state.mode)
         / "tables"
     )
     output = _plans_dir(rung) / "advance_check.json"
@@ -1573,7 +1599,7 @@ def execute_step_9(state: RunState, dry_run: bool = False) -> bool:
         / "04_reports"
         / "arc_d_v2"
         / rung
-        / "canonical"
+        / _report_subdir(state.mode)
         / "04_rung_decision.md"
     )
 

--- a/src/bid_euchre/arc_d_v2/tables.py
+++ b/src/bid_euchre/arc_d_v2/tables.py
@@ -950,7 +950,10 @@ def generate_chart_data(
     output_dir.mkdir(parents=True, exist_ok=True)
     generated = []
 
-    # 1. outcome_distributions.csv — from H2H self-play by_contract
+    # 1. outcome_summary.csv — summary metrics from H2H self-play by_contract
+    #    NOTE: This is *summary* data (one row per model per contract facet),
+    #    NOT per-deal observations. Renamed from outcome_distributions.csv to
+    #    avoid implying distributional granularity.
     if h2h_battery:
         rows = []
         for _mid, cell in h2h_battery.get("cells", {}).items():
@@ -983,8 +986,8 @@ def generate_chart_data(
                     )
         if rows:
             df = pd.DataFrame(rows)
-            df.to_csv(output_dir / "outcome_distributions.csv", index=False)
-            generated.append("outcome_distributions.csv")
+            df.to_csv(output_dir / "outcome_summary.csv", index=False)
+            generated.append("outcome_summary.csv")
 
     # 2. contract_mix.csv — deal counts by contract from H2H self-play
     if h2h_battery:
@@ -1587,7 +1590,7 @@ def generate_all_tables(
                 len(df),
             )
 
-    # 14. chart_data CSVs (outcome_distributions, contract_mix, etc.)
+    # 14. chart_data CSVs (outcome_summary, contract_mix, etc.)
     chart_data_dir = output_dir.parent / "chart_data"
     chart_data_csvs = generate_chart_data(
         h2h_battery=h2h_battery,

--- a/tests/unit/test_rung_orchestrator.py
+++ b/tests/unit/test_rung_orchestrator.py
@@ -28,6 +28,7 @@ from bid_euchre.arc_d_v2.config import AnchorModel, Roster, RosterModel
 from bid_euchre.arc_d_v2.orchestration import (
     STEP_DESCRIPTIONS,
     STEP_FUNCTIONS,
+    _report_subdir,
     compute_fingerprint,
     handle_rerun,
     load_roster,
@@ -38,6 +39,27 @@ from bid_euchre.arc_d_v2.schemas import (
     STEPS,
     RunState,
 )
+
+# ============================================================================
+# Report Subdir Helper Tests
+# ============================================================================
+
+
+class TestReportSubdir:
+    """Test _report_subdir returns mode-appropriate directory names."""
+
+    def test_quick_mode(self):
+        assert _report_subdir("quick") == "quick"
+
+    def test_full_mode(self):
+        assert _report_subdir("full") == "full"
+
+    def test_smoke_mode_returns_canonical(self):
+        assert _report_subdir("smoke") == "canonical"
+
+    def test_unknown_mode_returns_canonical(self):
+        assert _report_subdir("something_else") == "canonical"
+
 
 # ============================================================================
 # State Management Tests
@@ -2437,7 +2459,7 @@ class TestEvidenceManifestIncludesChartData:
         (report_dir / "charts").mkdir(parents=True)
         chart_data_dir = report_dir / "chart_data"
         chart_data_dir.mkdir(parents=True)
-        (chart_data_dir / "outcome_distributions.csv").write_text(
+        (chart_data_dir / "outcome_summary.csv").write_text(
             "model,contract,value\ngbt_av,suit,1.5\n"
         )
         (chart_data_dir / "contract_mix.csv").write_text(
@@ -2453,6 +2475,6 @@ class TestEvidenceManifestIncludesChartData:
 
         assert "chart_data" in manifest
         chart_data_names = [cd["name"] for cd in manifest["chart_data"]]
-        assert "outcome_distributions.csv" in chart_data_names
+        assert "outcome_summary.csv" in chart_data_names
         assert "contract_mix.csv" in chart_data_names
         assert len(manifest["chart_data"]) == 2

--- a/tests/unit/test_rung_tables.py
+++ b/tests/unit/test_rung_tables.py
@@ -1335,11 +1335,11 @@ class TestBehaviorByContractExpanded:
 class TestChartData:
     """Tests for chart_data CSV generation."""
 
-    def test_outcome_distributions_from_h2h(self, h2h_battery, tmp_path):
-        """outcome_distributions.csv generated from H2H self-play data."""
+    def test_outcome_summary_from_h2h(self, h2h_battery, tmp_path):
+        """outcome_summary.csv generated from H2H self-play data."""
         generated = generate_chart_data(h2h_battery=h2h_battery, output_dir=tmp_path)
-        assert "outcome_distributions.csv" in generated
-        df = pd.read_csv(tmp_path / "outcome_distributions.csv")
+        assert "outcome_summary.csv" in generated
+        df = pd.read_csv(tmp_path / "outcome_summary.csv")
         assert "model" in df.columns
         assert "contract" in df.columns
         assert "value" in df.columns
@@ -1396,5 +1396,5 @@ class TestChartData:
         generated = generate_all_tables(FIXTURES_DIR, output_dir)
         chart_data_items = [g for g in generated if g.startswith("chart_data/")]
         # Fixture h2h_battery has self-play cells with fullgame_eppd,
-        # so outcome_distributions should be present
+        # so outcome_summary should be present
         assert len(chart_data_items) > 0


### PR DESCRIPTION
## Plan
plans/sessions/2026-03-16_reporting-integrity-fixes.md

## Summary
- Fix 6 hardcoded `"canonical"` path segments in orchestration.py with mode-aware `_report_subdir()` helper (CRITICAL)
- Rename `outcome_distributions.csv` → `outcome_summary.csv` and change dashboard histogram → grouped bar chart to honestly represent summary data (CRITICAL)
- Fix `bid_behavior_panel` to show all contract types instead of `.iloc[0]` (WARNING)
- Fix `contract_mix_bars` to prefer `contract_mix.csv` over `bid_rate` (WARNING)
- Filter bid-type panel by `source=="comparator"` and handle NaN (WARNING)

## Why
Codex post-merge review of reporting suite PRs (#743-#748) found 2 CRITICAL and 3 WARNING integrity issues. The hardcoded paths would cause FULL mode reports to write to `canonical/` instead of `full/`, and the distribution chart misrepresented summary data as per-deal observations.

## Repro / Validation
```bash
make check-quiet
PYTHONPATH=src uv run pytest tests/unit/test_rung_orchestrator.py tests/unit/test_rung_tables.py -q
```

## Tests
- [x] `make check-quiet` passes
- [x] `PYTHONPATH=src uv run pytest tests/unit/test_rung_orchestrator.py` — 4 new `TestReportSubdir` tests
- [x] `PYTHONPATH=src uv run pytest tests/unit/test_rung_tables.py` — updated for `outcome_summary.csv`

## Expected impact
- Metrics impact: None (reporting only)
- Runtime impact: None

## Risk level
Low — reporting pipeline only, no engine/strategy changes.

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-ac06d617
branch: worktree-agent-ac06d617
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)