### PR TITLE
fix: remove dead else branch and add escalation to scheduler dedup set

### DIFF
--- a/plans/sessions/2026-03-20_batch-b-scheduler-dedup.md
+++ b/plans/sessions/2026-03-20_batch-b-scheduler-dedup.md
@@ -1,0 +1,74 @@
+# Batch B: Scheduler Dedup Fixes
+
+**Date:** 2026-03-20
+**Author:** author-c
+**Scope:** `src/bid_euchre/ops/scheduler.py`, `tests/unit/test_ops_scheduler.py`
+**Issues:** #1042 (dead else branch), #1045 (missing escalation in dedup set)
+
+## Problem
+
+Two bugs in `_evaluate_retries_for_findings()` (scheduler.py lines 154-165):
+
+1. **Dead else branch (#1042):** `read_events()` returns `list[dict[str, Any]]` (confirmed
+   in `events.py:125`). The `else` branch with `getattr()` is unreachable dead code that
+   obscures the fact that events are always dicts.
+
+2. **Missing escalation dedup (#1045):** The dedup guard checks `("retry_attempted",
+   "task_rerouted")` but not `"escalation"`. Per `_RETRY_EVENT_MAP` in `recovery.py:490-494`,
+   the `"escalate"` action emits an `"escalation"` event. Without including it, escalated
+   tasks can be re-processed on every tick.
+
+## Fix
+
+Replace the dedup loop (lines 154-165) with a simplified version that:
+- Removes the dead `isinstance` / `else` branch -- always use `.get()` on dicts
+- Adds `"escalation"` to the dedup event set alongside `"retry_attempted"` and `"task_rerouted"`
+
+### Before
+```python
+already_retried: set[str] = set()
+for evt in events:
+    if isinstance(evt, dict):
+        etype = evt.get("event_type", "")
+        payload = evt.get("payload", {})
+    else:
+        etype = getattr(evt, "event_type", "")
+        payload = getattr(evt, "payload", {})
+    if etype in ("retry_attempted", "task_rerouted"):
+        tid = payload.get("task_id") if isinstance(payload, dict) else None
+        if tid:
+            already_retried.add(tid)
+```
+
+### After
+```python
+already_retried: set[str] = set()
+for evt in events:
+    etype = evt.get("event_type", "")
+    payload = evt.get("payload", {})
+    if etype in ("retry_attempted", "task_rerouted", "escalation"):
+        tid = payload.get("task_id") if isinstance(payload, dict) else None
+        if tid:
+            already_retried.add(tid)
+```
+
+## Tests
+
+Add two tests to `TestEvaluateRetriesForFindings` in `test_ops_scheduler.py`:
+
+1. **`test_dedup_skips_already_escalated_tasks`** -- Pre-populate event log with an
+   `escalation` event for task `t1`, then create a subagent_failure finding for `t1`.
+   Verify `_evaluate_retries_for_findings` returns 0 (skipped).
+
+2. **`test_events_are_always_dicts`** -- Verify that events from `read_events()` are
+   always dicts, validating the removal of the else branch.
+
+## Validation
+
+```bash
+uv run python -m pytest tests/unit/test_ops_scheduler.py -v
+make check-quiet
+```
+
+## Outcome
+<!-- Filled after implementation -->

--- a/src/bid_euchre/ops/scheduler.py
+++ b/src/bid_euchre/ops/scheduler.py
@@ -153,13 +153,9 @@ def _evaluate_retries_for_findings(
     # to prevent cascading re-emission on every tick for persistent failures.
     already_retried: set[str] = set()
     for evt in events:
-        if isinstance(evt, dict):
-            etype = evt.get("event_type", "")
-            payload = evt.get("payload", {})
-        else:
-            etype = getattr(evt, "event_type", "")
-            payload = getattr(evt, "payload", {})
-        if etype in ("retry_attempted", "task_rerouted"):
+        etype = evt.get("event_type", "")
+        payload = evt.get("payload", {})
+        if etype in ("retry_attempted", "task_rerouted", "escalation"):
             tid = payload.get("task_id") if isinstance(payload, dict) else None
             if tid:
                 already_retried.add(tid)

--- a/tests/unit/test_ops_scheduler.py
+++ b/tests/unit/test_ops_scheduler.py
@@ -779,3 +779,103 @@ class TestEvaluateRetriesForFindings:
         ]
         # 3 failures with default max_retries=3 means reroute
         assert len(retry_events) >= 1
+
+    def test_dedup_skips_already_escalated_tasks(self, events_dir: Path) -> None:
+        """Tasks with existing escalation events are not re-processed (#1045)."""
+        from bid_euchre.ops.watchdogs import WatchdogFinding
+
+        # Pre-populate with task failures AND an existing escalation event
+        events_file = events_dir / "events.jsonl"
+        lines = [
+            json.dumps(
+                {
+                    "timestamp": "2026-03-20T10:00:00Z",
+                    "event_type": "task_failed",
+                    "source": "hook",
+                    "lane_id": "author-a",
+                    "payload": {"task_id": "t1", "details": "error 1"},
+                }
+            ),
+            json.dumps(
+                {
+                    "timestamp": "2026-03-20T10:01:00Z",
+                    "event_type": "task_failed",
+                    "source": "hook",
+                    "lane_id": "author-a",
+                    "payload": {"task_id": "t1", "details": "error 2"},
+                }
+            ),
+            json.dumps(
+                {
+                    "timestamp": "2026-03-20T10:02:00Z",
+                    "event_type": "task_failed",
+                    "source": "hook",
+                    "lane_id": "author-a",
+                    "payload": {"task_id": "t1", "details": "error 3"},
+                }
+            ),
+            json.dumps(
+                {
+                    "timestamp": "2026-03-20T10:03:00Z",
+                    "event_type": "task_failed",
+                    "source": "hook",
+                    "lane_id": "author-a",
+                    "payload": {"task_id": "t1", "details": "error 4"},
+                }
+            ),
+            # Existing escalation event -- should prevent re-emission
+            json.dumps(
+                {
+                    "timestamp": "2026-03-20T10:04:00Z",
+                    "event_type": "escalation",
+                    "source": "ops.retry",
+                    "lane_id": "author-a",
+                    "payload": {
+                        "task_id": "t1",
+                        "retry_count": 4,
+                        "last_failure": "error 4",
+                        "details": "Task t1 exceeded retry cap",
+                    },
+                }
+            ),
+        ]
+        events_file.write_text("\n".join(lines) + "\n")
+
+        findings = [
+            WatchdogFinding(
+                watchdog_name="subagent_failure_check",
+                severity="warning",
+                target="author-a:t1",
+                message="Task t1 failed 4 times",
+                threshold="3 failures",
+                recommended_action="Escalate",
+            ),
+        ]
+
+        emitted = _evaluate_retries_for_findings(findings, events_dir)
+        assert emitted == 0, "Should skip t1 -- escalation event already exists"
+
+    def test_events_are_always_dicts(self, events_dir: Path) -> None:
+        """Verify read_events() returns list[dict], validating dead-branch removal (#1042)."""
+        from bid_euchre.ops.events import append_event, read_events
+
+        # Write a few events of different types
+        append_event(
+            event_type="retry_attempted",
+            source="test",
+            lane_id="test-lane",
+            payload={"task_id": "t1"},
+            events_dir=events_dir,
+        )
+        append_event(
+            event_type="escalation",
+            source="test",
+            lane_id="test-lane",
+            payload={"task_id": "t2"},
+            events_dir=events_dir,
+        )
+
+        events = read_events(events_dir)
+        assert len(events) >= 2
+        for evt in events:
+            assert isinstance(evt, dict), f"Expected dict, got {type(evt)}"


### PR DESCRIPTION
## Plan
`plans/sessions/2026-03-20_batch-b-scheduler-dedup.md`

## Summary
- Remove unreachable dead `else` branch in scheduler dedup loop (events are always dicts)
- Add `"escalation"` to the dedup event set so escalated tasks are not re-processed every tick
- Add two regression tests covering both fixes

## Why
Two bugs in `_evaluate_retries_for_findings()`:

1. `read_events()` returns `list[dict[str, Any]]`. The `else` branch with `getattr()` was unreachable dead code that obscured this fact (#1042).
2. The dedup guard checked `("retry_attempted", "task_rerouted")` but missed `"escalation"`. Per `_RETRY_EVENT_MAP` in `recovery.py`, the `"escalate"` action emits an `"escalation"` event. Without dedup, escalated tasks were re-processed on every scheduler tick (#1045).

Closes #1042
Closes #1045

## Repro / Validation
**Command(s) run:**
```
uv run python -m pytest tests/unit/test_ops_scheduler.py -v
make check-quiet
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_scheduler.py -v` (30/30 pass)
- [x] `make check-quiet` (all checks pass)

## Expected impact
- Metrics impact: None
- Runtime impact: None (fewer redundant escalation events emitted)

## Risk level
- [x] Low (ops tooling only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a8dceec5
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a8dceec5
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a8dceec5  693cc02d [fix/scheduler-dedup-gaps]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)