### PR TITLE
docs: add implementation handoff protocol to agent guidance

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,6 +5,27 @@ Domain docs live in docs/ — read them on-demand when working in relevant areas
 Skills in .claude/skills/ provide workflow guidance — invoke with /skill-name.
 TUI task list conventions are in `.claude/rules/25_task_lists.md` — use for multi-step work.
 
+## Implementation Handoff Protocol
+
+When generating an implementation handoff for another Codex/Claude agent,
+the prompt must require this sequence before code changes begin:
+1. Refresh the governing/implementation plan context.
+2. Draft or refresh a concrete execution plan.
+3. Spawn at least one reviewer agent to review that plan.
+4. Create a task list for implementation, validation, and PR shipping.
+5. Assess the work for safe parallelism and delegate only disjoint write scopes.
+6. Execute the work end to end autonomously:
+   - implement
+   - test
+   - run smoke/failure-injection validation
+   - commit
+   - open/update the PR
+   - include `Validation Performed` evidence in the PR body
+
+Do not hand off implementation work with only a file list or goal summary.
+The handoff must explicitly tell the next agent to plan, review the plan,
+manage a task list, assess parallelism, and ship the work autonomously.
+
 ## Compaction Instructions
 
 When compacting conversation context, preserve:

--- a/.claude/rules/25_task_lists.md
+++ b/.claude/rules/25_task_lists.md
@@ -73,6 +73,20 @@ The list drifts and loses its value as a progress signal. Prevent this:
 - Reference the checkpoint step ID in subjects (e.g., "R2.3: Generate behavior tables")
 - On completion, update both the TUI task AND `checkpoints.md`
 
+## Implementation Handoff Requirement
+
+If you are writing a handoff prompt for another implementation agent, the
+handoff must explicitly require the recipient to:
+- refresh or draft the implementation plan first
+- have a spawned reviewer agent review that plan before major edits
+- create and maintain a task list for execution and validation
+- assess the work for safe parallelism before delegating
+- execute the work end to end autonomously through PR creation
+
+This rule exists so handoffs do not skip directly from goal statement to
+implementation without planning, review, task discipline, and bounded
+parallelism.
+
 ## Relationship to Other Systems
 
 | System | Scope | Persists? | Use for |

--- a/.claude/skills/reviewing-changes/HANDOFF_TEMPLATE.md
+++ b/.claude/skills/reviewing-changes/HANDOFF_TEMPLATE.md
@@ -40,6 +40,14 @@ The user can `/copy` this into a new Claude Code session to resume work.
 - Commit status: `pending` (review loop in progress)
 - Verdict: DISPATCHED — review loop running asynchronously
 
+### Implementation Directive
+- Refresh the governing/implementation plan before making edits.
+- Draft or refine the execution plan for the remaining work.
+- Spawn at least one reviewer agent to review that plan before major edits.
+- Create and maintain a task list for implementation, validation, and PR shipping.
+- Assess the work for safe parallelism before delegating.
+- Execute the work end to end autonomously through validation and PR update/shipment unless blocked.
+
 ### Context for Next Agent
 [2-3 sentences: What this PR does, what the review loop will check,
 what the next agent needs to know.]

--- a/docs/02_agent/AGENTS.md
+++ b/docs/02_agent/AGENTS.md
@@ -543,6 +543,28 @@ proposed --> in_progress --> completed
 Any status --> superseded (when replaced)
 ```
 
+### 12.4 Implementation Handoff Rule
+
+When an agent writes a handoff prompt for another agent to continue or execute
+implementation work, the handoff must direct the next agent to do the
+following in order:
+
+1. Refresh the governing plan and relevant implementation plan.
+2. Draft or refine a concrete execution plan.
+3. Spawn at least one reviewer agent to review that plan before major edits.
+4. Create a task list covering implementation, validation, and PR shipment.
+5. Assess the work for safe parallelism and only delegate disjoint write scopes.
+6. Execute the work end to end autonomously:
+   - implement
+   - test
+   - run smoke/failure-injection validation
+   - commit
+   - open or update the PR
+   - include required validation evidence in the PR body
+
+Handoffs that omit this sequence are incomplete for governed implementation
+work. A file list or goal summary alone is not sufficient.
+
 **Template:** `plans/_templates/sub_plan.md`
 
 **Anti-pattern:** Do not invent ad hoc planning structures once a governing


### PR DESCRIPTION
## Summary
- Add **Implementation Handoff Protocol** to `.claude/CLAUDE.md` requiring plan refresh, plan review, task list, parallelism assessment, and autonomous end-to-end execution in all implementation handoffs.
- Add **Implementation Handoff Requirement** section to `.claude/rules/25_task_lists.md` reinforcing the same sequence.
- Add **§12.4 Implementation Handoff Rule** to `docs/02_agent/AGENTS.md` as a formal numbered section in the governed plan framework.
- Add **Implementation Directive** block to `HANDOFF_TEMPLATE.md` so all generated handoffs include the protocol by default.

## Why
Implementation handoffs that contain only a file list or goal summary lead to agents skipping planning, review, task discipline, and parallelism assessment. This codifies the required sequence at all repo-local enforcement points.

## What this enforces
Every handoff must direct the next agent to:
1. Refresh the governing/implementation plan
2. Draft or refine a concrete execution plan
3. Spawn a reviewer agent to review that plan
4. Create and maintain a task list
5. Assess safe parallelism
6. Execute end to end autonomously through PR shipment

## What this does NOT enforce
- Cannot override Codex-level system prompts
- Past ad hoc handoffs in chat are not retroactively changed
- True hard enforcement would need Codex-level prompt policy

## Repro / Validation
Docs-only change — no code, no tests affected.

```
pwd && git rev-parse --show-toplevel && git worktree list
```

## Tests
N/A — docs/template changes only. CI will skip heavy steps via `dorny/paths-filter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)