### PR TITLE
docs: reconcile Phase 3 plan with BD-004 delivery (fix:convention #1265)

### DIFF
--- a/plans/agent_ops/3_supervision_and_scaling/plan.md
+++ b/plans/agent_ops/3_supervision_and_scaling/plan.md
@@ -37,7 +37,11 @@ Before treating Phase 4 as ready, verify Batch D (Platform-6 + Platform-7):
   archaeology
 - [x] In the current tmux-first steward layout, a dispatched task can land in the
   target live author session through a repo-owned delivery adapter without
-  manual pane inspection
+  manual pane inspection *(added by SP-3-03, satisfied by PR #1263)*
+
+> **Note:** Criterion 4 was added to the gate after the initial Batch D
+> assessment. It was introduced and verified by SP-3-03 (BD-004 v1 pane
+> delivery, PR #1263).
 
 ## Platform-6 Summary (Complete)
 
@@ -79,6 +83,9 @@ From governing plan:
     demand without requiring all author panes to be pre-opened
   - Dynamic worker creation and retirement obey repo-owned concurrency and
     cleanup limits
+  - A dispatched task reaches the target live author session through a
+    repo-owned delivery adapter without manual pane inspection
+    *(BD-004, delivered by SP-3-03 / PR #1263)*
 
 ## Later Delivery Upgrades
 


### PR DESCRIPTION
## Summary
- Annotate Batch D pass gate criterion 4 with SP-3-03/PR #1263 provenance
- Add note clarifying the criterion was added after the initial batch assessment
- Mirror the BD-004 delivery adapter scope in Platform-7's done-when list

## Why
Convention follow-up from autonomous review of PR #1263. The review identified
two reconciliation gaps in the Phase 3 plan: the newly added gate criterion
lacked provenance, and Platform-7's done-when list didn't reflect the BD-004
delivery scope it shipped.

Closes #1265

## Repro / Validation
```bash
make check-quiet  # All checks passed
```

**Config:** N/A (docs-only)
**Seed:** N/A

## Tests
- [x] `make check-quiet` — all checks passed (5949 tests, ruff, repo-lint, notebook-check, docs-check)

## Expected impact
- Metrics impact: None (plan documentation only)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git worktree list`:
(persistent steward worktree — brws-author-c lane)

## Validation Performed
- `make check-quiet` passes (ruff, pytest 5949 passed, notebook-check, docs-check, repo-lint)
- Only 1 file changed: `plans/agent_ops/3_supervision_and_scaling/plan.md` (+8 lines)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)