### PR TITLE
feat: add TUI task list conventions rule

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,6 +3,7 @@
 Project overview, commands, architecture, and constraints are in the root CLAUDE.md.
 Domain docs live in docs/ — read them on-demand when working in relevant areas.
 Skills in .claude/skills/ provide workflow guidance — invoke with /skill-name.
+TUI task list conventions are in `.claude/rules/25_task_lists.md` — use for multi-step work.
 
 ## Compaction Instructions
 

--- a/.claude/rules/25_task_lists.md
+++ b/.claude/rules/25_task_lists.md
@@ -1,0 +1,86 @@
+# TUI Task List Conventions
+
+> The Claude Code task system (`TaskCreate`, `TaskUpdate`, `TaskList`) is a first-class
+> workflow tool. These conventions prevent task list drift in long sessions.
+
+## When to Create Tasks
+
+Create a TUI task list when:
+- Work involves 3+ distinct steps
+- Executing a governed plan step that decomposes into sub-steps
+- User provides multiple requests in one message
+- Working in plan mode
+
+Do NOT create tasks for: single-step work, pure Q&A, trivial edits.
+
+## Naming
+
+- **`subject`:** Imperative form, specific outcome ("Wire bid_type to logger", not "Work on logging")
+- **`activeForm`:** Present continuous matching subject ("Wiring bid_type to logger")
+- **`description`:** Include acceptance criteria and file paths when known
+
+## Dependencies and Parallelism
+
+Wire dependencies at creation time so the task list is a readable execution graph.
+
+- **Sequential:** Use `addBlockedBy` when tasks must run in order.
+  Example: "Write implementation" → "Run unit tests" → "Run make check"
+- **Parallel:** Tasks with no `blockedBy` edges are implicitly parallel. Omit
+  dependency edges between independent tasks — their independence is the signal.
+- **Fan-out / fan-in:** Wire the downstream task with `addBlockedBy` listing all
+  upstream IDs. Example: Tasks 1,2,3 are independent; Task 4 "Compare results"
+  has `addBlockedBy: [1,2,3]`.
+- **Task selection:** When multiple unblocked tasks are available, prefer lowest
+  ID first. Exception: agents assigned via `owner` work their own tasks.
+- **Sub-agent delegation:** Assign each spawned agent as `owner` of its task.
+  Parent monitors via `TaskList` to check completions and newly-unblocked work.
+
+## Status Protocol
+
+- Set `in_progress` **before** starting work (drives spinner UX)
+- Set `completed` only when fully done (tests pass, files written)
+- Use `deleted` for superseded or irrelevant tasks — never leave stale pendings
+- Never mark `completed` if blocked, errored, or partial
+
+## Hygiene — Keeping the List Current
+
+In long sessions, agents get absorbed in implementation and stop updating tasks.
+The list drifts and loses its value as a progress signal. Prevent this:
+
+- **Transition before action:** Always `TaskUpdate` status *before* starting and
+  *after* finishing. If agents skip transitions, the list becomes fiction.
+- **Scope changes → task changes:** When an approach is abandoned, immediately
+  `deleted` obsolete tasks and create replacements. No zombie pendings.
+- **Periodic audit:** After completing any task, call `TaskList` to review the
+  full list. Delete or update anything stale. One tool call prevents compounding drift.
+- **Cap at ~10 active tasks:** If the list grows larger, consolidate or split into
+  phases — create later-phase tasks only after earlier phases complete.
+- **Session-end sweep:** Before ending a session, call `TaskList` and ensure:
+  - No tasks left `in_progress` (complete or revert to `pending`)
+  - No stale `pending` tasks (delete or note in `checkpoints.md` / `MEMORY.md`)
+  - Unfinished work captured in the persistent system, not just the ephemeral list
+
+### Anti-Patterns
+
+- Creating 15+ tasks upfront and never revisiting the list
+- Leaving tasks `in_progress` across long tangents without updating
+- Completing work without marking the task — the spinner lies to the user
+- Treating the task list as write-only (create but never read/audit)
+
+## Governed Initiative Integration
+
+- When executing a checkpoint step, create TUI tasks for sub-steps
+- Reference the checkpoint step ID in subjects (e.g., "R2.3: Generate behavior tables")
+- On completion, update both the TUI task AND `checkpoints.md`
+
+## Relationship to Other Systems
+
+| System | Scope | Persists? | Use for |
+|--------|-------|-----------|---------|
+| TUI Tasks | Current session | No | Step-by-step execution, spinner UX |
+| `checkpoints.md` | Governed phase | Yes (git) | Cross-session progress |
+| `MEMORY.md` | Project-wide | Yes (file) | High-level status |
+| GitHub Issues | External | Yes | Follow-ups, bugs |
+
+TUI tasks are the intra-session complement to checkpoints (inter-session).
+They do not replace any existing system.


### PR DESCRIPTION
## Summary
- Add `.claude/rules/25_task_lists.md` — first-class conventions for the Claude Code TUI task system
- Reference added in `.claude/CLAUDE.md`

## Why
Long sessions suffer from task list drift — agents create tasks but stop updating them, leaving stale spinners and zombie pendings. This rule codifies trigger conditions, naming, dependency/parallelism patterns, status protocol, and hygiene rules to keep the list useful.

## Key Sections in the Rule
1. **Trigger conditions** — when to create tasks (3+ steps, governed plan sub-steps, multiple requests)
2. **Naming** — imperative subjects, present-continuous activeForm, acceptance criteria in description
3. **Dependencies & parallelism** — sequential chains, implicit parallelism, fan-out/fan-in, sub-agent ownership
4. **Status protocol** — transition before action, never mark completed if partial
5. **Hygiene** — periodic audit after each completion, cap at ~10 active, session-end sweep, anti-patterns
6. **Governed initiative integration** — checkpoint step IDs in subjects, dual update (TUI + checkpoints.md)

## Repro / Validation
```bash
make check-quiet  # passes — no Python changes
```

## Tests
- `make check-quiet` — all checks passed
- No Python code changes, so no unit tests needed
- Rule file validated by repo-linter (markdown structure)

## Worktree Proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-task-list-conventions
toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-task-list-conventions
worktree: Bid-Euchre-task-list-conventions c5fc229 [task-list-conventions]
```

## Plan
`plans/sessions/2026-03-16_tui-task-list-conventions.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)