### PR TITLE
fix: harden JSON encoding in daemon hook and code fence parsing

### DIFF
--- a/.claude/hooks/post-tool-daemon-notify.sh
+++ b/.claude/hooks/post-tool-daemon-notify.sh
@@ -47,8 +47,10 @@ for sentinel in "$RUNTIME_DIR"/ci_polls/pr_*/FAILED "$RUNTIME_DIR"/review_loops/
     # Read summary (first line only, cap at 200 chars)
     summary=$(head -1 "$sentinel" 2>/dev/null | cut -c1-200 || echo "unknown failure")
 
-    # Build message
-    MESSAGES="${MESSAGES}${daemon_label} for PR #${pr_num} FAILED: ${summary}. Log: ${daemon_dir}/$([ "$parent_dir" = "ci_polls" ] && echo "poller.log" || echo "driver.log")\n"
+    # Build message (use printf for real newlines, not literal \n)
+    log_file=$([ "$parent_dir" = "ci_polls" ] && echo "poller.log" || echo "driver.log")
+    MESSAGES="${MESSAGES}${daemon_label} for PR #${pr_num} FAILED: ${summary}. Log: ${daemon_dir}/${log_file}
+"
 
     # Rename to NOTIFIED so we only alert once
     mv "$sentinel" "${daemon_dir}/NOTIFIED" 2>/dev/null || true
@@ -56,17 +58,26 @@ done
 
 # If we found any failures, emit them as additionalContext
 if [ -n "$MESSAGES" ]; then
-    # Escape for JSON
-    JSON_MSG=$(printf '%s' "$MESSAGES" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g' | tr '\n' ' ')
+    FULL_MSG="WARNING — Background daemon failure(s) detected:
+${MESSAGES}Check the log files for details. You may need to re-push or manually investigate."
 
-    cat <<EOF
+    # Use jq for robust JSON encoding (handles all special chars correctly).
+    # Falls back to sed-based escaping if jq is unavailable.
+    if command -v jq >/dev/null 2>&1; then
+        jq -n --arg ctx "$FULL_MSG" \
+            '{hookSpecificOutput: {hookEventName: "PostToolUse", additionalContext: $ctx}}'
+    else
+        # Fallback: escape \, ", tab, then collapse newlines to spaces
+        JSON_MSG=$(printf '%s' "$FULL_MSG" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g' | tr '\n' ' ')
+        cat <<ENDJSON
 {
   "hookSpecificOutput": {
     "hookEventName": "PostToolUse",
-    "additionalContext": "WARNING — Background daemon failure(s) detected:\n${JSON_MSG}\nCheck the log files for details. You may need to re-push or manually investigate."
+    "additionalContext": "${JSON_MSG}"
   }
 }
-EOF
+ENDJSON
+    fi
 fi
 
 exit 0

--- a/scripts/internal/codex_plan_review_adapter.py
+++ b/scripts/internal/codex_plan_review_adapter.py
@@ -731,10 +731,10 @@ def _convert_codex_findings(
 
 
 # Regex to strip markdown code fences from Claude CLI output.
-# Matches ```json ... ``` or ``` ... ``` with optional language tag.
+# Matches ```json ... ``` or ``` ... ``` with optional language tag (case-insensitive).
 _CODE_FENCE_RE = re.compile(
-    r"```(?:json|JSON)?\s*\n(.*?)\n\s*```",
-    re.DOTALL,
+    r"```(?:json)?\s*\n(.*?)\n\s*```",
+    re.DOTALL | re.IGNORECASE,
 )
 
 # Severity mapping from Claude CLI's natural output to PlanReviewFinding schema.

--- a/tests/unit/test_codex_plan_review_adapter.py
+++ b/tests/unit/test_codex_plan_review_adapter.py
@@ -524,6 +524,17 @@ class TestStripCodeFences:
         raw = '```JSON\n[{"a": 1}]\n```'
         assert _strip_code_fences(raw) == '[{"a": 1}]'
 
+    def test_mixed_case_json_tag(self) -> None:
+        """```Json and other case variants are handled (case-insensitive)."""
+        raw = '```Json\n[{"a": 1}]\n```'
+        assert _strip_code_fences(raw) == '[{"a": 1}]'
+
+    def test_jsonc_tag_not_matched(self) -> None:
+        """```jsonc is NOT matched — only 'json' or bare fences are stripped."""
+        raw = '```jsonc\n[{"a": 1}]\n```'
+        # Falls through to raw.strip() since 'jsonc' doesn't match optional 'json'
+        assert _strip_code_fences(raw) == raw.strip()
+
 
 # --- Schema Normalization Tests ---
 

--- a/tests/unit/test_daemon_notify.py
+++ b/tests/unit/test_daemon_notify.py
@@ -208,6 +208,24 @@ class TestDaemonNotifyHook:
         assert result.returncode == 0
         assert result.stdout.strip() == ""
 
+    def test_special_chars_in_sentinel_produce_valid_json(self, tmp_path: Path) -> None:
+        """Sentinel content with quotes, backslashes, tabs produces valid JSON."""
+        ci_dir = tmp_path / ".claude" / "runtime" / "ci_polls" / "pr_77"
+        ci_dir.mkdir(parents=True)
+        # Content with JSON-special characters: quotes, backslash, tab
+        (ci_dir / "FAILED").write_text(
+            'CI_FAILED: Check "lint\\format" failed\t(exit 1)\n'
+        )
+
+        result = _run_hook(tmp_path)
+        assert result.returncode == 0
+
+        # The key test: output must be valid JSON despite special chars
+        output = json.loads(result.stdout)
+        ctx = output["hookSpecificOutput"]["additionalContext"]
+        assert "PR #77" in ctx
+        assert "CI_FAILED" in ctx
+
     def test_multiple_failures_combined(self, tmp_path: Path) -> None:
         """Multiple FAILED sentinels should be combined into one output."""
         ci_dir = tmp_path / ".claude" / "runtime" / "ci_polls" / "pr_10"


### PR DESCRIPTION
## Summary
- **Hook JSON encoding:** Replace fragile `sed`-based JSON escaping in `post-tool-daemon-notify.sh` with `jq -n --arg` for robust encoding of all special characters. Retains `sed` fallback for environments without `jq`.
- **Code fence regex:** Make `_CODE_FENCE_RE` case-insensitive so it handles `Json`, `JSON`, `json` variants, not just `json`/`JSON`.
- **3 new tests:** `test_special_chars_in_sentinel_produce_valid_json`, `test_mixed_case_json_tag`, `test_jsonc_tag_not_matched`.

## Why
Post-merge review of PRs #808–#812 identified two fragile string-processing patterns:
1. The daemon notify hook constructed JSON via `sed` escaping, which missed some JSON-special chars (`\r`, control chars). With `jq`, all encoding is handled correctly.
2. The code fence regex only matched the exact strings `json` and `JSON`, missing mixed-case variants like `Json`.

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_daemon_notify.py tests/unit/test_codex_plan_review_adapter.py::TestStripCodeFences -v
# 22 passed (includes 3 new tests)
make check-quiet  # All checks passed
```

## Tests
- `uv run python -m pytest tests/unit/test_daemon_notify.py -v` — 14 passed (1 new)
- `uv run python -m pytest tests/unit/test_codex_plan_review_adapter.py::TestStripCodeFences -v` — 8 passed (2 new)
- `make check-quiet` — all passed

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/worktree-review-followups
branch: fix/review-followups
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)