### PR TITLE
browser-game: Phase 3 Step 1 game board template and landing page

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Bid Euchre{% endblock %}</title>
+    <link rel="stylesheet" href="/static/style.css">
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
+    <script src="/static/game.js" defer></script>
     {% block head %}{% endblock %}
 </head>
 <body>

--- a/web/templates/game.html
+++ b/web/templates/game.html
@@ -1,0 +1,99 @@
+{% extends "base.html" %}
+
+{% block title %}Bid Euchre — Game{% endblock %}
+
+{% block content %}
+{#
+    Main game board template for the Bid Euchre browser game.
+
+    This template composes the partial templates based on the current game phase.
+    Routes render this template with the appropriate context variables; each
+    partial documents its own expected variables in a header comment.
+
+    Top-level context variables (passed by the route handler):
+        link_uuid    — player's game link UUID
+        nickname     — player's (HTML-escaped) display name
+        phase        — overall game phase:
+                         "nickname"     — need nickname input
+                         "model_select" — choosing AI opponent
+                         "auction"      — bidding in progress
+                         "trick_play"   — playing cards
+                         "hand_result"  — between hands, showing result
+                         "match_result" — match complete, win/loss screen
+                         "redeal"       — all-pass redeal notification
+
+    Each phase includes the relevant partials. The #game-board div is the
+    primary HTMX swap target for all game-action responses.
+#}
+
+<div id="game-board">
+
+    {# ---- Setup phases: nickname & model selection ---- #}
+    {% if phase == "nickname" %}
+        {% include "partials/nickname_form.html" %}
+
+    {% elif phase == "model_select" %}
+        {% include "partials/model_select.html" %}
+
+    {# ---- Match result (win/loss screen) ---- #}
+    {% elif phase == "match_result" %}
+        {% include "partials/match_result.html" %}
+
+    {# ---- Hand result (between hands) ---- #}
+    {% elif phase == "hand_result" %}
+        {% include "partials/hand_result.html" %}
+
+    {# ---- Active game phases: auction and trick play ---- #}
+    {% elif phase in ("auction", "trick_play", "redeal") %}
+
+        {# AI hands — face-down card backs with counts #}
+        <div style="display:flex; justify-content:space-between; align-items:flex-start; gap:0.5rem;">
+            {# Left opponent (seat 1) #}
+            <div style="text-align:center; flex:0 0 auto;">
+                <div class="ai-hand">
+                    {% for _ in range(opp_left_count | default(0)) %}
+                    <div class="card-back"></div>
+                    {% endfor %}
+                </div>
+                <span class="ai-card-count">AI Left ({{ opp_left_count | default(0) }})</span>
+            </div>
+
+            {# Partner (seat 2) #}
+            <div style="text-align:center; flex:1 1 auto;">
+                <div class="ai-hand">
+                    {% for _ in range(partner_count | default(0)) %}
+                    <div class="card-back"></div>
+                    {% endfor %}
+                </div>
+                <span class="ai-card-count">Partner ({{ partner_count | default(0) }})</span>
+            </div>
+
+            {# Right opponent (seat 3) #}
+            <div style="text-align:center; flex:0 0 auto;">
+                <div class="ai-hand">
+                    {% for _ in range(opp_right_count | default(0)) %}
+                    <div class="card-back"></div>
+                    {% endfor %}
+                </div>
+                <span class="ai-card-count">AI Right ({{ opp_right_count | default(0) }})</span>
+            </div>
+        </div>
+
+        {# Trick area — always shown during active play #}
+        {% include "partials/trick.html" %}
+
+        {# Bid panel — auction phase only, when it's the human's turn #}
+        {% if phase == "auction" %}
+            {% include "partials/bid_panel.html" %}
+        {% endif %}
+
+        {# Human hand — always shown during active play #}
+        {% include "partials/hand.html" %}
+
+        {# Score bar — always shown during active play #}
+        {% include "partials/score.html" %}
+
+    {% endif %}
+
+</div>
+{% endblock %}

--- a/web/templates/landing.html
+++ b/web/templates/landing.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block title %}Bid Euchre — Play Online{% endblock %}
+
+{% block content %}
+<div style="text-align:center; padding:3rem 1rem;">
+    <h2 style="font-size:2rem; margin-bottom:0.5rem;">Bid Euchre</h2>
+    <p style="color:var(--color-text-muted, #bdbdbd); margin-bottom:2rem; font-size:1.1rem;">
+        Double-deck, 10-to-Ace, with bowers. Play against AI opponents.
+    </p>
+    <form method="post" action="/new">
+        <button type="submit" class="btn btn--play-again">Start a New Game</button>
+    </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary

- Create `game.html` — main game layout that composes partials by phase (nickname → model_select → auction → trick_play → hand_result → match_result). `#game-board` div is the primary HTMX swap target.
- Create `landing.html` — landing page with "Start a New Game" form that POSTs to `/new`
- Update `base.html` — add `style.css` and `game.js` (deferred) links

## Why

Phase 3 Step 1 (SP-3-02): the page-level templates were the missing piece connecting the partials (PR #1488) and static assets (PR #1489) into a composable game UI. Routes still return inline HTML — Step 4 (vertical slice) will wire them to use `Jinja2Templates.render()`.

## Design

- `game.html` switches on `phase` to include the right partials
- AI hands shown as face-down card backs with visible count
- Score bar, trick area, bid panel, and human card fan compose from partials
- Fallback: all forms have `method="post"` + `action` for non-JS usage

## Repro / Validation

```bash
# Tier 1 — hosted play tests (178 passed)
uv run python -m pytest tests/unit/hosted_play/ -v

# Repo lint + ruff
make repo-lint && make lint
```

## Tests

- 178 hosted play tests pass (routes, state, app, AI manager, engine, config)
- No new Python code — templates only; wiring tests come in Step 4

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
branch: browser-game/phase3-step1-game-board
```

## Task Packet

`804d65e87b5e` — Phase 3 Step 1: Game board template and landing page (redo)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)