### PR TITLE
docs: SP-4-01 Platform-8 scope lock and sub-plan registration

### DIFF
--- a/plans/agent_ops/4_remote_channel/checkpoints.md
+++ b/plans/agent_ops/4_remote_channel/checkpoints.md
@@ -1,11 +1,22 @@
 # Phase 4 — Remote Operator Channels — Checkpoints
 
 **Phase:** 4 (`4_remote_channel`)
-**Status:** PENDING
+**Status:** IN_PROGRESS
 **Governing plan:** `plans/agent_ops/governing_plan.md`
 **Phase plan:** `plans/agent_ops/4_remote_channel/plan.md`
 
 ## Steps
+
+### Step 0 — Scope lock and sub-plan registration
+
+**Status:** COMPLETE
+**Description:** Create SP-4-01 sub-plan for Platform-8 scope lock, register in
+sub-plan registry, and update checkpoints. Docs-only — no code changes.
+**Depends on:** Phase 3 COMPLETE
+**Done when:**
+- SP-4-01 sub-plan exists at `4_remote_channel/sub/2026-03-23_platform-8-scope-lock.md`
+- Sub-plan registered in `sub_plan_registry.md`
+- Checkpoints updated with Step 0 entry and session log
 
 ### Step 1 — Platform-8a: Configure Telegram plugin and prove core capabilities
 
@@ -50,3 +61,4 @@ configured Telegram channel. Audit trail deferred to hardening (Platform-14).
 | Date | Summary |
 |------|---------|
 | 2026-03-23 | Phase 4 plan and checkpoints created. Official Claude Code Channels discovery (v2.1.80+) reduces Platform-8a scope from "build transport skeleton" to "configure official Telegram plugin." Permission relay and sender gating are framework-provided. Audit trail deferred to hardening (Platform-14). |
+| 2026-03-23 | Step 0 (scope lock): SP-4-01 sub-plan created and registered. Key decisions: free-form messages allowed, no remote command grammar, orchestrator is single ingress, author lanes remain tmux-only. Platform-8b audit trail tracked in issue #1324. Phase status moved from PENDING to IN_PROGRESS. |

--- a/plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8-scope-lock.md
+++ b/plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8-scope-lock.md
@@ -1,0 +1,100 @@
+# Platform-8 Scope Lock
+
+**ID:** SP-4-01
+**Date:** 2026-03-23
+**Parent:** `plans/agent_ops/governing_plan.md` -- Phase 4, Platform-8
+**Status:** completed
+**Owner:** author-scratch
+
+---
+
+## Inputs
+
+- `plans/agent_ops/4_remote_channel/plan.md` -- Phase 4 plan with discovery notes
+- `plans/agent_ops/4_remote_channel/checkpoints.md` -- Phase 4 progress tracking
+- Claude Code Channels reference: <https://code.claude.com/docs/en/channels-reference>
+- Official Telegram plugin: <https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/telegram>
+
+## Assumptions
+
+- Claude Code v2.1.80+ is available (or will be before Step 1 execution begins)
+- The official Telegram plugin provides pairing, sender gating, and permission relay
+- Bun runtime is available for plugin execution
+- Active claude.ai login is available on the steward host
+
+## Dependencies
+
+- Phase 3 COMPLETE (satisfied)
+- No sub-plan dependencies within Phase 4 (this is the first action)
+
+## Plan
+
+### Platform-8a: Configure Official Telegram Plugin
+
+The official Channels framework (v2.1.80+) provides the transport skeleton,
+sender gating, and permission relay. Platform-8a scope is reduced from
+"build transport skeleton" to "configure and prove the official plugin."
+
+**Steps (mapped to checkpoints Step 1):**
+
+1. **Preflight verification** -- confirm Claude Code version >= 2.1.80,
+   Bun availability, plugin resolvability, and auth prerequisites
+2. **Plugin configuration** -- set up Telegram bot token, configure
+   `STEWARD_CHANNELS="telegram"` in tmux launcher, add `--channels telegram`
+   flag to session launch
+3. **Pairing proof** -- pair from phone via QR/pairing code, verify sender
+   gating rejects unknown senders
+4. **Permission relay proof** -- trigger a tool-approval prompt, approve
+   remotely from phone (v2.1.81+ for permission relay)
+5. **Kill switch proof** -- terminate channel subprocess, verify session
+   continues without channel, reconnect by restarting subprocess
+6. **Registry integration** -- record channel status in lane metadata via
+   `write_lane_metadata`
+
+**Key decisions:**
+- Free-form messages allowed (no remote command grammar)
+- Orchestrator is the single ingress point for remote messages
+- Author lanes remain tmux-only unless explicitly opted in
+- Kill switch = terminate channel subprocess (graceful degradation)
+
+### Platform-8b: Audit Trail -- DEFERRED
+
+Audit trail is deferred to Platform-9c hardening phase (tracked in issue #1324).
+
+**Rationale:**
+- v1 relies on session logs + Telegram chat history
+- Repo-owned structured audit trail adds value for cross-session analysis
+  but is not blocking for the v1 remote supervision use case
+- Hardening phase is the natural home for structured logging improvements
+
+## Files Changed
+
+- `plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8-scope-lock.md` -- NEW: this sub-plan
+- `plans/agent_ops/sub_plan_registry.md` -- register SP-4-01
+- `plans/agent_ops/4_remote_channel/checkpoints.md` -- add Step 0, update session log
+
+## Validation
+
+- [x] Sub-plan follows template structure
+- [x] Registered in sub-plan registry
+- [x] Checkpoints updated with Step 0 (scope lock) entry
+- [x] `make check-quiet` passes
+
+## Planned Outputs
+
+- `plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8-scope-lock.md` -- this sub-plan
+- Updated `plans/agent_ops/sub_plan_registry.md` with SP-4-01 entry
+- Updated `plans/agent_ops/4_remote_channel/checkpoints.md` with Step 0
+
+## Observed Outputs
+
+- Sub-plan created at planned path
+- Registry updated with SP-4-01 (completed)
+- Checkpoints updated with Step 0 COMPLETE, session log entry added
+
+## Outcome
+
+- Status: completed
+- PR: (this PR)
+- Deviations from plan: none
+- Issues discovered: none

--- a/plans/agent_ops/sub_plan_registry.md
+++ b/plans/agent_ops/sub_plan_registry.md
@@ -1,7 +1,7 @@
 # Sub-Plan Registry — Agentic Orchestration Platform
 
 **Governing plan:** `plans/agent_ops/governing_plan.md`
-**Last updated:** 2026-03-23 by author-b (register SP-3-06/07/08)
+**Last updated:** 2026-03-23 by author-scratch (register SP-4-01)
 
 ---
 
@@ -24,6 +24,7 @@
 | SP-3-06 | Task dispatch CLI and execution-surface hardening | Post-Phase-3 transition: CLI dispatch, execution-surface rules | completed | orchestrator | _(no sub-plan file — single-PR scope)_ | 2026-03-23 | 2026-03-23 (PR #1275) |
 | SP-3-07 | Bidirectional message bus across all steward lanes | Post-Phase-3 transition: message bus wiring for 16-lane layout | completed | orchestrator | _(no sub-plan file — single-PR scope)_ | 2026-03-23 | 2026-03-23 (PR #1276) |
 | SP-3-08 | Monitoring cycle with session-start auto-launch | Post-Phase-3 transition: ops monitoring cycle and auto-launch | completed | orchestrator | _(no sub-plan file — single-PR scope)_ | 2026-03-23 | 2026-03-23 (PR #1277) |
+| SP-4-01 | Platform-8 scope lock | Phase 4, Platform-8 scope lock and sub-plan registration | completed | author-scratch | `plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8-scope-lock.md` | 2026-03-23 | 2026-03-23 |
 
 ## Status Summary
 
@@ -32,7 +33,7 @@
 | proposed | 1 |
 | in_progress | 0 |
 | blocked | 0 |
-| completed | 13 |
+| completed | 14 |
 | abandoned | 0 |
 | superseded | 1 |
 


### PR DESCRIPTION
## Summary

- Create sub-plan SP-4-01 for Platform-8 (remote operator channel) scope lock
- Register SP-4-01 in the sub-plan registry (14th completed sub-plan)
- Add Step 0 (scope lock) to Phase 4 checkpoints, mark COMPLETE
- Phase 4 status transitions from PENDING to IN_PROGRESS

## Why

First governed action for Phase 4 (Remote Operator Channels). Documents key decisions before implementation begins:

- Official Telegram plugin (v2.1.80+) provides transport, sender gating, and permission relay
- Free-form messages allowed, no remote command grammar
- Orchestrator is single ingress point for remote messages
- Author lanes remain tmux-only unless explicitly opted in
- Platform-8b audit trail deferred to hardening (tracked in issue #1324)

## Plan

`plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8-scope-lock.md` (SP-4-01)

## Repro / Validation

```bash
make check-quiet  # All checks passed (docs-only PR)
```

## Tests

Docs-only PR — no code changes, no tests needed.

## Worktree proof

```
pwd: Bid-Euchre-steward-author-scratch
branch: docs/sp-4-01-platform-8-scope-lock
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)