### PR TITLE
docs: fix review-surface branch-protection claims (v3)

### DIFF
--- a/.claude/rules/deferred/60_review_gate.md
+++ b/.claude/rules/deferred/60_review_gate.md
@@ -20,7 +20,7 @@ Codex CLI is the sole reviewer — local, ~60s latency, uses ChatGPT subscriptio
 
 | Context | Publisher | Required by branch protection? | Purpose |
 |---------|-----------|-------------------------------|---------|
-| `reviewing-changes` | Review coordinator (`review_driver.py`), initial `pending` from dispatcher | **No** (advisory only) | Post-merge code review signal |
+| `reviewing-changes` | Review coordinator (`review_driver.py`), initial `pending` from dispatcher | **No** (advisory only) | Pre-merge code review signal |
 
 > **Note (2026-03-12):** `reviewing-changes` was demoted from required to advisory
 > after the review coordinator hook was found to be unregistered (PR #624).

--- a/docs/02_agent/CODEX_GITHUB_REVIEW.md
+++ b/docs/02_agent/CODEX_GITHUB_REVIEW.md
@@ -87,9 +87,26 @@ check-name registration for the ChatGPT-subscription path.
 |---------|------|-----------|-----------|------|
 | `tests` | GitHub Actions check | Yes (branch protection) | CI | Build truth |
 | `governance` | GitHub Actions check | Yes (branch protection) | CI | Repo policy |
-| `reviewing-changes` | Commit status | Yes (branch protection) | Review coordinator | **Reviewer of record** |
+| `reviewing-changes` | Commit status | No (advisory) | Review coordinator | **Reviewer of record** |
 | `claude-review` | GitHub Actions check | No (advisory) | Claude Code Review workflow | Advisory overlay |
 | Codex Cloud | PR issue comment | No (overlay) | `chatgpt-codex-connector[bot]` | Advisory overlay |
+
+### Terminology Note: "Advisory" vs "Advisory"
+
+Two distinct senses of "advisory" appear in this repo:
+
+1. **Branch-protection advisory** — `reviewing-changes` is not enforced by
+   GitHub branch protection rules. Only `tests` and `governance` are required.
+   The coordinator's status is advisory in the branch-protection sense: GitHub
+   will allow a merge even if `reviewing-changes` is pending or failed.
+
+2. **Ops classification `advisory`** — In `classify_check()` and ops tooling,
+   `advisory` is a category for checks that provide supplementary signal
+   (e.g., `claude-review`). The coordinator's `reviewing-changes` status is
+   classified as `review_gate`, not `advisory`, in the ops taxonomy.
+
+The coordinator is the **reviewer of record** — its review is the one that
+matters for merge quality — but it is not enforced by GitHub branch protection.
 
 ## Review Modes
 

--- a/docs/02_agent/PLATFORM_ENTRY_CHECKLIST.md
+++ b/docs/02_agent/PLATFORM_ENTRY_CHECKLIST.md
@@ -19,7 +19,7 @@
 
 ## 2. Review Surfaces
 
-- [x] `reviewing-changes` is the merge-relevant gate (branch protection)
+- [x] `reviewing-changes` is the reviewer-of-record gate (advisory, not branch protection)
 - [x] `claude-review` is advisory only, visible without poisoning CI
   - stabilized in #1017, #1025, #1030
 - [x] Codex Cloud proving-run behavior recorded in `docs/02_agent/CODEX_GITHUB_REVIEW.md`


### PR DESCRIPTION
## Summary
- Fix `reviewing-changes` listed as `Yes (branch protection)` → `No (advisory)` in CODEX_GITHUB_REVIEW.md gate table
- Fix `Post-merge` → `Pre-merge` purpose label in 60_review_gate.md Status Contexts
- Fix PLATFORM_ENTRY_CHECKLIST claim from "merge-relevant gate (branch protection)" to "reviewer-of-record gate (advisory)"
- Add terminology disambiguation note distinguishing branch-protection "advisory" from ops classification `advisory` category

## Why
After #1123 restructured review architecture and #1133 renamed "review loop" → "review coordinator", the factual branch-protection claims were carried forward unchanged. Only `tests` and `governance` are required by branch protection (validated via `gh api repos/{owner}/{repo}/branches/main/protection`).

Replaces #1140 (closed — stale base with 8 conflict markers after #1123/#1133).

## Repro / Validation
```bash
gh api repos/{owner}/{repo}/branches/main/protection --jq '.required_status_checks.contexts'
# → ["tests","governance"]

rg -n "Yes.*branch protection" docs/02_agent/CODEX_GITHUB_REVIEW.md
# Before: line 90 matches; After: no match

make check-quiet  # 5269 passed, 5 failed (pre-existing matplotlib font issue on main)
```

## Tests
- [x] `make check-quiet` — 5269 passed, 5 failed (pre-existing font env issue, confirmed on main)
- [x] Grep-verified no remaining `Yes (branch protection)` claims for `reviewing-changes`

## Expected impact
- Metrics impact: none (docs only)
- Runtime impact: none

## Risk level
Low — docs only, no code changes.

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
git worktree list: steward-author worktree
```

## Files changed (3)

| File | Change |
|------|--------|
| `docs/02_agent/CODEX_GITHUB_REVIEW.md` | Fixed `Yes (branch protection)` → `No (advisory)` in gate table; added terminology disambiguation note |
| `.claude/rules/deferred/60_review_gate.md` | Fixed Purpose `Post-merge` → `Pre-merge` code review signal |
| `docs/02_agent/PLATFORM_ENTRY_CHECKLIST.md` | Fixed "merge-relevant gate (branch protection)" → "reviewer-of-record gate (advisory)" |

Closes #1121
Closes #1046

🤖 Generated with [Claude Code](https://claude.com/claude-code)