### PR TITLE
fix: restore dirty-worktree liveness fallback removed in #1091

### DIFF
--- a/plans/sessions/2026-03-20_restore-dirty-worktree-liveness.md
+++ b/plans/sessions/2026-03-20_restore-dirty-worktree-liveness.md
@@ -1,0 +1,114 @@
+# Restore Dirty-Worktree Liveness Fallback
+
+**Date:** 2026-03-20
+**Author:** author-b
+**Branch:** `fix/stale-slice-sequencing`
+
+## Problem
+
+PR #1091 rewrote the fallback liveness probe in `src/bid_euchre/ops/status.py`,
+replacing the old `_probe_lane_liveness()` with `_probe_fallback_liveness()`.
+The rewrite added 4 data-driven signals (events, task state, session metadata,
+registry last_active) but removed the dirty-worktree subprocess check that was
+previously signal #2.
+
+**Regression case:** A lane with uncommitted work in its worktree but no active
+session_id, no recent events, no in-progress tasks, and no fresh
+session/last_active timestamps is now reported as `idle` instead of
+`likely_active`. This reopens the trust gap that slice 6 was supposed to close.
+
+## Approach
+
+Restore dirty-worktree probing as the **lowest-priority** signal (#5) in
+`_probe_fallback_liveness()`. This preserves the #1091 design (data-driven
+signals first, subprocess last) while closing the regression.
+
+## Changes
+
+### 1. `src/bid_euchre/ops/status.py`
+
+#### `_probe_fallback_liveness()` — add signal #5
+
+- Add parameters: `worktree_path: str = ""`, `check_worktree: bool = True`
+- After signal #4 (registry last_active) and before the "no evidence" fallback,
+  add signal #5:
+  ```
+  # --- Signal 5: Dirty worktree (subprocess, lowest priority) ---
+  if check_worktree and worktree_path:
+      try:
+          from bid_euchre.ops.worktrees import is_worktree_dirty
+          if is_worktree_dirty(worktree_path):
+              wt_name = Path(worktree_path).name
+              return _LivenessProbe(
+                  is_likely_live=True,
+                  is_stale=False,
+                  source="worktree_dirty",
+                  detail=f"uncommitted changes in {wt_name}",
+              )
+      except Exception:
+          pass  # Subprocess failure — degrade gracefully, skip signal
+  ```
+- Update docstring to document signal #5
+
+#### `synthesize_lane_activity()` — pass worktree_path through
+
+- The `worktree_path` is already available via `lane.get("worktree_path", "")`
+  (line 740 in current code). Pass it to `_probe_fallback_liveness()`:
+  ```python
+  probe = _probe_fallback_liveness(
+      lane_id,
+      session=session,
+      lane_tasks=lane_tasks,
+      events=events,
+      last_active_ts=last_active_ts,
+      worktree_path=lane.get("worktree_path", ""),  # NEW
+      now=now,
+      stale_minutes=stale_minutes,
+  )
+  ```
+
+#### `LaneStatus.liveness_source` docstring
+
+- Add `"worktree_dirty"` to the documented set of source values (line 79)
+
+### 2. `tests/unit/test_ops_status.py`
+
+Add tests in two locations:
+
+#### `TestProbeFallbackLiveness` — unit tests for signal #5
+
+- `test_dirty_worktree_returns_likely_live` — mock `is_worktree_dirty` → True,
+  verify `is_likely_live=True, source="worktree_dirty"`
+- `test_clean_worktree_returns_idle` — mock `is_worktree_dirty` → False,
+  verify `is_likely_live=False, source=None`
+- `test_worktree_check_failure_degrades_gracefully` — mock raises exception,
+  verify returns idle (not crash)
+- `test_worktree_check_skipped_when_disabled` — `check_worktree=False`,
+  verify `is_worktree_dirty` not called
+- `test_worktree_signal_lowest_priority` — fresh event + dirty worktree →
+  `source="events"` (not `"worktree_dirty"`)
+
+#### `TestSynthesizeLaneActivityLiveness` — integration test
+
+- `test_likely_active_from_dirty_worktree` — lane with no session, no events,
+  no tasks, but dirty worktree → `state="likely_active"`, `liveness_source="worktree_dirty"`
+
+## Validation
+
+- **Tier 1:** `uv run python -m pytest tests/unit/test_ops_status.py -v`
+- **Tier 2:** `make check-quiet` before PR
+
+## Out of Scope
+
+- PR #1098 (slice 7) — already in flight, tracked separately
+- Platform pre-phase entry — blocked on slice 7, tracked in checkpoints
+- Stale docs (P2 finding) — already fixed by c61bc24c
+
+## Outcome
+
+Implemented and validated. PR pending.
+
+- `_probe_fallback_liveness()` now has signal #5 (dirty worktree) as lowest priority
+- `synthesize_lane_activity()` passes `worktree_path` through to the probe
+- 7 new tests added (6 unit + 1 integration), all passing
+- Full `make check-quiet` passes (149/149 status tests, 71/71 CLI tests)

--- a/src/bid_euchre/ops/status.py
+++ b/src/bid_euchre/ops/status.py
@@ -77,7 +77,7 @@ class LaneStatus:
     # --- Liveness provenance ---
     # Where the state determination came from:
     # "registry" (session_id), "events", "task_state", "session_metadata",
-    # "last_active", or None (genuinely idle / no evidence).
+    # "last_active", "worktree_dirty", or None (genuinely idle / no evidence).
     liveness_source: str | None = None
 
     # --- Event context (enriched from durable event log) ---
@@ -414,6 +414,8 @@ def _probe_fallback_liveness(
     last_active_ts: str | None,
     now: datetime,
     stale_minutes: int,
+    worktree_path: str | None = None,
+    check_worktree: bool = True,
 ) -> _LivenessProbe:
     """Check repo-local signals for lane activity beyond registry session_id.
 
@@ -425,6 +427,12 @@ def _probe_fallback_liveness(
        recent ``last_forward_progress_at`` timestamp.
     3. **Session metadata** — if the lane's session ``started_at`` is recent.
     4. **Registry last_active** — if the registry's ``last_active`` is recent.
+    5. **Dirty worktree** — if the worktree has uncommitted changes (subprocess
+       check, lowest priority).  Gated by ``check_worktree`` and requires a
+       valid ``worktree_path``.  Exceptions (``FileNotFoundError``,
+       ``subprocess.TimeoutExpired``, etc.) are caught and the signal is
+       silently skipped so that a subprocess failure never blocks status
+       aggregation.
 
     Returns a ``_LivenessProbe`` indicating whether the lane is likely live,
     stale (evidence exists but is aging), or genuinely idle.
@@ -437,6 +445,11 @@ def _probe_fallback_liveness(
         last_active_ts: Registry ``last_active`` timestamp, if any.
         now: Current time for freshness checks.
         stale_minutes: Threshold for "recent" evidence.
+        worktree_path: Filesystem path to the lane's worktree directory.
+            When provided (and ``check_worktree`` is True), a ``git status``
+            subprocess is used as the lowest-priority liveness signal.
+        check_worktree: If False, skip the dirty-worktree subprocess check
+            entirely.  Default True.
 
     Returns:
         ``_LivenessProbe`` with the determination.
@@ -551,6 +564,33 @@ def _probe_fallback_liveness(
                     ),
                 )
 
+    # --- Signal 5: Dirty worktree (subprocess, lowest priority) ---
+    # This is a last-resort check: if no data-driven signal found activity,
+    # check whether the worktree has uncommitted changes.  A dirty worktree
+    # strongly suggests someone is actively editing, even if the registry and
+    # event log have no record.
+    if check_worktree and worktree_path:
+        try:
+            from bid_euchre.ops.worktrees import is_worktree_dirty
+
+            if is_worktree_dirty(worktree_path):
+                wt_name = Path(worktree_path).name
+                return _LivenessProbe(
+                    is_likely_live=True,
+                    is_stale=False,
+                    source="worktree_dirty",
+                    detail=f"uncommitted changes in {wt_name}",
+                )
+        except Exception:  # noqa: BLE001
+            # Subprocess failures (FileNotFoundError, TimeoutExpired, git
+            # errors) must not block status aggregation.  Degrade gracefully
+            # by skipping this signal.
+            logger.debug(
+                "dirty-worktree check failed for %s, skipping signal",
+                worktree_path,
+                exc_info=True,
+            )
+
     # --- No fresh evidence found ---
     if stale_candidate is not None:
         return stale_candidate
@@ -650,6 +690,7 @@ def synthesize_lane_activity(
                 lane_tasks=lane_tasks,
                 events=events,
                 last_active_ts=last_active_ts,
+                worktree_path=lane.get("worktree_path") or None,
                 now=now,
                 stale_minutes=stale_minutes,
             )

--- a/tests/unit/test_ops_status.py
+++ b/tests/unit/test_ops_status.py
@@ -1653,6 +1653,152 @@ class TestProbeFallbackLiveness:
         assert probe.is_stale is False
         assert probe.source is None
 
+    def test_dirty_worktree_returns_likely_live(self, tmp_path: Path) -> None:
+        """Dirty worktree with no other evidence → likely_active."""
+        now = datetime(2026, 3, 20, 12, 0, 0, tzinfo=timezone.utc)
+        # Create a fake worktree dir so is_worktree_dirty can find it
+        wt = tmp_path / "wt-author-b"
+        wt.mkdir()
+        # Mock is_worktree_dirty to return True
+        import unittest.mock as mock
+
+        with mock.patch(
+            "bid_euchre.ops.worktrees.is_worktree_dirty", return_value=True
+        ):
+            probe = _probe_fallback_liveness(
+                "author-b",
+                session=None,
+                lane_tasks=[],
+                events=[],
+                last_active_ts=None,
+                now=now,
+                stale_minutes=30,
+                worktree_path=str(wt),
+            )
+        assert probe.is_likely_live is True
+        assert probe.is_stale is False
+        assert probe.source == "worktree_dirty"
+        assert "uncommitted changes" in probe.detail
+
+    def test_clean_worktree_returns_idle(self, tmp_path: Path) -> None:
+        """Clean worktree with no other evidence → genuinely idle."""
+        now = datetime(2026, 3, 20, 12, 0, 0, tzinfo=timezone.utc)
+        wt = tmp_path / "wt-author-b"
+        wt.mkdir()
+        import unittest.mock as mock
+
+        with mock.patch(
+            "bid_euchre.ops.worktrees.is_worktree_dirty", return_value=False
+        ):
+            probe = _probe_fallback_liveness(
+                "author-b",
+                session=None,
+                lane_tasks=[],
+                events=[],
+                last_active_ts=None,
+                now=now,
+                stale_minutes=30,
+                worktree_path=str(wt),
+            )
+        assert probe.is_likely_live is False
+        assert probe.is_stale is False
+        assert probe.source is None
+
+    def test_worktree_file_not_found_degrades_gracefully(self) -> None:
+        """FileNotFoundError from is_worktree_dirty → skip signal, idle."""
+        now = datetime(2026, 3, 20, 12, 0, 0, tzinfo=timezone.utc)
+        import unittest.mock as mock
+
+        with mock.patch(
+            "bid_euchre.ops.worktrees.is_worktree_dirty",
+            side_effect=FileNotFoundError("no such dir"),
+        ):
+            probe = _probe_fallback_liveness(
+                "author-b",
+                session=None,
+                lane_tasks=[],
+                events=[],
+                last_active_ts=None,
+                now=now,
+                stale_minutes=30,
+                worktree_path="/nonexistent/path",
+            )
+        assert probe.is_likely_live is False
+        assert probe.source is None
+
+    def test_worktree_subprocess_error_degrades_gracefully(self) -> None:
+        """Generic exception from is_worktree_dirty → skip signal, idle."""
+        now = datetime(2026, 3, 20, 12, 0, 0, tzinfo=timezone.utc)
+        import unittest.mock as mock
+
+        with mock.patch(
+            "bid_euchre.ops.worktrees.is_worktree_dirty",
+            side_effect=OSError("subprocess failed"),
+        ):
+            probe = _probe_fallback_liveness(
+                "author-b",
+                session=None,
+                lane_tasks=[],
+                events=[],
+                last_active_ts=None,
+                now=now,
+                stale_minutes=30,
+                worktree_path="/some/path",
+            )
+        assert probe.is_likely_live is False
+        assert probe.source is None
+
+    def test_worktree_check_skipped_when_disabled(self) -> None:
+        """check_worktree=False → is_worktree_dirty never called."""
+        now = datetime(2026, 3, 20, 12, 0, 0, tzinfo=timezone.utc)
+        import unittest.mock as mock
+
+        with mock.patch("bid_euchre.ops.worktrees.is_worktree_dirty") as mock_dirty:
+            probe = _probe_fallback_liveness(
+                "author-b",
+                session=None,
+                lane_tasks=[],
+                events=[],
+                last_active_ts=None,
+                now=now,
+                stale_minutes=30,
+                worktree_path="/some/path",
+                check_worktree=False,
+            )
+        mock_dirty.assert_not_called()
+        assert probe.is_likely_live is False
+        assert probe.source is None
+
+    def test_worktree_signal_lowest_priority(self) -> None:
+        """Fresh event takes priority over dirty worktree."""
+        now = datetime(2026, 3, 20, 12, 0, 0, tzinfo=timezone.utc)
+        events = [
+            {
+                "lane_id": "author-b",
+                "event_type": "ci_success",
+                "timestamp": "2026-03-20T11:50:00+00:00",
+            },
+        ]
+        import unittest.mock as mock
+
+        with mock.patch(
+            "bid_euchre.ops.worktrees.is_worktree_dirty", return_value=True
+        ) as mock_dirty:
+            probe = _probe_fallback_liveness(
+                "author-b",
+                session=None,
+                lane_tasks=[],
+                events=events,
+                last_active_ts=None,
+                now=now,
+                stale_minutes=30,
+                worktree_path="/some/path",
+            )
+        # Fresh event returns early — worktree check never reached
+        mock_dirty.assert_not_called()
+        assert probe.is_likely_live is True
+        assert probe.source == "events"
+
 
 class TestSynthesizeLaneActivityLiveness:
     """Tests for fallback liveness in synthesize_lane_activity()."""
@@ -1749,6 +1895,24 @@ class TestSynthesizeLaneActivityLiveness:
         lane = result[0]
         assert lane.state == "blocked"
         assert lane.liveness_source == "registry"
+
+    def test_likely_active_from_dirty_worktree(self) -> None:
+        """No session, no events, no tasks, but dirty worktree → likely_active."""
+        import unittest.mock as mock
+
+        now = datetime(2026, 3, 20, 12, 0, 0, tzinfo=timezone.utc)
+        lanes = [_make_lane("author-b")]  # worktree_path = /tmp/wt-author-b
+
+        with mock.patch(
+            "bid_euchre.ops.worktrees.is_worktree_dirty", return_value=True
+        ):
+            result = synthesize_lane_activity(lanes, {}, {}, [], now=now)
+
+        lane = result[0]
+        assert lane.state == "likely_active"
+        assert lane.liveness_source == "worktree_dirty"
+        # likely_active lanes are not flagged for attention (they're live)
+        assert lane.attention_needed is False
 
 
 class TestLivenessFormatting:


### PR DESCRIPTION
## Summary

- Restores the dirty-worktree subprocess check as signal #5 (lowest priority) in `_probe_fallback_liveness()`
- Wires `worktree_path` from lane registry data through `synthesize_lane_activity()` to the probe
- Adds 7 regression tests (6 unit + 1 integration)

## Why

PR #1091 rewrote the fallback liveness probe with 4 data-driven signals but removed the dirty-worktree subprocess check that was previously signal #2. This left a regression where a lane with uncommitted changes but no active session, events, tasks, or fresh timestamps would be reported as `idle` instead of `likely_active`.

## Changes

| File | Change |
|------|--------|
| `src/bid_euchre/ops/status.py` | Add `worktree_path` and `check_worktree` params to `_probe_fallback_liveness()`, add signal #5, pass `worktree_path` through `synthesize_lane_activity()`, update docstrings |
| `tests/unit/test_ops_status.py` | 6 unit tests for signal #5 (dirty→live, clean→idle, FileNotFoundError, OSError, disabled, priority) + 1 integration test |
| `plans/sessions/2026-03-20_restore-dirty-worktree-liveness.md` | Session plan |

## Repro / Validation

```bash
# Targeted tests (7 new)
uv run python -m pytest tests/unit/test_ops_status.py -v -k "dirty or worktree_dirty or clean_worktree or file_not_found or subprocess_error or skipped_when_disabled or lowest_priority"

# Full suite
uv run python -m pytest tests/unit/test_ops_status.py tests/unit/test_ops_cli.py -v
```

## Tests

- `make check-quiet` ✅ (149/149 status tests, 71/71 CLI tests)

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: fix/stale-slice-sequencing
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)