### PR TITLE
test: regression tests for forward-selected bidder sanity check

### DIFF
--- a/tests/unit/test_action_value_bidder.py
+++ b/tests/unit/test_action_value_bidder.py
@@ -777,6 +777,24 @@ class TestForwardSelectedArtifact:
             expected_indices,
         )
 
+    def test_ols_behavioral_check_with_forward_selected(self, tmp_path):
+        """Regression test for #791: forward-selected OLS artifact with
+        _needs_full_state=True must not IndexError during behavioral check.
+
+        Prior to PR #788, the sanity check passed the wrong partner_feature_names
+        when _needs_full_state=True, causing extract_state_features to return
+        fewer features than expected by hand_indices, triggering an IndexError.
+        """
+        artifact = _make_forward_selected_ols_artifact()
+        path = tmp_path / "forward_selected.json"
+        path.write_text(json.dumps(artifact))
+
+        # skip_behavioral_check=False (the default) — this is the path that
+        # used to crash with IndexError before PR #788
+        bidder = ActionValueBidder(str(path), skip_behavioral_check=False)
+        assert bidder._needs_full_state is True
+        assert bidder._has_positional is False
+
 
 # ── extract_action_features include_moon_loner flag ──────
 

--- a/tests/unit/test_gbt_bidder.py
+++ b/tests/unit/test_gbt_bidder.py
@@ -420,3 +420,67 @@ class TestGBTForwardSelected:
         obs = _make_obs(current_high_bid=0)
         action = bidder.choose_bid(obs)
         assert isinstance(action, BidAction)
+
+    def test_gbt_behavioral_check_with_forward_selected(self, tmp_path):
+        """Regression test for #791: forward-selected GBT artifact with
+        _needs_full_state=True must not IndexError during behavioral check.
+
+        Prior to PR #788, the sanity check passed the wrong partner_feature_names
+        when _needs_full_state=True, causing extract_state_features to return
+        fewer features than expected by hand_indices, triggering an IndexError.
+        """
+        import joblib
+        from sklearn.ensemble import GradientBoostingRegressor
+
+        hand_subset = list(_HAND_FEATURE_NAMES[:10])
+        partner_subset = ["partner_passed"]
+        state_names = hand_subset + partner_subset
+        n_state = len(state_names)
+        n_action = len(ACTION_FEATURE_NAMES)
+
+        # Train tiny GBT models on random data
+        rng = np.random.RandomState(42)
+        X_bid = rng.randn(20, n_state + n_action)
+        X_pass = rng.randn(20, n_state)
+        y = rng.randn(20)
+
+        models_meta = {}
+        for family in ("suit", "high", "low"):
+            model = GradientBoostingRegressor(
+                n_estimators=5, max_depth=2, random_state=42
+            )
+            model.fit(X_bid, y)
+            model_file = f"gbt_{family}.joblib"
+            joblib.dump(model, tmp_path / model_file)
+            models_meta[family] = {
+                "model_file": model_file,
+                "feature_names": state_names + list(ACTION_FEATURE_NAMES),
+                "r_squared": 0.50,
+                "feature_importances": [0.1] * (n_state + n_action),
+            }
+
+        pass_model = GradientBoostingRegressor(
+            n_estimators=5, max_depth=2, random_state=42
+        )
+        pass_model.fit(X_pass, y)
+        joblib.dump(pass_model, tmp_path / "gbt_pass.joblib")
+        models_meta["pass"] = {
+            "model_file": "gbt_pass.joblib",
+            "feature_names": list(state_names),
+            "r_squared": 0.50,
+            "feature_importances": [0.1] * n_state,
+        }
+
+        artifact = {
+            "schema_version": "action_value_gbt_v1",
+            "models": models_meta,
+            "metadata": {"context_features": ["partner_passed"]},
+        }
+        path = tmp_path / "gbt_forward.json"
+        path.write_text(json.dumps(artifact))
+
+        # skip_behavioral_check=False (the default) — this is the path that
+        # used to crash with IndexError before PR #788
+        bidder = GBTActionValueBidder(str(path), skip_behavioral_check=False)
+        assert bidder._needs_full_state is True
+        assert bidder._has_positional is False


### PR DESCRIPTION
## Summary
- Add regression test for OLS forward-selected artifact with `skip_behavioral_check=False` (the default)
- Add regression test for GBT forward-selected artifact with `skip_behavioral_check=False` (the default)
- Both tests verify no `IndexError` is raised when `_needs_full_state=True` during behavioral sanity check

Closes #791

## Why
PR #788 fixed an `IndexError` in `_check_ols_predictions_sane` / `_check_gbt_predictions_sane` when forward-selected models use features spanning hand + partner blocks (`_needs_full_state=True`). The fix passes `partner_feature_names=None` when `_needs_full_state=True`. However, all existing forward-selected bidder tests used `skip_behavioral_check=True`, leaving the fixed code path untested.

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_action_value_bidder.py::TestForwardSelectedArtifact::test_ols_behavioral_check_with_forward_selected tests/unit/test_gbt_bidder.py::TestGBTForwardSelected::test_gbt_behavioral_check_with_forward_selected -x -q
# 2 passed
```

## Tests
```bash
uv run python -m pytest tests/unit/test_action_value_bidder.py tests/unit/test_gbt_bidder.py -x -q
# 80 passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/worktree-791-regression-tests
branch: 791-forward-selected-sanity-regression
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)