### PR TITLE
ops: add monitoring cycle with session-start auto-launch (SP-3-08)

### DIFF
--- a/.claude/agents/steward-ops.md
+++ b/.claude/agents/steward-ops.md
@@ -47,10 +47,29 @@ uv run python scripts/internal/ops.py message send \
   --summary "CI failure on PR #<N>, author lane unresponsive"
 ```
 
-## Periodic Health Check (every 10 minutes)
+## Automated Monitoring (SP-3-08)
 
-On startup, schedule a recurring 10-minute monitoring loop using `/loop 10m`.
-Report only when something changes or needs attention — skip if steady-state.
+On startup, schedule the automated monitoring loop:
+
+```
+/loop 3m uv run python scripts/internal/ops.py monitor
+```
+
+This runs a monitoring cycle every 3 minutes that:
+1. Takes a pool snapshot (lane health, tmux pane liveness)
+2. Checks open PRs for merge conflicts and failing CI
+3. Detects stale dispatched packets (unacked after 30 min)
+4. Sends structured findings to the orchestrator inbox
+
+High-severity findings (dead tmux panes, merge conflicts, stale dispatches)
+are sent with `priority=high` so the orchestrator sees them immediately.
+
+Use `--skip-pr-check` to disable the `gh` call (offline/testing).
+Use `--no-notify` to suppress inbox messages (dry run).
+
+## Manual Health Check
+
+For deeper investigation beyond the automated cycle:
 
 ### What to check
 

--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -276,6 +276,15 @@ tmux new-window -t "$SESSION" -n ops -c "$MAIN_DIR" \
 tmux new-window -t "$SESSION" -n review -c "$REVIEW" \
     "$CLAUDE_BIN" --name review --agent steward-review
 
+# Auto-launch ops monitoring loop (SP-3-08).
+# Wait briefly for the claude process to initialize, then send the /loop
+# command.  Best-effort — if it fails the ops agent can start it manually.
+(
+    sleep 10
+    tmux send-keys -t "${SESSION}:ops" \
+        "/loop 3m uv run python scripts/internal/ops.py monitor" Enter
+) &
+
 tmux select-window -t "${SESSION}:orchestrator"
 
 update_last_active

--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -42,6 +42,7 @@ Usage:
     uv run python scripts/internal/ops.py message show MSG_ID [--json]
     uv run python scripts/internal/ops.py message send --from LANE --to LANE --type TYPE --summary TEXT [--task-id ID] [--thread ID] [--json]
     uv run python scripts/internal/ops.py supervisor [--json] [--save] [--diff SNAPSHOT_PATH]
+    uv run python scripts/internal/ops.py monitor [--skip-pr-check] [--no-notify] [--json]
     uv run python scripts/internal/ops.py workers [--json]
     uv run python scripts/internal/ops.py workers wake LANE_ID [--json]
     uv run python scripts/internal/ops.py workers park LANE_ID [--json]
@@ -1824,6 +1825,33 @@ def cmd_supervisor(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_monitor(args: argparse.Namespace) -> int:
+    """Run a single ops monitoring cycle (SP-3-08)."""
+    from bid_euchre.ops.monitor import (
+        format_findings_json,
+        format_findings_text,
+        run_monitoring_cycle,
+    )
+
+    skip_pr = getattr(args, "skip_pr_check", False)
+    no_notify = getattr(args, "no_notify", False)
+
+    findings = run_monitoring_cycle(
+        runtime_dir=args.runtime_dir,
+        notify_orchestrator=not no_notify,
+        skip_pr_check=skip_pr,
+    )
+
+    if args.json:
+        print(json.dumps(format_findings_json(findings), indent=2))
+    else:
+        print(format_findings_text(findings))
+
+    # Exit 1 if any high-severity findings
+    has_high = any(f.severity == "high" for f in findings)
+    return 1 if has_high else 0
+
+
 def cmd_workers(args: argparse.Namespace) -> int:
     """Worker pool lifecycle management (Platform-7)."""
     from bid_euchre.ops.worker_pool import (
@@ -2449,6 +2477,21 @@ def build_parser() -> argparse.ArgumentParser:
         help="Path to a previous snapshot JSON file to diff against",
     )
 
+    # monitor (SP-3-08: ops monitoring cycle)
+    monitor_parser = subparsers.add_parser(
+        "monitor", help="Run a single ops monitoring cycle (SP-3-08)"
+    )
+    monitor_parser.add_argument(
+        "--skip-pr-check",
+        action="store_true",
+        help="Skip the gh pr list check (for testing or offline use)",
+    )
+    monitor_parser.add_argument(
+        "--no-notify",
+        action="store_true",
+        help="Do not send findings to the orchestrator inbox",
+    )
+
     # workers (Platform-7: worker pool lifecycle management)
     workers_parser = subparsers.add_parser(
         "workers", help="Worker pool lifecycle management (Platform-7)"
@@ -2539,6 +2582,7 @@ def main(argv: list[str] | None = None) -> int:
         "inbox": cmd_inbox,
         "message": cmd_message,
         "supervisor": cmd_supervisor,
+        "monitor": cmd_monitor,
         "workers": cmd_workers,
     }
 

--- a/src/bid_euchre/ops/monitor.py
+++ b/src/bid_euchre/ops/monitor.py
@@ -1,0 +1,498 @@
+"""Ops monitoring cycle (SP-3-08).
+
+Runs a single monitoring sweep across lane health, open PRs, CI status,
+and stale dispatched packets.  Produces structured findings that are
+optionally sent to the orchestrator inbox via the message bus.
+
+Usage::
+
+    from bid_euchre.ops.monitor import run_monitoring_cycle
+
+    findings = run_monitoring_cycle()
+    # findings is a list of MonitorFinding dataclasses
+
+The CLI wrapper (``ops.py monitor``) calls this and formats the output.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("ops.monitor")
+
+# A dispatched packet with no progress after this many minutes is flagged.
+STALE_DISPATCH_MINUTES: int = 30
+
+# Severity levels for findings.
+SEVERITY_INFO = "info"
+SEVERITY_WARN = "warn"
+SEVERITY_HIGH = "high"
+
+
+@dataclass(frozen=True)
+class MonitorFinding:
+    """A single finding from one monitoring sweep."""
+
+    category: str  # "lane_health", "pr_status", "ci_status", "stale_dispatch"
+    severity: str  # "info", "warn", "high"
+    summary: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Individual check functions
+# ---------------------------------------------------------------------------
+
+
+def check_lane_health(
+    runtime_dir: Path | None = None,
+) -> list[MonitorFinding]:
+    """Check lane pool health via a pool snapshot.
+
+    Flags:
+    - Lanes with ``pool_status == "active"`` but no tmux pane (degraded).
+    - Lanes marked critical by the supervisor.
+    - Summary of pool capacity.
+
+    Args:
+        runtime_dir: Override for the runtime directory root.
+
+    Returns:
+        List of findings.
+    """
+    findings: list[MonitorFinding] = []
+    try:
+        from bid_euchre.ops.worker_pool import take_pool_snapshot
+
+        pool = take_pool_snapshot(runtime_dir)
+    except Exception as exc:
+        findings.append(
+            MonitorFinding(
+                category="lane_health",
+                severity=SEVERITY_WARN,
+                summary=f"Could not take pool snapshot: {exc}",
+            )
+        )
+        return findings
+
+    for worker in pool.workers:
+        # Active lane with dead tmux pane
+        if worker.pool_status == "active" and not worker.tmux_alive:
+            findings.append(
+                MonitorFinding(
+                    category="lane_health",
+                    severity=SEVERITY_HIGH,
+                    summary=(
+                        f"Lane {worker.lane_id!r} is active but tmux pane is dead"
+                    ),
+                    details={
+                        "lane_id": worker.lane_id,
+                        "task_id": worker.current_task_id,
+                    },
+                )
+            )
+
+        # Critical health from supervisor
+        if worker.health == "critical":
+            findings.append(
+                MonitorFinding(
+                    category="lane_health",
+                    severity=SEVERITY_HIGH,
+                    summary=f"Lane {worker.lane_id!r} health is critical",
+                    details={"lane_id": worker.lane_id},
+                )
+            )
+
+    # Capacity summary (info)
+    findings.append(
+        MonitorFinding(
+            category="lane_health",
+            severity=SEVERITY_INFO,
+            summary=(
+                f"Pool: {pool.active_count} active, {pool.idle_count} idle, "
+                f"{pool.parked_count} parked, {pool.retired_count} retired, "
+                f"capacity={pool.available_capacity}"
+            ),
+            details={
+                "active": pool.active_count,
+                "idle": pool.idle_count,
+                "parked": pool.parked_count,
+                "retired": pool.retired_count,
+                "capacity": pool.available_capacity,
+            },
+        )
+    )
+
+    return findings
+
+
+def check_open_prs() -> list[MonitorFinding]:
+    """Check open PRs via ``gh pr list``.
+
+    Flags:
+    - PRs with failing checks.
+    - PRs with merge conflicts.
+    - Total count of open PRs.
+
+    Returns:
+        List of findings.
+    """
+    findings: list[MonitorFinding] = []
+
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--state",
+                "open",
+                "--json",
+                "number,title,headRefName,statusCheckRollup,mergeable",
+                "--limit",
+                "20",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            findings.append(
+                MonitorFinding(
+                    category="pr_status",
+                    severity=SEVERITY_WARN,
+                    summary=f"gh pr list failed: {result.stderr[:200]}",
+                )
+            )
+            return findings
+
+        prs = json.loads(result.stdout) if result.stdout.strip() else []
+    except (
+        FileNotFoundError,
+        subprocess.TimeoutExpired,
+        OSError,
+        json.JSONDecodeError,
+    ) as exc:
+        findings.append(
+            MonitorFinding(
+                category="pr_status",
+                severity=SEVERITY_WARN,
+                summary=f"Could not check PRs: {exc}",
+            )
+        )
+        return findings
+
+    if not prs:
+        findings.append(
+            MonitorFinding(
+                category="pr_status",
+                severity=SEVERITY_INFO,
+                summary="No open PRs.",
+            )
+        )
+        return findings
+
+    for pr in prs:
+        pr_num = pr.get("number", "?")
+        title = pr.get("title", "?")
+
+        # Check for merge conflicts
+        mergeable = pr.get("mergeable", "UNKNOWN")
+        if mergeable == "CONFLICTING":
+            findings.append(
+                MonitorFinding(
+                    category="pr_status",
+                    severity=SEVERITY_HIGH,
+                    summary=f"PR #{pr_num} has merge conflicts: {title}",
+                    details={
+                        "pr": pr_num,
+                        "title": title,
+                        "branch": pr.get("headRefName"),
+                    },
+                )
+            )
+
+        # Check for failing CI
+        checks = pr.get("statusCheckRollup") or []
+        failing = [
+            c
+            for c in checks
+            if c.get("conclusion") in ("FAILURE", "ERROR", "CANCELLED")
+        ]
+        if failing:
+            check_names = [c.get("name", "?") for c in failing[:3]]
+            findings.append(
+                MonitorFinding(
+                    category="ci_status",
+                    severity=SEVERITY_WARN,
+                    summary=(
+                        f"PR #{pr_num} has {len(failing)} failing check(s): "
+                        f"{', '.join(check_names)}"
+                    ),
+                    details={"pr": pr_num, "failing_checks": check_names},
+                )
+            )
+
+    # Summary
+    findings.append(
+        MonitorFinding(
+            category="pr_status",
+            severity=SEVERITY_INFO,
+            summary=f"{len(prs)} open PR(s).",
+            details={"count": len(prs)},
+        )
+    )
+
+    return findings
+
+
+def check_stale_dispatches(
+    runtime_dir: Path | None = None,
+    *,
+    stale_minutes: int = STALE_DISPATCH_MINUTES,
+    now: datetime | None = None,
+) -> list[MonitorFinding]:
+    """Check for dispatched task packets that have been idle too long.
+
+    A dispatched packet with no progress (ack or result) after
+    ``stale_minutes`` is flagged as potentially stuck.
+
+    Args:
+        runtime_dir: Override for the runtime directory root.
+        stale_minutes: Minutes after which a dispatched packet is flagged.
+        now: Override current time for testing.
+
+    Returns:
+        List of findings.
+    """
+    findings: list[MonitorFinding] = []
+
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    try:
+        from bid_euchre.ops.task_queue import list_packets, load_ack
+
+        if runtime_dir is None:
+            runtime_dir = Path(".claude/runtime")
+
+        task_queue_root = runtime_dir / "task_queue"
+        dispatched = list_packets(task_queue_root, status_filter="dispatched")
+    except Exception as exc:
+        findings.append(
+            MonitorFinding(
+                category="stale_dispatch",
+                severity=SEVERITY_WARN,
+                summary=f"Could not check dispatched packets: {exc}",
+            )
+        )
+        return findings
+
+    for pkt in dispatched:
+        # Check if there's an ack (indicates the lane received the task)
+        ack = load_ack(pkt.packet_id, task_queue_root)
+        if ack is not None:
+            # Has been acknowledged — not stale
+            continue
+
+        # Check dispatch time
+        try:
+            ts_str = pkt.created_at.replace("Z", "+00:00")
+            dispatch_time = datetime.fromisoformat(ts_str)
+            if dispatch_time.tzinfo is None:
+                dispatch_time = dispatch_time.replace(tzinfo=timezone.utc)
+            age_minutes = (now - dispatch_time).total_seconds() / 60.0
+        except (ValueError, TypeError):
+            age_minutes = 0.0
+
+        if age_minutes > stale_minutes:
+            findings.append(
+                MonitorFinding(
+                    category="stale_dispatch",
+                    severity=SEVERITY_HIGH,
+                    summary=(
+                        f"Packet {pkt.packet_id!r} dispatched to "
+                        f"{pkt.owner!r} has been unacked for "
+                        f"{age_minutes:.0f}min (threshold: {stale_minutes}min)"
+                    ),
+                    details={
+                        "packet_id": pkt.packet_id,
+                        "owner": pkt.owner,
+                        "title": pkt.title,
+                        "age_minutes": round(age_minutes),
+                    },
+                )
+            )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator notification
+# ---------------------------------------------------------------------------
+
+
+def _send_findings_to_orchestrator(
+    findings: list[MonitorFinding],
+    *,
+    bus_root: Path | None = None,
+) -> str | None:
+    """Send a monitoring summary to the orchestrator inbox.
+
+    If there are high-severity findings, the message priority is set to
+    ``high``. Otherwise it is ``normal``.
+
+    Args:
+        findings: The findings from the monitoring cycle.
+        bus_root: Override for the message bus root.
+
+    Returns:
+        The message_id if sent, or None on failure.
+    """
+    if not findings:
+        return None
+
+    from bid_euchre.ops.message_bus import create_message, send_message
+
+    has_high = any(f.severity == SEVERITY_HIGH for f in findings)
+    high_count = sum(1 for f in findings if f.severity == SEVERITY_HIGH)
+    warn_count = sum(1 for f in findings if f.severity == SEVERITY_WARN)
+    info_count = sum(1 for f in findings if f.severity == SEVERITY_INFO)
+
+    # Build summary line
+    if has_high:
+        summary = (
+            f"Monitor: {high_count} HIGH, {warn_count} warn, {info_count} info findings"
+        )
+    elif warn_count > 0:
+        summary = f"Monitor: {warn_count} warn, {info_count} info findings"
+    else:
+        summary = f"Monitor: {info_count} info findings (all nominal)"
+
+    # Build payload with structured findings
+    payload = {
+        "findings": [asdict(f) for f in findings],
+        "high_count": high_count,
+        "warn_count": warn_count,
+        "info_count": info_count,
+    }
+
+    priority = "high" if has_high else "normal"
+
+    msg = create_message(
+        from_lane="ops",
+        to_lane="orchestrator",
+        message_type="supervisor_alert",
+        summary=summary,
+        priority=priority,
+        payload=payload,
+    )
+
+    try:
+        return send_message(msg, bus_root)
+    except (ValueError, OSError) as exc:
+        logger.warning("Failed to send monitor summary: %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def run_monitoring_cycle(
+    runtime_dir: Path | None = None,
+    *,
+    now: datetime | None = None,
+    stale_minutes: int = STALE_DISPATCH_MINUTES,
+    notify_orchestrator: bool = True,
+    skip_pr_check: bool = False,
+) -> list[MonitorFinding]:
+    """Run a single monitoring sweep.
+
+    Collects findings from:
+    1. Lane pool health snapshot
+    2. Open PR status (via ``gh``)
+    3. Stale dispatched packet detection
+
+    Optionally sends a summary to the orchestrator inbox.
+
+    Args:
+        runtime_dir: Override for the runtime directory root.
+        now: Override current time for testing.
+        stale_minutes: Minutes after which a dispatched packet is flagged.
+        notify_orchestrator: If True, send findings to orchestrator inbox.
+        skip_pr_check: If True, skip the gh pr check (for testing).
+
+    Returns:
+        List of all findings from the sweep.
+    """
+    findings: list[MonitorFinding] = []
+
+    # 1. Lane health
+    findings.extend(check_lane_health(runtime_dir))
+
+    # 2. Open PRs and CI
+    if not skip_pr_check:
+        findings.extend(check_open_prs())
+
+    # 3. Stale dispatched packets
+    findings.extend(
+        check_stale_dispatches(runtime_dir, stale_minutes=stale_minutes, now=now)
+    )
+
+    # 4. Notify orchestrator
+    if notify_orchestrator:
+        _send_findings_to_orchestrator(findings)
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Formatters
+# ---------------------------------------------------------------------------
+
+_SEVERITY_MARKERS = {
+    SEVERITY_HIGH: "!!",
+    SEVERITY_WARN: "! ",
+    SEVERITY_INFO: "  ",
+}
+
+
+def format_findings_text(findings: list[MonitorFinding]) -> str:
+    """Format findings as human-readable text."""
+    if not findings:
+        return "Monitor: no findings."
+
+    high = [f for f in findings if f.severity == SEVERITY_HIGH]
+    warn = [f for f in findings if f.severity == SEVERITY_WARN]
+    info = [f for f in findings if f.severity == SEVERITY_INFO]
+
+    lines: list[str] = []
+    lines.append(
+        f"=== Monitor Cycle: {len(high)} HIGH, {len(warn)} warn, {len(info)} info ==="
+    )
+
+    for f in findings:
+        marker = _SEVERITY_MARKERS.get(f.severity, "  ")
+        lines.append(f"  [{marker}] [{f.category}] {f.summary}")
+
+    return "\n".join(lines)
+
+
+def format_findings_json(findings: list[MonitorFinding]) -> dict[str, Any]:
+    """Format findings as a JSON-serializable dict."""
+    return {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "total": len(findings),
+        "high": sum(1 for f in findings if f.severity == SEVERITY_HIGH),
+        "warn": sum(1 for f in findings if f.severity == SEVERITY_WARN),
+        "info": sum(1 for f in findings if f.severity == SEVERITY_INFO),
+        "findings": [asdict(f) for f in findings],
+    }

--- a/tests/unit/test_ops_monitor.py
+++ b/tests/unit/test_ops_monitor.py
@@ -1,0 +1,445 @@
+"""Tests for ops monitoring cycle (SP-3-08)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from bid_euchre.ops.monitor import (
+    SEVERITY_HIGH,
+    SEVERITY_INFO,
+    SEVERITY_WARN,
+    MonitorFinding,
+    check_lane_health,
+    check_open_prs,
+    check_stale_dispatches,
+    format_findings_json,
+    format_findings_text,
+    run_monitoring_cycle,
+)
+
+# ---------------------------------------------------------------------------
+# check_lane_health tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckLaneHealth:
+    """Tests for lane health checking."""
+
+    def test_returns_capacity_summary(self, tmp_path: Path) -> None:
+        """Always includes a capacity info summary."""
+        pool_mock = MagicMock()
+        pool_mock.workers = []
+        pool_mock.active_count = 0
+        pool_mock.idle_count = 2
+        pool_mock.parked_count = 1
+        pool_mock.retired_count = 0
+        pool_mock.available_capacity = 5
+
+        with patch(
+            "bid_euchre.ops.worker_pool.take_pool_snapshot",
+            return_value=pool_mock,
+        ):
+            findings = check_lane_health(tmp_path)
+
+        info_findings = [f for f in findings if f.severity == SEVERITY_INFO]
+        assert len(info_findings) == 1
+        assert "capacity=5" in info_findings[0].summary
+
+    def test_flags_active_lane_with_dead_tmux(self, tmp_path: Path) -> None:
+        """Active lane with dead tmux pane is flagged HIGH."""
+        worker = MagicMock()
+        worker.lane_id = "author-a"
+        worker.pool_status = "active"
+        worker.tmux_alive = False
+        worker.current_task_id = "pkt123"
+        worker.health = "healthy"
+
+        pool_mock = MagicMock()
+        pool_mock.workers = [worker]
+        pool_mock.active_count = 1
+        pool_mock.idle_count = 0
+        pool_mock.parked_count = 0
+        pool_mock.retired_count = 0
+        pool_mock.available_capacity = 4
+
+        with patch(
+            "bid_euchre.ops.worker_pool.take_pool_snapshot",
+            return_value=pool_mock,
+        ):
+            findings = check_lane_health(tmp_path)
+
+        high_findings = [f for f in findings if f.severity == SEVERITY_HIGH]
+        assert len(high_findings) == 1
+        assert "author-a" in high_findings[0].summary
+        assert "dead" in high_findings[0].summary
+
+    def test_flags_critical_health(self, tmp_path: Path) -> None:
+        """Critical supervisor health is flagged HIGH."""
+        worker = MagicMock()
+        worker.lane_id = "author-b"
+        worker.pool_status = "idle"
+        worker.tmux_alive = True
+        worker.current_task_id = None
+        worker.health = "critical"
+
+        pool_mock = MagicMock()
+        pool_mock.workers = [worker]
+        pool_mock.active_count = 0
+        pool_mock.idle_count = 1
+        pool_mock.parked_count = 0
+        pool_mock.retired_count = 0
+        pool_mock.available_capacity = 5
+
+        with patch(
+            "bid_euchre.ops.worker_pool.take_pool_snapshot",
+            return_value=pool_mock,
+        ):
+            findings = check_lane_health(tmp_path)
+
+        high_findings = [f for f in findings if f.severity == SEVERITY_HIGH]
+        assert len(high_findings) == 1
+        assert "critical" in high_findings[0].summary
+
+    def test_handles_snapshot_failure(self, tmp_path: Path) -> None:
+        """Gracefully handles pool snapshot failure."""
+        with patch(
+            "bid_euchre.ops.worker_pool.take_pool_snapshot",
+            side_effect=RuntimeError("no registry"),
+        ):
+            findings = check_lane_health(tmp_path)
+
+        assert len(findings) == 1
+        assert findings[0].severity == SEVERITY_WARN
+        assert "snapshot" in findings[0].summary
+
+
+# ---------------------------------------------------------------------------
+# check_open_prs tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckOpenPRs:
+    """Tests for PR status checking."""
+
+    def test_no_open_prs(self) -> None:
+        """Reports info when no PRs are open."""
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = "[]"
+
+        with patch("subprocess.run", return_value=result):
+            findings = check_open_prs()
+
+        assert len(findings) == 1
+        assert findings[0].severity == SEVERITY_INFO
+        assert "No open PRs" in findings[0].summary
+
+    def test_flags_conflicting_pr(self) -> None:
+        """Conflicting PR is flagged HIGH."""
+        prs = [
+            {
+                "number": 42,
+                "title": "Fix something",
+                "headRefName": "fix/something",
+                "mergeable": "CONFLICTING",
+                "statusCheckRollup": [],
+            }
+        ]
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = json.dumps(prs)
+
+        with patch("subprocess.run", return_value=result):
+            findings = check_open_prs()
+
+        high = [f for f in findings if f.severity == SEVERITY_HIGH]
+        assert len(high) == 1
+        assert "merge conflicts" in high[0].summary
+        assert "#42" in high[0].summary
+
+    def test_flags_failing_checks(self) -> None:
+        """Failing CI checks are flagged WARN."""
+        prs = [
+            {
+                "number": 99,
+                "title": "Big feature",
+                "headRefName": "feat/big",
+                "mergeable": "MERGEABLE",
+                "statusCheckRollup": [
+                    {"name": "tests", "conclusion": "FAILURE"},
+                    {"name": "lint", "conclusion": "SUCCESS"},
+                ],
+            }
+        ]
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = json.dumps(prs)
+
+        with patch("subprocess.run", return_value=result):
+            findings = check_open_prs()
+
+        warn = [f for f in findings if f.severity == SEVERITY_WARN]
+        assert len(warn) == 1
+        assert "tests" in warn[0].summary
+
+    def test_handles_gh_failure(self) -> None:
+        """Gracefully handles gh command failure."""
+        result = MagicMock()
+        result.returncode = 1
+        result.stderr = "not authenticated"
+
+        with patch("subprocess.run", return_value=result):
+            findings = check_open_prs()
+
+        assert len(findings) == 1
+        assert findings[0].severity == SEVERITY_WARN
+
+    def test_handles_gh_not_found(self) -> None:
+        """Gracefully handles gh not being installed."""
+        with patch("subprocess.run", side_effect=FileNotFoundError("gh")):
+            findings = check_open_prs()
+
+        assert len(findings) == 1
+        assert findings[0].severity == SEVERITY_WARN
+
+
+# ---------------------------------------------------------------------------
+# check_stale_dispatches tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckStaleDispatches:
+    """Tests for stale dispatch detection."""
+
+    def test_no_dispatched_packets(self, tmp_path: Path) -> None:
+        """No dispatched packets produces no findings."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        with patch(
+            "bid_euchre.ops.task_queue.list_packets",
+            return_value=[],
+        ):
+            findings = check_stale_dispatches(runtime_dir)
+
+        assert len(findings) == 0
+
+    def test_fresh_unacked_packet_not_flagged(self, tmp_path: Path) -> None:
+        """A recently-dispatched unacked packet is not flagged."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        now = datetime(2026, 3, 23, 12, 0, 0, tzinfo=timezone.utc)
+        pkt = MagicMock()
+        pkt.packet_id = "pkt001"
+        pkt.owner = "author-a"
+        pkt.title = "Fresh task"
+        pkt.created_at = "2026-03-23T11:45:00Z"  # 15 min ago
+
+        with (
+            patch("bid_euchre.ops.task_queue.list_packets", return_value=[pkt]),
+            patch("bid_euchre.ops.task_queue.load_ack", return_value=None),
+        ):
+            findings = check_stale_dispatches(runtime_dir, now=now)
+
+        assert len(findings) == 0
+
+    def test_stale_unacked_packet_flagged(self, tmp_path: Path) -> None:
+        """A dispatched packet unacked for >30min is flagged HIGH."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        now = datetime(2026, 3, 23, 12, 0, 0, tzinfo=timezone.utc)
+        pkt = MagicMock()
+        pkt.packet_id = "pkt002"
+        pkt.owner = "author-b"
+        pkt.title = "Stale task"
+        pkt.created_at = "2026-03-23T11:00:00Z"  # 60 min ago
+
+        with (
+            patch("bid_euchre.ops.task_queue.list_packets", return_value=[pkt]),
+            patch("bid_euchre.ops.task_queue.load_ack", return_value=None),
+        ):
+            findings = check_stale_dispatches(runtime_dir, now=now)
+
+        assert len(findings) == 1
+        assert findings[0].severity == SEVERITY_HIGH
+        assert "pkt002" in findings[0].summary
+        assert "60" in findings[0].summary
+
+    def test_acked_packet_not_flagged(self, tmp_path: Path) -> None:
+        """A dispatched packet that has been acked is not flagged."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        now = datetime(2026, 3, 23, 12, 0, 0, tzinfo=timezone.utc)
+        pkt = MagicMock()
+        pkt.packet_id = "pkt003"
+        pkt.owner = "author-a"
+        pkt.title = "Acked task"
+        pkt.created_at = "2026-03-23T10:00:00Z"  # 120 min ago
+
+        ack_mock = MagicMock()
+
+        with (
+            patch("bid_euchre.ops.task_queue.list_packets", return_value=[pkt]),
+            patch("bid_euchre.ops.task_queue.load_ack", return_value=ack_mock),
+        ):
+            findings = check_stale_dispatches(runtime_dir, now=now)
+
+        assert len(findings) == 0
+
+    def test_custom_stale_threshold(self, tmp_path: Path) -> None:
+        """Custom stale_minutes threshold is respected."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        now = datetime(2026, 3, 23, 12, 0, 0, tzinfo=timezone.utc)
+        pkt = MagicMock()
+        pkt.packet_id = "pkt004"
+        pkt.owner = "author-c"
+        pkt.title = "Threshold test"
+        pkt.created_at = "2026-03-23T11:50:00Z"  # 10 min ago
+
+        with (
+            patch("bid_euchre.ops.task_queue.list_packets", return_value=[pkt]),
+            patch("bid_euchre.ops.task_queue.load_ack", return_value=None),
+        ):
+            # With 5-min threshold, should be flagged
+            findings = check_stale_dispatches(runtime_dir, now=now, stale_minutes=5)
+
+        assert len(findings) == 1
+        assert findings[0].severity == SEVERITY_HIGH
+
+
+# ---------------------------------------------------------------------------
+# run_monitoring_cycle tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunMonitoringCycle:
+    """Tests for the full monitoring cycle."""
+
+    def test_combines_all_checks(self, tmp_path: Path) -> None:
+        """Cycle combines lane health, PR, and stale dispatch findings."""
+        pool_mock = MagicMock()
+        pool_mock.workers = []
+        pool_mock.active_count = 0
+        pool_mock.idle_count = 0
+        pool_mock.parked_count = 0
+        pool_mock.retired_count = 0
+        pool_mock.available_capacity = 5
+
+        with (
+            patch(
+                "bid_euchre.ops.worker_pool.take_pool_snapshot",
+                return_value=pool_mock,
+            ),
+            patch("bid_euchre.ops.task_queue.list_packets", return_value=[]),
+            patch(
+                "bid_euchre.ops.monitor._send_findings_to_orchestrator",
+                return_value="msg123",
+            ),
+        ):
+            findings = run_monitoring_cycle(
+                tmp_path,
+                skip_pr_check=True,
+                notify_orchestrator=True,
+            )
+
+        # Should have at least the capacity summary
+        categories = {f.category for f in findings}
+        assert "lane_health" in categories
+
+    def test_skip_pr_check(self, tmp_path: Path) -> None:
+        """skip_pr_check=True skips PR checking."""
+        pool_mock = MagicMock()
+        pool_mock.workers = []
+        pool_mock.active_count = 0
+        pool_mock.idle_count = 0
+        pool_mock.parked_count = 0
+        pool_mock.retired_count = 0
+        pool_mock.available_capacity = 5
+
+        with (
+            patch(
+                "bid_euchre.ops.worker_pool.take_pool_snapshot",
+                return_value=pool_mock,
+            ),
+            patch("bid_euchre.ops.task_queue.list_packets", return_value=[]),
+            patch("subprocess.run") as mock_run,
+        ):
+            findings = run_monitoring_cycle(
+                tmp_path,
+                skip_pr_check=True,
+                notify_orchestrator=False,
+            )
+
+        # subprocess.run should NOT have been called (no gh pr list)
+        mock_run.assert_not_called()
+        categories = {f.category for f in findings}
+        assert "pr_status" not in categories
+
+    def test_no_notify(self, tmp_path: Path) -> None:
+        """notify_orchestrator=False suppresses inbox messages."""
+        pool_mock = MagicMock()
+        pool_mock.workers = []
+        pool_mock.active_count = 0
+        pool_mock.idle_count = 0
+        pool_mock.parked_count = 0
+        pool_mock.retired_count = 0
+        pool_mock.available_capacity = 5
+
+        with (
+            patch(
+                "bid_euchre.ops.worker_pool.take_pool_snapshot",
+                return_value=pool_mock,
+            ),
+            patch("bid_euchre.ops.task_queue.list_packets", return_value=[]),
+            patch(
+                "bid_euchre.ops.monitor._send_findings_to_orchestrator"
+            ) as mock_notify,
+        ):
+            run_monitoring_cycle(
+                tmp_path,
+                skip_pr_check=True,
+                notify_orchestrator=False,
+            )
+
+        mock_notify.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Formatter tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatters:
+    """Tests for finding formatters."""
+
+    def test_format_text_empty(self) -> None:
+        assert "no findings" in format_findings_text([])
+
+    def test_format_text_with_findings(self) -> None:
+        findings = [
+            MonitorFinding("lane_health", SEVERITY_HIGH, "Lane dead"),
+            MonitorFinding("pr_status", SEVERITY_INFO, "2 open PRs"),
+        ]
+        text = format_findings_text(findings)
+        assert "1 HIGH" in text
+        assert "Lane dead" in text
+        assert "2 open PRs" in text
+
+    def test_format_json_structure(self) -> None:
+        findings = [
+            MonitorFinding("lane_health", SEVERITY_WARN, "Something"),
+        ]
+        data = format_findings_json(findings)
+        assert data["total"] == 1
+        assert data["warn"] == 1
+        assert data["high"] == 0
+        assert len(data["findings"]) == 1
+        assert data["findings"][0]["category"] == "lane_health"


### PR DESCRIPTION
## Summary

- Add `src/bid_euchre/ops/monitor.py` — new monitoring cycle module with `run_monitoring_cycle()` that sweeps lane health, PR status, and stale dispatches
- Add `ops.py monitor [--skip-pr-check] [--no-notify] [--json]` CLI subcommand
- Update `steward-ops.md` to use `/loop 3m` with the monitor command on session start
- Update `steward-session.sh` to auto-send `/loop 3m` to the ops pane on launch
- Add 20 unit tests covering all check functions, cycle integration, and formatters

## Why

SP-3-08: The steward ops lane needs an automated monitoring loop that proactively detects lane health issues (dead tmux panes, critical supervisor health), PR problems (merge conflicts, failing CI), and stale dispatches (unacked task packets). Findings are sent as structured `supervisor_alert` messages to the orchestrator inbox with `priority=high` for blockers, giving the orchestrator proactive visibility into system state.

## Monitoring Cycle

Each cycle:
1. **Pool snapshot** — flags active lanes with dead tmux panes, critical health
2. **PR check** — `gh pr list` for merge conflicts and failing CI checks
3. **Stale dispatch** — dispatched packets unacked after 30 min
4. **Inbox notify** — sends structured findings to orchestrator inbox

## Repro / Validation

```bash
# Tier 1: targeted tests (129 pass)
uv run python -m pytest tests/unit/test_ops_monitor.py tests/unit/test_ops_cli.py -x -q

# Tier 2: full validation
make check-quiet

# Manual smoke (skip PR check for offline, suppress inbox)
uv run python scripts/internal/ops.py monitor --skip-pr-check --no-notify
```

## Tests

- `uv run python -m pytest tests/unit/test_ops_monitor.py -x -q` — 20 passed
- `uv run python -m pytest tests/unit/test_ops_cli.py -x -q` — 109 passed
- `make check-quiet` — all checks passed

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: ops/sp3-08-ops-monitoring-loop
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)