### PR TITLE
fix: expose now parameter on read_inbox for deterministic tests

### DIFF
--- a/src/bid_euchre/ops/message_bus.py
+++ b/src/bid_euchre/ops/message_bus.py
@@ -434,6 +434,7 @@ def read_inbox(
     message_type: str | None = None,
     limit: int = 50,
     auto_expire: bool = True,
+    now: float | None = None,
 ) -> list[dict[str, Any]]:
     """Read and filter a lane's inbox messages.
 
@@ -443,6 +444,11 @@ def read_inbox(
     When *auto_expire* is ``True`` (the default), messages whose
     ``payload.ttl_seconds`` has elapsed are automatically transitioned
     to ``expired`` before filtering.
+
+    *now* is an optional epoch timestamp forwarded to
+    ``_expire_stale_on_read``.  When ``None`` (default), the current
+    wall-clock time is used.  Pass an explicit value in tests to avoid
+    ``time.sleep`` calls.
     """
     root = shared_bus_root(bus_root)
     raw = _read_inbox_raw(lane_id, root)
@@ -456,7 +462,7 @@ def read_inbox(
 
     # Lazily expire stale messages before applying user filters
     if auto_expire:
-        _expire_stale_on_read(by_id, lane_id, root)
+        _expire_stale_on_read(by_id, lane_id, root, now=now)
 
     # Apply filters
     from collections import deque

--- a/tests/unit/test_ops_message_bus.py
+++ b/tests/unit/test_ops_message_bus.py
@@ -1134,16 +1134,18 @@ class TestTTLAutoExpireOnRead:
         )
         send_message(msg2, bus_root, events_dir=events_dir)
 
-        # Sleep briefly to ensure TTL elapses
-        _time.sleep(1.1)
+        # Use deterministic future timestamp instead of sleeping
+        future = _time.time() + 2.0
 
         # Reading inbox should auto-expire
-        inbox2 = read_inbox("target2", bus_root)
+        inbox2 = read_inbox("target2", bus_root, now=future)
         assert len(inbox2) == 1
         assert inbox2[0]["status"] == "expired"
 
     def test_auto_expire_disabled(self, bus_root: Path, events_dir: Path) -> None:
         """When auto_expire=False, stale messages are not expired."""
+        import time as _time
+
         msg = create_message(
             "a",
             "target",
@@ -1153,12 +1155,12 @@ class TestTTLAutoExpireOnRead:
         )
         send_message(msg, bus_root, events_dir=events_dir)
 
-        import time as _time
-
-        _time.sleep(1.1)
+        # Use deterministic future timestamp — auto_expire=False so now is
+        # irrelevant, but proves the message isn't expired by side-effect.
+        future = _time.time() + 2.0
 
         # With auto_expire=False, message stays pending
-        inbox = read_inbox("target", bus_root, auto_expire=False)
+        inbox = read_inbox("target", bus_root, auto_expire=False, now=future)
         assert len(inbox) == 1
         assert inbox[0]["status"] == "pending"
 
@@ -1166,6 +1168,8 @@ class TestTTLAutoExpireOnRead:
         self, bus_root: Path, events_dir: Path
     ) -> None:
         """Already-resolved messages are not re-expired on read."""
+        import time as _time
+
         msg = create_message(
             "a",
             "target",
@@ -1177,11 +1181,10 @@ class TestTTLAutoExpireOnRead:
         ack_message(msg.message_id, "target", bus_root, events_dir=events_dir)
         resolve_message(msg.message_id, "target", bus_root, events_dir=events_dir)
 
-        import time as _time
+        # Use deterministic future timestamp instead of sleeping
+        future = _time.time() + 2.0
 
-        _time.sleep(1.1)
-
-        inbox = read_inbox("target", bus_root, status="resolved")
+        inbox = read_inbox("target", bus_root, status="resolved", now=future)
         assert len(inbox) == 1
         assert inbox[0]["status"] == "resolved"
 


### PR DESCRIPTION
## Summary
- Add `now: float | None = None` keyword parameter to `read_inbox()` and forward it to `_expire_stale_on_read()`
- Replace all 3 `time.sleep(1.1)` calls in TTL auto-expire tests with deterministic future timestamps

## Why
Issue #1285: `read_inbox()` didn't expose the `now` parameter that `_expire_stale_on_read()` already accepts, forcing TTL tests to use real wall-clock sleeps. This made tests ~3.3s slower than necessary and introduced flakiness potential on slow CI runners.

## Changes
| File | Change |
|------|--------|
| `src/bid_euchre/ops/message_bus.py` | Add `now` kwarg to `read_inbox()`, pass through to `_expire_stale_on_read()` |
| `tests/unit/test_ops_message_bus.py` | Replace 3× `time.sleep(1.1)` with `now=time.time() + 2.0` |

## Repro / Validation
```bash
# Run the affected tests — all pass without sleeps
uv run python -m pytest tests/unit/test_ops_message_bus.py -xvs -k "auto_expire"

# Verify no time.sleep remaining
grep -c "time.sleep" tests/unit/test_ops_message_bus.py  # → 0

# Full validation
make check-quiet  # ✓ All checks passed
```

## Tests
```bash
uv run python -m pytest tests/unit/test_ops_message_bus.py -xvs -k "auto_expire"  # 4 passed
make check-quiet  # ✓ All checks passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: fix/read-inbox-now-param-b
```

Fixes #1285

🤖 Generated with [Claude Code](https://claude.com/claude-code)