### PR TITLE
docs: fix shared-surface table dashboard path in Phase 4 checkpoints

### DIFF
--- a/plans/agent_ops/4_remote_channel/checkpoints.md
+++ b/plans/agent_ops/4_remote_channel/checkpoints.md
@@ -49,7 +49,7 @@ implementation.
 | File | Primary Owner | Secondary Owner(s) | Serialization Rule |
 |------|---------------|---------------------|-------------------|
 | `scripts/internal/ops.py` | SP-4-02 | SP-4-03, SP-4-04 | SP-4-02 lands CLI hardening first; SP-4-03 rebases before adding token subcommands; SP-4-04 adds channel status CLI last (Step 6) |
-| `scripts/generate_dashboard.py` | SP-4-03 | SP-4-02, SP-4-04 | SP-4-03 owns new dashboard panels; SP-4-02 may add data feeds but not panel layout; SP-4-04 may add channel status indicator (Step 6, optional) |
+| `src/bid_euchre/ops/dashboard.py` | SP-4-03 | SP-4-02, SP-4-04 | SP-4-03 owns new dashboard panels; SP-4-02 may add data feeds but not panel layout; SP-4-04 may add channel status indicator (Step 6, optional) |
 | `src/bid_euchre/ops/monitor.py` | SP-4-02 | SP-4-04 | SP-4-02 owns stall recovery and auto-dispatch; SP-4-04 channel health check deferred to Platform-9c |
 | `.claude/tmux/steward-session.sh` | SP-4-04 | — | SP-4-04 adds `--channels telegram` flag and channel env vars; no other SP modifies the launcher |
 


### PR DESCRIPTION
## Summary
- Fix the shared-surface ownership table in Phase 4 checkpoints to reference the correct dashboard file
- Changed `scripts/generate_dashboard.py` → `src/bid_euchre/ops/dashboard.py`

## Why
Issue #1390: the shared-surface table pointed at `scripts/generate_dashboard.py` (the PR analytics Bollinger Band dashboard) but SP-4-03 (token economy observability) extends the ops dashboard at `src/bid_euchre/ops/dashboard.py`.

Closes #1390

## Scope
- `plans/agent_ops/4_remote_channel/checkpoints.md` only (docs-only change)

## Validation
```bash
make check-quiet  # ✓ All checks passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: fix/checkpoints-shared-surface-1390
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)