### PR TITLE
test: reject single-quoted LANE_ID in scope-drift-guard hook

### DIFF
--- a/tests/unit/test_ops_scope.py
+++ b/tests/unit/test_ops_scope.py
@@ -596,8 +596,15 @@ class TestScopeDriftGuardHookContract:
         assert (
             "sys.argv[1]" in hook_content
         ), "Hook should read LANE_ID from sys.argv[1]"
-        # The shell argument should be passed after the closing quote
-        # of the -c string
+        # The shell argument should be double-quoted after the closing
+        # quote of the -c string so the variable expands correctly
         assert (
-            '"$LANE_ID"' in hook_content or "'$LANE_ID'" in hook_content
-        ), "Hook should pass $LANE_ID as a shell argument to python -c"
+            '"$LANE_ID"' in hook_content
+        ), "Hook should pass $LANE_ID as a double-quoted shell argument to python -c"
+
+    def test_no_single_quoted_lane_id_argument(self, hook_content: str) -> None:
+        """Single-quoted '$LANE_ID' must not appear — it prevents expansion."""
+        assert "'$LANE_ID'" not in hook_content, (
+            "Hook uses single-quoted '$LANE_ID' which prevents shell "
+            "variable expansion — use double quotes instead"
+        )


### PR DESCRIPTION
## Summary
- Tighten `test_lane_id_passed_via_sys_argv` to require double-quoted `"$LANE_ID"` only (was accepting single-quoted form which prevents shell expansion)
- Add `test_no_single_quoted_lane_id_argument` to explicitly reject `'$LANE_ID'`

## Why
Issue #1399: the hook contract test accepted `'$LANE_ID'` (single-quoted) as valid, but single quotes in bash prevent variable expansion — the hook would receive the literal string `$LANE_ID` instead of its value.

Closes #1399

## Scope
- `tests/unit/test_ops_scope.py` only

## Validation
```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/test_ops_scope.py -v  # 51 passed

# Tier 2 — full validation
make check-quiet  # ✓ All checks passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: fix/scope-drift-single-quote-1399
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)