### PR TITLE
fix: dispatch copies packet JSON to target worktree task_queue

### DIFF
--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -45,8 +45,9 @@ logger = logging.getLogger("ops.worker_pool")
 # ---------------------------------------------------------------------------
 
 #: Maximum number of simultaneously active (non-idle) author lanes.
-#: Matches the 5 persistent author worktrees in steward-session.sh.
-MAX_ACTIVE_AUTHORS: int = 5
+#: Matches the dual-domain layout in steward-session.sh:
+#: 4 platform + 4 browser-game + 1 scratch + 3 flex = 12 worker lanes.
+MAX_ACTIVE_AUTHORS: int = 12
 
 #: Idle threshold (minutes) before a lane is eligible for parking.
 IDLE_PARK_MINUTES: int = 15
@@ -845,6 +846,8 @@ def dispatch_to_worker(
     2. Take pool snapshot, verify lane_id has capacity.
     3. If lane is parked/retired: wake_worker() first.
     4. Transition packet to "dispatched" with owner = lane_id.
+    4b. Copy dispatched packet JSON to the target worktree's task_queue
+        so the author lane can discover it via ``/start-task``.
     5. Write inbox message via message_bus (audit trail).
     6. Nudge the target pane with ``/start-task <packet_id>``.
     7. Record delivery outcome (update inbox message status).
@@ -966,6 +969,34 @@ def dispatch_to_worker(
             reason=f"Failed to transition packet: {exc}",
             executed=False,
             error="transition_failed",
+        )
+
+    # 4b. Copy dispatched packet to the target worktree's task_queue
+    #     so the author lane can discover it via /start-task.
+    worktree_path = _resolve_worktree_path(lane_id, runtime_dir)
+    if worktree_path:
+        wt_task_queue = Path(worktree_path) / ".claude" / "runtime" / "task_queue"
+        try:
+            wt_task_queue.mkdir(parents=True, exist_ok=True)
+            src_packet = task_queue_root / f"{packet_id}.json"
+            if src_packet.exists():
+                shutil.copy2(str(src_packet), str(wt_task_queue / f"{packet_id}.json"))
+                logger.info(
+                    "Copied packet %s to worktree task_queue at %s",
+                    packet_id,
+                    wt_task_queue,
+                )
+        except OSError as exc:
+            logger.warning(
+                "Failed to copy packet %s to worktree %s: %s",
+                packet_id,
+                worktree_path,
+                exc,
+            )
+    else:
+        logger.warning(
+            "Could not resolve worktree path for %s; packet not copied to worktree",
+            lane_id,
         )
 
     # 5. Write inbox message via message_bus

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -127,7 +127,7 @@ class TestConstants:
     """Test module-level constants."""
 
     def test_max_active_authors(self) -> None:
-        assert MAX_ACTIVE_AUTHORS == 5
+        assert MAX_ACTIVE_AUTHORS == 12
 
     def test_idle_park_minutes(self) -> None:
         assert IDLE_PARK_MINUTES == 15
@@ -401,9 +401,24 @@ class TestSelectWorker:
 
     def test_no_capacity(self) -> None:
         """At MAX_ACTIVE_AUTHORS, returns None."""
+        # Create 12 active workers to fill the dual-domain layout capacity
+        lane_ids = [
+            "author-a",
+            "author-b",
+            "author-c",
+            "author-d",
+            "author-scratch",
+            "brws-author-a",
+            "brws-author-b",
+            "brws-author-c",
+            "brws-author-d",
+            "flex-a",
+            "flex-b",
+            "flex-c",
+        ]
         workers = [
-            _make_worker(f"author-{c}", "active", current_task_id=f"t{i}")
-            for i, c in enumerate(["a", "b", "c", "d", "scratch"])
+            _make_worker(lid, "active", current_task_id=f"t{i}")
+            for i, lid in enumerate(lane_ids)
         ]
         pool = _make_pool(workers)
         assert pool.available_capacity == 0
@@ -1274,6 +1289,95 @@ class TestDispatchToWorker:
 
         # transition_status should receive task_queue subdir
         mock_transition.assert_called_once_with("pkt1", "dispatched", expected_tq)
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.transition_status")
+    @patch(f"{_TASK_QUEUE}.save_packet")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_copies_packet_to_worktree(
+        self,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_transition: MagicMock,
+        mock_snapshot: MagicMock,
+        mock_resolve_wt: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+        tmp_path: Path,
+    ) -> None:
+        """After dispatch, the packet JSON is copied to the worktree task_queue."""
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test",
+            description="Test task",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool([_make_worker("author-a", "idle")])
+
+        # Simulate the dispatched packet file that transition_status would write
+        tq_dir = runtime_dir / "task_queue"
+        tq_dir.mkdir(parents=True, exist_ok=True)
+        packet_file = tq_dir / "pkt1.json"
+        packet_file.write_text(
+            json.dumps({"packet_id": "pkt1", "status": "dispatched"})
+        )
+
+        # Set up a fake worktree directory
+        worktree_dir = tmp_path / "worktree-author-a"
+        worktree_dir.mkdir()
+        mock_resolve_wt.return_value = str(worktree_dir)
+
+        result = dispatch_to_worker("pkt1", "author-a", runtime_dir=runtime_dir)
+        assert result.executed is True
+
+        # Verify the packet was copied to the worktree's task_queue
+        wt_packet = worktree_dir / ".claude" / "runtime" / "task_queue" / "pkt1.json"
+        assert wt_packet.exists(), "Packet JSON should be copied to worktree task_queue"
+        copied_data = json.loads(wt_packet.read_text())
+        assert copied_data["packet_id"] == "pkt1"
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.transition_status")
+    @patch(f"{_TASK_QUEUE}.save_packet")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_succeeds_when_worktree_path_unresolved(
+        self,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_transition: MagicMock,
+        mock_snapshot: MagicMock,
+        mock_resolve_wt: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """Dispatch still succeeds even when worktree path cannot be resolved."""
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test",
+            description="Test task",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool([_make_worker("author-a", "idle")])
+        mock_resolve_wt.return_value = None  # worktree path not found
+
+        result = dispatch_to_worker("pkt1", "author-a", runtime_dir=runtime_dir)
+        # Dispatch should still succeed — copy is best-effort
+        assert result.executed is True
+        assert result.error is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Plan
N/A — operational fix from orchestrator task packet.

## Summary
- `dispatch_to_worker()` now copies the dispatched packet JSON to the target worktree's `.claude/runtime/task_queue/` directory after transitioning to "dispatched" status
- Updates `MAX_ACTIVE_AUTHORS` from 5 to 12 to match the dual-domain layout (4 platform + 4 browser-game + 1 scratch + 3 flex)
- Adds 2 new tests: packet copy to worktree, and graceful fallback when worktree path is unresolvable

## Why
Author worktrees couldn't find their dispatched task packets via `/start-task` because packets only existed in the main checkout's runtime directory. This fix ensures the packet JSON is available in the lane's own worktree.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_worker_pool.py -x  # 114 passed
make check-quiet  # All checks passed
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_worker_pool.py -x` (114 passed)
- [x] `make check-quiet` (all checks passed)

## Expected impact
- Metrics impact: none
- Runtime impact: one extra `shutil.copy2()` per dispatch (negligible)

## Risk level
- [x] Medium (ops infrastructure)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         464270e7 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c        1098d399 [fix/dispatch-copy-packet-to-worktree]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)