### PR TITLE
fix: address 5 deferred review findings in ops package

### DIFF
--- a/plans/sessions/2026-03-19_deferred-review-findings.md
+++ b/plans/sessions/2026-03-19_deferred-review-findings.md
@@ -1,0 +1,201 @@
+# Deferred Review Findings — Ops Package Hardening
+
+**Date:** 2026-03-19
+**Goal:** Address the 5 deferred findings from the steward review batch (PRs #878, #892) that were triaged out of PR #910.
+**Branch:** `fix/deferred-review-findings` from `origin/main`
+**PR:** One PR for all 5 fixes (same review batch, all ops-internal)
+
+## Context
+
+PR #910 fixed 7 findings. These 5 were deferred with rationale. This session re-evaluates and addresses all of them.
+
+## Execution Groups
+
+- **Group A (events.py):** H1 + M7 → M2. Sequential — same file, H1+M7 coupled.
+- **Group B (recovery.py):** F6. Independent, parallel-ready.
+- **Group C (worktrees.py):** F7. Independent, parallel-ready.
+
+## Refined Findings
+
+### H1+M7: `drain_events()` crash safety + concurrent locking
+
+**File:** `src/bid_euchre/ops/events.py`, lines 170-243
+**Function:** `drain_events(events_dir, *, up_to)`
+
+**Current code flow (lines 205-240):**
+1. L205-224: Open events_file, read all lines, sort into `to_drain`/`to_keep` — NO LOCK
+2. L230-232: Append `to_drain` to `archive_file` — NO LOCK
+3. L236-240: Write `to_keep` to temp file, `rename()` over events_file — NO LOCK
+
+**H1 problem:** If crash between L232 (archive append) and L240 (rename), drained events exist in BOTH archive and active log. Next drain re-archives them → duplicates.
+
+**H1 fix:** Reorder to rename-before-archive-append:
+1. Write temp with `to_keep` events
+2. `rename()` temp over active log (atomic — drained events removed)
+3. Append `to_drain` to archive
+Crash between steps 2 and 3 → drained events removed from active but missing from archive (acceptable — archive is best-effort historical, events are advisory).
+
+**M7 problem:** Between L205 read and L240 rename, a concurrent `append_event()` (which holds flock only for its own write at L99-105) can write a new event to the old active file. The rename replaces it → new event lost.
+
+**M7 fix:** Hold `fcntl.flock(LOCK_EX)` on events_file for the entire drain cycle (read → filter → write temp → rename → archive append). This serializes drain with concurrent appends since `append_event()` already acquires `LOCK_EX`.
+
+**Combined implementation:**
+```python
+def drain_events(events_dir, *, up_to=None):
+    # ... setup ...
+    with open(events_file, "r+") as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        try:
+            # Read and classify
+            for line in f: ...
+
+            if not to_drain: return 0
+
+            # 1. Write remaining to temp (while holding lock)
+            tmp_file = events_file.with_suffix(".tmp")
+            with open(tmp_file, "w") as tmp:
+                for line in to_keep: tmp.write(line + "\n")
+
+            # 2. Atomic rename (removes drained from active)
+            tmp_file.rename(events_file)
+
+            # 3. Append drained to archive (best-effort)
+            with open(archive_file, "a") as af:
+                for line in to_drain: af.write(line + "\n")
+        finally:
+            fcntl.flock(f, fcntl.LOCK_UN)
+```
+
+**Edge cases:**
+- Empty log: returns 0 early (before lock acquisition via exists() check)
+- File exists but empty: flock succeeds, no lines → returns 0
+- `up_to` partial drain: only matching events drained, rest kept
+- Archive file doesn't exist: `open("a")` creates it
+
+**Tests:**
+- `test_drain_atomic_rename_before_archive`: Verify drain order by checking archive has events after rename
+- `test_drain_holds_lock_during_operation`: Use thread to try concurrent append during drain
+
+### M2: `read_events()` memory optimization
+
+**File:** `src/bid_euchre/ops/events.py`, lines 111-167
+**Function:** `read_events(events_dir, *, since, event_type, lane_id, limit)`
+
+**Current code (lines 138-167):**
+```python
+events: list[dict] = []
+with open(events_file) as f:
+    for line in f:
+        # ... parse and filter ...
+        events.append(event)
+events.reverse()
+return events[:limit]
+```
+Loads ALL matching events, reverses, then slices. O(N) memory for N total matching events.
+
+**Fix:** Use `collections.deque(maxlen=limit)` to keep only the last `limit` matching events during iteration. Then reverse the deque for most-recent-first output. O(limit) memory.
+
+```python
+from collections import deque
+
+matched: deque[dict] = deque(maxlen=limit)
+with open(events_file) as f:
+    for line in f:
+        # ... parse and filter ...
+        matched.append(event)
+result = list(matched)
+result.reverse()
+return result
+```
+
+**Behavioral change:** None. Same output, less memory. Existing tests pass unchanged.
+
+**Tests:**
+- Existing `test_limit` already validates the behavior. No new test needed — purely an optimization.
+
+### F6: `get_active_failures()` resolution correlation
+
+**File:** `src/bid_euchre/ops/recovery.py`, lines 165-193
+**Function:** `get_active_failures(events_dir, *, limit)`
+
+**Current code (lines 187-192):**
+```python
+for event in events:
+    event_type = event.get("event_type", "")
+    if event_type in _FAILURE_EVENT_TYPES:
+        failures.append(classify_failure(event))
+```
+No resolution check — ALL failure events returned as "active."
+
+**Fix:** Define resolution map and walk events newest-first:
+
+```python
+# New module-level constant
+_RESOLUTION_MAP: dict[str, frozenset[str]] = {
+    "ci_success": frozenset({"ci_failure"}),
+    "task_completed": frozenset({"task_failed", "task_blocked"}),
+    "heartbeat_ok": frozenset({"heartbeat_stale"}),
+    "worktree_archived": frozenset({"worktree_quarantined"}),
+    "recovery_action": frozenset({"escalation"}),
+}
+
+def _resolution_target(event: dict) -> str:
+    payload = event.get("payload", {})
+    return str(payload.get("target", event.get("lane_id", "unknown")))
+```
+
+Algorithm (events are newest-first from `read_events`):
+1. See resolution event → mark `(failure_type, target)` as resolved
+2. See failure event → only include if `(event_type, target)` NOT resolved
+
+**Tests:**
+- `test_resolved_failure_excluded`: ci_failure + ci_success for same target → 0 active
+- `test_newer_failure_after_resolution_still_active`: ci_success + ci_failure (newer) → 1 active
+- `test_different_target_not_resolved`: ci_failure(PR#1) + ci_success(PR#2) → 1 active
+- `test_multiple_resolution_types`: task_failed + task_completed → resolved
+
+### F7: `_update_registry_cleanup_state()` TOCTOU race
+
+**File:** `src/bid_euchre/ops/worktrees.py`, lines 584-620
+**Function:** `_update_registry_cleanup_state(registry_dir, worktree_path, cleanup_state)`
+
+**Current code (lines 607-616):**
+```python
+for f in sorted(registry_dir.glob("*.json")):
+    try:
+        data = json.loads(f.read_text())  # READ
+    except ...: continue
+    if ...:
+        data["cleanup_state"] = cleanup_state
+        f.write_text(json.dumps(data, indent=2))  # WRITE
+```
+Read and write are separate operations with no lock. Concurrent writes can overwrite each other.
+
+**Fix:** Use `open("r+")` with `fcntl.flock()`:
+```python
+import fcntl
+
+for json_path in sorted(registry_dir.glob("*.json")):
+    try:
+        with open(json_path, "r+") as fh:
+            fcntl.flock(fh, fcntl.LOCK_EX)
+            try:
+                data = json.loads(fh.read())
+                if match:
+                    data["cleanup_state"] = cleanup_state
+                    fh.seek(0)
+                    fh.truncate()
+                    fh.write(json.dumps(data, indent=2))
+                    return True
+            finally:
+                fcntl.flock(fh, fcntl.LOCK_UN)
+    except ...: continue
+```
+
+**Tests:**
+- Existing `test_quarantine_persists_cleanup_state` validates the behavior end-to-end
+- New: `test_update_registry_cleanup_state_writes_atomically`: Verify file is valid JSON after update
+
+## Outcome
+
+_To be filled after implementation._

--- a/src/bid_euchre/ops/events.py
+++ b/src/bid_euchre/ops/events.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import fcntl
 import json
 import logging
+from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -135,7 +136,9 @@ def read_events(
     if not events_file.exists():
         return []
 
-    events: list[dict[str, Any]] = []
+    # Use a bounded deque to keep only the last `limit` matching events,
+    # avoiding O(N) memory for the full log when limit is small (M2).
+    matched: deque[dict[str, Any]] = deque(maxlen=limit)
     with open(events_file) as f:
         for line in f:
             line = line.strip()
@@ -160,11 +163,12 @@ def read_events(
                 except (KeyError, ValueError):
                     continue
 
-            events.append(event)
+            matched.append(event)
 
-    # Most recent first, capped at limit
-    events.reverse()
-    return events[:limit]
+    # Most recent first
+    result = list(matched)
+    result.reverse()
+    return result
 
 
 def drain_events(
@@ -177,11 +181,17 @@ def drain_events(
     Moves events with timestamps <= ``up_to`` from the active log to
     the archive file. If ``up_to`` is None, drains all events.
 
-    Note:
-        If the process crashes between archive append and active log rewrite,
-        drained events may appear in both files on next read. This is acceptable
-        because (a) events are advisory, not transactional, and (b) consumers
-        should be idempotent. The alternative (data loss) is worse.
+    Crash safety (H1):
+        The active log is updated via atomic rename *before* archive append.
+        If a crash occurs between rename and archive append, drained events
+        are removed from the active log but missing from the archive. This
+        is acceptable because (a) events are advisory, not transactional,
+        and (b) the archive is best-effort historical storage.
+
+    Concurrency (M7):
+        An exclusive ``fcntl.flock()`` is held for the entire
+        read→filter→rename→archive cycle, serializing drain with concurrent
+        ``append_event()`` calls that acquire the same lock.
 
     Args:
         events_dir: Override for events directory.
@@ -202,42 +212,51 @@ def drain_events(
     to_drain: list[str] = []
     to_keep: list[str] = []
 
-    with open(events_file) as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
+    # Hold exclusive lock for the entire drain cycle to prevent concurrent
+    # append_event() calls from writing to the old file between read and rename.
+    with open(events_file, "r+") as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        try:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
 
-            if up_to is None:
-                to_drain.append(line)
-                continue
-
-            try:
-                event = json.loads(line)
-                event_time = datetime.fromisoformat(event["timestamp"])
-                if event_time <= up_to:
+                if up_to is None:
                     to_drain.append(line)
-                else:
+                    continue
+
+                try:
+                    event = json.loads(line)
+                    event_time = datetime.fromisoformat(event["timestamp"])
+                    if event_time <= up_to:
+                        to_drain.append(line)
+                    else:
+                        to_keep.append(line)
+                except (json.JSONDecodeError, KeyError, ValueError):
+                    # Keep malformed lines in active log
                     to_keep.append(line)
-            except (json.JSONDecodeError, KeyError, ValueError):
-                # Keep malformed lines in active log
-                to_keep.append(line)
 
-    if not to_drain:
-        return 0
+            if not to_drain:
+                return 0
 
-    # Append drained events to archive
-    with open(archive_file, "a") as f:
-        for line in to_drain:
-            f.write(line + "\n")
+            # 1. Write remaining events to temp file (while holding lock)
+            tmp_file = events_file.with_suffix(".tmp")
+            with open(tmp_file, "w") as tmp:
+                for line in to_keep:
+                    tmp.write(line + "\n")
 
-    # Atomically rewrite active log with remaining events.
-    # Write to a temp file first, then rename to avoid data loss on crash.
-    tmp_file = events_file.with_suffix(".tmp")
-    with open(tmp_file, "w") as f:
-        for line in to_keep:
-            f.write(line + "\n")
-    tmp_file.rename(events_file)
+            # 2. Atomic rename: removes drained events from active log.
+            #    Done BEFORE archive append so crash can only lose archive
+            #    entries (best-effort), never duplicate them.
+            tmp_file.rename(events_file)
+
+            # 3. Append drained events to archive (best-effort historical)
+            with open(archive_file, "a") as af:
+                for line in to_drain:
+                    af.write(line + "\n")
+        finally:
+            fcntl.flock(f, fcntl.LOCK_UN)
 
     logger.info("Drained %d events to archive", len(to_drain))
     return len(to_drain)

--- a/src/bid_euchre/ops/recovery.py
+++ b/src/bid_euchre/ops/recovery.py
@@ -129,6 +129,16 @@ _FAILURE_EVENT_TYPES = frozenset(
     }
 )
 
+# Maps resolution event types to the failure types they resolve.
+# Used by get_active_failures() to exclude resolved failures.
+_RESOLUTION_MAP: dict[str, frozenset[str]] = {
+    "ci_success": frozenset({"ci_failure"}),
+    "task_completed": frozenset({"task_failed", "task_blocked"}),
+    "heartbeat_ok": frozenset({"heartbeat_stale"}),
+    "worktree_archived": frozenset({"worktree_quarantined"}),
+    "recovery_action": frozenset({"escalation"}),
+}
+
 
 def classify_failure(event: dict[str, Any]) -> FailureClassification:
     """Classify a single event into a failure with recovery guidance.
@@ -162,33 +172,66 @@ def classify_failure(event: dict[str, Any]) -> FailureClassification:
     )
 
 
+def _resolution_target(event: dict[str, Any]) -> str:
+    """Extract the resolution-matching target from an event.
+
+    Uses ``payload.target`` if present, falling back to ``lane_id``.
+    This key is used to correlate failure events with their resolutions.
+    """
+    payload = event.get("payload", {})
+    return str(payload.get("target", event.get("lane_id", "unknown")))
+
+
 def get_active_failures(
     events_dir: Path,
     *,
     limit: int = 50,
 ) -> list[FailureClassification]:
-    """Read recent events and return those that need attention.
+    """Read recent events and return only unresolved failures.
 
-    Only returns events matching failure types (CI failures, blocked tasks,
-    stale heartbeats, etc.). Resolution events (ci_success, task_completed)
-    are not included.
+    Scans recent events (newest-first) and correlates failure events with
+    resolution events by target. A failure is considered resolved when a
+    matching resolution event (e.g., ``ci_success`` for ``ci_failure``)
+    exists with a later timestamp for the same target.
+
+    Resolution pairs (defined in ``_RESOLUTION_MAP``):
+    - ``ci_failure`` ← ``ci_success``
+    - ``task_failed`` / ``task_blocked`` ← ``task_completed``
+    - ``heartbeat_stale`` ← ``heartbeat_ok``
+    - ``worktree_quarantined`` ← ``worktree_archived``
+    - ``escalation`` ← ``recovery_action``
 
     Args:
         events_dir: Path to the events directory.
         limit: Maximum number of events to scan.
 
     Returns:
-        List of FailureClassification objects, most recent first.
+        List of FailureClassification objects for unresolved failures,
+        most recent first.
     """
     from bid_euchre.ops.events import read_events
 
     events = read_events(events_dir, limit=limit)
 
+    # Walk events newest-first. Resolution events mark (failure_type, target)
+    # as resolved. Only failure events whose key is NOT resolved are returned.
+    resolved_keys: set[tuple[str, str]] = set()
     failures: list[FailureClassification] = []
+
     for event in events:
         event_type = event.get("event_type", "")
+        target = _resolution_target(event)
+
+        # If this is a resolution event, mark the corresponding failure
+        # types as resolved for this target.
+        resolved_failure_types = _RESOLUTION_MAP.get(event_type, frozenset())
+        for ft in resolved_failure_types:
+            resolved_keys.add((ft, target))
+
+        # If this is a failure event, only include if not yet resolved.
         if event_type in _FAILURE_EVENT_TYPES:
-            failures.append(classify_failure(event))
+            if (event_type, target) not in resolved_keys:
+                failures.append(classify_failure(event))
 
     return failures
 

--- a/src/bid_euchre/ops/worktrees.py
+++ b/src/bid_euchre/ops/worktrees.py
@@ -7,6 +7,7 @@ or unregistered worktrees.
 
 from __future__ import annotations
 
+import fcntl
 import json
 import logging
 import subprocess
@@ -604,18 +605,28 @@ def _update_registry_cleanup_state(
 
     resolved = str(Path(worktree_path).resolve())
 
-    for f in sorted(registry_dir.glob("*.json")):
+    for json_path in sorted(registry_dir.glob("*.json")):
         try:
-            data = json.loads(f.read_text())
+            with open(json_path, "r+") as fh:
+                fcntl.flock(fh, fcntl.LOCK_EX)
+                try:
+                    data = json.loads(fh.read())
+                    entry_path = data.get("worktree_path", "")
+                    if entry_path and str(Path(entry_path).resolve()) == resolved:
+                        data["cleanup_state"] = cleanup_state
+                        fh.seek(0)
+                        fh.truncate()
+                        fh.write(json.dumps(data, indent=2))
+                        logger.info(
+                            "Updated registry %s: cleanup_state=%s",
+                            json_path.name,
+                            cleanup_state,
+                        )
+                        return True
+                finally:
+                    fcntl.flock(fh, fcntl.LOCK_UN)
         except (json.JSONDecodeError, OSError):
             continue
-
-        entry_path = data.get("worktree_path", "")
-        if entry_path and str(Path(entry_path).resolve()) == resolved:
-            data["cleanup_state"] = cleanup_state
-            f.write_text(json.dumps(data, indent=2))
-            logger.info("Updated registry %s: cleanup_state=%s", f.name, cleanup_state)
-            return True
 
     return False
 

--- a/tests/unit/test_ops_events.py
+++ b/tests/unit/test_ops_events.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import json
+import threading
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
 
 from bid_euchre.ops.events import (
+    ARCHIVE_FILE,
     EVENTS_FILE,
     VALID_EVENT_TYPES,
     append_event,
@@ -225,3 +228,90 @@ class TestDrainEvents:
 
     def test_drain_nonexistent_dir(self, tmp_path: Path) -> None:
         assert drain_events(tmp_path / "no_such") == 0
+
+    def test_drain_archive_written_after_active_rename(self, events_dir: Path) -> None:
+        """Archive append happens AFTER active log rename (H1 crash safety).
+
+        Verify that after drain, the active log contains only kept events
+        and archive contains only drained events — no duplication.
+        """
+        events_file = events_dir / EVENTS_FILE
+        now = datetime.now(timezone.utc)
+        old = now - timedelta(hours=2)
+
+        # Write 2 old events (will be drained) and 1 recent (will be kept)
+        for ts in [old, old + timedelta(minutes=1), now]:
+            event = {
+                "timestamp": ts.isoformat(),
+                "event_type": "task_completed",
+                "source": "test",
+                "lane_id": "ops",
+                "payload": {"ts": ts.isoformat()},
+            }
+            with open(events_file, "a") as f:
+                f.write(json.dumps(event) + "\n")
+
+        cutoff = now - timedelta(hours=1)
+        drained = drain_events(events_dir, up_to=cutoff)
+        assert drained == 2
+
+        # Active log should have exactly 1 event (the recent one)
+        remaining = read_events(events_dir)
+        assert len(remaining) == 1
+
+        # Archive should have exactly 2 events
+        archive = events_dir / ARCHIVE_FILE
+        assert archive.exists()
+        archive_lines = [
+            l for l in archive.read_text().strip().split("\n") if l.strip()
+        ]
+        assert len(archive_lines) == 2
+
+    def test_drain_serializes_with_concurrent_append(self, events_dir: Path) -> None:
+        """drain_events() holds lock, preventing concurrent append loss (M7).
+
+        Appends that start during drain must complete after drain releases
+        the lock, ensuring the appended event survives.
+        """
+        # Write initial events
+        for i in range(3):
+            append_event("task_completed", "test", "ops", {"i": i}, events_dir)
+
+        drain_started = threading.Event()
+        drain_done = threading.Event()
+        append_done = threading.Event()
+
+        def do_drain() -> None:
+            drain_started.set()
+            drain_events(events_dir)
+            drain_done.set()
+
+        def do_append() -> None:
+            # Wait for drain to start, then try appending
+            drain_started.wait(timeout=5)
+            # Small delay to let drain acquire lock
+            time.sleep(0.05)
+            append_event(
+                "ci_failure", "concurrent", "ops", {"concurrent": True}, events_dir
+            )
+            append_done.set()
+
+        t1 = threading.Thread(target=do_drain)
+        t2 = threading.Thread(target=do_append)
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+        assert drain_done.is_set(), "drain should complete"
+        assert append_done.is_set(), "append should complete"
+
+        # The concurrent append should survive (written to the new active log
+        # after drain released the lock and renamed the file).
+        remaining = read_events(events_dir)
+        assert len(remaining) >= 1
+        # At least the concurrent event should be present
+        concurrent_events = [
+            e for e in remaining if e.get("payload", {}).get("concurrent") is True
+        ]
+        assert len(concurrent_events) == 1

--- a/tests/unit/test_ops_recovery.py
+++ b/tests/unit/test_ops_recovery.py
@@ -143,7 +143,7 @@ class TestGetActiveFailures:
             json.dumps(
                 {
                     "timestamp": "2026-03-18T10:01:00Z",
-                    "event_type": "ci_success",
+                    "event_type": "session_started",
                     "source": "hook",
                     "lane_id": "author-a",
                     "payload": {},
@@ -165,6 +165,200 @@ class TestGetActiveFailures:
         assert len(failures) == 2
         types = {f.failure_type for f in failures}
         assert types == {"ci_failure", "task_blocked"}
+
+    def test_resolved_failure_excluded(self, events_dir: Path) -> None:
+        """ci_failure followed by ci_success for same target → resolved (F6)."""
+        events_file = events_dir / "events.jsonl"
+        lines = [
+            json.dumps(
+                {
+                    "timestamp": "2026-03-18T10:00:00Z",
+                    "event_type": "ci_failure",
+                    "source": "hook",
+                    "lane_id": "author-a",
+                    "payload": {"details": "lint failed"},
+                }
+            ),
+            json.dumps(
+                {
+                    "timestamp": "2026-03-18T10:05:00Z",
+                    "event_type": "ci_success",
+                    "source": "hook",
+                    "lane_id": "author-a",
+                    "payload": {},
+                }
+            ),
+        ]
+        events_file.write_text("\n".join(lines) + "\n")
+
+        failures = get_active_failures(events_dir)
+        assert len(failures) == 0
+
+    def test_newer_failure_after_resolution_still_active(
+        self, events_dir: Path
+    ) -> None:
+        """ci_success then ci_failure (newer) → failure is active (F6)."""
+        events_file = events_dir / "events.jsonl"
+        lines = [
+            json.dumps(
+                {
+                    "timestamp": "2026-03-18T10:00:00Z",
+                    "event_type": "ci_success",
+                    "source": "hook",
+                    "lane_id": "author-a",
+                    "payload": {},
+                }
+            ),
+            json.dumps(
+                {
+                    "timestamp": "2026-03-18T10:05:00Z",
+                    "event_type": "ci_failure",
+                    "source": "hook",
+                    "lane_id": "author-a",
+                    "payload": {"details": "test failed"},
+                }
+            ),
+        ]
+        events_file.write_text("\n".join(lines) + "\n")
+
+        failures = get_active_failures(events_dir)
+        assert len(failures) == 1
+        assert failures[0].failure_type == "ci_failure"
+
+    def test_different_target_not_resolved(self, events_dir: Path) -> None:
+        """ci_failure(PR#1) + ci_success(PR#2) → failure still active (F6)."""
+        events_file = events_dir / "events.jsonl"
+        lines = [
+            json.dumps(
+                {
+                    "timestamp": "2026-03-18T10:00:00Z",
+                    "event_type": "ci_failure",
+                    "source": "hook",
+                    "lane_id": "author-a",
+                    "payload": {"details": "lint failed", "target": "PR #100"},
+                }
+            ),
+            json.dumps(
+                {
+                    "timestamp": "2026-03-18T10:05:00Z",
+                    "event_type": "ci_success",
+                    "source": "hook",
+                    "lane_id": "author-a",
+                    "payload": {"target": "PR #200"},
+                }
+            ),
+        ]
+        events_file.write_text("\n".join(lines) + "\n")
+
+        failures = get_active_failures(events_dir)
+        assert len(failures) == 1
+        assert failures[0].target == "PR #100"
+
+    def test_task_completed_resolves_task_failed(self, events_dir: Path) -> None:
+        """task_completed resolves both task_failed and task_blocked (F6)."""
+        events_file = events_dir / "events.jsonl"
+        lines = [
+            json.dumps(
+                {
+                    "timestamp": "2026-03-18T10:00:00Z",
+                    "event_type": "task_failed",
+                    "source": "scheduler",
+                    "lane_id": "author-a",
+                    "payload": {"details": "build error"},
+                }
+            ),
+            json.dumps(
+                {
+                    "timestamp": "2026-03-18T10:01:00Z",
+                    "event_type": "task_blocked",
+                    "source": "scheduler",
+                    "lane_id": "author-a",
+                    "payload": {"details": "blocked by dependency"},
+                }
+            ),
+            json.dumps(
+                {
+                    "timestamp": "2026-03-18T10:05:00Z",
+                    "event_type": "task_completed",
+                    "source": "scheduler",
+                    "lane_id": "author-a",
+                    "payload": {},
+                }
+            ),
+        ]
+        events_file.write_text("\n".join(lines) + "\n")
+
+        failures = get_active_failures(events_dir)
+        assert len(failures) == 0
+
+    def test_heartbeat_ok_resolves_heartbeat_stale(self, events_dir: Path) -> None:
+        """heartbeat_ok resolves heartbeat_stale for same lane (F6)."""
+        events_file = events_dir / "events.jsonl"
+        lines = [
+            json.dumps(
+                {
+                    "timestamp": "2026-03-18T10:00:00Z",
+                    "event_type": "heartbeat_stale",
+                    "source": "watchdog",
+                    "lane_id": "author-b",
+                    "payload": {"message": "No heartbeat for 10 min"},
+                }
+            ),
+            json.dumps(
+                {
+                    "timestamp": "2026-03-18T10:05:00Z",
+                    "event_type": "heartbeat_ok",
+                    "source": "watchdog",
+                    "lane_id": "author-b",
+                    "payload": {},
+                }
+            ),
+        ]
+        events_file.write_text("\n".join(lines) + "\n")
+
+        failures = get_active_failures(events_dir)
+        assert len(failures) == 0
+
+    def test_mixed_resolved_and_unresolved(self, events_dir: Path) -> None:
+        """Some failures resolved, others not → only unresolved returned (F6)."""
+        events_file = events_dir / "events.jsonl"
+        lines = [
+            # Old ci_failure — will be resolved
+            json.dumps(
+                {
+                    "timestamp": "2026-03-18T10:00:00Z",
+                    "event_type": "ci_failure",
+                    "source": "hook",
+                    "lane_id": "author-a",
+                    "payload": {"details": "lint failed"},
+                }
+            ),
+            # ci_success resolves the ci_failure
+            json.dumps(
+                {
+                    "timestamp": "2026-03-18T10:02:00Z",
+                    "event_type": "ci_success",
+                    "source": "hook",
+                    "lane_id": "author-a",
+                    "payload": {},
+                }
+            ),
+            # Unresolved escalation on a different lane
+            json.dumps(
+                {
+                    "timestamp": "2026-03-18T10:03:00Z",
+                    "event_type": "escalation",
+                    "source": "watchdog",
+                    "lane_id": "ops",
+                    "payload": {"details": "repeated failures"},
+                }
+            ),
+        ]
+        events_file.write_text("\n".join(lines) + "\n")
+
+        failures = get_active_failures(events_dir)
+        assert len(failures) == 1
+        assert failures[0].failure_type == "escalation"
 
     def test_most_recent_first(self, events_dir: Path) -> None:
         events_file = events_dir / "events.jsonl"

--- a/tests/unit/test_ops_worktrees.py
+++ b/tests/unit/test_ops_worktrees.py
@@ -11,6 +11,7 @@ import pytest
 from bid_euchre.ops.worktrees import (
     PROTECTED_WORKTREE_NAMES,
     GitWorktree,
+    _update_registry_cleanup_state,
     classify_cleanup_candidates,
     is_protected,
     is_worktree_dirty,
@@ -981,3 +982,68 @@ class TestArchiveWorktree:
 
         with pytest.raises(FileNotFoundError, match="not found"):
             archive_worktree("/tmp/no-such-worktree-xyz", runtime_dir)
+
+
+class TestUpdateRegistryCleanupState:
+    """Tests for _update_registry_cleanup_state()."""
+
+    @pytest.fixture()
+    def registry_dir(self, tmp_path: Path) -> Path:
+        d = tmp_path / "worktree_registry"
+        d.mkdir()
+        return d
+
+    def test_updates_matching_entry(self, registry_dir: Path) -> None:
+        """Updates cleanup_state for a matching worktree path (F7)."""
+        _write_registry_entry(
+            registry_dir,
+            "author-a.json",
+            lane_id="author-a",
+            worktree_path="/tmp/wt-author",
+        )
+
+        result = _update_registry_cleanup_state(
+            registry_dir, "/tmp/wt-author", "quarantined"
+        )
+        assert result is True
+
+        data = json.loads((registry_dir / "author-a.json").read_text())
+        assert data["cleanup_state"] == "quarantined"
+
+    def test_returns_false_for_no_match(self, registry_dir: Path) -> None:
+        """Returns False when no registry entry matches the path."""
+        _write_registry_entry(
+            registry_dir,
+            "author-a.json",
+            lane_id="author-a",
+            worktree_path="/tmp/wt-author",
+        )
+
+        result = _update_registry_cleanup_state(
+            registry_dir, "/tmp/wt-nonexistent", "quarantined"
+        )
+        assert result is False
+
+    def test_produces_valid_json_after_update(self, registry_dir: Path) -> None:
+        """File remains valid JSON after read-modify-write (F7 TOCTOU fix)."""
+        _write_registry_entry(
+            registry_dir,
+            "task.json",
+            lane_id="task-1",
+            worktree_path="/tmp/wt-task",
+        )
+
+        _update_registry_cleanup_state(registry_dir, "/tmp/wt-task", "archived")
+
+        # Must be valid JSON with the updated field
+        data = json.loads((registry_dir / "task.json").read_text())
+        assert data["cleanup_state"] == "archived"
+        # Original fields preserved
+        assert data["lane_id"] == "task-1"
+        assert data["worktree_path"] == "/tmp/wt-task"
+
+    def test_nonexistent_dir_returns_false(self, tmp_path: Path) -> None:
+        result = _update_registry_cleanup_state(
+            tmp_path / "no_such_dir", "/tmp/wt", "quarantined"
+        )
+        assert result is False


### PR DESCRIPTION
## Summary

- **H1+M7**: `drain_events()` — hold `fcntl.flock()` for the full read→filter→rename→archive cycle (prevents concurrent append loss) and reorder to rename-before-archive-append (eliminates crash duplication window)
- **M2**: `read_events()` — use `collections.deque(maxlen=limit)` to avoid O(N) memory when limit is small
- **F6**: `get_active_failures()` — correlate failure events with resolution events by target, filtering out resolved failures (ci_failure+ci_success, task_failed+task_completed, etc.)
- **F7**: `_update_registry_cleanup_state()` — add `fcntl.flock()` around read-modify-write to prevent TOCTOU races

## Why

These 5 findings were deferred from PR #910 (which fixed 7 other findings from the same review batch, PRs #878/#892). They represent crash safety, concurrency, memory efficiency, and usability improvements to the ops package.

## Repro / Validation

```bash
# Targeted tests (13 new + 81 existing = 94 total)
uv run python -m pytest tests/unit/test_ops_events.py tests/unit/test_ops_recovery.py tests/unit/test_ops_worktrees.py -v

# Full validation
make check-quiet
```

## Tests

- `make check-quiet` — all checks pass
- 13 new tests added:
  - `test_drain_archive_written_after_active_rename` — H1 crash safety ordering
  - `test_drain_serializes_with_concurrent_append` — M7 lock serialization
  - `test_resolved_failure_excluded` — F6 basic resolution
  - `test_newer_failure_after_resolution_still_active` — F6 temporal ordering
  - `test_different_target_not_resolved` — F6 target isolation
  - `test_task_completed_resolves_task_failed` — F6 multi-type resolution
  - `test_heartbeat_ok_resolves_heartbeat_stale` — F6 heartbeat pair
  - `test_mixed_resolved_and_unresolved` — F6 mixed scenario
  - `test_updates_matching_entry` — F7 basic update
  - `test_returns_false_for_no_match` — F7 no-match case
  - `test_produces_valid_json_after_update` — F7 data integrity
  - `test_nonexistent_dir_returns_false` — F7 missing dir
- Updated `test_filters_failure_events_only` to use non-resolution event type (session_started instead of ci_success) to test failure filtering independently of resolution correlation

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
Worktree: Bid-Euchre-steward-author-b (persistent lane)
```

## Plan

`plans/sessions/2026-03-19_deferred-review-findings.md` — refined with real function signatures, line numbers, and implementation details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)