### PR TITLE
fix: raise claude-review max-turns to 10 and suppress issue spam

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -50,22 +50,7 @@ jobs:
 
             Post your findings as review comments on the PR.
 
-          # Read-only tool allowlist — prevents turn waste from permission denials.
-          # The reviewer can inspect code and post comments but cannot modify the repo.
-          allowed_tools: |
-            Read
-            Glob
-            Grep
-            Bash(git diff *)
-            Bash(git log *)
-            Bash(git show *)
-            Bash(git status)
-            Bash(gh pr diff *)
-            Bash(gh pr view *)
-            Bash(gh pr checks *)
-            Bash(gh pr comment *)
-
-          claude_args: "--max-turns 5"
+          claude_args: "--max-turns 10"
 
       - name: Flag reviewer infra failure
         if: always() && steps.claude-review.outcome == 'failure'
@@ -79,8 +64,11 @@ jobs:
           DENIALS=0
 
           if [ -z "$EXECUTION_FILE" ]; then
-            # Output was never set — action crashed before producing metadata
-            SUBTYPE="missing_execution_file"
+            # Output was never set — action crashed before producing metadata.
+            # The action does not set execution_file on error_max_turns exits,
+            # so this is the most common case. Warn but do not create an issue.
+            echo "::warning::claude-review exited without execution_file (likely max-turns exhaustion)"
+            exit 0
           elif [ ! -f "$EXECUTION_FILE" ]; then
             # Path was set but file doesn't exist on disk
             SUBTYPE="execution_file_not_found"
@@ -91,6 +79,13 @@ jobs:
             # Guard against empty jq output
             [ -z "$SUBTYPE" ] && SUBTYPE="unparseable_execution_file"
             [ -z "$DENIALS" ] && DENIALS=0
+          fi
+
+          # error_max_turns is a normal operational boundary, not an infra failure.
+          # Warn but do not create a noise issue.
+          if [ "$SUBTYPE" = "error_max_turns" ]; then
+            echo "::warning::claude-review hit max-turns (denials=$DENIALS) — not an infra failure"
+            exit 0
           fi
 
           gh issue create \

--- a/plans/sessions/2026-03-20_claude-review-max-turns-fix.md
+++ b/plans/sessions/2026-03-20_claude-review-max-turns-fix.md
@@ -1,0 +1,135 @@
+# Fix Claude Review Max-Turns Failures
+
+**Date:** 2026-03-20
+**Author:** author-b
+**Branch:** `fix/claude-review-max-turns`
+**Status:** PLANNING
+
+## Problem Statement
+
+The `claude-code-review.yml` GitHub Action workflow has a **60% failure rate**
+(18 failures / 30 recent runs). Every failure creates a spam GitHub issue via
+the infra-failure classifier, producing 14+ open noise issues.
+
+### Root Cause Analysis
+
+Two compounding problems:
+
+1. **`allowed_tools` input is dead code.** The `anthropics/claude-code-action@v1`
+   action does not accept an `allowed_tools` input. GitHub Actions warns but ignores
+   it silently. The reviewer retains access to all tools and wastes 1-2 turns on
+   permission-denied write operations (Edit, Write, git push).
+
+2. **`--max-turns 5` is too tight.** With 1-2 turns wasted on denials, only 3-4
+   effective turns remain. That's insufficient for: read diff + inspect files +
+   post comments. The action exits with `error_max_turns`.
+
+3. **Infra-failure classifier creates issues for max-turns exits.** The action
+   does NOT set the `execution_file` output when exiting via `error_max_turns`.
+   The classifier sees a blank `EXECUTION_FILE`, classifies it as
+   `missing_execution_file`, and creates a noise issue.
+
+### Evidence
+
+```
+# Failed run 23361490206:
+"subtype": "error_max_turns",
+"num_turns": 6,
+"permission_denials_count": 2
+
+# Classifier env in infra-failure step:
+EXECUTION_FILE:     # <-- empty, action didn't set it
+
+# Result: issue created with title "claude-review infra failure (missing_execution_file)"
+```
+
+GitHub Actions warning on every run:
+```
+##[warning]Unexpected input(s) 'allowed_tools', valid inputs are [...]
+```
+
+## Plan
+
+### Step 1: Remove broken `allowed_tools` input
+
+**File:** `.github/workflows/claude-code-review.yml`
+
+Remove the `allowed_tools` block (lines 53-66 in current file). This input is
+silently ignored by the action — it provides no tool restriction and adds
+confusion. The `contents: read` GitHub permission already prevents actual repo
+modifications.
+
+### Step 2: Raise `--max-turns` from 5 to 10
+
+**File:** `.github/workflows/claude-code-review.yml`
+
+Change `claude_args: "--max-turns 5"` to `claude_args: "--max-turns 10"`.
+
+Rationale: Successful runs complete in 3-5 turns. With 10 turns, even 2-3
+permission denials leave 7-8 effective turns — more than enough. This should
+bring the failure rate near zero.
+
+### Step 3: Update infra-failure classifier to filter max-turns exits
+
+**File:** `.github/workflows/claude-code-review.yml`
+
+Two changes to the classifier:
+
+a. When `EXECUTION_FILE` is blank (the most common failure path), emit a
+   warning annotation but **do not create a GitHub issue**. The action does not
+   set `execution_file` on `error_max_turns` exits, so blank means "probably
+   max-turns" — not an infra failure.
+
+b. When `EXECUTION_FILE` exists and `SUBTYPE` is `error_max_turns`, emit a
+   warning annotation but **do not create a GitHub issue**. Max-turns is a
+   normal operational boundary, not an infra failure.
+
+Issue creation is preserved for genuine infra failures: `execution_file_not_found`,
+`unparseable_execution_file`, `unknown`, and any other unexpected subtypes.
+
+### Step 4: Update regression tests
+
+**File:** `tests/unit/test_claude_review_workflow.py`
+
+| Test | Change |
+|------|--------|
+| `test_max_turns_value` | Assert `--max-turns 10` (was 5) |
+| `test_has_allowed_tools` | Remove — input does not exist in the action |
+| `test_allowed_tools_includes_read_tools` | Remove — dead code |
+| `test_allowed_tools_excludes_write_tools` | Remove — dead code |
+| `test_allowed_tools_includes_pr_comment` | Remove — dead code |
+| `_allowed_tools_set` helper | Remove — unused after above |
+| `test_has_infra_failure_flag_step` | Update docstring — issue creation is now conditional, not universal |
+| `test_classifier_handles_missing_execution_file` | Update — assert early exit (no `gh issue create`) on blank path |
+| (new) `test_classifier_suppresses_max_turns` | Add — assert `error_max_turns` path exits without issue creation |
+
+### Step 5: Batch-close spam issues
+
+Close all 14 open "claude-review infra failure" issues with a comment linking
+to this PR as the fix. This is a manual cleanup step after the PR merges, or
+can be done as part of PR validation.
+
+### Step 6: Validation
+
+- `uv run python -m pytest tests/unit/test_claude_review_workflow.py` — targeted
+- `make check-quiet` — full pre-PR validation
+
+## Parallelism Assessment
+
+This is a **single-file-pair change** (workflow + test file). No parallelism
+needed — all changes are tightly coupled and touch overlapping code.
+
+## Risks
+
+- **Max-turns 10 may increase cost per review.** Acceptable — the action runs
+  on Claude Code OAuth (subscription), not API billing.
+- **Blank `EXECUTION_FILE` could indicate a real crash, not max-turns.** Risk is
+  low — the warning annotation preserves visibility. If real crashes become
+  frequent, we can add log parsing in a follow-up. Known gap: OOM or token-expiry
+  crashes also produce blank `EXECUTION_FILE` and would be silently downgraded
+  to a warning. A future follow-up could add threshold-based alerting
+  (e.g., >N blank-file failures per week triggers escalation).
+
+## Outcome
+
+_To be filled after implementation._

--- a/tests/unit/test_claude_review_workflow.py
+++ b/tests/unit/test_claude_review_workflow.py
@@ -40,53 +40,34 @@ class TestClaudeReviewWorkflow:
         assert "do not" in prompt, "prompt must include prohibitions"
 
     def test_max_turns_value(self):
-        """Max turns must be explicitly set to a small bound."""
+        """Max turns must be explicitly set to a bounded value."""
         step = self._review_step()
         claude_args = step["with"]["claude_args"]
         assert (
-            claude_args == "--max-turns 5"
-        ), f"expected '--max-turns 5', got {claude_args!r}"
+            claude_args == "--max-turns 10"
+        ), f"expected '--max-turns 10', got {claude_args!r}"
 
     def test_no_continue_on_error(self):
         """Review step must NOT use continue-on-error — failures must be visible."""
         step = self._review_step()
         assert step.get("continue-on-error") is not True
 
-    # -- allowed_tools constraints --
+    def test_no_allowed_tools_input(self):
+        """allowed_tools is not a valid action input — must not be present.
 
-    def test_has_allowed_tools(self):
-        """Review step must declare an explicit allowed_tools allowlist."""
+        The anthropics/claude-code-action@v1 action silently ignores this input.
+        Its presence provides no tool restriction and adds confusion.
+        """
         step = self._review_step()
-        assert "allowed_tools" in step["with"], "allowed_tools must be present"
-
-    def test_allowed_tools_includes_read_tools(self):
-        """Allowlist must include core read-only inspection tools."""
-        tools = self._allowed_tools_set()
-        for required in ("Read", "Glob", "Grep"):
-            assert required in tools, f"missing read tool: {required}"
-
-    def test_allowed_tools_excludes_write_tools(self):
-        """Allowlist must NOT include tools that modify the repository."""
-        tools_text = self._review_step()["with"]["allowed_tools"]
-        for forbidden in ("Edit", "Write", "NotebookEdit"):
-            assert forbidden not in tools_text, f"write tool present: {forbidden}"
-        # No git push, git commit, or destructive gh commands
-        for forbidden_bash in ("git push", "git commit", "git checkout", "gh pr merge"):
-            assert (
-                forbidden_bash not in tools_text
-            ), f"destructive bash pattern present: {forbidden_bash}"
-
-    def test_allowed_tools_includes_pr_comment(self):
-        """Reviewer must be able to post PR comments (its primary output)."""
-        tools = self._allowed_tools_set()
-        assert any(
-            "gh pr comment" in t for t in tools
-        ), "must include Bash(gh pr comment *)"
+        assert "allowed_tools" not in step.get("with", {}), (
+            "allowed_tools is not a valid input for claude-code-action@v1 — "
+            "remove it (GitHub Actions ignores it silently)"
+        )
 
     # -- infra-failure classifier constraints --
 
     def test_has_infra_failure_flag_step(self):
-        """A follow-up step must create an issue on reviewer infra failure."""
+        """A follow-up step must handle reviewer failures (conditional issue creation)."""
         steps = self.cfg["jobs"]["claude-review"]["steps"]
         flag_steps = [
             s for s in steps if s.get("name") == "Flag reviewer infra failure"
@@ -95,20 +76,48 @@ class TestClaudeReviewWorkflow:
         flag_step = flag_steps[0]
         # Must scope to the review step specifically, not blanket failure()
         assert "steps.claude-review.outcome" in flag_step["if"]
-        # Must have GH_TOKEN for gh issue create
+        # Must have GH_TOKEN for gh issue create (used on genuine failures)
         assert "GH_TOKEN" in str(flag_step.get("env", {}))
 
-    def test_classifier_handles_missing_execution_file(self):
-        """Classifier must explicitly handle blank/missing EXECUTION_FILE."""
+    def test_classifier_suppresses_blank_execution_file(self):
+        """Blank EXECUTION_FILE must warn and exit 0, not create an issue.
+
+        The action does not set execution_file on error_max_turns exits.
+        Creating an issue for every blank file would spam the repo.
+        """
         flag_step = self._flag_step()
         script = flag_step["run"]
-        # Must check for blank EXECUTION_FILE (not just file-not-found)
+        # Must check for blank EXECUTION_FILE
         assert (
             '-z "$EXECUTION_FILE"' in script
         ), "classifier must check for blank EXECUTION_FILE"
+        # Must exit 0 (no issue creation) on blank path
+        # Find the blank-file branch and verify it has exit 0 before gh issue create
+        blank_idx = script.index('-z "$EXECUTION_FILE"')
+        exit_idx = script.index("exit 0", blank_idx)
+        issue_idx = script.index("gh issue create")
         assert (
-            "missing_execution_file" in script
-        ), "must classify blank EXECUTION_FILE as 'missing_execution_file'"
+            exit_idx < issue_idx
+        ), "blank EXECUTION_FILE path must exit 0 before reaching gh issue create"
+
+    def test_classifier_suppresses_max_turns(self):
+        """error_max_turns must warn and exit 0, not create an issue.
+
+        Max-turns exhaustion is a normal operational boundary, not an infra
+        failure. Issue creation is reserved for genuine infra failures.
+        """
+        flag_step = self._flag_step()
+        script = flag_step["run"]
+        assert (
+            "error_max_turns" in script
+        ), "classifier must check for error_max_turns subtype"
+        # The error_max_turns guard must exit 0 before gh issue create
+        max_turns_idx = script.index("error_max_turns")
+        exit_idx = script.index("exit 0", max_turns_idx)
+        issue_idx = script.index("gh issue create")
+        assert (
+            exit_idx < issue_idx
+        ), "error_max_turns path must exit 0 before reaching gh issue create"
 
     def test_classifier_handles_file_not_found(self):
         """Classifier must handle EXECUTION_FILE path set but file absent."""
@@ -146,8 +155,3 @@ class TestClaudeReviewWorkflow:
             if s.get("name") == "Flag reviewer infra failure":
                 return s
         raise AssertionError("Flag reviewer infra failure step not found")
-
-    def _allowed_tools_set(self) -> set[str]:
-        """Parse allowed_tools into a set of tool entries."""
-        raw = self._review_step()["with"]["allowed_tools"]
-        return {line.strip() for line in raw.strip().splitlines() if line.strip()}


### PR DESCRIPTION
## Summary

- Remove broken `allowed_tools` input — silently ignored by `anthropics/claude-code-action@v1` (not a valid input), providing zero tool restriction
- Raise `--max-turns` from 5 to 10 — 60% of runs were hitting max-turns because permission denials wasted 1-2 of the 5-turn budget
- Update infra-failure classifier to suppress issue creation for max-turns exits — blank `EXECUTION_FILE` and `error_max_turns` subtype now warn instead of creating noise issues

## Why

The claude-code-review workflow had a **60% failure rate** (18/30 recent runs). Every failure created a GitHub issue via the infra-failure classifier, producing 14+ open spam issues titled "claude-review infra failure on PR #XXXX".

**Root cause chain:**
1. `allowed_tools` is not a valid input for `claude-code-action@v1` → GitHub warns but ignores it → reviewer has unrestricted tool access
2. Reviewer tries write operations → permission denials waste 1-2 turns
3. With `--max-turns 5` and 2 denials, only 3 effective turns remain → `error_max_turns`
4. Action doesn't set `execution_file` output on max-turns exit → classifier sees blank → creates "missing_execution_file" issue

**Evidence from run logs:**
```
"subtype": "error_max_turns",
"num_turns": 6,
"permission_denials_count": 2
```

## Repro / Validation

```bash
# Targeted tests
uv run python -m pytest tests/unit/test_claude_review_workflow.py -v
# 12 passed

# Full validation
make check-quiet
# All checks passed
```

## Tests

- `test_max_turns_value` — asserts `--max-turns 10`
- `test_no_allowed_tools_input` — asserts `allowed_tools` is NOT present (was dead input)
- `test_classifier_suppresses_blank_execution_file` — asserts blank path exits before `gh issue create`
- `test_classifier_suppresses_max_turns` — asserts `error_max_turns` path exits before `gh issue create`
- Removed 4 tests for `allowed_tools` (dead input): `test_has_allowed_tools`, `test_allowed_tools_includes_read_tools`, `test_allowed_tools_excludes_write_tools`, `test_allowed_tools_includes_pr_comment`

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: fix/claude-review-max-turns
```

## Follow-up

- Close 14 open "claude-review infra failure" spam issues after merge
- Known gap: blank `EXECUTION_FILE` could mask genuine crashes (OOM, token expiry) — future follow-up could add threshold-based alerting

🤖 Generated with [Claude Code](https://claude.com/claude-code)