### PR TITLE
fix: status.py liveness — task_blocked event and clock-skew clamp

### DIFF
--- a/src/bid_euchre/ops/status.py
+++ b/src/bid_euchre/ops/status.py
@@ -46,6 +46,7 @@ PROGRESS_EVENT_TYPES = frozenset(
         "task_started",
         "task_completed",
         "task_failed",
+        "task_blocked",
         "retry_attempted",
         "task_rerouted",
         "escalation",
@@ -54,6 +55,8 @@ PROGRESS_EVENT_TYPES = frozenset(
         "pr_opened",
         "pr_merged",
         "commit_pushed",
+        "review_outcome",
+        "plan_review_outcome",
         "skill_promoted",
         "skill_disabled",
         "session_started",
@@ -794,10 +797,12 @@ def synthesize_lane_activity(
             attention_reason = f"blocked: {blockers}" if blockers else "blocked"
         elif state == "active" and last_progress:
             lp_dt = _parse_iso_timestamp(last_progress)
-            if lp_dt and (now - lp_dt).total_seconds() / 60 > stale_minutes:
-                age_min = int((now - lp_dt).total_seconds() / 60)
-                attention_needed = True
-                attention_reason = f"stale: no progress for {age_min}min"
+            if lp_dt:
+                age_seconds = max(0.0, (now - lp_dt).total_seconds())
+                if age_seconds / 60 > stale_minutes:
+                    age_min = int(age_seconds / 60)
+                    attention_needed = True
+                    attention_reason = f"stale: no progress for {age_min}min"
         elif state == "stale":
             # Stale lanes have evidence of past activity but it's aging.
             # Flag for operator attention — the process may have died.


### PR DESCRIPTION
## Plan
N/A — follow-up issue batch from post-merge reviews

## Summary
- Add `task_blocked` (plus `review_outcome`, `plan_review_outcome`) to `PROGRESS_EVENT_TYPES` (#1136)
- Apply `max(0.0, ...)` clock-skew clamping in `synthesize_lane_activity()` attention-flag path (#1137)
- Close lingering #1055 (non-progress event filtering already landed in PR #1130 but GitHub did not auto-close the issue)

## Why
Blocked lanes emitting `task_blocked` were misclassified as idle because the event type wasn't in the progress set. Clock-skew could produce negative ages in the attention-flag path, unlike the already-clamped `_probe_fallback_liveness()`. Issue #1055 was already fixed by PR #1130 but never closed.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_status.py -x -q  # 156 passed
make check-quiet  # 5268 passed; 5 font-related chart test failures (pre-existing on main)
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_status.py -x` — 156/156 passed
- [x] `make check-quiet` — 5268 passed (5 pre-existing font failures in chart tests)
- [x] `ruff check --fix && ruff format` — clean

## Expected impact
- Metrics impact: None
- Runtime impact: None (trivial set addition + max() call)

## Risk level
- [ ] Low (docs/tests only)
- [x] Medium (ops infrastructure)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a01be0a3
```
`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a01be0a3
```
`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                                   24c7a922 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a01be0a3  4aba41fe [fix/status-liveness-fixes]
```

## Checklist
- [x] No generated artifacts committed
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept: status.py liveness fixes)

Closes #1136
Closes #1137
Closes #1055