### PR TITLE
fix: pool_status classifier and dashboard task_queue wiring (BD-001/BD-002/BD-003)

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -34,6 +34,7 @@ Usage:
     uv run python scripts/internal/ops.py repairs [--json]
     uv run python scripts/internal/ops.py task list [--status STATUS] [--owner LANE] [--json]
     uv run python scripts/internal/ops.py task show PACKET_ID [--json]
+    uv run python scripts/internal/ops.py task approve PACKET_ID [--json]
     uv run python scripts/internal/ops.py inbox [--lane LANE] [--status STATUS] [--type TYPE] [--thread THREAD] [--json]
     uv run python scripts/internal/ops.py inbox stats [--json]
     uv run python scripts/internal/ops.py message show MSG_ID [--json]
@@ -1405,6 +1406,7 @@ def cmd_task(args: argparse.Namespace) -> int:
         load_packet,
         load_result,
         save_packet,
+        transition_status,
     )
 
     task_queue_root = args.runtime_dir / "task_queue"
@@ -1511,8 +1513,22 @@ def cmd_task(args: argparse.Namespace) -> int:
                 print(f"  Validation: {', '.join(pkt.validation)}")
         return 0
 
+    elif action == "approve":
+        updated = transition_status(args.packet_id, "approved", task_queue_root)
+        if updated is None:
+            print(f"Packet {args.packet_id!r} not found.", file=sys.stderr)
+            return 1
+        if args.json:
+            from dataclasses import asdict
+
+            print(json.dumps(asdict(updated), indent=2, default=str))
+        else:
+            print(f"Approved: {updated.packet_id}")
+            print(f"  Status: {updated.status}")
+        return 0
+
     else:
-        print("Usage: ops.py task {list|show|create}", file=sys.stderr)
+        print("Usage: ops.py task {list|show|create|approve}", file=sys.stderr)
         return 1
 
 
@@ -2219,6 +2235,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Validation command (repeatable)",
     )
+
+    task_approve_parser = task_sub.add_parser(
+        "approve", help="Transition a task packet to 'approved' status"
+    )
+    task_approve_parser.add_argument("packet_id", help="The packet ID to approve")
 
     # inbox (Platform-3 message bus)
     inbox_parser = subparsers.add_parser(

--- a/src/bid_euchre/ops/status.py
+++ b/src/bid_euchre/ops/status.py
@@ -949,6 +949,29 @@ def aggregate_status(
         if status != "completed":
             tasks_by_lane.setdefault(owner, []).append(task)
 
+    # Also include dispatched task packets from the orchestrator task queue.
+    # These are the durable packets created by Platform-2 intake — they may
+    # not yet have a corresponding task_state entry.
+    try:
+        from bid_euchre.ops.task_queue import list_packets
+
+        dispatched = list_packets(
+            runtime_dir / "task_queue", status_filter="dispatched"
+        )
+        for pkt in dispatched:
+            if pkt.owner:
+                tasks_by_lane.setdefault(pkt.owner, []).append(
+                    {
+                        "task_id": pkt.packet_id,
+                        "subject": pkt.title,
+                        "status": "in_progress",
+                        "owner_lane": pkt.owner,
+                        "schema_version": 2,
+                    }
+                )
+    except Exception:
+        logger.debug("Could not load task_queue packets", exc_info=True)
+
     # Synthesize lane activity from all data sources
     report.lanes = synthesize_lane_activity(
         lanes_data,

--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -275,9 +275,13 @@ def _classify_pool_status(
             return "parked"
         return "retired"
 
-    # Active task or active/likely_active state -> active
-    if has_task or lane.state in ("active", "likely_active"):
+    # Active task -> lane is busy
+    if has_task:
         return "active"
+
+    # Lane shows signs of life but has no task -> idle (dispatchable)
+    if lane.state in ("active", "likely_active"):
+        return "idle"
 
     # Otherwise idle
     return "idle"

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -204,18 +204,32 @@ class TestClassifyPoolStatus:
             _classify_pool_status(lane, "healthy", True, True, "foreground") == "active"
         )
 
-    def test_active_state_is_active(self) -> None:
+    def test_active_state_no_task_is_idle(self) -> None:
+        """BD-001: active state without a task should be idle (dispatchable)."""
         lane = MagicMock(state="active")
         assert (
-            _classify_pool_status(lane, "healthy", False, True, "foreground")
-            == "active"
+            _classify_pool_status(lane, "healthy", False, True, "foreground") == "idle"
         )
 
-    def test_likely_active_is_active(self) -> None:
+    def test_likely_active_no_task_is_idle(self) -> None:
+        """BD-001: likely_active state without a task should be idle (dispatchable)."""
         lane = MagicMock(state="likely_active")
         assert (
-            _classify_pool_status(lane, "healthy", False, True, "background")
-            == "active"
+            _classify_pool_status(lane, "healthy", False, True, "background") == "idle"
+        )
+
+    def test_active_state_with_task_is_active(self) -> None:
+        """Active state WITH a task should still be active."""
+        lane = MagicMock(state="active")
+        assert (
+            _classify_pool_status(lane, "healthy", True, True, "foreground") == "active"
+        )
+
+    def test_likely_active_with_task_is_active(self) -> None:
+        """likely_active state WITH a task should still be active."""
+        lane = MagicMock(state="likely_active")
+        assert (
+            _classify_pool_status(lane, "healthy", True, True, "background") == "active"
         )
 
     def test_no_task_background_is_idle(self) -> None:


### PR DESCRIPTION
## Plan
Orchestrator task packet 134d10d3cfc9 — Batch D dispatch bug fixes.

## Summary
- **BD-001:** Fix `_classify_pool_status()` so that lanes with `active`/`likely_active` state but no task are classified as `"idle"` (dispatchable) instead of `"active"` (blocked)
- **BD-002:** Wire dispatched task packets from `task_queue/` into the dashboard report's `tasks_by_lane` lookup in `generate_report()`, so the dashboard reflects orchestrator-dispatched work
- **BD-003:** Add `task approve` subcommand to `ops.py` CLI that calls `transition_status(packet_id, 'approved')`

## Why
BD-001 is a dispatch-blocking correctness defect: `dispatch_to_worker()` rejects any lane with `pool_status == "active"`, which was blocking dispatch to all lanes with live tmux panes even when they had no task assigned. BD-002 ensures dashboard visibility of orchestrator task queue entries. BD-003 adds operator convenience for approving pending tasks.

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/test_ops_worker_pool.py -x -v` — 75 passed
- `uv run python -m pytest tests/unit/test_ops_status.py -x -v` — 164 passed
- `make check-quiet` — all checks passed

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_worker_pool.py` — 75 passed
- [x] `uv run python -m pytest tests/unit/test_ops_status.py` — 164 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None (ops tooling only)
- Runtime impact: None

## Risk level
- [x] Low (ops tooling)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         b0bcf872 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author          3223d5c1 [fix/batch-d-dispatch-bugs]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b        66ab1830 [docs/batch-d-completion-update]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c        bc8d889f [docs/batch-d-qa-log]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d        51b8c4a9 [fix/worker-pool-task-queue-root]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-scratch  8e0b935c [codex/steward-author-scratch]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-ops             8e0b935c [codex/steward-ops]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-review          ee8e3c88 (detached HEAD)
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)