### PR TITLE
ops: add stall detection to monitor for idle dispatched lanes

### DIFF
--- a/src/bid_euchre/ops/monitor.py
+++ b/src/bid_euchre/ops/monitor.py
@@ -29,6 +29,10 @@ logger = logging.getLogger("ops.monitor")
 # A dispatched packet with no progress after this many minutes is flagged.
 STALE_DISPATCH_MINUTES: int = 30
 
+# Stall detection: dispatched+acked lane with no tmux activity growth.
+STALL_THRESHOLD_MINUTES: int = 10
+STALL_CONSECUTIVE_CYCLES: int = 2
+
 # Severity levels for findings.
 SEVERITY_INFO = "info"
 SEVERITY_WARN = "warn"
@@ -334,6 +338,222 @@ def check_stale_dispatches(
 
 
 # ---------------------------------------------------------------------------
+# Stall detection helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_stall_state_path(runtime_dir: Path | None = None) -> Path:
+    """Return the path to the stall detection state file."""
+    if runtime_dir is None:
+        runtime_dir = Path(".claude/runtime")
+    return runtime_dir / "stall_state.json"
+
+
+def _load_stall_state(state_path: Path) -> dict[str, Any]:
+    """Load stall detection state from disk.
+
+    Returns an empty dict if the file doesn't exist or is corrupt.
+    """
+    try:
+        return json.loads(state_path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_stall_state(state_path: Path, state: dict[str, Any]) -> None:
+    """Persist stall detection state to disk."""
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(state, indent=2) + "\n")
+
+
+def _get_pane_activity_epoch(
+    lane_id: str,
+    tmux_session: str = "steward",
+    runtime_dir: Path | None = None,
+) -> int | None:
+    """Query the tmux pane's last-activity epoch for a lane.
+
+    Uses ``tmux display-message -t <target> -p '#{pane_activity}'``.
+
+    Returns:
+        The unix epoch timestamp of last pane activity, or None if the
+        probe fails (pane dead, tmux unavailable, etc.).
+    """
+    from bid_euchre.ops.worker_pool import _resolve_tmux_target
+
+    target = _resolve_tmux_target(lane_id, tmux_session, runtime_dir)
+    try:
+        result = subprocess.run(
+            ["tmux", "display-message", "-t", target, "-p", "#{pane_activity}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip().isdigit():
+            return int(result.stdout.strip())
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+    return None
+
+
+def check_stalled_lanes(
+    runtime_dir: Path | None = None,
+    *,
+    stall_minutes: int = STALL_THRESHOLD_MINUTES,
+    consecutive_cycles: int = STALL_CONSECUTIVE_CYCLES,
+    now: datetime | None = None,
+    tmux_session: str = "steward",
+    _activity_probe: Any | None = None,
+) -> list[MonitorFinding]:
+    """Detect dispatched+acked lanes that have stopped making progress.
+
+    A lane is considered stalled when:
+    1. It has a dispatched packet that has been acked (lane accepted the work).
+    2. The dispatch is older than ``stall_minutes``.
+    3. The tmux pane's activity epoch has not changed over
+       ``consecutive_cycles`` consecutive monitor invocations.
+
+    Cross-cycle state is persisted in a JSON state file so that each
+    single-shot monitor invocation can compare against previous observations.
+
+    Args:
+        runtime_dir: Override for the runtime directory root.
+        stall_minutes: Minimum dispatch age before stall detection activates.
+        consecutive_cycles: Number of unchanged cycles before flagging.
+        now: Override current time for testing.
+        tmux_session: tmux session name.
+        _activity_probe: Optional callable(lane_id) -> int|None for testing.
+            If provided, used instead of tmux probe.
+
+    Returns:
+        List of WARN findings for stalled lanes.
+    """
+    findings: list[MonitorFinding] = []
+
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    try:
+        from bid_euchre.ops.task_queue import list_packets, load_ack
+
+        if runtime_dir is None:
+            runtime_dir = Path(".claude/runtime")
+
+        task_queue_root = runtime_dir / "task_queue"
+        dispatched = list_packets(task_queue_root, status_filter="dispatched")
+    except Exception as exc:
+        findings.append(
+            MonitorFinding(
+                category="stall_detection",
+                severity=SEVERITY_WARN,
+                summary=f"Could not check for stalled lanes: {exc}",
+            )
+        )
+        return findings
+
+    # Load cross-cycle state
+    state_path = _default_stall_state_path(runtime_dir)
+    state = _load_stall_state(state_path)
+    observations: dict[str, Any] = state.get("observations", {})
+
+    # Track which lanes are still dispatched (for cleanup)
+    active_lanes: set[str] = set()
+
+    for pkt in dispatched:
+        lane_id = pkt.owner
+        if lane_id is None:
+            continue
+
+        # Only check acked dispatches (lane has started work)
+        ack = load_ack(pkt.packet_id, task_queue_root)
+        if ack is None:
+            continue
+
+        active_lanes.add(lane_id)
+
+        # Check dispatch age
+        try:
+            ts_str = pkt.created_at.replace("Z", "+00:00")
+            dispatch_time = datetime.fromisoformat(ts_str)
+            if dispatch_time.tzinfo is None:
+                dispatch_time = dispatch_time.replace(tzinfo=timezone.utc)
+            age_minutes = (now - dispatch_time).total_seconds() / 60.0
+        except (ValueError, TypeError):
+            age_minutes = 0.0
+
+        if age_minutes < stall_minutes:
+            # Too fresh — reset observation and skip
+            observations[lane_id] = {
+                "packet_id": pkt.packet_id,
+                "activity_epoch": None,
+                "unchanged_count": 0,
+            }
+            continue
+
+        # Probe tmux pane activity
+        if _activity_probe is not None:
+            activity_epoch = _activity_probe(lane_id)
+        else:
+            activity_epoch = _get_pane_activity_epoch(
+                lane_id, tmux_session, runtime_dir
+            )
+
+        if activity_epoch is None:
+            # Can't probe — skip (dead panes caught by check_lane_health)
+            continue
+
+        # Compare with previous observation
+        prev = observations.get(lane_id, {})
+        prev_packet = prev.get("packet_id")
+        prev_epoch = prev.get("activity_epoch")
+        prev_count = prev.get("unchanged_count", 0)
+
+        if prev_packet == pkt.packet_id and prev_epoch == activity_epoch:
+            # Same packet, same activity — increment stall counter
+            unchanged_count = prev_count + 1
+        else:
+            # Activity changed or new packet — reset
+            unchanged_count = 0
+
+        observations[lane_id] = {
+            "packet_id": pkt.packet_id,
+            "activity_epoch": activity_epoch,
+            "unchanged_count": unchanged_count,
+        }
+
+        if unchanged_count >= consecutive_cycles:
+            findings.append(
+                MonitorFinding(
+                    category="stall_detection",
+                    severity=SEVERITY_WARN,
+                    summary=(
+                        f"Lane {lane_id!r} may be stalled: dispatched "
+                        f"{age_minutes:.0f}min ago, no activity change over "
+                        f"{unchanged_count} monitor cycle(s)"
+                    ),
+                    details={
+                        "lane_id": lane_id,
+                        "packet_id": pkt.packet_id,
+                        "title": pkt.title,
+                        "age_minutes": round(age_minutes),
+                        "unchanged_cycles": unchanged_count,
+                        "last_activity_epoch": activity_epoch,
+                    },
+                )
+            )
+
+    # Clean up observations for lanes no longer dispatched
+    for old_lane in list(observations.keys()):
+        if old_lane not in active_lanes:
+            del observations[old_lane]
+
+    # Persist state
+    _save_stall_state(state_path, {"observations": observations})
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
 # Orchestrator notification
 # ---------------------------------------------------------------------------
 
@@ -420,6 +640,7 @@ def run_monitoring_cycle(
     1. Lane pool health snapshot
     2. Open PR status (via ``gh``)
     3. Stale dispatched packet detection
+    4. Stalled lane detection (acked but idle)
 
     Optionally sends a summary to the orchestrator inbox.
 
@@ -447,7 +668,10 @@ def run_monitoring_cycle(
         check_stale_dispatches(runtime_dir, stale_minutes=stale_minutes, now=now)
     )
 
-    # 4. Notify orchestrator
+    # 4. Stalled lane detection (acked dispatches with no progress)
+    findings.extend(check_stalled_lanes(runtime_dir, now=now))
+
+    # 5. Notify orchestrator
     if notify_orchestrator:
         _send_findings_to_orchestrator(findings)
 

--- a/tests/unit/test_ops_monitor.py
+++ b/tests/unit/test_ops_monitor.py
@@ -12,9 +12,12 @@ from bid_euchre.ops.monitor import (
     SEVERITY_INFO,
     SEVERITY_WARN,
     MonitorFinding,
+    _default_stall_state_path,
+    _save_stall_state,
     check_lane_health,
     check_open_prs,
     check_stale_dispatches,
+    check_stalled_lanes,
     format_findings_json,
     format_findings_text,
     run_monitoring_cycle,
@@ -313,6 +316,280 @@ class TestCheckStaleDispatches:
 
         assert len(findings) == 1
         assert findings[0].severity == SEVERITY_HIGH
+
+
+# ---------------------------------------------------------------------------
+# check_stalled_lanes tests
+# ---------------------------------------------------------------------------
+
+
+def _make_dispatched_pkt(
+    packet_id: str = "pkt100",
+    owner: str = "author-a",
+    title: str = "Test task",
+    created_at: str = "2026-03-23T11:00:00Z",
+) -> MagicMock:
+    """Helper to create a mock dispatched packet."""
+    pkt = MagicMock()
+    pkt.packet_id = packet_id
+    pkt.owner = owner
+    pkt.title = title
+    pkt.created_at = created_at
+    return pkt
+
+
+class TestCheckStalledLanes:
+    """Tests for stall detection on dispatched+acked lanes."""
+
+    def test_no_dispatched_packets(self, tmp_path: Path) -> None:
+        """No dispatched packets produces no findings."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        with patch(
+            "bid_euchre.ops.task_queue.list_packets",
+            return_value=[],
+        ):
+            findings = check_stalled_lanes(runtime_dir)
+
+        assert len(findings) == 0
+
+    def test_unacked_dispatch_skipped(self, tmp_path: Path) -> None:
+        """Dispatched but unacked packets are not checked (handled by stale check)."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        now = datetime(2026, 3, 23, 12, 0, 0, tzinfo=timezone.utc)
+        pkt = _make_dispatched_pkt(created_at="2026-03-23T11:00:00Z")
+
+        with (
+            patch("bid_euchre.ops.task_queue.list_packets", return_value=[pkt]),
+            patch("bid_euchre.ops.task_queue.load_ack", return_value=None),
+        ):
+            findings = check_stalled_lanes(
+                runtime_dir,
+                now=now,
+                _activity_probe=lambda _: 1000,
+            )
+
+        assert len(findings) == 0
+
+    def test_fresh_dispatch_not_flagged(self, tmp_path: Path) -> None:
+        """Acked dispatch younger than stall_minutes is not flagged."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        now = datetime(2026, 3, 23, 12, 0, 0, tzinfo=timezone.utc)
+        # Only 5 min old — below the 10-min threshold
+        pkt = _make_dispatched_pkt(created_at="2026-03-23T11:55:00Z")
+
+        with (
+            patch("bid_euchre.ops.task_queue.list_packets", return_value=[pkt]),
+            patch("bid_euchre.ops.task_queue.load_ack", return_value=MagicMock()),
+        ):
+            findings = check_stalled_lanes(
+                runtime_dir,
+                now=now,
+                _activity_probe=lambda _: 1000,
+            )
+
+        assert len(findings) == 0
+
+    def test_active_lane_not_flagged_first_cycle(self, tmp_path: Path) -> None:
+        """First observation of an active lane does not flag (needs 2+ cycles)."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        now = datetime(2026, 3, 23, 12, 0, 0, tzinfo=timezone.utc)
+        pkt = _make_dispatched_pkt(created_at="2026-03-23T11:00:00Z")  # 60min ago
+
+        with (
+            patch("bid_euchre.ops.task_queue.list_packets", return_value=[pkt]),
+            patch("bid_euchre.ops.task_queue.load_ack", return_value=MagicMock()),
+        ):
+            findings = check_stalled_lanes(
+                runtime_dir,
+                now=now,
+                _activity_probe=lambda _: 1000,
+            )
+
+        assert len(findings) == 0
+
+    def test_stalled_lane_detected_after_two_cycles(self, tmp_path: Path) -> None:
+        """Lane flagged as stalled when activity unchanged over 2 consecutive cycles."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        now = datetime(2026, 3, 23, 12, 0, 0, tzinfo=timezone.utc)
+        pkt = _make_dispatched_pkt(created_at="2026-03-23T11:00:00Z")  # 60min ago
+
+        def probe(_: str) -> int:
+            return 9999  # fixed activity epoch — simulates no change
+
+        with (
+            patch("bid_euchre.ops.task_queue.list_packets", return_value=[pkt]),
+            patch("bid_euchre.ops.task_queue.load_ack", return_value=MagicMock()),
+        ):
+            # Cycle 1: first observation — no finding
+            f1 = check_stalled_lanes(runtime_dir, now=now, _activity_probe=probe)
+            assert len(f1) == 0
+
+            # Cycle 2: same activity — unchanged_count=1, still below threshold
+            f2 = check_stalled_lanes(runtime_dir, now=now, _activity_probe=probe)
+            assert len(f2) == 0
+
+            # Cycle 3: same activity — unchanged_count=2, now at threshold
+            f3 = check_stalled_lanes(runtime_dir, now=now, _activity_probe=probe)
+
+        assert len(f3) == 1
+        assert f3[0].severity == SEVERITY_WARN
+        assert f3[0].category == "stall_detection"
+        assert "author-a" in f3[0].summary
+        assert "stalled" in f3[0].summary
+        assert f3[0].details["unchanged_cycles"] == 2
+
+    def test_activity_change_resets_counter(self, tmp_path: Path) -> None:
+        """Activity change resets the stall counter."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        now = datetime(2026, 3, 23, 12, 0, 0, tzinfo=timezone.utc)
+        pkt = _make_dispatched_pkt(created_at="2026-03-23T11:00:00Z")
+
+        call_count = [0]
+
+        def changing_probe(_: str) -> int:
+            call_count[0] += 1
+            # Returns same value for first 2 calls, then changes
+            if call_count[0] <= 2:
+                return 9999
+            return 10001  # activity changed
+
+        with (
+            patch("bid_euchre.ops.task_queue.list_packets", return_value=[pkt]),
+            patch("bid_euchre.ops.task_queue.load_ack", return_value=MagicMock()),
+        ):
+            # Cycle 1: first observation
+            check_stalled_lanes(runtime_dir, now=now, _activity_probe=changing_probe)
+            # Cycle 2: same activity (unchanged_count=1)
+            check_stalled_lanes(runtime_dir, now=now, _activity_probe=changing_probe)
+            # Cycle 3: activity changed — resets counter
+            f3 = check_stalled_lanes(
+                runtime_dir, now=now, _activity_probe=changing_probe
+            )
+
+        assert len(f3) == 0
+
+    def test_probe_failure_skips_lane(self, tmp_path: Path) -> None:
+        """Lane is skipped if activity probe returns None."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        now = datetime(2026, 3, 23, 12, 0, 0, tzinfo=timezone.utc)
+        pkt = _make_dispatched_pkt(created_at="2026-03-23T11:00:00Z")
+
+        with (
+            patch("bid_euchre.ops.task_queue.list_packets", return_value=[pkt]),
+            patch("bid_euchre.ops.task_queue.load_ack", return_value=MagicMock()),
+        ):
+            findings = check_stalled_lanes(
+                runtime_dir,
+                now=now,
+                _activity_probe=lambda _: None,
+            )
+
+        assert len(findings) == 0
+
+    def test_state_file_persisted(self, tmp_path: Path) -> None:
+        """State file is written after each cycle."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        now = datetime(2026, 3, 23, 12, 0, 0, tzinfo=timezone.utc)
+        pkt = _make_dispatched_pkt(created_at="2026-03-23T11:00:00Z")
+
+        with (
+            patch("bid_euchre.ops.task_queue.list_packets", return_value=[pkt]),
+            patch("bid_euchre.ops.task_queue.load_ack", return_value=MagicMock()),
+        ):
+            check_stalled_lanes(
+                runtime_dir,
+                now=now,
+                _activity_probe=lambda _: 5000,
+            )
+
+        state_path = _default_stall_state_path(runtime_dir)
+        assert state_path.exists()
+        state = json.loads(state_path.read_text())
+        assert "observations" in state
+        assert "author-a" in state["observations"]
+        assert state["observations"]["author-a"]["activity_epoch"] == 5000
+
+    def test_stale_observations_cleaned_up(self, tmp_path: Path) -> None:
+        """Observations for lanes no longer dispatched are cleaned up."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        # Pre-seed state with an old lane observation
+        state_path = _default_stall_state_path(runtime_dir)
+        _save_stall_state(
+            state_path,
+            {
+                "observations": {
+                    "author-z": {
+                        "packet_id": "old",
+                        "activity_epoch": 1000,
+                        "unchanged_count": 5,
+                    }
+                }
+            },
+        )
+
+        with patch(
+            "bid_euchre.ops.task_queue.list_packets",
+            return_value=[],
+        ):
+            check_stalled_lanes(runtime_dir)
+
+        state = json.loads(state_path.read_text())
+        assert "author-z" not in state.get("observations", {})
+
+    def test_custom_thresholds(self, tmp_path: Path) -> None:
+        """Custom stall_minutes and consecutive_cycles are respected."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        now = datetime(2026, 3, 23, 12, 0, 0, tzinfo=timezone.utc)
+        # 5 min ago — would be skipped at default 10min, but not at 3min
+        pkt = _make_dispatched_pkt(created_at="2026-03-23T11:55:00Z")
+
+        def probe(_: str) -> int:
+            return 9999
+
+        with (
+            patch("bid_euchre.ops.task_queue.list_packets", return_value=[pkt]),
+            patch("bid_euchre.ops.task_queue.load_ack", return_value=MagicMock()),
+        ):
+            # With stall_minutes=3 and consecutive_cycles=1, second cycle flags
+            f1 = check_stalled_lanes(
+                runtime_dir,
+                now=now,
+                stall_minutes=3,
+                consecutive_cycles=1,
+                _activity_probe=probe,
+            )
+            assert len(f1) == 0  # first observation
+
+            f2 = check_stalled_lanes(
+                runtime_dir,
+                now=now,
+                stall_minutes=3,
+                consecutive_cycles=1,
+                _activity_probe=probe,
+            )
+
+        assert len(f2) == 1
+        assert f2[0].severity == SEVERITY_WARN
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Plan
N/A — bounded task from issue #1314

## Summary
- Add `check_stalled_lanes()` to the ops monitor cycle that detects lanes where a dispatched+acked packet shows no tmux pane activity change over 2+ consecutive monitor cycles
- Uses cross-cycle state persisted in `stall_state.json` with tmux `#{pane_activity}` epoch as the activity signal
- Reports stalled lanes as WARN severity findings in the monitor output

## Why
Lanes can stall between validation and PR creation (e.g., agent context exhaustion, Bash timeout) with no signal to the orchestrator. The existing `check_stale_dispatches` only catches **unacked** dispatches. This new check catches **acked** dispatches where the lane has stopped making progress — the more common failure mode.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_monitor.py -v  # 30 tests, all pass
make check-quiet                                           # full validation pass
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_monitor.py` — 10 new tests + 20 existing
- [x] `make check-quiet` — full validation

New test cases:
- `test_no_dispatched_packets` — empty queue produces no findings
- `test_unacked_dispatch_skipped` — unacked dispatches deferred to stale check
- `test_fresh_dispatch_not_flagged` — dispatches younger than threshold skipped
- `test_active_lane_not_flagged_first_cycle` — first observation never flags
- `test_stalled_lane_detected_after_two_cycles` — core detection across 3 cycles
- `test_activity_change_resets_counter` — activity change resets stall counter
- `test_probe_failure_skips_lane` — graceful degradation when tmux unavailable
- `test_state_file_persisted` — cross-cycle state correctly written
- `test_stale_observations_cleaned_up` — old lane entries removed
- `test_custom_thresholds` — configurable stall_minutes and consecutive_cycles

## Expected impact
- Metrics impact: None
- Runtime impact: Negligible — one additional tmux display-message per dispatched+acked lane per cycle

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b  0707a13b [ops/stall-detection]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)