### PR TITLE
test: add timeout/error path coverage for review infra

### DIFF
--- a/tests/integration/test_plan_review_loop.py
+++ b/tests/integration/test_plan_review_loop.py
@@ -399,3 +399,149 @@ class TestStateKeyCollision:
         p1.write_text("# Amendments A")
         p2.write_text("# Amendments B")
         assert plan_state_key(p1) != plan_state_key(p2)
+
+
+# --- Failure Scenario Tests ---
+
+from unittest.mock import patch
+
+
+class TestBothReviewersFail:
+    """Test behavior when both Codex and Claude failsafe fail."""
+
+    @patch("plan_review_driver._create_fallback_issue", return_value=None)
+    @patch(
+        "plan_review_driver.invoke_claude_failsafe",
+        return_value=PlanReviewResult(
+            success=False,
+            findings=[],
+            tier="small",
+            reviewer="claude_failsafe",
+            raw_output="",
+            latency_seconds=1.0,
+            error="No command available",
+        ),
+    )
+    @patch(
+        "plan_review_driver.invoke_codex_plan_review",
+        return_value=PlanReviewResult(
+            success=False,
+            findings=[],
+            tier="small",
+            reviewer="codex_cli",
+            raw_output="",
+            latency_seconds=300.0,
+            error="Timeout after 600s",
+        ),
+    )
+    def test_synthetic_critical_injected(
+        self, mock_codex, mock_claude, mock_issue, tmp_path: Path
+    ) -> None:
+        """When both fail, a synthetic CRITICAL finding is injected."""
+        plan = tmp_path / "test.md"
+        plan.write_text("<!-- review-tier: small -->\n# Plan\n")
+        result = run_plan_review_loop(plan, base_dir=tmp_path)
+        assert result.verdict == "NOT_READY"
+        assert result.total_findings == 1
+        finding = result.findings[0]
+        sev = finding.severity if hasattr(finding, "severity") else finding["severity"]
+        desc = (
+            finding.description
+            if hasattr(finding, "description")
+            else finding["description"]
+        )
+        assert sev == "CRITICAL"
+        assert "both Codex CLI and Claude fallback failed" in desc
+
+    @patch("plan_review_driver._create_fallback_issue", return_value=None)
+    @patch(
+        "plan_review_driver.invoke_claude_failsafe",
+        return_value=PlanReviewResult(
+            success=False,
+            findings=[],
+            tier="small",
+            reviewer="claude_failsafe",
+            raw_output="",
+            latency_seconds=1.0,
+            error="Timed out",
+        ),
+    )
+    @patch(
+        "plan_review_driver.invoke_codex_plan_review",
+        return_value=PlanReviewResult(
+            success=False,
+            findings=[],
+            tier="small",
+            reviewer="codex_cli",
+            raw_output="",
+            latency_seconds=600.0,
+            error="Timeout after 600s",
+        ),
+    )
+    def test_state_records_stop_reason(
+        self, mock_codex, mock_claude, mock_issue, tmp_path: Path
+    ) -> None:
+        """State file records correct stop reason when both fail."""
+        plan = tmp_path / "test.md"
+        plan.write_text("<!-- review-tier: small -->\n# Plan\n")
+        run_plan_review_loop(plan, base_dir=tmp_path)
+        state = load_plan_review_state(plan_state_key(plan), tmp_path)
+        assert state is not None
+        assert (
+            "both unavailable" in state.stop_reason.lower()
+            or "fallback" in state.stop_reason.lower()
+        )
+
+
+class TestUnparseableOutput:
+    """Test behavior when Codex returns unparseable output."""
+
+    @patch("plan_review_driver._create_fallback_issue", return_value=None)
+    @patch(
+        "plan_review_driver.invoke_claude_failsafe",
+        return_value=PlanReviewResult(
+            success=True,
+            findings=[
+                PlanReviewFinding(
+                    severity="INFO",
+                    category="convention",
+                    file="test.md",
+                    line=1,
+                    description="Fallback found an issue",
+                    check_id=None,
+                ),
+            ],
+            tier="small",
+            reviewer="claude_failsafe",
+            raw_output="[{}]",
+            latency_seconds=5.0,
+        ),
+    )
+    @patch(
+        "plan_review_driver.invoke_codex_plan_review",
+        return_value=PlanReviewResult(
+            success=False,
+            findings=[],
+            tier="small",
+            reviewer="codex_cli",
+            raw_output="gibberish output",
+            latency_seconds=100.0,
+            error="Unparseable output: no findings matched",
+        ),
+    )
+    def test_fallback_findings_used(
+        self, mock_codex, mock_claude, mock_issue, tmp_path: Path
+    ) -> None:
+        """When Codex fails with unparseable output, Claude failsafe findings are used."""
+        plan = tmp_path / "test.md"
+        plan.write_text("<!-- review-tier: small -->\n# Plan\n")
+        result = run_plan_review_loop(plan, base_dir=tmp_path)
+        assert result.fallback_used is True
+        assert result.total_findings == 1
+        finding = result.findings[0]
+        desc = (
+            finding.description
+            if hasattr(finding, "description")
+            else finding["description"]
+        )
+        assert desc == "Fallback found an issue"

--- a/tests/unit/test_codex_plan_review_adapter.py
+++ b/tests/unit/test_codex_plan_review_adapter.py
@@ -485,3 +485,154 @@ class TestClaudeFailsafeResolution:
                 result = invoke_claude_failsafe(plan, "small")
                 assert result.success is True
                 assert len(result.findings) == 0
+
+
+# --- Timeout and Error Path Tests ---
+
+from subprocess import TimeoutExpired
+
+from codex_plan_review_adapter import invoke_codex_plan_review
+
+
+class TestCodexPlanReviewTimeout:
+    """Test timeout and error paths in invoke_codex_plan_review."""
+
+    @patch("codex_plan_review_adapter._check_codex_auth", return_value=None)
+    @patch(
+        "codex_plan_review_adapter._run_with_pty",
+        return_value=(None, "partial output..."),
+    )
+    @patch("codex_review_adapter._resolve_codex_binary", return_value=["codex"])
+    def test_timeout_returns_failure(self, mock_resolve, mock_pty, mock_auth, tmp_path):
+        """Timeout (returncode=None) produces success=False with Timeout error."""
+        plan = tmp_path / "test.md"
+        plan.write_text("# Plan\n")
+        result = invoke_codex_plan_review(plan, "small", timeout=10)
+        assert result.success is False
+        assert "Timeout" in result.error
+        assert result.reviewer == "codex_cli"
+
+    @patch("codex_plan_review_adapter._check_codex_auth", return_value=None)
+    @patch("codex_plan_review_adapter._run_with_pty", return_value=(None, ""))
+    @patch("codex_review_adapter._resolve_codex_binary", return_value=["codex"])
+    def test_timeout_with_empty_output(
+        self, mock_resolve, mock_pty, mock_auth, tmp_path
+    ):
+        """Timeout with no captured output still returns error."""
+        plan = tmp_path / "test.md"
+        plan.write_text("# Plan\n")
+        result = invoke_codex_plan_review(plan, "medium", timeout=5)
+        assert result.success is False
+        assert "Timeout" in result.error
+        assert result.raw_output == ""
+
+    @patch("codex_plan_review_adapter._check_codex_auth", return_value=None)
+    @patch(
+        "codex_plan_review_adapter._run_with_pty", return_value=(2, "error: bad args")
+    )
+    @patch("codex_review_adapter._resolve_codex_binary", return_value=["codex"])
+    def test_nonzero_exit_returns_failure(
+        self, mock_resolve, mock_pty, mock_auth, tmp_path
+    ):
+        """Non-zero exit code produces success=False with exit code in error."""
+        plan = tmp_path / "test.md"
+        plan.write_text("# Plan\n")
+        result = invoke_codex_plan_review(plan, "small")
+        assert result.success is False
+        assert "Exit code 2" in result.error
+
+    @patch("codex_plan_review_adapter._check_codex_auth", return_value=None)
+    @patch(
+        "codex_plan_review_adapter._run_with_pty",
+        return_value=(0, "Some output that doesn't match any pattern"),
+    )
+    @patch("codex_review_adapter._resolve_codex_binary", return_value=["codex"])
+    def test_unparseable_output_returns_failure(
+        self, mock_resolve, mock_pty, mock_auth, tmp_path
+    ):
+        """Output that matches no findings and no clean signal produces error."""
+        plan = tmp_path / "test.md"
+        plan.write_text("# Plan\n")
+        result = invoke_codex_plan_review(plan, "small")
+        assert result.success is False
+        assert "Unparseable output" in result.error
+
+    @patch("codex_plan_review_adapter._check_codex_auth", return_value=None)
+    @patch(
+        "codex_plan_review_adapter._run_with_pty", return_value=(None, "partial review")
+    )
+    @patch("codex_review_adapter._resolve_codex_binary", return_value=["codex"])
+    def test_timeout_persists_raw_output(
+        self, mock_resolve, mock_pty, mock_auth, tmp_path
+    ):
+        """Raw output is written to output_dir on timeout."""
+        plan = tmp_path / "test.md"
+        plan.write_text("# Plan\n")
+        out_dir = tmp_path / "state"
+        invoke_codex_plan_review(plan, "small", timeout=10, output_dir=out_dir)
+        raw_file = out_dir / "codex_output_raw.txt"
+        assert raw_file.exists()
+        assert raw_file.read_text() == "partial review"
+
+
+class TestClaudeFailsafeTimeout:
+    """Test timeout and error paths in invoke_claude_failsafe."""
+
+    @patch("codex_plan_review_adapter.shutil.which", return_value=None)
+    def test_no_claude_in_path_returns_error(self, mock_which, tmp_path):
+        """When claude is not in PATH and no env var, returns error."""
+        plan = tmp_path / "test.md"
+        plan.write_text("# Plan\n")
+        env = os.environ.copy()
+        env.pop("CLAUDE_REVIEW_CMD", None)
+        with patch.dict(os.environ, env, clear=True):
+            result = invoke_claude_failsafe(plan, "small")
+            assert result.success is False
+            assert "not in PATH" in result.error
+
+    @patch("codex_plan_review_adapter.shutil.which", return_value="/usr/bin/claude")
+    def test_subprocess_timeout_returns_error(self, mock_which, tmp_path):
+        """TimeoutExpired from subprocess produces timeout error."""
+        plan = tmp_path / "test.md"
+        plan.write_text("# Plan\n")
+        env = os.environ.copy()
+        env.pop("CLAUDE_REVIEW_CMD", None)
+        with patch.dict(os.environ, env, clear=True):
+            with patch("codex_plan_review_adapter.subprocess.run") as mock_run:
+                mock_run.side_effect = TimeoutExpired(cmd=["claude"], timeout=300)
+                result = invoke_claude_failsafe(plan, "small")
+                assert result.success is False
+                assert "timed out" in result.error
+
+    @patch("codex_plan_review_adapter.shutil.which", return_value="/usr/bin/claude")
+    def test_nonzero_exit_returns_error(self, mock_which, tmp_path):
+        """Non-zero exit from claude CLI returns error."""
+        plan = tmp_path / "test.md"
+        plan.write_text("# Plan\n")
+        env = os.environ.copy()
+        env.pop("CLAUDE_REVIEW_CMD", None)
+        with patch.dict(os.environ, env, clear=True):
+            with patch("codex_plan_review_adapter.subprocess.run") as mock_run:
+                mock_run.return_value.returncode = 1
+                mock_run.return_value.stdout = "error output"
+                mock_run.return_value.stderr = "stderr"
+                result = invoke_claude_failsafe(plan, "small")
+                assert result.success is False
+                assert "exited with code 1" in result.error
+
+    @patch("codex_plan_review_adapter.shutil.which", return_value="/usr/bin/claude")
+    def test_failsafe_persists_raw_output(self, mock_which, tmp_path):
+        """Raw output is written to output_dir on success or failure."""
+        plan = tmp_path / "test.md"
+        plan.write_text("# Plan\n")
+        out_dir = tmp_path / "state"
+        env = os.environ.copy()
+        env.pop("CLAUDE_REVIEW_CMD", None)
+        with patch.dict(os.environ, env, clear=True):
+            with patch("codex_plan_review_adapter.subprocess.run") as mock_run:
+                mock_run.return_value.returncode = 0
+                mock_run.return_value.stdout = "[]"
+                mock_run.return_value.stderr = ""
+                invoke_claude_failsafe(plan, "small", output_dir=out_dir)
+                raw_file = out_dir / "claude_failsafe_raw.txt"
+                assert raw_file.exists()

--- a/tests/unit/test_codex_review_adapter.py
+++ b/tests/unit/test_codex_review_adapter.py
@@ -679,3 +679,51 @@ class TestEnvVarLauncher:
                 "--base",
                 "main",
             ]
+
+
+# --- Timeout and Error Path Tests ---
+
+
+class TestCodexCLITimeout:
+    """Test timeout handling in invoke_codex_cli."""
+
+    @patch(
+        "codex_plan_review_adapter._run_with_pty", return_value=(None, "partial output")
+    )
+    @patch("codex_review_adapter._resolve_codex_binary", return_value=["codex"])
+    def test_timeout_returns_failure(self, mock_resolve, mock_pty):
+        """Timeout (returncode=None) produces success=False."""
+        result = invoke_codex_cli(base="main")
+        assert result.success is False
+        assert "Timeout" in result.error
+
+    @patch("codex_plan_review_adapter._run_with_pty", return_value=(None, ""))
+    @patch("codex_review_adapter._resolve_codex_binary", return_value=["codex"])
+    def test_timeout_with_empty_output(self, mock_resolve, mock_pty):
+        """Timeout with no output still returns error."""
+        result = invoke_codex_cli(base="main")
+        assert result.success is False
+        assert "Timeout" in result.error
+        assert result.raw_output == ""
+
+    @patch(
+        "codex_plan_review_adapter._run_with_pty",
+        return_value=(2, "error: bad argument"),
+    )
+    @patch("codex_review_adapter._resolve_codex_binary", return_value=["codex"])
+    def test_nonzero_exit_returns_failure(self, mock_resolve, mock_pty):
+        """Non-zero exit code produces success=False."""
+        result = invoke_codex_cli(base="main")
+        assert result.success is False
+        assert "Exit code 2" in result.error
+
+    @patch(
+        "codex_plan_review_adapter._run_with_pty",
+        return_value=(0, "gibberish that matches nothing"),
+    )
+    @patch("codex_review_adapter._resolve_codex_binary", return_value=["codex"])
+    def test_unparseable_output_returns_failure(self, mock_resolve, mock_pty):
+        """Output matching no patterns produces error."""
+        result = invoke_codex_cli(base="main")
+        assert result.success is False
+        assert "Unparseable" in result.error

--- a/tests/unit/test_pty_runner.py
+++ b/tests/unit/test_pty_runner.py
@@ -1,0 +1,103 @@
+"""Tests for _run_with_pty — real subprocess execution, no mocks.
+
+These tests exercise the actual PTY subprocess wrapper to verify
+timeout behavior, output capture, and process cleanup.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# Add scripts/internal to path for imports
+sys.path.insert(
+    0, str(Path(__file__).resolve().parent.parent.parent / "scripts" / "internal")
+)
+
+from codex_plan_review_adapter import _run_with_pty
+
+
+class TestPTYBasic:
+    """Basic PTY functionality: run a command, capture output."""
+
+    def test_echo_captures_output(self):
+        """Simple echo command produces output and exit code 0."""
+        rc, output = _run_with_pty(["echo", "hello"], timeout=10)
+        assert rc == 0
+        assert "hello" in output
+
+    def test_exit_code_propagated(self):
+        """Non-zero exit code is returned correctly."""
+        rc, output = _run_with_pty(["sh", "-c", "exit 42"], timeout=10)
+        assert rc == 42
+
+    def test_stderr_captured(self):
+        """stderr output is captured through the PTY."""
+        rc, output = _run_with_pty(
+            ["sh", "-c", "echo error >&2"],
+            timeout=10,
+        )
+        assert rc == 0
+        assert "error" in output
+
+
+class TestPTYTimeout:
+    """Timeout behavior: process killed, partial output captured."""
+
+    def test_timeout_kills_process(self):
+        """A long-running command is killed when timeout expires."""
+        start = time.monotonic()
+        rc, output = _run_with_pty(["sleep", "30"], timeout=2)
+        elapsed = time.monotonic() - start
+
+        assert rc is None  # None = killed by timeout
+        assert elapsed < 5  # Should complete in ~2s, not 30s
+
+    def test_timeout_captures_partial_output(self):
+        """Output produced before timeout is captured."""
+        rc, output = _run_with_pty(
+            ["sh", "-c", "echo before_timeout; sleep 30"],
+            timeout=2,
+        )
+        assert rc is None
+        assert "before_timeout" in output
+
+    def test_fast_command_no_timeout(self):
+        """A fast command completes well within timeout."""
+        start = time.monotonic()
+        rc, output = _run_with_pty(["echo", "fast"], timeout=60)
+        elapsed = time.monotonic() - start
+
+        assert rc == 0
+        assert "fast" in output
+        assert elapsed < 5  # Should be near-instant
+
+
+class TestPTYEdgeCases:
+    """Edge cases for PTY subprocess handling."""
+
+    def test_command_not_found(self):
+        """Non-existent command raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            _run_with_pty(["nonexistent_command_xyz"], timeout=5)
+
+    def test_empty_output_command(self):
+        """Command that produces no output returns empty string."""
+        rc, output = _run_with_pty(["true"], timeout=10)
+        assert rc == 0
+        # PTY may add minimal whitespace but no substantive content
+        assert len(output.strip()) == 0 or output.strip() == ""
+
+    def test_multiline_output(self):
+        """Multi-line output is captured correctly."""
+        rc, output = _run_with_pty(
+            ["sh", "-c", "echo line1; echo line2; echo line3"],
+            timeout=10,
+        )
+        assert rc == 0
+        assert "line1" in output
+        assert "line2" in output
+        assert "line3" in output


### PR DESCRIPTION
## Summary
- Add 25 new tests covering timeout and error paths in review infrastructure
- New `test_pty_runner.py` with real subprocess PTY tests (no mocks)
- Extend plan review adapter tests with timeout, failsafe, and output persistence tests
- Extend PR review adapter tests with timeout and error classification tests
- Extend integration tests with both-reviewers-fail and unparseable-output scenarios

## Why
The review infrastructure had zero test coverage for timeout paths. All tests mocked `_run_with_pty`, so the `returncode is None` branch was never exercised. This allowed a 78% plan review failure rate to go undetected.

> **Note:** Recreated from #779 which was auto-closed when its base (#777) was squash-merged.

## Plan
`plans/sessions/2026-03-17_review-infrastructure-reliability.md` (PR 2 of 3)

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_codex_plan_review_adapter.py \
  tests/unit/test_codex_review_adapter.py \
  tests/unit/test_pty_runner.py \
  tests/integration/test_plan_review_loop.py -q
# 160 passed

make check-quiet  # All checks passed
```

## Tests
- 25 new tests (135 → 160)
- `make check-quiet` passes

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-test-review-timeouts
branch: test/review-timeout-coverage
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)