### PR TITLE
ops: wire bidirectional message bus across all steward lanes (SP-3-07)

### DIFF
--- a/.claude/agents/steward-author-a.md
+++ b/.claude/agents/steward-author-a.md
@@ -50,14 +50,42 @@ clarification before starting.
 4. **PR** — open with worktree proof, repro command, and validation evidence
 5. **Handoff** — update checkpoints / MEMORY.md as appropriate
 
-## Progress Reporting
+## Message Bus
 
-Report progress to the orchestrator via bus messages
-(`src/bid_euchre/ops/message_bus.py` `send_message()`):
-- **ack** — task received and understood
-- **progress** — meaningful milestone reached (e.g., implementation done, tests passing)
-- **blocker** — cannot proceed without input or external resolution
-- **completion** — task done, PR opened or handoff recorded
+Use the message bus CLI to communicate with the orchestrator and other lanes.
+
+**Check inbox** (on startup or when nudged):
+```bash
+uv run python scripts/internal/ops.py inbox --lane author-a
+```
+
+**Acknowledge a message** (after reading an assignment):
+```bash
+uv run python scripts/internal/ops.py inbox ack <MSG_ID> --lane author-a
+```
+
+**Send progress updates** to the orchestrator:
+```bash
+# Task received and understood
+uv run python scripts/internal/ops.py message send \
+  --from author-a --to orchestrator --type ack \
+  --summary "Task received: <title>" --task-id <PACKET_ID>
+
+# Meaningful milestone (implementation done, tests passing)
+uv run python scripts/internal/ops.py message send \
+  --from author-a --to orchestrator --type progress \
+  --summary "Implementation complete, tests passing" --task-id <PACKET_ID>
+
+# Cannot proceed — needs input or external resolution
+uv run python scripts/internal/ops.py message send \
+  --from author-a --to orchestrator --type blocker \
+  --summary "Blocked: <reason>" --task-id <PACKET_ID>
+
+# Task done, PR opened
+uv run python scripts/internal/ops.py message send \
+  --from author-a --to orchestrator --type completion \
+  --summary "Done: PR #<N> opened" --task-id <PACKET_ID>
+```
 
 ## Dashboard Relationship
 

--- a/.claude/agents/steward-author-b.md
+++ b/.claude/agents/steward-author-b.md
@@ -50,14 +50,42 @@ clarification before starting.
 4. **PR** — open with worktree proof, repro command, and validation evidence
 5. **Handoff** — update checkpoints / MEMORY.md as appropriate
 
-## Progress Reporting
+## Message Bus
 
-Report progress to the orchestrator via bus messages
-(`src/bid_euchre/ops/message_bus.py` `send_message()`):
-- **ack** — task received and understood
-- **progress** — meaningful milestone reached (e.g., implementation done, tests passing)
-- **blocker** — cannot proceed without input or external resolution
-- **completion** — task done, PR opened or handoff recorded
+Use the message bus CLI to communicate with the orchestrator and other lanes.
+
+**Check inbox** (on startup or when nudged):
+```bash
+uv run python scripts/internal/ops.py inbox --lane author-b
+```
+
+**Acknowledge a message** (after reading an assignment):
+```bash
+uv run python scripts/internal/ops.py inbox ack <MSG_ID> --lane author-b
+```
+
+**Send progress updates** to the orchestrator:
+```bash
+# Task received and understood
+uv run python scripts/internal/ops.py message send \
+  --from author-b --to orchestrator --type ack \
+  --summary "Task received: <title>" --task-id <PACKET_ID>
+
+# Meaningful milestone (implementation done, tests passing)
+uv run python scripts/internal/ops.py message send \
+  --from author-b --to orchestrator --type progress \
+  --summary "Implementation complete, tests passing" --task-id <PACKET_ID>
+
+# Cannot proceed — needs input or external resolution
+uv run python scripts/internal/ops.py message send \
+  --from author-b --to orchestrator --type blocker \
+  --summary "Blocked: <reason>" --task-id <PACKET_ID>
+
+# Task done, PR opened
+uv run python scripts/internal/ops.py message send \
+  --from author-b --to orchestrator --type completion \
+  --summary "Done: PR #<N> opened" --task-id <PACKET_ID>
+```
 
 ## Dashboard Relationship
 

--- a/.claude/agents/steward-author-c.md
+++ b/.claude/agents/steward-author-c.md
@@ -50,14 +50,42 @@ clarification before starting.
 4. **PR** — open with worktree proof, repro command, and validation evidence
 5. **Handoff** — update checkpoints / MEMORY.md as appropriate
 
-## Progress Reporting
+## Message Bus
 
-Report progress to the orchestrator via bus messages
-(`src/bid_euchre/ops/message_bus.py` `send_message()`):
-- **ack** — task received and understood
-- **progress** — meaningful milestone reached (e.g., implementation done, tests passing)
-- **blocker** — cannot proceed without input or external resolution
-- **completion** — task done, PR opened or handoff recorded
+Use the message bus CLI to communicate with the orchestrator and other lanes.
+
+**Check inbox** (on startup or when nudged):
+```bash
+uv run python scripts/internal/ops.py inbox --lane author-c
+```
+
+**Acknowledge a message** (after reading an assignment):
+```bash
+uv run python scripts/internal/ops.py inbox ack <MSG_ID> --lane author-c
+```
+
+**Send progress updates** to the orchestrator:
+```bash
+# Task received
+uv run python scripts/internal/ops.py message send \
+  --from author-c --to orchestrator --type ack \
+  --summary "Task received: <title>" --task-id <PACKET_ID>
+
+# Milestone reached
+uv run python scripts/internal/ops.py message send \
+  --from author-c --to orchestrator --type progress \
+  --summary "Implementation complete, tests passing" --task-id <PACKET_ID>
+
+# Blocked
+uv run python scripts/internal/ops.py message send \
+  --from author-c --to orchestrator --type blocker \
+  --summary "Blocked: <reason>" --task-id <PACKET_ID>
+
+# Task done
+uv run python scripts/internal/ops.py message send \
+  --from author-c --to orchestrator --type completion \
+  --summary "Done: PR #<N> opened" --task-id <PACKET_ID>
+```
 
 ## Dashboard Relationship
 

--- a/.claude/agents/steward-author-d.md
+++ b/.claude/agents/steward-author-d.md
@@ -50,14 +50,42 @@ clarification before starting.
 4. **PR** — open with worktree proof, repro command, and validation evidence
 5. **Handoff** — update checkpoints / MEMORY.md as appropriate
 
-## Progress Reporting
+## Message Bus
 
-Report progress to the orchestrator via bus messages
-(`src/bid_euchre/ops/message_bus.py` `send_message()`):
-- **ack** — task received and understood
-- **progress** — meaningful milestone reached (e.g., implementation done, tests passing)
-- **blocker** — cannot proceed without input or external resolution
-- **completion** — task done, PR opened or handoff recorded
+Use the message bus CLI to communicate with the orchestrator and other lanes.
+
+**Check inbox** (on startup or when nudged):
+```bash
+uv run python scripts/internal/ops.py inbox --lane author-d
+```
+
+**Acknowledge a message** (after reading an assignment):
+```bash
+uv run python scripts/internal/ops.py inbox ack <MSG_ID> --lane author-d
+```
+
+**Send progress updates** to the orchestrator:
+```bash
+# Task received
+uv run python scripts/internal/ops.py message send \
+  --from author-d --to orchestrator --type ack \
+  --summary "Task received: <title>" --task-id <PACKET_ID>
+
+# Milestone reached
+uv run python scripts/internal/ops.py message send \
+  --from author-d --to orchestrator --type progress \
+  --summary "Implementation complete, tests passing" --task-id <PACKET_ID>
+
+# Blocked
+uv run python scripts/internal/ops.py message send \
+  --from author-d --to orchestrator --type blocker \
+  --summary "Blocked: <reason>" --task-id <PACKET_ID>
+
+# Task done
+uv run python scripts/internal/ops.py message send \
+  --from author-d --to orchestrator --type completion \
+  --summary "Done: PR #<N> opened" --task-id <PACKET_ID>
+```
 
 ## Dashboard Relationship
 

--- a/.claude/agents/steward-author-scratch.md
+++ b/.claude/agents/steward-author-scratch.md
@@ -48,6 +48,20 @@ When exploratory work is ready for implementation:
 3. A dedicated author lane picks up implementation
 4. This lane does not own the resulting PR
 
+## Message Bus
+
+Check your inbox and send messages via the bus CLI:
+
+```bash
+# Check inbox
+uv run python scripts/internal/ops.py inbox --lane author-scratch
+
+# Send findings to orchestrator for promotion
+uv run python scripts/internal/ops.py message send \
+  --from author-scratch --to orchestrator --type progress \
+  --summary "Exploration complete: <findings summary>"
+```
+
 ## Dashboard Relationship
 
 Author lanes are **background** by default in the dashboard-first layout.

--- a/.claude/agents/steward-ops.md
+++ b/.claude/agents/steward-ops.md
@@ -27,6 +27,26 @@ The dashboard shows foreground/background lanes, attention items, inbox
 highlights, and task queue state. Start here before drilling into individual
 lane details.
 
+## Message Bus
+
+Monitor bus health and inbox state as part of your periodic health checks:
+
+```bash
+# Inbox overview across all lanes (unresolved counts)
+uv run python scripts/internal/ops.py inbox stats
+
+# Check your own inbox
+uv run python scripts/internal/ops.py inbox --lane ops
+
+# Acknowledge a message
+uv run python scripts/internal/ops.py inbox ack <MSG_ID> --lane ops
+
+# Escalate an issue to the orchestrator
+uv run python scripts/internal/ops.py message send \
+  --from ops --to orchestrator --type escalation \
+  --summary "CI failure on PR #<N>, author lane unresponsive"
+```
+
 ## Periodic Health Check (every 10 minutes)
 
 On startup, schedule a recurring 10-minute monitoring loop using `/loop 10m`.

--- a/.claude/agents/steward-orchestrator.md
+++ b/.claude/agents/steward-orchestrator.md
@@ -110,6 +110,30 @@ with `/start-task <packet_id>`.
 
 The low-level `workers dispatch` command remains available for debugging only.
 
+## Message Bus
+
+Monitor author lane progress via the message bus:
+
+```bash
+# Check your inbox for author lane responses
+uv run python scripts/internal/ops.py inbox --lane orchestrator
+
+# Acknowledge a message
+uv run python scripts/internal/ops.py inbox ack <MSG_ID> --lane orchestrator
+
+# Send a message to an author lane
+uv run python scripts/internal/ops.py message send \
+  --from orchestrator --to <lane> --type <type> \
+  --summary "<summary>" --task-id <PACKET_ID>
+
+# Check all inbox stats
+uv run python scripts/internal/ops.py inbox stats
+```
+
+Message types used by the orchestrator: `assignment` (sent automatically
+during dispatch), `escalation` (urgent attention needed), `recovery`
+(remediation instructions).
+
 ## Status Inspection
 
 Use `uv run python scripts/internal/ops.py dashboard` for lane overview, or

--- a/.claude/agents/steward-review.md
+++ b/.claude/agents/steward-review.md
@@ -44,3 +44,20 @@ Rules:
 - If no findings or all findings are WARN/INFO, status is `passed`.
 - Never return `passed` when you cannot confidently assess the diff.
   Use `failed` with a reason instead.
+
+## Message Bus
+
+Check your inbox and report review results via the bus:
+
+```bash
+# Check inbox for review requests
+uv run python scripts/internal/ops.py inbox --lane review
+
+# Acknowledge a review request
+uv run python scripts/internal/ops.py inbox ack <MSG_ID> --lane review
+
+# Report review completion to orchestrator
+uv run python scripts/internal/ops.py message send \
+  --from review --to orchestrator --type completion \
+  --summary "Review passed: PR #<N>"
+```

--- a/.claude/skills/start-task/SKILL.md
+++ b/.claude/skills/start-task/SKILL.md
@@ -37,9 +37,21 @@ decomposition (use `/executing-plans` for that).
    uv run python scripts/internal/ops.py task list
    ```
 
-2. **Acknowledge the inbox message** (if dispatched via the bus):
-   Check your inbox for an assignment message and acknowledge it so the
-   orchestrator knows you received the task.
+2. **Check and acknowledge the inbox message** (if dispatched via the bus):
+   ```bash
+   # Check inbox for assignment messages (replace <LANE> with your lane ID)
+   uv run python scripts/internal/ops.py inbox --lane <LANE> --type assignment
+   ```
+   If there is an assignment message for this task, acknowledge it:
+   ```bash
+   uv run python scripts/internal/ops.py inbox ack <MSG_ID> --lane <LANE>
+   ```
+   Then send an ack message back to the orchestrator:
+   ```bash
+   uv run python scripts/internal/ops.py message send \
+     --from <LANE> --to orchestrator --type ack \
+     --summary "Task received: <title>" --task-id <PACKET_ID>
+   ```
 
 3. **Verify scope is clear:**
    - Are the file patterns in `scope_declared` specific enough?

--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -38,7 +38,9 @@ Usage:
     uv run python scripts/internal/ops.py task dispatch PACKET_ID LANE_ID [--approve] [--json]
     uv run python scripts/internal/ops.py inbox [--lane LANE] [--status STATUS] [--type TYPE] [--thread THREAD] [--json]
     uv run python scripts/internal/ops.py inbox stats [--json]
+    uv run python scripts/internal/ops.py inbox ack MSG_ID --lane LANE [--json]
     uv run python scripts/internal/ops.py message show MSG_ID [--json]
+    uv run python scripts/internal/ops.py message send --from LANE --to LANE --type TYPE --summary TEXT [--task-id ID] [--thread ID] [--json]
     uv run python scripts/internal/ops.py supervisor [--json] [--save] [--diff SNAPSHOT_PATH]
     uv run python scripts/internal/ops.py workers [--json]
     uv run python scripts/internal/ops.py workers wake LANE_ID [--json]
@@ -1579,14 +1581,37 @@ def cmd_task(args: argparse.Namespace) -> int:
 
 
 def cmd_inbox(args: argparse.Namespace) -> int:
-    """Communication bus inbox inspection (Platform-3)."""
-    from bid_euchre.ops.message_bus import inbox_stats, read_inbox
+    """Communication bus inbox inspection and acknowledgment (Platform-3)."""
+    from bid_euchre.ops.message_bus import ack_message, inbox_stats, read_inbox
 
     bus_root = args.runtime_dir / "message_bus"
 
     action = getattr(args, "inbox_action", None)
 
-    if action == "stats":
+    if action == "ack":
+        msg_id = getattr(args, "message_id", None)
+        lane = getattr(args, "lane", None)
+        if not msg_id or not lane:
+            print(
+                "Usage: ops.py inbox ack MSG_ID --lane LANE",
+                file=sys.stderr,
+            )
+            return 1
+        result = ack_message(msg_id, lane, bus_root)
+        if result is None:
+            print(
+                f"Message {msg_id!r} not found in {lane!r} inbox.",
+                file=sys.stderr,
+            )
+            return 1
+        if args.json:
+            print(json.dumps(result, indent=2, default=str))
+        else:
+            print(f"Acknowledged: {msg_id} in {lane} inbox")
+            print(f"  Status: {result.get('status', '?')}")
+        return 0
+
+    elif action == "stats":
         stats = inbox_stats(bus_root)
         if args.json:
             print(json.dumps(stats, indent=2))
@@ -1659,14 +1684,46 @@ def cmd_inbox(args: argparse.Namespace) -> int:
 
 
 def cmd_message(args: argparse.Namespace) -> int:
-    """Show details of a single message from the audit trail (Platform-3)."""
+    """Show or send messages via the audit trail (Platform-3)."""
     from bid_euchre.ops.message_bus import read_messages
 
     bus_root = args.runtime_dir / "message_bus"
 
     action = getattr(args, "message_action", None)
+
+    if action == "send":
+        from bid_euchre.ops.message_bus import create_message, send_message
+
+        msg = create_message(
+            from_lane=args.from_lane,
+            to_lane=args.to_lane,
+            message_type=args.msg_type,
+            summary=args.summary,
+            task_id=getattr(args, "task_id", None),
+            thread_id=getattr(args, "thread_id", None),
+        )
+        try:
+            msg_id = send_message(msg, bus_root)
+        except ValueError as exc:
+            print(f"Send failed: {exc}", file=sys.stderr)
+            return 1
+        if args.json:
+            from dataclasses import asdict
+
+            print(json.dumps(asdict(msg), indent=2, default=str))
+        else:
+            print(f"Sent message: {msg_id}")
+            print(f"  From:    {args.from_lane}")
+            print(f"  To:      {args.to_lane}")
+            print(f"  Type:    {args.msg_type}")
+            print(f"  Summary: {args.summary}")
+        return 0
+
     if action != "show":
-        print("Usage: ops.py message show MSG_ID", file=sys.stderr)
+        print(
+            "Usage: ops.py message {show|send} ...",
+            file=sys.stderr,
+        )
         return 1
 
     msg_id = args.message_id
@@ -2319,6 +2376,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     inbox_sub.add_parser("stats", help="Per-lane inbox statistics")
 
+    inbox_ack_parser = inbox_sub.add_parser("ack", help="Acknowledge an inbox message")
+    inbox_ack_parser.add_argument("message_id", help="The message ID to acknowledge")
+    inbox_ack_parser.add_argument(
+        "--lane", required=True, help="Lane whose inbox contains the message"
+    )
+
     inbox_parser.add_argument(
         "--lane", default=None, help="Show inbox for a specific lane"
     )
@@ -2334,6 +2397,39 @@ def build_parser() -> argparse.ArgumentParser:
 
     message_show_parser = message_sub.add_parser("show", help="Show a message by ID")
     message_show_parser.add_argument("message_id", help="The message ID to show")
+
+    message_send_parser = message_sub.add_parser(
+        "send", help="Send a message to another lane's inbox"
+    )
+    message_send_parser.add_argument(
+        "--from", required=True, dest="from_lane", help="Sender lane ID"
+    )
+    message_send_parser.add_argument(
+        "--to", required=True, dest="to_lane", help="Recipient lane ID"
+    )
+    message_send_parser.add_argument(
+        "--type",
+        required=True,
+        dest="msg_type",
+        choices=[
+            "ack",
+            "progress",
+            "blocker",
+            "completion",
+            "escalation",
+            "recovery",
+        ],
+        help="Message type",
+    )
+    message_send_parser.add_argument(
+        "--summary", required=True, help="One-line message summary"
+    )
+    message_send_parser.add_argument(
+        "--task-id", default=None, dest="task_id", help="Associated task packet ID"
+    )
+    message_send_parser.add_argument(
+        "--thread", default=None, dest="thread_id", help="Thread ID for conversation"
+    )
 
     # supervisor (Platform-6: supervisor routines and delta summaries)
     supervisor_parser = subparsers.add_parser(

--- a/tests/unit/test_ops_cli.py
+++ b/tests/unit/test_ops_cli.py
@@ -3290,3 +3290,157 @@ class TestCmdSupervisor:
         assert rc == 1
         captured = capsys.readouterr()
         assert "Error loading snapshot" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Message bus CLI (SP-3-07)
+# ---------------------------------------------------------------------------
+
+
+class TestMessageSend:
+    """Tests for ops.py message send subcommand."""
+
+    def test_message_send_basic(
+        self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import ops
+
+        # Ensure message_bus dir exists
+        (runtime_dir / "message_bus" / "inbox").mkdir(parents=True)
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "message",
+                "send",
+                "--from",
+                "author-a",
+                "--to",
+                "orchestrator",
+                "--type",
+                "ack",
+                "--summary",
+                "Task received: test",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Sent message:" in out
+        assert "author-a" in out
+
+    def test_message_send_json(
+        self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import ops
+
+        (runtime_dir / "message_bus" / "inbox").mkdir(parents=True)
+
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "message",
+                "send",
+                "--from",
+                "author-b",
+                "--to",
+                "orchestrator",
+                "--type",
+                "progress",
+                "--summary",
+                "Tests passing",
+                "--task-id",
+                "abc123",
+            ]
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["from_lane"] == "author-b"
+        assert data["to_lane"] == "orchestrator"
+        assert data["message_type"] == "progress"
+        assert data["task_id"] == "abc123"
+
+
+class TestInboxAck:
+    """Tests for ops.py inbox ack subcommand."""
+
+    def test_inbox_ack_not_found(
+        self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import ops
+
+        (runtime_dir / "message_bus" / "inbox").mkdir(parents=True)
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "inbox",
+                "ack",
+                "nonexistent_msg_id",
+                "--lane",
+                "author-a",
+            ]
+        )
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "not found" in err
+
+    def test_inbox_ack_roundtrip(
+        self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Send a message then ack it via CLI."""
+        import ops
+
+        (runtime_dir / "message_bus" / "inbox").mkdir(parents=True)
+
+        # First send a message
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "message",
+                "send",
+                "--from",
+                "orchestrator",
+                "--to",
+                "author-a",
+                "--type",
+                "ack",
+                "--summary",
+                "Test assignment",
+            ]
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        msg_id = data["message_id"]
+
+        # Now ack it
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "inbox",
+                "ack",
+                msg_id,
+                "--lane",
+                "author-a",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Acknowledged" in out
+        assert msg_id in out


### PR DESCRIPTION
## Plan
Task packet `1210b7364134` (SP-3-07: Wire bidirectional message bus across all steward lanes)

## Summary
- Add `inbox ack` and `message send` CLI subcommands to ops.py
- Update all 8 steward agent profiles with concrete message bus CLI commands
- Update start-task skill with inbox check and ack workflow
- Add 4 CLI tests for the new subcommands

## Why
The Platform-3 message bus infrastructure (send_message, read_inbox, ack_message)
was built but no lane actually used it — messages were write-only with no
read/ack/send surface exposed to agents. This PR wires every lane to participate
in bidirectional messaging, making task dispatch acknowledgment, progress
reporting, blocker escalation, and completion signaling actionable.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_cli.py -k "MessageSend or InboxAck" -x  # 4 passed
make check-quiet  # All passed
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_cli.py -k "MessageSend or InboxAck"` (4 passed)
- [x] `make check-quiet` (full validation)

## Expected impact
- Metrics impact: None (ops tooling + agent prompts only)
- Runtime impact: None (new CLI subcommands, no behavior change to existing code)

## Risk level
- [x] Low (ops tooling + prompt surface only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                    [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author     [ops/sp3-07-message-bus-wiring]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)


🤖 Generated with [Claude Code](https://claude.com/claude-code)