### PR TITLE
fix: close YAML and HTML injection gaps in skill promotion

### DIFF
--- a/src/bid_euchre/ops/skill_promotion.py
+++ b/src/bid_euchre/ops/skill_promotion.py
@@ -474,16 +474,24 @@ def _render_skill_md(candidate: SkillCandidate) -> str:
     # YAML front matter matching existing skill conventions
     provenance_lines = []
     for key, val in sorted(candidate.provenance.items()):
+        safe_key = _sanitize_comment(key)
         if isinstance(val, list):
             safe_vals = ", ".join(_sanitize_comment(v) for v in val)
-            provenance_lines.append(f"#   {key}: {safe_vals}")
+            provenance_lines.append(f"#   {safe_key}: {safe_vals}")
         else:
-            provenance_lines.append(f"#   {key}: {_sanitize_comment(val)}")
+            provenance_lines.append(f"#   {safe_key}: {_sanitize_comment(val)}")
 
     provenance_block = "\n".join(provenance_lines)
 
-    # Escape internal double quotes in YAML values
-    safe_desc = candidate.description.replace('"', '\\"')
+    # Escape YAML-significant characters in quoted scalar values.
+    # Newlines would break out of the quoted scalar and allow injection
+    # of extra front-matter keys; backslashes need escaping first.
+    safe_desc = (
+        candidate.description.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+    )
 
     return (
         (

--- a/tests/unit/test_ops_skill_promotion.py
+++ b/tests/unit/test_ops_skill_promotion.py
@@ -900,3 +900,45 @@ class TestRenderingSanitization:
         assert "-- >" in content
         # The raw --> should not appear in the provenance section
         assert "value --> escape" not in content
+
+    def test_provenance_keys_sanitized(self, candidates_dir: Path) -> None:
+        """Provenance keys containing --> are also sanitized (Codex finding)."""
+        c = propose_skill(
+            name="key-test",
+            description="Testing key sanitization",
+            content="# Test\n",
+            source_workflow="test",
+            proposed_by="author-b",
+            provenance={"evil-->key": "safe_value"},
+            candidates_dir=candidates_dir,
+        )
+        content = _render_skill_md(c)
+        assert "evil-- >key" in content
+        assert "evil-->key" not in content
+
+    def test_yaml_description_newline_injection(self, candidates_dir: Path) -> None:
+        """Description with embedded newlines cannot inject extra YAML keys (Codex finding)."""
+        c = _propose(
+            candidates_dir,
+            description='good"\nmalicious: yes\n"',
+        )
+        content = _render_skill_md(c)
+        # The front matter should be exactly 2 key lines: name and description.
+        # If newlines were not escaped, the injected text would appear as a
+        # third YAML key on its own line.
+        front_matter = content.split("---")[1]
+        lines = [ln for ln in front_matter.strip().split("\n") if ln.strip()]
+        assert len(lines) == 2, f"Expected 2 YAML lines, got {len(lines)}: {lines}"
+        assert lines[0].startswith("name:")
+        assert lines[1].startswith("description:")
+        # "malicious:" must not appear as a standalone YAML key (start of line)
+        for ln in lines:
+            assert not ln.strip().startswith(
+                "malicious:"
+            ), f"Injected YAML key found: {ln}"
+
+    def test_yaml_description_backslash_preserved(self, candidates_dir: Path) -> None:
+        """Backslashes in description are properly escaped."""
+        c = _propose(candidates_dir, description="path\\to\\file")
+        content = _render_skill_md(c)
+        assert 'description: "path\\\\to\\\\file"' in content


### PR DESCRIPTION
## Summary

Follow-up to #1070 — addresses two Codex review findings that were not included before #1070 was merged:

- **YAML newline injection:** Escape `\n`, `\r`, and `\\` in the YAML description field to prevent embedded newlines from breaking out of the quoted scalar and injecting extra front-matter keys
- **Provenance key sanitization:** Apply `_sanitize_comment()` to provenance keys (not just values) in the HTML comment block to prevent key-based `-->` comment injection/breakout

## Why

#1070 was merged while the Codex review follow-up commit was still propagating (GitHub PR API caching issue after force push). These two gaps were identified by Codex review and need a separate PR.

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_ops_skill_promotion.py -v
# 70 passed (3 new regression tests)

make check-quiet
# ✓ All checks passed
```

## Tests

- `test_provenance_keys_sanitized` — verifies `-->` in provenance keys is sanitized
- `test_yaml_description_newline_injection` — verifies embedded newlines cannot inject extra YAML keys
- `test_yaml_description_backslash_preserved` — verifies backslashes are properly escaped

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: fix/skill-promotion-injection-gaps
```

## Files changed

| File | Change |
|------|--------|
| `src/bid_euchre/ops/skill_promotion.py` | Escape `\n`/`\r`/`\\` in description; sanitize provenance keys |
| `tests/unit/test_ops_skill_promotion.py` | 3 new regression tests |


🤖 Generated with [Claude Code](https://claude.com/claude-code)