### PR TITLE
docs: close Phase 3 and record dual-domain transition entry (SP-3-04)

### DIFF
--- a/plans/agent_ops/3_supervision_and_scaling/checkpoints.md
+++ b/plans/agent_ops/3_supervision_and_scaling/checkpoints.md
@@ -15,7 +15,7 @@
 | Step 2: Platform-7 scope lock and sub-plan | COMPLETE | 2026-03-22 | author-c | SP-3-02 created and plan-reviewed. Worker-pool manager: idle reuse, bounded dynamic author creation, parking/retirement. |
 | Step 3: Platform-7 implementation | COMPLETE | 2026-03-22 | author-d | worker_pool.py module, CLI subcommand, 69 tests. PR #1250 + fix PR #1252. |
 | Step 4: Batch D pass gate verification | COMPLETE | 2026-03-22 | orchestrator (Batch D proving run) | Batch D pass gate PASSED. All 3 criteria met. PRs #1256, #1257, #1258. 5 findings (BD-001--BD-005). Phase 3 exit blocked on BD-004 (#1259). |
-| Step 5: Phase 3 handoff | COMPLETE | 2026-03-22 | author-b | BD-004 closed via PR #1263. Phase 3 COMPLETE. Governing plan, checkpoints, QA log, sub-plan registry, and MEMORY.md updated. |
+| Step 5: Phase 3 handoff | COMPLETE | 2026-03-22 | author-scratch (SP-3-04 closeout) | BD-004 closed via PR #1263. Phase 3 durably closed. All planning state reconciled. |
 
 **Status values:** `PENDING`, `IN_PROGRESS`, `COMPLETE`, `BLOCKED`, `SKIPPED`
 
@@ -25,6 +25,7 @@
 |-------------|------|--------|---------------|
 | SP-3-02 | `plans/agent_ops/3_supervision_and_scaling/sub/2026-03-22_platform7-worker-pool-manager.md` | completed | Step 3 |
 | SP-3-03 | `plans/agent_ops/3_supervision_and_scaling/sub/2026-03-22_bd004-v1-pane-delivery.md` | completed | Step 5 |
+| SP-3-04 | `plans/agent_ops/3_supervision_and_scaling/sub/2026-03-22_phase3-closeout-and-transition-entry.md` | completed | Step 5 |
 
 ## Blockers
 
@@ -88,3 +89,14 @@ None. All blockers resolved.
 - Governing plan updated: Phase 3 → COMPLETE. Phase 4/5 ready for entry.
 - Next: Phase 4 (remote channel) or Phase 5 (portability and learning),
   both depend on Phase 3 completion.
+
+### 2026-03-22 -- author-scratch (SP-3-04 closeout)
+- Phase 3 durable planning state reconciled across all plan files.
+- BD-004 closed (#1259) via PR #1263. BD-001/BD-002/BD-003 fixed via PR #1261.
+- plan.md: Phase Status → COMPLETE, Platform-7 → COMPLETE, Batch D pass gate
+  checklist → all checked, sub-plans table updated with SP-3-03/SP-3-04/SP-3-05.
+- qa_log.md: BD-001 through BD-004 → fixed. BD-005 remains open (INFO, non-blocking).
+- sub_plan_registry.md: SP-3-04 → completed, SP-3-05 → proposed.
+- governing_plan.md: no numbered phase currently active; next governed action
+  is SP-3-05 (dual-domain layout transition), then Platform-8 scope lock.
+- Phase 3 durably closed. No remaining work items.

--- a/plans/agent_ops/3_supervision_and_scaling/plan.md
+++ b/plans/agent_ops/3_supervision_and_scaling/plan.md
@@ -2,8 +2,8 @@
 
 **Governing plan:** `plans/agent_ops/governing_plan.md`
 **Phase:** `3_supervision_and_scaling`
-**Status:** IN_PROGRESS
-**Last updated:** 2026-03-22 by author-b (Phase 3 plan creation)
+**Status:** COMPLETE
+**Last updated:** 2026-03-22 by author-scratch (SP-3-04 closeout)
 
 ---
 
@@ -25,17 +25,17 @@ Phase 2 (`2_visible_operating_model`) is COMPLETE:
 | Slice | Goal | Status | Batch | Depends On |
 |-------|------|--------|-------|------------|
 | `Platform-6` | `ops` supervisor routines and delta summaries | COMPLETE (PR #1242) | D | Platform-3, Platform-4 |
-| `Platform-7` | Background worker-pool management and bounded dynamic author scaling | PENDING | D | Platform-1, Platform-2, Platform-3 |
+| `Platform-7` | Background worker-pool management and bounded dynamic author scaling | COMPLETE (PR #1250, #1252) | D | Platform-1, Platform-2, Platform-3 |
 
 ## Batch D Pass Gate
 
 Before treating Phase 4 as ready, verify Batch D (Platform-6 + Platform-7):
 
-- [ ] `ops` delta summaries are reliable enough to drive intervention decisions
-- [ ] Worker reuse/open-on-demand behavior works in a live multi-lane proving run
-- [ ] Stale/blocked/degraded lane handling is auditable and does not require pane
+- [x] `ops` delta summaries are reliable enough to drive intervention decisions
+- [x] Worker reuse/open-on-demand behavior works in a live multi-lane proving run
+- [x] Stale/blocked/degraded lane handling is auditable and does not require pane
   archaeology
-- [ ] In the current tmux-first steward layout, a dispatched task can land in the
+- [x] In the current tmux-first steward layout, a dispatched task can land in the
   target live author session through a repo-owned delivery adapter without
   manual pane inspection
 
@@ -104,7 +104,10 @@ Active sub-plans are tracked in `plans/agent_ops/sub_plan_registry.md`.
 | ID | Slice | Status |
 |----|-------|--------|
 | SP-3-01 | Platform-6 | completed |
-| SP-3-02 | Platform-7 | pending |
+| SP-3-02 | Platform-7 | completed |
+| SP-3-03 | BD-004 v1 pane delivery | completed |
+| SP-3-04 | Phase 3 closeout and transition entry | completed |
+| SP-3-05 | Dual-domain steward layout transition | proposed |
 
 ## Step Sequence
 

--- a/plans/agent_ops/3_supervision_and_scaling/qa_log.md
+++ b/plans/agent_ops/3_supervision_and_scaling/qa_log.md
@@ -7,8 +7,8 @@
 
 | ID | Severity | Source | Status | Description | Fix PR |
 |----|----------|--------|--------|-------------|--------|
-| BD-001 | WARN | Batch D proving run | closed | `_classify_pool_status()` in worker_pool.py:279 treats `likely_active` + no-task as "active", blocking dispatch to idle lanes. Should return "idle" when has_task=False. | #1261 |
-| BD-002 | WARN | Batch D proving run | closed | Dashboard `active_tasks` count (via `status.py` `load_tasks()`) reads from `task_state/` directory, not `task_queue/`. Per-lane `current_task_id` is a `WorkerState` field in the workers CLI, not a dashboard field. | #1261 |
-| BD-003 | INFO | Batch D proving run | closed | `workers dispatch` CLI requires packet in "approved" status but no CLI subcommand exists for approval. Workaround: call `transition_status()` Python API directly. | #1261 |
-| BD-004 | WARN | Batch D proving run | closed | Dispatch flow does not deliver tasks into live tmux pane sessions end-to-end. Execution via Agent subprocesses, not pane message delivery. Phase 3 exit gate. Tracked as #1259. | #1263 |
+| BD-001 | WARN | Batch D proving run | fixed | `_classify_pool_status()` in worker_pool.py:279 treats `likely_active` + no-task as "active", blocking dispatch to idle lanes. Should return "idle" when has_task=False. | #1261 |
+| BD-002 | WARN | Batch D proving run | fixed | Dashboard `active_tasks` count (via `status.py` `load_tasks()`) reads from `task_state/` directory, not `task_queue/`. Per-lane `current_task_id` is a `WorkerState` field in the workers CLI, not a dashboard field. | #1261 |
+| BD-003 | INFO | Batch D proving run | fixed | `workers dispatch` CLI requires packet in "approved" status but no CLI subcommand exists for approval. Workaround: call `transition_status()` Python API directly. | #1261 |
+| BD-004 | WARN | Batch D proving run | fixed | Dispatch flow does not deliver tasks into live tmux pane sessions end-to-end. Execution via Agent subprocesses, not pane message delivery. Phase 3 exit gate. Tracked as #1259. | #1263 |
 | BD-005 | INFO | Batch D proving run | open | Task packets don't auto-transition to `completed` when executing agent finishes. No completion callback from agent to task queue. | -- |

--- a/plans/agent_ops/3_supervision_and_scaling/sub/2026-03-22_bd004-v1-pane-delivery.md
+++ b/plans/agent_ops/3_supervision_and_scaling/sub/2026-03-22_bd004-v1-pane-delivery.md
@@ -1,0 +1,193 @@
+# BD-004 v1: tmux-backed pane delivery adapter
+
+**Sub-plan ID:** SP-3-03
+**Parent step:** Phase 3, Step 5 (Phase 3 handoff) — blocked on BD-004
+**Created:** 2026-03-22
+**Status:** pending
+
+## Goal
+
+Close BD-004 (#1259) by implementing the v1 delivery adapter: after
+`dispatch_to_worker()` writes durable task/message state and wakes the
+target lane, nudge the live tmux pane to invoke a repo-owned consumer
+entrypoint that reads and executes the dispatched task.
+
+## Design
+
+### Architecture
+
+```
+dispatch_to_worker(packet_id, lane_id)
+  ├── 1. Write durable task state (task_queue)       [exists]
+  ├── 2. Write inbox message (message_bus)            [NEW]
+  ├── 3. wake_worker() if parked/retired              [exists]
+  ├── 4. nudge_pane(lane_id, packet_id)               [NEW]
+  │     └── tmux send-keys "/start-task {packet_id}" Enter
+  ├── 5. Record delivery outcome in message_bus       [NEW]
+  └── Pane's Claude session receives prompt,
+      reads task packet, and starts work
+```
+
+### Key constraints
+
+- Task queue + message bus remain the source of truth
+- `tmux send-keys` sends a **short command**, not the full task body
+- The command triggers a **repo-owned entrypoint** that reads durable state
+- Nudge failures are auditable via message_bus delivery records
+- No polling loops, no MCP sidecars, no cmux — those are v2/v3
+
+## Implementation steps
+
+### Step 1: Consumer entrypoint — `/start-task` skill
+
+**File:** `.claude/skills/start-task.md` (already exists, needs update)
+
+Update the existing `start-task` skill to:
+1. Accept an optional `packet_id` argument
+2. If `packet_id` provided: load the specific packet from task_queue
+3. If no `packet_id`: scan task_queue for dispatched packets owned by
+   the current lane (by matching lane name from `--name` CLI arg or
+   worktree path)
+4. Render the task as a structured prompt with title, description,
+   scope lock, and validation commands
+5. Begin execution
+
+**Read first:**
+- `.claude/skills/start-task.md` (current implementation)
+- `src/bid_euchre/ops/task_queue.py` (`load_packet`, `list_packets`)
+- `src/bid_euchre/ops/message_bus.py` (`read_inbox`, `ack_message`)
+
+### Step 2: Inbox message on dispatch
+
+**File:** `src/bid_euchre/ops/worker_pool.py` (`dispatch_to_worker`)
+
+After transitioning the packet to `dispatched` status (existing step 4),
+add a call to write an inbox message:
+
+```python
+from bid_euchre.ops.message_bus import send_message
+
+send_message(
+    from_lane="orchestrator",
+    to_lane=lane_id,
+    message_type="task_dispatched",
+    payload={"packet_id": packet_id, "title": packet.title},
+    task_id=packet_id,
+)
+```
+
+This makes the dispatch auditable via the message bus and gives the
+consumer entrypoint a second lookup path.
+
+### Step 3: Pane nudge helper
+
+**File:** `src/bid_euchre/ops/worker_pool.py`
+
+Add a `nudge_pane()` function:
+
+```python
+def nudge_pane(
+    lane_id: str,
+    packet_id: str,
+    *,
+    tmux_session: str = DEFAULT_TMUX_SESSION,
+) -> PoolAction:
+    """Send a short command to the lane's tmux pane to trigger task consumption."""
+    import subprocess
+
+    target = f"{tmux_session}:{lane_id}"
+    cmd = f"/start-task {packet_id}"
+
+    try:
+        subprocess.run(
+            ["tmux", "send-keys", "-t", target, cmd, "Enter"],
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
+        return PoolAction(
+            action="nudge",
+            lane_id=lane_id,
+            reason=f"Sent '{cmd}' to pane {target}",
+            executed=True,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        return PoolAction(
+            action="nudge",
+            lane_id=lane_id,
+            reason=f"Failed to nudge pane: {exc}",
+            executed=False,
+            error="nudge_failed",
+        )
+```
+
+Call this from `dispatch_to_worker()` after the wake step succeeds.
+
+### Step 4: Record delivery outcome
+
+**File:** `src/bid_euchre/ops/worker_pool.py`
+
+After `nudge_pane()`, update the inbox message status:
+- If nudge succeeded: update message status to `delivered`
+- If nudge failed: leave as `pending` (supervisor can retry later)
+
+### Step 5: Integration in dispatch_to_worker
+
+**File:** `src/bid_euchre/ops/worker_pool.py`
+
+Wire steps 2-4 into the existing `dispatch_to_worker()` flow, after the
+packet transition (step 4 in the current code). The new sequence:
+
+```
+existing: verify packet → check capacity → wake if needed → transition packet
+new:      → write inbox message → nudge pane → record outcome → return action
+```
+
+### Step 6: Tests
+
+**Files:**
+- `tests/unit/test_ops_worker_pool.py`
+
+Add tests for:
+- `nudge_pane()` success path (mock subprocess)
+- `nudge_pane()` failure path (subprocess error)
+- `dispatch_to_worker()` now calls nudge after dispatch
+- Inbox message written on dispatch
+
+### Step 7: End-to-end proving test
+
+Manually verify the full chain:
+1. Create and approve a task packet
+2. Call `workers dispatch` (now with CLI approve fix from BD-003)
+3. Observe: pane receives `/start-task` command
+4. Observe: Claude session reads the packet and starts work
+5. Record as BD-004 gate evidence
+
+## Scope lock
+
+- `.claude/skills/start-task.md`
+- `src/bid_euchre/ops/worker_pool.py`
+- `tests/unit/test_ops_worker_pool.py`
+
+## Validation
+
+```bash
+uv run python -m pytest tests/unit/test_ops_worker_pool.py -x
+make check-quiet
+```
+
+## Acceptance criteria
+
+- [ ] `/start-task <packet_id>` reads and renders the dispatched task
+- [ ] `dispatch_to_worker()` writes an inbox message
+- [ ] `dispatch_to_worker()` nudges the target pane via tmux send-keys
+- [ ] Nudge outcome is recorded durably
+- [ ] End-to-end proving test passes (orchestrator dispatch → pane execution)
+- [ ] BD-004 gate closed
+
+## Deferred
+
+- Background polling loops (v2 — Channels sidecar)
+- Auto-completion callbacks (BD-005)
+- cmux transport (v3)
+- Supervisor retry/nudge automation

--- a/plans/agent_ops/3_supervision_and_scaling/sub/2026-03-22_dual-domain-steward-layout-transition.md
+++ b/plans/agent_ops/3_supervision_and_scaling/sub/2026-03-22_dual-domain-steward-layout-transition.md
@@ -1,0 +1,264 @@
+<!-- review-tier: governing -->
+# Dual-Domain Steward Layout Transition
+
+**ID:** SP-3-05
+**Date:** 2026-03-22
+**Parent:** post-Phase-3 transition package before Phase 4 (`4_remote_channel`)
+**Status:** proposed
+**Owner:** TBD
+
+---
+
+## Goal
+
+Enable concurrent platform and browser-game development by splitting execution
+capacity into domain-aware worker pools while keeping one centralized control
+surface for intake, supervision, review, and issues.
+
+This is intentionally a transition package, not a new numbered platform
+slice. It should land after Phase 3 closeout and before Platform-8 scope lock.
+
+## Non-Goals
+
+- Duplicating `orchestrator`
+- Duplicating `ops`
+- Duplicating `review`
+- Starting Platform-8 / Platform-9 work
+- Implementing browser-game product code
+- Replacing repo-owned task/message/review state with tmux or cmux state
+
+## Operator Model
+
+### Target layout
+
+```
+Window 1: central-ops
+  - orchestrator
+  - ops
+  - review
+  - issues
+
+Window 2: platform-workers
+  - author-a
+  - author-b
+  - author-c
+  - author-d
+
+Window 3: browser-workers
+  - brws-author-a
+  - brws-author-b
+  - brws-author-c
+  - brws-author-d
+
+Window 4: scratch-flex
+  - author-scratch
+  - flex-a
+  - flex-b
+  - flex-c
+```
+
+### Control principle
+
+- one orchestrator
+- one ops lane
+- one review lane
+- one issues lane
+- domain split applies to worker execution capacity, not to control-plane truth
+
+## Design Constraints
+
+1. Preserve the existing platform worker identities:
+   - `author-a`
+   - `author-b`
+   - `author-c`
+   - `author-d`
+   - `author-scratch`
+2. Add new browser/flex lanes without renaming the existing platform pool.
+3. Domain is a routing property, not a capability truth model.
+4. Default worker selection order must be:
+   - same-domain lane
+   - flex lane
+   - explicit cross-domain override only
+5. Do not reuse `steward-author-a` verbatim for every lane. Lane identity must
+   remain explicit in the launched session prompt/profile.
+6. Keep a rollback path to the legacy tmux layout until the new layout survives
+   at least one dual-domain proving run.
+
+## Why The Original One-Shot Cutover Was Too Risky
+
+The earlier plan understated the scope in three ways:
+
+1. Renaming the whole pool to `plat-*` / `brws-*` would rewrite the canonical
+   lane-identity contract across task validation, recovery, hooks, status, and
+   worktree tooling.
+2. Adding `TaskPacket.domain` without wiring it through the real intake path
+   would make routing decorative instead of real.
+3. Reusing `steward-author-a` for all workers would collapse prompt identity
+   and corrupt lane-local acknowledgements and reporting.
+
+This sub-plan keeps the full desired outcome but stages it so those risks are
+handled deliberately.
+
+## Implementation Sequence
+
+### PR 1 -- Domain routing contract
+
+Goal: make domain a real routing signal before any tmux cutover.
+
+Required work:
+- add `domain` to `TaskPacket`
+- add `--domain` to `ops.py task create`
+- add optional domain filtering to dashboard and worker-pool views
+- teach `delegate-task` and `steward-orchestrator` to carry domain
+- add domain metadata to lane registry entries
+- update `select_worker()` to support domain-aware routing
+
+Routing rule:
+- same-domain first
+- flex second
+- cross-domain only if the orchestrator explicitly overrides
+
+Likely files:
+- `src/bid_euchre/ops/task_queue.py`
+- `src/bid_euchre/ops/worker_pool.py`
+- `scripts/internal/ops.py`
+- `src/bid_euchre/ops/dashboard.py`
+- `.claude/skills/delegate-task/SKILL.md`
+- `.claude/agents/steward-orchestrator.md`
+
+### PR 2 -- Lane identity expansion
+
+Goal: introduce browser/flex lanes without breaking canonical identity.
+
+Required work:
+- widen canonical lane handling to include:
+  - `brws-author-a` through `brws-author-d`
+  - `flex-a` through `flex-c`
+- update status/recovery/hook/CI/worktree mapping surfaces that assume only
+  the current five author lanes
+- add explicit agent profiles for the new lanes, or create a shared author
+  contract plus distinct lane-identity wrappers
+- update worktree protection rules
+
+Likely files:
+- `src/bid_euchre/ops/task_queue.py`
+- `src/bid_euchre/ops/worker_pool.py`
+- `src/bid_euchre/ops/worktrees.py`
+- `src/bid_euchre/ops/status.py`
+- `src/bid_euchre/ops/recovery.py`
+- `.claude/hooks/post-task-event.sh`
+- `scripts/internal/ci_poller.sh`
+- `.claude/agents/*`
+- `.claude/agents/README.md`
+- `.claude/rules/75_worktree_protection.md`
+
+### PR 3 -- tmux launcher and worktree cutover
+
+Goal: make the new layout the operator-facing default while preserving a
+rollback path.
+
+Required work:
+- rewrite `steward-session.sh` for the new 4-window tiled layout
+- add browser/flex worktree creation
+- add `issues` pane in the central control window
+- preserve a legacy launcher path or toggle for immediate rollback
+- extend session/bootstrap tests
+
+Likely files:
+- `.claude/tmux/steward-session.sh`
+- `tests/unit/test_steward_session.py`
+- `.claude/rules/75_worktree_protection.md`
+
+## Scope Lock
+
+### Code / runtime
+
+- `src/bid_euchre/ops/task_queue.py`
+- `src/bid_euchre/ops/worker_pool.py`
+- `src/bid_euchre/ops/worktrees.py`
+- `src/bid_euchre/ops/status.py`
+- `src/bid_euchre/ops/recovery.py`
+- `src/bid_euchre/ops/dashboard.py`
+- `scripts/internal/ops.py`
+- `scripts/internal/ci_poller.sh`
+
+### Prompt / skill / hook surface
+
+- `.claude/agents/steward-orchestrator.md`
+- `.claude/agents/README.md`
+- new or updated worker lane agent files under `.claude/agents/`
+- `.claude/skills/delegate-task/SKILL.md`
+- `.claude/hooks/post-task-event.sh`
+
+### Infrastructure / bootstrap
+
+- `.claude/tmux/steward-session.sh`
+- `.claude/rules/75_worktree_protection.md`
+
+### Tests
+
+- `tests/unit/test_ops_worker_pool.py`
+- `tests/unit/test_steward_session.py`
+- any narrow adjacent unit coverage needed for lane mapping or routing
+
+## Validation
+
+### Automated
+
+```bash
+uv run python -m pytest \
+  tests/unit/test_ops_worker_pool.py \
+  tests/unit/test_steward_session.py -x
+
+make check-quiet
+```
+
+### Manual proving
+
+1. Start the new steward session in detached mode.
+2. Confirm all central lanes and both worker pools register correctly.
+3. Dispatch one platform task and verify it stays in the platform pool.
+4. Dispatch one browser-game task and verify it stays in the browser pool.
+5. Dispatch one overflow task and verify flex is preferred before
+   cross-domain reuse.
+6. Confirm centralized `ops` and `review` can monitor both streams without
+   pane archaeology.
+7. Confirm the legacy launcher can still be used if the cutover regresses.
+
+## Acceptance Criteria
+
+- [ ] domain is stored on task packets and supplied through the normal
+      orchestrator / CLI intake path
+- [ ] worker selection honors same-domain -> flex -> explicit override
+- [ ] the platform pool keeps `author-a` through `author-d` identities
+- [ ] browser and flex lanes have explicit lane identities
+- [ ] one central ops/review/orchestrator surface can supervise both domains
+- [ ] the new tmux layout boots cleanly in detached mode
+- [ ] the legacy layout remains available as rollback until proving is done
+
+## Out Of Scope
+
+- Remote-channel work (`Platform-8`, `Platform-9`)
+- Browser-game feature implementation
+- cmux transport adoption
+- multi-orchestrator arbitration
+- domain-specific capability prompts that diverge behaviorally from the shared
+  author contract
+
+## Risks / Smoothing Actions
+
+### Main risks
+
+- contract churn from widening lane identity too broadly in one pass
+- routing drift if domain is not carried through the real intake flow
+- operator confusion if the layout changes before filtered views and routing do
+- prompt identity drift if new lanes do not have explicit lane-local identity
+
+### Required smoothing actions
+
+- ship the work in three PRs, not one
+- preserve the legacy launcher until a dual-domain proving run passes
+- keep cross-domain fallback explicit, not automatic
+- land routing before layout
+- prove one real platform task plus one real browser-game task before retiring
+  any old worktrees

--- a/plans/agent_ops/3_supervision_and_scaling/sub/2026-03-22_phase3-closeout-and-transition-entry.md
+++ b/plans/agent_ops/3_supervision_and_scaling/sub/2026-03-22_phase3-closeout-and-transition-entry.md
@@ -1,0 +1,138 @@
+<!-- review-tier: medium -->
+# Phase 3 Closeout And Transition Entry
+
+**ID:** SP-3-04
+**Date:** 2026-03-22
+**Parent:** `plans/agent_ops/governing_plan.md` -- Phase 3 (`3_supervision_and_scaling`), Step 5
+**Status:** completed
+**Owner:** author-scratch
+
+---
+
+## Goal
+
+Durably close Phase 3 now that Batch D and BD-004 are resolved, reconcile the
+stale planning state, and hand off the next governed action as the
+dual-domain steward layout transition package that will run before any
+Platform-8 implementation work starts.
+
+## Why This Exists
+
+Phase 3 runtime work is effectively done, but the durable planning state still
+lags shipped reality:
+
+- `checkpoints.md` still says Step 5 is blocked on BD-004
+- `plan.md` still shows `Platform-7` as pending
+- `sub_plan_registry.md` does not yet reflect all Phase 3 sub-plans
+
+This sub-plan closes that gap and makes the next step explicit so the browser-
+game and platform tracks can proceed from durable repo state rather than chat.
+
+## Inputs
+
+- `plans/agent_ops/governing_plan.md`
+- `plans/agent_ops/amendments.md`
+- `plans/agent_ops/sub_plan_registry.md`
+- `plans/agent_ops/3_supervision_and_scaling/plan.md`
+- `plans/agent_ops/3_supervision_and_scaling/checkpoints.md`
+- `plans/agent_ops/3_supervision_and_scaling/qa_log.md`
+- `plans/agent_ops/3_supervision_and_scaling/sub/2026-03-22_platform7-worker-pool-manager.md`
+- `plans/agent_ops/3_supervision_and_scaling/sub/2026-03-22_bd004-v1-pane-delivery.md`
+- GitHub issue `#1259` (BD-004) -- CLOSED
+- PR `#1260` (Batch D docs update) -- MERGED
+- PR `#1261` (BD-001/BD-002/BD-003 fix line) -- MERGED
+
+## Done When
+
+1. Phase 3 checkpoints no longer show BD-004 as an active blocker.
+2. Phase 3 plan reflects `Platform-7` and Batch D as complete.
+3. The sub-plan registry reflects the Phase 3 sub-plan set accurately enough
+   that a new session can resume from files alone.
+4. The governing plan and amendments record the post-Phase-3 dual-domain
+   layout transition as the next governed action before Platform-8.
+5. The next operational step is unambiguous:
+   - first the layout transition package
+   - then Platform-8 scope lock
+
+## Work Items
+
+### Step 1 -- Reconcile Phase 3 durable state
+
+Update:
+- `plans/agent_ops/3_supervision_and_scaling/checkpoints.md`
+- `plans/agent_ops/3_supervision_and_scaling/plan.md`
+- `plans/agent_ops/sub_plan_registry.md`
+
+Required corrections:
+- remove the lingering BD-004 block from Step 5
+- mark Step 5 `COMPLETE` once the closeout PR lands
+- mark `Platform-7` complete in `plan.md`
+- mark the Batch D pass-gate checklist complete
+- reconcile `SP-3-02`, `SP-3-03`, and this closeout plan entry
+
+### Step 2 -- Record the transition package as the next governed action
+
+Update:
+- `plans/agent_ops/governing_plan.md`
+- `plans/agent_ops/amendments.md`
+
+Required note:
+- the dual-domain steward layout refactor is a bounded transition package
+  between Phase 3 and Platform-8
+- it does not renumber the platform roadmap
+- it exists to support parallel platform + browser-game work while preserving
+  centralized control
+
+### Step 3 -- Hand off the next action cleanly
+
+The Phase 3 closeout PR should point directly at:
+- `SP-3-05` (dual-domain steward layout transition)
+
+It should also say explicitly:
+- Platform-8 planning has not started yet
+- browser-game work may proceed after the transition package is in place
+- residual non-blocking debt stays as debt, not as a hidden Phase 3 blocker
+
+## Scope Lock
+
+- `plans/agent_ops/governing_plan.md`
+- `plans/agent_ops/amendments.md`
+- `plans/agent_ops/sub_plan_registry.md`
+- `plans/agent_ops/3_supervision_and_scaling/plan.md`
+- `plans/agent_ops/3_supervision_and_scaling/checkpoints.md`
+- `plans/agent_ops/3_supervision_and_scaling/qa_log.md` if cross-references need cleanup
+
+## Validation
+
+```bash
+rg -n "BD-004|Step 5|Platform-7|SP-3-02|SP-3-03|SP-3-04|SP-3-05" \
+  plans/agent_ops/3_supervision_and_scaling/plan.md \
+  plans/agent_ops/3_supervision_and_scaling/checkpoints.md \
+  plans/agent_ops/sub_plan_registry.md \
+  plans/agent_ops/governing_plan.md \
+  plans/agent_ops/amendments.md
+
+make check-quiet
+```
+
+## Acceptance Criteria
+
+- [ ] `checkpoints.md` no longer says Phase 3 exit is blocked on BD-004
+- [ ] `plan.md` no longer shows `Platform-7` as pending
+- [ ] `sub_plan_registry.md` includes the relevant Phase 3 sub-plans
+- [ ] the governing plan records the layout transition as the next step before
+      Platform-8
+- [ ] a fresh operator can determine the next action from repo state only
+
+## Out Of Scope
+
+- Implementing the dual-domain layout transition itself
+- Starting Platform-8 scope lock
+- Starting browser-game feature work
+- Reopening Batch D proving
+
+## Risks / Notes
+
+- The main failure mode is leaving the repo in a half-closed state where
+  runtime reality says Phase 3 is done but the plan says it is not. This
+  sub-plan exists specifically to avoid that drift.

--- a/plans/agent_ops/amendments.md
+++ b/plans/agent_ops/amendments.md
@@ -1,7 +1,7 @@
 # Agentic Orchestration Platform — Amendments
 
 **Governing plan:** `plans/agent_ops/governing_plan.md`
-**Last updated:** 2026-03-22
+**Last updated:** 2026-03-22 (SP-3-04 closeout)
 
 ---
 
@@ -177,3 +177,30 @@ clean upgrade path to Claude Channels once remote-channel prerequisites exist,
 and treat `cmux` as a later transport/presentation upgrade rather than as
 control-plane truth. Recording the full ladder now prevents future slices from
 re-litigating the same architectural boundary.
+
+---
+
+## A7 — Phase 3 closeout and dual-domain transition entry (2026-03-22)
+
+**PR:** SP-3-04 closeout PR
+
+**What changed:**
+1. **Phase 3 durably closed** — All planning state (checkpoints, plan, QA log,
+   sub-plan registry, governing plan) reconciled to reflect Phase 3 completion.
+   BD-004 marked fixed (PR #1263), BD-001/BD-002/BD-003 marked fixed (PR #1261).
+   Platform-7 marked COMPLETE. Batch D pass gate checklist fully checked.
+2. **No active numbered phase** — The governing plan checkpoint contract now
+   states that no numbered phase is currently active. Phase 4 and Phase 5 are
+   both unblocked but not yet entered.
+3. **Dual-domain transition entry recorded** — SP-3-05 registered as a proposed
+   sub-plan for the dual-domain steward layout transition. This is a bounded
+   transition package between Phase 3 and Platform-8, not a new numbered phase.
+   It enables concurrent platform and browser-game development.
+4. **Next governed action made explicit** — The sequence is: SP-3-05 (layout
+   transition), then Phase 4 scope lock. Browser-game work may proceed after
+   the transition package is in place.
+
+**Rationale:** Phase 3 runtime work was complete but durable planning state
+lagged behind shipped reality. This amendment closes that gap and establishes
+the dual-domain layout transition as the next governed action, preventing
+future sessions from having to reconstruct intent from chat history.

--- a/plans/agent_ops/governing_plan.md
+++ b/plans/agent_ops/governing_plan.md
@@ -101,8 +101,11 @@ Each active phase maintains a checkpoint file at:
 
 Current active phase:
 
-- Phase 4 (`4_remote_channel`) and Phase 5 (`5_portability_and_learning`) are
-  both unblocked and ready for entry (both depend on Phase 3).
+- No numbered phase is currently active. The next governed action is the
+  post-Phase-3 dual-domain layout transition (SP-3-05), followed by
+  Phase 4 scope lock. Phase 4 (`4_remote_channel`) and Phase 5
+  (`5_portability_and_learning`) are both unblocked and ready for entry
+  (both depend on Phase 3, which is COMPLETE).
 
 Completed phases:
 

--- a/plans/agent_ops/sub_plan_registry.md
+++ b/plans/agent_ops/sub_plan_registry.md
@@ -1,7 +1,7 @@
 # Sub-Plan Registry — Agentic Orchestration Platform
 
 **Governing plan:** `plans/agent_ops/governing_plan.md`
-**Last updated:** 2026-03-22 by author-b (SP-3-03 completed, Phase 3 COMPLETE)
+**Last updated:** 2026-03-22 by author-scratch (SP-3-04 closeout)
 
 ---
 
@@ -19,15 +19,17 @@
 | SP-2-03 | Agent frontmatter hardening | Phase 2 post-Batch-C follow-up (Amendment A3) | completed | author-b | `plans/agent_ops/2_visible_operating_model/sub/2026-03-22_agent-frontmatter-hardening.md` | 2026-03-22 | 2026-03-22 (PR #1239) |
 | SP-3-02 | Platform-7 worker pool manager | Phase 3 Platform-7 implementation | completed | author-d | `plans/agent_ops/3_supervision_and_scaling/sub/2026-03-22_platform7-worker-pool-manager.md` | 2026-03-22 | 2026-03-22 (PR #1250, #1252) |
 | SP-3-03 | BD-004 v1 pane delivery adapter | Phase 3 BD-004 exit gate fix | completed | author-a | `plans/agent_ops/3_supervision_and_scaling/sub/2026-03-22_bd004-v1-pane-delivery.md` | 2026-03-22 | 2026-03-22 (PR #1263) |
+| SP-3-04 | Phase 3 closeout and transition entry | Phase 3 durable state reconciliation | completed | author-scratch | `plans/agent_ops/3_supervision_and_scaling/sub/2026-03-22_phase3-closeout-and-transition-entry.md` | 2026-03-22 | 2026-03-22 |
+| SP-3-05 | Dual-domain steward layout transition | Post-Phase-3 transition package before Platform-8 | proposed | TBD | `plans/agent_ops/3_supervision_and_scaling/sub/2026-03-22_dual-domain-steward-layout-transition.md` | 2026-03-22 | -- |
 
 ## Status Summary
 
 | Status | Count |
 |--------|-------|
-| proposed | 0 |
+| proposed | 1 |
 | in_progress | 0 |
 | blocked | 0 |
-| completed | 9 |
+| completed | 10 |
 | abandoned | 0 |
 | superseded | 1 |
 


### PR DESCRIPTION
## Summary

- Reconcile all stale Phase 3 planning state to match shipped reality
- Mark Phase 3 COMPLETE across checkpoints, plan, QA log, sub-plan registry, and governing plan
- Record the dual-domain steward layout transition (SP-3-05) as the next governed action before Platform-8

## What was reconciled

| File | Change |
|------|--------|
| `checkpoints.md` | Step 5 → COMPLETE, BD-004 blocker removed, session log added |
| `plan.md` | Phase Status → COMPLETE, Platform-7 → COMPLETE, Batch D checklist → all checked, sub-plans table updated |
| `qa_log.md` | BD-001–BD-004 → fixed (PRs #1261, #1263), BD-005 remains open (INFO) |
| `sub_plan_registry.md` | SP-3-03 completed, SP-3-04 completed, SP-3-05 proposed |
| `governing_plan.md` | No active phase; next action = SP-3-05 then Platform-8 |
| `amendments.md` | A7 entry for Phase 3 closeout and transition |

## Why

Phase 3 runtime work was done (BD-004 closed, all PRs merged) but durable planning state lagged reality. A fresh operator reading repo state would see stale blockers and pending steps. This PR fixes that.

## Next governed action

1. **SP-3-05** — Dual-domain steward layout transition (3 PRs: routing contract, lane identity expansion, tmux cutover)
2. **Platform-8 scope lock** — only after SP-3-05 lands

## Validation

- `rg` consistency check for BD-004/Step 5/Platform-7/SP-3-0x references
- `make check-quiet` passes
- Docs-only PR — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)