### PR TITLE
fix: skip plutil test on non-macOS CI

### DIFF
--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -7,6 +7,7 @@ infrastructure without requiring tmux to be running.
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -244,6 +245,10 @@ class TestLaunchdTemplate:
     def test_plist_exists(self) -> None:
         assert PLIST_TEMPLATE.exists(), f"Missing: {PLIST_TEMPLATE}"
 
+    @pytest.mark.skipif(
+        shutil.which("plutil") is None,
+        reason="plutil is macOS-only; not available on Linux CI",
+    )
     def test_plist_valid_xml(self) -> None:
         result = subprocess.run(
             ["plutil", "-lint", str(PLIST_TEMPLATE)],


### PR DESCRIPTION
## Plan
N/A — one-line CI fix for pre-existing bug on main.

## Summary
- Add `skipif(shutil.which("plutil") is None)` guard to `test_plist_valid_xml`
- Add `import shutil` to support the guard

## Why
`plutil` is macOS-only but `test_plist_valid_xml` (introduced in #858) calls
it unconditionally. This breaks CI on all open PRs running on Linux runners.
The same guard pattern is already used by `test_dry_run_succeeds` in the same file.

Closes #868

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_steward_session.py -v  # 21 pass
make check-quiet  # all pass
```

## Tests
- 21 tests pass in `test_steward_session.py`
- `make check-quiet` passes

## Worktree proof
```
/Users/claude_runner/Projects/Bid-Euchre-meta/wt-plutil-skip
branch: fix/plutil-skip-ci
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)