### PR TITLE
fix(ops): harden SessionStart hook to prevent blank-prompt failures

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -179,7 +179,8 @@ meaningful work.
 Hooks are registered across two files:
 
 **`.claude/settings.json`** (committed, shared):
-- `SessionStart` → `compact-context.sh`, `session-sync-worktree.sh`
+- `SessionStart` (compact) → `compact-context.sh`
+- `SessionStart` (all) → `session-sync-worktree.sh` (no matcher — fires on init, clear, compact)
 - `PreToolUse` (Edit|Write) → `rule-loader.sh`
 - `PreToolUse` (Bash) → `pre-bash-dispatch.sh` (consolidated dispatcher)
 - `PostToolUse` (Write|Edit) → `post-write-check.sh`

--- a/.claude/hooks/session-sync-worktree.sh
+++ b/.claude/hooks/session-sync-worktree.sh
@@ -4,9 +4,13 @@
 # state, never deletes branches, never touches non-steward worktrees.
 # See: .claude/rules/75_worktree_protection.md, GitHub issue #1208.
 #
-# Triggered by SessionStart hook with "worktree-sync" matcher.
+# Triggered by SessionStart hook (fires on all session starts: init, clear,
+# compact).  Must NEVER exit non-zero — a failing SessionStart hook leaves
+# the session at a blank prompt with 0 tokens and no context.
 
-set -euo pipefail
+# Safety: guarantee exit 0 on ANY error.  SessionStart hooks that exit
+# non-zero break the session (blank prompt, 0 tokens, no /start-task pickup).
+trap 'exit 0' ERR
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 LOG_PREFIX="[session-sync]"
@@ -45,8 +49,12 @@ fi
 # Check if current branch has an open PR (skip if so — active work).
 # Fail closed: if gh is unavailable or auth fails, skip sync rather than
 # risk resetting a branch that has an open PR we can't see.
-PR_STATE="$(gh pr view "$CURRENT_BRANCH" --repo Questuart/Bid-Euchre --json state --jq '.state' 2>/dev/null)" || {
-  echo >&2 "${LOG_PREFIX} WARNING: Could not query PR state (gh unavailable or auth error) — skipping auto-sync."
+#
+# Use `timeout 5` to cap the network call — without it, a slow GitHub API
+# response can exhaust the hook's 15s timeout and kill the whole hook,
+# bypassing all || guards and leaving the session broken.
+PR_STATE="$(timeout 5 gh pr view "$CURRENT_BRANCH" --repo Questuart/Bid-Euchre --json state --jq '.state' 2>/dev/null)" || {
+  echo >&2 "${LOG_PREFIX} WARNING: Could not query PR state (gh unavailable, auth error, or timeout) — skipping auto-sync."
   exit 0
 }
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,7 +34,6 @@
         ]
       },
       {
-        "matcher": "worktree-sync",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary

- Replace `set -euo pipefail` with `trap 'exit 0' ERR` in `session-sync-worktree.sh` — guarantees the hook never exits non-zero, which would break the session (blank prompt, 0 tokens)
- Remove the `worktree-sync` matcher from `settings.json` — this matcher never matched any real session type, making the hook fire unreliably or not at all
- Add `timeout 5` around `gh pr view` — prevents a slow GitHub API call from exhausting the hook's 15s timeout and killing the process before the `||` guards can run

## Why

When lane refresh runs `/clear`, the new session triggers SessionStart hooks. If `session-sync-worktree.sh` exits non-zero (via `set -e` on an edge case, or the hook timeout being exhausted by a slow `gh pr view`), the session is left at a blank prompt with 0 tokens and no context. The lane never picks up dispatched work.

## Repro / Validation

```bash
# Test hook in isolation — all paths exit 0
CLAUDE_PROJECT_DIR=/path/to/steward-worktree bash .claude/hooks/session-sync-worktree.sh; echo $?
CLAUDE_PROJECT_DIR=/nonexistent/steward-path bash .claude/hooks/session-sync-worktree.sh; echo $?

# Unit tests
uv run python -m pytest tests/unit/test_session_sync_hook.py -v

# Full validation
make check-quiet
```

## Tests

```bash
uv run python -m pytest tests/unit/test_session_sync_hook.py -v     # 3 passed
uv run python -m pytest tests/unit/test_ops_worker_pool.py -v       # 170 passed
make check-quiet                                                     # all checks passed
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: fix/session-start-hook-errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)