### PR TITLE
docs: add Phase 3 QA log with Batch D proving run findings

### DIFF
--- a/plans/agent_ops/3_supervision_and_scaling/qa_log.md
+++ b/plans/agent_ops/3_supervision_and_scaling/qa_log.md
@@ -1,0 +1,12 @@
+# Phase 3 QA Log
+
+**Phase:** 3_supervision_and_scaling
+**Last updated:** 2026-03-22
+
+## Findings
+
+| ID | Severity | Source | Status | Description |
+|----|----------|--------|--------|-------------|
+| BD-001 | WARN | Batch D proving run | open | `_classify_pool_status()` in worker_pool.py:279 treats `likely_active` + no-task as "active", blocking dispatch to idle lanes. Should return "idle" when has_task=False. |
+| BD-002 | WARN | Batch D proving run | open | Dashboard `active_tasks` and `current_task_id` read from `task_state/` directory, not `task_queue/` (orchestrator packets). Dispatched task packets don't appear in dashboard lane status. |
+| BD-003 | INFO | Batch D proving run | open | `workers dispatch` CLI requires packet in "approved" status but no CLI subcommand exists for approval. Workaround: call `transition_status()` Python API directly. |


### PR DESCRIPTION
## Plan
plans/agent_ops/governing_plan.md — Batch D proving run

## Summary
- Create `plans/agent_ops/3_supervision_and_scaling/qa_log.md` with initial Batch D proving run findings
- Three findings recorded: BD-001 (pool status classification), BD-002 (dashboard task source), BD-003 (missing approval CLI)

## Why
The Batch D proving run surfaced operational findings that need tracking. This QA log provides a durable record for follow-up fixes.

## Repro / Validation
**Command(s) run:**
- `test -f plans/agent_ops/3_supervision_and_scaling/qa_log.md` (PASS)
- `make check-quiet` (PASS)

**Config (if applicable):**
- N/A

**Seed (if applicable):**
- N/A

## Tests
- [x] Other: `make check-quiet` — all checks passed

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         80af6f1f [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author          34dbe6c6 [chore/regen-dashboard-20260322]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b        f586812b [docs/batch-d-proving-run-checkpoint]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c        bc8d889f [docs/batch-d-qa-log]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d        51b8c4a9 [fix/worker-pool-task-queue-root]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-scratch  8e0b935c [codex/steward-author-scratch]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-ops             8e0b935c [codex/steward-ops]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-review          ee8e3c88 (detached HEAD)
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)