### PR TITLE
fix: annotate stale doc references (repo review R18)

### DIFF
--- a/docs/01_core/schemas/hybrid_olsa_v1.md
+++ b/docs/01_core/schemas/hybrid_olsa_v1.md
@@ -90,7 +90,7 @@ When both arms are trained, a `rung_bundle_r{N}.json` packages them:
   },
   "split_manifest": "split_manifest_r0_suit.json",
   "training_report": "training_report_r0.json",
-  "progression_report": "docs/04_reports/arc_d_v2/r1/r0_to_r1_progression.md"
+  "progression_report": "docs/04_reports/arc_d_v2/r1/r0_to_r1_progression.md"  // [not yet generated]
 }
 ```
 

--- a/docs/04_reports/codex_validation/results_2026-03-08.md
+++ b/docs/04_reports/codex_validation/results_2026-03-08.md
@@ -4,7 +4,7 @@
 
 - **PR:** #574 (closed without merge)
 - **Date:** 2026-03-08
-- **Test fixture:** scripts/internal/codex_test_fixture.py (temporary fixture, existed only on closed test branch; now deleted)
+- **Test fixture:** scripts/internal/codex_test_fixture.py [deleted — temporary fixture, existed only on closed test branch]
 - **Seeded violations:** C1 (unseeded RNG x2), C2 (falsy guard), X3 (merge
   markers), X3 (commented-out block), import boundary, breakpoint()
 
@@ -25,9 +25,9 @@
 
 | Severity | File | Line | Check | Finding | Correct? |
 |----------|------|------|-------|---------|----------|
-| CRITICAL (P0) | scripts/internal/codex_test_fixture.py (deleted) | 34 | X3 | Merge conflict markers — invalid Python syntax | Yes |
-| CRITICAL (P1) | scripts/internal/codex_test_fixture.py (deleted) | 24 | C2 | Falsy numeric guard — `avg_tricks or 5.0` replaces valid 0.0 | Yes |
-| CRITICAL (P1) | scripts/internal/codex_test_fixture.py (deleted) | 17 | C1 | Unseeded `random.Random()` — non-deterministic | Yes |
+| CRITICAL (P0) | scripts/internal/codex_test_fixture.py [deleted] | 34 | X3 | Merge conflict markers — invalid Python syntax | Yes |
+| CRITICAL (P1) | scripts/internal/codex_test_fixture.py [deleted] | 24 | C2 | Falsy numeric guard — `avg_tricks or 5.0` replaces valid 0.0 | Yes |
+| CRITICAL (P1) | scripts/internal/codex_test_fixture.py [deleted] | 17 | C1 | Unseeded `random.Random()` — non-deterministic | Yes |
 
 ### Missed Violations
 
@@ -64,7 +64,7 @@ are handled by repo-lint and ruff.
 
 - **PR:** #579 (closed without merge)
 - **Date:** 2026-03-08
-- **Test fixture:** scripts/internal/codex_v2_test_fixture.py (temporary fixture, existed only on closed test branch; now deleted)
+- **Test fixture:** scripts/internal/codex_v2_test_fixture.py [deleted — temporary fixture, existed only on closed test branch]
 - **Seeded violations:** breakpoint(), redundant else after return, `== None`, `== True`
 
 ### Response Metadata

--- a/docs/04_reports/codex_validation/results_2026-03-09_e2e.md
+++ b/docs/04_reports/codex_validation/results_2026-03-09_e2e.md
@@ -12,7 +12,7 @@ state transition → artifact persistence.
 - **PR:** #593 (closed without merge)
 - **Branch:** `e2e-validation-seeded-bugs`
 - **Date:** 2026-03-09
-- **Test file:** src/bid_euchre/validation/e2e_test_seeded_bugs.py (temporary fixture, existed only on closed test branch; now deleted)
+- **Test file:** src/bid_euchre/validation/e2e_test_seeded_bugs.py [deleted — temporary fixture, existed only on closed test branch]
 - **Driver invocation:** `review_driver.py --pr 593 --trigger pr_created`
 
 ### Seeded Violations


### PR DESCRIPTION
## Plan
N/A — repo review R18 cleanup

## Summary
- Annotate 3 stale path references in active docs with `[deleted]` / `[not yet generated]` markers
- R18-2 (orphan `src/bid_euchre/utils/`) contains only untracked `__pycache__` — no git-tracked files to remove; physical directory cleanup is outside git scope

## Why
Addresses R18-2 and R18-5 from repo review 2026-03-18. Stale path references
in active documentation can mislead readers into looking for files that no longer
exist or were never generated.

## Repro / Validation
**Command(s) run:**
- `make check-quiet` — all checks passed

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `make check-quiet` passes (docs-only change, no code affected)

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-cleanup-r18
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-cleanup-r18
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         750c1d1 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-cleanup-r18             7a19b0f [codex/cleanup-r18]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)