### PR TITLE
ops: add domain routing contract for dual-domain worker pools (SP-3-05)

### DIFF
--- a/.claude/agents/steward-orchestrator.md
+++ b/.claude/agents/steward-orchestrator.md
@@ -50,16 +50,31 @@ When creating a task packet, always specify:
 - **scope_declared:** File patterns that will be touched
 - **validation:** Commands the author must run (e.g., specific test files)
 - **priority:** low / normal / high
+- **domain:** Execution domain — `platform` or `browser-game`. Controls
+  which worker pool the task routes to. Omit for domain-agnostic work.
+
+## Domain Routing
+
+Worker selection honors domain affinity:
+1. **Same-domain** lanes first (e.g., platform task → platform worker)
+2. **Flex** lanes second (lanes with no fixed domain, e.g., author-scratch)
+3. **Cross-domain** only with explicit `allow_cross_domain` override
+
+Current lane-domain assignments:
+- `author-a` through `author-d`: **platform**
+- `author-scratch`: **flex** (no domain)
+- Future `brws-author-*` lanes: **browser-game**
 
 ## Delegation Guidelines
 
-| Task Type | Preview Required | Suggested Lane |
-|-----------|-----------------|----------------|
-| Single-file bugfix | No | Any idle author |
-| Multi-file feature | Yes | author-a or author-b |
-| Architectural change | Yes + plan review | author-a |
-| Exploratory analysis | No | author-scratch |
-| Overflow / parallel work | Yes | author-c or author-d |
+| Task Type | Preview Required | Suggested Lane | Domain |
+|-----------|-----------------|----------------|--------|
+| Single-file bugfix | No | Any idle author | Infer from scope |
+| Multi-file feature | Yes | author-a or author-b | platform |
+| Architectural change | Yes + plan review | author-a | platform |
+| Exploratory analysis | No | author-scratch | (flex) |
+| Overflow / parallel work | Yes | author-c or author-d | Match source |
+| Browser-game work | Yes | brws-author-* (future) | browser-game |
 
 ## Status Inspection
 

--- a/.claude/skills/delegate-task/SKILL.md
+++ b/.claude/skills/delegate-task/SKILL.md
@@ -27,6 +27,8 @@ intake-to-dispatch flow into a reusable workflow.
    - **scope_declared:** File patterns that will be touched
    - **validation:** Commands the author must run (e.g., specific test files)
    - **priority:** low / normal / high
+   - **domain:** Execution domain for routing — `platform` or `browser-game`.
+     Determines which worker pool the task routes to. Omit for flex/unspecified.
 
 2. **Choose the target lane** using the delegation guidelines:
 
@@ -63,7 +65,9 @@ intake-to-dispatch flow into a reusable workflow.
      --description "<description with acceptance criteria>" \
      --owner "<lane>" \
      --priority "<priority>" \
-     --scope-declared "<comma-separated file patterns>"
+     --domain "<platform|browser-game>" \
+     --scope "<file-pattern>" \
+     --scope "<another-pattern>"
    ```
 
 7. **Verify dispatch:**

--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -32,7 +32,7 @@ Usage:
     uv run python scripts/internal/ops.py skills promote CANDIDATE_ID [--json]
     uv run python scripts/internal/ops.py skills disable NAME [--reason TEXT] [--disabled-by LANE] [--json]
     uv run python scripts/internal/ops.py repairs [--json]
-    uv run python scripts/internal/ops.py task list [--status STATUS] [--owner LANE] [--json]
+    uv run python scripts/internal/ops.py task list [--status STATUS] [--owner LANE] [--domain DOMAIN] [--json]
     uv run python scripts/internal/ops.py task show PACKET_ID [--json]
     uv run python scripts/internal/ops.py task approve PACKET_ID [--json]
     uv run python scripts/internal/ops.py inbox [--lane LANE] [--status STATUS] [--type TYPE] [--thread THREAD] [--json]
@@ -1418,6 +1418,7 @@ def cmd_task(args: argparse.Namespace) -> int:
             task_queue_root,
             status_filter=args.status,
             owner_filter=args.owner,
+            domain_filter=getattr(args, "domain", None),
         )
         if args.json:
             from dataclasses import asdict
@@ -1461,6 +1462,8 @@ def cmd_task(args: argparse.Namespace) -> int:
             print(f"  Status:      {pkt.status}")
             print(f"  Owner:       {pkt.owner or '(unassigned)'}")
             print(f"  Priority:    {pkt.priority}")
+            if pkt.domain:
+                print(f"  Domain:      {pkt.domain}")
             print(f"  Created by:  {pkt.created_by}")
             print(f"  Created at:  {pkt.created_at}")
             print(f"  Description: {pkt.description}")
@@ -1494,6 +1497,7 @@ def cmd_task(args: argparse.Namespace) -> int:
             description=args.description or "",
             owner=args.owner,
             priority=args.priority,
+            domain=getattr(args, "domain", None),
             scope_declared=args.scope_declared,
             validation=args.validation,
         )
@@ -1507,6 +1511,8 @@ def cmd_task(args: argparse.Namespace) -> int:
             print(f"  Title:    {pkt.title}")
             print(f"  Owner:    {pkt.owner or '(unassigned)'}")
             print(f"  Priority: {pkt.priority}")
+            if pkt.domain:
+                print(f"  Domain:   {pkt.domain}")
             if pkt.scope_declared:
                 print(f"  Scope:    {', '.join(pkt.scope_declared)}")
             if pkt.validation:
@@ -2202,6 +2208,9 @@ def build_parser() -> argparse.ArgumentParser:
         "--status", default=None, help="Filter by packet status"
     )
     task_list_parser.add_argument("--owner", default=None, help="Filter by owner lane")
+    task_list_parser.add_argument(
+        "--domain", default=None, help="Filter by execution domain"
+    )
 
     task_show_parser = task_sub.add_parser("show", help="Show a task packet by ID")
     task_show_parser.add_argument("packet_id", help="The packet ID to show")
@@ -2221,6 +2230,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     task_create_parser.add_argument(
         "--description", default="", help="Full task description"
+    )
+    task_create_parser.add_argument(
+        "--domain",
+        default=None,
+        choices=["platform", "browser-game"],
+        help="Execution domain for routing (platform / browser-game)",
     )
     task_create_parser.add_argument(
         "--scope",

--- a/src/bid_euchre/ops/dashboard.py
+++ b/src/bid_euchre/ops/dashboard.py
@@ -551,9 +551,10 @@ def format_dashboard_text(
         lines.append(f"Task Queue: {tq['total']} packets")
         for pkt_info in tq.get("packets", []):
             owner_str = pkt_info.get("owner") or "(unassigned)"
+            domain_str = f" [{pkt_info['domain']}]" if pkt_info.get("domain") else ""
             lines.append(
                 f"  [{pkt_info.get('status', '?')}] "
-                f"{pkt_info.get('title', '?')} -> {owner_str}"
+                f"{pkt_info.get('title', '?')} -> {owner_str}{domain_str}"
             )
 
     if view.warning_count > 0:

--- a/src/bid_euchre/ops/task_queue.py
+++ b/src/bid_euchre/ops/task_queue.py
@@ -47,6 +47,10 @@ VALID_STATUSES = frozenset(
 
 VALID_PRIORITIES = frozenset({"low", "normal", "high"})
 
+# Known execution domains for routing.  ``None`` means "unspecified" and
+# the orchestrator may assign one later.
+KNOWN_DOMAINS: frozenset[str] = frozenset({"platform", "browser-game"})
+
 VALID_ACK_ACTIONS = frozenset({"approve", "edit", "redirect", "reject"})
 
 VALID_RESULT_STATUSES = frozenset({"completed", "failed", "blocked"})
@@ -102,6 +106,7 @@ class TaskPacket:
     scope_declared: list[str] = field(default_factory=list)
     validation: list[str] = field(default_factory=list)
     priority: str = "normal"
+    domain: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -116,6 +121,10 @@ class TaskPacket:
         if self.owner is not None and self.owner not in KNOWN_AUTHOR_LANES:
             raise ValueError(
                 f"Unknown owner lane {self.owner!r}; expected one of {sorted(KNOWN_AUTHOR_LANES)}"
+            )
+        if self.domain is not None and self.domain not in KNOWN_DOMAINS:
+            raise ValueError(
+                f"Unknown domain {self.domain!r}; expected one of {sorted(KNOWN_DOMAINS)} or None"
             )
 
 
@@ -185,6 +194,7 @@ def create_packet(
     scope_declared: list[str] | None = None,
     validation: list[str] | None = None,
     priority: str = "normal",
+    domain: str | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> TaskPacket:
     """Create a new TaskPacket with generated ID and timestamp."""
@@ -199,6 +209,7 @@ def create_packet(
         scope_declared=scope_declared or [],
         validation=validation or [],
         priority=priority,
+        domain=domain,
         metadata=metadata or {},
     )
 
@@ -405,6 +416,7 @@ def list_packets(
     *,
     status_filter: str | None = None,
     owner_filter: str | None = None,
+    domain_filter: str | None = None,
 ) -> list[TaskPacket]:
     """List all active TaskPackets in the queue.
 
@@ -412,6 +424,7 @@ def list_packets(
         root: Override for the task queue root directory.
         status_filter: If set, only return packets with this status.
         owner_filter: If set, only return packets assigned to this lane.
+        domain_filter: If set, only return packets with this domain.
 
     Returns:
         List of TaskPacket instances, sorted by created_at ascending.
@@ -438,6 +451,8 @@ def list_packets(
         if status_filter and pkt.status != status_filter:
             continue
         if owner_filter and pkt.owner != owner_filter:
+            continue
+        if domain_filter and pkt.domain != domain_filter:
             continue
 
         packets.append(pkt)
@@ -559,6 +574,7 @@ def apply_ack(
             scope_declared=list(pkt.scope_declared),
             validation=list(pkt.validation),
             priority=pkt.priority,
+            domain=pkt.domain,
             metadata={
                 **pkt.metadata,
                 "redirected_from": ack.packet_id,
@@ -626,12 +642,15 @@ def queue_summary(root: Path | None = None) -> dict[str, Any]:
     packets = list_packets(root)
     by_status: dict[str, int] = {}
     by_owner: dict[str, int] = {}
+    by_domain: dict[str, int] = {}
     packet_summaries: list[dict[str, Any]] = []
 
     for pkt in packets:
         by_status[pkt.status] = by_status.get(pkt.status, 0) + 1
         owner_key = pkt.owner or "(unassigned)"
         by_owner[owner_key] = by_owner.get(owner_key, 0) + 1
+        domain_key = pkt.domain or "(unspecified)"
+        by_domain[domain_key] = by_domain.get(domain_key, 0) + 1
         packet_summaries.append(
             {
                 "packet_id": pkt.packet_id,
@@ -639,6 +658,7 @@ def queue_summary(root: Path | None = None) -> dict[str, Any]:
                 "status": pkt.status,
                 "owner": pkt.owner,
                 "priority": pkt.priority,
+                "domain": pkt.domain,
                 "created_at": pkt.created_at,
             }
         )
@@ -647,5 +667,6 @@ def queue_summary(root: Path | None = None) -> dict[str, Any]:
         "total": len(packets),
         "by_status": by_status,
         "by_owner": by_owner,
+        "by_domain": by_domain,
         "packets": packet_summaries,
     }

--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -60,6 +60,17 @@ DEFAULT_TMUX_SESSION: str = "steward"
 #: Pool status values.
 POOL_STATUSES: frozenset[str] = frozenset({"active", "idle", "parked", "retired"})
 
+#: Default domain assignment for each managed lane.
+#: Lanes with ``None`` are "flex" — available to any domain when same-domain
+#: lanes are exhausted.
+LANE_DOMAINS: dict[str, str | None] = {
+    "author-a": "platform",
+    "author-b": "platform",
+    "author-c": "platform",
+    "author-d": "platform",
+    "author-scratch": None,  # flex
+}
+
 
 def _managed_lanes() -> frozenset[str]:
     """Return the set of lane IDs managed by the worker pool.
@@ -69,6 +80,11 @@ def _managed_lanes() -> frozenset[str]:
     from bid_euchre.ops.task_queue import KNOWN_AUTHOR_LANES
 
     return KNOWN_AUTHOR_LANES
+
+
+def get_lane_domain(lane_id: str) -> str | None:
+    """Return the configured domain for a lane, or None if flex/unknown."""
+    return LANE_DOMAINS.get(lane_id)
 
 
 # ---------------------------------------------------------------------------
@@ -88,6 +104,7 @@ class WorkerState:
     visibility: str  # "foreground", "background", "hidden"
     tmux_alive: bool  # whether the tmux pane/window exists and has a process
     session_handle: str | None
+    domain: str | None = None  # configured lane domain, None = flex
 
 
 @dataclass
@@ -415,6 +432,7 @@ def take_pool_snapshot(
                 visibility=visibility,
                 tmux_alive=tmux_alive,
                 session_handle=lane.session_handle,
+                domain=get_lane_domain(lane.lane_id),
             )
         )
         counts[pool_status] = counts.get(pool_status, 0) + 1
@@ -434,19 +452,33 @@ def select_worker(
     pool: PoolSnapshot,
     *,
     preferred_lane: str | None = None,
+    domain: str | None = None,
+    allow_cross_domain: bool = False,
 ) -> str | None:
-    """Choose the best lane for new work.
+    """Choose the best lane for new work, with optional domain routing.
 
-    Priority order:
-    1. preferred_lane (if idle or parked and healthy)
+    Priority order (within each tier, same-domain lanes are tried first,
+    then flex lanes, then cross-domain only if *allow_cross_domain* is set):
+
+    1. preferred_lane (if idle or parked and healthy, and domain-compatible)
     2. idle lanes (already running, no active task)
     3. parked lanes (need waking, but worktree exists)
     4. retired lanes (need full resume)
     5. None if at MAX_ACTIVE_AUTHORS
 
+    Domain routing rule:
+    - same-domain first (worker.domain == domain)
+    - flex second (worker.domain is None)
+    - cross-domain only if *allow_cross_domain* is True
+
+    When *domain* is None, all lanes are eligible (no domain filtering).
+
     Args:
         pool: Current pool snapshot.
         preferred_lane: Preferred lane ID, if any.
+        domain: Execution domain to route to (e.g. "platform", "browser-game").
+        allow_cross_domain: If True, allow routing to lanes in a different
+            domain when same-domain and flex lanes are exhausted.
 
     Returns:
         Lane ID or None if no capacity.
@@ -456,32 +488,60 @@ def select_worker(
 
     workers_by_id = {w.lane_id: w for w in pool.workers}
 
+    def _domain_compatible(w: WorkerState) -> bool:
+        """Check if a worker is compatible with the requested domain."""
+        if domain is None:
+            return True  # no domain preference — all lanes eligible
+        if w.domain == domain:
+            return True  # same domain
+        if w.domain is None:
+            return True  # flex lane
+        return allow_cross_domain  # cross-domain only if explicitly allowed
+
+    def _domain_sort_key(w: WorkerState) -> int:
+        """Sort key: same-domain (0) > flex (1) > cross-domain (2)."""
+        if domain is None:
+            return 0
+        if w.domain == domain:
+            return 0
+        if w.domain is None:
+            return 1
+        return 2
+
     # 1. Check preferred lane
     if preferred_lane and preferred_lane in workers_by_id:
         w = workers_by_id[preferred_lane]
-        if w.pool_status in ("idle", "parked", "retired"):
+        if w.pool_status in ("idle", "parked", "retired") and _domain_compatible(w):
             return preferred_lane
 
+    # Helper: filter, sort by domain preference, return first match
+    def _best_from(status: str) -> str | None:
+        candidates = [
+            w
+            for w in pool.workers
+            if w.pool_status == status
+            and w.health != "critical"
+            and _domain_compatible(w)
+        ]
+        if not candidates:
+            return None
+        candidates.sort(key=_domain_sort_key)
+        return candidates[0].lane_id
+
     # 2. Idle lanes (already running)
-    idle_workers = [
-        w for w in pool.workers if w.pool_status == "idle" and w.health != "critical"
-    ]
-    if idle_workers:
-        return idle_workers[0].lane_id
+    result = _best_from("idle")
+    if result:
+        return result
 
     # 3. Parked lanes
-    parked_workers = [
-        w for w in pool.workers if w.pool_status == "parked" and w.health != "critical"
-    ]
-    if parked_workers:
-        return parked_workers[0].lane_id
+    result = _best_from("parked")
+    if result:
+        return result
 
     # 4. Retired lanes
-    retired_workers = [
-        w for w in pool.workers if w.pool_status == "retired" and w.health != "critical"
-    ]
-    if retired_workers:
-        return retired_workers[0].lane_id
+    result = _best_from("retired")
+    if result:
+        return result
 
     return None
 
@@ -1061,10 +1121,11 @@ def format_pool_text(pool: PoolSnapshot) -> str:
         for w in pool.workers:
             tmux_str = "tmux:up" if w.tmux_alive else "tmux:down"
             task_str = f"  task:{w.current_task_id}" if w.current_task_id else ""
+            domain_str = f"  domain:{w.domain}" if w.domain else "  domain:flex"
             lines.append(
                 f"  {w.lane_id:15s} [{w.pool_status:8s}] "
                 f"health:{w.health:8s} vis:{w.visibility:10s} "
-                f"{tmux_str}{task_str}"
+                f"{tmux_str}{domain_str}{task_str}"
             )
     else:
         lines.append("  (no managed workers found)")

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -12,6 +12,7 @@ import pytest
 from bid_euchre.ops.worker_pool import (
     DEFAULT_TMUX_SESSION,
     IDLE_PARK_MINUTES,
+    LANE_DOMAINS,
     MAX_ACTIVE_AUTHORS,
     PARKED_RETIRE_MINUTES,
     POOL_STATUSES,
@@ -29,6 +30,7 @@ from bid_euchre.ops.worker_pool import (
     format_actions_json,
     format_pool_json,
     format_pool_text,
+    get_lane_domain,
     nudge_pane,
     park_worker,
     retire_worker,
@@ -68,6 +70,7 @@ def _make_worker(
     visibility: str = "background",
     tmux_alive: bool = True,
     session_handle: str | None = None,
+    domain: str | None = None,
 ) -> WorkerState:
     """Create a WorkerState for testing."""
     return WorkerState(
@@ -79,6 +82,7 @@ def _make_worker(
         visibility=visibility,
         tmux_alive=tmux_alive,
         session_handle=session_handle,
+        domain=domain,
     )
 
 
@@ -440,6 +444,218 @@ class TestSelectWorker:
             ]
         )
         assert select_worker(pool, preferred_lane="author-b") == "author-b"
+
+
+# ---------------------------------------------------------------------------
+# Domain routing
+# ---------------------------------------------------------------------------
+
+
+class TestDomainRouting:
+    """Test domain-aware select_worker() routing."""
+
+    def test_get_lane_domain(self) -> None:
+        """get_lane_domain returns configured domain or None."""
+        assert get_lane_domain("author-a") == "platform"
+        assert get_lane_domain("author-scratch") is None
+        assert get_lane_domain("unknown-lane") is None
+
+    def test_lane_domains_constant(self) -> None:
+        """LANE_DOMAINS covers all known author lanes."""
+        from bid_euchre.ops.task_queue import KNOWN_AUTHOR_LANES
+
+        assert set(LANE_DOMAINS.keys()) == set(KNOWN_AUTHOR_LANES)
+
+    def test_same_domain_preferred(self) -> None:
+        """Same-domain lane selected over flex lane."""
+        pool = _make_pool(
+            [
+                _make_worker("author-scratch", "idle", domain=None),  # flex
+                _make_worker("author-a", "idle", domain="platform"),
+            ]
+        )
+        assert select_worker(pool, domain="platform") == "author-a"
+
+    def test_flex_used_when_no_same_domain(self) -> None:
+        """Flex lane selected when no same-domain lanes available."""
+        pool = _make_pool(
+            [
+                _make_worker(
+                    "author-a", "active", domain="platform", current_task_id="t1"
+                ),
+                _make_worker("author-scratch", "idle", domain=None),  # flex
+            ]
+        )
+        assert select_worker(pool, domain="platform") == "author-scratch"
+
+    def test_cross_domain_rejected_by_default(self) -> None:
+        """Cross-domain lanes not selected without allow_cross_domain."""
+        pool = _make_pool(
+            [
+                _make_worker("author-a", "idle", domain="platform"),
+            ]
+        )
+        assert select_worker(pool, domain="browser-game") is None
+
+    def test_cross_domain_allowed_with_override(self) -> None:
+        """Cross-domain lanes selected when allow_cross_domain=True."""
+        pool = _make_pool(
+            [
+                _make_worker("author-a", "idle", domain="platform"),
+            ]
+        )
+        result = select_worker(pool, domain="browser-game", allow_cross_domain=True)
+        assert result == "author-a"
+
+    def test_no_domain_selects_any(self) -> None:
+        """When domain=None, all lanes are eligible (backward compat)."""
+        pool = _make_pool(
+            [
+                _make_worker("author-a", "idle", domain="platform"),
+                _make_worker("author-b", "idle", domain="browser-game"),
+            ]
+        )
+        # Should pick first idle regardless of domain
+        assert select_worker(pool, domain=None) == "author-a"
+
+    def test_domain_routing_prefers_idle_same_domain_over_parked(self) -> None:
+        """Idle same-domain preferred over parked same-domain."""
+        pool = _make_pool(
+            [
+                _make_worker("author-a", "parked", domain="platform"),
+                _make_worker("author-b", "idle", domain="platform"),
+            ]
+        )
+        assert select_worker(pool, domain="platform") == "author-b"
+
+    def test_domain_routing_parked_same_domain_over_idle_flex(self) -> None:
+        """Parked same-domain NOT preferred over idle flex — idle tier wins."""
+        pool = _make_pool(
+            [
+                _make_worker("author-a", "parked", domain="platform"),
+                _make_worker("author-scratch", "idle", domain=None),
+            ]
+        )
+        # Idle (any domain-compatible) should beat parked
+        assert select_worker(pool, domain="platform") == "author-scratch"
+
+    def test_preferred_lane_domain_incompatible(self) -> None:
+        """Preferred lane skipped if domain-incompatible."""
+        pool = _make_pool(
+            [
+                _make_worker("author-a", "idle", domain="platform"),
+                _make_worker("author-b", "idle", domain="browser-game"),
+            ]
+        )
+        # author-b is browser-game, but we want platform — should skip it
+        result = select_worker(pool, preferred_lane="author-b", domain="platform")
+        assert result == "author-a"
+
+    def test_preferred_lane_domain_compatible(self) -> None:
+        """Preferred lane selected when domain-compatible."""
+        pool = _make_pool(
+            [
+                _make_worker("author-a", "idle", domain="platform"),
+                _make_worker("author-b", "idle", domain="platform"),
+            ]
+        )
+        result = select_worker(pool, preferred_lane="author-b", domain="platform")
+        assert result == "author-b"
+
+    def test_flex_preferred_lane(self) -> None:
+        """Flex preferred lane is domain-compatible with any domain."""
+        pool = _make_pool(
+            [
+                _make_worker("author-a", "idle", domain="platform"),
+                _make_worker("author-scratch", "idle", domain=None),
+            ]
+        )
+        result = select_worker(
+            pool, preferred_lane="author-scratch", domain="browser-game"
+        )
+        assert result == "author-scratch"
+
+    def test_worker_state_domain_field(self) -> None:
+        """WorkerState has domain field."""
+        w = _make_worker("author-a", "idle", domain="platform")
+        assert w.domain == "platform"
+        w_flex = _make_worker("author-scratch", "idle", domain=None)
+        assert w_flex.domain is None
+
+
+class TestTaskPacketDomain:
+    """Test domain field on TaskPacket."""
+
+    def test_create_packet_with_domain(self) -> None:
+        from bid_euchre.ops.task_queue import create_packet
+
+        pkt = create_packet("test", "desc", domain="platform")
+        assert pkt.domain == "platform"
+
+    def test_create_packet_without_domain(self) -> None:
+        from bid_euchre.ops.task_queue import create_packet
+
+        pkt = create_packet("test", "desc")
+        assert pkt.domain is None
+
+    def test_invalid_domain_rejected(self) -> None:
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        with pytest.raises(ValueError, match="Unknown domain"):
+            TaskPacket(
+                packet_id="x",
+                title="t",
+                description="d",
+                owner=None,
+                created_by="o",
+                created_at="now",
+                status="pending",
+                domain="invalid",
+            )
+
+    def test_list_packets_domain_filter(self, tmp_path: Path) -> None:
+        from bid_euchre.ops.task_queue import create_packet, list_packets, save_packet
+
+        root = tmp_path / "tq"
+        root.mkdir()
+        (root / "archive").mkdir()
+
+        p1 = create_packet("A", "desc", domain="platform")
+        p2 = create_packet("B", "desc", domain="browser-game")
+        p3 = create_packet("C", "desc")  # no domain
+        save_packet(p1, root)
+        save_packet(p2, root)
+        save_packet(p3, root)
+
+        plat = list_packets(root, domain_filter="platform")
+        assert len(plat) == 1
+        assert plat[0].domain == "platform"
+
+        brws = list_packets(root, domain_filter="browser-game")
+        assert len(brws) == 1
+        assert brws[0].domain == "browser-game"
+
+        all_pkts = list_packets(root)
+        assert len(all_pkts) == 3
+
+    def test_queue_summary_includes_domain(self, tmp_path: Path) -> None:
+        from bid_euchre.ops.task_queue import (
+            create_packet,
+            queue_summary,
+            save_packet,
+        )
+
+        root = tmp_path / "tq"
+        root.mkdir()
+        (root / "archive").mkdir()
+
+        p1 = create_packet("A", "desc", domain="platform")
+        save_packet(p1, root)
+
+        summary = queue_summary(root)
+        assert "by_domain" in summary
+        assert summary["by_domain"]["platform"] == 1
+        assert summary["packets"][0]["domain"] == "platform"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Plan
`plans/agent_ops/3_supervision_and_scaling/sub/2026-03-22_dual-domain-steward-layout-transition.md` §PR 1

## Summary
- Add `domain` field to `TaskPacket` with validation (`platform` / `browser-game`)
- Implement domain-aware `select_worker()` routing: same-domain → flex → cross-domain override
- Add `--domain` to ops.py CLI for task create/list, show domain in dashboard
- Update delegate-task skill and orchestrator agent docs for domain awareness
- 18 new tests covering domain routing, TaskPacket domain field, and filtering

## Why
Enables concurrent platform and browser-game development by making domain a
first-class routing signal in the task dispatch pipeline. This is the
foundation for PR 2 (lane identity expansion) and PR 3 (tmux launcher cutover)
in the dual-domain steward layout transition (SP-3-05).

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_worker_pool.py -x  # 103 passed
uv run python -m pytest tests/unit/test_ops_task_queue.py -x    # 64 passed
make check-quiet                                                 # All passed
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_worker_pool.py` (103 passed, 18 new)
- [x] `uv run python -m pytest tests/unit/test_ops_task_queue.py` (64 passed)
- [x] `make check-quiet` (full validation)

## Expected impact
- Metrics impact: None (ops tooling only)
- Runtime impact: None (new optional field, backward compatible)

## Risk level
- [x] Low (ops tooling + tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                                   fb312396 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author                    23b311f9 [ops/sp3-05-domain-routing]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)


🤖 Generated with [Claude Code](https://claude.com/claude-code)