### PR TITLE
feat: add governance metadata checker for infra PRs

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -50,5 +50,23 @@ jobs:
             echo "No plan files changed — skipping plan lint"
           fi
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Infra PR metadata check (advisory)
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          CHANGED=$(git diff --name-only origin/main...HEAD 2>/dev/null || true)
+          if [ -z "$CHANGED" ]; then
+            echo "No changed files detected — skipping infra metadata check"
+          else
+            python scripts/check_infra_pr_metadata.py \
+              --pr-body "$PR_BODY" \
+              --changed-files $CHANGED
+          fi
+
       - name: Governance passed
         run: echo "All governance checks passed"

--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -41,6 +41,7 @@ Structure:
 
 Canonical scripts:
 - `check_docs_freshness.py` — Docs freshness gate (path refs + script list completeness)
+- `check_infra_pr_metadata.py` — Infra PR metadata checker (advisory governance gate)
 - `compare_rollup.py` — Drift detection (compares rollup against baseline fixture)
 - `compare_runs.py` — Run comparison utility with bootstrap statistics
 - `generate_report.py` — Per-run report generator
@@ -200,6 +201,7 @@ Every experiment run creates a standardized directory under `data/runs/<run_id>/
 | Command | Purpose |
 |---------|---------|
 | `scripts/check_docs_freshness.py` | Docs freshness gate (path refs + script list) |
+| `scripts/check_infra_pr_metadata.py` | Infra PR metadata checker (advisory governance gate) |
 | `scripts/compare_runs.py` | Compare two runs with bootstrap statistics |
 | `scripts/compare_rollup.py` | Drift detection against baseline fixture |
 | `scripts/lint_repo.py` | Repository linter |

--- a/scripts/check_infra_pr_metadata.py
+++ b/scripts/check_infra_pr_metadata.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Check whether PRs touching infra paths include infra-incident metadata.
+
+Usage (CI):
+  python scripts/check_infra_pr_metadata.py --pr-body "$PR_BODY" --changed-files file1 file2 ...
+
+Usage (local, reads git diff):
+  python scripts/check_infra_pr_metadata.py --pr-body "$PR_BODY" --base origin/main --head HEAD
+
+Exit codes:
+  0 — check passed or not applicable
+  1 — advisory warning (missing metadata for infra-touching PR)
+
+Phase 3a: advisory output only (GitHub Actions warning annotations).
+Phase 3b: will hard-fail for PRs explicitly marked as infra-incident work.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+
+# Infrastructure path prefixes — kept in sync with scripts/lint_repo.py
+INFRA_PATH_PREFIXES = (
+    ".github/workflows/",
+    ".claude/hooks/",
+    "scripts/internal/",
+)
+
+INFRA_EXACT_FILES = frozenset({"Makefile"})
+
+# Extensions that are documentation-only under infra paths
+INFRA_DOC_EXTENSIONS = frozenset({".md", ".txt", ".rst"})
+
+# Section header pattern in PR body
+INFRA_INCIDENT_HEADER = re.compile(
+    r"^##\s+Infra\s+Incident", re.MULTILINE | re.IGNORECASE
+)
+
+# Minimal field patterns inside the section.
+# Use [^\S\n]* (horizontal whitespace only) to prevent matching across lines.
+INFRA_FIELD_PATTERNS = {
+    "Issue": re.compile(r"^\s*-\s*Issue:[^\S\n]*\S", re.MULTILINE),
+    "Regression test": re.compile(r"^\s*-\s*Regression test:[^\S\n]*\S", re.MULTILINE),
+}
+
+
+def is_infra_path(path: str) -> bool:
+    """Return True if *path* is an infrastructure file (non-doc)."""
+    if path in INFRA_EXACT_FILES:
+        return True
+    for prefix in INFRA_PATH_PREFIXES:
+        if path == prefix.rstrip("/") or path.startswith(prefix):
+            # Exempt documentation-only files
+            ext = path[path.rfind(".") :].lower() if "." in path else ""
+            if ext in INFRA_DOC_EXTENSIONS:
+                return False
+            return True
+    return False
+
+
+def get_changed_files_from_git(base: str, head: str) -> list[str]:
+    """Return changed files between base..head, excluding deletions."""
+    out = subprocess.check_output(
+        ["git", "diff", "--name-only", "--diff-filter=d", f"{base}..{head}"],
+        text=True,
+    ).strip()
+    if not out:
+        return []
+    return out.splitlines()
+
+
+def has_infra_incident_section(pr_body: str) -> bool:
+    """Return True if the PR body contains an ## Infra Incident header."""
+    return bool(INFRA_INCIDENT_HEADER.search(pr_body))
+
+
+def check_infra_fields(pr_body: str) -> list[str]:
+    """Return list of missing field names in the Infra Incident section."""
+    missing = []
+    for name, pattern in INFRA_FIELD_PATTERNS.items():
+        if not pattern.search(pr_body):
+            missing.append(name)
+    return missing
+
+
+def check(pr_body: str, changed_files: list[str]) -> tuple[bool, list[str]]:
+    """Run the infra PR metadata check.
+
+    Returns (has_infra_changes, warnings).
+    """
+    infra_files = [f for f in changed_files if is_infra_path(f)]
+
+    if not infra_files:
+        return False, []
+
+    warnings: list[str] = []
+
+    if not has_infra_incident_section(pr_body):
+        warnings.append(
+            f"PR touches {len(infra_files)} infra file(s) but has no "
+            f"'## Infra Incident' section. Consider filling it if this "
+            f"fixes an infra breakage."
+        )
+    else:
+        missing = check_infra_fields(pr_body)
+        if missing:
+            warnings.append(
+                f"'## Infra Incident' section is present but missing: "
+                f"{', '.join(missing)}"
+            )
+
+    return True, warnings
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--pr-body",
+        required=True,
+        help="Full text of the PR description body",
+    )
+    group = ap.add_mutually_exclusive_group()
+    group.add_argument(
+        "--changed-files",
+        nargs="*",
+        default=None,
+        help="Explicit list of changed file paths",
+    )
+    group.add_argument(
+        "--base",
+        default=None,
+        help="Git base ref (e.g., origin/main). Used with --head.",
+    )
+    ap.add_argument(
+        "--head",
+        default="HEAD",
+        help="Git head ref (default: HEAD). Used with --base.",
+    )
+
+    args = ap.parse_args()
+
+    if args.changed_files is not None:
+        changed = args.changed_files
+    elif args.base is not None:
+        changed = get_changed_files_from_git(args.base, args.head)
+    else:
+        ap.error("Provide either --changed-files or --base")
+        return 1  # unreachable
+
+    has_infra, warnings = check(args.pr_body, changed)
+
+    if not has_infra:
+        print("No infra files changed — skipping metadata check.")
+        return 0
+
+    if warnings:
+        for w in warnings:
+            # GitHub Actions annotation format
+            print(f"::warning::{w}")
+        # Phase 3a: advisory only — return 0
+        return 0
+
+    print("Infra metadata check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_check_infra_pr_metadata.py
+++ b/tests/unit/test_check_infra_pr_metadata.py
@@ -1,0 +1,171 @@
+"""Tests for the infra PR metadata checker (scripts/check_infra_pr_metadata.py)."""
+
+from __future__ import annotations
+
+from scripts.check_infra_pr_metadata import (
+    check,
+    check_infra_fields,
+    has_infra_incident_section,
+    is_infra_path,
+)
+
+# -- is_infra_path tests -----------------------------------------------------
+
+
+class TestIsInfraPath:
+    """Tests for the is_infra_path helper."""
+
+    def test_workflow_file(self):
+        assert is_infra_path(".github/workflows/ci.yml") is True
+
+    def test_hook_file(self):
+        assert is_infra_path(".claude/hooks/post-push-ci-check.sh") is True
+
+    def test_scripts_internal(self):
+        assert is_infra_path("scripts/internal/review_driver.py") is True
+
+    def test_makefile(self):
+        assert is_infra_path("Makefile") is True
+
+    def test_src_not_infra(self):
+        assert is_infra_path("src/bid_euchre/core/rules.py") is False
+
+    def test_tests_not_infra(self):
+        assert is_infra_path("tests/unit/test_rules.py") is False
+
+    def test_top_level_scripts_not_infra(self):
+        assert is_infra_path("scripts/lint_repo.py") is False
+
+    def test_markdown_under_hooks_exempt(self):
+        assert is_infra_path(".claude/hooks/README.md") is False
+
+    def test_txt_under_workflows_exempt(self):
+        assert is_infra_path(".github/workflows/notes.txt") is False
+
+
+# -- has_infra_incident_section tests -----------------------------------------
+
+
+class TestHasInfraIncidentSection:
+    """Tests for PR body section detection."""
+
+    def test_present(self):
+        body = "## Summary\nStuff\n\n## Infra Incident\n- Issue: #123\n"
+        assert has_infra_incident_section(body) is True
+
+    def test_absent(self):
+        body = "## Summary\nStuff\n\n## Tests\n- pytest\n"
+        assert has_infra_incident_section(body) is False
+
+    def test_case_insensitive(self):
+        body = "## infra incident\n- Issue: #100\n"
+        assert has_infra_incident_section(body) is True
+
+    def test_extra_spaces(self):
+        body = "##  Infra  Incident\n- Issue: #100\n"
+        assert has_infra_incident_section(body) is True
+
+    def test_empty_body(self):
+        assert has_infra_incident_section("") is False
+
+
+# -- check_infra_fields tests ------------------------------------------------
+
+
+class TestCheckInfraFields:
+    """Tests for field validation within the Infra Incident section."""
+
+    def test_all_fields_present(self):
+        body = (
+            "## Infra Incident\n"
+            "- Issue: #123\n"
+            "- Regression test: tests/unit/test_ci.py\n"
+        )
+        assert check_infra_fields(body) == []
+
+    def test_missing_issue(self):
+        body = "## Infra Incident\n- Issue:\n- Regression test: tests/unit/test_ci.py\n"
+        missing = check_infra_fields(body)
+        assert "Issue" in missing
+
+    def test_missing_regression_test(self):
+        body = "## Infra Incident\n- Issue: #123\n- Regression test:\n"
+        missing = check_infra_fields(body)
+        assert "Regression test" in missing
+
+    def test_all_fields_empty(self):
+        body = "## Infra Incident\n- Issue:\n- Regression test:\n"
+        missing = check_infra_fields(body)
+        assert len(missing) == 2
+
+
+# -- check() integration tests -----------------------------------------------
+
+
+class TestCheck:
+    """Tests for the top-level check() function."""
+
+    def test_no_infra_files_returns_no_warnings(self):
+        has_infra, warnings = check(
+            "## Summary\nStuff",
+            ["src/bid_euchre/core/rules.py", "tests/unit/test_rules.py"],
+        )
+        assert has_infra is False
+        assert warnings == []
+
+    def test_infra_files_no_section_warns(self):
+        has_infra, warnings = check(
+            "## Summary\nFixed CI",
+            [".github/workflows/ci.yml"],
+        )
+        assert has_infra is True
+        assert len(warnings) == 1
+        assert "Infra Incident" in warnings[0]
+
+    def test_infra_files_with_complete_section_passes(self):
+        body = (
+            "## Summary\nFixed CI\n\n"
+            "## Infra Incident\n"
+            "- Issue: #100\n"
+            "- First occurrence or repeat: repeat\n"
+            "- Regression test: tests/unit/test_ci.py\n"
+            "- Detection/logging note: CI logs\n"
+        )
+        has_infra, warnings = check(body, [".github/workflows/ci.yml"])
+        assert has_infra is True
+        assert warnings == []
+
+    def test_infra_files_with_incomplete_section_warns(self):
+        body = (
+            "## Summary\nFixed CI\n\n## Infra Incident\n- Issue:\n- Regression test:\n"
+        )
+        has_infra, warnings = check(body, ["scripts/internal/ci_poller.sh"])
+        assert has_infra is True
+        assert len(warnings) == 1
+        assert "missing" in warnings[0].lower()
+
+    def test_makefile_triggers_check(self):
+        has_infra, warnings = check("## Summary\nUpdated build", ["Makefile"])
+        assert has_infra is True
+        assert len(warnings) == 1
+
+    def test_doc_only_infra_change_exempt(self):
+        """Markdown files under infra paths don't trigger the check."""
+        has_infra, warnings = check(
+            "## Summary\nUpdated README",
+            [".claude/hooks/README.md"],
+        )
+        assert has_infra is False
+        assert warnings == []
+
+    def test_multiple_infra_files_counted(self):
+        has_infra, warnings = check(
+            "## Summary\nBig refactor",
+            [
+                ".github/workflows/ci.yml",
+                "scripts/internal/review_driver.py",
+                "Makefile",
+            ],
+        )
+        assert has_infra is True
+        assert "3 infra file(s)" in warnings[0]


### PR DESCRIPTION
## Plan
`plans/sessions/2026-03-17_infra-incident-enforcement.md` — PR 3 of 5

## Summary
- Add `scripts/check_infra_pr_metadata.py` — checks whether PRs touching infra paths include an `## Infra Incident` section with `Issue` and `Regression test` fields
- Wire into `.github/workflows/governance.yml` as advisory (warnings only, no failure)
- 25 unit tests for path detection, section parsing, field validation, and the top-level check
- Register new script in `docs/01_core/ARCHITECTURE.md`

## Why
The PR template (PR #813) added the `## Infra Incident` section, but nothing validates it. This checker gives contributors a nudge when they touch infra files without filling in the incident metadata. Phase 3a is advisory-only; phase 3b will hard-fail for explicit infra-incident PRs.

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/test_check_infra_pr_metadata.py -v` — 25 passed
- `make check-quiet` — all passed

## Tests
- [x] `uv run python -m pytest tests/unit/test_check_infra_pr_metadata.py -v`
- [x] `make check-quiet`

## Expected impact
- Metrics impact: None
- Runtime impact: None (governance workflow only)

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-infra-pr3
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-infra-pr3
```

`git worktree list` (abbreviated):
```
.../Bid-Euchre           3e77dcb [main]
.../Bid-Euchre-infra-pr3 571e19a [infra/governance-metadata-checker]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)