### PR TITLE
fix: adjust dispatch tmux nudge for pane-base-index

### DIFF
--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -147,6 +147,26 @@ class PoolAction:
 # ---------------------------------------------------------------------------
 
 
+def _get_pane_base_index() -> int:
+    """Query tmux for the global ``pane-base-index`` option.
+
+    Returns the integer value (typically 0 or 1).  Falls back to 0 when
+    tmux is unavailable (e.g. in test environments or CI).
+    """
+    try:
+        result = subprocess.run(
+            ["tmux", "show-options", "-gv", "pane-base-index"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return int(result.stdout.strip())
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError, ValueError):
+        pass
+    return 0
+
+
 def _resolve_tmux_target(
     lane_id: str,
     tmux_session: str,
@@ -156,6 +176,10 @@ def _resolve_tmux_target(
 
     Reads ``tmux_window`` and ``tmux_pane`` from the lane's worktree registry
     entry to construct a ``{session}:{window}.{pane}`` target string.
+
+    The registry stores 0-based pane positions (first pane = 0, second = 1,
+    etc.).  This function adjusts by the tmux ``pane-base-index`` option so
+    that the returned target uses the actual tmux pane index.
 
     Falls back to ``{session}:{lane_id}`` if the registry entry is missing or
     does not contain pane metadata (backwards compatibility with the legacy
@@ -180,8 +204,10 @@ def _resolve_tmux_target(
         window = data.get("tmux_window")
         pane = data.get("tmux_pane")
         if window and pane is not None:
-            return f"{tmux_session}:{window}.{pane}"
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
+            base_index = _get_pane_base_index()
+            adjusted_pane = int(pane) + base_index
+            return f"{tmux_session}:{window}.{adjusted_pane}"
+    except (FileNotFoundError, json.JSONDecodeError, OSError, ValueError):
         pass
     # Fallback: legacy one-window-per-lane naming
     return f"{tmux_session}:{lane_id}"

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -21,6 +21,7 @@ from bid_euchre.ops.worker_pool import (
     WorkerState,
     _classify_pool_status,
     _get_lane_task_id,
+    _get_pane_base_index,
     _managed_lanes,
     _minutes_since,
     _probe_tmux_pane,
@@ -305,10 +306,41 @@ class TestGetLaneTaskId:
 # ---------------------------------------------------------------------------
 
 
+class TestGetPaneBaseIndex:
+    """Test _get_pane_base_index() tmux option query."""
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_returns_parsed_value(self, mock_run: MagicMock) -> None:
+        """Returns integer from tmux show-options output."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="1\n")
+        assert _get_pane_base_index() == 1
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_returns_zero_default(self, mock_run: MagicMock) -> None:
+        """Returns 0 when tmux reports pane-base-index=0."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="0\n")
+        assert _get_pane_base_index() == 0
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_falls_back_on_error(self, mock_run: MagicMock) -> None:
+        """Falls back to 0 when tmux is unavailable."""
+        mock_run.side_effect = FileNotFoundError("tmux not found")
+        assert _get_pane_base_index() == 0
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_falls_back_on_nonzero_exit(self, mock_run: MagicMock) -> None:
+        """Falls back to 0 when tmux command fails."""
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        assert _get_pane_base_index() == 0
+
+
 class TestResolveTmuxTarget:
     """Test _resolve_tmux_target() registry-based target resolution."""
 
-    def test_registry_with_window_and_pane(self, tmp_path: Path) -> None:
+    @patch(f"{_WORKER_POOL}._get_pane_base_index", return_value=0)
+    def test_registry_with_window_and_pane(
+        self, _mock_base: MagicMock, tmp_path: Path
+    ) -> None:
         """When registry has tmux_window and tmux_pane, use them."""
         registry_dir = tmp_path / "worktree_registry"
         registry_dir.mkdir()
@@ -322,7 +354,10 @@ class TestResolveTmuxTarget:
         result = _resolve_tmux_target("author-a", "steward", tmp_path)
         assert result == "steward:author-a"
 
-    def test_registry_no_pane_falls_back(self, tmp_path: Path) -> None:
+    @patch(f"{_WORKER_POOL}._get_pane_base_index", return_value=0)
+    def test_registry_no_pane_falls_back(
+        self, _mock_base: MagicMock, tmp_path: Path
+    ) -> None:
         """When registry has window but no pane, fall back."""
         registry_dir = tmp_path / "worktree_registry"
         registry_dir.mkdir()
@@ -331,7 +366,10 @@ class TestResolveTmuxTarget:
         result = _resolve_tmux_target("author-a", "steward", tmp_path)
         assert result == "steward:author-a"
 
-    def test_registry_pane_zero_is_valid(self, tmp_path: Path) -> None:
+    @patch(f"{_WORKER_POOL}._get_pane_base_index", return_value=0)
+    def test_registry_pane_zero_is_valid(
+        self, _mock_base: MagicMock, tmp_path: Path
+    ) -> None:
         """Pane index 0 should not be treated as falsy."""
         registry_dir = tmp_path / "worktree_registry"
         registry_dir.mkdir()
@@ -339,6 +377,30 @@ class TestResolveTmuxTarget:
         (registry_dir / "orchestrator.json").write_text(json.dumps(entry))
         result = _resolve_tmux_target("orchestrator", "steward", tmp_path)
         assert result == "steward:central-ops.0"
+
+    @patch(f"{_WORKER_POOL}._get_pane_base_index", return_value=1)
+    def test_pane_base_index_adjustment(
+        self, _mock_base: MagicMock, tmp_path: Path
+    ) -> None:
+        """Pane index is adjusted by pane-base-index (e.g. 0 -> 1)."""
+        registry_dir = tmp_path / "worktree_registry"
+        registry_dir.mkdir()
+        entry = {"tmux_window": "platform", "tmux_pane": "0"}
+        (registry_dir / "author-a.json").write_text(json.dumps(entry))
+        result = _resolve_tmux_target("author-a", "steward", tmp_path)
+        assert result == "steward:platform.1"
+
+    @patch(f"{_WORKER_POOL}._get_pane_base_index", return_value=1)
+    def test_pane_base_index_adjustment_higher_pane(
+        self, _mock_base: MagicMock, tmp_path: Path
+    ) -> None:
+        """Pane index 2 adjusted to 3 with pane-base-index=1."""
+        registry_dir = tmp_path / "worktree_registry"
+        registry_dir.mkdir()
+        entry = {"tmux_window": "central-ops", "tmux_pane": "2"}
+        (registry_dir / "review.json").write_text(json.dumps(entry))
+        result = _resolve_tmux_target("review", "steward", tmp_path)
+        assert result == "steward:central-ops.3"
 
 
 class TestProbeTmuxPane:
@@ -381,7 +443,8 @@ class TestProbeTmuxPane:
         mock_run.return_value = MagicMock(returncode=0, stdout="")
         assert _probe_tmux_pane("author-a", "steward") is False
 
-    def test_with_registry_target(self, tmp_path: Path) -> None:
+    @patch(f"{_WORKER_POOL}._get_pane_base_index", return_value=0)
+    def test_with_registry_target(self, _mock_base: MagicMock, tmp_path: Path) -> None:
         """When registry provides window.pane, probe targets that."""
         registry_dir = tmp_path / "worktree_registry"
         registry_dir.mkdir()
@@ -1710,7 +1773,10 @@ class TestNudgePane:
         assert result.executed is False
         assert result.error == "nudge_failed"
 
-    def test_nudge_uses_registry_target(self, tmp_path: Path) -> None:
+    @patch(f"{_WORKER_POOL}._get_pane_base_index", return_value=0)
+    def test_nudge_uses_registry_target(
+        self, _mock_base: MagicMock, tmp_path: Path
+    ) -> None:
         """When registry has window.pane, nudge targets that."""
         registry_dir = tmp_path / "worktree_registry"
         registry_dir.mkdir()


### PR DESCRIPTION
## Plan
N/A — task packet `6de87332c7b7` from orchestrator. Closes #1316.

## Summary
- Add `_get_pane_base_index()` helper that queries tmux for the `pane-base-index` option
- Update `_resolve_tmux_target()` to adjust stored 0-based pane positions by the base index
- Falls back to 0 (no adjustment) when tmux is unavailable (CI/tests)
- Add 6 new tests covering the pane-base-index query and adjustment logic
- Fix 2 existing tests that needed `_get_pane_base_index` mocked to avoid mock leakage

## Why
The dispatch code in `worker_pool.py` resolves lane-to-pane mappings using 0-based indices from the registry, but the steward's tmux has `pane-base-index=1`. This caused every `task dispatch` nudge to target the wrong pane, requiring manual `tmux send-keys` follow-up during the proving run.

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/test_ops_worker_pool.py` — 127 passed
- `make check-quiet` — all checks passed

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_worker_pool.py` — 127 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None
- Runtime impact: One extra `tmux show-options` call per pane resolution (~1ms)

## Risk level
- [x] Medium (strategy/experiments)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         d52fd264 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author          5e9b1c30 [fix/dispatch-tmux-pane-indices]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)