### PR TITLE
fix: add inbox purge subcommand to compact per-lane inboxes

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -1767,6 +1767,8 @@ def cmd_inbox(args: argparse.Namespace) -> int:
     from bid_euchre.ops.message_bus import (
         ack_message,
         bulk_ack_messages,
+        compact_all_inboxes,
+        compact_inbox,
         import_native_inbox,
         inbox_stats,
         read_inbox,
@@ -1860,6 +1862,40 @@ def cmd_inbox(args: argparse.Namespace) -> int:
                     print(f"  {lane['lane_id']:20s}  total={lane['total']}")
                     for status, count in sorted(lane.get("by_status", {}).items()):
                         print(f"    {status:16s}: {count}")
+        return 0
+
+    elif action == "purge":
+        max_age = getattr(args, "max_age", 24.0)
+        lane = getattr(args, "lane", None)
+
+        if lane:
+            results = [compact_inbox(lane, bus_root, max_age_hours=max_age)]
+        else:
+            results = compact_all_inboxes(bus_root, max_age_hours=max_age)
+
+        if args.json:
+            print(json.dumps(results, indent=2))
+        else:
+            total_removed = sum(r["removed"] for r in results)
+            total_before = sum(r["before"] for r in results)
+            total_after = sum(r["after"] for r in results)
+            if not results:
+                print("No inbox files found.")
+            else:
+                print(
+                    f"Purged {total_removed} terminal message(s) "
+                    f"older than {max_age}h across {len(results)} inbox(es)"
+                )
+                print(f"  Raw records before: {total_before}")
+                print(f"  Deduplicated after: {total_after}")
+                print()
+                for r in results:
+                    if r["removed"] > 0 or r["before"] != r["after"]:
+                        print(
+                            f"  {r['lane_id']:20s}  "
+                            f"{r['before']} -> {r['after']}  "
+                            f"(-{r['removed']} purged)"
+                        )
         return 0
 
     # Default: list messages
@@ -2873,6 +2909,22 @@ def build_parser() -> argparse.ArgumentParser:
         "--filter-summary",
         default=None,
         help="Regex pattern to match against message summary (case-insensitive)",
+    )
+
+    inbox_purge_parser = inbox_sub.add_parser(
+        "purge",
+        help="Remove old terminal messages from per-lane inbox files",
+    )
+    inbox_purge_parser.add_argument(
+        "--lane",
+        default=None,
+        help="Lane to compact (default: all lanes)",
+    )
+    inbox_purge_parser.add_argument(
+        "--max-age",
+        type=float,
+        default=24.0,
+        help="Remove terminal messages older than N hours (default: 24)",
     )
 
     inbox_parser.add_argument(

--- a/src/bid_euchre/ops/message_bus.py
+++ b/src/bid_euchre/ops/message_bus.py
@@ -1025,6 +1025,163 @@ def inbox_stats(bus_root: Path | None = None) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Inbox compaction (purge terminal messages)
+# ---------------------------------------------------------------------------
+
+
+def compact_inbox(
+    lane_id: str,
+    bus_root: Path | None = None,
+    *,
+    max_age_hours: float = 24.0,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Compact a lane's inbox by removing old handled messages.
+
+    Rewrites the per-lane inbox JSONL file, keeping only:
+    - Active messages (pending, delivered) regardless of age
+    - Handled messages (acked, resolved, expired, dead_lettered) newer
+      than ``max_age_hours``
+
+    The global audit trail (``messages.jsonl``) is **not** touched.
+
+    Deduplication is applied during compaction: only the latest record per
+    ``message_id`` is retained (the inbox is append-only, so multiple
+    records may exist for the same message as its status changed).
+
+    Args:
+        lane_id: The lane whose inbox to compact.
+        bus_root: Override for bus root directory.
+        max_age_hours: Remove handled messages older than this (default 24h).
+        now: Override for current time as Unix timestamp (for testing).
+
+    Returns:
+        Dict with keys: ``lane_id``, ``before`` (raw line count),
+        ``after`` (deduplicated retained count), ``removed`` (unique
+        messages purged).
+    """
+    root = shared_bus_root(bus_root)
+    inbox = _inbox_path(lane_id, root)
+    lock = _inbox_lock_path(lane_id, root)
+
+    if not inbox.exists():
+        return {"lane_id": lane_id, "before": 0, "after": 0, "removed": 0}
+
+    current_time = now or time.time()
+    cutoff_ts = current_time - (max_age_hours * 3600)
+    # Messages that have been handled — safe to purge when old enough.
+    # Includes acked (handled but not yet resolved) and all terminal states.
+    purgeable = {"acked", "resolved", "expired", "dead_lettered"}
+
+    # Read under lock to prevent concurrent writes during compaction
+    with open(lock, "a") as lock_fh:
+        fcntl.flock(lock_fh, fcntl.LOCK_EX)
+        try:
+            raw = []
+            with open(inbox) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        raw.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+
+            before_count = len(raw)
+
+            # Deduplicate: latest record per message_id wins
+            by_id: dict[str, dict[str, Any]] = {}
+            for rec in raw:
+                mid = rec.get("message_id")
+                if mid:
+                    by_id[mid] = rec
+
+            # Partition: keep vs remove
+            kept: list[dict[str, Any]] = []
+            removed_count = 0
+            for mid, rec in by_id.items():
+                status = rec.get("status", "pending")
+                if status not in purgeable:
+                    kept.append(rec)
+                    continue
+
+                # Handled message — check age
+                created = rec.get("created_at", "")
+                try:
+                    created_ts = datetime.fromisoformat(created).timestamp()
+                except (ValueError, TypeError):
+                    # Can't parse timestamp — keep to be safe
+                    kept.append(rec)
+                    continue
+
+                if created_ts < cutoff_ts:
+                    removed_count += 1
+                else:
+                    kept.append(rec)
+
+            # Rewrite the inbox file atomically (write tmp then rename)
+            tmp_path = inbox.with_suffix(".jsonl.tmp")
+            with open(tmp_path, "w") as f:
+                for rec in kept:
+                    f.write(json.dumps(rec, sort_keys=True, default=str) + "\n")
+                f.flush()
+            tmp_path.rename(inbox)
+
+        finally:
+            fcntl.flock(lock_fh, fcntl.LOCK_UN)
+
+    logger.info(
+        "Compacted inbox for %s: %d raw -> %d kept (%d removed)",
+        lane_id,
+        before_count,
+        len(kept),
+        removed_count,
+    )
+    return {
+        "lane_id": lane_id,
+        "before": before_count,
+        "after": len(kept),
+        "removed": removed_count,
+    }
+
+
+def compact_all_inboxes(
+    bus_root: Path | None = None,
+    *,
+    max_age_hours: float = 24.0,
+    now: float | None = None,
+) -> list[dict[str, Any]]:
+    """Compact all per-lane inbox files.
+
+    Iterates over every ``*.jsonl`` file in the inbox directory and
+    calls :func:`compact_inbox` for each.
+
+    Args:
+        bus_root: Override for bus root directory.
+        max_age_hours: Remove terminal messages older than this (default 24h).
+        now: Override for current time as Unix timestamp (for testing).
+
+    Returns:
+        List of per-lane compaction result dicts.
+    """
+    root = shared_bus_root(bus_root)
+    inbox_dir = root / INBOX_DIR
+    if not inbox_dir.exists():
+        return []
+
+    results: list[dict[str, Any]] = []
+    for inbox_file in sorted(inbox_dir.glob("*.jsonl")):
+        lane_id = inbox_file.stem
+        if lane_id.startswith("."):
+            continue  # Skip lock files and temp files
+        result = compact_inbox(lane_id, root, max_age_hours=max_age_hours, now=now)
+        results.append(result)
+
+    return results
+
+
+# ---------------------------------------------------------------------------
 # Native inbox bridge
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_ops_message_bus.py
+++ b/tests/unit/test_ops_message_bus.py
@@ -30,6 +30,8 @@ from bid_euchre.ops.message_bus import (
     bulk_ack_messages,
     check_dead_letters,
     check_expired,
+    compact_all_inboxes,
+    compact_inbox,
     create_message,
     import_native_inbox,
     inbox_stats,
@@ -1421,3 +1423,142 @@ class TestNativeInboxBridge:
         # Total in inbox
         inbox = read_inbox("author-a", bus_root)
         assert len(inbox) == 2
+
+
+# ---------------------------------------------------------------------------
+# Inbox compaction (purge)
+# ---------------------------------------------------------------------------
+
+
+class TestCompactInbox:
+    """Test compact_inbox and compact_all_inboxes."""
+
+    def test_empty_inbox_is_noop(self, bus_root: Path) -> None:
+        result = compact_inbox("nonexistent-lane", bus_root)
+        assert result == {
+            "lane_id": "nonexistent-lane",
+            "before": 0,
+            "after": 0,
+            "removed": 0,
+        }
+
+    def test_purges_old_acked_messages(self, bus_root: Path, events_dir: Path) -> None:
+        """Acked messages older than max_age are removed."""
+        # Send and ack a message
+        msg = create_message("orchestrator", "author-a", "assignment", "Old task")
+        send_message(msg, bus_root, events_dir=events_dir)
+        ack_message(msg.message_id, "author-a", bus_root, events_dir=events_dir)
+
+        # Verify it's in the inbox
+        inbox = read_inbox("author-a", bus_root)
+        assert len(inbox) == 1
+        assert inbox[0]["status"] == "acked"
+
+        # Compact with now far in the future — message should be purged
+        future_time = time.time() + 100_000
+        result = compact_inbox(
+            "author-a", bus_root, max_age_hours=24.0, now=future_time
+        )
+        assert result["removed"] == 1
+        assert result["after"] == 0
+
+        # Inbox should be empty
+        inbox = read_inbox("author-a", bus_root)
+        assert len(inbox) == 0
+
+    def test_preserves_recent_acked_messages(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Acked messages newer than max_age are kept."""
+        msg = create_message("orchestrator", "author-a", "assignment", "Recent task")
+        send_message(msg, bus_root, events_dir=events_dir)
+        ack_message(msg.message_id, "author-a", bus_root, events_dir=events_dir)
+
+        # Compact with current time — message is recent, should be kept
+        result = compact_inbox("author-a", bus_root, max_age_hours=24.0)
+        assert result["removed"] == 0
+        assert result["after"] == 1
+
+    def test_preserves_active_messages(self, bus_root: Path, events_dir: Path) -> None:
+        """Pending and delivered messages are never removed."""
+        msg = create_message("orchestrator", "author-a", "assignment", "Active task")
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        # Even with now far in the future, pending/delivered messages stay
+        future_time = time.time() + 100_000
+        result = compact_inbox("author-a", bus_root, max_age_hours=0, now=future_time)
+        assert result["removed"] == 0
+        assert result["after"] == 1
+
+    def test_purges_resolved_messages(self, bus_root: Path, events_dir: Path) -> None:
+        """Resolved (terminal) messages older than max_age are removed."""
+        msg = create_message("orchestrator", "author-a", "assignment", "Done task")
+        send_message(msg, bus_root, events_dir=events_dir)
+        ack_message(msg.message_id, "author-a", bus_root, events_dir=events_dir)
+        resolve_message(msg.message_id, "author-a", bus_root, events_dir=events_dir)
+
+        future_time = time.time() + 100_000
+        result = compact_inbox(
+            "author-a", bus_root, max_age_hours=24.0, now=future_time
+        )
+        assert result["removed"] == 1
+        assert result["after"] == 0
+
+    def test_deduplicates_append_only_records(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Multiple status records for the same message_id are deduplicated."""
+        msg = create_message("orchestrator", "author-a", "assignment", "Multi-update")
+        send_message(msg, bus_root, events_dir=events_dir)
+        # Send creates 1 record, ack appends another → 2 raw records
+        ack_message(msg.message_id, "author-a", bus_root, events_dir=events_dir)
+
+        # Before compaction: 2 raw records for 1 message
+        result = compact_inbox("author-a", bus_root, max_age_hours=24.0)
+        assert result["before"] == 2  # 2 raw JSONL lines
+        assert result["after"] == 1  # 1 deduplicated message kept
+        assert result["removed"] == 0  # recent acked, not removed
+
+    def test_compact_all_inboxes(self, bus_root: Path, events_dir: Path) -> None:
+        """compact_all_inboxes processes all lane inbox files."""
+        # Create messages in two different lane inboxes
+        msg1 = create_message("orchestrator", "author-a", "assignment", "Task A")
+        send_message(msg1, bus_root, events_dir=events_dir)
+        ack_message(msg1.message_id, "author-a", bus_root, events_dir=events_dir)
+
+        msg2 = create_message("orchestrator", "author-b", "assignment", "Task B")
+        send_message(msg2, bus_root, events_dir=events_dir)
+        ack_message(msg2.message_id, "author-b", bus_root, events_dir=events_dir)
+
+        future_time = time.time() + 100_000
+        results = compact_all_inboxes(bus_root, max_age_hours=24.0, now=future_time)
+
+        assert len(results) == 2
+        lane_ids = {r["lane_id"] for r in results}
+        assert lane_ids == {"author-a", "author-b"}
+        assert sum(r["removed"] for r in results) == 2
+
+    def test_mixed_messages_selective_purge(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Only old handled messages are purged; active and recent kept."""
+        # Old acked message
+        old_msg = create_message("orchestrator", "author-a", "assignment", "Old")
+        send_message(old_msg, bus_root, events_dir=events_dir)
+        ack_message(old_msg.message_id, "author-a", bus_root, events_dir=events_dir)
+
+        # Active (pending) message
+        active_msg = create_message("orchestrator", "author-a", "assignment", "Active")
+        send_message(active_msg, bus_root, events_dir=events_dir)
+
+        # Compact with future time — only old acked gets purged
+        future_time = time.time() + 100_000
+        result = compact_inbox(
+            "author-a", bus_root, max_age_hours=24.0, now=future_time
+        )
+        assert result["removed"] == 1  # old acked
+        assert result["after"] == 1  # active pending
+
+        inbox = read_inbox("author-a", bus_root)
+        assert len(inbox) == 1
+        assert inbox[0]["summary"] == "Active"


### PR DESCRIPTION
## Plan
N/A — standalone fix for issue #1317.

## Summary
- Add `compact_inbox()` and `compact_all_inboxes()` helpers to `message_bus.py`
- Wire as `ops.py inbox purge [--lane LANE] [--max-age HOURS]` CLI subcommand
- 8 unit tests covering purge, preservation, dedup, and multi-lane compaction

## Why
The orchestrator inbox accumulated ~1000+ stale acked messages from verdict
bridge development (fake PRs #42, #77, #99, #100, #101, #102). This noise
made inbox inspection slow and cluttered. The purge command removes old
handled messages (acked/resolved/expired/dead_lettered) while preserving
active messages and the global audit trail.

Closes #1317.

## Repro / Validation
**Command(s) run:**
```bash
# Purge all handled messages (any age)
uv run python scripts/internal/ops.py inbox purge --max-age 0

# Purge with default 24h threshold
uv run python scripts/internal/ops.py inbox purge

# Purge a specific lane
uv run python scripts/internal/ops.py inbox purge --lane orchestrator --max-age 1
```

**Result (before/after):**
```
Purged 1817 terminal message(s) older than 0.0h across 14 inbox(es)
  Raw records before: 3063
  Deduplicated after: 1246

  orchestrator          2693 -> 1053  (-1640 purged)
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_message_bus.py -v` — 92 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None (operator tooling only)
- Runtime impact: None

## Risk level
- [x] Low (ops tooling + tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git worktree list` (abridged):
```
Bid-Euchre-steward-brws-author-d   8eaf6080 [fix/1317-inbox-purge]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)