### PR TITLE
fix: populate seeds in evidence_manifest.json and canonical manifests

### DIFF
--- a/docs/04_reports/arc_d_v2/r0/canonical/00_manifest.md
+++ b/docs/04_reports/arc_d_v2/r0/canonical/00_manifest.md
@@ -4,7 +4,7 @@
 **Rung:** r0
 **Provenance SHA:** `13ba62ee796891736b44b4bd5be380ab6b971938`
 **Mode:** QUICK
-**Seeds:** []
+**Seeds:** [42, 123, 456]
 **Anchor:** anchor_hybrid_r0_full
 
 ## Model Roster

--- a/docs/04_reports/arc_d_v2/r0/canonical/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r0/canonical/evidence_manifest.json
@@ -56,7 +56,11 @@
       "status": "evaluated"
     }
   ],
-  "seeds": [],
+  "seeds": [
+    42,
+    123,
+    456
+  ],
   "mode": "QUICK",
   "run_ids": [],
   "lifecycle": [],

--- a/docs/04_reports/arc_d_v2/r0/full/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r0/full/evidence_manifest.json
@@ -56,7 +56,11 @@
       "status": "evaluated"
     }
   ],
-  "seeds": [],
+  "seeds": [
+    42,
+    123,
+    456
+  ],
   "mode": "full",
   "run_ids": [],
   "lifecycle": [],

--- a/docs/04_reports/arc_d_v2/r0/quick/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r0/quick/evidence_manifest.json
@@ -56,7 +56,11 @@
       "status": "evaluated"
     }
   ],
-  "seeds": [],
+  "seeds": [
+    42,
+    123,
+    456
+  ],
   "mode": "quick",
   "run_ids": [],
   "lifecycle": [],

--- a/docs/04_reports/arc_d_v2/r1/canonical/00_manifest.md
+++ b/docs/04_reports/arc_d_v2/r1/canonical/00_manifest.md
@@ -4,7 +4,7 @@
 **Rung:** r1
 **Provenance SHA:** `3ee7051e98ad6dfb9756dbe69ae903fe0150e982`
 **Mode:** QUICK
-**Seeds:** []
+**Seeds:** [42, 123, 456]
 **Anchor:** anchor_hybrid_r0_full
 
 ## Model Roster

--- a/docs/04_reports/arc_d_v2/r1/canonical/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r1/canonical/evidence_manifest.json
@@ -56,7 +56,11 @@
       "status": "evaluated"
     }
   ],
-  "seeds": [],
+  "seeds": [
+    42,
+    123,
+    456
+  ],
   "mode": "QUICK",
   "run_ids": [],
   "lifecycle": [],

--- a/docs/04_reports/arc_d_v2/r1/full/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r1/full/evidence_manifest.json
@@ -56,7 +56,11 @@
       "status": "evaluated"
     }
   ],
-  "seeds": [],
+  "seeds": [
+    42,
+    123,
+    456
+  ],
   "mode": "full",
   "run_ids": [],
   "lifecycle": [],

--- a/docs/04_reports/arc_d_v2/r1/quick/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r1/quick/evidence_manifest.json
@@ -56,7 +56,11 @@
       "status": "evaluated"
     }
   ],
-  "seeds": [],
+  "seeds": [
+    42,
+    123,
+    456
+  ],
   "mode": "quick",
   "run_ids": [],
   "lifecycle": [],

--- a/docs/04_reports/arc_d_v2/r2/canonical/00_manifest.md
+++ b/docs/04_reports/arc_d_v2/r2/canonical/00_manifest.md
@@ -4,7 +4,7 @@
 **Rung:** r2
 **Provenance SHA:** `3ee7051e98ad6dfb9756dbe69ae903fe0150e982`
 **Mode:** QUICK
-**Seeds:** []
+**Seeds:** [42]
 **Anchor:** anchor_hybrid_r0_full
 
 ## Model Roster

--- a/docs/04_reports/arc_d_v2/r2/canonical/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r2/canonical/evidence_manifest.json
@@ -56,7 +56,9 @@
       "status": "evaluated"
     }
   ],
-  "seeds": [],
+  "seeds": [
+    42
+  ],
   "mode": "QUICK",
   "run_ids": [],
   "lifecycle": [],

--- a/docs/04_reports/arc_d_v2/r2/full/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r2/full/evidence_manifest.json
@@ -56,7 +56,9 @@
       "status": "evaluated"
     }
   ],
-  "seeds": [],
+  "seeds": [
+    42
+  ],
   "mode": "full",
   "run_ids": [],
   "lifecycle": [],

--- a/docs/04_reports/arc_d_v2/r2/quick/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r2/quick/evidence_manifest.json
@@ -56,7 +56,9 @@
       "status": "evaluated"
     }
   ],
-  "seeds": [],
+  "seeds": [
+    42
+  ],
   "mode": "quick",
   "run_ids": [],
   "lifecycle": [],

--- a/docs/04_reports/arc_d_v2/r3/canonical/00_manifest.md
+++ b/docs/04_reports/arc_d_v2/r3/canonical/00_manifest.md
@@ -4,7 +4,7 @@
 **Rung:** r3
 **Provenance SHA:** `3d8f505e9a772daf9cb6ffd341a870a48a29aef5`
 **Mode:** QUICK
-**Seeds:** []
+**Seeds:** [42]
 **Anchor:** anchor_hybrid_r0_full
 
 ## Model Roster

--- a/docs/04_reports/arc_d_v2/r3/canonical/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r3/canonical/evidence_manifest.json
@@ -56,7 +56,9 @@
       "status": "evaluated"
     }
   ],
-  "seeds": [],
+  "seeds": [
+    42
+  ],
   "mode": "QUICK",
   "run_ids": [],
   "lifecycle": [],

--- a/docs/04_reports/arc_d_v2/r3/quick/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r3/quick/evidence_manifest.json
@@ -56,7 +56,9 @@
       "status": "evaluated"
     }
   ],
-  "seeds": [],
+  "seeds": [
+    42
+  ],
   "mode": "quick",
   "run_ids": [],
   "lifecycle": [],


### PR DESCRIPTION
## Summary
- Populate `seeds` field in all 11 `evidence_manifest.json` files (R0-R3, all modes)
- Populate `Seeds:` in all 4 canonical `00_manifest.md` files (R0-R3)
- Resolves JSON/markdown manifest inconsistency from #861

## Why
Post-merge review of #861 found two gaps:
1. **HIGH**: All `evidence_manifest.json` files still had `"seeds": []` — the machine-readable authoritative source was inconsistent with the corrected markdown
2. **MED**: Canonical bundle `00_manifest.md` files were not patched (only quick/full were)

## Finding Validation

| # | Finding | Verdict |
|---|---------|---------|
| 1 | `evidence_manifest.json` seeds empty | **Confirmed → Fixed** — all 11 JSON files patched |
| 2 | Canonical `00_manifest.md` seeds empty | **Confirmed → Fixed** — all 4 canonical MDs patched |
| 3 | Filename seed extraction fragility | **Acknowledged** — tech debt, no action (min-value guard) |
| 4 | #857 old-schema backward compat | **Dismissed** — low risk, all generators now use `check_name` |

Seed values: `[42, 123, 456]` for R0-R1, `[42]` for R2-R3.

## Repro / Validation
```bash
# Verify consistency
python3 -c "
import json; from pathlib import Path
base = Path('docs/04_reports/arc_d_v2')
for r in ['r0','r1','r2','r3']:
  for m in ['quick','full','canonical']:
    jp = base/r/m/'evidence_manifest.json'
    mp = base/r/m/'00_manifest.md'
    if jp.exists():
      js = json.loads(jp.read_text())['seeds']
      ms = [l for l in mp.read_text().splitlines() if 'Seeds:' in l][0] if mp.exists() else 'N/A'
      ok = '✅' if str(js) in str(ms) else '❌'
      print(f'{ok} {r}/{m}: JSON={js}, MD={ms}')
"
```

## Tests
- `make check-quiet` — all pass

## Worktree Proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/wt-fix-manifest-seeds
branch: fix/manifest-seeds-json-canonical
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)