### PR TITLE
fix: atomic writes in skill_promotion — os.replace and SKILL.md

### DIFF
--- a/src/bid_euchre/ops/skill_promotion.py
+++ b/src/bid_euchre/ops/skill_promotion.py
@@ -27,6 +27,7 @@ Integration:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -145,9 +146,10 @@ def _save_candidate(candidate: SkillCandidate, candidates_dir: Path) -> Path:
             f.write(content)
             f.flush()
             os.fsync(f.fileno())
-        Path(tmp_path).rename(path)
+        os.replace(tmp_path, str(path))
     except BaseException:
-        Path(tmp_path).unlink(missing_ok=True)
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
         raise
     return path
 
@@ -350,11 +352,21 @@ def promote_skill(
             f"{findings_summary}"
         )
 
-    # Write the skill
+    # Write the skill atomically (temp + fsync + rename)
     skill_dir.mkdir(parents=True, exist_ok=True)
     skill_md = skill_dir / "SKILL.md"
     skill_content = _render_skill_md(candidate)
-    skill_md.write_text(skill_content, encoding="utf-8")
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=str(skill_dir), suffix=".tmp")
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+            f.write(skill_content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, str(skill_md))
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+        raise
 
     # Update candidate status
     candidate.status = "promoted"


### PR DESCRIPTION
## Plan
N/A — follow-up issue batch from post-merge reviews

## Summary
- Use `os.replace()` instead of `Path.rename()` in `_save_candidate()` (#1134)
- Make `promote_skill()` SKILL.md write atomic via temp+fsync+rename (#1135)
- Use `os.unlink` + `contextlib.suppress(OSError)` for cleanup consistency

## Why
`Path.rename()` raises `FileExistsError` on Windows when the destination exists — `os.replace()` is the repo's established convention. The SKILL.md write was non-atomic, risking truncation on interrupted writes.

## Repro / Validation
**Command(s) run:**
- Pre-commit + pre-push hooks passed (ruff check, ruff format, repo-linter)

## Tests
- [x] Pre-commit hooks passed
- [x] Ruff check + format clean

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [ ] Low (docs/tests only)
- [x] Medium (ops infrastructure)

## Worktree proof (required)
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a9cebc47
```
`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a9cebc47
```
`git worktree list`:
```
(agent worktree — ephemeral)
```

## Checklist
- [x] No generated artifacts committed
- [x] PR is focused (one concept: atomic writes in skill_promotion)

Closes #1134
Closes #1135