### PR TITLE
docs: add shared-dataset rationale to runbook and LA-5

### DIFF
--- a/plans/arc_d_v2/amendments.md
+++ b/plans/arc_d_v2/amendments.md
@@ -227,6 +227,8 @@ non-canonical QUICK outputs were archived and the regeneration pipeline was repa
 
 **Shared dataset reuse (§4.5):**
 - R0, R1, R2 all share the same base dataset (same features, same deals)
+- Combined with the fixed R0 anchor, this isolates capacity vs information effects
+  (lineage plan Goal 1) — only model architecture varies across rungs
 - Output path: `data/runs/arc_d_v2/base_datasets/pre_r3/{mode}/seed_{seed}/`
 - Step 1 skips generation if the shared dataset already exists (idempotent)
 - R3+ continues to use rung-local datasets (moon/loner expansion)

--- a/plans/arc_d_v2/v2_regeneration_repair_runbook.md
+++ b/plans/arc_d_v2/v2_regeneration_repair_runbook.md
@@ -104,6 +104,11 @@ Notes:
 - Not shared:
   `r3`
 
+**Rationale:** Combined with the fixed R0 anchor (§4.1), shared pre-R3 datasets
+ensure that rung-to-rung comparisons isolate model capacity differences (Goal 1,
+lineage plan §3) — the dataset, continuation policy, and feature set are identical
+across R0/R1/R2, so the only variable is the model architecture.
+
 `r3` keeps its own mode-sized dataset builds because it adds moon/loner actions.
 `r3` still uses the fixed `r0` continuation artifact and the same dataset-build seed
 registry by mode; only the action space changes and the dataset is not shared with


### PR DESCRIPTION
## Summary
- Added explicit rationale to runbook §4.3 connecting shared pre-R3 datasets to the lineage's primary research goal (isolating capacity vs information effects, Goal 1)
- Added matching one-liner in LA-5 amendment's "Shared dataset reuse" section

## Why
The design chain (shared datasets + fixed anchor → only model architecture varies → capacity isolation) was implied across three separate sections but never stated as a single rationale. Future readers had to cross-reference the lineage plan Goal 1, the anchor contract §4.1, and the dataset scope §4.3 to reconstruct the "why."

## Repro / Validation
Docs-only change — no code, no tests needed.

```
git diff main -- plans/arc_d_v2/v2_regeneration_repair_runbook.md plans/arc_d_v2/amendments.md
```

## Tests
N/A — docs only.

## Worktree proof
This is the `codex/steward-author-b` branch (dedicated worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)