### PR TITLE
fix: dashboard cleanup — limit warning, stale docstring, validity mask

### DIFF
--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate churn-corrected Bollinger Band dashboard for PR analytics.
+"""PR analytics Bollinger Band dashboard.
 
 Produces a 4-panel PNG:
   1. PRs merged per day with Bollinger Bands (working days only)
@@ -17,10 +17,13 @@ from __future__ import annotations
 
 import argparse
 import json as _json
+import logging
 import os
 import subprocess
 from collections import defaultdict
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 import matplotlib
 
@@ -46,11 +49,17 @@ def _git(args: list[str], repo: str) -> str:
     return result.stdout
 
 
+_GH_PR_LIMIT = 10_000
+
+
 def _gather_pr_counts(repo: str) -> tuple[dict[str, int], dict[str, int]]:
     """Return per-day PR merge counts and total additions from merged PRs.
 
     Uses ``gh pr list`` as the data source.  Requires the ``gh`` CLI to be
     installed and authenticated.
+
+    Warns when the number of PRs returned equals ``_GH_PR_LIMIT``, which
+    indicates the result set may be truncated.
     """
     result = subprocess.run(
         [
@@ -62,7 +71,7 @@ def _gather_pr_counts(repo: str) -> tuple[dict[str, int], dict[str, int]]:
             "--json",
             "mergedAt,additions",
             "--limit",
-            "10000",
+            str(_GH_PR_LIMIT),
         ],
         capture_output=True,
         text=True,
@@ -70,6 +79,13 @@ def _gather_pr_counts(repo: str) -> tuple[dict[str, int], dict[str, int]]:
         check=True,
     )
     prs = _json.loads(result.stdout)
+
+    if len(prs) >= _GH_PR_LIMIT:
+        logger.warning(
+            "gh pr list returned %d PRs (the configured limit). "
+            "Results may be truncated — consider increasing _GH_PR_LIMIT.",
+            len(prs),
+        )
 
     pr_counts: dict[str, int] = defaultdict(int)
     pr_additions: dict[str, int] = defaultdict(int)
@@ -212,6 +228,7 @@ def generate_dashboard(repo: str, output: str) -> None:
     tick_labels = [sorted_dates[i] for i in tick_positions]
 
     valid = ~np.isnan(raw_sma)
+    add_valid = ~np.isnan(add_sma)
     churn_valid = ~np.isnan(lc_sma)
 
     # ── Plot ─────────────────────────────────────────────────────────────
@@ -261,7 +278,7 @@ def generate_dashboard(repo: str, output: str) -> None:
         add_upper,
         add_lower,
         add_pctb,
-        valid,
+        add_valid,
         latest_idx,
         band_color="#27ae60",
         sma_color="#27ae60",

--- a/tests/unit/test_generate_dashboard.py
+++ b/tests/unit/test_generate_dashboard.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -18,6 +19,7 @@ import matplotlib.pyplot as plt  # noqa: E402
 scripts_dir = str(Path(__file__).resolve().parents[2] / "scripts")
 sys.path.insert(0, scripts_dir)
 from generate_dashboard import (  # noqa: E402
+    _GH_PR_LIMIT,
     _bollinger,
     _draw_bollinger_panel,
     _gather_pr_counts,
@@ -159,3 +161,36 @@ class TestGatherPrCounts:
 
         assert counts == {"2026-03-20": 1}
         assert additions == {"2026-03-20": 30}
+
+    def test_warns_when_hitting_limit(self, caplog):
+        """Emits a warning when PR count equals _GH_PR_LIMIT."""
+        prs = [
+            {"mergedAt": f"2026-03-{(i % 28) + 1:02d}T10:00:00Z", "additions": 1}
+            for i in range(_GH_PR_LIMIT)
+        ]
+        fake_result = type(
+            "Result", (), {"stdout": self._mock_gh_output(prs), "returncode": 0}
+        )()
+        with (
+            patch("generate_dashboard.subprocess.run", return_value=fake_result),
+            caplog.at_level(logging.WARNING),
+        ):
+            _gather_pr_counts("/fake/repo")
+
+        assert any("truncated" in r.message for r in caplog.records)
+
+    def test_no_warning_below_limit(self, caplog):
+        """No warning when PR count is below _GH_PR_LIMIT."""
+        prs = [
+            {"mergedAt": "2026-03-20T10:00:00Z", "additions": 50},
+        ]
+        fake_result = type(
+            "Result", (), {"stdout": self._mock_gh_output(prs), "returncode": 0}
+        )()
+        with (
+            patch("generate_dashboard.subprocess.run", return_value=fake_result),
+            caplog.at_level(logging.WARNING),
+        ):
+            _gather_pr_counts("/fake/repo")
+
+        assert not any("truncated" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- **Limit warning:** `_gather_pr_counts` now warns when `gh pr list` returns
  exactly `_GH_PR_LIMIT` (10,000) PRs, indicating possible truncation
- **Stale docstring:** Removed "churn-corrected" from module docstring — churn
  correction was removed in the PR-based metrics refactor (#1343)
- **Validity mask:** Panel 2 (additions) now uses its own `add_valid` mask
  (`~np.isnan(add_sma)`) instead of reusing Panel 1's PR-count validity mask

## Why
Issue #1346 — three small correctness/hygiene fixes to the recently refactored
dashboard script.

## Repro / Validation
```bash
uv run python scripts/generate_dashboard.py --output /tmp/test.png
uv run python -m pytest tests/unit/test_generate_dashboard.py -v
make check-quiet
```

## Tests
- `tests/unit/test_generate_dashboard.py` — 2 new tests for limit warning
  (at-limit warns, below-limit silent), all 10 pass
- `make check-quiet` passes

## Worktree proof
```
pwd: Bid-Euchre-steward-author-b
branch: fix/dashboard-cleanup
```

Closes #1346

🤖 Generated with [Claude Code](https://claude.com/claude-code)