### PR TITLE
ops: auto-import token economy data into dashboard runtime

### DIFF
--- a/src/bid_euchre/ops/token_economy.py
+++ b/src/bid_euchre/ops/token_economy.py
@@ -1350,11 +1350,58 @@ def detect_anti_patterns(*, output_dir: Path | None = None) -> list[AntiPattern]
 
 
 # ---------------------------------------------------------------------------
+# Auto-import — populate store on first dashboard access or when stale
+# ---------------------------------------------------------------------------
+
+#: Maximum age of the session store before auto-reimport (seconds).
+_STALE_THRESHOLD_SECONDS = 3600  # 1 hour
+
+
+def _is_store_stale(output_dir: Path) -> bool:
+    """Check whether the session store needs a refresh.
+
+    Returns True when the store doesn't exist, is empty, or the JSONL file
+    hasn't been modified within :data:`_STALE_THRESHOLD_SECONDS`.
+    """
+    usage_file = output_dir / "session_usage.jsonl"
+    if not usage_file.exists() or usage_file.stat().st_size == 0:
+        return True
+    age = datetime.now(timezone.utc).timestamp() - usage_file.stat().st_mtime
+    return age > _STALE_THRESHOLD_SECONDS
+
+
+def _ensure_imported(output_dir: Path) -> None:
+    """Auto-import usage data if the store is empty or stale.
+
+    Runs ``import_usage_data`` followed by ``attribute_sessions`` so that
+    both ``session_usage.jsonl`` and ``session_attributions.jsonl`` are
+    populated.  This is best-effort — failures are logged and swallowed
+    so the dashboard never crashes due to import issues.
+    """
+    if not _is_store_stale(output_dir):
+        return
+
+    try:
+        result = import_usage_data(output_dir=output_dir)
+        if result.sessions_imported > 0 or result.sessions_skipped > 0:
+            attribute_sessions(output_dir=output_dir)
+        logger.info(
+            "Auto-imported token economy data: %d new, %d skipped",
+            result.sessions_imported,
+            result.sessions_skipped,
+        )
+    except Exception as exc:
+        logger.debug("Auto-import failed (best-effort): %s", exc)
+
+
+# ---------------------------------------------------------------------------
 # Dashboard surface — JSON-serializable token economy snapshot
 # ---------------------------------------------------------------------------
 
 
-def dashboard_token_economy(*, output_dir: Path | None = None) -> dict[str, Any]:
+def dashboard_token_economy(
+    *, output_dir: Path | None = None, auto_import: bool = True
+) -> dict[str, Any]:
     """Build a dashboard-ready dict with token economy sections.
 
     Returns a JSON-serializable dict containing:
@@ -1364,18 +1411,28 @@ def dashboard_token_economy(*, output_dir: Path | None = None) -> dict[str, Any]
     - ``throughput``: throughput-normalized metrics
     - ``anti_patterns``: detected anti-patterns
 
-    Returns an empty dict (``{}``) when no usage data is imported,
-    ensuring the dashboard renders cleanly without token data.
+    When *auto_import* is True (the default), auto-imports usage data from
+    ``~/.claude/usage-data/`` when the store is empty or stale (older than
+    1 hour).  Returns an empty dict (``{}``) when no usage data is available
+    even after import.
 
     Parameters
     ----------
     output_dir
         Path to the token economy store. Defaults to repo runtime path.
+    auto_import
+        If True, automatically run ``import_usage_data`` + ``attribute_sessions``
+        when the store is empty or stale.  Set to False in tests to avoid
+        reading real system usage data.
     """
     try:
         resolved_output = _resolve_output_dir(output_dir)
     except ValueError:
         return {}
+
+    # Auto-import: populate store if empty or stale
+    if auto_import:
+        _ensure_imported(resolved_output)
 
     sessions = _load_sessions(resolved_output)
     if not sessions:

--- a/tests/unit/test_ops_token_economy.py
+++ b/tests/unit/test_ops_token_economy.py
@@ -29,6 +29,7 @@ from bid_euchre.ops.token_economy import (
     ThroughputMetrics,
     UsageSummary,
     _is_session_complete,
+    _is_store_stale,
     attribute_sessions,
     dashboard_token_economy,
     detect_anti_patterns,
@@ -1230,7 +1231,7 @@ class TestDashboardTokenEconomy:
         ]
         _write_attributions(output_dir, attributions)
 
-        result = dashboard_token_economy(output_dir=output_dir)
+        result = dashboard_token_economy(output_dir=output_dir, auto_import=False)
 
         assert isinstance(result, dict)
         assert "overview" in result
@@ -1256,7 +1257,7 @@ class TestDashboardTokenEconomy:
 
     def test_dashboard_empty_store(self, output_dir: Path) -> None:
         """Dashboard returns empty dict when no data exists."""
-        result = dashboard_token_economy(output_dir=output_dir)
+        result = dashboard_token_economy(output_dir=output_dir, auto_import=False)
         assert result == {}
 
     def test_dashboard_null_safe(self, output_dir: Path) -> None:
@@ -1270,7 +1271,7 @@ class TestDashboardTokenEconomy:
         ]
         _write_sessions(output_dir, sessions)
 
-        result = dashboard_token_economy(output_dir=output_dir)
+        result = dashboard_token_economy(output_dir=output_dir, auto_import=False)
 
         assert result["overview"]["session_count"] == 1
         assert result["overview"]["total_tokens"] == 0
@@ -1288,7 +1289,7 @@ class TestDashboardTokenEconomy:
         ]
         _write_sessions(output_dir, sessions)
 
-        result = dashboard_token_economy(output_dir=output_dir)
+        result = dashboard_token_economy(output_dir=output_dir, auto_import=False)
 
         assert len(result["anti_patterns"]) > 0
         assert result["anti_patterns"][0]["pattern_id"] == "verbosity_waste"
@@ -1347,7 +1348,7 @@ class TestDashboardTokenEconomy:
         ]
         _write_attributions(output_dir, attributions)
 
-        result = dashboard_token_economy(output_dir=output_dir)
+        result = dashboard_token_economy(output_dir=output_dir, auto_import=False)
 
         # The zero-commit lane should appear in top_lanes with
         # tokens_per_commit=0.0, NOT None
@@ -1359,6 +1360,71 @@ class TestDashboardTokenEconomy:
             f"Expected 0.0, got {zero_lane['tokens_per_commit']!r} — "
             "zero values must not be filtered to None (issue #1420)"
         )
+
+
+# ---------------------------------------------------------------------------
+# Auto-import / staleness tests
+# ---------------------------------------------------------------------------
+
+
+class TestAutoImport:
+    """Verify _is_store_stale and auto_import flag behavior."""
+
+    def test_stale_when_no_file(self, tmp_path: Path) -> None:
+        """Empty directory is stale."""
+        assert _is_store_stale(tmp_path) is True
+
+    def test_stale_when_empty_file(self, tmp_path: Path) -> None:
+        """Zero-byte JSONL is stale."""
+        (tmp_path / "session_usage.jsonl").write_text("")
+        assert _is_store_stale(tmp_path) is True
+
+    def test_not_stale_when_recent(self, tmp_path: Path) -> None:
+        """Recently written JSONL is not stale."""
+        (tmp_path / "session_usage.jsonl").write_text('{"session_id":"s1"}\n')
+        assert _is_store_stale(tmp_path) is False
+
+    def test_auto_import_populates_from_source(self, tmp_path: Path) -> None:
+        """dashboard_token_economy with auto_import reads from source dir.
+
+        Creates a fake usage-data source and verifies the dashboard
+        auto-imports it.
+        """
+        from unittest.mock import patch
+
+        # Set up a fake source with one session
+        usage_dir = tmp_path / "usage-data"
+        (usage_dir / "session-meta").mkdir(parents=True)
+        meta = {
+            "session_id": "auto-001",
+            "input_tokens": 100,
+            "output_tokens": 400,
+            "duration_minutes": 10,
+            "lines_added": 10,
+            "lines_removed": 2,
+            "git_commits": 1,
+            "start_time": "2026-03-20T10:00:00Z",
+            "project_path": "/tmp/test",
+        }
+        (usage_dir / "session-meta" / "auto-001.json").write_text(json.dumps(meta))
+
+        output_dir = tmp_path / "token_economy"
+        output_dir.mkdir()
+
+        # Patch DEFAULT_USAGE_DIR so auto-import reads from our fake source
+        with patch("bid_euchre.ops.token_economy.DEFAULT_USAGE_DIR", usage_dir):
+            result = dashboard_token_economy(output_dir=output_dir, auto_import=True)
+
+        assert result != {}, "Auto-import should populate the store"
+        assert result["overview"]["session_count"] == 1
+        assert result["overview"]["total_tokens"] == 500
+
+    def test_auto_import_false_skips_import(self, tmp_path: Path) -> None:
+        """auto_import=False returns empty dict from empty store."""
+        output_dir = tmp_path / "token_economy"
+        output_dir.mkdir()
+        result = dashboard_token_economy(output_dir=output_dir, auto_import=False)
+        assert result == {}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Plan
- Issue #1454 (SP-4-03 runtime dashboard integration)

## Summary
- Add `_is_store_stale()` and `_ensure_imported()` helpers to `token_economy.py` that auto-detect when the runtime store is empty or stale (>1h)
- Modify `dashboard_token_economy()` to auto-trigger `import_usage_data()` + `attribute_sessions()` on first dashboard access when the store needs refresh
- Add `auto_import` parameter (default True) so tests can opt out of reading real system usage data

## Why
The dashboard's token_economy section returned `null` because `import_usage_data()` was never called to populate `.claude/runtime/token_economy/`. The data pipeline was disconnected — raw usage data existed at `~/.claude/usage-data/` (316 sessions) but was never imported into the runtime store.

## Repro / Validation
**Command(s) run:**
- `uv run python scripts/internal/ops.py dashboard` — now shows Token Economy section with real data
- `uv run python -m pytest tests/unit/test_ops_token_economy.py tests/unit/test_ops_dashboard.py -q` — 113 passed

**Before fix:**
```
Token Economy
  (not displayed — token_economy was null/empty dict)
```

**After fix:**
```
Token Economy
  Tokens: 2,671,254 (308 sessions, 244 commits)
  Efficiency: 5,114 tok/hr, 3.8x out/in, +67,115 net lines
  Top lanes:
    main-checkout       2,574,317 tok  10,908 tok/commit
    unattributed           96,937 tok  12,117 tok/commit
  Anti-patterns: 1 detected
    [high] Retry/churn sessions
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_token_economy.py` — 78 passed (5 new)
- [x] `uv run python -m pytest tests/unit/test_ops_dashboard.py` — 35 passed
- [x] `make check-quiet` — 6324 passed (1 pre-existing flaky failure unrelated to this PR)

## Expected impact
- Metrics impact: none
- Runtime impact: first dashboard call may take ~1s longer due to import; subsequent calls within 1h use cached data

## Risk level
- [x] Low (ops tooling only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c  1485aa16 [ops/token-economy-dashboard]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)