### PR TITLE
fix: treat gh-issue-list non-zero exits as dedup failures

### DIFF
--- a/scripts/internal/review_driver.py
+++ b/scripts/internal/review_driver.py
@@ -219,15 +219,25 @@ def _create_follow_up_issues(
                 capture_output=True,
                 text=True,
             )
-            existing = json.loads(dedup_result.stdout or "[]")
-            if existing:
-                logger.info(
-                    "Skipping duplicate issue for %s on PR #%d: %s",
+            if dedup_result.returncode != 0:
+                logger.warning(
+                    "gh issue list exited %d for %s on PR #%d, "
+                    "treating as dedup failure — proceeding with creation",
+                    dedup_result.returncode,
                     label,
                     pr_number,
-                    existing[0].get("url", "?"),
                 )
-                continue
+                # Fall through to issue creation below
+            else:
+                existing = json.loads(dedup_result.stdout or "[]")
+                if existing:
+                    logger.info(
+                        "Skipping duplicate issue for %s on PR #%d: %s",
+                        label,
+                        pr_number,
+                        existing[0].get("url", "?"),
+                    )
+                    continue
         except (json.JSONDecodeError, subprocess.CalledProcessError, OSError) as e:
             logger.warning("Dedup check failed, proceeding with creation: %s", e)
 

--- a/tests/unit/test_review_driver.py
+++ b/tests/unit/test_review_driver.py
@@ -1025,6 +1025,41 @@ class TestCreateFollowUpIssuesDedup:
 
         assert len(urls) == 1
 
+    def test_dedup_nonzero_exit_proceeds_with_creation(self) -> None:
+        """Non-zero exit from `gh issue list` logs warning and proceeds (#1082)."""
+
+        call_count = {"n": 0}
+
+        def _side_effect(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            if "list" in cmd:
+                # gh issue list returns non-zero (e.g., auth failure)
+                result = MagicMock()
+                result.returncode = 1
+                result.stdout = ""
+                return result
+            # The create call succeeds
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "https://github.com/test/repo/issues/104"
+            call_count["n"] += 1
+            return result
+
+        with (
+            patch("review_driver.subprocess.run", side_effect=_side_effect),
+            patch("review_driver.logger") as mock_logger,
+        ):
+            urls = _create_follow_up_issues(42, [_P2_FINDING])
+
+        # Issue should have been created despite dedup lookup failure
+        assert len(urls) == 1
+        assert "issues/104" in urls[0]
+        assert call_count["n"] >= 1
+        # Warning should mention non-zero exit
+        mock_logger.warning.assert_called()
+        warning_msg = mock_logger.warning.call_args[0][0]
+        assert "gh issue list exited" in warning_msg
+
     def test_dedup_does_not_catch_unexpected_error(self) -> None:
         """Unexpected errors (e.g., TypeError) must propagate, not be silently
         swallowed. This is the key behavioral change from #1043."""


### PR DESCRIPTION
## Plan
N/A

## Summary
- When `gh issue list` returns a non-zero exit code during the follow-up issue dedup check, the review driver now logs a warning and falls through to issue creation instead of silently parsing potentially empty stdout.
- Added regression test for the new returncode guard.

Closes #1082
Closes #1077 (already fixed by PR #1131 but never closed)

## Why
Non-zero exits from `gh issue list` (e.g., auth failures, rate limits) were silently swallowed: the code parsed `"[]"` from empty stdout and treated it as "no duplicate found," without logging that the dedup lookup failed. This makes it impossible to diagnose dedup guard failures in review coordinator logs.

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/test_review_driver.py -x` (71 passed)

**Config (if applicable):**
N/A

**Seed (if applicable):**
N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_review_driver.py` — 71 passed
- [ ] Other: N/A

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a304c00a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a304c00a
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                                   main
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a304c00a   fix/wave1-leftovers
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)