### PR TITLE
fix(web): escape nicknames (XSS) and fix hx-post URL

### DIFF
--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -648,3 +648,62 @@ class TestEdgeCases:
             data={"turn_number": 0, "card_index": 0},
         )
         assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# XSS prevention (issue #1438)
+# ---------------------------------------------------------------------------
+
+
+class TestXSSPrevention:
+    """Verify user-supplied nicknames are HTML-escaped in responses."""
+
+    def test_nickname_html_escaped_in_set_nickname(self, client):
+        """set_nickname() must escape HTML in the nickname."""
+        link_uuid = _create_game(client)
+        xss_payload = '<script>alert("xss")</script>'
+        resp = _set_nickname(client, link_uuid, xss_payload)
+        assert resp.status_code == 200
+        # Raw script tag must NOT appear in the response
+        assert "<script>" not in resp.text
+        # Escaped form should appear
+        assert "&lt;script&gt;" in resp.text
+
+    def test_nickname_html_escaped_in_game_page(self, client):
+        """game_page() must escape HTML in the stored nickname."""
+        link_uuid = _create_game(client)
+        xss_payload = '<img src=x onerror="alert(1)">'
+        _set_nickname(client, link_uuid, xss_payload)
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        # Raw tag must NOT appear
+        assert '<img src=x onerror="alert(1)">' not in resp.text
+        assert "&lt;img" in resp.text
+
+    def test_nickname_html_escaped_in_new_match(self, client):
+        """new_match() must escape HTML in the stored nickname."""
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid, "<b>bold</b>")
+        resp = client.post(f"/play/{link_uuid}/new-match")
+        assert resp.status_code == 200
+        assert "<b>bold</b>" not in resp.text
+        assert "&lt;b&gt;" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# hx-post URL interpolation (issue #1439)
+# ---------------------------------------------------------------------------
+
+
+class TestHxPostUrl:
+    """Verify hx-post attribute contains the correct interpolated URL."""
+
+    def test_hx_post_contains_link_uuid(self, client):
+        """The nickname form hx-post must include the actual link_uuid."""
+        link_uuid = _create_game(client)
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        # The hx-post attribute should contain the real UUID, not the
+        # literal placeholder "{link_uuid}"
+        assert f'hx-post="/play/{link_uuid}/nickname"' in resp.text
+        assert "{link_uuid}" not in resp.text

--- a/web/routes.py
+++ b/web/routes.py
@@ -10,6 +10,7 @@ no rule/scoring logic lives here.
 
 from __future__ import annotations
 
+import html
 import json
 import random
 import uuid
@@ -216,7 +217,7 @@ async def game_page(request: Request, link_uuid: str):
                 "<html><body>"
                 "<h2>Enter your nickname</h2>"
                 f'<form method="post" action="/play/{link_uuid}/nickname"'
-                ' hx-post="/play/{link_uuid}/nickname" hx-target="#main">'
+                f' hx-post="/play/{link_uuid}/nickname" hx-target="#main">'
                 '<input name="nickname" required>'
                 '<button type="submit">Set Nickname</button>'
                 "</form>"
@@ -241,7 +242,7 @@ async def game_page(request: Request, link_uuid: str):
             )
             return HTMLResponse(
                 "<html><body>"
-                f"<h2>Welcome, {player.nickname}!</h2>"
+                f"<h2>Welcome, {html.escape(player.nickname)}!</h2>"
                 f'<form method="post" action="/play/{link_uuid}/select-ai">'
                 f'<select name="model_id">{options}</select>'
                 '<button type="submit">Start Match</button>'
@@ -256,7 +257,7 @@ async def game_page(request: Request, link_uuid: str):
         visible = engine.get_visible_state(state)
         return HTMLResponse(
             "<html><body>"
-            f"<h2>Game Board — {player.nickname}</h2>"
+            f"<h2>Game Board — {html.escape(player.nickname)}</h2>"
             f"<pre>{json.dumps(visible, indent=2)}</pre>"
             "</body></html>"
         )
@@ -288,7 +289,7 @@ async def set_nickname(
             for m in models
         )
         return HTMLResponse(
-            f"<h2>Welcome, {nickname}!</h2>"
+            f"<h2>Welcome, {html.escape(nickname)}!</h2>"
             f'<form method="post" action="/play/{link_uuid}/select-ai">'
             f'<select name="model_id">{options}</select>'
             '<button type="submit">Start Match</button>'
@@ -578,7 +579,7 @@ async def new_match(
             for m in models
         )
         return HTMLResponse(
-            f"<h2>New Match — {player.nickname}</h2>"
+            f"<h2>New Match — {html.escape(player.nickname)}</h2>"
             f'<form method="post" action="/play/{link_uuid}/select-ai">'
             f'<select name="model_id">{options}</select>'
             '<button type="submit">Start Match</button>'


### PR DESCRIPTION
## Summary

- **XSS fix (#1438):** Apply `html.escape()` to all user-supplied nickname values before HTML interpolation in `game_page()`, `set_nickname()`, and `new_match()` route handlers. Added `import html` at the top of `web/routes.py`.
- **Broken hx-post fix (#1439):** Add missing `f`-string prefix to the `hx-post` attribute in the nickname form so `{link_uuid}` is properly interpolated instead of rendered as a literal string.

## Why

Both bugs are security/correctness issues in the browser-game web layer. The XSS vulnerability allows arbitrary script injection via player nicknames. The broken hx-post means the HTMX nickname form submits to a URL containing the literal text `{link_uuid}` instead of the actual UUID.

Closes #1438, closes #1439.

## Repro / Validation

```bash
# Tier 1 — targeted tests (21 pass, including 4 new)
uv run python -m pytest tests/unit/hosted_play/test_routes.py -v

# Tier 2 — full validation
make check-quiet
```

## Tests

- `TestXSSPrevention::test_nickname_html_escaped_in_set_nickname` — verifies `<script>` tags are escaped in set_nickname response
- `TestXSSPrevention::test_nickname_html_escaped_in_game_page` — verifies stored nickname is escaped when game page renders
- `TestXSSPrevention::test_nickname_html_escaped_in_new_match` — verifies nickname is escaped in new-match response
- `TestHxPostUrl::test_hx_post_contains_link_uuid` — verifies hx-post URL contains actual UUID, not literal `{link_uuid}`

## Worktree proof

```
pwd: Bid-Euchre-steward-brws-author-a
branch: fix/web-xss-and-hxpost
```

## Scope

Only `web/routes.py` modified (production code). Test file `tests/unit/hosted_play/test_routes.py` extended with 4 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)