### PR TITLE
fix: align --priority CLI choices with VALID_PRIORITIES

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -1480,15 +1480,13 @@ def cmd_task(args: argparse.Namespace) -> int:
         return 0
 
     elif action == "create":
-        scope = getattr(args, "scope_declared", None)
-        validation = getattr(args, "validation", None)
         pkt = create_packet(
             title=args.title,
             description=args.description or "",
             owner=args.owner,
-            priority=args.priority or "normal",
-            scope_declared=scope,
-            validation=validation,
+            priority=args.priority,
+            scope_declared=args.scope_declared,
+            validation=args.validation,
         )
         save_packet(pkt, task_queue_root)
         if args.json:
@@ -2068,8 +2066,8 @@ def build_parser() -> argparse.ArgumentParser:
     task_create_parser.add_argument(
         "--priority",
         default="normal",
-        choices=["low", "normal", "high", "critical"],
-        help="Priority: low / normal / high / critical (default: normal)",
+        choices=["low", "normal", "high"],
+        help="Priority: low / normal / high (default: normal)",
     )
     task_create_parser.add_argument(
         "--description", default="", help="Full task description"

--- a/tests/unit/test_ops_cli.py
+++ b/tests/unit/test_ops_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from pathlib import Path
@@ -3019,3 +3020,48 @@ class TestTaskCreate:
         assert "Text output task" in out
         assert "src/*.py" in out
         assert "make check-quiet" in out
+
+
+class TestPriorityChoicesContract:
+    """Verify CLI --priority choices stay in sync with VALID_PRIORITIES."""
+
+    def test_cli_priority_choices_match_valid_priorities(self) -> None:
+        """The argparse choices for --priority must equal VALID_PRIORITIES from task_queue."""
+        import ops
+
+        from bid_euchre.ops.task_queue import VALID_PRIORITIES
+
+        parser = ops.build_parser()
+
+        # Walk subparsers to find 'task create' and its --priority action
+        task_subparser = None
+        for action in parser._subparsers._actions:
+            if isinstance(action, argparse._SubParsersAction):
+                task_subparser = action.choices.get("task")
+                break
+
+        assert task_subparser is not None, "Expected 'task' subcommand"
+
+        create_subparser = None
+        for action in task_subparser._subparsers._actions:
+            if isinstance(action, argparse._SubParsersAction):
+                create_subparser = action.choices.get("create")
+                break
+
+        assert create_subparser is not None, "Expected 'task create' subcommand"
+
+        priority_action = None
+        for action in create_subparser._actions:
+            if (
+                hasattr(action, "option_strings")
+                and "--priority" in action.option_strings
+            ):
+                priority_action = action
+                break
+
+        assert (
+            priority_action is not None
+        ), "Expected --priority argument on task create"
+        assert (
+            set(priority_action.choices) == set(VALID_PRIORITIES)
+        ), f"CLI choices {priority_action.choices} != VALID_PRIORITIES {VALID_PRIORITIES}"


### PR DESCRIPTION
## Plan
N/A -- follow-up fix from post-merge review of PR #1237

## Summary
- Remove `critical` from `--priority` argparse choices on `task create` subparser -- only `low`, `normal`, `high` are valid per `VALID_PRIORITIES` in `task_queue.py`
- Remove redundant `or "normal"` fallback on `priority=args.priority` (argparse `default="normal"` already handles it)
- Replace unnecessary `getattr(args, ...)` calls with direct `args.scope_declared` and `args.validation` (argparse guarantees these attrs exist)
- Add contract test `TestPriorityChoicesContract` that asserts CLI choices == `VALID_PRIORITIES`, preventing future drift

## Why
Post-merge review of PR #1237 found that `--priority critical` passes argparse validation but crashes with `ValueError` in `TaskPacket.__post_init__` because `VALID_PRIORITIES` is `frozenset({"low", "normal", "high"})`. The CLI and the dataclass contract must agree.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_cli.py -v
make check-quiet
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_cli.py -v` (all passed)
- [x] `make check-quiet` (all checks passed)

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         ed67010b [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author          ed67010b [ops/platform6-supervisor]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b        aef77ffb [ops/agent-frontmatter-hardening]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c        b9b0c248 [fix/suppress-hook-output]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d        ed67010b [fix/priority-choices-mismatch]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-scratch  ee8e3c88 [fix/pr846-coverage-gaps]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-ops             ee8e3c88 [chore/archive-session-plans-mar18-19]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-review          ee8e3c88 (detached HEAD)
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)