### PR TITLE
fix: base stall timer on dispatch timestamp

### DIFF
--- a/src/bid_euchre/ops/monitor.py
+++ b/src/bid_euchre/ops/monitor.py
@@ -471,9 +471,13 @@ def check_stalled_lanes(
 
         active_lanes.add(lane_id)
 
-        # Check dispatch age
+        # Check dispatch age — prefer metadata.dispatched_at (set by
+        # dispatch_to_worker) over created_at (packet creation time).
         try:
-            ts_str = pkt.created_at.replace("Z", "+00:00")
+            raw_ts: str = (getattr(pkt, "metadata", None) or {}).get(
+                "dispatched_at", ""
+            ) or pkt.created_at
+            ts_str = raw_ts.replace("Z", "+00:00")
             dispatch_time = datetime.fromisoformat(ts_str)
             if dispatch_time.tzinfo is None:
                 dispatch_time = dispatch_time.replace(tzinfo=timezone.utc)

--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -1151,6 +1151,12 @@ def dispatch_to_worker(
         pkt_data = _asdict(packet)
         pkt_data["owner"] = lane_id
         pkt_data["status"] = "approved"  # keep current status for re-save
+        # Record dispatch timestamp in metadata for stall detection
+        meta = dict(pkt_data.get("metadata") or {})
+        meta["dispatched_at"] = datetime.now(timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        pkt_data["metadata"] = meta
         updated_pkt = TaskPacket(**pkt_data)
         save_packet(updated_pkt, task_queue_root)
 

--- a/tests/unit/test_ops_monitor.py
+++ b/tests/unit/test_ops_monitor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from bid_euchre.ops.monitor import (
@@ -328,6 +329,7 @@ def _make_dispatched_pkt(
     owner: str = "author-a",
     title: str = "Test task",
     created_at: str = "2026-03-23T11:00:00Z",
+    metadata: dict[str, Any] | None = None,
 ) -> MagicMock:
     """Helper to create a mock dispatched packet."""
     pkt = MagicMock()
@@ -335,6 +337,7 @@ def _make_dispatched_pkt(
     pkt.owner = owner
     pkt.title = title
     pkt.created_at = created_at
+    pkt.metadata = metadata or {}
     return pkt
 
 
@@ -590,6 +593,68 @@ class TestCheckStalledLanes:
 
         assert len(f2) == 1
         assert f2[0].severity == SEVERITY_WARN
+
+    def test_dispatched_at_metadata_preferred_over_created_at(
+        self, tmp_path: Path
+    ) -> None:
+        """Stall timer uses metadata.dispatched_at when available."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        now = datetime(2026, 3, 23, 12, 0, 0, tzinfo=timezone.utc)
+        # created_at is 60 min ago (would be past stall_minutes threshold)
+        # but dispatched_at is only 5 min ago (should be considered fresh)
+        pkt = _make_dispatched_pkt(
+            created_at="2026-03-23T11:00:00Z",
+            metadata={"dispatched_at": "2026-03-23T11:55:00Z"},
+        )
+
+        with (
+            patch("bid_euchre.ops.task_queue.list_packets", return_value=[pkt]),
+            patch("bid_euchre.ops.task_queue.load_ack", return_value=MagicMock()),
+        ):
+            findings = check_stalled_lanes(
+                runtime_dir,
+                now=now,
+                _activity_probe=lambda _: 1000,
+            )
+
+        # Should be considered fresh (5 min < 10 min threshold) despite
+        # created_at being 60 min ago.
+        assert len(findings) == 0
+
+    def test_falls_back_to_created_at_without_dispatched_at(
+        self, tmp_path: Path
+    ) -> None:
+        """Stall timer falls back to created_at when metadata.dispatched_at absent."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        now = datetime(2026, 3, 23, 12, 0, 0, tzinfo=timezone.utc)
+        # No dispatched_at in metadata — 60 min old created_at should be used
+        pkt = _make_dispatched_pkt(
+            created_at="2026-03-23T11:00:00Z",
+            metadata={},
+        )
+
+        def probe(_: str) -> int:
+            return 9999
+
+        with (
+            patch("bid_euchre.ops.task_queue.list_packets", return_value=[pkt]),
+            patch("bid_euchre.ops.task_queue.load_ack", return_value=MagicMock()),
+        ):
+            # Cycle 1
+            f1 = check_stalled_lanes(runtime_dir, now=now, _activity_probe=probe)
+            assert len(f1) == 0
+            # Cycle 2
+            f2 = check_stalled_lanes(runtime_dir, now=now, _activity_probe=probe)
+            assert len(f2) == 0
+            # Cycle 3: should flag (past threshold + 2 unchanged cycles)
+            f3 = check_stalled_lanes(runtime_dir, now=now, _activity_probe=probe)
+
+        assert len(f3) == 1
+        assert f3[0].category == "stall_detection"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Stall detection in `detect_stalled_lanes()` was using `pkt.created_at` (packet creation time) to compute dispatch age, but a packet can be created well before it is dispatched
- `dispatch_to_worker()` now records a `dispatched_at` timestamp in the packet's `metadata` dict at dispatch time
- `detect_stalled_lanes()` prefers `metadata.dispatched_at` over `created_at`, falling back gracefully for legacy packets

## Why
Closes #1342. The stall timer could overcount dispatch age for packets that sit in pending/approved states before dispatch, causing false-positive stall warnings.

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_ops_monitor.py -x -q
make check-quiet
```

## Tests
- `test_dispatched_at_metadata_preferred_over_created_at` — verifies fresh dispatch (via metadata) is not flagged even when `created_at` is old
- `test_falls_back_to_created_at_without_dispatched_at` — verifies fallback behavior for packets without metadata timestamp

## Worktree proof
```
pwd: Bid-Euchre-steward-brws-author-c
branch: fix/stall-timer-dispatch-timestamp
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)