### PR TITLE
fix: align review mode classifier with CI paths-filter patterns

### DIFF
--- a/plans/sessions/2026-03-20_batch4-ci-classifier.md
+++ b/plans/sessions/2026-03-20_batch4-ci-classifier.md
@@ -1,0 +1,67 @@
+# Batch 4 — CI Classifier Input Mismatch
+
+**Date:** 2026-03-20
+**Goal:** Align `classify_review_mode()` file detection patterns with CI workflow's `dorny/paths-filter` to prevent review mode misclassification (#934).
+
+## Problem
+
+The review driver's `classify_review_mode()` determines review mode (STANDARD
+vs REPORT_AUDIT vs PLAN_AUDIT) by checking if changed files end with `.py` and
+start with `src/`, `scripts/`, or `tests/`.
+
+The CI workflow's `dorny/paths-filter` uses broader patterns for "code":
+- `src/**`, `scripts/**`, `tests/**`, `experiments/**`
+- `Makefile`, `pyproject.toml`, `.github/workflows/ci.yml`
+
+**Mismatch:** A PR that changes only `pyproject.toml` + `docs/04_reports/`
+would be classified as REPORT_AUDIT by the review driver, but CI runs full
+tests because paths-filter treats `pyproject.toml` as "code". The review
+mode determines which prechecks and Codex prompts are used, so a mismatch
+could cause insufficient review for infrastructure-affecting changes.
+
+## Fix
+
+Align `classify_review_mode()` with CI's paths-filter patterns:
+
+```python
+# Before:
+has_code = any(
+    f.endswith(".py")
+    and (f.startswith("src/") or f.startswith("scripts/") or f.startswith("tests/"))
+    for f in changed_files
+)
+
+# After — aligned with CI paths-filter (see .github/workflows/ci.yml):
+_CODE_PREFIXES = ("src/", "scripts/", "tests/", "experiments/", ".github/workflows/")
+_CODE_EXACT = ("Makefile", "pyproject.toml")
+
+has_code = any(
+    any(f.startswith(p) for p in _CODE_PREFIXES) or f in _CODE_EXACT
+    for f in changed_files
+)
+```
+
+Also add a comment cross-referencing the CI workflow for future maintenance.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `scripts/internal/review_driver.py` | Broaden `classify_review_mode()` patterns |
+| `tests/unit/test_review_driver.py` | Add tests for non-.py code detection |
+
+## Test Plan
+
+1. `test_classify_review_mode_pyproject` — `pyproject.toml` triggers STANDARD
+2. `test_classify_review_mode_makefile` — `Makefile` triggers STANDARD
+3. `test_classify_review_mode_experiments` — `experiments/configs/foo.yaml` triggers STANDARD
+4. Existing tests continue to pass
+
+## Scope Boundary
+
+- Only `review_driver.py` and its tests
+- No CI workflow changes
+- No `ci.py` changes (that module classifies failures, not file types)
+
+## Outcome
+<!-- Filled after implementation -->

--- a/scripts/internal/review_driver.py
+++ b/scripts/internal/review_driver.py
@@ -207,10 +207,24 @@ def classify_review_mode(changed_files: list[str]) -> ReviewMode:
 
     Code files always trigger STANDARD mode. Plan/report-only PRs
     get specialized audit modes.
+
+    The code-detection patterns are intentionally aligned with the CI
+    workflow's ``dorny/paths-filter`` ``code`` filter (see
+    ``.github/workflows/ci.yml``) so that any PR triggering full CI
+    tests also receives STANDARD review (#934).
     """
+    # Aligned with .github/workflows/ci.yml dorny/paths-filter 'code' filter.
+    _code_prefixes = (
+        "src/",
+        "scripts/",
+        "tests/",
+        "experiments/",
+        ".github/workflows/",
+    )
+    _code_exact = ("Makefile", "pyproject.toml")
+
     has_code = any(
-        f.endswith(".py")
-        and (f.startswith("src/") or f.startswith("scripts/") or f.startswith("tests/"))
+        any(f.startswith(p) for p in _code_prefixes) or f in _code_exact
         for f in changed_files
     )
     has_reports = any(f.startswith("docs/04_reports/") for f in changed_files)

--- a/tests/unit/test_review_driver.py
+++ b/tests/unit/test_review_driver.py
@@ -612,6 +612,36 @@ class TestFormatReviewComment:
         )
         assert mode == ReviewMode.STANDARD
 
+    def test_pyproject_triggers_standard(self) -> None:
+        """pyproject.toml is infrastructure code — triggers STANDARD (#934)."""
+        from review_state import ReviewMode
+
+        mode = classify_review_mode(["pyproject.toml", "docs/01_core/RULES.md"])
+        assert mode == ReviewMode.STANDARD
+
+    def test_makefile_triggers_standard(self) -> None:
+        """Makefile is infrastructure code — triggers STANDARD (#934)."""
+        from review_state import ReviewMode
+
+        mode = classify_review_mode(["Makefile"])
+        assert mode == ReviewMode.STANDARD
+
+    def test_experiments_yaml_triggers_standard(self) -> None:
+        """experiments/ configs are code per CI paths-filter (#934)."""
+        from review_state import ReviewMode
+
+        mode = classify_review_mode(
+            ["experiments/configs/quick_test.yaml", "plans/sessions/test.md"]
+        )
+        assert mode == ReviewMode.STANDARD
+
+    def test_github_workflow_triggers_standard(self) -> None:
+        """.github/workflows/ changes are code (#934)."""
+        from review_state import ReviewMode
+
+        mode = classify_review_mode([".github/workflows/ci.yml"])
+        assert mode == ReviewMode.STANDARD
+
 
 # ---------------------------------------------------------------------------
 # _step_applying_fixes: filtered findings preference tests (Bug 1 fix)


### PR DESCRIPTION
## Summary

- `classify_review_mode()` now detects infrastructure code files (Makefile, pyproject.toml, experiments/, .github/workflows/) that CI's `dorny/paths-filter` treats as "code" — ensuring STANDARD review mode for any PR that triggers full CI tests.

## Why

The review driver's file classification used `.endswith(".py")` as a gate, missing non-Python code files that CI considers significant. A PR changing only `pyproject.toml` + `docs/04_reports/` would get REPORT_AUDIT instead of STANDARD, even though CI runs full tests for it (#934).

## Files Changed

| File | Change |
|------|--------|
| `scripts/internal/review_driver.py` | Broadened `classify_review_mode()` patterns, added CI cross-reference |
| `tests/unit/test_review_driver.py` | 4 new tests (pyproject.toml, Makefile, experiments/ YAML, .github/workflows/) |
| `plans/sessions/2026-03-20_batch4-ci-classifier.md` | Implementation plan |

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_review_driver.py -v -k "pyproject or makefile or experiments or github_workflow"  # 4/4 pass
make check-quiet  # All checks pass
```

## Tests

- `make check-quiet` — full suite passes
- 4 new tests:
  - `test_pyproject_triggers_standard`
  - `test_makefile_triggers_standard`
  - `test_experiments_yaml_triggers_standard`
  - `test_github_workflow_triggers_standard`

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: fix/ci-classifier
```

Closes #934

🤖 Generated with [Claude Code](https://claude.com/claude-code)
