### PR TITLE
docs: fix stale references + document internal scripts

### DIFF
--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -95,6 +95,12 @@ that import typed schemas and paths from `bid_euchre.arc_d_v2`.
 - `update_arc_registry.py` — Arc D registry updater (MODEL_ARC_RUNS.md)
 - `validate_arc_d_rung_contract.py` — Arc D rung bundle validator
 
+Shell scripts:
+- `ci_poller.sh` — Background CI poller; monitors GitHub PR checks with optional auto-merge (launched by post-push hook)
+- `clean_worktrees.sh` — Removes git worktrees and local branches whose upstream remote has been deleted (`[gone]`)
+- `overnight_full_orchestrator.sh` — Sequential overnight orchestrator for FULL-mode Arc D v2 rung runs (all rungs x seeds)
+- `set_review_status.sh` — Publishes GitHub commit statuses for the review gate (`reviewing-changes` context)
+
 Deprecation wrappers at old paths (`scripts/*.py`) forward to `scripts/internal/` with a warning.
 
 ### `tests/`
@@ -254,6 +260,10 @@ Every experiment run creates a standardized directory under `data/runs/<run_id>/
 | `scripts/internal/update_arc_registry.py` | Arc D registry updater (MODEL_ARC_RUNS.md) |
 | `scripts/internal/validate_action_value_artifact.py` | Behavioral validation gate for action-value artifacts |
 | `scripts/internal/validate_arc_d_rung_contract.py` | Arc D rung bundle validator |
+| `scripts/internal/ci_poller.sh` | Background CI poller with optional auto-merge (launched by post-push hook) |
+| `scripts/internal/clean_worktrees.sh` | Remove worktrees and branches whose upstream remote is deleted (`[gone]`) |
+| `scripts/internal/overnight_full_orchestrator.sh` | Sequential overnight orchestrator for FULL-mode Arc D v2 rung runs |
+| `scripts/internal/set_review_status.sh` | Publish GitHub commit statuses for review gate contexts |
 
 ### Research tooling (canonical path)
 

--- a/docs/01_core/schemas/hybrid_olsa_v1.md
+++ b/docs/01_core/schemas/hybrid_olsa_v1.md
@@ -90,7 +90,7 @@ When both arms are trained, a `rung_bundle_r{N}.json` packages them:
   },
   "split_manifest": "split_manifest_r0_suit.json",
   "training_report": "training_report_r0.json",
-  "progression_report": "docs/04_reports/arc_d_v1/r1/r0_to_r1_progression.md"
+  "progression_report": "docs/04_reports/arc_d_v2/r1/r0_to_r1_progression.md"
 }
 ```
 
@@ -100,7 +100,7 @@ and current rung. R0 bundles are exempt (no prior rung to compare against).
 
 ```text
 R0: progression_report absent (exempted)
-R1+: progression_report = "docs/04_reports/arc_d_v1/r1/r0_to_r1_progression.md" (required)
+R1+: progression_report = "docs/04_reports/arc_d_v2/<rung>/r{N-1}_to_r{N}_progression.md" (required)
 ```
 
 ## R5 Extension: Offensive/Defensive Sub-Models

--- a/docs/02_agent/PR_PROMPT_TEMPLATES.md
+++ b/docs/02_agent/PR_PROMPT_TEMPLATES.md
@@ -457,11 +457,7 @@ Primary PR path (gold path):
 
 Fallback (TLS/auth edge case):
 - Primary path is `gh pr create ... --body-file pr_body.md`.
-- If TLS/auth prevents creation even after remediation and retry, run:
-  `scripts/create_pr_curl.sh "<PR Title>" pr_body.md main`
-- The script must print a PR URL. If the script is missing or does not produce the URL, STOP and report (do not invent a new script).
-- If the fallback succeeds, treat it as the PR creation step above and continue with proof/cleanup.
-- Manual PR mode is not allowed unless explicitly requested by the user.
+- If TLS/auth prevents creation even after remediation and retry: STOP and report.
 - Manual PR mode is not allowed unless explicitly requested by the user.
 
 PR ID PROOF (required):
@@ -836,10 +832,7 @@ Primary PR path (gold path):
 
 Fallback (TLS/auth edge case):
 - Primary path is `gh pr create ... --body-file pr_body.md`.
-- If TLS/auth prevents creation even after remediation and retry, run:
-  `scripts/create_pr_curl.sh "<PR Title>" pr_body.md main`
-- The script must print a PR URL. If the script is missing or does not produce the URL, STOP and report (do not invent a new script).
-- If the fallback succeeds, treat it as the PR creation step above and continue with proof/cleanup.
+- If TLS/auth prevents creation even after remediation and retry: STOP and report.
 
 PR ID PROOF (required):
 - gh pr view --json number,url,headRefName --jq '{number:.number,url:.url,branch:.headRefName}'

--- a/docs/02_agent/REPORT_NARRATIVE_CONVENTIONS.md
+++ b/docs/02_agent/REPORT_NARRATIVE_CONVENTIONS.md
@@ -168,8 +168,12 @@ header.
 When a report is substantially revised, archive the previous version:
 
 ```
-docs/04_reports/arc_d_v1/r0/archive/model_arc_r0_v1_20260224.md
+docs/04_reports/<arc>/<rung>/archive/{name}_v{N}_{original_date}.md
 ```
+
+> **Note:** The `docs/04_reports/arc_d_v1/` directory has been removed as part of
+> the v2 lineage migration. The convention above still applies to current report
+> directories (e.g., `docs/04_reports/arc_d_v2/`).
 
 Format: `{name}_v{N}_{original_date}.md`
 

--- a/docs/04_reports/codex_validation/results_2026-03-08.md
+++ b/docs/04_reports/codex_validation/results_2026-03-08.md
@@ -4,7 +4,7 @@
 
 - **PR:** #574 (closed without merge)
 - **Date:** 2026-03-08
-- **Test fixture:** scripts/internal/codex_test_fixture.py (on closed test branch, not merged)
+- **Test fixture:** scripts/internal/codex_test_fixture.py (temporary fixture, existed only on closed test branch; now deleted)
 - **Seeded violations:** C1 (unseeded RNG x2), C2 (falsy guard), X3 (merge
   markers), X3 (commented-out block), import boundary, breakpoint()
 
@@ -25,9 +25,9 @@
 
 | Severity | File | Line | Check | Finding | Correct? |
 |----------|------|------|-------|---------|----------|
-| CRITICAL (P0) | scripts/internal/codex_test_fixture.py | 34 | X3 | Merge conflict markers — invalid Python syntax | Yes |
-| CRITICAL (P1) | scripts/internal/codex_test_fixture.py | 24 | C2 | Falsy numeric guard — `avg_tricks or 5.0` replaces valid 0.0 | Yes |
-| CRITICAL (P1) | scripts/internal/codex_test_fixture.py | 17 | C1 | Unseeded `random.Random()` — non-deterministic | Yes |
+| CRITICAL (P0) | scripts/internal/codex_test_fixture.py (deleted) | 34 | X3 | Merge conflict markers — invalid Python syntax | Yes |
+| CRITICAL (P1) | scripts/internal/codex_test_fixture.py (deleted) | 24 | C2 | Falsy numeric guard — `avg_tricks or 5.0` replaces valid 0.0 | Yes |
+| CRITICAL (P1) | scripts/internal/codex_test_fixture.py (deleted) | 17 | C1 | Unseeded `random.Random()` — non-deterministic | Yes |
 
 ### Missed Violations
 
@@ -64,7 +64,7 @@ are handled by repo-lint and ruff.
 
 - **PR:** #579 (closed without merge)
 - **Date:** 2026-03-08
-- **Test fixture:** scripts/internal/codex_v2_test_fixture.py (on closed test branch, not merged)
+- **Test fixture:** scripts/internal/codex_v2_test_fixture.py (temporary fixture, existed only on closed test branch; now deleted)
 - **Seeded violations:** breakpoint(), redundant else after return, `== None`, `== True`
 
 ### Response Metadata

--- a/docs/04_reports/codex_validation/results_2026-03-09_e2e.md
+++ b/docs/04_reports/codex_validation/results_2026-03-09_e2e.md
@@ -12,7 +12,7 @@ state transition → artifact persistence.
 - **PR:** #593 (closed without merge)
 - **Branch:** `e2e-validation-seeded-bugs`
 - **Date:** 2026-03-09
-- **Test file:** src/bid_euchre/validation/e2e_test_seeded_bugs.py (on closed test branch, not merged)
+- **Test file:** src/bid_euchre/validation/e2e_test_seeded_bugs.py (temporary fixture, existed only on closed test branch; now deleted)
 - **Driver invocation:** `review_driver.py --pr 593 --trigger pr_created`
 
 ### Seeded Violations

--- a/docs/FLOW_DIAGRAM.md
+++ b/docs/FLOW_DIAGRAM.md
@@ -231,7 +231,7 @@ flowchart TD
     subgraph Core["Core Modules (src/bid_euchre/)"]
         direction TB
 
-        ExpConfig["experiments/config.py"]
+        ExpConfig["src/bid_euchre/experiments/config.py"]
 
         SimDeals["sim/deals.py"]
         SimEngine["sim/simulation.py"]


### PR DESCRIPTION
## Summary
- Fix 8 stale path references across 7 doc files (R17-4)
- Document 4 internal shell scripts in ARCHITECTURE.md (R17-6)
- All changes are docs-only; no code changes

## Why
Repo review #786 identified stale references and undocumented shell scripts. This PR addresses findings R17-4 (stale paths) and R17-6 (missing script documentation).

## Stale references fixed
| File | Fix |
|------|-----|
| `docs/FLOW_DIAGRAM.md` | `experiments/config.py` -> `src/bid_euchre/experiments/config.py` |
| `docs/02_agent/REPORT_NARRATIVE_CONVENTIONS.md` | Removed stale `arc_d_v1` archive path, noted v2 migration |
| `docs/02_agent/PR_PROMPT_TEMPLATES.md` (2 locations) | Removed deleted `scripts/create_pr_curl.sh` fallback |
| `docs/04_reports/codex_validation/results_2026-03-09_e2e.md` | Marked temporary test fixture as deleted |
| `docs/04_reports/codex_validation/results_2026-03-08.md` | Marked temporary test fixtures as deleted |
| `docs/01_core/schemas/hybrid_olsa_v1.md` (2 locations) | Updated `arc_d_v1` -> `arc_d_v2` report paths |

## Scripts documented in ARCHITECTURE.md
| Script | Purpose |
|--------|---------|
| `ci_poller.sh` | Background CI poller with optional auto-merge |
| `clean_worktrees.sh` | Remove worktrees/branches with deleted upstream |
| `overnight_full_orchestrator.sh` | Sequential overnight FULL-mode rung orchestrator |
| `set_review_status.sh` | Publish GitHub commit statuses for review gate |

## Repro / Validation
```bash
make check-quiet  # All checks passed
```

## Tests
- `make check-quiet` passes (docs-only change, no test changes needed)

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-docs
git worktree add ../Bid-Euchre-docs -b codex/review-cleanup-docs
```

## Note on CANONICAL_BIDLESS.md
The task listed `tests/strategy_sanity.json` and `tests/strategy_sanity.md` as stale paths at lines 19, 381, 404. On inspection, the actual references at those lines are `reports/sanity_tests/strategy_sanity.json` (within run directories), which are still generated by `diagnostics/sanity_tests.py`. These references are correct and were left unchanged.

---
Addresses R17-4 and R17-6 from repo review 2026-03-17 (#786).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>