### PR TITLE
test: add coverage for PR #846 post-merge findings

### DIFF
--- a/plans/sessions/2026-03-18_pr846-coverage-gaps.md
+++ b/plans/sessions/2026-03-18_pr846-coverage-gaps.md
@@ -1,0 +1,128 @@
+<!-- review-tier: small -->
+# Session Plan: PR #846 Post-Merge Coverage Gaps
+
+**Date:** 2026-03-18
+**Trigger:** Post-merge review of PR #846 (`fix: resolve 3 follow-up issues (#830, #833, #840)`)
+**Lane:** TBD (author-a or author-b)
+**PR Strategy:** Single PR — test-only, no production code changes
+
+## Post-Merge Review Summary
+
+PR #846 merged cleanly. Architecture and correctness reviews passed clean.
+Coverage review found 2 WARN-level gaps and 2 INFO-level edge cases.
+
+## Confirmed Findings
+
+### WARN-1: Flat-schema `elif` branch untested in `run()`
+
+**File:** `scripts/internal/generate_interpretability_charts.py` (lines 359–369)
+**Confirmed:** ✅ Real gap
+
+PR #846 added a new `elif` branch in `run()` that handles `feature_importances.csv`
+with the flat schema (`model, contract, feature_name, importance` — no `rank` column).
+This branch synthesizes rank via `groupby().rank(ascending=False, method="first")`.
+
+Existing tests exercise:
+- SHAP summary path (`test_run_charts_from_csvs`)
+- Ranked importance via `selection_paths.csv` (`test_run_dispatches_importance_schema`)
+- Ranked importance via `feature_importances.csv` (`test_run_prefers_feature_importances_csv`)
+- Selection path schema (`test_run_dispatches_selection_path_schema`)
+
+**None write a flat-schema CSV** (no `rank` column) to `feature_importances.csv` and
+verify `run()` still produces `feature_importance.png` via the rank-synthesis path.
+
+### WARN-2: Step 6 dual-write (both CSVs) not asserted together
+
+**File:** `src/bid_euchre/arc_d_v2/tables.py` (step 6, ~line 1053)
+**Confirmed:** ✅ Real gap
+
+Step 6 now writes both `feature_importances.csv` AND `selection_paths.csv` in a single
+call for backward compatibility. Two existing tests each check one file:
+- `test_chart_data_includes_feature_importances` → asserts `feature_importances.csv` + ranked schema
+- `test_selection_paths_from_training_artifacts` → asserts `selection_paths.csv`
+
+**No test asserts both files are produced in the same call.** A regression that drops
+one write while keeping the other would go undetected.
+
+### INFO-1: Docstring "Pass 1.5" label is misleading (cosmetic)
+
+**File:** `tests/unit/test_codex_plan_review_adapter.py` line 239
+**Confirmed:** ✅ Cosmetic only
+
+The `TestParsePlanFindingsReversedFormat` class docstring references "Pass 1.5"
+as a label, but no code path is labeled "Pass 1.5" — the reversed format is handled
+by `_FINDING_LINE_RE.search()`. The behavior works; the explanation is just imprecise.
+
+### INFO-2: No reversed-format test without line number
+
+**File:** `tests/unit/test_codex_plan_review_adapter.py`
+**Confirmed:** ✅ Real edge case gap, low risk
+
+All 4 reversed-format tests include line numbers (`:42`, `:90-95`, `:10`, `:25`).
+No test covers the variant `— src/foo.py` (without `:N` suffix). The underlying
+regex in `_FINDING_LINE_RE` handles this case, but it's not exercised.
+
+## Fix Plan
+
+### Fix 1: Test flat-schema branch in `run()`
+
+**File:** `tests/unit/test_interpretability.py`
+**Class:** `TestChartGeneration`
+**New test:** `test_run_dispatches_flat_importance_schema`
+
+Write a `feature_importances.csv` with flat schema (no `rank` column) to
+`chart_data_dir`, invoke `run()`, and assert:
+1. `"feature_importance.png" in generated`
+2. Output file exists
+3. No crash from rank synthesis
+
+This covers WARN-1 and implicitly exercises the rank synthesis edge cases
+(INFO-3 from original review).
+
+### Fix 2: Assert dual-write in step 6
+
+**File:** `tests/unit/test_rung_tables.py`
+**Class:** `TestExtractFeatureImportancesFlat`
+**Modify:** `test_chart_data_includes_feature_importances`
+
+After the existing assertions, additionally assert:
+1. `"selection_paths.csv" in generated` (backward compat write)
+2. Both files have identical content (same DataFrame)
+
+This covers WARN-2.
+
+### Fix 3: Add no-line-number reversed-format test
+
+**File:** `tests/unit/test_codex_plan_review_adapter.py`
+**Class:** `TestParsePlanFindingsReversedFormat`
+**New test:** `test_reversed_format_no_line_number`
+
+Input: `- [P1] Missing docs — src/bid_euchre/foo.py\n`
+Assert: finding parsed, `line` is None or 0, file is `src/bid_euchre/foo.py`.
+
+This covers INFO-2.
+
+### Fix 4: Fix "Pass 1.5" docstring (cosmetic)
+
+**File:** `tests/unit/test_codex_plan_review_adapter.py`
+**Change:** Update class docstring to say "which handles reversed format via
+`_FINDING_LINE_RE`" instead of referencing "Pass 1.5".
+
+This covers INFO-1.
+
+## Files Changed
+
+| File | Change Type |
+|------|-------------|
+| `tests/unit/test_interpretability.py` | Add 1 new test |
+| `tests/unit/test_rung_tables.py` | Extend 1 existing test |
+| `tests/unit/test_codex_plan_review_adapter.py` | Add 1 new test + fix docstring |
+
+## Validation
+
+- Tier 1: `uv run python -m pytest tests/unit/test_interpretability.py tests/unit/test_rung_tables.py tests/unit/test_codex_plan_review_adapter.py -x -q`
+- Tier 2: `make check-quiet` before PR
+
+## Outcome
+
+_To be filled after implementation._

--- a/tests/unit/test_codex_plan_review_adapter.py
+++ b/tests/unit/test_codex_plan_review_adapter.py
@@ -237,8 +237,9 @@ class TestParsePlanFindingsReversedFormat:
     """Test that reversed-format Codex output is parsed through delegation.
 
     The plan review adapter delegates to parse_codex_output() from the code
-    review adapter, which already handles reversed format (Pass 1.5). These
-    tests confirm the delegation path works correctly for plan review (fixes #830).
+    review adapter, which handles reversed format via ``_FINDING_LINE_RE``.
+    These tests confirm the delegation path works correctly for plan review
+    (fixes #830).
     """
 
     def test_reversed_format_standard(self) -> None:
@@ -280,6 +281,14 @@ class TestParsePlanFindingsReversedFormat:
         findings = parse_plan_findings(output)
         assert len(findings) == 1
         assert "review_driver.sh" in findings[0].file
+
+    def test_reversed_format_no_line_number(self) -> None:
+        """Reversed format without :N line suffix is still parsed."""
+        output = "- [P1] Missing docs — src/bid_euchre/foo.py\n"
+        findings = parse_plan_findings(output)
+        assert len(findings) == 1
+        assert "foo.py" in findings[0].file
+        assert findings[0].line is None or findings[0].line == 0
 
 
 # --- Finding Dataclass Tests ---

--- a/tests/unit/test_interpretability.py
+++ b/tests/unit/test_interpretability.py
@@ -1084,3 +1084,33 @@ class TestChartGeneration:
 
         assert "feature_importance.png" in generated
         assert (output_dir / "feature_importance.png").exists()
+
+    def test_run_dispatches_flat_importance_schema(self, tmp_path: Path):
+        """run() synthesizes rank and generates chart when CSV has flat schema (no rank)."""
+        mod = _import_generate_interpretability_charts()
+
+        chart_data_dir = tmp_path / "chart_data"
+        chart_data_dir.mkdir()
+
+        # Write CSV with flat schema: model, contract, feature_name, importance
+        # (NO rank column) — exercises the groupby().rank() synthesis branch
+        flat_df = pd.DataFrame(
+            [
+                {
+                    "model": "gbt_av",
+                    "contract": ct,
+                    "feature_name": f"f{i}",
+                    "importance": 1.0 / i,
+                }
+                for ct in ("suit", "high")
+                for i in range(1, 4)
+            ]
+        )
+        assert "rank" not in flat_df.columns
+        flat_df.to_csv(chart_data_dir / "feature_importances.csv", index=False)
+
+        output_dir = tmp_path / "charts"
+        generated = mod.run(chart_data_dir, output_dir)
+
+        assert "feature_importance.png" in generated
+        assert (output_dir / "feature_importance.png").exists()

--- a/tests/unit/test_rung_tables.py
+++ b/tests/unit/test_rung_tables.py
@@ -2220,6 +2220,12 @@ class TestExtractFeatureImportancesFlat:
         }
         assert len(df) == 2
 
+        # Verify backward-compat dual-write: selection_paths.csv is also produced
+        assert "selection_paths.csv" in generated
+        assert (tmp_path / "selection_paths.csv").exists()
+        df_sel = pd.read_csv(tmp_path / "selection_paths.csv")
+        pd.testing.assert_frame_equal(df, df_sel)
+
     def test_outcome_distributions_from_parquet(self, tmp_path):
         """outcome_distributions.csv uses parquet data when available."""
         parquet_path = FIXTURES_DIR / "action_value.parquet"


### PR DESCRIPTION
## Summary

- Add test for flat-schema branch (no `rank` column) in interpretability `run()` 
- Assert dual-write of `feature_importances.csv` + `selection_paths.csv` in step 6
- Add test for reversed-format finding without `:N` line number suffix
- Fix misleading "Pass 1.5" docstring reference to `_FINDING_LINE_RE`

## Why

Post-merge review of PR #846 identified 2 WARN-level coverage gaps and 2 INFO-level edge cases. This PR closes all 4 with test-only changes (no production code modifications).

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_interpretability.py tests/unit/test_rung_tables.py tests/unit/test_codex_plan_review_adapter.py -x -q
# 254 passed

make check-quiet
# All checks passed
```

## Tests

- Tier 1: `uv run python -m pytest tests/unit/test_interpretability.py tests/unit/test_rung_tables.py tests/unit/test_codex_plan_review_adapter.py -x -q` (254 passed)
- Tier 2: `make check-quiet` (all checks passed)

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-scratch
toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-scratch
```

## Findings addressed

| ID | Level | Description |
|----|-------|-------------|
| WARN-1 | WARN | Flat-schema `elif` branch untested in `run()` |
| WARN-2 | WARN | Step 6 dual-write (both CSVs) not asserted together |
| INFO-1 | INFO | Docstring "Pass 1.5" label is misleading |
| INFO-2 | INFO | No reversed-format test without line number |