### PR TITLE
fix: address Codex review findings for reporting PRs #759/#764

### DIFF
--- a/scripts/internal/generate_rung_charts.py
+++ b/scripts/internal/generate_rung_charts.py
@@ -717,9 +717,17 @@ def generate_seat_balance(
         return False
 
     fig, ax = plt.subplots(figsize=(8, 5))
-    if "seat" in df.columns and "value" in df.columns:
+    # Support both legacy schema (seat, value) and current schema
+    # (seat, contract, mean_tricks, n_hands)
+    value_col = None
+    if "value" in df.columns:
+        value_col = "value"
+    elif "mean_tricks" in df.columns:
+        value_col = "mean_tricks"
+
+    if "seat" in df.columns and value_col is not None:
         seats = sorted(df["seat"].unique())
-        data = [df[df["seat"] == s]["value"].values for s in seats]
+        data = [df[df["seat"] == s][value_col].values for s in seats]
         ax.boxplot(data, labels=[f"Seat {s}" for s in seats])
     else:
         ax.text(

--- a/src/bid_euchre/arc_d_v2/report.py
+++ b/src/bid_euchre/arc_d_v2/report.py
@@ -171,7 +171,6 @@ def generate_report(report_dir: Path) -> str:
     interp_charts = [
         "shap_summary.png",
         "shap_dependence_top5.png",
-        "feature_importance.png",
         "selection_path.png",
     ]
     has_interp = False
@@ -228,15 +227,20 @@ def generate_report(report_dir: Path) -> str:
             "",
         ]
     )
-    h2h = _read_csv_safe(tables_dir / "h2h_delta_matrix.csv")
-    if h2h is not None:
-        lines.append(_df_to_markdown(h2h))
-    else:
-        lines.append(_table_placeholder("h2h_delta_matrix.csv"))
-    lines.append("")
-
+    # Charts first, compact table excerpt below
     lines.append(_chart_embed(charts_dir, "delta_bars_by_contract.png"))
     lines.append(_chart_embed(charts_dir, "h2h_heatmap.png"))
+    lines.append("")
+
+    h2h = _read_csv_safe(tables_dir / "h2h_delta_matrix.csv")
+    if h2h is not None:
+        lines.append(
+            "<details><summary>Full H2H Delta Matrix (click to expand)</summary>\n"
+        )
+        lines.append(_df_to_markdown(h2h))
+        lines.append("\n</details>\n")
+    else:
+        lines.append(_table_placeholder("h2h_delta_matrix.csv"))
     lines.append("")
 
     # section 8 Behavioral Analysis

--- a/src/bid_euchre/arc_d_v2/tables.py
+++ b/src/bid_euchre/arc_d_v2/tables.py
@@ -1008,13 +1008,16 @@ def generate_chart_data(
             df.to_csv(output_dir / "contract_mix.csv", index=False)
             generated.append("contract_mix.csv")
 
-    # 3. outcome_distributions.csv — H2H battery by_contract statistics
+    # 3. h2h_by_contract.csv — H2H battery by_contract statistics
+    #    NOTE: This is per-matchup summary data (one row per model×opponent×contract),
+    #    NOT per-deal observations. Renamed from outcome_distributions.csv to avoid
+    #    implying distributional granularity.
     if h2h_battery:
-        rows = _extract_outcome_distributions(h2h_battery)
+        rows = _extract_h2h_by_contract(h2h_battery)
         if rows:
             df = pd.DataFrame(rows)
-            df.to_csv(output_dir / "outcome_distributions.csv", index=False)
-            generated.append("outcome_distributions.csv")
+            df.to_csv(output_dir / "h2h_by_contract.csv", index=False)
+            generated.append("h2h_by_contract.csv")
 
     # 4. bid_levels.csv — aggregate bidding metrics per model from comparator CIs
     if comparator_cis:
@@ -1039,14 +1042,15 @@ def generate_chart_data(
     return generated
 
 
-def _extract_outcome_distributions(h2h_battery: dict) -> list[dict]:
+def _extract_h2h_by_contract(h2h_battery: dict) -> list[dict]:
     """Flatten H2H battery by_contract statistics into chart_data rows.
 
-    Extracts cross-matchup (not self-play) per-contract data into rows
-    suitable for outcome distribution charts.
+    Extracts per-matchup per-contract summary data into rows for
+    H2H analysis charts. This is summary data (one row per
+    model×opponent×contract), NOT per-deal observations.
 
     Returns list of dicts with keys:
-        model, contract, net_eppd_delta, deals_total, win_rate
+        model, opponent, contract, net_eppd_delta, deals_total, win_rate
     """
     rows: list[dict] = []
     for _mid, cell in h2h_battery.get("cells", {}).items():
@@ -1320,47 +1324,73 @@ def generate_model_eval_csvs(
     calibration_rows: list[dict] = []
 
     for model_name, artifact in training_artifacts.items():
-        if artifact.get("schema_version") != "action_value_gbt_v1":
+        schema = artifact.get("schema_version", "")
+        supported_schemas = (
+            "action_value_gbt_v1",
+            "action_value_olsa_v1",
+            "two_stage_action_value_v1",
+        )
+        if schema not in supported_schemas:
             continue
 
         models_meta = artifact.get("models", {})
 
         for contract, meta in models_meta.items():
-            model_file = meta.get("model_file")
-            if not model_file:
-                continue
-
             feature_names = meta.get("feature_names", [])
             if not feature_names:
                 continue
 
-            # Try to find model file relative to eval parquet
-            if eval_parquet_path is not None:
-                candidate_dirs = [
-                    eval_parquet_path.parent.parent / "artifacts",
-                    eval_parquet_path.parent,
-                ]
-                model_path = None
-                for cdir in candidate_dirs:
-                    p = cdir / model_file
-                    if p.exists():
-                        model_path = p
-                        break
-                if model_path is None:
-                    logger.info(
-                        "Model file %s not found for %s/%s; skipping",
-                        model_file,
-                        model_name,
-                        contract,
-                    )
-                    continue
-            else:
-                continue
+            # Load model or coefficients depending on schema
+            predict_fn = None
 
-            try:
-                model = joblib.load(model_path)
-            except Exception as e:
-                logger.warning("Failed to load model %s: %s", model_path, e)
+            if schema == "action_value_gbt_v1":
+                # GBT: load joblib model file
+                model_file = meta.get("model_file")
+                if not model_file:
+                    continue
+                if eval_parquet_path is not None:
+                    candidate_dirs = [
+                        eval_parquet_path.parent.parent / "artifacts",
+                        eval_parquet_path.parent,
+                    ]
+                    model_path = None
+                    for cdir in candidate_dirs:
+                        p = cdir / model_file
+                        if p.exists():
+                            model_path = p
+                            break
+                    if model_path is None:
+                        logger.info(
+                            "Model file %s not found for %s/%s; skipping",
+                            model_file,
+                            model_name,
+                            contract,
+                        )
+                        continue
+                else:
+                    continue
+                try:
+                    model = joblib.load(model_path)
+                    predict_fn = model.predict
+                except Exception as e:
+                    logger.warning("Failed to load model %s: %s", model_path, e)
+                    continue
+
+            elif schema in ("action_value_olsa_v1", "two_stage_action_value_v1"):
+                # OLS/two-stage: use coefficients from JSON directly
+                coefficients = meta.get("coefficients")
+                intercept = meta.get("intercept")
+                if coefficients is None or intercept is None:
+                    continue
+                coefs = np.array(coefficients, dtype=float)
+                intercept_val = float(intercept)
+
+                def _make_linear_predict(c, i):
+                    return lambda X: X @ c + i
+
+                predict_fn = _make_linear_predict(coefs, intercept_val)
+
+            if predict_fn is None:
                 continue
 
             # Filter eval data to this contract
@@ -1393,7 +1423,7 @@ def generate_model_eval_csvs(
             actuals = family_df[actual_col].values.astype(float)
 
             try:
-                preds = model.predict(X)
+                preds = predict_fn(X)
             except Exception as e:
                 logger.warning(
                     "Prediction failed for %s/%s: %s",

--- a/tests/unit/test_rung_tables.py
+++ b/tests/unit/test_rung_tables.py
@@ -24,7 +24,7 @@ from bid_euchre.arc_d_v2.tables import (
     _classify_tier,
     _extract_bid_levels,
     _extract_feature_importance,
-    _extract_outcome_distributions,
+    _extract_h2h_by_contract,
     _merge_comparator_cis,
     _merge_h2h_batteries,
     _per_seed_sanity_comparator,
@@ -1405,8 +1405,8 @@ class TestChartData:
         # so outcome_summary should be present
         assert len(chart_data_items) > 0
 
-    def test_outcome_distributions_from_h2h(self, h2h_battery, tmp_path):
-        """outcome_distributions.csv generated from H2H battery by_contract."""
+    def test_h2h_by_contract_from_h2h(self, h2h_battery, tmp_path):
+        """h2h_by_contract.csv generated from H2H battery by_contract."""
         # Add by_contract data to a cross-matchup cell for testing
         h2h = dict(h2h_battery)
         cells = dict(h2h["cells"])
@@ -1427,16 +1427,16 @@ class TestChartData:
         h2h["cells"] = cells
 
         generated = generate_chart_data(h2h_battery=h2h, output_dir=tmp_path)
-        assert "outcome_distributions.csv" in generated
-        df = pd.read_csv(tmp_path / "outcome_distributions.csv")
+        assert "h2h_by_contract.csv" in generated
+        df = pd.read_csv(tmp_path / "h2h_by_contract.csv")
         assert "model" in df.columns
         assert "opponent" in df.columns
         assert "contract" in df.columns
         assert "net_eppd_delta" in df.columns
         assert len(df) > 0
 
-    def test_outcome_distributions_no_by_contract(self, tmp_path):
-        """outcome_distributions still emits pooled rows from cells without by_contract."""
+    def test_h2h_by_contract_no_by_contract(self, tmp_path):
+        """h2h_by_contract still emits pooled rows from cells without by_contract."""
         h2h = {
             "cells": {
                 "a_vs_b": {
@@ -1449,8 +1449,8 @@ class TestChartData:
             },
         }
         generated = generate_chart_data(h2h_battery=h2h, output_dir=tmp_path)
-        assert "outcome_distributions.csv" in generated
-        df = pd.read_csv(tmp_path / "outcome_distributions.csv")
+        assert "h2h_by_contract.csv" in generated
+        df = pd.read_csv(tmp_path / "h2h_by_contract.csv")
         assert len(df) == 1
         assert df.iloc[0]["contract"] == "pooled"
 
@@ -1635,8 +1635,8 @@ class TestFeatureImportanceExtraction:
 # ──────────────────────────────────────────────
 
 
-class TestOutcomeDistributionsExtraction:
-    """Tests for _extract_outcome_distributions helper."""
+class TestH2hByContractExtraction:
+    """Tests for _extract_h2h_by_contract helper."""
 
     def test_basic_extraction(self):
         """Extracts pooled rows from cells without by_contract."""
@@ -1651,7 +1651,7 @@ class TestOutcomeDistributionsExtraction:
                 },
             },
         }
-        rows = _extract_outcome_distributions(h2h)
+        rows = _extract_h2h_by_contract(h2h)
         assert len(rows) == 1
         assert rows[0]["contract"] == "pooled"
         assert rows[0]["model"] == "model_a"
@@ -1676,7 +1676,7 @@ class TestOutcomeDistributionsExtraction:
                 },
             },
         }
-        rows = _extract_outcome_distributions(h2h)
+        rows = _extract_h2h_by_contract(h2h)
         assert len(rows) == 2  # 1 suit + 1 pooled
         contracts = [r["contract"] for r in rows]
         assert "suit" in contracts


### PR DESCRIPTION
## Plan
Response to Codex post-merge review of PRs #759 and #764.

## Summary
- **CRITICAL 1**: Rename `outcome_distributions.csv` → `h2h_by_contract.csv` — honest name for per-matchup summary data
- **CRITICAL 2**: Broaden `generate_model_eval_csvs()` to support OLS and two-stage artifacts (not just GBT) via coefficient-based linear prediction
- **WARNING 1**: Fix `seat_balance` chart reader to accept current schema (`mean_tricks`) alongside legacy (`value`)
- **WARNING 2**: Make H2H report section chart-first with collapsible `<details>` matrix
- **WARNING 3**: Remove duplicate `feature_importance.png` from section 4 (already in section 3)

## Why
Codex post-merge review found 2 CRITICAL and 3 WARNING issues in the reporting suite PRs. The CRITICALs are semantic (misleading CSV name) and coverage (GBT-only model eval excludes 4/5 models). The WARNINGs are integration gaps and report readability issues.

## Repro / Validation
```bash
make check-quiet
PYTHONPATH=src uv run pytest tests/unit/test_rung_tables.py tests/unit/test_rung_report.py tests/unit/test_rung_charts.py -q
```

## Tests
- [x] `make check-quiet` passes
- [x] 118 tests pass across 3 test files
- [x] Renamed test methods and class names to match new CSV names

## Expected impact
- Metrics impact: None (reporting only)
- Runtime impact: None

## Risk level
Low — reporting pipeline only, no engine/strategy changes.

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-codex-fixes
branch: fix/codex-review-findings
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)