### PR TITLE
fix: add HALT+SKIP test and fix ADVANCE recommendation text

### DIFF
--- a/src/bid_euchre/arc_d_v2/report.py
+++ b/src/bid_euchre/arc_d_v2/report.py
@@ -572,10 +572,19 @@ def generate_decision_report(
     lines.append("## Recommendation")
     lines.append("")
     if decision == "ADVANCE":
-        lines.append(
-            "All hypothesis checks passed. Evidence supports advancing "
-            "to the next rung."
-        )
+        n_skip = 0
+        if hypothesis_outcomes is not None and "status" in hypothesis_outcomes.columns:
+            n_skip = (hypothesis_outcomes["status"].str.upper() == "SKIP").sum()
+        if n_skip > 0:
+            lines.append(
+                f"All evaluated hypothesis checks passed ({n_skip} skipped). "
+                "Evidence supports advancing to the next rung."
+            )
+        else:
+            lines.append(
+                "All hypothesis checks passed. Evidence supports advancing "
+                "to the next rung."
+            )
     elif decision == "HALT":
         n_fail = 0
         if hypothesis_outcomes is not None and "status" in hypothesis_outcomes.columns:

--- a/tests/unit/test_rung_report.py
+++ b/tests/unit/test_rung_report.py
@@ -206,10 +206,22 @@ class TestDecisionReport:
             charts_dir=charts_dir,
         )
         assert "**ADVANCE**" in content
+        assert "All hypothesis checks passed." in content
+        assert "skipped" not in content
 
     def test_halt_when_any_fail(self, tmp_path, charts_dir):
         """Reports HALT when any hypothesis check fails."""
         tables_dir = _make_hypothesis_outcomes(tmp_path, ["PASS", "FAIL", "PASS"])
+        content = generate_decision_report(
+            tables_dir=tables_dir,
+            charts_dir=charts_dir,
+        )
+        assert "**HALT**" in content
+        assert "1 hypothesis check(s) failed" in content
+
+    def test_halt_when_fail_plus_skips(self, tmp_path, charts_dir):
+        """Reports HALT when FAILs coexist with SKIPs — SKIP does not mask FAIL."""
+        tables_dir = _make_hypothesis_outcomes(tmp_path, ["PASS", "FAIL", "SKIP"])
         content = generate_decision_report(
             tables_dir=tables_dir,
             charts_dir=charts_dir,
@@ -240,6 +252,8 @@ class TestDecisionReport:
             charts_dir=charts_dir,
         )
         assert "**ADVANCE**" in content
+        assert "2 skipped" in content
+        assert "All evaluated hypothesis checks passed" in content
 
     def test_pending_when_all_skipped(self, tmp_path, charts_dir):
         """Reports PENDING when all hypothesis checks are skipped."""


### PR DESCRIPTION
## Summary

- Add `test_halt_when_fail_plus_skips`: verifies SKIP does not mask FAIL in decision logic
- Fix ADVANCE recommendation text in `generate_decision_report()` to report skip count when hypotheses are skipped
- Strengthen existing ADVANCE tests with explicit text assertions

## Why

Closes #797

The ADVANCE recommendation text said "All hypothesis checks passed" even when
some hypotheses were SKIP-status (trimmed by LA-4). This was misleading — the
text should distinguish between "all passed" and "all evaluated passed (N skipped)".
Additionally, the HALT+SKIP combination lacked a dedicated test to prove SKIP
does not mask FAIL.

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_rung_report.py -x -q
# 21 passed
```

## Tests

- `uv run python -m pytest tests/unit/test_rung_report.py -x -q` — 21 passed
- New test: `test_halt_when_fail_plus_skips` — HALT when FAILs coexist with SKIPs
- Strengthened: `test_advance_when_all_pass` — asserts "All hypothesis checks passed." and no "skipped"
- Strengthened: `test_advance_when_passes_plus_skips` — asserts "2 skipped" and "All evaluated hypothesis checks passed"

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/797-halt-skip
show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/797-halt-skip
worktree: 797-halt-skip-test-and-advance-text branch
```

## Checklist

- [x] Branch based on `main`
- [x] Scope lock — only touched `report.py` and `test_rung_report.py`
- [x] Tests pass
- [x] No artifacts in `data/runs/` or `data/reports/`
- [x] Exact repro command in PR description