### PR TITLE
fix: add dirty-worktree guard to reset_worktree

### DIFF
--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -818,6 +818,7 @@ def retire_worker(
 def reset_worktree(
     lane_id: str,
     *,
+    force: bool = False,
     runtime_dir: Path | None = None,
 ) -> PoolAction:
     """Reset a lane's worktree to origin/main.
@@ -826,8 +827,17 @@ def reset_worktree(
     target worktree.  This ensures the worktree starts from a clean state
     before a new task begins.
 
+    Before resetting, checks for uncommitted changes.  If the worktree is
+    dirty and *force* is ``False``, the reset is aborted and a
+    ``dirty_worktree`` error is returned.  If *force* is ``True``, the diff
+    is saved to ``/tmp/<lane_id>.diff`` before proceeding with the reset so
+    that no work is silently lost.
+
     Args:
         lane_id: Lane whose worktree should be reset.
+        force: If ``True``, save any uncommitted diff and proceed with the
+            reset even when the worktree is dirty.  If ``False`` (default),
+            abort when the worktree is dirty.
         runtime_dir: Override for the runtime directory root.
 
     Returns:
@@ -845,6 +855,48 @@ def reset_worktree(
         )
 
     try:
+        # --- dirty-worktree guard -------------------------------------------
+        status_result = subprocess.run(
+            ["git", "status", "--short"],
+            cwd=worktree_path,
+            check=True,
+            capture_output=True,
+            timeout=10,
+            text=True,
+        )
+        is_dirty = bool(status_result.stdout.strip())
+
+        if is_dirty and not force:
+            dirty_files = status_result.stdout.strip()
+            return PoolAction(
+                action="reset_worktree",
+                lane_id=lane_id,
+                reason=(
+                    f"Worktree at {worktree_path} has uncommitted changes "
+                    f"(use force=True to save diff and proceed):\n{dirty_files}"
+                ),
+                executed=False,
+                error="dirty_worktree",
+            )
+
+        if is_dirty and force:
+            diff_path = Path(f"/tmp/{lane_id}.diff")
+            diff_result = subprocess.run(
+                ["git", "diff", "HEAD"],
+                cwd=worktree_path,
+                check=True,
+                capture_output=True,
+                timeout=15,
+                text=True,
+            )
+            diff_path.write_text(diff_result.stdout)
+            logger.warning(
+                "Worktree for %s was dirty — diff saved to %s",
+                lane_id,
+                diff_path,
+            )
+
+        # --- reset -----------------------------------------------------------
         subprocess.run(
             ["git", "fetch", "origin", "main"],
             cwd=worktree_path,
@@ -859,10 +911,14 @@ def reset_worktree(
             capture_output=True,
             timeout=15,
         )
+
+        reason = f"Reset worktree at {worktree_path} to origin/main"
+        if is_dirty:
+            reason += f" (dirty diff saved to /tmp/{lane_id}.diff)"
         return PoolAction(
             action="reset_worktree",
             lane_id=lane_id,
-            reason=f"Reset worktree at {worktree_path} to origin/main",
+            reason=reason,
             executed=True,
         )
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
@@ -1119,7 +1175,7 @@ def dispatch_to_worker(
 
     # 3b. Reset worktree and clear session if requested
     if reset:
-        reset_result = reset_worktree(lane_id, runtime_dir=runtime_dir)
+        reset_result = reset_worktree(lane_id, force=True, runtime_dir=runtime_dir)
         if not reset_result.executed:
             logger.warning(
                 "Worktree reset failed for %s: %s (continuing dispatch)",

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -1739,22 +1739,47 @@ class TestNudgePane:
 class TestResetWorktree:
     """Test reset_worktree() with mocked subprocess and worktree resolution."""
 
+    @staticmethod
+    def _make_status_clean() -> MagicMock:
+        """Return a mock CompletedProcess for a clean ``git status --short``."""
+        m = MagicMock(returncode=0)
+        m.stdout = ""
+        return m
+
+    @staticmethod
+    def _make_status_dirty(files: str = " M foo.py\n?? bar.py") -> MagicMock:
+        m = MagicMock(returncode=0)
+        m.stdout = files
+        return m
+
+    @staticmethod
+    def _make_diff(content: str = "diff --git a/foo.py ...") -> MagicMock:
+        m = MagicMock(returncode=0)
+        m.stdout = content
+        return m
+
+    # -- clean worktree (original happy path) --------------------------------
+
     @patch(f"{_WORKER_POOL}._resolve_worktree_path")
     @patch(f"{_WORKER_POOL}.subprocess.run")
     def test_reset_success(self, mock_run: MagicMock, mock_resolve: MagicMock) -> None:
         mock_resolve.return_value = "/tmp/wt-author-a"
-        mock_run.return_value = MagicMock(returncode=0)
+        clean_status = self._make_status_clean()
+        ok = MagicMock(returncode=0)
+        mock_run.side_effect = [clean_status, ok, ok]  # status, fetch, reset
         result = reset_worktree("author-a")
         assert result.executed is True
         assert result.action == "reset_worktree"
         assert result.error is None
         assert "origin/main" in result.reason
-        # Should call git fetch then git reset
-        assert mock_run.call_count == 2
-        fetch_call = mock_run.call_args_list[0]
+        # Should call git status, git fetch, git reset
+        assert mock_run.call_count == 3
+        status_call = mock_run.call_args_list[0]
+        assert status_call[0][0] == ["git", "status", "--short"]
+        fetch_call = mock_run.call_args_list[1]
         assert fetch_call[0][0] == ["git", "fetch", "origin", "main"]
         assert fetch_call[1]["cwd"] == "/tmp/wt-author-a"
-        reset_call = mock_run.call_args_list[1]
+        reset_call = mock_run.call_args_list[2]
         assert reset_call[0][0] == ["git", "reset", "--hard", "origin/main"]
         assert reset_call[1]["cwd"] == "/tmp/wt-author-a"
 
@@ -1773,7 +1798,8 @@ class TestResetWorktree:
         import subprocess as sp
 
         mock_resolve.return_value = "/tmp/wt-author-a"
-        mock_run.side_effect = sp.CalledProcessError(1, "git")
+        clean_status = self._make_status_clean()
+        mock_run.side_effect = [clean_status, sp.CalledProcessError(1, "git")]
         result = reset_worktree("author-a")
         assert result.executed is False
         assert result.error == "reset_failed"
@@ -1784,10 +1810,79 @@ class TestResetWorktree:
         import subprocess as sp
 
         mock_resolve.return_value = "/tmp/wt-author-a"
-        mock_run.side_effect = sp.TimeoutExpired("git", 30)
+        clean_status = self._make_status_clean()
+        mock_run.side_effect = [clean_status, sp.TimeoutExpired("git", 30)]
         result = reset_worktree("author-a")
         assert result.executed is False
         assert result.error == "reset_failed"
+
+    # -- dirty worktree guard ------------------------------------------------
+
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path")
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_dirty_worktree_aborts_without_force(
+        self, mock_run: MagicMock, mock_resolve: MagicMock
+    ) -> None:
+        """Dirty worktree + force=False → error='dirty_worktree', no reset."""
+        mock_resolve.return_value = "/tmp/wt-author-a"
+        mock_run.return_value = self._make_status_dirty()
+        result = reset_worktree("author-a")
+        assert result.executed is False
+        assert result.error == "dirty_worktree"
+        assert "uncommitted changes" in result.reason
+        assert "foo.py" in result.reason
+        # Only git status was called — no fetch/reset
+        assert mock_run.call_count == 1
+
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path")
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_dirty_worktree_force_saves_diff(
+        self, mock_run: MagicMock, mock_resolve: MagicMock, tmp_path: Path
+    ) -> None:
+        """Dirty worktree + force=True → saves diff, then resets successfully."""
+        mock_resolve.return_value = "/tmp/wt-author-a"
+        dirty_status = self._make_status_dirty()
+        diff_mock = self._make_diff("diff content here")
+        ok = MagicMock(returncode=0)
+        mock_run.side_effect = [
+            dirty_status,
+            diff_mock,
+            ok,
+            ok,
+        ]  # status, diff, fetch, reset
+
+        diff_path = Path("/tmp/author-a.diff")
+        result = reset_worktree("author-a", force=True)
+
+        assert result.executed is True
+        assert result.error is None
+        assert "origin/main" in result.reason
+        assert "dirty diff saved" in result.reason
+        # 4 calls: status, diff, fetch, reset
+        assert mock_run.call_count == 4
+        diff_call = mock_run.call_args_list[1]
+        assert diff_call[0][0] == ["git", "diff", "HEAD"]
+        # Verify the diff was written to /tmp/<lane>.diff
+        assert diff_path.exists()
+        assert diff_path.read_text() == "diff content here"
+        # Cleanup
+        diff_path.unlink(missing_ok=True)
+
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path")
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_clean_worktree_with_force(
+        self, mock_run: MagicMock, mock_resolve: MagicMock
+    ) -> None:
+        """Clean worktree + force=True → proceeds normally (no diff save)."""
+        mock_resolve.return_value = "/tmp/wt-author-a"
+        clean_status = self._make_status_clean()
+        ok = MagicMock(returncode=0)
+        mock_run.side_effect = [clean_status, ok, ok]
+        result = reset_worktree("author-a", force=True)
+        assert result.executed is True
+        assert result.error is None
+        # 3 calls: status, fetch, reset (no diff save needed)
+        assert mock_run.call_count == 3
 
 
 # ---------------------------------------------------------------------------
@@ -1925,7 +2020,9 @@ class TestDispatchWithReset:
             "pkt1", "author-a", runtime_dir=runtime_dir, reset=True
         )
         assert result.executed is True
-        mock_reset.assert_called_once_with("author-a", runtime_dir=runtime_dir)
+        mock_reset.assert_called_once_with(
+            "author-a", force=True, runtime_dir=runtime_dir
+        )
         mock_clear.assert_called_once()
         mock_sleep.assert_called_once_with(2)
 


### PR DESCRIPTION
## Plan
N/A — issue fix (post-merge review finding)

## Summary
- `reset_worktree()` now checks `git status --short` before running `git reset --hard`
- If dirty and `force=False` (default): aborts with `error="dirty_worktree"` listing the dirty files
- If dirty and `force=True`: saves diff to `/tmp/<lane_id>.diff`, logs path, then proceeds
- `dispatch_to_worker()` passes `force=True` since dispatch is intentional

## Why
Closes #1341. `reset_worktree()` ran `git reset --hard origin/main` without checking for uncommitted changes, risking silent loss of work on dirty worktrees. Per `.claude/rules/75_worktree_protection.md`, diffs should be saved before destructive operations.

## Repro / Validation
**Command(s) run:**
```
make check-quiet   # ✓ All checks passed
uv run python -m pytest tests/unit/test_ops_worker_pool.py -v  # 136 passed
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_worker_pool.py` — 136 passed
- [x] `make check-quiet` — all checks passed

New test cases:
- `test_dirty_worktree_aborts_without_force` — dirty + force=False → error, no reset
- `test_dirty_worktree_force_saves_diff` — dirty + force=True → saves diff, resets
- `test_clean_worktree_with_force` — clean + force=True → normal reset (no diff save)

## Expected impact
- Metrics impact: None
- Runtime impact: One extra `git status --short` call (~10ms) per reset

## Risk level
- [x] Low (ops tooling only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author  0bdfd6ee [fix/dirty-worktree-guard]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)