### PR TITLE
docs: backfill canonical 02_decision.md — PENDING→PRELIMINARY (R0–R3)

### DIFF
--- a/docs/04_reports/arc_d_v2/r0/canonical/02_decision.md
+++ b/docs/04_reports/arc_d_v2/r0/canonical/02_decision.md
@@ -1,8 +1,8 @@
-# Rung ? (QUICK) — Decision Report
+# Rung r0 (canonical) — Decision Report
 
 ## Advancement Decision
 
-**PENDING**
+**PRELIMINARY**
 
 ## Evidence Summary
 
@@ -58,7 +58,21 @@ See Chart 7 (H2H Heatmap), Chart 6 (H2H Delta by Contract), and Chart 23 (Intell
 
 ## Recommendation
 
-Hypothesis outcomes not yet available. Run the advance check pipeline to populate results.
+**PRELIMINARY — formal advance-check evidence absent**
+
+Data-driven triage based on available canonical evidence:
+
+- **selected_ols_av** net_eppd = 1.720
+- **constrained_ols_av** net_eppd = 1.600
+- **full_ols_av** net_eppd = 1.480
+- Best H2H win rate: **modeloespecifico** (70.0% vs heuristic tier)
+- Data sanity: all checks passed
+
+**Watch items / caveats:**
+
+- Formal hypothesis tests not yet executed
+- Canonical sample sizes (single seed) may be insufficient for tail analysis
+- Run the advance-check pipeline (`--mode FULL`) for definitive evidence
 
 ## Supporting Evidence
 
@@ -70,4 +84,4 @@ Hypothesis outcomes not yet available. Run the advance check pipeline to populat
 - Chart 23: Intelligence-Faceted H2H
 - Full tables: `tables/comparator_rankings.csv`, `tables/h2h_delta_matrix.csv`, `tables/h2h_tier_summary.csv`
 
-<\!-- gate_status: data sanity checks in Evidence Summary above -->
+<!-- gate_status: data sanity checks in Evidence Summary above -->

--- a/docs/04_reports/arc_d_v2/r1/canonical/02_decision.md
+++ b/docs/04_reports/arc_d_v2/r1/canonical/02_decision.md
@@ -1,8 +1,8 @@
-# Rung ? (QUICK) — Decision Report
+# Rung r1 (canonical) — Decision Report
 
 ## Advancement Decision
 
-**PENDING**
+**PRELIMINARY**
 
 ## Evidence Summary
 
@@ -58,7 +58,21 @@ See Chart 7 (H2H Heatmap), Chart 6 (H2H Delta by Contract), and Chart 23 (Intell
 
 ## Recommendation
 
-Hypothesis outcomes not yet available. Run the advance check pipeline to populate results.
+**PRELIMINARY — formal advance-check evidence absent**
+
+Data-driven triage based on available canonical evidence:
+
+- **gbt_av** net_eppd = 3.120
+- **full_ols_av** net_eppd = 1.960
+- **selected_ols_av** net_eppd = 1.920
+- Best H2H win rate: **modeloespecifico** (70.0% vs heuristic tier)
+- Data sanity: all checks passed
+
+**Watch items / caveats:**
+
+- Formal hypothesis tests not yet executed
+- Canonical sample sizes (single seed) may be insufficient for tail analysis
+- Run the advance-check pipeline (`--mode FULL`) for definitive evidence
 
 ## Supporting Evidence
 
@@ -70,4 +84,4 @@ Hypothesis outcomes not yet available. Run the advance check pipeline to populat
 - Chart 23: Intelligence-Faceted H2H
 - Full tables: `tables/comparator_rankings.csv`, `tables/h2h_delta_matrix.csv`, `tables/h2h_tier_summary.csv`
 
-<\!-- gate_status: data sanity checks in Evidence Summary above -->
+<!-- gate_status: data sanity checks in Evidence Summary above -->

--- a/docs/04_reports/arc_d_v2/r2/canonical/02_decision.md
+++ b/docs/04_reports/arc_d_v2/r2/canonical/02_decision.md
@@ -1,8 +1,8 @@
-# Rung ? (QUICK) — Decision Report
+# Rung r2 (canonical) — Decision Report
 
 ## Advancement Decision
 
-**PENDING**
+**PRELIMINARY**
 
 ## Evidence Summary
 
@@ -58,7 +58,21 @@ See Chart 7 (H2H Heatmap), Chart 6 (H2H Delta by Contract), and Chart 23 (Intell
 
 ## Recommendation
 
-Hypothesis outcomes not yet available. Run the advance check pipeline to populate results.
+**PRELIMINARY — formal advance-check evidence absent**
+
+Data-driven triage based on available canonical evidence:
+
+- **gbt_av** net_eppd = 3.120
+- **full_ols_av** net_eppd = 1.960
+- **selected_ols_av** net_eppd = 1.920
+- Best H2H win rate: **modeloespecifico** (70.0% vs heuristic tier)
+- Data sanity: all checks passed
+
+**Watch items / caveats:**
+
+- Formal hypothesis tests not yet executed
+- Canonical sample sizes (single seed) may be insufficient for tail analysis
+- Run the advance-check pipeline (`--mode FULL`) for definitive evidence
 
 ## Supporting Evidence
 
@@ -70,4 +84,4 @@ Hypothesis outcomes not yet available. Run the advance check pipeline to populat
 - Chart 23: Intelligence-Faceted H2H
 - Full tables: `tables/comparator_rankings.csv`, `tables/h2h_delta_matrix.csv`, `tables/h2h_tier_summary.csv`
 
-<\!-- gate_status: data sanity checks in Evidence Summary above -->
+<!-- gate_status: data sanity checks in Evidence Summary above -->

--- a/docs/04_reports/arc_d_v2/r3/canonical/02_decision.md
+++ b/docs/04_reports/arc_d_v2/r3/canonical/02_decision.md
@@ -1,8 +1,8 @@
-# Rung ? (QUICK) — Decision Report
+# Rung r3 (canonical) — Decision Report
 
 ## Advancement Decision
 
-**PENDING**
+**PRELIMINARY**
 
 ## Evidence Summary
 
@@ -58,7 +58,21 @@ See Chart 7 (H2H Heatmap), Chart 6 (H2H Delta by Contract), and Chart 23 (Intell
 
 ## Recommendation
 
-Hypothesis outcomes not yet available. Run the advance check pipeline to populate results.
+**PRELIMINARY — formal advance-check evidence absent**
+
+Data-driven triage based on available canonical evidence:
+
+- **gbt_av** net_eppd = 3.700
+- **full_ols_av** net_eppd = 1.840
+- **constrained_ols_av** net_eppd = 1.680
+- Best H2H win rate: **modeloespecifico** (70.0% vs heuristic tier)
+- Data sanity: all checks passed
+
+**Watch items / caveats:**
+
+- Formal hypothesis tests not yet executed
+- Canonical sample sizes (single seed) may be insufficient for tail analysis
+- Run the advance-check pipeline (`--mode FULL`) for definitive evidence
 
 ## Supporting Evidence
 
@@ -70,4 +84,4 @@ Hypothesis outcomes not yet available. Run the advance check pipeline to populat
 - Chart 23: Intelligence-Faceted H2H
 - Full tables: `tables/comparator_rankings.csv`, `tables/h2h_delta_matrix.csv`, `tables/h2h_tier_summary.csv`
 
-<\!-- gate_status: data sanity checks in Evidence Summary above -->
+<!-- gate_status: data sanity checks in Evidence Summary above -->


### PR DESCRIPTION
## Summary

- Convert 4 canonical `02_decision.md` files from blank **PENDING** to **PRELIMINARY** triage
- Fix broken titles: `Rung ? (QUICK)` → `Rung rN (canonical)`
- Fix escaped HTML comment syntax (`<\!--` → `<!--`)
- Update MEMORY.md: mark backfill task complete, update session handoff

## Why

These were the last PENDING decision reports in the Arc D v2 lineage. Converting them to PRELIMINARY with data-driven triage (matching PR #844's pattern for QUICK reports) closes the final loose end.

## Files changed

| File | Change |
|------|--------|
| `docs/04_reports/arc_d_v2/r0/canonical/02_decision.md` | PENDING→PRELIMINARY, fix title, add triage |
| `docs/04_reports/arc_d_v2/r1/canonical/02_decision.md` | PENDING→PRELIMINARY, fix title, add triage |
| `docs/04_reports/arc_d_v2/r2/canonical/02_decision.md` | PENDING→PRELIMINARY, fix title, add triage |
| `docs/04_reports/arc_d_v2/r3/canonical/02_decision.md` | PENDING→PRELIMINARY, fix title, add triage |

## Repro / Validation

```bash
make check-quiet  # ✓ All checks passed
```

## Tests

Docs-only change — no code modified.

```bash
make check-quiet  # ✓ All checks passed
```

## Worktree proof

Persistent steward-author worktree (`Bid-Euchre-steward-author`), branch `codex/steward-author`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)