### PR TITLE
fix: update stale timeout comment in pre-bash-dispatch

### DIFF
--- a/.claude/hooks/pre-bash-dispatch.sh
+++ b/.claude/hooks/pre-bash-dispatch.sh
@@ -12,7 +12,7 @@
 # command is allowed to proceed.
 #
 # Exit codes: 0 = allow, 2 = block (propagated from sub-hooks)
-# Timeout: 15s (accommodates merge guard's gh API calls)
+# Timeout: 20s (accommodates merge guard's gh API calls)
 set -euo pipefail
 
 HOOKS_DIR="${CLAUDE_PROJECT_DIR:-.}/.claude/hooks"

--- a/tests/unit/test_hook_dispatchers.py
+++ b/tests/unit/test_hook_dispatchers.py
@@ -142,6 +142,28 @@ class TestPostBashDispatch:
         assert raw == ""
 
 
+class TestPreBashDispatchTimeout:
+    """Timeout comment in pre-bash-dispatch.sh must match settings.json."""
+
+    def test_timeout_comment_matches_settings(self) -> None:
+        """Regression: header comment must agree with configured timeout."""
+        script = (HOOKS_DIR / "pre-bash-dispatch.sh").read_text()
+        settings = json.loads((HOOKS_DIR.parent / "settings.json").read_text())
+        # Find the configured timeout for pre-bash-dispatch.sh
+        configured_timeout = None
+        for group in settings.get("hooks", {}).get("PreToolUse", []):
+            for hook in group.get("hooks", []):
+                cmd = hook.get("command", "")
+                if "pre-bash-dispatch.sh" in cmd:
+                    configured_timeout = hook.get("timeout")
+                    break
+        assert configured_timeout is not None, "pre-bash-dispatch not found in settings"
+        assert f"# Timeout: {configured_timeout}s" in script, (
+            f"Header comment should say 'Timeout: {configured_timeout}s' "
+            f"but does not match"
+        )
+
+
 class TestPostPushCiCheckStdoutRedirect:
     """post-push-ci-check.sh must redirect background process stdout."""
 


### PR DESCRIPTION
## Summary
- Update header comment in `pre-bash-dispatch.sh` from `Timeout: 15s` to `Timeout: 20s` to match the actual configured timeout in `settings.json`
- Add regression test that verifies the comment matches the configured timeout

## Why
PR #1330 bumped the timeout from 15s to 20s but did not update the header comment. This causes confusion when reading the script. Fixes #1332.

## Validation
```bash
make check-quiet   # ✓ All checks passed
uv run python -m pytest tests/unit/test_hook_dispatchers.py::TestPreBashDispatchTimeout -v  # ✓ 1 passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
branch: fix/stale-timeout-comment
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)