### PR TITLE
fix: reconcile registry counts and tighten test assertions

### DIFF
--- a/plans/agent_ops/sub_plan_registry.md
+++ b/plans/agent_ops/sub_plan_registry.md
@@ -26,7 +26,7 @@
 | SP-3-08 | Monitoring cycle with session-start auto-launch | Post-Phase-3 transition: ops monitoring cycle and auto-launch | completed | orchestrator | _(no sub-plan file — single-PR scope)_ | 2026-03-23 | 2026-03-23 (PR #1277) |
 | SP-4-01 | Platform-8 scope lock | Phase 4, Platform-8 scope lock and sub-plan registration | completed | author-scratch | `plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8-scope-lock.md` | 2026-03-23 | 2026-03-23 |
 | SP-4-02 | Remote-ops preflight hardening | Phase 4, Pre-Platform-8 operational hardening | completed | orchestrator | `plans/agent_ops/4_remote_channel/sub/2026-03-23_remote-ops-preflight-hardening.md` | 2026-03-23 | 2026-03-24 (~20 PRs; all 6 steps complete, all exit criteria met) |
-| SP-4-03 | Token economy observability and dashboard | Phase 4, Pre-Platform-8 token observability | completed | orchestrator | `plans/agent_ops/4_remote_channel/sub/2026-03-23_token-economy-observability-and-dashboard.md` | 2026-03-23 | 2026-03-23 (baseline report at `plans/sessions/2026-03-23_token-economy-baseline.md`; live dashboard integration is partial — follow-up needed) |
+| SP-4-03 | Token economy observability and dashboard | Phase 4, Pre-Platform-8 token observability | completed | orchestrator | `plans/agent_ops/4_remote_channel/sub/2026-03-23_token-economy-observability-and-dashboard.md` | 2026-03-23 | 2026-03-24 (baseline report at `plans/sessions/2026-03-23_token-economy-baseline.md`; dashboard auto-import via PR #1466) |
 | SP-4-04 | Platform-8a Telegram transport configuration | Phase 4, Platform-8a transport proving | completed | flex-a | `plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8a-telegram-transport.md` | 2026-03-23 | 2026-03-24 (PRs #1436, #1451, #1452; proven end-to-end) |
 
 ## Status Summary
@@ -36,7 +36,7 @@
 | proposed | 0 |
 | in_progress | 0 |
 | blocked | 0 |
-| completed | 17 |
+| completed | 18 |
 | abandoned | 0 |
 | superseded | 1 |
 

--- a/tests/unit/hosted_play/test_app.py
+++ b/tests/unit/hosted_play/test_app.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import Engine
+from sqlalchemy.orm import Session
 from starlette.testclient import TestClient
 
 from web.ai_manager import AIManager
@@ -61,15 +63,15 @@ class TestLifespan:
         app = _make_app(tmp_path)
         with TestClient(app):
             assert hasattr(app.state, "engine")
-            assert app.state.engine is not None
+            assert isinstance(app.state.engine, Engine)
 
     def test_state_has_session_factory(self, tmp_path):
         app = _make_app(tmp_path)
         with TestClient(app):
             assert hasattr(app.state, "session_factory")
-            # Factory should be callable
+            # Factory should be callable and produce a Session
             session = app.state.session_factory()
-            assert session is not None
+            assert isinstance(session, Session)
             session.close()
 
     def test_state_has_ai_manager(self, tmp_path):


### PR DESCRIPTION
## Plan
N/A — convention follow-ups from review coordinator findings

## Summary
- Update SP-4-03 completion note to reflect dashboard auto-import (PR #1466) and remove stale "partial — follow-up needed" language
- Correct completed-plan count from 17 to 18 in registry summary
- Tighten `test_app.py` engine/session assertions to use `isinstance` checks instead of bare `is not None`

## Why
Three small convention follow-ups identified by the review coordinator on PRs #1453, #1456, and #1465. Combined into one PR since all are low-risk, non-overlapping fixes.

Closes #1457, closes #1462, closes #1470

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_app.py -v  # 10/10 passed
make check-quiet  # 6345 passed, 1 flaky timing test (unrelated)
```

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_app.py -v` — 10/10 passed
- [x] `make check-quiet` — all pass except 1 pre-existing flaky timing test (`test_script_runs_quickly` 3.51s > 2.0s)

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c
```

`git worktree list` (abbreviated):
```
Bid-Euchre-steward-flex-c  d14358a1 [fix/convention-followups-1457-1462-1470]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>