### PR TITLE
fix(test): tighten session-sync test to reject old redirect pattern

### DIFF
--- a/tests/unit/test_session_sync_hook.py
+++ b/tests/unit/test_session_sync_hook.py
@@ -50,10 +50,13 @@ class TestSessionSyncSilentSuccess:
             len(reset_lines) == 1
         ), f"Expected 1 git reset line, found {len(reset_lines)}"
         reset_line = reset_lines[0]
-        # Must redirect stdout (>/dev/null) — not just stderr (2>/dev/null)
+        # Must redirect both stdout AND stderr (>/dev/null 2>&1),
+        # not just stderr alone (2>/dev/null).  The old pattern
+        # "2>/dev/null" is a substring of the correct redirect, so we
+        # check for the full pattern to avoid a false-positive.
         assert (
-            ">/dev/null" in reset_line
-        ), f"git reset must redirect stdout to /dev/null: {reset_line}"
+            ">/dev/null 2>&1" in reset_line
+        ), f"git reset must redirect stdout+stderr (>/dev/null 2>&1): {reset_line}"
 
     def test_non_steward_dir_exits_silently(self) -> None:
         """Hook exits 0 with no output when PROJECT_DIR is not a steward dir."""


### PR DESCRIPTION
## Summary
- Fixes false-positive assertion in `test_git_reset_silences_stdout` that accepted both old and new redirect patterns
- Now asserts the full `>/dev/null 2>&1` pattern instead of just `>/dev/null`

## Why
The old assertion `">/dev/null" in reset_line` is a substring of both `2>/dev/null` (the broken pattern) and `>/dev/null 2>&1` (the correct pattern). This means the test would pass even if the hook regressed to the old stderr-only redirect, making it a false-positive.

Closes #1450

## Repro / Validation
```bash
# Verify the fix distinguishes patterns correctly:
python3 -c "
old = 'git reset --hard origin/main 2>/dev/null'
new = 'git reset --hard origin/main >/dev/null 2>&1'
print('Old assertion passes both:', '>/dev/null' in old, '>/dev/null' in new)
print('New assertion rejects old:', '>/dev/null 2>&1' in old, '>/dev/null 2>&1' in new)
"
```

## Tests
```bash
uv run python -m pytest tests/unit/test_session_sync_hook.py -v  # 3/3 pass
make check-quiet  # All checks passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: fix/session-sync-test-assertion
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)