### PR TITLE
docs: add Amendment A6 — BD-004 staged delivery-adapter roadmap

### DIFF
--- a/plans/agent_ops/3_supervision_and_scaling/plan.md
+++ b/plans/agent_ops/3_supervision_and_scaling/plan.md
@@ -35,6 +35,9 @@ Before treating Phase 4 as ready, verify Batch D (Platform-6 + Platform-7):
 - [ ] Worker reuse/open-on-demand behavior works in a live multi-lane proving run
 - [ ] Stale/blocked/degraded lane handling is auditable and does not require pane
   archaeology
+- [ ] In the current tmux-first steward layout, a dispatched task can land in the
+  target live author session through a repo-owned delivery adapter without
+  manual pane inspection
 
 ## Platform-6 Summary (Complete)
 
@@ -62,6 +65,12 @@ From governing plan:
 - Worker-pool dashboard state
 - Open/resume author panes on delegation and return them to background/hidden
   state when idle
+- BD-004 closure path for this phase:
+  - use a thin tmux-backed delivery adapter on top of durable task/message state
+  - dispatch should wake the target lane if needed, then invoke a packet-specific
+    repo-owned consumer entrypoint in the live pane
+  - do not introduce channel-sidecar or `cmux` delivery as the required Phase 3
+    fix; those are later adapter upgrades
 - Note: if scaling and retirement logic do not fit cleanly, this slice may
   land as two PRs under the same parent label
 - Done when:
@@ -70,6 +79,15 @@ From governing plan:
     demand without requiring all author panes to be pre-opened
   - Dynamic worker creation and retirement obey repo-owned concurrency and
     cleanup limits
+
+## Later Delivery Upgrades
+
+After the Phase 3 gate is closed with the tmux-backed v1 delivery adapter:
+
+- `v2` (later, Platform-8-capable): optional Claude channel sidecar that watches
+  repo-owned task/inbox state and pushes events into the running session
+- `v3` (later, optional): `cmux` transport upgrade if workspace/surface refs are
+  populated and stable enough to replace raw tmux targeting cleanly
 
 ## Key Constraints
 

--- a/plans/agent_ops/amendments.md
+++ b/plans/agent_ops/amendments.md
@@ -148,3 +148,32 @@ not the operational bootstrap, sender-gating, or debugging realities surfaced
 by Claude's official Channels docs. Capturing these details now makes the slice
 more likely to prove cleanly without confusing channel transport failure,
 operator access failure, and architecture failure.
+
+---
+
+## A6 — BD-004 staged delivery-adapter roadmap (2026-03-22)
+
+**PR:** pending follow-up
+
+**What changed:**
+1. **Batch D gate aligned with the real Phase 3 blocker** -- The governing and
+   Phase 3 plans now state explicitly that, for the shipped tmux-first steward
+   layout, a dispatched task must be able to land in the target live author
+   session through a repo-owned delivery adapter.
+2. **`v1` delivery path made explicit** -- Phase 3 closes BD-004 with the
+   narrowest adapter that fits the current runtime: durable task/message state
+   plus a packet-specific tmux pane nudge into the already-running lane session.
+3. **`v2` upgrade path recorded** -- Platform-8 may later replace that pane
+   nudge with a Claude Channels sidecar that watches durable state and pushes
+   lane-local events into the running session, while keeping repo-owned state as
+   truth.
+4. **`v3` transport upgrade recorded** -- If `cmux` workspace/surface metadata
+   becomes live and stable, the delivery adapter may later move from tmux
+   targeting to `cmux` surface targeting without changing the durable contract.
+
+**Rationale:** The discussion around BD-004 established a three-stage answer:
+close the current gate cheaply with the existing tmux session model, preserve a
+clean upgrade path to Claude Channels once remote-channel prerequisites exist,
+and treat `cmux` as a later transport/presentation upgrade rather than as
+control-plane truth. Recording the full ladder now prevents future slices from
+re-litigating the same architectural boundary.

--- a/plans/agent_ops/governing_plan.md
+++ b/plans/agent_ops/governing_plan.md
@@ -862,6 +862,9 @@ shift or larger autonomy step as trustworthy.
 - worker reuse/open-on-demand behavior works in a live multi-lane proving run
 - stale/blocked/degraded lane handling is auditable and does not require pane
   archaeology
+- for the current tmux-first steward layout, a dispatched task can land in the
+  target live author session through a repo-owned delivery adapter rather than
+  manual pane inspection
 
 #### Batch E pass gate
 
@@ -1167,12 +1170,41 @@ These are the short names future handoffs should use.
 - note:
   - if scaling and retirement logic do not fit cleanly, this slice may land as
     two PRs under the same parent label
+  - BD-004 closure for the shipped tmux-first layout should use the thinnest
+    possible delivery adapter: after `dispatch_to_worker()` writes durable task
+    and bus state and wakes the target lane if needed, nudge the live pane to
+    invoke a packet-specific repo-owned entrypoint (for example
+    `/start-task <packet_id>`). The task queue and message bus remain the
+    source of truth.
 - done when:
   - `orchestrator` can reuse idle authors before creating new workers
   - a delegated task can cause the needed author lane to open or resume on
     demand without requiring all author panes to be pre-opened
   - dynamic worker creation and retirement obey repo-owned concurrency and
     cleanup limits
+  - the current tmux-backed steward layout can deliver a specific dispatched
+    packet into the live target lane without pasting full task bodies into pane
+    history or requiring manual pane inspection
+
+### Delivery Adapter Roadmap (BD-004)
+
+- `v1` -- Phase 3 gate fix for the current tmux-first steward layout
+  - keep task queue + message bus as durable truth
+  - wake or resume the target author pane if needed
+  - explicitly nudge the live pane to invoke a packet-specific repo-owned
+    consumer entrypoint
+  - record delivery or nudge outcome durably enough for supervisor follow-up
+- `v2` -- Platform-8-capable channel-sidecar upgrade
+  - a Claude channel server may watch durable task or inbox state and push the
+    event into the running lane session
+  - this replaces only the delivery adapter, not the repo-owned task/message
+    contract
+  - keep it optional until channel preflight, security gating, and proving are
+    satisfied
+- `v3` -- optional `cmux` transport upgrade
+  - if `cmux_workspace_ref` / `cmux_surface_ref` become live and stable, the
+    pane nudge adapter may move from tmux targeting to `cmux` surface targeting
+  - `cmux` remains presentation and transport metadata, not control-plane truth
 
 ### `Platform-8` — Remote Operator Channel
 
@@ -1202,6 +1234,14 @@ These are the short names future handoffs should use.
     official plugin path fails
   - operator-side SSH/Termius access is a debugging and recovery path only; it
     does not satisfy the remote-channel slice by itself
+- delivery-adapter upgrade path:
+  - the Platform-7 tmux nudge remains the compatibility baseline until a
+    channel-backed adapter proves stable
+  - a local channel sidecar may replace the pane-nudge adapter once the steward
+    session is launched with the required Claude Channels support and the
+    repo-owned task/message contract remains canonical
+  - any channel-backed lane delivery path must be treated as an adapter on top
+    of repo-owned state, not as a second source of task truth
 - done when:
   - one remote channel can deliver summarized alerts and accept bounded replies
   - the implementation path is validated against either an official plugin or a


### PR DESCRIPTION
## Summary
- Add Amendment A6 documenting the BD-004 staged delivery-adapter roadmap
- Update governing plan Batch D gate criteria, Platform-7 done criteria, Platform-8 delivery scope
- Update Phase 3 plan with BD-004 closure path and later upgrade ladder (v1/v2/v3)

## Why
BD-004 (end-to-end pane delivery) is the Phase 3 exit gate. Research into Claude Code Channels, OpenClaw/ClawTeam, and Hermes Agent converged on a three-stage approach. Recording the full ladder prevents future re-litigation.

## Repro / Validation
N/A — docs/plans only

## Tests
`make check-quiet` (docs-only, no code changes)

## Worktree proof
Committed from Bid-Euchre-steward-author worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)