### PR TITLE
hooks: bump pre-bash-dispatch timeout from 15s to 20s

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,7 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-bash-dispatch.sh",
-            "timeout": 15
+            "timeout": 20
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Bump `pre-bash-dispatch.sh` hook timeout from 15s to 20s in `.claude/settings.json`

## Why
PR #1318 consolidated three PreToolUse Bash hooks into a single dispatcher with a 15s timeout, but the individual hooks previously summed to ~20s of budget. When `gh` API calls are slow the 15s budget can be tight, causing timeouts.

Closes #1322

## Repro / Validation
```bash
make check-quiet   # ✓ All checks passed
```

## Tests
- `make check-quiet` — all checks passed

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

## Scope
- `.claude/settings.json` — timeout value only (15 → 20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)