### PR TITLE
fix: address 7 charting review findings (#877/#881 follow-up)

### DIFF
--- a/docs/04_reports/arc_d_v2/r0/canonical/tables/artifact_inventory.csv
+++ b/docs/04_reports/arc_d_v2/r0/canonical/tables/artifact_inventory.csv
@@ -1,7 +1,7 @@
 artifact_name,path,schema_version,model_class,git_sha
-constrained_ols_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r0/training_artifact_av.json,action_value_olsa_v1,ols,13ba62ee796891736b44b4bd5be380ab6b971938
-full_ols_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r0/training_artifact_av.json,action_value_olsa_v1,ols,13ba62ee796891736b44b4bd5be380ab6b971938
-gbt_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r0/training_artifact_av.json,action_value_gbt_v1,gbt,13ba62ee796891736b44b4bd5be380ab6b971938
-selected_ols_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r0/training_artifact_av.json,action_value_olsa_v1,ols,13ba62ee796891736b44b4bd5be380ab6b971938
-selected_two_stage_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r0/training_artifact_av.json,two_stage_action_value_v1,two-stage,13ba62ee796891736b44b4bd5be380ab6b971938
-roster,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r0/roster.json,roster_v1,,
+constrained_ols_av,data/artifacts/arc_d_v2/r0/training_artifact_av.json,action_value_olsa_v1,ols,13ba62ee796891736b44b4bd5be380ab6b971938
+full_ols_av,data/artifacts/arc_d_v2/r0/training_artifact_av.json,action_value_olsa_v1,ols,13ba62ee796891736b44b4bd5be380ab6b971938
+gbt_av,data/artifacts/arc_d_v2/r0/training_artifact_av.json,action_value_gbt_v1,gbt,13ba62ee796891736b44b4bd5be380ab6b971938
+selected_ols_av,data/artifacts/arc_d_v2/r0/training_artifact_av.json,action_value_olsa_v1,ols,13ba62ee796891736b44b4bd5be380ab6b971938
+selected_two_stage_av,data/artifacts/arc_d_v2/r0/training_artifact_av.json,two_stage_action_value_v1,two-stage,13ba62ee796891736b44b4bd5be380ab6b971938
+roster,data/artifacts/arc_d_v2/r0/roster.json,roster_v1,,

--- a/docs/04_reports/arc_d_v2/r0/full/00_manifest.md
+++ b/docs/04_reports/arc_d_v2/r0/full/00_manifest.md
@@ -76,15 +76,15 @@
 | 7 | H2H Heatmap | `full_chart_suite/h2h_heatmap.png` | 65,627 bytes | present |
 | 8 | H2H Ranking Scatter | `full_chart_suite/h2h_ranking_scatter.png` | 45,732 bytes | present |
 | 9 | Outcome Distributions | `full_chart_suite/outcome_distributions.png` | 75,476 bytes | present |
-| 10 | Seat Balance | `full_chart_suite/seat_balance.png` | - | absent |
+| 10 | Seat Balance | `full_chart_suite/seat_balance.png` | 24,493 bytes | present |
 | 11 | Contract Mix | `full_chart_suite/contract_mix_bars.png` | 27,378 bytes | present |
 | 12 | Bid and Make Rates | `full_chart_suite/bid_behavior_panel.png` | 40,149 bytes | present |
 | 13 | Bid Level Distribution | `full_chart_suite/bid_level_distribution.png` | 33,579 bytes | present |
 | 14 | R-squared by Contract | `full_chart_suite/r2_by_contract.png` | 35,910 bytes | present |
 | 15 | MAE by Contract | `full_chart_suite/mae_by_contract.png` | 34,173 bytes | present |
-| 16 | Predicted vs Actual | `full_chart_suite/pred_vs_actual.png` | - | absent |
-| 17 | Residual Distribution | `full_chart_suite/residual_distribution.png` | - | absent |
-| 18 | Calibration Curve | `full_chart_suite/calibration_curve.png` | - | absent |
+| 16 | Predicted vs Actual | `full_chart_suite/pred_vs_actual.png` | 79,478 bytes | present |
+| 17 | Residual Distribution | `full_chart_suite/residual_distribution.png` | 35,137 bytes | present |
+| 18 | Calibration Curve | `full_chart_suite/calibration_curve.png` | 45,733 bytes | present |
 | 19 | Selection Path | `full_chart_suite/selection_path.png` | 99,004 bytes | present |
 | 20 | Feature Importance | `full_chart_suite/feature_importance.png` | 103,181 bytes | present |
 | 21 | Decision Agreement | `full_chart_suite/decision_agreement.png` | - | absent |

--- a/docs/04_reports/arc_d_v2/r0/full/01_results.md
+++ b/docs/04_reports/arc_d_v2/r0/full/01_results.md
@@ -66,15 +66,15 @@ Generated from canonical CSV tables and chart PNGs.
 
 ### Chart 16. Predicted vs Actual
 
-*Chart not available — source data absent.*
+![Predicted vs Actual](charts/full_chart_suite/pred_vs_actual.png)
 
 ### Chart 17. Residual Distribution
 
-*Chart not available — source data absent.*
+![Residual Distribution](charts/full_chart_suite/residual_distribution.png)
 
 ### Chart 18. Calibration Curve
 
-*Chart not available — source data absent.*
+![Calibration Curve](charts/full_chart_suite/calibration_curve.png)
 
 ### Chart 20. Feature Importance
 
@@ -200,7 +200,7 @@ Generated from canonical CSV tables and chart PNGs.
 
 ## 10. Data Quality Notes
 
-- **Outcome distributions (Chart 9):** synthetic data — parquet-backed real distributions unavailable for this bundle
+- **Outcome distributions (Chart 9):** parquet-backed real distributions
 - **Sanity: bid_rate_range** — failed. This may be expected for small sample sizes or early rungs.
 - **Sanity: bid_rate_range** — failed. This may be expected for small sample sizes or early rungs.
 - **Sanity: bid_rate_range** — failed. This may be expected for small sample sizes or early rungs.

--- a/docs/04_reports/arc_d_v2/r0/full/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r0/full/evidence_manifest.json
@@ -320,8 +320,9 @@
       "name": "full_chart_suite/seat_balance.png",
       "title": "Seat Balance",
       "required": false,
-      "present": false,
-      "size_bytes": 0
+      "present": true,
+      "size_bytes": 24493,
+      "path": "docs/04_reports/arc_d_v2/r0/full/charts/full_chart_suite/seat_balance.png"
     },
     {
       "number": 11,
@@ -373,24 +374,27 @@
       "name": "full_chart_suite/pred_vs_actual.png",
       "title": "Predicted vs Actual",
       "required": false,
-      "present": false,
-      "size_bytes": 0
+      "present": true,
+      "size_bytes": 79478,
+      "path": "docs/04_reports/arc_d_v2/r0/full/charts/full_chart_suite/pred_vs_actual.png"
     },
     {
       "number": 17,
       "name": "full_chart_suite/residual_distribution.png",
       "title": "Residual Distribution",
       "required": false,
-      "present": false,
-      "size_bytes": 0
+      "present": true,
+      "size_bytes": 35137,
+      "path": "docs/04_reports/arc_d_v2/r0/full/charts/full_chart_suite/residual_distribution.png"
     },
     {
       "number": 18,
       "name": "full_chart_suite/calibration_curve.png",
       "title": "Calibration Curve",
       "required": false,
-      "present": false,
-      "size_bytes": 0
+      "present": true,
+      "size_bytes": 45733,
+      "path": "docs/04_reports/arc_d_v2/r0/full/charts/full_chart_suite/calibration_curve.png"
     },
     {
       "number": 19,

--- a/docs/04_reports/arc_d_v2/r0/full/tables/artifact_inventory.csv
+++ b/docs/04_reports/arc_d_v2/r0/full/tables/artifact_inventory.csv
@@ -1,7 +1,7 @@
 artifact_name,path,schema_version,model_class,git_sha
-constrained_ols_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r0/training_artifact_av.json,action_value_olsa_v1,ols,13ba62ee796891736b44b4bd5be380ab6b971938
-full_ols_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r0/training_artifact_av.json,action_value_olsa_v1,ols,13ba62ee796891736b44b4bd5be380ab6b971938
-gbt_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r0/training_artifact_av.json,action_value_gbt_v1,gbt,13ba62ee796891736b44b4bd5be380ab6b971938
-selected_ols_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r0/training_artifact_av.json,action_value_olsa_v1,ols,13ba62ee796891736b44b4bd5be380ab6b971938
-selected_two_stage_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r0/training_artifact_av.json,two_stage_action_value_v1,two-stage,13ba62ee796891736b44b4bd5be380ab6b971938
-roster,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r0/roster.json,roster_v1,,
+constrained_ols_av,data/artifacts/arc_d_v2/r0/training_artifact_av.json,action_value_olsa_v1,ols,13ba62ee796891736b44b4bd5be380ab6b971938
+full_ols_av,data/artifacts/arc_d_v2/r0/training_artifact_av.json,action_value_olsa_v1,ols,13ba62ee796891736b44b4bd5be380ab6b971938
+gbt_av,data/artifacts/arc_d_v2/r0/training_artifact_av.json,action_value_gbt_v1,gbt,13ba62ee796891736b44b4bd5be380ab6b971938
+selected_ols_av,data/artifacts/arc_d_v2/r0/training_artifact_av.json,action_value_olsa_v1,ols,13ba62ee796891736b44b4bd5be380ab6b971938
+selected_two_stage_av,data/artifacts/arc_d_v2/r0/training_artifact_av.json,two_stage_action_value_v1,two-stage,13ba62ee796891736b44b4bd5be380ab6b971938
+roster,data/artifacts/arc_d_v2/r0/roster.json,roster_v1,,

--- a/docs/04_reports/arc_d_v2/r1/canonical/tables/artifact_inventory.csv
+++ b/docs/04_reports/arc_d_v2/r1/canonical/tables/artifact_inventory.csv
@@ -1,7 +1,7 @@
 artifact_name,path,schema_version,model_class,git_sha
-constrained_ols_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r1/training_artifact_av.json,action_value_olsa_v1,ols,3ee7051e98ad6dfb9756dbe69ae903fe0150e982
-full_ols_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r1/training_artifact_av.json,action_value_olsa_v1,ols,3ee7051e98ad6dfb9756dbe69ae903fe0150e982
-gbt_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r1/training_artifact_av.json,action_value_gbt_v1,gbt,3ee7051e98ad6dfb9756dbe69ae903fe0150e982
-selected_ols_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r1/training_artifact_av.json,action_value_olsa_v1,ols,3ee7051e98ad6dfb9756dbe69ae903fe0150e982
-selected_two_stage_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r1/training_artifact_av.json,two_stage_action_value_v1,two-stage,3ee7051e98ad6dfb9756dbe69ae903fe0150e982
-roster,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r1/roster.json,roster_v1,,
+constrained_ols_av,data/artifacts/arc_d_v2/r1/training_artifact_av.json,action_value_olsa_v1,ols,3ee7051e98ad6dfb9756dbe69ae903fe0150e982
+full_ols_av,data/artifacts/arc_d_v2/r1/training_artifact_av.json,action_value_olsa_v1,ols,3ee7051e98ad6dfb9756dbe69ae903fe0150e982
+gbt_av,data/artifacts/arc_d_v2/r1/training_artifact_av.json,action_value_gbt_v1,gbt,3ee7051e98ad6dfb9756dbe69ae903fe0150e982
+selected_ols_av,data/artifacts/arc_d_v2/r1/training_artifact_av.json,action_value_olsa_v1,ols,3ee7051e98ad6dfb9756dbe69ae903fe0150e982
+selected_two_stage_av,data/artifacts/arc_d_v2/r1/training_artifact_av.json,two_stage_action_value_v1,two-stage,3ee7051e98ad6dfb9756dbe69ae903fe0150e982
+roster,data/artifacts/arc_d_v2/r1/roster.json,roster_v1,,

--- a/docs/04_reports/arc_d_v2/r1/full/00_manifest.md
+++ b/docs/04_reports/arc_d_v2/r1/full/00_manifest.md
@@ -76,15 +76,15 @@
 | 7 | H2H Heatmap | `full_chart_suite/h2h_heatmap.png` | 64,673 bytes | present |
 | 8 | H2H Ranking Scatter | `full_chart_suite/h2h_ranking_scatter.png` | 46,790 bytes | present |
 | 9 | Outcome Distributions | `full_chart_suite/outcome_distributions.png` | 77,952 bytes | present |
-| 10 | Seat Balance | `full_chart_suite/seat_balance.png` | - | absent |
+| 10 | Seat Balance | `full_chart_suite/seat_balance.png` | 24,493 bytes | present |
 | 11 | Contract Mix | `full_chart_suite/contract_mix_bars.png` | 27,378 bytes | present |
 | 12 | Bid and Make Rates | `full_chart_suite/bid_behavior_panel.png` | 40,159 bytes | present |
 | 13 | Bid Level Distribution | `full_chart_suite/bid_level_distribution.png` | 33,565 bytes | present |
 | 14 | R-squared by Contract | `full_chart_suite/r2_by_contract.png` | 35,934 bytes | present |
 | 15 | MAE by Contract | `full_chart_suite/mae_by_contract.png` | 36,745 bytes | present |
-| 16 | Predicted vs Actual | `full_chart_suite/pred_vs_actual.png` | - | absent |
-| 17 | Residual Distribution | `full_chart_suite/residual_distribution.png` | - | absent |
-| 18 | Calibration Curve | `full_chart_suite/calibration_curve.png` | - | absent |
+| 16 | Predicted vs Actual | `full_chart_suite/pred_vs_actual.png` | 67,882 bytes | present |
+| 17 | Residual Distribution | `full_chart_suite/residual_distribution.png` | 37,714 bytes | present |
+| 18 | Calibration Curve | `full_chart_suite/calibration_curve.png` | 54,536 bytes | present |
 | 19 | Selection Path | `full_chart_suite/selection_path.png` | 82,582 bytes | present |
 | 20 | Feature Importance | `full_chart_suite/feature_importance.png` | 104,763 bytes | present |
 | 21 | Decision Agreement | `full_chart_suite/decision_agreement.png` | - | absent |

--- a/docs/04_reports/arc_d_v2/r1/full/01_results.md
+++ b/docs/04_reports/arc_d_v2/r1/full/01_results.md
@@ -66,15 +66,15 @@ Generated from canonical CSV tables and chart PNGs.
 
 ### Chart 16. Predicted vs Actual
 
-*Chart not available — source data absent.*
+![Predicted vs Actual](charts/full_chart_suite/pred_vs_actual.png)
 
 ### Chart 17. Residual Distribution
 
-*Chart not available — source data absent.*
+![Residual Distribution](charts/full_chart_suite/residual_distribution.png)
 
 ### Chart 18. Calibration Curve
 
-*Chart not available — source data absent.*
+![Calibration Curve](charts/full_chart_suite/calibration_curve.png)
 
 ### Chart 20. Feature Importance
 
@@ -200,7 +200,7 @@ Generated from canonical CSV tables and chart PNGs.
 
 ## 10. Data Quality Notes
 
-- **Outcome distributions (Chart 9):** synthetic data — parquet-backed real distributions unavailable for this bundle
+- **Outcome distributions (Chart 9):** parquet-backed real distributions
 - **Sanity: bid_rate_range** — failed. This may be expected for small sample sizes or early rungs.
 - **Sanity: bid_rate_range** — failed. This may be expected for small sample sizes or early rungs.
 - **Sanity: bid_rate_range** — failed. This may be expected for small sample sizes or early rungs.

--- a/docs/04_reports/arc_d_v2/r1/full/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r1/full/evidence_manifest.json
@@ -320,8 +320,9 @@
       "name": "full_chart_suite/seat_balance.png",
       "title": "Seat Balance",
       "required": false,
-      "present": false,
-      "size_bytes": 0
+      "present": true,
+      "size_bytes": 24493,
+      "path": "docs/04_reports/arc_d_v2/r1/full/charts/full_chart_suite/seat_balance.png"
     },
     {
       "number": 11,
@@ -373,24 +374,27 @@
       "name": "full_chart_suite/pred_vs_actual.png",
       "title": "Predicted vs Actual",
       "required": false,
-      "present": false,
-      "size_bytes": 0
+      "present": true,
+      "size_bytes": 67882,
+      "path": "docs/04_reports/arc_d_v2/r1/full/charts/full_chart_suite/pred_vs_actual.png"
     },
     {
       "number": 17,
       "name": "full_chart_suite/residual_distribution.png",
       "title": "Residual Distribution",
       "required": false,
-      "present": false,
-      "size_bytes": 0
+      "present": true,
+      "size_bytes": 37714,
+      "path": "docs/04_reports/arc_d_v2/r1/full/charts/full_chart_suite/residual_distribution.png"
     },
     {
       "number": 18,
       "name": "full_chart_suite/calibration_curve.png",
       "title": "Calibration Curve",
       "required": false,
-      "present": false,
-      "size_bytes": 0
+      "present": true,
+      "size_bytes": 54536,
+      "path": "docs/04_reports/arc_d_v2/r1/full/charts/full_chart_suite/calibration_curve.png"
     },
     {
       "number": 19,

--- a/docs/04_reports/arc_d_v2/r1/full/tables/artifact_inventory.csv
+++ b/docs/04_reports/arc_d_v2/r1/full/tables/artifact_inventory.csv
@@ -1,7 +1,7 @@
 artifact_name,path,schema_version,model_class,git_sha
-constrained_ols_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r1/training_artifact_av.json,action_value_olsa_v1,ols,a6f403474cb96feab8c01fae7c58e56f3e0d87a5
-full_ols_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r1/training_artifact_av.json,action_value_olsa_v1,ols,8418ea5537c8c26e9cf4cac309e8ba4c21327fb5
-gbt_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r1/training_artifact_av.json,action_value_gbt_v1,gbt,8418ea5537c8c26e9cf4cac309e8ba4c21327fb5
-selected_ols_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r1/training_artifact_av.json,action_value_olsa_v1,ols,a6f403474cb96feab8c01fae7c58e56f3e0d87a5
-selected_two_stage_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r1/training_artifact_av.json,two_stage_action_value_v1,two-stage,13ba62ee796891736b44b4bd5be380ab6b971938
-roster,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r1/roster.json,roster_v1,,
+constrained_ols_av,data/artifacts/arc_d_v2/r1/training_artifact_av.json,action_value_olsa_v1,ols,a6f403474cb96feab8c01fae7c58e56f3e0d87a5
+full_ols_av,data/artifacts/arc_d_v2/r1/training_artifact_av.json,action_value_olsa_v1,ols,8418ea5537c8c26e9cf4cac309e8ba4c21327fb5
+gbt_av,data/artifacts/arc_d_v2/r1/training_artifact_av.json,action_value_gbt_v1,gbt,8418ea5537c8c26e9cf4cac309e8ba4c21327fb5
+selected_ols_av,data/artifacts/arc_d_v2/r1/training_artifact_av.json,action_value_olsa_v1,ols,a6f403474cb96feab8c01fae7c58e56f3e0d87a5
+selected_two_stage_av,data/artifacts/arc_d_v2/r1/training_artifact_av.json,two_stage_action_value_v1,two-stage,13ba62ee796891736b44b4bd5be380ab6b971938
+roster,data/artifacts/arc_d_v2/r1/roster.json,roster_v1,,

--- a/docs/04_reports/arc_d_v2/r2/canonical/tables/artifact_inventory.csv
+++ b/docs/04_reports/arc_d_v2/r2/canonical/tables/artifact_inventory.csv
@@ -1,7 +1,7 @@
 artifact_name,path,schema_version,model_class,git_sha
-constrained_ols_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r2/training_artifact_av.json,action_value_olsa_v1,ols,3ee7051e98ad6dfb9756dbe69ae903fe0150e982
-full_ols_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r2/training_artifact_av.json,action_value_olsa_v1,ols,3ee7051e98ad6dfb9756dbe69ae903fe0150e982
-gbt_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r2/training_artifact_av.json,action_value_gbt_v1,gbt,3ee7051e98ad6dfb9756dbe69ae903fe0150e982
-selected_ols_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r2/training_artifact_av.json,action_value_olsa_v1,ols,3ee7051e98ad6dfb9756dbe69ae903fe0150e982
-selected_two_stage_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r2/training_artifact_av.json,two_stage_action_value_v1,two-stage,3ee7051e98ad6dfb9756dbe69ae903fe0150e982
-roster,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r2/roster.json,roster_v1,,
+constrained_ols_av,data/artifacts/arc_d_v2/r2/training_artifact_av.json,action_value_olsa_v1,ols,3ee7051e98ad6dfb9756dbe69ae903fe0150e982
+full_ols_av,data/artifacts/arc_d_v2/r2/training_artifact_av.json,action_value_olsa_v1,ols,3ee7051e98ad6dfb9756dbe69ae903fe0150e982
+gbt_av,data/artifacts/arc_d_v2/r2/training_artifact_av.json,action_value_gbt_v1,gbt,3ee7051e98ad6dfb9756dbe69ae903fe0150e982
+selected_ols_av,data/artifacts/arc_d_v2/r2/training_artifact_av.json,action_value_olsa_v1,ols,3ee7051e98ad6dfb9756dbe69ae903fe0150e982
+selected_two_stage_av,data/artifacts/arc_d_v2/r2/training_artifact_av.json,two_stage_action_value_v1,two-stage,3ee7051e98ad6dfb9756dbe69ae903fe0150e982
+roster,data/artifacts/arc_d_v2/r2/roster.json,roster_v1,,

--- a/docs/04_reports/arc_d_v2/r2/full/00_manifest.md
+++ b/docs/04_reports/arc_d_v2/r2/full/00_manifest.md
@@ -68,15 +68,15 @@
 | 7 | H2H Heatmap | `full_chart_suite/h2h_heatmap.png` | 128,679 bytes | present |
 | 8 | H2H Ranking Scatter | `full_chart_suite/h2h_ranking_scatter.png` | 56,424 bytes | present |
 | 9 | Outcome Distributions | `full_chart_suite/outcome_distributions.png` | 89,050 bytes | present |
-| 10 | Seat Balance | `full_chart_suite/seat_balance.png` | - | absent |
+| 10 | Seat Balance | `full_chart_suite/seat_balance.png` | 24,493 bytes | present |
 | 11 | Contract Mix | `full_chart_suite/contract_mix_bars.png` | 38,410 bytes | present |
 | 12 | Bid and Make Rates | `full_chart_suite/bid_behavior_panel.png` | 49,477 bytes | present |
 | 13 | Bid Level Distribution | `full_chart_suite/bid_level_distribution.png` | 42,019 bytes | present |
 | 14 | R-squared by Contract | `full_chart_suite/r2_by_contract.png` | 35,891 bytes | present |
 | 15 | MAE by Contract | `full_chart_suite/mae_by_contract.png` | 36,660 bytes | present |
-| 16 | Predicted vs Actual | `full_chart_suite/pred_vs_actual.png` | - | absent |
-| 17 | Residual Distribution | `full_chart_suite/residual_distribution.png` | - | absent |
-| 18 | Calibration Curve | `full_chart_suite/calibration_curve.png` | - | absent |
+| 16 | Predicted vs Actual | `full_chart_suite/pred_vs_actual.png` | 67,896 bytes | present |
+| 17 | Residual Distribution | `full_chart_suite/residual_distribution.png` | 36,877 bytes | present |
+| 18 | Calibration Curve | `full_chart_suite/calibration_curve.png` | 51,404 bytes | present |
 | 19 | Selection Path | `full_chart_suite/selection_path.png` | 80,965 bytes | present |
 | 20 | Feature Importance | `full_chart_suite/feature_importance.png` | 104,763 bytes | present |
 | 21 | Decision Agreement | `full_chart_suite/decision_agreement.png` | - | absent |

--- a/docs/04_reports/arc_d_v2/r2/full/01_results.md
+++ b/docs/04_reports/arc_d_v2/r2/full/01_results.md
@@ -66,15 +66,15 @@ Generated from canonical CSV tables and chart PNGs.
 
 ### Chart 16. Predicted vs Actual
 
-*Chart not available — source data absent.*
+![Predicted vs Actual](charts/full_chart_suite/pred_vs_actual.png)
 
 ### Chart 17. Residual Distribution
 
-*Chart not available — source data absent.*
+![Residual Distribution](charts/full_chart_suite/residual_distribution.png)
 
 ### Chart 18. Calibration Curve
 
-*Chart not available — source data absent.*
+![Calibration Curve](charts/full_chart_suite/calibration_curve.png)
 
 ### Chart 20. Feature Importance
 
@@ -211,7 +211,7 @@ Generated from canonical CSV tables and chart PNGs.
 
 ## 10. Data Quality Notes
 
-- **Outcome distributions (Chart 9):** synthetic data — parquet-backed real distributions unavailable for this bundle
+- **Outcome distributions (Chart 9):** parquet-backed real distributions
 - **Sanity: bid_rate_range** — failed. This may be expected for small sample sizes or early rungs.
 - **Sanity: bid_rate_range** — failed. This may be expected for small sample sizes or early rungs.
 - **Sanity: bid_rate_range** — failed. This may be expected for small sample sizes or early rungs.

--- a/docs/04_reports/arc_d_v2/r2/full/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r2/full/evidence_manifest.json
@@ -278,8 +278,9 @@
       "name": "full_chart_suite/seat_balance.png",
       "title": "Seat Balance",
       "required": false,
-      "present": false,
-      "size_bytes": 0
+      "present": true,
+      "size_bytes": 24493,
+      "path": "docs/04_reports/arc_d_v2/r2/full/charts/full_chart_suite/seat_balance.png"
     },
     {
       "number": 11,
@@ -331,24 +332,27 @@
       "name": "full_chart_suite/pred_vs_actual.png",
       "title": "Predicted vs Actual",
       "required": false,
-      "present": false,
-      "size_bytes": 0
+      "present": true,
+      "size_bytes": 67896,
+      "path": "docs/04_reports/arc_d_v2/r2/full/charts/full_chart_suite/pred_vs_actual.png"
     },
     {
       "number": 17,
       "name": "full_chart_suite/residual_distribution.png",
       "title": "Residual Distribution",
       "required": false,
-      "present": false,
-      "size_bytes": 0
+      "present": true,
+      "size_bytes": 36877,
+      "path": "docs/04_reports/arc_d_v2/r2/full/charts/full_chart_suite/residual_distribution.png"
     },
     {
       "number": 18,
       "name": "full_chart_suite/calibration_curve.png",
       "title": "Calibration Curve",
       "required": false,
-      "present": false,
-      "size_bytes": 0
+      "present": true,
+      "size_bytes": 51404,
+      "path": "docs/04_reports/arc_d_v2/r2/full/charts/full_chart_suite/calibration_curve.png"
     },
     {
       "number": 19,

--- a/docs/04_reports/arc_d_v2/r2/full/tables/artifact_inventory.csv
+++ b/docs/04_reports/arc_d_v2/r2/full/tables/artifact_inventory.csv
@@ -1,7 +1,7 @@
 artifact_name,path,schema_version,model_class,git_sha
-constrained_ols_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r2/training_artifact_av.json,action_value_olsa_v1,ols,a6f403474cb96feab8c01fae7c58e56f3e0d87a5
-full_ols_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r2/training_artifact_av.json,action_value_olsa_v1,ols,a6f403474cb96feab8c01fae7c58e56f3e0d87a5
-gbt_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r2/training_artifact_av.json,action_value_gbt_v1,gbt,a6f403474cb96feab8c01fae7c58e56f3e0d87a5
-selected_ols_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r2/training_artifact_av.json,action_value_olsa_v1,ols,a6f403474cb96feab8c01fae7c58e56f3e0d87a5
-selected_two_stage_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r2/training_artifact_av.json,two_stage_action_value_v1,two-stage,a6f403474cb96feab8c01fae7c58e56f3e0d87a5
-roster,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r2/roster.json,roster_v1,,
+constrained_ols_av,data/artifacts/arc_d_v2/r2/training_artifact_av.json,action_value_olsa_v1,ols,a6f403474cb96feab8c01fae7c58e56f3e0d87a5
+full_ols_av,data/artifacts/arc_d_v2/r2/training_artifact_av.json,action_value_olsa_v1,ols,a6f403474cb96feab8c01fae7c58e56f3e0d87a5
+gbt_av,data/artifacts/arc_d_v2/r2/training_artifact_av.json,action_value_gbt_v1,gbt,a6f403474cb96feab8c01fae7c58e56f3e0d87a5
+selected_ols_av,data/artifacts/arc_d_v2/r2/training_artifact_av.json,action_value_olsa_v1,ols,a6f403474cb96feab8c01fae7c58e56f3e0d87a5
+selected_two_stage_av,data/artifacts/arc_d_v2/r2/training_artifact_av.json,two_stage_action_value_v1,two-stage,a6f403474cb96feab8c01fae7c58e56f3e0d87a5
+roster,data/artifacts/arc_d_v2/r2/roster.json,roster_v1,,

--- a/docs/04_reports/arc_d_v2/r3/canonical/tables/artifact_inventory.csv
+++ b/docs/04_reports/arc_d_v2/r3/canonical/tables/artifact_inventory.csv
@@ -1,7 +1,7 @@
 artifact_name,path,schema_version,model_class,git_sha
-constrained_ols_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r3/training_artifact_av.json,action_value_olsa_v1,ols,3d8f505e9a772daf9cb6ffd341a870a48a29aef5
-full_ols_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r3/training_artifact_av.json,action_value_olsa_v1,ols,3d8f505e9a772daf9cb6ffd341a870a48a29aef5
-gbt_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r3/training_artifact_av.json,action_value_gbt_v1,gbt,3d8f505e9a772daf9cb6ffd341a870a48a29aef5
-selected_ols_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r3/training_artifact_av.json,action_value_olsa_v1,ols,3d8f505e9a772daf9cb6ffd341a870a48a29aef5
-selected_two_stage_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r3/training_artifact_av.json,two_stage_action_value_v1,two-stage,3d8f505e9a772daf9cb6ffd341a870a48a29aef5
-roster,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/artifacts/arc_d_v2/r3/roster.json,roster_v1,,
+constrained_ols_av,data/artifacts/arc_d_v2/r3/training_artifact_av.json,action_value_olsa_v1,ols,3d8f505e9a772daf9cb6ffd341a870a48a29aef5
+full_ols_av,data/artifacts/arc_d_v2/r3/training_artifact_av.json,action_value_olsa_v1,ols,3d8f505e9a772daf9cb6ffd341a870a48a29aef5
+gbt_av,data/artifacts/arc_d_v2/r3/training_artifact_av.json,action_value_gbt_v1,gbt,3d8f505e9a772daf9cb6ffd341a870a48a29aef5
+selected_ols_av,data/artifacts/arc_d_v2/r3/training_artifact_av.json,action_value_olsa_v1,ols,3d8f505e9a772daf9cb6ffd341a870a48a29aef5
+selected_two_stage_av,data/artifacts/arc_d_v2/r3/training_artifact_av.json,two_stage_action_value_v1,two-stage,3d8f505e9a772daf9cb6ffd341a870a48a29aef5
+roster,data/artifacts/arc_d_v2/r3/roster.json,roster_v1,,

--- a/docs/04_reports/arc_d_v2/r3/full/tables/artifact_inventory.csv
+++ b/docs/04_reports/arc_d_v2/r3/full/tables/artifact_inventory.csv
@@ -1,5 +1,5 @@
 artifact_name,path,schema_version,model_class,git_sha
-full_ols_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author/data/artifacts/arc_d_v2/r3/training_artifact_av.json,action_value_olsa_v1,ols,1da8c0116c49a3fd70d31b233cebc17dd1aaee0a
-gbt_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author/data/artifacts/arc_d_v2/r3/training_artifact_av.json,action_value_gbt_v1,gbt,1da8c0116c49a3fd70d31b233cebc17dd1aaee0a
-selected_two_stage_av,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author/data/artifacts/arc_d_v2/r3/training_artifact_av.json,two_stage_action_value_v1,two-stage,1da8c0116c49a3fd70d31b233cebc17dd1aaee0a
-roster,/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author/data/artifacts/arc_d_v2/r3/roster.json,roster_v1,,
+full_ols_av,data/artifacts/arc_d_v2/r3/training_artifact_av.json,action_value_olsa_v1,ols,1da8c0116c49a3fd70d31b233cebc17dd1aaee0a
+gbt_av,data/artifacts/arc_d_v2/r3/training_artifact_av.json,action_value_gbt_v1,gbt,1da8c0116c49a3fd70d31b233cebc17dd1aaee0a
+selected_two_stage_av,data/artifacts/arc_d_v2/r3/training_artifact_av.json,two_stage_action_value_v1,two-stage,1da8c0116c49a3fd70d31b233cebc17dd1aaee0a
+roster,data/artifacts/arc_d_v2/r3/roster.json,roster_v1,,

--- a/plans/sessions/2026-03-18_charting-review-fixes.md
+++ b/plans/sessions/2026-03-18_charting-review-fixes.md
@@ -1,0 +1,171 @@
+# Charting Infrastructure Review Fixes
+
+**Date:** 2026-03-18
+**Source:** Post-merge review findings from PRs #877 and #881
+**Scope:** 2 code fixes + report bundle metadata/text corrections
+
+## Findings Triage
+
+| ID | Finding | Severity | Action |
+|----|---------|----------|--------|
+| F1 | CDF/CCDF tail panel not faceted by contract | P2 | Fix |
+| F2 | Missing pass_rate in health dashboard rate panel | P2 | Fix |
+| F3 | Charts 16-18 say "source data absent" but PNGs exist | P1 | Fix |
+| F4 | Chart 9 note says "synthetic data" but real data exists | P2 | Fix |
+| F5 | evidence_manifest.json marks charts 10/16/17/18 as absent | P1 | Fix |
+| F6 | 00_manifest.md marks charts as absent | P1 | Fix |
+| F7 | artifact_inventory.csv uses absolute paths | P1 | Fix |
+| F8 | R2/R3 quick 02_decision.md says "all checks passed" but FAILs exist | P2 | **False positive** |
+| F9 | Feature importances rank ordering for OLS models | P2 | **False positive** |
+
+### F8 False Positive Rationale
+
+The decision generator (report.py:559-566) reads `data_sanity.csv`, not
+`sanity_bounds_check.csv`. R2/R3 quick `data_sanity.csv` has zero FAIL rows (confirmed).
+The FAILs in `sanity_bounds_check.csv` are bid_rate_range checks for aggressive bidders,
+documented in Data Quality Notes in 01_results.md. The decision report text "all checks
+passed" is technically correct for its data source.
+
+**Follow-up (separate PR):** The generator could be improved to also check
+sanity_bounds_check.csv, but this is scope expansion beyond the review findings.
+
+### F9 False Positive Rationale
+
+The review claims rank 1 has the smallest importance value for OLS models. Investigation
+of `_extract_feature_importance()` (tables.py:1246-1293) shows:
+- **OLS models:** Uses forward-selection `step` number as rank, cumulative R² as importance
+- **GBT models:** Sorts by gini importance descending, rank 1 = highest
+
+For OLS, rank 1 = "first feature selected" = most impactful single feature. The cumulative
+R² naturally increases with each added feature. The rank IS correct. No fix needed.
+
+## PR Structure
+
+Single PR — all fixes address "charting infrastructure review findings" as one concept.
+Code fixes (F1, F2) improve the chart generator. Report fixes (F3-F7) correct stale
+metadata in committed bundles. Both are review follow-ups from the same PRs (#877, #881).
+
+**PR:** `fix/charting-review-findings`
+**Files:**
+- `scripts/internal/generate_rung_charts.py` (code: F1, F2)
+- `src/bid_euchre/arc_d_v2/tables.py` (code: F7 root cause)
+- `docs/04_reports/arc_d_v2/{r0,r1,r2}/full/` (report bundles: F3-F7)
+- `docs/04_reports/arc_d_v2/r3/canonical/tables/artifact_inventory.csv` (F7)
+
+## Implementation Plan
+
+### PR 1: Chart Generation Code Fixes
+
+#### Task 1A: Contract-faceted CDF/CCDF panel (F1)
+**File:** `scripts/internal/generate_rung_charts.py` lines 1683-1709
+**Current:** Pools all contracts into one CDF curve per model
+**Fix:** When `outcome_distributions.csv` has a `contract` column, generate
+separate CDF curves per contract (using color for model, linestyle for contract),
+or produce a 2×2 sub-panel. Simplest correct fix: filter by contract, add
+contract to legend label.
+
+**Approach:** If contract column exists, loop over contracts within each model,
+using linestyle variation. If no contract column, fall back to current behavior.
+
+#### Task 1B: Add pass_rate to rate panel (F2)
+**File:** `scripts/internal/generate_rung_charts.py` lines 1786-1800
+**Current:** Only plots bid_rate and make_rate as grouped bars
+**Fix:** Add a third bar group for pass_rate when available. Adjust bar width
+from 0.35 to 0.25, position three groups. Update title from "Bid / Make Rates"
+to "Bid / Pass / Make Rates".
+
+#### Task 1C: Targeted tests
+Run chart generation tests to verify no regressions.
+
+### PR 2: Report Bundle Corrections
+
+#### Dependency graph
+```
+F7 (artifact_inventory paths) ──┐
+F3 (charts 16-18 text)       ──┤
+F4 (Chart 9 synthetic note)  ──┼── All independent, parallelizable per rung
+F5 (evidence_manifest.json)  ──┤
+F6 (00_manifest.md)           ──┤
+F8 (decision sanity claims)  ──┘
+```
+
+All fixes are independent text/data edits. No ordering constraint.
+Can batch all rung edits per finding type.
+
+#### Task 2A: Fix artifact_inventory.csv absolute paths (F7)
+**Files (4):**
+- `docs/04_reports/arc_d_v2/r0/full/tables/artifact_inventory.csv`
+- `docs/04_reports/arc_d_v2/r1/full/tables/artifact_inventory.csv`
+- `docs/04_reports/arc_d_v2/r2/full/tables/artifact_inventory.csv`
+- `docs/04_reports/arc_d_v2/r3/canonical/tables/artifact_inventory.csv`
+
+**Fix:** Replace `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/` with
+`data/` (repo-relative paths). R3 quick already has correct paths (confirmed).
+
+**Also fix generator:** `tables.py:generate_artifact_inventory()` — convert
+`rung_dir` to repo-relative path before embedding. Use `Path.relative_to()` or
+strip the repo root prefix.
+
+#### Task 2B: Fix Charts 16-18 "source data absent" text (F3)
+**Files (3):** `docs/04_reports/arc_d_v2/{r0,r1,r2}/full/01_results.md`
+**Fix:** Replace placeholder text with image references:
+- Chart 16: `![Predicted vs Actual](charts/full_chart_suite/pred_vs_actual.png)`
+- Chart 17: `![Residual Distribution](charts/full_chart_suite/residual_distribution.png)`
+- Chart 18: `![Calibration Curve](charts/full_chart_suite/calibration_curve.png)`
+
+PNGs confirmed to exist in all three rung bundles.
+
+#### Task 2C: Fix Chart 10 (Seat Balance) text (part of F3/F6)
+**Check:** Does `seat_balance.png` exist in R0/R1/R2 full bundles? Confirmed yes.
+**Fix:** If `seat_balance.png` exists in R0/R1/R2, update 01_results.md and
+manifests accordingly. (If no text placeholder exists for Chart 10, only manifest
+fixes needed.)
+
+#### Task 2D: Fix Chart 9 synthetic data note (F4)
+**Files (3):** `docs/04_reports/arc_d_v2/{r0,r1,r2}/full/01_results.md`
+**Fix:** In Section 10 "Data Quality Notes", replace:
+```
+- **Outcome distributions (Chart 9):** synthetic data — parquet-backed real distributions unavailable for this bundle
+```
+With:
+```
+- **Outcome distributions (Chart 9):** parquet-backed real distributions
+```
+
+#### Task 2E: Fix evidence_manifest.json (F5)
+**Files (3):** `docs/04_reports/arc_d_v2/{r0,r1,r2}/full/evidence_manifest.json`
+**Fix:** For charts 10, 16, 17, 18 — set `"present": true`, add actual
+`"size_bytes"` and `"path"` values by checking the actual PNG files.
+
+#### Task 2F: Fix 00_manifest.md (F6)
+**Files (3):** `docs/04_reports/arc_d_v2/{r0,r1,r2}/full/00_manifest.md`
+**Fix:** Change chart entries from `absent` to `present` with correct file paths.
+
+#### Task 2G: Fix artifact_inventory generator (F7 root cause)
+**File:** `src/bid_euchre/arc_d_v2/tables.py` lines 726-764
+**Fix:** Make `rung_dir` paths repo-relative before embedding in CSV.
+Detect repo root (find `.git` directory ancestor) and use `Path.relative_to()`.
+
+## Execution Order
+
+```
+Code fixes (independent):       Report bundle fixes (independent):
+  1A (CDF faceting) ──┐           2A (inventory paths) ──┐
+  1B (pass_rate)    ──┤           2B (charts 16-18)    ──┤
+  2G (generator)    ──┘           2C (chart 10)        ──┼── all parallel
+                                  2D (chart 9 note)    ──┤
+                                  2E (manifest json)   ──┤
+                                  2F (manifest md)     ──┘
+```
+
+All tasks are independent — no ordering constraint between any of them.
+
+## Validation
+
+- `uv run python -m pytest tests/ -k "chart" --no-header -q` (chart-related tests)
+- `make check-quiet` (full validation)
+- `grep -r '/Users/' docs/04_reports/` (verify no absolute paths remain)
+
+## Outcome
+
+_To be filled after implementation._

--- a/scripts/internal/generate_rung_charts.py
+++ b/scripts/internal/generate_rung_charts.py
@@ -1680,30 +1680,46 @@ def generate_dashboard_health(
     else:
         _unavailable_panel(ax, "Outcome Distributions")
 
-    # ── Panel 2: CDF / CCDF tail panel ──
+    # ── Panel 2: CDF / CCDF tail panel (contract-faceted when available) ──
     ax = axes[0, 1]
     if _is_real:
         models = sorted(dist_df["model"].unique())
         model_colors = _get_model_colors(models)
+        has_contracts = "contract" in dist_df.columns
+        contracts = sorted(dist_df["contract"].unique()) if has_contracts else [None]
+        contract_styles = {
+            "suit": "-",
+            "high": "--",
+            "low": ":",
+        }
         for model in models:
-            mdf = dist_df[dist_df["model"] == model]
-            expanded: list[int] = []
-            for _, row in mdf.iterrows():
-                expanded.extend([int(row["tricks_won"])] * int(row["count"]))
-            if expanded:
-                sorted_vals = np.sort(expanded)
-                cdf_y = np.arange(1, len(sorted_vals) + 1) / len(sorted_vals)
-                ax.plot(
-                    sorted_vals,
-                    cdf_y,
-                    label=model,
-                    color=model_colors[model],
-                    linewidth=1.2,
-                )
+            for contract in contracts:
+                if contract is not None:
+                    mdf = dist_df[
+                        (dist_df["model"] == model) & (dist_df["contract"] == contract)
+                    ]
+                else:
+                    mdf = dist_df[dist_df["model"] == model]
+                expanded: list[int] = []
+                for _, row in mdf.iterrows():
+                    expanded.extend([int(row["tricks_won"])] * int(row["count"]))
+                if expanded:
+                    sorted_vals = np.sort(expanded)
+                    cdf_y = np.arange(1, len(sorted_vals) + 1) / len(sorted_vals)
+                    label = f"{model} ({contract})" if contract is not None else model
+                    linestyle = contract_styles.get(str(contract), "-")
+                    ax.plot(
+                        sorted_vals,
+                        cdf_y,
+                        label=label,
+                        color=model_colors[model],
+                        linestyle=linestyle,
+                        linewidth=1.2,
+                    )
         ax.set_xlabel("Tricks Won", fontsize=9)
         ax.set_ylabel("Cumulative Probability", fontsize=9)
         ax.set_title("CDF — Outcome Distribution", fontsize=11)
-        ax.legend(fontsize=7, loc="best")
+        ax.legend(fontsize=6, loc="best", ncol=2 if has_contracts else 1)
         ax.grid(True, alpha=0.3)
     else:
         _unavailable_panel(ax, "CDF / CCDF (requires row-level data)")
@@ -1783,23 +1799,36 @@ def generate_dashboard_health(
             comp = behavior_df
         models = comp["model"].tolist()
         x = np.arange(len(models))
-        width = 0.35
+        has_pass = "pass_rate" in comp.columns
+        width = 0.25 if has_pass else 0.35
         bid_rates = comp["bid_rate"].values
+        pass_rates = comp["pass_rate"].values if has_pass else None
         make_rates = (
             comp["make_rate"].values
             if "make_rate" in comp.columns
             else np.zeros(len(models))
         )
-        ax.bar(x - width / 2, bid_rates, width, label="Bid Rate", color="#4C72B0")
-        ax.bar(x + width / 2, make_rates, width, label="Make Rate", color="#55A868")
+        if has_pass:
+            ax.bar(x - width, bid_rates, width, label="Bid Rate", color="#4C72B0")
+            ax.bar(x, pass_rates, width, label="Pass Rate", color="#DD8452")
+            ax.bar(x + width, make_rates, width, label="Make Rate", color="#55A868")
+        else:
+            ax.bar(x - width / 2, bid_rates, width, label="Bid Rate", color="#4C72B0")
+            ax.bar(x + width / 2, make_rates, width, label="Make Rate", color="#55A868")
         ax.set_xticks(x)
         ax.set_xticklabels(models, rotation=45, ha="right", fontsize=7)
         ax.set_ylabel("Rate", fontsize=9)
-        ax.set_title("Bid / Make Rates", fontsize=11)
+        ax.set_title(
+            "Bid / Pass / Make Rates" if has_pass else "Bid / Make Rates",
+            fontsize=11,
+        )
         ax.legend(fontsize=8)
-        ax.set_ylim(0, max(1.05, max(bid_rates.max(), make_rates.max()) * 1.05))
+        all_rates = [bid_rates.max(), make_rates.max()]
+        if pass_rates is not None:
+            all_rates.append(pass_rates.max())
+        ax.set_ylim(0, max(1.05, max(all_rates) * 1.05))
     else:
-        _unavailable_panel(ax, "Bid / Make Rates")
+        _unavailable_panel(ax, "Bid / Pass / Make Rates")
 
     # ── Panel 6: Bid-level distribution ──
     ax = axes[2, 1]

--- a/src/bid_euchre/arc_d_v2/tables.py
+++ b/src/bid_euchre/arc_d_v2/tables.py
@@ -723,6 +723,20 @@ def generate_dataset_provenance(
     return pd.DataFrame(rows)
 
 
+def _make_repo_relative(path: Path) -> str:
+    """Convert an absolute path to repo-relative by stripping up to ``data/``.
+
+    Looks for ``/data/`` in the path string and returns from ``data/`` onward.
+    Falls back to the path basename if ``/data/`` is not found.
+    """
+    s = str(path)
+    marker = "/data/"
+    idx = s.find(marker)
+    if idx >= 0:
+        return s[idx + 1 :]  # Strip leading slash, keep "data/..."
+    return s
+
+
 def generate_artifact_inventory(
     training_artifacts: dict[str, dict] | None = None,
     roster: dict | None = None,
@@ -731,19 +745,22 @@ def generate_artifact_inventory(
     """Generate artifact_inventory.csv -- artifact paths and versions.
 
     Columns: artifact_name, path, schema_version, model_class, git_sha
+
+    Paths are repo-relative (e.g. ``data/artifacts/arc_d_v2/r0/...``).
     """
     rows = []
     if training_artifacts:
         for model_name, artifact in training_artifacts.items():
             meta = artifact.get("metadata", {})
+            raw_path = (
+                rung_dir / f"training_artifact_{model_name.split('_')[-1]}.json"
+                if rung_dir
+                else None
+            )
             rows.append(
                 {
                     "artifact_name": model_name,
-                    "path": str(
-                        rung_dir / f"training_artifact_{model_name.split('_')[-1]}.json"
-                    )
-                    if rung_dir
-                    else "",
+                    "path": _make_repo_relative(raw_path) if raw_path else "",
                     "schema_version": artifact.get("schema_version", ""),
                     "model_class": meta.get("model_class", ""),
                     "git_sha": meta.get("git_sha", ""),
@@ -751,10 +768,11 @@ def generate_artifact_inventory(
             )
 
     if roster:
+        raw_path = rung_dir / "roster.json" if rung_dir else None
         rows.append(
             {
                 "artifact_name": "roster",
-                "path": str(rung_dir / "roster.json") if rung_dir else "",
+                "path": _make_repo_relative(raw_path) if raw_path else "",
                 "schema_version": roster.get("schema_version", ""),
                 "model_class": "",
                 "git_sha": "",

--- a/tests/unit/test_rung_charts.py
+++ b/tests/unit/test_rung_charts.py
@@ -1455,3 +1455,143 @@ class TestDashboardHealthPanel3Paths:
         )
         assert result is True
         assert (charts_dir / "dashboard_health.png").exists()
+
+
+# ──────────────────────────────────────────────
+#  CDF/CCDF tail panel contract faceting (F1)
+# ──────────────────────────────────────────────
+
+
+class TestCdfContractFaceting:
+    """Tests that CDF panel facets by contract when data has contract column."""
+
+    def test_cdf_with_contract_column(self, charts_mod, tmp_path):
+        """Health dashboard CDF panel handles per-contract distribution data."""
+        tables_dir = tmp_path / "tables"
+        tables_dir.mkdir()
+        charts_dir = tmp_path / "charts"
+        charts_dir.mkdir()
+        chart_data_dir = tmp_path / "chart_data"
+        chart_data_dir.mkdir()
+
+        # behavior_summary.csv (minimal)
+        pd.DataFrame(
+            {
+                "model": ["gbt", "ols"],
+                "bid_rate": [0.6, 0.5],
+                "make_rate": [0.7, 0.6],
+            }
+        ).to_csv(tables_dir / "behavior_summary.csv", index=False)
+
+        # outcome_distributions.csv WITH contract column
+        rows = []
+        for model in ["gbt", "ols"]:
+            for contract in ["suit", "high", "low"]:
+                for tricks in range(0, 11):
+                    rows.append(
+                        {
+                            "model": model,
+                            "contract": contract,
+                            "tricks_won": tricks,
+                            "count": max(1, 10 - abs(tricks - 5)),
+                            "fraction": 0.1,
+                            "source": "parquet",
+                        }
+                    )
+        pd.DataFrame(rows).to_csv(
+            chart_data_dir / "outcome_distributions.csv", index=False
+        )
+
+        result = charts_mod.generate_dashboard_health(
+            tables_dir, charts_dir, chart_data_dir
+        )
+        assert result is True
+        assert (charts_dir / "dashboard_health.png").exists()
+
+    def test_cdf_without_contract_column(self, charts_mod, tmp_path):
+        """Health dashboard CDF panel falls back when no contract column."""
+        tables_dir = tmp_path / "tables"
+        tables_dir.mkdir()
+        charts_dir = tmp_path / "charts"
+        charts_dir.mkdir()
+        chart_data_dir = tmp_path / "chart_data"
+        chart_data_dir.mkdir()
+
+        pd.DataFrame(
+            {
+                "model": ["gbt", "ols"],
+                "bid_rate": [0.6, 0.5],
+                "make_rate": [0.7, 0.6],
+            }
+        ).to_csv(tables_dir / "behavior_summary.csv", index=False)
+
+        # outcome_distributions.csv WITHOUT contract column
+        rows = []
+        for model in ["gbt", "ols"]:
+            for tricks in range(0, 11):
+                rows.append(
+                    {
+                        "model": model,
+                        "tricks_won": tricks,
+                        "count": max(1, 10 - abs(tricks - 5)),
+                        "fraction": 0.1,
+                        "source": "parquet",
+                    }
+                )
+        pd.DataFrame(rows).to_csv(
+            chart_data_dir / "outcome_distributions.csv", index=False
+        )
+
+        result = charts_mod.generate_dashboard_health(
+            tables_dir, charts_dir, chart_data_dir
+        )
+        assert result is True
+        assert (charts_dir / "dashboard_health.png").exists()
+
+
+# ──────────────────────────────────────────────
+#  Pass rate in health dashboard rate panel (F2)
+# ──────────────────────────────────────────────
+
+
+class TestPassRateInRatePanel:
+    """Tests that rate panel includes pass_rate when available."""
+
+    def test_rate_panel_with_pass_rate(self, charts_mod, tmp_path):
+        """Health dashboard rate panel renders 3 bar groups with pass_rate."""
+        tables_dir = tmp_path / "tables"
+        tables_dir.mkdir()
+        charts_dir = tmp_path / "charts"
+        charts_dir.mkdir()
+
+        pd.DataFrame(
+            {
+                "model": ["gbt", "ols"],
+                "bid_rate": [0.65, 0.55],
+                "pass_rate": [0.35, 0.45],
+                "make_rate": [0.72, 0.61],
+            }
+        ).to_csv(tables_dir / "behavior_summary.csv", index=False)
+
+        result = charts_mod.generate_dashboard_health(tables_dir, charts_dir)
+        assert result is True
+        assert (charts_dir / "dashboard_health.png").exists()
+
+    def test_rate_panel_without_pass_rate(self, charts_mod, tmp_path):
+        """Health dashboard rate panel renders 2 bar groups without pass_rate."""
+        tables_dir = tmp_path / "tables"
+        tables_dir.mkdir()
+        charts_dir = tmp_path / "charts"
+        charts_dir.mkdir()
+
+        pd.DataFrame(
+            {
+                "model": ["gbt", "ols"],
+                "bid_rate": [0.65, 0.55],
+                "make_rate": [0.72, 0.61],
+            }
+        ).to_csv(tables_dir / "behavior_summary.csv", index=False)
+
+        result = charts_mod.generate_dashboard_health(tables_dir, charts_dir)
+        assert result is True
+        assert (charts_dir / "dashboard_health.png").exists()


### PR DESCRIPTION
## Summary

- **CDF/CCDF tail panel:** facet by contract type using linestyle variation (suit=solid, high=dashed, low=dotted)
- **Health dashboard rate panel:** add pass_rate as third bar group when available in behavior_summary.csv
- **Artifact inventory generator:** emit repo-relative `data/...` paths instead of absolute `/Users/...` paths
- **Report bundles (R0–R2 full, R0–R3 canonical):** correct stale metadata — chart presence flags, provenance notes, file sizes

## Why

Post-merge review findings from PRs #877 and #881 identified 9 issues. Investigation
confirmed 7 are real fixes and 2 are false positives:
- **F8 (false positive):** Decision report "all checks passed" refers to `data_sanity.csv`
  (no FAILs), not `sanity_bounds_check.csv` (has bid_rate_range FAILs for aggressive bidders)
- **F9 (false positive):** OLS feature importance rank ordering is correct — rank 1 = first
  forward-selected feature with cumulative R², ascending values are expected

## Repro / Validation

```bash
make check-quiet                    # Full validation
uv run python -m pytest tests/unit/test_rung_charts.py -k "CdfContract or PassRate" -v
grep -r '/Users/' docs/04_reports/arc_d_v2/*/full/tables/artifact_inventory.csv   # Should find no matches
grep -r '/Users/' docs/04_reports/arc_d_v2/*/canonical/tables/artifact_inventory.csv  # Should find no matches
```

## Tests

- `make check-quiet` — all pass
- `TestCdfContractFaceting` — 2 tests (with/without contract column)
- `TestPassRateInRatePanel` — 2 tests (with/without pass_rate)
- 212 chart-related tests pass, 0 failures

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: codex/steward-author-d
```

## Files changed (21)

**Code (3):**
- `scripts/internal/generate_rung_charts.py` — CDF faceting + pass_rate panel
- `src/bid_euchre/arc_d_v2/tables.py` — repo-relative path helper
- `tests/unit/test_rung_charts.py` — 4 new regression tests

**Report bundles (17):**
- `docs/04_reports/arc_d_v2/{r0,r1,r2}/full/{01_results.md, 00_manifest.md, evidence_manifest.json}` — chart presence + provenance
- `docs/04_reports/arc_d_v2/{r0,r1,r2}/full/tables/artifact_inventory.csv` — repo-relative paths
- `docs/04_reports/arc_d_v2/{r0,r1,r2}/canonical/tables/artifact_inventory.csv` — repo-relative paths
- `docs/04_reports/arc_d_v2/r3/{canonical,full}/tables/artifact_inventory.csv` — repo-relative paths

**Plan (1):**
- `plans/sessions/2026-03-18_charting-review-fixes.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)