### PR TITLE
fix: update stale 0-based pane index comments to 1-based

### DIFF
--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -5,27 +5,27 @@
 # Creates (or attaches to) a tmux session with 4 windows:
 #
 #   Window 1 — central-ops (3 panes, main-vertical layout)
-#     .0  orchestrator    -- single intake point (large left, ~66%)
-#     .1  ops             -- operator monitoring lane (top right)
-#     .2  review          -- independent review lane (bottom right)
+#     .1  orchestrator    -- single intake point (large left, ~66%)
+#     .2  ops             -- operator monitoring lane (top right)
+#     .3  review          -- independent review lane (bottom right)
 #
 #   Window 2 — platform (4 panes, tiled)
-#     .0  author-a        -- primary platform author lane
-#     .1  author-b        -- secondary platform author lane
-#     .2  author-c        -- overflow platform author lane
-#     .3  author-d        -- overflow platform author lane
+#     .1  author-a        -- primary platform author lane
+#     .2  author-b        -- secondary platform author lane
+#     .3  author-c        -- overflow platform author lane
+#     .4  author-d        -- overflow platform author lane
 #
 #   Window 3 — browser (4 panes, tiled)
-#     .0  brws-author-a   -- primary browser-game author lane
-#     .1  brws-author-b   -- secondary browser-game author lane
-#     .2  brws-author-c   -- overflow browser-game author lane
-#     .3  brws-author-d   -- overflow browser-game author lane
+#     .1  brws-author-a   -- primary browser-game author lane
+#     .2  brws-author-b   -- secondary browser-game author lane
+#     .3  brws-author-c   -- overflow browser-game author lane
+#     .4  brws-author-d   -- overflow browser-game author lane
 #
 #   Window 4 — scratch (4 panes, tiled)
-#     .0  author-scratch  -- exploratory Claude lane
-#     .1  flex-a          -- domain-agnostic overflow lane
-#     .2  flex-b          -- domain-agnostic overflow lane
-#     .3  flex-c          -- domain-agnostic overflow lane
+#     .1  author-scratch  -- exploratory Claude lane
+#     .2  flex-a          -- domain-agnostic overflow lane
+#     .3  flex-b          -- domain-agnostic overflow lane
+#     .4  flex-c          -- domain-agnostic overflow lane
 #
 # Writes v2 worktree registry metadata for each launched lane.
 # See docs/02_agent/AUTONOMOUS_OPERATOR_WORKFLOW.md for the full model.

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -307,7 +307,7 @@ class TestWindowLayout:
         "flex-c",
     ]
 
-    # Lanes per window, in pane creation order (pane 0 = first)
+    # Lanes per window, in pane creation order (pane 1 = first, 1-based)
     WINDOW_PANES = {
         "central-ops": ["orchestrator", "ops", "review"],
         "platform": ["author-a", "author-b", "author-c", "author-d"],


### PR DESCRIPTION
## Plan
N/A — trivial comment fix (Issue #1338)

## Summary
- Updated header comment block in `steward-session.sh` to use 1-based pane indices (`.1/.2/.3/.4`) instead of stale 0-based (`.0/.1/.2/.3`)
- Updated test comment in `test_steward_session.py` to reflect 1-based indexing

## Why
PR #1331 switched to `pane-base-index=1` and updated all functional code, but the header comment block and a test comment were missed. These stale comments are misleading for anyone reading the layout docs.

Closes #1338

## Repro / Validation
**Command(s) run:**
```bash
bash -n .claude/tmux/steward-session.sh
uv run python -m pytest tests/unit/test_steward_session.py -v  # 48 passed
make check-quiet  # All checks passed
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_steward_session.py` — 48 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None (comments only)
- Runtime impact: None (comments only)

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         79736625 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a   271176e4 [fix/stale-pane-index-comments]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)