### PR TITLE
fix: add spinner-aware activity detection to approval-stall detector

### DIFF
--- a/src/bid_euchre/ops/monitor.py
+++ b/src/bid_euchre/ops/monitor.py
@@ -791,6 +791,25 @@ def check_stalled_lanes(
 # Approval-stall detection: lanes blocked on tool-approval prompts
 # ---------------------------------------------------------------------------
 
+#: Characters and patterns that indicate a lane is actively working (spinner,
+#: progress indicators).  Presence of these in the last few pane lines means
+#: the lane is NOT stalled — any approval-prompt text is historical noise.
+_SPINNER_GLYPHS: frozenset[str] = frozenset("✶✻✽✢⏺✳⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
+
+_ACTIVE_WORK_PATTERNS: list[re.Pattern[str]] = [
+    # Claude Code spinner status line: "⏺ Running…", "✻ Bash(…"
+    re.compile(r"[✶✻✽✢⏺✳⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]"),
+    # Duration counters (e.g. "1m 23s", "0:45", "12s" but NOT "3.2s")
+    re.compile(r"\d+m\s+\d+s|\d+:\d{2}(?!.*test)|(?<![.\d])\d+s\b"),
+    # Running / timeout indicators
+    re.compile(r"Running[…\.]|timeout", re.IGNORECASE),
+    # Tool execution progress (not prompts — these appear inline during runs)
+    re.compile(r"(?:Bash|Edit|Read|Write|Grep|Glob)\(.*\.\.\.", re.IGNORECASE),
+]
+
+#: Number of trailing pane lines to scan for activity indicators.
+_ACTIVITY_TAIL_LINES: int = 5
+
 #: Regex patterns that match Claude Code tool-approval / elicitation prompts.
 #: Each is compiled once at import time for efficiency.
 _APPROVAL_PATTERNS: list[re.Pattern[str]] = [
@@ -859,6 +878,37 @@ def _capture_pane_content(
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         pass
     return None
+
+
+def _detect_active_work(content: str) -> bool:
+    """Check the tail of pane content for spinner / progress indicators.
+
+    Only the last ``_ACTIVITY_TAIL_LINES`` non-empty lines are checked, since
+    spinners and progress indicators appear at the bottom of the pane where
+    current activity is displayed.
+
+    Args:
+        content: The captured pane text.
+
+    Returns:
+        True if the lane appears to be actively working (spinner, running
+        indicator, or progress counter detected).
+    """
+    lines = content.splitlines()
+    # Grab the last N non-empty lines
+    tail: list[str] = []
+    for line in reversed(lines):
+        stripped = line.strip()
+        if stripped:
+            tail.append(stripped)
+            if len(tail) >= _ACTIVITY_TAIL_LINES:
+                break
+
+    for line in tail:
+        for pattern in _ACTIVE_WORK_PATTERNS:
+            if pattern.search(line):
+                return True
+    return False
 
 
 def _match_approval_prompt(content: str) -> str | None:
@@ -945,6 +995,12 @@ def check_approval_stalls(
             _capture_fn=_capture_fn,
         )
         if content is None:
+            continue
+
+        # If the lane shows active-work indicators (spinner, progress
+        # counters, etc.), it is executing — any approval-prompt text in the
+        # pane is historical noise, not a real stall.
+        if _detect_active_work(content):
             continue
 
         prompt_text = _match_approval_prompt(content)

--- a/tests/unit/test_ops_monitor.py
+++ b/tests/unit/test_ops_monitor.py
@@ -15,6 +15,7 @@ from bid_euchre.ops.monitor import (
     SEVERITY_WARN,
     MonitorFinding,
     _default_stall_state_path,
+    _detect_active_work,
     _match_approval_prompt,
     _save_stall_state,
     check_approval_stalls,
@@ -1946,3 +1947,213 @@ class TestMatchApprovalPrompt:
         content = "prompt\n  [Y]es, always allow\n"
         result = _match_approval_prompt(content)
         assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# _detect_active_work tests
+# ---------------------------------------------------------------------------
+
+
+class TestDetectActiveWork:
+    """Tests for the _detect_active_work helper."""
+
+    def test_detects_spinner_glyph(self) -> None:
+        content = "some output\nprocessing files\n⏺ Running Bash(make check)…\n"
+        assert _detect_active_work(content) is True
+
+    def test_detects_braille_spinner(self) -> None:
+        content = "working\n⠹ Building…\n"
+        assert _detect_active_work(content) is True
+
+    def test_detects_duration_counter_m_s(self) -> None:
+        content = "output\nRunning tests  1m 23s\n"
+        assert _detect_active_work(content) is True
+
+    def test_detects_duration_counter_colon(self) -> None:
+        content = "output\nElapsed: 0:45\n"
+        assert _detect_active_work(content) is True
+
+    def test_detects_seconds_counter(self) -> None:
+        content = "output\nCompleted in 12s\n"
+        assert _detect_active_work(content) is True
+
+    def test_detects_running_ellipsis(self) -> None:
+        content = "output\nRunning… tests\n"
+        assert _detect_active_work(content) is True
+
+    def test_detects_running_dots(self) -> None:
+        content = "output\nRunning...\n"
+        assert _detect_active_work(content) is True
+
+    def test_detects_timeout_indicator(self) -> None:
+        content = "output\ntimeout --signal=TERM 300\n"
+        assert _detect_active_work(content) is True
+
+    def test_detects_tool_execution_progress(self) -> None:
+        content = "output\nBash(make check-quiet)...\n"
+        assert _detect_active_work(content) is True
+
+    def test_no_match_normal_output(self) -> None:
+        content = "Running tests...\nPASSED 42 tests in 3.2s\nAll checks green.\n"
+        # "Running..." matches — but that's intentional, it means active work.
+        # Let's use content without active indicators.
+        content = "PASSED 42 tests in 3.2s\nAll checks green.\nDone.\n"
+        assert _detect_active_work(content) is False
+
+    def test_no_match_approval_prompt_only(self) -> None:
+        """An approval prompt without spinners is NOT active work."""
+        content = (
+            "Working on implementation...\n"
+            "  Allow Bash(git status) [Y]es, always / [N]o\n"
+            ">\n"
+        )
+        assert _detect_active_work(content) is False
+
+    def test_only_checks_tail_lines(self) -> None:
+        """Activity indicators early in the pane are ignored."""
+        # Put a spinner far from the bottom with 10+ empty/normal lines after
+        lines = ["⏺ Running Bash(make check)…"]
+        lines.extend(["normal output"] * 10)
+        lines.append("Done.")
+        content = "\n".join(lines) + "\n"
+        assert _detect_active_work(content) is False
+
+
+# ---------------------------------------------------------------------------
+# check_approval_stalls with spinner-activity detection
+# ---------------------------------------------------------------------------
+
+
+class TestApprovalStallsWithSpinner:
+    """Tests that active lanes are not flagged as approval-stalled."""
+
+    def test_spinner_active_lane_not_flagged(self, tmp_path: Path) -> None:
+        """A lane with a spinner should not be flagged even if approval text exists."""
+        pane_content = {
+            "author-a": (
+                "Working on implementation...\n"
+                "  Allow Bash(git status) [Y]es, always / [N]o\n"
+                "Some more output\n"
+                "⏺ Running Bash(make check-quiet)…\n"
+                "  1m 23s\n"
+            ),
+        }
+
+        def capture_fn(lane_id: str) -> str | None:
+            return pane_content.get(lane_id)
+
+        notifications: list[tuple[str, str, str]] = []
+
+        def notify_fn(lane_id: str, prompt_text: str, target: str) -> None:
+            notifications.append((lane_id, prompt_text, target))
+
+        with patch(
+            "bid_euchre.ops.worker_pool._resolve_tmux_target",
+            return_value="steward:platform.1",
+        ):
+            findings = check_approval_stalls(
+                runtime_dir=tmp_path,
+                _capture_fn=capture_fn,
+                _notify_fn=notify_fn,
+            )
+
+        assert len(findings) == 0
+        assert len(notifications) == 0
+
+    def test_no_spinner_still_flags_approval(self, tmp_path: Path) -> None:
+        """A lane without a spinner but with an approval prompt is still flagged."""
+        pane_content = {
+            "author-b": (
+                "Working on implementation...\n"
+                "  Allow Bash(git status) [Y]es, always / [N]o\n"
+                ">\n"
+            ),
+        }
+
+        def capture_fn(lane_id: str) -> str | None:
+            return pane_content.get(lane_id)
+
+        with patch(
+            "bid_euchre.ops.worker_pool._resolve_tmux_target",
+            return_value="steward:platform.2",
+        ):
+            findings = check_approval_stalls(
+                runtime_dir=tmp_path,
+                _capture_fn=capture_fn,
+                _notify_fn=lambda *_: None,
+            )
+
+        assert len(findings) == 1
+        assert findings[0].category == "approval_stall"
+        assert "author-b" in findings[0].summary
+
+    def test_make_check_with_spinner_not_flagged(self, tmp_path: Path) -> None:
+        """A lane running make check-quiet with active spinner is not flagged."""
+        pane_content = {
+            "flex-a": (
+                "$ make check-quiet\nruff check passed\npytest running...\n⠹ Running…\n"
+            ),
+        }
+
+        def capture_fn(lane_id: str) -> str | None:
+            return pane_content.get(lane_id)
+
+        with patch(
+            "bid_euchre.ops.worker_pool._resolve_tmux_target",
+            return_value="steward:flex.0",
+        ):
+            findings = check_approval_stalls(
+                runtime_dir=tmp_path,
+                _capture_fn=capture_fn,
+                _notify_fn=lambda *_: None,
+            )
+
+        assert len(findings) == 0
+
+    def test_spinner_clears_then_approval_detected(self, tmp_path: Path) -> None:
+        """After spinner stops, an approval prompt is detected correctly."""
+        # First call: lane active with spinner
+        active_content = {
+            "author-c": "Working...\n⏺ Running Bash(make check)…\n",
+        }
+        # Second call: spinner gone, prompt visible
+        stalled_content = {
+            "author-c": (
+                "Done with check.\n  Allow Bash(git push) [Y]es, always / [N]o\n>\n"
+            ),
+        }
+
+        call_count = {"n": 0}
+
+        def capture_fn(lane_id: str) -> str | None:
+            if call_count["n"] == 0:
+                return active_content.get(lane_id)
+            return stalled_content.get(lane_id)
+
+        notifications: list[tuple[str, str, str]] = []
+
+        def notify_fn(lane_id: str, prompt_text: str, target: str) -> None:
+            notifications.append((lane_id, prompt_text, target))
+
+        with patch(
+            "bid_euchre.ops.worker_pool._resolve_tmux_target",
+            return_value="steward:platform.3",
+        ):
+            # First check — spinner active, no findings
+            findings1 = check_approval_stalls(
+                runtime_dir=tmp_path,
+                _capture_fn=capture_fn,
+                _notify_fn=notify_fn,
+            )
+            assert len(findings1) == 0
+
+            # Second check — spinner gone, prompt detected
+            call_count["n"] = 1
+            findings2 = check_approval_stalls(
+                runtime_dir=tmp_path,
+                _capture_fn=capture_fn,
+                _notify_fn=notify_fn,
+            )
+            assert len(findings2) == 1
+            assert "author-c" in findings2[0].summary
+            assert len(notifications) == 1


### PR DESCRIPTION
## Plan
N/A — issue-driven fix (#1442)

## Summary
- Add `_detect_active_work()` helper that detects spinner glyphs, progress counters, and running indicators in the last 5 lines of pane content
- Wire activity detection into `check_approval_stalls()` to skip lanes that are actively working
- Add 16 new tests covering the helper and integration with approval-stall detection

## Why
The approval-stall detector (#1434) scrapes pane content for approval prompts but doesn't check whether the lane is actively working. A lane running `make check-quiet` with an active spinner was being falsely classified as stalled.

Closes #1442

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_monitor.py -v
# 84 passed
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_monitor.py -v` — 84 passed
- [x] Pre-commit hooks pass (ruff, format, repo-lint)

## Expected impact
- Metrics impact: None
- Runtime impact: Negligible (one additional regex scan of last 5 pane lines per lane check)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d  f1b3ea57 [fix/spinner-activity-detection]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)