### PR TITLE
ops: auto-refresh stale lane worktrees before task dispatch

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -1572,8 +1572,13 @@ def cmd_task(args: argparse.Namespace) -> int:
                     return 1
 
         do_reset = getattr(args, "reset", False)
+        no_auto_refresh = getattr(args, "no_auto_refresh", False)
         result = dispatch_to_worker(
-            packet_id, lane_id, runtime_dir=args.runtime_dir, reset=do_reset
+            packet_id,
+            lane_id,
+            runtime_dir=args.runtime_dir,
+            reset=do_reset,
+            no_auto_refresh=no_auto_refresh,
         )
         if args.json:
             from dataclasses import asdict
@@ -2447,8 +2452,13 @@ def cmd_workers(args: argparse.Namespace) -> int:
         packet_id = args.packet_id
         lane_id = args.lane_id
         do_reset = getattr(args, "reset", False)
+        no_auto_refresh = getattr(args, "no_auto_refresh", False)
         result = dispatch_to_worker(
-            packet_id, lane_id, runtime_dir=args.runtime_dir, reset=do_reset
+            packet_id,
+            lane_id,
+            runtime_dir=args.runtime_dir,
+            reset=do_reset,
+            no_auto_refresh=no_auto_refresh,
         )
         if args.json:
             from dataclasses import asdict
@@ -3128,6 +3138,13 @@ def build_parser() -> argparse.ArgumentParser:
         default=False,
         help="Reset worktree to origin/main and clear Claude session before dispatching",
     )
+    task_dispatch_parser.add_argument(
+        "--no-refresh",
+        action="store_true",
+        dest="no_auto_refresh",
+        default=False,
+        help="Skip automatic staleness check and refresh of the target worktree",
+    )
 
     task_accept_parser = task_sub.add_parser(
         "accept",
@@ -3382,6 +3399,13 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         default=False,
         help="Reset worktree to origin/main and clear Claude session before dispatching",
+    )
+    workers_dispatch.add_argument(
+        "--no-refresh",
+        action="store_true",
+        dest="no_auto_refresh",
+        default=False,
+        help="Skip automatic staleness check and refresh of the target worktree",
     )
 
     workers_maintain = workers_sub.add_parser(

--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -459,6 +459,65 @@ def _get_lane_task_id(
     return None
 
 
+def _is_worktree_stale(
+    lane_id: str,
+    runtime_dir: Path | None = None,
+) -> bool:
+    """Check whether a lane's worktree is on a stale (non-main) branch.
+
+    A worktree is "stale" if it is checked out on a branch other than ``main``
+    or is ahead of ``origin/main``.  This indicates leftover state from a
+    previous task.
+
+    The check uses ``git rev-parse`` inside the resolved worktree path.
+    Returns ``False`` on any error (safe default: assume not stale).
+
+    Args:
+        lane_id: Lane to check.
+        runtime_dir: Override for the runtime directory root.
+
+    Returns:
+        ``True`` if the worktree appears stale, ``False`` otherwise.
+    """
+    worktree_path = _resolve_worktree_path(lane_id, runtime_dir)
+    if not worktree_path:
+        return False
+
+    try:
+        # Get the current branch name
+        branch_result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if branch_result.returncode != 0:
+            return False
+
+        branch = branch_result.stdout.strip()
+        if branch != "main":
+            return True
+
+        # On main — check if ahead of origin/main
+        ahead_result = subprocess.run(
+            ["git", "rev-list", "--count", "origin/main..HEAD"],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if ahead_result.returncode == 0:
+            ahead_count = int(ahead_result.stdout.strip())
+            if ahead_count > 0:
+                return True
+
+    except (subprocess.TimeoutExpired, OSError, ValueError):
+        return False
+
+    return False
+
+
 def _minutes_since(iso_timestamp: str | None, now: datetime) -> float | None:
     """Calculate minutes elapsed since an ISO 8601 timestamp.
 
@@ -1151,6 +1210,7 @@ def dispatch_to_worker(
     tmux_session: str = DEFAULT_TMUX_SESSION,
     runtime_dir: Path | None = None,
     reset: bool = False,
+    no_auto_refresh: bool = False,
 ) -> PoolAction:
     """Complete lifecycle: wake worker, assign task packet, nudge pane.
 
@@ -1158,6 +1218,7 @@ def dispatch_to_worker(
     1. Load task packet, verify it is in "approved" status.
     2. Take pool snapshot, verify lane_id has capacity.
     3. If lane is parked/retired: wake_worker() first.
+    3a. Auto-refresh stale worktrees (unless ``no_auto_refresh`` or ``reset``).
     3b. If ``reset=True``: reset worktree to origin/main and clear session.
     4. Transition packet to "dispatched" with owner = lane_id.
     4b. Copy dispatched packet JSON to the target worktree's task_queue
@@ -1178,6 +1239,8 @@ def dispatch_to_worker(
         reset: If True, reset the worktree to origin/main and send /clear
             to the Claude session before dispatching.  Recommended when the
             lane is idle and stale context should be discarded.
+        no_auto_refresh: If True, skip the automatic staleness check and
+            refresh.  Useful when the caller knows the lane is already clean.
 
     Returns:
         A :class:`PoolAction` describing what happened.
@@ -1263,6 +1326,34 @@ def dispatch_to_worker(
                 executed=False,
                 error=f"wake_failed:{wake_result.error}",
             )
+
+    # 3a. Auto-refresh stale worktrees
+    #     Skip if caller already requested explicit reset (step 3b does the same
+    #     thing) or if auto-refresh is disabled.
+    if not reset and not no_auto_refresh:
+        if _is_worktree_stale(lane_id, runtime_dir):
+            logger.info(
+                "Lane %s worktree is stale; auto-refreshing before dispatch",
+                lane_id,
+            )
+            auto_refresh = refresh_worker(
+                lane_id,
+                force=True,
+                tmux_session=tmux_session,
+                runtime_dir=runtime_dir,
+            )
+            if auto_refresh.executed:
+                logger.info("Auto-refresh succeeded for %s", lane_id)
+                import time
+
+                # Brief pause to let /clear complete before sending /start-task
+                time.sleep(2)
+            else:
+                logger.warning(
+                    "Auto-refresh failed for %s: %s (continuing dispatch)",
+                    lane_id,
+                    auto_refresh.reason,
+                )
 
     # 3b. Reset worktree and clear session if requested
     if reset:

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -22,6 +22,7 @@ from bid_euchre.ops.worker_pool import (
     _classify_pool_status,
     _dynamic_pane_lookup,
     _get_lane_task_id,
+    _is_worktree_stale,
     _managed_lanes,
     _minutes_since,
     _probe_tmux_pane,
@@ -2348,6 +2349,359 @@ class TestDispatchWithReset:
         assert result.executed is True
         mock_reset.assert_called_once()
         mock_clear.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Dispatch auto-refresh stale worktrees
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchAutoRefresh:
+    """Test that dispatch_to_worker() auto-refreshes stale lanes."""
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}.nudge_pane")
+    @patch("time.sleep")
+    @patch(f"{_WORKER_POOL}.refresh_worker")
+    @patch(f"{_WORKER_POOL}._is_worktree_stale")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.transition_status")
+    @patch(f"{_TASK_QUEUE}.save_packet")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_auto_refreshes_stale_lane(
+        self,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_transition: MagicMock,
+        mock_snapshot: MagicMock,
+        mock_stale: MagicMock,
+        mock_refresh: MagicMock,
+        mock_sleep: MagicMock,
+        mock_nudge: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """Dispatch should auto-refresh a stale lane before dispatching."""
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test Task",
+            description="Do the thing",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool([_make_worker("author-a", "idle")])
+        mock_stale.return_value = True
+        mock_refresh.return_value = PoolAction(
+            action="refresh",
+            lane_id="author-a",
+            reason="Refreshed OK",
+            executed=True,
+        )
+        mock_nudge.return_value = PoolAction(
+            action="nudge",
+            lane_id="author-a",
+            reason="Nudge OK",
+            executed=True,
+        )
+
+        result = dispatch_to_worker("pkt1", "author-a", runtime_dir=runtime_dir)
+        assert result.executed is True
+        mock_stale.assert_called_once_with("author-a", runtime_dir)
+        mock_refresh.assert_called_once_with(
+            "author-a",
+            force=True,
+            tmux_session=DEFAULT_TMUX_SESSION,
+            runtime_dir=runtime_dir,
+        )
+        mock_sleep.assert_called_once_with(2)
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}.nudge_pane")
+    @patch(f"{_WORKER_POOL}.refresh_worker")
+    @patch(f"{_WORKER_POOL}._is_worktree_stale")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.transition_status")
+    @patch(f"{_TASK_QUEUE}.save_packet")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_skips_refresh_for_clean_lane(
+        self,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_transition: MagicMock,
+        mock_snapshot: MagicMock,
+        mock_stale: MagicMock,
+        mock_refresh: MagicMock,
+        mock_nudge: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """Dispatch should NOT refresh if the lane is not stale."""
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test Task",
+            description="Do the thing",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool([_make_worker("author-a", "idle")])
+        mock_stale.return_value = False
+        mock_nudge.return_value = PoolAction(
+            action="nudge",
+            lane_id="author-a",
+            reason="Nudge OK",
+            executed=True,
+        )
+
+        result = dispatch_to_worker("pkt1", "author-a", runtime_dir=runtime_dir)
+        assert result.executed is True
+        mock_refresh.assert_not_called()
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}.nudge_pane")
+    @patch(f"{_WORKER_POOL}.refresh_worker")
+    @patch(f"{_WORKER_POOL}._is_worktree_stale")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.transition_status")
+    @patch(f"{_TASK_QUEUE}.save_packet")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_skips_refresh_when_no_auto_refresh(
+        self,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_transition: MagicMock,
+        mock_snapshot: MagicMock,
+        mock_stale: MagicMock,
+        mock_refresh: MagicMock,
+        mock_nudge: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """no_auto_refresh=True should skip staleness check entirely."""
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test Task",
+            description="Do the thing",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool([_make_worker("author-a", "idle")])
+        mock_nudge.return_value = PoolAction(
+            action="nudge",
+            lane_id="author-a",
+            reason="Nudge OK",
+            executed=True,
+        )
+
+        result = dispatch_to_worker(
+            "pkt1", "author-a", runtime_dir=runtime_dir, no_auto_refresh=True
+        )
+        assert result.executed is True
+        mock_stale.assert_not_called()
+        mock_refresh.assert_not_called()
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}.nudge_pane")
+    @patch(f"{_WORKER_POOL}.refresh_worker")
+    @patch(f"{_WORKER_POOL}._is_worktree_stale")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.transition_status")
+    @patch(f"{_TASK_QUEUE}.save_packet")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_skips_auto_refresh_when_reset_true(
+        self,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_transition: MagicMock,
+        mock_snapshot: MagicMock,
+        mock_stale: MagicMock,
+        mock_refresh: MagicMock,
+        mock_nudge: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """When reset=True, auto-refresh should be skipped (reset handles it)."""
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test Task",
+            description="Do the thing",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool([_make_worker("author-a", "idle")])
+        mock_nudge.return_value = PoolAction(
+            action="nudge",
+            lane_id="author-a",
+            reason="Nudge OK",
+            executed=True,
+        )
+
+        with (
+            patch(f"{_WORKER_POOL}.reset_worktree") as mock_reset_wt,
+            patch(f"{_WORKER_POOL}.clear_session") as mock_clear,
+            patch("time.sleep"),
+        ):
+            mock_reset_wt.return_value = PoolAction(
+                action="reset_worktree",
+                lane_id="author-a",
+                reason="Reset OK",
+                executed=True,
+            )
+            mock_clear.return_value = PoolAction(
+                action="clear_session",
+                lane_id="author-a",
+                reason="Clear OK",
+                executed=True,
+            )
+            result = dispatch_to_worker(
+                "pkt1", "author-a", runtime_dir=runtime_dir, reset=True
+            )
+        assert result.executed is True
+        # Auto-refresh should not be called; the explicit reset handles it
+        mock_stale.assert_not_called()
+        mock_refresh.assert_not_called()
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}.nudge_pane")
+    @patch(f"{_WORKER_POOL}.refresh_worker")
+    @patch(f"{_WORKER_POOL}._is_worktree_stale")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.transition_status")
+    @patch(f"{_TASK_QUEUE}.save_packet")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_continues_if_auto_refresh_fails(
+        self,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_transition: MagicMock,
+        mock_snapshot: MagicMock,
+        mock_stale: MagicMock,
+        mock_refresh: MagicMock,
+        mock_nudge: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """Dispatch should succeed even when auto-refresh fails."""
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test Task",
+            description="Do the thing",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool([_make_worker("author-a", "idle")])
+        mock_stale.return_value = True
+        mock_refresh.return_value = PoolAction(
+            action="refresh",
+            lane_id="author-a",
+            reason="Dirty worktree",
+            executed=False,
+            error="dirty_worktree",
+        )
+        mock_nudge.return_value = PoolAction(
+            action="nudge",
+            lane_id="author-a",
+            reason="Nudge OK",
+            executed=True,
+        )
+
+        result = dispatch_to_worker("pkt1", "author-a", runtime_dir=runtime_dir)
+        # Dispatch should still succeed despite refresh failure
+        assert result.executed is True
+        mock_refresh.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _is_worktree_stale()
+# ---------------------------------------------------------------------------
+
+
+class TestIsWorktreeStale:
+    """Test _is_worktree_stale() helper."""
+
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path")
+    def test_stale_non_main_branch(
+        self,
+        mock_resolve: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Lane on a non-main branch is stale."""
+        mock_resolve.return_value = str(tmp_path)
+        with patch(f"{_WORKER_POOL}.subprocess.run") as mock_run:
+            # git rev-parse --abbrev-ref HEAD returns "fix/some-branch"
+            mock_run.return_value = MagicMock(returncode=0, stdout="fix/some-branch\n")
+            assert _is_worktree_stale("author-a") is True
+
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path")
+    def test_clean_main_branch(
+        self,
+        mock_resolve: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Lane on main with 0 commits ahead is not stale."""
+        mock_resolve.return_value = str(tmp_path)
+        with patch(f"{_WORKER_POOL}.subprocess.run") as mock_run:
+            # First call: branch = main; second call: 0 commits ahead
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="main\n"),
+                MagicMock(returncode=0, stdout="0\n"),
+            ]
+            assert _is_worktree_stale("author-a") is False
+
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path")
+    def test_main_branch_ahead(
+        self,
+        mock_resolve: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Lane on main but ahead of origin/main is stale."""
+        mock_resolve.return_value = str(tmp_path)
+        with patch(f"{_WORKER_POOL}.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="main\n"),
+                MagicMock(returncode=0, stdout="3\n"),
+            ]
+            assert _is_worktree_stale("author-a") is True
+
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path")
+    def test_unresolved_worktree_not_stale(
+        self,
+        mock_resolve: MagicMock,
+    ) -> None:
+        """Unresolvable worktree returns False (safe default)."""
+        mock_resolve.return_value = None
+        assert _is_worktree_stale("author-a") is False
+
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path")
+    def test_git_error_returns_false(
+        self,
+        mock_resolve: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Git errors return False (safe default)."""
+        mock_resolve.return_value = str(tmp_path)
+        with patch(f"{_WORKER_POOL}.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=128, stdout="")
+            assert _is_worktree_stale("author-a") is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Auto-detect stale worktrees (non-main branch or ahead of origin/main) during task dispatch and refresh them automatically
- Add `--no-refresh` CLI flag to skip auto-refresh when the caller knows the lane is clean
- 10 new tests covering all auto-refresh paths and the `_is_worktree_stale()` helper

## Why
When dispatching a new task to a lane that just finished different work, the orchestrator must manually call `lane refresh` first. This is easy to forget, leaving the lane on a stale branch with old context. Automating the staleness check eliminates this manual step.

## Changes
| File | Change |
|------|--------|
| `src/bid_euchre/ops/worker_pool.py` | Add `_is_worktree_stale()` helper, add `no_auto_refresh` param and auto-refresh logic to `dispatch_to_worker()` |
| `scripts/internal/ops.py` | Wire `--no-refresh` flag to both `task dispatch` and `workers dispatch` CLI commands |
| `tests/unit/test_ops_worker_pool.py` | Add `TestDispatchAutoRefresh` (5 tests) and `TestIsWorktreeStale` (5 tests) |

## Design decisions
- Auto-refresh is skipped when `reset=True` (the explicit reset already handles this)
- Auto-refresh failure logs a warning but does not block dispatch (the lane can handle its own cleanup)
- `_is_worktree_stale()` returns `False` on any error (safe default)
- Uses `force=True` on the auto-refresh to handle dirty worktrees gracefully (saves diff to /tmp)

## Repro / Validation
```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/test_ops_worker_pool.py -v

# Tier 2 — full validation
make check-quiet
```

## Tests
- `uv run python -m pytest tests/unit/test_ops_worker_pool.py -v` — 170 passed
- `make check-quiet` — 6335 passed, 1 unrelated flaky failure (timing test)

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: ops/dispatch-auto-refresh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)