### PR TITLE
feat: 22-chart registry, numbered report headings, team0/team1 labels, table truncation

### DIFF
--- a/src/bid_euchre/arc_d_v2/chart_registry.py
+++ b/src/bid_euchre/arc_d_v2/chart_registry.py
@@ -1,0 +1,183 @@
+"""Chart registry for Arc D v2 rung reports.
+
+Defines the canonical 22-chart numbered registry. Chart numbers are stable
+identifiers — they never change based on availability. Used by report.py
+for numbered headings and by manifest.py for chart inventory.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ChartEntry:
+    """A single chart in the registry."""
+
+    number: int
+    filename: str
+    title: str
+    required: bool
+    source: str
+
+
+CHART_REGISTRY: tuple[ChartEntry, ...] = (
+    ChartEntry(
+        1,
+        "dashboard_competitive.png",
+        "Competitive Dashboard",
+        True,
+        "canonical tables",
+    ),
+    ChartEntry(
+        2,
+        "dashboard_health.png",
+        "Health Dashboard",
+        True,
+        "canonical tables + chart_data",
+    ),
+    ChartEntry(
+        3,
+        "dashboard_model_eval.png",
+        "Model Evaluation Dashboard",
+        True,
+        "canonical tables + chart_data",
+    ),
+    ChartEntry(
+        4,
+        "comparator_ranking_bars.png",
+        "Comparator Ranking Bars",
+        True,
+        "tables/comparator_rankings.csv",
+    ),
+    ChartEntry(
+        5,
+        "tail_risk_panel.png",
+        "Tail Risk Panel",
+        True,
+        "tables/comparator_rankings.csv",
+    ),
+    ChartEntry(
+        6,
+        "delta_bars_by_contract.png",
+        "H2H Delta by Contract",
+        True,
+        "tables/h2h_delta_matrix.csv",
+    ),
+    ChartEntry(
+        7, "h2h_heatmap.png", "H2H Heatmap", True, "tables/h2h_delta_matrix.csv"
+    ),
+    ChartEntry(
+        8,
+        "h2h_ranking_scatter.png",
+        "H2H Ranking Scatter",
+        False,
+        "tables/comparator_rankings.csv + h2h_tier_summary.csv",
+    ),
+    ChartEntry(
+        9,
+        "outcome_distributions.png",
+        "Outcome Distributions",
+        False,
+        "chart_data/outcome_distributions.csv",
+    ),
+    ChartEntry(
+        10, "seat_balance.png", "Seat Balance", False, "chart_data/seat_balance.csv"
+    ),
+    ChartEntry(
+        11, "contract_mix_bars.png", "Contract Mix", True, "chart_data/contract_mix.csv"
+    ),
+    ChartEntry(
+        12,
+        "bid_behavior_panel.png",
+        "Bid and Make Rates",
+        True,
+        "tables/behavior_summary.csv",
+    ),
+    ChartEntry(
+        13,
+        "bid_level_distribution.png",
+        "Bid Level Distribution",
+        False,
+        "chart_data/bid_levels.csv",
+    ),
+    ChartEntry(
+        14,
+        "r2_by_contract.png",
+        "R-squared by Contract",
+        True,
+        "tables/model_performance.csv",
+    ),
+    ChartEntry(
+        15,
+        "mae_by_contract.png",
+        "MAE by Contract",
+        True,
+        "tables/model_performance.csv",
+    ),
+    ChartEntry(
+        16,
+        "pred_vs_actual.png",
+        "Predicted vs Actual",
+        False,
+        "chart_data/predictions.csv",
+    ),
+    ChartEntry(
+        17,
+        "residual_distribution.png",
+        "Residual Distribution",
+        False,
+        "chart_data/residuals.csv",
+    ),
+    ChartEntry(
+        18,
+        "calibration_curve.png",
+        "Calibration Curve",
+        False,
+        "chart_data/calibration_bins.csv",
+    ),
+    ChartEntry(
+        19,
+        "selection_path.png",
+        "Selection Path",
+        False,
+        "chart_data/selection_paths.csv",
+    ),
+    ChartEntry(
+        20,
+        "feature_importance.png",
+        "Feature Importance",
+        False,
+        "chart_data/selection_paths.csv",
+    ),
+    ChartEntry(
+        21,
+        "decision_agreement.png",
+        "Decision Agreement",
+        False,
+        "chart_data/decision_comparison.csv",
+    ),
+    ChartEntry(
+        22,
+        "disagreement_outcomes.png",
+        "Disagreement Outcomes",
+        False,
+        "chart_data/disagreement_outcomes.csv",
+    ),
+)
+
+
+def get_chart_by_number(n: int) -> ChartEntry | None:
+    """Look up a chart entry by its stable number."""
+    for entry in CHART_REGISTRY:
+        if entry.number == n:
+            return entry
+    return None
+
+
+def get_chart_by_filename(filename: str) -> ChartEntry | None:
+    """Look up a chart entry by its PNG filename."""
+    for entry in CHART_REGISTRY:
+        if entry.filename == filename:
+            return entry
+    return None

--- a/src/bid_euchre/arc_d_v2/manifest.py
+++ b/src/bid_euchre/arc_d_v2/manifest.py
@@ -14,6 +14,7 @@ import logging
 import subprocess
 from pathlib import Path
 
+from bid_euchre.arc_d_v2.chart_registry import CHART_REGISTRY, get_chart_by_filename
 from bid_euchre.arc_d_v2.lifecycle import list_runs
 
 logger = logging.getLogger(__name__)
@@ -75,6 +76,55 @@ def _get_lifecycle_status(rung_dir: Path) -> list[dict]:
             if art_status.quarantine_reason:
                 entry["quarantine_reason"] = art_status.quarantine_reason
         entries.append(entry)
+    return entries
+
+
+def _inventory_chart_dir(charts_dir: Path) -> list[dict]:
+    """Build chart inventory covering all 22 registry entries.
+
+    For each chart in CHART_REGISTRY, records presence/absence and size.
+    Charts present on disk but not in the registry are appended at the end.
+    """
+    # Build a set of filenames on disk
+    on_disk: dict[str, int] = {}
+    if charts_dir.exists():
+        for p in sorted(charts_dir.glob("*.png")):
+            on_disk[p.name] = p.stat().st_size
+
+    entries: list[dict] = []
+    seen_filenames: set[str] = set()
+
+    for chart in CHART_REGISTRY:
+        entry: dict = {
+            "number": chart.number,
+            "name": chart.filename,
+            "title": chart.title,
+            "required": chart.required,
+        }
+        if chart.filename in on_disk:
+            entry["present"] = True
+            entry["size_bytes"] = on_disk[chart.filename]
+            entry["path"] = str(charts_dir / chart.filename)
+        else:
+            entry["present"] = False
+            entry["size_bytes"] = 0
+        entries.append(entry)
+        seen_filenames.add(chart.filename)
+
+    # Include any extra PNGs not in the registry
+    for name, size in sorted(on_disk.items()):
+        if name not in seen_filenames:
+            entry_extra = get_chart_by_filename(name)
+            entries.append(
+                {
+                    "name": name,
+                    "title": entry_extra.title if entry_extra else name,
+                    "present": True,
+                    "size_bytes": size,
+                    "path": str(charts_dir / name),
+                }
+            )
+
     return entries
 
 
@@ -140,9 +190,9 @@ def generate_evidence_manifest(
     tables_dir = report_dir / "tables"
     table_inventory = _inventory_dir(tables_dir, ".csv")
 
-    # Inventory charts
+    # Inventory charts — annotate with registry number/title/status
     charts_dir = report_dir / "charts"
-    chart_inventory = _inventory_dir(charts_dir, ".png")
+    chart_inventory = _inventory_chart_dir(charts_dir)
 
     # Inventory chart data
     chart_data_dir = report_dir / "chart_data"
@@ -309,20 +359,27 @@ def render_manifest_markdown(manifest: dict) -> str:
             lines.append(f"| `{t.get('name', '')}` | {size:,} bytes |")
         lines.append("")
 
-    # Charts
+    # Charts — registry-aware inventory
     charts = manifest.get("charts", [])
     if charts:
         lines.extend(
             [
                 "## Charts",
                 "",
-                "| Name | Size |",
-                "|------|------|",
+                "| # | Title | File | Size | Status |",
+                "|---|-------|------|------|--------|",
             ]
         )
         for c in charts:
+            num = c.get("number", "")
+            title = c.get("title", "")
+            name = c.get("name", "")
             size = c.get("size_bytes", 0)
-            lines.append(f"| `{c.get('name', '')}` | {size:,} bytes |")
+            present = c.get("present", True)
+            status = "present" if present else "absent"
+            num_str = str(num) if num else "-"
+            size_str = f"{size:,} bytes" if present else "-"
+            lines.append(f"| {num_str} | {title} | `{name}` | {size_str} | {status} |")
         lines.append("")
 
     # Chart Data

--- a/src/bid_euchre/arc_d_v2/report.py
+++ b/src/bid_euchre/arc_d_v2/report.py
@@ -14,7 +14,17 @@ from pathlib import Path
 
 import pandas as pd
 
+from bid_euchre.arc_d_v2.chart_registry import get_chart_by_filename
+
 logger = logging.getLogger(__name__)
+
+# Column renames applied when rendering H2H tables in markdown.
+# The underlying CSV schema is unchanged — only the report-facing labels change.
+_H2H_COLUMN_RENAMES = {"model_a": "team0", "model_b": "team1"}
+
+# Tables with more than this many rows are truncated in the report.
+_TABLE_ROW_LIMIT = 12
+_TABLE_ROW_SHOW = 10
 
 
 def _read_csv_safe(path: Path) -> pd.DataFrame | None:
@@ -36,11 +46,32 @@ def _table_placeholder(table_name: str) -> str:
 
 def _chart_placeholder(chart_name: str) -> str:
     """Return a placeholder for a missing chart."""
+    entry = get_chart_by_filename(chart_name)
+    if entry is not None:
+        return (
+            f"### Chart {entry.number}. {entry.title}\n\n"
+            f"*Chart not available — source data absent.*\n"
+        )
     return f"> [chart_name={chart_name}] not yet generated\n"
 
 
-def _df_to_markdown(df: pd.DataFrame, float_format: str = "%.4f") -> str:
-    """Convert a DataFrame to a markdown table string."""
+def _df_to_markdown(
+    df: pd.DataFrame,
+    float_format: str = "%.4f",
+    *,
+    table_name: str = "",
+    column_renames: dict[str, str] | None = None,
+) -> str:
+    """Convert a DataFrame to a markdown table string.
+
+    Args:
+        df: The DataFrame to render.
+        float_format: Format string for float columns.
+        table_name: If non-empty and the table exceeds _TABLE_ROW_LIMIT rows,
+            the output is truncated with a note pointing to this CSV file.
+        column_renames: Optional column header renames for the rendered output.
+            Does NOT modify the underlying DataFrame or CSV.
+    """
     # Format float columns
     formatted = df.copy()
     for col in formatted.select_dtypes(include=["float64", "float32"]).columns:
@@ -48,24 +79,45 @@ def _df_to_markdown(df: pd.DataFrame, float_format: str = "%.4f") -> str:
             lambda x: float_format % x if pd.notna(x) else ""
         )
 
+    # Truncate long tables
+    truncated = False
+    if table_name and len(formatted) > _TABLE_ROW_LIMIT:
+        formatted = formatted.head(_TABLE_ROW_SHOW)
+        truncated = True
+
+    # Apply column renames for display
+    display_cols = list(formatted.columns)
+    if column_renames:
+        display_cols = [column_renames.get(c, c) for c in display_cols]
+
     # Build header
-    cols = list(formatted.columns)
-    header = "| " + " | ".join(cols) + " |"
-    separator = "| " + " | ".join(["---"] * len(cols)) + " |"
+    header = "| " + " | ".join(display_cols) + " |"
+    separator = "| " + " | ".join(["---"] * len(display_cols)) + " |"
 
     # Build rows
     rows = []
     for _, row in formatted.iterrows():
-        cells = [str(row[c]) if pd.notna(row[c]) else "" for c in cols]
+        cells = [str(row[c]) if pd.notna(row[c]) else "" for c in formatted.columns]
         rows.append("| " + " | ".join(cells) + " |")
 
-    return "\n".join([header, separator] + rows) + "\n"
+    parts = [header, separator] + rows
+    if truncated:
+        parts.append("")
+        parts.append(f"*Full table omitted from markdown — see `tables/{table_name}`*")
+
+    return "\n".join(parts) + "\n"
 
 
 def _chart_embed(charts_dir: Path, chart_name: str) -> str:
     """Return markdown image embed or placeholder for a chart."""
+    entry = get_chart_by_filename(chart_name)
     chart_path = charts_dir / chart_name
     if chart_path.exists():
+        if entry is not None:
+            return (
+                f"### Chart {entry.number}. {entry.title}\n\n"
+                f"![{entry.title}](charts/{chart_name})\n"
+            )
         return f"![{chart_name}](charts/{chart_name})\n"
     return _chart_placeholder(chart_name)
 
@@ -103,13 +155,8 @@ def generate_report(report_dir: Path) -> str:
                 "",
             ]
         )
-        for dash_file, dash_title in dashboards:
-            if (charts_dir / dash_file).exists():
-                lines.append(f"### {dash_title}\n")
-                lines.append(f"![{dash_title}](charts/{dash_file})\n")
-            else:
-                lines.append(f"### {dash_title}\n")
-                lines.append(_chart_placeholder(dash_file))
+        for dash_file, _dash_title in dashboards:
+            lines.append(_chart_embed(charts_dir, dash_file))
         lines.append("")
 
     # section 1 Data Sanity
@@ -121,7 +168,7 @@ def generate_report(report_dir: Path) -> str:
     )
     data_sanity = _read_csv_safe(tables_dir / "data_sanity.csv")
     if data_sanity is not None:
-        lines.append(_df_to_markdown(data_sanity))
+        lines.append(_df_to_markdown(data_sanity, table_name="data_sanity.csv"))
     else:
         lines.append(_table_placeholder("data_sanity.csv"))
     lines.append("")
@@ -135,7 +182,7 @@ def generate_report(report_dir: Path) -> str:
     )
     model_perf = _read_csv_safe(tables_dir / "model_performance.csv")
     if model_perf is not None:
-        lines.append(_df_to_markdown(model_perf))
+        lines.append(_df_to_markdown(model_perf, table_name="model_performance.csv"))
     else:
         lines.append(_table_placeholder("model_performance.csv"))
     lines.append("")
@@ -211,7 +258,7 @@ def generate_report(report_dir: Path) -> str:
     )
     comparator = _read_csv_safe(tables_dir / "comparator_rankings.csv")
     if comparator is not None:
-        lines.append(_df_to_markdown(comparator))
+        lines.append(_df_to_markdown(comparator, table_name="comparator_rankings.csv"))
     else:
         lines.append(_table_placeholder("comparator_rankings.csv"))
     lines.append("")
@@ -237,7 +284,13 @@ def generate_report(report_dir: Path) -> str:
         lines.append(
             "<details><summary>Full H2H Delta Matrix (click to expand)</summary>\n"
         )
-        lines.append(_df_to_markdown(h2h))
+        lines.append(
+            _df_to_markdown(
+                h2h,
+                table_name="h2h_delta_matrix.csv",
+                column_renames=_H2H_COLUMN_RENAMES,
+            )
+        )
         lines.append("\n</details>\n")
     else:
         lines.append(_table_placeholder("h2h_delta_matrix.csv"))
@@ -253,7 +306,7 @@ def generate_report(report_dir: Path) -> str:
     behavior = _read_csv_safe(tables_dir / "behavior_summary.csv")
     if behavior is not None:
         lines.append("### Pooled Behavior Summary\n")
-        lines.append(_df_to_markdown(behavior))
+        lines.append(_df_to_markdown(behavior, table_name="behavior_summary.csv"))
     else:
         lines.append(_table_placeholder("behavior_summary.csv"))
     lines.append("")
@@ -261,7 +314,9 @@ def generate_report(report_dir: Path) -> str:
     behavior_contract = _read_csv_safe(tables_dir / "behavior_by_contract.csv")
     if behavior_contract is not None:
         lines.append("### Behavior by Contract\n")
-        lines.append(_df_to_markdown(behavior_contract))
+        lines.append(
+            _df_to_markdown(behavior_contract, table_name="behavior_by_contract.csv")
+        )
     else:
         lines.append(_table_placeholder("behavior_by_contract.csv"))
     lines.append("")
@@ -279,7 +334,7 @@ def generate_report(report_dir: Path) -> str:
     )
     sanity = _read_csv_safe(tables_dir / "sanity_bounds_check.csv")
     if sanity is not None:
-        lines.append(_df_to_markdown(sanity))
+        lines.append(_df_to_markdown(sanity, table_name="sanity_bounds_check.csv"))
     else:
         lines.append(_table_placeholder("sanity_bounds_check.csv"))
     lines.append("")

--- a/tests/unit/test_chart_registry.py
+++ b/tests/unit/test_chart_registry.py
@@ -1,0 +1,443 @@
+"""Tests for chart registry, numbered report headings, and manifest chart inventory.
+
+Covers:
+- Chart registry has exactly 22 entries with unique numbers and filenames
+- get_chart_by_number() and get_chart_by_filename() work correctly
+- Report rendering uses numbered headings (Chart N. Title)
+- Report rendering emits placeholders for missing optional charts
+- H2H table rendering uses team0/team1 labels
+- Long tables are truncated at ~12 rows
+- Manifest includes chart number and presence status
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from bid_euchre.arc_d_v2.chart_registry import (
+    CHART_REGISTRY,
+    ChartEntry,
+    get_chart_by_filename,
+    get_chart_by_number,
+)
+from bid_euchre.arc_d_v2.manifest import render_manifest_markdown
+from bid_euchre.arc_d_v2.report import (
+    _H2H_COLUMN_RENAMES,
+    _TABLE_ROW_LIMIT,
+    _TABLE_ROW_SHOW,
+    _chart_embed,
+    _chart_placeholder,
+    _df_to_markdown,
+    generate_report,
+)
+
+FIXTURES_DIR = Path(__file__).resolve().parents[2] / "data" / "fixtures" / "arc_d_v2"
+
+
+# ──────────────────────────────────────────────
+#  Chart Registry
+# ──────────────────────────────────────────────
+
+
+class TestChartRegistry:
+    def test_exactly_22_entries(self):
+        assert len(CHART_REGISTRY) == 22
+
+    def test_unique_numbers(self):
+        numbers = [e.number for e in CHART_REGISTRY]
+        assert len(numbers) == len(set(numbers))
+
+    def test_unique_filenames(self):
+        filenames = [e.filename for e in CHART_REGISTRY]
+        assert len(filenames) == len(set(filenames))
+
+    def test_numbers_are_1_to_22(self):
+        numbers = sorted(e.number for e in CHART_REGISTRY)
+        assert numbers == list(range(1, 23))
+
+    def test_all_filenames_end_with_png(self):
+        for entry in CHART_REGISTRY:
+            assert entry.filename.endswith(".png"), f"{entry.filename} is not a PNG"
+
+    def test_entries_are_frozen(self):
+        entry = CHART_REGISTRY[0]
+        with pytest.raises(AttributeError):
+            entry.number = 99  # type: ignore[misc]
+
+    def test_entry_is_dataclass(self):
+        entry = CHART_REGISTRY[0]
+        assert isinstance(entry, ChartEntry)
+        assert hasattr(entry, "number")
+        assert hasattr(entry, "filename")
+        assert hasattr(entry, "title")
+        assert hasattr(entry, "required")
+        assert hasattr(entry, "source")
+
+
+class TestGetChartByNumber:
+    def test_returns_correct_entry(self):
+        entry = get_chart_by_number(1)
+        assert entry is not None
+        assert entry.filename == "dashboard_competitive.png"
+
+    def test_returns_none_for_invalid(self):
+        assert get_chart_by_number(0) is None
+        assert get_chart_by_number(23) is None
+        assert get_chart_by_number(-1) is None
+
+    def test_all_numbers_resolve(self):
+        for n in range(1, 23):
+            entry = get_chart_by_number(n)
+            assert entry is not None, f"Chart number {n} not found"
+            assert entry.number == n
+
+
+class TestGetChartByFilename:
+    def test_returns_correct_entry(self):
+        entry = get_chart_by_filename("dashboard_competitive.png")
+        assert entry is not None
+        assert entry.number == 1
+
+    def test_returns_none_for_unknown(self):
+        assert get_chart_by_filename("nonexistent.png") is None
+        assert get_chart_by_filename("") is None
+
+    def test_all_filenames_resolve(self):
+        for reg_entry in CHART_REGISTRY:
+            entry = get_chart_by_filename(reg_entry.filename)
+            assert entry is not None
+            assert entry.number == reg_entry.number
+
+
+# ──────────────────────────────────────────────
+#  Report — Numbered Headings
+# ──────────────────────────────────────────────
+
+
+class TestReportNumberedHeadings:
+    @pytest.fixture
+    def charts_dir(self, tmp_path):
+        charts = tmp_path / "report" / "charts"
+        charts.mkdir(parents=True)
+        return charts
+
+    def test_chart_embed_uses_numbered_heading(self, charts_dir):
+        """When a chart PNG exists, _chart_embed uses 'Chart N. Title' heading."""
+        (charts_dir / "dashboard_competitive.png").write_bytes(b"PNG")
+        result = _chart_embed(charts_dir, "dashboard_competitive.png")
+        assert "### Chart 1. Competitive Dashboard" in result
+        assert "![Competitive Dashboard]" in result
+
+    def test_chart_embed_numbered_for_various_charts(self, charts_dir):
+        """Multiple chart types get their correct numbered headings."""
+        test_cases = [
+            ("r2_by_contract.png", 14, "R-squared by Contract"),
+            ("h2h_heatmap.png", 7, "H2H Heatmap"),
+            ("contract_mix_bars.png", 11, "Contract Mix"),
+        ]
+        for filename, expected_num, expected_title in test_cases:
+            (charts_dir / filename).write_bytes(b"PNG")
+            result = _chart_embed(charts_dir, filename)
+            assert f"### Chart {expected_num}. {expected_title}" in result
+
+
+class TestReportPlaceholders:
+    @pytest.fixture
+    def charts_dir(self, tmp_path):
+        charts = tmp_path / "report" / "charts"
+        charts.mkdir(parents=True)
+        return charts
+
+    def test_missing_registered_chart_has_numbered_placeholder(self, charts_dir):
+        """Missing chart from registry shows Chart N. Title + absence note."""
+        result = _chart_placeholder("dashboard_competitive.png")
+        assert "### Chart 1. Competitive Dashboard" in result
+        assert "source data absent" in result
+
+    def test_missing_unregistered_chart_has_generic_placeholder(self, charts_dir):
+        """Charts not in registry get the generic placeholder."""
+        result = _chart_placeholder("unknown_chart.png")
+        assert "not yet generated" in result
+        assert "Chart" not in result or "unknown_chart.png" in result
+
+    def test_full_report_has_placeholders_for_missing_charts(self, tmp_path):
+        """Full report generation emits placeholders for optional missing charts."""
+        report_dir = tmp_path / "report"
+        tables_dir = report_dir / "tables"
+        tables_dir.mkdir(parents=True)
+        charts_dir = report_dir / "charts"
+        charts_dir.mkdir(parents=True)
+
+        content = generate_report(report_dir)
+        # Missing registered charts should get numbered placeholders
+        assert "source data absent" in content or "not yet generated" in content
+
+
+# ──────────────────────────────────────────────
+#  Report — H2H team0/team1 Labels
+# ──────────────────────────────────────────────
+
+
+class TestH2HTeamLabels:
+    def test_column_renames_mapping(self):
+        """The rename mapping is model_a -> team0, model_b -> team1."""
+        assert _H2H_COLUMN_RENAMES == {"model_a": "team0", "model_b": "team1"}
+
+    def test_df_to_markdown_with_column_renames(self):
+        """_df_to_markdown applies column renames to headers."""
+        df = pd.DataFrame(
+            {
+                "model_a": ["gbt", "ols"],
+                "model_b": ["smart", "smart"],
+                "delta": [1.5, 0.8],
+            }
+        )
+        result = _df_to_markdown(
+            df, column_renames={"model_a": "team0", "model_b": "team1"}
+        )
+        assert "team0" in result
+        assert "team1" in result
+        # Original column names should NOT appear in headers
+        lines = result.split("\n")
+        header = lines[0]
+        assert "model_a" not in header
+        assert "model_b" not in header
+
+    def test_h2h_table_in_report_uses_team_labels(self, tmp_path):
+        """H2H delta matrix table uses team0/team1 in rendered report."""
+        report_dir = tmp_path / "report"
+        tables_dir = report_dir / "tables"
+        tables_dir.mkdir(parents=True)
+        charts_dir = report_dir / "charts"
+        charts_dir.mkdir(parents=True)
+
+        # Write a minimal H2H delta matrix CSV
+        h2h_df = pd.DataFrame(
+            {
+                "model_a": ["gbt_av", "gbt_av"],
+                "model_b": ["smart_bid", "ols_av"],
+                "facet": ["pooled", "pooled"],
+                "net_eppd_delta": [1.5, 0.8],
+                "ci_low": [1.0, 0.3],
+                "ci_high": [2.0, 1.3],
+                "win_rate_a": [0.62, 0.55],
+                "deals_total": [500, 500],
+            }
+        )
+        h2h_df.to_csv(tables_dir / "h2h_delta_matrix.csv", index=False)
+
+        content = generate_report(report_dir)
+        # The rendered table should use team0/team1
+        assert "| team0 |" in content or "| team0 " in content
+        assert "| team1 |" in content or "| team1 " in content
+
+    def test_data_values_preserved_with_renames(self):
+        """Renaming columns does not change cell values."""
+        df = pd.DataFrame(
+            {
+                "model_a": ["gbt"],
+                "model_b": ["smart"],
+                "value": [1.0],
+            }
+        )
+        result = _df_to_markdown(
+            df, column_renames={"model_a": "team0", "model_b": "team1"}
+        )
+        assert "gbt" in result
+        assert "smart" in result
+
+
+# ──────────────────────────────────────────────
+#  Report — Long Table Truncation
+# ──────────────────────────────────────────────
+
+
+class TestLongTableTruncation:
+    def test_short_table_not_truncated(self):
+        """Table with <= 12 rows is not truncated."""
+        df = pd.DataFrame({"a": range(10), "b": range(10)})
+        result = _df_to_markdown(df, table_name="test.csv")
+        assert "Full table omitted" not in result
+        # All 10 data rows present (+ header + separator = 12 lines)
+        data_lines = [
+            line for line in result.strip().split("\n") if line.startswith("|")
+        ]
+        assert len(data_lines) == 12  # 10 data + header + separator
+
+    def test_long_table_truncated(self):
+        """Table with > 12 rows is truncated to 10 rows with a note."""
+        df = pd.DataFrame({"a": range(20), "b": range(20)})
+        result = _df_to_markdown(df, table_name="test.csv")
+        assert "Full table omitted from markdown" in result
+        assert "tables/test.csv" in result
+        # Only 10 data rows present
+        data_lines = [
+            line
+            for line in result.strip().split("\n")
+            if line.startswith("|") and "---" not in line and "a" not in line
+        ]
+        assert len(data_lines) == _TABLE_ROW_SHOW
+
+    def test_exactly_at_limit_not_truncated(self):
+        """Table with exactly 12 rows is not truncated."""
+        df = pd.DataFrame({"a": range(_TABLE_ROW_LIMIT), "b": range(_TABLE_ROW_LIMIT)})
+        result = _df_to_markdown(df, table_name="test.csv")
+        assert "Full table omitted" not in result
+
+    def test_one_over_limit_truncated(self):
+        """Table with 13 rows IS truncated."""
+        df = pd.DataFrame(
+            {"a": range(_TABLE_ROW_LIMIT + 1), "b": range(_TABLE_ROW_LIMIT + 1)}
+        )
+        result = _df_to_markdown(df, table_name="test.csv")
+        assert "Full table omitted" in result
+
+    def test_no_truncation_without_table_name(self):
+        """Without table_name, tables are never truncated (backward compat)."""
+        df = pd.DataFrame({"a": range(50), "b": range(50)})
+        result = _df_to_markdown(df)
+        assert "Full table omitted" not in result
+        data_lines = [
+            line for line in result.strip().split("\n") if line.startswith("|")
+        ]
+        assert len(data_lines) == 52  # 50 data + header + separator
+
+
+# ──────────────────────────────────────────────
+#  Manifest — Chart Inventory
+# ──────────────────────────────────────────────
+
+
+class TestManifestChartInventory:
+    def test_manifest_chart_inventory_has_all_22(self, tmp_path):
+        """Chart inventory includes all 22 registry entries."""
+        from bid_euchre.arc_d_v2.manifest import _inventory_chart_dir
+
+        charts_dir = tmp_path / "charts"
+        charts_dir.mkdir()
+        # Create a few chart PNGs
+        (charts_dir / "dashboard_competitive.png").write_bytes(b"PNG" * 100)
+        (charts_dir / "h2h_heatmap.png").write_bytes(b"PNG" * 50)
+
+        inventory = _inventory_chart_dir(charts_dir)
+        # Should have at least 22 entries (registry) + 0 extras
+        assert len(inventory) >= 22
+
+        # Check that all 22 numbers are present
+        numbers = [e.get("number") for e in inventory if "number" in e]
+        assert sorted(numbers) == list(range(1, 23))
+
+    def test_present_charts_have_size(self, tmp_path):
+        from bid_euchre.arc_d_v2.manifest import _inventory_chart_dir
+
+        charts_dir = tmp_path / "charts"
+        charts_dir.mkdir()
+        (charts_dir / "dashboard_competitive.png").write_bytes(b"X" * 42)
+
+        inventory = _inventory_chart_dir(charts_dir)
+        entry = next(e for e in inventory if e["name"] == "dashboard_competitive.png")
+        assert entry["present"] is True
+        assert entry["size_bytes"] == 42
+        assert "path" in entry
+
+    def test_absent_charts_marked_absent(self, tmp_path):
+        from bid_euchre.arc_d_v2.manifest import _inventory_chart_dir
+
+        charts_dir = tmp_path / "charts"
+        charts_dir.mkdir()
+
+        inventory = _inventory_chart_dir(charts_dir)
+        # All should be absent
+        for entry in inventory:
+            if "number" in entry:
+                assert entry["present"] is False
+                assert entry["size_bytes"] == 0
+
+    def test_manifest_markdown_includes_chart_number(self):
+        """Rendered manifest markdown includes chart number and status."""
+        manifest = {
+            "schema_version": "arc_d_evidence_manifest_v1",
+            "lineage_id": "arc_d_v2",
+            "rung_id": "r0",
+            "provenance_sha": "abc123",
+            "governing_plan": "",
+            "anchor": "",
+            "roster": [],
+            "seeds": [],
+            "mode": "QUICK",
+            "run_ids": [],
+            "artifacts": [],
+            "tables": [],
+            "charts": [
+                {
+                    "number": 1,
+                    "name": "dashboard_competitive.png",
+                    "title": "Competitive Dashboard",
+                    "required": True,
+                    "present": True,
+                    "size_bytes": 1024,
+                    "path": "/tmp/charts/dashboard_competitive.png",
+                },
+                {
+                    "number": 7,
+                    "name": "h2h_heatmap.png",
+                    "title": "H2H Heatmap",
+                    "required": True,
+                    "present": False,
+                    "size_bytes": 0,
+                },
+            ],
+            "chart_data": [],
+        }
+        md = render_manifest_markdown(manifest)
+        assert "## Charts" in md
+        assert "| # |" in md
+        assert "| 1 |" in md
+        assert "Competitive Dashboard" in md
+        assert "present" in md
+        assert "| 7 |" in md
+        assert "absent" in md
+
+
+# ──────────────────────────────────────────────
+#  Full Report Integration (with fixtures)
+# ──────────────────────────────────────────────
+
+
+@pytest.mark.skipif(not FIXTURES_DIR.exists(), reason="Fixture directory not available")
+class TestReportWithFixtures:
+    @pytest.fixture
+    def report_dir(self, tmp_path):
+        """Prepare a report directory with tables from fixtures."""
+        from bid_euchre.arc_d_v2.tables import generate_all_tables
+
+        report_dir = tmp_path / "report"
+        tables_dir = report_dir / "tables"
+        charts_dir = report_dir / "charts"
+        charts_dir.mkdir(parents=True, exist_ok=True)
+
+        generate_all_tables(FIXTURES_DIR, tables_dir)
+        return report_dir
+
+    def test_has_all_sections(self, report_dir):
+        content = generate_report(report_dir)
+        for section in [
+            "## 1. Data Sanity",
+            "## 2. Offline Model Performance",
+            "## 6. Comparator Rankings",
+            "## 7. H2H Battery",
+            "## 8. Behavioral Analysis",
+        ]:
+            assert section in content, f"Missing section: {section}"
+
+    def test_h2h_uses_team_labels(self, report_dir):
+        """H2H section uses team0/team1 labels."""
+        content = generate_report(report_dir)
+        # The H2H table is rendered with team0/team1
+        if "h2h_delta_matrix" not in content or "not yet generated" in content:
+            pytest.skip("H2H data not available in fixtures")
+        assert "team0" in content
+        assert "team1" in content


### PR DESCRIPTION
## Summary
- Add `chart_registry.py` with 22-chart numbered registry (stable numbers, never change based on availability)
- Update `report.py`: numbered chart headings (`### Chart N. Title`), placeholders for missing optional charts, team0/team1 H2H labels, long table truncation (>12 rows)
- Update `manifest.py`: chart inventory with number, title, byte size, presence/absence
- Add 33 new unit tests

## Why
Phase A of `plans/arc_d_v2/full_chart_suite_implementation.md`. Establishes the numbered chart contract that all chart generators and reports render into. Required by the reporting scope plan §4.2.

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_chart_registry.py tests/unit/test_rung_report.py -x -q  # 39 passed, 1 skipped
uv run ruff check src/bid_euchre/arc_d_v2/chart_registry.py src/bid_euchre/arc_d_v2/report.py src/bid_euchre/arc_d_v2/manifest.py
```

## Tests
- `tests/unit/test_chart_registry.py` — 33 tests (registry integrity, lookups, numbered headings, placeholders, team labels, truncation, manifest)
- All existing report/table tests pass

## Worktree proof
```
branch: worktree-agent-ab3dcc38
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)