### PR TITLE
fix: render zero tokens_per_commit in text dashboard

### DIFF
--- a/src/bid_euchre/ops/dashboard.py
+++ b/src/bid_euchre/ops/dashboard.py
@@ -595,7 +595,7 @@ def format_dashboard_text(
             lines.append("  Top lanes:")
             for tl in top_lanes[:3]:
                 tpc = tl.get("tokens_per_commit")
-                tpc_str = f"{tpc:,.0f} tok/commit" if tpc else "—"
+                tpc_str = f"{tpc:,.0f} tok/commit" if tpc is not None else "—"
                 lines.append(
                     f"    {tl['lane_id']:<18s} {tl['total_tokens']:>10,d} tok"
                     f"  {tpc_str}"

--- a/tests/unit/test_ops_dashboard.py
+++ b/tests/unit/test_ops_dashboard.py
@@ -491,6 +491,51 @@ class TestFormatDashboardText:
         assert "Tasks: 3 active, 1 blocked" in text
         assert "Task Queue: 2 packets" in text
 
+    def test_token_economy_zero_tokens_per_commit(self) -> None:
+        """Zero tokens_per_commit should render as '0 tok/commit', not '—'."""
+        now = datetime(2026, 3, 21, 12, 0, 0, tzinfo=timezone.utc)
+        view = DashboardView(
+            generated_at=now.isoformat(),
+            foreground=DashboardSection(title="Foreground Lanes", lanes=[]),
+            background=DashboardSection(title="Background Lanes", lanes=[]),
+            token_economy={
+                "overview": {
+                    "total_tokens": 100_000,
+                    "session_count": 5,
+                    "total_git_commits": 3,
+                    "tokens_per_hour": 5000,
+                    "output_input_ratio": 2.1,
+                    "net_lines": 42,
+                },
+                "top_lanes": [
+                    {
+                        "lane_id": "author-a",
+                        "total_tokens": 50_000,
+                        "tokens_per_commit": 0.0,
+                    },
+                    {
+                        "lane_id": "author-b",
+                        "total_tokens": 30_000,
+                        "tokens_per_commit": 15_000.0,
+                    },
+                    {
+                        "lane_id": "author-c",
+                        "total_tokens": 20_000,
+                        "tokens_per_commit": None,
+                    },
+                ],
+            },
+        )
+        text = format_dashboard_text(view, now=now)
+        # Zero should show as "0 tok/commit", not "—"
+        assert "0 tok/commit" in text
+        # None should show as "—"
+        lines = text.split("\n")
+        author_c_line = [l for l in lines if "author-c" in l][0]
+        assert "—" in author_c_line
+        # Non-zero should show the value
+        assert "15,000 tok/commit" in text
+
 
 # ---------------------------------------------------------------------------
 # Tests: format_dashboard_json


### PR DESCRIPTION
## Summary
- Fix C2 anti-pattern (falsy numeric guard) in `format_dashboard_text()` that rendered `tokens_per_commit=0.0` as "—" instead of "0 tok/commit"
- Add regression test covering zero, None, and non-zero `tokens_per_commit` cases

## Why
Issue #1444 (follow-up from PR #1441 review): PR #1441 fixed the data preparation side in `dashboard_token_economy()`, but the text rendering in `format_dashboard_text()` still used `if tpc` which treats `0.0` as falsy. Zero is valid data — it means the lane ran but produced no commits.

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_ops_dashboard.py::TestFormatDashboardText::test_token_economy_zero_tokens_per_commit -v
uv run python -m pytest tests/unit/test_ops_dashboard.py -v  # 36 passed
make lint      # passed
make repo-lint # passed
```

## Tests
```bash
uv run python -m pytest tests/unit/test_ops_dashboard.py -v  # 36 passed
uv run python -m pytest tests/ -m "not slow" --ignore=tests/unit/hosted_play -q  # 6183 passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
branch: fix/dashboard-text-zero-tokens-1444
```

Closes #1444

🤖 Generated with [Claude Code](https://claude.com/claude-code)