### PR TITLE
fix: apply SP-4-03 review fixes missed by auto-merge squash

### DIFF
--- a/plans/agent_ops/4_remote_channel/checkpoints.md
+++ b/plans/agent_ops/4_remote_channel/checkpoints.md
@@ -14,8 +14,8 @@
 sub-plan registry, and update checkpoints. Docs-only — no code changes.
 **Depends on:** Phase 3 COMPLETE
 **Done when:**
-- SP-4-01 sub-plan exists at `4_remote_channel/sub/2026-03-23_platform-8-scope-lock.md`
-- Sub-plan registered in `sub_plan_registry.md`
+- SP-4-01 sub-plan exists at `plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8-scope-lock.md`
+- Sub-plan registered in `plans/agent_ops/sub_plan_registry.md`
 - Checkpoints updated with Step 0 entry and session log
 
 ### Step 1 — Platform-8a: Configure Telegram plugin and prove core capabilities
@@ -35,7 +35,7 @@ sub-plan registry, and update checkpoints. Docs-only — no code changes.
 
 | Sub-Plan ID | File | Status | Blocking Step |
 |-------------|------|--------|---------------|
-| SP-4-01 | `4_remote_channel/sub/2026-03-23_platform-8-scope-lock.md` | completed | Step 0 |
+| SP-4-01 | `plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8-scope-lock.md` | completed | Step 0 |
 | SP-4-02 | `plans/agent_ops/4_remote_channel/sub/2026-03-23_remote-ops-preflight-hardening.md` | in_progress | Pre-Platform-8 |
 | SP-4-03 | `plans/agent_ops/4_remote_channel/sub/2026-03-23_token-economy-observability-and-dashboard.md` | proposed | Pre-Platform-8 |
 
@@ -53,4 +53,4 @@ sub-plan registry, and update checkpoints. Docs-only — no code changes.
 | 2026-03-23 | SP-3-05 blocker cleared. Dual-domain layout shipped (PRs #1281–#1294), proving run passed. 4-window tiled layout canonical, 12 worker lanes active across platform/browser-game/flex pools. |
 | 2026-03-23 | Step 0 (scope lock): SP-4-01 sub-plan created and registered. Key decisions: free-form messages allowed, no remote command grammar, orchestrator is single ingress, author lanes remain tmux-only. Platform-8b audit trail tracked in issue #1324. Phase status moved from PENDING to IN_PROGRESS. |
 | 2026-03-23 | SP-4-02 registered and committed. Preflight hardening plan covers 6 steps: lifecycle proving, operational cleanup, stall recovery, scope enforcement, reset/clear validation, and auto-dispatch. Gated rollout order (Steps 1-2 first, then 3-4 parallel, then 5-6). |
-| 2026-03-23 | SP-4-03 registered. Token economy observability as parallel preflight slice alongside SP-4-02. Covers usage import, lane attribution, CLI/dashboard views, and baseline anti-pattern report. Disjoint file scope from SP-4-02 — safe to run in parallel. |
+| 2026-03-23 | SP-4-03 registered. Token economy observability alongside SP-4-02. Covers usage import, lane attribution, CLI/dashboard views, and baseline anti-pattern report. Overlaps SP-4-02 in `scripts/internal/ops.py` and dashboard — serialize shared surfaces during implementation. Codex review surfaced 3 plan-quality findings (boundary exception, malformed telemetry, attribution key) for orchestrator to address. |

--- a/plans/agent_ops/4_remote_channel/plan.md
+++ b/plans/agent_ops/4_remote_channel/plan.md
@@ -26,7 +26,8 @@ treats the remote channel as a thin transport into `orchestrator`.
   Platform-8 transport work begins
 - SP-4-03 (token economy observability) establishes a token-cost baseline
   before remote transport adds a new cost dimension. SP-4-02 and SP-4-03
-  are safe to run in parallel (disjoint file scopes).
+  overlap in `scripts/internal/ops.py` and dashboard surfaces — serialize
+  shared CLI/dashboard work or split further during implementation.
 
 ## Phase Constraints
 
@@ -103,6 +104,6 @@ Before treating Phase 5 as ready, verify Batch E (Platform-8 + Platform-9):
 
 ## Step Sequence
 
-See `checkpoints.md` for current step progress. Phase 4 follows the standard
+See `plans/agent_ops/4_remote_channel/checkpoints.md` for current step progress. Phase 4 follows the standard
 step template from the governing plan: scope lock -> implementation ->
 verification -> handoff, repeated per slice.

--- a/plans/agent_ops/4_remote_channel/sub/2026-03-23_token-economy-observability-and-dashboard.md
+++ b/plans/agent_ops/4_remote_channel/sub/2026-03-23_token-economy-observability-and-dashboard.md
@@ -148,9 +148,11 @@ The baseline report must explicitly evaluate:
 - Read from:
   - `~/.claude/usage-data/session-meta/*.json`
   - `~/.claude/usage-data/facets/*.json`
-- Normalize into:
-  - `.claude/runtime/token_economy/session_usage.jsonl`
-  - `.claude/runtime/token_economy/session_rollups.json`
+- Normalize into (created by this sub-plan):
+  ```
+  .claude/runtime/token_economy/session_usage.jsonl
+  .claude/runtime/token_economy/session_rollups.json
+  ```
 - Preserve source identifiers so imports are idempotent
 - Record import timestamp and source path/hash
 
@@ -246,7 +248,7 @@ Before using token-economy work to change behavior:
 - [ ] Native Claude usage data is imported into repo-owned runtime state
 - [ ] Session imports are idempotent
 - [ ] Steward worktrees can be attributed to lane identities with acceptable accuracy
-- [ ] `ops.py` exposes token-economy summary/throughput/anti-pattern views
+- [ ] `scripts/internal/ops.py` exposes token-economy summary/throughput/anti-pattern views
 - [ ] Existing dashboard surfaces include token-economy information
 - [ ] A baseline report identifies the top 3 token-waste patterns
 - [ ] At least one correlation to shipped throughput exists:


### PR DESCRIPTION
## Summary

- Qualify bare file paths in checkpoints.md and plan.md for review precheck
- Use fenced code block for planned runtime paths in token economy plan
- Correct inaccurate disjoint-scope claim per Codex review feedback
- Record Codex plan-quality findings in session log for orchestrator

## Why

PR #1363 was squash-merged via auto-merge before 3 follow-up fix commits
were included. This PR applies those missing fixes:

1. Path qualification (precheck P1 findings)
2. Code block for planned paths (false-positive avoidance)
3. Disjoint-scope correction (Codex identified overlap in ops.py/dashboard)

## Plan

`plans/agent_ops/4_remote_channel/sub/2026-03-23_token-economy-observability-and-dashboard.md`

## Repro / Validation

```bash
make check-quiet   # docs-only, all checks pass
```

## Tests

Docs-only PR — no code changes, no test impact.

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-scratch
branch: fix/sp-4-03-review-fixes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)