### PR TITLE
ops: remove issues pane and reshape central-ops to 3-pane layout

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -30,7 +30,7 @@ Each `.md` file defines an agent that can be launched via the Agent tool.
 
 ### Specialist Agents
 
-- `issues` — bounded issue triage; files issues, never implements fixes
+- `issues` — bounded issue triage; files issues, never implements fixes (standalone, not session-launched)
 - `repair` — bounded post-merge repair; fixes shipped mistakes via follow-up PRs
 - `plan-reviewer` — independent plan review with tiered rubrics
 - `coverage-reviewer` — post-merge test coverage gap detection
@@ -52,7 +52,7 @@ outside the lane's intended role.
 |------|-------------|-----------|
 | `steward-review` | `allowedTools` (Read, Grep, Glob, Bash, ToolSearch, Skill) | Read-only review; cannot Edit/Write code |
 | `steward-ops` | `disallowedTools` (Edit, Write, Agent) | Monitoring-only; cannot modify files or spawn agents |
-| `issues` | `allowedTools` (Read, Grep, Glob, Bash, ToolSearch, Skill) | Triage-only; files issues via Bash/gh, cannot Edit/Write code |
+| `issues` | `allowedTools` (Read, Grep, Glob, Bash, ToolSearch, Skill) | Triage-only; files issues via Bash/gh, cannot Edit/Write code (standalone, not session-launched) |
 
 ### Lanes Without Enforced Boundaries (by design)
 
@@ -72,7 +72,7 @@ boundary.
 | Model | Agents |
 |-------|--------|
 | `sonnet` | All specialist reviewers, blind-comparator, steward-review, steward-ops |
-| `inherit` (default) | All author lanes, orchestrator, issues, repair |
+| `inherit` (default) | All author lanes, orchestrator, repair |
 
 ## Prompt-First Workflow
 
@@ -83,4 +83,6 @@ steward dashboard using the orchestrator, dashboard, and named skills.
 
 These agents are launched by `steward-session.sh` via `--agent <name>` flags,
 which writes v2 registry metadata and establishes stable role identity per
-tmux window.
+tmux pane. The session launches 15 lanes across 4 windows (central-ops,
+platform, browser, scratch). Standalone agents like `issues` can be invoked
+manually but are not part of the session layout.

--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -1,29 +1,27 @@
 #!/bin/bash
-# Canonical steward session bootstrap — 4-window tiled layout.
+# Canonical steward session bootstrap — 4-window layout.
 # Usage: steward-session.sh [session-name]
 #
-# Creates (or attaches to) a tmux session with 4 windows, each containing
-# 4 tiled panes:
+# Creates (or attaches to) a tmux session with 4 windows:
 #
-#   Window 1 — central-ops (pane targeting: steward:central-ops.{0-3})
-#     .0  orchestrator    -- single intake point for delegating work
-#     .1  ops             -- operator monitoring lane
-#     .2  review          -- independent review lane
-#     .3  issues          -- issue triage lane
+#   Window 1 — central-ops (3 panes, main-vertical layout)
+#     .0  orchestrator    -- single intake point (large left, ~66%)
+#     .1  ops             -- operator monitoring lane (top right)
+#     .2  review          -- independent review lane (bottom right)
 #
-#   Window 2 — platform (pane targeting: steward:platform.{0-3})
+#   Window 2 — platform (4 panes, tiled)
 #     .0  author-a        -- primary platform author lane
 #     .1  author-b        -- secondary platform author lane
 #     .2  author-c        -- overflow platform author lane
 #     .3  author-d        -- overflow platform author lane
 #
-#   Window 3 — browser (pane targeting: steward:browser.{0-3})
+#   Window 3 — browser (4 panes, tiled)
 #     .0  brws-author-a   -- primary browser-game author lane
 #     .1  brws-author-b   -- secondary browser-game author lane
 #     .2  brws-author-c   -- overflow browser-game author lane
 #     .3  brws-author-d   -- overflow browser-game author lane
 #
-#   Window 4 — scratch (pane targeting: steward:scratch.{0-3})
+#   Window 4 — scratch (4 panes, tiled)
 #     .0  author-scratch  -- exploratory Claude lane
 #     .1  flex-a          -- domain-agnostic overflow lane
 #     .2  flex-b          -- domain-agnostic overflow lane
@@ -281,14 +279,13 @@ ensure_worktree "$FLEX_C" "codex/steward-flex-c"
 ensure_review_worktree
 
 # Write v2 registry metadata for each lane.
-# tmux_window = group name, tmux_pane = pane index within the window (0-3).
+# tmux_window = group name, tmux_pane = pane index within the window.
 # Pane target format: ${SESSION}:${tmux_window}.${tmux_pane}
 
-# Central ops  (window: central-ops, panes 0-3)
+# Central ops  (window: central-ops, panes 0-2, main-vertical layout)
 write_lane_metadata "orchestrator"   "orchestrator" "$MAIN_DIR"       "--"                              "central-ops" "0" "foreground" "Orchestrator"
 write_lane_metadata "ops"            "ops"          "$MAIN_DIR"       "--"                              "central-ops" "1" "foreground" "Ops"
 write_lane_metadata "review"         "review"       "$REVIEW"         "detached"                        "central-ops" "2" "foreground" "Review"
-write_lane_metadata "issues"         "issues"       "$MAIN_DIR"       "--"                              "central-ops" "3" "foreground" "Issues"
 
 # Platform workers  (window: platform, panes 0-3)
 write_lane_metadata "author-a"       "author"       "$AUTHOR_A"       "codex/steward-author"            "platform" "0" "background" "Author A"
@@ -309,23 +306,19 @@ write_lane_metadata "flex-b"         "flex"          "$FLEX_B"          "codex/s
 write_lane_metadata "flex-c"         "flex"          "$FLEX_C"          "codex/steward-flex-c"           "scratch" "3" "background" "Flex C"
 
 # ---------------------------------------------------------------------------
-# Window + pane creation — 4 windows × 4 tiled panes
+# Window + pane creation — 4 windows (central-ops: 3 panes, others: 4 panes)
 # ---------------------------------------------------------------------------
-# Pattern per window:
-#   new-session / new-window creates the window with pane .0
-#   3 × split-window adds panes .1, .2, .3
-#   select-layout tiled evens out the quadrants
+# central-ops uses main-vertical: orchestrator large left, ops/review stacked right.
+# Worker windows use tiled: 4 equal quadrants.
 
-# --- Window 1: central-ops ---
+# --- Window 1: central-ops (3 panes, main-vertical) ---
 tmux new-session -d -s "$SESSION" -n central-ops -c "$MAIN_DIR" \
     "$CLAUDE_BIN" --name orchestrator --agent steward-orchestrator
 tmux split-window -t "${SESSION}:central-ops" -c "$MAIN_DIR" \
     "$CLAUDE_BIN" --name ops --agent steward-ops
 tmux split-window -t "${SESSION}:central-ops" -c "$REVIEW" \
     "$CLAUDE_BIN" --name review --agent steward-review
-tmux split-window -t "${SESSION}:central-ops" -c "$MAIN_DIR" \
-    "$CLAUDE_BIN" --name issues --agent issues
-tmux select-layout -t "${SESSION}:central-ops" tiled
+tmux select-layout -t "${SESSION}:central-ops" main-vertical
 
 # --- Window 2: platform ---
 tmux new-window -t "$SESSION" -n platform -c "$AUTHOR_A" \

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -277,17 +277,19 @@ class TestStewardSessionScript:
         ), "ensure_worktree() must call validate_worktree_path before creating"
 
 
-class TestTiledWindowLayout:
-    """Validate the 4-window tiled layout (4 panes per window)."""
+class TestWindowLayout:
+    """Validate the 4-window layout (central-ops: 3 panes, others: 4 panes)."""
 
     EXPECTED_WINDOWS = ["central-ops", "platform", "browser", "scratch"]
 
+    # Worker windows with 4 tiled panes each
+    TILED_WINDOWS = ["platform", "browser", "scratch"]
+
     EXPECTED_LANES = [
-        # Central ops
+        # Central ops (3 panes)
         "orchestrator",
         "ops",
         "review",
-        "issues",
         # Platform workers
         "author-a",
         "author-b",
@@ -307,7 +309,7 @@ class TestTiledWindowLayout:
 
     # Lanes per window, in pane creation order (pane 0 = first)
     WINDOW_PANES = {
-        "central-ops": ["orchestrator", "ops", "review", "issues"],
+        "central-ops": ["orchestrator", "ops", "review"],
         "platform": ["author-a", "author-b", "author-c", "author-d"],
         "browser": [
             "brws-author-a",
@@ -324,6 +326,20 @@ class TestTiledWindowLayout:
         assert (
             "dashboard" not in content.lower()
         ), "steward-session.sh must not reference a 'dashboard' window"
+
+    def test_no_issues_lane(self) -> None:
+        """The issues lane must not appear in the launcher."""
+        content = STEWARD_SCRIPT.read_text()
+        assert (
+            "--name issues" not in content
+        ), "issues lane must be removed from the launcher"
+        # Metadata should not include issues
+        metadata_lines = [
+            line
+            for line in content.split("\n")
+            if line.strip().startswith('write_lane_metadata "issues"')
+        ]
+        assert len(metadata_lines) == 0, "issues metadata must be removed"
 
     def test_four_windows_created(self) -> None:
         """Exactly 4 tmux windows must be created (1 new-session + 3 new-window)."""
@@ -343,26 +359,41 @@ class TestTiledWindowLayout:
                 f"-n {window_name}" in content
             ), f"Expected window named '{window_name}'"
 
-    def test_split_window_creates_panes(self) -> None:
-        """Each window must have 3 split-window commands (for panes .1, .2, .3)."""
+    def test_central_ops_has_3_panes(self) -> None:
+        """central-ops must have 2 split-window commands (for 3 panes total)."""
         content = STEWARD_SCRIPT.read_text()
-        for window_name in self.EXPECTED_WINDOWS:
+        split_count = content.count('split-window -t "${SESSION}:central-ops"')
+        assert (
+            split_count == 2
+        ), f"central-ops must have 2 split-window commands, found {split_count}"
+
+    def test_central_ops_main_vertical(self) -> None:
+        """central-ops must use main-vertical layout (orchestrator large left)."""
+        content = STEWARD_SCRIPT.read_text()
+        assert (
+            'select-layout -t "${SESSION}:central-ops" main-vertical' in content
+        ), "central-ops must use main-vertical layout"
+
+    def test_worker_windows_have_4_panes(self) -> None:
+        """Each worker window must have 3 split-window commands (for 4 panes)."""
+        content = STEWARD_SCRIPT.read_text()
+        for window_name in self.TILED_WINDOWS:
             split_count = content.count(f'split-window -t "${{SESSION}}:{window_name}"')
             assert split_count == 3, (
                 f"Window '{window_name}' must have 3 split-window commands, "
                 f"found {split_count}"
             )
 
-    def test_tiled_layout_applied(self) -> None:
-        """Each window must have select-layout tiled applied."""
+    def test_worker_windows_tiled(self) -> None:
+        """Worker windows must use tiled layout."""
         content = STEWARD_SCRIPT.read_text()
-        for window_name in self.EXPECTED_WINDOWS:
+        for window_name in self.TILED_WINDOWS:
             assert (
                 f'select-layout -t "${{SESSION}}:{window_name}" tiled' in content
             ), f"Window '{window_name}' must have select-layout tiled"
 
     def test_all_lanes_launched(self) -> None:
-        """All 16 lanes must appear in new-session, new-window, or split-window commands."""
+        """All 15 lanes must appear in new-session, new-window, or split-window."""
         content = STEWARD_SCRIPT.read_text()
         for lane in self.EXPECTED_LANES:
             assert (
@@ -380,14 +411,13 @@ class TestTiledWindowLayout:
         ]
 
     def test_metadata_pane_indices(self) -> None:
-        """All lanes must have pane indices 0-3 in their metadata."""
+        """All lanes must have valid pane indices in their metadata."""
         metadata_lines = self._metadata_invocation_lines()
         assert len(metadata_lines) == len(self.EXPECTED_LANES), (
             f"Expected {len(self.EXPECTED_LANES)} write_lane_metadata calls, "
             f"found {len(metadata_lines)}"
         )
         for line in metadata_lines:
-            # Each line must have a pane index (0, 1, 2, or 3)
             has_pane_idx = any(f'"{i}"' in line for i in range(4))
             assert (
                 has_pane_idx
@@ -405,9 +435,8 @@ class TestTiledWindowLayout:
     def test_central_ops_foreground(self) -> None:
         """Central ops lanes must have foreground visibility."""
         metadata_lines = self._metadata_invocation_lines()
-        central_ops_lanes = {"orchestrator", "ops", "review", "issues"}
+        central_ops_lanes = {"orchestrator", "ops", "review"}
         for line in metadata_lines:
-            # Check if this line is for a central ops lane
             for lane in central_ops_lanes:
                 if f'"{lane}"' in line and line.index(f'"{lane}"') < 30:
                     assert (
@@ -442,6 +471,11 @@ class TestTiledWindowLayout:
         """The ops monitoring loop must target central-ops.1 (ops pane)."""
         content = STEWARD_SCRIPT.read_text()
         assert "central-ops.1" in content, "Ops monitoring must target central-ops.1"
+
+    def test_review_check_targets_correct_pane(self) -> None:
+        """The review-check loop must target central-ops.2 (review pane)."""
+        content = STEWARD_SCRIPT.read_text()
+        assert "central-ops.2" in content, "Review-check must target central-ops.2"
 
     def test_legacy_rollback_exists(self) -> None:
         """steward-session-legacy.sh must exist for rollback."""


### PR DESCRIPTION
## Summary

- Removes the issues lane from the steward session (metadata + pane creation)
- Reshapes central-ops from 4 equal tiled panes to a **3-pane main-vertical layout**: orchestrator (~66% left), ops + review stacked vertically (~33% right)
- Updates agent README to mark issues as standalone (not session-launched)

## Why

The issues lane was underutilized and consumed a quarter of the central-ops window. Removing it gives the orchestrator more screen real estate (the primary interaction point for the operator) while keeping ops monitoring and review visible in the right column.

## Layout (central-ops window)

```
┌──────────────────────┬──────────┐
│                      │   ops    │
│   orchestrator       │  (.1)    │
│      (.0)            ├──────────┤
│                      │  review  │
│                      │  (.2)    │
└──────────────────────┴──────────┘
      ~66% width         ~33%
```

## Repro / Validation

```bash
bash -n .claude/tmux/steward-session.sh   # Syntax check
uv run python -m pytest tests/unit/test_steward_session.py -q
make check-quiet
```

## Tests

- `make check-quiet` — all tests pass
- `tests/unit/test_steward_session.py` — 49 tests (rewritten `TestWindowLayout`)
  - New: `test_no_issues_lane`, `test_central_ops_has_3_panes`, `test_central_ops_main_vertical`, `test_review_check_targets_correct_pane`

## Worktree proof

```
pwd: Bid-Euchre-steward-author (persistent author-a worktree)
Branch: ops/central-ops-3pane
```

## Files changed

| File | Change |
|------|--------|
| `.claude/tmux/steward-session.sh` | Remove issues pane, 4→3 panes, tiled→main-vertical |
| `.claude/agents/README.md` | Mark issues as standalone, update lane count |
| `tests/unit/test_steward_session.py` | Rewrite layout tests for 15-lane structure |

🤖 Generated with [Claude Code](https://claude.com/claude-code)