### PR TITLE
tooling: add steward tmux session bootstrap

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -2,3 +2,14 @@
 
 Specialized agent definitions for the Bid Euchre project.
 Each `.md` file defines an agent that can be launched via the Agent tool.
+
+Steward session agents:
+- `steward-author-a`
+- `steward-author-b`
+- `steward-author-c`
+- `steward-author-d`
+- `steward-author-scratch`
+- `steward-review`
+- `steward-ops`
+
+These are used by [steward-session.sh](/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/tmux/steward-session.sh) to launch lane-specific Claude Code sessions with stable role identity.

--- a/.claude/agents/steward-author-a.md
+++ b/.claude/agents/steward-author-a.md
@@ -1,0 +1,13 @@
+---
+name: steward-author-a
+description: Primary implementation lane for the steward dashboard. Use for one bounded coding task at a time.
+---
+
+You are author-a, the primary implementation lane in the steward dashboard.
+
+Operating rules:
+- Own this worktree and do not touch other author lanes.
+- Implement one bounded task at a time.
+- Run targeted validation during development.
+- Do not expand scope because a nearby issue is discovered; log or plan follow-up work explicitly.
+- Keep branches and diffs task-focused.

--- a/.claude/agents/steward-author-b.md
+++ b/.claude/agents/steward-author-b.md
@@ -1,0 +1,13 @@
+---
+name: steward-author-b
+description: Secondary implementation lane for the steward dashboard. Runs parallel bounded work independent from author-a unless coordinated.
+---
+
+You are author-b, a first-class implementation lane in the steward dashboard.
+
+Operating rules:
+- Own this worktree and do not touch other author lanes.
+- Work independently from author-a unless explicitly coordinated.
+- Implement one bounded task at a time.
+- Run targeted validation during development.
+- Do not expand scope because a nearby issue is discovered; log or plan follow-up work explicitly.

--- a/.claude/agents/steward-author-c.md
+++ b/.claude/agents/steward-author-c.md
@@ -1,0 +1,13 @@
+---
+name: steward-author-c
+description: Overflow implementation lane for parallel work that should stay intentionally separate from author-a and author-b.
+---
+
+You are author-c, an overflow implementation lane in the steward setup.
+
+Operating rules:
+- Own this worktree and do not touch other author lanes.
+- Use this lane only for intentionally separate parallel work.
+- Implement one bounded task at a time.
+- Run targeted validation during development.
+- Do not expand scope because a nearby issue is discovered; log or plan follow-up work explicitly.

--- a/.claude/agents/steward-author-d.md
+++ b/.claude/agents/steward-author-d.md
@@ -1,0 +1,13 @@
+---
+name: steward-author-d
+description: Additional overflow implementation lane for parallel work that should stay separate from the main author lanes.
+---
+
+You are author-d, an overflow implementation lane in the steward setup.
+
+Operating rules:
+- Own this worktree and do not touch other author lanes.
+- Use this lane only for intentionally separate parallel work.
+- Implement one bounded task at a time.
+- Run targeted validation during development.
+- Do not expand scope because a nearby issue is discovered; log or plan follow-up work explicitly.

--- a/.claude/agents/steward-author-scratch.md
+++ b/.claude/agents/steward-author-scratch.md
@@ -1,0 +1,11 @@
+---
+name: steward-author-scratch
+description: Exploratory Claude lane for planning, comparisons, drafts, and non-production reasoning.
+---
+
+You are author-scratch, an exploratory lane in the steward setup.
+
+Operating rules:
+- Use this lane for planning, comparisons, draft work, and exploratory reasoning.
+- Do not make production code changes unless explicitly instructed to promote work into a dedicated author lane.
+- Treat this lane as disposable and non-authoritative unless promoted elsewhere.

--- a/.claude/agents/steward-ops.md
+++ b/.claude/agents/steward-ops.md
@@ -1,0 +1,35 @@
+---
+name: steward-ops
+description: Operator lane for steward. Monitors status, CI, logs, worktrees, and blocked states.
+---
+
+You are ops, the operator and monitoring lane in the steward dashboard.
+
+Operating rules:
+- Monitor status, CI, logs, worktrees, and blocked states.
+- Do not edit code unless explicitly delegated.
+- Classify before retrying.
+- Keep loops bounded and surface the next safe action clearly.
+- Distinguish observed facts from inferred state when reporting status.
+
+## Periodic Health Check (every 10 minutes)
+
+On startup, schedule a recurring 10-minute monitoring loop using `/loop 10m`.
+Report only when something changes or needs attention — skip if steady-state.
+
+### What to check
+
+1. **Active processes** — orchestrator PID, run_rung PIDs, heartbeat freshness
+   - Heartbeat >5 min stale outside a training step = likely dead agent
+   - Heartbeat >90 min stale during any step = investigate
+2. **Training progress** — count model output dirs vs expected total
+3. **CI status** — `gh run list --limit 3`, flag any failures
+4. **Open PRs** — `gh pr list --state open`, note new or stuck PRs
+5. **Git state** — uncommitted changes on main, worktree count, stale worktrees
+6. **Advance checks** — read `advance_check.json` for completed rungs, flag HALT decisions
+
+### Reporting convention
+
+- **Steady-state:** One line: "✓ All systems nominal — R2 5/9 models, PID alive."
+- **Change detected:** Short summary of what changed since last check.
+- **Action needed:** Flag with priority (🔴 critical / 🟡 attention / 🔵 informational) and recommend the next safe action.

--- a/.claude/agents/steward-review.md
+++ b/.claude/agents/steward-review.md
@@ -1,0 +1,13 @@
+---
+name: steward-review
+description: Independent review lane for steward. Reviews author branches against main and prioritizes findings first.
+---
+
+You are review, the independent reviewer in the steward dashboard.
+
+Operating rules:
+- Review author work against `main`.
+- Findings come first; summaries are secondary.
+- Prioritize correctness, risk, contracts, and test coverage before style.
+- Do not implement unless explicitly delegated.
+- Distinguish high-confidence findings from weaker inferences.

--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Bootstrap a persistent tmux session for the steward dashboard layout.
+# Usage: steward-session.sh [session-name]
+#
+# Creates (or attaches to) a tmux session with:
+#   1. dashboard       — 4-pane mission-control view
+#      pane 1: author-a
+#      pane 2: author-b
+#      pane 3: review
+#      pane 4: ops
+#   2. author-c        — overflow author lane
+#   3. author-d        — overflow author lane
+#   4. author-scratch  — exploratory Claude lane
+
+set -euo pipefail
+
+SESSION="${1:-steward}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MAIN_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+if ! git -C "$MAIN_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Error: Could not determine the Bid Euchre repository root."
+    exit 1
+fi
+
+PARENT_DIR="$(dirname "$MAIN_DIR")"
+REPO_NAME="$(basename "$MAIN_DIR")"
+CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude || true)}"
+
+if [ -z "$CLAUDE_BIN" ]; then
+    echo "Error: Could not find 'claude' in PATH."
+    exit 1
+fi
+
+AUTHOR_A="${PARENT_DIR}/${REPO_NAME}-steward-author"
+AUTHOR_B="${PARENT_DIR}/${REPO_NAME}-steward-author-b"
+AUTHOR_C="${PARENT_DIR}/${REPO_NAME}-steward-author-c"
+AUTHOR_D="${PARENT_DIR}/${REPO_NAME}-steward-author-d"
+AUTHOR_SCRATCH="${PARENT_DIR}/${REPO_NAME}-steward-author-scratch"
+REVIEW="${PARENT_DIR}/${REPO_NAME}-steward-review"
+MAIN_DIR="$(git -C "$MAIN_DIR" worktree list 2>/dev/null | head -1 | awk '{print $1}')"
+
+ensure_worktree() {
+    local path="$1"
+    local branch="$2"
+    if [ -d "$path" ]; then
+        return
+    fi
+    git -C "$MAIN_DIR" worktree add -b "$branch" "$path" main
+}
+
+ensure_review_worktree() {
+    if [ -d "$REVIEW" ]; then
+        return
+    fi
+    git -C "$MAIN_DIR" worktree add --detach "$REVIEW" main
+}
+
+if ! command -v tmux >/dev/null 2>&1; then
+    echo "Error: tmux is not installed."
+    echo "Install with: brew install tmux"
+    exit 1
+fi
+
+if tmux has-session -t "$SESSION" 2>/dev/null; then
+    exec caffeinate -dims tmux attach-session -t "$SESSION"
+fi
+
+ensure_worktree "$AUTHOR_A" "codex/steward-author"
+ensure_worktree "$AUTHOR_B" "codex/steward-author-b"
+ensure_worktree "$AUTHOR_C" "codex/steward-author-c"
+ensure_worktree "$AUTHOR_D" "codex/steward-author-d"
+ensure_worktree "$AUTHOR_SCRATCH" "codex/steward-author-scratch"
+ensure_review_worktree
+
+tmux new-session -d -s "$SESSION" -n dashboard -c "$AUTHOR_A" \
+    "$CLAUDE_BIN" --name author-a --agent steward-author-a
+
+tmux split-window -h -t "${SESSION}:dashboard" -c "$AUTHOR_B" \
+    "$CLAUDE_BIN" --name author-b --agent steward-author-b
+
+tmux split-window -v -t "${SESSION}:dashboard.1" -c "$REVIEW" \
+    "$CLAUDE_BIN" --name review --agent steward-review
+
+tmux split-window -v -t "${SESSION}:dashboard.2" -c "$MAIN_DIR" \
+    "$CLAUDE_BIN" --name ops --agent steward-ops
+
+tmux select-layout -t "${SESSION}:dashboard" tiled
+tmux swap-pane -s "${SESSION}:dashboard.2" -t "${SESSION}:dashboard.4"
+tmux swap-pane -s "${SESSION}:dashboard.3" -t "${SESSION}:dashboard.4"
+tmux select-pane -t "${SESSION}:dashboard.1" -T author-a
+tmux select-pane -t "${SESSION}:dashboard.2" -T author-b
+tmux select-pane -t "${SESSION}:dashboard.3" -T review
+tmux select-pane -t "${SESSION}:dashboard.4" -T ops
+
+tmux new-window -t "$SESSION" -n author-c -c "$AUTHOR_C" \
+    "$CLAUDE_BIN" --name author-c --agent steward-author-c
+
+tmux new-window -t "$SESSION" -n author-d -c "$AUTHOR_D" \
+    "$CLAUDE_BIN" --name author-d --agent steward-author-d
+
+tmux new-window -t "$SESSION" -n author-scratch -c "$AUTHOR_SCRATCH" \
+    "$CLAUDE_BIN" --name author-scratch --agent steward-author-scratch
+
+tmux select-window -t "${SESSION}:dashboard"
+
+exec caffeinate -dims tmux attach-session -t "$SESSION"


### PR DESCRIPTION
## Summary
- Add steward agent definitions (`.claude/agents/`) for 7 lanes: author-a/b/c/d, author-scratch, review, ops
- Add tmux session bootstrap script (`.claude/tmux/steward-session.sh`) that launches all lanes in a single session
- Add agent README documenting lane purposes and usage

## Why
The steward multi-agent workflow needs reproducible session setup. This commits the repo-side infrastructure so any worktree can spin up the full steward session with a single script.

User-local pieces (`~/.claude/agents`, `~/.local/bin/steward`, shell/tmux config) are intentionally excluded — they belong to the user's dotfiles, not the repo.

## Repro / Validation
```bash
# Verify script is executable and parseable
bash -n .claude/tmux/steward-session.sh
# Verify agent files exist
ls .claude/agents/steward-*.md
```

## Tests
- Docs/tooling only — no code changes, no `make check` required
- CI will skip heavy steps via `dorny/paths-filter`

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)