### PR TITLE
ops: add session-to-lane attribution for token economy (SP-4-03 Step 2)

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -52,6 +52,7 @@ Usage:
     uv run python scripts/internal/ops.py workers dispatch PACKET_ID LANE_ID [--json]
     uv run python scripts/internal/ops.py workers maintain [--dry-run] [--json]
     uv run python scripts/internal/ops.py usage import [--usage-dir DIR] [--output-dir DIR] [--json]
+    uv run python scripts/internal/ops.py usage attribute [--output-dir DIR] [--json]
 """
 
 from __future__ import annotations
@@ -2432,9 +2433,31 @@ def cmd_usage(args: argparse.Namespace) -> int:
             print(f"  Output dir:        {result.output_dir}")
         return 0
 
+    elif action == "attribute":
+        from bid_euchre.ops.token_economy import attribute_sessions
+
+        result = attribute_sessions(
+            output_dir=getattr(args, "output_dir", None),
+        )
+
+        if args.json:
+            from dataclasses import asdict
+
+            print(json.dumps(asdict(result), indent=2, default=str))
+        else:
+            print("Attribution complete:")
+            print(f"  Total sessions:          {result.total_sessions}")
+            print(f"  Attributed:              {result.attributed}")
+            print(f"  Partially attributed:    {result.partially_attributed}")
+            print(f"  Unattributed:            {result.unattributed}")
+            if result.lanes_found:
+                print(f"  Lanes found:             {', '.join(result.lanes_found)}")
+            print(f"  Output dir:              {result.output_dir}")
+        return 0
+
     else:
         print(
-            "Usage: ops.py usage {import}",
+            "Usage: ops.py usage {import|attribute}",
             file=sys.stderr,
         )
         return 1
@@ -3156,6 +3179,16 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         default=None,
         help="Output directory (default: .claude/runtime/token_economy/)",
+    )
+
+    usage_attr_parser = usage_sub.add_parser(
+        "attribute", help="Attribute sessions to lanes and work outcomes"
+    )
+    usage_attr_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Token economy store directory (default: .claude/runtime/token_economy/)",
     )
 
     return parser

--- a/src/bid_euchre/ops/token_economy.py
+++ b/src/bid_euchre/ops/token_economy.py
@@ -1,4 +1,4 @@
-"""Token economy observability — import native Claude usage data.
+"""Token economy observability — import and attribute Claude usage data.
 
 Reads from ``~/.claude/usage-data/session-meta/*.json`` and
 ``~/.claude/usage-data/facets/*.json`` and normalizes them into a
@@ -7,7 +7,9 @@ repo-owned store under ``.claude/runtime/token_economy/``.
 Public API
 ----------
 import_usage_data
-    Main entry point. Idempotent — re-running does not duplicate sessions.
+    Import native usage data. Idempotent — re-running does not duplicate sessions.
+attribute_sessions
+    Infer lane/worktree attribution for imported sessions.
 """
 
 from __future__ import annotations
@@ -15,8 +17,10 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import re
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
@@ -492,5 +496,378 @@ def import_usage_data(
         sessions_skipped=skipped,
         sessions_failed=failed,
         total_sessions=total,
+        output_dir=str(resolved_output),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Attribution — lane inference from project_path
+# ---------------------------------------------------------------------------
+
+#: Canonical mapping from worktree directory basenames to lane IDs.
+#: Matches the pool definitions in ``task_queue.KNOWN_AUTHOR_LANES`` and
+#: ``worktrees.PROTECTED_WORKTREE_NAMES``.
+_WORKTREE_TO_LANE: dict[str, str] = {
+    # Platform pool
+    "Bid-Euchre-steward-author": "author-a",
+    "Bid-Euchre-steward-author-b": "author-b",
+    "Bid-Euchre-steward-author-c": "author-c",
+    "Bid-Euchre-steward-author-d": "author-d",
+    "Bid-Euchre-steward-author-scratch": "author-scratch",
+    # Browser-game pool
+    "Bid-Euchre-steward-brws-author-a": "brws-author-a",
+    "Bid-Euchre-steward-brws-author-b": "brws-author-b",
+    "Bid-Euchre-steward-brws-author-c": "brws-author-c",
+    "Bid-Euchre-steward-brws-author-d": "brws-author-d",
+    # Flex pool
+    "Bid-Euchre-steward-flex-a": "flex-a",
+    "Bid-Euchre-steward-flex-b": "flex-b",
+    "Bid-Euchre-steward-flex-c": "flex-c",
+    # Control plane
+    "Bid-Euchre-steward-review": "review",
+    "Bid-Euchre-steward-ops": "ops",
+}
+
+#: Worktree class categorization by lane prefix.
+_LANE_POOL: dict[str, str] = {
+    "author-": "platform",
+    "brws-author-": "browser-game",
+    "flex-": "flex",
+    "review": "control",
+    "ops": "control",
+}
+
+
+class AttributionQuality(str, Enum):
+    """Quality of session-to-lane attribution."""
+
+    ATTRIBUTED = "attributed"
+    PARTIALLY_ATTRIBUTED = "partially_attributed"
+    UNATTRIBUTED = "unattributed"
+
+
+@dataclass
+class SessionAttribution:
+    """Attribution result for a single session."""
+
+    session_id: str
+    lane_id: str | None = None
+    worktree_class: str | None = (
+        None  # "platform" | "browser-game" | "flex" | "control"
+    )
+    worktree_name: str | None = None
+    quality: str = AttributionQuality.UNATTRIBUTED.value
+    matched_packets: list[str] = field(default_factory=list)
+    attribution_timestamp: str = ""
+
+    # Token/throughput from the session for easy rollup
+    input_tokens: int = 0
+    output_tokens: int = 0
+    duration_minutes: int = 0
+    lines_added: int = 0
+    lines_removed: int = 0
+    git_commits: int = 0
+
+
+def infer_lane_from_path(project_path: str | None) -> tuple[str | None, str | None]:
+    """Infer lane ID and worktree name from a session's project_path.
+
+    Parameters
+    ----------
+    project_path
+        The ``project_path`` field from a session record (absolute filesystem path).
+
+    Returns
+    -------
+    tuple[str | None, str | None]
+        ``(lane_id, worktree_name)`` if the path matches a known steward worktree,
+        ``(None, None)`` otherwise.
+    """
+    if not project_path:
+        return None, None
+
+    # Extract directory basename from the path.
+    # Handle paths that may end with / or contain subdirectories.
+    path = Path(project_path)
+    basename = path.name
+
+    # Direct match against known worktree names
+    lane_id = _WORKTREE_TO_LANE.get(basename)
+    if lane_id is not None:
+        return lane_id, basename
+
+    # Check parent directories — sessions may run from subdirectories
+    for parent in path.parents:
+        parent_name = parent.name
+        lane_id = _WORKTREE_TO_LANE.get(parent_name)
+        if lane_id is not None:
+            return lane_id, parent_name
+
+    # Try heuristic: look for "steward-" pattern in the path
+    match = re.search(r"Bid-Euchre-steward-([a-z0-9-]+)", project_path)
+    if match:
+        suffix = match.group(1)
+        # Reconstruct the worktree name and check
+        worktree_name = f"Bid-Euchre-steward-{suffix}"
+        lane_id = _WORKTREE_TO_LANE.get(worktree_name)
+        if lane_id is not None:
+            return lane_id, worktree_name
+
+    # Check if it's the main checkout (Bid-Euchre without steward suffix)
+    if basename == "Bid-Euchre" or "/Bid-Euchre/" in project_path:
+        return "main-checkout", "Bid-Euchre"
+
+    return None, None
+
+
+def _classify_pool(lane_id: str) -> str | None:
+    """Classify a lane ID into its pool category."""
+    for prefix, pool in _LANE_POOL.items():
+        if lane_id.startswith(prefix) or lane_id == prefix:
+            return pool
+    return None
+
+
+def _load_sessions(output_dir: Path) -> list[dict[str, Any]]:
+    """Load all session records from session_usage.jsonl."""
+    usage_file = output_dir / "session_usage.jsonl"
+    records: list[dict[str, Any]] = []
+    if not usage_file.exists():
+        return records
+    for line in usage_file.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return records
+
+
+def _time_overlaps(
+    session_start: str | None,
+    session_duration: int | None,
+    packet_created: str,
+    packet_completed: str | None,
+) -> bool:
+    """Check if a session's time window overlaps with a packet's lifecycle.
+
+    Uses a generous overlap: session active period vs packet created→completed.
+    """
+    if not session_start or session_duration is None:
+        return False
+    try:
+        s_start = datetime.fromisoformat(session_start.replace("Z", "+00:00"))
+        from datetime import timedelta
+
+        s_end = s_start + timedelta(minutes=max(session_duration, 1))
+        p_start = datetime.fromisoformat(packet_created.replace("Z", "+00:00"))
+        if packet_completed:
+            p_end = datetime.fromisoformat(packet_completed.replace("Z", "+00:00"))
+        else:
+            # Packet still open — extend to far future
+            p_end = datetime.max.replace(tzinfo=timezone.utc)
+        return s_start < p_end and s_end > p_start
+    except (ValueError, TypeError):
+        return False
+
+
+def join_to_packets(
+    attributions: list[SessionAttribution],
+    *,
+    task_queue_root: Path | None = None,
+) -> list[SessionAttribution]:
+    """Correlate attributed sessions with task packets by lane + time overlap.
+
+    Modifies attributions in-place by populating ``matched_packets`` and
+    upgrading quality from ``partially_attributed`` to ``attributed`` when
+    a packet match is found.
+
+    Parameters
+    ----------
+    attributions
+        List of :class:`SessionAttribution` objects with ``lane_id`` set.
+    task_queue_root
+        Path to ``.claude/runtime/task_queue/``. If None, auto-resolves.
+    """
+    resolved_tq: Path
+    if task_queue_root is not None:
+        resolved_tq = task_queue_root
+    else:
+        try:
+            from _repo_utils import find_repo_root  # type: ignore[import-not-found]
+
+            resolved_tq = find_repo_root() / ".claude" / "runtime" / "task_queue"
+        except Exception:
+            logger.warning("Cannot resolve task_queue_root; skipping packet join")
+            return attributions
+
+    if not resolved_tq.is_dir():
+        return attributions
+
+    # Load all packets (including archived)
+    packets: list[dict[str, Any]] = []
+    for pkt_file in sorted(resolved_tq.glob("*.json")):
+        data = _load_json(pkt_file)
+        if data and data.get("packet_id"):
+            packets.append(data)
+
+    # Also check archive directory
+    archive_dir = resolved_tq / "archive"
+    if archive_dir.is_dir():
+        for pkt_file in sorted(archive_dir.glob("*.json")):
+            data = _load_json(pkt_file)
+            if data and data.get("packet_id"):
+                packets.append(data)
+
+    # Build lane→session index for efficient matching
+    lane_sessions: dict[str, list[SessionAttribution]] = {}
+    for attr in attributions:
+        if attr.lane_id and attr.lane_id != "main-checkout":
+            lane_sessions.setdefault(attr.lane_id, []).append(attr)
+
+    # Match packets to sessions by lane ownership + time overlap
+    for pkt in packets:
+        pkt_owner = pkt.get("owner")
+        if not pkt_owner:
+            continue
+        pkt_id = pkt.get("packet_id", "")
+        pkt_created = pkt.get("created_at", "")
+        # Check metadata for completion timestamp
+        pkt_meta = pkt.get("metadata", {})
+        pkt_completed = pkt_meta.get("completed_at")
+
+        sessions_for_lane = lane_sessions.get(pkt_owner, [])
+        for attr in sessions_for_lane:
+            # Time overlap: use attribution_timestamp (= session start_time)
+            # with generous duration fallback for sessions missing duration
+            if _time_overlaps(
+                attr.attribution_timestamp,  # fallback to attr timestamp
+                attr.duration_minutes if attr.duration_minutes else 60,
+                pkt_created,
+                pkt_completed,
+            ):
+                if pkt_id not in attr.matched_packets:
+                    attr.matched_packets.append(pkt_id)
+                    if attr.quality == AttributionQuality.PARTIALLY_ATTRIBUTED.value:
+                        attr.quality = AttributionQuality.ATTRIBUTED.value
+
+    return attributions
+
+
+@dataclass
+class AttributionResult:
+    """Summary of an attribute_sessions() run."""
+
+    total_sessions: int
+    attributed: int
+    partially_attributed: int
+    unattributed: int
+    lanes_found: list[str]
+    output_dir: str
+
+
+def attribute_sessions(
+    *,
+    output_dir: Path | None = None,
+    task_queue_root: Path | None = None,
+) -> AttributionResult:
+    """Attribute imported sessions to lanes and correlate with work outcomes.
+
+    Reads ``session_usage.jsonl``, infers lane from ``project_path``, joins
+    with task packets by lane + time overlap, and writes attribution results
+    to ``session_attributions.jsonl``.
+
+    Parameters
+    ----------
+    output_dir
+        Path to the token economy store. Defaults to
+        ``<repo-root>/.claude/runtime/token_economy/``.
+    task_queue_root
+        Path to ``.claude/runtime/task_queue/``. If None, auto-resolves.
+
+    Returns
+    -------
+    AttributionResult
+        Summary of attribution quality and lane distribution.
+    """
+    resolved_output = _resolve_output_dir(output_dir)
+    sessions = _load_sessions(resolved_output)
+
+    if not sessions:
+        return AttributionResult(
+            total_sessions=0,
+            attributed=0,
+            partially_attributed=0,
+            unattributed=0,
+            lanes_found=[],
+            output_dir=str(resolved_output),
+        )
+
+    now = datetime.now(timezone.utc).isoformat()
+    attributions: list[SessionAttribution] = []
+    lanes_seen: set[str] = set()
+
+    for session in sessions:
+        sid = session.get("session_id", "")
+        project_path = session.get("project_path")
+        lane_id, worktree_name = infer_lane_from_path(project_path)
+
+        pool = _classify_pool(lane_id) if lane_id else None
+
+        if lane_id is not None and lane_id != "main-checkout":
+            quality = AttributionQuality.PARTIALLY_ATTRIBUTED.value
+            lanes_seen.add(lane_id)
+        elif lane_id == "main-checkout":
+            quality = AttributionQuality.PARTIALLY_ATTRIBUTED.value
+            lanes_seen.add(lane_id)
+        else:
+            quality = AttributionQuality.UNATTRIBUTED.value
+
+        attr = SessionAttribution(
+            session_id=sid,
+            lane_id=lane_id,
+            worktree_class=pool,
+            worktree_name=worktree_name,
+            quality=quality,
+            attribution_timestamp=session.get("start_time", now),
+            input_tokens=session.get("input_tokens") or 0,
+            output_tokens=session.get("output_tokens") or 0,
+            duration_minutes=session.get("duration_minutes") or 0,
+            lines_added=session.get("lines_added") or 0,
+            lines_removed=session.get("lines_removed") or 0,
+            git_commits=session.get("git_commits") or 0,
+        )
+        attributions.append(attr)
+
+    # Join to task packets (upgrades quality where match found)
+    join_to_packets(attributions, task_queue_root=task_queue_root)
+
+    # Write attributions
+    attr_file = resolved_output / "session_attributions.jsonl"
+    with attr_file.open("w", encoding="utf-8") as f:
+        for attr in attributions:
+            f.write(json.dumps(asdict(attr), default=str) + "\n")
+
+    # Count by quality
+    n_attributed = sum(
+        1 for a in attributions if a.quality == AttributionQuality.ATTRIBUTED.value
+    )
+    n_partial = sum(
+        1
+        for a in attributions
+        if a.quality == AttributionQuality.PARTIALLY_ATTRIBUTED.value
+    )
+    n_unattributed = sum(
+        1 for a in attributions if a.quality == AttributionQuality.UNATTRIBUTED.value
+    )
+
+    return AttributionResult(
+        total_sessions=len(attributions),
+        attributed=n_attributed,
+        partially_attributed=n_partial,
+        unattributed=n_unattributed,
+        lanes_found=sorted(lanes_seen),
         output_dir=str(resolved_output),
     )

--- a/tests/unit/test_ops_token_economy.py
+++ b/tests/unit/test_ops_token_economy.py
@@ -1,4 +1,4 @@
-"""Tests for the token economy usage data importer.
+"""Tests for the token economy usage data importer and attribution.
 
 Validates:
 - Idempotent import (re-run produces same count)
@@ -6,6 +6,9 @@ Validates:
 - Imported session count matches source count
 - Facet data is merged when available
 - Rollup aggregation is correct
+- Lane inference from project_path
+- Attribution quality enum
+- Session-to-packet correlation
 """
 
 from __future__ import annotations
@@ -16,10 +19,16 @@ from pathlib import Path
 import pytest
 
 from bid_euchre.ops.token_economy import (
+    AttributionQuality,
+    AttributionResult,
     ImportResult,
     SchemaValidationError,
+    SessionAttribution,
     SessionRecord,
+    attribute_sessions,
     import_usage_data,
+    infer_lane_from_path,
+    join_to_packets,
     validate_facet,
     validate_session_meta,
 )
@@ -430,3 +439,380 @@ class TestSessionRecord:
     def test_schema_version(self) -> None:
         rec = SessionRecord(session_id="test")
         assert rec.schema_version == 1
+
+
+# ---------------------------------------------------------------------------
+# Lane inference tests
+# ---------------------------------------------------------------------------
+
+
+class TestInferLaneFromPath:
+    """Test lane ID inference from session project_path."""
+
+    def test_platform_author_a(self) -> None:
+        path = "/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author"
+        lane, wt = infer_lane_from_path(path)
+        assert lane == "author-a"
+        assert wt == "Bid-Euchre-steward-author"
+
+    def test_platform_author_b(self) -> None:
+        path = "/Users/foo/Bid-Euchre-meta/Bid-Euchre-steward-author-b"
+        lane, wt = infer_lane_from_path(path)
+        assert lane == "author-b"
+        assert wt == "Bid-Euchre-steward-author-b"
+
+    def test_platform_author_scratch(self) -> None:
+        path = "/Users/foo/Bid-Euchre-meta/Bid-Euchre-steward-author-scratch"
+        lane, wt = infer_lane_from_path(path)
+        assert lane == "author-scratch"
+
+    def test_browser_game_pool(self) -> None:
+        path = "/Users/foo/meta/Bid-Euchre-steward-brws-author-a"
+        lane, wt = infer_lane_from_path(path)
+        assert lane == "brws-author-a"
+        assert wt == "Bid-Euchre-steward-brws-author-a"
+
+    def test_flex_pool(self) -> None:
+        path = "/Users/foo/meta/Bid-Euchre-steward-flex-b"
+        lane, wt = infer_lane_from_path(path)
+        assert lane == "flex-b"
+
+    def test_control_ops(self) -> None:
+        path = "/Users/foo/meta/Bid-Euchre-steward-ops"
+        lane, wt = infer_lane_from_path(path)
+        assert lane == "ops"
+
+    def test_control_review(self) -> None:
+        path = "/Users/foo/meta/Bid-Euchre-steward-review"
+        lane, wt = infer_lane_from_path(path)
+        assert lane == "review"
+
+    def test_main_checkout(self) -> None:
+        path = "/Users/foo/Projects/Bid-Euchre-meta/Bid-Euchre"
+        lane, wt = infer_lane_from_path(path)
+        assert lane == "main-checkout"
+        assert wt == "Bid-Euchre"
+
+    def test_unknown_project(self) -> None:
+        path = "/Users/foo/some-other-project"
+        lane, wt = infer_lane_from_path(path)
+        assert lane is None
+        assert wt is None
+
+    def test_none_path(self) -> None:
+        lane, wt = infer_lane_from_path(None)
+        assert lane is None
+        assert wt is None
+
+    def test_empty_path(self) -> None:
+        lane, wt = infer_lane_from_path("")
+        assert lane is None
+        assert wt is None
+
+    def test_subdirectory_of_worktree(self) -> None:
+        """Sessions may run from subdirectories of the worktree."""
+        path = "/Users/foo/meta/Bid-Euchre-steward-author/src/bid_euchre"
+        lane, wt = infer_lane_from_path(path)
+        assert lane == "author-a"
+        assert wt == "Bid-Euchre-steward-author"
+
+    def test_all_known_lanes_covered(self) -> None:
+        """Every known author lane maps from at least one worktree path."""
+        from bid_euchre.ops.token_economy import _WORKTREE_TO_LANE
+
+        expected_lanes = {
+            "author-a",
+            "author-b",
+            "author-c",
+            "author-d",
+            "author-scratch",
+            "brws-author-a",
+            "brws-author-b",
+            "brws-author-c",
+            "brws-author-d",
+            "flex-a",
+            "flex-b",
+            "flex-c",
+            "review",
+            "ops",
+        }
+        assert set(_WORKTREE_TO_LANE.values()) == expected_lanes
+
+
+# ---------------------------------------------------------------------------
+# Attribution quality tests
+# ---------------------------------------------------------------------------
+
+
+class TestAttributionQuality:
+    def test_enum_values(self) -> None:
+        assert AttributionQuality.ATTRIBUTED.value == "attributed"
+        assert AttributionQuality.PARTIALLY_ATTRIBUTED.value == "partially_attributed"
+        assert AttributionQuality.UNATTRIBUTED.value == "unattributed"
+
+    def test_string_enum(self) -> None:
+        """AttributionQuality is a str enum for JSON serialization."""
+        assert isinstance(AttributionQuality.ATTRIBUTED, str)
+
+
+# ---------------------------------------------------------------------------
+# Attribution integration tests
+# ---------------------------------------------------------------------------
+
+
+def _populate_store(output_dir: Path, sessions: list[dict]) -> None:
+    """Write session records to session_usage.jsonl for attribution tests."""
+    usage_file = output_dir / "session_usage.jsonl"
+    with usage_file.open("w", encoding="utf-8") as f:
+        for s in sessions:
+            f.write(json.dumps(s) + "\n")
+
+
+class TestAttributeSessions:
+    def test_attribute_steward_sessions(self, output_dir: Path) -> None:
+        """Sessions from steward worktrees get lane attribution."""
+        sessions = [
+            {
+                "session_id": "s1",
+                "project_path": "/Users/foo/meta/Bid-Euchre-steward-author",
+                "start_time": "2026-03-20T10:00:00Z",
+                "duration_minutes": 30,
+                "input_tokens": 100,
+                "output_tokens": 500,
+                "lines_added": 20,
+                "lines_removed": 5,
+                "git_commits": 1,
+            },
+            {
+                "session_id": "s2",
+                "project_path": "/Users/foo/meta/Bid-Euchre-steward-flex-a",
+                "start_time": "2026-03-20T11:00:00Z",
+                "duration_minutes": 15,
+                "input_tokens": 50,
+                "output_tokens": 200,
+                "lines_added": 10,
+                "lines_removed": 2,
+                "git_commits": 0,
+            },
+        ]
+        _populate_store(output_dir, sessions)
+
+        # Use an empty task queue so packet join is skipped
+        tq_dir = output_dir / "empty_tq"
+        tq_dir.mkdir()
+
+        result = attribute_sessions(output_dir=output_dir, task_queue_root=tq_dir)
+
+        assert isinstance(result, AttributionResult)
+        assert result.total_sessions == 2
+        assert result.partially_attributed == 2  # lane found, no packet match
+        assert result.unattributed == 0
+        assert "author-a" in result.lanes_found
+        assert "flex-a" in result.lanes_found
+
+        # Verify attributions file
+        attr_file = output_dir / "session_attributions.jsonl"
+        assert attr_file.exists()
+        lines = [json.loads(l) for l in attr_file.read_text().splitlines() if l.strip()]
+        assert len(lines) == 2
+        assert lines[0]["lane_id"] == "author-a"
+        assert lines[0]["worktree_class"] == "platform"
+        assert lines[1]["lane_id"] == "flex-a"
+        assert lines[1]["worktree_class"] == "flex"
+
+    def test_attribute_unrecognized_project(self, output_dir: Path) -> None:
+        """Sessions from unknown projects are marked unattributed."""
+        sessions = [
+            {
+                "session_id": "s1",
+                "project_path": "/Users/foo/other-project",
+                "start_time": "2026-03-20T10:00:00Z",
+                "duration_minutes": 10,
+                "input_tokens": 100,
+                "output_tokens": 500,
+            },
+        ]
+        _populate_store(output_dir, sessions)
+
+        tq_dir = output_dir / "empty_tq"
+        tq_dir.mkdir()
+
+        result = attribute_sessions(output_dir=output_dir, task_queue_root=tq_dir)
+
+        assert result.unattributed == 1
+        assert result.partially_attributed == 0
+
+    def test_attribute_empty_store(self, output_dir: Path) -> None:
+        """Empty session store returns zero counts."""
+        result = attribute_sessions(output_dir=output_dir)
+        assert result.total_sessions == 0
+        assert result.lanes_found == []
+
+    def test_attribute_main_checkout(self, output_dir: Path) -> None:
+        """Main checkout sessions are partially attributed."""
+        sessions = [
+            {
+                "session_id": "s1",
+                "project_path": "/Users/foo/meta/Bid-Euchre",
+                "start_time": "2026-03-20T10:00:00Z",
+                "duration_minutes": 10,
+                "input_tokens": 100,
+                "output_tokens": 500,
+            },
+        ]
+        _populate_store(output_dir, sessions)
+
+        tq_dir = output_dir / "empty_tq"
+        tq_dir.mkdir()
+
+        result = attribute_sessions(output_dir=output_dir, task_queue_root=tq_dir)
+
+        assert result.partially_attributed == 1
+        assert "main-checkout" in result.lanes_found
+
+
+# ---------------------------------------------------------------------------
+# Packet join tests
+# ---------------------------------------------------------------------------
+
+
+class TestJoinToPackets:
+    def test_join_by_lane_and_time(self, tmp_path: Path) -> None:
+        """Sessions are joined to packets by matching lane + time overlap."""
+        # Create a task queue with one packet
+        tq_dir = tmp_path / "task_queue"
+        tq_dir.mkdir()
+        pkt = {
+            "packet_id": "pkt-001",
+            "title": "Test task",
+            "description": "Test",
+            "owner": "author-a",
+            "created_by": "orchestrator",
+            "created_at": "2026-03-20T09:30:00Z",
+            "status": "completed",
+            "metadata": {"completed_at": "2026-03-20T11:00:00Z"},
+        }
+        (tq_dir / "pkt-001.json").write_text(json.dumps(pkt), encoding="utf-8")
+
+        # Create attribution with overlapping time
+        attr = SessionAttribution(
+            session_id="s1",
+            lane_id="author-a",
+            quality=AttributionQuality.PARTIALLY_ATTRIBUTED.value,
+            attribution_timestamp="2026-03-20T10:00:00Z",
+            duration_minutes=30,
+        )
+
+        result = join_to_packets([attr], task_queue_root=tq_dir)
+
+        assert len(result) == 1
+        assert "pkt-001" in result[0].matched_packets
+        assert result[0].quality == AttributionQuality.ATTRIBUTED.value
+
+    def test_no_join_wrong_lane(self, tmp_path: Path) -> None:
+        """Sessions don't join to packets on a different lane."""
+        tq_dir = tmp_path / "task_queue"
+        tq_dir.mkdir()
+        pkt = {
+            "packet_id": "pkt-001",
+            "title": "Test task",
+            "description": "Test",
+            "owner": "author-b",
+            "created_by": "orchestrator",
+            "created_at": "2026-03-20T09:30:00Z",
+            "status": "completed",
+            "metadata": {},
+        }
+        (tq_dir / "pkt-001.json").write_text(json.dumps(pkt), encoding="utf-8")
+
+        attr = SessionAttribution(
+            session_id="s1",
+            lane_id="author-a",
+            quality=AttributionQuality.PARTIALLY_ATTRIBUTED.value,
+            attribution_timestamp="2026-03-20T10:00:00Z",
+            duration_minutes=30,
+        )
+
+        result = join_to_packets([attr], task_queue_root=tq_dir)
+
+        assert result[0].matched_packets == []
+        assert result[0].quality == AttributionQuality.PARTIALLY_ATTRIBUTED.value
+
+    def test_no_join_non_overlapping_time(self, tmp_path: Path) -> None:
+        """Sessions don't join if time windows don't overlap."""
+        tq_dir = tmp_path / "task_queue"
+        tq_dir.mkdir()
+        pkt = {
+            "packet_id": "pkt-001",
+            "title": "Test task",
+            "description": "Test",
+            "owner": "author-a",
+            "created_by": "orchestrator",
+            "created_at": "2026-03-20T09:00:00Z",
+            "status": "completed",
+            "metadata": {"completed_at": "2026-03-20T09:30:00Z"},
+        }
+        (tq_dir / "pkt-001.json").write_text(json.dumps(pkt), encoding="utf-8")
+
+        attr = SessionAttribution(
+            session_id="s1",
+            lane_id="author-a",
+            quality=AttributionQuality.PARTIALLY_ATTRIBUTED.value,
+            attribution_timestamp="2026-03-20T12:00:00Z",
+            duration_minutes=30,
+        )
+
+        result = join_to_packets([attr], task_queue_root=tq_dir)
+
+        assert result[0].matched_packets == []
+
+    def test_join_with_archived_packets(self, tmp_path: Path) -> None:
+        """Archived packets are also checked for joins."""
+        tq_dir = tmp_path / "task_queue"
+        tq_dir.mkdir()
+        archive_dir = tq_dir / "archive"
+        archive_dir.mkdir()
+
+        pkt = {
+            "packet_id": "pkt-archived",
+            "title": "Archived task",
+            "description": "Test",
+            "owner": "author-a",
+            "created_by": "orchestrator",
+            "created_at": "2026-03-20T09:30:00Z",
+            "status": "completed",
+            "metadata": {"completed_at": "2026-03-20T11:00:00Z"},
+        }
+        (archive_dir / "pkt-archived.json").write_text(
+            json.dumps(pkt), encoding="utf-8"
+        )
+
+        attr = SessionAttribution(
+            session_id="s1",
+            lane_id="author-a",
+            quality=AttributionQuality.PARTIALLY_ATTRIBUTED.value,
+            attribution_timestamp="2026-03-20T10:00:00Z",
+            duration_minutes=30,
+        )
+
+        result = join_to_packets([attr], task_queue_root=tq_dir)
+
+        assert "pkt-archived" in result[0].matched_packets
+
+    def test_empty_task_queue(self, tmp_path: Path) -> None:
+        """Empty task queue leaves attributions unchanged."""
+        tq_dir = tmp_path / "task_queue"
+        tq_dir.mkdir()
+
+        attr = SessionAttribution(
+            session_id="s1",
+            lane_id="author-a",
+            quality=AttributionQuality.PARTIALLY_ATTRIBUTED.value,
+            attribution_timestamp="2026-03-20T10:00:00Z",
+            duration_minutes=30,
+        )
+
+        result = join_to_packets([attr], task_queue_root=tq_dir)
+
+        assert result[0].matched_packets == []
+        assert result[0].quality == AttributionQuality.PARTIALLY_ATTRIBUTED.value


### PR DESCRIPTION
## Summary
- Extend `token_economy.py` with lane inference from `project_path`, `AttributionQuality` enum, and `join_to_packets()` for session↔packet correlation
- Wire `ops.py usage attribute` CLI entry point
- Add 24 new tests (46 total) covering lane inference, attribution quality, packet joining, and edge cases

## Why
SP-4-03 Step 2 of the Token Economy Observability sub-plan. After Step 1 imported raw usage data, this step makes it operationally meaningful by attributing sessions to lanes (which worktree? which pool?) and correlating them with task packets (which work item was this session contributing to?).

## Key design decisions
- **Worktree-to-lane mapping** — canonical `_WORKTREE_TO_LANE` dict covers all 14 steward lanes (platform, browser-game, flex, control) plus main checkout detection
- **Three-tier quality** — `attributed` (lane + packet match), `partially_attributed` (lane only), `unattributed` (unknown project)
- **Pool classification** — `_classify_pool()` maps lanes to pool categories (platform, browser-game, flex, control)
- **Time-window overlap** — `join_to_packets()` uses generous temporal overlap between session active period and packet lifecycle, checking both active and archived packets
- **Parent directory traversal** — `infer_lane_from_path()` checks parent directories so sessions from subdirectories (e.g., `Bid-Euchre-steward-author/src/`) still match

## Repro / Validation
```bash
# Run unit tests
uv run python -m pytest tests/unit/test_ops_token_economy.py -v

# Run import + attribution pipeline (requires ~/.claude/usage-data/)
uv run python scripts/internal/ops.py usage import
uv run python scripts/internal/ops.py usage attribute

# Full validation
make check-quiet
```

## Tests
- `uv run python -m pytest tests/unit/test_ops_token_economy.py -v` — 46 tests, all passing
- `make check` — all checks passed

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: ops/token-economy-attribution
```

## Scope
| File | Change |
|------|--------|
| `src/bid_euchre/ops/token_economy.py` | Extend — add lane inference, attribution, packet joining |
| `scripts/internal/ops.py` | Add `usage attribute` CLI subcommand |
| `tests/unit/test_ops_token_economy.py` | Extend — 24 new tests (46 total) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)