### PR TITLE
fix: use pane_start_command instead of pane_title for tmux lookup

### DIFF
--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -156,12 +156,15 @@ def _dynamic_pane_lookup(
 ) -> str | None:
     """Dynamically resolve a lane's pane index by querying tmux.
 
-    Runs ``tmux list-panes`` on the target window and matches pane titles
-    against the ``lane_id`` string.  This is robust to stale registry data
-    and works regardless of ``pane-base-index`` configuration.
+    Runs ``tmux list-panes`` on the target window and matches the
+    ``--name <lane_id>`` token in each pane's start command.  This is
+    robust to stale registry data and works regardless of
+    ``pane-base-index`` configuration.
 
-    The query is scoped to a single window, so substring matching on
-    ``lane_id`` is unambiguous (each window hosts a disjoint set of lanes).
+    Uses ``#{pane_start_command}`` rather than ``#{pane_title}`` because
+    start commands are immutable for the pane's lifetime, while pane
+    titles change dynamically (e.g. Claude Code TUI prepends spinner
+    characters like ``⠐`` or ``✳``).
 
     Args:
         lane_id: Lane identifier to look up (e.g. ``"author-a"``).
@@ -171,6 +174,7 @@ def _dynamic_pane_lookup(
     Returns:
         The pane index as a string, or ``None`` if resolution fails.
     """
+    needle = f"--name {lane_id}"
     try:
         result = subprocess.run(
             [
@@ -179,7 +183,7 @@ def _dynamic_pane_lookup(
                 "-t",
                 f"{tmux_session}:{window}",
                 "-F",
-                "#{pane_index} #{pane_title}",
+                "#{pane_index} #{pane_start_command}",
             ],
             capture_output=True,
             text=True,
@@ -189,7 +193,15 @@ def _dynamic_pane_lookup(
             return None
         for line in result.stdout.strip().splitlines():
             parts = line.split(None, 1)
-            if len(parts) >= 2 and lane_id in parts[1]:
+            if len(parts) < 2:
+                continue
+            cmd = parts[1]
+            idx = cmd.find(needle)
+            if idx < 0:
+                continue
+            # Verify needle is a complete token (not a prefix of a longer name)
+            end = idx + len(needle)
+            if end == len(cmd) or cmd[end] in (" ", "\t"):
                 return parts[0]
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         pass
@@ -206,8 +218,9 @@ def _resolve_tmux_target(
     Resolution strategy (most to least reliable):
 
     1. **Dynamic lookup** — query ``tmux list-panes`` for the lane's window
-       and match pane titles against ``lane_id``.  This is always correct
-       regardless of ``pane-base-index`` or stale registry data.
+       and match ``--name <lane_id>`` in ``#{pane_start_command}``.  This is
+       always correct regardless of ``pane-base-index`` or stale registry
+       data, and is immune to TUI-driven pane title changes.
     2. **Registry fallback** — read ``tmux_window`` and ``tmux_pane`` from
        the lane's worktree registry entry.  Used when tmux is not available
        (e.g. in tests or before the session is started).

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -309,24 +309,30 @@ class TestGetLaneTaskId:
 
 
 class TestDynamicPaneLookup:
-    """Test _dynamic_pane_lookup() tmux pane title matching."""
+    """Test _dynamic_pane_lookup() pane_start_command matching."""
 
     @patch(f"{_WORKER_POOL}.subprocess.run")
     def test_finds_matching_pane(self, mock_run: MagicMock) -> None:
-        """Matches lane_id substring in pane title."""
+        """Matches --name <lane_id> in pane start command."""
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout="1 steward-author-a\n2 steward-author-b\n",
+            stdout=(
+                "1 /usr/bin/claude --name author-a --agent steward-author-a\n"
+                "2 /usr/bin/claude --name author-b --agent steward-author-b\n"
+            ),
         )
         result = _dynamic_pane_lookup("author-a", "steward", "platform")
         assert result == "1"
 
     @patch(f"{_WORKER_POOL}.subprocess.run")
     def test_no_match(self, mock_run: MagicMock) -> None:
-        """Returns None when no pane title matches."""
+        """Returns None when no pane start command matches."""
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout="1 steward-author-c\n2 steward-author-d\n",
+            stdout=(
+                "1 /usr/bin/claude --name author-c --agent steward-author-c\n"
+                "2 /usr/bin/claude --name author-d --agent steward-author-d\n"
+            ),
         )
         result = _dynamic_pane_lookup("author-a", "steward", "platform")
         assert result is None
@@ -354,11 +360,27 @@ class TestDynamicPaneLookup:
         assert result is None
 
     @patch(f"{_WORKER_POOL}.subprocess.run")
-    def test_pane_title_with_spinner(self, mock_run: MagicMock) -> None:
-        """Matches even when pane title has a Claude Code spinner prefix."""
+    def test_no_false_positive_on_substring(self, mock_run: MagicMock) -> None:
+        """Does not match when lane_id is a substring of another lane name."""
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout="2 ⠐ steward-flex-a\n3 ✳ steward-flex-b\n",
+            stdout=("1 /usr/bin/claude --name author-ab --agent steward-author-ab\n"),
+        )
+        # "author-a" should NOT match "--name author-ab"
+        result = _dynamic_pane_lookup("author-a", "steward", "platform")
+        assert result is None
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_matches_with_cmux_path(self, mock_run: MagicMock) -> None:
+        """Matches when claude binary is at a cmux.app path."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=(
+                "2 /Applications/cmux.app/Contents/Resources/bin/claude "
+                "--name flex-a --agent steward-flex-a\n"
+                "3 /Applications/cmux.app/Contents/Resources/bin/claude "
+                "--name flex-b --agent steward-flex-b\n"
+            ),
         )
         result = _dynamic_pane_lookup("flex-a", "steward", "scratch")
         assert result == "2"
@@ -375,7 +397,7 @@ class TestDynamicPaneLookup:
                 "-t",
                 "steward:platform",
                 "-F",
-                "#{pane_index} #{pane_title}",
+                "#{pane_index} #{pane_start_command}",
             ],
             capture_output=True,
             text=True,


### PR DESCRIPTION
## Summary

- Switch `_dynamic_pane_lookup()` from matching `lane_id` in `#{pane_title}` to matching `--name <lane_id>` in `#{pane_start_command}`
- Add word-boundary checking to prevent false positives on substring lane names
- Update all tests to reflect new matching format

## Why

`#{pane_title}` is fragile — Claude Code's TUI dynamically prepends spinner characters (`⠐`, `✳`, `⠂`) and the naming is inconsistent across panes. `#{pane_start_command}` is immutable for the pane's lifetime (set at creation, never changes) and always contains the exact `--name <lane_id>` flag.

Closes #1356

## Repro / Validation

```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/test_ops_worker_pool.py::TestDynamicPaneLookup -v

# Tier 2 — full validation
make check-quiet
```

## Tests

- `tests/unit/test_ops_worker_pool.py` — 146/146 pass
- Added `test_no_false_positive_on_substring` for word-boundary edge case
- Added `test_matches_with_cmux_path` for real-world Claude binary paths

## Worktree proof

```
pwd: Bid-Euchre-steward-author
branch: fix/pane-start-command-lookup
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)