### PR TITLE
fix: persist cleanup_state to registry + stale plan docs (#896 follow-up)

### DIFF
--- a/plans/sessions/2026-03-18_pr3b-safe-cleanup-hooks.md
+++ b/plans/sessions/2026-03-18_pr3b-safe-cleanup-hooks.md
@@ -145,11 +145,12 @@ ops.py recover [--json]                          # Show recovery guidance
 ### 4. Hooks
 
 **`post-task-event.sh`** — PostToolUse hook on `Bash`:
-- Matches tool output containing `gh pr merge`, `task completed`, etc.
+- Reads PostToolUse JSON from stdin (matching existing hook patterns: `INPUT=$(cat)` + `jq`)
+- Matches `.tool_input.command` for `gh pr merge` and checks `.tool_response.exit_code == 0`
 - Resolves `lane_id` from the worktree directory name (e.g., `Bid-Euchre-steward-author-c` → `author-c`),
   falling back to `"unknown"` if the name doesn't match a known pattern
 - Calls `uv run python -c "from bid_euchre.ops.events import append_event; ..."`
-- Emits `task_completed` or relevant event type
+- Emits `task_completed` event on successful merge
 - Timeout: 5s (must be fast)
 
 **`pre-worktree-cleanup.sh`** — PreToolUse hook on `Bash`:

--- a/src/bid_euchre/ops/worktrees.py
+++ b/src/bid_euchre/ops/worktrees.py
@@ -561,6 +561,45 @@ def prune_worktrees(
     return results
 
 
+def _update_registry_cleanup_state(
+    registry_dir: Path,
+    worktree_path: str,
+    cleanup_state: str,
+) -> bool:
+    """Update the ``cleanup_state`` field in a worktree registry entry.
+
+    Finds the registry JSON file whose ``worktree_path`` matches, then
+    rewrites it with the new ``cleanup_state``.
+
+    Args:
+        registry_dir: Path to the worktree_registry directory.
+        worktree_path: The worktree path to match.
+        cleanup_state: New cleanup state value.
+
+    Returns:
+        True if a matching entry was found and updated, False otherwise.
+    """
+    if not registry_dir.exists():
+        return False
+
+    resolved = str(Path(worktree_path).resolve())
+
+    for f in sorted(registry_dir.glob("*.json")):
+        try:
+            data = json.loads(f.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        entry_path = data.get("worktree_path", "")
+        if entry_path and str(Path(entry_path).resolve()) == resolved:
+            data["cleanup_state"] = cleanup_state
+            f.write_text(json.dumps(data, indent=2))
+            logger.info("Updated registry %s: cleanup_state=%s", f.name, cleanup_state)
+            return True
+
+    return False
+
+
 def quarantine_worktree(
     worktree_path: str,
     reason: str,
@@ -599,6 +638,11 @@ def quarantine_worktree(
     diff_file.write_text(diff_content)
 
     logger.info("Quarantined %s → %s (reason: %s)", worktree_path, diff_file, reason)
+
+    # Persist cleanup_state to registry
+    _update_registry_cleanup_state(
+        runtime_dir / "worktree_registry", worktree_path, "quarantined"
+    )
 
     # Emit event
     try:
@@ -685,6 +729,9 @@ def archive_worktree(
         )
 
     logger.info("Archived worktree: %s", worktree_path)
+
+    # Persist cleanup_state to registry
+    _update_registry_cleanup_state(registry_dir, worktree_path, "archived")
 
     # Emit event
     try:

--- a/tests/unit/test_ops_worktrees.py
+++ b/tests/unit/test_ops_worktrees.py
@@ -548,6 +548,43 @@ class TestQuarantineWorktree:
 
         assert (runtime_dir / "worktree_quarantine").is_dir()
 
+    def test_quarantine_persists_cleanup_state(
+        self, runtime_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Quarantine must update cleanup_state in the registry JSON."""
+        import subprocess as sp
+
+        from bid_euchre.ops import worktrees as wt_mod
+
+        monkeypatch.setattr(
+            sp,
+            "run",
+            lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": ""})(),
+        )
+
+        # Create a registry entry for the worktree
+        (runtime_dir / "worktree_registry").mkdir(parents=True, exist_ok=True)
+        _write_registry_entry(
+            runtime_dir / "worktree_registry",
+            "task-q.json",
+            lane_id="task-q",
+            lifecycle_class="ephemeral",
+            worktree_path="/tmp/wt-q",
+        )
+
+        wt_mod.quarantine_worktree(
+            "/tmp/wt-q",
+            "dirty and stale",
+            runtime_dir,
+            events_dir=runtime_dir / "events",
+        )
+
+        # Verify registry entry was updated
+        updated = json.loads(
+            (runtime_dir / "worktree_registry" / "task-q.json").read_text()
+        )
+        assert updated["cleanup_state"] == "quarantined"
+
 
 class TestArchiveWorktree:
     """Tests for archive_worktree()."""
@@ -612,3 +649,39 @@ class TestArchiveWorktree:
         assert any(
             "worktree" in str(cmd) and "remove" in str(cmd) for cmd in commands_run
         )
+
+    def test_archive_persists_cleanup_state(
+        self, runtime_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Archive must update cleanup_state in the registry JSON."""
+        import subprocess as sp
+
+        from bid_euchre.ops import worktrees as wt_mod
+
+        monkeypatch.setattr(wt_mod, "is_worktree_dirty", lambda p: False)
+
+        def mock_run(*args: object, **kwargs: object) -> object:
+            return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+        monkeypatch.setattr(sp, "run", mock_run)
+
+        # Create a registry entry
+        _write_registry_entry(
+            runtime_dir / "worktree_registry",
+            "task-a.json",
+            lane_id="task-a",
+            lifecycle_class="ephemeral",
+            worktree_path="/tmp/some-archivable",
+        )
+
+        wt_mod.archive_worktree(
+            "/tmp/some-archivable",
+            runtime_dir,
+            events_dir=runtime_dir / "events",
+        )
+
+        # Verify registry entry was updated
+        updated = json.loads(
+            (runtime_dir / "worktree_registry" / "task-a.json").read_text()
+        )
+        assert updated["cleanup_state"] == "archived"


### PR DESCRIPTION
## Summary

- Add `_update_registry_cleanup_state()` helper that persists `cleanup_state` to the matching worktree registry JSON file
- Wire into `quarantine_worktree()` → `"quarantined"` and `archive_worktree()` → `"archived"`
- Update Phase 3B plan description for `post-task-event.sh` to match stdin JSON implementation

## Why

#896 was auto-merged before this commit was pushed. The registry persistence fix closes the last lifecycle gap identified in post-merge review: quarantine/archive operations now update the canonical registry, matching the Phase 3B plan contract and the `worktree_registry/README.md` lifecycle states.

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_ops_worktrees.py -v -k "quarantine or archive"
make check-quiet
```

## Tests

- `test_quarantine_persists_cleanup_state` — verifies registry JSON has `cleanup_state: "quarantined"` after quarantine
- `test_archive_persists_cleanup_state` — verifies registry JSON has `cleanup_state: "archived"` after archive

## Validation Performed

### Automated tests
```bash
uv run python -m pytest tests/unit/test_ops_worktrees.py -v -k "quarantine or archive"  # 10 passed
make check-quiet  # All checks passed
```

### Manual smoke check
Ran `_update_registry_cleanup_state()` against a temp registry-backed fixture:
```
quarantine update returned: True
cleanup_state after quarantine: quarantined
archive update returned: True
cleanup_state after archive: archived
non-existent path returned: False
SMOKE PASS: all 3 checks passed
```
Confirmed: registry JSON file is rewritten with correct `cleanup_state` after both quarantine and archive. Non-matching paths return `False` silently.

### Failure-injection check
- `_update_registry_cleanup_state()` on a non-existent registry dir returns `False` silently (no crash)
- Quarantine on a worktree with no matching registry entry still saves the diff and emits the event — registry update is best-effort

### Rollback / disable path
- All changes are additive: one new helper function, two calls from existing functions
- `_update_registry_cleanup_state()` failing silently means removal has no side effects

### Known gaps
- No integration test against real registry files on disk (tests use temp dirs with fixture-written JSON)
- `archive_worktree()` subprocess mock doesn't test interaction between real git removal and registry update ordering

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
branch: codex/steward-author-c
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)