### PR TITLE
fix(ops): handle auto-merge in post-merge-notify hook

### DIFF
--- a/.claude/hooks/post-merge-notify.sh
+++ b/.claude/hooks/post-merge-notify.sh
@@ -6,6 +6,11 @@
 #   2. Transitions it to "completed" status
 #   3. Sends a completion message to the orchestrator via message bus
 #
+# Handles two merge modes:
+#   - Direct merge (`gh pr merge <N> --squash`): completes immediately
+#   - Auto-merge (`gh pr merge <N> --auto --squash`): launches a background
+#     watcher that polls for actual merge, then completes (issue #1461)
+#
 # Guards:
 #   - Only fires on successful `gh pr merge` (same as post-merge-review.sh)
 #   - Deduplicates via sentinel file (one notification per PR)
@@ -35,6 +40,12 @@ fi
 
 # Extract PR number for deduplication and messaging
 PR_NUM=$(echo "$COMMAND" | grep -oE '[0-9]+' | head -1 || true)
+
+# Fallback: extract PR number from command stdout (e.g., "Merged pull request #1453")
+if [ -z "$PR_NUM" ]; then
+    PR_NUM=$(echo "$INPUT" | jq -r '.tool_response.stdout // ""' 2>/dev/null \
+        | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | head -1 || true)
+fi
 
 # Dedupe guard — one notification per PR merge
 if [ -n "$PR_NUM" ]; then
@@ -74,10 +85,20 @@ if [ -z "$LANE_ID" ] && [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
     esac
 fi
 
-# Run the completion logic in Python (fire-and-forget, don't block on failure)
-# Gap B: primary lookup by PR number, fallback to lane identity
-LANE_ID="${LANE_ID:-}" PR_NUM="${PR_NUM:-unknown}" \
-uv run python -c "
+# ---------------------------------------------------------------------------
+# Completion logic (reusable function)
+# ---------------------------------------------------------------------------
+run_completion() {
+    local lane="$1"
+    local pr="$2"
+    local project_dir="${3:-${CLAUDE_PROJECT_DIR:-.}}"
+
+    # Run in the correct directory so uv finds pyproject.toml
+    (
+        cd "$project_dir" 2>/dev/null || true
+
+        LANE_ID="$lane" PR_NUM="$pr" \
+        uv run python -c "
 import os, sys
 
 lane_id = os.environ.get('LANE_ID', '')
@@ -128,6 +149,94 @@ try:
 except Exception as exc:
     print(f'post-merge-notify: message send failed: {exc}', file=sys.stderr)
 " 2>/dev/null || true
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Auto-merge detection: if --auto flag is present, the PR isn't merged yet.
+# Launch a background watcher that polls for actual merge completion.
+# (Issue #1461: auto-merged PRs bypass the PostToolUse hook)
+# ---------------------------------------------------------------------------
+if [[ "$COMMAND" == *"--auto"* ]]; then
+    if [ -n "$PR_NUM" ]; then
+        # Capture values for the background subshell
+        _LANE_ID="$LANE_ID"
+        _PR_NUM="$PR_NUM"
+        _PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+
+        (
+            # Background watcher: poll for actual merge, then send completion.
+            # Polls every 30s for up to 30 minutes (60 iterations).
+            # Self-terminates on MERGED, CLOSED, or timeout.
+            for _attempt in $(seq 1 60); do
+                sleep 30
+                STATE=$(gh pr view "$_PR_NUM" --json state --jq '.state' 2>/dev/null || echo "unknown")
+
+                if [ "$STATE" = "MERGED" ]; then
+                    # PR is actually merged — run completion logic
+                    cd "$_PROJECT_DIR" 2>/dev/null || true
+                    LANE_ID="$_LANE_ID" PR_NUM="$_PR_NUM" \
+                    uv run python -c "
+import os, sys
+
+lane_id = os.environ.get('LANE_ID', '')
+pr_num = os.environ['PR_NUM']
+
+packet_id = None
+try:
+    from bid_euchre.ops.task_queue import list_packets, transition_status
+    dispatched = list_packets(status_filter='dispatched')
+    if pr_num and pr_num != 'unknown':
+        for pkt in dispatched:
+            pkt_pr = (pkt.metadata or {}).get('pr_number')
+            if pkt_pr is not None and str(pkt_pr) == str(pr_num):
+                packet_id = pkt.packet_id
+                lane_id = lane_id or pkt.owner or ''
+                break
+    if packet_id is None and lane_id:
+        for pkt in dispatched:
+            if pkt.owner == lane_id:
+                packet_id = pkt.packet_id
+                break
+    if packet_id:
+        transition_status(packet_id, 'completed')
+except Exception as exc:
+    print(f'post-merge-watcher: task transition failed: {exc}', file=sys.stderr)
+
+from_lane = lane_id or 'unknown'
+try:
+    from bid_euchre.ops.message_bus import create_message, send_message
+    msg = create_message(
+        from_lane=from_lane,
+        to_lane='orchestrator',
+        message_type='completion',
+        summary=f'PR #{pr_num} merged (auto-merge) — task complete',
+        task_id=packet_id,
+        payload={'pr_number': pr_num, 'packet_id': packet_id, 'auto_merge': True},
+    )
+    send_message(msg)
+except Exception as exc:
+    print(f'post-merge-watcher: message send failed: {exc}', file=sys.stderr)
+" 2>/dev/null || true
+
+                    # Create sentinel after successful completion
+                    touch "/tmp/.claude-post-merge-notify-${_PR_NUM}"
+                    exit 0
+                elif [ "$STATE" = "CLOSED" ]; then
+                    # PR closed without merging — nothing to do
+                    exit 0
+                fi
+            done
+            # Timeout after 30 minutes — give up silently
+        ) </dev/null >/dev/null 2>&1 &
+    fi
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Direct merge: complete immediately (existing behavior)
+# ---------------------------------------------------------------------------
+run_completion "$LANE_ID" "${PR_NUM:-unknown}" "${CLAUDE_PROJECT_DIR:-.}"
 
 # Gap C: sentinel created AFTER successful execution so failures can retry
 if [ -n "${PR_NUM:-}" ]; then

--- a/tests/unit/test_post_merge_notify_hook.py
+++ b/tests/unit/test_post_merge_notify_hook.py
@@ -1,0 +1,253 @@
+"""Tests for the post-merge-notify hook behavior.
+
+Validates key behaviors (issue #1461):
+1. Direct merge creates sentinel and exits immediately
+2. Auto-merge (--auto flag) does NOT create sentinel immediately
+3. PR number fallback: extracted from stdout when not in command
+4. Non-merge commands are ignored (guard check)
+5. Failed commands are ignored (exit code guard)
+6. Dedupe sentinel prevents double-firing
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_PATH = REPO_ROOT / ".claude" / "hooks" / "post-merge-notify.sh"
+
+
+def _run_hook(
+    *,
+    command: str,
+    exit_code: int = 0,
+    stdout: str = "",
+    tmp_path: Path,
+    env_overrides: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run the post-merge-notify hook with the given input."""
+    hook_input = json.dumps(
+        {
+            "tool_input": {"command": command},
+            "tool_response": {
+                "stdout": stdout,
+                "stderr": "",
+                "exit_code": exit_code,
+            },
+        }
+    )
+    # Minimal env: PATH + HOME + jq/uv access, but no CLAUDE_ vars
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", "/tmp"),
+        # Prevent hook from writing to the real message bus
+        "BID_EUCHRE_BUS_DIR": str(tmp_path / "test_bus"),
+    }
+    if env_overrides:
+        env.update(env_overrides)
+
+    return subprocess.run(
+        ["bash", str(HOOK_PATH)],
+        input=hook_input,
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+class TestPostMergeNotifyGuards:
+    """Test that the guard checks correctly filter commands."""
+
+    def test_non_merge_command_exits_immediately(self, tmp_path: Path) -> None:
+        """Non-merge commands should exit 0 with no side effects."""
+        result = _run_hook(
+            command="git status",
+            tmp_path=tmp_path,
+        )
+        assert result.returncode == 0
+
+    def test_failed_merge_exits_immediately(self, tmp_path: Path) -> None:
+        """Failed merge commands should exit 0 with no side effects."""
+        sentinel = Path("/tmp/.claude-post-merge-notify-4444")
+        sentinel.unlink(missing_ok=True)
+
+        result = _run_hook(
+            command="gh pr merge 4444 --squash",
+            exit_code=1,
+            tmp_path=tmp_path,
+        )
+        assert result.returncode == 0
+        assert not sentinel.exists()
+
+    def test_dedupe_sentinel_prevents_refire(self, tmp_path: Path) -> None:
+        """If sentinel exists, hook should exit immediately."""
+        pr_num = "3333"
+        sentinel = Path(f"/tmp/.claude-post-merge-notify-{pr_num}")
+        sentinel.touch()
+        try:
+            result = _run_hook(
+                command=f"gh pr merge {pr_num} --squash",
+                tmp_path=tmp_path,
+            )
+            assert result.returncode == 0
+        finally:
+            sentinel.unlink(missing_ok=True)
+
+
+class TestPRNumberExtraction:
+    """Test PR number extraction from command and stdout."""
+
+    def test_pr_number_from_command(self, tmp_path: Path) -> None:
+        """PR number should be extracted from the command string."""
+        pr_num = "2222"
+        sentinel = Path(f"/tmp/.claude-post-merge-notify-{pr_num}")
+        sentinel.unlink(missing_ok=True)
+        try:
+            result = _run_hook(
+                command=f"gh pr merge {pr_num} --squash",
+                tmp_path=tmp_path,
+            )
+            assert result.returncode == 0
+            assert sentinel.exists(), "Sentinel should be created for direct merge"
+        finally:
+            sentinel.unlink(missing_ok=True)
+
+    def test_pr_number_from_stdout_fallback(self, tmp_path: Path) -> None:
+        """When command has no PR number, extract from stdout."""
+        pr_num = "1111"
+        sentinel = Path(f"/tmp/.claude-post-merge-notify-{pr_num}")
+        sentinel.unlink(missing_ok=True)
+        try:
+            result = _run_hook(
+                command="gh pr merge --squash",
+                stdout=f"✓ Squashed and merged pull request #{pr_num}",
+                tmp_path=tmp_path,
+            )
+            assert result.returncode == 0
+            assert sentinel.exists(), "Sentinel should be created via stdout fallback"
+        finally:
+            sentinel.unlink(missing_ok=True)
+
+
+class TestAutoMergeDetection:
+    """Test auto-merge flag detection and deferred completion."""
+
+    def test_auto_merge_does_not_create_sentinel_immediately(
+        self, tmp_path: Path
+    ) -> None:
+        """Auto-merge should NOT create sentinel (PR isn't merged yet)."""
+        pr_num = "9876"
+        sentinel = Path(f"/tmp/.claude-post-merge-notify-{pr_num}")
+        sentinel.unlink(missing_ok=True)
+        try:
+            result = _run_hook(
+                command=f"gh pr merge {pr_num} --auto --squash",
+                stdout=f"✓ Auto-merge enabled for pull request #{pr_num}",
+                tmp_path=tmp_path,
+            )
+            assert result.returncode == 0
+            assert not sentinel.exists(), (
+                "Sentinel should NOT be created for --auto "
+                "(PR isn't merged yet, watcher handles it)"
+            )
+        finally:
+            sentinel.unlink(missing_ok=True)
+
+    def test_auto_merge_with_delete_branch(self, tmp_path: Path) -> None:
+        """Auto-merge with --delete-branch should also defer."""
+        pr_num = "9875"
+        sentinel = Path(f"/tmp/.claude-post-merge-notify-{pr_num}")
+        sentinel.unlink(missing_ok=True)
+        try:
+            result = _run_hook(
+                command=f"gh pr merge {pr_num} --auto --squash --delete-branch",
+                stdout=f"✓ Auto-merge enabled for pull request #{pr_num}",
+                tmp_path=tmp_path,
+            )
+            assert result.returncode == 0
+            assert (
+                not sentinel.exists()
+            ), "Sentinel should NOT be created for --auto --delete-branch"
+        finally:
+            sentinel.unlink(missing_ok=True)
+
+    def test_direct_merge_creates_sentinel(self, tmp_path: Path) -> None:
+        """Direct merge (no --auto) should create sentinel immediately."""
+        pr_num = "9874"
+        sentinel = Path(f"/tmp/.claude-post-merge-notify-{pr_num}")
+        sentinel.unlink(missing_ok=True)
+        try:
+            result = _run_hook(
+                command=f"gh pr merge {pr_num} --squash",
+                stdout=f"✓ Squashed and merged pull request #{pr_num}",
+                tmp_path=tmp_path,
+            )
+            assert result.returncode == 0
+            assert sentinel.exists(), "Sentinel should be created for direct merge"
+        finally:
+            sentinel.unlink(missing_ok=True)
+
+
+class TestLaneIdResolution:
+    """Test lane identity resolution from environment variables."""
+
+    @pytest.mark.parametrize(
+        "dir_name,expected_lane",
+        [
+            ("Bid-Euchre-steward-author", "author-a"),
+            ("Bid-Euchre-steward-author-b", "author-b"),
+            ("Bid-Euchre-steward-flex-a", "flex-a"),
+            ("Bid-Euchre-steward-flex-b", "flex-b"),
+            ("Bid-Euchre-steward-brws-author-c", "brws-author-c"),
+            ("Bid-Euchre-steward-ops", "ops"),
+        ],
+    )
+    def test_lane_from_project_dir(
+        self,
+        tmp_path: Path,
+        dir_name: str,
+        expected_lane: str,  # noqa: ARG002
+    ) -> None:
+        """CLAUDE_PROJECT_DIR should resolve to correct lane ID."""
+        # We can't easily verify the lane_id from outside the hook,
+        # but we can verify the hook doesn't crash with valid dir names.
+        pr_num = "8765"
+        sentinel = Path(f"/tmp/.claude-post-merge-notify-{pr_num}")
+        sentinel.unlink(missing_ok=True)
+        try:
+            result = _run_hook(
+                command=f"gh pr merge {pr_num} --squash",
+                tmp_path=tmp_path,
+                env_overrides={
+                    "CLAUDE_PROJECT_DIR": f"/tmp/{dir_name}",
+                },
+            )
+            assert result.returncode == 0
+            assert sentinel.exists()
+        finally:
+            sentinel.unlink(missing_ok=True)
+
+    def test_lane_from_agent_name(self, tmp_path: Path) -> None:
+        """CLAUDE_AGENT_NAME should resolve to lane ID."""
+        pr_num = "8764"
+        sentinel = Path(f"/tmp/.claude-post-merge-notify-{pr_num}")
+        sentinel.unlink(missing_ok=True)
+        try:
+            result = _run_hook(
+                command=f"gh pr merge {pr_num} --squash",
+                tmp_path=tmp_path,
+                env_overrides={
+                    "CLAUDE_AGENT_NAME": "steward-author-c",
+                },
+            )
+            assert result.returncode == 0
+            assert sentinel.exists()
+        finally:
+            sentinel.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

- **Root cause:** All 4 problem PRs (#1453, #1455, #1456, #1460) were merged by `app/github-actions` (auto-merge), not via `gh pr merge` CLI — the PostToolUse hook only fires on CLI commands, so auto-merges silently bypassed the completion pipeline
- **Fix:** Detect `--auto` flag and launch a background watcher that polls for actual merge completion instead of completing prematurely
- **Bonus:** Add stdout fallback for PR number extraction when not in the command string

## Why

Issue #1461: Post-merge completion messages not reaching orchestrator inbox. The orchestrator had to manually poll `gh pr list --state merged` to discover finished work.

## Root Cause Analysis

Two bugs in `post-merge-notify.sh`:
1. **Premature completion:** `gh pr merge --auto` fires the hook (exit code 0) but the PR isn't merged yet — just auto-merge enabled. The hook completed the task and created a sentinel, blocking any future notification.
2. **Missing completion:** When GitHub Actions auto-merges the PR later, no CLI command is involved, so the PostToolUse hook never fires.

## Changes

| File | Change |
|------|--------|
| `.claude/hooks/post-merge-notify.sh` | Detect `--auto` flag, launch background watcher, add stdout PR# fallback, extract completion to reusable function |
| `tests/unit/test_post_merge_notify_hook.py` | 15 new tests covering guards, PR extraction, auto-merge detection, lane identity |

## Repro / Validation

```bash
# Direct merge (immediate completion, sentinel created)
echo '{"tool_input":{"command":"gh pr merge 7777 --squash"},...}' | bash .claude/hooks/post-merge-notify.sh
# → Sentinel at /tmp/.claude-post-merge-notify-7777 ✓

# Auto-merge (deferred, no sentinel yet)
echo '{"tool_input":{"command":"gh pr merge 6666 --auto --squash"},...}' | bash .claude/hooks/post-merge-notify.sh
# → No sentinel (watcher polls in background) ✓

# Stdout fallback (PR number from output, not command)
echo '{"tool_input":{"command":"gh pr merge --squash"},"tool_response":{"stdout":"✓ Merged #5555",...}}' | bash .claude/hooks/post-merge-notify.sh
# → Sentinel at /tmp/.claude-post-merge-notify-5555 ✓
```

## Tests

```bash
uv run python -m pytest tests/unit/test_post_merge_notify_hook.py -v  # 15 passed
uv run python -m pytest tests/unit/test_post_merge_notify_hook.py tests/unit/test_auto_merge_workflow.py tests/unit/test_post_merge_review_hook.py tests/unit/test_merge_guard.py -v  # 62 passed (all merge-related)
```

`make check-quiet` has pre-existing failures (missing fastapi/sqlalchemy for browser-game tests) unrelated to this change.

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b
branch: fix/post-merge-completion-pipeline
```

Closes #1461

🤖 Generated with [Claude Code](https://claude.com/claude-code)