### PR TITLE
fix: make backup diff creation atomic for same-second resets

### DIFF
--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -959,13 +959,6 @@ def reset_worktree(
 
         if is_dirty and force:
             ts = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%S")
-            diff_path = Path(f"/tmp/{lane_id}_{ts}.diff")
-            # Disambiguate if a backup with this timestamp already exists
-            # (multiple resets within the same second)
-            seq = 1
-            while diff_path.exists():
-                diff_path = Path(f"/tmp/{lane_id}_{ts}_{seq}.diff")
-                seq += 1
             diff_result = subprocess.run(
                 ["git", "diff", "HEAD"],
                 cwd=worktree_path,
@@ -974,7 +967,18 @@ def reset_worktree(
                 timeout=15,
                 text=True,
             )
-            diff_path.write_text(diff_result.stdout)
+            # Atomic exclusive creation — avoids TOCTOU race when multiple
+            # resets fire within the same second.
+            diff_path = Path(f"/tmp/{lane_id}_{ts}.diff")
+            seq = 1
+            while True:
+                try:
+                    with diff_path.open("x") as f:
+                        f.write(diff_result.stdout)
+                    break
+                except FileExistsError:
+                    diff_path = Path(f"/tmp/{lane_id}_{ts}_{seq}.diff")
+                    seq += 1
             logger.warning(
                 "Worktree for %s was dirty — diff saved to %s",
                 lane_id,

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -2011,6 +2011,46 @@ class TestResetWorktree:
 
     @patch(f"{_WORKER_POOL}._resolve_worktree_path")
     @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_dirty_worktree_force_atomic_collision(
+        self, mock_run: MagicMock, mock_resolve: MagicMock, tmp_path: Path
+    ) -> None:
+        """Same-second resets use atomic exclusive creation to avoid TOCTOU race."""
+        mock_resolve.return_value = "/tmp/wt-author-a"
+        dirty_status = self._make_status_dirty()
+        diff_mock = self._make_diff("second diff content")
+        ok = MagicMock(returncode=0)
+        mock_run.side_effect = [dirty_status, diff_mock, ok, ok]
+
+        from datetime import datetime, timezone
+
+        frozen = datetime(2026, 1, 15, 12, 30, 45, tzinfo=timezone.utc)
+        ts = "20260115T123045"
+
+        # Pre-create the base path to simulate a same-second collision
+        base_diff = Path(f"/tmp/author-a_{ts}.diff")
+        base_diff.write_text("first diff content")
+
+        try:
+            with patch(f"{_WORKER_POOL}.datetime") as mock_dt:
+                mock_dt.now.return_value = frozen
+                mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+                result = reset_worktree("author-a", force=True)
+
+            assert result.executed is True
+            assert result.error is None
+
+            # Should have created the _1 suffixed file
+            seq_diff = Path(f"/tmp/author-a_{ts}_1.diff")
+            assert seq_diff.exists()
+            assert seq_diff.read_text() == "second diff content"
+            # Original file should be untouched
+            assert base_diff.read_text() == "first diff content"
+        finally:
+            base_diff.unlink(missing_ok=True)
+            Path(f"/tmp/author-a_{ts}_1.diff").unlink(missing_ok=True)
+
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path")
+    @patch(f"{_WORKER_POOL}.subprocess.run")
     def test_clean_worktree_with_force(
         self, mock_run: MagicMock, mock_resolve: MagicMock
     ) -> None:


### PR DESCRIPTION
## Plan
N/A — atomicity fix per issue #1393 (follow-up from PR #1389 review).

## Summary
- Replaced TOCTOU race in `reset_worktree()` backup diff creation with atomic exclusive file creation via `open("x")`
- Moved `git diff HEAD` subprocess call before the file write loop so diff content is captured once regardless of write retries
- Added test for same-second collision scenario

## Why
The previous pattern checked `diff_path.exists()` then wrote with `diff_path.write_text()` — another process could create the same file between check and write. `open("x")` atomically creates-or-raises `FileExistsError`, eliminating the race window.

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/test_ops_worker_pool.py::TestResetWorktree -v` — 8/8 passed
- `make check-quiet` — all checks passed

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_worker_pool.py::TestResetWorktree -v` — 8 passed
- [x] `make check-quiet` — all passed

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git worktree list` (excerpt):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b  1fb65f6f [fix/atomic-backup-diff-1393]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

Closes #1393