### PR TITLE
fix: normalize mode case in PRELIMINARY decision logic

### DIFF
--- a/src/bid_euchre/arc_d_v2/report.py
+++ b/src/bid_euchre/arc_d_v2/report.py
@@ -412,10 +412,11 @@ def _extract_advancement_decision(
 
     Returns one of: ADVANCE, HOLD, HALT, PRELIMINARY, PENDING.
 
-    When *mode* is ``"QUICK"`` and hypothesis outcomes are absent or empty,
-    returns ``"PRELIMINARY"`` instead of ``"PENDING"`` to signal that a
-    data-driven triage summary should be generated.
+    When *mode* is ``"QUICK"`` (case-insensitive) and hypothesis outcomes
+    are absent or empty, returns ``"PRELIMINARY"`` instead of ``"PENDING"``
+    to signal that a data-driven triage summary should be generated.
     """
+    mode = mode.upper()
     if hypothesis_outcomes is None or len(hypothesis_outcomes) == 0:
         return "PRELIMINARY" if mode == "QUICK" else "PENDING"
 

--- a/tests/unit/test_rung_report.py
+++ b/tests/unit/test_rung_report.py
@@ -369,6 +369,28 @@ class TestPreliminaryTriage:
         assert "PENDING" not in content
         assert "Rung R0" in content
 
+    def test_quick_lowercase_mode_returns_preliminary(self, tmp_path):
+        """Lowercase 'quick' (from orchestrator) also triggers PRELIMINARY."""
+        tables = tmp_path / "tables"
+        tables.mkdir()
+        charts = tmp_path / "charts"
+        charts.mkdir()
+        (tables / "hypothesis_outcomes.csv").write_text(
+            "hypothesis_id,description,status\n"
+        )
+        (tables / "comparator_rankings.csv").write_text(
+            "model,net_eppd,ci_low,ci_high,rank,facet\ngbt_av,2.0,1.8,2.2,1,pooled\n"
+        )
+
+        content = generate_decision_report(
+            tables_dir=tables,
+            charts_dir=charts,
+            rung="r0",
+            mode="quick",  # lowercase, as passed by orchestrator
+        )
+        assert "PRELIMINARY" in content
+        assert "PENDING" not in content
+
     def test_preliminary_includes_comparator_data(self, tmp_path):
         """PRELIMINARY triage includes top model performance from comparator data."""
         tables = tmp_path / "tables"


### PR DESCRIPTION
## Summary
- Fix case-sensitive mode comparison in `_extract_advancement_decision()` — orchestrator passes lowercase `quick` but function compared against uppercase `QUICK`
- PRELIMINARY triage was never triggering in actual pipeline runs

## Why
Codex review P1 finding on PR #844: the new PRELIMINARY path didn't work in the actual orchestrated QUICK workflow because mode comparison was case-sensitive.

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_rung_report.py::TestPreliminaryTriage -v
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_rung_report.py -v` (28 passed)
- Added `test_quick_lowercase_mode_returns_preliminary` covering the orchestrator case

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/worktree-fix-mode-case
branch: fix/preliminary-mode-case-sensitivity
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)