### PR TITLE
ops: add token economy usage data importer (SP-4-03 Step 1)

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -51,6 +51,7 @@ Usage:
     uv run python scripts/internal/ops.py workers retire LANE_ID [--json]
     uv run python scripts/internal/ops.py workers dispatch PACKET_ID LANE_ID [--json]
     uv run python scripts/internal/ops.py workers maintain [--dry-run] [--json]
+    uv run python scripts/internal/ops.py usage import [--usage-dir DIR] [--output-dir DIR] [--json]
 """
 
 from __future__ import annotations
@@ -2406,6 +2407,39 @@ def cmd_workers(args: argparse.Namespace) -> int:
         return 0
 
 
+def cmd_usage(args: argparse.Namespace) -> int:
+    """Token economy: import and query usage data."""
+    action = getattr(args, "usage_action", None)
+
+    if action == "import":
+        from bid_euchre.ops.token_economy import import_usage_data
+
+        result = import_usage_data(
+            usage_dir=getattr(args, "usage_dir", None),
+            output_dir=getattr(args, "output_dir", None),
+        )
+
+        if args.json:
+            from dataclasses import asdict
+
+            print(json.dumps(asdict(result), indent=2, default=str))
+        else:
+            print("Import complete:")
+            print(f"  Sessions imported: {result.sessions_imported}")
+            print(f"  Sessions skipped:  {result.sessions_skipped}")
+            print(f"  Sessions failed:   {result.sessions_failed}")
+            print(f"  Total sessions:    {result.total_sessions}")
+            print(f"  Output dir:        {result.output_dir}")
+        return 0
+
+    else:
+        print(
+            "Usage: ops.py usage {import}",
+            file=sys.stderr,
+        )
+        return 1
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the argument parser."""
     parser = argparse.ArgumentParser(
@@ -3102,6 +3136,28 @@ def build_parser() -> argparse.ArgumentParser:
         help="Only propose actions without executing them",
     )
 
+    # usage (Token economy: import and query usage data)
+    usage_parser = subparsers.add_parser(
+        "usage", help="Token economy: import and query usage data"
+    )
+    usage_sub = usage_parser.add_subparsers(dest="usage_action")
+
+    usage_import_parser = usage_sub.add_parser(
+        "import", help="Import native Claude usage data into repo runtime"
+    )
+    usage_import_parser.add_argument(
+        "--usage-dir",
+        type=Path,
+        default=None,
+        help="Path to ~/.claude/usage-data/ (default: auto-detect)",
+    )
+    usage_import_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Output directory (default: .claude/runtime/token_economy/)",
+    )
+
     return parser
 
 
@@ -3160,6 +3216,7 @@ def main(argv: list[str] | None = None) -> int:
         "monitor": cmd_monitor,
         "review-check": cmd_review_check,
         "workers": cmd_workers,
+        "usage": cmd_usage,
     }
 
     handler = commands.get(args.command)

--- a/src/bid_euchre/ops/__init__.py
+++ b/src/bid_euchre/ops/__init__.py
@@ -25,6 +25,7 @@ Modules:
     dashboard   -- Dashboard-first supervision surface (Platform-4)
     supervisor  -- Supervisor routines and delta summaries (Platform-6)
     worker_pool -- Worker pool lifecycle management (Platform-7)
+    token_economy -- Token economy observability (usage data import/rollups)
 """
 
 # Shared constant: GitHub status/check context names that represent

--- a/src/bid_euchre/ops/token_economy.py
+++ b/src/bid_euchre/ops/token_economy.py
@@ -1,0 +1,496 @@
+"""Token economy observability — import native Claude usage data.
+
+Reads from ``~/.claude/usage-data/session-meta/*.json`` and
+``~/.claude/usage-data/facets/*.json`` and normalizes them into a
+repo-owned store under ``.claude/runtime/token_economy/``.
+
+Public API
+----------
+import_usage_data
+    Main entry point. Idempotent — re-running does not duplicate sessions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Schema version — bump when normalized record format changes
+# ---------------------------------------------------------------------------
+SCHEMA_VERSION = 1
+
+# Default source directory
+DEFAULT_USAGE_DIR = Path.home() / ".claude" / "usage-data"
+
+# Expected fields in session-meta JSON (required subset)
+_REQUIRED_SESSION_FIELDS = frozenset({"session_id"})
+
+# Optional session-meta fields we extract (missing → None/default)
+_OPTIONAL_SESSION_FIELDS = frozenset(
+    {
+        "project_path",
+        "start_time",
+        "duration_minutes",
+        "user_message_count",
+        "assistant_message_count",
+        "input_tokens",
+        "output_tokens",
+        "lines_added",
+        "lines_removed",
+        "files_modified",
+        "git_commits",
+        "git_pushes",
+        "tool_counts",
+        "tool_errors",
+        "tool_error_categories",
+        "languages",
+        "user_interruptions",
+        "uses_task_agent",
+        "uses_mcp",
+        "uses_web_search",
+        "uses_web_fetch",
+        "first_prompt",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Normalized session record
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SessionRecord:
+    """Normalized usage record for one Claude session."""
+
+    session_id: str
+    schema_version: int = SCHEMA_VERSION
+
+    # Source tracking for idempotent import
+    source_path: str = ""
+    source_hash: str = ""
+    import_timestamp: str = ""
+
+    # Core metrics from session-meta
+    project_path: str | None = None
+    start_time: str | None = None
+    duration_minutes: int | None = None
+    user_message_count: int | None = None
+    assistant_message_count: int | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    lines_added: int | None = None
+    lines_removed: int | None = None
+    files_modified: int | None = None
+    git_commits: int | None = None
+    git_pushes: int | None = None
+    tool_counts: dict[str, int] = field(default_factory=dict)
+    tool_errors: int | None = None
+    tool_error_categories: dict[str, int] = field(default_factory=dict)
+    languages: dict[str, int] = field(default_factory=dict)
+    user_interruptions: int | None = None
+    uses_task_agent: bool | None = None
+    uses_mcp: bool | None = None
+    uses_web_search: bool | None = None
+    uses_web_fetch: bool | None = None
+    first_prompt: str | None = None
+
+    # Facet data (from facets/*.json)
+    underlying_goal: str | None = None
+    outcome: str | None = None
+    session_type: str | None = None
+    claude_helpfulness: str | None = None
+    brief_summary: str | None = None
+    goal_categories: dict[str, int] = field(default_factory=dict)
+    friction_counts: dict[str, int] = field(default_factory=dict)
+    friction_detail: str | None = None
+    primary_success: str | None = None
+    user_satisfaction_counts: dict[str, int] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class SchemaValidationError(ValueError):
+    """Raised when a source file fails schema validation."""
+
+
+def validate_session_meta(data: dict[str, Any], path: Path) -> None:
+    """Validate a session-meta JSON dict has the required fields.
+
+    Raises :class:`SchemaValidationError` if validation fails.
+    """
+    if not isinstance(data, dict):
+        raise SchemaValidationError(
+            f"Expected dict, got {type(data).__name__} in {path}"
+        )
+
+    missing = _REQUIRED_SESSION_FIELDS - data.keys()
+    if missing:
+        raise SchemaValidationError(f"Missing required field(s) {missing} in {path}")
+
+    sid = data["session_id"]
+    if not isinstance(sid, str) or not sid.strip():
+        raise SchemaValidationError(f"session_id must be a non-empty string in {path}")
+
+
+def validate_facet(data: dict[str, Any], path: Path) -> None:
+    """Validate a facets JSON dict.
+
+    Raises :class:`SchemaValidationError` if validation fails.
+    """
+    if not isinstance(data, dict):
+        raise SchemaValidationError(
+            f"Expected dict, got {type(data).__name__} in {path}"
+        )
+    # Facet files must have a session_id to join with session-meta
+    sid = data.get("session_id")
+    if sid is not None and (not isinstance(sid, str) or not sid.strip()):
+        raise SchemaValidationError(
+            f"session_id must be a non-empty string if present in {path}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Hashing
+# ---------------------------------------------------------------------------
+
+
+def _file_hash(path: Path) -> str:
+    """Return the SHA-256 hex digest of a file's contents."""
+    h = hashlib.sha256()
+    h.update(path.read_bytes())
+    return h.hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    """Load and return a JSON dict, or None if the file is invalid."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        logger.warning("Skipping malformed JSON: %s (%s)", path, exc)
+        return None
+    if not isinstance(data, dict):
+        logger.warning("Skipping non-dict JSON: %s", path)
+        return None
+    return data
+
+
+def _load_session_meta(path: Path) -> dict[str, Any] | None:
+    """Load and validate a session-meta JSON file."""
+    data = _load_json(path)
+    if data is None:
+        return None
+    try:
+        validate_session_meta(data, path)
+    except SchemaValidationError as exc:
+        logger.warning("Validation failed: %s", exc)
+        return None
+    return data
+
+
+def _load_facet(path: Path) -> dict[str, Any] | None:
+    """Load and validate a facets JSON file."""
+    data = _load_json(path)
+    if data is None:
+        return None
+    try:
+        validate_facet(data, path)
+    except SchemaValidationError as exc:
+        logger.warning("Validation failed: %s", exc)
+        return None
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Record building
+# ---------------------------------------------------------------------------
+
+_FACET_FIELDS = {
+    "underlying_goal",
+    "outcome",
+    "session_type",
+    "claude_helpfulness",
+    "brief_summary",
+    "goal_categories",
+    "friction_counts",
+    "friction_detail",
+    "primary_success",
+    "user_satisfaction_counts",
+}
+
+
+def _build_record(
+    session_data: dict[str, Any],
+    facet_data: dict[str, Any] | None,
+    source_path: Path,
+    source_hash: str,
+    now: str,
+) -> SessionRecord:
+    """Build a normalized SessionRecord from raw data."""
+    rec = SessionRecord(
+        session_id=session_data["session_id"],
+        source_path=str(source_path),
+        source_hash=source_hash,
+        import_timestamp=now,
+    )
+
+    # Copy optional session-meta fields
+    for fld in _OPTIONAL_SESSION_FIELDS:
+        val = session_data.get(fld)
+        if val is not None:
+            setattr(rec, fld, val)
+
+    # Merge facet data
+    if facet_data is not None:
+        for fld in _FACET_FIELDS:
+            val = facet_data.get(fld)
+            if val is not None:
+                setattr(rec, fld, val)
+
+    return rec
+
+
+# ---------------------------------------------------------------------------
+# Idempotent store
+# ---------------------------------------------------------------------------
+
+
+def _load_existing_ids(output_dir: Path) -> set[str]:
+    """Load the set of session IDs already in session_usage.jsonl."""
+    usage_file = output_dir / "session_usage.jsonl"
+    ids: set[str] = set()
+    if not usage_file.exists():
+        return ids
+    for line in usage_file.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+            sid = rec.get("session_id")
+            if sid:
+                ids.add(sid)
+        except json.JSONDecodeError:
+            continue
+    return ids
+
+
+def _append_records(records: list[SessionRecord], output_dir: Path) -> None:
+    """Append session records to session_usage.jsonl."""
+    usage_file = output_dir / "session_usage.jsonl"
+    with usage_file.open("a", encoding="utf-8") as f:
+        for rec in records:
+            f.write(json.dumps(asdict(rec), default=str) + "\n")
+
+
+def _write_rollups(output_dir: Path) -> dict[str, Any]:
+    """Compute and write session_rollups.json from session_usage.jsonl."""
+    usage_file = output_dir / "session_usage.jsonl"
+    records: list[dict[str, Any]] = []
+    if usage_file.exists():
+        for line in usage_file.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+    total_input = 0
+    total_output = 0
+    total_duration = 0
+    total_lines_added = 0
+    total_lines_removed = 0
+    total_commits = 0
+    total_pushes = 0
+    total_files_modified = 0
+    total_user_messages = 0
+    total_assistant_messages = 0
+    total_tool_errors = 0
+    session_count = len(records)
+
+    for rec in records:
+        total_input += rec.get("input_tokens") or 0
+        total_output += rec.get("output_tokens") or 0
+        total_duration += rec.get("duration_minutes") or 0
+        total_lines_added += rec.get("lines_added") or 0
+        total_lines_removed += rec.get("lines_removed") or 0
+        total_commits += rec.get("git_commits") or 0
+        total_pushes += rec.get("git_pushes") or 0
+        total_files_modified += rec.get("files_modified") or 0
+        total_user_messages += rec.get("user_message_count") or 0
+        total_assistant_messages += rec.get("assistant_message_count") or 0
+        total_tool_errors += rec.get("tool_errors") or 0
+
+    rollup = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "session_count": session_count,
+        "totals": {
+            "input_tokens": total_input,
+            "output_tokens": total_output,
+            "total_tokens": total_input + total_output,
+            "duration_minutes": total_duration,
+            "lines_added": total_lines_added,
+            "lines_removed": total_lines_removed,
+            "net_lines": total_lines_added - total_lines_removed,
+            "git_commits": total_commits,
+            "git_pushes": total_pushes,
+            "files_modified": total_files_modified,
+            "user_messages": total_user_messages,
+            "assistant_messages": total_assistant_messages,
+            "tool_errors": total_tool_errors,
+        },
+    }
+
+    rollup_file = output_dir / "session_rollups.json"
+    rollup_file.write_text(
+        json.dumps(rollup, indent=2, default=str) + "\n",
+        encoding="utf-8",
+    )
+
+    return rollup
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ImportResult:
+    """Summary of an import_usage_data() run."""
+
+    sessions_imported: int
+    sessions_skipped: int
+    sessions_failed: int
+    total_sessions: int
+    output_dir: str
+
+
+def _resolve_output_dir(output_dir: Path | None) -> Path:
+    """Resolve the output directory, defaulting to repo runtime path."""
+    if output_dir is not None:
+        return output_dir
+    try:
+        from _repo_utils import find_repo_root  # type: ignore[import-not-found]
+
+        return find_repo_root() / ".claude" / "runtime" / "token_economy"
+    except Exception:
+        raise ValueError(
+            "output_dir must be provided when repo root cannot be determined"
+        )
+
+
+def import_usage_data(
+    *,
+    usage_dir: Path | None = None,
+    output_dir: Path | None = None,
+) -> ImportResult:
+    """Import Claude usage data into the repo-owned token economy store.
+
+    Parameters
+    ----------
+    usage_dir
+        Path to ``~/.claude/usage-data/`` (or equivalent). Defaults to
+        :data:`DEFAULT_USAGE_DIR`.
+    output_dir
+        Path to ``.claude/runtime/token_economy/`` (or equivalent). Defaults to
+        ``<repo-root>/.claude/runtime/token_economy/``.
+
+    Returns
+    -------
+    ImportResult
+        Summary of how many sessions were imported, skipped, or failed.
+    """
+    resolved_usage = usage_dir if usage_dir is not None else DEFAULT_USAGE_DIR
+    resolved_output = _resolve_output_dir(output_dir)
+
+    # Ensure output directory exists
+    resolved_output.mkdir(parents=True, exist_ok=True)
+
+    session_meta_dir = resolved_usage / "session-meta"
+    facets_dir = resolved_usage / "facets"
+
+    if not session_meta_dir.is_dir():
+        logger.warning("No session-meta directory found at %s", session_meta_dir)
+        return ImportResult(
+            sessions_imported=0,
+            sessions_skipped=0,
+            sessions_failed=0,
+            total_sessions=0,
+            output_dir=str(resolved_output),
+        )
+
+    # Load existing IDs for idempotent import
+    existing_ids = _load_existing_ids(resolved_output)
+
+    # Scan session-meta files
+    meta_files = sorted(session_meta_dir.glob("*.json"))
+    now = datetime.now(timezone.utc).isoformat()
+
+    imported = 0
+    skipped = 0
+    failed = 0
+    new_records: list[SessionRecord] = []
+
+    for meta_path in meta_files:
+        # Load session-meta
+        session_data = _load_session_meta(meta_path)
+        if session_data is None:
+            failed += 1
+            continue
+
+        sid = session_data["session_id"]
+
+        # Idempotent: skip already-imported sessions
+        if sid in existing_ids:
+            skipped += 1
+            continue
+
+        # Load matching facet data (optional — not all sessions have facets)
+        facet_path = facets_dir / meta_path.name
+        facet_data = None
+        if facet_path.exists():
+            facet_data = _load_facet(facet_path)
+
+        # Build normalized record
+        source_hash = _file_hash(meta_path)
+        rec = _build_record(session_data, facet_data, meta_path, source_hash, now)
+        new_records.append(rec)
+        existing_ids.add(sid)  # prevent within-batch duplicates
+        imported += 1
+
+    # Append new records
+    if new_records:
+        _append_records(new_records, resolved_output)
+
+    # Recompute rollups
+    _write_rollups(resolved_output)
+
+    total = imported + skipped + failed
+
+    return ImportResult(
+        sessions_imported=imported,
+        sessions_skipped=skipped,
+        sessions_failed=failed,
+        total_sessions=total,
+        output_dir=str(resolved_output),
+    )

--- a/tests/unit/test_ops_token_economy.py
+++ b/tests/unit/test_ops_token_economy.py
@@ -1,0 +1,432 @@
+"""Tests for the token economy usage data importer.
+
+Validates:
+- Idempotent import (re-run produces same count)
+- Schema validation rejects malformed input
+- Imported session count matches source count
+- Facet data is merged when available
+- Rollup aggregation is correct
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bid_euchre.ops.token_economy import (
+    ImportResult,
+    SchemaValidationError,
+    SessionRecord,
+    import_usage_data,
+    validate_facet,
+    validate_session_meta,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_session_meta(
+    session_id: str = "test-session-001",
+    *,
+    input_tokens: int = 100,
+    output_tokens: int = 500,
+    duration_minutes: int = 10,
+    lines_added: int = 20,
+    lines_removed: int = 5,
+    git_commits: int = 1,
+    git_pushes: int = 1,
+    files_modified: int = 3,
+    project_path: str = "/tmp/test-project",
+    user_message_count: int = 2,
+    assistant_message_count: int = 8,
+    tool_errors: int = 0,
+) -> dict:
+    return {
+        "session_id": session_id,
+        "project_path": project_path,
+        "start_time": "2026-03-20T10:00:00Z",
+        "duration_minutes": duration_minutes,
+        "user_message_count": user_message_count,
+        "assistant_message_count": assistant_message_count,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "lines_added": lines_added,
+        "lines_removed": lines_removed,
+        "files_modified": files_modified,
+        "git_commits": git_commits,
+        "git_pushes": git_pushes,
+        "tool_counts": {"Bash": 5, "Read": 3},
+        "tool_errors": tool_errors,
+        "tool_error_categories": {},
+        "languages": {"Python": 2},
+        "user_interruptions": 0,
+        "uses_task_agent": False,
+        "uses_mcp": False,
+        "uses_web_search": False,
+        "uses_web_fetch": False,
+        "first_prompt": "Test prompt",
+    }
+
+
+def _make_facet(
+    session_id: str = "test-session-001",
+    *,
+    outcome: str = "fully_achieved",
+    brief_summary: str = "Test session",
+) -> dict:
+    return {
+        "session_id": session_id,
+        "underlying_goal": "Test goal",
+        "outcome": outcome,
+        "session_type": "iterative_refinement",
+        "claude_helpfulness": "essential",
+        "brief_summary": brief_summary,
+        "goal_categories": {"infrastructure_automation": 1},
+        "friction_counts": {},
+        "friction_detail": "",
+        "primary_success": "multi_file_changes",
+        "user_satisfaction_counts": {"satisfied": 1},
+    }
+
+
+@pytest.fixture()
+def usage_dir(tmp_path: Path) -> Path:
+    """Create a mock usage-data directory with session-meta and facets."""
+    meta_dir = tmp_path / "usage-data" / "session-meta"
+    meta_dir.mkdir(parents=True)
+    facets_dir = tmp_path / "usage-data" / "facets"
+    facets_dir.mkdir(parents=True)
+    return tmp_path / "usage-data"
+
+
+@pytest.fixture()
+def output_dir(tmp_path: Path) -> Path:
+    """Create an output directory for the importer."""
+    out = tmp_path / "token_economy"
+    out.mkdir(parents=True)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Schema validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSessionMeta:
+    def test_valid_session_meta(self, tmp_path: Path) -> None:
+        data = _make_session_meta()
+        validate_session_meta(data, tmp_path / "test.json")  # no raise
+
+    def test_missing_session_id(self, tmp_path: Path) -> None:
+        data = {"project_path": "/tmp/test"}
+        with pytest.raises(SchemaValidationError, match="Missing required"):
+            validate_session_meta(data, tmp_path / "test.json")
+
+    def test_empty_session_id(self, tmp_path: Path) -> None:
+        data = {"session_id": ""}
+        with pytest.raises(SchemaValidationError, match="non-empty string"):
+            validate_session_meta(data, tmp_path / "test.json")
+
+    def test_non_dict_input(self, tmp_path: Path) -> None:
+        with pytest.raises(SchemaValidationError, match="Expected dict"):
+            validate_session_meta([], tmp_path / "test.json")  # type: ignore[arg-type]
+
+    def test_numeric_session_id(self, tmp_path: Path) -> None:
+        data = {"session_id": 123}
+        with pytest.raises(SchemaValidationError, match="non-empty string"):
+            validate_session_meta(data, tmp_path / "test.json")  # type: ignore[arg-type]
+
+
+class TestValidateFacet:
+    def test_valid_facet(self, tmp_path: Path) -> None:
+        data = _make_facet()
+        validate_facet(data, tmp_path / "test.json")  # no raise
+
+    def test_non_dict_input(self, tmp_path: Path) -> None:
+        with pytest.raises(SchemaValidationError, match="Expected dict"):
+            validate_facet("not a dict", tmp_path / "test.json")  # type: ignore[arg-type]
+
+    def test_empty_session_id_in_facet(self, tmp_path: Path) -> None:
+        data = {"session_id": "  "}
+        with pytest.raises(SchemaValidationError, match="non-empty string"):
+            validate_facet(data, tmp_path / "test.json")
+
+    def test_facet_without_session_id_is_valid(self, tmp_path: Path) -> None:
+        """Facets may not have session_id (they join by filename)."""
+        data = {"outcome": "fully_achieved"}
+        validate_facet(data, tmp_path / "test.json")  # no raise
+
+
+# ---------------------------------------------------------------------------
+# Import tests
+# ---------------------------------------------------------------------------
+
+
+class TestImportUsageData:
+    def test_import_basic(self, usage_dir: Path, output_dir: Path) -> None:
+        """Import 3 sessions, verify counts match."""
+        meta_dir = usage_dir / "session-meta"
+        facets_dir = usage_dir / "facets"
+
+        for i in range(3):
+            sid = f"session-{i:03d}"
+            fname = f"{sid}.json"
+            (meta_dir / fname).write_text(
+                json.dumps(_make_session_meta(sid)), encoding="utf-8"
+            )
+            (facets_dir / fname).write_text(
+                json.dumps(_make_facet(sid)), encoding="utf-8"
+            )
+
+        result = import_usage_data(usage_dir=usage_dir, output_dir=output_dir)
+
+        assert isinstance(result, ImportResult)
+        assert result.sessions_imported == 3
+        assert result.sessions_skipped == 0
+        assert result.sessions_failed == 0
+        assert result.total_sessions == 3
+
+        # Verify JSONL file has exactly 3 lines
+        jsonl = (output_dir / "session_usage.jsonl").read_text(encoding="utf-8")
+        lines = [l for l in jsonl.strip().splitlines() if l.strip()]
+        assert len(lines) == 3
+
+        # Verify rollups
+        rollups = json.loads(
+            (output_dir / "session_rollups.json").read_text(encoding="utf-8")
+        )
+        assert rollups["session_count"] == 3
+        assert rollups["totals"]["input_tokens"] == 300  # 100 * 3
+        assert rollups["totals"]["output_tokens"] == 1500  # 500 * 3
+
+    def test_idempotent_import(self, usage_dir: Path, output_dir: Path) -> None:
+        """Re-running import does not duplicate sessions."""
+        meta_dir = usage_dir / "session-meta"
+
+        for i in range(2):
+            sid = f"session-{i:03d}"
+            (meta_dir / f"{sid}.json").write_text(
+                json.dumps(_make_session_meta(sid)), encoding="utf-8"
+            )
+
+        # First import
+        r1 = import_usage_data(usage_dir=usage_dir, output_dir=output_dir)
+        assert r1.sessions_imported == 2
+        assert r1.sessions_skipped == 0
+
+        # Second import (same data)
+        r2 = import_usage_data(usage_dir=usage_dir, output_dir=output_dir)
+        assert r2.sessions_imported == 0
+        assert r2.sessions_skipped == 2
+
+        # Verify still only 2 lines in JSONL
+        jsonl = (output_dir / "session_usage.jsonl").read_text(encoding="utf-8")
+        lines = [l for l in jsonl.strip().splitlines() if l.strip()]
+        assert len(lines) == 2
+
+    def test_incremental_import(self, usage_dir: Path, output_dir: Path) -> None:
+        """New sessions are added, existing ones are skipped."""
+        meta_dir = usage_dir / "session-meta"
+
+        # First batch
+        (meta_dir / "session-001.json").write_text(
+            json.dumps(_make_session_meta("session-001")), encoding="utf-8"
+        )
+        r1 = import_usage_data(usage_dir=usage_dir, output_dir=output_dir)
+        assert r1.sessions_imported == 1
+
+        # Add another session
+        (meta_dir / "session-002.json").write_text(
+            json.dumps(_make_session_meta("session-002")), encoding="utf-8"
+        )
+        r2 = import_usage_data(usage_dir=usage_dir, output_dir=output_dir)
+        assert r2.sessions_imported == 1
+        assert r2.sessions_skipped == 1
+
+        # Total should be 2 lines
+        jsonl = (output_dir / "session_usage.jsonl").read_text(encoding="utf-8")
+        lines = [l for l in jsonl.strip().splitlines() if l.strip()]
+        assert len(lines) == 2
+
+    def test_malformed_json_rejected(self, usage_dir: Path, output_dir: Path) -> None:
+        """Malformed JSON files are counted as failed, not crash."""
+        meta_dir = usage_dir / "session-meta"
+
+        # Valid session
+        (meta_dir / "good.json").write_text(
+            json.dumps(_make_session_meta("good-session")), encoding="utf-8"
+        )
+        # Malformed JSON
+        (meta_dir / "bad.json").write_text("{ this is not valid json", encoding="utf-8")
+
+        result = import_usage_data(usage_dir=usage_dir, output_dir=output_dir)
+        assert result.sessions_imported == 1
+        assert result.sessions_failed == 1
+        assert result.total_sessions == 2
+
+    def test_missing_required_field_rejected(
+        self, usage_dir: Path, output_dir: Path
+    ) -> None:
+        """Files missing session_id are rejected."""
+        meta_dir = usage_dir / "session-meta"
+
+        (meta_dir / "no-id.json").write_text(
+            json.dumps({"project_path": "/tmp/test"}), encoding="utf-8"
+        )
+
+        result = import_usage_data(usage_dir=usage_dir, output_dir=output_dir)
+        assert result.sessions_imported == 0
+        assert result.sessions_failed == 1
+
+    def test_facet_data_merged(self, usage_dir: Path, output_dir: Path) -> None:
+        """Facet data is merged into the session record when available."""
+        meta_dir = usage_dir / "session-meta"
+        facets_dir = usage_dir / "facets"
+
+        sid = "test-facet-merge"
+        fname = f"{sid}.json"
+        (meta_dir / fname).write_text(
+            json.dumps(_make_session_meta(sid)), encoding="utf-8"
+        )
+        (facets_dir / fname).write_text(
+            json.dumps(
+                _make_facet(sid, outcome="partially_achieved", brief_summary="Merged!")
+            ),
+            encoding="utf-8",
+        )
+
+        import_usage_data(usage_dir=usage_dir, output_dir=output_dir)
+
+        jsonl = (output_dir / "session_usage.jsonl").read_text(encoding="utf-8")
+        rec = json.loads(jsonl.strip())
+        assert rec["outcome"] == "partially_achieved"
+        assert rec["brief_summary"] == "Merged!"
+        assert rec["underlying_goal"] == "Test goal"
+
+    def test_session_without_facet(self, usage_dir: Path, output_dir: Path) -> None:
+        """Sessions without facet files are imported successfully."""
+        meta_dir = usage_dir / "session-meta"
+
+        sid = "no-facet-session"
+        (meta_dir / f"{sid}.json").write_text(
+            json.dumps(_make_session_meta(sid)), encoding="utf-8"
+        )
+        # No corresponding facet file
+
+        result = import_usage_data(usage_dir=usage_dir, output_dir=output_dir)
+        assert result.sessions_imported == 1
+
+        jsonl = (output_dir / "session_usage.jsonl").read_text(encoding="utf-8")
+        rec = json.loads(jsonl.strip())
+        assert rec["outcome"] is None
+        assert rec["brief_summary"] is None
+
+    def test_empty_usage_dir(self, tmp_path: Path) -> None:
+        """Empty/missing session-meta dir returns zero counts."""
+        empty_dir = tmp_path / "empty-usage"
+        empty_dir.mkdir()
+        out = tmp_path / "token_economy"
+
+        result = import_usage_data(usage_dir=empty_dir, output_dir=out)
+        assert result.sessions_imported == 0
+        assert result.total_sessions == 0
+
+    def test_rollup_aggregation(self, usage_dir: Path, output_dir: Path) -> None:
+        """Rollups aggregate token counts correctly."""
+        meta_dir = usage_dir / "session-meta"
+
+        (meta_dir / "s1.json").write_text(
+            json.dumps(
+                _make_session_meta(
+                    "s1",
+                    input_tokens=200,
+                    output_tokens=1000,
+                    lines_added=50,
+                    lines_removed=10,
+                    git_commits=3,
+                    tool_errors=2,
+                )
+            ),
+            encoding="utf-8",
+        )
+        (meta_dir / "s2.json").write_text(
+            json.dumps(
+                _make_session_meta(
+                    "s2",
+                    input_tokens=300,
+                    output_tokens=2000,
+                    lines_added=100,
+                    lines_removed=20,
+                    git_commits=1,
+                    tool_errors=1,
+                )
+            ),
+            encoding="utf-8",
+        )
+
+        import_usage_data(usage_dir=usage_dir, output_dir=output_dir)
+
+        rollups = json.loads(
+            (output_dir / "session_rollups.json").read_text(encoding="utf-8")
+        )
+        assert rollups["session_count"] == 2
+        totals = rollups["totals"]
+        assert totals["input_tokens"] == 500
+        assert totals["output_tokens"] == 3000
+        assert totals["total_tokens"] == 3500
+        assert totals["lines_added"] == 150
+        assert totals["lines_removed"] == 30
+        assert totals["net_lines"] == 120
+        assert totals["git_commits"] == 4
+        assert totals["tool_errors"] == 3
+
+    def test_source_tracking_in_record(self, usage_dir: Path, output_dir: Path) -> None:
+        """Records include source path and hash for traceability."""
+        meta_dir = usage_dir / "session-meta"
+
+        sid = "tracked-session"
+        fname = f"{sid}.json"
+        (meta_dir / fname).write_text(
+            json.dumps(_make_session_meta(sid)), encoding="utf-8"
+        )
+
+        import_usage_data(usage_dir=usage_dir, output_dir=output_dir)
+
+        jsonl = (output_dir / "session_usage.jsonl").read_text(encoding="utf-8")
+        rec = json.loads(jsonl.strip())
+        assert rec["source_path"].endswith(fname)
+        assert len(rec["source_hash"]) == 64  # SHA-256 hex digest
+        assert rec["import_timestamp"]  # non-empty
+        assert rec["schema_version"] == 1
+
+    def test_non_dict_json_rejected(self, usage_dir: Path, output_dir: Path) -> None:
+        """JSON files containing arrays instead of dicts are rejected."""
+        meta_dir = usage_dir / "session-meta"
+
+        (meta_dir / "array.json").write_text("[1, 2, 3]", encoding="utf-8")
+
+        result = import_usage_data(usage_dir=usage_dir, output_dir=output_dir)
+        assert result.sessions_failed == 1
+        assert result.sessions_imported == 0
+
+
+# ---------------------------------------------------------------------------
+# SessionRecord tests
+# ---------------------------------------------------------------------------
+
+
+class TestSessionRecord:
+    def test_defaults(self) -> None:
+        rec = SessionRecord(session_id="test")
+        assert rec.session_id == "test"
+        assert rec.input_tokens is None
+        assert rec.tool_counts == {}
+        assert rec.outcome is None
+
+    def test_schema_version(self) -> None:
+        rec = SessionRecord(session_id="test")
+        assert rec.schema_version == 1


### PR DESCRIPTION
## Summary
- Create `src/bid_euchre/ops/token_economy.py` — reads native Claude usage data from `~/.claude/usage-data/` and normalizes it into `.claude/runtime/token_economy/`
- Wire `ops.py usage import` CLI entry point for operator use
- Add 22 unit tests covering schema validation, idempotent import, facet merging, rollup aggregation, and error handling

## Why
SP-4-03 Step 1 of the Token Economy Observability sub-plan. The platform needs a repo-owned view of token usage before any optimization work can begin. This importer creates the foundational normalized store that subsequent steps (attribution, CLI summaries, dashboard views, baseline report) will build on.

## Key design decisions
- **Idempotent by session ID** — re-running the importer never duplicates sessions; existing IDs are tracked via the JSONL output file
- **Schema validation** — required fields checked on import; malformed JSON is logged and skipped (not crash)
- **Facet merging** — when a matching facets file exists (same filename), qualitative data (outcome, helpfulness, goals) is merged into the session record
- **Source traceability** — each record includes `source_path`, `source_hash` (SHA-256), and `import_timestamp`
- **JSONL + rollups** — `session_usage.jsonl` for per-session records, `session_rollups.json` for aggregated totals

## Repro / Validation
```bash
# Run unit tests
uv run python -m pytest tests/unit/test_ops_token_economy.py -v

# Run the importer against real data (if ~/.claude/usage-data/ exists)
uv run python scripts/internal/ops.py usage import

# Verify idempotent re-run
uv run python scripts/internal/ops.py usage import  # 0 imported, N skipped

# Full validation
make check-quiet
```

## Tests
- `uv run python -m pytest tests/unit/test_ops_token_economy.py -v` — 22 tests, all passing
- `make check-quiet` — all checks passed

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: ops/token-economy-import
```

## Scope
| File | Change |
|------|--------|
| `src/bid_euchre/ops/token_economy.py` | NEW — importer module |
| `src/bid_euchre/ops/__init__.py` | Add module to docstring |
| `scripts/internal/ops.py` | Add `usage import` CLI subcommand |
| `tests/unit/test_ops_token_economy.py` | NEW — 22 unit tests |

🤖 Generated with [Claude Code](https://claude.com/claude-code)