### PR TITLE
fix: add dedup guard and fix consecutive count in claude-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,7 +55,7 @@ jobs:
             Post your findings as review comments on the PR.
 
           # Tool access strategy:
-          # - Bash is scoped to gh commands via allowed-tools in the action config
+          # - Bash available (scoped via --disallowedTools blocklist in claude_args)
           # - Read/Grep/Glob are allowed by default
           # - Write tools and network/agent tools are disallowed to prevent
           #   wasted turns on permission denials (~36% turn waste before this fix)
@@ -89,11 +89,19 @@ jobs:
               --jq '[.[] | select(.status == "completed")] | .[0:'"$BLANK_EXEC_THRESHOLD"'] | map(.conclusion)' \
               2>/dev/null || echo "[]")
 
-            # Count consecutive failures (all recent runs failed)
-            CONSECUTIVE_FAILURES=$(echo "$RECENT_RUNS" | jq '[.[] | select(. == "failure")] | length' 2>/dev/null || echo "0")
+            # Count truly consecutive failures from the start: stop at first non-failure
+            CONSECUTIVE_FAILURES=$(echo "$RECENT_RUNS" | jq 'reduce .[] as $c ({n:0,stop:false}; if .stop then . else (if $c == "failure" then .n += 1 else .stop = true end) end) | .n' 2>/dev/null || echo "0")
 
             if [ "$CONSECUTIVE_FAILURES" -ge "$BLANK_EXEC_THRESHOLD" ]; then
               echo "::error::claude-review has $CONSECUTIVE_FAILURES consecutive blank-execution failures — creating infra issue"
+
+              # Dedup: skip if an open issue already exists for this alert
+              EXISTING=$(gh issue list --search "claude-review: consecutive blank-execution" --state open --limit 1 --json number --jq '.[0].number' 2>/dev/null || echo "")
+              if [ -n "$EXISTING" ]; then
+                echo "::warning::Infra issue #$EXISTING already open — skipping duplicate"
+                exit 1
+              fi
+
               gh issue create \
                 --title "claude-review: $CONSECUTIVE_FAILURES consecutive blank-execution failures" \
                 --body "The Claude Code Review action has failed $CONSECUTIVE_FAILURES consecutive times without producing an \`execution_file\`. This pattern suggests a persistent infrastructure problem (not intermittent max-turns noise).

--- a/tests/unit/test_claude_review_workflow.py
+++ b/tests/unit/test_claude_review_workflow.py
@@ -216,6 +216,63 @@ class TestClaudeReviewWorkflow:
             "unparseable_execution_file" in script
         ), "must classify empty jq output as 'unparseable_execution_file'"
 
+    def test_threshold_dedup_guard(self):
+        """Threshold-breach issue creation must check for existing open issues.
+
+        Without dedup, the 4th, 5th, etc. consecutive failures each create
+        a new issue. The guard searches for an existing open issue and skips
+        creation if one exists (#1164).
+        """
+        flag_step = self._flag_step()
+        script = flag_step["run"]
+        # Dedup guard must appear before the threshold gh issue create
+        assert "gh issue list --search" in script, (
+            "threshold-breach path must search for existing open issues "
+            "before creating a new one"
+        )
+        # The search must look for the same title pattern used in creation
+        assert (
+            "consecutive blank-execution" in script
+        ), "dedup search must match the threshold-breach issue title pattern"
+        # Dedup guard must come before the threshold issue create
+        dedup_idx = script.index("gh issue list --search")
+        # Find the threshold issue create (first one, not the genuine-failure one)
+        threshold_create_idx = script.index("gh issue create")
+        assert (
+            dedup_idx < threshold_create_idx
+        ), "dedup guard must appear before the threshold gh issue create"
+
+    def test_consecutive_count_uses_reduce(self):
+        """Failure count must be truly consecutive — stop at first non-failure.
+
+        The original implementation counted all failures in the window, not
+        consecutive ones from the start. The fix uses a jq reduce that stops
+        counting at the first non-failure (#1164).
+        """
+        flag_step = self._flag_step()
+        script = flag_step["run"]
+        assert "reduce" in script, (
+            "consecutive failure count must use jq reduce for true "
+            "sequential counting (not filter-then-length)"
+        )
+
+    def test_bash_scoping_comment_mentions_blocklist(self):
+        """The Bash scoping comment must reference --disallowedTools blocklist.
+
+        The action does NOT use an allowed-tools allowlist — it uses
+        --disallowedTools in claude_args (#1167).
+        """
+        # Check the raw YAML text for the comment; step dict won't include it
+        workflow_text = WORKFLOW.read_text()
+        assert "scoped via --disallowedTools blocklist" in workflow_text, (
+            "Bash scoping comment must mention --disallowedTools blocklist, "
+            "not allowed-tools allowlist"
+        )
+        # The old misleading phrasing must not be present
+        assert (
+            "allowed-tools in the action config" not in workflow_text
+        ), "old misleading comment about allowed-tools must be removed"
+
     # -- helpers --
 
     def _review_step(self):


### PR DESCRIPTION
## Plan
N/A — targeted fix for two issues.

## Summary
- Add dedup guard before threshold-breach issue creation to prevent duplicate issues on 4th+ consecutive failures
- Fix consecutive failure count to be truly sequential (stop at first non-failure) using jq `reduce`
- Correct misleading comment about Bash scoping (`allowed-tools` -> `--disallowedTools blocklist`)

## Why
The threshold-breach alerting (added in PR #1153) creates a GitHub issue after 3 consecutive blank-execution failures. Two bugs: (1) the count was not truly consecutive — it counted all failures in the window regardless of ordering, and (2) no dedup check, so the 4th, 5th, etc. failures each created a new issue. Additionally, a comment inaccurately described the tool access strategy.

Closes #1164
Closes #1167

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/test_claude_review_workflow.py -v` (21 passed)
- jq reduce validated locally with edge cases: `[F,F,F]`->3, `[F,F,S]`->2, `[S,F,F]`->0, `[F,S,F]`->1, `[]`->0

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_claude_review_workflow.py -v` — 21/21 passed
- [ ] Integration (if engine/rules changed): N/A
- [x] Other: 3 new regression tests added
  - `test_threshold_dedup_guard` — dedup search appears before threshold issue create
  - `test_consecutive_count_uses_reduce` — jq reduce for true sequential counting
  - `test_bash_scoping_comment_mentions_blocklist` — correct comment wording

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-acf59ae5
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-acf59ae5
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                                   24c7a922 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/agent-acf59ae5  62380bf0 [fix/claude-review-dedup-and-docs]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)