### PR TITLE
fix: correct PP1 typo and vacuously true assertion in precheck tests

### DIFF
--- a/tests/unit/test_deterministic_prechecks.py
+++ b/tests/unit/test_deterministic_prechecks.py
@@ -558,11 +558,12 @@ class TestCheckDiffChangedFiles:
         )
 
         # Should find broken refs in plan_a but NOT plan_b
-        pp1_findings = [f for f in findings if f.check_id == "PP1"]
-        files_with_findings = {f.file for f in pp1_findings}
+        p1_findings = [f for f in findings if f.check_id == "P1"]
+        files_with_findings = {f.file for f in p1_findings}
         assert (
-            "plans/sessions/plan_a.md" in files_with_findings or len(pp1_findings) >= 0
-        )
+            len(p1_findings) > 0
+        ), "Expected P1 findings for plan with broken references"
+        assert "plans/sessions/plan_a.md" in files_with_findings
         assert "plans/sessions/plan_b.md" not in files_with_findings
 
     def test_report_pr_no_plan_path_leak(self, tmp_path: Path) -> None:
@@ -577,5 +578,5 @@ class TestCheckDiffChangedFiles:
             repo_root=tmp_path,
             changed_files=["docs/04_reports/r0/01_results.md"],
         )
-        pp1 = [f for f in findings if f.check_id == "PP1"]
-        assert len(pp1) == 0
+        p1 = [f for f in findings if f.check_id == "P1"]
+        assert len(p1) == 0


### PR DESCRIPTION
## Summary

- Fix "PP1" -> "P1" typo in two test filters (`test_plan_audit_restricted_to_provided_files`, `test_report_pr_no_plan_path_leak`) that caused zero-match filtering since check_id "PP1" does not exist
- Replace vacuously true assertion (`len(pp1_findings) >= 0`, always True for any list) with meaningful assertions that verify broken references actually produce P1 findings
- Downstream variable names updated from `pp1_findings`/`pp1` to `p1_findings`/`p1`

## Why

PR #875 introduced a typo ("PP1" instead of "P1") that made two precheck tests vacuously true. The filter `f.check_id == "PP1"` always returns an empty list since the real check_id is "P1", so:
- `len(pp1_findings) >= 0` is trivially True (any list has length >= 0)
- `"plans/sessions/plan_a.md" in files_with_findings` was short-circuited by the `or` clause
- `len(pp1) == 0` was trivially True (empty list has length 0)

These tests were passing without actually validating the precheck behavior they claimed to test.

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_deterministic_prechecks.py -v  # 50/50 pass
make check-quiet  # All checks passed
```

## Tests

- `uv run python -m pytest tests/unit/test_deterministic_prechecks.py -v` -- 50/50 pass
- `make check-quiet` -- all checks passed

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a569cac0
branch: fix/test-precheck-correctness
```

## Findings source

Steward review batch -- verified test correctness issues from #875 post-merge review.