### PR TITLE
fix(convention): extract shared completion logic in post-merge-notify hook

### DIFF
--- a/.claude/hooks/post-merge-notify.sh
+++ b/.claude/hooks/post-merge-notify.sh
@@ -92,17 +92,19 @@ run_completion() {
     local lane="$1"
     local pr="$2"
     local project_dir="${3:-${CLAUDE_PROJECT_DIR:-.}}"
+    local auto_merge="${4:-false}"
 
     # Run in the correct directory so uv finds pyproject.toml
     (
         cd "$project_dir" 2>/dev/null || true
 
-        LANE_ID="$lane" PR_NUM="$pr" \
+        LANE_ID="$lane" PR_NUM="$pr" AUTO_MERGE="$auto_merge" \
         uv run python -c "
 import os, sys
 
 lane_id = os.environ.get('LANE_ID', '')
 pr_num = os.environ['PR_NUM']
+auto_merge = os.environ.get('AUTO_MERGE', 'false') == 'true'
 
 # 1. Find and complete the active dispatched task packet
 #    Primary (Gap B): look up by PR number in metadata
@@ -135,15 +137,19 @@ except Exception as exc:
 
 # 2. Send completion message to orchestrator via message bus
 from_lane = lane_id or 'unknown'
+suffix = ' (auto-merge)' if auto_merge else ''
+payload = {'pr_number': pr_num, 'packet_id': packet_id}
+if auto_merge:
+    payload['auto_merge'] = True
 try:
     from bid_euchre.ops.message_bus import create_message, send_message
     msg = create_message(
         from_lane=from_lane,
         to_lane='orchestrator',
         message_type='completion',
-        summary=f'PR #{pr_num} merged — task complete',
+        summary=f'PR #{pr_num} merged{suffix} — task complete',
         task_id=packet_id,
-        payload={'pr_number': pr_num, 'packet_id': packet_id},
+        payload=payload,
     )
     send_message(msg)
 except Exception as exc:
@@ -173,51 +179,8 @@ if [[ "$COMMAND" == *"--auto"* ]]; then
                 STATE=$(gh pr view "$_PR_NUM" --json state --jq '.state' 2>/dev/null || echo "unknown")
 
                 if [ "$STATE" = "MERGED" ]; then
-                    # PR is actually merged — run completion logic
-                    cd "$_PROJECT_DIR" 2>/dev/null || true
-                    LANE_ID="$_LANE_ID" PR_NUM="$_PR_NUM" \
-                    uv run python -c "
-import os, sys
-
-lane_id = os.environ.get('LANE_ID', '')
-pr_num = os.environ['PR_NUM']
-
-packet_id = None
-try:
-    from bid_euchre.ops.task_queue import list_packets, transition_status
-    dispatched = list_packets(status_filter='dispatched')
-    if pr_num and pr_num != 'unknown':
-        for pkt in dispatched:
-            pkt_pr = (pkt.metadata or {}).get('pr_number')
-            if pkt_pr is not None and str(pkt_pr) == str(pr_num):
-                packet_id = pkt.packet_id
-                lane_id = lane_id or pkt.owner or ''
-                break
-    if packet_id is None and lane_id:
-        for pkt in dispatched:
-            if pkt.owner == lane_id:
-                packet_id = pkt.packet_id
-                break
-    if packet_id:
-        transition_status(packet_id, 'completed')
-except Exception as exc:
-    print(f'post-merge-watcher: task transition failed: {exc}', file=sys.stderr)
-
-from_lane = lane_id or 'unknown'
-try:
-    from bid_euchre.ops.message_bus import create_message, send_message
-    msg = create_message(
-        from_lane=from_lane,
-        to_lane='orchestrator',
-        message_type='completion',
-        summary=f'PR #{pr_num} merged (auto-merge) — task complete',
-        task_id=packet_id,
-        payload={'pr_number': pr_num, 'packet_id': packet_id, 'auto_merge': True},
-    )
-    send_message(msg)
-except Exception as exc:
-    print(f'post-merge-watcher: message send failed: {exc}', file=sys.stderr)
-" 2>/dev/null || true
+                    # PR is actually merged — reuse shared completion logic
+                    run_completion "$_LANE_ID" "$_PR_NUM" "$_PROJECT_DIR" "true"
 
                     # Create sentinel after successful completion
                     touch "/tmp/.claude-post-merge-notify-${_PR_NUM}"


### PR DESCRIPTION
Closes #1478

## Summary

- Refactored `run_completion()` in `post-merge-notify.sh` to accept an optional 4th parameter `auto_merge` (defaults to `"false"`)
- The inline Python now conditionally adds `(auto-merge)` to the summary and `auto_merge: True` to the payload based on this parameter
- Replaced ~40 lines of duplicated inline Python in the auto-merge background watcher with a single call: `run_completion "$_LANE_ID" "$_PR_NUM" "$_PROJECT_DIR" "true"`

## Why

The auto-merge watcher contained a near-duplicate of the `run_completion()` function's Python code. The only differences were the summary suffix and an `auto_merge` payload key. If the completion logic changes (task queue API, message format, lookup strategy), both copies would need to be updated in sync — a silent divergence risk in a bash hook that receives less scrutiny.

## Repro / Validation

```bash
# Verify bash syntax
bash -n .claude/hooks/post-merge-notify.sh

# Repo lint + ruff
make repo-lint && make lint

# Full unit test suite (5867 passed)
PYTHONPATH=.:src uv run python -m pytest -q -x tests/unit/ \
  --ignore=tests/unit/hosted_play \
  --ignore=tests/unit/test_run_notebooks.py -m "not slow"
```

## Tests

- `bash -n` syntax check: ✅
- `make repo-lint`: ✅
- `make lint`: ✅
- `make notebook-check`: ✅
- `make docs-check`: ✅
- Unit tests (5867 passed, 44 skipped): ✅

Note: `hosted_play` tests skipped due to pre-existing missing `starlette`/`sqlalchemy` deps in this worktree — unrelated to this change.

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b
branch: fix/extract-completion-logic
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)