### PR TITLE
browser-game: add hosted-play and web package skeletons (Phase 0 Step 2)

### DIFF
--- a/plans/browser_game/0_foundation/checkpoints.md
+++ b/plans/browser_game/0_foundation/checkpoints.md
@@ -12,7 +12,7 @@
 |------|--------|------|---------------|-------|
 | Step 0: Draft governing plan and initiative scaffold | COMPLETE | 2026-03-14 | Codex | Governing plan, amendments log, registry, and phase checkpoints created. |
 | Step 1: Lock hosted-play rules contract | COMPLETE | 2026-03-15 | Codex | Authoritative rules contract now lives at `docs/01_core/HOSTED_PLAY_RULES.md`; planning draft left as a pointer only. |
-| Step 2: Add dependencies and package skeleton | IN_PROGRESS | 2026-03-15 | Codex | `hosted` extras added to `pyproject.toml`; package skeleton still pending. |
+| Step 2: Add dependencies and package skeleton | COMPLETE | 2026-03-23 | brws-author-a | `hosted` extras in `pyproject.toml`; package skeleton added (`src/bid_euchre/hosted_play/__init__.py`, `web/__init__.py`). |
 | Step 3: Create database schema | PENDING | -- | -- | Create `web/schema.sql` with players, matches, hands, decisions tables. See governing plan §5.2 and SP-2-01. |
 | Step 4: Inventory model artifacts | COMPLETE | 2026-03-15 | Codex | Verified `heuristic` is always available; hybrid and GBT artifacts exist under `data/artifacts/arc_d/r0/` and `data/artifacts/arc_d_v2/r0/`. |
 | Step 5: Promote plan to ACTIVE | COMPLETE | 2026-03-15 | Codex | Governing plan status set to `ACTIVE`; Phase 0 now tracks only execution-prep work. |
@@ -26,10 +26,14 @@
 ## Blockers
 
 - [x] ~~Authoritative hosted-play rules doc~~ → `docs/01_core/HOSTED_PLAY_RULES.md`
-- [ ] Package skeleton not yet added (`src/bid_euchre/hosted_play/__init__.py`, `web/__init__.py`)
+- [x] ~~Package skeleton~~ → `src/bid_euchre/hosted_play/__init__.py`, `web/__init__.py`
 - [ ] Initial database schema not yet locked in files
 
 ## Session Log
+
+### 2026-03-23 -- brws-author-a
+- Completed: Added package skeleton — `src/bid_euchre/hosted_play/__init__.py` and `web/__init__.py`. Step 2 → COMPLETE.
+- Next: Step 3 (database schema) remains PENDING.
 
 ### 2026-03-15 -- Codex
 - Completed: Promoted the hosted-play rules draft into the authoritative docs path, added the `hosted` dependency extra to `pyproject.toml`, and locked the initial artifact roster in the planning docs.

--- a/src/bid_euchre/hosted_play/__init__.py
+++ b/src/bid_euchre/hosted_play/__init__.py
@@ -1,0 +1,9 @@
+"""Hosted-play domain engine for browser-based Bid Euchre.
+
+Provides stepwise hand/match state transitions that reuse existing rule
+and strategy interfaces from ``bid_euchre.core``, ``bid_euchre.strategy``,
+``bid_euchre.sim``, and ``bid_euchre.scoring``.
+
+This package is web-framework-free.  The ``web/`` application layer imports
+from here; this package must never import from ``web/``.
+"""

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,0 +1,6 @@
+"""Browser-game web application for Bid Euchre hosted play.
+
+FastAPI app, route handlers, templates, and static assets.
+Imports the hosted-play domain package from ``bid_euchre.hosted_play``
+and existing ``bid_euchre`` modules — never the reverse.
+"""


### PR DESCRIPTION
## Plan
`plans/browser_game/governing_plan.md` §5.1 (Package Layout), Phase 0 Step 2
`plans/browser_game/0_foundation/checkpoints.md`

## Summary
- Add `src/bid_euchre/hosted_play/__init__.py` — domain engine package marker
- Add `web/__init__.py` — web application package marker
- Mark Phase 0 Step 2 COMPLETE in foundation checkpoints

## Why
The browser-game governing plan defines a two-layer package layout. This PR
creates the minimal package skeletons so that subsequent Phase 1 (state engine)
and Phase 2 (backend API) work has importable packages to build on.

## Repro / Validation
**Command(s) run:**
- `uv run python -c 'import bid_euchre.hosted_play'` — verifies the package is importable
- `make check-quiet` — full validation passes

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `make check-quiet` — all checks passed
- [x] Import validation: `uv run python -c 'import bid_euchre.hosted_play'`

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a   507c05f5 [brws/phase0-package-skeleton]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)