### PR TITLE
fix(ops): reduce message bus noise with dedup, multi-type filter, and short TTL

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -1913,8 +1913,14 @@ def cmd_inbox(args: argparse.Namespace) -> int:
     # Default: list messages
     lane = getattr(args, "lane", None)
     status_filter = getattr(args, "status", None)
-    type_filter = getattr(args, "type", None)
+    raw_type = getattr(args, "type", None)
     thread_filter = getattr(args, "thread", None)
+
+    # Support comma-separated type filters (e.g. --type completion,escalation)
+    type_filter: str | list[str] | None = None
+    if raw_type is not None:
+        parts = [t.strip() for t in raw_type.split(",") if t.strip()]
+        type_filter = parts[0] if len(parts) == 1 else parts
 
     if lane is None:
         # Show aggregate stats across all lanes
@@ -3208,7 +3214,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--lane", default=None, help="Show inbox for a specific lane"
     )
     inbox_parser.add_argument("--status", default=None, help="Filter by message status")
-    inbox_parser.add_argument("--type", default=None, help="Filter by message type")
+    inbox_parser.add_argument(
+        "--type",
+        default=None,
+        help="Filter by message type (comma-separated for multiple, e.g. completion,escalation)",
+    )
     inbox_parser.add_argument("--thread", default=None, help="Filter by thread ID")
     inbox_parser.add_argument(
         "--include-native",

--- a/src/bid_euchre/ops/message_bus.py
+++ b/src/bid_euchre/ops/message_bus.py
@@ -35,7 +35,7 @@ import os
 import subprocess
 import time
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -431,7 +431,7 @@ def read_inbox(
     *,
     status: str | None = None,
     thread_id: str | None = None,
-    message_type: str | None = None,
+    message_type: str | Sequence[str] | None = None,
     limit: int = 50,
     auto_expire: bool = True,
     now: float | None = None,
@@ -446,6 +446,8 @@ def read_inbox(
     to ``expired`` before filtering.
 
     Args:
+        message_type: Filter by message type.  Accepts a single type string,
+            a sequence of type strings (matches any), or ``None`` (no filter).
         now: Override for current time as Unix timestamp (for testing).
             Passed through to ``_expire_stale_on_read()``.
     """
@@ -463,6 +465,14 @@ def read_inbox(
     if auto_expire:
         _expire_stale_on_read(by_id, lane_id, root, now=now)
 
+    # Normalise message_type filter to a frozenset for O(1) lookups
+    type_filter: frozenset[str] | None = None
+    if message_type is not None:
+        if isinstance(message_type, str):
+            type_filter = frozenset({message_type})
+        else:
+            type_filter = frozenset(message_type)
+
     # Apply filters
     from collections import deque
 
@@ -472,7 +482,7 @@ def read_inbox(
             continue
         if thread_id is not None and rec.get("thread_id") != thread_id:
             continue
-        if message_type is not None and rec.get("message_type") != message_type:
+        if type_filter is not None and rec.get("message_type") not in type_filter:
             continue
         matched.append(rec)
 
@@ -505,29 +515,58 @@ def query_unresolved(
 # ---------------------------------------------------------------------------
 
 
+def _content_dedup_key(msg: BusMessage) -> tuple[str, str, str, str]:
+    """Return a content-based dedup key for a message.
+
+    Two messages are considered content-duplicates when they share the same
+    ``(to_lane, from_lane, message_type, summary)`` tuple.  This prevents
+    repeated verdict notifications, test artifacts, and other noise from
+    accumulating in the recipient's inbox.
+    """
+    return (msg.to_lane, msg.from_lane, msg.message_type, msg.summary)
+
+
 def send_message(
     msg: BusMessage,
     bus_root: Path | None = None,
     *,
     events_dir: Path | None = None,
+    deduplicate: bool = False,
 ) -> str:
     """Send a message: write to audit trail + recipient inbox, emit event.
 
     Enforces duplicate suppression: if a message with the same message_id
     already exists in the audit trail, the send is rejected.
 
+    When *deduplicate* is ``True``, content-based dedup is applied: if a
+    non-terminal message with the same ``(to_lane, from_lane, message_type,
+    summary)`` already exists in the recipient's inbox, the new message is
+    silently dropped and the existing message's ID is returned.
+
     Args:
         msg: The message to send.
         bus_root: Override for bus root directory.
         events_dir: Override for events directory (for testing).
+        deduplicate: Enable content-based duplicate suppression.
 
     Returns:
-        The message_id of the sent message.
+        The message_id of the sent (or existing duplicate) message.
 
     Raises:
         ValueError: If a message with the same ID already exists.
     """
     root = shared_bus_root(bus_root)
+
+    # Content-based dedup: check recipient inbox for existing match
+    if deduplicate:
+        existing = _find_content_duplicate(msg, root)
+        if existing is not None:
+            logger.debug(
+                "Content-dedup suppressed message %s (existing: %s)",
+                msg.message_id,
+                existing,
+            )
+            return existing
 
     # Duplicate suppression: check audit trail under lock
     audit_path = root / MESSAGES_FILE
@@ -591,6 +630,38 @@ def send_message(
         msg.message_type,
     )
     return msg.message_id
+
+
+def _find_content_duplicate(msg: BusMessage, bus_root: Path) -> str | None:
+    """Check the recipient inbox for a non-terminal content-duplicate.
+
+    Returns the existing message_id if found, else ``None``.
+    """
+    raw = _read_inbox_raw(msg.to_lane, bus_root)
+
+    # Deduplicate: latest record per message_id
+    by_id: dict[str, dict[str, Any]] = {}
+    for rec in raw:
+        mid = rec.get("message_id")
+        if mid:
+            by_id[mid] = rec
+
+    terminal = {"resolved", "expired", "dead_lettered"}
+    key = _content_dedup_key(msg)
+
+    for mid, rec in by_id.items():
+        if rec.get("status") in terminal:
+            continue
+        existing_key = (
+            rec.get("to_lane", ""),
+            rec.get("from_lane", ""),
+            rec.get("message_type", ""),
+            rec.get("summary", ""),
+        )
+        if existing_key == key:
+            return mid
+
+    return None
 
 
 def _update_inbox_status(

--- a/src/bid_euchre/ops/review_queue.py
+++ b/src/bid_euchre/ops/review_queue.py
@@ -419,9 +419,10 @@ def _emit_verdict_bus_message(
                 "verdict_status": verdict.status,
                 "n_findings": len(verdict.findings),
                 "reason": verdict.reason,
+                "ttl_seconds": 3600,  # 1h — verdicts are ephemeral signals
             },
         )
-        send_message(msg, bus_root=root)
+        send_message(msg, bus_root=root, deduplicate=True)
         logger.info(
             "Bus message sent to orchestrator: PR #%d verdict=%s",
             verdict.pr_number,

--- a/tests/unit/test_ops_message_bus.py
+++ b/tests/unit/test_ops_message_bus.py
@@ -24,6 +24,8 @@ from bid_euchre.ops.message_bus import (
     VALID_MESSAGE_TRANSITIONS,
     VALID_MESSAGE_TYPES,
     BusMessage,
+    _content_dedup_key,
+    _find_content_duplicate,
     _native_content_hash,
     ack_message,
     append_message,
@@ -1620,3 +1622,147 @@ class TestCompactInbox:
         inbox = read_inbox("author-a", bus_root)
         assert len(inbox) == 1
         assert inbox[0]["summary"] == "Active"
+
+
+# ---------------------------------------------------------------------------
+# Multi-type inbox filter
+# ---------------------------------------------------------------------------
+
+
+class TestMultiTypeInboxFilter:
+    """Test read_inbox with multi-type message_type filter."""
+
+    def test_single_type_string_still_works(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Backward compat: single string filter still matches."""
+        msg_a = create_message("a", "b", "assignment", "A")
+        msg_b = create_message("a", "b", "completion", "B")
+        send_message(msg_a, bus_root, events_dir=events_dir)
+        send_message(msg_b, bus_root, events_dir=events_dir)
+
+        result = read_inbox("b", bus_root, message_type="completion")
+        assert len(result) == 1
+        assert result[0]["summary"] == "B"
+
+    def test_multi_type_list_matches_any(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """A list of types matches messages of any listed type."""
+        msg_a = create_message("a", "b", "assignment", "A")
+        msg_b = create_message("a", "b", "completion", "B")
+        msg_c = create_message("a", "b", "blocker", "C")
+        for m in (msg_a, msg_b, msg_c):
+            send_message(m, bus_root, events_dir=events_dir)
+
+        result = read_inbox("b", bus_root, message_type=["completion", "blocker"])
+        assert len(result) == 2
+        summaries = {r["summary"] for r in result}
+        assert summaries == {"B", "C"}
+
+    def test_multi_type_no_match_returns_empty(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Multi-type filter returns empty when no types match."""
+        msg = create_message("a", "b", "assignment", "A")
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        result = read_inbox("b", bus_root, message_type=["completion", "blocker"])
+        assert result == []
+
+    def test_none_type_returns_all(self, bus_root: Path, events_dir: Path) -> None:
+        """message_type=None returns all messages (no filter)."""
+        msg_a = create_message("a", "b", "assignment", "A")
+        msg_b = create_message("a", "b", "completion", "B")
+        send_message(msg_a, bus_root, events_dir=events_dir)
+        send_message(msg_b, bus_root, events_dir=events_dir)
+
+        result = read_inbox("b", bus_root, message_type=None)
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# Content-based dedup
+# ---------------------------------------------------------------------------
+
+
+class TestContentDedup:
+    """Test content-based duplicate suppression in send_message."""
+
+    def test_dedup_key_deterministic(self) -> None:
+        """Same message fields produce the same dedup key."""
+        msg1 = create_message("review", "orchestrator", "progress", "Verdict X")
+        msg2 = create_message("review", "orchestrator", "progress", "Verdict X")
+        assert _content_dedup_key(msg1) == _content_dedup_key(msg2)
+
+    def test_dedup_key_differs_on_summary(self) -> None:
+        """Different summaries produce different dedup keys."""
+        msg1 = create_message("review", "orchestrator", "progress", "Verdict A")
+        msg2 = create_message("review", "orchestrator", "progress", "Verdict B")
+        assert _content_dedup_key(msg1) != _content_dedup_key(msg2)
+
+    def test_dedup_suppresses_duplicate_send(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Second send with deduplicate=True returns existing ID, no new message."""
+        msg1 = create_message("review", "orchestrator", "progress", "Verdict PR #42")
+        send_message(msg1, bus_root, events_dir=events_dir)
+
+        msg2 = create_message("review", "orchestrator", "progress", "Verdict PR #42")
+        result_id = send_message(
+            msg2, bus_root, events_dir=events_dir, deduplicate=True
+        )
+
+        assert result_id == msg1.message_id
+        inbox = read_inbox("orchestrator", bus_root)
+        assert len(inbox) == 1
+
+    def test_dedup_false_allows_duplicates(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """With deduplicate=False (default), duplicates are sent normally."""
+        msg1 = create_message("review", "orchestrator", "progress", "Verdict PR #42")
+        send_message(msg1, bus_root, events_dir=events_dir)
+
+        msg2 = create_message("review", "orchestrator", "progress", "Verdict PR #42")
+        result_id = send_message(
+            msg2, bus_root, events_dir=events_dir, deduplicate=False
+        )
+
+        assert result_id == msg2.message_id
+        inbox = read_inbox("orchestrator", bus_root)
+        assert len(inbox) == 2
+
+    def test_dedup_allows_after_terminal(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """After resolving the original, a new content-duplicate can be sent."""
+        msg1 = create_message("review", "orchestrator", "progress", "Verdict PR #42")
+        send_message(msg1, bus_root, events_dir=events_dir)
+        ack_message(msg1.message_id, "orchestrator", bus_root, events_dir=events_dir)
+        resolve_message(
+            msg1.message_id, "orchestrator", bus_root, events_dir=events_dir
+        )
+
+        msg2 = create_message("review", "orchestrator", "progress", "Verdict PR #42")
+        result_id = send_message(
+            msg2, bus_root, events_dir=events_dir, deduplicate=True
+        )
+
+        # New message sent because old one is resolved (terminal)
+        assert result_id == msg2.message_id
+
+    def test_find_content_duplicate_returns_none_on_empty(self, bus_root: Path) -> None:
+        """No duplicate found in empty inbox."""
+        msg = create_message("review", "orchestrator", "progress", "Test")
+        assert _find_content_duplicate(msg, bus_root) is None
+
+    def test_find_content_duplicate_ignores_different_summary(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Messages with different summaries are not duplicates."""
+        msg1 = create_message("review", "orchestrator", "progress", "Verdict A")
+        send_message(msg1, bus_root, events_dir=events_dir)
+
+        msg2 = create_message("review", "orchestrator", "progress", "Verdict B")
+        assert _find_content_duplicate(msg2, bus_root) is None


### PR DESCRIPTION
## Summary

- Add content-based dedup to `send_message()` via `deduplicate=True` — suppresses duplicate messages with the same `(to, from, type, summary)` tuple
- Support multi-type filtering in `read_inbox()` (`str | Sequence[str]`)
- Support comma-separated `--type` in CLI (e.g. `--type completion,escalation`) so the orchestrator can read only actionable messages
- Set 1h TTL on review verdict bus messages (was 24h default) to auto-expire ephemeral notifications
- Enable dedup on review verdict notifications to prevent spam accumulation

## Why

Issue #1463: Message bus accumulates massive noise — hundreds of duplicate review verdict messages, stale test artifacts, and 223+ unacked messages at session start. This PR tackles the root causes: repeated identical messages, overly long TTLs on ephemeral signals, and no way to filter by multiple types at once.

Closes #1463

## Scope Pressure

`review_queue.py` is slightly outside the declared scope (`message_bus.py` + `ops.py`) but the change is a one-line TTL override in the same `ops/` package — directly required to reduce verdict spam.

## Repro / Validation

```bash
# Multi-type filter
uv run python scripts/internal/ops.py inbox --lane orchestrator --type completion,escalation

# Run all impacted tests
uv run python -m pytest tests/unit/test_ops_message_bus.py tests/unit/test_ops_reviews.py tests/unit/test_ops_cli.py -v
```

## Tests

- `uv run python -m pytest tests/unit/test_ops_message_bus.py` — 106 passed (11 new)
- `uv run python -m pytest tests/unit/test_ops_reviews.py` — 119 passed
- `uv run python -m pytest tests/unit/test_ops_cli.py` — 130 passed
- `make lint` — clean

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
branch: fix/message-bus-noise-1463
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)