### PR TITLE
ops: add tmux pane delivery adapter for dispatch (BD-004 v1)

### DIFF
--- a/.claude/skills/start-task/SKILL.md
+++ b/.claude/skills/start-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start-task
-description: Receives a task packet from the orchestrator and bootstraps author lane work — scope lock, branch setup, and implementation kickoff. Use when an author lane begins a new delegated task.
+description: Receives a task packet from the orchestrator and bootstraps author lane work — scope lock, branch setup, and implementation kickoff. Use when an author lane begins a new delegated task. Accepts an optional packet_id argument for direct dispatch.
 ---
 
 # /start-task — Author Task Bootstrap
@@ -9,10 +9,17 @@ Receive a delegated task packet and bootstrap work in this author lane. This
 skill covers the receipt-to-implementation-start phase — not multi-unit plan
 decomposition (use `/executing-plans` for that).
 
+## Arguments
+
+- `packet_id` (optional) — If provided, load that specific task packet from
+  the task queue. If omitted, scan the queue for dispatched packets owned by
+  this lane.
+
 ## When to Use
 
 - You are an author lane (author-a/b/c/d) and the orchestrator has assigned
   you a task packet
+- A pane nudge sent `/start-task <packet_id>` into your session
 - You are starting a new bounded coding task from a plan step or handoff
 - You need to set up a fresh branch and scope lock before implementation
 
@@ -20,22 +27,31 @@ decomposition (use `/executing-plans` for that).
 
 ### Phase 1 — Receive and Acknowledge
 
-1. **Read the task packet** (title, description, scope_declared, validation):
+1. **Read the task packet** (title, description, scope_declared, validation).
+   If a `packet_id` argument was provided, load that specific packet:
+   ```bash
+   uv run python scripts/internal/ops.py task show <packet_id>
+   ```
+   Otherwise, list dispatched packets for this lane:
    ```bash
    uv run python scripts/internal/ops.py task list
    ```
 
-2. **Verify scope is clear:**
+2. **Acknowledge the inbox message** (if dispatched via the bus):
+   Check your inbox for an assignment message and acknowledge it so the
+   orchestrator knows you received the task.
+
+3. **Verify scope is clear:**
    - Are the file patterns in `scope_declared` specific enough?
    - Is the validation command runnable?
    - Is there a plan or sub-plan reference to read?
 
-3. If scope is ambiguous, ask the orchestrator for clarification before
+4. If scope is ambiguous, ask the orchestrator for clarification before
    proceeding. Do not guess at scope boundaries.
 
 ### Phase 2 — Branch Setup
 
-4. **Ensure you are in your dedicated author worktree** (not the main checkout).
+5. **Ensure you are in your dedicated author worktree** (not the main checkout).
    Then create a fresh branch from main:
    ```bash
    git fetch origin main
@@ -46,25 +62,38 @@ decomposition (use `/executing-plans` for that).
    or governing plan (e.g., `ops/platform5-canonical-prompts`,
    `fix/scoring-edge-case`).
 
-5. If the task references a plan or sub-plan, **read it now**:
+6. If the task references a plan or sub-plan, **read it now**:
    ```bash
    cat plans/agent_ops/<phase>/sub/<sub-plan>.md
    ```
 
 ### Phase 3 — Scope Lock
 
-6. **Confirm file scope** matches the task packet's `scope_declared`:
+7. **Confirm file scope** matches the task packet's `scope_declared`:
    - List the files you expect to touch
    - Verify no overlap with other active author lanes
    - If you discover the task requires files outside declared scope, report
      the scope pressure to the orchestrator before proceeding
 
-7. **Confirm validation commands** from the task packet are runnable.
+8. **Confirm validation commands** from the task packet are runnable.
 
 ### Phase 4 — Begin Implementation
 
-8. Start coding within the declared scope. Follow the standard author
-   lifecycle: implement → validate (Tier 1) → PR → handoff.
+9. Start coding within the declared scope. Follow the standard author
+   lifecycle: implement -> validate (Tier 1) -> PR -> handoff.
+
+## Nudge-Based Dispatch
+
+When the orchestrator dispatches a task via `dispatch_to_worker()`, the
+following happens automatically:
+
+1. The task packet is transitioned to `dispatched` status with you as owner
+2. An inbox message is written to your message bus inbox
+3. A `tmux send-keys` nudge injects `/start-task <packet_id>` into your pane
+4. This skill activates and loads the specific packet
+
+The nudge is best-effort — if it fails, the task remains in durable state
+and you can pick it up manually via `task list`.
 
 ## Gotchas
 
@@ -81,3 +110,5 @@ decomposition (use `/executing-plans` for that).
 - `.claude/skills/executing-plans/WORK_UNIT_TEMPLATE.md` — work unit format
 - `.claude/CLAUDE.md` § Implementation Handoff Protocol — handoff sequence
 - `.claude/rules/15_testing_tiers.md` — validation tiers
+- `src/bid_euchre/ops/worker_pool.py` — dispatch_to_worker, nudge_pane
+- `src/bid_euchre/ops/message_bus.py` — inbox messages, ack_message

--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -18,6 +18,7 @@ Usage::
         park_worker,
         retire_worker,
         dispatch_to_worker,
+        nudge_pane,
         run_pool_maintenance,
     )
 
@@ -706,6 +707,60 @@ def retire_worker(
     )
 
 
+def nudge_pane(
+    lane_id: str,
+    packet_id: str,
+    *,
+    tmux_session: str = DEFAULT_TMUX_SESSION,
+) -> PoolAction:
+    """Send a short command to the lane's tmux pane to trigger task consumption.
+
+    Uses ``tmux send-keys`` to inject ``/start-task <packet_id>`` into the
+    target pane.  The command is a Claude Code slash-command that loads the
+    dispatched task packet from durable state and begins execution.
+
+    Args:
+        lane_id: Target lane whose pane should receive the command.
+        packet_id: Task packet ID to pass to the ``/start-task`` skill.
+        tmux_session: tmux session name.
+
+    Returns:
+        A :class:`PoolAction` with ``action="nudge"`` describing the outcome.
+    """
+    target = f"{tmux_session}:{lane_id}"
+    cmd = f"/start-task {packet_id}"
+
+    try:
+        subprocess.run(
+            ["tmux", "send-keys", "-t", target, cmd, "Enter"],
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
+        return PoolAction(
+            action="nudge",
+            lane_id=lane_id,
+            reason=f"Sent '{cmd}' to pane {target}",
+            executed=True,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        return PoolAction(
+            action="nudge",
+            lane_id=lane_id,
+            reason=f"Failed to nudge pane: {exc}",
+            executed=False,
+            error="nudge_failed",
+        )
+    except (FileNotFoundError, OSError) as exc:
+        return PoolAction(
+            action="nudge",
+            lane_id=lane_id,
+            reason=f"Failed to nudge pane: {exc}",
+            executed=False,
+            error="nudge_failed",
+        )
+
+
 def dispatch_to_worker(
     packet_id: str,
     lane_id: str,
@@ -713,15 +768,18 @@ def dispatch_to_worker(
     tmux_session: str = DEFAULT_TMUX_SESSION,
     runtime_dir: Path | None = None,
 ) -> PoolAction:
-    """Complete lifecycle: wake worker, assign task packet, update state.
+    """Complete lifecycle: wake worker, assign task packet, nudge pane.
 
     Steps:
     1. Load task packet, verify it is in "approved" status.
     2. Take pool snapshot, verify lane_id has capacity.
     3. If lane is parked/retired: wake_worker() first.
     4. Transition packet to "dispatched" with owner = lane_id.
-    5. Set lane visibility to "foreground".
-    6. Return PoolAction.
+    5. Write inbox message via message_bus (audit trail).
+    6. Nudge the target pane with ``/start-task <packet_id>``.
+    7. Record delivery outcome (update inbox message status).
+    8. Set lane visibility to "foreground".
+    9. Return PoolAction.
 
     This is the high-level entry point the orchestrator calls.
 
@@ -840,7 +898,50 @@ def dispatch_to_worker(
             error="transition_failed",
         )
 
-    # 5. Ensure visibility is foreground
+    # 5. Write inbox message via message_bus
+    message_id: str | None = None
+    try:
+        from bid_euchre.ops.message_bus import create_message, send_message
+
+        msg = create_message(
+            from_lane="orchestrator",
+            to_lane=lane_id,
+            message_type="assignment",
+            summary=f"Task dispatched: {packet.title}",
+            task_id=packet_id,
+            payload={"packet_id": packet_id, "title": packet.title},
+        )
+        message_id = send_message(msg)
+    except Exception as exc:
+        # Inbox message is best-effort; dispatch still succeeds
+        logger.warning(
+            "Failed to send inbox message for dispatch %s: %s",
+            packet_id,
+            exc,
+        )
+
+    # 6. Nudge the target pane
+    nudge_result = nudge_pane(lane_id, packet_id, tmux_session=tmux_session)
+
+    # 7. Record delivery outcome
+    if message_id is not None:
+        try:
+            from bid_euchre.ops.message_bus import (
+                _update_inbox_status,
+                shared_bus_root,
+            )
+
+            if nudge_result.executed:
+                bus_root = shared_bus_root()
+                _update_inbox_status(message_id, lane_id, "delivered", bus_root)
+        except Exception as exc:
+            logger.warning(
+                "Failed to update delivery status for message %s: %s",
+                message_id,
+                exc,
+            )
+
+    # 8. Ensure visibility is foreground
     from bid_euchre.ops.dashboard import set_lane_visibility
 
     set_lane_visibility(lane_id, "foreground", runtime_dir)

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -29,6 +29,7 @@ from bid_euchre.ops.worker_pool import (
     format_actions_json,
     format_pool_json,
     format_pool_text,
+    nudge_pane,
     park_worker,
     retire_worker,
     run_pool_maintenance,
@@ -1178,3 +1179,349 @@ class TestFormatters:
         assert len(data) == 1
         assert data[0]["action"] == "park"
         assert data[0]["executed"] is True
+
+
+# ---------------------------------------------------------------------------
+# Nudge pane
+# ---------------------------------------------------------------------------
+
+
+class TestNudgePane:
+    """Test nudge_pane() with mocked subprocess."""
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_nudge_success(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(returncode=0)
+        result = nudge_pane("author-a", "pkt123")
+        assert result.executed is True
+        assert result.action == "nudge"
+        assert result.error is None
+        assert "/start-task pkt123" in result.reason
+        assert "steward:author-a" in result.reason
+        mock_run.assert_called_once_with(
+            [
+                "tmux",
+                "send-keys",
+                "-t",
+                "steward:author-a",
+                "/start-task pkt123",
+                "Enter",
+            ],
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_nudge_custom_session(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(returncode=0)
+        result = nudge_pane("author-b", "pkt456", tmux_session="custom")
+        assert result.executed is True
+        mock_run.assert_called_once_with(
+            [
+                "tmux",
+                "send-keys",
+                "-t",
+                "custom:author-b",
+                "/start-task pkt456",
+                "Enter",
+            ],
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_nudge_subprocess_error(self, mock_run: MagicMock) -> None:
+        import subprocess as sp
+
+        mock_run.side_effect = sp.CalledProcessError(1, "tmux")
+        result = nudge_pane("author-a", "pkt123")
+        assert result.executed is False
+        assert result.error == "nudge_failed"
+        assert result.action == "nudge"
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_nudge_timeout(self, mock_run: MagicMock) -> None:
+        import subprocess as sp
+
+        mock_run.side_effect = sp.TimeoutExpired("tmux", 5)
+        result = nudge_pane("author-a", "pkt123")
+        assert result.executed is False
+        assert result.error == "nudge_failed"
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_nudge_tmux_not_found(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = FileNotFoundError("tmux not found")
+        result = nudge_pane("author-a", "pkt123")
+        assert result.executed is False
+        assert result.error == "nudge_failed"
+
+
+# ---------------------------------------------------------------------------
+# Dispatch with nudge and inbox message
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchNudgeIntegration:
+    """Test that dispatch_to_worker() calls nudge_pane and writes inbox message."""
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}.nudge_pane")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.transition_status")
+    @patch(f"{_TASK_QUEUE}.save_packet")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_calls_nudge(
+        self,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_transition: MagicMock,
+        mock_snapshot: MagicMock,
+        mock_nudge: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """Dispatch should call nudge_pane after transitioning the packet."""
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test Task",
+            description="Do the thing",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool([_make_worker("author-a", "idle")])
+        mock_nudge.return_value = PoolAction(
+            action="nudge",
+            lane_id="author-a",
+            reason="nudged",
+            executed=True,
+        )
+
+        with patch("bid_euchre.ops.message_bus.send_message", return_value="msg123"):
+            with patch("bid_euchre.ops.message_bus.create_message") as mock_cm:
+                mock_cm.return_value = MagicMock(message_id="msg123")
+                result = dispatch_to_worker("pkt1", "author-a", runtime_dir=runtime_dir)
+
+        assert result.executed is True
+        mock_nudge.assert_called_once_with(
+            "author-a", "pkt1", tmux_session=DEFAULT_TMUX_SESSION
+        )
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}.nudge_pane")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.transition_status")
+    @patch(f"{_TASK_QUEUE}.save_packet")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_writes_inbox_message(
+        self,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_transition: MagicMock,
+        mock_snapshot: MagicMock,
+        mock_nudge: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """Dispatch should write an inbox message via message_bus."""
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test Task",
+            description="Do the thing",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool([_make_worker("author-a", "idle")])
+        mock_nudge.return_value = PoolAction(
+            action="nudge",
+            lane_id="author-a",
+            reason="nudged",
+            executed=True,
+        )
+
+        with patch(
+            "bid_euchre.ops.message_bus.send_message", return_value="msg123"
+        ) as mock_send:
+            with patch("bid_euchre.ops.message_bus.create_message") as mock_cm:
+                from bid_euchre.ops.message_bus import BusMessage
+
+                fake_msg = BusMessage(
+                    message_id="msg123",
+                    thread_id=None,
+                    task_id="pkt1",
+                    from_lane="orchestrator",
+                    to_lane="author-a",
+                    message_type="assignment",
+                    priority="normal",
+                    status="pending",
+                    created_at="2026-03-22T12:00:00Z",
+                    acked_at=None,
+                    resolved_at=None,
+                    requires_human=False,
+                    summary="Task dispatched: Test Task",
+                    payload={"packet_id": "pkt1", "title": "Test Task"},
+                )
+                mock_cm.return_value = fake_msg
+                result = dispatch_to_worker("pkt1", "author-a", runtime_dir=runtime_dir)
+
+        assert result.executed is True
+        mock_cm.assert_called_once()
+        mock_send.assert_called_once_with(fake_msg)
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}.nudge_pane")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.transition_status")
+    @patch(f"{_TASK_QUEUE}.save_packet")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_succeeds_even_if_nudge_fails(
+        self,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_transition: MagicMock,
+        mock_snapshot: MagicMock,
+        mock_nudge: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """Dispatch should succeed even if nudge fails (nudge is best-effort)."""
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test",
+            description="Test",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool([_make_worker("author-a", "idle")])
+        mock_nudge.return_value = PoolAction(
+            action="nudge",
+            lane_id="author-a",
+            reason="tmux failed",
+            executed=False,
+            error="nudge_failed",
+        )
+
+        with patch("bid_euchre.ops.message_bus.send_message", return_value="msg123"):
+            with patch("bid_euchre.ops.message_bus.create_message") as mock_cm:
+                mock_cm.return_value = MagicMock(message_id="msg123")
+                result = dispatch_to_worker("pkt1", "author-a", runtime_dir=runtime_dir)
+
+        # Dispatch itself still succeeds — nudge is best-effort
+        assert result.executed is True
+        assert result.error is None
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}.nudge_pane")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.transition_status")
+    @patch(f"{_TASK_QUEUE}.save_packet")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_succeeds_even_if_inbox_fails(
+        self,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_transition: MagicMock,
+        mock_snapshot: MagicMock,
+        mock_nudge: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """Dispatch should succeed even if inbox message fails (best-effort)."""
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test",
+            description="Test",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool([_make_worker("author-a", "idle")])
+        mock_nudge.return_value = PoolAction(
+            action="nudge",
+            lane_id="author-a",
+            reason="nudged",
+            executed=True,
+        )
+
+        with patch(
+            "bid_euchre.ops.message_bus.send_message",
+            side_effect=RuntimeError("bus down"),
+        ):
+            with patch("bid_euchre.ops.message_bus.create_message") as mock_cm:
+                mock_cm.return_value = MagicMock(message_id="msg123")
+                result = dispatch_to_worker("pkt1", "author-a", runtime_dir=runtime_dir)
+
+        # Dispatch itself still succeeds
+        assert result.executed is True
+        assert result.error is None
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}.nudge_pane")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.transition_status")
+    @patch(f"{_TASK_QUEUE}.save_packet")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_records_delivery_on_nudge_success(
+        self,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_transition: MagicMock,
+        mock_snapshot: MagicMock,
+        mock_nudge: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """On nudge success, dispatch should update inbox message to delivered."""
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test",
+            description="Test",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool([_make_worker("author-a", "idle")])
+        mock_nudge.return_value = PoolAction(
+            action="nudge",
+            lane_id="author-a",
+            reason="nudged",
+            executed=True,
+        )
+
+        with patch("bid_euchre.ops.message_bus.send_message", return_value="msg123"):
+            with patch("bid_euchre.ops.message_bus.create_message") as mock_cm:
+                mock_cm.return_value = MagicMock(message_id="msg123")
+                with patch(
+                    "bid_euchre.ops.message_bus._update_inbox_status"
+                ) as mock_update:
+                    with patch(
+                        "bid_euchre.ops.message_bus.shared_bus_root"
+                    ) as mock_root:
+                        mock_root.return_value = Path("/tmp/bus")
+                        result = dispatch_to_worker(
+                            "pkt1", "author-a", runtime_dir=runtime_dir
+                        )
+
+        assert result.executed is True
+        mock_update.assert_called_once_with(
+            "msg123", "author-a", "delivered", Path("/tmp/bus")
+        )


### PR DESCRIPTION
## Plan
- `plans/agent_ops/3_supervision_and_scaling/sub/2026-03-22_bd004-v1-pane-delivery.md` (SP-3-03)

## Summary
- Add `nudge_pane()` function to `worker_pool.py` that injects `/start-task <packet_id>` into a tmux pane via `tmux send-keys`
- Wire nudge + inbox message into `dispatch_to_worker()` flow (steps 5-7: write inbox message, nudge pane, record delivery outcome)
- Update `/start-task` skill with `packet_id` argument support and nudge-based dispatch documentation

## Why
Closes the BD-004 gap (#1259) — dispatch flow did not deliver tasks into live tmux pane sessions. During Batch D proving run, task execution relied on Agent tool subprocesses instead of pane delivery. This v1 adapter completes the dispatch→pane pipeline: `dispatch_to_worker()` now writes an inbox message, nudges the target pane, and records delivery status. The nudge is best-effort — if it fails, durable state remains for manual pickup.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_worker_pool.py -x  # 85 passed
make check-quiet  # All checks passed
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_worker_pool.py -x` — 85 passed (8 new)
- [x] `make check-quiet` — all checks passed
- [ ] Other: End-to-end proving test (Step 7 of sub-plan, manual verification)

### New tests
| Test | What |
|------|------|
| `test_nudge_success` | nudge_pane sends correct tmux command |
| `test_nudge_custom_session` | nudge_pane respects custom tmux session |
| `test_nudge_subprocess_error` | CalledProcessError → executed=False |
| `test_nudge_timeout` | TimeoutExpired → executed=False |
| `test_nudge_tmux_not_found` | FileNotFoundError → executed=False |
| `test_dispatch_calls_nudge` | dispatch_to_worker calls nudge_pane |
| `test_dispatch_writes_inbox_message` | dispatch writes inbox message via bus |
| `test_dispatch_succeeds_even_if_nudge_fails` | nudge failure doesn't fail dispatch |
| `test_dispatch_succeeds_even_if_inbox_fails` | inbox failure doesn't fail dispatch |
| `test_dispatch_records_delivery_on_nudge_success` | delivery outcome recorded durably |

## Expected impact
- Metrics impact: None
- Runtime impact: None (new tmux subprocess call in dispatch, ~5s timeout cap)

## Risk level
- [x] Low (ops tooling only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         83a2898e [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author          dd32fdf9 [ops/bd004-v1-pane-delivery]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

Closes #1259

🤖 Generated with [Claude Code](https://claude.com/claude-code)