### PR TITLE
docs: reconcile Agent Ops Phase 4 governance docs

### DIFF
--- a/plans/agent_ops/4_remote_channel/checkpoints.md
+++ b/plans/agent_ops/4_remote_channel/checkpoints.md
@@ -3,7 +3,7 @@
 **Phase:** 4 (`4_remote_channel`)
 **Status:** IN_PROGRESS
 **Governing plan:** `plans/agent_ops/governing_plan.md`
-**Last updated:** 2026-03-23 by author-a (SP-4-03 completed)
+**Last updated:** 2026-03-23 by author-scratch (reconcile SP-4-03/SP-4-04 status)
 
 ---
 
@@ -58,6 +58,9 @@ implementation.
 - [x] ~~SP-3-05 dual-domain steward layout transition~~ — COMPLETE (2026-03-23).
   Dual-domain layout shipped in pre-proving hardening session (PRs #1281–#1294).
   Proving run passed 2026-03-23. Phase 4 scope lock is unblocked.
+- [ ] **SP-4-04 Steps 3-5** (pairing proof, permission relay proof, kill switch proof) are
+  BLOCKED on user-side Telegram preflight: Bun install, Claude auth, and bot token
+  configuration. Step 2 (launcher Telegram config) is complete (PR #1452).
 
 ## Session Log
 
@@ -71,3 +74,4 @@ implementation.
 | 2026-03-23 | SP-4-04 registered (flex-a). Platform-8a Telegram transport sub-plan: 6 steps covering preflight, plugin config, pairing proof, permission relay proof, kill switch proof, and registry integration. Steps 3-5 parallelizable after Step 2. Key constraint: orchestrator-only ingress, no audit trail (deferred to Platform-9c). |
 | 2026-03-23 | SP-4-03 completed (author-a). Baseline token economy report produced at `plans/sessions/2026-03-23_token-economy-baseline.md`. Key findings: 52.4% shipped-token rate, 10.9K tokens/commit, 71% zero-commit session rate. Top 3 waste patterns: abandoned-work churn (42.9% of tokens), wrong-approach retry (60 friction events), high-error session tax (16.8% of tokens). Pre-steward data only (2026-02-03 to 2026-03-14); per-lane attribution requires post-steward follow-up. |
 | 2026-03-23 | SP-4-04 Step 2 (author-a): Telegram config added to tmux launcher. `STEWARD_TELEGRAM_ENABLED` env var (default 0) controls kill switch. When enabled, appends `--channels telegram` to orchestrator pane only. `STEWARD_CHANNELS` exported for orchestrator. Author lanes remain tmux-only. |
+| 2026-03-23 | Governance reconciliation (author-scratch): Fixed sub_plan_registry.md vs checkpoints.md disagreement — SP-4-03 updated to `completed` (baseline report done; live dashboard integration partial, follow-up needed), SP-4-04 updated to `in_progress` with owner `flex-a`. SP-4-04 Steps 3-5 marked BLOCKED on user-side Telegram preflight. |

--- a/plans/agent_ops/sub_plan_registry.md
+++ b/plans/agent_ops/sub_plan_registry.md
@@ -1,7 +1,7 @@
 # Sub-Plan Registry — Agentic Orchestration Platform
 
 **Governing plan:** `plans/agent_ops/governing_plan.md`
-**Last updated:** 2026-03-23 by flex-a (register SP-4-04)
+**Last updated:** 2026-03-23 by author-scratch (reconcile SP-4-03/SP-4-04 status)
 
 ---
 
@@ -26,17 +26,17 @@
 | SP-3-08 | Monitoring cycle with session-start auto-launch | Post-Phase-3 transition: ops monitoring cycle and auto-launch | completed | orchestrator | _(no sub-plan file — single-PR scope)_ | 2026-03-23 | 2026-03-23 (PR #1277) |
 | SP-4-01 | Platform-8 scope lock | Phase 4, Platform-8 scope lock and sub-plan registration | completed | author-scratch | `plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8-scope-lock.md` | 2026-03-23 | 2026-03-23 |
 | SP-4-02 | Remote-ops preflight hardening | Phase 4, Pre-Platform-8 operational hardening | in_progress | orchestrator | `plans/agent_ops/4_remote_channel/sub/2026-03-23_remote-ops-preflight-hardening.md` | 2026-03-23 | — |
-| SP-4-03 | Token economy observability and dashboard | Phase 4, Pre-Platform-8 token observability | proposed | orchestrator | `plans/agent_ops/4_remote_channel/sub/2026-03-23_token-economy-observability-and-dashboard.md` | 2026-03-23 | — |
-| SP-4-04 | Platform-8a Telegram transport configuration | Phase 4, Platform-8a transport proving | proposed | unassigned | `plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8a-telegram-transport.md` | 2026-03-23 | — |
+| SP-4-03 | Token economy observability and dashboard | Phase 4, Pre-Platform-8 token observability | completed | orchestrator | `plans/agent_ops/4_remote_channel/sub/2026-03-23_token-economy-observability-and-dashboard.md` | 2026-03-23 | 2026-03-23 (baseline report at `plans/sessions/2026-03-23_token-economy-baseline.md`; live dashboard integration is partial — follow-up needed) |
+| SP-4-04 | Platform-8a Telegram transport configuration | Phase 4, Platform-8a transport proving | in_progress | flex-a | `plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8a-telegram-transport.md` | 2026-03-23 | — |
 
 ## Status Summary
 
 | Status | Count |
 |--------|-------|
-| proposed | 2 |
-| in_progress | 1 |
+| proposed | 0 |
+| in_progress | 2 |
 | blocked | 0 |
-| completed | 14 |
+| completed | 15 |
 | abandoned | 0 |
 | superseded | 1 |
 


### PR DESCRIPTION
## Summary

- Fix P1 docs inconsistency where `sub_plan_registry.md` listed SP-4-03 as `proposed` and SP-4-04 as `proposed/unassigned`, while `checkpoints.md` correctly showed SP-4-03 as `completed` and SP-4-04 as `in_progress`
- Update status summary counts and add blocker note for SP-4-04 Steps 3-5
- Add session log entry documenting the reconciliation

## Why

Review finding: governance docs disagreed on sub-plan status, creating confusion about actual Phase 4 progress. The checkpoints were correct (verified from session logs and merged PRs); the registry was stale.

## Changes

| File | Change |
|------|--------|
| `plans/agent_ops/sub_plan_registry.md` | SP-4-03: `proposed` → `completed` (2026-03-23), added scope note. SP-4-04: `proposed`/`unassigned` → `in_progress`/`flex-a`. Status summary: proposed 2→0, in_progress 1→2, completed 14→15. |
| `plans/agent_ops/4_remote_channel/checkpoints.md` | Added SP-4-04 Steps 3-5 BLOCKED note (user-side Telegram preflight). Added session log entry. |

## Validation

```bash
make check-quiet  # 3 pre-existing collection errors (missing starlette dep), unrelated to docs changes
git diff --stat   # Only 2 declared-scope files changed
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-scratch
branch: docs/reconcile-phase4-governance
```

## Test plan

- [x] Docs-only — no code changes
- [x] Only declared-scope files modified
- [x] Status counts verified (18 total: 0+2+0+15+0+1)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)