### PR TITLE
fix(web): guard against None nickname before html.escape (#1464)

### DIFF
--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -689,6 +689,15 @@ class TestXSSPrevention:
         assert "<b>bold</b>" not in resp.text
         assert "&lt;b&gt;" in resp.text
 
+    def test_new_match_none_nickname_does_not_crash(self, client):
+        """new_match() must not crash when player.nickname is None (#1464)."""
+        link_uuid = _create_game(client)
+        # Do NOT set a nickname — player.nickname remains None
+        resp = client.post(f"/play/{link_uuid}/new-match")
+        assert resp.status_code == 200
+        assert "New Match" in resp.text
+        assert "Player" in resp.text
+
 
 # ---------------------------------------------------------------------------
 # hx-post URL interpolation (issue #1439)

--- a/web/routes.py
+++ b/web/routes.py
@@ -572,6 +572,7 @@ async def new_match(
             raise HTTPException(status_code=404, detail="Game not found")
 
         # Return model selection form
+        safe_nick = html.escape(player.nickname or "Player")
         ai_manager = _get_ai_manager(request)
         models = ai_manager.list_available()
         options = "".join(
@@ -579,7 +580,7 @@ async def new_match(
             for m in models
         )
         return HTMLResponse(
-            f"<h2>New Match — {html.escape(player.nickname)}</h2>"
+            f"<h2>New Match — {safe_nick}</h2>"
             f'<form method="post" action="/play/{link_uuid}/select-ai">'
             f'<select name="model_id">{options}</select>'
             '<button type="submit">Start Match</button>'


### PR DESCRIPTION
## Summary

- Guard against `None` nickname in `new_match()` endpoint before calling `html.escape()`, defaulting to `"Player"` when nickname is unset
- Add test covering the `None` nickname case to prevent regression

## Why

Convention follow-up from PR #1458 (issue #1464). The `new_match` endpoint at `web/routes.py:582` calls `html.escape(player.nickname)` without checking for `None`, which would crash with `TypeError` if a player somehow reaches the new-match endpoint without having set a nickname.

## Repro / Validation

```bash
uv run python -m pytest tests/unit/hosted_play/test_routes.py -v
# 22 passed
```

## Tests

- `uv run python -m pytest tests/unit/hosted_play/test_routes.py -v` — 22/22 passed
- `uv run ruff check web/routes.py tests/unit/hosted_play/test_routes.py` — clean
- `uv run ruff format --check web/routes.py tests/unit/hosted_play/test_routes.py` — clean
- `make repo-lint` — passed

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: fix/nickname-guard-html-escape
```

Closes #1464

🤖 Generated with [Claude Code](https://claude.com/claude-code)