### PR TITLE
fix: unify CI classifiers and update for sharded CI architecture

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -52,5 +52,5 @@ Discard: exploration tangents, superseded plans, verbose file contents already s
 ## Docs-Only CI (Resolved)
 - CI now uses `dorny/paths-filter` instead of `paths-ignore` (PR #635)
 - The `tests` job always triggers and posts a status
-- Docs/plans-only PRs skip heavy steps via per-step `if` conditions
+- Docs/plans-only PRs skip heavy jobs via path-filter gating
 - No more deadlock — no need for `# trigger CI` workarounds

--- a/.claude/rules/deferred/60_review_gate.md
+++ b/.claude/rules/deferred/60_review_gate.md
@@ -176,7 +176,8 @@ overlap or replace each other.
 
 ## Known Issue: Docs-Only PRs and CI
 
-**Resolved (PR #635):** The CI workflow now uses `dorny/paths-filter` instead of
-`paths-ignore`. The `tests` job always triggers and posts a status. For docs/plans-only
-PRs, heavy steps (checkout, install, lint, test) are skipped via per-step `if` conditions,
-so the job completes in seconds with a green status. No more deadlock.
+**Resolved (PR #635, updated PR #1086):** The CI workflow uses `dorny/paths-filter`
+to gate job execution. The `tests` aggregation gate always triggers and posts a status.
+For docs/plans-only PRs, heavy jobs (`checks`, `tests-shard`, `notebooks`,
+`promotion-gate`) are skipped entirely via path-filter gating, and the `tests`
+aggregation gate passes on all-skipped upstream. No more deadlock.

--- a/.claude/skills/debugging-ci/SYMPTOM_TABLE.md
+++ b/.claude/skills/debugging-ci/SYMPTOM_TABLE.md
@@ -18,7 +18,7 @@ Full lookup table for common CI and validation failures.
 |---------|-----------|-----|
 | CI red after push | One or more jobs failed | `gh pr checks <PR>` — identify which job, read its log |
 | CI not triggered | Workflow not matching paths | Check `.github/workflows/ci.yml` path filters |
-| CI passes but status missing | `dorny/paths-filter` skipped all steps | Expected for docs-only PRs — tests job still posts green status |
+| CI passes but status missing | `dorny/paths-filter` skipped heavy jobs | Expected for docs-only PRs — `tests` aggregation gate still posts green status |
 
 ## Review Loop Issues
 

--- a/src/bid_euchre/ops/__init__.py
+++ b/src/bid_euchre/ops/__init__.py
@@ -73,8 +73,22 @@ def classify_check(name: str) -> str:
 
 # DEPRECATED fail-closed allowlist — prefer classify_check() (fail-open denylist).
 # New CI jobs are included by default via classify_check(); this set is retained
-# for backward compat only. Update both when adding workflow jobs. See #1036, #1041.
-CI_CHECK_NAMES: frozenset[str] = frozenset({"tests", "prechecks", "governance"})
+# for backward compat only.  Updated for sharded CI (PR #1086): the old
+# "prechecks" and "governance" jobs were removed; the new jobs are "checks",
+# "tests-shard" (matrix: "tests-shard (1)", "tests-shard (2)"), "notebooks",
+# "promotion-gate", and the "tests" aggregation gate.  See #1036, #1041, #1093.
+CI_CHECK_NAMES: frozenset[str] = frozenset(
+    {
+        "changes",
+        "checks",
+        "tests-shard",
+        "tests-shard (1)",
+        "tests-shard (2)",
+        "notebooks",
+        "promotion-gate",
+        "tests",
+    }
+)
 
 # Default timeout (seconds) for gh CLI subprocess calls.
 # Operator surfaces must never hang indefinitely.

--- a/tests/unit/test_check_classifier.py
+++ b/tests/unit/test_check_classifier.py
@@ -85,8 +85,14 @@ class TestConsistencyWithGithubPrState:
                     pr_state_classify(ctx) != "ci"
                 ), f"Non-CI context {ctx!r} classified as 'ci' by github_pr_state"
 
-            # Known CI checks must be included by both
-            for name in ("tests", "prechecks", "governance"):
+            # Known CI checks must be included by both (sharded CI job names)
+            for name in (
+                "tests",
+                "checks",
+                "tests-shard",
+                "notebooks",
+                "promotion-gate",
+            ):
                 assert (
                     pr_state_classify(name) == "ci"
                 ), f"CI check {name!r} not classified as 'ci' by github_pr_state"

--- a/tests/unit/test_ops_ci.py
+++ b/tests/unit/test_ops_ci.py
@@ -629,13 +629,25 @@ class TestCICheckNamesConsistency:
     """Verify CI classification constants are consistent."""
 
     def test_ci_check_names_accessible(self) -> None:
-        """CI_CHECK_NAMES allowlist is importable and has expected members."""
+        """CI_CHECK_NAMES allowlist is importable and has expected members.
+
+        Updated for sharded CI (#1086): old jobs (prechecks, governance)
+        replaced by checks, tests-shard, notebooks, promotion-gate.
+        """
         from bid_euchre.ops import CI_CHECK_NAMES
 
+        # Current sharded CI job names
         assert "tests" in CI_CHECK_NAMES
-        assert "prechecks" in CI_CHECK_NAMES
-        assert "governance" in CI_CHECK_NAMES
+        assert "checks" in CI_CHECK_NAMES
+        assert "tests-shard" in CI_CHECK_NAMES
+        assert "tests-shard (1)" in CI_CHECK_NAMES
+        assert "tests-shard (2)" in CI_CHECK_NAMES
+        assert "notebooks" in CI_CHECK_NAMES
+        assert "promotion-gate" in CI_CHECK_NAMES
+        # Non-CI checks must NOT be in the set
         assert "reviewing-changes" not in CI_CHECK_NAMES
+        assert "claude-review" not in CI_CHECK_NAMES
+        assert "enable-auto-merge" not in CI_CHECK_NAMES
 
     def test_classify_check_consistent_with_non_ci(self) -> None:
         """classify_check categorizes review/advisory contexts as non-CI."""
@@ -643,5 +655,11 @@ class TestCICheckNamesConsistency:
 
         assert classify_check("reviewing-changes") == "review_gate"
         assert classify_check("claude-review") == "advisory"
+        assert classify_check("enable-auto-merge") == "advisory"
+        # Current sharded CI job names all classify as "ci"
         assert classify_check("tests") == "ci"
-        assert classify_check("prechecks") == "ci"
+        assert classify_check("checks") == "ci"
+        assert classify_check("tests-shard") == "ci"
+        assert classify_check("tests-shard (1)") == "ci"
+        assert classify_check("notebooks") == "ci"
+        assert classify_check("promotion-gate") == "ci"


### PR DESCRIPTION
## Plan
- `plans/sessions/2026-03-20_batch-d-unify-ci-classifiers.md`

## Summary
- Unify CI classification on `classify_check()` (fail-open denylist) as single source of truth; both `review_driver.py` and `ops/ci.py` already use it via `github_pr_state.get_ci_status()` and `poll_ci_status()`
- Update deprecated `CI_CHECK_NAMES` allowlist with sharded CI job names: `changes`, `checks`, `tests-shard`, `tests-shard (1)`, `tests-shard (2)`, `notebooks`, `promotion-gate`, `tests`
- Fix 3 stale docs references describing "per-step `if` conditions" skipping, updated to "per-job path-filter gating" to match the sharded CI architecture from PR #1086

## Why
Two CI classification systems disagreed: `CI_CHECK_NAMES` (fail-closed allowlist with stale job names) vs `classify_check()` (fail-open denylist). The allowlist still listed removed jobs (`prechecks`, `governance`) and was missing new sharded jobs. While `classify_check()` was already authoritative at runtime, the stale `CI_CHECK_NAMES` and docs created confusion about the actual CI architecture.

Closes #1036
Closes #1093

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_ci.py tests/unit/test_check_classifier.py -x -q
# 80 passed
uv run ruff check --fix src/bid_euchre/ops/__init__.py tests/unit/test_ops_ci.py tests/unit/test_check_classifier.py
uv run ruff format src/bid_euchre/ops/__init__.py tests/unit/test_ops_ci.py tests/unit/test_check_classifier.py
```

**Config (if applicable):** N/A

**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_ci.py tests/unit/test_check_classifier.py -x -q` (80 passed)
- [ ] Other: CI handles full validation

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                    e3d4487c [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b   d89900ec [fix/unify-ci-classifiers]
(other worktrees omitted for brevity)
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)