### PR TITLE
fix: complete shared queue root migration and fix claude-review CI

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,12 +55,17 @@ jobs:
             Post your findings as review comments on the PR.
 
           # Tool access strategy:
-          # - Bash available (scoped via --disallowedTools blocklist in claude_args)
+          # - Bash scoped via --disallowedTools blocklist + --allowedTools allowlist
+          # - --allowedTools pre-approves read-only Bash commands for CI (#1197)
+          #   Without it, Bash commands require interactive approval (impossible in CI)
           # - Read/Grep/Glob are allowed by default
           # - Write tools and network/agent tools are disallowed to prevent
           #   wasted turns on permission denials (~36% turn waste before this fix)
           show_full_output: true
-          claude_args: '--max-turns 15 --disallowedTools "Edit,Write,NotebookEdit,Agent,WebFetch,WebSearch,LSP"'
+          claude_args: >-
+            --max-turns 15
+            --disallowedTools "Edit,Write,NotebookEdit,Agent,WebFetch,WebSearch,LSP"
+            --allowedTools "Bash(gh pr diff *),Bash(gh pr view *),Bash(gh pr checks *),Bash(gh api *),Bash(git diff *),Bash(git log *),Bash(git show *),Bash(find *),Bash(grep *),Bash(cat *)"
 
       - name: Upload review execution log
         if: always() && steps.claude-review.outputs.execution_file

--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -1285,7 +1285,9 @@ def cmd_queue(args: argparse.Namespace) -> int:
     """Show shared review queue state (request + verdict packets).
 
     Uses the canonical shared queue root (derived from git common dir)
-    so that all worktrees see the same queue.
+    so that all worktrees see the same queue.  When ``--runtime-dir`` is
+    explicitly provided and contains a ``review_queue/`` subdirectory,
+    that override takes precedence (useful for debug/sandbox workflows).
     """
     from bid_euchre.ops.review_queue import shared_queue_root
     from bid_euchre.ops.reviews import (
@@ -1295,7 +1297,12 @@ def cmd_queue(args: argparse.Namespace) -> int:
         get_queue_entry,
     )
 
-    queue_dir = shared_queue_root()
+    # Respect explicit --runtime-dir override for debug/sandbox (#1196).
+    local_queue = args.runtime_dir / "review_queue"
+    if getattr(args, "_runtime_dir_explicit", False) and local_queue.is_dir():
+        queue_dir = local_queue
+    else:
+        queue_dir = shared_queue_root()
     pr_number = getattr(args, "pr", None)
 
     if pr_number is not None:
@@ -1347,7 +1354,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--runtime-dir",
         type=Path,
         default=None,
-        help="Override runtime directory (default: .claude/runtime)",
+        help=(
+            "Override runtime directory (default: .claude/runtime). "
+            "For queue, only used when the override contains a review_queue/ subdir; "
+            "otherwise the shared queue root is used (see BID_EUCHRE_REVIEW_QUEUE_DIR)."
+        ),
     )
     parser.add_argument(
         "--plans-dir",
@@ -1708,6 +1719,10 @@ def main(argv: list[str] | None = None) -> int:
 
     # Resolve directories relative to repo root
     repo_root = find_repo_root()
+
+    # Stash whether the user explicitly passed --runtime-dir before we apply
+    # the default.  cmd_queue() uses this to respect explicit overrides (#1196).
+    args._runtime_dir_explicit = args.runtime_dir is not None
 
     if args.runtime_dir is None:
         args.runtime_dir = repo_root / ".claude" / "runtime"

--- a/scripts/internal/review_lane_runner.py
+++ b/scripts/internal/review_lane_runner.py
@@ -33,7 +33,6 @@ from typing import Any
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 from bid_euchre.ops.review_queue import (
-    DEFAULT_QUEUE_DIR,
     STATUS_BLOCKED,
     STATUS_FAILED,
     STATUS_PASSED,
@@ -43,6 +42,7 @@ from bid_euchre.ops.review_queue import (
     ReviewVerdict,
     read_request,
     read_verdict,
+    shared_queue_root,
     write_verdict,
 )
 
@@ -145,7 +145,7 @@ def find_pending_requests(queue_dir: Path | None = None) -> list[ReviewRequest]:
     Returns:
         List of ``ReviewRequest`` objects sorted by PR number (FIFO-ish).
     """
-    root = queue_dir or DEFAULT_QUEUE_DIR
+    root = queue_dir if queue_dir is not None else shared_queue_root()
     if not root.exists():
         return []
 

--- a/tests/unit/test_claude_review_workflow.py
+++ b/tests/unit/test_claude_review_workflow.py
@@ -259,15 +259,14 @@ class TestClaudeReviewWorkflow:
     def test_bash_scoping_comment_mentions_blocklist(self):
         """The Bash scoping comment must reference --disallowedTools blocklist.
 
-        The action does NOT use an allowed-tools allowlist — it uses
-        --disallowedTools in claude_args (#1167).
+        The action uses both --disallowedTools (blocklist) and --allowedTools
+        (allowlist for read-only Bash commands in CI, #1197).
         """
         # Check the raw YAML text for the comment; step dict won't include it
         workflow_text = WORKFLOW.read_text()
-        assert "scoped via --disallowedTools blocklist" in workflow_text, (
-            "Bash scoping comment must mention --disallowedTools blocklist, "
-            "not allowed-tools allowlist"
-        )
+        assert (
+            "scoped via --disallowedTools blocklist" in workflow_text
+        ), "Bash scoping comment must mention --disallowedTools blocklist"
         # The old misleading phrasing must not be present
         assert (
             "allowed-tools in the action config" not in workflow_text

--- a/tests/unit/test_ops_cli.py
+++ b/tests/unit/test_ops_cli.py
@@ -2639,3 +2639,48 @@ class TestCmdQueue:
         data = json.loads(capsys.readouterr().out)
         assert data["pr_number"] == 999
         assert data["effective_status"] == "no_request"
+
+    def test_queue_explicit_runtime_dir_override(
+        self,
+        tmp_path: Path,
+        plans_dir: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Explicit --runtime-dir with a review_queue/ subdir overrides shared root (#1196)."""
+        from bid_euchre.ops.review_queue import ReviewRequest, write_request
+
+        # Create a separate runtime dir with its own queue + request
+        alt_runtime = tmp_path / "alt_runtime"
+        alt_queue = alt_runtime / "review_queue"
+        alt_events = alt_runtime / "events"
+        alt_events.mkdir(parents=True)
+
+        req = ReviewRequest(
+            pr_number=77,
+            head_sha="override123",
+            branch="feat/override",
+            requester="author-a",
+        )
+        write_request(req, alt_queue, emit_event=False, events_dir=alt_events)
+
+        # Clear env override so we're testing the --runtime-dir path, not env var
+        monkeypatch.delenv("BID_EUCHRE_REVIEW_QUEUE_DIR", raising=False)
+
+        import ops
+
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(alt_runtime),
+                "--plans-dir",
+                str(plans_dir),
+                "queue",
+            ]
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert len(data) == 1
+        assert data[0]["pr_number"] == 77
+        assert data[0]["request_sha"] == "override123"


### PR DESCRIPTION
## Plan
`plans/sessions/2026-03-21_post-1195-follow-up.md`

## Summary
- `ops.py cmd_queue()` respects explicit `--runtime-dir` when the override contains a `review_queue/` subdir, instead of silently ignoring it
- `review_lane_runner.py find_pending_requests()` uses `shared_queue_root()` instead of relative `DEFAULT_QUEUE_DIR`, fixing queue visibility in linked worktrees
- `claude-code-review.yml` adds `--allowedTools` to pre-approve read-only Bash commands so the reviewer works in CI without interactive approval

## Why
Three follow-up findings from the #1195 review cycle (Codex P2 + CI log analysis). Without these fixes: (1) debug workflows with `--runtime-dir` silently read the wrong queue, (2) the review lane runner in linked worktrees scans an empty local queue while hooks enqueue to the shared root, and (3) the Claude Code reviewer in CI crashes because every Bash command requires approval that nobody can grant.

Closes #1196, closes #1197

## Repro / Validation
**Command(s) run:**
```bash
# Tier 1
uv run python -m pytest -q tests/unit/test_ops_cli.py::TestCmdQueue -x
uv run python -m pytest -q tests/unit/test_review_queue.py tests/unit/test_merge_guard.py -x
uv run python -m pytest -q tests/unit/test_claude_review_workflow.py -x

# Tier 2
make check-quiet  # ✓ All checks passed
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `make check-quiet` — all 5462 tests pass
- [x] New test: `TestCmdQueue::test_queue_explicit_runtime_dir_override` — verifies explicit `--runtime-dir` is respected for queue subcommand
- [x] Updated test: `test_bash_scoping_comment_mentions_blocklist` — reflects both blocklist + allowlist strategy

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (ops tooling + CI workflow)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                  afeb20e0 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author   9ebbce61 [fix/post-1195-follow-up]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)