### PR TITLE
browser-game: fix convention follow-ups in test_app.py

### DIFF
--- a/tests/unit/hosted_play/test_app.py
+++ b/tests/unit/hosted_play/test_app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from fastapi.middleware.cors import CORSMiddleware
 from starlette.testclient import TestClient
 
 from web.ai_manager import AIManager
@@ -37,11 +38,9 @@ class TestCreateApp:
 
     def test_cors_middleware_registered(self, tmp_path):
         app = _make_app(tmp_path)
-        # CORS middleware is in the middleware stack
-        middleware_classes = [
-            type(m).__name__ for m in getattr(app, "user_middleware", [])
-        ]
-        assert "Middleware" in str(middleware_classes) or len(app.user_middleware) > 0
+        # Verify CORSMiddleware specifically (not just any middleware)
+        middleware_classes = [m.cls for m in app.user_middleware]
+        assert CORSMiddleware in middleware_classes
 
 
 # ---------------------------------------------------------------------------
@@ -83,11 +82,14 @@ class TestLifespan:
         app = _make_app(tmp_path)
         with TestClient(app):
             engine = app.state.engine
-        # After exiting the TestClient context, the engine should be disposed.
-        # Verify pool has no active connections (connections returned to pool
-        # and pool drained after dispose).
-        status = engine.pool.status()
-        assert "Checked out connections: 0" in status
+        # After exiting the TestClient context, engine.dispose() has run.
+        # Assert the pool was fully disposed — no connections remain at all,
+        # not just zero checked-out.
+        pool = engine.pool
+        assert (
+            pool.checkedout() == 0
+        ), f"Expected 0 checked-out, got {pool.checkedout()}"
+        assert pool.checkedin() == 0, f"Expected 0 checked-in, got {pool.checkedin()}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Check for `CORSMiddleware` specifically instead of generic wrapper string matching
- Assert full pool disposal (`checkedin + checkedout == 0`) instead of only zero checked-out via string parsing

## Why
Address two P3 review findings from PR #1446 (issue #1449). The original assertions were too loose — they would pass even if the wrong middleware was registered or if the pool wasn't fully disposed.

Closes #1449

## Repro / Validation
```bash
uv run python -m pytest tests/unit/hosted_play/test_app.py -v
make check-quiet
```

## Tests
- `uv run python -m pytest tests/unit/hosted_play/test_app.py -v` — 10/10 passed
- `make check-quiet` — all checks passed

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
branch: browser-game/fix-convention-1449
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>