### PR TITLE
ops: fix get_retry_summary() chronology and close PR-5 docs

### DIFF
--- a/plans/agent_ops/0_bootstrap/checkpoints.md
+++ b/plans/agent_ops/0_bootstrap/checkpoints.md
@@ -75,3 +75,8 @@
 - Aligned session plan, checkpoints, governing plan, and operator docs.
 - Next: Step 3 (Platform-1 implementation handoff) opens once bridge gate
   is satisfied per the entry checklist.
+
+### 2026-03-20 -- author-a (summary chronology fix)
+- Fixed `get_retry_summary()` follow-up counting: was not chronology-aware
+  (#1112 fixed `get_pending_retries()` but missed the summary function).
+  Applied same string-comparison approach. 2 regression tests added.

--- a/plans/sessions/2026-03-20_pr5-closeout-baseline-cleanup.md
+++ b/plans/sessions/2026-03-20_pr5-closeout-baseline-cleanup.md
@@ -1,0 +1,54 @@
+# PR-5 Closeout Baseline Cleanup
+
+**Date:** 2026-03-20
+**Goal:** Close remaining baseline gaps so the repo is ready for the post-PR-5
+bridge and the later platform pre-phase.
+
+## Context
+
+PR-5 slices 5, 6, and 7 all merged. Several follow-up fixes also landed:
+
+- slice 5: `#1054` (+ hardening: `#1070`, `#1088`)
+- slice 6: `#1068`, `#1091`
+- slice 7: `#1098`
+- dirty-worktree liveness fallback: `#1104`
+- retry chronology for `get_pending_retries()`: `#1112`
+
+This cleanup PR addresses the one remaining code gap (`get_retry_summary()`
+chronology) and updates plan/checkpoint docs to match what actually shipped.
+
+## What This PR Does
+
+1. **Fix `get_retry_summary()` chronology** — the follow-up counting in
+   `get_retry_summary()` was not chronology-aware. #1112 fixed
+   `get_pending_retries()` but missed the summary function. This PR applies
+   the same string-comparison approach to the summary's follow-up counting.
+
+2. **Refresh closeout docs** — mark all slices done with correct PR
+   attributions, update blockers, set next queue.
+
+## What This PR Does NOT Do
+
+- `get_pending_retries()` fix — already on main via #1112
+- Dirty-worktree liveness — already on main via #1104
+- Review-event production wiring — deferred to bridge slice
+- Platform-1 implementation
+
+## Done When
+
+- [x] `get_retry_summary()` chronology fix applied
+- [x] Regression tests added
+- [x] PR-5 closeout docs match reality with correct attribution
+- [x] Review-event gap explicitly documented as deferred
+- [x] Targeted ops tests pass
+- [x] `make check-quiet` passes
+
+## Outcome
+
+1. **`get_retry_summary()` chronology fix (new in this PR):** Follow-up events
+   before the earliest failure for a task are no longer counted. Uses
+   string-comparison approach matching #1112's pattern. 2 new tests added.
+
+2. **Docs/checkpoint refresh:** Done with correct provenance — #1104 for
+   dirty-worktree, #1112 for `get_pending_retries()`, this PR for
+   `get_retry_summary()`. Next queue: bridge → filesystem → Platform-1.

--- a/src/bid_euchre/ops/retries.py
+++ b/src/bid_euchre/ops/retries.py
@@ -206,21 +206,30 @@ def get_retry_summary(events: list[dict[str, Any]]) -> RetrySummary:
     tasks have failures, how many were retried/rerouted/escalated,
     and how many are pending (dropped without follow-up).
 
+    Follow-up counting is **chronology-aware**: a follow-up event only
+    counts toward failures that occurred before it.  This matches
+    ``get_pending_retries()`` semantics.
+
     Args:
         events: List of event dicts (from ``read_events``).
 
     Returns:
         RetrySummary with aggregate counts.
     """
-    # Collect all task_ids with failures
+    # Collect all task_ids with failures and their earliest failure timestamp.
     failed_task_ids: set[str] = set()
+    earliest_failure: dict[str, str] = {}
     for event in events:
         if event.get("event_type") == "task_failed":
             task_id = _extract_task_id(event)
             if task_id:
                 failed_task_ids.add(task_id)
+                ts = event.get("timestamp", "")
+                if task_id not in earliest_failure or ts < earliest_failure[task_id]:
+                    earliest_failure[task_id] = ts
 
-    # Collect follow-up actions per task
+    # Collect follow-up actions per task (chronology-aware).
+    # A follow-up only counts if it occurs at or after the earliest failure.
     task_followups: dict[str, set[str]] = {tid: set() for tid in failed_task_ids}
     for event in events:
         event_type = event.get("event_type", "")
@@ -229,6 +238,13 @@ def get_retry_summary(events: list[dict[str, Any]]) -> RetrySummary:
             continue
         task_id = _extract_task_id(event)
         if task_id and task_id in task_followups:
+            followup_ts = event.get("timestamp", "")
+            task_earliest = earliest_failure.get(task_id, "")
+            # Only count follow-ups at or after the earliest failure.
+            # If timestamps are missing (empty string), count the follow-up
+            # to preserve backward compat for events without timestamps.
+            if followup_ts and task_earliest and followup_ts < task_earliest:
+                continue
             task_followups[task_id].add(action)
 
     # Count categories

--- a/tests/unit/test_ops_retries.py
+++ b/tests/unit/test_ops_retries.py
@@ -455,6 +455,65 @@ class TestGetRetrySummary:
         assert summary.retried_tasks == 1
         assert summary.dropped_count == 1
 
+    def test_summary_followup_before_failure_not_counted(self) -> None:
+        """Follow-up events before the earliest failure are not counted.
+
+        t1: retry@10:00, failed@10:05
+        The retry at 10:00 predates the failure at 10:05 and should not
+        register as a retried task in the summary.
+        """
+        events = [
+            _make_event(
+                "task_failed",
+                task_id="t1",
+                details="crash",
+                timestamp="2026-03-20T10:05:00Z",
+            ),
+            _make_event(
+                "retry_attempted",
+                task_id="t1",
+                timestamp="2026-03-20T10:00:00Z",
+            ),
+        ]
+        summary = get_retry_summary(events)
+        assert summary.total_tasks_with_failures == 1
+        # Retry predates the failure → should NOT count as retried
+        assert summary.retried_tasks == 0
+        # The failure is still pending (no follow-up after it)
+        assert summary.dropped_count == 1
+
+    def test_summary_retried_count_with_chronology(self) -> None:
+        """Summary counts reflect chronology-aware resolution.
+
+        t1: failed@10:00, retry@10:05, failed@10:10
+        The retry at 10:05 is after the earliest failure at 10:00,
+        so retried_tasks should count. But the newer failure at 10:10
+        makes t1 still pending (dropped).
+        """
+        events = [
+            _make_event(
+                "task_failed",
+                task_id="t1",
+                details="second crash",
+                timestamp="2026-03-20T10:10:00Z",
+            ),
+            _make_event(
+                "retry_attempted",
+                task_id="t1",
+                timestamp="2026-03-20T10:05:00Z",
+            ),
+            _make_event(
+                "task_failed",
+                task_id="t1",
+                details="first crash",
+                timestamp="2026-03-20T10:00:00Z",
+            ),
+        ]
+        summary = get_retry_summary(events)
+        assert summary.total_tasks_with_failures == 1
+        assert summary.retried_tasks == 1
+        assert summary.dropped_count == 1
+
     def test_to_dict(self) -> None:
         summary = RetrySummary(
             total_tasks_with_failures=2,


### PR DESCRIPTION
## Plan
`plans/sessions/2026-03-20_pr5-closeout-baseline-cleanup.md`

## Summary
- Fix `get_retry_summary()` chronology bug: follow-up events before the earliest failure were counted, inflating retried/resolved/rerouted/escalated counts
- Update checkpoints and session plan to reflect all PR-5 slices complete with correct PR attribution

## Why
#1112 fixed the same chronology bug in `get_pending_retries()` but missed `get_retry_summary()`. The summary's follow-up counting still used the old non-chronological approach where any follow-up for a task_id — even one predating the failure — was counted.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_retries.py -q
# 39 passed

make check-quiet
# All checks passed
```

**Chronology repro scenario (now a test):**
```
retry_attempted("t1") @ 10:00
task_failed("t1") @ 10:05

Before: summary.retried_tasks = 1 (wrong — retry predates failure)
After:  summary.retried_tasks = 0 (correct — retry doesn't resolve future failure)
```

## Tests
- [x] `make check-quiet` passes
- [x] 2 new `get_retry_summary()` chronology regression tests

## Expected impact
- Metrics impact: none (ops tooling only)
- Runtime impact: negligible — summary now tracks earliest failure timestamp per task

## Risk level
Low — bounded to `get_retry_summary()` in ops retry reporting. No changes to game engine, strategies, or experiment infrastructure.

## Provenance
- dirty-worktree liveness → #1104 (already on main)
- `get_pending_retries()` chronology → #1112 (already on main)
- `get_retry_summary()` chronology → **this PR**
- review-event emission → deferred to bridge slice

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: ops/pr5-slice7-followthrough
```

## Validation Performed
- Targeted tests: 39/39 passed
- `make check-quiet`: all checks passed
- Rebased on origin/main (1b2c0327, includes #1112)

🤖 Generated with [Claude Code](https://claude.com/claude-code)