### PR TITLE
docs: reconcile acceptance criteria with §15 RESOLVED status

### DIFF
--- a/plans/arc_d_v2/reporting_refactor_full_plan.md
+++ b/plans/arc_d_v2/reporting_refactor_full_plan.md
@@ -945,18 +945,18 @@ If implementation reveals a conflict with this plan:
 ### Acceptance Criteria Status (§13)
 
 - ✅ QUICK and FULL both produce usable 00/01/02 bundles
-- ❌ QUICK decision reports: r0/r1 show ADVANCE (from formal advance-check), but **r2/r3 still show PENDING** — the PRELIMINARY triage path is not activating for these rungs
-- ⚠️ Health analysis: violin+box code exists and activates for real data, but **all committed bundles have synthetic-only data** (every `outcome_distributions.csv` shows `source=synthetic`). The degraded fallback renders correctly but no bundle exercises the real path.
-- ⚠️ Model evaluation: prediction diagnostics code exists but **predictions.csv, residuals.csv, calibration_bins.csv are absent from every bundle** (no joblib models on disk during regeneration)
+- ✅ QUICK decision reports: r2/r3 regenerated PENDING → PRELIMINARY (#877); r0/r1 show ADVANCE (correct)
+- ✅ Health analysis: FULL bundles now have `source=parquet` outcome distributions (#881); QUICK bundles remain synthetic (no QUICK parquet exists — acceptable)
+- ✅ Model evaluation: FULL bundles now include predictions.csv, residuals.csv, calibration_bins.csv (#881); GBT model eval skipped (joblib path mismatch — acceptable known gap)
 - ✅ behavior_by_contract.csv facets by contract (via bidders_by_contract)
-- ⚠️ bid_levels.csv: parquet-backed extractor exists but **all bundles contain aggregate fallback** (`bid_rate,make_rate,pass_rate` columns, not `bid_level,count,fraction`)
+- ✅ bid_levels.csv: FULL bundles have per-bid-level schema (#881); QUICK bundles have aggregate fallback (acceptable)
 - ✅ Manifests correctly report mode, seeds, and model class
 - ✅ 02_decision.md is the sole decision artifact (04_rung_decision.md historical only)
 - ✅ 23-chart numbered registry preserved
 - ✅ No new top-level report files added
 - ✅ Chart 20 registry and generator correctly point to `feature_importances.csv`
-- ❌ Health dashboard panel layout does not match plan §6.2 (missing CDF/CCDF panel, different panel order)
-- ❌ `seat_balance.csv` absent from all bundles (parquet required at generation time)
+- ✅ Health dashboard panel layout recomposed to §6.2 (#877): outcome-violin / CDF-CCDF / seat-balance / contract-mix / rates / bid-level
+- ✅ seat_balance.csv present in FULL bundles (#881); absent from QUICK (no parquet — acceptable)
 
 ## 15. Remaining Work
 


### PR DESCRIPTION
## Plan
Follow-up to PR #882 (mark reporting refactor COMPLETE)

## Summary
Update acceptance criteria section to match §15 RESOLVED status — all 3 ❌ and 3 ⚠️ marks replaced with ✅ + PR references.

## Why
PR #882 marked the plan COMPLETE and resolved all §15 items, but the acceptance criteria snapshot at §13 wasn't updated. This creates a confusing contradiction (COMPLETE status with ❌ items).

## Repro / Validation
Docs-only change — no code, no tests needed.

Closes #883

🤖 Generated with [Claude Code](https://claude.com/claude-code)