### PR TITLE
ops: add actionable lifecycle checks to monitor

### DIFF
--- a/src/bid_euchre/ops/monitor.py
+++ b/src/bid_euchre/ops/monitor.py
@@ -247,6 +247,27 @@ def check_open_prs() -> list[MonitorFinding]:
                 )
             )
 
+        # Check for all-green CI (PR ready for merge)
+        all_complete = checks and all(
+            c.get("conclusion") == "SUCCESS" or c.get("status") == "COMPLETED"
+            for c in checks
+        )
+        # Only flag as ready if there are actual checks AND none failing
+        if all_complete and not failing:
+            findings.append(
+                MonitorFinding(
+                    category="pr_ready",
+                    severity=SEVERITY_WARN,
+                    summary=(f"PR #{pr_num} CI green, ready for merge: {title}"),
+                    details={
+                        "pr": pr_num,
+                        "title": title,
+                        "branch": pr.get("headRefName"),
+                        "checks_passed": len(checks),
+                    },
+                )
+            )
+
     # Summary
     findings.append(
         MonitorFinding(
@@ -337,6 +358,172 @@ def check_stale_dispatches(
                     },
                 )
             )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Idle lane detection
+# ---------------------------------------------------------------------------
+
+
+def check_idle_lanes(
+    runtime_dir: Path | None = None,
+) -> list[MonitorFinding]:
+    """Detect lanes that are idle and available for dispatch.
+
+    A lane is considered idle when it has ``pool_status == "idle"`` or has
+    no current task assigned.  These lanes are immediately available for
+    new work and the orchestrator should be notified so it can dispatch.
+
+    Args:
+        runtime_dir: Override for the runtime directory root.
+
+    Returns:
+        List of findings for idle lanes.
+    """
+    findings: list[MonitorFinding] = []
+
+    try:
+        from bid_euchre.ops.worker_pool import take_pool_snapshot
+
+        pool = take_pool_snapshot(runtime_dir)
+    except Exception as exc:
+        findings.append(
+            MonitorFinding(
+                category="lane_idle",
+                severity=SEVERITY_WARN,
+                summary=f"Could not check for idle lanes: {exc}",
+            )
+        )
+        return findings
+
+    idle_lanes: list[str] = []
+    for worker in pool.workers:
+        if worker.pool_status == "idle" and worker.tmux_alive:
+            idle_lanes.append(worker.lane_id)
+
+    if idle_lanes:
+        for lane_id in idle_lanes:
+            findings.append(
+                MonitorFinding(
+                    category="lane_idle",
+                    severity=SEVERITY_INFO,
+                    summary=f"Lane {lane_id!r} idle and available for dispatch",
+                    details={"lane_id": lane_id},
+                )
+            )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Recently merged PR detection
+# ---------------------------------------------------------------------------
+
+
+def check_recently_merged_prs(
+    runtime_dir: Path | None = None,
+) -> list[MonitorFinding]:
+    """Detect PRs that have been merged recently.
+
+    Queries ``gh pr list --state merged`` and compares against a persisted
+    set of already-reported merged PR numbers.  Only new merges since the
+    last cycle produce findings.
+
+    Args:
+        runtime_dir: Override for the runtime directory root.
+
+    Returns:
+        List of findings for newly merged PRs.
+    """
+    findings: list[MonitorFinding] = []
+
+    if runtime_dir is None:
+        runtime_dir = Path(".claude/runtime")
+
+    state_path = runtime_dir / "merged_pr_state.json"
+
+    # Load previously seen merged PRs
+    try:
+        seen: set[int] = set(json.loads(state_path.read_text()).get("seen", []))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        seen = set()
+
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--state",
+                "merged",
+                "--json",
+                "number,title,headRefName,mergedAt",
+                "--limit",
+                "10",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            findings.append(
+                MonitorFinding(
+                    category="pr_merged",
+                    severity=SEVERITY_WARN,
+                    summary=f"gh pr list --state merged failed: {result.stderr[:200]}",
+                )
+            )
+            return findings
+
+        prs = json.loads(result.stdout) if result.stdout.strip() else []
+    except (
+        FileNotFoundError,
+        subprocess.TimeoutExpired,
+        OSError,
+        json.JSONDecodeError,
+    ) as exc:
+        findings.append(
+            MonitorFinding(
+                category="pr_merged",
+                severity=SEVERITY_WARN,
+                summary=f"Could not check merged PRs: {exc}",
+            )
+        )
+        return findings
+
+    new_merged_numbers: set[int] = set()
+    for pr in prs:
+        pr_num = pr.get("number")
+        if pr_num is None:
+            continue
+        new_merged_numbers.add(pr_num)
+
+        if pr_num not in seen:
+            title = pr.get("title", "?")
+            branch = pr.get("headRefName", "?")
+            findings.append(
+                MonitorFinding(
+                    category="pr_merged",
+                    severity=SEVERITY_INFO,
+                    summary=f"PR #{pr_num} merged: {title} ({branch})",
+                    details={
+                        "pr": pr_num,
+                        "title": title,
+                        "branch": branch,
+                        "merged_at": pr.get("mergedAt"),
+                    },
+                )
+            )
+
+    # Persist the current set of seen merged PRs (keep up to last 50)
+    updated_seen = sorted(seen | new_merged_numbers)[-50:]
+    try:
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(json.dumps({"seen": updated_seen}) + "\n")
+    except OSError:
+        pass  # Best-effort persistence
 
     return findings
 
@@ -1396,12 +1583,14 @@ def run_monitoring_cycle(
 
     Collects findings from:
     1. Lane pool health snapshot
-    2. Open PR status (via ``gh``)
+    2. Open PR status and CI-ready detection (via ``gh``)
     3. Stale dispatched packet detection
-    4. Stalled lane detection (acked but idle), with optional recovery
-    5. Approval-stall detection (lanes blocked on tool-approval prompts)
-    6. Auto-complete dispatched packets whose PRs were merged externally
-    7. Auto-dispatch approved packets to idle lanes
+    4. Idle lane detection (available for dispatch)
+    5. Stalled lane detection (acked but idle), with optional recovery
+    6. Approval-stall detection (lanes blocked on tool-approval prompts)
+    7. Recently merged PR detection (new merges since last cycle)
+    8. Auto-complete dispatched packets whose PRs were merged externally
+    9. Auto-dispatch approved packets to idle lanes
 
     Optionally sends a summary to the orchestrator inbox.
 
@@ -1422,7 +1611,7 @@ def run_monitoring_cycle(
     # 1. Lane health
     findings.extend(check_lane_health(runtime_dir))
 
-    # 2. Open PRs and CI
+    # 2. Open PRs, CI status, and CI-ready detection
     if not skip_pr_check:
         findings.extend(check_open_prs())
 
@@ -1431,21 +1620,28 @@ def run_monitoring_cycle(
         check_stale_dispatches(runtime_dir, stale_minutes=stale_minutes, now=now)
     )
 
-    # 4. Stalled lane detection (acked dispatches with no progress)
+    # 4. Idle lane detection
+    findings.extend(check_idle_lanes(runtime_dir))
+
+    # 5. Stalled lane detection (acked dispatches with no progress)
     findings.extend(check_stalled_lanes(runtime_dir, now=now, no_recovery=no_recovery))
 
-    # 5. Approval-stall detection (lanes blocked on approval prompts)
+    # 6. Approval-stall detection (lanes blocked on approval prompts)
     findings.extend(check_approval_stalls(runtime_dir=runtime_dir))
 
-    # 6. Auto-complete dispatched packets whose PRs were merged externally
+    # 7. Recently merged PRs (new since last cycle)
+    if not skip_pr_check:
+        findings.extend(check_recently_merged_prs(runtime_dir))
+
+    # 8. Auto-complete dispatched packets whose PRs were merged externally
     if not skip_pr_check:
         findings.extend(check_merged_dispatches(runtime_dir))
 
-    # 7. Auto-dispatch approved packets to idle lanes
+    # 9. Auto-dispatch approved packets to idle lanes
     if not no_auto_dispatch:
         findings.extend(check_auto_dispatch(runtime_dir, current_findings=findings))
 
-    # 8. Notify orchestrator
+    # 10. Notify orchestrator
     if notify_orchestrator:
         _send_findings_to_orchestrator(findings)
 

--- a/tests/unit/test_ops_monitor.py
+++ b/tests/unit/test_ops_monitor.py
@@ -20,9 +20,11 @@ from bid_euchre.ops.monitor import (
     _save_stall_state,
     check_approval_stalls,
     check_auto_dispatch,
+    check_idle_lanes,
     check_lane_health,
     check_merged_dispatches,
     check_open_prs,
+    check_recently_merged_prs,
     check_stale_dispatches,
     check_stalled_lanes,
     format_findings_json,
@@ -2157,3 +2159,304 @@ class TestApprovalStallsWithSpinner:
             assert len(findings2) == 1
             assert "author-c" in findings2[0].summary
             assert len(notifications) == 1
+
+
+# ---------------------------------------------------------------------------
+# check_idle_lanes tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckIdleLanes:
+    """Tests for idle lane detection."""
+
+    def test_reports_idle_lanes(self, tmp_path: Path) -> None:
+        """Idle lanes with live tmux are reported."""
+        worker_idle = MagicMock()
+        worker_idle.lane_id = "author-b"
+        worker_idle.pool_status = "idle"
+        worker_idle.tmux_alive = True
+
+        worker_active = MagicMock()
+        worker_active.lane_id = "author-a"
+        worker_active.pool_status = "active"
+        worker_active.tmux_alive = True
+
+        pool_mock = MagicMock()
+        pool_mock.workers = [worker_idle, worker_active]
+
+        with patch(
+            "bid_euchre.ops.worker_pool.take_pool_snapshot",
+            return_value=pool_mock,
+        ):
+            findings = check_idle_lanes(tmp_path)
+
+        idle_findings = [f for f in findings if f.category == "lane_idle"]
+        assert len(idle_findings) == 1
+        assert "author-b" in idle_findings[0].summary
+        assert idle_findings[0].severity == SEVERITY_INFO
+
+    def test_no_idle_lanes(self, tmp_path: Path) -> None:
+        """No findings when all lanes are active."""
+        worker = MagicMock()
+        worker.lane_id = "author-a"
+        worker.pool_status = "active"
+        worker.tmux_alive = True
+
+        pool_mock = MagicMock()
+        pool_mock.workers = [worker]
+
+        with patch(
+            "bid_euchre.ops.worker_pool.take_pool_snapshot",
+            return_value=pool_mock,
+        ):
+            findings = check_idle_lanes(tmp_path)
+
+        assert len(findings) == 0
+
+    def test_idle_lane_with_dead_tmux_not_reported(self, tmp_path: Path) -> None:
+        """Idle lanes with dead tmux panes are not reported as available."""
+        worker = MagicMock()
+        worker.lane_id = "author-c"
+        worker.pool_status = "idle"
+        worker.tmux_alive = False
+
+        pool_mock = MagicMock()
+        pool_mock.workers = [worker]
+
+        with patch(
+            "bid_euchre.ops.worker_pool.take_pool_snapshot",
+            return_value=pool_mock,
+        ):
+            findings = check_idle_lanes(tmp_path)
+
+        assert len(findings) == 0
+
+    def test_multiple_idle_lanes(self, tmp_path: Path) -> None:
+        """Multiple idle lanes each produce a finding."""
+        workers = []
+        for lid in ["author-a", "flex-a", "brws-author-b"]:
+            w = MagicMock()
+            w.lane_id = lid
+            w.pool_status = "idle"
+            w.tmux_alive = True
+            workers.append(w)
+
+        pool_mock = MagicMock()
+        pool_mock.workers = workers
+
+        with patch(
+            "bid_euchre.ops.worker_pool.take_pool_snapshot",
+            return_value=pool_mock,
+        ):
+            findings = check_idle_lanes(tmp_path)
+
+        assert len(findings) == 3
+        lane_ids = {f.details["lane_id"] for f in findings}
+        assert lane_ids == {"author-a", "flex-a", "brws-author-b"}
+
+    def test_handles_snapshot_failure(self, tmp_path: Path) -> None:
+        """Gracefully handles pool snapshot failure."""
+        with patch(
+            "bid_euchre.ops.worker_pool.take_pool_snapshot",
+            side_effect=RuntimeError("no registry"),
+        ):
+            findings = check_idle_lanes(tmp_path)
+
+        assert len(findings) == 1
+        assert findings[0].severity == SEVERITY_WARN
+        assert "idle" in findings[0].summary.lower()
+
+
+# ---------------------------------------------------------------------------
+# check_recently_merged_prs tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckRecentlyMergedPRs:
+    """Tests for recently merged PR detection."""
+
+    def test_reports_new_merges(self, tmp_path: Path) -> None:
+        """Newly merged PRs are reported as findings."""
+        prs = [
+            {
+                "number": 100,
+                "title": "Fix scoring",
+                "headRefName": "fix/scoring",
+                "mergedAt": "2026-03-23T10:00:00Z",
+            },
+            {
+                "number": 101,
+                "title": "Add feature",
+                "headRefName": "feat/new",
+                "mergedAt": "2026-03-23T11:00:00Z",
+            },
+        ]
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = json.dumps(prs)
+
+        with patch("subprocess.run", return_value=result):
+            findings = check_recently_merged_prs(tmp_path)
+
+        merged = [f for f in findings if f.category == "pr_merged"]
+        assert len(merged) == 2
+        nums = {f.details["pr"] for f in merged}
+        assert nums == {100, 101}
+
+    def test_deduplicates_across_cycles(self, tmp_path: Path) -> None:
+        """Previously seen merges are not re-reported."""
+        # Seed the state with PR #100 already seen
+        state_path = tmp_path / "merged_pr_state.json"
+        state_path.write_text(json.dumps({"seen": [100]}) + "\n")
+
+        prs = [
+            {
+                "number": 100,
+                "title": "Fix scoring",
+                "headRefName": "fix/scoring",
+                "mergedAt": "2026-03-23T10:00:00Z",
+            },
+            {
+                "number": 102,
+                "title": "New PR",
+                "headRefName": "feat/new",
+                "mergedAt": "2026-03-23T12:00:00Z",
+            },
+        ]
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = json.dumps(prs)
+
+        with patch("subprocess.run", return_value=result):
+            findings = check_recently_merged_prs(tmp_path)
+
+        merged = [f for f in findings if f.category == "pr_merged"]
+        assert len(merged) == 1
+        assert merged[0].details["pr"] == 102
+
+    def test_persists_state(self, tmp_path: Path) -> None:
+        """Seen PR numbers are persisted after a cycle."""
+        prs = [
+            {
+                "number": 200,
+                "title": "PR 200",
+                "headRefName": "feat/200",
+                "mergedAt": "2026-03-23T10:00:00Z",
+            },
+        ]
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = json.dumps(prs)
+
+        with patch("subprocess.run", return_value=result):
+            check_recently_merged_prs(tmp_path)
+
+        state_path = tmp_path / "merged_pr_state.json"
+        assert state_path.exists()
+        state = json.loads(state_path.read_text())
+        assert 200 in state["seen"]
+
+    def test_no_merged_prs(self, tmp_path: Path) -> None:
+        """No findings when no PRs are merged."""
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = "[]"
+
+        with patch("subprocess.run", return_value=result):
+            findings = check_recently_merged_prs(tmp_path)
+
+        assert len(findings) == 0
+
+    def test_handles_gh_failure(self, tmp_path: Path) -> None:
+        """Gracefully handles gh command failure."""
+        result = MagicMock()
+        result.returncode = 1
+        result.stderr = "auth error"
+        result.stdout = ""
+
+        with patch("subprocess.run", return_value=result):
+            findings = check_recently_merged_prs(tmp_path)
+
+        assert len(findings) == 1
+        assert findings[0].severity == SEVERITY_WARN
+        assert "failed" in findings[0].summary
+
+
+# ---------------------------------------------------------------------------
+# check_open_prs — pr_ready detection tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckOpenPRsReady:
+    """Tests for CI-ready PR detection in check_open_prs."""
+
+    def test_flags_pr_with_all_green_checks(self) -> None:
+        """PR with all checks passing is flagged as pr_ready."""
+        prs = [
+            {
+                "number": 50,
+                "title": "Good PR",
+                "headRefName": "feat/good",
+                "mergeable": "MERGEABLE",
+                "statusCheckRollup": [
+                    {"name": "tests", "conclusion": "SUCCESS", "status": "COMPLETED"},
+                    {"name": "lint", "conclusion": "SUCCESS", "status": "COMPLETED"},
+                ],
+            }
+        ]
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = json.dumps(prs)
+
+        with patch("subprocess.run", return_value=result):
+            findings = check_open_prs()
+
+        ready = [f for f in findings if f.category == "pr_ready"]
+        assert len(ready) == 1
+        assert "#50" in ready[0].summary
+        assert ready[0].severity == SEVERITY_WARN
+
+    def test_does_not_flag_pr_with_failing_checks(self) -> None:
+        """PR with failing checks is NOT flagged as pr_ready."""
+        prs = [
+            {
+                "number": 51,
+                "title": "Broken PR",
+                "headRefName": "feat/broken",
+                "mergeable": "MERGEABLE",
+                "statusCheckRollup": [
+                    {"name": "tests", "conclusion": "FAILURE", "status": "COMPLETED"},
+                    {"name": "lint", "conclusion": "SUCCESS", "status": "COMPLETED"},
+                ],
+            }
+        ]
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = json.dumps(prs)
+
+        with patch("subprocess.run", return_value=result):
+            findings = check_open_prs()
+
+        ready = [f for f in findings if f.category == "pr_ready"]
+        assert len(ready) == 0
+
+    def test_does_not_flag_pr_with_no_checks(self) -> None:
+        """PR with no checks is NOT flagged as pr_ready."""
+        prs = [
+            {
+                "number": 52,
+                "title": "No checks PR",
+                "headRefName": "feat/noci",
+                "mergeable": "MERGEABLE",
+                "statusCheckRollup": [],
+            }
+        ]
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = json.dumps(prs)
+
+        with patch("subprocess.run", return_value=result):
+            findings = check_open_prs()
+
+        ready = [f for f in findings if f.category == "pr_ready"]
+        assert len(ready) == 0


### PR DESCRIPTION
## Summary

- Add `check_idle_lanes()`: detects lanes with `pool_status == "idle"` and live tmux, producing `lane_idle` findings so the orchestrator knows which lanes are available for dispatch
- Add `check_recently_merged_prs()`: queries `gh pr list --state merged` and deduplicates against persisted state to produce `pr_merged` findings only for new merges
- Add `pr_ready` detection in existing `check_open_prs()`: flags open PRs where all CI checks pass as `pr_ready` (WARN severity) so the orchestrator can act on merge-ready PRs

## Why

The monitor loop was sending "N info findings (all nominal)" messages that gave the orchestrator no actionable intelligence. Issue #1469 identified that the orchestrator had to manually poll for merged PRs, idle lanes, and CI-ready PRs — defeating the purpose of the ops loop.

## Validation

```bash
# Targeted tests (13 new tests)
uv run python -m pytest tests/unit/test_ops_monitor.py -v

# Full unit suite
uv run python -m pytest tests/unit/ -q
# 6006 passed, 44 skipped in 216s

# Lint
uv run ruff check . && uv run ruff format --check src/bid_euchre/ops/monitor.py tests/unit/test_ops_monitor.py
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
branch: ops/monitor-actionable-alerts
```

## Scope

Only touched declared files:
- `src/bid_euchre/ops/monitor.py` — 3 new check functions + wiring into `run_monitoring_cycle()`
- `tests/unit/test_ops_monitor.py` — 13 new tests across 3 test classes

Closes #1469

🤖 Generated with [Claude Code](https://claude.com/claude-code)