### PR TITLE
feat: intelligence-faceted H2H chart + 02_decision.md generator

### DIFF
--- a/scripts/internal/generate_rung_charts.py
+++ b/scripts/internal/generate_rung_charts.py
@@ -791,6 +791,83 @@ def _unavailable_panel(ax: plt.Axes, label: str) -> None:
 
 
 # ──────────────────────────────────────────────
+#  Intelligence-faceted H2H chart
+# ──────────────────────────────────────────────
+
+# Tier display colors for consistent tier coloring
+_TIER_COLORS = {
+    "smart": "#4C72B0",
+    "anchor": "#DD8452",
+    "heuristic": "#55A868",
+}
+
+
+def generate_intelligence_faceted_h2h(
+    tables_dir: Path,
+    output_dir: Path,
+    dpi: int = 150,
+) -> bool:
+    """Grouped bar chart of H2H performance faceted by intelligence tier.
+
+    Reads ``h2h_tier_summary.csv`` (columns: model, tier, mean_delta,
+    mean_win_rate, n_opponents) and produces a chart showing each model's
+    mean H2H delta grouped by opponent tier.
+
+    Output: ``h2h_intelligence_faceted.png``
+    """
+    df = _read_csv_safe(tables_dir / "h2h_tier_summary.csv")
+    if df is None:
+        return False
+
+    required_cols = {"model", "tier", "mean_delta"}
+    if not required_cols.issubset(df.columns):
+        logger.warning(
+            "h2h_tier_summary.csv missing required columns: %s",
+            required_cols - set(df.columns),
+        )
+        return False
+
+    tiers = [t for t in ("smart", "anchor", "heuristic") if t in df["tier"].values]
+    if not tiers:
+        logger.warning("No recognized tiers in h2h_tier_summary.csv")
+        return False
+
+    models = sorted(df["model"].unique())
+    model_colors = _get_model_colors(models)
+
+    x = np.arange(len(tiers))
+    width = 0.8 / max(len(models), 1)
+
+    fig, ax = plt.subplots(figsize=(10, max(4, len(models) * 0.6 + 2)))
+
+    for i, model in enumerate(models):
+        vals = []
+        for tier in tiers:
+            row = df[(df["model"] == model) & (df["tier"] == tier)]
+            vals.append(float(row["mean_delta"].iloc[0]) if len(row) > 0 else 0.0)
+        offset = (i - len(models) / 2 + 0.5) * width
+        ax.bar(
+            x + offset,
+            vals,
+            width,
+            label=model,
+            color=model_colors[model],
+        )
+
+    ax.set_xticks(x)
+    ax.set_xticklabels([f"vs {t}" for t in tiers], fontsize=10)
+    ax.set_ylabel("Mean H2H Delta (net EPPD)", fontsize=10)
+    ax.set_title("H2H Performance by Opponent Intelligence Tier", fontsize=12)
+    ax.axhline(y=0, color="gray", linestyle="--", linewidth=0.5)
+    ax.legend(fontsize=8, loc="best")
+    ax.grid(axis="y", alpha=0.3)
+
+    fig.tight_layout()
+    _save_chart(fig, output_dir, "h2h_intelligence_faceted.png", dpi)
+    return True
+
+
+# ──────────────────────────────────────────────
 #  Dashboard: Competitive
 # ──────────────────────────────────────────────
 
@@ -1310,6 +1387,10 @@ def generate_all_charts(
         (
             "mae_by_contract.png",
             lambda: generate_mae_by_contract(tables_dir, output_dir, dpi),
+        ),
+        (
+            "h2h_intelligence_faceted.png",
+            lambda: generate_intelligence_faceted_h2h(tables_dir, output_dir, dpi),
         ),
     ]
 

--- a/scripts/internal/generate_rung_report.py
+++ b/scripts/internal/generate_rung_report.py
@@ -3,9 +3,16 @@
 
 Canonical domain logic lives in ``bid_euchre.arc_d_v2.report``.
 
+Generates both:
+- ``01_results.md`` — full results report
+- ``02_decision.md`` — concise decision report
+
 Usage:
     uv run python scripts/internal/generate_rung_report.py \\
         --report-dir /tmp/rung_report
+
+    uv run python scripts/internal/generate_rung_report.py \\
+        --report-dir /tmp/rung_report --rung R3 --mode QUICK
 """
 
 from __future__ import annotations
@@ -14,7 +21,7 @@ import argparse
 import logging
 from pathlib import Path
 
-from bid_euchre.arc_d_v2.report import generate_report
+from bid_euchre.arc_d_v2.report import generate_decision_report, generate_report
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +43,16 @@ def main() -> None:
         help="Output file path (default: report-dir/01_results.md)",
     )
     parser.add_argument(
+        "--rung",
+        default="?",
+        help="Rung identifier (e.g., R0, R3) for decision report",
+    )
+    parser.add_argument(
+        "--mode",
+        default="QUICK",
+        help="Compute mode (e.g., QUICK, FULL) for decision report",
+    )
+    parser.add_argument(
         "--verbose",
         "-v",
         action="store_true",
@@ -49,12 +66,26 @@ def main() -> None:
         format="%(levelname)s: %(message)s",
     )
 
+    # 01_results.md
     report_content = generate_report(args.report_dir)
-
     output_path = args.output or (args.report_dir / "01_results.md")
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(report_content)
     logger.info("Wrote report: %s", output_path)
+
+    # 02_decision.md
+    tables_dir = args.report_dir / "tables"
+    charts_dir = args.report_dir / "charts"
+    chart_data_dir = args.report_dir / "chart_data"
+    decision_path = output_path.parent / "02_decision.md"
+    generate_decision_report(
+        tables_dir=tables_dir,
+        charts_dir=charts_dir,
+        chart_data_dir=chart_data_dir if chart_data_dir.exists() else None,
+        output_path=decision_path,
+        rung=args.rung,
+        mode=args.mode,
+    )
 
 
 if __name__ == "__main__":

--- a/src/bid_euchre/arc_d_v2/report.py
+++ b/src/bid_euchre/arc_d_v2/report.py
@@ -1,8 +1,10 @@
 """Markdown rung report generation from canonical CSV tables and chart PNGs.
 
-Reads CSVs from tables/ and PNGs from charts/ and renders a structured
-markdown report (01_results.md) with sections matching the canonical
-rung report structure.
+Reads CSVs from tables/ and PNGs from charts/ and renders structured
+markdown reports:
+
+- ``01_results.md`` — full results report with all sections
+- ``02_decision.md`` — concise decision report with advancement recommendation
 
 Extracted from ``scripts/internal/generate_rung_report.py``.
 """
@@ -285,3 +287,237 @@ def generate_report(report_dir: Path) -> str:
     lines.append("")
 
     return "\n".join(lines)
+
+
+# ──────────────────────────────────────────────
+#  Decision report (02_decision.md)
+# ──────────────────────────────────────────────
+
+
+def _extract_advancement_decision(
+    hypothesis_outcomes: pd.DataFrame | None,
+) -> str:
+    """Determine advancement decision from hypothesis outcomes.
+
+    Returns one of: ADVANCE, HOLD, HALT, PENDING.
+    """
+    if hypothesis_outcomes is None or len(hypothesis_outcomes) == 0:
+        return "PENDING"
+
+    if "status" not in hypothesis_outcomes.columns:
+        return "PENDING"
+
+    statuses = hypothesis_outcomes["status"].str.upper().tolist()
+    if not statuses:
+        return "PENDING"
+
+    n_fail = sum(1 for s in statuses if s == "FAIL")
+    n_pass = sum(1 for s in statuses if s == "PASS")
+
+    if n_fail > 0:
+        return "HALT"
+    if n_pass == len(statuses):
+        return "ADVANCE"
+    return "HOLD"
+
+
+def _top_n_comparator_table(
+    comparator: pd.DataFrame | None,
+    n: int = 3,
+) -> str:
+    """Build a concise top-N comparator table (pooled facet only)."""
+    if comparator is None:
+        return _table_placeholder("comparator_rankings.csv")
+
+    if "facet" in comparator.columns:
+        pooled = comparator[comparator["facet"] == "pooled"].copy()
+    else:
+        pooled = comparator.copy()
+
+    if len(pooled) == 0:
+        return _table_placeholder("comparator_rankings.csv (pooled)")
+
+    # Sort by net_eppd descending, take top N
+    if "net_eppd" in pooled.columns:
+        pooled = pooled.sort_values("net_eppd", ascending=False).head(n)
+    else:
+        pooled = pooled.head(n)
+
+    # Select display columns
+    display_cols = [
+        c
+        for c in ["model", "net_eppd", "ci_low", "ci_high", "rank"]
+        if c in pooled.columns
+    ]
+    if not display_cols:
+        return _table_placeholder("comparator_rankings.csv")
+
+    return _df_to_markdown(pooled[display_cols])
+
+
+def _h2h_tier_summary_table(
+    h2h_tier: pd.DataFrame | None,
+) -> str:
+    """Build a concise H2H tier summary table using team0/team1 labels."""
+    if h2h_tier is None:
+        return _table_placeholder("h2h_tier_summary.csv")
+
+    required = {"model", "tier", "mean_delta"}
+    if not required.issubset(h2h_tier.columns):
+        return _table_placeholder("h2h_tier_summary.csv")
+
+    # Rename model columns to team0-oriented labels for H2H context
+    display = h2h_tier.copy()
+    display = display.rename(columns={"model": "team0_model"})
+
+    display_cols = [
+        c
+        for c in ["team0_model", "tier", "mean_delta", "mean_win_rate", "n_opponents"]
+        if c in display.columns
+    ]
+    return _df_to_markdown(display[display_cols])
+
+
+def _hypothesis_summary_table(
+    outcomes: pd.DataFrame | None,
+) -> str:
+    """Build a concise hypothesis pass/fail summary."""
+    if outcomes is None or len(outcomes) == 0:
+        return "> No hypothesis outcomes available.\n"
+
+    display_cols = [
+        c for c in ["hypothesis_id", "description", "status"] if c in outcomes.columns
+    ]
+    if not display_cols:
+        return _table_placeholder("hypothesis_outcomes.csv")
+
+    return _df_to_markdown(outcomes[display_cols])
+
+
+def generate_decision_report(
+    tables_dir: Path,
+    charts_dir: Path,
+    chart_data_dir: Path | None = None,
+    output_path: Path | None = None,
+    rung: str = "?",
+    mode: str = "QUICK",
+) -> str:
+    """Generate the 02_decision.md report.
+
+    Produces a concise decision-focused report that synthesizes evidence
+    from tables and charts into an advancement recommendation.
+
+    Args:
+        tables_dir: Directory containing ``*.csv`` tables.
+        charts_dir: Directory containing ``*.png`` charts.
+        chart_data_dir: Directory containing chart source CSVs (optional).
+        output_path: If provided, write the report to this file.
+        rung: Rung identifier (e.g., ``"R0"``, ``"R3"``).
+        mode: Compute mode (e.g., ``"QUICK"``, ``"FULL"``).
+
+    Returns:
+        Rendered markdown decision report string.
+    """
+    # Read the key tables
+    hypothesis_outcomes = _read_csv_safe(tables_dir / "hypothesis_outcomes.csv")
+    comparator = _read_csv_safe(tables_dir / "comparator_rankings.csv")
+    h2h_tier = _read_csv_safe(tables_dir / "h2h_tier_summary.csv")
+
+    decision = _extract_advancement_decision(hypothesis_outcomes)
+
+    lines: list[str] = []
+
+    # Title
+    lines.append(f"# Rung {rung} ({mode}) — Decision Report")
+    lines.append("")
+
+    # Advancement Decision
+    lines.append("## Advancement Decision")
+    lines.append("")
+    lines.append(f"**{decision}**")
+    lines.append("")
+
+    # Evidence Summary
+    lines.append("## Evidence Summary")
+    lines.append("")
+
+    # Comparator Standing
+    lines.append("### Comparator Standing")
+    lines.append("")
+    lines.append(_top_n_comparator_table(comparator))
+    lines.append("")
+    lines.append(
+        "See Chart 1 (Comparator Ranking Bars) and "
+        "Chart 4 (Tail Risk Panel) for visual context."
+    )
+    lines.append("")
+
+    # Head-to-Head Performance
+    lines.append("### Head-to-Head Performance")
+    lines.append("")
+    lines.append(_h2h_tier_summary_table(h2h_tier))
+    lines.append("")
+    lines.append(
+        "See Chart 3 (H2H Heatmap), Chart 2 (Delta Bars by Contract), "
+        "and the intelligence-faceted H2H chart for tier-level analysis."
+    )
+    lines.append("")
+
+    # Hypothesis Outcomes
+    lines.append("### Hypothesis Outcomes")
+    lines.append("")
+    lines.append(_hypothesis_summary_table(hypothesis_outcomes))
+    lines.append("")
+
+    # Recommendation
+    lines.append("## Recommendation")
+    lines.append("")
+    if decision == "ADVANCE":
+        lines.append(
+            "All hypothesis checks passed. Evidence supports advancing "
+            "to the next rung."
+        )
+    elif decision == "HALT":
+        n_fail = 0
+        if hypothesis_outcomes is not None and "status" in hypothesis_outcomes.columns:
+            n_fail = (hypothesis_outcomes["status"].str.upper() == "FAIL").sum()
+        lines.append(
+            f"{n_fail} hypothesis check(s) failed. "
+            "Review the failing checks and address root causes before "
+            "re-running this rung."
+        )
+    elif decision == "HOLD":
+        lines.append(
+            "Some hypothesis checks have indeterminate status. "
+            "Additional evidence or manual review is needed."
+        )
+    else:
+        lines.append(
+            "Hypothesis outcomes not yet available. "
+            "Run the advance check pipeline to populate results."
+        )
+    lines.append("")
+
+    # Supporting Evidence
+    lines.append("## Supporting Evidence")
+    lines.append("")
+    lines.append("- Chart 1: Comparator Ranking Bars")
+    lines.append("- Chart 2: Delta Bars by Contract")
+    lines.append("- Chart 3: H2H Heatmap")
+    lines.append("- Chart 4: Tail Risk Panel")
+    lines.append("- Chart 5: Bid Behavior Panel")
+    lines.append("- Chart 9: Intelligence-Faceted H2H")
+    lines.append(
+        "- Full tables: `tables/comparator_rankings.csv`, "
+        "`tables/h2h_delta_matrix.csv`, `tables/h2h_tier_summary.csv`"
+    )
+    lines.append("")
+
+    content = "\n".join(lines)
+
+    if output_path is not None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(content)
+        logger.info("Wrote decision report: %s", output_path)
+
+    return content

--- a/tests/unit/test_rung_charts.py
+++ b/tests/unit/test_rung_charts.py
@@ -1,6 +1,7 @@
 """Tests for diagnostic chart generators in generate_rung_charts.py.
 
 Covers:
+- Intelligence-faceted H2H chart generation
 - predictions scatter plot generation
 - residuals histogram generation
 - calibration curve generation
@@ -116,6 +117,91 @@ def selection_paths_csv(tmp_path):
     chart_data_dir.mkdir()
     df.to_csv(chart_data_dir / "selection_paths.csv", index=False)
     return chart_data_dir
+
+
+# ──────────────────────────────────────────────
+#  Intelligence-faceted H2H tests
+# ──────────────────────────────────────────────
+
+
+@pytest.fixture
+def h2h_tier_summary_csv(tmp_path):
+    """Create an h2h_tier_summary.csv fixture file."""
+    df = pd.DataFrame(
+        {
+            "model": [
+                "gbt_av",
+                "gbt_av",
+                "gbt_av",
+                "ols_av",
+                "ols_av",
+                "ols_av",
+            ],
+            "tier": [
+                "smart",
+                "anchor",
+                "heuristic",
+                "smart",
+                "anchor",
+                "heuristic",
+            ],
+            "mean_delta": [1.2, 0.8, 2.1, -0.3, 0.4, 1.5],
+            "mean_win_rate": [0.58, 0.55, 0.65, 0.48, 0.52, 0.60],
+            "n_opponents": [3, 1, 3, 3, 1, 3],
+        }
+    )
+    tables_dir = tmp_path / "tables"
+    tables_dir.mkdir()
+    df.to_csv(tables_dir / "h2h_tier_summary.csv", index=False)
+    return tables_dir
+
+
+class TestIntelligenceFacetedH2H:
+    """Tests for generate_intelligence_faceted_h2h."""
+
+    def test_produces_png(self, charts_mod, h2h_tier_summary_csv, tmp_path):
+        """Produces h2h_intelligence_faceted.png from valid tier summary CSV."""
+        output_dir = tmp_path / "charts"
+        output_dir.mkdir()
+        result = charts_mod.generate_intelligence_faceted_h2h(
+            h2h_tier_summary_csv, output_dir
+        )
+        assert result is True
+        png_path = output_dir / "h2h_intelligence_faceted.png"
+        assert png_path.exists()
+        assert png_path.stat().st_size > 0
+
+    def test_missing_csv_returns_false(self, charts_mod, tmp_path):
+        """Returns False when h2h_tier_summary.csv is missing."""
+        tables_dir = tmp_path / "tables"
+        tables_dir.mkdir()
+        output_dir = tmp_path / "charts"
+        output_dir.mkdir()
+        result = charts_mod.generate_intelligence_faceted_h2h(tables_dir, output_dir)
+        assert result is False
+
+    def test_missing_columns_returns_false(self, charts_mod, tmp_path):
+        """Returns False when CSV lacks required columns."""
+        tables_dir = tmp_path / "tables"
+        tables_dir.mkdir()
+        df = pd.DataFrame({"model": ["gbt"], "wrong_col": [1.0]})
+        df.to_csv(tables_dir / "h2h_tier_summary.csv", index=False)
+        output_dir = tmp_path / "charts"
+        output_dir.mkdir()
+        result = charts_mod.generate_intelligence_faceted_h2h(tables_dir, output_dir)
+        assert result is False
+
+    def test_wired_into_generate_all_charts(
+        self, charts_mod, h2h_tier_summary_csv, tmp_path
+    ):
+        """generate_all_charts includes intelligence-faceted H2H when data exists."""
+        charts_dir = tmp_path / "charts"
+        generated = charts_mod.generate_all_charts(
+            tables_dir=h2h_tier_summary_csv,
+            output_dir=charts_dir,
+        )
+        assert "h2h_intelligence_faceted.png" in generated
+        assert (charts_dir / "h2h_intelligence_faceted.png").exists()
 
 
 # ──────────────────────────────────────────────

--- a/tests/unit/test_rung_report.py
+++ b/tests/unit/test_rung_report.py
@@ -4,17 +4,22 @@ Covers:
 - Report generates deterministically from fixture CSVs
 - All required sections present
 - Missing tables produce placeholders, not crashes
+- Decision report generates valid markdown
+- Decision report references chart numbers
+- Decision report handles missing data gracefully
+- Decision report uses team0/team1 labels
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
+import pandas as pd
 import pytest
 
 FIXTURES_DIR = Path(__file__).resolve().parents[2] / "data" / "fixtures" / "arc_d_v2"
 
-from bid_euchre.arc_d_v2.report import generate_report
+from bid_euchre.arc_d_v2.report import generate_decision_report, generate_report
 from bid_euchre.arc_d_v2.tables import generate_all_tables
 
 REQUIRED_SECTIONS = [
@@ -84,3 +89,199 @@ class TestReportWithEmptyTables:
         content = generate_report(report_dir)
         assert "# Rung Results Report" in content
         assert "not yet generated" in content
+
+
+# ──────────────────────────────────────────────
+#  Decision report tests
+# ──────────────────────────────────────────────
+
+
+def _make_hypothesis_outcomes(tmp_path, statuses):
+    """Write a hypothesis_outcomes.csv with given statuses."""
+    tables_dir = tmp_path / "tables"
+    tables_dir.mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame(
+        {
+            "hypothesis_id": [f"H{i}" for i in range(len(statuses))],
+            "description": [f"Hypothesis {i}" for i in range(len(statuses))],
+            "status": statuses,
+            "evidence": ["observed=1.0"] * len(statuses),
+            "notes": [""] * len(statuses),
+        }
+    )
+    df.to_csv(tables_dir / "hypothesis_outcomes.csv", index=False)
+    return tables_dir
+
+
+def _make_comparator_rankings(tables_dir):
+    """Write a comparator_rankings.csv fixture."""
+    df = pd.DataFrame(
+        {
+            "model": ["gbt_av", "ols_av", "anchor_hybrid_r0_full"],
+            "facet": ["pooled", "pooled", "pooled"],
+            "net_eppd": [2.3, 1.8, 0.5],
+            "ci_low": [2.0, 1.5, 0.2],
+            "ci_high": [2.6, 2.1, 0.8],
+            "bid_rate": [0.5, 0.4, 0.3],
+            "make_rate": [0.6, 0.5, 0.4],
+            "net_cvar_5": [-1.0, -1.2, -2.0],
+            "rank": [1, 2, 3],
+        }
+    )
+    df.to_csv(tables_dir / "comparator_rankings.csv", index=False)
+
+
+def _make_h2h_tier_summary(tables_dir):
+    """Write an h2h_tier_summary.csv fixture."""
+    df = pd.DataFrame(
+        {
+            "model": ["gbt_av", "gbt_av", "ols_av", "ols_av"],
+            "tier": ["smart", "anchor", "smart", "anchor"],
+            "mean_delta": [1.2, 0.8, -0.3, 0.4],
+            "mean_win_rate": [0.58, 0.55, 0.48, 0.52],
+            "n_opponents": [3, 1, 3, 1],
+        }
+    )
+    df.to_csv(tables_dir / "h2h_tier_summary.csv", index=False)
+
+
+class TestDecisionReport:
+    """Tests for generate_decision_report."""
+
+    @pytest.fixture
+    def tables_with_all_data(self, tmp_path):
+        """Tables directory with hypothesis outcomes, comparator, and H2H tier."""
+        tables_dir = _make_hypothesis_outcomes(tmp_path, ["PASS", "PASS", "PASS"])
+        _make_comparator_rankings(tables_dir)
+        _make_h2h_tier_summary(tables_dir)
+        return tables_dir
+
+    @pytest.fixture
+    def charts_dir(self, tmp_path):
+        charts = tmp_path / "charts"
+        charts.mkdir(parents=True, exist_ok=True)
+        return charts
+
+    def test_generates_valid_markdown(self, tables_with_all_data, charts_dir):
+        """Decision report produces valid non-empty markdown."""
+        content = generate_decision_report(
+            tables_dir=tables_with_all_data,
+            charts_dir=charts_dir,
+            rung="R3",
+            mode="QUICK",
+        )
+        assert len(content) > 100
+        assert "# Rung R3 (QUICK) — Decision Report" in content
+
+    def test_has_required_sections(self, tables_with_all_data, charts_dir):
+        """Decision report contains all required sections."""
+        content = generate_decision_report(
+            tables_dir=tables_with_all_data,
+            charts_dir=charts_dir,
+            rung="R3",
+            mode="QUICK",
+        )
+        assert "## Advancement Decision" in content
+        assert "## Evidence Summary" in content
+        assert "### Comparator Standing" in content
+        assert "### Head-to-Head Performance" in content
+        assert "### Hypothesis Outcomes" in content
+        assert "## Recommendation" in content
+        assert "## Supporting Evidence" in content
+
+    def test_references_chart_numbers(self, tables_with_all_data, charts_dir):
+        """Decision report references specific chart numbers."""
+        content = generate_decision_report(
+            tables_dir=tables_with_all_data,
+            charts_dir=charts_dir,
+        )
+        assert "Chart 1" in content
+        assert "Chart 3" in content
+        assert "Chart 4" in content
+
+    def test_advance_when_all_pass(self, tables_with_all_data, charts_dir):
+        """Reports ADVANCE when all hypothesis checks pass."""
+        content = generate_decision_report(
+            tables_dir=tables_with_all_data,
+            charts_dir=charts_dir,
+        )
+        assert "**ADVANCE**" in content
+
+    def test_halt_when_any_fail(self, tmp_path, charts_dir):
+        """Reports HALT when any hypothesis check fails."""
+        tables_dir = _make_hypothesis_outcomes(tmp_path, ["PASS", "FAIL", "PASS"])
+        content = generate_decision_report(
+            tables_dir=tables_dir,
+            charts_dir=charts_dir,
+        )
+        assert "**HALT**" in content
+        assert "1 hypothesis check(s) failed" in content
+
+    def test_pending_when_no_hypothesis_outcomes(self, tmp_path, charts_dir):
+        """Reports PENDING when hypothesis_outcomes.csv is missing."""
+        tables_dir = tmp_path / "tables"
+        tables_dir.mkdir(parents=True, exist_ok=True)
+        content = generate_decision_report(
+            tables_dir=tables_dir,
+            charts_dir=charts_dir,
+        )
+        assert "**PENDING**" in content
+        assert "not yet available" in content
+
+    def test_uses_team0_labels(self, tables_with_all_data, charts_dir):
+        """Decision report uses team0/team1 labeling for H2H data."""
+        content = generate_decision_report(
+            tables_dir=tables_with_all_data,
+            charts_dir=charts_dir,
+        )
+        assert "team0_model" in content
+
+    def test_top_3_comparator_table(self, tables_with_all_data, charts_dir):
+        """Decision report includes top-3 comparator models."""
+        content = generate_decision_report(
+            tables_dir=tables_with_all_data,
+            charts_dir=charts_dir,
+        )
+        assert "gbt_av" in content
+        assert "ols_av" in content
+
+    def test_writes_to_output_path(self, tables_with_all_data, charts_dir, tmp_path):
+        """Decision report writes to the specified output path."""
+        output_path = tmp_path / "output" / "02_decision.md"
+        generate_decision_report(
+            tables_dir=tables_with_all_data,
+            charts_dir=charts_dir,
+            output_path=output_path,
+            rung="R0",
+            mode="FULL",
+        )
+        assert output_path.exists()
+        content = output_path.read_text()
+        assert "# Rung R0 (FULL) — Decision Report" in content
+
+    def test_deterministic(self, tables_with_all_data, charts_dir):
+        """Decision report generates identically on two runs."""
+        content1 = generate_decision_report(
+            tables_dir=tables_with_all_data,
+            charts_dir=charts_dir,
+            rung="R3",
+        )
+        content2 = generate_decision_report(
+            tables_dir=tables_with_all_data,
+            charts_dir=charts_dir,
+            rung="R3",
+        )
+        assert content1 == content2
+
+    def test_graceful_with_empty_tables(self, tmp_path, charts_dir):
+        """Decision report renders gracefully with empty tables directory."""
+        tables_dir = tmp_path / "tables"
+        tables_dir.mkdir(parents=True, exist_ok=True)
+        content = generate_decision_report(
+            tables_dir=tables_dir,
+            charts_dir=charts_dir,
+        )
+        assert "# Rung" in content
+        assert "**PENDING**" in content
+        # Should not crash, should have placeholder text
+        assert "not yet generated" in content or "not yet available" in content


### PR DESCRIPTION
## Summary
- Add `generate_intelligence_faceted_h2h()` chart generator using `h2h_tier_summary.csv` (smart/anchor/heuristic tiers)
- Add `generate_decision_report()` to report.py — generates `02_decision.md` with advancement decision, numbered chart citations, concise summary tables, team0/team1 labels
- Wire `02_decision.md` generation into `generate_rung_report.py`
- Add 15 new tests (4 chart + 11 report)

## Why
Phase D of `plans/arc_d_v2/full_chart_suite_implementation.md`. Closes gaps G3 (intelligence-faceted H2H) and G10 (02_decision.md generation) from the full chart suite scope.

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_rung_charts.py tests/unit/test_rung_report.py -x -q  # 33 passed
```

## Tests
- `test_rung_charts.py`: 4 new tests (PNG generation, missing CSV, missing columns, pipeline wiring)
- `test_rung_report.py`: 11 new tests (markdown structure, chart references, ADVANCE/HALT/PENDING logic, team labels, file output)

## Worktree proof
```
branch: worktree-agent-a680945e
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)