### PR TITLE
fix: atomic write for _save_candidate() and sanitize HTML5 --!> terminator

### DIFF
--- a/src/bid_euchre/ops/skill_promotion.py
+++ b/src/bid_euchre/ops/skill_promotion.py
@@ -29,7 +29,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
+import tempfile
 import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -131,13 +133,22 @@ def _load_candidate(path: Path) -> SkillCandidate:
 
 
 def _save_candidate(candidate: SkillCandidate, candidates_dir: Path) -> Path:
-    """Persist a candidate to disk."""
+    """Persist a candidate to disk atomically (temp + rename)."""
     candidates_dir.mkdir(parents=True, exist_ok=True)
     path = candidates_dir / f"{candidate.candidate_id}.json"
-    path.write_text(
-        json.dumps(candidate.to_dict(), indent=2, ensure_ascii=False) + "\n",
-        encoding="utf-8",
-    )
+    content = json.dumps(candidate.to_dict(), indent=2, ensure_ascii=False) + "\n"
+
+    # Atomic write: write to temp file, fsync, then rename
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=str(candidates_dir), suffix=".tmp")
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        Path(tmp_path).rename(path)
+    except BaseException:
+        Path(tmp_path).unlink(missing_ok=True)
+        raise
     return path
 
 
@@ -463,10 +474,13 @@ def get_candidate(
 
 
 def _sanitize_comment(value: object) -> str:
-    """Strip HTML comment close sequence to prevent injection."""
+    """Strip HTML comment close sequences to prevent injection.
+
+    Handles both standard ``-->`` and HTML5 ``--!>`` terminators.
+    """
     if value is None:
         return "None"
-    return str(value).replace("-->", "-- >")
+    return str(value).replace("--!>", "--! >").replace("-->", "-- >")
 
 
 def _render_skill_md(candidate: SkillCandidate) -> str:

--- a/tests/unit/test_ops_skill_promotion.py
+++ b/tests/unit/test_ops_skill_promotion.py
@@ -15,6 +15,7 @@ from bid_euchre.ops.skill_promotion import (
     SkillCandidate,
     _render_skill_md,
     _sanitize_comment,
+    _save_candidate,
     disable_skill,
     format_candidates_json,
     format_candidates_text,
@@ -942,3 +943,64 @@ class TestRenderingSanitization:
         c = _propose(candidates_dir, description="path\\to\\file")
         content = _render_skill_md(c)
         assert 'description: "path\\\\to\\\\file"' in content
+
+    def test_html5_comment_terminator_sanitized(self, candidates_dir: Path) -> None:
+        """Values containing --!> are sanitized in rendered SKILL.md."""
+        c = _propose(
+            candidates_dir,
+            source_workflow="evil --!> <script>alert(1)</script>",
+        )
+        content = _render_skill_md(c)
+        assert "evil --! > <script>" in content
+        assert "evil --!> <script>" not in content
+
+    def test_sanitize_comment_html5(self) -> None:
+        assert _sanitize_comment("bad --!> value") == "bad --! > value"
+
+    def test_both_terminators_sanitized(self) -> None:
+        assert _sanitize_comment("a --> b --!> c") == "a -- > b --! > c"
+
+
+# ── Atomic write ──────────────────────────────────────────────
+
+
+class TestAtomicWrite:
+    """Verify _save_candidate() atomic write round-trip."""
+
+    def test_save_candidate_atomic_write(self, candidates_dir: Path) -> None:
+        """Verify _save_candidate() writes valid JSON that can be read back."""
+        c = SkillCandidate(
+            candidate_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            name="atomic-test",
+            description="Testing atomic write",
+            content="# Atomic\n",
+            source_workflow="test workflow",
+            proposed_by="author-b",
+            proposed_at="2026-03-20T00:00:00Z",
+            provenance={"prs": ["#1"]},
+        )
+        path = _save_candidate(c, candidates_dir)
+        assert path.exists()
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data["name"] == "atomic-test"
+        assert data["candidate_id"] == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        assert data["provenance"] == {"prs": ["#1"]}
+
+    def test_save_candidate_creates_dir(self, tmp_path: Path) -> None:
+        """Verify it creates the directory if missing."""
+        new_dir = tmp_path / "does_not_exist" / "nested"
+        c = SkillCandidate(
+            candidate_id="11111111-2222-3333-4444-555555555555",
+            name="dir-test",
+            description="Testing directory creation",
+            content="# Dir\n",
+            source_workflow="test workflow",
+            proposed_by="author-b",
+            proposed_at="2026-03-20T00:00:00Z",
+            provenance={},
+        )
+        path = _save_candidate(c, new_dir)
+        assert new_dir.exists()
+        assert path.exists()
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data["name"] == "dir-test"


### PR DESCRIPTION
## Summary
- Replaced `path.write_text()` in `_save_candidate()` with temp-file + fsync + rename for atomic writes, consistent with other ops modules
- Extended `_sanitize_comment()` to block the HTML5 `--!>` comment terminator in addition to the standard `-->`

## Why
- #1060: Non-atomic write could leave corrupt candidate JSON if process is interrupted mid-write
- #1077: HTML5 treats `--!>` as a comment close sequence, enabling comment breakout in SKILL.md

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_ops_skill_promotion.py -v
make check-quiet
```

## Tests
- 75 total tests (70 existing + 5 new), all passing
- New: `TestRenderingSanitization` (3 tests for `--!>` handling), `TestAtomicWrite` (2 tests for round-trip and dir creation)

## Worktree proof
Working from `Bid-Euchre-steward-author-b` persistent worktree.

Closes #1060
Closes #1077

🤖 Generated with [Claude Code](https://claude.com/claude-code)