### PR TITLE
ops: add auto-dispatch to monitor cycle (SP-4-02 Step 6)

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -2111,12 +2111,14 @@ def cmd_monitor(args: argparse.Namespace) -> int:
     skip_pr = getattr(args, "skip_pr_check", False)
     no_notify = getattr(args, "no_notify", False)
     no_recovery = getattr(args, "no_recovery", False)
+    no_auto_dispatch = getattr(args, "no_auto_dispatch", False)
 
     findings = run_monitoring_cycle(
         runtime_dir=args.runtime_dir,
         notify_orchestrator=not no_notify,
         skip_pr_check=skip_pr,
         no_recovery=no_recovery,
+        no_auto_dispatch=no_auto_dispatch,
     )
 
     if args.json:
@@ -3035,6 +3037,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--no-recovery",
         action="store_true",
         help="Disable stall recovery actions (report only, no re-nudge/escalate)",
+    )
+    monitor_parser.add_argument(
+        "--no-auto-dispatch",
+        action="store_true",
+        help="Disable auto-dispatch of approved packets to idle lanes",
     )
 
     # review-check (merged PR review scanning)

--- a/src/bid_euchre/ops/monitor.py
+++ b/src/bid_euchre/ops/monitor.py
@@ -29,6 +29,9 @@ logger = logging.getLogger("ops.monitor")
 # A dispatched packet with no progress after this many minutes is flagged.
 STALE_DISPATCH_MINUTES: int = 30
 
+# Maximum auto-dispatches per monitor cycle (rate limit / kill switch).
+MAX_AUTO_DISPATCH_PER_CYCLE: int = 2
+
 # Stall detection: dispatched+acked lane with no tmux activity growth.
 STALL_THRESHOLD_MINUTES: int = 10
 STALL_CONSECUTIVE_CYCLES: int = 2
@@ -784,6 +787,184 @@ def check_stalled_lanes(
 
 
 # ---------------------------------------------------------------------------
+# Auto-dispatch: assign approved packets to idle lanes (SP-4-02 Step 6)
+# ---------------------------------------------------------------------------
+
+
+def check_auto_dispatch(
+    runtime_dir: Path | None = None,
+    *,
+    max_dispatches: int = MAX_AUTO_DISPATCH_PER_CYCLE,
+    current_findings: list[MonitorFinding] | None = None,
+    tmux_session: str = "steward",
+    _dispatch_fn: Any | None = None,
+) -> list[MonitorFinding]:
+    """Auto-dispatch approved packets to idle lanes.
+
+    When a lane goes idle after completing a task, the monitor can
+    auto-dispatch the next queued approved packet.  Domain affinity is
+    used to match packets to lanes: same-domain → flex → skip.
+
+    Safety guards:
+    - Rate limit: at most ``max_dispatches`` dispatches per cycle.
+    - Skip lanes that have unresolved HIGH findings in the current cycle.
+    - Skip lanes that already have a dispatched packet.
+    - Skip lanes with ``health == "critical"``.
+
+    Args:
+        runtime_dir: Override for the runtime directory root.
+        max_dispatches: Maximum dispatches per cycle (kill switch).
+        current_findings: Findings from earlier checks in the current cycle.
+            Used to skip lanes with unresolved HIGH findings.
+        tmux_session: tmux session name.
+        _dispatch_fn: Optional callable(packet_id, lane_id) for testing.
+            If provided, used instead of ``dispatch_to_worker()``.
+
+    Returns:
+        List of findings (INFO for successful dispatches, WARN for errors).
+    """
+    findings: list[MonitorFinding] = []
+
+    if max_dispatches <= 0:
+        return findings
+
+    try:
+        from bid_euchre.ops.task_queue import list_packets
+        from bid_euchre.ops.worker_pool import (
+            select_worker,
+            take_pool_snapshot,
+        )
+
+        pool = take_pool_snapshot(runtime_dir, tmux_session=tmux_session)
+        if runtime_dir is None:
+            runtime_dir = Path(".claude/runtime")
+        task_queue_root = runtime_dir / "task_queue"
+        approved = list_packets(task_queue_root, status_filter="approved")
+    except Exception as exc:
+        findings.append(
+            MonitorFinding(
+                category="auto_dispatch",
+                severity=SEVERITY_WARN,
+                summary=f"Could not check for auto-dispatch: {exc}",
+            )
+        )
+        return findings
+
+    if not approved:
+        return findings
+
+    if pool.available_capacity <= 0:
+        return findings
+
+    # Build set of lanes with unresolved HIGH findings from this cycle.
+    high_lanes: set[str] = set()
+    if current_findings:
+        for f in current_findings:
+            if f.severity == SEVERITY_HIGH:
+                lane_id = f.details.get("lane_id")
+                if lane_id:
+                    high_lanes.add(lane_id)
+
+    dispatched_count = 0
+
+    for pkt in approved:
+        if dispatched_count >= max_dispatches:
+            break
+
+        # Select best lane for this packet's domain
+        domain = getattr(pkt, "domain", None)
+        lane_id = select_worker(pool, domain=domain)
+
+        if lane_id is None:
+            continue
+
+        # Skip lanes with unresolved HIGH findings
+        if lane_id in high_lanes:
+            continue
+
+        # Attempt dispatch
+        try:
+            if _dispatch_fn is not None:
+                _dispatch_fn(pkt.packet_id, lane_id)
+            else:
+                from bid_euchre.ops.worker_pool import dispatch_to_worker
+
+                result = dispatch_to_worker(
+                    pkt.packet_id,
+                    lane_id,
+                    tmux_session=tmux_session,
+                    runtime_dir=runtime_dir,
+                    reset=True,
+                )
+                if result.error:
+                    findings.append(
+                        MonitorFinding(
+                            category="auto_dispatch",
+                            severity=SEVERITY_WARN,
+                            summary=(
+                                f"Auto-dispatch failed for packet "
+                                f"{pkt.packet_id!r} → {lane_id!r}: "
+                                f"{result.error}"
+                            ),
+                            details={
+                                "packet_id": pkt.packet_id,
+                                "lane_id": lane_id,
+                                "error": result.error,
+                            },
+                        )
+                    )
+                    continue
+
+            findings.append(
+                MonitorFinding(
+                    category="auto_dispatch",
+                    severity=SEVERITY_INFO,
+                    summary=(
+                        f"Auto-dispatched packet {pkt.packet_id!r} "
+                        f"({pkt.title!r}) → {lane_id!r}"
+                    ),
+                    details={
+                        "packet_id": pkt.packet_id,
+                        "title": pkt.title,
+                        "lane_id": lane_id,
+                        "domain": domain,
+                    },
+                )
+            )
+            dispatched_count += 1
+
+            # Mark lane as no longer idle in the snapshot so the next
+            # iteration doesn't pick it again.
+            for w in pool.workers:
+                if w.lane_id == lane_id:
+                    # WorkerState is a dataclass (not frozen), mutate in place
+                    w.pool_status = "active"
+                    w.current_task_id = pkt.packet_id
+                    break
+            pool.active_count += 1
+            pool.available_capacity = max(0, pool.available_capacity - 1)
+
+        except Exception as exc:
+            findings.append(
+                MonitorFinding(
+                    category="auto_dispatch",
+                    severity=SEVERITY_WARN,
+                    summary=(
+                        f"Auto-dispatch error for packet "
+                        f"{pkt.packet_id!r} → {lane_id!r}: {exc}"
+                    ),
+                    details={
+                        "packet_id": pkt.packet_id,
+                        "lane_id": lane_id,
+                        "error": str(exc),
+                    },
+                )
+            )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
 # Orchestrator notification
 # ---------------------------------------------------------------------------
 
@@ -864,6 +1045,7 @@ def run_monitoring_cycle(
     notify_orchestrator: bool = True,
     skip_pr_check: bool = False,
     no_recovery: bool = False,
+    no_auto_dispatch: bool = False,
 ) -> list[MonitorFinding]:
     """Run a single monitoring sweep.
 
@@ -872,6 +1054,8 @@ def run_monitoring_cycle(
     2. Open PR status (via ``gh``)
     3. Stale dispatched packet detection
     4. Stalled lane detection (acked but idle), with optional recovery
+    5. Auto-complete dispatched packets whose PRs were merged externally
+    6. Auto-dispatch approved packets to idle lanes
 
     Optionally sends a summary to the orchestrator inbox.
 
@@ -882,6 +1066,7 @@ def run_monitoring_cycle(
         notify_orchestrator: If True, send findings to orchestrator inbox.
         skip_pr_check: If True, skip the gh pr check (for testing).
         no_recovery: If True, disable stall recovery actions (report only).
+        no_auto_dispatch: If True, disable auto-dispatch of approved packets.
 
     Returns:
         List of all findings from the sweep.
@@ -907,7 +1092,11 @@ def run_monitoring_cycle(
     if not skip_pr_check:
         findings.extend(check_merged_dispatches(runtime_dir))
 
-    # 6. Notify orchestrator
+    # 6. Auto-dispatch approved packets to idle lanes
+    if not no_auto_dispatch:
+        findings.extend(check_auto_dispatch(runtime_dir, current_findings=findings))
+
+    # 7. Notify orchestrator
     if notify_orchestrator:
         _send_findings_to_orchestrator(findings)
 

--- a/tests/unit/test_ops_monitor.py
+++ b/tests/unit/test_ops_monitor.py
@@ -9,12 +9,14 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 from bid_euchre.ops.monitor import (
+    MAX_AUTO_DISPATCH_PER_CYCLE,
     SEVERITY_HIGH,
     SEVERITY_INFO,
     SEVERITY_WARN,
     MonitorFinding,
     _default_stall_state_path,
     _save_stall_state,
+    check_auto_dispatch,
     check_lane_health,
     check_merged_dispatches,
     check_open_prs,
@@ -1260,6 +1262,433 @@ class TestRunMonitoringCycle:
             )
 
         mock_notify.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# check_auto_dispatch tests (SP-4-02 Step 6)
+# ---------------------------------------------------------------------------
+
+
+def _make_approved_pkt(
+    packet_id: str = "apkt001",
+    title: str = "Approved task",
+    domain: str | None = "platform",
+) -> MagicMock:
+    """Helper to create a mock approved packet."""
+    pkt = MagicMock()
+    pkt.packet_id = packet_id
+    pkt.title = title
+    pkt.domain = domain
+    pkt.status = "approved"
+    return pkt
+
+
+def _make_pool_snapshot(
+    workers: list[Any] | None = None,
+    active: int = 0,
+    idle: int = 0,
+    parked: int = 0,
+    retired: int = 0,
+    capacity: int = 5,
+) -> MagicMock:
+    """Helper to create a mock PoolSnapshot."""
+    pool = MagicMock()
+    pool.workers = workers or []
+    pool.active_count = active
+    pool.idle_count = idle
+    pool.parked_count = parked
+    pool.retired_count = retired
+    pool.available_capacity = capacity
+    return pool
+
+
+def _make_worker(
+    lane_id: str = "author-a",
+    pool_status: str = "idle",
+    health: str = "healthy",
+    current_task_id: str | None = None,
+    domain: str | None = "platform",
+) -> MagicMock:
+    """Helper to create a mock WorkerState."""
+    w = MagicMock()
+    w.lane_id = lane_id
+    w.pool_status = pool_status
+    w.health = health
+    w.current_task_id = current_task_id
+    w.domain = domain
+    return w
+
+
+class TestCheckAutoDispatch:
+    """Tests for auto-dispatch of approved packets to idle lanes."""
+
+    def test_no_approved_packets(self, tmp_path: Path) -> None:
+        """No approved packets → no dispatches."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        pool = _make_pool_snapshot(capacity=5)
+
+        with (
+            patch(
+                "bid_euchre.ops.worker_pool.take_pool_snapshot",
+                return_value=pool,
+            ),
+            patch(
+                "bid_euchre.ops.task_queue.list_packets",
+                return_value=[],
+            ),
+        ):
+            findings = check_auto_dispatch(runtime_dir)
+
+        assert len(findings) == 0
+
+    def test_dispatches_approved_to_idle_lane(self, tmp_path: Path) -> None:
+        """Approved packet dispatched to idle lane via _dispatch_fn."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        worker = _make_worker(lane_id="author-a", pool_status="idle")
+        pool = _make_pool_snapshot(workers=[worker], idle=1, capacity=5)
+        pkt = _make_approved_pkt(packet_id="apkt001", domain="platform")
+
+        dispatches: list[tuple[str, str]] = []
+
+        def mock_dispatch(packet_id: str, lane_id: str) -> None:
+            dispatches.append((packet_id, lane_id))
+
+        with (
+            patch(
+                "bid_euchre.ops.worker_pool.take_pool_snapshot",
+                return_value=pool,
+            ),
+            patch(
+                "bid_euchre.ops.task_queue.list_packets",
+                return_value=[pkt],
+            ),
+            patch(
+                "bid_euchre.ops.worker_pool.select_worker",
+                return_value="author-a",
+            ),
+        ):
+            findings = check_auto_dispatch(runtime_dir, _dispatch_fn=mock_dispatch)
+
+        assert len(findings) == 1
+        assert findings[0].category == "auto_dispatch"
+        assert findings[0].severity == SEVERITY_INFO
+        assert "apkt001" in findings[0].summary
+        assert "author-a" in findings[0].summary
+        assert len(dispatches) == 1
+        assert dispatches[0] == ("apkt001", "author-a")
+
+    def test_rate_limit_enforced(self, tmp_path: Path) -> None:
+        """At most max_dispatches per cycle."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        worker_a = _make_worker(lane_id="author-a", pool_status="idle")
+        worker_b = _make_worker(lane_id="author-b", pool_status="idle")
+        worker_c = _make_worker(lane_id="author-c", pool_status="idle")
+        pool = _make_pool_snapshot(
+            workers=[worker_a, worker_b, worker_c],
+            idle=3,
+            capacity=5,
+        )
+
+        pkts = [
+            _make_approved_pkt(packet_id=f"apkt{i:03d}", title=f"Task {i}")
+            for i in range(4)
+        ]
+
+        dispatches: list[tuple[str, str]] = []
+        select_calls = iter(["author-a", "author-b", "author-c", "author-d"])
+
+        def mock_dispatch(packet_id: str, lane_id: str) -> None:
+            dispatches.append((packet_id, lane_id))
+
+        with (
+            patch(
+                "bid_euchre.ops.worker_pool.take_pool_snapshot",
+                return_value=pool,
+            ),
+            patch(
+                "bid_euchre.ops.task_queue.list_packets",
+                return_value=pkts,
+            ),
+            patch(
+                "bid_euchre.ops.worker_pool.select_worker",
+                side_effect=lambda *a, **kw: next(select_calls),
+            ),
+        ):
+            findings = check_auto_dispatch(
+                runtime_dir,
+                max_dispatches=2,
+                _dispatch_fn=mock_dispatch,
+            )
+
+        info_findings = [f for f in findings if f.severity == SEVERITY_INFO]
+        assert len(info_findings) == 2
+        assert len(dispatches) == 2
+
+    def test_skips_lane_with_high_finding(self, tmp_path: Path) -> None:
+        """Lanes with HIGH findings in current cycle are skipped."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        worker = _make_worker(lane_id="author-a", pool_status="idle")
+        pool = _make_pool_snapshot(workers=[worker], idle=1, capacity=5)
+        pkt = _make_approved_pkt()
+
+        # Simulate a HIGH finding for author-a from earlier checks
+        current_findings = [
+            MonitorFinding(
+                category="lane_health",
+                severity=SEVERITY_HIGH,
+                summary="Lane author-a has dead tmux",
+                details={"lane_id": "author-a"},
+            ),
+        ]
+
+        dispatches: list[tuple[str, str]] = []
+
+        with (
+            patch(
+                "bid_euchre.ops.worker_pool.take_pool_snapshot",
+                return_value=pool,
+            ),
+            patch(
+                "bid_euchre.ops.task_queue.list_packets",
+                return_value=[pkt],
+            ),
+            patch(
+                "bid_euchre.ops.worker_pool.select_worker",
+                return_value="author-a",
+            ),
+        ):
+            findings = check_auto_dispatch(
+                runtime_dir,
+                current_findings=current_findings,
+                _dispatch_fn=lambda pid, lid: dispatches.append((pid, lid)),
+            )
+
+        assert len(dispatches) == 0
+        assert len(findings) == 0
+
+    def test_no_capacity_skips(self, tmp_path: Path) -> None:
+        """No available capacity → no dispatches."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        pool = _make_pool_snapshot(capacity=0)
+        pkt = _make_approved_pkt()
+
+        with (
+            patch(
+                "bid_euchre.ops.worker_pool.take_pool_snapshot",
+                return_value=pool,
+            ),
+            patch(
+                "bid_euchre.ops.task_queue.list_packets",
+                return_value=[pkt],
+            ),
+        ):
+            findings = check_auto_dispatch(runtime_dir)
+
+        assert len(findings) == 0
+
+    def test_no_matching_lane_skips(self, tmp_path: Path) -> None:
+        """No matching lane for a packet → skip that packet."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        pool = _make_pool_snapshot(capacity=5)
+        pkt = _make_approved_pkt()
+
+        dispatches: list[tuple[str, str]] = []
+
+        with (
+            patch(
+                "bid_euchre.ops.worker_pool.take_pool_snapshot",
+                return_value=pool,
+            ),
+            patch(
+                "bid_euchre.ops.task_queue.list_packets",
+                return_value=[pkt],
+            ),
+            patch(
+                "bid_euchre.ops.worker_pool.select_worker",
+                return_value=None,
+            ),
+        ):
+            findings = check_auto_dispatch(
+                runtime_dir,
+                _dispatch_fn=lambda pid, lid: dispatches.append((pid, lid)),
+            )
+
+        assert len(dispatches) == 0
+        assert len(findings) == 0
+
+    def test_dispatch_exception_produces_warn(self, tmp_path: Path) -> None:
+        """Exception during dispatch produces WARN finding."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        worker = _make_worker(lane_id="author-a", pool_status="idle")
+        pool = _make_pool_snapshot(workers=[worker], idle=1, capacity=5)
+        pkt = _make_approved_pkt()
+
+        def bad_dispatch(packet_id: str, lane_id: str) -> None:
+            raise RuntimeError("tmux not found")
+
+        with (
+            patch(
+                "bid_euchre.ops.worker_pool.take_pool_snapshot",
+                return_value=pool,
+            ),
+            patch(
+                "bid_euchre.ops.task_queue.list_packets",
+                return_value=[pkt],
+            ),
+            patch(
+                "bid_euchre.ops.worker_pool.select_worker",
+                return_value="author-a",
+            ),
+        ):
+            findings = check_auto_dispatch(runtime_dir, _dispatch_fn=bad_dispatch)
+
+        assert len(findings) == 1
+        assert findings[0].severity == SEVERITY_WARN
+        assert findings[0].category == "auto_dispatch"
+        assert "tmux not found" in findings[0].summary
+
+    def test_max_dispatches_zero_noop(self, tmp_path: Path) -> None:
+        """max_dispatches=0 is a kill switch — no dispatches."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        findings = check_auto_dispatch(runtime_dir, max_dispatches=0)
+        assert len(findings) == 0
+
+    def test_snapshot_failure_graceful(self, tmp_path: Path) -> None:
+        """Pool snapshot failure produces WARN, doesn't crash."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        with patch(
+            "bid_euchre.ops.worker_pool.take_pool_snapshot",
+            side_effect=RuntimeError("no registry"),
+        ):
+            findings = check_auto_dispatch(runtime_dir)
+
+        assert len(findings) == 1
+        assert findings[0].severity == SEVERITY_WARN
+        assert "auto-dispatch" in findings[0].summary.lower()
+
+    def test_default_rate_limit_is_two(self) -> None:
+        """Default MAX_AUTO_DISPATCH_PER_CYCLE is 2."""
+        assert MAX_AUTO_DISPATCH_PER_CYCLE == 2
+
+    def test_domain_passed_to_select_worker(self, tmp_path: Path) -> None:
+        """Packet domain is passed through to select_worker."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        worker = _make_worker(lane_id="brws-author-a", domain="browser-game")
+        pool = _make_pool_snapshot(workers=[worker], idle=1, capacity=5)
+        pkt = _make_approved_pkt(domain="browser-game")
+
+        dispatches: list[tuple[str, str]] = []
+
+        with (
+            patch(
+                "bid_euchre.ops.worker_pool.take_pool_snapshot",
+                return_value=pool,
+            ),
+            patch(
+                "bid_euchre.ops.task_queue.list_packets",
+                return_value=[pkt],
+            ),
+            patch(
+                "bid_euchre.ops.worker_pool.select_worker",
+                return_value="brws-author-a",
+            ) as mock_select,
+        ):
+            findings = check_auto_dispatch(
+                runtime_dir,
+                _dispatch_fn=lambda pid, lid: dispatches.append((pid, lid)),
+            )
+
+        mock_select.assert_called_once_with(pool, domain="browser-game")
+        assert len(dispatches) == 1
+        assert findings[0].details["domain"] == "browser-game"
+
+
+class TestRunMonitoringCycleAutoDispatch:
+    """Tests for auto-dispatch integration in run_monitoring_cycle."""
+
+    def test_no_auto_dispatch_flag_disables(self, tmp_path: Path) -> None:
+        """no_auto_dispatch=True prevents auto-dispatch step."""
+        pool_mock = MagicMock()
+        pool_mock.workers = []
+        pool_mock.active_count = 0
+        pool_mock.idle_count = 0
+        pool_mock.parked_count = 0
+        pool_mock.retired_count = 0
+        pool_mock.available_capacity = 5
+
+        with (
+            patch(
+                "bid_euchre.ops.worker_pool.take_pool_snapshot",
+                return_value=pool_mock,
+            ),
+            patch("bid_euchre.ops.task_queue.list_packets", return_value=[]),
+            patch(
+                "bid_euchre.ops.monitor.check_auto_dispatch",
+            ) as mock_auto,
+            patch(
+                "bid_euchre.ops.monitor._send_findings_to_orchestrator",
+                return_value=None,
+            ),
+        ):
+            run_monitoring_cycle(
+                tmp_path,
+                skip_pr_check=True,
+                no_auto_dispatch=True,
+            )
+
+        mock_auto.assert_not_called()
+
+    def test_auto_dispatch_enabled_by_default(self, tmp_path: Path) -> None:
+        """Auto-dispatch runs by default when not disabled."""
+        pool_mock = MagicMock()
+        pool_mock.workers = []
+        pool_mock.active_count = 0
+        pool_mock.idle_count = 0
+        pool_mock.parked_count = 0
+        pool_mock.retired_count = 0
+        pool_mock.available_capacity = 5
+
+        with (
+            patch(
+                "bid_euchre.ops.worker_pool.take_pool_snapshot",
+                return_value=pool_mock,
+            ),
+            patch("bid_euchre.ops.task_queue.list_packets", return_value=[]),
+            patch(
+                "bid_euchre.ops.monitor.check_auto_dispatch",
+                return_value=[],
+            ) as mock_auto,
+            patch(
+                "bid_euchre.ops.monitor._send_findings_to_orchestrator",
+                return_value=None,
+            ),
+        ):
+            run_monitoring_cycle(
+                tmp_path,
+                skip_pr_check=True,
+            )
+
+        mock_auto.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `check_auto_dispatch()` to the monitor cycle that assigns approved task packets to idle lanes
- Domain affinity routing: same-domain → flex → skip (via existing `select_worker()`)
- Rate limited to 2 dispatches per cycle, with `--no-auto-dispatch` kill switch
- Skips lanes with unresolved HIGH findings from the current cycle

## Why
When a lane completes a task and goes idle, approved packets sit in the queue until
the orchestrator manually dispatches them. This closes the loop: the monitor cycle
now auto-assigns queued work to available lanes, reducing operator intervention.

## Changes
| File | Change |
|------|--------|
| `src/bid_euchre/ops/monitor.py` | Add `MAX_AUTO_DISPATCH_PER_CYCLE`, `check_auto_dispatch()`, wire into `run_monitoring_cycle()` |
| `scripts/internal/ops.py` | Add `--no-auto-dispatch` CLI flag, pass to `run_monitoring_cycle()` |
| `tests/unit/test_ops_monitor.py` | 13 new tests covering all auto-dispatch paths |

## Safety controls
- **Rate limit:** `MAX_AUTO_DISPATCH_PER_CYCLE = 2` (constant, adjustable)
- **Kill switch:** `--no-auto-dispatch` flag on `ops.py monitor`
- **HIGH-finding skip:** Lanes with unresolved HIGH findings in the current cycle are skipped
- **Capacity check:** No dispatch when `available_capacity <= 0`
- **Error isolation:** Dispatch failures produce WARN findings (non-fatal to cycle)

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_ops_monitor.py -v
make check-quiet
```

## Tests
- `make check-quiet` — all checks pass (58 monitor tests, full suite green)
- 13 new tests: no approved packets, dispatch to idle lane, rate limit, HIGH-finding skip,
  no capacity, no matching lane, dispatch exception, kill switch, snapshot failure,
  default rate limit, domain passthrough, `no_auto_dispatch` flag, auto-dispatch enabled by default

## Worktree proof
```
pwd: Bid-Euchre-steward-author-c
branch: ops/sp4-02-step6-auto-dispatch
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)