### PR TITLE
fix: prevent double-close and temp file leak in save_memory error path

### DIFF
--- a/src/bid_euchre/ops/memory.py
+++ b/src/bid_euchre/ops/memory.py
@@ -177,13 +177,16 @@ def save_memory(store: MemoryStore, memory_dir: Path) -> None:
     content = json.dumps(store.to_dict(), indent=2) + "\n"
 
     fd, tmp = tempfile.mkstemp(dir=str(memory_dir), suffix=".tmp")
+    fd_open = True
     try:
         os.write(fd, content.encode("utf-8"))
         os.fsync(fd)
         os.close(fd)
+        fd_open = False
         os.replace(tmp, str(memory_path))
     except BaseException:
-        os.close(fd)
+        if fd_open:
+            os.close(fd)
         try:
             os.unlink(tmp)
         except OSError:

--- a/tests/unit/test_ops_memory.py
+++ b/tests/unit/test_ops_memory.py
@@ -168,6 +168,34 @@ class TestLoadSave:
         assert data["version"] == 1
         assert len(data["entries"]) == 1
 
+    def test_save_replace_failure_cleans_up(self, memory_dir: Path) -> None:
+        """If os.replace() fails, the temp file must be cleaned up and the original error preserved (#951)."""
+        from unittest.mock import patch
+
+        store = MemoryStore(
+            entries=[
+                MemoryEntry(
+                    entry_id="abc",
+                    category="repo_fact",
+                    key="test",
+                    value="val",
+                    source_file="f.md",
+                    added_by="test",
+                    added_at="2026-03-18T10:00:00+00:00",
+                )
+            ]
+        )
+
+        with patch(
+            "bid_euchre.ops.memory.os.replace", side_effect=OSError("cross-device link")
+        ):
+            with pytest.raises(OSError, match="cross-device link"):
+                save_memory(store, memory_dir)
+
+        # No .tmp files should remain
+        tmp_files = list(memory_dir.glob("*.tmp"))
+        assert tmp_files == [], f"Leaked temp files: {tmp_files}"
+
 
 class TestValidation:
     """Tests for validate_entry() and validate_provenance()."""


### PR DESCRIPTION
## Summary

- Fix double-close of file descriptor in `save_memory()` atomic write error path
- Add regression test that verifies `os.replace()` failures preserve the original error and clean up temp files

## Why

Pre-merge review of PR #971 identified a [P1] finding: if `os.replace()` fails after `os.close(fd)` in the atomic write path, the exception handler calls `os.close(fd)` again, raising `EBADF` and masking the original error. The `os.unlink(tmp)` cleanup is also skipped, leaking the temp file — exactly the failure mode the PR was designed to prevent.

## Fix

Track fd state with a `fd_open` boolean flag. Only close fd in the exception handler if it hasn't already been closed in the happy path.

## Repro / Validation

```bash
# Targeted tests (76/76 pass)
uv run python -m pytest tests/unit/test_ops_memory.py tests/unit/test_ops_compaction.py -q

# Specific regression test
uv run python -m pytest tests/unit/test_ops_memory.py -k test_save_replace_failure_cleans_up -v
```

## Tests

- `test_save_replace_failure_cleans_up`: patches `os.replace()` to raise `OSError("cross-device link")`, asserts the original error is preserved (not masked by EBADF), and asserts no `.tmp` files remain in the directory.

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/worktree-fix-double-close
branch: fix/save-memory-double-close
```

## Validation Performed

```
76 passed in 14.14s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)