### PR TITLE
fix: remove app-bundle fallback and make Claude failsafe functional

### DIFF
--- a/scripts/internal/codex_plan_review_adapter.py
+++ b/scripts/internal/codex_plan_review_adapter.py
@@ -17,6 +17,7 @@ import os
 import pty
 import re
 import select
+import shutil
 import subprocess
 import time
 from dataclasses import asdict, dataclass
@@ -439,6 +440,41 @@ def invoke_codex_plan_review(
     )
 
 
+def _build_claude_review_prompt(plan_path: Path, tier: str) -> str:
+    """Build a structured prompt for Claude CLI plan review.
+
+    Args:
+        plan_path: Path to the plan file.
+        tier: Detected plan tier.
+
+    Returns:
+        Prompt string that instructs Claude to output JSON findings.
+    """
+    try:
+        content = plan_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        content = "(could not read plan file)"
+
+    return (
+        f"Review this {tier}-tier plan file ({plan_path}) for issues. "
+        "Output ONLY a JSON array of findings. Each finding must have these fields:\n"
+        '  "severity": "CRITICAL" | "WARNING" | "INFO"\n'
+        '  "category": "convention" | "risk" | "research" | "process"\n'
+        f'  "file": "{plan_path}"\n'
+        '  "line": <line number or 0>\n'
+        '  "description": "<what is wrong>"\n'
+        '  "check_id": null\n\n'
+        "Check for:\n"
+        "- Referenced file paths that don't exist in the repo\n"
+        "- Missing seed/config in experiment commands\n"
+        "- Contradictory or unclear steps\n"
+        "- Missing rollback/failure handling\n"
+        "- Scope too broad for a single PR\n\n"
+        "If no issues found, output: []\n\n"
+        f"Plan content:\n```\n{content}\n```"
+    )
+
+
 def invoke_claude_failsafe(
     plan_path: Path,
     tier: str,
@@ -447,9 +483,10 @@ def invoke_claude_failsafe(
 ) -> PlanReviewResult:
     """Invoke Claude failsafe reviewer when Codex CLI is unavailable.
 
-    Checks ``CLAUDE_REVIEW_CMD`` env var for a test seam. If set, runs
-    that command with plan_path and tier as arguments and parses JSON output.
-    If not set, returns a minimal result indicating no live session available.
+    Resolution order:
+    1. ``CLAUDE_REVIEW_CMD`` env var (test seam / custom command)
+    2. ``claude`` CLI in PATH (auto-detected, uses ``--print -p`` mode)
+    3. Returns failure if neither is available
 
     Args:
         plan_path: Path to the plan file.
@@ -457,12 +494,19 @@ def invoke_claude_failsafe(
         timeout: Maximum wait time in seconds.
 
     Returns:
-        PlanReviewResult with findings from Claude or a placeholder.
+        PlanReviewResult with findings from Claude or error info.
     """
     start = time.monotonic()
     claude_cmd = os.environ.get("CLAUDE_REVIEW_CMD", "").strip()
 
-    if not claude_cmd:
+    if claude_cmd:
+        # Explicit command via env var (test seam)
+        cmd = [*claude_cmd.split(), str(plan_path), tier]
+    elif shutil.which("claude"):
+        # Auto-detect claude CLI and use --print mode
+        prompt = _build_claude_review_prompt(plan_path, tier)
+        cmd = ["claude", "--print", "-p", prompt]
+    else:
         elapsed = time.monotonic() - start
         return PlanReviewResult(
             success=False,
@@ -471,18 +515,20 @@ def invoke_claude_failsafe(
             reviewer="claude_failsafe",
             raw_output="",
             latency_seconds=elapsed,
-            error="CLAUDE_REVIEW_CMD not set -- Claude failsafe requires a live session",
+            error=(
+                "No review command available: CLAUDE_REVIEW_CMD not set "
+                "and claude CLI not in PATH"
+            ),
         )
+
+    logger.info(
+        "Invoking Claude failsafe (cmd=%s, tier=%s, file=%s)",
+        cmd[0],
+        tier,
+        plan_path,
+    )
 
     try:
-        cmd = [*claude_cmd.split(), str(plan_path), tier]
-        logger.info(
-            "Invoking Claude failsafe (cmd=%s, tier=%s, file=%s)",
-            cmd,
-            tier,
-            plan_path,
-        )
-
         result = subprocess.run(
             cmd,
             capture_output=True,

--- a/scripts/internal/codex_review_adapter.py
+++ b/scripts/internal/codex_review_adapter.py
@@ -26,9 +26,6 @@ DEFAULT_TIMEOUT_SECONDS = 300
 # Max retries before giving up
 MAX_RETRIES = 3
 
-# Known path for macOS Codex app bundle binary
-_CODEX_APP_PATH = Path("/Applications/Codex.app/Contents/Resources/codex")
-
 # Patterns in stderr that indicate a CLI argument/invocation error
 # (as opposed to a review-time error like auth failure or network issue)
 _CLI_ARG_ERROR_PATTERNS = [
@@ -272,8 +269,12 @@ def _resolve_codex_binary() -> list[str]:
     Preference order:
     1. ``CODEX_REVIEW_CMD`` env var (custom launcher, e.g. Docker wrapper)
     2. ``codex`` in PATH (fastest — no npx overhead)
-    3. macOS app bundle binary at known path
-    4. ``npx @openai/codex`` fallback (downloads if needed)
+    3. ``npx @openai/codex`` fallback (downloads if needed)
+
+    Note: The macOS Codex desktop app (``/Applications/Codex.app``) is
+    intentionally NOT used as a fallback. Its internal binary launches
+    a full Electron GUI rather than running a headless CLI review, causing
+    a 300s timeout with no useful output.
     """
     custom_cmd = os.environ.get("CODEX_REVIEW_CMD", "").strip()
     if custom_cmd:
@@ -282,8 +283,6 @@ def _resolve_codex_binary() -> list[str]:
         return parts
     if shutil.which("codex"):
         return ["codex"]
-    if _CODEX_APP_PATH.is_file():
-        return [str(_CODEX_APP_PATH)]
     return ["npx", "@openai/codex"]
 
 

--- a/tests/unit/test_codex_plan_review_adapter.py
+++ b/tests/unit/test_codex_plan_review_adapter.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 # Add scripts/internal to path for imports
 sys.path.insert(
@@ -13,8 +15,10 @@ sys.path.insert(
 
 from codex_plan_review_adapter import (
     PlanReviewFinding,
+    _build_claude_review_prompt,
     _check_codex_auth,
     detect_plan_tier,
+    invoke_claude_failsafe,
     parse_plan_findings,
     plan_state_key,
 )
@@ -347,3 +351,137 @@ class TestCheckCodexAuth:
         result = _check_codex_auth(auth_path=auth_file)
         assert result is not None
         assert "no valid credentials" in result
+
+
+# --- Claude Failsafe Tests ---
+
+
+class TestBuildClaudeReviewPrompt:
+    """Test prompt construction for Claude CLI failsafe."""
+
+    def test_prompt_includes_tier(self, tmp_path: Path) -> None:
+        plan = tmp_path / "test.md"
+        plan.write_text("# My Plan\n\nDo the thing.\n")
+        prompt = _build_claude_review_prompt(plan, "medium")
+        assert "medium-tier" in prompt
+
+    def test_prompt_includes_plan_content(self, tmp_path: Path) -> None:
+        plan = tmp_path / "test.md"
+        plan.write_text("# My Plan\n\nStep 1: do X.\n")
+        prompt = _build_claude_review_prompt(plan, "small")
+        assert "Step 1: do X" in prompt
+
+    def test_prompt_handles_unreadable_file(self) -> None:
+        plan = Path("/nonexistent/path/plan.md")
+        prompt = _build_claude_review_prompt(plan, "small")
+        assert "could not read" in prompt
+
+    def test_prompt_requests_json_output(self, tmp_path: Path) -> None:
+        plan = tmp_path / "test.md"
+        plan.write_text("# Plan\n")
+        prompt = _build_claude_review_prompt(plan, "small")
+        assert "JSON array" in prompt
+
+
+class TestClaudeFailsafeResolution:
+    """Test Claude failsafe resolution order: env var -> claude CLI -> error."""
+
+    def test_env_var_takes_priority(self, tmp_path: Path) -> None:
+        """CLAUDE_REVIEW_CMD is used when set."""
+        plan = tmp_path / "test.md"
+        plan.write_text("# Plan\n")
+
+        with patch.dict(os.environ, {"CLAUDE_REVIEW_CMD": "echo"}):
+            with patch("codex_plan_review_adapter.subprocess.run") as mock_run:
+                mock_run.return_value.returncode = 0
+                mock_run.return_value.stdout = "[]"
+                mock_run.return_value.stderr = ""
+                result = invoke_claude_failsafe(plan, "small")
+                # Should invoke the env var command, not claude CLI
+                cmd = mock_run.call_args[0][0]
+                assert cmd[0] == "echo"
+                assert result.success is True
+
+    @patch("codex_plan_review_adapter.shutil.which", return_value="/usr/bin/claude")
+    def test_auto_detects_claude_cli(self, mock_which, tmp_path: Path) -> None:
+        """When CLAUDE_REVIEW_CMD not set, auto-detects claude CLI."""
+        plan = tmp_path / "test.md"
+        plan.write_text("# Plan\n")
+
+        env = os.environ.copy()
+        env.pop("CLAUDE_REVIEW_CMD", None)
+        with patch.dict(os.environ, env, clear=True):
+            with patch("codex_plan_review_adapter.subprocess.run") as mock_run:
+                mock_run.return_value.returncode = 0
+                mock_run.return_value.stdout = "[]"
+                mock_run.return_value.stderr = ""
+                result = invoke_claude_failsafe(plan, "small")
+                cmd = mock_run.call_args[0][0]
+                assert cmd[0] == "claude"
+                assert "--print" in cmd
+                assert "-p" in cmd
+                assert result.success is True
+
+    @patch("codex_plan_review_adapter.shutil.which", return_value=None)
+    def test_returns_error_when_nothing_available(
+        self, mock_which, tmp_path: Path
+    ) -> None:
+        """When neither env var nor claude CLI available, returns error."""
+        plan = tmp_path / "test.md"
+        plan.write_text("# Plan\n")
+
+        env = os.environ.copy()
+        env.pop("CLAUDE_REVIEW_CMD", None)
+        with patch.dict(os.environ, env, clear=True):
+            result = invoke_claude_failsafe(plan, "small")
+            assert result.success is False
+            assert "not in PATH" in result.error
+
+    @patch("codex_plan_review_adapter.shutil.which", return_value="/usr/bin/claude")
+    def test_parses_json_findings(self, mock_which, tmp_path: Path) -> None:
+        """Claude CLI JSON output is parsed into PlanReviewFinding objects."""
+        plan = tmp_path / "test.md"
+        plan.write_text("# Plan\n")
+
+        findings_json = json.dumps(
+            [
+                {
+                    "severity": "WARNING",
+                    "category": "convention",
+                    "file": "test.md",
+                    "line": 5,
+                    "description": "Missing seed",
+                    "check_id": None,
+                }
+            ]
+        )
+
+        env = os.environ.copy()
+        env.pop("CLAUDE_REVIEW_CMD", None)
+        with patch.dict(os.environ, env, clear=True):
+            with patch("codex_plan_review_adapter.subprocess.run") as mock_run:
+                mock_run.return_value.returncode = 0
+                mock_run.return_value.stdout = findings_json
+                mock_run.return_value.stderr = ""
+                result = invoke_claude_failsafe(plan, "small")
+                assert result.success is True
+                assert len(result.findings) == 1
+                assert result.findings[0].severity == "WARNING"
+                assert result.findings[0].description == "Missing seed"
+
+    @patch("codex_plan_review_adapter.shutil.which", return_value="/usr/bin/claude")
+    def test_handles_empty_json_array(self, mock_which, tmp_path: Path) -> None:
+        """Empty JSON array means no findings (clean review)."""
+        plan = tmp_path / "test.md"
+        plan.write_text("# Plan\n")
+
+        env = os.environ.copy()
+        env.pop("CLAUDE_REVIEW_CMD", None)
+        with patch.dict(os.environ, env, clear=True):
+            with patch("codex_plan_review_adapter.subprocess.run") as mock_run:
+                mock_run.return_value.returncode = 0
+                mock_run.return_value.stdout = "[]"
+                mock_run.return_value.stderr = ""
+                result = invoke_claude_failsafe(plan, "small")
+                assert result.success is True
+                assert len(result.findings) == 0

--- a/tests/unit/test_codex_review_adapter.py
+++ b/tests/unit/test_codex_review_adapter.py
@@ -14,7 +14,6 @@ sys.path.insert(
 
 from codex_review_adapter import (
     _CLEAN_REVIEW_PATTERNS,
-    _CODEX_APP_PATH,
     CodexFinding,
     CodexReviewResult,
     _classify_error,
@@ -301,15 +300,9 @@ class TestBinaryResolution:
         assert _resolve_codex_binary() == ["codex"]
 
     @patch("codex_review_adapter.shutil.which", return_value=None)
-    def test_falls_back_to_app_bundle(self, mock_which):
-        with patch.object(Path, "is_file", return_value=True):
-            result = _resolve_codex_binary()
-            assert result == [str(_CODEX_APP_PATH)]
-
-    @patch("codex_review_adapter.shutil.which", return_value=None)
     def test_falls_back_to_npx(self, mock_which):
-        with patch.object(Path, "is_file", return_value=False):
-            assert _resolve_codex_binary() == ["npx", "@openai/codex"]
+        """When codex not in PATH, falls through to npx."""
+        assert _resolve_codex_binary() == ["npx", "@openai/codex"]
 
 
 class TestCommandConstruction:
@@ -481,9 +474,8 @@ class TestEnvVarLauncher:
         env = os.environ.copy()
         env.pop("CODEX_REVIEW_CMD", None)
         with patch.dict(os.environ, env, clear=True):
-            with patch.object(Path, "is_file", return_value=False):
-                result = _resolve_codex_binary()
-                assert result == ["npx", "@openai/codex"]
+            result = _resolve_codex_binary()
+            assert result == ["npx", "@openai/codex"]
 
     @patch("codex_plan_review_adapter._run_with_pty")
     def test_env_var_in_invoke_command(self, mock_pty):


### PR DESCRIPTION
## Plan
N/A — bugfix for issue #762

## Summary
- Remove macOS Codex desktop app binary from `_resolve_codex_binary()` fallback chain — it launches a full Electron GUI instead of running a headless CLI review, causing a 300s timeout
- Make `invoke_claude_failsafe()` auto-detect the `claude` CLI when `CLAUDE_REVIEW_CMD` is not set, so the fallback actually produces findings instead of always returning "not configured"
- Add 9 new tests covering Claude failsafe resolution order and prompt building

## Why
Issue #762: `/review-plan` skill failed because (1) Codex CLI wasn't installed, (2) the adapter picked up the Codex desktop app binary which launched a GUI, (3) the Claude fallback was a dead-end test seam with no production path. This PR fixes layers 2 and 3 defensively so the system degrades gracefully regardless of Codex CLI installation state.

## Repro / Validation
**Command(s) run:**
```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/test_codex_review_adapter.py tests/unit/test_codex_plan_review_adapter.py tests/unit/test_plan_review_driver.py -v
# 122 passed

# Tier 2 — full validation
make check-quiet  # All checks passed

# Smoke test — binary resolution
PYTHONPATH=scripts/internal uv run python -c "
from codex_review_adapter import _resolve_codex_binary
print(_resolve_codex_binary())  # ['codex'] (not app bundle)
"

# Smoke test — Claude failsafe
PYTHONPATH=scripts/internal uv run python -c "
import shutil
print('claude available:', shutil.which('claude') is not None)  # True
"
```

**Seed:** N/A (no experiments)

## Tests
- [x] `uv run python -m pytest tests/unit/test_codex_review_adapter.py tests/unit/test_codex_plan_review_adapter.py tests/unit/test_plan_review_driver.py -v` — 122 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None (infrastructure-only)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-plan-review
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-plan-review
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                   33ee241 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-plan-review   9846b87 [fix/plan-review-fallback]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)