### PR TITLE
fix: wire cross_rung_progression CLI + annotate dormant extractors

### DIFF
--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -234,6 +234,7 @@ Every experiment run creates a standardized directory under `data/runs/<run_id>/
 | `scripts/internal/github_pr_state.py` | GitHub CLI wrappers for PR metadata and CI status |
 | `scripts/internal/generate_r1_5_diagnostics.py` | R1.5-v2 calibration diagnostics (cross-rung analysis + bimodality tests) |
 | `scripts/internal/generate_r4_charts.py` | One-off report chart regeneration utility |
+| `scripts/internal/generate_cross_rung_tables.py` | Cross-rung progression table from per-rung comparator CIs |
 | `scripts/internal/generate_rung_charts.py` | CSV-first rung chart generation for Arc D v2 reports |
 | `scripts/internal/generate_rung_tables.py` | Canonical CSV table generation for Arc D v2 rung reports |
 | `scripts/internal/generate_rung_report.py` | Markdown rung report renderer from CSV tables and chart PNGs |

--- a/scripts/internal/generate_cross_rung_tables.py
+++ b/scripts/internal/generate_cross_rung_tables.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python
+"""CLI wrapper for cross-rung progression table generation.
+
+Loads comparator CIs JSON from each rung's artifacts directory and produces
+a cross_rung_progression.csv showing per-model metrics across rungs for
+trend analysis.
+
+Canonical domain logic lives in ``bid_euchre.arc_d_v2.tables``.
+
+Usage:
+    uv run python scripts/internal/generate_cross_rung_tables.py \
+        --artifacts-base data/artifacts/arc_d_v2 \
+        --rungs r0,r1,r2,r3 \
+        --mode quick \
+        --seed 42 \
+        --output-dir docs/04_reports/arc_d_v2/cross_rung/tables
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+from bid_euchre.arc_d_v2.tables import generate_cross_rung_progression
+
+logger = logging.getLogger(__name__)
+
+
+def _load_comparator_cis(
+    artifacts_base: Path,
+    rung: str,
+    mode: str | None,
+    seed: int | None,
+) -> dict | None:
+    """Load a comparator CIs JSON for a single rung.
+
+    Resolution order (matching ``_load_json_glob`` in tables.py):
+    1. ``{rung}/comparator_cis_{mode}_{seed}.json`` — deterministic
+    2. ``{rung}/comparator_cis.json`` — legacy bare name
+    3. ``{rung}/comparator_cis_*.json`` — newest by mtime (last resort)
+    """
+    rung_dir = artifacts_base / rung
+
+    # Deterministic path when mode and seed are known
+    if mode and seed is not None:
+        deterministic = rung_dir / f"comparator_cis_{mode}_{seed}.json"
+        if deterministic.exists():
+            logger.debug("Loading deterministic: %s", deterministic)
+            return json.loads(deterministic.read_text())
+
+    # Legacy bare name
+    bare = rung_dir / "comparator_cis.json"
+    if bare.exists():
+        logger.debug("Loading bare: %s", bare)
+        return json.loads(bare.read_text())
+
+    # Glob fallback
+    candidates = sorted(
+        rung_dir.glob("comparator_cis_*.json"),
+        key=lambda p: p.stat().st_mtime,
+    )
+    if candidates:
+        chosen = candidates[-1]
+        logger.warning(
+            "Glob fallback for %s: chose %s from %d candidates",
+            rung,
+            chosen.name,
+            len(candidates),
+        )
+        return json.loads(chosen.read_text())
+
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate cross-rung progression table from comparator CIs artifacts."
+        ),
+    )
+    parser.add_argument(
+        "--artifacts-base",
+        required=True,
+        type=Path,
+        help=(
+            "Base directory containing per-rung artifact subdirectories "
+            "(e.g. data/artifacts/arc_d_v2)"
+        ),
+    )
+    parser.add_argument(
+        "--rungs",
+        required=True,
+        help="Comma-separated rung labels (e.g. r0,r1,r2,r3)",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["smoke", "quick", "full"],
+        default=None,
+        help="Execution mode for deterministic artifact selection",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Seed for deterministic artifact selection",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        type=Path,
+        help="Directory to write cross_rung_progression.csv",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s: %(message)s",
+    )
+
+    rungs = [r.strip() for r in args.rungs.split(",") if r.strip()]
+    if not rungs:
+        logger.error("No rungs specified")
+        return 1
+
+    # Load comparator CIs for each rung
+    rung_comparator_cis: dict[str, dict] = {}
+    for rung in rungs:
+        cis = _load_comparator_cis(args.artifacts_base, rung, args.mode, args.seed)
+        if cis is None:
+            logger.warning(
+                "No comparator CIs found for rung %s in %s — skipping",
+                rung,
+                args.artifacts_base / rung,
+            )
+            continue
+        rung_comparator_cis[rung] = cis
+
+    if not rung_comparator_cis:
+        logger.error(
+            "No comparator CIs found for any rung. Check --artifacts-base path."
+        )
+        return 1
+
+    logger.info(
+        "Loaded comparator CIs for %d rungs: %s",
+        len(rung_comparator_cis),
+        ", ".join(sorted(rung_comparator_cis.keys())),
+    )
+
+    # Generate the cross-rung progression table
+    df = generate_cross_rung_progression(rung_comparator_cis)
+
+    # Write output
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = args.output_dir / "cross_rung_progression.csv"
+    df.to_csv(output_path, index=False)
+    logger.info("Wrote %s (%d rows)", output_path, len(df))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/bid_euchre/arc_d_v2/tables.py
+++ b/src/bid_euchre/arc_d_v2/tables.py
@@ -1472,6 +1472,14 @@ def _extract_decision_comparison(
     an informational log message.
 
     Schema: model_a, model_b, contract, deal_id, decision_a, decision_b, agreed
+
+    Note: This extractor is currently dormant -- wired through
+    ``generate_chart_data()`` but non-productive on the current
+    ``action_value.parquet`` schema, which lacks ``bid_decision`` and
+    ``model`` columns.  The productive path for decision_comparison.csv
+    is ``generate_interpretability.py`` step 3b, which computes decisions
+    from loaded models.  This function would activate if the parquet
+    schema were extended.
     """
     merged, contract_col = _load_and_merge_pairwise(
         parquet_paths, set(), "decision_comparison"
@@ -1503,6 +1511,14 @@ def _extract_disagreement_outcomes(
 
     Schema: model_a, model_b, contract, deal_id, decision_a, decision_b,
             tricks_won_a, tricks_won_b
+
+    Note: This extractor is currently dormant -- wired through
+    ``generate_chart_data()`` but non-productive on the current
+    ``action_value.parquet`` schema, which lacks ``bid_decision`` and
+    ``model`` columns.  The productive path for disagreement_outcomes.csv
+    is ``generate_interpretability.py`` step 3b, which computes decisions
+    from loaded models.  This function would activate if the parquet
+    schema were extended.
     """
     merged, contract_col = _load_and_merge_pairwise(
         parquet_paths, {"tricks_won"}, "disagreement_outcomes"

--- a/tests/unit/test_cross_rung_tables_cli.py
+++ b/tests/unit/test_cross_rung_tables_cli.py
@@ -1,0 +1,277 @@
+"""Tests for the cross-rung progression table CLI script.
+
+Covers:
+- JSON loading resolution (deterministic, bare, glob fallback)
+- CLI main() integration with fixture data
+- Error handling for missing artifacts
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+
+# The CLI script lives in scripts/internal/ and is imported via importlib
+# since it is not a package.  We import it as a module.
+SCRIPT_DIR = Path(__file__).resolve().parents[2] / "scripts" / "internal"
+FIXTURES_DIR = Path(__file__).resolve().parents[2] / "data" / "fixtures" / "arc_d_v2"
+
+
+def _import_cli():
+    """Import the CLI module dynamically from scripts/internal/."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "generate_cross_rung_tables",
+        SCRIPT_DIR / "generate_cross_rung_tables.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_comparator_cis(seed, net_eppd_a, net_eppd_b):
+    """Create a minimal comparator CIs fixture for testing."""
+    return {
+        "schema": "comparator_cis_v1",
+        "seed": seed,
+        "n_bootstrap": 1000,
+        "ranked_order": ["model_a", "model_b"]
+        if net_eppd_a >= net_eppd_b
+        else ["model_b", "model_a"],
+        "bidders": {
+            "model_a": {
+                "net_eppd": net_eppd_a,
+                "bid_rate": 0.40,
+                "make_rate": 0.65,
+                "cvar_5": -1.5,
+            },
+            "model_b": {
+                "net_eppd": net_eppd_b,
+                "bid_rate": 0.35,
+                "make_rate": 0.60,
+                "cvar_5": -2.0,
+            },
+        },
+    }
+
+
+cli = _import_cli()
+
+
+class TestLoadComparatorCis:
+    """Tests for the _load_comparator_cis resolution logic."""
+
+    def test_deterministic_path(self, tmp_path):
+        """Loads from {rung}/comparator_cis_{mode}_{seed}.json when present."""
+        rung_dir = tmp_path / "r0"
+        rung_dir.mkdir()
+        cis = _make_comparator_cis(42, 2.0, 1.0)
+        (rung_dir / "comparator_cis_quick_42.json").write_text(json.dumps(cis))
+
+        result = cli._load_comparator_cis(tmp_path, "r0", "quick", 42)
+        assert result is not None
+        assert result["seed"] == 42
+        assert "model_a" in result["bidders"]
+
+    def test_bare_name_fallback(self, tmp_path):
+        """Falls back to comparator_cis.json when deterministic path missing."""
+        rung_dir = tmp_path / "r0"
+        rung_dir.mkdir()
+        cis = _make_comparator_cis(42, 2.0, 1.0)
+        (rung_dir / "comparator_cis.json").write_text(json.dumps(cis))
+
+        result = cli._load_comparator_cis(tmp_path, "r0", "quick", 99)
+        assert result is not None
+        assert result["seed"] == 42
+
+    def test_glob_fallback(self, tmp_path):
+        """Falls back to glob when neither deterministic nor bare exist."""
+        rung_dir = tmp_path / "r1"
+        rung_dir.mkdir()
+        cis = _make_comparator_cis(123, 1.5, 0.5)
+        (rung_dir / "comparator_cis_full_123.json").write_text(json.dumps(cis))
+
+        # Request mode=quick seed=42 -- neither deterministic nor bare exist
+        result = cli._load_comparator_cis(tmp_path, "r1", "quick", 42)
+        assert result is not None
+        assert result["seed"] == 123
+
+    def test_no_mode_or_seed(self, tmp_path):
+        """When mode/seed are None, loads bare name."""
+        rung_dir = tmp_path / "r0"
+        rung_dir.mkdir()
+        cis = _make_comparator_cis(42, 2.0, 1.0)
+        (rung_dir / "comparator_cis.json").write_text(json.dumps(cis))
+
+        result = cli._load_comparator_cis(tmp_path, "r0", None, None)
+        assert result is not None
+
+    def test_missing_rung_returns_none(self, tmp_path):
+        """Returns None when the rung directory does not exist."""
+        result = cli._load_comparator_cis(tmp_path, "r99", "quick", 42)
+        assert result is None
+
+    def test_empty_rung_dir_returns_none(self, tmp_path):
+        """Returns None when rung dir exists but has no matching JSON."""
+        rung_dir = tmp_path / "r0"
+        rung_dir.mkdir()
+
+        result = cli._load_comparator_cis(tmp_path, "r0", "quick", 42)
+        assert result is None
+
+
+class TestCLIMain:
+    """Integration tests for the CLI main() function."""
+
+    def test_basic_two_rung_output(self, tmp_path):
+        """Produces cross_rung_progression.csv from two rungs."""
+        artifacts_base = tmp_path / "artifacts"
+        for rung, net_a, net_b in [("r0", 2.0, 1.0), ("r1", 2.5, 1.2)]:
+            rung_dir = artifacts_base / rung
+            rung_dir.mkdir(parents=True)
+            cis = _make_comparator_cis(42, net_a, net_b)
+            (rung_dir / "comparator_cis_quick_42.json").write_text(json.dumps(cis))
+
+        output_dir = tmp_path / "output"
+
+        with patch(
+            "sys.argv",
+            [
+                "generate_cross_rung_tables.py",
+                "--artifacts-base",
+                str(artifacts_base),
+                "--rungs",
+                "r0,r1",
+                "--mode",
+                "quick",
+                "--seed",
+                "42",
+                "--output-dir",
+                str(output_dir),
+            ],
+        ):
+            rc = cli.main()
+
+        assert rc == 0
+        csv_path = output_dir / "cross_rung_progression.csv"
+        assert csv_path.exists()
+
+        df = pd.read_csv(csv_path)
+        assert "rung" in df.columns
+        assert "model" in df.columns
+        assert "rank" in df.columns
+        assert "net_eppd" in df.columns
+        assert set(df["rung"].unique()) == {"r0", "r1"}
+        # 2 models * 2 rungs = 4 rows
+        assert len(df) == 4
+
+    def test_missing_all_rungs_returns_error(self, tmp_path):
+        """Returns nonzero when no artifacts found for any rung."""
+        artifacts_base = tmp_path / "empty"
+        artifacts_base.mkdir()
+        output_dir = tmp_path / "output"
+
+        with patch(
+            "sys.argv",
+            [
+                "generate_cross_rung_tables.py",
+                "--artifacts-base",
+                str(artifacts_base),
+                "--rungs",
+                "r0,r1",
+                "--output-dir",
+                str(output_dir),
+            ],
+        ):
+            rc = cli.main()
+
+        assert rc == 1
+        assert not (output_dir / "cross_rung_progression.csv").exists()
+
+    def test_partial_rungs_still_succeeds(self, tmp_path):
+        """Succeeds when only some rungs have artifacts (others are skipped)."""
+        artifacts_base = tmp_path / "artifacts"
+        rung_dir = artifacts_base / "r0"
+        rung_dir.mkdir(parents=True)
+        cis = _make_comparator_cis(42, 2.0, 1.0)
+        (rung_dir / "comparator_cis.json").write_text(json.dumps(cis))
+
+        output_dir = tmp_path / "output"
+
+        with patch(
+            "sys.argv",
+            [
+                "generate_cross_rung_tables.py",
+                "--artifacts-base",
+                str(artifacts_base),
+                "--rungs",
+                "r0,r1,r2",
+                "--output-dir",
+                str(output_dir),
+            ],
+        ):
+            rc = cli.main()
+
+        assert rc == 0
+        df = pd.read_csv(output_dir / "cross_rung_progression.csv")
+        # Only r0 loaded successfully
+        assert set(df["rung"].unique()) == {"r0"}
+
+    def test_empty_rungs_arg_returns_error(self, tmp_path):
+        """Returns nonzero when --rungs is empty."""
+        with patch(
+            "sys.argv",
+            [
+                "generate_cross_rung_tables.py",
+                "--artifacts-base",
+                str(tmp_path),
+                "--rungs",
+                "",
+                "--output-dir",
+                str(tmp_path / "out"),
+            ],
+        ):
+            rc = cli.main()
+
+        assert rc == 1
+
+    def test_uses_fixture_data(self, tmp_path):
+        """Loads the committed fixture comparator_cis.json via bare-name path."""
+        # Create artifacts base with symlink-like structure pointing to fixture
+        artifacts_base = tmp_path / "artifacts"
+        rung_dir = artifacts_base / "r0"
+        rung_dir.mkdir(parents=True)
+
+        # Copy the fixture into the test artifacts directory
+        fixture_cis = json.loads((FIXTURES_DIR / "comparator_cis.json").read_text())
+        (rung_dir / "comparator_cis.json").write_text(json.dumps(fixture_cis))
+
+        output_dir = tmp_path / "output"
+
+        with patch(
+            "sys.argv",
+            [
+                "generate_cross_rung_tables.py",
+                "--artifacts-base",
+                str(artifacts_base),
+                "--rungs",
+                "r0",
+                "--output-dir",
+                str(output_dir),
+            ],
+        ):
+            rc = cli.main()
+
+        assert rc == 0
+        df = pd.read_csv(output_dir / "cross_rung_progression.csv")
+        # Fixture has 3 bidders
+        assert len(df) == 3
+        assert set(df["model"].unique()) == {
+            "gbt_av",
+            "selected_ols_av",
+            "modeloespecifico",
+        }


### PR DESCRIPTION
## Plan
Reporting refactor plan, PR 3 of 3.

## Summary
- Add `scripts/internal/generate_cross_rung_tables.py`: CLI wrapper that loads per-rung comparator CIs JSON artifacts and calls `generate_cross_rung_progression()` to produce `cross_rung_progression.csv`
- Annotate `_extract_decision_comparison()` and `_extract_disagreement_outcomes()` in `tables.py` as dormant extractors (wired through `generate_chart_data()` but non-productive on current parquet schema)
- Add 11 tests covering artifact loading resolution, multi-rung output, partial-rung handling, error paths, and fixture data integration
- Register new script in `docs/01_core/ARCHITECTURE.md`

## Why
`generate_cross_rung_progression()` existed in `tables.py` but was never called by any script or orchestration step. This PR wires it via a CLI script following the same pattern as `generate_rung_tables.py`, making it invocable for cross-rung trend analysis. The dormant extractor annotations prevent future confusion about why `decision_comparison.csv` and `disagreement_outcomes.csv` are never produced by `generate_chart_data()`.

## Repro / Validation
**Command(s) run:**
```bash
make check-quiet   # all checks pass
uv run python -m pytest tests/unit/test_cross_rung_tables_cli.py -v   # 11/11 pass
uv run python -m pytest tests/unit/test_rung_tables.py::TestCrossRungProgression -v   # 3/3 pass
```

**Seed (if applicable):** N/A (no experiment run)

## Tests
- [x] `uv run python -m pytest tests/unit/test_cross_rung_tables_cli.py -v` (11 pass)
- [x] `uv run python -m pytest tests/unit/test_rung_tables.py::TestCrossRungProgression -v` (3 pass)
- [x] `make check-quiet` (all pass)

## Expected impact
- Metrics impact: None (new script, no behavior changes)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a6a14e26
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a6a14e26
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                                   9dbc2c5 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a6a14e26  79a3be0 [fix/cross-rung-progression-wiring]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)