### PR TITLE
fix: silence PreToolUse hooks to eliminate TUI noise (#1255)

### DIFF
--- a/.claude/hooks/pre-bash-dispatch.sh
+++ b/.claude/hooks/pre-bash-dispatch.sh
@@ -79,6 +79,7 @@ if [ -x "$HOOKS_DIR/rule-loader.sh" ]; then
     fi
 fi
 
-# All guards passed, no context to inject
-echo '{"suppressOutput": true}'
+# All guards passed, no context to inject — exit silently.
+# PreToolUse hooks have no suppressOutput field; any stdout triggers
+# Claude Code's "Async hook PreToolUse completed" TUI notification.
 exit 0

--- a/.claude/hooks/pre-merge-review-guard.sh
+++ b/.claude/hooks/pre-merge-review-guard.sh
@@ -21,7 +21,6 @@ INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 
 if [ -z "$COMMAND" ]; then
-  echo '{"suppressOutput": true}'
   exit 0
 fi
 
@@ -37,7 +36,6 @@ fi
 # block legitimate non-merge commands.
 TRIMMED="${COMMAND#"${COMMAND%%[![:space:]]*}"}"
 if [[ "$TRIMMED" != "gh pr merge"* ]]; then
-  echo '{"suppressOutput": true}'
   exit 0
 fi
 
@@ -185,6 +183,5 @@ BLOCK
   exit 2
 fi
 
-# All checks passed — allow the merge
-echo '{"suppressOutput": true}'
+# All checks passed — allow the merge (exit silently)
 exit 0

--- a/.claude/hooks/pre-worktree-cleanup.sh
+++ b/.claude/hooks/pre-worktree-cleanup.sh
@@ -21,7 +21,6 @@ INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 
 if [ -z "$COMMAND" ]; then
-    echo '{"suppressOutput": true}'
     exit 0
 fi
 
@@ -37,7 +36,6 @@ elif echo "$COMMAND" | grep -q "git worktree prune"; then
 fi
 
 if [ -z "$MATCHED" ]; then
-    echo '{"suppressOutput": true}'
     exit 0
 fi
 

--- a/.claude/hooks/rule-loader.sh
+++ b/.claude/hooks/rule-loader.sh
@@ -25,14 +25,13 @@ case "$TOOL_NAME" in
     FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
     ;;
   *)
-    # No match — exit with empty response
-    echo '{"suppressOutput": true}'
+    # No match — exit silently (no stdout = no TUI notification for PreToolUse)
     exit 0
     ;;
 esac
 
 if [ -z "$FILE_PATH" ]; then
-  echo '{"suppressOutput": true}'
+  # No file path — exit silently (no stdout = no TUI notification for PreToolUse)
   exit 0
 fi
 
@@ -69,9 +68,8 @@ if echo "$FILE_PATH" | grep -q 'gh pr'; then
   RULES_TO_LOAD+=("40_prs.md" "60_review_gate.md")
 fi
 
-# No rules matched
+# No rules matched — exit silently
 if [ ${#RULES_TO_LOAD[@]} -eq 0 ]; then
-  echo '{"suppressOutput": true}'
   exit 0
 fi
 
@@ -95,9 +93,8 @@ for rule in "${RULES_TO_LOAD[@]}"; do
   fi
 done
 
-# Nothing new to load
+# Nothing new to load — exit silently
 if [ ${#NEW_RULES[@]} -eq 0 ]; then
-  echo '{"suppressOutput": true}'
   exit 0
 fi
 
@@ -112,10 +109,9 @@ for rule in "${NEW_RULES[@]}"; do
   fi
 done
 
-# Output additionalContext JSON
+# Output additionalContext JSON (PreToolUse schema — no suppressOutput field)
 if [ -n "$CONTEXT" ]; then
   # Use jq to safely encode the content as JSON
-  echo "$CONTEXT" | jq -Rs '{additionalContext: ., suppressOutput: true}' 2>/dev/null || echo '{"suppressOutput": true}'
-else
-  echo '{"suppressOutput": true}'
+  echo "$CONTEXT" | jq -Rs '{additionalContext: .}' 2>/dev/null || true
 fi
+# If no context or jq fails, exit silently (no stdout = no TUI notification)

--- a/.claude/hooks/scope-drift-guard.sh
+++ b/.claude/hooks/scope-drift-guard.sh
@@ -18,14 +18,12 @@ INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 
 if [ -z "$COMMAND" ]; then
-  echo '{"suppressOutput": true}'
   exit 0
 fi
 
 # Only guard on direct "git commit" commands (not quoted inside tmux etc.)
 TRIMMED="${COMMAND#"${COMMAND%%[![:space:]]*}"}"
 if [[ "$TRIMMED" != "git commit"* ]]; then
-  echo '{"suppressOutput": true}'
   exit 0
 fi
 
@@ -54,7 +52,6 @@ fi
 
 if [ -z "$LANE_ID" ]; then
   # Cannot determine lane — skip enforcement silently
-  echo '{"suppressOutput": true}'
   exit 0
 fi
 
@@ -93,7 +90,6 @@ print(json.dumps(verdict.to_dict()))
 
 if [ -z "$RESULT" ]; then
   # Python invocation failed — don't block work
-  echo '{"suppressOutput": true}'
   exit 0
 fi
 

--- a/tests/unit/test_hook_dispatchers.py
+++ b/tests/unit/test_hook_dispatchers.py
@@ -3,7 +3,7 @@
 The pre-bash-dispatch.sh and post-bash-dispatch.sh scripts consolidate
 multiple hooks into single invocations to reduce TUI noise.  These tests
 verify:
-  - Normal commands pass through with suppressOutput
+  - Normal commands produce no stdout (PreToolUse has no suppressOutput)
   - Blocking commands propagate exit code 2
   - Rule-loader context injection works through the dispatcher
   - PostToolUse dispatcher suppresses TUI notification for non-matching commands
@@ -58,14 +58,14 @@ class TestPreBashDispatch:
 
     SCRIPT = "pre-bash-dispatch.sh"
 
-    def test_normal_command_passes_with_suppress(self) -> None:
-        """A safe command should pass through with suppressOutput."""
-        rc, _raw, out = _run_hook(
+    def test_normal_command_produces_no_stdout(self) -> None:
+        """A safe command should produce no stdout (PreToolUse has no suppressOutput)."""
+        rc, raw, out = _run_hook(
             self.SCRIPT, {"tool_name": "Bash", "tool_input": {"command": "ls -la"}}
         )
         assert rc == 0
-        assert out is not None
-        assert out.get("suppressOutput") is True
+        assert raw == ""
+        assert out is None
 
     def test_dangerous_worktree_command_blocks(self) -> None:
         """Dangerous worktree operations should block with exit 2."""
@@ -92,7 +92,7 @@ class TestPreBashDispatch:
         assert "BLOCKED" in raw
 
     def test_rule_loader_context_injection(self) -> None:
-        """Rule-loader should inject context when matching notebook paths."""
+        """Rule-loader should inject additionalContext for matching paths."""
         # Clear any loaded-rules sentinel so the rule-loader triggers
         runtime_dir = HOOKS_DIR.parents[1] / ".claude" / "runtime"
         for sentinel in runtime_dir.glob(".loaded_rules_*"):
@@ -107,9 +107,48 @@ class TestPreBashDispatch:
         )
         assert rc == 0
         assert out is not None
-        assert out.get("suppressOutput") is True
         # Rule-loader should have injected context for notebook paths
         assert out.get("additionalContext") is not None
+        # PreToolUse hooks should NOT include suppressOutput (not a valid field)
+        assert "suppressOutput" not in out
+
+
+class TestRuleLoaderDirect:
+    """rule-loader.sh produces no stdout for non-matching PreToolUse paths."""
+
+    SCRIPT = "rule-loader.sh"
+
+    def test_non_matching_path_produces_no_stdout(self) -> None:
+        """Non-matching paths should produce no stdout to avoid TUI noise."""
+        rc, raw, out = _run_hook(
+            self.SCRIPT,
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": "/some/unrelated/file.py"},
+            },
+        )
+        assert rc == 0
+        assert raw == ""
+        assert out is None
+
+    def test_matching_path_has_no_suppress_output(self) -> None:
+        """Matching paths should return additionalContext but not suppressOutput."""
+        # Clear sentinels
+        runtime_dir = HOOKS_DIR.parents[1] / ".claude" / "runtime"
+        for sentinel in runtime_dir.glob(".loaded_rules_*"):
+            sentinel.unlink(missing_ok=True)
+
+        rc, _raw, out = _run_hook(
+            self.SCRIPT,
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": "notebooks/analysis.py"},
+            },
+        )
+        assert rc == 0
+        assert out is not None
+        assert out.get("additionalContext") is not None
+        assert "suppressOutput" not in out
 
 
 class TestPostBashDispatch:

--- a/tests/unit/test_hook_suppress_output.py
+++ b/tests/unit/test_hook_suppress_output.py
@@ -1,8 +1,11 @@
-"""Tests for PreToolUse hook suppressOutput on happy paths.
+"""Tests for PreToolUse hook silent exit on happy paths.
 
-Each PreToolUse hook must output {"suppressOutput": true} on its exit-0
-code paths to avoid noisy "Async hook PreToolUse completed" messages.
-Blocking paths (exit 2) must NOT emit suppressOutput.
+PreToolUse hooks must produce NO stdout on their exit-0 code paths to
+avoid noisy "Async hook PreToolUse completed" messages.  Unlike PostToolUse
+hooks, PreToolUse hooks have no suppressOutput field — any stdout triggers
+Claude Code's default completion notification.
+
+Blocking paths (exit 2) may emit free-form text to explain the block.
 """
 
 from __future__ import annotations
@@ -16,10 +19,10 @@ HOOKS_DIR = Path(__file__).resolve().parents[2] / ".claude" / "hooks"
 
 def _run_hook(
     script: str, payload: dict, env_override: dict | None = None
-) -> tuple[int, dict | None]:
+) -> tuple[int, str, dict | None]:
     """Run a hook script with JSON payload on stdin.
 
-    Returns (exit_code, parsed_json_or_None).
+    Returns (exit_code, raw_stdout, parsed_json_or_None).
     """
     import os
 
@@ -44,90 +47,82 @@ def _run_hook(
         except json.JSONDecodeError:
             pass  # Blocking paths emit free-form text, not JSON
 
-    return result.returncode, parsed
+    return result.returncode, stdout, parsed
 
 
-class TestRuleLoaderSuppressOutput:
-    """rule-loader.sh must emit suppressOutput on all exit-0 paths."""
+class TestRuleLoaderSilentExit:
+    """rule-loader.sh must emit NO stdout on all exit-0 non-matching paths."""
 
     SCRIPT = "rule-loader.sh"
 
-    def test_unmatched_tool_emits_suppress(self) -> None:
-        """Glob tool doesn't match any case arm."""
-        rc, out = _run_hook(self.SCRIPT, {"tool_name": "Glob", "tool_input": {}})
+    def test_unmatched_tool_produces_no_stdout(self) -> None:
+        """Glob tool doesn't match any case arm — should be silent."""
+        rc, raw, _out = _run_hook(self.SCRIPT, {"tool_name": "Glob", "tool_input": {}})
         assert rc == 0
-        assert out is not None
-        assert out.get("suppressOutput") is True
+        assert raw == ""
 
-    def test_empty_file_path_emits_suppress(self) -> None:
-        """Read with empty file_path triggers early exit."""
-        rc, out = _run_hook(
+    def test_empty_file_path_produces_no_stdout(self) -> None:
+        """Read with empty file_path triggers early exit — should be silent."""
+        rc, raw, _out = _run_hook(
             self.SCRIPT, {"tool_name": "Read", "tool_input": {"file_path": ""}}
         )
         assert rc == 0
-        assert out is not None
-        assert out.get("suppressOutput") is True
+        assert raw == ""
 
-    def test_no_rules_matched_emits_suppress(self) -> None:
-        """Read on a path that doesn't trigger any rule pattern."""
-        rc, out = _run_hook(
+    def test_no_rules_matched_produces_no_stdout(self) -> None:
+        """Read on a path that doesn't trigger any rule pattern — should be silent."""
+        rc, raw, _out = _run_hook(
             self.SCRIPT,
             {"tool_name": "Read", "tool_input": {"file_path": "/tmp/unrelated.txt"}},
         )
         assert rc == 0
-        assert out is not None
-        assert out.get("suppressOutput") is True
+        assert raw == ""
 
 
-class TestPreWorktreeCleanupSuppressOutput:
-    """pre-worktree-cleanup.sh must emit suppressOutput on non-matching paths."""
+class TestPreWorktreeCleanupSilentExit:
+    """pre-worktree-cleanup.sh must produce no stdout on non-matching paths."""
 
     SCRIPT = "pre-worktree-cleanup.sh"
 
-    def test_empty_command_emits_suppress(self) -> None:
-        """Non-Bash tool input (no command field)."""
-        rc, out = _run_hook(self.SCRIPT, {"tool_name": "Read", "tool_input": {}})
+    def test_empty_command_produces_no_stdout(self) -> None:
+        """Non-Bash tool input (no command field) — should be silent."""
+        rc, raw, _out = _run_hook(self.SCRIPT, {"tool_name": "Read", "tool_input": {}})
         assert rc == 0
-        assert out is not None
-        assert out.get("suppressOutput") is True
+        assert raw == ""
 
-    def test_safe_command_emits_suppress(self) -> None:
-        """Safe bash command that doesn't match any dangerous pattern."""
-        rc, out = _run_hook(
+    def test_safe_command_produces_no_stdout(self) -> None:
+        """Safe bash command that doesn't match any dangerous pattern — silent."""
+        rc, raw, _out = _run_hook(
             self.SCRIPT, {"tool_name": "Bash", "tool_input": {"command": "ls -la"}}
         )
         assert rc == 0
-        assert out is not None
-        assert out.get("suppressOutput") is True
+        assert raw == ""
 
     def test_dangerous_command_blocks_without_suppress(self) -> None:
-        """Dangerous worktree command should block (exit 2) without suppressOutput."""
-        rc, out = _run_hook(
+        """Dangerous worktree command should block (exit 2) with text."""
+        rc, raw, _out = _run_hook(
             self.SCRIPT,
             {"tool_name": "Bash", "tool_input": {"command": "git worktree prune"}},
         )
         assert rc == 2
-        # Blocking path emits human-readable text, not JSON with suppressOutput
-        assert out is None or out.get("suppressOutput") is not True
+        assert "BLOCKED" in raw
 
 
-class TestPreMergeReviewGuardSuppressOutput:
-    """pre-merge-review-guard.sh must emit suppressOutput on non-merge commands."""
+class TestPreMergeReviewGuardSilentExit:
+    """pre-merge-review-guard.sh must produce no stdout on non-merge commands."""
 
     SCRIPT = "pre-merge-review-guard.sh"
 
-    def test_empty_command_emits_suppress(self) -> None:
-        """Non-Bash tool input (no command field)."""
-        rc, out = _run_hook(self.SCRIPT, {"tool_name": "Read", "tool_input": {}})
+    def test_empty_command_produces_no_stdout(self) -> None:
+        """Non-Bash tool input (no command field) — should be silent."""
+        rc, raw, _out = _run_hook(self.SCRIPT, {"tool_name": "Read", "tool_input": {}})
         assert rc == 0
-        assert out is not None
-        assert out.get("suppressOutput") is True
+        assert raw == ""
 
-    def test_non_merge_command_emits_suppress(self) -> None:
-        """Regular bash command that isn't gh pr merge."""
-        rc, out = _run_hook(
+    def test_non_merge_command_produces_no_stdout(self) -> None:
+        """Regular bash command that isn't gh pr merge — should be silent."""
+        rc, raw, _out = _run_hook(
             self.SCRIPT, {"tool_name": "Bash", "tool_input": {"command": "git status"}}
         )
         assert rc == 0
-        assert out is not None
-        assert out.get("suppressOutput") is True
+        assert raw == ""


### PR DESCRIPTION
## Summary

- **Root cause identified**: `suppressOutput` is not a valid field in Claude Code's PreToolUse hook response schema (unlike PostToolUse). Any stdout from a PreToolUse hook triggers the "Async hook PreToolUse completed" TUI notification.
- All PreToolUse hooks now produce **zero bytes on stdout** when there's nothing to report, instead of outputting `{"suppressOutput": true}`.
- Tests updated to verify silent exit behavior for all PreToolUse hooks.

## Why

Issue #1255: "Async hook PreToolUse completed" messages clutter TUI output in every active lane. Two prior PRs (#1318 consolidation, #1417 suppressOutput) didn't resolve it because `suppressOutput` is not recognized for PreToolUse hooks — it only works for PostToolUse.

## Investigation Findings

| Hook Event | `suppressOutput` valid? | Fix |
|-----------|------------------------|-----|
| PostToolUse | ✅ Yes | Already working (PR #1417) |
| PreToolUse | ❌ No | **This PR**: emit no stdout |

## Changed Files

| File | Change |
|------|--------|
| `.claude/hooks/rule-loader.sh` | Silent exit on all non-matching paths; remove `suppressOutput` from `additionalContext` output |
| `.claude/hooks/pre-bash-dispatch.sh` | Silent exit on normal pass-through |
| `.claude/hooks/pre-worktree-cleanup.sh` | Silent exit on non-matching commands |
| `.claude/hooks/pre-merge-review-guard.sh` | Silent exit on non-merge commands |
| `.claude/hooks/scope-drift-guard.sh` | Silent exit on non-commit commands |
| `tests/unit/test_hook_dispatchers.py` | Updated to expect empty stdout for PreToolUse |
| `tests/unit/test_hook_suppress_output.py` | Rewritten to verify zero-byte stdout on happy paths |

## Repro / Validation

```bash
# Verify hooks produce no stdout for normal commands
echo '{"tool_name": "Read", "tool_input": {"file_path": "/tmp/test.py"}}' | \
  CLAUDE_PROJECT_DIR=. .claude/hooks/rule-loader.sh | wc -c
# Expected: 0

echo '{"tool_name": "Bash", "tool_input": {"command": "ls"}}' | \
  CLAUDE_PROJECT_DIR=. .claude/hooks/pre-bash-dispatch.sh | wc -c
# Expected: 0

# Verify context injection still works
echo '{"tool_name": "Read", "tool_input": {"file_path": "notebooks/test.py"}}' | \
  CLAUDE_PROJECT_DIR=. .claude/hooks/rule-loader.sh | jq keys
# Expected: ["additionalContext"]
```

## Tests

```bash
uv run python -m pytest tests/unit/test_hook_dispatchers.py tests/unit/test_hook_suppress_output.py -v  # 18 passed
make check-quiet  # All checks passed
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: fix/async-hook-tui-noise-1255
```

## Note

If the "Async hook PreToolUse completed" noise persists after this change, it means the notification is a Claude Code framework behavior triggered by hook *execution* (not hook *output*), in which case it cannot be suppressed from hook code at all. In that scenario, the finding should be documented on issue #1255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)