### PR TITLE
ci: retry auto-merge after PR becomes mergeable

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,7 +3,9 @@ name: Auto-merge
 on:
   pull_request:
     branches: [main]
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
+  check_suite:
+    types: [completed]
 
 permissions:
   contents: write
@@ -11,12 +13,56 @@ permissions:
 
 jobs:
   enable-auto-merge:
-    # Only auto-merge PRs from the repo owner (not external contributors)
-    if: github.event.pull_request.user.login == github.repository_owner
     runs-on: ubuntu-latest
+    # pull_request events: must be owner-authored (gate immediately)
+    # check_suite events: must have succeeded (eligibility checked in step)
+    if: >-
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.user.login == github.repository_owner)
+      ||
+      (github.event_name == 'check_suite' &&
+       github.event.check_suite.conclusion == 'success')
     steps:
       - name: Enable auto-merge (squash)
-        run: gh pr merge ${{ github.event.pull_request.number }} --auto --squash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.check_suite.head_sha }}
+          REPO_OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            echo "::group::Enable auto-merge for PR #${PR_NUMBER} (${EVENT_ACTION})"
+            gh pr merge "$PR_NUMBER" --auto --squash \
+              && echo "Auto-merge enabled for PR #${PR_NUMBER}" \
+              || echo "::notice::Auto-merge attempt returned non-zero (may already be enabled or PR not eligible)"
+            echo "::endgroup::"
+
+          elif [ "$EVENT_NAME" = "check_suite" ]; then
+            echo "::group::Check suite completed for ${HEAD_SHA:0:12}"
+
+            # Find open, owner-authored PRs targeting main for this head SHA
+            prs=$(gh pr list \
+              --state open \
+              --base main \
+              --json number,author,headRefOid \
+              --jq ".[] | select(.headRefOid == \"${HEAD_SHA}\" and .author.login == \"${REPO_OWNER}\") | .number")
+
+            if [ -z "$prs" ]; then
+              echo "No eligible open PRs found for SHA ${HEAD_SHA:0:12}"
+              echo "::endgroup::"
+              exit 0
+            fi
+
+            for pr in $prs; do
+              echo "Retrying auto-merge for PR #${pr}"
+              gh pr merge "$pr" --auto --squash \
+                && echo "Auto-merge enabled for PR #${pr}" \
+                || echo "::notice::Auto-merge attempt for PR #${pr} returned non-zero (may already be enabled)"
+            done
+            echo "::endgroup::"
+          fi

--- a/plans/sessions/2026-03-21_auto-merge-retry.md
+++ b/plans/sessions/2026-03-21_auto-merge-retry.md
@@ -1,0 +1,51 @@
+# Auto-Merge Retry After PR Becomes Mergeable
+
+**Date:** 2026-03-21
+**Lane:** author-b
+**Branch:** `ci/retry-auto-merge`
+**Handoff:** `plans/sessions/2026-03-21_auto-merge-retry-followup-handoff.md`
+
+## Goal
+
+Ensure owner-authored PRs that miss the initial GitHub auto-merge enablement
+attempt get another GitHub-side chance to queue auto-merge after they actually
+become mergeable.
+
+## Design
+
+### Current behavior
+- `.github/workflows/auto-merge.yml` runs `gh pr merge --auto --squash` only on
+  PR `opened` / `reopened`
+- If the initial attempt fails (API glitch, draft PR, etc.) or auto-merge gets
+  disabled (e.g., by a force push), the PR sits unmerged
+
+### Changes
+1. **Add `synchronize` to `pull_request` triggers** — re-enables auto-merge
+   after rebases or force pushes that disable it
+2. **Add `check_suite: completed` trigger** — retries auto-merge after CI
+   completes, catching PRs that missed the initial window
+3. **Job-level gate** — `check_suite` events only fire the job when
+   `conclusion == 'success'`; `pull_request` events still require owner authorship
+4. **Idempotent retry** — `gh pr merge --auto --squash` failures are logged as
+   notices, not errors, so "already enabled" or "not eligible" don't fail the run
+5. **PR resolution for check_suite** — uses `gh pr list` to find open,
+   owner-authored PRs targeting `main` for the check suite's head SHA
+
+### Safety properties
+- Closed/merged PRs: `--state open` filter excludes them
+- Target branch: `--base main` filter ensures only main-targeting PRs
+- Owner only: `author.login == REPO_OWNER` filter matches current policy
+- Idempotent: already-enabled auto-merge doesn't cause failures
+
+### Out of scope (per handoff)
+- `review_driver.py` — intentionally does not call `enable_auto_merge()`
+- Local merge guard — unchanged
+- Branch protection — unchanged
+
+## Files Changed
+
+- `.github/workflows/auto-merge.yml` — add retry triggers and check_suite path
+
+## Outcome
+
+PR: (pending)

--- a/tests/unit/test_auto_merge_workflow.py
+++ b/tests/unit/test_auto_merge_workflow.py
@@ -1,0 +1,91 @@
+"""Regression tests for .github/workflows/auto-merge.yml structure.
+
+The auto-merge workflow enables GitHub auto-merge for owner-authored PRs.
+It fires on PR open/reopen/synchronize and retries after check suites
+complete. These tests verify the structural invariants that keep the
+workflow safe and correctly scoped.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "auto-merge.yml"
+
+
+class TestAutoMergeWorkflowStructure:
+    """Validate the auto-merge workflow shape."""
+
+    def setup_method(self) -> None:
+        self.workflow = yaml.safe_load(WORKFLOW.read_text())
+        self.jobs = self.workflow["jobs"]
+
+    def test_has_pull_request_trigger(self) -> None:
+        """PR trigger must include opened, reopened, and synchronize."""
+        # YAML parses bare `on` as boolean True
+        pr_trigger = self.workflow[True]["pull_request"]
+        assert "main" in pr_trigger["branches"]
+        required_types = {"opened", "reopened", "synchronize"}
+        assert required_types.issubset(set(pr_trigger["types"]))
+
+    def test_has_check_suite_trigger(self) -> None:
+        """check_suite trigger must fire on completed events."""
+        cs_trigger = self.workflow[True]["check_suite"]
+        assert "completed" in cs_trigger["types"]
+
+    def test_job_condition_gates_owner_for_pull_request(self) -> None:
+        """pull_request events must be gated to repo owner."""
+        job_if = self.jobs["enable-auto-merge"]["if"]
+        assert "pull_request" in job_if
+        assert "repository_owner" in job_if
+
+    def test_job_condition_gates_success_for_check_suite(self) -> None:
+        """check_suite events must be gated to successful conclusions."""
+        job_if = self.jobs["enable-auto-merge"]["if"]
+        assert "check_suite" in job_if
+        assert "success" in job_if
+
+    def test_permissions_are_minimal(self) -> None:
+        """Workflow should have write permissions for contents and PRs only."""
+        perms = self.workflow["permissions"]
+        assert perms["contents"] == "write"
+        assert perms["pull-requests"] == "write"
+        # No additional permissions
+        assert set(perms.keys()) == {"contents", "pull-requests"}
+
+    def test_step_uses_env_vars_not_inline_expressions(self) -> None:
+        """Shell script should use env vars for event data (security)."""
+        step = self.jobs["enable-auto-merge"]["steps"][0]
+        env = step["env"]
+        # Key event data passed via env, not inline ${{ }} in run
+        assert "EVENT_NAME" in env
+        assert "PR_NUMBER" in env
+        assert "HEAD_SHA" in env
+        assert "REPO_OWNER" in env
+
+    def test_check_suite_path_filters_owner_authored_prs(self) -> None:
+        """The check_suite retry path must filter to owner-authored PRs."""
+        step = self.jobs["enable-auto-merge"]["steps"][0]
+        script = step["run"]
+        # Must filter by author login matching repo owner
+        assert "author.login" in script
+        assert "REPO_OWNER" in script
+        # Must filter to open PRs targeting main
+        assert "--state open" in script
+        assert "--base main" in script
+
+    def test_auto_merge_uses_squash(self) -> None:
+        """All gh pr merge calls must use --auto --squash."""
+        step = self.jobs["enable-auto-merge"]["steps"][0]
+        script = step["run"]
+        assert "--auto --squash" in script
+
+    def test_failures_are_tolerated(self) -> None:
+        """gh pr merge failures should produce notices, not job failures."""
+        step = self.jobs["enable-auto-merge"]["steps"][0]
+        script = step["run"]
+        # Should have || fallback for idempotency
+        assert "::notice::" in script


### PR DESCRIPTION
## Plan
`plans/sessions/2026-03-21_auto-merge-retry.md` (handoff: `plans/sessions/2026-03-21_auto-merge-retry-followup-handoff.md`)

## Summary
- Add `synchronize` to `pull_request` triggers so auto-merge is re-enabled after rebases/force pushes
- Add `check_suite: completed` trigger to retry auto-merge after CI passes
- For check_suite events, resolve eligible PRs via `gh pr list` filtered to open, owner-authored PRs targeting main
- Add 9 structural regression tests locking the workflow invariants

## Why
Owner-authored PRs that miss the initial auto-merge enablement attempt (at PR open) currently sit clean-but-unmerged unless manually merged. This adds a retry path so GitHub auto-merge gets another chance after CI completes or the PR is rebased.

**Key boundary decisions:**
- This is an unattended-merge ergonomics fix, not a review-truth redesign
- `review_driver.py` intentionally remains out of merge authority (confirmed: it explicitly documents it does NOT call `enable_auto_merge`)
- The local merge guard still governs steward CLI merges
- GitHub auto-merge is being made retryable, not authoritative

## Repro / Validation
**Command(s) run:**
- `make check-quiet` ✅
- `uv run python -m pytest tests/unit/test_auto_merge_workflow.py -v` ✅ (9/9 pass)

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_auto_merge_workflow.py -v` — 9 structural tests
- [ ] Other: Manual smoke test pending (requires a real PR lifecycle)

## Expected impact
- Metrics impact: None (workflow-only, no game logic)
- Runtime impact: Additional workflow runs on `check_suite` events; each run is a single `gh pr list` API call that exits quickly if no eligible PRs

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git worktree list` (relevant line):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b  4493e7ea [ci/retry-auto-merge]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)