### PR TITLE
fix: H2H config lookup uses mapped mode, not smoke

### DIFF
--- a/src/bid_euchre/arc_d_v2/orchestration.py
+++ b/src/bid_euchre/arc_d_v2/orchestration.py
@@ -1176,7 +1176,7 @@ def execute_step_4(state: RunState, seed: int, dry_run: bool = False) -> bool:
         return False
 
     # Phase 2: Run the actual H2H experiment
-    config_path = artifacts_dir / f"h2h_battery_{state.mode}_config.yaml"
+    config_path = artifacts_dir / f"h2h_battery_{mode_for_h2h.lower()}_config.yaml"
     if not config_path.exists():
         error = f"H2H config not found at {config_path}"
         logger.error("Step 4: %s", error)


### PR DESCRIPTION
## Plan
`plans/arc_d_v2/v2_regeneration_repair_runbook.md` §9.3 (smoke regeneration)

## Summary
- Fix H2H config filename mismatch: orchestrator looked for `h2h_battery_smoke_config.yaml` but the H2H script generates `h2h_battery_quick_config.yaml` (smoke maps to QUICK)

## Why
Step 4 (H2H battery) fails during smoke regeneration because the config file lookup uses `state.mode` ("smoke") instead of the mapped mode ("quick") that was passed to the H2H battery script.

## Repro / Validation
```bash
# Before fix: Step 4 fails with "H2H config not found at .../h2h_battery_smoke_config.yaml"
uv run python scripts/internal/run_rung.py --rung r0 --mode smoke --seed 42

# After fix: Step 4 correctly finds h2h_battery_quick_config.yaml
```

## Tests
- [x] Verified Steps 0-3b pass in smoke mode
- One-line fix, no new tests needed (existing H2H tests don't cover smoke mode mapping)

## Risk level
- [x] Medium (strategy/experiments)

## Worktree proof
`pwd`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-h2h-fix`

## Checklist
- [x] No generated artifacts committed
- [x] PR is focused (one concept)
