### PR TITLE
planning: add task discipline and review architecture to agent-ops plan

### DIFF
--- a/plans/sessions/2026-03-15_autonomous-agent-ops-workflow.md
+++ b/plans/sessions/2026-03-15_autonomous-agent-ops-workflow.md
@@ -6,10 +6,10 @@
 
 ## Plan
 - PR-1: Establish the operating model, bootstrap scripts, and documentation for role-based worktrees (`author`, `review`, `ops`) using the existing Claude worktree hook system as the foundation.
-- PR-2: Add a repo-owned tmux launcher and VS Code audit workspace so autonomous sessions can be started consistently and audited from a stable editor surface.
-- PR-3: Add a lightweight operator CLI (`ops.py`) that summarizes worktree health, review-loop state, rung state, heartbeats, watchdog status for long-running processes, scheduled health checks, and latest artifacts from one command.
-- PR-4: Add a two-layer memory system: small curated memory for stable operator facts plus a local audit index over execution logs, review artifacts, checkpoints, and manifests for searchable history.
-- PR-5: Roll out the autonomous workflow in stages, validate that it works for real tasks, add skill-promotion and context-safety workflows, and retire ad hoc “multiple terminals in one checkout” usage.
+- PR-2: Add a repo-owned steward session launcher and VS Code audit workspace so autonomous sessions can be started consistently and audited from a stable editor surface, while shifting review inspection from local loop state to GitHub/CI outcomes.
+- PR-3: Add a lightweight operator CLI (`ops.py`) that summarizes worktree health, GitHub/CI review outcomes, local plan-review status, rung state, heartbeats, watchdog status for long-running processes, and latest artifacts from one command.
+- PR-4: Add a two-layer memory system: small curated memory for stable operator facts plus a local audit index over execution logs, CI/review outcomes, checkpoints, and manifests for searchable history.
+- PR-5: Roll out the autonomous workflow in stages, validate online-first PR review plus local `/review-plan`, add skill-promotion and context-safety workflows, and retire ad hoc “multiple terminals in one checkout” usage.
 
 ## Sequencing — Roadmap Position
 
@@ -110,6 +110,23 @@ These decisions were resolved during the 2026-03-16 review session.
 - The full migration (removing deny rules, adding PreToolUse hook redirection to `ops.py worktrees prune`) lands with PR-3.
 - **Why:** Permission changes affect every Claude session. They should be deliberate and versioned, not drift in as side tweaks.
 
+### Review Architecture Migration (2026-03-18)
+
+**Decision:** PR review becomes online-first; plan review remains local/in-session; existing local PR/plan review loops are transitional, not strategic.
+
+- GitHub is the source of truth for PR review state.
+- Deterministic prechecks should move to GitHub Actions as a normal PR check.
+- Local PR review-loop state under `.claude/runtime/review_loops/**` and local plan-review loop state under `.claude/runtime/plan_reviews/**` should not become new first-class dependencies of the ops layer.
+- `/review-plan` remains the user-facing plan review command, but its backend should be simplified to a local Claude-first in-session flow rather than a Codex CLI subprocess loop.
+- Existing local PR/plan review loop code may be kept functioning during migration, but it should not be expanded further unless strictly required for transition safety.
+
+**Dated repo fact (2026-03-18):**
+- Branch protection on `main` currently requires `tests` and `governance`.
+- `reviewing-changes` is advisory, not required.
+
+**Implementation constraint:**
+- `scripts/internal/deterministic_prechecks.py` uses `git diff origin/main...HEAD`, so any GitHub workflow that runs it must fetch history deeply enough for the merge base to exist.
+
 ## Decisions
 
 ### Target Workflow
@@ -121,8 +138,8 @@ These decisions were resolved during the 2026-03-16 review session.
 
 ### Roles
 - `author`: primary implementation agent; writes code, runs targeted checks, opens PRs.
-- `review`: independent reviewer agent; inspects diffs, runs targeted validation, reviews plan/report/code changes.
-- `ops`: monitoring and orchestration agent; watches rung status, review loop state, heartbeats, failures, and artifact publication.
+- `review`: advisory/manual reviewer; triages online PR review outcomes, performs bounded local plan/report/code reviews, and runs follow-up validation when online review or CI flags issues.
+- `ops`: monitoring and orchestration agent; watches rung status, GitHub/CI review outcomes, heartbeats, failures, and artifact publication.
 
 ### Worktree Lifecycle Policy
 - The system maintains exactly three default persistent role worktrees: `author`, `review`, and `ops`.
@@ -159,10 +176,46 @@ The Claude Code permission model must evolve alongside the worktree lifecycle sy
 - The planner produces a bounded task list, file plan, validation plan, and completion criteria before execution begins.
 - Execution may revise the plan only through explicit plan updates recorded in task metadata or plan files.
 
+### Task Discipline And Lane Governance
+- Every active execution lane must have one canonical repo-local task record while work is in progress.
+- The task record is the lane's execution contract. It must define:
+  - `task_id`
+  - `owner_lane`
+  - `goal`
+  - `in_scope`
+  - `out_of_scope`
+  - ordered checklist items
+  - validation steps
+  - completion criteria
+  - escalation triggers
+- One lane should own one primary task at a time. Newly discovered work should become:
+  - a follow-up item
+  - a handoff to another lane
+  - or an escalation to `ops`
+- Agents must keep the repo-local task record aligned with the in-session task list they are actually following.
+- A lane is considered drifting if its changed files, validations, or reported progress no longer match its declared task scope.
+- Each lane must have an explicit charter that states:
+  - what it owns
+  - what it must not touch
+  - when it must escalate
+  - what counts as done
+- Escalation is required, not optional, when:
+  - requested work exceeds declared scope
+  - touched files move outside allowed ownership without explicit reassignment
+  - validation fails repeatedly beyond the configured threshold
+  - the lane is blocked beyond the configured threshold
+  - destructive or risky recovery action is needed
+  - the plan/requirements become materially ambiguous
+- Task completion requires:
+  - updating task state
+  - recording validation outcome
+  - writing a short completion note or handoff summary
+  - emitting follow-ups or blockers explicitly instead of leaving them implicit in chat history
+
 ### Role Capability Policy
 - `author` may edit repo files, run targeted tests, run bounded validation, create branches/worktrees, and prepare or open PRs.
 - `review` defaults to read, diff, review, and targeted validation only; write access is limited to review artifacts or explicitly delegated fix-up work.
-- `ops` may inspect runtime state, refresh indexes, run status commands, and perform bounded orchestration/recovery actions; code edits are off by default unless explicitly delegated.
+- `ops` may inspect runtime state, refresh indexes, run status commands, poll GitHub/CI review outcomes, and perform bounded orchestration/recovery actions; code edits are off by default unless explicitly delegated.
 - Destructive or recovery actions remain approval-gated regardless of role.
 
 ### User Role
@@ -174,7 +227,9 @@ The Claude Code permission model must evolve alongside the worktree lifecycle sy
 - `.claude/scripts/claude-worktree.sh` already creates a worktree and starts Claude.
 - `.claude/hooks/worktree-guard.sh` and `.claude/hooks/worktree-reminder.sh` already enforce “no edits from main checkout”.
 - `scripts/internal/clean_worktrees.sh` already handles stale worktree cleanup.
-- `scripts/internal/run_rung.py`, `src/bid_euchre/arc_d_v2/orchestration.py`, and review-loop scripts already expose most of the runtime state the operator surface needs.
+- `scripts/internal/run_rung.py` and `src/bid_euchre/arc_d_v2/orchestration.py` already expose most of the runtime/orchestration state the operator surface needs.
+- `scripts/internal/deterministic_prechecks.py` should be reused as the basis for a GitHub-hosted deterministic prechecks job.
+- Existing local review-loop scripts and adapters are transitional references only; they should not be expanded into long-term operator dependencies.
 
 ## Scope
 
@@ -184,44 +239,41 @@ The Claude Code permission model must evolve alongside the worktree lifecycle sy
 - VS Code audit workspace and tasks.
 - Repo-local status/audit CLI.
 - Local audit index for repo runtime artifacts.
+- GitHub-hosted deterministic prechecks and provider-neutral PR review outcome monitoring.
+- Simplified local `/review-plan` flow for plan review.
 - Documentation and rollout procedure.
 
 ### Out Of Scope
 - Replacing VS Code with a terminal-only workflow.
 - Introducing Airflow, Dagster, Prefect, or other heavyweight orchestrators.
 - Introducing fully dynamic self-modifying agent behavior.
-- Replacing the existing review loop or rung orchestrator state machines.
+- Replacing the existing rung orchestrator state machines.
+- Preserving the current local PR/plan review loops as canonical long-term architecture.
 
 ## Architecture
 
 ### Control Surfaces
-- Terminal control surface: cmux as the default outer terminal host, with Ghostty as an acceptable fallback host, and tmux as the persistent inner session manager.
+- Terminal control surface: Ghostty + tmux for persistent autonomous sessions.
 - Editor audit surface: VS Code multi-root workspace spanning main checkout plus role worktrees.
-- Repo control surface: repo-owned scripts and tasks for bootstrap, status, resume, routing, notification, and cleanup.
-
-### Coordination Model
-- Repo-local task and routing metadata remain the system of record.
-- cmux provides the default outer workspace host, notifications, and top-level surface targeting.
-- In the initial implementation, all active lanes live inside one tmux session hosted by one cmux surface. Per-lane routing therefore targets tmux panes/windows first; cmux is the notification and outer-host layer.
-- Human-facing labels such as tmux pane titles may be used for notifications, but canonical routing must not rely on display labels alone.
+- Repo control surface: repo-owned scripts and tasks for bootstrap, status, resume, and cleanup.
 
 ### State Model
 - Worktree state: branch, path, dirty/clean status, last activity.
 - Worktree registry state: role/class (`persistent` or `ephemeral`), task/plan/PR linkage, TTL, cleanup status, and active session ownership.
 - Session state: active role, current task, governing/session plan link, last checkpoint, and restart metadata.
 - Task state: canonical todo list, current `in_progress` item, blocked reasons, validation status, and explicit completion marker.
-- Event state: durable event log for review requests, CI failures, heartbeat anomalies, task completions, and other hook-produced operational signals.
-- Review queue state: queued review requests, claim status, owner, source lane/task/PR, and completion status.
+- Progress state: last completed checklist item, last meaningful artifact touched, last validation run, current blocker, and last forward-progress timestamp.
+- Event state: durable event log for CI failures, heartbeat anomalies, task completions, local review requests, and other hook-produced operational signals.
 - Scheduler state: last tick time, last successful health pass, next due checks, and host-level recovery metadata.
-- Review state: `.claude/runtime/review_loops/**`, sidecars, PR metadata.
-- Plan-review state: `.claude/runtime/plan_reviews/**`.
+- PR review state: provider-neutral review outcomes including GitHub PR checks, deterministic prechecks CI status, and visible online review artifacts/comments.
+- Plan-review state: local `/review-plan` outputs and summaries; `.claude/runtime/plan_reviews/**` is transitional/legacy unless retained as a simplified local artifact store.
 - Rung/orchestration state: `plans/**/state.json`, `execution_log.jsonl`, heartbeat files, checkpoints.
 - Artifact/report state: manifests, latest report dirs, evidence outputs.
 - CI state: per-PR check status (pending/pass/fail), failure class, retry count, last push SHA, remediation history.
 
 ### Audit Model
 - VS Code shows all checkouts and generated audit artifacts.
-- `ops.py status` provides a single summary for humans and agents.
+- `ops.py status` provides a single summary for humans and agents, centered on provider-neutral review outcomes rather than local review-loop internals.
 - Curated memory stores stable facts, preferences, and workflow invariants that should survive across sessions.
 - Local audit index supports query-style retrieval over runtime artifacts and recent operational history.
 - Non-lossy context compaction archives older session detail to disk while retaining an artifact index and summary for restart/resume.
@@ -234,11 +286,22 @@ The Claude Code permission model must evolve alongside the worktree lifecycle sy
 - Session-local cron helpers are not a persistence primitive. Durable monitoring must be driven by repo-owned state plus host-level recovery, not by Claude-session-only timers.
 
 ### Scheduling And Monitoring Model
-- `ops` is the active scheduler/orchestrator role. It owns periodic health checks, event draining, review-queue maintenance, and escalation.
-- `review` is queue-driven with light polling. It should react to durable review requests rather than free-running full-repo scans.
+- `ops` is the active scheduler/orchestrator role. It owns periodic health checks, event draining, GitHub/CI review outcome polling, and escalation.
+- `review` is an advisory/manual reviewer role for local plan/report/code review and follow-up validation. It is not a durable autonomous review-loop daemon.
 - Hooks produce durable events on disk; they do not themselves become the long-lived scheduler.
 - Host-level persistence is provided by OS-level startup/recovery (macOS `launchd` in the first implementation), whose job is to ensure the steward session and `ops` lane are re-established after terminal/session loss.
 - Claude-session-only cron facilities may be used as convenience inside a running session, but they must not be the authoritative persistence or scheduling mechanism.
+- `ops` should monitor not just liveness but task adherence:
+  - whether the lane heartbeat is fresh
+  - whether progress is being recorded
+  - whether changed files remain inside declared scope
+  - whether validation is advancing toward completion
+- Heartbeats should distinguish:
+  - process alive
+  - task progressing
+  - task blocked
+  - task drifting
+- The monitoring model should support lane inbox/outbox artifacts or equivalent message records so handoffs are durable and auditable rather than hidden in chat state.
 
 ### Context Safety Model
 - Agent-loaded context sources are explicitly classified as trusted, generated, or untrusted.
@@ -289,46 +352,44 @@ The Claude Code permission model must evolve alongside the worktree lifecycle sy
 - Ephemeral worktrees are created with explicit metadata and are discoverable as cleanup candidates later.
 - Documentation clearly states the role responsibilities and the “one writer per worktree” rule.
 
-### PR-2: Persistent Session Manager, cmux Host, And VS Code Audit Surface
+### PR-2: Persistent Session Manager And VS Code Audit Surface
 
 **Depends on:** PR-1 (role worktree conventions and bootstrap scripts).
-**Produces:** tmux session layout, cmux host wrapper, VS Code workspace. Required by PR-5 (rollout).
+**Produces:** tmux session layout, VS Code workspace. Required by PR-5 (rollout).
 
 #### Objectives
 - Replace fragile ad hoc terminal tabs with a deterministic, resumable session layout.
-- Make VS Code the stable audit surface across all active worktrees.
-- Establish cmux as the default outer coordination host while preserving tmux as the resumable runtime layer.
+- Make VS Code and GitHub the stable audit surfaces across all active worktrees.
 - Ensure the steward session, especially the `ops` lane, can be re-established automatically after host/session loss.
 
 #### Deliverables
-- `.claude/tmux/agent-ops-session.sh`
-- `.claude/tmux/agent-ops-layout.conf` or equivalent repo-owned layout file
-- `.claude/cmux/agent-ops-session.sh` or equivalent wrapper around the tmux session
+- `.claude/tmux/steward-session.sh` or equivalent canonical steward launcher
+- `.claude/tmux/agent-ops-layout.conf` or equivalent repo-owned layout file if still needed after steward alignment
 - `.claude/launchd/ensure-steward-session.plist` template or generator script for macOS host-level recovery
 - `Bid-Euchre-agent-audit.code-workspace`
 - `.vscode/tasks.json`
 - docs updates in `docs/02_agent/AUTONOMOUS_OPERATOR_WORKFLOW.md`
 
 #### Requirements
-- tmux layout must create windows for `author`, `review`, `ops`, and optional `scratch`.
-- Each tmux window must start in the correct worktree.
-- The cmux wrapper must start or attach the steward tmux session cleanly and expose stable workspace/surface targets for notifications.
-- The initial cmux integration does not require one native cmux surface per lane; per-lane routing may continue to use tmux pane/window targets in the first implementation.
+- tmux layout must support the steward baseline (`author-a`, `author-b`, `review`, `ops`) plus overflow/scratch lanes without locking the long-term worker model to a fixed small set.
+- Each tmux window/pane must start in the correct worktree.
 - The repo must provide a documented host-level recovery path that re-establishes the steward session and `ops` lane after process loss or reboot.
 - VS Code workspace must include:
   - main checkout
-  - author worktree
+  - active worker worktree(s)
   - review worktree
-  - ops worktree
+  - ops/control-plane view
 - VS Code tasks must include:
   - targeted pytest
   - `make check-quiet`
   - `scripts/internal/run_rung.py --status`
-  - review-loop state inspection
+  - GitHub PR checks inspection
+  - deterministic prechecks status inspection
   - heartbeat inspection
+  - local plan review artifact inspection only as needed
 
 #### Acceptance Criteria
-- One repo-owned command starts the tmux session with all role windows and works cleanly when launched from cmux.
+- One repo-owned command starts the tmux session with all role windows.
 - On macOS, one repo-owned launchd template or setup step can re-establish the steward session without manual recreation after host/session loss.
 - One repo-owned workspace file opens the audit layout in VS Code.
 - The user can inspect all active role worktrees and runtime artifacts from VS Code without moving agent sessions into the VS Code terminal.
@@ -344,43 +405,37 @@ The Claude Code permission model must evolve alongside the worktree lifecycle sy
 - Provide deterministic recovery guidance when autonomous work hits common failure modes.
 - Detect and surface long-running process failures early through lightweight watchdogs rather than manual polling.
 - Enable autonomous post-push CI remediation: `ops` polls CI status, classifies failures, and `author` applies bounded safe fixes without human intervention.
-- Make lane-aware notifications and routing a first-class behavior: notifications should include a human-facing lane label, but routing and persistence must remain keyed to canonical metadata.
-- Make `ops` the scheduler brain for persistent monitoring and make `review` operate from a durable review queue rather than session-only timers.
+- Make `ops` the scheduler brain for persistent monitoring while treating PR review as an online-first GitHub/CI concern and local plan review as a bounded in-session concern.
 
 #### Deliverables
 - `scripts/internal/ops.py`
 - supporting module(s) under `src/bid_euchre/ops/`
 - `src/bid_euchre/ops/worktrees.py`
 - `src/bid_euchre/ops/watchdogs.py`
-- `src/bid_euchre/ops/messages.py`
-- `src/bid_euchre/ops/notifications.py`
 - `src/bid_euchre/ops/events.py`
-- `src/bid_euchre/ops/review_queue.py`
+- `src/bid_euchre/ops/reviews.py`
 - `src/bid_euchre/ops/scheduler.py`
 - recovery-template data or helpers under `src/bid_euchre/ops/recovery.py`
 - `.claude/hooks/post-task-event.sh` — hook that appends durable operational events
-- `.claude/hooks/post-review-request.sh` or equivalent hook/helper that queues review requests durably
 - `.claude/hooks/pre-worktree-cleanup.sh` — PreToolUse hook that detects direct `rm -rf` on worktree directories and redirects to `ops.py worktrees prune`
+- `.github/workflows/deterministic-prechecks.yml` — GitHub-hosted deterministic prechecks for PRs
+- `docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md` — migrate to hybrid review architecture and mark local PR loop state transitional
+- `docs/02_agent/CODEX_GITHUB_REVIEW.md` — document the online PR review path and pilot assumptions
+- `.claude/skills/review-plan/SKILL.md` — simplify to a Claude-only in-session plan review flow
+- `.claude/skills/reviewing-plans/SKILL.md` — align rubric usage with the simplified `/review-plan` path
 - unit tests under `tests/unit/`
 - optional `Makefile` targets like `make ops-status`
-- **Permission migration:** Once the PreToolUse hook and `ops.py worktrees prune` are validated: (1) replace broad `Bash(*worktree remove*)` and `Bash(*worktree prune*)` deny rules with hook-based interception, (2) audit and remove any overly broad `Bash(git worktree:*)` allow rules from `settings.local.json`, (3) remove interim `rm -rf` deny rules that are now covered by the hook
+- **Permission migration:** Remove interim `rm -rf ../:*` deny rules from user settings once the PreToolUse hook and `ops.py worktrees prune` are validated
 - `src/bid_euchre/ops/ci.py` — CI status polling, failure classification, and remediation policy
 - `tests/unit/test_ops_ci.py` — CI failure classification and remediation policy tests
-- `tests/unit/test_ops_messages.py` — routing and message transport tests
-- `tests/unit/test_ops_notifications.py` — lane-aware notification formatting tests
 - `tests/unit/test_ops_events.py` — durable event append/drain tests
-- `tests/unit/test_ops_review_queue.py` — review queue enqueue/claim/complete tests
+- `tests/unit/test_ops_reviews.py` — provider-neutral review outcome aggregation tests
 - `tests/unit/test_ops_scheduler.py` — scheduler tick, due-check, and recovery tests
 
 #### Commands
 - `ops.py status`
-- `ops.py message --to <role>`
-- `ops.py notify --to <role>`
 - `ops.py events`
 - `ops.py events drain`
-- `ops.py review-queue`
-- `ops.py review-queue enqueue`
-- `ops.py review-queue claim`
 - `ops.py tick`
 - `ops.py daemon`
 - `ops.py worktrees`
@@ -428,28 +483,27 @@ The Claude Code permission model must evolve alongside the worktree lifecycle sy
 - `git worktree list`
 - `.claude/runtime/worktree_registry/**`
 - `.claude/runtime/events/**`
-- `.claude/runtime/review_queue/**`
 - `.claude/runtime/scheduler/**`
-- `.claude/runtime/review_loops/**/state.json`
-- `.claude/runtime/plan_reviews/**/state.json`
+- GitHub PR checks and review metadata (`gh pr checks`, `gh pr view`, or equivalent provider APIs)
+- deterministic prechecks workflow results
+- `.claude/runtime/plan_reviews/**` local artifacts only where retained for simplified `/review-plan`
+- `.claude/runtime/review_loops/**` transitional/legacy only while migration is incomplete
 - `.claude/runtime/task_state/**`
 - `plans/**/state.json`
 - `plans/**/execution_log.jsonl`
 - heartbeat files
 - evidence/report manifests
 - process metadata and watchdog threshold configuration
-- tmux pane/window targets and cmux workspace/surface metadata when available
 
 #### Watchdog Coverage
 - rung orchestrators with stale or missing heartbeats
-- review loops that stop changing state for too long
-- review-queue items that remain unclaimed or unresolved too long
 - long-running commands that exceed configured wall-time bounds
 - task sessions that remain `in_progress` without evidence of forward progress
 - abandoned dirty worktrees associated with inactive sessions
 - worktree count/age drift beyond configured limits
 - detached or metadata-missing worktrees that cannot be safely classified
 - PRs stuck in CI pending or failure state beyond configured thresholds
+- PRs missing expected online review or deterministic prechecks outcomes beyond configured thresholds
 - CI remediation loops that exceed retry caps without resolution
 
 #### Watchdog Behavior
@@ -457,9 +511,8 @@ The Claude Code permission model must evolve alongside the worktree lifecycle sy
 - Auto-remediation is opt-in and limited to explicitly safe actions.
 - Watchdogs must not silently kill or mutate important processes by default.
 - Worktree cleanup defaults to dry-run reporting first; removal requires clean-state or explicit quarantine/archive handling.
-- Notification and transport helpers must distinguish canonical role/worktree identity from human-facing display labels such as tmux pane titles.
 - `ops` periodic monitoring should be implemented as a durable scheduler loop (`tick`/`daemon`) backed by repo-local state, not by session-only cron.
-- `review` periodic behavior should be queue-driven with bounded polling rather than continuous broad scans.
+- `review` work should be triggered by explicit local tasks or follow-up validation requests, not by a durable autonomous loop.
 
 #### Worktree Cleanup Policy
 - Persistent role worktrees are never auto-pruned.
@@ -472,28 +525,27 @@ The Claude Code permission model must evolve alongside the worktree lifecycle sy
 - Human-readable summary by default.
 - JSON output mode for agent consumption.
 - Non-zero exit when requested checks find blocking failures or stale runtime state.
-- Health output must cover stale heartbeats, stuck review loops, abandoned dirty worktrees, and missing or stale indexes.
-- Health and scheduler output must show whether the event queue, review queue, and host-level recovery path are healthy.
+- Health output must cover stale heartbeats, abandoned dirty worktrees, missing review outcomes, and missing or stale indexes.
+- Health and scheduler output must show whether the event queue, GitHub/CI polling, local plan-review path, and host-level recovery path are healthy.
 - Watchdog output must identify which process or session is unhealthy, why it tripped, which threshold fired, and the next bounded recovery action.
 - Recovery output must classify common failures and recommend the next bounded action instead of generic retry loops.
 - Worktree output must distinguish persistent role worktrees from ephemeral task worktrees and show cleanup candidacy clearly.
-- Notification output must include a human-facing lane label without treating that label as the canonical routing identity.
 
 #### Acceptance Criteria
 - `ops.py status` answers “what is running, what is blocked, what failed, and what needs attention next?” in one command.
+- `ops.py status` or equivalent operator surfaces should be able to identify lanes that are alive-but-drifting, alive-but-blocked, or complete-but-unclosed.
 - The CLI works from the main checkout and any worktree.
 - Agents can use JSON mode without custom parsing hacks.
 - Scheduled health checks can run unattended and produce actionable summaries without human triage first.
 - `ops` can recover its own periodic monitoring after session restart by reading scheduler state rather than relying on re-entered cron commands.
-- `review` can resume from a durable review queue without rescanning the entire repo manually.
+- GitHub is the source of truth for PR review outcomes surfaced by `ops.py`.
+- Deterministic prechecks run as a visible GitHub PR check with workflow fetch depth sufficient for `origin/main...HEAD`.
+- `/review-plan` remains available as a local in-session review flow without depending on a Codex CLI subprocess loop.
 - Common failure classes have deterministic recovery paths surfaced through the operator CLI.
 - Watchdogs reliably detect stalled or overlong autonomous processes without introducing unsafe default auto-kill behavior.
 - Worktree sprawl is bounded through explicit lifecycle states, safe prune flows, and visibility into stale/abandoned worktrees.
-- Routing and notification events are recorded in repo-local state rather than existing only in terminal transport.
-- Direct `git worktree remove`, `git worktree prune`, and `rm -rf` on worktree directories are intercepted by PreToolUse hook and redirected to `ops.py worktrees prune`.
-- Agents never invoke raw `git worktree remove` or `git worktree prune`; all cleanup goes through the safe `ops.py worktrees` wrapper which enforces persistent/ephemeral classification, dirty checks, and archive-before-delete.
-- Broad deny rules (`Bash(*worktree remove*steward*)`, `Bash(*worktree prune*)`) remain as a hard floor until the PreToolUse hook is validated; then the permission migration replaces them with hook-based interception.
-- Any broad `Bash(git worktree:*)` allow rules in `settings.local.json` are audited and removed as part of the migration.
+- Direct `rm -rf` on worktree directories is intercepted by PreToolUse hook and redirected to `ops.py worktrees prune`.
+- Interim `rm -rf ../:*` deny rules can be safely removed from user permission settings after hook validation.
 
 ### PR-4: Local Audit Index
 
@@ -502,7 +554,7 @@ The Claude Code permission model must evolve alongside the worktree lifecycle sy
 
 #### Objectives
 - Give agents and the user fast retrieval over operational state and history.
-- Minimize repeated full-file rereads of plans, logs, reports, and sidecars.
+- Minimize repeated full-file rereads of plans, logs, reports, CI outputs, and sidecars.
 - Separate durable small-memory facts from large searchable operational history.
 - Preserve old session detail without forcing it to remain in the live prompt/context window.
 
@@ -521,14 +573,15 @@ The Claude Code permission model must evolve alongside the worktree lifecycle sy
 
 #### Memory Layers
 - Curated memory: stable repo facts, user preferences, workflow invariants, role instructions, and approved operational shortcuts.
-- Audit index: searchable operational history over runtime artifacts, review outputs, checkpoints, and reports.
+- Audit index: searchable operational history over runtime artifacts, GitHub/CI review outcomes, local plan review outputs, checkpoints, and reports.
 - Session archive: non-lossy compaction target containing older observations, operation summaries, and touched-artifact indexes for restart/resume.
 
 #### Indexed Sources
 - durable event log
-- review queue artifacts
-- review-loop sidecars and states
-- plan-review sidecars and states
+- GitHub PR check snapshots / exported status summaries
+- online review artifacts or exported review summaries
+- local `/review-plan` artifacts and summaries
+- review-loop and plan-review sidecars only as transitional/legacy sources during migration
 - rung `state.json`
 - `execution_log.jsonl`
 - `checkpoints.md`
@@ -538,8 +591,9 @@ The Claude Code permission model must evolve alongside the worktree lifecycle sy
 #### Query Use Cases
 - “What failed in the last rung run?”
 - “Which worktree owns the active implementation branch?”
-- “What review findings are still open?”
-- “Which review requests are queued or stale?”
+- “Which PRs have failing or pending checks?”
+- “Which PRs are missing deterministic prechecks or visible online review outcomes?”
+- “Which local plan reviews are pending or completed?”
 - “What events did ops process in the last hour?”
 - “Which rung is blocked and why?”
 - “What artifacts were produced most recently?”
@@ -576,7 +630,8 @@ The Claude Code permission model must evolve alongside the worktree lifecycle sy
 
 #### Rollout Steps
 - Pilot on one bounded implementation task.
-- Pilot on one plan review or report review task.
+- Pilot one online PR review path with exactly one reviewer enabled.
+- Pilot one local `/review-plan` or report-review task.
 - Pilot on one rung-monitoring task.
 - Validate handoff behavior across restarts and across multiple active worktrees.
 - Promote at least one repeated multi-step workflow into a reusable skill.
@@ -587,6 +642,8 @@ The Claude Code permission model must evolve alongside the worktree lifecycle sy
 #### Acceptance Criteria
 - The user can delegate a task, open VS Code, and audit progress without sharing a checkout with the autonomous agent.
 - An agent can start, continue, review, and monitor work autonomously from dedicated role worktrees.
+- PR review runs online-first with visible GitHub/CI outcomes and without depending on local review-loop orchestration.
+- Local plan review works in-session through `/review-plan` without PTY/parser fragility from a Codex subprocess loop.
 - Repeated successful workflows are captured as skills or documented operator procedures.
 - High-autonomy context loading has a defined safety boundary and validation path.
 - Autonomous work is reversible through documented snapshot/recovery mechanisms.
@@ -596,7 +653,7 @@ The Claude Code permission model must evolve alongside the worktree lifecycle sy
 - `docs/02_agent/AUTONOMOUS_OPERATOR_WORKFLOW.md` — canonical workflow doc for the new operating model.
 - `.claude/scripts/start-role-worktree.sh` — role-aware worktree bootstrap and reuse logic.
 - `.claude/scripts/start-agent-role.sh` — starts Claude in the correct role worktree with expected instructions.
-- `.claude/tmux/agent-ops-session.sh` — tmux bootstrap for persistent multi-role sessions.
+- `.claude/tmux/steward-session.sh` — canonical tmux bootstrap for the steward session baseline.
 - `.claude/tmux/agent-ops-layout.conf` — stable tmux window and pane layout.
 - `.claude/launchd/ensure-steward-session.plist` — macOS host-level recovery template for steward session bootstrap.
 - `Bid-Euchre-agent-audit.code-workspace` — multi-root audit workspace for VS Code.
@@ -606,21 +663,25 @@ The Claude Code permission model must evolve alongside the worktree lifecycle sy
 - `src/bid_euchre/ops/status.py` — status aggregation logic.
 - `src/bid_euchre/ops/worktrees.py` — worktree registry, classification, TTL, and cleanup policy helpers.
 - `src/bid_euchre/ops/events.py` — durable event append/drain helpers.
-- `src/bid_euchre/ops/review_queue.py` — review queue state and claim logic.
+- `src/bid_euchre/ops/reviews.py` — provider-neutral PR review outcome aggregation and local plan review status helpers.
 - `src/bid_euchre/ops/scheduler.py` — periodic scheduler loop and due-check logic.
 - `src/bid_euchre/ops/memory.py` — curated memory ingestion, validation, and query helpers.
 - `.claude/hooks/post-task-event.sh` — durable event producer hook for task completions/failures.
-- `.claude/hooks/post-review-request.sh` — durable review-request enqueue hook/helper.
 - `.claude/hooks/pre-worktree-cleanup.sh` — PreToolUse hook redirecting direct `rm -rf` on worktree dirs to `ops.py worktrees prune`.
 - `src/bid_euchre/ops/watchdogs.py` — watchdog rules for long-running process health and stall detection.
 - `src/bid_euchre/ops/ci.py` — CI status polling, failure classification, remediation policy, and retry tracking.
+- `.github/workflows/deterministic-prechecks.yml` — GitHub-hosted deterministic prechecks workflow.
+- `docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md` — migrated review architecture doc, marking local loop state transitional.
+- `docs/02_agent/CODEX_GITHUB_REVIEW.md` — online review path and pilot guidance.
+- `.claude/skills/review-plan/SKILL.md` — Claude-only in-session plan review flow.
+- `.claude/skills/reviewing-plans/SKILL.md` — rubric support for `/review-plan`.
 - `src/bid_euchre/ops/recovery.py` — failure classification and bounded recovery templates.
 - `src/bid_euchre/ops/compaction.py` — session compaction and archive metadata helpers.
 - `src/bid_euchre/ops/index.py` — audit index build/query logic.
 - `tests/unit/test_ops_status.py` — CLI/status tests.
 - `tests/unit/test_ops_worktrees.py` — worktree lifecycle, prune, quarantine, and archive tests.
 - `tests/unit/test_ops_events.py` — durable event log tests.
-- `tests/unit/test_ops_review_queue.py` — review queue tests.
+- `tests/unit/test_ops_reviews.py` — review outcome aggregation and local plan review status tests.
 - `tests/unit/test_ops_scheduler.py` — scheduler/due-check/recovery tests.
 - `tests/unit/test_ops_memory.py` — curated memory tests.
 - `tests/unit/test_ops_watchdogs.py` — watchdog threshold and stall-detection tests.
@@ -630,10 +691,10 @@ The Claude Code permission model must evolve alongside the worktree lifecycle sy
 - `tests/unit/test_ops_index.py` — audit index tests.
 
 ## User-Owned Tasks
-- Install cmux and use it as the default steward host (Ghostty remains an acceptable fallback).
+- Install Ghostty or confirm another terminal host.
 - Install and adopt tmux.
 - Decide whether to keep the current shell profile or add aliases/launchers.
-- Confirm that `cmux ping`, `cmux notify`, and the Claude notification hook work from inside tmux.
+- Decide whether Ghostty becomes the default terminal or only the autonomous-agent terminal.
 - Install or enable the repo-provided `launchd` recovery job if host-level persistence is desired on macOS.
 
 ## Agent-Owned Tasks
@@ -641,7 +702,7 @@ The Claude Code permission model must evolve alongside the worktree lifecycle sy
 - Reuse existing worktree hooks instead of replacing them.
 - Add tests for all new repo-local behavior.
 - Implement scheduled health checks, curated memory, and safety scanning as repo-owned capabilities.
-- Implement durable event production, review queueing, and scheduler state as repo-owned capabilities.
+- Implement durable event production, provider-neutral review outcome monitoring, and scheduler state as repo-owned capabilities.
 - Implement task-state tracking, compaction, recovery templates, shadow snapshot helpers, and watchdogs as repo-owned capabilities.
 - Implement worktree lifecycle tracking, TTL policy, and safe cleanup as repo-owned capabilities.
 - Validate the workflow through bounded pilots before making it default.
@@ -656,14 +717,12 @@ The following capabilities have no prior repo precedent and carry higher impleme
 - **SQLite audit index (PR-4):** Introduces a database dependency for operational state. Must remain optional — the workflow should degrade gracefully if the index is stale or absent.
 - **CI remediation loop (PR-3):** Autonomous CI fix-and-repush could introduce scope creep or unbounded retries. Mitigated by strict failure classification, retry caps (max 3), and escalation for non-remediable classes. The `risky/destructive` class is never auto-remediated.
 - **Host-level persistence (PR-2/PR-3):** `launchd` recovery plus scheduler state must not create duplicate steward sessions or duplicate monitor loops. Idempotent bootstrap and lock/state checks are required.
+- **Online review provider drift (PR-3/PR-5):** GitHub-hosted reviewer behavior, branch protection settings, or API surfaces may change. Keep provider usage documented as of a dated review and avoid hard-coding assumptions deeper than necessary.
+- **Duplicate reviewer noise (PR-3/PR-5):** Running multiple online reviewers simultaneously could create low-signal PR noise. Pilot exactly one reviewer path first and avoid dual automatic reviewers during migration.
 
 ## Risks And Mitigations
 - Role drift between worktrees.
   - Mitigation: role-aware bootstrap, docs, and visible role banners in startup scripts.
-- cmux transport diverging from repo task state.
-  - Mitigation: treat cmux as transport and notification only; record assignments, handoffs, and escalations in repo-local metadata/logs.
-- tmux pane titles disappearing or becoming stale.
-  - Mitigation: use pane titles only for display; route by canonical role/worktree metadata and tmux targets.
 - Too much duplication with existing hooks/scripts.
   - Mitigation: wrap and extend current `.claude/scripts/claude-worktree.sh` instead of replacing it.
 - tmux or VS Code workflow becoming mandatory for all contributors.
@@ -680,22 +739,22 @@ The following capabilities have no prior repo precedent and carry higher impleme
   - Mitigation: classify failures, cap retries, and surface explicit next-step guidance.
 - Watchdogs producing noisy false positives.
   - Mitigation: per-process thresholds, observe-only rollout first, and bounded actions that default to notify rather than mutate.
-- Review queue becoming a dumping ground without ownership.
-  - Mitigation: claim/owner model, stale-item watchdogs, and explicit completion or escalation states.
 - Cleanup accidentally removing valuable in-progress worktrees.
   - Mitigation: persistent vs ephemeral classification, dry-run-first cleanup, quarantine for dirty worktrees, and no default deletion of role worktrees.
 - CI remediation introducing unrelated changes or scope creep.
   - Mitigation: fix scope = failure scope; re-push must not include unrelated changes; Tier 1 validation before each re-push.
 - CI remediation becoming an unbounded retry loop.
   - Mitigation: max 3 attempts per PR; non-remediable classes escalate immediately; all actions logged.
+- Local review-loop code lingering as a hidden dependency.
+  - Mitigation: mark `.claude/runtime/review_loops/**` and `.claude/runtime/plan_reviews/**` transitional/legacy, and do not build new ops dependencies on them.
 - Added tooling without operational adoption.
   - Mitigation: staged rollout with acceptance checks after each PR.
 
 ## Verification Strategy
 - Unit tests for `ops.py` parsing and state aggregation.
 - Unit tests for role metadata and recovery logic.
-- Unit tests for routing and lane-aware notification formatting.
-- Unit tests for durable event append/drain, review queue claim/complete, and scheduler tick/recovery behavior.
+- Unit tests for durable event append/drain, review outcome aggregation, and scheduler tick/recovery behavior.
+- Unit tests for task-state progression, WIP-limit enforcement, escalation trigger handling, and drift detection.
 - Unit tests for worktree registry classification, TTL handling, prune eligibility, and quarantine behavior.
 - Unit tests for curated memory validation and promotion.
 - Unit tests for audit index build/query behavior.
@@ -704,28 +763,33 @@ The following capabilities have no prior repo precedent and carry higher impleme
 - Unit tests for CI failure classification across all 6 failure classes.
 - Unit tests for remediation policy (retry caps, escalation triggers, scope constraints).
 - Unit tests for non-lossy compaction and archive lookup.
-- Manual smoke test of role bootstrap, cmux host startup, and tmux session creation.
-- Manual smoke test that notifications can be triggered from inside tmux under cmux.
+- Manual smoke test of role bootstrap and tmux session creation.
 - Manual smoke test that `launchd` or equivalent host-level recovery re-establishes the steward session and `ops` lane after process loss.
 - Manual smoke test of worktree prune dry-run, quarantine, and archive flows.
 - Manual smoke test of VS Code workspace opening all intended roots.
 - Manual smoke test of scheduled health checks and stuck-session detection.
-- Manual smoke test that a queued review request survives session restart and is claimed by `review`.
+- Manual smoke test that deterministic prechecks appear as a visible GitHub PR check with sufficient fetch depth.
+- Manual smoke test that one online reviewer path is visible on PRs without duplicate automated reviewer noise.
+- Manual smoke test that `/review-plan` runs locally in-session without Codex subprocess orchestration.
 - Manual smoke test of long-running process watchdogs against intentionally stalled sessions.
+- Manual smoke test that a lane with stale progress or out-of-scope edits is surfaced as drifting rather than merely alive.
+- Manual smoke test that blocked lanes escalate according to the documented triggers instead of silently retrying forever.
 - Manual smoke test of snapshot-based rollback and recovery after an intentionally bad edit sequence.
 - Manual smoke test of CI remediation: introduce a lint failure, push, verify `ops.py ci` classifies it correctly and `author` auto-fixes within retry cap.
 - Pilot tasks that exercise:
   - implementation flow
-  - review flow
+  - online PR review flow
+  - local `/review-plan` flow
   - rung monitoring flow
 
 ## Success Criteria
-- The default path for autonomous work is: bootstrap role worktrees -> start tmux session inside cmux -> delegate tasks to agents -> audit in VS Code.
+- The default path for autonomous work is: bootstrap role worktrees -> start tmux session -> delegate tasks to agents -> audit in VS Code.
 - No autonomous writing occurs from the main checkout.
-- The user no longer needs to manage multiple ad hoc terminals in a shared checkout or manually relay routine notifications between agents.
+- The user no longer needs to manage multiple ad hoc terminals in a shared checkout.
 - A single repo-owned status surface answers the operational questions that currently require manual inspection.
 - Autonomous work is resumable, explicitly tracked, and recoverable without relying on implicit terminal context.
-- `ops` monitoring survives session loss through host-level recovery plus repo-local scheduler state, and `review` resumes from a durable queue rather than a session-only timer.
+- `ops` monitoring survives session loss through host-level recovery plus repo-local scheduler state, PR review state comes from GitHub/CI outcomes, and local plan review remains an in-session flow rather than a local subprocess loop.
+- Each active lane stays bounded by an explicit task contract, surfaces progress durably, and can be identified as on-track, blocked, or drifting without reading raw terminal history.
 
 ## Outcome
 <!-- Filled after implementation -->
@@ -733,5 +797,5 @@ The following capabilities have no prior repo precedent and carry higher impleme
 - Notes:
   - Planning-only session (2026-03-15). Existing Claude worktree hooks and helper scripts should be treated as implementation inputs, not replaced blindly.
   - Review session (2026-03-16): Compatibility analysis confirmed PRs 1-2 low-risk during FULL backfill. User-side setup completed (Ghostty, tmux, permissions verified, 37 stale worktrees cleaned). Four design decisions resolved. Sequencing revised: Phase 4a first, then PR-1, then PR-2. CI remediation loop added to PR-3 scope.
-  - Setup refinement (2026-03-17): cmux is now treated as the default outer coordination host and tmux as the persistence layer. Live setup confirmed the initial topology is one cmux surface hosting one tmux session, so per-lane routing remains tmux-targeted while notifications use human-facing display labels such as pane titles.
-  - Scheduling refinement (2026-03-18): Session-only cron helpers are not treated as durable persistence. The plan now assumes hook-produced durable events, queue-driven review, `ops`-owned scheduler state, and host-level recovery (`launchd` on macOS) for monitoring persistence.
+  - Scheduling refinement (2026-03-18): Session-only cron helpers are not treated as durable persistence. The plan now assumes hook-produced durable events, `ops`-owned scheduler state, provider-neutral review outcome monitoring, and host-level recovery (`launchd` on macOS) for monitoring persistence.
+  - Review architecture refinement (2026-03-18): PR review is now online-first with GitHub-hosted deterministic prechecks and provider-neutral outcome monitoring. Local PR/plan review loops are transitional only. `/review-plan` remains the local plan-review entrypoint but should be simplified to an in-session Claude-first flow.


### PR DESCRIPTION
## Summary
- Add **Task Discipline & Lane Governance** section: explicit task contracts, lane charters, WIP limits, escalation triggers, drift detection, and progress heartbeat requirements
- Add **Review Architecture Migration** decision: PR review is online-first (GitHub/CI), plan review stays local via `/review-plan`, local review loops marked transitional/legacy
- Update PR-3/4/5 scope to target provider-neutral review aggregation, GitHub-hosted deterministic prechecks, and simplified local plan review instead of local queue-driven review loops
- Remove cmux coordination model in favor of Ghostty + tmux

## Why
The plan needed explicit governance for how agents stay on track (task contracts, drift detection, escalation) and a clear position on where review state lives (GitHub for PRs, local for plans). Without this, PR-3 through PR-5 would have been built on the wrong review architecture assumptions.

## Repro / Validation
Plan/docs-only change — no code, no tests affected.

```bash
# Verify file parses and key sections exist
grep -c "Task Discipline" plans/sessions/2026-03-15_autonomous-agent-ops-workflow.md
grep -c "Review Architecture Migration" plans/sessions/2026-03-15_autonomous-agent-ops-workflow.md
grep -c "online-first" plans/sessions/2026-03-15_autonomous-agent-ops-workflow.md
```

## Tests
Plan-only update — `make check` not required. Pre-commit hooks pass (repo-linter, trailing whitespace, EOF).

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: codex/steward-author-d
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)