### PR TITLE
docs: update Phase 3 checkpoints and QA log for Batch D completion

### DIFF
--- a/plans/agent_ops/3_supervision_and_scaling/checkpoints.md
+++ b/plans/agent_ops/3_supervision_and_scaling/checkpoints.md
@@ -2,7 +2,7 @@
 
 **Governing plan:** `plans/agent_ops/governing_plan.md`
 **Phase/Rung:** `3_supervision_and_scaling`
-**Last updated:** 2026-03-22 by author-b (Batch D proving run IN_PROGRESS)
+**Last updated:** 2026-03-22 by orchestrator (Batch D COMPLETE, Step 5 blocked on BD-004)
 
 ---
 
@@ -14,8 +14,8 @@
 | Step 1: Platform-6 implementation | COMPLETE | 2026-03-22 | author-b | PR #1242 merged. Delta summaries, escalation/recovery recommendations, attention routing. |
 | Step 2: Platform-7 scope lock and sub-plan | COMPLETE | 2026-03-22 | author-c | SP-3-02 created and plan-reviewed. Worker-pool manager: idle reuse, bounded dynamic author creation, parking/retirement. |
 | Step 3: Platform-7 implementation | COMPLETE | 2026-03-22 | author-d | worker_pool.py module, CLI subcommand, 69 tests. PR #1250 + fix PR #1252. |
-| Step 4: Batch D pass gate verification | IN_PROGRESS | 2026-03-22 | orchestrator (Batch D proving run) | Verify: ops delta summaries reliable, worker reuse works in multi-lane proving run, stale/blocked lane handling auditable. |
-| Step 5: Phase 3 handoff | PENDING | -- | -- | Update governing plan, prepare Phase 4/5 entry. |
+| Step 4: Batch D pass gate verification | COMPLETE | 2026-03-22 | orchestrator (Batch D proving run) | Batch D pass gate PASSED. All 3 criteria met. PRs #1256, #1257, #1258. 5 findings (BD-001--BD-005). Phase 3 exit blocked on BD-004 (#1259). |
+| Step 5: Phase 3 handoff | PENDING | -- | -- | Update governing plan, prepare Phase 4/5 entry. Blocked on BD-004 (end-to-end pane delivery, #1259). |
 
 **Status values:** `PENDING`, `IN_PROGRESS`, `COMPLETE`, `BLOCKED`, `SKIPPED`
 
@@ -27,7 +27,7 @@
 
 ## Blockers
 
-None currently.
+- **BD-004** (#1259): End-to-end tmux pane delivery not proven. Phase 3 exit gate.
 
 ## Session Log
 
@@ -62,3 +62,16 @@ None currently.
   `task_queue/`, so orchestrator task packets do not appear in dashboard
   lane status.
 - Next: dispatch fix tasks to author lanes, then re-verify pass gate criteria.
+
+### 2026-03-22 -- orchestrator (Batch D proving run completion)
+- Step 4 → COMPLETE. Batch D pass gate PASSED (all 3 criteria satisfied).
+- 3 tasks dispatched and completed: #1256 (dashboard regen, author-a),
+  #1257 (checkpoints update, author-b), #1258 (QA log, author-c).
+- 5 findings recorded: BD-001 (pool_status classifier), BD-002 (dashboard
+  task_queue disconnect), BD-003 (no CLI approve), BD-004 (pane delivery
+  gap, #1259), BD-005 (no completion callback).
+- Post-merge review of #1256/#1257/#1258: all PASSED. Two WARN findings
+  on #1258: BD-002 field name inaccuracy and BD-003 missing from checkpoints.
+- Phase 3 exit gate: BD-004 — end-to-end tmux pane delivery must be proven
+  before Step 5 can complete.
+- Fix PR dispatched for BD-001 + BD-002 (author-a).

--- a/plans/agent_ops/3_supervision_and_scaling/qa_log.md
+++ b/plans/agent_ops/3_supervision_and_scaling/qa_log.md
@@ -5,8 +5,10 @@
 
 ## Findings
 
-| ID | Severity | Source | Status | Description |
-|----|----------|--------|--------|-------------|
-| BD-001 | WARN | Batch D proving run | open | `_classify_pool_status()` in worker_pool.py:279 treats `likely_active` + no-task as "active", blocking dispatch to idle lanes. Should return "idle" when has_task=False. |
-| BD-002 | WARN | Batch D proving run | open | Dashboard `active_tasks` and `current_task_id` read from `task_state/` directory, not `task_queue/` (orchestrator packets). Dispatched task packets don't appear in dashboard lane status. |
-| BD-003 | INFO | Batch D proving run | open | `workers dispatch` CLI requires packet in "approved" status but no CLI subcommand exists for approval. Workaround: call `transition_status()` Python API directly. |
+| ID | Severity | Source | Status | Description | Fix PR |
+|----|----------|--------|--------|-------------|--------|
+| BD-001 | WARN | Batch D proving run | open | `_classify_pool_status()` in worker_pool.py:279 treats `likely_active` + no-task as "active", blocking dispatch to idle lanes. Should return "idle" when has_task=False. | -- |
+| BD-002 | WARN | Batch D proving run | open | Dashboard `active_tasks` count (via `status.py` `load_tasks()`) reads from `task_state/` directory, not `task_queue/`. Per-lane `current_task_id` is a `WorkerState` field in the workers CLI, not a dashboard field. | -- |
+| BD-003 | INFO | Batch D proving run | open | `workers dispatch` CLI requires packet in "approved" status but no CLI subcommand exists for approval. Workaround: call `transition_status()` Python API directly. | -- |
+| BD-004 | WARN | Batch D proving run | open | Dispatch flow does not deliver tasks into live tmux pane sessions end-to-end. Execution via Agent subprocesses, not pane message delivery. Phase 3 exit gate. Tracked as #1259. | -- |
+| BD-005 | INFO | Batch D proving run | open | Task packets don't auto-transition to `completed` when executing agent finishes. No completion callback from agent to task queue. | -- |


### PR DESCRIPTION
## Plan
`plans/agent_ops/governing_plan.md` — Phase 3, Step 4 (Batch D pass gate verification)

## Summary
- Mark Step 4 (Batch D pass gate verification) as COMPLETE in Phase 3 checkpoints
- Fix BD-002 description in QA log to accurately describe `active_tasks` sourcing
- Add BD-004 (pane delivery gap, #1259) and BD-005 (no completion callback) to QA log
- Add Fix PR column to findings table for resolution tracking
- Record BD-004 as Phase 3 exit blocker in both checkpoints and blockers section

## Why
The orchestrator completed the Batch D proving run and all 3 pass gate criteria are satisfied. This PR records the completion state, all 5 findings, and the remaining Phase 3 exit blocker (BD-004) so the next session can resume from checkpoints.

## Repro / Validation
**Command(s) run:**
- `grep -q COMPLETE plans/agent_ops/3_supervision_and_scaling/checkpoints.md` (PASS)
- `make check-quiet` (all checks passed)

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] Other: `make check-quiet` — all checks passed (docs-only PR)

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         b0bcf872 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author          b0bcf872 [fix/batch-d-dispatch-bugs]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b        66ab1830 [docs/batch-d-completion-update]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c        bc8d889f [docs/batch-d-qa-log]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d        51b8c4a9 [fix/worker-pool-task-queue-root]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-scratch  8e0b935c [codex/steward-author-scratch]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-ops             8e0b935c [codex/steward-ops]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-review          ee8e3c88 (detached HEAD)
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)