### PR TITLE
fix: harden claude-review workflow — gh pr diff, threshold alerting

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # Full history so the reviewer can run git diff origin/main...HEAD
-          fetch-depth: 0
+          # Shallow clone is sufficient — reviewer uses `gh pr diff` (not git diff)
+          fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
@@ -44,7 +44,7 @@ jobs:
             DO NOT attempt to modify files, create commits, push branches, or
             perform any implementation work. You may only read and comment.
 
-            Start by running `git diff origin/main...HEAD --stat` to understand
+            Start by running `gh pr diff ${{ github.event.pull_request.number }}` to understand
             the change scope, then read the changed files for detailed review.
 
             Review this pull request for:
@@ -55,7 +55,7 @@ jobs:
             Post your findings as review comments on the PR.
 
           # Tool access strategy:
-          # - Bash is ALLOWED (read-only: git diff, ruff check, pytest --collect-only)
+          # - Bash is scoped to gh commands via allowed-tools in the action config
           # - Read/Grep/Glob are allowed by default
           # - Write tools and network/agent tools are disallowed to prevent
           #   wasted turns on permission denials (~36% turn waste before this fix)
@@ -75,7 +75,39 @@ jobs:
           if [ -z "$EXECUTION_FILE" ]; then
             # Output was never set — action crashed before producing metadata.
             # The action does not set execution_file on error_max_turns exits,
-            # so this is the most common case. Warn but do not create an issue.
+            # so this is the most common case. Usually harmless, but consecutive
+            # blank-execution failures may indicate a persistent infra problem.
+            #
+            # Threshold alerting: count recent consecutive blank-execution runs
+            # by querying workflow run conclusions. If >= BLANK_EXEC_THRESHOLD
+            # consecutive failures, escalate to an issue instead of just warning.
+            BLANK_EXEC_THRESHOLD=3
+            RECENT_RUNS=$(gh run list \
+              --workflow "claude-code-review.yml" \
+              --limit "$((BLANK_EXEC_THRESHOLD + 1))" \
+              --json conclusion,status \
+              --jq '[.[] | select(.status == "completed")] | .[0:'"$BLANK_EXEC_THRESHOLD"'] | map(.conclusion)' \
+              2>/dev/null || echo "[]")
+
+            # Count consecutive failures (all recent runs failed)
+            CONSECUTIVE_FAILURES=$(echo "$RECENT_RUNS" | jq '[.[] | select(. == "failure")] | length' 2>/dev/null || echo "0")
+
+            if [ "$CONSECUTIVE_FAILURES" -ge "$BLANK_EXEC_THRESHOLD" ]; then
+              echo "::error::claude-review has $CONSECUTIVE_FAILURES consecutive blank-execution failures — creating infra issue"
+              gh issue create \
+                --title "claude-review: $CONSECUTIVE_FAILURES consecutive blank-execution failures" \
+                --body "The Claude Code Review action has failed $CONSECUTIVE_FAILURES consecutive times without producing an \`execution_file\`. This pattern suggests a persistent infrastructure problem (not intermittent max-turns noise).
+
+          **Consecutive failures:** $CONSECUTIVE_FAILURES
+          **Threshold:** $BLANK_EXEC_THRESHOLD
+          **Latest run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          Investigate: OOM, token expiry, auth failure, or action version regression." \
+                --label "follow-up"
+              # Exit non-zero so the check stays failed as a visible signal
+              exit 1
+            fi
+
             echo "::warning::claude-review exited without execution_file (likely max-turns exhaustion)"
             exit 0
           elif [ ! -f "$EXECUTION_FILE" ]; then

--- a/tests/unit/test_claude_review_workflow.py
+++ b/tests/unit/test_claude_review_workflow.py
@@ -98,14 +98,41 @@ class TestClaudeReviewWorkflow:
                 tool in claude_args
             ), f"'{tool}' must be in --disallowedTools to prevent wasted turns"
 
-    def test_full_git_history_for_diff(self):
-        """Checkout must use fetch-depth 0 so git diff origin/main works."""
+    def test_shallow_clone_sufficient(self):
+        """Checkout uses shallow clone — reviewer uses gh pr diff (not git diff)."""
         steps = self.cfg["jobs"]["claude-review"]["steps"]
         checkout = next(s for s in steps if "checkout" in s.get("uses", ""))
-        assert checkout["with"]["fetch-depth"] == 0, (
-            "fetch-depth must be 0 for full git history — "
-            "the reviewer needs git diff origin/main...HEAD"
+        assert checkout["with"]["fetch-depth"] == 1, (
+            "fetch-depth must be 1 (shallow) — reviewer uses gh pr diff, "
+            "not git diff, so full history is unnecessary"
         )
+
+    def test_prompt_uses_gh_pr_diff(self):
+        """Reviewer prompt must use `gh pr diff` not `git diff`.
+
+        The allowed-tools only grant scoped Bash for `gh` commands.
+        Unrestricted `git diff` may be denied by the sandbox (#1146).
+        """
+        step = self._review_step()
+        prompt = step["with"]["prompt"]
+        assert "gh pr diff" in prompt, "prompt must use gh pr diff (not git diff)"
+        assert "git diff" not in prompt, "prompt must not reference git diff"
+
+    def test_threshold_alerting_for_blank_execution(self):
+        """Consecutive blank-execution failures must escalate to an issue.
+
+        After BLANK_EXEC_THRESHOLD consecutive failures, the classifier
+        creates an infra issue instead of silently warning (#1092).
+        """
+        flag_step = self._flag_step()
+        script = flag_step["run"]
+        assert "BLANK_EXEC_THRESHOLD" in script, (
+            "classifier must define BLANK_EXEC_THRESHOLD for consecutive "
+            "blank-execution alerting"
+        )
+        assert (
+            "CONSECUTIVE_FAILURES" in script
+        ), "classifier must count consecutive failures"
 
     # -- infra-failure classifier constraints --
 
@@ -123,10 +150,11 @@ class TestClaudeReviewWorkflow:
         assert "GH_TOKEN" in str(flag_step.get("env", {}))
 
     def test_classifier_suppresses_blank_execution_file(self):
-        """Blank EXECUTION_FILE must warn and exit 0, not create an issue.
+        """Blank EXECUTION_FILE below threshold must warn and exit 0.
 
         The action does not set execution_file on error_max_turns exits.
-        Creating an issue for every blank file would spam the repo.
+        Below the threshold, blank files exit 0 (suppressed). Above the
+        threshold, consecutive failures escalate to an issue (#1092).
         """
         flag_step = self._flag_step()
         script = flag_step["run"]
@@ -134,14 +162,19 @@ class TestClaudeReviewWorkflow:
         assert (
             '-z "$EXECUTION_FILE"' in script
         ), "classifier must check for blank EXECUTION_FILE"
-        # Must exit 0 (no issue creation) on blank path
-        # Find the blank-file branch and verify it has exit 0 before gh issue create
+        # The blank-execution branch must contain both:
+        # - exit 0 (below threshold, suppress)
+        # - exit 1 (above threshold, escalate)
         blank_idx = script.index('-z "$EXECUTION_FILE"')
-        exit_idx = script.index("exit 0", blank_idx)
-        issue_idx = script.index("gh issue create")
+        # Find the elif that ends the blank-execution branch
+        elif_idx = script.index("elif", blank_idx)
+        blank_section = script[blank_idx:elif_idx]
         assert (
-            exit_idx < issue_idx
-        ), "blank EXECUTION_FILE path must exit 0 before reaching gh issue create"
+            "exit 0" in blank_section
+        ), "blank EXECUTION_FILE path must exit 0 below threshold"
+        assert (
+            "exit 1" in blank_section
+        ), "blank EXECUTION_FILE path must exit 1 above threshold"
 
     def test_classifier_suppresses_max_turns(self):
         """error_max_turns must warn and exit 0, not create an issue.
@@ -154,13 +187,15 @@ class TestClaudeReviewWorkflow:
         assert (
             "error_max_turns" in script
         ), "classifier must check for error_max_turns subtype"
-        # The error_max_turns guard must exit 0 before gh issue create
+        # The error_max_turns guard must exit 0 before the final gh issue create
+        # (the one for genuine infra failures, not the threshold alerting one)
         max_turns_idx = script.index("error_max_turns")
         exit_idx = script.index("exit 0", max_turns_idx)
-        issue_idx = script.index("gh issue create")
+        # Find the last gh issue create (genuine failure path)
+        last_issue_idx = script.rindex("gh issue create")
         assert (
-            exit_idx < issue_idx
-        ), "error_max_turns path must exit 0 before reaching gh issue create"
+            exit_idx < last_issue_idx
+        ), "error_max_turns path must exit 0 before the genuine-failure issue create"
 
     def test_classifier_handles_file_not_found(self):
         """Classifier must handle EXECUTION_FILE path set but file absent."""


### PR DESCRIPTION
## Plan
N/A — three targeted follow-up fixes from steward review findings.

## Summary
- Replace `git diff origin/main...HEAD` with `gh pr diff` in reviewer prompt since allowed-tools only grant scoped Bash for `gh` commands (#1146)
- Add threshold alerting for consecutive blank-execution failures: after 3+ consecutive failures, escalate to an infra issue instead of silently warning (#1092)
- `max-turns` is already at 15 (set in prior PR #1085), above the requested 10 — closing #1034 as resolved

## Why
The reviewer prompt instructed `git diff` which may not be available in the scoped Bash sandbox, wasting a turn. Blank EXECUTION_FILE exits were unconditionally suppressed (exit 0), hiding genuine infra failures behind max-turns noise.

Closes #1146
Closes #1092
Closes #1034

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/test_claude_review_workflow.py -v` (18 tests pass)
- `make check` (pre-existing matplotlib font failures only, unrelated)

**Config (if applicable):**
N/A

**Seed (if applicable):**
N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_claude_review_workflow.py -v` — 18 tests
- [ ] Other: workflow YAML changes are validated structurally by tests, not by local CI

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): Reduces CI checkout time (fetch-depth 1 vs 0); threshold alerting adds a `gh run list` call only on blank-execution failures

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-ab408f7a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-ab408f7a
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                                   24c7a922 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-ab408f7a  c326da36 [fix/claude-review-workflow-hardening]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)