### PR TITLE
fix: add test coverage for 4 open issues

### DIFF
--- a/tests/unit/test_check_classifier.py
+++ b/tests/unit/test_check_classifier.py
@@ -134,3 +134,60 @@ class TestDriftDetection:
                 )
         finally:
             sys.path.pop(0)
+
+    def test_fallback_actually_exercises_fallback_path(self) -> None:
+        """Force ImportError to exercise the inline fallback classifier (#1094).
+
+        The normal import succeeds because bid_euchre is installed in test env,
+        so test_fallback_denylist_matches_non_ci_contexts tests the canonical
+        path, not the fallback.  This test reloads the module with bid_euchre
+        blocked to verify the inline fallback logic.
+        """
+        from unittest.mock import patch
+
+        scripts_dir = Path(__file__).resolve().parents[2] / "scripts" / "internal"
+        sys.path.insert(0, str(scripts_dir))
+        try:
+            # Remove cached module so reimport picks up the patched import
+            if "github_pr_state" in sys.modules:
+                saved_module = sys.modules.pop("github_pr_state")
+            else:
+                saved_module = None
+
+            # Block bid_euchre.ops import to trigger the fallback branch
+            original_import = (
+                __builtins__.__import__
+                if hasattr(__builtins__, "__import__")
+                else __import__
+            )
+
+            def blocking_import(name, *args, **kwargs):
+                if name == "bid_euchre.ops":
+                    raise ImportError("Simulated: bid_euchre not installed")
+                return original_import(name, *args, **kwargs)
+
+            with patch("builtins.__import__", side_effect=blocking_import):
+                import github_pr_state as gps_fallback
+
+            fallback_classify = gps_fallback._classify_check
+
+            # Verify fallback returns "non_ci" for all NON_CI_CONTEXTS
+            for ctx in NON_CI_CONTEXTS:
+                result = fallback_classify(ctx)
+                assert (
+                    result != "ci"
+                ), f"Fallback _classify_check classified {ctx!r} as 'ci'"
+                # Fallback returns "non_ci" (not "review_gate"/"advisory")
+                assert (
+                    result == "non_ci"
+                ), f"Fallback should return 'non_ci' for {ctx!r}, got {result!r}"
+
+            # Verify fallback returns "ci" for unknown checks
+            assert fallback_classify("tests") == "ci"
+            assert fallback_classify("some-unknown-job") == "ci"
+        finally:
+            # Restore original module
+            sys.modules.pop("github_pr_state", None)
+            if saved_module is not None:
+                sys.modules["github_pr_state"] = saved_module
+            sys.path.pop(0)

--- a/tests/unit/test_fs_boundary.py
+++ b/tests/unit/test_fs_boundary.py
@@ -442,3 +442,122 @@ class TestRequirePath:
         runtime = repo_layout["runtime_dirs"][0]
         result = require_path(runtime, boundaries=repo_layout, emit_event=False)
         assert result == PathClass.MANAGED_RUNTIME
+
+    def test_require_path_with_exception(self, repo_layout: dict[str, str]) -> None:
+        """Explicit exception should allow an otherwise-external path."""
+        external = repo_layout["external"]
+        result = require_path(
+            external,
+            boundaries=repo_layout,
+            exceptions=[external],
+            emit_event=False,
+        )
+        assert result == PathClass.EXPLICIT_EXCEPTION
+
+
+# ---------------------------------------------------------------------------
+# Auto-discovery tests (check_path / require_path with boundaries=None)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPathAutoDiscovery:
+    """Tests for check_path() when boundaries are auto-discovered (#1120)."""
+
+    def test_auto_discovers_boundaries(self, repo_layout: dict[str, str]) -> None:
+        """check_path() calls get_repo_boundaries() when boundaries=None."""
+        from unittest.mock import patch
+
+        subpath = Path(repo_layout["repo_root"]) / "src" / "app.py"
+        with patch(
+            "bid_euchre.ops.fs_boundary.get_repo_boundaries",
+            return_value=repo_layout,
+        ) as mock_get:
+            result = check_path(str(subpath))
+
+        mock_get.assert_called_once()
+        assert result == PathClass.REPO_ROOT
+
+    def test_auto_discovers_external(self, repo_layout: dict[str, str]) -> None:
+        """check_path() correctly classifies external path via auto-discovery."""
+        from unittest.mock import patch
+
+        with patch(
+            "bid_euchre.ops.fs_boundary.get_repo_boundaries",
+            return_value=repo_layout,
+        ) as mock_get:
+            result = check_path(repo_layout["external"])
+
+        mock_get.assert_called_once()
+        assert result == PathClass.EXTERNAL
+
+    def test_skips_auto_discovery_when_boundaries_provided(
+        self, repo_layout: dict[str, str]
+    ) -> None:
+        """check_path() does not call get_repo_boundaries() when boundaries given."""
+        from unittest.mock import patch
+
+        subpath = Path(repo_layout["repo_root"]) / "src" / "file.py"
+        with patch(
+            "bid_euchre.ops.fs_boundary.get_repo_boundaries",
+        ) as mock_get:
+            result = check_path(str(subpath), boundaries=repo_layout)
+
+        mock_get.assert_not_called()
+        assert result == PathClass.REPO_ROOT
+
+    def test_check_path_with_exceptions(self, repo_layout: dict[str, str]) -> None:
+        """check_path() forwards exceptions parameter correctly."""
+        external = repo_layout["external"]
+        result = check_path(external, boundaries=repo_layout, exceptions=[external])
+        assert result == PathClass.EXPLICIT_EXCEPTION
+
+
+class TestRequirePathAutoDiscovery:
+    """Tests for require_path() when boundaries are auto-discovered (#1120)."""
+
+    def test_auto_discovers_boundaries(self, repo_layout: dict[str, str]) -> None:
+        """require_path() calls get_repo_boundaries() when boundaries=None."""
+        from unittest.mock import patch
+
+        subpath = Path(repo_layout["repo_root"]) / "src" / "app.py"
+        with patch(
+            "bid_euchre.ops.fs_boundary.get_repo_boundaries",
+            return_value=repo_layout,
+        ) as mock_get:
+            result = require_path(str(subpath), emit_event=False)
+
+        mock_get.assert_called_once()
+        assert result == PathClass.REPO_ROOT
+
+    def test_auto_discovers_and_rejects_external(
+        self, repo_layout: dict[str, str]
+    ) -> None:
+        """require_path() raises BoundaryViolationError for external via auto-discovery."""
+        from unittest.mock import patch
+
+        with patch(
+            "bid_euchre.ops.fs_boundary.get_repo_boundaries",
+            return_value=repo_layout,
+        ) as mock_get:
+            with pytest.raises(BoundaryViolationError) as exc_info:
+                require_path(repo_layout["external"], emit_event=False)
+
+        mock_get.assert_called_once()
+        assert exc_info.value.classification == PathClass.EXTERNAL
+
+    def test_skips_auto_discovery_when_boundaries_provided(
+        self, repo_layout: dict[str, str]
+    ) -> None:
+        """require_path() does not call get_repo_boundaries() when boundaries given."""
+        from unittest.mock import patch
+
+        subpath = Path(repo_layout["repo_root"]) / "src" / "bar.py"
+        with patch(
+            "bid_euchre.ops.fs_boundary.get_repo_boundaries",
+        ) as mock_get:
+            result = require_path(
+                str(subpath), boundaries=repo_layout, emit_event=False
+            )
+
+        mock_get.assert_not_called()
+        assert result == PathClass.REPO_ROOT

--- a/tests/unit/test_github_pr_state.py
+++ b/tests/unit/test_github_pr_state.py
@@ -221,6 +221,7 @@ class TestCIClassification:
             "governance",
             "reviewing-changes",
             "claude-review",
+            "enable-auto-merge",
         ):
             local = _classify_check(name)
             canonical = classify_check(name)

--- a/tests/unit/test_ops_status.py
+++ b/tests/unit/test_ops_status.py
@@ -1899,6 +1899,23 @@ class TestSynthesizeLaneActivityLiveness:
         assert lane.state == "blocked"
         assert lane.liveness_source == "registry"
 
+    def test_blocked_lane_no_session_id(self) -> None:
+        """Blocked lane with no session_id -> liveness_source is None (#1106)."""
+        lanes = [_make_lane("author-a")]  # no session_id
+        sessions: dict = {}  # no active session
+        tasks = {
+            "author-a": [
+                _make_task("t1", "author-a", status="blocked", blocked_by=["CI"]),
+            ],
+        }
+
+        result = synthesize_lane_activity(lanes, sessions, tasks, [])
+        lane = result[0]
+        assert lane.state == "blocked"
+        assert lane.liveness_source is None
+        # Blocked lanes always need attention, even without session
+        assert lane.attention_needed is True
+
     def test_likely_active_from_dirty_worktree(self) -> None:
         """No session, no events, no tasks, but dirty worktree → likely_active."""
         import unittest.mock as mock


### PR DESCRIPTION
## Plan
N/A -- standalone test-coverage wave.

## Summary
- Add auto-discovery tests for `check_path()` and `require_path()` wrappers (#1120)
- Add blocked-lane-without-session_id test verifying `liveness_source=None` (#1106)
- Add fallback `_classify_check` test that forces `ImportError` to exercise inline denylist (#1094)
- Add `enable-auto-merge` to consistency check tuple in `test_github_pr_state.py` (#1094)

## Why
Four open issues flagged missing test coverage on reviewed/merged code. This PR
adds the missing tests without production code changes.

Closes #1120
Closes #1106
Closes #1094
Closes #1105

(#1105 was already fixed in #1128 but the issue was left open.)

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_fs_boundary.py tests/unit/test_check_classifier.py tests/unit/test_github_pr_state.py tests/unit/test_ops_status.py -k "AutoDiscovery or test_blocked_lane_no_session_id or fallback_actually or test_consistent or test_require_path_with_exception" -v
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_fs_boundary.py -v` (38 passed)
- [x] `uv run python -m pytest tests/unit/test_ops_status.py -k test_blocked_lane_no_session_id -v` (1 passed)
- [x] `uv run python -m pytest tests/unit/test_check_classifier.py -v` (17 passed)
- [x] `uv run python -m pytest tests/unit/test_github_pr_state.py -k test_consistent -v` (1 passed)

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a4bfc202
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a4bfc202
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                                   24c7a922 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-a4bfc202  1cc9384c [fix/test-coverage-wave2]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)