### PR TITLE
fix: silence git reset stdout in session-sync hook

### DIFF
--- a/.claude/hooks/session-sync-worktree.sh
+++ b/.claude/hooks/session-sync-worktree.sh
@@ -75,7 +75,7 @@ fi
 # Switch to tracking origin/main. We can't checkout 'main' directly because
 # it's used by the primary worktree — instead reset the current branch to
 # origin/main, giving us the same effect.
-git -C "$PROJECT_DIR" reset --hard origin/main 2>/dev/null || {
+git -C "$PROJECT_DIR" reset --hard origin/main >/dev/null 2>&1 || {
   echo >&2 "${LOG_PREFIX} WARNING: Failed to reset to origin/main — skipping."
   exit 0
 }

--- a/tests/unit/test_session_sync_hook.py
+++ b/tests/unit/test_session_sync_hook.py
@@ -37,6 +37,24 @@ class TestSessionSyncSilentSuccess:
                 "WARNING" in line
             ), f"Non-warning stderr output found (issue #1421): {line}"
 
+    def test_git_reset_silences_stdout(self) -> None:
+        """The git reset command must redirect both stdout and stderr (issue #1437)."""
+        content = HOOK_PATH.read_text()
+        # Find the git reset line
+        reset_lines = [
+            line.strip()
+            for line in content.splitlines()
+            if "git" in line and "reset" in line and not line.strip().startswith("#")
+        ]
+        assert (
+            len(reset_lines) == 1
+        ), f"Expected 1 git reset line, found {len(reset_lines)}"
+        reset_line = reset_lines[0]
+        # Must redirect stdout (>/dev/null) — not just stderr (2>/dev/null)
+        assert (
+            ">/dev/null" in reset_line
+        ), f"git reset must redirect stdout to /dev/null: {reset_line}"
+
     def test_non_steward_dir_exits_silently(self) -> None:
         """Hook exits 0 with no output when PROJECT_DIR is not a steward dir."""
         import os


### PR DESCRIPTION
## Summary

- Redirect both stdout and stderr for the `git reset --hard` command in `session-sync-worktree.sh`
- Changed `2>/dev/null` → `>/dev/null 2>&1` to suppress "HEAD is now at …" output

## Why

Follow-up from PR #1432 — the sync path at line 78 still printed git reset success output to stdout, cluttering the TUI. Closes #1437.

## Repro / Validation

```bash
# Verify the redirect:
grep 'git.*reset.*hard' .claude/hooks/session-sync-worktree.sh
# Should show: >/dev/null 2>&1

# Full validation:
make check-quiet
```

## Tests

- `tests/unit/test_session_sync_hook.py::TestSessionSyncSilentSuccess::test_git_reset_silences_stdout` — new test verifying stdout redirect
- `make check-quiet` ✅

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: fix/session-sync-quiet
worktree: Bid-Euchre-steward-author (persistent author-a lane)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)