### PR TITLE
fix: separate ci, review gate, and advisory check categories in ops

### DIFF
--- a/src/bid_euchre/ops/__init__.py
+++ b/src/bid_euchre/ops/__init__.py
@@ -25,6 +25,41 @@ Modules:
 # Extend this tuple when adding a new online reviewer.
 DEFAULT_REVIEW_CONTEXTS: tuple[str, ...] = ("reviewing-changes",)
 
+# --- Three-category check classification ---
+#
+# review_gate: merge-relevant review statuses (branch protection may require these)
+# advisory:   informational review checks (never block CI or merge)
+# ci:         everything else (real CI checks)
+
+REVIEW_GATE_CONTEXTS: tuple[str, ...] = DEFAULT_REVIEW_CONTEXTS
+"""Check names that are merge-relevant review gates (alias for DEFAULT_REVIEW_CONTEXTS)."""
+
+ADVISORY_CONTEXTS: tuple[str, ...] = ("claude-review",)
+"""Check names that are advisory-only — infrastructure failures here must not poison CI."""
+
+NON_CI_CONTEXTS: tuple[str, ...] = REVIEW_GATE_CONTEXTS + ADVISORY_CONTEXTS
+"""Union of all non-CI check contexts (review gate + advisory)."""
+
+
+def classify_check(name: str) -> str:
+    """Classify a GitHub check/status context name into a category.
+
+    Args:
+        name: The check or status context name (e.g. ``"tests"``,
+            ``"reviewing-changes"``, ``"claude-review"``).
+
+    Returns:
+        ``"review_gate"`` for merge-relevant review statuses,
+        ``"advisory"`` for informational review checks, or
+        ``"ci"`` for everything else (conservative default).
+    """
+    if name in REVIEW_GATE_CONTEXTS:
+        return "review_gate"
+    if name in ADVISORY_CONTEXTS:
+        return "advisory"
+    return "ci"
+
+
 # Default timeout (seconds) for gh CLI subprocess calls.
 # Operator surfaces must never hang indefinitely.
 GH_TIMEOUT_SECONDS: int = 30

--- a/src/bid_euchre/ops/ci.py
+++ b/src/bid_euchre/ops/ci.py
@@ -18,7 +18,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
-from bid_euchre.ops import DEFAULT_REVIEW_CONTEXTS, GH_TIMEOUT_SECONDS
+from bid_euchre.ops import GH_TIMEOUT_SECONDS, classify_check
 
 logger = logging.getLogger("ops.ci")
 
@@ -229,15 +229,16 @@ def classify_ci_failure(
 def poll_ci_status(
     pr_number: int,
     *,
-    review_contexts: tuple[str, ...] = DEFAULT_REVIEW_CONTEXTS,
+    review_contexts: tuple[str, ...] | None = None,
 ) -> CIStatusReport:
     """Poll CI status for a PR with per-check breakdown.
 
     Args:
         pr_number: GitHub PR number.
-        review_contexts: Check names to exclude from CI aggregation
-            (they represent review outcomes, not CI results). Uses the
-            same shared default as ``reviews.py``.
+        review_contexts: Explicit check names to exclude from CI aggregation.
+            When ``None`` (default), uses ``classify_check()`` to dynamically
+            identify non-CI checks. Pass an explicit tuple for backward
+            compatibility.
 
     Returns:
         CIStatusReport with overall status and per-check results.
@@ -283,8 +284,12 @@ def poll_ci_status(
             classifications=[],
         )
 
-    # Filter out review contexts to avoid counting review status as CI
-    ci_checks = [c for c in raw_checks if c.get("name") not in review_contexts]
+    # Filter out non-CI checks (review gate + advisory) to avoid counting
+    # review status or advisory infra failures as CI.
+    if review_contexts is not None:
+        ci_checks = [c for c in raw_checks if c.get("name") not in review_contexts]
+    else:
+        ci_checks = [c for c in raw_checks if classify_check(c.get("name", "")) == "ci"]
 
     check_results: list[CICheckResult] = []
     classifications: list[CIFailureClassification] = []

--- a/src/bid_euchre/ops/reviews.py
+++ b/src/bid_euchre/ops/reviews.py
@@ -15,7 +15,13 @@ import logging
 import subprocess
 from dataclasses import asdict, dataclass
 
-from bid_euchre.ops import DEFAULT_REVIEW_CONTEXTS, GH_TIMEOUT_SECONDS
+from bid_euchre.ops import (
+    ADVISORY_CONTEXTS,
+    DEFAULT_REVIEW_CONTEXTS,  # noqa: F401 — re-exported for backward compat
+    GH_TIMEOUT_SECONDS,
+    REVIEW_GATE_CONTEXTS,
+    classify_check,
+)
 
 logger = logging.getLogger("ops.reviews")
 
@@ -31,6 +37,7 @@ class ReviewOutcome:
     review_status: str  # "success", "failure", "pending", "none"
     has_precheck_ci: bool  # whether deterministic-prechecks check exists
     url: str
+    advisory_status: str = "none"  # "success", "failure", "pending", "none"
     checks: list[dict] | None = None  # per-check breakdown when available
 
     def to_dict(self) -> dict:
@@ -123,21 +130,29 @@ def _get_pr_checks(pr_number: int) -> list[dict]:
 
 def _classify_ci_status(
     checks: list[dict],
-    review_contexts: tuple[str, ...] = DEFAULT_REVIEW_CONTEXTS,
+    review_contexts: tuple[str, ...] | None = None,
 ) -> str:
     """Classify overall CI status from individual checks.
 
-    Excludes review-related status contexts to avoid circular dependency.
+    Excludes non-CI status contexts (review gate + advisory) to avoid
+    circular dependency and prevent advisory infra failures from poisoning
+    CI status.
 
     Args:
         checks: List of check dicts with ``name`` and ``state`` keys.
-        review_contexts: Check names to treat as review (not CI) statuses.
+        review_contexts: Explicit check names to exclude. When ``None``
+            (default), uses ``classify_check()`` to dynamically identify
+            non-CI checks. Pass an explicit tuple for backward compatibility.
 
     Returns:
         "success", "failure", "pending", or "unknown"
     """
-    # Filter out review statuses
-    ci_checks = [c for c in checks if c.get("name") not in review_contexts]
+    if review_contexts is not None:
+        # Backward-compatible: explicit exclusion list
+        ci_checks = [c for c in checks if c.get("name") not in review_contexts]
+    else:
+        # Default: use classify_check() to exclude all non-CI checks
+        ci_checks = [c for c in checks if classify_check(c.get("name", "")) == "ci"]
     if not ci_checks:
         return "pending"
 
@@ -154,7 +169,7 @@ def _classify_ci_status(
 
 def _get_review_status(
     checks: list[dict],
-    review_contexts: tuple[str, ...] = DEFAULT_REVIEW_CONTEXTS,
+    review_contexts: tuple[str, ...] = REVIEW_GATE_CONTEXTS,
 ) -> str:
     """Extract review status from recognized review contexts.
 
@@ -196,6 +211,38 @@ def _has_precheck_ci(checks: list[dict]) -> bool:
     )
 
 
+def _get_advisory_status(
+    checks: list[dict],
+    advisory_contexts: tuple[str, ...] = ADVISORY_CONTEXTS,
+) -> str:
+    """Extract advisory review status from recognized advisory contexts.
+
+    Same aggregation pattern as ``_get_review_status`` but filters on
+    ``ADVISORY_CONTEXTS`` (informational checks that must not block CI).
+
+    Args:
+        checks: List of check dicts with ``name`` and ``state`` keys.
+        advisory_contexts: Check names recognized as advisory outcomes.
+
+    Returns:
+        "success", "failure", "pending", or "none" (if no advisory context found).
+    """
+    states = [
+        check.get("state", "PENDING")
+        for check in checks
+        if check.get("name") in advisory_contexts
+    ]
+    if not states:
+        return "none"
+    if any(s == "FAILURE" for s in states):
+        return "failure"
+    if any(s in ("PENDING", "IN_PROGRESS") for s in states):
+        return "pending"
+    if all(s == "SUCCESS" for s in states):
+        return "success"
+    return "unknown"
+
+
 def get_open_pr_reviews() -> list[ReviewOutcome]:
     """Get review outcomes for all open PRs.
 
@@ -221,6 +268,7 @@ def get_open_pr_reviews() -> list[ReviewOutcome]:
                 review_status=_get_review_status(checks),
                 has_precheck_ci=_has_precheck_ci(checks),
                 url=pr.get("url", ""),
+                advisory_status=_get_advisory_status(checks),
                 checks=checks,
             )
         )
@@ -267,6 +315,7 @@ def get_pr_review_detail(pr_number: int) -> ReviewOutcome:
         review_status=_get_review_status(checks),
         has_precheck_ci=_has_precheck_ci(checks),
         url=pr.get("url", ""),
+        advisory_status=_get_advisory_status(checks),
         checks=checks,
     )
 
@@ -285,10 +334,13 @@ def format_reviews_text(outcomes: list[ReviewOutcome]) -> str:
         review_icon = {"success": "+", "failure": "x", "pending": "~"}.get(
             o.review_status, "-"
         )
+        advisory_icon = {"success": "+", "failure": "x", "pending": "~"}.get(
+            o.advisory_status, "-"
+        )
         precheck = "yes" if o.has_precheck_ci else "no"
         lines.append(
             f"  #{o.pr_number:<5d} CI=[{ci_icon}] Review=[{review_icon}] "
-            f"Precheck=[{precheck}]"
+            f"Advisory=[{advisory_icon}] Precheck=[{precheck}]"
         )
         lines.append(f"         {o.title}")
         lines.append(f"         {o.branch} | {o.url}")
@@ -307,6 +359,7 @@ def format_reviews_json(outcomes: list[ReviewOutcome]) -> list[dict]:
             "branch": o.branch,
             "ci_status": o.ci_status,
             "review_status": o.review_status,
+            "advisory_status": o.advisory_status,
             "has_precheck_ci": o.has_precheck_ci,
             "url": o.url,
         }

--- a/tests/unit/test_check_classifier.py
+++ b/tests/unit/test_check_classifier.py
@@ -1,0 +1,80 @@
+"""Tests for the three-category check classifier in ops/__init__.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from bid_euchre.ops import (
+    ADVISORY_CONTEXTS,
+    DEFAULT_REVIEW_CONTEXTS,
+    NON_CI_CONTEXTS,
+    REVIEW_GATE_CONTEXTS,
+    classify_check,
+)
+
+
+class TestClassifyCheck:
+    """Tests for classify_check()."""
+
+    def test_reviewing_changes_is_review_gate(self) -> None:
+        assert classify_check("reviewing-changes") == "review_gate"
+
+    def test_claude_review_is_advisory(self) -> None:
+        assert classify_check("claude-review") == "advisory"
+
+    def test_tests_is_ci(self) -> None:
+        assert classify_check("tests") == "ci"
+
+    def test_lint_is_ci(self) -> None:
+        assert classify_check("lint") == "ci"
+
+    def test_unknown_name_defaults_to_ci(self) -> None:
+        """Unknown check names must default to 'ci' (conservative)."""
+        assert classify_check("some-random-check") == "ci"
+
+    def test_empty_name_is_ci(self) -> None:
+        assert classify_check("") == "ci"
+
+
+class TestConstants:
+    """Tests for the check classification constants."""
+
+    def test_review_gate_contains_reviewing_changes(self) -> None:
+        assert "reviewing-changes" in REVIEW_GATE_CONTEXTS
+
+    def test_advisory_contains_claude_review(self) -> None:
+        assert "claude-review" in ADVISORY_CONTEXTS
+
+    def test_non_ci_is_union(self) -> None:
+        """NON_CI_CONTEXTS is the union of review gate + advisory."""
+        expected = set(REVIEW_GATE_CONTEXTS) | set(ADVISORY_CONTEXTS)
+        assert set(NON_CI_CONTEXTS) == expected
+
+    def test_review_gate_is_alias_for_default(self) -> None:
+        """REVIEW_GATE_CONTEXTS == DEFAULT_REVIEW_CONTEXTS (backward compat)."""
+        assert REVIEW_GATE_CONTEXTS == DEFAULT_REVIEW_CONTEXTS
+
+    def test_no_overlap_between_review_gate_and_advisory(self) -> None:
+        """Review gate and advisory must be disjoint categories."""
+        overlap = set(REVIEW_GATE_CONTEXTS) & set(ADVISORY_CONTEXTS)
+        assert overlap == set(), f"Unexpected overlap: {overlap}"
+
+
+class TestConsistencyWithGithubPrState:
+    """Verify github_pr_state.py CI allowlist excludes all non-CI contexts."""
+
+    def test_ci_allowlist_excludes_non_ci_contexts(self) -> None:
+        """The CI allowlist in scripts/internal must not contain any non-CI context."""
+        # Add scripts/internal to path for import
+        scripts_dir = Path(__file__).resolve().parents[2] / "scripts" / "internal"
+        sys.path.insert(0, str(scripts_dir))
+        try:
+            from github_pr_state import _CI_CHECK_NAMES
+
+            for ctx in NON_CI_CONTEXTS:
+                assert (
+                    ctx not in _CI_CHECK_NAMES
+                ), f"Non-CI context {ctx!r} found in _CI_CHECK_NAMES allowlist"
+        finally:
+            sys.path.pop(0)

--- a/tests/unit/test_ops_ci.py
+++ b/tests/unit/test_ops_ci.py
@@ -334,6 +334,48 @@ class TestPollCIStatus:
         assert report.overall == "pending"
 
     @patch("bid_euchre.ops.ci.subprocess.run")
+    def test_default_excludes_claude_review(self, mock_run: object) -> None:
+        """Default (None) excludes claude-review from CI checks."""
+        checks = [
+            {"name": "claude-review", "state": "FAILURE"},
+            {"name": "tests", "state": "SUCCESS"},
+        ]
+        mock_run.return_value = _mock_result(stdout=json.dumps(checks))
+
+        report = poll_ci_status(901)
+        assert report.overall == "success"
+        assert len(report.checks) == 1
+        assert report.checks[0].name == "tests"
+
+    @patch("bid_euchre.ops.ci.subprocess.run")
+    def test_default_excludes_both_non_ci(self, mock_run: object) -> None:
+        """Default excludes both reviewing-changes and claude-review."""
+        checks = [
+            {"name": "reviewing-changes", "state": "FAILURE"},
+            {"name": "claude-review", "state": "FAILURE"},
+            {"name": "tests", "state": "SUCCESS"},
+        ]
+        mock_run.return_value = _mock_result(stdout=json.dumps(checks))
+
+        report = poll_ci_status(902)
+        assert report.overall == "success"
+        assert len(report.checks) == 1
+
+    @patch("bid_euchre.ops.ci.subprocess.run")
+    def test_explicit_override_uses_old_logic(self, mock_run: object) -> None:
+        """Explicit review_contexts uses old exclusion logic."""
+        checks = [
+            {"name": "claude-review", "state": "FAILURE"},
+            {"name": "tests", "state": "SUCCESS"},
+        ]
+        mock_run.return_value = _mock_result(stdout=json.dumps(checks))
+
+        # Only excluding reviewing-changes, so claude-review counts as CI
+        report = poll_ci_status(903, review_contexts=("reviewing-changes",))
+        assert report.overall == "failure"
+        assert len(report.checks) == 2
+
+    @patch("bid_euchre.ops.ci.subprocess.run")
     def test_custom_review_context_excluded(self, mock_run: object) -> None:
         """Custom review contexts are excluded from CI checks."""
         checks = [

--- a/tests/unit/test_ops_reviews.py
+++ b/tests/unit/test_ops_reviews.py
@@ -12,6 +12,7 @@ from bid_euchre.ops.reviews import (
     DEFAULT_REVIEW_CONTEXTS,
     ReviewOutcome,
     _classify_ci_status,
+    _get_advisory_status,
     _get_review_status,
     _has_precheck_ci,
     format_reviews_json,
@@ -162,6 +163,48 @@ class TestGetReviewStatus:
         )
 
 
+class TestClassifyCIStatusDefaultExcludesAdvisory:
+    """Tests for _classify_ci_status() default excluding advisory checks."""
+
+    def test_default_excludes_claude_review(self) -> None:
+        """Default (None) excludes claude-review from CI status."""
+        checks = [
+            {"name": "claude-review", "state": "FAILURE"},
+            {"name": "tests", "state": "SUCCESS"},
+        ]
+        assert _classify_ci_status(checks) == "success"
+
+    def test_default_excludes_reviewing_changes(self) -> None:
+        """Default (None) still excludes reviewing-changes."""
+        checks = [
+            {"name": "reviewing-changes", "state": "FAILURE"},
+            {"name": "tests", "state": "SUCCESS"},
+        ]
+        assert _classify_ci_status(checks) == "success"
+
+    def test_default_excludes_both(self) -> None:
+        """Default (None) excludes both review gate and advisory."""
+        checks = [
+            {"name": "reviewing-changes", "state": "FAILURE"},
+            {"name": "claude-review", "state": "FAILURE"},
+            {"name": "tests", "state": "SUCCESS"},
+        ]
+        assert _classify_ci_status(checks) == "success"
+
+    def test_explicit_override_uses_old_logic(self) -> None:
+        """Explicit review_contexts uses the override, not classify_check."""
+        checks = [
+            {"name": "claude-review", "state": "FAILURE"},
+            {"name": "tests", "state": "SUCCESS"},
+        ]
+        # With explicit override that does NOT include claude-review,
+        # it should count as CI and cause failure.
+        assert (
+            _classify_ci_status(checks, review_contexts=("reviewing-changes",))
+            == "failure"
+        )
+
+
 class TestClassifyCIStatusCustomContexts:
     """Tests for _classify_ci_status() with custom review contexts."""
 
@@ -196,6 +239,32 @@ class TestHasPrecheckCI:
 
     def test_empty_checks(self) -> None:
         assert _has_precheck_ci([]) is False
+
+
+class TestGetAdvisoryStatus:
+    """Tests for _get_advisory_status()."""
+
+    def test_claude_review_success(self) -> None:
+        checks = [{"name": "claude-review", "state": "SUCCESS"}]
+        assert _get_advisory_status(checks) == "success"
+
+    def test_claude_review_failure(self) -> None:
+        checks = [{"name": "claude-review", "state": "FAILURE"}]
+        assert _get_advisory_status(checks) == "failure"
+
+    def test_claude_review_pending(self) -> None:
+        checks = [{"name": "claude-review", "state": "PENDING"}]
+        assert _get_advisory_status(checks) == "pending"
+
+    def test_no_advisory_checks_returns_none(self) -> None:
+        checks = [
+            {"name": "tests", "state": "SUCCESS"},
+            {"name": "reviewing-changes", "state": "SUCCESS"},
+        ]
+        assert _get_advisory_status(checks) == "none"
+
+    def test_empty_checks(self) -> None:
+        assert _get_advisory_status([]) == "none"
 
 
 # --- Integration tests with mocked gh ---
@@ -330,6 +399,57 @@ class TestGetOpenPRReviews:
         assert outcomes[0].ci_status == "failure"
         assert outcomes[0].review_status == "pending"
 
+    @patch("bid_euchre.ops.reviews._run_gh")
+    def test_advisory_status_populated(self, mock_gh: object) -> None:
+        """advisory_status is populated from claude-review check."""
+        pr_list = [
+            {
+                "number": 500,
+                "title": "PR with advisory",
+                "headRefName": "feat/d",
+                "url": "https://github.com/org/repo/pull/500",
+            }
+        ]
+        checks = [
+            {"name": "tests", "state": "SUCCESS"},
+            {"name": "reviewing-changes", "state": "SUCCESS"},
+            {"name": "claude-review", "state": "FAILURE"},
+        ]
+        mock_gh.side_effect = [
+            _mock_result(stdout=json.dumps(pr_list)),
+            _mock_result(stdout=json.dumps(checks)),
+        ]
+
+        outcomes = get_open_pr_reviews()
+        assert len(outcomes) == 1
+        assert outcomes[0].ci_status == "success"
+        assert outcomes[0].review_status == "success"
+        assert outcomes[0].advisory_status == "failure"
+
+    @patch("bid_euchre.ops.reviews._run_gh")
+    def test_advisory_status_none_when_absent(self, mock_gh: object) -> None:
+        """advisory_status is 'none' when no advisory check exists."""
+        pr_list = [
+            {
+                "number": 501,
+                "title": "PR without advisory",
+                "headRefName": "feat/e",
+                "url": "https://github.com/org/repo/pull/501",
+            }
+        ]
+        checks = [
+            {"name": "tests", "state": "SUCCESS"},
+            {"name": "reviewing-changes", "state": "SUCCESS"},
+        ]
+        mock_gh.side_effect = [
+            _mock_result(stdout=json.dumps(pr_list)),
+            _mock_result(stdout=json.dumps(checks)),
+        ]
+
+        outcomes = get_open_pr_reviews()
+        assert len(outcomes) == 1
+        assert outcomes[0].advisory_status == "none"
+
 
 class TestGetPRReviewDetail:
     """Tests for get_pr_review_detail() with mocked gh CLI."""
@@ -400,7 +520,24 @@ class TestFormatReviewsText:
         assert "feat/test" in text
         assert "CI=[+]" in text
         assert "Review=[~]" in text
+        assert "Advisory=[-]" in text  # default "none" → "-"
         assert "Precheck=[yes]" in text
+
+    def test_advisory_failure_icon(self) -> None:
+        outcomes = [
+            ReviewOutcome(
+                pr_number=99,
+                title="Advisory fail",
+                branch="b",
+                ci_status="success",
+                review_status="success",
+                has_precheck_ci=False,
+                url="u",
+                advisory_status="failure",
+            )
+        ]
+        text = format_reviews_text(outcomes)
+        assert "Advisory=[x]" in text
 
     def test_failure_icons(self) -> None:
         outcomes = [
@@ -440,5 +577,22 @@ class TestFormatReviewsJSON:
         result = format_reviews_json(outcomes)
         assert len(result) == 1
         assert result[0]["pr_number"] == 42
+        assert result[0]["advisory_status"] == "none"
         # Verify it's JSON-serializable
         json.dumps(result)
+
+    def test_advisory_status_in_json(self) -> None:
+        outcomes = [
+            ReviewOutcome(
+                pr_number=42,
+                title="Test",
+                branch="b",
+                ci_status="success",
+                review_status="success",
+                has_precheck_ci=False,
+                url="u",
+                advisory_status="failure",
+            )
+        ]
+        result = format_reviews_json(outcomes)
+        assert result[0]["advisory_status"] == "failure"


### PR DESCRIPTION
## Plan
`plans/sessions/2026-03-20_review-gate-claude-review-stabilizer.md`

## Summary
- Add three-category check classifier (`classify_check()`) to `ops/__init__.py` — categorizes GitHub checks as `ci`, `review_gate`, or `advisory`
- Update `ops/reviews.py` and `ops/ci.py` to use `classify_check()` by default, preventing `claude-review` infrastructure failures from poisoning CI status
- Add `advisory_status` field to `ReviewOutcome` with full formatter support

## Why
The `claude-review` GitHub Action (Claude Code Review) is advisory-only — it should never block CI or merge. Prior to #1017 (merged upstream), a `claude-review` failure could poison CI status in the ops modules (`reviews.py`, `ci.py`). While #1017 addressed this in `github_pr_state.py` via an allowlist approach, the ops modules still used the old `DEFAULT_REVIEW_CONTEXTS` tuple which only knew about `reviewing-changes`.

This PR introduces a proper three-category model in the ops layer:
- **`review_gate`**: merge-relevant review statuses (`reviewing-changes`)
- **`advisory`**: informational checks that must never poison CI (`claude-review`)
- **`ci`**: everything else (conservative default for unknown checks)

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest -q tests/unit/test_check_classifier.py tests/unit/test_ops_reviews.py tests/unit/test_ops_ci.py tests/unit/test_claude_review_workflow.py tests/unit/test_github_pr_state.py
# 167 passed

make check-quiet
# ✓ All checks passed
```

## Tests
- [x] `make check-quiet` passes
- [x] New `tests/unit/test_check_classifier.py` — 12 tests for classifier + constants + consistency
- [x] Extended `tests/unit/test_ops_reviews.py` — advisory status, default exclusion, formatter tests
- [x] Extended `tests/unit/test_ops_ci.py` — default exclusion, explicit override backward compat

## Expected impact
- Metrics impact: None (ops tooling only)
- Runtime impact: None

## Risk level
- [x] Low (ops tooling + tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d  40efca1 [fix/review-gate-separation]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)