### PR TITLE
ops: ingest PR comment signals for review overlays

### DIFF
--- a/plans/sessions/2026-03-20_pr-comment-ingestion-bridge.md
+++ b/plans/sessions/2026-03-20_pr-comment-ingestion-bridge.md
@@ -1,0 +1,81 @@
+# PR Comment Ingestion Bridge (Lane B)
+
+**Date:** 2026-03-20
+**Status:** in_progress
+**Parent plan:** `plans/sessions/2026-03-20_post-pr5-bridge-controls-and-review-surfaces.md` (Lane B)
+**Goal:** Make PR comments a first-class ops signal. Codex Cloud comments from
+`chatgpt-codex-connector[bot]` are the primary real case.
+
+## Locked Decisions
+
+- Codex Cloud is comment-based unless new empirical evidence says otherwise
+- Do NOT add `codex-review.yml`
+- Do NOT add speculative `ADVISORY_CONTEXTS` entries
+- Ingest/surface comments only; do NOT enable autonomous public replies
+
+## Implementation Steps
+
+### 1. Comment Query & Normalization (`scripts/internal/github_pr_state.py`)
+
+Add to existing module:
+
+- `TRUSTED_BOT_LOGINS: frozenset[str]` — `{"chatgpt-codex-connector[bot]"}`
+- `@dataclass PRComment` — normalized comment record:
+  - `pr_number: int`, `comment_id: int`, `author_login: str`
+  - `author_type: str` (human|trusted_bot|other_bot)
+  - `created_at: str`, `body: str`, `source_channel: str` (issue_comment)
+- `classify_comment_author(login: str, user_type: str) -> str` — returns
+  human/trusted_bot/other_bot
+- `get_pr_comments(pr_number: int) -> list[PRComment]` — calls
+  `gh api repos/{owner}/{repo}/issues/{pr_number}/comments` with
+  `--jq` for login, id, body, created_at, author_association, user type
+
+### 2. Event Type (`src/bid_euchre/ops/events.py`)
+
+- Add `"pr_comment_ingested"` to `VALID_EVENT_TYPES`
+
+### 3. Comment Overlay in Reviews (`src/bid_euchre/ops/reviews.py`)
+
+- `@dataclass CommentOverlay` — per-PR comment signal:
+  - `pr_number: int`, `total_comments: int`, `trusted_bot_comments: int`
+  - `latest_trusted_bot_comment: str | None` (body excerpt, max 200 chars)
+  - `latest_trusted_bot_author: str | None`
+  - `latest_trusted_bot_time: str | None`
+  - `comments: list[dict]` (optional raw list)
+- `get_pr_comment_overlay(pr_number: int) -> CommentOverlay` — fetch + classify
+- `format_comment_overlays_text(overlays: list[CommentOverlay]) -> str`
+- `format_comment_overlays_json(overlays: list[CommentOverlay]) -> list[dict]`
+
+### 4. Index Entry Type (`src/bid_euchre/ops/index.py`)
+
+- Add `"pr_comment"` to `ENTRY_TYPES`
+- Add `_ingest_pr_comments()` — reads from a JSONL sidecar file:
+  `.claude/runtime/pr_comments/pr_{N}.jsonl`
+- Wire into `build_index()` as step 10
+
+### 5. CLI Surface (`scripts/internal/ops.py`)
+
+- Add `comments` subcommand:
+  - `ops.py comments --pr N [--json]` — show comment overlay for a PR
+  - `ops.py comments --pr N --ingest [--json]` — ingest + emit event + index
+- Wire parser and dispatch
+
+### 6. Tests
+
+All new test files (none exist yet):
+
+- `tests/unit/test_github_pr_state.py` — PRComment dataclass, classify_comment_author,
+  get_pr_comments mock
+- `tests/unit/test_ops_events.py` — pr_comment_ingested event type works
+- `tests/unit/test_ops_reviews.py` — CommentOverlay, format functions
+- `tests/unit/test_ops_index.py` — pr_comment entry type, _ingest_pr_comments
+- `tests/unit/test_ops_cli.py` — comments subcommand dispatch
+
+## Validation
+
+- Tier 1: `uv run pytest -q tests/unit/test_github_pr_state.py tests/unit/test_ops_events.py tests/unit/test_ops_index.py tests/unit/test_ops_reviews.py tests/unit/test_ops_cli.py`
+- Tier 2: `make check-quiet`
+
+## Outcome
+
+<!-- filled after implementation -->

--- a/scripts/internal/github_pr_state.py
+++ b/scripts/internal/github_pr_state.py
@@ -18,6 +18,125 @@ logger = logging.getLogger("github_pr_state")
 # HTML comment marker for deduplication of machine-owned PR comments.
 REVIEW_COMMENT_MARKER = "<!-- review-loop-comment -->"
 
+# --- PR comment ingestion ---
+
+# Trusted bot logins recognized for comment-based review signals.
+# Only add verified identities here — never speculative names.
+TRUSTED_BOT_LOGINS: frozenset[str] = frozenset(
+    {
+        "chatgpt-codex-connector[bot]",
+    }
+)
+
+# GitHub user types that indicate bot accounts.
+_BOT_USER_TYPES: frozenset[str] = frozenset({"Bot", "bot"})
+
+
+@dataclass
+class PRComment:
+    """Normalized PR issue comment for operational ingestion.
+
+    Represents a single comment on a PR issue thread, classified
+    by author identity for trusted-bot detection.
+    """
+
+    pr_number: int
+    comment_id: int
+    author_login: str
+    author_type: str  # "human", "trusted_bot", "other_bot"
+    created_at: str  # ISO 8601 timestamp
+    body: str
+    source_channel: str = "issue_comment"
+
+
+def classify_comment_author(login: str, user_type: str = "") -> str:
+    """Classify a comment author as human, trusted_bot, or other_bot.
+
+    Args:
+        login: GitHub username (e.g., ``"octocat"`` or
+            ``"chatgpt-codex-connector[bot]"``).
+        user_type: GitHub user type field (e.g., ``"User"``, ``"Bot"``).
+            When empty, classification falls back to login pattern matching.
+
+    Returns:
+        ``"trusted_bot"`` if login is in ``TRUSTED_BOT_LOGINS``,
+        ``"other_bot"`` if user_type is ``"Bot"`` or login ends with ``[bot]``,
+        ``"human"`` otherwise.
+    """
+    if login in TRUSTED_BOT_LOGINS:
+        return "trusted_bot"
+    if user_type in _BOT_USER_TYPES or login.endswith("[bot]"):
+        return "other_bot"
+    return "human"
+
+
+def get_pr_comments(
+    pr_number: int,
+    *,
+    timeout: int = 30,
+) -> list[PRComment]:
+    """Fetch and normalize issue comments for a PR.
+
+    Uses ``gh api`` to retrieve all issue comments, then classifies
+    each by author identity.
+
+    Args:
+        pr_number: PR number.
+        timeout: Subprocess timeout in seconds.
+
+    Returns:
+        List of :class:`PRComment` objects, ordered by creation time.
+
+    Raises:
+        RuntimeError: If the ``gh`` CLI call fails.
+    """
+    jq_expr = (
+        "[.[] | {id: .id, login: .user.login, user_type: .user.type, "
+        "created_at: .created_at, body: .body}]"
+    )
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                f"repos/{{owner}}/{{repo}}/issues/{pr_number}/comments",
+                "--jq",
+                jq_expr,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(f"PR #{pr_number}: comment fetch timed out after {timeout}s")
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"PR #{pr_number}: failed to fetch comments: {result.stderr[:200]}"
+        )
+
+    try:
+        raw_comments = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"PR #{pr_number}: invalid JSON from comment fetch: {e}")
+
+    comments: list[PRComment] = []
+    for raw in raw_comments:
+        login = raw.get("login", "")
+        user_type = raw.get("user_type", "")
+        comments.append(
+            PRComment(
+                pr_number=pr_number,
+                comment_id=raw.get("id", 0),
+                author_login=login,
+                author_type=classify_comment_author(login, user_type),
+                created_at=raw.get("created_at", ""),
+                body=raw.get("body", ""),
+            )
+        )
+
+    return comments
+
 
 @dataclass
 class PRMetadata:

--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -9,6 +9,7 @@ Usage:
     uv run python scripts/internal/ops.py health [--json]
     uv run python scripts/internal/ops.py watchdogs [--json]
     uv run python scripts/internal/ops.py reviews [--json]
+    uv run python scripts/internal/ops.py comments --pr N [--ingest] [--json]
     uv run python scripts/internal/ops.py ci [--json]
     uv run python scripts/internal/ops.py ci --pr N [--json]
     uv run python scripts/internal/ops.py daemon [--interval N] [--max-ticks N] [--json]
@@ -428,6 +429,57 @@ def cmd_reviews(args: argparse.Namespace) -> int:
         print(json.dumps(format_reviews_json(outcomes), indent=2))
     else:
         print(format_reviews_text(outcomes))
+
+    return 0
+
+
+def cmd_comments(args: argparse.Namespace) -> int:
+    """Show or ingest PR comment overlays."""
+    from bid_euchre.ops.reviews import (
+        format_comment_overlays_json,
+        format_comment_overlays_text,
+        get_pr_comment_overlay,
+    )
+
+    pr_number = getattr(args, "pr", None)
+    if pr_number is None:
+        print("Error: --pr <number> is required for comments command", file=sys.stderr)
+        return 1
+
+    ingest = getattr(args, "ingest", False)
+
+    overlay = get_pr_comment_overlay(pr_number)
+
+    if ingest and overlay.total_comments > 0:
+        # Write comment sidecar JSONL for index ingestion
+        pr_comments_dir = args.runtime_dir / "pr_comments"
+        pr_comments_dir.mkdir(parents=True, exist_ok=True)
+        sidecar_file = pr_comments_dir / f"pr_{pr_number}.jsonl"
+        with open(sidecar_file, "w") as f:
+            for c in overlay.comments:
+                record = {**c, "pr_number": pr_number}
+                f.write(json.dumps(record, sort_keys=True) + "\n")
+
+        # Emit event
+        from bid_euchre.ops.events import append_event
+
+        append_event(
+            event_type="pr_comment_ingested",
+            source="ops.comments",
+            lane_id="operator",
+            payload={
+                "pr_number": pr_number,
+                "total_comments": overlay.total_comments,
+                "trusted_bot_comments": overlay.trusted_bot_comments,
+                "sidecar_file": str(sidecar_file),
+            },
+            events_dir=args.runtime_dir / "events",
+        )
+
+    if args.json:
+        print(json.dumps(format_comment_overlays_json([overlay]), indent=2))
+    else:
+        print(format_comment_overlays_text([overlay]))
 
     return 0
 
@@ -1245,6 +1297,19 @@ def build_parser() -> argparse.ArgumentParser:
         "--pr", type=int, default=None, help="Show detail for a specific PR number"
     )
 
+    # comments
+    comments_parser = subparsers.add_parser(
+        "comments", help="PR comment overlays (Codex Cloud, bots, humans)"
+    )
+    comments_parser.add_argument(
+        "--pr", type=int, default=None, help="PR number (required)"
+    )
+    comments_parser.add_argument(
+        "--ingest",
+        action="store_true",
+        help="Write comment sidecar for index and emit event",
+    )
+
     # ci
     ci_parser = subparsers.add_parser("ci", help="CI status and failure classification")
     ci_parser.add_argument(
@@ -1510,6 +1575,7 @@ def main(argv: list[str] | None = None) -> int:
         "watchdogs": cmd_watchdogs,
         "recover": cmd_recover,
         "reviews": cmd_reviews,
+        "comments": cmd_comments,
         "ci": cmd_ci,
         "daemon": cmd_daemon,
         "retry": cmd_retry,

--- a/src/bid_euchre/ops/events.py
+++ b/src/bid_euchre/ops/events.py
@@ -48,6 +48,7 @@ VALID_EVENT_TYPES = frozenset(
         "snapshot_rolled_back",
         "skill_promoted",
         "skill_disabled",
+        "pr_comment_ingested",
     }
 )
 

--- a/src/bid_euchre/ops/index.py
+++ b/src/bid_euchre/ops/index.py
@@ -127,6 +127,7 @@ ENTRY_TYPES = frozenset(
         "log_entry",
         "review_outcome",
         "plan_review_outcome",
+        "pr_comment",
     }
 )
 
@@ -705,6 +706,87 @@ class _IngestCounts:
     entries: int = 0
 
 
+def _ingest_pr_comments(
+    conn: sqlite3.Connection, pr_comments_dir: Path
+) -> _IngestCounts:
+    """Ingest PR comment JSONL sidecars from the pr_comments runtime directory.
+
+    Expected file layout::
+
+        .claude/runtime/pr_comments/pr_123.jsonl
+        .claude/runtime/pr_comments/pr_456.jsonl
+
+    Each line in a JSONL file is a normalized comment record with at least:
+    ``comment_id``, ``author_login``, ``author_type``, ``created_at``,
+    ``body`` (or ``body_excerpt``), ``pr_number``.
+
+    Returns:
+        _IngestCounts with accurate per-source and per-entry tallies.
+    """
+    if not pr_comments_dir.exists():
+        return _IngestCounts()
+
+    counts = _IngestCounts()
+    for jsonl_file in sorted(pr_comments_dir.glob("pr_*.jsonl")):
+        try:
+            stat = jsonl_file.stat()
+            source_id = _upsert_source(
+                conn,
+                "pr_comment",
+                str(jsonl_file),
+                datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+                stat.st_size,
+            )
+
+            n = 0
+            for line in jsonl_file.read_text().strip().split("\n"):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "Skipping malformed comment line in %s: %s",
+                        jsonl_file.name,
+                        line[:80],
+                    )
+                    continue
+
+                pr_num = record.get("pr_number", "")
+                author = record.get("author_login", "unknown")
+                author_type = record.get("author_type", "unknown")
+                body = record.get("body_excerpt", record.get("body", ""))[:200]
+                timestamp = record.get("created_at", "")
+
+                content = f"PR #{pr_num} comment by {author} ({author_type}): {body}"
+                metadata = {
+                    "pr_number": pr_num,
+                    "comment_id": record.get("comment_id", 0),
+                    "author_login": author,
+                    "author_type": author_type,
+                }
+
+                _insert_entry(
+                    conn,
+                    source_id,
+                    "pr_comment",
+                    timestamp,
+                    content,
+                    metadata,
+                )
+                n += 1
+
+            if n > 0:
+                counts.sources += 1
+                counts.entries += n
+
+        except (OSError, ValueError) as e:
+            logger.warning("Skipping PR comment file %s: %s", jsonl_file, e)
+
+    return counts
+
+
 # ── Build / Rebuild ──────────────────────────────────────────────
 
 
@@ -894,6 +976,15 @@ def build_index(
             result.entries_indexed += ic.entries
         except Exception as e:
             result.errors.append(f"report_metadata: {e}")
+
+        # 10. Ingest PR comment sidecars
+        pr_comments_dir = runtime_dir / "pr_comments"
+        try:
+            ic = _ingest_pr_comments(conn, pr_comments_dir)
+            result.sources_indexed += ic.sources
+            result.entries_indexed += ic.entries
+        except Exception as e:
+            result.errors.append(f"pr_comments: {e}")
 
         # Update metadata
         conn.execute(

--- a/src/bid_euchre/ops/reviews.py
+++ b/src/bid_euchre/ops/reviews.py
@@ -1,7 +1,8 @@
 """Provider-neutral PR review outcome aggregation.
 
 Queries GitHub for open PRs and enriches each with CI status,
-review commit-status, and deterministic precheck status.
+review commit-status, deterministic precheck status, and
+comment-based review overlays (e.g., Codex Cloud bot comments).
 
 GitHub is the source of truth for review outcomes (online-first).
 This module does NOT depend on .claude/runtime/review_loops/** —
@@ -13,7 +14,7 @@ from __future__ import annotations
 import json
 import logging
 import subprocess
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -424,4 +425,212 @@ def format_reviews_json(outcomes: list[ReviewOutcome]) -> list[dict]:
             "url": o.url,
         }
         for o in outcomes
+    ]
+
+
+# --- Comment-Based Review Overlays ---
+#
+# PR issue comments are a separate signal channel from checks/statuses.
+# Codex Cloud review arrives as issue comments from
+# chatgpt-codex-connector[bot], not as checks or statuses.
+# These overlays surface comment-derived signals without conflating
+# them with CI or the reviewing-changes gate.
+
+# Trusted bot logins recognized for comment-based review signals.
+# Only add verified identities here — never speculative names.
+TRUSTED_BOT_LOGINS: frozenset[str] = frozenset(
+    {
+        "chatgpt-codex-connector[bot]",
+    }
+)
+
+# GitHub user types that indicate bot accounts.
+_BOT_USER_TYPES: frozenset[str] = frozenset({"Bot", "bot"})
+
+# Maximum body excerpt length for comment overlay summaries.
+_MAX_EXCERPT_LEN: int = 200
+
+
+def classify_comment_author(login: str, user_type: str = "") -> str:
+    """Classify a comment author as human, trusted_bot, or other_bot.
+
+    Args:
+        login: GitHub username (e.g., ``"octocat"`` or
+            ``"chatgpt-codex-connector[bot]"``).
+        user_type: GitHub user type field (e.g., ``"User"``, ``"Bot"``).
+            When empty, classification falls back to login pattern matching.
+
+    Returns:
+        ``"trusted_bot"`` if login is in ``TRUSTED_BOT_LOGINS``,
+        ``"other_bot"`` if user_type is ``"Bot"`` or login ends with ``[bot]``,
+        ``"human"`` otherwise.
+    """
+    if login in TRUSTED_BOT_LOGINS:
+        return "trusted_bot"
+    if user_type in _BOT_USER_TYPES or login.endswith("[bot]"):
+        return "other_bot"
+    return "human"
+
+
+@dataclass
+class CommentOverlay:
+    """Per-PR summary of comment-based review signals.
+
+    Surfaces PR issue comments as operational overlays, separate from
+    CI checks and the ``reviewing-changes`` status gate.
+    """
+
+    pr_number: int
+    total_comments: int = 0
+    trusted_bot_comments: int = 0
+    human_comments: int = 0
+    other_bot_comments: int = 0
+    latest_trusted_bot_excerpt: str | None = None
+    latest_trusted_bot_author: str | None = None
+    latest_trusted_bot_time: str | None = None
+    comments: list[dict] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def _get_pr_issue_comments(pr_number: int) -> list[dict]:
+    """Fetch issue comments for a PR via gh API.
+
+    Returns:
+        List of dicts with keys: id, login, user_type, created_at, body.
+        Returns empty list on failure (graceful degradation).
+    """
+    jq_expr = (
+        "[.[] | {id: .id, login: .user.login, user_type: .user.type, "
+        "created_at: .created_at, body: .body}]"
+    )
+    result = _run_gh(
+        [
+            "api",
+            f"repos/{{owner}}/{{repo}}/issues/{pr_number}/comments",
+            "--jq",
+            jq_expr,
+        ]
+    )
+    if result.returncode != 0:
+        logger.warning(
+            "PR #%d: failed to fetch comments: %s",
+            pr_number,
+            result.stderr[:200],
+        )
+        return []
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        logger.warning(
+            "PR #%d: invalid JSON from comment fetch: %s",
+            pr_number,
+            result.stdout[:200],
+        )
+        return []
+
+
+def get_pr_comment_overlay(
+    pr_number: int,
+    *,
+    raw_comments: list[dict] | None = None,
+) -> CommentOverlay:
+    """Build a comment overlay for a single PR.
+
+    Fetches issue comments from GitHub (or accepts pre-fetched data),
+    classifies each by author identity, and produces an overlay summary.
+
+    Args:
+        pr_number: PR number.
+        raw_comments: Pre-fetched comment dicts (for testing or batching).
+            When ``None``, fetches from GitHub.
+
+    Returns:
+        :class:`CommentOverlay` summarizing comment signals.
+    """
+    if raw_comments is None:
+        raw_comments = _get_pr_issue_comments(pr_number)
+
+    overlay = CommentOverlay(pr_number=pr_number)
+    overlay.total_comments = len(raw_comments)
+
+    latest_trusted: dict | None = None
+
+    for raw in raw_comments:
+        login = raw.get("login", "")
+        user_type = raw.get("user_type", "")
+        author_type = classify_comment_author(login, user_type)
+
+        comment_record = {
+            "comment_id": raw.get("id", 0),
+            "author_login": login,
+            "author_type": author_type,
+            "created_at": raw.get("created_at", ""),
+            "body_excerpt": (raw.get("body", "") or "")[:_MAX_EXCERPT_LEN],
+        }
+        overlay.comments.append(comment_record)
+
+        if author_type == "trusted_bot":
+            overlay.trusted_bot_comments += 1
+            if latest_trusted is None or raw.get("created_at", "") > latest_trusted.get(
+                "created_at", ""
+            ):
+                latest_trusted = raw
+        elif author_type == "other_bot":
+            overlay.other_bot_comments += 1
+        else:
+            overlay.human_comments += 1
+
+    if latest_trusted is not None:
+        body = latest_trusted.get("body", "") or ""
+        overlay.latest_trusted_bot_excerpt = body[:_MAX_EXCERPT_LEN]
+        overlay.latest_trusted_bot_author = latest_trusted.get("login", "")
+        overlay.latest_trusted_bot_time = latest_trusted.get("created_at", "")
+
+    return overlay
+
+
+def format_comment_overlays_text(overlays: list[CommentOverlay]) -> str:
+    """Format comment overlays as human-readable text."""
+    if not overlays:
+        return "=== PR Comment Overlays ===\n\nNo comment data."
+
+    lines = ["=== PR Comment Overlays ===", ""]
+    for o in overlays:
+        trusted_icon = "+" if o.trusted_bot_comments > 0 else "-"
+        lines.append(
+            f"  #{o.pr_number:<5d} Comments={o.total_comments} "
+            f"Trusted=[{trusted_icon}:{o.trusted_bot_comments}] "
+            f"Human={o.human_comments} OtherBot={o.other_bot_comments}"
+        )
+        if o.latest_trusted_bot_author:
+            lines.append(
+                f"         Latest trusted: {o.latest_trusted_bot_author} "
+                f"@ {o.latest_trusted_bot_time}"
+            )
+            if o.latest_trusted_bot_excerpt:
+                excerpt = o.latest_trusted_bot_excerpt.replace("\n", " ")[:80]
+                lines.append(f"         > {excerpt}...")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def format_comment_overlays_json(overlays: list[CommentOverlay]) -> list[dict]:
+    """Format comment overlays as JSON-serializable list."""
+    return [
+        {
+            "pr_number": o.pr_number,
+            "total_comments": o.total_comments,
+            "trusted_bot_comments": o.trusted_bot_comments,
+            "human_comments": o.human_comments,
+            "other_bot_comments": o.other_bot_comments,
+            "latest_trusted_bot_excerpt": o.latest_trusted_bot_excerpt,
+            "latest_trusted_bot_author": o.latest_trusted_bot_author,
+            "latest_trusted_bot_time": o.latest_trusted_bot_time,
+            "comments": o.comments,
+        }
+        for o in overlays
     ]

--- a/tests/unit/test_github_pr_state.py
+++ b/tests/unit/test_github_pr_state.py
@@ -1,8 +1,9 @@
-"""Tests for github_pr_state.py — PR metadata, body, changed files, CI status, comment upsert."""
+"""Tests for github_pr_state.py — PR metadata, body, changed files, CI status, comment upsert, comment ingestion."""
 
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -14,11 +15,15 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "intern
 
 from github_pr_state import (
     REVIEW_COMMENT_MARKER,
+    TRUSTED_BOT_LOGINS,
+    PRComment,
     PRMetadata,
     _classify_check,
+    classify_comment_author,
     get_ci_status,
     get_pr_body,
     get_pr_changed_files,
+    get_pr_comments,
     get_pr_metadata,
     upsert_review_comment,
 )
@@ -464,3 +469,131 @@ class TestUpsertReviewComment:
         assert result is True
         # Should have made 4 calls: list, get 111, get 222, create
         assert mock_run.call_count == 4
+
+
+# ---------------------------------------------------------------------------
+# PR comment ingestion tests
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyCommentAuthor:
+    """Test classify_comment_author() identity classification."""
+
+    def test_trusted_bot_by_login(self) -> None:
+        assert classify_comment_author("chatgpt-codex-connector[bot]") == "trusted_bot"
+
+    def test_trusted_bot_ignores_user_type(self) -> None:
+        """Trusted bot is recognized by login alone, regardless of user_type."""
+        assert (
+            classify_comment_author("chatgpt-codex-connector[bot]", "User")
+            == "trusted_bot"
+        )
+
+    def test_other_bot_by_user_type(self) -> None:
+        assert classify_comment_author("dependabot[bot]", "Bot") == "other_bot"
+
+    def test_other_bot_by_login_suffix(self) -> None:
+        """Bots with [bot] suffix are detected even without user_type."""
+        assert classify_comment_author("some-other[bot]") == "other_bot"
+
+    def test_human_user(self) -> None:
+        assert classify_comment_author("octocat", "User") == "human"
+
+    def test_human_without_user_type(self) -> None:
+        assert classify_comment_author("octocat") == "human"
+
+    def test_empty_login(self) -> None:
+        assert classify_comment_author("") == "human"
+
+
+class TestTrustedBotLogins:
+    """Test TRUSTED_BOT_LOGINS constant."""
+
+    def test_contains_codex_connector(self) -> None:
+        assert "chatgpt-codex-connector[bot]" in TRUSTED_BOT_LOGINS
+
+    def test_is_frozenset(self) -> None:
+        assert isinstance(TRUSTED_BOT_LOGINS, frozenset)
+
+
+class TestPRComment:
+    """Test PRComment dataclass."""
+
+    def test_default_source_channel(self) -> None:
+        c = PRComment(
+            pr_number=42,
+            comment_id=123,
+            author_login="octocat",
+            author_type="human",
+            created_at="2026-03-20T10:00:00Z",
+            body="Hello",
+        )
+        assert c.source_channel == "issue_comment"
+
+    def test_all_fields(self) -> None:
+        c = PRComment(
+            pr_number=42,
+            comment_id=456,
+            author_login="chatgpt-codex-connector[bot]",
+            author_type="trusted_bot",
+            created_at="2026-03-20T12:00:00Z",
+            body="Review complete",
+            source_channel="issue_comment",
+        )
+        assert c.pr_number == 42
+        assert c.author_type == "trusted_bot"
+
+
+class TestGetPRComments:
+    """Test get_pr_comments() with mocked gh CLI."""
+
+    @patch("github_pr_state.subprocess.run")
+    def test_returns_classified_comments(self, mock_run: Mock) -> None:
+        raw = [
+            {
+                "id": 100,
+                "login": "octocat",
+                "user_type": "User",
+                "created_at": "2026-03-20T10:00:00Z",
+                "body": "LGTM",
+            },
+            {
+                "id": 200,
+                "login": "chatgpt-codex-connector[bot]",
+                "user_type": "Bot",
+                "created_at": "2026-03-20T11:00:00Z",
+                "body": "Review findings...",
+            },
+        ]
+        mock_run.return_value = Mock(returncode=0, stdout=json.dumps(raw))
+
+        comments = get_pr_comments(42)
+        assert len(comments) == 2
+        assert comments[0].author_type == "human"
+        assert comments[0].author_login == "octocat"
+        assert comments[1].author_type == "trusted_bot"
+        assert comments[1].author_login == "chatgpt-codex-connector[bot]"
+
+    @patch("github_pr_state.subprocess.run")
+    def test_empty_comments(self, mock_run: Mock) -> None:
+        mock_run.return_value = Mock(returncode=0, stdout="[]")
+        comments = get_pr_comments(42)
+        assert comments == []
+
+    @patch("github_pr_state.subprocess.run")
+    def test_raises_on_failure(self, mock_run: Mock) -> None:
+        mock_run.return_value = Mock(returncode=1, stderr="not found")
+        with pytest.raises(RuntimeError, match="failed to fetch comments"):
+            get_pr_comments(99)
+
+    @patch("github_pr_state.subprocess.run")
+    def test_raises_on_timeout(self, mock_run: Mock) -> None:
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="gh", timeout=30)
+        with pytest.raises(RuntimeError, match="timed out"):
+            get_pr_comments(99)
+
+    @patch("github_pr_state.subprocess.run")
+    def test_raises_on_invalid_json(self, mock_run: Mock) -> None:
+        mock_run.return_value = Mock(returncode=0, stdout="not json")
+        with pytest.raises(RuntimeError, match="invalid JSON"):
+            get_pr_comments(42)

--- a/tests/unit/test_ops_cli.py
+++ b/tests/unit/test_ops_cli.py
@@ -2014,3 +2014,146 @@ class TestCompactSessionContextCli:
             ]
         )
         assert rc == 0
+
+
+# --- Comments subcommand tests ---
+
+
+class TestCmdComments:
+    """Tests for the comments subcommand."""
+
+    def test_comments_requires_pr(
+        self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """comments without --pr should fail."""
+        import ops
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "comments",
+            ]
+        )
+        assert rc == 1
+        assert "required" in capsys.readouterr().err.lower()
+
+    def test_comments_json_output(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """comments --pr N --json returns JSON overlay (mocked gh)."""
+        from unittest.mock import patch as _patch
+
+        import ops
+
+        raw_comments = [
+            {
+                "id": 1,
+                "login": "octocat",
+                "user_type": "User",
+                "created_at": "2026-03-20T10:00:00Z",
+                "body": "LGTM",
+            },
+            {
+                "id": 2,
+                "login": "chatgpt-codex-connector[bot]",
+                "user_type": "Bot",
+                "created_at": "2026-03-20T11:00:00Z",
+                "body": "Review findings",
+            },
+        ]
+
+        import subprocess
+
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(raw_comments), stderr=""
+        )
+
+        with _patch("bid_euchre.ops.reviews._run_gh", return_value=mock_result):
+            rc = ops.main(
+                [
+                    "--json",
+                    "--runtime-dir",
+                    str(runtime_dir),
+                    "--plans-dir",
+                    str(plans_dir),
+                    "comments",
+                    "--pr",
+                    "42",
+                ]
+            )
+
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert len(data) == 1
+        assert data[0]["pr_number"] == 42
+        assert data[0]["total_comments"] == 2
+        assert data[0]["trusted_bot_comments"] == 1
+
+    def test_comments_ingest_writes_sidecar(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """comments --pr N --ingest writes sidecar JSONL and emits event."""
+        from unittest.mock import patch as _patch
+
+        import ops
+
+        raw_comments = [
+            {
+                "id": 1,
+                "login": "chatgpt-codex-connector[bot]",
+                "user_type": "Bot",
+                "created_at": "2026-03-20T11:00:00Z",
+                "body": "Ingested review",
+            },
+        ]
+
+        import subprocess
+
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(raw_comments), stderr=""
+        )
+
+        with _patch("bid_euchre.ops.reviews._run_gh", return_value=mock_result):
+            rc = ops.main(
+                [
+                    "--json",
+                    "--runtime-dir",
+                    str(runtime_dir),
+                    "--plans-dir",
+                    str(plans_dir),
+                    "comments",
+                    "--pr",
+                    "42",
+                    "--ingest",
+                ]
+            )
+
+        assert rc == 0
+
+        # Verify sidecar written
+        sidecar = runtime_dir / "pr_comments" / "pr_42.jsonl"
+        assert sidecar.exists()
+        lines = [l for l in sidecar.read_text().strip().split("\n") if l.strip()]
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["pr_number"] == 42
+
+        # Verify event emitted
+        events_file = runtime_dir / "events" / "events.jsonl"
+        assert events_file.exists()
+        event_lines = [
+            l for l in events_file.read_text().strip().split("\n") if l.strip()
+        ]
+        assert len(event_lines) >= 1
+        event = json.loads(event_lines[-1])
+        assert event["event_type"] == "pr_comment_ingested"
+        assert event["payload"]["pr_number"] == 42

--- a/tests/unit/test_ops_events.py
+++ b/tests/unit/test_ops_events.py
@@ -78,6 +78,18 @@ class TestAppendEvent:
         events = read_events(events_dir, limit=len(VALID_EVENT_TYPES) + 1)
         assert len(events) == len(VALID_EVENT_TYPES)
 
+    def test_pr_comment_ingested_event_accepted(self, events_dir: Path) -> None:
+        """pr_comment_ingested is a valid event type for comment ingestion."""
+        result = append_event(
+            "pr_comment_ingested",
+            "ops.comments",
+            "operator",
+            {"pr_number": 42, "total_comments": 3, "trusted_bot_comments": 1},
+            events_dir,
+        )
+        assert result["event_type"] == "pr_comment_ingested"
+        assert result["payload"]["pr_number"] == 42
+
 
 class TestReadEvents:
     """Tests for read_events()."""

--- a/tests/unit/test_ops_index.py
+++ b/tests/unit/test_ops_index.py
@@ -1079,3 +1079,134 @@ class TestStalenessCache:
         # idx2's cache should still be valid
         stats2 = get_stats(idx2)
         assert isinstance(stats2.stale_sources, int)
+
+
+# ── PR comment ingestion tests ────────────────────────────────────
+
+
+class TestPRCommentIngestion:
+    """Tests for pr_comment JSONL sidecar ingestion."""
+
+    def test_indexes_pr_comment_sidecars(self, index_dir: Path, tmp_path: Path) -> None:
+        """build_index ingests pr_comments/*.jsonl sidecars."""
+        repo = tmp_path / "repo"
+        rt = repo / ".claude" / "runtime"
+        rt.mkdir(parents=True)
+        plans = repo / "plans"
+        plans.mkdir()
+
+        # Create pr_comments sidecar
+        pr_comments_dir = rt / "pr_comments"
+        pr_comments_dir.mkdir()
+        comments = [
+            {
+                "comment_id": 100,
+                "author_login": "octocat",
+                "author_type": "human",
+                "created_at": "2026-03-20T10:00:00Z",
+                "body_excerpt": "LGTM",
+                "pr_number": 42,
+            },
+            {
+                "comment_id": 200,
+                "author_login": "chatgpt-codex-connector[bot]",
+                "author_type": "trusted_bot",
+                "created_at": "2026-03-20T11:00:00Z",
+                "body_excerpt": "Review findings: no issues",
+                "pr_number": 42,
+            },
+        ]
+        lines = [json.dumps(c) for c in comments]
+        (pr_comments_dir / "pr_42.jsonl").write_text("\n".join(lines) + "\n")
+
+        result = build_index(index_dir, runtime_dir=rt, plans_dir=plans, repo_root=repo)
+        assert result.errors == []
+        assert result.sources_indexed >= 1
+        assert result.entries_indexed >= 2
+
+        # Verify searchable
+        resp = query(index_dir, "codex connector")
+        assert resp.total_matches >= 1
+
+    def test_pr_comment_entry_type_in_results(
+        self, index_dir: Path, tmp_path: Path
+    ) -> None:
+        """Ingested comments have entry_type 'pr_comment'."""
+        repo = tmp_path / "repo"
+        rt = repo / ".claude" / "runtime"
+        rt.mkdir(parents=True)
+        plans = repo / "plans"
+        plans.mkdir()
+
+        pr_comments_dir = rt / "pr_comments"
+        pr_comments_dir.mkdir()
+        comment = {
+            "comment_id": 300,
+            "author_login": "chatgpt-codex-connector[bot]",
+            "author_type": "trusted_bot",
+            "created_at": "2026-03-20T12:00:00Z",
+            "body_excerpt": "Unique searchable token xyzabc",
+            "pr_number": 99,
+        }
+        (pr_comments_dir / "pr_99.jsonl").write_text(json.dumps(comment) + "\n")
+
+        build_index(index_dir, runtime_dir=rt, plans_dir=plans, repo_root=repo)
+
+        resp = query(index_dir, "xyzabc")
+        assert resp.total_matches >= 1
+        assert any(r.entry_type == "pr_comment" for r in resp.results)
+
+    def test_empty_pr_comments_dir(self, index_dir: Path, tmp_path: Path) -> None:
+        """Empty pr_comments directory causes no errors."""
+        repo = tmp_path / "repo"
+        rt = repo / ".claude" / "runtime"
+        rt.mkdir(parents=True)
+        (rt / "pr_comments").mkdir()
+        plans = repo / "plans"
+        plans.mkdir()
+
+        result = build_index(index_dir, runtime_dir=rt, plans_dir=plans, repo_root=repo)
+        assert result.errors == []
+
+    def test_no_pr_comments_dir(self, index_dir: Path, tmp_path: Path) -> None:
+        """Missing pr_comments directory causes no errors."""
+        repo = tmp_path / "repo"
+        rt = repo / ".claude" / "runtime"
+        rt.mkdir(parents=True)
+        plans = repo / "plans"
+        plans.mkdir()
+
+        result = build_index(index_dir, runtime_dir=rt, plans_dir=plans, repo_root=repo)
+        assert result.errors == []
+
+    def test_malformed_jsonl_lines_skipped(
+        self, index_dir: Path, tmp_path: Path
+    ) -> None:
+        """Malformed JSONL lines are skipped, valid lines are indexed."""
+        repo = tmp_path / "repo"
+        rt = repo / ".claude" / "runtime"
+        rt.mkdir(parents=True)
+        plans = repo / "plans"
+        plans.mkdir()
+
+        pr_comments_dir = rt / "pr_comments"
+        pr_comments_dir.mkdir()
+        content = (
+            "not valid json\n"
+            + json.dumps(
+                {
+                    "comment_id": 400,
+                    "author_login": "octocat",
+                    "author_type": "human",
+                    "created_at": "2026-03-20T13:00:00Z",
+                    "body_excerpt": "Valid comment",
+                    "pr_number": 50,
+                }
+            )
+            + "\n"
+        )
+        (pr_comments_dir / "pr_50.jsonl").write_text(content)
+
+        result = build_index(index_dir, runtime_dir=rt, plans_dir=plans, repo_root=repo)
+        assert result.errors == []
+        assert result.entries_indexed >= 1

--- a/tests/unit/test_ops_reviews.py
+++ b/tests/unit/test_ops_reviews.py
@@ -11,15 +11,21 @@ import pytest
 
 from bid_euchre.ops.reviews import (
     DEFAULT_REVIEW_CONTEXTS,
+    TRUSTED_BOT_LOGINS,
+    CommentOverlay,
     ReviewOutcome,
     _classify_ci_status,
     _get_advisory_status,
     _get_review_status,
     _has_precheck_ci,
+    classify_comment_author,
     emit_review_event,
+    format_comment_overlays_json,
+    format_comment_overlays_text,
     format_reviews_json,
     format_reviews_text,
     get_open_pr_reviews,
+    get_pr_comment_overlay,
     get_pr_review_detail,
 )
 
@@ -681,3 +687,197 @@ class TestEmitReviewEvent:
         assert len(events) == 1
         assert events[0]["event_type"] == "review_outcome"
         assert events[0]["payload"]["pr_number"] == 42
+
+
+# --- Comment overlay tests ---
+
+
+class TestClassifyCommentAuthorReviews:
+    """Tests for classify_comment_author() in reviews module."""
+
+    def test_trusted_bot(self) -> None:
+        assert classify_comment_author("chatgpt-codex-connector[bot]") == "trusted_bot"
+
+    def test_other_bot_by_type(self) -> None:
+        assert classify_comment_author("dependabot[bot]", "Bot") == "other_bot"
+
+    def test_other_bot_by_suffix(self) -> None:
+        assert classify_comment_author("my-bot[bot]") == "other_bot"
+
+    def test_human(self) -> None:
+        assert classify_comment_author("octocat", "User") == "human"
+
+    def test_human_no_type(self) -> None:
+        assert classify_comment_author("octocat") == "human"
+
+    def test_trusted_bot_logins_contains_codex(self) -> None:
+        assert "chatgpt-codex-connector[bot]" in TRUSTED_BOT_LOGINS
+
+
+class TestCommentOverlay:
+    """Tests for CommentOverlay dataclass."""
+
+    def test_defaults(self) -> None:
+        overlay = CommentOverlay(pr_number=42)
+        assert overlay.total_comments == 0
+        assert overlay.trusted_bot_comments == 0
+        assert overlay.human_comments == 0
+        assert overlay.other_bot_comments == 0
+        assert overlay.latest_trusted_bot_excerpt is None
+        assert overlay.comments == []
+
+    def test_to_dict(self) -> None:
+        overlay = CommentOverlay(pr_number=42, total_comments=3)
+        d = overlay.to_dict()
+        assert d["pr_number"] == 42
+        assert d["total_comments"] == 3
+
+
+class TestGetPRCommentOverlay:
+    """Tests for get_pr_comment_overlay() with pre-fetched data."""
+
+    def test_empty_comments(self) -> None:
+        overlay = get_pr_comment_overlay(42, raw_comments=[])
+        assert overlay.pr_number == 42
+        assert overlay.total_comments == 0
+
+    def test_classifies_comments(self) -> None:
+        raw = [
+            {
+                "id": 1,
+                "login": "octocat",
+                "user_type": "User",
+                "created_at": "2026-03-20T10:00:00Z",
+                "body": "LGTM",
+            },
+            {
+                "id": 2,
+                "login": "chatgpt-codex-connector[bot]",
+                "user_type": "Bot",
+                "created_at": "2026-03-20T11:00:00Z",
+                "body": "Review findings: no issues found.",
+            },
+            {
+                "id": 3,
+                "login": "dependabot[bot]",
+                "user_type": "Bot",
+                "created_at": "2026-03-20T12:00:00Z",
+                "body": "Bump version",
+            },
+        ]
+        overlay = get_pr_comment_overlay(42, raw_comments=raw)
+        assert overlay.total_comments == 3
+        assert overlay.human_comments == 1
+        assert overlay.trusted_bot_comments == 1
+        assert overlay.other_bot_comments == 1
+        assert overlay.latest_trusted_bot_author == "chatgpt-codex-connector[bot]"
+        assert overlay.latest_trusted_bot_time == "2026-03-20T11:00:00Z"
+        assert "Review findings" in (overlay.latest_trusted_bot_excerpt or "")
+
+    def test_latest_trusted_bot_is_most_recent(self) -> None:
+        raw = [
+            {
+                "id": 1,
+                "login": "chatgpt-codex-connector[bot]",
+                "user_type": "Bot",
+                "created_at": "2026-03-20T10:00:00Z",
+                "body": "First review",
+            },
+            {
+                "id": 2,
+                "login": "chatgpt-codex-connector[bot]",
+                "user_type": "Bot",
+                "created_at": "2026-03-20T14:00:00Z",
+                "body": "Second review",
+            },
+        ]
+        overlay = get_pr_comment_overlay(42, raw_comments=raw)
+        assert overlay.trusted_bot_comments == 2
+        assert overlay.latest_trusted_bot_time == "2026-03-20T14:00:00Z"
+        assert "Second review" in (overlay.latest_trusted_bot_excerpt or "")
+
+    def test_body_excerpt_truncated(self) -> None:
+        long_body = "x" * 500
+        raw = [
+            {
+                "id": 1,
+                "login": "chatgpt-codex-connector[bot]",
+                "user_type": "Bot",
+                "created_at": "2026-03-20T10:00:00Z",
+                "body": long_body,
+            },
+        ]
+        overlay = get_pr_comment_overlay(42, raw_comments=raw)
+        assert len(overlay.latest_trusted_bot_excerpt or "") <= 200
+
+    @patch("bid_euchre.ops.reviews._run_gh")
+    def test_fetches_from_github_when_no_raw(self, mock_gh: object) -> None:
+        """When raw_comments is None, fetches from GitHub."""
+        raw = [
+            {
+                "id": 10,
+                "login": "octocat",
+                "user_type": "User",
+                "created_at": "2026-03-20T10:00:00Z",
+                "body": "nice",
+            },
+        ]
+        mock_gh.return_value = _mock_result(stdout=json.dumps(raw))
+        overlay = get_pr_comment_overlay(42)
+        assert overlay.total_comments == 1
+        assert overlay.human_comments == 1
+
+    @patch("bid_euchre.ops.reviews._run_gh")
+    def test_gh_failure_returns_empty_overlay(self, mock_gh: object) -> None:
+        """GitHub failure returns overlay with zero comments."""
+        mock_gh.return_value = _mock_result(returncode=1, stderr="not found")
+        overlay = get_pr_comment_overlay(42)
+        assert overlay.total_comments == 0
+
+
+class TestFormatCommentOverlays:
+    """Tests for comment overlay formatting."""
+
+    def test_text_empty(self) -> None:
+        text = format_comment_overlays_text([])
+        assert "No comment data" in text
+
+    def test_text_with_trusted_bot(self) -> None:
+        overlay = CommentOverlay(
+            pr_number=42,
+            total_comments=3,
+            trusted_bot_comments=1,
+            human_comments=2,
+            latest_trusted_bot_author="chatgpt-codex-connector[bot]",
+            latest_trusted_bot_time="2026-03-20T10:00:00Z",
+            latest_trusted_bot_excerpt="Review findings...",
+        )
+        text = format_comment_overlays_text([overlay])
+        assert "#42" in text
+        assert "Trusted=[+:1]" in text
+        assert "Human=2" in text
+        assert "chatgpt-codex-connector[bot]" in text
+
+    def test_text_no_trusted_bot(self) -> None:
+        overlay = CommentOverlay(
+            pr_number=42,
+            total_comments=1,
+            human_comments=1,
+        )
+        text = format_comment_overlays_text([overlay])
+        assert "Trusted=[-:0]" in text
+
+    def test_json_serializable(self) -> None:
+        overlay = CommentOverlay(
+            pr_number=42,
+            total_comments=2,
+            trusted_bot_comments=1,
+            human_comments=1,
+            latest_trusted_bot_excerpt="Review ok",
+        )
+        result = format_comment_overlays_json([overlay])
+        assert len(result) == 1
+        assert result[0]["pr_number"] == 42
+        assert result[0]["trusted_bot_comments"] == 1
+        # Must be JSON-serializable
+        json.dumps(result)


### PR DESCRIPTION
## Plan
- `plans/sessions/2026-03-20_post-pr5-bridge-controls-and-review-surfaces.md` (Lane B)
- `plans/sessions/2026-03-20_pr-comment-ingestion-bridge.md`

## Summary
- Add PR comment query/normalization with trusted bot identity classification
- Add CommentOverlay for surfacing comment-based review signals (separate from CI/merge gate)
- Add `ops.py comments --pr N [--ingest] [--json]` CLI subcommand
- Add pr_comment entry type to audit index with JSONL sidecar ingestion
- Add pr_comment_ingested event type for durable event log

## Why
Codex Cloud review arrives as PR issue comments from `chatgpt-codex-connector[bot]`, not as checks
or statuses. To make these visible operationally, PR comments need their own ingestion/classification
path that does not conflate them with CI checks or the `reviewing-changes` merge gate.

This is Lane B of the post-PR-5 bridge, shipping before Platform-1.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_github_pr_state.py tests/unit/test_ops_events.py tests/unit/test_ops_reviews.py tests/unit/test_ops_index.py tests/unit/test_ops_cli.py -x -q
# 213 passed

make check-quiet
# All checks passed
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_github_pr_state.py` — 51 tests (14 new)
- [x] `uv run python -m pytest tests/unit/test_ops_events.py` — 25 tests (1 new)
- [x] `uv run python -m pytest tests/unit/test_ops_reviews.py` — 79 tests (21 new)
- [x] `uv run python -m pytest tests/unit/test_ops_index.py` — 55 tests (5 new)
- [x] `uv run python -m pytest tests/unit/test_ops_cli.py -k comments` — 3 new tests
- [x] `make check-quiet` — full validation passes

## Expected impact
- Metrics impact: None (ops tooling only)
- Runtime impact: None (new subcommand, opt-in ingestion)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c  0a6bf534 [codex/steward-author-c]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)