### PR TITLE
ops: add automated context clearing to dispatch flow

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -1565,7 +1565,10 @@ def cmd_task(args: argparse.Namespace) -> int:
                     )
                     return 1
 
-        result = dispatch_to_worker(packet_id, lane_id, runtime_dir=args.runtime_dir)
+        do_reset = getattr(args, "reset", False)
+        result = dispatch_to_worker(
+            packet_id, lane_id, runtime_dir=args.runtime_dir, reset=do_reset
+        )
         if args.json:
             from dataclasses import asdict
 
@@ -1573,7 +1576,10 @@ def cmd_task(args: argparse.Namespace) -> int:
         else:
             print(format_action_text(result))
             if result.executed:
-                print(f"\nDispatched {packet_id} -> {lane_id}")
+                if do_reset:
+                    print(f"\nDispatched {packet_id} -> {lane_id} (with reset)")
+                else:
+                    print(f"\nDispatched {packet_id} -> {lane_id}")
                 print(f"  The lane should receive /start-task {packet_id}")
         return 0 if result.executed else 1
 
@@ -2325,7 +2331,10 @@ def cmd_workers(args: argparse.Namespace) -> int:
     elif action == "dispatch":
         packet_id = args.packet_id
         lane_id = args.lane_id
-        result = dispatch_to_worker(packet_id, lane_id, runtime_dir=args.runtime_dir)
+        do_reset = getattr(args, "reset", False)
+        result = dispatch_to_worker(
+            packet_id, lane_id, runtime_dir=args.runtime_dir, reset=do_reset
+        )
         if args.json:
             from dataclasses import asdict
 
@@ -2815,6 +2824,12 @@ def build_parser() -> argparse.ArgumentParser:
         dest="auto_approve",
         help="Auto-approve the packet before dispatching (for pending/previewing packets)",
     )
+    task_dispatch_parser.add_argument(
+        "--reset",
+        action="store_true",
+        default=False,
+        help="Reset worktree to origin/main and clear Claude session before dispatching",
+    )
 
     task_accept_parser = task_sub.add_parser(
         "accept",
@@ -3004,6 +3019,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     workers_dispatch.add_argument("packet_id", help="Task packet ID to dispatch")
     workers_dispatch.add_argument("lane_id", help="Target lane ID")
+    workers_dispatch.add_argument(
+        "--reset",
+        action="store_true",
+        default=False,
+        help="Reset worktree to origin/main and clear Claude session before dispatching",
+    )
 
     workers_maintain = workers_sub.add_parser(
         "maintain", help="Run periodic maintenance (park idle, retire parked)"

--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -17,6 +17,8 @@ Usage::
         wake_worker,
         park_worker,
         retire_worker,
+        reset_worktree,
+        clear_session,
         dispatch_to_worker,
         nudge_pane,
         run_pool_maintenance,
@@ -813,6 +815,128 @@ def retire_worker(
     )
 
 
+def reset_worktree(
+    lane_id: str,
+    *,
+    runtime_dir: Path | None = None,
+) -> PoolAction:
+    """Reset a lane's worktree to origin/main.
+
+    Runs ``git fetch origin main && git reset --hard origin/main`` inside the
+    target worktree.  This ensures the worktree starts from a clean state
+    before a new task begins.
+
+    Args:
+        lane_id: Lane whose worktree should be reset.
+        runtime_dir: Override for the runtime directory root.
+
+    Returns:
+        A :class:`PoolAction` with ``action="reset_worktree"`` describing the
+        outcome.
+    """
+    worktree_path = _resolve_worktree_path(lane_id, runtime_dir)
+    if not worktree_path:
+        return PoolAction(
+            action="reset_worktree",
+            lane_id=lane_id,
+            reason=f"Could not resolve worktree path for {lane_id!r}",
+            executed=False,
+            error="worktree_not_found",
+        )
+
+    try:
+        subprocess.run(
+            ["git", "fetch", "origin", "main"],
+            cwd=worktree_path,
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+        subprocess.run(
+            ["git", "reset", "--hard", "origin/main"],
+            cwd=worktree_path,
+            check=True,
+            capture_output=True,
+            timeout=15,
+        )
+        return PoolAction(
+            action="reset_worktree",
+            lane_id=lane_id,
+            reason=f"Reset worktree at {worktree_path} to origin/main",
+            executed=True,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        return PoolAction(
+            action="reset_worktree",
+            lane_id=lane_id,
+            reason=f"Failed to reset worktree: {exc}",
+            executed=False,
+            error="reset_failed",
+        )
+    except (FileNotFoundError, OSError) as exc:
+        return PoolAction(
+            action="reset_worktree",
+            lane_id=lane_id,
+            reason=f"Failed to reset worktree: {exc}",
+            executed=False,
+            error="reset_failed",
+        )
+
+
+def clear_session(
+    lane_id: str,
+    *,
+    tmux_session: str = DEFAULT_TMUX_SESSION,
+    runtime_dir: Path | None = None,
+) -> PoolAction:
+    """Send /clear to a lane's tmux pane to reset the Claude Code session.
+
+    Uses ``tmux send-keys`` to inject ``/clear`` followed by Enter into the
+    target pane.  This resets the Claude Code context window so the lane
+    starts fresh.
+
+    Args:
+        lane_id: Target lane whose session should be cleared.
+        tmux_session: tmux session name.
+        runtime_dir: Override for the runtime directory root.
+
+    Returns:
+        A :class:`PoolAction` with ``action="clear_session"`` describing the
+        outcome.
+    """
+    target = _resolve_tmux_target(lane_id, tmux_session, runtime_dir)
+
+    try:
+        subprocess.run(
+            ["tmux", "send-keys", "-t", target, "/clear", "Enter"],
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
+        return PoolAction(
+            action="clear_session",
+            lane_id=lane_id,
+            reason=f"Sent /clear to pane {target}",
+            executed=True,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        return PoolAction(
+            action="clear_session",
+            lane_id=lane_id,
+            reason=f"Failed to clear session: {exc}",
+            executed=False,
+            error="clear_failed",
+        )
+    except (FileNotFoundError, OSError) as exc:
+        return PoolAction(
+            action="clear_session",
+            lane_id=lane_id,
+            reason=f"Failed to clear session: {exc}",
+            executed=False,
+            error="clear_failed",
+        )
+
+
 def nudge_pane(
     lane_id: str,
     packet_id: str,
@@ -879,6 +1003,7 @@ def dispatch_to_worker(
     *,
     tmux_session: str = DEFAULT_TMUX_SESSION,
     runtime_dir: Path | None = None,
+    reset: bool = False,
 ) -> PoolAction:
     """Complete lifecycle: wake worker, assign task packet, nudge pane.
 
@@ -886,6 +1011,7 @@ def dispatch_to_worker(
     1. Load task packet, verify it is in "approved" status.
     2. Take pool snapshot, verify lane_id has capacity.
     3. If lane is parked/retired: wake_worker() first.
+    3b. If ``reset=True``: reset worktree to origin/main and clear session.
     4. Transition packet to "dispatched" with owner = lane_id.
     4b. Copy dispatched packet JSON to the target worktree's task_queue
         so the author lane can discover it via ``/start-task``.
@@ -902,6 +1028,9 @@ def dispatch_to_worker(
         lane_id: Target lane for the work.
         tmux_session: tmux session name.
         runtime_dir: Override for the runtime directory root.
+        reset: If True, reset the worktree to origin/main and send /clear
+            to the Claude session before dispatching.  Recommended when the
+            lane is idle and stale context should be discarded.
 
     Returns:
         A :class:`PoolAction` describing what happened.
@@ -987,6 +1116,29 @@ def dispatch_to_worker(
                 executed=False,
                 error=f"wake_failed:{wake_result.error}",
             )
+
+    # 3b. Reset worktree and clear session if requested
+    if reset:
+        reset_result = reset_worktree(lane_id, runtime_dir=runtime_dir)
+        if not reset_result.executed:
+            logger.warning(
+                "Worktree reset failed for %s: %s (continuing dispatch)",
+                lane_id,
+                reset_result.reason,
+            )
+        clear_result = clear_session(
+            lane_id, tmux_session=tmux_session, runtime_dir=runtime_dir
+        )
+        if not clear_result.executed:
+            logger.warning(
+                "Session clear failed for %s: %s (continuing dispatch)",
+                lane_id,
+                clear_result.reason,
+            )
+        import time
+
+        # Brief pause to let /clear complete before sending /start-task
+        time.sleep(2)
 
     # 4. Transition packet to dispatched
     try:

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -26,6 +26,7 @@ from bid_euchre.ops.worker_pool import (
     _probe_tmux_pane,
     _resolve_agent_name,
     _resolve_tmux_target,
+    clear_session,
     dispatch_to_worker,
     format_action_text,
     format_actions_json,
@@ -34,6 +35,7 @@ from bid_euchre.ops.worker_pool import (
     get_lane_domain,
     nudge_pane,
     park_worker,
+    reset_worktree,
     retire_worker,
     run_pool_maintenance,
     select_worker,
@@ -1727,6 +1729,315 @@ class TestNudgePane:
             assert "steward:platform.1" in result.reason
             call_args = mock_run.call_args[0][0]
             assert call_args[3] == "steward:platform.1"
+
+
+# ---------------------------------------------------------------------------
+# Reset worktree
+# ---------------------------------------------------------------------------
+
+
+class TestResetWorktree:
+    """Test reset_worktree() with mocked subprocess and worktree resolution."""
+
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path")
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_reset_success(self, mock_run: MagicMock, mock_resolve: MagicMock) -> None:
+        mock_resolve.return_value = "/tmp/wt-author-a"
+        mock_run.return_value = MagicMock(returncode=0)
+        result = reset_worktree("author-a")
+        assert result.executed is True
+        assert result.action == "reset_worktree"
+        assert result.error is None
+        assert "origin/main" in result.reason
+        # Should call git fetch then git reset
+        assert mock_run.call_count == 2
+        fetch_call = mock_run.call_args_list[0]
+        assert fetch_call[0][0] == ["git", "fetch", "origin", "main"]
+        assert fetch_call[1]["cwd"] == "/tmp/wt-author-a"
+        reset_call = mock_run.call_args_list[1]
+        assert reset_call[0][0] == ["git", "reset", "--hard", "origin/main"]
+        assert reset_call[1]["cwd"] == "/tmp/wt-author-a"
+
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path")
+    def test_reset_worktree_not_found(self, mock_resolve: MagicMock) -> None:
+        mock_resolve.return_value = None
+        result = reset_worktree("author-x")
+        assert result.executed is False
+        assert result.error == "worktree_not_found"
+
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path")
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_reset_fetch_fails(
+        self, mock_run: MagicMock, mock_resolve: MagicMock
+    ) -> None:
+        import subprocess as sp
+
+        mock_resolve.return_value = "/tmp/wt-author-a"
+        mock_run.side_effect = sp.CalledProcessError(1, "git")
+        result = reset_worktree("author-a")
+        assert result.executed is False
+        assert result.error == "reset_failed"
+
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path")
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_reset_timeout(self, mock_run: MagicMock, mock_resolve: MagicMock) -> None:
+        import subprocess as sp
+
+        mock_resolve.return_value = "/tmp/wt-author-a"
+        mock_run.side_effect = sp.TimeoutExpired("git", 30)
+        result = reset_worktree("author-a")
+        assert result.executed is False
+        assert result.error == "reset_failed"
+
+
+# ---------------------------------------------------------------------------
+# Clear session
+# ---------------------------------------------------------------------------
+
+
+class TestClearSession:
+    """Test clear_session() with mocked subprocess."""
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_clear_success(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(returncode=0)
+        result = clear_session("author-a")
+        assert result.executed is True
+        assert result.action == "clear_session"
+        assert result.error is None
+        assert "/clear" in result.reason
+        mock_run.assert_called_once_with(
+            [
+                "tmux",
+                "send-keys",
+                "-t",
+                "steward:author-a",
+                "/clear",
+                "Enter",
+            ],
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_clear_custom_session(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(returncode=0)
+        result = clear_session("author-b", tmux_session="custom")
+        assert result.executed is True
+        call_args = mock_run.call_args[0][0]
+        assert call_args[3] == "custom:author-b"
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_clear_subprocess_error(self, mock_run: MagicMock) -> None:
+        import subprocess as sp
+
+        mock_run.side_effect = sp.CalledProcessError(1, "tmux")
+        result = clear_session("author-a")
+        assert result.executed is False
+        assert result.error == "clear_failed"
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_clear_tmux_not_found(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = FileNotFoundError("tmux not found")
+        result = clear_session("author-a")
+        assert result.executed is False
+        assert result.error == "clear_failed"
+
+    def test_clear_uses_registry_target(self, tmp_path: Path) -> None:
+        """When registry has window.pane, clear targets that."""
+        registry_dir = tmp_path / "worktree_registry"
+        registry_dir.mkdir()
+        entry = {"tmux_window": "platform", "tmux_pane": "1"}
+        (registry_dir / "author-b.json").write_text(json.dumps(entry))
+        with patch(f"{_WORKER_POOL}.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            result = clear_session("author-b", runtime_dir=tmp_path)
+            assert result.executed is True
+            assert "steward:platform.1" in result.reason
+            call_args = mock_run.call_args[0][0]
+            assert call_args[3] == "steward:platform.1"
+
+
+# ---------------------------------------------------------------------------
+# Dispatch with reset
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchWithReset:
+    """Test dispatch_to_worker() with reset=True."""
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}.nudge_pane")
+    @patch("time.sleep")
+    @patch(f"{_WORKER_POOL}.clear_session")
+    @patch(f"{_WORKER_POOL}.reset_worktree")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.transition_status")
+    @patch(f"{_TASK_QUEUE}.save_packet")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_with_reset_calls_reset_and_clear(
+        self,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_transition: MagicMock,
+        mock_snapshot: MagicMock,
+        mock_reset: MagicMock,
+        mock_clear: MagicMock,
+        mock_sleep: MagicMock,
+        mock_nudge: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """Dispatch with reset=True should call reset_worktree and clear_session."""
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test Task",
+            description="Do the thing",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool([_make_worker("author-a", "idle")])
+        mock_reset.return_value = PoolAction(
+            action="reset_worktree",
+            lane_id="author-a",
+            reason="Reset OK",
+            executed=True,
+        )
+        mock_clear.return_value = PoolAction(
+            action="clear_session",
+            lane_id="author-a",
+            reason="Clear OK",
+            executed=True,
+        )
+        mock_nudge.return_value = PoolAction(
+            action="nudge",
+            lane_id="author-a",
+            reason="Nudge OK",
+            executed=True,
+        )
+
+        result = dispatch_to_worker(
+            "pkt1", "author-a", runtime_dir=runtime_dir, reset=True
+        )
+        assert result.executed is True
+        mock_reset.assert_called_once_with("author-a", runtime_dir=runtime_dir)
+        mock_clear.assert_called_once()
+        mock_sleep.assert_called_once_with(2)
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}.nudge_pane")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.transition_status")
+    @patch(f"{_TASK_QUEUE}.save_packet")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_without_reset_skips_reset(
+        self,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_transition: MagicMock,
+        mock_snapshot: MagicMock,
+        mock_nudge: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """Dispatch with reset=False (default) should NOT call reset_worktree."""
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test Task",
+            description="Do the thing",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool([_make_worker("author-a", "idle")])
+        mock_nudge.return_value = PoolAction(
+            action="nudge",
+            lane_id="author-a",
+            reason="Nudge OK",
+            executed=True,
+        )
+
+        with (
+            patch(f"{_WORKER_POOL}.reset_worktree") as mock_reset,
+            patch(f"{_WORKER_POOL}.clear_session") as mock_clear,
+        ):
+            result = dispatch_to_worker(
+                "pkt1", "author-a", runtime_dir=runtime_dir, reset=False
+            )
+            assert result.executed is True
+            mock_reset.assert_not_called()
+            mock_clear.assert_not_called()
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}.nudge_pane")
+    @patch("time.sleep")
+    @patch(f"{_WORKER_POOL}.clear_session")
+    @patch(f"{_WORKER_POOL}.reset_worktree")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.transition_status")
+    @patch(f"{_TASK_QUEUE}.save_packet")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_continues_if_reset_fails(
+        self,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_transition: MagicMock,
+        mock_snapshot: MagicMock,
+        mock_reset: MagicMock,
+        mock_clear: MagicMock,
+        mock_sleep: MagicMock,
+        mock_nudge: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """Dispatch should continue even if reset_worktree fails (best-effort)."""
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test Task",
+            description="Do the thing",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool([_make_worker("author-a", "idle")])
+        mock_reset.return_value = PoolAction(
+            action="reset_worktree",
+            lane_id="author-a",
+            reason="Failed to reset",
+            executed=False,
+            error="reset_failed",
+        )
+        mock_clear.return_value = PoolAction(
+            action="clear_session",
+            lane_id="author-a",
+            reason="Clear OK",
+            executed=True,
+        )
+        mock_nudge.return_value = PoolAction(
+            action="nudge",
+            lane_id="author-a",
+            reason="Nudge OK",
+            executed=True,
+        )
+
+        result = dispatch_to_worker(
+            "pkt1", "author-a", runtime_dir=runtime_dir, reset=True
+        )
+        # Dispatch should still succeed despite reset failure
+        assert result.executed is True
+        mock_reset.assert_called_once()
+        mock_clear.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `reset_worktree()` and `clear_session()` functions to `worker_pool.py`
- Add `--reset` flag to both `ops.py task dispatch` and `ops.py workers dispatch` CLI commands
- When `--reset` is passed, dispatch automates the 3-step lane reset before task delivery:
  1. `git fetch origin main && git reset --hard origin/main` in the target worktree
  2. `/clear` via tmux send-keys to reset Claude session context
  3. Brief 2s pause, then normal `/start-task` nudge

## Why

Issue #1290. Operators have been manually performing a 3-step reset (git reset, /clear, /start-task) when dispatching to lanes with stale context. This automates that sequence as an opt-in `--reset` flag on dispatch, making fleet-wide task dispatch more reliable.

## Design Decisions

- **Opt-in flag** (not default behavior): `--reset` must be explicitly passed to avoid accidentally resetting a lane mid-work
- **Best-effort**: Both reset and clear are best-effort — dispatch continues even if either fails, with warnings logged
- **2s sleep**: Brief pause after `/clear` lets the Claude session process the command before `/start-task` arrives

## Repro / Validation

```bash
# Unit tests
uv run python -m pytest tests/unit/test_ops_worker_pool.py -q

# Full validation
make check-quiet

# Manual dispatch with reset (requires running steward session)
uv run python scripts/internal/ops.py task dispatch PACKET_ID LANE_ID --reset --approve
```

## Tests

- 12 new unit tests: `TestResetWorktree` (4), `TestClearSession` (5), `TestDispatchWithReset` (3)
- All 133 worker pool tests pass
- `make check-quiet` passes

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: ops/dispatch-context-clearing
```

## Plan reference

N/A — standalone fix from issue #1290.

Closes #1290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)