### PR TITLE
fix: silence session-sync hook success notices

### DIFF
--- a/.claude/hooks/session-sync-worktree.sh
+++ b/.claude/hooks/session-sync-worktree.sh
@@ -38,7 +38,6 @@ fi
 
 # Already on main — just pull
 if [[ "$CURRENT_BRANCH" == "main" ]]; then
-  echo >&2 "${LOG_PREFIX} Already on main — pulling latest."
   git -C "$PROJECT_DIR" pull origin main --ff-only 2>/dev/null || true
   exit 0
 fi
@@ -55,7 +54,6 @@ PR_STATE="$(gh pr view "$CURRENT_BRANCH" --repo Questuart/Bid-Euchre --json stat
 PR_STATE="${PR_STATE:-NONE}"
 
 if [[ "$PR_STATE" == "OPEN" ]]; then
-  echo >&2 "${LOG_PREFIX} Branch '$CURRENT_BRANCH' has an open PR — skipping auto-sync."
   exit 0
 fi
 
@@ -74,8 +72,6 @@ fi
 # --------------------------------------------------------------------------
 # Safe to sync: no open PR, no unpushed commits, clean working tree
 # --------------------------------------------------------------------------
-echo >&2 "${LOG_PREFIX} Syncing '$CURRENT_BRANCH' → main (PR state: ${PR_STATE})"
-
 # Switch to tracking origin/main. We can't checkout 'main' directly because
 # it's used by the primary worktree — instead reset the current branch to
 # origin/main, giving us the same effect.
@@ -83,5 +79,3 @@ git -C "$PROJECT_DIR" reset --hard origin/main 2>/dev/null || {
   echo >&2 "${LOG_PREFIX} WARNING: Failed to reset to origin/main — skipping."
   exit 0
 }
-
-echo >&2 "${LOG_PREFIX} Synced to $(git -C "$PROJECT_DIR" log --oneline -1)"

--- a/tests/unit/test_session_sync_hook.py
+++ b/tests/unit/test_session_sync_hook.py
@@ -1,0 +1,56 @@
+"""Tests for session-sync-worktree.sh hook.
+
+Validates that the session-sync hook only emits stderr output for
+WARNING conditions, keeping success paths silent to reduce TUI noise.
+See: GitHub issue #1421.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+HOOK_PATH = (
+    Path(__file__).resolve().parents[2]
+    / ".claude"
+    / "hooks"
+    / "session-sync-worktree.sh"
+)
+
+
+class TestSessionSyncSilentSuccess:
+    """Success paths must not emit stderr output (issue #1421)."""
+
+    def test_all_echo_stderr_statements_are_warnings(self) -> None:
+        """Every 'echo >&2' in the hook must contain 'WARNING:'."""
+        content = HOOK_PATH.read_text()
+        # Match lines that echo to stderr (echo >&2)
+        echo_stderr_lines = [
+            line.strip()
+            for line in content.splitlines()
+            if re.search(r"\becho\s+>&2\b", line) and not line.strip().startswith("#")
+        ]
+        assert len(echo_stderr_lines) > 0, "Expected at least one WARNING echo"
+        for line in echo_stderr_lines:
+            assert (
+                "WARNING" in line
+            ), f"Non-warning stderr output found (issue #1421): {line}"
+
+    def test_non_steward_dir_exits_silently(self) -> None:
+        """Hook exits 0 with no output when PROJECT_DIR is not a steward dir."""
+        import os
+
+        env = os.environ.copy()
+        env["CLAUDE_PROJECT_DIR"] = "/tmp/plain-project-dir"
+
+        result = subprocess.run(
+            ["bash", str(HOOK_PATH)],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=5,
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+        assert result.stderr.strip() == ""


### PR DESCRIPTION
## Summary
- Remove 4 non-warning `echo >&2` statements from `session-sync-worktree.sh` that clutter the TUI on every session start
- All 5 WARNING messages for actual problems (dirty tree, detached HEAD, unpushed commits, gh auth failure, reset failure) are preserved
- Add regression tests to enforce the "only warnings on stderr" invariant

## Why
Issue #1421 — the session-sync hook emits success notices to stderr on every SessionStart, creating noise in every TUI pane. These messages provide no actionable information when things work correctly.

## Repro / Validation
```bash
# Static invariant test
uv run python -m pytest tests/unit/test_session_sync_hook.py -v

# Verify non-steward dirs exit silently
CLAUDE_PROJECT_DIR=/tmp/foo bash .claude/hooks/session-sync-worktree.sh
# (no output expected)
```

## Tests
```bash
uv run python -m pytest tests/unit/test_session_sync_hook.py -v  # 2 passed
make lint      # passed
make repo-lint # passed
```

Note: `make check-quiet` has a pre-existing failure in `tests/unit/hosted_play/test_db.py` (missing `sqlalchemy` dep from PR #1430) — unrelated to this change.

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
branch: fix/session-sync-silence-success-1421
```

Closes #1421

🤖 Generated with [Claude Code](https://claude.com/claude-code)