### PR TITLE
fix: harden memory.py — corrupt file backup and flock locking

### DIFF
--- a/plans/sessions/2026-03-20_batch1-memory-safety.md
+++ b/plans/sessions/2026-03-20_batch1-memory-safety.md
@@ -1,0 +1,121 @@
+# Batch 1 — memory.py Data Safety
+
+**Date:** 2026-03-20
+**Goal:** Close remaining data safety gaps in `memory.py` (#950 residual, #1002). #951 is already fully fixed.
+
+## Current State
+
+| Issue | Status | Evidence |
+|-------|--------|----------|
+| #950 | **Partially fixed** | `MemoryStore.from_dict()` skips bad entries (line 106-116, test at line 88). BUT `load_memory()` still returns empty store on `json.JSONDecodeError` (line 162), and the next `save_memory()` would persist that empty store, permanently losing data. |
+| #951 | **Fully fixed** | `save_memory()` uses tempfile+fsync+replace (line 179-194). 3 tests cover it (lines 143-235). |
+| #1002 | **Not fixed** | No `flock()` anywhere in memory.py. `add_entry()` and `remove_entry()` do load→modify→save without locking. |
+
+## Plan
+
+### Fix 1: Backup corrupt file before returning empty (#950 residual)
+
+**File:** `src/bid_euchre/ops/memory.py`, `load_memory()` (line 159-164)
+
+**Change:** When `json.JSONDecodeError` is caught, rename the corrupt file to
+`memory.json.corrupt.<ISO-timestamp>` before returning an empty store. This
+preserves the corrupt data for manual recovery and prevents the next write
+from silently overwriting it.
+
+```python
+# Before (current):
+except (json.JSONDecodeError, KeyError, TypeError) as e:
+    logger.warning("Failed to load curated memory: %s", e)
+    return MemoryStore()
+
+# After:
+except json.JSONDecodeError as e:
+    # Preserve corrupt file for recovery before returning empty store
+    backup = memory_path.with_suffix(
+        f".corrupt.{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
+    )
+    try:
+        memory_path.rename(backup)
+        logger.warning(
+            "Corrupt memory file backed up to %s: %s", backup.name, e
+        )
+    except OSError as rename_err:
+        logger.warning(
+            "Failed to backup corrupt memory (%s): %s", rename_err, e
+        )
+    return MemoryStore()
+except (KeyError, TypeError) as e:
+    logger.warning("Failed to load curated memory: %s", e)
+    return MemoryStore()
+```
+
+### Fix 2: Add flock around read-modify-write cycle (#1002)
+
+**File:** `src/bid_euchre/ops/memory.py`
+
+**Design:** Add a `_locked_update()` context manager that:
+1. Opens/creates a `.lock` file in memory_dir
+2. Acquires `fcntl.flock(LOCK_EX)` on it
+3. Yields the loaded `MemoryStore`
+4. On context exit, saves the store and releases the lock
+
+**Why a separate lock file?** The main `memory.json` file is replaced
+atomically via `os.replace()` — can't hold a flock on a file that gets
+replaced. A dedicated `.lock` file persists across writes.
+
+**Functions to update:**
+- `add_entry()` — use `_locked_update()` instead of load→modify→save
+- `remove_entry()` — use `_locked_update()` instead of load→modify→save
+
+**Read-only functions (no lock needed):**
+- `load_memory()` — reads are safe with atomic writes (either old or new content)
+- `get_entry()`, `list_entries()`, `search_entries()` — all call `load_memory()`
+
+```python
+import fcntl
+from contextlib import contextmanager
+from typing import Generator
+
+LOCK_FILE = ".memory.lock"
+
+@contextmanager
+def _locked_update(memory_dir: Path) -> Generator[MemoryStore, None, None]:
+    """Context manager for exclusive read-modify-write on the memory store."""
+    memory_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = memory_dir / LOCK_FILE
+    with open(lock_path, "w") as lock_fh:
+        fcntl.flock(lock_fh, fcntl.LOCK_EX)
+        try:
+            store = load_memory(memory_dir)
+            yield store
+            save_memory(store, memory_dir)
+        finally:
+            fcntl.flock(lock_fh, fcntl.LOCK_UN)
+```
+
+### Tests to Add
+
+1. **test_load_backs_up_corrupt_file** — Write invalid JSON, call `load_memory()`,
+   verify `.corrupt.*` file exists and contains the original bytes.
+2. **test_load_corrupt_backup_failure** — Corrupt file + readonly dir,
+   verify warning logged but no crash.
+3. **test_locked_update_basic** — Verify `_locked_update()` loads, modifies, saves.
+4. **test_locked_update_creates_lock_file** — Verify `.memory.lock` file is created.
+5. **test_concurrent_add_entry** — Use threading to verify two concurrent `add_entry()`
+   calls don't lose writes.
+
+## Files Changed
+
+- `src/bid_euchre/ops/memory.py` — 2 fixes, ~40 lines added
+- `tests/unit/test_ops_memory.py` — 5 new tests, ~80 lines
+
+## Scope Boundary
+
+- Only `memory.py` and its tests
+- Compaction bugs (#954, #959) are Batch 3 — not touched here
+- Events flock race (#938) is Batch 3 — not touched here
+
+## Outcome
+<!-- Filled after implementation -->
+- PR: pending
+- Notes: pending

--- a/src/bid_euchre/ops/memory.py
+++ b/src/bid_euchre/ops/memory.py
@@ -18,19 +18,22 @@ Storage: ``.claude/runtime/curated_memory/memory.json`` (gitignored)
 
 from __future__ import annotations
 
+import fcntl
 import json
 import logging
 import os
 import tempfile
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Generator
 
 logger = logging.getLogger("ops.memory")
 
 DEFAULT_MEMORY_DIR = Path(".claude/runtime/curated_memory")
 MEMORY_FILE = "memory.json"
+LOCK_FILE = ".memory.lock"
 
 # Categories for organizing memory entries
 VALID_CATEGORIES = frozenset(
@@ -159,7 +162,25 @@ def load_memory(memory_dir: Path) -> MemoryStore:
     try:
         data = json.loads(memory_path.read_text())
         return MemoryStore.from_dict(data)
-    except (json.JSONDecodeError, KeyError, TypeError) as e:
+    except json.JSONDecodeError as e:
+        # Preserve corrupt file for manual recovery before returning empty
+        # store.  Without this, the next save_memory() would silently
+        # overwrite the corrupt data, permanently destroying all entries.
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S_%fZ")
+        backup = memory_path.with_suffix(f".corrupt.{ts}")
+        try:
+            memory_path.rename(backup)
+            logger.warning("Corrupt memory file backed up to %s: %s", backup.name, e)
+        except OSError as rename_err:
+            logger.warning(
+                "Failed to backup corrupt memory file (%s): %s",
+                rename_err,
+                e,
+            )
+        return MemoryStore()
+    except (KeyError, TypeError) as e:
+        # Structural issues (valid JSON but unexpected shape).  No backup
+        # needed — the file can be manually inspected as-is.
         logger.warning("Failed to load curated memory: %s", e)
         return MemoryStore()
 
@@ -170,6 +191,13 @@ def save_memory(store: MemoryStore, memory_dir: Path) -> None:
     Writes to a same-directory tempfile, fsyncs, then atomically replaces
     the target via ``os.replace()`` so a crash mid-write cannot leave a
     truncated file (see #951).
+
+    .. note::
+
+        This function does **not** acquire a file lock.  Callers that perform
+        a read-modify-write cycle (load → mutate → save) must serialize via
+        :func:`_locked_update` or their own ``flock()`` on the same
+        :data:`LOCK_FILE` to prevent lost updates (#1002).
     """
     memory_dir.mkdir(parents=True, exist_ok=True)
     memory_path = _get_memory_path(memory_dir)
@@ -192,6 +220,35 @@ def save_memory(store: MemoryStore, memory_dir: Path) -> None:
         except OSError:
             pass
         raise
+
+
+@contextmanager
+def _locked_update(memory_dir: Path) -> Generator[MemoryStore, None, None]:
+    """Acquire an exclusive lock, yield a loaded :class:`MemoryStore`, and
+    save it back on clean exit.
+
+    This serializes concurrent read-modify-write cycles (e.g. two
+    ``add_entry()`` calls from different processes) so that neither
+    update is lost (#1002).
+
+    A dedicated lock file (rather than the data file) is used because
+    ``save_memory()`` atomically *replaces* the data file via
+    ``os.replace()``, which would invalidate an ``flock`` held on the
+    original inode.
+
+    Raises whatever ``save_memory`` raises on write failure; the lock is
+    always released.
+    """
+    memory_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = memory_dir / LOCK_FILE
+    with open(lock_path, "a") as lock_fh:
+        fcntl.flock(lock_fh, fcntl.LOCK_EX)
+        try:
+            store = load_memory(memory_dir)
+            yield store
+            save_memory(store, memory_dir)
+        finally:
+            fcntl.flock(lock_fh, fcntl.LOCK_UN)
 
 
 # ── Validation ───────────────────────────────────────────────────
@@ -313,24 +370,23 @@ def add_entry(
         tags=tags or [],
     )
 
-    # Validate
+    # Validate *before* acquiring the lock so we don't hold it during
+    # potentially slow I/O (source file existence check).
     result = validate_provenance(entry, check_source_exists=check_source_exists)
     if not result.valid:
         raise ValueError(f"Invalid memory entry: {'; '.join(result.errors)}")
 
-    # Load existing store
-    store = load_memory(memory_dir)
-
-    # Check for existing entry with same key+category
-    existing = [e for e in store.entries if e.key == key and e.category == category]
-    if existing:
-        entry.supersedes = existing[0].entry_id
-        store.entries = [
-            e for e in store.entries if not (e.key == key and e.category == category)
-        ]
-
-    store.entries.append(entry)
-    save_memory(store, memory_dir)
+    # Locked read-modify-write to prevent lost updates (#1002).
+    with _locked_update(memory_dir) as store:
+        existing = [e for e in store.entries if e.key == key and e.category == category]
+        if existing:
+            entry.supersedes = existing[0].entry_id
+            store.entries = [
+                e
+                for e in store.entries
+                if not (e.key == key and e.category == category)
+            ]
+        store.entries.append(entry)
 
     return entry
 
@@ -340,14 +396,12 @@ def remove_entry(memory_dir: Path, entry_id: str) -> bool:
 
     Returns True if the entry was found and removed.
     """
-    store = load_memory(memory_dir)
-    original_len = len(store.entries)
-    store.entries = [e for e in store.entries if e.entry_id != entry_id]
+    with _locked_update(memory_dir) as store:
+        original_len = len(store.entries)
+        store.entries = [e for e in store.entries if e.entry_id != entry_id]
+        removed = len(store.entries) < original_len
 
-    if len(store.entries) < original_len:
-        save_memory(store, memory_dir)
-        return True
-    return False
+    return removed
 
 
 def get_entry(memory_dir: Path, entry_id: str) -> MemoryEntry | None:

--- a/tests/unit/test_ops_memory.py
+++ b/tests/unit/test_ops_memory.py
@@ -8,9 +8,11 @@ from pathlib import Path
 import pytest
 
 from bid_euchre.ops.memory import (
+    LOCK_FILE,
     VALID_CATEGORIES,
     MemoryEntry,
     MemoryStore,
+    _locked_update,
     add_entry,
     format_memory_json,
     format_memory_text,
@@ -614,3 +616,187 @@ class TestFormatting:
         text = format_memory_text(entries)
         assert "[repo_fact]" in text
         assert "[preference]" in text
+
+
+class TestCorruptFileBackup:
+    """Tests for corrupt file backup on JSONDecodeError (#950 residual)."""
+
+    def test_load_backs_up_corrupt_file(self, memory_dir: Path) -> None:
+        """Corrupt JSON is renamed to .corrupt.* and empty store returned."""
+        corrupt_content = "not valid json {{{"
+        (memory_dir / "memory.json").write_text(corrupt_content)
+
+        store = load_memory(memory_dir)
+
+        # Returns empty store
+        assert store.entries == []
+
+        # Original file removed
+        assert not (memory_dir / "memory.json").exists()
+
+        # Backup file exists with original content
+        backups = list(memory_dir.glob("memory.corrupt.*"))
+        assert len(backups) == 1
+        assert backups[0].read_text() == corrupt_content
+
+    def test_load_corrupt_backup_logs_warning(
+        self, memory_dir: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Corrupt file backup logs a warning with the backup filename."""
+        (memory_dir / "memory.json").write_text("{invalid")
+
+        with caplog.at_level(logging.WARNING, logger="ops.memory"):
+            load_memory(memory_dir)
+
+        assert any("backed up to" in r.message.lower() for r in caplog.records)
+
+    def test_load_corrupt_backup_failure_still_returns_empty(
+        self, memory_dir: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """If backup rename fails, still return empty store (don't crash)."""
+        (memory_dir / "memory.json").write_text("corrupt!")
+
+        # Make the directory read-only so rename fails
+        memory_dir.chmod(0o555)
+        try:
+            with caplog.at_level(logging.WARNING, logger="ops.memory"):
+                store = load_memory(memory_dir)
+            assert store.entries == []
+            assert any("failed to backup" in r.message.lower() for r in caplog.records)
+        finally:
+            memory_dir.chmod(0o755)
+
+    def test_load_structural_error_no_backup(self, memory_dir: Path) -> None:
+        """KeyError/TypeError from bad structure does NOT trigger backup."""
+        import json as _json
+
+        # Valid JSON but totally wrong structure (list instead of dict)
+        # This will hit the TypeError/AttributeError path
+        (memory_dir / "memory.json").write_text(_json.dumps({"entries": "not-a-list"}))
+
+        store = load_memory(memory_dir)
+
+        # Returns empty store (from_dict handles this gracefully)
+        assert isinstance(store, MemoryStore)
+
+        # Original file is NOT backed up (still exists)
+        assert (memory_dir / "memory.json").exists()
+        assert list(memory_dir.glob("memory.corrupt.*")) == []
+
+
+class TestLockedUpdate:
+    """Tests for _locked_update context manager (#1002)."""
+
+    def test_locked_update_basic(self, memory_dir: Path) -> None:
+        """_locked_update loads, allows mutation, and saves."""
+        # Pre-populate
+        store = MemoryStore(
+            entries=[
+                MemoryEntry(
+                    entry_id="aaa",
+                    category="repo_fact",
+                    key="k1",
+                    value="v1",
+                    source_file="f.md",
+                    added_by="test",
+                    added_at="2026-03-18T10:00:00+00:00",
+                )
+            ]
+        )
+        save_memory(store, memory_dir)
+
+        # Mutate inside lock
+        with _locked_update(memory_dir) as s:
+            s.entries.append(
+                MemoryEntry(
+                    entry_id="bbb",
+                    category="preference",
+                    key="k2",
+                    value="v2",
+                    source_file="f.md",
+                    added_by="test",
+                    added_at="2026-03-18T11:00:00+00:00",
+                )
+            )
+
+        # Verify persisted
+        reloaded = load_memory(memory_dir)
+        assert len(reloaded.entries) == 2
+        assert {e.entry_id for e in reloaded.entries} == {"aaa", "bbb"}
+
+    def test_locked_update_creates_lock_file(self, memory_dir: Path) -> None:
+        """Lock file is created in memory_dir."""
+        with _locked_update(memory_dir) as _s:
+            assert (memory_dir / LOCK_FILE).exists()
+
+    def test_locked_update_exception_does_not_save(self, memory_dir: Path) -> None:
+        """If caller raises inside the context, changes are NOT persisted."""
+        store = MemoryStore(
+            entries=[
+                MemoryEntry(
+                    entry_id="aaa",
+                    category="repo_fact",
+                    key="k1",
+                    value="original",
+                    source_file="f.md",
+                    added_by="test",
+                    added_at="2026-03-18T10:00:00+00:00",
+                )
+            ]
+        )
+        save_memory(store, memory_dir)
+
+        with pytest.raises(RuntimeError, match="abort"):
+            with _locked_update(memory_dir) as s:
+                s.entries[0] = MemoryEntry(
+                    entry_id="aaa",
+                    category="repo_fact",
+                    key="k1",
+                    value="MODIFIED",
+                    source_file="f.md",
+                    added_by="test",
+                    added_at="2026-03-18T10:00:00+00:00",
+                )
+                raise RuntimeError("abort")
+
+        # Original value preserved
+        reloaded = load_memory(memory_dir)
+        assert reloaded.entries[0].value == "original"
+
+    def test_concurrent_add_entry_no_lost_writes(
+        self, memory_dir: Path, source_file: Path
+    ) -> None:
+        """Two threads calling add_entry concurrently must not lose writes."""
+        import threading
+
+        barrier = threading.Barrier(2, timeout=5)
+        errors: list[Exception] = []
+
+        def _add(key: str) -> None:
+            try:
+                barrier.wait()  # Force both threads to contend on the lock
+                add_entry(
+                    memory_dir,
+                    category="repo_fact",
+                    key=key,
+                    value=f"value-{key}",
+                    source_file=str(source_file),
+                    added_by="test",
+                )
+            except Exception as exc:
+                errors.append(exc)
+
+        t1 = threading.Thread(target=_add, args=("concurrent_a",))
+        t2 = threading.Thread(target=_add, args=("concurrent_b",))
+        t1.start()
+        t2.start()
+        t1.join(timeout=10)
+        t2.join(timeout=10)
+
+        assert not errors, f"Thread errors: {errors}"
+
+        # Both entries must be present — no lost writes
+        entries = list_entries(memory_dir)
+        keys = {e.key for e in entries}
+        assert "concurrent_a" in keys, f"Lost write for concurrent_a. Keys: {keys}"
+        assert "concurrent_b" in keys, f"Lost write for concurrent_b. Keys: {keys}"


### PR DESCRIPTION
## Summary

- **Corrupt file backup (#950):** When `load_memory()` encounters invalid JSON, the corrupt file is renamed to `.corrupt.<timestamp>` before returning an empty store, preserving data for manual recovery. Previously the next `save_memory()` would silently overwrite, permanently destroying all entries.
- **File locking (#1002):** Read-modify-write cycles (`add_entry`, `remove_entry`) are now serialized via `fcntl.flock()` on a dedicated `.memory.lock` file, preventing lost updates from concurrent processes. Validation stays outside the lock to avoid holding it during potentially slow source-file I/O.
- **#951 (non-atomic writes):** Already fixed on main (tempfile+fsync+replace). No additional changes needed.

## Why

Post-merge review (PRs #926–#998) identified three data safety gaps in `memory.py`. Two (#950 per-entry handling, #951 atomic writes) were partially/fully fixed previously. This PR closes the remaining gaps: corrupt file preservation and concurrent write protection.

## Files Changed

| File | Change |
|------|--------|
| `src/bid_euchre/ops/memory.py` | Corrupt backup in `load_memory()`, `_locked_update()` context manager, rewritten `add_entry()`/`remove_entry()` |
| `tests/unit/test_ops_memory.py` | 8 new tests (43 total) |
| `plans/sessions/2026-03-20_batch1-memory-safety.md` | Implementation plan |

## Design Decisions

- **Separate lock file:** `save_memory()` uses `os.replace()` which replaces the inode, invalidating any flock held on the data file. A dedicated `.memory.lock` file persists across writes.
- **Lock file uses `"a"` mode:** Matches `events.py` convention. Avoids unnecessary truncation.
- **Microsecond timestamp in backup name:** Prevents collision if two processes detect corruption simultaneously (reviewer WARN-1).
- **No backup for KeyError/TypeError:** Structural issues (valid JSON, wrong shape) don't need backup — the file can be inspected as-is (reviewer WARN-2).

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_ops_memory.py -v  # 43/43 pass
make check-quiet                                           # All checks pass
```

## Tests

- `make check-quiet` — full suite passes
- `tests/unit/test_ops_memory.py` — 43 tests (8 new):
  - `test_load_backs_up_corrupt_file` — corrupt JSON renamed, content preserved
  - `test_load_corrupt_backup_logs_warning` — warning logged with backup path
  - `test_load_corrupt_backup_failure_still_returns_empty` — graceful degradation on read-only dir
  - `test_load_structural_error_no_backup` — valid JSON wrong shape, no backup
  - `test_locked_update_basic` — load→mutate→save cycle
  - `test_locked_update_creates_lock_file` — `.memory.lock` created
  - `test_locked_update_exception_does_not_save` — changes rolled back on exception
  - `test_concurrent_add_entry_no_lost_writes` — barrier-based concurrency test

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: fix/memory-safety
```

Closes #950
Closes #1002

🤖 Generated with [Claude Code](https://claude.com/claude-code)