### PR TITLE
test: salvage temp-file-cleanup assertion from closed PR #978

### DIFF
--- a/tests/unit/test_ops_memory.py
+++ b/tests/unit/test_ops_memory.py
@@ -206,6 +206,34 @@ class TestLoadSave:
             len(close_calls) == 1
         ), f"os.close() called {len(close_calls)} times, expected 1"
 
+    def test_save_replace_failure_cleans_up(self, memory_dir: Path) -> None:
+        """If os.replace() fails, the temp file must be cleaned up and the original error preserved (#951)."""
+        from unittest.mock import patch
+
+        store = MemoryStore(
+            entries=[
+                MemoryEntry(
+                    entry_id="abc",
+                    category="repo_fact",
+                    key="test",
+                    value="val",
+                    source_file="f.md",
+                    added_by="test",
+                    added_at="2026-03-18T10:00:00+00:00",
+                )
+            ]
+        )
+
+        with patch(
+            "bid_euchre.ops.memory.os.replace", side_effect=OSError("cross-device link")
+        ):
+            with pytest.raises(OSError, match="cross-device link"):
+                save_memory(store, memory_dir)
+
+        # No .tmp files should remain
+        tmp_files = list(memory_dir.glob("*.tmp"))
+        assert tmp_files == [], f"Leaked temp files: {tmp_files}"
+
 
 class TestValidation:
     """Tests for validate_entry() and validate_provenance()."""


### PR DESCRIPTION
## Plan
N/A — single test salvage from closed PR.

## Summary
- Salvaged `test_save_replace_failure_cleans_up` from closed PR #978
- Added to `TestLoadSave` class, right after the existing `test_save_no_double_close_on_replace_failure` from PR #977

## Why
PR #978 was closed as superseded by #977 (both fixed the same double-close bug in `save_memory`). However, #978 contained a complementary test that validates **different properties** than #977's test:

| Test | From PR | Validates |
|------|---------|-----------|
| `test_save_no_double_close_on_replace_failure` | #977 (merged) | `os.close()` called exactly once |
| `test_save_replace_failure_cleans_up` | #978 (closed) | No leaked `.tmp` files + original `OSError` preserved |

These are orthogonal invariants of the same error path, so both are valuable.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_memory.py -v
make check-quiet
```

**Config:** N/A
**Seed:** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_memory.py -v` — 35/35 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None
- Runtime impact: None (test-only)

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/worktree-test-salvage-978
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/worktree-test-salvage-978
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                    4bab417 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/worktree-test-salvage-978     4bab417 [test/salvage-978-cleanup-assertion]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)