### PR TITLE
fix: CI poller hook fails when push originates from worktree

### DIFF
--- a/.claude/hooks/post-push-ci-check.sh
+++ b/.claude/hooks/post-push-ci-check.sh
@@ -7,6 +7,23 @@
 set -euo pipefail
 
 INPUT=$(cat)
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"
+
+git_in_project() {
+    git -C "$PROJECT_DIR" "$@"
+}
+
+gh_in_project() {
+    (
+        cd "$PROJECT_DIR"
+        gh "$@"
+    )
+}
+
+sanitize_token() {
+    printf '%s' "$1" | sed 's#[^A-Za-z0-9._-]#_#g'
+}
 
 # Only trigger for git push commands that succeeded
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
@@ -17,28 +34,29 @@ if [[ "$COMMAND" == *"git push"* ]] && [[ "$EXIT_CODE" == "0" ]] \
    && [[ "$COMMAND" != *"--delete"* ]] && [[ "$COMMAND" != *" :"* ]]; then
 
     # Determine current branch
-    BRANCH=$(git branch --show-current 2>/dev/null || true)
+    BRANCH=$(git_in_project branch --show-current 2>/dev/null || true)
     if [ -z "$BRANCH" ] || [ "$BRANCH" = "main" ]; then
         exit 0
     fi
 
     # Dedupe: don't trigger twice for the same push
-    HEAD_SHA=$(git rev-parse --short HEAD 2>/dev/null || true)
-    SENTINEL="/tmp/.claude-push-ci-check-${BRANCH}-${HEAD_SHA}"
+    HEAD_SHA=$(git_in_project rev-parse --short HEAD 2>/dev/null || true)
+    SAFE_BRANCH=$(sanitize_token "$BRANCH")
+    SENTINEL="/tmp/.claude-push-ci-check-${SAFE_BRANCH}-${HEAD_SHA}"
     if [ -f "$SENTINEL" ]; then
         exit 0
     fi
     touch "$SENTINEL"
 
     # Check if a PR exists for this branch
-    PR_NUM=$(gh pr view --json number --jq '.number' 2>/dev/null || echo "")
+    PR_NUM=$(gh_in_project pr view --json number --jq '.number' 2>/dev/null || echo "")
     if [ -z "$PR_NUM" ]; then
         # No PR yet — nothing to monitor
         exit 0
     fi
 
     # Locate the CI poller script
-    REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+    REPO_ROOT=$(git_in_project rev-parse --show-toplevel 2>/dev/null || echo "")
     POLLER="${REPO_ROOT}/scripts/internal/ci_poller.sh"
 
     if [ ! -f "$POLLER" ]; then
@@ -46,7 +64,10 @@ if [[ "$COMMAND" == *"git push"* ]] && [[ "$EXIT_CODE" == "0" ]] \
     fi
 
     # Launch CI poller in background with auto-merge enabled
-    bash "$POLLER" --pr "$PR_NUM" --auto-merge &
+    (
+        cd "$REPO_ROOT"
+        bash "$POLLER" --pr "$PR_NUM" --repo-root "$REPO_ROOT" --auto-merge
+    ) &
 
     cat <<EOF
 {

--- a/scripts/internal/ci_poller.sh
+++ b/scripts/internal/ci_poller.sh
@@ -5,7 +5,7 @@
 # Designed to be launched by post-push-ci-check.sh hook.
 #
 # Usage:
-#   ci_poller.sh --pr <N> [--auto-merge] [--timeout <seconds>] [--interval <seconds>]
+#   ci_poller.sh --pr <N> [--repo-root <path>] [--auto-merge] [--timeout <seconds>] [--interval <seconds>]
 #
 # State:
 #   .claude/runtime/ci_polls/pr_<N>/status.json — current polling state
@@ -21,6 +21,7 @@ set -euo pipefail
 
 # Defaults
 PR_NUM=""
+REPO_ROOT=""
 AUTO_MERGE=false
 TIMEOUT=900   # 15 minutes
 INTERVAL=30   # 30 seconds
@@ -30,6 +31,7 @@ STARTUP_DELAY=15  # seconds to wait before first poll (allows review loop to cla
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --pr) PR_NUM="$2"; shift 2 ;;
+        --repo-root) REPO_ROOT="$2"; shift 2 ;;
         --auto-merge) AUTO_MERGE=true; shift ;;
         --timeout) TIMEOUT="$2"; shift 2 ;;
         --interval) INTERVAL="$2"; shift 2 ;;
@@ -44,11 +46,18 @@ if [ -z "$PR_NUM" ]; then
 fi
 
 # Locate repo root
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+if [ -n "$REPO_ROOT" ]; then
+    REPO_ROOT=$(cd "$REPO_ROOT" 2>/dev/null && pwd || echo "")
+else
+    REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+fi
+
 if [ -z "$REPO_ROOT" ]; then
     echo "Error: not in a git repo" >&2
     exit 3
 fi
+
+cd "$REPO_ROOT"
 
 # State directory
 STATE_DIR="${REPO_ROOT}/.claude/runtime/ci_polls/pr_${PR_NUM}"

--- a/tests/unit/test_post_push_ci_check_hook.py
+++ b/tests/unit/test_post_push_ci_check_hook.py
@@ -1,0 +1,122 @@
+"""Regression tests for the post-push CI polling hook."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_PATH = REPO_ROOT / ".claude" / "hooks" / "post-push-ci-check.sh"
+
+
+def _run(
+    cmd: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _wait_for_file(path: Path, timeout_s: float = 3.0) -> None:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if path.exists():
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"Timed out waiting for {path}")
+
+
+def test_post_push_hook_uses_project_dir_and_sanitizes_branch(
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "worktree"
+    project_dir.mkdir()
+
+    _run(["git", "init"], cwd=project_dir)
+    _run(["git", "config", "user.name", "Test User"], cwd=project_dir)
+    _run(["git", "config", "user.email", "test@example.com"], cwd=project_dir)
+
+    (project_dir / "README.md").write_text("hook test\n", encoding="utf-8")
+    _run(["git", "add", "README.md"], cwd=project_dir)
+    _run(["git", "commit", "-m", "init"], cwd=project_dir)
+    _run(["git", "checkout", "-b", "fix/test-poller"], cwd=project_dir)
+
+    (project_dir / "scripts" / "internal").mkdir(parents=True)
+    poller_cwd = project_dir / "poller.cwd"
+    poller_args = project_dir / "poller.args"
+    _write_executable(
+        project_dir / "scripts" / "internal" / "ci_poller.sh",
+        f"""#!/bin/bash
+set -euo pipefail
+printf '%s\\n' "$PWD" > "{poller_cwd}"
+printf '%s\\n' "$@" > "{poller_args}"
+""",
+    )
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    gh_cwd = project_dir / "gh.cwd"
+    _write_executable(
+        bin_dir / "gh",
+        f"""#!/bin/bash
+set -euo pipefail
+printf '%s\\n' "$PWD" > "{gh_cwd}"
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+    echo 776
+    exit 0
+fi
+echo "unexpected gh args: $*" >&2
+exit 1
+""",
+    )
+
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(project_dir)
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+
+    hook_input = json.dumps(
+        {
+            "tool_input": {"command": "git push origin fix/test-poller"},
+            "tool_response": {"exit_code": 0},
+        }
+    )
+    result = subprocess.run(
+        ["bash", str(HOOK_PATH)],
+        input=hook_input,
+        cwd=tmp_path,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    _wait_for_file(gh_cwd)
+    _wait_for_file(poller_cwd)
+    _wait_for_file(poller_args)
+
+    assert gh_cwd.read_text(encoding="utf-8").strip() == str(project_dir)
+    assert poller_cwd.read_text(encoding="utf-8").strip() == str(project_dir)
+    assert poller_args.read_text(encoding="utf-8").splitlines() == [
+        "--pr",
+        "776",
+        "--repo-root",
+        str(project_dir),
+        "--auto-merge",
+    ]
+    assert "PR #776" in result.stdout


### PR DESCRIPTION
## Summary
- Fix two bugs preventing the post-push CI poller from firing in worktree workflows
- Anchor all git/gh calls to `CLAUDE_PROJECT_DIR` via helper functions (`git_in_project`, `gh_in_project`)
- Sanitize branch tokens in sentinel file paths (branches with `/` like `fix/foo` broke `touch`)
- Pass explicit `--repo-root` to `ci_poller.sh` so it doesn't depend on ambient CWD
- Add regression test reproducing both failure modes

## Why
PR #776 was pushed from a worktree but the CI poller never started. Two independent bugs:
1. Hook resolved `git branch --show-current` and `gh pr view` from ambient CWD — if the hook ran outside the worktree, it saw `main` and exited early
2. Sentinel path used raw branch name (`/tmp/.claude-push-ci-check-fix/foo-...`) — invalid path with `set -euo pipefail` killed the script silently

## Repro / Validation
```bash
# Regression test reproduces both bugs (runs from outside repo, uses slash-named branch)
uv run python -m pytest tests/unit/test_post_push_ci_check_hook.py -q

# Full validation
make check-quiet
```

## Tests
- `uv run python -m pytest tests/unit/test_post_push_ci_check_hook.py` — 1 passed
- `make check-quiet` — all checks passed
- `bash -n .claude/hooks/post-push-ci-check.sh` — syntax OK
- `bash -n scripts/internal/ci_poller.sh` — syntax OK

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-ci-poller-cwd
branch: fix/ci-poller-worktree-cwd
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)