### PR TITLE
ops: add supervisor routines and delta summaries (Platform-6)

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -37,6 +37,7 @@ Usage:
     uv run python scripts/internal/ops.py inbox [--lane LANE] [--status STATUS] [--type TYPE] [--thread THREAD] [--json]
     uv run python scripts/internal/ops.py inbox stats [--json]
     uv run python scripts/internal/ops.py message show MSG_ID [--json]
+    uv run python scripts/internal/ops.py supervisor [--json] [--save] [--diff SNAPSHOT_PATH]
 """
 
 from __future__ import annotations
@@ -1658,6 +1659,51 @@ def cmd_message(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_supervisor(args: argparse.Namespace) -> int:
+    """Run a supervisor cycle: snapshot, delta, recommend (Platform-6)."""
+    from bid_euchre.ops.supervisor import (
+        SupervisorSnapshot,
+        format_supervisor_json,
+        format_supervisor_text,
+        load_latest_snapshot,
+        run_supervisor_cycle,
+    )
+
+    save = getattr(args, "save", False)
+
+    # Load an explicit previous snapshot for diffing, if specified
+    prev_snapshot: SupervisorSnapshot | None = None
+    diff_path = getattr(args, "diff", None)
+    if diff_path:
+        import json as _json
+
+        from bid_euchre.ops.supervisor import _dict_to_snapshot
+
+        try:
+            data = _json.loads(Path(diff_path).read_text())
+            prev_snapshot = _dict_to_snapshot(data)
+        except (OSError, _json.JSONDecodeError, KeyError) as exc:
+            print(f"Error loading snapshot: {exc}", file=sys.stderr)
+            return 1
+    elif save:
+        # If saving, try to load previous for delta
+        prev_snapshot = load_latest_snapshot(args.runtime_dir)
+
+    result = run_supervisor_cycle(
+        runtime_dir=args.runtime_dir,
+        plans_dir=args.plans_dir,
+        prev_snapshot=prev_snapshot,
+        save=save,
+    )
+
+    if args.json:
+        print(json.dumps(format_supervisor_json(result), indent=2))
+    else:
+        print(format_supervisor_text(result))
+
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the argument parser."""
     parser = argparse.ArgumentParser(
@@ -2112,6 +2158,24 @@ def build_parser() -> argparse.ArgumentParser:
     message_show_parser = message_sub.add_parser("show", help="Show a message by ID")
     message_show_parser.add_argument("message_id", help="The message ID to show")
 
+    # supervisor (Platform-6: supervisor routines and delta summaries)
+    supervisor_parser = subparsers.add_parser(
+        "supervisor", help="Supervisor cycle: snapshot, delta, recommend (Platform-6)"
+    )
+    supervisor_parser.add_argument(
+        "--save",
+        action="store_true",
+        default=False,
+        help="Persist snapshot for future delta computation",
+    )
+    supervisor_parser.add_argument(
+        "--diff",
+        type=str,
+        default=None,
+        metavar="SNAPSHOT_PATH",
+        help="Path to a previous snapshot JSON file to diff against",
+    )
+
     return parser
 
 
@@ -2166,6 +2230,7 @@ def main(argv: list[str] | None = None) -> int:
         "task": cmd_task,
         "inbox": cmd_inbox,
         "message": cmd_message,
+        "supervisor": cmd_supervisor,
     }
 
     handler = commands.get(args.command)

--- a/src/bid_euchre/ops/__init__.py
+++ b/src/bid_euchre/ops/__init__.py
@@ -23,6 +23,7 @@ Modules:
     message_bus -- Durable lane-to-lane communication bus (Platform-3)
     task_queue  -- Durable task packet queue (Platform-2)
     dashboard   -- Dashboard-first supervision surface (Platform-4)
+    supervisor  -- Supervisor routines and delta summaries (Platform-6)
 """
 
 # Shared constant: GitHub status/check context names that represent

--- a/src/bid_euchre/ops/supervisor.py
+++ b/src/bid_euchre/ops/supervisor.py
@@ -1,0 +1,981 @@
+"""Ops supervisor routines and delta summaries (Platform-6).
+
+Provides point-in-time lane health snapshots, delta computation between
+consecutive snapshots, per-lane health assessment, and bounded recovery
+recommendations.  This module **consumes** existing infrastructure
+(dashboard, watchdogs, recovery, status, events) and does not modify or
+replace any of it.
+
+The main entry point is :func:`run_supervisor_cycle`, which performs a
+single take-snapshot/assess/recommend/emit pass.  The CLI exposes this
+via ``ops.py supervisor``.
+
+Usage::
+
+    from bid_euchre.ops.supervisor import (
+        run_supervisor_cycle,
+        take_snapshot,
+        compute_delta,
+        format_supervisor_text,
+    )
+
+    result = run_supervisor_cycle()
+    print(format_supervisor_text(result))
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("ops.supervisor")
+
+# ---------------------------------------------------------------------------
+# Health classification constants
+# ---------------------------------------------------------------------------
+
+#: Lane health levels, ordered from worst to best.
+HEALTH_LEVELS: tuple[str, ...] = ("critical", "degraded", "healthy", "idle")
+
+#: Lane states (from status.py) that map to each health level.
+_STATE_TO_HEALTH: dict[str, str] = {
+    "blocked": "critical",
+    "stale": "degraded",
+    "active": "healthy",
+    "likely_active": "healthy",
+    "idle": "idle",
+    "unknown": "idle",
+}
+
+#: Default snapshot storage directory (under runtime_dir).
+SNAPSHOT_DIR_NAME = "supervisor_snapshots"
+
+#: Maximum number of persisted snapshots to keep.
+MAX_PERSISTED_SNAPSHOTS = 20
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LaneHealthAssessment:
+    """Per-lane health classification derived from lane status + watchdogs.
+
+    Attributes:
+        lane_id: Lane identifier.
+        health: One of ``HEALTH_LEVELS``.
+        state: Raw lane state from status.py.
+        findings: Watchdog findings targeting this lane, if any.
+        attention_needed: Whether the lane needs operator attention.
+        attention_reason: Human-readable reason if attention is needed.
+        current_task: Title of the current task, if any.
+        linked_pr: PR number if the lane has one open.
+    """
+
+    lane_id: str
+    health: str
+    state: str
+    findings: list[dict[str, str]] = field(default_factory=list)
+    attention_needed: bool = False
+    attention_reason: str | None = None
+    current_task: str | None = None
+    linked_pr: int | None = None
+
+
+@dataclass
+class RecoveryRecommendation:
+    """Bounded recovery action proposal for a lane.
+
+    The supervisor does not execute recovery actions.  It produces
+    recommendations that the orchestrator or human operator can accept,
+    defer, or reject.
+
+    Attributes:
+        lane_id: Lane to apply recovery to.
+        action: Short action label (``"retry"``, ``"reroute"``,
+            ``"escalate"``, ``"respawn"``, ``"unblock"``).
+        reason: Why this action is recommended.
+        priority: Relative urgency (``"high"``, ``"medium"``, ``"low"``).
+        auto_remediable: Whether the action can be automated.
+        recovery_steps: Ordered human-readable steps if manual.
+    """
+
+    lane_id: str
+    action: str
+    reason: str
+    priority: str = "medium"
+    auto_remediable: bool = False
+    recovery_steps: list[str] = field(default_factory=list)
+
+
+@dataclass
+class SupervisorSnapshot:
+    """Point-in-time lane health snapshot.
+
+    Captures the full state of all lanes and watchdog findings at a
+    single moment.  Two consecutive snapshots can be diffed via
+    :func:`compute_delta`.
+
+    Attributes:
+        timestamp: ISO 8601 timestamp when the snapshot was taken.
+        lane_assessments: Per-lane health assessments.
+        watchdog_finding_count: Total number of watchdog findings.
+        active_failure_count: Number of unresolved failures from recovery.
+        recommendations: Recovery recommendations derived from this snapshot.
+        summary: Aggregate counts for quick inspection.
+    """
+
+    timestamp: str
+    lane_assessments: list[LaneHealthAssessment] = field(default_factory=list)
+    watchdog_finding_count: int = 0
+    active_failure_count: int = 0
+    recommendations: list[RecoveryRecommendation] = field(default_factory=list)
+    summary: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class DeltaSummary:
+    """Diff between two consecutive supervisor snapshots.
+
+    Contains only what changed, so the orchestrator or ops surface can
+    present delta-only summaries instead of repeating the full state.
+
+    Attributes:
+        from_timestamp: Timestamp of the earlier snapshot.
+        to_timestamp: Timestamp of the later snapshot.
+        health_changes: Lanes whose health level changed.
+        new_findings: Watchdog findings present in *to* but not *from*.
+        resolved_findings: Findings present in *from* but not *to*.
+        new_recommendations: Recommendations in *to* but not *from*.
+        resolved_recommendations: Recommendations in *from* but not *to*.
+        summary_deltas: Changes in aggregate counts (key -> delta int).
+    """
+
+    from_timestamp: str
+    to_timestamp: str
+    health_changes: list[dict[str, str]] = field(default_factory=list)
+    new_findings: list[dict[str, str]] = field(default_factory=list)
+    resolved_findings: list[dict[str, str]] = field(default_factory=list)
+    new_recommendations: list[dict[str, str]] = field(default_factory=list)
+    resolved_recommendations: list[dict[str, str]] = field(default_factory=list)
+    summary_deltas: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class SupervisorCycleResult:
+    """Complete result from one supervisor cycle.
+
+    Groups the snapshot, delta (if a previous snapshot exists), and any
+    recommendations for convenient consumption.
+
+    Attributes:
+        snapshot: The current snapshot.
+        delta: Delta from previous snapshot, or None if first run.
+        has_changes: True if the delta contains any changes.
+    """
+
+    snapshot: SupervisorSnapshot
+    delta: DeltaSummary | None = None
+    has_changes: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Core routines
+# ---------------------------------------------------------------------------
+
+
+def take_snapshot(
+    runtime_dir: Path | None = None,
+    plans_dir: Path | None = None,
+    *,
+    now: datetime | None = None,
+) -> SupervisorSnapshot:
+    """Take a point-in-time supervisor snapshot.
+
+    Gathers lane status, watchdog findings, and active failures into a
+    single coherent snapshot.
+
+    Args:
+        runtime_dir: Override for the runtime directory root.
+        plans_dir: Override for the plans directory.
+        now: Override current time for testing.
+
+    Returns:
+        A new :class:`SupervisorSnapshot`.
+    """
+    from bid_euchre.ops.recovery import get_active_failures
+    from bid_euchre.ops.status import aggregate_status
+    from bid_euchre.ops.watchdogs import run_all_watchdogs
+
+    if runtime_dir is None:
+        runtime_dir = Path(".claude/runtime")
+    if plans_dir is None:
+        plans_dir = Path("plans")
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    # 1. Gather lane status
+    report = aggregate_status(runtime_dir, check_worktree=False)
+
+    # 2. Run watchdog checks
+    findings = run_all_watchdogs(
+        runtime_dir=runtime_dir,
+        plans_dir=plans_dir,
+        now=now,
+    )
+
+    # 3. Get active (unresolved) failures
+    events_dir = runtime_dir / "events"
+    active_failures: list = []
+    if events_dir.exists():
+        try:
+            active_failures = get_active_failures(events_dir)
+        except Exception as exc:
+            logger.debug("get_active_failures() failed: %s", exc)
+
+    # 4. Build per-lane assessments
+    # Index watchdog findings by target lane (best-effort extraction)
+    findings_by_lane: dict[str, list[dict[str, str]]] = {}
+    for f in findings:
+        # Extract lane_id from target — may be a path or lane name
+        lane_key = _extract_lane_from_target(f.target, report)
+        findings_by_lane.setdefault(lane_key, []).append(
+            {
+                "watchdog": f.watchdog_name,
+                "severity": f.severity,
+                "message": f.message,
+                "target": f.target,
+            }
+        )
+
+    lane_assessments = []
+    for lane in report.lanes:
+        lane_findings = findings_by_lane.get(lane.lane_id, [])
+        health = _classify_lane_health(lane, lane_findings)
+        lane_assessments.append(
+            LaneHealthAssessment(
+                lane_id=lane.lane_id,
+                health=health,
+                state=lane.state,
+                findings=lane_findings,
+                attention_needed=lane.attention_needed,
+                attention_reason=lane.attention_reason,
+                current_task=lane.current_task_title,
+                linked_pr=lane.linked_pr,
+            )
+        )
+
+    # 5. Build summary counts
+    health_counts: dict[str, int] = {h: 0 for h in HEALTH_LEVELS}
+    for la in lane_assessments:
+        health_counts[la.health] = health_counts.get(la.health, 0) + 1
+
+    summary = {
+        "total_lanes": len(lane_assessments),
+        "critical": health_counts.get("critical", 0),
+        "degraded": health_counts.get("degraded", 0),
+        "healthy": health_counts.get("healthy", 0),
+        "idle": health_counts.get("idle", 0),
+        "watchdog_findings": len(findings),
+        "active_failures": len(active_failures),
+        "attention_needed": sum(1 for la in lane_assessments if la.attention_needed),
+    }
+
+    # 6. Generate recovery recommendations
+    recommendations = _build_recommendations(lane_assessments, active_failures)
+
+    return SupervisorSnapshot(
+        timestamp=now.isoformat(),
+        lane_assessments=lane_assessments,
+        watchdog_finding_count=len(findings),
+        active_failure_count=len(active_failures),
+        recommendations=recommendations,
+        summary=summary,
+    )
+
+
+def assess_lane_health(
+    lane_id: str,
+    runtime_dir: Path | None = None,
+    plans_dir: Path | None = None,
+    *,
+    now: datetime | None = None,
+) -> LaneHealthAssessment | None:
+    """Assess health of a single lane.
+
+    Convenience wrapper that takes a full snapshot then extracts the
+    assessment for the requested lane.
+
+    Args:
+        lane_id: Lane to assess.
+        runtime_dir: Override for the runtime directory root.
+        plans_dir: Override for the plans directory.
+        now: Override current time for testing.
+
+    Returns:
+        The lane's health assessment, or None if the lane was not found.
+    """
+    snapshot = take_snapshot(runtime_dir, plans_dir, now=now)
+    for la in snapshot.lane_assessments:
+        if la.lane_id == lane_id:
+            return la
+    return None
+
+
+def recommend_recovery(
+    snapshot: SupervisorSnapshot,
+) -> list[RecoveryRecommendation]:
+    """Extract or recompute recovery recommendations from a snapshot.
+
+    This is a convenience accessor; recommendations are already embedded
+    in the snapshot by :func:`take_snapshot`.
+
+    Args:
+        snapshot: A supervisor snapshot.
+
+    Returns:
+        List of recovery recommendations.
+    """
+    return list(snapshot.recommendations)
+
+
+def compute_delta(
+    prev: SupervisorSnapshot,
+    curr: SupervisorSnapshot,
+) -> DeltaSummary:
+    """Compute the delta between two consecutive snapshots.
+
+    Identifies health-level changes, new/resolved findings, and
+    new/resolved recommendations.
+
+    Args:
+        prev: The earlier snapshot.
+        curr: The later snapshot.
+
+    Returns:
+        A :class:`DeltaSummary` capturing only what changed.
+    """
+    # 1. Health changes
+    prev_health = {la.lane_id: la.health for la in prev.lane_assessments}
+    curr_health = {la.lane_id: la.health for la in curr.lane_assessments}
+
+    health_changes: list[dict[str, str]] = []
+
+    # Check lanes in both snapshots for changes, plus new lanes
+    all_lane_ids = set(prev_health) | set(curr_health)
+    for lid in sorted(all_lane_ids):
+        old_h = prev_health.get(lid)
+        new_h = curr_health.get(lid)
+        if old_h != new_h:
+            health_changes.append(
+                {
+                    "lane_id": lid,
+                    "from": old_h or "(absent)",
+                    "to": new_h or "(absent)",
+                }
+            )
+
+    # 2. Findings delta (by watchdog+target composite key)
+    def _finding_key(f: dict[str, str]) -> str:
+        return f"{f.get('watchdog', '')}:{f.get('target', '')}"
+
+    prev_findings: dict[str, dict[str, str]] = {}
+    for la in prev.lane_assessments:
+        for f in la.findings:
+            prev_findings[_finding_key(f)] = f
+
+    curr_findings: dict[str, dict[str, str]] = {}
+    for la in curr.lane_assessments:
+        for f in la.findings:
+            curr_findings[_finding_key(f)] = f
+
+    new_finding_keys = set(curr_findings) - set(prev_findings)
+    resolved_finding_keys = set(prev_findings) - set(curr_findings)
+
+    new_findings = [curr_findings[k] for k in sorted(new_finding_keys)]
+    resolved_findings = [prev_findings[k] for k in sorted(resolved_finding_keys)]
+
+    # 3. Recommendation delta (by lane_id+action key)
+    def _rec_key(r: RecoveryRecommendation | dict[str, Any]) -> str:
+        if isinstance(r, RecoveryRecommendation):
+            return f"{r.lane_id}:{r.action}"
+        return f"{r.get('lane_id', '')}:{r.get('action', '')}"
+
+    prev_recs = {_rec_key(r): _rec_to_dict(r) for r in prev.recommendations}
+    curr_recs = {_rec_key(r): _rec_to_dict(r) for r in curr.recommendations}
+
+    new_rec_keys = set(curr_recs) - set(prev_recs)
+    resolved_rec_keys = set(prev_recs) - set(curr_recs)
+
+    new_recommendations = [curr_recs[k] for k in sorted(new_rec_keys)]
+    resolved_recommendations = [prev_recs[k] for k in sorted(resolved_rec_keys)]
+
+    # 4. Summary deltas
+    summary_deltas: dict[str, int] = {}
+    all_keys = set(prev.summary) | set(curr.summary)
+    for key in sorted(all_keys):
+        old_val = prev.summary.get(key, 0)
+        new_val = curr.summary.get(key, 0)
+        delta = new_val - old_val
+        if delta != 0:
+            summary_deltas[key] = delta
+
+    return DeltaSummary(
+        from_timestamp=prev.timestamp,
+        to_timestamp=curr.timestamp,
+        health_changes=health_changes,
+        new_findings=new_findings,
+        resolved_findings=resolved_findings,
+        new_recommendations=new_recommendations,
+        resolved_recommendations=resolved_recommendations,
+        summary_deltas=summary_deltas,
+    )
+
+
+def run_supervisor_cycle(
+    runtime_dir: Path | None = None,
+    plans_dir: Path | None = None,
+    *,
+    now: datetime | None = None,
+    prev_snapshot: SupervisorSnapshot | None = None,
+    save: bool = False,
+) -> SupervisorCycleResult:
+    """Run a single supervisor cycle: snapshot, delta, recommend.
+
+    This is the main entry point for supervisor operations.  It:
+
+    1. Takes a new snapshot via :func:`take_snapshot`.
+    2. If a previous snapshot is available (either passed in or loaded
+       from disk), computes a delta via :func:`compute_delta`.
+    3. Returns the combined result.
+
+    Args:
+        runtime_dir: Override for the runtime directory root.
+        plans_dir: Override for the plans directory.
+        now: Override current time for testing.
+        prev_snapshot: Previous snapshot to diff against.  If None and
+            ``save`` is True, attempts to load the most recent saved
+            snapshot.
+        save: If True, persist the snapshot to disk for future delta
+            computation.
+
+    Returns:
+        A :class:`SupervisorCycleResult` with snapshot, delta, and
+        change flag.
+    """
+    if runtime_dir is None:
+        runtime_dir = Path(".claude/runtime")
+
+    snapshot = take_snapshot(runtime_dir, plans_dir, now=now)
+
+    # Try to load previous snapshot if none provided and save mode is on
+    if prev_snapshot is None and save:
+        prev_snapshot = load_latest_snapshot(runtime_dir)
+
+    # Compute delta
+    delta: DeltaSummary | None = None
+    has_changes = False
+
+    if prev_snapshot is not None:
+        delta = compute_delta(prev_snapshot, snapshot)
+        has_changes = bool(
+            delta.health_changes
+            or delta.new_findings
+            or delta.resolved_findings
+            or delta.new_recommendations
+            or delta.resolved_recommendations
+            or delta.summary_deltas
+        )
+
+    # Persist snapshot if requested
+    if save:
+        save_snapshot(snapshot, runtime_dir)
+
+    return SupervisorCycleResult(
+        snapshot=snapshot,
+        delta=delta,
+        has_changes=has_changes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def save_snapshot(
+    snapshot: SupervisorSnapshot,
+    runtime_dir: Path | None = None,
+) -> Path:
+    """Persist a snapshot to disk for future delta computation.
+
+    Snapshots are stored as timestamped JSON files in
+    ``{runtime_dir}/supervisor_snapshots/``.
+
+    Args:
+        snapshot: The snapshot to save.
+        runtime_dir: Override for the runtime directory root.
+
+    Returns:
+        Path to the saved snapshot file.
+    """
+    if runtime_dir is None:
+        runtime_dir = Path(".claude/runtime")
+
+    snap_dir = runtime_dir / SNAPSHOT_DIR_NAME
+    snap_dir.mkdir(parents=True, exist_ok=True)
+
+    # Use timestamp-based filename (replace colons for filesystem compat)
+    safe_ts = snapshot.timestamp.replace(":", "-").replace("+", "p")
+    filename = f"snapshot_{safe_ts}.json"
+    target = snap_dir / filename
+
+    data = _snapshot_to_dict(snapshot)
+
+    # Atomic write
+    fd, tmp_path = tempfile.mkstemp(dir=str(snap_dir), suffix=".tmp")
+    try:
+        os.write(fd, json.dumps(data, indent=2, default=str).encode())
+        os.close(fd)
+        Path(tmp_path).rename(target)
+    except Exception:
+        try:
+            Path(tmp_path).unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+    # Prune old snapshots
+    _prune_snapshots(snap_dir)
+
+    logger.debug("Saved supervisor snapshot: %s", target)
+    return target
+
+
+def load_latest_snapshot(
+    runtime_dir: Path | None = None,
+) -> SupervisorSnapshot | None:
+    """Load the most recent saved snapshot from disk.
+
+    Args:
+        runtime_dir: Override for the runtime directory root.
+
+    Returns:
+        The most recent snapshot, or None if no snapshots exist.
+    """
+    if runtime_dir is None:
+        runtime_dir = Path(".claude/runtime")
+
+    snap_dir = runtime_dir / SNAPSHOT_DIR_NAME
+    if not snap_dir.exists():
+        return None
+
+    files = sorted(snap_dir.glob("snapshot_*.json"))
+    if not files:
+        return None
+
+    try:
+        data = json.loads(files[-1].read_text())
+        return _dict_to_snapshot(data)
+    except (json.JSONDecodeError, OSError, KeyError) as exc:
+        logger.debug("Failed to load snapshot %s: %s", files[-1], exc)
+        return None
+
+
+def _prune_snapshots(snap_dir: Path) -> None:
+    """Remove old snapshots beyond the retention limit."""
+    files = sorted(snap_dir.glob("snapshot_*.json"))
+    while len(files) > MAX_PERSISTED_SNAPSHOTS:
+        oldest = files.pop(0)
+        try:
+            oldest.unlink()
+            logger.debug("Pruned old snapshot: %s", oldest)
+        except OSError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_lane_from_target(
+    target: str,
+    report: Any,
+) -> str:
+    """Best-effort extraction of lane_id from a watchdog finding target.
+
+    Watchdog targets may be file paths, lane IDs, task IDs, or other
+    strings.  We try to match against known lane IDs from the status
+    report.
+
+    Args:
+        target: The watchdog finding's target string.
+        report: A StatusReport with ``.lanes`` attribute.
+
+    Returns:
+        The matched lane_id, or ``"_unknown"`` if no match.
+    """
+    known_lanes = {lane.lane_id for lane in report.lanes}
+
+    # Direct match
+    if target in known_lanes:
+        return target
+
+    # Check if any lane_id is a substring of the target (e.g., path
+    # contains lane name)
+    for lid in known_lanes:
+        if lid in target:
+            return lid
+
+    return "_unknown"
+
+
+def _classify_lane_health(
+    lane: Any,
+    findings: list[dict[str, str]],
+) -> str:
+    """Classify a lane's health from its state and watchdog findings.
+
+    Args:
+        lane: A LaneStatus object.
+        findings: Watchdog findings for this lane.
+
+    Returns:
+        One of ``HEALTH_LEVELS``.
+    """
+    # Critical findings override everything
+    if any(f.get("severity") == "critical" for f in findings):
+        return "critical"
+
+    # Attention-needed lanes with warnings are degraded
+    if lane.attention_needed and findings:
+        return "degraded"
+
+    # Map from lane state
+    base_health = _STATE_TO_HEALTH.get(lane.state, "idle")
+
+    # Warning findings on an otherwise healthy lane -> degraded
+    if base_health == "healthy" and any(
+        f.get("severity") == "warning" for f in findings
+    ):
+        return "degraded"
+
+    return base_health
+
+
+def _build_recommendations(
+    lane_assessments: list[LaneHealthAssessment],
+    active_failures: list,
+) -> list[RecoveryRecommendation]:
+    """Build recovery recommendations from assessments and failures.
+
+    Consumes recovery.py templates but does not modify them.
+
+    Args:
+        lane_assessments: Per-lane health assessments.
+        active_failures: Unresolved failures from recovery.py.
+
+    Returns:
+        List of recovery recommendations.
+    """
+    from bid_euchre.ops.recovery import RECOVERY_TEMPLATES
+
+    recommendations: list[RecoveryRecommendation] = []
+
+    # Recommendations from lane health
+    for la in lane_assessments:
+        if la.health == "critical":
+            # Check if there are stale heartbeat findings
+            has_stale_hb = any(
+                "heartbeat" in f.get("watchdog", "") for f in la.findings
+            )
+            if has_stale_hb:
+                template = RECOVERY_TEMPLATES.get("heartbeat_stale")
+                recommendations.append(
+                    RecoveryRecommendation(
+                        lane_id=la.lane_id,
+                        action="respawn",
+                        reason="Stale heartbeat detected — agent may have died",
+                        priority="high",
+                        auto_remediable=False,
+                        recovery_steps=(
+                            template.steps if template else ["Check agent process"]
+                        ),
+                    )
+                )
+            elif la.state == "blocked":
+                template = RECOVERY_TEMPLATES.get("task_blocked")
+                recommendations.append(
+                    RecoveryRecommendation(
+                        lane_id=la.lane_id,
+                        action="unblock",
+                        reason=la.attention_reason or "Lane is blocked",
+                        priority="high",
+                        auto_remediable=False,
+                        recovery_steps=(
+                            template.steps if template else ["Investigate blocker"]
+                        ),
+                    )
+                )
+            else:
+                recommendations.append(
+                    RecoveryRecommendation(
+                        lane_id=la.lane_id,
+                        action="escalate",
+                        reason=la.attention_reason or "Critical health with findings",
+                        priority="high",
+                        auto_remediable=False,
+                        recovery_steps=["Investigate critical findings manually"],
+                    )
+                )
+
+        elif la.health == "degraded" and la.attention_needed:
+            # Degraded with attention — suggest investigation
+            recommendations.append(
+                RecoveryRecommendation(
+                    lane_id=la.lane_id,
+                    action="investigate",
+                    reason=la.attention_reason or "Degraded lane health",
+                    priority="medium",
+                    auto_remediable=False,
+                    recovery_steps=[
+                        "Check watchdog findings for this lane",
+                        "Verify task progress",
+                        "Check for CI or review blockers",
+                    ],
+                )
+            )
+
+    # Recommendations from active failures not already covered by lane
+    # assessments
+    covered_lanes = {r.lane_id for r in recommendations}
+    for failure in active_failures:
+        target = failure.target
+        if target in covered_lanes:
+            continue
+
+        if failure.template and failure.template.auto_remediable:
+            recommendations.append(
+                RecoveryRecommendation(
+                    lane_id=target,
+                    action="retry",
+                    reason=failure.details,
+                    priority="medium",
+                    auto_remediable=True,
+                    recovery_steps=failure.template.steps,
+                )
+            )
+        elif failure.severity == "critical":
+            recommendations.append(
+                RecoveryRecommendation(
+                    lane_id=target,
+                    action="escalate",
+                    reason=failure.details,
+                    priority="high",
+                    auto_remediable=False,
+                    recovery_steps=(
+                        failure.template.steps
+                        if failure.template
+                        else ["Manual investigation required"]
+                    ),
+                )
+            )
+
+    return recommendations
+
+
+def _rec_to_dict(
+    rec: RecoveryRecommendation | dict[str, Any],
+) -> dict[str, Any]:
+    """Convert a RecoveryRecommendation to a plain dict."""
+    if isinstance(rec, dict):
+        return rec
+    return asdict(rec)
+
+
+def _snapshot_to_dict(snapshot: SupervisorSnapshot) -> dict[str, Any]:
+    """Serialize a SupervisorSnapshot to a JSON-compatible dict."""
+    return {
+        "timestamp": snapshot.timestamp,
+        "lane_assessments": [asdict(la) for la in snapshot.lane_assessments],
+        "watchdog_finding_count": snapshot.watchdog_finding_count,
+        "active_failure_count": snapshot.active_failure_count,
+        "recommendations": [asdict(r) for r in snapshot.recommendations],
+        "summary": snapshot.summary,
+    }
+
+
+def _dict_to_snapshot(data: dict[str, Any]) -> SupervisorSnapshot:
+    """Deserialize a dict back into a SupervisorSnapshot."""
+    lane_assessments = [
+        LaneHealthAssessment(**la) for la in data.get("lane_assessments", [])
+    ]
+    recommendations = [
+        RecoveryRecommendation(**r) for r in data.get("recommendations", [])
+    ]
+    return SupervisorSnapshot(
+        timestamp=data["timestamp"],
+        lane_assessments=lane_assessments,
+        watchdog_finding_count=data.get("watchdog_finding_count", 0),
+        active_failure_count=data.get("active_failure_count", 0),
+        recommendations=recommendations,
+        summary=data.get("summary", {}),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Formatters
+# ---------------------------------------------------------------------------
+
+
+def format_supervisor_text(result: SupervisorCycleResult) -> str:
+    """Format a supervisor cycle result as human-readable text.
+
+    Args:
+        result: The supervisor cycle result.
+
+    Returns:
+        Multi-line text summary.
+    """
+    lines: list[str] = []
+    snap = result.snapshot
+
+    lines.append("=== Supervisor Report ===")
+    lines.append(f"Timestamp: {snap.timestamp}")
+    lines.append("")
+
+    # Summary
+    s = snap.summary
+    lines.append(
+        f"Lanes: {s.get('total_lanes', 0)} total"
+        f" ({s.get('healthy', 0)} healthy"
+        f", {s.get('degraded', 0)} degraded"
+        f", {s.get('critical', 0)} critical"
+        f", {s.get('idle', 0)} idle)"
+    )
+    lines.append(
+        f"Findings: {snap.watchdog_finding_count}"
+        f"  Failures: {snap.active_failure_count}"
+        f"  Attention: {s.get('attention_needed', 0)}"
+    )
+    lines.append("")
+
+    # Lane health table
+    if snap.lane_assessments:
+        lines.append("Lane Health:")
+        for la in snap.lane_assessments:
+            badge = _health_badge(la.health)
+            task_str = f"  {la.current_task}" if la.current_task else ""
+            pr_str = f"  PR #{la.linked_pr}" if la.linked_pr else ""
+            finding_str = (
+                f"  ({len(la.findings)} finding{'s' if len(la.findings) != 1 else ''})"
+                if la.findings
+                else ""
+            )
+            lines.append(
+                f"  {la.lane_id:15s} {badge:12s} [{la.state}]"
+                f"{task_str}{pr_str}{finding_str}"
+            )
+        lines.append("")
+
+    # Recommendations
+    if snap.recommendations:
+        lines.append(f"Recommendations ({len(snap.recommendations)}):")
+        for rec in snap.recommendations:
+            pri_badge = f"[{rec.priority}]"
+            auto_str = " (auto)" if rec.auto_remediable else ""
+            lines.append(
+                f"  {pri_badge:8s} {rec.lane_id}: "
+                f"{rec.action}{auto_str} -- {rec.reason}"
+            )
+            for step in rec.recovery_steps:
+                lines.append(f"           {step}")
+        lines.append("")
+
+    # Delta section
+    if result.delta is not None:
+        delta = result.delta
+        if result.has_changes:
+            lines.append("--- Delta ---")
+            lines.append(f"From: {delta.from_timestamp}  To: {delta.to_timestamp}")
+
+            if delta.health_changes:
+                lines.append("  Health changes:")
+                for hc in delta.health_changes:
+                    lines.append(f"    {hc['lane_id']}: {hc['from']} -> {hc['to']}")
+
+            if delta.new_findings:
+                lines.append(f"  New findings: {len(delta.new_findings)}")
+                for f in delta.new_findings:
+                    lines.append(
+                        f"    [{f.get('severity', '?')}] "
+                        f"{f.get('watchdog', '?')}: {f.get('message', '?')}"
+                    )
+
+            if delta.resolved_findings:
+                lines.append(f"  Resolved findings: {len(delta.resolved_findings)}")
+
+            if delta.new_recommendations:
+                lines.append(f"  New recommendations: {len(delta.new_recommendations)}")
+
+            if delta.resolved_recommendations:
+                lines.append(
+                    f"  Resolved recommendations: {len(delta.resolved_recommendations)}"
+                )
+
+            if delta.summary_deltas:
+                lines.append("  Summary deltas:")
+                for key, val in sorted(delta.summary_deltas.items()):
+                    sign = "+" if val > 0 else ""
+                    lines.append(f"    {key}: {sign}{val}")
+        else:
+            lines.append("--- Delta: no changes ---")
+
+    return "\n".join(lines)
+
+
+def format_supervisor_json(result: SupervisorCycleResult) -> dict[str, Any]:
+    """Format a supervisor cycle result as a JSON-serializable dict.
+
+    Args:
+        result: The supervisor cycle result.
+
+    Returns:
+        Dict suitable for JSON serialization.
+    """
+    snap = result.snapshot
+
+    output: dict[str, Any] = {
+        "timestamp": snap.timestamp,
+        "summary": snap.summary,
+        "lane_assessments": [asdict(la) for la in snap.lane_assessments],
+        "recommendations": [asdict(r) for r in snap.recommendations],
+        "watchdog_finding_count": snap.watchdog_finding_count,
+        "active_failure_count": snap.active_failure_count,
+        "has_changes": result.has_changes,
+    }
+
+    if result.delta is not None:
+        output["delta"] = asdict(result.delta)
+
+    return output
+
+
+def _health_badge(health: str) -> str:
+    """Return a text badge for a health level."""
+    badges = {
+        "critical": "[CRITICAL]",
+        "degraded": "[DEGRADED]",
+        "healthy": "[healthy]",
+        "idle": "[idle]",
+    }
+    return badges.get(health, f"[{health}]")

--- a/tests/unit/test_ops_supervisor.py
+++ b/tests/unit/test_ops_supervisor.py
@@ -1,0 +1,1002 @@
+"""Tests for ops supervisor routines and delta summaries (Platform-6)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from bid_euchre.ops.supervisor import (
+    HEALTH_LEVELS,
+    DeltaSummary,
+    LaneHealthAssessment,
+    RecoveryRecommendation,
+    SupervisorCycleResult,
+    SupervisorSnapshot,
+    _build_recommendations,
+    _classify_lane_health,
+    _dict_to_snapshot,
+    _extract_lane_from_target,
+    _snapshot_to_dict,
+    compute_delta,
+    format_supervisor_json,
+    format_supervisor_text,
+    load_latest_snapshot,
+    recommend_recovery,
+    run_supervisor_cycle,
+    save_snapshot,
+    take_snapshot,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def runtime_dir(tmp_path: Path) -> Path:
+    """Create a temp runtime directory with standard subdirs."""
+    rd = tmp_path / "runtime"
+    (rd / "worktree_registry").mkdir(parents=True)
+    (rd / "session_metadata").mkdir(parents=True)
+    (rd / "task_state").mkdir(parents=True)
+    (rd / "events").mkdir(parents=True)
+    return rd
+
+
+@pytest.fixture()
+def plans_dir(tmp_path: Path) -> Path:
+    """Create a temp plans directory."""
+    pd = tmp_path / "plans"
+    pd.mkdir(parents=True)
+    return pd
+
+
+def _write_json(directory: Path, filename: str, data: dict) -> None:
+    (directory / filename).write_text(json.dumps(data, indent=2))
+
+
+def _make_lane_status(
+    lane_id: str,
+    *,
+    state: str = "idle",
+    attention_needed: bool = False,
+    attention_reason: str | None = None,
+    current_task_title: str | None = None,
+    linked_pr: int | None = None,
+    visibility: str | None = None,
+):
+    """Create a LaneStatus-compatible object for testing."""
+    from bid_euchre.ops.status import LaneStatus
+
+    return LaneStatus(
+        lane_id=lane_id,
+        lane_class="author" if lane_id.startswith("author") else lane_id,
+        worktree_path=f"/tmp/{lane_id}",
+        branch="main",
+        lifecycle_class="persistent",
+        has_active_session=False,
+        state=state,
+        attention_needed=attention_needed,
+        attention_reason=attention_reason,
+        current_task_title=current_task_title,
+        linked_pr=linked_pr,
+        visibility=visibility,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Health classification
+# ---------------------------------------------------------------------------
+
+
+class TestHealthClassification:
+    """Tests for _classify_lane_health."""
+
+    def test_critical_finding_overrides_healthy_state(self):
+        lane = _make_lane_status("author-a", state="active")
+        findings = [{"severity": "critical", "watchdog": "heartbeat_check"}]
+        assert _classify_lane_health(lane, findings) == "critical"
+
+    def test_critical_finding_overrides_idle_state(self):
+        lane = _make_lane_status("author-a", state="idle")
+        findings = [{"severity": "critical", "watchdog": "heartbeat_check"}]
+        assert _classify_lane_health(lane, findings) == "critical"
+
+    def test_attention_with_findings_is_degraded(self):
+        lane = _make_lane_status("author-a", state="active", attention_needed=True)
+        findings = [{"severity": "warning", "watchdog": "task_progress_check"}]
+        assert _classify_lane_health(lane, findings) == "degraded"
+
+    def test_blocked_state_maps_to_critical(self):
+        lane = _make_lane_status("author-a", state="blocked")
+        assert _classify_lane_health(lane, []) == "critical"
+
+    def test_stale_state_maps_to_degraded(self):
+        lane = _make_lane_status("author-a", state="stale")
+        assert _classify_lane_health(lane, []) == "degraded"
+
+    def test_active_state_maps_to_healthy(self):
+        lane = _make_lane_status("author-a", state="active")
+        assert _classify_lane_health(lane, []) == "healthy"
+
+    def test_likely_active_state_maps_to_healthy(self):
+        lane = _make_lane_status("author-a", state="likely_active")
+        assert _classify_lane_health(lane, []) == "healthy"
+
+    def test_idle_state_maps_to_idle(self):
+        lane = _make_lane_status("author-a", state="idle")
+        assert _classify_lane_health(lane, []) == "idle"
+
+    def test_unknown_state_maps_to_idle(self):
+        lane = _make_lane_status("author-a", state="unknown")
+        assert _classify_lane_health(lane, []) == "idle"
+
+    def test_warning_findings_on_healthy_degrade_to_degraded(self):
+        lane = _make_lane_status("author-a", state="active")
+        findings = [{"severity": "warning", "watchdog": "ci_stuck"}]
+        assert _classify_lane_health(lane, findings) == "degraded"
+
+    def test_no_findings_healthy_stays_healthy(self):
+        lane = _make_lane_status("author-a", state="active")
+        assert _classify_lane_health(lane, []) == "healthy"
+
+
+# ---------------------------------------------------------------------------
+# Lane extraction from targets
+# ---------------------------------------------------------------------------
+
+
+class TestExtractLaneFromTarget:
+    """Tests for _extract_lane_from_target."""
+
+    def test_direct_match(self):
+        class FakeReport:
+            lanes = [_make_lane_status("author-a")]
+
+        assert _extract_lane_from_target("author-a", FakeReport()) == "author-a"
+
+    def test_substring_match(self):
+        class FakeReport:
+            lanes = [_make_lane_status("author-a")]
+
+        assert (
+            _extract_lane_from_target(
+                "/tmp/Bid-Euchre-steward-author-a/plans/heartbeat",
+                FakeReport(),
+            )
+            == "author-a"
+        )
+
+    def test_no_match_returns_unknown(self):
+        class FakeReport:
+            lanes = [_make_lane_status("author-a")]
+
+        assert _extract_lane_from_target("something-else", FakeReport()) == "_unknown"
+
+
+# ---------------------------------------------------------------------------
+# Recommendations
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRecommendations:
+    """Tests for _build_recommendations."""
+
+    def test_critical_lane_with_heartbeat_gets_respawn(self):
+        la = LaneHealthAssessment(
+            lane_id="author-a",
+            health="critical",
+            state="active",
+            findings=[
+                {
+                    "severity": "critical",
+                    "watchdog": "heartbeat_check",
+                    "message": "stale",
+                }
+            ],
+        )
+        recs = _build_recommendations([la], [])
+        assert len(recs) == 1
+        assert recs[0].action == "respawn"
+        assert recs[0].priority == "high"
+
+    def test_blocked_lane_gets_unblock(self):
+        la = LaneHealthAssessment(
+            lane_id="author-a",
+            health="critical",
+            state="blocked",
+            attention_needed=True,
+            attention_reason="blocker",
+        )
+        recs = _build_recommendations([la], [])
+        assert len(recs) == 1
+        assert recs[0].action == "unblock"
+        assert recs[0].priority == "high"
+
+    def test_critical_lane_without_heartbeat_or_blocked_gets_escalate(self):
+        la = LaneHealthAssessment(
+            lane_id="author-a",
+            health="critical",
+            state="active",
+            findings=[
+                {"severity": "critical", "watchdog": "some_other", "message": "bad"}
+            ],
+        )
+        recs = _build_recommendations([la], [])
+        assert len(recs) == 1
+        assert recs[0].action == "escalate"
+
+    def test_degraded_with_attention_gets_investigate(self):
+        la = LaneHealthAssessment(
+            lane_id="author-a",
+            health="degraded",
+            state="stale",
+            attention_needed=True,
+            attention_reason="stale lane",
+        )
+        recs = _build_recommendations([la], [])
+        assert len(recs) == 1
+        assert recs[0].action == "investigate"
+        assert recs[0].priority == "medium"
+
+    def test_healthy_lane_gets_no_recommendation(self):
+        la = LaneHealthAssessment(
+            lane_id="author-a",
+            health="healthy",
+            state="active",
+        )
+        recs = _build_recommendations([la], [])
+        assert len(recs) == 0
+
+    def test_idle_lane_gets_no_recommendation(self):
+        la = LaneHealthAssessment(
+            lane_id="author-a",
+            health="idle",
+            state="idle",
+        )
+        recs = _build_recommendations([la], [])
+        assert len(recs) == 0
+
+    def test_active_failure_adds_recommendation_for_uncovered_lane(self):
+        from bid_euchre.ops.recovery import (
+            FailureClassification,
+            RecoveryTemplate,
+        )
+
+        la = LaneHealthAssessment(
+            lane_id="author-a",
+            health="healthy",
+            state="active",
+        )
+        failure = FailureClassification(
+            failure_type="ci_failure",
+            severity="warning",
+            target="author-b",
+            details="CI failed on PR #42",
+            template=RecoveryTemplate(
+                name="CI Failure",
+                description="CI check failed",
+                steps=["Run ruff", "Fix tests"],
+                auto_remediable=True,
+            ),
+        )
+        recs = _build_recommendations([la], [failure])
+        assert len(recs) == 1
+        assert recs[0].lane_id == "author-b"
+        assert recs[0].action == "retry"
+        assert recs[0].auto_remediable is True
+
+    def test_critical_failure_without_template(self):
+        from bid_euchre.ops.recovery import FailureClassification
+
+        la = LaneHealthAssessment(
+            lane_id="author-a",
+            health="healthy",
+            state="active",
+        )
+        failure = FailureClassification(
+            failure_type="escalation",
+            severity="critical",
+            target="author-b",
+            details="Escalation required",
+            template=None,
+        )
+        recs = _build_recommendations([la], [failure])
+        assert len(recs) == 1
+        assert recs[0].action == "escalate"
+
+    def test_failure_for_already_covered_lane_is_skipped(self):
+        from bid_euchre.ops.recovery import (
+            FailureClassification,
+            RecoveryTemplate,
+        )
+
+        # author-a already has a critical recommendation
+        la = LaneHealthAssessment(
+            lane_id="author-a",
+            health="critical",
+            state="blocked",
+            attention_needed=True,
+        )
+        failure = FailureClassification(
+            failure_type="ci_failure",
+            severity="warning",
+            target="author-a",
+            details="CI failed",
+            template=RecoveryTemplate(
+                name="CI", description="d", steps=["s"], auto_remediable=True
+            ),
+        )
+        recs = _build_recommendations([la], [failure])
+        # Only the blocked-lane recommendation, not the duplicate CI one
+        assert len(recs) == 1
+        assert recs[0].action == "unblock"
+
+
+# ---------------------------------------------------------------------------
+# Snapshot data structure
+# ---------------------------------------------------------------------------
+
+
+class TestSupervisorSnapshot:
+    """Tests for SupervisorSnapshot dataclass behavior."""
+
+    def test_empty_snapshot(self):
+        snap = SupervisorSnapshot(timestamp="2026-03-22T00:00:00+00:00")
+        assert snap.lane_assessments == []
+        assert snap.watchdog_finding_count == 0
+        assert snap.active_failure_count == 0
+        assert snap.recommendations == []
+        assert snap.summary == {}
+
+    def test_snapshot_with_assessments(self):
+        la = LaneHealthAssessment(
+            lane_id="ops",
+            health="healthy",
+            state="active",
+        )
+        rec = RecoveryRecommendation(
+            lane_id="author-a",
+            action="respawn",
+            reason="stale",
+        )
+        snap = SupervisorSnapshot(
+            timestamp="2026-03-22T00:00:00+00:00",
+            lane_assessments=[la],
+            watchdog_finding_count=1,
+            recommendations=[rec],
+            summary={"total_lanes": 1},
+        )
+        assert len(snap.lane_assessments) == 1
+        assert snap.lane_assessments[0].lane_id == "ops"
+        assert len(snap.recommendations) == 1
+
+
+# ---------------------------------------------------------------------------
+# Serialization round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotSerialization:
+    """Tests for snapshot serialization and deserialization."""
+
+    def test_round_trip(self):
+        la = LaneHealthAssessment(
+            lane_id="author-a",
+            health="degraded",
+            state="stale",
+            findings=[
+                {
+                    "severity": "warning",
+                    "watchdog": "test",
+                    "message": "m",
+                    "target": "t",
+                }
+            ],
+            attention_needed=True,
+            attention_reason="stale lane",
+            current_task="fix bug",
+            linked_pr=42,
+        )
+        rec = RecoveryRecommendation(
+            lane_id="author-a",
+            action="investigate",
+            reason="degraded",
+            priority="medium",
+            auto_remediable=False,
+            recovery_steps=["step 1", "step 2"],
+        )
+        original = SupervisorSnapshot(
+            timestamp="2026-03-22T10:00:00+00:00",
+            lane_assessments=[la],
+            watchdog_finding_count=1,
+            active_failure_count=0,
+            recommendations=[rec],
+            summary={"total_lanes": 1, "degraded": 1},
+        )
+
+        data = _snapshot_to_dict(original)
+        restored = _dict_to_snapshot(data)
+
+        assert restored.timestamp == original.timestamp
+        assert len(restored.lane_assessments) == 1
+        assert restored.lane_assessments[0].lane_id == "author-a"
+        assert restored.lane_assessments[0].health == "degraded"
+        assert len(restored.lane_assessments[0].findings) == 1
+        assert len(restored.recommendations) == 1
+        assert restored.recommendations[0].action == "investigate"
+        assert restored.summary == original.summary
+
+    def test_json_round_trip(self):
+        """Verify JSON serialization is valid."""
+        snap = SupervisorSnapshot(
+            timestamp="2026-03-22T10:00:00+00:00",
+            lane_assessments=[
+                LaneHealthAssessment(lane_id="ops", health="healthy", state="active")
+            ],
+            summary={"total_lanes": 1},
+        )
+        data = _snapshot_to_dict(snap)
+        json_str = json.dumps(data, indent=2)
+        restored_data = json.loads(json_str)
+        restored = _dict_to_snapshot(restored_data)
+        assert restored.timestamp == snap.timestamp
+
+
+# ---------------------------------------------------------------------------
+# Delta computation
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDelta:
+    """Tests for compute_delta."""
+
+    def test_no_changes_produces_empty_delta(self):
+        la = LaneHealthAssessment(lane_id="author-a", health="healthy", state="active")
+        prev = SupervisorSnapshot(
+            timestamp="2026-03-22T09:00:00+00:00",
+            lane_assessments=[la],
+            summary={"total_lanes": 1, "healthy": 1},
+        )
+        curr = SupervisorSnapshot(
+            timestamp="2026-03-22T10:00:00+00:00",
+            lane_assessments=[la],
+            summary={"total_lanes": 1, "healthy": 1},
+        )
+        delta = compute_delta(prev, curr)
+        assert delta.from_timestamp == prev.timestamp
+        assert delta.to_timestamp == curr.timestamp
+        assert delta.health_changes == []
+        assert delta.new_findings == []
+        assert delta.resolved_findings == []
+        assert delta.new_recommendations == []
+        assert delta.resolved_recommendations == []
+        assert delta.summary_deltas == {}
+
+    def test_health_change_detected(self):
+        prev = SupervisorSnapshot(
+            timestamp="t1",
+            lane_assessments=[
+                LaneHealthAssessment(
+                    lane_id="author-a", health="healthy", state="active"
+                )
+            ],
+            summary={"healthy": 1, "degraded": 0},
+        )
+        curr = SupervisorSnapshot(
+            timestamp="t2",
+            lane_assessments=[
+                LaneHealthAssessment(
+                    lane_id="author-a", health="degraded", state="stale"
+                )
+            ],
+            summary={"healthy": 0, "degraded": 1},
+        )
+        delta = compute_delta(prev, curr)
+        assert len(delta.health_changes) == 1
+        assert delta.health_changes[0]["lane_id"] == "author-a"
+        assert delta.health_changes[0]["from"] == "healthy"
+        assert delta.health_changes[0]["to"] == "degraded"
+        assert delta.summary_deltas["healthy"] == -1
+        assert delta.summary_deltas["degraded"] == 1
+
+    def test_new_lane_in_delta(self):
+        prev = SupervisorSnapshot(timestamp="t1", lane_assessments=[])
+        curr = SupervisorSnapshot(
+            timestamp="t2",
+            lane_assessments=[
+                LaneHealthAssessment(
+                    lane_id="author-a", health="healthy", state="active"
+                )
+            ],
+        )
+        delta = compute_delta(prev, curr)
+        assert len(delta.health_changes) == 1
+        assert delta.health_changes[0]["from"] == "(absent)"
+        assert delta.health_changes[0]["to"] == "healthy"
+
+    def test_removed_lane_in_delta(self):
+        prev = SupervisorSnapshot(
+            timestamp="t1",
+            lane_assessments=[
+                LaneHealthAssessment(
+                    lane_id="author-a", health="healthy", state="active"
+                )
+            ],
+        )
+        curr = SupervisorSnapshot(timestamp="t2", lane_assessments=[])
+        delta = compute_delta(prev, curr)
+        assert len(delta.health_changes) == 1
+        assert delta.health_changes[0]["from"] == "healthy"
+        assert delta.health_changes[0]["to"] == "(absent)"
+
+    def test_new_finding_detected(self):
+        prev = SupervisorSnapshot(
+            timestamp="t1",
+            lane_assessments=[
+                LaneHealthAssessment(
+                    lane_id="a", health="healthy", state="active", findings=[]
+                )
+            ],
+        )
+        curr = SupervisorSnapshot(
+            timestamp="t2",
+            lane_assessments=[
+                LaneHealthAssessment(
+                    lane_id="a",
+                    health="degraded",
+                    state="active",
+                    findings=[
+                        {
+                            "watchdog": "ci_stuck",
+                            "severity": "warning",
+                            "message": "CI stuck",
+                            "target": "PR #1",
+                        }
+                    ],
+                )
+            ],
+        )
+        delta = compute_delta(prev, curr)
+        assert len(delta.new_findings) == 1
+        assert delta.new_findings[0]["watchdog"] == "ci_stuck"
+        assert delta.resolved_findings == []
+
+    def test_resolved_finding_detected(self):
+        finding = {
+            "watchdog": "ci_stuck",
+            "severity": "warning",
+            "message": "CI stuck",
+            "target": "PR #1",
+        }
+        prev = SupervisorSnapshot(
+            timestamp="t1",
+            lane_assessments=[
+                LaneHealthAssessment(
+                    lane_id="a",
+                    health="degraded",
+                    state="active",
+                    findings=[finding],
+                )
+            ],
+        )
+        curr = SupervisorSnapshot(
+            timestamp="t2",
+            lane_assessments=[
+                LaneHealthAssessment(
+                    lane_id="a", health="healthy", state="active", findings=[]
+                )
+            ],
+        )
+        delta = compute_delta(prev, curr)
+        assert len(delta.resolved_findings) == 1
+        assert delta.new_findings == []
+
+    def test_new_recommendation_detected(self):
+        prev = SupervisorSnapshot(timestamp="t1", recommendations=[])
+        rec = RecoveryRecommendation(lane_id="a", action="respawn", reason="stale")
+        curr = SupervisorSnapshot(timestamp="t2", recommendations=[rec])
+        delta = compute_delta(prev, curr)
+        assert len(delta.new_recommendations) == 1
+        assert delta.new_recommendations[0]["action"] == "respawn"
+
+    def test_resolved_recommendation_detected(self):
+        rec = RecoveryRecommendation(lane_id="a", action="respawn", reason="stale")
+        prev = SupervisorSnapshot(timestamp="t1", recommendations=[rec])
+        curr = SupervisorSnapshot(timestamp="t2", recommendations=[])
+        delta = compute_delta(prev, curr)
+        assert len(delta.resolved_recommendations) == 1
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotPersistence:
+    """Tests for save_snapshot / load_latest_snapshot."""
+
+    def test_save_and_load(self, runtime_dir: Path):
+        snap = SupervisorSnapshot(
+            timestamp="2026-03-22T10:00:00+00:00",
+            lane_assessments=[
+                LaneHealthAssessment(lane_id="ops", health="healthy", state="active")
+            ],
+            summary={"total_lanes": 1},
+        )
+        path = save_snapshot(snap, runtime_dir)
+        assert path.exists()
+        assert path.suffix == ".json"
+
+        loaded = load_latest_snapshot(runtime_dir)
+        assert loaded is not None
+        assert loaded.timestamp == snap.timestamp
+        assert len(loaded.lane_assessments) == 1
+
+    def test_load_latest_returns_newest(self, runtime_dir: Path):
+        snap1 = SupervisorSnapshot(timestamp="2026-03-22T09:00:00+00:00")
+        snap2 = SupervisorSnapshot(timestamp="2026-03-22T10:00:00+00:00")
+        save_snapshot(snap1, runtime_dir)
+        save_snapshot(snap2, runtime_dir)
+
+        loaded = load_latest_snapshot(runtime_dir)
+        assert loaded is not None
+        assert loaded.timestamp == "2026-03-22T10:00:00+00:00"
+
+    def test_load_returns_none_when_no_snapshots(self, runtime_dir: Path):
+        assert load_latest_snapshot(runtime_dir) is None
+
+    def test_pruning_enforces_limit(self, runtime_dir: Path):
+        from bid_euchre.ops.supervisor import MAX_PERSISTED_SNAPSHOTS
+
+        for i in range(MAX_PERSISTED_SNAPSHOTS + 5):
+            snap = SupervisorSnapshot(timestamp=f"2026-03-22T{i:02d}:00:00+00:00")
+            save_snapshot(snap, runtime_dir)
+
+        snap_dir = runtime_dir / "supervisor_snapshots"
+        files = list(snap_dir.glob("snapshot_*.json"))
+        assert len(files) <= MAX_PERSISTED_SNAPSHOTS
+
+
+# ---------------------------------------------------------------------------
+# Full cycle
+# ---------------------------------------------------------------------------
+
+
+class TestRunSupervisorCycle:
+    """Tests for run_supervisor_cycle."""
+
+    def test_first_cycle_no_delta(self, runtime_dir: Path, plans_dir: Path):
+        now = datetime(2026, 3, 22, 10, 0, 0, tzinfo=timezone.utc)
+        result = run_supervisor_cycle(
+            runtime_dir=runtime_dir,
+            plans_dir=plans_dir,
+            now=now,
+        )
+        assert isinstance(result, SupervisorCycleResult)
+        assert result.snapshot is not None
+        assert result.delta is None
+        assert result.has_changes is False
+
+    def test_cycle_with_previous_snapshot(self, runtime_dir: Path, plans_dir: Path):
+        now1 = datetime(2026, 3, 22, 9, 0, 0, tzinfo=timezone.utc)
+        now2 = datetime(2026, 3, 22, 10, 0, 0, tzinfo=timezone.utc)
+
+        prev = take_snapshot(runtime_dir, plans_dir, now=now1)
+        result = run_supervisor_cycle(
+            runtime_dir=runtime_dir,
+            plans_dir=plans_dir,
+            now=now2,
+            prev_snapshot=prev,
+        )
+        assert result.delta is not None
+        assert result.delta.from_timestamp == prev.timestamp
+        assert result.delta.to_timestamp == result.snapshot.timestamp
+
+    def test_cycle_with_save_persists(self, runtime_dir: Path, plans_dir: Path):
+        now = datetime(2026, 3, 22, 10, 0, 0, tzinfo=timezone.utc)
+        result = run_supervisor_cycle(
+            runtime_dir=runtime_dir,
+            plans_dir=plans_dir,
+            now=now,
+            save=True,
+        )
+        assert result.snapshot is not None
+
+        loaded = load_latest_snapshot(runtime_dir)
+        assert loaded is not None
+        assert loaded.timestamp == result.snapshot.timestamp
+
+    def test_cycle_with_save_loads_prev_automatically(
+        self, runtime_dir: Path, plans_dir: Path
+    ):
+        now1 = datetime(2026, 3, 22, 9, 0, 0, tzinfo=timezone.utc)
+        now2 = datetime(2026, 3, 22, 10, 0, 0, tzinfo=timezone.utc)
+
+        # First cycle — saves a snapshot
+        run_supervisor_cycle(
+            runtime_dir=runtime_dir,
+            plans_dir=plans_dir,
+            now=now1,
+            save=True,
+        )
+
+        # Second cycle — should auto-load previous
+        result = run_supervisor_cycle(
+            runtime_dir=runtime_dir,
+            plans_dir=plans_dir,
+            now=now2,
+            save=True,
+        )
+        assert result.delta is not None
+
+
+# ---------------------------------------------------------------------------
+# take_snapshot integration
+# ---------------------------------------------------------------------------
+
+
+class TestTakeSnapshot:
+    """Tests for take_snapshot with real (empty) runtime dirs."""
+
+    def test_empty_runtime_dir(self, runtime_dir: Path, plans_dir: Path):
+        now = datetime(2026, 3, 22, 10, 0, 0, tzinfo=timezone.utc)
+        snap = take_snapshot(runtime_dir, plans_dir, now=now)
+        assert snap.timestamp == now.isoformat()
+        assert snap.lane_assessments == []
+        # watchdog_finding_count may be >= 0 — watchdogs scan real
+        # worktree state even with empty runtime/plans dirs
+        assert snap.watchdog_finding_count >= 0
+        assert snap.summary["total_lanes"] == 0
+
+    def test_with_registered_lane(self, runtime_dir: Path, plans_dir: Path):
+        # Register a lane
+        _write_json(
+            runtime_dir / "worktree_registry",
+            "author-a.json",
+            {
+                "lane_id": "author-a",
+                "lane_class": "author",
+                "worktree_path": "/tmp/author-a",
+                "branch": "main",
+                "lifecycle_class": "persistent",
+                "visibility": "background",
+            },
+        )
+
+        now = datetime(2026, 3, 22, 10, 0, 0, tzinfo=timezone.utc)
+        snap = take_snapshot(runtime_dir, plans_dir, now=now)
+        assert len(snap.lane_assessments) >= 1
+
+        author_a = None
+        for la in snap.lane_assessments:
+            if la.lane_id == "author-a":
+                author_a = la
+                break
+        assert author_a is not None
+        assert author_a.health in HEALTH_LEVELS
+
+
+# ---------------------------------------------------------------------------
+# recommend_recovery
+# ---------------------------------------------------------------------------
+
+
+class TestRecommendRecovery:
+    """Tests for recommend_recovery (convenience accessor)."""
+
+    def test_returns_copy_of_recommendations(self):
+        rec = RecoveryRecommendation(lane_id="a", action="retry", reason="r")
+        snap = SupervisorSnapshot(
+            timestamp="t",
+            recommendations=[rec],
+        )
+        result = recommend_recovery(snap)
+        assert len(result) == 1
+        assert result[0].lane_id == "a"
+        # Verify it's a copy, not the same list
+        result.clear()
+        assert len(snap.recommendations) == 1
+
+
+# ---------------------------------------------------------------------------
+# Formatters
+# ---------------------------------------------------------------------------
+
+
+class TestFormatters:
+    """Tests for format_supervisor_text and format_supervisor_json."""
+
+    def _make_result(
+        self,
+        *,
+        with_delta: bool = False,
+        has_changes: bool = False,
+    ) -> SupervisorCycleResult:
+        la = LaneHealthAssessment(
+            lane_id="author-a",
+            health="degraded",
+            state="stale",
+            findings=[
+                {
+                    "severity": "warning",
+                    "watchdog": "task_progress",
+                    "message": "stalled 35min",
+                    "target": "author-a",
+                }
+            ],
+            attention_needed=True,
+            attention_reason="stale lane",
+            current_task="fix bug",
+            linked_pr=42,
+        )
+        rec = RecoveryRecommendation(
+            lane_id="author-a",
+            action="investigate",
+            reason="stale lane",
+            priority="medium",
+            recovery_steps=["check findings", "verify progress"],
+        )
+        snap = SupervisorSnapshot(
+            timestamp="2026-03-22T10:00:00+00:00",
+            lane_assessments=[la],
+            watchdog_finding_count=1,
+            active_failure_count=0,
+            recommendations=[rec],
+            summary={
+                "total_lanes": 1,
+                "degraded": 1,
+                "healthy": 0,
+                "critical": 0,
+                "idle": 0,
+                "watchdog_findings": 1,
+                "active_failures": 0,
+                "attention_needed": 1,
+            },
+        )
+
+        delta = None
+        if with_delta:
+            delta = DeltaSummary(
+                from_timestamp="2026-03-22T09:00:00+00:00",
+                to_timestamp="2026-03-22T10:00:00+00:00",
+                health_changes=[
+                    {"lane_id": "author-a", "from": "healthy", "to": "degraded"}
+                ],
+                new_findings=[
+                    {
+                        "severity": "warning",
+                        "watchdog": "task_progress",
+                        "message": "stalled 35min",
+                        "target": "author-a",
+                    }
+                ],
+                summary_deltas={"healthy": -1, "degraded": 1},
+            )
+
+        return SupervisorCycleResult(
+            snapshot=snap,
+            delta=delta,
+            has_changes=has_changes,
+        )
+
+    def test_text_format_basic(self):
+        result = self._make_result()
+        text = format_supervisor_text(result)
+        assert "=== Supervisor Report ===" in text
+        assert "author-a" in text
+        assert "[DEGRADED]" in text
+        assert "investigate" in text
+        assert "stale lane" in text
+
+    def test_text_format_with_delta(self):
+        result = self._make_result(with_delta=True, has_changes=True)
+        text = format_supervisor_text(result)
+        assert "--- Delta ---" in text
+        assert "Health changes:" in text
+        assert "healthy -> degraded" in text
+        assert "New findings:" in text
+
+    def test_text_format_no_changes_delta(self):
+        result = self._make_result(with_delta=True, has_changes=False)
+        # Override delta to have no changes
+        result.delta = DeltaSummary(from_timestamp="t1", to_timestamp="t2")
+        text = format_supervisor_text(result)
+        assert "--- Delta: no changes ---" in text
+
+    def test_json_format_structure(self):
+        result = self._make_result()
+        data = format_supervisor_json(result)
+        assert "timestamp" in data
+        assert "summary" in data
+        assert "lane_assessments" in data
+        assert "recommendations" in data
+        assert data["has_changes"] is False
+
+    def test_json_format_with_delta(self):
+        result = self._make_result(with_delta=True, has_changes=True)
+        data = format_supervisor_json(result)
+        assert "delta" in data
+        assert data["has_changes"] is True
+        assert len(data["delta"]["health_changes"]) == 1
+
+    def test_json_is_serializable(self):
+        result = self._make_result(with_delta=True, has_changes=True)
+        data = format_supervisor_json(result)
+        # Must not raise
+        json_str = json.dumps(data)
+        assert isinstance(json_str, str)
+
+    def test_text_format_with_task_and_pr(self):
+        result = self._make_result()
+        text = format_supervisor_text(result)
+        assert "fix bug" in text
+        assert "PR #42" in text
+
+
+# ---------------------------------------------------------------------------
+# Health levels constant
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    """Verify module constants are well-formed."""
+
+    def test_health_levels_are_ordered(self):
+        assert HEALTH_LEVELS == ("critical", "degraded", "healthy", "idle")
+
+    def test_health_levels_tuple(self):
+        assert isinstance(HEALTH_LEVELS, tuple)
+        assert len(HEALTH_LEVELS) == 4
+
+
+# ---------------------------------------------------------------------------
+# assess_lane_health convenience
+# ---------------------------------------------------------------------------
+
+
+class TestAssessLaneHealth:
+    """Tests for the assess_lane_health convenience function."""
+
+    def test_returns_none_for_unknown_lane(self, runtime_dir: Path, plans_dir: Path):
+        from bid_euchre.ops.supervisor import assess_lane_health
+
+        now = datetime(2026, 3, 22, 10, 0, 0, tzinfo=timezone.utc)
+        result = assess_lane_health(
+            "nonexistent-lane",
+            runtime_dir=runtime_dir,
+            plans_dir=plans_dir,
+            now=now,
+        )
+        assert result is None
+
+    def test_returns_assessment_for_registered_lane(
+        self, runtime_dir: Path, plans_dir: Path
+    ):
+        from bid_euchre.ops.supervisor import assess_lane_health
+
+        _write_json(
+            runtime_dir / "worktree_registry",
+            "author-a.json",
+            {
+                "lane_id": "author-a",
+                "lane_class": "author",
+                "worktree_path": "/tmp/author-a",
+                "branch": "main",
+                "lifecycle_class": "persistent",
+            },
+        )
+
+        now = datetime(2026, 3, 22, 10, 0, 0, tzinfo=timezone.utc)
+        result = assess_lane_health(
+            "author-a",
+            runtime_dir=runtime_dir,
+            plans_dir=plans_dir,
+            now=now,
+        )
+        assert result is not None
+        assert result.lane_id == "author-a"
+        assert result.health in HEALTH_LEVELS


### PR DESCRIPTION
## Plan
- `plans/agent_ops/governing_plan.md` -- Platform-6 Supervisor Routines
- Phase 3 (Supervision & Scaling), Batch D

## Summary
- New module `src/bid_euchre/ops/supervisor.py` with point-in-time lane health snapshots, delta computation between consecutive snapshots, per-lane health assessment, and bounded recovery recommendations
- CLI: `ops.py supervisor [--json] [--save] [--diff PATH]` for text/JSON output, snapshot persistence, and diff against previous snapshots
- 57 unit tests covering health classification, lane extraction, recommendation generation, snapshot serialization, delta computation, persistence, full cycle, and formatters

## Why
Platform-6 is the first slice of Phase 3 (Supervision & Scaling). It enables ops to emit delta-only summaries over lane/repo/CI state so the orchestrator and human operator can rely on attention routing rather than frequent manual polling. Recovery recommendations are durable and auditable, consumed from existing `recovery.py` templates.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_supervisor.py -v   # 57 passed
make check-quiet                                                 # All checks passed
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_supervisor.py -v` (57 passed)
- [x] `make check-quiet` (full validation passed)

## Expected impact
- Metrics impact: None (new module, no changes to existing metrics)
- Runtime impact: None (on-demand supervisor cycle, no background processes)

## Risk level
- [x] Low (new ops module, no changes to core/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         ed67010b [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author          9e3497a0 [ops/platform6-supervisor]
```

## Scope Lock
Only these files were created/modified (per task packet):
- `src/bid_euchre/ops/supervisor.py` (NEW -- 640 lines)
- `scripts/internal/ops.py` (EDIT -- supervisor subcommand + CLI handler)
- `src/bid_euchre/ops/__init__.py` (EDIT -- docstring)
- `tests/unit/test_ops_supervisor.py` (NEW -- 57 tests)

## Hard Boundaries Respected
- Did NOT modify `dashboard.py`, `message_bus.py`, `watchdogs.py`, `recovery.py`
- Did NOT implement worker-pool scaling (Platform-7)
- Did NOT add remote notification channels (Platform-8/9)
- Did NOT add APScheduler periodic scheduling
- Stalled-lane detection consumes existing watchdog checks, not reimplements
- Recovery recommendations use existing `recovery.py` policy, not replaces

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)