### PR TITLE
feat: add repo-lint gate requiring tests for infra changes

### DIFF
--- a/scripts/lint_repo.py
+++ b/scripts/lint_repo.py
@@ -57,12 +57,15 @@ def ensure_ref_exists(ref: str) -> None:
         )
 
 
-def list_changed_files(base: str, head: str) -> list[str]:
-    """
-    Return changed files between base..head (added/modified/renamed), excluding deletions.
+def list_changed_files_with_status(base: str, head: str) -> list[tuple[str, str]]:
+    """Return (status_letter, path) pairs for changed files between base..head.
+
+    Status letters: A=added, M=modified, R=renamed, C=copied, T=type-change.
+    Deletions (D) are excluded.  For renames (R100 old new) the *new* path
+    is returned.
     """
     out = run_git("diff", "--name-status", f"{base}..{head}")
-    files: list[str] = []
+    result: list[tuple[str, str]] = []
     for line in out.splitlines():
         if not line.strip():
             continue
@@ -70,10 +73,19 @@ def list_changed_files(base: str, head: str) -> list[str]:
         status = parts[0]
         if status.startswith("D"):
             continue
-        # Handle rename lines: R100 old new -> take last token (new path)
+        # Normalise multi-digit statuses: R100 → R, C095 → C
+        letter = status[0]
+        # Handle rename/copy lines: R100 old new → take last token (new path)
         path = parts[-1]
-        files.append(path)
-    return files
+        result.append((letter, path))
+    return result
+
+
+def list_changed_files(base: str, head: str) -> list[str]:
+    """
+    Return changed files between base..head (added/modified/renamed), excluding deletions.
+    """
+    return [path for _status, path in list_changed_files_with_status(base, head)]
 
 
 def is_under(path: str, prefix: str) -> bool:
@@ -606,6 +618,88 @@ def check_no_import_experiments_package(
                 )
             )
     return violations
+
+
+# --- Infra change enforcement ---
+
+# Paths considered "infrastructure".  Modifications to *existing* files
+# under these prefixes require a corresponding test change.
+INFRA_PATH_PREFIXES = [
+    ".github/workflows/",
+    ".claude/hooks/",
+    "scripts/internal/",
+]
+
+# Exact files (not directories) that are also infra.
+INFRA_EXACT_FILES = {
+    "Makefile",
+}
+
+# Extensions within infra paths that are documentation-only and can
+# never affect runtime behaviour.
+INFRA_DOC_EXTENSIONS = {".md", ".txt", ".rst"}
+
+
+def _is_infra_path(path: str) -> bool:
+    """Return True if *path* is an infrastructure file."""
+    if path in INFRA_EXACT_FILES:
+        return True
+    return any(is_under(path, prefix) for prefix in INFRA_PATH_PREFIXES)
+
+
+def check_infra_changes_require_tests(
+    changed_with_status: list[tuple[str, str]],
+) -> list[Violation]:
+    """If existing infra files are modified, at least one test file must change.
+
+    Phase-1 scoping:
+    - Only *modifications* to existing infra files trigger the gate (status M
+      or T).  Pure additions (A) and renames (R) of new infra files are exempt.
+    - Documentation-only changes (.md, .txt, .rst) under infra paths are exempt.
+    - If any qualifying infra file changed **and** no file under ``tests/``
+      appears in the changeset, a blocking violation is returned.
+    """
+    qualifying_infra: list[str] = []
+    has_test_change = False
+
+    for status, path in changed_with_status:
+        # Track whether *any* test file changed (regardless of status)
+        if is_under(path, "tests/"):
+            has_test_change = True
+
+        # Only modifications to existing files qualify
+        if status not in ("M", "T"):
+            continue
+
+        if not _is_infra_path(path):
+            continue
+
+        # Exempt documentation-only files
+        ext = Path(path).suffix.lower()
+        if ext in INFRA_DOC_EXTENSIONS:
+            continue
+
+        qualifying_infra.append(path)
+
+    if qualifying_infra and not has_test_change:
+        # Produce one violation listing all offending infra files
+        files_str = ", ".join(qualifying_infra[:5])
+        extra = (
+            f" (+{len(qualifying_infra) - 5} more)" if len(qualifying_infra) > 5 else ""
+        )
+        return [
+            Violation(
+                rule="infra-changes-require-tests",
+                path=qualifying_infra[0],
+                message=(
+                    f"Modified infra file(s) without any test changes: "
+                    f"{files_str}{extra}. "
+                    f"Add or update a regression test under tests/."
+                ),
+            )
+        ]
+
+    return []
 
 
 # --- Promotion contract lint rules ---
@@ -1292,9 +1386,11 @@ def main() -> int:
 
     ensure_ref_exists(args.base)
 
-    changed = list_changed_files(args.base, args.head)
+    changed_with_status = list_changed_files_with_status(args.base, args.head)
+    changed = [path for _status, path in changed_with_status]
 
     violations: list[Violation] = []
+    violations += check_infra_changes_require_tests(changed_with_status)
     violations += check_no_generated_artifacts(changed)
     violations += check_no_deprecated_changes(changed)
     violations += check_src_no_experiments_or_tests_imports(changed, repo_root)

--- a/tests/unit/test_lint_repo.py
+++ b/tests/unit/test_lint_repo.py
@@ -8,10 +8,12 @@ from pathlib import Path
 from scripts.lint_repo import (
     _has_model_artifact_schema,
     _is_gate_artifact,
+    _is_infra_path,
     _is_model_artifact,
     _is_split_manifest,
     check_artifacts_require_freeze,
     check_gate_artifacts_schema,
+    check_infra_changes_require_tests,
     check_semantic_gate_schema,
     check_split_manifest_schema,
 )
@@ -761,3 +763,158 @@ class TestArtifactSha256Check:
         )
         assert len(violations) == 1
         assert "artifact_sha256" in violations[0].message
+
+
+# -- _is_infra_path tests ---------------------------------------------------
+
+
+class TestIsInfraPath:
+    """Tests for the _is_infra_path helper."""
+
+    def test_workflow_file(self):
+        assert _is_infra_path(".github/workflows/ci.yml") is True
+
+    def test_hook_file(self):
+        assert _is_infra_path(".claude/hooks/post-push-ci-check.sh") is True
+
+    def test_scripts_internal_file(self):
+        assert _is_infra_path("scripts/internal/review_driver.py") is True
+
+    def test_makefile(self):
+        assert _is_infra_path("Makefile") is True
+
+    def test_src_file_not_infra(self):
+        assert _is_infra_path("src/bid_euchre/core/rules.py") is False
+
+    def test_top_level_scripts_not_infra(self):
+        assert _is_infra_path("scripts/lint_repo.py") is False
+
+    def test_tests_not_infra(self):
+        assert _is_infra_path("tests/unit/test_rules.py") is False
+
+    def test_claude_settings_not_infra(self):
+        assert _is_infra_path(".claude/settings.json") is False
+
+
+# -- check_infra_changes_require_tests tests ---------------------------------
+
+
+class TestCheckInfraChangesRequireTests:
+    """Tests for the check_infra_changes_require_tests lint rule."""
+
+    def test_modified_workflow_no_tests_violation(self):
+        """Modified existing workflow with no test changes -> violation."""
+        changed = [
+            ("M", ".github/workflows/ci.yml"),
+            ("M", "src/bid_euchre/core/rules.py"),
+        ]
+        violations = check_infra_changes_require_tests(changed)
+        assert len(violations) == 1
+        assert violations[0].rule == "infra-changes-require-tests"
+        assert ".github/workflows/ci.yml" in violations[0].message
+
+    def test_modified_hook_with_test_passes(self):
+        """Modified existing hook with matching test change -> pass."""
+        changed = [
+            ("M", ".claude/hooks/post-push-ci-check.sh"),
+            ("M", "tests/unit/test_post_push_ci_check_hook.py"),
+        ]
+        violations = check_infra_changes_require_tests(changed)
+        assert violations == []
+
+    def test_new_infra_file_without_tests_passes(self):
+        """New infra file without tests -> pass (phase 1 exemption)."""
+        changed = [
+            ("A", ".github/workflows/new_workflow.yml"),
+        ]
+        violations = check_infra_changes_require_tests(changed)
+        assert violations == []
+
+    def test_renamed_infra_file_without_tests_passes(self):
+        """Renamed infra file without tests -> pass (phase 1 exemption)."""
+        changed = [
+            ("R", ".github/workflows/renamed.yml"),
+        ]
+        violations = check_infra_changes_require_tests(changed)
+        assert violations == []
+
+    def test_non_infra_changes_ignored(self):
+        """Non-infra file modifications without tests -> no violation."""
+        changed = [
+            ("M", "src/bid_euchre/core/rules.py"),
+            ("M", "src/bid_euchre/sim/deals.py"),
+        ]
+        violations = check_infra_changes_require_tests(changed)
+        assert violations == []
+
+    def test_modified_makefile_no_tests_violation(self):
+        """Modified Makefile without test changes -> violation."""
+        changed = [
+            ("M", "Makefile"),
+        ]
+        violations = check_infra_changes_require_tests(changed)
+        assert len(violations) == 1
+        assert violations[0].rule == "infra-changes-require-tests"
+
+    def test_modified_scripts_internal_no_tests_violation(self):
+        """Modified scripts/internal/ file without tests -> violation."""
+        changed = [
+            ("M", "scripts/internal/review_driver.py"),
+        ]
+        violations = check_infra_changes_require_tests(changed)
+        assert len(violations) == 1
+        assert violations[0].rule == "infra-changes-require-tests"
+
+    def test_doc_only_change_in_infra_path_exempt(self):
+        """Markdown change under infra path -> no violation (doc exempt)."""
+        changed = [
+            ("M", ".claude/hooks/README.md"),
+        ]
+        violations = check_infra_changes_require_tests(changed)
+        assert violations == []
+
+    def test_any_test_file_satisfies_gate(self):
+        """Any test file change (even unrelated) satisfies the gate."""
+        changed = [
+            ("M", ".github/workflows/ci.yml"),
+            ("A", "tests/unit/test_something_new.py"),
+        ]
+        violations = check_infra_changes_require_tests(changed)
+        assert violations == []
+
+    def test_multiple_infra_files_one_violation(self):
+        """Multiple modified infra files produce one violation."""
+        changed = [
+            ("M", ".github/workflows/ci.yml"),
+            ("M", "scripts/internal/review_driver.py"),
+            ("M", "Makefile"),
+        ]
+        violations = check_infra_changes_require_tests(changed)
+        assert len(violations) == 1
+        assert "ci.yml" in violations[0].message
+        assert "review_driver.py" in violations[0].message
+
+    def test_mixed_add_and_modify_only_modify_triggers(self):
+        """Mixed A + M: only modified files trigger the gate."""
+        changed = [
+            ("A", ".github/workflows/new_workflow.yml"),
+            ("M", ".github/workflows/ci.yml"),
+        ]
+        violations = check_infra_changes_require_tests(changed)
+        assert len(violations) == 1
+        # The new file should not appear in the message
+        assert "new_workflow.yml" not in violations[0].message
+
+    def test_empty_changeset_passes(self):
+        """Empty changeset produces no violations."""
+        violations = check_infra_changes_require_tests([])
+        assert violations == []
+
+    def test_type_change_triggers_gate(self):
+        """Type-change (T) status triggers the gate like M."""
+        changed = [
+            ("T", "scripts/internal/ci_poller.sh"),
+        ]
+        violations = check_infra_changes_require_tests(changed)
+        assert len(violations) == 1
+        assert violations[0].rule == "infra-changes-require-tests"


### PR DESCRIPTION
## Plan
`plans/sessions/2026-03-17_infra-incident-enforcement.md` — PR 1 of 5

## Summary
- Add `check_infra_changes_require_tests()` to `scripts/lint_repo.py` that blocks modifications to existing infra files (`.github/workflows/`, `.claude/hooks/`, `scripts/internal/`, `Makefile`) when no test file under `tests/` changes in the same PR
- Add `list_changed_files_with_status()` helper that preserves git diff status letters (M/A/R/T) for status-aware checks
- Add 21 new unit tests covering `_is_infra_path` helper and all gate scenarios

## Why
Infra changes (workflows, hooks, build scripts) frequently ship without regression tests, leading to repeated breakages that are fixed ad hoc and forgotten. This gate makes the gap mechanically detectable in CI.

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/test_lint_repo.py -v` — 91 passed (70 existing + 21 new)
- `make check-quiet` — all checks passed
- `uv run python scripts/lint_repo.py --base origin/main --head HEAD` — passed

## Tests
- [x] `uv run python -m pytest tests/unit/test_lint_repo.py -v`
- [x] `make check-quiet`

## Expected impact
- Metrics impact: None (linter-only)
- Runtime impact: None (runs in CI only)

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-infra-lint
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-infra-lint
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                             799f2d4 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-infra-lint                  3f0e51d [infra/lint-require-tests]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

## Design Notes

**Phase-1 scoping decisions:**
- Only **modifications** (M, T) to existing infra files trigger the gate. Pure additions (A) and renames (R) are exempt to reduce false positives on new automation.
- `.md`/`.txt`/`.rst` files under infra paths are exempt (documentation can't break runtime).
- **Any** test file change satisfies the gate — not just a file specifically named for the infra change. This keeps the rule simple and avoids over-fitting.
- Multiple qualifying infra files produce a single violation (not N violations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)