### PR TITLE
ops: stabilize lane activity and current-work status

### DIFF
--- a/src/bid_euchre/ops/status.py
+++ b/src/bid_euchre/ops/status.py
@@ -66,6 +66,10 @@ class LaneStatus:
     attention_needed: bool = False
     attention_reason: str | None = None
 
+    # --- Event context (enriched from durable event log) ---
+    last_event_type: str | None = None
+    last_event_at: str | None = None
+
 
 @dataclass
 class StatusReport:
@@ -242,6 +246,8 @@ def _derive_current_step(task: dict[str, Any]) -> str | None:
         in_prog = [item for item in items if item.get("status") == "in_progress"]
         if in_prog:
             return f"step {done + 1}/{total}: {in_prog[0].get('description', '?')}"
+        if done == total:
+            return f"all {total} steps done"
         if done > 0:
             return f"step {done}/{total}"
 
@@ -272,6 +278,27 @@ def _find_pr_from_events(
             pr = payload.get("pr_number")
             if isinstance(pr, int):
                 return pr
+    return None
+
+
+def _find_last_event_for_lane(
+    events: list[dict[str, Any]],
+    lane_id: str,
+) -> dict[str, Any] | None:
+    """Find the most recent event for a given lane.
+
+    Scans events (assumed most-recent-first) and returns the first match.
+
+    Args:
+        events: List of event dicts, most recent first.
+        lane_id: Lane to filter by.
+
+    Returns:
+        The most recent event dict for the lane, or None.
+    """
+    for event in events:
+        if event.get("lane_id") == lane_id:
+            return event
     return None
 
 
@@ -428,7 +455,15 @@ def synthesize_lane_activity(
         if linked_pr is None:
             linked_pr = _find_pr_from_events(events, lane_id)
 
-        # Last progress: best available timestamp
+        # Event context: most recent event for this lane
+        last_event = _find_last_event_for_lane(events, lane_id)
+        last_event_type: str | None = None
+        last_event_at: str | None = None
+        if last_event:
+            last_event_type = last_event.get("event_type")
+            last_event_at = last_event.get("timestamp")
+
+        # Last progress: best available timestamp from all sources
         last_progress_candidates: list[str] = []
         if primary_task:
             prog = primary_task.get("progress")
@@ -443,6 +478,10 @@ def synthesize_lane_activity(
         last_active_ts = lane.get("last_active")
         if last_active_ts:
             last_progress_candidates.append(last_active_ts)
+        # Include event timestamp — events may be more recent than
+        # session/registry timestamps for lanes that have finished work.
+        if last_event_at:
+            last_progress_candidates.append(last_event_at)
 
         last_progress = _max_timestamp(last_progress_candidates)
 
@@ -482,6 +521,8 @@ def synthesize_lane_activity(
             last_progress=last_progress,
             attention_needed=attention_needed,
             attention_reason=attention_reason,
+            last_event_type=last_event_type,
+            last_event_at=last_event_at,
         )
         results.append(lane_status)
 
@@ -617,28 +658,97 @@ def _format_time_short(ts: str | None) -> str:
     return dt.strftime("%H:%M")
 
 
-def format_status_text(report: StatusReport) -> str:
+def _format_relative_time(
+    ts: str | None,
+    *,
+    now: datetime | None = None,
+) -> str:
+    """Format a timestamp as a human-readable relative time.
+
+    Produces output like ``"5m ago"``, ``"2h ago"``, ``"1d ago"``, or
+    ``"3d+"`` for longer durations. Falls back to ``"—"`` if the
+    timestamp is missing or unparseable.
+
+    Args:
+        ts: ISO 8601 timestamp string.
+        now: Current time for relative computation (default: UTC now).
+
+    Returns:
+        Short relative time string.
+    """
+    if not ts:
+        return "—"
+    dt = _parse_iso_timestamp(ts)
+    if dt is None:
+        return "—"
+    if now is None:
+        now = datetime.now(timezone.utc)
+    delta_seconds = (now - dt).total_seconds()
+    if delta_seconds < 0:
+        return "now"
+    minutes = int(delta_seconds / 60)
+    if minutes < 1:
+        return "now"
+    if minutes < 60:
+        return f"{minutes}m ago"
+    hours = minutes // 60
+    if hours < 24:
+        return f"{hours}h ago"
+    days = hours // 24
+    if days <= 3:
+        return f"{days}d ago"
+    return f"{days}d+"
+
+
+def _branch_short(branch: str) -> str:
+    """Shorten a branch name for display.
+
+    Strips common prefixes like ``codex/steward-`` to save horizontal space.
+    """
+    for prefix in ("codex/steward-", "codex/", "refs/heads/"):
+        if branch.startswith(prefix):
+            return branch[len(prefix) :]
+    return branch
+
+
+def format_status_text(
+    report: StatusReport,
+    *,
+    now: datetime | None = None,
+) -> str:
     """Format a StatusReport as human-readable text.
 
     Args:
         report: The status report to format.
+        now: Current time for relative timestamps (default: UTC now).
 
     Returns:
         Multi-line text summary.
     """
+    if now is None:
+        now = datetime.now(timezone.utc)
+
     lines: list[str] = []
     lines.append("=== Steward Status ===")
     lines.append("")
 
-    # Lane Activity
-    lines.append(f"Lane Activity: {len(report.lanes)}")
+    # Lane Activity — summary line with state counts
+    state_counts: dict[str, int] = {}
+    for lane in report.lanes:
+        state_counts[lane.state] = state_counts.get(lane.state, 0) + 1
+    summary_parts = [
+        f"{count} {state}" for state, count in sorted(state_counts.items())
+    ]
+    summary_str = ", ".join(summary_parts) if summary_parts else "none"
+    lines.append(f"Lane Activity: {len(report.lanes)} lanes ({summary_str})")
+
     for lane in report.lanes:
         # State badge
         state_badge = f"[{lane.state}]"
         if lane.attention_needed:
             state_badge = f"[{lane.state}!]"
 
-        # Task info
+        # Task info — prefer specific task, fall back to session, then branch
         if lane.current_task_title:
             task_info = lane.current_task_title
             if lane.current_step:
@@ -647,23 +757,30 @@ def format_status_text(report: StatusReport) -> str:
             task_info = lane.session_task
         elif lane.session_task:
             task_info = f"idle, last: {lane.session_task}"
+        elif lane.last_event_type:
+            task_info = f"idle, last event: {lane.last_event_type}"
         else:
             task_info = "—"
+
+        # Branch info — always show for orientation
+        branch_short = _branch_short(lane.branch) if lane.branch else ""
+        branch_info = f"  @{branch_short}" if branch_short else ""
 
         # PR info
         pr_info = f"  PR #{lane.linked_pr}" if lane.linked_pr else ""
 
-        # Time
-        time_info = f"  {_format_time_short(lane.last_progress)}"
+        # Time — show relative for quick scanning
+        time_info = f"  {_format_relative_time(lane.last_progress, now=now)}"
 
         lines.append(
-            f"  {lane.lane_id:15s} {state_badge:12s} {task_info}{pr_info}{time_info}"
+            f"  {lane.lane_id:15s} {state_badge:12s} "
+            f"{task_info}{pr_info}{branch_info}{time_info}"
         )
 
     lines.append("")
 
     # Attention items
-    attention_lanes = [l for l in report.lanes if l.attention_needed]
+    attention_lanes = [lane for lane in report.lanes if lane.attention_needed]
     if attention_lanes:
         lines.append(f"Attention: {len(attention_lanes)}")
         for lane in attention_lanes:
@@ -706,13 +823,30 @@ def format_status_text(report: StatusReport) -> str:
 def format_status_json(report: StatusReport) -> dict[str, Any]:
     """Format a StatusReport as a JSON-serializable dict.
 
+    Includes a ``summary`` block with state/task counts and a generation
+    timestamp for downstream tooling stability.
+
     Args:
         report: The status report to format.
 
     Returns:
         Dict suitable for JSON serialization.
     """
+    # Compute state counts for summary
+    state_counts: dict[str, int] = {}
+    for lane in report.lanes:
+        state_counts[lane.state] = state_counts.get(lane.state, 0) + 1
+
     return {
+        "summary": {
+            "total_lanes": len(report.lanes),
+            "lanes_by_state": state_counts,
+            "active_tasks": len(report.active_tasks),
+            "blocked_tasks": len(report.blocked_tasks),
+            "completed_tasks": len(report.completed_tasks),
+            "warnings": len(report.warnings),
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+        },
         "lanes": [
             {
                 "lane_id": lane.lane_id,
@@ -732,6 +866,8 @@ def format_status_json(report: StatusReport) -> dict[str, Any]:
                 "has_active_session": lane.has_active_session,
                 "session_task": lane.session_task,
                 "last_checkpoint": lane.last_checkpoint,
+                "last_event_type": lane.last_event_type,
+                "last_event_at": lane.last_event_at,
             }
             for lane in report.lanes
         ],

--- a/tests/unit/test_ops_status.py
+++ b/tests/unit/test_ops_status.py
@@ -12,6 +12,10 @@ from bid_euchre.ops.status import (
     STALE_MINUTES,
     LaneStatus,
     StatusReport,
+    _branch_short,
+    _derive_current_step,
+    _find_last_event_for_lane,
+    _format_relative_time,
     aggregate_status,
     emit_scope_snapshot,
     format_status_json,
@@ -1229,6 +1233,603 @@ class TestAggregateStatusLaneActivity:
 
         report = aggregate_status(runtime_dir)
         assert report.lanes[0].linked_pr == 982
+
+
+# ---- New helpers and enrichment tests ----
+
+
+class TestDeriveCurrentStepAllDone:
+    """Tests for _derive_current_step when all items completed."""
+
+    def test_all_items_completed(self) -> None:
+        """All items completed → 'all N steps done'."""
+        task = {
+            "items": [
+                {"id": 1, "description": "Step A", "status": "completed"},
+                {"id": 2, "description": "Step B", "status": "completed"},
+                {"id": 3, "description": "Step C", "status": "completed"},
+            ],
+        }
+        assert _derive_current_step(task) == "all 3 steps done"
+
+    def test_single_item_completed(self) -> None:
+        task = {"items": [{"id": 1, "description": "Only step", "status": "completed"}]}
+        assert _derive_current_step(task) == "all 1 steps done"
+
+    def test_no_items_returns_none(self) -> None:
+        task = {"items": []}
+        assert _derive_current_step(task) is None
+
+    def test_progress_field_takes_precedence_over_all_done(self) -> None:
+        """Explicit progress note wins over checklist summary."""
+        task = {
+            "progress": {"last_completed_item": "Manual override note"},
+            "items": [
+                {"id": 1, "description": "Step", "status": "completed"},
+            ],
+        }
+        assert _derive_current_step(task) == "Manual override note"
+
+
+class TestFindLastEventForLane:
+    """Tests for _find_last_event_for_lane()."""
+
+    def test_finds_matching_lane(self) -> None:
+        events = [
+            {"lane_id": "author-a", "event_type": "ci_success", "timestamp": "T2"},
+            {"lane_id": "author-b", "event_type": "ci_failure", "timestamp": "T1"},
+        ]
+        result = _find_last_event_for_lane(events, "author-a")
+        assert result is not None
+        assert result["event_type"] == "ci_success"
+
+    def test_returns_first_match_most_recent(self) -> None:
+        """Events are most-recent-first, so first match is latest."""
+        events = [
+            {"lane_id": "ops", "event_type": "task_completed", "timestamp": "T3"},
+            {"lane_id": "ops", "event_type": "ci_success", "timestamp": "T2"},
+        ]
+        result = _find_last_event_for_lane(events, "ops")
+        assert result is not None
+        assert result["event_type"] == "task_completed"
+
+    def test_no_match_returns_none(self) -> None:
+        events = [
+            {"lane_id": "author-a", "event_type": "ci_success"},
+        ]
+        assert _find_last_event_for_lane(events, "ops") is None
+
+    def test_empty_events(self) -> None:
+        assert _find_last_event_for_lane([], "author-a") is None
+
+
+class TestFormatRelativeTime:
+    """Tests for _format_relative_time()."""
+
+    def test_minutes(self) -> None:
+        now = datetime(2026, 3, 19, 15, 0, 0, tzinfo=timezone.utc)
+        assert _format_relative_time("2026-03-19T14:55:00+00:00", now=now) == "5m ago"
+
+    def test_hours(self) -> None:
+        now = datetime(2026, 3, 19, 15, 0, 0, tzinfo=timezone.utc)
+        assert _format_relative_time("2026-03-19T13:00:00+00:00", now=now) == "2h ago"
+
+    def test_days(self) -> None:
+        now = datetime(2026, 3, 19, 15, 0, 0, tzinfo=timezone.utc)
+        assert _format_relative_time("2026-03-17T15:00:00+00:00", now=now) == "2d ago"
+
+    def test_days_plus(self) -> None:
+        now = datetime(2026, 3, 19, 15, 0, 0, tzinfo=timezone.utc)
+        assert _format_relative_time("2026-03-10T15:00:00+00:00", now=now) == "9d+"
+
+    def test_now(self) -> None:
+        now = datetime(2026, 3, 19, 15, 0, 0, tzinfo=timezone.utc)
+        assert _format_relative_time("2026-03-19T14:59:50+00:00", now=now) == "now"
+
+    def test_future(self) -> None:
+        now = datetime(2026, 3, 19, 15, 0, 0, tzinfo=timezone.utc)
+        assert _format_relative_time("2026-03-19T16:00:00+00:00", now=now) == "now"
+
+    def test_none_returns_dash(self) -> None:
+        assert _format_relative_time(None) == "—"
+
+    def test_garbage_returns_dash(self) -> None:
+        assert _format_relative_time("not-a-time") == "—"
+
+
+class TestBranchShort:
+    """Tests for _branch_short()."""
+
+    def test_strips_codex_steward_prefix(self) -> None:
+        assert _branch_short("codex/steward-author") == "author"
+
+    def test_strips_codex_prefix(self) -> None:
+        assert _branch_short("codex/some-branch") == "some-branch"
+
+    def test_strips_refs_heads_prefix(self) -> None:
+        assert _branch_short("refs/heads/main") == "main"
+
+    def test_no_prefix(self) -> None:
+        assert _branch_short("feature/my-branch") == "feature/my-branch"
+
+    def test_empty(self) -> None:
+        assert _branch_short("") == ""
+
+
+class TestSynthesizeLaneActivityEventEnrichment:
+    """Tests for event-enriched lane activity fields."""
+
+    def test_event_context_populated(self) -> None:
+        """Last event type and timestamp are populated per lane."""
+        lanes = [_make_lane("author-a", session_id="s1")]
+        sessions = {"author-a": {"task": "Work", "started_at": "2026-03-19T10:00:00Z"}}
+        events = [
+            {
+                "lane_id": "author-a",
+                "event_type": "ci_success",
+                "timestamp": "2026-03-19T10:05:00Z",
+                "payload": {},
+            },
+        ]
+
+        result = synthesize_lane_activity(lanes, sessions, {}, events)
+        lane = result[0]
+        assert lane.last_event_type == "ci_success"
+        assert lane.last_event_at == "2026-03-19T10:05:00Z"
+
+    def test_no_events_for_lane(self) -> None:
+        """Lane with no matching events → event fields are None."""
+        lanes = [_make_lane("author-a", session_id="s1")]
+        sessions = {"author-a": {"task": "Work", "started_at": "2026-03-19T10:00:00Z"}}
+        events = [
+            {"lane_id": "ops", "event_type": "scheduler_tick", "timestamp": "T1"},
+        ]
+
+        result = synthesize_lane_activity(lanes, sessions, {}, events)
+        lane = result[0]
+        assert lane.last_event_type is None
+        assert lane.last_event_at is None
+
+    def test_event_timestamp_enriches_last_progress(self) -> None:
+        """Event timestamp is used in last_progress when it's the most recent."""
+        now = datetime(2026, 3, 19, 16, 0, 0, tzinfo=timezone.utc)
+        # Session started at 14:00, event at 15:30 — event is more recent
+        lanes = [_make_lane("author-a", session_id="s1")]
+        sessions = {
+            "author-a": {"task": "Work", "started_at": "2026-03-19T14:00:00+00:00"}
+        }
+        events = [
+            {
+                "lane_id": "author-a",
+                "event_type": "ci_success",
+                "timestamp": "2026-03-19T15:30:00+00:00",
+                "payload": {},
+            },
+        ]
+
+        result = synthesize_lane_activity(lanes, sessions, {}, events, now=now)
+        lane = result[0]
+        # Event timestamp (15:30) is later than session started_at (14:00)
+        assert lane.last_progress == "2026-03-19T15:30:00+00:00"
+
+    def test_idle_lane_with_event_shows_event_context(self) -> None:
+        """Idle lane with no session but with events → shows last event type."""
+        now = datetime(2026, 3, 19, 16, 0, 0, tzinfo=timezone.utc)
+        lanes = [_make_lane("author-b", lifecycle_class="ephemeral")]
+        events = [
+            {
+                "lane_id": "author-b",
+                "event_type": "task_completed",
+                "timestamp": "2026-03-19T15:00:00+00:00",
+                "payload": {},
+            },
+        ]
+
+        result = synthesize_lane_activity(lanes, {}, {}, events, now=now)
+        lane = result[0]
+        assert lane.state == "idle"
+        assert lane.last_event_type == "task_completed"
+        # Event timestamp used for last_progress
+        assert lane.last_progress == "2026-03-19T15:00:00+00:00"
+
+
+class TestMixedRuntimeStatesIntegration:
+    """Integration test: multiple lanes with varied states and partial data."""
+
+    def test_multi_lane_mixed_states(self, runtime_dir: Path) -> None:
+        """5 lanes: active+task, active+no-task, blocked, idle+session, idle+no-data."""
+        recent = datetime.now(timezone.utc).isoformat()
+
+        # Lane 1: active with task and PR
+        _write_json(
+            runtime_dir / "worktree_registry",
+            "author-a.json",
+            {
+                "schema_version": 2,
+                "lane_id": "author-a",
+                "lane_class": "author",
+                "worktree_path": "/tmp/wt-a",
+                "branch": "codex/steward-author",
+                "class": "persistent",
+                "session_id": "uuid-a",
+                "last_active": recent,
+            },
+        )
+        _write_json(
+            runtime_dir / "session_metadata",
+            "session-a.json",
+            {
+                "schema_version": 2,
+                "session_id": "uuid-a",
+                "lane_id": "author-a",
+                "started_at": recent,
+                "task": "Implement lane activity",
+            },
+        )
+        _write_json(
+            runtime_dir / "task_state",
+            "t-a.json",
+            {
+                "schema_version": 2,
+                "task_id": "t-a",
+                "owner_lane": "author-a",
+                "subject": "Implement lane activity",
+                "status": "in_progress",
+                "pr_number": 1025,
+                "items": [
+                    {"id": 1, "description": "Code", "status": "completed"},
+                    {"id": 2, "description": "Test", "status": "in_progress"},
+                ],
+                "blocked_by": [],
+            },
+        )
+
+        # Lane 2: active session, no task (ops monitoring)
+        _write_json(
+            runtime_dir / "worktree_registry",
+            "ops.json",
+            {
+                "schema_version": 2,
+                "lane_id": "ops",
+                "lane_class": "ops",
+                "worktree_path": "/tmp/wt-ops",
+                "branch": "codex/steward-ops",
+                "class": "persistent",
+                "session_id": "uuid-ops",
+                "last_active": recent,
+            },
+        )
+        _write_json(
+            runtime_dir / "session_metadata",
+            "session-ops.json",
+            {
+                "schema_version": 2,
+                "session_id": "uuid-ops",
+                "lane_id": "ops",
+                "started_at": recent,
+                "task": "Daily monitoring",
+            },
+        )
+
+        # Lane 3: blocked task
+        _write_json(
+            runtime_dir / "worktree_registry",
+            "author-b.json",
+            {
+                "schema_version": 2,
+                "lane_id": "author-b",
+                "lane_class": "author",
+                "worktree_path": "/tmp/wt-b",
+                "branch": "codex/steward-author-b",
+                "class": "persistent",
+                "session_id": "uuid-b",
+                "last_active": recent,
+            },
+        )
+        _write_json(
+            runtime_dir / "task_state",
+            "t-b.json",
+            {
+                "schema_version": 2,
+                "task_id": "t-b",
+                "owner_lane": "author-b",
+                "subject": "Blocked on CI",
+                "status": "blocked",
+                "blocked_by": ["CI red on main"],
+                "items": [],
+            },
+        )
+
+        # Lane 4: idle persistent with old session (no active session_id)
+        _write_json(
+            runtime_dir / "worktree_registry",
+            "review.json",
+            {
+                "schema_version": 2,
+                "lane_id": "review",
+                "lane_class": "review",
+                "worktree_path": "/tmp/wt-review",
+                "branch": "codex/steward-review",
+                "class": "persistent",
+                "session_id": None,
+                "last_active": "2026-03-19T10:00:00Z",
+            },
+        )
+        _write_json(
+            runtime_dir / "session_metadata",
+            "session-review-old.json",
+            {
+                "schema_version": 2,
+                "session_id": "old-review",
+                "lane_id": "review",
+                "started_at": "2026-03-19T10:00:00Z",
+                "task": "Previous review",
+            },
+        )
+
+        # Lane 5: idle ephemeral with no data at all
+        _write_json(
+            runtime_dir / "worktree_registry",
+            "work-123.json",
+            {
+                "schema_version": 2,
+                "lane_id": "work-123",
+                "lane_class": "author",
+                "worktree_path": "/tmp/wt-work-123",
+                "branch": "work-20260319-123",
+                "class": "ephemeral",
+                "session_id": None,
+                "last_active": None,
+            },
+        )
+
+        # Add an event for author-a
+        event_line = json.dumps(
+            {
+                "event_type": "ci_success",
+                "lane_id": "author-a",
+                "payload": {"pr_number": 1025},
+                "timestamp": recent,
+            }
+        )
+        (runtime_dir / "events" / "events.jsonl").write_text(event_line + "\n")
+
+        report = aggregate_status(runtime_dir)
+
+        # Verify all 5 lanes present
+        assert len(report.lanes) == 5
+        by_id = {lane.lane_id: lane for lane in report.lanes}
+
+        # Lane 1: active with task
+        assert by_id["author-a"].state == "active"
+        assert by_id["author-a"].current_task_id == "t-a"
+        assert by_id["author-a"].current_task_title == "Implement lane activity"
+        assert by_id["author-a"].current_step == "step 2/2: Test"
+        assert by_id["author-a"].linked_pr == 1025
+        assert by_id["author-a"].last_event_type == "ci_success"
+        assert by_id["author-a"].attention_needed is False
+
+        # Lane 2: active ops
+        assert by_id["ops"].state == "active"
+        assert by_id["ops"].current_task_id is None
+        assert by_id["ops"].session_task == "Daily monitoring"
+
+        # Lane 3: blocked
+        assert by_id["author-b"].state == "blocked"
+        assert by_id["author-b"].attention_needed is True
+        assert "CI red" in (by_id["author-b"].attention_reason or "")
+
+        # Lane 4: idle persistent → attention needed
+        assert by_id["review"].state == "idle"
+        assert by_id["review"].attention_needed is True
+        assert by_id["review"].session_task == "Previous review"
+
+        # Lane 5: idle ephemeral → no attention
+        assert by_id["work-123"].state == "idle"
+        assert by_id["work-123"].attention_needed is False
+        assert by_id["work-123"].last_event_type is None
+
+        # Verify JSON output includes summary
+        data = format_status_json(report)
+        assert "summary" in data
+        assert data["summary"]["total_lanes"] == 5
+        assert data["summary"]["lanes_by_state"]["active"] == 2
+        assert data["summary"]["lanes_by_state"]["blocked"] == 1
+        assert data["summary"]["lanes_by_state"]["idle"] == 2
+        assert data["summary"]["active_tasks"] == len(report.active_tasks)
+        assert "generated_at" in data["summary"]
+
+        # Verify JSON includes event fields
+        lane_a_json = next(l for l in data["lanes"] if l["lane_id"] == "author-a")
+        assert lane_a_json["last_event_type"] == "ci_success"
+        assert lane_a_json["last_event_at"] is not None
+
+        # Verify text output includes state summary, branch info, and relative time
+        text = format_status_text(report)
+        assert "lanes (" in text
+        assert "2 active" in text
+        assert "1 blocked" in text
+        assert "2 idle" in text
+        assert "@author" in text  # branch shortening
+        assert "Attention:" in text
+        assert "Blocked on CI" in text
+
+
+class TestJsonOutputStability:
+    """Tests that JSON output has a stable, useful schema for tooling."""
+
+    def test_empty_report_json_schema(self) -> None:
+        """Empty report produces a complete, well-formed JSON structure."""
+        report = StatusReport()
+        data = format_status_json(report)
+
+        # Top-level keys are always present
+        assert set(data.keys()) == {
+            "summary",
+            "lanes",
+            "active_tasks",
+            "blocked_tasks",
+            "completed_tasks",
+            "warnings",
+        }
+
+        # Summary always present with stable fields
+        summary = data["summary"]
+        assert isinstance(summary["total_lanes"], int)
+        assert isinstance(summary["lanes_by_state"], dict)
+        assert isinstance(summary["active_tasks"], int)
+        assert isinstance(summary["blocked_tasks"], int)
+        assert isinstance(summary["completed_tasks"], int)
+        assert isinstance(summary["warnings"], int)
+        assert isinstance(summary["generated_at"], str)
+
+    def test_lane_json_has_all_fields(self) -> None:
+        """Every lane entry in JSON has the complete field set."""
+        lane = LaneStatus(
+            lane_id="author-a",
+            lane_class="author",
+            worktree_path="/tmp/wt-a",
+            branch="codex/steward-author",
+            lifecycle_class="persistent",
+            has_active_session=True,
+            state="active",
+            last_event_type="ci_success",
+            last_event_at="2026-03-19T15:00:00Z",
+        )
+        report = StatusReport(lanes=[lane])
+        data = format_status_json(report)
+        lane_json = data["lanes"][0]
+
+        expected_fields = {
+            "lane_id",
+            "lane_class",
+            "state",
+            "current_task_id",
+            "current_task_title",
+            "current_step",
+            "linked_pr",
+            "last_progress",
+            "last_active",
+            "attention_needed",
+            "attention_reason",
+            "worktree_path",
+            "branch",
+            "lifecycle_class",
+            "has_active_session",
+            "session_task",
+            "last_checkpoint",
+            "last_event_type",
+            "last_event_at",
+        }
+        assert set(lane_json.keys()) == expected_fields
+        assert lane_json["last_event_type"] == "ci_success"
+        assert lane_json["last_event_at"] == "2026-03-19T15:00:00Z"
+
+
+class TestTextOutputEnhancements:
+    """Tests for the improved text output format."""
+
+    def test_state_summary_in_header(self) -> None:
+        """Header line includes lane count and state breakdown."""
+        lanes = [
+            LaneStatus(
+                lane_id="a",
+                lane_class="author",
+                worktree_path="/tmp/a",
+                branch="b",
+                lifecycle_class="persistent",
+                has_active_session=True,
+                state="active",
+            ),
+            LaneStatus(
+                lane_id="b",
+                lane_class="author",
+                worktree_path="/tmp/b",
+                branch="b2",
+                lifecycle_class="persistent",
+                has_active_session=False,
+                state="idle",
+                attention_needed=True,
+                attention_reason="idle",
+            ),
+        ]
+        report = StatusReport(lanes=lanes)
+        text = format_status_text(report)
+        assert "2 lanes" in text
+        assert "1 active" in text
+        assert "1 idle" in text
+
+    def test_branch_info_in_lane_row(self) -> None:
+        """Lane row includes shortened branch name."""
+        lane = LaneStatus(
+            lane_id="author-a",
+            lane_class="author",
+            worktree_path="/tmp/wt-a",
+            branch="codex/steward-author",
+            lifecycle_class="persistent",
+            has_active_session=True,
+            state="active",
+        )
+        report = StatusReport(lanes=[lane])
+        text = format_status_text(report)
+        assert "@author" in text
+
+    def test_relative_time_in_lane_row(self) -> None:
+        """Lane row shows relative time instead of absolute HH:MM."""
+        now = datetime(2026, 3, 19, 15, 0, 0, tzinfo=timezone.utc)
+        lane = LaneStatus(
+            lane_id="author-a",
+            lane_class="author",
+            worktree_path="/tmp/wt-a",
+            branch="b",
+            lifecycle_class="persistent",
+            has_active_session=True,
+            state="active",
+            last_progress="2026-03-19T14:45:00+00:00",
+        )
+        report = StatusReport(lanes=[lane])
+        text = format_status_text(report, now=now)
+        assert "15m ago" in text
+
+    def test_idle_lane_with_event_context(self) -> None:
+        """Idle lane with no session but event → shows last event type."""
+        lane = LaneStatus(
+            lane_id="work-123",
+            lane_class="author",
+            worktree_path="/tmp/wt-w",
+            branch="work-branch",
+            lifecycle_class="ephemeral",
+            has_active_session=False,
+            state="idle",
+            last_event_type="task_completed",
+        )
+        report = StatusReport(lanes=[lane])
+        text = format_status_text(report)
+        assert "idle, last event: task_completed" in text
+
+    def test_idle_lane_with_session_shows_last_task(self) -> None:
+        """Idle lane with preserved session → shows 'idle, last: task'."""
+        lane = LaneStatus(
+            lane_id="review",
+            lane_class="review",
+            worktree_path="/tmp/wt-r",
+            branch="codex/steward-review",
+            lifecycle_class="persistent",
+            has_active_session=False,
+            state="idle",
+            session_task="Previous review",
+            attention_needed=True,
+            attention_reason="idle",
+        )
+        report = StatusReport(lanes=[lane])
+        text = format_status_text(report)
+        assert "idle, last: Previous review" in text
+
+    def test_no_lanes_shows_none_summary(self) -> None:
+        """Empty report shows 0 lanes with 'none' summary."""
+        report = StatusReport()
+        text = format_status_text(report)
+        assert "0 lanes (none)" in text
 
 
 # ---- Task Scope Management Tests ----


### PR DESCRIPTION
## Plan
PR-5 slice 6: lane-activity/current-work stabilization and trusted operator visibility

## Summary
- Enrich `LaneStatus` with event context (`last_event_type`, `last_event_at`) so the status view answers what the lane's last meaningful activity was
- Improve current-step derivation, last-progress timestamp selection, and text/JSON output for reliable daily supervision
- Add comprehensive tests for mixed runtime states, partial data, and all output format enhancements

## Why
`ops.py status` had gaps where idle lanes showed no context, event timestamps weren't considered in last-progress selection, completed checklists showed as partial, and JSON output lacked a summary block for tooling. This makes the lane-activity view trustworthy enough to support daily supervision without guessing from panes.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_status.py -q    # 122 passed
make check-quiet                                              # all checks passed
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_status.py` — 122 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None (ops tooling only)
- Runtime impact: None (negligible — one extra event scan per lane)

## Risk level
- [x] Low (ops tooling + tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author  f88a8e9 [ops/stabilize-lane-activity]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

## Changes

### `src/bid_euchre/ops/status.py`
1. **LaneStatus**: Added `last_event_type` and `last_event_at` fields for event context
2. **`_derive_current_step`**: Handle all-items-completed → "all N steps done"
3. **`_find_last_event_for_lane`**: New helper to extract most recent event per lane
4. **`synthesize_lane_activity`**: Populate event fields, use event timestamps in `last_progress` selection
5. **`_format_relative_time`**: New helper for "5m ago" / "2h ago" / "1d ago" display
6. **`_branch_short`**: New helper to shorten branch names (strip `codex/steward-` prefix)
7. **`format_status_text`**: State summary line, branch info, relative time, event context for idle lanes
8. **`format_status_json`**: Added `summary` block with state/task counts and `generated_at`; added event fields to lane entries

### `tests/unit/test_ops_status.py` (30 new tests)
- `TestDeriveCurrentStepAllDone` — all-completed, single item, empty, precedence
- `TestFindLastEventForLane` — matching, first-match, no-match, empty
- `TestFormatRelativeTime` — minutes, hours, days, days+, now, future, none, garbage
- `TestBranchShort` — prefix stripping, no prefix, empty
- `TestSynthesizeLaneActivityEventEnrichment` — event context, no events, event enriches last_progress, idle with event
- `TestMixedRuntimeStatesIntegration` — 5-lane integration test (active+task, active+no-task, blocked, idle+session, idle+no-data) with full JSON/text assertions
- `TestJsonOutputStability` — empty report schema, complete field set
- `TestTextOutputEnhancements` — state summary, branch info, relative time, event context, last task, empty report