### PR TITLE
fix: harden ops persistence — atomic writes, per-entry recovery, partial archive cleanup

### DIFF
--- a/src/bid_euchre/ops/compaction.py
+++ b/src/bid_euchre/ops/compaction.py
@@ -208,6 +208,10 @@ def compact_session(
 
     except OSError as e:
         logger.error("Failed to compact session %s: %s", session_id, e)
+        # Clean up partial archive so a retry is not permanently blocked
+        # by a stale directory (see #954).
+        if session_dir.exists():
+            shutil.rmtree(session_dir)
         return CompactionResult(
             session_id=session_id,
             archive_path=str(session_dir),

--- a/src/bid_euchre/ops/memory.py
+++ b/src/bid_euchre/ops/memory.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import tempfile
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -96,11 +98,21 @@ class MemoryStore:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> MemoryStore:
-        """Create from a dict."""
+        """Create from a dict.
+
+        Malformed entries are skipped with a warning rather than failing
+        the entire load (see #950).
+        """
+        entries: list[MemoryEntry] = []
+        for raw in data.get("entries", []):
+            try:
+                entries.append(MemoryEntry.from_dict(raw))
+            except (KeyError, TypeError) as e:
+                logger.warning("Skipping malformed memory entry: %s", e)
         return cls(
             version=data.get("version", 1),
             last_updated=data.get("last_updated"),
-            entries=[MemoryEntry.from_dict(e) for e in data.get("entries", [])],
+            entries=entries,
         )
 
 
@@ -153,24 +165,30 @@ def load_memory(memory_dir: Path) -> MemoryStore:
 
 
 def save_memory(store: MemoryStore, memory_dir: Path) -> None:
-    """Save curated memory to disk.
+    """Save curated memory to disk atomically.
 
-    Uses exclusive file locking (``fcntl.flock``) to prevent corruption
-    when multiple agents write concurrently.
+    Writes to a same-directory tempfile, fsyncs, then atomically replaces
+    the target via ``os.replace()`` so a crash mid-write cannot leave a
+    truncated file (see #951).
     """
-    import fcntl
-
     memory_dir.mkdir(parents=True, exist_ok=True)
     memory_path = _get_memory_path(memory_dir)
     store.last_updated = _now_iso()
     content = json.dumps(store.to_dict(), indent=2) + "\n"
-    with open(memory_path, "w") as f:
-        fcntl.flock(f, fcntl.LOCK_EX)
+
+    fd, tmp = tempfile.mkstemp(dir=str(memory_dir), suffix=".tmp")
+    try:
+        os.write(fd, content.encode("utf-8"))
+        os.fsync(fd)
+        os.close(fd)
+        os.replace(tmp, str(memory_path))
+    except BaseException:
+        os.close(fd)
         try:
-            f.write(content)
-            f.flush()
-        finally:
-            fcntl.flock(f, fcntl.LOCK_UN)
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 # ── Validation ───────────────────────────────────────────────────

--- a/tests/unit/test_ops_compaction.py
+++ b/tests/unit/test_ops_compaction.py
@@ -162,6 +162,58 @@ class TestCompactSession:
         )
         assert result.success
 
+    def test_partial_write_failure_cleans_up(self, archive_dir: Path) -> None:
+        """A failed compaction must not leave a stale dir that blocks retry (#954)."""
+        from unittest.mock import patch
+
+        session_id = "session-fail"
+        session_dir = archive_dir / session_id
+
+        # Patch Path.write_text to fail on artifacts.json (after metadata.json
+        # has been written, so the directory exists with partial content).
+        original_write_text = Path.write_text
+        call_count = 0
+
+        def failing_write_text(
+            self_path: Path, *args: object, **kwargs: object
+        ) -> None:
+            nonlocal call_count
+            call_count += 1
+            # Let metadata.json succeed (call 1), fail on artifacts.json (call 2)
+            if call_count == 2:
+                raise OSError("Simulated disk full")
+            original_write_text(self_path, *args, **kwargs)
+
+        with patch.object(Path, "write_text", failing_write_text):
+            result = compact_session(
+                session_id=session_id,
+                lane_id="author-a",
+                context_text="context",
+                artifacts=[
+                    ArtifactRef(path="src/foo.py", action="created"),
+                ],
+                archive_dir=archive_dir,
+            )
+
+        # First call should fail
+        assert not result.success
+        assert "Simulated disk full" in result.error
+
+        # Partial directory must be cleaned up
+        assert (
+            not session_dir.exists()
+        ), "Partial archive dir should be removed after failure"
+
+        # Retry with same session_id must succeed (not blocked by stale dir)
+        result2 = compact_session(
+            session_id=session_id,
+            lane_id="author-a",
+            context_text="retry context",
+            artifacts=[],
+            archive_dir=archive_dir,
+        )
+        assert result2.success
+
 
 class TestRetrieval:
     """Tests for list_archives, get_archive, get_archive_artifacts, get_archive_context."""

--- a/tests/unit/test_ops_memory.py
+++ b/tests/unit/test_ops_memory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -83,6 +84,89 @@ class TestLoadSave:
         store = MemoryStore()
         save_memory(store, nested)
         assert (nested / "memory.json").exists()
+
+    def test_load_skips_malformed_entries(
+        self, memory_dir: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A single bad entry must not discard the entire store (#950)."""
+        import json as _json
+
+        good_entry = {
+            "entry_id": "aaa",
+            "category": "repo_fact",
+            "key": "k1",
+            "value": "v1",
+            "source_file": "f.md",
+            "added_by": "test",
+            "added_at": "2026-03-18T10:00:00+00:00",
+        }
+        bad_entry = {
+            # missing entry_id -- will raise KeyError
+            "category": "repo_fact",
+            "key": "k2",
+            "value": "v2",
+            "source_file": "f.md",
+            "added_by": "test",
+            "added_at": "2026-03-18T11:00:00+00:00",
+        }
+        good_entry_2 = {
+            "entry_id": "ccc",
+            "category": "preference",
+            "key": "k3",
+            "value": "v3",
+            "source_file": "f.md",
+            "added_by": "test",
+            "added_at": "2026-03-18T12:00:00+00:00",
+        }
+        data = {
+            "version": 1,
+            "last_updated": "2026-03-18T12:00:00+00:00",
+            "entries": [good_entry, bad_entry, good_entry_2],
+        }
+        (memory_dir / "memory.json").write_text(_json.dumps(data))
+
+        with caplog.at_level(logging.WARNING, logger="ops.memory"):
+            store = load_memory(memory_dir)
+
+        # Two good entries survive; the bad one is skipped
+        assert len(store.entries) == 2
+        assert store.entries[0].entry_id == "aaa"
+        assert store.entries[1].entry_id == "ccc"
+        # Top-level metadata preserved
+        assert store.version == 1
+        assert store.last_updated == "2026-03-18T12:00:00+00:00"
+        # Warning was logged
+        assert any(
+            "malformed memory entry" in r.message.lower() for r in caplog.records
+        )
+
+    def test_save_atomic_no_temp_files(self, memory_dir: Path) -> None:
+        """After save_memory(), no .tmp files should remain (#951)."""
+        store = MemoryStore(
+            entries=[
+                MemoryEntry(
+                    entry_id="abc",
+                    category="repo_fact",
+                    key="test",
+                    value="val",
+                    source_file="f.md",
+                    added_by="test",
+                    added_at="2026-03-18T10:00:00+00:00",
+                )
+            ]
+        )
+        save_memory(store, memory_dir)
+
+        # No leftover temp files
+        tmp_files = list(memory_dir.glob("*.tmp"))
+        assert tmp_files == [], f"Leftover temp files: {tmp_files}"
+
+        # The written file is valid JSON
+        import json as _json
+
+        data = _json.loads((memory_dir / "memory.json").read_text())
+        assert data["version"] == 1
+        assert len(data["entries"]) == 1
 
 
 class TestValidation:


### PR DESCRIPTION
## Plan
`plans/sessions/2026-03-19_ops-persistence-hardening.md`

## Summary
- Per-entry error handling in `MemoryStore.from_dict()`: a single malformed entry no longer discards the entire curated memory store (#950)
- Atomic writes in `save_memory()`: write to tempfile + fsync + `os.replace` prevents truncated `memory.json` on agent crash (#951)
- Partial archive cleanup in `compact_session()`: failed compaction removes the partial session directory so retry is not permanently blocked (#954)

## Why
PR #940 introduced curated memory and session compaction. Post-merge review identified three reliability bugs that form a realistic data-loss chain: agent dies mid-write (#951) -> truncated JSON -> next load returns empty store (#950) -> next save persists empty store -> all curated memory permanently lost. Additionally, partial archive directories block retry permanently (#954).

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_memory.py tests/unit/test_ops_compaction.py -v
make check-quiet
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Validation Performed

### Tier 1 — Targeted tests (75/75 pass)
```
tests/unit/test_ops_memory.py::TestLoadSave::test_load_skips_malformed_entries PASSED
tests/unit/test_ops_memory.py::TestLoadSave::test_save_atomic_no_temp_files PASSED
tests/unit/test_ops_compaction.py::TestCompactSession::test_partial_write_failure_cleans_up PASSED
```
All 75 tests in both files pass.

### Tier 2 — Full validation
```
make check-quiet -> All checks passed
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_memory.py tests/unit/test_ops_compaction.py -v` (75 passed)
- [x] `make check-quiet` (all checks passed)
- [ ] Integration (if engine/rules changed): N/A — ops package only

## Expected impact
- Metrics impact: None — ops infrastructure only, no game/scoring/experiment code touched
- Runtime impact: Negligible — `os.replace` adds one syscall per save, `shutil.rmtree` only on error path

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/worktree-codex-harden-ops
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/worktree-codex-harden-ops
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         580a44f [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/worktree-codex-harden-ops          871eaab [codex/harden-ops-persistence]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

Closes #950, #951, #954