### PR TITLE
docs: add lane refresh step to delegate-task and run-fleet skills

### DIFF
--- a/.claude/skills/delegate-task/SKILL.md
+++ b/.claude/skills/delegate-task/SKILL.md
@@ -58,6 +58,18 @@ intake-to-dispatch flow into a reusable workflow.
 5. For trivial tasks (single-file fix, typo, previously approved pattern):
    - Skip preview and proceed directly to dispatch
 
+### Phase 2.5 — Refresh Lane
+
+5b. **Refresh the target lane** before dispatching to ensure a clean worktree:
+   ```bash
+   uv run python scripts/internal/ops.py lane refresh <lane>
+   ```
+   This rebases the lane's worktree onto `origin/main` and clears stale
+   session state. Task dispatch (`task dispatch`) auto-refreshes the lane,
+   so this step is optional for the normal dispatch path — but it is useful
+   for manual workflows or when you want to verify lane health before
+   committing to a dispatch.
+
 ### Phase 3 — Dispatch
 
 6. **Create the task packet** (if not already created during preview):

--- a/.claude/skills/run-fleet/SKILL.md
+++ b/.claude/skills/run-fleet/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: run-fleet
+description: Run the steward fleet autonomously — maximize safe, mergeable throughput across all tracks by continuously dispatching, monitoring, triaging, and recovering lanes.
+---
+
+# /run-fleet — Autonomous Fleet Orchestration
+
+Run the steward fleet continuously and autonomously, maximizing safe
+mergeable throughput across all defined tracks.
+
+## When to Use
+
+- User says "run", "go", "run fleet", "keep going", or similar
+- Starting a new autonomous orchestration session after a handoff
+- Resuming orchestration after a break
+
+## Startup Checklist
+
+Before entering the main dispatch loop:
+
+1. Recover context (`/recovering-context` or read MEMORY.md)
+2. Check dashboard health: `uv run python scripts/internal/ops.py dashboard --json`
+3. Bulk-refresh idle lanes:
+   ```bash
+   uv run python scripts/internal/ops.py lane refresh --all-idle
+   ```
+4. Triage inbox and open issues
+5. Define Wave 1 candidates
+
+## Primary Goal
+
+Maximize safe, mergeable throughput across all defined tracks.
+
+## Secondary Goals
+
+- Keep as many lanes productively busy as possible
+- Maintain full operator observability through the steward layout
+- Minimize token waste, rework, and manual babysitting
+- Leave behind a clear next-wave plan, not just partial work
+
+## Execution Model
+
+- Run continuously and autonomously
+- Treat waves as planning buckets, not hard synchronization barriers
+- Do not wait for an entire wave to finish if part of the next wave is
+  already unblocked
+- Always keep a 2-wave lookahead:
+  - while Wave N is executing, define Wave N+1
+  - before Wave N completes, sketch Wave N+2
+- Prefer steady pipeline flow over batch pauses
+
+## Source of Truth
+
+- The handoff (session context, MEMORY.md, checkpoints) defines the active
+  tracks, lane pools, governing plans, sub-plans, constraints, and initial
+  dispatch candidates
+- If the handoff and repo state disagree, verify the repo state and adapt
+  without breaking the governing plan
+
+## Dispatch Discipline
+
+Before each dispatch cycle:
+
+1. Check lane health, dirty worktrees, stale packets, inbox backlog, open
+   PRs, newly opened or updated GitHub issues, current task lists, and
+   current blockers
+2. Verify the candidate task is still valid, unblocked, and within scope
+3. Confirm file-scope isolation
+4. Dispatch to the best-fit idle lane
+
+At session start, run a bulk lane refresh to reset all stale worktrees
+before the first dispatch cycle:
+```bash
+uv run python scripts/internal/ops.py lane refresh --all-idle
+```
+
+> **Note:** `task dispatch` auto-refreshes the target lane, so per-dispatch
+> refresh is not needed. The bulk refresh at startup is still recommended for
+> observability — it surfaces dirty worktrees and stale state before work
+> begins.
+
+Rules:
+- Prefer small, mergeable PRs over large speculative changes
+- Only dispatch work with clear file-scope ownership
+- One active writer per overlapping file set
+
+## Lane Discipline
+
+- Respect the lane/track affinity defined in the handoff
+- Use tmux-pane delivery only
+- Do not use hidden subprocess agents or isolated temp worktrees unless the
+  handoff explicitly authorizes them
+- If a lane becomes stale or risky, use the platform's reset/recovery path
+  instead of forcing more work through bad context
+
+## Autonomy Rules
+
+Proceed without asking for confirmation unless one of these occurs:
+- Credentials, secrets, plugins, or external setup are required
+- Two high-priority tasks need the same file set
+- Governing plans conflict or are ambiguous
+- Tests suggest a likely regression outside assigned scope
+- A destructive recovery action would be required
+- A user smoke test or proving step is required on the critical path
+
+If one track is blocked, keep the others moving. If a user smoke test is
+needed for only one slice, isolate that slice, mark it pending, and
+continue other work.
+
+## User Smoke-Test Rule
+
+If a task reaches a point where user smoke testing or proving is required:
+
+1. Stop dependent follow-on work on that specific slice
+2. Do not keep extending that slice past the smoke-test boundary
+3. Record the state durably:
+   - Add a concise session note
+   - Update the relevant plan/checkpoint with `USER SMOKE TEST PENDING`
+   - File or update an issue tracking the pending smoke test
+4. Provide a compact smoke-test handoff:
+   - What changed
+   - Exactly what the user should test
+   - Expected outcome
+   - What remains blocked on the result
+5. Continue all other unblocked tracks and lanes
+
+Only pause autonomous execution if:
+- The smoke test is required before any other safe work can proceed
+- The result determines which implementation branch is correct
+- Proceeding further would risk invalidating the test or building on an
+  unverified assumption
+
+## Parallelism Rules
+
+- Maximize parallelism subject to file-scope isolation and review capacity
+- Keep idle lanes low, but do not fill them with low-value churn
+- If no safe implementation task is ready for a lane, use that lane for
+  planning, validation, review support, or issue cleanup
+
+## Token-Efficiency Rules
+
+- Optimize for throughput per token, not just visible activity
+- Avoid repeated long restatements of context already in the handoff
+- Avoid redundant repo rereads unless state has materially changed
+- Reuse lane context when helpful, but clear/reset when stale context
+  would cause drift
+- Prefer direct execution over extended meta-discussion
+
+## Reprioritization
+
+Reprioritize dynamically based on:
+- Merged PRs
+- Blocked tasks
+- Failing validations
+- Review backlog
+- Lane health
+- File-scope conflicts
+- Newly opened or newly unblocked work
+
+## Issue Intake and Triage
+
+Regularly triage newly opened and recently updated GitHub issues:
+- At startup
+- At the start of each new wave
+- After meaningful merge batches
+- Whenever active work is blocked and idle capacity appears
+
+For each issue, classify quickly:
+- Critical blocker to active work
+- High-value next-wave candidate
+- Backlog / defer
+- Out of current scope
+
+If actionable, in scope, and file-scope isolated: create or route work
+without waiting for user confirmation. If it changes platform scope or
+governance, record that before dispatching.
+
+## Task-List Maintenance
+
+Update task lists at minimum:
+- At startup after repo-state review
+- Before each new wave is dispatched
+- After each meaningful merge batch
+- Whenever priority order changes
+- Whenever a slice becomes blocked, deferred, or user-test-pending
+
+Keep entries concise, current, and action-oriented. Remove stale entries.
+If task lists and repo state diverge, reconcile promptly.
+
+## Recovery Behavior
+
+- If a lane stalls, use the bounded recovery path defined by the platform
+- If recovery fails, escalate or reassign rather than letting work sit
+- If a task proves over-scoped, narrow it and ship the useful subset
+
+## Reporting
+
+Maintain concise session notes. Explicitly track:
+- User smoke tests pending and which lanes/tracks are blocked on them
+- Which tracks remain active
+- Newly triaged GitHub issues
+- Which issues were dispatched vs deferred and why
+
+Periodically use `/check-in` to summarize current state.
+
+At the end of the run, produce a compact handoff:
+- What shipped
+- What is in flight
+- What is blocked
+- Recommended next wave
+
+## Success Condition
+
+- Maximize safe, observable, mergeable progress across all active tracks
+- Keep idle capacity low
+- Keep drift, hidden work, and unnecessary token burn low
+- Stop cleanly at true user-validation boundaries
+- Leave the system in a better operational state than it started


### PR DESCRIPTION
## Summary
- **delegate-task:** Add Phase 2.5 — Refresh Lane step with explicit `lane refresh` command for manual workflows
- **run-fleet:** Add Startup Checklist (bulk `lane refresh --all-idle` before first dispatch) and Dispatch Discipline note that `task dispatch` auto-refreshes

## Why
Task dispatch now auto-refreshes the target lane (#1452 and follow-on work), but the orchestrator skills didn't document the refresh workflow. This PR reinforces the pattern: auto-refresh for dispatches, bulk refresh at session startup for observability.

## Repro / Validation
Docs-only — no code changes.

```bash
# Verify files are well-formed markdown
cat .claude/skills/delegate-task/SKILL.md
cat .claude/skills/run-fleet/SKILL.md
```

## Tests
- `make check-quiet` — repo-lint and pre-commit hooks pass
- CI will skip heavy jobs (docs-only paths-filter gating)

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-scratch
branch: docs/skill-refresh-step
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)