### PR TITLE
fix: preserve zero-valued tokens_per_commit in dashboard

### DIFF
--- a/src/bid_euchre/ops/token_economy.py
+++ b/src/bid_euchre/ops/token_economy.py
@@ -1406,9 +1406,7 @@ def dashboard_token_economy(*, output_dir: Path | None = None) -> dict[str, Any]
             "total_tokens": ls.total_tokens,
             "session_count": ls.session_count,
             "git_commits": ls.git_commits,
-            "tokens_per_commit": round(ls.tokens_per_commit, 0)
-            if ls.tokens_per_commit
-            else None,
+            "tokens_per_commit": round(ls.tokens_per_commit, 0),
             "net_lines": ls.net_lines,
         }
         for ls in lanes[:5]  # top 5 most expensive
@@ -1417,7 +1415,9 @@ def dashboard_token_economy(*, output_dir: Path | None = None) -> dict[str, Any]
     # Cheapest productive lanes (have commits, sorted by tokens_per_commit asc)
     productive = [ls for ls in lanes if ls.git_commits > 0]
     productive.sort(
-        key=lambda x: x.tokens_per_commit if x.tokens_per_commit else float("inf")
+        key=lambda x: (
+            x.tokens_per_commit if x.tokens_per_commit is not None else float("inf")
+        )
     )
     efficient_lanes = [
         {
@@ -1425,9 +1425,7 @@ def dashboard_token_economy(*, output_dir: Path | None = None) -> dict[str, Any]
             "pool": ls.pool,
             "total_tokens": ls.total_tokens,
             "git_commits": ls.git_commits,
-            "tokens_per_commit": round(ls.tokens_per_commit, 0)
-            if ls.tokens_per_commit
-            else None,
+            "tokens_per_commit": round(ls.tokens_per_commit, 0),
             "net_lines": ls.net_lines,
         }
         for ls in productive[:5]  # top 5 most efficient

--- a/tests/unit/test_ops_token_economy.py
+++ b/tests/unit/test_ops_token_economy.py
@@ -1293,6 +1293,73 @@ class TestDashboardTokenEconomy:
         assert len(result["anti_patterns"]) > 0
         assert result["anti_patterns"][0]["pattern_id"] == "verbosity_waste"
 
+    def test_dashboard_preserves_zero_tokens_per_commit(self, output_dir: Path) -> None:
+        """Zero-valued tokens_per_commit is preserved, not filtered to None.
+
+        Regression test for issue #1420: lanes with zero commits should show
+        tokens_per_commit=0.0 rather than None in the dashboard output.
+        """
+        sessions = [
+            _make_session_record(
+                "s1",
+                input_tokens=0,
+                output_tokens=0,
+                git_commits=0,
+                lines_added=0,
+                lines_removed=0,
+                project_path="/Users/foo/Bid-Euchre-steward-author",
+            ),
+            _make_session_record(
+                "s2",
+                input_tokens=100,
+                output_tokens=400,
+                git_commits=2,
+                lines_added=20,
+                lines_removed=5,
+                project_path="/Users/foo/Bid-Euchre-steward-flex-a",
+            ),
+        ]
+        _write_sessions(output_dir, sessions)
+
+        attributions = [
+            {
+                "session_id": "s1",
+                "lane_id": "author-a",
+                "worktree_class": "platform",
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "git_commits": 0,
+                "lines_added": 0,
+                "lines_removed": 0,
+                "duration_minutes": 10,
+            },
+            {
+                "session_id": "s2",
+                "lane_id": "flex-a",
+                "worktree_class": "flex",
+                "input_tokens": 100,
+                "output_tokens": 400,
+                "git_commits": 2,
+                "lines_added": 20,
+                "lines_removed": 5,
+                "duration_minutes": 30,
+            },
+        ]
+        _write_attributions(output_dir, attributions)
+
+        result = dashboard_token_economy(output_dir=output_dir)
+
+        # The zero-commit lane should appear in top_lanes with
+        # tokens_per_commit=0.0, NOT None
+        zero_lane = next(
+            (l for l in result["top_lanes"] if l["lane_id"] == "author-a"), None
+        )
+        assert zero_lane is not None, "Zero-commit lane missing from top_lanes"
+        assert zero_lane["tokens_per_commit"] == 0.0, (
+            f"Expected 0.0, got {zero_lane['tokens_per_commit']!r} — "
+            "zero values must not be filtered to None (issue #1420)"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Incomplete session exclusion tests


### PR DESCRIPTION
## Summary
- Fix C2 anti-pattern (falsy numeric guard) in `dashboard_token_economy()` that filtered `tokens_per_commit=0.0` to `None`
- Three locations fixed: `top_lanes` dict, `efficient_lanes` dict, and `productive` sort key
- Add regression test for zero-commit lane visibility in dashboard output

## Why
Issue #1420 (follow-up from PR #1415): lanes with zero commits had `tokens_per_commit` displayed as `None` instead of `0.0`. Zero is valid data — it means the lane ran but produced no commits — and should be preserved in the output.

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_ops_token_economy.py -v  # 73 passed
make lint      # passed
make repo-lint # passed
```

## Tests
```bash
uv run python -m pytest tests/unit/test_ops_token_economy.py::TestDashboardTokenEconomy::test_dashboard_preserves_zero_tokens_per_commit -v
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
branch: fix/dashboard-zero-tokens-per-commit-1420
```

Closes #1420

🤖 Generated with [Claude Code](https://claude.com/claude-code)