### PR TITLE
fix: use 1-based pane indices in registry metadata

### DIFF
--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -277,31 +277,33 @@ ensure_worktree "$FLEX_C" "codex/steward-flex-c"
 ensure_review_worktree
 
 # Write v2 registry metadata for each lane.
-# tmux_window = group name, tmux_pane = pane index within the window.
+# tmux_window = group name, tmux_pane = 1-based pane index within the window.
 # Pane target format: ${SESSION}:${tmux_window}.${tmux_pane}
+# Indices are 1-based to match tmux pane-base-index=1.
 
-# Central ops  (window: central-ops, panes 0-2, main-vertical layout)
-write_lane_metadata "orchestrator"   "orchestrator" "$MAIN_DIR"       "--"                              "central-ops" "0" "foreground" "Orchestrator"
-write_lane_metadata "ops"            "ops"          "$MAIN_DIR"       "--"                              "central-ops" "1" "foreground" "Ops"
-write_lane_metadata "review"         "review"       "$REVIEW"         "detached"                        "central-ops" "2" "foreground" "Review"
+# Central ops  (window: central-ops, panes 1-3, main-vertical layout)
+# Note: pane indices are 1-based to match tmux pane-base-index=1.
+write_lane_metadata "orchestrator"   "orchestrator" "$MAIN_DIR"       "--"                              "central-ops" "1" "foreground" "Orchestrator"
+write_lane_metadata "ops"            "ops"          "$MAIN_DIR"       "--"                              "central-ops" "2" "foreground" "Ops"
+write_lane_metadata "review"         "review"       "$REVIEW"         "detached"                        "central-ops" "3" "foreground" "Review"
 
-# Platform workers  (window: platform, panes 0-3)
-write_lane_metadata "author-a"       "author"       "$AUTHOR_A"       "codex/steward-author"            "platform" "0" "background" "Author A"
-write_lane_metadata "author-b"       "author"       "$AUTHOR_B"       "codex/steward-author-b"          "platform" "1" "background" "Author B"
-write_lane_metadata "author-c"       "author"       "$AUTHOR_C"       "codex/steward-author-c"          "platform" "2" "background" "Author C"
-write_lane_metadata "author-d"       "author"       "$AUTHOR_D"       "codex/steward-author-d"          "platform" "3" "background" "Author D"
+# Platform workers  (window: platform, panes 1-4)
+write_lane_metadata "author-a"       "author"       "$AUTHOR_A"       "codex/steward-author"            "platform" "1" "background" "Author A"
+write_lane_metadata "author-b"       "author"       "$AUTHOR_B"       "codex/steward-author-b"          "platform" "2" "background" "Author B"
+write_lane_metadata "author-c"       "author"       "$AUTHOR_C"       "codex/steward-author-c"          "platform" "3" "background" "Author C"
+write_lane_metadata "author-d"       "author"       "$AUTHOR_D"       "codex/steward-author-d"          "platform" "4" "background" "Author D"
 
-# Browser-game workers  (window: browser, panes 0-3)
-write_lane_metadata "brws-author-a"  "author"       "$BRWS_A"         "codex/steward-brws-author-a"     "browser" "0" "background" "Brws Author A"
-write_lane_metadata "brws-author-b"  "author"       "$BRWS_B"         "codex/steward-brws-author-b"     "browser" "1" "background" "Brws Author B"
-write_lane_metadata "brws-author-c"  "author"       "$BRWS_C"         "codex/steward-brws-author-c"     "browser" "2" "background" "Brws Author C"
-write_lane_metadata "brws-author-d"  "author"       "$BRWS_D"         "codex/steward-brws-author-d"     "browser" "3" "background" "Brws Author D"
+# Browser-game workers  (window: browser, panes 1-4)
+write_lane_metadata "brws-author-a"  "author"       "$BRWS_A"         "codex/steward-brws-author-a"     "browser" "1" "background" "Brws Author A"
+write_lane_metadata "brws-author-b"  "author"       "$BRWS_B"         "codex/steward-brws-author-b"     "browser" "2" "background" "Brws Author B"
+write_lane_metadata "brws-author-c"  "author"       "$BRWS_C"         "codex/steward-brws-author-c"     "browser" "3" "background" "Brws Author C"
+write_lane_metadata "brws-author-d"  "author"       "$BRWS_D"         "codex/steward-brws-author-d"     "browser" "4" "background" "Brws Author D"
 
-# Scratch / flex  (window: scratch, panes 0-3)
-write_lane_metadata "author-scratch" "scratch"      "$AUTHOR_SCRATCH"  "codex/steward-author-scratch"   "scratch" "0" "background" "Scratch"
-write_lane_metadata "flex-a"         "flex"          "$FLEX_A"          "codex/steward-flex-a"           "scratch" "1" "background" "Flex A"
-write_lane_metadata "flex-b"         "flex"          "$FLEX_B"          "codex/steward-flex-b"           "scratch" "2" "background" "Flex B"
-write_lane_metadata "flex-c"         "flex"          "$FLEX_C"          "codex/steward-flex-c"           "scratch" "3" "background" "Flex C"
+# Scratch / flex  (window: scratch, panes 1-4)
+write_lane_metadata "author-scratch" "scratch"      "$AUTHOR_SCRATCH"  "codex/steward-author-scratch"   "scratch" "1" "background" "Scratch"
+write_lane_metadata "flex-a"         "flex"          "$FLEX_A"          "codex/steward-flex-a"           "scratch" "2" "background" "Flex A"
+write_lane_metadata "flex-b"         "flex"          "$FLEX_B"          "codex/steward-flex-b"           "scratch" "3" "background" "Flex B"
+write_lane_metadata "flex-c"         "flex"          "$FLEX_C"          "codex/steward-flex-c"           "scratch" "4" "background" "Flex C"
 
 # ---------------------------------------------------------------------------
 # Window + pane creation — 4 windows (central-ops: 3 panes, others: 4 panes)

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -312,10 +312,10 @@ class TestResolveTmuxTarget:
         """When registry has tmux_window and tmux_pane, use them."""
         registry_dir = tmp_path / "worktree_registry"
         registry_dir.mkdir()
-        entry = {"tmux_window": "platform", "tmux_pane": "0"}
+        entry = {"tmux_window": "platform", "tmux_pane": "1"}
         (registry_dir / "author-a.json").write_text(json.dumps(entry))
         result = _resolve_tmux_target("author-a", "steward", tmp_path)
-        assert result == "steward:platform.0"
+        assert result == "steward:platform.1"
 
     def test_registry_missing_falls_back(self, tmp_path: Path) -> None:
         """When registry file is missing, fall back to session:lane_id."""
@@ -332,7 +332,11 @@ class TestResolveTmuxTarget:
         assert result == "steward:author-a"
 
     def test_registry_pane_zero_is_valid(self, tmp_path: Path) -> None:
-        """Pane index 0 should not be treated as falsy."""
+        """Pane index 0 should not be treated as falsy.
+
+        Even though production uses 1-based indices (pane-base-index=1),
+        the function must handle 0 without treating it as a missing value.
+        """
         registry_dir = tmp_path / "worktree_registry"
         registry_dir.mkdir()
         entry = {"tmux_window": "central-ops", "tmux_pane": "0"}
@@ -385,15 +389,15 @@ class TestProbeTmuxPane:
         """When registry provides window.pane, probe targets that."""
         registry_dir = tmp_path / "worktree_registry"
         registry_dir.mkdir()
-        entry = {"tmux_window": "platform", "tmux_pane": "0"}
+        entry = {"tmux_window": "platform", "tmux_pane": "1"}
         (registry_dir / "author-a.json").write_text(json.dumps(entry))
         with patch(f"{_WORKER_POOL}.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout="12345\n")
             result = _probe_tmux_pane("author-a", "steward", runtime_dir=tmp_path)
             assert result is True
-            # Verify it targeted the correct pane
+            # Verify it targeted the correct 1-based pane
             call_args = mock_run.call_args[0][0]
-            assert "steward:platform.0" in call_args
+            assert "steward:platform.1" in call_args
 
 
 # ---------------------------------------------------------------------------
@@ -1711,18 +1715,18 @@ class TestNudgePane:
         assert result.error == "nudge_failed"
 
     def test_nudge_uses_registry_target(self, tmp_path: Path) -> None:
-        """When registry has window.pane, nudge targets that."""
+        """When registry has window.pane, nudge targets that (1-based)."""
         registry_dir = tmp_path / "worktree_registry"
         registry_dir.mkdir()
-        entry = {"tmux_window": "platform", "tmux_pane": "0"}
+        entry = {"tmux_window": "platform", "tmux_pane": "1"}
         (registry_dir / "author-a.json").write_text(json.dumps(entry))
         with patch(f"{_WORKER_POOL}.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
             result = nudge_pane("author-a", "pkt789", runtime_dir=tmp_path)
             assert result.executed is True
-            assert "steward:platform.0" in result.reason
+            assert "steward:platform.1" in result.reason
             call_args = mock_run.call_args[0][0]
-            assert call_args[3] == "steward:platform.0"
+            assert call_args[3] == "steward:platform.1"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -411,17 +411,20 @@ class TestWindowLayout:
         ]
 
     def test_metadata_pane_indices(self) -> None:
-        """All lanes must have valid pane indices in their metadata."""
+        """All lanes must have valid 1-based pane indices in their metadata.
+
+        Pane indices are 1-based to match tmux pane-base-index=1.
+        """
         metadata_lines = self._metadata_invocation_lines()
         assert len(metadata_lines) == len(self.EXPECTED_LANES), (
             f"Expected {len(self.EXPECTED_LANES)} write_lane_metadata calls, "
             f"found {len(metadata_lines)}"
         )
         for line in metadata_lines:
-            has_pane_idx = any(f'"{i}"' in line for i in range(4))
+            has_pane_idx = any(f'"{i}"' in line for i in range(1, 5))
             assert (
                 has_pane_idx
-            ), f"Lane metadata must have a pane index (0-3): {line.strip()}"
+            ), f"Lane metadata must have a 1-based pane index (1-4): {line.strip()}"
 
     def test_metadata_window_names(self) -> None:
         """All metadata must reference one of the 4 group window names."""


### PR DESCRIPTION
## Summary
- `write_lane_metadata()` in `steward-session.sh` wrote 0-based pane indices (0-3) to the worktree registry, but tmux uses `pane-base-index=1`
- `_resolve_tmux_target()` passes registry values through directly, so `nudge_pane()` targeted wrong panes (e.g. `steward:platform.0` instead of `steward:platform.1`)
- Updated all 15 `write_lane_metadata` calls to write 1-based indices matching actual tmux pane numbering

## Why
Dispatch nudges (`/start-task <packet_id>`) were sent to wrong tmux panes, requiring manual `send-keys` workarounds (#1316 context). This was the root cause.

## Changes
- `.claude/tmux/steward-session.sh` — all pane indices changed from 0-based to 1-based
- `tests/unit/test_steward_session.py` — updated `test_metadata_pane_indices` to validate 1-4 range
- `tests/unit/test_ops_worker_pool.py` — updated test fixtures to use realistic 1-based indices

## Repro / Validation
```bash
# Before: registry entry for author-a has tmux_pane: "0"
# After: registry entry for author-a has tmux_pane: "1"
# Verify with: cat .claude/runtime/worktree_registry/author-a.json | jq .tmux_pane
```

## Tests
```bash
make check-quiet  # ✅ All checks passed
uv run python -m pytest tests/unit/test_ops_worker_pool.py tests/unit/test_steward_session.py -v  # 169 passed
```

## Worktree proof
```
pwd: Bid-Euchre-steward-flex-a
branch: fix/registry-pane-indices
```

Closes #1309

🤖 Generated with [Claude Code](https://claude.com/claude-code)