### PR TITLE
docs: Codex Cloud proving-run target

### DIFF
--- a/docs/02_agent/CODEX_GITHUB_REVIEW.md
+++ b/docs/02_agent/CODEX_GITHUB_REVIEW.md
@@ -71,6 +71,23 @@ setting disabled), the loop publishes success and the PR can be merged manually.
 
 See `docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md` for crash recovery procedures.
 
+## Codex Cloud Review (Under Investigation)
+
+Codex Cloud (chatgpt.com/codex) offers a subscription-backed GitHub code review
+path that does not require an API key or a GitHub Actions workflow. To enable:
+
+1. Connect the repo at chatgpt.com/codex/settings/code-review
+2. Trigger via `@codex review` comment on a PR, or enable automatic reviews
+
+**Status:** Not yet enabled for this repo. A proving run is needed to determine
+what GitHub artifacts Codex Cloud actually emits (PR review only, or PR review
+plus check run/status). Until verified empirically, no speculative classification
+has been added to `ADVISORY_CONTEXTS` or `reviews.py`.
+
+**Possible integration points** (to be confirmed after proving run):
+- If Codex Cloud emits a check/status: classify in `ops/__init__.py`
+- If Codex Cloud posts only PR reviews: handle in `ops/reviews.py`
+
 ## Migration from GitHub Codex Plugin
 
 The GitHub Codex plugin was previously used as a passive overlay (auto-reviewed


### PR DESCRIPTION
## Summary
- Add "Codex Cloud Review (Under Investigation)" section to CODEX_GITHUB_REVIEW.md
- Documents the subscription-backed review path and what needs to be verified

## Why
This PR serves a dual purpose:
1. Documents the Codex Cloud integration investigation status
2. Acts as the **throwaway target** for the Codex Cloud proving run

Once Codex Cloud is enabled for this repo, `@codex review` will be
triggered on this PR to empirically observe what GitHub artifacts
Codex Cloud actually emits (PR review only, or PR review + check/status).

## What we're testing
- Whether Codex Cloud posts only a standard GitHub PR review
- Whether it also emits a check run or commit status
- The exact reviewer identity / app name
- Whether any follow-up belongs in `ops/__init__.py` or `ops/reviews.py`

## Repro / Validation
```bash
# Docs-only change, no code validation needed
cat docs/02_agent/CODEX_GITHUB_REVIEW.md
```

## Test plan
- [ ] Enable Codex Cloud for repo at chatgpt.com/codex/settings/code-review
- [ ] Post `@codex review` comment on this PR
- [ ] Observe GitHub artifacts via `gh pr checks` and `gh api` for statuses/check-runs
- [ ] Record findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)