### PR TITLE
ops: add worker pool lifecycle management (Platform-7)

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -38,6 +38,12 @@ Usage:
     uv run python scripts/internal/ops.py inbox stats [--json]
     uv run python scripts/internal/ops.py message show MSG_ID [--json]
     uv run python scripts/internal/ops.py supervisor [--json] [--save] [--diff SNAPSHOT_PATH]
+    uv run python scripts/internal/ops.py workers [--json]
+    uv run python scripts/internal/ops.py workers wake LANE_ID [--json]
+    uv run python scripts/internal/ops.py workers park LANE_ID [--json]
+    uv run python scripts/internal/ops.py workers retire LANE_ID [--json]
+    uv run python scripts/internal/ops.py workers dispatch PACKET_ID LANE_ID [--json]
+    uv run python scripts/internal/ops.py workers maintain [--dry-run] [--json]
 """
 
 from __future__ import annotations
@@ -1699,6 +1705,91 @@ def cmd_supervisor(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_workers(args: argparse.Namespace) -> int:
+    """Worker pool lifecycle management (Platform-7)."""
+    from bid_euchre.ops.worker_pool import (
+        dispatch_to_worker,
+        format_action_text,
+        format_actions_json,
+        format_pool_json,
+        format_pool_text,
+        park_worker,
+        retire_worker,
+        run_pool_maintenance,
+        take_pool_snapshot,
+        wake_worker,
+    )
+
+    action = getattr(args, "workers_action", None)
+
+    if action == "wake":
+        lane_id = args.lane_id
+        result = wake_worker(lane_id, runtime_dir=args.runtime_dir)
+        if args.json:
+            from dataclasses import asdict
+
+            print(json.dumps(asdict(result), indent=2))
+        else:
+            print(format_action_text(result))
+        return 0 if result.executed else 1
+
+    elif action == "park":
+        lane_id = args.lane_id
+        result = park_worker(lane_id, runtime_dir=args.runtime_dir)
+        if args.json:
+            from dataclasses import asdict
+
+            print(json.dumps(asdict(result), indent=2))
+        else:
+            print(format_action_text(result))
+        return 0 if result.executed else 1
+
+    elif action == "retire":
+        lane_id = args.lane_id
+        result = retire_worker(lane_id, runtime_dir=args.runtime_dir)
+        if args.json:
+            from dataclasses import asdict
+
+            print(json.dumps(asdict(result), indent=2))
+        else:
+            print(format_action_text(result))
+        return 0 if result.executed else 1
+
+    elif action == "dispatch":
+        packet_id = args.packet_id
+        lane_id = args.lane_id
+        result = dispatch_to_worker(packet_id, lane_id, runtime_dir=args.runtime_dir)
+        if args.json:
+            from dataclasses import asdict
+
+            print(json.dumps(asdict(result), indent=2))
+        else:
+            print(format_action_text(result))
+        return 0 if result.executed else 1
+
+    elif action == "maintain":
+        dry_run = getattr(args, "dry_run", False)
+        actions = run_pool_maintenance(runtime_dir=args.runtime_dir, dry_run=dry_run)
+        if args.json:
+            print(json.dumps(format_actions_json(actions), indent=2))
+        else:
+            if actions:
+                for a in actions:
+                    print(format_action_text(a))
+            else:
+                print("No maintenance actions needed.")
+        return 0
+
+    else:
+        # Default: show pool snapshot
+        pool = take_pool_snapshot(args.runtime_dir)
+        if args.json:
+            print(json.dumps(format_pool_json(pool), indent=2))
+        else:
+            print(format_pool_text(pool))
+        return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the argument parser."""
     parser = argparse.ArgumentParser(
@@ -2171,6 +2262,41 @@ def build_parser() -> argparse.ArgumentParser:
         help="Path to a previous snapshot JSON file to diff against",
     )
 
+    # workers (Platform-7: worker pool lifecycle management)
+    workers_parser = subparsers.add_parser(
+        "workers", help="Worker pool lifecycle management (Platform-7)"
+    )
+    workers_sub = workers_parser.add_subparsers(dest="workers_action")
+
+    workers_wake = workers_sub.add_parser(
+        "wake", help="Wake (open/resume) an author pane"
+    )
+    workers_wake.add_argument("lane_id", help="Lane ID to wake")
+
+    workers_park = workers_sub.add_parser("park", help="Park an idle author lane")
+    workers_park.add_argument("lane_id", help="Lane ID to park")
+
+    workers_retire = workers_sub.add_parser(
+        "retire", help="Retire a parked author lane"
+    )
+    workers_retire.add_argument("lane_id", help="Lane ID to retire")
+
+    workers_dispatch = workers_sub.add_parser(
+        "dispatch", help="Dispatch a task packet to an author lane"
+    )
+    workers_dispatch.add_argument("packet_id", help="Task packet ID to dispatch")
+    workers_dispatch.add_argument("lane_id", help="Target lane ID")
+
+    workers_maintain = workers_sub.add_parser(
+        "maintain", help="Run periodic maintenance (park idle, retire parked)"
+    )
+    workers_maintain.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Only propose actions without executing them",
+    )
+
     return parser
 
 
@@ -2226,6 +2352,7 @@ def main(argv: list[str] | None = None) -> int:
         "inbox": cmd_inbox,
         "message": cmd_message,
         "supervisor": cmd_supervisor,
+        "workers": cmd_workers,
     }
 
     handler = commands.get(args.command)

--- a/src/bid_euchre/ops/__init__.py
+++ b/src/bid_euchre/ops/__init__.py
@@ -24,6 +24,7 @@ Modules:
     task_queue  -- Durable task packet queue (Platform-2)
     dashboard   -- Dashboard-first supervision surface (Platform-4)
     supervisor  -- Supervisor routines and delta summaries (Platform-6)
+    worker_pool -- Worker pool lifecycle management (Platform-7)
 """
 
 # Shared constant: GitHub status/check context names that represent

--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -1,0 +1,1003 @@
+"""Worker pool lifecycle management (Platform-7).
+
+Enables the orchestrator to reuse idle author lanes, open/resume author
+panes on demand when delegating work, and park or retire lanes when idle.
+All state flows through repo-owned artifacts (worktree registry, task queue);
+tmux is used for pane lifecycle only.
+
+Uses subprocess ``tmux`` commands (not libtmux) for the first version,
+matching the pattern in ``steward-session.sh``.  libtmux migration is
+deferred to Platform-10 (portability layer).
+
+Usage::
+
+    from bid_euchre.ops.worker_pool import (
+        take_pool_snapshot,
+        select_worker,
+        wake_worker,
+        park_worker,
+        retire_worker,
+        dispatch_to_worker,
+        run_pool_maintenance,
+    )
+
+    pool = take_pool_snapshot()
+    lane = select_worker(pool)
+    if lane:
+        action = dispatch_to_worker(packet_id, lane)
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("ops.worker_pool")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Maximum number of simultaneously active (non-idle) author lanes.
+#: Matches the 5 persistent author worktrees in steward-session.sh.
+MAX_ACTIVE_AUTHORS: int = 5
+
+#: Idle threshold (minutes) before a lane is eligible for parking.
+IDLE_PARK_MINUTES: int = 15
+
+#: Parked threshold (minutes) before a parked lane is eligible for retirement.
+PARKED_RETIRE_MINUTES: int = 60
+
+#: Default tmux session name (matches steward-session.sh default).
+DEFAULT_TMUX_SESSION: str = "steward"
+
+#: Pool status values.
+POOL_STATUSES: frozenset[str] = frozenset({"active", "idle", "parked", "retired"})
+
+
+def _managed_lanes() -> frozenset[str]:
+    """Return the set of lane IDs managed by the worker pool.
+
+    Imports KNOWN_AUTHOR_LANES from task_queue to avoid duplication.
+    """
+    from bid_euchre.ops.task_queue import KNOWN_AUTHOR_LANES
+
+    return KNOWN_AUTHOR_LANES
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WorkerState:
+    """Snapshot of one author lane's pool state."""
+
+    lane_id: str
+    pool_status: str  # "active", "idle", "parked", "retired"
+    health: str  # from supervisor: "healthy", "idle", "degraded", "critical"
+    current_task_id: str | None
+    last_activity: str | None  # ISO 8601
+    visibility: str  # "foreground", "background", "hidden"
+    tmux_alive: bool  # whether the tmux pane/window exists and has a process
+    session_handle: str | None
+
+
+@dataclass
+class PoolSnapshot:
+    """Point-in-time summary of the worker pool."""
+
+    timestamp: str
+    workers: list[WorkerState] = field(default_factory=list)
+    active_count: int = 0
+    idle_count: int = 0
+    parked_count: int = 0
+    retired_count: int = 0
+    available_capacity: int = MAX_ACTIVE_AUTHORS
+
+
+@dataclass
+class PoolAction:
+    """A single lifecycle action proposed or executed by the pool manager."""
+
+    action: str  # "wake", "park", "retire", "reuse", "dispatch"
+    lane_id: str
+    reason: str
+    executed: bool = False
+    error: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _probe_tmux_pane(
+    lane_id: str,
+    tmux_session: str,
+) -> bool:
+    """Check if a tmux window for lane_id exists in the session.
+
+    Uses ``tmux list-windows`` to check for a window whose name matches
+    the lane_id.
+
+    Args:
+        lane_id: Lane identifier to look for.
+        tmux_session: tmux session name.
+
+    Returns:
+        True if a window named *lane_id* exists in the session.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "tmux",
+                "list-windows",
+                "-t",
+                tmux_session,
+                "-F",
+                "#{window_name}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            return False
+        window_names = result.stdout.strip().splitlines()
+        return lane_id in window_names
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def _create_tmux_window(
+    lane_id: str,
+    worktree_path: str,
+    tmux_session: str,
+) -> bool:
+    """Create a new tmux window for the lane.
+
+    Creates a window in the steward session pointed at the lane's worktree.
+    The window runs the claude CLI with the lane's agent profile.
+
+    Args:
+        lane_id: Lane identifier (becomes the window name).
+        worktree_path: Path to the lane's worktree directory.
+        tmux_session: tmux session name.
+
+    Returns:
+        True on success, False on failure.
+    """
+    claude_bin = shutil.which("claude")
+    if not claude_bin:
+        logger.error("Cannot find 'claude' binary in PATH")
+        return False
+
+    agent_name = _resolve_agent_name(lane_id)
+
+    try:
+        result = subprocess.run(
+            [
+                "tmux",
+                "new-window",
+                "-t",
+                tmux_session,
+                "-n",
+                lane_id,
+                "-c",
+                worktree_path,
+                claude_bin,
+                "--name",
+                lane_id,
+                "--agent",
+                agent_name,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            logger.error(
+                "tmux new-window failed for %s: %s",
+                lane_id,
+                result.stderr.strip(),
+            )
+            return False
+        return True
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        logger.error("tmux new-window error for %s: %s", lane_id, exc)
+        return False
+
+
+def _resolve_agent_name(lane_id: str) -> str:
+    """Map lane_id to the canonical agent profile name.
+
+    Examples:
+        "author-a"       -> "steward-author-a"
+        "author-scratch" -> "steward-author-scratch"
+    """
+    return f"steward-{lane_id}"
+
+
+def _resolve_worktree_path(
+    lane_id: str,
+    runtime_dir: Path | None = None,
+) -> str | None:
+    """Look up the worktree path for a lane from the registry.
+
+    Args:
+        lane_id: Lane to look up.
+        runtime_dir: Override for the runtime directory root.
+
+    Returns:
+        Worktree path string, or None if not found.
+    """
+    from bid_euchre.ops.status import aggregate_status
+
+    if runtime_dir is None:
+        runtime_dir = Path(".claude/runtime")
+
+    report = aggregate_status(runtime_dir, check_worktree=False)
+    for lane in report.lanes:
+        if lane.lane_id == lane_id:
+            return lane.worktree_path
+    return None
+
+
+def _classify_pool_status(
+    lane: Any,
+    health: str,
+    has_task: bool,
+    tmux_alive: bool,
+    visibility: str,
+) -> str:
+    """Derive pool_status from lane state, health, task presence, and visibility.
+
+    Args:
+        lane: LaneStatus object.
+        health: Health classification from supervisor.
+        has_task: Whether the lane has an active/dispatched task.
+        tmux_alive: Whether the tmux pane is alive.
+        visibility: Effective visibility.
+
+    Returns:
+        One of "active", "idle", "parked", "retired".
+    """
+    # Hidden lanes are parked or retired depending on tmux state
+    if visibility == "hidden":
+        if tmux_alive:
+            return "parked"
+        return "retired"
+
+    # Active task or active/likely_active state -> active
+    if has_task or lane.state in ("active", "likely_active"):
+        return "active"
+
+    # Otherwise idle
+    return "idle"
+
+
+def _get_lane_task_id(
+    lane_id: str,
+    runtime_dir: Path | None = None,
+) -> str | None:
+    """Find the active/dispatched task ID for a lane, if any.
+
+    Args:
+        lane_id: Lane to check.
+        runtime_dir: Override for the task queue root directory.
+
+    Returns:
+        Packet ID of the active task, or None.
+    """
+    from bid_euchre.ops.task_queue import list_packets
+
+    # Check dispatched packets owned by this lane
+    dispatched = list_packets(
+        runtime_dir, status_filter="dispatched", owner_filter=lane_id
+    )
+    if dispatched:
+        return dispatched[0].packet_id
+    return None
+
+
+def _minutes_since(iso_timestamp: str | None, now: datetime) -> float | None:
+    """Calculate minutes elapsed since an ISO 8601 timestamp.
+
+    Returns None if the timestamp is None or unparseable.
+    """
+    if not iso_timestamp:
+        return None
+    try:
+        # Handle various ISO formats
+        ts_str = iso_timestamp.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(ts_str)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        delta = now - dt
+        return delta.total_seconds() / 60.0
+    except (ValueError, TypeError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+
+def take_pool_snapshot(
+    runtime_dir: Path | None = None,
+    *,
+    tmux_session: str = DEFAULT_TMUX_SESSION,
+    now: datetime | None = None,
+) -> PoolSnapshot:
+    """Build a point-in-time worker pool snapshot.
+
+    Reads from:
+    - worktree registry (via status.aggregate_status)
+    - supervisor snapshot (via supervisor.take_snapshot)
+    - tmux session state (via _probe_tmux_pane)
+
+    Filters to managed lanes only.
+
+    Args:
+        runtime_dir: Override for the runtime directory root.
+        tmux_session: tmux session name to probe.
+        now: Override current time for testing.
+
+    Returns:
+        A new :class:`PoolSnapshot`.
+    """
+    from bid_euchre.ops.dashboard import effective_visibility
+    from bid_euchre.ops.status import aggregate_status
+    from bid_euchre.ops.supervisor import take_snapshot as supervisor_snapshot
+
+    if runtime_dir is None:
+        runtime_dir = Path(".claude/runtime")
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    managed = _managed_lanes()
+
+    # Gather lane status
+    report = aggregate_status(runtime_dir, check_worktree=False)
+
+    # Gather supervisor health assessments
+    try:
+        sup_snap = supervisor_snapshot(runtime_dir, now=now)
+        health_by_lane = {la.lane_id: la.health for la in sup_snap.lane_assessments}
+    except Exception as exc:
+        logger.debug("Supervisor snapshot failed: %s", exc)
+        health_by_lane = {}
+
+    workers: list[WorkerState] = []
+    counts = {"active": 0, "idle": 0, "parked": 0, "retired": 0}
+
+    for lane in report.lanes:
+        if lane.lane_id not in managed:
+            continue
+
+        visibility = effective_visibility(lane)
+        health = health_by_lane.get(lane.lane_id, "idle")
+        tmux_alive = _probe_tmux_pane(lane.lane_id, tmux_session)
+        task_id = _get_lane_task_id(lane.lane_id, runtime_dir)
+
+        pool_status = _classify_pool_status(
+            lane, health, task_id is not None, tmux_alive, visibility
+        )
+
+        # Determine last activity time
+        last_activity = lane.last_progress or lane.last_active
+
+        workers.append(
+            WorkerState(
+                lane_id=lane.lane_id,
+                pool_status=pool_status,
+                health=health,
+                current_task_id=task_id,
+                last_activity=last_activity,
+                visibility=visibility,
+                tmux_alive=tmux_alive,
+                session_handle=lane.session_handle,
+            )
+        )
+        counts[pool_status] = counts.get(pool_status, 0) + 1
+
+    return PoolSnapshot(
+        timestamp=now.isoformat(),
+        workers=workers,
+        active_count=counts["active"],
+        idle_count=counts["idle"],
+        parked_count=counts["parked"],
+        retired_count=counts["retired"],
+        available_capacity=max(0, MAX_ACTIVE_AUTHORS - counts["active"]),
+    )
+
+
+def select_worker(
+    pool: PoolSnapshot,
+    *,
+    preferred_lane: str | None = None,
+) -> str | None:
+    """Choose the best lane for new work.
+
+    Priority order:
+    1. preferred_lane (if idle or parked and healthy)
+    2. idle lanes (already running, no active task)
+    3. parked lanes (need waking, but worktree exists)
+    4. retired lanes (need full resume)
+    5. None if at MAX_ACTIVE_AUTHORS
+
+    Args:
+        pool: Current pool snapshot.
+        preferred_lane: Preferred lane ID, if any.
+
+    Returns:
+        Lane ID or None if no capacity.
+    """
+    if pool.available_capacity <= 0:
+        return None
+
+    workers_by_id = {w.lane_id: w for w in pool.workers}
+
+    # 1. Check preferred lane
+    if preferred_lane and preferred_lane in workers_by_id:
+        w = workers_by_id[preferred_lane]
+        if w.pool_status in ("idle", "parked", "retired"):
+            return preferred_lane
+
+    # 2. Idle lanes (already running)
+    idle_workers = [
+        w for w in pool.workers if w.pool_status == "idle" and w.health != "critical"
+    ]
+    if idle_workers:
+        return idle_workers[0].lane_id
+
+    # 3. Parked lanes
+    parked_workers = [
+        w for w in pool.workers if w.pool_status == "parked" and w.health != "critical"
+    ]
+    if parked_workers:
+        return parked_workers[0].lane_id
+
+    # 4. Retired lanes
+    retired_workers = [
+        w for w in pool.workers if w.pool_status == "retired" and w.health != "critical"
+    ]
+    if retired_workers:
+        return retired_workers[0].lane_id
+
+    return None
+
+
+def wake_worker(
+    lane_id: str,
+    *,
+    tmux_session: str = DEFAULT_TMUX_SESSION,
+    runtime_dir: Path | None = None,
+) -> PoolAction:
+    """Open or resume an author pane for the given lane.
+
+    Steps:
+    1. Check if tmux window already exists for lane_id.
+       - If alive: set visibility to "foreground", return.
+    2. If window does not exist: create a new tmux window in the
+       steward session, pointed at the lane's worktree.
+    3. Update registry: visibility -> "foreground".
+    4. Return PoolAction with executed=True.
+
+    Args:
+        lane_id: Lane to wake.
+        tmux_session: tmux session name.
+        runtime_dir: Override for the runtime directory root.
+
+    Returns:
+        A :class:`PoolAction` describing what happened.
+    """
+    from bid_euchre.ops.dashboard import set_lane_visibility
+
+    if lane_id not in _managed_lanes():
+        return PoolAction(
+            action="wake",
+            lane_id=lane_id,
+            reason=f"Lane {lane_id!r} is not a managed author lane",
+            executed=False,
+            error="not_managed",
+        )
+
+    if runtime_dir is None:
+        runtime_dir = Path(".claude/runtime")
+
+    # Check if already alive
+    if _probe_tmux_pane(lane_id, tmux_session):
+        # Already running -- just ensure visibility
+        set_lane_visibility(lane_id, "foreground", runtime_dir)
+        return PoolAction(
+            action="wake",
+            lane_id=lane_id,
+            reason="Pane already alive; set visibility to foreground",
+            executed=True,
+        )
+
+    # Need to create a new tmux window
+    worktree_path = _resolve_worktree_path(lane_id, runtime_dir)
+    if not worktree_path:
+        return PoolAction(
+            action="wake",
+            lane_id=lane_id,
+            reason=f"Could not resolve worktree path for {lane_id!r}",
+            executed=False,
+            error="no_worktree",
+        )
+
+    success = _create_tmux_window(lane_id, worktree_path, tmux_session)
+    if not success:
+        return PoolAction(
+            action="wake",
+            lane_id=lane_id,
+            reason="Failed to create tmux window",
+            executed=False,
+            error="tmux_failed",
+        )
+
+    # Update visibility
+    set_lane_visibility(lane_id, "foreground", runtime_dir)
+
+    return PoolAction(
+        action="wake",
+        lane_id=lane_id,
+        reason="Created tmux window and set visibility to foreground",
+        executed=True,
+    )
+
+
+def park_worker(
+    lane_id: str,
+    *,
+    tmux_session: str = DEFAULT_TMUX_SESSION,
+    runtime_dir: Path | None = None,
+) -> PoolAction:
+    """Move an idle author lane to parked state.
+
+    Sets visibility to "hidden" but does NOT kill the tmux pane.
+    The claude process may still be running but idle.
+
+    Args:
+        lane_id: Lane to park.
+        tmux_session: tmux session name.
+        runtime_dir: Override for the runtime directory root.
+
+    Returns:
+        A :class:`PoolAction` describing what happened.
+    """
+    from bid_euchre.ops.dashboard import set_lane_visibility
+
+    if lane_id not in _managed_lanes():
+        return PoolAction(
+            action="park",
+            lane_id=lane_id,
+            reason=f"Lane {lane_id!r} is not a managed author lane",
+            executed=False,
+            error="not_managed",
+        )
+
+    if runtime_dir is None:
+        runtime_dir = Path(".claude/runtime")
+
+    # Verify no active task
+    task_id = _get_lane_task_id(lane_id, runtime_dir)
+    if task_id:
+        return PoolAction(
+            action="park",
+            lane_id=lane_id,
+            reason=f"Lane has active task {task_id!r}; cannot park",
+            executed=False,
+            error="has_active_task",
+        )
+
+    # Set visibility to hidden
+    set_lane_visibility(lane_id, "hidden", runtime_dir)
+
+    return PoolAction(
+        action="park",
+        lane_id=lane_id,
+        reason="Set visibility to hidden; tmux pane left running",
+        executed=True,
+    )
+
+
+def retire_worker(
+    lane_id: str,
+    *,
+    tmux_session: str = DEFAULT_TMUX_SESSION,
+    runtime_dir: Path | None = None,
+) -> PoolAction:
+    """Fully retire a parked lane.
+
+    Sets visibility to "hidden" and sends SIGTERM to the tmux pane's
+    process (if alive).  The worktree is never removed (per worktree
+    protection rules).
+
+    Args:
+        lane_id: Lane to retire.
+        tmux_session: tmux session name.
+        runtime_dir: Override for the runtime directory root.
+
+    Returns:
+        A :class:`PoolAction` describing what happened.
+    """
+    from bid_euchre.ops.dashboard import set_lane_visibility
+
+    if lane_id not in _managed_lanes():
+        return PoolAction(
+            action="retire",
+            lane_id=lane_id,
+            reason=f"Lane {lane_id!r} is not a managed author lane",
+            executed=False,
+            error="not_managed",
+        )
+
+    if runtime_dir is None:
+        runtime_dir = Path(".claude/runtime")
+
+    # Verify no active task
+    task_id = _get_lane_task_id(lane_id, runtime_dir)
+    if task_id:
+        return PoolAction(
+            action="retire",
+            lane_id=lane_id,
+            reason=f"Lane has active task {task_id!r}; cannot retire",
+            executed=False,
+            error="has_active_task",
+        )
+
+    # Set visibility to hidden
+    set_lane_visibility(lane_id, "hidden", runtime_dir)
+
+    # Terminate the tmux pane if alive
+    if _probe_tmux_pane(lane_id, tmux_session):
+        try:
+            subprocess.run(
+                [
+                    "tmux",
+                    "send-keys",
+                    "-t",
+                    f"{tmux_session}:{lane_id}",
+                    "",
+                    "",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            # Kill the window
+            subprocess.run(
+                [
+                    "tmux",
+                    "kill-window",
+                    "-t",
+                    f"{tmux_session}:{lane_id}",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            logger.info("Terminated tmux window for %s", lane_id)
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+            logger.warning(
+                "Failed to terminate tmux window for %s: %s",
+                lane_id,
+                exc,
+            )
+            return PoolAction(
+                action="retire",
+                lane_id=lane_id,
+                reason=f"Visibility set to hidden but tmux kill failed: {exc}",
+                executed=True,
+                error="tmux_kill_failed",
+            )
+
+    return PoolAction(
+        action="retire",
+        lane_id=lane_id,
+        reason="Set visibility to hidden and terminated tmux pane",
+        executed=True,
+    )
+
+
+def dispatch_to_worker(
+    packet_id: str,
+    lane_id: str,
+    *,
+    tmux_session: str = DEFAULT_TMUX_SESSION,
+    runtime_dir: Path | None = None,
+) -> PoolAction:
+    """Complete lifecycle: wake worker, assign task packet, update state.
+
+    Steps:
+    1. Load task packet, verify it is in "approved" status.
+    2. Take pool snapshot, verify lane_id has capacity.
+    3. If lane is parked/retired: wake_worker() first.
+    4. Transition packet to "dispatched" with owner = lane_id.
+    5. Set lane visibility to "foreground".
+    6. Return PoolAction.
+
+    This is the high-level entry point the orchestrator calls.
+
+    Args:
+        packet_id: Task packet ID to dispatch.
+        lane_id: Target lane for the work.
+        tmux_session: tmux session name.
+        runtime_dir: Override for the runtime directory root.
+
+    Returns:
+        A :class:`PoolAction` describing what happened.
+    """
+    from bid_euchre.ops.task_queue import load_packet, transition_status
+
+    if runtime_dir is None:
+        runtime_dir = Path(".claude/runtime")
+
+    # 1. Verify packet exists and is approved
+    packet = load_packet(packet_id, runtime_dir)
+    if packet is None:
+        return PoolAction(
+            action="dispatch",
+            lane_id=lane_id,
+            reason=f"Task packet {packet_id!r} not found",
+            executed=False,
+            error="packet_not_found",
+        )
+
+    if packet.status != "approved":
+        return PoolAction(
+            action="dispatch",
+            lane_id=lane_id,
+            reason=(
+                f"Packet {packet_id!r} is in {packet.status!r} status; "
+                f"expected 'approved'"
+            ),
+            executed=False,
+            error="wrong_status",
+        )
+
+    # 2. Take snapshot and verify capacity
+    pool = take_pool_snapshot(runtime_dir, tmux_session=tmux_session)
+    worker = next((w for w in pool.workers if w.lane_id == lane_id), None)
+
+    if worker is None:
+        return PoolAction(
+            action="dispatch",
+            lane_id=lane_id,
+            reason=f"Lane {lane_id!r} not found in pool snapshot",
+            executed=False,
+            error="lane_not_found",
+        )
+
+    if worker.pool_status == "active":
+        return PoolAction(
+            action="dispatch",
+            lane_id=lane_id,
+            reason=f"Lane {lane_id!r} is already active with a task",
+            executed=False,
+            error="lane_busy",
+        )
+
+    if pool.available_capacity <= 0 and worker.pool_status not in ("idle",):
+        return PoolAction(
+            action="dispatch",
+            lane_id=lane_id,
+            reason="No available capacity in the worker pool",
+            executed=False,
+            error="no_capacity",
+        )
+
+    # 3. Wake if parked/retired
+    if worker.pool_status in ("parked", "retired"):
+        wake_result = wake_worker(
+            lane_id,
+            tmux_session=tmux_session,
+            runtime_dir=runtime_dir,
+        )
+        if not wake_result.executed:
+            return PoolAction(
+                action="dispatch",
+                lane_id=lane_id,
+                reason=f"Failed to wake lane: {wake_result.reason}",
+                executed=False,
+                error=f"wake_failed:{wake_result.error}",
+            )
+
+    # 4. Transition packet to dispatched
+    try:
+        # Update packet owner to lane_id before transitioning
+        # (TaskPacket is frozen, so we re-save with owner set)
+        from dataclasses import asdict as _asdict
+
+        from bid_euchre.ops.task_queue import TaskPacket, save_packet
+
+        pkt_data = _asdict(packet)
+        pkt_data["owner"] = lane_id
+        pkt_data["status"] = "approved"  # keep current status for re-save
+        updated_pkt = TaskPacket(**pkt_data)
+        save_packet(updated_pkt, runtime_dir)
+
+        transition_status(packet_id, "dispatched", runtime_dir)
+    except (ValueError, OSError) as exc:
+        return PoolAction(
+            action="dispatch",
+            lane_id=lane_id,
+            reason=f"Failed to transition packet: {exc}",
+            executed=False,
+            error="transition_failed",
+        )
+
+    # 5. Ensure visibility is foreground
+    from bid_euchre.ops.dashboard import set_lane_visibility
+
+    set_lane_visibility(lane_id, "foreground", runtime_dir)
+
+    return PoolAction(
+        action="dispatch",
+        lane_id=lane_id,
+        reason=f"Dispatched packet {packet_id!r} to {lane_id!r}",
+        executed=True,
+    )
+
+
+def run_pool_maintenance(
+    *,
+    tmux_session: str = DEFAULT_TMUX_SESSION,
+    runtime_dir: Path | None = None,
+    now: datetime | None = None,
+    dry_run: bool = False,
+) -> list[PoolAction]:
+    """Periodic maintenance: park idle workers, retire parked ones.
+
+    Scans all managed lanes and applies lifecycle transitions:
+    - idle > IDLE_PARK_MINUTES -> park
+    - parked > PARKED_RETIRE_MINUTES -> retire
+
+    Args:
+        tmux_session: tmux session name.
+        runtime_dir: Override for the runtime directory root.
+        now: Override current time for testing.
+        dry_run: If True, only propose actions without executing them.
+
+    Returns:
+        List of proposed (dry_run=True) or executed actions.
+    """
+    if runtime_dir is None:
+        runtime_dir = Path(".claude/runtime")
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    pool = take_pool_snapshot(runtime_dir, tmux_session=tmux_session, now=now)
+    actions: list[PoolAction] = []
+
+    for worker in pool.workers:
+        idle_minutes = _minutes_since(worker.last_activity, now)
+
+        if worker.pool_status == "idle" and idle_minutes is not None:
+            if idle_minutes > IDLE_PARK_MINUTES:
+                action = PoolAction(
+                    action="park",
+                    lane_id=worker.lane_id,
+                    reason=(
+                        f"Idle for {idle_minutes:.0f} min "
+                        f"(threshold: {IDLE_PARK_MINUTES} min)"
+                    ),
+                    executed=False,
+                )
+                if not dry_run:
+                    result = park_worker(
+                        worker.lane_id,
+                        tmux_session=tmux_session,
+                        runtime_dir=runtime_dir,
+                    )
+                    action.executed = result.executed
+                    action.error = result.error
+                actions.append(action)
+
+        elif worker.pool_status == "parked" and idle_minutes is not None:
+            if idle_minutes > PARKED_RETIRE_MINUTES:
+                action = PoolAction(
+                    action="retire",
+                    lane_id=worker.lane_id,
+                    reason=(
+                        f"Parked for {idle_minutes:.0f} min "
+                        f"(threshold: {PARKED_RETIRE_MINUTES} min)"
+                    ),
+                    executed=False,
+                )
+                if not dry_run:
+                    result = retire_worker(
+                        worker.lane_id,
+                        tmux_session=tmux_session,
+                        runtime_dir=runtime_dir,
+                    )
+                    action.executed = result.executed
+                    action.error = result.error
+                actions.append(action)
+
+    return actions
+
+
+# ---------------------------------------------------------------------------
+# Formatters
+# ---------------------------------------------------------------------------
+
+
+def format_pool_text(pool: PoolSnapshot) -> str:
+    """Format a pool snapshot as human-readable text.
+
+    Args:
+        pool: Pool snapshot to format.
+
+    Returns:
+        Multi-line text summary.
+    """
+    lines: list[str] = []
+    lines.append("=== Worker Pool ===")
+    lines.append(f"Timestamp: {pool.timestamp}")
+    lines.append(
+        f"Active: {pool.active_count}  Idle: {pool.idle_count}  "
+        f"Parked: {pool.parked_count}  Retired: {pool.retired_count}  "
+        f"Capacity: {pool.available_capacity}"
+    )
+    lines.append("")
+
+    if pool.workers:
+        lines.append("Workers:")
+        for w in pool.workers:
+            tmux_str = "tmux:up" if w.tmux_alive else "tmux:down"
+            task_str = f"  task:{w.current_task_id}" if w.current_task_id else ""
+            lines.append(
+                f"  {w.lane_id:15s} [{w.pool_status:8s}] "
+                f"health:{w.health:8s} vis:{w.visibility:10s} "
+                f"{tmux_str}{task_str}"
+            )
+    else:
+        lines.append("  (no managed workers found)")
+
+    return "\n".join(lines)
+
+
+def format_pool_json(pool: PoolSnapshot) -> dict[str, Any]:
+    """Format a pool snapshot as a JSON-serializable dict.
+
+    Args:
+        pool: Pool snapshot to format.
+
+    Returns:
+        Dict suitable for JSON serialization.
+    """
+    return {
+        "timestamp": pool.timestamp,
+        "summary": {
+            "active": pool.active_count,
+            "idle": pool.idle_count,
+            "parked": pool.parked_count,
+            "retired": pool.retired_count,
+            "available_capacity": pool.available_capacity,
+        },
+        "workers": [asdict(w) for w in pool.workers],
+    }
+
+
+def format_action_text(action: PoolAction) -> str:
+    """Format a single pool action as human-readable text."""
+    status = "OK" if action.executed else "SKIPPED"
+    error_str = f" (error: {action.error})" if action.error else ""
+    return f"[{status}] {action.action} {action.lane_id}: {action.reason}{error_str}"
+
+
+def format_actions_json(actions: list[PoolAction]) -> list[dict[str, Any]]:
+    """Format pool actions as JSON-serializable list."""
+    return [asdict(a) for a in actions]

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -1,0 +1,1063 @@
+"""Tests for ops worker pool lifecycle management (Platform-7)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bid_euchre.ops.worker_pool import (
+    DEFAULT_TMUX_SESSION,
+    IDLE_PARK_MINUTES,
+    MAX_ACTIVE_AUTHORS,
+    PARKED_RETIRE_MINUTES,
+    POOL_STATUSES,
+    PoolAction,
+    PoolSnapshot,
+    WorkerState,
+    _classify_pool_status,
+    _managed_lanes,
+    _minutes_since,
+    _probe_tmux_pane,
+    _resolve_agent_name,
+    dispatch_to_worker,
+    format_action_text,
+    format_actions_json,
+    format_pool_json,
+    format_pool_text,
+    park_worker,
+    retire_worker,
+    run_pool_maintenance,
+    select_worker,
+    take_pool_snapshot,
+    wake_worker,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def runtime_dir(tmp_path: Path) -> Path:
+    """Create a temp runtime directory with standard subdirs."""
+    rd = tmp_path / "runtime"
+    (rd / "worktree_registry").mkdir(parents=True)
+    (rd / "session_metadata").mkdir(parents=True)
+    (rd / "task_state").mkdir(parents=True)
+    (rd / "events").mkdir(parents=True)
+    (rd / "task_queue").mkdir(parents=True)
+    return rd
+
+
+def _write_json(directory: Path, filename: str, data: dict) -> None:
+    (directory / filename).write_text(json.dumps(data, indent=2))
+
+
+def _make_worker(
+    lane_id: str = "author-a",
+    pool_status: str = "idle",
+    health: str = "idle",
+    current_task_id: str | None = None,
+    last_activity: str | None = None,
+    visibility: str = "background",
+    tmux_alive: bool = True,
+    session_handle: str | None = None,
+) -> WorkerState:
+    """Create a WorkerState for testing."""
+    return WorkerState(
+        lane_id=lane_id,
+        pool_status=pool_status,
+        health=health,
+        current_task_id=current_task_id,
+        last_activity=last_activity,
+        visibility=visibility,
+        tmux_alive=tmux_alive,
+        session_handle=session_handle,
+    )
+
+
+def _make_pool(
+    workers: list[WorkerState] | None = None,
+    timestamp: str = "2026-03-22T12:00:00+00:00",
+) -> PoolSnapshot:
+    """Create a PoolSnapshot for testing."""
+    if workers is None:
+        workers = []
+    active = sum(1 for w in workers if w.pool_status == "active")
+    idle = sum(1 for w in workers if w.pool_status == "idle")
+    parked = sum(1 for w in workers if w.pool_status == "parked")
+    retired = sum(1 for w in workers if w.pool_status == "retired")
+    return PoolSnapshot(
+        timestamp=timestamp,
+        workers=workers,
+        active_count=active,
+        idle_count=idle,
+        parked_count=parked,
+        retired_count=retired,
+        available_capacity=max(0, MAX_ACTIVE_AUTHORS - active),
+    )
+
+
+# Patch targets: since the functions use deferred imports (``from X import Y``
+# inside the function body), we must patch at the *source* module path so that
+# the fresh import picks up the mock.
+_DASHBOARD = "bid_euchre.ops.dashboard"
+_STATUS = "bid_euchre.ops.status"
+_SUPERVISOR = "bid_euchre.ops.supervisor"
+_TASK_QUEUE = "bid_euchre.ops.task_queue"
+_WORKER_POOL = "bid_euchre.ops.worker_pool"
+
+
+# ---------------------------------------------------------------------------
+# Constants and helpers
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    """Test module-level constants."""
+
+    def test_max_active_authors(self) -> None:
+        assert MAX_ACTIVE_AUTHORS == 5
+
+    def test_idle_park_minutes(self) -> None:
+        assert IDLE_PARK_MINUTES == 15
+
+    def test_parked_retire_minutes(self) -> None:
+        assert PARKED_RETIRE_MINUTES == 60
+
+    def test_default_tmux_session(self) -> None:
+        assert DEFAULT_TMUX_SESSION == "steward"
+
+    def test_pool_statuses(self) -> None:
+        assert POOL_STATUSES == {"active", "idle", "parked", "retired"}
+
+    def test_managed_lanes(self) -> None:
+        lanes = _managed_lanes()
+        assert "author-a" in lanes
+        assert "author-b" in lanes
+        assert "author-scratch" in lanes
+        assert len(lanes) == 5
+
+
+class TestResolveAgentName:
+    """Test _resolve_agent_name()."""
+
+    def test_author_a(self) -> None:
+        assert _resolve_agent_name("author-a") == "steward-author-a"
+
+    def test_author_scratch(self) -> None:
+        assert _resolve_agent_name("author-scratch") == "steward-author-scratch"
+
+    def test_author_b(self) -> None:
+        assert _resolve_agent_name("author-b") == "steward-author-b"
+
+
+class TestMinutesSince:
+    """Test _minutes_since()."""
+
+    def test_none_timestamp(self) -> None:
+        now = datetime.now(timezone.utc)
+        assert _minutes_since(None, now) is None
+
+    def test_empty_string(self) -> None:
+        now = datetime.now(timezone.utc)
+        assert _minutes_since("", now) is None
+
+    def test_valid_timestamp(self) -> None:
+        now = datetime(2026, 3, 22, 12, 30, 0, tzinfo=timezone.utc)
+        ts = "2026-03-22T12:00:00+00:00"
+        result = _minutes_since(ts, now)
+        assert result is not None
+        assert abs(result - 30.0) < 0.01
+
+    def test_z_suffix(self) -> None:
+        now = datetime(2026, 3, 22, 12, 15, 0, tzinfo=timezone.utc)
+        ts = "2026-03-22T12:00:00Z"
+        result = _minutes_since(ts, now)
+        assert result is not None
+        assert abs(result - 15.0) < 0.01
+
+    def test_invalid_timestamp(self) -> None:
+        now = datetime.now(timezone.utc)
+        assert _minutes_since("not-a-date", now) is None
+
+
+class TestClassifyPoolStatus:
+    """Test _classify_pool_status()."""
+
+    def test_hidden_tmux_alive_is_parked(self) -> None:
+        lane = MagicMock(state="idle")
+        assert _classify_pool_status(lane, "idle", False, True, "hidden") == "parked"
+
+    def test_hidden_tmux_dead_is_retired(self) -> None:
+        lane = MagicMock(state="idle")
+        assert _classify_pool_status(lane, "idle", False, False, "hidden") == "retired"
+
+    def test_active_task_is_active(self) -> None:
+        lane = MagicMock(state="idle")
+        assert (
+            _classify_pool_status(lane, "healthy", True, True, "foreground") == "active"
+        )
+
+    def test_active_state_is_active(self) -> None:
+        lane = MagicMock(state="active")
+        assert (
+            _classify_pool_status(lane, "healthy", False, True, "foreground")
+            == "active"
+        )
+
+    def test_likely_active_is_active(self) -> None:
+        lane = MagicMock(state="likely_active")
+        assert (
+            _classify_pool_status(lane, "healthy", False, True, "background")
+            == "active"
+        )
+
+    def test_no_task_background_is_idle(self) -> None:
+        lane = MagicMock(state="idle")
+        assert _classify_pool_status(lane, "idle", False, True, "background") == "idle"
+
+
+# ---------------------------------------------------------------------------
+# Probe tmux pane
+# ---------------------------------------------------------------------------
+
+
+class TestProbeTmuxPane:
+    """Test _probe_tmux_pane() with mocked subprocess."""
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_window_found(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="dashboard\nauthor-a\nauthor-b\n"
+        )
+        assert _probe_tmux_pane("author-a", "steward") is True
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_window_not_found(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(returncode=0, stdout="dashboard\nauthor-b\n")
+        assert _probe_tmux_pane("author-a", "steward") is False
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_tmux_not_available(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = FileNotFoundError("tmux not found")
+        assert _probe_tmux_pane("author-a", "steward") is False
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_tmux_error(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        assert _probe_tmux_pane("author-a", "steward") is False
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_tmux_timeout(self, mock_run: MagicMock) -> None:
+        import subprocess
+
+        mock_run.side_effect = subprocess.TimeoutExpired("tmux", 5)
+        assert _probe_tmux_pane("author-a", "steward") is False
+
+
+# ---------------------------------------------------------------------------
+# Select worker
+# ---------------------------------------------------------------------------
+
+
+class TestSelectWorker:
+    """Test select_worker() priority logic."""
+
+    def test_preferred_lane_idle(self) -> None:
+        pool = _make_pool(
+            [
+                _make_worker("author-a", "idle"),
+                _make_worker("author-b", "idle"),
+            ]
+        )
+        assert select_worker(pool, preferred_lane="author-b") == "author-b"
+
+    def test_preferred_lane_parked(self) -> None:
+        pool = _make_pool(
+            [
+                _make_worker("author-a", "idle"),
+                _make_worker("author-b", "parked"),
+            ]
+        )
+        assert select_worker(pool, preferred_lane="author-b") == "author-b"
+
+    def test_preferred_lane_active_skipped(self) -> None:
+        """If preferred lane is active, fall through to idle."""
+        pool = _make_pool(
+            [
+                _make_worker("author-a", "idle"),
+                _make_worker("author-b", "active", current_task_id="t1"),
+            ]
+        )
+        assert select_worker(pool, preferred_lane="author-b") == "author-a"
+
+    def test_idle_before_parked(self) -> None:
+        pool = _make_pool(
+            [
+                _make_worker("author-a", "parked"),
+                _make_worker("author-b", "idle"),
+            ]
+        )
+        assert select_worker(pool) == "author-b"
+
+    def test_parked_before_retired(self) -> None:
+        pool = _make_pool(
+            [
+                _make_worker("author-a", "retired"),
+                _make_worker("author-b", "parked"),
+            ]
+        )
+        assert select_worker(pool) == "author-b"
+
+    def test_retired_selected_as_last_resort(self) -> None:
+        pool = _make_pool(
+            [
+                _make_worker("author-a", "retired"),
+            ]
+        )
+        assert select_worker(pool) == "author-a"
+
+    def test_no_capacity(self) -> None:
+        """At MAX_ACTIVE_AUTHORS, returns None."""
+        workers = [
+            _make_worker(f"author-{c}", "active", current_task_id=f"t{i}")
+            for i, c in enumerate(["a", "b", "c", "d", "scratch"])
+        ]
+        pool = _make_pool(workers)
+        assert pool.available_capacity == 0
+        assert select_worker(pool) is None
+
+    def test_critical_health_skipped(self) -> None:
+        pool = _make_pool(
+            [
+                _make_worker("author-a", "idle", health="critical"),
+                _make_worker("author-b", "idle", health="healthy"),
+            ]
+        )
+        assert select_worker(pool) == "author-b"
+
+    def test_all_critical_returns_none(self) -> None:
+        pool = _make_pool(
+            [
+                _make_worker("author-a", "idle", health="critical"),
+            ]
+        )
+        assert select_worker(pool) is None
+
+    def test_empty_pool(self) -> None:
+        pool = _make_pool([])
+        assert select_worker(pool) is None
+
+    def test_preferred_lane_not_in_pool(self) -> None:
+        pool = _make_pool(
+            [
+                _make_worker("author-a", "idle"),
+            ]
+        )
+        assert select_worker(pool, preferred_lane="author-z") == "author-a"
+
+    def test_preferred_retired(self) -> None:
+        pool = _make_pool(
+            [
+                _make_worker("author-a", "idle"),
+                _make_worker("author-b", "retired"),
+            ]
+        )
+        assert select_worker(pool, preferred_lane="author-b") == "author-b"
+
+
+# ---------------------------------------------------------------------------
+# Wake worker
+# ---------------------------------------------------------------------------
+
+
+class TestWakeWorker:
+    """Test wake_worker() with mocked tmux."""
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}._probe_tmux_pane", return_value=True)
+    def test_already_alive(
+        self,
+        mock_probe: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        result = wake_worker("author-a", runtime_dir=runtime_dir)
+        assert result.executed is True
+        assert result.error is None
+        assert "already alive" in result.reason.lower()
+        mock_vis.assert_called_once_with("author-a", "foreground", runtime_dir)
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}._create_tmux_window", return_value=True)
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path", return_value="/tmp/wt")
+    @patch(f"{_WORKER_POOL}._probe_tmux_pane", return_value=False)
+    def test_create_window(
+        self,
+        mock_probe: MagicMock,
+        mock_resolve: MagicMock,
+        mock_create: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        result = wake_worker("author-a", runtime_dir=runtime_dir)
+        assert result.executed is True
+        assert result.error is None
+        mock_create.assert_called_once_with("author-a", "/tmp/wt", DEFAULT_TMUX_SESSION)
+
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path", return_value=None)
+    @patch(f"{_WORKER_POOL}._probe_tmux_pane", return_value=False)
+    def test_no_worktree(
+        self,
+        mock_probe: MagicMock,
+        mock_resolve: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        result = wake_worker("author-a", runtime_dir=runtime_dir)
+        assert result.executed is False
+        assert result.error == "no_worktree"
+
+    @patch(f"{_WORKER_POOL}._create_tmux_window", return_value=False)
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path", return_value="/tmp/wt")
+    @patch(f"{_WORKER_POOL}._probe_tmux_pane", return_value=False)
+    def test_tmux_create_fails(
+        self,
+        mock_probe: MagicMock,
+        mock_resolve: MagicMock,
+        mock_create: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        result = wake_worker("author-a", runtime_dir=runtime_dir)
+        assert result.executed is False
+        assert result.error == "tmux_failed"
+
+    def test_not_managed_lane(self, runtime_dir: Path) -> None:
+        result = wake_worker("orchestrator", runtime_dir=runtime_dir)
+        assert result.executed is False
+        assert result.error == "not_managed"
+
+
+# ---------------------------------------------------------------------------
+# Park worker
+# ---------------------------------------------------------------------------
+
+
+class TestParkWorker:
+    """Test park_worker() with mocked dependencies."""
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}._get_lane_task_id", return_value=None)
+    def test_park_idle_lane(
+        self,
+        mock_task: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        result = park_worker("author-a", runtime_dir=runtime_dir)
+        assert result.executed is True
+        assert result.error is None
+        mock_vis.assert_called_once_with("author-a", "hidden", runtime_dir)
+
+    @patch(f"{_WORKER_POOL}._get_lane_task_id", return_value="pkt123")
+    def test_park_active_lane_blocked(
+        self,
+        mock_task: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        result = park_worker("author-a", runtime_dir=runtime_dir)
+        assert result.executed is False
+        assert result.error == "has_active_task"
+
+    def test_park_not_managed(self, runtime_dir: Path) -> None:
+        result = park_worker("review", runtime_dir=runtime_dir)
+        assert result.executed is False
+        assert result.error == "not_managed"
+
+
+# ---------------------------------------------------------------------------
+# Retire worker
+# ---------------------------------------------------------------------------
+
+
+class TestRetireWorker:
+    """Test retire_worker() with mocked dependencies."""
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    @patch(f"{_WORKER_POOL}._probe_tmux_pane", return_value=True)
+    @patch(f"{_WORKER_POOL}._get_lane_task_id", return_value=None)
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    def test_retire_parked_lane(
+        self,
+        mock_vis: MagicMock,
+        mock_task: MagicMock,
+        mock_probe: MagicMock,
+        mock_subprocess: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        mock_subprocess.return_value = MagicMock(returncode=0)
+        result = retire_worker("author-a", runtime_dir=runtime_dir)
+        assert result.executed is True
+        mock_vis.assert_called_once_with("author-a", "hidden", runtime_dir)
+
+    @patch(f"{_WORKER_POOL}._probe_tmux_pane", return_value=False)
+    @patch(f"{_WORKER_POOL}._get_lane_task_id", return_value=None)
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    def test_retire_already_dead(
+        self,
+        mock_vis: MagicMock,
+        mock_task: MagicMock,
+        mock_probe: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        result = retire_worker("author-a", runtime_dir=runtime_dir)
+        assert result.executed is True
+        # No subprocess calls needed when pane is already dead
+
+    @patch(f"{_WORKER_POOL}._get_lane_task_id", return_value="pkt456")
+    def test_retire_active_lane_blocked(
+        self,
+        mock_task: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        result = retire_worker("author-a", runtime_dir=runtime_dir)
+        assert result.executed is False
+        assert result.error == "has_active_task"
+
+    def test_retire_not_managed(self, runtime_dir: Path) -> None:
+        result = retire_worker("ops", runtime_dir=runtime_dir)
+        assert result.executed is False
+        assert result.error == "not_managed"
+
+
+# ---------------------------------------------------------------------------
+# Take pool snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestTakePoolSnapshot:
+    """Test take_pool_snapshot() with mocked dependencies."""
+
+    @patch(f"{_WORKER_POOL}._get_lane_task_id", return_value=None)
+    @patch(f"{_WORKER_POOL}._probe_tmux_pane", return_value=False)
+    @patch(f"{_SUPERVISOR}.take_snapshot")
+    @patch(f"{_STATUS}.aggregate_status")
+    @patch(f"{_DASHBOARD}.effective_visibility")
+    def test_empty_registry(
+        self,
+        mock_vis: MagicMock,
+        mock_status: MagicMock,
+        mock_sup: MagicMock,
+        mock_probe: MagicMock,
+        mock_task: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        from bid_euchre.ops.status import StatusReport
+
+        mock_status.return_value = StatusReport()
+        mock_sup.return_value = MagicMock(lane_assessments=[])
+
+        now = datetime(2026, 3, 22, 12, 0, 0, tzinfo=timezone.utc)
+        pool = take_pool_snapshot(runtime_dir, now=now)
+
+        assert pool.timestamp == now.isoformat()
+        assert len(pool.workers) == 0
+        assert pool.available_capacity == MAX_ACTIVE_AUTHORS
+
+    @patch(f"{_WORKER_POOL}._get_lane_task_id")
+    @patch(f"{_WORKER_POOL}._probe_tmux_pane")
+    @patch(f"{_SUPERVISOR}.take_snapshot")
+    @patch(f"{_STATUS}.aggregate_status")
+    @patch(f"{_DASHBOARD}.effective_visibility")
+    def test_mixed_lanes(
+        self,
+        mock_vis: MagicMock,
+        mock_status: MagicMock,
+        mock_sup: MagicMock,
+        mock_probe: MagicMock,
+        mock_task: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        from bid_euchre.ops.status import LaneStatus, StatusReport
+        from bid_euchre.ops.supervisor import LaneHealthAssessment
+
+        # Create lanes: author-a (active), author-b (idle), orchestrator (filtered out)
+        lanes = [
+            LaneStatus(
+                lane_id="author-a",
+                lane_class="author",
+                worktree_path="/tmp/author-a",
+                branch="main",
+                lifecycle_class="persistent",
+                has_active_session=True,
+                state="active",
+                last_progress="2026-03-22T12:00:00Z",
+            ),
+            LaneStatus(
+                lane_id="author-b",
+                lane_class="author",
+                worktree_path="/tmp/author-b",
+                branch="main",
+                lifecycle_class="persistent",
+                has_active_session=False,
+                state="idle",
+            ),
+            LaneStatus(
+                lane_id="orchestrator",
+                lane_class="orchestrator",
+                worktree_path="/tmp/orch",
+                branch="main",
+                lifecycle_class="persistent",
+                has_active_session=True,
+                state="active",
+            ),
+        ]
+        mock_status.return_value = StatusReport(lanes=lanes)
+        mock_sup.return_value = MagicMock(
+            lane_assessments=[
+                LaneHealthAssessment(
+                    lane_id="author-a", health="healthy", state="active"
+                ),
+                LaneHealthAssessment(lane_id="author-b", health="idle", state="idle"),
+            ]
+        )
+        mock_vis.side_effect = (
+            lambda lane: "foreground" if lane.lane_id == "author-a" else "background"
+        )
+        mock_probe.side_effect = lambda lid, _: lid == "author-a"
+        mock_task.side_effect = (
+            lambda lid, rd=None: "pkt1" if lid == "author-a" else None
+        )
+
+        now = datetime(2026, 3, 22, 12, 0, 0, tzinfo=timezone.utc)
+        pool = take_pool_snapshot(runtime_dir, now=now)
+
+        # Only managed lanes (author-a, author-b), not orchestrator
+        assert len(pool.workers) == 2
+        lane_ids = {w.lane_id for w in pool.workers}
+        assert lane_ids == {"author-a", "author-b"}
+
+        author_a = next(w for w in pool.workers if w.lane_id == "author-a")
+        assert author_a.pool_status == "active"
+        assert author_a.health == "healthy"
+        assert author_a.tmux_alive is True
+        assert author_a.current_task_id == "pkt1"
+
+        author_b = next(w for w in pool.workers if w.lane_id == "author-b")
+        assert author_b.pool_status == "idle"
+
+        assert pool.active_count == 1
+        assert pool.idle_count == 1
+        assert pool.available_capacity == MAX_ACTIVE_AUTHORS - 1
+
+    @patch(f"{_WORKER_POOL}._get_lane_task_id", return_value=None)
+    @patch(f"{_WORKER_POOL}._probe_tmux_pane", return_value=False)
+    @patch(f"{_SUPERVISOR}.take_snapshot")
+    @patch(f"{_STATUS}.aggregate_status")
+    @patch(f"{_DASHBOARD}.effective_visibility")
+    def test_supervisor_failure_degrades_gracefully(
+        self,
+        mock_vis: MagicMock,
+        mock_status: MagicMock,
+        mock_sup: MagicMock,
+        mock_probe: MagicMock,
+        mock_task: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        from bid_euchre.ops.status import LaneStatus, StatusReport
+
+        lanes = [
+            LaneStatus(
+                lane_id="author-a",
+                lane_class="author",
+                worktree_path="/tmp/author-a",
+                branch="main",
+                lifecycle_class="persistent",
+                has_active_session=False,
+                state="idle",
+            ),
+        ]
+        mock_status.return_value = StatusReport(lanes=lanes)
+        mock_sup.side_effect = RuntimeError("watchdog failed")
+        mock_vis.return_value = "background"
+
+        now = datetime(2026, 3, 22, 12, 0, 0, tzinfo=timezone.utc)
+        pool = take_pool_snapshot(runtime_dir, now=now)
+
+        assert len(pool.workers) == 1
+        # Health defaults to "idle" when supervisor fails
+        assert pool.workers[0].health == "idle"
+
+
+# ---------------------------------------------------------------------------
+# Dispatch to worker
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchToWorker:
+    """Test dispatch_to_worker() end-to-end with mocked deps."""
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.transition_status")
+    @patch(f"{_TASK_QUEUE}.save_packet")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_to_idle_lane(
+        self,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_transition: MagicMock,
+        mock_snapshot: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test",
+            description="Test task",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool(
+            [
+                _make_worker("author-a", "idle"),
+            ]
+        )
+
+        result = dispatch_to_worker("pkt1", "author-a", runtime_dir=runtime_dir)
+        assert result.executed is True
+        assert result.error is None
+        assert "pkt1" in result.reason
+
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_packet_not_found(
+        self,
+        mock_load: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        mock_load.return_value = None
+        result = dispatch_to_worker("pkt999", "author-a", runtime_dir=runtime_dir)
+        assert result.executed is False
+        assert result.error == "packet_not_found"
+
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_wrong_status(
+        self,
+        mock_load: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test",
+            description="Test",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="pending",
+        )
+        result = dispatch_to_worker("pkt1", "author-a", runtime_dir=runtime_dir)
+        assert result.executed is False
+        assert result.error == "wrong_status"
+
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_lane_not_found(
+        self,
+        mock_load: MagicMock,
+        mock_snapshot: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test",
+            description="Test",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        # Empty pool -- lane_id won't be found
+        mock_snapshot.return_value = _make_pool([])
+
+        result = dispatch_to_worker("pkt1", "author-a", runtime_dir=runtime_dir)
+        assert result.executed is False
+        assert result.error == "lane_not_found"
+
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_lane_busy(
+        self,
+        mock_load: MagicMock,
+        mock_snapshot: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test",
+            description="Test",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool(
+            [
+                _make_worker("author-a", "active", current_task_id="pkt0"),
+            ]
+        )
+
+        result = dispatch_to_worker("pkt1", "author-a", runtime_dir=runtime_dir)
+        assert result.executed is False
+        assert result.error == "lane_busy"
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}.wake_worker")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.transition_status")
+    @patch(f"{_TASK_QUEUE}.save_packet")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_wakes_parked_lane(
+        self,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_transition: MagicMock,
+        mock_snapshot: MagicMock,
+        mock_wake: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test",
+            description="Test",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool(
+            [
+                _make_worker("author-a", "parked"),
+            ]
+        )
+        mock_wake.return_value = PoolAction(
+            action="wake",
+            lane_id="author-a",
+            reason="woke",
+            executed=True,
+        )
+
+        result = dispatch_to_worker("pkt1", "author-a", runtime_dir=runtime_dir)
+        assert result.executed is True
+        mock_wake.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Run pool maintenance
+# ---------------------------------------------------------------------------
+
+
+class TestRunPoolMaintenance:
+    """Test run_pool_maintenance() with mocked deps."""
+
+    @patch(f"{_WORKER_POOL}.retire_worker")
+    @patch(f"{_WORKER_POOL}.park_worker")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    def test_park_idle_worker(
+        self,
+        mock_snapshot: MagicMock,
+        mock_park: MagicMock,
+        mock_retire: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        now = datetime(2026, 3, 22, 12, 30, 0, tzinfo=timezone.utc)
+        # Worker idle for 20 minutes (> IDLE_PARK_MINUTES)
+        last_activity = "2026-03-22T12:10:00+00:00"
+        mock_snapshot.return_value = _make_pool(
+            [
+                _make_worker("author-a", "idle", last_activity=last_activity),
+            ]
+        )
+        mock_park.return_value = PoolAction(
+            action="park",
+            lane_id="author-a",
+            reason="parked",
+            executed=True,
+        )
+
+        actions = run_pool_maintenance(runtime_dir=runtime_dir, now=now)
+        assert len(actions) == 1
+        assert actions[0].action == "park"
+        assert actions[0].lane_id == "author-a"
+        mock_park.assert_called_once()
+
+    @patch(f"{_WORKER_POOL}.retire_worker")
+    @patch(f"{_WORKER_POOL}.park_worker")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    def test_retire_parked_worker(
+        self,
+        mock_snapshot: MagicMock,
+        mock_park: MagicMock,
+        mock_retire: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        now = datetime(2026, 3, 22, 14, 0, 0, tzinfo=timezone.utc)
+        # Worker parked for 90 minutes (> PARKED_RETIRE_MINUTES)
+        last_activity = "2026-03-22T12:30:00+00:00"
+        mock_snapshot.return_value = _make_pool(
+            [
+                _make_worker("author-b", "parked", last_activity=last_activity),
+            ]
+        )
+        mock_retire.return_value = PoolAction(
+            action="retire",
+            lane_id="author-b",
+            reason="retired",
+            executed=True,
+        )
+
+        actions = run_pool_maintenance(runtime_dir=runtime_dir, now=now)
+        assert len(actions) == 1
+        assert actions[0].action == "retire"
+        assert actions[0].lane_id == "author-b"
+        mock_retire.assert_called_once()
+
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    def test_dry_run_no_execution(
+        self,
+        mock_snapshot: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        now = datetime(2026, 3, 22, 12, 30, 0, tzinfo=timezone.utc)
+        last_activity = "2026-03-22T12:10:00+00:00"
+        mock_snapshot.return_value = _make_pool(
+            [
+                _make_worker("author-a", "idle", last_activity=last_activity),
+            ]
+        )
+
+        actions = run_pool_maintenance(runtime_dir=runtime_dir, now=now, dry_run=True)
+        assert len(actions) == 1
+        assert actions[0].action == "park"
+        assert actions[0].executed is False  # dry_run = no execution
+
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    def test_no_actions_needed(
+        self,
+        mock_snapshot: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        now = datetime(2026, 3, 22, 12, 5, 0, tzinfo=timezone.utc)
+        # Only 5 minutes idle (< IDLE_PARK_MINUTES)
+        last_activity = "2026-03-22T12:00:00+00:00"
+        mock_snapshot.return_value = _make_pool(
+            [
+                _make_worker("author-a", "idle", last_activity=last_activity),
+            ]
+        )
+
+        actions = run_pool_maintenance(runtime_dir=runtime_dir, now=now)
+        assert len(actions) == 0
+
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    def test_no_last_activity_skipped(
+        self,
+        mock_snapshot: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        now = datetime(2026, 3, 22, 12, 30, 0, tzinfo=timezone.utc)
+        mock_snapshot.return_value = _make_pool(
+            [
+                _make_worker("author-a", "idle", last_activity=None),
+            ]
+        )
+
+        actions = run_pool_maintenance(runtime_dir=runtime_dir, now=now)
+        assert len(actions) == 0
+
+
+# ---------------------------------------------------------------------------
+# Formatters
+# ---------------------------------------------------------------------------
+
+
+class TestFormatters:
+    """Test text and JSON formatters."""
+
+    def test_format_pool_text(self) -> None:
+        pool = _make_pool(
+            [
+                _make_worker("author-a", "active", health="healthy", tmux_alive=True),
+                _make_worker("author-b", "idle", health="idle", tmux_alive=False),
+            ]
+        )
+        text = format_pool_text(pool)
+        assert "Worker Pool" in text
+        assert "author-a" in text
+        assert "author-b" in text
+        assert "active" in text
+
+    def test_format_pool_text_empty(self) -> None:
+        pool = _make_pool([])
+        text = format_pool_text(pool)
+        assert "no managed workers" in text.lower()
+
+    def test_format_pool_json(self) -> None:
+        pool = _make_pool(
+            [
+                _make_worker("author-a", "idle"),
+            ]
+        )
+        data = format_pool_json(pool)
+        assert data["timestamp"] == pool.timestamp
+        assert data["summary"]["idle"] == 1
+        assert len(data["workers"]) == 1
+        assert data["workers"][0]["lane_id"] == "author-a"
+
+    def test_format_action_text_ok(self) -> None:
+        action = PoolAction(
+            action="park",
+            lane_id="author-a",
+            reason="idle too long",
+            executed=True,
+        )
+        text = format_action_text(action)
+        assert "[OK]" in text
+        assert "author-a" in text
+
+    def test_format_action_text_skipped(self) -> None:
+        action = PoolAction(
+            action="wake",
+            lane_id="author-b",
+            reason="failed",
+            executed=False,
+            error="tmux_failed",
+        )
+        text = format_action_text(action)
+        assert "[SKIPPED]" in text
+        assert "tmux_failed" in text
+
+    def test_format_actions_json(self) -> None:
+        actions = [
+            PoolAction(action="park", lane_id="author-a", reason="r", executed=True),
+        ]
+        data = format_actions_json(actions)
+        assert len(data) == 1
+        assert data[0]["action"] == "park"
+        assert data[0]["executed"] is True


### PR DESCRIPTION
## Plan
- `plans/agent_ops/3_supervision_and_scaling/sub/2026-03-22_platform7-worker-pool-manager.md` (SP-3-02)
- `plans/agent_ops/governing_plan.md` -- Phase 3, Platform-7

## Summary
- New `src/bid_euchre/ops/worker_pool.py` module enabling orchestrator to manage author lane lifecycle
- Core functions: `take_pool_snapshot()`, `select_worker()`, `wake_worker()`, `park_worker()`, `retire_worker()`, `dispatch_to_worker()`, `run_pool_maintenance()`
- CLI `ops.py workers` subcommand with show/wake/park/retire/dispatch/maintain sub-actions
- 69 unit tests covering snapshot building, selection priority, lifecycle actions, maintenance, formatting, and error handling

## Why
Platform-7 is the second and final slice of Phase 3 (Batch D: Supervision and Scaling). It enables the orchestrator to reuse idle author lanes before creating new workers, open/resume author panes on demand when delegating work, and park/retire lanes within repo-owned concurrency limits.

## Repro / Validation
**Command(s) run:**
```bash
# Tier 1 — unit tests
uv run python -m pytest tests/unit/test_ops_worker_pool.py -v  # 69 passed

# Tier 2 — full validation
make check-quiet  # All checks passed

# Manual smoke
uv run python scripts/internal/ops.py workers              # text output
uv run python scripts/internal/ops.py --json workers        # JSON output
uv run python scripts/internal/ops.py --json workers maintain --dry-run  # dry-run maintenance
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_worker_pool.py -v` -- 69 passed
- [x] `make check-quiet` -- All checks passed

## Expected impact
- Metrics impact: none (ops tooling only)
- Runtime impact: none (new module, no changes to existing behavior)

## Risk level
- [x] Low (ops tooling / new module only)

## Scope Lock

| Action | File | Change |
|--------|------|--------|
| CREATE | `src/bid_euchre/ops/worker_pool.py` | Worker pool lifecycle module |
| CREATE | `tests/unit/test_ops_worker_pool.py` | 69 unit tests |
| MODIFY | `src/bid_euchre/ops/__init__.py` | Added `worker_pool` to module docstring |
| MODIFY | `scripts/internal/ops.py` | Added `workers` subcommand |

## Design Decisions (Open Questions Resolved)

1. **Retirement signal**: SIGTERM via `tmux kill-window` after verifying no active task
2. **PoolSnapshot persistence**: Computed on demand (no disk persistence for v1)
3. **Agent startup task discovery**: Via agent profile prompt (existing task queue)
4. **PR scope**: Single PR (all functionality fits cleanly together)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         8e0b935c [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author          f4f8f897 [ops/platform7-worker-pool]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)