### PR TITLE
fix: harden claude-review workflow and tool permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,9 +37,34 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            Review this pull request for code quality, correctness, and security.
-            Analyze the diff, then post your findings as review comments.
-            Follow the project's CLAUDE.md guidelines.
+            You are a read-only code reviewer. Your job is to inspect the PR diff
+            and relevant source files, then post review findings as PR comments.
+
+            DO NOT attempt to modify files, create commits, push branches, or
+            perform any implementation work. You may only read and comment.
+
+            Review this pull request for:
+            - Code correctness and logic errors
+            - Security concerns
+            - Adherence to project conventions (see CLAUDE.md)
+
+            Post your findings as review comments on the PR.
+
+          # Read-only tool allowlist — prevents turn waste from permission denials.
+          # The reviewer can inspect code and post comments but cannot modify the repo.
+          allowed_tools: |
+            Read
+            Glob
+            Grep
+            Bash(git diff *)
+            Bash(git log *)
+            Bash(git show *)
+            Bash(git status)
+            Bash(gh pr diff *)
+            Bash(gh pr view *)
+            Bash(gh pr checks *)
+            Bash(gh pr comment *)
+
           claude_args: "--max-turns 5"
 
       - name: Flag reviewer infra failure
@@ -52,9 +77,20 @@ jobs:
           # Classify the failure: max-turns vs auth vs unknown
           SUBTYPE="unknown"
           DENIALS=0
-          if [ -f "$EXECUTION_FILE" ]; then
+
+          if [ -z "$EXECUTION_FILE" ]; then
+            # Output was never set — action crashed before producing metadata
+            SUBTYPE="missing_execution_file"
+          elif [ ! -f "$EXECUTION_FILE" ]; then
+            # Path was set but file doesn't exist on disk
+            SUBTYPE="execution_file_not_found"
+          else
+            # File exists — extract structured fields
             SUBTYPE=$(jq -r 'select(.type == "result") | .subtype // "unknown"' "$EXECUTION_FILE" 2>/dev/null | tail -1)
             DENIALS=$(jq -r 'select(.type == "result") | .permission_denials_count // 0' "$EXECUTION_FILE" 2>/dev/null | tail -1)
+            # Guard against empty jq output
+            [ -z "$SUBTYPE" ] && SUBTYPE="unparseable_execution_file"
+            [ -z "$DENIALS" ] && DENIALS=0
           fi
 
           gh issue create \

--- a/tests/unit/test_claude_review_workflow.py
+++ b/tests/unit/test_claude_review_workflow.py
@@ -32,6 +32,13 @@ class TestClaudeReviewWorkflow:
         prompt = step["with"]["prompt"]
         assert "review" in prompt.lower(), "prompt must mention 'review'"
 
+    def test_prompt_is_read_only(self):
+        """Prompt must explicitly forbid modifying files."""
+        step = self._review_step()
+        prompt = step["with"]["prompt"].lower()
+        assert "read-only" in prompt, "prompt must state 'read-only'"
+        assert "do not" in prompt, "prompt must include prohibitions"
+
     def test_max_turns_value(self):
         """Max turns must be explicitly set to a small bound."""
         step = self._review_step()
@@ -44,6 +51,39 @@ class TestClaudeReviewWorkflow:
         """Review step must NOT use continue-on-error — failures must be visible."""
         step = self._review_step()
         assert step.get("continue-on-error") is not True
+
+    # -- allowed_tools constraints --
+
+    def test_has_allowed_tools(self):
+        """Review step must declare an explicit allowed_tools allowlist."""
+        step = self._review_step()
+        assert "allowed_tools" in step["with"], "allowed_tools must be present"
+
+    def test_allowed_tools_includes_read_tools(self):
+        """Allowlist must include core read-only inspection tools."""
+        tools = self._allowed_tools_set()
+        for required in ("Read", "Glob", "Grep"):
+            assert required in tools, f"missing read tool: {required}"
+
+    def test_allowed_tools_excludes_write_tools(self):
+        """Allowlist must NOT include tools that modify the repository."""
+        tools_text = self._review_step()["with"]["allowed_tools"]
+        for forbidden in ("Edit", "Write", "NotebookEdit"):
+            assert forbidden not in tools_text, f"write tool present: {forbidden}"
+        # No git push, git commit, or destructive gh commands
+        for forbidden_bash in ("git push", "git commit", "git checkout", "gh pr merge"):
+            assert (
+                forbidden_bash not in tools_text
+            ), f"destructive bash pattern present: {forbidden_bash}"
+
+    def test_allowed_tools_includes_pr_comment(self):
+        """Reviewer must be able to post PR comments (its primary output)."""
+        tools = self._allowed_tools_set()
+        assert any(
+            "gh pr comment" in t for t in tools
+        ), "must include Bash(gh pr comment *)"
+
+    # -- infra-failure classifier constraints --
 
     def test_has_infra_failure_flag_step(self):
         """A follow-up step must create an issue on reviewer infra failure."""
@@ -58,6 +98,39 @@ class TestClaudeReviewWorkflow:
         # Must have GH_TOKEN for gh issue create
         assert "GH_TOKEN" in str(flag_step.get("env", {}))
 
+    def test_classifier_handles_missing_execution_file(self):
+        """Classifier must explicitly handle blank/missing EXECUTION_FILE."""
+        flag_step = self._flag_step()
+        script = flag_step["run"]
+        # Must check for blank EXECUTION_FILE (not just file-not-found)
+        assert (
+            '-z "$EXECUTION_FILE"' in script
+        ), "classifier must check for blank EXECUTION_FILE"
+        assert (
+            "missing_execution_file" in script
+        ), "must classify blank EXECUTION_FILE as 'missing_execution_file'"
+
+    def test_classifier_handles_file_not_found(self):
+        """Classifier must handle EXECUTION_FILE path set but file absent."""
+        flag_step = self._flag_step()
+        script = flag_step["run"]
+        assert (
+            '! -f "$EXECUTION_FILE"' in script
+        ), "classifier must check for file-not-found"
+        assert (
+            "execution_file_not_found" in script
+        ), "must classify missing file as 'execution_file_not_found'"
+
+    def test_classifier_guards_empty_jq_output(self):
+        """Classifier must guard against jq returning empty strings."""
+        flag_step = self._flag_step()
+        script = flag_step["run"]
+        assert (
+            "unparseable_execution_file" in script
+        ), "must classify empty jq output as 'unparseable_execution_file'"
+
+    # -- helpers --
+
     def _review_step(self):
         """Return the 'Run Claude Code Review' step."""
         steps = self.cfg["jobs"]["claude-review"]["steps"]
@@ -65,3 +138,16 @@ class TestClaudeReviewWorkflow:
             if s.get("id") == "claude-review":
                 return s
         raise AssertionError("claude-review step not found")
+
+    def _flag_step(self):
+        """Return the 'Flag reviewer infra failure' step."""
+        steps = self.cfg["jobs"]["claude-review"]["steps"]
+        for s in steps:
+            if s.get("name") == "Flag reviewer infra failure":
+                return s
+        raise AssertionError("Flag reviewer infra failure step not found")
+
+    def _allowed_tools_set(self) -> set[str]:
+        """Parse allowed_tools into a set of tool entries."""
+        raw = self._review_step()["with"]["allowed_tools"]
+        return {line.strip() for line in raw.strip().splitlines() if line.strip()}


### PR DESCRIPTION
## Summary
- Add explicit `allowed_tools` allowlist to claude-code-review.yml — read-only tools only (Read, Glob, Grep, git diff/log/show, gh pr diff/view/checks/comment)
- Harden infra-failure classifier to emit specific subtypes (`missing_execution_file`, `execution_file_not_found`, `unparseable_execution_file`) instead of collapsing to `unknown`
- Tighten review prompt to explicitly state read-only intent and prohibit file modifications

## Why
The claude-review workflow was burning turns on permission-denied tool attempts (Edit, Write, etc.), then hitting max-turn exhaustion. The infra-failure classifier step couldn't reliably read `EXECUTION_FILE` when the action crashed early, so filed issues with `subtype=unknown` — making triage harder.

## Changes

### 1. Read-only `allowed_tools` allowlist
Prevents the reviewer from attempting write tools that get denied and waste turns. The allowlist includes only inspection and commenting tools:
- `Read`, `Glob`, `Grep` for code inspection
- `Bash(git diff/log/show/status)` for VCS context
- `Bash(gh pr diff/view/checks/comment)` for PR interaction

### 2. Hardened infra-failure classifier
Three new explicit subtypes replace the catch-all `unknown`:
| Condition | Old subtype | New subtype |
|-----------|-------------|-------------|
| `EXECUTION_FILE` env var blank/unset | `unknown` | `missing_execution_file` |
| Path set but file doesn't exist | `unknown` | `execution_file_not_found` |
| File exists but jq returns empty | `unknown` | `unparseable_execution_file` |

### 3. Read-only review prompt
Explicitly tells Claude it is a read-only reviewer and must not attempt file modifications or implementation work.

### 4. Max turns unchanged
Kept at 5. The tool allowlist fix eliminates the primary turn waste (permission denials), so the existing budget should be sufficient. Can adjust in a follow-up if needed.

## Repro / Validation
```bash
# Targeted tests
uv run python -m pytest tests/unit/test_claude_review_workflow.py -v
# Full validation
make check-quiet
```

## Tests
- 14 tests in `test_claude_review_workflow.py` (8 new, 6 existing updated)
- New tests cover: `allowed_tools` presence, read-only tools, write-tool exclusion, PR comment capability, prompt read-only semantics, and all three classifier edge cases

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre
branch: fix/claude-review-hardening
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)