### PR TITLE
fix: use correct --channels plugin flag for Telegram integration

### DIFF
--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -52,7 +52,7 @@ if [ -z "$CLAUDE_BIN" ]; then
 fi
 
 # Telegram channel configuration (Platform-8a).
-# Set STEWARD_TELEGRAM_ENABLED=1 to add --channels telegram to the
+# Set STEWARD_TELEGRAM_ENABLED=1 to add the Telegram channel plugin to the
 # orchestrator pane.  Default is 0 (disabled / tmux-only).
 # Only the orchestrator lane gets the channel flag — author lanes remain
 # tmux-only per SP-4-01 key decisions.
@@ -316,11 +316,11 @@ write_lane_metadata "flex-c"         "flex"          "$FLEX_C"          "codex/s
 # Orchestrator channel flags (Platform-8a)
 # ---------------------------------------------------------------------------
 # When STEWARD_TELEGRAM_ENABLED=1 the orchestrator pane gets
-# --channels telegram so the Channels plugin connects on boot.
+# --channels so the Telegram plugin connects on boot.
 # All other panes launch without --channels (tmux-only).
 ORCH_CHANNEL_FLAGS=""
 if [ "$STEWARD_TELEGRAM_ENABLED" = "1" ]; then
-    ORCH_CHANNEL_FLAGS="--channels telegram"
+    ORCH_CHANNEL_FLAGS="--channels plugin:telegram@claude-plugins-official"
     export STEWARD_CHANNELS="telegram"
 fi
 

--- a/plans/agent_ops/4_remote_channel/checkpoints.md
+++ b/plans/agent_ops/4_remote_channel/checkpoints.md
@@ -51,7 +51,7 @@ implementation.
 | `scripts/internal/ops.py` | SP-4-02 | SP-4-03, SP-4-04 | SP-4-02 lands CLI hardening first; SP-4-03 rebases before adding token subcommands; SP-4-04 may add channel status CLI last (Step 6, optional) |
 | `src/bid_euchre/ops/dashboard.py` | SP-4-03 | SP-4-02, SP-4-04 | SP-4-03 owns new dashboard panels; SP-4-02 may add data feeds but not panel layout; SP-4-04 may add channel status indicator (Step 6, optional) |
 | `src/bid_euchre/ops/monitor.py` | SP-4-02 | SP-4-04 | SP-4-02 owns stall recovery and auto-dispatch; SP-4-04 channel health check deferred to Platform-9c |
-| `.claude/tmux/steward-session.sh` | SP-4-04 | — | SP-4-04 adds `--channels telegram` flag and channel env vars; no other SP modifies the launcher |
+| `.claude/tmux/steward-session.sh` | SP-4-04 | — | SP-4-04 adds `--channels plugin:telegram@claude-plugins-official` flag and channel env vars; no other SP modifies the launcher |
 
 ## Blockers
 

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -579,7 +579,8 @@ class TestTelegramChannelConfig:
                     break
         guard_text = "\n".join(guard_body)
         assert (
-            'ORCH_CHANNEL_FLAGS="--channels telegram"' in guard_text
+            'ORCH_CHANNEL_FLAGS="--channels plugin:telegram@claude-plugins-official"'
+            in guard_text
         ), "ORCH_CHANNEL_FLAGS assignment must be inside the STEWARD_TELEGRAM_ENABLED=1 guard"
 
 


### PR DESCRIPTION
## Summary
- Fix `--channels telegram` → `--channels plugin:telegram@claude-plugins-official` in steward-session.sh
- Update test assertion to match corrected flag value
- Update checkpoints.md serialization rule reference

## Why
The Claude Code Channels framework requires the full plugin specifier syntax
(`plugin:<name>@<marketplace>`), not a bare channel name. The original flag
was written speculatively before the Channels docs were available — the bot
token was configured and plugin installed, but the launcher passed the wrong
flag so the channel never activated.

## Repro / Validation
```bash
# Tier 1
uv run python -m pytest tests/unit/test_steward_session.py -x -q  # 53 passed

# Tier 2
make check-quiet  # All checks passed
```

## Tests
- `test_steward_session.py` — 53 tests pass (includes updated channel flag assertion)

## Worktree proof
- Worktree: `Bid-Euchre-steward-author`
- Branch: `fix/telegram-channel-flag`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>