### PR TITLE
fix: attach rule-loader hook to Read tool events

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|Read",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary
- Add `Read` to the PreToolUse matcher for the rule-loader hook in `.claude/settings.json`

## Why
The `rule-loader.sh` script already handles `Read` tool events (extracts `file_path` from Read input), but the settings.json matcher only routed `Edit|Write` events to it. This meant reading files in rule-triggering paths (notebooks/, plans/, docs/04_reports/, core/) would not trigger progressive rule disclosure.

## Change
- `.claude/settings.json`: Changed PreToolUse matcher from `"Edit|Write"` to `"Edit|Write|Read"`

## Validation
```bash
make check-quiet  # ✓ All checks passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
branch: fix/rule-loader-read-matcher
```

Closes #1321

🤖 Generated with [Claude Code](https://claude.com/claude-code)