### PR TITLE
fix: derive auxiliary scan paths from repo_root in build_index()

### DIFF
--- a/scripts/internal/build_audit_index.py
+++ b/scripts/internal/build_audit_index.py
@@ -51,6 +51,7 @@ def main(argv: list[str] | None = None) -> int:
         index_dir,
         runtime_dir=runtime_dir,
         plans_dir=plans_dir,
+        repo_root=repo_root,
         full_rebuild=args.rebuild,
     )
 

--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -582,6 +582,7 @@ def cmd_index(args: argparse.Namespace) -> int:
         index_dir,
         runtime_dir=args.runtime_dir,
         plans_dir=args.plans_dir,
+        repo_root=getattr(args, "repo_root", None),
         full_rebuild=rebuild,
     )
 
@@ -1024,6 +1025,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.plans_dir is None:
         args.plans_dir = repo_root / "plans"
+
+    args.repo_root = repo_root
 
     # Dispatch
     commands = {

--- a/src/bid_euchre/ops/index.py
+++ b/src/bid_euchre/ops/index.py
@@ -675,8 +675,10 @@ def build_index(
         plans_dir: Plans directory (default: plans/).
         repo_root: Repository root for deriving auxiliary scan paths
             (``data/runs``, ``docs/04_reports``).  When *None*,
-            defaults to the result of ``_resolve_repo_path("")``
-            (i.e. the git repo root or cwd).
+            inferred from *runtime_dir* (assumed to be
+            ``<repo>/.claude/runtime``) if a ``.git`` marker is
+            found two levels up; otherwise falls back to
+            ``_resolve_repo_path("")`` (git repo root or cwd).
         full_rebuild: If True, drop and rebuild from scratch.
 
     Returns:
@@ -694,9 +696,17 @@ def build_index(
     if plans_dir is None:
         plans_dir = _resolve_repo_path("plans")
 
-    # Derive repo_root for auxiliary scan paths (#952)
+    # Derive repo_root for auxiliary scan paths (#952).
+    # Prefer structural inference from runtime_dir (which is typically
+    # <repo>/.claude/runtime) so that callers that already inject
+    # runtime_dir get correct auxiliary paths even when cwd != repo root.
     if repo_root is None:
-        repo_root = _resolve_repo_path("")
+        if runtime_dir is not None and runtime_dir.name == "runtime":
+            candidate = runtime_dir.parent.parent
+            if (candidate / ".git").exists() or (candidate / ".git").is_file():
+                repo_root = candidate
+        if repo_root is None:
+            repo_root = _resolve_repo_path("")
 
     if full_rebuild:
         db_path = _get_db_path(index_dir)

--- a/tests/unit/test_ops_index.py
+++ b/tests/unit/test_ops_index.py
@@ -607,6 +607,56 @@ class TestRepoRootPathResolution:
         assert result.errors == []
         assert result.sources_indexed == 0
 
+    def test_repo_root_inferred_from_runtime_dir(self, tmp_path: Path) -> None:
+        """Regression: repo_root inferred from runtime_dir when .git exists."""
+        repo = tmp_path / "inferred_repo"
+        rt = repo / ".claude" / "runtime"
+        rt.mkdir(parents=True)
+        plans = repo / "plans"
+        plans.mkdir()
+        index_dir = rt / "audit_index"
+
+        # Place a .git marker so the inference succeeds
+        (repo / ".git").mkdir()
+
+        # Create a manifest in data/runs under the inferred repo root
+        runs_dir = repo / "data" / "runs" / "run_infer"
+        runs_dir.mkdir(parents=True)
+        (runs_dir / "evidence_manifest_R0.json").write_text(
+            json.dumps(
+                {
+                    "artifacts": [
+                        {"name": "metrics.json", "type": "metrics"},
+                    ]
+                }
+            )
+        )
+
+        # Create a report manifest in docs/04_reports under the inferred root
+        reports_dir = repo / "docs" / "04_reports" / "R0"
+        reports_dir.mkdir(parents=True)
+        (reports_dir / "manifest_R0.json").write_text(
+            json.dumps(
+                {
+                    "artifacts": [
+                        {"name": "01_results.md", "type": "report"},
+                    ]
+                }
+            )
+        )
+
+        # Call WITHOUT explicit repo_root -- should infer from runtime_dir
+        result = build_index(
+            index_dir,
+            runtime_dir=rt,
+            plans_dir=plans,
+        )
+        assert result.errors == []
+        assert (
+            result.sources_indexed >= 2
+        ), f"Expected >=2 sources (manifest + report), got {result.sources_indexed}"
+        assert result.entries_indexed >= 2
+
 
 class TestFtsUpdateTrigger:
     """Regression tests for #953: FTS AFTER UPDATE trigger."""
@@ -682,8 +732,7 @@ class TestFtsUpdateTrigger:
             conn.commit()
             assert (
                 conn.execute(
-                    "SELECT COUNT(*) FROM entries_fts "
-                    "WHERE entries_fts MATCH 'trigger'"
+                    "SELECT COUNT(*) FROM entries_fts WHERE entries_fts MATCH 'trigger'"
                 ).fetchone()[0]
                 == 1
             )
@@ -693,8 +742,7 @@ class TestFtsUpdateTrigger:
             conn.commit()
             assert (
                 conn.execute(
-                    "SELECT COUNT(*) FROM entries_fts "
-                    "WHERE entries_fts MATCH 'trigger'"
+                    "SELECT COUNT(*) FROM entries_fts WHERE entries_fts MATCH 'trigger'"
                 ).fetchone()[0]
                 == 0
             )


### PR DESCRIPTION
## Summary
- Add `repo_root` parameter to `build_index()` so `data/runs` and `docs/04_reports` paths resolve relative to the repo root, not CWD
- Infer `repo_root` from `runtime_dir` (by checking for `.git` two levels up) when not explicitly provided
- Update both CLI callers (`build_audit_index.py`, `ops.py`) to pass their already-computed `repo_root`

## Why
PR #976 added `repo_root` to the `build_index()` signature but neither CLI caller passed it. When callers injected `runtime_dir`/`plans_dir` pointing to another worktree/repo, the two auxiliary paths (`data/runs`, `docs/04_reports`) still resolved against CWD — silently missing manifests and reports. This was flagged as a P1 finding on the #976 review.

## Repro / Validation
```python
# Before fix: returns 0 sources for auxiliary paths
from pathlib import Path
from bid_euchre.ops.index import build_index
result = build_index(idx, runtime_dir=other_repo_rt, plans_dir=other_repo_plans)
assert result.sources_indexed == 0  # Bug: data/runs and docs/04_reports missed

# After fix: infers repo_root from runtime_dir
result = build_index(idx, runtime_dir=other_repo_rt, plans_dir=other_repo_plans)
assert result.sources_indexed >= 2  # Fixed: auxiliary paths follow repo_root
```

## Tests
```bash
uv run python -m pytest tests/unit/test_ops_index.py -v  # 45 pass (1 new)
make check-quiet  # All checks pass
```

New test: `test_repo_root_inferred_from_runtime_dir` — creates a fake repo, puts manifests in `data/runs` and `docs/04_reports`, calls `build_index()` WITHOUT explicit `repo_root`, asserts inference finds both.

## Worktree proof
Branch: `fix/build-index-repo-root`
Worktree: `.claude/worktrees/agent-ac20ee80`

🤖 Generated with [Claude Code](https://claude.com/claude-code)