### PR TITLE
fix: sanity check state vector mismatch for forward-selected models

### DIFF
--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -2274,10 +2274,15 @@ class ActionValueBidder(BiddingPolicy):
             self._needs_full_state = False
 
         if not skip_behavioral_check:
+            # Match _select_state: pass None for partner_feature_names when
+            # _needs_full_state so extract_state_features returns all 69 features
+            sanity_partner = (
+                None if self._needs_full_state else self._partner_feature_names
+            )
             _check_ols_predictions_sane(
                 self.models,
                 self.pass_model,
-                self._partner_feature_names,
+                sanity_partner,
                 has_interactions=self._has_interactions,
                 include_positional=self._has_positional or self._needs_full_state,
                 hand_indices=self._hand_indices if not self._has_positional else None,
@@ -2476,9 +2481,14 @@ class GBTActionValueBidder(BiddingPolicy):
             self._needs_full_state = False
 
         if not skip_behavioral_check:
+            # Match _select_state: pass None for partner_feature_names when
+            # _needs_full_state so extract_state_features returns all 69 features
+            sanity_partner = (
+                None if self._needs_full_state else self._partner_feature_names
+            )
             _check_gbt_predictions_sane(
                 self.gbt_models,
-                self._partner_feature_names,
+                sanity_partner,
                 include_positional=self._has_positional or self._needs_full_state,
                 hand_indices=self._hand_indices if not self._has_positional else None,
                 has_moon_loner=self._has_moon_loner,


### PR DESCRIPTION
## Plan
`plans/arc_d_v2/v2_regeneration_repair_runbook.md` §9.3 (smoke regeneration)

## Summary
- Fix IndexError in `_check_ols_predictions_sane` and `_check_gbt_predictions_sane` when forward-selected models use features spanning hand, partner, and positional blocks
- Pass `partner_feature_names=None` when `_needs_full_state=True`, matching runtime `_select_state` behavior

## Why
Forward-selected R1/R2 models can select features like `opp_right_passed` (index 58) and
`seat_rel_3` (index 68) from the full 69-element `STATE_FEATURE_NAMES`. The sanity check
called `extract_state_features` with `partner_feature_names=self._partner_feature_names`,
producing a shorter state vector (39+partner+positional ≈ 49 elements), while `hand_indices`
referenced full 69-element positions — causing `IndexError: index 68 is out of bounds`.

The runtime `_select_state` method already handles this correctly by passing `None` for
`partner_feature_names` when `_needs_full_state=True`, which returns all 69 features.
The sanity check was missing this conditional.

## Repro / Validation
```bash
# Before fix: R1/R2 smoke Step 4 fails with IndexError
uv run python scripts/internal/run_rung.py --rung r1 --mode smoke --seed 42

# Unit tests
uv run python -m pytest tests/unit/test_action_value_bidder.py tests/unit/test_two_stage_bidder.py -x -q
# 83 passed
```

## Tests
- [x] `tests/unit/test_action_value_bidder.py` — 62 passed
- [x] `tests/unit/test_two_stage_bidder.py` — 21 passed

## Risk level
- [x] High (core rules/sim/scoring)

## Worktree proof
`pwd`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-sanity-fix`

## Checklist
- [x] No generated artifacts committed
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
