### PR TITLE
fix: avoid backup diff filename collisions on rapid resets

### DIFF
--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -960,6 +960,12 @@ def reset_worktree(
         if is_dirty and force:
             ts = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%S")
             diff_path = Path(f"/tmp/{lane_id}_{ts}.diff")
+            # Disambiguate if a backup with this timestamp already exists
+            # (multiple resets within the same second)
+            seq = 1
+            while diff_path.exists():
+                diff_path = Path(f"/tmp/{lane_id}_{ts}_{seq}.diff")
+                seq += 1
             diff_result = subprocess.run(
                 ["git", "diff", "HEAD"],
                 cwd=worktree_path,


### PR DESCRIPTION
## Summary
- Add collision-avoidance loop to `reset_worktree()` backup diff filenames
- When a file with the same one-second timestamp already exists, append a sequence suffix (`_1`, `_2`, ...) to ensure uniqueness

## Why
Issue #1371: backup filenames use one-second timestamps (`%Y%m%dT%H%M%S`) which can collide if two resets happen within the same second. The sequence-suffix approach avoids collisions while preserving backward compatibility with existing filename expectations.

Closes #1371

## Scope
- `src/bid_euchre/ops/worker_pool.py` only (lines 960-966)

## Validation
```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/test_ops_worker_pool.py -v  # 149 passed

# Tier 2 — full validation
make check-quiet  # ✓ All checks passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: fix/backup-name-precision-1371
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)