### PR TITLE
fix: narrow exception handling in review driver follow-up issue dedup

### DIFF
--- a/plans/sessions/2026-03-20_batch-c-review-driver-dedup.md
+++ b/plans/sessions/2026-03-20_batch-c-review-driver-dedup.md
@@ -1,0 +1,65 @@
+# Batch C: Review Driver Dedup Hardening
+
+**Date:** 2026-03-20
+**Issue:** #1043
+**Branch:** `fix/review-driver-dedup-hardening`
+
+## Problem
+
+In `scripts/internal/review_driver.py`, the `_create_follow_up_issues()` function
+has a dedup guard (lines 159-190) with two defects:
+
+1. **Broad exception catch:** `except (json.JSONDecodeError, Exception) as e:` --
+   `Exception` subsumes `json.JSONDecodeError`, making the tuple redundant. More
+   critically, catching all exceptions silently swallows transient `gh` failures
+   (network timeout, auth issues), proceeding to issue creation and potentially
+   creating duplicates.
+
+2. **Quiet logging:** `logger.debug(...)` is too quiet for a dedup failure --
+   should be `logger.warning(...)` so operators see it.
+
+## Fix
+
+### review_driver.py (line 189-190)
+
+Replace:
+```python
+except (json.JSONDecodeError, Exception) as e:
+    logger.debug("Dedup check failed, proceeding with creation: %s", e)
+```
+
+With:
+```python
+except (json.JSONDecodeError, subprocess.CalledProcessError, OSError) as e:
+    logger.warning("Dedup check failed, proceeding with creation: %s", e)
+```
+
+Rationale:
+- `json.JSONDecodeError` -- malformed `gh` output
+- `subprocess.CalledProcessError` -- `gh` exits non-zero (already imported)
+- `OSError` -- file/network-level failures (e.g., `gh` not found)
+- Unexpected errors (TypeError, KeyError, etc.) will now propagate, surfacing bugs
+
+### Tests (new file: `tests/unit/test_review_driver_dedup.py`)
+
+1. **test_dedup_catches_subprocess_error** -- Mock `subprocess.run` to raise
+   `CalledProcessError` on the `gh issue list` call. Verify it catches gracefully
+   and proceeds to issue creation.
+
+2. **test_dedup_catches_json_error** -- Mock `subprocess.run` to return garbage
+   stdout. Verify `json.JSONDecodeError` is caught and proceeds.
+
+3. **test_dedup_does_not_catch_unexpected_error** -- Mock `subprocess.run` to raise
+   `TypeError`. Verify the exception propagates (is NOT caught).
+
+## Validation
+
+```bash
+uv run python -m pytest tests/unit/test_review_driver_dedup.py -v
+make check-quiet
+```
+
+## Outcome
+
+- PR: (to be filled)
+- Closes: #1043

--- a/scripts/internal/review_driver.py
+++ b/scripts/internal/review_driver.py
@@ -186,8 +186,8 @@ def _create_follow_up_issues(
                     existing[0].get("url", "?"),
                 )
                 continue
-        except (json.JSONDecodeError, Exception) as e:
-            logger.debug("Dedup check failed, proceeding with creation: %s", e)
+        except (json.JSONDecodeError, subprocess.CalledProcessError, OSError) as e:
+            logger.warning("Dedup check failed, proceeding with creation: %s", e)
 
         # Try with labels first, fall back to without
         result = subprocess.run(

--- a/tests/unit/test_review_driver.py
+++ b/tests/unit/test_review_driver.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 # Add scripts/internal to path for direct imports
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "internal"))
 
 from review_driver import (
+    _create_follow_up_issues,
     _format_review_comment,
     _parse_plan_files,
     check_scope_drift,
@@ -937,3 +939,132 @@ class TestDegradedReviewStatus:
         # Status should NOT say "degraded"
         for _, _, desc in status_calls:
             assert "degraded" not in desc.lower()
+
+
+# ---------------------------------------------------------------------------
+# _create_follow_up_issues dedup guard tests (#1043)
+# ---------------------------------------------------------------------------
+
+# A minimal P2 finding that will pass the WARN_SEVERITY filter.
+_P2_FINDING = {
+    "severity": "P2",
+    "category": "convention",
+    "check_id": "T1",
+    "file": "src/foo.py",
+    "line": 10,
+    "message": "Untested behavior change",
+}
+
+
+class TestCreateFollowUpIssuesDedup:
+    """Test that the dedup guard in _create_follow_up_issues catches only
+    expected exceptions and logs at WARNING level (#1043)."""
+
+    def test_dedup_catches_subprocess_error(self) -> None:
+        """CalledProcessError from `gh issue list` is caught gracefully;
+        issue creation still proceeds."""
+
+        def _side_effect(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            # The dedup check calls 'gh issue list'
+            if "list" in cmd:
+                raise subprocess.CalledProcessError(1, cmd, stderr="auth failed")
+            # The create call succeeds
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "https://github.com/test/repo/issues/99"
+            return result
+
+        with patch("review_driver.subprocess.run", side_effect=_side_effect):
+            urls = _create_follow_up_issues(42, [_P2_FINDING])
+
+        # Issue should have been created despite dedup failure
+        assert len(urls) == 1
+        assert "issues/99" in urls[0]
+
+    def test_dedup_catches_json_decode_error(self) -> None:
+        """Malformed gh output (JSONDecodeError) is caught; creation proceeds."""
+
+        call_count = {"n": 0}
+
+        def _side_effect(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            if "list" in cmd:
+                # Return garbage that json.loads will choke on
+                result = MagicMock()
+                result.returncode = 0
+                result.stdout = "NOT_VALID_JSON"
+                return result
+            # The create call succeeds
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "https://github.com/test/repo/issues/100"
+            call_count["n"] += 1
+            return result
+
+        with patch("review_driver.subprocess.run", side_effect=_side_effect):
+            urls = _create_follow_up_issues(42, [_P2_FINDING])
+
+        assert len(urls) == 1
+        assert call_count["n"] >= 1
+
+    def test_dedup_catches_os_error(self) -> None:
+        """OSError (e.g., gh not found) is caught; creation proceeds."""
+
+        def _side_effect(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            if "list" in cmd:
+                raise OSError("gh: command not found")
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "https://github.com/test/repo/issues/101"
+            return result
+
+        with patch("review_driver.subprocess.run", side_effect=_side_effect):
+            urls = _create_follow_up_issues(42, [_P2_FINDING])
+
+        assert len(urls) == 1
+
+    def test_dedup_does_not_catch_unexpected_error(self) -> None:
+        """Unexpected errors (e.g., TypeError) must propagate, not be silently
+        swallowed. This is the key behavioral change from #1043."""
+
+        def _side_effect(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            if "list" in cmd:
+                raise TypeError("unexpected error in dedup")
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "https://github.com/test/repo/issues/102"
+            return result
+
+        import pytest
+
+        with (
+            patch("review_driver.subprocess.run", side_effect=_side_effect),
+            pytest.raises(TypeError, match="unexpected error in dedup"),
+        ):
+            _create_follow_up_issues(42, [_P2_FINDING])
+
+    def test_dedup_logs_at_warning_level(self) -> None:
+        """Dedup failures should log at WARNING, not DEBUG (#1043)."""
+
+        def _side_effect(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            if "list" in cmd:
+                raise subprocess.CalledProcessError(1, cmd, stderr="timeout")
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "https://github.com/test/repo/issues/103"
+            return result
+
+        with (
+            patch("review_driver.subprocess.run", side_effect=_side_effect),
+            patch("review_driver.logger") as mock_logger,
+        ):
+            _create_follow_up_issues(42, [_P2_FINDING])
+
+        # Verify warning was called (not debug)
+        mock_logger.warning.assert_called()
+        warning_msg = mock_logger.warning.call_args[0][0]
+        assert "Dedup check failed" in warning_msg


### PR DESCRIPTION
## Plan
plans/sessions/2026-03-20_batch-c-review-driver-dedup.md

## Summary
- Narrowed exception catch in `_create_follow_up_issues()` dedup guard from bare `Exception` to `(JSONDecodeError, CalledProcessError, OSError)`
- Raised logging level from `debug` to `warning` so operators see dedup failures
- Added 5 tests covering caught and uncaught exception behavior

## Why
The broad `except (json.JSONDecodeError, Exception)` silently swallowed transient `gh` failures (network timeout, auth issues), falling through to issue creation and potentially creating duplicates. The `logger.debug()` made these failures invisible in normal log output.

Closes #1043

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_review_driver.py::TestCreateFollowUpIssuesDedup -v
uv run python -m pytest tests/unit/test_review_driver.py -v  # all 63 tests pass
make check-quiet  # all checks pass
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_review_driver.py -v` (63 pass)
- [x] `make check-quiet` (all checks pass)

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-add4cb6e
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-add4cb6e
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-add4cb6e  0cb15e34 [fix/review-driver-dedup-hardening]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)