### PR TITLE
fix: handle malformed timestamps in session selection

### DIFF
--- a/src/bid_euchre/ops/status.py
+++ b/src/bid_euchre/ops/status.py
@@ -322,14 +322,24 @@ def _is_newer_session(
     """Return True if *candidate* session started after *existing*.
 
     Uses parsed datetime comparison to handle mixed ISO 8601 formats
-    (``Z``, ``+00:00``, naive). Falls back to lexicographic comparison
-    only if both timestamps are unparseable.
+    (``Z``, ``+00:00``, naive). Handles all four cases:
+
+    - Both parseable → compare datetimes.
+    - Candidate parseable, existing malformed → candidate wins.
+    - Candidate malformed, existing parseable → existing wins.
+    - Both unparseable → lexicographic fallback.
     """
     c_ts = _parse_iso_timestamp(candidate.get("started_at"))
     e_ts = _parse_iso_timestamp(existing.get("started_at"))
     if c_ts is not None and e_ts is not None:
         return c_ts > e_ts
-    # Fallback: lexicographic (both unparseable or one missing)
+    if c_ts is not None:
+        # Candidate is valid, existing is malformed → candidate wins
+        return True
+    if e_ts is not None:
+        # Existing is valid, candidate is malformed → existing wins
+        return False
+    # Both unparseable → lexicographic fallback
     return candidate.get("started_at", "") > existing.get("started_at", "")
 
 

--- a/tests/unit/test_ops_status.py
+++ b/tests/unit/test_ops_status.py
@@ -934,6 +934,108 @@ class TestSessionSelectionTimezone:
         # Must pick "New task" (15:00) not "Old task" (14:00)
         assert lane.session_task == "New task"
 
+    def test_session_selection_malformed_vs_valid(self, runtime_dir: Path) -> None:
+        """Valid session wins over malformed session timestamp.
+
+        Regression test for Codex P2 finding on PR #998:
+        _is_newer_session() fell through to lexicographic comparison
+        when one timestamp was malformed, causing a bogus timestamp
+        to win over a valid one.
+        """
+        # Session with malformed timestamp
+        _write_json(
+            runtime_dir / "session_metadata",
+            "session-bad.json",
+            {
+                "schema_version": 2,
+                "session_id": "bad",
+                "lane_id": "author-a",
+                "started_at": "bogus-not-a-timestamp",
+                "task": "Bad session",
+            },
+        )
+        # Session with valid timestamp
+        _write_json(
+            runtime_dir / "session_metadata",
+            "session-good.json",
+            {
+                "schema_version": 2,
+                "session_id": "good",
+                "lane_id": "author-a",
+                "started_at": "2026-03-19T15:00:00+00:00",
+                "task": "Good session",
+            },
+        )
+        _write_json(
+            runtime_dir / "worktree_registry",
+            "author-a.json",
+            {
+                "schema_version": 2,
+                "lane_id": "author-a",
+                "lane_class": "author",
+                "worktree_path": "/tmp/wt-a",
+                "branch": "codex/steward-author",
+                "class": "persistent",
+                "session_id": "good",
+                "last_active": "2026-03-19T15:00:00+00:00",
+            },
+        )
+
+        report = aggregate_status(runtime_dir)
+        lane = report.lanes[0]
+        # Valid timestamp must always win over malformed
+        assert lane.session_task == "Good session"
+
+    def test_session_selection_valid_vs_malformed(self, runtime_dir: Path) -> None:
+        """Valid session wins regardless of file sort order.
+
+        Files are sorted alphabetically, so this test ensures the valid
+        session wins even when the malformed session file sorts later.
+        """
+        # Valid session (sorts first alphabetically)
+        _write_json(
+            runtime_dir / "session_metadata",
+            "a-session-valid.json",
+            {
+                "schema_version": 2,
+                "session_id": "valid",
+                "lane_id": "ops",
+                "started_at": "2026-03-19T10:00:00Z",
+                "task": "Valid session",
+            },
+        )
+        # Malformed session (sorts second alphabetically)
+        _write_json(
+            runtime_dir / "session_metadata",
+            "z-session-malformed.json",
+            {
+                "schema_version": 2,
+                "session_id": "malformed",
+                "lane_id": "ops",
+                "started_at": "zzz-definitely-not-a-date",
+                "task": "Malformed session",
+            },
+        )
+        _write_json(
+            runtime_dir / "worktree_registry",
+            "ops.json",
+            {
+                "schema_version": 2,
+                "lane_id": "ops",
+                "lane_class": "ops",
+                "worktree_path": "/tmp/wt-ops",
+                "branch": "codex/steward-ops",
+                "class": "persistent",
+                "session_id": "valid",
+                "last_active": "2026-03-19T10:00:00Z",
+            },
+        )
+
+        report = aggregate_status(runtime_dir)
+        lane = report.lanes[0]
+        # Valid timestamp must always beat malformed
+        assert lane.session_task == "Valid session"
+
 
 class TestAggregateStatusLaneActivity:
     """Integration tests for lane-activity via aggregate_status()."""


### PR DESCRIPTION
## Summary
- Fixes `_is_newer_session()` to handle valid-vs-malformed timestamp edge case
- Adds 2 regression tests for malformed session timestamp selection

## Why
Codex review P2 finding on PR #998: `_is_newer_session()` fell through to lexicographic comparison when one timestamp was malformed and the other was valid. A corrupted session file with `"started_at": "bogus"` could win over a valid session with `"started_at": "2026-03-19T15:00:00+00:00"` because `"b" > "2"` lexicographically.

## Changes

### `src/bid_euchre/ops/status.py`
- Updated `_is_newer_session()` to handle all four cases explicitly:
  - Both parseable → compare datetimes
  - Candidate parseable, existing malformed → candidate wins
  - Candidate malformed, existing parseable → existing wins
  - Both unparseable → lexicographic fallback

### `tests/unit/test_ops_status.py`
- Added `test_session_selection_malformed_vs_valid` — malformed session file sorted before valid
- Added `test_session_selection_valid_vs_malformed` — malformed session file sorted after valid (tests both file-order directions)

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_ops_status.py -v -k "session_selection or malformed"
make check-quiet
```

## Validation Performed

### Automated tests
- 67 tests in `test_ops_status.py` — all pass (2 new)
- `make check-quiet` — all checks pass

### Failure injection
- `"bogus-not-a-timestamp"` as `started_at` — valid session wins ✅
- `"zzz-definitely-not-a-date"` as `started_at` (sorts after valid lexicographically) — valid session still wins ✅

### Rollback path
Single-commit revert. Restores the previous fallback behavior.

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
branch: codex/steward-author-c
```

## Tests
```bash
uv run python -m pytest tests/unit/test_ops_status.py tests/unit/test_ops_cli.py -v  # all pass
make check-quiet  # All checks passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)