### PR TITLE
docs: close Phase 1 state-engine checkpoints

### DIFF
--- a/plans/browser_game/1_state_engine/checkpoints.md
+++ b/plans/browser_game/1_state_engine/checkpoints.md
@@ -4,6 +4,7 @@
 **Phase/Rung:** `1_state_engine`
 **Sub-plan:** `SP-1-01` → `1_state_engine/sub/2026-03-14_stepwise_engine.md`
 **Last updated:** 2026-03-23
+**Phase status:** CLOSED — all steps complete.
 
 ---
 
@@ -12,24 +13,30 @@
 | Step | Status | Date | Agent/Session | Notes |
 |------|--------|------|---------------|-------|
 | Step 0: Read sub-plan SP-1-01 and verify Phase 0 complete | COMPLETE | 2026-03-23 | Codex | Phase 0 closed after BG-1 plus `web/schema.sql`; Phase 1 is now runnable. |
-| Step 1: Implement state dataclasses (`state.py`) | COMPLETE | 2026-03-23 | Codex | Added `state.py` with dataclasses plus nested JSON serialization helpers; exported from `bid_euchre.hosted_play` and covered by unit tests. |
-| Step 2: Implement MatchEngine core (`engine.py`) | PENDING | -- | -- | start_match, submit_human_bid, submit_human_card, _advance_ai. See SP-1-01 §Engine Interface. |
-| Step 3: Implement serialization | PENDING | -- | -- | serialize/deserialize round-trip. Cards as [suit, rank]. |
-| Step 4: Implement get_visible_state | PENDING | -- | -- | Returns only seat 0's hand, current trick, scores. Hides other hands. |
-| Step 5: Write unit tests | PENDING | -- | -- | 11 required tests listed in SP-1-01 §Required Tests. |
-| Step 6: Run validation | IN_PROGRESS | 2026-03-23 | Codex | Running targeted hosted-play state tests before starting engine work. |
+| Step 1: Implement state dataclasses (`state.py`) | COMPLETE | 2026-03-23 | Codex | Added `state.py` with dataclasses plus nested JSON serialization helpers; exported from `bid_euchre.hosted_play` and covered by unit tests. PR #1380. |
+| Step 2: Implement MatchEngine core (`engine.py`) | COMPLETE | 2026-03-23 | brws-author-a | `start_match`, `submit_human_bid`, `submit_human_card`, `_advance_ai` — all implemented. PR #1392 (1135 lines). |
+| Step 3: Implement serialization | COMPLETE | 2026-03-23 | brws-author-a | `serialize()`/`deserialize()` delegate to `state.to_dict()`/`MatchState.from_dict()`. Cards as [suit, rank]. PR #1380 (state), PR #1392 (engine API). |
+| Step 4: Implement get_visible_state | COMPLETE | 2026-03-23 | brws-author-a | Returns seat 0's hand, current trick, scores, auction, phase. Hides other players' hands. PR #1392. |
+| Step 5: Write unit tests | COMPLETE | 2026-03-23 | brws-author-a | All 11 required tests from SP-1-01 plus bonus tests (bid order, determinism). PR #1392, PR #1402 (state serialization coverage). |
+| Step 6: Run validation | COMPLETE | 2026-03-23 | brws-author-a | `make check-quiet` passes. All hosted-play tests green. |
 
 ## Active Sub-Plans
 
 | Sub-Plan ID | File | Status | Blocking Step |
 |-------------|------|--------|---------------|
-| SP-1-01 | `1_state_engine/sub/2026-03-14_stepwise_engine.md` | in_progress | Step 2 |
+| SP-1-01 | `1_state_engine/sub/2026-03-14_stepwise_engine.md` | complete | — |
 
 ## Blockers
 
 - [x] ~~Phase 0 not complete.~~
 
 ## Session Log
+
+### 2026-03-23 — brws-author-a (checkpoint closure)
+- Verified: All 6 implementation steps complete with merged PRs.
+- PRs: #1380 (foundation + state.py), #1392 (MatchEngine core), #1402 (state serialization tests).
+- All 11 required tests from SP-1-01 present and passing.
+- Phase 1 CLOSED.
 
 ### 2026-03-23 — Codex
 - Completed: Phase 0 prerequisites are now satisfied, so Step 0 is closed.

--- a/plans/browser_game/1_state_engine/sub/2026-03-14_stepwise_engine.md
+++ b/plans/browser_game/1_state_engine/sub/2026-03-14_stepwise_engine.md
@@ -2,7 +2,7 @@
 
 **ID:** SP-1-01
 **Parent:** Phase 1 — State Engine
-**Status:** in_progress
+**Status:** complete
 **Governing plan:** `plans/browser_game/governing_plan.md`
 **Created:** 2026-03-14
 
@@ -241,4 +241,18 @@ uv run python -m pytest tests/unit/hosted_play/test_engine.py -v
 
 ## Outcome
 
-_To be filled after implementation._
+**Completed 2026-03-23.** All deliverables shipped across three merged PRs:
+
+| PR | Title | Key Deliverables |
+|----|-------|-----------------|
+| #1380 | browser-game: lock v1 serving contract and add hosted-play state foundations | `state.py` with dataclasses + JSON serialization helpers, `schema.sql`, serving contract |
+| #1392 | browser-game: implement Phase 1 MatchEngine core (engine.py) | `engine.py` (450 lines) — full step-based engine, `test_engine.py` (683 lines) — all 11 required tests + bonus |
+| #1402 | test: add comprehensive hosted-play state serialization coverage | Additional serialization test coverage for state dataclasses |
+
+**Files created:**
+- `src/bid_euchre/hosted_play/state.py` — State dataclasses (TrickState, TrickResult, HandState, MatchState)
+- `src/bid_euchre/hosted_play/engine.py` — MatchEngine with full step-based state machine
+- `tests/unit/hosted_play/test_engine.py` — 11 required tests + TestBidOrder, TestMatchDeterminism
+- `tests/unit/hosted_play/test_state.py` — State serialization round-trip tests
+
+**All delegation points honored:** `generate_deal`, `get_legal_indices`, `trick_winner`, `compute_points`, `BiddingPolicy.choose_bid`, `Strategy.choose_card` — no logic duplication.


### PR DESCRIPTION
## Plan
`plans/browser_game/1_state_engine/checkpoints.md` / `plans/browser_game/1_state_engine/sub/2026-03-14_stepwise_engine.md`

## Summary
- Mark Phase 1 (state engine) Steps 2–6 as COMPLETE with PR references (#1380, #1392, #1402)
- Mark sub-plan SP-1-01 as complete and fill in Outcome section
- Close Phase 1 — all implementation deliverables verified and merged

## Why
Three PRs implementing the full Phase 1 state engine have been merged but the
checkpoints still showed Steps 2–5 as PENDING. This updates the checkpoints to
reflect the actual state and formally closes Phase 1 so Phase 2 work can begin.

## Repro / Validation
**Command(s) run:**
- `make check-quiet` ✅
- Verified all 3 PRs are merged: `gh pr view {1380,1392,1402} --json state`
- Verified engine.py implements: start_match, submit_human_bid, submit_human_card, serialize, deserialize, get_visible_state
- Verified test_engine.py has all 11 required tests from SP-1-01

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `make check-quiet` passes (docs-only, no code changes)
- [ ] ~~Integration (if engine/rules changed)~~: N/A — docs only

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git worktree list`:
```
Bid-Euchre-steward-brws-author-a  46bdce93 [docs/phase1-checkpoint-closure]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it — N/A, docs-only
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)