### PR TITLE
ops: reduce noisy unregistered worktree warnings

### DIFF
--- a/src/bid_euchre/ops/watchdogs.py
+++ b/src/bid_euchre/ops/watchdogs.py
@@ -266,6 +266,8 @@ def check_worktree_health(
         runtime_dir = Path(".claude/runtime")
 
     from bid_euchre.ops.worktrees import (
+        is_main_worktree,
+        is_protected,
         list_worktrees_git,
         list_worktrees_registry,
         reconcile,
@@ -278,6 +280,28 @@ def check_worktree_health(
     report = reconcile(git_wts, registry)
 
     for wt in report.unregistered:
+        # Main checkout is always unregistered — skip silently.
+        if is_main_worktree(wt.path):
+            continue
+
+        # Protected steward lanes are expected persistent infrastructure.
+        # Downgrade to "info" so they don't drown out real problems.
+        if is_protected(wt.path):
+            findings.append(
+                WatchdogFinding(
+                    watchdog_name="worktree_health",
+                    severity="info",
+                    target=wt.path,
+                    message=(f"Protected steward worktree (unregistered): {wt.branch}"),
+                    threshold="n/a",
+                    recommended_action=(
+                        "Register in worktree_registry to silence this notice"
+                    ),
+                )
+            )
+            continue
+
+        # Genuinely unregistered — likely orphaned.
         findings.append(
             WatchdogFinding(
                 watchdog_name="worktree_health",

--- a/src/bid_euchre/ops/worktrees.py
+++ b/src/bid_euchre/ops/worktrees.py
@@ -202,6 +202,24 @@ def is_protected(worktree_path: str) -> bool:
     return dirname in PROTECTED_WORKTREE_NAMES
 
 
+def is_main_worktree(worktree_path: str) -> bool:
+    """Check if a worktree path is the main working tree (not a linked worktree).
+
+    The main working tree has a ``.git`` **directory**. Linked worktrees
+    created by ``git worktree add`` have a ``.git`` **file** that points
+    back to the main repository's ``.git/worktrees/`` directory.
+
+    Args:
+        worktree_path: Path to the worktree directory.
+
+    Returns:
+        True if the path is the main working tree.
+    """
+    git_path = Path(worktree_path) / ".git"
+    # is_dir() returns False for files and symlinks to files
+    return git_path.is_dir()
+
+
 def is_worktree_dirty(worktree_path: str) -> bool:
     """Check if a worktree has uncommitted changes.
 
@@ -377,6 +395,10 @@ def classify_cleanup_candidates(
 
     # Unregistered worktrees — unknown lifecycle
     for git_wt in report.unregistered:
+        # Skip the main checkout — it's expected to be unregistered and
+        # is never a cleanup target.
+        if is_main_worktree(git_wt.path):
+            continue
         protected = is_protected(git_wt.path)
         dirty = is_worktree_dirty(git_wt.path) if check_dirty else False
         candidates.append(

--- a/tests/unit/test_ops_watchdogs.py
+++ b/tests/unit/test_ops_watchdogs.py
@@ -14,6 +14,7 @@ from bid_euchre.ops.watchdogs import (
     check_scope_drift,
     check_subagent_failures,
     check_task_progress,
+    check_worktree_health,
     format_watchdog_json,
     format_watchdog_text,
     run_all_watchdogs,
@@ -199,6 +200,152 @@ class TestCheckTaskProgress:
         assert len(findings) == 1
         assert findings[0].severity == "warning"
         assert "waiting for ci" in findings[0].message.lower()
+
+
+class TestCheckWorktreeHealth:
+    """Tests for check_worktree_health() noise reduction."""
+
+    def test_main_checkout_skipped(
+        self,
+        runtime_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The main checkout should not produce a warning."""
+        from bid_euchre.ops import worktrees as wt_mod
+        from bid_euchre.ops.worktrees import GitWorktree
+
+        # Fake main checkout: has a .git directory
+        main_dir = tmp_path / "Bid-Euchre"
+        main_dir.mkdir()
+        (main_dir / ".git").mkdir()
+
+        monkeypatch.setattr(
+            wt_mod,
+            "list_worktrees_git",
+            lambda: [
+                GitWorktree(path=str(main_dir), head="abc123", branch="main"),
+            ],
+        )
+
+        findings = check_worktree_health(runtime_dir)
+        assert findings == []
+
+    def test_protected_steward_downgrades_to_info(
+        self,
+        runtime_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Unregistered steward worktrees produce 'info', not 'warning'."""
+        from bid_euchre.ops import worktrees as wt_mod
+        from bid_euchre.ops.worktrees import GitWorktree
+
+        # Fake linked worktree with a protected name (.git is a file)
+        steward_dir = tmp_path / "Bid-Euchre-steward-author"
+        steward_dir.mkdir()
+        (steward_dir / ".git").write_text("gitdir: /repo/.git/worktrees/x")
+
+        monkeypatch.setattr(
+            wt_mod,
+            "list_worktrees_git",
+            lambda: [
+                GitWorktree(
+                    path=str(steward_dir),
+                    head="abc123",
+                    branch="codex/steward-author",
+                ),
+            ],
+        )
+
+        findings = check_worktree_health(runtime_dir)
+        assert len(findings) == 1
+        assert findings[0].severity == "info"
+        assert "protected steward" in findings[0].message.lower()
+
+    def test_genuine_orphan_remains_warning(
+        self,
+        runtime_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A truly orphaned worktree still gets a 'warning'."""
+        from bid_euchre.ops import worktrees as wt_mod
+        from bid_euchre.ops.worktrees import GitWorktree
+
+        # Fake linked worktree with non-protected name
+        orphan_dir = tmp_path / "worktree-old-feature"
+        orphan_dir.mkdir()
+        (orphan_dir / ".git").write_text("gitdir: /repo/.git/worktrees/y")
+
+        monkeypatch.setattr(
+            wt_mod,
+            "list_worktrees_git",
+            lambda: [
+                GitWorktree(
+                    path=str(orphan_dir),
+                    head="def456",
+                    branch="old-feature",
+                ),
+            ],
+        )
+
+        findings = check_worktree_health(runtime_dir)
+        assert len(findings) == 1
+        assert findings[0].severity == "warning"
+        assert "unregistered worktree" in findings[0].message.lower()
+
+    def test_mixed_worktrees_correct_classification(
+        self,
+        runtime_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Main + steward + orphan: only orphan is warning, steward is info."""
+        from bid_euchre.ops import worktrees as wt_mod
+        from bid_euchre.ops.worktrees import GitWorktree
+
+        # Main checkout
+        main_dir = tmp_path / "Bid-Euchre"
+        main_dir.mkdir()
+        (main_dir / ".git").mkdir()
+
+        # Protected steward
+        steward_dir = tmp_path / "Bid-Euchre-steward-ops"
+        steward_dir.mkdir()
+        (steward_dir / ".git").write_text("gitdir: /repo/.git/worktrees/ops")
+
+        # Genuine orphan
+        orphan_dir = tmp_path / "worktree-stale"
+        orphan_dir.mkdir()
+        (orphan_dir / ".git").write_text("gitdir: /repo/.git/worktrees/stale")
+
+        monkeypatch.setattr(
+            wt_mod,
+            "list_worktrees_git",
+            lambda: [
+                GitWorktree(path=str(main_dir), head="a", branch="main"),
+                GitWorktree(
+                    path=str(steward_dir),
+                    head="b",
+                    branch="codex/steward-ops",
+                ),
+                GitWorktree(path=str(orphan_dir), head="c", branch="stale-branch"),
+            ],
+        )
+
+        findings = check_worktree_health(runtime_dir)
+        # Main is silently skipped, steward is info, orphan is warning
+        assert len(findings) == 2
+
+        severities = {f.severity for f in findings}
+        assert severities == {"info", "warning"}
+
+        info_finding = [f for f in findings if f.severity == "info"][0]
+        assert "steward" in info_finding.message.lower()
+
+        warn_finding = [f for f in findings if f.severity == "warning"][0]
+        assert "stale-branch" in warn_finding.message
 
 
 class TestRunAllWatchdogs:

--- a/tests/unit/test_ops_worktrees.py
+++ b/tests/unit/test_ops_worktrees.py
@@ -13,6 +13,7 @@ from bid_euchre.ops.worktrees import (
     GitWorktree,
     _update_registry_cleanup_state,
     classify_cleanup_candidates,
+    is_main_worktree,
     is_protected,
     is_worktree_dirty,
     list_worktrees_registry,
@@ -163,6 +164,28 @@ class TestIsProtected:
 
     def test_partial_match_not_protected(self) -> None:
         assert not is_protected("/tmp/Bid-Euchre-steward-author-extra")
+
+
+class TestIsMainWorktree:
+    """Tests for is_main_worktree()."""
+
+    def test_main_checkout_has_git_dir(self, tmp_path: Path) -> None:
+        """A directory with a .git/ directory is the main working tree."""
+        (tmp_path / ".git").mkdir()
+        assert is_main_worktree(str(tmp_path)) is True
+
+    def test_linked_worktree_has_git_file(self, tmp_path: Path) -> None:
+        """A directory with a .git file (not directory) is a linked worktree."""
+        (tmp_path / ".git").write_text("gitdir: /some/repo/.git/worktrees/foo")
+        assert is_main_worktree(str(tmp_path)) is False
+
+    def test_no_git_at_all(self, tmp_path: Path) -> None:
+        """A directory without any .git is not the main worktree."""
+        assert is_main_worktree(str(tmp_path)) is False
+
+    def test_nonexistent_path(self) -> None:
+        """Nonexistent path returns False (no crash)."""
+        assert is_main_worktree("/tmp/no-such-dir-xyz") is False
 
 
 class TestReconcile:
@@ -359,6 +382,44 @@ class TestClassifyCleanupCandidates:
         )
         assert len(candidates) == 1
         assert candidates[0].cleanup_state == "stale"
+
+    def test_main_checkout_skipped(self, tmp_path: Path) -> None:
+        """The main checkout is never a cleanup candidate even when unregistered."""
+        # Create a fake main checkout (has .git directory)
+        main_dir = tmp_path / "Bid-Euchre"
+        main_dir.mkdir()
+        (main_dir / ".git").mkdir()
+
+        now = datetime(2026, 3, 18, 12, 0, 0, tzinfo=timezone.utc)
+        git_wts = [
+            GitWorktree(path=str(main_dir), head="abc", branch="main"),
+        ]
+        registry: list[dict] = []
+
+        candidates = classify_cleanup_candidates(
+            git_wts, registry, now=now, check_dirty=False
+        )
+        # Main checkout should be filtered out
+        assert len(candidates) == 0
+
+    def test_linked_worktree_still_candidate(self, tmp_path: Path) -> None:
+        """A linked worktree (non-main) that is unregistered remains a candidate."""
+        # Create a fake linked worktree (has .git file, not directory)
+        linked_dir = tmp_path / "worktree-feature"
+        linked_dir.mkdir()
+        (linked_dir / ".git").write_text("gitdir: /some/repo/.git/worktrees/feature")
+
+        now = datetime(2026, 3, 18, 12, 0, 0, tzinfo=timezone.utc)
+        git_wts = [
+            GitWorktree(path=str(linked_dir), head="abc", branch="feature-x"),
+        ]
+        registry: list[dict] = []
+
+        candidates = classify_cleanup_candidates(
+            git_wts, registry, now=now, check_dirty=False
+        )
+        assert len(candidates) == 1
+        assert candidates[0].lifecycle_class == "unknown"
 
 
 class TestIsWorktreeDirty:


### PR DESCRIPTION
## Summary
- Add `is_main_worktree()` helper to detect the main working tree vs linked worktrees (`.git` directory vs `.git` file)
- `check_worktree_health()`: skip main checkout silently, downgrade protected steward lanes from "warning" to "info", keep genuine orphans as "warning"
- `classify_cleanup_candidates()`: skip main checkout from unregistered cleanup candidate list

## Why
Ops health checks produced high volumes of "unregistered worktree" warnings for the main checkout and 7 persistent steward lanes — all expected infrastructure. This noise drowned out genuine orphaned worktree signals, making the watchdog output non-actionable.

## Repro / Validation

```bash
# Targeted tests (Tier 1)
uv run python -m pytest tests/unit/test_ops_watchdogs.py tests/unit/test_ops_worktrees.py -q
# → 102 passed

# Full validation (Tier 2)
make check-quiet
# → All checks passed
```

## Tests
- `TestIsMainWorktree`: 4 tests (git dir, git file, no git, nonexistent path)
- `TestCheckWorktreeHealth`: 4 tests (main skipped, steward→info, orphan→warning, mixed classification)
- `TestClassifyCleanupCandidates`: 2 tests (main checkout skipped, linked worktree still candidate)
- All 102 tests in both files pass

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-worktree-reduce-wt-noise
branch: reduce-wt-noise
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)