### PR TITLE
fix: exclude incomplete sessions from throughput ratios

### DIFF
--- a/src/bid_euchre/ops/token_economy.py
+++ b/src/bid_euchre/ops/token_economy.py
@@ -950,6 +950,16 @@ def _load_attributions(output_dir: Path) -> list[dict[str, Any]]:
     return records
 
 
+def _is_session_complete(rec: dict[str, Any]) -> bool:
+    """Return True if a session has completion markers.
+
+    A session is considered complete if it has a non-None ``duration_minutes``
+    field.  In-progress sessions lack this value because Claude computes
+    duration only when the session ends.
+    """
+    return rec.get("duration_minutes") is not None
+
+
 @dataclass
 class UsageSummary:
     """Aggregate usage summary across all imported sessions."""
@@ -975,16 +985,27 @@ class UsageSummary:
     tokens_per_hour: float = 0.0
 
 
-def usage_summary(*, output_dir: Path | None = None) -> UsageSummary:
+def usage_summary(
+    *,
+    output_dir: Path | None = None,
+    exclude_incomplete: bool = False,
+) -> UsageSummary:
     """Compute aggregate usage summary across all sessions.
 
     Parameters
     ----------
     output_dir
         Path to the token economy store. Defaults to repo runtime path.
+    exclude_incomplete
+        When True, skip sessions that lack completion markers (e.g. no
+        ``duration_minutes``).  Useful for throughput ratios where in-progress
+        sessions would skew denominators.
     """
     resolved_output = _resolve_output_dir(output_dir)
     sessions = _load_sessions(resolved_output)
+
+    if exclude_incomplete:
+        sessions = [s for s in sessions if _is_session_complete(s)]
 
     if not sessions:
         return UsageSummary()
@@ -1114,13 +1135,16 @@ class ThroughputMetrics:
 def throughput_summary(*, output_dir: Path | None = None) -> ThroughputMetrics:
     """Compute throughput-normalized token metrics.
 
+    Excludes incomplete sessions (those lacking ``duration_minutes``) so
+    that in-progress work does not skew ratio denominators.
+
     Parameters
     ----------
     output_dir
         Path to the token economy store. Defaults to repo runtime path.
     """
     resolved_output = _resolve_output_dir(output_dir)
-    s = usage_summary(output_dir=resolved_output)
+    s = usage_summary(output_dir=resolved_output, exclude_incomplete=True)
 
     m = ThroughputMetrics(
         total_sessions=s.session_count,
@@ -1287,6 +1311,10 @@ def detect_anti_patterns(*, output_dir: Path | None = None) -> list[AntiPattern]
     - read_amplification: high assistant/user message ratio
     - fragmentation: many short sessions
 
+    Incomplete sessions (those lacking ``duration_minutes``) are excluded —
+    in-progress work has unknown commit/duration data and would produce
+    misleading anti-pattern signals.
+
     Parameters
     ----------
     output_dir
@@ -1299,10 +1327,12 @@ def detect_anti_patterns(*, output_dir: Path | None = None) -> list[AntiPattern]
     """
     resolved_output = _resolve_output_dir(output_dir)
     sessions = _load_sessions(resolved_output)
+    # Exclude incomplete sessions — unknown commit/duration data skews checks
+    sessions = [s for s in sessions if _is_session_complete(s)]
     if not sessions:
         return []
 
-    s = usage_summary(output_dir=resolved_output)
+    s = usage_summary(output_dir=resolved_output, exclude_incomplete=True)
 
     checks: list[AntiPattern | None] = [
         _check_verbosity_waste(s),

--- a/tests/unit/test_ops_token_economy.py
+++ b/tests/unit/test_ops_token_economy.py
@@ -28,6 +28,7 @@ from bid_euchre.ops.token_economy import (
     SessionRecord,
     ThroughputMetrics,
     UsageSummary,
+    _is_session_complete,
     attribute_sessions,
     dashboard_token_economy,
     detect_anti_patterns,
@@ -1291,3 +1292,132 @@ class TestDashboardTokenEconomy:
 
         assert len(result["anti_patterns"]) > 0
         assert result["anti_patterns"][0]["pattern_id"] == "verbosity_waste"
+
+
+# ---------------------------------------------------------------------------
+# Incomplete session exclusion tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsSessionComplete:
+    def test_complete_session(self) -> None:
+        """Session with duration_minutes is complete."""
+        rec = {"session_id": "s1", "duration_minutes": 30}
+        assert _is_session_complete(rec) is True
+
+    def test_incomplete_session_none(self) -> None:
+        """Session with duration_minutes=None is incomplete."""
+        rec = {"session_id": "s1", "duration_minutes": None}
+        assert _is_session_complete(rec) is False
+
+    def test_incomplete_session_missing(self) -> None:
+        """Session without duration_minutes key is incomplete."""
+        rec = {"session_id": "s1"}
+        assert _is_session_complete(rec) is False
+
+    def test_zero_duration_is_complete(self) -> None:
+        """Session with duration_minutes=0 is still considered complete."""
+        rec = {"session_id": "s1", "duration_minutes": 0}
+        assert _is_session_complete(rec) is True
+
+
+class TestIncompleteSessionExclusion:
+    """Verify incomplete sessions are excluded from throughput ratios and
+    anti-pattern detection (issue #1412)."""
+
+    def test_throughput_excludes_incomplete(self, output_dir: Path) -> None:
+        """Throughput metrics ignore sessions without duration_minutes."""
+        complete = _make_session_record(
+            "s1",
+            input_tokens=100,
+            output_tokens=400,
+            duration_minutes=60,
+            git_commits=2,
+            lines_added=50,
+            lines_removed=10,
+        )
+        # Incomplete session: has tokens but no duration (still in progress)
+        incomplete = {
+            "session_id": "s2",
+            "input_tokens": 5000,
+            "output_tokens": 20000,
+            "lines_added": 0,
+            "lines_removed": 0,
+            "git_commits": 0,
+            "git_pushes": 0,
+            "start_time": "2026-03-21T10:00:00Z",
+            # duration_minutes intentionally omitted — incomplete session
+        }
+        _write_sessions(output_dir, [complete, incomplete])
+
+        result = throughput_summary(output_dir=output_dir)
+
+        # Should only reflect the complete session
+        assert result.total_sessions == 1
+        assert result.total_tokens == 500  # 100 + 400 from complete only
+        assert result.tokens_per_commit == pytest.approx(250.0)
+
+    def test_usage_summary_exclude_incomplete(self, output_dir: Path) -> None:
+        """usage_summary with exclude_incomplete=True filters properly."""
+        complete = _make_session_record("s1", duration_minutes=30)
+        incomplete = {
+            "session_id": "s2",
+            "input_tokens": 1000,
+            "output_tokens": 2000,
+            "start_time": "2026-03-21T10:00:00Z",
+            # no duration_minutes
+        }
+        _write_sessions(output_dir, [complete, incomplete])
+
+        # Default: includes all
+        all_result = usage_summary(output_dir=output_dir)
+        assert all_result.session_count == 2
+
+        # Excluding incomplete
+        filtered = usage_summary(output_dir=output_dir, exclude_incomplete=True)
+        assert filtered.session_count == 1
+
+    def test_anti_patterns_exclude_incomplete(self, output_dir: Path) -> None:
+        """Anti-pattern detection ignores incomplete sessions."""
+        # One complete session with zero commits (would normally be "churn")
+        complete_zero = _make_session_record("s1", git_commits=0, duration_minutes=30)
+        complete_good = _make_session_record("s2", git_commits=3, duration_minutes=45)
+        # Incomplete session with zero commits — should NOT count as churn
+        incomplete = {
+            "session_id": "s3",
+            "input_tokens": 500,
+            "output_tokens": 1000,
+            "git_commits": 0,
+            "git_pushes": 0,
+            "lines_added": 0,
+            "lines_removed": 0,
+            "start_time": "2026-03-21T10:00:00Z",
+            # no duration_minutes — still in progress
+        }
+        _write_sessions(output_dir, [complete_zero, complete_good, incomplete])
+
+        findings = detect_anti_patterns(output_dir=output_dir)
+
+        churn = [f for f in findings if f.pattern_id == "retry_churn"]
+        if churn:
+            # If churn is detected, the denominator should be 2 (complete only),
+            # not 3 (which would include the incomplete session)
+            assert churn[0].evidence["total_sessions"] == 2
+
+    def test_all_incomplete_returns_empty(self, output_dir: Path) -> None:
+        """When all sessions are incomplete, anti-patterns returns empty."""
+        incomplete = {
+            "session_id": "s1",
+            "input_tokens": 5000,
+            "output_tokens": 20000,
+            "git_commits": 0,
+            "start_time": "2026-03-21T10:00:00Z",
+        }
+        _write_sessions(output_dir, [incomplete])
+
+        findings = detect_anti_patterns(output_dir=output_dir)
+        assert findings == []
+
+        result = throughput_summary(output_dir=output_dir)
+        assert result.total_sessions == 0
+        assert result.total_tokens == 0


### PR DESCRIPTION
## Summary

- Add `_is_session_complete()` helper that checks for `duration_minutes` presence as a session completion marker
- `throughput_summary()` now excludes incomplete sessions via `usage_summary(exclude_incomplete=True)`
- `detect_anti_patterns()` filters out incomplete sessions before running checks, preventing in-progress sessions from inflating retry churn and fragmentation counts
- `usage_summary()` gains an `exclude_incomplete` parameter (default False for backward compatibility)
- 8 new unit tests covering the helper, throughput exclusion, anti-pattern exclusion, and edge cases

## Why

Issue #1412: Throughput ratio calculations (tokens_per_commit, tokens_per_net_line, etc.) included in-progress sessions that lacked completion data. This skewed metrics — sessions without `duration_minutes` contributed tokens to numerators but zero values to denominators (commits, net lines, duration). Similarly, anti-pattern checks like retry_churn counted incomplete sessions as "zero-commit" sessions, producing false positives.

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_ops_token_economy.py -v
make check-quiet
```

## Tests

- `TestIsSessionComplete` — 4 tests for the completion marker helper
- `TestIncompleteSessionExclusion` — 4 tests for throughput, usage_summary, anti-pattern, and all-incomplete edge case

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
branch: fix/exclude-incomplete-sessions-throughput
```

Closes #1412

🤖 Generated with [Claude Code](https://claude.com/claude-code)