### PR TITLE
ops: add Telegram channel config to steward tmux launcher

### DIFF
--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -51,6 +51,13 @@ if [ -z "$CLAUDE_BIN" ]; then
     exit 1
 fi
 
+# Telegram channel configuration (Platform-8a).
+# Set STEWARD_TELEGRAM_ENABLED=1 to add --channels telegram to the
+# orchestrator pane.  Default is 0 (disabled / tmux-only).
+# Only the orchestrator lane gets the channel flag — author lanes remain
+# tmux-only per SP-4-01 key decisions.
+STEWARD_TELEGRAM_ENABLED="${STEWARD_TELEGRAM_ENABLED:-0}"
+
 # Platform pool worktrees
 AUTHOR_A="${PARENT_DIR}/${REPO_NAME}-steward-author"
 AUTHOR_B="${PARENT_DIR}/${REPO_NAME}-steward-author-b"
@@ -306,6 +313,18 @@ write_lane_metadata "flex-b"         "flex"          "$FLEX_B"          "codex/s
 write_lane_metadata "flex-c"         "flex"          "$FLEX_C"          "codex/steward-flex-c"           "scratch" "4" "background" "Flex C"
 
 # ---------------------------------------------------------------------------
+# Orchestrator channel flags (Platform-8a)
+# ---------------------------------------------------------------------------
+# When STEWARD_TELEGRAM_ENABLED=1 the orchestrator pane gets
+# --channels telegram so the Channels plugin connects on boot.
+# All other panes launch without --channels (tmux-only).
+ORCH_CHANNEL_FLAGS=""
+if [ "$STEWARD_TELEGRAM_ENABLED" = "1" ]; then
+    ORCH_CHANNEL_FLAGS="--channels telegram"
+    export STEWARD_CHANNELS="telegram"
+fi
+
+# ---------------------------------------------------------------------------
 # Window + pane creation — 4 windows (central-ops: 3 panes, others: 4 panes)
 # ---------------------------------------------------------------------------
 # central-ops uses main-vertical: orchestrator large left, ops/review stacked right.
@@ -313,7 +332,7 @@ write_lane_metadata "flex-c"         "flex"          "$FLEX_C"          "codex/s
 
 # --- Window 1: central-ops (3 panes, main-vertical) ---
 tmux new-session -d -s "$SESSION" -n central-ops -c "$MAIN_DIR" \
-    "$CLAUDE_BIN" --name orchestrator --agent steward-orchestrator
+    "$CLAUDE_BIN" --name orchestrator --agent steward-orchestrator $ORCH_CHANNEL_FLAGS
 tmux split-window -t "${SESSION}:central-ops" -c "$MAIN_DIR" \
     "$CLAUDE_BIN" --name ops --agent steward-ops
 tmux split-window -t "${SESSION}:central-ops" -c "$REVIEW" \

--- a/plans/agent_ops/4_remote_channel/checkpoints.md
+++ b/plans/agent_ops/4_remote_channel/checkpoints.md
@@ -38,7 +38,7 @@ sub-plan registry, and update checkpoints. Docs-only — no code changes.
 | SP-4-01 | `plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8-scope-lock.md` | completed | Step 0 |
 | SP-4-02 | `plans/agent_ops/4_remote_channel/sub/2026-03-23_remote-ops-preflight-hardening.md` | in_progress | Pre-Platform-8 |
 | SP-4-03 | `plans/agent_ops/4_remote_channel/sub/2026-03-23_token-economy-observability-and-dashboard.md` | completed | Pre-Platform-8 |
-| SP-4-04 | `plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8a-telegram-transport.md` | proposed | Step 1 |
+| SP-4-04 | `plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8a-telegram-transport.md` | in_progress | Step 1 |
 
 ### Shared Surface Ownership
 
@@ -70,3 +70,4 @@ implementation.
 | 2026-03-23 | SP-4-03 registered. Token economy observability alongside SP-4-02. Covers usage import, lane attribution, CLI/dashboard views, and baseline anti-pattern report. Overlaps SP-4-02 in `scripts/internal/ops.py` and dashboard — serialize shared surfaces during implementation. Codex review surfaced 3 plan-quality findings (boundary exception, malformed telemetry, attribution key) for orchestrator to address. |
 | 2026-03-23 | SP-4-04 registered (flex-a). Platform-8a Telegram transport sub-plan: 6 steps covering preflight, plugin config, pairing proof, permission relay proof, kill switch proof, and registry integration. Steps 3-5 parallelizable after Step 2. Key constraint: orchestrator-only ingress, no audit trail (deferred to Platform-9c). |
 | 2026-03-23 | SP-4-03 completed (author-a). Baseline token economy report produced at `plans/sessions/2026-03-23_token-economy-baseline.md`. Key findings: 52.4% shipped-token rate, 10.9K tokens/commit, 71% zero-commit session rate. Top 3 waste patterns: abandoned-work churn (42.9% of tokens), wrong-approach retry (60 friction events), high-error session tax (16.8% of tokens). Pre-steward data only (2026-02-03 to 2026-03-14); per-lane attribution requires post-steward follow-up. |
+| 2026-03-23 | SP-4-04 Step 2 (author-a): Telegram config added to tmux launcher. `STEWARD_TELEGRAM_ENABLED` env var (default 0) controls kill switch. When enabled, appends `--channels telegram` to orchestrator pane only. `STEWARD_CHANNELS` exported for orchestrator. Author lanes remain tmux-only. |

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -516,6 +516,73 @@ class TestWindowLayout:
             assert var in content, f"Missing worktree path variable: {var}"
 
 
+class TestTelegramChannelConfig:
+    """Tests for the Telegram channel configuration (Platform-8a)."""
+
+    def test_telegram_enabled_env_var_defaults_to_zero(self) -> None:
+        """STEWARD_TELEGRAM_ENABLED must default to 0 (disabled)."""
+        content = STEWARD_SCRIPT.read_text()
+        assert (
+            'STEWARD_TELEGRAM_ENABLED="${STEWARD_TELEGRAM_ENABLED:-0}"' in content
+        ), "STEWARD_TELEGRAM_ENABLED must default to 0"
+
+    def test_channels_flag_only_on_orchestrator(self) -> None:
+        """--channels must only appear on the orchestrator pane launch, via ORCH_CHANNEL_FLAGS."""
+        content = STEWARD_SCRIPT.read_text()
+        # The orchestrator launch line must reference ORCH_CHANNEL_FLAGS
+        assert (
+            "--agent steward-orchestrator $ORCH_CHANNEL_FLAGS" in content
+        ), "Orchestrator pane must append $ORCH_CHANNEL_FLAGS"
+
+        # No other launch line should reference ORCH_CHANNEL_FLAGS or --channels
+        launch_lines = [
+            line.strip()
+            for line in content.split("\n")
+            if ("--name " in line or "--agent " in line) and "$CLAUDE_BIN" in line
+        ]
+        for line in launch_lines:
+            if "steward-orchestrator" in line:
+                continue
+            assert (
+                "ORCH_CHANNEL_FLAGS" not in line
+            ), f"Non-orchestrator lane must not use ORCH_CHANNEL_FLAGS: {line}"
+            assert (
+                "--channels" not in line
+            ), f"Non-orchestrator lane must not use --channels: {line}"
+
+    def test_steward_channels_exported_when_enabled(self) -> None:
+        """STEWARD_CHANNELS must be exported when STEWARD_TELEGRAM_ENABLED=1."""
+        content = STEWARD_SCRIPT.read_text()
+        assert (
+            'export STEWARD_CHANNELS="telegram"' in content
+        ), "STEWARD_CHANNELS must be exported as 'telegram' when enabled"
+
+    def test_channel_flags_empty_by_default(self) -> None:
+        """ORCH_CHANNEL_FLAGS must be empty string by default."""
+        content = STEWARD_SCRIPT.read_text()
+        assert (
+            'ORCH_CHANNEL_FLAGS=""' in content
+        ), "ORCH_CHANNEL_FLAGS must default to empty string"
+
+    def test_channel_flags_conditional_on_enabled(self) -> None:
+        """ORCH_CHANNEL_FLAGS must only be set inside the STEWARD_TELEGRAM_ENABLED=1 guard."""
+        content = STEWARD_SCRIPT.read_text()
+        lines = content.split("\n")
+        in_guard = False
+        guard_body: list[str] = []
+        for line in lines:
+            if "STEWARD_TELEGRAM_ENABLED" in line and '"1"' in line and "if" in line:
+                in_guard = True
+            if in_guard:
+                guard_body.append(line)
+                if line.strip() == "fi":
+                    break
+        guard_text = "\n".join(guard_body)
+        assert (
+            'ORCH_CHANNEL_FLAGS="--channels telegram"' in guard_text
+        ), "ORCH_CHANNEL_FLAGS assignment must be inside the STEWARD_TELEGRAM_ENABLED=1 guard"
+
+
 class TestBoundaryValidation:
     """Tests for validate_worktree_path() in steward-session.sh."""
 


### PR DESCRIPTION
## Summary

- Add `STEWARD_TELEGRAM_ENABLED` env var (default `0`) as a kill switch for Telegram channel integration
- When enabled (`=1`), appends `--channels telegram` to the **orchestrator pane only** and exports `STEWARD_CHANNELS=telegram`
- Author lanes remain tmux-only per SP-4-01 key decisions
- Add 5 regression tests validating the config structure

## Why

SP-4-04 Step 2 (Platform-8a Telegram Transport). The official Claude Code Channels plugin needs to be wired into the orchestrator session launch so remote supervision via Telegram can be toggled on/off.

## Repro / Validation

```bash
# Validation commands from task packet:
grep -q 'STEWARD_CHANNELS' .claude/tmux/steward-session.sh
grep -q '\-\-channels telegram' .claude/tmux/steward-session.sh
bash -n .claude/tmux/steward-session.sh

# Tier 1 tests:
uv run python -m pytest tests/unit/test_steward_session.py::TestTelegramChannelConfig -v

# Tier 2:
make check-quiet
```

## Tests

- `tests/unit/test_steward_session.py::TestTelegramChannelConfig` — 5 tests:
  - `test_telegram_enabled_env_var_defaults_to_zero`
  - `test_channels_flag_only_on_orchestrator`
  - `test_steward_channels_exported_when_enabled`
  - `test_channel_flags_empty_by_default`
  - `test_channel_flags_conditional_on_enabled`
- `make check-quiet` ✅

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: ops/platform-8a-telegram-config
worktree: Bid-Euchre-steward-author (persistent author-a lane)
```

## Scope

Files changed (declared scope only):
- `.claude/tmux/steward-session.sh` — Telegram channel config + orchestrator flag
- `plans/agent_ops/4_remote_channel/checkpoints.md` — SP-4-04 status update + session log
- `tests/unit/test_steward_session.py` — Regression tests for channel config

🤖 Generated with [Claude Code](https://claude.com/claude-code)