### PR TITLE
refactor: Option B — add subdir field to ChartEntry, remove basename fallback

### DIFF
--- a/src/bid_euchre/arc_d_v2/chart_registry.py
+++ b/src/bid_euchre/arc_d_v2/chart_registry.py
@@ -12,16 +12,25 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+# Shorthand for the standalone chart subdirectory.
+_FCS = "full_chart_suite"
+
 
 @dataclass(frozen=True)
 class ChartEntry:
     """A single chart in the registry."""
 
     number: int
-    filename: str
+    filename: str  # Bare name (stable identifier, no directory prefix)
     title: str
     required: bool
     source: str
+    subdir: str = ""  # "" for dashboards, "full_chart_suite" for standalone
+
+    @property
+    def path(self) -> str:
+        """Full relative path including subdirectory prefix."""
+        return f"{self.subdir}/{self.filename}" if self.subdir else self.filename
 
 
 CHART_REGISTRY: tuple[ChartEntry, ...] = (
@@ -48,143 +57,163 @@ CHART_REGISTRY: tuple[ChartEntry, ...] = (
     ),
     ChartEntry(
         4,
-        "full_chart_suite/comparator_ranking_bars.png",
+        "comparator_ranking_bars.png",
         "Comparator Ranking Bars",
         True,
         "tables/comparator_rankings.csv",
+        subdir=_FCS,
     ),
     ChartEntry(
         5,
-        "full_chart_suite/tail_risk_panel.png",
+        "tail_risk_panel.png",
         "Tail Risk Panel",
         True,
         "tables/comparator_rankings.csv",
+        subdir=_FCS,
     ),
     ChartEntry(
         6,
-        "full_chart_suite/delta_bars_by_contract.png",
+        "delta_bars_by_contract.png",
         "H2H Delta by Contract",
         True,
         "tables/h2h_delta_matrix.csv",
+        subdir=_FCS,
     ),
     ChartEntry(
         7,
-        "full_chart_suite/h2h_heatmap.png",
+        "h2h_heatmap.png",
         "H2H Heatmap",
         True,
         "tables/h2h_delta_matrix.csv",
+        subdir=_FCS,
     ),
     ChartEntry(
         8,
-        "full_chart_suite/h2h_ranking_scatter.png",
+        "h2h_ranking_scatter.png",
         "H2H Ranking Scatter",
         False,
         "tables/comparator_rankings.csv + h2h_tier_summary.csv",
+        subdir=_FCS,
     ),
     ChartEntry(
         9,
-        "full_chart_suite/outcome_distributions.png",
+        "outcome_distributions.png",
         "Outcome Distributions",
         False,
         "chart_data/outcome_distributions.csv",
+        subdir=_FCS,
     ),
     ChartEntry(
         10,
-        "full_chart_suite/seat_balance.png",
+        "seat_balance.png",
         "Seat Balance",
         False,
         "chart_data/seat_balance.csv",
+        subdir=_FCS,
     ),
     ChartEntry(
         11,
-        "full_chart_suite/contract_mix_bars.png",
+        "contract_mix_bars.png",
         "Contract Mix",
         True,
         "chart_data/contract_mix.csv",
+        subdir=_FCS,
     ),
     ChartEntry(
         12,
-        "full_chart_suite/bid_behavior_panel.png",
+        "bid_behavior_panel.png",
         "Bid and Make Rates",
         True,
         "tables/behavior_summary.csv",
+        subdir=_FCS,
     ),
     ChartEntry(
         13,
-        "full_chart_suite/bid_level_distribution.png",
+        "bid_level_distribution.png",
         "Bid Level Distribution",
         False,
         "chart_data/bid_levels.csv",
+        subdir=_FCS,
     ),
     ChartEntry(
         14,
-        "full_chart_suite/r2_by_contract.png",
+        "r2_by_contract.png",
         "R-squared by Contract",
         True,
         "tables/model_performance.csv",
+        subdir=_FCS,
     ),
     ChartEntry(
         15,
-        "full_chart_suite/mae_by_contract.png",
+        "mae_by_contract.png",
         "MAE by Contract",
         True,
         "tables/model_performance.csv",
+        subdir=_FCS,
     ),
     ChartEntry(
         16,
-        "full_chart_suite/pred_vs_actual.png",
+        "pred_vs_actual.png",
         "Predicted vs Actual",
         False,
         "chart_data/predictions.csv",
+        subdir=_FCS,
     ),
     ChartEntry(
         17,
-        "full_chart_suite/residual_distribution.png",
+        "residual_distribution.png",
         "Residual Distribution",
         False,
         "chart_data/residuals.csv",
+        subdir=_FCS,
     ),
     ChartEntry(
         18,
-        "full_chart_suite/calibration_curve.png",
+        "calibration_curve.png",
         "Calibration Curve",
         False,
         "chart_data/calibration_bins.csv",
+        subdir=_FCS,
     ),
     ChartEntry(
         19,
-        "full_chart_suite/selection_path.png",
+        "selection_path.png",
         "Selection Path",
         False,
         "chart_data/selection_paths.csv",
+        subdir=_FCS,
     ),
     ChartEntry(
         20,
-        "full_chart_suite/feature_importance.png",
+        "feature_importance.png",
         "Feature Importance",
         False,
         "chart_data/selection_paths.csv",
+        subdir=_FCS,
     ),
     ChartEntry(
         21,
-        "full_chart_suite/decision_agreement.png",
+        "decision_agreement.png",
         "Decision Agreement",
         False,
         "chart_data/decision_comparison.csv",
+        subdir=_FCS,
     ),
     ChartEntry(
         22,
-        "full_chart_suite/disagreement_outcomes.png",
+        "disagreement_outcomes.png",
         "Disagreement Outcomes",
         False,
         "chart_data/disagreement_outcomes.csv",
+        subdir=_FCS,
     ),
     ChartEntry(
         23,
-        "full_chart_suite/h2h_intelligence_faceted.png",
+        "h2h_intelligence_faceted.png",
         "Intelligence-Faceted H2H",
         False,
         "tables/h2h_tier_summary.csv",
+        subdir=_FCS,
     ),
 )
 
@@ -198,14 +227,8 @@ def get_chart_by_number(n: int) -> ChartEntry | None:
 
 
 def get_chart_by_filename(filename: str) -> ChartEntry | None:
-    """Look up a chart entry by its PNG filename (with or without prefix)."""
+    """Look up a chart entry by its bare PNG filename."""
     for entry in CHART_REGISTRY:
         if entry.filename == filename:
-            return entry
-    # Also match by basename for backward compatibility
-    for entry in CHART_REGISTRY:
-        if entry.filename.endswith("/" + filename) or (
-            "/" not in filename and entry.filename.split("/")[-1] == filename
-        ):
             return entry
     return None

--- a/src/bid_euchre/arc_d_v2/manifest.py
+++ b/src/bid_euchre/arc_d_v2/manifest.py
@@ -103,26 +103,28 @@ def _inventory_chart_dir(charts_dir: Path) -> list[dict]:
     seen_filenames: set[str] = set()
 
     for chart in CHART_REGISTRY:
+        chart_path = chart.path
         entry: dict = {
             "number": chart.number,
-            "name": chart.filename,
+            "name": chart_path,
             "title": chart.title,
             "required": chart.required,
         }
-        if chart.filename in on_disk:
+        if chart_path in on_disk:
             entry["present"] = True
-            entry["size_bytes"] = on_disk[chart.filename]
-            entry["path"] = str(charts_dir / chart.filename)
+            entry["size_bytes"] = on_disk[chart_path]
+            entry["path"] = str(charts_dir / chart_path)
         else:
             entry["present"] = False
             entry["size_bytes"] = 0
         entries.append(entry)
-        seen_filenames.add(chart.filename)
+        seen_filenames.add(chart_path)
 
     # Include any extra PNGs not in the registry
     for name, size in sorted(on_disk.items()):
         if name not in seen_filenames:
-            entry_extra = get_chart_by_filename(name)
+            bare = name.rsplit("/", 1)[-1]
+            entry_extra = get_chart_by_filename(bare)
             entries.append(
                 {
                     "name": name,

--- a/src/bid_euchre/arc_d_v2/report.py
+++ b/src/bid_euchre/arc_d_v2/report.py
@@ -46,9 +46,14 @@ def _table_placeholder(table_name: str) -> str:
     return f"> [table_name={table_name}] not yet generated\n"
 
 
+def _bare_filename(chart_name: str) -> str:
+    """Extract bare filename from a chart path (strip directory prefix)."""
+    return chart_name.rsplit("/", 1)[-1]
+
+
 def _chart_placeholder(chart_name: str) -> str:
     """Return a placeholder for a missing chart."""
-    entry = get_chart_by_filename(chart_name)
+    entry = get_chart_by_filename(_bare_filename(chart_name))
     if entry is not None:
         return (
             f"### Chart {entry.number}. {entry.title}\n\n"
@@ -116,7 +121,7 @@ def _chart_embed(charts_dir: Path, chart_name: str) -> str:
     The ``chart_name`` may include the ``full_chart_suite/`` prefix for
     standalone charts (4-23). The file is looked up relative to charts_dir.
     """
-    entry = get_chart_by_filename(chart_name)
+    entry = get_chart_by_filename(_bare_filename(chart_name))
     chart_path = charts_dir / chart_name
     if chart_path.exists():
         if entry is not None:
@@ -509,13 +514,13 @@ def generate_decision_report(
     lines.append("")
     lines.append(_top_n_comparator_table(comparator))
     lines.append("")
-    comp_bars = get_chart_by_filename("full_chart_suite/comparator_ranking_bars.png")
+    comp_bars = get_chart_by_filename("comparator_ranking_bars.png")
     comp_ref = (
         f"Chart {comp_bars.number} ({comp_bars.title})"
         if comp_bars
         else "Comparator Ranking Bars"
     )
-    tail_risk = get_chart_by_filename("full_chart_suite/tail_risk_panel.png")
+    tail_risk = get_chart_by_filename("tail_risk_panel.png")
     tail_ref = (
         f"Chart {tail_risk.number} ({tail_risk.title})"
         if tail_risk
@@ -529,19 +534,19 @@ def generate_decision_report(
     lines.append("")
     lines.append(_h2h_tier_summary_table(h2h_tier))
     lines.append("")
-    h2h_heatmap = get_chart_by_filename("full_chart_suite/h2h_heatmap.png")
+    h2h_heatmap = get_chart_by_filename("h2h_heatmap.png")
     h2h_heat_ref = (
         f"Chart {h2h_heatmap.number} ({h2h_heatmap.title})"
         if h2h_heatmap
         else "H2H Heatmap"
     )
-    delta_bars = get_chart_by_filename("full_chart_suite/delta_bars_by_contract.png")
+    delta_bars = get_chart_by_filename("delta_bars_by_contract.png")
     delta_ref = (
         f"Chart {delta_bars.number} ({delta_bars.title})"
         if delta_bars
         else "Delta Bars by Contract"
     )
-    intel_h2h = get_chart_by_filename("full_chart_suite/h2h_intelligence_faceted.png")
+    intel_h2h = get_chart_by_filename("h2h_intelligence_faceted.png")
     intel_ref = (
         f"Chart {intel_h2h.number} ({intel_h2h.title})"
         if intel_h2h
@@ -591,19 +596,19 @@ def generate_decision_report(
     lines.append("## Supporting Evidence")
     lines.append("")
     evidence_charts = [
-        "full_chart_suite/comparator_ranking_bars.png",
-        "full_chart_suite/delta_bars_by_contract.png",
-        "full_chart_suite/h2h_heatmap.png",
-        "full_chart_suite/tail_risk_panel.png",
-        "full_chart_suite/bid_behavior_panel.png",
-        "full_chart_suite/h2h_intelligence_faceted.png",
+        "comparator_ranking_bars.png",
+        "delta_bars_by_contract.png",
+        "h2h_heatmap.png",
+        "tail_risk_panel.png",
+        "bid_behavior_panel.png",
+        "h2h_intelligence_faceted.png",
     ]
     for chart_file in evidence_charts:
         entry = get_chart_by_filename(chart_file)
         if entry:
             lines.append(f"- Chart {entry.number}: {entry.title}")
         else:
-            basename = chart_file.split("/")[-1].replace(".png", "").replace("_", " ")
+            basename = chart_file.replace(".png", "").replace("_", " ")
             lines.append(f"- {basename}")
     lines.append(
         "- Full tables: `tables/comparator_rankings.csv`, "

--- a/tests/unit/test_chart_registry.py
+++ b/tests/unit/test_chart_registry.py
@@ -2,9 +2,9 @@
 
 Covers:
 - Chart registry has exactly 23 entries with unique numbers and filenames
-- Charts 4-23 use full_chart_suite/ prefix, charts 1-3 are plain dashboards
+- Charts 4-23 have subdir="full_chart_suite", charts 1-3 have subdir=""
+- entry.filename is always a bare name (no /), entry.path includes subdir
 - get_chart_by_number() and get_chart_by_filename() work correctly
-- get_chart_by_filename() backward-compatible basename lookup
 - Report rendering uses numbered headings (Chart N. Title)
 - Report rendering emits placeholders for missing optional charts
 - H2H table rendering uses team0/team1 labels
@@ -66,23 +66,43 @@ class TestChartRegistry:
         for entry in CHART_REGISTRY:
             assert entry.filename.endswith(".png"), f"{entry.filename} is not a PNG"
 
-    def test_dashboards_plain_filenames(self):
-        """Charts 1-3 (dashboards) have plain filenames without subdirectory."""
+    def test_no_filename_contains_slash(self):
+        """All filenames are bare names without directory separators."""
+        for entry in CHART_REGISTRY:
+            assert (
+                "/" not in entry.filename
+            ), f"Chart {entry.number} filename should be bare: {entry.filename}"
+
+    def test_dashboards_have_empty_subdir(self):
+        """Charts 1-3 (dashboards) have subdir=''."""
         for n in (1, 2, 3):
             entry = get_chart_by_number(n)
             assert entry is not None
-            assert (
-                "/" not in entry.filename
-            ), f"Dashboard chart {n} should not have subdirectory prefix"
+            assert entry.subdir == "", f"Dashboard chart {n} should have empty subdir"
 
-    def test_standalone_charts_have_suite_prefix(self):
-        """Charts 4-23 (standalone) have full_chart_suite/ prefix."""
+    def test_standalone_charts_have_suite_subdir(self):
+        """Charts 4-23 (standalone) have subdir='full_chart_suite'."""
         for n in range(4, 24):
             entry = get_chart_by_number(n)
             assert entry is not None
-            assert entry.filename.startswith(
-                "full_chart_suite/"
-            ), f"Chart {n} ({entry.filename}) should have full_chart_suite/ prefix"
+            assert (
+                entry.subdir == "full_chart_suite"
+            ), f"Chart {n} should have subdir='full_chart_suite'"
+
+    def test_path_property_dashboards(self):
+        """Dashboard path equals filename (no subdir prefix)."""
+        for n in (1, 2, 3):
+            entry = get_chart_by_number(n)
+            assert entry is not None
+            assert entry.path == entry.filename
+
+    def test_path_property_standalone(self):
+        """Standalone chart path includes subdir prefix."""
+        for n in range(4, 24):
+            entry = get_chart_by_number(n)
+            assert entry is not None
+            assert entry.path == f"full_chart_suite/{entry.filename}"
+            assert entry.path.startswith("full_chart_suite/")
 
     def test_entries_are_frozen(self):
         entry = CHART_REGISTRY[0]
@@ -97,12 +117,14 @@ class TestChartRegistry:
         assert hasattr(entry, "title")
         assert hasattr(entry, "required")
         assert hasattr(entry, "source")
+        assert hasattr(entry, "subdir")
 
     def test_chart_23_is_intelligence_faceted_h2h(self):
         """Chart 23 is the intelligence-faceted H2H chart."""
         entry = get_chart_by_number(23)
         assert entry is not None
-        assert entry.filename == "full_chart_suite/h2h_intelligence_faceted.png"
+        assert entry.filename == "h2h_intelligence_faceted.png"
+        assert entry.path == "full_chart_suite/h2h_intelligence_faceted.png"
         assert entry.title == "Intelligence-Faceted H2H"
 
 
@@ -140,17 +162,16 @@ class TestGetChartByFilename:
             assert entry is not None
             assert entry.number == reg_entry.number
 
-    def test_backward_compatible_basename_lookup(self):
-        """Looking up by basename (without prefix) finds the entry."""
+    def test_bare_filename_lookup_for_standalone(self):
+        """Looking up by bare filename finds standalone charts."""
         entry = get_chart_by_filename("comparator_ranking_bars.png")
         assert entry is not None
         assert entry.number == 4
 
-    def test_full_path_lookup(self):
-        """Looking up by full prefixed filename works."""
+    def test_prefixed_path_does_not_match(self):
+        """Looking up by full path does NOT match (filename is bare only)."""
         entry = get_chart_by_filename("full_chart_suite/comparator_ranking_bars.png")
-        assert entry is not None
-        assert entry.number == 4
+        assert entry is None
 
 
 # ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `subdir` field to `ChartEntry` dataclass (`""` for dashboards, `"full_chart_suite"` for standalone)
- Add `path` property that computes relative path from charts/ root
- Revert `filename` to bare names (stable identifiers for lookups)
- Simplify `get_chart_by_filename()` — remove basename fallback loop
- Update report.py, manifest.py, and tests for new field

## Why
The previous implementation stored full paths in `filename` (e.g., `"full_chart_suite/comparator_ranking_bars.png"`) and used a basename fallback in lookups. Option B separates identity (bare `filename`) from layout (`subdir`), making lookups simple and layout changes a display concern.

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_chart_registry.py tests/unit/test_rung_report.py tests/unit/test_rung_charts.py tests/unit/test_rung_tables.py -x -q
# 208 passed, 1 skipped
```

## Tests
- Updated 8 test methods in test_chart_registry.py for subdir/path semantics
- All 208 tests pass

## Worktree proof
```
branch: worktree-agent-ad9de158
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)