### PR TITLE
ops: auto-detect Telegram plugin in steward-session.sh

### DIFF
--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -52,11 +52,20 @@ if [ -z "$CLAUDE_BIN" ]; then
 fi
 
 # Telegram channel configuration (Platform-8a).
-# Set STEWARD_TELEGRAM_ENABLED=1 to add the Telegram channel plugin to the
-# orchestrator pane.  Default is 0 (disabled / tmux-only).
+# Auto-detect: if the Telegram plugin is installed and enabled, default to on.
+# Override: set STEWARD_TELEGRAM_ENABLED=0 to explicitly disable, or =1 to force enable.
 # Only the orchestrator lane gets the channel flag — author lanes remain
 # tmux-only per SP-4-01 key decisions.
-STEWARD_TELEGRAM_ENABLED="${STEWARD_TELEGRAM_ENABLED:-0}"
+if [ -z "${STEWARD_TELEGRAM_ENABLED+x}" ]; then
+    _plugins="$("$CLAUDE_BIN" plugins list 2>/dev/null || true)"
+    if printf '%s\n' "$_plugins" | grep -q 'telegram' && \
+       ! printf '%s\n' "$_plugins" | grep -A4 'telegram' | grep -q 'disabled'; then
+        STEWARD_TELEGRAM_ENABLED="1"
+    else
+        STEWARD_TELEGRAM_ENABLED="0"
+    fi
+    unset _plugins
+fi
 
 # Platform pool worktrees
 AUTHOR_A="${PARENT_DIR}/${REPO_NAME}-steward-author"

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -519,12 +519,21 @@ class TestWindowLayout:
 class TestTelegramChannelConfig:
     """Tests for the Telegram channel configuration (Platform-8a)."""
 
-    def test_telegram_enabled_env_var_defaults_to_zero(self) -> None:
-        """STEWARD_TELEGRAM_ENABLED must default to 0 (disabled)."""
+    def test_telegram_autodetect_with_fallback_to_zero(self) -> None:
+        """STEWARD_TELEGRAM_ENABLED must auto-detect from plugins, defaulting to 0."""
         content = STEWARD_SCRIPT.read_text()
+        # Must check whether the env var is already set (explicit override)
         assert (
-            'STEWARD_TELEGRAM_ENABLED="${STEWARD_TELEGRAM_ENABLED:-0}"' in content
-        ), "STEWARD_TELEGRAM_ENABLED must default to 0"
+            "${STEWARD_TELEGRAM_ENABLED+x}" in content
+        ), "Must check for explicit STEWARD_TELEGRAM_ENABLED override"
+        # Must auto-detect by running 'plugins list'
+        assert (
+            "plugins list" in content
+        ), "Must auto-detect Telegram plugin via 'plugins list'"
+        # Must fall back to 0 when plugin is not enabled
+        assert (
+            'STEWARD_TELEGRAM_ENABLED="0"' in content
+        ), "Must default STEWARD_TELEGRAM_ENABLED to 0 when plugin not enabled"
 
     def test_channels_flag_only_on_orchestrator(self) -> None:
         """--channels must only appear on the orchestrator pane launch, via ORCH_CHANNEL_FLAGS."""


### PR DESCRIPTION
## Summary
- Replace the static `STEWARD_TELEGRAM_ENABLED` default (hardcoded to `0`) with auto-detection via `claude plugins list`
- Fix the grep pattern from the task spec: the original single-line `telegram.*enabled` would never match since `plugins list` output places name and status on separate lines, and `disabled` contains the substring `enabled`
- Update the corresponding test from exact-string match to structural assertions on the auto-detection block

## Why
The orchestrator alias currently requires manually setting `STEWARD_TELEGRAM_ENABLED=1`. With auto-detection, `steward-session.sh` automatically enables Telegram when the plugin is installed and enabled — no alias change needed. Explicit overrides (`=0` or `=1`) still work.

## Repro / Validation
```bash
# Syntax check
bash -n .claude/tmux/steward-session.sh

# Unit tests
uv run python -m pytest tests/unit/test_steward_session.py -v

# Functional test (in shell)
unset STEWARD_TELEGRAM_ENABLED
CLAUDE_BIN="$(command -v claude)"
_plugins="$("$CLAUDE_BIN" plugins list 2>/dev/null || true)"
if printf '%s\n' "$_plugins" | grep -q 'telegram' && \
   ! printf '%s\n' "$_plugins" | grep -A4 'telegram' | grep -q 'disabled'; then
    STEWARD_TELEGRAM_ENABLED="1"
else
    STEWARD_TELEGRAM_ENABLED="0"
fi
echo "Result: $STEWARD_TELEGRAM_ENABLED"  # 0 if plugin disabled, 1 if enabled
```

## Tests
```bash
uv run python -m pytest tests/unit/test_steward_session.py -v  # 53 passed
make check-quiet  # ✓ All checks passed
```

## Worktree proof
```
worktree: Bid-Euchre-steward-flex-a
branch: ops/telegram-autodetect
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)