### PR TITLE
ops: add bulk-ack and TTL auto-expire to message bus

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -1583,7 +1583,12 @@ def cmd_task(args: argparse.Namespace) -> int:
 
 def cmd_inbox(args: argparse.Namespace) -> int:
     """Communication bus inbox inspection and acknowledgment (Platform-3)."""
-    from bid_euchre.ops.message_bus import ack_message, inbox_stats, read_inbox
+    from bid_euchre.ops.message_bus import (
+        ack_message,
+        bulk_ack_messages,
+        inbox_stats,
+        read_inbox,
+    )
 
     bus_root = args.runtime_dir / "message_bus"
 
@@ -1610,6 +1615,42 @@ def cmd_inbox(args: argparse.Namespace) -> int:
         else:
             print(f"Acknowledged: {msg_id} in {lane} inbox")
             print(f"  Status: {result.get('status', '?')}")
+        return 0
+
+    elif action == "ack-all":
+        import re
+
+        lane = getattr(args, "lane", None)
+        if not lane:
+            print(
+                "Usage: ops.py inbox ack-all --lane LANE [--filter-summary PATTERN]",
+                file=sys.stderr,
+            )
+            return 1
+        summary_pattern = getattr(args, "filter_summary", None)
+        if summary_pattern:
+            pat = re.compile(summary_pattern, re.IGNORECASE)
+
+            def filter_fn(msg: dict) -> bool:
+                return bool(pat.search(msg.get("summary", "")))
+        else:
+
+            def filter_fn(msg: dict) -> bool:
+                return True
+
+        acked = bulk_ack_messages(lane, filter_fn, bus_root)
+        if args.json:
+            print(json.dumps(acked, indent=2, default=str))
+        else:
+            if not acked:
+                print(f"No ack-able messages in {lane} inbox.")
+            else:
+                print(f"Bulk-acked {len(acked)} message(s) in {lane} inbox:")
+                for msg in acked:
+                    print(
+                        f"  {msg.get('message_id', '?'):16s}  "
+                        f"{msg.get('summary', '')[:60]}"
+                    )
         return 0
 
     elif action == "stats":
@@ -2408,6 +2449,18 @@ def build_parser() -> argparse.ArgumentParser:
     inbox_ack_parser.add_argument("message_id", help="The message ID to acknowledge")
     inbox_ack_parser.add_argument(
         "--lane", required=True, help="Lane whose inbox contains the message"
+    )
+
+    inbox_ack_all_parser = inbox_sub.add_parser(
+        "ack-all", help="Bulk-acknowledge inbox messages"
+    )
+    inbox_ack_all_parser.add_argument(
+        "--lane", required=True, help="Lane whose inbox to bulk-ack"
+    )
+    inbox_ack_all_parser.add_argument(
+        "--filter-summary",
+        default=None,
+        help="Regex pattern to match against message summary (case-insensitive)",
     )
 
     inbox_parser.add_argument(

--- a/src/bid_euchre/ops/message_bus.py
+++ b/src/bid_euchre/ops/message_bus.py
@@ -35,6 +35,7 @@ import os
 import subprocess
 import time
 import uuid
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -89,7 +90,7 @@ VALID_MESSAGE_TRANSITIONS: dict[str, frozenset[str]] = {
 
 # Default delivery policy
 DEFAULT_MAX_RETRIES = 3
-DEFAULT_TTL_SECONDS: int | None = None  # No expiry by default
+DEFAULT_TTL_SECONDS: int = 86400  # 24-hour expiry by default
 
 
 # ---------------------------------------------------------------------------
@@ -387,6 +388,43 @@ def _read_inbox_raw(lane_id: str, bus_root: Path) -> list[dict[str, Any]]:
     return records
 
 
+def _expire_stale_on_read(
+    by_id: dict[str, dict[str, Any]],
+    lane_id: str,
+    bus_root: Path,
+    *,
+    now: float | None = None,
+) -> None:
+    """Lazily expire messages past their TTL during a read operation.
+
+    Mutates *by_id* in-place: any message that has exceeded its
+    ``payload.ttl_seconds`` is transitioned to ``expired`` and the dict
+    value is replaced with the updated record.  This avoids the need
+    for a separate ``check_expired()`` sweep for the common 24-hour case.
+
+    Only non-terminal messages with a numeric ``ttl_seconds`` are checked.
+    """
+    current_time = now or time.time()
+    terminal = {"resolved", "expired", "dead_lettered"}
+
+    for mid, rec in list(by_id.items()):
+        if rec.get("status") in terminal:
+            continue
+        ttl = rec.get("payload", {}).get("ttl_seconds")
+        if ttl is None:
+            continue
+        created = rec.get("created_at", "")
+        try:
+            created_ts = datetime.fromisoformat(created).timestamp()
+        except (ValueError, TypeError):
+            continue
+        if current_time - created_ts > ttl:
+            updated = _update_inbox_status(mid, lane_id, "expired", bus_root)
+            if updated:
+                by_id[mid] = updated
+                logger.debug("Auto-expired message %s on read (TTL=%s)", mid, ttl)
+
+
 def read_inbox(
     lane_id: str,
     bus_root: Path | None = None,
@@ -395,11 +433,16 @@ def read_inbox(
     thread_id: str | None = None,
     message_type: str | None = None,
     limit: int = 50,
+    auto_expire: bool = True,
 ) -> list[dict[str, Any]]:
     """Read and filter a lane's inbox messages.
 
     Returns list of message dicts, most recent first, up to ``limit``.
     Each message_id appears once (latest record wins for status updates).
+
+    When *auto_expire* is ``True`` (the default), messages whose
+    ``payload.ttl_seconds`` has elapsed are automatically transitioned
+    to ``expired`` before filtering.
     """
     root = shared_bus_root(bus_root)
     raw = _read_inbox_raw(lane_id, root)
@@ -410,6 +453,10 @@ def read_inbox(
         mid = rec.get("message_id")
         if mid:
             by_id[mid] = rec
+
+    # Lazily expire stale messages before applying user filters
+    if auto_expire:
+        _expire_stale_on_read(by_id, lane_id, root)
 
     # Apply filters
     from collections import deque
@@ -627,6 +674,67 @@ def ack_message(
             logger.warning("Failed to emit message_acked event for %s", message_id)
 
     return updated
+
+
+def bulk_ack_messages(
+    lane_id: str,
+    filter_fn: Callable[[dict[str, Any]], bool],
+    bus_root: Path | None = None,
+    *,
+    events_dir: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Acknowledge all messages in a lane's inbox that match *filter_fn*.
+
+    Only messages in ack-able states (``pending`` or ``delivered``) are
+    considered.  Messages already acked, resolved, or terminal are skipped.
+
+    Args:
+        lane_id: The lane whose inbox to scan.
+        filter_fn: Predicate receiving a message dict; return ``True`` to ack.
+        bus_root: Override for bus root directory.
+        events_dir: Override for events directory (for testing).
+
+    Returns:
+        List of acked message dicts.
+    """
+    root = shared_bus_root(bus_root)
+    raw = _read_inbox_raw(lane_id, root)
+
+    # Deduplicate: latest record per message_id wins
+    by_id: dict[str, dict[str, Any]] = {}
+    for rec in raw:
+        mid = rec.get("message_id")
+        if mid:
+            by_id[mid] = rec
+
+    ackable = {"pending", "delivered"}
+    acked: list[dict[str, Any]] = []
+    for mid, rec in by_id.items():
+        if rec.get("status") not in ackable:
+            continue
+        if not filter_fn(rec):
+            continue
+        updated = _update_inbox_status(
+            mid, lane_id, "acked", root, extra_fields={"acked_at": _now_iso()}
+        )
+        if updated is not None:
+            acked.append(updated)
+            try:
+                from bid_euchre.ops.events import append_event
+
+                append_event(
+                    "message_acked",
+                    "ops.message_bus",
+                    lane_id,
+                    {"message_id": mid, "bulk": True},
+                    events_dir=events_dir,
+                )
+            except Exception:
+                logger.warning("Failed to emit message_acked event for %s", mid)
+
+    if acked:
+        logger.info("Bulk-acked %d message(s) for %s", len(acked), lane_id)
+    return acked
 
 
 def resolve_message(

--- a/tests/unit/test_ops_message_bus.py
+++ b/tests/unit/test_ops_message_bus.py
@@ -18,6 +18,7 @@ import pytest
 
 from bid_euchre.ops.message_bus import (
     DEFAULT_MAX_RETRIES,
+    DEFAULT_TTL_SECONDS,
     VALID_MESSAGE_PRIORITIES,
     VALID_MESSAGE_STATUSES,
     VALID_MESSAGE_TRANSITIONS,
@@ -25,6 +26,7 @@ from bid_euchre.ops.message_bus import (
     BusMessage,
     ack_message,
     append_message,
+    bulk_ack_messages,
     check_dead_letters,
     check_expired,
     create_message,
@@ -202,7 +204,7 @@ class TestBusMessageCreation:
         msg = create_message("a", "b", "assignment", "test")
         assert msg.payload["max_retries"] == DEFAULT_MAX_RETRIES
         assert msg.payload["retry_count"] == 0
-        assert msg.payload["ttl_seconds"] is None
+        assert msg.payload["ttl_seconds"] == DEFAULT_TTL_SECONDS
 
     def test_custom_delivery_policy_preserved(self) -> None:
         msg = create_message(
@@ -640,8 +642,14 @@ class TestCheckExpired:
         assert len(expired) == 0
 
     def test_no_ttl_never_expires(self, bus_root: Path, events_dir: Path) -> None:
-        """Messages without ttl_seconds never expire."""
-        msg = create_message("a", "b", "assignment", "Forever task")
+        """Messages with ttl_seconds=None never expire."""
+        msg = create_message(
+            "a",
+            "b",
+            "assignment",
+            "Forever task",
+            payload={"ttl_seconds": None},
+        )
         send_message(msg, bus_root, events_dir=events_dir)
 
         far_future = time.time() + 365 * 24 * 3600  # 1 year
@@ -924,3 +932,206 @@ class TestE2ESmoke:
         # Each lane's inbox has the right messages
         assert len(read_inbox("author-a", bus_root)) == 1
         assert len(read_inbox("orchestrator", bus_root)) == 2
+
+
+# ---------------------------------------------------------------------------
+# Bulk ack
+# ---------------------------------------------------------------------------
+
+
+class TestBulkAckMessages:
+    """Test bulk_ack_messages delivery semantics."""
+
+    def test_bulk_ack_all(self, bus_root: Path, events_dir: Path) -> None:
+        """Ack all pending messages in a lane."""
+        m1 = create_message("a", "target", "assignment", "Task 1")
+        m2 = create_message("a", "target", "progress", "Task 2")
+        send_message(m1, bus_root, events_dir=events_dir)
+        send_message(m2, bus_root, events_dir=events_dir)
+
+        acked = bulk_ack_messages(
+            "target", lambda _: True, bus_root, events_dir=events_dir
+        )
+        assert len(acked) == 2
+        assert all(r["status"] == "acked" for r in acked)
+
+    def test_bulk_ack_with_filter(self, bus_root: Path, events_dir: Path) -> None:
+        """Only messages matching filter_fn are acked."""
+        m1 = create_message("a", "target", "assignment", "Fix scoring bug")
+        m2 = create_message("a", "target", "progress", "Test progress update")
+        send_message(m1, bus_root, events_dir=events_dir)
+        send_message(m2, bus_root, events_dir=events_dir)
+
+        acked = bulk_ack_messages(
+            "target",
+            lambda msg: "scoring" in msg.get("summary", "").lower(),
+            bus_root,
+            events_dir=events_dir,
+        )
+        assert len(acked) == 1
+        assert acked[0]["summary"] == "Fix scoring bug"
+
+        # The other message remains pending
+        inbox = read_inbox("target", bus_root, status="pending")
+        assert len(inbox) == 1
+        assert inbox[0]["summary"] == "Test progress update"
+
+    def test_bulk_ack_skips_non_ackable(self, bus_root: Path, events_dir: Path) -> None:
+        """Already-acked and terminal messages are not re-acked."""
+        m1 = create_message("a", "target", "assignment", "Already acked")
+        m2 = create_message("a", "target", "progress", "Still pending")
+        send_message(m1, bus_root, events_dir=events_dir)
+        send_message(m2, bus_root, events_dir=events_dir)
+
+        # Ack m1 individually first
+        ack_message(m1.message_id, "target", bus_root, events_dir=events_dir)
+
+        # Bulk ack should only ack m2
+        acked = bulk_ack_messages(
+            "target", lambda _: True, bus_root, events_dir=events_dir
+        )
+        assert len(acked) == 1
+        assert acked[0]["message_id"] == m2.message_id
+
+    def test_bulk_ack_empty_inbox(self, bus_root: Path, events_dir: Path) -> None:
+        """Bulk ack on empty inbox returns empty list."""
+        acked = bulk_ack_messages(
+            "empty-lane", lambda _: True, bus_root, events_dir=events_dir
+        )
+        assert acked == []
+
+    def test_bulk_ack_emits_events(self, bus_root: Path, events_dir: Path) -> None:
+        """Each bulk-acked message emits an event with bulk=True."""
+        m1 = create_message("a", "target", "assignment", "Task 1")
+        m2 = create_message("a", "target", "assignment", "Task 2")
+        send_message(m1, bus_root, events_dir=events_dir)
+        send_message(m2, bus_root, events_dir=events_dir)
+
+        bulk_ack_messages("target", lambda _: True, bus_root, events_dir=events_dir)
+
+        events_file = events_dir / "events.jsonl"
+        lines = events_file.read_text().strip().split("\n")
+        ack_events = [
+            json.loads(line)
+            for line in lines
+            if json.loads(line)["event_type"] == "message_acked"
+        ]
+        assert len(ack_events) == 2
+        assert all(ev["payload"].get("bulk") is True for ev in ack_events)
+
+
+# ---------------------------------------------------------------------------
+# TTL auto-expire on read
+# ---------------------------------------------------------------------------
+
+
+class TestTTLAutoExpireOnRead:
+    """Test that read_inbox auto-expires stale messages."""
+
+    def test_default_ttl_is_24h(self) -> None:
+        """DEFAULT_TTL_SECONDS should be 86400 (24 hours)."""
+        assert DEFAULT_TTL_SECONDS == 86400
+
+    def test_auto_expire_on_read(self, bus_root: Path, events_dir: Path) -> None:
+        """Messages past their TTL are expired when inbox is read."""
+        msg = create_message(
+            "a",
+            "target",
+            "assignment",
+            "Short-lived task",
+            payload={"ttl_seconds": 60},
+        )
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        # Read immediately — message should be pending
+        inbox = read_inbox("target", bus_root)
+        assert len(inbox) == 1
+        assert inbox[0]["status"] == "pending"
+
+        # Simulate time passing — read_inbox auto-expires internally
+        # We need to manipulate the message creation time to be in the past.
+        # Since auto_expire uses the current time, we create a message
+        # with a very short TTL and old timestamp.
+        import time as _time
+
+        # Create another message with TTL=1 second
+        msg2 = create_message(
+            "a",
+            "target2",
+            "assignment",
+            "Expiring soon",
+            payload={"ttl_seconds": 1},
+        )
+        send_message(msg2, bus_root, events_dir=events_dir)
+
+        # Sleep briefly to ensure TTL elapses
+        _time.sleep(1.1)
+
+        # Reading inbox should auto-expire
+        inbox2 = read_inbox("target2", bus_root)
+        assert len(inbox2) == 1
+        assert inbox2[0]["status"] == "expired"
+
+    def test_auto_expire_disabled(self, bus_root: Path, events_dir: Path) -> None:
+        """When auto_expire=False, stale messages are not expired."""
+        msg = create_message(
+            "a",
+            "target",
+            "assignment",
+            "Should stay pending",
+            payload={"ttl_seconds": 1},
+        )
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        import time as _time
+
+        _time.sleep(1.1)
+
+        # With auto_expire=False, message stays pending
+        inbox = read_inbox("target", bus_root, auto_expire=False)
+        assert len(inbox) == 1
+        assert inbox[0]["status"] == "pending"
+
+    def test_auto_expire_does_not_touch_terminal(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Already-resolved messages are not re-expired on read."""
+        msg = create_message(
+            "a",
+            "target",
+            "assignment",
+            "Resolved task",
+            payload={"ttl_seconds": 1},
+        )
+        send_message(msg, bus_root, events_dir=events_dir)
+        ack_message(msg.message_id, "target", bus_root, events_dir=events_dir)
+        resolve_message(msg.message_id, "target", bus_root, events_dir=events_dir)
+
+        import time as _time
+
+        _time.sleep(1.1)
+
+        inbox = read_inbox("target", bus_root, status="resolved")
+        assert len(inbox) == 1
+        assert inbox[0]["status"] == "resolved"
+
+    def test_no_ttl_never_auto_expires(self, bus_root: Path, events_dir: Path) -> None:
+        """Messages with ttl_seconds=None are never auto-expired on read."""
+        msg = create_message(
+            "a",
+            "target",
+            "assignment",
+            "Eternal message",
+            payload={"ttl_seconds": None},
+        )
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        # Even far in the future, no expiry
+        inbox = read_inbox("target", bus_root)
+        assert len(inbox) == 1
+        assert inbox[0]["status"] == "pending"
+
+    def test_new_messages_get_default_ttl(self) -> None:
+        """create_message injects DEFAULT_TTL_SECONDS into payload."""
+        msg = create_message("a", "b", "assignment", "Default TTL")
+        assert msg.payload["ttl_seconds"] == 86400


### PR DESCRIPTION
## Summary

- Add `bulk_ack_messages(lane_id, filter_fn)` to `message_bus.py` for acking multiple messages matching a predicate
- Add CLI `ops.py inbox ack-all --lane LANE [--filter-summary PATTERN]` for operator-level bulk cleanup
- Change `DEFAULT_TTL_SECONDS` from `None` to `86400` (24h) — new messages auto-expire after 24 hours
- Add lazy TTL enforcement in `read_inbox()` — stale messages are expired on read without separate `check_expired()` sweep

## Why

Known debt item: message bus needed TTL/expiry enforcement on unacked messages (listed in MEMORY.md). Bulk-ack is needed for operator cleanup of stale messages across lanes.

## Repro / Validation

```bash
# Tier 1: targeted tests
uv run python -m pytest tests/unit/test_ops_message_bus.py -x -v

# Tier 2: full validation
make check-quiet
```

## Tests

- 70 tests pass in `test_ops_message_bus.py` (11 new tests added)
- New test classes: `TestBulkAckMessages` (5 tests), `TestTTLAutoExpireOnRead` (6 tests)
- Updated existing `test_delivery_policy_defaults_in_payload` and `test_no_ttl_never_expires` for new 24h default

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: ops/bulk-ack-ttl-expiry
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)