### PR TITLE
fix: resolve 3 post-merge review findings (#892 follow-up)

### DIFF
--- a/.claude/hooks/post-task-event.sh
+++ b/.claude/hooks/post-task-event.sh
@@ -1,17 +1,23 @@
 #!/usr/bin/env bash
 # PostToolUse hook: Emit durable events on task-relevant tool completions.
 #
-# Matches Bash tool output containing patterns like "gh pr merge" and emits
-# structured events to the ops event log.
+# Reads PostToolUse JSON from stdin (matching existing hook patterns like
+# post-pr-review.sh and post-merge-ci-check.sh). Matches successful
+# gh pr merge commands and emits task_completed events.
 #
 # Timeout: 5s (must be fast — runs on every Bash tool completion)
 
 set -euo pipefail
 
-# Read tool output from stdin (PostToolUse receives tool_input and tool_output)
-TOOL_OUTPUT="${TOOL_OUTPUT:-}"
-if [ -z "$TOOL_OUTPUT" ]; then
-    # Try reading from the environment or bail
+# Read PostToolUse JSON payload from stdin
+INPUT=$(cat)
+
+# Extract the bash command and exit code
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+EXIT_CODE=$(echo "$INPUT" | jq -r '.tool_response.exit_code // 0' 2>/dev/null || echo "0")
+
+# Only process successful commands
+if [ "$EXIT_CODE" != "0" ]; then
     exit 0
 fi
 
@@ -31,16 +37,15 @@ if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
     esac
 fi
 
-# Check for task-relevant patterns in tool output
+# Check for task-relevant patterns in the command
 EVENT_TYPE=""
 DETAILS=""
 
-if echo "$TOOL_OUTPUT" | grep -q "gh pr merge"; then
+if [[ "$COMMAND" == *"gh pr merge"* ]]; then
     EVENT_TYPE="task_completed"
-    DETAILS="PR merged"
-elif echo "$TOOL_OUTPUT" | grep -q "Successfully rebased"; then
-    # Not a failure event, just informational — skip
-    exit 0
+    # Try to extract PR number from command
+    PR_NUM=$(echo "$COMMAND" | grep -oE '[0-9]+' | head -1 || true)
+    DETAILS="PR #${PR_NUM:-unknown} merged"
 fi
 
 # Only emit if we matched a relevant pattern

--- a/.claude/hooks/pre-worktree-cleanup.sh
+++ b/.claude/hooks/pre-worktree-cleanup.sh
@@ -1,32 +1,37 @@
 #!/usr/bin/env bash
-# PreToolUse hook: Advisory warning when dangerous worktree removal is attempted.
+# PreToolUse hook: Block dangerous worktree removal and redirect to safe ops flow.
 #
 # Matches Bash tool input containing patterns like:
 #   rm -rf ../Bid-Euchre*
 #   git worktree remove
 #   git worktree prune
 #
-# Prints a warning suggesting the safe ops.py worktrees prune flow instead.
-# Advisory only — does NOT block the command (exit 0).
+# Blocks the command and suggests ops.py worktrees prune instead.
+# Per governing plan: "Direct rm -rf on worktree directories is intercepted
+# by PreToolUse hook and redirected to ops.py worktrees prune."
 #
 # Timeout: 5s
 
 set -euo pipefail
 
-# PreToolUse receives tool_input via environment
-TOOL_INPUT="${TOOL_INPUT:-}"
-if [ -z "$TOOL_INPUT" ]; then
+# PreToolUse receives JSON on stdin
+INPUT=$(cat)
+
+# Extract the command being attempted
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+
+if [ -z "$COMMAND" ]; then
     exit 0
 fi
 
 # Check for dangerous worktree operations
 MATCHED=""
 
-if echo "$TOOL_INPUT" | grep -qE "rm\s+(-rf?|--recursive)\s+.*Bid-Euchre"; then
+if echo "$COMMAND" | grep -qE "rm\s+(-rf?|--recursive)\s+.*Bid-Euchre"; then
     MATCHED="rm -rf on Bid-Euchre directory"
-elif echo "$TOOL_INPUT" | grep -q "git worktree remove"; then
+elif echo "$COMMAND" | grep -q "git worktree remove"; then
     MATCHED="git worktree remove"
-elif echo "$TOOL_INPUT" | grep -q "git worktree prune"; then
+elif echo "$COMMAND" | grep -q "git worktree prune"; then
     MATCHED="git worktree prune"
 fi
 
@@ -34,21 +39,20 @@ if [ -z "$MATCHED" ]; then
     exit 0
 fi
 
-# Print advisory warning (shows up in tool output)
+# Block the command and redirect to safe flow
 cat <<EOF
-
-⚠ WARNING: Detected potentially dangerous worktree operation: $MATCHED
+BLOCKED: Detected dangerous worktree operation: $MATCHED
 
 Use the safe cleanup flow instead:
   uv run python scripts/internal/ops.py worktrees prune           # dry-run first
   uv run python scripts/internal/ops.py worktrees prune --execute  # then execute
+  uv run python scripts/internal/ops.py worktrees archive <path>   # archive one worktree
 
 This ensures:
   - Protected steward worktrees are never removed
   - Dirty worktrees are quarantined (diff saved) first
   - Events are emitted for audit trail
-
 EOF
 
-# Advisory only — allow the command to proceed (exit 0)
-exit 0
+# Non-zero exit blocks the command from executing
+exit 2

--- a/plans/sessions/2026-03-18_pr3b-safe-cleanup-hooks.md
+++ b/plans/sessions/2026-03-18_pr3b-safe-cleanup-hooks.md
@@ -153,9 +153,10 @@ ops.py recover [--json]                          # Show recovery guidance
 - Timeout: 5s (must be fast)
 
 **`pre-worktree-cleanup.sh`** — PreToolUse hook on `Bash`:
-- Matches tool input containing `rm -rf ../Bid-Euchre` or `git worktree remove`
-- Prints warning + suggests `uv run python scripts/internal/ops.py worktrees prune`
-- Does NOT block (advisory only — blocking requires `exitCode` non-zero)
+- Reads JSON from stdin (matching existing hook patterns)
+- Matches `.tool_input.command` containing `rm -rf ../Bid-Euchre` or `git worktree remove/prune`
+- Blocks the command (`exit 2`) and suggests `ops.py worktrees prune`
+- Per governing plan: "intercepted by PreToolUse hook and redirected to `ops.py worktrees prune`"
 - Timeout: 5s
 
 ## Implementation Order

--- a/src/bid_euchre/ops/worktrees.py
+++ b/src/bid_euchre/ops/worktrees.py
@@ -432,10 +432,13 @@ def prune_worktrees(
     git_wts = list_worktrees_git()
     registry = list_worktrees_registry(registry_dir)
 
+    # Always check dirty state — even in dry-run mode, the operator needs
+    # accurate reporting. A stale dirty worktree must show as "quarantined"
+    # not "removed" so the dry-run output matches execute behavior.
     candidates = classify_cleanup_candidates(
         git_wts,
         registry,
-        check_dirty=not dry_run,
+        check_dirty=True,
     )
 
     results: list[PruneResult] = []

--- a/tests/unit/test_ops_worktrees.py
+++ b/tests/unit/test_ops_worktrees.py
@@ -459,6 +459,36 @@ class TestPruneWorktrees:
         # Persistent worktrees are not candidates at all
         assert len(results) == 0
 
+    def test_dry_run_dirty_stale_shows_quarantined(
+        self, runtime_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Dry-run must check dirtiness and show quarantined, not removed."""
+        from bid_euchre.ops import worktrees as wt_mod
+
+        monkeypatch.setattr(
+            wt_mod,
+            "list_worktrees_git",
+            lambda: [GitWorktree(path="/tmp/wt-dirty", head="abc", branch="task-2")],
+        )
+        # Mock is_worktree_dirty to return True
+        monkeypatch.setattr(wt_mod, "is_worktree_dirty", lambda p: True)
+
+        _write_registry_entry(
+            runtime_dir / "worktree_registry",
+            "task-dirty.json",
+            lane_id="task-2",
+            lifecycle_class="ephemeral",
+            worktree_path="/tmp/wt-dirty",
+            last_active="2020-01-01T00:00:00+00:00",
+            ttl_hours=1.0,
+        )
+
+        results = wt_mod.prune_worktrees(runtime_dir, dry_run=True)
+        assert len(results) == 1
+        # Must show quarantined, not removed — dirtiness is checked even in dry-run
+        assert results[0].action == "quarantined"
+        assert results[0].dry_run is True
+
 
 class TestQuarantineWorktree:
     """Tests for quarantine_worktree()."""


### PR DESCRIPTION
## Summary

- **pre-worktree-cleanup.sh**: Change from advisory (`exit 0`) to blocking (`exit 2`) per governing plan contract; read JSON from stdin matching existing hook patterns
- **post-task-event.sh**: Rewrite to read PostToolUse JSON from stdin via `INPUT=$(cat)` + `jq`, matching `post-pr-review.sh` and `post-merge-ci-check.sh` patterns (was reading `TOOL_OUTPUT` env var which is never set)
- **prune_worktrees()**: Always check dirty state (`check_dirty=True`) even in dry-run mode — previously dry-run skipped dirty checks, so stale dirty worktrees showed "Would remove" instead of "Would quarantine"

## Why

Three review findings from #892 that were pushed after the squash merge window closed. All three are in the safety boundary — hook I/O, blocking behavior, and dry-run accuracy.

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_ops_worktrees.py tests/unit/test_ops_cli.py tests/unit/test_ops_recovery.py -v
make check-quiet
```

## Tests

- Added `test_dry_run_dirty_stale_shows_quarantined` proving fix P1.3
- 142 total ops tests passing (was 141, +1 new)
- `make check-quiet` passes

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
branch: codex/steward-author-c
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)