### PR TITLE
docs: add task discipline contract and lane governance

### DIFF
--- a/.claude/runtime/README.md
+++ b/.claude/runtime/README.md
@@ -6,13 +6,13 @@ files are gitignored.
 
 ## Directories
 
-| Directory | Schema | Purpose |
-|-----------|--------|---------|
-| `worktree_registry/` | v2 | Canonical lane/worktree identity and metadata |
-| `session_metadata/` | v2 | Active and recent session state for resume and audit |
-| `task_state/` | v1 | Delegated task items, progress, and validation contracts |
-| `review_loops/` | -- | Review loop state (managed by `review_driver.py`) |
-| `plan_reviews/` | -- | Plan review state (managed by review skill) |
+| Directory | Schema | Status | Purpose |
+|-----------|--------|--------|---------|
+| `worktree_registry/` | v2 | Canonical | Lane/worktree identity and metadata |
+| `session_metadata/` | v2 | Canonical | Active and recent session state for resume and audit |
+| `task_state/` | v2 | Canonical | Delegated task items, scope, and validation contracts |
+| `review_loops/` | -- | Transitional | Local review loop state (managed by `review_driver.py`). PR review is migrating to online-first (GitHub). Do not build new dependencies on this directory. |
+| `plan_reviews/` | -- | Transitional | Local plan review state (managed by review skill). Will be simplified to in-session flow. Do not build new dependencies on this directory. |
 
 ## Schema Documentation
 
@@ -21,7 +21,7 @@ semantics, lifecycle, and migration notes.
 
 - `worktree_registry/README.md` -- v2 schema with `lane_id`, `lane_class`, transport fields
 - `session_metadata/README.md` -- v2 schema with canonical `lane_id`, optional `role` compat
-- `task_state/README.md` -- v1 schema for delegated task tracking
+- `task_state/README.md` -- v2 schema with `owner_lane`, `in_scope`, `out_of_scope`, escalation triggers
 
 ## Identity Contract
 

--- a/.claude/runtime/task_state/README.md
+++ b/.claude/runtime/task_state/README.md
@@ -3,17 +3,31 @@
 Runtime metadata for delegated tasks. JSON files in this directory are
 gitignored; only this README is committed.
 
-## Schema (v1)
+## Schema (v2)
 
 Each delegated task writes a JSON file named `<task_id>.json`.
 
+### v2 Example
+
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "task_id": "550e8400-e29b-41d4-a716-446655440001",
+  "owner_lane": "author-a",
   "subject": "Extract chart_data CSVs",
+  "goal": "Extract chart_data CSV files from R0-R3 JSON artifacts for the reporting suite",
   "status": "in_progress",
   "plan_link": "plans/arc_d_v2/reporting_suite_compaction_plan.md",
+  "in_scope": [
+    "Parse R0-R3 JSON artifacts",
+    "Generate chart CSV files",
+    "Validate output against existing baselines"
+  ],
+  "out_of_scope": [
+    "Chart rendering",
+    "Report generation",
+    "Schema changes to source artifacts"
+  ],
   "items": [
     {"id": 1, "description": "Parse R0 JSON artifacts", "status": "completed"},
     {"id": 2, "description": "Generate R0 chart CSV", "status": "in_progress"},
@@ -21,23 +35,55 @@ Each delegated task writes a JSON file named `<task_id>.json`.
   ],
   "blocked_by": [],
   "validation_steps": ["make lint", "uv run pytest tests/unit/test_foo.py"],
-  "completion_criteria": "All 9 CSVs extracted and validated"
+  "completion_criteria": "All 9 CSVs extracted and validated",
+  "escalation_triggers": [
+    "Touched files outside src/bid_euchre/arc_d_v2/",
+    "Validation fails 3+ times on same step",
+    "Blocked for more than 30 minutes"
+  ],
+  "completion_note": null
 }
 ```
 
 ### Fields
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `schema_version` | int | yes | Always `1` for this version |
-| `task_id` | string | yes | UUID v4 identifying this task |
-| `subject` | string | yes | Short description of the task |
-| `status` | string | yes | One of `pending`, `in_progress`, `blocked`, `completed`, `abandoned` |
-| `plan_link` | string | no | Relative path to the plan authorizing this task |
-| `items` | array | yes | Ordered list of sub-items (see below) |
-| `blocked_by` | array | no | List of blocker descriptions |
-| `validation_steps` | array | no | Commands to run for validation |
-| `completion_criteria` | string | no | What "done" means for this task |
+| Field | Type | Required | Since | Description |
+|-------|------|----------|-------|-------------|
+| `schema_version` | int | yes | v1 | Schema version (`2` for this version) |
+| `task_id` | string | yes | v1 | UUID v4 identifying this task |
+| `owner_lane` | string | yes | v2 | Canonical `lane_id` of the lane that owns this task |
+| `subject` | string | yes | v1 | Short description of the task (imperative form) |
+| `goal` | string | yes | v2 | One-sentence goal statement for the task |
+| `status` | string | yes | v1 | One of `pending`, `in_progress`, `blocked`, `completed`, `abandoned` |
+| `plan_link` | string | no | v1 | Relative path to the plan authorizing this task |
+| `in_scope` | array | yes | v2 | List of strings defining what this task covers |
+| `out_of_scope` | array | yes | v2 | List of strings defining what this task must not do |
+| `items` | array | yes | v1 | Ordered checklist of sub-items (see below) |
+| `blocked_by` | array | no | v1 | List of blocker descriptions |
+| `validation_steps` | array | no | v1 | Commands to run for validation |
+| `completion_criteria` | string | no | v1 | What "done" means for this task |
+| `escalation_triggers` | array | no | v2 | Conditions under which the lane must escalate rather than continue |
+| `completion_note` | string/null | no | v2 | Short summary written at task completion or handoff |
+
+### Field Semantics
+
+**`owner_lane`** is the canonical `lane_id` of the lane that owns this task.
+One lane should own one primary task at a time. If a lane discovers work
+outside its scope, it should create a follow-up, hand off to another lane,
+or escalate to `ops`.
+
+**`in_scope`** and **`out_of_scope`** define the task's boundaries. A lane is
+considered drifting if its changed files, validations, or reported progress
+no longer match the declared scope.
+
+**`escalation_triggers`** define when the lane must stop and escalate rather
+than continuing autonomously. Escalation is required, not optional, when
+any trigger condition is met.
+
+**`completion_note`** is written at task completion or abandonment. It provides
+a short summary of what was done, what was left undone, and any follow-ups.
+This replaces implicit handoff information that would otherwise exist only
+in chat history.
 
 ### Item Fields
 
@@ -62,9 +108,11 @@ Each delegated task writes a JSON file named `<task_id>.json`.
 Non-trivial tasks (>3 files, new code, design choices) must create a task
 record before execution begins. The task record captures:
 
-1. A bounded list of items (the "what")
-2. Validation steps (the "how to verify")
-3. Completion criteria (the "definition of done")
+1. A bounded scope (`in_scope`, `out_of_scope`)
+2. An ordered checklist of items (the "what")
+3. Validation steps (the "how to verify")
+4. Completion criteria (the "definition of done")
+5. Escalation triggers (the "when to stop and ask")
 
 Execution may revise the plan only through explicit updates to the task
 record. Ad hoc scope expansion without updating the task state is an
@@ -76,5 +124,27 @@ A task is `completed` only when:
 1. All items are `completed` or explicitly `skipped`
 2. All validation steps pass
 3. Completion criteria are met
+4. A `completion_note` is written summarizing outcome and any follow-ups
 
-The agent must set `status: "completed"` explicitly — it is never inferred.
+The agent must set `status: "completed"` explicitly -- it is never inferred.
+
+### v1 Compatibility
+
+v1 task files are accepted by v2 readers. Missing v2 fields are inferred:
+
+| v2 Field | Inferred Value from v1 |
+|----------|----------------------|
+| `owner_lane` | Inferred from session metadata if available, otherwise `"unknown"` |
+| `goal` | Same as `subject` |
+| `in_scope` | `[]` (unbounded -- legacy behavior) |
+| `out_of_scope` | `[]` (unbounded -- legacy behavior) |
+| `escalation_triggers` | `[]` (no automatic escalation -- legacy behavior) |
+| `completion_note` | null |
+
+Writers should produce v2 entries. v1 entries remain readable.
+
+## v1 Schema (Deprecated)
+
+The v1 schema did not include `owner_lane`, `goal`, `in_scope`,
+`out_of_scope`, `escalation_triggers`, or `completion_note`. See git
+history for the full v1 specification.

--- a/docs/02_agent/AUTONOMOUS_OPERATOR_WORKFLOW.md
+++ b/docs/02_agent/AUTONOMOUS_OPERATOR_WORKFLOW.md
@@ -310,6 +310,72 @@ user:
 
 ---
 
+## Task Discipline and Lane Governance
+
+### One Task Per Lane
+
+Every active execution lane should own one primary task at a time. The task
+is recorded in `.claude/runtime/task_state/<task_id>.json` using the v2
+schema (see `.claude/runtime/task_state/README.md`).
+
+Newly discovered work during execution should become:
+- A follow-up item on the current task (if in scope)
+- A new task handed off to another lane
+- An escalation to `ops`
+
+It should **not** silently expand the current task's scope.
+
+### Task Record as Execution Contract
+
+The task record defines the lane's execution boundaries:
+- **`in_scope`** -- what this task covers
+- **`out_of_scope`** -- what this task must not do
+- **`escalation_triggers`** -- when to stop and ask rather than continue
+
+A lane is considered drifting if its changed files, validations, or reported
+progress no longer match the declared task scope.
+
+### Lane Charters
+
+Each lane class has an implicit charter derived from the capability matrix
+above. In summary:
+
+| Lane Class | Owns | Must Not Touch | Escalates When |
+|------------|------|----------------|----------------|
+| `author` | Implementation in its worktree | Other lanes' worktrees, main checkout | Scope exceeds task, validation fails repeatedly, blocked, destructive action needed |
+| `scratch` | Exploratory work, drafts | Production code, other lanes' work | Work becomes production-ready (hand off to author) |
+| `review` | Review artifacts, validation | Implementation code (except delegated fixes) | Blocking findings that need implementation |
+| `ops` | Status, orchestration, health | Implementation code | Recovery action needs approval |
+
+### Escalation Requirements
+
+Escalation is required, not optional, when:
+- Requested work exceeds the declared `in_scope`
+- Touched files move outside the lane's allowed ownership
+- Validation fails repeatedly (3+ times on the same step)
+- The lane is blocked beyond a reasonable threshold
+- Destructive or risky recovery action is needed
+- The plan or requirements become materially ambiguous
+
+### Task Completion Requirements
+
+When completing a task, a lane must:
+1. Update `status` to `completed` in the task record
+2. Record the validation outcome
+3. Write a `completion_note` summarizing what was done and any follow-ups
+4. Emit follow-ups or blockers explicitly rather than leaving them implicit
+   in chat history
+
+### Progress Visibility
+
+Lanes should keep their repo-local task record aligned with the in-session
+task list they are actually following. The task record in
+`.claude/runtime/task_state/` is the durable progress signal; the in-session
+TUI task list (see `.claude/rules/25_task_lists.md`) is the ephemeral
+intra-session complement.
+
+---
+
 ## Session Metadata
 
 Each active session writes metadata to
@@ -350,11 +416,14 @@ discovery and handoff for governed initiatives.
 ## Task State
 
 Delegated tasks are tracked in `.claude/runtime/task_state/<task_id>.json`.
+See `.claude/runtime/task_state/README.md` for the full v2 schema.
+
 Task state provides:
 
-- **Bounded scope:** A finite list of items to complete
-- **Progress tracking:** Which items are done, in progress, or blocked
-- **Validation contract:** What commands to run and what "done" means
+- **Bounded scope:** `in_scope` and `out_of_scope` define task boundaries
+- **Progress tracking:** Ordered checklist items with status
+- **Validation contract:** Commands to run and completion criteria
+- **Escalation contract:** Conditions that require stopping and escalating
 - **Auditability:** The user can inspect task state from VS Code at any time
 
 ### When to Create a Task Record
@@ -438,10 +507,19 @@ operates within a lane worktree bootstrapped by this workflow.
 
 ### Autonomous Review Loop (AUTONOMOUS_REVIEW_LOOP.md)
 
-The review loop runs from the main checkout (not from lane worktrees). It
-is triggered by PR creation hooks and operates independently. The `review`
+The local review loop runs from the main checkout (not from lane worktrees).
+It is triggered by PR creation hooks and operates independently. The `review`
 lane worktree is for manual or agent-driven review work, not for the
 automated review loop.
+
+**Transitional status:** The local review loop infrastructure
+(`.claude/runtime/review_loops/`, `.claude/runtime/plan_reviews/`) is
+transitional. PR review is migrating to an online-first model where GitHub
+is the source of truth for review state and deterministic prechecks run as
+GitHub Actions. Do not build new first-class dependencies on the local
+review loop directories. See
+`plans/sessions/2026-03-15_autonomous-agent-ops-workflow.md` for the
+review architecture migration plan.
 
 ### Existing Worktree Scripts
 


### PR DESCRIPTION
## Summary
- Extends `task_state/README.md` from v1 to v2 with `owner_lane`, `goal`, `in_scope`, `out_of_scope`, `escalation_triggers`, and `completion_note` fields
- Adds "Task Discipline and Lane Governance" section to `AUTONOMOUS_OPERATOR_WORKFLOW.md` covering one-task-per-lane, lane charters, escalation requirements, and completion obligations
- Marks `review_loops/` and `plan_reviews/` as transitional in `.claude/runtime/README.md` and the workflow doc

## Why
Follow-up to PR #835 (merged). A review identified that PR-1 established lane identity and bootstrap but was missing the task-discipline contract required by the governing plan (`plans/sessions/2026-03-15_autonomous-agent-ops-workflow.md` lines 179-213). This PR closes that gap so autonomous lanes have a documented execution contract with explicit scope boundaries and escalation triggers.

## Repro / Validation
```bash
make check-quiet    # 3898 tests + lint + docs-check pass
```

## Tests
- `make check-quiet` passes
- Cross-document consistency verified: task_state v2 fields match governing plan requirements; workflow doc lane charters align with capability matrix; runtime README correctly labels transitional directories

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
branch: codex/steward-author-c
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)