### PR TITLE
docs: add concrete channel-aware steward startup path (Platform-8)

### DIFF
--- a/plans/agent_ops/governing_plan.md
+++ b/plans/agent_ops/governing_plan.md
@@ -1223,6 +1223,33 @@ These are the short names future handoffs should use.
   - verify the steward session is launched with the needed `--channels` entries
   - verify plugin/runtime prerequisites before proving (for example Bun for
     official plugins)
+- channel-aware startup path:
+  - the tmux launcher (`steward-session.sh`) gains an optional
+    `STEWARD_CHANNELS` environment variable (e.g.,
+    `STEWARD_CHANNELS="telegram"` or `STEWARD_CHANNELS="telegram,discord"`)
+  - when `STEWARD_CHANNELS` is set, the launcher runs a preflight check
+    before creating any tmux windows:
+    1. confirm `claude --version` reports a channels-capable build
+    2. confirm each named channel plugin is resolvable (e.g., the Bun-based
+       Telegram plugin exists at the expected path)
+    3. confirm auth prerequisites are satisfied (claude.ai login, plugin
+       pairing tokens)
+    4. if any preflight check fails, log the failure and fall back to the
+       tmux-only startup path (no `--channels` flags), so the steward session
+       is never blocked by channel misconfiguration
+  - when preflight passes, each lane launch command adds `--channels`
+    entries derived from `STEWARD_CHANNELS`:
+    ```
+    $CLAUDE_BIN --name orchestrator --agent steward-orchestrator \
+      --channels telegram
+    ```
+    only the orchestrator and ops lanes receive `--channels` by default;
+    author lanes remain tmux-only unless explicitly opted in
+  - the registry metadata (`write_lane_metadata`) records which channels
+    were enabled for each lane, so the supervisor and dashboard can surface
+    channel health alongside lane status
+  - this startup path is additive — omitting `STEWARD_CHANNELS` preserves
+    the existing tmux-only behavior with no changes to the launch sequence
 - proving ladder:
   - prove the channel shape locally first with a non-production path
     (for example fakechat or a minimal webhook channel server)


### PR DESCRIPTION
## Plan
`plans/agent_ops/governing_plan.md` — Platform-8 section

## Summary
- Add a `channel-aware startup path` subsection to the Platform-8 slice of the governing plan
- Describes `STEWARD_CHANNELS` env var, preflight validation, per-lane `--channels` injection, registry metadata, and graceful fallback

## Why
Review finding from issue #1254 (convention follow-up for PR #1252): the governing plan described channel preflight checks and delivery-adapter upgrade concepts but lacked a concrete startup path showing how the tmux launcher integrates Claude Channels.

## Repro / Validation
**Command(s) run:**
```bash
make check-quiet
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `make check-quiet` — all checks passed
- [x] Plans/docs-only change — no code tests needed

## Expected impact
- Metrics impact: None (docs-only)
- Runtime impact: None (docs-only)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         5cf1a6a8 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d   7f8f3ded [fix/1254-channel-startup-path]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

Closes #1254

🤖 Generated with [Claude Code](https://claude.com/claude-code)