### PR TITLE
docs: record Codex Cloud proving-run findings

### DIFF
--- a/docs/02_agent/CODEX_GITHUB_REVIEW.md
+++ b/docs/02_agent/CODEX_GITHUB_REVIEW.md
@@ -1,16 +1,40 @@
-# Codex Review — CLI-Only
+# Codex Review — Local Gate + Cloud Overlay
 
-> Codex CLI is the sole automated reviewer for all PRs. The GitHub Codex
-> plugin has been retired due to rate limiting and latency issues.
+> `reviewing-changes` from the local autonomous review loop is the
+> merge-relevant review gate. `claude-review` is an advisory GitHub check.
+> Codex Cloud is an optional manual overlay via `@codex review` and, as of the
+> 2026-03-20 proving run, currently lands as an issue comment from
+> `chatgpt-codex-connector[bot]` rather than as a check, status, or PR review.
 
 ## Overview
 
-All pre-merge code review is handled by the **autonomous review loop**
+This repo currently has three distinct review surfaces:
+
+1. **Autonomous review loop** (`reviewing-changes`)
+   - merge-relevant
+   - local/background
+   - driven by `scripts/internal/review_driver.py`
+   - invokes Codex CLI locally
+
+2. **Claude Code Review** (`claude-review`)
+   - advisory only
+   - GitHub Actions check
+   - must remain visible without poisoning CI
+
+3. **Codex Cloud** (`@codex review`)
+   - optional manual overlay
+   - uses the user's ChatGPT subscription plus Codex Cloud repo enablement
+   - not part of branch protection
+   - not currently integrated into ops check/review classification
+
+## Autonomous Review Loop
+
+All merge-relevant automated review is handled by the autonomous review loop
 (`review_driver.py`), which invokes **Codex CLI** (`codex review --base main`)
-locally. There is no dependency on GitHub's Codex plugin.
+locally.
 
 The review loop:
-1. Runs deterministic prechecks (C1/C2/N1/N2/N3/X2/X3)
+1. Runs deterministic prechecks
 2. Runs `make check-quiet`
 3. Invokes Codex CLI for code review
 4. Auto-fixes safe patterns (convention fixes)
@@ -29,20 +53,73 @@ The review loop:
 | Retry policy | Up to 3 attempts before `stopped_review_failure` |
 | Custom launcher | `CODEX_REVIEW_CMD` env var (optional) |
 
+## Relationship To Other Gates
+
+| Surface | Type | Required? | Publisher |
+|---------|------|-----------|-----------|
+| `tests` | GitHub Actions check | Yes (branch protection) | CI |
+| `governance` | GitHub Actions check | Yes (branch protection) | CI |
+| `reviewing-changes` | Commit status | Yes (branch protection) | Review loop (`review_driver.py`) |
+| `claude-review` | GitHub Actions check | No (advisory) | Claude Code Review workflow |
+| Codex Cloud `@codex review` | PR issue comment | No (overlay only) | `chatgpt-codex-connector[bot]` |
+
+## Codex Cloud Review
+
+Codex Cloud review uses the user's ChatGPT subscription plus repo enablement in
+Codex settings. It is not driven by a repo-local GitHub Actions workflow for
+this repo.
+
+### Trigger
+
+- Enable the repository in Codex Cloud settings
+- Comment `@codex review` on a PR
+
+### Observed Delivery Mechanism (2026-03-20 proving run)
+
+| Artifact | Present? | Details |
+|----------|----------|---------|
+| PR review object | No | No Pull Request Reviews API objects created |
+| Check run | No | No new GitHub checks beyond normal CI |
+| Commit status | No | No new status contexts |
+| PR issue comment | Yes | Posted by `chatgpt-codex-connector[bot]` |
+| Reaction on trigger comment | Yes | `eyes` reaction acknowledging `@codex review` |
+
+Observed identity:
+
+| Field | Value |
+|-------|-------|
+| GitHub App slug | `chatgpt-codex-connector` |
+| Bot login | `chatgpt-codex-connector[bot]` |
+| App display name | `ChatGPT Codex Connector` |
+| Delivery mechanism | PR issue comment |
+
+### Current Implication
+
+Codex Cloud does **not** currently flow through the repo's existing review
+classification hooks:
+
+- not `classify_check()` / `ADVISORY_CONTEXTS`
+- not `ops.reviews` PR-review aggregation
+
+If the repo later wants Codex Cloud findings surfaced in ops tooling, that is a
+new comment-ingestion capability:
+
+- detect PR issue comments from `chatgpt-codex-connector[bot]`
+- parse or summarize those findings
+- present them separately from checks and PR reviews
+
+Do not add a speculative `codex-review.yml` workflow or speculative advisory
+check-name registration for the ChatGPT-subscription path.
+
 ## PR Comments
 
-The review loop posts structured PR comments on terminal states (not just
-commit statuses). Comments use an HTML marker for idempotent upsert and
+The autonomous review loop posts structured PR comments on terminal states (not
+just commit statuses). Comments use an HTML marker for idempotent upsert and
 include the stop reason, findings table, and a recovery command. See
 `docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md` for details.
 
-## Relationship to Other Gates
-
-| Gate | Type | Required? | Publisher |
-|------|------|-----------|-----------|
-| `tests` | GitHub Actions | Yes (branch protection) | CI |
-| `governance` | GitHub Actions | Yes (branch protection) | CI |
-| `reviewing-changes` | Commit status | Yes (branch protection) | Review loop (`review_driver.py`) |
+Codex Cloud comments are separate from those loop comments and should be
+treated as overlay feedback, not as the branch-protection gate.
 
 ## Review Modes
 
@@ -56,44 +133,18 @@ PRs are classified by review mode based on changed file types:
 
 ## Merge Flow
 
-1. Claude opens PR via `gh pr create`
-2. PostToolUse hooks fire:
-   - `post-pr-review.sh` → dispatches `/reviewing-changes` (publishes initial `pending` status)
-   - `post-pr-review-loop.sh` → launches `review_driver.py` in background
-3. Review loop runs prechecks → make check → Codex CLI → auto-fix cycle
-4. On success: loop publishes `success` status and enables auto-merge
-5. GitHub merges automatically once CI + branch protection are satisfied
+1. Claude opens a PR via `gh pr create`
+2. PostToolUse hooks dispatch `/reviewing-changes` and launch
+   `review_driver.py` in the background
+3. The review loop runs prechecks, `make check-quiet`, and Codex CLI review
+4. On success, the loop publishes `reviewing-changes=success` and enables
+   auto-merge
+5. GitHub merges automatically once CI and branch protection are satisfied
 
-No human merge step required. If auto-merge fails (e.g., conflicts, repo
-setting disabled), the loop publishes success and the PR can be merged manually.
+Codex Cloud, when used, is additive commentary. It does not currently publish a
+merge-blocking artifact for this repo.
 
 ## Recovery
 
-See `docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md` for crash recovery procedures.
-
-## Codex Cloud Review (Under Investigation)
-
-Codex Cloud (chatgpt.com/codex) offers a subscription-backed GitHub code review
-path that does not require an API key or a GitHub Actions workflow. To enable:
-
-1. Connect the repo at chatgpt.com/codex/settings/code-review
-2. Trigger via `@codex review` comment on a PR, or enable automatic reviews
-
-**Status:** Not yet enabled for this repo. A proving run is needed to determine
-what GitHub artifacts Codex Cloud actually emits (PR review only, or PR review
-plus check run/status). Until verified empirically, no speculative classification
-has been added to `ADVISORY_CONTEXTS` or `reviews.py`.
-
-**Possible integration points** (to be confirmed after proving run):
-- If Codex Cloud emits a check/status: classify in `ops/__init__.py`
-- If Codex Cloud posts only PR reviews: handle in `ops/reviews.py`
-
-## Migration from GitHub Codex Plugin
-
-The GitHub Codex plugin was previously used as a passive overlay (auto-reviewed
-PRs when opened). It has been retired because:
-- Rate limiting caused delays and unpredictable review availability
-- Latency was 60-254s vs ~60s for local CLI
-- It could not be added as a required branch protection check
-- The autonomous review loop with Codex CLI provides the same coverage
-  with better reliability and control
+See `docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md` for crash recovery procedures for
+the merge-relevant local review loop.


### PR DESCRIPTION
## Summary
- Restructure CODEX_GITHUB_REVIEW.md around the three review surfaces:
  autonomous loop (merge-relevant), claude-review (advisory), Codex Cloud (overlay)
- Replace speculative "Under Investigation" section with empirical findings from PR #1066

## Why
The PR #1066 proving run confirmed that Codex Cloud delivers reviews as **issue comments**
from `chatgpt-codex-connector[bot]`, not PR reviews, check runs, or commit statuses.
This means the earlier speculative approach (adding `codex-review` to `ADVISORY_CONTEXTS`
or creating a `codex-review.yml` workflow) was the wrong integration shape.

The doc now records the verified delivery mechanism and notes that any future ops
integration would require comment-ingestion, not check/status classification.

## Repro / Validation
```bash
# Docs-only change
cat docs/02_agent/CODEX_GITHUB_REVIEW.md
```

## Tests
No tests — docs-only change. No code or ops behavior modified.

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
branch: codex/steward-author-c
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)