### PR TITLE
ops: add review-quality instrumentation for local review loop

### DIFF
--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -277,6 +277,7 @@ Every experiment run creates a standardized directory under `data/runs/<run_id>/
 | `scripts/internal/test_review_infra.py` | Tiered (SMOKE/QUICK/FULL) end-to-end review infrastructure test harness |
 | `scripts/internal/review_common.py` | Shared severity constants and predicates for the review pipeline |
 | `scripts/internal/review_driver.py` | Autonomous review loop orchestrator (state machine) |
+| `scripts/internal/review_quality_audit.py` | Review-quality audit: scan loop artifacts, report missed blockers, noisy findings, deterministic-check candidates |
 | `scripts/internal/review_state.py` | Review loop state schema, persistence, and transitions |
 | `scripts/internal/rung_state.py` | Rung orchestrator state management (RunState persistence, step/model tracking) |
 | `scripts/internal/run_rung.py` | Arc D v2 rung orchestrator (9-step runbook execution, multi-seed, QUICK/FULL pipeline) |

--- a/plans/sessions/2026-03-20_review-quality-instrumentation.md
+++ b/plans/sessions/2026-03-20_review-quality-instrumentation.md
@@ -1,0 +1,233 @@
+# Review Quality Instrumentation
+
+**Date:** 2026-03-20
+**Status:** proposed
+**Goal:** Add a bounded audit/instrumentation lane that measures where the
+current local review loop misses issues or produces noisy findings, without
+changing the merge gate or review-coordinator architecture.
+
+## Relation to Active Bridge Work
+
+This is a supporting lane that may run in parallel with the post-PR-5 bridge,
+especially the local review-architecture reset.
+
+It exists to answer a concrete question before `Platform-1`:
+
+- what kinds of issues are still being missed pre-merge?
+- which findings are high-noise and should not block?
+- which repeated misses are strong candidates for deterministic checks?
+
+This lane should inform later review-loop tightening, but it should not itself
+become a review-architecture rewrite.
+
+## Entry Conditions
+
+- PR-5 closeout baseline cleanup is merged
+- the review loop remains operational on `origin/main`
+- the local review-architecture reset may be running in parallel
+
+## Why This Exists
+
+The repo has already accumulated evidence that:
+
+1. hosted review surfaces are brittle
+2. current local Codex CLI review is not catching enough important issues
+3. some review-loop findings are noisy enough to waste cycles
+
+Before broadening platform/autonomy scope, the repo should have a lightweight,
+durable way to measure review effectiveness and identify the highest-signal next
+improvements.
+
+## Decisions Locked By This Plan
+
+1. This lane is **measurement-first**, not architecture-first.
+   - do not redesign the review loop here
+   - do not change merge-gate ownership
+
+2. This lane is **repo-local and bounded**.
+   - prefer using existing local artifacts, PR metadata, committed reports, and
+     review-loop outputs
+   - avoid dependence on hosted review services
+
+3. Output should be **operator-usable**.
+   - findings should roll up into a short audit summary
+   - the result should clearly separate:
+     - missed blockers
+     - noisy findings / false positives
+     - candidate deterministic checks
+
+4. This lane should not widen into broad data science/reporting infrastructure.
+
+## Ownership / Non-Overlap Rules
+
+This lane should avoid overlapping the active review reset lane unless a small,
+explicitly coordinated hook is needed.
+
+Preferred ownership:
+
+- `scripts/internal/confidence_scorer.py`
+- new audit/report helper(s) under `scripts/internal/`
+- review-quality tests
+- review-loop docs only where the instrumentation/report output is described
+
+Avoid unless coordination is required:
+
+- `scripts/internal/review_driver.py`
+- canonical PR comment publication logic
+- `reviewing-changes` status publication behavior
+- broad state-machine changes
+
+## Concrete Questions to Answer
+
+The implementation should make it easy to answer:
+
+1. Which post-merge follow-up fixes correspond to issues the review loop should
+   have caught?
+2. Which check IDs or finding classes are producing low-value noise?
+3. Which file categories or PR shapes are most associated with misses?
+4. Which misses are deterministic enough to promote into prechecks?
+
+## Required Deliverables
+
+### 1. Durable audit input shape
+
+Add or document a stable way to collect review-quality inputs from repo-local
+artifacts such as:
+
+- review-loop round artifacts
+- committed follow-up session plans / fix PRs
+- PR metadata already available to repo tooling
+- deterministic precheck outputs
+- confidence scoring outputs
+
+This does not need to be a large new schema. A small JSON summary or Markdown
+report is enough if it is stable and testable.
+
+### 2. Review-quality audit command or helper
+
+Provide one repo-local way to generate a bounded audit/report from recent data.
+
+Expected characteristics:
+
+- works without hosted-review dependencies
+- focuses on recent PRs or a bounded sample
+- highlights:
+  - missed pre-merge issues
+  - noisy findings
+  - deterministic-check candidates
+
+### 3. Short operator-facing summary
+
+The lane should produce a compact summary format that can support:
+
+- handoffs
+- plan amendments
+- future deterministic-check prioritization
+
+### 4. Tests
+
+Add tests for:
+
+- classification/rollup of review outcomes
+- audit summary generation on synthetic sample inputs
+- regression coverage for the chosen data model
+
+## Likely Files
+
+| File | Expected role |
+|------|---------------|
+| `scripts/internal/confidence_scorer.py` | reuse or extend scoring/audit helpers if appropriate |
+| `scripts/internal/review_driver.py` | only if a small hook is truly needed |
+| `scripts/internal/` | likely new audit/report helper |
+| `tests/unit/test_confidence_scorer.py` | scoring/report tests if touched |
+| `tests/unit/test_review_driver.py` | only if a small hook is added |
+| `docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md` | describe the audit/instrumentation output if shipped |
+| `plans/sessions/2026-03-20_review-quality-instrumentation.md` | fill outcome section after implementation |
+
+## Suggested Implementation Shape
+
+1. Validate what local artifacts already exist and are reliable enough to mine.
+2. Add the smallest useful audit/report helper.
+3. Generate bounded rollups by finding class / source / outcome.
+4. Ensure the output explicitly distinguishes:
+   - misses that should have blocked
+   - warnings/noise that should be downgraded or filtered
+   - candidates for deterministic prechecks
+5. Update docs only enough to explain how to run and interpret the audit.
+
+## Out of Scope
+
+- replacing the review loop
+- changing the `reviewing-changes` contract
+- broad prompt redesign
+- hosted review experimentation
+- automatic public PR replies
+- platform/orchestrator/dashboard work
+
+## Done When
+
+- [ ] there is one repo-local way to generate a bounded review-quality audit
+- [ ] the output distinguishes misses, noise, and deterministic-check
+      candidates
+- [ ] tests cover the chosen summary/report behavior
+- [ ] docs are updated if operator-facing usage changed
+- [ ] the implementation stays out of merge-gate / coordinator redesign
+- [ ] `make check-quiet` passes
+
+## Suggested Validation
+
+- `uv run pytest -q tests/unit/test_confidence_scorer.py tests/unit/test_review_driver.py`
+- targeted tests for any new audit helper
+- `make check-quiet`
+
+## Outcome
+
+**PR:** (pending — opened after `make check-quiet` passes)
+**Branch:** `codex/steward-author-c`
+
+### Delivered
+
+1. **`scripts/internal/review_quality_audit.py`** — bounded audit helper
+   - Scans `.claude/runtime/review_loops/pr_*/` state files and round artifacts
+   - Aggregates findings by `(check_id, source)` across all rounds
+   - Identifies noisy check_ids (high confidence-filter rate)
+   - Identifies deterministic-check candidates (recurring Codex findings not yet in prechecks)
+   - Correlates post-merge fix PRs as missed-blocker signals
+   - Produces Markdown or JSON summary output
+   - CLI: `python scripts/internal/review_quality_audit.py [--json] [--base PATH]`
+
+2. **`tests/unit/test_review_quality_audit.py`** — 49 tests covering:
+   - Loop outcome scanning (state file parsing, enrichment from rounds)
+   - Finding aggregation (precheck + codex + scoring + fix counts)
+   - Noise detection (filter-rate thresholds)
+   - Missed-blocker extraction (fix PR title classification)
+   - Deterministic-candidate identification (codex-only, excludes existing prechecks)
+   - Summary generation and Markdown formatting
+   - Full pipeline integration (scan → aggregate → summary → format)
+   - Edge cases (empty data, malformed JSON, non-PR directories)
+
+3. **`docs/01_core/ARCHITECTURE.md`** — registered new script in the internal tooling table
+
+### Validated Data Sources
+
+| Source | Location | Shape |
+|--------|----------|-------|
+| Loop state files | `.claude/runtime/review_loops/pr_<N>/state.json` | `ReviewLoopState` JSON |
+| Precheck findings | `round_<N>/prechecks.json` | list of Finding dicts |
+| Codex review | `round_<N>/codex_review.json` | `{success, findings, raw_output}` |
+| Confidence scoring | `round_<N>/confidence_scoring.json` | `{total_findings, passed, filtered, findings}` |
+| Fix summary | `round_<N>/fix_summary.json` | `{fixes_applied, fixes_skipped, actions}` |
+
+### Key Findings from Local Data (77 loops)
+
+- **Completion rate:** 26% (20/77 merged)
+- **Top failure mode:** `stopped_ci_failure` (32/77 = 42%)
+- **Review availability:** `stopped_review_failure` (8/77) + `waiting_for_codex` (12/77) = 26% stuck on Codex
+- **Codex findings often lack `check_id`** — marked `unstructured`, not promotable to deterministic checks
+- **Confidence scorer filters mostly work** — noisy P2 findings on unmodified lines correctly filtered
+
+### Residual Gaps
+
+- No automated GitHub API integration for fix-PR correlation — requires `--fix-prs-json` input file
+- Cannot distinguish "CI failure on PR code" from "CI failure on infra" without parsing CI logs
+- `waiting_for_codex` loops may be live or dead — no timeout detection in the audit

--- a/scripts/internal/review_quality_audit.py
+++ b/scripts/internal/review_quality_audit.py
@@ -1,0 +1,628 @@
+"""Review-quality audit: measure where the review loop misses or over-reports.
+
+Scans local review-loop artifacts (state files, round findings,
+confidence-scoring reports) and produces a bounded summary that
+distinguishes:
+
+  1. Missed blockers — post-merge fixes that the loop should have caught
+  2. Noisy findings — check_ids with high filter/false-positive rates
+  3. Deterministic-check candidates — repeated Codex findings that could
+     become prechecks
+
+Usage::
+
+    # Audit all local review-loop data
+    python scripts/internal/review_quality_audit.py
+
+    # Audit with JSON output
+    python scripts/internal/review_quality_audit.py --json
+
+    # Audit specific base directory (for testing)
+    python scripts/internal/review_quality_audit.py --base /path/to/review_loops
+
+This module is repo-local measurement only.  It does not change the
+``reviewing-changes`` contract or the merge gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LoopOutcome:
+    """Summary of one review-loop run."""
+
+    pr_number: int
+    terminal_state: str
+    iteration_count: int
+    stop_reason: str | None
+    total_findings: int = 0
+    filtered_findings: int = 0
+    codex_findings: int = 0
+    precheck_findings: int = 0
+
+
+@dataclass
+class FindingAggregate:
+    """Aggregate stats for one (check_id, source) pair."""
+
+    check_id: str
+    source: str  # "deterministic_precheck", "codex_cli"
+    total: int = 0
+    filtered: int = 0  # filtered by confidence scorer
+    p0_count: int = 0
+    p1_count: int = 0
+    p2_count: int = 0
+    auto_fixed: int = 0
+    skipped: int = 0  # skipped by fix adapter
+
+
+@dataclass
+class MissedBlockerSignal:
+    """A post-merge fix that the pre-merge loop should have caught."""
+
+    pr_number: int
+    title: str
+    category: str  # extracted from title prefix like "fix:", "fix(fix:convention):"
+
+
+@dataclass
+class AuditSummary:
+    """Top-level audit report."""
+
+    total_loops: int = 0
+    outcome_distribution: dict[str, int] = field(default_factory=dict)
+    completion_rate: float = 0.0
+    finding_aggregates: list[FindingAggregate] = field(default_factory=list)
+    noisy_check_ids: list[str] = field(default_factory=list)
+    missed_blocker_signals: list[MissedBlockerSignal] = field(default_factory=list)
+    deterministic_candidates: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        return d
+
+
+# ---------------------------------------------------------------------------
+# Scanning
+# ---------------------------------------------------------------------------
+
+
+def scan_loop_outcomes(base: Path) -> list[LoopOutcome]:
+    """Scan review-loop state files and return per-PR outcomes."""
+    outcomes: list[LoopOutcome] = []
+
+    if not base.is_dir():
+        return outcomes
+
+    for pr_dir in sorted(base.iterdir()):
+        if not pr_dir.is_dir() or not pr_dir.name.startswith("pr_"):
+            continue
+
+        state_path = pr_dir / "state.json"
+        if not state_path.exists():
+            continue
+
+        try:
+            state = json.loads(state_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        pr_num = state.get("pr_number", 0)
+        outcome = LoopOutcome(
+            pr_number=pr_num,
+            terminal_state=state.get("state", "unknown"),
+            iteration_count=state.get("iteration_count", 0),
+            stop_reason=state.get("stop_reason"),
+        )
+
+        # Aggregate findings across rounds
+        for round_dir in sorted(pr_dir.iterdir()):
+            if not round_dir.is_dir() or not round_dir.name.startswith("round_"):
+                continue
+            _enrich_from_round(outcome, round_dir)
+
+        outcomes.append(outcome)
+
+    return outcomes
+
+
+def _enrich_from_round(outcome: LoopOutcome, round_dir: Path) -> None:
+    """Add finding counts from a single round directory."""
+    # Prechecks
+    prechecks_path = round_dir / "prechecks.json"
+    if prechecks_path.exists():
+        try:
+            prechecks = json.loads(prechecks_path.read_text())
+            if isinstance(prechecks, list):
+                outcome.precheck_findings += len(prechecks)
+                outcome.total_findings += len(prechecks)
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    # Codex review
+    codex_path = round_dir / "codex_review.json"
+    if codex_path.exists():
+        try:
+            codex = json.loads(codex_path.read_text())
+            findings = codex.get("findings", [])
+            outcome.codex_findings += len(findings)
+            outcome.total_findings += len(findings)
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    # Confidence scoring (filter counts)
+    scoring_path = round_dir / "confidence_scoring.json"
+    if scoring_path.exists():
+        try:
+            scoring = json.loads(scoring_path.read_text())
+            outcome.filtered_findings += scoring.get("filtered", 0)
+        except (json.JSONDecodeError, OSError):
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Finding aggregation
+# ---------------------------------------------------------------------------
+
+
+def aggregate_findings(base: Path) -> list[FindingAggregate]:
+    """Aggregate findings by (check_id, source) across all rounds."""
+    agg: dict[tuple[str, str], FindingAggregate] = {}
+
+    if not base.is_dir():
+        return []
+
+    for pr_dir in sorted(base.iterdir()):
+        if not pr_dir.is_dir() or not pr_dir.name.startswith("pr_"):
+            continue
+
+        for round_dir in sorted(pr_dir.iterdir()):
+            if not round_dir.is_dir() or not round_dir.name.startswith("round_"):
+                continue
+
+            _aggregate_prechecks(round_dir, agg)
+            _aggregate_codex(round_dir, agg)
+            _aggregate_scoring(round_dir, agg)
+            _aggregate_fixes(round_dir, agg)
+
+    return sorted(agg.values(), key=lambda a: a.total, reverse=True)
+
+
+def _get_or_create(
+    agg: dict[tuple[str, str], FindingAggregate],
+    check_id: str,
+    source: str,
+) -> FindingAggregate:
+    """Get or create an aggregate entry."""
+    key = (check_id, source)
+    if key not in agg:
+        agg[key] = FindingAggregate(check_id=check_id, source=source)
+    return agg[key]
+
+
+def _aggregate_prechecks(
+    round_dir: Path, agg: dict[tuple[str, str], FindingAggregate]
+) -> None:
+    """Aggregate precheck findings from a round."""
+    path = round_dir / "prechecks.json"
+    if not path.exists():
+        return
+    try:
+        findings = json.loads(path.read_text())
+        if not isinstance(findings, list):
+            return
+    except (json.JSONDecodeError, OSError):
+        return
+
+    for f in findings:
+        check_id = f.get("check_id") or "unknown"
+        entry = _get_or_create(agg, check_id, "deterministic_precheck")
+        entry.total += 1
+        sev = f.get("severity", "P2")
+        if sev == "P0":
+            entry.p0_count += 1
+        elif sev == "P1":
+            entry.p1_count += 1
+        else:
+            entry.p2_count += 1
+
+
+def _aggregate_codex(
+    round_dir: Path, agg: dict[tuple[str, str], FindingAggregate]
+) -> None:
+    """Aggregate Codex CLI findings from a round."""
+    path = round_dir / "codex_review.json"
+    if not path.exists():
+        return
+    try:
+        data = json.loads(path.read_text())
+        findings = data.get("findings", [])
+    except (json.JSONDecodeError, OSError):
+        return
+
+    for f in findings:
+        check_id = f.get("check_id") or "unstructured"
+        entry = _get_or_create(agg, check_id, "codex_cli")
+        entry.total += 1
+        sev = f.get("severity", "P2")
+        if sev == "P0":
+            entry.p0_count += 1
+        elif sev == "P1":
+            entry.p1_count += 1
+        else:
+            entry.p2_count += 1
+
+
+def _aggregate_scoring(
+    round_dir: Path, agg: dict[tuple[str, str], FindingAggregate]
+) -> None:
+    """Aggregate confidence-scoring filter counts."""
+    path = round_dir / "confidence_scoring.json"
+    if not path.exists():
+        return
+    try:
+        data = json.loads(path.read_text())
+        findings = data.get("findings", [])
+    except (json.JSONDecodeError, OSError):
+        return
+
+    for f in findings:
+        if f.get("filtered"):
+            check_id = f.get("check_id") or "unknown"
+            # Try to infer source — scoring happens after codex review
+            entry = _get_or_create(agg, check_id, "codex_cli")
+            entry.filtered += 1
+
+
+def _aggregate_fixes(
+    round_dir: Path, agg: dict[tuple[str, str], FindingAggregate]
+) -> None:
+    """Aggregate auto-fix results."""
+    path = round_dir / "fix_summary.json"
+    if not path.exists():
+        return
+    try:
+        data = json.loads(path.read_text())
+        actions = data.get("actions", [])
+    except (json.JSONDecodeError, OSError):
+        return
+
+    for action in actions:
+        check_id = action.get("check_id") or "unstructured"
+        status = action.get("status", "")
+        # Auto-fix actions come from Codex findings
+        entry = _get_or_create(agg, check_id, "codex_cli")
+        if status == "applied":
+            entry.auto_fixed += 1
+        elif status == "skipped":
+            entry.skipped += 1
+
+
+# ---------------------------------------------------------------------------
+# Noise detection
+# ---------------------------------------------------------------------------
+
+
+def identify_noisy_check_ids(
+    aggregates: list[FindingAggregate],
+    min_occurrences: int = 3,
+    min_filter_rate: float = 0.5,
+) -> list[str]:
+    """Identify check_ids with high confidence-filter rates.
+
+    A check_id is noisy if it has appeared at least *min_occurrences*
+    times and more than *min_filter_rate* fraction of its P2 findings
+    were filtered by the confidence scorer.
+
+    Returns:
+        Sorted list of noisy check_id strings.
+    """
+    noisy: list[str] = []
+    for a in aggregates:
+        if a.p2_count < min_occurrences:
+            continue
+        if a.p2_count > 0 and a.filtered / a.p2_count >= min_filter_rate:
+            noisy.append(a.check_id)
+    return sorted(set(noisy))
+
+
+# ---------------------------------------------------------------------------
+# Missed-blocker signals
+# ---------------------------------------------------------------------------
+
+
+def classify_fix_pr(title: str) -> str | None:
+    """Extract fix category from a PR title.
+
+    Returns the category string (e.g. "bug", "convention", "test") or
+    None if the title doesn't look like a fix PR.
+    """
+    title_lower = title.lower().strip()
+
+    # Pattern: "fix(fix:category): ..."
+    if title_lower.startswith("fix(fix:"):
+        end = title_lower.index(")")
+        return title_lower[8:end].strip() or "general"
+
+    # Pattern: "fix: ..."
+    if title_lower.startswith("fix:"):
+        return "general"
+
+    # Pattern: "fix(category): ..."
+    if title_lower.startswith("fix("):
+        try:
+            end = title_lower.index(")")
+            return title_lower[4:end].strip() or "general"
+        except ValueError:
+            return "general"
+
+    return None
+
+
+def extract_missed_blocker_signals(
+    fix_prs: list[dict[str, Any]],
+) -> list[MissedBlockerSignal]:
+    """Extract missed-blocker signals from post-merge fix PRs.
+
+    Args:
+        fix_prs: List of dicts with keys: number, title.
+
+    Returns:
+        List of MissedBlockerSignal for PRs that look like post-merge fixes.
+    """
+    signals: list[MissedBlockerSignal] = []
+    for pr in fix_prs:
+        title = pr.get("title", "")
+        category = classify_fix_pr(title)
+        if category is not None:
+            signals.append(
+                MissedBlockerSignal(
+                    pr_number=pr.get("number", 0),
+                    title=title,
+                    category=category,
+                )
+            )
+    return signals
+
+
+# ---------------------------------------------------------------------------
+# Deterministic-check candidates
+# ---------------------------------------------------------------------------
+
+
+def identify_deterministic_candidates(
+    aggregates: list[FindingAggregate],
+    min_occurrences: int = 2,
+) -> list[str]:
+    """Identify Codex findings that recur enough to become deterministic prechecks.
+
+    A candidate is a Codex CLI finding with a structured check_id
+    (not 'unstructured') that appeared at least *min_occurrences* times
+    and is not already a deterministic precheck.
+
+    Returns:
+        Sorted list of candidate check_id strings.
+    """
+    # Collect existing deterministic precheck check_ids
+    existing: set[str] = set()
+    for a in aggregates:
+        if a.source == "deterministic_precheck":
+            existing.add(a.check_id)
+
+    candidates: list[str] = []
+    for a in aggregates:
+        if a.source != "codex_cli":
+            continue
+        if a.check_id in ("unstructured", "unknown"):
+            continue
+        if a.check_id in existing:
+            continue
+        if a.total >= min_occurrences:
+            candidates.append(a.check_id)
+
+    return sorted(set(candidates))
+
+
+# ---------------------------------------------------------------------------
+# Summary generation
+# ---------------------------------------------------------------------------
+
+
+def generate_summary(
+    outcomes: list[LoopOutcome],
+    aggregates: list[FindingAggregate],
+    missed_signals: list[MissedBlockerSignal],
+    *,
+    noisy_min_occurrences: int = 3,
+    noisy_min_filter_rate: float = 0.5,
+    deterministic_min_occurrences: int = 2,
+) -> AuditSummary:
+    """Generate the full audit summary from scanned data."""
+    outcome_dist: Counter[str] = Counter()
+    for o in outcomes:
+        outcome_dist[o.terminal_state] += 1
+
+    merged_count = outcome_dist.get("merged", 0)
+    total = len(outcomes)
+    completion_rate = merged_count / total if total > 0 else 0.0
+
+    noisy = identify_noisy_check_ids(
+        aggregates,
+        min_occurrences=noisy_min_occurrences,
+        min_filter_rate=noisy_min_filter_rate,
+    )
+    deterministic = identify_deterministic_candidates(
+        aggregates,
+        min_occurrences=deterministic_min_occurrences,
+    )
+
+    # Categorize missed-blocker signals
+    missed_categories: Counter[str] = Counter()
+    for s in missed_signals:
+        missed_categories[s.category] += 1
+
+    return AuditSummary(
+        total_loops=total,
+        outcome_distribution=dict(outcome_dist),
+        completion_rate=round(completion_rate, 3),
+        finding_aggregates=aggregates,
+        noisy_check_ids=noisy,
+        missed_blocker_signals=missed_signals,
+        deterministic_candidates=deterministic,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+
+def format_markdown(summary: AuditSummary) -> str:
+    """Format audit summary as Markdown for handoff/plan updates."""
+    lines: list[str] = []
+    lines.append("# Review Quality Audit")
+    lines.append("")
+
+    # Outcome distribution
+    lines.append("## Loop Outcome Distribution")
+    lines.append("")
+    lines.append(f"**Total loops:** {summary.total_loops}")
+    lines.append(f"**Completion rate (merged):** {summary.completion_rate:.1%}")
+    lines.append("")
+    lines.append("| State | Count |")
+    lines.append("|-------|-------|")
+    for state, count in sorted(
+        summary.outcome_distribution.items(), key=lambda x: -x[1]
+    ):
+        lines.append(f"| {state} | {count} |")
+    lines.append("")
+
+    # Finding aggregates
+    if summary.finding_aggregates:
+        lines.append("## Finding Aggregates (by check_id × source)")
+        lines.append("")
+        lines.append(
+            "| check_id | source | total | P0 | P1 | P2 | filtered | auto_fixed | skipped |"
+        )
+        lines.append(
+            "|----------|--------|-------|----|----|----|----------|------------|---------|"
+        )
+        for a in summary.finding_aggregates:
+            lines.append(
+                f"| {a.check_id} | {a.source} | {a.total} | {a.p0_count} "
+                f"| {a.p1_count} | {a.p2_count} | {a.filtered} "
+                f"| {a.auto_fixed} | {a.skipped} |"
+            )
+        lines.append("")
+
+    # Noisy check_ids
+    if summary.noisy_check_ids:
+        lines.append("## Noisy Check IDs (high filter rate)")
+        lines.append("")
+        for cid in summary.noisy_check_ids:
+            lines.append(f"- `{cid}`")
+        lines.append("")
+
+    # Missed blockers
+    if summary.missed_blocker_signals:
+        lines.append("## Missed Blocker Signals (post-merge fix PRs)")
+        lines.append("")
+        cat_counts: Counter[str] = Counter()
+        for s in summary.missed_blocker_signals:
+            cat_counts[s.category] += 1
+        lines.append("**By category:**")
+        lines.append("")
+        for cat, count in cat_counts.most_common():
+            lines.append(f"- `{cat}`: {count}")
+        lines.append("")
+        lines.append("**Recent fix PRs:**")
+        lines.append("")
+        for s in summary.missed_blocker_signals[:20]:
+            lines.append(f"- #{s.pr_number}: {s.title}")
+        if len(summary.missed_blocker_signals) > 20:
+            lines.append(f"- ... and {len(summary.missed_blocker_signals) - 20} more")
+        lines.append("")
+
+    # Deterministic candidates
+    if summary.deterministic_candidates:
+        lines.append("## Deterministic-Check Candidates")
+        lines.append("")
+        lines.append(
+            "These Codex CLI findings recur frequently and could become "
+            "deterministic prechecks:"
+        )
+        lines.append("")
+        for cid in summary.deterministic_candidates:
+            lines.append(f"- `{cid}`")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the review-quality audit."""
+    parser = argparse.ArgumentParser(
+        description="Review-quality audit for the local review loop"
+    )
+    parser.add_argument(
+        "--base",
+        type=Path,
+        default=Path(".claude/runtime/review_loops"),
+        help="Base directory containing review-loop state (default: .claude/runtime/review_loops)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output JSON instead of Markdown",
+    )
+    parser.add_argument(
+        "--fix-prs-json",
+        type=Path,
+        default=None,
+        help="Path to JSON file of merged fix PRs (each: {number, title})",
+    )
+    args = parser.parse_args(argv)
+
+    # Scan outcomes and findings
+    outcomes = scan_loop_outcomes(args.base)
+    aggregates = aggregate_findings(args.base)
+
+    # Load fix PRs if provided
+    missed_signals: list[MissedBlockerSignal] = []
+    if args.fix_prs_json and args.fix_prs_json.exists():
+        try:
+            fix_prs = json.loads(args.fix_prs_json.read_text())
+            missed_signals = extract_missed_blocker_signals(fix_prs)
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    summary = generate_summary(outcomes, aggregates, missed_signals)
+
+    if args.json_output:
+        print(json.dumps(summary.to_dict(), indent=2))
+    else:
+        print(format_markdown(summary))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_review_quality_audit.py
+++ b/tests/unit/test_review_quality_audit.py
@@ -1,0 +1,776 @@
+"""Tests for review_quality_audit — review-loop quality measurement."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# The module under test lives in scripts/internal/, not in the installed package.
+_SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts" / "internal"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from review_quality_audit import (
+    AuditSummary,
+    FindingAggregate,
+    MissedBlockerSignal,
+    aggregate_findings,
+    classify_fix_pr,
+    extract_missed_blocker_signals,
+    format_markdown,
+    generate_summary,
+    identify_deterministic_candidates,
+    identify_noisy_check_ids,
+    scan_loop_outcomes,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures — create synthetic review-loop directories
+# ---------------------------------------------------------------------------
+
+
+def _write_state(pr_dir: Path, state: dict) -> None:
+    """Write a state.json into a PR directory."""
+    pr_dir.mkdir(parents=True, exist_ok=True)
+    (pr_dir / "state.json").write_text(json.dumps(state))
+
+
+def _write_round(
+    pr_dir: Path,
+    round_num: int,
+    *,
+    prechecks: list | None = None,
+    codex_review: dict | None = None,
+    confidence_scoring: dict | None = None,
+    fix_summary: dict | None = None,
+) -> None:
+    """Write round artifacts into a PR round directory."""
+    round_dir = pr_dir / f"round_{round_num}"
+    round_dir.mkdir(parents=True, exist_ok=True)
+
+    if prechecks is not None:
+        (round_dir / "prechecks.json").write_text(json.dumps(prechecks))
+    if codex_review is not None:
+        (round_dir / "codex_review.json").write_text(json.dumps(codex_review))
+    if confidence_scoring is not None:
+        (round_dir / "confidence_scoring.json").write_text(
+            json.dumps(confidence_scoring)
+        )
+    if fix_summary is not None:
+        (round_dir / "fix_summary.json").write_text(json.dumps(fix_summary))
+
+
+@pytest.fixture
+def review_base(tmp_path: Path) -> Path:
+    """Create a synthetic review-loop base with realistic data."""
+    base = tmp_path / "review_loops"
+
+    # PR 100: merged successfully, had some findings
+    pr100 = base / "pr_100"
+    _write_state(
+        pr100,
+        {
+            "pr_number": 100,
+            "state": "merged",
+            "iteration_count": 1,
+            "stop_reason": None,
+        },
+    )
+    _write_round(
+        pr100,
+        1,
+        prechecks=[
+            {
+                "severity": "P2",
+                "check_id": "PV1",
+                "file": "<PR body>",
+                "line": 0,
+                "message": "No plan ref",
+                "raw_source": "plan_validation",
+            }
+        ],
+        codex_review={
+            "success": True,
+            "findings": [
+                {
+                    "severity": "P2",
+                    "file": "src/foo.py",
+                    "line": 10,
+                    "check_id": "C4",
+                    "message": "Function too long",
+                    "raw_source": "codex_cli",
+                }
+            ],
+        },
+        confidence_scoring={
+            "total_findings": 1,
+            "passed": 0,
+            "filtered": 1,
+            "threshold": 75,
+            "findings": [
+                {
+                    "file": "src/foo.py",
+                    "line": 10,
+                    "check_id": "C4",
+                    "severity": "P2",
+                    "confidence": 40,
+                    "filtered": True,
+                }
+            ],
+        },
+        fix_summary={
+            "fixes_applied": 0,
+            "fixes_skipped": 1,
+            "actions": [
+                {
+                    "file": "src/foo.py",
+                    "check_id": "C4",
+                    "status": "skipped",
+                    "reason": "Not auto-fixable",
+                }
+            ],
+        },
+    )
+
+    # PR 200: stopped_ci_failure
+    pr200 = base / "pr_200"
+    _write_state(
+        pr200,
+        {
+            "pr_number": 200,
+            "state": "stopped_ci_failure",
+            "iteration_count": 0,
+            "stop_reason": "CI failed",
+        },
+    )
+
+    # PR 300: merged, no findings
+    pr300 = base / "pr_300"
+    _write_state(
+        pr300,
+        {
+            "pr_number": 300,
+            "state": "merged",
+            "iteration_count": 0,
+            "stop_reason": None,
+        },
+    )
+
+    # PR 400: stopped_review_failure
+    pr400 = base / "pr_400"
+    _write_state(
+        pr400,
+        {
+            "pr_number": 400,
+            "state": "stopped_review_failure",
+            "iteration_count": 1,
+            "stop_reason": "Codex CLI unavailable",
+        },
+    )
+    _write_round(
+        pr400,
+        1,
+        prechecks=[
+            {
+                "severity": "P1",
+                "check_id": "C1",
+                "file": "src/bar.py",
+                "line": 5,
+                "message": "Unseeded RNG",
+                "raw_source": "deterministic_precheck",
+            },
+            {
+                "severity": "P2",
+                "check_id": "X3",
+                "file": "src/bar.py",
+                "line": 12,
+                "message": "breakpoint()",
+                "raw_source": "deterministic_precheck",
+            },
+        ],
+    )
+
+    # PR 500: merged with codex findings that have structured check_ids
+    pr500 = base / "pr_500"
+    _write_state(
+        pr500,
+        {
+            "pr_number": 500,
+            "state": "merged",
+            "iteration_count": 1,
+            "stop_reason": None,
+        },
+    )
+    _write_round(
+        pr500,
+        1,
+        codex_review={
+            "success": True,
+            "findings": [
+                {
+                    "severity": "P1",
+                    "file": "src/baz.py",
+                    "line": 20,
+                    "check_id": "T1",
+                    "message": "Untested behavior change",
+                    "raw_source": "codex_cli",
+                },
+                {
+                    "severity": "P2",
+                    "file": "src/baz.py",
+                    "line": 30,
+                    "check_id": "T1",
+                    "message": "Another untested change",
+                    "raw_source": "codex_cli",
+                },
+                {
+                    "severity": "P2",
+                    "file": "src/baz.py",
+                    "line": 40,
+                    "check_id": None,
+                    "message": "Unstructured prose finding",
+                    "raw_source": "codex_cli",
+                },
+            ],
+        },
+        confidence_scoring={
+            "total_findings": 3,
+            "passed": 2,
+            "filtered": 1,
+            "threshold": 75,
+            "findings": [
+                {
+                    "check_id": "T1",
+                    "severity": "P1",
+                    "confidence": 100,
+                    "filtered": False,
+                },
+                {
+                    "check_id": "T1",
+                    "severity": "P2",
+                    "confidence": 60,
+                    "filtered": True,
+                },
+                {
+                    "check_id": None,
+                    "severity": "P2",
+                    "confidence": 80,
+                    "filtered": False,
+                },
+            ],
+        },
+    )
+
+    return base
+
+
+# ---------------------------------------------------------------------------
+# scan_loop_outcomes
+# ---------------------------------------------------------------------------
+
+
+class TestScanLoopOutcomes:
+    """Verify loop-outcome scanning from state files."""
+
+    def test_scans_all_prs(self, review_base: Path):
+        outcomes = scan_loop_outcomes(review_base)
+        assert len(outcomes) == 5
+        pr_nums = {o.pr_number for o in outcomes}
+        assert pr_nums == {100, 200, 300, 400, 500}
+
+    def test_terminal_states(self, review_base: Path):
+        outcomes = scan_loop_outcomes(review_base)
+        states = {o.pr_number: o.terminal_state for o in outcomes}
+        assert states[100] == "merged"
+        assert states[200] == "stopped_ci_failure"
+        assert states[400] == "stopped_review_failure"
+
+    def test_finding_counts_enriched(self, review_base: Path):
+        outcomes = scan_loop_outcomes(review_base)
+        pr100 = next(o for o in outcomes if o.pr_number == 100)
+        assert pr100.precheck_findings == 1
+        assert pr100.codex_findings == 1
+        assert pr100.total_findings == 2
+        assert pr100.filtered_findings == 1
+
+    def test_empty_base(self, tmp_path: Path):
+        outcomes = scan_loop_outcomes(tmp_path / "nonexistent")
+        assert outcomes == []
+
+    def test_malformed_state_skipped(self, tmp_path: Path):
+        base = tmp_path / "loops"
+        pr_dir = base / "pr_999"
+        pr_dir.mkdir(parents=True)
+        (pr_dir / "state.json").write_text("not json")
+        outcomes = scan_loop_outcomes(base)
+        assert outcomes == []
+
+    def test_non_pr_directories_skipped(self, tmp_path: Path):
+        base = tmp_path / "loops"
+        (base / "not_a_pr").mkdir(parents=True)
+        (base / "readme.txt").parent.mkdir(parents=True, exist_ok=True)
+        (base / "readme.txt").write_text("ignore")
+        outcomes = scan_loop_outcomes(base)
+        assert outcomes == []
+
+
+# ---------------------------------------------------------------------------
+# aggregate_findings
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateFindings:
+    """Verify finding aggregation by (check_id, source)."""
+
+    def test_aggregates_by_check_id_and_source(self, review_base: Path):
+        aggs = aggregate_findings(review_base)
+        # Should have entries for precheck and codex sources
+        sources = {a.source for a in aggs}
+        assert "deterministic_precheck" in sources
+        assert "codex_cli" in sources
+
+    def test_precheck_counts(self, review_base: Path):
+        aggs = aggregate_findings(review_base)
+        pv1 = next(
+            (
+                a
+                for a in aggs
+                if a.check_id == "PV1" and a.source == "deterministic_precheck"
+            ),
+            None,
+        )
+        assert pv1 is not None
+        assert pv1.total == 1
+        assert pv1.p2_count == 1
+
+    def test_codex_counts(self, review_base: Path):
+        aggs = aggregate_findings(review_base)
+        t1_codex = next(
+            (a for a in aggs if a.check_id == "T1" and a.source == "codex_cli"),
+            None,
+        )
+        assert t1_codex is not None
+        assert t1_codex.total == 2  # One P1 + one P2
+        assert t1_codex.p1_count == 1
+        assert t1_codex.p2_count == 1
+
+    def test_filter_counts_from_scoring(self, review_base: Path):
+        aggs = aggregate_findings(review_base)
+        c4 = next(
+            (a for a in aggs if a.check_id == "C4" and a.source == "codex_cli"),
+            None,
+        )
+        assert c4 is not None
+        assert c4.filtered == 1
+
+    def test_fix_skipped_counts(self, review_base: Path):
+        aggs = aggregate_findings(review_base)
+        c4 = next(
+            (a for a in aggs if a.check_id == "C4" and a.source == "codex_cli"),
+            None,
+        )
+        assert c4 is not None
+        assert c4.skipped == 1
+
+    def test_unstructured_codex_findings(self, review_base: Path):
+        aggs = aggregate_findings(review_base)
+        unstructured = next(
+            (
+                a
+                for a in aggs
+                if a.check_id == "unstructured" and a.source == "codex_cli"
+            ),
+            None,
+        )
+        assert unstructured is not None
+        assert unstructured.total == 1
+
+    def test_sorted_by_total_descending(self, review_base: Path):
+        aggs = aggregate_findings(review_base)
+        totals = [a.total for a in aggs]
+        assert totals == sorted(totals, reverse=True)
+
+    def test_empty_base(self, tmp_path: Path):
+        aggs = aggregate_findings(tmp_path / "nonexistent")
+        assert aggs == []
+
+
+# ---------------------------------------------------------------------------
+# identify_noisy_check_ids
+# ---------------------------------------------------------------------------
+
+
+class TestIdentifyNoisyCheckIds:
+    """Verify noisy-check detection."""
+
+    def test_high_filter_rate_detected(self):
+        aggs = [
+            FindingAggregate(
+                check_id="N3",
+                source="codex_cli",
+                total=10,
+                p2_count=8,
+                filtered=6,
+            ),
+        ]
+        noisy = identify_noisy_check_ids(aggs, min_occurrences=3, min_filter_rate=0.5)
+        assert "N3" in noisy
+
+    def test_low_filter_rate_not_detected(self):
+        aggs = [
+            FindingAggregate(
+                check_id="C1",
+                source="codex_cli",
+                total=10,
+                p2_count=10,
+                filtered=1,
+            ),
+        ]
+        noisy = identify_noisy_check_ids(aggs, min_occurrences=3, min_filter_rate=0.5)
+        assert "C1" not in noisy
+
+    def test_below_min_occurrences_not_detected(self):
+        aggs = [
+            FindingAggregate(
+                check_id="X1",
+                source="codex_cli",
+                total=2,
+                p2_count=2,
+                filtered=2,
+            ),
+        ]
+        noisy = identify_noisy_check_ids(aggs, min_occurrences=3, min_filter_rate=0.5)
+        assert "X1" not in noisy
+
+    def test_empty_aggregates(self):
+        noisy = identify_noisy_check_ids([])
+        assert noisy == []
+
+    def test_deduplicates(self):
+        aggs = [
+            FindingAggregate(
+                check_id="N3",
+                source="codex_cli",
+                total=5,
+                p2_count=5,
+                filtered=5,
+            ),
+            FindingAggregate(
+                check_id="N3",
+                source="deterministic_precheck",
+                total=4,
+                p2_count=4,
+                filtered=4,
+            ),
+        ]
+        noisy = identify_noisy_check_ids(aggs, min_occurrences=3, min_filter_rate=0.5)
+        assert noisy.count("N3") == 1
+
+
+# ---------------------------------------------------------------------------
+# classify_fix_pr
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyFixPr:
+    """Verify PR title classification."""
+
+    def test_fix_colon(self):
+        assert classify_fix_pr("fix: improve error handling") == "general"
+
+    def test_fix_convention(self):
+        assert (
+            classify_fix_pr("fix(fix:convention): follow-up for PR #100")
+            == "convention"
+        )
+
+    def test_fix_bug(self):
+        assert classify_fix_pr("fix(fix:bug): handle null pointer") == "bug"
+
+    def test_fix_test(self):
+        assert classify_fix_pr("fix(fix:test): add missing coverage") == "test"
+
+    def test_fix_category_parens(self):
+        assert classify_fix_pr("fix(ops): harden scheduler") == "ops"
+
+    def test_not_fix(self):
+        assert classify_fix_pr("feat: add new bidding strategy") is None
+
+    def test_docs_not_fix(self):
+        assert classify_fix_pr("docs: update architecture guide") is None
+
+    def test_case_insensitive(self):
+        assert classify_fix_pr("Fix: uppercase fix") == "general"
+
+    def test_empty_category(self):
+        assert classify_fix_pr("fix(): empty parens") == "general"
+
+
+# ---------------------------------------------------------------------------
+# extract_missed_blocker_signals
+# ---------------------------------------------------------------------------
+
+
+class TestExtractMissedBlockerSignals:
+    """Verify missed-blocker extraction from PR lists."""
+
+    def test_extracts_fix_prs(self):
+        prs = [
+            {"number": 1, "title": "fix: handle edge case"},
+            {"number": 2, "title": "feat: new feature"},
+            {"number": 3, "title": "fix(fix:bug): null pointer"},
+        ]
+        signals = extract_missed_blocker_signals(prs)
+        assert len(signals) == 2
+        assert signals[0].pr_number == 1
+        assert signals[0].category == "general"
+        assert signals[1].pr_number == 3
+        assert signals[1].category == "bug"
+
+    def test_empty_list(self):
+        signals = extract_missed_blocker_signals([])
+        assert signals == []
+
+    def test_no_fix_prs(self):
+        prs = [
+            {"number": 1, "title": "docs: update readme"},
+            {"number": 2, "title": "feat: new bidder"},
+        ]
+        signals = extract_missed_blocker_signals(prs)
+        assert signals == []
+
+
+# ---------------------------------------------------------------------------
+# identify_deterministic_candidates
+# ---------------------------------------------------------------------------
+
+
+class TestIdentifyDeterministicCandidates:
+    """Verify deterministic-check candidate identification."""
+
+    def test_recurring_codex_check_id_is_candidate(self):
+        aggs = [
+            FindingAggregate(check_id="T1", source="codex_cli", total=5),
+        ]
+        candidates = identify_deterministic_candidates(aggs, min_occurrences=2)
+        assert "T1" in candidates
+
+    def test_precheck_check_ids_excluded(self):
+        aggs = [
+            FindingAggregate(check_id="C1", source="deterministic_precheck", total=10),
+            FindingAggregate(check_id="C1", source="codex_cli", total=5),
+        ]
+        candidates = identify_deterministic_candidates(aggs, min_occurrences=2)
+        # C1 is already a deterministic precheck, so not a candidate
+        assert "C1" not in candidates
+
+    def test_unstructured_excluded(self):
+        aggs = [
+            FindingAggregate(check_id="unstructured", source="codex_cli", total=20),
+        ]
+        candidates = identify_deterministic_candidates(aggs, min_occurrences=2)
+        assert "unstructured" not in candidates
+
+    def test_below_min_occurrences_excluded(self):
+        aggs = [
+            FindingAggregate(check_id="T2", source="codex_cli", total=1),
+        ]
+        candidates = identify_deterministic_candidates(aggs, min_occurrences=2)
+        assert "T2" not in candidates
+
+    def test_empty_aggregates(self):
+        candidates = identify_deterministic_candidates([])
+        assert candidates == []
+
+
+# ---------------------------------------------------------------------------
+# generate_summary
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSummary:
+    """Verify end-to-end summary generation."""
+
+    def test_basic_summary(self, review_base: Path):
+        outcomes = scan_loop_outcomes(review_base)
+        aggregates = aggregate_findings(review_base)
+        missed = extract_missed_blocker_signals(
+            [
+                {"number": 10, "title": "fix: handle crash"},
+                {"number": 20, "title": "fix(fix:convention): style issue"},
+            ]
+        )
+        summary = generate_summary(outcomes, aggregates, missed)
+
+        assert summary.total_loops == 5
+        assert summary.outcome_distribution["merged"] == 3
+        assert summary.outcome_distribution["stopped_ci_failure"] == 1
+        assert summary.completion_rate == pytest.approx(0.6, abs=0.01)
+        assert len(summary.finding_aggregates) > 0
+        assert len(summary.missed_blocker_signals) == 2
+
+    def test_empty_data(self):
+        summary = generate_summary([], [], [])
+        assert summary.total_loops == 0
+        assert summary.completion_rate == 0.0
+        assert summary.finding_aggregates == []
+        assert summary.noisy_check_ids == []
+        assert summary.missed_blocker_signals == []
+        assert summary.deterministic_candidates == []
+
+    def test_to_dict(self, review_base: Path):
+        outcomes = scan_loop_outcomes(review_base)
+        aggregates = aggregate_findings(review_base)
+        summary = generate_summary(outcomes, aggregates, [])
+        d = summary.to_dict()
+        assert isinstance(d, dict)
+        assert "total_loops" in d
+        assert "outcome_distribution" in d
+        assert "finding_aggregates" in d
+        assert isinstance(d["finding_aggregates"], list)
+
+
+# ---------------------------------------------------------------------------
+# format_markdown
+# ---------------------------------------------------------------------------
+
+
+class TestFormatMarkdown:
+    """Verify Markdown output formatting."""
+
+    def test_contains_header(self):
+        summary = AuditSummary(total_loops=10, outcome_distribution={"merged": 5})
+        md = format_markdown(summary)
+        assert "# Review Quality Audit" in md
+        assert "**Total loops:** 10" in md
+
+    def test_outcome_table(self):
+        summary = AuditSummary(
+            total_loops=4,
+            outcome_distribution={"merged": 2, "stopped_ci_failure": 2},
+            completion_rate=0.5,
+        )
+        md = format_markdown(summary)
+        assert "| merged | 2 |" in md
+        assert "| stopped_ci_failure | 2 |" in md
+        assert "50.0%" in md
+
+    def test_noisy_section(self):
+        summary = AuditSummary(
+            total_loops=1,
+            outcome_distribution={},
+            noisy_check_ids=["N3", "X3"],
+        )
+        md = format_markdown(summary)
+        assert "Noisy Check IDs" in md
+        assert "`N3`" in md
+        assert "`X3`" in md
+
+    def test_missed_blockers_section(self):
+        summary = AuditSummary(
+            total_loops=1,
+            outcome_distribution={},
+            missed_blocker_signals=[
+                MissedBlockerSignal(
+                    pr_number=42, title="fix: crash", category="general"
+                ),
+            ],
+        )
+        md = format_markdown(summary)
+        assert "Missed Blocker Signals" in md
+        assert "#42" in md
+
+    def test_deterministic_section(self):
+        summary = AuditSummary(
+            total_loops=1,
+            outcome_distribution={},
+            deterministic_candidates=["T1"],
+        )
+        md = format_markdown(summary)
+        assert "Deterministic-Check Candidates" in md
+        assert "`T1`" in md
+
+    def test_finding_aggregates_table(self):
+        summary = AuditSummary(
+            total_loops=1,
+            outcome_distribution={},
+            finding_aggregates=[
+                FindingAggregate(
+                    check_id="C4",
+                    source="codex_cli",
+                    total=5,
+                    p0_count=0,
+                    p1_count=1,
+                    p2_count=4,
+                    filtered=3,
+                    auto_fixed=0,
+                    skipped=2,
+                ),
+            ],
+        )
+        md = format_markdown(summary)
+        assert "| C4 | codex_cli |" in md
+
+    def test_empty_summary_no_crash(self):
+        summary = AuditSummary()
+        md = format_markdown(summary)
+        assert "# Review Quality Audit" in md
+
+    def test_truncated_missed_blockers(self):
+        signals = [
+            MissedBlockerSignal(
+                pr_number=i, title=f"fix: issue {i}", category="general"
+            )
+            for i in range(30)
+        ]
+        summary = AuditSummary(
+            total_loops=1,
+            outcome_distribution={},
+            missed_blocker_signals=signals,
+        )
+        md = format_markdown(summary)
+        assert "... and 10 more" in md
+
+
+# ---------------------------------------------------------------------------
+# Integration: full pipeline on synthetic data
+# ---------------------------------------------------------------------------
+
+
+class TestFullPipeline:
+    """End-to-end integration of scan → aggregate → summary → format."""
+
+    def test_full_pipeline(self, review_base: Path):
+        outcomes = scan_loop_outcomes(review_base)
+        aggregates = aggregate_findings(review_base)
+        missed = extract_missed_blocker_signals(
+            [{"number": 99, "title": "fix: post-merge fix"}]
+        )
+
+        summary = generate_summary(outcomes, aggregates, missed)
+        md = format_markdown(summary)
+
+        # Verify pipeline produces coherent output
+        assert summary.total_loops == 5
+        assert len(md) > 100
+        assert "# Review Quality Audit" in md
+        assert "Loop Outcome Distribution" in md
+
+        # JSON round-trip
+        d = summary.to_dict()
+        assert json.loads(json.dumps(d)) == d
+
+    def test_pipeline_on_empty_data(self, tmp_path: Path):
+        base = tmp_path / "empty"
+        base.mkdir()
+
+        outcomes = scan_loop_outcomes(base)
+        aggregates = aggregate_findings(base)
+        summary = generate_summary(outcomes, aggregates, [])
+        md = format_markdown(summary)
+
+        assert summary.total_loops == 0
+        assert "# Review Quality Audit" in md


### PR DESCRIPTION
## Summary
- Add `scripts/internal/review_quality_audit.py` — bounded audit helper that scans review-loop artifacts and produces a summary distinguishing missed blockers, noisy findings, and deterministic-check candidates
- Add 49 tests in `tests/unit/test_review_quality_audit.py` covering all scanning, aggregation, classification, and formatting paths
- Register the new script in `docs/01_core/ARCHITECTURE.md`
- Fill outcome section in `plans/sessions/2026-03-20_review-quality-instrumentation.md`

## Why
The repo needs a lightweight, repo-local way to measure where the current review loop misses real issues and where it emits noisy findings, before broadening platform/autonomy scope. This is measurement-first instrumentation — no architecture changes.

## Key design decisions
- **Repo-local only** — scans `.claude/runtime/review_loops/` artifacts, no hosted-review dependencies
- **Three-way output** — clearly separates missed blockers, noisy findings, and deterministic-check candidates
- **Does not change the `reviewing-changes` contract** — pure measurement
- **CLI + library** — usable as `python scripts/internal/review_quality_audit.py [--json]` or imported

## Repro / Validation
```bash
# Targeted tests
uv run python -m pytest tests/unit/test_review_quality_audit.py tests/unit/test_confidence_scorer.py -v

# Full validation
make check-quiet
```

## Tests
- `uv run python -m pytest tests/unit/test_review_quality_audit.py` — 49 tests ✅
- `uv run python -m pytest tests/unit/test_confidence_scorer.py` — 31 tests ✅ (no regressions)
- `make check-quiet` — ✅ all checks pass

## Worktree proof
```
pwd: Bid-Euchre-steward-author-c
branch: codex/steward-author-c
```

## Plan reference
`plans/sessions/2026-03-20_review-quality-instrumentation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)