### PR TITLE
docs: verify Phase 2 prerequisites and close Step 0 checkpoint

### DIFF
--- a/plans/browser_game/2_backend_api/checkpoints.md
+++ b/plans/browser_game/2_backend_api/checkpoints.md
@@ -11,7 +11,7 @@
 
 | Step | Status | Date | Agent/Session | Notes |
 |------|--------|------|---------------|-------|
-| Step 0: Read sub-plan SP-2-01 and verify Phase 1 complete | PENDING | -- | -- | Cannot start until Phase 1 engine passes all tests. |
+| Step 0: Read sub-plan SP-2-01 and verify Phase 1 complete | COMPLETE | 2026-03-23 | brws-author-b | Phase 1 CLOSED (PRs #1380, #1392, #1402). MatchEngine API verified against SP-2-01 route handler requirements. |
 | Step 1: Implement DB models and schema init (`db.py`, `schema.sql`) | PENDING | -- | -- | SQLAlchemy models for `players`, `matches`, `hands`, and `decisions`. No V1 database `model_registry` table. |
 | Step 2: Implement AI manager (`ai_manager.py`) | PENDING | -- | -- | Config-backed approved roster plus startup preload/caching. V1 roster is `heuristic` always and `hybrid_olsa` when configured. |
 | Step 3: Implement FastAPI app and routes (`app.py`, `routes.py`) | PENDING | -- | -- | All endpoints from SP-2-01 §Route Handlers. Idempotent submissions. |
@@ -23,13 +23,19 @@
 
 | Sub-Plan ID | File | Status | Blocking Step |
 |-------------|------|--------|---------------|
-| SP-2-01 | `2_backend_api/sub/2026-03-14_fastapi_app.md` | proposed | Step 0 |
+| SP-2-01 | `2_backend_api/sub/2026-03-14_fastapi_app.md` | proposed | Step 1 |
 
 ## Blockers
 
-- [ ] Phase 1 not complete.
+- [x] ~~Phase 1 not complete.~~ Phase 1 CLOSED 2026-03-23 (PRs #1380, #1392, #1402).
 
 ## Session Log
+
+### 2026-03-23 — brws-author-b
+- Completed: Step 0 — verified Phase 1 prerequisites against SP-2-01.
+- Verified: Phase 1 CLOSED on main. `MatchEngine` provides all APIs required by SP-2-01 route handlers: `start_match()`, `submit_human_bid()`, `submit_human_card()`, `get_visible_state()`, `serialize()`, `deserialize()`. State dataclasses (`MatchState`, `HandState`, `TrickState`, `TrickResult`) with full JSON round-trip. 60 tests passing.
+- Verified: SP-2-01 route handler design (`/bid`, `/play-card`) maps directly to engine API — no gaps.
+- Next: Step 1 (DB models + schema init) is now unblocked.
 
 ### 2026-03-23 — Codex
 - Completed: Aligned backend Step 1/2 notes with amendment BG-1 and the new Phase 0 schema contract.

--- a/plans/browser_game/sub_plan_registry.md
+++ b/plans/browser_game/sub_plan_registry.md
@@ -10,7 +10,7 @@
 | ID | Title | Parent Section | Status | Owner | File | Created | Completed |
 |----|-------|----------------|--------|-------|------|---------|-----------|
 | SP-0-01 | Phase 0 Foundation Lock | §7.4 Phase 0 Dependencies | completed | Codex | `0_foundation/sub/2026-03-14_phase0_foundation_lock.md` | 2026-03-14 | 2026-03-23 |
-| SP-1-01 | Stepwise Match Engine | Phase 1 — State Engine | in_progress | Codex | `1_state_engine/sub/2026-03-14_stepwise_engine.md` | 2026-03-14 | -- |
+| SP-1-01 | Stepwise Match Engine | Phase 1 — State Engine | completed | brws-author-a | `1_state_engine/sub/2026-03-14_stepwise_engine.md` | 2026-03-14 | 2026-03-23 |
 | SP-2-01 | FastAPI App & Persistence | Phase 2 — Backend API | proposed | -- | `2_backend_api/sub/2026-03-14_fastapi_app.md` | 2026-03-14 | -- |
 | SP-3-01 | HTMX Game UI | Phase 3 — Frontend Product | proposed | -- | `3_frontend_product/sub/2026-03-14_htmx_game_ui.md` | 2026-03-14 | -- |
 | SP-4-01 | Export & Replay Validation | Phase 4 — Data Pipeline | proposed | -- | `4_data_pipeline/sub/2026-03-14_export_replay.md` | 2026-03-14 | -- |
@@ -20,9 +20,9 @@
 | Status | Count |
 |--------|-------|
 | proposed | 3 |
-| in_progress | 1 |
+| in_progress | 0 |
 | blocked | 0 |
-| completed | 1 |
+| completed | 2 |
 | abandoned | 0 |
 | superseded | 0 |
 


### PR DESCRIPTION
## Summary

- Mark Phase 2 Backend API Step 0 as COMPLETE after verifying Phase 1 state engine is fully shipped
- Clear the Phase 1 blocker in Phase 2 checkpoints
- Close SP-1-01 in the sub-plan registry (was left as `in_progress` after Phase 1 closure)

## Why

Phase 1 is CLOSED on main (PRs #1380, #1392, #1402, checkpoint closure #1422). Phase 2 Step 0
requires reading SP-2-01 and verifying Phase 1 prerequisites — this is now satisfied:

- `MatchEngine` provides all APIs required by SP-2-01 route handlers: `start_match()`,
  `submit_human_bid()`, `submit_human_card()`, `get_visible_state()`, `serialize()`, `deserialize()`
- State dataclasses (`MatchState`, `HandState`, `TrickState`, `TrickResult`) with full JSON round-trip
- 60 hosted-play unit tests passing
- SP-2-01 route handler design (`/bid`, `/play-card`) maps directly to engine API — no gaps

Phase 2 Step 1 (DB models + schema init) is now unblocked.

## Repro / Validation

```bash
# Docs-only — verify tests still pass
uv run python -m pytest tests/unit/hosted_play/ -v
make check-quiet
```

## Tests

- `make check-quiet` ✅ — all checks pass

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
branch: browser-game/phase2-prep
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)