### PR TITLE
docs: add infra-incident PR template and testing policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -64,6 +64,13 @@
 - [ ] Blocking findings addressed
 - [ ] Non-blocking findings captured as follow-up issues (if any)
 
+## Infra Incident (optional — fill when fixing infra breakage)
+<!-- Delete this section if not an infra-incident PR -->
+- Issue: <!-- Link to GitHub issue with `infra-incident` label, or N/A -->
+- First occurrence or repeat: <!-- "first" or link to prior issue -->
+- Regression test: <!-- Path to new/updated test, e.g., tests/unit/test_ci_poller.py -->
+- Detection/logging note: <!-- How was this detected? What monitoring exists now? -->
+
 ## Checklist
 - [ ] No generated artifacts committed (`data/runs`, `data/reports`)
 - [ ] If behavior changed, tests updated/added to lock it

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -80,6 +80,32 @@ All experiments require explicit seed via `--seed <int>`. Tests that exercise th
 
 See `docs/01_core/REPRODUCIBILITY.md` for the full determinism contract including deal derivation formula and paired-deal design.
 
+## Infrastructure Testing Policy
+
+Modifications to existing infrastructure files must include regression tests. The
+repo linter (`scripts/lint_repo.py`, rule `infra-changes-require-tests`) enforces
+this mechanically in CI.
+
+**Infrastructure paths:**
+- `.github/workflows/**`
+- `.claude/hooks/**`
+- `scripts/internal/**`
+- `Makefile`
+
+**What triggers the gate:**
+- Modifying an existing file under any infra path (git status `M` or `T`).
+- At least one file under `tests/` must also change in the same PR.
+
+**Exempt from the gate:**
+- Adding new infra files (phase 1 — new automation does not yet require tests).
+- Documentation-only changes (`.md`, `.txt`, `.rst`) under infra paths.
+
+**Repeat infra incidents:**
+- When fixing a recurring infra breakage, fill the `## Infra Incident` section
+  in the PR template and link a GitHub issue labeled `infra-incident`.
+- Unattended infra scripts should expose minimal machine-readable state
+  (`status.json` + append-only log) for post-mortem debugging.
+
 ## Statistical Rigor in Tests
 
 - Sample size minimums apply: >=2,000 deals for bias detection, >=50,000 for production reports


### PR DESCRIPTION
## Plan
`plans/sessions/2026-03-17_infra-incident-enforcement.md` — PR 2 of 5

## Summary
- Add optional `## Infra Incident` section to `.github/pull_request_template.md` for capturing issue links, recurrence, regression tests, and detection notes
- Add `Infrastructure Testing Policy` section to `docs/TESTING_STRATEGY.md` documenting the gate from PR #812

## Why
The repo-lint gate (#812) enforces infra changes ship with tests, but the policy needs to be documented where contributors look: the PR template and the testing strategy doc. The infra-incident section also creates a lightweight structured path for reporting recurring infra breakages.

## Repro / Validation
**Command(s) run:**
- `make docs-check` — passed

## Tests
- [x] `make docs-check`
- N/A (docs-only PR)

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-infra-pr2
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-infra-pr2
```

`git worktree list` (abbreviated):
```
.../Bid-Euchre          3e77dcb [main]
.../Bid-Euchre-infra-pr2 73e43de [infra/pr-template-docs-policy]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)