### PR TITLE
ops: add lane refresh CLI command

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -2324,6 +2324,55 @@ def cmd_review_check(args: argparse.Namespace) -> int:
     return 1 if has_blockers else 0
 
 
+def cmd_lane(args: argparse.Namespace) -> int:
+    """Lane lifecycle management (refresh, etc.)."""
+    action = getattr(args, "lane_action", None)
+
+    if action == "refresh":
+        all_idle = getattr(args, "all_idle", False)
+        force = getattr(args, "force", False)
+
+        if all_idle:
+            from bid_euchre.ops.worker_pool import (
+                format_action_text,
+                format_actions_json,
+                refresh_all_idle,
+            )
+
+            actions = refresh_all_idle(force=force, runtime_dir=args.runtime_dir)
+            if args.json:
+                print(json.dumps(format_actions_json(actions), indent=2))
+            else:
+                if actions:
+                    for a in actions:
+                        print(format_action_text(a))
+                else:
+                    print("No idle lanes to refresh.")
+            # Return 0 if at least one action executed, 1 if all failed
+            return 0 if any(a.executed for a in actions) or not actions else 1
+
+        # Single lane refresh
+        lane_id = getattr(args, "lane_id", None)
+        if not lane_id:
+            print("Error: either lane_id or --all-idle is required", file=sys.stderr)
+            return 1
+
+        from bid_euchre.ops.worker_pool import format_action_text, refresh_worker
+
+        result = refresh_worker(lane_id, force=force, runtime_dir=args.runtime_dir)
+        if args.json:
+            from dataclasses import asdict
+
+            print(json.dumps(asdict(result), indent=2))
+        else:
+            print(format_action_text(result))
+        return 0 if result.executed else 1
+
+    else:
+        print("Usage: ops.py lane refresh <lane-id> | --all-idle")
+        return 1
+
+
 def cmd_workers(args: argparse.Namespace) -> int:
     """Worker pool lifecycle management (Platform-7)."""
     from bid_euchre.ops.worker_pool import (
@@ -3250,6 +3299,35 @@ def build_parser() -> argparse.ArgumentParser:
         help="Do not send findings to the orchestrator inbox",
     )
 
+    # lane (lane lifecycle management)
+    lane_parser = subparsers.add_parser(
+        "lane", help="Lane lifecycle management (refresh, etc.)"
+    )
+    lane_sub = lane_parser.add_subparsers(dest="lane_action")
+
+    lane_refresh_parser = lane_sub.add_parser(
+        "refresh",
+        help="Reset worktree to origin/main and clear Claude session",
+    )
+    lane_refresh_parser.add_argument(
+        "lane_id",
+        nargs="?",
+        default=None,
+        help="Lane ID to refresh (e.g. author-a)",
+    )
+    lane_refresh_parser.add_argument(
+        "--all-idle",
+        action="store_true",
+        default=False,
+        help="Refresh all lanes without active dispatched packets",
+    )
+    lane_refresh_parser.add_argument(
+        "--force",
+        action="store_true",
+        default=False,
+        help="Save dirty worktree diff to /tmp and proceed with reset",
+    )
+
     # workers (Platform-7: worker pool lifecycle management)
     workers_parser = subparsers.add_parser(
         "workers", help="Worker pool lifecycle management (Platform-7)"
@@ -3420,6 +3498,7 @@ def main(argv: list[str] | None = None) -> int:
         "supervisor": cmd_supervisor,
         "monitor": cmd_monitor,
         "review-check": cmd_review_check,
+        "lane": cmd_lane,
         "workers": cmd_workers,
         "usage": cmd_usage,
     }

--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -19,6 +19,8 @@ Usage::
         retire_worker,
         reset_worktree,
         clear_session,
+        refresh_worker,
+        refresh_all_idle,
         dispatch_to_worker,
         nudge_pane,
         run_pool_maintenance,
@@ -1393,6 +1395,127 @@ def dispatch_to_worker(
         reason=f"Dispatched packet {packet_id!r} to {lane_id!r}",
         executed=True,
     )
+
+
+def refresh_worker(
+    lane_id: str,
+    *,
+    force: bool = False,
+    tmux_session: str = DEFAULT_TMUX_SESSION,
+    runtime_dir: Path | None = None,
+) -> PoolAction:
+    """Refresh a lane: reset worktree to origin/main and clear Claude session.
+
+    Combines :func:`reset_worktree` and :func:`clear_session` into a single
+    operation with an active-task safety guard.  Intended for the orchestrator
+    to prepare a lane for new work after a prior task has been completed or
+    merged.
+
+    **Safety:** Refuses to refresh a lane that has a dispatched (active) task
+    packet.  This prevents accidental destruction of in-progress work.
+
+    Args:
+        lane_id: Lane to refresh (e.g. ``"author-a"``).
+        force: If ``True``, save any uncommitted diff and proceed even when
+            the worktree is dirty.  Passed through to :func:`reset_worktree`.
+        tmux_session: tmux session name.
+        runtime_dir: Override for the runtime directory root.
+
+    Returns:
+        A :class:`PoolAction` with ``action="refresh"`` describing the outcome.
+    """
+    if lane_id not in _managed_lanes():
+        return PoolAction(
+            action="refresh",
+            lane_id=lane_id,
+            reason=f"Lane {lane_id!r} is not a managed worker lane",
+            executed=False,
+            error="unknown_lane",
+        )
+
+    # Safety: refuse if lane has active task
+    task_id = _get_lane_task_id(lane_id, runtime_dir)
+    if task_id is not None:
+        return PoolAction(
+            action="refresh",
+            lane_id=lane_id,
+            reason=(
+                f"Lane {lane_id!r} has active task {task_id!r}; "
+                f"refusing refresh (complete or cancel the task first)"
+            ),
+            executed=False,
+            error="active_task",
+        )
+
+    # Step 1: Reset worktree to origin/main
+    reset_result = reset_worktree(lane_id, force=force, runtime_dir=runtime_dir)
+    if not reset_result.executed:
+        return PoolAction(
+            action="refresh",
+            lane_id=lane_id,
+            reason=f"Worktree reset failed: {reset_result.reason}",
+            executed=False,
+            error=f"reset_failed:{reset_result.error}",
+        )
+
+    # Step 2: Clear Claude Code session
+    clear_result = clear_session(
+        lane_id, tmux_session=tmux_session, runtime_dir=runtime_dir
+    )
+    if not clear_result.executed:
+        # Reset succeeded but clear failed — report partial success
+        return PoolAction(
+            action="refresh",
+            lane_id=lane_id,
+            reason=(
+                f"Worktree reset OK but session clear failed: {clear_result.reason}"
+            ),
+            executed=True,
+            error="clear_failed",
+        )
+
+    return PoolAction(
+        action="refresh",
+        lane_id=lane_id,
+        reason=f"Refreshed {lane_id}: worktree reset to origin/main, session cleared",
+        executed=True,
+    )
+
+
+def refresh_all_idle(
+    *,
+    force: bool = False,
+    tmux_session: str = DEFAULT_TMUX_SESSION,
+    runtime_dir: Path | None = None,
+) -> list[PoolAction]:
+    """Refresh all idle lanes (those without active dispatched packets).
+
+    Takes a pool snapshot, filters to lanes that are not active (no dispatched
+    task), and calls :func:`refresh_worker` on each.  Lanes with active tasks
+    are silently skipped.
+
+    Args:
+        force: Passed through to :func:`refresh_worker`.
+        tmux_session: tmux session name.
+        runtime_dir: Override for the runtime directory root.
+
+    Returns:
+        A list of :class:`PoolAction` results, one per refreshed lane.
+    """
+    pool = take_pool_snapshot(runtime_dir, tmux_session=tmux_session)
+    actions: list[PoolAction] = []
+    for worker in pool.workers:
+        if worker.current_task_id is not None:
+            continue  # has active task, skip
+        actions.append(
+            refresh_worker(
+                worker.lane_id,
+                force=force,
+                tmux_session=tmux_session,
+                runtime_dir=runtime_dir,
+            )
+        )
+    return actions
 
 
 def run_pool_maintenance(

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -36,6 +36,8 @@ from bid_euchre.ops.worker_pool import (
     get_lane_domain,
     nudge_pane,
     park_worker,
+    refresh_all_idle,
+    refresh_worker,
     reset_worktree,
     retire_worker,
     run_pool_maintenance,
@@ -2836,3 +2838,228 @@ class TestDispatchRedispatchCycles:
             assert "dirty_file.py" in diff_path.read_text()
         finally:
             diff_path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# refresh_worker()
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshWorker:
+    """Test refresh_worker() — combined reset + clear with safety guard."""
+
+    @patch(f"{_WORKER_POOL}.clear_session")
+    @patch(f"{_WORKER_POOL}.reset_worktree")
+    @patch(f"{_WORKER_POOL}._get_lane_task_id")
+    def test_refresh_success(
+        self,
+        mock_task: MagicMock,
+        mock_reset: MagicMock,
+        mock_clear: MagicMock,
+    ) -> None:
+        """Happy path: no active task, reset and clear both succeed."""
+        mock_task.return_value = None
+        mock_reset.return_value = PoolAction(
+            action="reset_worktree",
+            lane_id="author-a",
+            reason="Reset OK",
+            executed=True,
+        )
+        mock_clear.return_value = PoolAction(
+            action="clear_session",
+            lane_id="author-a",
+            reason="Cleared OK",
+            executed=True,
+        )
+        result = refresh_worker("author-a")
+        assert result.executed is True
+        assert result.action == "refresh"
+        assert result.error is None
+        assert "origin/main" in result.reason
+        assert "session cleared" in result.reason
+
+    @patch(f"{_WORKER_POOL}._get_lane_task_id")
+    def test_refresh_refused_active_task(self, mock_task: MagicMock) -> None:
+        """Refuse to refresh a lane with an active dispatched task."""
+        mock_task.return_value = "abc123"
+        result = refresh_worker("author-a")
+        assert result.executed is False
+        assert result.error == "active_task"
+        assert "abc123" in result.reason
+
+    def test_refresh_unknown_lane(self) -> None:
+        """Unknown lane ID is rejected immediately."""
+        result = refresh_worker("not-a-real-lane")
+        assert result.executed is False
+        assert result.error == "unknown_lane"
+
+    @patch(f"{_WORKER_POOL}.reset_worktree")
+    @patch(f"{_WORKER_POOL}._get_lane_task_id")
+    def test_refresh_reset_fails(
+        self,
+        mock_task: MagicMock,
+        mock_reset: MagicMock,
+    ) -> None:
+        """If worktree reset fails, refresh fails without attempting clear."""
+        mock_task.return_value = None
+        mock_reset.return_value = PoolAction(
+            action="reset_worktree",
+            lane_id="author-a",
+            reason="Worktree not found",
+            executed=False,
+            error="worktree_not_found",
+        )
+        result = refresh_worker("author-a")
+        assert result.executed is False
+        assert "reset_failed" in result.error
+
+    @patch(f"{_WORKER_POOL}.clear_session")
+    @patch(f"{_WORKER_POOL}.reset_worktree")
+    @patch(f"{_WORKER_POOL}._get_lane_task_id")
+    def test_refresh_clear_fails_partial_success(
+        self,
+        mock_task: MagicMock,
+        mock_reset: MagicMock,
+        mock_clear: MagicMock,
+    ) -> None:
+        """Reset succeeds but clear fails → partial success (executed=True)."""
+        mock_task.return_value = None
+        mock_reset.return_value = PoolAction(
+            action="reset_worktree",
+            lane_id="author-a",
+            reason="Reset OK",
+            executed=True,
+        )
+        mock_clear.return_value = PoolAction(
+            action="clear_session",
+            lane_id="author-a",
+            reason="tmux not found",
+            executed=False,
+            error="clear_failed",
+        )
+        result = refresh_worker("author-a")
+        assert result.executed is True
+        assert result.error == "clear_failed"
+        assert "reset ok" in result.reason.lower()
+
+    @patch(f"{_WORKER_POOL}.clear_session")
+    @patch(f"{_WORKER_POOL}.reset_worktree")
+    @patch(f"{_WORKER_POOL}._get_lane_task_id")
+    def test_refresh_passes_force_to_reset(
+        self,
+        mock_task: MagicMock,
+        mock_reset: MagicMock,
+        mock_clear: MagicMock,
+    ) -> None:
+        """force=True is forwarded to reset_worktree."""
+        mock_task.return_value = None
+        mock_reset.return_value = PoolAction(
+            action="reset_worktree",
+            lane_id="author-b",
+            reason="Reset OK",
+            executed=True,
+        )
+        mock_clear.return_value = PoolAction(
+            action="clear_session",
+            lane_id="author-b",
+            reason="Cleared OK",
+            executed=True,
+        )
+        refresh_worker("author-b", force=True)
+        mock_reset.assert_called_once_with("author-b", force=True, runtime_dir=None)
+
+
+# ---------------------------------------------------------------------------
+# refresh_all_idle()
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshAllIdle:
+    """Test refresh_all_idle() — batch refresh of all idle lanes."""
+
+    @patch(f"{_WORKER_POOL}.refresh_worker")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    def test_skips_active_lanes(
+        self,
+        mock_snapshot: MagicMock,
+        mock_refresh: MagicMock,
+    ) -> None:
+        """Lanes with current_task_id are skipped."""
+        mock_snapshot.return_value = _make_pool(
+            [
+                _make_worker("author-a", pool_status="active", current_task_id="t1"),
+                _make_worker("author-b", pool_status="idle"),
+            ]
+        )
+        mock_refresh.return_value = PoolAction(
+            action="refresh",
+            lane_id="author-b",
+            reason="Refreshed",
+            executed=True,
+        )
+        actions = refresh_all_idle()
+        # Should only refresh author-b, not author-a
+        assert len(actions) == 1
+        mock_refresh.assert_called_once_with(
+            "author-b", force=False, tmux_session="steward", runtime_dir=None
+        )
+
+    @patch(f"{_WORKER_POOL}.refresh_worker")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    def test_refreshes_all_idle_lanes(
+        self,
+        mock_snapshot: MagicMock,
+        mock_refresh: MagicMock,
+    ) -> None:
+        """All lanes without active tasks are refreshed."""
+        mock_snapshot.return_value = _make_pool(
+            [
+                _make_worker("author-a", pool_status="idle"),
+                _make_worker("author-b", pool_status="parked"),
+                _make_worker("author-c", pool_status="idle"),
+            ]
+        )
+        mock_refresh.return_value = PoolAction(
+            action="refresh",
+            lane_id="any",
+            reason="Refreshed",
+            executed=True,
+        )
+        actions = refresh_all_idle()
+        assert len(actions) == 3
+        assert mock_refresh.call_count == 3
+
+    @patch(f"{_WORKER_POOL}.refresh_worker")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    def test_empty_pool_returns_empty_list(
+        self,
+        mock_snapshot: MagicMock,
+        mock_refresh: MagicMock,
+    ) -> None:
+        """No workers in pool → empty list, no calls to refresh_worker."""
+        mock_snapshot.return_value = _make_pool([])
+        actions = refresh_all_idle()
+        assert actions == []
+        mock_refresh.assert_not_called()
+
+    @patch(f"{_WORKER_POOL}.refresh_worker")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    def test_passes_force_flag(
+        self,
+        mock_snapshot: MagicMock,
+        mock_refresh: MagicMock,
+    ) -> None:
+        """force=True is passed through to each refresh_worker call."""
+        mock_snapshot.return_value = _make_pool(
+            [_make_worker("flex-a", pool_status="idle")]
+        )
+        mock_refresh.return_value = PoolAction(
+            action="refresh",
+            lane_id="flex-a",
+            reason="Refreshed",
+            executed=True,
+        )
+        refresh_all_idle(force=True)
+        mock_refresh.assert_called_once_with(
+            "flex-a", force=True, tmux_session="steward", runtime_dir=None
+        )


### PR DESCRIPTION
## Plan
N/A — standalone issue fix (#1419)

## Summary
- Add `ops.py lane refresh <lane-id>` command to reset a worktree to origin/main and clear the Claude Code session
- Add `--all-idle` flag to batch-refresh all lanes without active dispatched packets
- Safety guard refuses refresh when a lane has an active task packet

## Why
After completing a task, author lanes retain stale context and old branches. The orchestrator needs a single command to prepare lanes for new work instead of manually running git reset + /clear sequences.

## Repro / Validation
**Command(s) run:**
```bash
uv run python scripts/internal/ops.py lane refresh --help
uv run python -m pytest tests/unit/test_ops_worker_pool.py -v
make check-quiet
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_worker_pool.py` — 160 passed
- [x] `make check-quiet` — all checks passed
- [ ] Other: N/A

## Expected impact
- Metrics impact: None
- Runtime impact: None (new CLI command only)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a  f47e9434 [ops/lane-refresh-cli]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

Closes #1419