### PR TITLE
fix: add string-literal masking to deterministic prechecks

### DIFF
--- a/scripts/internal/deterministic_prechecks.py
+++ b/scripts/internal/deterministic_prechecks.py
@@ -83,6 +83,19 @@ _N3_STATS_RE = re.compile(
     re.IGNORECASE,
 )
 
+# --- String-literal masking ---
+# Replace content inside triple-quoted strings with blank lines so that test
+# fixture strings (containing merge markers, TODO, breakpoint, etc.) do not
+# trigger false-positive findings.  Line count is preserved for accurate
+# line-number reporting.
+_TRIPLE_QUOTE_RE = re.compile(r'("""[\s\S]*?"""|\'\'\'[\s\S]*?\'\'\')')
+
+
+def _mask_string_literals(content: str) -> str:
+    """Replace triple-quoted string interiors with blank lines."""
+    return _TRIPLE_QUOTE_RE.sub(lambda m: "\n" * m.group().count("\n"), content)
+
+
 # --- C5: Redundant except catch ---
 # Detects `except (Specific, ..., Exception)` where Exception makes the
 # specific catches redundant.  Observed in PR #1075 where
@@ -117,7 +130,9 @@ def check_file(
         List of Finding objects.
     """
     findings: list[Finding] = []
-    lines = content.split("\n")
+    # Mask triple-quoted string interiors to avoid false positives on test fixtures
+    masked = _mask_string_literals(content)
+    lines = masked.split("\n")
 
     # --- P0: Merge conflict markers ---
     for i, line in enumerate(lines, 1):
@@ -148,8 +163,8 @@ def check_file(
             )
 
     # --- P1: Large commented-out blocks ---
-    for match in _COMMENT_BLOCK_RE.finditer(content):
-        block_start = content[: match.start()].count("\n") + 1
+    for match in _COMMENT_BLOCK_RE.finditer(masked):
+        block_start = masked[: match.start()].count("\n") + 1
         block_lines = match.group().count("\n")
         findings.append(
             Finding(

--- a/tests/unit/test_deterministic_prechecks.py
+++ b/tests/unit/test_deterministic_prechecks.py
@@ -11,6 +11,7 @@ from deterministic_prechecks import (
     Finding,
     _check_undocumented_contract_change,
     _check_untested_behavior_change,
+    _mask_string_literals,
     check_diff,
     check_file,
     get_blocking_findings,
@@ -780,3 +781,47 @@ class TestT1UntestedBehaviorChange:
         )
         t1 = [f for f in findings if f.check_id == "T1"]
         assert len(t1) == 0
+
+
+# ---------------------------------------------------------------------------
+# String-literal masking tests
+# ---------------------------------------------------------------------------
+
+
+class TestMaskStringLiterals:
+    """Verify _mask_string_literals strips triple-quoted string interiors."""
+
+    def test_masks_triple_double_quotes(self) -> None:
+        code = 'x = 1\nFIXTURE = """\n<<<<<<< HEAD\n=======\n>>>>>>>\n"""\ny = 2\n'
+        masked = _mask_string_literals(code)
+        assert "<<<<<<< HEAD" not in masked
+        assert masked.count("\n") == code.count("\n")
+
+    def test_masks_triple_single_quotes(self) -> None:
+        code = "x = 1\nFIXTURE = '''\nbreakpoint()\n'''\ny = 2\n"
+        masked = _mask_string_literals(code)
+        assert "breakpoint()" not in masked
+        assert masked.count("\n") == code.count("\n")
+
+    def test_preserves_non_string_code(self) -> None:
+        code = "def foo():\n    breakpoint()\n    x = None\n"
+        masked = _mask_string_literals(code)
+        assert masked == code
+
+    def test_no_false_positives_on_test_fixtures(self) -> None:
+        """Scanning a file with test fixtures should not produce blocking findings."""
+        content = (
+            'MERGE = """\n'
+            "<<<<<<< HEAD\n"
+            "x = 1\n"
+            "=======\n"
+            "x = 2\n"
+            ">>>>>>> branch\n"
+            '"""\n'
+            'TODO = """\n'
+            "# TODO: remove before merge\n"
+            '"""\n'
+        )
+        findings = check_file("tests/unit/test_example.py", content)
+        blockers = get_blocking_findings(findings)
+        assert len(blockers) == 0


### PR DESCRIPTION
## Summary

- Add `_mask_string_literals()` to `deterministic_prechecks.py` that blanks out triple-quoted string interiors before scanning
- Prevents false P0/P1 blocking findings from test fixture strings containing merge markers, TODO markers, breakpoint calls, etc.
- 4 new tests for the masking behavior

## Why

PR #1126 added C5/T1 precheck rules and the prechecks CI job failed because the scanner detected patterns inside test fixture string literals (not real code). This is a follow-up fix.

## Plan reference

`plans/sessions/2026-03-20_safe-issue-work-during-review-transition.md`

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_deterministic_prechecks.py -x -q  # 69 passed
```

Self-scan verification: 0 blockers (down from 5).

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/worktree-fix-orphans
branch: fix/precheck-string-masking
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)