### PR TITLE
docs: fix implementation history PR count (10 → 11)

### DIFF
--- a/plans/arc_d_v2/reporting_refactor_full_plan.md
+++ b/plans/arc_d_v2/reporting_refactor_full_plan.md
@@ -938,7 +938,7 @@ Accepted degraded states documented in §16.6.
 
 ### Implementation History
 
-10 PRs merged covering Phases 0-6 plus final closeout:
+11 PRs merged covering Phases 0-6 plus final closeout:
 
 | PR | Scope | Status |
 |----|-------|--------|


### PR DESCRIPTION
## Summary

- Fix stale PR count in Implementation History header: `10` → `11`

## Why

Codex review on PR #965 found the Outcome block says "11 PRs merged" while the Implementation History header still said "10 PRs merged" — an internal inconsistency introduced when #948 and #962 were added to the table but only the Outcome count was updated.

## Test plan

- [x] Docs-only, 1-line change
- [x] All three "PRs merged" references now consistent: line 913 = 7 (historical §14 context), lines 936 and 941 = 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)