### PR TITLE
docs: archive 13 untracked session plans from Mar 18-19

### DIFF
--- a/plans/sessions/2026-03-18_chart-refactor-final-handoff.md
+++ b/plans/sessions/2026-03-18_chart-refactor-final-handoff.md
@@ -1,0 +1,177 @@
+# Chart Refactor Final Handoff
+**Date:** 2026-03-18
+**Goal:** Hand off the remaining work needed to move the Arc D v2 reporting/charting refactor from “mostly landed” to “actually complete against the original plan.”
+
+## Executive State
+
+The refactor is **not fully complete** against the original reporting plan.
+
+As of the latest audited state:
+- `#919` closed the chart-data ownership guard in code.
+- `#942` appears to correctly land the missing `#919` follow-up work:
+  - regenerated `behavior_by_contract.csv` bundles with `suit/high/low/pooled`
+  - corrected stale plan bullets
+  - added ownership-guard regression tests
+
+If `#942` merges cleanly, that should close the specific `#919` follow-up gaps.
+
+But even after that, the **original plan is still not fully done**. The largest remaining gaps are:
+- QUICK bundles still use synthetic outcome distributions
+- Charts 21 and 22 are still absent from shipped bundles
+- `04_rung_decision.md` still ships in full bundles, even though deprecated
+
+## What The Next Agent Should Assume
+
+- Do **not** assume the governing plan in `main` is perfectly up to date until `#942` is merged and verified on `main`.
+- Do **not** treat “closeout” language from `#919` or `#942` as proof that the original refactor plan is complete.
+- Treat `#942` as the likely last cleanup PR for the `#919` review findings, not as proof that the broader chart/report contract is fully satisfied.
+
+## Immediate Verification Step
+
+Before doing any new work, verify whether `#942` merged and actually landed on `main`.
+
+Check:
+- `docs/04_reports/arc_d_v2/r{0,1,2,3}/{quick,full}/tables/behavior_by_contract.csv`
+- `plans/arc_d_v2/reporting_refactor_full_plan.md`
+- `tests/unit/test_rung_tables.py`
+
+Expected post-merge state:
+- all 8 `behavior_by_contract.csv` files contain `suit`, `high`, `low`, and `pooled`
+- governing plan §2.2 no longer describes `Rung ?`, `PENDING`, `Mode: QUICK`, or `Seeds: []` as current truth
+- tests include:
+  - `test_decision_comparison_not_in_canonical_path`
+  - `test_disagreement_outcomes_not_in_canonical_path`
+
+## Remaining Work After #942
+
+### Workstream 1 — Decide what “complete” means for QUICK distributions
+
+Current state:
+- QUICK bundles still ship synthetic `outcome_distributions.csv`
+- this is explicitly labeled with `source=synthetic`
+- the original plan wanted “real health/distribution analysis”
+
+Decision needed:
+- Option A: accept synthetic QUICK distributions as an intentional degraded mode and update the governing plan to say the refactor is complete with that degraded policy
+- Option B: do not call the refactor complete until QUICK has real row-level distribution data too
+
+Recommendation:
+- take **Option A** unless there is a practical path to generate QUICK parquet-backed distributions without turning QUICK into FULL
+
+Tradeoff:
+- Option A preserves QUICK speed/readability but accepts a degraded health surface
+
+Why:
+- the current design already distinguishes QUICK vs FULL and explicitly supports degraded states when raw artifacts are unavailable
+
+Files to update if Option A is chosen:
+- `plans/arc_d_v2/reporting_refactor_full_plan.md`
+- potentially `00_manifest.md` / `01_results.md` wording if needed
+
+### Workstream 2 — Finish Charts 21 and 22 or explicitly remove them from “completion”
+
+Current state:
+- `decision_agreement.png` and `disagreement_outcomes.png` are still absent across shipped bundles
+- canonical data source is `generate_interpretability.py`, not `generate_chart_data()`
+
+Needed work:
+- run the interpretability pipeline with trained `.joblib` models and eval parquet
+- generate:
+  - `decision_comparison.csv`
+  - `disagreement_outcomes.csv`
+  - Chart 21
+  - Chart 22
+- regenerate affected bundles and results reports
+
+If artifacts do not exist:
+- keep the ownership guard as-is
+- update the governing plan so “complete” no longer implies these charts are present
+
+Recommendation:
+- first verify whether the required `.joblib` models and eval parquet actually exist for any rung/mode
+
+Tradeoff:
+- pushing this to “optional/deferred” makes the suite more honest, but it means the original 23-chart aspiration was not fully realized
+
+Why:
+- the current repo state still cannot honestly claim those charts are delivered
+
+Files likely involved:
+- `scripts/internal/generate_interpretability.py`
+- `scripts/internal/generate_interpretability_charts.py`
+- `docs/04_reports/arc_d_v2/r*/{quick,full}/**`
+- `plans/arc_d_v2/reporting_refactor_full_plan.md`
+
+### Workstream 3 — Remove the remaining decision-report sprawl
+
+Current state:
+- `04_rung_decision.md` is deprecated but still shipped in all FULL bundles
+
+Needed work:
+- decide whether to:
+  - remove `04_rung_decision.md` from full bundles entirely, or
+  - keep it indefinitely as a historical artifact and explicitly exclude it from completion criteria
+
+Recommendation:
+- remove it from regenerated FULL bundles once any useful narrative has been folded into `02_decision.md`
+
+Tradeoff:
+- removal is cleaner but requires confidence that `02_decision.md` now carries the necessary decision narrative
+
+Why:
+- the original plan explicitly tried to constrain the suite to the canonical `00/01/02` surface
+
+Files likely involved:
+- `src/bid_euchre/arc_d_v2/report.py`
+- `docs/04_reports/arc_d_v2/r*/full/02_decision.md`
+- `docs/04_reports/arc_d_v2/r*/full/04_rung_decision.md`
+
+## Suggested Execution Order
+
+1. Verify `#942` on `main`
+2. Make the QUICK synthetic-distribution policy explicit
+3. Audit whether Charts 21/22 are practically generatable with current artifacts
+4. Either generate Charts 21/22 or formally move them out of completion scope
+5. Remove `04_rung_decision.md` from regenerated full bundles or formalize it as legacy-only
+6. Re-run a final bundle audit against the governing plan
+7. Only then change the governing plan status from `PARTIALLY COMPLETE`
+
+## Final Acceptance Checklist
+
+The next agent should only call the refactor “complete” if all of the following are true:
+
+- `#942` is merged and verified on `main`
+- the governing plan matches actual shipped bundle state
+- the QUICK synthetic distribution policy is explicit and accepted
+- Charts 21/22 are either shipped or explicitly removed from completion claims
+- `04_rung_decision.md` is no longer part of the maintained reporting surface
+- a final audit says the original plan is either:
+  - fully complete, or
+  - intentionally complete-with-degraded-quick-and-no-21/22
+
+## Useful Verification Commands
+
+```bash
+git fetch origin main
+git show origin/main:docs/04_reports/arc_d_v2/r2/quick/tables/behavior_by_contract.csv | sed -n '1,12p'
+git show origin/main:plans/arc_d_v2/reporting_refactor_full_plan.md | sed -n '33,80p'
+git show origin/main:tests/unit/test_rung_tables.py | rg "not_in_canonical"
+```
+
+```bash
+PYTHONPATH=. uv run python -m pytest -q tests/unit/test_rung_tables.py -k 'not_in_canonical or BehaviorByContractExpanded'
+PYTHONPATH=. uv run python -m pytest -q tests/unit/test_bundle_hygiene.py
+```
+
+```bash
+for p in docs/04_reports/arc_d_v2/r{0,1,2,3}/{quick,full}/00_manifest.md; do
+  echo "== $p =="
+  rg -n "decision_agreement.png|disagreement_outcomes.png" "$p"
+done
+```
+
+## Bottom Line
+
+The likely post-`#942` state is:
+- **specific closeout fixes:** done
+- **original chart refactor plan:** still needs one final decision-and-audit pass before it can honestly be called complete

--- a/plans/sessions/2026-03-18_commit-dashboard.md
+++ b/plans/sessions/2026-03-18_commit-dashboard.md
@@ -1,0 +1,69 @@
+# Commit Analytics Dashboard — GitHub Actions Auto-Update
+**Date:** 2026-03-18
+**Goal:** Deploy an auto-updating churn-corrected Bollinger Band chart to the repo, generated daily by GitHub Actions and embedded in the README.
+
+## Context
+Interactive exploration session produced a commit analytics pipeline that:
+- Computes daily commit counts (working days only)
+- Calculates line-level churn ratio (gross vs net line changes)
+- Derives effective commits = raw × (1 − churn ratio)
+- Renders 10-working-day Bollinger Bands with %B and bandwidth panels
+
+## Plan
+
+### Step 1: Create `scripts/generate_dashboard.py`
+- Clean up the `/tmp/commit_timeseries.py` prototype into a production script
+- Must work headless in CI (matplotlib Agg backend)
+- Accept `--output` flag for the output PNG path (default: `assets/dashboard/commit_bollinger.png`)
+- Accept `--repo` flag for git repo path (default: `.`)
+- Remove hardcoded "today" — derive from latest commit date
+- Add `if __name__ == "__main__"` guard with argparse
+
+### Step 2: Create `assets/dashboard/` directory
+- Add `.gitkeep` or the initial generated PNG
+- This directory holds auto-generated dashboard images
+
+### Step 3: Create `.github/workflows/dashboard.yml`
+- **Triggers:**
+  - `push` to `main` (update after merges)
+  - `schedule: cron '0 6 * * *'` (daily at 6am UTC)
+  - `workflow_dispatch` (manual trigger)
+- **Job:**
+  - Checkout with `fetch-depth: 0` (needs full history for git log)
+  - Setup Python 3.12 + uv
+  - Install deps (`uv sync --frozen`)
+  - Run `uv run python scripts/generate_dashboard.py --output assets/dashboard/commit_bollinger.png`
+  - Commit and push if the image changed (use `stefanzweifel/git-auto-commit-action@v5`)
+- **Permissions:** `contents: write` (to push the updated image)
+- **Concurrency:** `dashboard` group, cancel-in-progress
+
+### Step 4: Add image embed to README.md
+- Add a `## Dashboard` section near the top of the README
+- Embed: `![Commit Analytics](assets/dashboard/commit_bollinger.png)`
+- Brief description of what the chart shows
+
+### Step 5: Validate locally
+- Run the script against the repo
+- Verify the PNG generates correctly
+- Run `make check-quiet` to ensure no regressions
+
+## Files
+- `scripts/generate_dashboard.py` — new: chart generation script
+- `assets/dashboard/commit_bollinger.png` — new: generated chart (auto-committed)
+- `.github/workflows/dashboard.yml` — new: GitHub Actions workflow
+- `README.md` — edit: add dashboard embed section
+
+## Dependencies
+- `matplotlib` — already in `pyproject.toml`
+- `numpy` — already in `pyproject.toml`
+- Full git history — workflow uses `fetch-depth: 0`
+- `stefanzweifel/git-auto-commit-action@v5` — trusted, widely-used action for auto-commits
+
+## Risks
+- **Auto-commit loop:** The dashboard workflow commits a PNG, which triggers `push` to `main`, which triggers the dashboard workflow again. Mitigate with: `paths-ignore: ['assets/dashboard/**']` on the push trigger, or check if the image actually changed before committing.
+- **Large binary in git:** PNG at 150 DPI is ~200-400KB. Acceptable for a single file. Could add to `.gitattributes` as LFS if it grows.
+
+## Outcome
+<!-- Filled after implementation -->
+- PR: #NNN / abandoned / deferred
+- Notes: any deviations from plan

--- a/plans/sessions/2026-03-18_post-merge-review-followups.md
+++ b/plans/sessions/2026-03-18_post-merge-review-followups.md
@@ -1,0 +1,74 @@
+# Post-Merge Review Batch Follow-ups
+**Date:** 2026-03-18
+**Goal:** Fix div-by-zero bug, document metric semantics, and file follow-up issues for all WARN findings from the PR #903/#906/#909/#918 post-merge review batch.
+
+## Context
+
+Post-merge reviews of 4 PRs produced 10 WARN findings total, 0 BLOCKs. This plan addresses all follow-up actions, prioritized by risk.
+
+## Plan
+
+### PR 1: fix/dashboard-divzero — Bug fix + smoke tests
+**Branch:** `fix/dashboard-divzero`
+**Scope:** `scripts/generate_dashboard.py`, new test file
+
+**Changes:**
+1. Guard division in `_draw_bollinger_panel` (line 354-356) when `n_valid == 0`
+   - Wrap the stats bar text in `if n_valid > 0:` guard
+   - When `n_valid == 0`, display "No valid Bollinger data" instead
+2. Fix misleading `WINDOW` comment at line 32 ("10 working days ≈ 2 calendar weeks") — the data includes all days with commits, not just weekdays. Change to "10 active days".
+3. Add `tests/unit/test_generate_dashboard.py` with:
+   - `test_bollinger_empty_data` — n < WINDOW, verifies no crash
+   - `test_bollinger_basic` — verifies SMA/band computation for known input
+   - `test_draw_bollinger_panel_zero_valid` — matplotlib panel renders without error when n_valid=0
+   - `test_generate_dashboard_smoke` — end-to-end with a tiny git repo fixture
+
+**Key function signatures (from code read):**
+- `_bollinger(data: np.ndarray, window: int, num_std: int) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]`
+- `_draw_bollinger_panel(ax, x, data, sma, upper, lower, pct_b, valid, latest_idx, *, band_color, sma_color, dot_color) -> None`
+- `generate_dashboard(repo: str, output: str) -> None`
+
+**Validation:** `uv run python -m pytest tests/unit/test_generate_dashboard.py -v`
+
+### PR 2: docs/metric-denominator-semantics — Documentation
+**Branch:** `docs/metric-denominator-semantics`
+**Scope:** `docs/01_core/METRICS.md` only
+
+**Changes:**
+Add a new subsection under "Auction Metrics" documenting the denominator difference:
+- Pooled `net_eppd`: denominator = all deals (including all-pass redeals)
+- Per-contract `net_eppd`: denominator = only deals with actual bids in that contract type
+- Per-contract `bid_rate` is always 1.0 by construction (all-pass excluded)
+- Caveat: pooled and per-contract `net_eppd` are NOT directly comparable due to different denominators
+
+**Validation:** `make docs-check`
+
+### Issue 3: File 5 follow-up issues
+**No branch needed — GitHub issues only.**
+
+| # | PR | Finding | Label |
+|---|-----|---------|-------|
+| 1 | #906 | CI classifier input mismatch — `changed_files` list may diverge from `dorny/paths-filter` output | `follow-up`, `fix:process` |
+| 2 | #906 | Duplicate severity-mapping logic in `review_driver.py` and `prechecks.py` | `follow-up`, `fix:convention` |
+| 3 | #906 | Inconsistent JSON schema between precheck output and review loop state | `follow-up`, `fix:convention` |
+| 4 | #909 | Missing test coverage for multi-seed merge path with `bidders_by_contract` | `follow-up`, `fix:test` |
+| 5 | #918 | flock/rename race condition in event draining | `follow-up`, `fix:process` |
+
+## Files
+- `scripts/generate_dashboard.py` — guard div-by-zero, fix comment
+- `tests/unit/test_generate_dashboard.py` — new test file (smoke tests)
+- `docs/01_core/METRICS.md` — add per-contract denominator semantics section
+
+## Rollback
+Both PRs are low-risk and reversible via `git revert`. No data migrations or schema changes.
+
+## Execution Order
+1. PR 1 (bug fix) — highest priority, real correctness bug
+2. PR 2 (docs) — can run in parallel with PR 1
+3. Issues — file after PRs are created (reference PR URLs in issue bodies)
+
+## Outcome
+- PR 1: #933 — fix: guard division-by-zero in dashboard Bollinger stats bar
+- PR 2: #931 — docs: document per-contract vs pooled net_eppd denominator semantics
+- Issues: #934, #935, #936, #937, #938
+- Labels created: `fix:process` (#c5def5), `fix:convention` (#0075ca)

--- a/plans/sessions/2026-03-18_pr909-review-fixes.md
+++ b/plans/sessions/2026-03-18_pr909-review-fixes.md
@@ -1,0 +1,186 @@
+# PR #909 Review Fix Plan
+
+**PR:** `feat: per-contract extraction in comparator CIs pipeline`
+**Branch:** `fix/behavior-by-contract-faceting`
+**Date:** 2026-03-18
+
+## Context
+
+PR #909 adds per-contract (suit/high/low) extraction to `extract_comparator_cis.py`.
+A review identified 2 correctness bugs, 2 design issues, and 1 process issue. All
+findings validated against source code.
+
+## Validated Findings
+
+| # | Severity | Finding | Validated |
+|---|----------|---------|-----------|
+| F1 | CRITICAL | All-pass redeals use `dummy_ctype = "high"` (simulation.py:426), logged as `contract="high"` in JSONL. Extraction code counts these in `by_contract["high"]["deals_total"]` but skips adding points (bidder_position is None), deflating net_eppd/bid_rate for "high" contract. | ✅ Traced: simulation.py:426 → line 810 → log_hand_end:880 → extraction line 77-81 |
+| F2 | HIGH | `by_contract` silently dropped in `--single-seat` mode. Merge dict (line 420-424) only aggregates 3 keys; `by_contract` from `_parse_jsonl_points` return is ignored. | ✅ Confirmed: merge loop lines 463-467 only touch 3 keys |
+| F3 | MEDIUM | Per-contract `bid_rate` is vacuously 1.0 for suit/low (after F1 fix). Every deal with contract=X inherently had a bid, so denominator=numerator. | ✅ Semantic consequence of per-contract filtering |
+| F4 | MEDIUM | Fixture `bidders_by_contract` has hand-crafted values (e.g., bid_rate=0.4667 for suit) that extraction code can't produce. Tests validate tables.py consumption, not extraction correctness. | ✅ No test covers `_parse_jsonl_points` directly |
+| F5 | LOW | No schema version bump for `comparator_cis_v1`. | Additive, optional |
+| F6 | PROCESS | Base branch targets merged `fix/reporting-refactor-status-correction`. | ✅ PR metadata confirms |
+
+## Fix Plan
+
+### Step 1: Retarget base branch
+```bash
+gh pr edit 909 --base main
+```
+
+### Step 2: Fix F1 — All-pass "high" poisoning
+
+**File:** `scripts/internal/extract_comparator_cis.py`
+
+**Change:** In `_parse_jsonl_points`, move per-contract `deals_total` increment
+to AFTER the all-pass check. Only count deals in per-contract buckets if they
+have a winning bid (i.e., are not all-pass redeals).
+
+```python
+# BEFORE (buggy): counts all-pass as "high"
+deals_total += 1
+contract = record.get("contract")
+if contract in by_contract:
+    by_contract[contract]["deals_total"] += 1
+
+# Skip all-pass redeals
+if winning_bid is None or bidder_position is None:
+    continue
+
+# AFTER (fixed): only count in per-contract after all-pass check
+deals_total += 1
+contract = record.get("contract")
+
+winning_bid = record.get("winning_bid")
+bidder_position = record.get("bidder_position")
+
+# Skip all-pass redeals (no winning bid or bidder)
+if winning_bid is None or bidder_position is None:
+    continue
+
+# Only count in per-contract for real bids (not all-pass)
+if contract in by_contract:
+    by_contract[contract]["deals_total"] += 1
+```
+
+**Consequence:** After this fix, per-contract `deals_total` = per-contract
+`hands_with_bids`, making `bid_rate` = 1.0 for all contracts. This is
+technically correct but uninformative — see Step 4 for documentation.
+
+### Step 3: Fix F2 — Wire `by_contract` through single-seat merge
+
+**File:** `scripts/internal/extract_comparator_cis.py`
+
+**Change:** Add `by_contract` to the merged dict initialization and aggregate
+it from each seat run.
+
+```python
+# Initialize merged with by_contract
+merged = {
+    "bidder_team_points": [],
+    "net_bidder_team_points": [],
+    "deals_total": 0,
+    "by_contract": {
+        ct: {"bidder_team_points": [], "net_bidder_team_points": [], "deals_total": 0}
+        for ct in ("suit", "high", "low")
+    },
+}
+
+# In seat loop, merge by_contract:
+for ct in ("suit", "high", "low"):
+    seat_ct = seat_data.get("by_contract", {}).get(ct, {})
+    merged["by_contract"][ct]["bidder_team_points"].extend(
+        seat_ct.get("bidder_team_points", [])
+    )
+    merged["by_contract"][ct]["net_bidder_team_points"].extend(
+        seat_ct.get("net_bidder_team_points", [])
+    )
+    merged["by_contract"][ct]["deals_total"] += seat_ct.get("deals_total", 0)
+```
+
+### Step 4: Fix F4 — Add extraction-level test with synthetic JSONL
+
+**File:** `tests/unit/test_extract_comparator_cis.py` (new) or add to
+existing test file.
+
+**Test:** Create synthetic JSONL with:
+- Normal suit/high/low bid hands
+- All-pass redeals (winning_bid=None/0, bidder_position=None, contract="high")
+
+Verify:
+- `by_contract["high"]["deals_total"]` excludes all-pass hands
+- `by_contract["suit"]["deals_total"]` counts only suit-contract deals
+- Per-contract bid_rate = 1.0 for all contracts (expected after F1 fix)
+- Pooled `deals_total` includes all-pass hands (unchanged behavior)
+
+### Step 5: Document F3 — bid_rate semantics
+
+Add a brief docstring note in `_compute_bidder_metrics` or in the per-contract
+metrics section clarifying that per-contract bid_rate is always 1.0 by
+construction (every deal in a contract bucket had a bid).
+
+### Step 6 (optional): Schema annotation
+
+Add `"bidders_by_contract"` to the schema string or bump to `comparator_cis_v2`.
+Low priority — additive field, backwards-compatible.
+
+## Plan Review Amendments
+
+Incorporated from plan-reviewer findings (R1, P2, P5, P15, P2, P6, P7):
+
+1. **R1 (CRITICAL):** Step 4 test MUST explicitly set `contract="high"` for
+   all-pass records. The `_make_hand_end` helper defaults to `contract="suit"`,
+   so without this the regression test would pass on unfixed code.
+
+2. **P15:** Steps 2 and 3 are NOT safely independent at commit granularity.
+   If F1 lands without F2, single-seat merge silently drops `by_contract`.
+   Both MUST land atomically (same commit).
+
+3. **P5:** The non-single-seat path (lines 471-489) already returns
+   `by_contract` from `_parse_jsonl_points` and stores it directly in
+   `all_data[name]`. No change needed — `by_contract` flows through
+   naturally in non-single-seat mode.
+
+4. **P2 (line 40):** The code snippet was illustrative. Implementation must
+   restructure the existing loop body — move the `contract` read and
+   per-contract increment below the all-pass guard, not duplicate variables.
+
+5. **P2 (line 119):** Docstring note belongs in `_parse_jsonl_points` or at
+   the per-contract call site, not in `_compute_bidder_metrics` (which handles
+   both pooled and per-contract data).
+
+6. **P6:** Add acceptance criterion for non-single-seat path.
+
+7. **P7:** Promote schema annotation from optional to recommended.
+
+## Execution Order
+
+1. Step 1 (retarget) — independent, first
+2. Steps 2+3 (F1+F2 fixes) — **atomic**, single commit
+3. Step 4 (tests) — depends on Steps 2+3 (tests verify fixed behavior)
+4. Steps 5+6 (docs + schema) — after tests pass
+5. Tier 2 validation (`make check-quiet`)
+
+## Acceptance Criteria
+
+- [ ] All-pass redeals do NOT inflate `by_contract["high"]["deals_total"]`
+- [ ] `--single-seat` mode produces `bidders_by_contract` in output
+- [ ] Non-single-seat mode also produces `bidders_by_contract` in output
+- [ ] Unit test with synthetic JSONL covers all-pass (contract="high") + real bids
+- [ ] `make check-quiet` passes
+- [ ] Base branch is `main`
+
+## Outcome
+
+**Completed 2026-03-18.** All fixes pushed to PR #909 branch `fix/behavior-by-contract-faceting`.
+
+Commit `5a2fc88`:
+- F1 fix: per-contract tracking moved after all-pass guard (lines 79-112)
+- F2 fix: `by_contract` wired through single-seat merge (lines 445-512)
+- Schema bumped to `comparator_cis_v2`
+- Docstring added to `_parse_jsonl_points`
+- 3 new regression tests: `test_by_contract_basic`, `test_all_pass_does_not_poison_high`,
+  `test_per_contract_bid_rate_is_one`
+- Branch cleaned from 18 stale stacked-base commits down to 3 focused commits
+- Base retargeted from merged `fix/reporting-refactor-status-correction` to `main`
+- `make check-quiet` passes, all 145 rung_tables tests + 9 extraction tests pass

--- a/plans/sessions/2026-03-18_pr909-test-coverage-gaps.md
+++ b/plans/sessions/2026-03-18_pr909-test-coverage-gaps.md
@@ -1,0 +1,102 @@
+# PR #909 Post-Merge Test Coverage Gaps
+
+**Date:** 2026-03-18
+**Parent PR:** #909 (`feat: per-contract extraction in comparator CIs pipeline`)
+**Trigger:** Post-merge review identified 3 WARNING-level test coverage gaps
+
+## Context
+
+PR #909 added per-contract extraction to `scripts/internal/extract_comparator_cis.py`.
+All correctness bugs were fixed pre-merge (plan: `plans/sessions/2026-03-18_pr909-review-fixes.md`).
+Post-merge review found 3 untested behaviors — all code paths are correct but lack
+regression protection.
+
+## Findings to Address
+
+| # | Finding | Risk | File |
+|---|---------|------|------|
+| G1 | No test for absent `contract` field in JSONL records (pre-contract-field era logs) | Low — `.get("contract")` returns `None`, `None not in by_contract` is `True`, silently excluded | `test_extract_comparator_cis.py` |
+| G2 | Schema version bump `comparator_cis_v1` → `v2` not verified by test assertion | Low — string is hardcoded at line 675, but no test locks it | `test_extract_comparator_cis.py` |
+| G3 | No CLI integration test for non-single-seat path asserting `bidders_by_contract` in output JSON | Medium — the non-single-seat path flows `by_contract` through naturally (line 529) but has no end-to-end coverage | `test_extract_comparator_cis.py` |
+
+## Plan
+
+### Step 1: G1 — Test absent `contract` field
+
+**Where:** `tests/unit/test_extract_comparator_cis.py`, class `TestParseJsonlPoints`
+
+**Test:** `test_missing_contract_field_excluded_from_by_contract`
+- Create synthetic JSONL with 3 records: 1 suit, 1 high, 1 with NO `contract` key
+- All three have valid `winning_bid` and `bidder_position` (not all-pass)
+- Assert `by_contract["suit"]["deals_total"] == 1`
+- Assert `by_contract["high"]["deals_total"] == 1`
+- Assert `by_contract["low"]["deals_total"] == 0`
+- Assert pooled `deals_total == 3` (missing-contract record still counted in pool)
+
+**Helper change:** `_make_hand_end` currently defaults `contract="suit"`. Add
+`contract=_SENTINEL` pattern so caller can explicitly omit the field by passing
+`contract=None`. When `contract is None`, don't include the key in the record dict.
+
+### Step 2: G2 — Assert schema version string
+
+**Where:** `tests/unit/test_extract_comparator_cis.py`, new class `TestSchemaVersion`
+
+**Test:** `test_output_schema_is_v2`
+- Import the module
+- Assert that the schema string `"comparator_cis_v2"` appears in `main` function source
+  OR (preferred) run a minimal CLI invocation and check `output["schema"]`
+- Since `main()` requires real filesystem args, the simplest approach: add this to
+  an existing CLI test class (`TestCLISkipRunContract`) or create a focused subprocess test
+
+**Pragmatic approach:** Add the assertion to the G3 integration test (Step 3) since that
+test already produces output JSON. Check `output["schema"] == "comparator_cis_v2"`.
+
+### Step 3: G3 — CLI integration test for non-single-seat path
+
+**Where:** `tests/unit/test_extract_comparator_cis.py`, class `TestCLISkipRunContract`
+or new class `TestCLINonSingleSeat`
+
+**Test:** `test_non_single_seat_produces_bidders_by_contract`
+- Create 2 synthetic bidder run directories matching pattern
+  `auction_comparator_{name}_{seed}_{timestamp}`
+- Each contains `game_log.jsonl` with suit + high + low records
+- Each contains `meta.json` with matching seed
+- Create a battery JSON referencing both bidders
+- Run CLI via subprocess: `python extract_comparator_cis.py --artifacts-dir ... --runs-dir ... --seed 42 --n-bootstrap 100 --output ...`
+  (no `--single-seat` flag)
+- Parse output JSON
+- Assert `"bidders_by_contract"` key exists
+- Assert each contract type has expected `deals_total`
+- Assert `output["schema"] == "comparator_cis_v2"` (covers G2)
+
+**Helper:** Use `_make_meta_json` (line 85) for meta.json creation. Create a
+minimal battery JSON with `net_eppd` and `eppd` values matching what the synthetic
+JSONL will produce, so validation passes (or use `--force`).
+
+## Execution Order
+
+1. Step 1 (G1) — unit test, no dependencies
+2. Step 3 (G3 + G2) — CLI integration test, independent of Step 1
+3. Tier 1 validation: `uv run python -m pytest tests/unit/test_extract_comparator_cis.py -v`
+4. Tier 2 validation: `make check-quiet`
+
+## Acceptance Criteria
+
+- [ ] Missing `contract` field records excluded from `by_contract` but counted in pool
+- [ ] Schema string `"comparator_cis_v2"` locked by test assertion
+- [ ] Non-single-seat CLI path produces `bidders_by_contract` in output
+- [ ] All existing tests still pass
+- [ ] `make check-quiet` passes
+
+## Outcome
+
+**Completed 2026-03-18.** All 3 coverage gaps addressed in a single commit.
+
+- G1: `test_missing_contract_field_excluded_from_by_contract` — verifies absent `contract`
+  field records are excluded from per-contract buckets but counted in pooled total
+- G2: Schema assertion `output["schema"] == "comparator_cis_v2"` embedded in G3 CLI test
+- G3: `test_non_single_seat_produces_bidders_by_contract` — full CLI integration test
+  with synthetic run directories, verifying `bidders_by_contract` in output and correct
+  per-contract deal counts
+
+45 tests pass (43 original + 2 new). `make check-quiet` passes.

--- a/plans/sessions/2026-03-18_reporting-refactor-post-904-909-closeout.md
+++ b/plans/sessions/2026-03-18_reporting-refactor-post-904-909-closeout.md
@@ -1,0 +1,278 @@
+# Reporting Refactor Post-#904/#909 Closeout
+**Date:** 2026-03-18
+**Goal:** Finish aligning the shipped `arc_d_v2` reporting suite with the governing refactor plan after PRs `#904` and `#909`. This plan separates what still needs code changes from what is genuinely blocked on missing experiment artifacts.
+
+## Current State
+
+### Confirmed improvements
+- Governing-plan status was moved away from a false `COMPLETE` state.
+- `outcome_summary.csv` was removed from committed `quick/full` bundles.
+- `04_rung_decision.md` is now deprecated in `full` bundles rather than silently acting as a parallel decision surface.
+- QUICK `02_decision.md` is no longer universally `PENDING`; `r0/r1` show `ADVANCE`, `r2/r3` show `PRELIMINARY`.
+- `extract_comparator_cis.py` now emits `bidders_by_contract`, which is the right upstream hook for real contract-faceted behavior outputs on future regenerations.
+- Bundle hygiene tests exist and pass.
+
+### Verified remaining gaps
+- Produced `quick` bundles still ship synthetic `outcome_distributions.csv`.
+- Produced `quick` bundles still ship pooled-only `behavior_by_contract.csv`.
+- Produced `quick` bundles still lack Charts `10`, `16`, `17`, `18`, `21`, and `22`.
+- The governing plan still has stale “current truth” bullets that describe pre-`#877` bundle state rather than current branch state.
+- Chart-data ownership is still not fully disciplined:
+  - `decision_comparison.csv` / `disagreement_outcomes.csv` still have both a dormant parquet path and a productive interpretability path.
+  - `selection_paths.csv` is still dual-written from feature-importance rows.
+  - `cross_rung_progression.csv` still exists as a target contract item without canonical bundle generation.
+
+### Real blockers
+- This checkout only has `data/fixtures/`; it does not have the `data/artifacts/arc_d_v2/` and run outputs needed to regenerate the missing model-eval and seat-balance evidence.
+- Per-contract behavior output in shipped bundles depends on rerunning extraction against real comparator JSONL logs after `#909`.
+
+## Plan
+
+- Step 1: Correct the governing plan so it is a trustworthy handoff document again.
+  - Update `plans/arc_d_v2/reporting_refactor_full_plan.md` §2.2 so it matches current branch truth.
+  - Remove stale bullets claiming QUICK decisions are still `Rung ?` / `PENDING`.
+  - Remove stale bullets claiming FULL manifests are still uniformly `Mode: QUICK` / `Seeds: []`.
+  - Keep only the real remaining gaps: synthetic distributions, pooled-only shipped behavior faceting, missing shipped chart family, deprecated extra decision file, and ownership drift.
+
+- Step 2: Close the remaining code-side ownership and contract gaps that are **not** blocked on source data.
+  - Make one canonical producer for `decision_comparison.csv` and `disagreement_outcomes.csv`.
+    - Preferred owner: `scripts/internal/generate_interpretability.py`
+    - Non-canonical parquet extractor path in `src/bid_euchre/arc_d_v2/tables.py` should be clearly fallback-only or removed from normal regeneration.
+  - Decide the disposition of `cross_rung_progression.csv`.
+    - If canonical: wire it into normal generation and manifest/report expectations.
+    - If not canonical: remove it from the target contract and acceptance checks.
+  - Decide the disposition of `selection_paths.csv`.
+    - If it remains canonical, define real selection-path semantics distinct from feature importance.
+    - Otherwise demote it to a compatibility alias and stop treating Chart 19 as distinct evidence.
+
+- Step 3: Merge the upstream comparator-faceting fix and prepare regeneration prerequisites.
+  - Merge PR `#909`.
+  - Record that shipped bundle faceting is still incomplete until regeneration runs against real comparator logs.
+  - Confirm which artifact directories and JSONL sources are required for:
+    - `behavior_by_contract.csv`
+    - `seat_balance.csv`
+    - `predictions.csv`
+    - `residuals.csv`
+    - `calibration_bins.csv`
+    - `decision_comparison.csv`
+    - `disagreement_outcomes.csv`
+
+- Step 4: Regenerate canonical bundles when source artifacts are available.
+  - Regenerate `docs/04_reports/arc_d_v2/r0-r3/quick/`.
+  - Regenerate `docs/04_reports/arc_d_v2/r0-r3/full/` for rungs with the necessary parquet/model artifacts.
+  - Do not regenerate `canonical/`.
+
+- Step 5: Re-audit the regenerated bundles against the governing plan.
+  - Verify `behavior_by_contract.csv` contains `suit`, `high`, and `low` rows.
+  - Verify `outcome_distributions.csv` is parquet-backed where row-level data exists; otherwise ensure degraded state is explicit.
+  - Verify Charts `10`, `16`, `17`, `18`, `21`, and `22` render whenever their source CSVs exist.
+  - Verify `01_results.md` no longer shows placeholder sections where the source data is present.
+  - Verify `02_decision.md` remains the sole maintained decision artifact.
+
+- Step 6: Only then declare the remaining gaps as data-blocked.
+  - If code-side ownership cleanup is complete and regeneration still cannot fill specific charts, record those as true source-artifact blockers.
+  - Do not describe the refactor as “pipeline code now correct” until both:
+    - code-side contract cleanup is complete
+    - bundle-level regeneration proves the intended outputs are actually emitted
+
+## Workstreams
+
+### Workstream A — Plan Truth Correction
+- File: `plans/arc_d_v2/reporting_refactor_full_plan.md`
+- Deliverable:
+  - accurate §2.2 current-state bullets
+  - accurate acceptance / remaining-work text
+- Success condition:
+  - no internal contradictions between plan status and branch state
+
+### Workstream B — Chart-Data Ownership Cleanup
+- Files:
+  - `src/bid_euchre/arc_d_v2/tables.py`
+  - `scripts/internal/generate_interpretability.py`
+  - `src/bid_euchre/arc_d_v2/chart_registry.py`
+- Deliverable:
+  - one canonical writer per chart-data artifact
+  - explicit disposition for `cross_rung_progression.csv`
+  - explicit disposition for `selection_paths.csv`
+- Success condition:
+  - no target artifact is simultaneously “canonical” in two different generation paths
+
+### Workstream C — Regeneration Readiness
+- Files:
+  - `scripts/internal/extract_comparator_cis.py`
+  - regeneration commands / working notes
+- Deliverable:
+  - merged `#909`
+  - documented artifact prerequisites for regeneration
+- Success condition:
+  - next agent can regenerate without rediscovering missing inputs
+
+### Workstream D — Bundle Regeneration and Audit
+- Files:
+  - `docs/04_reports/arc_d_v2/r*/quick/**`
+  - `docs/04_reports/arc_d_v2/r*/full/**`
+  - `tests/unit/test_bundle_hygiene.py`
+  - reporting bundle tests as needed
+- Deliverable:
+  - regenerated bundles reflecting the current pipeline
+  - follow-up audit documenting what is now fixed vs still degraded
+- Success condition:
+  - shipped bundles, not just infrastructure, align materially better with the governing plan
+
+## Implementation Sequence
+
+- PR 1: Governing-plan truth correction
+  - fix stale §2.2 bullets
+  - sync acceptance/remaining-work text with actual branch state
+
+- PR 2: Chart-data ownership cleanup
+  - canonicalize `decision_comparison.csv` / `disagreement_outcomes.csv`
+  - decide `cross_rung_progression.csv`
+  - decide `selection_paths.csv`
+
+- PR 3: Merge `#909`
+  - land comparator per-contract extraction
+  - document regeneration prerequisites
+
+- PR 4: Regeneration
+  - rerun bundle generation with real logs/artifacts
+  - do not touch `canonical/`
+
+- PR 5: Bundle audit / closeout
+  - verify shipped outputs against plan
+  - record any remaining true data-blocked items
+
+## Acceptance Criteria
+- The governing plan accurately describes the current repo state.
+- `quick` bundles no longer rely on stale status text to describe fixed issues.
+- `behavior_by_contract.csv` is contract-faceted in regenerated bundles when comparator logs are available.
+- Missing charts are treated as source-data gaps only after regeneration has been attempted with the required inputs.
+- `decision_comparison.csv` and `disagreement_outcomes.csv` have a single canonical producer in normal regeneration.
+- `cross_rung_progression.csv` is either canonically generated or explicitly removed from the target contract.
+- `selection_paths.csv` is either semantically distinct from feature importance or explicitly demoted from canonical evidence.
+- A post-regeneration audit exists that distinguishes:
+  - fixed in code
+  - fixed in shipped bundles
+  - still blocked on missing artifacts
+
+## Validation
+- `PYTHONPATH=. uv run python -m pytest -q tests/unit/test_bundle_hygiene.py`
+- `rg -n "Rung \\?|PENDING|Mode: QUICK|Seeds: \\[\\]" plans/arc_d_v2/reporting_refactor_full_plan.md docs/04_reports/arc_d_v2/*/{quick,full}`
+- `rg -n "selection_paths.csv|decision_comparison|disagreement_outcomes|cross_rung_progression" src/bid_euchre/arc_d_v2/tables.py scripts/internal/generate_interpretability.py src/bid_euchre/arc_d_v2/chart_registry.py`
+- `rg -n "contract,net_eppd" docs/04_reports/arc_d_v2/*/quick/tables/behavior_by_contract.csv`
+
+## Outcome (Partial — 2026-03-18, author-d session)
+
+### Completed
+- **Step 1 (Workstream A):** §2.2 stale bullets corrected — 8 items marked fixed with strikethrough, "Still outstanding" section reflects real gaps. §13 acceptance criteria corrected (✅→❌/⚠️). §16 added with 5 verified gaps.
+- **Step 2 partial (Workstream B):** `selection_paths.csv` dual-write removed from `tables.py` — now exclusively produced by `generate_interpretability.py`. `cross_rung_progression.csv` decided as optional (§16.5). `decision_comparison.csv`/`disagreement_outcomes.csv` ownership documented in §16.5 but dormant code paths not guarded.
+- **Step 4 partial (Workstream D):** R3/full chart_data regenerated — 4 new CSVs (predictions, residuals, calibration_bins, seat_balance) + 2 upgraded (outcome_distributions synthetic→parquet, bid_levels aggregate→per-level). R3/full now has 10 chart_data CSVs matching R0-R2/full.
+
+### PRs
+- [#904](https://github.com/Questuart/Bid-Euchre/pull/904): governing plan correction, outcome_summary removal, deprecation, 34 tests
+- [#909](https://github.com/Questuart/Bid-Euchre/pull/909): per-contract extraction, fixture enrichment, R3/full chart_data, ownership cleanup, §2.2 fix (stacked on #904)
+
+### Remaining gaps → see Handoff section below
+
+## Handoff
+
+### Context for next agent
+
+Two PRs (#904, #909) are open and under review. Once merged, the following
+gaps remain from this closeout plan. The next agent should address them in
+a single session.
+
+**Source artifacts ARE available** in the main checkout at
+`/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/`:
+- `data/artifacts/arc_d_v2/r{0,1,2,3}/` — H2H batteries, comparator CIs, training artifacts, joblib models
+- `data/runs/arc_d_v2/` — parquet datasets (r3_datasets/quick/seed_1001/)
+- R0/R1 have FULL H2H batteries (3 seeds); R2/R3 only have QUICK
+
+### Directive
+
+> **Draft a plan, have a reviewer review the plan, create a task list to
+> support execution, assess for parallelism, then execute the plan end to
+> end autonomously.**
+
+### Gap 1: Guard dormant extractors (code, no data dependency)
+
+`_extract_decision_comparison()` and `_extract_disagreement_outcomes()` in
+`src/bid_euchre/arc_d_v2/tables.py` (lines ~1072-1086) are dormant parquet
+extractors that will silently activate if the parquet schema ever gains
+`bid_decision` + `model` columns — potentially shadowing the canonical
+producer (`generate_interpretability.py`). Add an explicit guard or remove
+from the normal `generate_chart_data` call path so only the interpretability
+pipeline produces these CSVs.
+
+**Files:** `src/bid_euchre/arc_d_v2/tables.py`
+**Test impact:** `tests/unit/test_rung_tables.py` (existing graceful-skip tests should still pass)
+
+### Gap 2: Write regeneration prerequisites doc (doc, no data dependency)
+
+Document which artifact paths are required for each chart_data CSV so the
+next agent doing regeneration doesn't have to rediscover inputs. Include:
+
+| CSV | Required Artifact | Path Pattern |
+|-----|------------------|--------------|
+| `behavior_by_contract.csv` | comparator_cis with `bidders_by_contract` | Re-extract from JSONL via `extract_comparator_cis.py` |
+| `seat_balance.csv` | action_value.parquet | `data/runs/arc_d_v2/*/datasets/` |
+| `predictions.csv` | training_artifact_*.json + parquet | `data/artifacts/arc_d_v2/<rung>/` |
+| `residuals.csv` | training_artifact_*.json + parquet | same |
+| `calibration_bins.csv` | training_artifact_*.json + parquet | same |
+| `decision_comparison.csv` | trained models (joblib) + parquet | `generate_interpretability.py` |
+| `disagreement_outcomes.csv` | trained models (joblib) + parquet | same |
+
+**File:** New doc or section in the governing plan
+
+### Gap 3: Regenerate QUICK bundles (data-dependent)
+
+QUICK bundles still have:
+- Synthetic `outcome_distributions.csv` (no QUICK parquet → acceptable)
+- Pooled-only `behavior_by_contract.csv` (comparator CIs lack `bidders_by_contract` → need re-extraction from JSONL)
+
+To fix `behavior_by_contract.csv` in QUICK bundles: re-run
+`extract_comparator_cis.py` against JSONL game logs in `data/runs/` for each
+rung, then regenerate tables. Check if JSONL logs exist:
+```bash
+find /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/data/runs -name "*.jsonl" -path "*comparator*" | head -5
+```
+
+If JSONL logs don't exist, this is a true data blocker — document it and move on.
+
+### Gap 4: Verify chart rendering (data-dependent)
+
+After regeneration, verify Charts 10, 16, 17, 18, 21, 22 render when their
+source CSVs exist. Run chart generation against regenerated bundles:
+```bash
+uv run python scripts/internal/generate_rung_charts.py \
+  --tables-dir docs/04_reports/arc_d_v2/r0/full/tables \
+  --chart-data-dir docs/04_reports/arc_d_v2/r0/full/chart_data \
+  --output-dir /tmp/chart_verify/r0
+```
+Check which charts are produced vs absent.
+
+### Gap 5: Write post-regeneration audit (doc)
+
+Create a brief audit doc categorizing each acceptance criterion as:
+- **Fixed in code** — pipeline change landed
+- **Fixed in shipped bundles** — regenerated and committed
+- **Still blocked** — requires artifacts/logs not available
+
+**File:** `plans/sessions/` or a section in the governing plan §16
+
+### Parallelism Assessment
+
+- **Gaps 1 + 2** can run in parallel (independent code change + doc)
+- **Gap 3** depends on PRs #904/#909 being merged first
+- **Gap 4** depends on Gap 3
+- **Gap 5** depends on Gaps 3 + 4
+
+### Acceptance Criteria (from the closeout plan)
+
+All of these must be verified before the closeout plan can be marked COMPLETE:
+- [ ] `decision_comparison.csv` / `disagreement_outcomes.csv` dormant extractors guarded
+- [ ] Regeneration prerequisites documented
+- [ ] `behavior_by_contract.csv` contract-faceted in shipped bundles (or documented as data-blocked)
+- [ ] Charts 10, 16, 17, 18, 21, 22 verified (present or documented absent)
+- [ ] Post-regeneration audit exists with fixed/shipped/blocked categorization
+- [ ] Governing plan §2.2 and §16 are internally consistent with branch state

--- a/plans/sessions/2026-03-19_ops-index-hardening.md
+++ b/plans/sessions/2026-03-19_ops-index-hardening.md
@@ -1,0 +1,257 @@
+<!-- review-tier: medium -->
+# Session Plan: Ops Index Hardening (#952, #953, #957)
+**Date:** 2026-03-19
+**Goal:** Ship one cohesive Author-A PR that fixes the `ops/index.py` correctness and testability bugs without overlapping Author-Scratch's active memory/compaction work.
+**Closes:** #952, #953, #957
+
+## Executive State
+
+- Author-Scratch currently owns the ops persistence reliability slice in `memory.py` and `compaction.py` under `plans/sessions/2026-03-19_ops-persistence-hardening.md`.
+- This execution slice owns only the `ops/index.py` bug cluster.
+- The planned PR should stay focused on correctness and testability. The staleness-scan performance issue `#956` is a follow-up unless the executing agent can prove a fix stays local and test-backed without widening the query/read-path contract.
+
+## Primary Sources Of Truth
+
+- `plans/sessions/2026-03-19_ops-persistence-hardening.md`
+- `src/bid_euchre/ops/index.py`
+- `tests/unit/test_ops_index.py`
+- `tests/unit/test_ops_cli.py`
+- `scripts/internal/build_audit_index.py`
+- `scripts/internal/ops.py`
+- `.claude/CLAUDE.md`
+- `docs/02_agent/AGENTS.md`
+- `docs/02_agent/PLAN_REVIEW_TIERS.md`
+
+## Coordination And Write Ownership
+
+### Owned by this plan
+
+- `src/bid_euchre/ops/index.py`
+- `tests/unit/test_ops_index.py`
+- `tests/unit/test_ops_cli.py` only if CLI-facing behavior or output changes
+- `scripts/internal/build_audit_index.py` or `scripts/internal/ops.py` only if explicit `repo_root` plumbing becomes necessary
+
+### Explicitly not owned by this plan
+
+- `src/bid_euchre/ops/memory.py`
+- `src/bid_euchre/ops/compaction.py`
+- their corresponding test files
+
+No code-edit overlap with Scratch is expected if this boundary is respected.
+
+## Scope
+
+### In scope
+
+1. Fix `#952` by removing hardcoded CWD-relative auxiliary paths from `build_index()`.
+2. Fix `#953` by completing the FTS5 external-content trigger set with an `AFTER UPDATE` trigger.
+3. Fix `#957` by making `sources_indexed` accurate for compound ingestors.
+4. Add regression tests for all in-scope issues.
+5. Preserve backward compatibility for existing callers unless a minimal caller update is required.
+
+### Out of scope
+
+- `#950`, `#951`, `#954` in memory/compaction
+- `#956` staleness-check performance and query/read-path semantics
+- `#959` compaction symlink containment
+- `#928`, `#929`, `#930` watchdog wiring
+- `#829`, `#830`
+- Manual GitHub issue housekeeping
+
+## Autonomous Execution Requirements
+
+Before writing code, the executing agent must:
+
+1. Refresh context by reading the primary sources above and this plan.
+2. Draft or refine the execution plan if source-level discovery changes the approach.
+3. Spawn at least one reviewer agent to review that plan before major edits.
+4. Create and maintain a bounded task list covering implementation, validation, and PR shipment.
+5. Assess safe parallelism before delegating and only delegate disjoint write scopes.
+6. Execute the work end to end autonomously:
+   - implement
+   - test
+   - run focused failure-injection or direct-schema validation where relevant
+   - commit
+   - open or update the PR
+   - include `Validation Performed` evidence in the PR body
+
+Do not start implementation until the plan-review step and task-list setup are complete.
+
+## Workstreams
+
+### Workstream A — Repo-Root-Aware Path Resolution (`#952`)
+
+**Objective:** Make `build_index()` derive all auxiliary scan paths from explicit inputs rather than the process CWD.
+
+**Required changes**
+
+- Eliminate direct `Path("data/runs")` and `Path("docs/04_reports")` usage inside `build_index()`.
+- Introduce a repo-root-aware derivation strategy that preserves current behavior for existing callers.
+- Keep test ergonomics simple: `tmp_path` fixtures should be able to provide all scanned paths without `chdir()`.
+
+**Recommended approach**
+
+- Add an optional `repo_root: Path | None = None` parameter to `build_index()`.
+- Derive default `runtime_dir`, `plans_dir`, `data_runs_dir`, and `reports_dir` from `repo_root` when not explicitly passed.
+- Prefer keeping call-site changes minimal. Only touch `scripts/internal/build_audit_index.py` or `scripts/internal/ops.py` if explicit `repo_root` passing is needed for clarity or correctness.
+
+**Required tests**
+
+- A `tmp_path`-backed repo-root fixture with:
+  - a `data/runs/.../evidence_manifest*.json`
+  - a `docs/04_reports/.../manifest*.json`
+- Assert that `build_index()` ingests those sources without relying on `os.getcwd()`.
+
+### Workstream B — FTS Schema Contract Completion (`#953`)
+
+**Objective:** Complete the FTS5 external-content synchronization contract.
+
+**Required changes**
+
+- Add the missing `AFTER UPDATE` trigger to `init_schema()`.
+- Keep insert/delete behavior unchanged.
+
+**Required tests**
+
+- Initialize a test database.
+- Insert a source and entry.
+- Directly `UPDATE entries SET content = ...`.
+- Assert FTS-backed query results reflect the updated content rather than stale text.
+
+### Workstream C — Accurate Source Accounting (`#957`)
+
+**Objective:** Make `BuildResult.sources_indexed` reflect actual upserted sources for compound ingestors.
+
+**Required changes**
+
+- Fix the mismatch where `_ingest_review_loop`, `_ingest_plan_reviews`, and `_ingest_report_metadata` may upsert many sources but `build_index()` counts each call as one source.
+- Keep `entries_indexed` behavior unchanged.
+- Prefer a small internal API change over ad hoc counter patches.
+
+**Recommended approach**
+
+- Have compound ingestors return both `sources_count` and `entries_count`, or return a small internal result object with both fields.
+- Update `build_index()` to aggregate exact counts from those ingestors.
+
+**Required tests**
+
+- Create review-loop sidecars with:
+  - one `state.json`
+  - two per-round artifacts
+- Create one plan-review artifact.
+- Create one report metadata manifest.
+- Assert `sources_indexed` matches the true number of ingested sources, not the number of ingestor calls.
+
+### Workstream D — Deferred Performance Follow-Up (`#956`)
+
+**Objective:** Keep the first PR bounded.
+
+`#956` is intentionally deferred unless the executing agent can prove that:
+
+- the fix stays local to `src/bid_euchre/ops/index.py`
+- the query/read-path contract remains clear
+- targeted tests cover the changed behavior without broad CLI or API churn
+
+If those conditions are not met, record `#956` as an explicit follow-up in the PR body and closeout note.
+
+## Files
+
+- `src/bid_euchre/ops/index.py` — main implementation
+- `tests/unit/test_ops_index.py` — regression coverage for `#952`, `#953`, `#957`
+- `tests/unit/test_ops_cli.py` — only if CLI-facing behavior changes
+- `scripts/internal/build_audit_index.py` — only if explicit repo-root plumbing is needed
+- `scripts/internal/ops.py` — only if explicit repo-root plumbing is needed
+
+## Bounded Task List
+
+1. Review current `index.py` implementation and test coverage gaps.
+2. Run one plan-review sub-agent and incorporate material feedback.
+3. Create the execution task list.
+4. Implement `#952` path derivation fix.
+5. Add `#952` regression tests.
+6. Implement `#953` update trigger.
+7. Add `#953` regression test.
+8. Implement `#957` source-count fix.
+9. Add `#957` exact-count regression test.
+10. Reassess whether `#956` is still best deferred.
+11. Run targeted tests.
+12. Run `make check-quiet`.
+13. Commit on a `codex/` branch.
+14. Open or update the PR with `Validation Performed` evidence.
+
+## Parallelism Guidance
+
+No code-edit parallelism is recommended by default because the main write scope is one source file and one primary test file.
+
+Safe parallelism, if the executing agent judges it worthwhile:
+
+- Reviewer agent: plan review only
+- Worker A: source-level implementation design notes for `index.py`
+- Worker B: test-design proposal for `tests/unit/test_ops_index.py`
+
+Keep actual file edits, integration, validation, and PR preparation in the main agent unless write scopes are truly disjoint.
+
+## Risks And Rollback
+
+### Risk 1 — Repo-root fix widens public API more than necessary
+
+Mitigation:
+- Keep `repo_root` optional.
+- Preserve existing caller behavior by default.
+- Touch call sites only if required.
+
+### Risk 2 — Source-count fix becomes a broad internal refactor
+
+Mitigation:
+- Restrict the API change to the three compound ingestors.
+- Do not refactor every simple ingestor unless required.
+
+### Risk 3 — `#956` slips into the same PR and broadens scope
+
+Mitigation:
+- Treat `#956` as deferred by default.
+- Include it only with explicit justification and dedicated tests.
+
+### Rollback
+
+- Revert the branch or commit if targeted regressions fail unexpectedly.
+- If one issue proves larger than expected, split it out and keep the rest of the PR shippable.
+
+## Validation Requirements
+
+Minimum required commands:
+
+```bash
+uv run python -m pytest -q tests/unit/test_ops_index.py
+```
+
+```bash
+make check-quiet
+```
+
+Run this if `tests/unit/test_ops_cli.py`, `scripts/internal/ops.py`, or `scripts/internal/build_audit_index.py` change:
+
+```bash
+uv run python -m pytest -q tests/unit/test_ops_cli.py -k "index or query"
+```
+
+Required behavioral checks:
+
+- confirm `build_index()` can ingest `data/runs` and `docs/04_reports` sources from a `tmp_path`-backed repo root without relying on CWD
+- confirm a direct SQL update to `entries.content` is reflected in FTS query results
+- confirm `sources_indexed` reflects the true number of upserted sources for review loops, plan reviews, and report metadata
+
+## Deliverables
+
+1. Code and tests committed on a `codex/` branch.
+2. PR opened or updated.
+3. PR body includes:
+   - summary of `#952`, `#953`, `#957`
+   - exact validation commands run
+   - whether `#956` was deferred or included
+   - explicit non-overlap note with Scratch's memory/compaction work
+
+## Outcome
+<!-- Filled after implementation -->
+- PR: #NNN / deferred
+- Notes: record any scope changes, caller updates, or `#956` deferral

--- a/plans/sessions/2026-03-19_ops-persistence-hardening.md
+++ b/plans/sessions/2026-03-19_ops-persistence-hardening.md
@@ -1,0 +1,192 @@
+<!-- review-tier: medium -->
+# Session Plan: Ops Persistence Hardening (#950, #951, #954)
+**Date:** 2026-03-19
+**Goal:** Ship one cohesive PR that removes the verified data-loss chain in curated memory and the retry-blocking partial-archive failure in session compaction, with regression coverage and autonomous PR shipment.
+**Closes:** #950, #951, #954
+
+## Summary
+
+- Fix three follow-up bugs from PR #940 in the ops persistence layer.
+- Keep index configurability, index performance, schema-completeness, and compaction symlink hardening out of scope for this PR.
+- Require the executing agent to follow the repo implementation-handoff protocol before code changes begin.
+
+## Primary Sources Of Truth
+
+- `src/bid_euchre/ops/memory.py`
+- `src/bid_euchre/ops/compaction.py`
+- `tests/unit/test_ops_memory.py`
+- `tests/unit/test_ops_compaction.py`
+- `.claude/CLAUDE.md`
+- `docs/02_agent/AGENTS.md`
+- `docs/02_agent/PLAN_REVIEW_TIERS.md`
+
+## Scope
+
+### In scope
+
+1. Fix `#950` in `load_memory()` so malformed entries are skipped individually and valid entries are preserved.
+2. Fix `#951` in `save_memory()` so curated memory writes are atomic.
+3. Fix `#954` in `compact_session()` so failed archive writes do not leave a blocking partial archive behind.
+4. Add regression tests for each failure mode above.
+5. Ship a single PR with validation evidence.
+
+### Out of scope
+
+- `#952` `#953` `#956` `#957` in `src/bid_euchre/ops/index.py`
+- `#959` symlink-containment hardening in `delete_archive()`
+- `#928` `#929` `#930` watchdog/event wiring
+- `#829` review-driver architecture work
+- `#830` unless the executing agent reproduces a real parser failure on current `main`
+- Manual GitHub housekeeping for stale-open issues from PR #949
+
+## Autonomous Execution Requirements
+
+Before writing code, the executing agent must:
+
+1. Refresh context by reading the primary sources above and this plan.
+2. Draft or refine a concrete execution plan if new source-level discoveries require adjustment.
+3. Spawn at least one reviewer agent to review that plan before major edits.
+4. Create and maintain a bounded task list covering implementation, validation, and PR shipment.
+5. Assess safe parallelism before delegating and only delegate disjoint write scopes.
+6. Execute the work end to end autonomously:
+   - implement
+   - test
+   - run failure-injection or interrupted-write validation
+   - commit
+   - open or update the PR
+   - include `Validation Performed` evidence in the PR body
+
+Do not start implementation until the plan-review step and task-list setup are complete.
+
+## Implementation Plan
+
+### Workstream A — Curated Memory Resilience
+
+**Objective:** Remove the current data-loss chain in `ops/memory.py`.
+
+**Required changes**
+
+- `load_memory()` must preserve valid entries even when one entry is malformed.
+- `save_memory()` must stop writing directly to the canonical JSON path.
+- Warning logs should identify malformed entries or failed load/save paths clearly enough for diagnosis.
+
+**Implementation notes**
+
+- Parse the top-level JSON once, then validate or construct entries individually.
+- Preserve `version` and `last_updated` from the file even when some entries are skipped.
+- Use a same-directory temp file plus `os.replace()` or equivalent atomic rename.
+- Ensure failed temp-file writes do not destroy the previous good store.
+
+### Workstream B — Session Compaction Atomicity
+
+**Objective:** Make archive creation atomic-or-absent from the caller perspective.
+
+**Required changes**
+
+- If `compact_session()` fails after creating the session directory, remove the partial archive before returning failure.
+- Cleanup must be limited to the session directory created for the active `session_id`.
+- Existing duplicate-archive behavior should remain unchanged for already-complete archives.
+
+### Workstream C — Regression Coverage
+
+**Objective:** Prove the failure modes are fixed and stay fixed.
+
+**Required tests**
+
+- Corrupt-entry load test:
+  - one valid entry
+  - one malformed entry
+  - one additional valid entry
+  - expected result: valid entries survive, malformed entry is skipped
+- Interrupted-save or write-failure test:
+  - simulate a write failure before final replace
+  - expected result: prior on-disk file remains readable and unchanged
+- Partial-archive failure test:
+  - force a write failure after `session_dir.mkdir()`
+  - expected result: `compact_session()` returns failure and the session directory does not remain on disk
+
+## Files
+
+- `src/bid_euchre/ops/memory.py` — per-entry load resilience and atomic save path
+- `src/bid_euchre/ops/compaction.py` — cleanup on partial archive failure
+- `tests/unit/test_ops_memory.py` — load/save regression tests
+- `tests/unit/test_ops_compaction.py` — compaction failure-path regression test
+
+## Bounded Task List
+
+1. Review current implementation and tests.
+2. Run one plan-review sub-agent and incorporate material feedback.
+3. Create the execution task list.
+4. Implement `ops/memory.py` fixes.
+5. Add `test_ops_memory.py` regressions.
+6. Implement `ops/compaction.py` cleanup fix.
+7. Add `test_ops_compaction.py` failure-path regression.
+8. Run targeted tests.
+9. Run `make check-quiet`.
+10. Commit on a `codex/` branch.
+11. Open or update the PR with `Validation Performed` evidence.
+
+## Parallelism Guidance
+
+This slice is small enough that no code-edit parallelism is required by default.
+
+Safe parallelism, if the executing agent judges it worthwhile:
+
+- Reviewer agent: plan review only
+- Worker A: `ops/memory.py` + `test_ops_memory.py`
+- Worker B: `ops/compaction.py` + `test_ops_compaction.py`
+
+Do not allow multiple agents to edit the same source file or the same test file.
+Keep final integration, validation, and PR preparation in the main agent.
+
+## Risks And Rollback
+
+### Risk 1 — Atomic write implementation leaks temp files
+
+Mitigation:
+- Create temp files in the destination directory.
+- Clean up orphaned temp files on failure when possible.
+
+### Risk 2 — Cleanup path deletes more than intended
+
+Mitigation:
+- Only remove the specific `session_dir` for the active `session_id`.
+- Preserve the current duplicate-archive early-return guard.
+
+### Rollback
+
+- Revert the branch or commit if targeted regressions fail unexpectedly.
+- Do not broaden scope into index changes while debugging; record deferrals instead.
+
+## Validation Requirements
+
+Minimum required commands:
+
+```bash
+uv run python -m pytest -q tests/unit/test_ops_memory.py tests/unit/test_ops_compaction.py
+```
+
+```bash
+make check-quiet
+```
+
+Required behavioral checks:
+
+- confirm malformed memory entries no longer wipe valid entries
+- confirm failed memory save attempts preserve the previous on-disk file
+- confirm partial archive directories do not block re-archival after a forced failure
+
+## Deliverables
+
+1. Code and tests committed on a `codex/` branch.
+2. PR opened or updated.
+3. PR body includes:
+   - brief summary of issues fixed
+   - exact validation commands run
+   - results of failure-injection checks
+   - note of explicitly deferred follow-ups
+
+## Outcome
+<!-- Filled after implementation -->
+- PR: #NNN / deferred
+- Notes: record any scope changes or deferred follow-ups

--- a/plans/sessions/2026-03-19_reporting-next-phase-autonomous-execution.md
+++ b/plans/sessions/2026-03-19_reporting-next-phase-autonomous-execution.md
@@ -1,0 +1,269 @@
+# Reporting Next Phase Autonomous Execution
+**Date:** 2026-03-19
+**Goal:** Move Arc D v2 reporting from “complete with degraded states” to the strongest practical post-refactor state by removing the remaining degraded modes, regenerating stale bundles, and shifting from infrastructure work to analytical/report-quality work.
+
+## Executive State
+
+The reporting refactor is structurally complete, but the next meaningful work is still substantive:
+
+- Charts 21/22 are still absent and remain the largest analytical blind spot.
+- `r3/full` is still stale relative to `r0-r2/full`.
+- GBT model-eval extraction remains incomplete.
+- QUICK outcome distributions are still synthetic by policy.
+- The next improvements should optimize for decision-maker usefulness, not more chart-suite churn.
+
+This plan treats those five items as one coordinated execution slice.
+
+## Primary Sources Of Truth
+
+- `plans/arc_d_v2/reporting_refactor_full_plan.md`
+- `plans/arc_d_v2/reporting_pr_scope_full_chart_suite.md`
+- `docs/04_reports/arc_d_v2/r{0,1,2,3}/{quick,full}/`
+
+## Scope
+
+### In scope
+
+1. Finish decision-analysis chart production for Charts 21/22 if artifacts permit.
+2. Bring `r3/full` into parity with the current FULL reporting contract.
+3. Fix or document GBT model-eval loading.
+4. Revisit the long-term QUICK synthetic-distribution policy.
+5. Improve report quality and decision usefulness without expanding the surface area.
+
+### Out of scope
+
+- Reopening the 23-chart registry contract.
+- Adding new top-level report families.
+- Reintroducing `canonical/` as a maintained surface.
+- Notebook-driven reporting as the primary path.
+
+## Autonomous Execution Requirements
+
+Before writing code, the executing agent must:
+
+1. Read the governing plan sections relevant to:
+   - accepted degraded states
+   - Charts 21/22
+   - FULL model-eval chart requirements
+   - QUICK/FULL mode policy
+2. Draft a concrete session plan for the execution slice.
+3. Create a bounded task list.
+4. Assess safe parallelism and spawn at least one plan-review sub-agent.
+5. Incorporate plan-review feedback before implementation.
+
+Do not start implementation until the plan, task list, and plan-review step are complete.
+
+## Workstreams
+
+### Workstream A — Charts 21/22 Decision Analysis
+
+**Objective:** Produce `decision_comparison.csv`, `disagreement_outcomes.csv`, `decision_agreement.png`, and `disagreement_outcomes.png` if the required `.joblib` + parquet inputs exist.
+
+**Tasks**
+
+- Verify artifact availability for each rung:
+  - trained `.joblib` models
+  - eval parquet with the schema needed by `generate_interpretability.py`
+- If artifacts exist:
+  - run interpretability generation
+  - render Charts 21/22
+  - regenerate affected manifests and results reports
+- If artifacts do not exist:
+  - leave canonical ownership as-is
+  - explicitly preserve DS-2 as data-blocked
+  - update the PR summary and plan/status docs to say the gap is evidence-blocked, not code-blocked
+
+**Success condition**
+
+- Either Charts 21/22 ship in at least the eligible FULL bundles, or the repo has a fully verified, explicit “data-blocked” closeout note with no ambiguity.
+
+### Workstream B — R3/FULL Parity
+
+**Objective:** Eliminate DS-4 if the current artifacts support regeneration.
+
+**Tasks**
+
+- Audit `r3/full` against `r0-r2/full` for:
+  - rendered Charts 10 and 16-18
+  - model roster class metadata
+  - results/report sections that still understate on-disk data
+- If current inputs are sufficient:
+  - regenerate `r3/full`
+  - update manifest, evidence manifest, and results report
+- If inputs are still insufficient:
+  - keep DS-4 explicit and narrow
+  - ensure the governing plan says exactly why parity is not possible
+
+**Success condition**
+
+- `r3/full` either matches the current FULL contract or is the only explicitly documented stale exception with concrete cause.
+
+### Workstream C — GBT Model-Eval Loading
+
+**Objective:** Remove or narrow DS-3 by fixing GBT artifact discovery if practical.
+
+**Tasks**
+
+- Trace how OLS-family training artifacts are discovered for prediction/residual/calibration extraction.
+- Compare that path to GBT artifact layout.
+- Fix the joblib-path mismatch if it is a local pipeline problem.
+- If GBT loading cannot be fixed without artifact changes:
+  - document the exact blocker
+  - preserve DS-3 with tighter wording
+
+**Success condition**
+
+- GBT model-eval rows either appear in generated CSVs/charts or the repo contains a precise, verified reason they cannot.
+
+### Workstream D — QUICK Distribution Policy
+
+**Objective:** Decide whether QUICK synthetic distributions remain an accepted product decision or should be retired.
+
+**Tasks**
+
+- Re-check whether any practical QUICK parquet-backed path now exists.
+- If not:
+  - keep DS-1
+  - make sure QUICK reports clearly label synthetic/degraded distribution evidence
+- If yes:
+  - estimate the runtime/complexity cost of upgrading QUICK
+  - only implement if it does not collapse QUICK into FULL
+
+**Success condition**
+
+- QUICK distribution policy is explicit, stable, and honest in plan/report language.
+
+### Workstream E — Report Quality
+
+**Objective:** Improve report usefulness after infrastructure fixes, without adding new surfaces.
+
+**Tasks**
+
+- Review `01_results.md` and `02_decision.md` after any regeneration for:
+  - placeholder text that should now be removed
+  - weak narrative around failure modes
+  - missing explanation of degraded states
+- Prioritize improvements that help a human decision-maker:
+  - what is missing
+  - what is trustworthy
+  - what changed materially by rung
+- Keep the surface fixed to:
+  - `00_manifest.md`
+  - `01_results.md`
+  - `02_decision.md`
+
+**Success condition**
+
+- Regenerated reports read as decision artifacts, not just chart inventories.
+
+## Bounded Task List
+
+1. Verify current artifact availability for interpretability and GBT eval.
+2. Draft execution plan and get one plan-review sub-agent response.
+3. Split work into at least two non-overlapping write scopes if parallelism is useful.
+4. Attempt Charts 21/22 generation.
+5. Attempt `r3/full` regeneration.
+6. Attempt GBT artifact loading fix.
+7. Revalidate QUICK synthetic policy.
+8. Refresh manifests/results/decision reports.
+9. Run targeted tests.
+10. Run bundle-audit checks.
+11. Update governing docs/status language if any degraded state is removed or narrowed.
+12. Prepare PR with validation evidence.
+
+## Parallelism Guidance
+
+The executing agent should assess safe parallelism before editing.
+
+Good disjoint splits:
+
+- **Agent A:** Artifact audit and generation feasibility for Charts 21/22 and GBT eval.
+- **Agent B:** Report-quality pass and post-regeneration text cleanup in `01_results.md` / `02_decision.md`.
+- **Agent C:** Validation harness and bundle-audit command preparation.
+
+Keep these owned by the main agent:
+
+- final regeneration choices
+- final plan/status edits
+- integration of generated artifacts
+- PR body and validation evidence
+
+Do not allow multiple agents to edit the same plan file or the same generated bundle paths.
+
+## Recommended Execution Order
+
+1. Draft session plan and task list.
+2. Run plan review with at least one sub-agent.
+3. Audit interpretability + GBT artifact availability.
+4. Implement the highest-value unblock first:
+   - Charts 21/22 if artifacts exist
+   - otherwise GBT loading or `r3/full` regeneration
+5. Regenerate affected FULL bundles.
+6. Reassess QUICK synthetic policy.
+7. Improve report narrative in regenerated bundles.
+8. Run validation.
+9. Open PR with full evidence.
+
+## Validation Requirements
+
+Minimum automated validation:
+
+- `PYTHONPATH=. uv run python -m pytest -q tests/unit/test_rung_tables.py`
+- `PYTHONPATH=. uv run python -m pytest -q tests/unit/test_rung_charts.py`
+- `PYTHONPATH=. uv run python -m pytest -q tests/unit/test_rung_report.py`
+- `PYTHONPATH=. uv run python -m pytest -q tests/unit/test_bundle_hygiene.py`
+- `make check-quiet`
+
+Artifact and report validation:
+
+- verify whether Charts 21/22 are present or still explicitly absent
+- verify whether `r3/full` manifests/charts/results match on-disk chart data
+- verify whether GBT model-eval rows appear where expected
+- verify QUICK distribution labeling remains explicit
+- verify no deprecated decision artifacts reappear
+
+Suggested audit commands:
+
+```bash
+git fetch origin main
+for p in docs/04_reports/arc_d_v2/r{0,1,2,3}/{quick,full}/00_manifest.md; do
+  echo "== $p =="
+  rg -n "decision_agreement|disagreement_outcomes|seat_balance|pred_vs_actual|residual_distribution|calibration_curve" "$p"
+done
+```
+
+```bash
+for p in docs/04_reports/arc_d_v2/r{0,1,2,3}/quick/chart_data/outcome_distributions.csv; do
+  echo "== $p =="
+  sed -n '1,6p' "$p"
+done
+```
+
+```bash
+git show origin/main:docs/04_reports/arc_d_v2/r3/full/00_manifest.md | sed -n '10,110p'
+```
+
+## Deliverables
+
+1. Code/docs/artifacts committed on branch.
+2. PR opened.
+3. PR body includes:
+   - plan summary
+   - artifact availability findings
+   - tests run
+   - bundle-audit evidence
+   - final degraded states removed, narrowed, or retained
+4. Short closeout note stating whether reporting is now:
+   - fully complete
+   - complete with fewer degraded states
+   - still complete with the same degraded states
+
+## Definition Of Done
+
+This slice is successful if:
+
+- the highest-value remaining analytical gap is reduced
+- any remaining degraded states are narrower and better justified
+- `r3/full` is either regenerated or explicitly proven blocked
+- report quality improves without expanding the reporting surface
+- the next person can tell, from the PR alone, exactly what reporting still cannot do and why

--- a/plans/sessions/2026-03-19_reporting-residuals-post-972-handoff.md
+++ b/plans/sessions/2026-03-19_reporting-residuals-post-972-handoff.md
@@ -1,0 +1,206 @@
+# Reporting Residuals Post-#972 Handoff
+**Date:** 2026-03-19
+**Goal:** Finish the highest-value remaining reporting work after PR `#972`, ideally in one PR, by realizing the GBT model-eval fix in shipped FULL bundles and tightening the governing-plan/report truthfulness that follows from it.
+
+## Primary References
+
+- `plans/arc_d_v2/reporting_refactor_full_plan.md`
+- `plans/sessions/2026-03-19_reporting-next-phase-autonomous-execution.md`
+- PR `#972` branch / merge state
+
+## Current State
+
+Assuming `#972` is merged or ready to merge:
+
+- DS-4 is resolved or pending resolution via `r3/full` chart parity.
+- DS-3 is narrowed in code, but not yet fully realized in shipped bundles.
+- The highest-value remaining reporting work is:
+  - regenerate `r0-r2/full` model-eval CSVs with GBT rows
+  - refresh manifests/results to reflect the new rows
+  - re-audit degraded states after the regeneration
+
+Still accepted unless this slice proves otherwise:
+
+- DS-1: QUICK synthetic outcome distributions
+- DS-2: Charts 21/22 data-blocked
+
+## Scope For One PR
+
+This should fit in one PR **if** the artifacts needed for FULL regeneration are present and stable.
+
+### In scope
+
+1. Verify `#972` state on `main` or stack cleanly on top of it.
+2. Regenerate `r0-r2/full` model-eval CSVs so GBT rows actually ship.
+3. Refresh affected FULL manifests and results reports.
+4. Re-audit DS-3 after regeneration.
+5. If cheap and directly adjacent, improve `01_results.md` / `02_decision.md` wording where the new model-eval evidence changes the interpretation.
+
+### Out of scope
+
+- Charts 21/22 unless artifact availability turns out to be trivial after audit.
+- QUICK-mode redesign.
+- New top-level reporting surfaces.
+- Notebook-driven reporting.
+
+## Mandatory Execution Sequence
+
+Before implementation:
+
+1. Read the governing plan sections for:
+   - DS-1 through DS-4
+   - FULL model-eval chart-data expectations
+   - acceptance criteria status
+2. Read `plans/sessions/2026-03-19_reporting-next-phase-autonomous-execution.md`.
+3. Draft a concrete session plan for this residual slice.
+4. Create a bounded task list.
+5. Assess safe parallelism.
+6. Spawn at least one agent to review the plan before major edits.
+7. Incorporate plan-review feedback.
+
+Do not start implementation until the plan, task list, and plan review are complete.
+
+## Main Objective
+
+Turn DS-3 from “code fix shipped, regeneration deferred” into shipped reporting evidence.
+
+That means:
+
+- `predictions.csv`
+- `residuals.csv`
+- `calibration_bins.csv`
+
+for `r0-r2/full` should include GBT rows if the fixed discovery path in `tables.py` now works against the real artifacts.
+
+## Concrete Task List
+
+1. Verify merge/base state.
+   - If `#972` is merged, branch from `main`.
+   - If not, stack on `#972` cleanly and state that explicitly in the PR.
+
+2. Audit artifact availability for `r0-r2/full`.
+   - confirm `training_artifact_gbt_av.json`
+   - confirm `.joblib` files under `data/artifacts/arc_d_v2/<rung>/`
+   - confirm FULL eval parquet paths
+
+3. Draft the execution plan and get one plan-review agent response.
+
+4. Regenerate `r0-r2/full` model-eval chart-data.
+   - validate that GBT rows appear in:
+     - `predictions.csv`
+     - `residuals.csv`
+     - `calibration_bins.csv`
+
+5. Refresh bundle surfaces impacted by the regenerated CSVs.
+   - `00_manifest.md`
+   - `evidence_manifest.json`
+   - `01_results.md`
+   - any affected charts/dashboards if regeneration changes them materially
+
+6. Re-evaluate DS-3.
+   - If GBT rows now ship in `r0-r2/full`, narrow or remove DS-3 accordingly.
+   - If regeneration still fails, document the exact blocker rather than leaving generic wording.
+
+7. Optional adjacent pass:
+   - tighten `01_results.md` or `02_decision.md` narrative only where the new GBT evidence materially changes interpretation.
+
+8. Run validation.
+
+9. Open PR with explicit before/after evidence.
+
+## Safe Parallelism
+
+Use parallelism only if write scopes are disjoint.
+
+Good splits:
+
+- **Agent A:** artifact audit and regeneration feasibility for `r0-r2/full`
+- **Agent B:** report-quality wording audit for affected FULL bundles
+- **Agent C:** validation command preparation / bundle-audit checks
+
+Keep these with the main agent:
+
+- final regeneration commands
+- integration of regenerated artifacts
+- governing-plan degraded-state edits
+- final PR body and evidence summary
+
+Do not have multiple agents edit the same generated bundle directories or the same plan file.
+
+## Validation Requirements
+
+Minimum:
+
+- `PYTHONPATH=. uv run python -m pytest -q tests/unit/test_rung_tables.py`
+- `PYTHONPATH=. uv run python -m pytest -q tests/unit/test_rung_charts.py`
+- `PYTHONPATH=. uv run python -m pytest -q tests/unit/test_rung_report.py`
+- `PYTHONPATH=. uv run python -m pytest -q tests/unit/test_bundle_hygiene.py`
+- `make check-quiet`
+
+Required artifact checks:
+
+- GBT rows actually appear in regenerated `r0-r2/full` model-eval CSVs
+- manifests/evidence manifests inventory the regenerated CSVs accurately
+- `01_results.md` no longer understates the available model-eval evidence
+- DS-3 wording in the governing plan matches the shipped bundle state
+
+Suggested audit commands:
+
+```bash
+for p in docs/04_reports/arc_d_v2/r{0,1,2}/full/chart_data/{predictions,residuals,calibration_bins}.csv; do
+  echo "== $p =="
+  sed -n '1,8p' "$p"
+done
+```
+
+```bash
+for p in docs/04_reports/arc_d_v2/r{0,1,2}/full/00_manifest.md; do
+  echo "== $p =="
+  rg -n "Predicted vs Actual|Residual Distribution|Calibration Curve" "$p"
+done
+```
+
+```bash
+git show origin/main:plans/arc_d_v2/reporting_refactor_full_plan.md | sed -n '1098,1122p'
+```
+
+## PR Guidance
+
+This can be one PR if the regeneration works.
+
+Recommended PR framing:
+
+- primary change: realize GBT model-eval support in shipped FULL bundles
+- secondary change: narrow or resolve DS-3 in plan docs
+- optional tertiary change: small report-quality wording updates tied directly to the new evidence
+
+Do not expand scope to Charts 21/22 unless the artifact path is unexpectedly trivial.
+
+## Deliverables
+
+1. Code/docs/artifacts committed on branch.
+2. PR opened.
+3. PR body includes:
+   - base/stacking state relative to `#972`
+   - artifact availability findings
+   - regeneration commands
+   - tests run
+   - before/after DS-3 status
+   - any remaining blockers
+4. Short handoff summary stating:
+   - what shipped
+   - whether DS-3 is now realized or still deferred
+   - whether any adjacent report-quality cleanup landed
+   - PR number/link
+
+## Success Condition
+
+This slice is successful if one PR can move reporting forward from:
+
+- “GBT fix exists in code”
+
+to:
+
+- “GBT-backed model-eval evidence actually ships in the FULL bundles that can support it”
+
+and the governing plan truthfully reflects that new state.

--- a/plans/sessions/2026-03-19_skills-expansion-execution-handoff.md
+++ b/plans/sessions/2026-03-19_skills-expansion-execution-handoff.md
@@ -1,0 +1,241 @@
+# Skills Expansion Execution Handoff
+**Date:** 2026-03-19
+**Goal:** Implement the READY skills-expansion plan in one docs/skills PR, from fresh worktree through validation and PR creation.
+
+## Primary References
+
+- `plans/sessions/2026-03-19_skills-expansion.md`
+- `plans/sessions/2026-03-19_skills-expansion-review-handoff.md`
+- `.claude/CLAUDE.md` (`Implementation Handoff Protocol`)
+- `.claude/rules/25_task_lists.md`
+
+## Current State
+
+- The implementation plan at `plans/sessions/2026-03-19_skills-expansion.md` has already been reviewed and is now `READY`.
+- There is **no PR yet** for this work.
+- The currently open PR `#978` is unrelated. Do not stack on it or modify its branch.
+- Use the **explicit file lists below as the source of truth**. If any summary counts in the plan drift, prefer the concrete paths.
+
+## Mandatory Execution Sequence
+
+Before any code or docs edits, do this in order:
+
+1. Read the plan file and this handoff fully.
+2. Refresh or draft a concrete execution plan for this PR slice.
+3. Spawn at least one reviewer agent to review that refreshed execution plan before major edits.
+4. Create and maintain a task list covering implementation, validation, and PR shipment.
+5. Assess safe parallelism and delegate only disjoint write scopes.
+6. Execute the work end to end autonomously:
+   - implement
+   - validate
+   - commit
+   - open the PR
+   - include `Validation Performed` evidence in the PR body
+
+Do not skip directly from reading the plan to editing files.
+
+## Branch / Worktree Setup
+
+Start from `main` in a fresh worktree and use a `codex/` branch name.
+
+Suggested pattern:
+
+```bash
+git fetch origin main
+git worktree add ../Bid-Euchre-skills-expansion -b codex/skills-expansion origin/main
+```
+
+If that path or branch already exists, choose a nearby variant, but keep the branch prefixed with `codex/`.
+
+## Scope
+
+### In Scope
+
+- Create 7 new skills.
+- Create 3 supporting progressive-disclosure files.
+- Retire 3 stale skills.
+- Update existing skills for stale tool/task references.
+- Add gotchas sections to 5 existing skills.
+- Clean up the live `/reviewing-plans` references called out in the plan.
+
+### Out of Scope
+
+- Any Python source changes.
+- Any workflow-hook behavior change for skill-usage logging (`.claude/settings.json` remains deferred).
+- Any update to frozen/historical Arc D lineage plans beyond what the implementation plan explicitly calls live cleanup.
+- Any unrelated cleanup beyond the files listed below.
+
+## Source-of-Truth File List
+
+### New Files
+
+- `.claude/skills/running-experiments/SKILL.md`
+- `.claude/skills/running-experiments/QUICK_REFERENCE.md`
+- `.claude/skills/analyzing-results/SKILL.md`
+- `.claude/skills/analyzing-results/CHECKLIST.md`
+- `.claude/skills/debugging-ci/SKILL.md`
+- `.claude/skills/debugging-ci/SYMPTOM_TABLE.md`
+- `.claude/skills/managing-worktrees/SKILL.md`
+- `.claude/skills/validating-changes/SKILL.md`
+- `.claude/skills/adding-strategies/SKILL.md`
+- `.claude/skills/triaging-issues/SKILL.md`
+
+### Deleted Files
+
+- `.claude/skills/reviewing-plans/SKILL.md`
+- `.claude/skills/drafting-rung-reports/SKILL.md`
+- `.claude/skills/narrating-reports/SKILL.md`
+
+### Modified Files
+
+- `.claude/skills/reviewing-changes/SKILL.md`
+- `.claude/skills/executing-plans/SKILL.md`
+- `.claude/skills/shipping-changes/SKILL.md`
+- `.claude/skills/planning-code-first/SKILL.md`
+- `.claude/skills/recovering-context/SKILL.md`
+- `.claude/skills/fixing-bugs/SKILL.md`
+- `.claude/skills/summarizing-sessions/SKILL.md`
+- `.claude/skills/reviewing-repo/SKILL.md`
+- `docs/02_agent/PLAN_REVIEW_RUBRIC.md`
+- `.claude/hooks/README.md`
+
+## Non-Negotiable Content Requirements
+
+### New Skill Quality Bar
+
+For each new `SKILL.md`:
+
+- Frontmatter must include correct `name` and `description`.
+- Descriptions must be **trigger-oriented**, not generic summaries.
+- Guidance must stay specific to this repo and its workflows.
+- References should point to authoritative repo docs for progressive disclosure.
+- Gotchas must be concrete and project-specific.
+
+### Existing Skill Updates
+
+- Replace `TodoWrite` references with `TaskCreate` / `TaskUpdate` where planned.
+- Replace stale `Task tool` wording with `Agent tool` in:
+  - `.claude/skills/summarizing-sessions/SKILL.md`
+  - `.claude/skills/reviewing-repo/SKILL.md`
+- Add gotchas sections to the 5 planned existing skills using repo-specific failure modes, not generic agent advice.
+
+### Retirement Cleanup
+
+- Remove the three retired skill files listed above.
+- Update live `/reviewing-plans` references in:
+  - `docs/02_agent/PLAN_REVIEW_RUBRIC.md`
+  - `.claude/hooks/README.md`
+- Do **not** expand cleanup into frozen/history-only references unless the work is trivial and clearly in scope.
+
+## Safe Parallelism Guidance
+
+Parallelize only across disjoint write scopes.
+
+Good splits:
+
+- Worker A: `running-experiments/`, `analyzing-results/`
+- Worker B: `debugging-ci/`, `managing-worktrees/`, `validating-changes/`
+- Worker C: `adding-strategies/`, `triaging-issues/`
+- Main agent: deletions, shared skill edits, doc cleanup, integration, validation, PR
+
+Keep these with the main agent:
+
+- final wording consistency across new skills
+- retired-skill deletions
+- `PLAN_REVIEW_RUBRIC.md` and `.claude/hooks/README.md`
+- final validation
+- commit / PR body / PR creation
+
+Do not have multiple agents edit the same existing skill file.
+
+## Recommended Execution Flow
+
+1. Verify `main` base and create the worktree/branch.
+2. Refresh the execution plan and get one reviewer-agent pass on it.
+3. Create the task list.
+4. Implement the new skill folders and support docs.
+5. Update existing skills and docs.
+6. Delete retired skills.
+7. Run validation.
+8. Fix any validation failures.
+9. Commit and open the PR.
+10. Update the plan `## Outcome` section if appropriate once the PR exists.
+
+## Validation Requirements
+
+Minimum required:
+
+- `make check`
+
+Required grep / sanity checks:
+
+```bash
+rg -n "TodoWrite|Task tool" .claude/skills
+```
+
+Expected result:
+
+- no remaining live hits in the shipped skill set
+
+```bash
+rg -n "/reviewing-plans" docs/02_agent/PLAN_REVIEW_RUBRIC.md .claude/hooks/README.md
+```
+
+Expected result:
+
+- no remaining live hits in those two files
+
+```bash
+find .claude/skills -maxdepth 2 -name SKILL.md | sort
+```
+
+Use this to confirm the retired skills are gone and the new skill directories exist.
+
+Manual validation required:
+
+- spot-check each new skill description for trigger specificity
+- verify gotchas are repo-specific
+- verify references in each new skill point to real docs/scripts
+- verify the overlap boundary is still clear for:
+  - `validating-changes` vs `debugging-ci`
+  - `running-experiments` vs `analyzing-results`
+
+## PR Guidance
+
+Open one PR from the new `codex/` branch.
+
+The PR body should include:
+
+- plan path: `plans/sessions/2026-03-19_skills-expansion.md`
+- confirmation that the implementation followed the reviewed plan
+- concise file-group summary:
+  - new skills
+  - retired skills
+  - existing-skill updates
+  - live reference cleanup
+- `Validation Performed` with the exact commands run
+- note that `.claude/settings.json` skill-usage logging was intentionally deferred
+
+After `gh pr create`, expect the normal post-PR review hook flow to run.
+
+## Deliverables
+
+1. Branch in a dedicated worktree.
+2. All planned file edits complete and committed.
+3. PR opened.
+4. Short completion note with:
+   - PR number / link
+   - validation performed
+   - whether any scope was deferred
+   - any remaining follow-up risk
+
+## Success Condition
+
+This handoff is complete when one PR has:
+
+- added the 7 new skills and 3 support docs
+- retired the 3 stale skills
+- updated the planned existing skills and live docs references
+- passed `make check`
+- removed the targeted stale `TodoWrite`, `Task tool`, and live `/reviewing-plans` references in the scoped files
+- shipped with a PR body that includes clear validation evidence

--- a/plans/sessions/2026-03-19_skills-expansion-review-handoff.md
+++ b/plans/sessions/2026-03-19_skills-expansion-review-handoff.md
@@ -1,0 +1,105 @@
+# Review Handoff: Skills Expansion Plan
+
+**Date:** 2026-03-19
+**Plan file:** `plans/sessions/2026-03-19_skills-expansion.md`
+**Author:** Claude (main session)
+**Review requested by:** User
+
+## Task for Reviewer
+
+You are an independent reviewer. Your job is to review the plan at
+`plans/sessions/2026-03-19_skills-expansion.md` for quality, completeness,
+and risks that the author may have missed.
+
+### Review Scope
+
+1. **Read the plan file** at the path above.
+
+2. **Verify all referenced paths exist on disk** — the author claims to have
+   verified them, but you should independently confirm:
+   - All doc paths in References sections
+   - All script paths in command examples
+   - All skill paths in Modified/Deleted files sections
+
+3. **Evaluate against these criteria:**
+
+   **Content quality:**
+   - Do the 7 new skill descriptions serve as trigger conditions (not summaries)?
+   - Are gotchas specific to this project (not generic advice)?
+   - Does each skill reference authoritative docs for progressive disclosure?
+   - Is there meaningful overlap or conflict between new skills and existing ones?
+     Specifically: `validating-changes` vs `debugging-ci` (both touch `make check`),
+     `running-experiments` vs `analyzing-results` (experiment lifecycle).
+
+   **Retirement decisions:**
+   - Is retiring `drafting-rung-reports` and `narrating-reports` premature?
+     Check the browser game governing plan (`plans/browser_game/governing_plan.md`)
+     to see if those skills could be needed again.
+   - Is retiring `reviewing-plans` safe? Check if anything in `.claude/settings.json`
+     or hooks references it by name.
+
+   **Completeness:**
+   - Are there other existing skills with stale references (beyond TodoWrite)?
+   - Are there other obvious skill gaps not identified in the plan?
+   - Does the delivery strategy (single PR) make sense, or should retirements
+     be separated from additions?
+
+   **Risk assessment:**
+   - The plan proposes a single PR with 20 file operations. Is this reviewable?
+   - Could any skill description trigger too aggressively and cause unwanted invocations?
+   - Are the gotchas sections for existing skills (Phase 6.1) sufficiently specified,
+     or should the plan include draft content for each?
+
+4. **Check for internal contradictions:**
+   - Estimated scope vs actual file list
+   - Acceptance criteria vs plan steps
+   - Phase numbering consistency
+
+5. **Output your review** using this format:
+
+```markdown
+## Independent Plan Review: Skills Expansion
+
+### Path Verification
+| Path | Exists? | Notes |
+|------|---------|-------|
+
+### Content Quality
+[Findings]
+
+### Retirement Analysis
+[Findings re: drafting-rung-reports, narrating-reports, reviewing-plans]
+
+### Completeness Gaps
+[Any missing items]
+
+### Risk Assessment
+[Findings]
+
+### Internal Consistency
+[Any contradictions found]
+
+### Verdict
+READY / NEEDS_ATTENTION / NOT_READY
+
+### Recommended Changes (if any)
+[Ordered by priority]
+```
+
+## Important Constraints
+
+- **Read-only review.** Do NOT edit any files.
+- **Verify against disk.** Always Glob/Read to check claims.
+- **Be specific.** "Could be improved" is not helpful. Say what should change and why.
+- **New files are exempt from path verification** — only verify existing referenced paths.
+
+## Context
+
+The plan was motivated by Thariq Shihipar's tweet about Claude Code skill categories:
+https://x.com/trq212/status/2033949937936085378
+
+The repo has 15 existing skills in `.claude/skills/`. The plan adds 7, retires 3,
+updates 3, and adds gotchas to 5 — for a net result of 19 skills (15 - 3 + 7).
+
+The project is a Bid Euchre AI research framework. Arc D v2 (the multi-model lineage
+initiative) is COMPLETE. The next active initiative is browser game hosting.

--- a/plans/sessions/2026-03-19_skills-expansion.md
+++ b/plans/sessions/2026-03-19_skills-expansion.md
@@ -1,0 +1,462 @@
+<!-- review-tier: medium -->
+# Skills Expansion: 7 New Skills + 3 Retirements + 4 Updates + 3 Meta-Improvements
+**Date:** 2026-03-19
+**Goal:** Implement the 7 skill gaps, retire 3 stale skills, update 4 existing skills,
+and apply 3 meta-improvements identified from Thariq's "Lessons from Building Claude Code:
+How We Use Skills" analysis, mapped against our existing 15 skills.
+
+**Source:** https://x.com/trq212/status/2033949937936085378
+
+## Context
+
+Our existing skills heavily cover **code quality/review** (5 skills) and
+**planning/execution** (4 skills) but have zero coverage in:
+- Product Verification (experiment running)
+- Data Fetching & Analysis (statistical analysis)
+- Runbooks (symptom-driven debugging)
+- CI/CD & Deployment (pre-PR validation)
+- Infrastructure Operations (worktree management)
+
+This plan adds skills for each gap and applies Thariq's three meta-best-practices
+(gotchas sections, folder-as-skill, usage measurement) to the full skill suite.
+
+## Delivery Strategy
+
+**Single PR** with all 7 new skills + 3 meta-improvements. Rationale:
+- All changes are `.claude/skills/` markdown + optional shell scripts
+- No source code changes — zero regression risk
+- Skills are independently useful but thematically unified
+- Splitting into 7+ PRs would be pure churn for docs-only changes
+
+**Estimated scope:** ~10 new files (7 SKILL.md + 3 supporting files), ~10 edits
+to existing files (5 Gotchas additions + 4 tool-name fixes + 2 doc reference updates
+for reviewing-plans retirement), 3 deletions (retired skills).
+
+## Plan
+
+### Phase 1: High-Priority Skills (3 skills)
+
+#### 1.1 `running-experiments` (Product Verification)
+
+**File:** `.claude/skills/running-experiments/SKILL.md`
+
+**Trigger description:** "Guides experiment execution: config validation, seeded runs,
+suite execution, and result comparison. Use when running experiments, comparing runs,
+or validating strategy changes."
+
+**Content outline:**
+- Phase 0: Pre-flight (verify worktree, check config exists, dry-run validation)
+- Phase 1: Smoke Run (quick_test.yaml, --seed 42, --n-per 10)
+- Phase 2: Suite Execution (run_suite.py, choosing appropriate suite)
+- Phase 3: Comparison (compare_runs.py with bootstrap, --format markdown for PR)
+- Phase 4: Interpretation (what the output metrics mean, pass/fail thresholds)
+
+**Gotchas section:**
+- Missing `--seed` silently produces non-reproducible results
+- `--n-per 10` is smoke-only; production needs ≥50,000 (per `05_rigor.md`)
+- `--allow-nondeterministic` voids all comparison claims
+- `compare_runs.py` requires both runs to use the same config structure
+- Output goes to `data/runs/<run_id>/` — never commit these
+
+**Key commands to embed:**
+```
+uv run python experiments/run_experiment.py --seed 42 --dry-run --config <cfg>
+uv run python experiments/run_experiment.py --seed 42 --config <cfg> --n_per 10
+uv run python scripts/run_suite.py --suite <suite> --seed 42 --n-per 20
+uv run python scripts/compare_runs.py --baseline <b> --candidate <c> --seed 42 --n-bootstrap 10000 --format markdown
+```
+
+**References (progressive disclosure):** Link to `docs/01_core/EXPERIMENTS.md`,
+`docs/01_core/REPRODUCIBILITY.md`, `docs/01_core/METRICS.md`
+
+---
+
+#### 1.2 `analyzing-results` (Data Fetching & Analysis)
+
+**File:** `.claude/skills/analyzing-results/SKILL.md`
+
+**Trigger description:** "Guides statistical analysis of experiment results: reading
+comparator output, interpreting metrics, checking significance, and producing
+committed evidence artifacts. Use when analyzing experiment runs or preparing
+statistical claims for reports."
+
+**Content outline:**
+- Phase 1: Load Results (read run metadata, identify comparator output files)
+- Phase 2: Statistical Checklist (ANOVA/t-tests, CIs, effect sizes, sample size validation)
+- Phase 3: Interpretation (net_eppd, CVaR, bid_rate, H2H win rate thresholds)
+- Phase 4: Artifact Commitment (notebook → committed JSON, traceability requirements)
+
+**Gotchas section:**
+- Visual-only validation is a blocker per `05_rigor.md` — always pair with statistical test
+- N < 2,000 insufficient for bias detection; N < 50,000 insufficient for production claims
+- Notebook outputs are gitignored — trace claims to committed JSON artifacts
+- Effect sizes (Cohen's d, R²) required alongside p-values
+- Multiple comparison corrections needed when testing >3 hypotheses
+
+**Key metrics reference table:**
+| Metric | Script | Minimum N | What it measures |
+|--------|--------|-----------|-----------------|
+| net_eppd | compare_runs.py | 2,000 | Expected points per deal delta |
+| CVaR | compare_runs.py | 5,000 | Tail risk (worst-case performance) |
+| H2H win rate | run_arc_d_h2h_battery.py | 2,000 | Head-to-head match win percentage |
+| R² | compare_runs.py | 1,000 | Variance explained by model |
+
+**References:** Link to `docs/01_core/METRICS.md`, `.claude/rules/deferred/05_rigor.md`,
+`.claude/rules/deferred/45_notebook_boundary.md`
+
+---
+
+#### 1.3 `debugging-ci` (Runbooks)
+
+**File:** `.claude/skills/debugging-ci/SKILL.md`
+
+**Trigger description:** "Symptom-driven runbook for CI failures, review loop issues,
+and make check errors. Use when CI is red, review status is stuck, or validation
+commands fail."
+
+**Content outline — symptom → diagnosis → fix table:**
+
+| Symptom | Diagnosis | Fix |
+|---------|-----------|-----|
+| `make check` fails on ruff | Read error output | `ruff check --fix && ruff format` on cited files |
+| `make check` fails on pytest | Identify failing test | Run targeted: `uv run pytest tests/unit/test_X.py -k "test_name"` |
+| `make check` fails on notebook-check | Notebook outputs not cleared | `make notebook-sync` then verify |
+| `make check` fails on docs-check | Docs freshness stale | `uv run python scripts/check_docs_freshness.py` to identify |
+| `make check` fails on repo-lint | Import boundary violation | Check `src/` not importing from `experiments/` or `tests/` |
+| CI red on GitHub after push | Check which job failed | `gh pr checks <PR>` then read failure log |
+| Review status stuck `pending` | Loop crashed or never started | Check `.claude/runtime/review_loops/pr_<N>/state.json` |
+| Review status stuck `pending` (>1hr) | Fallback workflow should fire | Manual: `scripts/internal/set_review_status.sh success "Manual override"` |
+| Review loop in `failure` | Blocking precheck found | Read state.json for blocker details, fix in PR |
+| `git push` rejected | Branch behind main | `git fetch origin main && git rebase origin/main` |
+| Worktree hook blocks edits | Working on main checkout | Create worktree: `git worktree add ../Bid-Euchre-<name> -b <branch>` |
+
+**Escalation protocol:**
+1. Try the automated fix from the table
+2. If still failing, read full error output and apply targeted fix
+3. If infrastructure issue (not code), check `scripts/internal/` for relevant tooling
+4. If stuck, manual status override + open GitHub issue
+
+**References:** Link to `.claude/rules/deferred/60_review_gate.md`,
+`scripts/internal/review_driver.py`, `scripts/internal/set_review_status.sh`
+
+---
+
+### Phase 2: Medium-Priority Skills (2 skills)
+
+#### 2.1 `managing-worktrees` (Infrastructure Operations)
+
+**File:** `.claude/skills/managing-worktrees/SKILL.md`
+
+**Trigger description:** "Manages git worktrees: creation, cleanup, and protection rules.
+Use when creating new worktrees, cleaning up after merges, or checking worktree status."
+
+**Content outline:**
+- Create: `git worktree add ../Bid-Euchre-<name> -b <branch>`
+- List: `git worktree list`
+- Status check: Working tree clean? `git -C <path> status --short`
+- Safe cleanup protocol (3-step: check protected list → verify PR merged → verify clean)
+
+**Protected worktrees (hardcoded list):**
+```
+Bid-Euchre-steward-author
+Bid-Euchre-steward-author-b
+Bid-Euchre-steward-author-c
+Bid-Euchre-steward-author-d
+Bid-Euchre-steward-author-scratch
+Bid-Euchre-steward-review
+Bid-Euchre-steward-ops
+```
+
+**Gotchas section:**
+- NEVER run `git worktree prune` — it removes stale entries indiscriminately
+- NEVER remove any worktree matching `*steward*`
+- Always save diffs before removing dirty worktrees: `git -C <path> diff > /tmp/<name>.diff`
+- The UserPromptSubmit hook auto-creates worktrees when blocked — don't fight it
+- Worktree names should match branch names for discoverability
+
+**References:** Link to `.claude/rules/75_worktree_protection.md`
+
+---
+
+#### 2.2 `validating-changes` (CI/CD)
+
+**File:** `.claude/skills/validating-changes/SKILL.md`
+
+**Trigger description:** "Guides the two-tier testing workflow: targeted tests during
+development (Tier 1) and full validation before PRs (Tier 2). Use when deciding
+which tests to run or when make check fails."
+
+**Content outline:**
+- Tier 1 decision tree:
+  - Changed `src/bid_euchre/foo/bar.py` → run `tests/unit/test_bar.py`
+  - Changed `__init__.py` exports → widen to Tier 2 immediately
+  - Changed test fixtures or conftest → widen to Tier 2 immediately
+  - Changed function signatures used across modules → widen to Tier 2
+  - Unsure what depends on change → `grep -rl "from bid_euchre.foo" tests/`
+- Tier 2: `make check-quiet` (preferred) or `make check` (for debugging)
+- After review fixes: small (1-2 files) → Tier 1; broad (3+) → Tier 2
+
+**Gotchas section:**
+- Don't run `make check` repeatedly during active development — it's slow
+- `make check-quiet` logs to tmpfile — read the log on failure
+- `make notebook-check` verifies sync + outputs cleared but does NOT execute notebooks
+- `make notebook-run` (SMOKE) and `make notebook-run-full` (QUICK) execute but are NOT in `make check`
+- `make repo-lint` catches import boundary violations — `src/` must NOT import from `experiments/` or `tests/`
+
+**References:** Link to `.claude/rules/15_testing_tiers.md`,
+`.claude/rules/10_workflow.md`
+
+---
+
+### Phase 3: Lower-Priority Skills (2 skills)
+
+#### 3.1 `adding-strategies` (Code Scaffolding)
+
+**File:** `.claude/skills/adding-strategies/SKILL.md`
+
+**Trigger description:** "Scaffolds a new bot strategy: implementation, export, registration,
+tests, config, and smoke validation. Use when adding a new bidding or playing strategy."
+
+**Content outline — checklist:**
+1. Implement in `src/bid_euchre/strategy/<name>.py`
+   - Class must accept `seed` parameter
+   - Use `random.Random(seed)` for all randomness — never global `random.*`
+2. Export in `src/bid_euchre/strategy/__init__.py`
+3. Register in `src/bid_euchre/experiments/config.py` → `StrategyConfig.create_strategy()`
+4. Add unit tests in `tests/unit/test_<name>.py`
+5. Add/update YAML config in `experiments/configs/`
+6. Run seeded smoke: `uv run python experiments/run_experiment.py --seed 42 --config <cfg> --n_per 10`
+
+**Gotchas section:**
+- Strategies MUST use local `random.Random(seed)`, never global `random.*` — C1 blocker
+- The `create_strategy()` registry in `config.py` is the canonical mapping
+- Strategy class names should match the YAML config `strategy_type` field
+- Test both bidding and playing decisions, not just construction
+
+**References:** Link to `docs/01_core/ARCHITECTURE.md`,
+`src/bid_euchre/strategy/__init__.py`, `src/bid_euchre/experiments/config.py`
+
+---
+
+#### 3.2 `triaging-issues` (Business Process)
+
+**File:** `.claude/skills/triaging-issues/SKILL.md`
+
+**Trigger description:** "Triages GitHub issues and review findings into labeled,
+prioritized follow-up work. Use when creating follow-up issues from review findings
+or organizing outstanding work."
+
+**Content outline:**
+- Label taxonomy (from `60_review_gate.md`):
+  | Label | Color | Applied to |
+  |-------|-------|------------|
+  | `follow-up` | `#fbca04` | All follow-up issues |
+  | `fix:bug` | `#d73a4a` | C1, C2 findings |
+  | `fix:convention` | `#0075ca` | Auto-fix patterns, C4 |
+  | `fix:test` | `#e4e669` | T1 findings |
+  | `fix:docs` | `#0e8a16` | X2 findings |
+  | `fix:process` | `#c5def5` | X1, X3, N1/N2/N3 |
+- Priority mapping: BLOCK findings → immediate fix PR; WARN → follow-up issue
+- Deduplication: Search existing issues before creating (`gh issue list --label follow-up`)
+- Batching convention: Group related findings into batch PRs (e.g., "fix: convention follow-up batch N")
+
+**Gotchas section:**
+- Always check for existing issues before creating duplicates
+- Link follow-up issues to the originating PR
+- Batch related fixes — don't create one PR per finding
+- `fix:bug` label items (C1, C2) should be prioritized over `fix:convention`
+
+**References:** Link to `.claude/rules/deferred/60_review_gate.md`
+
+---
+
+### Phase 4: Skill Retirements (3 skills)
+
+#### 4.1 Retire `reviewing-plans`
+
+**Reason:** Already marked `DEPRECATED` in its own frontmatter. Replaced by `/review-plan`
+which provides independent review via Codex CLI + Claude failsafe. The deprecated skill
+is retained only for backward compatibility and is "no longer auto-triggered."
+
+**Action:** Delete `.claude/skills/reviewing-plans/SKILL.md` and its directory.
+
+**Live reference cleanup required:**
+- `docs/02_agent/PLAN_REVIEW_RUBRIC.md` (lines 5, 13): Update `/reviewing-plans` → `/review-plan`
+- `.claude/hooks/README.md` (line 87): History note — update to past tense mentioning replacement
+- `plans/arc_d_v2/lineage_plan.md` (line 770): Frozen/COMPLETE plan — no update needed
+- Archive plans (`plans/archive/`): Historical records — no update needed
+
+---
+
+#### 4.2 Retire `drafting-rung-reports`
+
+**Reason:** Tightly coupled to Arc D v2 lineage workflow (R0-R3 promotion reports,
+comparator rankings, H2H battery analysis, measurement integrity reviews). Arc D v2
+is **COMPLETE** as of 2026-03-19. The skill references `data/artifacts/arc_d/r{N}/`
+artifact paths, R{N-1} cross-rung comparison patterns, and promotion decision JSON
+schemas that are specific to that initiative.
+
+**Action:** Delete `.claude/skills/drafting-rung-reports/SKILL.md` and its directory.
+If a new lineage initiative starts (e.g., browser game evaluation), a fresh skill
+should be created from scratch rather than resurrecting this one.
+
+---
+
+#### 4.3 Retire `narrating-reports`
+
+**Reason:** Same as `drafting-rung-reports` — this skill is exclusively about adding
+narrative overlays to Arc D v2 rung reports. It references `promotion_decision_r{N}.json`,
+`rung_bundle_r{N}.json`, `REPORT_NARRATIVE_CONVENTIONS.md`, and section-by-section
+commentary patterns (S2-S9) that are specific to the completed lineage.
+
+**Action:** Delete `.claude/skills/narrating-reports/SKILL.md` and its directory.
+
+---
+
+### Phase 5: Skill Updates (3 skills)
+
+#### 5.1 Update `fixing-bugs`
+
+**Issue:** References `TodoWrite` (line 22: "Track progress with TodoWrite"). `TodoWrite`
+was renamed to the TUI task system (`TaskCreate`/`TaskUpdate`/`TaskList`).
+
+**Action:** Replace `TodoWrite` reference with `TaskCreate`/`TaskUpdate`.
+
+---
+
+#### 5.2 Update `executing-plans`
+
+**Issue:** References `TodoWrite` in two places (line 38: "Track progress with TodoWrite",
+line 75: "Mark unit as blocked in TodoWrite"). Same migration needed.
+
+**Action:** Replace both `TodoWrite` references with `TaskCreate`/`TaskUpdate`.
+
+---
+
+#### 5.3 Update `summarizing-sessions`
+
+**Issue:** References "Task tool (`subagent_type: general-purpose`)" (line 69) for spawning
+a reviewer agent. The tool is actually `Agent` (not "Task tool"), and the `subagent_type`
+parameter syntax is correct but the tool name is wrong.
+
+**Action:** Change "Task tool" → "Agent tool" in the reviewer agent spawn section.
+
+---
+
+#### 5.4 Update `reviewing-repo`
+
+**Issue:** References "Task tool (`subagent_type: general-purpose`)" (line 22) for spawning
+sub-agents. Same stale tool-name issue as `summarizing-sessions`.
+
+**Action:** Change "Task tool" → "Agent tool".
+
+---
+
+### Phase 6: Meta-Improvements (3 changes)
+
+#### 6.1 Add Gotchas Sections to Existing Skills
+
+**Target skills** (those lacking gotchas that would benefit):
+- `reviewing-changes/SKILL.md` — Add gotchas about common dispatcher mistakes
+- `executing-plans/SKILL.md` — Add gotchas about agent context window limits
+- `shipping-changes/SKILL.md` — Add gotchas about worktree cleanup edge cases
+- `planning-code-first/SKILL.md` — Add gotchas about stale line number references
+- `recovering-context/SKILL.md` — Add gotchas about MEMORY.md truncation
+
+Each gotchas section: 3-5 bullets of common failure modes specific to that skill,
+drawn from actual project experience (e.g., the agent reliability rule, the MEMORY.md
+200-line limit, the worktree protection list).
+
+#### 6.2 Folder-as-Skill Enhancement
+
+Where appropriate, add supporting files to skill folders:
+
+| Skill | New File | Purpose |
+|-------|----------|---------|
+| `running-experiments` | `QUICK_REFERENCE.md` | Command cheat-sheet for copy-paste |
+| `debugging-ci` | `SYMPTOM_TABLE.md` | Separable symptom→fix lookup table |
+| `analyzing-results` | `CHECKLIST.md` | Statistical rigor checklist (from `05_rigor.md` gold standard) |
+
+These are progressive-disclosure files — the SKILL.md references them but they're
+only loaded on demand, keeping the main skill focused.
+
+#### 6.3 Skill Usage Measurement (Deferred — Needs Hook Design)
+
+Thariq recommends PreToolUse hooks for skill invocation logging. This requires:
+- A hook on the `Skill` tool matcher
+- A log file at `.claude/runtime/skill_usage.jsonl`
+- Fields: timestamp, skill_name, session_id
+
+**Recommendation:** Defer to a separate PR. Hook changes affect all sessions and
+deserve their own review cycle. Document the design here for future implementation.
+
+---
+
+## Files
+
+### New Files (10)
+- `.claude/skills/running-experiments/SKILL.md` — Experiment execution guide
+- `.claude/skills/running-experiments/QUICK_REFERENCE.md` — Command cheat-sheet
+- `.claude/skills/analyzing-results/SKILL.md` — Statistical analysis guide
+- `.claude/skills/analyzing-results/CHECKLIST.md` — Rigor checklist
+- `.claude/skills/debugging-ci/SKILL.md` — Symptom-driven CI runbook
+- `.claude/skills/debugging-ci/SYMPTOM_TABLE.md` — Separable lookup table
+- `.claude/skills/managing-worktrees/SKILL.md` — Worktree operations guide
+- `.claude/skills/validating-changes/SKILL.md` — Two-tier testing guide
+- `.claude/skills/adding-strategies/SKILL.md` — Strategy scaffolding checklist
+- `.claude/skills/triaging-issues/SKILL.md` — Issue triage and labeling guide
+
+### Deleted Files (3)
+- `.claude/skills/reviewing-plans/SKILL.md` — Deprecated, replaced by `/review-plan`
+- `.claude/skills/drafting-rung-reports/SKILL.md` — Arc D v2 specific, lineage COMPLETE
+- `.claude/skills/narrating-reports/SKILL.md` — Arc D v2 specific, lineage COMPLETE
+
+### Modified Files (10)
+- `.claude/skills/reviewing-changes/SKILL.md` — Add Gotchas section
+- `.claude/skills/executing-plans/SKILL.md` — Add Gotchas section + fix TodoWrite → Tasks
+- `.claude/skills/shipping-changes/SKILL.md` — Add Gotchas section
+- `.claude/skills/planning-code-first/SKILL.md` — Add Gotchas section
+- `.claude/skills/recovering-context/SKILL.md` — Add Gotchas section
+- `.claude/skills/fixing-bugs/SKILL.md` — Fix TodoWrite → Tasks
+- `.claude/skills/summarizing-sessions/SKILL.md` — Fix "Task tool" → "Agent tool"
+- `.claude/skills/reviewing-repo/SKILL.md` — Fix "Task tool" → "Agent tool"
+- `docs/02_agent/PLAN_REVIEW_RUBRIC.md` — Update `/reviewing-plans` → `/review-plan`
+- `.claude/hooks/README.md` — Update history note for `/reviewing-plans` retirement
+
+### Deferred (not in this PR)
+- `.claude/settings.json` — Skill usage hook (Phase 6.3)
+
+## Validation
+
+Since this is a docs/skills-only PR:
+- `make check` will pass (no Python changes)
+- CI `dorny/paths-filter` will skip heavy steps
+- Manual validation: verify each skill triggers correctly via description matching
+
+## Acceptance Criteria
+
+- [ ] All 7 new skill directories created with SKILL.md
+- [ ] 3 supporting files (QUICK_REFERENCE, SYMPTOM_TABLE, CHECKLIST) created
+- [ ] 3 stale skills retired (reviewing-plans, drafting-rung-reports, narrating-reports)
+- [ ] 4 existing skills updated (TodoWrite → Tasks + "Task tool" → "Agent tool")
+- [ ] Live references to `/reviewing-plans` updated in docs and hooks README
+- [ ] 5 existing skills updated with Gotchas sections
+- [ ] Each skill has correct frontmatter (name, description)
+- [ ] Description fields are trigger-oriented (not summaries)
+- [ ] Each skill references authoritative docs via progressive disclosure
+- [ ] No Python source code changes
+- [ ] `make check` passes
+
+## Risks and Mitigations
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Skills too verbose → context bloat | Medium | Keep SKILL.md focused; use supporting files for details |
+| Description triggers too broad → false invocations | Low | Test descriptions against common queries |
+| Gotchas become stale as project evolves | Medium | Gotchas reference rules/docs, not hardcoded values |
+| Single PR too large for review | Low | All files are independent markdown — reviewable in parallel |
+
+## Outcome
+<!-- Filled after implementation -->
+- PR: pending
+- Notes: —


### PR DESCRIPTION
## Summary
- Archive 13 session plan files that were accumulating as untracked on main
- 7 files from 2026-03-18 (chart refactor, commit dashboard, post-merge review, PR #909 review/coverage, reporting closeout)
- 6 files from 2026-03-19 (ops hardening, reporting residuals, skills expansion)

## Why
Session plans document context and decisions for completed work. These were sitting untracked and at risk of being lost during cleanup.

## Repro / Validation
Docs-only — no code changes. `git diff --stat main` shows 13 new markdown files under `plans/sessions/`.

## Tests
N/A — plans only, CI will skip heavy steps via `dorny/paths-filter`.

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-ops
branch: chore/archive-session-plans-mar18-19
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)