### PR TITLE
fix: native inbox bridge dedup, locking, and timestamps

### DIFF
--- a/src/bid_euchre/ops/message_bus.py
+++ b/src/bid_euchre/ops/message_bus.py
@@ -1035,12 +1035,15 @@ DEFAULT_NATIVE_INBOX_DIR = Path.home() / ".claude" / "teams" / "default" / "inbo
 def _native_content_hash(entry: dict[str, Any]) -> str:
     """Compute a stable content hash for a native inbox entry.
 
-    Uses (from, timestamp, summary) as the dedup key.  This is stable
+    Uses (from, timestamp, summary, text) as the dedup key.  This is stable
     across reruns as long as the native inbox entry hasn't changed.
     """
     import hashlib
 
-    key = f"{entry.get('from', '')}|{entry.get('timestamp', '')}|{entry.get('summary', '')}"
+    key = (
+        f"{entry.get('from', '')}|{entry.get('timestamp', '')}"
+        f"|{entry.get('summary', '')}|{entry.get('text', '')}"
+    )
     return hashlib.sha256(key.encode()).hexdigest()[:16]
 
 
@@ -1083,66 +1086,78 @@ def import_native_inbox(
         logger.warning("Native inbox for %s is not a JSON array", lane_id)
         return []
 
-    # Read existing inbox to find already-imported hashes
+    # Use a dedicated lock for the native import cycle to prevent concurrent
+    # imports from inserting duplicates.  This is separate from the inbox lock
+    # (which send_message acquires internally) to avoid deadlock.
     root = shared_bus_root(bus_root)
-    existing_raw = _read_inbox_raw(lane_id, root)
-    existing_hashes: set[str] = set()
-    for rec in existing_raw:
-        payload = rec.get("payload", {})
-        native_hash = payload.get("native_hash")
-        if native_hash:
-            existing_hashes.add(native_hash)
+    import_lock = root / INBOX_DIR / f".{lane_id}.native_import.lock"
+    import_lock.parent.mkdir(parents=True, exist_ok=True)
 
     imported: list[dict[str, Any]] = []
-    for entry in entries:
-        if not isinstance(entry, dict):
-            continue
-        content_hash = _native_content_hash(entry)
-        if content_hash in existing_hashes:
-            continue
-
-        # Map native fields to BusMessage
-        from_lane = entry.get("from", "unknown")
-        summary = entry.get("summary", "")
-        text = entry.get("text", "")
-        timestamp = entry.get("timestamp", _now_iso())
-
-        msg = BusMessage(
-            message_id=uuid.uuid4().hex[:16],
-            thread_id=None,
-            task_id=None,
-            from_lane=from_lane,
-            to_lane=lane_id,
-            message_type="progress",  # best-fit generic type for native messages
-            priority="normal",
-            status="pending",
-            created_at=timestamp,
-            acked_at=None,
-            resolved_at=None,
-            requires_human=False,
-            summary=summary[:200] if summary else text[:200],
-            payload={
-                "native_hash": content_hash,
-                "native_text": text,
-                "native_read": entry.get("read", False),
-                "max_retries": DEFAULT_MAX_RETRIES,
-                "retry_count": 0,
-                "ttl_seconds": DEFAULT_TTL_SECONDS,
-            },
-            source_transport="claude_native",
-        )
-
+    with open(import_lock, "a") as lock_fh:
+        fcntl.flock(lock_fh, fcntl.LOCK_EX)
         try:
-            send_message(msg, bus_root, events_dir=events_dir)
-            imported.append(asdict(msg))
-            existing_hashes.add(content_hash)
-        except (ValueError, OSError) as exc:
-            logger.warning(
-                "Failed to import native message for %s (hash=%s): %s",
-                lane_id,
-                content_hash,
-                exc,
-            )
+            # Read existing inbox to find already-imported hashes
+            existing_raw = _read_inbox_raw(lane_id, root)
+            existing_hashes: set[str] = set()
+            for rec in existing_raw:
+                payload = rec.get("payload", {})
+                native_hash = payload.get("native_hash")
+                if native_hash:
+                    existing_hashes.add(native_hash)
+
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                content_hash = _native_content_hash(entry)
+                if content_hash in existing_hashes:
+                    continue
+
+                # Map native fields to BusMessage
+                from_lane = entry.get("from", "unknown")
+                summary = entry.get("summary", "")
+                text = entry.get("text", "")
+                native_timestamp = entry.get("timestamp", "")
+
+                msg = BusMessage(
+                    message_id=uuid.uuid4().hex[:16],
+                    thread_id=None,
+                    task_id=None,
+                    from_lane=from_lane,
+                    to_lane=lane_id,
+                    message_type="progress",  # best-fit generic type
+                    priority="normal",
+                    status="pending",
+                    created_at=_now_iso(),  # import time, not native time
+                    acked_at=None,
+                    resolved_at=None,
+                    requires_human=False,
+                    summary=summary[:200] if summary else text[:200],
+                    payload={
+                        "native_hash": content_hash,
+                        "native_text": text,
+                        "native_read": entry.get("read", False),
+                        "native_timestamp": native_timestamp,
+                        "max_retries": DEFAULT_MAX_RETRIES,
+                        "retry_count": 0,
+                        "ttl_seconds": DEFAULT_TTL_SECONDS,
+                    },
+                    source_transport="claude_native",
+                )
+
+                try:
+                    send_message(msg, bus_root, events_dir=events_dir)
+                    imported.append(asdict(msg))
+                    existing_hashes.add(content_hash)
+                except (ValueError, OSError) as exc:
+                    logger.warning(
+                        "Failed to import native message for %s (hash=%s): %s",
+                        lane_id,
+                        content_hash,
+                        exc,
+                    )
+        finally:
+            fcntl.flock(lock_fh, fcntl.LOCK_UN)
 
     logger.info(
         "Imported %d native message(s) for %s (%d skipped as duplicates)",

--- a/tests/unit/test_ops_message_bus.py
+++ b/tests/unit/test_ops_message_bus.py
@@ -1243,6 +1243,22 @@ class TestNativeInboxBridge:
         }
         assert _native_content_hash(entry1) != _native_content_hash(entry2)
 
+    def test_content_hash_includes_text(self) -> None:
+        """Entries with same metadata but different text produce different hashes."""
+        entry1 = {
+            "from": "team-lead",
+            "timestamp": "2026-03-22T12:00:00Z",
+            "summary": "Review approved",
+            "text": "Looks good to merge.",
+        }
+        entry2 = {
+            "from": "team-lead",
+            "timestamp": "2026-03-22T12:00:00Z",
+            "summary": "Review approved",
+            "text": "Needs one more fix before merge.",
+        }
+        assert _native_content_hash(entry1) != _native_content_hash(entry2)
+
     def test_import_basic(
         self, bus_root: Path, events_dir: Path, native_dir: Path
     ) -> None:
@@ -1353,7 +1369,7 @@ class TestNativeInboxBridge:
     def test_import_preserves_native_metadata(
         self, bus_root: Path, events_dir: Path, native_dir: Path
     ) -> None:
-        """Imported messages carry native_text and native_read in payload."""
+        """Imported messages carry native_text, native_read, and native_timestamp."""
         entries = [
             {
                 "from": "reviewer",
@@ -1374,6 +1390,11 @@ class TestNativeInboxBridge:
         payload = imported[0]["payload"]
         assert payload["native_text"] == "Detailed review text here."
         assert payload["native_read"] is True
+        assert payload["native_timestamp"] == "2026-03-22T14:00:00Z"
+
+        # created_at should be import time (now), not native timestamp
+        created_at = imported[0]["created_at"]
+        assert created_at != "2026-03-22T14:00:00Z"
 
     def test_import_incremental(
         self, bus_root: Path, events_dir: Path, native_dir: Path


### PR DESCRIPTION
## Summary

- Include `text` in native inbox dedup key to prevent false dedup when messages share (from, timestamp, summary) but differ in body content
- Add dedicated per-lane import lock (`native_import.lock`) around the read-check-write cycle to prevent concurrent imports from inserting duplicates — uses a separate lock file to avoid deadlock with `send_message`'s internal inbox lock
- Use import time (`_now_iso()`) for `created_at` instead of native message timestamp — original timestamp preserved as `native_timestamp` in payload for provenance

## Why

Convention follow-up for PR #1294 (native inbox bridge). Addresses three findings from autonomous review (issue #1295).

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_ops_message_bus.py -x --tb=short  # 85 passed
make check-quiet  # All checks passed
```

## Tests

- Added `test_content_hash_includes_text` — verifies entries with same metadata but different text produce different hashes
- Updated `test_import_preserves_native_metadata` — verifies `native_timestamp` preserved in payload and `created_at` differs from native timestamp

## Worktree proof

```
pwd: Bid-Euchre-steward-author-scratch
branch: fix/convention-1295-inbox-bridge
```

Closes #1295

🤖 Generated with [Claude Code](https://claude.com/claude-code)