### PR TITLE
docs: use canonical auction keys in stepwise engine plan

### DIFF
--- a/plans/browser_game/1_state_engine/sub/2026-03-14_stepwise_engine.md
+++ b/plans/browser_game/1_state_engine/sub/2026-03-14_stepwise_engine.md
@@ -52,7 +52,7 @@ class HandState:
     deal_id: int
 
     # Auction state
-    auction: List[dict] = field(default_factory=list)  # [{seat, action, n, contract, trump}, ...]
+    auction: List[dict] = field(default_factory=list)  # [{seat, n, action, contract, bid_type}, ...]
     current_high_bid: int = 0
     bidder_seat: Optional[int] = None
     winning_bid: Optional[int] = None


### PR DESCRIPTION
## Summary
- Fix auction entry comment in stepwise engine plan to use canonical keys matching the actual hosted_play engine implementation

## Why
The plan's `HandState.auction` comment listed `{seat, action, n, contract, trump}` but the actual `_process_bid` method in `src/bid_euchre/hosted_play/engine.py` creates entries with `{seat, n, action, contract, bid_type}`. The `trump` key was from the simulation format, not the engine format.

## Repro / Validation
```bash
# Docs-only change — verify with make check
make check-quiet
```

## Tests
```
make check-quiet   # ✓ All checks passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

Closes #1388 (partial — addresses finding 1 of 3; remaining findings target agent_ops plans)

🤖 Generated with [Claude Code](https://claude.com/claude-code)