### PR TITLE
fix: pass task_queue subdir to task_queue functions in worker_pool.py

### DIFF
--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -298,9 +298,14 @@ def _get_lane_task_id(
     """
     from bid_euchre.ops.task_queue import list_packets
 
+    # task_queue functions expect the task_queue subdirectory, not the
+    # runtime root.  When runtime_dir is provided (e.g. ".claude/runtime"),
+    # derive the correct path; when None, let shared_task_root() default.
+    task_queue_root = (runtime_dir / "task_queue") if runtime_dir else None
+
     # Check dispatched packets owned by this lane
     dispatched = list_packets(
-        runtime_dir, status_filter="dispatched", owner_filter=lane_id
+        task_queue_root, status_filter="dispatched", owner_filter=lane_id
     )
     if dispatched:
         return dispatched[0].packet_id
@@ -666,20 +671,6 @@ def retire_worker(
             subprocess.run(
                 [
                     "tmux",
-                    "send-keys",
-                    "-t",
-                    f"{tmux_session}:{lane_id}",
-                    "",
-                    "",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            # Kill the window
-            subprocess.run(
-                [
-                    "tmux",
                     "kill-window",
                     "-t",
                     f"{tmux_session}:{lane_id}",
@@ -744,8 +735,12 @@ def dispatch_to_worker(
     if runtime_dir is None:
         runtime_dir = Path(".claude/runtime")
 
+    # task_queue functions expect the task_queue subdirectory, not the
+    # runtime root.
+    task_queue_root = runtime_dir / "task_queue"
+
     # 1. Verify packet exists and is approved
-    packet = load_packet(packet_id, runtime_dir)
+    packet = load_packet(packet_id, task_queue_root)
     if packet is None:
         return PoolAction(
             action="dispatch",
@@ -789,6 +784,9 @@ def dispatch_to_worker(
             error="lane_busy",
         )
 
+    # An idle lane is already counted as non-active, so dispatching it does
+    # not consume additional capacity.  Only reject when there is truly no
+    # room (capacity exhausted AND the lane would need to be woken/promoted).
     if pool.available_capacity <= 0 and worker.pool_status not in ("idle",):
         return PoolAction(
             action="dispatch",
@@ -826,9 +824,9 @@ def dispatch_to_worker(
         pkt_data["owner"] = lane_id
         pkt_data["status"] = "approved"  # keep current status for re-save
         updated_pkt = TaskPacket(**pkt_data)
-        save_packet(updated_pkt, runtime_dir)
+        save_packet(updated_pkt, task_queue_root)
 
-        transition_status(packet_id, "dispatched", runtime_dir)
+        transition_status(packet_id, "dispatched", task_queue_root)
     except (ValueError, OSError) as exc:
         return PoolAction(
             action="dispatch",

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -19,6 +19,7 @@ from bid_euchre.ops.worker_pool import (
     PoolSnapshot,
     WorkerState,
     _classify_pool_status,
+    _get_lane_task_id,
     _managed_lanes,
     _minutes_since,
     _probe_tmux_pane,
@@ -220,6 +221,61 @@ class TestClassifyPoolStatus:
     def test_no_task_background_is_idle(self) -> None:
         lane = MagicMock(state="idle")
         assert _classify_pool_status(lane, "idle", False, True, "background") == "idle"
+
+
+# ---------------------------------------------------------------------------
+# _get_lane_task_id — task_queue_root correctness
+# ---------------------------------------------------------------------------
+
+
+class TestGetLaneTaskId:
+    """Test _get_lane_task_id() passes task_queue subdirectory, not runtime_dir."""
+
+    @patch(f"{_TASK_QUEUE}.list_packets", return_value=[])
+    def test_passes_task_queue_subdir(
+        self,
+        mock_list: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """Verify list_packets receives runtime_dir/'task_queue', not runtime_dir."""
+        result = _get_lane_task_id("author-a", runtime_dir)
+        assert result is None
+        mock_list.assert_called_once()
+        actual_root = mock_list.call_args[0][0]
+        assert actual_root == runtime_dir / "task_queue"
+
+    @patch(f"{_TASK_QUEUE}.list_packets", return_value=[])
+    def test_none_runtime_dir_passes_none(
+        self,
+        mock_list: MagicMock,
+    ) -> None:
+        """When runtime_dir is None, pass None so shared_task_root() defaults."""
+        _get_lane_task_id("author-a", None)
+        mock_list.assert_called_once()
+        actual_root = mock_list.call_args[0][0]
+        assert actual_root is None
+
+    @patch(f"{_TASK_QUEUE}.list_packets")
+    def test_returns_packet_id(
+        self,
+        mock_list: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_list.return_value = [
+            TaskPacket(
+                packet_id="pkt42",
+                title="Test",
+                description="d",
+                owner="author-a",
+                created_by="orchestrator",
+                created_at="2026-03-22T12:00:00Z",
+                status="dispatched",
+            )
+        ]
+        result = _get_lane_task_id("author-a", runtime_dir)
+        assert result == "pkt42"
 
 
 # ---------------------------------------------------------------------------
@@ -866,6 +922,53 @@ class TestDispatchToWorker:
         result = dispatch_to_worker("pkt1", "author-a", runtime_dir=runtime_dir)
         assert result.executed is True
         mock_wake.assert_called_once()
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.transition_status")
+    @patch(f"{_TASK_QUEUE}.save_packet")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_uses_task_queue_subdir(
+        self,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_transition: MagicMock,
+        mock_snapshot: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """Verify load_packet/save_packet/transition_status receive task_queue subdir."""
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test",
+            description="Test task",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool(
+            [
+                _make_worker("author-a", "idle"),
+            ]
+        )
+
+        dispatch_to_worker("pkt1", "author-a", runtime_dir=runtime_dir)
+
+        expected_tq = runtime_dir / "task_queue"
+
+        # load_packet should receive task_queue subdir
+        mock_load.assert_called_once_with("pkt1", expected_tq)
+
+        # save_packet should receive task_queue subdir
+        assert mock_save.call_count == 1
+        actual_save_root = mock_save.call_args[0][1]
+        assert actual_save_root == expected_tq
+
+        # transition_status should receive task_queue subdir
+        mock_transition.assert_called_once_with("pkt1", "dispatched", expected_tq)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Plan
Post-merge review finding from PR #1250 (BLOCK-level correctness bugs).

## Summary
- Fix `_get_lane_task_id` to pass `runtime_dir / "task_queue"` (not `runtime_dir`) to `list_packets`
- Fix `dispatch_to_worker` to pass `runtime_dir / "task_queue"` to `load_packet`, `save_packet`, and `transition_status`
- Remove dead `send-keys` no-op in `retire_worker` (sends empty strings, does nothing)
- Add clarifying comment on capacity check logic in `dispatch_to_worker`

## Why
`_get_lane_task_id` and `dispatch_to_worker` were passing the runtime root directory directly to task_queue functions, but those functions expect the `runtime_dir / "task_queue"` subdirectory. This made the active-task safety guard in `park_worker` and `retire_worker` ineffective (always returned None) and dispatch unable to find/transition packets.

Reference: `cmd_task` in `ops.py` correctly does `task_queue_root = args.runtime_dir / "task_queue"` at line ~1404.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_worker_pool.py tests/unit/test_ops_cli.py -v
make check-quiet
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_worker_pool.py` — 73 passed
- [x] `uv run python -m pytest tests/unit/test_ops_cli.py` — 102 passed
- [x] `make check-quiet` — all checks passed
- [x] New: `TestGetLaneTaskId` (3 tests) — verifies correct task_queue subdir passed
- [x] New: `test_dispatch_uses_task_queue_subdir` — verifies load/save/transition receive task_queue subdir

## Expected impact
- Metrics impact: None
- Runtime impact: None (path fix only)

## Risk level
- [ ] Low (docs/tests only)
- [x] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         e9b3c8a1 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author          cad90e6a [docs/amendment-a5-platform8-preflight]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b        a9362fa4 [author-b/phase3-plan-and-review-fixes]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c        9274c38e [docs/platform7-sub-plan]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d        51b8c4a9 [fix/worker-pool-task-queue-root]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-scratch  8e0b935c [codex/steward-author-scratch]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-ops             8e0b935c [codex/steward-ops]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-review          ee8e3c88 (detached HEAD)
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)