### PR TITLE
fix: repo hygiene — update CLAUDE.md module table + stale test path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ uv run python scripts/compare_runs.py \
 uv run python -m pytest -m "not slow" tests/     # Fast suite
 uv run python -m pytest tests/unit/              # Unit only
 uv run python -m pytest tests/integration/       # Integration only
-uv run python -m pytest tests/unit/core/test_rules.py::test_specific  # Single test
+uv run python -m pytest tests/unit/test_rules.py::test_specific  # Single test
 ```
 
 **Note:** All commands use `uv run` which handles the virtualenv automatically. If already in an activated venv, plain `python` works too.
@@ -150,6 +150,7 @@ uv run python -m pytest tests/unit/core/test_rules.py::test_specific  # Single t
 | `reporting/` | Report generation utilities |
 | `logging/` | JSONL game logging |
 | `analysis/` | Statistical analysis (stats, paired comparisons, models) |
+| `arc_d_v2/` | Arc D v2 lineage orchestration, charts, tables, reports |
 | `validation/` | Promotion validation and schemas |
 | `scoring.py` | Top-level scoring module |
 


### PR DESCRIPTION
## Summary

- **Add `arc_d_v2/` to CLAUDE.md Source Layout table** (R17-2) — the module was missing from the architecture documentation despite being a major package
- **Fix stale test path reference** (R17-11) — `tests/unit/core/test_rules.py` → `tests/unit/test_rules.py` (there is no `core/` subdirectory under `tests/unit/`)
- **Orphan `src/bid_euchre/utils/` (R17-1)** — confirmed it contained only `__pycache__` (gitignored), so no tracked files to delete

## Why

Addresses findings R17-1, R17-2, and R17-11 from review PR #786. Keeps CLAUDE.md accurate for agent and developer reference.

## Repro / Validation

```bash
# In worktree
make check-quiet  # All checks passed
```

No code changes — documentation only.

## Tests

```bash
make check-quiet  # ✓ All checks passed
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-hygiene
branch: codex/review-cleanup-hygiene
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)