### PR TITLE
fix: allowlist-based CI classifier, flag reviewer infra failures

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,7 +43,7 @@ jobs:
           claude_args: "--max-turns 5"
 
       - name: Flag reviewer infra failure
-        if: failure()
+        if: always() && steps.claude-review.outcome == 'failure'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EXECUTION_FILE: ${{ steps.claude-review.outputs.execution_file }}

--- a/scripts/internal/github_pr_state.py
+++ b/scripts/internal/github_pr_state.py
@@ -151,7 +151,6 @@ _CI_CHECK_NAMES: set[str] = {
     "tests",
     "prechecks",
     "governance",
-    "enable-auto-merge",
 }
 
 

--- a/tests/unit/test_claude_review_workflow.py
+++ b/tests/unit/test_claude_review_workflow.py
@@ -70,8 +70,9 @@ class TestClaudeReviewWorkflow:
         ]
         assert len(flag_steps) == 1
         flag_step = flag_steps[0]
-        # Must only run on failure, and must have GH_TOKEN for gh issue create
-        assert "failure()" in flag_step["if"]
+        # Must scope to the review step specifically, not blanket failure()
+        assert "steps.claude-review.outcome" in flag_step["if"]
+        # Must have GH_TOKEN for gh issue create
         assert "GH_TOKEN" in str(flag_step.get("env", {}))
 
     def _review_step(self):

--- a/tests/unit/test_github_pr_state.py
+++ b/tests/unit/test_github_pr_state.py
@@ -200,10 +200,11 @@ class TestCICheckAllowlist:
     def test_contains_governance(self) -> None:
         assert "governance" in _CI_CHECK_NAMES
 
-    def test_does_not_contain_review_contexts(self) -> None:
-        """Review/advisory checks must never appear in the CI allowlist."""
+    def test_does_not_contain_non_validation_checks(self) -> None:
+        """Review, advisory, and plumbing checks must not appear in CI allowlist."""
         assert "reviewing-changes" not in _CI_CHECK_NAMES
         assert "claude-review" not in _CI_CHECK_NAMES
+        assert "enable-auto-merge" not in _CI_CHECK_NAMES
 
 
 class TestGetCIStatus:
@@ -257,6 +258,17 @@ class TestGetCIStatus:
         mock_run.return_value = _mock_checks_result(
             [
                 {"name": "claude-review", "state": "FAILURE"},
+                {"name": "tests", "state": "SUCCESS"},
+            ]
+        )
+        assert get_ci_status(1) == "success"
+
+    @patch("github_pr_state.subprocess.run")
+    def test_enable_auto_merge_failure_ignored(self, mock_run: Mock) -> None:
+        """enable-auto-merge is plumbing, not validation — ignored."""
+        mock_run.return_value = _mock_checks_result(
+            [
+                {"name": "enable-auto-merge", "state": "FAILURE"},
                 {"name": "tests", "state": "SUCCESS"},
             ]
         )


### PR DESCRIPTION
## Summary
- Replace blacklist in `get_ci_status()` with explicit CI allowlist (`_CI_CHECK_NAMES`) — only `tests`, `prechecks`, `governance`, `enable-auto-merge` are considered CI
- Add infra failure flagging step to `claude-code-review.yml` — creates a follow-up issue when the review action crashes, with proper `GH_TOKEN`
- No `continue-on-error` — review failures remain visible as check status
- `DEFAULT_REVIEW_CONTEXTS` and `reviewing-changes` untouched — remains the sole review gate

## Why
`claude-review` infrastructure failures (expired OAuth token, permission denials, max-turns) were being treated as CI failures by `get_ci_status()`, causing the `reviewing-changes` loop to abort on every PR. The blacklist approach (`!= "reviewing-changes"`) was fragile — any new non-CI check could poison CI status again.

The allowlist inverts the default: only explicitly listed CI checks matter. Unknown checks are ignored automatically.

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_github_pr_state.py tests/unit/test_claude_review_workflow.py tests/unit/test_ops_reviews.py -v
# 81 passed

make check-quiet
# All checks passed
```

## Tests
- `TestCICheckAllowlist` (4 tests): allowlist contains expected CI names, excludes review contexts
- `TestGetCIStatus` (9 tests): CI pass/fail/pending, review failures ignored, **future unknown checks ignored**, empty/error cases
- `TestClaudeReviewWorkflow` (2 new): no continue-on-error, infra flag step exists with GH_TOKEN
- Existing `test_ops_reviews.py` (47 tests): all passing, unmodified

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: fix/convention-batch-4
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)