### PR TITLE
fix: atomic writes in skill_promotion.py

### DIFF
--- a/src/bid_euchre/ops/skill_promotion.py
+++ b/src/bid_euchre/ops/skill_promotion.py
@@ -27,6 +27,7 @@ Integration:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -145,9 +146,10 @@ def _save_candidate(candidate: SkillCandidate, candidates_dir: Path) -> Path:
             f.write(content)
             f.flush()
             os.fsync(f.fileno())
-        Path(tmp_path).rename(path)
+        os.replace(tmp_path, str(path))
     except BaseException:
-        Path(tmp_path).unlink(missing_ok=True)
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
         raise
     return path
 
@@ -350,11 +352,21 @@ def promote_skill(
             f"{findings_summary}"
         )
 
-    # Write the skill
+    # Write the skill atomically (temp + fsync + rename)
     skill_dir.mkdir(parents=True, exist_ok=True)
     skill_md = skill_dir / "SKILL.md"
     skill_content = _render_skill_md(candidate)
-    skill_md.write_text(skill_content, encoding="utf-8")
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=str(skill_dir), suffix=".tmp")
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+            f.write(skill_content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, str(skill_md))
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+        raise
 
     # Update candidate status
     candidate.status = "promoted"


### PR DESCRIPTION
## Plan
N/A — targeted follow-up fixes from steward review.

## Summary
- Use `os.replace()` instead of `Path.rename()` in `_save_candidate()` to match repo convention and avoid Windows `FileExistsError` on overwrite
- Make `promote_skill()` SKILL.md write atomic via temp+fsync+`os.replace` pattern
- Use `os.unlink` + `contextlib.suppress(OSError)` for cleanup consistency

Closes #1134
Closes #1135

Note: #1077 (`--!>` comment terminator) was already fixed in PR #1131 and is present on main.

## Why
`_save_candidate()` used `Path.rename()` which fails on Windows when the destination exists (review/promote flows). The SKILL.md write used plain `write_text()` which can leave a truncated file on crash. Both now use the atomic temp+fsync+rename pattern established in `memory.py` and `status.py`.

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/test_ops_skill_promotion.py -x -v` (75 passed)
- `make check` (5268 passed; 5 pre-existing matplotlib font failures unrelated to this change)

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_skill_promotion.py -x -v`
- [x] `make check` (pre-existing font failures only)

## Expected impact
- Metrics impact: None
- Runtime impact: Negligible (one extra fsync per SKILL.md write)

## Risk level
- [x] Low (ops tooling only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a9cebc47
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a9cebc47
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a9cebc47  a4abe5a9 [fix/skill-promotion-atomic-writes]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)