### PR TITLE
fix: pass --force flag and add symlink containment in ops (#967, #959)

### DIFF
--- a/plans/sessions/2026-03-20_ops-bugs-batch3.md
+++ b/plans/sessions/2026-03-20_ops-bugs-batch3.md
@@ -1,0 +1,79 @@
+# Fix #967 + #959: ops bugs — force flag and symlink containment
+
+## Context
+
+Two remaining bugs from triage Batch 3. Issues #954 and #938 were already fixed
+(closed). These are the two that still need code changes.
+
+## Issue #967 — archive_worktree --force not passed to git
+
+**File:** `src/bid_euchre/ops/worktrees.py`, line 801
+**Current:** `["git", "worktree", "remove", worktree_path]`
+**Problem:** `force=True` parameter is accepted but never passed to the git command.
+
+### Fix
+
+```python
+cmd = ["git", "worktree", "remove", worktree_path]
+if force:
+    cmd.append("--force")
+result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+```
+
+### Test
+
+Add `test_archive_passes_force_flag` to `TestArchiveWorktree` — mock
+`subprocess.run`, call with `force=True`, verify `--force` is in the command.
+
+**Note:** Can't test with a real dirty worktree in unit tests (requires git
+repo setup). Mocking `subprocess.run` is the practical approach, matching
+existing test patterns in the file.
+
+## Issue #959 — delete_archive follows symlinks without containment check
+
+**File:** `src/bid_euchre/ops/compaction.py`, line 338
+**Current:** `shutil.rmtree(session_dir)` without checking resolved path.
+**Problem:** A symlink inside the archive dir could point outside, and rmtree
+would follow it and delete the target.
+
+### Fix
+
+Add resolve check before rmtree:
+
+```python
+session_dir = archive_dir / session_id
+if not session_dir.exists():
+    return False
+
+# Defence-in-depth: verify resolved path stays inside archive_dir (#959)
+if not session_dir.resolve().is_relative_to(archive_dir.resolve()):
+    logger.warning(
+        "Refusing to delete %s: resolved path escapes archive directory",
+        session_dir,
+    )
+    return False
+```
+
+### Test
+
+Add `test_delete_archive_rejects_symlink_escape` to `TestPathTraversal` —
+create a symlink inside archive_dir pointing to a target outside, verify
+`delete_archive()` returns False and the target is NOT deleted.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `src/bid_euchre/ops/worktrees.py` | Add `--force` to git command when `force=True` |
+| `src/bid_euchre/ops/compaction.py` | Add resolve containment check in `delete_archive()` |
+| `tests/unit/test_ops_worktrees.py` | Add `test_archive_passes_force_flag` |
+| `tests/unit/test_ops_compaction.py` | Add `test_delete_archive_rejects_symlink_escape` |
+
+## Validation
+
+- `uv run python -m pytest tests/unit/test_ops_worktrees.py tests/unit/test_ops_compaction.py -v` (Tier 1)
+- `make check-quiet` (Tier 2, before PR)
+
+## Outcome
+
+_(To be filled after implementation)_

--- a/src/bid_euchre/ops/compaction.py
+++ b/src/bid_euchre/ops/compaction.py
@@ -334,6 +334,16 @@ def delete_archive(session_id: str, archive_dir: Path | None = None) -> bool:
     if not session_dir.exists():
         return False
 
+    # Defence-in-depth: verify resolved path stays inside archive_dir (#959).
+    # _validate_session_id blocks ".." but cannot prevent symlinks whose
+    # targets lie outside the archive tree.
+    if not session_dir.resolve().is_relative_to(archive_dir.resolve()):
+        logger.warning(
+            "Refusing to delete %s: resolved path escapes archive directory",
+            session_dir,
+        )
+        return False
+
     try:
         shutil.rmtree(session_dir)
     except OSError as e:

--- a/src/bid_euchre/ops/worktrees.py
+++ b/src/bid_euchre/ops/worktrees.py
@@ -797,8 +797,11 @@ def archive_worktree(
             continue
 
     # Perform removal
+    cmd = ["git", "worktree", "remove", worktree_path]
+    if force:
+        cmd.append("--force")
     result = subprocess.run(
-        ["git", "worktree", "remove", worktree_path],
+        cmd,
         capture_output=True,
         text=True,
         timeout=30,

--- a/tests/unit/test_ops_compaction.py
+++ b/tests/unit/test_ops_compaction.py
@@ -452,6 +452,27 @@ class TestPathTraversalValidation:
         with pytest.raises(ValueError, match="Invalid session_id"):
             get_archive_context("back\\slash", archive_dir)
 
+    def test_delete_archive_rejects_symlink_escape(
+        self, archive_dir: Path, tmp_path: Path
+    ) -> None:
+        """delete_archive refuses to follow symlinks that escape archive dir (#959)."""
+        # Create a target directory outside the archive
+        target = tmp_path / "important_data"
+        target.mkdir()
+        (target / "precious.txt").write_text("do not delete")
+
+        # Create a symlink inside archive_dir that points to the external target
+        symlink_name = "session-evil"
+        (archive_dir / symlink_name).symlink_to(target)
+
+        # delete_archive should refuse and return False
+        result = delete_archive(symlink_name, archive_dir)
+        assert result is False, "delete_archive should refuse symlink escaping archive"
+
+        # Verify the external target was NOT deleted
+        assert target.exists(), "External target should not have been deleted"
+        assert (target / "precious.txt").exists()
+
 
 class TestFormatting:
     """Tests for formatting helpers."""

--- a/tests/unit/test_ops_worktrees.py
+++ b/tests/unit/test_ops_worktrees.py
@@ -896,6 +896,40 @@ class TestArchiveWorktree:
             "worktree" in str(cmd) and "remove" in str(cmd) for cmd in commands_run
         )
 
+    def test_archive_passes_force_flag(
+        self, runtime_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """force=True must pass --force to git worktree remove (#967)."""
+        import subprocess as sp
+
+        from bid_euchre.ops import worktrees as wt_mod
+
+        wt_dir = tmp_path / "dirty-worktree"
+        wt_dir.mkdir()
+
+        monkeypatch.setattr(wt_mod, "is_worktree_dirty", lambda p: False)
+
+        commands_run: list[list[str]] = []
+
+        def mock_run(*args: object, **kwargs: object) -> object:
+            cmd = args[0] if args else kwargs.get("args", [])
+            commands_run.append(list(cmd))
+            return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+        monkeypatch.setattr(sp, "run", mock_run)
+
+        wt_mod.archive_worktree(
+            str(wt_dir),
+            runtime_dir,
+            events_dir=runtime_dir / "events",
+            force=True,
+        )
+
+        # Verify --force was passed to git
+        git_cmds = [c for c in commands_run if "worktree" in str(c)]
+        assert len(git_cmds) >= 1
+        assert "--force" in git_cmds[0], f"--force missing from command: {git_cmds[0]}"
+
     def test_archive_cleans_registry_entry(
         self, runtime_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

- `archive_worktree()` now passes `--force` to the git subprocess command when `force=True`, allowing removal of dirty worktrees (#967)
- `delete_archive()` validates the resolved session path stays inside the archive directory before `rmtree`, preventing symlink escape (#959)
- Also closed 2 already-fixed issues: #954 (partial archive cleanup, PR #971) and #938 (flock/rename race, PR #918)

## Why

- #967: `--force` flag was accepted as a parameter but never passed to git, so dirty worktrees couldn't be removed even with `force=True`
- #959: Defence-in-depth — `_validate_session_id()` blocks `..` traversal but can't prevent planted symlinks whose targets lie outside the archive tree

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_ops_worktrees.py tests/unit/test_ops_compaction.py -v
make check-quiet
```

## Tests

- `test_archive_passes_force_flag` — mocks subprocess.run, verifies `--force` is in the git command when `force=True`
- `test_delete_archive_rejects_symlink_escape` — creates a symlink inside archive_dir pointing to external target, verifies `delete_archive` returns False and target is NOT deleted

95 tests pass (93 existing + 2 new).

## Worktree proof

- Worktree: `Bid-Euchre-steward-author-b`
- Branch: `fix/ops-force-symlink`

Closes #967
Closes #959

🤖 Generated with [Claude Code](https://claude.com/claude-code)