### PR TITLE
fix: suppress noisy PreToolUse hook output on happy paths

### DIFF
--- a/.claude/hooks/pre-merge-review-guard.sh
+++ b/.claude/hooks/pre-merge-review-guard.sh
@@ -21,11 +21,13 @@ INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 
 if [ -z "$COMMAND" ]; then
+  echo '{"suppressOutput": true}'
   exit 0
 fi
 
 # Only guard gh pr merge commands
 if [[ "$COMMAND" != *"gh pr merge"* ]]; then
+  echo '{"suppressOutput": true}'
   exit 0
 fi
 
@@ -174,4 +176,5 @@ BLOCK
 fi
 
 # All checks passed — allow the merge
+echo '{"suppressOutput": true}'
 exit 0

--- a/.claude/hooks/pre-worktree-cleanup.sh
+++ b/.claude/hooks/pre-worktree-cleanup.sh
@@ -21,6 +21,7 @@ INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 
 if [ -z "$COMMAND" ]; then
+    echo '{"suppressOutput": true}'
     exit 0
 fi
 
@@ -36,6 +37,7 @@ elif echo "$COMMAND" | grep -q "git worktree prune"; then
 fi
 
 if [ -z "$MATCHED" ]; then
+    echo '{"suppressOutput": true}'
     exit 0
 fi
 

--- a/.claude/hooks/rule-loader.sh
+++ b/.claude/hooks/rule-loader.sh
@@ -26,13 +26,13 @@ case "$TOOL_NAME" in
     ;;
   *)
     # No match — exit with empty response
-    echo '{}'
+    echo '{"suppressOutput": true}'
     exit 0
     ;;
 esac
 
 if [ -z "$FILE_PATH" ]; then
-  echo '{}'
+  echo '{"suppressOutput": true}'
   exit 0
 fi
 
@@ -71,7 +71,7 @@ fi
 
 # No rules matched
 if [ ${#RULES_TO_LOAD[@]} -eq 0 ]; then
-  echo '{}'
+  echo '{"suppressOutput": true}'
   exit 0
 fi
 
@@ -97,7 +97,7 @@ done
 
 # Nothing new to load
 if [ ${#NEW_RULES[@]} -eq 0 ]; then
-  echo '{}'
+  echo '{"suppressOutput": true}'
   exit 0
 fi
 
@@ -115,9 +115,7 @@ done
 # Output additionalContext JSON
 if [ -n "$CONTEXT" ]; then
   # Use jq to safely encode the content as JSON
-  echo "$CONTEXT" | jq -Rs '{additionalContext: .}' 2>/dev/null || echo '{}'
+  echo "$CONTEXT" | jq -Rs '{additionalContext: ., suppressOutput: true}' 2>/dev/null || echo '{"suppressOutput": true}'
 else
-  echo '{}'
+  echo '{"suppressOutput": true}'
 fi
-
-exit 0

--- a/tests/unit/test_hook_suppress_output.py
+++ b/tests/unit/test_hook_suppress_output.py
@@ -1,0 +1,133 @@
+"""Tests for PreToolUse hook suppressOutput on happy paths.
+
+Each PreToolUse hook must output {"suppressOutput": true} on its exit-0
+code paths to avoid noisy "Async hook PreToolUse completed" messages.
+Blocking paths (exit 2) must NOT emit suppressOutput.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+HOOKS_DIR = Path(__file__).resolve().parents[2] / ".claude" / "hooks"
+
+
+def _run_hook(
+    script: str, payload: dict, env_override: dict | None = None
+) -> tuple[int, dict | None]:
+    """Run a hook script with JSON payload on stdin.
+
+    Returns (exit_code, parsed_json_or_None).
+    """
+    import os
+
+    env = os.environ.copy()
+    if env_override:
+        env.update(env_override)
+
+    result = subprocess.run(
+        ["bash", str(HOOKS_DIR / script)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=10,
+    )
+
+    parsed = None
+    stdout = result.stdout.strip()
+    if stdout:
+        try:
+            parsed = json.loads(stdout)
+        except json.JSONDecodeError:
+            pass  # Blocking paths emit free-form text, not JSON
+
+    return result.returncode, parsed
+
+
+class TestRuleLoaderSuppressOutput:
+    """rule-loader.sh must emit suppressOutput on all exit-0 paths."""
+
+    SCRIPT = "rule-loader.sh"
+
+    def test_unmatched_tool_emits_suppress(self) -> None:
+        """Glob tool doesn't match any case arm."""
+        rc, out = _run_hook(self.SCRIPT, {"tool_name": "Glob", "tool_input": {}})
+        assert rc == 0
+        assert out is not None
+        assert out.get("suppressOutput") is True
+
+    def test_empty_file_path_emits_suppress(self) -> None:
+        """Read with empty file_path triggers early exit."""
+        rc, out = _run_hook(
+            self.SCRIPT, {"tool_name": "Read", "tool_input": {"file_path": ""}}
+        )
+        assert rc == 0
+        assert out is not None
+        assert out.get("suppressOutput") is True
+
+    def test_no_rules_matched_emits_suppress(self) -> None:
+        """Read on a path that doesn't trigger any rule pattern."""
+        rc, out = _run_hook(
+            self.SCRIPT,
+            {"tool_name": "Read", "tool_input": {"file_path": "/tmp/unrelated.txt"}},
+        )
+        assert rc == 0
+        assert out is not None
+        assert out.get("suppressOutput") is True
+
+
+class TestPreWorktreeCleanupSuppressOutput:
+    """pre-worktree-cleanup.sh must emit suppressOutput on non-matching paths."""
+
+    SCRIPT = "pre-worktree-cleanup.sh"
+
+    def test_empty_command_emits_suppress(self) -> None:
+        """Non-Bash tool input (no command field)."""
+        rc, out = _run_hook(self.SCRIPT, {"tool_name": "Read", "tool_input": {}})
+        assert rc == 0
+        assert out is not None
+        assert out.get("suppressOutput") is True
+
+    def test_safe_command_emits_suppress(self) -> None:
+        """Safe bash command that doesn't match any dangerous pattern."""
+        rc, out = _run_hook(
+            self.SCRIPT, {"tool_name": "Bash", "tool_input": {"command": "ls -la"}}
+        )
+        assert rc == 0
+        assert out is not None
+        assert out.get("suppressOutput") is True
+
+    def test_dangerous_command_blocks_without_suppress(self) -> None:
+        """Dangerous worktree command should block (exit 2) without suppressOutput."""
+        rc, out = _run_hook(
+            self.SCRIPT,
+            {"tool_name": "Bash", "tool_input": {"command": "git worktree prune"}},
+        )
+        assert rc == 2
+        # Blocking path emits human-readable text, not JSON with suppressOutput
+        assert out is None or out.get("suppressOutput") is not True
+
+
+class TestPreMergeReviewGuardSuppressOutput:
+    """pre-merge-review-guard.sh must emit suppressOutput on non-merge commands."""
+
+    SCRIPT = "pre-merge-review-guard.sh"
+
+    def test_empty_command_emits_suppress(self) -> None:
+        """Non-Bash tool input (no command field)."""
+        rc, out = _run_hook(self.SCRIPT, {"tool_name": "Read", "tool_input": {}})
+        assert rc == 0
+        assert out is not None
+        assert out.get("suppressOutput") is True
+
+    def test_non_merge_command_emits_suppress(self) -> None:
+        """Regular bash command that isn't gh pr merge."""
+        rc, out = _run_hook(
+            self.SCRIPT, {"tool_name": "Bash", "tool_input": {"command": "git status"}}
+        )
+        assert rc == 0
+        assert out is not None
+        assert out.get("suppressOutput") is True


### PR DESCRIPTION
## Summary
- Add `{"suppressOutput": true}` to all exit-0 (happy-path) code paths in three PreToolUse hooks: `rule-loader.sh`, `pre-worktree-cleanup.sh`, `pre-merge-review-guard.sh`
- Blocking paths (exit 2) remain visible — only no-op pass-throughs are suppressed
- Add regression tests verifying suppressOutput behavior for all three hooks

## Why
Every tool call triggers all PreToolUse hooks, and each one prints "Async hook PreToolUse completed" when it exits without suppressing output. This creates significant noise in the Claude Code output. The `suppressOutput` field tells Claude Code to silently acknowledge the hook's success.

## Changes
| File | Change |
|------|--------|
| `.claude/hooks/rule-loader.sh` | Replace `echo '{}'` with `echo '{"suppressOutput": true}'` on all 5 early-exit paths; add `suppressOutput: true` to the jq additionalContext output |
| `.claude/hooks/pre-worktree-cleanup.sh` | Add `echo '{"suppressOutput": true}'` before exit 0 on empty-command and no-match paths |
| `.claude/hooks/pre-merge-review-guard.sh` | Add `echo '{"suppressOutput": true}'` before exit 0 on empty-command, non-merge, and all-passed paths |
| `tests/unit/test_hook_suppress_output.py` | 8 tests covering all three hooks' happy and blocking paths |

## Validation
```bash
# Smoke test each hook
echo '{"tool_name":"Read","tool_input":{"file_path":"README.md"}}' | bash .claude/hooks/rule-loader.sh | jq .
echo '{"tool_name":"Bash","tool_input":{"command":"ls"}}' | bash .claude/hooks/pre-worktree-cleanup.sh | jq .
echo '{"tool_name":"Bash","tool_input":{"command":"ls"}}' | bash .claude/hooks/pre-merge-review-guard.sh | jq .

# Full test suite
make check-quiet  # ✓ All checks passed
uv run python -m pytest tests/unit/test_hook_suppress_output.py -v  # 8/8 passed
```

## Worktree proof
Working from `Bid-Euchre-steward-author-c` persistent worktree on branch `fix/suppress-hook-output`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)