### PR TITLE
fix: pass LANE_ID as sys.argv in scope-drift-guard hook

### DIFF
--- a/.claude/hooks/scope-drift-guard.sh
+++ b/.claude/hooks/scope-drift-guard.sh
@@ -58,14 +58,17 @@ if [ -z "$LANE_ID" ]; then
   exit 0
 fi
 
-# Run enforcement via Python
+# Run enforcement via Python — pass LANE_ID as sys.argv[1] to avoid
+# unsafe shell interpolation into Python source (issue #1379).
 RESULT=$(uv run python -c "
 import json, subprocess, sys
 
 from bid_euchre.ops.scope import enforce_scope_drift, get_active_task_scope
 
+lane_id = sys.argv[1]
+
 # Find active task for this lane
-task_id, patterns = get_active_task_scope('${LANE_ID}')
+task_id, patterns = get_active_task_scope(lane_id)
 if task_id is None or not patterns:
     print(json.dumps({'action': 'skip', 'reason': 'No active task or no scope patterns.'}))
     sys.exit(0)
@@ -86,7 +89,7 @@ if not staged:
 
 verdict = enforce_scope_drift(staged, patterns, task_id=task_id)
 print(json.dumps(verdict.to_dict()))
-" 2>/dev/null)
+" "$LANE_ID" 2>/dev/null)
 
 if [ -z "$RESULT" ]; then
   # Python invocation failed — don't block work

--- a/tests/unit/test_ops_scope.py
+++ b/tests/unit/test_ops_scope.py
@@ -556,3 +556,48 @@ class TestGetActiveTaskScope:
         task_id, patterns = get_active_task_scope("author-a", queue_root)
         assert task_id == "pkt-1"
         assert patterns == []
+
+
+# --- Hook contract regression tests ---
+
+
+class TestScopeDriftGuardHookContract:
+    """Regression tests for scope-drift-guard.sh hook.
+
+    Issue #1379: the hook previously embedded LANE_ID directly into
+    Python source via shell interpolation ('${LANE_ID}'). If the env
+    var contained quotes, this would break the Python string literal.
+    The fix passes LANE_ID as sys.argv[1] instead.
+    """
+
+    @pytest.fixture()
+    def hook_content(self) -> str:
+        """Read the scope-drift-guard hook source."""
+        hook_path = (
+            Path(__file__).resolve().parents[2]
+            / ".claude"
+            / "hooks"
+            / "scope-drift-guard.sh"
+        )
+        assert hook_path.exists(), f"Hook not found at {hook_path}"
+        return hook_path.read_text()
+
+    def test_no_shell_interpolation_of_lane_id_in_python(
+        self, hook_content: str
+    ) -> None:
+        """LANE_ID must not be shell-interpolated into Python source."""
+        assert "'${LANE_ID}'" not in hook_content, (
+            "Hook still uses unsafe shell interpolation of LANE_ID "
+            "into Python source (issue #1379)"
+        )
+
+    def test_lane_id_passed_via_sys_argv(self, hook_content: str) -> None:
+        """LANE_ID must be passed as a command-line argument."""
+        assert (
+            "sys.argv[1]" in hook_content
+        ), "Hook should read LANE_ID from sys.argv[1]"
+        # The shell argument should be passed after the closing quote
+        # of the -c string
+        assert (
+            '"$LANE_ID"' in hook_content or "'$LANE_ID'" in hook_content
+        ), "Hook should pass $LANE_ID as a shell argument to python -c"


### PR DESCRIPTION
## Plan
- N/A (single-file bugfix from issue #1379)

## Summary
- Fix unsafe shell interpolation of LANE_ID into Python source in scope-drift-guard hook
- Pass LANE_ID as `sys.argv[1]` instead of embedding `'${LANE_ID}'` in Python string literal
- Add regression tests verifying the hook contract

## Why
If `CLAUDE_AGENT_NAME` contained quotes or other shell-special characters, the previous approach would break the Python string literal inside the `-c` script, causing the scope-drift guard to silently fail (stderr redirected to `/dev/null`).

## Repro / Validation
**Command(s) run:**
- `make check-quiet` — all checks pass
- `uv run python -m pytest tests/unit/test_ops_scope.py -k "test_no_shell_interpolation or test_lane_id_passed"` — 2/2 pass

**Config (if applicable):**
- N/A

**Seed (if applicable):**
- N/A

## Tests
- [x] Other: `make check-quiet` passes
- [x] Other: 2 new regression tests in `TestScopeDriftGuardHookContract`

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a  89ddc38d [fix/scope-drift-guard-lane-injection]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

Closes #1379