### PR TITLE
fix: convention batch 4 — docstrings, severity assertions, manifest backfill

### DIFF
--- a/docs/04_reports/arc_d_v2/r0/canonical/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r0/canonical/evidence_manifest.json
@@ -3,7 +3,7 @@
   "lineage_id": "arc_d_v2",
   "rung_id": "r0",
   "provenance_sha": "13ba62ee796891736b44b4bd5be380ab6b971938",
-  "governing_plan": "",
+  "governing_plan": "plans/arc_d_v2/lineage_plan.md",
   "plan_shas": [],
   "anchor": "anchor_hybrid_r0_full",
   "roster": [

--- a/docs/04_reports/arc_d_v2/r0/full/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r0/full/evidence_manifest.json
@@ -3,7 +3,7 @@
   "lineage_id": "arc_d_v2",
   "rung_id": "r0",
   "provenance_sha": "238b33866b872987d86a2169aca6ca2cc8a6d61c",
-  "governing_plan": "",
+  "governing_plan": "plans/arc_d_v2/lineage_plan.md",
   "plan_shas": [],
   "anchor": "anchor_hybrid_r0_full",
   "roster": [

--- a/docs/04_reports/arc_d_v2/r1/canonical/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r1/canonical/evidence_manifest.json
@@ -3,7 +3,7 @@
   "lineage_id": "arc_d_v2",
   "rung_id": "r1",
   "provenance_sha": "3ee7051e98ad6dfb9756dbe69ae903fe0150e982",
-  "governing_plan": "",
+  "governing_plan": "plans/arc_d_v2/lineage_plan.md",
   "plan_shas": [],
   "anchor": "anchor_hybrid_r0_full",
   "roster": [

--- a/docs/04_reports/arc_d_v2/r1/full/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r1/full/evidence_manifest.json
@@ -3,7 +3,7 @@
   "lineage_id": "arc_d_v2",
   "rung_id": "r1",
   "provenance_sha": "238b33866b872987d86a2169aca6ca2cc8a6d61c",
-  "governing_plan": "",
+  "governing_plan": "plans/arc_d_v2/lineage_plan.md",
   "plan_shas": [],
   "anchor": "anchor_hybrid_r0_full",
   "roster": [

--- a/docs/04_reports/arc_d_v2/r1/quick/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r1/quick/evidence_manifest.json
@@ -3,7 +3,7 @@
   "lineage_id": "arc_d_v2",
   "rung_id": "r1",
   "provenance_sha": "a090bcebbba05ee8cd27ae773567eb8ba28f75a9",
-  "governing_plan": "",
+  "governing_plan": "plans/arc_d_v2/lineage_plan.md",
   "plan_shas": [],
   "anchor": "anchor_hybrid_r0_full",
   "roster": [

--- a/docs/04_reports/arc_d_v2/r2/canonical/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r2/canonical/evidence_manifest.json
@@ -3,7 +3,7 @@
   "lineage_id": "arc_d_v2",
   "rung_id": "r2",
   "provenance_sha": "3ee7051e98ad6dfb9756dbe69ae903fe0150e982",
-  "governing_plan": "",
+  "governing_plan": "plans/arc_d_v2/lineage_plan.md",
   "plan_shas": [],
   "anchor": "anchor_hybrid_r0_full",
   "roster": [

--- a/docs/04_reports/arc_d_v2/r2/full/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r2/full/evidence_manifest.json
@@ -3,7 +3,7 @@
   "lineage_id": "arc_d_v2",
   "rung_id": "r2",
   "provenance_sha": "238b33866b872987d86a2169aca6ca2cc8a6d61c",
-  "governing_plan": "",
+  "governing_plan": "plans/arc_d_v2/lineage_plan.md",
   "plan_shas": [],
   "anchor": "anchor_hybrid_r0_full",
   "roster": [

--- a/docs/04_reports/arc_d_v2/r2/quick/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r2/quick/evidence_manifest.json
@@ -3,7 +3,7 @@
   "lineage_id": "arc_d_v2",
   "rung_id": "r2",
   "provenance_sha": "a090bcebbba05ee8cd27ae773567eb8ba28f75a9",
-  "governing_plan": "",
+  "governing_plan": "plans/arc_d_v2/lineage_plan.md",
   "plan_shas": [],
   "anchor": "anchor_hybrid_r0_full",
   "roster": [

--- a/docs/04_reports/arc_d_v2/r3/canonical/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r3/canonical/evidence_manifest.json
@@ -3,7 +3,7 @@
   "lineage_id": "arc_d_v2",
   "rung_id": "r3",
   "provenance_sha": "3d8f505e9a772daf9cb6ffd341a870a48a29aef5",
-  "governing_plan": "",
+  "governing_plan": "plans/arc_d_v2/lineage_plan.md",
   "plan_shas": [],
   "anchor": "anchor_hybrid_r0_full",
   "roster": [

--- a/docs/04_reports/arc_d_v2/r3/full/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r3/full/evidence_manifest.json
@@ -3,7 +3,7 @@
   "lineage_id": "arc_d_v2",
   "rung_id": "r3",
   "provenance_sha": "238b33866b872987d86a2169aca6ca2cc8a6d61c",
-  "governing_plan": "",
+  "governing_plan": "plans/arc_d_v2/lineage_plan.md",
   "plan_shas": [],
   "anchor": "anchor_hybrid_r0_full",
   "roster": [

--- a/docs/04_reports/arc_d_v2/r3/quick/evidence_manifest.json
+++ b/docs/04_reports/arc_d_v2/r3/quick/evidence_manifest.json
@@ -3,7 +3,7 @@
   "lineage_id": "arc_d_v2",
   "rung_id": "r3",
   "provenance_sha": "a090bcebbba05ee8cd27ae773567eb8ba28f75a9",
-  "governing_plan": "",
+  "governing_plan": "plans/arc_d_v2/lineage_plan.md",
   "plan_shas": [],
   "anchor": "anchor_hybrid_r0_full",
   "roster": [

--- a/plans/arc_d_v2/reporting_refactor_full_plan.md
+++ b/plans/arc_d_v2/reporting_refactor_full_plan.md
@@ -1119,8 +1119,10 @@ degraded modes. They do not block the plan's COMPLETE WITH DEGRADED STATES statu
   CSVs now contain suit/high/low/pass contract rows across all 5 models.
 - **Chart regeneration (PR #993):** Charts 16-18 (pred_vs_actual,
   residual_distribution, calibration_curve) and dashboard_model_eval regenerated
-  for R0-R2/FULL from GBT-inclusive CSVs. All model-eval PNGs now reflect 5
-  models. Manifests and evidence manifests updated with new byte sizes.
+  for R0-R2/FULL only from GBT-inclusive CSVs (R3 charts not regenerated — R3
+  bundle predates the chart pipeline update; see DS-4). All R0-R2 model-eval
+  PNGs now reflect 5 models. Manifests and evidence manifests updated with new
+  byte sizes.
 - **Contract-faceted regeneration (PR #997):** Charts 16-18 and
   dashboard_model_eval regenerated for R0-R3/FULL with contract-faceted
   predictions/residuals/calibration data (suit/high/low/pass × 5 models).

--- a/plans/sessions/2026-03-20_convention-batch-4.md
+++ b/plans/sessions/2026-03-20_convention-batch-4.md
@@ -1,0 +1,72 @@
+# Convention Batch 4 — Batch 5 from triage plan
+
+## Context
+
+7 issues assigned to Batch 5 (convention follow-ups). After investigation,
+2 are already fixed and 1 should close as out-of-scope. Remaining 4 are
+small fixes suitable for a single PR.
+
+## Already Fixed — Close Immediately
+
+### #958 — extract duplicated _find_repo_root()
+Already extracted to `scripts/internal/_repo_utils.py`. All 4 scripts now
+import `from _repo_utils import find_repo_root`. Close.
+
+### #963 — outcome_distributions.status, 04_rung_decision.md, plan status
+All three findings are stale:
+- `outcome_distributions.status` — files already removed (confirmed: no matches in `docs/04_reports/`)
+- `04_rung_decision.md` for R2/full — file no longer exists
+- Plan status already marked resolved with "✅ Fully resolved" comments
+Close as stale.
+
+## Close as Out-of-Scope
+
+### #936 — Inconsistent JSON schema between precheck and review loop
+The issue itself notes: "Low — both systems work independently and the
+inconsistency only matters if building cross-system aggregation." The two
+systems (`deterministic_prechecks.py` Finding dataclass vs `review_driver.py`
+Codex finding dict) serve different purposes and have intentionally different
+shapes. Schema alignment would require significant refactoring of both systems
+with no functional benefit. Close as won't-fix with explanation.
+
+## Fixes — Single PR
+
+### #955 — CLI docstrings show --json in wrong position
+
+**Files:** `scripts/internal/build_curated_memory.py`, `scripts/internal/compact_session_context.py`
+
+`--json` is on the parent parser (line 24/25 in each), but docstrings show it
+after the subcommand (e.g., `list [--json]`). Fix: move `[--json]` to before
+the subcommand name in each usage line.
+
+### #946 — Assert WARNING severity in prose fallback test
+
+**File:** `tests/unit/test_codex_plan_review_adapter.py`
+
+The issue requests adding a severity assertion so prose fallback regressions
+are caught. Need to find the test that exercises prose fallback parsing and
+verify it asserts `severity == "WARNING"`.
+
+### #995 — Limit DS-3 chart-regeneration claim to R0-R2/FULL
+
+**File:** `plans/arc_d_v2/reporting_refactor_full_plan.md`
+
+The DS-3 resolution note at line ~1106 should clarify that chart regeneration
+was for R0-R2/FULL only (R3 was regenerated before the chart pipeline update).
+
+### #1001 — Backfill governing_plan in 7 evidence manifests
+
+**Files:** 7 `evidence_manifest.json` files under `docs/04_reports/arc_d_v2/`
+
+Set `governing_plan` to `"plans/arc_d_v2/lineage_plan.md"` in:
+- r0/canonical, r1/quick, r1/canonical, r2/quick, r2/canonical, r3/quick, r3/canonical
+
+## Validation
+
+- `uv run python -m pytest tests/unit/test_codex_plan_review_adapter.py -v` (for #946)
+- `uv run ruff check && uv run ruff format` on changed Python files
+- `make check-quiet` (Tier 2)
+
+## Outcome
+
+_(To be filled after implementation)_

--- a/plans/sessions/2026-03-20_review-infra-batch7.md
+++ b/plans/sessions/2026-03-20_review-infra-batch7.md
@@ -1,0 +1,53 @@
+# Review Infra — Batch 7 from triage plan
+
+## Context
+
+2 issues assigned to Batch 7 (review infrastructure improvements).
+
+## #829 — Review driver should checkout PR branch before Codex
+
+**Assessment: Close as deferred architectural improvement.**
+
+This is a significant architectural change to the review driver. The current
+workarounds (PR #826) are effective:
+- RC1 (empty diff) → detected as clean review
+- RC3 (PV2 false positive) → demoted to P2 warning
+
+The review driver already documents this limitation (lines 471, 808).
+The fix (ephemeral worktree per review) adds complexity and risk to a
+system that's advisory-only. The cost/benefit doesn't justify the change
+while the workarounds are in place.
+
+Close with explanation and recommendation to revisit if the workarounds
+prove insufficient.
+
+## #830 — Port reversed-format parser to plan review adapter
+
+**Assessment: Implement.**
+
+Port `_REVERSED_FINDING_RE` and `_parse_reversed_format()` from
+`codex_review_adapter.py` to `codex_plan_review_adapter.py`.
+
+### Files
+
+| File | Change |
+|------|--------|
+| `scripts/internal/codex_plan_review_adapter.py` | Add `_REVERSED_FINDING_RE`, `_parse_reversed_format()`, wire into parser |
+| `tests/unit/test_codex_plan_review_adapter.py` | Add reversed-format parsing tests |
+
+### Implementation
+
+1. Copy `_REVERSED_FINDING_RE` regex from `codex_review_adapter.py` (line 127)
+2. Adapt `_parse_reversed_format()` for `PlanReviewFinding` return type
+3. Wire into `parse_plan_findings()` as a fallback before prose parsing
+4. Port line-range handling (`90-95` → extract `90`)
+5. Add tests matching the review adapter test patterns
+
+### Validation
+
+- `uv run python -m pytest tests/unit/test_codex_plan_review_adapter.py -v`
+- `make check-quiet`
+
+## Outcome
+
+_(To be filled after implementation)_

--- a/scripts/internal/build_curated_memory.py
+++ b/scripts/internal/build_curated_memory.py
@@ -1,11 +1,11 @@
 """Build or update curated memory entries.
 
 Usage:
-    uv run python scripts/internal/build_curated_memory.py list [--category CAT] [--json]
-    uv run python scripts/internal/build_curated_memory.py add --category CAT --key KEY --value VALUE --source FILE --by AGENT [--tags TAG1,TAG2] [--json]
-    uv run python scripts/internal/build_curated_memory.py remove --id ENTRY_ID [--json]
-    uv run python scripts/internal/build_curated_memory.py search --text TEXT [--json]
-    uv run python scripts/internal/build_curated_memory.py validate [--json]
+    uv run python scripts/internal/build_curated_memory.py [--json] list [--category CAT]
+    uv run python scripts/internal/build_curated_memory.py [--json] add --category CAT --key KEY --value VALUE --source FILE --by AGENT [--tags TAG1,TAG2]
+    uv run python scripts/internal/build_curated_memory.py [--json] remove --id ENTRY_ID
+    uv run python scripts/internal/build_curated_memory.py [--json] search --text TEXT
+    uv run python scripts/internal/build_curated_memory.py [--json] validate
 """
 
 from __future__ import annotations

--- a/scripts/internal/compact_session_context.py
+++ b/scripts/internal/compact_session_context.py
@@ -1,12 +1,12 @@
 """Compact and archive session context.
 
 Usage:
-    uv run python scripts/internal/compact_session_context.py compact \
+    uv run python scripts/internal/compact_session_context.py [--json] compact \
         --session-id SESSION_ID --lane LANE --context-file FILE \
-        [--summary TEXT] [--outcome TEXT] [--pr PR1,PR2] [--json]
-    uv run python scripts/internal/compact_session_context.py list [--json]
-    uv run python scripts/internal/compact_session_context.py show --session-id SESSION_ID [--json]
-    uv run python scripts/internal/compact_session_context.py artifacts --session-id SESSION_ID [--json]
+        [--summary TEXT] [--outcome TEXT] [--pr PR1,PR2]
+    uv run python scripts/internal/compact_session_context.py [--json] list
+    uv run python scripts/internal/compact_session_context.py [--json] show --session-id SESSION_ID
+    uv run python scripts/internal/compact_session_context.py [--json] artifacts --session-id SESSION_ID
 """
 
 from __future__ import annotations

--- a/tests/unit/test_codex_plan_review_adapter.py
+++ b/tests/unit/test_codex_plan_review_adapter.py
@@ -281,6 +281,7 @@ class TestParsePlanFindingsReversedFormat:
         findings = parse_plan_findings(output)
         assert len(findings) == 1
         assert "review_driver.sh" in findings[0].file
+        assert findings[0].severity == "WARNING"  # P1 → WARNING (#946)
 
     def test_reversed_format_no_line_number(self) -> None:
         """Reversed format without :N line suffix is still parsed."""
@@ -289,6 +290,20 @@ class TestParsePlanFindingsReversedFormat:
         assert len(findings) == 1
         assert "foo.py" in findings[0].file
         assert findings[0].line is None or findings[0].line == 0
+        assert findings[0].severity == "WARNING"  # P1 → WARNING (#946)
+
+    def test_severity_mapping_end_to_end(self) -> None:
+        """P0/P1/P2 Codex severities map to CRITICAL/WARNING/INFO (#946)."""
+        output = (
+            "- [P0] Security issue — src/bid_euchre/a.py:1\n"
+            "- [P1] Convention issue — src/bid_euchre/b.py:2\n"
+            "- [P2] Minor style — src/bid_euchre/c.py:3\n"
+        )
+        findings = parse_plan_findings(output)
+        assert len(findings) == 3
+        assert findings[0].severity == "CRITICAL"  # P0 → CRITICAL
+        assert findings[1].severity == "WARNING"  # P1 → WARNING
+        assert findings[2].severity == "INFO"  # P2 → INFO
 
 
 # --- Finding Dataclass Tests ---


### PR DESCRIPTION
## Summary

- Fix CLI docstrings showing `--json` in wrong position (#955)
- Add severity mapping assertions (P0→CRITICAL, P1→WARNING, P2→INFO) to plan review tests (#946)
- Narrow DS-3 chart-regeneration claim to R0-R2/FULL in reporting plan (#995)
- Backfill `governing_plan` in 11 evidence manifests (issue reported 7, found 11) (#1001)
- Also closed 5 already-fixed or out-of-scope issues: #958, #963, #936, #829, #830

## Why

Batch of convention follow-ups from post-merge review automation. All low-severity, high-confidence fixes.

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_codex_plan_review_adapter.py -v -k "reversed_format or severity_mapping"
make check-quiet
```

## Tests

- `test_reversed_format_shell_extension` — now asserts `severity == "WARNING"` (was missing)
- `test_reversed_format_no_line_number` — now asserts `severity == "WARNING"` (was missing)
- `test_severity_mapping_end_to_end` — new test: P0/P1/P2 → CRITICAL/WARNING/INFO

83 tests pass in test_codex_plan_review_adapter.py.

## Worktree proof

- Worktree: `Bid-Euchre-steward-author-b`
- Branch: `fix/convention-batch-4`

Closes #955
Closes #946
Closes #995
Closes #1001

🤖 Generated with [Claude Code](https://claude.com/claude-code)