### PR TITLE
ops: add token economy dashboard surfaces (SP-4-03 Step 4)

### DIFF
--- a/src/bid_euchre/ops/dashboard.py
+++ b/src/bid_euchre/ops/dashboard.py
@@ -201,6 +201,7 @@ class DashboardView:
     active_task_count: int = 0
     blocked_task_count: int = 0
     warning_count: int = 0
+    token_economy: dict[str, Any] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -392,6 +393,16 @@ def build_dashboard_view(
     attention_items = _derive_attention_items(report)
     inbox_highlights = _derive_inbox_highlights(bus_root, now=now)
 
+    # Token economy (best-effort — never fail dashboard on missing data)
+    token_economy: dict[str, Any] = {}
+    try:
+        from bid_euchre.ops.token_economy import dashboard_token_economy
+
+        te_output_dir = (runtime_dir or Path(".claude/runtime")) / "token_economy"
+        token_economy = dashboard_token_economy(output_dir=te_output_dir)
+    except Exception:
+        pass  # Token economy data is optional
+
     return DashboardView(
         generated_at=now.isoformat(),
         foreground=DashboardSection(
@@ -408,6 +419,7 @@ def build_dashboard_view(
         active_task_count=len(report.active_tasks),
         blocked_task_count=len(report.blocked_tasks),
         warning_count=len(report.warnings),
+        token_economy=token_economy,
     )
 
 
@@ -560,6 +572,42 @@ def format_dashboard_text(
     if view.warning_count > 0:
         lines.append(f"Warnings: {view.warning_count}")
 
+    # Token economy
+    te = view.token_economy
+    if te:
+        lines.append("")
+        lines.append("Token Economy")
+        overview = te.get("overview", {})
+        if overview:
+            lines.append(
+                f"  Tokens: {overview.get('total_tokens', 0):,}"
+                f" ({overview.get('session_count', 0)} sessions"
+                f", {overview.get('total_git_commits', 0)} commits)"
+            )
+            lines.append(
+                f"  Efficiency: {overview.get('tokens_per_hour', 0):,.0f} tok/hr"
+                f", {overview.get('output_input_ratio', 0):.1f}x out/in"
+                f", {overview.get('net_lines', 0):+,d} net lines"
+            )
+
+        top_lanes = te.get("top_lanes", [])
+        if top_lanes:
+            lines.append("  Top lanes:")
+            for tl in top_lanes[:3]:
+                tpc = tl.get("tokens_per_commit")
+                tpc_str = f"{tpc:,.0f} tok/commit" if tpc else "—"
+                lines.append(
+                    f"    {tl['lane_id']:<18s} {tl['total_tokens']:>10,d} tok"
+                    f"  {tpc_str}"
+                )
+
+        anti_patterns = te.get("anti_patterns", [])
+        if anti_patterns:
+            lines.append(f"  Anti-patterns: {len(anti_patterns)} detected")
+            for ap in anti_patterns[:3]:
+                sev = ap.get("severity", "?")
+                lines.append(f"    [{sev}] {ap.get('name', '?')}")
+
     return "\n".join(lines)
 
 
@@ -594,4 +642,5 @@ def format_dashboard_json(view: DashboardView) -> dict[str, Any]:
         "attention_items": [asdict(item) for item in view.attention_items],
         "inbox_highlights": [asdict(h) for h in view.inbox_highlights],
         "task_queue": view.task_queue_summary,
+        "token_economy": view.token_economy or None,
     }

--- a/src/bid_euchre/ops/token_economy.py
+++ b/src/bid_euchre/ops/token_economy.py
@@ -18,6 +18,8 @@ throughput_summary
     Compute throughput-normalized token metrics.
 detect_anti_patterns
     Flag high-waste usage patterns.
+dashboard_token_economy
+    Build a dashboard-ready dict with token economy sections.
 """
 
 from __future__ import annotations
@@ -1252,3 +1254,119 @@ def detect_anti_patterns(*, output_dir: Path | None = None) -> list[AntiPattern]
     findings.sort(key=lambda x: severity_order.get(x.severity, 99))
 
     return findings
+
+
+# ---------------------------------------------------------------------------
+# Dashboard surface — JSON-serializable token economy snapshot
+# ---------------------------------------------------------------------------
+
+
+def dashboard_token_economy(*, output_dir: Path | None = None) -> dict[str, Any]:
+    """Build a dashboard-ready dict with token economy sections.
+
+    Returns a JSON-serializable dict containing:
+    - ``overview``: aggregate metrics
+    - ``top_lanes``: most expensive lanes
+    - ``efficient_lanes``: cheapest productive lanes
+    - ``throughput``: throughput-normalized metrics
+    - ``anti_patterns``: detected anti-patterns
+
+    Returns an empty dict (``{}``) when no usage data is imported,
+    ensuring the dashboard renders cleanly without token data.
+
+    Parameters
+    ----------
+    output_dir
+        Path to the token economy store. Defaults to repo runtime path.
+    """
+    try:
+        resolved_output = _resolve_output_dir(output_dir)
+    except ValueError:
+        return {}
+
+    sessions = _load_sessions(resolved_output)
+    if not sessions:
+        return {}
+
+    # Overview
+    s = usage_summary(output_dir=resolved_output)
+    overview = {
+        "session_count": s.session_count,
+        "total_tokens": s.total_tokens,
+        "total_input_tokens": s.total_input_tokens,
+        "total_output_tokens": s.total_output_tokens,
+        "total_duration_minutes": s.total_duration_minutes,
+        "net_lines": s.net_lines,
+        "total_git_commits": s.total_git_commits,
+        "output_input_ratio": round(s.output_input_ratio, 1),
+        "tokens_per_hour": round(s.tokens_per_hour, 0),
+        "time_range_start": s.time_range_start,
+        "time_range_end": s.time_range_end,
+    }
+
+    # Top expensive lanes
+    lanes = lane_summary(output_dir=resolved_output)
+    top_lanes = [
+        {
+            "lane_id": ls.lane_id,
+            "pool": ls.pool,
+            "total_tokens": ls.total_tokens,
+            "session_count": ls.session_count,
+            "git_commits": ls.git_commits,
+            "tokens_per_commit": round(ls.tokens_per_commit, 0)
+            if ls.tokens_per_commit
+            else None,
+            "net_lines": ls.net_lines,
+        }
+        for ls in lanes[:5]  # top 5 most expensive
+    ]
+
+    # Cheapest productive lanes (have commits, sorted by tokens_per_commit asc)
+    productive = [ls for ls in lanes if ls.git_commits > 0]
+    productive.sort(
+        key=lambda x: x.tokens_per_commit if x.tokens_per_commit else float("inf")
+    )
+    efficient_lanes = [
+        {
+            "lane_id": ls.lane_id,
+            "pool": ls.pool,
+            "total_tokens": ls.total_tokens,
+            "git_commits": ls.git_commits,
+            "tokens_per_commit": round(ls.tokens_per_commit, 0)
+            if ls.tokens_per_commit
+            else None,
+            "net_lines": ls.net_lines,
+        }
+        for ls in productive[:5]  # top 5 most efficient
+    ]
+
+    # Throughput
+    t = throughput_summary(output_dir=resolved_output)
+    throughput = {
+        "tokens_per_commit": round(t.tokens_per_commit, 0),
+        "tokens_per_net_line": round(t.tokens_per_net_line, 0),
+        "tokens_per_hour": round(t.tokens_per_hour, 0),
+        "output_input_ratio": round(t.output_input_ratio, 1),
+        "tool_errors_per_1k_tokens": round(t.tool_errors_per_1k_tokens, 2),
+        "assistant_per_user_message": round(t.assistant_per_user_message, 1),
+    }
+
+    # Anti-patterns
+    findings = detect_anti_patterns(output_dir=resolved_output)
+    anti_patterns = [
+        {
+            "pattern_id": f.pattern_id,
+            "name": f.name,
+            "severity": f.severity,
+            "description": f.description,
+        }
+        for f in findings
+    ]
+
+    return {
+        "overview": overview,
+        "top_lanes": top_lanes,
+        "efficient_lanes": efficient_lanes,
+        "throughput": throughput,
+        "anti_patterns": anti_patterns,
+    }

--- a/tests/unit/test_ops_token_economy.py
+++ b/tests/unit/test_ops_token_economy.py
@@ -29,6 +29,7 @@ from bid_euchre.ops.token_economy import (
     ThroughputMetrics,
     UsageSummary,
     attribute_sessions,
+    dashboard_token_economy,
     detect_anti_patterns,
     import_usage_data,
     infer_lane_from_path,
@@ -1167,3 +1168,126 @@ class TestDetectAntiPatterns:
         frag = [f for f in findings if f.pattern_id == "fragmentation"]
         assert len(frag) == 1
         assert frag[0].severity == "low"
+
+
+# ---------------------------------------------------------------------------
+# Dashboard token economy tests
+# ---------------------------------------------------------------------------
+
+
+class TestDashboardTokenEconomy:
+    def test_dashboard_with_data(self, output_dir: Path) -> None:
+        """Dashboard builds complete sections when data exists."""
+        sessions = [
+            _make_session_record(
+                "s1",
+                input_tokens=100,
+                output_tokens=400,
+                duration_minutes=30,
+                git_commits=2,
+                lines_added=50,
+                lines_removed=10,
+                project_path="/Users/foo/Bid-Euchre-steward-author",
+            ),
+            _make_session_record(
+                "s2",
+                input_tokens=200,
+                output_tokens=800,
+                duration_minutes=45,
+                git_commits=1,
+                lines_added=30,
+                lines_removed=5,
+                project_path="/Users/foo/Bid-Euchre-steward-flex-a",
+            ),
+        ]
+        _write_sessions(output_dir, sessions)
+
+        # Write attributions for lane breakdown
+        attributions = [
+            {
+                "session_id": "s1",
+                "lane_id": "author-a",
+                "worktree_class": "platform",
+                "input_tokens": 100,
+                "output_tokens": 400,
+                "git_commits": 2,
+                "lines_added": 50,
+                "lines_removed": 10,
+                "duration_minutes": 30,
+            },
+            {
+                "session_id": "s2",
+                "lane_id": "flex-a",
+                "worktree_class": "flex",
+                "input_tokens": 200,
+                "output_tokens": 800,
+                "git_commits": 1,
+                "lines_added": 30,
+                "lines_removed": 5,
+                "duration_minutes": 45,
+            },
+        ]
+        _write_attributions(output_dir, attributions)
+
+        result = dashboard_token_economy(output_dir=output_dir)
+
+        assert isinstance(result, dict)
+        assert "overview" in result
+        assert "top_lanes" in result
+        assert "efficient_lanes" in result
+        assert "throughput" in result
+        assert "anti_patterns" in result
+
+        # Overview checks
+        assert result["overview"]["session_count"] == 2
+        assert result["overview"]["total_tokens"] == 1500
+        assert result["overview"]["total_git_commits"] == 3
+
+        # Top lanes
+        assert len(result["top_lanes"]) == 2
+        assert result["top_lanes"][0]["lane_id"] == "flex-a"  # most expensive
+
+        # Efficient lanes (sorted by tokens_per_commit asc)
+        assert len(result["efficient_lanes"]) == 2
+
+        # Throughput
+        assert result["throughput"]["tokens_per_commit"] > 0
+
+    def test_dashboard_empty_store(self, output_dir: Path) -> None:
+        """Dashboard returns empty dict when no data exists."""
+        result = dashboard_token_economy(output_dir=output_dir)
+        assert result == {}
+
+    def test_dashboard_null_safe(self, output_dir: Path) -> None:
+        """Dashboard handles sessions with missing optional fields."""
+        sessions = [
+            {
+                "session_id": "s1",
+                "start_time": "2026-03-20T10:00:00Z",
+                # Minimal fields — many optional fields missing
+            },
+        ]
+        _write_sessions(output_dir, sessions)
+
+        result = dashboard_token_economy(output_dir=output_dir)
+
+        assert result["overview"]["session_count"] == 1
+        assert result["overview"]["total_tokens"] == 0
+
+    def test_dashboard_anti_patterns_included(self, output_dir: Path) -> None:
+        """Dashboard includes anti-pattern findings."""
+        sessions = [
+            _make_session_record(
+                "s1",
+                input_tokens=5000,
+                output_tokens=50000,
+                lines_added=20,
+                lines_removed=10,  # net 10 → 5500 tok/net line
+            ),
+        ]
+        _write_sessions(output_dir, sessions)
+
+        result = dashboard_token_economy(output_dir=output_dir)
+
+        assert len(result["anti_patterns"]) > 0
+        assert result["anti_patterns"][0]["pattern_id"] == "verbosity_waste"


### PR DESCRIPTION
## Summary
- Add `dashboard_token_economy()` to `token_economy.py` — builds JSON-serializable dashboard dict with overview, top/efficient lanes, throughput, and anti-patterns
- Extend `DashboardView` with `token_economy` field wired into both text and JSON formatters
- Integration is best-effort: dashboard renders cleanly when no usage data exists

## Why
SP-4-03 Step 4 of the Token Economy Observability sub-plan. After Steps 1-3 built the import/attribution/CLI pipeline, this step surfaces token economy data in the existing steward dashboard — the primary operator supervision tool. Operators can now see token efficiency alongside lane status in a single view.

## Key design decisions
- **Extend existing dashboard, don't create a second one** — `DashboardView` gets a new `token_economy` dict field
- **Best-effort integration** — `build_dashboard_view()` wraps token economy call in try/except so missing data never breaks the dashboard
- **Text formatter shows top 3** — lanes and anti-patterns are truncated to top 3 in text view for readability; JSON view includes all
- **Efficient lanes** sorted by tokens_per_commit ascending — highlights cheapest productive lanes

## Dashboard sections added

| Section | Content |
|---------|---------|
| Overview | Total tokens, sessions, commits, efficiency, time range |
| Top lanes | 5 most expensive lanes by total tokens |
| Efficient lanes | 5 cheapest productive lanes (commits > 0) |
| Throughput | Tokens/commit, tokens/net line, tokens/hour |
| Anti-patterns | All detected waste patterns with severity |

## Repro / Validation
```bash
# Run unit tests (64 total)
uv run python -m pytest tests/unit/test_ops_token_economy.py -v

# Run the full pipeline + dashboard
uv run python scripts/internal/ops.py usage import
uv run python scripts/internal/ops.py usage attribute
uv run python scripts/internal/ops.py dashboard --json | python3 -m json.tool | grep -A5 token_economy

# Full validation
make check-quiet
```

## Tests
- `uv run python -m pytest tests/unit/test_ops_token_economy.py -v` — 64 tests, all passing
- `uv run python -m pytest tests/unit/test_ops_dashboard.py -v` — 35 existing dashboard tests, all passing
- `make check-quiet` — all checks passed

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: ops/token-economy-dashboard
```

## Scope
| File | Change |
|------|--------|
| `src/bid_euchre/ops/token_economy.py` | Extend — add `dashboard_token_economy()` |
| `src/bid_euchre/ops/dashboard.py` | Extend — add `token_economy` field to `DashboardView`, wire into builder + formatters |
| `tests/unit/test_ops_token_economy.py` | Extend — 4 new tests (64 total) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)