### PR TITLE
docs: add issue-triage workflow and agent profile (PR-5 slice 2)

### DIFF
--- a/.claude/agents/issues.md
+++ b/.claude/agents/issues.md
@@ -1,0 +1,50 @@
+---
+name: issues
+description: Bounded issue-triage agent for creating deduplicated GitHub issues from qualified operational findings.
+---
+
+You are an issue-triage agent. Your job is to capture qualified operational
+findings as deduplicated GitHub issues. You do NOT fix issues — you file them.
+
+## Operating Rules
+
+1. **Triage only.** Create and update issues. Do not implement fixes unless
+   the issue is `agent-ready` AND assigned to your lane.
+2. **Qualify before filing.** A finding must meet at least one threshold:
+   - Observed >=2 times in separate sessions or PRs
+   - Correctness or contract violation (any count)
+   - Explicitly flagged `agent-ready` by a reviewer
+3. **Dedupe before creating.** Search open issues for matching category and
+   subsystem. If found, append a comment instead of creating a duplicate.
+4. **Respect the budget.** Maximum 5 new issues per session. Stop and log
+   overflow findings in session notes.
+5. **Use structured titles.** Format: `[<category>] <subsystem>: <description>`
+   where category is one of: `triage`, `infra`, `fix`, `convention`.
+6. **Label correctly.** Every triage issue gets the `triage` label plus
+   exactly one `fix:*` label. Add `needs-human` if the fix requires a
+   human decision.
+7. **Do not add `agent-ready` unilaterally.** If you believe an issue is
+   ready for autonomous work, add a comment explaining why — do not add
+   the label yourself.
+
+## What NOT to File
+
+- One-time transient failures (retry succeeded)
+- Style preferences without a documented convention
+- Speculative improvements without evidence
+- Findings already tracked in an open issue (update it instead)
+
+## Issue Body Template
+
+Use the template from `docs/02_agent/ISSUE_TRIAGE_WORKFLOW.md` (Finding,
+Evidence, Context, Suggested Fix, Constraints sections).
+
+## Existing Systems — Do Not Duplicate
+
+- `review_driver.py` creates follow-up issues with `fix(<label>)` prefix
+- `infra_incident_dedupe.yml` creates infra issues with `[infra]` prefix
+- Do not create triage issues for findings that these systems already handle
+
+## Reference
+
+Full workflow specification: `docs/02_agent/ISSUE_TRIAGE_WORKFLOW.md`

--- a/docs/02_agent/AUTONOMOUS_OPERATOR_WORKFLOW.md
+++ b/docs/02_agent/AUTONOMOUS_OPERATOR_WORKFLOW.md
@@ -784,19 +784,20 @@ workflow (`plans/sessions/2026-03-15_autonomous-agent-ops-workflow.md`):
 | PR-3 | Operator CLI (`ops.py`), reviews/CI surfaces, scheduler, watchdogs, retry/reroute | Shipped |
 | PR-4 | Audit index, curated memory, session compaction | Shipped |
 | PR-5 (slice 1) | CI event producers, scope management, retry events | Shipped (#961) |
+| PR-5 (slice 2) | Issue-triage workflow, agent profile, conventions | Shipped |
 
 > **Note:** PR-5 in the governing plan covers the full rollout/integration
 > phase including context safety, skill promotion, issue triage, and shadow
-> snapshots. Only the deferred watchdog producer wiring slice has shipped
-> so far. The remaining PR-5 deliverables are listed under
-> "Remaining Future Work."
+> snapshots. Slices 1 (event producers/scope) and 2 (issue triage) have
+> shipped. The remaining PR-5 deliverables are listed under
+> "Remaining Future Work." Issue-triage details:
+> `docs/02_agent/ISSUE_TRIAGE_WORKFLOW.md`.
 
 ### Remaining Future Work (PR-5 continuation)
 
 - Context safety scanning for auto-loaded content
 - Shadow snapshots and rollback workflow
 - Skill promotion workflow (promote repeated multi-step workflows into skills)
-- Issue-triage workflow and conventions for qualified operational findings
 - Fully automated scope tracking via file-write hooks
 - Automated retry execution (currently advisory only)
 - CI event emission from GitHub Actions (currently only from local CI poller)

--- a/docs/02_agent/ISSUE_TRIAGE_WORKFLOW.md
+++ b/docs/02_agent/ISSUE_TRIAGE_WORKFLOW.md
@@ -1,0 +1,280 @@
+# Issue Triage Workflow
+
+This document defines how autonomous agents create, deduplicate, and manage
+GitHub issues for qualified operational findings. It is part of the PR-5
+rollout of the autonomous operator workflow.
+
+**Governing plan:** `plans/sessions/2026-03-15_autonomous-agent-ops-workflow.md`
+
+---
+
+## Core Principle
+
+**Issue existence does not imply autonomous coding authority.**
+
+Issues created through this workflow capture knowledge and track backlog.
+They do not authorize implementation work unless explicitly gated (see
+[Execution Gate](#execution-gate) below).
+
+---
+
+## Qualification Thresholds
+
+A finding qualifies for a GitHub issue when **any** of the following are true:
+
+| Condition | Rationale |
+|-----------|-----------|
+| Observed >=2 times in separate sessions or PRs | Pattern, not noise |
+| Correctness or contract violation (any count) | Severity overrides frequency |
+| Explicitly flagged `agent-ready` by a reviewer | Human-endorsed priority |
+
+A finding does **not** qualify when:
+
+| Condition | Action Instead |
+|-----------|---------------|
+| One-time transient failure (retry succeeded) | Log and move on |
+| Already tracked in an open issue | Append comment to existing issue |
+| Style preference without a documented convention | Ignore or propose convention first |
+| Speculative improvement without evidence | Discuss in session, do not file |
+
+---
+
+## Dedupe Key Contract
+
+### Title Prefix Scheme for Agent-Created Triage Issues
+
+All agent-created triage issues use a structured title prefix:
+
+```
+[<category>] <subsystem>: <short_description>
+```
+
+**Category values:**
+
+| Category | When to use |
+|----------|-------------|
+| `triage` | General operational findings from agent sessions |
+| `infra` | Infrastructure failures (aligns with infra-incident workflow) |
+| `fix` | Code-level findings from reviews or validation |
+| `convention` | Convention or style findings that have a documented rule |
+
+**Examples:**
+
+```
+[triage] ops/events: stale event file not drained after 72h
+[fix] strategy/heuristic: unseeded random in play_card fallback
+[convention] tests: missing assertion for new behavior in test_watchdogs
+```
+
+### Dedupe Procedure
+
+Before creating any issue, an agent **must**:
+
+1. Search open issues with matching `category` and `subsystem` in the title
+2. If a matching open issue exists: **append a timestamped comment** with
+   the new occurrence details instead of creating a duplicate
+3. If no match exists: create a new issue using the title prefix scheme
+
+### Existing Issue-Creation Systems (Unchanged)
+
+This prefix scheme applies **only** to new agent-created triage issues.
+Existing systems keep their own title formats:
+
+| Creator | Title Format | Modified? |
+|---------|-------------|-----------|
+| `review_driver.py` | `fix(<label>): follow-up for PR #N` | No |
+| `infra_incident_dedupe.yml` | `[infra] <subsystem> <failure_key>` | No |
+| Manual (steward review) | Free-form | No |
+| **Agent triage (this workflow)** | `[<category>] <subsystem>: <desc>` | N/A (new) |
+
+When the `[infra]` category is used for agent-created triage issues, the
+agent should first check whether the existing `infra_incident_dedupe.yml`
+workflow is more appropriate. Prefer the GitHub Actions workflow for
+CI/infrastructure failures that have a clear subsystem and failure key.
+
+---
+
+## Label Taxonomy
+
+### New Labels
+
+| Label | Color | Purpose |
+|-------|-------|---------|
+| `triage` | `#D4C5F9` | Agent-created triage issues from this workflow |
+| `agent-ready` | `#0E8A16` | Issue is pre-analyzed and safe for autonomous implementation |
+| `needs-human` | `#B60205` | Issue requires human decision before work begins |
+
+### Existing Labels (Reused As-Is)
+
+| Label | Applied When |
+|-------|-------------|
+| `follow-up` | Review-loop follow-up issues (from `review_driver.py`) |
+| `fix:bug` | Correctness findings (C1, C2) |
+| `fix:convention` | Convention/auto-fix findings |
+| `fix:test` | Untested behavior changes (T1) |
+| `fix:docs` | Undocumented contract changes (X2) |
+| `fix:process` | Process/workflow findings (X1, X3, N1/N2/N3) |
+| `infra-incident` | Infrastructure failures |
+| `steward-review` | Periodic steward review findings |
+
+### Label Selection Rules
+
+Every agent-created triage issue must have:
+1. The `triage` label (identifies the creation source)
+2. Exactly one `fix:*` label matching the finding category
+3. Optionally `agent-ready` or `needs-human` for execution gating
+
+Do not add `follow-up` to triage issues — that label is reserved for
+`review_driver.py` outputs.
+
+---
+
+## Execution Gate
+
+### The Rule
+
+An agent may only begin autonomous implementation work on a triage issue
+when **all** of the following are true:
+
+1. The issue has the `agent-ready` label
+2. The issue is assigned to a specific lane (via GitHub assignee or a
+   comment like `assigned: author-a`)
+3. The agent's current task contract includes the issue's scope
+4. The work fits within the agent's lane charter (see
+   `AUTONOMOUS_OPERATOR_WORKFLOW.md` Lane Capability Matrix)
+
+### What This Means
+
+- Issues **without** `agent-ready` are backlog only. They document findings
+  but do not authorize any code changes.
+- The `agent-ready` label is added by:
+  - A human reviewer who has verified the issue is well-defined
+  - An agent reviewer who has confirmed the fix is bounded and safe
+  - The `needs-human` label, if present, explicitly blocks `agent-ready`
+- An agent that discovers a qualified finding should **create the issue**
+  and **stop**. It should not also start fixing it in the same session
+  unless the finding is already `agent-ready` and assigned.
+
+### Escalation
+
+If an agent believes an issue is `agent-ready` but it lacks the label:
+1. Add a comment explaining why it appears ready
+2. Do not add the label unilaterally
+3. Continue with other work
+
+---
+
+## Anti-Spam Rules
+
+| Rule | Threshold | Rationale |
+|------|-----------|-----------|
+| Max new issues per session | 5 | Prevents runaway issue creation |
+| Cooldown between creates | 60 seconds | Rate-limits bursts |
+| Must search before create | Always | Dedupe is mandatory, not optional |
+| Must update-existing-first | Always | Append comment to matching open issue |
+| Transient failures | Never create issue | Retry first; only persistent patterns qualify |
+| Already-closed issues | Do not reopen | Create new issue referencing the closed one |
+
+### Budget Enforcement
+
+These thresholds are conventions enforced by agent discipline and the
+`.claude/agents/issues.md` profile, not by code. If a programmatic
+issue-creation helper is added in the future (e.g., under `src/bid_euchre/ops/`),
+it should enforce these limits at the API level.
+
+### What Happens at the Limit
+
+When an agent hits the session budget (5 issues):
+1. Stop creating issues for the remainder of the session
+2. Log remaining qualified findings in session notes or `checkpoints.md`
+3. Note the overflow in the session handoff so the next session can resume
+
+---
+
+## Project Routing (Optional)
+
+If GitHub Projects are adopted for backlog management:
+
+- Agent-created triage issues should be added to a `Triage` project column
+- `agent-ready` issues move to a `Ready` column
+- Assigned issues move to an `In Progress` column
+- Completed issues move to `Done` on PR merge
+
+This routing is optional. The workflow functions without GitHub Projects —
+labels and assignees provide sufficient gating on their own.
+
+---
+
+## Issue Body Template
+
+Agent-created triage issues should use a consistent body format:
+
+```markdown
+## Finding
+
+<1-2 sentence description of the finding>
+
+## Evidence
+
+| Field | Value |
+|-------|-------|
+| **Category** | `<fix:bug / fix:convention / fix:test / fix:docs / fix:process>` |
+| **Subsystem** | `<module or file path>` |
+| **First observed** | <PR number or session date> |
+| **Occurrences** | <count> |
+| **Severity** | <BLOCK / WARN / INFO> |
+
+## Context
+
+<Additional context: related PRs, error messages, reproduction steps>
+
+## Suggested Fix
+
+<Brief description of expected fix, if known. "Needs investigation" if not.>
+
+## Constraints
+
+- [ ] Bounded to the identified subsystem
+- [ ] Does not require architectural changes
+- [ ] Has a clear test to lock the fix
+```
+
+---
+
+## Relationship to Existing Systems
+
+| System | Creates Issues? | This Workflow Applies? |
+|--------|----------------|----------------------|
+| Review loop (`review_driver.py`) | Yes (P2 findings) | No — uses its own `fix(<label>)` prefix |
+| Infra-incident workflow | Yes (infra failures) | No — uses its own `[infra]` prefix |
+| Post-merge review | No (creates PRs) | No |
+| Steward periodic review | Yes (manual) | No — manual, free-form |
+| **Agent triage (this doc)** | Yes | **Yes** |
+
+The agent triage workflow is additive. It does not replace, modify, or
+interfere with any existing issue-creation system.
+
+---
+
+## Disable / Rollback Path
+
+This workflow is purely prescriptive (documentation + agent profile). It has
+no code enforcement and no hooks. To disable or roll back:
+
+| Action | How | Impact |
+|--------|-----|--------|
+| Disable triage guidance | Delete `.claude/agents/issues.md` | Agents lose triage guidance; no other workflow affected |
+| Tighten qualification rules | Edit this doc's thresholds | Single-file change, no downstream breakage |
+| Remove workflow entirely | Delete this doc + `.claude/agents/issues.md` | Returns to pre-slice-2 state |
+| Remove new labels | Delete `triage`, `agent-ready`, `needs-human` from GitHub | No effect on existing issues using other labels |
+
+---
+
+## References
+
+- `plans/sessions/2026-03-15_autonomous-agent-ops-workflow.md` — PR-5 governing plan
+- `docs/02_agent/AUTONOMOUS_OPERATOR_WORKFLOW.md` — canonical operator workflow
+- `scripts/internal/review_driver.py` — existing review-loop issue creation
+- `.github/workflows/infra_incident_dedupe.yml` — existing infra-incident dedupe
+- `.claude/rules/deferred/60_review_gate.md` — follow-up issue labels and severity
+- `.claude/agents/issues.md` — agent profile for triage work

--- a/plans/sessions/2026-03-19_pr5-slice2-issue-triage.md
+++ b/plans/sessions/2026-03-19_pr5-slice2-issue-triage.md
@@ -1,0 +1,189 @@
+# PR-5 Slice 2: Issue-Triage Workflow
+
+**Date:** 2026-03-19
+**Parent plan:** `plans/sessions/2026-03-15_autonomous-agent-ops-workflow.md` (PR-5)
+**Slice 1:** #961 (CI event producers, scope management, retry emission)
+**Cleanup:** #966 (PR-5 scope labeling, escalation test coverage)
+
+## Goal
+
+Document the issue-triage workflow so that qualified operational findings can
+be captured as deduplicated GitHub issues without flooding the backlog or
+implying autonomous coding authority.
+
+## Scope
+
+### In scope
+
+1. **`docs/02_agent/ISSUE_TRIAGE_WORKFLOW.md`** — new canonical doc defining:
+   - Qualification thresholds (when a finding deserves an issue)
+   - Dedupe key contract (title prefix + label matching)
+   - Label taxonomy for triage issues (extends existing `follow-up`, `fix:*`,
+     `infra-incident`, `steward-review` labels)
+   - `agent-ready` gating — issue existence does not imply autonomous coding
+   - Anti-spam rules (issue budget, cooldown, update-existing-first)
+   - Project routing conventions (if GitHub Projects are adopted)
+   - Disable/rollback path
+
+2. **`docs/02_agent/AUTONOMOUS_OPERATOR_WORKFLOW.md`** — update Future Work
+   section to:
+   - Add "Issue Triage" subsection under Rollout and Safety
+   - Reference the new workflow doc
+   - Remove issue-triage from the implicit "not yet implemented" bucket
+
+3. **`.claude/agents/issues.md`** — optional agent profile providing bounded
+   triage guidance for any agent performing issue-triage work. This is a
+   lightweight prompt, not a persistent autonomous fixer.
+
+### Out of scope
+
+- Implementing a programmatic issue-creation helper in `src/bid_euchre/ops/`
+  (follow-on, not this slice)
+- Persistent `issues` lane or always-on issue fixer
+- GitHub Projects board setup (documented as optional convention)
+- Context-safety workflow (separate PR-5 slice)
+- Skill-promotion workflow (separate PR-5 slice)
+- Shadow snapshot/rollback workflow (separate PR-5 slice)
+
+## Existing Infrastructure
+
+The repo already has several issue-creation patterns to align with:
+
+| System | Pattern | Dedupe | Labels |
+|--------|---------|--------|--------|
+| Review loop (`review_driver.py`) | Creates follow-up issues for P2 findings | Title prefix `fix(<label>): follow-up for PR #N` | `follow-up`, `fix:bug`, `fix:convention`, `fix:test`, `fix:docs`, `fix:process` |
+| Infra-incident dedupe workflow (`.github/workflows/infra_incident_dedupe.yml`) | Creates or appends to infra-incident issues | Title prefix `[infra] <subsystem> <failure_key>` | `infra-incident`, `repeat-failure` |
+| Steward review | Manual issue creation from periodic reviews | Manual | `steward-review` |
+| Post-merge review | Background review agent creates fix PRs for critical findings | N/A (creates PRs, not issues) | N/A |
+
+The issue-triage workflow doc must be consistent with these existing patterns
+and must not create a competing dedupe scheme.
+
+## Design Decisions
+
+### Qualification Threshold
+
+A finding qualifies for an issue when:
+- It has been observed ≥2 times in separate sessions or PRs, OR
+- It is a correctness/contract violation regardless of occurrence count, OR
+- It is explicitly flagged by a reviewer as `agent-ready`
+
+A finding does NOT qualify when:
+- It is a one-time transient failure (retry succeeded)
+- It is already tracked in an open issue (update-existing instead)
+- It is a style preference without a documented convention
+
+### Dedupe Key Contract
+
+All agent-created issues use a structured title prefix for dedupe:
+
+```
+[<category>] <subsystem>: <failure_key>
+```
+
+Where `<category>` is one of: `triage`, `infra`, `fix`, `convention`.
+
+Before creating an issue, the agent must search open issues with the same
+category and subsystem. If found, append a comment instead of creating a
+duplicate.
+
+**Scope of this prefix scheme:** The `[<category>]` bracket prefix applies
+only to new agent-created triage issues. Existing issue-creation systems
+keep their own schemes and are not modified:
+
+| Creator | Title Format | Unchanged? |
+|---------|-------------|------------|
+| `review_driver.py` | `fix(<label>): follow-up for PR #N` | Yes |
+| `infra_incident_dedupe.yml` | `[infra] <subsystem> <failure_key>` | Yes |
+| Manual (steward review) | Free-form | Yes |
+| **New: agent triage** | `[<category>] <subsystem>: <failure_key>` | N/A (new) |
+
+### Label Taxonomy
+
+New labels for triage (extend existing set):
+
+| Label | Color | Purpose |
+|-------|-------|---------|
+| `triage` | `#D4C5F9` | Agent-created triage issues |
+| `agent-ready` | `#0E8A16` | Issue is pre-analyzed and ready for autonomous work |
+| `needs-human` | `#B60205` | Issue requires human decision before work begins |
+
+Existing labels reused as-is:
+- `follow-up` — review-loop follow-up issues
+- `fix:bug`, `fix:convention`, `fix:test`, `fix:docs`, `fix:process` — finding categories
+- `infra-incident` — infrastructure failures
+- `steward-review` — periodic steward review findings
+
+### Execution Gate
+
+**Issue existence does NOT imply autonomous coding authority.**
+
+An agent may only begin implementation work on a triage issue when:
+1. The issue has the `agent-ready` label, AND
+2. The issue is assigned to a specific lane (via assignee or comment), AND
+3. The agent's current task contract includes the issue's scope
+
+Issues without `agent-ready` are backlog only — they capture knowledge but
+do not authorize work.
+
+### Anti-Spam Rules
+
+| Rule | Threshold |
+|------|-----------|
+| Max new issues per session | 5 |
+| Cooldown between issue creates | 60 seconds |
+| Must search before create | Always (dedupe check) |
+| Must update-existing-first | Always (append comment to matching open issue) |
+| Transient failures | Never create issue (retry first) |
+
+## Deliverables
+
+| # | File | Action |
+|---|------|--------|
+| 1 | `docs/02_agent/ISSUE_TRIAGE_WORKFLOW.md` | Create |
+| 2 | `.claude/agents/issues.md` | Create |
+| 3 | `docs/02_agent/AUTONOMOUS_OPERATOR_WORKFLOW.md` | Update (Future Work → add issue triage reference) |
+
+## Validation Plan
+
+### Automated
+- `make check-quiet` (full pre-PR gate)
+
+### Manual Pre-PR Checks (not in `make check`)
+- Grep consistency check: all labels mentioned in the workflow doc exist in
+  the label taxonomy table
+- Grep consistency check: dedupe key format matches existing patterns
+- These are manual pre-PR steps, not automated gates. They verify doc
+  internal consistency only.
+
+### Manual Smoke
+- **Happy path:** A qualified repeated finding (e.g., "untested behavior change
+  in ops/events.py observed in PRs #961 and #966") maps to a single
+  deduplicated issue with `triage` + `fix:test` labels
+- **Unhappy path:** A one-time transient lint failure does NOT qualify for
+  issue creation (qualification threshold rejects it)
+- **Disable path:** Removing the `issues.md` agent profile disables the
+  triage guidance without breaking any other workflow
+
+### Failure Injection
+- Verify that if the dedupe search returns an existing open issue, the
+  workflow prescribes "append comment" not "create new"
+
+### Rollback / Disable Path
+- **Agent profile:** Remove `.claude/agents/issues.md` to disable triage
+  guidance without affecting any other workflow
+- **Workflow doc:** Amend or delete `ISSUE_TRIAGE_WORKFLOW.md` if
+  qualification thresholds or anti-spam rules prove too permissive. Since
+  the doc is purely prescriptive (no code enforcement), tightening rules
+  is a single-file edit with no downstream breakage
+- **Labels:** New labels (`triage`, `agent-ready`, `needs-human`) can be
+  removed from GitHub without affecting existing issue infrastructure
+
+## Parallelism Assessment
+
+All three deliverables can be written sequentially in a single author lane.
+No parallelism needed — the files are small docs, not code. Total estimated
+scope: ~200 lines of markdown across 3 files.
+
+## Outcome
+<!-- Filled after implementation -->


### PR DESCRIPTION
## Plan
- `plans/sessions/2026-03-19_pr5-slice2-issue-triage.md`
- Parent: `plans/sessions/2026-03-15_autonomous-agent-ops-workflow.md` (PR-5)

## Summary
- Add `docs/02_agent/ISSUE_TRIAGE_WORKFLOW.md`: qualification thresholds, dedupe key contract, label taxonomy, `agent-ready` execution gate, anti-spam rules, rollback/disable path
- Add `.claude/agents/issues.md`: bounded triage agent profile
- Update `docs/02_agent/AUTONOMOUS_OPERATOR_WORKFLOW.md`: mark issue-triage shipped in implementation history table, remove from remaining future work list

## Why
PR-5 requires an issue-triage workflow so that qualified operational findings can be captured as deduplicated GitHub issues without flooding the backlog or implying autonomous coding authority. This is the second slice of the PR-5 rollout after #961 (event producers/scope management).

## Repro / Validation
**Command(s) run:**
- `make check-quiet` — all checks pass
- Manual grep consistency checks for label references, dedupe patterns, and cross-references

**Config (if applicable):** N/A (docs-only)
**Seed (if applicable):** N/A

## Tests
- [x] `make check-quiet` passes (docs-check validates all file references)
- [ ] Integration (if engine/rules changed): N/A
- [x] Other: manual consistency checks

## Expected impact
- Metrics impact: None (docs-only)
- Runtime impact: None (docs-only)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

`git worktree list`:
```
See steward worktree layout in AUTONOMOUS_OPERATOR_WORKFLOW.md
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

## Validation Performed

### Automated checks
- `make check-quiet` passes (includes repo-lint, ruff, pytest, notebook-check, docs-check)
- docs-check validates all file path references in new markdown files (caught and fixed one stale path reference)

### Manual smoke checks
- **Happy path:** A qualified repeated finding (e.g., "untested behavior in ops/events.py observed in PRs #961 and #966") maps to a single deduplicated issue via the `[fix] ops/events: <description>` title prefix, with `triage` + `fix:test` labels, and is blocked from autonomous implementation by the absence of the `agent-ready` label
- **Unhappy path:** A one-time transient lint failure does NOT qualify for issue creation because the qualification threshold requires >=2 occurrences or a correctness/contract violation
- **Label consistency:** All labels referenced in ISSUE_TRIAGE_WORKFLOW.md are defined in the label taxonomy table
- **Cross-reference:** AUTONOMOUS_OPERATOR_WORKFLOW.md references ISSUE_TRIAGE_WORKFLOW.md (1 hit), issues.md references ISSUE_TRIAGE_WORKFLOW.md (2 hits)
- **Dedupe prefix isolation:** Verified that the new `[<category>]` prefix applies only to new agent-created triage issues; existing `fix(<label>)` (review_driver.py) and `[infra]` (infra_incident_dedupe.yml) patterns are unchanged

### Failure injection
- Verified that the dedupe procedure prescribes "append comment to existing issue" when a matching open issue is found, not "create new issue"
- Verified that agents hitting the session budget (5 issues) are instructed to stop creating and log overflow findings

### Rollback / disable path
- Remove `.claude/agents/issues.md` to disable triage guidance (no other workflow affected)
- Amend or delete `ISSUE_TRIAGE_WORKFLOW.md` to tighten rules (single-file edit, no code enforcement)
- New labels (`triage`, `agent-ready`, `needs-human`) can be removed from GitHub independently

### Known gaps
- Anti-spam thresholds are enforced by agent discipline and the agent profile, not by code. A future programmatic helper under `src/bid_euchre/ops/` could enforce at the API level.
- New labels (`triage`, `agent-ready`, `needs-human`) need to be created in GitHub after merge (documented in workflow doc with colors).
- GitHub Projects routing is documented as optional — not yet adopted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)