### PR TITLE
fix: simplify claude-code-review workflow to documented v1 pattern

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,8 +36,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          prompt: |
+            Review this pull request for code quality, correctness, and security.
+            Analyze the diff, then post your findings as review comments.
+            Follow the project's CLAUDE.md guidelines.
+          claude_args: "--max-turns 5"

--- a/tests/unit/test_claude_review_workflow.py
+++ b/tests/unit/test_claude_review_workflow.py
@@ -1,0 +1,51 @@
+"""Regression tests for .github/workflows/claude-code-review.yml structure."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[2] / ".github/workflows/claude-code-review.yml"
+)
+
+
+class TestClaudeReviewWorkflow:
+    """Validate claude-code-review.yml has the expected structure."""
+
+    def setup_method(self):
+        self.cfg = yaml.safe_load(WORKFLOW.read_text())
+
+    def test_uses_v1_action(self):
+        step = self._review_step()
+        assert step["uses"] == "anthropics/claude-code-action@v1"
+
+    def test_has_oauth_token(self):
+        step = self._review_step()
+        with_block = step["with"]
+        assert "claude_code_oauth_token" in with_block
+
+    def test_no_plugin_marketplaces(self):
+        """plugin_marketplaces causes 'claude not found' errors on runners."""
+        step = self._review_step()
+        with_block = step["with"]
+        assert "plugin_marketplaces" not in with_block
+        assert "plugins" not in with_block
+
+    def test_has_prompt(self):
+        step = self._review_step()
+        assert "prompt" in step["with"]
+
+    def test_has_max_turns(self):
+        step = self._review_step()
+        assert "claude_args" in step["with"]
+        assert "--max-turns" in step["with"]["claude_args"]
+
+    def _review_step(self):
+        """Return the 'Run Claude Code Review' step."""
+        steps = self.cfg["jobs"]["claude-review"]["steps"]
+        for s in steps:
+            if s.get("id") == "claude-review":
+                return s
+        raise AssertionError("claude-review step not found")


### PR DESCRIPTION
## Summary
- Remove `plugin_marketplaces` and `plugins` config from `claude-code-review.yml` that caused "Executable not found in $PATH: claude" errors on every PR
- Switch to the simpler prompt-based pattern from Anthropic's official docs
- Add regression tests to prevent reintroduction of the broken config

## Why
The `plugin_marketplaces` config tried to run `claude marketplace add ...` which requires the `claude` CLI to already be on the runner's PATH. But the action installs the CLI *during* its run, creating a chicken-and-egg failure. Every PR showed a red `claude-review` check.

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_claude_review_workflow.py -v
```

All 5 tests pass:
- `test_uses_v1_action` - confirms v1 action reference
- `test_has_oauth_token` - confirms OAuth auth
- `test_no_plugin_marketplaces` - regression guard against broken config
- `test_has_prompt` - confirms prompt-based review
- `test_has_max_turns` - confirms max-turns limit

## Tests
```bash
uv run python -m pytest tests/unit/test_claude_review_workflow.py -v  # 5 passed
```

## Worktree proof
Working in `.claude/worktrees/fix-claude-review-workflow`

Closes #970

🤖 Generated with [Claude Code](https://claude.com/claude-code)