### PR TITLE
fix: harden ops status — liveness source, ImportError logging, no-probe flag

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -102,7 +102,8 @@ def cmd_status(args: argparse.Namespace) -> int:
         format_status_text,
     )
 
-    report = aggregate_status(args.runtime_dir)
+    check_worktree = not getattr(args, "no_probe", False)
+    report = aggregate_status(args.runtime_dir, check_worktree=check_worktree)
 
     if args.json:
         print(json.dumps(format_status_json(report), indent=2))
@@ -398,7 +399,8 @@ def cmd_health(args: argparse.Namespace) -> int:
         run_all_watchdogs,
     )
 
-    status = aggregate_status(args.runtime_dir)
+    check_worktree = not getattr(args, "no_probe", False)
+    status = aggregate_status(args.runtime_dir, check_worktree=check_worktree)
     findings = run_all_watchdogs(args.runtime_dir, args.plans_dir)
 
     if args.json:
@@ -1321,7 +1323,15 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command", help="Command to run")
 
     # status
-    subparsers.add_parser("status", help="Lane/session/task health summary")
+    status_parser = subparsers.add_parser(
+        "status", help="Lane/session/task health summary"
+    )
+    status_parser.add_argument(
+        "--no-probe",
+        action="store_true",
+        default=False,
+        help="Skip dirty-worktree subprocess probes (faster with many idle lanes)",
+    )
 
     # worktrees (with nested prune/quarantine/archive subcommands)
     wt_parser = subparsers.add_parser(
@@ -1368,7 +1378,13 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers.add_parser("tick", help="Run one scheduler cycle")
 
     # health
-    subparsers.add_parser("health", help="Aggregated health check")
+    health_parser = subparsers.add_parser("health", help="Aggregated health check")
+    health_parser.add_argument(
+        "--no-probe",
+        action="store_true",
+        default=False,
+        help="Skip dirty-worktree subprocess probes (faster with many idle lanes)",
+    )
 
     # watchdogs
     subparsers.add_parser("watchdogs", help="Run watchdog checks")

--- a/src/bid_euchre/ops/status.py
+++ b/src/bid_euchre/ops/status.py
@@ -621,11 +621,18 @@ def _probe_fallback_liveness(
                     source="worktree_dirty",
                     detail=f"uncommitted changes in {wt_name}",
                 )
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             # Subprocess failures (FileNotFoundError, TimeoutExpired, git
             # errors) must not block status aggregation.  Degrade gracefully
             # by skipping this signal.
-            logger.debug(
+            #
+            # ImportError is more serious (missing module / broken import) so
+            # escalate to warning to avoid silent masking.
+            log_level = (
+                logging.WARNING if isinstance(exc, ImportError) else logging.DEBUG
+            )
+            logger.log(
+                log_level,
                 "dirty-worktree check failed for %s, skipping signal",
                 worktree_path,
                 exc_info=True,
@@ -651,6 +658,7 @@ def synthesize_lane_activity(
     *,
     now: datetime | None = None,
     stale_minutes: int = STALE_MINUTES,
+    check_worktree: bool = True,
 ) -> list[LaneStatus]:
     """Synthesize lane-activity view from existing repo-local state.
 
@@ -672,6 +680,9 @@ def synthesize_lane_activity(
         events: Recent events, most-recent-first.
         now: Current time for staleness checks (default: UTC now).
         stale_minutes: Minutes without progress before flagging stale.
+        check_worktree: If False, skip the dirty-worktree subprocess probe
+            in the fallback liveness check.  Useful for fast status queries
+            when 7+ worktrees would each spawn a ``git status`` subprocess.
 
     Returns:
         List of enriched LaneStatus objects.
@@ -716,7 +727,7 @@ def synthesize_lane_activity(
 
         if primary_task and primary_task.get("status") == "blocked":
             state = "blocked"
-            liveness_source = "registry" if has_active_session else None
+            liveness_source = "task_state"
         elif has_active_session:
             state = "active"
             liveness_source = "registry"
@@ -733,6 +744,7 @@ def synthesize_lane_activity(
                 worktree_path=lane.get("worktree_path") or None,
                 now=now,
                 stale_minutes=stale_minutes,
+                check_worktree=check_worktree,
             )
             probe_detail = probe.detail
             if probe.is_likely_live:
@@ -884,11 +896,18 @@ def _load_recent_events(
     return events
 
 
-def aggregate_status(runtime_dir: Path | None = None) -> StatusReport:
+def aggregate_status(
+    runtime_dir: Path | None = None,
+    *,
+    check_worktree: bool = True,
+) -> StatusReport:
     """Build a unified status report across lanes, sessions, and tasks.
 
     Args:
         runtime_dir: Override for the runtime directory root.
+        check_worktree: If False, skip dirty-worktree subprocess probes
+            in the fallback liveness check.  Saves ~1 ``git status``
+            subprocess per idle lane (7+ with all protected worktrees).
 
     Returns:
         StatusReport with categorized entries and warnings.
@@ -928,6 +947,7 @@ def aggregate_status(runtime_dir: Path | None = None) -> StatusReport:
         sessions_by_lane,
         tasks_by_lane,
         events,
+        check_worktree=check_worktree,
     )
 
     # Session metadata files are preserved for resume/audit — they are

--- a/tests/unit/test_ops_status.py
+++ b/tests/unit/test_ops_status.py
@@ -1885,7 +1885,11 @@ class TestSynthesizeLaneActivityLiveness:
         assert lane.liveness_source == "registry"
 
     def test_blocked_lane_liveness_source(self) -> None:
-        """Blocked lane with session_id → liveness_source is 'registry'."""
+        """Blocked lane with session_id -> liveness_source is 'task_state'.
+
+        The state is determined by the blocked task, not the registry, so
+        liveness_source should reflect that (#1084 W2).
+        """
         lanes = [_make_lane("author-a", session_id="s1")]
         sessions = {"author-a": {"task": "Work", "started_at": "2026-03-20T12:00:00Z"}}
         tasks = {
@@ -1897,10 +1901,10 @@ class TestSynthesizeLaneActivityLiveness:
         result = synthesize_lane_activity(lanes, sessions, tasks, [])
         lane = result[0]
         assert lane.state == "blocked"
-        assert lane.liveness_source == "registry"
+        assert lane.liveness_source == "task_state"
 
     def test_blocked_lane_no_session_id(self) -> None:
-        """Blocked lane with no session_id -> liveness_source is None (#1106)."""
+        """Blocked lane with no session_id -> liveness_source is 'task_state' (#1084 W2)."""
         lanes = [_make_lane("author-a")]  # no session_id
         sessions: dict = {}  # no active session
         tasks = {
@@ -1912,7 +1916,7 @@ class TestSynthesizeLaneActivityLiveness:
         result = synthesize_lane_activity(lanes, sessions, tasks, [])
         lane = result[0]
         assert lane.state == "blocked"
-        assert lane.liveness_source is None
+        assert lane.liveness_source == "task_state"
         # Blocked lanes always need attention, even without session
         assert lane.attention_needed is True
 


### PR DESCRIPTION
## Plan
N/A — targeted bug fixes from #1101 and #1084.

## Summary
- Set `liveness_source="task_state"` for blocked lanes instead of conditionally `"registry"` or `None` (#1084 W2)
- Log `ImportError` at WARNING level in the dirty-worktree catch-all, keeping other exceptions at DEBUG (#1084 W3)
- Add `--no-probe` CLI flag to `ops status` and `ops health` to skip git-status subprocess probes (#1084 W1)

## Why
Blocked lanes reported misleading liveness_source ("registry" or None) when the state
was actually determined by task_state. The broad `except Exception` silently masked
`ImportError` at DEBUG level. And with 7+ protected worktrees, `aggregate_status()`
spawned unnecessary `git status` subprocesses for every idle lane.

Note: #1101 clock-skew (`max(0.0, ...)`) and stale-candidate priority (`stale_age`
tracking) were already fixed in prior PRs.

Closes #1101
Closes #1084

## Repro / Validation
**Command(s) run:**
```
uv run python -m pytest tests/unit/test_ops_status.py tests/unit/test_ops_cli.py -x -q
# 237 passed
uv run ruff check src/bid_euchre/ops/status.py scripts/internal/ops.py tests/unit/test_ops_status.py
uv run ruff format --check src/bid_euchre/ops/status.py scripts/internal/ops.py tests/unit/test_ops_status.py
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_status.py tests/unit/test_ops_cli.py -x -q` — 237 passed
- [x] Updated `test_blocked_lane_liveness_source` and `test_blocked_lane_no_session_id` to assert `"task_state"`

## Expected impact
- Metrics impact: None (ops tooling only)
- Runtime impact: `--no-probe` skips ~7 git subprocess invocations per status call

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                  e3d4487c [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b f3c2fcb5 [fix/ops-status-hardening]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)