### PR TITLE
browser-game: add 8 HTMX template partials for Phase 3 game UI

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -1,0 +1,467 @@
+"""Unit tests for Jinja2 template partials in web/templates/partials/.
+
+Validates that each partial renders correctly with representative context
+data matching the visible state contract from MatchEngine.get_visible_state().
+"""
+
+from __future__ import annotations
+
+import os
+
+import jinja2
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+TEMPLATES_DIR = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "..",
+    "web",
+    "templates",
+)
+
+
+@pytest.fixture()
+def env():
+    """Jinja2 environment loading from web/templates/."""
+    return jinja2.Environment(
+        loader=jinja2.FileSystemLoader(TEMPLATES_DIR),
+        autoescape=True,
+        undefined=jinja2.StrictUndefined,
+    )
+
+
+# ---------------------------------------------------------------------------
+# nickname_form.html
+# ---------------------------------------------------------------------------
+
+
+class TestNicknameForm:
+    def test_renders_form_with_link_uuid(self, env):
+        tmpl = env.get_template("partials/nickname_form.html")
+        html = tmpl.render(link_uuid="abc-123")
+        assert 'action="/play/abc-123/nickname"' in html
+        assert 'hx-post="/play/abc-123/nickname"' in html
+        assert 'name="nickname"' in html
+        assert "Set Nickname" in html
+
+    def test_has_required_attribute(self, env):
+        tmpl = env.get_template("partials/nickname_form.html")
+        html = tmpl.render(link_uuid="test-uuid")
+        assert "required" in html
+
+
+# ---------------------------------------------------------------------------
+# model_select.html
+# ---------------------------------------------------------------------------
+
+
+class ModelStub:
+    """Minimal stand-in for ModelInfo."""
+
+    def __init__(self, id: str, name: str, description: str):
+        self.id = id
+        self.name = name
+        self.description = description
+
+
+class TestModelSelect:
+    def test_renders_models_dropdown(self, env):
+        models = [
+            ModelStub("heuristic", "Heuristic", "Rule-based"),
+            ModelStub("hybrid", "Hybrid", "Statistical bidder"),
+        ]
+        tmpl = env.get_template("partials/model_select.html")
+        html = tmpl.render(link_uuid="abc-123", nickname="Alice", models=models)
+        assert 'value="heuristic"' in html
+        assert "Heuristic" in html
+        assert 'value="hybrid"' in html
+        assert "Alice" in html
+        assert 'action="/play/abc-123/select-ai"' in html
+
+    def test_renders_single_model(self, env):
+        models = [ModelStub("heuristic", "Heuristic", "Rule-based")]
+        tmpl = env.get_template("partials/model_select.html")
+        html = tmpl.render(link_uuid="x", nickname="Bob", models=models)
+        assert 'value="heuristic"' in html
+        assert "Start Match" in html
+
+
+# ---------------------------------------------------------------------------
+# bid_panel.html
+# ---------------------------------------------------------------------------
+
+
+class TestBidPanel:
+    def test_renders_pass_option(self, env):
+        tmpl = env.get_template("partials/bid_panel.html")
+        html = tmpl.render(
+            link_uuid="abc-123",
+            turn_number=0,
+            auction=[],
+            current_high_bid=0,
+            dealer_seat=3,
+        )
+        assert 'value="0">Pass' in html
+        assert 'name="turn_number"' in html
+        assert 'value="0"' in html
+
+    def test_shows_legal_bid_levels_above_current(self, env):
+        tmpl = env.get_template("partials/bid_panel.html")
+        html = tmpl.render(
+            link_uuid="abc-123",
+            turn_number=4,
+            auction=[
+                {"seat": 1, "n": 0, "action": "pass"},
+                {"seat": 2, "n": 5, "action": "bid", "contract": "H"},
+            ],
+            current_high_bid=5,
+            dealer_seat=0,
+        )
+        # Extract only the bid_n select options for precise checking.
+        # Bid levels 1-5 should NOT appear as bid_n options.
+        # (value="4" also exists in the turn_number hidden input, so
+        # we check within the select element specifically.)
+        import re
+
+        bid_select = re.search(
+            r'<select id="bid-level"[^>]*>(.*?)</select>', html, re.DOTALL
+        )
+        assert bid_select is not None
+        bid_options = bid_select.group(1)
+        for n in range(1, 6):
+            assert f'value="{n}">{n}' not in bid_options
+        # Should have bid levels 6-10
+        for n in range(6, 11):
+            assert f'value="{n}">{n}' in bid_options
+        # Pass is always available
+        assert "Pass" in bid_options
+
+    def test_shows_all_contract_types(self, env):
+        tmpl = env.get_template("partials/bid_panel.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=0,
+            auction=[],
+            current_high_bid=0,
+            dealer_seat=0,
+        )
+        assert "Spades" in html
+        assert "Hearts" in html
+        assert "Diamonds" in html
+        assert "Clubs" in html
+        assert "High (no trump)" in html
+        assert "Low (no trump)" in html
+
+    def test_auction_transcript_shows_entries(self, env):
+        tmpl = env.get_template("partials/bid_panel.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=2,
+            auction=[
+                {"seat": 1, "n": 0, "action": "pass"},
+                {"seat": 2, "n": 3, "action": "bid", "contract": "S"},
+            ],
+            current_high_bid=3,
+            dealer_seat=0,
+        )
+        assert "Pass" in html
+        # Spade symbol in transcript
+        assert "\u2660" in html  # ♠
+
+    def test_form_targets_correct_route(self, env):
+        tmpl = env.get_template("partials/bid_panel.html")
+        html = tmpl.render(
+            link_uuid="test-uuid",
+            turn_number=5,
+            auction=[],
+            current_high_bid=0,
+            dealer_seat=0,
+        )
+        assert 'hx-post="/play/test-uuid/bid"' in html
+        assert 'hx-target="#game-board"' in html
+
+
+# ---------------------------------------------------------------------------
+# hand.html
+# ---------------------------------------------------------------------------
+
+
+class TestHand:
+    def test_renders_cards_during_auction(self, env):
+        """During auction, cards are shown but not clickable."""
+        tmpl = env.get_template("partials/hand.html")
+        html = tmpl.render(
+            link_uuid="abc-123",
+            turn_number=0,
+            human_hand=[["S", "A"], ["H", "K"], ["D", "10"]],
+            legal_plays=None,
+            phase="auction",
+        )
+        assert "\u2660" in html  # ♠
+        assert "\u2665" in html  # ♥
+        assert "\u2666" in html  # ♦
+        assert "A" in html
+        assert "K" in html
+        # No card--legal or card--illegal during auction (plain cards)
+        assert "card--legal" not in html
+
+    def test_legal_cards_are_form_buttons(self, env):
+        """During trick play, legal cards are form buttons."""
+        tmpl = env.get_template("partials/hand.html")
+        html = tmpl.render(
+            link_uuid="abc-123",
+            turn_number=8,
+            human_hand=[["S", "A"], ["H", "K"], ["D", "10"]],
+            legal_plays=[0, 2],  # First and third cards are legal
+            phase="trick_play",
+        )
+        # Legal cards have form with hx-post
+        assert 'hx-post="/play/abc-123/play-card"' in html
+        assert 'name="card_index" value="0"' in html
+        assert 'name="card_index" value="2"' in html
+        assert "card--legal" in html
+
+    def test_illegal_cards_are_divs(self, env):
+        """During trick play, illegal cards are plain divs."""
+        tmpl = env.get_template("partials/hand.html")
+        html = tmpl.render(
+            link_uuid="abc-123",
+            turn_number=8,
+            human_hand=[["S", "A"], ["H", "K"], ["D", "10"]],
+            legal_plays=[0],  # Only first card is legal
+            phase="trick_play",
+        )
+        assert "card--illegal" in html
+        # card_index=1 should NOT appear in a form
+        assert 'name="card_index" value="1"' not in html
+
+    def test_turn_number_in_forms(self, env):
+        tmpl = env.get_template("partials/hand.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=42,
+            human_hand=[["C", "J"]],
+            legal_plays=[0],
+            phase="trick_play",
+        )
+        assert 'name="turn_number" value="42"' in html
+
+
+# ---------------------------------------------------------------------------
+# trick.html
+# ---------------------------------------------------------------------------
+
+
+class TestTrick:
+    def test_renders_empty_trick(self, env):
+        tmpl = env.get_template("partials/trick.html")
+        html = tmpl.render(
+            current_trick={"leader": 0, "plays": []},
+            completed_tricks=[],
+            tricks_team0=0,
+            tricks_team1=0,
+        )
+        assert "Trick 1 of 10" in html
+        assert "0\u20131" not in html or "0\u20130" in html  # 0–0
+
+    def test_renders_played_cards(self, env):
+        tmpl = env.get_template("partials/trick.html")
+        html = tmpl.render(
+            current_trick={
+                "leader": 1,
+                "plays": [
+                    [1, ["H", "A"]],
+                    [2, ["S", "K"]],
+                ],
+            },
+            completed_tricks=[],
+            tricks_team0=0,
+            tricks_team1=0,
+        )
+        assert "A" in html  # Ace
+        assert "\u2665" in html  # ♥
+        assert "K" in html  # King
+        assert "\u2660" in html  # ♠
+
+    def test_trick_number_increments(self, env):
+        tmpl = env.get_template("partials/trick.html")
+        # After 3 completed tricks
+        html = tmpl.render(
+            current_trick={"leader": 0, "plays": []},
+            completed_tricks=[{}, {}, {}],
+            tricks_team0=2,
+            tricks_team1=1,
+        )
+        assert "Trick 4 of 10" in html
+
+    def test_no_current_trick(self, env):
+        """When current_trick is None (e.g., hand complete)."""
+        tmpl = env.get_template("partials/trick.html")
+        html = tmpl.render(
+            current_trick=None,
+            completed_tricks=[{}, {}, {}, {}, {}],
+            tricks_team0=3,
+            tricks_team1=2,
+        )
+        assert "trick-area" in html
+
+
+# ---------------------------------------------------------------------------
+# score.html
+# ---------------------------------------------------------------------------
+
+
+class TestScore:
+    def test_renders_scores(self, env):
+        tmpl = env.get_template("partials/score.html")
+        html = tmpl.render(
+            score_human=15,
+            score_ai=-3,
+            hands_played=4,
+            contract_type="suit",
+            trump="H",
+            winning_bid=6,
+            bidder_seat=0,
+            tricks_team0=4,
+            tricks_team1=2,
+            dealer_seat=3,
+            phase="trick_play",
+        )
+        assert "15" in html
+        assert "-3" in html
+        assert "Hand 5" in html
+        assert "6" in html  # bid
+        assert "\u2665" in html  # ♥
+        assert "You" in html  # declarer
+
+    def test_auction_in_progress(self, env):
+        tmpl = env.get_template("partials/score.html")
+        html = tmpl.render(
+            score_human=0,
+            score_ai=0,
+            hands_played=0,
+            contract_type=None,
+            trump=None,
+            winning_bid=None,
+            bidder_seat=None,
+            tricks_team0=0,
+            tricks_team1=0,
+            dealer_seat=0,
+            phase="auction",
+        )
+        assert "Auction in progress" in html
+        assert "Hand 1" in html
+
+    def test_high_contract_display(self, env):
+        tmpl = env.get_template("partials/score.html")
+        html = tmpl.render(
+            score_human=10,
+            score_ai=5,
+            hands_played=2,
+            contract_type="HIGH",
+            trump=None,
+            winning_bid=7,
+            bidder_seat=1,
+            tricks_team0=0,
+            tricks_team1=0,
+            dealer_seat=2,
+            phase="trick_play",
+        )
+        assert "7" in html
+        assert "High" in html
+
+
+# ---------------------------------------------------------------------------
+# hand_result.html
+# ---------------------------------------------------------------------------
+
+
+class TestHandResult:
+    def test_made_bid(self, env):
+        tmpl = env.get_template("partials/hand_result.html")
+        html = tmpl.render(
+            winning_bid=6,
+            bidder_seat=0,
+            contract_type="suit",
+            trump="S",
+            tricks_team0=7,
+            tricks_team1=3,
+            points_team0=7,
+            points_team1=3,
+            score_human=7,
+            score_ai=3,
+            hands_played=1,
+        )
+        assert "Made it!" in html
+        assert "7" in html  # tricks
+        assert "\u2660" in html  # ♠
+
+    def test_set_bid(self, env):
+        tmpl = env.get_template("partials/hand_result.html")
+        html = tmpl.render(
+            winning_bid=8,
+            bidder_seat=0,
+            contract_type="suit",
+            trump="H",
+            tricks_team0=5,
+            tricks_team1=5,
+            points_team0=-8,
+            points_team1=5,
+            score_human=-8,
+            score_ai=5,
+            hands_played=1,
+        )
+        assert "Set!" in html
+        assert "-8" in html  # points
+
+
+# ---------------------------------------------------------------------------
+# match_result.html
+# ---------------------------------------------------------------------------
+
+
+class TestMatchResult:
+    def test_human_wins(self, env):
+        tmpl = env.get_template("partials/match_result.html")
+        html = tmpl.render(
+            link_uuid="abc-123",
+            winner="human",
+            score_human=55,
+            score_ai=30,
+            hands_played=12,
+        )
+        assert "You Win!" in html
+        assert "55" in html
+        assert "30" in html
+        assert "12" in html
+        assert "Play Again" in html
+        assert 'hx-post="/play/abc-123/new-match"' in html
+
+    def test_ai_wins(self, env):
+        tmpl = env.get_template("partials/match_result.html")
+        html = tmpl.render(
+            link_uuid="x",
+            winner="ai",
+            score_human=20,
+            score_ai=54,
+            hands_played=8,
+        )
+        assert "You Lose" in html
+        assert "Play Again" in html
+
+    def test_play_again_form(self, env):
+        tmpl = env.get_template("partials/match_result.html")
+        html = tmpl.render(
+            link_uuid="test-id",
+            winner="human",
+            score_human=52,
+            score_ai=10,
+            hands_played=5,
+        )
+        assert 'action="/play/test-id/new-match"' in html
+        assert 'hx-target="#game-board"' in html

--- a/web/templates/partials/bid_panel.html
+++ b/web/templates/partials/bid_panel.html
@@ -1,0 +1,86 @@
+{# Bid amount + contract type selector partial.
+   Context variables:
+     - link_uuid: str — player's game link UUID
+     - turn_number: int — current turn for idempotency
+     - auction: list[dict] — auction transcript entries
+       Each entry: {seat, n, action, contract? (if action == "bid")}
+     - current_high_bid: int — highest bid so far (0 if no bids yet)
+     - dealer_seat: int — seat number of the dealer
+#}
+{% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
+{% set seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"} %}
+
+<div id="bid-panel">
+    <h3>Auction</h3>
+
+    {# Show auction transcript so far #}
+    {% if auction %}
+    <div class="auction-transcript">
+        <table class="auction-table">
+            <thead>
+                <tr>
+                    <th>Player</th>
+                    <th>Bid</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for entry in auction %}
+                <tr>
+                    <td>{{ seat_labels.get(entry.seat, "Seat " ~ entry.seat) }}</td>
+                    <td>
+                        {% if entry.action == "pass" %}
+                            Pass
+                        {% else %}
+                            {{ entry.n }}
+                            {% if entry.contract in suit_symbols %}
+                                {{ suit_symbols[entry.contract] }}
+                            {% elif entry.contract == "HIGH" %}
+                                High
+                            {% elif entry.contract == "LOW" %}
+                                Low
+                            {% endif %}
+                        {% endif %}
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% endif %}
+
+    {# Bid form — only shown when it's the human's turn #}
+    <form method="post"
+          action="/play/{{ link_uuid }}/bid"
+          hx-post="/play/{{ link_uuid }}/bid"
+          hx-target="#game-board"
+          hx-swap="innerHTML">
+        <input type="hidden" name="turn_number" value="{{ turn_number }}">
+
+        <div class="bid-controls">
+            <label for="bid-level">Bid:</label>
+            <select id="bid-level" name="bid_n">
+                <option value="0">Pass</option>
+                {% for n in range(current_high_bid + 1, 11) %}
+                <option value="{{ n }}">{{ n }}</option>
+                {% endfor %}
+            </select>
+
+            <label for="bid-contract">Contract:</label>
+            <select id="bid-contract" name="bid_contract">
+                <option value="S">♠ Spades</option>
+                <option value="H">♥ Hearts</option>
+                <option value="D">♦ Diamonds</option>
+                <option value="C">♣ Clubs</option>
+                <option value="HIGH">High (no trump)</option>
+                <option value="LOW">Low (no trump)</option>
+            </select>
+
+            <button type="submit">Submit Bid</button>
+        </div>
+    </form>
+
+    {% if current_high_bid > 0 %}
+    <p class="bid-info">Current high bid: {{ current_high_bid }}</p>
+    {% endif %}
+    <p class="bid-info">Dealer: {{ seat_labels.get(dealer_seat, "Seat " ~ dealer_seat) }}</p>
+</div>

--- a/web/templates/partials/hand.html
+++ b/web/templates/partials/hand.html
@@ -1,0 +1,49 @@
+{# Player's hand partial — legal cards as form buttons, illegal as plain divs.
+   Context variables:
+     - link_uuid: str — player's game link UUID
+     - turn_number: int — current turn for idempotency
+     - human_hand: list[list[str, str]] — cards as [suit, rank] pairs
+     - legal_plays: list[int] | None — legal card indices (None if not in trick_play phase)
+     - phase: str — current hand phase ("auction", "trick_play", "complete", "redeal")
+#}
+{% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
+{% set suit_classes = {"S": "spades", "H": "hearts", "D": "diamonds", "C": "clubs"} %}
+
+<div id="human-hand" class="hand">
+    <h3>Your Hand</h3>
+    <div class="card-fan">
+        {% for card in human_hand %}
+            {% set suit = card[0] %}
+            {% set rank = card[1] %}
+            {% set idx = loop.index0 %}
+            {% set suit_class = suit_classes.get(suit, "spades") %}
+            {% set suit_sym = suit_symbols.get(suit, suit) %}
+
+            {% if phase == "trick_play" and legal_plays is not none and idx in legal_plays %}
+                {# Legal card — clickable form button #}
+                <form method="post"
+                      action="/play/{{ link_uuid }}/play-card"
+                      hx-post="/play/{{ link_uuid }}/play-card"
+                      hx-target="#game-board"
+                      hx-swap="innerHTML"
+                      class="card-form">
+                    <input type="hidden" name="turn_number" value="{{ turn_number }}">
+                    <input type="hidden" name="card_index" value="{{ idx }}">
+                    <button type="submit"
+                            class="card card--{{ suit_class }} card--legal"
+                            title="{{ rank }}{{ suit_sym }} (click to play)">
+                        <span class="card__rank">{{ rank }}</span>
+                        <span class="card__suit">{{ suit_sym }}</span>
+                    </button>
+                </form>
+            {% else %}
+                {# Illegal or non-play-phase card — plain div #}
+                <div class="card card--{{ suit_class }}{% if phase == 'trick_play' %} card--illegal{% endif %}"
+                     title="{{ rank }}{{ suit_sym }}">
+                    <span class="card__rank">{{ rank }}</span>
+                    <span class="card__suit">{{ suit_sym }}</span>
+                </div>
+            {% endif %}
+        {% endfor %}
+    </div>
+</div>

--- a/web/templates/partials/hand_result.html
+++ b/web/templates/partials/hand_result.html
@@ -1,0 +1,76 @@
+{# Hand result banner partial — shown between hands after scoring.
+   Context variables:
+     - winning_bid: int — the winning bid amount
+     - bidder_seat: int — seat of the declarer
+     - contract_type: str — "suit", "HIGH", or "LOW"
+     - trump: str | None — trump suit letter (if suit contract)
+     - tricks_team0: int — tricks won by human team (seats 0, 2)
+     - tricks_team1: int — tricks won by AI team (seats 1, 3)
+     - points_team0: int — points scored by human team this hand
+     - points_team1: int — points scored by AI team this hand
+     - score_human: int — running match score for human team
+     - score_ai: int — running match score for AI team
+     - hands_played: int — total hands completed
+#}
+{% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
+{% set seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"} %}
+
+{# Determine if the declaring team made their bid #}
+{% set declarer_team = 0 if bidder_seat in [0, 2] else 1 %}
+{% set declarer_tricks = tricks_team0 if declarer_team == 0 else tricks_team1 %}
+{% set made = declarer_tricks >= winning_bid %}
+{% set human_declared = bidder_seat in [0, 2] %}
+
+<div id="hand-result" class="hand-result {% if made and human_declared %}result--made{% elif not made and not human_declared %}result--made{% else %}result--set{% endif %}">
+    <div class="result-banner">
+        {% if made %}
+            <h2 class="result-title">Made it!</h2>
+            <p class="result-detail">
+                {{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }} bid {{ winning_bid }}
+                {% if contract_type == "suit" and trump %}
+                    {{ suit_symbols.get(trump, trump) }}
+                {% elif contract_type == "HIGH" %}
+                    High
+                {% elif contract_type == "LOW" %}
+                    Low
+                {% endif %}
+                and took {{ declarer_tricks }} tricks.
+            </p>
+        {% else %}
+            <h2 class="result-title">Set!</h2>
+            <p class="result-detail">
+                {{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }} bid {{ winning_bid }}
+                {% if contract_type == "suit" and trump %}
+                    {{ suit_symbols.get(trump, trump) }}
+                {% elif contract_type == "HIGH" %}
+                    High
+                {% elif contract_type == "LOW" %}
+                    Low
+                {% endif %}
+                but only took {{ declarer_tricks }} tricks.
+            </p>
+        {% endif %}
+    </div>
+
+    <div class="result-scoring">
+        <table class="result-table">
+            <tr>
+                <td>Your team:</td>
+                <td class="{% if points_team0 > 0 %}points--positive{% elif points_team0 < 0 %}points--negative{% endif %}">
+                    {{ "+" if points_team0 > 0 }}{{ points_team0 }}
+                </td>
+            </tr>
+            <tr>
+                <td>AI team:</td>
+                <td class="{% if points_team1 > 0 %}points--positive{% elif points_team1 < 0 %}points--negative{% endif %}">
+                    {{ "+" if points_team1 > 0 }}{{ points_team1 }}
+                </td>
+            </tr>
+        </table>
+    </div>
+
+    <div class="result-match-score">
+        <p>Match score: You {{ score_human }} &mdash; AI {{ score_ai }}</p>
+        <p class="hands-count">Hands played: {{ hands_played }}</p>
+    </div>
+</div>

--- a/web/templates/partials/match_result.html
+++ b/web/templates/partials/match_result.html
@@ -1,0 +1,39 @@
+{# Win/loss screen partial with Play Again button.
+   Context variables:
+     - link_uuid: str — player's game link UUID
+     - winner: str — "human" or "ai"
+     - score_human: int — final human team score
+     - score_ai: int — final AI team score
+     - hands_played: int — total hands played in the match
+#}
+<div id="match-result" class="match-result {% if winner == 'human' %}result--win{% else %}result--loss{% endif %}">
+    <div class="result-banner">
+        {% if winner == "human" %}
+            <h1 class="result-title">You Win! 🎉</h1>
+        {% else %}
+            <h1 class="result-title">You Lose</h1>
+        {% endif %}
+    </div>
+
+    <div class="final-score">
+        <table class="score-table">
+            <tr>
+                <td>Your team:</td>
+                <td class="score-final">{{ score_human }}</td>
+            </tr>
+            <tr>
+                <td>AI team:</td>
+                <td class="score-final">{{ score_ai }}</td>
+            </tr>
+        </table>
+        <p class="hands-count">Hands played: {{ hands_played }}</p>
+    </div>
+
+    <form method="post"
+          action="/play/{{ link_uuid }}/new-match"
+          hx-post="/play/{{ link_uuid }}/new-match"
+          hx-target="#game-board"
+          hx-swap="innerHTML">
+        <button type="submit" class="btn btn--play-again">Play Again</button>
+    </form>
+</div>

--- a/web/templates/partials/model_select.html
+++ b/web/templates/partials/model_select.html
@@ -1,0 +1,22 @@
+{# AI model picker partial.
+   Context variables:
+     - link_uuid: str — player's game link UUID
+     - nickname: str — player's (escaped) nickname
+     - models: list[ModelInfo] — available AI models (each has .id, .name, .description)
+#}
+<div id="model-select">
+    <h2>Welcome, {{ nickname }}!</h2>
+    <p>Choose your AI opponent:</p>
+    <form method="post"
+          action="/play/{{ link_uuid }}/select-ai"
+          hx-post="/play/{{ link_uuid }}/select-ai"
+          hx-target="#game-board"
+          hx-swap="innerHTML">
+        <select name="model_id" required>
+            {% for model in models %}
+            <option value="{{ model.id }}">{{ model.name }} &mdash; {{ model.description }}</option>
+            {% endfor %}
+        </select>
+        <button type="submit">Start Match</button>
+    </form>
+</div>

--- a/web/templates/partials/nickname_form.html
+++ b/web/templates/partials/nickname_form.html
@@ -1,0 +1,22 @@
+{# Nickname input form partial.
+   Context variables:
+     - link_uuid: str — player's game link UUID
+#}
+<div id="nickname-form">
+    <h2>Enter your nickname</h2>
+    <form method="post"
+          action="/play/{{ link_uuid }}/nickname"
+          hx-post="/play/{{ link_uuid }}/nickname"
+          hx-target="#game-board"
+          hx-swap="innerHTML">
+        <label for="nickname-input">Nickname:</label>
+        <input id="nickname-input"
+               name="nickname"
+               type="text"
+               maxlength="30"
+               required
+               autofocus
+               placeholder="Your name">
+        <button type="submit">Set Nickname</button>
+    </form>
+</div>

--- a/web/templates/partials/score.html
+++ b/web/templates/partials/score.html
@@ -1,0 +1,64 @@
+{# Match score + hand info + contract display partial.
+   Context variables:
+     - score_human: int — human team's total match score
+     - score_ai: int — AI team's total match score
+     - hands_played: int — number of completed hands
+     - contract_type: str | None — "suit", "HIGH", or "LOW" (None if auction in progress)
+     - trump: str | None — trump suit letter if contract_type == "suit"
+     - winning_bid: int | None — winning bid amount (None if auction in progress)
+     - bidder_seat: int | None — seat of the declarer (None if auction in progress)
+     - tricks_team0: int — current hand tricks for human team
+     - tricks_team1: int — current hand tricks for AI team
+     - dealer_seat: int — seat number of the dealer
+     - phase: str — current hand phase
+#}
+{% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
+{% set seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"} %}
+
+<div id="score-bar" class="score-bar">
+    <div class="score-section">
+        <span class="score-label">You:</span>
+        <span class="score-value{% if score_human >= 0 %} score--positive{% else %} score--negative{% endif %}">
+            {{ score_human }}
+        </span>
+        <span class="score-separator">|</span>
+        <span class="score-label">AI:</span>
+        <span class="score-value{% if score_ai >= 0 %} score--positive{% else %} score--negative{% endif %}">
+            {{ score_ai }}
+        </span>
+    </div>
+
+    <div class="hand-info">
+        <span>Hand {{ hands_played + 1 }}</span>
+        <span class="info-separator">&middot;</span>
+        <span>Dealer: {{ seat_labels.get(dealer_seat, "Seat " ~ dealer_seat) }}</span>
+    </div>
+
+    {% if contract_type is not none and winning_bid is not none %}
+    <div class="contract-info">
+        <span>Contract: {{ winning_bid }}
+            {% if contract_type == "suit" and trump %}
+                {{ suit_symbols.get(trump, trump) }}
+            {% elif contract_type == "HIGH" %}
+                High
+            {% elif contract_type == "LOW" %}
+                Low
+            {% endif %}
+        </span>
+        <span class="info-separator">&middot;</span>
+        <span>Declarer: {{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}</span>
+        {% if phase == "trick_play" %}
+        <span class="info-separator">&middot;</span>
+        <span>Tricks: {{ tricks_team0 }}&ndash;{{ tricks_team1 }}</span>
+        {% endif %}
+    </div>
+    {% elif phase == "auction" %}
+    <div class="contract-info">
+        <span>Auction in progress</span>
+    </div>
+    {% endif %}
+
+    <div class="match-target">
+        First to &plusmn;52 wins
+    </div>
+</div>

--- a/web/templates/partials/trick.html
+++ b/web/templates/partials/trick.html
@@ -1,0 +1,93 @@
+{# Current trick area partial — 4 card slots arranged by seat position.
+   Context variables:
+     - current_trick: dict | None — {leader: int, plays: list[[seat, [suit, rank]]]}
+     - completed_tricks: list[dict] — completed tricks for reference count
+     - tricks_team0: int — tricks won by human's team (seats 0, 2)
+     - tricks_team1: int — tricks won by AI team (seats 1, 3)
+#}
+{% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
+{% set suit_classes = {"S": "spades", "H": "hearts", "D": "diamonds", "C": "clubs"} %}
+{% set seat_labels = {0: "You", 1: "AI Left", 2: "Partner", 3: "AI Right"} %}
+
+{# Build a dict mapping seat -> card for the current trick.
+   Uses namespace to work around Jinja2 for-loop scoping. #}
+{% set ns = namespace(cards={}) %}
+{% if current_trick %}
+    {% for play in current_trick.plays %}
+        {% set _ = ns.cards.update({play[0]: play[1]}) %}
+    {% endfor %}
+{% endif %}
+
+<div id="trick-area" class="trick-area">
+    <h3>Trick {{ (completed_tricks | length) + 1 }} of 10</h3>
+    <div class="trick-table">
+        {# Top — seat 2 (partner) #}
+        <div class="trick-slot trick-slot--top">
+            {% if 2 in ns.cards %}
+                {% set card = ns.cards[2] %}
+                {% set suit = card[0] %}
+                <div class="card card--{{ suit_classes.get(suit, 'spades') }} card--played">
+                    <span class="card__rank">{{ card[1] }}</span>
+                    <span class="card__suit">{{ suit_symbols.get(suit, suit) }}</span>
+                </div>
+            {% else %}
+                <div class="card-slot card-slot--empty">
+                    <span class="seat-label">{{ seat_labels[2] }}</span>
+                </div>
+            {% endif %}
+        </div>
+
+        {# Middle row: Left (seat 1), Center spacer, Right (seat 3) #}
+        <div class="trick-row-middle">
+            <div class="trick-slot trick-slot--left">
+                {% if 1 in ns.cards %}
+                    {% set card = ns.cards[1] %}
+                    {% set suit = card[0] %}
+                    <div class="card card--{{ suit_classes.get(suit, 'spades') }} card--played">
+                        <span class="card__rank">{{ card[1] }}</span>
+                        <span class="card__suit">{{ suit_symbols.get(suit, suit) }}</span>
+                    </div>
+                {% else %}
+                    <div class="card-slot card-slot--empty">
+                        <span class="seat-label">{{ seat_labels[1] }}</span>
+                    </div>
+                {% endif %}
+            </div>
+
+            <div class="trick-center">
+                <span class="trick-count">{{ tricks_team0 }}&ndash;{{ tricks_team1 }}</span>
+            </div>
+
+            <div class="trick-slot trick-slot--right">
+                {% if 3 in ns.cards %}
+                    {% set card = ns.cards[3] %}
+                    {% set suit = card[0] %}
+                    <div class="card card--{{ suit_classes.get(suit, 'spades') }} card--played">
+                        <span class="card__rank">{{ card[1] }}</span>
+                        <span class="card__suit">{{ suit_symbols.get(suit, suit) }}</span>
+                    </div>
+                {% else %}
+                    <div class="card-slot card-slot--empty">
+                        <span class="seat-label">{{ seat_labels[3] }}</span>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+
+        {# Bottom — seat 0 (human) #}
+        <div class="trick-slot trick-slot--bottom">
+            {% if 0 in ns.cards %}
+                {% set card = ns.cards[0] %}
+                {% set suit = card[0] %}
+                <div class="card card--{{ suit_classes.get(suit, 'spades') }} card--played">
+                    <span class="card__rank">{{ card[1] }}</span>
+                    <span class="card__suit">{{ suit_symbols.get(suit, suit) }}</span>
+                </div>
+            {% else %}
+                <div class="card-slot card-slot--empty">
+                    <span class="seat-label">{{ seat_labels[0] }}</span>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- **SP-3-02 Step 2**: Create all 8 template partials for HTMX swap responses
- Partials: `nickname_form`, `model_select`, `bid_panel`, `hand`, `trick`, `score`, `hand_result`, `match_result`
- Each partial is a self-contained Jinja2 fragment with documented context variables matching `MatchEngine.get_visible_state()`

## Why
Phase 3 of the browser game governing plan requires a playable UI. These partials are the building blocks for HTMX partial swaps — the routes will render these templates instead of inline HTML once the route integration step lands.

## Key Design Decisions
- **Bid panel**: Shows only legal bid levels (strictly above current high bid) via `range(current_high_bid + 1, 11)`. Contract type selector includes all 6 options (4 suits + High + Low).
- **Card play**: Each legal card is a per-card `<form>` with `hx-post` to `/play/{uuid}/play-card`, carrying `card_index` and `turn_number` for idempotency. Illegal cards are plain `<div>`s with `card--illegal` class.
- **Trick area**: Uses Jinja2 `namespace` to work around for-loop variable scoping when extracting played cards per seat.
- **All forms**: Include `hx-target="#game-board" hx-swap="innerHTML"` for HTMX swap targeting.

## Repro / Validation
```bash
# Tier 1 — partials unit tests (25 tests)
uv run python -m pytest tests/unit/hosted_play/test_partials.py -v

# Tier 2 — full validation
make check-quiet
```

## Tests
- 25 new unit tests in `tests/unit/hosted_play/test_partials.py`
- Tests render each partial with representative game state data and verify:
  - Correct HTMX attributes and form targets
  - Legal bid levels filtered correctly
  - Card play forms carry correct `card_index` and `turn_number`
  - Suit symbols render (♠♥♦♣)
  - Score, hand result, and match result display correctly

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
branch: browser-game/phase3-step2-partials
```

## Files Changed
| File | Purpose |
|------|---------|
| `web/templates/partials/nickname_form.html` | Nickname input form |
| `web/templates/partials/model_select.html` | AI model picker |
| `web/templates/partials/bid_panel.html` | Bid amount + contract type selector |
| `web/templates/partials/hand.html` | Player's cards (legal as form buttons) |
| `web/templates/partials/trick.html` | Current trick area (4 card slots) |
| `web/templates/partials/score.html` | Match score + hand info + contract display |
| `web/templates/partials/hand_result.html` | Made/set banner between hands |
| `web/templates/partials/match_result.html` | Win/loss screen with Play Again |
| `tests/unit/hosted_play/test_partials.py` | 25 unit tests for all partials |

🤖 Generated with [Claude Code](https://claude.com/claude-code)