### PR TITLE
browser-game: fix AI decision logging with exact action events

### DIFF
--- a/src/bid_euchre/hosted_play/__init__.py
+++ b/src/bid_euchre/hosted_play/__init__.py
@@ -8,10 +8,11 @@ This package is web-framework-free.  The ``web/`` application layer imports
 from here; this package must never import from ``web/``.
 """
 
-from .engine import HUMAN_SEAT, MATCH_TARGET, MatchEngine
+from .engine import HUMAN_SEAT, MATCH_TARGET, AIActionEvent, MatchEngine
 from .state import HandState, MatchState, TrickResult, TrickState
 
 __all__ = [
+    "AIActionEvent",
     "HUMAN_SEAT",
     "MATCH_TARGET",
     "HandState",

--- a/src/bid_euchre/hosted_play/engine.py
+++ b/src/bid_euchre/hosted_play/engine.py
@@ -7,6 +7,7 @@ turns.  Delegates **all** rule evaluation to existing ``core/``, ``sim/``,
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from bid_euchre.core.rules import get_legal_indices, trick_winner
@@ -34,6 +35,47 @@ def _bid_order(dealer_seat: int) -> list[int]:
     return [(dealer_seat + i + 1) % _NUM_PLAYERS for i in range(_NUM_PLAYERS)]
 
 
+@dataclass
+class AIActionEvent:
+    """Exact data captured from a single AI decision during auto-advance.
+
+    Populated by ``_advance_ai()`` so that callers (route handlers) can log
+    deterministic-replay-grade decision rows without approximation.
+    """
+
+    turn_number: int
+    seat: int
+    phase: str  # "bid" or "play"
+    legal_actions: Any  # list[dict] for bids, list[int] for plays
+    chosen_action: Any  # dict for bids, int for plays
+    game_state: dict[str, Any]
+
+
+def _build_game_snapshot(hand: Any, seat: int) -> dict[str, Any]:
+    """Build a game-state snapshot dict for decision logging."""
+    snapshot: dict[str, Any] = {
+        "phase": hand.phase,
+        "seat": seat,
+        "turn_number": hand.turn_number,
+        "dealer_seat": hand.dealer_seat,
+        "current_high_bid": hand.current_high_bid,
+        "auction": list(hand.auction),
+        "contract_type": hand.contract_type,
+        "trump": hand.trump,
+        "tricks_team0": hand.tricks_team0,
+        "tricks_team1": hand.tricks_team1,
+        "hand_size": len(hand.hands[seat]),
+    }
+    if hand.current_trick is not None:
+        snapshot["current_trick"] = {
+            "leader": hand.current_trick.leader,
+            "plays": [
+                [s, [card.suit, card.rank]] for s, card in hand.current_trick.plays
+            ],
+        }
+    return snapshot
+
+
 # ---------------------------------------------------------------------------
 # MatchEngine
 # ---------------------------------------------------------------------------
@@ -54,6 +96,7 @@ class MatchEngine:
     ) -> None:
         self.bidding_policy = bidding_policy
         self.play_strategy = play_strategy
+        self.last_ai_events: list[AIActionEvent] = []
 
     # ------------------------------------------------------------------
     # Public API
@@ -61,6 +104,7 @@ class MatchEngine:
 
     def start_match(self, seed: int, ai_model: str) -> MatchState:
         """Create a new match, deal the first hand, and advance AI."""
+        self.last_ai_events = []
         state = MatchState(seed=seed, ai_model=ai_model)
         state = self._deal_new_hand(state)
         state = self._advance_ai(state)
@@ -68,6 +112,7 @@ class MatchEngine:
 
     def submit_human_bid(self, state: MatchState, bid: BidAction) -> MatchState:
         """Process the human's bid, then auto-advance AI."""
+        self.last_ai_events = []
         hand = state.current_hand
         assert hand is not None
         assert hand.phase == "auction"
@@ -79,6 +124,7 @@ class MatchEngine:
 
     def submit_human_card(self, state: MatchState, card_index: int) -> MatchState:
         """Process the human's card play, then auto-advance AI."""
+        self.last_ai_events = []
         hand = state.current_hand
         assert hand is not None
         assert hand.phase == "trick_play"
@@ -194,7 +240,11 @@ class MatchEngine:
     # ------------------------------------------------------------------
 
     def _advance_ai(self, state: MatchState) -> MatchState:
-        """Auto-play all AI turns until the human's turn or hand/match end."""
+        """Auto-play all AI turns until the human's turn or hand/match end.
+
+        Populates ``self.last_ai_events`` with exact decision data for every
+        AI action taken during this advance cycle.
+        """
         while True:
             # Match finished — nothing to advance
             if state.status == "complete":
@@ -223,6 +273,22 @@ class MatchEngine:
                     auction_transcript=tuple(hand.auction),
                 )
                 bid = self.bidding_policy.choose_bid(obs)
+
+                # Capture exact event data before the bid modifies state
+                legal_bids = self.get_legal_bids(state)
+                self.last_ai_events.append(
+                    AIActionEvent(
+                        turn_number=hand.turn_number,
+                        seat=seat,
+                        phase="bid",
+                        legal_actions=[
+                            {"n": b.n, "contract": b.contract} for b in legal_bids
+                        ],
+                        chosen_action={"n": bid.n, "contract": bid.contract},
+                        game_state=_build_game_snapshot(hand, seat),
+                    )
+                )
+
                 state = self._process_bid(state, seat, bid)
 
             elif hand.phase == "trick_play":
@@ -236,6 +302,25 @@ class MatchEngine:
                     hand.trump,
                     seat,
                 )
+
+                # Capture exact event data before the play modifies state
+                legal_indices = get_legal_indices(
+                    hand.hands[seat],
+                    hand.current_trick.plays,
+                    hand.contract_type,
+                    hand.trump,
+                )
+                self.last_ai_events.append(
+                    AIActionEvent(
+                        turn_number=hand.turn_number,
+                        seat=seat,
+                        phase="play",
+                        legal_actions=legal_indices,
+                        chosen_action=card_idx,
+                        game_state=_build_game_snapshot(hand, seat),
+                    )
+                )
+
                 state = self._process_card_play(state, seat, card_idx)
             else:
                 # Unexpected phase — bail to avoid infinite loop

--- a/tests/unit/hosted_play/test_engine.py
+++ b/tests/unit/hosted_play/test_engine.py
@@ -676,6 +676,128 @@ class TestBidOrder:
         assert _bid_order(3) == [0, 1, 2, 3]
 
 
+class TestAIActionEvents:
+    """Verify engine emits exact AI action events during auto-advance."""
+
+    def test_start_match_emits_bid_events(self, engine: MatchEngine) -> None:
+        """start_match() emits events for AI bids in the first auction."""
+        state = engine.start_match(SEED, "heuristic")
+        hand = state.current_hand
+        assert hand is not None
+
+        # Engine should have captured AI bid events during start_match
+        events = engine.last_ai_events
+        assert len(events) > 0, "Expected at least one AI event from start_match"
+
+        for event in events:
+            assert event.seat != HUMAN_SEAT, "AI events should not be for human seat"
+            assert event.phase == "bid"
+            assert isinstance(event.legal_actions, list)
+            assert len(event.legal_actions) > 0, "legal_actions must not be empty"
+            assert isinstance(event.chosen_action, dict)
+            assert "n" in event.chosen_action
+            assert "contract" in event.chosen_action
+            assert isinstance(event.game_state, dict)
+            assert event.game_state["phase"] == "auction"
+
+    def test_submit_human_bid_emits_events(self, engine: MatchEngine) -> None:
+        """submit_human_bid() emits events for subsequent AI bids."""
+        state = engine.start_match(SEED, "heuristic")
+        hand = state.current_hand
+        assert hand is not None
+
+        if hand.phase != "auction" or hand.current_seat != HUMAN_SEAT:
+            pytest.skip("Human not in auction position after start")
+
+        # Human passes
+        state = engine.submit_human_bid(state, BidAction.pass_bid())
+
+        # Events should be fresh (only from this submit call)
+        for event in engine.last_ai_events:
+            assert event.seat != HUMAN_SEAT
+            assert len(event.legal_actions) > 0
+
+    def test_submit_human_card_emits_play_events(self, engine: MatchEngine) -> None:
+        """submit_human_card() emits events for subsequent AI plays."""
+        state = engine.start_match(SEED, "heuristic")
+        hand = state.current_hand
+        assert hand is not None
+
+        # Get to trick play
+        while hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+            if 5 > hand.current_high_bid:
+                state = engine.submit_human_bid(state, BidAction.bid(5, "S"))
+            else:
+                state = engine.submit_human_bid(state, BidAction.pass_bid())
+            hand = state.current_hand
+            if hand is None:
+                pytest.skip("Match ended during auction")
+
+        if hand.phase != "trick_play" or hand.current_seat != HUMAN_SEAT:
+            pytest.skip("Human not in trick play position")
+
+        legal = engine.get_legal_plays(state)
+        state = engine.submit_human_card(state, legal[0])
+
+        # Should have AI play events
+        play_events = [e for e in engine.last_ai_events if e.phase == "play"]
+        if len(play_events) > 0:
+            for event in play_events:
+                assert event.seat != HUMAN_SEAT
+                assert isinstance(event.legal_actions, list)
+                assert len(event.legal_actions) > 0
+                assert isinstance(event.chosen_action, int)
+                assert event.game_state["phase"] == "trick_play"
+
+    def test_events_cleared_between_calls(self, engine: MatchEngine) -> None:
+        """Each public method resets last_ai_events."""
+        state = engine.start_match(SEED, "heuristic")
+        events_from_start = list(engine.last_ai_events)
+        assert len(events_from_start) > 0
+
+        hand = state.current_hand
+        assert hand is not None
+        if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+            state = engine.submit_human_bid(state, BidAction.pass_bid())
+            # Events should be fresh, not accumulated from start_match
+            assert engine.last_ai_events != events_from_start
+
+    def test_event_seat_is_exact(self, engine: MatchEngine) -> None:
+        """Event seat matches the actual AI seat that acted."""
+        engine.start_match(SEED, "heuristic")
+        events = engine.last_ai_events
+
+        for event in events:
+            assert 0 <= event.seat < 4
+            assert event.seat != HUMAN_SEAT
+            # Seat must be one of the AI seats
+            assert event.seat in (1, 2, 3)
+
+    def test_event_game_state_has_required_fields(self, engine: MatchEngine) -> None:
+        """Event game_state contains context fields for replay."""
+        engine.start_match(SEED, "heuristic")
+        events = engine.last_ai_events
+        assert len(events) > 0
+
+        required_fields = {
+            "phase",
+            "seat",
+            "turn_number",
+            "dealer_seat",
+            "current_high_bid",
+            "auction",
+            "contract_type",
+            "trump",
+            "tricks_team0",
+            "tricks_team1",
+            "hand_size",
+        }
+        for event in events:
+            assert required_fields.issubset(
+                event.game_state.keys()
+            ), f"Missing fields: {required_fields - event.game_state.keys()}"
+
+
 class TestMatchDeterminism:
     """Same seed + config = identical results."""
 

--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -852,3 +852,154 @@ class TestHxPostUrl:
         # literal placeholder "{link_uuid}"
         assert f'hx-post="/play/{link_uuid}/nickname"' in resp.text
         assert "{link_uuid}" not in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Test: AI decision content quality
+# ---------------------------------------------------------------------------
+
+
+class TestAIDecisionContent:
+    """Verify AI decision rows have non-empty legal_actions and chosen_action.
+
+    Regression test for the P1 finding: AI decision rows must contain exact
+    legal_actions, chosen_action, and game_state — not empty placeholders.
+    """
+
+    def test_ai_bid_decisions_have_content(self, client, app):
+        """After a bid route, AI bid decision rows have non-empty fields."""
+        link_uuid = _setup_game(client)
+
+        # Play a few auction turns to generate AI bid decisions
+        for _ in range(10):
+            result = _get_match_state(app, link_uuid)
+            assert result is not None
+            state, _, session = result
+            session.close()
+
+            hand = state.current_hand
+            if hand is None:
+                break
+
+            if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+                client.post(
+                    f"/play/{link_uuid}/bid",
+                    data={
+                        "turn_number": hand.turn_number,
+                        "bid_n": 0,
+                        "bid_contract": "",
+                    },
+                )
+                break  # One bid is enough to trigger AI auto-advance
+            else:
+                break
+
+        # Query AI decision rows
+        session = app.state.session_factory()
+        ai_decisions = session.query(Decision).filter(Decision.actor_type == "ai").all()
+
+        assert len(ai_decisions) > 0, "Expected at least one AI decision row"
+
+        for d in ai_decisions:
+            legal = json.loads(d.legal_actions_json)
+            chosen = json.loads(d.chosen_action_json)
+            game_st = json.loads(d.game_state_json)
+
+            assert (
+                legal != []
+            ), f"AI decision turn={d.turn_number} has empty legal_actions"
+            assert (
+                chosen != {}
+            ), f"AI decision turn={d.turn_number} has empty chosen_action"
+            assert (
+                game_st != {}
+            ), f"AI decision turn={d.turn_number} has empty game_state"
+
+            # Verify legal_actions structure for bid phase
+            if d.phase == "bid":
+                assert isinstance(legal, list)
+                assert all("n" in b and "contract" in b for b in legal)
+                assert "n" in chosen
+                assert "contract" in chosen
+
+            # Verify game_state has required context fields
+            assert "phase" in game_st
+            assert "seat" in game_st
+            assert "turn_number" in game_st
+
+        session.close()
+
+    def test_ai_play_decisions_have_content(self, client, app):
+        """After a play-card route, AI play decision rows have non-empty fields."""
+        link_uuid = _setup_game(client)
+
+        # Navigate to trick play and play one card
+        for _ in range(20):
+            result = _get_match_state(app, link_uuid)
+            assert result is not None
+            state, _, session = result
+            session.close()
+
+            hand = state.current_hand
+            if hand is None:
+                break
+
+            if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+                client.post(
+                    f"/play/{link_uuid}/bid",
+                    data={
+                        "turn_number": hand.turn_number,
+                        "bid_n": 0,
+                        "bid_contract": "",
+                    },
+                )
+            elif hand.phase == "trick_play" and hand.current_seat == HUMAN_SEAT:
+                ai_manager = app.state.ai_manager
+                info = ai_manager.get_model_info(state.ai_model)
+                engine = MatchEngine(
+                    bidding_policy=info.bidding_policy,
+                    play_strategy=info.play_strategy,
+                )
+                legal = engine.get_legal_plays(state)
+                client.post(
+                    f"/play/{link_uuid}/play-card",
+                    data={
+                        "turn_number": hand.turn_number,
+                        "card_index": legal[0],
+                    },
+                )
+                break
+            else:
+                break
+
+        # Query AI play decision rows
+        session = app.state.session_factory()
+        ai_play_decisions = (
+            session.query(Decision)
+            .filter(Decision.actor_type == "ai", Decision.phase == "play")
+            .all()
+        )
+
+        if len(ai_play_decisions) == 0:
+            session.close()
+            pytest.skip("No AI play decisions generated in this game state")
+
+        for d in ai_play_decisions:
+            legal = json.loads(d.legal_actions_json)
+            chosen = json.loads(d.chosen_action_json)
+            game_st = json.loads(d.game_state_json)
+
+            assert (
+                legal != []
+            ), f"AI play decision turn={d.turn_number} has empty legal_actions"
+            assert isinstance(legal, list)
+            assert all(isinstance(idx, int) for idx in legal)
+            assert isinstance(
+                chosen, int
+            ), f"AI play chosen_action should be int, got {type(chosen)}"
+            assert (
+                game_st != {}
+            ), f"AI play decision turn={d.turn_number} has empty game_state"
+            assert game_st.get("phase") == "trick_play"
+
+        session.close()

--- a/web/routes.py
+++ b/web/routes.py
@@ -428,17 +428,15 @@ async def submit_bid(
         )
 
         # Apply action — engine auto-advances AI
-        prev_turn = hand.turn_number
         state = engine.submit_human_bid(state, bid)
 
-        # Log AI decisions that occurred during auto-advance
+        # Log AI decisions captured during auto-advance
         _log_ai_decisions_after_advance(
             session,
             match_row,
             hand_row,
+            engine,
             state,
-            prev_turn,
-            "bid",
         )
 
         # Update hand row if hand completed or redealt
@@ -539,17 +537,15 @@ async def submit_card(
         )
 
         # Apply action — engine auto-advances AI
-        prev_turn = hand.turn_number
         state = engine.submit_human_card(state, card_index)
 
-        # Log AI decisions that occurred during auto-advance
+        # Log AI decisions captured during auto-advance
         _log_ai_decisions_after_advance(
             session,
             match_row,
             hand_row,
+            engine,
             state,
-            prev_turn,
-            "play",
         )
 
         # Update hand row if hand completed (redeals cannot occur during
@@ -613,45 +609,28 @@ def _log_ai_decisions_after_advance(
     session,
     match_row: Match,
     hand_row: Hand,
+    engine: MatchEngine,
     state,
-    prev_turn: int,
-    calling_phase: str,
 ) -> None:
-    """Log AI decisions that occurred between prev_turn and current turn.
+    """Log AI decisions captured during the engine's last auto-advance.
 
-    After the engine auto-advances AI turns, we know AI acted for every
-    turn_number between ``prev_turn + 1`` and the current turn_number.
-
-    *calling_phase* is ``"bid"`` or ``"play"`` (matching the DB constraint)
-    and is passed from the calling route handler.
-
-    Note: The engine doesn't expose per-step callbacks, so legal actions
-    and game states for intermediate AI turns are recorded as empty
-    placeholders.  This is a known V1 limitation.
+    Uses the exact per-turn action events emitted by ``MatchEngine._advance_ai``
+    (via ``engine.last_ai_events``) so that every AI decision row has the actual
+    seat, legal_actions, chosen_action, and game_state snapshot.
     """
-    current_hand = state.current_hand
-    if current_hand is None:
-        return
-
-    current_turn = current_hand.turn_number
     ai_model = state.ai_model
 
-    for t in range(prev_turn + 1, current_turn):
-        # Simplified seat calculation — approximation for V1
-        seat = (HUMAN_SEAT + 1 + (t - prev_turn - 1)) % 4
-        if seat == HUMAN_SEAT:
-            continue  # Skip — human turns are logged separately
-
+    for event in engine.last_ai_events:
         _log_decision(
             session,
             match_row,
             hand_row,
-            turn_number=t,
-            seat=seat,
-            phase=calling_phase,
+            turn_number=event.turn_number,
+            seat=event.seat,
+            phase=event.phase,
             actor_type="ai",
             decision_source=ai_model,
-            legal_actions=[],
-            chosen_action={},
-            game_state={},
+            legal_actions=event.legal_actions,
+            chosen_action=event.chosen_action,
+            game_state=event.game_state,
         )


### PR DESCRIPTION
## Summary
- Add `AIActionEvent` dataclass and event capture to `MatchEngine._advance_ai()` so every AI decision during auto-advance records exact seat, legal_actions, chosen_action, and game_state snapshot
- Update `_log_ai_decisions_after_advance()` in routes.py to consume engine events instead of approximating them after the fact
- Add 8 regression tests (6 engine-level, 2 route-level) verifying AI decision rows have non-empty, structurally correct data

## Why
P1 finding: AI decision rows logged empty `legal_actions=[]`, `chosen_action={}`, `game_state={}`, and used an approximated seat calculation. This data was not deterministic-replay grade and was unusable for training export. The fix captures exact decision data at the point of each AI action.

## Repro / Validation
```bash
# Tier 1 — targeted tests (all 146 pass)
uv run python -m pytest tests/unit/hosted_play/ -v

# Tier 2 — full validation (6327 passed, 1 pre-existing flaky timing test)
make check-quiet

# Repo linter
make repo-lint
```

## Tests
- `tests/unit/hosted_play/test_engine.py::TestAIActionEvents` — 6 new tests verifying event capture (non-empty legal_actions, exact seats, game_state fields, event clearing between calls)
- `tests/unit/hosted_play/test_routes.py::TestAIDecisionContent` — 2 new tests verifying DB decision rows have non-empty legal_actions, chosen_action, and game_state after bid and play routes

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
branch: browser-game/fix-ai-decision-logging
```

## Files changed
| File | Change |
|------|--------|
| `src/bid_euchre/hosted_play/engine.py` | Add `AIActionEvent`, `_build_game_snapshot()`, event capture in `_advance_ai()` |
| `src/bid_euchre/hosted_play/__init__.py` | Export `AIActionEvent` |
| `web/routes.py` | Rewrite `_log_ai_decisions_after_advance()` to consume engine events |
| `tests/unit/hosted_play/test_engine.py` | 6 new event tests |
| `tests/unit/hosted_play/test_routes.py` | 2 new decision content tests |

🤖 Generated with [Claude Code](https://claude.com/claude-code)