### PR TITLE
fix: add parquet-backed bid-level distributions + synthetic degradation markers

### DIFF
--- a/src/bid_euchre/arc_d_v2/tables.py
+++ b/src/bid_euchre/arc_d_v2/tables.py
@@ -1031,13 +1031,17 @@ def generate_chart_data(
             df.to_csv(output_dir / "h2h_by_contract.csv", index=False)
             generated.append("h2h_by_contract.csv")
 
-    # 4. bid_levels.csv — aggregate bidding metrics per model from comparator CIs
-    if comparator_cis:
-        rows = _extract_bid_levels(comparator_cis)
-        if rows:
-            df = pd.DataFrame(rows)
-            df.to_csv(output_dir / "bid_levels.csv", index=False)
-            generated.append("bid_levels.csv")
+    # 4. bid_levels.csv — prefer parquet-backed per-level distribution
+    bid_level_rows: list[dict] = []
+    if parquet_paths:
+        bid_level_rows = _extract_bid_levels_from_parquet(parquet_paths)
+    if not bid_level_rows and comparator_cis:
+        # Fallback: aggregate rates from comparator CIs
+        bid_level_rows = _extract_bid_levels(comparator_cis)
+    if bid_level_rows:
+        df = pd.DataFrame(bid_level_rows)
+        df.to_csv(output_dir / "bid_levels.csv", index=False)
+        generated.append("bid_levels.csv")
 
     # 5. seat_balance.csv — per-seat trick distributions from parquet if available
     #    Deferred: requires per-seat JSONL/parquet not present in battery summaries.
@@ -1062,6 +1066,14 @@ def generate_chart_data(
             df = pd.DataFrame(rows)
             df.to_csv(output_dir / "outcome_distributions.csv", index=False)
             generated.append("outcome_distributions.csv")
+            # Mark degraded state if all rows are synthetic
+            if all(r.get("source") == "synthetic" for r in rows):
+                status_path = output_dir / "outcome_distributions.status"
+                status_path.write_text("degraded:synthetic\n")
+                logger.warning(
+                    "outcome_distributions.csv is fully synthetic — "
+                    "no parquet-backed distribution data available"
+                )
 
     # 8. feature_importances.csv — flat feature importance table
     if training_artifacts:
@@ -1130,6 +1142,104 @@ def _extract_h2h_by_contract(h2h_battery: dict) -> list[dict]:
                 "deals_total": cell.get("deals_total"),
                 "win_rate": _safe_round(cell.get("win_rate_a")),
             }
+        )
+    return rows
+
+
+def _extract_bid_levels_from_parquet(
+    parquet_paths: list[Path],
+) -> list[dict]:
+    """Extract per-bid-level distribution from action-value parquet files.
+
+    Uses the ``bid_n`` column in parquet data to produce actual bid-level
+    frequency rows: model, contract, bid_level, count, fraction.
+
+    Args:
+        parquet_paths: List of paths to action-value parquet files.
+
+    Returns:
+        List of dicts with keys: model, contract, bid_level, count, fraction.
+        Empty list if no valid parquet files found or bid_n column absent.
+    """
+    frames: list[pd.DataFrame] = []
+    for path in parquet_paths:
+        if not path.exists():
+            continue
+        try:
+            df = pd.read_parquet(path)
+            frames.append(df)
+        except Exception as e:
+            logger.warning("Failed to read parquet %s for bid_levels: %s", path, e)
+            continue
+
+    if not frames:
+        return []
+
+    combined = pd.concat(frames, ignore_index=True)
+
+    if "bid_n" not in combined.columns:
+        logger.info(
+            "bid_n column not in parquet; bid_levels will use aggregate fallback"
+        )
+        return []
+
+    # Determine contract column
+    contract_col = None
+    for candidate in ("contract_family", "contract_type", "contract"):
+        if candidate in combined.columns:
+            contract_col = candidate
+            break
+
+    if contract_col is None:
+        return []
+
+    # Filter to bidding actions only (action_type == "bid" if column exists)
+    if "action_type" in combined.columns:
+        bid_df = combined[combined["action_type"] == "bid"].copy()
+    else:
+        # If no action_type, use all rows with non-null bid_n
+        bid_df = combined[combined["bid_n"].notna()].copy()
+
+    if len(bid_df) == 0:
+        return []
+
+    # Determine model column if present
+    model_col = None
+    for candidate in ("model", "bidder", "model_name"):
+        if candidate in bid_df.columns:
+            model_col = candidate
+            break
+
+    rows: list[dict] = []
+
+    # Group by model (if present), contract, bid_level
+    if model_col:
+        group_cols = [model_col, contract_col, "bid_n"]
+    else:
+        group_cols = [contract_col, "bid_n"]
+
+    grouped = bid_df.groupby(group_cols).size().reset_index(name="count")
+
+    # Compute fractions within each model+contract group
+    fraction_group_cols = [model_col, contract_col] if model_col else [contract_col]
+    totals = grouped.groupby(fraction_group_cols)["count"].transform("sum")
+    grouped["fraction"] = grouped["count"] / totals
+
+    for _, row in grouped.iterrows():
+        entry: dict = {
+            "model": row[model_col] if model_col else "unknown",
+            "contract": row[contract_col],
+            "bid_level": int(row["bid_n"]),
+            "count": int(row["count"]),
+            "fraction": _safe_round(float(row["fraction"])),
+        }
+        rows.append(entry)
+
+    if rows:
+        logger.info(
+            "Extracted %d bid-level distribution rows from %d parquet file(s)",
+            len(rows),
+            len(frames),
         )
     return rows
 

--- a/tests/unit/test_rung_tables.py
+++ b/tests/unit/test_rung_tables.py
@@ -23,6 +23,7 @@ from bid_euchre.arc_d_v2.tables import (
     TIER_SMART,
     _classify_tier,
     _extract_bid_levels,
+    _extract_bid_levels_from_parquet,
     _extract_decision_comparison,
     _extract_disagreement_outcomes,
     _extract_feature_importance,
@@ -2283,3 +2284,121 @@ class TestExtractFeatureImportancesFlat:
         """disagreement_outcomes returns empty with no parquet files."""
         rows = _extract_disagreement_outcomes([])
         assert rows == []
+
+
+class TestBidLevelsFromParquet:
+    """Tests for parquet-backed bid-level distribution extraction."""
+
+    def test_bid_levels_from_parquet(self, tmp_path):
+        """bid_levels.csv extracted from parquet has per-level rows."""
+        # Create test parquet with bid_n column
+        df = pd.DataFrame(
+            {
+                "contract_family": ["suit", "suit", "suit", "high", "high"],
+                "bid_n": [6, 7, 6, 8, 9],
+                "action_type": ["bid", "bid", "bid", "bid", "bid"],
+                "tricks_won": [7, 8, 6, 9, 10],
+                "focal_seat": [0, 1, 2, 0, 1],
+            }
+        )
+        pq_path = tmp_path / "test.parquet"
+        df.to_parquet(pq_path)
+
+        rows = _extract_bid_levels_from_parquet([pq_path])
+        assert len(rows) > 0
+
+        result_df = pd.DataFrame(rows)
+        assert "bid_level" in result_df.columns
+        assert "contract" in result_df.columns
+        assert "count" in result_df.columns
+        assert "fraction" in result_df.columns
+
+        # suit bid_n=6 appears twice, bid_n=7 once
+        suit_6 = result_df[
+            (result_df["contract"] == "suit") & (result_df["bid_level"] == 6)
+        ]
+        assert len(suit_6) == 1
+        assert suit_6.iloc[0]["count"] == 2
+
+    def test_bid_levels_fallback_to_aggregate(self):
+        """bid_levels.csv falls back to aggregate when no parquet available."""
+        comparator_cis = {
+            "bidders": {
+                "model_a": {"bid_rate": 0.7, "make_rate": 0.8},
+                "model_b": {"bid_rate": 0.6, "make_rate": 0.9},
+            }
+        }
+        rows = _extract_bid_levels(comparator_cis)
+        assert len(rows) == 2
+        assert all("model" in r for r in rows)
+        assert all("bid_rate" in r for r in rows)
+
+    def test_bid_levels_parquet_preferred_over_aggregate(self, tmp_path):
+        """bid_levels uses parquet when available, ignoring aggregate fallback."""
+        # Create parquet with bid_n
+        df = pd.DataFrame(
+            {
+                "contract_family": ["suit", "suit"],
+                "bid_n": [6, 7],
+                "action_type": ["bid", "bid"],
+            }
+        )
+        pq_path = tmp_path / "test.parquet"
+        df.to_parquet(pq_path)
+
+        comparator_cis = {
+            "bidders": {
+                "model_a": {"bid_rate": 0.7, "make_rate": 0.8},
+            }
+        }
+        generated = generate_chart_data(
+            comparator_cis=comparator_cis,
+            output_dir=tmp_path,
+            parquet_paths=[pq_path],
+        )
+        assert "bid_levels.csv" in generated
+        result_df = pd.read_csv(tmp_path / "bid_levels.csv")
+        # Parquet-backed rows have bid_level column, not bid_rate
+        assert "bid_level" in result_df.columns
+
+    def test_bid_levels_from_parquet_no_bid_n(self, tmp_path):
+        """bid_levels returns empty when parquet lacks bid_n column."""
+        df = pd.DataFrame(
+            {
+                "contract_family": ["suit", "suit"],
+                "action_type": ["bid", "bid"],
+                "tricks_won": [7, 8],
+            }
+        )
+        pq_path = tmp_path / "test.parquet"
+        df.to_parquet(pq_path)
+
+        rows = _extract_bid_levels_from_parquet([pq_path])
+        assert rows == []
+
+    def test_outcome_distributions_synthetic_flagged(self, tmp_path):
+        """Synthetic outcome distributions write a .status sidecar file."""
+        h2h = {
+            "cells": {
+                "self_a": {
+                    "bidder_a": "model_a",
+                    "bidder_b": "model_a",
+                    "by_contract": {
+                        "suit": {"deals_total": 100, "mean_tricks_won": 5.5},
+                    },
+                }
+            }
+        }
+        rows = _extract_outcome_distributions(h2h, parquet_paths=None)
+        assert len(rows) > 0
+        assert all(r["source"] == "synthetic" for r in rows)
+
+        # Verify the full pipeline writes a .status sidecar
+        generated = generate_chart_data(
+            h2h_battery=h2h,
+            output_dir=tmp_path,
+        )
+        assert "outcome_distributions.csv" in generated
+        status_path = tmp_path / "outcome_distributions.status"
+        assert status_path.exists()
+        assert "degraded:synthetic" in status_path.read_text()


### PR DESCRIPTION
## Summary
- Extract per-bid-level distributions from parquet `bid_n` column for Chart 13, with fallback to aggregate rates when parquet unavailable
- Mark synthetic `outcome_distributions.csv` with a degraded status sidecar file (`outcome_distributions.status`) for manifest consumption
- Verified `_merge_comparator_cis()` correctly preserves `bidders_by_contract` — no fix needed

## Why
Chart 13 (bid-level distributions) currently only has aggregate bid_rate/make_rate from comparator CIs. The parquet files contain actual `bid_n` values that enable true per-level frequency distributions. Additionally, synthetic outcome distributions should be explicitly flagged so downstream consumers can distinguish real vs interpolated data.

## Changes
- `src/bid_euchre/arc_d_v2/tables.py`:
  - Add `_extract_bid_levels_from_parquet()` — groups parquet data by model×contract×bid_n to produce frequency rows
  - Update `generate_chart_data()` section 4 to prefer parquet-backed bid levels over aggregate fallback
  - Update section 7 to write `outcome_distributions.status` sidecar when all rows are synthetic
- `tests/unit/test_rung_tables.py`:
  - Add `TestBidLevelsFromParquet` class with 5 new tests

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_rung_tables.py -v  # 127 passed
make check-quiet  # All checks passed
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_rung_tables.py -v` — 127 passed
- [x] `make check-quiet` — all checks passed
- [x] `uv run python scripts/lint_repo.py --base origin/main --head HEAD` — passed

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-af0a93bd
branch: fix/chart-data-schema-completion
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)