### PR TITLE
feat: chunked dataset generation for memory-constrained FULL runs

### DIFF
--- a/scripts/internal/generate_action_value_dataset.py
+++ b/scripts/internal/generate_action_value_dataset.py
@@ -18,9 +18,11 @@ Usage:
 """
 
 import argparse
+import json
 import random
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pandas as pd
@@ -573,6 +575,60 @@ def simulate_counterfactual(
     return net_points, tricks_won, focal_declared
 
 
+def _load_completed_chunks(manifest_path: Path) -> set[tuple[int, int]]:
+    """Read manifest.jsonl, return set of (deal_start, deal_end) for completed chunks."""
+    completed: set[tuple[int, int]] = set()
+    if manifest_path.exists():
+        with open(manifest_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                entry = json.loads(line)
+                if entry.get("status") == "complete":
+                    completed.add((entry["deal_start"], entry["deal_end"]))
+    return completed
+
+
+def _write_chunk(
+    rows: list[dict],
+    output_dir: Path,
+    deal_start: int,
+    deal_end: int,
+    seed: int,
+    started_at: str,
+) -> None:
+    """Write a chunk of rows as a parquet part file and append to manifest."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    part_name = f"part_{deal_start:06d}_{deal_end:06d}.parquet"
+    part_path = output_dir / part_name
+
+    df = pd.DataFrame(rows)
+    df.to_parquet(part_path, index=False)
+
+    finished_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    started_dt = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+    finished_dt = datetime.fromisoformat(finished_at.replace("Z", "+00:00"))
+    duration_sec = (finished_dt - started_dt).total_seconds()
+
+    manifest_entry = {
+        "seed": seed,
+        "deal_start": deal_start,
+        "deal_end": deal_end,
+        "n_deals": deal_end - deal_start + 1,
+        "rows": len(rows),
+        "path": part_name,
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "duration_sec": round(duration_sec, 1),
+        "status": "complete",
+    }
+
+    manifest_path = output_dir / "manifest.jsonl"
+    with open(manifest_path, "a") as f:
+        f.write(json.dumps(manifest_entry) + "\n")
+
+
 def generate_dataset(
     seed: int,
     n_deals: int,
@@ -580,7 +636,9 @@ def generate_dataset(
     progress: bool = True,
     n_opponent_samples: int = 1,
     include_moon_loner: bool = False,
-) -> pd.DataFrame:
+    chunk_size: int | None = None,
+    output_dir: Path | None = None,
+) -> pd.DataFrame | None:
     """Generate the full counterfactual action-value dataset.
 
     For each (deal, focal_seat), enumerates all legal actions, forces each one,
@@ -595,11 +653,25 @@ def generate_dataset(
     card exchange followed by 4-player trick play; loner bids simulate 3-player
     trick play (partner sits out). Both use specialized scoring (+/-20 for moon,
     +/-40 for loner). Action features is_moon and is_loner are set accordingly.
+
+    When chunk_size is set and output_dir is provided, rows are flushed to
+    parquet part files every chunk_size deals. Returns None (data is on disk).
+    When chunk_size is None, returns the full DataFrame (existing behavior).
     """
+    chunked = chunk_size is not None and output_dir is not None
+    completed_chunks: set[tuple[int, int]] = set()
+    if chunked:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        manifest_path = output_dir / "manifest.jsonl"
+        completed_chunks = _load_completed_chunks(manifest_path)
+
     rows: list[dict] = []
-    hand_id = 0
     t0 = time.time()
     multi = n_opponent_samples > 1
+    total_rows_written = 0
+
+    # Track chunk boundaries for chunked mode
+    chunk_deal_start = 0
 
     # Contracts to evaluate for moon/loner: all 6 contract types
     contracts = [
@@ -611,11 +683,41 @@ def generate_dataset(
         ("LOW", "low", None),
     ]
 
+    chunk_started_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
     for deal_id in range(n_deals):
+        # Determine current chunk boundaries
+        if chunked:
+            current_chunk_start = (deal_id // chunk_size) * chunk_size
+            current_chunk_end = min(current_chunk_start + chunk_size, n_deals) - 1
+
+            # Check if this is the start of a new chunk
+            if deal_id == current_chunk_start:
+                chunk_deal_start = current_chunk_start
+                chunk_started_at = datetime.now(timezone.utc).strftime(
+                    "%Y-%m-%dT%H:%M:%SZ"
+                )
+
+            # Skip if this chunk is already complete (resumability)
+            if (current_chunk_start, current_chunk_end) in completed_chunks:
+                if deal_id == current_chunk_end:
+                    if progress:
+                        print(
+                            f"  [skip] Chunk deals {current_chunk_start}-"
+                            f"{current_chunk_end} already complete",
+                            file=sys.stderr,
+                        )
+                continue
+
+        # Global hand_id: deterministic from deal_id
+        hand_id = deal_id * 4
+
         hands = generate_deal(seed, deal_id)
         dealer = _deterministic_dealer(seed, deal_id)
 
         for focal_seat in range(4):
+            current_hand_id = hand_id + focal_seat
+
             # Run partial auction up to focal_seat (uses ORIGINAL hands
             # so that features reflect the actual deal configuration)
             current_high_bid, transcript = run_partial_auction(
@@ -699,7 +801,7 @@ def generate_dataset(
 
                 # Build row
                 row = {
-                    "hand_id": hand_id,
+                    "hand_id": current_hand_id,
                     "deal_id": deal_id,
                     "focal_seat": focal_seat,
                     "action_type": action_type,
@@ -756,7 +858,7 @@ def generate_dataset(
                         )
 
                     moon_row = {
-                        "hand_id": hand_id,
+                        "hand_id": current_hand_id,
                         "deal_id": deal_id,
                         "focal_seat": focal_seat,
                         "action_type": "bid",
@@ -804,7 +906,7 @@ def generate_dataset(
                         )
 
                     loner_row = {
-                        "hand_id": hand_id,
+                        "hand_id": current_hand_id,
                         "deal_id": deal_id,
                         "focal_seat": focal_seat,
                         "action_type": "bid",
@@ -824,9 +926,34 @@ def generate_dataset(
                         loner_row["n_samples"] = n_opponent_samples
                     rows.append(loner_row)
 
-            hand_id += 1
+        # Flush chunk if at chunk boundary
+        if chunked:
+            current_chunk_end = (
+                min((deal_id // chunk_size + 1) * chunk_size, n_deals) - 1
+            )
+            if deal_id == current_chunk_end and rows:
+                _write_chunk(
+                    rows,
+                    output_dir,
+                    chunk_deal_start,
+                    current_chunk_end,
+                    seed,
+                    chunk_started_at,
+                )
+                total_rows_written += len(rows)
+                if progress:
+                    elapsed = time.time() - t0
+                    rate = (deal_id + 1) / elapsed
+                    print(
+                        f"  [{deal_id + 1}/{n_deals}] chunk "
+                        f"{chunk_deal_start}-{current_chunk_end} "
+                        f"written ({len(rows)} rows), "
+                        f"{rate:.1f} deals/s, {elapsed:.1f}s elapsed",
+                        file=sys.stderr,
+                    )
+                rows = []
 
-        if progress and (deal_id + 1) % max(1, n_deals // 10) == 0:
+        elif progress and (deal_id + 1) % max(1, n_deals // 10) == 0:
             elapsed = time.time() - t0
             rate = (deal_id + 1) / elapsed
             print(
@@ -835,7 +962,19 @@ def generate_dataset(
                 file=sys.stderr,
             )
 
-    return pd.DataFrame(rows)
+    if chunked:
+        # Any remaining rows (shouldn't happen if n_deals % chunk_size == 0,
+        # but handle partial final chunk)
+        if rows:
+            final_start = (n_deals - 1) // chunk_size * chunk_size
+            final_end = n_deals - 1
+            _write_chunk(
+                rows, output_dir, final_start, final_end, seed, chunk_started_at
+            )
+            total_rows_written += len(rows)
+        return None
+    else:
+        return pd.DataFrame(rows)
 
 
 def validate_gate_x1(
@@ -987,22 +1126,37 @@ def main():
         action="store_true",
         help="Include moon/loner counterfactuals (R3+, not on by default)",
     )
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=None,
+        help="Write parquet part files every N deals (reduces peak memory)",
+    )
     args = parser.parse_args()
 
     n_deals = args.n_deals if args.n_deals is not None else MODE_DEALS[args.mode]
     n_opp = args.n_opponent_samples
     include_ml = args.include_moon_loner
+    chunk_size = args.chunk_size
 
     print("=== R1.5 Counterfactual Action-Value Dataset Generator ===")
     print(f"  Seed: {args.seed}")
     print(f"  Mode: {args.mode} ({n_deals} deals)")
     print(f"  Opponent samples: {n_opp}")
     print(f"  Moon/loner: {'yes' if include_ml else 'no'}")
+    print(f"  Chunk size: {chunk_size or 'disabled (single file)'}")
     print(f"  Continuation: {args.continuation_artifact}")
 
     # Load continuation policy
     print("  Loading continuation policy...")
     continuation = load_continuation_policy(args.continuation_artifact)
+
+    # Determine output directories
+    output_dir = Path(args.output_dir)
+    datasets_dir = output_dir / "datasets"
+
+    # Chunked output dir is a subdirectory
+    chunked_output_dir = datasets_dir / "action_value" if chunk_size else None
 
     # Generate dataset
     sim_equiv = n_deals * n_opp
@@ -1012,34 +1166,52 @@ def main():
         f"~40 actions{extra_per_seat} × {n_opp} samples)..."
     )
     print(f"  Simulation equivalents: ~{sim_equiv * 4 * 40:,}")
-    df = generate_dataset(
+
+    result = generate_dataset(
         args.seed,
         n_deals,
         continuation,
         n_opponent_samples=n_opp,
         include_moon_loner=include_ml,
+        chunk_size=chunk_size,
+        output_dir=chunked_output_dir,
     )
 
-    print(f"  Total rows: {len(df)}")
-    print(f"  Columns: {len(df.columns)}")
+    if chunk_size:
+        # Chunked mode: read back and validate
+        part_files = sorted(chunked_output_dir.glob("part_*.parquet"))
+        total_rows = sum(len(pd.read_parquet(p)) for p in part_files)
+        print(f"  Total rows: {total_rows} across {len(part_files)} part files")
 
-    # Validate
-    if not args.skip_validation:
-        print("  Running Gate X1 validation...")
-        validate_gate_x1(df, n_deals, include_moon_loner=include_ml)
+        if not args.skip_validation:
+            print("  Running Gate X1 validation on concatenated chunks...")
+            df = pd.concat([pd.read_parquet(p) for p in part_files], ignore_index=True)
+            validate_gate_x1(df, n_deals, include_moon_loner=include_ml)
 
-    # Write output
-    output_dir = Path(args.output_dir)
-    datasets_dir = output_dir / "datasets"
-    datasets_dir.mkdir(parents=True, exist_ok=True)
+        print(f"\n  Output: {chunked_output_dir}/")
+        print(f"  Parts: {len(part_files)}")
+        print(f"  Rows: {total_rows}")
+        print(f"  Deals: {n_deals}")
+        print("  Done.")
+    else:
+        df = result
+        print(f"  Total rows: {len(df)}")
+        print(f"  Columns: {len(df.columns)}")
 
-    output_path = datasets_dir / "action_value.parquet"
-    df.to_parquet(output_path, index=False)
+        # Validate
+        if not args.skip_validation:
+            print("  Running Gate X1 validation...")
+            validate_gate_x1(df, n_deals, include_moon_loner=include_ml)
 
-    print(f"\n  Output: {output_path}")
-    print(f"  Rows: {len(df)}")
-    print(f"  Deals: {n_deals}")
-    print("  Done.")
+        # Write output
+        datasets_dir.mkdir(parents=True, exist_ok=True)
+        output_path = datasets_dir / "action_value.parquet"
+        df.to_parquet(output_path, index=False)
+
+        print(f"\n  Output: {output_path}")
+        print(f"  Rows: {len(df)}")
+        print(f"  Deals: {n_deals}")
+        print("  Done.")
 
 
 if __name__ == "__main__":

--- a/scripts/internal/train_action_value.py
+++ b/scripts/internal/train_action_value.py
@@ -208,7 +208,8 @@ def load_dataset(
     """Load and validate the action-value parquet dataset.
 
     Args:
-        parquet_path: Path to the parquet file.
+        parquet_path: Path to a parquet file OR a directory containing
+            ``part_*.parquet`` files (chunked output from the generator).
         target_col: Target column name (must exist in dataset).
         state_feature_names: State feature names to validate. Defaults to
             full STATE_FEATURE_NAMES.
@@ -216,7 +217,15 @@ def load_dataset(
     if state_feature_names is None:
         state_feature_names = STATE_FEATURE_NAMES
 
-    df = pd.read_parquet(parquet_path)
+    path = Path(parquet_path)
+    if path.is_dir():
+        # Directory-based loading: glob part files, sort, concatenate
+        part_files = sorted(path.glob("part_*.parquet"))
+        if not part_files:
+            raise ValueError(f"No part_*.parquet files found in {path}")
+        df = pd.concat([pd.read_parquet(p) for p in part_files], ignore_index=True)
+    else:
+        df = pd.read_parquet(parquet_path)
 
     # Validate required columns (exclude computed features — they're derived
     # at matrix-build time, not stored in the parquet)
@@ -856,11 +865,30 @@ def _compute_provenance_hashes(
     Returns (dataset_sha256, continuation_content_hash).
     The continuation hash uses content_hash() (excluding freeze fields) so
     the hash remains stable regardless of whether the artifact is frozen.
+
+    If dataset_path is a directory (chunked output), hashes the manifest.jsonl
+    file instead of hashing individual parquet files.
     """
     from bid_euchre.models.freeze import content_hash as compute_content_hash
     from bid_euchre.models.freeze import sha256_file
 
-    dataset_sha = sha256_file(dataset_path)
+    ds_path = Path(dataset_path)
+    if ds_path.is_dir():
+        manifest = ds_path / "manifest.jsonl"
+        if manifest.exists():
+            dataset_sha = sha256_file(str(manifest))
+        else:
+            # Fallback: hash all part files concatenated
+            import hashlib
+
+            h = hashlib.sha256()
+            for part in sorted(ds_path.glob("part_*.parquet")):
+                with open(part, "rb") as f:
+                    for chunk in iter(lambda: f.read(8192), b""):
+                        h.update(chunk)
+            dataset_sha = h.hexdigest()
+    else:
+        dataset_sha = sha256_file(dataset_path)
 
     cont_sha = None
     cont_path = Path(continuation_artifact_path)
@@ -976,7 +1004,7 @@ def main():
     parser.add_argument(
         "--dataset",
         required=True,
-        help="Path to action_value.parquet",
+        help="Path to action_value.parquet or directory with part_*.parquet files",
     )
     parser.add_argument(
         "--output-dir",

--- a/src/bid_euchre/arc_d_v2/orchestration.py
+++ b/src/bid_euchre/arc_d_v2/orchestration.py
@@ -49,7 +49,7 @@ MODE_SEEDS: dict[str, list[int]] = {
 MODE_DEALS: dict[str, int] = {
     "smoke": 500,
     "quick": 2500,
-    "full": 50000,
+    "full": 20000,
 }
 
 # Step descriptions for logging
@@ -720,6 +720,10 @@ def execute_step_1(state: RunState, seed: int, dry_run: bool = False) -> bool:
     if rung in ("r3", "r4"):
         cmd.append("--include-moon-loner")
 
+    # Full mode: use chunked generation to reduce peak memory
+    if state.mode == "full":
+        cmd.extend(["--chunk-size", "5000"])
+
     if dry_run:
         logger.info("Step 1: would run: %s", " ".join(cmd))
         state.mark_step_complete("1", seed)
@@ -758,7 +762,10 @@ def execute_step_2(state: RunState, seed: int, dry_run: bool = False) -> bool:
         return True
 
     dataset_dir = _repo_root() / "data" / "runs" / f"av_{rung}_{state.mode}_{seed}"
-    dataset_path = dataset_dir / "datasets" / "action_value.parquet"
+    # Prefer chunked directory if it exists; fall back to single file
+    chunked_dir = dataset_dir / "datasets" / "action_value"
+    single_file = dataset_dir / "datasets" / "action_value.parquet"
+    dataset_path = chunked_dir if chunked_dir.is_dir() else single_file
 
     # Locate continuation artifact (same logic as step 1)
     continuation = (

--- a/tests/unit/test_action_value_dataset.py
+++ b/tests/unit/test_action_value_dataset.py
@@ -1,5 +1,6 @@
 """Unit tests for the R1.5 counterfactual action-value dataset generator."""
 
+import json
 import sys
 from pathlib import Path
 
@@ -13,6 +14,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "intern
 from generate_action_value_dataset import (
     _bidding_order,
     _deterministic_dealer,
+    _load_completed_chunks,
     _play_tricks,
     _play_tricks_loner,
     generate_dataset,
@@ -954,3 +956,210 @@ class TestMoonLonerDataset:
         loner_families = set(loner_df["contract_family"].unique())
         assert {"suit", "high", "low"} == moon_families
         assert {"suit", "high", "low"} == loner_families
+
+
+# ── Chunked Dataset Generation ───────────────────────────
+
+
+class TestChunkedGeneration:
+    """Tests for chunked parquet output mode."""
+
+    @pytest.fixture
+    def chunked_dir(self, tmp_path, raiser):
+        """Generate a 20-deal dataset in 5-deal chunks."""
+        output_dir = tmp_path / "action_value"
+        generate_dataset(
+            seed=42,
+            n_deals=20,
+            continuation_policy=raiser,
+            progress=False,
+            chunk_size=5,
+            output_dir=output_dir,
+        )
+        return output_dir
+
+    @pytest.fixture
+    def single_df(self, raiser):
+        """Generate the same dataset as a single DataFrame."""
+        return generate_dataset(
+            seed=42,
+            n_deals=20,
+            continuation_policy=raiser,
+            progress=False,
+        )
+
+    def test_part_files_exist(self, chunked_dir):
+        """Chunked output creates the expected part files."""
+        parts = sorted(chunked_dir.glob("part_*.parquet"))
+        assert len(parts) == 4
+        expected_names = [
+            "part_000000_000004.parquet",
+            "part_000005_000009.parquet",
+            "part_000010_000014.parquet",
+            "part_000015_000019.parquet",
+        ]
+        actual_names = [p.name for p in parts]
+        assert actual_names == expected_names
+
+    def test_manifest_exists(self, chunked_dir):
+        """Manifest file is written with correct entries."""
+        manifest_path = chunked_dir / "manifest.jsonl"
+        assert manifest_path.exists()
+        entries = []
+        with open(manifest_path) as f:
+            for line in f:
+                entries.append(json.loads(line.strip()))
+        assert len(entries) == 4
+        for entry in entries:
+            assert entry["status"] == "complete"
+            assert entry["seed"] == 42
+            assert entry["n_deals"] == 5
+            assert entry["rows"] > 0
+
+    def test_manifest_deal_ranges(self, chunked_dir):
+        """Manifest entries cover all deal ranges without gaps."""
+        manifest_path = chunked_dir / "manifest.jsonl"
+        entries = []
+        with open(manifest_path) as f:
+            for line in f:
+                entries.append(json.loads(line.strip()))
+        ranges = [(e["deal_start"], e["deal_end"]) for e in entries]
+        assert ranges == [(0, 4), (5, 9), (10, 14), (15, 19)]
+
+    def test_concatenated_equals_single(self, chunked_dir, single_df):
+        """Concatenated chunks must equal single-file output."""
+        parts = sorted(chunked_dir.glob("part_*.parquet"))
+        chunked_df = pd.concat([pd.read_parquet(p) for p in parts], ignore_index=True)
+        single_reset = single_df.reset_index(drop=True)
+        # Compare column by column for better diagnostics
+        assert set(chunked_df.columns) == set(single_reset.columns)
+        assert len(chunked_df) == len(single_reset)
+        pd.testing.assert_frame_equal(chunked_df[single_reset.columns], single_reset)
+
+    def test_hand_id_globally_unique(self, chunked_dir):
+        """hand_id must be globally unique across all chunks."""
+        parts = sorted(chunked_dir.glob("part_*.parquet"))
+        all_hand_ids = []
+        for p in parts:
+            df = pd.read_parquet(p, columns=["hand_id"])
+            all_hand_ids.extend(df["hand_id"].unique().tolist())
+        assert len(all_hand_ids) == len(set(all_hand_ids))
+
+    def test_hand_id_deterministic(self, chunked_dir):
+        """hand_id = deal_id * 4 + focal_seat."""
+        parts = sorted(chunked_dir.glob("part_*.parquet"))
+        for p in parts:
+            df = pd.read_parquet(p, columns=["hand_id", "deal_id", "focal_seat"])
+            expected = df["deal_id"] * 4 + df["focal_seat"]
+            np.testing.assert_array_equal(df["hand_id"].values, expected.values)
+
+    def test_gate_x1_passes_on_concatenated(self, chunked_dir):
+        """Gate X1 validation passes on concatenated chunks."""
+        parts = sorted(chunked_dir.glob("part_*.parquet"))
+        df = pd.concat([pd.read_parquet(p) for p in parts], ignore_index=True)
+        validate_gate_x1(df, n_deals=20)
+
+    def test_returns_none_in_chunked_mode(self, tmp_path, raiser):
+        """generate_dataset returns None when chunked."""
+        output_dir = tmp_path / "av_none_test"
+        result = generate_dataset(
+            seed=42,
+            n_deals=10,
+            continuation_policy=raiser,
+            progress=False,
+            chunk_size=5,
+            output_dir=output_dir,
+        )
+        assert result is None
+
+    def test_unchunked_returns_dataframe(self, raiser):
+        """generate_dataset returns DataFrame without chunk_size."""
+        result = generate_dataset(
+            seed=42,
+            n_deals=5,
+            continuation_policy=raiser,
+            progress=False,
+        )
+        assert isinstance(result, pd.DataFrame)
+
+
+class TestChunkedResumability:
+    """Tests for chunk resumption from manifest."""
+
+    def test_load_completed_chunks_empty(self, tmp_path):
+        """No manifest means no completed chunks."""
+        manifest = tmp_path / "manifest.jsonl"
+        assert _load_completed_chunks(manifest) == set()
+
+    def test_load_completed_chunks(self, tmp_path):
+        """Completed chunks are read from manifest."""
+        manifest = tmp_path / "manifest.jsonl"
+        entries = [
+            {"deal_start": 0, "deal_end": 4, "status": "complete"},
+            {"deal_start": 5, "deal_end": 9, "status": "complete"},
+        ]
+        with open(manifest, "w") as f:
+            for e in entries:
+                f.write(json.dumps(e) + "\n")
+        completed = _load_completed_chunks(manifest)
+        assert completed == {(0, 4), (5, 9)}
+
+    def test_resume_skips_completed(self, tmp_path, raiser):
+        """Resuming generation skips already-completed chunks."""
+        output_dir = tmp_path / "av_resume"
+
+        # First run: generate all 10 deals in 5-deal chunks
+        generate_dataset(
+            seed=42,
+            n_deals=10,
+            continuation_policy=raiser,
+            progress=False,
+            chunk_size=5,
+            output_dir=output_dir,
+        )
+
+        # Read manifest — should have 2 entries
+        manifest_path = output_dir / "manifest.jsonl"
+        with open(manifest_path) as f:
+            entries_before = f.readlines()
+        assert len(entries_before) == 2
+
+        # Run again — should skip both chunks (no new manifest entries)
+        generate_dataset(
+            seed=42,
+            n_deals=10,
+            continuation_policy=raiser,
+            progress=False,
+            chunk_size=5,
+            output_dir=output_dir,
+        )
+
+        with open(manifest_path) as f:
+            entries_after = f.readlines()
+        # Still 2 entries (no new writes)
+        assert len(entries_after) == 2
+
+
+class TestChunkedNonDivisible:
+    """Test chunked output when n_deals is not divisible by chunk_size."""
+
+    def test_partial_final_chunk(self, tmp_path, raiser):
+        """7 deals with chunk_size=5 produces 2 chunks (5 + 2)."""
+        output_dir = tmp_path / "av_partial"
+        generate_dataset(
+            seed=42,
+            n_deals=7,
+            continuation_policy=raiser,
+            progress=False,
+            chunk_size=5,
+            output_dir=output_dir,
+        )
+        parts = sorted(output_dir.glob("part_*.parquet"))
+        assert len(parts) == 2
+        # First chunk: deals 0-4, second chunk: deals 5-6
+        assert parts[0].name == "part_000000_000004.parquet"
+        assert parts[1].name == "part_000005_000006.parquet"
+
+        # Verify all 7 deals are covered
+        df = pd.concat([pd.read_parquet(p) for p in parts], ignore_index=True)
+        assert set(df["deal_id"].unique()) == set(range(7))

--- a/tests/unit/test_rung_orchestrator.py
+++ b/tests/unit/test_rung_orchestrator.py
@@ -2478,3 +2478,230 @@ class TestEvidenceManifestIncludesChartData:
         assert "outcome_summary.csv" in chart_data_names
         assert "contract_mix.csv" in chart_data_names
         assert len(manifest["chart_data"]) == 2
+
+
+# ============================================================================
+# Chunked Dataset Generation (Step 1) Tests
+# ============================================================================
+
+
+class TestStep1ChunkedMode:
+    """Test that Step 1 command includes --chunk-size for full mode."""
+
+    def test_step_1_full_mode_includes_chunk_size(self, tmp_path):
+        """Full mode Step 1 command includes --chunk-size 5000."""
+        state = RunState.create_fresh("r0", "full", [42, 123, 456])
+        state_path = tmp_path / "state.json"
+        state.save(state_path)
+
+        captured_cmd = []
+
+        def mock_run(cmd, *args, **kwargs):
+            captured_cmd.extend(cmd)
+            return True, ""
+
+        with (
+            patch.object(run_rung_mod, "run_subprocess", side_effect=mock_run),
+            patch.object(run_rung_mod, "_repo_root", return_value=tmp_path),
+            patch.object(run_rung_mod, "_state_path", return_value=state_path),
+        ):
+            # Create dummy continuation artifact
+            cont_dir = tmp_path / "data" / "artifacts" / "arc_d" / "r0"
+            cont_dir.mkdir(parents=True)
+            (cont_dir / "hybrid_r0_full.json").write_text("{}")
+
+            run_rung_mod.execute_step_1(state, seed=42)
+
+        assert "--chunk-size" in captured_cmd
+        chunk_idx = captured_cmd.index("--chunk-size")
+        assert captured_cmd[chunk_idx + 1] == "5000"
+
+    def test_step_1_smoke_mode_no_chunk_size(self, tmp_path):
+        """Smoke mode Step 1 command does NOT include --chunk-size."""
+        state = RunState.create_fresh("r0", "smoke", [42])
+        state_path = tmp_path / "state.json"
+        state.save(state_path)
+
+        captured_cmd = []
+
+        def mock_run(cmd, *args, **kwargs):
+            captured_cmd.extend(cmd)
+            return True, ""
+
+        with (
+            patch.object(run_rung_mod, "run_subprocess", side_effect=mock_run),
+            patch.object(run_rung_mod, "_repo_root", return_value=tmp_path),
+            patch.object(run_rung_mod, "_state_path", return_value=state_path),
+        ):
+            cont_dir = tmp_path / "data" / "artifacts" / "arc_d" / "r0"
+            cont_dir.mkdir(parents=True)
+            (cont_dir / "hybrid_r0_full.json").write_text("{}")
+
+            run_rung_mod.execute_step_1(state, seed=42)
+
+        assert "--chunk-size" not in captured_cmd
+
+    def test_step_1_quick_mode_no_chunk_size(self, tmp_path):
+        """Quick mode Step 1 command does NOT include --chunk-size."""
+        state = RunState.create_fresh("r0", "quick", [42])
+        state_path = tmp_path / "state.json"
+        state.save(state_path)
+
+        captured_cmd = []
+
+        def mock_run(cmd, *args, **kwargs):
+            captured_cmd.extend(cmd)
+            return True, ""
+
+        with (
+            patch.object(run_rung_mod, "run_subprocess", side_effect=mock_run),
+            patch.object(run_rung_mod, "_repo_root", return_value=tmp_path),
+            patch.object(run_rung_mod, "_state_path", return_value=state_path),
+        ):
+            cont_dir = tmp_path / "data" / "artifacts" / "arc_d" / "r0"
+            cont_dir.mkdir(parents=True)
+            (cont_dir / "hybrid_r0_full.json").write_text("{}")
+
+            run_rung_mod.execute_step_1(state, seed=42)
+
+        assert "--chunk-size" not in captured_cmd
+
+
+class TestStep2ChunkedDatasetPath:
+    """Test that Step 2 uses chunked directory when available."""
+
+    def test_step_2_prefers_chunked_dir(self, tmp_path):
+        """Step 2 uses chunked directory path when it exists."""
+        roster = Roster(
+            models=[
+                RosterModel(
+                    name="gbt_av",
+                    class_name="GBTActionValueBidder",
+                    trainable=True,
+                    model_class="gbt",
+                ),
+            ],
+            anchor=AnchorModel(name="", artifact="", class_name=""),
+        )
+
+        plan_dir = tmp_path / "plans" / "arc_d_v2" / "r0"
+        plan_dir.mkdir(parents=True)
+
+        # Create both chunked dir and single file
+        ds_dir = tmp_path / "data" / "runs" / "av_r0_full_42" / "datasets"
+        ds_dir.mkdir(parents=True)
+        (ds_dir / "action_value.parquet").write_bytes(b"fake")
+        chunked = ds_dir / "action_value"
+        chunked.mkdir()
+        (chunked / "part_000000_004999.parquet").write_bytes(b"fake")
+
+        # Continuation artifact
+        art_dir = tmp_path / "data" / "artifacts" / "arc_d" / "r0"
+        art_dir.mkdir(parents=True)
+        (art_dir / "hybrid_r0_full.json").write_text("{}")
+
+        state = RunState.create_fresh("r0", "full", [42, 123, 456])
+        state.mark_step_started("1", 42)
+        state.mark_step_complete("1", 42)
+
+        captured_cmds = []
+
+        with (
+            patch.object(run_rung_mod, "load_roster", return_value=roster),
+            patch.object(run_rung_mod, "_repo_root", return_value=tmp_path),
+            patch.object(run_rung_mod, "_plans_dir", return_value=plan_dir),
+            patch.object(
+                run_rung_mod,
+                "_state_path",
+                return_value=plan_dir / "state.json",
+            ),
+            patch.object(
+                run_rung_mod,
+                "run_subprocess",
+                side_effect=lambda cmd, *a, **kw: (
+                    captured_cmds.append(cmd),
+                    (True, ""),
+                )[-1],
+            ),
+        ):
+            ok = run_rung_mod.execute_step_2(state, 42)
+
+        assert ok is True
+        assert len(captured_cmds) == 1
+        # The --dataset argument should point to the chunked directory
+        cmd = captured_cmds[0]
+        ds_idx = cmd.index("--dataset")
+        ds_path = cmd[ds_idx + 1]
+        assert ds_path.endswith("action_value")
+
+    def test_step_2_falls_back_to_single_file(self, tmp_path):
+        """Step 2 falls back to single parquet when no chunked dir exists."""
+        roster = Roster(
+            models=[
+                RosterModel(
+                    name="gbt_av",
+                    class_name="GBTActionValueBidder",
+                    trainable=True,
+                    model_class="gbt",
+                ),
+            ],
+            anchor=AnchorModel(name="", artifact="", class_name=""),
+        )
+
+        plan_dir = tmp_path / "plans" / "arc_d_v2" / "r0"
+        plan_dir.mkdir(parents=True)
+
+        # Only single file (no chunked dir)
+        ds_dir = tmp_path / "data" / "runs" / "av_r0_full_42" / "datasets"
+        ds_dir.mkdir(parents=True)
+        (ds_dir / "action_value.parquet").write_bytes(b"fake")
+
+        art_dir = tmp_path / "data" / "artifacts" / "arc_d" / "r0"
+        art_dir.mkdir(parents=True)
+        (art_dir / "hybrid_r0_full.json").write_text("{}")
+
+        state = RunState.create_fresh("r0", "full", [42, 123, 456])
+        state.mark_step_started("1", 42)
+        state.mark_step_complete("1", 42)
+
+        captured_cmds = []
+
+        with (
+            patch.object(run_rung_mod, "load_roster", return_value=roster),
+            patch.object(run_rung_mod, "_repo_root", return_value=tmp_path),
+            patch.object(run_rung_mod, "_plans_dir", return_value=plan_dir),
+            patch.object(
+                run_rung_mod,
+                "_state_path",
+                return_value=plan_dir / "state.json",
+            ),
+            patch.object(
+                run_rung_mod,
+                "run_subprocess",
+                side_effect=lambda cmd, *a, **kw: (
+                    captured_cmds.append(cmd),
+                    (True, ""),
+                )[-1],
+            ),
+        ):
+            ok = run_rung_mod.execute_step_2(state, 42)
+
+        assert ok is True
+        assert len(captured_cmds) == 1
+        cmd = captured_cmds[0]
+        ds_idx = cmd.index("--dataset")
+        ds_path = cmd[ds_idx + 1]
+        assert ds_path.endswith("action_value.parquet")
+
+
+class TestModeDealsFull:
+    """Test that MODE_DEALS['full'] is reduced to 20000."""
+
+    def test_full_mode_deals(self):
+        assert run_rung_mod.MODE_DEALS["full"] == 20000
+
+    def test_smoke_mode_deals_unchanged(self):
+        assert run_rung_mod.MODE_DEALS["smoke"] == 500
+
+    def test_quick_mode_deals_unchanged(self):
+        assert run_rung_mod.MODE_DEALS["quick"] == 2500

--- a/tests/unit/test_train_action_value.py
+++ b/tests/unit/test_train_action_value.py
@@ -130,6 +130,29 @@ class TestLoadDataset:
         with pytest.raises(ValueError, match="missing columns"):
             load_dataset(str(path))
 
+    def test_loads_directory(self, smoke_parquet_path, tmp_path):
+        """load_dataset accepts a directory with part_*.parquet files."""
+        # Split the SMOKE parquet into 2 part files
+        df = pd.read_parquet(smoke_parquet_path)
+        mid = len(df) // 2
+        part_dir = tmp_path / "action_value"
+        part_dir.mkdir()
+        df.iloc[:mid].to_parquet(part_dir / "part_000000_000249.parquet", index=False)
+        df.iloc[mid:].to_parquet(part_dir / "part_000250_000499.parquet", index=False)
+
+        loaded = load_dataset(str(part_dir))
+        assert len(loaded) == len(df)
+        # Check all required columns present
+        for col in STATE_FEATURE_NAMES:
+            assert col in loaded.columns
+
+    def test_directory_no_parts_raises(self, tmp_path):
+        """An empty directory should raise ValueError."""
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        with pytest.raises(ValueError, match="No part_"):
+            load_dataset(str(empty_dir))
+
 
 # ── Splitting ─────────────────────────────────────────────────
 


### PR DESCRIPTION
## Plan
`plans/sessions/2026-03-16_chunked-dataset-generation.md`

## Summary
- Add `--chunk-size` to `generate_action_value_dataset.py` for chunked parquet output with manifest.jsonl tracking and resumability
- Extend `train_action_value.py` `load_dataset()` to accept directories of `part_*.parquet` files
- Reduce `MODE_DEALS["full"]` from 50k to 20k and add `--chunk-size 5000` for full mode in orchestration

## Why
On 16GB M3 Mac, FULL 50k-deal runs cause swap thrashing (18GB swap, 13% CPU) because the generator accumulates ~3.2 GB of row dicts in memory, then creates a second ~2 GB copy during DataFrame conversion. Chunked output flushes to disk every N deals, keeping peak memory under 1 GB per chunk.

## Repro / Validation
**Command(s) run:**
```bash
# Tier 1 tests (all pass)
PYTHONPATH=src uv run pytest tests/unit/test_action_value_dataset.py -q  # 86 passed
PYTHONPATH=src uv run pytest tests/unit/test_train_action_value.py -q    # 52 passed, 33 skipped
PYTHONPATH=src uv run pytest tests/unit/test_rung_orchestrator.py -q     # 137 passed, 1 skipped

# Tier 2 (full validation)
make check-quiet  # All checks passed
```

**Seed (if applicable):** 42 (in tests)

## Tests
- [x] `make check-quiet` (full suite)
- [x] Unit tests for chunked generation (equivalence, manifest, hand_id, resumability, partial chunks)
- [x] Unit tests for directory-based loading
- [x] Unit tests for Step 1 `--chunk-size` command construction (full, smoke, quick modes)
- [x] Unit tests for Step 2 chunked directory preference and single-file fallback
- [x] Unit tests for MODE_DEALS["full"] == 20000

## Expected impact
- Metrics impact: None (chunked output is byte-for-byte equivalent to single-file output when concatenated)
- Runtime impact: FULL runs use 20k deals instead of 50k (reduces training data ~2.5x but still yields ~3.2M training rows). Chunked I/O adds negligible overhead.

## Risk level
- [x] Medium (strategy/experiments)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-chunked-gen
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-chunked-gen
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                  33ee241 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-chunked-gen      7633f51 [feat/chunked-dataset-gen]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)