### PR TITLE
ops: add communication bus v1 foundation (Platform-3)

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -34,6 +34,9 @@ Usage:
     uv run python scripts/internal/ops.py repairs [--json]
     uv run python scripts/internal/ops.py task list [--status STATUS] [--owner LANE] [--json]
     uv run python scripts/internal/ops.py task show PACKET_ID [--json]
+    uv run python scripts/internal/ops.py inbox [--lane LANE] [--status STATUS] [--type TYPE] [--thread THREAD] [--json]
+    uv run python scripts/internal/ops.py inbox stats [--json]
+    uv run python scripts/internal/ops.py message show MSG_ID [--json]
 """
 
 from __future__ import annotations
@@ -1443,6 +1446,153 @@ def cmd_task(args: argparse.Namespace) -> int:
         return 1
 
 
+def cmd_inbox(args: argparse.Namespace) -> int:
+    """Communication bus inbox inspection (Platform-3)."""
+    from bid_euchre.ops.message_bus import inbox_stats, read_inbox
+
+    bus_root = args.runtime_dir / "message_bus"
+
+    action = getattr(args, "inbox_action", None)
+
+    if action == "stats":
+        stats = inbox_stats(bus_root)
+        if args.json:
+            print(json.dumps(stats, indent=2))
+        else:
+            lanes = stats.get("lanes", [])
+            if not lanes:
+                print("No inbox data.")
+            else:
+                print(f"Inbox Stats: {len(lanes)} lane(s)")
+                print()
+                for lane in lanes:
+                    print(f"  {lane['lane_id']:20s}  total={lane['total']}")
+                    for status, count in sorted(lane.get("by_status", {}).items()):
+                        print(f"    {status:16s}: {count}")
+        return 0
+
+    # Default: list messages
+    lane = getattr(args, "lane", None)
+    status_filter = getattr(args, "status", None)
+    type_filter = getattr(args, "type", None)
+    thread_filter = getattr(args, "thread", None)
+
+    if lane is None:
+        # Show aggregate stats across all lanes
+        stats = inbox_stats(bus_root)
+        if args.json:
+            print(json.dumps(stats, indent=2))
+        else:
+            lanes = stats.get("lanes", [])
+            if not lanes:
+                print("No inbox data. Use --lane LANE to inspect a specific lane.")
+            else:
+                print(f"Inbox Overview: {len(lanes)} lane(s)")
+                print("  Use --lane LANE to see messages for a specific lane.")
+                print()
+                for ln in lanes:
+                    total = ln["total"]
+                    by_s = ln.get("by_status", {})
+                    pending = by_s.get("pending", 0) + by_s.get("delivered", 0)
+                    print(f"  {ln['lane_id']:20s}  {total} msg  ({pending} unresolved)")
+        return 0
+
+    messages = read_inbox(
+        lane,
+        bus_root,
+        status=status_filter,
+        thread_id=thread_filter,
+        message_type=type_filter,
+    )
+
+    if args.json:
+        print(json.dumps(messages, indent=2, default=str))
+    else:
+        if not messages:
+            print(f"No messages in {lane} inbox.")
+        else:
+            print(f"Inbox for {lane}: {len(messages)} message(s)")
+            print()
+            for msg in messages:
+                priority = msg.get("priority", "normal")
+                prio_flag = " !" if priority in ("high", "urgent") else ""
+                print(
+                    f"  {msg.get('message_id', '?'):16s}  "
+                    f"[{msg.get('status', '?'):14s}]  "
+                    f"{msg.get('message_type', '?'):18s}  "
+                    f"from={msg.get('from_lane', '?'):12s}  "
+                    f"{msg.get('summary', '')[:50]}{prio_flag}"
+                )
+    return 0
+
+
+def cmd_message(args: argparse.Namespace) -> int:
+    """Show details of a single message from the audit trail (Platform-3)."""
+    from bid_euchre.ops.message_bus import read_messages
+
+    bus_root = args.runtime_dir / "message_bus"
+
+    action = getattr(args, "message_action", None)
+    if action != "show":
+        print("Usage: ops.py message show MSG_ID", file=sys.stderr)
+        return 1
+
+    msg_id = args.message_id
+
+    # Search audit trail for the message
+    # Read all (large limit) and find by ID
+    all_msgs = read_messages(bus_root, limit=10000)
+    found = None
+    for msg in all_msgs:
+        if msg.get("message_id") == msg_id:
+            found = msg
+            break
+
+    if found is None:
+        print(f"Message {msg_id!r} not found in audit trail.", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(found, indent=2, default=str))
+    else:
+        print(f"Message: {found.get('message_id', '?')}")
+        print(f"  Type:        {found.get('message_type', '?')}")
+        print(f"  Status:      {found.get('status', '?')}")
+        print(f"  From:        {found.get('from_lane', '?')}")
+        print(f"  To:          {found.get('to_lane', '?')}")
+        print(f"  Priority:    {found.get('priority', '?')}")
+        print(f"  Created at:  {found.get('created_at', '?')}")
+        print(f"  Summary:     {found.get('summary', '?')}")
+        thread = found.get("thread_id")
+        if thread:
+            print(f"  Thread:      {thread}")
+        task = found.get("task_id")
+        if task:
+            print(f"  Task:        {task}")
+        parent = found.get("parent_message_id")
+        if parent:
+            print(f"  Parent:      {parent}")
+        if found.get("requires_human"):
+            print("  Requires human attention: YES")
+        acked = found.get("acked_at")
+        if acked:
+            print(f"  Acked at:    {acked}")
+        resolved = found.get("resolved_at")
+        if resolved:
+            print(f"  Resolved at: {resolved}")
+        payload = found.get("payload", {})
+        if payload:
+            # Show payload without delivery policy internals
+            display = {
+                k: v
+                for k, v in payload.items()
+                if k not in ("max_retries", "retry_count", "ttl_seconds")
+            }
+            if display:
+                print(f"  Payload:     {display}")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the argument parser."""
     parser = argparse.ArgumentParser(
@@ -1822,6 +1972,30 @@ def build_parser() -> argparse.ArgumentParser:
     task_show_parser = task_sub.add_parser("show", help="Show a task packet by ID")
     task_show_parser.add_argument("packet_id", help="The packet ID to show")
 
+    # inbox (Platform-3 message bus)
+    inbox_parser = subparsers.add_parser(
+        "inbox", help="Communication bus inbox (Platform-3)"
+    )
+    inbox_sub = inbox_parser.add_subparsers(dest="inbox_action")
+
+    inbox_sub.add_parser("stats", help="Per-lane inbox statistics")
+
+    inbox_parser.add_argument(
+        "--lane", default=None, help="Show inbox for a specific lane"
+    )
+    inbox_parser.add_argument("--status", default=None, help="Filter by message status")
+    inbox_parser.add_argument("--type", default=None, help="Filter by message type")
+    inbox_parser.add_argument("--thread", default=None, help="Filter by thread ID")
+
+    # message (Platform-3 audit trail)
+    message_parser = subparsers.add_parser(
+        "message", help="Communication bus message detail (Platform-3)"
+    )
+    message_sub = message_parser.add_subparsers(dest="message_action")
+
+    message_show_parser = message_sub.add_parser("show", help="Show a message by ID")
+    message_show_parser.add_argument("message_id", help="The message ID to show")
+
     return parser
 
 
@@ -1873,6 +2047,8 @@ def main(argv: list[str] | None = None) -> int:
         "queue": cmd_queue,
         "repairs": cmd_repairs,
         "task": cmd_task,
+        "inbox": cmd_inbox,
+        "message": cmd_message,
     }
 
     handler = commands.get(args.command)

--- a/src/bid_euchre/ops/__init__.py
+++ b/src/bid_euchre/ops/__init__.py
@@ -20,6 +20,8 @@ Modules:
     memory      -- Curated memory for stable operator facts
     context_safety -- Content scanning for memory/summary/skill promotion
     compaction  -- Session compaction and non-lossy context archival
+    message_bus -- Durable lane-to-lane communication bus (Platform-3)
+    task_queue  -- Durable task packet queue (Platform-2)
 """
 
 # Shared constant: GitHub status/check context names that represent

--- a/src/bid_euchre/ops/events.py
+++ b/src/bid_euchre/ops/events.py
@@ -53,6 +53,10 @@ VALID_EVENT_TYPES = frozenset(
         "pr_comment_ingested",
         "review_request",
         "review_verdict",
+        "message_sent",
+        "message_acked",
+        "message_expired",
+        "message_dead_lettered",
     }
 )
 

--- a/src/bid_euchre/ops/message_bus.py
+++ b/src/bid_euchre/ops/message_bus.py
@@ -1,0 +1,845 @@
+"""Durable lane-to-lane communication bus (Platform-3, v1 foundation).
+
+Provides the core data contract for structured inter-lane messaging:
+- ``BusMessage`` — a frozen dataclass representing a single message
+- Append-only JSONL audit trail at ``<shared_root>/message_bus/messages.jsonl``
+- Per-lane JSONL inbox files at ``<shared_root>/message_bus/inbox/<lane_id>.jsonl``
+- Delivery semantics: ack, resolve, TTL expiry, dead-letter
+
+Storage layout::
+
+    <shared_root>/message_bus/
+        messages.jsonl          # Global audit trail (append-only)
+        .messages.lock          # flock file for audit trail
+        inbox/
+            orchestrator.jsonl  # Per-lane inbox
+            author-a.jsonl
+            review.jsonl
+            ...
+
+The bus stores and queries messages. It does not actively push or poll.
+Delivery automation (supervisor checking inboxes, retry loops) belongs to
+later platform slices.
+
+Cross-worktree visibility is guaranteed via ``shared_bus_root()``, which
+derives the path from ``git rev-parse --git-common-dir``.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import functools
+import json
+import logging
+import os
+import subprocess
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("ops.message_bus")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_BUS_DIR = Path(".claude/runtime/message_bus")
+MESSAGES_FILE = "messages.jsonl"
+LOCK_FILE = ".messages.lock"
+INBOX_DIR = "inbox"
+
+VALID_MESSAGE_TYPES = frozenset(
+    {
+        "assignment",
+        "ack",
+        "progress",
+        "blocker",
+        "completion",
+        "escalation",
+        "recovery",
+        "supervisor_alert",
+    }
+)
+
+VALID_MESSAGE_PRIORITIES = frozenset({"low", "normal", "high", "urgent"})
+
+VALID_MESSAGE_STATUSES = frozenset(
+    {
+        "pending",
+        "delivered",
+        "acked",
+        "resolved",
+        "expired",
+        "dead_lettered",
+    }
+)
+
+# Valid status transitions for the message lifecycle.
+VALID_MESSAGE_TRANSITIONS: dict[str, frozenset[str]] = {
+    "pending": frozenset({"delivered", "acked", "expired", "dead_lettered"}),
+    "delivered": frozenset({"acked", "expired", "dead_lettered"}),
+    "acked": frozenset({"resolved"}),
+    "resolved": frozenset(),  # terminal
+    "expired": frozenset(),  # terminal
+    "dead_lettered": frozenset(),  # terminal
+}
+
+# Default delivery policy
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_TTL_SECONDS: int | None = None  # No expiry by default
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BusMessage:
+    """A single lane-to-lane message on the communication bus.
+
+    Frozen to enforce immutability — status updates create new records
+    in the inbox (append-only JSONL).
+
+    The 16-field contract follows the governing plan's message schema
+    (lines 326–345).
+    """
+
+    message_id: str
+    thread_id: str | None
+    task_id: str | None  # Links to TaskPacket.packet_id
+    from_lane: str
+    to_lane: str
+    message_type: str
+    priority: str
+    status: str
+    created_at: str  # ISO 8601
+    acked_at: str | None
+    resolved_at: str | None
+    requires_human: bool
+    summary: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    source_transport: str = "bus"
+    parent_message_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.message_type not in VALID_MESSAGE_TYPES:
+            raise ValueError(
+                f"Invalid message_type {self.message_type!r}; "
+                f"expected one of {sorted(VALID_MESSAGE_TYPES)}"
+            )
+        if self.priority not in VALID_MESSAGE_PRIORITIES:
+            raise ValueError(
+                f"Invalid priority {self.priority!r}; "
+                f"expected one of {sorted(VALID_MESSAGE_PRIORITIES)}"
+            )
+        if self.status not in VALID_MESSAGE_STATUSES:
+            raise ValueError(
+                f"Invalid status {self.status!r}; "
+                f"expected one of {sorted(VALID_MESSAGE_STATUSES)}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Factory helper
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    """Return current UTC time as ISO 8601 string."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def create_message(
+    from_lane: str,
+    to_lane: str,
+    message_type: str,
+    summary: str,
+    *,
+    thread_id: str | None = None,
+    task_id: str | None = None,
+    priority: str = "normal",
+    requires_human: bool = False,
+    payload: dict[str, Any] | None = None,
+    source_transport: str = "bus",
+    parent_message_id: str | None = None,
+) -> BusMessage:
+    """Create a new BusMessage with generated ID and timestamp.
+
+    Delivery policy defaults (max_retries, ttl_seconds) are stored in
+    ``payload`` to keep the core schema stable.
+    """
+    base_payload = payload or {}
+    # Inject delivery policy defaults if not already set
+    if "max_retries" not in base_payload:
+        base_payload["max_retries"] = DEFAULT_MAX_RETRIES
+    if "retry_count" not in base_payload:
+        base_payload["retry_count"] = 0
+    if "ttl_seconds" not in base_payload:
+        base_payload["ttl_seconds"] = DEFAULT_TTL_SECONDS
+
+    return BusMessage(
+        message_id=uuid.uuid4().hex[:16],
+        thread_id=thread_id,
+        task_id=task_id,
+        from_lane=from_lane,
+        to_lane=to_lane,
+        message_type=message_type,
+        priority=priority,
+        status="pending",
+        created_at=_now_iso(),
+        acked_at=None,
+        resolved_at=None,
+        requires_human=requires_human,
+        summary=summary,
+        payload=base_payload,
+        source_transport=source_transport,
+        parent_message_id=parent_message_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared bus root — canonical across all worktrees
+# ---------------------------------------------------------------------------
+
+
+@functools.lru_cache(maxsize=1)
+def _resolve_git_common_bus_root() -> Path:
+    """Resolve the message bus root from git's common directory.
+
+    Same pattern as ``shared_queue_root()`` in ``review_queue.py``.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            git_common = Path(result.stdout.strip())
+            if not git_common.is_absolute():
+                git_common = (Path.cwd() / git_common).resolve()
+            else:
+                git_common = git_common.resolve()
+            main_root = git_common.parent
+            return main_root / ".claude" / "runtime" / "message_bus"
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    return DEFAULT_BUS_DIR
+
+
+def shared_bus_root(bus_dir: Path | None = None) -> Path:
+    """Return the canonical message bus root shared across all worktrees.
+
+    Resolution order:
+
+    1. Explicit ``bus_dir`` parameter (test override).
+    2. ``BID_EUCHRE_BUS_DIR`` environment variable.
+    3. Derived from ``git rev-parse --git-common-dir`` (cached).
+    4. Falls back to :data:`DEFAULT_BUS_DIR`.
+
+    Creates the directory structure if it doesn't exist.
+    """
+    if bus_dir is not None:
+        root = bus_dir
+    else:
+        env_override = os.environ.get("BID_EUCHRE_BUS_DIR")
+        if env_override:
+            root = Path(env_override)
+        else:
+            root = _resolve_git_common_bus_root()
+
+    root.mkdir(parents=True, exist_ok=True)
+    (root / INBOX_DIR).mkdir(exist_ok=True)
+    return root
+
+
+# ---------------------------------------------------------------------------
+# JSONL audit trail
+# ---------------------------------------------------------------------------
+
+
+def _append_jsonl(path: Path, data: dict[str, Any], lock_path: Path) -> None:
+    """Append a JSON line to a file under flock protection.
+
+    Same flock pattern as ``append_event()`` in ``events.py``.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "a") as lock_fh:
+        fcntl.flock(lock_fh, fcntl.LOCK_EX)
+        try:
+            with open(path, "a") as f:
+                f.write(json.dumps(data, sort_keys=True, default=str) + "\n")
+                f.flush()
+        finally:
+            fcntl.flock(lock_fh, fcntl.LOCK_UN)
+
+
+def append_message(msg: BusMessage, bus_root: Path | None = None) -> None:
+    """Append a message to the global audit trail JSONL."""
+    root = shared_bus_root(bus_root)
+    audit_path = root / MESSAGES_FILE
+    lock_path = root / LOCK_FILE
+    _append_jsonl(audit_path, asdict(msg), lock_path)
+    logger.debug("Audit trail appended: %s", msg.message_id)
+
+
+def read_messages(
+    bus_root: Path | None = None,
+    *,
+    since: datetime | None = None,
+    from_lane: str | None = None,
+    to_lane: str | None = None,
+    thread_id: str | None = None,
+    message_type: str | None = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Read and filter messages from the global audit trail.
+
+    Returns list of message dicts, most recent first, up to ``limit``.
+    """
+    root = shared_bus_root(bus_root)
+    audit_path = root / MESSAGES_FILE
+    if not audit_path.exists():
+        return []
+
+    from collections import deque
+
+    matched: deque[dict[str, Any]] = deque(maxlen=limit)
+    with open(audit_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("Skipping malformed audit line: %s", line[:100])
+                continue
+
+            # Apply filters
+            if from_lane is not None and record.get("from_lane") != from_lane:
+                continue
+            if to_lane is not None and record.get("to_lane") != to_lane:
+                continue
+            if thread_id is not None and record.get("thread_id") != thread_id:
+                continue
+            if message_type is not None and record.get("message_type") != message_type:
+                continue
+            if since is not None:
+                try:
+                    msg_time = datetime.fromisoformat(record["created_at"])
+                    if msg_time <= since:
+                        continue
+                except (KeyError, ValueError):
+                    continue
+
+            matched.append(record)
+
+    result = list(matched)
+    result.reverse()
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Per-lane inbox
+# ---------------------------------------------------------------------------
+
+
+def _inbox_path(lane_id: str, bus_root: Path) -> Path:
+    """Return the inbox JSONL path for a lane."""
+    return bus_root / INBOX_DIR / f"{lane_id}.jsonl"
+
+
+def _inbox_lock_path(lane_id: str, bus_root: Path) -> Path:
+    """Return the lock file path for a lane's inbox."""
+    return bus_root / INBOX_DIR / f".{lane_id}.lock"
+
+
+def _append_to_inbox(msg: BusMessage, bus_root: Path) -> None:
+    """Append a message to the recipient lane's inbox."""
+    inbox = _inbox_path(msg.to_lane, bus_root)
+    lock = _inbox_lock_path(msg.to_lane, bus_root)
+    _append_jsonl(inbox, asdict(msg), lock)
+    logger.debug("Inbox appended for %s: %s", msg.to_lane, msg.message_id)
+
+
+def _read_inbox_raw(lane_id: str, bus_root: Path) -> list[dict[str, Any]]:
+    """Read all records from a lane's inbox JSONL (chronological order)."""
+    inbox = _inbox_path(lane_id, bus_root)
+    if not inbox.exists():
+        return []
+
+    records: list[dict[str, Any]] = []
+    with open(inbox) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                logger.warning("Skipping malformed inbox line for %s", lane_id)
+    return records
+
+
+def read_inbox(
+    lane_id: str,
+    bus_root: Path | None = None,
+    *,
+    status: str | None = None,
+    thread_id: str | None = None,
+    message_type: str | None = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Read and filter a lane's inbox messages.
+
+    Returns list of message dicts, most recent first, up to ``limit``.
+    Each message_id appears once (latest record wins for status updates).
+    """
+    root = shared_bus_root(bus_root)
+    raw = _read_inbox_raw(lane_id, root)
+
+    # Deduplicate: latest record per message_id wins
+    by_id: dict[str, dict[str, Any]] = {}
+    for rec in raw:
+        mid = rec.get("message_id")
+        if mid:
+            by_id[mid] = rec
+
+    # Apply filters
+    from collections import deque
+
+    matched: deque[dict[str, Any]] = deque(maxlen=limit)
+    for rec in by_id.values():
+        if status is not None and rec.get("status") != status:
+            continue
+        if thread_id is not None and rec.get("thread_id") != thread_id:
+            continue
+        if message_type is not None and rec.get("message_type") != message_type:
+            continue
+        matched.append(rec)
+
+    result = list(matched)
+    result.reverse()
+    return result
+
+
+def query_unresolved(
+    lane_id: str,
+    bus_root: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Return pending + delivered + acked messages for a lane (not terminal)."""
+    root = shared_bus_root(bus_root)
+    raw = _read_inbox_raw(lane_id, root)
+
+    # Deduplicate: latest record per message_id wins
+    by_id: dict[str, dict[str, Any]] = {}
+    for rec in raw:
+        mid = rec.get("message_id")
+        if mid:
+            by_id[mid] = rec
+
+    terminal = {"resolved", "expired", "dead_lettered"}
+    return [rec for rec in by_id.values() if rec.get("status") not in terminal]
+
+
+# ---------------------------------------------------------------------------
+# Delivery semantics
+# ---------------------------------------------------------------------------
+
+
+def send_message(
+    msg: BusMessage,
+    bus_root: Path | None = None,
+    *,
+    events_dir: Path | None = None,
+) -> str:
+    """Send a message: write to audit trail + recipient inbox, emit event.
+
+    Enforces duplicate suppression: if a message with the same message_id
+    already exists in the audit trail, the send is rejected.
+
+    Args:
+        msg: The message to send.
+        bus_root: Override for bus root directory.
+        events_dir: Override for events directory (for testing).
+
+    Returns:
+        The message_id of the sent message.
+
+    Raises:
+        ValueError: If a message with the same ID already exists.
+    """
+    root = shared_bus_root(bus_root)
+
+    # Duplicate suppression: check audit trail under lock
+    audit_path = root / MESSAGES_FILE
+    lock_path = root / LOCK_FILE
+
+    with open(lock_path, "a") as lock_fh:
+        fcntl.flock(lock_fh, fcntl.LOCK_EX)
+        try:
+            # Check for duplicate
+            if audit_path.exists():
+                with open(audit_path) as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            rec = json.loads(line)
+                            if rec.get("message_id") == msg.message_id:
+                                raise ValueError(
+                                    f"Duplicate message_id {msg.message_id!r} "
+                                    f"already exists in audit trail"
+                                )
+                        except json.JSONDecodeError:
+                            continue
+
+            # Append to audit trail (under same lock)
+            with open(audit_path, "a") as f:
+                f.write(json.dumps(asdict(msg), sort_keys=True, default=str) + "\n")
+                f.flush()
+        finally:
+            fcntl.flock(lock_fh, fcntl.LOCK_UN)
+
+    # Append to recipient inbox
+    _append_to_inbox(msg, root)
+
+    # Emit event
+    try:
+        from bid_euchre.ops.events import append_event
+
+        append_event(
+            "message_sent",
+            "ops.message_bus",
+            msg.from_lane,
+            {
+                "message_id": msg.message_id,
+                "to_lane": msg.to_lane,
+                "message_type": msg.message_type,
+                "thread_id": msg.thread_id,
+                "task_id": msg.task_id,
+            },
+            events_dir=events_dir,
+        )
+    except Exception:
+        logger.warning("Failed to emit message_sent event for %s", msg.message_id)
+
+    logger.info(
+        "Sent message %s: %s -> %s (%s)",
+        msg.message_id,
+        msg.from_lane,
+        msg.to_lane,
+        msg.message_type,
+    )
+    return msg.message_id
+
+
+def _update_inbox_status(
+    message_id: str,
+    lane_id: str,
+    new_status: str,
+    bus_root: Path,
+    *,
+    extra_fields: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Update a message's status in a lane's inbox.
+
+    Appends a new record with the updated status (append-only inbox).
+    Validates the transition against VALID_MESSAGE_TRANSITIONS.
+
+    Returns the updated record, or None if message not found.
+    """
+    raw = _read_inbox_raw(lane_id, bus_root)
+
+    # Find the latest record for this message
+    latest: dict[str, Any] | None = None
+    for rec in raw:
+        if rec.get("message_id") == message_id:
+            latest = rec
+
+    if latest is None:
+        logger.warning("Message %s not found in %s inbox", message_id, lane_id)
+        return None
+
+    # Validate transition
+    current_status = latest.get("status", "pending")
+    allowed = VALID_MESSAGE_TRANSITIONS.get(current_status, frozenset())
+    if new_status not in allowed:
+        raise ValueError(
+            f"Invalid transition {current_status!r} -> {new_status!r} for "
+            f"message {message_id!r}; allowed: {sorted(allowed) if allowed else '(terminal)'}"
+        )
+
+    # Build updated record
+    updated = {**latest, "status": new_status}
+    if extra_fields:
+        updated.update(extra_fields)
+
+    # Append updated record to inbox
+    inbox = _inbox_path(lane_id, bus_root)
+    lock = _inbox_lock_path(lane_id, bus_root)
+    _append_jsonl(inbox, updated, lock)
+
+    return updated
+
+
+def ack_message(
+    message_id: str,
+    lane_id: str,
+    bus_root: Path | None = None,
+    *,
+    events_dir: Path | None = None,
+) -> dict[str, Any] | None:
+    """Acknowledge a message in a lane's inbox.
+
+    Sets status to ``acked`` and records ``acked_at`` timestamp.
+
+    Returns the updated record, or None if not found.
+    """
+    root = shared_bus_root(bus_root)
+    updated = _update_inbox_status(
+        message_id,
+        lane_id,
+        "acked",
+        root,
+        extra_fields={"acked_at": _now_iso()},
+    )
+
+    if updated is not None:
+        try:
+            from bid_euchre.ops.events import append_event
+
+            append_event(
+                "message_acked",
+                "ops.message_bus",
+                lane_id,
+                {"message_id": message_id},
+                events_dir=events_dir,
+            )
+        except Exception:
+            logger.warning("Failed to emit message_acked event for %s", message_id)
+
+    return updated
+
+
+def resolve_message(
+    message_id: str,
+    lane_id: str,
+    bus_root: Path | None = None,
+) -> dict[str, Any] | None:
+    """Resolve a message (mark as completed/handled).
+
+    Sets status to ``resolved`` and records ``resolved_at`` timestamp.
+
+    Returns the updated record, or None if not found.
+    """
+    root = shared_bus_root(bus_root)
+    return _update_inbox_status(
+        message_id,
+        lane_id,
+        "resolved",
+        root,
+        extra_fields={"resolved_at": _now_iso()},
+    )
+
+
+def check_expired(
+    bus_root: Path | None = None,
+    *,
+    events_dir: Path | None = None,
+    now: float | None = None,
+) -> list[dict[str, Any]]:
+    """Scan all inboxes for messages past their TTL and mark them expired.
+
+    Args:
+        bus_root: Override for bus root directory.
+        events_dir: Override for events directory (for testing).
+        now: Override for current time as Unix timestamp (for testing).
+
+    Returns:
+        List of expired message records.
+    """
+    root = shared_bus_root(bus_root)
+    inbox_dir = root / INBOX_DIR
+    if not inbox_dir.exists():
+        return []
+
+    current_time = now or time.time()
+    expired_msgs: list[dict[str, Any]] = []
+
+    for inbox_file in sorted(inbox_dir.glob("*.jsonl")):
+        lane_id = inbox_file.stem
+        if lane_id.startswith("."):
+            continue  # Skip lock files
+
+        raw = _read_inbox_raw(lane_id, root)
+
+        # Deduplicate: latest record per message_id
+        by_id: dict[str, dict[str, Any]] = {}
+        for rec in raw:
+            mid = rec.get("message_id")
+            if mid:
+                by_id[mid] = rec
+
+        for mid, rec in by_id.items():
+            status = rec.get("status", "pending")
+            if status in ("resolved", "expired", "dead_lettered"):
+                continue
+
+            ttl = rec.get("payload", {}).get("ttl_seconds")
+            if ttl is None:
+                continue
+
+            created = rec.get("created_at", "")
+            try:
+                created_dt = datetime.fromisoformat(created)
+                created_ts = created_dt.timestamp()
+            except (ValueError, TypeError):
+                continue
+
+            if current_time - created_ts > ttl:
+                updated = _update_inbox_status(mid, lane_id, "expired", root)
+                if updated:
+                    expired_msgs.append(updated)
+                    try:
+                        from bid_euchre.ops.events import append_event
+
+                        append_event(
+                            "message_expired",
+                            "ops.message_bus",
+                            lane_id,
+                            {"message_id": mid, "ttl_seconds": ttl},
+                            events_dir=events_dir,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Failed to emit message_expired event for %s", mid
+                        )
+
+    return expired_msgs
+
+
+def check_dead_letters(
+    bus_root: Path | None = None,
+    *,
+    events_dir: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Scan all inboxes for messages exceeding max_retries.
+
+    Messages with ``payload.retry_count >= payload.max_retries`` are
+    marked ``dead_lettered``.
+
+    Returns:
+        List of dead-lettered message records.
+    """
+    root = shared_bus_root(bus_root)
+    inbox_dir = root / INBOX_DIR
+    if not inbox_dir.exists():
+        return []
+
+    dead_msgs: list[dict[str, Any]] = []
+
+    for inbox_file in sorted(inbox_dir.glob("*.jsonl")):
+        lane_id = inbox_file.stem
+        if lane_id.startswith("."):
+            continue
+
+        raw = _read_inbox_raw(lane_id, root)
+
+        # Deduplicate
+        by_id: dict[str, dict[str, Any]] = {}
+        for rec in raw:
+            mid = rec.get("message_id")
+            if mid:
+                by_id[mid] = rec
+
+        for mid, rec in by_id.items():
+            status = rec.get("status", "pending")
+            if status in ("resolved", "expired", "dead_lettered"):
+                continue
+
+            payload = rec.get("payload", {})
+            max_retries = payload.get("max_retries", DEFAULT_MAX_RETRIES)
+            retry_count = payload.get("retry_count", 0)
+
+            if retry_count >= max_retries:
+                updated = _update_inbox_status(mid, lane_id, "dead_lettered", root)
+                if updated:
+                    dead_msgs.append(updated)
+                    try:
+                        from bid_euchre.ops.events import append_event
+
+                        append_event(
+                            "message_dead_lettered",
+                            "ops.message_bus",
+                            lane_id,
+                            {
+                                "message_id": mid,
+                                "max_retries": max_retries,
+                                "retry_count": retry_count,
+                            },
+                            events_dir=events_dir,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Failed to emit message_dead_lettered event for %s",
+                            mid,
+                        )
+
+    return dead_msgs
+
+
+# ---------------------------------------------------------------------------
+# Inbox summary (for status enrichment / CLI)
+# ---------------------------------------------------------------------------
+
+
+def inbox_stats(bus_root: Path | None = None) -> dict[str, Any]:
+    """Return per-lane inbox statistics.
+
+    Returns:
+        Dict with keys: lanes (list of dicts with lane_id, total,
+        by_status counts).
+    """
+    root = shared_bus_root(bus_root)
+    inbox_dir = root / INBOX_DIR
+    if not inbox_dir.exists():
+        return {"lanes": []}
+
+    lane_stats: list[dict[str, Any]] = []
+
+    for inbox_file in sorted(inbox_dir.glob("*.jsonl")):
+        lane_id = inbox_file.stem
+        if lane_id.startswith("."):
+            continue
+
+        raw = _read_inbox_raw(lane_id, root)
+
+        # Deduplicate
+        by_id: dict[str, dict[str, Any]] = {}
+        for rec in raw:
+            mid = rec.get("message_id")
+            if mid:
+                by_id[mid] = rec
+
+        by_status: dict[str, int] = {}
+        for rec in by_id.values():
+            s = rec.get("status", "unknown")
+            by_status[s] = by_status.get(s, 0) + 1
+
+        lane_stats.append(
+            {
+                "lane_id": lane_id,
+                "total": len(by_id),
+                "by_status": by_status,
+            }
+        )
+
+    return {"lanes": lane_stats}

--- a/tests/unit/test_ops_message_bus.py
+++ b/tests/unit/test_ops_message_bus.py
@@ -1,0 +1,896 @@
+"""Tests for the Platform-3 communication bus module.
+
+Covers: BusMessage creation/validation, JSONL audit trail round-trip,
+per-lane inbox read/write, send/ack/resolve delivery semantics,
+TTL expiry, dead-letter handling, duplicate suppression, inbox stats,
+and shared root resolution.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from bid_euchre.ops.message_bus import (
+    DEFAULT_MAX_RETRIES,
+    VALID_MESSAGE_PRIORITIES,
+    VALID_MESSAGE_STATUSES,
+    VALID_MESSAGE_TRANSITIONS,
+    VALID_MESSAGE_TYPES,
+    BusMessage,
+    ack_message,
+    append_message,
+    check_dead_letters,
+    check_expired,
+    create_message,
+    inbox_stats,
+    query_unresolved,
+    read_inbox,
+    read_messages,
+    resolve_message,
+    send_message,
+    shared_bus_root,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def bus_root(tmp_path: Path) -> Path:
+    """Create a temporary bus root with inbox directory."""
+    root = tmp_path / "message_bus"
+    return shared_bus_root(root)
+
+
+@pytest.fixture()
+def events_dir(tmp_path: Path) -> Path:
+    """Create a temporary events directory for event emission."""
+    d = tmp_path / "events"
+    d.mkdir()
+    return d
+
+
+# ---------------------------------------------------------------------------
+# BusMessage creation and validation
+# ---------------------------------------------------------------------------
+
+
+class TestBusMessageCreation:
+    """Test BusMessage creation and field validation."""
+
+    def test_create_message_defaults(self) -> None:
+        msg = create_message(
+            "orchestrator", "author-a", "assignment", "Fix the scoring bug"
+        )
+        assert msg.from_lane == "orchestrator"
+        assert msg.to_lane == "author-a"
+        assert msg.message_type == "assignment"
+        assert msg.summary == "Fix the scoring bug"
+        assert msg.status == "pending"
+        assert msg.priority == "normal"
+        assert msg.requires_human is False
+        assert msg.source_transport == "bus"
+        assert msg.acked_at is None
+        assert msg.resolved_at is None
+        assert msg.thread_id is None
+        assert msg.task_id is None
+        assert msg.parent_message_id is None
+        assert len(msg.message_id) == 16
+        assert msg.created_at  # Non-empty
+
+    def test_create_message_with_all_fields(self) -> None:
+        msg = create_message(
+            "author-a",
+            "review",
+            "completion",
+            "PR #42 ready for review",
+            thread_id="thread-001",
+            task_id="pkt-abc123",
+            priority="high",
+            requires_human=True,
+            payload={"pr_number": 42},
+            source_transport="hook",
+            parent_message_id="parent-msg-001",
+        )
+        assert msg.thread_id == "thread-001"
+        assert msg.task_id == "pkt-abc123"
+        assert msg.priority == "high"
+        assert msg.requires_human is True
+        assert msg.source_transport == "hook"
+        assert msg.parent_message_id == "parent-msg-001"
+        assert msg.payload["pr_number"] == 42
+        # Delivery policy defaults injected
+        assert msg.payload["max_retries"] == DEFAULT_MAX_RETRIES
+        assert msg.payload["retry_count"] == 0
+
+    def test_invalid_message_type_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid message_type"):
+            BusMessage(
+                message_id="test",
+                thread_id=None,
+                task_id=None,
+                from_lane="a",
+                to_lane="b",
+                message_type="invalid_type",
+                priority="normal",
+                status="pending",
+                created_at="2026-01-01T00:00:00Z",
+                acked_at=None,
+                resolved_at=None,
+                requires_human=False,
+                summary="test",
+            )
+
+    def test_invalid_priority_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid priority"):
+            BusMessage(
+                message_id="test",
+                thread_id=None,
+                task_id=None,
+                from_lane="a",
+                to_lane="b",
+                message_type="assignment",
+                priority="critical",
+                status="pending",
+                created_at="2026-01-01T00:00:00Z",
+                acked_at=None,
+                resolved_at=None,
+                requires_human=False,
+                summary="test",
+            )
+
+    def test_invalid_status_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid status"):
+            BusMessage(
+                message_id="test",
+                thread_id=None,
+                task_id=None,
+                from_lane="a",
+                to_lane="b",
+                message_type="assignment",
+                priority="normal",
+                status="invalid_status",
+                created_at="2026-01-01T00:00:00Z",
+                acked_at=None,
+                resolved_at=None,
+                requires_human=False,
+                summary="test",
+            )
+
+    def test_all_valid_message_types(self) -> None:
+        for mtype in VALID_MESSAGE_TYPES:
+            msg = create_message("a", "b", mtype, "test")
+            assert msg.message_type == mtype
+
+    def test_all_valid_priorities(self) -> None:
+        for p in VALID_MESSAGE_PRIORITIES:
+            msg = create_message("a", "b", "assignment", "test", priority=p)
+            assert msg.priority == p
+
+    def test_all_valid_statuses(self) -> None:
+        for s in VALID_MESSAGE_STATUSES:
+            msg = BusMessage(
+                message_id="test",
+                thread_id=None,
+                task_id=None,
+                from_lane="a",
+                to_lane="b",
+                message_type="assignment",
+                priority="normal",
+                status=s,
+                created_at="2026-01-01T00:00:00Z",
+                acked_at=None,
+                resolved_at=None,
+                requires_human=False,
+                summary="test",
+            )
+            assert msg.status == s
+
+    def test_frozen_immutability(self) -> None:
+        msg = create_message("a", "b", "assignment", "test")
+        with pytest.raises(AttributeError):
+            msg.status = "acked"  # type: ignore[misc]
+
+    def test_delivery_policy_defaults_in_payload(self) -> None:
+        msg = create_message("a", "b", "assignment", "test")
+        assert msg.payload["max_retries"] == DEFAULT_MAX_RETRIES
+        assert msg.payload["retry_count"] == 0
+        assert msg.payload["ttl_seconds"] is None
+
+    def test_custom_delivery_policy_preserved(self) -> None:
+        msg = create_message(
+            "a",
+            "b",
+            "assignment",
+            "test",
+            payload={"max_retries": 5, "ttl_seconds": 600},
+        )
+        assert msg.payload["max_retries"] == 5
+        assert msg.payload["ttl_seconds"] == 600
+        assert msg.payload["retry_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Shared bus root
+# ---------------------------------------------------------------------------
+
+
+class TestSharedBusRoot:
+    """Test shared_bus_root directory creation."""
+
+    def test_creates_directory_structure(self, tmp_path: Path) -> None:
+        root = shared_bus_root(tmp_path / "bus")
+        assert root.exists()
+        assert (root / "inbox").exists()
+
+    def test_idempotent(self, tmp_path: Path) -> None:
+        root1 = shared_bus_root(tmp_path / "bus")
+        root2 = shared_bus_root(tmp_path / "bus")
+        assert root1 == root2
+
+    def test_env_override(self, tmp_path: Path) -> None:
+        env_dir = tmp_path / "env_bus"
+        with patch.dict("os.environ", {"BID_EUCHRE_BUS_DIR": str(env_dir)}):
+            # Clear LRU cache to pick up env var
+            from bid_euchre.ops.message_bus import _resolve_git_common_bus_root
+
+            _resolve_git_common_bus_root.cache_clear()
+            root = shared_bus_root()
+            assert root == env_dir
+            assert root.exists()
+
+
+# ---------------------------------------------------------------------------
+# JSONL audit trail
+# ---------------------------------------------------------------------------
+
+
+class TestAuditTrail:
+    """Test append-only JSONL audit trail."""
+
+    def test_append_and_read(self, bus_root: Path) -> None:
+        msg = create_message("orchestrator", "author-a", "assignment", "Do task")
+        append_message(msg, bus_root)
+
+        records = read_messages(bus_root)
+        assert len(records) == 1
+        assert records[0]["message_id"] == msg.message_id
+        assert records[0]["summary"] == "Do task"
+
+    def test_read_empty_trail(self, bus_root: Path) -> None:
+        assert read_messages(bus_root) == []
+
+    def test_multiple_messages_most_recent_first(self, bus_root: Path) -> None:
+        msg1 = create_message("a", "b", "assignment", "First")
+        msg2 = create_message("c", "d", "progress", "Second")
+        append_message(msg1, bus_root)
+        append_message(msg2, bus_root)
+
+        records = read_messages(bus_root)
+        assert len(records) == 2
+        # Most recent first
+        assert records[0]["summary"] == "Second"
+        assert records[1]["summary"] == "First"
+
+    def test_filter_by_from_lane(self, bus_root: Path) -> None:
+        append_message(
+            create_message("orchestrator", "author-a", "assignment", "A"), bus_root
+        )
+        append_message(
+            create_message("author-a", "review", "completion", "B"), bus_root
+        )
+
+        records = read_messages(bus_root, from_lane="orchestrator")
+        assert len(records) == 1
+        assert records[0]["summary"] == "A"
+
+    def test_filter_by_to_lane(self, bus_root: Path) -> None:
+        append_message(
+            create_message("orchestrator", "author-a", "assignment", "A"), bus_root
+        )
+        append_message(
+            create_message("orchestrator", "author-b", "assignment", "B"), bus_root
+        )
+
+        records = read_messages(bus_root, to_lane="author-b")
+        assert len(records) == 1
+        assert records[0]["summary"] == "B"
+
+    def test_filter_by_thread_id(self, bus_root: Path) -> None:
+        append_message(
+            create_message("a", "b", "assignment", "T1", thread_id="thread-1"),
+            bus_root,
+        )
+        append_message(
+            create_message("a", "b", "progress", "T2", thread_id="thread-2"),
+            bus_root,
+        )
+
+        records = read_messages(bus_root, thread_id="thread-1")
+        assert len(records) == 1
+        assert records[0]["summary"] == "T1"
+
+    def test_filter_by_message_type(self, bus_root: Path) -> None:
+        append_message(create_message("a", "b", "assignment", "A"), bus_root)
+        append_message(create_message("a", "b", "blocker", "B"), bus_root)
+
+        records = read_messages(bus_root, message_type="blocker")
+        assert len(records) == 1
+        assert records[0]["summary"] == "B"
+
+    def test_filter_by_since(self, bus_root: Path) -> None:
+        msg = create_message("a", "b", "assignment", "Old")
+        append_message(msg, bus_root)
+
+        # Filter after creation time should exclude it
+        future = datetime(2099, 1, 1, tzinfo=timezone.utc)
+        records = read_messages(bus_root, since=future)
+        assert len(records) == 0
+
+    def test_limit_respected(self, bus_root: Path) -> None:
+        for i in range(10):
+            append_message(create_message("a", "b", "progress", f"Msg {i}"), bus_root)
+
+        records = read_messages(bus_root, limit=3)
+        assert len(records) == 3
+
+    def test_malformed_lines_skipped(self, bus_root: Path) -> None:
+        """Malformed JSONL lines are skipped gracefully."""
+        audit_path = bus_root / "messages.jsonl"
+        audit_path.write_text("not valid json\n")
+        append_message(create_message("a", "b", "assignment", "Valid"), bus_root)
+
+        records = read_messages(bus_root)
+        assert len(records) == 1
+        assert records[0]["summary"] == "Valid"
+
+
+# ---------------------------------------------------------------------------
+# Per-lane inbox
+# ---------------------------------------------------------------------------
+
+
+class TestInbox:
+    """Test per-lane inbox read/write."""
+
+    def test_read_empty_inbox(self, bus_root: Path) -> None:
+        assert read_inbox("nonexistent-lane", bus_root) == []
+
+    def test_send_populates_inbox(self, bus_root: Path, events_dir: Path) -> None:
+        msg = create_message("orchestrator", "author-a", "assignment", "Task 1")
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        inbox = read_inbox("author-a", bus_root)
+        assert len(inbox) == 1
+        assert inbox[0]["message_id"] == msg.message_id
+        assert inbox[0]["summary"] == "Task 1"
+
+    def test_inbox_deduplicates_by_message_id(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """When a message status is updated, the latest record wins."""
+        msg = create_message("orchestrator", "author-a", "assignment", "Task")
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        # Ack updates the inbox with a new record
+        ack_message(msg.message_id, "author-a", bus_root, events_dir=events_dir)
+
+        inbox = read_inbox("author-a", bus_root)
+        assert len(inbox) == 1
+        assert inbox[0]["status"] == "acked"
+
+    def test_inbox_filter_by_status(self, bus_root: Path, events_dir: Path) -> None:
+        msg1 = create_message("a", "target", "assignment", "Pending one")
+        msg2 = create_message("a", "target", "progress", "Will be acked")
+        send_message(msg1, bus_root, events_dir=events_dir)
+        send_message(msg2, bus_root, events_dir=events_dir)
+        ack_message(msg2.message_id, "target", bus_root, events_dir=events_dir)
+
+        pending = read_inbox("target", bus_root, status="pending")
+        assert len(pending) == 1
+        assert pending[0]["summary"] == "Pending one"
+
+        acked = read_inbox("target", bus_root, status="acked")
+        assert len(acked) == 1
+        assert acked[0]["summary"] == "Will be acked"
+
+    def test_inbox_filter_by_thread(self, bus_root: Path, events_dir: Path) -> None:
+        msg1 = create_message("a", "b", "assignment", "Thread A", thread_id="ta")
+        msg2 = create_message("a", "b", "assignment", "Thread B", thread_id="tb")
+        send_message(msg1, bus_root, events_dir=events_dir)
+        send_message(msg2, bus_root, events_dir=events_dir)
+
+        result = read_inbox("b", bus_root, thread_id="ta")
+        assert len(result) == 1
+        assert result[0]["thread_id"] == "ta"
+
+    def test_inbox_filter_by_message_type(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        msg1 = create_message("a", "b", "assignment", "Assign")
+        msg2 = create_message("a", "b", "blocker", "Block")
+        send_message(msg1, bus_root, events_dir=events_dir)
+        send_message(msg2, bus_root, events_dir=events_dir)
+
+        result = read_inbox("b", bus_root, message_type="blocker")
+        assert len(result) == 1
+        assert result[0]["message_type"] == "blocker"
+
+    def test_query_unresolved(self, bus_root: Path, events_dir: Path) -> None:
+        msg1 = create_message("a", "target", "assignment", "Active")
+        msg2 = create_message("a", "target", "progress", "Will resolve")
+        send_message(msg1, bus_root, events_dir=events_dir)
+        send_message(msg2, bus_root, events_dir=events_dir)
+
+        # Ack and resolve msg2
+        ack_message(msg2.message_id, "target", bus_root, events_dir=events_dir)
+        resolve_message(msg2.message_id, "target", bus_root)
+
+        unresolved = query_unresolved("target", bus_root)
+        assert len(unresolved) == 1
+        assert unresolved[0]["message_id"] == msg1.message_id
+
+
+# ---------------------------------------------------------------------------
+# Delivery semantics: send
+# ---------------------------------------------------------------------------
+
+
+class TestSendMessage:
+    """Test send_message delivery semantics."""
+
+    def test_send_writes_audit_trail_and_inbox(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        msg = create_message("orchestrator", "author-a", "assignment", "Work")
+        mid = send_message(msg, bus_root, events_dir=events_dir)
+        assert mid == msg.message_id
+
+        # Audit trail
+        trail = read_messages(bus_root)
+        assert len(trail) == 1
+        assert trail[0]["message_id"] == mid
+
+        # Inbox
+        inbox = read_inbox("author-a", bus_root)
+        assert len(inbox) == 1
+        assert inbox[0]["message_id"] == mid
+
+    def test_send_emits_event(self, bus_root: Path, events_dir: Path) -> None:
+        msg = create_message("orchestrator", "author-a", "assignment", "Work")
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        events_file = events_dir / "events.jsonl"
+        assert events_file.exists()
+        lines = events_file.read_text().strip().split("\n")
+        assert len(lines) == 1
+        event = json.loads(lines[0])
+        assert event["event_type"] == "message_sent"
+        assert event["payload"]["message_id"] == msg.message_id
+
+    def test_duplicate_suppression(self, bus_root: Path, events_dir: Path) -> None:
+        """Sending the same message_id twice raises ValueError."""
+        msg = create_message("a", "b", "assignment", "Original")
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        with pytest.raises(ValueError, match="Duplicate message_id"):
+            send_message(msg, bus_root, events_dir=events_dir)
+
+
+# ---------------------------------------------------------------------------
+# Delivery semantics: ack
+# ---------------------------------------------------------------------------
+
+
+class TestAckMessage:
+    """Test ack_message delivery semantics."""
+
+    def test_ack_updates_inbox(self, bus_root: Path, events_dir: Path) -> None:
+        msg = create_message("a", "b", "assignment", "Task")
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        result = ack_message(msg.message_id, "b", bus_root, events_dir=events_dir)
+        assert result is not None
+        assert result["status"] == "acked"
+        assert result["acked_at"] is not None
+
+    def test_ack_emits_event(self, bus_root: Path, events_dir: Path) -> None:
+        msg = create_message("a", "b", "assignment", "Task")
+        send_message(msg, bus_root, events_dir=events_dir)
+        ack_message(msg.message_id, "b", bus_root, events_dir=events_dir)
+
+        events_file = events_dir / "events.jsonl"
+        lines = events_file.read_text().strip().split("\n")
+        assert len(lines) == 2  # message_sent + message_acked
+        ack_event = json.loads(lines[1])
+        assert ack_event["event_type"] == "message_acked"
+
+    def test_ack_nonexistent_returns_none(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        result = ack_message(
+            "nonexistent", "some-lane", bus_root, events_dir=events_dir
+        )
+        assert result is None
+
+    def test_ack_already_acked_raises(self, bus_root: Path, events_dir: Path) -> None:
+        """Acking an already-acked message raises (acked -> acked not valid)."""
+        msg = create_message("a", "b", "assignment", "Task")
+        send_message(msg, bus_root, events_dir=events_dir)
+        ack_message(msg.message_id, "b", bus_root, events_dir=events_dir)
+
+        with pytest.raises(ValueError, match="Invalid transition"):
+            ack_message(msg.message_id, "b", bus_root, events_dir=events_dir)
+
+
+# ---------------------------------------------------------------------------
+# Delivery semantics: resolve
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMessage:
+    """Test resolve_message delivery semantics."""
+
+    def test_resolve_after_ack(self, bus_root: Path, events_dir: Path) -> None:
+        msg = create_message("a", "b", "assignment", "Task")
+        send_message(msg, bus_root, events_dir=events_dir)
+        ack_message(msg.message_id, "b", bus_root, events_dir=events_dir)
+
+        result = resolve_message(msg.message_id, "b", bus_root)
+        assert result is not None
+        assert result["status"] == "resolved"
+        assert result["resolved_at"] is not None
+
+    def test_resolve_without_ack_raises(self, bus_root: Path, events_dir: Path) -> None:
+        """Cannot resolve a pending message (must ack first)."""
+        msg = create_message("a", "b", "assignment", "Task")
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        with pytest.raises(ValueError, match="Invalid transition"):
+            resolve_message(msg.message_id, "b", bus_root)
+
+    def test_resolve_already_resolved_raises(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        msg = create_message("a", "b", "assignment", "Task")
+        send_message(msg, bus_root, events_dir=events_dir)
+        ack_message(msg.message_id, "b", bus_root, events_dir=events_dir)
+        resolve_message(msg.message_id, "b", bus_root)
+
+        with pytest.raises(ValueError, match="Invalid transition"):
+            resolve_message(msg.message_id, "b", bus_root)
+
+
+# ---------------------------------------------------------------------------
+# TTL expiry
+# ---------------------------------------------------------------------------
+
+
+class TestCheckExpired:
+    """Test TTL expiry detection."""
+
+    def test_expired_message_detected(self, bus_root: Path, events_dir: Path) -> None:
+        """A message with ttl_seconds in the past is marked expired."""
+        msg = create_message(
+            "a",
+            "b",
+            "assignment",
+            "Urgent task",
+            payload={"ttl_seconds": 60},
+        )
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        # Simulate time passing well beyond TTL
+        future_time = time.time() + 3600  # 1 hour later
+        expired = check_expired(bus_root, events_dir=events_dir, now=future_time)
+        assert len(expired) == 1
+        assert expired[0]["message_id"] == msg.message_id
+        assert expired[0]["status"] == "expired"
+
+    def test_non_expired_message_not_detected(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """A message within its TTL is not expired."""
+        msg = create_message(
+            "a",
+            "b",
+            "assignment",
+            "Patient task",
+            payload={"ttl_seconds": 86400},  # 24 hours
+        )
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        # Check immediately (well within TTL)
+        expired = check_expired(bus_root, events_dir=events_dir, now=time.time())
+        assert len(expired) == 0
+
+    def test_no_ttl_never_expires(self, bus_root: Path, events_dir: Path) -> None:
+        """Messages without ttl_seconds never expire."""
+        msg = create_message("a", "b", "assignment", "Forever task")
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        far_future = time.time() + 365 * 24 * 3600  # 1 year
+        expired = check_expired(bus_root, events_dir=events_dir, now=far_future)
+        assert len(expired) == 0
+
+    def test_expired_emits_event(self, bus_root: Path, events_dir: Path) -> None:
+        msg = create_message(
+            "a", "b", "assignment", "Short-lived", payload={"ttl_seconds": 1}
+        )
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        check_expired(bus_root, events_dir=events_dir, now=time.time() + 100)
+
+        events_file = events_dir / "events.jsonl"
+        lines = events_file.read_text().strip().split("\n")
+        expired_events = [
+            json.loads(l)
+            for l in lines
+            if json.loads(l)["event_type"] == "message_expired"
+        ]
+        assert len(expired_events) == 1
+
+    def test_already_expired_not_re_expired(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Running check_expired twice doesn't double-expire."""
+        msg = create_message(
+            "a", "b", "assignment", "One-time", payload={"ttl_seconds": 1}
+        )
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        future = time.time() + 100
+        expired1 = check_expired(bus_root, events_dir=events_dir, now=future)
+        assert len(expired1) == 1
+
+        expired2 = check_expired(bus_root, events_dir=events_dir, now=future + 100)
+        assert len(expired2) == 0  # Already expired, skip
+
+
+# ---------------------------------------------------------------------------
+# Dead-letter handling
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDeadLetters:
+    """Test dead-letter detection when max_retries exceeded."""
+
+    def test_dead_letter_on_max_retries(self, bus_root: Path, events_dir: Path) -> None:
+        msg = create_message(
+            "a",
+            "b",
+            "assignment",
+            "Failing task",
+            payload={"max_retries": 2, "retry_count": 3},
+        )
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        dead = check_dead_letters(bus_root, events_dir=events_dir)
+        assert len(dead) == 1
+        assert dead[0]["message_id"] == msg.message_id
+        assert dead[0]["status"] == "dead_lettered"
+
+    def test_no_dead_letter_within_retries(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        msg = create_message(
+            "a",
+            "b",
+            "assignment",
+            "Still trying",
+            payload={"max_retries": 5, "retry_count": 2},
+        )
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        dead = check_dead_letters(bus_root, events_dir=events_dir)
+        assert len(dead) == 0
+
+    def test_dead_letter_emits_event(self, bus_root: Path, events_dir: Path) -> None:
+        msg = create_message(
+            "a",
+            "b",
+            "assignment",
+            "Exhausted",
+            payload={"max_retries": 1, "retry_count": 5},
+        )
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        check_dead_letters(bus_root, events_dir=events_dir)
+
+        events_file = events_dir / "events.jsonl"
+        lines = events_file.read_text().strip().split("\n")
+        dl_events = [
+            json.loads(l)
+            for l in lines
+            if json.loads(l)["event_type"] == "message_dead_lettered"
+        ]
+        assert len(dl_events) == 1
+
+    def test_already_dead_lettered_not_re_processed(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        msg = create_message(
+            "a",
+            "b",
+            "assignment",
+            "Done",
+            payload={"max_retries": 1, "retry_count": 5},
+        )
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        dead1 = check_dead_letters(bus_root, events_dir=events_dir)
+        assert len(dead1) == 1
+
+        dead2 = check_dead_letters(bus_root, events_dir=events_dir)
+        assert len(dead2) == 0  # Already processed
+
+
+# ---------------------------------------------------------------------------
+# Transition map integrity
+# ---------------------------------------------------------------------------
+
+
+class TestTransitionMap:
+    """Test the message status transition map for consistency."""
+
+    def test_all_statuses_have_transitions(self) -> None:
+        assert set(VALID_MESSAGE_TRANSITIONS.keys()) == VALID_MESSAGE_STATUSES
+
+    def test_all_targets_are_valid_statuses(self) -> None:
+        for source, targets in VALID_MESSAGE_TRANSITIONS.items():
+            for target in targets:
+                assert (
+                    target in VALID_MESSAGE_STATUSES
+                ), f"Transition {source!r} -> {target!r}: target not a valid status"
+
+    def test_terminal_states_have_no_transitions(self) -> None:
+        for terminal in ("resolved", "expired", "dead_lettered"):
+            assert VALID_MESSAGE_TRANSITIONS[terminal] == frozenset(), (
+                f"{terminal!r} should be terminal but allows: "
+                f"{VALID_MESSAGE_TRANSITIONS[terminal]}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Inbox stats
+# ---------------------------------------------------------------------------
+
+
+class TestInboxStats:
+    """Test inbox_stats summary."""
+
+    def test_empty_stats(self, bus_root: Path) -> None:
+        stats = inbox_stats(bus_root)
+        assert stats["lanes"] == []
+
+    def test_stats_with_messages(self, bus_root: Path, events_dir: Path) -> None:
+        send_message(
+            create_message("a", "author-a", "assignment", "M1"),
+            bus_root,
+            events_dir=events_dir,
+        )
+        send_message(
+            create_message("a", "author-a", "progress", "M2"),
+            bus_root,
+            events_dir=events_dir,
+        )
+        send_message(
+            create_message("a", "author-b", "assignment", "M3"),
+            bus_root,
+            events_dir=events_dir,
+        )
+
+        stats = inbox_stats(bus_root)
+        lanes = {ln["lane_id"]: ln for ln in stats["lanes"]}
+        assert "author-a" in lanes
+        assert "author-b" in lanes
+        assert lanes["author-a"]["total"] == 2
+        assert lanes["author-b"]["total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# End-to-end smoke: full message lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestE2ESmoke:
+    """End-to-end smoke test for the happy path."""
+
+    def test_send_ack_resolve_lifecycle(self, bus_root: Path, events_dir: Path) -> None:
+        # 1. Orchestrator sends assignment
+        msg = create_message(
+            "orchestrator",
+            "author-a",
+            "assignment",
+            "Fix scoring bug",
+            thread_id="task-thread-001",
+            task_id="pkt-abc123",
+        )
+        mid = send_message(msg, bus_root, events_dir=events_dir)
+
+        # 2. Author-a sees it in inbox
+        inbox = read_inbox("author-a", bus_root)
+        assert len(inbox) == 1
+        assert inbox[0]["status"] == "pending"
+
+        # 3. Author-a acknowledges
+        ack_result = ack_message(mid, "author-a", bus_root, events_dir=events_dir)
+        assert ack_result is not None
+        assert ack_result["status"] == "acked"
+
+        # 4. Inbox now shows acked
+        inbox = read_inbox("author-a", bus_root)
+        assert len(inbox) == 1
+        assert inbox[0]["status"] == "acked"
+
+        # 5. Query unresolved still returns it (acked is not terminal)
+        unresolved = query_unresolved("author-a", bus_root)
+        assert len(unresolved) == 1
+
+        # 6. Author-a resolves (work done)
+        resolve_result = resolve_message(mid, "author-a", bus_root)
+        assert resolve_result is not None
+        assert resolve_result["status"] == "resolved"
+
+        # 7. No more unresolved
+        unresolved = query_unresolved("author-a", bus_root)
+        assert len(unresolved) == 0
+
+        # 8. Audit trail has the original message
+        trail = read_messages(bus_root)
+        assert len(trail) == 1
+        assert trail[0]["task_id"] == "pkt-abc123"
+
+    def test_multi_lane_thread(self, bus_root: Path, events_dir: Path) -> None:
+        """Multiple messages in the same thread across lanes."""
+        thread = "task-42"
+
+        # Orchestrator -> author-a
+        m1 = create_message(
+            "orchestrator",
+            "author-a",
+            "assignment",
+            "Start task",
+            thread_id=thread,
+            task_id="pkt42",
+        )
+        send_message(m1, bus_root, events_dir=events_dir)
+
+        # Author-a -> orchestrator (progress)
+        m2 = create_message(
+            "author-a",
+            "orchestrator",
+            "progress",
+            "50% done",
+            thread_id=thread,
+            task_id="pkt42",
+            parent_message_id=m1.message_id,
+        )
+        send_message(m2, bus_root, events_dir=events_dir)
+
+        # Author-a -> orchestrator (completion)
+        m3 = create_message(
+            "author-a",
+            "orchestrator",
+            "completion",
+            "PR #99 ready",
+            thread_id=thread,
+            task_id="pkt42",
+            parent_message_id=m2.message_id,
+        )
+        send_message(m3, bus_root, events_dir=events_dir)
+
+        # Thread query on audit trail
+        thread_msgs = read_messages(bus_root, thread_id=thread)
+        assert len(thread_msgs) == 3
+
+        # Each lane's inbox has the right messages
+        assert len(read_inbox("author-a", bus_root)) == 1
+        assert len(read_inbox("orchestrator", bus_root)) == 2


### PR DESCRIPTION
## Plan
- `plans/agent_ops/1_coordination_core/sub/2026-03-21_platform3-communication-bus.md` (SP-1-03)
- `plans/agent_ops/governing_plan.md` — Platform-3, Phase 1 Coordination Core

## Summary
- Add durable lane-to-lane communication bus (`src/bid_euchre/ops/message_bus.py`) with BusMessage frozen dataclass (16-field governing-plan contract), flock-protected JSONL audit trail, per-lane JSONL inboxes, and full delivery semantics (send, ack, resolve, TTL expiry, dead-letter, duplicate suppression)
- Add 4 new event types to `events.py` (additive): `message_sent`, `message_acked`, `message_expired`, `message_dead_lettered`
- Add `inbox` (list/stats) and `message show` CLI subcommands to `ops.py` with text + JSON output
- 57 new tests covering schema validation, JSONL round-trip, inbox deduplication, delivery lifecycle, TTL expiry, dead-letter, duplicate suppression, transition map integrity, and end-to-end smoke

## Why
Platform-3 Slice 1 of the Agentic Orchestration Platform governing plan. Provides the foundation for durable lane-to-lane coordination state that doesn't rely on transient terminal history. Links to Platform-2's TaskPacket substrate via `task_id` field and groups related messages via `thread_id`.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_message_bus.py -v  # 57/57 pass (0.18s)
uv run python -m pytest tests/unit/test_ops_task_queue.py -q   # 62/62 pass (no regression)
uv run python -m pytest tests/unit/test_ops_events.py -q       # 24/24 pass (no regression)
uv run python scripts/internal/ops.py --json inbox             # returns {"lanes": []}
uv run python scripts/internal/ops.py --json inbox stats       # returns {"lanes": []}
uv run python scripts/internal/ops.py message show nonexistent # returns error exit=1
make check-quiet                                               # 5610 passed, 0 failures
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_message_bus.py` — 57 pass
- [x] `uv run python -m pytest -m "not slow" tests/` — 5610 pass
- [x] CLI smoke: `inbox`, `inbox stats`, `message show` (text + JSON)
- [x] Unhappy: TTL-expired message detected by `check_expired()`
- [x] Unhappy: dead-letter on `max_retries` exceeded
- [x] Unhappy: duplicate `message_id` rejected

## Expected impact
- Metrics impact: None (new ops module, no engine changes)
- Runtime impact: None (new code, not wired into existing paths)

## Risk level
- [x] Low (ops tooling only, additive changes to existing files)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         5c23a2e5 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b        bf3d2788 [ops/platform3-communication-bus]
```

## Files Changed (5)
| File | Change |
|------|--------|
| `src/bid_euchre/ops/message_bus.py` | **NEW**: BusMessage model, JSONL audit trail, per-lane inbox, delivery semantics |
| `src/bid_euchre/ops/events.py` | Add 4 new event types (additive) |
| `src/bid_euchre/ops/__init__.py` | Add module docstring lines for message_bus and task_queue |
| `scripts/internal/ops.py` | Add `inbox`, `inbox stats`, `message show` CLI subcommands |
| `tests/unit/test_ops_message_bus.py` | **NEW**: 57 tests for message bus |

## Done-When (governing plan lines 1118–1125)
1. ✅ Durable messages can be stored, queried, and replayed locally without relying on transient pane history
2. ✅ Acknowledgement, retry, TTL, and dead-letter behavior are defined and covered by at least one unhappy-path test each
3. ✅ Review requests and verdicts are stored durably and drive the merge-safety gate (already satisfied by existing `review_queue.py` — no changes needed)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] Behavior changed → tests added (57 new tests)
- [x] PR is focused (one concept: Platform-3 communication bus v1)
- [x] `make check-quiet` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)