### PR TITLE
fix: address post-merge review findings from PRs #971/#972

### DIFF
--- a/docs/04_reports/arc_d_v2/r0/full/00_manifest.md
+++ b/docs/04_reports/arc_d_v2/r0/full/00_manifest.md
@@ -7,6 +7,8 @@
 **Seeds:** [42, 123, 456]
 **Anchor:** anchor_hybrid_r0_full
 
+**Governing Plan:** `plans/arc_d_v2/r0/plan.md`
+
 ## Model Roster
 
 | Model | Class | Trainable | Status |
@@ -97,11 +99,11 @@
 | Name | Size |
 |------|------|
 | `bid_levels.csv` | 159 bytes |
+| `calibration_bins.csv` | 1,731 bytes |
 | `contract_mix.csv` | 520 bytes |
 | `feature_importances.csv` | 6,067 bytes |
 | `h2h_by_contract.csv` | 5,759 bytes |
 | `outcome_distributions.csv` | 674 bytes |
-| `calibration_bins.csv` | 1,731 bytes |
 | `predictions.csv` | 679,196 bytes |
 | `residuals.csv` | 2,710 bytes |
 | `seat_balance.csv` | 347 bytes |

--- a/docs/04_reports/arc_d_v2/r0/full/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r0/full/evidence_manifest.json
@@ -3,7 +3,7 @@
   "lineage_id": "arc_d_v2",
   "rung_id": "r0",
   "provenance_sha": "a090bcebbba05ee8cd27ae773567eb8ba28f75a9",
-  "governing_plan": "",
+  "governing_plan": "plans/arc_d_v2/r0/plan.md",
   "plan_shas": [],
   "anchor": "anchor_hybrid_r0_full",
   "roster": [

--- a/docs/04_reports/arc_d_v2/r1/full/00_manifest.md
+++ b/docs/04_reports/arc_d_v2/r1/full/00_manifest.md
@@ -7,6 +7,8 @@
 **Seeds:** [42, 123, 456]
 **Anchor:** anchor_hybrid_r0_full
 
+**Governing Plan:** `plans/arc_d_v2/r1/plan.md`
+
 ## Model Roster
 
 | Model | Class | Trainable | Status |
@@ -97,11 +99,11 @@
 | Name | Size |
 |------|------|
 | `bid_levels.csv` | 159 bytes |
+| `calibration_bins.csv` | 1,729 bytes |
 | `contract_mix.csv` | 520 bytes |
 | `feature_importances.csv` | 10,218 bytes |
 | `h2h_by_contract.csv` | 5,752 bytes |
 | `outcome_distributions.csv` | 674 bytes |
-| `calibration_bins.csv` | 1,729 bytes |
 | `predictions.csv` | 677,667 bytes |
 | `residuals.csv` | 2,734 bytes |
 | `seat_balance.csv` | 347 bytes |

--- a/docs/04_reports/arc_d_v2/r1/full/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r1/full/evidence_manifest.json
@@ -3,7 +3,7 @@
   "lineage_id": "arc_d_v2",
   "rung_id": "r1",
   "provenance_sha": "a090bcebbba05ee8cd27ae773567eb8ba28f75a9",
-  "governing_plan": "",
+  "governing_plan": "plans/arc_d_v2/r1/plan.md",
   "plan_shas": [],
   "anchor": "anchor_hybrid_r0_full",
   "roster": [

--- a/docs/04_reports/arc_d_v2/r3/full/00_manifest.md
+++ b/docs/04_reports/arc_d_v2/r3/full/00_manifest.md
@@ -4,8 +4,38 @@
 **Rung:** r3
 **Provenance SHA:** `7bf48a81c2e46028150a3eb6f8d2d2d3d7428475`
 **Mode:** FULL
-**Seeds:** []
-**Anchor:**
+**Seeds:** [42]
+**Anchor:** anchor_hybrid_r0_full
+
+**Governing Plan:** `plans/arc_d_v2/r3/plan.md`
+
+## Model Roster
+
+| Model | Class | Trainable | Status |
+|-------|-------|-----------|--------|
+| modeloespecifico | ModeloEspecifico | False | evaluated |
+| selected_two_stage_av | TwoStageActionValueBidder | True | evaluated |
+| gbt_av | GBTActionValueBidder | True | evaluated |
+| constrained_ols_av | ActionValueBidder | True | evaluated |
+| selected_ols_av | ActionValueBidder | True | evaluated |
+| full_ols_av | ActionValueBidder | True | evaluated |
+| stricthellraiser | StrictHellRaiser | False | evaluated |
+| rankthetank | RanktheTank | False | evaluated |
+
+## Artifacts
+
+| Name | Schema | Path |
+|------|--------|------|
+| comparator_battery_r3_42 | arc_d_comparator_v1 | `data/artifacts/arc_d_v2/r3/comparator_battery_r3_42.json` |
+| comparator_cis_r3_42 | comparator_cis_v1 | `data/artifacts/arc_d_v2/r3/comparator_cis_r3_42.json` |
+| h2h_battery_quick_42 | h2h_battery_v2 | `data/artifacts/arc_d_v2/r3/h2h_battery_quick_42.json` |
+| h2h_battery_smoke_42 | h2h_battery_v2 | `data/artifacts/arc_d_v2/r3/h2h_battery_smoke_42.json` |
+| roster | roster_v1 | `data/artifacts/arc_d_v2/r3/roster.json` |
+| training_artifact_constrained_ols_av | action_value_olsa_v1 | `data/artifacts/arc_d_v2/r3/training_artifact_constrained_ols_av.json` |
+| training_artifact_full_ols_av | action_value_olsa_v1 | `data/artifacts/arc_d_v2/r3/training_artifact_full_ols_av.json` |
+| training_artifact_gbt_av | action_value_gbt_v1 | `data/artifacts/arc_d_v2/r3/training_artifact_gbt_av.json` |
+| training_artifact_selected_ols_av | action_value_olsa_v1 | `data/artifacts/arc_d_v2/r3/training_artifact_selected_ols_av.json` |
+| training_artifact_selected_two_stage_av | two_stage_action_value_v1 | `data/artifacts/arc_d_v2/r3/training_artifact_selected_two_stage_av.json` |
 
 ## Tables
 

--- a/docs/04_reports/arc_d_v2/r3/full/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r3/full/evidence_manifest.json
@@ -3,15 +3,117 @@
   "lineage_id": "arc_d_v2",
   "rung_id": "r3",
   "provenance_sha": "7bf48a81c2e46028150a3eb6f8d2d2d3d7428475",
-  "governing_plan": "",
+  "governing_plan": "plans/arc_d_v2/r3/plan.md",
   "plan_shas": [],
-  "anchor": "",
-  "roster": [],
-  "seeds": [],
+  "anchor": "anchor_hybrid_r0_full",
+  "roster": [
+    {
+      "name": "modeloespecifico",
+      "class_name": "ModeloEspecifico",
+      "trainable": false,
+      "status": "evaluated"
+    },
+    {
+      "name": "selected_two_stage_av",
+      "class_name": "TwoStageActionValueBidder",
+      "trainable": true,
+      "status": "evaluated"
+    },
+    {
+      "name": "gbt_av",
+      "class_name": "GBTActionValueBidder",
+      "trainable": true,
+      "status": "evaluated"
+    },
+    {
+      "name": "constrained_ols_av",
+      "class_name": "ActionValueBidder",
+      "trainable": true,
+      "status": "evaluated"
+    },
+    {
+      "name": "selected_ols_av",
+      "class_name": "ActionValueBidder",
+      "trainable": true,
+      "status": "evaluated"
+    },
+    {
+      "name": "full_ols_av",
+      "class_name": "ActionValueBidder",
+      "trainable": true,
+      "status": "evaluated"
+    },
+    {
+      "name": "stricthellraiser",
+      "class_name": "StrictHellRaiser",
+      "trainable": false,
+      "status": "evaluated"
+    },
+    {
+      "name": "rankthetank",
+      "class_name": "RanktheTank",
+      "trainable": false,
+      "status": "evaluated"
+    }
+  ],
+  "seeds": [
+    42
+  ],
   "mode": "FULL",
   "run_ids": [],
   "lifecycle": [],
-  "artifacts": [],
+  "artifacts": [
+    {
+      "name": "comparator_battery_r3_42",
+      "path": "data/artifacts/arc_d_v2/r3/comparator_battery_r3_42.json",
+      "schema_version": "arc_d_comparator_v1"
+    },
+    {
+      "name": "comparator_cis_r3_42",
+      "path": "data/artifacts/arc_d_v2/r3/comparator_cis_r3_42.json",
+      "schema_version": "comparator_cis_v1"
+    },
+    {
+      "name": "h2h_battery_quick_42",
+      "path": "data/artifacts/arc_d_v2/r3/h2h_battery_quick_42.json",
+      "schema_version": "h2h_battery_v2"
+    },
+    {
+      "name": "h2h_battery_smoke_42",
+      "path": "data/artifacts/arc_d_v2/r3/h2h_battery_smoke_42.json",
+      "schema_version": "h2h_battery_v2"
+    },
+    {
+      "name": "roster",
+      "path": "data/artifacts/arc_d_v2/r3/roster.json",
+      "schema_version": "roster_v1"
+    },
+    {
+      "name": "training_artifact_constrained_ols_av",
+      "path": "data/artifacts/arc_d_v2/r3/training_artifact_constrained_ols_av.json",
+      "schema_version": "action_value_olsa_v1"
+    },
+    {
+      "name": "training_artifact_full_ols_av",
+      "path": "data/artifacts/arc_d_v2/r3/training_artifact_full_ols_av.json",
+      "schema_version": "action_value_olsa_v1"
+    },
+    {
+      "name": "training_artifact_gbt_av",
+      "path": "data/artifacts/arc_d_v2/r3/training_artifact_gbt_av.json",
+      "schema_version": "action_value_gbt_v1"
+    },
+    {
+      "name": "training_artifact_selected_ols_av",
+      "path": "data/artifacts/arc_d_v2/r3/training_artifact_selected_ols_av.json",
+      "schema_version": "action_value_olsa_v1"
+    },
+    {
+      "name": "training_artifact_selected_two_stage_av",
+      "path": "data/artifacts/arc_d_v2/r3/training_artifact_selected_two_stage_av.json",
+      "schema_version": "two_stage_action_value_v1"
+    }
+  ],
   "tables": [
     {
       "name": "artifact_inventory.csv",

--- a/plans/sessions/2026-03-19_review-findings-971-972.md
+++ b/plans/sessions/2026-03-19_review-findings-971-972.md
@@ -1,0 +1,112 @@
+# Session Plan: Fix Post-Merge Review Findings from PRs #971 and #972
+
+**Date:** 2026-03-19
+**Author:** author-b
+**Branch:** `fix/review-findings-971-972` (new, from main)
+
+## Context
+
+Post-merge reviews of PRs #971 and #972 identified three actionable findings.
+Both PRs are already merged. These are follow-up fixes.
+
+## Findings
+
+### F1: Double `os.close(fd)` in `save_memory()` (PR #971, WARN, High confidence)
+
+**File:** `src/bid_euchre/ops/memory.py` lines ~178-190
+
+**Problem:** The error path calls `os.close(fd)` after `os.close(fd)` already
+succeeded in the try block. If `os.replace()` fails after `os.close(fd)`, the
+except handler double-closes the fd, raising `OSError: [Errno 9] Bad file
+descriptor` which masks the original exception.
+
+```python
+try:
+    os.write(fd, content.encode("utf-8"))
+    os.fsync(fd)
+    os.close(fd)        # fd closed here
+    os.replace(tmp, str(memory_path))
+except BaseException:
+    os.close(fd)         # double close if os.replace() failed!
+    ...
+```
+
+**Fix:** Track fd closure state with a boolean flag, or restructure to close fd
+before the `os.replace()` call and remove from the except handler. A `closed`
+sentinel is clearer.
+
+### F2: R3/FULL manifest provenance wipe (PR #972, WARN, High confidence)
+
+**Files:**
+- `docs/04_reports/arc_d_v2/r3/full/evidence_manifest.json`
+- `docs/04_reports/arc_d_v2/r3/full/00_manifest.md`
+
+**Problem:** PR #972 regenerated the R3/FULL manifest without passing `--plan-dir`
+and without providing a proper `--rung-dir` with artifacts. This wiped provenance
+metadata that was correctly populated by PR #949:
+- `governing_plan: ""` (was `"plans/arc_d_v2/r3/plan.md"`)
+- `roster: []` (was 8 models)
+- `seeds: []` (was `[42]`)
+- `artifacts: []` (was populated)
+- `anchor: ""` (was `"anchor_hybrid_r0_full"`)
+
+**Fix:** Regenerate the manifest with correct arguments, restoring the provenance
+metadata. R0/FULL and R1/FULL also have `governing_plan: ""` — check if those
+need similar repair.
+
+### F3: R²=0.0 described as "negative R²" in quality note (PR #972, INFO, Medium)
+
+**File:** `src/bid_euchre/arc_d_v2/report.py` line ~398
+
+**Problem:** The `r2_positive` check triggers when R² ≤ 0 (check: `r2 > 0`).
+When R²=0.0, the quality note says "negative R² indicates the model performs
+worse than a constant predictor" — but R²=0.0 means the model performs *exactly*
+as well as a constant predictor, not worse. The text is technically inaccurate.
+
+**Fix:** Change text to "non-positive R² indicates the model performs no better
+than a constant predictor on this contract" or handle R²=0.0 as a separate case.
+
+## Implementation Plan
+
+### Task 1: Fix double `os.close(fd)` in `save_memory()`
+
+**Files:** `src/bid_euchre/ops/memory.py`, `tests/unit/test_ops_memory.py`
+
+1. Add `closed = False` sentinel before the try block
+2. Set `closed = True` after `os.close(fd)` in the try block
+3. Guard the except handler: `if not closed: os.close(fd)`
+4. Add a test that mocks `os.replace()` to raise and verifies no double-close
+
+### Task 2: Regenerate R3/FULL evidence manifest
+
+**Files:** `docs/04_reports/arc_d_v2/r3/full/evidence_manifest.json`,
+`docs/04_reports/arc_d_v2/r3/full/00_manifest.md`
+
+1. Run `generate_evidence_manifest.py` with correct args for R3/FULL
+2. Verify provenance metadata is restored (governing_plan, roster, seeds, etc.)
+3. Also check R0/FULL and R1/FULL — repair governing_plan if missing
+
+### Task 3: Fix R² quality note text
+
+**Files:** `src/bid_euchre/arc_d_v2/report.py`, `tests/unit/test_report_template.py`
+
+1. Change "negative R²" to "non-positive R²" and "performs worse" to "performs
+   no better"
+2. Add/update test for quality note wording
+
+## Parallelism Assessment
+
+- Tasks 1, 2, and 3 are **independent** — disjoint file sets, no dependencies.
+- However, this is a single-author lane, so execute sequentially.
+- All three fit in one PR (one concept: "fix review findings from #971/#972").
+
+## Validation
+
+- Run `uv run python -m pytest tests/unit/test_ops_memory.py` (Task 1)
+- Run `uv run python -m pytest tests/unit/test_report_template.py` (Task 3)
+- Verify manifest JSON has correct provenance (Task 2)
+- Run `make check-quiet` before PR
+
+## Outcome
+
+_To be filled after implementation._

--- a/src/bid_euchre/arc_d_v2/report.py
+++ b/src/bid_euchre/arc_d_v2/report.py
@@ -395,8 +395,8 @@ def generate_report(report_dir: Path) -> str:
                 elif "r2_positive" in check:
                     notes.append(
                         f"- **Sanity: {check}** — failed{count_note}. "
-                        f"Value {value}; negative R² indicates the model performs "
-                        "worse than a constant predictor on this contract."
+                        f"Value {value}; non-positive R² indicates the model performs "
+                        "no better than a constant predictor on this contract."
                     )
                 else:
                     notes.append(

--- a/src/bid_euchre/ops/memory.py
+++ b/src/bid_euchre/ops/memory.py
@@ -177,13 +177,16 @@ def save_memory(store: MemoryStore, memory_dir: Path) -> None:
     content = json.dumps(store.to_dict(), indent=2) + "\n"
 
     fd, tmp = tempfile.mkstemp(dir=str(memory_dir), suffix=".tmp")
+    closed = False
     try:
         os.write(fd, content.encode("utf-8"))
         os.fsync(fd)
         os.close(fd)
+        closed = True
         os.replace(tmp, str(memory_path))
     except BaseException:
-        os.close(fd)
+        if not closed:
+            os.close(fd)
         try:
             os.unlink(tmp)
         except OSError:

--- a/tests/unit/test_ops_memory.py
+++ b/tests/unit/test_ops_memory.py
@@ -168,6 +168,44 @@ class TestLoadSave:
         assert data["version"] == 1
         assert len(data["entries"]) == 1
 
+    def test_save_no_double_close_on_replace_failure(self, memory_dir: Path) -> None:
+        """os.close(fd) must not be called twice when os.replace() fails (#971)."""
+        import os
+        from unittest.mock import patch
+
+        store = MemoryStore(
+            entries=[
+                MemoryEntry(
+                    entry_id="abc",
+                    category="repo_fact",
+                    key="test",
+                    value="val",
+                    source_file="f.md",
+                    added_by="test",
+                    added_at="2026-03-18T10:00:00+00:00",
+                )
+            ]
+        )
+
+        close_calls: list[int] = []
+        original_close = os.close
+
+        def tracking_close(fd: int) -> None:
+            close_calls.append(fd)
+            original_close(fd)
+
+        with (
+            patch("os.replace", side_effect=OSError("disk full")),
+            patch("os.close", side_effect=tracking_close),
+        ):
+            with pytest.raises(OSError, match="disk full"):
+                save_memory(store, memory_dir)
+
+        # The fd should be closed exactly once, not twice
+        assert (
+            len(close_calls) == 1
+        ), f"os.close() called {len(close_calls)} times, expected 1"
+
 
 class TestValidation:
     """Tests for validate_entry() and validate_provenance()."""

--- a/tests/unit/test_rung_report.py
+++ b/tests/unit/test_rung_report.py
@@ -529,6 +529,18 @@ class TestDataQualityNotes:
         assert "## 10. Data Quality Notes" in content
         assert "synthetic data" in content
 
+    def test_section10_r2_zero_says_non_positive(self, base_report_dir):
+        """R²=0.0 quality note says 'non-positive', not 'negative' (#972)."""
+        tables_dir = base_report_dir / "tables"
+        (tables_dir / "sanity_bounds_check.csv").write_text(
+            "model,check_name,value,lower_bound,upper_bound,status\n"
+            "ols_av,r2_positive_pass,0.0,0.0,1.0,FAIL\n"
+        )
+        content = generate_report(base_report_dir)
+        assert "non-positive R²" in content
+        assert "negative R²" not in content
+        assert "no better than a constant predictor" in content
+
 
 class TestDecisionReportDataSanity:
     """Tests for the Data Sanity block in generate_decision_report()."""


### PR DESCRIPTION
## Summary

- **Double `os.close(fd)` fix:** Track fd closure state with boolean sentinel in `save_memory()` to prevent masking `os.replace()` failures with `OSError: Bad file descriptor` (PR #971 finding)
- **R3/FULL manifest provenance restore:** PR #972 wiped provenance metadata (governing_plan, roster, seeds, anchor, artifacts) during manifest regeneration — restored from known-good state while preserving chart status updates
- **R0/R1 FULL governing_plan repair:** Populated empty `governing_plan` field with correct plan paths (`plans/arc_d_v2/r0/plan.md`, `plans/arc_d_v2/r1/plan.md`)
- **Quality note text accuracy:** Changed "negative R²" to "non-positive R²" since R²=0.0 means the model performs exactly as well as (not worse than) a constant predictor

## Why

Post-merge reviews of PRs #971 and #972 identified a bug in error handling, a data quality regression in manifest provenance, and an inaccurate quality note description. All are follow-up fixes.

## Repro / Validation

```bash
# Targeted tests
uv run python -m pytest tests/unit/test_ops_memory.py::TestLoadSave::test_save_no_double_close_on_replace_failure -xvs
uv run python -m pytest tests/unit/test_rung_report.py::TestDataQualityNotes::test_section10_r2_zero_says_non_positive -xvs

# Full suite
make check-quiet  # ✓ All checks passed
```

## Tests

- `test_save_no_double_close_on_replace_failure` — mocks `os.replace()` to raise, verifies `os.close()` called exactly once
- `test_section10_r2_zero_says_non_positive` — verifies quality note says "non-positive R²", not "negative R²"

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: fix/review-findings-971-972
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)