### PR TITLE
fix: include changes job in CI aggregation gate evaluation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,12 +213,13 @@ jobs:
 
       - name: Evaluate upstream results
         run: |
+          echo "changes:        ${{ needs.changes.result }}"
           echo "checks:         ${{ needs.checks.result }}"
           echo "tests-shard:    ${{ needs.tests-shard.result }}"
           echo "notebooks:      ${{ needs.notebooks.result }}"
           echo "promotion-gate: ${{ needs.promotion-gate.result }}"
 
-          results=("${{ needs.checks.result }}" "${{ needs.tests-shard.result }}" "${{ needs.notebooks.result }}" "${{ needs.promotion-gate.result }}")
+          results=("${{ needs.changes.result }}" "${{ needs.checks.result }}" "${{ needs.tests-shard.result }}" "${{ needs.notebooks.result }}" "${{ needs.promotion-gate.result }}")
           for r in "${results[@]}"; do
             if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then
               echo "::error::Upstream job result: $r"

--- a/tests/unit/test_ci_workflow.py
+++ b/tests/unit/test_ci_workflow.py
@@ -106,3 +106,25 @@ class TestCIWorkflowStructure:
             assert "install" not in name.lower()
             assert "checkout" not in name.lower()
             assert "setup" not in name.lower()
+
+    def test_aggregator_evaluates_all_upstream_jobs(self) -> None:
+        """The gate must check every upstream job including ``changes``.
+
+        If ``changes`` fails but is omitted from the evaluation, all
+        downstream jobs would be skipped and the gate would pass green,
+        silently masking the failure.
+        """
+        tests_job = self.jobs["tests"]
+        # Find the evaluation step that runs the bash gate logic
+        eval_steps = [
+            s
+            for s in tests_job.get("steps", [])
+            if "results=(" in str(s.get("run", ""))
+        ]
+        assert len(eval_steps) == 1, "Expected exactly one evaluation step"
+        run_script = eval_steps[0]["run"]
+        # Every job listed in needs must appear in the results array
+        for job_name in tests_job["needs"]:
+            assert (
+                f"needs.{job_name}.result" in run_script
+            ), f"Aggregator does not evaluate {job_name!r} result"


### PR DESCRIPTION
## Summary

- Add `needs.changes.result` to the `tests` aggregation gate's evaluation array
- Add regression test ensuring every `needs` dependency is evaluated by the gate

## Why

Follow-up fix for #1086. The `tests` aggregation gate declared `needs: [changes, ...]` but only evaluated 4 of 5 upstream results. If `changes` failed (e.g. paths-filter action error), all downstream jobs would be skipped and the gate would pass green — silently masking the failure.

## Validation

```
$ uv run python -m pytest -q tests/unit/test_ci_workflow.py tests/unit/test_ci_shard_baseline.py
15 passed in 0.68s
$ make repo-lint
Repo linter passed.
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml').read()); print('yaml ok')"
yaml ok
```

## Test plan

- [x] New `test_aggregator_evaluates_all_upstream_jobs` test passes
- [x] All 15 existing tests pass
- [x] YAML validation passes
- [x] Repo linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)