### PR TITLE
feat: notify agents when background CI/review daemons fail

### DIFF
--- a/.claude/hooks/post-tool-daemon-notify.sh
+++ b/.claude/hooks/post-tool-daemon-notify.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# PostToolUse hook — notifies agents of background daemon failures.
+#
+# Checks .claude/runtime/{ci_polls,review_loops}/pr_*/FAILED sentinel files.
+# When found, injects failure context into the agent's tool response and
+# renames the sentinel to NOTIFIED to prevent repeated alerts.
+#
+# Lightweight: only reads local files, no network calls.
+set -euo pipefail
+
+# Locate repo root via CLAUDE_PROJECT_DIR or git
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-}"
+if [ -z "$PROJECT_DIR" ]; then
+    PROJECT_DIR=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+fi
+
+if [ -z "$PROJECT_DIR" ]; then
+    exit 0
+fi
+
+RUNTIME_DIR="${PROJECT_DIR}/.claude/runtime"
+
+if [ ! -d "$RUNTIME_DIR" ]; then
+    exit 0
+fi
+
+# Collect all FAILED sentinels
+MESSAGES=""
+
+for sentinel in "$RUNTIME_DIR"/ci_polls/pr_*/FAILED "$RUNTIME_DIR"/review_loops/pr_*/FAILED; do
+    # Skip unmatched globs
+    [ -f "$sentinel" ] || continue
+
+    # Extract daemon type and PR number from path
+    # e.g., .claude/runtime/ci_polls/pr_123/FAILED
+    daemon_dir=$(dirname "$sentinel")
+    pr_dir=$(basename "$daemon_dir")
+    pr_num="${pr_dir#pr_}"
+    parent_dir=$(basename "$(dirname "$daemon_dir")")
+
+    case "$parent_dir" in
+        ci_polls)       daemon_label="CI poller" ;;
+        review_loops)   daemon_label="Review loop" ;;
+        *)              daemon_label="Background daemon" ;;
+    esac
+
+    # Read summary (first line only, cap at 200 chars)
+    summary=$(head -1 "$sentinel" 2>/dev/null | cut -c1-200 || echo "unknown failure")
+
+    # Build message
+    MESSAGES="${MESSAGES}${daemon_label} for PR #${pr_num} FAILED: ${summary}. Log: ${daemon_dir}/$([ "$parent_dir" = "ci_polls" ] && echo "poller.log" || echo "driver.log")\n"
+
+    # Rename to NOTIFIED so we only alert once
+    mv "$sentinel" "${daemon_dir}/NOTIFIED" 2>/dev/null || true
+done
+
+# If we found any failures, emit them as additionalContext
+if [ -n "$MESSAGES" ]; then
+    # Escape for JSON
+    JSON_MSG=$(printf '%s' "$MESSAGES" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g' | tr '\n' ' ')
+
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "WARNING — Background daemon failure(s) detected:\n${JSON_MSG}\nCheck the log files for details. You may need to re-push or manually investigate."
+  }
+}
+EOF
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -72,6 +72,11 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-merge-review.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-tool-daemon-notify.sh",
+            "timeout": 5
           }
         ]
       }

--- a/scripts/internal/ci_poller.sh
+++ b/scripts/internal/ci_poller.sh
@@ -146,6 +146,7 @@ while true; do
     if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
         echo "[$(date -u +%H:%M:%S)] Timeout after ${ELAPSED}s."
         write_status "timeout" "CI still pending after ${TIMEOUT}s"
+        echo "CI_TIMEOUT: CI still pending after ${TIMEOUT}s" > "$STATE_DIR/FAILED"
         exit 2
     fi
 
@@ -179,6 +180,7 @@ while true; do
         FAILED_NAMES=$(echo "$CHECK_OUTPUT" | jq -r '[.[] | select(.state == "FAILURE") | .name] | join(", ")' 2>/dev/null || echo "unknown")
         echo "[$(date -u +%H:%M:%S)] CI FAILED: $FAILED_NAMES"
         write_status "failed" "Failed checks: $FAILED_NAMES"
+        echo "CI_FAILED: Failed checks: $FAILED_NAMES" > "$STATE_DIR/FAILED"
         exit 1
     fi
 
@@ -210,6 +212,7 @@ while true; do
 
             echo "[$(date -u +%H:%M:%S)] Auto-merge also failed (rc=$AUTO_RC): $AUTO_OUTPUT"
             write_status "merge_failed" "All checks passed but merge failed — manual merge required"
+            echo "MERGE_FAILED: All checks passed but merge failed — manual merge required" > "$STATE_DIR/FAILED"
             exit 1
         else
             write_status "passed" "All checks passed"

--- a/scripts/internal/review_driver.py
+++ b/scripts/internal/review_driver.py
@@ -37,6 +37,40 @@ from review_state import (
 
 logger = logging.getLogger("review_driver")
 
+# Failure state categories that should trigger agent notification
+_FAILURE_STATES = frozenset(
+    {
+        ReviewState.STOPPED_CI_FAILURE,
+        ReviewState.STOPPED_REVIEW_FAILURE,
+        ReviewState.STOPPED_MAX_ITERATIONS,
+        ReviewState.STOPPED_NO_PROGRESS,
+    }
+)
+
+
+def _write_failure_sentinel(loop_state: ReviewLoopState) -> None:
+    """Write a FAILED sentinel file so the notification hook can alert the agent.
+
+    Only writes for terminal failure states. The sentinel is a one-line summary
+    read by .claude/hooks/post-tool-daemon-notify.sh.
+    """
+    if loop_state.current_state not in _FAILURE_STATES:
+        return
+
+    state_dir = Path(".claude/runtime/review_loops") / f"pr_{loop_state.pr_number}"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    sentinel = state_dir / "FAILED"
+
+    reason = loop_state.stop_reason or loop_state.current_state.value
+    label = loop_state.current_state.value.upper()
+    summary = f"{label}: {reason}"
+
+    try:
+        sentinel.write_text(summary + "\n")
+        logger.info("PR #%d: wrote failure sentinel: %s", loop_state.pr_number, summary)
+    except OSError:
+        logger.warning("PR #%d: failed to write failure sentinel", loop_state.pr_number)
+
 
 def _publish_status(pr_number: int, state: str, description: str) -> bool:
     """Publish a review status to GitHub, logging errors but not raising.
@@ -1272,6 +1306,7 @@ def main() -> int:
             except Exception:
                 loop_state.state = ReviewState.STOPPED_REVIEW_FAILURE.value
             save_state(loop_state)
+            _write_failure_sentinel(loop_state)
             return 1
 
         # If we didn't advance (stuck in a polling state), sleep before retry
@@ -1302,6 +1337,7 @@ def main() -> int:
             loop_state.pr_number,
             loop_state.stop_reason or "completed",
         )
+        _write_failure_sentinel(loop_state)
 
     return 0
 

--- a/tests/unit/test_daemon_notify.py
+++ b/tests/unit/test_daemon_notify.py
@@ -1,0 +1,260 @@
+"""Tests for daemon failure notification — sentinel writes and hook behavior."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add scripts/internal to path for direct imports
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "internal"))
+
+from review_driver import _write_failure_sentinel
+from review_state import ReviewLoopState, ReviewState
+
+HOOK_SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / ".claude"
+    / "hooks"
+    / "post-tool-daemon-notify.sh"
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runtime_dir(tmp_path: Path) -> Path:
+    """Create a temporary runtime directory mimicking .claude/runtime/."""
+    rd = tmp_path / ".claude" / "runtime"
+    rd.mkdir(parents=True)
+    return rd
+
+
+def _make_loop_state(
+    pr_number: int = 42,
+    state: ReviewState = ReviewState.STOPPED_CI_FAILURE,
+    stop_reason: str = "CI failed",
+) -> ReviewLoopState:
+    """Create a minimal ReviewLoopState for testing."""
+    ls = ReviewLoopState(
+        pr_number=pr_number,
+        branch="test-branch",
+        run_id="test-run",
+    )
+    # Set state directly (bypass transition validation)
+    ls.state = state.value
+    ls.stop_reason = stop_reason
+    return ls
+
+
+# ---------------------------------------------------------------------------
+# _write_failure_sentinel tests
+# ---------------------------------------------------------------------------
+
+
+class TestWriteFailureSentinel:
+    """Tests for _write_failure_sentinel in review_driver.py."""
+
+    def test_writes_sentinel_on_ci_failure(self, tmp_path: Path) -> None:
+        ls = _make_loop_state(
+            state=ReviewState.STOPPED_CI_FAILURE, stop_reason="CI failed"
+        )
+        with _chdir(tmp_path):
+            _write_failure_sentinel(ls)
+        sentinel = (
+            tmp_path / ".claude" / "runtime" / "review_loops" / "pr_42" / "FAILED"
+        )
+        assert sentinel.exists()
+        content = sentinel.read_text()
+        assert "STOPPED_CI_FAILURE" in content
+        assert "CI failed" in content
+
+    def test_writes_sentinel_on_review_failure(self, tmp_path: Path) -> None:
+        ls = _make_loop_state(
+            state=ReviewState.STOPPED_REVIEW_FAILURE,
+            stop_reason="Codex CLI failed 3 times",
+        )
+        with _chdir(tmp_path):
+            _write_failure_sentinel(ls)
+        sentinel = (
+            tmp_path / ".claude" / "runtime" / "review_loops" / "pr_42" / "FAILED"
+        )
+        assert sentinel.exists()
+        assert "Codex CLI failed" in sentinel.read_text()
+
+    def test_writes_sentinel_on_max_iterations(self, tmp_path: Path) -> None:
+        ls = _make_loop_state(
+            state=ReviewState.STOPPED_MAX_ITERATIONS,
+            stop_reason="Hit max iterations (3)",
+        )
+        with _chdir(tmp_path):
+            _write_failure_sentinel(ls)
+        sentinel = (
+            tmp_path / ".claude" / "runtime" / "review_loops" / "pr_42" / "FAILED"
+        )
+        assert sentinel.exists()
+        assert "max iterations" in sentinel.read_text()
+
+    def test_writes_sentinel_on_no_progress(self, tmp_path: Path) -> None:
+        ls = _make_loop_state(
+            state=ReviewState.STOPPED_NO_PROGRESS,
+            stop_reason="No findings resolved after fix attempt",
+        )
+        with _chdir(tmp_path):
+            _write_failure_sentinel(ls)
+        sentinel = (
+            tmp_path / ".claude" / "runtime" / "review_loops" / "pr_42" / "FAILED"
+        )
+        assert sentinel.exists()
+
+    def test_no_sentinel_on_success(self, tmp_path: Path) -> None:
+        """Non-failure terminal states (MERGED) should NOT write sentinels."""
+        ls = _make_loop_state(state=ReviewState.MERGED, stop_reason="")
+        with _chdir(tmp_path):
+            _write_failure_sentinel(ls)
+        sentinel = (
+            tmp_path / ".claude" / "runtime" / "review_loops" / "pr_42" / "FAILED"
+        )
+        assert not sentinel.exists()
+
+    def test_no_sentinel_on_non_terminal(self, tmp_path: Path) -> None:
+        """Non-terminal states should NOT write sentinels."""
+        ls = _make_loop_state(state=ReviewState.WAITING_FOR_CI, stop_reason="")
+        with _chdir(tmp_path):
+            _write_failure_sentinel(ls)
+        sentinel = (
+            tmp_path / ".claude" / "runtime" / "review_loops" / "pr_42" / "FAILED"
+        )
+        assert not sentinel.exists()
+
+
+# ---------------------------------------------------------------------------
+# post-tool-daemon-notify.sh hook tests
+# ---------------------------------------------------------------------------
+
+
+class TestDaemonNotifyHook:
+    """Tests for .claude/hooks/post-tool-daemon-notify.sh."""
+
+    def test_no_output_when_no_sentinels(self, tmp_path: Path) -> None:
+        """Hook should produce no output when no FAILED sentinels exist."""
+        runtime = tmp_path / ".claude" / "runtime"
+        runtime.mkdir(parents=True)
+        result = _run_hook(tmp_path)
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_no_output_when_runtime_missing(self, tmp_path: Path) -> None:
+        """Hook should exit cleanly when runtime dir doesn't exist."""
+        result = _run_hook(tmp_path)
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_ci_poller_failure_detected(self, tmp_path: Path) -> None:
+        """Hook should detect and report CI poller FAILED sentinel."""
+        ci_dir = tmp_path / ".claude" / "runtime" / "ci_polls" / "pr_99"
+        ci_dir.mkdir(parents=True)
+        (ci_dir / "FAILED").write_text("CI_FAILED: Failed checks: tests\n")
+
+        result = _run_hook(tmp_path)
+        assert result.returncode == 0
+
+        output = json.loads(result.stdout)
+        ctx = output["hookSpecificOutput"]["additionalContext"]
+        assert "CI poller" in ctx
+        assert "PR #99" in ctx
+        assert "CI_FAILED" in ctx
+
+    def test_review_loop_failure_detected(self, tmp_path: Path) -> None:
+        """Hook should detect and report review loop FAILED sentinel."""
+        rl_dir = tmp_path / ".claude" / "runtime" / "review_loops" / "pr_55"
+        rl_dir.mkdir(parents=True)
+        (rl_dir / "FAILED").write_text("STOPPED_CI_FAILURE: CI failed\n")
+
+        result = _run_hook(tmp_path)
+        assert result.returncode == 0
+
+        output = json.loads(result.stdout)
+        ctx = output["hookSpecificOutput"]["additionalContext"]
+        assert "Review loop" in ctx
+        assert "PR #55" in ctx
+
+    def test_sentinel_renamed_to_notified(self, tmp_path: Path) -> None:
+        """After reporting, FAILED should be renamed to NOTIFIED."""
+        ci_dir = tmp_path / ".claude" / "runtime" / "ci_polls" / "pr_10"
+        ci_dir.mkdir(parents=True)
+        (ci_dir / "FAILED").write_text("CI_TIMEOUT: timed out\n")
+
+        _run_hook(tmp_path)
+
+        assert not (ci_dir / "FAILED").exists()
+        assert (ci_dir / "NOTIFIED").exists()
+
+    def test_notified_sentinel_not_re_reported(self, tmp_path: Path) -> None:
+        """Already-NOTIFIED sentinels should not trigger output."""
+        ci_dir = tmp_path / ".claude" / "runtime" / "ci_polls" / "pr_10"
+        ci_dir.mkdir(parents=True)
+        (ci_dir / "NOTIFIED").write_text("CI_TIMEOUT: timed out\n")
+
+        result = _run_hook(tmp_path)
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_multiple_failures_combined(self, tmp_path: Path) -> None:
+        """Multiple FAILED sentinels should be combined into one output."""
+        ci_dir = tmp_path / ".claude" / "runtime" / "ci_polls" / "pr_10"
+        ci_dir.mkdir(parents=True)
+        (ci_dir / "FAILED").write_text("CI_FAILED: tests failed\n")
+
+        rl_dir = tmp_path / ".claude" / "runtime" / "review_loops" / "pr_20"
+        rl_dir.mkdir(parents=True)
+        (rl_dir / "FAILED").write_text("STOPPED_REVIEW_FAILURE: crashed\n")
+
+        result = _run_hook(tmp_path)
+        assert result.returncode == 0
+
+        output = json.loads(result.stdout)
+        ctx = output["hookSpecificOutput"]["additionalContext"]
+        assert "PR #10" in ctx
+        assert "PR #20" in ctx
+        # Both should be renamed
+        assert not (ci_dir / "FAILED").exists()
+        assert not (rl_dir / "FAILED").exists()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _chdir(path: Path):
+    """Context manager to change cwd temporarily."""
+    old = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(old)
+
+
+def _run_hook(project_dir: Path) -> subprocess.CompletedProcess:
+    """Run the daemon notify hook with CLAUDE_PROJECT_DIR set."""
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(project_dir)
+    return subprocess.run(
+        ["bash", str(HOOK_SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        timeout=10,
+    )


### PR DESCRIPTION
## Summary
- Background daemons (`ci_poller.sh`, `review_driver.py`) now write a `FAILED` sentinel file on terminal failure states
- New PostToolUse hook (`post-tool-daemon-notify.sh`) reads sentinels and injects failure context into the agent's next tool response
- Sentinels are renamed to `NOTIFIED` after delivery to prevent repeated alerts

## Why
Background CI polling and review loop daemons fail silently — failures are logged to files nobody reads. Agents that created PRs have no visibility into daemon failures (CI failure, timeout, merge failure, review crash). This closes the feedback loop.

## Plan
`plans/sessions/2026-03-17_daemon-failure-notifications.md`

## Repro / Validation
```bash
# Run the 13 new tests
uv run python -m pytest tests/unit/test_daemon_notify.py -v

# Full validation
make check-quiet
```

## Tests
- 13 new tests in `tests/unit/test_daemon_notify.py`
  - 6 tests for `_write_failure_sentinel` (4 failure states + success/non-terminal negative cases)
  - 7 tests for the shell hook (no sentinels, missing runtime, CI/review detection, rename to NOTIFIED, multiple failures)

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/worktree-daemon-failure-notifications
branch: daemon-failure-notifications
```

## Files changed
| File | Change |
|------|--------|
| `.claude/hooks/post-tool-daemon-notify.sh` | New hook — reads FAILED sentinels, injects context |
| `.claude/settings.json` | Register new hook in PostToolUse Bash array |
| `scripts/internal/ci_poller.sh` | Write FAILED sentinel at 3 exit points (CI fail, timeout, merge fail) |
| `scripts/internal/review_driver.py` | Add `_write_failure_sentinel()` + wire into exception handler and terminal state check |
| `tests/unit/test_daemon_notify.py` | 13 tests covering sentinel writes and hook behavior |

🤖 Generated with [Claude Code](https://claude.com/claude-code)