### PR TITLE
docs: record review-gate stabilizer priority in agent ops plans

### DIFF
--- a/plans/agent_ops/0_bootstrap/checkpoints.md
+++ b/plans/agent_ops/0_bootstrap/checkpoints.md
@@ -12,7 +12,7 @@
 |------|--------|------|---------------|-------|
 | Step 0: Create governing-plan scaffold | COMPLETE | 2026-03-19 | Codex | Added canonical governing plan path, sub-plan registry, amendments log, and phase files. |
 | Step 1: Normalize discovery and references | COMPLETE | 2026-03-19 | Codex | Registered `agent_ops` in `CLAUDE.md` and updated plan references to the canonical governing-plan path. |
-| Step 2: Track Platform-1 entry criteria | IN_PROGRESS | 2026-03-19 | Codex | PR-5 slices 3-7 remain the main gate; any slice not yet complete must be explicitly recorded as non-blocking before Platform-1 should begin. |
+| Step 2: Track Platform-1 entry criteria | IN_PROGRESS | 2026-03-19 | Codex | PR-5 slices 3-7 remain the main gate; once slices 3 and 4 ship, prioritize the review-gate / `claude-review` reliability stabilizer before additional high-churn rollout work if auto-merge remains enabled. Any slice not yet complete must be explicitly recorded as non-blocking before Platform-1 should begin. |
 | Step 3: Open Platform-1 implementation handoff / sub-plan | PENDING | -- | -- | Create the first execution handoff once Step 2 is clear. |
 
 **Status values:** `PENDING`, `IN_PROGRESS`, `COMPLETE`, `BLOCKED`, `SKIPPED`
@@ -27,6 +27,9 @@
 - [ ] PR-5 slices 3-7 are not yet all complete; Platform-1 should not begin
   until the remaining slices are either complete or explicitly recorded as
   non-blocking in the governing-plan entry criteria.
+- [ ] After slices 3 and 4 land, ship the review-gate / `claude-review`
+  reliability stabilizer before resuming additional high-churn rollout work if
+  auto-merge remains enabled.
 
 ## Session Log
 
@@ -35,5 +38,8 @@
   `CLAUDE.md` registration for `agent_ops`.
 - In progress: Platform-1 entry criteria remain gated on PR-5 slices 3-7,
   unless remaining items are explicitly recorded as non-blocking.
+- Added priority note: once slices 3 and 4 ship, take the review-gate /
+  `claude-review` stabilizer next to reduce auto-merge churn before the rest
+  of PR-5 and the governed platform work.
 - Next: finish PR-5 closeout, then open the first Platform-1 execution
   handoff or sub-plan under the governed initiative.

--- a/plans/sessions/2026-03-15_autonomous-agent-ops-workflow.md
+++ b/plans/sessions/2026-03-15_autonomous-agent-ops-workflow.md
@@ -768,6 +768,14 @@ follow-on governed orchestration platform becomes the main line of work.
 The following may need to interleave opportunistically if they block trusted
 operator use during PR-5:
 
+- **Immediate post-slices 3/4 priority:** review-gate semantics /
+  `claude-review` reliability fix. Once slices 3 and 4 ship, take a small
+  stabilizer PR that:
+  - keeps `get_ci_status()` limited to true CI/build/governance checks
+  - stops `claude-review` infra failure from masquerading as CI failure
+  - keeps review findings distinct from reviewer-service-health failures
+  - preserves a clear merge-relevant review gate while reducing auto-merge
+    churn during the rest of the refactor arc
 - worktree registry/bootstrap fixes
 - main-checkout exemption in worktree prune/quarantine flows
 - review/CI process fixes such as issue `#987`
@@ -775,12 +783,23 @@ operator use during PR-5:
 These should stay small and focused; do not fold them into large PR-5 slices
 unless they are inseparable from the capability being shipped.
 
+Recommended sequencing:
+
+1. finish `PR-5 slice 3`
+2. finish `PR-5 slice 4`
+3. land the review-gate / `claude-review` stabilizer
+4. continue with `PR-5 slice 5` through `PR-5 slice 7`
+
 ##### Practical delivery expectation
 
 At current shipping rates, the **remaining PR-5 closeout stack** is the part
 that can plausibly be pushed through in roughly one to two focused days if
 review churn stays low. The follow-on governed initiative is intentionally a
 larger multi-PR platform effort and should not be treated as a same-day stack.
+
+If auto-merge remains enabled, treat the review-gate / `claude-review`
+stabilizer as the next reliability slice after 3/4, because it improves the
+delivery substrate for the rest of PR-5 and the governed follow-on work.
 
 > **User migration note:** The explicit schedule for when the user should
 > change day-to-day workflow (existing steward layout -> dashboard-first ->


### PR DESCRIPTION
## Summary

- **`plans/agent_ops/0_bootstrap/checkpoints.md`**: Updated Phase 0 Step 2 notes and open-items list to record that the review-gate / `claude-review` reliability stabilizer should ship immediately after slices 3 and 4, before continuing PR-5 slices 5-7.
- **`plans/sessions/2026-03-15_autonomous-agent-ops-workflow.md`**: Added recommended sequencing (slices 3 -> 4 -> stabilizer -> 5-7) and priority rationale in the interleaving-opportunities and delivery-expectations sections.

## Why

These are progress notes capturing a priority decision: the review-gate stabilizer improves the delivery substrate for all subsequent work, so it should land before additional high-churn rollout slices.

## Validation

Docs-only change -- no code, no tests affected. Two markdown plan files updated.

## Worktree proof

Branch: `docs/review-gate-stabilizer-priority`
Worktree: `.claude/worktrees/agent-acf94270`