### PR TITLE
fix: pass resolved queue root in review lane runner

### DIFF
--- a/plans/sessions/2026-03-21_post-1195-follow-up.md
+++ b/plans/sessions/2026-03-21_post-1195-follow-up.md
@@ -1,0 +1,119 @@
+# Post-#1195 Follow-Up: Complete Shared Queue Root + claude-review Fix
+
+**Date:** 2026-03-21
+**Parent PR:** #1195 (fix: share review queue across worktrees)
+**Issues:** #1196, #1197
+**Lane:** Any free `author-*` lane
+**Dependency:** #1195 merged
+
+## Goal
+
+Ship one bounded PR addressing three follow-up findings from the #1195 review cycle: two Codex P2 findings about incomplete shared-queue-root migration, and one CI infra fix for the `claude-review` permission denials.
+
+## Findings to Address
+
+### 1. `ops.py --runtime-dir` silently ignored for queue command (#1196)
+
+**Source:** Codex review on #1195 (P2)
+
+`cmd_queue()` hard-codes `shared_queue_root()`, so the advertised `--runtime-dir` CLI flag is dead for the queue subcommand. Debug/sandbox workflows that pass `--runtime-dir /tmp/runtime queue` silently read the live shared queue instead.
+
+**File:** `scripts/internal/ops.py`, function `cmd_queue()` (line ~1284)
+
+**Fix:** Respect `--runtime-dir` override when explicitly provided. Pattern:
+
+```python
+def cmd_queue(args: argparse.Namespace) -> int:
+    from bid_euchre.ops.review_queue import shared_queue_root
+
+    # Respect explicit --runtime-dir override for debug/sandbox workflows.
+    # The original value is None when not provided by the user (set to
+    # default later in main()). We stash the original in _runtime_dir_explicit.
+    local_queue = args.runtime_dir / "review_queue"
+    if getattr(args, "_runtime_dir_explicit", False) and local_queue.is_dir():
+        queue_dir = local_queue
+    else:
+        queue_dir = shared_queue_root()
+    ...
+```
+
+This requires threading a `_runtime_dir_explicit` flag from the argument parser. The simplest approach: in `main()` where `args.runtime_dir` is defaulted, also set `args._runtime_dir_explicit = (args.runtime_dir is not None)` BEFORE applying the default.
+
+**Alternative (simpler):** Just always use `shared_queue_root()` and accept that `--runtime-dir` doesn't apply to queue. Update the `--runtime-dir` help text to note the exception. The `TestCmdQueue` tests already use `BID_EUCHRE_REVIEW_QUEUE_DIR` env override to redirect. Choose whichever feels cleanest — the explicit-flag approach is more correct but the simpler approach may be fine given that `BID_EUCHRE_REVIEW_QUEUE_DIR` exists as an escape hatch.
+
+### 2. `review_lane_runner.py` still uses `DEFAULT_QUEUE_DIR` (#1196)
+
+**Source:** Codex review on #1195 (P2), also WARN-2 in manual review
+
+`find_pending_requests()` at line 148 resolves the queue root via `queue_dir or DEFAULT_QUEUE_DIR`. In a linked worktree, the runner sees an empty local queue while hooks enqueue to the shared root.
+
+**File:** `scripts/internal/review_lane_runner.py`, line 148
+
+**Fix:**
+
+```python
+# Before:
+root = queue_dir or DEFAULT_QUEUE_DIR
+
+# After:
+from bid_euchre.ops.review_queue import shared_queue_root
+root = queue_dir if queue_dir is not None else shared_queue_root()
+```
+
+Apply the same pattern everywhere in `review_lane_runner.py` that uses `queue_dir or DEFAULT_QUEUE_DIR`. Search for all occurrences:
+
+```bash
+grep -n "queue_dir or DEFAULT_QUEUE_DIR" scripts/internal/review_lane_runner.py
+```
+
+### 3. Add `--allowedTools` to `claude-code-review.yml` (#1197)
+
+**Source:** CI log analysis on #1195 — `claude-review` fails because Bash commands need interactive approval but CI has no interactive user.
+
+**File:** `.github/workflows/claude-code-review.yml`, line 63
+
+**Fix:** Add `--allowedTools` to the `claude_args`:
+
+```yaml
+claude_args: >-
+  --max-turns 15
+  --disallowedTools "Edit,Write,NotebookEdit,Agent,WebFetch,WebSearch,LSP"
+  --allowedTools "Bash(gh pr diff *),Bash(gh pr view *),Bash(gh pr checks *),Bash(gh api *),Bash(git diff *),Bash(git log *),Bash(git show *),Bash(find *),Bash(grep *),Bash(cat *)"
+```
+
+This pre-approves read-only bash commands so the reviewer can function in CI without interactive approval.
+
+## Explicitly Out of Scope
+
+- No changes to `review_queue.py` or the merge guard (those are done in #1195)
+- No changes to the queue format or data model
+- No docs updates (the docstring in `shared_queue_root()` already documents the env override)
+- INFO-1 (bash fallback not honoring env var) — negligible risk, not worth the complexity
+- INFO-2 (private function import in tests) — acceptable test pattern
+
+## Files to Touch
+
+| File | Change |
+|------|--------|
+| `scripts/internal/ops.py` | `cmd_queue()` respects `--runtime-dir` or documents the exception |
+| `scripts/internal/review_lane_runner.py` | Replace `queue_dir or DEFAULT_QUEUE_DIR` with `shared_queue_root()` |
+| `.github/workflows/claude-code-review.yml` | Add `--allowedTools` to `claude_args` |
+| `tests/unit/test_ops_cli.py` | Update `TestCmdQueue` if `cmd_queue` behavior changes |
+
+## Validation
+
+```bash
+# Tier 1: targeted
+uv run python -m pytest -q tests/unit/test_ops_cli.py::TestCmdQueue
+uv run python -m pytest -q tests/unit/test_review_queue.py
+uv run python -m pytest -q tests/unit/test_merge_guard.py
+
+# Tier 2: full
+make check-quiet
+```
+
+The `claude-code-review.yml` change requires no local tests — it will be validated by the next PR that triggers the workflow.
+
+## Outcome
+- PR: #1198
+- Issues closed: #1196, #1197

--- a/scripts/internal/review_lane_runner.py
+++ b/scripts/internal/review_lane_runner.py
@@ -159,11 +159,11 @@ def find_pending_requests(queue_dir: Path | None = None) -> list[ReviewRequest]:
         except ValueError:
             continue
 
-        req = read_request(pr_number, queue_dir)
+        req = read_request(pr_number, root)
         if req is None:
             continue
 
-        verdict = read_verdict(pr_number, queue_dir)
+        verdict = read_verdict(pr_number, root)
         if verdict is not None and verdict.status not in (STATUS_PENDING,):
             # Re-claimable if running and stale (#1183)
             if verdict.status == STATUS_RUNNING and _is_verdict_stale_running(verdict):

--- a/tests/unit/test_review_lane_runner.py
+++ b/tests/unit/test_review_lane_runner.py
@@ -126,6 +126,25 @@ class TestFindPendingRequests:
     def test_nonexistent_dir(self, tmp_path: Path) -> None:
         assert find_pending_requests(tmp_path / "nonexistent") == []
 
+    def test_none_queue_dir_delegates_to_shared_queue_root(
+        self, queue_dir: Path, events_dir: Path
+    ) -> None:
+        """When queue_dir is None, find_pending_requests uses shared_queue_root().
+
+        Regression test for #1196: the runner previously fell back to the
+        relative DEFAULT_QUEUE_DIR, which is invisible in linked worktrees.
+        """
+        req = _make_request(pr_number=55)
+        write_request(req, queue_dir, emit_event=False, events_dir=events_dir)
+
+        with patch(
+            "review_lane_runner.shared_queue_root", return_value=queue_dir
+        ) as mock_sqr:
+            pending = find_pending_requests(None)
+            mock_sqr.assert_called_once()
+        assert len(pending) == 1
+        assert pending[0].pr_number == 55
+
 
 # ---------------------------------------------------------------------------
 # process_request — SHA verification


### PR DESCRIPTION
## Plan
`plans/sessions/2026-03-21_post-1195-follow-up.md`

## Summary
- `find_pending_requests()` now passes the resolved `root` path to `read_request()` and `read_verdict()` instead of the raw `queue_dir` (which may be `None`)
- Adds regression test verifying `find_pending_requests(None)` delegates to `shared_queue_root()`
- Includes plan file outcome update from #1198

## Why
Follow-up to #1198 review findings. When `queue_dir=None`, the function resolved it to `shared_queue_root()` for directory iteration but still passed `None` to `read_request`/`read_verdict`, causing redundant `shared_queue_root()` calls on each PR slot. This also means the test for the `None` path couldn't work without this fix — `read_request(pr_number, None)` would resolve to a different path than the one being iterated.

## Repro / Validation
**Command(s) run:**
```bash
# Tier 1
uv run python -m pytest -q tests/unit/test_review_lane_runner.py::TestFindPendingRequests -x -v
# 7 passed (including new test)

# Tier 2
make check-quiet  # ✓ All checks passed
```

## Tests
- [x] `make check-quiet` — all checks pass
- [x] New test: `test_none_queue_dir_delegates_to_shared_queue_root`

## Expected impact
- Metrics impact: None
- Runtime impact: Eliminates redundant `shared_queue_root()` subprocess calls per PR slot

## Risk level
- [x] Low (ops tooling)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                  (main)
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author   (fix/post-1198-review-fixes)
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)