### PR TITLE
fix: unify CI classifiers — replace fail-closed allowlist with classify_check()

### DIFF
--- a/plans/sessions/2026-03-20_batch-d-unify-ci-classifiers.md
+++ b/plans/sessions/2026-03-20_batch-d-unify-ci-classifiers.md
@@ -1,0 +1,56 @@
+# Batch D — Unify CI Classifiers
+
+## Issue
+
+#1036: Two CI classification systems answer "is this check name a real CI check?" with opposite defaults:
+
+1. **`CI_CHECK_NAMES`** in `github_pr_state.py` — fail-closed allowlist. New CI jobs not in the set are invisible to the review loop.
+2. **`classify_check()`** in `ops/__init__.py` — fail-open denylist. New CI jobs default to "ci".
+
+Risk: a new CI workflow job not added to `CI_CHECK_NAMES` is invisible to the review loop, which could merge PRs while the new check is failing.
+
+## Fix
+
+**Option 1 (chosen):** Make `github_pr_state.py` use `classify_check()` — the fail-open denylist becomes the single source of truth.
+
+### Changes
+
+**`scripts/internal/github_pr_state.py`:**
+- Remove the `CI_CHECK_NAMES` import and fallback definition (lines 146-152)
+- Import `classify_check` from `bid_euchre.ops` instead
+- Change `get_ci_status()` to use `classify_check()`:
+  ```python
+  # Before:
+  ci_checks = [c for c in checks if c.get("name") in _CI_CHECK_NAMES]
+
+  # After:
+  ci_checks = [c for c in checks if classify_check(c.get("name", "")) == "ci"]
+  ```
+- Update the fallback for import failure to inline the logic
+
+**`src/bid_euchre/ops/__init__.py`:**
+- Keep `CI_CHECK_NAMES` but add a deprecation docstring comment
+- No behavioral change — it's still exported for backward compat
+
+**`tests/unit/test_check_classifier.py`:**
+- Update `TestConsistencyWithGithubPrState` to verify `github_pr_state` uses `classify_check()` instead of `CI_CHECK_NAMES`
+- Add a drift-detection test: assert every name in `CI_CHECK_NAMES` classifies as "ci"
+
+**`tests/unit/test_github_pr_state.py`:**
+- Add test verifying new CI jobs (unknown check names) are included by default
+- Add test verifying advisory/review-gate checks are excluded
+
+## Files
+- `scripts/internal/github_pr_state.py` — CI status polling
+- `src/bid_euchre/ops/__init__.py` — classify_check, CI_CHECK_NAMES
+- `tests/unit/test_check_classifier.py` — classifier tests
+- `tests/unit/test_github_pr_state.py` — PR state tests (if exists, else create)
+
+## Validation
+```bash
+uv run python -m pytest tests/unit/test_check_classifier.py tests/unit/test_github_pr_state.py -v
+make check-quiet
+```
+
+## Outcome
+<!-- Filled after implementation -->

--- a/plans/sessions/2026-03-20_issue-triage-swarm.md
+++ b/plans/sessions/2026-03-20_issue-triage-swarm.md
@@ -1,0 +1,170 @@
+# Issue Triage Swarm — 2026-03-20
+
+## Goal
+
+Close 7 open issues across 4 parallel PRs, each authored by an independent
+agent in its own worktree. Every agent plans, gets reviewed, then executes
+autonomously through PR creation.
+
+## Batches
+
+### Batch A — Workflow jq guards (#1039)
+
+**Branch:** `fix/jq-empty-output-guards`
+**Lane:** author-b
+**Issues closed:** #1039
+**Risk:** LOW (2-line shell fix, no Python)
+
+**File:** `.github/workflows/claude-code-review.yml` lines 56-57
+
+**Fix:**
+After the jq extraction of `SUBTYPE` and `DENIALS`, add:
+```bash
+SUBTYPE=${SUBTYPE:-unknown}
+DENIALS=${DENIALS:-0}
+```
+Also add handling for missing `$EXECUTION_FILE`:
+```bash
+if [ ! -f "$EXECUTION_FILE" ]; then
+  SUBTYPE="missing_execution_file"
+fi
+```
+
+**Validation:** Syntax check (bash -n not applicable for YAML, but visual inspection). `make check` is not required since no Python changes.
+
+---
+
+### Batch B — Scheduler dedup fixes (#1042 + #1045)
+
+**Branch:** `fix/scheduler-dedup-gaps`
+**Lane:** author-c
+**Issues closed:** #1042, #1045
+**Risk:** LOW (small changes, existing test coverage)
+
+**Files:**
+- `src/bid_euchre/ops/scheduler.py` (lines 155-165)
+- `tests/unit/test_ops_scheduler.py` (add tests)
+
+**Fix 1 — Dead else branch (#1042):**
+Remove the `else` branch (lines 159-161) since `read_events()` always returns
+`list[dict[str, Any]]`. Replace with dict access directly + a type assertion:
+```python
+for evt in events:
+    etype = evt.get("event_type", "")
+    payload = evt.get("payload", {})
+    if etype in ("retry_attempted", "task_rerouted", "escalation"):
+        tid = payload.get("task_id") if isinstance(payload, dict) else None
+        if tid:
+            already_retried.add(tid)
+```
+
+**Fix 2 — Escalation in dedup set (#1045):**
+Add `"escalation"` to the dedup set on line 162:
+```python
+if etype in ("retry_attempted", "task_rerouted", "escalation"):
+```
+
+**Tests:**
+- Add `test_dedup_skips_already_escalated_tasks` — pre-populate event log with
+  an `escalation` event and verify the task is skipped
+- Add `test_dedup_dict_only_no_else_branch` — verify dict-only event processing
+
+**Validation:** `uv run python -m pytest tests/unit/test_ops_scheduler.py -v`
+
+---
+
+### Batch C — Review driver dedup hardening (#1043)
+
+**Branch:** `fix/review-driver-dedup-hardening`
+**Lane:** author-d
+**Issues closed:** #1043
+**Risk:** LOW (exception narrowing, logging level change)
+
+**Files:**
+- `scripts/internal/review_driver.py` (lines 177-190)
+- `tests/unit/test_review_driver.py` (add tests)
+
+**Fix 1 — Narrow exception catch:**
+```python
+# Before:
+except (json.JSONDecodeError, Exception) as e:
+    logger.debug("Dedup check failed, proceeding with creation: %s", e)
+
+# After:
+except (json.JSONDecodeError, subprocess.CalledProcessError) as e:
+    logger.warning("Dedup check failed, proceeding with creation: %s", e)
+```
+
+**Fix 2 — Promote logging level:** `logger.debug` → `logger.warning`
+
+**Tests:**
+- Add test verifying that dedup exception is narrowed (mock gh to raise
+  CalledProcessError, verify it's caught; mock to raise ValueError, verify
+  it propagates)
+
+**Validation:** `uv run python -m pytest tests/unit/test_review_driver.py -v`
+
+---
+
+### Batch D — CI classifier unification (#1036 + #1041)
+
+**Branch:** `fix/unify-ci-classifiers`
+**Lane:** author-a (this lane, after coordination)
+**Issues closed:** #1036, #1041
+**Risk:** MEDIUM (changes CI polling logic used by review loop)
+
+**Files:**
+- `scripts/internal/github_pr_state.py` (lines 146-192)
+- `src/bid_euchre/ops/__init__.py` (line 67 — CI_CHECK_NAMES)
+- `tests/unit/test_github_pr_state.py`
+- `tests/unit/test_check_classifier.py`
+
+**Fix:**
+Replace the fail-closed `CI_CHECK_NAMES` allowlist in `github_pr_state.py`
+with `classify_check()` from `bid_euchre.ops`:
+
+```python
+# Before (fail-closed allowlist):
+from bid_euchre.ops import CI_CHECK_NAMES as _CI_CHECK_NAMES
+ci_checks = [c for c in checks if c.get("name") in _CI_CHECK_NAMES]
+
+# After (fail-open denylist, single source of truth):
+from bid_euchre.ops import classify_check
+ci_checks = [c for c in checks if classify_check(c.get("name", "")) == "ci"]
+```
+
+Keep `CI_CHECK_NAMES` in `__init__.py` but add a deprecation comment.
+Update the fallback in `github_pr_state.py` to use inline classify_check.
+
+**Tests:**
+- Update `test_check_classifier.py` consistency test
+- Add `test_github_pr_state.py` test verifying classify_check integration
+- Add drift-detection test asserting CI_CHECK_NAMES ⊂ classify_check("ci")
+
+**Validation:** `uv run python -m pytest tests/unit/test_check_classifier.py tests/unit/test_github_pr_state.py -v`
+
+---
+
+## Execution Model
+
+```
+Master (author-a)
+  ├── spawn Batch A agent (author-b worktree) ──→ plan → review → execute → PR
+  ├── spawn Batch B agent (author-c worktree) ──→ plan → review → execute → PR
+  ├── spawn Batch C agent (author-d worktree) ──→ plan → review → execute → PR
+  └── Batch D: execute locally after A/B/C launch
+```
+
+Each agent:
+1. Writes a concrete execution plan
+2. Spawns an independent reviewer agent for that plan
+3. Creates a TUI task list for implementation + validation
+4. Implements the fix
+5. Runs targeted tests (Tier 1)
+6. Runs `make check-quiet` (Tier 2) — except Batch A (no Python)
+7. Commits and opens PR with exact repro commands
+8. Closes referenced issues
+
+## Outcome
+
+<!-- Filled after implementation -->

--- a/scripts/internal/github_pr_state.py
+++ b/scripts/internal/github_pr_state.py
@@ -143,22 +143,32 @@ def get_pr_head_sha(pr_number: int) -> str:
     return result.stdout.strip()
 
 
-# Shared CI check allowlist — single source of truth lives in
-# bid_euchre.ops.CI_CHECK_NAMES.  Import here to stay in sync.
+# CI check classification — single source of truth is classify_check()
+# in bid_euchre.ops (fail-open denylist: unknown checks default to "ci").
+# See #1036 for the unification rationale.
 try:
-    from bid_euchre.ops import CI_CHECK_NAMES as _CI_CHECK_NAMES
+    from bid_euchre.ops import classify_check as _classify_check
 except ImportError:
     # Fallback for environments where bid_euchre is not installed.
-    _CI_CHECK_NAMES: frozenset[str] = frozenset({"tests", "prechecks", "governance"})  # type: ignore[no-redef]
+    # Inline the denylist logic so new CI jobs are still included by default.
+    # Keep in sync with REVIEW_GATE_CONTEXTS + ADVISORY_CONTEXTS in ops/__init__.py.
+    _FALLBACK_NON_CI: frozenset[str] = frozenset(
+        {"reviewing-changes", "claude-review", "enable-auto-merge"}
+    )
+
+    def _classify_check(name: str) -> str:  # type: ignore[misc]
+        """Inline fallback for classify_check when bid_euchre is not installed."""
+        if name in _FALLBACK_NON_CI:
+            return "non_ci"
+        return "ci"
 
 
 def get_ci_status(pr_number: int) -> str:
     """Get the CI status of a PR.
 
-    Uses an explicit allowlist (:data:`_CI_CHECK_NAMES`) so that only
-    real CI checks (tests, lint, governance) are considered.  Review
-    statuses, advisory actions, and any future non-CI contexts are
-    excluded automatically.
+    Uses :func:`classify_check` (fail-open denylist) so that only known
+    non-CI checks (review gates, advisory) are excluded.  New CI jobs
+    are included by default without needing allowlist updates.
 
     Returns:
         "success", "failure", "pending", or "unknown"
@@ -179,8 +189,8 @@ def get_ci_status(pr_number: int) -> str:
         return "unknown"
 
     checks = json.loads(result.stdout)
-    # Only consider checks that are known CI jobs
-    ci_checks = [c for c in checks if c.get("name") in _CI_CHECK_NAMES]
+    # Exclude non-CI checks (review gate + advisory) via classify_check
+    ci_checks = [c for c in checks if _classify_check(c.get("name", "")) == "ci"]
     if not ci_checks:
         return "pending"
 

--- a/src/bid_euchre/ops/__init__.py
+++ b/src/bid_euchre/ops/__init__.py
@@ -35,8 +35,11 @@ DEFAULT_REVIEW_CONTEXTS: tuple[str, ...] = ("reviewing-changes",)
 REVIEW_GATE_CONTEXTS: tuple[str, ...] = DEFAULT_REVIEW_CONTEXTS
 """Check names that are merge-relevant review gates (alias for DEFAULT_REVIEW_CONTEXTS)."""
 
-ADVISORY_CONTEXTS: tuple[str, ...] = ("claude-review",)
+ADVISORY_CONTEXTS: tuple[str, ...] = ("claude-review", "enable-auto-merge")
 """Check names that are advisory-only — infrastructure failures here must not poison CI.
+
+``enable-auto-merge`` is GitHub plumbing (the auto-merge queue action), not a
+validation check. Its failures should never count as CI failures.
 
 NOTE: When Codex Cloud review is enabled (via chatgpt.com/codex), observe
 the actual GitHub check/status context name it emits, then add it here.
@@ -66,10 +69,10 @@ def classify_check(name: str) -> str:
     return "ci"
 
 
-# Allowlist of GitHub check names that represent real CI (build/test/lint).
-# Used by scripts/internal/github_pr_state.py for review-loop CI polling
-# (fail-closed: only known CI check names are considered).
-# Update this set when adding new CI workflow jobs.
+# DEPRECATED: Fail-closed CI allowlist. Retained for backward compatibility.
+# Prefer classify_check() which uses a fail-open denylist — new CI jobs are
+# included by default without needing to update this set.
+# See #1036 for the unification rationale.
 CI_CHECK_NAMES: frozenset[str] = frozenset({"tests", "prechecks", "governance"})
 
 # Default timeout (seconds) for gh CLI subprocess calls.

--- a/tests/unit/test_check_classifier.py
+++ b/tests/unit/test_check_classifier.py
@@ -23,6 +23,10 @@ class TestClassifyCheck:
     def test_claude_review_is_advisory(self) -> None:
         assert classify_check("claude-review") == "advisory"
 
+    def test_enable_auto_merge_is_advisory(self) -> None:
+        """enable-auto-merge is plumbing, not CI (#1036)."""
+        assert classify_check("enable-auto-merge") == "advisory"
+
     def test_tests_is_ci(self) -> None:
         assert classify_check("tests") == "ci"
 
@@ -30,7 +34,7 @@ class TestClassifyCheck:
         assert classify_check("lint") == "ci"
 
     def test_unknown_name_defaults_to_ci(self) -> None:
-        """Unknown check names must default to 'ci' (conservative)."""
+        """Unknown check names must default to 'ci' (fail-open denylist)."""
         assert classify_check("some-random-check") == "ci"
 
     def test_empty_name_is_ci(self) -> None:
@@ -45,6 +49,10 @@ class TestConstants:
 
     def test_advisory_contains_claude_review(self) -> None:
         assert "claude-review" in ADVISORY_CONTEXTS
+
+    def test_advisory_contains_enable_auto_merge(self) -> None:
+        """enable-auto-merge is plumbing — must be in advisory (#1036)."""
+        assert "enable-auto-merge" in ADVISORY_CONTEXTS
 
     def test_non_ci_is_union(self) -> None:
         """NON_CI_CONTEXTS is the union of review gate + advisory."""
@@ -62,19 +70,67 @@ class TestConstants:
 
 
 class TestConsistencyWithGithubPrState:
-    """Verify github_pr_state.py CI allowlist excludes all non-CI contexts."""
+    """Verify github_pr_state.py uses classify_check for CI classification."""
 
-    def test_ci_allowlist_excludes_non_ci_contexts(self) -> None:
-        """The CI allowlist in scripts/internal must not contain any non-CI context."""
-        # Add scripts/internal to path for import
+    def test_github_pr_state_uses_classify_check(self) -> None:
+        """github_pr_state._classify_check must agree with ops.classify_check."""
         scripts_dir = Path(__file__).resolve().parents[2] / "scripts" / "internal"
         sys.path.insert(0, str(scripts_dir))
         try:
-            from github_pr_state import _CI_CHECK_NAMES
+            from github_pr_state import _classify_check as pr_state_classify
 
+            # All non-CI contexts must be excluded by both classifiers
             for ctx in NON_CI_CONTEXTS:
                 assert (
-                    ctx not in _CI_CHECK_NAMES
-                ), f"Non-CI context {ctx!r} found in _CI_CHECK_NAMES allowlist"
+                    pr_state_classify(ctx) != "ci"
+                ), f"Non-CI context {ctx!r} classified as 'ci' by github_pr_state"
+
+            # Known CI checks must be included by both
+            for name in ("tests", "prechecks", "governance"):
+                assert (
+                    pr_state_classify(name) == "ci"
+                ), f"CI check {name!r} not classified as 'ci' by github_pr_state"
+
+            # Unknown checks must default to CI (fail-open)
+            assert pr_state_classify("brand-new-workflow") == "ci"
+        finally:
+            sys.path.pop(0)
+
+
+class TestDriftDetection:
+    """Catch drift between CI_CHECK_NAMES (deprecated) and classify_check."""
+
+    def test_ci_check_names_members_classify_as_ci(self) -> None:
+        """Every name in the deprecated CI_CHECK_NAMES must classify as 'ci'.
+
+        If this fails, a CI check was added to the allowlist but is being
+        excluded by the denylist — an inconsistency that should be resolved.
+        """
+        from bid_euchre.ops import CI_CHECK_NAMES
+
+        for name in CI_CHECK_NAMES:
+            assert (
+                classify_check(name) == "ci"
+            ), f"CI_CHECK_NAMES member {name!r} does not classify as 'ci'"
+
+    def test_fallback_denylist_matches_non_ci_contexts(self) -> None:
+        """The inline fallback denylist in github_pr_state.py must cover all
+        NON_CI_CONTEXTS from ops/__init__.py.
+
+        If this fails, a new non-CI context was added to ops but not to the
+        inline fallback, which would cause divergence when bid_euchre is not
+        importable.
+        """
+        scripts_dir = Path(__file__).resolve().parents[2] / "scripts" / "internal"
+        sys.path.insert(0, str(scripts_dir))
+        try:
+            from github_pr_state import _classify_check as pr_state_classify
+
+            for ctx in NON_CI_CONTEXTS:
+                result = pr_state_classify(ctx)
+                assert result != "ci", (
+                    f"NON_CI_CONTEXTS member {ctx!r} classified as 'ci' by "
+                    f"github_pr_state fallback — update _FALLBACK_NON_CI"
+                )
         finally:
             sys.path.pop(0)

--- a/tests/unit/test_github_pr_state.py
+++ b/tests/unit/test_github_pr_state.py
@@ -13,9 +13,9 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "internal"))
 
 from github_pr_state import (
-    _CI_CHECK_NAMES,
     REVIEW_COMMENT_MARKER,
     PRMetadata,
+    _classify_check,
     get_ci_status,
     get_pr_body,
     get_pr_changed_files,
@@ -179,7 +179,7 @@ class TestGetPRChangedFiles:
 
 
 # ---------------------------------------------------------------------------
-# get_ci_status tests — allowlist-based CI classification
+# get_ci_status tests — classify_check-based CI classification
 # ---------------------------------------------------------------------------
 
 
@@ -188,33 +188,50 @@ def _mock_checks_result(checks: list[dict]) -> Mock:
     return Mock(returncode=0, stdout=json.dumps(checks))
 
 
-class TestCICheckAllowlist:
-    """Verify the CI allowlist contains expected check names."""
+class TestCIClassification:
+    """Verify classify_check-based CI classification in github_pr_state."""
 
-    def test_contains_tests(self) -> None:
-        assert "tests" in _CI_CHECK_NAMES
+    def test_known_ci_checks_classified_as_ci(self) -> None:
+        """Known CI check names must classify as 'ci'."""
+        assert _classify_check("tests") == "ci"
+        assert _classify_check("prechecks") == "ci"
+        assert _classify_check("governance") == "ci"
 
-    def test_contains_prechecks(self) -> None:
-        assert "prechecks" in _CI_CHECK_NAMES
+    def test_review_gate_excluded(self) -> None:
+        """Review gate checks must not classify as 'ci'."""
+        assert _classify_check("reviewing-changes") != "ci"
 
-    def test_contains_governance(self) -> None:
-        assert "governance" in _CI_CHECK_NAMES
+    def test_advisory_excluded(self) -> None:
+        """Advisory checks must not classify as 'ci'."""
+        assert _classify_check("claude-review") != "ci"
+        assert _classify_check("enable-auto-merge") != "ci"
 
-    def test_does_not_contain_non_validation_checks(self) -> None:
-        """Review, advisory, and plumbing checks must not appear in CI allowlist."""
-        assert "reviewing-changes" not in _CI_CHECK_NAMES
-        assert "claude-review" not in _CI_CHECK_NAMES
-        assert "enable-auto-merge" not in _CI_CHECK_NAMES
+    def test_unknown_checks_default_to_ci(self) -> None:
+        """Unknown check names must classify as 'ci' (fail-open denylist)."""
+        assert _classify_check("some-new-ci-job") == "ci"
+        assert _classify_check("lint-v2") == "ci"
 
-    def test_matches_shared_constant(self) -> None:
-        """Local _CI_CHECK_NAMES must equal the shared CI_CHECK_NAMES constant."""
-        from bid_euchre.ops import CI_CHECK_NAMES
+    def test_consistent_with_ops_classify_check(self) -> None:
+        """Local _classify_check must agree with ops.classify_check on all known names."""
+        from bid_euchre.ops import classify_check
 
-        assert set(_CI_CHECK_NAMES) == set(CI_CHECK_NAMES)
+        for name in (
+            "tests",
+            "prechecks",
+            "governance",
+            "reviewing-changes",
+            "claude-review",
+        ):
+            local = _classify_check(name)
+            canonical = classify_check(name)
+            # Both should agree on CI vs non-CI
+            assert (local == "ci") == (
+                canonical == "ci"
+            ), f"Disagreement on {name!r}: local={local}, canonical={canonical}"
 
 
 class TestGetCIStatus:
-    """Test get_ci_status with allowlist-based classification."""
+    """Test get_ci_status with classify_check-based classification."""
 
     @patch("github_pr_state.subprocess.run")
     def test_all_ci_checks_pass(self, mock_run: Mock) -> None:
@@ -249,7 +266,7 @@ class TestGetCIStatus:
 
     @patch("github_pr_state.subprocess.run")
     def test_reviewing_changes_failure_ignored(self, mock_run: Mock) -> None:
-        """reviewing-changes is not in the CI allowlist — ignored."""
+        """reviewing-changes is a review gate — excluded from CI."""
         mock_run.return_value = _mock_checks_result(
             [
                 {"name": "reviewing-changes", "state": "FAILURE"},
@@ -260,7 +277,7 @@ class TestGetCIStatus:
 
     @patch("github_pr_state.subprocess.run")
     def test_claude_review_failure_ignored(self, mock_run: Mock) -> None:
-        """claude-review is not in the CI allowlist — ignored."""
+        """claude-review is advisory — excluded from CI."""
         mock_run.return_value = _mock_checks_result(
             [
                 {"name": "claude-review", "state": "FAILURE"},
@@ -271,7 +288,7 @@ class TestGetCIStatus:
 
     @patch("github_pr_state.subprocess.run")
     def test_enable_auto_merge_failure_ignored(self, mock_run: Mock) -> None:
-        """enable-auto-merge is plumbing, not validation — ignored."""
+        """enable-auto-merge is advisory (plumbing) — excluded from CI."""
         mock_run.return_value = _mock_checks_result(
             [
                 {"name": "enable-auto-merge", "state": "FAILURE"},
@@ -281,15 +298,20 @@ class TestGetCIStatus:
         assert get_ci_status(1) == "success"
 
     @patch("github_pr_state.subprocess.run")
-    def test_future_unknown_check_ignored(self, mock_run: Mock) -> None:
-        """Any unknown check name not in allowlist is ignored."""
+    def test_future_unknown_check_included_as_ci(self, mock_run: Mock) -> None:
+        """Unknown check names default to CI (fail-open denylist).
+
+        This is the key behavioral change from #1036: previously unknown
+        checks were invisible (fail-closed). Now they count as CI so new
+        workflow jobs are automatically monitored.
+        """
         mock_run.return_value = _mock_checks_result(
             [
-                {"name": "some-new-advisory-thing", "state": "FAILURE"},
+                {"name": "some-new-ci-job", "state": "FAILURE"},
                 {"name": "tests", "state": "SUCCESS"},
             ]
         )
-        assert get_ci_status(1) == "success"
+        assert get_ci_status(1) == "failure"
 
     @patch("github_pr_state.subprocess.run")
     def test_only_non_ci_checks_returns_pending(self, mock_run: Mock) -> None:


### PR DESCRIPTION
## Summary
- Replace fail-closed `CI_CHECK_NAMES` allowlist in `github_pr_state.py` with fail-open `classify_check()` denylist
- Add `enable-auto-merge` to `ADVISORY_CONTEXTS` so plumbing failures don't count as CI
- Add inline fallback with drift-detection tests to catch divergence when `bid_euchre` is not importable
- Deprecate `CI_CHECK_NAMES` (kept for backward compat)

## Why
Two CI classification systems answered "is this check name a real CI check?" with opposite defaults (#1036):
- `CI_CHECK_NAMES` (fail-closed): new CI jobs invisible to review loop
- `classify_check()` (fail-open): new CI jobs included by default

This meant a new CI workflow job not in `CI_CHECK_NAMES` could be failing while the review loop reported CI as passing, allowing merges.

## Plan
plans/sessions/2026-03-20_batch-d-unify-ci-classifiers.md

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_check_classifier.py tests/unit/test_github_pr_state.py tests/unit/test_ops_ci.py -v
# 114 passed

make check-quiet
# All checks passed
```

## Tests
- `tests/unit/test_check_classifier.py` — new `enable-auto-merge` advisory test, `TestDriftDetection` class (2 tests), updated consistency test
- `tests/unit/test_github_pr_state.py` — rewritten `TestCIClassification` class (5 tests), inverted `test_future_unknown_check_included_as_ci` (key behavioral change)
- `tests/unit/test_ops_ci.py` — existing tests pass unchanged

## Worktree proof
This is the persistent `Bid-Euchre-steward-author` worktree (author-a lane).

## Files
- `scripts/internal/github_pr_state.py` — CI status polling
- `src/bid_euchre/ops/__init__.py` — classify_check, ADVISORY_CONTEXTS, CI_CHECK_NAMES
- `tests/unit/test_check_classifier.py` — classifier + drift tests
- `tests/unit/test_github_pr_state.py` — PR state CI tests
- `plans/sessions/2026-03-20_batch-d-unify-ci-classifiers.md` — plan
- `plans/sessions/2026-03-20_issue-triage-swarm.md` — swarm coordination plan

Closes #1036
Closes #1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)