### PR TITLE
fix: resolve dispatch tmux nudge pane indices dynamically

### DIFF
--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -149,19 +149,70 @@ class PoolAction:
 # ---------------------------------------------------------------------------
 
 
+def _dynamic_pane_lookup(
+    lane_id: str,
+    tmux_session: str,
+    window: str,
+) -> str | None:
+    """Dynamically resolve a lane's pane index by querying tmux.
+
+    Runs ``tmux list-panes`` on the target window and matches pane titles
+    against the ``lane_id`` string.  This is robust to stale registry data
+    and works regardless of ``pane-base-index`` configuration.
+
+    The query is scoped to a single window, so substring matching on
+    ``lane_id`` is unambiguous (each window hosts a disjoint set of lanes).
+
+    Args:
+        lane_id: Lane identifier to look up (e.g. ``"author-a"``).
+        tmux_session: tmux session name (e.g. ``"steward"``).
+        window: tmux window name to query (e.g. ``"platform"``).
+
+    Returns:
+        The pane index as a string, or ``None`` if resolution fails.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "tmux",
+                "list-panes",
+                "-t",
+                f"{tmux_session}:{window}",
+                "-F",
+                "#{pane_index} #{pane_title}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            return None
+        for line in result.stdout.strip().splitlines():
+            parts = line.split(None, 1)
+            if len(parts) >= 2 and lane_id in parts[1]:
+                return parts[0]
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+    return None
+
+
 def _resolve_tmux_target(
     lane_id: str,
     tmux_session: str,
     runtime_dir: Path | None = None,
 ) -> str:
-    """Resolve a lane's tmux pane target from registry metadata.
+    """Resolve a lane's tmux pane target, preferring dynamic lookup.
 
-    Reads ``tmux_window`` and ``tmux_pane`` from the lane's worktree registry
-    entry to construct a ``{session}:{window}.{pane}`` target string.
+    Resolution strategy (most to least reliable):
 
-    Falls back to ``{session}:{lane_id}`` if the registry entry is missing or
-    does not contain pane metadata (backwards compatibility with the legacy
-    one-window-per-lane layout).
+    1. **Dynamic lookup** — query ``tmux list-panes`` for the lane's window
+       and match pane titles against ``lane_id``.  This is always correct
+       regardless of ``pane-base-index`` or stale registry data.
+    2. **Registry fallback** — read ``tmux_window`` and ``tmux_pane`` from
+       the lane's worktree registry entry.  Used when tmux is not available
+       (e.g. in tests or before the session is started).
+    3. **Legacy fallback** — ``{session}:{lane_id}`` for the legacy
+       one-window-per-lane layout.
 
     Args:
         lane_id: Lane identifier.
@@ -177,14 +228,25 @@ def _resolve_tmux_target(
     if runtime_dir is None:
         runtime_dir = Path(".claude/runtime")
     registry_file = runtime_dir / "worktree_registry" / f"{lane_id}.json"
+
+    window: str | None = None
+    registry_pane: str | None = None
     try:
         data = json.loads(registry_file.read_text())
         window = data.get("tmux_window")
-        pane = data.get("tmux_pane")
-        if window and pane is not None:
-            return f"{tmux_session}:{window}.{pane}"
+        registry_pane = data.get("tmux_pane")
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         pass
+
+    if window:
+        # Try dynamic resolution first — robust to stale registry pane indices
+        dynamic_pane = _dynamic_pane_lookup(lane_id, tmux_session, window)
+        if dynamic_pane is not None:
+            return f"{tmux_session}:{window}.{dynamic_pane}"
+        # Fall back to registry pane index
+        if registry_pane is not None:
+            return f"{tmux_session}:{window}.{registry_pane}"
+
     # Fallback: legacy one-window-per-lane naming
     return f"{tmux_session}:{lane_id}"
 

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -20,6 +20,7 @@ from bid_euchre.ops.worker_pool import (
     PoolSnapshot,
     WorkerState,
     _classify_pool_status,
+    _dynamic_pane_lookup,
     _get_lane_task_id,
     _managed_lanes,
     _minutes_since,
@@ -307,11 +308,103 @@ class TestGetLaneTaskId:
 # ---------------------------------------------------------------------------
 
 
-class TestResolveTmuxTarget:
-    """Test _resolve_tmux_target() registry-based target resolution."""
+class TestDynamicPaneLookup:
+    """Test _dynamic_pane_lookup() tmux pane title matching."""
 
-    def test_registry_with_window_and_pane(self, tmp_path: Path) -> None:
-        """When registry has tmux_window and tmux_pane, use them."""
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_finds_matching_pane(self, mock_run: MagicMock) -> None:
+        """Matches lane_id substring in pane title."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="1 steward-author-a\n2 steward-author-b\n",
+        )
+        result = _dynamic_pane_lookup("author-a", "steward", "platform")
+        assert result == "1"
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_no_match(self, mock_run: MagicMock) -> None:
+        """Returns None when no pane title matches."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="1 steward-author-c\n2 steward-author-d\n",
+        )
+        result = _dynamic_pane_lookup("author-a", "steward", "platform")
+        assert result is None
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_tmux_not_running(self, mock_run: MagicMock) -> None:
+        """Returns None when tmux is not available."""
+        mock_run.side_effect = FileNotFoundError("tmux not found")
+        result = _dynamic_pane_lookup("author-a", "steward", "platform")
+        assert result is None
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_tmux_command_fails(self, mock_run: MagicMock) -> None:
+        """Returns None when tmux list-panes returns non-zero."""
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        result = _dynamic_pane_lookup("author-a", "steward", "platform")
+        assert result is None
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_tmux_timeout(self, mock_run: MagicMock) -> None:
+        import subprocess as sp
+
+        mock_run.side_effect = sp.TimeoutExpired("tmux", 5)
+        result = _dynamic_pane_lookup("author-a", "steward", "platform")
+        assert result is None
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_pane_title_with_spinner(self, mock_run: MagicMock) -> None:
+        """Matches even when pane title has a Claude Code spinner prefix."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="2 ⠐ steward-flex-a\n3 ✳ steward-flex-b\n",
+        )
+        result = _dynamic_pane_lookup("flex-a", "steward", "scratch")
+        assert result == "2"
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_constructs_correct_tmux_command(self, mock_run: MagicMock) -> None:
+        """Verifies the correct tmux command is constructed."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        _dynamic_pane_lookup("author-a", "steward", "platform")
+        mock_run.assert_called_once_with(
+            [
+                "tmux",
+                "list-panes",
+                "-t",
+                "steward:platform",
+                "-F",
+                "#{pane_index} #{pane_title}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+
+
+class TestResolveTmuxTarget:
+    """Test _resolve_tmux_target() with dynamic + registry resolution."""
+
+    @patch(f"{_WORKER_POOL}._dynamic_pane_lookup", return_value="2")
+    def test_dynamic_resolution_preferred(
+        self, mock_lookup: MagicMock, tmp_path: Path
+    ) -> None:
+        """Dynamic lookup is preferred over stale registry pane index."""
+        registry_dir = tmp_path / "worktree_registry"
+        registry_dir.mkdir()
+        # Registry has stale 0-based index; dynamic returns correct 2
+        entry = {"tmux_window": "platform", "tmux_pane": "0"}
+        (registry_dir / "author-a.json").write_text(json.dumps(entry))
+        result = _resolve_tmux_target("author-a", "steward", tmp_path)
+        assert result == "steward:platform.2"
+        mock_lookup.assert_called_once_with("author-a", "steward", "platform")
+
+    @patch(f"{_WORKER_POOL}._dynamic_pane_lookup", return_value=None)
+    def test_registry_fallback_when_dynamic_fails(
+        self, mock_lookup: MagicMock, tmp_path: Path
+    ) -> None:
+        """Falls back to registry pane index when dynamic lookup fails."""
         registry_dir = tmp_path / "worktree_registry"
         registry_dir.mkdir()
         entry = {"tmux_window": "platform", "tmux_pane": "1"}
@@ -324,8 +417,11 @@ class TestResolveTmuxTarget:
         result = _resolve_tmux_target("author-a", "steward", tmp_path)
         assert result == "steward:author-a"
 
-    def test_registry_no_pane_falls_back(self, tmp_path: Path) -> None:
-        """When registry has window but no pane, fall back."""
+    @patch(f"{_WORKER_POOL}._dynamic_pane_lookup", return_value=None)
+    def test_registry_no_pane_falls_back(
+        self, mock_lookup: MagicMock, tmp_path: Path
+    ) -> None:
+        """When registry has window but no pane and dynamic fails, fall back."""
         registry_dir = tmp_path / "worktree_registry"
         registry_dir.mkdir()
         entry = {"tmux_window": "platform"}
@@ -333,7 +429,10 @@ class TestResolveTmuxTarget:
         result = _resolve_tmux_target("author-a", "steward", tmp_path)
         assert result == "steward:author-a"
 
-    def test_registry_pane_zero_is_valid(self, tmp_path: Path) -> None:
+    @patch(f"{_WORKER_POOL}._dynamic_pane_lookup", return_value=None)
+    def test_registry_pane_zero_is_valid(
+        self, mock_lookup: MagicMock, tmp_path: Path
+    ) -> None:
         """Pane index 0 should not be treated as falsy.
 
         Even though production uses 1-based indices (pane-base-index=1),
@@ -345,6 +444,19 @@ class TestResolveTmuxTarget:
         (registry_dir / "orchestrator.json").write_text(json.dumps(entry))
         result = _resolve_tmux_target("orchestrator", "steward", tmp_path)
         assert result == "steward:central-ops.0"
+
+    @patch(f"{_WORKER_POOL}._dynamic_pane_lookup", return_value=None)
+    def test_no_window_skips_dynamic_lookup(
+        self, mock_lookup: MagicMock, tmp_path: Path
+    ) -> None:
+        """When registry has no window, dynamic lookup is not attempted."""
+        registry_dir = tmp_path / "worktree_registry"
+        registry_dir.mkdir()
+        entry = {"tmux_pane": "1"}
+        (registry_dir / "author-a.json").write_text(json.dumps(entry))
+        result = _resolve_tmux_target("author-a", "steward", tmp_path)
+        assert result == "steward:author-a"
+        mock_lookup.assert_not_called()
 
 
 class TestProbeTmuxPane:


### PR DESCRIPTION
## Summary
- Add `_dynamic_pane_lookup()` that queries `tmux list-panes` by pane title to resolve correct pane indices at runtime
- Modify `_resolve_tmux_target()` to prefer dynamic lookup over stale registry metadata, with registry fallback when tmux is unavailable
- Add 7 tests for `_dynamic_pane_lookup()` and update 6 tests for `_resolve_tmux_target()` to cover both resolution paths

## Why
Registry metadata can store stale 0-based pane indices (written before PR #1305 fixed `steward-session.sh`), while tmux uses `pane-base-index=1`. This caused `nudge_pane()` to target non-existent panes (e.g., `steward:platform.0` instead of `steward:platform.1`), requiring manual `tmux send-keys` for every dispatch during the proving run.

Closes #1316

## Resolution Strategy
1. **Dynamic lookup (preferred)** — query `tmux list-panes -t {session}:{window}` and match pane titles against `lane_id`. Always correct regardless of `pane-base-index` or registry staleness.
2. **Registry fallback** — use `tmux_pane` from worktree registry when tmux is unavailable (tests, pre-session).
3. **Legacy fallback** — `{session}:{lane_id}` for one-window-per-lane layout.

## Scope Lock
- `src/bid_euchre/ops/worker_pool.py` — `_dynamic_pane_lookup()` (new), `_resolve_tmux_target()` (modified)
- `tests/unit/test_ops_worker_pool.py` — new `TestDynamicPaneLookup` class, updated `TestResolveTmuxTarget`

## Validation
```bash
uv run python -m pytest tests/unit/test_ops_worker_pool.py -v  # 142 passed
make check-quiet  # All checks passed
```

## Worktree proof
```
worktree: Bid-Euchre-steward-flex-a
branch: fix/registry-pane-indices
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)