### PR TITLE
fix: pass STEWARD_CHANNELS through tmux environment

### DIFF
--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -327,10 +327,13 @@ write_lane_metadata "flex-c"         "flex"          "$FLEX_C"          "codex/s
 # When STEWARD_TELEGRAM_ENABLED=1 the orchestrator pane gets
 # --channels so the Telegram plugin connects on boot.
 # All other panes launch without --channels (tmux-only).
+# STEWARD_CHANNELS is propagated via tmux set-environment (not shell export)
+# so that panes spawned by the tmux server can read it.
 ORCH_CHANNEL_FLAGS=""
+STEWARD_CHANNELS=""
 if [ "$STEWARD_TELEGRAM_ENABLED" = "1" ]; then
     ORCH_CHANNEL_FLAGS="--channels plugin:telegram@claude-plugins-official"
-    export STEWARD_CHANNELS="telegram"
+    STEWARD_CHANNELS="telegram"
 fi
 
 # ---------------------------------------------------------------------------
@@ -342,6 +345,15 @@ fi
 # --- Window 1: central-ops (3 panes, main-vertical) ---
 tmux new-session -d -s "$SESSION" -n central-ops -c "$MAIN_DIR" \
     "$CLAUDE_BIN" --name orchestrator --agent steward-orchestrator $ORCH_CHANNEL_FLAGS
+
+# Propagate channel config into the tmux session environment so all panes
+# can read it.  Shell `export` only affects the launcher process; tmux panes
+# are spawned by the tmux server and need `set-environment` instead.
+if [ -n "$STEWARD_CHANNELS" ]; then
+    tmux set-environment -t "$SESSION" STEWARD_CHANNELS "$STEWARD_CHANNELS"
+fi
+tmux set-environment -t "$SESSION" STEWARD_TELEGRAM_ENABLED "$STEWARD_TELEGRAM_ENABLED"
+
 tmux split-window -t "${SESSION}:central-ops" -c "$MAIN_DIR" \
     "$CLAUDE_BIN" --name ops --agent steward-ops
 tmux split-window -t "${SESSION}:central-ops" -c "$REVIEW" \

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -559,12 +559,15 @@ class TestTelegramChannelConfig:
                 "--channels" not in line
             ), f"Non-orchestrator lane must not use --channels: {line}"
 
-    def test_steward_channels_exported_when_enabled(self) -> None:
-        """STEWARD_CHANNELS must be exported when STEWARD_TELEGRAM_ENABLED=1."""
+    def test_steward_channels_propagated_via_tmux(self) -> None:
+        """STEWARD_CHANNELS must be propagated via tmux set-environment, not shell export."""
         content = STEWARD_SCRIPT.read_text()
         assert (
-            'export STEWARD_CHANNELS="telegram"' in content
-        ), "STEWARD_CHANNELS must be exported as 'telegram' when enabled"
+            "tmux set-environment" in content and "STEWARD_CHANNELS" in content
+        ), "STEWARD_CHANNELS must be propagated via tmux set-environment"
+        assert (
+            "export STEWARD_CHANNELS" not in content
+        ), "STEWARD_CHANNELS must not use shell export (tmux panes don't inherit it)"
 
     def test_channel_flags_empty_by_default(self) -> None:
         """ORCH_CHANNEL_FLAGS must be empty string by default."""


### PR DESCRIPTION
## Summary

- Replace `export STEWARD_CHANNELS="telegram"` with `tmux set-environment` to propagate the variable through the tmux session environment
- Also propagate `STEWARD_TELEGRAM_ENABLED` for consistency
- Update unit test to assert the new `tmux set-environment` pattern and disallow shell `export`

## Why

Shell `export` only affects child processes of the launcher script. Tmux panes are spawned by the tmux server, not the launcher, so they don't inherit the client shell's exported variables. `tmux set-environment` sets variables in the session environment where all panes can read them.

## Repro / Validation

```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/test_steward_session.py -v
# 53 passed

# Tier 2 — full validation
make check-quiet
# ✓ All checks passed (6319 passed, 45 skipped, 5 deselected)
```

## Worktree Proof

```
pwd: .../Bid-Euchre-steward-flex-a
branch: fix/steward-channels-tmux-env
```

Closes #1440

🤖 Generated with [Claude Code](https://claude.com/claude-code)