### PR TITLE
fix: widen infra-gate coverage to .claude/scripts/ and .claude/tmux/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Bid Euchre AI Research Framework — a Python framework for deterministic simula
 
 - Always use `git worktree` for PR branches — never work directly on main.
 - Pattern: `git worktree add ../worktree-<branch> -b <branch>`
-- After merging a PR: update local main (`git pull`), clean up the worktree, and update MEMORY.md.
+- After merging a PR: update local main (`git pull`), clean up the worktree (ephemeral PR worktrees only; persistent role worktrees are never removed — see `docs/02_agent/AUTONOMOUS_OPERATOR_WORKFLOW.md` § Cleanup Policy), and update MEMORY.md.
 - When merging stacked PRs, merge bottom-up and immediately recreate any auto-closed downstream PRs before proceeding.
 
 ### Stacked PRs

--- a/scripts/lint_repo.py
+++ b/scripts/lint_repo.py
@@ -627,6 +627,8 @@ def check_no_import_experiments_package(
 INFRA_PATH_PREFIXES = [
     ".github/workflows/",
     ".claude/hooks/",
+    ".claude/scripts/",
+    ".claude/tmux/",
     "scripts/internal/",
 ]
 

--- a/tests/unit/test_lint_repo.py
+++ b/tests/unit/test_lint_repo.py
@@ -918,3 +918,31 @@ class TestCheckInfraChangesRequireTests:
         violations = check_infra_changes_require_tests(changed)
         assert len(violations) == 1
         assert violations[0].rule == "infra-changes-require-tests"
+
+    def test_modified_claude_script_without_tests_violation(self):
+        """Modified .claude/scripts/ file without tests -> violation."""
+        changed = [
+            ("M", ".claude/scripts/start-role-worktree.sh"),
+        ]
+        violations = check_infra_changes_require_tests(changed)
+        assert len(violations) == 1
+        assert violations[0].rule == "infra-changes-require-tests"
+        assert "start-role-worktree.sh" in violations[0].message
+
+    def test_modified_tmux_script_without_tests_violation(self):
+        """Modified .claude/tmux/ file without tests -> violation."""
+        changed = [
+            ("M", ".claude/tmux/steward-session.sh"),
+        ]
+        violations = check_infra_changes_require_tests(changed)
+        assert len(violations) == 1
+        assert violations[0].rule == "infra-changes-require-tests"
+        assert "steward-session.sh" in violations[0].message
+
+    def test_new_claude_script_no_violation(self):
+        """New .claude/scripts/ file without tests -> no violation (additions exempt)."""
+        changed = [
+            ("A", ".claude/scripts/new-script.sh"),
+        ]
+        violations = check_infra_changes_require_tests(changed)
+        assert violations == []


### PR DESCRIPTION
## Summary
- Add `.claude/scripts/` and `.claude/tmux/` to `INFRA_PATH_PREFIXES` in `lint_repo.py`
- Add worktree cleanup caveat to CLAUDE.md distinguishing ephemeral vs persistent role worktrees
- Add 3 tests for the new infra path prefixes

## Why
Post-merge review of PR #835 identified that shell scripts in `.claude/scripts/` and `.claude/tmux/` were modified without tests, and the repo-lint infra gate (PR #812) didn't fire because those paths weren't in `INFRA_PATH_PREFIXES`. This widens the gate to prevent recurrence.

The CLAUDE.md change resolves a documentation contradiction: L19 said "clean up the worktree" without distinguishing ephemeral PR worktrees from persistent role worktrees (which should never be cleaned up per `AUTONOMOUS_OPERATOR_WORKFLOW.md` § Cleanup Policy).

## Tests
- `test_modified_claude_script_without_tests_violation` — `.claude/scripts/` modification triggers gate
- `test_modified_tmux_script_without_tests_violation` — `.claude/tmux/` modification triggers gate
- `test_new_claude_script_no_violation` — additions are exempt (existing pattern)

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_lint_repo.py -k "infra" -v
make check-quiet  # all pass
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-abb1a29a
branch: fix/infra-gate-coverage
```

## Risk level
- [x] Low (lint rule + docs + tests)

## Checklist
- [x] No generated artifacts committed
- [x] Tests lock new behavior
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)