### PR TITLE
fix: narrow GitHub Action permissions + review follow-ups (#798-#803)

### DIFF
--- a/.claude/rules/deferred/60_review_gate.md
+++ b/.claude/rules/deferred/60_review_gate.md
@@ -169,6 +169,9 @@ overlap or replace each other.
   or branch protection rules.
 - The `allowed_tools` list in `claude.yml` is intentionally read-only +
   CI/PR management. It does not include `Edit`, `Write`, or `git push`.
+- The workflow uses `contents: read` (not `write`) to match its read-only intent.
+  `gh pr` subcommands are enumerated explicitly (view, checks, list, diff,
+  comment, status) — no wildcards that could match destructive operations.
 
 ## Known Issue: Docs-Only PRs and CI
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,7 +19,7 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
       id-token: write
@@ -43,7 +43,10 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Allowed tools — scoped to read-only inspection + CI/PR management
+          # Allowed tools — scoped to read-only inspection + CI/PR management.
+          # IMPORTANT: Do NOT add wildcards like "gh pr *" — that matches
+          # destructive subcommands (merge, close, edit). Enumerate safe
+          # subcommands explicitly.
           allowed_tools: |
             Bash(make check)
             Bash(make check-quiet)
@@ -52,8 +55,16 @@ jobs:
             Bash(uv run python -m pytest *)
             Bash(uv run ruff check *)
             Bash(uv run ruff format --check *)
-            Bash(gh pr *)
-            Bash(gh issue *)
+            Bash(gh pr view *)
+            Bash(gh pr checks *)
+            Bash(gh pr list *)
+            Bash(gh pr diff *)
+            Bash(gh pr comment *)
+            Bash(gh pr status *)
+            Bash(gh issue view *)
+            Bash(gh issue list *)
+            Bash(gh issue comment *)
             Bash(git diff *)
             Bash(git log *)
             Bash(git show *)
+            Bash(git status)

--- a/scripts/internal/codex_review_adapter.py
+++ b/scripts/internal/codex_review_adapter.py
@@ -148,35 +148,39 @@ _PROSE_SEVERITY_KEYWORDS = {
     ],
 }
 
-# Patterns that indicate a genuinely clean review (no findings expected)
+# Patterns that indicate a genuinely clean review (no findings expected).
+# Each string is one alternative; compiled with | join for readability.
+_CLEAN_REVIEW_PATTERN_STRINGS: list[str] = [
+    # --- Original patterns ---
+    r"no\s+(?:issues?|findings?|problems?|concerns?)(?:\s+found)?",
+    r"(?:changes?\s+)?look(?:s)?\s+good",
+    r"0\s+findings",
+    r"lgtm",
+    r"all\s+(?:good|clear|clean)",
+    r"ship\s+it",
+    r"(?:^|\.\s+)approved(?:\.|\s*$)",
+    r"nothing\s+to\s+(?:flag|report|note)",
+    r"changes?\s+(?:are\s+)?clean",
+    # --- Expanded patterns (PR #799 — Codex uses varied phrasings) ---
+    r"no\s+(?:significant|major|critical|blocking)\s+issues?",
+    r"no\s+(?:blockers?|violations?)",
+    r"everything\s+(?:looks?\s+good|checks?\s+out)",
+    r"(?:I\s+)?(?:found|see|find|detect(?:ed)?)\s+no\s+issues?",
+    r"(?:I\s+)?(?:don'?t|do\s+not)\s+see\s+(?:any\s+)?issues?",
+    r"good\s+to\s+go",
+    r"ready\s+to\s+merge",
+    r"no\s+(?:action|changes?)\s+(?:needed|required)",
+    r"pass(?:es)?\s+all\s+checks",
+    r"(?:code|plan|changes?|implementation)\s+(?:is|are)\s+(?:correct|sound|solid)",
+    r"(?:looks?|appears?)\s+correct",
+    r"nothing\s+(?:stands?\s+out|to\s+(?:add|mention|change))",
+    r"no\s+(?:errors?|problems?)\s+detected",
+    r"satisfactory",
+    r"no\s+(?:items?|things?)\s+to\s+(?:flag|report|address)",
+]
+
 _CLEAN_REVIEW_PATTERNS = re.compile(
-    r"(?i)"
-    # Original patterns
-    r"(?:no\s+(?:issues?|findings?|problems?|concerns?)(?:\s+found)?)"
-    r"|(?:(?:changes?\s+)?look(?:s)?\s+good)"
-    r"|(?:0\s+findings)"
-    r"|(?:lgtm)"
-    r"|(?:all\s+(?:good|clear|clean))"
-    r"|(?:ship\s+it)"
-    r"|(?:(?:^|\.\s+)approved(?:\.|\s*$))"
-    r"|(?:nothing\s+to\s+(?:flag|report|note))"
-    r"|(?:changes?\s+(?:are\s+)?clean)"
-    # Expanded patterns (PR #799 fix — Codex uses varied phrasings)
-    r"|(?:no\s+(?:significant|major|critical|blocking)\s+issues?)"
-    r"|(?:no\s+(?:blockers?|violations?))"
-    r"|(?:everything\s+(?:looks?\s+good|checks?\s+out))"
-    r"|(?:(?:I\s+)?(?:found|see|find|detect(?:ed)?)\s+no\s+issues?)"
-    r"|(?:(?:I\s+)?(?:don'?t|do\s+not)\s+see\s+(?:any\s+)?issues?)"
-    r"|(?:good\s+to\s+go)"
-    r"|(?:ready\s+to\s+merge)"
-    r"|(?:no\s+(?:action|changes?)\s+(?:needed|required))"
-    r"|(?:pass(?:es)?\s+all\s+checks)"
-    r"|(?:(?:code|plan|changes?|implementation)\s+(?:is|are)\s+(?:correct|sound|solid))"
-    r"|(?:(?:looks?|appears?)\s+correct)"
-    r"|(?:nothing\s+(?:stands?\s+out|to\s+(?:add|mention|change)))"
-    r"|(?:no\s+(?:errors?|problems?)\s+detected)"
-    r"|(?:satisfactory)"
-    r"|(?:no\s+(?:items?|things?)\s+to\s+(?:flag|report|address))"
+    r"(?i)(?:" + "|".join(_CLEAN_REVIEW_PATTERN_STRINGS) + r")"
 )
 
 

--- a/src/bid_euchre/arc_d_v2/tables.py
+++ b/src/bid_euchre/arc_d_v2/tables.py
@@ -1381,16 +1381,22 @@ def _extract_outcome_distributions_from_parquet(
     return rows
 
 
-def _extract_decision_comparison(
+def _load_and_merge_pairwise(
     parquet_paths: list[Path],
-) -> list[dict]:
-    """Extract per-deal bid decision comparison across models.
+    required_columns: set[str],
+    caller: str,
+) -> tuple[pd.DataFrame | None, str]:
+    """Load parquet files and produce pairwise model merges.
 
-    Requires parquet files with bid decision columns (e.g., ``bid_decision``,
-    ``model``). If the schema lacks these columns, returns an empty list with
-    an informational log message.
+    Shared helper for :func:`_extract_decision_comparison` and
+    :func:`_extract_disagreement_outcomes`.  Handles file reading, column
+    validation, contract-column detection, and pairwise model merging.
 
-    Schema: model_a, model_b, contract, deal_id, decision_a, decision_b, agreed
+    Returns:
+        ``(merged_df, contract_col)`` on success, or ``(None, "")`` if data
+        is missing or the schema lacks required columns.  ``merged_df``
+        contains one row per (model_a, model_b, deal) triple with columns
+        suffixed ``_a`` / ``_b``.
     """
     frames: list[pd.DataFrame] = []
     for path in parquet_paths:
@@ -1404,20 +1410,20 @@ def _extract_decision_comparison(
             continue
 
     if not frames:
-        return []
+        return None, ""
 
     combined = pd.concat(frames, ignore_index=True)
 
-    # Check for required columns: need bid decision data per model per deal
-    required = {"bid_decision", "model", "deal_id"}
-    if not required.issubset(combined.columns):
+    # Column check
+    base_required = {"bid_decision", "model", "deal_id"} | required_columns
+    if not base_required.issubset(combined.columns):
         logger.info(
-            "decision_comparison: parquet missing required columns %s. "
-            "Available: %s. Skipping.",
-            required - set(combined.columns),
+            "%s: parquet missing required columns %s. Available: %s. Skipping.",
+            caller,
+            base_required - set(combined.columns),
             list(combined.columns),
         )
-        return []
+        return None, ""
 
     # Determine contract column
     contract_col = None
@@ -1429,9 +1435,9 @@ def _extract_decision_comparison(
         contract_col = "contract"
         combined[contract_col] = "pooled"
 
-    # Build pairwise comparisons
+    # Build pairwise merges
     models = sorted(combined["model"].unique())
-    rows: list[dict] = []
+    merge_frames: list[pd.DataFrame] = []
     for i, model_a in enumerate(models):
         for model_b in models[i + 1 :]:
             df_a = combined[combined["model"] == model_a]
@@ -1439,20 +1445,48 @@ def _extract_decision_comparison(
             merged = df_a.merge(
                 df_b, on=["deal_id", contract_col], suffixes=("_a", "_b")
             )
-            for _, row in merged.iterrows():
-                rows.append(
-                    {
-                        "model_a": model_a,
-                        "model_b": model_b,
-                        "contract": row[contract_col],
-                        "deal_id": row["deal_id"],
-                        "decision_a": row["bid_decision_a"],
-                        "decision_b": row["bid_decision_b"],
-                        "agreed": row["bid_decision_a"] == row["bid_decision_b"],
-                    }
-                )
+            if not merged.empty:
+                merged = merged.copy()
+                merged["model_a"] = model_a
+                merged["model_b"] = model_b
+                merge_frames.append(merged)
 
-    return rows
+    if not merge_frames:
+        return None, ""
+
+    result = pd.concat(merge_frames, ignore_index=True)
+    return result, contract_col
+
+
+def _extract_decision_comparison(
+    parquet_paths: list[Path],
+) -> list[dict]:
+    """Extract per-deal bid decision comparison across models.
+
+    Requires parquet files with bid decision columns (e.g., ``bid_decision``,
+    ``model``). If the schema lacks these columns, returns an empty list with
+    an informational log message.
+
+    Schema: model_a, model_b, contract, deal_id, decision_a, decision_b, agreed
+    """
+    merged, contract_col = _load_and_merge_pairwise(
+        parquet_paths, set(), "decision_comparison"
+    )
+    if merged is None:
+        return []
+
+    return [
+        {
+            "model_a": row["model_a"],
+            "model_b": row["model_b"],
+            "contract": row[contract_col],
+            "deal_id": row["deal_id"],
+            "decision_a": row["bid_decision_a"],
+            "decision_b": row["bid_decision_b"],
+            "agreed": row["bid_decision_a"] == row["bid_decision_b"],
+        }
+        for _, row in merged.iterrows()
+    ]
 
 
 def _extract_disagreement_outcomes(
@@ -1466,69 +1500,26 @@ def _extract_disagreement_outcomes(
     Schema: model_a, model_b, contract, deal_id, decision_a, decision_b,
             tricks_won_a, tricks_won_b
     """
-    frames: list[pd.DataFrame] = []
-    for path in parquet_paths:
-        if not path.exists():
-            continue
-        try:
-            df = pd.read_parquet(path)
-            frames.append(df)
-        except Exception as e:
-            logger.warning("Failed to read parquet %s: %s", path, e)
-            continue
-
-    if not frames:
+    merged, contract_col = _load_and_merge_pairwise(
+        parquet_paths, {"tricks_won"}, "disagreement_outcomes"
+    )
+    if merged is None:
         return []
 
-    combined = pd.concat(frames, ignore_index=True)
-
-    # Check for required columns
-    required = {"bid_decision", "model", "deal_id", "tricks_won"}
-    if not required.issubset(combined.columns):
-        logger.info(
-            "disagreement_outcomes: parquet missing required columns %s. "
-            "Available: %s. Skipping.",
-            required - set(combined.columns),
-            list(combined.columns),
-        )
-        return []
-
-    # Determine contract column
-    contract_col = None
-    for candidate in ("contract_family", "contract_type", "contract"):
-        if candidate in combined.columns:
-            contract_col = candidate
-            break
-    if contract_col is None:
-        contract_col = "contract"
-        combined[contract_col] = "pooled"
-
-    # Build disagreement rows
-    models = sorted(combined["model"].unique())
-    rows: list[dict] = []
-    for i, model_a in enumerate(models):
-        for model_b in models[i + 1 :]:
-            df_a = combined[combined["model"] == model_a]
-            df_b = combined[combined["model"] == model_b]
-            merged = df_a.merge(
-                df_b, on=["deal_id", contract_col], suffixes=("_a", "_b")
-            )
-            disagreements = merged[merged["bid_decision_a"] != merged["bid_decision_b"]]
-            for _, row in disagreements.iterrows():
-                rows.append(
-                    {
-                        "model_a": model_a,
-                        "model_b": model_b,
-                        "contract": row[contract_col],
-                        "deal_id": row["deal_id"],
-                        "decision_a": row["bid_decision_a"],
-                        "decision_b": row["bid_decision_b"],
-                        "tricks_won_a": row["tricks_won_a"],
-                        "tricks_won_b": row["tricks_won_b"],
-                    }
-                )
-
-    return rows
+    disagreements = merged[merged["bid_decision_a"] != merged["bid_decision_b"]]
+    return [
+        {
+            "model_a": row["model_a"],
+            "model_b": row["model_b"],
+            "contract": row[contract_col],
+            "deal_id": row["deal_id"],
+            "decision_a": row["bid_decision_a"],
+            "decision_b": row["bid_decision_b"],
+            "tricks_won_a": row["tricks_won_a"],
+            "tricks_won_b": row["tricks_won_b"],
+        }
+        for _, row in disagreements.iterrows()
+    ]
 
 
 def _extract_feature_importances_flat(

--- a/tests/unit/test_plan_review_driver.py
+++ b/tests/unit/test_plan_review_driver.py
@@ -552,12 +552,14 @@ class TestRawOutputPersistence:
 
         result = run_plan_review_loop(plan_file, base_dir=tmp_path)
 
-        # Read the sidecar and verify raw output section
+        # Read the sidecar and verify it was written with expected structure.
+        # The fallback reviewer has empty raw_output, so "## Raw Output" may be
+        # absent if only the fallback's result was captured last.  Verify the
+        # sidecar at minimum contains the final state section.
         sidecar = Path(result.sidecar_path)
         assert sidecar.exists()
         content = sidecar.read_text()
-        # The fallback's empty raw_output is last, so check that sidecar was written
-        assert "## Raw Output" not in content or "## Final State" in content
+        assert "## Final State" in content
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **🔴 HIGH:** Narrow `Bash(gh pr *)` wildcard in `claude.yml` to explicit safe subcommands (view, checks, list, diff, comment, status) — prevents `gh pr merge/close/edit` from being invocable via the Claude GitHub Action
- **🔴 HIGH:** Downgrade `contents: write` to `contents: read` to match the stated read-only intent
- **⚠️ WARN:** DRY refactor `_extract_decision_comparison` / `_extract_disagreement_outcomes` in `tables.py` — extract shared `_load_and_merge_pairwise` helper eliminating ~80% code duplication
- **ℹ️ INFO:** Refactor `_CLEAN_REVIEW_PATTERNS` regex into maintainable list-of-strings format
- **ℹ️ INFO:** Strengthen weak test assertion in `test_raw_output_in_sidecar_on_failure`

## Why
Post-merge review of PRs #798–#803 identified a process safety gap where the `gh pr *` wildcard could match destructive subcommands (`merge`, `close`, `edit`), and a `contents: write` permission contradicted the documented read-only intent. The remaining fixes address code quality findings from the same review.

## Repro / Validation
```bash
make check-quiet  # All checks pass
uv run python -m pytest tests/unit/test_rung_tables.py -k "decision_comparison or disagreement_outcomes" -v
uv run python -m pytest tests/unit/test_codex_review_adapter.py -k "clean" -v
uv run python -m pytest tests/unit/test_plan_review_driver.py -k "sidecar" -v
```

## Tests
- 4 existing extractor tests pass after DRY refactor (graceful skip, empty paths)
- 48 existing clean review pattern tests pass after regex restructure
- 6 existing sidecar tests pass with strengthened assertion

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/worktree-review-followups
git worktree list shows: worktree-review-followups fix/review-followups-798-803
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)