### PR TITLE
fix: emit task_completed event in task complete CLI

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -1618,6 +1618,26 @@ def cmd_task(args: argparse.Namespace) -> int:
             print(f"Failed to complete packet {packet_id!r}.", file=sys.stderr)
             return 1
 
+        # Emit task_completed event (append-only, best-effort)
+        try:
+            from bid_euchre.ops.events import append_event
+
+            append_event(
+                event_type="task_completed",
+                source="ops.task_complete",
+                lane_id=completed_by or (pkt.owner or "unknown"),
+                payload={
+                    "packet_id": packet_id,
+                    "title": pkt.title,
+                    "summary": summary,
+                    "pr_number": pr_number,
+                    "completed_by": completed_by or (pkt.owner or "unknown"),
+                },
+                events_dir=args.runtime_dir / "events",
+            )
+        except Exception:
+            pass  # best-effort — don't fail completion on event emission
+
         if args.json:
             from dataclasses import asdict
 

--- a/tests/unit/test_ops_cli.py
+++ b/tests/unit/test_ops_cli.py
@@ -3421,6 +3421,29 @@ class TestTaskComplete:
         )
         assert archive_path.exists()
 
+        # Verify task_completed event was emitted
+        events_dir = runtime_dir / "events"
+        event_files = sorted(events_dir.glob("*.jsonl"))
+        assert event_files, "Expected at least one event file"
+        events = []
+        for ef in event_files:
+            for line in ef.read_text().splitlines():
+                if line.strip():
+                    events.append(json.loads(line))
+        completed_events = [
+            e for e in events if e.get("event_type") == "task_completed"
+        ]
+        assert (
+            len(completed_events) == 1
+        ), f"Expected 1 task_completed event, got {len(completed_events)}"
+        evt = completed_events[0]
+        assert evt["payload"]["packet_id"] == packet_id
+        assert evt["payload"]["title"] == "Complete test"
+        assert evt["payload"]["summary"] == "All done"
+        assert evt["payload"]["pr_number"] == 1234
+        assert evt["payload"]["completed_by"] == "author-a"
+        assert evt["lane_id"] == "author-a"
+
     def test_task_complete_json_output(
         self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
## Summary
- Add `append_event(event_type="task_completed", ...)` to the `task complete` CLI handler
- Mirrors the existing `task_started` event emitted by `task accept`
- Best-effort: event emission failure does not block packet completion

## Why
The `task accept` subcommand emits a `task_started` event but `task complete` was silent (#1307, #1308). This breaks event-driven workflows that depend on lifecycle symmetry (started → completed).

## Scope
- `scripts/internal/ops.py` — task complete handler only (lines 1621–1639)
- `tests/unit/test_ops_cli.py` — extended `test_task_complete_dispatched` with event assertions

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_ops_cli.py::TestTaskComplete -xvs
make check-quiet
```

## Tests
- `make check-quiet` ✅ (all checks pass)
- `tests/unit/test_ops_cli.py::TestTaskComplete` — 7/7 pass

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
branch: fix/task-complete-event
```

Closes #1307
Closes #1308

🤖 Generated with [Claude Code](https://claude.com/claude-code)