### PR TITLE
fix: address Platform-2 review findings F1-F5

### DIFF
--- a/plans/agent_ops/sub_plan_registry.md
+++ b/plans/agent_ops/sub_plan_registry.md
@@ -10,7 +10,7 @@
 | ID | Title | Parent Section | Status | Owner | File | Created | Completed |
 |----|-------|----------------|--------|-------|------|---------|-----------|
 | SP-0-01 | Phase 0 bridge hardening for Platform-1 entry | Phase 0 dependencies; entry criteria; `Platform-1` done-when | superseded | Codex | `plans/agent_ops/0_bootstrap/sub/2026-03-20_platform-entry-hardening.md` | 2026-03-20 | 2026-03-20 |
-| SP-0-02 | Platform-1 prep PR handoff | Phase 0 dependencies and `Platform-1` handoff boundary | completed | Opus | `plans/agent_ops/0_bootstrap/sub/2026-03-20_platform1-prep-pr-handoff.md` | 2026-03-20 | 2026-03-21 |
+| SP-0-02 | Platform-1 prep PR handoff | Phase 0 dependencies and `Platform-1` handoff boundary | completed (closed by PR #1218) | Opus | `plans/agent_ops/0_bootstrap/sub/2026-03-20_platform1-prep-pr-handoff.md` | 2026-03-20 | 2026-03-21 |
 | SP-1-01 | Platform-1 lane registry foundation | Phase 1 Platform-1 implementation | completed | author-b | `plans/agent_ops/1_coordination_core/sub/2026-03-21_platform1-lane-registry-foundation.md` | 2026-03-21 | 2026-03-21 |
 | SP-1-02 | Platform-2 orchestrator intake | Phase 1 Platform-2 implementation | in_progress | author-b | `plans/agent_ops/1_coordination_core/sub/2026-03-21_platform2-orchestrator-intake.md` | 2026-03-21 | -- |
 

--- a/src/bid_euchre/ops/__init__.py
+++ b/src/bid_euchre/ops/__init__.py
@@ -93,15 +93,3 @@ CI_CHECK_NAMES: frozenset[str] = frozenset(
 # Default timeout (seconds) for gh CLI subprocess calls.
 # Operator surfaces must never hang indefinitely.
 GH_TIMEOUT_SECONDS: int = 30
-
-# ---------------------------------------------------------------------------
-# Task queue event types (Platform-2)
-# ---------------------------------------------------------------------------
-# These extend VALID_EVENT_TYPES in events.py for task lifecycle signals.
-TASK_QUEUE_EVENT_TYPES: tuple[str, ...] = (
-    "task_packet_created",
-    "task_packet_dispatched",
-    "task_packet_completed",
-    "task_packet_rejected",
-    "task_packet_redirected",
-)

--- a/src/bid_euchre/ops/task_queue.py
+++ b/src/bid_euchre/ops/task_queue.py
@@ -14,7 +14,6 @@ Storage is file-based under ``.claude/runtime/task_queue/``:
 
 from __future__ import annotations
 
-import fcntl
 import json
 import logging
 import shutil
@@ -60,6 +59,22 @@ KNOWN_AUTHOR_LANES = frozenset(
         "author-scratch",
     }
 )
+
+# Valid state transitions for the task packet lifecycle.
+# Enforced by transition_status() to prevent incoherent state from
+# misbehaving agents.
+#
+# The pending state allows both preview (non-trivial) and direct approval
+# (trivial tasks that skip preview per orchestrator profile guidelines).
+VALID_TRANSITIONS: dict[str, frozenset[str]] = {
+    "pending": frozenset({"previewing", "approved", "rejected", "redirected"}),
+    "previewing": frozenset({"approved", "rejected", "redirected"}),
+    "approved": frozenset({"dispatched", "rejected"}),
+    "dispatched": frozenset({"completed"}),
+    "completed": frozenset(),  # terminal
+    "rejected": frozenset(),  # terminal
+    "redirected": frozenset(),  # terminal
+}
 
 
 # ---------------------------------------------------------------------------
@@ -251,15 +266,18 @@ def shared_task_root(runtime_dir: Path | None = None) -> Path:
 
 
 def _write_json_atomic(path: Path, data: dict[str, Any]) -> None:
-    """Write JSON data atomically using a temporary file + rename."""
+    """Write JSON data atomically using a temporary file + rename.
+
+    Relies on POSIX ``rename()`` atomicity for crash safety.
+    No cross-process locking — last writer wins in concurrent scenarios.
+    Platform-3 may add a lockfile protocol if needed.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = path.with_suffix(".tmp")
     try:
         with open(tmp_path, "w") as f:
-            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
             json.dump(data, f, indent=2, default=str)
             f.write("\n")
-            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
         tmp_path.rename(path)
     except Exception:
         if tmp_path.exists():
@@ -469,6 +487,15 @@ def transition_status(
         logger.warning("Cannot transition: packet %s not found", packet_id)
         return None
 
+    # Validate the transition against the state machine
+    allowed = VALID_TRANSITIONS.get(pkt.status, frozenset())
+    if new_status not in allowed:
+        raise ValueError(
+            f"Invalid transition {pkt.status!r} -> {new_status!r} for "
+            f"packet {packet_id!r}; allowed targets from {pkt.status!r}: "
+            f"{sorted(allowed) if allowed else '(terminal state)'}"
+        )
+
     # Build updated packet (frozen dataclass — reconstruct)
     data = asdict(pkt)
     data["status"] = new_status
@@ -542,10 +569,10 @@ def apply_ack(
         return new_pkt
 
     elif ack.action == "reject":
-        transition_status(ack.packet_id, "rejected", root)
+        rejected_pkt = transition_status(ack.packet_id, "rejected", root)
         archive_packet(ack.packet_id, root)
         logger.info("Rejected and archived %s", ack.packet_id)
-        return load_packet(ack.packet_id, root)  # Will be None (archived)
+        return rejected_pkt  # Return the final state before archive
 
     return None
 

--- a/tests/unit/test_ops_task_queue.py
+++ b/tests/unit/test_ops_task_queue.py
@@ -18,6 +18,7 @@ from bid_euchre.ops.task_queue import (
     VALID_PRIORITIES,
     VALID_RESULT_STATUSES,
     VALID_STATUSES,
+    VALID_TRANSITIONS,
     TaskPacket,
     apply_ack,
     archive_packet,
@@ -331,7 +332,8 @@ class TestListPackets:
     def test_list_filter_by_status(self, tmp_path: Path) -> None:
         pkt1 = create_packet("Task 1", "Desc 1")
         save_packet(pkt1, tmp_path)
-        # Transition one to approved
+        # Transition through valid flow: pending -> previewing -> approved
+        transition_status(pkt1.packet_id, "previewing", tmp_path)
         transition_status(pkt1.packet_id, "approved", tmp_path)
         pkt2 = create_packet("Task 2", "Desc 2")
         save_packet(pkt2, tmp_path)
@@ -375,6 +377,12 @@ class TestLifecycleTransitions:
         pkt = create_packet("Task", "d")
         save_packet(pkt, tmp_path)
 
+        # pending -> previewing (valid)
+        updated = transition_status(pkt.packet_id, "previewing", tmp_path)
+        assert updated is not None
+        assert updated.status == "previewing"
+
+        # previewing -> approved (valid)
         updated = transition_status(pkt.packet_id, "approved", tmp_path)
         assert updated is not None
         assert updated.status == "approved"
@@ -384,6 +392,34 @@ class TestLifecycleTransitions:
         assert reloaded is not None
         assert reloaded.status == "approved"
 
+    def test_transition_pending_to_approved_direct(self, tmp_path: Path) -> None:
+        """Trivial tasks can skip preview: pending -> approved."""
+        pkt = create_packet("Trivial fix", "d")
+        save_packet(pkt, tmp_path)
+
+        updated = transition_status(pkt.packet_id, "approved", tmp_path)
+        assert updated is not None
+        assert updated.status == "approved"
+
+    def test_transition_invalid_from_terminal_raises(self, tmp_path: Path) -> None:
+        """Terminal states (completed, rejected, redirected) cannot transition."""
+        pkt = create_packet("Task", "d")
+        save_packet(pkt, tmp_path)
+        transition_status(pkt.packet_id, "rejected", tmp_path)
+
+        with pytest.raises(ValueError, match="Invalid transition"):
+            transition_status(pkt.packet_id, "approved", tmp_path)
+
+    def test_transition_dispatched_to_pending_raises(self, tmp_path: Path) -> None:
+        """Backward transitions are not allowed."""
+        pkt = create_packet("Task", "d")
+        save_packet(pkt, tmp_path)
+        transition_status(pkt.packet_id, "approved", tmp_path)
+        transition_status(pkt.packet_id, "dispatched", tmp_path)
+
+        with pytest.raises(ValueError, match="Invalid transition"):
+            transition_status(pkt.packet_id, "pending", tmp_path)
+
     def test_transition_nonexistent_returns_none(self, tmp_path: Path) -> None:
         shared_task_root(tmp_path)
         assert transition_status("nonexistent", "approved", tmp_path) is None
@@ -391,6 +427,26 @@ class TestLifecycleTransitions:
     def test_transition_invalid_status_raises(self, tmp_path: Path) -> None:
         with pytest.raises(ValueError, match="Invalid target status"):
             transition_status("any", "bogus", tmp_path)
+
+    def test_valid_transitions_covers_all_statuses(self) -> None:
+        """Every valid status has an entry in the transition map."""
+        assert set(VALID_TRANSITIONS.keys()) == VALID_STATUSES
+
+    def test_transition_map_targets_are_valid(self) -> None:
+        """All transition targets are themselves valid statuses."""
+        for source, targets in VALID_TRANSITIONS.items():
+            for target in targets:
+                assert (
+                    target in VALID_STATUSES
+                ), f"Transition {source!r} -> {target!r}: target is not a valid status"
+
+    def test_terminal_states_have_no_transitions(self) -> None:
+        """Terminal states (completed, rejected, redirected) cannot transition."""
+        for terminal in ("completed", "rejected", "redirected"):
+            assert VALID_TRANSITIONS[terminal] == frozenset(), (
+                f"{terminal!r} should be terminal but allows: "
+                f"{VALID_TRANSITIONS[terminal]}"
+            )
 
     def test_archive_packet(self, tmp_path: Path) -> None:
         pkt = create_packet("Task", "d")
@@ -490,7 +546,11 @@ class TestApplyAck:
         save_packet(pkt, tmp_path)
 
         ack = create_ack(pkt.packet_id, "reject")
-        apply_ack(ack, tmp_path)
+        rejected = apply_ack(ack, tmp_path)
+
+        # Return value should be the rejected packet (not None)
+        assert rejected is not None
+        assert rejected.status == "rejected"
 
         # After reject, packet is archived (not loadable from queue root)
         assert load_packet(pkt.packet_id, tmp_path) is None
@@ -517,6 +577,7 @@ class TestCompletePacket:
     def test_complete_and_archive(self, tmp_path: Path) -> None:
         pkt = create_packet("Task", "d", owner="author-b")
         save_packet(pkt, tmp_path)
+        transition_status(pkt.packet_id, "approved", tmp_path)
         transition_status(pkt.packet_id, "dispatched", tmp_path)
 
         result = create_result(
@@ -531,9 +592,49 @@ class TestCompletePacket:
         archive_dir = tmp_path / "archive"
         assert (archive_dir / f"{pkt.packet_id}.result.json").exists()
 
+    def test_complete_with_failed_result(self, tmp_path: Path) -> None:
+        """Failed result archives packet with dispatched status + result sidecar."""
+        pkt = create_packet("Task", "d", owner="author-a")
+        save_packet(pkt, tmp_path)
+        transition_status(pkt.packet_id, "approved", tmp_path)
+        transition_status(pkt.packet_id, "dispatched", tmp_path)
+
+        result = create_result(pkt.packet_id, "failed", "Tests failed")
+        final = complete_packet(result, tmp_path)
+
+        # Packet returned with its last valid status (dispatched)
+        assert final is not None
+        assert final.status == "dispatched"
+
+        # Packet is archived
+        assert load_packet(pkt.packet_id, tmp_path) is None
+
+        # Result sidecar in archive records the actual failure
+        archive_dir = tmp_path / "archive"
+        result_path = archive_dir / f"{pkt.packet_id}.result.json"
+        assert result_path.exists()
+        result_data = json.loads(result_path.read_text())
+        assert result_data["status"] == "failed"
+
+    def test_complete_with_blocked_result(self, tmp_path: Path) -> None:
+        """Blocked result archives packet with dispatched status + result sidecar."""
+        pkt = create_packet("Task", "d", owner="author-b")
+        save_packet(pkt, tmp_path)
+        transition_status(pkt.packet_id, "approved", tmp_path)
+        transition_status(pkt.packet_id, "dispatched", tmp_path)
+
+        result = create_result(pkt.packet_id, "blocked", "Blocked by dependency")
+        final = complete_packet(result, tmp_path)
+
+        assert final is not None
+        assert final.status == "dispatched"
+        assert load_packet(pkt.packet_id, tmp_path) is None
+
     def test_complete_without_archive(self, tmp_path: Path) -> None:
         pkt = create_packet("Task", "d", owner="author-a")
         save_packet(pkt, tmp_path)
+        transition_status(pkt.packet_id, "approved", tmp_path)
+        transition_status(pkt.packet_id, "dispatched", tmp_path)
 
         result = create_result(pkt.packet_id, "completed", "Done")
         complete_packet(result, tmp_path, archive=False)
@@ -565,6 +666,8 @@ class TestQueueSummary:
         save_packet(create_packet("T2", "d", owner="author-b"), tmp_path)
         pkt3 = create_packet("T3", "d", owner="author-a")
         save_packet(pkt3, tmp_path)
+        # Valid transition: pending -> approved -> dispatched
+        transition_status(pkt3.packet_id, "approved", tmp_path)
         transition_status(pkt3.packet_id, "dispatched", tmp_path)
 
         summary = queue_summary(tmp_path)


### PR DESCRIPTION
## Plan
- Follow-up to PR #1221 (Platform-2 orchestrator intake)
- SP-1-02 scope

## Summary
- **F1:** Remove dead `TASK_QUEUE_EVENT_TYPES` constant (never registered in `VALID_EVENT_TYPES`)
- **F2:** Add `VALID_TRANSITIONS` state machine map and enforce in `transition_status()`
- **F3:** Remove misleading `flock` on tmp file — `rename()` is already atomic on POSIX
- **F4:** `apply_ack(reject)` now returns the rejected packet state (not `None`)
- **F5:** Add tests for "failed" and "blocked" result paths through `complete_packet`
- **W3:** Annotate SP-0-02 completion with closing PR reference

## Why
Post-merge review of PR #1221 identified 3 WARN and 2 INFO findings.
All are addressed in this follow-up PR to strengthen the Platform-2
contract before multi-agent use.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_task_queue.py -v  # 62 passed
make check-quiet  # all checks passed
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_task_queue.py` — 62 tests (8 new)
- [x] `make check-quiet` — full suite green

New tests:
- `test_transition_pending_to_approved_direct` — trivial tasks skip preview
- `test_transition_invalid_from_terminal_raises` — terminal states block transitions
- `test_transition_dispatched_to_pending_raises` — backward transitions blocked
- `test_valid_transitions_covers_all_statuses` — map completeness
- `test_transition_map_targets_are_valid` — all targets are valid statuses
- `test_terminal_states_have_no_transitions` — terminal states are empty
- `test_complete_with_failed_result` — failed result archives with sidecar
- `test_complete_with_blocked_result` — blocked result archives with sidecar

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (ops tooling follow-up fixes)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                    [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b   [ops/platform2-orchestrator-intake]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed
- [x] Tests updated/added to lock new behavior (8 new tests)
- [x] PR is focused (one concept: review follow-up fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)