### PR TITLE
fix: quarantine untracked files, clean registry on archive, accurate dry-run

### DIFF
--- a/src/bid_euchre/ops/worktrees.py
+++ b/src/bid_euchre/ops/worktrees.py
@@ -607,7 +607,7 @@ def quarantine_worktree(
     *,
     events_dir: Path | None = None,
 ) -> Path:
-    """Save a worktree's uncommitted diff and mark it as quarantined.
+    """Save a worktree's uncommitted diff and untracked file list.
 
     Args:
         worktree_path: Path to the worktree directory.
@@ -625,7 +625,7 @@ def quarantine_worktree(
     slug = Path(worktree_path).name.replace("/", "_").replace(" ", "_")
     diff_file = quarantine_dir / f"{slug}.diff"
 
-    # Save the diff
+    # Save the diff (tracked changes)
     result = subprocess.run(
         ["git", "-C", worktree_path, "diff", "HEAD"],
         capture_output=True,
@@ -635,7 +635,25 @@ def quarantine_worktree(
     diff_content = (
         result.stdout if result.returncode == 0 else f"# diff failed: {result.stderr}"
     )
-    diff_file.write_text(diff_content)
+
+    # Also capture untracked files
+    untracked_result = subprocess.run(
+        ["git", "-C", worktree_path, "ls-files", "--others", "--exclude-standard"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    untracked_section = ""
+    if untracked_result.returncode == 0 and untracked_result.stdout.strip():
+        untracked_section = (
+            "\n\n# Untracked files\n"
+            + "\n".join(
+                f"# - {f}" for f in untracked_result.stdout.strip().splitlines()
+            )
+            + "\n"
+        )
+
+    diff_file.write_text(diff_content + untracked_section)
 
     logger.info("Quarantined %s → %s (reason: %s)", worktree_path, diff_file, reason)
 
@@ -707,14 +725,21 @@ def archive_worktree(
             f"Use quarantine first, or pass force=True."
         )
 
-    # Look up lane_id from registry for event attribution
+    # Look up lane_id and registry file path for event attribution + cleanup
     registry_dir = runtime_dir / "worktree_registry"
-    registry = list_worktrees_registry(registry_dir)
     lane_id = "ops"
-    for entry in registry:
-        if str(Path(entry.get("worktree_path", "")).resolve()) == resolved:
-            lane_id = entry.get("lane_id", "ops")
-            break
+    registry_file_to_remove: Path | None = None
+    for reg_file in (
+        sorted(registry_dir.glob("*.json")) if registry_dir.exists() else []
+    ):
+        try:
+            reg_data = json.loads(reg_file.read_text())
+            if str(Path(reg_data.get("worktree_path", "")).resolve()) == resolved:
+                lane_id = reg_data.get("lane_id", "ops")
+                registry_file_to_remove = reg_file
+                break
+        except (json.JSONDecodeError, OSError):
+            continue
 
     # Perform removal
     result = subprocess.run(
@@ -728,10 +753,17 @@ def archive_worktree(
             f"git worktree remove failed: {result.stderr.strip()}"
         )
 
-    logger.info("Archived worktree: %s", worktree_path)
+    # Clean up registry entry now that worktree is removed
+    if registry_file_to_remove is not None:
+        try:
+            registry_file_to_remove.unlink()
+            logger.info("Removed registry entry: %s", registry_file_to_remove.name)
+        except OSError:
+            logger.warning(
+                "Failed to remove registry entry: %s", registry_file_to_remove.name
+            )
 
-    # Persist cleanup_state to registry
-    _update_registry_cleanup_state(registry_dir, worktree_path, "archived")
+    logger.info("Archived worktree: %s", worktree_path)
 
     # Emit event
     try:

--- a/tests/unit/test_ops_worktrees.py
+++ b/tests/unit/test_ops_worktrees.py
@@ -585,6 +585,83 @@ class TestQuarantineWorktree:
         )
         assert updated["cleanup_state"] == "quarantined"
 
+    def test_quarantine_captures_untracked_files(
+        self, runtime_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Quarantine diff file must include untracked file listing (892-M2)."""
+        import subprocess as sp
+
+        from bid_euchre.ops import worktrees as wt_mod
+
+        call_count = 0
+
+        def mock_run(*args: object, **kwargs: object) -> object:
+            nonlocal call_count
+            cmd = args[0] if args else kwargs.get("args", [])
+            call_count += 1
+            if "diff" in cmd:
+                return type(
+                    "R",
+                    (),
+                    {"returncode": 0, "stdout": "diff --git a/foo\n+modified\n"},
+                )()
+            if "ls-files" in cmd:
+                return type(
+                    "R",
+                    (),
+                    {"returncode": 0, "stdout": "new_file.py\ndata/scratch.csv\n"},
+                )()
+            return type("R", (), {"returncode": 0, "stdout": ""})()
+
+        monkeypatch.setattr(sp, "run", mock_run)
+
+        diff_path = wt_mod.quarantine_worktree(
+            "/tmp/wt-untracked",
+            "stale with untracked",
+            runtime_dir,
+            events_dir=tmp_path / "events",
+        )
+
+        content = diff_path.read_text()
+        # Must contain the diff
+        assert "diff --git" in content
+        # Must contain untracked file listing
+        assert "# Untracked files" in content
+        assert "# - new_file.py" in content
+        assert "# - data/scratch.csv" in content
+
+    def test_quarantine_no_untracked_section_when_clean(
+        self, runtime_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When there are no untracked files, no untracked section is added."""
+        import subprocess as sp
+
+        from bid_euchre.ops import worktrees as wt_mod
+
+        def mock_run(*args: object, **kwargs: object) -> object:
+            cmd = args[0] if args else kwargs.get("args", [])
+            if "diff" in cmd:
+                return type(
+                    "R",
+                    (),
+                    {"returncode": 0, "stdout": "diff --git a/foo\n+bar\n"},
+                )()
+            # ls-files returns empty (no untracked files)
+            return type("R", (), {"returncode": 0, "stdout": ""})()
+
+        monkeypatch.setattr(sp, "run", mock_run)
+
+        diff_path = wt_mod.quarantine_worktree(
+            "/tmp/wt-clean-untracked",
+            "stale but no untracked",
+            runtime_dir,
+            events_dir=tmp_path / "events",
+        )
+
+        content = diff_path.read_text()
+        assert "diff --git" in content
+        assert "# Untracked files" not in content
+
 
 class TestArchiveWorktree:
     """Tests for archive_worktree()."""
@@ -650,38 +727,74 @@ class TestArchiveWorktree:
             "worktree" in str(cmd) and "remove" in str(cmd) for cmd in commands_run
         )
 
-    def test_archive_persists_cleanup_state(
+    def test_archive_cleans_registry_entry(
         self, runtime_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Archive must update cleanup_state in the registry JSON."""
+        """After successful removal, the registry JSON file is deleted (892-M4)."""
         import subprocess as sp
 
         from bid_euchre.ops import worktrees as wt_mod
 
         monkeypatch.setattr(wt_mod, "is_worktree_dirty", lambda p: False)
-
-        def mock_run(*args: object, **kwargs: object) -> object:
-            return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
-
-        monkeypatch.setattr(sp, "run", mock_run)
-
-        # Create a registry entry
-        _write_registry_entry(
-            runtime_dir / "worktree_registry",
-            "task-a.json",
-            lane_id="task-a",
-            lifecycle_class="ephemeral",
-            worktree_path="/tmp/some-archivable",
+        monkeypatch.setattr(
+            sp,
+            "run",
+            lambda *a, **kw: type(
+                "R", (), {"returncode": 0, "stdout": "", "stderr": ""}
+            )(),
         )
 
+        # Create a registry entry for the worktree we will archive
+        registry_dir = runtime_dir / "worktree_registry"
+        _write_registry_entry(
+            registry_dir,
+            "task-archive.json",
+            lane_id="task-archive",
+            lifecycle_class="ephemeral",
+            worktree_path="/tmp/wt-to-archive",
+        )
+        # Also create an unrelated entry that should survive
+        _write_registry_entry(
+            registry_dir,
+            "other.json",
+            lane_id="other",
+            worktree_path="/tmp/other-wt",
+        )
+
+        assert (registry_dir / "task-archive.json").exists()
+        assert (registry_dir / "other.json").exists()
+
         wt_mod.archive_worktree(
-            "/tmp/some-archivable",
+            "/tmp/wt-to-archive",
             runtime_dir,
             events_dir=runtime_dir / "events",
         )
 
-        # Verify registry entry was updated
-        updated = json.loads(
-            (runtime_dir / "worktree_registry" / "task-a.json").read_text()
+        # The archived worktree's registry entry should be removed
+        assert not (registry_dir / "task-archive.json").exists()
+        # The unrelated entry should remain
+        assert (registry_dir / "other.json").exists()
+
+    def test_archive_no_crash_without_registry_entry(
+        self, runtime_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Archive succeeds even when no registry entry exists for the worktree."""
+        import subprocess as sp
+
+        from bid_euchre.ops import worktrees as wt_mod
+
+        monkeypatch.setattr(wt_mod, "is_worktree_dirty", lambda p: False)
+        monkeypatch.setattr(
+            sp,
+            "run",
+            lambda *a, **kw: type(
+                "R", (), {"returncode": 0, "stdout": "", "stderr": ""}
+            )(),
         )
-        assert updated["cleanup_state"] == "archived"
+
+        # No registry entry for this worktree — should not crash
+        wt_mod.archive_worktree(
+            "/tmp/unregistered-wt",
+            runtime_dir,
+            events_dir=runtime_dir / "events",
+        )


### PR DESCRIPTION
## Plan
N/A — steward review batch fixes from PR #892

## Summary
- **892-M2 (CRITICAL):** `quarantine_worktree()` now captures untracked files via `git ls-files --others --exclude-standard` and appends them to the saved diff file
- **892-M4:** `archive_worktree()` now deletes the registry JSON file after successful `git worktree remove`, preventing stale registry accumulation
- **892-M3:** Dry-run dirty accuracy was already fixed in PR #896; existing test locks the behavior

## Why
Steward review of PR #892 identified 3 safety gaps in the ops worktree lifecycle code. The quarantine gap (892-M2) was rated CRITICAL because untracked files were silently lost during quarantine, meaning data could be irrecoverably dropped.

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/test_ops_worktrees.py -v` (39 passed)
- `make check-quiet` (all checks passed)

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_worktrees.py -v`
- [x] `make check-quiet`
- 4 new tests:
  - `test_quarantine_captures_untracked_files` — verifies untracked file listing in diff output
  - `test_quarantine_no_untracked_section_when_clean` — verifies no section when no untracked files
  - `test_archive_cleans_registry_entry` — verifies registry JSON deleted, unrelated entries survive
  - `test_archive_no_crash_without_registry_entry` — verifies archive works without registry entry

## Expected impact
- Metrics impact: None
- Runtime impact: One additional `git ls-files` subprocess call per quarantine (negligible)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a8b0e5d1
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a8b0e5d1
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a8b0e5d1  33a239d [fix/worktree-safety]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)