### PR TITLE
docs: close Phase 2 checkpoints and create Phase 3 browser-ui sub-plan

### DIFF
--- a/plans/browser_game/2_backend_api/checkpoints.md
+++ b/plans/browser_game/2_backend_api/checkpoints.md
@@ -14,22 +14,27 @@
 | Step 0: Read sub-plan SP-2-01 and verify Phase 1 complete | COMPLETE | 2026-03-23 | brws-author-b | Phase 1 CLOSED (PRs #1380, #1392, #1402). MatchEngine API verified against SP-2-01 route handler requirements. |
 | Step 1: Implement DB models and schema init (`db.py`, `schema.sql`) | COMPLETE | 2026-03-23 | brws-author-b | PR #1430. SQLAlchemy models + config + schema. |
 | Step 2: Implement AI manager (`ai_manager.py`) | COMPLETE | 2026-03-23 | brws-author-b | PR #1430. Config-backed heuristic + hybrid_olsa roster. |
-| Step 3: Implement FastAPI app and routes (`app.py`, `routes.py`) | IN_PROGRESS | 2026-03-24 | brws-author-b | 8 route handlers with idempotent submissions. |
-| Step 4: Implement decision logging in routes | IN_PROGRESS | 2026-03-24 | brws-author-b | Human decisions logged with full detail; AI decisions with placeholders (V1 limitation). |
-| Step 5: Write integration tests | IN_PROGRESS | 2026-03-24 | brws-author-b | 17 tests covering all 10 required scenarios + edge cases. |
-| Step 6: Run validation | IN_PROGRESS | 2026-03-24 | brws-author-b | 17/17 tests passing, `make check-quiet` green. |
+| Step 3: Implement FastAPI app and routes (`app.py`, `routes.py`) | COMPLETE | 2026-03-24 | brws-author-b | PR #1435. 8 route handlers with idempotent submissions. |
+| Step 4: Implement decision logging in routes | COMPLETE | 2026-03-24 | brws-author-b | PR #1435. Human decisions logged with full detail; AI decisions with placeholders (V1 limitation). |
+| Step 5: Write integration tests | COMPLETE | 2026-03-24 | brws-author-b | PR #1435. 17 tests covering all 10 required scenarios + edge cases. |
+| Step 6: Run validation | COMPLETE | 2026-03-24 | brws-author-b | PR #1435. 17/17 tests passing, `make check-quiet` green. |
 
 ## Active Sub-Plans
 
 | Sub-Plan ID | File | Status | Blocking Step |
 |-------------|------|--------|---------------|
-| SP-2-01 | `2_backend_api/sub/2026-03-14_fastapi_app.md` | in_progress | Steps 3-6 |
+| SP-2-01 | `2_backend_api/sub/2026-03-14_fastapi_app.md` | completed | Steps 0-6 (all COMPLETE) |
 
 ## Blockers
 
 - [x] ~~Phase 1 not complete.~~ Phase 1 CLOSED 2026-03-23 (PRs #1380, #1392, #1402).
 
 ## Session Log
+
+### 2026-03-24 — brws-author-a (Phase 2 closure)
+- Closed: Phase 2 COMPLETE. All steps (0-6) marked COMPLETE. SP-2-01 completed.
+- PR #1435 merged — FastAPI app, routes, DB models, AI manager, decision logging, 17 integration tests.
+- Phase 3 (Frontend Product) is now unblocked.
 
 ### 2026-03-24 — brws-author-b
 - Completed: Steps 3-6 — Route handlers, decision logging, integration tests, validation.

--- a/plans/browser_game/2_backend_api/sub/2026-03-14_fastapi_app.md
+++ b/plans/browser_game/2_backend_api/sub/2026-03-14_fastapi_app.md
@@ -2,7 +2,7 @@
 
 **ID:** SP-2-01
 **Parent:** Phase 2 — Backend API
-**Status:** proposed
+**Status:** completed
 **Governing plan:** `plans/browser_game/governing_plan.md`
 **Created:** 2026-03-14
 
@@ -212,4 +212,6 @@ uv run python -m pytest tests/unit/hosted_play/test_routes.py -v
 
 ## Outcome
 
-_To be filled after implementation._
+- Result: COMPLETE
+- PRs: #1430 (DB models, AI manager, schema), #1435 (routes, templates, tests)
+- Notes: All 9 planned files created. 8 route handlers with HTMX partial responses. 17 integration tests covering all 10 required scenarios plus 7 edge cases. V1 limitation: AI decision logging uses placeholders for legal_actions/game_state. `make check-quiet` green.

--- a/plans/browser_game/3_frontend_product/checkpoints.md
+++ b/plans/browser_game/3_frontend_product/checkpoints.md
@@ -2,8 +2,9 @@
 
 **Governing plan:** `plans/browser_game/governing_plan.md`
 **Phase/Rung:** `3_frontend_product`
-**Sub-plan:** `SP-3-01` → `3_frontend_product/sub/2026-03-14_htmx_game_ui.md`
-**Last updated:** 2026-03-14
+**Sub-plan:** `SP-3-02` → `3_frontend_product/sub/2026-03-24_browser-ui.md`
+**Design reference:** `SP-3-01` → `3_frontend_product/sub/2026-03-14_htmx_game_ui.md` (superseded as execution plan; retained as design reference for CSS, layout, HTMX patterns)
+**Last updated:** 2026-03-24
 
 ---
 
@@ -11,24 +12,28 @@
 
 | Step | Status | Date | Agent/Session | Notes |
 |------|--------|------|---------------|-------|
-| Step 0: Read sub-plan SP-3-01 and verify Phase 2 complete | PENDING | -- | -- | Cannot start until backend API passes all tests. |
-| Step 1: Build base template and CSS card styles | PENDING | -- | -- | `base.html`, `style.css`. CSS-only cards with Unicode suits. |
-| Step 2: Build landing, nickname, and model selection pages | PENDING | -- | -- | `landing.html`, `nickname_form.html`, `model_select.html`. |
-| Step 3: Build game table layout and trick area | PENDING | -- | -- | `game.html`, `trick.html`, `hand.html`, `score.html`. |
-| Step 4: Build bid panel | PENDING | -- | -- | `bid_panel.html`. Dynamic legal bid levels. Contract type selector. |
-| Step 5: Build hand/match result screens | PENDING | -- | -- | `hand_result.html`, `match_result.html`. |
-| Step 6: Add decision timer JS | PENDING | -- | -- | `game.js`. Minimal JS for timing + HTMX enhancements. |
-| Step 7: Manual browser validation | PENDING | -- | -- | Full checklist from SP-3-01 §Validation. |
+| Step 0: Verify Phase 2 complete and read SP-3-02 | PENDING | -- | -- | Phase 2 CLOSED (PRs #1430, #1435). Routes already return HTMX partials. |
+| Step 1: Game board template (HTML/CSS for card display, bid UI, play UI) | PENDING | -- | -- | `game.html`, `base.html`, `style.css`. CSS-only card rendering with Unicode suits. |
+| Step 2: Template partials for HTMX responses (bid result, card play result, trick complete) | PENDING | -- | -- | `bid_panel.html`, `hand.html`, `trick.html`, `score.html`, `hand_result.html`, `match_result.html`. |
+| Step 3: Static assets (CSS, minimal JS for HTMX) | PENDING | -- | -- | `style.css`, `game.js`. Decision timer, card click handler, HTMX enhancements. |
+| Step 4: End-to-end local vertical slice (uvicorn + browser test) | PENDING | -- | -- | Full match flow: create → nickname → select AI → bid → play → score → win/loss. |
+| Step 5: Refresh/resume proof (browser refresh preserves game state) | PENDING | -- | -- | Idempotent submissions + persisted state survive refresh at any point. |
 
 ## Active Sub-Plans
 
 | Sub-Plan ID | File | Status | Blocking Step |
 |-------------|------|--------|---------------|
-| SP-3-01 | `3_frontend_product/sub/2026-03-14_htmx_game_ui.md` | proposed | Step 0 |
+| SP-3-02 | `3_frontend_product/sub/2026-03-24_browser-ui.md` | proposed | Step 0 |
+| SP-3-01 | `3_frontend_product/sub/2026-03-14_htmx_game_ui.md` | superseded | -- |
 
 ## Blockers
 
-- [ ] Phase 2 not complete.
+- [x] ~~Phase 2 not complete.~~ Phase 2 CLOSED 2026-03-24 (PRs #1430, #1435).
+
+## Key Constraint
+
+Server-rendered HTML with HTMX, no frontend build tooling. Routes already
+return HTMX partials from `web/routes.py` (#1435).
 
 ## Note on Parallelism
 
@@ -36,6 +41,11 @@ Phase 3 and Phase 4 can execute in parallel after Phase 2 merges.
 If two agents are available, launch both simultaneously.
 
 ## Session Log
+
+### 2026-03-24 — brws-author-a
+- Completed: Phase 2 closure confirmed. Updated checkpoints with new 5-step structure from SP-3-02.
+- Phase 3 is now unblocked. SP-3-01 superseded by SP-3-02 (refined step structure).
+- Next: Step 0 (verify Phase 2 + read SP-3-02), then Step 1 (game board template).
 
 ### 2026-03-14 — Claude
 - Completed: Sub-plan SP-3-01 created with card CSS, game table layout, HTMX wiring patterns, decision timer, and 12-item validation checklist.

--- a/plans/browser_game/3_frontend_product/sub/2026-03-24_browser-ui.md
+++ b/plans/browser_game/3_frontend_product/sub/2026-03-24_browser-ui.md
@@ -1,0 +1,150 @@
+# SP-3-02: Browser UI Implementation
+
+**ID:** SP-3-02
+**Parent:** Phase 3 — Frontend Product
+**Status:** proposed
+**Governing plan:** `plans/browser_game/governing_plan.md`
+**Design reference:** `SP-3-01` → `3_frontend_product/sub/2026-03-14_htmx_game_ui.md`
+**Created:** 2026-03-24
+**Supersedes:** SP-3-01 (as execution plan; SP-3-01 retained as design reference)
+
+---
+
+## Goal
+
+Build the browser UI for match setup, bidding, trick play, score display,
+and refresh-safe resume. Server-rendered HTML with HTMX partial swaps —
+no frontend build tooling. Routes already return HTMX partials from
+`web/routes.py` (PR #1435).
+
+## Prerequisites
+
+- Phase 2 CLOSED: PRs #1430 (DB models, AI manager), #1435 (routes, templates, tests)
+- Routes return HTMX partials for all game actions
+- `web/templates/base.html` exists (minimal scaffold from Phase 2)
+- `MatchEngine` provides stepwise hand/match progression
+
+## Steps
+
+### Step 1: Game Board Template
+
+**Files to create/update:**
+
+| File | Purpose |
+|------|---------|
+| `web/templates/game.html` | Main game layout (extends `base.html`) — card table with 4 seats, trick area, score bar |
+| `web/templates/landing.html` | Landing page with "Start a New Game" button |
+| `web/static/style.css` | Card rendering CSS (Unicode suits, rank text, fan layout, legal/illegal states) |
+
+**Key design decisions (from SP-3-01):**
+- CSS-only card rendering — no images. Unicode suits (`♠♥♦♣`) + rank text.
+- Card layout: overlapping fan (`margin: 0 -10px`), hover lift effect.
+- Legal cards: green border + glow. Illegal cards: dimmed + `cursor: not-allowed`.
+- Game table: partner (top), opponents (left/right), human (bottom), trick area (center).
+- AI hands shown as face-down card backs with visible count.
+
+**Acceptance criteria:**
+- `game.html` renders the 4-seat table layout with trick area and score bar
+- `landing.html` has a form that POSTs to `/new`
+- `style.css` renders cards with correct colors (red for ♥♦, black for ♠♣)
+
+### Step 2: Template Partials for HTMX Responses
+
+**Files to create/update:**
+
+| File | Purpose |
+|------|---------|
+| `web/templates/partials/nickname_form.html` | Nickname input form |
+| `web/templates/partials/model_select.html` | AI model picker with available models |
+| `web/templates/partials/bid_panel.html` | Bid amount + contract type selector |
+| `web/templates/partials/hand.html` | Player's cards (legal cards as form buttons, illegal as plain divs) |
+| `web/templates/partials/trick.html` | Current trick area (4 card slots) |
+| `web/templates/partials/score.html` | Match score + hand info + contract display |
+| `web/templates/partials/hand_result.html` | Made/set banner between hands |
+| `web/templates/partials/match_result.html` | Win/loss screen with "Play Again" button |
+
+**Key design decisions (from SP-3-01):**
+- Each partial is a self-contained HTMX swap target.
+- Bid panel: `<select>` for bid level (pass + legal levels) and contract type (♠♥♦♣ + High + Low).
+- Card play: each legal card is a `<form>` with `hx-post` to `/play/{uuid}/play-card`.
+- All forms include `turn_number` hidden input for idempotency.
+- `#game-board` is the primary HTMX swap target (`hx-target="#game-board" hx-swap="innerHTML"`).
+
+**Acceptance criteria:**
+- All 8 partials render correctly within `game.html`
+- Bid panel shows only legal bid levels from visible state
+- Card play forms submit correct `card_index` and `turn_number`
+
+### Step 3: Static Assets (CSS, minimal JS)
+
+**Files to create/update:**
+
+| File | Purpose |
+|------|---------|
+| `web/static/style.css` | Complete CSS: card styles, table layout, responsive basics, phase-specific views |
+| `web/static/game.js` | Decision timer (records `decision_time_ms`), HTMX swap hooks, card click handler |
+
+**Key design decisions (from SP-3-01):**
+- Decision timer: `Date.now()` on load, inject `decision_time_ms` hidden input on `htmx:beforeRequest`.
+- Timer reset: listen for `htmx:afterSwap` to restart timing on new decision prompt.
+- No frontend build tooling — raw CSS and vanilla JS served as static files.
+
+**Acceptance criteria:**
+- `game.js` injects `decision_time_ms` on every bid/play form submission
+- Timer resets correctly after each HTMX swap
+- CSS renders correctly in modern browsers (Chrome, Firefox, Safari)
+
+### Step 4: End-to-End Local Vertical Slice
+
+**Validation command:**
+```bash
+PYTHONPATH=src uv run uvicorn web.app:app --reload --port 8000
+# Open http://localhost:8000 in browser
+```
+
+**Flow to validate:**
+1. Landing page → "Start a New Game" → POST `/new` → redirect to `/play/{uuid}`
+2. Enter nickname → POST `/play/{uuid}/nickname` → model selection partial
+3. Select AI model → POST `/play/{uuid}/select-ai` → first hand dealt, game board appears
+4. Bid phase → select bid level + contract → POST `/play/{uuid}/bid` → board updates
+5. Play phase → click legal card → POST `/play/{uuid}/play-card` → trick updates, AI plays
+6. After 10 tricks → hand result banner → next hand auto-starts
+7. Play to +52 or -52 → match result screen
+8. "Play Again" → POST `/play/{uuid}/new-match` → new model selection
+
+**Acceptance criteria:**
+- Complete match playable from landing to win/loss screen
+- AI turns auto-advance without user interaction
+- All-pass hands trigger redeal
+- Decision logging verified in database (decisions table populated)
+
+### Step 5: Refresh/Resume Proof
+
+**Tests to perform:**
+1. Refresh browser mid-auction → resumes at correct bid state
+2. Refresh browser mid-trick → resumes with correct cards played
+3. Refresh between hands → shows correct hand result or next hand
+4. Double-click bid/play button → idempotent (same response, no state corruption)
+5. Navigate away and return via URL → full state restored from DB
+
+**Acceptance criteria:**
+- `GET /play/{uuid}` always renders correct current state from persisted `match_state_json`
+- No double-counting of actions on duplicate POST
+- Browser back/forward buttons don't corrupt state
+
+## Validation Commands
+
+```bash
+# Tier 1 (during dev): run existing route tests to verify no regression
+uv run python -m pytest tests/unit/hosted_play/test_routes.py -v
+
+# Tier 2 (before PR): full validation
+make check-quiet
+
+# Manual: local server test
+PYTHONPATH=src uv run uvicorn web.app:app --reload --port 8000
+```
+
+## Outcome
+
+_To be filled after implementation._

--- a/plans/browser_game/sub_plan_registry.md
+++ b/plans/browser_game/sub_plan_registry.md
@@ -1,7 +1,7 @@
 # Sub-Plan Registry — Browser Game Hosting and Human Data Capture
 
 **Governing plan:** `plans/browser_game/governing_plan.md`
-**Last updated:** 2026-03-23
+**Last updated:** 2026-03-24
 
 ---
 
@@ -11,20 +11,21 @@
 |----|-------|----------------|--------|-------|------|---------|-----------|
 | SP-0-01 | Phase 0 Foundation Lock | §7.4 Phase 0 Dependencies | completed | Codex | `0_foundation/sub/2026-03-14_phase0_foundation_lock.md` | 2026-03-14 | 2026-03-23 |
 | SP-1-01 | Stepwise Match Engine | Phase 1 — State Engine | completed | brws-author-a | `1_state_engine/sub/2026-03-14_stepwise_engine.md` | 2026-03-14 | 2026-03-23 |
-| SP-2-01 | FastAPI App & Persistence | Phase 2 — Backend API | proposed | -- | `2_backend_api/sub/2026-03-14_fastapi_app.md` | 2026-03-14 | -- |
-| SP-3-01 | HTMX Game UI | Phase 3 — Frontend Product | proposed | -- | `3_frontend_product/sub/2026-03-14_htmx_game_ui.md` | 2026-03-14 | -- |
+| SP-2-01 | FastAPI App & Persistence | Phase 2 — Backend API | completed | brws-author-b | `2_backend_api/sub/2026-03-14_fastapi_app.md` | 2026-03-14 | 2026-03-24 |
+| SP-3-01 | HTMX Game UI (design reference) | Phase 3 — Frontend Product | superseded | -- | `3_frontend_product/sub/2026-03-14_htmx_game_ui.md` | 2026-03-14 | -- |
+| SP-3-02 | Browser UI Implementation | Phase 3 — Frontend Product | proposed | -- | `3_frontend_product/sub/2026-03-24_browser-ui.md` | 2026-03-24 | -- |
 | SP-4-01 | Export & Replay Validation | Phase 4 — Data Pipeline | proposed | -- | `4_data_pipeline/sub/2026-03-14_export_replay.md` | 2026-03-14 | -- |
 
 ## Status Summary
 
 | Status | Count |
 |--------|-------|
-| proposed | 3 |
+| proposed | 2 |
 | in_progress | 0 |
 | blocked | 0 |
-| completed | 2 |
+| completed | 3 |
 | abandoned | 0 |
-| superseded | 0 |
+| superseded | 1 |
 
 ## Conventions
 


### PR DESCRIPTION
## Plan
- `plans/browser_game/governing_plan.md` (Phase 2 → Phase 3 transition)

## Summary
- Close Phase 2 (Backend API) checkpoints — mark Steps 3-6 as COMPLETE, SP-2-01 as completed
- Create SP-3-02 implementation sub-plan for Phase 3 (Browser UI) with 5-step structure
- Update Phase 3 checkpoints with refined steps and unblock after Phase 2 closure

## Why
PR #1435 merged all Phase 2 deliverables (routes, templates, tests). Phase 2 checkpoints
need closure, and Phase 3 needs an executable sub-plan before implementation can begin.

## Repro / Validation
**Command(s) run:**
- `make check-quiet` → ✓ All checks passed

**Config (if applicable):** N/A (docs-only)

**Seed (if applicable):** N/A

## Tests
- [x] `make check-quiet` — all checks passed
- [x] Other: docs-only PR, no code changes

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a  1f26b180 [docs/phase2-closure-phase3-subplan]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)