### PR TITLE
fix: emit audit event for explicit_exception path in fs_boundary

### DIFF
--- a/src/bid_euchre/ops/events.py
+++ b/src/bid_euchre/ops/events.py
@@ -49,6 +49,7 @@ VALID_EVENT_TYPES = frozenset(
         "skill_promoted",
         "skill_disabled",
         "fs_boundary_violation",
+        "fs_boundary_exception",
         "pr_comment_ingested",
     }
 )

--- a/src/bid_euchre/ops/fs_boundary.py
+++ b/src/bid_euchre/ops/fs_boundary.py
@@ -249,6 +249,14 @@ def require_in_boundary(
             )
         raise BoundaryViolationError(str(path), classification)
 
+    if classification == PathClass.EXPLICIT_EXCEPTION and emit_event:
+        _emit_exception_event(
+            str(path),
+            events_dir=events_dir,
+            source=source,
+            lane_id=lane_id,
+        )
+
     return classification
 
 
@@ -353,3 +361,33 @@ def _emit_violation_event(
         )
     except Exception:  # noqa: BLE001
         logger.warning("Failed to emit boundary violation event for %s", path)
+
+
+def _emit_exception_event(
+    path: str,
+    *,
+    events_dir: Path | None = None,
+    source: str = "ops.fs_boundary",
+    lane_id: str = "ops",
+) -> None:
+    """Emit an audit event when a path is allowed via explicit exception.
+
+    This provides audit visibility for paths that bypass the default-deny
+    boundary policy. Best-effort: failures are logged but do not propagate.
+    """
+    try:
+        from bid_euchre.ops.events import append_event
+
+        append_event(
+            "fs_boundary_exception",
+            source,
+            lane_id,
+            {
+                "path": path,
+                "classification": PathClass.EXPLICIT_EXCEPTION.value,
+                "action": "allowed_exception",
+            },
+            events_dir,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning("Failed to emit boundary exception event for %s", path)

--- a/tests/unit/test_fs_boundary.py
+++ b/tests/unit/test_fs_boundary.py
@@ -333,6 +333,57 @@ class TestRequireInBoundary:
         assert event["payload"]["action"] == "denied"
         assert repo_layout["external"] in event["payload"]["path"]
 
+    def test_emits_audit_event_on_explicit_exception(
+        self, repo_layout: dict[str, str]
+    ) -> None:
+        """Allowing a path via explicit exception should emit an audit event (#1151)."""
+        events_dir = Path(repo_layout["events_dir"])
+
+        result = require_in_boundary(
+            repo_layout["external"],
+            repo_root=repo_layout["repo_root"],
+            worktree_paths=repo_layout["worktree_paths"],
+            runtime_dirs=repo_layout["runtime_dirs"],
+            exceptions=[repo_layout["external"]],
+            emit_event=True,
+            events_dir=events_dir,
+        )
+        assert result == PathClass.EXPLICIT_EXCEPTION
+
+        # Verify audit event was written
+        events_file = events_dir / "events.jsonl"
+        assert events_file.exists(), "Expected events.jsonl to be created"
+
+        lines = events_file.read_text().strip().splitlines()
+        assert len(lines) >= 1
+
+        event = json.loads(lines[-1])
+        assert event["event_type"] == "fs_boundary_exception"
+        assert event["payload"]["classification"] == "explicit_exception"
+        assert event["payload"]["action"] == "allowed_exception"
+        assert repo_layout["external"] in event["payload"]["path"]
+
+    def test_no_audit_event_when_emit_event_false(
+        self, repo_layout: dict[str, str]
+    ) -> None:
+        """Explicit exception with emit_event=False should not write an event."""
+        events_dir = Path(repo_layout["events_dir"])
+
+        result = require_in_boundary(
+            repo_layout["external"],
+            repo_root=repo_layout["repo_root"],
+            worktree_paths=repo_layout["worktree_paths"],
+            runtime_dirs=repo_layout["runtime_dirs"],
+            exceptions=[repo_layout["external"]],
+            emit_event=False,
+            events_dir=events_dir,
+        )
+        assert result == PathClass.EXPLICIT_EXCEPTION
+
+        # No event file should exist (no events emitted)
+        events_file = events_dir / "events.jsonl"
+        assert not events_file.exists()
+
 
 # ---------------------------------------------------------------------------
 # PathClass enum tests


### PR DESCRIPTION
## Plan
- N/A (issue-driven fix)

## Summary
- Emit a `fs_boundary_exception` audit event when `require_in_boundary()` allows a path via `EXPLICIT_EXCEPTION`
- Register `fs_boundary_exception` in `VALID_EVENT_TYPES`
- Add two regression tests covering event emission and `emit_event=False` suppression

## Why
The bridge plan and platform entry checklist require "explicit exception path with audit visibility." `fs_boundary.py` emitted audit events when paths were *denied* as EXTERNAL but not when *allowed* via EXPLICIT_EXCEPTION. This closes that audit gap.

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/test_fs_boundary.py tests/unit/test_ops_cli.py -x -q` (40 + 80 passed)

**Config (if applicable):**
- N/A

**Seed (if applicable):**
- N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_fs_boundary.py -x -q` (40 passed)
- [x] `uv run python -m pytest tests/unit/test_ops_cli.py -x -q` (80 passed)
- [x] Other: ruff check + ruff format clean

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): One additional best-effort JSONL append per explicit-exception path check (negligible)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         e3d4487c [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b        65196703 [fix/unify-ci-classifiers]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

Closes #1151

Note: Issue #1083 was closed as not-applicable -- the target file `scripts/internal/ci_shadow_trial_report.py` was removed in PR #1086.