### PR TITLE
docs: fix 5 post-merge review follow-up issues (wave 1)

### DIFF
--- a/.claude/rules/deferred/60_review_gate.md
+++ b/.claude/rules/deferred/60_review_gate.md
@@ -73,12 +73,12 @@ Aligned with `/reviewing-changes` CHECKLIST.md check IDs:
 
 - **C1** — Unseeded randomness (`random.Random()` without seed, global `random.*`)
 - **C2** — Falsy numeric guard (`x = x or fallback` on numeric metric)
-- **N1** — Missing contract-type facet in notebook visualization
-- **N2** — Collapsed matchup table (team0/team1 in single row)
 - **X3** — Merge artifacts (conflict markers, TODO-remove, large commented-out blocks)
 
 ### WARN checks (non-blocking, follow-up issue)
 
+- **N1** — Missing contract-type facet in notebook visualization
+- **N2** — Collapsed matchup table (team0/team1 in single row)
 - **C3** — Gate check ordering (most-restrictive first)
 - **C4** — Function complexity (>50 lines or nesting >4)
 - **N3** — Inference claim without statistical test

--- a/docs/02_agent/CODEX_GITHUB_REVIEW.md
+++ b/docs/02_agent/CODEX_GITHUB_REVIEW.md
@@ -129,6 +129,10 @@ PRs are classified by review mode based on changed file types:
    posts the canonical summary comment, and enables auto-merge
 6. GitHub merges automatically once CI and branch protection are satisfied
 
+No human merge step required.  If auto-merge fails (e.g., conflicts, repo
+setting disabled), the coordinator publishes success and the PR can be merged
+manually.
+
 Codex Cloud, when used, is additive commentary.  It does not publish a
 merge-blocking artifact for this repo.
 

--- a/docs/03_TODO/REPO_REVIEW_2026-03-20.md
+++ b/docs/03_TODO/REPO_REVIEW_2026-03-20.md
@@ -143,7 +143,11 @@ PRs 1-3 are documentation-only. PR 4 is conditional on whether the notebook is u
 | R18-11 | 2 hardcoded `trump='H'` | **Unchanged** → R20-9 | Documented as appropriate |
 | R18-12 | 3 hardcoded `seat=0` defaults | **Unchanged** → R20-8 | Documented as appropriate |
 
-**Resolution rate:** 4/9 R18 issues resolved, 1 improved, 1 worsened, 3 unchanged (documented as appropriate).
+**Resolution rate:** 3/9 R18 issues resolved, 1 improved, 1 worsened, 4 unchanged (documented as appropriate).
+
+> **Note:** R18 defined 12 issues (R18-1 through R18-12). This table tracks 9;
+> R18-8, R18-9, and R18-10 (all LOW severity, resolved or no-action-required
+> at R18) were excluded from the longitudinal tracking.
 
 ---
 

--- a/plans/sessions/2026-03-20_pr5-slice7-followthrough.md
+++ b/plans/sessions/2026-03-20_pr5-slice7-followthrough.md
@@ -82,4 +82,4 @@ Add `emit_review_event(outcome, lane_id, events_dir)` analogous to `emit_ci_even
 
 ## Outcome
 
-PR: (to be filled after PR creation)
+PR #1098 merged. PR-5 slice 7 shipped: scope drift detection, retry follow-through scanning, review event emission, and CLI wiring.

--- a/plans/sessions/2026-03-20_trusted-liveness-repair.md
+++ b/plans/sessions/2026-03-20_trusted-liveness-repair.md
@@ -107,4 +107,4 @@ Cover all paths:
 
 ## Outcome
 
-(filled after implementation)
+PR #1091 merged. Trusted lane liveness repair shipped: fallback probe, new lane states (likely_active, stale), liveness_source field, and full test coverage.

--- a/plans/sessions/2026-03-21_post-merge-review-fixes-batch6.md
+++ b/plans/sessions/2026-03-21_post-merge-review-fixes-batch6.md
@@ -72,7 +72,7 @@ the same null-check_id finding.
 ## Validation
 
 - **Tier 1:** `uv run python -m pytest tests/unit/test_review_quality_audit.py -x -v`
-- **Tier 1:** `uv run python -m pytest tests/unit/test_index.py -x -v`
+- **Tier 1:** `uv run python -m pytest tests/unit/test_ops_index.py -x -v`
 - **Tier 2:** `make check-quiet` before PR
 
 ## Outcome


### PR DESCRIPTION
## Plan
N/A — trivial follow-up fixes from post-merge review issues.

## Summary
- Move N1/N2 from BLOCK to WARN in review gate rules to match actual P2 severity (#1147)
- Fix R20 repo review resolution count arithmetic: 3/9 resolved, 4 unchanged (#1100)
- Backfill plan outcome sections for PRs #1091 and #1098 (#1110)
- Restore manual-merge fallback note in CODEX_GITHUB_REVIEW.md merge flow (#1076)
- Fix broken test file path in batch6 session plan validation command (#1139)

Two issues (#1047 and #1057) were found to be already resolved by subsequent
PRs. They will be closed separately with a comment.

Closes #1147
Closes #1100
Closes #1110
Closes #1076
Closes #1139

## Why
Post-merge review follow-up issues identified docs inconsistencies, missing
outcome sections, incorrect arithmetic, and broken validation paths. All are
XS markdown-only fixes.

## Repro / Validation
**Command(s) run:**
- `make docs-check` — passed
- `make repo-lint` — passed

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] Other: `make docs-check` and `make repo-lint` (docs-only PR)

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a819882b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a819882b
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                                   24c7a922 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a819882b  5c4e0612 [fix/docs-followup-batch-wave1]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)