### PR TITLE
fix: harden skill-promotion — path traversal, YAML injection, Makefile extras

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test:
 	PYTHONPATH=.:src $(PYTHON) -m pytest -q -m "not slow" tests/
 
 ensure-venv:
-	@[ -d .venv ] || { echo ">>> Bootstrapping venv (fresh worktree detected)"; uv sync --all-extras; }
+	@[ -d .venv ] || { echo ">>> Bootstrapping venv (fresh worktree detected)"; uv sync --extra dev; }
 
 check: ensure-venv repo-lint lint test notebook-check docs-check
 	@echo "✓ All checks passed"

--- a/plans/sessions/2026-03-20_post-merge-review-skill-promotion.md
+++ b/plans/sessions/2026-03-20_post-merge-review-skill-promotion.md
@@ -1,0 +1,144 @@
+# Post-Merge Review Fixes: Skill Promotion & CI Extras
+
+**Date:** 2026-03-20
+**Source:** Post-merge review findings for PRs #1054 and #1050
+**Scope:** Security hardening of skill_promotion.py + Makefile consistency fix
+**Branch:** `fix/post-merge-skill-promotion-hardening`
+
+## Context
+
+Post-merge review of PR #1054 (skill promotion workflow) and PR #1050
+(CI efficiency) identified actionable findings. This plan covers the
+immediate-fix items.
+
+## Findings Summary
+
+| # | Source | Severity | Description | Status |
+|---|--------|----------|-------------|--------|
+| F1 | #1054 | CRITICAL | Path traversal via unvalidated `candidate_id` in `review_skill()`, `promote_skill()`, `get_candidate()` | Fix now |
+| F2 | #1054 | MEDIUM | Name not re-validated after loading candidate from disk in `promote_skill()` | Fix now |
+| F3 | #1054 | LOW | YAML front matter: `name` field unquoted (description already fixed) | Fix now |
+| F4 | #1054 | LOW | HTML comment injection — interpolated values can contain `-->` | Fix now |
+| H1 | #1050 | LOW | Makefile `ensure-venv` uses `--all-extras` while CI uses `--extra dev` | Fix now |
+
+## Implementation Plan
+
+### Task 1: Add `candidate_id` validation (F1 — CRITICAL)
+
+**File:** `src/bid_euchre/ops/skill_promotion.py`
+
+Add a `_validate_candidate_id()` helper that validates the input is a
+well-formed UUID (via `uuid.UUID(candidate_id)`). Call it at the top of:
+- `review_skill()` (line 219, before path construction on line 220)
+- `promote_skill()` (line 272, before path construction on line 275)
+- `get_candidate()` (line 427, before path construction on line 428)
+
+Implementation:
+```python
+def _validate_candidate_id(candidate_id: str) -> None:
+    """Validate candidate_id is a well-formed UUID to prevent path traversal."""
+    try:
+        uuid.UUID(candidate_id)
+    except (ValueError, AttributeError):
+        raise ValueError(
+            f"Invalid candidate ID '{candidate_id}': must be a valid UUID."
+        )
+```
+
+### Task 2: Re-validate name after loading from disk (F2 — MEDIUM)
+
+**File:** `src/bid_euchre/ops/skill_promotion.py`
+
+In `promote_skill()`, after loading the candidate (line 279), add:
+```python
+name_errors = validate_skill_name(candidate.name)
+if name_errors:
+    raise ValueError(
+        f"Candidate '{candidate_id}' has invalid skill name "
+        f"'{candidate.name}': {'; '.join(name_errors)}"
+    )
+```
+
+This defends against tampered candidate JSON files on disk.
+
+### Task 3: Quote YAML `name` field in `_render_skill_md` (F3 — LOW)
+
+**File:** `src/bid_euchre/ops/skill_promotion.py`, line 452
+
+Change:
+```python
+f"name: {candidate.name}\n"
+```
+To:
+```python
+f'name: "{candidate.name}"\n'
+```
+
+### Task 4: Sanitize HTML comment values (F4 — LOW)
+
+**File:** `src/bid_euchre/ops/skill_promotion.py`, `_render_skill_md()`
+
+Add a helper to strip `-->` from values interpolated into HTML comments:
+```python
+def _sanitize_comment(value: str | None) -> str:
+    """Strip HTML comment close sequence to prevent injection."""
+    if value is None:
+        return "None"
+    return str(value).replace("-->", "—>")
+```
+
+Apply to all HTML comment interpolations (lines 457-463).
+
+### Task 5: Fix Makefile `ensure-venv` extras (H1 — LOW)
+
+**File:** `Makefile`, line 63
+
+Change:
+```makefile
+@[ -d .venv ] || { echo ">>> Bootstrapping venv (fresh worktree detected)"; uv sync --all-extras; }
+```
+To:
+```makefile
+@[ -d .venv ] || { echo ">>> Bootstrapping venv (fresh worktree detected)"; uv sync --extra dev; }
+```
+
+This aligns local `make check` with CI's `uv sync --frozen --extra dev`.
+
+### Task 6: Add tests for new validation
+
+**File:** `tests/unit/test_ops_skill_promotion.py`
+
+Add tests:
+1. `test_review_rejects_path_traversal_candidate_id` — `review_skill("../../etc")` raises ValueError
+2. `test_promote_rejects_path_traversal_candidate_id` — same for `promote_skill`
+3. `test_get_candidate_rejects_path_traversal_id` — same for `get_candidate`
+4. `test_promote_rejects_tampered_name` — candidate with manually altered name raises ValueError
+5. `test_render_sanitizes_html_comments` — HTML comment injection is stripped
+6. `test_review_rejects_non_uuid_candidate_id` — non-UUID strings rejected
+7. `test_render_yaml_name_quoted` — verify name field is quoted in output
+
+### Task 7: Run validation
+
+- Tier 1: `uv run python -m pytest tests/unit/test_ops_skill_promotion.py -v`
+- Tier 2: `make check-quiet`
+
+## Parallelism Assessment
+
+- **Tasks 1-5** are independent code edits in different file regions — can be done sequentially in one pass.
+- **Task 6** (tests) depends on Tasks 1-4 being implemented.
+- **Task 7** depends on all prior tasks.
+- No parallelism needed — single-author sequential execution is fastest.
+
+## Acceptance Criteria
+
+- [ ] All three `candidate_id`-accepting functions validate UUID format
+- [ ] `promote_skill()` re-validates `candidate.name` after disk load
+- [ ] YAML front matter `name` field is quoted
+- [ ] HTML comment values are sanitized
+- [ ] Makefile `ensure-venv` uses `--extra dev`
+- [ ] New tests pass and existing tests unbroken
+- [ ] `make check-quiet` passes
+
+## Outcome
+
+_To be filled after implementation._

--- a/src/bid_euchre/ops/skill_promotion.py
+++ b/src/bid_euchre/ops/skill_promotion.py
@@ -88,6 +88,20 @@ class SkillCandidate:
 # ── Validation helpers ──────────────────────────────────────────
 
 
+def _validate_candidate_id(candidate_id: str) -> None:
+    """Validate *candidate_id* is a well-formed UUID to prevent path traversal.
+
+    Raises:
+        ValueError: If the string is not a valid UUID.
+    """
+    try:
+        uuid.UUID(candidate_id)
+    except (ValueError, AttributeError):
+        raise ValueError(
+            f"Invalid candidate ID '{candidate_id}': must be a valid UUID."
+        )
+
+
 def validate_skill_name(name: str) -> list[str]:
     """Return a list of validation errors for *name* (empty if valid)."""
     errors: list[str] = []
@@ -214,8 +228,10 @@ def review_skill(
 
     Raises:
         FileNotFoundError: If the candidate does not exist.
-        ValueError: If the candidate is not in a reviewable state.
+        ValueError: If the candidate is not in a reviewable state, or
+            the candidate_id is not a valid UUID.
     """
+    _validate_candidate_id(candidate_id)
     cdir = candidates_dir or DEFAULT_CANDIDATES_DIR
     path = cdir / f"{candidate_id}.json"
 
@@ -267,8 +283,10 @@ def promote_skill(
     Raises:
         FileNotFoundError: If the candidate does not exist.
         ValueError: If the candidate is not approved, or the safety scan
-            rejects the content, or a skill with that name already exists.
+            rejects the content, or a skill with that name already exists,
+            or the candidate_id is not a valid UUID.
     """
+    _validate_candidate_id(candidate_id)
     cdir = candidates_dir or DEFAULT_CANDIDATES_DIR
     sdir = skills_dir or DEFAULT_SKILLS_DIR
 
@@ -277,6 +295,14 @@ def promote_skill(
         raise FileNotFoundError(f"Candidate '{candidate_id}' not found.")
 
     candidate = _load_candidate(path)
+
+    # Re-validate name after loading from disk (defense against tampered JSON)
+    name_errors = validate_skill_name(candidate.name)
+    if name_errors:
+        raise ValueError(
+            f"Candidate '{candidate_id}' has invalid skill name "
+            f"'{candidate.name}': {'; '.join(name_errors)}"
+        )
 
     if candidate.status != "approved":
         raise ValueError(
@@ -423,7 +449,9 @@ def get_candidate(
 
     Raises:
         FileNotFoundError: If the candidate does not exist.
+        ValueError: If the candidate_id is not a valid UUID.
     """
+    _validate_candidate_id(candidate_id)
     cdir = candidates_dir or DEFAULT_CANDIDATES_DIR
     path = cdir / f"{candidate_id}.json"
     if not path.exists():
@@ -434,33 +462,44 @@ def get_candidate(
 # ── Rendering ───────────────────────────────────────────────────
 
 
+def _sanitize_comment(value: object) -> str:
+    """Strip HTML comment close sequence to prevent injection."""
+    if value is None:
+        return "None"
+    return str(value).replace("-->", "-- >")
+
+
 def _render_skill_md(candidate: SkillCandidate) -> str:
     """Render a SKILL.md file from a candidate."""
     # YAML front matter matching existing skill conventions
     provenance_lines = []
     for key, val in sorted(candidate.provenance.items()):
         if isinstance(val, list):
-            provenance_lines.append(f"#   {key}: {', '.join(str(v) for v in val)}")
+            safe_vals = ", ".join(_sanitize_comment(v) for v in val)
+            provenance_lines.append(f"#   {key}: {safe_vals}")
         else:
-            provenance_lines.append(f"#   {key}: {val}")
+            provenance_lines.append(f"#   {key}: {_sanitize_comment(val)}")
 
     provenance_block = "\n".join(provenance_lines)
+
+    # Escape internal double quotes in YAML values
+    safe_desc = candidate.description.replace('"', '\\"')
 
     return (
         (
             f"---\n"
-            f"name: {candidate.name}\n"
-            f'description: "{candidate.description}"\n'
+            f'name: "{candidate.name}"\n'
+            f'description: "{safe_desc}"\n'
             f"---\n"
             f"\n"
             f"<!-- Promoted by skill-promotion workflow -->\n"
-            f"<!-- candidate_id: {candidate.candidate_id} -->\n"
-            f"<!-- proposed_by: {candidate.proposed_by} -->\n"
-            f"<!-- proposed_at: {candidate.proposed_at} -->\n"
-            f"<!-- reviewed_by: {candidate.reviewed_by} -->\n"
-            f"<!-- reviewed_at: {candidate.reviewed_at} -->\n"
-            f"<!-- source_workflow: {candidate.source_workflow} -->\n"
-            f"<!-- safety_scan_outcome: {candidate.safety_scan_outcome} -->\n"
+            f"<!-- candidate_id: {_sanitize_comment(candidate.candidate_id)} -->\n"
+            f"<!-- proposed_by: {_sanitize_comment(candidate.proposed_by)} -->\n"
+            f"<!-- proposed_at: {_sanitize_comment(candidate.proposed_at)} -->\n"
+            f"<!-- reviewed_by: {_sanitize_comment(candidate.reviewed_by)} -->\n"
+            f"<!-- reviewed_at: {_sanitize_comment(candidate.reviewed_at)} -->\n"
+            f"<!-- source_workflow: {_sanitize_comment(candidate.source_workflow)} -->\n"
+            f"<!-- safety_scan_outcome: {_sanitize_comment(candidate.safety_scan_outcome)} -->\n"
         )
         + (
             f"<!-- provenance:\n{provenance_block}\n-->\n\n"

--- a/tests/unit/test_ops_skill_promotion.py
+++ b/tests/unit/test_ops_skill_promotion.py
@@ -13,6 +13,8 @@ import pytest
 
 from bid_euchre.ops.skill_promotion import (
     SkillCandidate,
+    _render_skill_md,
+    _sanitize_comment,
     disable_skill,
     format_candidates_json,
     format_candidates_text,
@@ -243,9 +245,11 @@ class TestReview:
         assert reviewed.status == "rejected"
 
     def test_review_nonexistent_raises(self, candidates_dir: Path) -> None:
+        import uuid
+
         with pytest.raises(FileNotFoundError):
             review_skill(
-                "nonexistent-id",
+                str(uuid.uuid4()),
                 approve=True,
                 reviewed_by="operator",
                 candidates_dir=candidates_dir,
@@ -321,7 +325,7 @@ class TestPromote:
 
         # Verify SKILL.md content
         content = skill_path.read_text()
-        assert "name: my-skill" in content
+        assert 'name: "my-skill"' in content
         assert 'description: "A useful skill"' in content
         assert "candidate_id:" in content
         assert "proposed_by: author-b" in content
@@ -358,9 +362,11 @@ class TestPromote:
     def test_promote_nonexistent_raises(
         self, candidates_dir: Path, skills_dir: Path
     ) -> None:
+        import uuid
+
         with pytest.raises(FileNotFoundError):
             promote_skill(
-                "nonexistent-id",
+                str(uuid.uuid4()),
                 candidates_dir=candidates_dir,
                 skills_dir=skills_dir,
             )
@@ -596,8 +602,10 @@ class TestListAndGet:
         assert loaded.candidate_id == c.candidate_id
 
     def test_get_nonexistent_raises(self, candidates_dir: Path) -> None:
+        import uuid
+
         with pytest.raises(FileNotFoundError):
-            get_candidate("nonexistent", candidates_dir=candidates_dir)
+            get_candidate(str(uuid.uuid4()), candidates_dir=candidates_dir)
 
 
 # ── SkillCandidate serialization ────────────────────────────────
@@ -720,3 +728,175 @@ class TestFormatting:
         assert len(result) == 1
         assert result[0]["name"] == "my-skill"
         assert result[0]["status"] == "pending"
+
+
+# ── Path traversal / candidate_id validation ─────────────────
+
+
+class TestCandidateIdValidation:
+    """F1: candidate_id must be a valid UUID to prevent path traversal."""
+
+    def test_review_rejects_path_traversal_id(self, candidates_dir: Path) -> None:
+        with pytest.raises(ValueError, match="Invalid candidate ID"):
+            review_skill(
+                "../../etc/passwd",
+                approve=True,
+                reviewed_by="operator",
+                candidates_dir=candidates_dir,
+            )
+
+    def test_promote_rejects_path_traversal_id(
+        self, candidates_dir: Path, skills_dir: Path
+    ) -> None:
+        with pytest.raises(ValueError, match="Invalid candidate ID"):
+            promote_skill(
+                "../../etc/passwd",
+                candidates_dir=candidates_dir,
+                skills_dir=skills_dir,
+            )
+
+    def test_get_candidate_rejects_path_traversal_id(
+        self, candidates_dir: Path
+    ) -> None:
+        with pytest.raises(ValueError, match="Invalid candidate ID"):
+            get_candidate("../../etc/passwd", candidates_dir=candidates_dir)
+
+    def test_review_rejects_non_uuid_string(self, candidates_dir: Path) -> None:
+        with pytest.raises(ValueError, match="Invalid candidate ID"):
+            review_skill(
+                "not-a-uuid-at-all",
+                approve=True,
+                reviewed_by="operator",
+                candidates_dir=candidates_dir,
+            )
+
+    def test_promote_rejects_non_uuid_string(
+        self, candidates_dir: Path, skills_dir: Path
+    ) -> None:
+        with pytest.raises(ValueError, match="Invalid candidate ID"):
+            promote_skill(
+                "not-a-uuid-at-all",
+                candidates_dir=candidates_dir,
+                skills_dir=skills_dir,
+            )
+
+    def test_get_candidate_rejects_non_uuid_string(self, candidates_dir: Path) -> None:
+        with pytest.raises(ValueError, match="Invalid candidate ID"):
+            get_candidate("not-a-uuid-at-all", candidates_dir=candidates_dir)
+
+    def test_valid_uuid_passes_validation(self, candidates_dir: Path) -> None:
+        """Valid UUID format should not raise ValueError (may raise FileNotFoundError)."""
+        import uuid
+
+        valid_id = str(uuid.uuid4())
+        with pytest.raises(FileNotFoundError):
+            get_candidate(valid_id, candidates_dir=candidates_dir)
+
+
+# ── Name re-validation after disk load ───────────────────────
+
+
+class TestNameRevalidation:
+    """F2: promote_skill re-validates candidate.name after loading from disk."""
+
+    def test_promote_rejects_tampered_name(
+        self, candidates_dir: Path, skills_dir: Path
+    ) -> None:
+        """If candidate JSON is tampered with a bad name, promote rejects it."""
+        c = _propose(candidates_dir)
+        review_skill(
+            c.candidate_id,
+            approve=True,
+            reviewed_by="operator",
+            candidates_dir=candidates_dir,
+        )
+
+        # Tamper the name to include path traversal
+        path = candidates_dir / f"{c.candidate_id}.json"
+        data = json.loads(path.read_text())
+        data["name"] = "../../etc"
+        path.write_text(json.dumps(data))
+
+        with pytest.raises(ValueError, match="invalid skill name"):
+            promote_skill(
+                c.candidate_id,
+                candidates_dir=candidates_dir,
+                skills_dir=skills_dir,
+            )
+
+    def test_promote_rejects_tampered_uppercase_name(
+        self, candidates_dir: Path, skills_dir: Path
+    ) -> None:
+        c = _propose(candidates_dir)
+        review_skill(
+            c.candidate_id,
+            approve=True,
+            reviewed_by="operator",
+            candidates_dir=candidates_dir,
+        )
+
+        path = candidates_dir / f"{c.candidate_id}.json"
+        data = json.loads(path.read_text())
+        data["name"] = "Bad Name!"
+        path.write_text(json.dumps(data))
+
+        with pytest.raises(ValueError, match="invalid skill name"):
+            promote_skill(
+                c.candidate_id,
+                candidates_dir=candidates_dir,
+                skills_dir=skills_dir,
+            )
+
+
+# ── YAML and HTML sanitization ───────────────────────────────
+
+
+class TestRenderingSanitization:
+    """F3/F4: YAML quoting and HTML comment sanitization."""
+
+    def test_yaml_name_is_quoted(self, candidates_dir: Path) -> None:
+        c = _propose(candidates_dir)
+        content = _render_skill_md(c)
+        assert 'name: "my-skill"' in content
+
+    def test_yaml_description_quotes_escaped(self, candidates_dir: Path) -> None:
+        c = _propose(candidates_dir, description='A skill with "quotes" inside')
+        content = _render_skill_md(c)
+        assert 'description: "A skill with \\"quotes\\" inside"' in content
+
+    def test_html_comment_injection_sanitized(self, candidates_dir: Path) -> None:
+        """Values containing --> are sanitized to prevent comment breakout."""
+        c = _propose(
+            candidates_dir,
+            source_workflow="evil --> <script>alert(1)</script>",
+        )
+        content = _render_skill_md(c)
+        # The injected --> should be sanitized to "-- >"
+        assert "evil -- > <script>" in content
+        # The raw injection should NOT appear
+        assert "evil --> <script>" not in content
+
+    def test_sanitize_comment_none(self) -> None:
+        assert _sanitize_comment(None) == "None"
+
+    def test_sanitize_comment_arrow(self) -> None:
+        assert _sanitize_comment("bad --> value") == "bad -- > value"
+
+    def test_sanitize_comment_clean(self) -> None:
+        assert _sanitize_comment("clean value") == "clean value"
+
+    def test_provenance_values_sanitized(self, candidates_dir: Path) -> None:
+        """Provenance block values containing --> are also sanitized."""
+        c = propose_skill(
+            name="prov-test",
+            description="Testing provenance",
+            content="# Test\n",
+            source_workflow="test",
+            proposed_by="author-b",
+            provenance={"evil_key": "value --> escape"},
+            candidates_dir=candidates_dir,
+        )
+        content = _render_skill_md(c)
+        assert "-- >" in content
+        # The raw --> should not appear in the provenance section
+        assert "value --> escape" not in content


### PR DESCRIPTION
## Summary

- **F1 (CRITICAL):** Add UUID validation for `candidate_id` in `review_skill()`, `promote_skill()`, and `get_candidate()` to prevent path traversal via malicious IDs like `../../etc/passwd`
- **F2:** Re-validate `candidate.name` after loading from disk in `promote_skill()` to defend against tampered candidate JSON files
- **F3+R2:** Quote YAML `name` field and escape `"` in `description` in `_render_skill_md()` front matter to prevent YAML injection
- **F4+R3:** Add `_sanitize_comment()` to strip `-->` from all HTML comment values (including provenance block) to prevent comment injection/breakout
- **H1:** Align Makefile `ensure-venv` with CI by changing `--all-extras` to `--extra dev`

## Why

Post-merge review of PRs #1054 and #1050 identified a critical path traversal vulnerability and several defense-in-depth hardening items. The `candidate_id` parameter was used directly in file path construction (`cdir / f"{candidate_id}.json"`) without validation — a UUID check is the correct fix since all candidate IDs are generated as UUIDs.

## Repro / Validation

```bash
# Tier 1: targeted tests (67 pass, 16 new)
uv run python -m pytest tests/unit/test_ops_skill_promotion.py -v

# Tier 2: full validation
make check-quiet
```

## Tests

- `TestCandidateIdValidation` — 7 tests covering path traversal and non-UUID rejection for all 3 functions
- `TestNameRevalidation` — 2 tests for tampered candidate name detection
- `TestRenderingSanitization` — 7 tests for YAML quoting, description quote escaping, HTML comment sanitization, provenance sanitization
- 3 existing tests updated to use valid UUID format (previously used `"nonexistent-id"`)

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: fix/post-merge-skill-promotion-hardening
```

## Files changed

| File | Change |
|------|--------|
| `src/bid_euchre/ops/skill_promotion.py` | `_validate_candidate_id()`, `_sanitize_comment()`, name re-validation, YAML quoting |
| `tests/unit/test_ops_skill_promotion.py` | 16 new tests + 3 updated existing tests |
| `Makefile` | `--all-extras` → `--extra dev` |
| `plans/sessions/2026-03-20_post-merge-review-skill-promotion.md` | Session plan |


🤖 Generated with [Claude Code](https://claude.com/claude-code)