### PR TITLE
fix: add --disallowedTools to claude-review to prevent permission denials

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -50,7 +50,12 @@ jobs:
 
             Post your findings as review comments on the PR.
 
-          claude_args: "--max-turns 10"
+          # --disallowedTools prevents the reviewer from attempting write tools
+          # (Edit, Write, NotebookEdit) that get denied and waste turns toward
+          # the max-turns budget.  The allowed_tools action input does NOT work
+          # (not declared in claude-code-action@v1 action.yml) — use CLI flags
+          # via claude_args instead.
+          claude_args: '--max-turns 10 --disallowedTools "Edit,Write,NotebookEdit"'
 
       - name: Flag reviewer infra failure
         if: always() && steps.claude-review.outcome == 'failure'

--- a/plans/sessions/2026-03-20_claude-review-permission-denials.md
+++ b/plans/sessions/2026-03-20_claude-review-permission-denials.md
@@ -1,0 +1,51 @@
+# Session Plan: Fix claude-review permission denials
+
+**Date:** 2026-03-20
+**Lane:** author-c
+**Priority:** Medium — advisory reviewer effectiveness, not merge-blocking
+
+## Problem
+
+The Claude Code Review GitHub Action (`claude-code-review.yml`) hits
+`error_max_turns` on some PRs after 2 of its 10 turns are wasted on
+permission denials for write tools (Edit, Write, NotebookEdit).
+
+### Root Cause
+
+The `allowed_tools` action input (added in PR #1058, removed in PR #1085) is
+NOT a valid input for `anthropics/claude-code-action@v1` — it's not declared
+in the action's `action.yml` and is silently ignored by GitHub Actions.
+PR #1085 correctly removed it but left no replacement, so the reviewer has
+no tool restrictions and Claude occasionally attempts write tools.
+
+### Solution
+
+Use `--disallowedTools` CLI flag via `claude_args` instead. This is a valid
+Claude Code CLI flag that restricts tool access at the runtime level.
+
+```yaml
+claude_args: '--max-turns 10 --disallowedTools "Edit,Write,NotebookEdit"'
+```
+
+### Investigation: Local review loop CI gate (Problem 2)
+
+The review loop's `get_ci_status()` already uses `classify_check()` which
+correctly excludes `claude-review` (advisory) from CI checks. The docs
+freshness failure that blocked PR #1098 was a real CI failure in the `tests`
+job, now fixed. **No code change needed.**
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `.github/workflows/claude-code-review.yml` | Add `--disallowedTools` to `claude_args` |
+| `tests/unit/test_claude_review_workflow.py` | Add tests for disallowed tools, update max-turns test |
+
+## Validation
+
+- [x] Tier 1: `test_claude_review_workflow.py` — 14/14 passed
+- [ ] Tier 2: `make check-quiet` before PR
+
+## Outcome
+
+<!-- Fill after PR creation -->

--- a/tests/unit/test_claude_review_workflow.py
+++ b/tests/unit/test_claude_review_workflow.py
@@ -39,13 +39,13 @@ class TestClaudeReviewWorkflow:
         assert "read-only" in prompt, "prompt must state 'read-only'"
         assert "do not" in prompt, "prompt must include prohibitions"
 
-    def test_max_turns_value(self):
+    def test_max_turns_in_claude_args(self):
         """Max turns must be explicitly set to a bounded value."""
         step = self._review_step()
         claude_args = step["with"]["claude_args"]
         assert (
-            claude_args == "--max-turns 10"
-        ), f"expected '--max-turns 10', got {claude_args!r}"
+            "--max-turns 10" in claude_args
+        ), f"expected '--max-turns 10' in claude_args, got {claude_args!r}"
 
     def test_no_continue_on_error(self):
         """Review step must NOT use continue-on-error — failures must be visible."""
@@ -56,13 +56,34 @@ class TestClaudeReviewWorkflow:
         """allowed_tools is not a valid action input — must not be present.
 
         The anthropics/claude-code-action@v1 action silently ignores this input.
-        Its presence provides no tool restriction and adds confusion.
+        Tool restrictions must be passed via --disallowedTools in claude_args.
         """
         step = self._review_step()
         assert "allowed_tools" not in step.get("with", {}), (
             "allowed_tools is not a valid input for claude-code-action@v1 — "
-            "remove it (GitHub Actions ignores it silently)"
+            "use --disallowedTools in claude_args instead"
         )
+
+    def test_disallowed_tools_in_claude_args(self):
+        """claude_args must include --disallowedTools to block write tools.
+
+        Without this, the reviewer wastes turns on permission-denied attempts
+        to use Edit/Write/NotebookEdit, burning 2+ turns of the max-turns budget.
+        """
+        step = self._review_step()
+        claude_args = step["with"]["claude_args"]
+        assert (
+            "--disallowedTools" in claude_args
+        ), "claude_args must include --disallowedTools to prevent write tool denials"
+
+    def test_disallowed_tools_blocks_write_tools(self):
+        """The --disallowedTools list must include Edit, Write, and NotebookEdit."""
+        step = self._review_step()
+        claude_args = step["with"]["claude_args"]
+        for tool in ("Edit", "Write", "NotebookEdit"):
+            assert (
+                tool in claude_args
+            ), f"write tool '{tool}' must be in --disallowedTools list"
 
     # -- infra-failure classifier constraints --
 


### PR DESCRIPTION
## Plan
`plans/sessions/2026-03-20_claude-review-permission-denials.md`

## Summary
- Add `--disallowedTools "Edit,Write,NotebookEdit"` to `claude_args` in the Claude Code Review workflow to prevent write tool permission denials
- Add regression tests verifying the disallowed tools configuration
- Document investigation findings for both reported problems

## Why
The Claude Code Review GitHub Action was wasting 2/10 turns on permission denials when Claude attempted write tools (Edit, Write, NotebookEdit). This consumed 20% of the turn budget, contributing to `error_max_turns` exits.

The `allowed_tools` action input (added in PR #1058, removed in PR #1085) is NOT a valid input for `anthropics/claude-code-action@v1` — it's not declared in the action's `action.yml`. The correct approach is `--disallowedTools` passed via the `claude_args` CLI flag.

### Investigation findings (Problem 2: review loop CI gate)
The local review loop's `get_ci_status()` already uses `classify_check()` which correctly excludes `claude-review` (classified as "advisory") from CI aggregation. The docs freshness failure that blocked PR #1098's review loop was a real CI failure in the `tests` job, now fixed. **No code change needed.**

## Repro / Validation
**Command(s) run:**
```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/test_claude_review_workflow.py -v  # 14/14 passed

# Tier 2 — full validation
make check-quiet  # All checks passed
```

**Evidence (PR #1098 run):**
```
Run: https://github.com/Questuart/Bid-Euchre/actions/runs/23363169761
"subtype": "error_max_turns"
"num_turns": 11
"permission_denials_count": 2
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_claude_review_workflow.py -v` — 14/14 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None (workflow-only change)
- Runtime impact: Eliminates ~2 wasted turns per claude-review run, improving review completion rate

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         829bdafb [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c        8f71064e [codex/steward-author-c]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)