### PR TITLE
fix: correct check_name column in report sanity rendering

### DIFF
--- a/src/bid_euchre/arc_d_v2/report.py
+++ b/src/bid_euchre/arc_d_v2/report.py
@@ -375,7 +375,7 @@ def generate_report(report_dir: Path) -> str:
         failures = sanity[sanity["status"].str.upper() == "FAIL"]
         if len(failures) > 0:
             for _, row in failures.iterrows():
-                check = row.get("check", "unknown")
+                check = row.get("check_name", "unknown")
                 notes.append(
                     f"- **Sanity: {check}** — failed. "
                     "This may be expected for small sample sizes or early rungs."
@@ -689,7 +689,7 @@ def generate_decision_report(
             lines.append(f"**{n_fail}/{n_total} sanity checks failed.**")
             lines.append("")
             for _, row in failures.iterrows():
-                check = row.get("check", "unknown")
+                check = row.get("check_name", "unknown")
                 lines.append(f"- {check}: FAIL")
             lines.append("")
             lines.append(

--- a/tests/unit/test_rung_report.py
+++ b/tests/unit/test_rung_report.py
@@ -415,7 +415,7 @@ class TestPreliminaryTriage:
         charts = tmp_path / "charts"
         charts.mkdir()
         (tables / "data_sanity.csv").write_text(
-            "check,status,detail\nbalance,PASS,ok\n"
+            "check_name,scope,value,threshold,status,detail\nbalance,overall,1.0,0.0,PASS,ok\n"
         )
 
         content = generate_decision_report(
@@ -444,3 +444,126 @@ class TestPreliminaryTriage:
         )
         assert "ADVANCE" in content
         assert "Rung R0" in content
+
+
+# ──────────────────────────────────────────────
+#  Data Quality / Sanity rendering tests
+# ──────────────────────────────────────────────
+
+
+class TestDataQualityNotes:
+    """Tests for Section 10 Data Quality Notes in generate_report()."""
+
+    @pytest.fixture
+    def base_report_dir(self, tmp_path):
+        """Minimal report directory with tables and charts dirs."""
+        report_dir = tmp_path / "report"
+        tables_dir = report_dir / "tables"
+        charts_dir = report_dir / "charts"
+        tables_dir.mkdir(parents=True, exist_ok=True)
+        charts_dir.mkdir(parents=True, exist_ok=True)
+        return report_dir
+
+    def test_section10_appears_with_sanity_failures(self, base_report_dir):
+        """Section 10 appears when sanity_bounds_check has FAIL rows."""
+        tables_dir = base_report_dir / "tables"
+        (tables_dir / "sanity_bounds_check.csv").write_text(
+            "model,check_name,value,lower_bound,upper_bound,status\n"
+            "gbt_av,bid_rate_range,0.02,0.05,0.95,FAIL\n"
+            "gbt_av,make_rate_range,0.50,0.10,1.00,PASS\n"
+        )
+        content = generate_report(base_report_dir)
+        assert "## 10. Data Quality Notes" in content
+
+    def test_section10_renders_check_name_not_unknown(self, base_report_dir):
+        """Sanity failure notes render the actual check_name, not 'unknown'."""
+        tables_dir = base_report_dir / "tables"
+        (tables_dir / "sanity_bounds_check.csv").write_text(
+            "model,check_name,value,lower_bound,upper_bound,status\n"
+            "gbt_av,bid_rate_range,0.02,0.05,0.95,FAIL\n"
+        )
+        content = generate_report(base_report_dir)
+        assert "bid_rate_range" in content
+        assert "unknown" not in content.split("## 10. Data Quality Notes")[1]
+
+    def test_section10_not_present_without_issues(self, base_report_dir):
+        """Section 10 is absent when there are no data quality issues."""
+        tables_dir = base_report_dir / "tables"
+        (tables_dir / "sanity_bounds_check.csv").write_text(
+            "model,check_name,value,lower_bound,upper_bound,status\n"
+            "gbt_av,bid_rate_range,0.50,0.05,0.95,PASS\n"
+        )
+        content = generate_report(base_report_dir)
+        assert "## 10. Data Quality Notes" not in content
+
+    def test_section10_with_degraded_distributions(self, base_report_dir):
+        """Section 10 appears when outcome distributions are degraded."""
+        chart_data_dir = base_report_dir / "chart_data"
+        chart_data_dir.mkdir(parents=True, exist_ok=True)
+        (chart_data_dir / "outcome_distributions.status").write_text(
+            "degraded: synthetic fallback"
+        )
+        content = generate_report(base_report_dir)
+        assert "## 10. Data Quality Notes" in content
+        assert "synthetic data" in content
+
+
+class TestDecisionReportDataSanity:
+    """Tests for the Data Sanity block in generate_decision_report()."""
+
+    @pytest.fixture
+    def charts_dir(self, tmp_path):
+        charts = tmp_path / "charts"
+        charts.mkdir(parents=True, exist_ok=True)
+        return charts
+
+    def test_data_sanity_renders_check_names(self, tmp_path, charts_dir):
+        """Data Sanity block renders actual check_name values, not 'unknown'."""
+        tables_dir = _make_hypothesis_outcomes(tmp_path, ["PASS", "PASS"])
+        _make_comparator_rankings(tables_dir)
+        _make_h2h_tier_summary(tables_dir)
+        (tables_dir / "data_sanity.csv").write_text(
+            "check_name,scope,value,threshold,status,detail\n"
+            "comparator_bidders_present,comparator,1,2,FAIL,only 1 bidder\n"
+            "h2h_min_deals,h2h,5,10,FAIL,min deals below threshold\n"
+        )
+        content = generate_decision_report(
+            tables_dir=tables_dir,
+            charts_dir=charts_dir,
+        )
+        assert "### Data Sanity" in content
+        assert "comparator_bidders_present" in content
+        assert "h2h_min_deals" in content
+        assert "unknown" not in content.split("### Data Sanity")[1].split("##")[0]
+
+    def test_data_sanity_shows_fail_count(self, tmp_path, charts_dir):
+        """Data Sanity block shows correct failure count."""
+        tables_dir = _make_hypothesis_outcomes(tmp_path, ["PASS", "PASS"])
+        _make_comparator_rankings(tables_dir)
+        _make_h2h_tier_summary(tables_dir)
+        (tables_dir / "data_sanity.csv").write_text(
+            "check_name,scope,value,threshold,status,detail\n"
+            "comparator_bidders_present,comparator,1,2,FAIL,only 1 bidder\n"
+            "h2h_min_deals,h2h,50,10,PASS,ok\n"
+        )
+        content = generate_decision_report(
+            tables_dir=tables_dir,
+            charts_dir=charts_dir,
+        )
+        assert "### Data Sanity" in content
+        assert "1/2 sanity checks failed" in content
+
+    def test_data_sanity_absent_when_all_pass(self, tmp_path, charts_dir):
+        """Data Sanity block is absent when all checks pass."""
+        tables_dir = _make_hypothesis_outcomes(tmp_path, ["PASS", "PASS"])
+        _make_comparator_rankings(tables_dir)
+        _make_h2h_tier_summary(tables_dir)
+        (tables_dir / "data_sanity.csv").write_text(
+            "check_name,scope,value,threshold,status,detail\n"
+            "h2h_min_deals,h2h,50,10,PASS,ok\n"
+        )
+        content = generate_decision_report(
+            tables_dir=tables_dir,
+            charts_dir=charts_dir,
+        )
+        assert "### Data Sanity" not in content


### PR DESCRIPTION
## Summary

- Fix `report.py` using wrong column name (`check` → `check_name`) when rendering sanity check failures in both `generate_report()` Section 10 and `generate_decision_report()` Data Sanity block
- Add 7 tests covering both code paths — previously untested
- Fix test fixture column names to match real CSV schemas

## Why

Post-merge review of PR #848 identified that `report.py` lines 378 and 692 both read `row.get("check", "unknown")` but `sanity_bounds_check.csv` and `data_sanity.csv` use column `check_name`. Every sanity failure rendered as "unknown" instead of the actual check name (e.g., `bid_rate_range`, `comparator_bidders_present`).

## Changes

| File | Change |
|------|--------|
| `src/bid_euchre/arc_d_v2/report.py` | `row.get("check", ...)` → `row.get("check_name", ...)` (2 locations) |
| `tests/unit/test_rung_report.py` | +7 tests: Section 10 rendering (4), Data Sanity block (3), fixture fix (1) |

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_rung_report.py -v --seed 42
# 34 passed (27 existing + 7 new)
```

Key new tests:
- `test_section10_renders_check_name_not_unknown` — asserts actual check name appears, "unknown" does not
- `test_data_sanity_renders_check_names` — same for decision report
- `test_data_sanity_shows_fail_count` — verifies "N/M sanity checks failed" text

## Tests

```
make check-quiet  # ✓ All checks passed
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: codex/steward-author-d
```

## Investigation Notes

The post-merge review also flagged R2 FULL `seed_sanity.csv` as "truncated" (header-only). Investigation confirmed this is **expected behavior** — an empty data section means zero seed-comparison warnings were detected (all checks passed). R0/R1 had outlier warnings; R2 did not. No action needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)