### PR TITLE
ops: remove stale issues lane reference from launcher

### DIFF
--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -355,7 +355,7 @@ tmux select-layout -t "${SESSION}:scratch" tiled
 # Wait briefly for the claude process to initialize, then send the /loop
 # command.  Best-effort — if it fails the ops agent can start it manually.
 # Target: central-ops window, pane 2 (ops lane).
-# Note: pane-base-index=1, so orchestrator=.1, ops=.2, review=.3, issues=.4.
+# Note: pane-base-index=1, so orchestrator=.1, ops=.2, review=.3.
 (
     sleep 10
     tmux send-keys -t "${SESSION}:central-ops.2" \

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -340,6 +340,10 @@ class TestWindowLayout:
             if line.strip().startswith('write_lane_metadata "issues"')
         ]
         assert len(metadata_lines) == 0, "issues metadata must be removed"
+        # No stale "issues" references in pane-index comments
+        assert (
+            "issues=" not in content
+        ), "stale 'issues=' reference in pane-index comment"
 
     def test_four_windows_created(self) -> None:
         """Exactly 4 tmux windows must be created (1 new-session + 3 new-window)."""


### PR DESCRIPTION
## Plan
N/A — task packet `71673a95f1f4` from orchestrator.

## Summary
- Remove stale `issues=.4` reference from pane-index comment in `steward-session.sh`
- Add regression test asserting no `issues=` references remain

## Why
The issues pane was already removed from the central-ops window layout. This cleans up the last stale comment referencing it. The bulk of the reshaping work (4 panes → 3 panes, tiled → main-vertical, issues lane removal) was completed in a prior PR.

## Repro / Validation
**Command(s) run:**
- `bash -n .claude/tmux/steward-session.sh` — syntax OK
- `uv run python -m pytest tests/unit/test_steward_session.py` — 48 passed
- `make check-quiet` — all checks passed

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_steward_session.py` — 48 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         79736625 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author          c463f48e [ops/reshape-central-ops-layout]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)