### PR TITLE
fix: handle both schemas in interpretability chart generation

### DIFF
--- a/scripts/internal/generate_interpretability_charts.py
+++ b/scripts/internal/generate_interpretability_charts.py
@@ -11,7 +11,8 @@ CLI:
 Charts produced:
   - shap_summary.png          — horizontal bar of mean |SHAP| per feature, faceted by contract
   - shap_dependence_top5.png  — scatter plots of top-5 features vs SHAP values
-  - selection_path.png        — line chart of R² vs features added
+  - selection_path.png        — line chart of R² vs features added (when selection_logs available)
+  - feature_importance.png    — horizontal bar of feature importance by model/contract (fallback)
   - decision_agreement.png    — bar chart of pairwise agreement rates
   - disagreement_outcomes.png — bar chart of who wins in disagreements
 """
@@ -117,8 +118,21 @@ def generate_shap_dependence(dependence_df: pd.DataFrame, output_dir: Path) -> N
         _save_chart(fig, output_dir, "shap_dependence_top5.png")
 
 
+def _has_columns(df: pd.DataFrame, required: set[str]) -> bool:
+    """Check whether *df* contains all *required* columns."""
+    return required.issubset(df.columns)
+
+
+# Column sets for the two selection_paths.csv schemas
+_SELECTION_PATH_COLS = {"model", "step", "oof_r2"}
+_FEATURE_IMPORTANCE_COLS = {"model", "contract", "rank", "feature_name", "importance"}
+
+
 def generate_selection_path_chart(selection_df: pd.DataFrame, output_dir: Path) -> None:
-    """Line chart of R² vs features added, one line per contract."""
+    """Line chart of R² vs features added, one line per contract.
+
+    Requires columns: model, contract, step, oof_r2.
+    """
     models = sorted(selection_df["model"].unique())
     n_models = len(models)
 
@@ -145,6 +159,49 @@ def generate_selection_path_chart(selection_df: pd.DataFrame, output_dir: Path) 
 
     fig.tight_layout()
     _save_chart(fig, output_dir, "selection_path.png")
+
+
+def generate_feature_importance_chart(
+    importance_df: pd.DataFrame, output_dir: Path, *, top_n: int = 15
+) -> None:
+    """Horizontal bar chart of feature importance, faceted by model and contract.
+
+    Requires columns: model, contract, rank, feature_name, importance.
+    This is the fallback chart when forward-selection path data is unavailable
+    and only static feature importances (e.g. GBT built-in) are present.
+    """
+    models = sorted(importance_df["model"].unique())
+    contracts = sorted(importance_df["contract"].unique())
+    n_cols = len(contracts)
+    n_rows = len(models)
+    if n_cols == 0 or n_rows == 0:
+        return
+
+    fig, axes = plt.subplots(
+        n_rows,
+        n_cols,
+        figsize=(5 * n_cols, max(4, 0.4 * top_n) * n_rows),
+        squeeze=False,
+    )
+
+    for r, model in enumerate(models):
+        mdf = importance_df[importance_df["model"] == model]
+        for c, contract in enumerate(contracts):
+            ax = axes[r, c]
+            cdf = mdf[mdf["contract"] == contract].nsmallest(top_n, "rank")
+            cdf = cdf.sort_values("importance", ascending=True)
+            if cdf.empty:
+                ax.set_visible(False)
+                continue
+            ax.barh(cdf["feature_name"], cdf["importance"], color="#4575b4")
+            ax.set_xlabel("Importance")
+            if c == 0:
+                ax.set_ylabel(model)
+            ax.set_title(f"{contract}")
+
+    fig.suptitle("Feature Importance by Model and Contract", fontsize=14, y=1.02)
+    fig.tight_layout()
+    _save_chart(fig, output_dir, "feature_importance.png")
 
 
 def generate_decision_agreement_chart(
@@ -282,11 +339,29 @@ def run(chart_data_dir: Path, output_dir: Path) -> list[str]:
         generate_shap_dependence(dep_df, output_dir)
         generated.append("shap_dependence_top5.png")
 
-    # Selection paths
+    # Selection paths / feature importance
+    # tables.py may write selection_paths.csv with either:
+    #   (a) step/oof_r2 columns (forward-selection path) → line chart
+    #   (b) rank/feature_name/importance columns (static importance) → bar chart
+    # Also check feature_importances.csv (canonical name for schema b).
     sel_df = _read_csv_safe(chart_data_dir / "selection_paths.csv")
-    if sel_df is not None:
+    fi_df = _read_csv_safe(chart_data_dir / "feature_importances.csv")
+
+    if sel_df is not None and _has_columns(sel_df, _SELECTION_PATH_COLS):
         generate_selection_path_chart(sel_df, output_dir)
         generated.append("selection_path.png")
+    elif fi_df is not None and _has_columns(fi_df, _FEATURE_IMPORTANCE_COLS):
+        generate_feature_importance_chart(fi_df, output_dir)
+        generated.append("feature_importance.png")
+    elif sel_df is not None and _has_columns(sel_df, _FEATURE_IMPORTANCE_COLS):
+        # selection_paths.csv contains importance data (legacy schema mismatch)
+        generate_feature_importance_chart(sel_df, output_dir)
+        generated.append("feature_importance.png")
+    elif sel_df is not None:
+        logger.warning(
+            "selection_paths.csv has unexpected columns %s; skipping chart",
+            list(sel_df.columns),
+        )
 
     # Decision agreement
     comp_df = _read_csv_safe(chart_data_dir / "decision_comparison.csv")

--- a/src/bid_euchre/arc_d_v2/tables.py
+++ b/src/bid_euchre/arc_d_v2/tables.py
@@ -1043,11 +1043,15 @@ def generate_chart_data(
     #    Deferred: requires per-seat JSONL/parquet not present in battery summaries.
     #    The function exists but is called separately when parquet data is available.
 
-    # 6. selection_paths.csv — feature importance from training artifacts
+    # 6. feature_importances.csv — feature importance from training artifacts
+    #    Also written as selection_paths.csv for backward compatibility.
     if training_artifacts:
         rows = _extract_feature_importance(training_artifacts)
         if rows:
             df = pd.DataFrame(rows)
+            df.to_csv(output_dir / "feature_importances.csv", index=False)
+            generated.append("feature_importances.csv")
+            # Backward compat: chart generators may look for either name
             df.to_csv(output_dir / "selection_paths.csv", index=False)
             generated.append("selection_paths.csv")
 

--- a/tests/unit/test_interpretability.py
+++ b/tests/unit/test_interpretability.py
@@ -977,3 +977,110 @@ class TestChartGeneration:
 
         assert "shap_summary.png" in generated
         assert (output_dir / "shap_summary.png").exists()
+
+    def test_feature_importance_chart(self, tmp_path: Path):
+        """Feature importance bar chart generates without error."""
+        mod = _import_generate_interpretability_charts()
+
+        importance_df = pd.DataFrame(
+            [
+                {
+                    "model": "gbt_av",
+                    "contract": "suit",
+                    "rank": i,
+                    "feature_name": f"f{i}",
+                    "importance": 1.0 / i,
+                }
+                for i in range(1, 6)
+            ]
+        )
+        mod.generate_feature_importance_chart(importance_df, tmp_path)
+        assert (tmp_path / "feature_importance.png").exists()
+
+    def test_run_dispatches_importance_schema(self, tmp_path: Path):
+        """run() generates feature_importance.png when CSV has rank/importance cols."""
+        mod = _import_generate_interpretability_charts()
+
+        chart_data_dir = tmp_path / "chart_data"
+        chart_data_dir.mkdir()
+
+        # Write CSV with rank/importance schema (the actual tables.py output)
+        importance_df = pd.DataFrame(
+            [
+                {
+                    "model": "gbt_av",
+                    "contract": ct,
+                    "rank": i,
+                    "feature_name": f"f{i}",
+                    "importance": 1.0 / i,
+                }
+                for ct in ("suit", "high")
+                for i in range(1, 4)
+            ]
+        )
+        importance_df.to_csv(chart_data_dir / "selection_paths.csv", index=False)
+
+        output_dir = tmp_path / "charts"
+        generated = mod.run(chart_data_dir, output_dir)
+
+        # Should dispatch to feature_importance chart, NOT crash
+        assert "feature_importance.png" in generated
+        assert (output_dir / "feature_importance.png").exists()
+        # selection_path.png should NOT be generated (wrong schema)
+        assert "selection_path.png" not in generated
+
+    def test_run_dispatches_selection_path_schema(self, tmp_path: Path):
+        """run() generates selection_path.png when CSV has step/oof_r2 cols."""
+        mod = _import_generate_interpretability_charts()
+
+        chart_data_dir = tmp_path / "chart_data"
+        chart_data_dir.mkdir()
+
+        # Write CSV with step/oof_r2 schema (forward-selection path data)
+        sel_df = pd.DataFrame(
+            [
+                {
+                    "model": "m1",
+                    "contract": "suit",
+                    "step": i,
+                    "feature_added": f"f{i}",
+                    "oof_r2": 0.2 + 0.1 * i,
+                    "delta_r2": 0.1,
+                }
+                for i in range(1, 4)
+            ]
+        )
+        sel_df.to_csv(chart_data_dir / "selection_paths.csv", index=False)
+
+        output_dir = tmp_path / "charts"
+        generated = mod.run(chart_data_dir, output_dir)
+
+        assert "selection_path.png" in generated
+        assert (output_dir / "selection_path.png").exists()
+
+    def test_run_prefers_feature_importances_csv(self, tmp_path: Path):
+        """run() reads feature_importances.csv when selection_paths.csv absent."""
+        mod = _import_generate_interpretability_charts()
+
+        chart_data_dir = tmp_path / "chart_data"
+        chart_data_dir.mkdir()
+
+        importance_df = pd.DataFrame(
+            [
+                {
+                    "model": "gbt_av",
+                    "contract": "suit",
+                    "rank": i,
+                    "feature_name": f"f{i}",
+                    "importance": 1.0 / i,
+                }
+                for i in range(1, 4)
+            ]
+        )
+        importance_df.to_csv(chart_data_dir / "feature_importances.csv", index=False)
+
+        output_dir = tmp_path / "charts"
+        generated = mod.run(chart_data_dir, output_dir)
+
+        assert "feature_importance.png" in generated
+        assert (output_dir / "feature_importance.png").exists()


### PR DESCRIPTION
## Summary

- Fix crash in `generate_interpretability_charts.py` when `selection_paths.csv` contains `rank/feature_name/importance` columns (from `tables.py`) instead of `step/oof_r2` columns (from forward-selection paths)
- Add `generate_feature_importance_chart()` — horizontal bar chart of feature importance, faceted by model and contract
- Schema dispatch in `run()`: detects columns present and routes to correct chart type
- `tables.py` now also writes `feature_importances.csv` (canonical name) alongside `selection_paths.csv` (backward compat)

## Why

During R2 FULL orchestration, `generate_interpretability_charts.py` crashed with a pandas KeyError on `"step"` column. Root cause: `tables.py::_extract_feature_importance()` writes `selection_paths.csv` with `rank/importance` columns (GBT built-in feature importances), but the chart generator expected `step/oof_r2` columns (forward-selection path data from `generate_interpretability.py`). The two producers have incompatible schemas for the same filename.

## Repro / Validation

```bash
# Targeted tests (4 new + 3 existing)
uv run python -m pytest tests/unit/test_interpretability.py::TestChartGeneration -v

# Full related test suite (201 tests)
uv run python -m pytest tests/unit/test_interpretability.py tests/unit/test_rung_tables.py tests/unit/test_rung_charts.py -v

# Full validation
make check-quiet
```

## Tests

- `test_feature_importance_chart` — new chart generates from rank/importance data
- `test_run_dispatches_importance_schema` — `run()` correctly routes rank/importance CSV to bar chart
- `test_run_dispatches_selection_path_schema` — `run()` still routes step/oof_r2 CSV to line chart  
- `test_run_prefers_feature_importances_csv` — `run()` reads `feature_importances.csv` when present

All 201 tests in related files pass. `make check-quiet` passes.

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-fix-interp-chart
branch: fix/interpretability-chart-schema
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)