### PR TITLE
ops: add lane registry visibility and resume foundation

### DIFF
--- a/.claude/runtime/worktree_registry/README.md
+++ b/.claude/runtime/worktree_registry/README.md
@@ -31,7 +31,9 @@ lanes) or `<role>.json` (for legacy role worktrees, backward compatible).
   "tmux_pane": "1",
   "cmux_workspace_ref": null,
   "cmux_surface_ref": null,
-  "legacy_role": null
+  "legacy_role": null,
+  "session_handle": "steward:author-a",
+  "visibility": "foreground"
 }
 ```
 
@@ -55,7 +57,9 @@ lanes) or `<role>.json` (for legacy role worktrees, backward compatible).
   "tmux_pane": null,
   "cmux_workspace_ref": null,
   "cmux_surface_ref": null,
-  "legacy_role": "author"
+  "legacy_role": "author",
+  "session_handle": "role:author-a",
+  "visibility": null
 }
 ```
 
@@ -80,6 +84,8 @@ lanes) or `<role>.json` (for legacy role worktrees, backward compatible).
 | `cmux_workspace_ref` | string/null | no | v2 | cmux workspace reference (future use) |
 | `cmux_surface_ref` | string/null | no | v2 | cmux surface reference (future use) |
 | `legacy_role` | string/null | no | v2 | Legacy role name (`author`, `review`, `ops`) if created by legacy scripts. Null for steward lanes. |
+| `session_handle` | string/null | no | v2 | Resume-targeting handle (e.g., `steward:author-a`, `role:author-a`). Null for ephemeral or legacy entries without a stable handle. |
+| `visibility` | string/null | no | v2 | Worker visibility class: `foreground` (dashboard panes), `background` (off-dashboard windows), or null (unknown/legacy). |
 
 ### Field Semantics
 
@@ -106,6 +112,19 @@ commands or navigate to a lane, but are not primary identity.
 the legacy `start-role-worktree.sh` script. It enables backward compatibility
 during the transition period. Null for worktrees created by the steward
 launcher.
+
+**`session_handle`** is a stable resume-targeting key. Format is
+`<transport>:<lane_id>` (e.g., `steward:author-a` for steward lanes,
+`role:author-a` for legacy role worktrees). Null for ephemeral worktrees or
+entries written before this field was introduced. Used by follow-on
+resume-by-name tooling.
+
+**`visibility`** is the worker visibility class, written by the launcher based
+on tmux layout. Values: `foreground` (dashboard panes visible in the main
+tmux window), `background` (off-dashboard windows like author-c, author-d,
+author-scratch). Null for legacy entries or entries written before this field
+was introduced. Not used for routing or scheduling — purely informational for
+operator tooling.
 
 ### Lifecycle Class Values
 
@@ -159,9 +178,12 @@ v1 entries are accepted by v2 readers. Missing v2 fields are inferred:
 | `tmux_*` | null |
 | `cmux_*` | null |
 | `legacy_role` | Same as `role` |
+| `session_handle` | null |
+| `visibility` | null |
 
 Writers should produce v2 entries. v1 entries will not be actively migrated
-but remain readable.
+but remain readable. Older v2 entries written before `session_handle` and
+`visibility` were introduced are also accepted — readers default both to null.
 
 ## v1 Schema (Deprecated)
 

--- a/.claude/scripts/start-role-worktree.sh
+++ b/.claude/scripts/start-role-worktree.sh
@@ -99,7 +99,9 @@ write_registry() {
   "tmux_pane": null,
   "cmux_workspace_ref": null,
   "cmux_surface_ref": null,
-  "legacy_role": "${role}"
+  "legacy_role": "${role}",
+  "session_handle": "role:${lane_id}",
+  "visibility": null
 }
 EOJSON
 }

--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -133,7 +133,7 @@ now_iso() {
 }
 
 # Write a v2 worktree registry entry for a steward lane.
-# Args: lane_id lane_class worktree_path branch tmux_window [tmux_pane]
+# Args: lane_id lane_class worktree_path branch tmux_window [tmux_pane] [visibility] [display_name]
 write_lane_metadata() {
     local lane_id="$1"
     local lane_class="$2"
@@ -141,6 +141,8 @@ write_lane_metadata() {
     local branch="$4"
     local tmux_window="$5"
     local tmux_pane="${6:-null}"
+    local visibility="${7:-null}"
+    local display_name="${8:-null}"
     local now
     now="$(now_iso)"
 
@@ -169,6 +171,21 @@ except Exception:
         pane_val="\"${tmux_pane}\""
     fi
 
+    # Quote visibility if it's not null
+    local vis_val="null"
+    if [ "$visibility" != "null" ]; then
+        vis_val="\"${visibility}\""
+    fi
+
+    # Quote display_name if it's not null
+    local dn_val="null"
+    if [ "$display_name" != "null" ]; then
+        dn_val="\"${display_name}\""
+    fi
+
+    # Derive session_handle from lane_id
+    local session_handle="\"steward:${lane_id}\""
+
     cat > "$REGISTRY_DIR/${lane_id}.json" <<EOJSON
 {
   "schema_version": 2,
@@ -181,13 +198,15 @@ except Exception:
   "last_active": "${now}",
   "session_id": null,
   "ttl_hours": null,
-  "display_name": null,
+  "display_name": ${dn_val},
   "tmux_session": "${SESSION}",
   "tmux_window": "${tmux_window}",
   "tmux_pane": ${pane_val},
   "cmux_workspace_ref": null,
   "cmux_surface_ref": null,
-  "legacy_role": null
+  "legacy_role": null,
+  "session_handle": ${session_handle},
+  "visibility": ${vis_val}
 }
 EOJSON
 }
@@ -215,13 +234,14 @@ ensure_worktree "$AUTHOR_SCRATCH" "codex/steward-author-scratch"
 ensure_review_worktree
 
 # Write v2 registry metadata for each lane
-write_lane_metadata "author-a"       "author"  "$AUTHOR_A"       "codex/steward-author"         "dashboard" "1"
-write_lane_metadata "author-b"       "author"  "$AUTHOR_B"       "codex/steward-author-b"       "dashboard" "2"
-write_lane_metadata "review"         "review"  "$REVIEW"         "detached"                     "dashboard" "3"
-write_lane_metadata "ops"            "ops"     "$MAIN_DIR"       "--"                           "dashboard" "4"
-write_lane_metadata "author-c"       "author"  "$AUTHOR_C"       "codex/steward-author-c"       "author-c"
-write_lane_metadata "author-d"       "author"  "$AUTHOR_D"       "codex/steward-author-d"       "author-d"
-write_lane_metadata "author-scratch" "scratch" "$AUTHOR_SCRATCH" "codex/steward-author-scratch"  "author-scratch"
+# Dashboard panes: visibility=foreground; off-dashboard windows: visibility=background
+write_lane_metadata "author-a"       "author"  "$AUTHOR_A"       "codex/steward-author"         "dashboard" "1"    "foreground" "Author A"
+write_lane_metadata "author-b"       "author"  "$AUTHOR_B"       "codex/steward-author-b"       "dashboard" "2"    "foreground" "Author B"
+write_lane_metadata "review"         "review"  "$REVIEW"         "detached"                     "dashboard" "3"    "foreground" "Review"
+write_lane_metadata "ops"            "ops"     "$MAIN_DIR"       "--"                           "dashboard" "4"    "foreground" "Ops"
+write_lane_metadata "author-c"       "author"  "$AUTHOR_C"       "codex/steward-author-c"       "author-c"  "null" "background" "Author C"
+write_lane_metadata "author-d"       "author"  "$AUTHOR_D"       "codex/steward-author-d"       "author-d"  "null" "background" "Author D"
+write_lane_metadata "author-scratch" "scratch" "$AUTHOR_SCRATCH" "codex/steward-author-scratch"  "author-scratch" "null" "background" "Scratch"
 
 tmux new-session -d -s "$SESSION" -n dashboard -c "$AUTHOR_A" \
     "$CLAUDE_BIN" --name author-a --agent steward-author-a

--- a/plans/sessions/2026-03-21_platform1-slice1-field-contract.md
+++ b/plans/sessions/2026-03-21_platform1-slice1-field-contract.md
@@ -1,0 +1,146 @@
+# Platform-1 Slice 1 — Additive Field Contract
+
+**Date:** 2026-03-21
+**Author:** author-b
+**Parent:** `plans/agent_ops/1_coordination_core/sub/2026-03-21_platform1-lane-registry-foundation.md` (SP-1-01)
+
+## Locked Field Contract
+
+### New Registry Fields (additive to v2 schema)
+
+| Field | Type | Default | Writer | Description |
+|-------|------|---------|--------|-------------|
+| `session_handle` | `string/null` | `null` | Launcher (`steward-session.sh`, `start-role-worktree.sh`) | Resume-targeting handle. For steward lanes, set to `"steward:<lane_id>"` (e.g., `"steward:author-a"`). For legacy role lanes, set to `"role:<role>"`. Null for ephemeral worktrees without a stable handle. |
+| `visibility` | `string/null` | `null` | Launcher | Worker visibility class: `"foreground"` (dashboard panes), `"background"` (off-dashboard windows), or `null` (unknown/legacy). Reserved value `"hidden"` is NOT written by any current launcher. |
+
+### Derivation Rules
+
+- **`session_handle`**: Composed from existing launcher data. Format is `"<transport>:<lane_id>"`:
+  - Steward launcher → `"steward:<lane_id>"` (e.g., `"steward:author-b"`)
+  - Legacy launcher → `"role:<role>"` (e.g., `"role:author"`)
+  - Ephemeral/unknown → `null`
+
+- **`visibility`**: Written by launchers based on tmux layout:
+  - Dashboard panes (author-a, author-b, review, ops in `dashboard` window) → `"foreground"`
+  - Off-dashboard windows (author-c, author-d, author-scratch) → `"background"`
+  - Legacy `start-role-worktree.sh` → `null` (no tmux layout info)
+  - Missing/unknown → `null` (reader defaults)
+
+### Backward Compatibility Rules
+
+1. **Missing fields default to `null`**: Older registry entries without `session_handle` or `visibility` are valid. Readers must `.setdefault()` both to `null`.
+2. **No schema_version bump**: These are additive nullable fields on the existing v2 schema. No version migration needed.
+3. **v1 entries**: The existing v1→v2 inference in `list_worktrees_registry()` already defaults missing fields. We add `session_handle` and `visibility` to the same defaulting block.
+
+### Display Name Defaults
+
+The existing `display_name` field is already in the schema but always written as `null`. This slice adds launcher-written defaults:
+
+| lane_id | display_name |
+|---------|-------------|
+| `author-a` | `"Author A"` |
+| `author-b` | `"Author B"` |
+| `author-c` | `"Author C"` |
+| `author-d` | `"Author D"` |
+| `author-scratch` | `"Scratch"` |
+| `review` | `"Review"` |
+| `ops` | `"Ops"` |
+| Legacy role lanes | `null` (no change) |
+
+### Operator Surface Changes
+
+#### `ops.py worktrees --json` (matched entries)
+
+Add `visibility` and `session_handle` to each matched entry dict:
+
+```json
+{
+  "path": "...",
+  "branch": "...",
+  "lane_id": "author-a",
+  "class": "persistent",
+  "visibility": "foreground",
+  "session_handle": "steward:author-a"
+}
+```
+
+#### `ops.py status --json` (lanes array)
+
+Add `visibility` and `session_handle` to each lane dict:
+
+```json
+{
+  "lane_id": "author-a",
+  "visibility": "foreground",
+  "session_handle": "steward:author-a",
+  ...existing fields...
+}
+```
+
+#### `ops.py status` (text output)
+
+No layout change to the text status line. The `visibility` field is informational and surfaced only in JSON. The text output already shows enough context via state badges and task info.
+
+#### `ops.py worktrees` (text output)
+
+Append visibility badge after lifecycle class:
+
+```
+  author-a        [persistent ] [fg ] codex/steward-author
+  author-c        [persistent ] [bg ] codex/steward-author-c
+  review          [persistent ] [—  ] detached
+```
+
+Where `fg` = foreground, `bg` = background, `—` = null/unknown.
+
+## File-by-File Implementation Plan
+
+### 1. `.claude/tmux/steward-session.sh`
+
+- Add `session_handle` and `visibility` parameters to `write_lane_metadata()` function
+- Add `display_name` parameter to `write_lane_metadata()` function
+- Update all 7 `write_lane_metadata` call sites with the new args
+- Dashboard lanes get `visibility="foreground"`, off-dashboard get `visibility="background"`
+
+### 2. `.claude/scripts/start-role-worktree.sh`
+
+- Add `session_handle`, `visibility`, `display_name` fields to `write_registry()` heredoc
+- `session_handle` = `"role:${role}"`, `visibility` = `null`, `display_name` = `null`
+
+### 3. `src/bid_euchre/ops/worktrees.py`
+
+- In `list_worktrees_registry()`, add `.setdefault("session_handle", None)` and `.setdefault("visibility", None)` to the v1→v2 inference block
+- Also add defaults in a new block for v2 entries missing the additive fields (backward compat for entries written before this PR)
+
+### 4. `src/bid_euchre/ops/status.py`
+
+- Add `visibility: str | None = None` and `session_handle: str | None = None` fields to `LaneStatus` dataclass
+- In `synthesize_lane_activity()`, read these from lane data and pass to `LaneStatus` constructor
+- In `format_status_json()`, include `visibility` and `session_handle` in lane dicts
+- No change to `format_status_text()` (visibility only in JSON)
+
+### 5. `scripts/internal/ops.py`
+
+- In `cmd_worktrees()`, add `visibility` and `session_handle` to matched JSON output
+- In `cmd_worktrees()` text output, add visibility badge after class column
+
+### 6. `.claude/runtime/worktree_registry/README.md`
+
+- Add `session_handle` and `visibility` to the fields table
+- Add to v2 examples
+- Add to v1→v2 migration table
+
+### 7. `.claude/runtime/session_metadata/README.md`
+
+- No changes needed (session_handle lives in registry, not session metadata)
+
+### 8. Tests
+
+- `test_ops_worktrees.py`: Test normalization defaults for entries missing `session_handle`/`visibility`
+- `test_ops_status.py`: Test that `LaneStatus` carries `visibility`/`session_handle` from registry
+- `test_ops_cli.py`: Test JSON output includes the new fields
+- `test_steward_session.py`: Test that bash syntax still validates (already covered by `bash -n`)
+
+## Outcome
+
+_Filled after implementation._

--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -144,6 +144,8 @@ def cmd_worktrees(args: argparse.Namespace) -> int:
                     "branch": wt.branch,
                     "lane_id": entry.get("lane_id", "?"),
                     "class": entry.get("class", "?"),
+                    "visibility": entry.get("visibility"),
+                    "session_handle": entry.get("session_handle"),
                 }
                 for wt, entry in report.matched
             ],
@@ -161,13 +163,18 @@ def cmd_worktrees(args: argparse.Namespace) -> int:
         }
         print(json.dumps(data, indent=2))
     else:
+        _VIS_BADGES = {"foreground": "fg", "background": "bg"}
+
         print("=== Worktree Registry ===")
         print()
         print(f"Registered & matched: {len(report.matched)}")
         for wt, entry in report.matched:
+            vis = entry.get("visibility")
+            vis_badge = _VIS_BADGES.get(vis, "\u2014") if vis else "\u2014"
             print(
                 f"  {entry.get('lane_id', '?'):15s} "
                 f"[{entry.get('class', '?'):10s}] "
+                f"[{vis_badge:3s}] "
                 f"{wt.branch}"
             )
 

--- a/src/bid_euchre/ops/status.py
+++ b/src/bid_euchre/ops/status.py
@@ -115,6 +115,10 @@ class LaneStatus:
     last_event_type: str | None = None
     last_event_at: str | None = None
 
+    # --- Worker visibility & resume (Platform-1 additive fields) ---
+    visibility: str | None = None
+    session_handle: str | None = None
+
 
 @dataclass
 class StatusReport:
@@ -850,6 +854,8 @@ def synthesize_lane_activity(
             liveness_source=liveness_source,
             last_event_type=last_event_type,
             last_event_at=last_event_at,
+            visibility=lane.get("visibility"),
+            session_handle=lane.get("session_handle"),
         )
         results.append(lane_status)
 
@@ -1214,6 +1220,8 @@ def format_status_json(report: StatusReport) -> dict[str, Any]:
                 "last_checkpoint": lane.last_checkpoint,
                 "last_event_type": lane.last_event_type,
                 "last_event_at": lane.last_event_at,
+                "visibility": lane.visibility,
+                "session_handle": lane.session_handle,
             }
             for lane in report.lanes
         ],

--- a/src/bid_euchre/ops/worktrees.py
+++ b/src/bid_euchre/ops/worktrees.py
@@ -184,6 +184,11 @@ def list_worktrees_registry(
             ]:
                 data.setdefault(transport_field, None)
 
+        # Additive v2 fields — default for entries written before these
+        # fields were introduced (both v1 entries and older v2 entries).
+        data.setdefault("session_handle", None)
+        data.setdefault("visibility", None)
+
         entries.append(data)
 
     return entries

--- a/tests/unit/test_ops_cli.py
+++ b/tests/unit/test_ops_cli.py
@@ -440,6 +440,116 @@ class TestCmdWorktrees:
         assert "matched" in data
         assert "unregistered" in data
 
+    def test_worktrees_json_includes_visibility(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Worktrees JSON output includes visibility and session_handle fields."""
+        from bid_euchre.ops import worktrees as wt_mod
+
+        # Create a registry entry with additive fields
+        reg_dir = runtime_dir / "worktree_registry"
+        reg_dir.mkdir(parents=True, exist_ok=True)
+        (reg_dir / "author-a.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 2,
+                    "lane_id": "author-a",
+                    "lane_class": "author",
+                    "worktree_path": "/tmp/wt-a",
+                    "branch": "codex/steward-author",
+                    "class": "persistent",
+                    "last_active": "2026-03-21T10:00:00Z",
+                    "session_handle": "steward:author-a",
+                    "visibility": "foreground",
+                }
+            )
+        )
+
+        # Mock git to return a matching worktree
+        monkeypatch.setattr(
+            wt_mod,
+            "list_worktrees_git",
+            lambda: [
+                wt_mod.GitWorktree(
+                    path="/tmp/wt-a", head="abc", branch="codex/steward-author"
+                )
+            ],
+        )
+
+        import ops
+
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "worktrees",
+            ]
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert len(data["matched"]) == 1
+        matched = data["matched"][0]
+        assert matched["visibility"] == "foreground"
+        assert matched["session_handle"] == "steward:author-a"
+
+    def test_worktrees_json_null_visibility_for_old_entries(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Old entries without visibility get null in JSON output."""
+        from bid_euchre.ops import worktrees as wt_mod
+
+        reg_dir = runtime_dir / "worktree_registry"
+        reg_dir.mkdir(parents=True, exist_ok=True)
+        (reg_dir / "ops.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 2,
+                    "lane_id": "ops",
+                    "lane_class": "ops",
+                    "worktree_path": "/tmp/wt-ops",
+                    "branch": "--",
+                    "class": "persistent",
+                    "last_active": "2026-03-21T10:00:00Z",
+                }
+            )
+        )
+
+        monkeypatch.setattr(
+            wt_mod,
+            "list_worktrees_git",
+            lambda: [wt_mod.GitWorktree(path="/tmp/wt-ops", head="def", branch="--")],
+        )
+
+        import ops
+
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "worktrees",
+            ]
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert len(data["matched"]) == 1
+        matched = data["matched"][0]
+        assert matched["visibility"] is None
+        assert matched["session_handle"] is None
+
 
 class TestCmdWorktreesPrune:
     """Tests for the worktrees prune subcommand."""

--- a/tests/unit/test_ops_status.py
+++ b/tests/unit/test_ops_status.py
@@ -506,6 +506,40 @@ class TestFormatters:
         assert lane_json["attention_needed"] is False
         assert lane_json["attention_reason"] is None
 
+    def test_json_includes_visibility_and_session_handle(self) -> None:
+        """JSON output includes Platform-1 additive fields."""
+        lane = LaneStatus(
+            lane_id="author-a",
+            lane_class="author",
+            worktree_path="/tmp/wt-a",
+            branch="codex/steward-author",
+            lifecycle_class="persistent",
+            has_active_session=False,
+            visibility="foreground",
+            session_handle="steward:author-a",
+        )
+        report = StatusReport(lanes=[lane])
+        data = format_status_json(report)
+        lane_json = data["lanes"][0]
+        assert lane_json["visibility"] == "foreground"
+        assert lane_json["session_handle"] == "steward:author-a"
+
+    def test_json_null_visibility_when_absent(self) -> None:
+        """JSON output shows null for missing visibility/session_handle."""
+        lane = LaneStatus(
+            lane_id="ops",
+            lane_class="ops",
+            worktree_path="/tmp/wt-ops",
+            branch="--",
+            lifecycle_class="persistent",
+            has_active_session=False,
+        )
+        report = StatusReport(lanes=[lane])
+        data = format_status_json(report)
+        lane_json = data["lanes"][0]
+        assert lane_json["visibility"] is None
+        assert lane_json["session_handle"] is None
+
     def test_text_shows_warnings(self) -> None:
         report = StatusReport(warnings=["Something is wrong"])
         text = format_status_text(report)
@@ -656,6 +690,42 @@ class TestSynthesizeLaneActivity:
         lane = result[0]
         assert lane.state == "idle"
         assert lane.attention_needed is False
+
+    # --- Platform-1 additive field tests ---
+
+    def test_visibility_and_session_handle_from_registry(self) -> None:
+        """Lane with visibility/session_handle in registry data surfaces in LaneStatus."""
+        lane_data = _make_lane("author-a", session_id="s1")
+        lane_data["visibility"] = "foreground"
+        lane_data["session_handle"] = "steward:author-a"
+
+        result = synthesize_lane_activity(
+            [lane_data],
+            {"author-a": {"task": "Test", "started_at": "2026-03-19T10:00:00Z"}},
+            {},
+            [],
+        )
+        assert result[0].visibility == "foreground"
+        assert result[0].session_handle == "steward:author-a"
+
+    def test_missing_visibility_defaults_to_none(self) -> None:
+        """Lane without visibility in registry data gets None in LaneStatus."""
+        lane_data = _make_lane("author-b")
+        # No visibility or session_handle keys in lane_data
+
+        result = synthesize_lane_activity([lane_data], {}, {}, [])
+        assert result[0].visibility is None
+        assert result[0].session_handle is None
+
+    def test_background_visibility_surfaces(self) -> None:
+        """Background visibility is surfaced correctly."""
+        lane_data = _make_lane("author-c")
+        lane_data["visibility"] = "background"
+        lane_data["session_handle"] = "steward:author-c"
+
+        result = synthesize_lane_activity([lane_data], {}, {}, [])
+        assert result[0].visibility == "background"
+        assert result[0].session_handle == "steward:author-c"
 
     def test_session_with_pending_task_is_active(self) -> None:
         """Lane with session + pending task → active.
@@ -2370,6 +2440,8 @@ class TestJsonOutputStability:
             "last_checkpoint",
             "last_event_type",
             "last_event_at",
+            "visibility",
+            "session_handle",
         }
         assert set(lane_json.keys()) == expected_fields
         assert lane_json["last_event_type"] == "ci_success"

--- a/tests/unit/test_ops_worktrees.py
+++ b/tests/unit/test_ops_worktrees.py
@@ -146,6 +146,71 @@ class TestListWorktreesRegistry:
         entries = list_worktrees_registry(registry_dir)
         assert len(entries) == 1
 
+    # --- Platform-1 additive field tests ---
+
+    def test_v2_entry_defaults_additive_fields(self, registry_dir: Path) -> None:
+        """v2 entry written before session_handle/visibility gets null defaults."""
+        _write_registry_entry(registry_dir, "author-a.json", lane_id="author-a")
+
+        entries = list_worktrees_registry(registry_dir)
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["session_handle"] is None
+        assert entry["visibility"] is None
+
+    def test_v2_entry_preserves_additive_fields(self, registry_dir: Path) -> None:
+        """v2 entry with session_handle/visibility preserves them."""
+        _write_registry_entry(
+            registry_dir,
+            "author-a.json",
+            lane_id="author-a",
+            session_handle="steward:author-a",
+            visibility="foreground",
+        )
+
+        entries = list_worktrees_registry(registry_dir)
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["session_handle"] == "steward:author-a"
+        assert entry["visibility"] == "foreground"
+
+    def test_v1_entry_defaults_additive_fields(self, registry_dir: Path) -> None:
+        """v1 entry gets null defaults for session_handle/visibility."""
+        v1_entry = {
+            "schema_version": 1,
+            "role": "author",
+            "worktree_path": "/tmp/wt-author",
+            "branch": "role/author",
+            "class": "persistent",
+            "created_at": "2026-03-16T22:00:00Z",
+            "last_active": "2026-03-16T22:00:00Z",
+            "session_id": None,
+            "ttl_hours": None,
+        }
+        (registry_dir / "author.json").write_text(json.dumps(v1_entry))
+
+        entries = list_worktrees_registry(registry_dir)
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["session_handle"] is None
+        assert entry["visibility"] is None
+        # Also verify other v1→v2 inference still works
+        assert entry["lane_id"] == "author-a"
+
+    def test_background_visibility_preserved(self, registry_dir: Path) -> None:
+        """Background visibility round-trips through read."""
+        _write_registry_entry(
+            registry_dir,
+            "author-c.json",
+            lane_id="author-c",
+            session_handle="steward:author-c",
+            visibility="background",
+        )
+
+        entries = list_worktrees_registry(registry_dir)
+        assert entries[0]["visibility"] == "background"
+        assert entries[0]["session_handle"] == "steward:author-c"
+
 
 class TestIsProtected:
     """Tests for is_protected()."""


### PR DESCRIPTION
## Plan
- `plans/agent_ops/1_coordination_core/sub/2026-03-21_platform1-lane-registry-foundation.md` (SP-1-01)
- `plans/sessions/2026-03-21_platform1-slice1-field-contract.md` (field contract)

## Summary
- Add `session_handle` and `visibility` as additive nullable fields to the v2 worktree registry schema
- Launcher writers emit resume-targeting handles and visibility classes (foreground/background)
- Reader normalization defaults both fields to null for backward compatibility with older entries
- Operator CLI surfaces the new fields in JSON and text output

## Why
Platform-1 slice 1: durable lane identity for resume targeting and worker visibility in operator tooling. Replaces tmux pane guesswork with explicit registry-backed metadata.

## Repro / Validation
**Command(s) run:**
- `bash -n .claude/tmux/steward-session.sh` — OK
- `bash -n .claude/scripts/start-role-worktree.sh` — OK
- `uv run python -m pytest tests/unit/test_ops_worktrees.py tests/unit/test_ops_status.py tests/unit/test_ops_cli.py tests/unit/test_steward_session.py -q` — 346 passed
- `make check-quiet` — all checks passed

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_worktrees.py tests/unit/test_ops_status.py tests/unit/test_ops_cli.py tests/unit/test_steward_session.py` — 346 passed, 0 failures
- 11 new tests:
  - 4 registry normalization tests (v1 defaults, v2 defaults, v2 preserves, background round-trip)
  - 5 status synthesis tests (visibility from registry, missing defaults, background, JSON includes, JSON null)
  - 2 CLI tests (worktrees JSON includes fields, old entries get null)
  - 1 stability test updated (expected_fields set)

## Expected impact
- Metrics impact: none (ops tooling only)
- Runtime impact: none (additive fields, no new I/O)

## Risk level
- [x] Low (ops tooling and docs only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git worktree list` (truncated):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                     85d83a24 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b    d87f1a5c [ops/lane-registry-visibility]
```

## Locked Field Contract

| Field | Type | Default | Writer |
|-------|------|---------|--------|
| `session_handle` | string/null | null | Launcher — `"steward:<lane_id>"` for steward, `"role:<lane_id>"` for legacy |
| `visibility` | string/null | null | Launcher — `"foreground"` (dashboard) or `"background"` (off-dashboard) |

Backward compatibility: older entries without these fields get null defaults via `setdefault()` in the reader normalization (both v1 and v2 entries).

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)