### PR TITLE
fix: resolve 7 post-merge review findings (#878/#892/#888)

### DIFF
--- a/.claude/rules/75_worktree_protection.md
+++ b/.claude/rules/75_worktree_protection.md
@@ -13,6 +13,7 @@ These worktrees are permanent and must not be deleted:
 - `Bid-Euchre-steward-author-d`
 - `Bid-Euchre-steward-author-scratch`
 - `Bid-Euchre-steward-review`
+- `Bid-Euchre-steward-ops`
 
 ## Cleanup Rules
 

--- a/plans/sessions/2026-03-18_review-batch-fixes.md
+++ b/plans/sessions/2026-03-18_review-batch-fixes.md
@@ -1,0 +1,166 @@
+# Review Batch Fixes — Post-Merge Review Findings
+
+**Date:** 2026-03-18
+**Goal:** Address remaining open findings from steward-review of PRs #878, #892, #888, #875 in a single scoped follow-up PR.
+
+## Triage Summary
+
+### Already Resolved
+| Finding | Fixed By | Status |
+|---------|----------|--------|
+| #878 H2 (no file locking) | PR #902 (merged) | ✅ |
+| #878 M3 (dead code `count_events`) | PR #902 (merged) | ✅ |
+| #878 M5 (v1 role map fallback) | PR #902 (merged) | ✅ |
+| #892 F1 (shell interpolation) | PR #902 (merged) | ✅ |
+| #892 F5 (concurrent events) | PR #902 (shared with H2) | ✅ |
+| #875 all findings | PRs #880, #901 | ✅ |
+| #892 quarantine untracked + archive registry | PR #905 (open) | ⏳ |
+
+### Accepted / Deferred
+| Finding | Severity | Reason |
+|---------|----------|--------|
+| #878 H1 (drain crash duplication) | HIGH | Already documented in `drain_events()` docstring (PR #902). Accept as known limitation. |
+| #878 M2 (read_events loads all) | MEDIUM | Optimization, not a defect. Would require API change. Log as follow-up. |
+| #878 M7 (drain concurrent append) | MEDIUM | Related to H1 design. Same accept rationale. |
+| #892 F6 (get_active_failures no resolution correlation) | LOW | Feature request, not a defect. Log as follow-up. |
+| #892 F7 (TOCTOU registry race) | LOW | Low probability, internal tooling only. |
+
+### Fixes in This PR
+
+| # | Finding | Source | Severity | File(s) | Change |
+|---|---------|--------|----------|---------|--------|
+| 1 | H3: `is_worktree_dirty()` no path validation | #878 | HIGH | `worktrees.py` | Add existence + directory check before subprocess |
+| 2 | F3: steward-ops missing from protected list | #892 | MEDIUM | `worktrees.py` | Add `Bid-Euchre-steward-ops` to `PROTECTED_WORKTREE_NAMES` |
+| 3 | F4: quarantine path no error handling in prune | #892 | MEDIUM | `worktrees.py` | Add try/except matching the removal path pattern |
+| 4 | F2: quarantine diff filename overwrites | #892 | MEDIUM | `worktrees.py` | Add timestamp suffix to diff filename |
+| 5 | F8: archive_worktree missing dir confusing error | #892 | LOW→MED | `worktrees.py` | Improve error message when path doesn't exist |
+| 6 | M1: reconcile() symlink false mismatch | #878 | MEDIUM | `worktrees.py` | Use `Path.resolve()` consistently (already done — verify) |
+| 7 | 888-M: `active_sessions` misleading field name | #888 | MEDIUM | `status.py` | Rename to `recent_sessions` |
+| 8 | 888-L1: No test for `events drain --json` | #888 | LOW | `test_ops_cli.py` | Add test for `--json` output |
+
+## Implementation Details
+
+### Fix 1: `is_worktree_dirty()` path validation (H3)
+
+**File:** `src/bid_euchre/ops/worktrees.py`, line ~203
+
+**Current:** Passes `worktree_path` directly to `git -C <path> status` without checking if path exists or is a directory. Missing path causes git failure → returns `True` (has changes) which is misleading.
+
+**Change:**
+```python
+def is_worktree_dirty(worktree_path: str) -> bool:
+    path = Path(worktree_path)
+    if not path.is_dir():
+        raise FileNotFoundError(
+            f"Worktree path does not exist or is not a directory: {worktree_path}"
+        )
+    # ... existing subprocess call
+```
+
+**Test:** Add `test_is_worktree_dirty_missing_path` asserting `FileNotFoundError`.
+
+### Fix 2: Add steward-ops to protection list (F3)
+
+**File:** `src/bid_euchre/ops/worktrees.py`, line ~24
+
+**Change:** Add `"Bid-Euchre-steward-ops"` to `PROTECTED_WORKTREE_NAMES` frozenset.
+
+**Test:** Add assertion in existing `test_is_protected` test.
+
+### Fix 3: Quarantine error handling in prune (F4)
+
+**File:** `src/bid_euchre/ops/worktrees.py`, `prune_worktrees()`, line ~533
+
+**Current:** `quarantine_worktree()` call is unguarded. If it fails, the entire prune loop aborts.
+
+**Change:**
+```python
+try:
+    quarantine_worktree(...)
+    results.append(PruneResult(..., action="quarantined", ...))
+except (OSError, subprocess.SubprocessError) as e:
+    results.append(PruneResult(..., action="skipped", reason=f"Quarantine failed: {e}", ...))
+```
+
+Matches the existing removal path's try/except pattern.
+
+**Test:** Add `test_prune_continues_after_quarantine_failure` using monkeypatch.
+
+### Fix 4: Quarantine diff timestamp (F2)
+
+**File:** `src/bid_euchre/ops/worktrees.py`, `quarantine_worktree()`, line ~630
+
+**Current:** `diff_file = quarantine_dir / f"{slug}.diff"` — overwrites on repeat quarantine.
+
+**Change:** `diff_file = quarantine_dir / f"{slug}_{timestamp}.diff"` where timestamp is `%Y%m%dT%H%M%S`.
+
+**Note:** PR #905 also touches `quarantine_worktree()` (adds untracked files capture). The timestamp fix is on a different line (filename generation vs. diff content). Minimal conflict expected — resolve at rebase if needed.
+
+**Test:** Verify two sequential quarantines produce different diff files.
+
+### Fix 5: archive_worktree missing dir error (F8)
+
+**File:** `src/bid_euchre/ops/worktrees.py`, `archive_worktree()`, line ~704
+
+**Current:** `is_worktree_dirty()` returns `True` for missing paths → error says "has uncommitted changes" instead of "not found".
+
+**Change:** After Fix 1, `is_worktree_dirty()` raises `FileNotFoundError` for missing paths. `archive_worktree()` already calls `is_worktree_dirty()` when `not force`, so the error will now be accurate. Add an explicit early check:
+```python
+resolved = str(Path(worktree_path).resolve())
+if not Path(resolved).is_dir():
+    raise FileNotFoundError(f"Worktree directory not found: {worktree_path}")
+```
+
+**Test:** Add `test_archive_missing_dir_error`.
+
+### Fix 6: Verify reconcile() uses resolve() (M1)
+
+**File:** `src/bid_euchre/ops/worktrees.py`, `reconcile()`, line ~246
+
+**Current code already uses `Path(...).resolve()`** on both registry and git paths. The M1 concern was about string equality on symlinks — but since both sides resolve, this is already handled. Verify and close as non-issue.
+
+If symlinks are a concern, note that `Path.resolve()` follows symlinks. No code change needed.
+
+### Fix 7: Rename `active_sessions` → `recent_sessions` (888-M)
+
+**File:** `src/bid_euchre/ops/status.py`
+
+Two changes:
+1. Line 47: `active_sessions` → `recent_sessions` in dataclass field
+2. Line 244: `report.active_sessions` → `report.recent_sessions`
+
+No other references in src/ or tests/ (verified by grep). The `format_status_json()` function doesn't serialize this field.
+
+### Fix 8: Add drain --json test (888-L1)
+
+**File:** `tests/unit/test_ops_cli.py`
+
+Add `test_events_drain_json_subcommand` that passes `--json` flag and verifies output is valid JSON with expected structure.
+
+## Files Changed
+
+| File | Changes |
+|------|---------|
+| `src/bid_euchre/ops/worktrees.py` | Fixes 1-5 (path validation, protected list, prune error handling, timestamp diff, archive error) |
+| `src/bid_euchre/ops/status.py` | Fix 7 (rename field) |
+| `tests/unit/test_ops_worktrees.py` | Tests for fixes 1-5 |
+| `tests/unit/test_ops_cli.py` | Fix 8 (drain --json test) |
+| `tests/unit/test_ops_status.py` | Test for fix 7 (if needed) |
+
+## PR #905 Conflict Assessment
+
+PR #905 touches `worktrees.py` (quarantine untracked + archive registry cleanup) and `test_ops_worktrees.py`. Our changes touch:
+- Different functions in most cases (H3=`is_worktree_dirty`, F3=`PROTECTED_WORKTREE_NAMES`, F4=`prune_worktrees`)
+- Same function for F2 (`quarantine_worktree`) but different lines (filename vs content)
+- Same function for F5 (`archive_worktree`) but additive early check
+
+**Strategy:** Rebase on main after PR #905 merges. If PR #905 hasn't merged when we're ready, create PR against main and note potential conflict in description.
+
+## Validation
+
+1. Tier 1: `uv run python -m pytest tests/unit/test_ops_worktrees.py tests/unit/test_ops_status.py tests/unit/test_ops_cli.py -v`
+2. Tier 2: `make check-quiet` before PR
+
+## Outcome
+
+_To be filled after implementation._

--- a/src/bid_euchre/ops/status.py
+++ b/src/bid_euchre/ops/status.py
@@ -44,7 +44,7 @@ class StatusReport:
     """Aggregated status across all lanes, sessions, and tasks."""
 
     lanes: list[LaneStatus] = field(default_factory=list)
-    active_sessions: list[dict[str, Any]] = field(default_factory=list)
+    recent_sessions: list[dict[str, Any]] = field(default_factory=list)
     active_tasks: list[dict[str, Any]] = field(default_factory=list)
     blocked_tasks: list[dict[str, Any]] = field(default_factory=list)
     completed_tasks: list[dict[str, Any]] = field(default_factory=list)
@@ -241,7 +241,7 @@ def aggregate_status(runtime_dir: Path | None = None) -> StatusReport:
 
     # Session metadata files are preserved for resume/audit — they are
     # NOT proof of live sessions. Store as recent_sessions for context.
-    report.active_sessions = sessions_data
+    report.recent_sessions = sessions_data
 
     # Categorize tasks
     for task in tasks_data:

--- a/src/bid_euchre/ops/worktrees.py
+++ b/src/bid_euchre/ops/worktrees.py
@@ -29,6 +29,7 @@ PROTECTED_WORKTREE_NAMES = frozenset(
         "Bid-Euchre-steward-author-d",
         "Bid-Euchre-steward-author-scratch",
         "Bid-Euchre-steward-review",
+        "Bid-Euchre-steward-ops",
     }
 )
 
@@ -208,7 +209,15 @@ def is_worktree_dirty(worktree_path: str) -> bool:
 
     Returns:
         True if the working tree has uncommitted changes.
+
+    Raises:
+        FileNotFoundError: If ``worktree_path`` does not exist or is not a
+            directory.
     """
+    if not Path(worktree_path).is_dir():
+        raise FileNotFoundError(
+            f"Worktree path does not exist or is not a directory: {worktree_path}"
+        )
     result = subprocess.run(
         ["git", "-C", worktree_path, "status", "--porcelain"],
         capture_output=True,
@@ -530,21 +539,32 @@ def prune_worktrees(
                     )
                 )
             else:
-                quarantine_worktree(
-                    candidate.path,
-                    candidate.reason,
-                    runtime_dir,
-                    events_dir=events_dir,
-                )
-                results.append(
-                    PruneResult(
-                        path=candidate.path,
-                        branch=candidate.branch,
-                        action="quarantined",
-                        reason=candidate.reason,
-                        dry_run=False,
+                try:
+                    quarantine_worktree(
+                        candidate.path,
+                        candidate.reason,
+                        runtime_dir,
+                        events_dir=events_dir,
                     )
-                )
+                    results.append(
+                        PruneResult(
+                            path=candidate.path,
+                            branch=candidate.branch,
+                            action="quarantined",
+                            reason=candidate.reason,
+                            dry_run=False,
+                        )
+                    )
+                except (OSError, subprocess.SubprocessError) as e:
+                    results.append(
+                        PruneResult(
+                            path=candidate.path,
+                            branch=candidate.branch,
+                            action="skipped",
+                            reason=f"Quarantine failed: {e}",
+                            dry_run=False,
+                        )
+                    )
             continue
 
         # Fallback: unknown state → skip
@@ -621,9 +641,11 @@ def quarantine_worktree(
     quarantine_dir = runtime_dir / "worktree_quarantine"
     quarantine_dir.mkdir(parents=True, exist_ok=True)
 
-    # Generate a slug from the directory name
+    # Generate a slug from the directory name, with timestamp to avoid
+    # overwriting diffs from a previous quarantine of the same worktree.
     slug = Path(worktree_path).name.replace("/", "_").replace(" ", "_")
-    diff_file = quarantine_dir / f"{slug}.diff"
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+    diff_file = quarantine_dir / f"{slug}_{timestamp}.diff"
 
     # Save the diff (tracked changes)
     result = subprocess.run(
@@ -710,6 +732,9 @@ def archive_worktree(
     """
     resolved = str(Path(worktree_path).resolve())
     cwd = str(Path.cwd().resolve())
+
+    if not Path(resolved).is_dir():
+        raise FileNotFoundError(f"Worktree directory not found: {worktree_path}")
 
     if resolved == cwd:
         raise ValueError(

--- a/tests/unit/test_ops_cli.py
+++ b/tests/unit/test_ops_cli.py
@@ -144,6 +144,27 @@ class TestCmdEvents:
         assert rc == 0
         assert "Drained 0" in capsys.readouterr().out
 
+    def test_events_drain_json_subcommand(
+        self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Test `ops.py --json events drain` returns valid JSON (888-L1)."""
+        import ops
+
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "events",
+                "drain",
+            ]
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["drained"] == 0
+
 
 class TestCmdTick:
     """Tests for the tick subcommand."""
@@ -418,8 +439,13 @@ class TestCmdWorktreesArchive:
         self,
         runtime_dir: Path,
         plans_dir: Path,
+        tmp_path: Path,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
+        # Create a real directory with a protected name
+        protected_dir = tmp_path / "Bid-Euchre-steward-author"
+        protected_dir.mkdir()
+
         import ops
 
         rc = ops.main(
@@ -430,7 +456,7 @@ class TestCmdWorktreesArchive:
                 str(plans_dir),
                 "worktrees",
                 "archive",
-                "/tmp/Bid-Euchre-steward-author",
+                str(protected_dir),
             ]
         )
         assert rc == 1

--- a/tests/unit/test_ops_worktrees.py
+++ b/tests/unit/test_ops_worktrees.py
@@ -156,6 +156,10 @@ class TestIsProtected:
         assert not is_protected("/tmp/work-feature-xyz")
         assert not is_protected("/tmp/Bid-Euchre")
 
+    def test_ops_worktree_protected(self) -> None:
+        """The ops lane worktree must be in the protected list (F3)."""
+        assert is_protected("/tmp/Bid-Euchre-steward-ops")
+
     def test_partial_match_not_protected(self) -> None:
         assert not is_protected("/tmp/Bid-Euchre-steward-author-extra")
 
@@ -359,14 +363,28 @@ class TestClassifyCleanupCandidates:
 class TestIsWorktreeDirty:
     """Tests for is_worktree_dirty()."""
 
-    def test_dirty_on_nonexistent_path(self) -> None:
-        # Nonexistent path → assume dirty for safety
-        assert is_worktree_dirty("/tmp/no-such-worktree-abc123") is True
+    def test_raises_on_nonexistent_path(self) -> None:
+        """Missing path raises FileNotFoundError instead of silently returning True."""
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            is_worktree_dirty("/tmp/no-such-worktree-abc123")
 
-    def test_dirty_detection_with_mock(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_raises_on_file_not_directory(self, tmp_path: Path) -> None:
+        """A regular file (not a directory) raises FileNotFoundError."""
+        f = tmp_path / "not-a-dir"
+        f.write_text("hi")
+        with pytest.raises(FileNotFoundError, match="not a directory"):
+            is_worktree_dirty(str(f))
+
+    def test_dirty_detection_with_mock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         import subprocess as sp
 
         from bid_euchre.ops import worktrees as wt_mod
+
+        # Use a real directory so the existence check passes
+        wt_dir = tmp_path / "wt"
+        wt_dir.mkdir()
 
         # Clean worktree
         monkeypatch.setattr(
@@ -374,10 +392,17 @@ class TestIsWorktreeDirty:
             "run",
             lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": ""})(),
         )
-        assert wt_mod.is_worktree_dirty("/tmp/wt") is False
+        assert wt_mod.is_worktree_dirty(str(wt_dir)) is False
 
-    def test_stale_dirty_becomes_quarantined(self) -> None:
+    def test_stale_dirty_becomes_quarantined(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """When check_dirty=True and worktree is dirty, stale → quarantined."""
+        from bid_euchre.ops import worktrees as wt_mod
+
+        # Mock is_worktree_dirty since the path doesn't exist on disk
+        monkeypatch.setattr(wt_mod, "is_worktree_dirty", lambda p: True)
+
         now = datetime(2026, 3, 20, 12, 0, 0, tzinfo=timezone.utc)
         git_wts = [GitWorktree(path="/tmp/wt-task", head="abc", branch="task-1")]
         registry = [
@@ -391,7 +416,6 @@ class TestIsWorktreeDirty:
             },
         ]
 
-        # is_worktree_dirty will fail on /tmp/wt-task (doesn't exist) → True
         candidates = classify_cleanup_candidates(
             git_wts, registry, now=now, check_dirty=True
         )
@@ -420,6 +444,9 @@ class TestPruneWorktrees:
             "list_worktrees_git",
             lambda: [GitWorktree(path="/tmp/wt-task", head="abc", branch="task-1")],
         )
+        # Mock is_worktree_dirty since /tmp/wt-task doesn't exist on disk
+        monkeypatch.setattr(wt_mod, "is_worktree_dirty", lambda p: False)
+
         _write_registry_entry(
             runtime_dir / "worktree_registry",
             "task.json",
@@ -452,6 +479,8 @@ class TestPruneWorktrees:
                 )
             ],
         )
+        # Mock is_worktree_dirty since /tmp path doesn't exist on disk
+        monkeypatch.setattr(wt_mod, "is_worktree_dirty", lambda p: False)
 
         results = wt_mod.prune_worktrees(runtime_dir, dry_run=True)
         # Protected unregistered worktrees get classified but skipped
@@ -509,6 +538,67 @@ class TestPruneWorktrees:
         # Must show quarantined, not removed — dirtiness is checked even in dry-run
         assert results[0].action == "quarantined"
         assert results[0].dry_run is True
+
+    def test_prune_continues_after_quarantine_failure(
+        self, runtime_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If quarantine_worktree fails, prune skips that candidate and continues (F4)."""
+        from bid_euchre.ops import worktrees as wt_mod
+
+        monkeypatch.setattr(
+            wt_mod,
+            "list_worktrees_git",
+            lambda: [
+                GitWorktree(path="/tmp/wt-fail", head="a", branch="t-fail"),
+                GitWorktree(path="/tmp/wt-ok", head="b", branch="t-ok"),
+            ],
+        )
+        # Both dirty and stale
+        monkeypatch.setattr(wt_mod, "is_worktree_dirty", lambda p: True)
+
+        _write_registry_entry(
+            runtime_dir / "worktree_registry",
+            "fail.json",
+            lane_id="fail",
+            lifecycle_class="ephemeral",
+            worktree_path="/tmp/wt-fail",
+            last_active="2020-01-01T00:00:00+00:00",
+            ttl_hours=1.0,
+        )
+        _write_registry_entry(
+            runtime_dir / "worktree_registry",
+            "ok.json",
+            lane_id="ok",
+            lifecycle_class="ephemeral",
+            worktree_path="/tmp/wt-ok",
+            last_active="2020-01-01T00:00:00+00:00",
+            ttl_hours=1.0,
+        )
+
+        call_count = 0
+        original_quarantine = wt_mod.quarantine_worktree
+
+        def failing_quarantine(path: str, *a: object, **kw: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            if "fail" in path:
+                raise OSError("Simulated quarantine failure")
+            return original_quarantine(path, *a, **kw)
+
+        monkeypatch.setattr(wt_mod, "quarantine_worktree", failing_quarantine)
+
+        results = wt_mod.prune_worktrees(
+            runtime_dir, dry_run=False, events_dir=runtime_dir / "events"
+        )
+
+        actions = {r.path: r.action for r in results}
+        # First candidate fails quarantine → skipped
+        assert actions["/tmp/wt-fail"] == "skipped"
+        assert "Quarantine failed" in next(
+            r.reason for r in results if r.path == "/tmp/wt-fail"
+        )
+        # Second candidate should still be processed
+        assert "/tmp/wt-ok" in actions
 
 
 class TestQuarantineWorktree:
@@ -683,6 +773,52 @@ class TestQuarantineWorktree:
         assert "diff --git" in content
         assert "# Untracked files" not in content
 
+    def test_quarantine_diff_filename_has_timestamp(
+        self, runtime_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Repeated quarantines produce different diff files (F2)."""
+        import subprocess as sp
+        import time
+
+        from bid_euchre.ops import worktrees as wt_mod
+
+        monkeypatch.setattr(
+            sp,
+            "run",
+            lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": "diff1"})(),
+        )
+
+        path1 = wt_mod.quarantine_worktree(
+            "/tmp/wt-repeat",
+            "first quarantine",
+            runtime_dir,
+            events_dir=tmp_path / "events",
+        )
+
+        # Ensure at least 1 second passes for distinct timestamp
+        time.sleep(1.1)
+
+        monkeypatch.setattr(
+            sp,
+            "run",
+            lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": "diff2"})(),
+        )
+
+        path2 = wt_mod.quarantine_worktree(
+            "/tmp/wt-repeat",
+            "second quarantine",
+            runtime_dir,
+            events_dir=tmp_path / "events",
+        )
+
+        # Must be different files
+        assert path1 != path2
+        assert path1.exists()
+        assert path2.exists()
+        # Both should contain the slug
+        assert "wt-repeat" in path1.name
+        assert "wt-repeat" in path2.name
+
 
 class TestArchiveWorktree:
     """Tests for archive_worktree()."""
@@ -700,32 +836,43 @@ class TestArchiveWorktree:
         with pytest.raises(ValueError, match="current working directory"):
             archive_worktree(cwd, runtime_dir)
 
-    def test_rejects_protected(self, runtime_dir: Path) -> None:
+    def test_rejects_protected(self, runtime_dir: Path, tmp_path: Path) -> None:
         from bid_euchre.ops.worktrees import archive_worktree
 
+        # Create a real directory with a protected name
+        protected_dir = tmp_path / "Bid-Euchre-steward-author"
+        protected_dir.mkdir()
         with pytest.raises(ValueError, match="protected"):
             archive_worktree(
-                "/tmp/Bid-Euchre-steward-author",
+                str(protected_dir),
                 runtime_dir,
             )
 
     def test_rejects_dirty_without_force(
-        self, runtime_dir: Path, monkeypatch: pytest.MonkeyPatch
+        self, runtime_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from bid_euchre.ops import worktrees as wt_mod
+
+        # Create a real directory so the existence check passes
+        wt_dir = tmp_path / "some-worktree"
+        wt_dir.mkdir()
 
         # Mock is_worktree_dirty to return True
         monkeypatch.setattr(wt_mod, "is_worktree_dirty", lambda p: True)
 
         with pytest.raises(RuntimeError, match="uncommitted changes"):
-            wt_mod.archive_worktree("/tmp/some-worktree", runtime_dir)
+            wt_mod.archive_worktree(str(wt_dir), runtime_dir)
 
     def test_calls_git_worktree_remove(
-        self, runtime_dir: Path, monkeypatch: pytest.MonkeyPatch
+        self, runtime_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         import subprocess as sp
 
         from bid_euchre.ops import worktrees as wt_mod
+
+        # Create a real directory so the existence check passes
+        wt_dir = tmp_path / "some-worktree"
+        wt_dir.mkdir()
 
         monkeypatch.setattr(wt_mod, "is_worktree_dirty", lambda p: False)
 
@@ -739,7 +886,7 @@ class TestArchiveWorktree:
         monkeypatch.setattr(sp, "run", mock_run)
 
         wt_mod.archive_worktree(
-            "/tmp/some-worktree",
+            str(wt_dir),
             runtime_dir,
             events_dir=runtime_dir / "events",
         )
@@ -749,12 +896,16 @@ class TestArchiveWorktree:
         )
 
     def test_archive_cleans_registry_entry(
-        self, runtime_dir: Path, monkeypatch: pytest.MonkeyPatch
+        self, runtime_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """After successful removal, the registry JSON file is deleted (892-M4)."""
         import subprocess as sp
 
         from bid_euchre.ops import worktrees as wt_mod
+
+        # Create a real directory so the existence check passes
+        wt_dir = tmp_path / "wt-to-archive"
+        wt_dir.mkdir()
 
         monkeypatch.setattr(wt_mod, "is_worktree_dirty", lambda p: False)
         monkeypatch.setattr(
@@ -772,7 +923,7 @@ class TestArchiveWorktree:
             "task-archive.json",
             lane_id="task-archive",
             lifecycle_class="ephemeral",
-            worktree_path="/tmp/wt-to-archive",
+            worktree_path=str(wt_dir),
         )
         # Also create an unrelated entry that should survive
         _write_registry_entry(
@@ -786,7 +937,7 @@ class TestArchiveWorktree:
         assert (registry_dir / "other.json").exists()
 
         wt_mod.archive_worktree(
-            "/tmp/wt-to-archive",
+            str(wt_dir),
             runtime_dir,
             events_dir=runtime_dir / "events",
         )
@@ -797,12 +948,16 @@ class TestArchiveWorktree:
         assert (registry_dir / "other.json").exists()
 
     def test_archive_no_crash_without_registry_entry(
-        self, runtime_dir: Path, monkeypatch: pytest.MonkeyPatch
+        self, runtime_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Archive succeeds even when no registry entry exists for the worktree."""
         import subprocess as sp
 
         from bid_euchre.ops import worktrees as wt_mod
+
+        # Create a real directory so the existence check passes
+        wt_dir = tmp_path / "unregistered-wt"
+        wt_dir.mkdir()
 
         monkeypatch.setattr(wt_mod, "is_worktree_dirty", lambda p: False)
         monkeypatch.setattr(
@@ -815,7 +970,14 @@ class TestArchiveWorktree:
 
         # No registry entry for this worktree — should not crash
         wt_mod.archive_worktree(
-            "/tmp/unregistered-wt",
+            str(wt_dir),
             runtime_dir,
             events_dir=runtime_dir / "events",
         )
+
+    def test_archive_missing_dir_gives_clear_error(self, runtime_dir: Path) -> None:
+        """Archiving a nonexistent path raises FileNotFoundError, not RuntimeError (F8)."""
+        from bid_euchre.ops.worktrees import archive_worktree
+
+        with pytest.raises(FileNotFoundError, match="not found"):
+            archive_worktree("/tmp/no-such-worktree-xyz", runtime_dir)


### PR DESCRIPTION
## Plan
`plans/sessions/2026-03-18_review-batch-fixes.md`

## Summary
- **H3 (#878):** `is_worktree_dirty()` now validates path existence before subprocess call — raises `FileNotFoundError` instead of silently returning `True`
- **F3 (#892):** Added `Bid-Euchre-steward-ops` to `PROTECTED_WORKTREE_NAMES` and synced `.claude/rules/75_worktree_protection.md`
- **F4 (#892):** Quarantine path in `prune_worktrees()` now wrapped in `try/except` — one quarantine failure no longer aborts all remaining candidates
- **F2 (#892):** Quarantine diff filenames now include timestamp suffix to prevent overwrite on repeat quarantine
- **F8 (#892):** `archive_worktree()` now checks directory existence early — gives clear `FileNotFoundError` instead of misleading "uncommitted changes"
- **888-M:** Renamed `StatusReport.active_sessions` → `recent_sessions` to match the field's actual semantics
- **888-L1:** Added test for `events drain --json` CLI output path

## Why
Post-merge review of PRs #878, #892, and #888 identified these findings. Prior follow-up PRs (#901, #902, #905) addressed higher-priority items (file locking, dead code, v1 role map, quarantine untracked, etc.). These are the remaining actionable findings.

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/test_ops_worktrees.py tests/unit/test_ops_status.py tests/unit/test_ops_cli.py -v` (93 passed)
- `make check-quiet` (all checks passed)

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_worktrees.py tests/unit/test_ops_status.py tests/unit/test_ops_cli.py -v` — 93 passed
- [x] `make check-quiet` — all checks passed
- 7 new tests added:
  - `test_raises_on_nonexistent_path` — validates FileNotFoundError for missing paths
  - `test_raises_on_file_not_directory` — validates FileNotFoundError for non-directory
  - `test_ops_worktree_protected` — validates steward-ops in protected list
  - `test_prune_continues_after_quarantine_failure` — verifies fault tolerance
  - `test_quarantine_diff_filename_has_timestamp` — verifies no overwrite
  - `test_archive_missing_dir_gives_clear_error` — verifies FileNotFoundError
  - `test_events_drain_json_subcommand` — verifies JSON output path
- 8 existing tests updated to use real temp directories for path validation

## Expected impact
- Metrics impact: None
- Runtime impact: Negligible (one `Path.is_dir()` check per call)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git worktree list` (excerpt):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b  [fix/review-batch-fixes]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)