### PR TITLE
ops: switch steward tmux layout to full-page-per-lane windows

### DIFF
--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -2,16 +2,15 @@
 # Canonical steward session bootstrap.
 # Usage: steward-session.sh [session-name]
 #
-# Creates (or attaches to) a tmux session with:
-#   1. dashboard       -- 4-pane mission-control view
-#      pane 1: author-a
-#      pane 2: author-b
-#      pane 3: review
-#      pane 4: ops
-#   2. orchestrator    -- single intake point for delegating work
-#   3. author-c        -- overflow author lane
-#   4. author-d        -- overflow author lane
-#   5. author-scratch  -- exploratory Claude lane
+# Creates (or attaches to) a tmux session with full-page windows:
+#   1. orchestrator    -- single intake point for delegating work
+#   2. author-a        -- primary author lane
+#   3. author-b        -- secondary author lane
+#   4. author-c        -- overflow author lane
+#   5. author-d        -- overflow author lane
+#   6. author-scratch  -- exploratory Claude lane
+#   7. ops             -- operator monitoring lane
+#   8. review          -- independent review lane
 #
 # Writes v2 worktree registry metadata for each launched lane.
 # See docs/02_agent/AUTONOMOUS_OPERATOR_WORKFLOW.md for the full model.
@@ -235,49 +234,49 @@ ensure_worktree "$AUTHOR_SCRATCH" "codex/steward-author-scratch"
 ensure_review_worktree
 
 # Write v2 registry metadata for each lane
-# Dashboard panes: visibility=foreground; off-dashboard windows: visibility=background
-write_lane_metadata "author-a"       "author"  "$AUTHOR_A"       "codex/steward-author"         "dashboard" "1"    "foreground" "Author A"
-write_lane_metadata "author-b"       "author"  "$AUTHOR_B"       "codex/steward-author-b"       "dashboard" "2"    "foreground" "Author B"
-write_lane_metadata "review"         "review"  "$REVIEW"         "detached"                     "dashboard" "3"    "foreground" "Review"
-write_lane_metadata "ops"            "ops"     "$MAIN_DIR"       "--"                           "dashboard" "4"    "foreground" "Ops"
-write_lane_metadata "orchestrator"   "orchestrator" "$MAIN_DIR" "--"                           "orchestrator" "null" "foreground" "Orchestrator"
-write_lane_metadata "author-c"       "author"  "$AUTHOR_C"       "codex/steward-author-c"       "author-c"  "null" "background" "Author C"
-write_lane_metadata "author-d"       "author"  "$AUTHOR_D"       "codex/steward-author-d"       "author-d"  "null" "background" "Author D"
-write_lane_metadata "author-scratch" "scratch" "$AUTHOR_SCRATCH" "codex/steward-author-scratch"  "author-scratch" "null" "background" "Scratch"
+# All lanes are full-page windows with foreground visibility
+write_lane_metadata "orchestrator"   "orchestrator" "$MAIN_DIR"       "--"                           "orchestrator" "null" "foreground" "Orchestrator"
+write_lane_metadata "author-a"       "author"  "$AUTHOR_A"       "codex/steward-author"         "author-a"  "null" "foreground" "Author A"
+write_lane_metadata "author-b"       "author"  "$AUTHOR_B"       "codex/steward-author-b"       "author-b"  "null" "foreground" "Author B"
+write_lane_metadata "author-c"       "author"  "$AUTHOR_C"       "codex/steward-author-c"       "author-c"  "null" "foreground" "Author C"
+write_lane_metadata "author-d"       "author"  "$AUTHOR_D"       "codex/steward-author-d"       "author-d"  "null" "foreground" "Author D"
+write_lane_metadata "author-scratch" "scratch" "$AUTHOR_SCRATCH" "codex/steward-author-scratch"  "author-scratch" "null" "foreground" "Scratch"
+write_lane_metadata "ops"            "ops"     "$MAIN_DIR"       "--"                           "ops"       "null" "foreground" "Ops"
+write_lane_metadata "review"         "review"  "$REVIEW"         "detached"                     "review"    "null" "foreground" "Review"
 
-tmux new-session -d -s "$SESSION" -n dashboard -c "$AUTHOR_A" \
-    "$CLAUDE_BIN" --name author-a --agent steward-author-a
-
-tmux split-window -h -t "${SESSION}:dashboard" -c "$AUTHOR_B" \
-    "$CLAUDE_BIN" --name author-b --agent steward-author-b
-
-tmux split-window -v -t "${SESSION}:dashboard.1" -c "$REVIEW" \
-    "$CLAUDE_BIN" --name review --agent steward-review
-
-tmux split-window -v -t "${SESSION}:dashboard.2" -c "$MAIN_DIR" \
-    "$CLAUDE_BIN" --name ops --agent steward-ops
-
-tmux select-layout -t "${SESSION}:dashboard" tiled
-tmux swap-pane -s "${SESSION}:dashboard.2" -t "${SESSION}:dashboard.4"
-tmux swap-pane -s "${SESSION}:dashboard.3" -t "${SESSION}:dashboard.4"
-tmux select-pane -t "${SESSION}:dashboard.1" -T author-a
-tmux select-pane -t "${SESSION}:dashboard.2" -T author-b
-tmux select-pane -t "${SESSION}:dashboard.3" -T review
-tmux select-pane -t "${SESSION}:dashboard.4" -T ops
-
-tmux new-window -t "$SESSION" -n orchestrator -c "$MAIN_DIR" \
+# Window 1: orchestrator (first window = session creation)
+tmux new-session -d -s "$SESSION" -n orchestrator -c "$MAIN_DIR" \
     "$CLAUDE_BIN" --name orchestrator --agent steward-orchestrator
 
+# Window 2: author-a
+tmux new-window -t "$SESSION" -n author-a -c "$AUTHOR_A" \
+    "$CLAUDE_BIN" --name author-a --agent steward-author-a
+
+# Window 3: author-b
+tmux new-window -t "$SESSION" -n author-b -c "$AUTHOR_B" \
+    "$CLAUDE_BIN" --name author-b --agent steward-author-b
+
+# Window 4: author-c
 tmux new-window -t "$SESSION" -n author-c -c "$AUTHOR_C" \
     "$CLAUDE_BIN" --name author-c --agent steward-author-c
 
+# Window 5: author-d
 tmux new-window -t "$SESSION" -n author-d -c "$AUTHOR_D" \
     "$CLAUDE_BIN" --name author-d --agent steward-author-d
 
+# Window 6: author-scratch
 tmux new-window -t "$SESSION" -n author-scratch -c "$AUTHOR_SCRATCH" \
     "$CLAUDE_BIN" --name author-scratch --agent steward-author-scratch
 
-tmux select-window -t "${SESSION}:dashboard"
+# Window 7: ops
+tmux new-window -t "$SESSION" -n ops -c "$MAIN_DIR" \
+    "$CLAUDE_BIN" --name ops --agent steward-ops
+
+# Window 8: review
+tmux new-window -t "$SESSION" -n review -c "$REVIEW" \
+    "$CLAUDE_BIN" --name review --agent steward-review
+
+tmux select-window -t "${SESSION}:orchestrator"
 
 update_last_active
 

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -277,6 +277,94 @@ class TestStewardSessionScript:
         ), "ensure_worktree() must call validate_worktree_path before creating"
 
 
+class TestFullPageLaneLayout:
+    """Validate that all lanes use individual full-page windows (no dashboard)."""
+
+    EXPECTED_LANES = [
+        "orchestrator",
+        "author-a",
+        "author-b",
+        "author-c",
+        "author-d",
+        "author-scratch",
+        "ops",
+        "review",
+    ]
+
+    def test_no_dashboard_window(self) -> None:
+        """The script must not create a dashboard window."""
+        content = STEWARD_SCRIPT.read_text()
+        # No tmux window named "dashboard" and no split-window/select-layout
+        assert "dashboard" not in content.lower(), (
+            "steward-session.sh must not reference a 'dashboard' window; "
+            "all lanes should have individual full-page windows"
+        )
+
+    def test_all_lanes_have_individual_windows(self) -> None:
+        """Each lane must have its own tmux window (new-session or new-window)."""
+        content = STEWARD_SCRIPT.read_text()
+        for lane in self.EXPECTED_LANES:
+            assert f"-n {lane}" in content, (
+                f"Lane '{lane}' must have its own tmux window "
+                f"(expected '-n {lane}' in new-session or new-window command)"
+            )
+
+    @staticmethod
+    def _metadata_invocation_lines() -> list[str]:
+        """Return write_lane_metadata invocation lines (not the function def)."""
+        content = STEWARD_SCRIPT.read_text()
+        return [
+            line
+            for line in content.split("\n")
+            if line.strip().startswith('write_lane_metadata "')
+        ]
+
+    def test_all_lanes_foreground_visibility(self) -> None:
+        """All write_lane_metadata calls must use foreground visibility."""
+        metadata_lines = self._metadata_invocation_lines()
+        assert len(metadata_lines) == len(self.EXPECTED_LANES), (
+            f"Expected {len(self.EXPECTED_LANES)} write_lane_metadata calls, "
+            f"found {len(metadata_lines)}"
+        )
+        for line in metadata_lines:
+            assert (
+                '"foreground"' in line
+            ), f"All lanes must have foreground visibility, but found: {line.strip()}"
+
+    def test_no_pane_indices_in_metadata(self) -> None:
+        """No lane should use numbered pane indices (all windows are full-page)."""
+        metadata_lines = self._metadata_invocation_lines()
+        for line in metadata_lines:
+            # The tmux_pane argument (6th positional) should be "null"
+            # Numbered pane indices like "1", "2", "3", "4" indicate
+            # a dashboard pane layout, not individual windows
+            assert (
+                '"null"' in line or "null" in line
+            ), f"Lane metadata should not use numbered pane indices: {line.strip()}"
+
+    def test_window_creation_order(self) -> None:
+        """Windows must be created in the expected order."""
+        content = STEWARD_SCRIPT.read_text()
+        lines = content.split("\n")
+        window_lines = [
+            line for line in lines if "new-session" in line or "new-window" in line
+        ]
+        # Filter to only the tmux window creation commands (not comments)
+        window_cmds = [l for l in window_lines if l.strip().startswith("tmux")]
+        assert len(window_cmds) == len(self.EXPECTED_LANES), (
+            f"Expected {len(self.EXPECTED_LANES)} window creation commands, "
+            f"found {len(window_cmds)}"
+        )
+        # First window uses new-session, rest use new-window
+        assert (
+            "new-session" in window_cmds[0]
+        ), "First window (orchestrator) must use tmux new-session"
+        for cmd in window_cmds[1:]:
+            assert (
+                "new-window" in cmd
+            ), f"Non-first windows must use tmux new-window: {cmd.strip()}"
+
+
 class TestBoundaryValidation:
     """Tests for validate_worktree_path() in steward-session.sh."""
 


### PR DESCRIPTION
## Plan
N/A — straightforward layout change.

## Summary
- Replace the 4-pane dashboard window with individual full-page windows for all 8 lanes
- All lanes now have foreground visibility (no more background lanes)
- Window order: orchestrator(1), author-a(2), author-b(3), author-c(4), author-d(5), author-scratch(6), ops(7), review(8)

## Why
The dashboard 4-pane split was too cramped for effective monitoring. Full-page windows give each lane the full terminal width, making it easier to read output and interact with each Claude instance via tmux window switching.

## Repro / Validation
**Command(s) run:**
- `make check-quiet` -- all checks passed
- `uv run python -m pytest tests/unit/test_steward_session.py -v` -- 36/36 passed

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_steward_session.py -v` -- 36 passed
- [x] New `TestFullPageLaneLayout` class with 5 tests:
  - `test_no_dashboard_window` -- no dashboard window references
  - `test_all_lanes_have_individual_windows` -- all 8 lanes have `-n <lane>` windows
  - `test_all_lanes_foreground_visibility` -- all metadata calls use "foreground"
  - `test_no_pane_indices_in_metadata` -- no numbered pane indices
  - `test_window_creation_order` -- correct new-session/new-window sequence

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/worktree-tmux-layout
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/worktree-tmux-layout
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         fb312396 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/worktree-tmux-layout               5d4fa4c7 [tmux/full-page-lanes]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)