### PR TITLE
docs: document per-contract vs pooled net_eppd denominator semantics

### DIFF
--- a/docs/01_core/METRICS.md
+++ b/docs/01_core/METRICS.md
@@ -70,6 +70,19 @@ When bidding is enabled (`contract_type: null` in scenario config), the evaluato
 
 **Source:** `src/bid_euchre/reporting/evaluator.py`
 
+### Per-Contract vs Pooled Metric Denominators
+
+The comparator CIs pipeline (`scripts/internal/extract_comparator_cis.py`) computes metrics at two granularities with **different denominators**:
+
+| Granularity | `deals_total` denominator | `bid_rate` |
+|-------------|--------------------------|------------|
+| **Pooled** | All deals including all-pass redeals | Fraction of deals with an auction winner |
+| **Per-contract** (suit/high/low) | Only deals with actual bids in that contract type | Always 1.0 by construction |
+
+**Key implication:** Pooled and per-contract `net_eppd` values are **not directly comparable** because they divide by different denominators. Pooled `net_eppd` is diluted by all-pass redeals (which contribute 0 points), while per-contract `net_eppd` reflects only deals where the contract was actually played.
+
+All-pass redeals (which use `dummy_ctype="high"` internally) are explicitly excluded from per-contract buckets to prevent contamination of the "high" contract metrics.
+
 ## Where to Find These Fields
 
 ### Results JSON Files


### PR DESCRIPTION
## Plan
- `plans/sessions/2026-03-18_post-merge-review-followups.md` (PR 2)

## Summary
- Documents the denominator difference between pooled and per-contract `net_eppd` metrics in `docs/01_core/METRICS.md`
- Clarifies that pooled denominators include all-pass redeals while per-contract denominators do not

## Why
Post-merge review of PR #909 (per-contract extraction in comparator CIs pipeline) found that the denominator semantics were undocumented. Readers could incorrectly compare pooled and per-contract metrics side-by-side without realizing the denominators differ.

## Repro / Validation
**Command(s) run:**
- `make docs-check` — passed

**Config (if applicable):**
- N/A

**Seed (if applicable):**
- N/A

## Tests
- [x] Other: `make docs-check` (docs-only change)

## Expected impact
- Metrics impact (if any): None (documentation only)
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/worktree-docs-metric-denominator
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/worktree-docs-metric-denominator
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                                   6dc99a8 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/worktree-docs-metric-denominator             5998d3c [docs/metric-denominator-semantics]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)