### PR TITLE
fix: share review queue across worktrees

### DIFF
--- a/.claude/hooks/pre-merge-review-guard.sh
+++ b/.claude/hooks/pre-merge-review-guard.sh
@@ -55,13 +55,27 @@ BLOCK
   exit 2
 fi
 
+# --- Resolve shared queue root (canonical across worktrees) ---
+QUEUE_ROOT=$(uv run python -c "from bid_euchre.ops.review_queue import shared_queue_root; print(shared_queue_root())" 2>/dev/null)
+if [ -z "$QUEUE_ROOT" ]; then
+  # Fallback: derive from git common dir directly
+  GIT_COMMON=$(git rev-parse --git-common-dir 2>/dev/null || echo "")
+  if [ -n "$GIT_COMMON" ]; then
+    MAIN_ROOT=$(cd "$GIT_COMMON/.." && pwd -P)
+    QUEUE_ROOT="${MAIN_ROOT}/.claude/runtime/review_queue"
+  else
+    QUEUE_ROOT="${CLAUDE_PROJECT_DIR:-.}/.claude/runtime/review_queue"
+  fi
+fi
+
 # --- Check 1: Verdict exists ---
-VERDICT_FILE="${CLAUDE_PROJECT_DIR:-.}/.claude/runtime/review_queue/pr_${PR_NUM}/verdict.json"
+VERDICT_FILE="${QUEUE_ROOT}/pr_${PR_NUM}/verdict.json"
 if [ ! -f "$VERDICT_FILE" ]; then
   cat <<BLOCK
 BLOCKED: No review verdict found for PR #${PR_NUM}.
 
 The review driver must complete and write a verdict before merge is allowed.
+Queue root: ${QUEUE_ROOT}
 Check review status:
   uv run python scripts/internal/ops.py reviews queue
 

--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -1282,7 +1282,12 @@ def cmd_skills_disable(args: argparse.Namespace) -> int:
 
 
 def cmd_queue(args: argparse.Namespace) -> int:
-    """Show local review queue state (request + verdict packets)."""
+    """Show shared review queue state (request + verdict packets).
+
+    Uses the canonical shared queue root (derived from git common dir)
+    so that all worktrees see the same queue.
+    """
+    from bid_euchre.ops.review_queue import shared_queue_root
     from bid_euchre.ops.reviews import (
         format_queue_json,
         format_queue_text,
@@ -1290,7 +1295,7 @@ def cmd_queue(args: argparse.Namespace) -> int:
         get_queue_entry,
     )
 
-    queue_dir = args.runtime_dir / "review_queue"
+    queue_dir = shared_queue_root()
     pr_number = getattr(args, "pr", None)
 
     if pr_number is not None:

--- a/src/bid_euchre/ops/review_queue.py
+++ b/src/bid_euchre/ops/review_queue.py
@@ -5,10 +5,16 @@ detection, and a deterministic precheck-to-blocked-verdict path.
 
 Storage layout::
 
-    .claude/runtime/review_queue/
+    <main_repo>/.claude/runtime/review_queue/
         pr_<N>/
             request.json        -- current review request
             verdict.json        -- latest verdict (may be stale)
+
+The queue root is shared across all git worktrees for the same
+repository via :func:`shared_queue_root`, which derives the path from
+``git rev-parse --git-common-dir``.  This ensures a verdict written in
+one worktree is visible to the merge guard running in any other
+worktree.
 
 All files are JSON. The queue is append-friendly but not append-only:
 each PR slot holds exactly one request and one verdict at a time.
@@ -18,9 +24,11 @@ against the request's ``head_sha``.
 
 from __future__ import annotations
 
+import functools
 import json
 import logging
 import os
+import subprocess
 import tempfile
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -32,6 +40,63 @@ from bid_euchre.ops.events import append_event
 logger = logging.getLogger("ops.review_queue")
 
 DEFAULT_QUEUE_DIR = Path(".claude/runtime/review_queue")
+
+
+# ---------------------------------------------------------------------------
+# Shared queue root — canonical across all worktrees for the same repo
+# ---------------------------------------------------------------------------
+
+
+@functools.lru_cache(maxsize=1)
+def _resolve_git_common_queue_root() -> Path:
+    """Resolve the review queue root from git's common directory.
+
+    The git common directory (``git rev-parse --git-common-dir``) is shared
+    across all worktrees for the same repository.  Its parent is the main
+    checkout root, so we can derive a single canonical queue path that every
+    worktree agrees on.
+
+    Cached for the lifetime of the process (one subprocess call).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            git_common = Path(result.stdout.strip())
+            if not git_common.is_absolute():
+                git_common = (Path.cwd() / git_common).resolve()
+            else:
+                git_common = git_common.resolve()
+            # Parent of .git dir is the main repo root
+            main_root = git_common.parent
+            return main_root / ".claude" / "runtime" / "review_queue"
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    return DEFAULT_QUEUE_DIR
+
+
+def shared_queue_root() -> Path:
+    """Return the canonical review queue root shared across all worktrees.
+
+    Resolution order:
+
+    1. ``BID_EUCHRE_REVIEW_QUEUE_DIR`` environment variable (test/debug override).
+    2. Derived from ``git rev-parse --git-common-dir`` (cached).
+    3. Falls back to :data:`DEFAULT_QUEUE_DIR` if git is unavailable.
+
+    All queue readers and writers should use this (via the path helpers) so
+    that a verdict written in worktree A is visible to the merge guard
+    running in worktree B.
+    """
+    env_override = os.environ.get("BID_EUCHRE_REVIEW_QUEUE_DIR")
+    if env_override:
+        return Path(env_override)
+    return _resolve_git_common_queue_root()
+
 
 # ---------------------------------------------------------------------------
 # Models
@@ -141,12 +206,12 @@ def pr_dir(pr_number: int, queue_dir: Path | None = None) -> Path:
 
     Args:
         pr_number: GitHub PR number.
-        queue_dir: Override for queue root. Defaults to ``DEFAULT_QUEUE_DIR``.
+        queue_dir: Override for queue root. Defaults to :func:`shared_queue_root`.
 
     Returns:
-        Path like ``.claude/runtime/review_queue/pr_42``.
+        Path like ``<main_repo>/.claude/runtime/review_queue/pr_42``.
     """
-    root = queue_dir or DEFAULT_QUEUE_DIR
+    root = queue_dir if queue_dir is not None else shared_queue_root()
     return root / f"pr_{pr_number}"
 
 

--- a/src/bid_euchre/ops/reviews.py
+++ b/src/bid_euchre/ops/reviews.py
@@ -841,15 +841,18 @@ def get_queue_entries(
 
     Gracefully handles a missing queue directory (returns empty list).
 
+    When ``queue_dir`` is ``None``, uses :func:`~bid_euchre.ops.review_queue.shared_queue_root`
+    so that all worktrees for the same repo see the same queue.
+
     Args:
         queue_dir: Override for queue root directory.
 
     Returns:
         List of :class:`QueueEntry`, sorted by PR number.
     """
-    from bid_euchre.ops.review_queue import DEFAULT_QUEUE_DIR
+    from bid_euchre.ops.review_queue import shared_queue_root
 
-    root = queue_dir or DEFAULT_QUEUE_DIR
+    root = queue_dir if queue_dir is not None else shared_queue_root()
     if not root.is_dir():
         return []
 

--- a/tests/unit/test_merge_guard.py
+++ b/tests/unit/test_merge_guard.py
@@ -10,6 +10,8 @@ import sys
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+import pytest
+
 # Add scripts/internal to path for direct imports
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "internal"))
 
@@ -196,8 +198,10 @@ class TestReviewDriverVerdictWriting:
             current_head_sha="sha_abc123",
         )
 
-        # Patch the write_verdict to use tmp_path
-        with patch("bid_euchre.ops.review_queue.DEFAULT_QUEUE_DIR", tmp_path):
+        # Patch shared_queue_root to redirect writes to tmp_path
+        with patch(
+            "bid_euchre.ops.review_queue.shared_queue_root", return_value=tmp_path
+        ):
             from review_driver import _write_verdict_if_applicable
 
             _write_verdict_if_applicable(loop)
@@ -219,7 +223,9 @@ class TestReviewDriverVerdictWriting:
             stop_reason="CI failed",
         )
 
-        with patch("bid_euchre.ops.review_queue.DEFAULT_QUEUE_DIR", tmp_path):
+        with patch(
+            "bid_euchre.ops.review_queue.shared_queue_root", return_value=tmp_path
+        ):
             from review_driver import _write_verdict_if_applicable
 
             _write_verdict_if_applicable(loop)
@@ -240,7 +246,9 @@ class TestReviewDriverVerdictWriting:
             current_head_sha="sha_ghi789",
         )
 
-        with patch("bid_euchre.ops.review_queue.DEFAULT_QUEUE_DIR", tmp_path):
+        with patch(
+            "bid_euchre.ops.review_queue.shared_queue_root", return_value=tmp_path
+        ):
             from review_driver import _write_verdict_if_applicable
 
             _write_verdict_if_applicable(loop)
@@ -260,7 +268,9 @@ class TestReviewDriverVerdictWriting:
             stop_reason="Codex output unparseable (degraded pass)",
         )
 
-        with patch("bid_euchre.ops.review_queue.DEFAULT_QUEUE_DIR", tmp_path):
+        with patch(
+            "bid_euchre.ops.review_queue.shared_queue_root", return_value=tmp_path
+        ):
             from review_driver import _write_verdict_if_applicable
 
             _write_verdict_if_applicable(loop, override_status=STATUS_PASSED)
@@ -342,35 +352,35 @@ class TestBashGuardIntegration:
             capture_output=True,
             text=True,
             env=env,
-            timeout=5,
+            timeout=10,
         )
         return result.returncode
 
     def test_blocks_when_no_verdict_file(self, tmp_path: Path) -> None:
         """Guard should block (exit 2) when verdict file is missing."""
-        # Point CLAUDE_PROJECT_DIR to tmp_path so the guard looks for
-        # verdict files in tmp_path/.claude/runtime/review_queue/
+        # Use BID_EUCHRE_REVIEW_QUEUE_DIR to point guard at empty tmp dir
+        queue_dir = tmp_path / "empty_queue"
+        queue_dir.mkdir()
         exit_code = self._run_guard(
             "gh pr merge 42 --squash",
-            env_override={"CLAUDE_PROJECT_DIR": str(tmp_path)},
+            env_override={"BID_EUCHRE_REVIEW_QUEUE_DIR": str(queue_dir)},
         )
         assert exit_code == 2
 
     def test_blocks_when_verdict_status_not_passed(self, tmp_path: Path) -> None:
         """Guard should block when verdict status is 'blocked'."""
+        queue_dir = tmp_path / "queue"
         v = ReviewVerdict(
             pr_number=42,
             reviewed_sha="abc1234567890",
             status=STATUS_BLOCKED,
             reason="Blocking findings",
         )
-        write_verdict(
-            v, tmp_path / ".claude" / "runtime" / "review_queue", emit_event=False
-        )
+        write_verdict(v, queue_dir, emit_event=False)
 
         exit_code = self._run_guard(
             "gh pr merge 42 --squash",
-            env_override={"CLAUDE_PROJECT_DIR": str(tmp_path)},
+            env_override={"BID_EUCHRE_REVIEW_QUEUE_DIR": str(queue_dir)},
         )
         assert exit_code == 2
 
@@ -386,7 +396,7 @@ class TestBashGuardIntegration:
             status=STATUS_PASSED,
             reason="clean review",
         )
-        queue_dir = tmp_path / ".claude" / "runtime" / "review_queue"
+        queue_dir = tmp_path / "queue"
         write_verdict(v, queue_dir, emit_event=False)
 
         # Read the verdict file and verify the jq-queried fields exist
@@ -401,3 +411,87 @@ class TestBashGuardIntegration:
         assert "reason" in data, "Guard queries .reason"
         assert data["reviewed_sha"] == "abc1234567890"
         assert data["status"] == "passed"
+
+
+# ---------------------------------------------------------------------------
+# Cross-worktree merge guard tests
+# ---------------------------------------------------------------------------
+
+
+class TestCrossWorktreeMergeGuard:
+    """Verify the merge guard uses the shared queue root.
+
+    The guard resolves the queue root via Python's shared_queue_root(),
+    which respects BID_EUCHRE_REVIEW_QUEUE_DIR. This simulates verdicts
+    being written from one worktree and the guard running from another.
+    """
+
+    def test_guard_blocks_when_no_shared_verdict(self, tmp_path: Path) -> None:
+        """Guard from worktree B should block when shared queue has no verdict."""
+        shared_queue = tmp_path / "shared_queue"
+        shared_queue.mkdir()
+
+        # Pure-Python guard check against empty shared queue
+        allowed, reason = _guard_check(42, "abc123", "success", shared_queue)
+        assert allowed is False
+        assert "No review verdict" in reason
+
+    def test_guard_allows_with_shared_passed_verdict(self, tmp_path: Path) -> None:
+        """Guard from worktree B should allow when worktree A wrote a passed verdict."""
+        shared_queue = tmp_path / "shared_queue"
+        sha = "abc1234567890"
+
+        # Simulate worktree A writing a verdict to the shared queue
+        v = ReviewVerdict(
+            pr_number=42,
+            reviewed_sha=sha,
+            status=STATUS_PASSED,
+            reason="Clean review from worktree A",
+        )
+        write_verdict(v, shared_queue, emit_event=False)
+
+        # Simulate worktree B checking the guard against the same shared queue
+        allowed, reason = _guard_check(42, sha, "success", shared_queue)
+        assert allowed is True
+        assert "Ready" in reason
+
+    def test_guard_blocks_stale_shared_verdict(self, tmp_path: Path) -> None:
+        """Guard should block when shared verdict SHA doesn't match current HEAD."""
+        shared_queue = tmp_path / "shared_queue"
+
+        v = ReviewVerdict(
+            pr_number=42,
+            reviewed_sha="old_sha_1234",
+            status=STATUS_PASSED,
+            reason="Clean",
+        )
+        write_verdict(v, shared_queue, emit_event=False)
+
+        # Current HEAD is different — guard should block
+        allowed, reason = _guard_check(42, "new_sha_5678", "success", shared_queue)
+        assert allowed is False
+        assert "Stale" in reason
+
+    def test_write_from_worktree_a_read_from_worktree_b(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """End-to-end: write via shared_queue_root(), read via shared_queue_root()."""
+        shared_dir = tmp_path / "shared"
+        monkeypatch.setenv("BID_EUCHRE_REVIEW_QUEUE_DIR", str(shared_dir))
+
+        sha = "sha_cross_wt"
+
+        # "Worktree A" writes a verdict (no explicit queue_dir)
+        v = ReviewVerdict(
+            pr_number=77,
+            reviewed_sha=sha,
+            status=STATUS_PASSED,
+            reason="Review from A",
+        )
+        write_verdict(v, emit_event=False)
+
+        # "Worktree B" reads and checks (no explicit queue_dir)
+        loaded = read_verdict(77)
+        assert loaded is not None
+        assert loaded.status == STATUS_PASSED
+        assert loaded.reviewed_sha == sha

--- a/tests/unit/test_ops_cli.py
+++ b/tests/unit/test_ops_cli.py
@@ -2463,6 +2463,18 @@ class TestBoundaryRejection:
 class TestCmdQueue:
     """Tests for the queue subcommand."""
 
+    @pytest.fixture(autouse=True)
+    def _use_test_queue(
+        self, runtime_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Point shared_queue_root() at the test's runtime queue dir.
+
+        cmd_queue uses shared_queue_root() to find the canonical queue.
+        In tests we redirect it to the test runtime dir via env override.
+        """
+        queue_dir = runtime_dir / "review_queue"
+        monkeypatch.setenv("BID_EUCHRE_REVIEW_QUEUE_DIR", str(queue_dir))
+
     def test_queue_empty_text(
         self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/tests/unit/test_ops_reviews.py
+++ b/tests/unit/test_ops_reviews.py
@@ -1353,3 +1353,98 @@ class TestFormatQueueJSON:
         assert result[0]["pr_number"] == 42
         assert result[0]["effective_status"] == "passed"
         json.dumps(result)
+
+
+# ---------------------------------------------------------------------------
+# Cross-worktree queue visibility
+# ---------------------------------------------------------------------------
+
+
+class TestCrossWorktreeQueueVisibility:
+    """Verify get_queue_entries/get_queue_entry read the shared queue root.
+
+    Uses BID_EUCHRE_REVIEW_QUEUE_DIR env override to simulate the shared
+    queue being written from one worktree and read from another.
+    """
+
+    def test_queue_entries_surfaces_shared_verdicts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """get_queue_entries() should find verdicts written to the shared queue."""
+        from bid_euchre.ops.review_queue import (
+            ReviewRequest,
+            ReviewVerdict,
+            write_request,
+            write_verdict,
+        )
+
+        shared_dir = tmp_path / "shared_queue"
+        monkeypatch.setenv("BID_EUCHRE_REVIEW_QUEUE_DIR", str(shared_dir))
+
+        # Write request + verdict to shared queue (simulates worktree A)
+        req = ReviewRequest(
+            pr_number=42, head_sha="sha_abc", branch="feat/x", requester="a"
+        )
+        write_request(req, shared_dir, emit_event=False)
+
+        v = ReviewVerdict(
+            pr_number=42, reviewed_sha="sha_abc", status="passed", reason="clean"
+        )
+        write_verdict(v, shared_dir, emit_event=False)
+
+        # Read from "worktree B" via get_queue_entries() with no explicit dir
+        entries = get_queue_entries()
+        assert len(entries) == 1
+        assert entries[0].pr_number == 42
+        assert entries[0].effective_status == QUEUE_PASSED
+        assert entries[0].verdict_sha == "sha_abc"
+
+    def test_queue_entry_surfaces_shared_verdict(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """get_queue_entry() should find a verdict at the shared root."""
+        from bid_euchre.ops.review_queue import (
+            ReviewRequest,
+            ReviewVerdict,
+            write_request,
+            write_verdict,
+        )
+
+        shared_dir = tmp_path / "shared_queue"
+        monkeypatch.setenv("BID_EUCHRE_REVIEW_QUEUE_DIR", str(shared_dir))
+
+        req = ReviewRequest(
+            pr_number=99, head_sha="sha_xyz", branch="fix/y", requester="b"
+        )
+        write_request(req, shared_dir, emit_event=False)
+
+        v = ReviewVerdict(
+            pr_number=99, reviewed_sha="sha_xyz", status="blocked", reason="findings"
+        )
+        write_verdict(v, shared_dir, emit_event=False)
+
+        # Read from "worktree B"
+        entry = get_queue_entry(99)
+        assert entry.pr_number == 99
+        assert entry.effective_status == QUEUE_BLOCKED
+        assert entry.has_verdict is True
+
+    def test_empty_shared_queue_returns_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """get_queue_entries() returns [] when shared queue dir is empty."""
+        shared_dir = tmp_path / "empty_queue"
+        shared_dir.mkdir()
+        monkeypatch.setenv("BID_EUCHRE_REVIEW_QUEUE_DIR", str(shared_dir))
+
+        entries = get_queue_entries()
+        assert entries == []
+
+    def test_nonexistent_shared_queue_returns_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """get_queue_entries() returns [] when shared queue dir doesn't exist."""
+        monkeypatch.setenv("BID_EUCHRE_REVIEW_QUEUE_DIR", str(tmp_path / "nonexistent"))
+
+        entries = get_queue_entries()
+        assert entries == []

--- a/tests/unit/test_review_driver.py
+++ b/tests/unit/test_review_driver.py
@@ -1252,7 +1252,9 @@ class TestRuntimeLimitTimeout:
         except Exception:
             loop.state = ReviewState.STOPPED_REVIEW_FAILURE.value
 
-        with patch("bid_euchre.ops.review_queue.DEFAULT_QUEUE_DIR", tmp_path):
+        with patch(
+            "bid_euchre.ops.review_queue.shared_queue_root", return_value=tmp_path
+        ):
             from review_driver import _write_verdict_if_applicable
 
             _write_verdict_if_applicable(loop)

--- a/tests/unit/test_review_queue.py
+++ b/tests/unit/test_review_queue.py
@@ -8,11 +8,11 @@ from pathlib import Path
 import pytest
 
 from bid_euchre.ops.review_queue import (
-    DEFAULT_QUEUE_DIR,
     VALID_STATUSES,
     PrecheckFinding,
     ReviewRequest,
     ReviewVerdict,
+    _resolve_git_common_queue_root,
     invalidate_stale_verdict,
     is_verdict_stale,
     pr_dir,
@@ -20,6 +20,7 @@ from bid_euchre.ops.review_queue import (
     read_request,
     read_verdict,
     request_path,
+    shared_queue_root,
     verdict_path,
     write_request,
     write_verdict,
@@ -107,7 +108,9 @@ class TestReviewVerdict:
 class TestFileLayout:
     def test_pr_dir_default(self) -> None:
         d = pr_dir(42)
-        assert d == DEFAULT_QUEUE_DIR / "pr_42"
+        # Default uses shared_queue_root(), which resolves via git common dir
+        assert d.name == "pr_42"
+        assert d.parent == shared_queue_root()
 
     def test_pr_dir_custom(self, tmp_path: object) -> None:
         from pathlib import Path
@@ -609,3 +612,135 @@ class TestVerdictWriterField:
         loaded = read_verdict(42, tmp_path)
         assert loaded is not None
         assert loaded.writer == "original_writer"
+
+
+# ---------------------------------------------------------------------------
+# Shared queue root — cross-worktree discovery
+# ---------------------------------------------------------------------------
+
+
+class TestSharedQueueRoot:
+    """Verify shared_queue_root() resolves to a canonical path."""
+
+    def test_env_override_takes_precedence(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """BID_EUCHRE_REVIEW_QUEUE_DIR env var overrides git resolution."""
+        override_dir = tmp_path / "custom_queue"
+        monkeypatch.setenv("BID_EUCHRE_REVIEW_QUEUE_DIR", str(override_dir))
+        assert shared_queue_root() == override_dir
+
+    def test_env_override_not_cached(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Env override is checked each call (not cached)."""
+        dir1 = tmp_path / "dir1"
+        dir2 = tmp_path / "dir2"
+
+        monkeypatch.setenv("BID_EUCHRE_REVIEW_QUEUE_DIR", str(dir1))
+        assert shared_queue_root() == dir1
+
+        monkeypatch.setenv("BID_EUCHRE_REVIEW_QUEUE_DIR", str(dir2))
+        assert shared_queue_root() == dir2
+
+    def test_git_common_dir_resolves_to_main_repo(self) -> None:
+        """In a git repo, shared_queue_root() should resolve via git common dir."""
+        # Clear the lru_cache to get a fresh resolution
+        _resolve_git_common_queue_root.cache_clear()
+        try:
+            root = _resolve_git_common_queue_root()
+            # Should be an absolute path ending in .claude/runtime/review_queue
+            assert root.is_absolute()
+            assert root.parts[-3:] == (".claude", "runtime", "review_queue")
+        finally:
+            _resolve_git_common_queue_root.cache_clear()
+
+    def test_path_helpers_use_shared_root_by_default(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """pr_dir/request_path/verdict_path default to shared_queue_root()."""
+        shared_dir = tmp_path / "shared_queue"
+        monkeypatch.setenv("BID_EUCHRE_REVIEW_QUEUE_DIR", str(shared_dir))
+
+        assert pr_dir(42) == shared_dir / "pr_42"
+        assert request_path(42) == shared_dir / "pr_42" / "request.json"
+        assert verdict_path(42) == shared_dir / "pr_42" / "verdict.json"
+
+    def test_explicit_queue_dir_overrides_shared_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Explicit queue_dir parameter still overrides the shared root."""
+        monkeypatch.setenv("BID_EUCHRE_REVIEW_QUEUE_DIR", str(tmp_path / "shared"))
+        local = tmp_path / "local"
+
+        assert pr_dir(42, local) == local / "pr_42"
+        assert request_path(42, local) == local / "pr_42" / "request.json"
+        assert verdict_path(42, local) == local / "pr_42" / "verdict.json"
+
+
+class TestCrossWorktreeVisibility:
+    """Verify that verdicts written via the shared root are visible from any worktree."""
+
+    def test_verdict_written_via_shared_root_visible_everywhere(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A verdict written using the shared root should be readable
+        from any context that also resolves to the shared root."""
+        shared_dir = tmp_path / "shared_queue"
+        monkeypatch.setenv("BID_EUCHRE_REVIEW_QUEUE_DIR", str(shared_dir))
+
+        # Worktree A writes a verdict (no explicit queue_dir → uses shared root)
+        verdict = ReviewVerdict(
+            pr_number=42,
+            reviewed_sha="sha_abc",
+            status="passed",
+            reason="Clean review",
+        )
+        write_verdict(verdict, emit_event=False)
+
+        # Worktree B reads the verdict (no explicit queue_dir → uses shared root)
+        loaded = read_verdict(42)
+        assert loaded is not None
+        assert loaded.status == "passed"
+        assert loaded.reviewed_sha == "sha_abc"
+
+    def test_request_written_via_shared_root_visible_everywhere(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A request written using the shared root should be readable
+        from any context that also resolves to the shared root."""
+        shared_dir = tmp_path / "shared_queue"
+        monkeypatch.setenv("BID_EUCHRE_REVIEW_QUEUE_DIR", str(shared_dir))
+
+        req = ReviewRequest(
+            pr_number=99,
+            head_sha="sha_xyz",
+            branch="feat/cross-wt",
+            requester="author-a",
+        )
+        write_request(req, emit_event=False)
+
+        loaded = read_request(99)
+        assert loaded is not None
+        assert loaded.head_sha == "sha_xyz"
+        assert loaded.branch == "feat/cross-wt"
+
+    def test_stale_detection_works_across_worktrees(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Stale-verdict detection should work when reader uses shared root."""
+        shared_dir = tmp_path / "shared_queue"
+        monkeypatch.setenv("BID_EUCHRE_REVIEW_QUEUE_DIR", str(shared_dir))
+
+        # Write a verdict at an old SHA
+        verdict = ReviewVerdict(
+            pr_number=42,
+            reviewed_sha="old_sha",
+            status="passed",
+            reason="test",
+        )
+        write_verdict(verdict, emit_event=False)
+
+        # From "another worktree", check staleness against new SHA
+        assert is_verdict_stale(42, "new_sha") is True
+        assert is_verdict_stale(42, "old_sha") is False


### PR DESCRIPTION
## Plan
plans/sessions/2026-03-20_post-pr4-proving-checklist.md

## Summary
- Add `shared_queue_root()` to `review_queue.py` — resolves the canonical queue path via `git rev-parse --git-common-dir` so all worktrees share one queue
- Update bash merge guard to resolve queue root via Python (with git-common-dir bash fallback)
- Update `reviews.py` `get_queue_entries()` and `ops.py cmd_queue` to use the shared root

## Why
Cross-worktree proving showed a merge from worktree B succeeded when worktree A held the verdict. The review queue was stored under each worktree's `.claude/runtime/`, making verdicts invisible to other worktrees. This is a proving-window blocker for cross-worktree enforcement.

#1189 remains the rerun target after merge. No docs or feature expansion included.

## Repro / Validation
**Command(s) run:**
```bash
# Targeted tests (265 pass)
uv run python -m pytest -q tests/unit/test_review_queue.py tests/unit/test_merge_guard.py tests/unit/test_ops_reviews.py tests/unit/test_review_driver.py

# Full validation
make check-quiet  # 5457 passed, 44 skipped, 5 deselected
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_review_queue.py` — shared root, cross-worktree visibility
- [x] `uv run python -m pytest tests/unit/test_merge_guard.py` — guard blocks/allows with shared queue
- [x] `uv run python -m pytest tests/unit/test_ops_reviews.py` — queue visibility surfaces shared verdicts
- [x] `uv run python -m pytest tests/unit/test_review_driver.py` — verdict writing via shared root
- [x] `uv run python -m pytest tests/unit/test_ops_cli.py::TestCmdQueue` — CLI queue command

### New test assertions
1. Queue-root resolution is shared across simulated worktrees for the same repo
2. A verdict written from worktree A is visible to readers in worktree B
3. The merge guard run from worktree B blocks when no shared verdict exists
4. The merge guard run from worktree B allows merge when a matching clean shared verdict exists
5. `get_queue_entries()` surfaces the shared verdict, not an empty local queue

## Expected impact
- Metrics impact: None (ops infra only)
- Runtime impact: One `git rev-parse --git-common-dir` call per process lifetime (cached)

## Risk level
- [x] Low (ops/infra only — no core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                     main
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author      fix/wire-merge-guard-hook
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)