### PR TITLE
ops: add boot-time merged-PR review loop to review agent

### DIFF
--- a/.claude/agents/steward-review.md
+++ b/.claude/agents/steward-review.md
@@ -21,6 +21,50 @@ Operating rules:
 - Do not implement fixes — file issues or report to orchestrator instead.
 - Distinguish high-confidence findings from weaker inferences.
 
+## Autonomy Rules
+
+You have **full authority** to create GitHub issues — this is your primary
+function. Do not ask for confirmation or present findings for approval.
+
+1. **File WARN issues IMMEDIATELY** without asking for confirmation.
+   Use `gh issue create` directly. File first, report after.
+2. **Never present findings for approval before filing.** Your review
+   output is authoritative. The orchestrator trusts your triage judgment.
+3. **The only time to pause** is for BLOCK findings that require PR
+   changes before merge. Report those to the orchestrator for action.
+4. **INFO findings** are logged in the review report only — no issues
+   filed, no approval needed.
+
+The triage budget (max 5 issues per review session) is your only
+constraint. Within that budget, act autonomously.
+
+## Startup
+
+On every session boot, set up a recurring merged-PR review loop:
+
+1. **Discover recent merges:**
+   ```bash
+   gh pr list --repo Questuart/Bid-Euchre --state merged --limit 5 \
+     --json number,title,mergedAt,headRefName
+   ```
+2. **Track last-reviewed PR number** to avoid re-reviewing. Store the
+   high-water mark in `.claude/runtime/review_state/last_merged_pr.txt`.
+   If the file does not exist, start from the most recent merged PR
+   (review nothing on first boot).
+3. **For each new merge since last check**, review the diff against `main`:
+   - Run `gh pr diff <number>` to get the changeset.
+   - Produce findings (BLOCK/WARN/INFO) using the same severity mapping
+     as queue-driven review below.
+   - File GitHub issues for WARN findings per the Issue Triage protocol.
+   - Log INFO findings in the review report only.
+4. **Update the high-water mark** after processing all new merges.
+5. **Set up a 15-minute recurring poll** using `/loop 15m` to repeat
+   steps 1–4 continuously. This ensures merged PRs are reviewed even
+   when no explicit review request arrives via the message bus.
+
+If any step fails, log the error and continue the poll — do not crash
+the loop on transient failures.
+
 ## Queue-Driven Review
 
 When invoked by the review lane runner, you receive a PR number, branch

--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -364,15 +364,15 @@ tmux select-layout -t "${SESSION}:scratch" tiled
         "/loop 3m uv run python scripts/internal/ops.py monitor" Enter
 ) &
 
-# Auto-launch review-check loop on the review pane.
-# Runs every 20 minutes, checking recently merged PRs for contract and
-# diff-stat issues.  Best-effort — if it fails the review agent can
-# start it manually.
+# Auto-launch merged-PR review loop on the review pane.
+# Triggers the review agent's startup behavior: discover recent merges,
+# review diffs, triage findings, then poll every 15 minutes.
+# Best-effort — if it fails the review agent can start it manually.
 # Target: central-ops window, pane 3 (review lane).
 (
     sleep 15
     tmux send-keys -t "${SESSION}:central-ops.3" \
-        "/loop 20m uv run python scripts/internal/ops.py review-check" Enter
+        "Review recently merged PRs and triage findings. Set up a 15m recurring poll." Enter
 ) &
 
 tmux select-window -t "${SESSION}:central-ops"

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -475,13 +475,26 @@ class TestWindowLayout:
         content = STEWARD_SCRIPT.read_text()
         assert "central-ops.2" in content, "Ops monitoring must target central-ops.2"
 
-    def test_review_check_targets_correct_pane(self) -> None:
-        """The review-check loop must target central-ops.3 (review pane).
+    def test_review_loop_targets_correct_pane(self) -> None:
+        """The merged-PR review loop must target central-ops.3 (review pane).
 
         With pane-base-index=1: orchestrator=.1, ops=.2, review=.3.
         """
         content = STEWARD_SCRIPT.read_text()
-        assert "central-ops.3" in content, "Review-check must target central-ops.3"
+        assert "central-ops.3" in content, "Review loop must target central-ops.3"
+
+    def test_review_pane_sends_natural_language_prompt(self) -> None:
+        """The review pane auto-launch must send a natural-language prompt,
+        not the old review-check CLI command."""
+        content = STEWARD_SCRIPT.read_text()
+        assert "review-check" not in content, (
+            "Old review-check CLI command must be replaced with "
+            "natural-language prompt for the review agent"
+        )
+        assert "Review recently merged PRs" in content, (
+            "Review pane must receive a natural-language prompt "
+            "to trigger the agent's startup behavior"
+        )
 
     def test_legacy_rollback_exists(self) -> None:
         """steward-session-legacy.sh must exist for rollback."""


### PR DESCRIPTION
## Summary
- Add a `## Startup` section to `.claude/agents/steward-review.md` with instructions for a boot-time merged-PR review loop
- Add a `## Autonomy Rules` section granting the review agent full authority to file WARN issues without confirmation
- Update `.claude/tmux/steward-session.sh` to send a natural-language prompt to the review pane instead of the old `review-check` CLI loop
- Update test to verify new prompt content and pane targeting

## Why

The review lane should automatically discover and review recently merged PRs on every session boot, filing GitHub issues for WARN findings. The old `review-check` CLI loop was a placeholder; this replaces it with agent-native behavior driven by the startup instructions in the agent definition. The autonomy rules ensure the agent files issues immediately without asking for confirmation, which is its primary function.

## Changes

**`.claude/agents/steward-review.md`** — New `## Startup` section:
1. Discover recent merges via `gh pr list --state merged`
2. Track last-reviewed PR number (high-water mark in `.claude/runtime/review_state/last_merged_pr.txt`)
3. Review diffs for new merges, produce BLOCK/WARN/INFO findings
4. File issues for WARN findings per triage protocol
5. Set up 15-minute recurring poll via `/loop 15m`

**`.claude/agents/steward-review.md`** — New `## Autonomy Rules` section:
1. File WARN issues immediately without confirmation
2. Full authority to create GitHub issues
3. Never present findings for approval — file first, report after
4. Only pause for BLOCK findings requiring PR changes

**`.claude/tmux/steward-session.sh`** — Replaced `/loop 20m uv run python scripts/internal/ops.py review-check` with `"Review recently merged PRs and triage findings. Set up a 15m recurring poll."`

**`tests/unit/test_steward_session.py`** — Updated `test_review_loop_targets_correct_pane`, added `test_review_pane_sends_natural_language_prompt`

## Validation

```bash
bash -n .claude/tmux/steward-session.sh   # Syntax OK
uv run python -m pytest tests/unit/test_steward_session.py::TestWindowLayout::test_review_loop_targets_correct_pane tests/unit/test_steward_session.py::TestWindowLayout::test_review_pane_sends_natural_language_prompt -v   # 2 passed
make check-quiet                           # All checks passed (pre-rebase)
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: ops/review-merged-pr-loop
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)