### PR TITLE
fix: stop claude-review from wasting turns on manual comment posting

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,10 +39,14 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             You are a read-only code reviewer. Your job is to inspect the PR diff
-            and relevant source files, then post review findings as PR comments.
+            and relevant source files, then produce review findings.
 
             DO NOT attempt to modify files, create commits, push branches, or
-            perform any implementation work. You may only read and comment.
+            perform any implementation work. You may only read and analyze code.
+
+            DO NOT attempt to post comments using `gh pr comment` or `gh api`.
+            The action framework handles posting your output automatically.
+            Just produce your findings as your final text output.
 
             Start by running `gh pr diff ${{ github.event.pull_request.number }}` to understand
             the change scope, then read the changed files for detailed review.
@@ -52,7 +56,8 @@ jobs:
             - Security concerns
             - Adherence to project conventions (see CLAUDE.md)
 
-            Post your findings as review comments on the PR.
+            Format your findings as a structured review with severity levels
+            (BLOCK, WARN, INFO) and a final summary.
 
           # Tool access strategy:
           # - Bash scoped via --disallowedTools blocklist + --allowedTools allowlist

--- a/tests/unit/test_claude_review_workflow.py
+++ b/tests/unit/test_claude_review_workflow.py
@@ -107,6 +107,38 @@ class TestClaudeReviewWorkflow:
             "not git diff, so full history is unnecessary"
         )
 
+    def test_prompt_does_not_instruct_manual_posting(self):
+        """Prompt must NOT tell Claude to post comments via gh pr comment.
+
+        Claude Code's sandbox heuristics block multi-line bodies containing
+        #-prefixed lines (markdown headers) as potential obfuscation. When
+        the prompt says "post findings as review comments", Claude attempts
+        gh pr comment with markdown, gets blocked repeatedly, and exhausts
+        all turns without producing output. The action framework handles
+        posting automatically — Claude just needs to produce text output.
+
+        Regression test for run 23388128292 (PR #1211).
+        """
+        step = self._review_step()
+        prompt = step["with"]["prompt"].lower()
+        assert "post" not in prompt or "do not" in prompt.split("post")[0][-30:], (
+            "prompt must not instruct Claude to post comments — "
+            "the action framework handles posting automatically"
+        )
+
+    def test_prompt_prohibits_gh_pr_comment(self):
+        """Prompt must explicitly forbid gh pr comment and gh api posting.
+
+        Without an explicit prohibition, Claude may still attempt to use
+        these tools to post review findings, wasting turns on sandbox
+        errors.
+        """
+        step = self._review_step()
+        prompt = step["with"]["prompt"].lower()
+        assert (
+            "do not" in prompt and "gh pr comment" in prompt
+        ), "prompt must explicitly prohibit gh pr comment"
+
     def test_prompt_uses_gh_pr_diff(self):
         """Reviewer prompt must use `gh pr diff` not `git diff`.
 


### PR DESCRIPTION
## Plan
N/A — targeted fix for observed CI failure on PR #1211

## Summary
- Rewrote `claude-code-review.yml` prompt to stop instructing Claude to manually post review comments
- Added explicit prohibition against `gh pr comment` and `gh api` for posting
- Added 2 regression tests in `test_claude_review_workflow.py`

## Why
Claude Code's sandbox heuristics block multi-line Bash commands containing `#`-prefixed lines (markdown headers) as potential obfuscation. The old prompt said "Post your findings as review comments on the PR", causing Claude to attempt `gh pr comment 1211 --body "## Summary..."` which got blocked 5 times with errors like:
- "Command contains a quoted newline followed by a #-prefixed line"
- "Command contains consecutive quote characters at word start (potential obfuscation)"

This burned all 15 turns before hitting `error_max_turns`. The `anthropics/claude-code-action@v1` framework handles posting automatically — Claude just needs to produce text output.

Evidence: run `23388128292` on PR #1211, job `68038353169`.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_claude_review_workflow.py -v  # 23 passed
make check-quiet  # all checks passed (after staging both files)
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_claude_review_workflow.py -v` — 23 passed
- [x] Other: Verified against actual run logs (run 23388128292)

## Expected impact
- Metrics impact: none (CI infra only)
- Runtime impact: Should eliminate max-turns exhaustion failures in claude-review

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
```

`git worktree list`:
```
(steward-author-d persistent worktree)
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)