### PR TITLE
fix: Platform-5 follow-ups — task create CLI, progress reporting, worktree, plan statuses

### DIFF
--- a/.claude/agents/steward-author-a.md
+++ b/.claude/agents/steward-author-a.md
@@ -41,6 +41,15 @@ clarification before starting.
 4. **PR** — open with worktree proof, repro command, and validation evidence
 5. **Handoff** — update checkpoints / MEMORY.md as appropriate
 
+## Progress Reporting
+
+Report progress to the orchestrator via bus messages
+(`src/bid_euchre/ops/message_bus.py` `send_message()`):
+- **ack** — task received and understood
+- **progress** — meaningful milestone reached (e.g., implementation done, tests passing)
+- **blocker** — cannot proceed without input or external resolution
+- **completion** — task done, PR opened or handoff recorded
+
 ## Dashboard Relationship
 
 Author lanes are **background** by default in the dashboard-first layout.

--- a/.claude/agents/steward-author-b.md
+++ b/.claude/agents/steward-author-b.md
@@ -41,6 +41,15 @@ clarification before starting.
 4. **PR** — open with worktree proof, repro command, and validation evidence
 5. **Handoff** — update checkpoints / MEMORY.md as appropriate
 
+## Progress Reporting
+
+Report progress to the orchestrator via bus messages
+(`src/bid_euchre/ops/message_bus.py` `send_message()`):
+- **ack** — task received and understood
+- **progress** — meaningful milestone reached (e.g., implementation done, tests passing)
+- **blocker** — cannot proceed without input or external resolution
+- **completion** — task done, PR opened or handoff recorded
+
 ## Dashboard Relationship
 
 Author lanes are **background** by default in the dashboard-first layout.

--- a/.claude/agents/steward-author-c.md
+++ b/.claude/agents/steward-author-c.md
@@ -41,6 +41,15 @@ clarification before starting.
 4. **PR** — open with worktree proof, repro command, and validation evidence
 5. **Handoff** — update checkpoints / MEMORY.md as appropriate
 
+## Progress Reporting
+
+Report progress to the orchestrator via bus messages
+(`src/bid_euchre/ops/message_bus.py` `send_message()`):
+- **ack** — task received and understood
+- **progress** — meaningful milestone reached (e.g., implementation done, tests passing)
+- **blocker** — cannot proceed without input or external resolution
+- **completion** — task done, PR opened or handoff recorded
+
 ## Dashboard Relationship
 
 Author lanes are **background** by default in the dashboard-first layout.

--- a/.claude/agents/steward-author-d.md
+++ b/.claude/agents/steward-author-d.md
@@ -41,6 +41,15 @@ clarification before starting.
 4. **PR** — open with worktree proof, repro command, and validation evidence
 5. **Handoff** — update checkpoints / MEMORY.md as appropriate
 
+## Progress Reporting
+
+Report progress to the orchestrator via bus messages
+(`src/bid_euchre/ops/message_bus.py` `send_message()`):
+- **ack** — task received and understood
+- **progress** — meaningful milestone reached (e.g., implementation done, tests passing)
+- **blocker** — cannot proceed without input or external resolution
+- **completion** — task done, PR opened or handoff recorded
+
 ## Dashboard Relationship
 
 Author lanes are **background** by default in the dashboard-first layout.

--- a/.claude/skills/delegate-task/SKILL.md
+++ b/.claude/skills/delegate-task/SKILL.md
@@ -60,8 +60,10 @@ intake-to-dispatch flow into a reusable workflow.
    ```bash
    uv run python scripts/internal/ops.py task create \
      --title "<title>" \
+     --description "<description with acceptance criteria>" \
      --owner "<lane>" \
-     --priority "<priority>"
+     --priority "<priority>" \
+     --scope-declared "<comma-separated file patterns>"
    ```
 
 7. **Verify dispatch:**

--- a/.claude/skills/start-task/SKILL.md
+++ b/.claude/skills/start-task/SKILL.md
@@ -35,13 +35,16 @@ decomposition (use `/executing-plans` for that).
 
 ### Phase 2 — Branch Setup
 
-4. **Ensure you are on a fresh branch from main:**
+4. **Ensure you are in your dedicated author worktree** (not the main checkout).
+   Then create a fresh branch from main:
    ```bash
    git fetch origin main
    git checkout -b <branch-name> origin/main
    ```
-   Branch naming: use the pattern from the task packet or governing plan
-   (e.g., `ops/platform5-canonical-prompts`, `fix/scoring-edge-case`).
+   If you are on `main` in the shared checkout, create a worktree first — see
+   `/managing-worktrees`. Branch naming: use the pattern from the task packet
+   or governing plan (e.g., `ops/platform5-canonical-prompts`,
+   `fix/scoring-edge-case`).
 
 5. If the task references a plan or sub-plan, **read it now**:
    ```bash

--- a/plans/agent_ops/2_visible_operating_model/plan.md
+++ b/plans/agent_ops/2_visible_operating_model/plan.md
@@ -25,7 +25,7 @@ Phase 1 (`1_coordination_core`) is COMPLETE:
 | Slice | Goal | Status | Batch | Depends On |
 |-------|------|--------|-------|------------|
 | `Platform-4` | Dashboard-first steward layout | COMPLETE | C | Phase 1 |
-| `Platform-5` | Canonical prompts and skills | PR PENDING | C | Phase 1 |
+| `Platform-5` | Canonical prompts and skills | COMPLETE | C | Phase 1 |
 
 ## Batch C Pass Gate
 
@@ -75,7 +75,7 @@ Active sub-plans are tracked in `plans/agent_ops/sub_plan_registry.md`.
 | ID | Slice | Status |
 |----|-------|--------|
 | SP-2-01 | Platform-4 | completed |
-| SP-2-02 | Platform-5 | in_progress |
+| SP-2-02 | Platform-5 | completed |
 
 ## Step Sequence
 

--- a/plans/agent_ops/2_visible_operating_model/sub/2026-03-21_platform5-canonical-prompts-and-skills.md
+++ b/plans/agent_ops/2_visible_operating_model/sub/2026-03-21_platform5-canonical-prompts-and-skills.md
@@ -3,7 +3,7 @@
 **ID:** SP-2-02
 **Date:** 2026-03-21
 **Parent:** `plans/agent_ops/governing_plan.md` -- Phase 2 / Platform-5
-**Status:** proposed
+**Status:** completed
 **Owner:** author-a
 **Discovery input:** author-scratch Platform-5 discovery pass (inline, 2026-03-21)
 
@@ -294,12 +294,27 @@ Update `.claude/agents/README.md` per scope § F.
 
 ## Observed Outputs
 
-_Filled during/after execution._
+- 5 enriched author agent definitions (a/b/c/d/scratch) — PR #1234
+- 1 polished ops agent definition (dashboard reference) — PR #1234
+- 1 minimal orchestrator touch (dashboard + skill ref) — PR #1234
+- 3 new orchestration workflow skills (start-task, delegate-task, monitor-pr) — PR #1234
+- 1 new prompt-first workflow doc (PROMPT_FIRST_WORKFLOW.md) — PR #1234
+- 1 updated agents README — PR #1234
+- Review prompt verified, no gap, left intact — PR #1234
+- Follow-up fix PR for 4 post-merge findings (task create CLI, progress
+  reporting section, worktree workflow, plan statuses)
 
 ## Outcome
 
-_Filled after completion._
+- Status: completed
+- PR: #1234 (main implementation), follow-up PR for post-merge findings
+- Deviations from plan: orchestrator touched minimally (dashboard + skill
+  reference, not listed as confirmed edit in plan). Progress Reporting section
+  was listed in plan scope § A item 4 but omitted from initial implementation —
+  added in follow-up PR.
+- Issues discovered: `delegate-task` skill referenced nonexistent `task create`
+  CLI subcommand — fixed by adding the subcommand to `ops.py`.
 
 ## Handoff
 
-_Filled at session end if work is incomplete._
+All work complete. Next: Step 4 (Batch C pass gate verification).

--- a/plans/agent_ops/sub_plan_registry.md
+++ b/plans/agent_ops/sub_plan_registry.md
@@ -15,16 +15,16 @@
 | SP-1-02 | Platform-2 orchestrator intake | Phase 1 Platform-2 implementation | completed | author-b | `plans/agent_ops/1_coordination_core/sub/2026-03-21_platform2-orchestrator-intake.md` | 2026-03-21 | 2026-03-21 |
 | SP-1-03 | Platform-3 communication bus v1 | Phase 1 Platform-3 implementation | completed | author-b | `plans/agent_ops/1_coordination_core/sub/2026-03-21_platform3-communication-bus.md` | 2026-03-21 | 2026-03-21 (PR #1225) |
 | SP-2-01 | Platform-4 dashboard-first layout | Phase 2 Platform-4 implementation | completed | author-b | `plans/agent_ops/2_visible_operating_model/sub/2026-03-21_platform4-dashboard-layout.md` | 2026-03-21 | 2026-03-21 |
-| SP-2-02 | Platform-5 canonical prompts and skills | Phase 2 Platform-5 implementation | in_progress | author-a | `plans/agent_ops/2_visible_operating_model/sub/2026-03-21_platform5-canonical-prompts-and-skills.md` | 2026-03-21 | -- |
+| SP-2-02 | Platform-5 canonical prompts and skills | Phase 2 Platform-5 implementation | completed | author-a | `plans/agent_ops/2_visible_operating_model/sub/2026-03-21_platform5-canonical-prompts-and-skills.md` | 2026-03-21 | 2026-03-22 (PR #1234) |
 
 ## Status Summary
 
 | Status | Count |
 |--------|-------|
 | proposed | 0 |
-| in_progress | 1 |
+| in_progress | 0 |
 | blocked | 0 |
-| completed | 5 |
+| completed | 6 |
 | abandoned | 0 |
 | superseded | 1 |
 

--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -1392,10 +1392,12 @@ def cmd_repairs(args: argparse.Namespace) -> int:
 def cmd_task(args: argparse.Namespace) -> int:
     """Orchestrator task queue inspection (Platform-2)."""
     from bid_euchre.ops.task_queue import (
+        create_packet,
         list_packets,
         load_ack,
         load_packet,
         load_result,
+        save_packet,
     )
 
     task_queue_root = args.runtime_dir / "task_queue"
@@ -1477,8 +1479,32 @@ def cmd_task(args: argparse.Namespace) -> int:
                     print(f"    PR: #{result.pr_number}")
         return 0
 
+    elif action == "create":
+        pkt = create_packet(
+            title=args.title,
+            description=args.description or "",
+            owner=args.owner,
+            priority=args.priority or "normal",
+            scope_declared=(
+                [s.strip() for s in args.scope_declared.split(",")]
+                if args.scope_declared
+                else None
+            ),
+        )
+        save_packet(pkt, task_queue_root)
+        if args.json:
+            from dataclasses import asdict
+
+            print(json.dumps(asdict(pkt), indent=2, default=str))
+        else:
+            print(f"Created task packet: {pkt.packet_id}")
+            print(f"  Title:    {pkt.title}")
+            print(f"  Owner:    {pkt.owner or '(unassigned)'}")
+            print(f"  Priority: {pkt.priority}")
+        return 0
+
     else:
-        print("Usage: ops.py task {list|show}", file=sys.stderr)
+        print("Usage: ops.py task {list|show|create}", file=sys.stderr)
         return 1
 
 
@@ -2028,6 +2054,25 @@ def build_parser() -> argparse.ArgumentParser:
 
     task_show_parser = task_sub.add_parser("show", help="Show a task packet by ID")
     task_show_parser.add_argument("packet_id", help="The packet ID to show")
+
+    task_create_parser = task_sub.add_parser("create", help="Create a new task packet")
+    task_create_parser.add_argument(
+        "--title", required=True, help="Short imperative task title"
+    )
+    task_create_parser.add_argument(
+        "--owner", default=None, help="Target author lane (e.g. author-a)"
+    )
+    task_create_parser.add_argument(
+        "--priority", default="normal", help="Priority: low / normal / high"
+    )
+    task_create_parser.add_argument(
+        "--description", default="", help="Full task description"
+    )
+    task_create_parser.add_argument(
+        "--scope-declared",
+        default=None,
+        help="Comma-separated file patterns (e.g. 'src/foo.py,tests/test_foo.py')",
+    )
 
     # inbox (Platform-3 message bus)
     inbox_parser = subparsers.add_parser(

--- a/tests/unit/test_ops_cli.py
+++ b/tests/unit/test_ops_cli.py
@@ -2794,3 +2794,104 @@ class TestCmdQueue:
         assert len(data) == 1
         assert data[0]["pr_number"] == 77
         assert data[0]["request_sha"] == "override123"
+
+
+class TestTaskCreate:
+    """Tests for ops.py task create subcommand."""
+
+    def test_task_create_basic(
+        self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import ops
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "task",
+                "create",
+                "--title",
+                "Fix scoring edge case",
+                "--owner",
+                "author-a",
+                "--priority",
+                "normal",
+                "--description",
+                "Fix the edge case in scoring",
+                "--scope-declared",
+                "src/bid_euchre/scoring.py,tests/unit/test_scoring.py",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Fix scoring edge case" in out
+
+    def test_task_create_json(
+        self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import ops
+
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "task",
+                "create",
+                "--title",
+                "Test JSON output",
+                "--owner",
+                "author-b",
+            ]
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["title"] == "Test JSON output"
+        assert data["owner"] == "author-b"
+        assert data["priority"] == "normal"
+        assert data["status"] == "pending"
+
+    def test_task_create_then_list(
+        self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import ops
+
+        # Create a packet
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "task",
+                "create",
+                "--title",
+                "Roundtrip test",
+                "--owner",
+                "author-a",
+            ]
+        )
+        assert rc == 0
+        created = json.loads(capsys.readouterr().out)
+
+        # List and verify it appears
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "task",
+                "list",
+            ]
+        )
+        assert rc == 0
+        packets = json.loads(capsys.readouterr().out)
+        ids = [p["packet_id"] for p in packets]
+        assert created["packet_id"] in ids


### PR DESCRIPTION
## Summary

- Add `task create` subcommand to `ops.py` wrapping `create_packet()` with `--title`, `--owner`, `--priority`, `--description`, `--scope-declared` flags
- Add Progress Reporting section to author-a/b/c/d prompts referencing bus message types (ack, progress, blocker, completion)
- Fix `start-task` skill to reference worktree workflow instead of bare `git checkout -b`
- Update 3 plan artifact statuses to completed/COMPLETE and fill SP-2-02 Observed Outputs and Outcome sections

## Why

Post-merge review of PR #1234 (Platform-5 canonical prompts and skills) identified 4 findings that need follow-up fixes:

1. **`delegate-task` skill references nonexistent CLI command** — `ops.py task create` didn't exist; only `list` and `show` were implemented. The Python API `create_packet()` exists but had no CLI wrapper.
2. **Author prompts missing progress reporting** — SP-2-02 scope listed 7 contract sections including progress reporting, but the implementation only had 6.
3. **`start-task` uses `git checkout -b` instead of worktree workflow** — project policy requires worktrees for PR branches.
4. **Stale plan artifact statuses** — SP-2-02, registry, and phase plan were not updated to completed after merge.

## Files Changed (11)

### Runtime Python (1)
- `scripts/internal/ops.py` — add `task create` subcommand and parser

### Tests (1)
- `tests/unit/test_ops_cli.py` — 3 new tests for `task create` (basic, JSON, roundtrip)

### Author prompts (4)
- `.claude/agents/steward-author-{a,b,c,d}.md` — add Progress Reporting section

### Skills (2)
- `.claude/skills/delegate-task/SKILL.md` — fix example command to include all required fields
- `.claude/skills/start-task/SKILL.md` — reference worktree workflow

### Plan artifacts (3)
- `plans/agent_ops/2_visible_operating_model/sub/2026-03-21_platform5-canonical-prompts-and-skills.md` — status → completed, fill Observed Outputs and Outcome
- `plans/agent_ops/sub_plan_registry.md` — SP-2-02 → completed
- `plans/agent_ops/2_visible_operating_model/plan.md` — Platform-5 → COMPLETE

## Validation Performed

```
✓ make check-quiet — all checks passed
✓ 3 new tests pass: TestTaskCreate (basic, JSON, roundtrip)
✓ task create CLI roundtrip verified: create → list → packet appears
✓ ruff format applied (pre-commit hook)
```

## Test Plan

- [x] `make check-quiet` passes
- [x] `uv run python -m pytest tests/unit/test_ops_cli.py::TestTaskCreate -v` — 3/3 pass
- [x] `task create` writes a packet that `task list` can find
- [ ] CI passes

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: fix/platform5-follow-ups
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)