### PR TITLE
fix: suppress async hook TUI noise on all exit paths

### DIFF
--- a/.claude/hooks/post-bash-dispatch.sh
+++ b/.claude/hooks/post-bash-dispatch.sh
@@ -70,9 +70,12 @@ run_hook "$HOOKS_DIR/post-tool-daemon-notify.sh"
 run_hook "$HOOKS_DIR/post-task-event.sh"
 run_hook "$HOOKS_DIR/post-merge-notify.sh"
 
-# Return combined output (if any hooks produced context)
+# Return combined output (if any hooks produced context),
+# otherwise suppress TUI notification (issue #1360).
 if [ -n "$COMBINED_CONTEXT" ]; then
     echo "$COMBINED_CONTEXT" | jq -Rs '{hookSpecificOutput: {hookEventName: "PostToolUse", additionalContext: .}}'
+else
+    echo '{"suppressOutput": true}'
 fi
 
 exit 0

--- a/.claude/hooks/post-write-check.sh
+++ b/.claude/hooks/post-write-check.sh
@@ -17,11 +17,13 @@ FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')
 
 # Only check Python files
 if [[ "$FILE_PATH" != *.py ]]; then
+    echo '{"suppressOutput": true}'
     exit 0
 fi
 
 # Only check if file exists
 if [[ ! -f "$FILE_PATH" ]]; then
+    echo '{"suppressOutput": true}'
     exit 0
 fi
 
@@ -80,6 +82,9 @@ if [ ${#findings[@]} -gt 0 ]; then
   }
 }
 EOF
+else
+    # No findings — suppress TUI notification (issue #1360)
+    echo '{"suppressOutput": true}'
 fi
 
 exit 0

--- a/.claude/hooks/session-sync-worktree.sh
+++ b/.claude/hooks/session-sync-worktree.sh
@@ -22,7 +22,7 @@ fi
 # Guard: skip if working tree is dirty
 # --------------------------------------------------------------------------
 if [[ -n "$(git -C "$PROJECT_DIR" status --porcelain 2>/dev/null)" ]]; then
-  echo "${LOG_PREFIX} WARNING: Dirty working tree — skipping auto-sync. Clean or stash changes manually."
+  echo >&2 "${LOG_PREFIX} WARNING: Dirty working tree — skipping auto-sync. Clean or stash changes manually."
   exit 0
 fi
 
@@ -32,13 +32,13 @@ fi
 CURRENT_BRANCH="$(git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || echo "")"
 
 if [[ -z "$CURRENT_BRANCH" ]]; then
-  echo "${LOG_PREFIX} WARNING: Detached HEAD — skipping auto-sync."
+  echo >&2 "${LOG_PREFIX} WARNING: Detached HEAD — skipping auto-sync."
   exit 0
 fi
 
 # Already on main — just pull
 if [[ "$CURRENT_BRANCH" == "main" ]]; then
-  echo "${LOG_PREFIX} Already on main — pulling latest."
+  echo >&2 "${LOG_PREFIX} Already on main — pulling latest."
   git -C "$PROJECT_DIR" pull origin main --ff-only 2>/dev/null || true
   exit 0
 fi
@@ -47,7 +47,7 @@ fi
 # Fail closed: if gh is unavailable or auth fails, skip sync rather than
 # risk resetting a branch that has an open PR we can't see.
 PR_STATE="$(gh pr view "$CURRENT_BRANCH" --repo Questuart/Bid-Euchre --json state --jq '.state' 2>/dev/null)" || {
-  echo "${LOG_PREFIX} WARNING: Could not query PR state (gh unavailable or auth error) — skipping auto-sync."
+  echo >&2 "${LOG_PREFIX} WARNING: Could not query PR state (gh unavailable or auth error) — skipping auto-sync."
   exit 0
 }
 
@@ -55,7 +55,7 @@ PR_STATE="$(gh pr view "$CURRENT_BRANCH" --repo Questuart/Bid-Euchre --json stat
 PR_STATE="${PR_STATE:-NONE}"
 
 if [[ "$PR_STATE" == "OPEN" ]]; then
-  echo "${LOG_PREFIX} Branch '$CURRENT_BRANCH' has an open PR — skipping auto-sync."
+  echo >&2 "${LOG_PREFIX} Branch '$CURRENT_BRANCH' has an open PR — skipping auto-sync."
   exit 0
 fi
 
@@ -67,21 +67,21 @@ git -C "$PROJECT_DIR" fetch origin main --quiet 2>/dev/null || true
 
 AHEAD="$(git -C "$PROJECT_DIR" rev-list origin/main..HEAD --count 2>/dev/null || echo "unknown")"
 if [[ "$AHEAD" != "0" ]]; then
-  echo "${LOG_PREFIX} WARNING: Branch '$CURRENT_BRANCH' is ${AHEAD} commit(s) ahead of origin/main — skipping auto-sync to avoid losing unpushed work."
+  echo >&2 "${LOG_PREFIX} WARNING: Branch '$CURRENT_BRANCH' is ${AHEAD} commit(s) ahead of origin/main — skipping auto-sync to avoid losing unpushed work."
   exit 0
 fi
 
 # --------------------------------------------------------------------------
 # Safe to sync: no open PR, no unpushed commits, clean working tree
 # --------------------------------------------------------------------------
-echo "${LOG_PREFIX} Syncing '$CURRENT_BRANCH' → main (PR state: ${PR_STATE})"
+echo >&2 "${LOG_PREFIX} Syncing '$CURRENT_BRANCH' → main (PR state: ${PR_STATE})"
 
 # Switch to tracking origin/main. We can't checkout 'main' directly because
 # it's used by the primary worktree — instead reset the current branch to
 # origin/main, giving us the same effect.
 git -C "$PROJECT_DIR" reset --hard origin/main 2>/dev/null || {
-  echo "${LOG_PREFIX} WARNING: Failed to reset to origin/main — skipping."
+  echo >&2 "${LOG_PREFIX} WARNING: Failed to reset to origin/main — skipping."
   exit 0
 }
 
-echo "${LOG_PREFIX} Synced to $(git -C "$PROJECT_DIR" log --oneline -1)"
+echo >&2 "${LOG_PREFIX} Synced to $(git -C "$PROJECT_DIR" log --oneline -1)"

--- a/tests/unit/test_hook_dispatchers.py
+++ b/tests/unit/test_hook_dispatchers.py
@@ -6,7 +6,7 @@ verify:
   - Normal commands pass through with suppressOutput
   - Blocking commands propagate exit code 2
   - Rule-loader context injection works through the dispatcher
-  - PostToolUse dispatcher produces no output for non-matching commands
+  - PostToolUse dispatcher suppresses TUI notification for non-matching commands
   - Background process stdout is properly redirected (post-push-ci-check fix)
 """
 
@@ -117,9 +117,9 @@ class TestPostBashDispatch:
 
     SCRIPT = "post-bash-dispatch.sh"
 
-    def test_normal_command_produces_no_output(self) -> None:
-        """Non-matching commands should produce no output."""
-        rc, raw, _out = _run_hook(
+    def test_normal_command_suppresses_output(self) -> None:
+        """Non-matching commands should suppress TUI notification (issue #1360)."""
+        rc, _raw, out = _run_hook(
             self.SCRIPT,
             {
                 "tool_input": {"command": "git status"},
@@ -127,11 +127,12 @@ class TestPostBashDispatch:
             },
         )
         assert rc == 0
-        assert raw == ""
+        assert out is not None
+        assert out.get("suppressOutput") is True
 
-    def test_failed_command_produces_no_output(self) -> None:
-        """Failed commands should produce no output (exit_code != 0)."""
-        rc, raw, _out = _run_hook(
+    def test_failed_command_suppresses_output(self) -> None:
+        """Failed commands should suppress TUI notification (issue #1360)."""
+        rc, _raw, out = _run_hook(
             self.SCRIPT,
             {
                 "tool_input": {"command": "git push origin main"},
@@ -139,7 +140,8 @@ class TestPostBashDispatch:
             },
         )
         assert rc == 0
-        assert raw == ""
+        assert out is not None
+        assert out.get("suppressOutput") is True
 
 
 class TestPreBashDispatchTimeout:


### PR DESCRIPTION
## Plan
- N/A (bugfix from issue #1360)

## Summary
- Add `{"suppressOutput": true}` to all hook exit paths that previously output nothing
- Redirect session-sync-worktree.sh echo messages to stderr to prevent plain text TUI noise
- Update dispatcher tests to expect suppressOutput JSON

## Why
Hooks that exit with `exit 0` and no stdout output cause Claude Code to display a generic "Async hook PreToolUse/PostToolUse completed" TUI notification. This fires on every Bash/Edit/Write tool call, cluttering the TUI for author lanes. Returning `{"suppressOutput": true}` tells Claude Code to suppress these notifications.

## Changes

| Hook | Fix |
|------|-----|
| `post-bash-dispatch.sh` | Output `{"suppressOutput": true}` when no sub-hooks produce context |
| `post-write-check.sh` | Output `{"suppressOutput": true}` on early exits (non-Python, missing file) and no-findings path |
| `session-sync-worktree.sh` | Redirect all `echo` messages to stderr (`>&2`) so plain text doesn't appear as hook output |

## Repro / Validation
**Command(s) run:**
- `make check-quiet` — all checks pass (6182 tests)
- `uv run python -m pytest tests/unit/test_hook_dispatchers.py -v` — all 8 tests pass

**Config (if applicable):**
- N/A

**Seed (if applicable):**
- N/A

## Tests
- [x] Other: `make check-quiet` passes
- [x] Other: Updated 2 existing tests in `TestPostBashDispatch` to verify suppressOutput

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): Reduced TUI noise — fewer "Async hook completed" messages

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a  5125b0cd [fix/hook-tui-noise]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

Closes #1360