### PR TITLE
fix: post-merge review batch 5 — dirty-check, error conflation, test hygiene

### DIFF
--- a/src/bid_euchre/ops/memory.py
+++ b/src/bid_euchre/ops/memory.py
@@ -172,11 +172,19 @@ def load_memory(memory_dir: Path) -> MemoryStore:
             memory_path.rename(backup)
             logger.warning("Corrupt memory file backed up to %s: %s", backup.name, e)
         except OSError as rename_err:
-            logger.warning(
-                "Failed to backup corrupt memory file (%s): %s",
-                rename_err,
-                e,
-            )
+            if not memory_path.exists():
+                # Source file already renamed by a concurrent process —
+                # recovery succeeded, just not by us.
+                logger.info(
+                    "Corrupt memory file already recovered by another process: %s",
+                    e,
+                )
+            else:
+                logger.warning(
+                    "Failed to backup corrupt memory file (%s): %s",
+                    rename_err,
+                    e,
+                )
         return MemoryStore()
     except (KeyError, TypeError) as e:
         # Structural issues (valid JSON but unexpected shape).  No backup
@@ -225,11 +233,16 @@ def save_memory(store: MemoryStore, memory_dir: Path) -> None:
 @contextmanager
 def _locked_update(memory_dir: Path) -> Generator[MemoryStore, None, None]:
     """Acquire an exclusive lock, yield a loaded :class:`MemoryStore`, and
-    save it back on clean exit.
+    save it back on clean exit — but only if the store was actually modified.
 
     This serializes concurrent read-modify-write cycles (e.g. two
     ``add_entry()`` calls from different processes) so that neither
     update is lost (#1002).
+
+    A snapshot of the store is taken before ``yield``.  After the caller
+    returns, the store is compared against the snapshot.  If nothing
+    changed, ``save_memory()`` is skipped — avoiding wasted I/O and
+    ``last_updated`` timestamp pollution on no-op mutations.
 
     A dedicated lock file (rather than the data file) is used because
     ``save_memory()`` atomically *replaces* the data file via
@@ -245,8 +258,10 @@ def _locked_update(memory_dir: Path) -> Generator[MemoryStore, None, None]:
         fcntl.flock(lock_fh, fcntl.LOCK_EX)
         try:
             store = load_memory(memory_dir)
+            snapshot = json.dumps(store.to_dict(), sort_keys=True)
             yield store
-            save_memory(store, memory_dir)
+            if json.dumps(store.to_dict(), sort_keys=True) != snapshot:
+                save_memory(store, memory_dir)
         finally:
             fcntl.flock(lock_fh, fcntl.LOCK_UN)
 

--- a/src/bid_euchre/ops/scheduler.py
+++ b/src/bid_euchre/ops/scheduler.py
@@ -355,11 +355,13 @@ def daemon(
             )
             result.total_events_emitted += tick_result.events_emitted
 
+            # Successful tick (no exception) — reset consecutive error
+            # counter.  tick_result.errors are non-fatal warnings (e.g.
+            # watchdog check failures) that get logged but must NOT
+            # count toward the consecutive-error shutdown threshold.
+            consecutive_errors = 0
             if tick_result.errors:
                 result.errors.extend(tick_result.errors)
-                consecutive_errors += 1
-            else:
-                consecutive_errors = 0
 
             logger.info(
                 "Daemon tick %d/%d: %d findings (%d critical)",

--- a/tests/unit/test_ops_index.py
+++ b/tests/unit/test_ops_index.py
@@ -1031,11 +1031,13 @@ class TestStalenessCache:
 
         assert call_count >= 1, "Cache should have been invalidated after build"
 
-    def test_staleness_cache_isolated_across_index_dirs(self, tmp_path: Path) -> None:
+    def test_staleness_cache_isolated_across_index_dirs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Two different index_dirs should not share cache entries."""
         import bid_euchre.ops.index as idx_mod
 
-        idx_mod._STALENESS_TTL_SECONDS = 3600.0
+        monkeypatch.setattr(idx_mod, "_STALENESS_TTL_SECONDS", 3600.0)
 
         # Create two independent indexes
         idx1 = tmp_path / "idx1"
@@ -1077,6 +1079,3 @@ class TestStalenessCache:
         # idx2's cache should still be valid
         stats2 = get_stats(idx2)
         assert isinstance(stats2.stale_sources, int)
-
-        # Restore default TTL
-        idx_mod._STALENESS_TTL_SECONDS = 30.0

--- a/tests/unit/test_ops_memory.py
+++ b/tests/unit/test_ops_memory.py
@@ -197,8 +197,8 @@ class TestLoadSave:
             original_close(fd)
 
         with (
-            patch("os.replace", side_effect=OSError("disk full")),
-            patch("os.close", side_effect=tracking_close),
+            patch("bid_euchre.ops.memory.os.replace", side_effect=OSError("disk full")),
+            patch("bid_euchre.ops.memory.os.close", side_effect=tracking_close),
         ):
             with pytest.raises(OSError, match="disk full"):
                 save_memory(store, memory_dir)
@@ -800,3 +800,97 @@ class TestLockedUpdate:
         keys = {e.key for e in entries}
         assert "concurrent_a" in keys, f"Lost write for concurrent_a. Keys: {keys}"
         assert "concurrent_b" in keys, f"Lost write for concurrent_b. Keys: {keys}"
+
+    def test_locked_update_no_op_skips_save(self, memory_dir: Path) -> None:
+        """_locked_update must skip save_memory when store is unmodified."""
+        from unittest.mock import patch as _patch
+
+        # Pre-populate with an entry
+        store = MemoryStore(
+            entries=[
+                MemoryEntry(
+                    entry_id="aaa",
+                    category="repo_fact",
+                    key="k1",
+                    value="v1",
+                    source_file="f.md",
+                    added_by="test",
+                    added_at="2026-03-18T10:00:00+00:00",
+                )
+            ]
+        )
+        save_memory(store, memory_dir)
+        original_updated = load_memory(memory_dir).last_updated
+
+        # Open _locked_update but make no changes
+        with _patch("bid_euchre.ops.memory.save_memory") as mock_save:
+            with _locked_update(memory_dir) as _s:
+                pass  # No mutations
+
+            mock_save.assert_not_called()
+
+        # last_updated should be unchanged
+        reloaded = load_memory(memory_dir)
+        assert reloaded.last_updated == original_updated
+
+    def test_locked_update_mutation_saves(self, memory_dir: Path) -> None:
+        """_locked_update must call save_memory when store is modified."""
+        from unittest.mock import patch as _patch
+
+        store = MemoryStore(
+            entries=[
+                MemoryEntry(
+                    entry_id="aaa",
+                    category="repo_fact",
+                    key="k1",
+                    value="v1",
+                    source_file="f.md",
+                    added_by="test",
+                    added_at="2026-03-18T10:00:00+00:00",
+                )
+            ]
+        )
+        save_memory(store, memory_dir)
+
+        # Mutate inside the context
+        with _patch("bid_euchre.ops.memory.save_memory") as mock_save:
+            with _locked_update(memory_dir) as s:
+                s.entries.append(
+                    MemoryEntry(
+                        entry_id="bbb",
+                        category="preference",
+                        key="k2",
+                        value="v2",
+                        source_file="f.md",
+                        added_by="test",
+                        added_at="2026-03-18T11:00:00+00:00",
+                    )
+                )
+
+            mock_save.assert_called_once()
+
+    def test_remove_nonexistent_no_timestamp_change(self, memory_dir: Path) -> None:
+        """Removing a nonexistent entry must not update last_updated."""
+        store = MemoryStore(
+            entries=[
+                MemoryEntry(
+                    entry_id="aaa",
+                    category="repo_fact",
+                    key="k1",
+                    value="v1",
+                    source_file="f.md",
+                    added_by="test",
+                    added_at="2026-03-18T10:00:00+00:00",
+                )
+            ]
+        )
+        save_memory(store, memory_dir)
+        original_updated = load_memory(memory_dir).last_updated
+
+        # Remove nonexistent — should be a no-op
+        removed = remove_entry(memory_dir, "nonexistent_id")
+        assert not removed
+
+        # last_updated must be unchanged (no save occurred)
+        reloaded = load_memory(memory_dir)
+        assert reloaded.last_updated == original_updated

--- a/tests/unit/test_ops_scheduler.py
+++ b/tests/unit/test_ops_scheduler.py
@@ -427,6 +427,56 @@ class TestDaemon:
         # Each tick emits at least a scheduler_tick event
         assert result.total_events_emitted >= 2
 
+    def test_daemon_warnings_do_not_trigger_shutdown(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        scheduler_dir: Path,
+        events_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """tick_result.errors (watchdog warnings) must NOT count toward
+        the consecutive-error shutdown threshold.
+
+        Regression test: the daemon previously conflated tick_result.errors
+        (non-fatal warnings from a successful tick) with actual exceptions.
+        5 consecutive ticks with warnings would trigger shutdown (>= 3).
+        After the fix, only exceptions increment the counter.
+        """
+        call_count = 0
+
+        def warning_tick(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            from bid_euchre.ops.scheduler import TickResult
+
+            return TickResult(
+                checks_run=["heartbeats"],
+                findings=[],
+                events_emitted=0,
+                errors=[f"watchdog warning {call_count}"],  # Non-fatal
+                tick_number=call_count,
+            )
+
+        from bid_euchre.ops import scheduler as sched_mod
+
+        monkeypatch.setattr(sched_mod, "tick", warning_tick)
+
+        result = daemon(
+            runtime_dir=runtime_dir,
+            plans_dir=plans_dir,
+            scheduler_dir=scheduler_dir,
+            events_dir=events_dir,
+            max_iterations=5,
+            _sleep_fn=self._noop_sleep,
+        )
+
+        # All 5 ticks must complete — warnings are not fatal
+        assert result.ticks_completed == 5
+        assert result.stopped_reason == "max_iterations"
+        # Warnings are still accumulated in result.errors
+        assert len(result.errors) == 5
+
 
 class TestDaemonFormatters:
     """Tests for daemon result formatters."""

--- a/tests/unit/test_ops_status.py
+++ b/tests/unit/test_ops_status.py
@@ -1078,6 +1078,39 @@ class TestParseIsoTimestamp:
         assert _parse_iso_timestamp("not-a-timestamp") is None
 
 
+class TestIsNewerSession:
+    """Direct unit tests for _is_newer_session() edge cases."""
+
+    def test_malformed_candidate_loses_to_valid_existing(self) -> None:
+        """Malformed candidate must lose to valid existing session.
+
+        Covers the branch at status.py where candidate is malformed but
+        existing is valid — existing wins (return False).
+        """
+        from bid_euchre.ops.status import _is_newer_session
+
+        malformed = {"started_at": "not-a-date"}
+        valid = {"started_at": "2026-03-18T12:00:00+00:00"}
+        assert not _is_newer_session(malformed, valid)
+
+    def test_valid_candidate_beats_malformed_existing(self) -> None:
+        """Valid candidate must beat malformed existing session."""
+        from bid_euchre.ops.status import _is_newer_session
+
+        valid = {"started_at": "2026-03-18T12:00:00+00:00"}
+        malformed = {"started_at": "garbage"}
+        assert _is_newer_session(valid, malformed)
+
+    def test_both_malformed_uses_lexicographic(self) -> None:
+        """When both are malformed, lexicographic fallback applies."""
+        from bid_euchre.ops.status import _is_newer_session
+
+        a = {"started_at": "zzz"}
+        b = {"started_at": "aaa"}
+        assert _is_newer_session(a, b)
+        assert not _is_newer_session(b, a)
+
+
 class TestAggregateStatusLaneActivity:
     """Integration tests for lane-activity via aggregate_status()."""
 


### PR DESCRIPTION
## Summary

- **F1 (HIGH):** `_locked_update()` now snapshots store state before yield and skips `save_memory()` when unchanged — prevents wasted I/O and `last_updated` timestamp pollution on no-op mutations
- **F2 (HIGH):** `daemon()` consecutive error counter no longer conflates `tick_result.errors` (non-fatal watchdog warnings) with actual exceptions — only exceptions trigger the 3-consecutive-error shutdown threshold
- **F10:** Concurrent corruption backup now distinguishes "already recovered by another process" from genuine rename failure
- **F17:** Replace direct `_STALENESS_TTL_SECONDS` assignment with `monkeypatch.setattr()` for proper test cleanup
- **F19:** Add direct unit tests for `_is_newer_session()` malformed-candidate branches
- **F22:** Normalize unqualified mock patch paths to qualified `bid_euchre.ops.memory.os.*`

## Why

Comprehensive review of PRs #982–#1013 identified 22 findings. Validation against the codebase confirmed 14 as actionable (3 false positives, 3 already resolved). This PR fixes the 6 most impactful confirmed findings (2 HIGH, 4 MEDIUM).

## Repro / Validation

```bash
# Tier 1: targeted tests on changed files
uv run python -m pytest tests/unit/test_ops_memory.py tests/unit/test_ops_scheduler.py tests/unit/test_ops_index.py tests/unit/test_ops_status.py -v

# Tier 2: full validation
make check
```

## Tests

- `test_locked_update_no_op_skips_save` — verifies `save_memory` not called on no-op
- `test_locked_update_mutation_saves` — regression guard for save on mutation
- `test_remove_nonexistent_no_timestamp_change` — verifies `last_updated` stable on no-op remove
- `test_daemon_warnings_do_not_trigger_shutdown` — 5 consecutive ticks with warnings complete without shutdown
- `test_malformed_candidate_loses_to_valid_existing` — direct `_is_newer_session()` unit test
- `test_valid_candidate_beats_malformed_existing` — direct `_is_newer_session()` unit test
- `test_both_malformed_uses_lexicographic` — direct `_is_newer_session()` unit test

All 192 targeted tests pass. Full `make check` passes.

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/worktree-post-merge-batch-5
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/worktree-post-merge-batch-5
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)