### PR TITLE
fix: use timestamped path for forced-reset backup diffs

### DIFF
--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -892,8 +892,10 @@ def reset_worktree(
     Before resetting, checks for uncommitted changes.  If the worktree is
     dirty and *force* is ``False``, the reset is aborted and a
     ``dirty_worktree`` error is returned.  If *force* is ``True``, the diff
-    is saved to ``/tmp/<lane_id>.diff`` before proceeding with the reset so
-    that no work is silently lost.
+    is saved to ``/tmp/<lane_id>_<timestamp>.diff`` before proceeding with
+    the reset so that no work is silently lost.  The timestamp suffix
+    ensures concurrent resets across lanes never overwrite each other's
+    backup diffs.
 
     Args:
         lane_id: Lane whose worktree should be reset.
@@ -927,6 +929,7 @@ def reset_worktree(
             text=True,
         )
         is_dirty = bool(status_result.stdout.strip())
+        diff_path: Path | None = None
 
         if is_dirty and not force:
             dirty_files = status_result.stdout.strip()
@@ -942,7 +945,8 @@ def reset_worktree(
             )
 
         if is_dirty and force:
-            diff_path = Path(f"/tmp/{lane_id}.diff")
+            ts = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%S")
+            diff_path = Path(f"/tmp/{lane_id}_{ts}.diff")
             diff_result = subprocess.run(
                 ["git", "diff", "HEAD"],
                 cwd=worktree_path,
@@ -975,8 +979,8 @@ def reset_worktree(
         )
 
         reason = f"Reset worktree at {worktree_path} to origin/main"
-        if is_dirty:
-            reason += f" (dirty diff saved to /tmp/{lane_id}.diff)"
+        if diff_path is not None:
+            reason += f" (dirty diff saved to {diff_path})"
         return PoolAction(
             action="reset_worktree",
             lane_id=lane_id,

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -1178,12 +1178,12 @@ class TestTakePoolSnapshot:
                 LaneHealthAssessment(lane_id="author-b", health="idle", state="idle"),
             ]
         )
-        mock_vis.side_effect = (
-            lambda lane: "foreground" if lane.lane_id == "author-a" else "background"
+        mock_vis.side_effect = lambda lane: (
+            "foreground" if lane.lane_id == "author-a" else "background"
         )
         mock_probe.side_effect = lambda lid, _: lid == "author-a"
-        mock_task.side_effect = (
-            lambda lid, rd=None: "pkt1" if lid == "author-a" else None
+        mock_task.side_effect = lambda lid, rd=None: (
+            "pkt1" if lid == "author-a" else None
         )
 
         now = datetime(2026, 3, 22, 12, 0, 0, tzinfo=timezone.utc)
@@ -1951,7 +1951,7 @@ class TestResetWorktree:
     def test_dirty_worktree_force_saves_diff(
         self, mock_run: MagicMock, mock_resolve: MagicMock, tmp_path: Path
     ) -> None:
-        """Dirty worktree + force=True → saves diff, then resets successfully."""
+        """Dirty worktree + force=True → saves diff with timestamped path."""
         mock_resolve.return_value = "/tmp/wt-author-a"
         dirty_status = self._make_status_dirty()
         diff_mock = self._make_diff("diff content here")
@@ -1963,18 +1963,25 @@ class TestResetWorktree:
             ok,
         ]  # status, diff, fetch, reset
 
-        diff_path = Path("/tmp/author-a.diff")
-        result = reset_worktree("author-a", force=True)
+        from datetime import datetime, timezone
 
+        frozen = datetime(2026, 1, 15, 12, 30, 45, tzinfo=timezone.utc)
+        with patch(f"{_WORKER_POOL}.datetime") as mock_dt:
+            mock_dt.now.return_value = frozen
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            result = reset_worktree("author-a", force=True)
+
+        diff_path = Path("/tmp/author-a_20260115T123045.diff")
         assert result.executed is True
         assert result.error is None
         assert "origin/main" in result.reason
         assert "dirty diff saved" in result.reason
+        assert "20260115T123045" in result.reason
         # 4 calls: status, diff, fetch, reset
         assert mock_run.call_count == 4
         diff_call = mock_run.call_args_list[1]
         assert diff_call[0][0] == ["git", "diff", "HEAD"]
-        # Verify the diff was written to /tmp/<lane>.diff
+        # Verify the diff was written to timestamped path
         assert diff_path.exists()
         assert diff_path.read_text() == "diff content here"
         # Cleanup


### PR DESCRIPTION
## Plan
N/A — issue fix (review follow-up for PR #1350)

## Summary
- Changed `reset_worktree()` to write forced-reset backup diffs to `/tmp/<lane>_<YYYYMMDDTHHmmSS>.diff` instead of the fixed `/tmp/<lane>.diff`
- Added `diff_path` initialization and null-check for Pyright correctness
- Updated docstring to document the timestamp suffix and concurrency safety

## Why
Closes #1357. When multiple lanes reset concurrently with `force=True`, the fixed `/tmp/<lane>.diff` path means later resets overwrite earlier backup diffs. A timestamped suffix ensures each backup is preserved.

## Repro / Validation
**Command(s) run:**
```
uv run python -m pytest tests/unit/test_ops_worker_pool.py -v  # 145 passed
make check-quiet  # ✓ All checks passed
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_worker_pool.py` — 145 passed
- [x] `make check-quiet` — all checks passed

Updated test:
- `test_dirty_worktree_force_saves_diff` — now mocks `datetime` and verifies the timestamped path `/tmp/author-a_20260115T123045.diff`

## Expected impact
- Metrics impact: None
- Runtime impact: One `datetime.now()` call (~1μs) per forced reset

## Risk level
- [x] Low (ops tooling only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c  a086dbe8 [fix/forced-reset-backup-path-1357]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)