### PR TITLE
feat: wire deferred watchdog producers and add scope management (PR-5)

### DIFF
--- a/docs/02_agent/AUTONOMOUS_OPERATOR_WORKFLOW.md
+++ b/docs/02_agent/AUTONOMOUS_OPERATOR_WORKFLOW.md
@@ -670,38 +670,129 @@ review architecture migration plan.
 
 ---
 
-## Future Work
+## Operator CLI Reference
 
-The following capabilities are planned for subsequent PRs and are documented
-here for context. They are not yet implemented.
+The operator CLI (`scripts/internal/ops.py`) provides a single entrypoint for
+workspace health monitoring, event inspection, and operational management.
 
-### Operator CLI (ops.py)
+### Commands
 
-- Single-command status summary
-- Worktree lifecycle management (`prune`, `quarantine`, `archive`)
-- Health checks and watchdogs
-- CI failure classification and bounded remediation
-- Recovery templates for common failure modes
+| Command | Purpose | Example |
+|---------|---------|---------|
+| `status` | Lane/session/task health summary | `ops.py status --json` |
+| `health` | Aggregated health (status + watchdogs) | `ops.py health` |
+| `watchdogs` | Run all watchdog checks | `ops.py watchdogs --json` |
+| `tick` | Run one scheduler cycle | `ops.py tick` |
+| `daemon` | Run bounded repeating tick loop | `ops.py daemon --interval 300 --max-ticks 50` |
+| `events` | Show recent events | `ops.py events --type ci_failure --limit 10` |
+| `events drain` | Archive all events | `ops.py events drain` |
+| `reviews` | PR review/check outcomes from GitHub | `ops.py reviews --pr 927` |
+| `ci` | CI status and failure classification | `ops.py ci --pr 940` |
+| `recover` | Recovery guidance for active failures | `ops.py recover` |
+| `retry` | Evaluate retry/reroute policy | `ops.py retry --task t1 --emit` |
+| `worktrees` | Worktree registry and reconciliation | `ops.py worktrees --json` |
+| `worktrees prune` | Prune stale worktrees (dry-run default) | `ops.py worktrees prune --execute` |
+| `worktrees quarantine` | Quarantine a dirty worktree | `ops.py worktrees quarantine /path` |
+| `worktrees archive` | Archive (remove) a worktree | `ops.py worktrees archive /path` |
+| `scope show` | Show task scope fields | `ops.py scope show --task t1` |
+| `scope set` | Set declared_files for a task | `ops.py scope set --task t1 --declared 'src/*.py'` |
+| `scope touch` | Record touched files for a task | `ops.py scope touch --task t1 --file src/a.py` |
+| `index` | Build or show audit index | `ops.py index --rebuild` |
+| `query` | Query the audit index | `ops.py query --text "ci_failure" --limit 5` |
+| `memory` | Show curated memory entries | `ops.py memory --category workflow` |
+| `compact` | List archived sessions | `ops.py compact` |
 
-### Scheduler and Event System
+All commands support `--json` for machine-readable output. Use
+`--runtime-dir` and `--plans-dir` to override default paths.
 
-- Durable event production/consumption
-- Queue-driven review execution
-- Scheduled health checks and remediation
-- ~~`launchd` recovery for persistent sessions~~ (delivered in PR-2)
+### Watchdog Checks
 
-### Audit Index and Memory
+Six watchdog checks run automatically via `ops.py tick` or `ops.py watchdogs`:
 
-- SQLite-based searchable index over runtime artifacts
-- Curated memory for stable operator facts
-- Session compaction and archive
+| Check | What it detects | Input source |
+|-------|----------------|-------------|
+| `heartbeats` | Stale/missing heartbeat files | `plans/**/heartbeat` files |
+| `task_progress` | Stalled in-progress tasks | `task_state/*.json` progress fields |
+| `worktree_health` | Unregistered/missing worktrees | Git worktree list vs registry |
+| `ci_stuck` | CI failing beyond threshold | `ci_failure`/`ci_success` events |
+| `subagent_failures` | Repeated task failures | `task_failed` events |
+| `scope_drift` | Files changed outside declared scope | `task_state/*.json` scope fields |
 
-### Rollout and Safety
+### Event Producers
+
+Events are emitted to the durable event log (runtime events JSONL) by:
+
+| Producer | Event types | Trigger |
+|----------|------------|---------|
+| `ci_poller.sh` | `ci_failure`, `ci_success` | CI pass/fail on PR checks |
+| `post-task-event.sh` | `task_completed` | `gh pr merge` via PostToolUse hook |
+| `ops.py tick` | `watchdog_finding`, `scheduler_tick` | Scheduler tick cycle |
+| `ops.py retry --emit` | `retry_attempted`, `task_rerouted`, `escalation` | Retry policy evaluation |
+
+### Task Scope Management
+
+Task scope enables the `scope_drift` watchdog to detect when an agent modifies
+files outside its declared scope. Scope is managed via the CLI:
+
+```bash
+# At task start: declare the intended file scope
+ops.py scope set --task t1 --declared 'src/bid_euchre/ops/*.py' 'tests/unit/test_ops_*.py'
+
+# During execution: record files as they are modified
+ops.py scope touch --task t1 --file src/bid_euchre/ops/watchdogs.py
+
+# Inspect current scope
+ops.py scope show --task t1
+```
+
+The scope API can also be called programmatically:
+
+```python
+from bid_euchre.ops.status import update_task_scope, get_task_scope
+
+update_task_scope("t1", declared_files=["src/bid_euchre/ops/*.py"])
+update_task_scope("t1", touched_files=["src/bid_euchre/ops/watchdogs.py"], append_touched=True)
+scope = get_task_scope("t1")
+```
+
+### Rollback and Disable
+
+All operator stack features are designed to be independently disablable:
+
+| Feature | Disable method |
+|---------|---------------|
+| CI event emission | Remove `emit_ci_event` calls from `ci_poller.sh` |
+| Scope tracking | Stop calling `ops.py scope set/touch` — watchdog degrades gracefully |
+| Retry event emission | Omit `--emit` flag (default: off) |
+| Watchdog checks | Pass `checks={"heartbeats"}` to run only specific checks |
+| Scheduler daemon | Do not run `ops.py daemon` — all checks are on-demand via `ops.py tick` |
+| Full stack | Remove `.claude/hooks/post-task-event.sh` and stop running `ops.py` |
+
+No feature alters core simulation, strategy, or experiment behavior.
+
+---
+
+## Shipped Work (Implementation History)
+
+The following capabilities were delivered across PRs 1-5 of the autonomous
+agent ops workflow (`plans/sessions/2026-03-15_autonomous-agent-ops-workflow.md`):
+
+| PR | Scope | Status |
+|----|-------|--------|
+| PR-1 | Operating model, worktree bootstrap, documentation | Shipped |
+| PR-2 | Steward session launcher, VS Code audit workspace, launchd recovery | Shipped |
+| PR-3 | Operator CLI (`ops.py`), reviews/CI surfaces, scheduler, watchdogs, retry/reroute | Shipped |
+| PR-4 | Audit index, curated memory, session compaction | Shipped |
+| PR-5 | CI event producers, scope management, retry events, operational proof | Shipped |
+
+### Remaining Future Work
 
 - Context safety scanning for auto-loaded content
 - Shadow snapshots for rollback
 - Skill promotion workflow
-- End-to-end validation pilots
+- Fully automated scope tracking via file-write hooks
+- Automated retry execution (currently advisory only)
+- CI event emission from GitHub Actions (currently only from local CI poller)
 
 See `plans/sessions/2026-03-15_autonomous-agent-ops-workflow.md` for the
 full implementation sequence and design decisions.

--- a/plans/sessions/2026-03-18_pr5-rollout-integration.md
+++ b/plans/sessions/2026-03-18_pr5-rollout-integration.md
@@ -1,0 +1,153 @@
+# PR-5: Rollout, Integration, and Operational Proof
+
+**Date:** 2026-03-18
+**Branch:** `codex/steward-author-c`
+**Parent plan:** `plans/sessions/2026-03-15_autonomous-agent-ops-workflow.md`
+**Closes issues:** #928, #929, #930
+
+## Goal
+
+Make the autonomous operator stack operationally credible by:
+1. Wiring deferred watchdog producers so all 6 watchdogs function against real data
+2. Adding event emission to the retry/reroute CLI command
+3. Adding a CLI `scope` subcommand to manage task scope fields
+4. Updating the operator workflow doc to reflect the complete shipped surface
+5. Running operational smoke and failure-injection validation
+
+## Scope
+
+### In Scope
+
+| Area | Files | Change |
+|------|-------|--------|
+| CI event producers | `scripts/internal/ci_poller.sh` | Emit `ci_failure`/`ci_success` events on CI outcome |
+| Scope field API | `src/bid_euchre/ops/status.py` | Add `update_task_scope()` helper |
+| Scope CLI | `scripts/internal/ops.py` | Add `ops.py scope` subcommand |
+| Retry event emission | `scripts/internal/ops.py` | Emit events in `cmd_retry()` |
+| Tests | `tests/unit/test_ops_*.py` | New tests for producers, scope API, retry events |
+| Docs | `docs/02_agent/AUTONOMOUS_OPERATOR_WORKFLOW.md` | Update "Future Work" → shipped, add operator CLI reference |
+
+### Out of Scope
+
+- Fully automated scope tracking via hooks (complex, needs separate design)
+- New hook scripts (scope tracking in hooks deferred)
+- Changes to other ops modules beyond what's listed
+- Reopening PR-1 through PR-4 architecture
+
+## Design
+
+### 1. CI Event Producers (Issue #928)
+
+The `ci_poller.sh` script already determines pass/fail status for PRs. Wire it to emit
+events to the durable event log:
+
+- On CI pass: emit `ci_success` with `{pr_number: N}` payload
+- On CI failure: emit `ci_failure` with `{pr_number: N, failure_class: "..."}` payload
+- Use `uv run python -c "from bid_euchre.ops.events import append_event; ..."` pattern
+  (same as `post-task-event.sh`)
+
+This makes `check_ci_stuck()` watchdog functional against real CI data.
+
+### 2. Task Scope Management (Issue #929)
+
+Add a Python API + CLI for managing scope fields on task state:
+
+**Python API** (`src/bid_euchre/ops/status.py`):
+```python
+def update_task_scope(
+    task_id: str,
+    *,
+    declared_files: list[str] | None = None,
+    touched_files: list[str] | None = None,
+    append_touched: bool = False,
+    runtime_dir: Path | None = None,
+) -> dict:
+    """Update scope fields on a task state file."""
+```
+
+**CLI** (`ops.py scope`):
+```
+ops.py scope set --task TASK_ID --declared 'src/bid_euchre/ops/*.py' 'tests/unit/test_ops_*.py'
+ops.py scope touch --task TASK_ID --file src/bid_euchre/ops/watchdogs.py
+ops.py scope show --task TASK_ID
+```
+
+This makes `check_scope_drift()` watchdog functional — agents or operators call
+`ops.py scope set` at task start and `ops.py scope touch` during execution.
+
+### 3. Retry/Reroute Event Emission (Issue #930)
+
+Modify `cmd_retry()` in `ops.py` to emit events after policy evaluation:
+- If action is "retry": emit `retry_attempted` event
+- If action is "reroute": emit `task_rerouted` event
+- If action is "escalate": emit `escalation` event
+- Add `--emit` flag (default: off) to control event emission (advisory by default)
+
+### 4. Docs Update
+
+Update `AUTONOMOUS_OPERATOR_WORKFLOW.md`:
+- Move items from "Future Work" to shipped status
+- Add Operator CLI reference table with all commands
+- Add rollback/disable instructions
+- Mark local review loop as transitional
+
+## Implementation Order
+
+1. Wire CI event producers in `ci_poller.sh`
+2. Add `update_task_scope()` to `status.py`
+3. Add `ops.py scope` CLI subcommand
+4. Add event emission to `cmd_retry()`
+5. Write tests for all new code
+6. Update docs
+7. Run `make check-quiet`
+8. Run operational smoke + failure injection
+9. Commit and open PR
+
+## Parallelism Assessment
+
+| Work | Owner | Files |
+|------|-------|-------|
+| CI poller + scope API + retry events | main agent | `ci_poller.sh`, `status.py`, `ops.py` |
+| Docs update | can be parallel agent | `AUTONOMOUS_OPERATOR_WORKFLOW.md` |
+| Tests | main agent (after implementation) | `test_ops_*.py` |
+
+The docs update has no file overlap with implementation — safe for parallel agent.
+Tests must follow implementation (sequential).
+
+## Validation Plan
+
+### Automated Tests
+- `test_ops_status.py`: test `update_task_scope()` API
+- `test_ops_cli.py`: test `ops.py scope` subcommand
+- `test_ops_recovery.py`: test retry event emission
+- `test_ops_watchdogs.py`: verify watchdog + producer integration
+- Full `make check-quiet` before PR
+
+### Manual Smoke
+- Run `ops.py watchdogs` in steward environment — verify no false positives
+- Run `ops.py health` — verify coherent text + JSON output
+- Run `ops.py scope show --task ...` — verify scope display
+- Run `ops.py retry --task ...` — verify policy + event emission
+
+### Failure Injection
+- Inject `ci_failure` event → verify `check_ci_stuck()` detects it after threshold
+- Inject `ci_success` event → verify `check_ci_stuck()` clears the stuck state
+- Create task with out-of-scope files → verify `check_scope_drift()` detects drift
+- Run retry at cap → verify `task_rerouted` event emitted
+- Remove all events → verify watchdogs degrade gracefully (no crash, no false positives)
+
+### Rollback Path
+- CI event emission is fire-and-forget in `ci_poller.sh` — removing the lines restores old behavior
+- Scope API is opt-in — no existing behavior changes if unused
+- Retry event emission is behind `--emit` flag — default off
+- Docs changes are additive
+
+## Outcome
+
+_To be filled after implementation._
+
+## Known Gaps (Deferred)
+
+- Fully automated scope tracking via file-write hooks (would need per-task context in hooks)
+- Automated retry execution (currently advisory only)
+- CI event emission from GitHub Actions (currently only from local CI poller)

--- a/scripts/internal/ci_poller.sh
+++ b/scripts/internal/ci_poller.sh
@@ -86,6 +86,44 @@ write_status() {
 SEOF
 }
 
+emit_ci_event() {
+    # Emit a durable CI event to the ops event log (fire-and-forget).
+    # Args: $1=event_type (ci_failure|ci_success), $2=failure_class (optional)
+    local event_type="$1"
+    local failure_class="${2:-}"
+    local lane_id="unknown"
+
+    # Infer lane_id from worktree directory name
+    local dir_name
+    dir_name=$(basename "$REPO_ROOT")
+    case "$dir_name" in
+        *steward-author-scratch) lane_id="author-scratch" ;;
+        *steward-author-b)       lane_id="author-b" ;;
+        *steward-author-c)       lane_id="author-c" ;;
+        *steward-author-d)       lane_id="author-d" ;;
+        *steward-author)         lane_id="author-a" ;;
+        *steward-review)         lane_id="review" ;;
+        *steward-ops)            lane_id="ops" ;;
+    esac
+
+    EVENT_TYPE="$event_type" LANE_ID="$lane_id" PR_NUM_ENV="$PR_NUM" \
+    FAILURE_CLASS="$failure_class" \
+    uv run python -c "
+import os, json
+from bid_euchre.ops.events import append_event
+payload = {'pr_number': int(os.environ['PR_NUM_ENV'])}
+fc = os.environ.get('FAILURE_CLASS', '')
+if fc:
+    payload['failure_class'] = fc
+append_event(
+    os.environ['EVENT_TYPE'],
+    'ci_poller',
+    os.environ['LANE_ID'],
+    payload,
+)
+" 2>/dev/null || true
+}
+
 cleanup() {
     rm -f "$PID_FILE"
 }
@@ -191,6 +229,7 @@ while true; do
         FAILED_NAMES=$(echo "$CHECK_OUTPUT" | jq -r '[.[] | select(.state == "FAILURE") | .name] | join(", ")' 2>/dev/null || echo "unknown")
         echo "[$(date -u +%H:%M:%S)] CI FAILED: $FAILED_NAMES"
         write_status "failed" "Failed checks: $FAILED_NAMES"
+        emit_ci_event "ci_failure" "$FAILED_NAMES"
         echo "CI_FAILED: Failed checks: $FAILED_NAMES" > "$STATE_DIR/FAILED"
         exit 1
     fi
@@ -198,6 +237,7 @@ while true; do
     # --- ALL PASSED (matches github_pr_state.py: all(s == "SUCCESS")) ---
     if [ "$SUCCEEDED" -eq "$TOTAL" ] && [ "$TOTAL" -gt 0 ]; then
         echo "[$(date -u +%H:%M:%S)] All ${TOTAL} checks passed!"
+        emit_ci_event "ci_success"
 
         if [ "$AUTO_MERGE" = true ]; then
             echo "[$(date -u +%H:%M:%S)] Attempting squash merge..."

--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -17,6 +17,9 @@ Usage:
     uv run python scripts/internal/ops.py query --text TEXT [--type TYPE] [--limit N] [--json]
     uv run python scripts/internal/ops.py memory [--category CAT] [--json]
     uv run python scripts/internal/ops.py compact [--json]
+    uv run python scripts/internal/ops.py scope show --task TASK_ID [--json]
+    uv run python scripts/internal/ops.py scope set --task TASK_ID --declared PATTERN [PATTERN ...]
+    uv run python scripts/internal/ops.py scope touch --task TASK_ID --file PATH [PATH ...]
 """
 
 from __future__ import annotations
@@ -477,7 +480,7 @@ def cmd_daemon(args: argparse.Namespace) -> int:
 
 
 def cmd_retry(args: argparse.Namespace) -> int:
-    """Evaluate retry/reroute policy for a task."""
+    """Evaluate retry/reroute policy for a task and optionally emit events."""
     from bid_euchre.ops.events import read_events
     from bid_euchre.ops.recovery import (
         evaluate_retry_policy,
@@ -492,6 +495,7 @@ def cmd_retry(args: argparse.Namespace) -> int:
 
     max_retries = getattr(args, "max_retries", 3)
     lane = getattr(args, "lane", None)
+    emit = getattr(args, "emit", False)
 
     events_dir = args.runtime_dir / "events"
     events = read_events(events_dir, limit=200)
@@ -500,12 +504,74 @@ def cmd_retry(args: argparse.Namespace) -> int:
         task_id, events, max_retries=max_retries, current_lane=lane
     )
 
+    # Emit durable event for the policy decision
+    if emit:
+        _emit_retry_event(policy, lane or "unknown", events_dir)
+
     if args.json:
         print(json.dumps(format_retry_policy_json(policy), indent=2))
     else:
         print(format_retry_policy_text(policy))
 
     return 0
+
+
+def _emit_retry_event(
+    policy: object,
+    lane_id: str,
+    events_dir: Path,
+) -> None:
+    """Emit a durable event based on the retry policy decision.
+
+    Maps policy actions to event types:
+    - retry → retry_attempted
+    - reroute → task_rerouted
+    - escalate → escalation
+    """
+    from bid_euchre.ops.events import append_event
+
+    action = getattr(policy, "action", "")
+    task_id = getattr(policy, "task_id", "unknown")
+    retry_count = getattr(policy, "retry_count", 0)
+    reroute_to = getattr(policy, "reroute_to", None)
+    last_failure = getattr(policy, "last_failure", "unknown")
+
+    event_map = {
+        "retry": "retry_attempted",
+        "reroute": "task_rerouted",
+        "escalate": "escalation",
+    }
+
+    event_type = event_map.get(action)
+    if not event_type:
+        return
+
+    payload: dict[str, object] = {
+        "task_id": task_id,
+        "retry_count": retry_count,
+        "last_failure": last_failure,
+    }
+
+    if action == "reroute" and reroute_to:
+        payload["source_lane"] = lane_id
+        payload["target_lane"] = reroute_to
+
+    if action == "escalate":
+        payload["details"] = (
+            f"Task {task_id} exceeded retry cap "
+            f"({retry_count} failures) — human attention required"
+        )
+
+    try:
+        append_event(
+            event_type=event_type,
+            source="ops.retry",
+            lane_id=lane_id,
+            payload=payload,
+            events_dir=events_dir,
+        )
+    except Exception as e:
+        print(f"Warning: failed to emit {event_type} event: {e}", file=sys.stderr)
 
 
 def cmd_index(args: argparse.Namespace) -> int:
@@ -628,6 +694,121 @@ def cmd_compact(args: argparse.Namespace) -> int:
         print(json.dumps(format_archives_json(archives), indent=2))
     else:
         print(format_archives_text(archives))
+
+    return 0
+
+
+def cmd_scope(args: argparse.Namespace) -> int:
+    """Manage task scope fields (declared_files, touched_files)."""
+    scope_action = getattr(args, "scope_action", None)
+
+    if scope_action == "set":
+        return cmd_scope_set(args)
+    if scope_action == "touch":
+        return cmd_scope_touch(args)
+    if scope_action == "show":
+        return cmd_scope_show(args)
+
+    # No subcommand — show help
+    print("Usage: ops.py scope {show|set|touch} --task TASK_ID ...", file=sys.stderr)
+    return 1
+
+
+def cmd_scope_set(args: argparse.Namespace) -> int:
+    """Set declared_files for a task's scope."""
+    from bid_euchre.ops.status import update_task_scope
+
+    task_id = getattr(args, "task", None)
+    declared = getattr(args, "declared", None)
+
+    if not task_id:
+        print("Error: --task required", file=sys.stderr)
+        return 1
+    if not declared:
+        print("Error: --declared required", file=sys.stderr)
+        return 1
+
+    try:
+        data = update_task_scope(
+            task_id, declared_files=declared, runtime_dir=args.runtime_dir
+        )
+    except (FileNotFoundError, ValueError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    scope = data.get("scope", {})
+    if args.json:
+        print(json.dumps(scope, indent=2))
+    else:
+        print(f"Scope updated for task {task_id}")
+        print(f"  declared_files: {scope.get('declared_files', [])}")
+
+    return 0
+
+
+def cmd_scope_touch(args: argparse.Namespace) -> int:
+    """Record touched files for a task's scope."""
+    from bid_euchre.ops.status import update_task_scope
+
+    task_id = getattr(args, "task", None)
+    files = getattr(args, "file", None)
+
+    if not task_id:
+        print("Error: --task required", file=sys.stderr)
+        return 1
+    if not files:
+        print("Error: --file required", file=sys.stderr)
+        return 1
+
+    try:
+        data = update_task_scope(
+            task_id,
+            touched_files=files,
+            append_touched=True,
+            runtime_dir=args.runtime_dir,
+        )
+    except (FileNotFoundError, ValueError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    scope = data.get("scope", {})
+    if args.json:
+        print(json.dumps(scope, indent=2))
+    else:
+        touched = scope.get("touched_files", [])
+        print(f"Recorded {len(files)} file(s) for task {task_id}")
+        print(f"  touched_files ({len(touched)} total): {touched}")
+
+    return 0
+
+
+def cmd_scope_show(args: argparse.Namespace) -> int:
+    """Show current scope for a task."""
+    from bid_euchre.ops.status import get_task_scope
+
+    task_id = getattr(args, "task", None)
+    if not task_id:
+        print("Error: --task required", file=sys.stderr)
+        return 1
+
+    try:
+        scope = get_task_scope(task_id, runtime_dir=args.runtime_dir)
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(scope, indent=2))
+    else:
+        declared = scope.get("declared_files", [])
+        touched = scope.get("touched_files", [])
+        print(f"Scope for task {task_id}:")
+        print(f"  declared_files ({len(declared)}):")
+        for p in declared:
+            print(f"    - {p}")
+        print(f"  touched_files ({len(touched)}):")
+        for p in touched:
+            print(f"    - {p}")
 
     return 0
 
@@ -759,6 +940,11 @@ def build_parser() -> argparse.ArgumentParser:
     retry_parser.add_argument(
         "--lane", type=str, default=None, help="Current lane (for reroute target)"
     )
+    retry_parser.add_argument(
+        "--emit",
+        action="store_true",
+        help="Emit durable event for the policy decision (default: off)",
+    )
 
     # index
     index_parser = subparsers.add_parser("index", help="Build or show audit index")
@@ -790,6 +976,41 @@ def build_parser() -> argparse.ArgumentParser:
 
     # compact
     subparsers.add_parser("compact", help="List archived sessions")
+
+    # scope (with nested set/touch/show subcommands)
+    scope_parser = subparsers.add_parser(
+        "scope", help="Manage task scope fields (declared/touched files)"
+    )
+    scope_sub = scope_parser.add_subparsers(dest="scope_action")
+
+    scope_show_parser = scope_sub.add_parser("show", help="Show scope for a task")
+    scope_show_parser.add_argument(
+        "--task", type=str, required=True, help="Task ID to inspect"
+    )
+
+    scope_set_parser = scope_sub.add_parser(
+        "set", help="Set declared_files for a task scope"
+    )
+    scope_set_parser.add_argument("--task", type=str, required=True, help="Task ID")
+    scope_set_parser.add_argument(
+        "--declared",
+        type=str,
+        nargs="+",
+        required=True,
+        help="Glob patterns for declared file scope",
+    )
+
+    scope_touch_parser = scope_sub.add_parser(
+        "touch", help="Record touched files for a task scope"
+    )
+    scope_touch_parser.add_argument("--task", type=str, required=True, help="Task ID")
+    scope_touch_parser.add_argument(
+        "--file",
+        type=str,
+        nargs="+",
+        required=True,
+        help="File paths to record as touched",
+    )
 
     return parser
 
@@ -829,6 +1050,7 @@ def main(argv: list[str] | None = None) -> int:
         "query": cmd_query,
         "memory": cmd_memory,
         "compact": cmd_compact,
+        "scope": cmd_scope,
     }
 
     handler = commands.get(args.command)

--- a/src/bid_euchre/ops/status.py
+++ b/src/bid_euchre/ops/status.py
@@ -359,3 +359,115 @@ def format_status_json(report: StatusReport) -> dict[str, Any]:
         "completed_tasks": report.completed_tasks,
         "warnings": report.warnings,
     }
+
+
+# ---------------------------------------------------------------------------
+# Task scope management
+# ---------------------------------------------------------------------------
+
+
+def update_task_scope(
+    task_id: str,
+    *,
+    declared_files: list[str] | None = None,
+    touched_files: list[str] | None = None,
+    append_touched: bool = False,
+    runtime_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Update scope fields on a task state file.
+
+    Reads the task state JSON, updates the ``scope`` object, and writes
+    it back atomically. Creates the ``scope`` key if it does not exist.
+
+    Args:
+        task_id: Task identifier (filename stem in ``task_state/``).
+        declared_files: Glob patterns for declared file scope. Replaces
+            existing ``scope.declared_files`` if provided.
+        touched_files: File paths to record as touched. Behavior depends
+            on ``append_touched``.
+        append_touched: If True, appends ``touched_files`` to the existing
+            list (deduplicating). If False, replaces the existing list.
+        runtime_dir: Override for the runtime directory root.
+
+    Returns:
+        The updated task state dict.
+
+    Raises:
+        FileNotFoundError: If the task state file does not exist.
+        ValueError: If neither ``declared_files`` nor ``touched_files``
+            is provided.
+    """
+    if declared_files is None and touched_files is None:
+        raise ValueError(
+            "At least one of declared_files or touched_files must be provided"
+        )
+
+    if runtime_dir is None:
+        runtime_dir = DEFAULT_RUNTIME_DIR
+
+    task_file = runtime_dir / "task_state" / f"{task_id}.json"
+    if not task_file.exists():
+        raise FileNotFoundError(f"Task state file not found: {task_file}")
+
+    data = json.loads(task_file.read_text())
+
+    # Ensure scope object exists
+    if "scope" not in data or not isinstance(data.get("scope"), dict):
+        data["scope"] = {"declared_files": [], "touched_files": []}
+
+    scope = data["scope"]
+
+    if declared_files is not None:
+        scope["declared_files"] = list(declared_files)
+
+    if touched_files is not None:
+        if append_touched:
+            existing = scope.get("touched_files", [])
+            # Deduplicate while preserving order
+            seen = set(existing)
+            merged = list(existing)
+            for f in touched_files:
+                if f not in seen:
+                    seen.add(f)
+                    merged.append(f)
+            scope["touched_files"] = merged
+        else:
+            scope["touched_files"] = list(touched_files)
+
+    data["scope"] = scope
+
+    # Atomic write via temp file
+    tmp_file = task_file.with_suffix(".tmp")
+    tmp_file.write_text(json.dumps(data, indent=2))
+    tmp_file.rename(task_file)
+
+    return data
+
+
+def get_task_scope(
+    task_id: str,
+    *,
+    runtime_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Read scope fields from a task state file.
+
+    Args:
+        task_id: Task identifier (filename stem in ``task_state/``).
+        runtime_dir: Override for the runtime directory root.
+
+    Returns:
+        The scope dict (``declared_files``, ``touched_files``), or an
+        empty dict if no scope is set.
+
+    Raises:
+        FileNotFoundError: If the task state file does not exist.
+    """
+    if runtime_dir is None:
+        runtime_dir = DEFAULT_RUNTIME_DIR
+
+    task_file = runtime_dir / "task_state" / f"{task_id}.json"
+    if not task_file.exists():
+        raise FileNotFoundError(f"Task state file not found: {task_file}")
+
+    data = json.loads(task_file.read_text())
+    return data.get("scope", {})

--- a/tests/unit/test_ops_cli.py
+++ b/tests/unit/test_ops_cli.py
@@ -1241,3 +1241,285 @@ class TestCmdCompact:
         assert rc == 0
         data = json.loads(capsys.readouterr().out)
         assert data == []
+
+
+# ---- PR-5: Scope CLI Tests ----
+
+
+class TestScopeShow:
+    """Tests for ops.py scope show."""
+
+    def test_show_scope(
+        self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import ops
+
+        (runtime_dir / "task_state" / "t1.json").write_text(
+            json.dumps(
+                {
+                    "task_id": "t1",
+                    "scope": {
+                        "declared_files": ["src/*.py"],
+                        "touched_files": ["src/a.py"],
+                    },
+                }
+            )
+        )
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "scope",
+                "show",
+                "--task",
+                "t1",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "src/*.py" in out
+        assert "src/a.py" in out
+
+    def test_show_scope_json(
+        self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import ops
+
+        (runtime_dir / "task_state" / "t1.json").write_text(
+            json.dumps(
+                {
+                    "task_id": "t1",
+                    "scope": {
+                        "declared_files": ["src/*.py"],
+                        "touched_files": [],
+                    },
+                }
+            )
+        )
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "scope",
+                "show",
+                "--task",
+                "t1",
+            ]
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["declared_files"] == ["src/*.py"]
+
+    def test_show_nonexistent_task(self, runtime_dir: Path, plans_dir: Path) -> None:
+        import ops
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "scope",
+                "show",
+                "--task",
+                "nonexistent",
+            ]
+        )
+        assert rc == 1
+
+
+class TestScopeSet:
+    """Tests for ops.py scope set."""
+
+    def test_set_declared(
+        self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import ops
+
+        (runtime_dir / "task_state" / "t1.json").write_text(
+            json.dumps({"task_id": "t1", "status": "in_progress"})
+        )
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "scope",
+                "set",
+                "--task",
+                "t1",
+                "--declared",
+                "src/bid_euchre/ops/*.py",
+                "tests/unit/test_ops_*.py",
+            ]
+        )
+        assert rc == 0
+        # Verify the file was updated
+        data = json.loads((runtime_dir / "task_state" / "t1.json").read_text())
+        assert data["scope"]["declared_files"] == [
+            "src/bid_euchre/ops/*.py",
+            "tests/unit/test_ops_*.py",
+        ]
+
+
+class TestScopeTouch:
+    """Tests for ops.py scope touch."""
+
+    def test_touch_files(
+        self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import ops
+
+        (runtime_dir / "task_state" / "t1.json").write_text(
+            json.dumps(
+                {
+                    "task_id": "t1",
+                    "status": "in_progress",
+                    "scope": {"declared_files": [], "touched_files": ["a.py"]},
+                }
+            )
+        )
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "scope",
+                "touch",
+                "--task",
+                "t1",
+                "--file",
+                "b.py",
+                "c.py",
+            ]
+        )
+        assert rc == 0
+        data = json.loads((runtime_dir / "task_state" / "t1.json").read_text())
+        assert data["scope"]["touched_files"] == ["a.py", "b.py", "c.py"]
+
+
+# ---- PR-5: Retry Event Emission Tests ----
+
+
+class TestRetryEmit:
+    """Tests for ops.py retry --emit."""
+
+    def test_retry_emits_event(
+        self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import ops
+
+        # Create a task_failed event to give retry something to evaluate
+        events_file = runtime_dir / "events" / "events.jsonl"
+        lines = [
+            json.dumps(
+                {
+                    "timestamp": "2026-03-18T10:00:00Z",
+                    "event_type": "task_failed",
+                    "source": "test",
+                    "lane_id": "author-a",
+                    "payload": {"task_id": "t1", "details": "lint error"},
+                }
+            )
+        ]
+        events_file.write_text("\n".join(lines) + "\n")
+
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "retry",
+                "--task",
+                "t1",
+                "--lane",
+                "author-a",
+                "--emit",
+            ]
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["action"] == "retry"
+
+        # Verify event was emitted
+        events_content = events_file.read_text()
+        assert "retry_attempted" in events_content
+
+    def test_retry_no_emit_by_default(
+        self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import ops
+
+        events_file = runtime_dir / "events" / "events.jsonl"
+        events_file.write_text("")
+
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "retry",
+                "--task",
+                "t1",
+            ]
+        )
+        assert rc == 0
+        # No event emitted when --emit not passed
+        events_content = events_file.read_text()
+        assert "retry_attempted" not in events_content
+
+    def test_retry_reroute_emits_task_rerouted(
+        self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import ops
+
+        events_file = runtime_dir / "events" / "events.jsonl"
+        lines = [
+            json.dumps(
+                {
+                    "timestamp": f"2026-03-18T10:0{i}:00Z",
+                    "event_type": "task_failed",
+                    "source": "test",
+                    "lane_id": "author-a",
+                    "payload": {"task_id": "t1", "details": f"error {i}"},
+                }
+            )
+            for i in range(3)
+        ]
+        events_file.write_text("\n".join(lines) + "\n")
+
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "retry",
+                "--task",
+                "t1",
+                "--lane",
+                "author-a",
+                "--max-retries",
+                "3",
+                "--emit",
+            ]
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["action"] == "reroute"
+
+        # Verify event was emitted
+        events_content = events_file.read_text()
+        assert "task_rerouted" in events_content

--- a/tests/unit/test_ops_status.py
+++ b/tests/unit/test_ops_status.py
@@ -12,9 +12,11 @@ from bid_euchre.ops.status import (
     aggregate_status,
     format_status_json,
     format_status_text,
+    get_task_scope,
     load_lane_registry,
     load_sessions,
     load_tasks,
+    update_task_scope,
 )
 
 
@@ -419,3 +421,156 @@ class TestFormatters:
         text = format_status_text(report)
         assert "Warnings: 1" in text
         assert "Something is wrong" in text
+
+
+# ---- Task Scope Management Tests ----
+
+
+class TestUpdateTaskScope:
+    """Tests for update_task_scope()."""
+
+    def test_set_declared_files(self, runtime_dir: Path) -> None:
+        (runtime_dir / "task_state" / "t1.json").write_text(
+            json.dumps({"task_id": "t1", "status": "in_progress"})
+        )
+        result = update_task_scope(
+            "t1",
+            declared_files=["src/bid_euchre/ops/*.py"],
+            runtime_dir=runtime_dir,
+        )
+        assert result["scope"]["declared_files"] == ["src/bid_euchre/ops/*.py"]
+        assert result["scope"]["touched_files"] == []
+
+    def test_set_touched_files_replace(self, runtime_dir: Path) -> None:
+        (runtime_dir / "task_state" / "t1.json").write_text(
+            json.dumps(
+                {
+                    "task_id": "t1",
+                    "status": "in_progress",
+                    "scope": {
+                        "declared_files": [],
+                        "touched_files": ["old.py"],
+                    },
+                }
+            )
+        )
+        result = update_task_scope(
+            "t1",
+            touched_files=["new.py"],
+            runtime_dir=runtime_dir,
+        )
+        assert result["scope"]["touched_files"] == ["new.py"]
+
+    def test_append_touched_deduplicates(self, runtime_dir: Path) -> None:
+        (runtime_dir / "task_state" / "t1.json").write_text(
+            json.dumps(
+                {
+                    "task_id": "t1",
+                    "status": "in_progress",
+                    "scope": {
+                        "declared_files": [],
+                        "touched_files": ["a.py", "b.py"],
+                    },
+                }
+            )
+        )
+        result = update_task_scope(
+            "t1",
+            touched_files=["b.py", "c.py"],
+            append_touched=True,
+            runtime_dir=runtime_dir,
+        )
+        assert result["scope"]["touched_files"] == ["a.py", "b.py", "c.py"]
+
+    def test_creates_scope_object_if_missing(self, runtime_dir: Path) -> None:
+        (runtime_dir / "task_state" / "t1.json").write_text(
+            json.dumps({"task_id": "t1", "status": "in_progress"})
+        )
+        result = update_task_scope(
+            "t1",
+            declared_files=["*.py"],
+            runtime_dir=runtime_dir,
+        )
+        assert "scope" in result
+        assert result["scope"]["declared_files"] == ["*.py"]
+        assert result["scope"]["touched_files"] == []
+
+    def test_raises_on_missing_task(self, runtime_dir: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            update_task_scope(
+                "nonexistent",
+                declared_files=["*.py"],
+                runtime_dir=runtime_dir,
+            )
+
+    def test_raises_on_no_arguments(self, runtime_dir: Path) -> None:
+        (runtime_dir / "task_state" / "t1.json").write_text(
+            json.dumps({"task_id": "t1"})
+        )
+        with pytest.raises(ValueError, match="At least one"):
+            update_task_scope("t1", runtime_dir=runtime_dir)
+
+    def test_atomic_write(self, runtime_dir: Path) -> None:
+        """Verify file is rewritten atomically (no .tmp leftover)."""
+        (runtime_dir / "task_state" / "t1.json").write_text(
+            json.dumps({"task_id": "t1", "status": "in_progress"})
+        )
+        update_task_scope(
+            "t1",
+            declared_files=["src/*.py"],
+            runtime_dir=runtime_dir,
+        )
+        assert not (runtime_dir / "task_state" / "t1.tmp").exists()
+        # Verify file is valid JSON
+        data = json.loads((runtime_dir / "task_state" / "t1.json").read_text())
+        assert data["scope"]["declared_files"] == ["src/*.py"]
+
+    def test_preserves_other_fields(self, runtime_dir: Path) -> None:
+        (runtime_dir / "task_state" / "t1.json").write_text(
+            json.dumps(
+                {
+                    "task_id": "t1",
+                    "status": "in_progress",
+                    "subject": "Do something",
+                    "owner_lane": "author-a",
+                }
+            )
+        )
+        result = update_task_scope(
+            "t1",
+            declared_files=["src/*.py"],
+            runtime_dir=runtime_dir,
+        )
+        assert result["subject"] == "Do something"
+        assert result["owner_lane"] == "author-a"
+
+
+class TestGetTaskScope:
+    """Tests for get_task_scope()."""
+
+    def test_returns_scope(self, runtime_dir: Path) -> None:
+        (runtime_dir / "task_state" / "t1.json").write_text(
+            json.dumps(
+                {
+                    "task_id": "t1",
+                    "scope": {
+                        "declared_files": ["src/*.py"],
+                        "touched_files": ["src/a.py"],
+                    },
+                }
+            )
+        )
+        scope = get_task_scope("t1", runtime_dir=runtime_dir)
+        assert scope["declared_files"] == ["src/*.py"]
+        assert scope["touched_files"] == ["src/a.py"]
+
+    def test_returns_empty_dict_if_no_scope(self, runtime_dir: Path) -> None:
+        (runtime_dir / "task_state" / "t1.json").write_text(
+            json.dumps({"task_id": "t1"})
+        )
+        scope = get_task_scope("t1", runtime_dir=runtime_dir)
+        assert scope == {}
+
+    def test_raises_on_missing_task(self, runtime_dir: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            get_task_scope("nonexistent", runtime_dir=runtime_dir)


### PR DESCRIPTION
## Summary

- Wire CI event producers in `ci_poller.sh` → `ci_failure`/`ci_success` events emitted to durable event log
- Add task scope management API (`update_task_scope()`, `get_task_scope()`) and CLI (`ops.py scope {show,set,touch}`)
- Add event emission to `ops.py retry --emit` → emits `retry_attempted`, `task_rerouted`, or `escalation` events
- Update `AUTONOMOUS_OPERATOR_WORKFLOW.md` with complete CLI reference, event producer table, rollback instructions

## Why

Closes the three deferred producer gaps from Phase 3D (PR #927):
- **#928**: `check_ci_stuck()` watchdog had no CI events to read → now `ci_poller.sh` emits them
- **#929**: `check_scope_drift()` watchdog had no scope fields → now `ops.py scope` manages them
- **#930**: retry/reroute policy had no event trail → now `--emit` flag writes events

This makes all 6 watchdogs in `run_all_watchdogs()` functional against real data, completing the autonomous operator stack rollout.

Closes #928, #929, #930.

## Repro / Validation

```bash
# Run targeted tests (all 160 pass, 0 regressions)
uv run python -m pytest tests/unit/test_ops_status.py tests/unit/test_ops_watchdogs.py tests/unit/test_ops_recovery.py tests/unit/test_ops_cli.py -x -q

# Full validation
make check-quiet
```

## Tests

- `test_ops_status.py`: 11 new tests for `update_task_scope()` and `get_task_scope()` API
- `test_ops_cli.py`: 8 new tests for scope CLI (`show`, `set`, `touch`) and retry emit (`--emit`, default off, reroute event)
- All 160 ops tests pass with zero regressions

## Validation Performed

### Automated Tests
```
160 passed in 0.98s
```
- 19 new tests covering all new code paths
- Zero regressions in existing ops test suite

### Manual Smoke Checks
- `ops.py watchdogs` — 7 findings (all worktree warnings, no false positives on CI/scope)
- `ops.py health` — coherent text output with status + watchdogs
- `ops.py --json health` — valid JSON, `"healthy": true`
- `ops.py scope show/set/touch` — all produce correct output

### Failure Injection
1. **CI stuck detection**: Injected `ci_failure` event 60min ago → watchdog detected "CI stuck failing on PR #999 for 60min (lint)". Added `ci_success` → stuck finding cleared. ✅
2. **Scope drift**: Created task with declared `src/bid_euchre/ops/*.py`, touched `src/bid_euchre/strategy/heuristic.py` → watchdog detected "touched files outside declared scope: src/bid_euchre/strategy/heuristic.py". ✅
3. **Retry at cap**: 3 `task_failed` events → `ops.py retry --emit` recommended REROUTE to author-b, emitted `task_rerouted` event to log. ✅
4. **Graceful degradation**: Empty runtime state → all watchdogs return normally, `recover` shows "All clear", scope show on nonexistent task returns error code 1. ✅

### Rollback Path
- CI event emission: Remove `emit_ci_event` calls from `ci_poller.sh` (fire-and-forget, no behavioral change)
- Scope tracking: Stop calling `ops.py scope` — watchdog degrades gracefully (no crash, no false positives)
- Retry events: Omit `--emit` flag (default: off)
- All changes are additive; no existing behavior is modified

### Known Gaps
- Fully automated scope tracking via file-write hooks (deferred — complex, needs per-task context)
- Automated retry execution (currently advisory only)
- CI event emission from GitHub Actions (currently only from local CI poller)

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)