### PR TITLE
docs: register SP-3-06/07/08 and update lane docs for dual-domain pools

### DIFF
--- a/.claude/agents/steward-orchestrator.md
+++ b/.claude/agents/steward-orchestrator.md
@@ -23,9 +23,9 @@ implementation work yourself.
    approval before dispatching.
 3. **Trivial tasks:** Single-file fixes, typo corrections, or previously
    approved patterns may be dispatched without preview.
-4. **Lane assignment:** Assign to existing author lanes only (author-a through
-   author-d, author-scratch). Check lane status before assigning — prefer
-   idle or least-loaded lanes.
+4. **Lane assignment:** Assign to a registered worker lane (see Domain Routing
+   below). Check lane status before assigning — prefer idle or least-loaded
+   lanes within the correct domain pool.
 5. **No self-execution:** You coordinate; authors execute. Do not write
    implementation code in this lane.
 6. **Scope lock:** Each task packet must declare its file scope and validation
@@ -70,9 +70,12 @@ Worker selection honors domain affinity:
 3. **Cross-domain** only with explicit `allow_cross_domain` override
 
 Current lane-domain assignments:
-- `author-a` through `author-d`: **platform**
-- `author-scratch`: **flex** (no domain)
-- Future `brws-author-*` lanes: **browser-game**
+
+| Pool | Lanes | Domain |
+|------|-------|--------|
+| Platform | `author-a`, `author-b`, `author-c`, `author-d` | `platform` |
+| Browser-game | `brws-author-a`, `brws-author-b`, `brws-author-c`, `brws-author-d` | `browser-game` |
+| Flex | `author-scratch`, `flex-a`, `flex-b`, `flex-c` | _(none — accepts any domain)_ |
 
 ## TUI Task Naming
 
@@ -89,12 +92,12 @@ all orchestrator-created tasks should follow this convention.
 
 | Task Type | Preview Required | Suggested Lane | Domain |
 |-----------|-----------------|----------------|--------|
-| Single-file bugfix | No | Any idle author | Infer from scope |
+| Single-file bugfix | No | Any idle author in matching pool | Infer from scope |
 | Multi-file feature | Yes | author-a or author-b | platform |
 | Architectural change | Yes + plan review | author-a | platform |
-| Exploratory analysis | No | author-scratch | (flex) |
-| Overflow / parallel work | Yes | author-c or author-d | Match source |
-| Browser-game work | Yes | brws-author-* (future) | browser-game |
+| Exploratory analysis | No | author-scratch or flex-* | (flex) |
+| Overflow / parallel work | Yes | author-c, author-d, or flex-* | Match source |
+| Browser-game work | Yes | brws-author-a through brws-author-d | browser-game |
 
 ## Dispatch
 
@@ -147,6 +150,7 @@ Use `uv run python scripts/internal/ops.py dashboard` for lane overview, or
 ## Constraints
 
 - Do not bypass the preview flow for non-trivial work
-- Do not assign to lanes that don't exist in the worktree registry
+- Do not assign to lanes that don't exist in the worktree registry (see
+  `.claude/rules/75_worktree_protection.md` for the canonical list)
 - Do not create tasks that span Platform-3 communication bus scope
 - Do not modify the task queue implementation itself from this lane

--- a/.claude/skills/delegate-task/SKILL.md
+++ b/.claude/skills/delegate-task/SKILL.md
@@ -22,8 +22,9 @@ intake-to-dispatch flow into a reusable workflow.
 1. **Create a TaskPacket** with these required fields:
    - **title:** Short imperative description (e.g., "Fix scoring edge case")
    - **description:** Full task description with acceptance criteria
-   - **owner:** Target author lane (author-a, author-b, author-c, author-d,
-     or author-scratch)
+   - **owner:** Target worker lane. Platform pool: `author-a` through
+     `author-d`. Browser-game pool: `brws-author-a` through `brws-author-d`.
+     Flex pool: `author-scratch`, `flex-a`, `flex-b`, `flex-c`.
    - **scope_declared:** File patterns that will be touched
    - **validation:** Commands the author must run (e.g., specific test files)
    - **priority:** low / normal / high
@@ -32,13 +33,14 @@ intake-to-dispatch flow into a reusable workflow.
 
 2. **Choose the target lane** using the delegation guidelines:
 
-   | Task Type | Preview Required | Suggested Lane |
-   |-----------|-----------------|----------------|
-   | Single-file bugfix | No | Any idle author |
-   | Multi-file feature | Yes | author-a or author-b |
-   | Architectural change | Yes + plan review | author-a |
-   | Exploratory analysis | No | author-scratch |
-   | Overflow / parallel work | Yes | author-c or author-d |
+   | Task Type | Preview Required | Suggested Lane | Domain |
+   |-----------|-----------------|----------------|--------|
+   | Single-file bugfix | No | Any idle author in matching pool | Infer |
+   | Multi-file feature | Yes | author-a or author-b | platform |
+   | Architectural change | Yes + plan review | author-a | platform |
+   | Exploratory analysis | No | author-scratch or flex-* | (flex) |
+   | Overflow / parallel work | Yes | author-c, author-d, or flex-* | Match source |
+   | Browser-game work | Yes | brws-author-a through brws-author-d | browser-game |
 
 3. **Check lane availability:**
    ```bash
@@ -93,7 +95,8 @@ intake-to-dispatch flow into a reusable workflow.
 
 - Do not bypass preview for non-trivial work — the user must see and approve
   the delegation before it happens
-- Do not assign to lanes that don't exist in the worktree registry
+- Do not assign to lanes that don't exist in the worktree registry (see
+  `.claude/rules/75_worktree_protection.md` for the canonical list)
 - If scope_declared is vague, tighten it before dispatching — authors should
   not have to guess their write boundary
 - The orchestrator coordinates; it does not execute implementation work itself

--- a/plans/agent_ops/3_supervision_and_scaling/plan.md
+++ b/plans/agent_ops/3_supervision_and_scaling/plan.md
@@ -108,6 +108,9 @@ Active sub-plans are tracked in `plans/agent_ops/sub_plan_registry.md`.
 | SP-3-03 | BD-004 v1 pane delivery | completed |
 | SP-3-04 | Phase 3 closeout and transition entry | completed |
 | SP-3-05 | Dual-domain steward layout transition | proposed |
+| SP-3-06 | Task dispatch CLI and execution-surface hardening | completed |
+| SP-3-07 | Bidirectional message bus across all steward lanes | completed |
+| SP-3-08 | Monitoring cycle with session-start auto-launch | completed |
 
 ## Step Sequence
 

--- a/plans/agent_ops/sub_plan_registry.md
+++ b/plans/agent_ops/sub_plan_registry.md
@@ -1,7 +1,7 @@
 # Sub-Plan Registry — Agentic Orchestration Platform
 
 **Governing plan:** `plans/agent_ops/governing_plan.md`
-**Last updated:** 2026-03-22 by author-scratch (SP-3-04 closeout)
+**Last updated:** 2026-03-23 by author-b (register SP-3-06/07/08)
 
 ---
 
@@ -21,6 +21,9 @@
 | SP-3-03 | BD-004 v1 pane delivery adapter | Phase 3 BD-004 exit gate fix | completed | author-a | `plans/agent_ops/3_supervision_and_scaling/sub/2026-03-22_bd004-v1-pane-delivery.md` | 2026-03-22 | 2026-03-22 (PR #1263) |
 | SP-3-04 | Phase 3 closeout and transition entry | Phase 3 durable state reconciliation | completed | author-scratch | `plans/agent_ops/3_supervision_and_scaling/sub/2026-03-22_phase3-closeout-and-transition-entry.md` | 2026-03-22 | 2026-03-22 |
 | SP-3-05 | Dual-domain steward layout transition | Post-Phase-3 transition package before Platform-8 | proposed | TBD | `plans/agent_ops/3_supervision_and_scaling/sub/2026-03-22_dual-domain-steward-layout-transition.md` | 2026-03-22 | -- |
+| SP-3-06 | Task dispatch CLI and execution-surface hardening | Post-Phase-3 transition: CLI dispatch, execution-surface rules | completed | orchestrator | _(no sub-plan file — single-PR scope)_ | 2026-03-23 | 2026-03-23 (PR #1275) |
+| SP-3-07 | Bidirectional message bus across all steward lanes | Post-Phase-3 transition: message bus wiring for 16-lane layout | completed | orchestrator | _(no sub-plan file — single-PR scope)_ | 2026-03-23 | 2026-03-23 (PR #1276) |
+| SP-3-08 | Monitoring cycle with session-start auto-launch | Post-Phase-3 transition: ops monitoring cycle and auto-launch | completed | orchestrator | _(no sub-plan file — single-PR scope)_ | 2026-03-23 | 2026-03-23 (PR #1277) |
 
 ## Status Summary
 
@@ -29,7 +32,7 @@
 | proposed | 1 |
 | in_progress | 0 |
 | blocked | 0 |
-| completed | 10 |
+| completed | 13 |
 | abandoned | 0 |
 | superseded | 1 |
 


### PR DESCRIPTION
## Plan
- Task packet `a470e75e4bf1` from orchestrator (Wave 1 pre-proving fix)
- Governing plan: `plans/agent_ops/governing_plan.md`

## Summary
- **Part A:** Register SP-3-06 (PR #1275), SP-3-07 (PR #1276), SP-3-08 (PR #1277) in `sub_plan_registry.md` and Phase 3 `plan.md` sub-plans table
- **Part B:** Replace narrow "author-a through author-d, author-scratch" lane assignment in `steward-orchestrator.md` with full 3-pool lane map (platform, browser-game, flex) and domain routing table; update `delegate-task/SKILL.md` to match

## Why
The post-Phase-3 transition shipped SP-3-06/07/08 without registering them in the durable plan trail. The orchestrator and delegation skill docs still referenced only the original 5 platform lanes, despite the codebase already supporting 16 lanes across 3 domain pools. This blocks the dual-domain proving run.

## Repro / Validation
**Command(s) run:**
```bash
# Validation 1: stale phrase removed
rg 'existing author lanes only' .claude/agents/
# → no matches (PASS)

# Validation 2: full suite
make check-quiet
# → ✓ All checks passed
```

## Tests
- [x] `make check-quiet` — all checks passed
- [x] No code changes — docs/plans only

## Expected impact
- Metrics impact: None (docs only)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git worktree list`:
```
Bid-Euchre                         464270e7 [main]
Bid-Euchre-steward-author-b        c3a37f3c [docs/register-sp306-08-update-lane-docs]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)