### PR TITLE
ops: add repo-bounded filesystem access policy

### DIFF
--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -44,9 +44,48 @@ AUTHOR_SCRATCH="${PARENT_DIR}/${REPO_NAME}-steward-author-scratch"
 REVIEW="${PARENT_DIR}/${REPO_NAME}-steward-review"
 MAIN_DIR="$(git -C "$MAIN_DIR" worktree list 2>/dev/null | head -1 | awk '{print $1}')"
 
+# ---------------------------------------------------------------------------
+# Filesystem boundary validation
+# ---------------------------------------------------------------------------
+# Worktree paths must be within PARENT_DIR (the parent of the main checkout).
+# This is a repo-level guard — it does not claim OS-level sandboxing.
+
+validate_worktree_path() {
+    local path="$1"
+    local resolved
+    # Resolve the path (create parent dirs first if needed for realpath)
+    if [ -e "$path" ]; then
+        resolved="$(cd "$path" && pwd -P)"
+    else
+        # Path doesn't exist yet — resolve the parent
+        local parent
+        parent="$(dirname "$path")"
+        if [ ! -d "$parent" ]; then
+            echo "Error: parent directory does not exist: $parent" >&2
+            return 1
+        fi
+        resolved="$(cd "$parent" && pwd -P)/$(basename "$path")"
+    fi
+
+    local parent_resolved
+    parent_resolved="$(cd "$PARENT_DIR" && pwd -P)"
+
+    case "$resolved" in
+        "${parent_resolved}"/*)
+            return 0
+            ;;
+        *)
+            echo "Error: worktree path is outside the repo boundary: $resolved" >&2
+            echo "  Expected path under: $parent_resolved" >&2
+            return 1
+            ;;
+    esac
+}
+
 ensure_worktree() {
     local path="$1"
     local branch="$2"
+    validate_worktree_path "$path" || exit 1
     if [ -d "$path" ]; then
         return
     fi
@@ -54,6 +93,7 @@ ensure_worktree() {
 }
 
 ensure_review_worktree() {
+    validate_worktree_path "$REVIEW" || exit 1
     if [ -d "$REVIEW" ]; then
         return
     fi

--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -45,6 +45,53 @@ if TYPE_CHECKING:
     from bid_euchre.ops.recovery import RetryPolicy
 
 
+# ---------------------------------------------------------------------------
+# Filesystem boundary enforcement
+# ---------------------------------------------------------------------------
+
+
+def _check_boundary(
+    path: str | Path,
+    args: argparse.Namespace,
+    *,
+    label: str = "path",
+) -> int | None:
+    """Validate that *path* is within the repo boundary.
+
+    Returns ``None`` if the path is allowed, or ``1`` (error exit code) if it
+    is outside the boundary. Emits an audit event on violation.
+
+    This is a thin CLI adapter around
+    :func:`bid_euchre.ops.fs_boundary.require_in_boundary`.
+    """
+    from bid_euchre.ops.fs_boundary import (
+        BoundaryViolationError,
+        get_repo_boundaries,
+        require_in_boundary,
+    )
+
+    boundaries = get_repo_boundaries(repo_root=args.repo_root)
+    events_dir = args.runtime_dir / "events"
+
+    try:
+        require_in_boundary(
+            path,
+            repo_root=boundaries["repo_root"],
+            worktree_paths=boundaries["worktree_paths"],
+            runtime_dirs=boundaries["runtime_dirs"],
+            events_dir=events_dir,
+            source="ops.cli",
+        )
+    except BoundaryViolationError:
+        print(
+            f"Error: {label} is outside the repo boundary: {path}",
+            file=sys.stderr,
+        )
+        return 1
+
+    return None
+
+
 def cmd_status(args: argparse.Namespace) -> int:
     """Show status across lanes, sessions, and tasks."""
     from bid_euchre.ops.status import (
@@ -199,6 +246,11 @@ def cmd_worktrees_quarantine(args: argparse.Namespace) -> int:
         print("Error: worktree path required", file=sys.stderr)
         return 1
 
+    # Boundary check: reject external paths
+    boundary_rc = _check_boundary(wt_path, args, label="worktree path")
+    if boundary_rc is not None:
+        return boundary_rc
+
     reason = getattr(args, "reason", "Manual quarantine")
     events_dir = args.runtime_dir / "events"
 
@@ -230,6 +282,11 @@ def cmd_worktrees_archive(args: argparse.Namespace) -> int:
     if not wt_path:
         print("Error: worktree path required", file=sys.stderr)
         return 1
+
+    # Boundary check: reject external paths
+    boundary_rc = _check_boundary(wt_path, args, label="worktree path")
+    if boundary_rc is not None:
+        return boundary_rc
 
     force = getattr(args, "force", False)
     events_dir = args.runtime_dir / "events"
@@ -890,6 +947,11 @@ def cmd_snapshot_create(args: argparse.Namespace) -> int:
         print("Error: --worktree required", file=sys.stderr)
         return 1
 
+    # Boundary check: reject external paths
+    boundary_rc = _check_boundary(worktree, args, label="--worktree")
+    if boundary_rc is not None:
+        return boundary_rc
+
     try:
         record = create_snapshot(
             worktree,
@@ -1035,6 +1097,12 @@ def cmd_skills_propose(args: argparse.Namespace) -> int:
     from bid_euchre.ops.skill_promotion import propose_skill
 
     content_file = Path(args.content_file)
+
+    # Boundary check: reject external content files
+    boundary_rc = _check_boundary(content_file, args, label="--content-file")
+    if boundary_rc is not None:
+        return boundary_rc
+
     if not content_file.exists():
         print(f"Error: content file not found: {content_file}", file=sys.stderr)
         return 1

--- a/src/bid_euchre/ops/events.py
+++ b/src/bid_euchre/ops/events.py
@@ -48,6 +48,7 @@ VALID_EVENT_TYPES = frozenset(
         "snapshot_rolled_back",
         "skill_promoted",
         "skill_disabled",
+        "fs_boundary_violation",
     }
 )
 

--- a/src/bid_euchre/ops/fs_boundary.py
+++ b/src/bid_euchre/ops/fs_boundary.py
@@ -1,0 +1,352 @@
+"""Repo-bounded filesystem access policy.
+
+Classifies filesystem paths into boundary categories and enforces a
+default-deny policy for paths outside the repository boundary.
+
+**Boundary model:**
+
+- ``REPO_ROOT`` — the main git checkout
+- ``REGISTERED_WORKTREE`` — any worktree listed by ``git worktree list``
+- ``MANAGED_RUNTIME`` — ``.claude/runtime`` directories within repo/worktrees
+- ``EXPLICIT_EXCEPTION`` — paths outside the boundary that were explicitly
+  allowed by the caller (auditable)
+- ``EXTERNAL`` — everything else (denied by default)
+
+This module enforces what repo-owned code can enforce. It does **not** claim
+OS-level sandboxing or process confinement — those are outside the repo's
+control surface.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import subprocess
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("ops.fs_boundary")
+
+
+class PathClass(enum.Enum):
+    """Classification of a filesystem path relative to the repo boundary."""
+
+    REPO_ROOT = "repo_root"
+    REGISTERED_WORKTREE = "registered_worktree"
+    MANAGED_RUNTIME = "managed_runtime"
+    EXPLICIT_EXCEPTION = "explicit_exception"
+    EXTERNAL = "external"
+
+
+class BoundaryViolationError(ValueError):
+    """Raised when a path is outside the repo boundary and no exception applies."""
+
+    def __init__(self, path: str, classification: PathClass) -> None:
+        self.path = path
+        self.classification = classification
+        super().__init__(
+            f"Path is outside the repo boundary: {path} "
+            f"(classified as {classification.value})"
+        )
+
+
+def _resolve_no_symlink(p: Path) -> Path:
+    """Resolve a path fully, following symlinks to their real target.
+
+    This prevents symlink-based escapes from the boundary.
+    """
+    return p.resolve()
+
+
+def get_worktree_paths() -> list[str]:
+    """Get all worktree paths from ``git worktree list``.
+
+    Returns:
+        List of resolved absolute paths for all worktrees (including main).
+        Returns an empty list if the git command fails.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        logger.warning("Failed to list git worktrees")
+        return []
+
+    if result.returncode != 0:
+        return []
+
+    paths: list[str] = []
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            wt_path = line[len("worktree ") :]
+            paths.append(str(_resolve_no_symlink(Path(wt_path))))
+
+    return paths
+
+
+def get_repo_boundaries(
+    *,
+    repo_root: Path | None = None,
+    extra_worktree_paths: list[str] | None = None,
+) -> dict[str, Any]:
+    """Discover the current repo boundaries.
+
+    Args:
+        repo_root: Override for repo root. If None, uses cwd walk.
+        extra_worktree_paths: Additional worktree paths beyond what git reports.
+
+    Returns:
+        Dict with ``repo_root``, ``worktree_paths``, and ``runtime_dirs``.
+    """
+    if repo_root is None:
+        # Walk up from cwd to find .git
+        p = Path.cwd().resolve()
+        while p != p.parent:
+            if (p / ".git").exists():
+                repo_root = p
+                break
+            p = p.parent
+        if repo_root is None:
+            repo_root = Path.cwd().resolve()
+
+    repo_root = _resolve_no_symlink(repo_root)
+
+    # Get all worktree paths from git
+    worktree_paths = get_worktree_paths()
+
+    # Add extra worktree paths if provided
+    if extra_worktree_paths:
+        for wt in extra_worktree_paths:
+            resolved = str(_resolve_no_symlink(Path(wt)))
+            if resolved not in worktree_paths:
+                worktree_paths.append(resolved)
+
+    # Ensure repo_root is in the worktree list
+    repo_root_str = str(repo_root)
+    if repo_root_str not in worktree_paths:
+        worktree_paths.insert(0, repo_root_str)
+
+    # Runtime dirs: .claude/runtime under each worktree
+    runtime_dirs = []
+    for wt in worktree_paths:
+        rd = Path(wt) / ".claude" / "runtime"
+        runtime_dirs.append(str(_resolve_no_symlink(rd)))
+
+    return {
+        "repo_root": str(repo_root),
+        "worktree_paths": worktree_paths,
+        "runtime_dirs": runtime_dirs,
+    }
+
+
+def classify_path(
+    path: str | Path,
+    *,
+    repo_root: str,
+    worktree_paths: list[str],
+    runtime_dirs: list[str],
+    exceptions: list[str] | None = None,
+) -> PathClass:
+    """Classify a filesystem path against the repo boundary.
+
+    All comparisons use fully resolved paths to prevent symlink escapes.
+
+    Args:
+        path: The path to classify.
+        repo_root: Resolved absolute path to the main repo checkout.
+        worktree_paths: Resolved absolute paths to all registered worktrees.
+        runtime_dirs: Resolved absolute paths to managed runtime directories.
+        exceptions: Optional list of resolved paths that are explicitly allowed
+            outside the boundary.
+
+    Returns:
+        The PathClass classification for the given path.
+    """
+    resolved = str(_resolve_no_symlink(Path(path)))
+
+    # Check explicit exceptions first (most specific override)
+    if exceptions:
+        for exc_path in exceptions:
+            exc_resolved = str(_resolve_no_symlink(Path(exc_path)))
+            if resolved == exc_resolved or resolved.startswith(exc_resolved + "/"):
+                return PathClass.EXPLICIT_EXCEPTION
+
+    # Check managed runtime dirs (more specific than worktree/repo)
+    for rd in runtime_dirs:
+        if resolved == rd or resolved.startswith(rd + "/"):
+            return PathClass.MANAGED_RUNTIME
+
+    # Check repo root specifically
+    repo_root_resolved = str(_resolve_no_symlink(Path(repo_root)))
+    if resolved == repo_root_resolved or resolved.startswith(repo_root_resolved + "/"):
+        return PathClass.REPO_ROOT
+
+    # Check registered worktrees (excluding repo root, already checked)
+    for wt in worktree_paths:
+        wt_resolved = str(_resolve_no_symlink(Path(wt)))
+        if wt_resolved == repo_root_resolved:
+            continue  # Already checked above
+        if resolved == wt_resolved or resolved.startswith(wt_resolved + "/"):
+            return PathClass.REGISTERED_WORKTREE
+
+    return PathClass.EXTERNAL
+
+
+def require_in_boundary(
+    path: str | Path,
+    *,
+    repo_root: str,
+    worktree_paths: list[str],
+    runtime_dirs: list[str],
+    exceptions: list[str] | None = None,
+    emit_event: bool = True,
+    events_dir: Path | None = None,
+    source: str = "ops.fs_boundary",
+    lane_id: str = "ops",
+) -> PathClass:
+    """Validate that a path is within the repo boundary.
+
+    Args:
+        path: The path to validate.
+        repo_root: Resolved absolute path to the main repo checkout.
+        worktree_paths: Resolved absolute paths to all registered worktrees.
+        runtime_dirs: Resolved absolute paths to managed runtime directories.
+        exceptions: Optional list of paths explicitly allowed outside boundary.
+        emit_event: If True, emit an audit event on boundary violation.
+        events_dir: Override for events directory.
+        source: Event source identifier.
+        lane_id: Event lane identifier.
+
+    Returns:
+        The PathClass classification (never EXTERNAL unless exceptions apply).
+
+    Raises:
+        BoundaryViolationError: If the path is classified as EXTERNAL.
+    """
+    classification = classify_path(
+        path,
+        repo_root=repo_root,
+        worktree_paths=worktree_paths,
+        runtime_dirs=runtime_dirs,
+        exceptions=exceptions,
+    )
+
+    if classification == PathClass.EXTERNAL:
+        if emit_event:
+            _emit_violation_event(
+                str(path),
+                classification,
+                events_dir=events_dir,
+                source=source,
+                lane_id=lane_id,
+            )
+        raise BoundaryViolationError(str(path), classification)
+
+    return classification
+
+
+def check_path(
+    path: str | Path,
+    *,
+    boundaries: dict[str, Any] | None = None,
+    exceptions: list[str] | None = None,
+) -> PathClass:
+    """Convenience wrapper: classify a path using auto-discovered boundaries.
+
+    Args:
+        path: The path to classify.
+        boundaries: Pre-computed boundaries from ``get_repo_boundaries()``.
+            If None, boundaries are auto-discovered.
+        exceptions: Optional list of paths explicitly allowed outside boundary.
+
+    Returns:
+        The PathClass classification.
+    """
+    if boundaries is None:
+        boundaries = get_repo_boundaries()
+
+    return classify_path(
+        path,
+        repo_root=boundaries["repo_root"],
+        worktree_paths=boundaries["worktree_paths"],
+        runtime_dirs=boundaries["runtime_dirs"],
+        exceptions=exceptions,
+    )
+
+
+def require_path(
+    path: str | Path,
+    *,
+    boundaries: dict[str, Any] | None = None,
+    exceptions: list[str] | None = None,
+    emit_event: bool = True,
+    events_dir: Path | None = None,
+    source: str = "ops.fs_boundary",
+    lane_id: str = "ops",
+) -> PathClass:
+    """Convenience wrapper: require a path is in-boundary using auto-discovered boundaries.
+
+    Args:
+        path: The path to validate.
+        boundaries: Pre-computed boundaries from ``get_repo_boundaries()``.
+            If None, boundaries are auto-discovered.
+        exceptions: Optional list of paths explicitly allowed outside boundary.
+        emit_event: If True, emit an audit event on boundary violation.
+        events_dir: Override for events directory.
+        source: Event source identifier.
+        lane_id: Event lane identifier.
+
+    Returns:
+        The PathClass classification (never EXTERNAL).
+
+    Raises:
+        BoundaryViolationError: If the path is classified as EXTERNAL.
+    """
+    if boundaries is None:
+        boundaries = get_repo_boundaries()
+
+    return require_in_boundary(
+        path,
+        repo_root=boundaries["repo_root"],
+        worktree_paths=boundaries["worktree_paths"],
+        runtime_dirs=boundaries["runtime_dirs"],
+        exceptions=exceptions,
+        emit_event=emit_event,
+        events_dir=events_dir,
+        source=source,
+        lane_id=lane_id,
+    )
+
+
+def _emit_violation_event(
+    path: str,
+    classification: PathClass,
+    *,
+    events_dir: Path | None = None,
+    source: str = "ops.fs_boundary",
+    lane_id: str = "ops",
+) -> None:
+    """Emit an audit event for a boundary violation.
+
+    Best-effort: failures are logged but do not propagate.
+    """
+    try:
+        from bid_euchre.ops.events import append_event
+
+        append_event(
+            "fs_boundary_violation",
+            source,
+            lane_id,
+            {
+                "path": path,
+                "classification": classification.value,
+                "action": "denied",
+            },
+            events_dir,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning("Failed to emit boundary violation event for %s", path)

--- a/tests/unit/test_fs_boundary.py
+++ b/tests/unit/test_fs_boundary.py
@@ -1,0 +1,357 @@
+"""Tests for the repo-bounded filesystem access policy.
+
+Covers path classification, boundary enforcement, symlink traversal
+prevention, and audit event emission.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bid_euchre.ops.fs_boundary import (
+    BoundaryViolationError,
+    PathClass,
+    classify_path,
+    require_in_boundary,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def repo_layout(tmp_path: Path) -> dict[str, str]:
+    """Build a fake repo layout with worktrees and runtime dirs.
+
+    Returns resolved string paths for each component.
+    """
+    repo_root = tmp_path / "Bid-Euchre"
+    repo_root.mkdir()
+    (repo_root / ".git").mkdir()
+
+    wt_author = tmp_path / "Bid-Euchre-steward-author"
+    wt_author.mkdir()
+
+    wt_review = tmp_path / "Bid-Euchre-steward-review"
+    wt_review.mkdir()
+
+    runtime = repo_root / ".claude" / "runtime"
+    runtime.mkdir(parents=True)
+    events = runtime / "events"
+    events.mkdir()
+
+    # Runtime dir under a worktree too
+    wt_runtime = wt_author / ".claude" / "runtime"
+    wt_runtime.mkdir(parents=True)
+
+    external = tmp_path / "unrelated-project"
+    external.mkdir()
+
+    return {
+        "repo_root": str(repo_root.resolve()),
+        "worktree_paths": [
+            str(repo_root.resolve()),
+            str(wt_author.resolve()),
+            str(wt_review.resolve()),
+        ],
+        "runtime_dirs": [
+            str(runtime.resolve()),
+            str(wt_runtime.resolve()),
+        ],
+        "external": str(external.resolve()),
+        "events_dir": str(events.resolve()),
+    }
+
+
+# ---------------------------------------------------------------------------
+# classify_path tests
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyPath:
+    """Tests for classify_path()."""
+
+    def test_repo_root_exact(self, repo_layout: dict[str, str]) -> None:
+        result = classify_path(
+            repo_layout["repo_root"],
+            repo_root=repo_layout["repo_root"],
+            worktree_paths=repo_layout["worktree_paths"],
+            runtime_dirs=repo_layout["runtime_dirs"],
+        )
+        assert result == PathClass.REPO_ROOT
+
+    def test_repo_root_subpath(self, repo_layout: dict[str, str]) -> None:
+        subpath = Path(repo_layout["repo_root"]) / "src" / "file.py"
+        result = classify_path(
+            str(subpath),
+            repo_root=repo_layout["repo_root"],
+            worktree_paths=repo_layout["worktree_paths"],
+            runtime_dirs=repo_layout["runtime_dirs"],
+        )
+        assert result == PathClass.REPO_ROOT
+
+    def test_registered_worktree_exact(self, repo_layout: dict[str, str]) -> None:
+        # The second worktree (not repo root)
+        wt = repo_layout["worktree_paths"][1]
+        result = classify_path(
+            wt,
+            repo_root=repo_layout["repo_root"],
+            worktree_paths=repo_layout["worktree_paths"],
+            runtime_dirs=repo_layout["runtime_dirs"],
+        )
+        assert result == PathClass.REGISTERED_WORKTREE
+
+    def test_registered_worktree_subpath(self, repo_layout: dict[str, str]) -> None:
+        wt = repo_layout["worktree_paths"][2]
+        subpath = Path(wt) / "tests" / "test_something.py"
+        result = classify_path(
+            str(subpath),
+            repo_root=repo_layout["repo_root"],
+            worktree_paths=repo_layout["worktree_paths"],
+            runtime_dirs=repo_layout["runtime_dirs"],
+        )
+        assert result == PathClass.REGISTERED_WORKTREE
+
+    def test_managed_runtime(self, repo_layout: dict[str, str]) -> None:
+        runtime = repo_layout["runtime_dirs"][0]
+        result = classify_path(
+            runtime,
+            repo_root=repo_layout["repo_root"],
+            worktree_paths=repo_layout["worktree_paths"],
+            runtime_dirs=repo_layout["runtime_dirs"],
+        )
+        assert result == PathClass.MANAGED_RUNTIME
+
+    def test_managed_runtime_subpath(self, repo_layout: dict[str, str]) -> None:
+        subpath = Path(repo_layout["runtime_dirs"][0]) / "events" / "events.jsonl"
+        result = classify_path(
+            str(subpath),
+            repo_root=repo_layout["repo_root"],
+            worktree_paths=repo_layout["worktree_paths"],
+            runtime_dirs=repo_layout["runtime_dirs"],
+        )
+        assert result == PathClass.MANAGED_RUNTIME
+
+    def test_managed_runtime_in_worktree(self, repo_layout: dict[str, str]) -> None:
+        """Runtime dir under a worktree is MANAGED_RUNTIME, not REGISTERED_WORKTREE."""
+        result = classify_path(
+            repo_layout["runtime_dirs"][1],
+            repo_root=repo_layout["repo_root"],
+            worktree_paths=repo_layout["worktree_paths"],
+            runtime_dirs=repo_layout["runtime_dirs"],
+        )
+        assert result == PathClass.MANAGED_RUNTIME
+
+    def test_external_path(self, repo_layout: dict[str, str]) -> None:
+        result = classify_path(
+            repo_layout["external"],
+            repo_root=repo_layout["repo_root"],
+            worktree_paths=repo_layout["worktree_paths"],
+            runtime_dirs=repo_layout["runtime_dirs"],
+        )
+        assert result == PathClass.EXTERNAL
+
+    def test_explicit_exception(self, repo_layout: dict[str, str]) -> None:
+        result = classify_path(
+            repo_layout["external"],
+            repo_root=repo_layout["repo_root"],
+            worktree_paths=repo_layout["worktree_paths"],
+            runtime_dirs=repo_layout["runtime_dirs"],
+            exceptions=[repo_layout["external"]],
+        )
+        assert result == PathClass.EXPLICIT_EXCEPTION
+
+    def test_explicit_exception_subpath(self, repo_layout: dict[str, str]) -> None:
+        """A subpath of an exception dir is also EXPLICIT_EXCEPTION."""
+        subpath = Path(repo_layout["external"]) / "data" / "file.txt"
+        result = classify_path(
+            str(subpath),
+            repo_root=repo_layout["repo_root"],
+            worktree_paths=repo_layout["worktree_paths"],
+            runtime_dirs=repo_layout["runtime_dirs"],
+            exceptions=[repo_layout["external"]],
+        )
+        assert result == PathClass.EXPLICIT_EXCEPTION
+
+    def test_root_path_is_external(self, repo_layout: dict[str, str]) -> None:
+        """The root filesystem '/' should be classified as external."""
+        result = classify_path(
+            "/",
+            repo_root=repo_layout["repo_root"],
+            worktree_paths=repo_layout["worktree_paths"],
+            runtime_dirs=repo_layout["runtime_dirs"],
+        )
+        assert result == PathClass.EXTERNAL
+
+    def test_home_dir_is_external(self, repo_layout: dict[str, str]) -> None:
+        result = classify_path(
+            "/Users/someone/Documents",
+            repo_root=repo_layout["repo_root"],
+            worktree_paths=repo_layout["worktree_paths"],
+            runtime_dirs=repo_layout["runtime_dirs"],
+        )
+        assert result == PathClass.EXTERNAL
+
+
+# ---------------------------------------------------------------------------
+# Symlink traversal tests
+# ---------------------------------------------------------------------------
+
+
+class TestSymlinkTraversal:
+    """Verify that symlinks cannot be used to escape the boundary."""
+
+    def test_symlink_to_external_is_external(
+        self, repo_layout: dict[str, str], tmp_path: Path
+    ) -> None:
+        """A symlink inside the repo pointing outside is classified by its real target."""
+        external_target = Path(repo_layout["external"]) / "secret.txt"
+        external_target.write_text("secret data")
+
+        repo_link = Path(repo_layout["repo_root"]) / "sneaky_link"
+        repo_link.symlink_to(external_target)
+
+        result = classify_path(
+            str(repo_link),
+            repo_root=repo_layout["repo_root"],
+            worktree_paths=repo_layout["worktree_paths"],
+            runtime_dirs=repo_layout["runtime_dirs"],
+        )
+        assert result == PathClass.EXTERNAL
+
+    def test_symlink_within_repo_is_allowed(self, repo_layout: dict[str, str]) -> None:
+        """A symlink from one repo location to another is fine."""
+        src = Path(repo_layout["repo_root"]) / "src"
+        src.mkdir(exist_ok=True)
+        target = Path(repo_layout["repo_root"]) / "src" / "real_file.py"
+        target.write_text("# code")
+
+        link = Path(repo_layout["repo_root"]) / "link_to_src"
+        link.symlink_to(target)
+
+        result = classify_path(
+            str(link),
+            repo_root=repo_layout["repo_root"],
+            worktree_paths=repo_layout["worktree_paths"],
+            runtime_dirs=repo_layout["runtime_dirs"],
+        )
+        assert result == PathClass.REPO_ROOT
+
+
+# ---------------------------------------------------------------------------
+# require_in_boundary tests
+# ---------------------------------------------------------------------------
+
+
+class TestRequireInBoundary:
+    """Tests for require_in_boundary()."""
+
+    def test_allows_repo_root(self, repo_layout: dict[str, str]) -> None:
+        result = require_in_boundary(
+            repo_layout["repo_root"],
+            repo_root=repo_layout["repo_root"],
+            worktree_paths=repo_layout["worktree_paths"],
+            runtime_dirs=repo_layout["runtime_dirs"],
+            emit_event=False,
+        )
+        assert result == PathClass.REPO_ROOT
+
+    def test_allows_worktree(self, repo_layout: dict[str, str]) -> None:
+        result = require_in_boundary(
+            repo_layout["worktree_paths"][1],
+            repo_root=repo_layout["repo_root"],
+            worktree_paths=repo_layout["worktree_paths"],
+            runtime_dirs=repo_layout["runtime_dirs"],
+            emit_event=False,
+        )
+        assert result == PathClass.REGISTERED_WORKTREE
+
+    def test_allows_runtime(self, repo_layout: dict[str, str]) -> None:
+        result = require_in_boundary(
+            repo_layout["runtime_dirs"][0],
+            repo_root=repo_layout["repo_root"],
+            worktree_paths=repo_layout["worktree_paths"],
+            runtime_dirs=repo_layout["runtime_dirs"],
+            emit_event=False,
+        )
+        assert result == PathClass.MANAGED_RUNTIME
+
+    def test_rejects_external(self, repo_layout: dict[str, str]) -> None:
+        with pytest.raises(BoundaryViolationError) as exc_info:
+            require_in_boundary(
+                repo_layout["external"],
+                repo_root=repo_layout["repo_root"],
+                worktree_paths=repo_layout["worktree_paths"],
+                runtime_dirs=repo_layout["runtime_dirs"],
+                emit_event=False,
+            )
+        assert exc_info.value.classification == PathClass.EXTERNAL
+        assert repo_layout["external"] in str(exc_info.value)
+
+    def test_allows_explicit_exception(self, repo_layout: dict[str, str]) -> None:
+        result = require_in_boundary(
+            repo_layout["external"],
+            repo_root=repo_layout["repo_root"],
+            worktree_paths=repo_layout["worktree_paths"],
+            runtime_dirs=repo_layout["runtime_dirs"],
+            exceptions=[repo_layout["external"]],
+            emit_event=False,
+        )
+        assert result == PathClass.EXPLICIT_EXCEPTION
+
+    def test_emits_audit_event_on_violation(self, repo_layout: dict[str, str]) -> None:
+        """Boundary violation should emit an audit event to the event log."""
+        events_dir = Path(repo_layout["events_dir"])
+
+        with pytest.raises(BoundaryViolationError):
+            require_in_boundary(
+                repo_layout["external"],
+                repo_root=repo_layout["repo_root"],
+                worktree_paths=repo_layout["worktree_paths"],
+                runtime_dirs=repo_layout["runtime_dirs"],
+                emit_event=True,
+                events_dir=events_dir,
+            )
+
+        # Verify event was written
+        events_file = events_dir / "events.jsonl"
+        assert events_file.exists(), "Expected events.jsonl to be created"
+
+        lines = events_file.read_text().strip().splitlines()
+        assert len(lines) >= 1
+
+        event = json.loads(lines[-1])
+        assert event["event_type"] == "fs_boundary_violation"
+        assert event["payload"]["classification"] == "external"
+        assert event["payload"]["action"] == "denied"
+        assert repo_layout["external"] in event["payload"]["path"]
+
+
+# ---------------------------------------------------------------------------
+# PathClass enum tests
+# ---------------------------------------------------------------------------
+
+
+class TestPathClassEnum:
+    """Basic tests for PathClass values."""
+
+    def test_all_values(self) -> None:
+        expected = {
+            "repo_root",
+            "registered_worktree",
+            "managed_runtime",
+            "explicit_exception",
+            "external",
+        }
+        actual = {pc.value for pc in PathClass}
+        assert actual == expected
+
+    def test_boundary_violation_error_attributes(self) -> None:
+        err = BoundaryViolationError("/tmp/evil", PathClass.EXTERNAL)
+        assert err.path == "/tmp/evil"
+        assert err.classification == PathClass.EXTERNAL
+        assert "outside the repo boundary" in str(err)

--- a/tests/unit/test_ops_cli.py
+++ b/tests/unit/test_ops_cli.py
@@ -522,6 +522,9 @@ class TestCmdWorktreesQuarantine:
 
         import ops
 
+        # Bypass boundary check — this test covers quarantine logic, not boundary
+        monkeypatch.setattr(ops, "_check_boundary", lambda *a, **kw: None)
+
         rc = ops.main(
             [
                 "--runtime-dir",
@@ -2014,3 +2017,296 @@ class TestCompactSessionContextCli:
             ]
         )
         assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Filesystem boundary tests
+# ---------------------------------------------------------------------------
+
+
+class TestBoundaryRejection:
+    """Tests that CLI commands reject paths outside the repo boundary."""
+
+    def _mock_boundaries(
+        self, monkeypatch: pytest.MonkeyPatch, repo_root: Path
+    ) -> None:
+        """Set up fs_boundary mocks that make *repo_root* the boundary."""
+        from bid_euchre.ops import fs_boundary
+
+        repo_root_str = str(repo_root.resolve())
+        runtime_str = str((repo_root / ".claude" / "runtime").resolve())
+
+        fake_boundaries = {
+            "repo_root": repo_root_str,
+            "worktree_paths": [repo_root_str],
+            "runtime_dirs": [runtime_str],
+        }
+        monkeypatch.setattr(
+            fs_boundary,
+            "get_repo_boundaries",
+            lambda **kw: fake_boundaries,
+        )
+
+    def test_quarantine_rejects_external(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """worktrees quarantine should reject paths outside the boundary."""
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        (repo_root / ".git").mkdir()
+        self._mock_boundaries(monkeypatch, repo_root)
+
+        import ops
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "worktrees",
+                "quarantine",
+                "/tmp/evil-worktree",
+                "--reason",
+                "test",
+            ]
+        )
+        assert rc == 1
+        assert "outside the repo boundary" in capsys.readouterr().err
+
+    def test_archive_rejects_external(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """worktrees archive should reject paths outside the boundary."""
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        (repo_root / ".git").mkdir()
+        self._mock_boundaries(monkeypatch, repo_root)
+
+        import ops
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "worktrees",
+                "archive",
+                "/tmp/evil-worktree",
+            ]
+        )
+        assert rc == 1
+        assert "outside the repo boundary" in capsys.readouterr().err
+
+    def test_snapshot_create_rejects_external(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """snapshot create should reject --worktree paths outside the boundary."""
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        (repo_root / ".git").mkdir()
+        self._mock_boundaries(monkeypatch, repo_root)
+
+        import ops
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "snapshot",
+                "create",
+                "--worktree",
+                "/tmp/evil-worktree",
+                "--reason",
+                "test",
+            ]
+        )
+        assert rc == 1
+        assert "outside the repo boundary" in capsys.readouterr().err
+
+    def test_skills_propose_rejects_external(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """skills propose should reject --content-file paths outside the boundary."""
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        (repo_root / ".git").mkdir()
+        self._mock_boundaries(monkeypatch, repo_root)
+
+        # Create a content file outside the boundary
+        external_file = tmp_path / "external" / "skill.md"
+        external_file.parent.mkdir()
+        external_file.write_text("# Evil skill")
+
+        import ops
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "skills",
+                "propose",
+                "--name",
+                "evil-skill",
+                "--description",
+                "test skill",
+                "--content-file",
+                str(external_file),
+                "--source-workflow",
+                "test",
+                "--proposed-by",
+                "ops",
+            ]
+        )
+        assert rc == 1
+        assert "outside the repo boundary" in capsys.readouterr().err
+
+    def test_snapshot_create_allows_in_boundary(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """snapshot create should allow --worktree paths inside the boundary.
+
+        The path passes the boundary check but create_snapshot may still fail
+        because the test dir isn't a real git repo — that's expected.
+        We only verify the error is NOT a boundary violation.
+        """
+        import subprocess as sp
+
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        (repo_root / ".git").mkdir()
+        self._mock_boundaries(monkeypatch, repo_root)
+
+        wt_path = repo_root / "some-subdir"
+        wt_path.mkdir()
+
+        import ops
+
+        # create_snapshot will call git commands that fail in test env.
+        # We want to verify boundary check passes — not that snapshot works.
+        # Track whether _check_boundary was called and returned None (allowed).
+        original_check = ops._check_boundary
+        boundary_result = []
+
+        def tracking_check(*a, **kw):
+            result = original_check(*a, **kw)
+            boundary_result.append(result)
+            return result
+
+        monkeypatch.setattr(ops, "_check_boundary", tracking_check)
+
+        # The command may raise or return 1 — we don't care
+        try:
+            ops.main(
+                [
+                    "--runtime-dir",
+                    str(runtime_dir),
+                    "--plans-dir",
+                    str(plans_dir),
+                    "snapshot",
+                    "create",
+                    "--worktree",
+                    str(wt_path),
+                    "--reason",
+                    "test",
+                ]
+            )
+        except (sp.SubprocessError, OSError):
+            pass  # Expected: test dir isn't a real git repo
+
+        # Boundary check was called and returned None (allowed)
+        assert boundary_result == [
+            None
+        ], f"Expected boundary check to allow the path, got {boundary_result}"
+
+    def test_quarantine_allows_registered_worktree(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Paths within a registered worktree should pass boundary checks."""
+        import subprocess as sp
+
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        (repo_root / ".git").mkdir()
+
+        wt_path = tmp_path / "Bid-Euchre-steward-author"
+        wt_path.mkdir()
+
+        from bid_euchre.ops import fs_boundary
+
+        repo_root_str = str(repo_root.resolve())
+        wt_str = str(wt_path.resolve())
+        runtime_str = str((repo_root / ".claude" / "runtime").resolve())
+
+        monkeypatch.setattr(
+            fs_boundary,
+            "get_repo_boundaries",
+            lambda **kw: {
+                "repo_root": repo_root_str,
+                "worktree_paths": [repo_root_str, wt_str],
+                "runtime_dirs": [runtime_str],
+            },
+        )
+
+        # Mock subprocess so quarantine itself doesn't fail
+        monkeypatch.setattr(
+            sp,
+            "run",
+            lambda *a, **kw: type(
+                "R", (), {"returncode": 0, "stdout": "diff\n", "stderr": ""}
+            )(),
+        )
+
+        import ops
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "worktrees",
+                "quarantine",
+                str(wt_path),
+                "--reason",
+                "test",
+            ]
+        )
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "outside the repo boundary" not in captured.err

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -250,6 +250,131 @@ class TestStewardSessionScript:
             "write_lane_metadata" in content
         ), "steward-session.sh must call write_lane_metadata for lane registry"
 
+    def test_has_boundary_validation(self) -> None:
+        """Script must contain validate_worktree_path() for boundary enforcement."""
+        content = STEWARD_SCRIPT.read_text()
+        assert "validate_worktree_path" in content, (
+            "steward-session.sh must define validate_worktree_path() for "
+            "filesystem boundary enforcement"
+        )
+
+    def test_ensure_worktree_calls_boundary_check(self) -> None:
+        """ensure_worktree() must call validate_worktree_path before creating."""
+        content = STEWARD_SCRIPT.read_text()
+        # Find ensure_worktree body and verify it calls validate_worktree_path
+        in_func = False
+        func_lines: list[str] = []
+        for line in content.split("\n"):
+            if "ensure_worktree()" in line and "validate" not in line:
+                in_func = True
+            if in_func:
+                func_lines.append(line)
+                if line.strip() == "}" and in_func:
+                    break
+        func_body = "\n".join(func_lines)
+        assert (
+            "validate_worktree_path" in func_body
+        ), "ensure_worktree() must call validate_worktree_path before creating"
+
+
+class TestBoundaryValidation:
+    """Tests for validate_worktree_path() in steward-session.sh."""
+
+    def test_accepts_path_in_parent_dir(self, tmp_path: Path) -> None:
+        """Paths within PARENT_DIR should be accepted."""
+        parent = tmp_path / "parent"
+        parent.mkdir()
+        wt_path = parent / "worktree"
+        wt_path.mkdir()
+
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                f"""
+PARENT_DIR="{parent}"
+validate_worktree_path() {{
+    local path="$1"
+    local resolved
+    if [ -e "$path" ]; then
+        resolved="$(cd "$path" && pwd -P)"
+    else
+        local par
+        par="$(dirname "$path")"
+        if [ ! -d "$par" ]; then
+            echo "Error: parent directory does not exist: $par" >&2
+            return 1
+        fi
+        resolved="$(cd "$par" && pwd -P)/$(basename "$path")"
+    fi
+    local parent_resolved
+    parent_resolved="$(cd "$PARENT_DIR" && pwd -P)"
+    case "$resolved" in
+        "${{parent_resolved}}"/*)
+            return 0
+            ;;
+        *)
+            echo "Error: worktree path is outside the repo boundary: $resolved" >&2
+            return 1
+            ;;
+    esac
+}}
+validate_worktree_path "{wt_path}"
+""",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+
+    def test_rejects_path_outside_parent_dir(self, tmp_path: Path) -> None:
+        """Paths outside PARENT_DIR should be rejected."""
+        parent = tmp_path / "parent"
+        parent.mkdir()
+        external = tmp_path / "external"
+        external.mkdir()
+
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                f"""
+PARENT_DIR="{parent}"
+validate_worktree_path() {{
+    local path="$1"
+    local resolved
+    if [ -e "$path" ]; then
+        resolved="$(cd "$path" && pwd -P)"
+    else
+        local par
+        par="$(dirname "$path")"
+        if [ ! -d "$par" ]; then
+            echo "Error: parent directory does not exist: $par" >&2
+            return 1
+        fi
+        resolved="$(cd "$par" && pwd -P)/$(basename "$path")"
+    fi
+    local parent_resolved
+    parent_resolved="$(cd "$PARENT_DIR" && pwd -P)"
+    case "$resolved" in
+        "${{parent_resolved}}"/*)
+            return 0
+            ;;
+        *)
+            echo "Error: worktree path is outside the repo boundary: $resolved" >&2
+            return 1
+            ;;
+    esac
+}}
+validate_worktree_path "{external}"
+""",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1
+        assert "outside the repo boundary" in result.stderr
+
 
 # ---------------------------------------------------------------------------
 # launchd template tests


### PR DESCRIPTION
## Summary

- Add `src/bid_euchre/ops/fs_boundary.py` — path classification helper that categorizes filesystem paths as `repo_root`, `registered_worktree`, `managed_runtime`, `explicit_exception`, or `external`
- Wire boundary checks into 4 CLI entrypoints that accept filesystem path arguments: `worktrees quarantine`, `worktrees archive`, `snapshot create`, `skills propose`
- Add `validate_worktree_path()` shell-level guard in `steward-session.sh` for worktree creation
- Add `fs_boundary_violation` audit event type for visibility when external paths are denied

## Why

PR-5 established the rollout/safety substrate, but agents could still freely read/write outside the repo boundary via repo-owned entrypoints. This bridge work makes repo-bounded file access the default policy before Platform-1 begins.

## Design Decisions

- **"In boundary"** includes: main checkout, registered `git worktree list` entries, `.claude/runtime` dirs
- **External paths** denied by default — no silent access
- **Explicit exception** path available for auditable overrides
- **Symlink traversal** prevented by full `Path.resolve()` on all comparisons
- **No OS-level sandboxing claims** — this enforces at the repo-owned entrypoint level only. The residual gap (desktop app, arbitrary scripts) is documented honestly

## Minimum Policy Contract

| Path Class | Default | Override |
|---|---|---|
| `repo_root` | ✅ Allow | — |
| `registered_worktree` | ✅ Allow | — |
| `managed_runtime` | ✅ Allow | — |
| `explicit_exception` | ❌ Deny | Caller passes `exceptions=` |
| `external` | ❌ Deny | Not overridable |

## Validation Performed

```
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/test_fs_boundary.py -v        # 22 passed
uv run python -m pytest tests/unit/test_steward_session.py -v    # 31 passed
uv run python -m pytest tests/unit/test_ops_cli.py -v            # 83 passed

# Tier 2 — full suite
make check-quiet                                                  # ✓ All checks passed
```

## Tests

- `tests/unit/test_fs_boundary.py` — 22 tests: all 5 path classes, symlink traversal prevention, boundary enforcement, audit event emission
- `tests/unit/test_ops_cli.py` — 6 new boundary rejection tests: external path rejection for quarantine/archive/snapshot/skills, in-boundary pass-through
- `tests/unit/test_steward_session.py` — 4 new tests: boundary validation function exists, ensure_worktree calls it, accept/reject path tests

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: ops/fs-boundary-policy
```

## Residual Gaps

- This does **not** sandbox the desktop app itself or arbitrary scripts outside `scripts/internal/` and `steward-session.sh`
- Historical research scripts in `scripts/` are not retrofitted (explicit non-goal per session plan)
- OS/container-level confinement is outside the repo's control surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)