### PR TITLE
browser-game: lock v1 serving contract and add hosted-play state foundations

### DIFF
--- a/plans/browser_game/0_foundation/checkpoints.md
+++ b/plans/browser_game/0_foundation/checkpoints.md
@@ -2,7 +2,7 @@
 
 **Governing plan:** `plans/browser_game/governing_plan.md`
 **Phase/Rung:** `0_foundation`
-**Last updated:** 2026-03-15 by Codex
+**Last updated:** 2026-03-23 by Codex
 
 ---
 
@@ -13,23 +13,26 @@
 | Step 0: Draft governing plan and initiative scaffold | COMPLETE | 2026-03-14 | Codex | Governing plan, amendments log, registry, and phase checkpoints created. |
 | Step 1: Lock hosted-play rules contract | COMPLETE | 2026-03-15 | Codex | Authoritative rules contract now lives at `docs/01_core/HOSTED_PLAY_RULES.md`; planning draft left as a pointer only. |
 | Step 2: Add dependencies and package skeleton | COMPLETE | 2026-03-23 | brws-author-a | `hosted` extras in `pyproject.toml`; package skeleton added (`src/bid_euchre/hosted_play/__init__.py`, `web/__init__.py`). |
-| Step 3: Create database schema | PENDING | -- | -- | Create `web/schema.sql` with players, matches, hands, decisions tables. See governing plan §5.2 and SP-2-01. |
-| Step 4: Inventory model artifacts | COMPLETE | 2026-03-15 | Codex | Verified `heuristic` is always available; hybrid and GBT artifacts exist under `data/artifacts/arc_d/r0/` and `data/artifacts/arc_d_v2/r0/`. |
+| Step 3: Create database schema | COMPLETE | 2026-03-23 | Codex | Added `web/schema.sql` with `players`, `matches`, `hands`, and `decisions`. V1 stores `ai_model` on matches and does not add a database `model_registry` table. |
+| Step 4: Inventory model artifacts | COMPLETE | 2026-03-23 | Codex | Verified `heuristic` is always available and `hybrid_olsa` artifacts exist under `data/artifacts/arc_d/r0/`; `gbt_action_value` artifacts exist but are deferred from V1 by amendment BG-1. |
 | Step 5: Promote plan to ACTIVE | COMPLETE | 2026-03-15 | Codex | Governing plan status set to `ACTIVE`; Phase 0 now tracks only execution-prep work. |
 
 ## Active Sub-Plans
 
-| Sub-Plan ID | File | Status | Blocking Step |
-|-------------|------|--------|---------------|
-| SP-0-01 | `sub/2026-03-14_phase0_foundation_lock.md` | in_progress | Step 2 |
+No active sub-plans. `SP-0-01` completed on 2026-03-23.
 
 ## Blockers
 
 - [x] ~~Authoritative hosted-play rules doc~~ → `docs/01_core/HOSTED_PLAY_RULES.md`
 - [x] ~~Package skeleton~~ → `src/bid_euchre/hosted_play/__init__.py`, `web/__init__.py`
-- [ ] Initial database schema not yet locked in files
+- [x] ~~Initial database schema not yet locked in files~~ → `web/schema.sql`
 
 ## Session Log
+
+### 2026-03-23 -- Codex
+- Completed: Recorded amendment BG-1 to narrow V1 serving to `heuristic` plus `hybrid_olsa`, clarified config-backed startup preload, and added `web/schema.sql`.
+- Completed: Step 3 → COMPLETE. Phase 0 foundation lock is now closed.
+- Next: Start Phase 1 Step 0 by reading `SP-1-01` and implementing the hosted-play state dataclasses plus stepwise engine.
 
 ### 2026-03-23 -- brws-author-a
 - Completed: Added package skeleton — `src/bid_euchre/hosted_play/__init__.py` and `web/__init__.py`. Step 2 → COMPLETE.

--- a/plans/browser_game/0_foundation/plan.md
+++ b/plans/browser_game/0_foundation/plan.md
@@ -2,7 +2,7 @@
 
 **Governing plan:** `plans/browser_game/governing_plan.md`
 **Phase:** `0_foundation`
-**Status:** PROPOSED
+**Status:** COMPLETE
 
 ---
 
@@ -16,18 +16,20 @@ re-arguing architecture during code work.
 1. Package layout: `src/bid_euchre/hosted_play/` plus `web/`
 2. Hosting target: Render primary, Postgres in production, SQLite for local dev/tests
 3. Rules extension path: `docs/01_core/HOSTED_PLAY_RULES.md`
-4. Persistence contract: matches, hands, action events, model registry
-5. Model publication policy: `heuristic` always, `hybrid_olsa` and `gbt_action_value` when configured artifacts exist
-6. Testing contract: where tests live and which commands are mandatory
-7. PR cut line: no more than five PRs for MVP
-8. Future extraction boundary: what must stay in `src/bid_euchre/hosted_play/` vs `web/`
-9. Dependency packaging: hosted app deps live in `[project.optional-dependencies].hosted`
+4. Persistence contract: `players`, `matches`, `hands`, `decisions`; no V1 database `model_registry`
+5. Model publication policy: `heuristic` always, `hybrid_olsa` when configured artifact exists; `gbt_action_value` deferred until post-MVP
+6. Model serving contract: approved bidders preload once at FastAPI startup and are cached in `app.state`
+7. Testing contract: where tests live and which commands are mandatory
+8. PR cut line: no more than five PRs for MVP
+9. Future extraction boundary: what must stay in `src/bid_euchre/hosted_play/` vs `web/`
+10. Dependency packaging: hosted app deps live in `[project.optional-dependencies].hosted`
 
 ## Deliverables
 
 - A foundation sub-plan with exact files and validation commands
 - A rules extension doc path locked in the repo plan
 - A recommended initial schema sketch
+- A config-backed approved model roster and startup preload contract
 - An artifact inventory task for actual bidder files
 - An explicit extraction-boundary contract so later repo split remains possible
 - A locked hosting/dependency strategy so Phase 1 does not reopen platform choices
@@ -41,5 +43,5 @@ re-arguing architecture during code work.
 
 _To be filled after execution._
 
-- Status: --
-- Notes: --
+- Status: COMPLETE
+- Notes: Phase 0 closed on 2026-03-23 after recording the V1 model-serving amendment and adding `web/schema.sql` as the initial hosted-play persistence contract.

--- a/plans/browser_game/0_foundation/sub/2026-03-14_phase0_foundation_lock.md
+++ b/plans/browser_game/0_foundation/sub/2026-03-14_phase0_foundation_lock.md
@@ -3,7 +3,7 @@
 **ID:** SP-0-01
 **Date:** 2026-03-14
 **Parent:** `plans/browser_game/governing_plan.md` -- §7.4 Phase 0 Dependencies
-**Status:** in_progress
+**Status:** completed
 **Owner:** Codex
 
 ---
@@ -36,7 +36,9 @@
 ### Step 1: Lock package and persistence boundaries
 - Confirm `src/bid_euchre/hosted_play/` as the reusable domain layer.
 - Confirm `web/` as the FastAPI interface layer.
-- Define the initial storage entities: `matches`, `hands`, `action_events`, `model_registry`.
+- Define the initial storage entities: `players`, `matches`, `hands`, `decisions`.
+- Keep the approved model roster in config/runtime state for V1 instead of a
+  database `model_registry` table.
 - Lock the future extraction boundary so web/ORM concerns do not leak into the hosted-play domain package.
 - Lock persistence mode to SQLite for local/dev and Postgres for deployed environments.
 
@@ -48,7 +50,9 @@
 ### Step 3: Inventory bidder artifacts and launch roster
 - Locate actual artifact files and determine which ones are suitable for hosted play.
 - Record any blockers if artifact generation or publication policy is still missing.
-- Lock the initial launch roster to `heuristic` (always), `hybrid_olsa` (if artifact present), and `gbt_action_value` (if artifact present).
+- Lock the initial launch roster to `heuristic` (always) and `hybrid_olsa`
+  (if artifact present).
+- Defer `gbt_action_value` until post-MVP.
 
 ### Step 4: Prepare PR-1 execution handoff
 - Convert the locked decisions into a concrete implementation sub-plan for PR-1.
@@ -60,18 +64,21 @@
 - `plans/browser_game/0_foundation/plan.md` -- Phase 0 details and exit criteria
 - `plans/browser_game/0_foundation/checkpoints.md` -- phase progress and active sub-plan tracking
 - `plans/browser_game/sub_plan_registry.md` -- register this sub-plan
+- `plans/browser_game/amendments.md` -- BG-1 records the V1 serving contract change
 - `docs/01_core/HOSTED_PLAY_RULES.md` -- NEW: rules extension document for hosted play
 - `pyproject.toml` -- dependency additions for web stack
+- `web/schema.sql` -- NEW: initial hosted-play persistence contract
 - `plans/browser_game/2_backend_api/sub/2026-03-14_fastapi_app.md` -- align AI manager and persistence assumptions with locked Phase 0 decisions
+- `plans/browser_game/2_backend_api/checkpoints.md` -- align backend Step 1/2 notes with the config-backed roster
 - `plans/browser_game/5_deployment_launch/checkpoints.md` -- align hosting target with locked Phase 0 decision
 
 ## Validation
 
-- [ ] Plan audit: referenced files and paths exist or are explicitly marked NEW
-- [ ] Contract check: package layout and PR boundaries align with the governing plan
-- [ ] Extraction check: hosted-play domain responsibilities are distinct from `web/` responsibilities
-- [ ] Artifact inventory: at least one approved bidder artifact path is identified, or a concrete blocker is recorded
-- [ ] Dependency check: `hosted` extras in `pyproject.toml` match the locked Phase 0 decision
+- [x] Plan audit: referenced files and paths exist or are explicitly marked NEW
+- [x] Contract check: package layout and PR boundaries align with the governing plan
+- [x] Extraction check: hosted-play domain responsibilities are distinct from `web/` responsibilities
+- [x] Artifact inventory: at least one approved bidder artifact path is identified, or a concrete blocker is recorded
+- [x] Dependency check: `hosted` extras in `pyproject.toml` match the locked Phase 0 decision
 
 ## Planned Outputs
 
@@ -86,21 +93,28 @@ _Filled during/after execution._
 - Output 1: `docs/01_core/HOSTED_PLAY_RULES.md` -- authoritative hosted-play rules contract created on 2026-03-15
 - Output 2: `plans/browser_game/hosted_play_rules.md` -- reduced to a pointer note so planning and implementation sources do not diverge
 - Output 3: `pyproject.toml` -- `hosted` optional dependency group added on 2026-03-15
+- Output 4: `plans/browser_game/amendments.md` -- BG-1 locked the V1 config-backed startup preload contract on 2026-03-23
+- Output 5: `web/schema.sql` -- initial hosted-play schema added on 2026-03-23
 
 ## Outcome
 
 _Filled after completion._
 
-- Status: --
+- Status: completed
 - PR: --
-- Deviations from plan: --
-- Issues discovered: --
+- Deviations from plan: Replaced the planned V1 `model_registry` table with a
+  config-backed approved roster recorded in amendment BG-1.
+- Issues discovered: None blocking. Artifact inventory showed that GBT assets
+  exist, but they were intentionally deferred from V1 to reduce serving
+  complexity.
 
 ## Handoff
 
 _Filled at session end if work is incomplete._
 
-- Current state: Governing plan revised; Phase 0 still needs execution decisions locked in code/docs.
-- Next action: Add package markers, then lock the initial schema sketch in the backend sub-plan.
-- Blockers: Initial schema is not yet locked in files.
+- Current state: Phase 0 foundation lock is complete. Rules contract, dependency
+  stack, package skeleton, model-serving amendment, and initial schema are all
+  locked in files.
+- Next action: Start Phase 1 by reading `plans/browser_game/1_state_engine/sub/2026-03-14_stepwise_engine.md` and implementing `state.py`, `engine.py`, and `tests/unit/hosted_play/test_engine.py`.
+- Blockers: None in Phase 0.
 - Files with uncommitted changes: --

--- a/plans/browser_game/1_state_engine/checkpoints.md
+++ b/plans/browser_game/1_state_engine/checkpoints.md
@@ -3,7 +3,7 @@
 **Governing plan:** `plans/browser_game/governing_plan.md`
 **Phase/Rung:** `1_state_engine`
 **Sub-plan:** `SP-1-01` → `1_state_engine/sub/2026-03-14_stepwise_engine.md`
-**Last updated:** 2026-03-14
+**Last updated:** 2026-03-23
 
 ---
 
@@ -11,25 +11,30 @@
 
 | Step | Status | Date | Agent/Session | Notes |
 |------|--------|------|---------------|-------|
-| Step 0: Read sub-plan SP-1-01 and verify Phase 0 complete | PENDING | -- | -- | Cannot start until Phase 0 steps 2-4 are done. |
-| Step 1: Implement state dataclasses (`state.py`) | PENDING | -- | -- | MatchState, HandState, TrickState, TrickResult. See SP-1-01 §State Dataclasses. |
+| Step 0: Read sub-plan SP-1-01 and verify Phase 0 complete | COMPLETE | 2026-03-23 | Codex | Phase 0 closed after BG-1 plus `web/schema.sql`; Phase 1 is now runnable. |
+| Step 1: Implement state dataclasses (`state.py`) | COMPLETE | 2026-03-23 | Codex | Added `state.py` with dataclasses plus nested JSON serialization helpers; exported from `bid_euchre.hosted_play` and covered by unit tests. |
 | Step 2: Implement MatchEngine core (`engine.py`) | PENDING | -- | -- | start_match, submit_human_bid, submit_human_card, _advance_ai. See SP-1-01 §Engine Interface. |
 | Step 3: Implement serialization | PENDING | -- | -- | serialize/deserialize round-trip. Cards as [suit, rank]. |
 | Step 4: Implement get_visible_state | PENDING | -- | -- | Returns only seat 0's hand, current trick, scores. Hides other hands. |
 | Step 5: Write unit tests | PENDING | -- | -- | 11 required tests listed in SP-1-01 §Required Tests. |
-| Step 6: Run validation | PENDING | -- | -- | `uv run python -m pytest tests/unit/hosted_play/test_engine.py -v` |
+| Step 6: Run validation | IN_PROGRESS | 2026-03-23 | Codex | Running targeted hosted-play state tests before starting engine work. |
 
 ## Active Sub-Plans
 
 | Sub-Plan ID | File | Status | Blocking Step |
 |-------------|------|--------|---------------|
-| SP-1-01 | `1_state_engine/sub/2026-03-14_stepwise_engine.md` | proposed | Step 0 |
+| SP-1-01 | `1_state_engine/sub/2026-03-14_stepwise_engine.md` | in_progress | Step 2 |
 
 ## Blockers
 
-- [ ] Phase 0 not complete.
+- [x] ~~Phase 0 not complete.~~
 
 ## Session Log
+
+### 2026-03-23 — Codex
+- Completed: Phase 0 prerequisites are now satisfied, so Step 0 is closed.
+- Completed: Added `src/bid_euchre/hosted_play/state.py`, exported the state dataclasses from `__init__.py`, and added initial unit tests under `tests/unit/hosted_play/`.
+- Next: Implement `engine.py`, then fold the serialization helpers into the engine-facing API.
 
 ### 2026-03-14 — Claude
 - Completed: Sub-plan SP-1-01 created with full engine design, state machine transitions, delegation points, edge cases, and 11 required tests.

--- a/plans/browser_game/1_state_engine/sub/2026-03-14_stepwise_engine.md
+++ b/plans/browser_game/1_state_engine/sub/2026-03-14_stepwise_engine.md
@@ -2,7 +2,7 @@
 
 **ID:** SP-1-01
 **Parent:** Phase 1 — State Engine
-**Status:** proposed
+**Status:** in_progress
 **Governing plan:** `plans/browser_game/governing_plan.md`
 **Created:** 2026-03-14
 

--- a/plans/browser_game/2_backend_api/checkpoints.md
+++ b/plans/browser_game/2_backend_api/checkpoints.md
@@ -3,7 +3,7 @@
 **Governing plan:** `plans/browser_game/governing_plan.md`
 **Phase/Rung:** `2_backend_api`
 **Sub-plan:** `SP-2-01` → `2_backend_api/sub/2026-03-14_fastapi_app.md`
-**Last updated:** 2026-03-14
+**Last updated:** 2026-03-23
 
 ---
 
@@ -12,8 +12,8 @@
 | Step | Status | Date | Agent/Session | Notes |
 |------|--------|------|---------------|-------|
 | Step 0: Read sub-plan SP-2-01 and verify Phase 1 complete | PENDING | -- | -- | Cannot start until Phase 1 engine passes all tests. |
-| Step 1: Implement DB models and schema init (`db.py`, `schema.sql`) | PENDING | -- | -- | SQLAlchemy models for players, matches, hands, decisions. |
-| Step 2: Implement AI manager (`ai_manager.py`) | PENDING | -- | -- | Model discovery, loading, roster. See SP-2-01 §AI Manager. |
+| Step 1: Implement DB models and schema init (`db.py`, `schema.sql`) | PENDING | -- | -- | SQLAlchemy models for `players`, `matches`, `hands`, and `decisions`. No V1 database `model_registry` table. |
+| Step 2: Implement AI manager (`ai_manager.py`) | PENDING | -- | -- | Config-backed approved roster plus startup preload/caching. V1 roster is `heuristic` always and `hybrid_olsa` when configured. |
 | Step 3: Implement FastAPI app and routes (`app.py`, `routes.py`) | PENDING | -- | -- | All endpoints from SP-2-01 §Route Handlers. Idempotent submissions. |
 | Step 4: Implement decision logging in routes | PENDING | -- | -- | Log human + AI decisions to `decisions` table on each action. |
 | Step 5: Write integration tests | PENDING | -- | -- | 10 required tests listed in SP-2-01 §Required Tests. |
@@ -30,6 +30,10 @@
 - [ ] Phase 1 not complete.
 
 ## Session Log
+
+### 2026-03-23 — Codex
+- Completed: Aligned backend Step 1/2 notes with amendment BG-1 and the new Phase 0 schema contract.
+- Next: Begin after Phase 1 merges. Use config-backed startup preload for `heuristic` and `hybrid_olsa`; do not add a V1 database `model_registry`.
 
 ### 2026-03-14 — Claude
 - Completed: Sub-plan SP-2-01 created with DB models, AI manager, route handlers, idempotent submission design, and 10 required tests.

--- a/plans/browser_game/2_backend_api/sub/2026-03-14_fastapi_app.md
+++ b/plans/browser_game/2_backend_api/sub/2026-03-14_fastapi_app.md
@@ -12,7 +12,9 @@
 
 Build a FastAPI web application with SQLAlchemy persistence, model loading,
 and route handlers for the full match lifecycle. Actions are idempotent
-and state survives browser refresh.
+and state survives browser refresh. For V1, approved AI models are
+configuration-backed and preloaded at app startup rather than discovered from a
+database registry.
 
 ## Files to Create
 
@@ -20,7 +22,7 @@ and state survives browser refresh.
 |------|-------------|---------|
 | `web/__init__.py` | ~1 | Package marker |
 | `web/app.py` | ~50 | FastAPI app setup, startup/shutdown, middleware |
-| `web/config.py` | ~30 | Environment settings (DB path, model dir, etc.) |
+| `web/config.py` | ~30 | Environment settings (DB URL/path, `HYBRID_OLSA_ARTIFACT`, default model id, etc.) |
 | `web/db.py` | ~120 | SQLAlchemy models + session management |
 | `web/schema.sql` | ~60 | Raw SQL schema for reference/init |
 | `web/ai_manager.py` | ~80 | Strategy loading from model roster |
@@ -45,12 +47,14 @@ class Player(Base):
 class Match(Base):
     __tablename__ = "matches"
     id: int (PK)
+    match_uuid: str (unique)
     player_id: int (FK → players)
     ai_model: str
     status: str  # "active" | "complete" | "abandoned"
     score_human: int (default 0)
     score_ai: int (default 0)
     hands_played: int (default 0)
+    current_hand_number: int (default 0)
     seed: int
     match_state_json: str  # serialized MatchState
     created_at: str
@@ -61,40 +65,48 @@ class Hand(Base):
     id: int (PK)
     match_id: int (FK → matches)
     hand_number: int
-    # ... per governing plan schema
+    deal_id: int
+    dealer_seat: int
+    status: str  # "in_progress" | "redeal" | "complete"
+    hand_state_json: str
+    # ... outcome fields per governing plan schema
 
 class Decision(Base):
     __tablename__ = "decisions"
     id: int (PK)
+    match_id: int (FK → matches)
     hand_id: int (FK → hands)
     turn_number: int
     seat: int
     phase: str  # "bid" | "play"
-    decision_source: str  # "human" | model name
+    actor_type: str  # "human" | "ai"
+    decision_source: str  # "human" | model id
     game_state_json: str
     legal_actions_json: str
     chosen_action_json: str
     decision_time_ms: int (nullable)
-    timestamp: str
+    created_at: str
 ```
 
 **Note:** V1 uses SQLite locally and Postgres in deployed environments.
 SQLAlchemy abstracts the difference. The `match_state_json` column stores the
 full serialized `MatchState` for resume — this avoids complex ORM mapping of
-nested game state.
+nested game state. The approved model roster is config-backed in V1, so there
+is no database `model_registry` table in the initial schema.
 
 ## AI Manager (`ai_manager.py`)
 
 ```python
 class AIManager:
-    """Loads bidding policies and play strategies from model roster."""
+    """Preloads approved bidding policies and play strategies at startup."""
 
-    def __init__(self, models_dir: Optional[Path] = None):
+    def __init__(self, config: HostedPlayConfig):
         self.available_models: dict[str, ModelInfo] = {}
-        self._discover_models(models_dir)
+        self.default_model_id = "heuristic"
+        self._load_models(config)
 
-    def _discover_models(self, models_dir):
-        """Register heuristic always; register hybrid_olsa and gbt_action_value when configured artifacts exist."""
+    def _load_models(self, config):
+        """Register and preload the approved V1 roster once per app process."""
 
     def get_model_info(self, model_id: str) -> ModelInfo:
         """Return display name, description, and instantiated policy/strategy."""
@@ -114,10 +126,12 @@ class ModelInfo:
 Model discovery at startup:
 1. `heuristic` — always available (`HeuristicSuitBidder()`)
 2. `hybrid_olsa` — available if `HYBRID_OLSA_ARTIFACT` or equivalent configured path exists
-3. `gbt_action_value` — available if `GBT_ACTION_VALUE_ARTIFACT` or equivalent configured path exists
+3. `gbt_action_value` — deferred until post-MVP
 
 Model discovery is driven by environment configuration rooted at a centralized
-models directory/path config, not by hardcoded paths in routes or templates.
+path config, not by hardcoded paths in routes or templates. Routes read cached
+model instances from `app.state.ai_manager`; they do not load artifacts on
+demand.
 
 ## Route Handlers (`routes.py`)
 
@@ -142,12 +156,13 @@ Every game-action POST (`/bid`, `/play-card`):
    return current visible state without modifying anything
 4. Call `MatchEngine.submit_human_bid()` or `submit_human_card()`
    - Engine auto-advances all AI turns
-5. Log the human decision to `decisions` table
-6. Log each AI decision to `decisions` table
-7. Serialize updated `MatchState` back to `match.match_state_json`
-8. Update `match` row (score, hands_played, status)
-9. If hand completed, insert `hands` row with outcome
-10. Return HTMX partial with updated game board
+5. Ensure the current `hands` row exists for the active hand
+6. Log the human decision to `decisions` table
+7. Log each AI decision to `decisions` table
+8. Serialize updated `MatchState` back to `match.match_state_json`
+9. Update `match` row (score, hands_played, status)
+10. If the hand completed or redealt, update the current `hands` row with outcome fields
+11. Return HTMX partial with updated game board
 
 ### Idempotent Submission
 
@@ -162,8 +177,9 @@ browser refresh and double-click safe.
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # 1. Initialize database (create tables if needed)
-    # 2. Load AI models via AIManager
+    # 2. Load approved V1 AI models once via AIManager
     # 3. Store AIManager in app.state
+    # 4. Routes only look up cached model ids; no per-request artifact loading
     yield
     # Cleanup
 

--- a/plans/browser_game/amendments.md
+++ b/plans/browser_game/amendments.md
@@ -1,11 +1,40 @@
 # Browser Game Hosting and Human Data Capture — Amendments
 
 **Governing plan:** `plans/browser_game/governing_plan.md`
-**Last updated:** 2026-03-14
+**Last updated:** 2026-03-23 (V1 model-serving contract)
 
 ---
 
-No amendments yet.
+## BG-1 — V1 model serving narrowed to config-backed startup preload (2026-03-23)
 
-Use this file once `plans/browser_game/governing_plan.md` moves to `ACTIVE` and
-phase-boundary changes are required.
+**PR:** pending follow-up
+
+**What changed:**
+1. **V1 launch roster narrowed** — `heuristic` remains always available and
+   `hybrid_olsa` is the only artifact-backed bidder in V1 when its configured
+   artifact path exists. `gbt_action_value` is explicitly deferred until
+   post-MVP.
+2. **"Model registry" clarified** — For V1, the governing plan's roster
+   language is satisfied by a config-backed approved model roster in
+   `web/config.py` and `web/ai_manager.py`, not by a mutable database
+   `model_registry` table.
+3. **Startup preload required** — Approved bidder instances are loaded once
+   during FastAPI startup and stored in `app.state`. Route handlers must only
+   look up a cached model by `ai_model` id; they must not load artifacts per
+   request, per turn, or per seat.
+4. **Match persistence simplified** — Hosted-play persistence stores the
+   selected `ai_model` id on each match. Artifact paths and bidder instances
+   stay in config/runtime state, not in persisted match rows.
+5. **Default launch path clarified** — `hybrid_olsa` is the default
+   artifact-backed launch option, with `heuristic` as the guaranteed fallback
+   when no approved artifact path is configured.
+
+**Rationale:**
+Local measurements taken on 2026-03-23 showed that `HybridOLSaBidder` is
+effectively free to load after import and runs at roughly `0.3 ms` per bid on
+the development machine, while `GBTActionValueBidder` adds materially more
+cold-start and runtime complexity. For the V1 browser game, the main product
+risk is startup/restart operational overhead, not steady-state bid latency.
+Narrowing the launch roster to `heuristic` plus `hybrid_olsa` keeps the
+hosted product simpler while preserving a clean upgrade path for more complex
+models later.

--- a/plans/browser_game/sub_plan_registry.md
+++ b/plans/browser_game/sub_plan_registry.md
@@ -1,7 +1,7 @@
 # Sub-Plan Registry — Browser Game Hosting and Human Data Capture
 
 **Governing plan:** `plans/browser_game/governing_plan.md`
-**Last updated:** 2026-03-15
+**Last updated:** 2026-03-23
 
 ---
 
@@ -9,8 +9,8 @@
 
 | ID | Title | Parent Section | Status | Owner | File | Created | Completed |
 |----|-------|----------------|--------|-------|------|---------|-----------|
-| SP-0-01 | Phase 0 Foundation Lock | §7.4 Phase 0 Dependencies | in_progress | Codex | `0_foundation/sub/2026-03-14_phase0_foundation_lock.md` | 2026-03-14 | -- |
-| SP-1-01 | Stepwise Match Engine | Phase 1 — State Engine | proposed | -- | `1_state_engine/sub/2026-03-14_stepwise_engine.md` | 2026-03-14 | -- |
+| SP-0-01 | Phase 0 Foundation Lock | §7.4 Phase 0 Dependencies | completed | Codex | `0_foundation/sub/2026-03-14_phase0_foundation_lock.md` | 2026-03-14 | 2026-03-23 |
+| SP-1-01 | Stepwise Match Engine | Phase 1 — State Engine | in_progress | Codex | `1_state_engine/sub/2026-03-14_stepwise_engine.md` | 2026-03-14 | -- |
 | SP-2-01 | FastAPI App & Persistence | Phase 2 — Backend API | proposed | -- | `2_backend_api/sub/2026-03-14_fastapi_app.md` | 2026-03-14 | -- |
 | SP-3-01 | HTMX Game UI | Phase 3 — Frontend Product | proposed | -- | `3_frontend_product/sub/2026-03-14_htmx_game_ui.md` | 2026-03-14 | -- |
 | SP-4-01 | Export & Replay Validation | Phase 4 — Data Pipeline | proposed | -- | `4_data_pipeline/sub/2026-03-14_export_replay.md` | 2026-03-14 | -- |
@@ -19,10 +19,10 @@
 
 | Status | Count |
 |--------|-------|
-| proposed | 4 |
+| proposed | 3 |
 | in_progress | 1 |
 | blocked | 0 |
-| completed | 0 |
+| completed | 1 |
 | abandoned | 0 |
 | superseded | 0 |
 

--- a/src/bid_euchre/hosted_play/__init__.py
+++ b/src/bid_euchre/hosted_play/__init__.py
@@ -7,3 +7,12 @@ and strategy interfaces from ``bid_euchre.core``, ``bid_euchre.strategy``,
 This package is web-framework-free.  The ``web/`` application layer imports
 from here; this package must never import from ``web/``.
 """
+
+from .state import HandState, MatchState, TrickResult, TrickState
+
+__all__ = [
+    "HandState",
+    "MatchState",
+    "TrickResult",
+    "TrickState",
+]

--- a/src/bid_euchre/hosted_play/state.py
+++ b/src/bid_euchre/hosted_play/state.py
@@ -1,0 +1,214 @@
+"""Hosted-play state dataclasses and JSON serialization helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from bid_euchre.core.cards import Card
+
+
+def _card_to_data(card: Card) -> list[str]:
+    return [card.suit, card.rank]
+
+
+def _card_from_data(data: list[str] | tuple[str, str]) -> Card:
+    if len(data) != 2:
+        raise ValueError(f"Expected card payload of length 2, got {data!r}")
+    suit, rank = data
+    return Card(suit=suit, rank=rank)
+
+
+def _plays_to_data(plays: list[tuple[int, Card]]) -> list[list[Any]]:
+    return [[seat, _card_to_data(card)] for seat, card in plays]
+
+
+def _plays_from_data(data: list[list[Any]]) -> list[tuple[int, Card]]:
+    plays: list[tuple[int, Card]] = []
+    for item in data:
+        if len(item) != 2:
+            raise ValueError(f"Expected play payload of length 2, got {item!r}")
+        seat, card = item
+        plays.append((int(seat), _card_from_data(card)))
+    return plays
+
+
+@dataclass(eq=True)
+class TrickState:
+    """Mutable state for the in-progress trick."""
+
+    leader: int
+    plays: list[tuple[int, Card]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "leader": self.leader,
+            "plays": _plays_to_data(self.plays),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TrickState":
+        return cls(
+            leader=int(data["leader"]),
+            plays=_plays_from_data(data.get("plays", [])),
+        )
+
+
+@dataclass(eq=True)
+class TrickResult:
+    """Completed trick record used for replay and resume."""
+
+    leader: int
+    plays: list[tuple[int, Card]]
+    winner: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "leader": self.leader,
+            "plays": _plays_to_data(self.plays),
+            "winner": self.winner,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TrickResult":
+        return cls(
+            leader=int(data["leader"]),
+            plays=_plays_from_data(data.get("plays", [])),
+            winner=int(data["winner"]),
+        )
+
+
+@dataclass(eq=True)
+class HandState:
+    """Persisted state for a single hosted-play hand."""
+
+    phase: str
+    hands: list[list[Card]]
+    dealer_seat: int
+    deal_id: int
+    auction: list[dict[str, Any]] = field(default_factory=list)
+    current_high_bid: int = 0
+    bidder_seat: int | None = None
+    winning_bid: int | None = None
+    contract_type: str | None = None
+    trump: str | None = None
+    current_trick: TrickState | None = None
+    completed_tricks: list[TrickResult] = field(default_factory=list)
+    tricks_team0: int = 0
+    tricks_team1: int = 0
+    points_team0: int = 0
+    points_team1: int = 0
+    current_seat: int = 0
+    turn_number: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "phase": self.phase,
+            "hands": [[_card_to_data(card) for card in hand] for hand in self.hands],
+            "dealer_seat": self.dealer_seat,
+            "deal_id": self.deal_id,
+            "auction": self.auction,
+            "current_high_bid": self.current_high_bid,
+            "bidder_seat": self.bidder_seat,
+            "winning_bid": self.winning_bid,
+            "contract_type": self.contract_type,
+            "trump": self.trump,
+            "current_trick": (
+                None if self.current_trick is None else self.current_trick.to_dict()
+            ),
+            "completed_tricks": [trick.to_dict() for trick in self.completed_tricks],
+            "tricks_team0": self.tricks_team0,
+            "tricks_team1": self.tricks_team1,
+            "points_team0": self.points_team0,
+            "points_team1": self.points_team1,
+            "current_seat": self.current_seat,
+            "turn_number": self.turn_number,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "HandState":
+        return cls(
+            phase=data["phase"],
+            hands=[
+                [_card_from_data(card) for card in hand]
+                for hand in data.get("hands", [])
+            ],
+            dealer_seat=int(data["dealer_seat"]),
+            deal_id=int(data["deal_id"]),
+            auction=list(data.get("auction", [])),
+            current_high_bid=int(data.get("current_high_bid", 0)),
+            bidder_seat=(
+                None if data.get("bidder_seat") is None else int(data["bidder_seat"])
+            ),
+            winning_bid=(
+                None if data.get("winning_bid") is None else int(data["winning_bid"])
+            ),
+            contract_type=data.get("contract_type"),
+            trump=data.get("trump"),
+            current_trick=(
+                None
+                if data.get("current_trick") is None
+                else TrickState.from_dict(data["current_trick"])
+            ),
+            completed_tricks=[
+                TrickResult.from_dict(trick)
+                for trick in data.get("completed_tricks", [])
+            ],
+            tricks_team0=int(data.get("tricks_team0", 0)),
+            tricks_team1=int(data.get("tricks_team1", 0)),
+            points_team0=int(data.get("points_team0", 0)),
+            points_team1=int(data.get("points_team1", 0)),
+            current_seat=int(data.get("current_seat", 0)),
+            turn_number=int(data.get("turn_number", 0)),
+        )
+
+
+@dataclass(eq=True)
+class MatchState:
+    """Persisted state for the full hosted-play match."""
+
+    seed: int
+    ai_model: str
+    score_human: int = 0
+    score_ai: int = 0
+    hands_played: int = 0
+    current_hand: HandState | None = None
+    status: str = "active"
+    winner: str | None = None
+    dealer_seat: int = 0
+    deal_id: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "seed": self.seed,
+            "ai_model": self.ai_model,
+            "score_human": self.score_human,
+            "score_ai": self.score_ai,
+            "hands_played": self.hands_played,
+            "current_hand": (
+                None if self.current_hand is None else self.current_hand.to_dict()
+            ),
+            "status": self.status,
+            "winner": self.winner,
+            "dealer_seat": self.dealer_seat,
+            "deal_id": self.deal_id,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "MatchState":
+        return cls(
+            seed=int(data["seed"]),
+            ai_model=data["ai_model"],
+            score_human=int(data.get("score_human", 0)),
+            score_ai=int(data.get("score_ai", 0)),
+            hands_played=int(data.get("hands_played", 0)),
+            current_hand=(
+                None
+                if data.get("current_hand") is None
+                else HandState.from_dict(data["current_hand"])
+            ),
+            status=data.get("status", "active"),
+            winner=data.get("winner"),
+            dealer_seat=int(data.get("dealer_seat", 0)),
+            deal_id=int(data.get("deal_id", 0)),
+        )

--- a/tests/unit/hosted_play/__init__.py
+++ b/tests/unit/hosted_play/__init__.py
@@ -1,0 +1,1 @@
+"""Hosted-play unit tests."""

--- a/tests/unit/hosted_play/test_state.py
+++ b/tests/unit/hosted_play/test_state.py
@@ -1,0 +1,80 @@
+from bid_euchre.core.cards import Card
+from bid_euchre.hosted_play import HandState, MatchState, TrickResult, TrickState
+
+
+def test_match_state_round_trip_with_nested_hand_state() -> None:
+    state = MatchState(
+        seed=42,
+        ai_model="hybrid_olsa",
+        score_human=12,
+        score_ai=-3,
+        hands_played=4,
+        status="active",
+        dealer_seat=2,
+        deal_id=9,
+        current_hand=HandState(
+            phase="trick_play",
+            hands=[
+                [Card("S", "A"), Card("H", "K")],
+                [Card("C", "Q")],
+                [Card("D", "J")],
+                [Card("S", "T")],
+            ],
+            dealer_seat=2,
+            deal_id=9,
+            auction=[
+                {"seat": 3, "n": 0, "contract": None},
+                {"seat": 0, "n": 5, "contract": "S"},
+            ],
+            current_high_bid=5,
+            bidder_seat=0,
+            winning_bid=5,
+            contract_type="suit",
+            trump="S",
+            current_trick=TrickState(
+                leader=0,
+                plays=[(0, Card("S", "A")), (1, Card("C", "Q"))],
+            ),
+            completed_tricks=[
+                TrickResult(
+                    leader=3,
+                    plays=[
+                        (3, Card("H", "A")),
+                        (0, Card("H", "K")),
+                        (1, Card("H", "Q")),
+                        (2, Card("H", "J")),
+                    ],
+                    winner=3,
+                )
+            ],
+            tricks_team0=1,
+            tricks_team1=0,
+            points_team0=0,
+            points_team1=0,
+            current_seat=2,
+            turn_number=6,
+        ),
+    )
+
+    restored = MatchState.from_dict(state.to_dict())
+
+    assert restored == state
+
+
+def test_match_state_round_trip_without_current_hand() -> None:
+    state = MatchState(
+        seed=7,
+        ai_model="heuristic",
+        score_human=52,
+        score_ai=18,
+        hands_played=11,
+        current_hand=None,
+        status="complete",
+        winner="human",
+        dealer_seat=1,
+        deal_id=11,
+    )
+
+    restored = MatchState.from_dict(state.to_dict())
+
+    assert restored == state

--- a/web/schema.sql
+++ b/web/schema.sql
@@ -1,0 +1,90 @@
+-- Hosted-play reference schema for the browser game V1.
+--
+-- This schema is SQLite-first for local/dev bootstrap. `web/db.py` will remain
+-- the portable SQLAlchemy source for SQLite and Postgres.
+--
+-- V1 does not create a database `model_registry` table. The approved AI roster
+-- is config-backed and preloaded at app startup.
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS players (
+    id INTEGER PRIMARY KEY,
+    link_uuid TEXT NOT NULL UNIQUE,
+    nickname TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS matches (
+    id INTEGER PRIMARY KEY,
+    match_uuid TEXT NOT NULL UNIQUE,
+    player_id INTEGER NOT NULL REFERENCES players(id) ON DELETE CASCADE,
+    ai_model TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('active', 'complete', 'abandoned')),
+    seed INTEGER NOT NULL,
+    score_human INTEGER NOT NULL DEFAULT 0,
+    score_ai INTEGER NOT NULL DEFAULT 0,
+    hands_played INTEGER NOT NULL DEFAULT 0,
+    current_hand_number INTEGER NOT NULL DEFAULT 0,
+    match_state_json TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS hands (
+    id INTEGER PRIMARY KEY,
+    match_id INTEGER NOT NULL REFERENCES matches(id) ON DELETE CASCADE,
+    hand_number INTEGER NOT NULL,
+    deal_id INTEGER NOT NULL,
+    dealer_seat INTEGER NOT NULL CHECK (dealer_seat BETWEEN 0 AND 3),
+    status TEXT NOT NULL CHECK (status IN ('in_progress', 'redeal', 'complete')),
+    winning_bid_n INTEGER,
+    winning_contract TEXT CHECK (
+        winning_contract IS NULL
+        OR winning_contract IN ('C', 'D', 'H', 'S', 'HIGH', 'LOW')
+    ),
+    bidder_seat INTEGER CHECK (bidder_seat IS NULL OR bidder_seat BETWEEN 0 AND 3),
+    contract_type TEXT CHECK (
+        contract_type IS NULL OR contract_type IN ('suit', 'high', 'low')
+    ),
+    trump_suit TEXT CHECK (
+        trump_suit IS NULL OR trump_suit IN ('C', 'D', 'H', 'S')
+    ),
+    tricks_team0 INTEGER NOT NULL DEFAULT 0,
+    tricks_team1 INTEGER NOT NULL DEFAULT 0,
+    points_team0 INTEGER NOT NULL DEFAULT 0,
+    points_team1 INTEGER NOT NULL DEFAULT 0,
+    hand_state_json TEXT NOT NULL,
+    started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at TEXT,
+    UNIQUE (match_id, hand_number)
+);
+
+CREATE TABLE IF NOT EXISTS decisions (
+    id INTEGER PRIMARY KEY,
+    match_id INTEGER NOT NULL REFERENCES matches(id) ON DELETE CASCADE,
+    hand_id INTEGER NOT NULL REFERENCES hands(id) ON DELETE CASCADE,
+    turn_number INTEGER NOT NULL CHECK (turn_number >= 0),
+    seat INTEGER NOT NULL CHECK (seat BETWEEN 0 AND 3),
+    phase TEXT NOT NULL CHECK (phase IN ('bid', 'play')),
+    actor_type TEXT NOT NULL CHECK (actor_type IN ('human', 'ai')),
+    decision_source TEXT NOT NULL,
+    legal_actions_json TEXT NOT NULL,
+    chosen_action_json TEXT NOT NULL,
+    game_state_json TEXT NOT NULL,
+    decision_time_ms INTEGER CHECK (
+        decision_time_ms IS NULL OR decision_time_ms >= 0
+    ),
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (hand_id, turn_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_matches_player_status
+    ON matches(player_id, status, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_hands_match_number
+    ON hands(match_id, hand_number);
+
+CREATE INDEX IF NOT EXISTS idx_decisions_match_turn
+    ON decisions(match_id, hand_id, turn_number);


### PR DESCRIPTION
## Plan
`plans/browser_game/governing_plan.md` — Phase 0 closure + Phase 1 Step 1

## Summary
- Close Phase 0 foundation: database schema (`web/schema.sql`), model serving contract (amendment BG-1), and Step 3/4 completion
- Add hosted-play state dataclasses (`HandState`, `MatchState`, `TrickState`, `TrickResult`) with JSON round-trip serialization
- Export state types from `hosted_play` package `__init__.py`
- Add unit tests for `MatchState` round-trip with and without nested hand state
- Update Phase 1/2 sub-plans and checkpoints to reflect Phase 0 closure

## Why
Phase 0 was complete in intent but not committed — the database schema, amendment BG-1, and Phase 1 state module existed only as saved artifacts. This PR lands all of that foundation work so Phase 1 (stepwise engine) can proceed from a clean committed baseline.

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/hosted_play/ -v` — 2 passed
- `make check-quiet` — all checks passed

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/ -v`
- [x] `make check-quiet`

## Expected impact
- Metrics impact: None (new module, no existing behavior changed)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git worktree list` (trimmed):
```
Bid-Euchre-steward-brws-author-a  8fffbb65 [browser-game/phase1-state-foundations]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)