### PR TITLE
fix: address 3 blocking review findings in review_queue

### DIFF
--- a/src/bid_euchre/ops/review_queue.py
+++ b/src/bid_euchre/ops/review_queue.py
@@ -313,15 +313,19 @@ def invalidate_stale_verdict(
     Returns:
         ``True`` if a stale verdict was removed, ``False`` otherwise.
     """
-    if not is_verdict_stale(pr_number, current_head_sha, queue_dir):
+    verdict = read_verdict(pr_number, queue_dir)
+    if verdict is None:
+        return False
+    if verdict.reviewed_sha == current_head_sha:
         return False
 
+    stale_sha = verdict.reviewed_sha
     path = verdict_path(pr_number, queue_dir)
     path.unlink(missing_ok=True)
     logger.info(
         "Stale verdict removed for PR #%d (reviewed %s, current %s)",
         pr_number,
-        "?",
+        stale_sha,
         current_head_sha,
     )
     return True
@@ -333,7 +337,7 @@ def invalidate_stale_verdict(
 
 # Precheck IDs aligned with the review gate definitions in
 # docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md and .claude/rules/deferred/60_review_gate.md.
-PRECHECK_IDS = frozenset({"C1", "C2", "C5", "N1", "N2", "N3", "T1", "X2", "X3"})
+PRECHECK_IDS = frozenset({"C1", "C2", "N1", "N2", "N3", "T1", "X2", "X3"})
 
 
 @dataclass(frozen=True)
@@ -365,6 +369,16 @@ class PrecheckFinding:
         if self.line is not None:
             d["line"] = self.line
         return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PrecheckFinding:
+        return cls(
+            check_id=str(data["check_id"]),
+            severity=str(data["severity"]),
+            message=str(data["message"]),
+            file=data.get("file"),
+            line=data.get("line"),
+        )
 
 
 def precheck_to_verdict(

--- a/tests/unit/test_review_queue.py
+++ b/tests/unit/test_review_queue.py
@@ -473,3 +473,22 @@ class TestPrecheckFinding:
         d = f.to_dict()
         assert d["file"] == "src/foo.py"
         assert d["line"] == 10
+
+    def test_from_dict_round_trip(self) -> None:
+        f = PrecheckFinding(
+            check_id="C1",
+            severity="BLOCK",
+            message="unseeded randomness",
+            file="src/strategy.py",
+            line=42,
+        )
+        d = f.to_dict()
+        restored = PrecheckFinding.from_dict(d)
+        assert restored == f
+
+    def test_from_dict_minimal(self) -> None:
+        d = {"check_id": "N1", "severity": "WARN", "message": "missing facet"}
+        f = PrecheckFinding.from_dict(d)
+        assert f.check_id == "N1"
+        assert f.file is None
+        assert f.line is None


### PR DESCRIPTION
## Plan
Follow-up to PR #1176 review findings.

## Summary
- Remove phantom C5 from PRECHECK_IDS (no C5 check exists in the codebase)
- Add `PrecheckFinding.from_dict()` classmethod for symmetric serialization contract
- Fix `invalidate_stale_verdict` to log actual stale SHA instead of `"?"`

## Why
PR #1176 auto-merged before 3 blocking review findings could be addressed.
This follow-up corrects a contract error (phantom C5), an API asymmetry
(missing `from_dict`), and an operational debuggability gap (lost SHA in log).

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_review_queue.py -v  # 30/30 passed
make check-quiet  # All checks passed
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_review_queue.py -v` (30 passed, +2 new)
- [x] `make check-quiet` (full validation passed)

## Expected impact
- Metrics impact: None (ops infrastructure only)
- Runtime impact: None (no existing callers)

## Risk level
Low — fixes to a new module with no callers yet. Purely corrective.

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: fix/review-queue-blocking-findings
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)