### PR TITLE
docs: update Phase 4 plan for official Channels discovery

### DIFF
--- a/plans/agent_ops/4_remote_channel/checkpoints.md
+++ b/plans/agent_ops/4_remote_channel/checkpoints.md
@@ -1,0 +1,52 @@
+# Phase 4 — Remote Operator Channels — Checkpoints
+
+**Phase:** 4 (`4_remote_channel`)
+**Status:** PENDING
+**Governing plan:** `plans/agent_ops/governing_plan.md`
+**Phase plan:** `plans/agent_ops/4_remote_channel/plan.md`
+
+## Steps
+
+### Step 1 — Platform-8a: Configure Telegram plugin and prove core capabilities
+
+**Status:** PENDING
+**Description:** Configure official Telegram plugin, prove pairing, sender
+gating, permission relay, and kill switch in the steward environment.
+**Depends on:** Phase 3 COMPLETE
+**Done when:**
+- Telegram plugin pairs with steward session
+- Sender gating rejects unknown senders
+- Permission relay enables remote tool approval
+- Kill switch terminates channel without session disruption
+- Lane registry records channel status
+
+### Step 2 — Platform-9: Prove idle-attention alerts with dedupe and ack
+
+**Status:** PENDING
+**Description:** Prove idle-attention alerts with dedupe and ack through the
+configured Telegram channel. Audit trail deferred to hardening (Platform-14).
+**Depends on:** Step 1
+**Done when:**
+- Idle-attention alerts fire after 5-minute threshold
+- Alerts are deduplicated and rate-limited
+- Acknowledgement or bounded reply recorded in durable coordination state
+
+### Step 3 — Batch E pass gate
+
+**Status:** PENDING
+**Description:** Verify Batch E pass gate criteria from the governing plan.
+**Depends on:** Steps 1 and 2
+**Done when:**
+- One real away-from-keyboard idle-attention flow reaches Telegram successfully
+- Acknowledgements and bounded replies are recorded durably
+- Dedupe/backoff prevents noisy alert spam in a proving run
+
+## Blockers
+
+(none)
+
+## Session Log
+
+| Date | Summary |
+|------|---------|
+| 2026-03-23 | Phase 4 plan and checkpoints created. Official Claude Code Channels discovery (v2.1.80+) reduces Platform-8a scope from "build transport skeleton" to "configure official Telegram plugin." Permission relay and sender gating are framework-provided. Audit trail deferred to hardening (Platform-14). |

--- a/plans/agent_ops/4_remote_channel/plan.md
+++ b/plans/agent_ops/4_remote_channel/plan.md
@@ -1,0 +1,132 @@
+# Phase 4 — Remote Operator Channels
+
+**Status:** PENDING (scope lock not yet entered)
+**Governing plan:** `plans/agent_ops/governing_plan.md`
+**Slices:** Platform-8 (Remote Operator Channel), Platform-9 (Idle Attention Flow)
+**Depends on:** Phase 3 (COMPLETE)
+
+## Discovery: Official Claude Code Channels
+
+> **Reference:** <https://code.claude.com/docs/en/channels-reference>
+
+Claude Code v2.1.80+ ships a Channels feature (research preview) with pre-built
+Telegram and Discord plugins. Key capabilities:
+
+| Capability | Description |
+|------------|-------------|
+| **Pairing** | Phone pairs to running Claude session via QR code / pairing code |
+| **Sender gating** | Only the paired account can send messages to the session |
+| **Reply tools** | Structured reply/approval surfaces in Telegram/Discord |
+| **Permission relay** | Remote tool-approval from phone — approve/deny tool calls without terminal access |
+| **Kill switch** | Terminate the channel subprocess to disconnect immediately |
+
+This discovery significantly reduces Platform-8 scope: the transport skeleton,
+sender gating, and permission relay are provided by the framework rather than
+built from scratch.
+
+### Prerequisites
+
+- Claude Code v2.1.80+ (`claude --version`)
+- Active claude.ai login (`claude auth status`)
+- `--channels telegram` flag in session launch
+- Bun runtime (for official Telegram plugin)
+
+## Platform-8a — Telegram Plugin Configuration and Proving
+
+**Scope (updated from "build transport skeleton"):** Configure the official
+Telegram plugin, prove pairing + sender gating + permission relay + kill switch
+in the steward environment.
+
+### Steps
+
+1. **Preflight verification** — confirm Claude Code version, Bun availability,
+   plugin resolvability, and auth prerequisites
+2. **Plugin configuration** — set up Telegram bot token, configure
+   `STEWARD_CHANNELS="telegram"` in tmux launcher
+3. **Pairing proof** — pair from phone, verify sender gating rejects unknown
+   senders
+4. **Permission relay proof** — trigger a tool-approval prompt, approve remotely
+   from phone
+5. **Kill switch proof** — terminate channel subprocess, verify session continues
+   without channel
+6. **Registry integration** — record channel status in lane metadata via
+   `write_lane_metadata`
+
+### Done when
+
+- Telegram plugin pairs successfully with the steward session
+- Sender gating rejects messages from non-paired accounts
+- Permission relay enables remote tool approval
+- Kill switch terminates channel cleanly without affecting the session
+- Lane registry records channel health status
+
+## Platform-8b — Audit Trail (Deferred to Hardening)
+
+> **Known gap:** v1 relies on session logs + Telegram chat history for audit
+> trail. A repo-owned audit trail (structured log of all channel
+> messages/approvals) is deferred to Platform-14 (hardening phase).
+
+This is a conscious deferral, not a missing requirement. The rationale:
+
+- Session logs capture all tool approvals and their outcomes
+- Telegram chat history preserves the operator-side conversation
+- A repo-owned structured audit trail adds value for cross-session analysis
+  but is not blocking for the v1 remote supervision use case
+- Hardening phase (Platform-14) is the natural home for structured logging
+  and operational observability improvements
+
+## Platform-9 — Idle Attention Flow
+
+**Scope:** Prove idle-attention alerts with dedupe and ack through the
+configured Telegram channel.
+
+### Steps
+
+1. **Idle detection** — ops supervisor detects lanes awaiting user attention
+   for >5 minutes
+2. **Alert routing** — summarized alert sent through Telegram channel
+3. **Dedupe and backoff** — prevent duplicate alerts for the same idle event
+4. **Acknowledgement handling** — operator ack via Telegram reply is recorded
+   in durable coordination state
+5. **Bounded reply mapping** — Telegram replies map to bounded inbound commands
+   (inspect, reroute, pause, summarize)
+
+### Done when
+
+- Idle-attention alerts fire after 5-minute threshold
+- Alerts are deduplicated and rate-limited
+- Acknowledgements and bounded replies are recorded durably
+
+## Phase 4 Operating Model
+
+### Permission Relay in v1
+
+Permission relay enables remote tool approval from phone. This is a key
+Platform-8 feature that was not anticipated in the original plan but is
+provided by the official Channels framework.
+
+In the v1 operating model:
+- Orchestrator and ops lanes receive `--channels telegram` by default
+- Author lanes remain tmux-only unless explicitly opted in
+- Permission relay is available on channel-enabled lanes
+- The operator can approve/deny tool calls from Telegram without terminal access
+
+### Channel Lifecycle
+
+```
+Session start
+  -> preflight check (version, auth, plugin)
+  -> if pass: launch with --channels telegram
+  -> if fail: fall back to tmux-only (no degradation)
+
+During operation:
+  -> pairing on first connect
+  -> sender gating on all inbound messages
+  -> permission relay on tool-approval prompts
+  -> idle alerts on 5-minute attention threshold
+
+Kill switch:
+  -> terminate channel subprocess
+  -> session continues without channel
+  -> reconnect by restarting channel subprocess
+```

--- a/plans/agent_ops/amendments.md
+++ b/plans/agent_ops/amendments.md
@@ -1,7 +1,7 @@
 # Agentic Orchestration Platform — Amendments
 
 **Governing plan:** `plans/agent_ops/governing_plan.md`
-**Last updated:** 2026-03-22 (SP-3-04 closeout)
+**Last updated:** 2026-03-23 (A9: Channels discovery)
 
 ---
 
@@ -204,3 +204,45 @@ re-litigating the same architectural boundary.
 lagged behind shipped reality. This amendment closes that gap and establishes
 the dual-domain layout transition as the next governed action, preventing
 future sessions from having to reconstruct intent from chat history.
+
+---
+
+## A9 — Official Claude Code Channels discovery — Platform-8a scope reduction (2026-03-23)
+
+**PR:** pending (this amendment)
+
+**What changed:**
+1. **Official Channels discovery** — Claude Code v2.1.80+ ships a Channels
+   feature (research preview) with pre-built Telegram and Discord plugins.
+   These provide pairing, sender gating, reply tools, and permission relay
+   out of the box. Reference: <https://code.claude.com/docs/en/channels-reference>
+2. **Platform-8a scope reduced** — Changed from "build transport skeleton" to
+   "configure official Telegram plugin, prove pairing + sender gating +
+   permission relay + kill switch." The framework provides the transport,
+   authentication, and permission relay machinery; the platform work is now
+   configuration and proving rather than implementation.
+3. **Permission relay added as key feature** — Remote tool approval from phone
+   was not anticipated in the original plan but is provided by the framework.
+   This enables operators to approve/deny tool calls from Telegram without
+   terminal access. The security boundary now enables permission relay during
+   Platform-8a proving (previously: "keep permission relay disabled by default").
+4. **Audit trail deferred to hardening** — Platform-8b (repo-owned structured
+   audit trail of channel messages/approvals) deferred to Platform-14
+   (hardening phase). v1 relies on session logs + Telegram chat history.
+   Noted as a known gap, not a blocking prerequisite.
+5. **Prerequisites documented** — Claude Code v2.1.80+, active claude.ai
+   login, `--channels` flag in tmux launcher, Bun runtime for official plugins.
+6. **Phase 4 plan and checkpoints created** — New directory
+   `plans/agent_ops/4_remote_channel/` with `plan.md` and `checkpoints.md`
+   reflecting the reduced scope.
+7. **Message flow correction** — "issues -> orchestrator" updated to
+   "review -> orchestrator" (issues lane removed in #1296, review owns
+   triage per #1297).
+
+**Rationale:** The original Platform-8 design assumed the transport skeleton,
+sender gating, and permission relay would need to be built from scratch or
+adapted from a minimal repo-owned fallback. The Channels research preview
+provides all of these as framework features. This reduces Platform-8 from a
+multi-PR implementation effort to a configuration-and-proving exercise, while
+preserving the same done-when criteria and the fallback-adapter escape hatch
+if the official plugin path proves unstable.

--- a/plans/agent_ops/governing_plan.md
+++ b/plans/agent_ops/governing_plan.md
@@ -113,6 +113,7 @@ Completed phases:
 - `plans/agent_ops/1_coordination_core/checkpoints.md` (Phase 1 — COMPLETE, 2026-03-21)
 - `plans/agent_ops/2_visible_operating_model/checkpoints.md` (Phase 2 — COMPLETE, 2026-03-22)
 - `plans/agent_ops/3_supervision_and_scaling/checkpoints.md` (Phase 3 — COMPLETE, 2026-03-22)
+- `plans/agent_ops/4_remote_channel/checkpoints.md` (Phase 4 — PENDING)
 
 Agents should treat checkpoints as the human-readable source of current step
 status, blockers, and session handoff state.
@@ -378,8 +379,8 @@ The platform must not rely on best-effort message passing between lanes.
   - supervisor alerts, retry/reroute recommendations
 - `review -> orchestrator`
   - plan review outcome, PR findings, validation status
-- `issues -> orchestrator`
-  - issue created/updated, threshold crossed
+- `review -> orchestrator`
+  - issue created/updated, threshold crossed, triage results
 - remote channel -> `orchestrator` / `ops`
   - bounded user replies, acknowledgements, reroute/inspect requests
 
@@ -575,6 +576,16 @@ The platform must expose its own health signals, including:
 - registry/message mismatch counts
 
 ## Remote Operator Channels
+
+> **Discovery (2026-03-23):** Claude Code v2.1.80+ ships a Channels feature
+> (research preview) with pre-built Telegram and Discord plugins. These provide
+> pairing, sender gating, reply tools, and permission relay out of the box.
+> Reference: <https://code.claude.com/docs/en/channels-reference>
+>
+> This significantly reduces Platform-8 scope: the transport skeleton, sender
+> gating, and permission relay are framework-provided. Platform-8a becomes
+> "configure official Telegram plugin and prove core capabilities" rather than
+> "build transport skeleton." See `plans/agent_ops/4_remote_channel/plan.md`.
 
 The platform should support an official Claude Code plugin path for:
 
@@ -1258,7 +1269,8 @@ These are the short names future handoffs should use.
     channel is needed immediately
 - security boundary:
   - require pairing and sender allowlists before enabling two-way use
-  - keep permission relay disabled by default in Platform-8
+  - permission relay (remote tool approval from phone) is available in the
+    official Channels framework; enable it as part of Platform-8a proving
   - treat inbound remote messages as transport only until they are recorded or
     reflected in repo-owned state
 - fallback boundary:


### PR DESCRIPTION
## Summary

- Create Phase 4 plan and checkpoints (`plans/agent_ops/4_remote_channel/`) reflecting Claude Code Channels discovery (v2.1.80+)
- Platform-8a scope reduced from "build transport skeleton" to "configure official Telegram plugin, prove pairing + sender gating + permission relay + kill switch"
- Add A9 amendment recording the Channels discovery and scope reduction
- Update governing plan with Channels discovery note, permission relay enablement, Phase 4 checkpoint entry, and message flow correction (`issues -> review` per #1296/#1297)
- Defer repo-owned audit trail to Platform-14 (hardening) as known gap

## Why

Claude Code v2.1.80+ ships Channels (research preview) with pre-built Telegram and Discord plugins providing pairing, sender gating, reply tools, and permission relay. This fundamentally changes Platform-8 from a multi-PR implementation effort to a configuration-and-proving exercise. The planning docs need to reflect this discovery before Phase 4 scope lock.

## Changes

| File | Change |
|------|--------|
| `plans/agent_ops/4_remote_channel/plan.md` | **New** — Phase 4 plan with Channels discovery, Platform-8a/8b/9 steps, v1 operating model |
| `plans/agent_ops/4_remote_channel/checkpoints.md` | **New** — Phase 4 checkpoints (3 steps: 8a config/prove, 9 idle-attention, Batch E gate) |
| `plans/agent_ops/governing_plan.md` | Channels discovery note in Remote Operator Channels section; permission relay enabled in security boundary; Phase 4 checkpoint entry added; message flow `issues -> review` fix |
| `plans/agent_ops/amendments.md` | A9: Official Claude Code Channels discovery — Platform-8a scope reduction |

## Repro / Validation

```bash
make check-quiet   # docs-only, all checks pass
```

## Tests

- `make check-quiet` — passed (docs-only PR, no code changes)

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: docs/phase4-channels-discovery
```

## Task

Dispatched as `e6fb8fe70516` to author-b lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)