### PR TITLE
test: harden chart + parquet edge cases from post-merge review

### DIFF
--- a/plans/sessions/2026-03-18_post-merge-test-hardening.md
+++ b/plans/sessions/2026-03-18_post-merge-test-hardening.md
@@ -1,0 +1,165 @@
+# Session Plan: Post-Merge Test Hardening (PRs #843–#845)
+
+**Date:** 2026-03-18
+**Lane:** author-d
+**Branch:** `fix/post-merge-chart-test-hardening`
+
+## Context
+
+Post-merge review of PRs #843, #844, #845 produced 18 findings across 9
+review agents. After cross-referencing every finding against the actual
+codebase on `origin/main` (post-rebase), **11 of 18 are false positives**
+(referencing functions that don't exist, stale checkouts, or misidentified
+code paths). The remaining 7 are genuine gaps — 2 correctness issues and 5
+missing test paths.
+
+## Finding Triage
+
+### False positives (NO action)
+
+| # | Original Finding | Why False |
+|---|-----------------|-----------|
+| 844-#1 | PRELIMINARY triage `data_sanity FAIL` path | `_build_preliminary_triage` does not exist in codebase |
+| 844-#2 | Tests don't pass explicit `mode=` | Tests at `test_rung_report.py:167,292` already pass `mode="QUICK"` and `mode="FULL"` |
+| 844-#3 | `_to_repo_relative` returncode | Function does not exist in codebase |
+| 844-#5 | Unknown mode value untested | `mode` is a display string; no validation logic to test |
+| 844-#6 | `_build_preliminary_triage` no-facet-column | Function does not exist |
+| 844-#7 | `_to_repo_relative` error handling | Function does not exist |
+| 843-#2 | All non-bid action_type empty fallback | `_extract_outcome_distributions_from_parquet` does not filter by `action_type`; filtering happens upstream in `generate_all_tables` |
+| 843-#3 | `.status` sidecar dead artifact | `lifecycle.py:_write_status` writes `status.json` which IS consumed by `list_runs`, `_get_lifecycle_status`, and `manifest.py:_get_lifecycle_status` |
+| 843-#4 | No test .status NOT written for clean runs | `.status` is lifecycle management, not parquet-related |
+| 843-#5 | Parquet without action_type column | Extraction function doesn't use `action_type` |
+| 844-#4 | Stale absolute paths in evidence_manifest.json | Machine paths in committed JSON are cosmetic; `_inventory_dir` uses Path objects for local ops |
+
+### Genuine findings — correctness fixes (2)
+
+| ID | Severity | File | Description |
+|----|----------|------|-------------|
+| C1 | MEDIUM | `generate_rung_charts.py:863,877` | "synthetic data" annotation fires on real-but-sparse data (≤2 unique `tricks_won`, no `source` column). Label should be "sparse data" unless `source=="synthetic"`. |
+| C2 | MEDIUM | `generate_rung_charts.py:898-920` | Standalone Chart 9: when `raw_data` is empty (all counts=0 in violin path), axes get xlabel="Model" and ylabel="Tricks Won" with nothing drawn. Should call equivalent of `_unavailable_panel`. |
+
+### Genuine findings — test coverage gaps (5)
+
+| ID | Severity | Target Function | Missing Path |
+|----|----------|----------------|--------------|
+| T1 | HIGH | `generate_dashboard_health` Panel 4 (line 1742) | No test provides `bid_level+count` schema to dashboard health |
+| T2 | HIGH | `generate_dashboard_health` Panel 3 (line 1714) | No test exercises `raw_data` empty-dict → `_unavailable_panel` fallback |
+| T3 | HIGH | `_extract_outcome_distributions_from_parquet` (line 1343) | No test for parquet with `tricks_won` but no contract column → returns `[]` |
+| T4 | MEDIUM | `generate_dashboard_health` Panel 3 (line 1676) | No test provides `source="synthetic"` data to dashboard Panel 3 |
+| T5 | MEDIUM | `_extract_outcome_distributions_from_parquet` (line 1367) | Fraction sum-to-1 invariant not asserted in existing parquet tests |
+
+## Implementation Plan
+
+### Step 1: Correctness fix — sparse annotation label (C1)
+
+**File:** `scripts/internal/generate_rung_charts.py`
+**Lines:** 863, 876-877
+
+Change the annotation text from `"synthetic data"` to `"sparse data"` when
+the trigger is `tricks_won.nunique() <= 2` but `is_synthetic` is False.
+Keep `"synthetic data"` when `is_synthetic` is True.
+
+```python
+# Line 863: condition stays the same
+if is_synthetic or cdf["tricks_won"].nunique() <= 2:
+    # ...existing bar code...
+    annotation = "synthetic data" if is_synthetic else "sparse data"
+    ax.annotate(annotation, ...)
+```
+
+### Step 2: Correctness fix — empty raw_data fallback (C2)
+
+**File:** `scripts/internal/generate_rung_charts.py`
+**Lines:** 898-920
+
+Add an `else` clause after `if raw_data:` to render a fallback. In the
+standalone chart, use `ax.text()` centered message (matching
+`_unavailable_panel` pattern, but standalone chart functions don't call
+the dashboard helper).
+
+```python
+if raw_data:
+    # ...existing violin+box code...
+else:
+    ax.text(0.5, 0.5, "Insufficient data", ...)
+    ax.set_xticks([])
+    ax.set_yticks([])
+```
+
+### Step 3: Test — dashboard health Panel 4 with bid_level+count schema (T1)
+
+**File:** `tests/unit/test_rung_charts.py`
+**Class:** `TestDashboardHealthOutcomeDistributions` (add new test)
+
+Create `chart_data/bid_levels.csv` with `model, contract, bid_level, count`
+schema. Verify `generate_dashboard_health` returns True and produces PNG.
+
+### Step 4: Test — dashboard health Panel 3 empty raw_data fallback (T2)
+
+**File:** `tests/unit/test_rung_charts.py`
+**Class:** `TestDashboardHealthOutcomeDistributions` (add new test)
+
+Provide `outcome_distributions.csv` with all `count=0` (real/parquet source,
+many tricks_won). Verify `generate_dashboard_health` still returns True
+(degrades gracefully via `_unavailable_panel`).
+
+### Step 5: Test — parquet extraction missing contract column (T3)
+
+**File:** `tests/unit/test_rung_tables.py`
+**Class:** New `TestExtractOutcomeDistributionsFromParquet`
+
+Create parquet with `tricks_won` and `model` but NO contract column
+(`contract_family`, `contract_type`, `contract` all absent). Verify function
+returns `[]`.
+
+### Step 6: Test — dashboard health Panel 3 synthetic path (T4)
+
+**File:** `tests/unit/test_rung_charts.py`
+**Class:** `TestDashboardHealthOutcomeDistributions` (add new test)
+
+Provide `outcome_distributions.csv` with `source="synthetic"` and few
+tricks_won bins. Verify `generate_dashboard_health` returns True and the
+chart renders the synthetic bar path (title includes "synthetic").
+
+### Step 7: Test — parquet extraction fraction invariant (T5)
+
+**File:** `tests/unit/test_rung_tables.py`
+**Class:** New `TestExtractOutcomeDistributionsFromParquet` (same as Step 5)
+
+Assert that within each `(model, contract)` group the `fraction` values sum
+to 1.0 (within float tolerance).
+
+### Step 8: Test — standalone Chart 9 sparse annotation label (C1 test)
+
+**File:** `tests/unit/test_rung_charts.py`
+**Class:** `TestOutcomeDistributionsViolin` (add new test)
+
+Provide data with ≤2 unique tricks_won but NO `source` column. Verify the
+chart renders successfully (bar path). This tests the corrected annotation
+doesn't crash and the sparse-but-not-synthetic path works.
+
+### Step 9: Validation
+
+```bash
+uv run python -m pytest tests/unit/test_rung_charts.py tests/unit/test_rung_tables.py -v
+make check-quiet
+```
+
+## Files Changed
+
+| File | Change Type |
+|------|-------------|
+| `scripts/internal/generate_rung_charts.py` | Fix (sparse annotation, empty raw_data) |
+| `tests/unit/test_rung_charts.py` | New tests (T1, T2, T4, C1-test) |
+| `tests/unit/test_rung_tables.py` | New tests (T3, T5) |
+
+## Scope Boundary
+
+- **In scope:** 2 correctness fixes + 6 new tests covering the 7 genuine findings
+- **Out of scope:** Chart 20 registry doc update (WARNING finding — separate PR if pursued)
+- **Out of scope:** Stale paths in committed evidence_manifest.json (cosmetic)
+- **Out of scope:** All 11 false-positive findings
+
+## Outcome
+
+_To be filled after implementation._

--- a/scripts/internal/generate_rung_charts.py
+++ b/scripts/internal/generate_rung_charts.py
@@ -873,8 +873,9 @@ def generate_outcome_distributions_chart(
                     color=model_colors[model],
                     width=0.8 / max(len(models), 1),
                 )
+            annotation = "synthetic data" if is_synthetic else "sparse data"
             ax.annotate(
-                "synthetic data",
+                annotation,
                 xy=(0.5, 0.97),
                 xycoords="axes fraction",
                 ha="center",
@@ -917,11 +918,27 @@ def generate_outcome_distributions_chart(
                     patch.set_alpha(0.7)
                 ax.set_xticks(positions)
                 ax.set_xticklabels(labels, rotation=45, ha="right", fontsize=7)
+                ax.set_xlabel("Model", fontsize=9)
+                ax.set_ylabel("Tricks Won", fontsize=9)
+            else:
+                # All counts are zero — no data to visualize
+                ax.text(
+                    0.5,
+                    0.5,
+                    "Insufficient data",
+                    ha="center",
+                    va="center",
+                    transform=ax.transAxes,
+                    fontsize=11,
+                    color="#888888",
+                )
+                ax.set_xticks([])
+                ax.set_yticks([])
 
-        ax.set_xlabel("Tricks Won" if is_synthetic else "Model", fontsize=9)
-        ax.set_ylabel("Count" if is_synthetic else "Tricks Won", fontsize=9)
         ax.set_title(f"{contract.title()}", fontsize=11)
-        if is_synthetic:
+        if is_synthetic or cdf["tricks_won"].nunique() <= 2:
+            ax.set_xlabel("Tricks Won", fontsize=9)
+            ax.set_ylabel("Count", fontsize=9)
             ax.legend(fontsize=7, loc="best")
 
     fig.suptitle(

--- a/tests/unit/test_rung_charts.py
+++ b/tests/unit/test_rung_charts.py
@@ -1258,3 +1258,200 @@ class TestFeatureImportancePreference:
         result = charts_mod.generate_feature_importance_chart(chart_data, output)
         assert result is True
         assert (output / "feature_importance.png").exists()
+
+
+# ──────────────────────────────────────────────
+#  Post-merge hardening: Chart 9 sparse annotation (C1)
+# ──────────────────────────────────────────────
+
+
+class TestOutcomeDistributionsSparseAnnotation:
+    """Tests that sparse real data gets 'sparse data' annotation, not 'synthetic data'."""
+
+    def test_sparse_real_data_no_crash(self, charts_mod, tmp_path):
+        """Chart 9 renders bar fallback for sparse real data (≤2 tricks_won, no source col)."""
+        chart_data = tmp_path / "chart_data"
+        chart_data.mkdir()
+        output = tmp_path / "charts" / "full_chart_suite"
+        output.mkdir(parents=True)
+
+        # Only 2 unique tricks_won values, no source column → sparse-but-not-synthetic
+        rows = []
+        for contract in ["suit", "high"]:
+            for tricks in [4, 5]:
+                rows.append(
+                    {
+                        "model": "test_model",
+                        "contract": contract,
+                        "tricks_won": tricks,
+                        "count": 10,
+                        "fraction": 0.5,
+                    }
+                )
+        pd.DataFrame(rows).to_csv(chart_data / "outcome_distributions.csv", index=False)
+
+        result = charts_mod.generate_outcome_distributions_chart(chart_data, output)
+        assert result is True
+        assert (output / "outcome_distributions.png").exists()
+
+
+# ──────────────────────────────────────────────
+#  Post-merge hardening: Chart 9 empty raw_data fallback (C2)
+# ──────────────────────────────────────────────
+
+
+class TestOutcomeDistributionsEmptyRawData:
+    """Tests that Chart 9 handles zero-count violin path gracefully."""
+
+    def test_all_zero_counts(self, charts_mod, tmp_path):
+        """Chart 9 renders fallback when all counts are 0 (real path, many tricks_won)."""
+        chart_data = tmp_path / "chart_data"
+        chart_data.mkdir()
+        output = tmp_path / "charts" / "full_chart_suite"
+        output.mkdir(parents=True)
+
+        # Many tricks_won values (>2), source=parquet, but all counts=0
+        rows = []
+        for contract in ["suit", "high"]:
+            for tricks in range(0, 11):
+                rows.append(
+                    {
+                        "model": "test_model",
+                        "contract": contract,
+                        "tricks_won": tricks,
+                        "count": 0,
+                        "fraction": 0.0,
+                        "source": "parquet",
+                    }
+                )
+        pd.DataFrame(rows).to_csv(chart_data / "outcome_distributions.csv", index=False)
+
+        result = charts_mod.generate_outcome_distributions_chart(chart_data, output)
+        assert result is True
+        assert (output / "outcome_distributions.png").exists()
+
+
+# ──────────────────────────────────────────────
+#  Post-merge hardening: Dashboard health Panel 4 bid_level+count (T1)
+# ──────────────────────────────────────────────
+
+
+class TestDashboardHealthBidLevelSchema:
+    """Tests dashboard health Panel 4 with parquet-backed bid_level+count schema."""
+
+    def test_panel4_bid_level_count_schema(self, charts_mod, tmp_path):
+        """Dashboard health renders Panel 4 with bid_level+count CSV."""
+        tables_dir = tmp_path / "tables"
+        tables_dir.mkdir()
+        charts_dir = tmp_path / "charts"
+        charts_dir.mkdir()
+        chart_data_dir = tmp_path / "chart_data"
+        chart_data_dir.mkdir()
+
+        # Behavior summary for panels 1 & 2
+        pd.DataFrame(
+            {
+                "model": ["gbt", "ols"],
+                "source": ["comparator", "comparator"],
+                "bid_rate": [0.65, 0.55],
+                "make_rate": [0.72, 0.61],
+                "mix_suit": [0.5, 0.5],
+                "mix_high": [0.3, 0.3],
+                "mix_low": [0.2, 0.2],
+            }
+        ).to_csv(tables_dir / "behavior_summary.csv", index=False)
+
+        # bid_levels.csv with bid_level+count schema (parquet-backed)
+        rows = []
+        for model in ["gbt", "ols"]:
+            for contract in ["suit", "high"]:
+                for bl in [6, 7, 8]:
+                    rows.append(
+                        {
+                            "model": model,
+                            "contract": contract,
+                            "bid_level": bl,
+                            "count": 100 - bl * 10,
+                        }
+                    )
+        pd.DataFrame(rows).to_csv(chart_data_dir / "bid_levels.csv", index=False)
+
+        result = charts_mod.generate_dashboard_health(
+            tables_dir, charts_dir, chart_data_dir
+        )
+        assert result is True
+        assert (charts_dir / "dashboard_health.png").exists()
+
+
+# ──────────────────────────────────────────────
+#  Post-merge hardening: Dashboard health Panel 3 paths (T2, T4)
+# ──────────────────────────────────────────────
+
+
+class TestDashboardHealthPanel3Paths:
+    """Tests dashboard health Panel 3 rendering variants."""
+
+    def test_panel3_zero_count_fallback(self, charts_mod, tmp_path):
+        """Dashboard health Panel 3 degrades gracefully with all-zero counts."""
+        tables_dir = tmp_path / "tables"
+        tables_dir.mkdir()
+        charts_dir = tmp_path / "charts"
+        charts_dir.mkdir()
+        chart_data_dir = tmp_path / "chart_data"
+        chart_data_dir.mkdir()
+
+        # Outcome distributions with all-zero counts (triggers empty raw_data)
+        rows = []
+        for tricks in range(0, 11):
+            rows.append(
+                {
+                    "model": "gbt",
+                    "contract": "suit",
+                    "tricks_won": tricks,
+                    "count": 0,
+                    "fraction": 0.0,
+                    "source": "parquet",
+                }
+            )
+        pd.DataFrame(rows).to_csv(
+            chart_data_dir / "outcome_distributions.csv", index=False
+        )
+
+        result = charts_mod.generate_dashboard_health(
+            tables_dir, charts_dir, chart_data_dir
+        )
+        assert result is True
+        assert (charts_dir / "dashboard_health.png").exists()
+
+    def test_panel3_synthetic_path(self, charts_mod, tmp_path):
+        """Dashboard health Panel 3 renders synthetic bar path."""
+        tables_dir = tmp_path / "tables"
+        tables_dir.mkdir()
+        charts_dir = tmp_path / "charts"
+        charts_dir.mkdir()
+        chart_data_dir = tmp_path / "chart_data"
+        chart_data_dir.mkdir()
+
+        # Outcome distributions with source=synthetic and few bins
+        rows = []
+        for contract in ["suit", "high"]:
+            for tricks in [4, 5]:
+                rows.append(
+                    {
+                        "model": "gbt",
+                        "contract": contract,
+                        "tricks_won": tricks,
+                        "count": 15,
+                        "fraction": 0.5,
+                        "source": "synthetic",
+                    }
+                )
+        pd.DataFrame(rows).to_csv(
+            chart_data_dir / "outcome_distributions.csv", index=False
+        )
+
+        result = charts_mod.generate_dashboard_health(
+            tables_dir, charts_dir, chart_data_dir
+        )
+        assert result is True
+        assert (charts_dir / "dashboard_health.png").exists()

--- a/tests/unit/test_rung_tables.py
+++ b/tests/unit/test_rung_tables.py
@@ -30,6 +30,7 @@ from bid_euchre.arc_d_v2.tables import (
     _extract_feature_importances_flat,
     _extract_h2h_by_contract,
     _extract_outcome_distributions,
+    _extract_outcome_distributions_from_parquet,
     _merge_comparator_cis,
     _merge_h2h_batteries,
     _per_seed_sanity_comparator,
@@ -2414,3 +2415,108 @@ class TestBidLevelsFromParquet:
         status_path = tmp_path / "outcome_distributions.status"
         assert status_path.exists()
         assert "degraded:synthetic" in status_path.read_text()
+
+
+# ──────────────────────────────────────────────
+#  Post-merge hardening: Parquet extraction edge cases (T3, T5)
+# ──────────────────────────────────────────────
+
+
+class TestExtractOutcomeDistributionsFromParquet:
+    """Direct tests for _extract_outcome_distributions_from_parquet."""
+
+    def test_missing_contract_column_returns_empty(self, tmp_path):
+        """Returns [] when parquet has tricks_won but no contract column."""
+        df = pd.DataFrame(
+            {
+                "hand_id": range(50),
+                "tricks_won": [5, 6, 7, 4, 8] * 10,
+                "model": ["gbt"] * 50,
+                # No contract_family, contract_type, or contract column
+            }
+        )
+        parquet_path = tmp_path / "action_value.parquet"
+        df.to_parquet(parquet_path)
+
+        rows = _extract_outcome_distributions_from_parquet([parquet_path])
+        assert rows == []
+
+    def test_missing_tricks_won_returns_empty(self, tmp_path):
+        """Returns [] when parquet has contract but no tricks_won column."""
+        df = pd.DataFrame(
+            {
+                "hand_id": range(50),
+                "contract_family": ["suit"] * 30 + ["high"] * 20,
+                "model": ["gbt"] * 50,
+                # No tricks_won column
+            }
+        )
+        parquet_path = tmp_path / "action_value.parquet"
+        df.to_parquet(parquet_path)
+
+        rows = _extract_outcome_distributions_from_parquet([parquet_path])
+        assert rows == []
+
+    def test_nonexistent_file_returns_empty(self, tmp_path):
+        """Returns [] when parquet file does not exist."""
+        fake_path = tmp_path / "nonexistent.parquet"
+        rows = _extract_outcome_distributions_from_parquet([fake_path])
+        assert rows == []
+
+    def test_fraction_sums_to_one(self, tmp_path):
+        """Fractions within each (model, contract) group sum to 1.0."""
+        df = pd.DataFrame(
+            {
+                "hand_id": range(100),
+                "contract_family": ["suit"] * 50 + ["high"] * 50,
+                "tricks_won": [3, 4, 5, 6, 7] * 20,
+                "model": ["gbt"] * 100,
+            }
+        )
+        parquet_path = tmp_path / "action_value.parquet"
+        df.to_parquet(parquet_path)
+
+        rows = _extract_outcome_distributions_from_parquet([parquet_path])
+        assert len(rows) > 0
+
+        # Group by model+contract and verify fractions sum to ~1.0
+        result_df = pd.DataFrame(rows)
+        for (model, contract), group in result_df.groupby(["model", "contract"]):
+            fraction_sum = group["fraction"].sum()
+            assert (
+                abs(fraction_sum - 1.0) < 1e-6
+            ), f"Fractions for ({model}, {contract}) sum to {fraction_sum}, not 1.0"
+
+    def test_uses_bidder_column_for_model(self, tmp_path):
+        """Discovers model from 'bidder' column when 'model' is absent."""
+        df = pd.DataFrame(
+            {
+                "hand_id": range(60),
+                "contract_family": ["suit"] * 30 + ["high"] * 30,
+                "tricks_won": [4, 5, 6] * 20,
+                "bidder": ["gbt_av"] * 30 + ["ols_av"] * 30,
+            }
+        )
+        parquet_path = tmp_path / "action_value.parquet"
+        df.to_parquet(parquet_path)
+
+        rows = _extract_outcome_distributions_from_parquet([parquet_path])
+        assert len(rows) > 0
+        models = {r["model"] for r in rows}
+        assert models == {"gbt_av", "ols_av"}
+
+    def test_all_rows_have_source_parquet(self, tmp_path):
+        """All output rows have source='parquet'."""
+        df = pd.DataFrame(
+            {
+                "hand_id": range(30),
+                "contract_family": ["suit"] * 30,
+                "tricks_won": [4, 5, 6] * 10,
+                "model": ["gbt"] * 30,
+            }
+        )
+        parquet_path = tmp_path / "action_value.parquet"
+        df.to_parquet(parquet_path)
+
+        rows = _extract_outcome_distributions_from_parquet([parquet_path])
+        assert all(r["source"] == "parquet" for r in rows)


### PR DESCRIPTION
## Summary
- Fix 2 correctness issues and add 11 new tests covering 7 genuine findings from post-merge review of PRs #843–#845
- Triage determined 11 of 18 original findings were false positives (nonexistent functions, stale checkouts, already-tested paths)
- Add session plan documenting triage rationale and finding classification

## Why
Post-merge review of chart upgrade PRs (#843-#845) identified untested code paths and two minor correctness issues. The sparse annotation mislabeling ("synthetic data" on real-but-sparse data) and blank-axes fallback needed targeted fixes.

## Changes

### Correctness fixes (`scripts/internal/generate_rung_charts.py`)
- **C1:** Sparse real data (≤2 unique `tricks_won`, no `source` column) now shows "sparse data" annotation instead of misleading "synthetic data"
- **C2:** Standalone Chart 9 violin path handles empty `raw_data` (all counts=0) with "Insufficient data" fallback; xlabel/ylabel moved inside `if raw_data:` branch to avoid dangling labels

### Test coverage (`tests/unit/test_rung_charts.py`, `tests/unit/test_rung_tables.py`)
- **T1:** Dashboard health Panel 4 with `bid_level+count` parquet-backed schema
- **T2:** Dashboard health Panel 3 zero-count → `_unavailable_panel` fallback
- **T4:** Dashboard health Panel 3 synthetic source path
- **C1 test:** Chart 9 sparse-but-not-synthetic bar path
- **C2 test:** Chart 9 all-zero-count empty `raw_data` fallback
- **T3:** Parquet extraction edge cases (missing contract col, missing tricks_won, nonexistent file)
- **T5:** Parquet extraction invariants (fraction sum-to-1, bidder column flexibility, source=parquet)

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_rung_charts.py tests/unit/test_rung_tables.py -v
make check-quiet
```

## Tests
- `make check-quiet` — ✅ all checks pass
- 185 tests in target files — all pass (11 new)

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: codex/steward-author-d
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)