### PR TITLE
test: exercise validity-mask regression in dashboard wiring test

### DIFF
--- a/tests/unit/test_generate_dashboard.py
+++ b/tests/unit/test_generate_dashboard.py
@@ -20,6 +20,7 @@ scripts_dir = str(Path(__file__).resolve().parents[2] / "scripts")
 sys.path.insert(0, scripts_dir)
 from generate_dashboard import (  # noqa: E402
     _GH_PR_LIMIT,
+    WINDOW,
     _bollinger,
     _draw_bollinger_panel,
     _gather_pr_counts,
@@ -194,6 +195,38 @@ class TestGenerateDashboardWiring:
             "Panel 4 and Panel 5 should receive different data arrays "
             "(churn_pct vs file_churn_pct)"
         )
+
+        # Validity masks: verify each panel receives its own correctly-computed
+        # mask (regression: PR #1365 — panel 5 previously reused panel 4's mask)
+        panel4_valid = draw_calls[3]["valid"]
+        panel5_valid = draw_calls[4]["valid"]
+        n_dates = len(dates)
+        expected_valid = n_dates - WINDOW + 1  # warmup period = WINDOW - 1
+
+        assert panel4_valid.sum() == expected_valid, (
+            f"Panel 4 validity mask: expected {expected_valid} valid, "
+            f"got {panel4_valid.sum()}"
+        )
+        assert panel5_valid.sum() == expected_valid, (
+            f"Panel 5 validity mask: expected {expected_valid} valid, "
+            f"got {panel5_valid.sum()}"
+        )
+
+        # Warmup period (first WINDOW-1 indices) should be invalid
+        assert not panel4_valid[
+            : WINDOW - 1
+        ].any(), "Panel 4: warmup period should be all invalid"
+        assert not panel5_valid[
+            : WINDOW - 1
+        ].any(), "Panel 5: warmup period should be all invalid"
+
+        # Post-warmup indices should be valid
+        assert panel4_valid[
+            WINDOW - 1 :
+        ].all(), "Panel 4: post-warmup indices should be all valid"
+        assert panel5_valid[
+            WINDOW - 1 :
+        ].all(), "Panel 5: post-warmup indices should be all valid"
 
 
 class TestDrawBollingerPanel:


### PR DESCRIPTION
## Summary
- Add validity-mask assertions to `test_panel5_receives_file_churn_data` wiring test
- Verify each panel's mask is independently computed with correct warmup/valid index patterns
- Import `WINDOW` constant to keep assertions in sync with the dashboard's Bollinger Band parameters

## Why
Issue #1376 (from PR #1372 review) identified that the wiring test exercises panel data arrays but not the validity masks. The original bug (PR #1365) was that panel 5 reused panel 4's validity mask — these new assertions guard against that regression at the wiring level.

Closes #1376

## Scope
- `tests/unit/test_generate_dashboard.py` only

## Validation
```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/test_generate_dashboard.py -v  # 17 passed

# Tier 2 — full validation
make check-quiet  # ✓ All checks passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: fix/dashboard-validity-mask-1376
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)