### PR TITLE
fix: treat skipped hypotheses as SKIP not FAIL in decision pipeline

### DIFF
--- a/src/bid_euchre/arc_d_v2/report.py
+++ b/src/bid_euchre/arc_d_v2/report.py
@@ -379,12 +379,17 @@ def _extract_advancement_decision(
     if not statuses:
         return "PENDING"
 
-    n_fail = sum(1 for s in statuses if s == "FAIL")
-    n_pass = sum(1 for s in statuses if s == "PASS")
+    # Exclude SKIP hypotheses (excluded models) from the decision
+    evaluated = [s for s in statuses if s != "SKIP"]
+    if not evaluated:
+        return "PENDING"
+
+    n_fail = sum(1 for s in evaluated if s == "FAIL")
+    n_pass = sum(1 for s in evaluated if s == "PASS")
 
     if n_fail > 0:
         return "HALT"
-    if n_pass == len(statuses):
+    if n_pass == len(evaluated):
         return "ADVANCE"
     return "HOLD"
 

--- a/src/bid_euchre/arc_d_v2/tables.py
+++ b/src/bid_euchre/arc_d_v2/tables.py
@@ -595,12 +595,21 @@ def generate_hypothesis_outcomes(
             expected_bound = h.get("expected_bound", "")
             surprise = h.get("surprise_hit", False)
 
-            status = "PASS" if passed else "FAIL"
+            if h.get("skipped"):
+                status = "SKIP"
+            elif passed:
+                status = "PASS"
+            else:
+                status = "FAIL"
             evidence = f"observed={observed}"
             if expected_bound:
                 evidence += f", bound={expected_bound}"
 
             notes_parts = []
+            if h.get("skipped"):
+                note = h.get("note", "")
+                if note:
+                    notes_parts.append(note)
             if surprise:
                 notes_parts.append("SURPRISE")
             if h.get("error"):

--- a/tests/unit/test_rung_report.py
+++ b/tests/unit/test_rung_report.py
@@ -228,6 +228,28 @@ class TestDecisionReport:
         assert "**PENDING**" in content
         assert "not yet available" in content
 
+    def test_advance_when_passes_plus_skips(self, tmp_path, charts_dir):
+        """Reports ADVANCE when evaluated checks pass and skipped checks are ignored."""
+        tables_dir = _make_hypothesis_outcomes(
+            tmp_path, ["PASS", "PASS", "SKIP", "PASS", "SKIP"]
+        )
+        _make_comparator_rankings(tables_dir)
+        _make_h2h_tier_summary(tables_dir)
+        content = generate_decision_report(
+            tables_dir=tables_dir,
+            charts_dir=charts_dir,
+        )
+        assert "**ADVANCE**" in content
+
+    def test_pending_when_all_skipped(self, tmp_path, charts_dir):
+        """Reports PENDING when all hypothesis checks are skipped."""
+        tables_dir = _make_hypothesis_outcomes(tmp_path, ["SKIP", "SKIP"])
+        content = generate_decision_report(
+            tables_dir=tables_dir,
+            charts_dir=charts_dir,
+        )
+        assert "**PENDING**" in content
+
     def test_uses_team0_labels(self, tables_with_all_data, charts_dir):
         """Decision report uses team0/team1 labeling for H2H data."""
         content = generate_decision_report(

--- a/tests/unit/test_rung_tables.py
+++ b/tests/unit/test_rung_tables.py
@@ -353,6 +353,38 @@ class TestHypothesisOutcomes:
         assert df.iloc[1]["status"] == "FAIL"
         assert "SURPRISE" in df.iloc[1]["notes"]
 
+    def test_skipped_hypothesis_status(self):
+        """Skipped hypotheses (excluded models) get status SKIP, not FAIL."""
+        advance_check = {
+            "hypothesis_checks": [
+                {
+                    "id": "H1",
+                    "description": "Passing hypothesis",
+                    "pass": True,
+                    "observed": 1.5,
+                    "expected_bound": "> 0.5",
+                    "surprise_hit": False,
+                    "error": None,
+                },
+                {
+                    "id": "H5",
+                    "description": "Skipped hypothesis",
+                    "pass": False,
+                    "observed": None,
+                    "expected_bound": None,
+                    "surprise_hit": False,
+                    "error": None,
+                    "skipped": True,
+                    "note": "SKIP: model(s) selected_ols_av not in active roster",
+                },
+            ],
+        }
+        df = generate_hypothesis_outcomes(advance_check)
+        assert len(df) == 2
+        assert df.iloc[0]["status"] == "PASS"
+        assert df.iloc[1]["status"] == "SKIP"
+        assert "selected_ols_av" in df.iloc[1]["notes"]
+
     def test_no_overwrite_populated_csv(self, tmp_path):
         """generate_all_tables does not overwrite populated hypothesis_outcomes."""
         output_dir = tmp_path / "tables"


### PR DESCRIPTION
## Plan
N/A — bugfix discovered during R0 FULL advance check processing

## Summary
- `generate_hypothesis_outcomes()` now maps `skipped: true` → status `SKIP` (was `FAIL`)
- `_extract_advancement_decision()` excludes `SKIP` from pass/fail tally
- 3 new tests covering skip handling in tables and decision report

## Why
Hypotheses H5 and H8 reference `selected_ols_av`, which was trimmed from the active roster by LA-4 (FULL roster trim). The advance check correctly marks these as `skipped: true` with `pass: false`, but `generate_hypothesis_outcomes()` only checked the `pass` field, mapping them to `FAIL`. This caused `_extract_advancement_decision()` to return `HALT` instead of `ADVANCE` for rungs where all *evaluated* hypotheses pass.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_rung_tables.py::TestHypothesisOutcomes tests/unit/test_rung_report.py::TestDecisionReport -v
make check-quiet
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_rung_tables.py::TestHypothesisOutcomes -v` (4/4 pass)
- [x] `uv run python -m pytest tests/unit/test_rung_report.py::TestDecisionReport -v` (13/13 pass)
- [x] `make check-quiet` — all checks pass

## Expected impact
- Metrics impact: None (reporting only)
- Runtime impact: None

## Risk level
- [x] Medium (strategy/experiments) — affects advance check decision output

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-skip-hypothesis
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-skip-hypothesis
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         13ba62e [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-skip-hypothesis     c06faa6 [fix/hypothesis-skip-status]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)