### PR TITLE
hooks: consolidate Bash hooks into dispatchers to suppress TUI noise

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -138,19 +138,56 @@ claude-work  # Uses auto-generated timestamp branch
 4. Changes to worktree directory
 5. Starts `claude` session in worktree
 
+### `pre-bash-dispatch.sh` (PreToolUse — Bash)
+
+**Trigger:** Before any Bash tool call
+
+**Purpose:** Consolidated dispatcher that runs all PreToolUse Bash hooks in a
+single invocation to minimize "Async hook completed" TUI messages (issue #1255).
+
+**Dispatches to (in order):**
+1. `pre-worktree-cleanup.sh` — blocks dangerous rm/worktree commands
+2. `pre-merge-review-guard.sh` — blocks merge without review verdict
+3. `rule-loader.sh` — progressive rule disclosure (context injection)
+
+Guards run first: if either blocks (exit 2), the block propagates immediately
+and rule-loader is skipped.
+
+### `post-bash-dispatch.sh` (PostToolUse — Bash)
+
+**Trigger:** After any Bash tool call
+
+**Purpose:** Consolidated dispatcher that runs all PostToolUse Bash hooks in a
+single invocation to minimize "Async hook completed" TUI messages (issue #1255).
+
+**Dispatches to (in order):**
+1. `post-pr-review.sh` — enqueues review request after `gh pr create`
+2. `post-pr-review-loop.sh` — launches review driver after `gh pr create`
+3. `post-push-ci-check.sh` — launches CI poller after `git push`
+4. `post-merge-ci-check.sh` — checks main CI after `gh pr merge`
+5. `post-merge-review.sh` — triggers post-merge review after `gh pr merge`
+6. `post-tool-daemon-notify.sh` — checks for background daemon failures
+7. `post-task-event.sh` — emits task events on relevant commands
+8. `post-merge-notify.sh` — auto-completes task lifecycle on merge
+
+For typical Bash commands, all sub-hooks exit immediately (<100ms each).
+Only specific commands (`gh pr create`, `git push`, `gh pr merge`) trigger
+meaningful work.
+
 ## Configuration
 
 Hooks are registered across two files:
 
 **`.claude/settings.json`** (committed, shared):
-- `SessionStart` → `compact-context.sh`
-- `PostToolUse` (Write) → `post-write-check.sh`
-- `PreToolUse` (Bash) → `pre-merge-review-guard.sh`
+- `SessionStart` → `compact-context.sh`, `session-sync-worktree.sh`
+- `PreToolUse` (Edit|Write) → `rule-loader.sh`
+- `PreToolUse` (Bash) → `pre-bash-dispatch.sh` (consolidated dispatcher)
+- `PostToolUse` (Write|Edit) → `post-write-check.sh`
+- `PostToolUse` (Bash) → `post-bash-dispatch.sh` (consolidated dispatcher)
 
 **`.claude/settings.local.json`** (gitignored, per-machine):
 - `SessionStart` → `worktree-reminder.sh`
 - `UserPromptSubmit` → `worktree-guard.sh`
-- `PostToolUse` (Bash) → `post-pr-review.sh`
 
 ## Limitations
 

--- a/.claude/hooks/post-bash-dispatch.sh
+++ b/.claude/hooks/post-bash-dispatch.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# post-bash-dispatch.sh — Consolidated PostToolUse dispatcher for Bash tool calls.
+#
+# Runs all PostToolUse hooks for Bash in a single invocation to minimize
+# "Async hook completed" TUI messages (issue #1255). Dispatches to each
+# sub-hook sequentially, collecting any additionalContext output.
+#
+# Sub-hooks (order matters for merge/push flows):
+#   1. post-pr-review.sh — enqueues review request after gh pr create
+#   2. post-pr-review-loop.sh — launches review driver after gh pr create
+#   3. post-push-ci-check.sh — launches CI poller after git push
+#   4. post-merge-ci-check.sh — checks main CI after gh pr merge
+#   5. post-merge-review.sh — triggers post-merge review after gh pr merge
+#   6. post-tool-daemon-notify.sh — checks for background daemon failures
+#   7. post-task-event.sh — emits task events on relevant commands
+#   8. post-merge-notify.sh — auto-completes task lifecycle on merge
+#
+# For typical Bash commands (cd, ls, git status, pytest, etc.), all hooks
+# exit immediately (<100ms each). Only specific commands (gh pr create,
+# git push, gh pr merge) trigger meaningful work.
+#
+# Timeout: 45s (accommodates post-merge-ci-check's sleep 10 + API calls)
+set -euo pipefail
+
+HOOKS_DIR="${CLAUDE_PROJECT_DIR:-.}/.claude/hooks"
+
+# Read JSON from stdin once
+INPUT=$(cat)
+
+# Collect additionalContext from all hooks that produce output
+COMBINED_CONTEXT=""
+
+run_hook() {
+    local hook_script="$1"
+    local output=""
+
+    if [ ! -x "$hook_script" ]; then
+        return 0
+    fi
+
+    # Run the hook, piping saved stdin.
+    # Sub-hooks that launch background processes must redirect their own
+    # stdout/stderr (e.g., > logfile 2>&1 &) so they don't hold this
+    # pipe open. See post-push-ci-check.sh fix.
+    output=$(echo "$INPUT" | "$hook_script" 2>/dev/null) || true
+
+    if [ -n "$output" ]; then
+        # Extract additionalContext from hookSpecificOutput (PostToolUse schema)
+        local ctx=""
+        ctx=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null || true)
+        if [ -n "$ctx" ]; then
+            if [ -n "$COMBINED_CONTEXT" ]; then
+                COMBINED_CONTEXT="${COMBINED_CONTEXT}
+---
+${ctx}"
+            else
+                COMBINED_CONTEXT="$ctx"
+            fi
+        fi
+    fi
+}
+
+# Run all sub-hooks sequentially
+run_hook "$HOOKS_DIR/post-pr-review.sh"
+run_hook "$HOOKS_DIR/post-pr-review-loop.sh"
+run_hook "$HOOKS_DIR/post-push-ci-check.sh"
+run_hook "$HOOKS_DIR/post-merge-ci-check.sh"
+run_hook "$HOOKS_DIR/post-merge-review.sh"
+run_hook "$HOOKS_DIR/post-tool-daemon-notify.sh"
+run_hook "$HOOKS_DIR/post-task-event.sh"
+run_hook "$HOOKS_DIR/post-merge-notify.sh"
+
+# Return combined output (if any hooks produced context)
+if [ -n "$COMBINED_CONTEXT" ]; then
+    echo "$COMBINED_CONTEXT" | jq -Rs '{hookSpecificOutput: {hookEventName: "PostToolUse", additionalContext: .}}'
+fi
+
+exit 0

--- a/.claude/hooks/post-push-ci-check.sh
+++ b/.claude/hooks/post-push-ci-check.sh
@@ -67,10 +67,14 @@ if [[ "$COMMAND" == *"git push"* ]] && [[ "$EXIT_CODE" == "0" ]] \
     # Auto-merge authority has been moved to the merge guard
     # (pre-merge-review-guard.sh). The poller now only monitors CI status
     # and writes status files; it does not attempt to merge.
+    #
+    # Redirect stdout/stderr to /dev/null so the background process does
+    # not hold the parent's stdout pipe open (needed for dispatcher
+    # consolidation — see post-bash-dispatch.sh, issue #1255).
     (
         cd "$REPO_ROOT"
         bash "$POLLER" --pr "$PR_NUM" --repo-root "$REPO_ROOT"
-    ) &
+    ) > /dev/null 2>&1 &
 
     cat <<EOF
 {

--- a/.claude/hooks/pre-bash-dispatch.sh
+++ b/.claude/hooks/pre-bash-dispatch.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# pre-bash-dispatch.sh — Consolidated PreToolUse dispatcher for Bash tool calls.
+#
+# Runs all PreToolUse hooks for Bash in a single invocation to minimize
+# "Async hook completed" TUI messages (issue #1255). Dispatches to:
+#   1. pre-worktree-cleanup.sh — blocks dangerous rm/worktree commands
+#   2. pre-merge-review-guard.sh — blocks merge without review verdict
+#   3. rule-loader.sh — progressive rule disclosure (context injection)
+#
+# Guards run first: if either blocks (exit 2), we propagate immediately.
+# Rule-loader runs last since context injection is only useful if the
+# command is allowed to proceed.
+#
+# Exit codes: 0 = allow, 2 = block (propagated from sub-hooks)
+# Timeout: 15s (accommodates merge guard's gh API calls)
+set -euo pipefail
+
+HOOKS_DIR="${CLAUDE_PROJECT_DIR:-.}/.claude/hooks"
+
+# Read JSON from stdin once, reuse for all sub-hooks
+INPUT=$(cat)
+
+# --- 1. Worktree cleanup guard (may block with exit 2) ---
+if [ -x "$HOOKS_DIR/pre-worktree-cleanup.sh" ]; then
+    WT_OUTPUT=""
+    WT_EXIT=0
+    WT_OUTPUT=$(echo "$INPUT" | "$HOOKS_DIR/pre-worktree-cleanup.sh" 2>/dev/null) || WT_EXIT=$?
+    if [ "$WT_EXIT" -ne 0 ]; then
+        # Propagate block — output the guard's message and exit
+        echo "$WT_OUTPUT"
+        exit "$WT_EXIT"
+    fi
+fi
+
+# --- 2. Merge review guard (may block with exit 2) ---
+if [ -x "$HOOKS_DIR/pre-merge-review-guard.sh" ]; then
+    MRG_OUTPUT=""
+    MRG_EXIT=0
+    MRG_OUTPUT=$(echo "$INPUT" | "$HOOKS_DIR/pre-merge-review-guard.sh" 2>/dev/null) || MRG_EXIT=$?
+    if [ "$MRG_EXIT" -ne 0 ]; then
+        echo "$MRG_OUTPUT"
+        exit "$MRG_EXIT"
+    fi
+fi
+
+# --- 3. Rule loader (never blocks, may return additionalContext) ---
+if [ -x "$HOOKS_DIR/rule-loader.sh" ]; then
+    RULE_OUTPUT=""
+    RULE_OUTPUT=$(echo "$INPUT" | "$HOOKS_DIR/rule-loader.sh" 2>/dev/null) || true
+
+    # Check if rule-loader returned additionalContext
+    if [ -n "$RULE_OUTPUT" ]; then
+        AC=$(echo "$RULE_OUTPUT" | jq -r '.additionalContext // empty' 2>/dev/null || true)
+        if [ -n "$AC" ]; then
+            # Pass through rule-loader's full output (includes additionalContext + suppressOutput)
+            echo "$RULE_OUTPUT"
+            exit 0
+        fi
+    fi
+fi
+
+# All guards passed, no context to inject
+echo '{"suppressOutput": true}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Edit|Write|Read|Bash",
+        "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",
@@ -16,13 +16,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-worktree-cleanup.sh",
-            "timeout": 5
-          },
-          {
-            "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-merge-review-guard.sh",
-            "timeout": 10
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-bash-dispatch.sh",
+            "timeout": 15
           }
         ]
       }
@@ -75,43 +70,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-pr-review.sh",
-            "timeout": 5
-          },
-          {
-            "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-pr-review-loop.sh",
-            "timeout": 5
-          },
-          {
-            "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-push-ci-check.sh",
-            "timeout": 10
-          },
-          {
-            "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-merge-ci-check.sh",
-            "timeout": 30
-          },
-          {
-            "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-merge-review.sh",
-            "timeout": 5
-          },
-          {
-            "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-tool-daemon-notify.sh",
-            "timeout": 5
-          },
-          {
-            "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-task-event.sh",
-            "timeout": 5
-          },
-          {
-            "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-merge-notify.sh",
-            "timeout": 10
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-bash-dispatch.sh",
+            "timeout": 45
           }
         ]
       }

--- a/tests/unit/test_hook_dispatchers.py
+++ b/tests/unit/test_hook_dispatchers.py
@@ -1,0 +1,152 @@
+"""Tests for consolidated hook dispatchers (issue #1255).
+
+The pre-bash-dispatch.sh and post-bash-dispatch.sh scripts consolidate
+multiple hooks into single invocations to reduce TUI noise.  These tests
+verify:
+  - Normal commands pass through with suppressOutput
+  - Blocking commands propagate exit code 2
+  - Rule-loader context injection works through the dispatcher
+  - PostToolUse dispatcher produces no output for non-matching commands
+  - Background process stdout is properly redirected (post-push-ci-check fix)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+HOOKS_DIR = Path(__file__).resolve().parents[2] / ".claude" / "hooks"
+
+
+def _run_hook(
+    script: str, payload: dict, env_override: dict | None = None
+) -> tuple[int, str, dict | None]:
+    """Run a hook script with JSON payload on stdin.
+
+    Returns (exit_code, raw_stdout, parsed_json_or_None).
+    """
+    env = os.environ.copy()
+    # Point to repo root so sub-hooks can be found
+    env["CLAUDE_PROJECT_DIR"] = str(HOOKS_DIR.parents[1])
+    if env_override:
+        env.update(env_override)
+
+    result = subprocess.run(
+        ["bash", str(HOOKS_DIR / script)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+
+    parsed = None
+    stdout = result.stdout.strip()
+    if stdout:
+        try:
+            parsed = json.loads(stdout)
+        except json.JSONDecodeError:
+            pass  # Blocking paths emit free-form text
+
+    return result.returncode, stdout, parsed
+
+
+class TestPreBashDispatch:
+    """pre-bash-dispatch.sh consolidates PreToolUse Bash hooks."""
+
+    SCRIPT = "pre-bash-dispatch.sh"
+
+    def test_normal_command_passes_with_suppress(self) -> None:
+        """A safe command should pass through with suppressOutput."""
+        rc, _raw, out = _run_hook(
+            self.SCRIPT, {"tool_name": "Bash", "tool_input": {"command": "ls -la"}}
+        )
+        assert rc == 0
+        assert out is not None
+        assert out.get("suppressOutput") is True
+
+    def test_dangerous_worktree_command_blocks(self) -> None:
+        """Dangerous worktree operations should block with exit 2."""
+        rc, raw, _out = _run_hook(
+            self.SCRIPT,
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "git worktree prune"},
+            },
+        )
+        assert rc == 2
+        assert "BLOCKED" in raw
+
+    def test_dangerous_rm_command_blocks(self) -> None:
+        """rm -rf on Bid-Euchre directories should block."""
+        rc, raw, _out = _run_hook(
+            self.SCRIPT,
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "rm -rf ../Bid-Euchre-steward-author"},
+            },
+        )
+        assert rc == 2
+        assert "BLOCKED" in raw
+
+    def test_rule_loader_context_injection(self) -> None:
+        """Rule-loader should inject context when matching notebook paths."""
+        # Clear any loaded-rules sentinel so the rule-loader triggers
+        runtime_dir = HOOKS_DIR.parents[1] / ".claude" / "runtime"
+        for sentinel in runtime_dir.glob(".loaded_rules_*"):
+            sentinel.unlink(missing_ok=True)
+
+        rc, _raw, out = _run_hook(
+            self.SCRIPT,
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "cat notebooks/analysis.py"},
+            },
+        )
+        assert rc == 0
+        assert out is not None
+        assert out.get("suppressOutput") is True
+        # Rule-loader should have injected context for notebook paths
+        assert out.get("additionalContext") is not None
+
+
+class TestPostBashDispatch:
+    """post-bash-dispatch.sh consolidates PostToolUse Bash hooks."""
+
+    SCRIPT = "post-bash-dispatch.sh"
+
+    def test_normal_command_produces_no_output(self) -> None:
+        """Non-matching commands should produce no output."""
+        rc, raw, _out = _run_hook(
+            self.SCRIPT,
+            {
+                "tool_input": {"command": "git status"},
+                "tool_response": {"exit_code": 0, "stdout": ""},
+            },
+        )
+        assert rc == 0
+        assert raw == ""
+
+    def test_failed_command_produces_no_output(self) -> None:
+        """Failed commands should produce no output (exit_code != 0)."""
+        rc, raw, _out = _run_hook(
+            self.SCRIPT,
+            {
+                "tool_input": {"command": "git push origin main"},
+                "tool_response": {"exit_code": 1, "stdout": ""},
+            },
+        )
+        assert rc == 0
+        assert raw == ""
+
+
+class TestPostPushCiCheckStdoutRedirect:
+    """post-push-ci-check.sh must redirect background process stdout."""
+
+    def test_background_redirect_present(self) -> None:
+        """The background poller launch must redirect stdout/stderr."""
+        hook_content = (HOOKS_DIR / "post-push-ci-check.sh").read_text()
+        # The fix adds > /dev/null 2>&1 to the background subshell
+        assert "> /dev/null 2>&1 &" in hook_content


### PR DESCRIPTION
## Summary

- **Consolidate 11 per-Bash-call hooks into 2 dispatcher scripts** (`pre-bash-dispatch.sh` and `post-bash-dispatch.sh`) to eliminate noisy "Async hook completed" TUI messages
- **Narrow rule-loader matcher** from `Edit|Write|Read|Bash` to `Edit|Write` (Bash handled by dispatcher, Read drops to 0 hooks)
- **Fix background stdout leak** in `post-push-ci-check.sh` that would block dispatcher's command substitution

## Why

Issue #1255: Every Bash tool call triggered 11 individual hook completions (3 PreToolUse + 8 PostToolUse), each producing an "Async hook completed" line in the TUI. Most hooks exit immediately for non-matching commands but still generate noise. The dispatcher pattern runs all sub-hooks from a single hook registration, reducing completion messages from 11 to 2 per Bash call.

## Hook count reduction

| Tool | Before | After | Reduction |
|------|--------|-------|-----------|
| Bash | 11 hooks | 2 hooks | **82%** |
| Read | 1 hook | 0 hooks | **100%** |
| Edit | 2 hooks | 2 hooks | — |
| Write | 2 hooks | 2 hooks | — |

## Repro / Validation

```bash
# Test dispatchers directly
echo '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' | \
  CLAUDE_PROJECT_DIR=. .claude/hooks/pre-bash-dispatch.sh

echo '{"tool_input":{"command":"git status"},"tool_response":{"exit_code":0,"stdout":""}}' | \
  CLAUDE_PROJECT_DIR=. .claude/hooks/post-bash-dispatch.sh

# Run regression tests
uv run python -m pytest tests/unit/test_hook_dispatchers.py -v
```

## Tests

```bash
uv run python -m pytest tests/unit/test_hook_dispatchers.py -v  # 7 passed
make check-quiet  # All checks passed
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b
branch: fix/suppress-noisy-hook-messages
```

Closes #1255

🤖 Generated with [Claude Code](https://claude.com/claude-code)