### PR TITLE
ops: cleanup control-plane startup and runtime hygiene before Platform-1

### DIFF
--- a/docs/02_agent/PLATFORM_ENTRY_CHECKLIST.md
+++ b/docs/02_agent/PLATFORM_ENTRY_CHECKLIST.md
@@ -58,6 +58,9 @@
   - issue-driven execution with explicit stop rules
 - [x] Deterministic precheck hardening shipped (#1126, #1132)
   - string-literal masking for C5/T1 checks
+- [x] Control-plane startup decoupled from research imports
+  - `bid_euchre.__init__` uses lazy `__getattr__` for experiments subpackage
+  - ops entrypoints no longer pay strategy/ML import cost
 
 ## 6. Intentionally Deferred to Platform-1 or Later
 

--- a/plans/agent_ops/0_bootstrap/checkpoints.md
+++ b/plans/agent_ops/0_bootstrap/checkpoints.md
@@ -2,7 +2,7 @@
 
 **Governing plan:** `plans/agent_ops/governing_plan.md`
 **Phase/Rung:** `0_bootstrap`
-**Last updated:** 2026-03-21 by author-b
+**Last updated:** 2026-03-21 by Opus
 
 ---
 
@@ -21,6 +21,7 @@
 
 | Sub-Plan ID | File | Status | Blocking Step |
 |-------------|------|--------|---------------|
+| SP-0-02 | `plans/agent_ops/0_bootstrap/sub/2026-03-20_platform1-prep-pr-handoff.md` | in_progress | -- (non-blocking) |
 
 ## Blockers
 
@@ -99,3 +100,13 @@
 - Step 3 (Platform-1 handoff) is now unblocked.
 - PR #1140 superseded by this reconciliation; #1141 confirmed duplicate
   of #1138 (already closed).
+
+### 2026-03-21 -- Opus (SP-0-02: control-plane cleanup)
+- Executing SP-0-02 (Platform-1 prep PR handoff).
+- Made `bid_euchre.__init__` import-light: replaced eager `from . import experiments`
+  with lazy `__getattr__` — ops entrypoints no longer import strategy/ML tree.
+- Reduced runtime hygiene noise: protected steward worktrees no longer appear
+  as "unknown" cleanup candidates when unregistered. Added regression test.
+- Reconciled entry checklist with control-plane cleanup.
+- SP-0-01 remains superseded; SP-0-02 is the active plan.
+- No new Platform-1 blockers discovered.

--- a/plans/agent_ops/0_bootstrap/sub/2026-03-20_platform-entry-hardening.md
+++ b/plans/agent_ops/0_bootstrap/sub/2026-03-20_platform-entry-hardening.md
@@ -1,0 +1,77 @@
+# Phase 0 Bridge Hardening For Platform-1 Entry
+
+**ID:** SP-0-01
+**Date:** 2026-03-20
+**Parent:** `plans/agent_ops/governing_plan.md` -- Phase 0 dependencies (§4.3), entry criteria (§PR Roadmap / Entry criteria), `Platform-1` done-when (§Handoff-Friendly Slice Definitions)
+**Status:** superseded
+**Owner:** Codex
+
+---
+
+## Inputs
+
+- Input 1: `plans/agent_ops/governing_plan.md` -- canonical Phase 0 gate, preferred tooling contract, and `Platform-1` readiness criteria.
+- Input 2: `docs/02_agent/PLATFORM_ENTRY_CHECKLIST.md` -- operator-facing bridge gate.
+- Input 3: `plans/agent_ops/0_bootstrap/checkpoints.md` -- bootstrap state and blocker log.
+- Input 4: `plans/sessions/2026-03-20_post-pr5-bridge-controls-and-review-surfaces.md` -- bounded bridge decisions and prior write-scope guidance.
+- Input 5: `scripts/internal/ops.py`, `src/bid_euchre/ops/reviews.py`, `src/bid_euchre/ops/index.py`, `src/bid_euchre/ops/status.py`, `src/bid_euchre/__init__.py`, `pyproject.toml` -- originally identified code surfaces.
+
+## Assumptions
+
+- This was written before the bridge gate had been fully reconciled.
+- Later shipped work closed most of the intended scope, making the remaining delta too small and too different to justify this original plan unchanged.
+
+## Dependencies
+
+- Phase 0 Step 2 (`plans/agent_ops/0_bootstrap/checkpoints.md`) -- complete.
+- PR-5 closeout -- complete.
+
+## Plan
+
+This plan is no longer the active execution plan.
+
+Its broad scope has been replaced by the narrower cleanup plan in:
+
+- `plans/agent_ops/0_bootstrap/sub/2026-03-20_platform1-prep-pr-handoff.md`
+
+## Files Changed
+
+- Superseded by `SP-0-02`; see that sub-plan for the active write scope.
+
+## Validation
+
+- Superseded; validation moved to `SP-0-02`.
+
+## Planned Outputs
+
+- Superseded; outputs moved to `SP-0-02`.
+
+## Observed Outputs
+
+_Filled during/after execution._
+
+- Review-surface bridge work and related hardening were largely shipped by follow-on merged work after this plan was drafted.
+- The remaining non-blocking delta was narrowed to control-plane cleanup rather than bridge-gate closure.
+
+## Outcome
+
+- Status: superseded
+- PR: --
+- Deviations from plan:
+  - original scope assumed the review-surface bridge and related Phase 0 hardening were still materially open
+  - later merged work appears to have closed most of that scope, leaving only smaller cleanup items
+- Issues discovered:
+  - keeping this broader plan active would overstate remaining work and blur the distinction between bridge-gate closure and non-blocking cleanup
+- Superseded by:
+  - `SP-0-02` -- `plans/agent_ops/0_bootstrap/sub/2026-03-20_platform1-prep-pr-handoff.md`
+
+## Handoff
+
+- Current state: do not execute this plan as written.
+- Next action: use `SP-0-02` as the active handoff for the prep PR.
+- Blockers: none.
+- Files with uncommitted changes:
+  - `plans/agent_ops/0_bootstrap/sub/2026-03-20_platform-entry-hardening.md`
+  - `plans/agent_ops/0_bootstrap/sub/2026-03-20_platform1-prep-pr-handoff.md`
+  - `plans/agent_ops/sub_plan_registry.md`
+  - `plans/agent_ops/0_bootstrap/checkpoints.md`

--- a/plans/agent_ops/0_bootstrap/sub/2026-03-20_platform1-prep-pr-handoff.md
+++ b/plans/agent_ops/0_bootstrap/sub/2026-03-20_platform1-prep-pr-handoff.md
@@ -1,0 +1,132 @@
+# Platform-1 Prep PR Handoff
+
+**ID:** SP-0-02
+**Date:** 2026-03-20
+**Parent:** `plans/agent_ops/governing_plan.md` -- Phase 0 dependencies (§4.3) and `Platform-1` handoff boundary
+**Status:** in_progress
+**Owner:** Opus
+
+---
+
+## Inputs
+
+- Input 1: `plans/agent_ops/governing_plan.md` -- canonical initiative scope and the boundary between Phase 0 cleanup and actual `Platform-1` work.
+- Input 2: `plans/agent_ops/0_bootstrap/checkpoints.md` -- bootstrap progress log and current phase context.
+- Input 3: `plans/agent_ops/sub_plan_registry.md` -- active sub-plan index.
+- Input 4: `plans/agent_ops/0_bootstrap/sub/2026-03-20_platform-entry-hardening.md` -- superseded broad plan; keep only the residual cleanup insights.
+- Input 5: `docs/02_agent/PLATFORM_ENTRY_CHECKLIST.md` -- operator checklist that still needs reconciliation to current shipped behavior.
+- Input 6: `scripts/internal/ops.py` -- CLI entrypoint for status/health/worktree/index surfaces.
+- Input 7: `src/bid_euchre/__init__.py` -- current package import side effects.
+- Input 8: `src/bid_euchre/ops/status.py` and `src/bid_euchre/ops/worktrees.py` -- runtime health, lane summaries, and worktree hygiene surfaces.
+- Input 9: `tests/unit/test_ops_cli.py`, `tests/unit/test_ops_status.py`, `tests/unit/test_ops_worktrees.py` -- existing regression coverage for the prep-PR scope.
+
+## Assumptions
+
+- Treat `Platform-1` as **unblocked** for planning purposes; this PR is cleanup and reconciliation, not a gate-closure PR.
+- Do **not** reopen review-surface bridge work, merge-truth design, or broader pre-Platform-1 debates inside this slice.
+- The only substantive code-prep items left are:
+  - import-light / lazy startup cleanup for ops entrypoints
+  - runtime hygiene cleanup for worktree/health noise
+  - docs/checkpoint reconciliation so Phase 0 durable state matches current reality
+- If the work reveals a concrete, still-open blocker to `Platform-1`, record it precisely and stop broadening scope.
+
+## Dependencies
+
+- `SP-0-01` -- superseded; this plan inherits only its residual cleanup items.
+- No additional bridge PR is required before this prep PR.
+
+## Plan
+
+### Step 1: Make the ops/control-plane import path lighter
+- Reduce startup coupling from `scripts/internal/ops.py` into the full research package.
+- Prefer the smallest safe fix:
+  - make `src/bid_euchre/__init__.py` import-light or lazy
+  - keep package-level behavior stable for current consumers
+- Goal: ops entrypoints should not pay unnecessary experiments/strategy import cost before reaching control-plane code.
+
+### Step 2: Clean up runtime hygiene surfaced by `ops.py health`
+- Reconcile or prune the currently unregistered worktrees that make health output noisy.
+- Tighten any obviously misleading health/status messaging only if the change is narrow and directly tied to cleanup.
+- Do not reopen larger lane-state semantics unless a concrete low-risk fix is required by the cleanup.
+
+### Step 3: Reconcile durable docs/checkpoints with current Platform-1 posture
+- Update bootstrap durable state so it no longer implies the bridge gate is still blocked if the shipped repo state says otherwise.
+- Mark `SP-0-01` as superseded and keep `SP-0-02` explicitly non-blocking.
+- Update the operator-facing checklist and checkpoint log only to reflect current shipped reality, not to redesign the roadmap.
+
+### Step 4: Ship one focused prep PR
+- Keep this as a single-concept PR: control-plane cleanup before/alongside `Platform-1`.
+- Avoid bundling actual `Platform-1` implementation, message-bus design, or new orchestration capabilities.
+
+## Files Changed
+
+- `src/bid_euchre/__init__.py` -- import-light / lazy package initialization for ops-friendly startup.
+- `scripts/internal/ops.py` -- only if needed for startup path, health wording, or narrow cleanup plumbing.
+- `src/bid_euchre/ops/worktrees.py` -- only if needed for bounded worktree hygiene or status cleanup.
+- `src/bid_euchre/ops/status.py` -- only if a minimal cleanup-related adjustment is needed.
+- `docs/02_agent/PLATFORM_ENTRY_CHECKLIST.md` -- reconcile checklist text/status with current shipped state.
+- `plans/agent_ops/0_bootstrap/checkpoints.md` -- record the supersession and current non-blocking prep scope.
+- `plans/agent_ops/sub_plan_registry.md` -- update sub-plan statuses.
+- `tests/unit/test_ops_cli.py` -- regression coverage for prep-PR behavior.
+- `tests/unit/test_ops_status.py` -- regression coverage if status semantics change.
+- `tests/unit/test_ops_worktrees.py` -- regression coverage if cleanup logic changes.
+
+## Validation
+
+- [ ] Targeted tests: `uv run pytest -q tests/unit/test_ops_cli.py tests/unit/test_ops_status.py tests/unit/test_ops_worktrees.py`
+- [ ] Startup smoke: `uv run python scripts/internal/ops.py --json status`
+- [ ] Health smoke: `uv run python scripts/internal/ops.py --json health`
+- [ ] Worktree smoke: `uv run python scripts/internal/ops.py --json worktrees`
+- [ ] Final repo validation: `make check-quiet`
+
+## Planned Outputs
+
+- One focused prep PR that leaves the control plane cleaner ahead of `Platform-1`.
+- Reduced ops startup coupling from package import side effects.
+- Cleaner runtime health/worktree surface with fewer stale or distracting warnings.
+- Durable docs/checkpoints that show `Platform-1` as unblocked and this work as non-blocking cleanup.
+
+## Observed Outputs
+
+_Filled during/after execution._
+
+- Output 1: --
+- Output 2: --
+
+## Outcome
+
+_Filled after completion._
+
+- Status: proposed
+- PR: --
+- Deviations from plan: --
+- Issues discovered: --
+
+## Handoff
+
+- Current state: this is the active prep-PR handoff. `SP-0-01` is superseded and should not be used for execution.
+- Next action:
+  1. Refresh `plans/agent_ops/governing_plan.md`, `plans/agent_ops/0_bootstrap/checkpoints.md`, this sub-plan, and the superseded `SP-0-01`.
+  2. Draft/refine the concrete execution plan for this narrow PR.
+  3. Spawn at least one reviewer agent to review that execution plan before major edits.
+  4. Build a task list covering implementation, validation, and PR shipment.
+  5. Assess safe parallelism and only delegate disjoint write scopes.
+  6. Execute end to end autonomously:
+     - implement
+     - test
+     - run smoke/failure-injection validation
+     - commit
+     - open or update the PR
+     - include validation evidence in the PR body
+- Suggested PR title:
+  - `ops: cleanup control-plane startup and runtime hygiene before Platform-1`
+- Suggested PR body focus:
+  - import-light ops startup
+  - worktree/health cleanup
+  - Phase 0 checklist/checkpoint reconciliation
+- Blockers: none recorded; if a real `Platform-1` blocker appears, record it precisely instead of expanding this PR.
+- Files with uncommitted changes:
+  - `plans/agent_ops/0_bootstrap/sub/2026-03-20_platform-entry-hardening.md`
+  - `plans/agent_ops/0_bootstrap/sub/2026-03-20_platform1-prep-pr-handoff.md`
+  - `plans/agent_ops/sub_plan_registry.md`
+  - `plans/agent_ops/0_bootstrap/checkpoints.md`

--- a/plans/agent_ops/sub_plan_registry.md
+++ b/plans/agent_ops/sub_plan_registry.md
@@ -1,7 +1,7 @@
 # Sub-Plan Registry — Agentic Orchestration Platform
 
 **Governing plan:** `plans/agent_ops/governing_plan.md`
-**Last updated:** 2026-03-19
+**Last updated:** 2026-03-21
 
 ---
 
@@ -9,17 +9,19 @@
 
 | ID | Title | Parent Section | Status | Owner | File | Created | Completed |
 |----|-------|----------------|--------|-------|------|---------|-----------|
+| SP-0-01 | Phase 0 bridge hardening for Platform-1 entry | Phase 0 dependencies; entry criteria; `Platform-1` done-when | superseded | Codex | `plans/agent_ops/0_bootstrap/sub/2026-03-20_platform-entry-hardening.md` | 2026-03-20 | 2026-03-20 |
+| SP-0-02 | Platform-1 prep PR handoff | Phase 0 dependencies and `Platform-1` handoff boundary | in_progress | Opus | `plans/agent_ops/0_bootstrap/sub/2026-03-20_platform1-prep-pr-handoff.md` | 2026-03-20 | -- |
 
 ## Status Summary
 
 | Status | Count |
 |--------|-------|
 | proposed | 0 |
-| in_progress | 0 |
+| in_progress | 1 |
 | blocked | 0 |
 | completed | 0 |
 | abandoned | 0 |
-| superseded | 0 |
+| superseded | 1 |
 
 ## Conventions
 

--- a/src/bid_euchre/__init__.py
+++ b/src/bid_euchre/__init__.py
@@ -5,12 +5,22 @@ A comprehensive framework for simulating and analyzing the card game Bid Euchre
 with various AI strategies and experimental configurations.
 """
 
-try:
-    from . import experiments
-    HAS_EXPERIMENTS = True
-    __all__ = ["experiments"]
-except ImportError:
-    HAS_EXPERIMENTS = False
-    __all__ = []
-
 __version__ = "0.1.0"
+
+
+def __getattr__(name: str):
+    """Lazy subpackage import — avoids eager strategy/ML imports on package load.
+
+    ``bid_euchre.experiments`` transitively imports the full strategy tree
+    (all bidder implementations, ML models, config parsing, etc.).  Deferring
+    this import means that lightweight consumers such as ``bid_euchre.ops.*``
+    and ``scripts/internal/ops.py`` do not pay the startup cost.
+
+    The lazy import is transparent: ``from bid_euchre import experiments`` and
+    ``import bid_euchre; bid_euchre.experiments`` both work as before.
+    """
+    if name == "experiments":
+        from . import experiments  # noqa: F811
+
+        return experiments
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/bid_euchre/ops/worktrees.py
+++ b/src/bid_euchre/ops/worktrees.py
@@ -399,19 +399,20 @@ def classify_cleanup_candidates(
         # is never a cleanup target.
         if is_main_worktree(git_wt.path):
             continue
-        protected = is_protected(git_wt.path)
+        # Skip protected steward worktrees — they are permanent lane
+        # infrastructure, not cleanup candidates, even when unregistered.
+        if is_protected(git_wt.path):
+            continue
         dirty = is_worktree_dirty(git_wt.path) if check_dirty else False
         candidates.append(
             CleanupCandidate(
                 path=git_wt.path,
                 branch=git_wt.branch,
                 lifecycle_class="unknown",
-                cleanup_state="idle" if not protected else "active",
-                reason="Not in worktree registry"
-                if not protected
-                else "Protected worktree (unregistered)",
+                cleanup_state="idle",
+                reason="Not in worktree registry",
                 is_dirty=dirty,
-                is_protected=protected,
+                is_protected=False,
             )
         )
 

--- a/tests/unit/test_ops_worktrees.py
+++ b/tests/unit/test_ops_worktrees.py
@@ -362,6 +362,19 @@ class TestClassifyCleanupCandidates:
         # Persistent + protected → no candidate
         assert len(candidates) == 0
 
+    def test_protected_unregistered_worktree_skipped(self) -> None:
+        """Protected steward worktrees are not cleanup candidates even when unregistered."""
+        now = datetime(2026, 3, 18, 12, 0, 0, tzinfo=timezone.utc)
+        path = "/tmp/Bid-Euchre-steward-ops"
+        git_wts = [GitWorktree(path=path, head="abc", branch="codex/steward-ops")]
+        registry: list[dict] = []  # No registry entry at all
+
+        candidates = classify_cleanup_candidates(
+            git_wts, registry, now=now, check_dirty=False
+        )
+        # Protected + unregistered → skipped entirely, not a candidate
+        assert len(candidates) == 0
+
     def test_default_ttl_applied(self) -> None:
         now = datetime(2026, 3, 20, 12, 0, 0, tzinfo=timezone.utc)
         git_wts = [GitWorktree(path="/tmp/wt-task", head="abc", branch="task-1")]


### PR DESCRIPTION
## Summary

- **Import decoupling:** Replace eager `from . import experiments` in `bid_euchre/__init__.py` with lazy `__getattr__` (PEP 562). Ops entrypoints no longer pay ~13s strategy/ML import cost on package load.
- **Runtime hygiene:** Skip protected steward worktrees from cleanup candidate classification in `classify_cleanup_candidates()`. They are permanent infrastructure, not cleanup targets.
- **Docs reconciliation:** Update Platform-1 entry checklist, bootstrap checkpoints, and sub-plan registry to reflect current shipped reality and SP-0-02 execution.

## Why

Control-plane readiness for Platform-1. The ops CLI (`scripts/internal/ops.py`) imports `bid_euchre.ops.*` modules, which triggers `bid_euchre/__init__.py`, which eagerly imported the full experiments/strategy tree — a heavy dependency irrelevant to ops work. Protected steward worktrees appearing as "unknown" cleanup candidates added noise to health/prune output without value.

## Repro / Validation

```bash
# Verify lazy import (experiments NOT loaded until accessed)
uv run python -c "
import bid_euchre
import sys
print('experiments loaded:', 'bid_euchre.experiments' in sys.modules)  # False
from bid_euchre.experiments.config import ExperimentConfig
print('experiments loaded:', 'bid_euchre.experiments' in sys.modules)  # True
"

# Targeted tests (303 passed)
uv run python -m pytest -q tests/unit/test_ops_worktrees.py tests/unit/test_ops_cli.py tests/unit/test_ops_status.py

# Smoke tests
uv run python scripts/internal/ops.py --json status
uv run python scripts/internal/ops.py --json health
uv run python scripts/internal/ops.py --json worktrees

# Full validation
make check-quiet  # ✓ All checks passed
```

## Tests

- `uv run python -m pytest -q tests/unit/test_ops_worktrees.py tests/unit/test_ops_cli.py tests/unit/test_ops_status.py` — 303 passed
- New test: `test_protected_unregistered_worktree_skipped` verifying protected steward worktrees are excluded from cleanup candidates when unregistered
- `make check-quiet` — all checks passed

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/platform1-prep-cleanup
toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/worktrees/platform1-prep-cleanup
```

## Governed initiative

- **Plan:** `plans/agent_ops/governing_plan.md` — Phase 0 Bootstrap
- **Sub-plan:** SP-0-02 (`plans/agent_ops/0_bootstrap/sub/2026-03-20_platform1-prep-pr-handoff.md`)
- **Scope:** Non-blocking prep PR; Platform-1 is unblocked independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)