### PR TITLE
feat: diagnostic chart generators + pipeline wiring for reporting dashboards

### DIFF
--- a/scripts/internal/generate_rung_charts.py
+++ b/scripts/internal/generate_rung_charts.py
@@ -480,6 +480,232 @@ def generate_outcome_summary(
     return True
 
 
+def generate_predictions_scatter(
+    chart_data_dir: Path,
+    output_dir: Path,
+    dpi: int = 150,
+) -> bool:
+    """Scatter plot of predicted vs actual values, faceted by contract.
+
+    Reads chart_data/predictions.csv (columns: model, contract, prediction, actual).
+    Produces charts/pred_vs_actual.png with 45-degree reference line.
+    """
+    df = _read_csv_safe(chart_data_dir / "predictions.csv")
+    if df is None:
+        return False
+
+    required = {"model", "contract", "prediction", "actual"}
+    if not required.issubset(df.columns):
+        logger.warning(
+            "predictions.csv missing required columns: %s", required - set(df.columns)
+        )
+        return False
+
+    contracts = sorted(df["contract"].unique())
+    n_contracts = max(len(contracts), 1)
+    fig, axes = plt.subplots(
+        1, n_contracts, figsize=(5 * n_contracts, 5), squeeze=False
+    )
+
+    for idx, contract in enumerate(contracts):
+        ax = axes[0, idx]
+        cdf = df[df["contract"] == contract]
+        models = sorted(cdf["model"].unique())
+        model_colors = _get_model_colors(models)
+
+        for model in models:
+            mdf = cdf[cdf["model"] == model]
+            ax.scatter(
+                mdf["actual"],
+                mdf["prediction"],
+                alpha=0.3,
+                s=8,
+                label=model,
+                color=model_colors[model],
+            )
+
+        # 45-degree reference line
+        all_vals = pd.concat([cdf["actual"], cdf["prediction"]])
+        vmin, vmax = all_vals.min(), all_vals.max()
+        ax.plot([vmin, vmax], [vmin, vmax], "k--", linewidth=0.8, alpha=0.5)
+        ax.set_xlabel("Actual", fontsize=9)
+        ax.set_ylabel("Predicted", fontsize=9)
+        ax.set_title(f"{contract.title()}", fontsize=11)
+        ax.legend(fontsize=7, loc="best")
+        ax.set_aspect("equal", adjustable="box")
+
+    fig.suptitle("Predicted vs Actual", fontsize=14, fontweight="bold")
+    fig.tight_layout(rect=[0, 0, 1, 0.95])
+    _save_chart(fig, output_dir, "pred_vs_actual.png", dpi)
+    return True
+
+
+def generate_residuals_chart(
+    chart_data_dir: Path,
+    output_dir: Path,
+    dpi: int = 150,
+) -> bool:
+    """Histogram of residuals by contract type.
+
+    Reads chart_data/residuals.csv (columns: model, contract, residual_bin, count).
+    Produces charts/residual_distribution.png.
+    """
+    df = _read_csv_safe(chart_data_dir / "residuals.csv")
+    if df is None:
+        return False
+
+    required = {"model", "contract", "residual_bin", "count"}
+    if not required.issubset(df.columns):
+        logger.warning(
+            "residuals.csv missing required columns: %s", required - set(df.columns)
+        )
+        return False
+
+    contracts = sorted(df["contract"].unique())
+    n_contracts = max(len(contracts), 1)
+    fig, axes = plt.subplots(
+        1, n_contracts, figsize=(5 * n_contracts, 4), squeeze=False
+    )
+
+    for idx, contract in enumerate(contracts):
+        ax = axes[0, idx]
+        cdf = df[df["contract"] == contract]
+        models = sorted(cdf["model"].unique())
+        model_colors = _get_model_colors(models)
+
+        for model in models:
+            mdf = cdf[cdf["model"] == model].sort_values("residual_bin")
+            ax.bar(
+                mdf["residual_bin"],
+                mdf["count"],
+                width=(mdf["residual_bin"].diff().median() or 0.1) * 0.8,
+                alpha=0.6,
+                label=model,
+                color=model_colors[model],
+            )
+
+        ax.set_xlabel("Residual (Pred - Actual)", fontsize=9)
+        ax.set_ylabel("Count", fontsize=9)
+        ax.set_title(f"{contract.title()}", fontsize=11)
+        ax.axvline(x=0, color="gray", linestyle="--", linewidth=0.5)
+        ax.legend(fontsize=7, loc="best")
+
+    fig.suptitle("Residual Distribution", fontsize=14, fontweight="bold")
+    fig.tight_layout(rect=[0, 0, 1, 0.95])
+    _save_chart(fig, output_dir, "residual_distribution.png", dpi)
+    return True
+
+
+def generate_calibration_curve(
+    chart_data_dir: Path,
+    output_dir: Path,
+    dpi: int = 150,
+) -> bool:
+    """Calibration curve (predicted vs actual mean) with 45-degree reference line.
+
+    Reads chart_data/calibration_bins.csv
+    (columns: model, contract, pred_bin, mean_pred, actual_mean, n_samples).
+    Produces charts/calibration_curve.png.
+    """
+    df = _read_csv_safe(chart_data_dir / "calibration_bins.csv")
+    if df is None:
+        return False
+
+    required = {"model", "contract", "mean_pred", "actual_mean"}
+    if not required.issubset(df.columns):
+        logger.warning(
+            "calibration_bins.csv missing required columns: %s",
+            required - set(df.columns),
+        )
+        return False
+
+    contracts = sorted(df["contract"].unique())
+    n_contracts = max(len(contracts), 1)
+    fig, axes = plt.subplots(
+        1, n_contracts, figsize=(5 * n_contracts, 5), squeeze=False
+    )
+
+    for idx, contract in enumerate(contracts):
+        ax = axes[0, idx]
+        cdf = df[df["contract"] == contract]
+        models = sorted(cdf["model"].unique())
+        model_colors = _get_model_colors(models)
+
+        for model in models:
+            mdf = cdf[cdf["model"] == model].sort_values("mean_pred")
+            ax.plot(
+                mdf["mean_pred"],
+                mdf["actual_mean"],
+                marker="o",
+                markersize=4,
+                label=model,
+                color=model_colors[model],
+            )
+
+        # 45-degree reference line
+        all_vals = pd.concat([cdf["mean_pred"], cdf["actual_mean"]])
+        vmin, vmax = all_vals.min(), all_vals.max()
+        ax.plot([vmin, vmax], [vmin, vmax], "k--", linewidth=0.8, alpha=0.5)
+        ax.set_xlabel("Mean Predicted", fontsize=9)
+        ax.set_ylabel("Mean Actual", fontsize=9)
+        ax.set_title(f"{contract.title()}", fontsize=11)
+        ax.legend(fontsize=7, loc="best")
+
+    fig.suptitle("Calibration Curve", fontsize=14, fontweight="bold")
+    fig.tight_layout(rect=[0, 0, 1, 0.95])
+    _save_chart(fig, output_dir, "calibration_curve.png", dpi)
+    return True
+
+
+def generate_feature_importance_chart(
+    chart_data_dir: Path,
+    output_dir: Path,
+    dpi: int = 150,
+) -> bool:
+    """Horizontal bar chart of top 15 features by importance.
+
+    Reads chart_data/selection_paths.csv
+    (columns: model, contract, rank, feature_name, importance).
+    Produces charts/feature_importance.png.
+    """
+    df = _read_csv_safe(chart_data_dir / "selection_paths.csv")
+    if df is None:
+        return False
+
+    required = {"model", "contract", "rank", "feature_name", "importance"}
+    if not required.issubset(df.columns):
+        logger.warning(
+            "selection_paths.csv missing required columns: %s",
+            required - set(df.columns),
+        )
+        return False
+
+    # Aggregate across contracts: mean importance per feature per model
+    models = sorted(df["model"].unique())
+    n_models = max(len(models), 1)
+    fig, axes = plt.subplots(1, n_models, figsize=(6 * n_models, 6), squeeze=False)
+
+    for idx, model in enumerate(models):
+        ax = axes[0, idx]
+        mdf = df[df["model"] == model]
+
+        # Aggregate: mean importance per feature across contracts
+        agg = (
+            mdf.groupby("feature_name")["importance"].mean().sort_values(ascending=True)
+        )
+        top = agg.tail(15)
+
+        ax.barh(top.index, top.values, color="#4C72B0")
+        ax.set_xlabel("Mean Importance", fontsize=9)
+        ax.set_title(f"{model} — Top Features", fontsize=11)
+        ax.tick_params(axis="y", labelsize=7)
+
+    fig.suptitle("Feature Importance", fontsize=14, fontweight="bold")
+    fig.tight_layout(rect=[0, 0, 1, 0.95])
+    _save_chart(fig, output_dir, "feature_importance.png", dpi)
+    return True
+
+
 def generate_seat_balance(
     chart_data_dir: Path,
     output_dir: Path,
@@ -1096,6 +1322,24 @@ def generate_all_charts(
             (
                 "seat_balance.png",
                 lambda: generate_seat_balance(chart_data_dir, output_dir, dpi),
+            ),
+            (
+                "pred_vs_actual.png",
+                lambda: generate_predictions_scatter(chart_data_dir, output_dir, dpi),
+            ),
+            (
+                "residual_distribution.png",
+                lambda: generate_residuals_chart(chart_data_dir, output_dir, dpi),
+            ),
+            (
+                "calibration_curve.png",
+                lambda: generate_calibration_curve(chart_data_dir, output_dir, dpi),
+            ),
+            (
+                "feature_importance.png",
+                lambda: generate_feature_importance_chart(
+                    chart_data_dir, output_dir, dpi
+                ),
             ),
         ]
         for chart_name, gen_fn in chart_data_generators:

--- a/src/bid_euchre/arc_d_v2/report.py
+++ b/src/bid_euchre/arc_d_v2/report.py
@@ -156,6 +156,7 @@ def generate_report(report_dir: Path) -> str:
         "pred_vs_actual.png",
         "residual_distribution.png",
         "calibration_curve.png",
+        "feature_importance.png",
     ]:
         lines.append(_chart_embed(charts_dir, chart_name))
     lines.append("")

--- a/src/bid_euchre/arc_d_v2/tables.py
+++ b/src/bid_euchre/arc_d_v2/tables.py
@@ -2051,4 +2051,28 @@ def generate_all_tables(
     for csv_name in chart_data_csvs:
         generated.append(f"chart_data/{csv_name}")
 
+    # 15. seat_balance.csv from parquet data (graceful skip if absent)
+    for s in seed_list:
+        parquet_candidate = rung_dir / f"seed_{s}" / "datasets" / "action_value.parquet"
+        if parquet_candidate.exists():
+            sb_result = generate_seat_balance_csv(parquet_candidate, chart_data_dir)
+            if sb_result and f"chart_data/{sb_result}" not in generated:
+                generated.append(f"chart_data/{sb_result}")
+            break  # Use first available seed's parquet
+
+    # 16. model eval CSVs (predictions, residuals, calibration) from parquet + models
+    if training_artifacts:
+        eval_parquet: Path | None = None
+        for s in seed_list:
+            candidate = rung_dir / f"seed_{s}" / "datasets" / "action_value.parquet"
+            if candidate.exists():
+                eval_parquet = candidate
+                break
+        if eval_parquet is not None:
+            eval_csvs = generate_model_eval_csvs(
+                training_artifacts, eval_parquet, chart_data_dir
+            )
+            for csv_name in eval_csvs:
+                generated.append(f"chart_data/{csv_name}")
+
     return generated

--- a/tests/unit/test_rung_charts.py
+++ b/tests/unit/test_rung_charts.py
@@ -1,0 +1,338 @@
+"""Tests for diagnostic chart generators in generate_rung_charts.py.
+
+Covers:
+- predictions scatter plot generation
+- residuals histogram generation
+- calibration curve generation
+- feature importance bar chart generation
+- Graceful degradation when CSV data is missing
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts" / "internal"
+
+
+def _import_chart_module():
+    """Import the chart generator script as a module."""
+    spec = importlib.util.spec_from_file_location(
+        "generate_rung_charts",
+        SCRIPTS_DIR / "generate_rung_charts.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def charts_mod():
+    """Module-level import of the chart generator."""
+    return _import_chart_module()
+
+
+# ──────────────────────────────────────────────
+#  Fixture data helpers
+# ──────────────────────────────────────────────
+
+
+@pytest.fixture
+def predictions_csv(tmp_path):
+    """Create a predictions.csv fixture file."""
+    df = pd.DataFrame(
+        {
+            "model": ["gbt"] * 6 + ["ols"] * 6,
+            "contract": ["suit", "suit", "high", "high", "low", "low"] * 2,
+            "prediction": [5.1, 4.8, 3.2, 3.5, 6.0, 5.8, 4.9, 5.0, 3.1, 3.3, 5.9, 5.7],
+            "actual": [5.0, 5.0, 3.0, 3.0, 6.0, 6.0, 5.0, 5.0, 3.0, 3.0, 6.0, 6.0],
+        }
+    )
+    chart_data_dir = tmp_path / "chart_data"
+    chart_data_dir.mkdir()
+    df.to_csv(chart_data_dir / "predictions.csv", index=False)
+    return chart_data_dir
+
+
+@pytest.fixture
+def residuals_csv(tmp_path):
+    """Create a residuals.csv fixture file."""
+    df = pd.DataFrame(
+        {
+            "model": ["gbt"] * 4 + ["ols"] * 4,
+            "contract": ["suit", "suit", "high", "high"] * 2,
+            "residual_bin": [-0.5, 0.0, 0.5, 1.0, -0.5, 0.0, 0.5, 1.0],
+            "count": [5, 20, 15, 3, 8, 18, 12, 5],
+        }
+    )
+    chart_data_dir = tmp_path / "chart_data"
+    chart_data_dir.mkdir()
+    df.to_csv(chart_data_dir / "residuals.csv", index=False)
+    return chart_data_dir
+
+
+@pytest.fixture
+def calibration_csv(tmp_path):
+    """Create a calibration_bins.csv fixture file."""
+    df = pd.DataFrame(
+        {
+            "model": ["gbt"] * 4,
+            "contract": ["suit"] * 4,
+            "pred_bin": [1, 2, 3, 4],
+            "mean_pred": [3.0, 4.0, 5.0, 6.0],
+            "actual_mean": [3.1, 4.2, 4.9, 5.8],
+            "n_samples": [25, 25, 25, 25],
+        }
+    )
+    chart_data_dir = tmp_path / "chart_data"
+    chart_data_dir.mkdir()
+    df.to_csv(chart_data_dir / "calibration_bins.csv", index=False)
+    return chart_data_dir
+
+
+@pytest.fixture
+def selection_paths_csv(tmp_path):
+    """Create a selection_paths.csv fixture file."""
+    df = pd.DataFrame(
+        {
+            "model": ["gbt"] * 5,
+            "contract": ["suit"] * 5,
+            "rank": [1, 2, 3, 4, 5],
+            "feature_name": [
+                "trump_count",
+                "hand_strength",
+                "seat",
+                "bid_level",
+                "void_count",
+            ],
+            "importance": [0.35, 0.25, 0.18, 0.12, 0.10],
+        }
+    )
+    chart_data_dir = tmp_path / "chart_data"
+    chart_data_dir.mkdir()
+    df.to_csv(chart_data_dir / "selection_paths.csv", index=False)
+    return chart_data_dir
+
+
+# ──────────────────────────────────────────────
+#  Predictions scatter tests
+# ──────────────────────────────────────────────
+
+
+class TestPredictionsScatter:
+    """Tests for generate_predictions_scatter."""
+
+    def test_produces_png(self, charts_mod, predictions_csv, tmp_path):
+        """Produces pred_vs_actual.png from valid predictions CSV."""
+        output_dir = tmp_path / "charts"
+        output_dir.mkdir()
+        result = charts_mod.generate_predictions_scatter(predictions_csv, output_dir)
+        assert result is True
+        png_path = output_dir / "pred_vs_actual.png"
+        assert png_path.exists()
+        assert png_path.stat().st_size > 0
+
+    def test_missing_csv_returns_false(self, charts_mod, tmp_path):
+        """Returns False when predictions.csv is missing."""
+        chart_data_dir = tmp_path / "chart_data"
+        chart_data_dir.mkdir()
+        output_dir = tmp_path / "charts"
+        output_dir.mkdir()
+        result = charts_mod.generate_predictions_scatter(chart_data_dir, output_dir)
+        assert result is False
+
+    def test_missing_columns_returns_false(self, charts_mod, tmp_path):
+        """Returns False when CSV lacks required columns."""
+        chart_data_dir = tmp_path / "chart_data"
+        chart_data_dir.mkdir()
+        df = pd.DataFrame({"model": ["gbt"], "wrong_col": [1.0]})
+        df.to_csv(chart_data_dir / "predictions.csv", index=False)
+        output_dir = tmp_path / "charts"
+        output_dir.mkdir()
+        result = charts_mod.generate_predictions_scatter(chart_data_dir, output_dir)
+        assert result is False
+
+
+# ──────────────────────────────────────────────
+#  Residuals chart tests
+# ──────────────────────────────────────────────
+
+
+class TestResidualsChart:
+    """Tests for generate_residuals_chart."""
+
+    def test_produces_png(self, charts_mod, residuals_csv, tmp_path):
+        """Produces residual_distribution.png from valid residuals CSV."""
+        output_dir = tmp_path / "charts"
+        output_dir.mkdir()
+        result = charts_mod.generate_residuals_chart(residuals_csv, output_dir)
+        assert result is True
+        png_path = output_dir / "residual_distribution.png"
+        assert png_path.exists()
+        assert png_path.stat().st_size > 0
+
+    def test_missing_csv_returns_false(self, charts_mod, tmp_path):
+        """Returns False when residuals.csv is missing."""
+        chart_data_dir = tmp_path / "chart_data"
+        chart_data_dir.mkdir()
+        output_dir = tmp_path / "charts"
+        output_dir.mkdir()
+        result = charts_mod.generate_residuals_chart(chart_data_dir, output_dir)
+        assert result is False
+
+
+# ──────────────────────────────────────────────
+#  Calibration curve tests
+# ──────────────────────────────────────────────
+
+
+class TestCalibrationCurve:
+    """Tests for generate_calibration_curve."""
+
+    def test_produces_png(self, charts_mod, calibration_csv, tmp_path):
+        """Produces calibration_curve.png from valid calibration CSV."""
+        output_dir = tmp_path / "charts"
+        output_dir.mkdir()
+        result = charts_mod.generate_calibration_curve(calibration_csv, output_dir)
+        assert result is True
+        png_path = output_dir / "calibration_curve.png"
+        assert png_path.exists()
+        assert png_path.stat().st_size > 0
+
+    def test_missing_csv_returns_false(self, charts_mod, tmp_path):
+        """Returns False when calibration_bins.csv is missing."""
+        chart_data_dir = tmp_path / "chart_data"
+        chart_data_dir.mkdir()
+        output_dir = tmp_path / "charts"
+        output_dir.mkdir()
+        result = charts_mod.generate_calibration_curve(chart_data_dir, output_dir)
+        assert result is False
+
+
+# ──────────────────────────────────────────────
+#  Feature importance chart tests
+# ──────────────────────────────────────────────
+
+
+class TestFeatureImportanceChart:
+    """Tests for generate_feature_importance_chart."""
+
+    def test_produces_png(self, charts_mod, selection_paths_csv, tmp_path):
+        """Produces feature_importance.png from valid selection_paths CSV."""
+        output_dir = tmp_path / "charts"
+        output_dir.mkdir()
+        result = charts_mod.generate_feature_importance_chart(
+            selection_paths_csv, output_dir
+        )
+        assert result is True
+        png_path = output_dir / "feature_importance.png"
+        assert png_path.exists()
+        assert png_path.stat().st_size > 0
+
+    def test_missing_csv_returns_false(self, charts_mod, tmp_path):
+        """Returns False when selection_paths.csv is missing."""
+        chart_data_dir = tmp_path / "chart_data"
+        chart_data_dir.mkdir()
+        output_dir = tmp_path / "charts"
+        output_dir.mkdir()
+        result = charts_mod.generate_feature_importance_chart(
+            chart_data_dir, output_dir
+        )
+        assert result is False
+
+    def test_missing_columns_returns_false(self, charts_mod, tmp_path):
+        """Returns False when CSV lacks required columns."""
+        chart_data_dir = tmp_path / "chart_data"
+        chart_data_dir.mkdir()
+        df = pd.DataFrame({"model": ["gbt"], "bad_col": [1.0]})
+        df.to_csv(chart_data_dir / "selection_paths.csv", index=False)
+        output_dir = tmp_path / "charts"
+        output_dir.mkdir()
+        result = charts_mod.generate_feature_importance_chart(
+            chart_data_dir, output_dir
+        )
+        assert result is False
+
+
+# ──────────────────────────────────────────────
+#  Integration: generate_all_charts includes new generators
+# ──────────────────────────────────────────────
+
+
+class TestAllChartsIntegration:
+    """Tests that generate_all_charts wires the new diagnostic generators."""
+
+    def test_all_charts_with_chart_data(self, charts_mod, tmp_path):
+        """generate_all_charts produces diagnostic PNGs when chart_data CSVs exist."""
+        tables_dir = tmp_path / "tables"
+        tables_dir.mkdir()
+        charts_dir = tmp_path / "charts"
+        chart_data_dir = tmp_path / "chart_data"
+        chart_data_dir.mkdir()
+
+        # Write predictions.csv fixture
+        pd.DataFrame(
+            {
+                "model": ["gbt"] * 4,
+                "contract": ["suit", "suit", "high", "high"],
+                "prediction": [5.1, 4.8, 3.2, 3.5],
+                "actual": [5.0, 5.0, 3.0, 3.0],
+            }
+        ).to_csv(chart_data_dir / "predictions.csv", index=False)
+
+        # Write residuals.csv fixture
+        pd.DataFrame(
+            {
+                "model": ["gbt"] * 4,
+                "contract": ["suit", "suit", "high", "high"],
+                "residual_bin": [-0.5, 0.0, 0.5, 1.0],
+                "count": [5, 20, 15, 3],
+            }
+        ).to_csv(chart_data_dir / "residuals.csv", index=False)
+
+        # Write calibration_bins.csv fixture
+        pd.DataFrame(
+            {
+                "model": ["gbt"] * 3,
+                "contract": ["suit"] * 3,
+                "pred_bin": [1, 2, 3],
+                "mean_pred": [3.0, 4.0, 5.0],
+                "actual_mean": [3.1, 4.2, 4.9],
+                "n_samples": [25, 25, 25],
+            }
+        ).to_csv(chart_data_dir / "calibration_bins.csv", index=False)
+
+        # Write selection_paths.csv fixture
+        pd.DataFrame(
+            {
+                "model": ["gbt"] * 3,
+                "contract": ["suit"] * 3,
+                "rank": [1, 2, 3],
+                "feature_name": ["trump_count", "hand_strength", "seat"],
+                "importance": [0.35, 0.25, 0.18],
+            }
+        ).to_csv(chart_data_dir / "selection_paths.csv", index=False)
+
+        generated = charts_mod.generate_all_charts(
+            tables_dir=tables_dir,
+            output_dir=charts_dir,
+            chart_data_dir=chart_data_dir,
+        )
+
+        # All 4 new diagnostic charts should be in the generated list
+        expected_new = [
+            "pred_vs_actual.png",
+            "residual_distribution.png",
+            "calibration_curve.png",
+            "feature_importance.png",
+        ]
+        for chart in expected_new:
+            assert (
+                chart in generated
+            ), f"Expected {chart} in generated list, got: {generated}"
+            assert (charts_dir / chart).exists(), f"{chart} file not found"
+            assert (charts_dir / chart).stat().st_size > 0, f"{chart} is empty"


### PR DESCRIPTION
## Summary
- Add 4 diagnostic chart generators to `generate_rung_charts.py`: predictions scatter, residuals histogram, calibration curve, feature importance bars
- Wire `generate_seat_balance_csv()` and `generate_model_eval_csvs()` into tables pipeline (Step 6)
- Embed `feature_importance.png` in report Section 3 (Offline Diagnostics)
- Add 11 new unit tests for chart generators with graceful degradation

## Why
Completes Phases 2-3 of the reporting suite compaction plan. The chart_data extraction functions (PR #759) produce the CSVs; this PR adds the chart generators that consume them and wires everything into the pipeline so Step 7 produces the diagnostic charts and Step 6 calls the new extraction functions.

## New Charts
| Chart | Source CSV | Output PNG |
|-------|-----------|------------|
| Predictions scatter | `predictions.csv` | `pred_vs_actual.png` |
| Residual distribution | `residuals.csv` | `residual_distribution.png` |
| Calibration curve | `calibration_bins.csv` | `calibration_curve.png` |
| Feature importance | `selection_paths.csv` | `feature_importance.png` |

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_rung_charts.py -x -q  # 11 passed
uv run ruff check scripts/internal/generate_rung_charts.py src/bid_euchre/arc_d_v2/tables.py src/bid_euchre/arc_d_v2/report.py
```

## Tests
- `tests/unit/test_rung_charts.py` — 11 new tests (PNG generation, missing CSV handling, wrong columns)
- All 161 chart/reporting tests pass

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-aebb61f5
branch: worktree-agent-aebb61f5
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)