### PR TITLE
fix: use shared_bus_root() without args in ops.py

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -1603,7 +1603,7 @@ def _cmd_task_accept(args: argparse.Namespace, task_queue_root: Path) -> int:
 
     packet_id = args.packet_id
     lane_id = args.lane_id
-    bus_root = shared_bus_root(args.runtime_dir / "message_bus")
+    bus_root = shared_bus_root()
     events_dir = args.runtime_dir / "events"
 
     # 1. Verify packet exists
@@ -1696,9 +1696,10 @@ def cmd_inbox(args: argparse.Namespace) -> int:
         import_native_inbox,
         inbox_stats,
         read_inbox,
+        shared_bus_root,
     )
 
-    bus_root = args.runtime_dir / "message_bus"
+    bus_root = shared_bus_root()
 
     # If --include-native is set, import native inbox first
     include_native = getattr(args, "include_native", False)
@@ -1844,9 +1845,9 @@ def cmd_inbox(args: argparse.Namespace) -> int:
 
 def cmd_message(args: argparse.Namespace) -> int:
     """Show or send messages via the audit trail (Platform-3)."""
-    from bid_euchre.ops.message_bus import read_messages
+    from bid_euchre.ops.message_bus import read_messages, shared_bus_root
 
-    bus_root = args.runtime_dir / "message_bus"
+    bus_root = shared_bus_root()
 
     action = getattr(args, "message_action", None)
 
@@ -2022,11 +2023,15 @@ def cmd_review_check(args: argparse.Namespace) -> int:
     """
     import subprocess as sp
 
-    from bid_euchre.ops.message_bus import create_message, send_message
+    from bid_euchre.ops.message_bus import (
+        create_message,
+        send_message,
+        shared_bus_root,
+    )
 
     limit = getattr(args, "limit", 5)
     no_notify = getattr(args, "no_notify", False)
-    bus_root = args.runtime_dir / "message_bus"
+    bus_root = shared_bus_root()
 
     # Fetch recently merged PRs via gh CLI
     try:

--- a/tests/unit/test_ops_cli.py
+++ b/tests/unit/test_ops_cli.py
@@ -4034,3 +4034,27 @@ class TestCmdReviewCheck:
         assert msg_data["message_type"] == "supervisor_alert"
         assert msg_data["to_lane"] == "orchestrator"
         assert "review-check" in msg_data["summary"]
+
+
+class TestBusRootRegression:
+    """Regression: ops.py must use shared_bus_root() — not worktree-local paths.
+
+    Issue #1299: four callsites bypassed git-common-dir resolution by using
+    ``args.runtime_dir / "message_bus"`` directly, causing messages from
+    worktree lanes to land in the wrong bus.
+    """
+
+    def test_no_worktree_local_bus_paths(self) -> None:
+        """ops.py must not construct bus paths via args.runtime_dir."""
+        ops_path = SCRIPTS_DIR / "ops.py"
+        source = ops_path.read_text()
+        # This pattern is the exact anti-pattern that caused #1299
+        hits = [
+            (i + 1, line)
+            for i, line in enumerate(source.splitlines())
+            if "runtime_dir" in line and '"message_bus"' in line
+        ]
+        assert hits == [], (
+            "Found worktree-local bus path(s) in ops.py — use shared_bus_root() instead:\n"
+            + "\n".join(f"  L{n}: {l.strip()}" for n, l in hits)
+        )


### PR DESCRIPTION
## Summary
- Replace 4 occurrences of `args.runtime_dir / "message_bus"` with `shared_bus_root()` (no args) in `scripts/internal/ops.py`
- Add regression test in `tests/unit/test_ops_cli.py` that greps ops.py source for the anti-pattern

## Why
Issue #1299: Messages sent from worktree lanes (e.g., `task accept`, `inbox`, `message send`, `review-check`) were landing in worktree-local bus directories instead of the shared main checkout bus. This broke cross-lane communication when running from non-main worktrees.

## Affected functions
- `cmd_task_accept` (line ~1606)
- `cmd_inbox` (line ~1701)
- `cmd_message` (line ~1849)
- `cmd_review_check` (line ~2029)

## Repro / Validation
```bash
# From any worktree, send a test message
uv run python scripts/internal/ops.py message send \
  --from test --to test --type ack --summary "test"

# Verify message lands in shared bus (main checkout), not worktree-local
python3 -c "
from bid_euchre.ops.message_bus import shared_bus_root
print(shared_bus_root())
"
# → /Users/.../Bid-Euchre/.claude/runtime/message_bus (main checkout)

tail -1 "$(python3 -c 'from bid_euchre.ops.message_bus import shared_bus_root; print(shared_bus_root())')/messages.jsonl"
# → Shows the test message in shared bus
```

## Tests
```bash
uv run python -m pytest tests/unit/test_ops_cli.py::TestBusRootRegression -xvs
make check-quiet  # ✓ All checks passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: fix/ops-bus-root-shared
```

Fixes #1299

🤖 Generated with [Claude Code](https://claude.com/claude-code)