### PR TITLE
docs: make SP-4-04 Step 6 serialization conditional in checkpoints

### DIFF
--- a/plans/agent_ops/4_remote_channel/checkpoints.md
+++ b/plans/agent_ops/4_remote_channel/checkpoints.md
@@ -48,7 +48,7 @@ implementation.
 
 | File | Primary Owner | Secondary Owner(s) | Serialization Rule |
 |------|---------------|---------------------|-------------------|
-| `scripts/internal/ops.py` | SP-4-02 | SP-4-03, SP-4-04 | SP-4-02 lands CLI hardening first; SP-4-03 rebases before adding token subcommands; SP-4-04 adds channel status CLI last (Step 6) |
+| `scripts/internal/ops.py` | SP-4-02 | SP-4-03, SP-4-04 | SP-4-02 lands CLI hardening first; SP-4-03 rebases before adding token subcommands; SP-4-04 may add channel status CLI last (Step 6, optional) |
 | `src/bid_euchre/ops/dashboard.py` | SP-4-03 | SP-4-02, SP-4-04 | SP-4-03 owns new dashboard panels; SP-4-02 may add data feeds but not panel layout; SP-4-04 may add channel status indicator (Step 6, optional) |
 | `src/bid_euchre/ops/monitor.py` | SP-4-02 | SP-4-04 | SP-4-02 owns stall recovery and auto-dispatch; SP-4-04 channel health check deferred to Platform-9c |
 | `.claude/tmux/steward-session.sh` | SP-4-04 | — | SP-4-04 adds `--channels telegram` flag and channel env vars; no other SP modifies the launcher |


### PR DESCRIPTION
## Summary
- Make the `scripts/internal/ops.py` serialization rule for SP-4-04 conditional ("may add ... optional") instead of unconditional ("adds ... last")

## Why
Issue #1398: the shared-surface table stated SP-4-04 Step 6 as unconditional, but the sub-plan (`2026-03-23_platform-8a-telegram-transport.md`) marks Step 6 activities as optional. The dashboard row (line 52) already used the correct conditional form. This aligns line 51 to match.

Closes #1398

## Scope
- `plans/agent_ops/4_remote_channel/checkpoints.md` only (docs-only change)

## Validation
```bash
# Docs-only — pre-commit hooks pass, CI path-filter will skip heavy jobs
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: fix/sp4-04-serialization-1398
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)