### PR TITLE
ops: add scope drift enforcement with commit-time guard (SP-4-02 Step 4)

### DIFF
--- a/.claude/hooks/pre-bash-dispatch.sh
+++ b/.claude/hooks/pre-bash-dispatch.sh
@@ -5,7 +5,8 @@
 # "Async hook completed" TUI messages (issue #1255). Dispatches to:
 #   1. pre-worktree-cleanup.sh — blocks dangerous rm/worktree commands
 #   2. pre-merge-review-guard.sh — blocks merge without review verdict
-#   3. rule-loader.sh — progressive rule disclosure (context injection)
+#   3. scope-drift-guard.sh — warns/blocks commit when staged files exceed task scope
+#   4. rule-loader.sh — progressive rule disclosure (context injection)
 #
 # Guards run first: if either blocks (exit 2), we propagate immediately.
 # Rule-loader runs last since context injection is only useful if the
@@ -43,7 +44,26 @@ if [ -x "$HOOKS_DIR/pre-merge-review-guard.sh" ]; then
     fi
 fi
 
-# --- 3. Rule loader (never blocks, may return additionalContext) ---
+# --- 3. Scope drift guard (may block with exit 2 or warn) ---
+if [ -x "$HOOKS_DIR/scope-drift-guard.sh" ]; then
+    SDG_OUTPUT=""
+    SDG_EXIT=0
+    SDG_OUTPUT=$(echo "$INPUT" | "$HOOKS_DIR/scope-drift-guard.sh" 2>/dev/null) || SDG_EXIT=$?
+    if [ "$SDG_EXIT" -ne 0 ]; then
+        echo "$SDG_OUTPUT"
+        exit "$SDG_EXIT"
+    fi
+    # Check if scope guard returned additionalContext (warning)
+    if [ -n "$SDG_OUTPUT" ]; then
+        SDG_AC=$(echo "$SDG_OUTPUT" | jq -r '.additionalContext // empty' 2>/dev/null || true)
+        if [ -n "$SDG_AC" ]; then
+            echo "$SDG_OUTPUT"
+            exit 0
+        fi
+    fi
+fi
+
+# --- 4. Rule loader (never blocks, may return additionalContext) ---
 if [ -x "$HOOKS_DIR/rule-loader.sh" ]; then
     RULE_OUTPUT=""
     RULE_OUTPUT=$(echo "$INPUT" | "$HOOKS_DIR/rule-loader.sh" 2>/dev/null) || true

--- a/.claude/hooks/scope-drift-guard.sh
+++ b/.claude/hooks/scope-drift-guard.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# PreToolUse hook — warns or blocks git commit when staged files exceed
+# the active task packet's declared scope.
+#
+# Only activates when:
+#   1. The Bash command starts with "git commit"
+#   2. A dispatched task packet exists for the current lane
+#   3. The packet has declared scope patterns
+#
+# Exit codes: 0 = allow, 2 = block (Claude Code convention)
+# Timeout: 10s
+set -euo pipefail
+
+# PreToolUse receives JSON on stdin
+INPUT=$(cat)
+
+# Extract the command being attempted
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+
+if [ -z "$COMMAND" ]; then
+  echo '{"suppressOutput": true}'
+  exit 0
+fi
+
+# Only guard on direct "git commit" commands (not quoted inside tmux etc.)
+TRIMMED="${COMMAND#"${COMMAND%%[![:space:]]*}"}"
+if [[ "$TRIMMED" != "git commit"* ]]; then
+  echo '{"suppressOutput": true}'
+  exit 0
+fi
+
+# Determine lane identity
+LANE_ID="${CLAUDE_AGENT_NAME:-}"
+if [ -z "$LANE_ID" ]; then
+  # Fallback: parse from project directory name
+  PROJ_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+  DIR_NAME=$(basename "$PROJ_DIR")
+  case "$DIR_NAME" in
+    *steward-author)    LANE_ID="author-a" ;;
+    *steward-author-b)  LANE_ID="author-b" ;;
+    *steward-author-c)  LANE_ID="author-c" ;;
+    *steward-author-d)  LANE_ID="author-d" ;;
+    *steward-author-scratch) LANE_ID="author-scratch" ;;
+    *brws-author-a)     LANE_ID="brws-author-a" ;;
+    *brws-author-b)     LANE_ID="brws-author-b" ;;
+    *brws-author-c)     LANE_ID="brws-author-c" ;;
+    *brws-author-d)     LANE_ID="brws-author-d" ;;
+    *steward-flex-a)    LANE_ID="flex-a" ;;
+    *steward-flex-b)    LANE_ID="flex-b" ;;
+    *steward-flex-c)    LANE_ID="flex-c" ;;
+    *)                  LANE_ID="" ;;
+  esac
+fi
+
+if [ -z "$LANE_ID" ]; then
+  # Cannot determine lane — skip enforcement silently
+  echo '{"suppressOutput": true}'
+  exit 0
+fi
+
+# Run enforcement via Python
+RESULT=$(uv run python -c "
+import json, subprocess, sys
+
+from bid_euchre.ops.scope import enforce_scope_drift, get_active_task_scope
+
+# Find active task for this lane
+task_id, patterns = get_active_task_scope('${LANE_ID}')
+if task_id is None or not patterns:
+    print(json.dumps({'action': 'skip', 'reason': 'No active task or no scope patterns.'}))
+    sys.exit(0)
+
+# Get staged files from git
+result = subprocess.run(
+    ['git', 'diff', '--cached', '--name-only'],
+    capture_output=True, text=True, timeout=5,
+)
+if result.returncode != 0:
+    print(json.dumps({'action': 'skip', 'reason': 'Cannot read staged files.'}))
+    sys.exit(0)
+
+staged = [f for f in result.stdout.strip().split('\n') if f]
+if not staged:
+    print(json.dumps({'action': 'skip', 'reason': 'No staged files.'}))
+    sys.exit(0)
+
+verdict = enforce_scope_drift(staged, patterns, task_id=task_id)
+print(json.dumps(verdict.to_dict()))
+" 2>/dev/null)
+
+if [ -z "$RESULT" ]; then
+  # Python invocation failed — don't block work
+  echo '{"suppressOutput": true}'
+  exit 0
+fi
+
+ACTION=$(echo "$RESULT" | jq -r '.action // "skip"' 2>/dev/null || echo "skip")
+REASON=$(echo "$RESULT" | jq -r '.reason // ""' 2>/dev/null || echo "")
+TASK_ID=$(echo "$RESULT" | jq -r '.task_id // ""' 2>/dev/null || echo "")
+OOS_FILES=$(echo "$RESULT" | jq -r '.out_of_scope[]? // empty' 2>/dev/null || echo "")
+
+case "$ACTION" in
+  block)
+    cat <<BLOCK
+SCOPE DRIFT BLOCKED: Commit blocked by scope enforcement.
+
+Task: ${TASK_ID}
+${REASON}
+
+Out-of-scope files:
+$(echo "$OOS_FILES" | sed 's/^/  ! /')
+
+To proceed, either:
+  1. Unstage out-of-scope files: git reset HEAD <file>
+  2. Update the task packet scope if the files are legitimately needed
+BLOCK
+    exit 2
+    ;;
+  warn)
+    # Warn but allow — inject context so Claude sees the warning
+    WARNING="SCOPE DRIFT WARNING (task ${TASK_ID}): ${REASON}"
+    if [ -n "$OOS_FILES" ]; then
+      WARNING="${WARNING}\nOut-of-scope: $(echo "$OOS_FILES" | tr '\n' ', ' | sed 's/,$//')"
+    fi
+    echo "{\"additionalContext\": \"${WARNING}\"}"
+    exit 0
+    ;;
+  *)
+    # skip or allow
+    echo '{"suppressOutput": true}'
+    exit 0
+    ;;
+esac

--- a/src/bid_euchre/ops/scope.py
+++ b/src/bid_euchre/ops/scope.py
@@ -143,6 +143,169 @@ def check_scope_drift(
     )
 
 
+@dataclass
+class ScopeEnforcementResult:
+    """Result of scope drift enforcement against staged files.
+
+    Actions:
+    - ``"skip"``  — no active task or no declared scope, nothing to enforce.
+    - ``"allow"`` — all staged files are within declared scope.
+    - ``"warn"``  — drift ratio exceeds the warning threshold.
+    - ``"block"`` — drift ratio exceeds the blocking threshold.
+    """
+
+    action: str  # "skip" | "allow" | "warn" | "block"
+    task_id: str | None
+    declared_patterns: list[str]
+    staged_files: list[str]
+    in_scope: list[str] = field(default_factory=list)
+    out_of_scope: list[str] = field(default_factory=list)
+    drift_ratio: float = 0.0
+    reason: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "action": self.action,
+            "task_id": self.task_id,
+            "declared_patterns": self.declared_patterns,
+            "staged_files": self.staged_files,
+            "in_scope": self.in_scope,
+            "out_of_scope": self.out_of_scope,
+            "drift_ratio": round(self.drift_ratio, 3),
+            "reason": self.reason,
+        }
+
+
+# Default thresholds
+WARN_DRIFT_RATIO = 0.5
+BLOCK_DRIFT_RATIO = 0.8
+
+
+def enforce_scope_drift(
+    staged_files: list[str],
+    declared_patterns: list[str],
+    task_id: str | None = None,
+    *,
+    warn_threshold: float = WARN_DRIFT_RATIO,
+    block_threshold: float = BLOCK_DRIFT_RATIO,
+) -> ScopeEnforcementResult:
+    """Enforce scope drift policy against staged files.
+
+    Compares *staged_files* (relative to repo root) against
+    *declared_patterns* (glob patterns from the task packet) and
+    returns an enforcement action:
+
+    - ``"skip"``  — no declared patterns (nothing to enforce).
+    - ``"allow"`` — drift ratio ≤ *warn_threshold*.
+    - ``"warn"``  — drift ratio > *warn_threshold* but ≤ *block_threshold*.
+    - ``"block"`` — drift ratio > *block_threshold*.
+
+    Args:
+        staged_files: Paths staged for commit (relative to repo root).
+        declared_patterns: Glob patterns from the active task packet.
+        task_id: Optional task identifier for reporting.
+        warn_threshold: Drift ratio above which a warning is emitted.
+        block_threshold: Drift ratio above which the commit is blocked.
+
+    Returns:
+        ScopeEnforcementResult with the verdict and details.
+    """
+    if not declared_patterns:
+        return ScopeEnforcementResult(
+            action="skip",
+            task_id=task_id,
+            declared_patterns=declared_patterns,
+            staged_files=staged_files,
+            in_scope=list(staged_files),
+            out_of_scope=[],
+            drift_ratio=0.0,
+            reason="No declared scope patterns — skipping enforcement.",
+        )
+
+    if not staged_files:
+        return ScopeEnforcementResult(
+            action="allow",
+            task_id=task_id,
+            declared_patterns=declared_patterns,
+            staged_files=[],
+            in_scope=[],
+            out_of_scope=[],
+            drift_ratio=0.0,
+            reason="No staged files.",
+        )
+
+    in_scope: list[str] = []
+    out_of_scope: list[str] = []
+    for path in staged_files:
+        if _matches_any_pattern(path, declared_patterns):
+            in_scope.append(path)
+        else:
+            out_of_scope.append(path)
+
+    drift_ratio = len(out_of_scope) / len(staged_files) if staged_files else 0.0
+
+    if drift_ratio > block_threshold:
+        action = "block"
+        reason = (
+            f"Drift ratio {drift_ratio:.0%} exceeds block threshold "
+            f"({block_threshold:.0%}). "
+            f"{len(out_of_scope)} of {len(staged_files)} staged file(s) "
+            f"are outside declared scope."
+        )
+    elif drift_ratio > warn_threshold:
+        action = "warn"
+        reason = (
+            f"Drift ratio {drift_ratio:.0%} exceeds warn threshold "
+            f"({warn_threshold:.0%}). "
+            f"{len(out_of_scope)} of {len(staged_files)} staged file(s) "
+            f"are outside declared scope."
+        )
+    else:
+        action = "allow"
+        reason = "Staged files are within acceptable scope."
+        if out_of_scope:
+            reason = (
+                f"{len(out_of_scope)} file(s) outside scope "
+                f"(ratio {drift_ratio:.0%} ≤ {warn_threshold:.0%})."
+            )
+
+    return ScopeEnforcementResult(
+        action=action,
+        task_id=task_id,
+        declared_patterns=declared_patterns,
+        staged_files=staged_files,
+        in_scope=in_scope,
+        out_of_scope=out_of_scope,
+        drift_ratio=drift_ratio,
+        reason=reason,
+    )
+
+
+def get_active_task_scope(
+    lane_id: str,
+    task_queue_root: Path | None = None,
+) -> tuple[str | None, list[str]]:
+    """Look up the active dispatched task and its declared scope patterns.
+
+    Args:
+        lane_id: Canonical lane identity (e.g., ``"author-a"``).
+        task_queue_root: Override for the task queue root directory.
+
+    Returns:
+        ``(packet_id, scope_declared)`` — the active task's ID and declared
+        scope patterns.  ``(None, [])`` if no active task is found.
+    """
+    from bid_euchre.ops.task_queue import list_packets
+
+    dispatched = list_packets(
+        task_queue_root, status_filter="dispatched", owner_filter=lane_id
+    )
+    if not dispatched:
+        return None, []
+    pkt = dispatched[0]
+    return pkt.packet_id, list(pkt.scope_declared)
+
+
 def emit_scope_drift_event(
     report: ScopeDriftReport,
     lane_id: str,

--- a/tests/unit/test_ops_scope.py
+++ b/tests/unit/test_ops_scope.py
@@ -9,11 +9,14 @@ import pytest
 
 from bid_euchre.ops.scope import (
     ScopeDriftReport,
+    ScopeEnforcementResult,
     _matches_any_pattern,
     check_scope_drift,
     emit_scope_drift_event,
+    enforce_scope_drift,
     format_scope_drift_json,
     format_scope_drift_text,
+    get_active_task_scope,
 )
 
 # --- Pattern matching ---
@@ -355,3 +358,201 @@ class TestFormatScopeDriftJSON:
         assert d["task_id"] == "t1"
         assert d["has_drift"] is False
         json.dumps(d)
+
+
+# --- Enforcement ---
+
+
+class TestScopeEnforcementResult:
+    """Tests for ScopeEnforcementResult dataclass."""
+
+    def test_to_dict_serializable(self) -> None:
+        result = ScopeEnforcementResult(
+            action="block",
+            task_id="t1",
+            declared_patterns=["src/*.py"],
+            staged_files=["docs/a.md"],
+            out_of_scope=["docs/a.md"],
+            drift_ratio=1.0,
+            reason="all out of scope",
+        )
+        d = result.to_dict()
+        assert d["action"] == "block"
+        assert d["drift_ratio"] == 1.0
+        json.dumps(d)
+
+
+class TestEnforceScopeDrift:
+    """Tests for enforce_scope_drift()."""
+
+    def test_no_declared_patterns_skips(self) -> None:
+        result = enforce_scope_drift(
+            staged_files=["src/foo.py"],
+            declared_patterns=[],
+            task_id="t1",
+        )
+        assert result.action == "skip"
+        assert "skipping" in result.reason.lower()
+
+    def test_no_staged_files_allows(self) -> None:
+        result = enforce_scope_drift(
+            staged_files=[],
+            declared_patterns=["src/*.py"],
+            task_id="t1",
+        )
+        assert result.action == "allow"
+
+    def test_all_in_scope_allows(self) -> None:
+        result = enforce_scope_drift(
+            staged_files=["src/ops/scope.py", "src/ops/events.py"],
+            declared_patterns=["src/ops/*.py"],
+            task_id="t1",
+        )
+        assert result.action == "allow"
+        assert result.drift_ratio == 0.0
+        assert result.out_of_scope == []
+
+    def test_warn_threshold(self) -> None:
+        """3 of 5 files out of scope → 60% → warn (> 50%, ≤ 80%)."""
+        result = enforce_scope_drift(
+            staged_files=[
+                "src/a.py",
+                "src/b.py",
+                "docs/c.md",
+                "docs/d.md",
+                "docs/e.md",
+            ],
+            declared_patterns=["src/*.py"],
+            task_id="t1",
+        )
+        assert result.action == "warn"
+        assert result.drift_ratio == pytest.approx(0.6)
+        assert len(result.out_of_scope) == 3
+
+    def test_block_threshold(self) -> None:
+        """9 of 10 files out of scope → 90% → block (> 80%)."""
+        staged = [f"docs/file{i}.md" for i in range(9)] + ["src/a.py"]
+        result = enforce_scope_drift(
+            staged_files=staged,
+            declared_patterns=["src/*.py"],
+            task_id="t1",
+        )
+        assert result.action == "block"
+        assert result.drift_ratio == pytest.approx(0.9)
+
+    def test_exactly_at_warn_threshold_allows(self) -> None:
+        """Exactly 50% → allow (thresholds are strict >)."""
+        result = enforce_scope_drift(
+            staged_files=["src/a.py", "docs/b.md"],
+            declared_patterns=["src/*.py"],
+            task_id="t1",
+        )
+        assert result.action == "allow"
+        assert result.drift_ratio == pytest.approx(0.5)
+
+    def test_exactly_at_block_threshold_warns(self) -> None:
+        """Exactly 80% → warn (threshold is strict >)."""
+        staged = ["src/a.py"] + [f"docs/f{i}.md" for i in range(4)]
+        result = enforce_scope_drift(
+            staged_files=staged,
+            declared_patterns=["src/*.py"],
+            task_id="t1",
+        )
+        # 4/5 = 80% exactly → warn (not block, since > is strict)
+        assert result.action == "warn"
+        assert result.drift_ratio == pytest.approx(0.8)
+
+    def test_custom_thresholds(self) -> None:
+        """Custom thresholds override defaults."""
+        result = enforce_scope_drift(
+            staged_files=["src/a.py", "docs/b.md"],
+            declared_patterns=["src/*.py"],
+            task_id="t1",
+            warn_threshold=0.3,
+            block_threshold=0.4,
+        )
+        # 1/2 = 50% > 40% block threshold
+        assert result.action == "block"
+
+    def test_minor_drift_allows_with_reason(self) -> None:
+        """1 of 5 files out of scope (20%) → allow, but reason mentions it."""
+        staged = ["src/a.py", "src/b.py", "src/c.py", "src/d.py", "docs/e.md"]
+        result = enforce_scope_drift(
+            staged_files=staged,
+            declared_patterns=["src/*.py"],
+            task_id="t1",
+        )
+        assert result.action == "allow"
+        assert "1 file(s) outside scope" in result.reason
+
+    def test_block_narrow_scope_out_of_scope_file(self) -> None:
+        """End-to-end: narrow scope with all staged files outside → block."""
+        result = enforce_scope_drift(
+            staged_files=["tests/unit/test_rules.py", "docs/readme.md"],
+            declared_patterns=["src/bid_euchre/ops/scope.py"],
+            task_id="t-narrow",
+        )
+        assert result.action == "block"
+        assert result.drift_ratio == pytest.approx(1.0)
+        assert len(result.out_of_scope) == 2
+
+
+class TestGetActiveTaskScope:
+    """Tests for get_active_task_scope()."""
+
+    @pytest.fixture()
+    def queue_root(self, tmp_path: Path) -> Path:
+        """Create a task queue directory."""
+        qr = tmp_path / "task_queue"
+        qr.mkdir()
+        return qr
+
+    def _write_packet(
+        self,
+        queue_root: Path,
+        packet_id: str,
+        *,
+        owner: str = "author-a",
+        status: str = "dispatched",
+        scope: list[str] | None = None,
+    ) -> None:
+        """Write a minimal task packet JSON."""
+        pkt = {
+            "packet_id": packet_id,
+            "title": "Test",
+            "description": "test",
+            "owner": owner,
+            "created_by": "orchestrator",
+            "created_at": "2026-01-01T00:00:00Z",
+            "status": status,
+            "scope_declared": scope or [],
+            "validation": [],
+            "priority": "normal",
+        }
+        (queue_root / f"{packet_id}.json").write_text(json.dumps(pkt))
+
+    def test_finds_dispatched_task(self, queue_root: Path) -> None:
+        self._write_packet(
+            queue_root, "pkt-1", scope=["src/ops/*.py", "tests/unit/test_ops_*.py"]
+        )
+        task_id, patterns = get_active_task_scope("author-a", queue_root)
+        assert task_id == "pkt-1"
+        assert patterns == ["src/ops/*.py", "tests/unit/test_ops_*.py"]
+
+    def test_no_dispatched_task(self, queue_root: Path) -> None:
+        self._write_packet(queue_root, "pkt-1", status="pending")
+        task_id, patterns = get_active_task_scope("author-a", queue_root)
+        assert task_id is None
+        assert patterns == []
+
+    def test_wrong_owner(self, queue_root: Path) -> None:
+        self._write_packet(queue_root, "pkt-1", owner="author-b")
+        task_id, patterns = get_active_task_scope("author-a", queue_root)
+        assert task_id is None
+        assert patterns == []
+
+    def test_empty_scope(self, queue_root: Path) -> None:
+        self._write_packet(queue_root, "pkt-1", scope=[])
+        task_id, patterns = get_active_task_scope("author-a", queue_root)
+        assert task_id == "pkt-1"
+        assert patterns == []


### PR DESCRIPTION
## Summary
- Add `enforce_scope_drift()` to `scope.py` — tiered enforcement (skip/allow/warn/block) against staged files using the active task packet's `scope_declared` patterns
- Add `scope-drift-guard.sh` hook that intercepts `git commit` commands and enforces scope at commit time
- Wire guard into `pre-bash-dispatch.sh` as step 3 (before rule-loader)
- Add 14 new tests covering enforcement logic, threshold boundaries, and active task lookup

## Why
SP-4-02 Step 4: Promote scope drift from passive detection to active enforcement. Author lanes working on dispatched tasks now get immediate feedback when staged files drift beyond declared scope — warn at >50% drift ratio, block at >80%.

## How it works
1. `scope-drift-guard.sh` activates only on `git commit` commands
2. Determines the current lane identity (`CLAUDE_AGENT_NAME` or directory name fallback)
3. Looks up the active dispatched task packet via `get_active_task_scope()`
4. If no active task or no scope patterns → skip silently (non-dispatched work unaffected)
5. Gets staged files via `git diff --cached --name-only`
6. Runs `enforce_scope_drift()` which classifies files and applies thresholds:
   - **allow**: drift ratio ≤ 50%
   - **warn**: drift ratio > 50% (injects context, does not block)
   - **block**: drift ratio > 80% (exit 2, blocks the commit)

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_ops_scope.py -v  # 48 tests, all pass
make check-quiet  # Full validation passes
```

## Tests
- `TestScopeEnforcementResult` — serialization
- `TestEnforceScopeDrift` — 10 tests: skip/allow/warn/block thresholds, custom thresholds, boundary values, narrow scope blocking
- `TestGetActiveTaskScope` — 4 tests: find dispatched task, wrong owner, wrong status, empty scope

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: ops/scope-drift-enforcement
```

Closes SP-4-02 Step 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)