### PR TITLE
fix: fail loud in get_repo_boundaries() and add check_path/require_path tests

### DIFF
--- a/src/bid_euchre/ops/fs_boundary.py
+++ b/src/bid_euchre/ops/fs_boundary.py
@@ -111,7 +111,10 @@ def get_repo_boundaries(
                 break
             p = p.parent
         if repo_root is None:
-            repo_root = Path.cwd().resolve()
+            raise RuntimeError(
+                "Cannot discover repo root: no .git directory found "
+                f"walking up from {Path.cwd().resolve()}"
+            )
 
     repo_root = _resolve_no_symlink(repo_root)
 

--- a/tests/unit/test_fs_boundary.py
+++ b/tests/unit/test_fs_boundary.py
@@ -14,8 +14,11 @@ import pytest
 from bid_euchre.ops.fs_boundary import (
     BoundaryViolationError,
     PathClass,
+    check_path,
     classify_path,
+    get_repo_boundaries,
     require_in_boundary,
+    require_path,
 )
 
 # ---------------------------------------------------------------------------
@@ -355,3 +358,87 @@ class TestPathClassEnum:
         assert err.path == "/tmp/evil"
         assert err.classification == PathClass.EXTERNAL
         assert "outside the repo boundary" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# get_repo_boundaries tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetRepoBoundaries:
+    """Tests for get_repo_boundaries()."""
+
+    def test_raises_when_no_git_found(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Running from a directory with no .git anywhere above should raise RuntimeError."""
+        no_git = tmp_path / "empty"
+        no_git.mkdir()
+        monkeypatch.chdir(no_git)
+
+        with pytest.raises(RuntimeError, match="Cannot discover repo root"):
+            get_repo_boundaries()
+
+    def test_explicit_repo_root_skips_discovery(self, tmp_path: Path) -> None:
+        """Passing repo_root explicitly should bypass .git discovery."""
+        fake_root = tmp_path / "fake-repo"
+        fake_root.mkdir()
+
+        boundaries = get_repo_boundaries(repo_root=fake_root)
+        assert boundaries["repo_root"] == str(fake_root.resolve())
+
+
+# ---------------------------------------------------------------------------
+# check_path tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPath:
+    """Tests for the check_path() convenience wrapper."""
+
+    def test_check_path_in_repo(self, repo_layout: dict[str, str]) -> None:
+        """A path inside repo_root should return REPO_ROOT."""
+        subpath = Path(repo_layout["repo_root"]) / "src" / "foo.py"
+        result = check_path(str(subpath), boundaries=repo_layout)
+        assert result == PathClass.REPO_ROOT
+
+    def test_check_path_external(self, repo_layout: dict[str, str]) -> None:
+        """A path outside all boundaries should return EXTERNAL."""
+        result = check_path(repo_layout["external"], boundaries=repo_layout)
+        assert result == PathClass.EXTERNAL
+
+    def test_check_path_with_boundaries(self, repo_layout: dict[str, str]) -> None:
+        """Pre-computed boundaries should be used without calling get_repo_boundaries()."""
+        wt = repo_layout["worktree_paths"][1]
+        subpath = Path(wt) / "some_file.py"
+        result = check_path(str(subpath), boundaries=repo_layout)
+        assert result == PathClass.REGISTERED_WORKTREE
+
+
+# ---------------------------------------------------------------------------
+# require_path tests
+# ---------------------------------------------------------------------------
+
+
+class TestRequirePath:
+    """Tests for the require_path() convenience wrapper."""
+
+    def test_require_path_allows_repo(self, repo_layout: dict[str, str]) -> None:
+        """A path inside repo_root should be allowed and return REPO_ROOT."""
+        subpath = Path(repo_layout["repo_root"]) / "src" / "bar.py"
+        result = require_path(str(subpath), boundaries=repo_layout, emit_event=False)
+        assert result == PathClass.REPO_ROOT
+
+    def test_require_path_rejects_external(self, repo_layout: dict[str, str]) -> None:
+        """An external path should raise BoundaryViolationError."""
+        with pytest.raises(BoundaryViolationError) as exc_info:
+            require_path(
+                repo_layout["external"], boundaries=repo_layout, emit_event=False
+            )
+        assert exc_info.value.classification == PathClass.EXTERNAL
+
+    def test_require_path_with_boundaries(self, repo_layout: dict[str, str]) -> None:
+        """Pre-computed boundaries should be used; runtime dir should return MANAGED_RUNTIME."""
+        runtime = repo_layout["runtime_dirs"][0]
+        result = require_path(runtime, boundaries=repo_layout, emit_event=False)
+        assert result == PathClass.MANAGED_RUNTIME


### PR DESCRIPTION
## Summary
- `get_repo_boundaries()` now raises `RuntimeError` when no `.git` directory is found instead of silently falling back to cwd
- Added 8 new tests covering `check_path()`, `require_path()`, and `get_repo_boundaries()` wrappers

## Why
- #1119: Silent fallback to cwd could allow external paths to be misclassified as repo-internal
- #1120: Two public convenience wrappers had zero direct test coverage

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_fs_boundary.py -v
make check-quiet
```

## Tests
- 30 total tests (22 existing + 8 new), all passing
- New: `TestGetRepoBoundaries` (2), `TestCheckPath` (3), `TestRequirePath` (3)

## Worktree proof
Working from `Bid-Euchre-steward-author-b` persistent worktree.

Closes #1119
Closes #1120

🤖 Generated with [Claude Code](https://claude.com/claude-code)