### PR TITLE
fix: separate dataset-build seeds from run seeds

### DIFF
--- a/scripts/internal/overnight_full_orchestrator.sh
+++ b/scripts/internal/overnight_full_orchestrator.sh
@@ -1,20 +1,21 @@
 #!/bin/bash
 # Overnight FULL Orchestrator (Sequential — safe for 16GB M3)
 #
-# Runs all 3 rungs × 3 seeds SEQUENTIALLY to avoid thermal shutdown.
-# Each run_rung.py handles Steps 1-7 end-to-end for one rung+seed.
+# Runs all 3 pre-R3 rungs SEQUENTIALLY. Each run_rung.py handles:
+#   - Step 1: dataset generation (holistic, iterates dataset seeds internally)
+#   - Steps 2-5: per-seed training/eval (iterates run seeds [42,123,456])
+#   - Steps 6-9: holistic reporting + advance check
 #
 # Usage: nohup bash scripts/internal/overnight_full_orchestrator.sh > /tmp/overnight_orchestrator.log 2>&1 &
 #
-# Estimated time: ~2-3 hours per rung × 9 runs = 18-27 hours total
-# (but run_rung.py is idempotent — safe to restart if interrupted)
+# Estimated time: ~6-9 hours total (sequential)
+# (run_rung.py is idempotent — safe to restart if interrupted)
 
 set -uo pipefail  # no -e: we want to continue on individual failures
 
 WORKTREE="/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre"
 LOG="/tmp/overnight_orchestrator.log"
 HEARTBEAT="/tmp/overnight_orchestrator_heartbeat"
-SEEDS=(42 123 456)
 RUNGS=(r0 r1 r2)
 
 cd "$WORKTREE"
@@ -27,24 +28,24 @@ heartbeat() {
     date '+%Y-%m-%d %H:%M:%S' > "$HEARTBEAT"
 }
 
-run_one() {
+run_rung() {
     local rung=$1
-    local seed=$2
-    local run_log="/tmp/full_${rung}_seed${seed}.log"
+    local run_log="/tmp/full_${rung}.log"
 
-    log "--- Starting $rung seed $seed ---"
+    log "--- Starting $rung (all seeds via MODE_SEEDS) ---"
     heartbeat
 
-    # run_rung.py is idempotent — if steps already completed, it skips them
+    # run_rung.py handles multi-seed dispatch internally.
+    # Step 1 uses MODE_DATASET_SEEDS; Steps 2-5 use MODE_SEEDS.
     uv run python scripts/internal/run_rung.py \
-        --rung "$rung" --mode full --seed "$seed" \
+        --rung "$rung" --mode full \
         > "$run_log" 2>&1
     local rc=$?
 
     if [ $rc -eq 0 ]; then
-        log "  $rung seed $seed: SUCCESS (exit code 0)"
+        log "  $rung: SUCCESS (exit code 0)"
     else
-        log "  $rung seed $seed: FAILED (exit code $rc) — see $run_log"
+        log "  $rung: FAILED (exit code $rc) — see $run_log"
     fi
 
     heartbeat
@@ -66,39 +67,36 @@ run_advance_checks() {
 }
 
 # ============================================================
-# Main execution — sequential, one at a time
+# Main execution — one rung at a time, multi-seed handled internally
 # ============================================================
 
 log "========================================="
 log "Overnight FULL Orchestrator (sequential)"
 log "Working directory: $WORKTREE"
-log "Seeds: ${SEEDS[*]}"
 log "Rungs: ${RUNGS[*]}"
-log "Total runs: $((${#SEEDS[@]} * ${#RUNGS[@]}))"
+log "Dataset seeds: 1001-1010 (10 shards × 5000 = 50000 deals)"
+log "Run seeds: 42, 123, 456 (3 train/val/test splits)"
 log "========================================="
 
 failed=0
 completed=0
-total=$((${#SEEDS[@]} * ${#RUNGS[@]}))
+total=${#RUNGS[@]}
 
-for seed in "${SEEDS[@]}"; do
-    log "=== Seed $seed ==="
-    for rung in "${RUNGS[@]}"; do
-        if run_one "$rung" "$seed"; then
-            completed=$((completed + 1))
-        else
-            failed=$((failed + 1))
-        fi
-        log "  Progress: $completed/$total completed, $failed failed"
-    done
+for rung in "${RUNGS[@]}"; do
+    if run_rung "$rung"; then
+        completed=$((completed + 1))
+    else
+        failed=$((failed + 1))
+    fi
+    log "  Progress: $completed/$total completed, $failed failed"
 done
 
 log "========================================="
 log "Sequential runs complete: $completed/$total succeeded, $failed failed"
 log "========================================="
 
-# Run advance checks if at least seed 42 completed for all rungs
-if [ $completed -ge 3 ]; then
+# Run advance checks if all rungs completed
+if [ $completed -eq $total ]; then
     log "Running advance checks..."
     run_advance_checks
 fi
@@ -107,6 +105,6 @@ log "========================================="
 log "Overnight orchestrator DONE"
 log "  Completed: $completed/$total"
 log "  Failed: $failed/$total"
-log "  Logs: /tmp/full_r{0,1,2}_seed{42,123,456}.log"
+log "  Logs: /tmp/full_r{0,1,2}.log"
 log "  Next: review advance_check_full.json, write decision reports"
 log "========================================="

--- a/scripts/internal/train_action_value.py
+++ b/scripts/internal/train_action_value.py
@@ -451,7 +451,10 @@ def run_forward_selection(
 
     X = _build_feature_matrix(train_df, feature_names)
     y = train_df[target_col].values
-    groups = train_df["hand_id"].values
+    # Use hand_uid for grouping when available (multi-shard datasets have
+    # non-unique hand_id across shards; hand_uid = f"{dataset_seed}:{hand_id}")
+    group_col = "hand_uid" if "hand_uid" in train_df.columns else "hand_id"
+    groups = train_df[group_col].values
 
     selected_names, selection_log = forward_select(
         X_train=X,

--- a/src/bid_euchre/arc_d_v2/orchestration.py
+++ b/src/bid_euchre/arc_d_v2/orchestration.py
@@ -45,11 +45,26 @@ MODE_SEEDS: dict[str, list[int]] = {
     "full": [42, 123, 456],
 }
 
-# Mode -> n_deals for dataset generation
+# Mode -> total deals for dataset generation (derived from shards below)
 MODE_DEALS: dict[str, int] = {
     "smoke": 25,
     "quick": 5000,
     "full": 50000,
+}
+
+# Mode -> dataset-build seeds (control WHICH deals exist in the corpus)
+# Distinct from MODE_SEEDS which control train/val/test splits.
+MODE_DATASET_SEEDS: dict[str, list[int]] = {
+    "smoke": [1001],
+    "quick": [1001],
+    "full": [1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010],
+}
+
+# Mode -> deals per shard (each dataset seed produces one shard)
+MODE_DEALS_PER_SHARD: dict[str, int] = {
+    "smoke": 25,
+    "quick": 5000,
+    "full": 5000,
 }
 
 # Step descriptions for logging
@@ -671,14 +686,20 @@ def execute_step_0(state: RunState, dry_run: bool = False) -> bool:
     return True
 
 
-def execute_step_1(state: RunState, seed: int, dry_run: bool = False) -> bool:
-    """Step 1: Generate training dataset."""
+def execute_step_1(state: RunState, dry_run: bool = False) -> bool:
+    """Step 1: Generate training dataset (holistic — all shards in one call).
+
+    Iterates over MODE_DATASET_SEEDS to build one shard per dataset seed.
+    Dataset seeds (1001-1010) are distinct from run seeds (42, 123, 456):
+    dataset seeds control which deals exist; run seeds control splits.
+    """
     rung = state.rung
     mode = state.mode.upper()
-    n_deals = MODE_DEALS.get(state.mode, 500)
+    dataset_seeds = MODE_DATASET_SEEDS[state.mode]
+    deals_per_shard = MODE_DEALS_PER_SHARD[state.mode]
 
-    _append_log(rung, {"event": "step_start", "step": "1", "seed": seed})
-    state.mark_step_started("1", seed)
+    _append_log(rung, {"event": "step_start", "step": "1"})
+    state.mark_step_started("1")
 
     # Fixed R0 anchor for all rungs (v2 repair contract §4.1)
     continuation = (
@@ -687,86 +708,92 @@ def execute_step_1(state: RunState, seed: int, dry_run: bool = False) -> bool:
     if not continuation.exists():
         logger.warning("R0 continuation artifact not found at %s", continuation)
 
-    if rung in ("r0", "r1", "r2"):
-        # Pre-R3: shared base dataset (v2 repair contract §4.5)
-        output_dir = (
-            _repo_root()
-            / "data"
-            / "runs"
-            / "arc_d_v2"
-            / "base_datasets"
-            / "pre_r3"
-            / state.mode
-            / f"seed_{seed}"
-        )
-    else:
-        # R3+: rung-local dataset
-        output_dir = _repo_root() / "data" / "runs" / f"av_{rung}_{state.mode}_{seed}"
+    for ds_seed in dataset_seeds:
+        if rung in ("r0", "r1", "r2"):
+            # Pre-R3: shared base dataset (v2 repair contract §4.5)
+            output_dir = (
+                _repo_root()
+                / "data"
+                / "runs"
+                / "arc_d_v2"
+                / "base_datasets"
+                / "pre_r3"
+                / state.mode
+                / f"seed_{ds_seed}"
+            )
+        else:
+            # R3+: rung-local dataset in r3_datasets/
+            output_dir = (
+                _repo_root()
+                / "data"
+                / "runs"
+                / "arc_d_v2"
+                / "r3_datasets"
+                / state.mode
+                / f"seed_{ds_seed}"
+            )
 
-    # Pre-R3: skip generation if shared dataset already exists
-    if rung in ("r0", "r1", "r2"):
+        # Skip if parquet files already exist for this shard
         av_dir = output_dir / "datasets" / "action_value"
-        if av_dir.is_dir() and any(av_dir.glob("part_*.parquet")):
+        if av_dir.is_dir() and any(av_dir.rglob("*.parquet")):
             logger.info(
-                "Step 1: shared pre-R3 %s dataset already exists at %s, skipping",
-                state.mode,
+                "Step 1: dataset shard seed=%d already exists at %s, skipping",
+                ds_seed,
                 av_dir,
             )
-            state.mark_step_complete("1", seed)
+            continue
+
+        cmd = [
+            "uv",
+            "run",
+            "python",
+            "scripts/internal/generate_action_value_dataset.py",
+            "--seed",
+            str(ds_seed),
+            "--n-deals",
+            str(deals_per_shard),
+            "--mode",
+            mode,
+            "--output-dir",
+            str(output_dir),
+            "--dataset-seed",
+            str(ds_seed),
+        ]
+        if continuation.exists():
+            cmd.extend(["--continuation-artifact", str(continuation)])
+
+        # R3+ action space expansion: include moon/loner counterfactuals
+        if rung in ("r3", "r4"):
+            cmd.append("--include-moon-loner")
+
+        # Chunked generation to reduce peak memory
+        if state.mode in ("full", "quick"):
+            chunk = 1000 if rung in ("r3", "r4") else 5000
+            cmd.extend(["--chunk-size", str(chunk)])
+
+        if dry_run:
+            logger.info("Step 1: would run: %s", " ".join(cmd))
+            continue
+
+        ok, error = run_subprocess(cmd, "1", rung, f"seed_{ds_seed}")
+        if not ok:
+            state.mark_step_failed("1", error)
             _append_log(
                 rung,
-                {"event": "step_complete", "step": "1", "seed": seed, "reused": True},
+                {
+                    "event": "step_failed",
+                    "step": "1",
+                    "ds_seed": ds_seed,
+                    "error": error[:200],
+                },
             )
             state.save(_state_path(rung))
-            return True
+            return False
 
-    cmd = [
-        "uv",
-        "run",
-        "python",
-        "scripts/internal/generate_action_value_dataset.py",
-        "--seed",
-        str(seed),
-        "--n-deals",
-        str(n_deals),
-        "--mode",
-        mode,
-        "--output-dir",
-        str(output_dir),
-    ]
-    if continuation.exists():
-        cmd.extend(["--continuation-artifact", str(continuation)])
-
-    # R3+ action space expansion: include moon/loner counterfactuals
-    if rung in ("r3", "r4"):
-        cmd.append("--include-moon-loner")
-
-    # Chunked generation to reduce peak memory
-    if state.mode in ("full", "quick"):
-        chunk = 1000 if rung in ("r3", "r4") else 5000
-        cmd.extend(["--chunk-size", str(chunk)])
-
-    if dry_run:
-        logger.info("Step 1: would run: %s", " ".join(cmd))
-        state.mark_step_complete("1", seed)
-        return True
-
-    ok, error = run_subprocess(cmd, "1", rung, f"seed_{seed}")
-    if ok:
-        state.mark_step_complete(
-            "1",
-            seed,
-            fingerprint=compute_fingerprint("1", None, seed, rung, state.mode),
-        )
-        _append_log(rung, {"event": "step_complete", "step": "1", "seed": seed})
-    else:
-        state.mark_step_failed("1", error, seed=seed)
-        _append_log(
-            rung,
-            {"event": "step_failed", "step": "1", "seed": seed, "error": error[:200]},
-        )
+    state.mark_step_complete("1")
+    _append_log(rung, {"event": "step_complete", "step": "1"})
     state.save(_state_path(rung))
-    return ok
+    return True
 
 
 def execute_step_2(state: RunState, seed: int, dry_run: bool = False) -> bool:
@@ -797,11 +824,11 @@ def execute_step_2(state: RunState, seed: int, dry_run: bool = False) -> bool:
         # For pre-R3, use the shared root for recursive discovery
         dataset_path = dataset_root
     else:
-        dataset_dir = _repo_root() / "data" / "runs" / f"av_{rung}_{state.mode}_{seed}"
-        # Prefer chunked directory if it exists; fall back to single file
-        chunked_dir = dataset_dir / "datasets" / "action_value"
-        single_file = dataset_dir / "datasets" / "action_value.parquet"
-        dataset_path = chunked_dir if chunked_dir.is_dir() else single_file
+        # R3+: rung-local dataset in r3_datasets/
+        dataset_root = (
+            _repo_root() / "data" / "runs" / "arc_d_v2" / "r3_datasets" / state.mode
+        )
+        dataset_path = dataset_root
 
     # Fixed R0 anchor for all rungs (v2 repair contract §4.1)
     continuation = (
@@ -1662,10 +1689,11 @@ def execute_step_9(state: RunState, dry_run: bool = False) -> bool:
 # ---------------------------------------------------------------------------
 
 # Steps that are per-seed (run once per seed)
-PER_SEED_STEPS = {"1", "2", "3", "3b", "4", "5"}
+PER_SEED_STEPS = {"2", "3", "3b", "4", "5"}
 
 # Steps that are holistic (run once, aggregate across seeds)
-HOLISTIC_STEPS = {"0", "6", "7", "8", "9"}
+# Step 1 is holistic: it iterates over dataset-build seeds internally.
+HOLISTIC_STEPS = {"0", "1", "6", "7", "8", "9"}
 
 STEP_FUNCTIONS = {
     "0": execute_step_0,

--- a/src/bid_euchre/arc_d_v2/paths.py
+++ b/src/bid_euchre/arc_d_v2/paths.py
@@ -31,6 +31,29 @@ PLANS_ROOT = _ROOT / "plans" / "arc_d_v2"
 REPORTS_ROOT = _ROOT / "docs" / "04_reports" / "arc_d_v2"
 RUNS_ROOT = _ROOT / "data" / "runs" / "arc_d_v2"
 
+# ── Dataset roots (dataset-build seed separation) ─────────────────────────
+
+PRE_R3_DATASETS_ROOT = RUNS_ROOT / "base_datasets" / "pre_r3"
+R3_DATASETS_ROOT = RUNS_ROOT / "r3_datasets"
+
+
+def pre_r3_dataset_root(mode: str) -> Path:
+    """Shared pre-R3 dataset root: ``data/runs/arc_d_v2/base_datasets/pre_r3/{mode}/``."""
+    return PRE_R3_DATASETS_ROOT / mode
+
+
+def r3_dataset_root(mode: str) -> Path:
+    """R3 dataset root: ``data/runs/arc_d_v2/r3_datasets/{mode}/``."""
+    return R3_DATASETS_ROOT / mode
+
+
+def dataset_root(rung: str, mode: str) -> Path:
+    """Dataset root for a rung, dispatching pre-R3 vs R3+."""
+    if rung in ("r0", "r1", "r2"):
+        return pre_r3_dataset_root(mode)
+    return r3_dataset_root(mode)
+
+
 # ── Lineage-level files ─────────────────────────────────────────────────────
 
 LINEAGE_PLAN = PLANS_ROOT / "lineage_plan.md"

--- a/tests/unit/test_rung_orchestrator.py
+++ b/tests/unit/test_rung_orchestrator.py
@@ -2494,10 +2494,10 @@ class TestStep1ChunkedMode:
         state_path = tmp_path / "state.json"
         state.save(state_path)
 
-        captured_cmd = []
+        captured_cmds = []
 
         def mock_run(cmd, *args, **kwargs):
-            captured_cmd.extend(cmd)
+            captured_cmds.append(list(cmd))
             return True, ""
 
         with (
@@ -2505,16 +2505,18 @@ class TestStep1ChunkedMode:
             patch.object(run_rung_mod, "_repo_root", return_value=tmp_path),
             patch.object(run_rung_mod, "_state_path", return_value=state_path),
         ):
-            # Create dummy continuation artifact
             cont_dir = tmp_path / "data" / "artifacts" / "arc_d" / "r0"
             cont_dir.mkdir(parents=True)
             (cont_dir / "hybrid_r0_full.json").write_text("{}")
 
-            run_rung_mod.execute_step_1(state, seed=42)
+            run_rung_mod.execute_step_1(state)
 
-        assert "--chunk-size" in captured_cmd
-        chunk_idx = captured_cmd.index("--chunk-size")
-        assert captured_cmd[chunk_idx + 1] == "5000"
+        # Full mode has 10 dataset seeds → 10 subprocess calls
+        assert len(captured_cmds) == 10
+        for cmd in captured_cmds:
+            assert "--chunk-size" in cmd
+            chunk_idx = cmd.index("--chunk-size")
+            assert cmd[chunk_idx + 1] == "5000"
 
     def test_step_1_smoke_mode_no_chunk_size(self, tmp_path):
         """Smoke mode Step 1 command does NOT include --chunk-size."""
@@ -2522,10 +2524,10 @@ class TestStep1ChunkedMode:
         state_path = tmp_path / "state.json"
         state.save(state_path)
 
-        captured_cmd = []
+        captured_cmds = []
 
         def mock_run(cmd, *args, **kwargs):
-            captured_cmd.extend(cmd)
+            captured_cmds.append(list(cmd))
             return True, ""
 
         with (
@@ -2537,9 +2539,10 @@ class TestStep1ChunkedMode:
             cont_dir.mkdir(parents=True)
             (cont_dir / "hybrid_r0_full.json").write_text("{}")
 
-            run_rung_mod.execute_step_1(state, seed=42)
+            run_rung_mod.execute_step_1(state)
 
-        assert "--chunk-size" not in captured_cmd
+        assert len(captured_cmds) == 1
+        assert "--chunk-size" not in captured_cmds[0]
 
     def test_step_1_quick_mode_includes_chunk_size(self, tmp_path):
         """Quick mode Step 1 now includes --chunk-size (v2 repair LA-5)."""
@@ -2547,10 +2550,10 @@ class TestStep1ChunkedMode:
         state_path = tmp_path / "state.json"
         state.save(state_path)
 
-        captured_cmd = []
+        captured_cmds = []
 
         def mock_run(cmd, *args, **kwargs):
-            captured_cmd.extend(cmd)
+            captured_cmds.append(list(cmd))
             return True, ""
 
         with (
@@ -2562,11 +2565,13 @@ class TestStep1ChunkedMode:
             cont_dir.mkdir(parents=True)
             (cont_dir / "hybrid_r0_full.json").write_text("{}")
 
-            run_rung_mod.execute_step_1(state, seed=42)
+            run_rung_mod.execute_step_1(state)
 
-        assert "--chunk-size" in captured_cmd
-        chunk_idx = captured_cmd.index("--chunk-size")
-        assert captured_cmd[chunk_idx + 1] == "5000"
+        assert len(captured_cmds) == 1
+        cmd = captured_cmds[0]
+        assert "--chunk-size" in cmd
+        chunk_idx = cmd.index("--chunk-size")
+        assert cmd[chunk_idx + 1] == "5000"
 
     def test_step_1_r3_full_uses_chunk_size_1000(self, tmp_path):
         """R3 full mode uses chunk size 1000, not 5000 (v2 repair LA-5)."""
@@ -2574,10 +2579,10 @@ class TestStep1ChunkedMode:
         state_path = tmp_path / "state.json"
         state.save(state_path)
 
-        captured_cmd = []
+        captured_cmds = []
 
         def mock_run(cmd, *args, **kwargs):
-            captured_cmd.extend(cmd)
+            captured_cmds.append(list(cmd))
             return True, ""
 
         with (
@@ -2589,11 +2594,13 @@ class TestStep1ChunkedMode:
             cont_dir.mkdir(parents=True)
             (cont_dir / "hybrid_r0_full.json").write_text("{}")
 
-            run_rung_mod.execute_step_1(state, seed=42)
+            run_rung_mod.execute_step_1(state)
 
-        assert "--chunk-size" in captured_cmd
-        chunk_idx = captured_cmd.index("--chunk-size")
-        assert captured_cmd[chunk_idx + 1] == "1000"
+        assert len(captured_cmds) == 10
+        for cmd in captured_cmds:
+            assert "--chunk-size" in cmd
+            chunk_idx = cmd.index("--chunk-size")
+            assert cmd[chunk_idx + 1] == "1000"
 
 
 class TestStep2ChunkedDatasetPath:
@@ -2672,8 +2679,8 @@ class TestStep2ChunkedDatasetPath:
         assert "pre_r3" in ds_path
         assert "full" in ds_path
 
-    def test_step_2_r3_uses_rung_local_chunked_dir(self, tmp_path):
-        """Step 2 for R3 uses rung-local chunked directory path."""
+    def test_step_2_r3_uses_r3_dataset_root(self, tmp_path):
+        """Step 2 for R3 uses r3_datasets/{mode}/ root path."""
         roster = Roster(
             models=[
                 RosterModel(
@@ -2689,12 +2696,20 @@ class TestStep2ChunkedDatasetPath:
         plan_dir = tmp_path / "plans" / "arc_d_v2" / "r3"
         plan_dir.mkdir(parents=True)
 
-        # Create rung-local chunked dataset
-        ds_dir = tmp_path / "data" / "runs" / "av_r3_full_42" / "datasets"
-        ds_dir.mkdir(parents=True)
-        chunked = ds_dir / "action_value"
-        chunked.mkdir()
-        (chunked / "part_000000_000999.parquet").write_bytes(b"fake")
+        # Create R3 dataset root with shard
+        r3_root = (
+            tmp_path
+            / "data"
+            / "runs"
+            / "arc_d_v2"
+            / "r3_datasets"
+            / "full"
+            / "seed_1001"
+            / "datasets"
+            / "action_value"
+        )
+        r3_root.mkdir(parents=True)
+        (r3_root / "part_000000_000999.parquet").write_bytes(b"fake")
 
         # Continuation artifact
         art_dir = tmp_path / "data" / "artifacts" / "arc_d" / "r0"
@@ -2702,8 +2717,8 @@ class TestStep2ChunkedDatasetPath:
         (art_dir / "hybrid_r0_full.json").write_text("{}")
 
         state = RunState.create_fresh("r3", "full", [42, 123, 456])
-        state.mark_step_started("1", 42)
-        state.mark_step_complete("1", 42)
+        state.mark_step_started("1")
+        state.mark_step_complete("1")
 
         captured_cmds = []
 
@@ -2732,8 +2747,8 @@ class TestStep2ChunkedDatasetPath:
         cmd = captured_cmds[0]
         ds_idx = cmd.index("--dataset")
         ds_path = cmd[ds_idx + 1]
-        assert "av_r3_full_42" in ds_path
-        assert ds_path.endswith("action_value")
+        assert "r3_datasets" in ds_path
+        assert "full" in ds_path
 
 
 class TestModeDeals:
@@ -2764,10 +2779,10 @@ class TestFixedR0Anchor:
         state_path = tmp_path / "state.json"
         state.save(state_path)
 
-        captured_cmd = []
+        captured_cmds = []
 
         def mock_run(cmd, *args, **kwargs):
-            captured_cmd.extend(cmd)
+            captured_cmds.append(list(cmd))
             return True, ""
 
         with (
@@ -2786,11 +2801,14 @@ class TestFixedR0Anchor:
                 rung_dir.mkdir(parents=True)
                 (rung_dir / f"hybrid_{rung}_full.json").write_text("{}")
 
-            run_rung_mod.execute_step_1(state, seed=42)
+            run_rung_mod.execute_step_1(state)
 
-        assert "--continuation-artifact" in captured_cmd
-        ca_idx = captured_cmd.index("--continuation-artifact")
-        ca_path = captured_cmd[ca_idx + 1]
+        # Smoke mode has 1 dataset seed → 1 subprocess call
+        assert len(captured_cmds) == 1
+        cmd = captured_cmds[0]
+        assert "--continuation-artifact" in cmd
+        ca_idx = cmd.index("--continuation-artifact")
+        ca_path = cmd[ca_idx + 1]
         assert "r0" in ca_path
         assert "hybrid_r0_full.json" in ca_path
         # Must NOT reference rung-local artifact
@@ -2804,19 +2822,19 @@ class TestFixedR0Anchor:
 
 
 class TestSharedDatasetPaths:
-    """Test that pre-R3 rungs use shared dataset paths."""
+    """Test that pre-R3 rungs use shared dataset paths with dataset seeds."""
 
     @pytest.mark.parametrize("rung", ["r0", "r1", "r2"])
     def test_step_1_pre_r3_uses_shared_path(self, tmp_path, rung):
-        """Pre-R3 Step 1 output goes to shared base_datasets/pre_r3/{mode}/seed_{seed}/."""
+        """Pre-R3 Step 1 output goes to base_datasets/pre_r3/{mode}/seed_{ds_seed}/."""
         state = RunState.create_fresh(rung, "quick", [42])
         state_path = tmp_path / "state.json"
         state.save(state_path)
 
-        captured_cmd = []
+        captured_cmds = []
 
         def mock_run(cmd, *args, **kwargs):
-            captured_cmd.extend(cmd)
+            captured_cmds.append(list(cmd))
             return True, ""
 
         with (
@@ -2828,27 +2846,30 @@ class TestSharedDatasetPaths:
             cont_dir.mkdir(parents=True)
             (cont_dir / "hybrid_r0_full.json").write_text("{}")
 
-            run_rung_mod.execute_step_1(state, seed=42)
+            run_rung_mod.execute_step_1(state)
 
-        od_idx = captured_cmd.index("--output-dir")
-        od_path = captured_cmd[od_idx + 1]
+        # Quick has 1 dataset seed (1001)
+        assert len(captured_cmds) == 1
+        cmd = captured_cmds[0]
+        od_idx = cmd.index("--output-dir")
+        od_path = cmd[od_idx + 1]
         assert "base_datasets" in od_path
         assert "pre_r3" in od_path
         assert "quick" in od_path
-        assert "seed_42" in od_path
+        assert "seed_1001" in od_path
         # Should NOT contain rung-specific name
         assert f"av_{rung}" not in od_path
 
-    def test_step_1_r3_uses_rung_local_path(self, tmp_path):
-        """R3 Step 1 output goes to rung-local av_r3_{mode}_{seed}/."""
+    def test_step_1_r3_uses_r3_datasets_path(self, tmp_path):
+        """R3 Step 1 output goes to r3_datasets/{mode}/seed_{ds_seed}/."""
         state = RunState.create_fresh("r3", "quick", [42])
         state_path = tmp_path / "state.json"
         state.save(state_path)
 
-        captured_cmd = []
+        captured_cmds = []
 
         def mock_run(cmd, *args, **kwargs):
-            captured_cmd.extend(cmd)
+            captured_cmds.append(list(cmd))
             return True, ""
 
         with (
@@ -2860,20 +2881,24 @@ class TestSharedDatasetPaths:
             cont_dir.mkdir(parents=True)
             (cont_dir / "hybrid_r0_full.json").write_text("{}")
 
-            run_rung_mod.execute_step_1(state, seed=42)
+            run_rung_mod.execute_step_1(state)
 
-        od_idx = captured_cmd.index("--output-dir")
-        od_path = captured_cmd[od_idx + 1]
-        assert "av_r3_quick_42" in od_path
+        assert len(captured_cmds) == 1
+        cmd = captured_cmds[0]
+        od_idx = cmd.index("--output-dir")
+        od_path = cmd[od_idx + 1]
+        assert "r3_datasets" in od_path
+        assert "quick" in od_path
+        assert "seed_1001" in od_path
         assert "base_datasets" not in od_path
 
     def test_step_1_pre_r3_skips_if_dataset_exists(self, tmp_path):
-        """Pre-R3 Step 1 skips generation if shared dataset already has part files."""
+        """Pre-R3 Step 1 skips generation if shared dataset already has parquet files."""
         state = RunState.create_fresh("r1", "quick", [42])
         state_path = tmp_path / "state.json"
         state.save(state_path)
 
-        # Create existing shared dataset
+        # Create existing shared dataset for seed 1001
         av_dir = (
             tmp_path
             / "data"
@@ -2882,17 +2907,17 @@ class TestSharedDatasetPaths:
             / "base_datasets"
             / "pre_r3"
             / "quick"
-            / "seed_42"
+            / "seed_1001"
             / "datasets"
             / "action_value"
         )
         av_dir.mkdir(parents=True)
         (av_dir / "part_000000_004999.parquet").write_bytes(b"fake")
 
-        captured_cmd = []
+        captured_cmds = []
 
         def mock_run(cmd, *args, **kwargs):
-            captured_cmd.extend(cmd)
+            captured_cmds.append(list(cmd))
             return True, ""
 
         with (
@@ -2904,9 +2929,211 @@ class TestSharedDatasetPaths:
             cont_dir.mkdir(parents=True)
             (cont_dir / "hybrid_r0_full.json").write_text("{}")
 
-            result = run_rung_mod.execute_step_1(state, seed=42)
+            result = run_rung_mod.execute_step_1(state)
 
         assert result is True
         # run_subprocess should NOT have been called (skipped)
-        assert len(captured_cmd) == 0
+        assert len(captured_cmds) == 0
         assert state.steps["1"]["status"] == "complete"
+
+
+# ============================================================================
+# Dataset-Build Seed Separation Tests (runbook §4.2)
+# ============================================================================
+
+
+class TestDatasetBuildSeedSeparation:
+    """Test MODE_DATASET_SEEDS, MODE_DEALS_PER_SHARD, and holistic Step 1."""
+
+    def test_mode_dataset_seeds_contract(self):
+        """MODE_DATASET_SEEDS matches runbook §4.2."""
+        assert run_rung_mod.MODE_DATASET_SEEDS["smoke"] == [1001]
+        assert run_rung_mod.MODE_DATASET_SEEDS["quick"] == [1001]
+        assert run_rung_mod.MODE_DATASET_SEEDS["full"] == list(range(1001, 1011))
+
+    def test_mode_deals_per_shard_contract(self):
+        """MODE_DEALS_PER_SHARD matches runbook §4.2."""
+        assert run_rung_mod.MODE_DEALS_PER_SHARD["smoke"] == 25
+        assert run_rung_mod.MODE_DEALS_PER_SHARD["quick"] == 5000
+        assert run_rung_mod.MODE_DEALS_PER_SHARD["full"] == 5000
+
+    def test_deals_total_equals_shards_times_per_shard(self):
+        """MODE_DEALS total = len(dataset_seeds) * deals_per_shard."""
+        for mode in ("smoke", "quick", "full"):
+            expected = (
+                len(run_rung_mod.MODE_DATASET_SEEDS[mode])
+                * run_rung_mod.MODE_DEALS_PER_SHARD[mode]
+            )
+            assert (
+                run_rung_mod.MODE_DEALS[mode] == expected
+            ), f"{mode}: {run_rung_mod.MODE_DEALS[mode]} != {expected}"
+
+    def test_step_1_not_in_per_seed_steps(self):
+        """Step 1 is holistic, not per-seed."""
+        assert "1" not in run_rung_mod.PER_SEED_STEPS
+        assert "1" in run_rung_mod.HOLISTIC_STEPS
+
+    def test_step_1_full_generates_10_shards(self, tmp_path):
+        """Full mode Step 1 generates 10 shards (one per dataset seed)."""
+        state = RunState.create_fresh("r0", "full", [42, 123, 456])
+        state_path = tmp_path / "state.json"
+        state.save(state_path)
+
+        captured_cmds = []
+
+        def mock_run(cmd, *args, **kwargs):
+            captured_cmds.append(list(cmd))
+            return True, ""
+
+        with (
+            patch.object(run_rung_mod, "run_subprocess", side_effect=mock_run),
+            patch.object(run_rung_mod, "_repo_root", return_value=tmp_path),
+            patch.object(run_rung_mod, "_state_path", return_value=state_path),
+        ):
+            cont_dir = tmp_path / "data" / "artifacts" / "arc_d" / "r0"
+            cont_dir.mkdir(parents=True)
+            (cont_dir / "hybrid_r0_full.json").write_text("{}")
+
+            run_rung_mod.execute_step_1(state)
+
+        assert len(captured_cmds) == 10
+        # Each call should use a different dataset seed
+        seeds_used = []
+        for cmd in captured_cmds:
+            seed_idx = cmd.index("--seed")
+            seeds_used.append(int(cmd[seed_idx + 1]))
+        assert seeds_used == list(range(1001, 1011))
+
+    def test_step_1_smoke_generates_1_shard_seed_1001(self, tmp_path):
+        """Smoke mode Step 1 generates exactly 1 shard with seed 1001."""
+        state = RunState.create_fresh("r0", "smoke", [42])
+        state_path = tmp_path / "state.json"
+        state.save(state_path)
+
+        captured_cmds = []
+
+        def mock_run(cmd, *args, **kwargs):
+            captured_cmds.append(list(cmd))
+            return True, ""
+
+        with (
+            patch.object(run_rung_mod, "run_subprocess", side_effect=mock_run),
+            patch.object(run_rung_mod, "_repo_root", return_value=tmp_path),
+            patch.object(run_rung_mod, "_state_path", return_value=state_path),
+        ):
+            cont_dir = tmp_path / "data" / "artifacts" / "arc_d" / "r0"
+            cont_dir.mkdir(parents=True)
+            (cont_dir / "hybrid_r0_full.json").write_text("{}")
+
+            run_rung_mod.execute_step_1(state)
+
+        assert len(captured_cmds) == 1
+        cmd = captured_cmds[0]
+        seed_idx = cmd.index("--seed")
+        assert cmd[seed_idx + 1] == "1001"
+        od_idx = cmd.index("--output-dir")
+        assert "seed_1001" in cmd[od_idx + 1]
+
+    def test_step_1_uses_dataset_seed_arg(self, tmp_path):
+        """Step 1 passes --dataset-seed matching the shard seed."""
+        state = RunState.create_fresh("r0", "quick", [42])
+        state_path = tmp_path / "state.json"
+        state.save(state_path)
+
+        captured_cmds = []
+
+        def mock_run(cmd, *args, **kwargs):
+            captured_cmds.append(list(cmd))
+            return True, ""
+
+        with (
+            patch.object(run_rung_mod, "run_subprocess", side_effect=mock_run),
+            patch.object(run_rung_mod, "_repo_root", return_value=tmp_path),
+            patch.object(run_rung_mod, "_state_path", return_value=state_path),
+        ):
+            cont_dir = tmp_path / "data" / "artifacts" / "arc_d" / "r0"
+            cont_dir.mkdir(parents=True)
+            (cont_dir / "hybrid_r0_full.json").write_text("{}")
+
+            run_rung_mod.execute_step_1(state)
+
+        cmd = captured_cmds[0]
+        assert "--dataset-seed" in cmd
+        ds_idx = cmd.index("--dataset-seed")
+        assert cmd[ds_idx + 1] == "1001"
+
+    def test_step_1_uses_deals_per_shard_not_total(self, tmp_path):
+        """Full mode Step 1 uses 5000 per shard, not 50000 total."""
+        state = RunState.create_fresh("r0", "full", [42, 123, 456])
+        state_path = tmp_path / "state.json"
+        state.save(state_path)
+
+        captured_cmds = []
+
+        def mock_run(cmd, *args, **kwargs):
+            captured_cmds.append(list(cmd))
+            return True, ""
+
+        with (
+            patch.object(run_rung_mod, "run_subprocess", side_effect=mock_run),
+            patch.object(run_rung_mod, "_repo_root", return_value=tmp_path),
+            patch.object(run_rung_mod, "_state_path", return_value=state_path),
+        ):
+            cont_dir = tmp_path / "data" / "artifacts" / "arc_d" / "r0"
+            cont_dir.mkdir(parents=True)
+            (cont_dir / "hybrid_r0_full.json").write_text("{}")
+
+            run_rung_mod.execute_step_1(state)
+
+        for cmd in captured_cmds:
+            nd_idx = cmd.index("--n-deals")
+            assert cmd[nd_idx + 1] == "5000"  # per-shard, not 50000 total
+
+    def test_step_1_partial_shard_resume(self, tmp_path):
+        """Step 1 skips already-generated shards and generates remaining ones."""
+        state = RunState.create_fresh("r0", "full", [42, 123, 456])
+        state_path = tmp_path / "state.json"
+        state.save(state_path)
+
+        # Pre-create shards for seeds 1001-1005 (first 5 of 10)
+        for ds_seed in range(1001, 1006):
+            av_dir = (
+                tmp_path
+                / "data"
+                / "runs"
+                / "arc_d_v2"
+                / "base_datasets"
+                / "pre_r3"
+                / "full"
+                / f"seed_{ds_seed}"
+                / "datasets"
+                / "action_value"
+            )
+            av_dir.mkdir(parents=True)
+            (av_dir / "part_000000_004999.parquet").write_bytes(b"fake")
+
+        captured_cmds = []
+
+        def mock_run(cmd, *args, **kwargs):
+            captured_cmds.append(list(cmd))
+            return True, ""
+
+        with (
+            patch.object(run_rung_mod, "run_subprocess", side_effect=mock_run),
+            patch.object(run_rung_mod, "_repo_root", return_value=tmp_path),
+            patch.object(run_rung_mod, "_state_path", return_value=state_path),
+        ):
+            cont_dir = tmp_path / "data" / "artifacts" / "arc_d" / "r0"
+            cont_dir.mkdir(parents=True)
+            (cont_dir / "hybrid_r0_full.json").write_text("{}")
+
+            result = run_rung_mod.execute_step_1(state)
+
+        assert result is True
+        # Only 5 remaining shards (1006-1010) should be generated
+        assert len(captured_cmds) == 5
+        seeds_generated = []
+        for cmd in captured_cmds:
+            seed_idx = cmd.index("--seed")
+            seeds_generated.append(int(cmd[seed_idx + 1]))
+        assert seeds_generated == list(range(1006, 1011))


### PR DESCRIPTION
## Summary
- Separate dataset-build seeds (1001-1010) from run seeds (42, 123, 456) per runbook §4.2
- Dataset seeds control which deals exist in the corpus; run seeds control train/val/test splits
- Fixes FULL mode generating 150k deals (3×50k) instead of the intended 50k (10×5k shards)

## Why
The orchestrator conflated run seeds with dataset-build seeds. `execute_step_1()` was in `PER_SEED_STEPS`, so for FULL mode it was called 3 times (once per run seed), each generating 50,000 deals. This produced 150k total deals instead of the intended 50k from 10 shards of 5k deals each.

## Changes
| File | Change |
|------|--------|
| `orchestration.py` | Add `MODE_DATASET_SEEDS`, `MODE_DEALS_PER_SHARD`; refactor `execute_step_1()` to holistic; move step 1 to `HOLISTIC_STEPS`; update R3 dataset path |
| `paths.py` | Add `pre_r3_dataset_root()`, `r3_dataset_root()`, `dataset_root()` helpers |
| `train_action_value.py` | Use `hand_uid` for forward-selection grouping when available |
| `overnight_full_orchestrator.sh` | Simplify to one call per rung (multi-seed handled internally) |
| `test_rung_orchestrator.py` | 9 new tests + 15 updated tests (156 total pass) |

## Repro / Validation
```bash
# In worktree
cd ../Bid-Euchre-seed-fix
uv run python -m pytest tests/unit/test_rung_orchestrator.py -x -q  # 156 pass
make check-quiet  # All checks pass
```

## Tests
- `make check-quiet` — all 5 checks pass
- 9 new tests covering seed separation contract, shard generation, partial resume
- 15 existing tests updated for new holistic Step 1 signature

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-seed-fix
branch: fix/separate-dataset-build-seeds
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)