### PR TITLE
feat: add review queue substrate with request/verdict models

### DIFF
--- a/src/bid_euchre/ops/events.py
+++ b/src/bid_euchre/ops/events.py
@@ -51,6 +51,8 @@ VALID_EVENT_TYPES = frozenset(
         "fs_boundary_violation",
         "fs_boundary_exception",
         "pr_comment_ingested",
+        "review_request",
+        "review_verdict",
     }
 )
 

--- a/src/bid_euchre/ops/review_queue.py
+++ b/src/bid_euchre/ops/review_queue.py
@@ -1,0 +1,436 @@
+"""Durable review-queue substrate keyed by PR + HEAD SHA.
+
+Provides request/verdict models, file-layout helpers, stale-verdict
+detection, and a deterministic precheck-to-blocked-verdict path.
+
+Storage layout::
+
+    .claude/runtime/review_queue/
+        pr_<N>/
+            request.json        -- current review request
+            verdict.json        -- latest verdict (may be stale)
+
+All files are JSON. The queue is append-friendly but not append-only:
+each PR slot holds exactly one request and one verdict at a time.
+Stale verdicts are detected by comparing the verdict's ``reviewed_sha``
+against the request's ``head_sha``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from bid_euchre.ops.events import append_event
+
+logger = logging.getLogger("ops.review_queue")
+
+DEFAULT_QUEUE_DIR = Path(".claude/runtime/review_queue")
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+# Verdict status values
+STATUS_PENDING = "pending"
+STATUS_RUNNING = "running"
+STATUS_PASSED = "passed"
+STATUS_BLOCKED = "blocked"
+STATUS_FAILED = "failed"
+
+VALID_STATUSES = frozenset(
+    {STATUS_PENDING, STATUS_RUNNING, STATUS_PASSED, STATUS_BLOCKED, STATUS_FAILED}
+)
+
+
+@dataclass(frozen=True)
+class ReviewRequest:
+    """A request for pre-merge review of a specific PR at a specific SHA.
+
+    Attributes:
+        pr_number: GitHub PR number.
+        head_sha: The commit SHA to review.
+        branch: Source branch name.
+        requester: Lane or agent that requested the review.
+        created_at: ISO 8601 timestamp of request creation.
+    """
+
+    pr_number: int
+    head_sha: str
+    branch: str
+    requester: str
+    created_at: str = field(default_factory=lambda: _now_iso())
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ReviewRequest:
+        return cls(
+            pr_number=int(data["pr_number"]),
+            head_sha=str(data["head_sha"]),
+            branch=str(data["branch"]),
+            requester=str(data["requester"]),
+            created_at=str(data.get("created_at", _now_iso())),
+        )
+
+
+@dataclass(frozen=True)
+class ReviewVerdict:
+    """A verdict for a review of a specific PR at a specific SHA.
+
+    Every verdict carries the SHA it reviewed, enabling deterministic
+    stale-verdict detection.
+
+    Attributes:
+        pr_number: GitHub PR number.
+        reviewed_sha: The commit SHA this verdict covers.
+        status: One of ``VALID_STATUSES``.
+        reason: Human-readable explanation.
+        findings: List of structured finding dicts (optional).
+        created_at: ISO 8601 timestamp of verdict creation.
+    """
+
+    pr_number: int
+    reviewed_sha: str
+    status: str
+    reason: str
+    findings: list[dict[str, Any]] = field(default_factory=list)
+    created_at: str = field(default_factory=lambda: _now_iso())
+
+    def __post_init__(self) -> None:
+        if self.status not in VALID_STATUSES:
+            raise ValueError(
+                f"Invalid verdict status {self.status!r}. "
+                f"Valid: {sorted(VALID_STATUSES)}"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ReviewVerdict:
+        return cls(
+            pr_number=int(data["pr_number"]),
+            reviewed_sha=str(data["reviewed_sha"]),
+            status=str(data["status"]),
+            reason=str(data["reason"]),
+            findings=list(data.get("findings", [])),
+            created_at=str(data.get("created_at", _now_iso())),
+        )
+
+
+# ---------------------------------------------------------------------------
+# File layout helpers
+# ---------------------------------------------------------------------------
+
+
+def pr_dir(pr_number: int, queue_dir: Path | None = None) -> Path:
+    """Return the directory for a PR's review queue slot.
+
+    Args:
+        pr_number: GitHub PR number.
+        queue_dir: Override for queue root. Defaults to ``DEFAULT_QUEUE_DIR``.
+
+    Returns:
+        Path like ``.claude/runtime/review_queue/pr_42``.
+    """
+    root = queue_dir or DEFAULT_QUEUE_DIR
+    return root / f"pr_{pr_number}"
+
+
+def request_path(pr_number: int, queue_dir: Path | None = None) -> Path:
+    """Return the path for a PR's request file."""
+    return pr_dir(pr_number, queue_dir) / "request.json"
+
+
+def verdict_path(pr_number: int, queue_dir: Path | None = None) -> Path:
+    """Return the path for a PR's verdict file."""
+    return pr_dir(pr_number, queue_dir) / "verdict.json"
+
+
+# ---------------------------------------------------------------------------
+# Read / write helpers
+# ---------------------------------------------------------------------------
+
+
+def write_request(
+    req: ReviewRequest,
+    queue_dir: Path | None = None,
+    *,
+    emit_event: bool = True,
+    events_dir: Path | None = None,
+) -> Path:
+    """Write a review request to disk and optionally emit an event.
+
+    Args:
+        req: The review request to persist.
+        queue_dir: Override for queue root directory.
+        emit_event: Whether to emit a ``review_request`` event.
+        events_dir: Override for events directory.
+
+    Returns:
+        The path where the request was written.
+    """
+    path = request_path(req.pr_number, queue_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(req.to_dict(), indent=2, sort_keys=True) + "\n")
+
+    if emit_event:
+        append_event(
+            event_type="review_request",
+            source="review_queue",
+            lane_id=req.requester,
+            payload={
+                "pr_number": req.pr_number,
+                "head_sha": req.head_sha,
+                "branch": req.branch,
+            },
+            events_dir=events_dir,
+        )
+
+    logger.info("Review request written: PR #%d @ %s", req.pr_number, req.head_sha)
+    return path
+
+
+def read_request(pr_number: int, queue_dir: Path | None = None) -> ReviewRequest | None:
+    """Read a review request from disk.
+
+    Returns:
+        The request, or ``None`` if no request file exists.
+    """
+    path = request_path(pr_number, queue_dir)
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text())
+    return ReviewRequest.from_dict(data)
+
+
+def write_verdict(
+    verdict: ReviewVerdict,
+    queue_dir: Path | None = None,
+    *,
+    emit_event: bool = True,
+    lane_id: str = "review",
+    events_dir: Path | None = None,
+) -> Path:
+    """Write a review verdict to disk and optionally emit an event.
+
+    Args:
+        verdict: The review verdict to persist.
+        queue_dir: Override for queue root directory.
+        emit_event: Whether to emit a ``review_verdict`` event.
+        lane_id: Lane identity for the event.
+        events_dir: Override for events directory.
+
+    Returns:
+        The path where the verdict was written.
+    """
+    path = verdict_path(verdict.pr_number, queue_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(verdict.to_dict(), indent=2, sort_keys=True) + "\n")
+
+    if emit_event:
+        append_event(
+            event_type="review_verdict",
+            source="review_queue",
+            lane_id=lane_id,
+            payload={
+                "pr_number": verdict.pr_number,
+                "reviewed_sha": verdict.reviewed_sha,
+                "status": verdict.status,
+                "reason": verdict.reason,
+                "n_findings": len(verdict.findings),
+            },
+            events_dir=events_dir,
+        )
+
+    logger.info(
+        "Review verdict written: PR #%d @ %s -> %s",
+        verdict.pr_number,
+        verdict.reviewed_sha,
+        verdict.status,
+    )
+    return path
+
+
+def read_verdict(pr_number: int, queue_dir: Path | None = None) -> ReviewVerdict | None:
+    """Read a review verdict from disk.
+
+    Returns:
+        The verdict, or ``None`` if no verdict file exists.
+    """
+    path = verdict_path(pr_number, queue_dir)
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text())
+    return ReviewVerdict.from_dict(data)
+
+
+# ---------------------------------------------------------------------------
+# Stale-verdict detection
+# ---------------------------------------------------------------------------
+
+
+def is_verdict_stale(
+    pr_number: int, current_head_sha: str, queue_dir: Path | None = None
+) -> bool:
+    """Check whether the stored verdict for a PR is stale.
+
+    A verdict is stale when its ``reviewed_sha`` does not match the
+    ``current_head_sha``. A missing verdict is not considered stale
+    (there's nothing to invalidate).
+
+    Args:
+        pr_number: GitHub PR number.
+        current_head_sha: The SHA currently at the PR's HEAD.
+        queue_dir: Override for queue root directory.
+
+    Returns:
+        ``True`` if a verdict exists and its SHA differs from
+        ``current_head_sha``. ``False`` otherwise.
+    """
+    verdict = read_verdict(pr_number, queue_dir)
+    if verdict is None:
+        return False
+    return verdict.reviewed_sha != current_head_sha
+
+
+def invalidate_stale_verdict(
+    pr_number: int, current_head_sha: str, queue_dir: Path | None = None
+) -> bool:
+    """Remove a verdict file if it is stale.
+
+    Args:
+        pr_number: GitHub PR number.
+        current_head_sha: The SHA currently at the PR's HEAD.
+        queue_dir: Override for queue root directory.
+
+    Returns:
+        ``True`` if a stale verdict was removed, ``False`` otherwise.
+    """
+    if not is_verdict_stale(pr_number, current_head_sha, queue_dir):
+        return False
+
+    path = verdict_path(pr_number, queue_dir)
+    path.unlink(missing_ok=True)
+    logger.info(
+        "Stale verdict removed for PR #%d (reviewed %s, current %s)",
+        pr_number,
+        "?",
+        current_head_sha,
+    )
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Deterministic precheck -> blocked verdict
+# ---------------------------------------------------------------------------
+
+# Precheck IDs aligned with the review gate definitions in
+# docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md and .claude/rules/deferred/60_review_gate.md.
+PRECHECK_IDS = frozenset({"C1", "C2", "C5", "N1", "N2", "N3", "T1", "X2", "X3"})
+
+
+@dataclass(frozen=True)
+class PrecheckFinding:
+    """A single deterministic precheck finding.
+
+    Attributes:
+        check_id: Precheck identifier (e.g., "C1", "X3").
+        severity: "BLOCK" or "WARN".
+        message: Human-readable description.
+        file: Optional file path.
+        line: Optional line number.
+    """
+
+    check_id: str
+    severity: str
+    message: str
+    file: str | None = None
+    line: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "check_id": self.check_id,
+            "severity": self.severity,
+            "message": self.message,
+        }
+        if self.file is not None:
+            d["file"] = self.file
+        if self.line is not None:
+            d["line"] = self.line
+        return d
+
+
+def precheck_to_verdict(
+    pr_number: int,
+    head_sha: str,
+    findings: list[PrecheckFinding],
+    queue_dir: Path | None = None,
+    *,
+    emit_event: bool = True,
+    lane_id: str = "review",
+    events_dir: Path | None = None,
+) -> ReviewVerdict:
+    """Convert deterministic precheck findings into a review verdict.
+
+    If any finding has severity ``"BLOCK"``, the verdict status is
+    ``"blocked"``. Otherwise it is ``"passed"``.
+
+    The verdict is written to disk and an event is emitted.
+
+    Args:
+        pr_number: GitHub PR number.
+        head_sha: The commit SHA that was prechecked.
+        findings: List of precheck findings.
+        queue_dir: Override for queue root directory.
+        emit_event: Whether to emit a ``review_verdict`` event.
+        lane_id: Lane identity for the event.
+        events_dir: Override for events directory.
+
+    Returns:
+        The created ``ReviewVerdict``.
+    """
+    blockers = [f for f in findings if f.severity == "BLOCK"]
+    has_blockers = len(blockers) > 0
+
+    status = STATUS_BLOCKED if has_blockers else STATUS_PASSED
+    if has_blockers:
+        reason = f"Deterministic precheck blocked: {len(blockers)} blocker(s) found"
+    elif findings:
+        reason = f"Deterministic precheck passed with {len(findings)} warning(s)"
+    else:
+        reason = "Deterministic precheck passed — clean"
+
+    verdict = ReviewVerdict(
+        pr_number=pr_number,
+        reviewed_sha=head_sha,
+        status=status,
+        reason=reason,
+        findings=[f.to_dict() for f in findings],
+    )
+
+    write_verdict(
+        verdict,
+        queue_dir,
+        emit_event=emit_event,
+        lane_id=lane_id,
+        events_dir=events_dir,
+    )
+
+    return verdict
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    """Return current UTC time as ISO 8601 string."""
+    return datetime.now(timezone.utc).isoformat()

--- a/tests/unit/test_review_queue.py
+++ b/tests/unit/test_review_queue.py
@@ -1,0 +1,475 @@
+"""Tests for the review queue substrate (request/verdict models, file layout, staleness)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bid_euchre.ops.review_queue import (
+    DEFAULT_QUEUE_DIR,
+    VALID_STATUSES,
+    PrecheckFinding,
+    ReviewRequest,
+    ReviewVerdict,
+    invalidate_stale_verdict,
+    is_verdict_stale,
+    pr_dir,
+    precheck_to_verdict,
+    read_request,
+    read_verdict,
+    request_path,
+    verdict_path,
+    write_request,
+    write_verdict,
+)
+
+# ---------------------------------------------------------------------------
+# Model round-trip tests
+# ---------------------------------------------------------------------------
+
+
+class TestReviewRequest:
+    def test_to_dict_round_trip(self) -> None:
+        req = ReviewRequest(
+            pr_number=42,
+            head_sha="abc123",
+            branch="feat/foo",
+            requester="author-a",
+            created_at="2026-03-20T00:00:00+00:00",
+        )
+        d = req.to_dict()
+        restored = ReviewRequest.from_dict(d)
+        assert restored == req
+
+    def test_from_dict_coerces_types(self) -> None:
+        """PR number should be coerced from string to int."""
+        d = {
+            "pr_number": "99",
+            "head_sha": "def456",
+            "branch": "fix/bar",
+            "requester": "review",
+        }
+        req = ReviewRequest.from_dict(d)
+        assert req.pr_number == 99
+        assert isinstance(req.pr_number, int)
+
+    def test_created_at_defaults(self) -> None:
+        req = ReviewRequest(
+            pr_number=1,
+            head_sha="aaa",
+            branch="main",
+            requester="test",
+        )
+        assert req.created_at  # Non-empty default
+
+
+class TestReviewVerdict:
+    def test_to_dict_round_trip(self) -> None:
+        verdict = ReviewVerdict(
+            pr_number=42,
+            reviewed_sha="abc123",
+            status="passed",
+            reason="All good",
+            findings=[{"check_id": "C1", "severity": "WARN", "message": "note"}],
+            created_at="2026-03-20T00:00:00+00:00",
+        )
+        d = verdict.to_dict()
+        restored = ReviewVerdict.from_dict(d)
+        assert restored == verdict
+
+    def test_invalid_status_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid verdict status"):
+            ReviewVerdict(
+                pr_number=1,
+                reviewed_sha="aaa",
+                status="invalid_status",
+                reason="test",
+            )
+
+    def test_all_valid_statuses_accepted(self) -> None:
+        for status in VALID_STATUSES:
+            v = ReviewVerdict(
+                pr_number=1,
+                reviewed_sha="aaa",
+                status=status,
+                reason="test",
+            )
+            assert v.status == status
+
+
+# ---------------------------------------------------------------------------
+# File layout tests
+# ---------------------------------------------------------------------------
+
+
+class TestFileLayout:
+    def test_pr_dir_default(self) -> None:
+        d = pr_dir(42)
+        assert d == DEFAULT_QUEUE_DIR / "pr_42"
+
+    def test_pr_dir_custom(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        custom = Path(str(tmp_path)) / "custom"
+        d = pr_dir(99, custom)
+        assert d == custom / "pr_99"
+
+    def test_request_path(self) -> None:
+        p = request_path(42)
+        assert p.name == "request.json"
+        assert p.parent == pr_dir(42)
+
+    def test_verdict_path(self) -> None:
+        p = verdict_path(42)
+        assert p.name == "verdict.json"
+        assert p.parent == pr_dir(42)
+
+
+# ---------------------------------------------------------------------------
+# Read / write round-trip tests
+# ---------------------------------------------------------------------------
+
+
+class TestRequestReadWrite:
+    def test_write_and_read_request(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        queue_dir = Path(str(tmp_path)) / "queue"
+        events_dir = Path(str(tmp_path)) / "events"
+
+        req = ReviewRequest(
+            pr_number=42,
+            head_sha="abc123def",
+            branch="feat/review-queue",
+            requester="author-a",
+        )
+        path = write_request(req, queue_dir, emit_event=True, events_dir=events_dir)
+        assert path.exists()
+
+        # Verify JSON is well-formed
+        data = json.loads(path.read_text())
+        assert data["pr_number"] == 42
+        assert data["head_sha"] == "abc123def"
+
+        # Round-trip
+        restored = read_request(42, queue_dir)
+        assert restored is not None
+        assert restored.pr_number == req.pr_number
+        assert restored.head_sha == req.head_sha
+        assert restored.branch == req.branch
+        assert restored.requester == req.requester
+
+    def test_read_missing_request_returns_none(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        queue_dir = Path(str(tmp_path)) / "queue"
+        assert read_request(999, queue_dir) is None
+
+    def test_write_request_emits_event(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        from bid_euchre.ops.events import read_events
+
+        queue_dir = Path(str(tmp_path)) / "queue"
+        events_dir = Path(str(tmp_path)) / "events"
+
+        req = ReviewRequest(
+            pr_number=77,
+            head_sha="sha777",
+            branch="feat/test",
+            requester="author-b",
+        )
+        write_request(req, queue_dir, emit_event=True, events_dir=events_dir)
+
+        events = read_events(events_dir, event_type="review_request")
+        assert len(events) == 1
+        assert events[0]["payload"]["pr_number"] == 77
+        assert events[0]["payload"]["head_sha"] == "sha777"
+        assert events[0]["lane_id"] == "author-b"
+
+    def test_write_request_no_event(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        from bid_euchre.ops.events import read_events
+
+        queue_dir = Path(str(tmp_path)) / "queue"
+        events_dir = Path(str(tmp_path)) / "events"
+
+        req = ReviewRequest(
+            pr_number=88,
+            head_sha="sha888",
+            branch="feat/quiet",
+            requester="review",
+        )
+        write_request(req, queue_dir, emit_event=False, events_dir=events_dir)
+
+        events = read_events(events_dir, event_type="review_request")
+        assert len(events) == 0
+
+
+class TestVerdictReadWrite:
+    def test_write_and_read_verdict(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        queue_dir = Path(str(tmp_path)) / "queue"
+        events_dir = Path(str(tmp_path)) / "events"
+
+        verdict = ReviewVerdict(
+            pr_number=42,
+            reviewed_sha="abc123def",
+            status="passed",
+            reason="Clean review",
+            findings=[],
+        )
+        path = write_verdict(verdict, queue_dir, emit_event=True, events_dir=events_dir)
+        assert path.exists()
+
+        restored = read_verdict(42, queue_dir)
+        assert restored is not None
+        assert restored.pr_number == verdict.pr_number
+        assert restored.reviewed_sha == verdict.reviewed_sha
+        assert restored.status == verdict.status
+        assert restored.reason == verdict.reason
+
+    def test_read_missing_verdict_returns_none(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        queue_dir = Path(str(tmp_path)) / "queue"
+        assert read_verdict(999, queue_dir) is None
+
+    def test_write_verdict_emits_event(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        from bid_euchre.ops.events import read_events
+
+        queue_dir = Path(str(tmp_path)) / "queue"
+        events_dir = Path(str(tmp_path)) / "events"
+
+        verdict = ReviewVerdict(
+            pr_number=42,
+            reviewed_sha="sha42",
+            status="blocked",
+            reason="Blocker found",
+            findings=[{"check_id": "C1", "severity": "BLOCK", "message": "unseeded"}],
+        )
+        write_verdict(
+            verdict,
+            queue_dir,
+            emit_event=True,
+            lane_id="review",
+            events_dir=events_dir,
+        )
+
+        events = read_events(events_dir, event_type="review_verdict")
+        assert len(events) == 1
+        assert events[0]["payload"]["status"] == "blocked"
+        assert events[0]["payload"]["n_findings"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Stale verdict detection
+# ---------------------------------------------------------------------------
+
+
+class TestStaleVerdict:
+    def _write_verdict_at_sha(self, tmp_path: object, pr_number: int, sha: str) -> None:
+        from pathlib import Path
+
+        queue_dir = Path(str(tmp_path)) / "queue"
+        events_dir = Path(str(tmp_path)) / "events"
+        verdict = ReviewVerdict(
+            pr_number=pr_number,
+            reviewed_sha=sha,
+            status="passed",
+            reason="test",
+        )
+        write_verdict(verdict, queue_dir, emit_event=False, events_dir=events_dir)
+
+    def test_stale_when_sha_differs(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        queue_dir = Path(str(tmp_path)) / "queue"
+        self._write_verdict_at_sha(tmp_path, 42, "old_sha")
+        assert is_verdict_stale(42, "new_sha", queue_dir) is True
+
+    def test_not_stale_when_sha_matches(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        queue_dir = Path(str(tmp_path)) / "queue"
+        self._write_verdict_at_sha(tmp_path, 42, "same_sha")
+        assert is_verdict_stale(42, "same_sha", queue_dir) is False
+
+    def test_not_stale_when_no_verdict(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        queue_dir = Path(str(tmp_path)) / "queue"
+        assert is_verdict_stale(42, "any_sha", queue_dir) is False
+
+    def test_invalidate_removes_stale_verdict(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        queue_dir = Path(str(tmp_path)) / "queue"
+        self._write_verdict_at_sha(tmp_path, 42, "old_sha")
+
+        removed = invalidate_stale_verdict(42, "new_sha", queue_dir)
+        assert removed is True
+        assert read_verdict(42, queue_dir) is None
+
+    def test_invalidate_keeps_fresh_verdict(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        queue_dir = Path(str(tmp_path)) / "queue"
+        self._write_verdict_at_sha(tmp_path, 42, "current_sha")
+
+        removed = invalidate_stale_verdict(42, "current_sha", queue_dir)
+        assert removed is False
+        assert read_verdict(42, queue_dir) is not None
+
+
+# ---------------------------------------------------------------------------
+# Deterministic precheck -> blocked verdict
+# ---------------------------------------------------------------------------
+
+
+class TestPrecheckToVerdict:
+    def test_blocker_creates_blocked_verdict(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        queue_dir = Path(str(tmp_path)) / "queue"
+        events_dir = Path(str(tmp_path)) / "events"
+
+        findings = [
+            PrecheckFinding(
+                check_id="C1",
+                severity="BLOCK",
+                message="Unseeded randomness in strategy.py",
+                file="src/bid_euchre/strategy/foo.py",
+                line=42,
+            ),
+        ]
+        verdict = precheck_to_verdict(
+            pr_number=99,
+            head_sha="sha_precheck",
+            findings=findings,
+            queue_dir=queue_dir,
+            emit_event=True,
+            events_dir=events_dir,
+        )
+
+        assert verdict.status == "blocked"
+        assert "1 blocker" in verdict.reason
+        assert verdict.reviewed_sha == "sha_precheck"
+        assert len(verdict.findings) == 1
+        assert verdict.findings[0]["check_id"] == "C1"
+
+        # Verify persisted
+        persisted = read_verdict(99, queue_dir)
+        assert persisted is not None
+        assert persisted.status == "blocked"
+
+    def test_warn_only_creates_passed_verdict(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        queue_dir = Path(str(tmp_path)) / "queue"
+        events_dir = Path(str(tmp_path)) / "events"
+
+        findings = [
+            PrecheckFinding(
+                check_id="N1",
+                severity="WARN",
+                message="Missing contract-type facet",
+            ),
+            PrecheckFinding(
+                check_id="T1",
+                severity="WARN",
+                message="Untested behavior change",
+            ),
+        ]
+        verdict = precheck_to_verdict(
+            pr_number=100,
+            head_sha="sha_warn",
+            findings=findings,
+            queue_dir=queue_dir,
+            emit_event=False,
+            events_dir=events_dir,
+        )
+
+        assert verdict.status == "passed"
+        assert "2 warning" in verdict.reason
+
+    def test_no_findings_creates_clean_passed_verdict(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        queue_dir = Path(str(tmp_path)) / "queue"
+        events_dir = Path(str(tmp_path)) / "events"
+
+        verdict = precheck_to_verdict(
+            pr_number=101,
+            head_sha="sha_clean",
+            findings=[],
+            queue_dir=queue_dir,
+            emit_event=False,
+            events_dir=events_dir,
+        )
+
+        assert verdict.status == "passed"
+        assert "clean" in verdict.reason
+        assert verdict.findings == []
+
+    def test_mixed_block_and_warn(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        queue_dir = Path(str(tmp_path)) / "queue"
+        events_dir = Path(str(tmp_path)) / "events"
+
+        findings = [
+            PrecheckFinding(
+                check_id="X3",
+                severity="BLOCK",
+                message="Merge conflict markers",
+            ),
+            PrecheckFinding(
+                check_id="N2",
+                severity="WARN",
+                message="Collapsed matchup table",
+            ),
+            PrecheckFinding(
+                check_id="C1",
+                severity="BLOCK",
+                message="Unseeded randomness",
+            ),
+        ]
+        verdict = precheck_to_verdict(
+            pr_number=102,
+            head_sha="sha_mixed",
+            findings=findings,
+            queue_dir=queue_dir,
+            emit_event=False,
+            events_dir=events_dir,
+        )
+
+        assert verdict.status == "blocked"
+        assert "2 blocker" in verdict.reason
+        assert len(verdict.findings) == 3
+
+
+class TestPrecheckFinding:
+    def test_to_dict_minimal(self) -> None:
+        f = PrecheckFinding(check_id="C1", severity="BLOCK", message="test")
+        d = f.to_dict()
+        assert d == {"check_id": "C1", "severity": "BLOCK", "message": "test"}
+        assert "file" not in d
+        assert "line" not in d
+
+    def test_to_dict_with_location(self) -> None:
+        f = PrecheckFinding(
+            check_id="X3",
+            severity="BLOCK",
+            message="conflict markers",
+            file="src/foo.py",
+            line=10,
+        )
+        d = f.to_dict()
+        assert d["file"] == "src/foo.py"
+        assert d["line"] == 10


### PR DESCRIPTION
## Plan
`plans/sessions/2026-03-20_pre-merge-review-redesign-author-a-handoff.md` — PR1: Queue Foundations

## Summary
- Add `src/bid_euchre/ops/review_queue.py` — durable packet substrate keyed by PR + HEAD SHA
- Add `review_request` and `review_verdict` event types to `events.py`
- Add 28 unit tests covering all code paths

## Why
First building block for the pre-merge review redesign. Provides the shared
contract for review requests and verdicts, file layout helpers, stale-verdict
detection (SHA-based), and deterministic precheck→blocked verdict path.

## Models & API

**ReviewRequest** — frozen dataclass: `pr_number`, `head_sha`, `branch`, `requester`, `created_at`
**ReviewVerdict** — frozen dataclass: `pr_number`, `reviewed_sha`, `status`, `reason`, `findings`, `created_at`
**PrecheckFinding** — frozen dataclass: `check_id`, `severity`, `message`, `file?`, `line?`

Key functions:
- `write_request()` / `read_request()` — persist/load request JSON
- `write_verdict()` / `read_verdict()` — persist/load verdict JSON
- `is_verdict_stale()` / `invalidate_stale_verdict()` — SHA-based staleness
- `precheck_to_verdict()` — deterministic precheck findings → blocked/passed verdict

Storage: `.claude/runtime/review_queue/pr_<N>/` with `request.json` and `verdict.json`

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_review_queue.py -v  # 28/28 passed
make check-quiet  # All checks passed
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_review_queue.py -v` (28 passed)
- [x] `make check-quiet` (full validation passed)

## Test Coverage
- Model round-trip (to_dict/from_dict) for Request and Verdict
- Type coercion (string PR number → int)
- Status validation (invalid status raises ValueError)
- File layout helpers (default + custom queue dirs)
- Request write/read round-trip with event emission
- Verdict write/read round-trip with event emission
- Stale verdict detection (SHA match/mismatch/missing)
- Stale verdict invalidation (removes file)
- Precheck→verdict: blocker→blocked, warn-only→passed, clean→passed, mixed→blocked
- PrecheckFinding serialization (minimal and with location)

## Expected impact
- Metrics impact: None (ops infrastructure only)
- Runtime impact: None (new module, no existing callers)

## Risk level
Low — new module with no callers yet. Additive only.

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: feat/review-queue-foundations
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)