### PR TITLE
fix: clamp clock-skew ages, prefer freshest stale signal, filter non-progress events

### DIFF
--- a/src/bid_euchre/ops/status.py
+++ b/src/bid_euchre/ops/status.py
@@ -38,6 +38,29 @@ LANE_STATES = frozenset(
     {"active", "likely_active", "stale", "blocked", "idle", "unknown"}
 )
 
+# Event types that indicate genuine lane progress/activity.
+# Infrastructure events (watchdog_finding, scheduler_tick, etc.) are excluded
+# because they are emitted by the ops subsystem, not by the lane itself.
+PROGRESS_EVENT_TYPES = frozenset(
+    {
+        "task_started",
+        "task_completed",
+        "task_failed",
+        "retry_attempted",
+        "task_rerouted",
+        "escalation",
+        "ci_success",
+        "ci_failure",
+        "pr_opened",
+        "pr_merged",
+        "commit_pushed",
+        "skill_promoted",
+        "skill_disabled",
+        "session_started",
+        "session_ended",
+    }
+)
+
 
 @dataclass
 class LaneStatus:
@@ -299,20 +322,25 @@ def _find_last_event_for_lane(
     events: list[dict[str, Any]],
     lane_id: str,
 ) -> dict[str, Any] | None:
-    """Find the most recent event for a given lane.
+    """Find the most recent progress event for a given lane.
 
-    Scans events (assumed most-recent-first) and returns the first match.
+    Scans events (assumed most-recent-first) and returns the first match
+    whose ``event_type`` is in :data:`PROGRESS_EVENT_TYPES`.  Infrastructure
+    events (``watchdog_finding``, ``scheduler_tick``, etc.) are skipped
+    because they do not indicate genuine lane activity.
 
     Args:
         events: List of event dicts, most recent first.
         lane_id: Lane to filter by.
 
     Returns:
-        The most recent event dict for the lane, or None.
+        The most recent progress event dict for the lane, or None.
     """
     for event in events:
         if event.get("lane_id") == lane_id:
-            return event
+            event_type = event.get("event_type", "")
+            if event_type in PROGRESS_EVENT_TYPES:
+                return event
     return None
 
 
@@ -456,12 +484,15 @@ def _probe_fallback_liveness(
     """
     threshold_seconds = stale_minutes * 60
 
+    stale_candidate: _LivenessProbe | None = None
+    stale_age: float = float("inf")
+
     # --- Signal 1: Recent events for this lane ---
     last_event = _find_last_event_for_lane(events, lane_id)
     if last_event:
         event_dt = _parse_iso_timestamp(last_event.get("timestamp"))
         if event_dt is not None:
-            age = (now - event_dt).total_seconds()
+            age = max(0.0, (now - event_dt).total_seconds())
             event_type = last_event.get("event_type", "unknown")
             if age <= threshold_seconds:
                 return _LivenessProbe(
@@ -472,19 +503,17 @@ def _probe_fallback_liveness(
                 )
             # Event exists but is stale — record as candidate
             # (may be overridden by fresher signals below)
-            stale_candidate = _LivenessProbe(
-                is_likely_live=False,
-                is_stale=True,
-                source="events",
-                detail=(
-                    f"last event '{event_type}' {int(age / 60)}m ago "
-                    f"(>{stale_minutes}m threshold)"
-                ),
-            )
-        else:
-            stale_candidate = None
-    else:
-        stale_candidate = None
+            if stale_candidate is None or age < stale_age:
+                stale_age = age
+                stale_candidate = _LivenessProbe(
+                    is_likely_live=False,
+                    is_stale=True,
+                    source="events",
+                    detail=(
+                        f"last event '{event_type}' {int(age / 60)}m ago "
+                        f"(>{stale_minutes}m threshold)"
+                    ),
+                )
 
     # --- Signal 2: In-progress tasks with recent progress ---
     for task in lane_tasks:
@@ -495,7 +524,7 @@ def _probe_fallback_liveness(
             progress_ts = progress.get("last_forward_progress_at")
             progress_dt = _parse_iso_timestamp(progress_ts)
             if progress_dt is not None:
-                age = (now - progress_dt).total_seconds()
+                age = max(0.0, (now - progress_dt).total_seconds())
                 subject = task.get("subject", "?")
                 if age <= threshold_seconds:
                     return _LivenessProbe(
@@ -507,7 +536,8 @@ def _probe_fallback_liveness(
                             f"progressed {int(age / 60)}m ago"
                         ),
                     )
-                if stale_candidate is None:
+                if stale_candidate is None or age < stale_age:
+                    stale_age = age
                     stale_candidate = _LivenessProbe(
                         is_likely_live=False,
                         is_stale=True,
@@ -522,7 +552,7 @@ def _probe_fallback_liveness(
     if session:
         session_dt = _parse_iso_timestamp(session.get("started_at"))
         if session_dt is not None:
-            age = (now - session_dt).total_seconds()
+            age = max(0.0, (now - session_dt).total_seconds())
             if age <= threshold_seconds:
                 return _LivenessProbe(
                     is_likely_live=True,
@@ -530,7 +560,8 @@ def _probe_fallback_liveness(
                     source="session_metadata",
                     detail=f"session started {int(age / 60)}m ago",
                 )
-            if stale_candidate is None:
+            if stale_candidate is None or age < stale_age:
+                stale_age = age
                 stale_candidate = _LivenessProbe(
                     is_likely_live=False,
                     is_stale=True,
@@ -545,7 +576,7 @@ def _probe_fallback_liveness(
     if last_active_ts:
         la_dt = _parse_iso_timestamp(last_active_ts)
         if la_dt is not None:
-            age = (now - la_dt).total_seconds()
+            age = max(0.0, (now - la_dt).total_seconds())
             if age <= threshold_seconds:
                 return _LivenessProbe(
                     is_likely_live=True,
@@ -553,7 +584,8 @@ def _probe_fallback_liveness(
                     source="last_active",
                     detail=f"registry last_active {int(age / 60)}m ago",
                 )
-            if stale_candidate is None:
+            if stale_candidate is None or age < stale_age:
+                stale_age = age
                 stale_candidate = _LivenessProbe(
                     is_likely_live=False,
                     is_stale=True,

--- a/tests/unit/test_ops_status.py
+++ b/tests/unit/test_ops_status.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from bid_euchre.ops.status import (
+    PROGRESS_EVENT_TYPES,
     STALE_MINUTES,
     LaneStatus,
     StatusReport,
@@ -330,7 +331,9 @@ class TestAggregateStatus:
         assert lane.has_active_session is False
         # Old evidence → stale (not active, not idle)
         assert lane.state == "stale"
-        assert lane.liveness_source == "session_metadata"
+        # last_active (12:00) is fresher than session started_at (10:00),
+        # so the freshest-stale-signal logic picks last_active.
+        assert lane.liveness_source == "last_active"
         # Session task available for context
         assert lane.session_task == "Previous task"
 
@@ -2871,3 +2874,165 @@ class TestEmitScopeSnapshot:
         touched = result["scope"]["touched_files"]
         # existing.py should not be duplicated
         assert touched == ["src/existing.py", "src/new.py"]
+
+
+# ---- Issue #1101: Liveness probe edge cases ----
+
+
+class TestLivenessClockSkew:
+    """Tests for clock-skew handling in _probe_fallback_liveness()."""
+
+    def test_future_timestamp_clamped_to_zero(self) -> None:
+        """Event timestamp 5 minutes in the future should be treated as recent.
+
+        Age is clamped to 0, so the detail string says '0m ago', not '-5m ago'.
+        """
+        now = datetime(2026, 3, 20, 12, 0, 0, tzinfo=timezone.utc)
+        # Event 5 minutes in the future (clock skew)
+        events = [
+            {
+                "lane_id": "author-b",
+                "event_type": "ci_success",
+                "timestamp": "2026-03-20T12:05:00+00:00",
+            },
+        ]
+        probe = _probe_fallback_liveness(
+            "author-b",
+            session=None,
+            lane_tasks=[],
+            events=events,
+            last_active_ts=None,
+            now=now,
+            stale_minutes=30,
+        )
+        assert probe.is_likely_live is True
+        assert probe.is_stale is False
+        assert probe.source == "events"
+        assert "0m ago" in probe.detail
+        assert "-" not in probe.detail  # No negative age in display
+
+    def test_future_stale_timestamp_also_clamped(self) -> None:
+        """A future session timestamp is clamped to 0 and treated as recent."""
+        now = datetime(2026, 3, 20, 12, 0, 0, tzinfo=timezone.utc)
+        # Session started 10 minutes in the future (clock skew)
+        session = {"started_at": "2026-03-20T12:10:00+00:00", "task": "Work"}
+        probe = _probe_fallback_liveness(
+            "author-b",
+            session=session,
+            lane_tasks=[],
+            events=[],
+            last_active_ts=None,
+            now=now,
+            stale_minutes=30,
+        )
+        # Age clamped to 0 → within threshold → likely live
+        assert probe.is_likely_live is True
+        assert probe.is_stale is False
+        assert probe.source == "session_metadata"
+        assert "0m ago" in probe.detail
+
+
+class TestStaleCandidateFreshest:
+    """Tests that stale_candidate keeps the freshest (smallest age) signal."""
+
+    def test_freshest_stale_signal_wins(self) -> None:
+        """When multiple signals are stale, the freshest one is reported.
+
+        events=120m stale, session=45m stale → stale_candidate should report
+        session (45m ago), not events (120m ago).
+        """
+        now = datetime(2026, 3, 20, 12, 0, 0, tzinfo=timezone.utc)
+        # Signal 1: event 120 minutes ago
+        events = [
+            {
+                "lane_id": "author-b",
+                "event_type": "ci_success",
+                "timestamp": "2026-03-20T10:00:00+00:00",  # 120m ago
+            },
+        ]
+        # Signal 3: session started 45 minutes ago
+        session = {
+            "started_at": "2026-03-20T11:15:00+00:00",  # 45m ago
+            "task": "Recent work",
+        }
+        probe = _probe_fallback_liveness(
+            "author-b",
+            session=session,
+            lane_tasks=[],
+            events=events,
+            last_active_ts=None,
+            now=now,
+            stale_minutes=30,
+        )
+        assert probe.is_likely_live is False
+        assert probe.is_stale is True
+        # Should prefer session_metadata (45m) over events (120m)
+        assert probe.source == "session_metadata"
+        assert "45m ago" in probe.detail
+
+
+# ---- Issue #1055: Progress event filter ----
+
+
+class TestProgressEventFilter:
+    """Tests that _find_last_event_for_lane filters non-progress events."""
+
+    def test_infrastructure_events_skipped(self) -> None:
+        """_find_last_event_for_lane with only infrastructure events returns None."""
+        events = [
+            {
+                "lane_id": "author-a",
+                "event_type": "watchdog_finding",
+                "timestamp": "2026-03-20T12:00:00Z",
+            },
+            {
+                "lane_id": "author-a",
+                "event_type": "scheduler_tick",
+                "timestamp": "2026-03-20T11:55:00Z",
+            },
+        ]
+        result = _find_last_event_for_lane(events, "author-a")
+        assert result is None
+
+    def test_progress_events_found(self) -> None:
+        """_find_last_event_for_lane with a task_completed event returns it."""
+        events = [
+            {
+                "lane_id": "author-a",
+                "event_type": "task_completed",
+                "timestamp": "2026-03-20T12:00:00Z",
+            },
+        ]
+        result = _find_last_event_for_lane(events, "author-a")
+        assert result is not None
+        assert result["event_type"] == "task_completed"
+
+    def test_progress_event_selected_over_infrastructure(self) -> None:
+        """When lane has both infrastructure and progress events, progress wins.
+
+        Events are most-recent-first. An infrastructure event that is newer
+        than a progress event should be skipped.
+        """
+        events = [
+            {
+                "lane_id": "author-a",
+                "event_type": "watchdog_finding",
+                "timestamp": "2026-03-20T12:05:00Z",
+            },
+            {
+                "lane_id": "author-a",
+                "event_type": "ci_success",
+                "timestamp": "2026-03-20T12:00:00Z",
+            },
+        ]
+        result = _find_last_event_for_lane(events, "author-a")
+        assert result is not None
+        assert result["event_type"] == "ci_success"
+
+    def test_progress_event_types_constant_is_frozenset(self) -> None:
+        """PROGRESS_EVENT_TYPES is a frozenset with expected members."""
+        assert isinstance(PROGRESS_EVENT_TYPES, frozenset)
+        assert "task_completed" in PROGRESS_EVENT_TYPES
+        assert "ci_success" in PROGRESS_EVENT_TYPES
+        assert "watchdog_finding" not in PROGRESS_EVENT_TYPES
+        assert "scheduler_tick" not in PROGRESS_EVENT_TYPES


### PR DESCRIPTION
## Summary
- Clamp negative ages from clock skew with `max(0.0, ...)` at all 4 age calculations in `_probe_fallback_liveness()`
- Replace first-stale-wins with freshest-stale-wins by tracking `stale_age` and preferring the smallest
- Add `PROGRESS_EVENT_TYPES` filter to exclude infrastructure events (`watchdog_finding`, `scheduler_tick`) from stale-lane timestamps

## Why
- #1101: Future timestamps produce misleading "-5m ago" and wrong liveness classification; first-stale-wins shows less informative signal to operator
- #1055: Infrastructure events inflated stale lane timestamps, making lanes appear more active than they were

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_ops_status.py -v
make check-quiet
```

## Tests
- 156 total tests (149 existing + 7 new), all passing
- New: `TestLivenessClockSkew` (2), `TestStaleCandidateFreshest` (1), `TestProgressEventFilter` (4)

## Worktree proof
Working from `Bid-Euchre-steward-author-b` persistent worktree.

Closes #1101
Closes #1055

🤖 Generated with [Claude Code](https://claude.com/claude-code)