### PR TITLE
fix: treat failed session clears as failed lane refresh

### DIFF
--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -1463,14 +1463,15 @@ def refresh_worker(
         lane_id, tmux_session=tmux_session, runtime_dir=runtime_dir
     )
     if not clear_result.executed:
-        # Reset succeeded but clear failed — report partial success
+        # Reset succeeded but clear failed — treat as failed refresh
+        # so callers don't assume the lane is ready for new work.
         return PoolAction(
             action="refresh",
             lane_id=lane_id,
             reason=(
                 f"Worktree reset OK but session clear failed: {clear_result.reason}"
             ),
-            executed=True,
+            executed=False,
             error="clear_failed",
         )
 

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -2946,13 +2946,13 @@ class TestRefreshWorker:
     @patch(f"{_WORKER_POOL}.clear_session")
     @patch(f"{_WORKER_POOL}.reset_worktree")
     @patch(f"{_WORKER_POOL}._get_lane_task_id")
-    def test_refresh_clear_fails_partial_success(
+    def test_refresh_clear_fails_is_failed(
         self,
         mock_task: MagicMock,
         mock_reset: MagicMock,
         mock_clear: MagicMock,
     ) -> None:
-        """Reset succeeds but clear fails → partial success (executed=True)."""
+        """Reset succeeds but clear fails → treated as failed refresh (#1428)."""
         mock_task.return_value = None
         mock_reset.return_value = PoolAction(
             action="reset_worktree",
@@ -2968,9 +2968,9 @@ class TestRefreshWorker:
             error="clear_failed",
         )
         result = refresh_worker("author-a")
-        assert result.executed is True
+        assert result.executed is False
         assert result.error == "clear_failed"
-        assert "reset ok" in result.reason.lower()
+        assert "session clear failed" in result.reason.lower()
 
     @patch(f"{_WORKER_POOL}.clear_session")
     @patch(f"{_WORKER_POOL}.reset_worktree")


### PR DESCRIPTION
## Summary
- Change `refresh_worker()` to return `executed=False` when `clear_session()` fails, instead of `executed=True` (partial success)
- Update existing test to verify the corrected failure propagation

## Why
When a session clear fails during lane refresh, callers assumed the lane was ready for new work (`executed=True`). This could lead to dispatching tasks to lanes with stale Claude Code context. Now the failure propagates correctly so callers can retry or escalate.

Closes #1428

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_ops_worker_pool.py -v -k refresh
make check-quiet
```

## Tests
- Updated `test_refresh_clear_fails_is_failed` (renamed from `test_refresh_clear_fails_partial_success`) to assert `executed=False`

## Worktree proof
```
pwd: Bid-Euchre-steward-author-b
branch: fix/session-clear-failure-propagation
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)