### PR TITLE
fix: persist all-pass redeal hand state before dealing next hand

### DIFF
--- a/src/bid_euchre/hosted_play/engine.py
+++ b/src/bid_euchre/hosted_play/engine.py
@@ -302,18 +302,31 @@ class MatchEngine:
 
         return state
 
+    def deal_after_redeal(self, state: MatchState) -> MatchState:
+        """Advance dealer, deal a new hand, and auto-advance AI after a redeal.
+
+        The route layer calls this after persisting the terminal ``"redeal"``
+        hand row.  Separating the redeal marker from the deal gives callers a
+        chance to write the old hand state before it is replaced.
+        """
+        hand = state.current_hand
+        assert hand is not None and hand.phase == "redeal"
+        state.dealer_seat = (state.dealer_seat + 1) % _NUM_PLAYERS
+        state.deal_id += 1
+        state = self._deal_new_hand(state)
+        state = self._advance_ai(state)
+        return state
+
     def _process_auction_end(self, state: MatchState) -> MatchState:
         """Finalize the auction: set contract or trigger redeal."""
         hand = state.current_hand
         assert hand is not None
 
         if hand.bidder_seat is None:
-            # All passed — redeal
+            # All passed — mark redeal and return.  The caller (route layer)
+            # persists this terminal state, then calls deal_after_redeal()
+            # to advance the dealer and start the next hand.
             hand.phase = "redeal"
-            state.dealer_seat = (state.dealer_seat + 1) % _NUM_PLAYERS
-            state.deal_id += 1
-            state = self._deal_new_hand(state)
-            state = self._advance_ai(state)
             return state
 
         # Contract set — transition to trick play

--- a/tests/unit/hosted_play/test_engine.py
+++ b/tests/unit/hosted_play/test_engine.py
@@ -203,7 +203,7 @@ class TestFullHandFlow:
 
 
 class TestAllPassRedeal:
-    """All 4 pass → new hand dealt, dealer advances."""
+    """All 4 pass → hand marked redeal; deal_after_redeal() starts next hand."""
 
     def test_all_pass_triggers_redeal(self, pass_engine: MatchEngine) -> None:
         state = pass_engine.start_match(SEED, "heuristic")
@@ -214,18 +214,32 @@ class TestAllPassRedeal:
         assert hand.phase == "auction"
         assert hand.current_seat == HUMAN_SEAT
 
-        # Human also passes
+        initial_dealer = state.dealer_seat
+        initial_deal_id = state.deal_id
+
+        # Human also passes → all-pass → hand marked "redeal"
         state = pass_engine.submit_human_bid(state, BidAction.pass_bid())
 
-        # After all pass, a new hand should be dealt with advanced dealer
+        hand = state.current_hand
+        assert hand is not None
+        assert hand.phase == "redeal"
+        # Dealer and deal_id not yet advanced (waiting for persistence)
+        assert state.dealer_seat == initial_dealer
+        assert state.deal_id == initial_deal_id
+        assert state.hands_played == 0  # Redeals don't count
+
+        # After persistence, deal the next hand
+        state = pass_engine.deal_after_redeal(state)
+
         hand = state.current_hand
         assert hand is not None
         assert hand.phase == "auction"
-        # Dealer should have rotated (possibly multiple times if human wasn't first bidder)
-        assert state.hands_played == 0  # No hands completed (redeals don't count)
+        assert state.hands_played == 0  # Still no completed hands
+        assert state.dealer_seat == (initial_dealer + 1) % 4
+        assert state.deal_id == initial_deal_id + 1
 
     def test_redeal_advances_dealer(self) -> None:
-        """Verify dealer rotates on redeal."""
+        """Verify dealer rotates only after deal_after_redeal()."""
         engine = MatchEngine(
             bidding_policy=AlwaysPassBidder(),
             play_strategy=FirstLegalPlay(),
@@ -236,9 +250,15 @@ class TestAllPassRedeal:
         # Human passes — triggers all-pass redeal
         state = engine.submit_human_bid(state, BidAction.pass_bid())
 
-        # After redeal, dealer should advance by at least 1
-        # (may advance more if multiple auto-redeals happen)
-        assert state.dealer_seat != initial_dealer
+        # Before deal_after_redeal, dealer hasn't rotated
+        assert state.dealer_seat == initial_dealer
+        assert state.current_hand is not None
+        assert state.current_hand.phase == "redeal"
+
+        # After deal_after_redeal, dealer advances
+        state = engine.deal_after_redeal(state)
+        expected = (initial_dealer + 1) % 4
+        assert state.dealer_seat == expected
 
 
 # ---------------------------------------------------------------------------
@@ -512,7 +532,7 @@ class TestDealerRotation:
             assert state.dealer_seat == expected
 
     def test_dealer_rotates_on_redeal(self) -> None:
-        """Dealer also rotates when all pass (redeal)."""
+        """Dealer rotates after deal_after_redeal() on all-pass."""
         engine = MatchEngine(
             bidding_policy=AlwaysPassBidder(),
             play_strategy=FirstLegalPlay(),
@@ -520,11 +540,16 @@ class TestDealerRotation:
         state = engine.start_match(SEED, "heuristic")
         initial_dealer = state.dealer_seat
 
-        # Human passes → all pass → redeal
+        # Human passes → all pass → redeal (hand marked, not yet dealt)
         state = engine.submit_human_bid(state, BidAction.pass_bid())
+        assert state.current_hand is not None
+        assert state.current_hand.phase == "redeal"
+        assert state.dealer_seat == initial_dealer  # Not yet rotated
 
-        # Dealer should have advanced (possibly multiple times)
-        assert state.dealer_seat != initial_dealer
+        # After deal_after_redeal, dealer advances
+        state = engine.deal_after_redeal(state)
+        expected = (initial_dealer + 1) % 4
+        assert state.dealer_seat == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -13,9 +13,11 @@ import pytest
 from starlette.testclient import TestClient
 
 from bid_euchre.hosted_play.engine import HUMAN_SEAT, MatchEngine
+from bid_euchre.strategy.bidding import BidAction, BiddingObservation, BiddingPolicy
+from web.ai_manager import AIManager, ModelInfo
 from web.app import create_app
 from web.config import HostedPlayConfig
-from web.db import Decision, Match, Player
+from web.db import Decision, Hand, Match, Player
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -609,6 +611,140 @@ class TestNewMatch:
         resp = client.post(f"/play/{link_uuid}/new-match")
         assert resp.status_code == 200
         assert "Start Match" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Redeal persistence
+# ---------------------------------------------------------------------------
+
+
+class _AlwaysPassBidder(BiddingPolicy):
+    """Bidding policy that always passes — forces all-pass redeals."""
+
+    def __init__(self) -> None:
+        super().__init__(name="always_pass")
+
+    def choose_bid(self, obs: BiddingObservation) -> BidAction:
+        return BidAction.pass_bid()
+
+
+@pytest.fixture()
+def allpass_client(config):
+    """TestClient whose AI always passes — forces all-pass redeals.
+
+    The AI manager is set during the lifespan (triggered by entering the
+    TestClient context), so we swap the bidding policy after startup.
+    """
+    application = create_app(config=config)
+    with TestClient(application) as c:
+        ai_manager: AIManager = application.state.ai_manager
+        info = ai_manager.available_models["heuristic"]
+        ai_manager.available_models["heuristic"] = ModelInfo(
+            id=info.id,
+            name=info.name,
+            description=info.description,
+            bidding_policy=_AlwaysPassBidder(),
+            play_strategy=info.play_strategy,
+        )
+        yield c, application
+
+
+class TestRedealPersistence:
+    """All-pass redeal creates a Hand row marked 'redeal' with correct metadata."""
+
+    def test_all_pass_hand_row_marked_redeal(self, allpass_client):
+        """Force all-pass → assert Hand row persisted as 'redeal'."""
+        client, app = allpass_client
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        _select_ai(client, link_uuid)
+
+        # Load the current match state to get the turn number
+        result = _get_match_state(app, link_uuid)
+        assert result is not None
+        state, match_row, session = result
+
+        hand = state.current_hand
+        assert hand is not None
+        assert hand.phase == "auction"
+        assert hand.current_seat == HUMAN_SEAT
+
+        original_deal_id = hand.deal_id
+        original_dealer = hand.dealer_seat
+        match_id = match_row.id
+        session.close()
+
+        # Human passes — all AI already passed → all-pass redeal
+        resp = client.post(
+            f"/play/{link_uuid}/bid",
+            data={
+                "turn_number": hand.turn_number,
+                "bid_n": 0,
+                "bid_contract": "",
+            },
+        )
+        assert resp.status_code == 200
+
+        # Verify the hand row for the redealt hand
+        session = app.state.session_factory()
+        try:
+            redeal_hand = (
+                session.query(Hand).filter_by(match_id=match_id, hand_number=0).first()
+            )
+            assert redeal_hand is not None, "Expected Hand row for the redealt hand"
+            assert redeal_hand.status == "redeal"
+            assert redeal_hand.deal_id == original_deal_id
+            assert redeal_hand.dealer_seat == original_dealer
+
+            # Verify a new hand row exists for the next deal
+            next_hand = (
+                session.query(Hand)
+                .filter_by(match_id=match_id)
+                .filter(Hand.deal_id > original_deal_id)
+                .first()
+            )
+            assert next_hand is not None, "Expected Hand row for the post-redeal hand"
+            assert next_hand.status == "in_progress"
+            assert next_hand.deal_id == original_deal_id + 1
+            assert next_hand.dealer_seat == (original_dealer + 1) % 4
+        finally:
+            session.close()
+
+    def test_match_state_has_new_hand_after_redeal(self, allpass_client):
+        """After redeal, serialized match state shows the new hand (not redeal)."""
+        client, app = allpass_client
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        _select_ai(client, link_uuid)
+
+        result = _get_match_state(app, link_uuid)
+        assert result is not None
+        state, _, session = result
+        hand = state.current_hand
+        assert hand is not None
+        session.close()
+
+        # Human passes → all-pass redeal
+        client.post(
+            f"/play/{link_uuid}/bid",
+            data={
+                "turn_number": hand.turn_number,
+                "bid_n": 0,
+                "bid_contract": "",
+            },
+        )
+
+        # Load the match state after redeal
+        result2 = _get_match_state(app, link_uuid)
+        assert result2 is not None
+        state2, _, session2 = result2
+
+        # Match state should show the new hand in auction phase
+        new_hand = state2.current_hand
+        assert new_hand is not None
+        assert new_hand.phase == "auction"
+        assert state2.hands_played == 0  # Redeals don't count
+        session2.close()
 
 
 # ---------------------------------------------------------------------------

--- a/web/routes.py
+++ b/web/routes.py
@@ -333,9 +333,12 @@ async def select_ai(
         session.add(match_row)
         session.flush()
 
-        # Create the initial hand row
+        # Create the initial hand row (use deal_id as hand_number to stay
+        # unique even when redeals occur before any hand completes)
         if state.current_hand is not None:
-            _ensure_hand_row(session, match_row, state.current_hand, state.hands_played)
+            _ensure_hand_row(
+                session, match_row, state.current_hand, state.current_hand.deal_id
+            )
 
         session.commit()
 
@@ -404,10 +407,9 @@ async def submit_bid(
 
         # Record pre-action state for decision logging
         pre_turn = hand.turn_number
-        hand_number = state.hands_played
 
-        # Ensure hand row exists
-        hand_row = _ensure_hand_row(session, match_row, hand, hand_number)
+        # Ensure hand row exists (keyed by deal_id for redeal-safe uniqueness)
+        hand_row = _ensure_hand_row(session, match_row, hand, hand.deal_id)
 
         # Log human decision
         _log_decision(
@@ -438,16 +440,28 @@ async def submit_bid(
             "bid",
         )
 
-        # Update hand row if hand completed
+        # Update hand row if hand completed or redealt
         current_hand = state.current_hand
-        if current_hand is not None and current_hand.phase in ("complete", "redeal"):
+        if current_hand is not None and current_hand.phase == "redeal":
+            # Persist the terminal redeal state before dealing next hand
             _update_hand_row(hand_row, current_hand)
+            state = engine.deal_after_redeal(state)
+            # Create a hand row for the newly dealt hand
+            if state.current_hand is not None:
+                _ensure_hand_row(
+                    session,
+                    match_row,
+                    state.current_hand,
+                    state.current_hand.deal_id,
+                )
+        elif current_hand is not None and current_hand.phase == "complete":
+            _update_hand_row(hand_row, current_hand)
+            # If a new hand started after completion, ensure its row exists
+            new_hand = state.current_hand
+            if new_hand is not None and new_hand.deal_id != hand.deal_id:
+                _ensure_hand_row(session, match_row, new_hand, new_hand.deal_id)
         elif current_hand is not None:
             hand_row.hand_state_json = json.dumps(current_hand.to_dict())
-
-        # If a new hand started, ensure its row exists
-        if state.hands_played > hand_number and state.current_hand is not None:
-            _ensure_hand_row(session, match_row, state.current_hand, state.hands_played)
 
         _update_match_row(match_row, state)
         session.commit()
@@ -504,10 +518,9 @@ async def submit_card(
 
         # Record pre-action state for decision logging
         pre_turn = hand.turn_number
-        hand_number = state.hands_played
 
-        # Ensure hand row exists
-        hand_row = _ensure_hand_row(session, match_row, hand, hand_number)
+        # Ensure hand row exists (keyed by deal_id for redeal-safe uniqueness)
+        hand_row = _ensure_hand_row(session, match_row, hand, hand.deal_id)
 
         # Log human decision
         _log_decision(
@@ -538,16 +551,17 @@ async def submit_card(
             "play",
         )
 
-        # Update hand row if hand completed
+        # Update hand row if hand completed (redeals cannot occur during
+        # card play, but keep the check consistent)
         current_hand = state.current_hand
-        if current_hand is not None and current_hand.phase in ("complete", "redeal"):
+        if current_hand is not None and current_hand.phase == "complete":
             _update_hand_row(hand_row, current_hand)
+            # If a new hand started after completion, ensure its row exists
+            new_hand = state.current_hand
+            if new_hand is not None and new_hand.deal_id != hand.deal_id:
+                _ensure_hand_row(session, match_row, new_hand, new_hand.deal_id)
         elif current_hand is not None:
             hand_row.hand_state_json = json.dumps(current_hand.to_dict())
-
-        # If a new hand started, ensure its row exists
-        if state.hands_played > hand_number and state.current_hand is not None:
-            _ensure_hand_row(session, match_row, state.current_hand, state.hands_played)
 
         _update_match_row(match_row, state)
         session.commit()


### PR DESCRIPTION
## Plan
N/A — P1 finding fix from code review

## Summary
- Split `_process_auction_end` so all-pass redeals return with `phase='redeal'` instead of immediately dealing the next hand
- Route layer now persists the terminal redeal hand row **before** the old `HandState` is replaced
- Use `deal_id` as `hand_number` (instead of `hands_played`) for redeal-safe uniqueness in the `hands` table

## Why
When all 4 players pass, the engine immediately dealt a new hand inside `_process_auction_end`, replacing `state.current_hand`. The route never got a chance to persist the old hand's terminal "redeal" state — the `hands` DB row remained stale as `in_progress` with the wrong deal_id/dealer_seat. Additionally, `hand_number = state.hands_played` caused key collisions when redeals occurred before any hand completed (both the redeal and next hand got `hand_number=0`).

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/ -v
# 140 passed

make check
# 6321 passed, 45 skipped, 1 flaky timing failure (unrelated: test_script_runs_quickly)
```

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/ -v` — 140 passed
- [x] `make check` — 6321 passed (1 pre-existing flaky timing test)
- [x] New: `TestRedealPersistence::test_all_pass_hand_row_marked_redeal` — forces all-pass, asserts Hand row status='redeal' with correct deal_id and dealer_seat
- [x] New: `TestRedealPersistence::test_match_state_has_new_hand_after_redeal` — verifies serialized match state shows new hand after redeal
- [x] Updated: `TestAllPassRedeal` and `TestDealerRotation` to exercise the two-step redeal API

## Expected impact
- Metrics impact: None (engine behavior unchanged; only persistence ordering changed)
- Runtime impact: None

## Risk level
- [x] Medium (hosted play engine + routes)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                   22210bbf [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d  738d6787 [fix/redeal-persistence]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)