### PR TITLE
fix: expose now parameter on read_inbox for deterministic tests

### DIFF
--- a/src/bid_euchre/ops/message_bus.py
+++ b/src/bid_euchre/ops/message_bus.py
@@ -434,6 +434,7 @@ def read_inbox(
     message_type: str | None = None,
     limit: int = 50,
     auto_expire: bool = True,
+    now: float | None = None,
 ) -> list[dict[str, Any]]:
     """Read and filter a lane's inbox messages.
 
@@ -443,6 +444,10 @@ def read_inbox(
     When *auto_expire* is ``True`` (the default), messages whose
     ``payload.ttl_seconds`` has elapsed are automatically transitioned
     to ``expired`` before filtering.
+
+    Args:
+        now: Override for current time as Unix timestamp (for testing).
+            Passed through to ``_expire_stale_on_read()``.
     """
     root = shared_bus_root(bus_root)
     raw = _read_inbox_raw(lane_id, root)
@@ -456,7 +461,7 @@ def read_inbox(
 
     # Lazily expire stale messages before applying user filters
     if auto_expire:
-        _expire_stale_on_read(by_id, lane_id, root)
+        _expire_stale_on_read(by_id, lane_id, root, now=now)
 
     # Apply filters
     from collections import deque

--- a/tests/unit/test_ops_message_bus.py
+++ b/tests/unit/test_ops_message_bus.py
@@ -1118,12 +1118,6 @@ class TestTTLAutoExpireOnRead:
         assert len(inbox) == 1
         assert inbox[0]["status"] == "pending"
 
-        # Simulate time passing — read_inbox auto-expires internally
-        # We need to manipulate the message creation time to be in the past.
-        # Since auto_expire uses the current time, we create a message
-        # with a very short TTL and old timestamp.
-        import time as _time
-
         # Create another message with TTL=1 second
         msg2 = create_message(
             "a",
@@ -1134,11 +1128,9 @@ class TestTTLAutoExpireOnRead:
         )
         send_message(msg2, bus_root, events_dir=events_dir)
 
-        # Sleep briefly to ensure TTL elapses
-        _time.sleep(1.1)
-
-        # Reading inbox should auto-expire
-        inbox2 = read_inbox("target2", bus_root)
+        # Use deterministic now= parameter instead of sleeping
+        future_time = time.time() + 100  # well past 1s TTL
+        inbox2 = read_inbox("target2", bus_root, now=future_time)
         assert len(inbox2) == 1
         assert inbox2[0]["status"] == "expired"
 
@@ -1153,12 +1145,9 @@ class TestTTLAutoExpireOnRead:
         )
         send_message(msg, bus_root, events_dir=events_dir)
 
-        import time as _time
-
-        _time.sleep(1.1)
-
-        # With auto_expire=False, message stays pending
-        inbox = read_inbox("target", bus_root, auto_expire=False)
+        # Use deterministic now= with auto_expire=False — message stays pending
+        future_time = time.time() + 100  # well past 1s TTL
+        inbox = read_inbox("target", bus_root, auto_expire=False, now=future_time)
         assert len(inbox) == 1
         assert inbox[0]["status"] == "pending"
 
@@ -1177,11 +1166,9 @@ class TestTTLAutoExpireOnRead:
         ack_message(msg.message_id, "target", bus_root, events_dir=events_dir)
         resolve_message(msg.message_id, "target", bus_root, events_dir=events_dir)
 
-        import time as _time
-
-        _time.sleep(1.1)
-
-        inbox = read_inbox("target", bus_root, status="resolved")
+        # Use deterministic now= instead of sleeping
+        future_time = time.time() + 100  # well past 1s TTL
+        inbox = read_inbox("target", bus_root, status="resolved", now=future_time)
         assert len(inbox) == 1
         assert inbox[0]["status"] == "resolved"
 


### PR DESCRIPTION
## Plan
N/A — bounded follow-up from issue #1285

## Summary
- Add `now: float | None = None` keyword parameter to `read_inbox()` and pass it through to `_expire_stale_on_read()`
- Replace 3 `time.sleep(1.1)` calls in TTL auto-expire tests with deterministic `now=` timestamps
- Test suite runtime drops from ~3.4s to ~0.26s

## Why
`_expire_stale_on_read()` already accepts a `now` parameter for deterministic testing, but `read_inbox()` didn't expose it — forcing tests to use real wall-clock sleeps. This made the test suite slower and non-deterministic.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_message_bus.py -v  # 84 passed in 0.26s
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_message_bus.py` — 84 passed (0.26s)
- [x] `make check-quiet` — in progress (Tier 1 clean)

## Expected impact
- Metrics impact: None
- Runtime impact: ~3s faster test suite (eliminates 3 × 1.1s sleeps)

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a  71a08b7e [fix/read-inbox-now-param]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)