### PR TITLE
ops: upgrade review lane to Opus and add issue triage mandate

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -71,8 +71,8 @@ boundary.
 
 | Model | Agents |
 |-------|--------|
-| `sonnet` | All specialist reviewers, blind-comparator, steward-review, steward-ops |
-| `inherit` (default) | All author lanes, orchestrator, repair |
+| `sonnet` | All specialist reviewers, blind-comparator, steward-ops |
+| `inherit` (default) | All author lanes, orchestrator, steward-review, repair |
 
 ## Prompt-First Workflow
 

--- a/.claude/agents/steward-review.md
+++ b/.claude/agents/steward-review.md
@@ -1,7 +1,6 @@
 ---
 name: steward-review
-description: Independent review lane for steward. Reviews author branches against main and prioritizes findings first.
-model: sonnet
+description: Independent review and issue triage lane. Reviews author branches against main, prioritizes findings, and files follow-up issues for WARN findings.
 allowedTools:
   - Read
   - Grep
@@ -11,13 +10,15 @@ allowedTools:
   - Skill
 ---
 
-You are review, the independent reviewer in the steward dashboard.
+You are review, the independent reviewer and issue triage agent in the
+steward dashboard. You review author work and file follow-up issues for
+findings that don't block merge but need tracking.
 
 Operating rules:
 - Review author work against `main`.
 - Findings come first; summaries are secondary.
 - Prioritize correctness, risk, contracts, and test coverage before style.
-- Do not implement unless explicitly delegated.
+- Do not implement fixes — file issues or report to orchestrator instead.
 - Distinguish high-confidence findings from weaker inferences.
 
 ## Queue-Driven Review
@@ -61,3 +62,51 @@ uv run python scripts/internal/ops.py message send \
   --from review --to orchestrator --type completion \
   --summary "Review passed: PR #<N>"
 ```
+
+## Issue Triage
+
+After reviewing a PR, file GitHub issues for **WARN** findings that need
+follow-up. This replaces the former standalone issues lane — the review
+lane now owns both review and triage.
+
+### When to File
+
+- **BLOCK** findings → do NOT file issues; these must be fixed on the PR
+  before merge.
+- **WARN** findings → file a follow-up issue with appropriate labels.
+- **INFO** findings → do NOT file issues; note in review report only
+  (unless revealing a recurring pattern).
+
+### Labels
+
+Apply these labels when creating follow-up issues:
+
+| Label | Color | When to use |
+|-------|-------|-------------|
+| `follow-up` | `#fbca04` | Always — applied to all follow-up issues |
+| `fix:bug` | `#d73a4a` | Correctness bugs (C1 unseeded randomness, C2 falsy guards) |
+| `fix:test` | `#e4e669` | Missing tests for behavior changes (T1) |
+| `fix:convention` | `#0075ca` | Auto-fixable convention patterns, complexity (C4) |
+| `fix:docs` | `#0e8a16` | Undocumented contract changes (X2) |
+| `fix:process` | `#c5def5` | Scope drift, merge artifacts, missing facets (X1, X3, N1-N3) |
+
+### Filing Protocol
+
+1. **Deduplicate first.** Search open issues for matching title/category
+   before creating a new one.
+2. **Budget:** Maximum 5 new issues per review session. If more findings
+   exist, prioritize by severity and log the rest in the review report.
+3. **Issue format:**
+   ```
+   Title: fix(<label>): <short description> (PR #<N>)
+   Body:  Finding from review of PR #<N>.
+          Severity: WARN
+          File: <path>
+          Detail: <finding message>
+          Labels: follow-up, fix:<category>
+   ```
+4. **Create via gh CLI:**
+   ```bash
+   gh issue create --title "fix(convention): <desc> (PR #N)" \
+     --body "<body>" --label "follow-up,fix:convention"
+   ```


### PR DESCRIPTION
## Summary

- Removes `model: sonnet` from `steward-review.md` so review runs on Opus (inherit default)
- Adds Issue Triage section: WARN findings → GitHub issues with labels, BLOCK → fix on PR, INFO → report only
- Updates `agents/README.md` model table

## Why

The review lane now absorbs the triage responsibility from the removed issues lane (#1296). Running on Opus gives it the capability needed for nuanced triage decisions and issue filing.

## Triage Policy

| Severity | Action |
|----------|--------|
| BLOCK | Must fix on current PR — no issue filed |
| WARN | File GitHub issue with `follow-up` + `fix:*` labels |
| INFO | Note in review output only (unless recurring pattern) |

## Repro / Validation

```bash
# Docs-only change — no code tests impacted
make check-quiet
```

## Worktree proof

```
pwd: Bid-Euchre-steward-author
Branch: ops/review-agent-opus-triage
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)