### PR TITLE
fix: event write locking, v1 role map fallback, shell quoting, dead code removal

### DIFF
--- a/.claude/hooks/post-task-event.sh
+++ b/.claude/hooks/post-task-event.sh
@@ -54,7 +54,16 @@ if [ -z "$EVENT_TYPE" ]; then
 fi
 
 # Emit the event (fire-and-forget, don't block on failure)
+# Use environment variables instead of string interpolation to avoid
+# injection from shell metacharacters in DETAILS or other values.
+EVENT_TYPE="$EVENT_TYPE" LANE_ID="$LANE_ID" DETAILS="$DETAILS" \
 uv run python -c "
+import os
 from bid_euchre.ops.events import append_event
-append_event('$EVENT_TYPE', 'hook.post-task', '$LANE_ID', {'details': '$DETAILS'})
+append_event(
+    os.environ['EVENT_TYPE'],
+    'hook.post-task',
+    os.environ['LANE_ID'],
+    {'details': os.environ['DETAILS']},
+)
 " 2>/dev/null || true

--- a/src/bid_euchre/ops/events.py
+++ b/src/bid_euchre/ops/events.py
@@ -10,6 +10,7 @@ Archive: ``.claude/runtime/events/events.archive.jsonl`` (drained events)
 
 from __future__ import annotations
 
+import fcntl
 import json
 import logging
 from datetime import datetime, timezone
@@ -96,7 +97,12 @@ def append_event(
     events_file = events_dir / EVENTS_FILE
 
     with open(events_file, "a") as f:
-        f.write(json.dumps(event, sort_keys=True) + "\n")
+        fcntl.flock(f, fcntl.LOCK_EX)
+        try:
+            f.write(json.dumps(event, sort_keys=True) + "\n")
+            f.flush()
+        finally:
+            fcntl.flock(f, fcntl.LOCK_UN)
 
     logger.debug("Event appended: %s from %s", event_type, source)
     return event
@@ -171,6 +177,12 @@ def drain_events(
     Moves events with timestamps <= ``up_to`` from the active log to
     the archive file. If ``up_to`` is None, drains all events.
 
+    Note:
+        If the process crashes between archive append and active log rewrite,
+        drained events may appear in both files on next read. This is acceptable
+        because (a) events are advisory, not transactional, and (b) consumers
+        should be idempotent. The alternative (data loss) is worse.
+
     Args:
         events_dir: Override for events directory.
         up_to: Drain events up to this timestamp. None drains all.
@@ -229,42 +241,3 @@ def drain_events(
 
     logger.info("Drained %d events to archive", len(to_drain))
     return len(to_drain)
-
-
-def count_events(
-    events_dir: Path | None = None,
-    *,
-    event_type: str | None = None,
-) -> int:
-    """Count events in the active log.
-
-    Args:
-        events_dir: Override for events directory.
-        event_type: Count only events of this type.
-
-    Returns:
-        Number of matching events.
-    """
-    if events_dir is None:
-        events_dir = DEFAULT_EVENTS_DIR
-
-    events_file = events_dir / EVENTS_FILE
-    if not events_file.exists():
-        return 0
-
-    count = 0
-    with open(events_file) as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            if event_type is None:
-                count += 1
-            else:
-                try:
-                    event = json.loads(line)
-                    if event.get("event_type") == event_type:
-                        count += 1
-                except json.JSONDecodeError:
-                    continue
-    return count

--- a/src/bid_euchre/ops/status.py
+++ b/src/bid_euchre/ops/status.py
@@ -101,7 +101,7 @@ def load_sessions(runtime_dir: Path | None = None) -> list[dict[str, Any]]:
         if data.get("schema_version", 1) < 2:
             role = data.get("role", "unknown")
             lane_id_map = {"author": "author-a", "review": "review", "ops": "ops"}
-            data.setdefault("lane_id", lane_id_map.get(role, role))
+            data.setdefault("lane_id", lane_id_map.get(role, "unknown"))
 
         sessions.append(data)
 

--- a/src/bid_euchre/ops/worktrees.py
+++ b/src/bid_euchre/ops/worktrees.py
@@ -168,9 +168,9 @@ def list_worktrees_registry(
         if data.get("schema_version", 1) < 2:
             role = data.get("role", "unknown")
             lane_id_map = {"author": "author-a", "review": "review", "ops": "ops"}
-            data.setdefault("lane_id", lane_id_map.get(role, role))
+            data.setdefault("lane_id", lane_id_map.get(role, "unknown"))
             lane_class_map = {"author": "author", "review": "review", "ops": "ops"}
-            data.setdefault("lane_class", lane_class_map.get(role, role))
+            data.setdefault("lane_class", lane_class_map.get(role, "unknown"))
             data.setdefault("display_name", None)
             data.setdefault("legacy_role", role)
             for transport_field in [

--- a/tests/unit/test_ops_events.py
+++ b/tests/unit/test_ops_events.py
@@ -12,7 +12,6 @@ from bid_euchre.ops.events import (
     EVENTS_FILE,
     VALID_EVENT_TYPES,
     append_event,
-    count_events,
     drain_events,
     read_events,
 )
@@ -72,8 +71,8 @@ class TestAppendEvent:
     def test_all_valid_event_types_accepted(self, events_dir: Path) -> None:
         for etype in VALID_EVENT_TYPES:
             append_event(etype, "test", "ops", {}, events_dir)
-        count = count_events(events_dir)
-        assert count == len(VALID_EVENT_TYPES)
+        events = read_events(events_dir, limit=len(VALID_EVENT_TYPES) + 1)
+        assert len(events) == len(VALID_EVENT_TYPES)
 
 
 class TestReadEvents:
@@ -226,24 +225,3 @@ class TestDrainEvents:
 
     def test_drain_nonexistent_dir(self, tmp_path: Path) -> None:
         assert drain_events(tmp_path / "no_such") == 0
-
-
-class TestCountEvents:
-    """Tests for count_events()."""
-
-    def test_count_all(self, events_dir: Path) -> None:
-        for _ in range(7):
-            append_event("task_completed", "test", "ops", {}, events_dir)
-        assert count_events(events_dir) == 7
-
-    def test_count_by_type(self, events_dir: Path) -> None:
-        append_event("task_completed", "test", "ops", {}, events_dir)
-        append_event("ci_failure", "test", "ops", {}, events_dir)
-        append_event("task_completed", "test", "ops", {}, events_dir)
-
-        assert count_events(events_dir, event_type="task_completed") == 2
-        assert count_events(events_dir, event_type="ci_failure") == 1
-        assert count_events(events_dir, event_type="session_started") == 0
-
-    def test_count_empty(self, events_dir: Path) -> None:
-        assert count_events(events_dir) == 0

--- a/tests/unit/test_ops_status.py
+++ b/tests/unit/test_ops_status.py
@@ -101,6 +101,23 @@ class TestLoadSessions:
         assert len(sessions) == 1
         assert sessions[0]["lane_id"] == "author-a"
 
+    def test_v1_unknown_role_maps_to_unknown(self, runtime_dir: Path) -> None:
+        """v1 session with unrecognized role should get lane_id='unknown'."""
+        _write_json(
+            runtime_dir / "session_metadata",
+            "bogus-session.json",
+            {
+                "schema_version": 1,
+                "session_id": "bogus-uuid",
+                "role": "bogus_role",
+                "started_at": "2026-03-16T10:00:00Z",
+                "worktree_path": "/tmp/wt-bogus",
+            },
+        )
+        sessions = load_sessions(runtime_dir)
+        assert len(sessions) == 1
+        assert sessions[0]["lane_id"] == "unknown"
+
 
 class TestLoadTasks:
     """Tests for load_tasks()."""

--- a/tests/unit/test_ops_worktrees.py
+++ b/tests/unit/test_ops_worktrees.py
@@ -105,6 +105,27 @@ class TestListWorktreesRegistry:
         assert entry["legacy_role"] == "author"
         assert entry["tmux_session"] is None
 
+    def test_v1_unknown_role_maps_to_unknown(self, registry_dir: Path) -> None:
+        """v1 entry with unrecognized role should get lane_id='unknown', not the raw role."""
+        v1_entry = {
+            "schema_version": 1,
+            "role": "bogus_role",
+            "worktree_path": "/tmp/wt-bogus",
+            "branch": "role/bogus",
+            "class": "ephemeral",
+            "created_at": "2026-03-16T22:00:00Z",
+            "last_active": "2026-03-16T22:00:00Z",
+            "session_id": None,
+            "ttl_hours": None,
+        }
+        (registry_dir / "bogus.json").write_text(json.dumps(v1_entry))
+
+        entries = list_worktrees_registry(registry_dir)
+        assert len(entries) == 1
+        assert entries[0]["lane_id"] == "unknown"
+        assert entries[0]["lane_class"] == "unknown"
+        assert entries[0]["legacy_role"] == "bogus_role"
+
     def test_skips_malformed_files(self, registry_dir: Path) -> None:
         (registry_dir / "bad.json").write_text("not json {{{")
         _write_registry_entry(registry_dir, "good.json", lane_id="ops")


### PR DESCRIPTION
## Plan
Steward review batch fixes -- PR 3 of 3.

## Summary
- **878-H2**: Add `fcntl` file locking to `append_event()` for concurrent write safety
- **878-H1**: Document `drain_events()` duplicate-on-crash window in docstring
- **878-M3**: Remove dead `count_events()` function (unused, redundant with `len(read_events(...))`)
- **878-M5**: v1 role map fallback produces `"unknown"` instead of raw role string in both `worktrees.py` and `status.py`
- **892-M1**: Shell hook uses environment variables instead of string interpolation to prevent injection from metacharacters in event details

## Why
PRs #878 and #892 were merged with verified reliability gaps in the ops events system, v1 role mapping, and shell hook. The steward review caught these issues. This PR addresses all 6 findings.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_events.py tests/unit/test_ops_status.py tests/unit/test_ops_worktrees.py -v
make check-quiet
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_events.py tests/unit/test_ops_status.py tests/unit/test_ops_worktrees.py -v` (76 passed)
- [x] `make check-quiet` (all checks passed)

**Test changes:**
- Removed `TestCountEvents` class (tested deleted function)
- Updated `test_all_valid_event_types_accepted` to use `read_events()` instead of `count_events()`
- Added `test_v1_unknown_role_maps_to_unknown` in `test_ops_worktrees.py`
- Added `test_v1_unknown_role_maps_to_unknown` in `test_ops_status.py`

## Expected impact
- Metrics impact: None
- Runtime impact: Negligible (fcntl lock/unlock on event append)

## Risk level
- [x] Low (ops infrastructure only, no engine/rules changes)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a3a7c64b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a3a7c64b
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                  0bae073 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a3a7c64b  4dfd384 [fix/ops-events-reliability]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept: ops events reliability fixes from steward review)