### PR TITLE
fix: rebuild missing attributions without re-importing host usage

### DIFF
--- a/src/bid_euchre/ops/token_economy.py
+++ b/src/bid_euchre/ops/token_economy.py
@@ -1381,13 +1381,29 @@ def _ensure_imported(output_dir: Path) -> None:
 
     Runs ``import_usage_data`` followed by ``attribute_sessions`` so that
     both ``session_usage.jsonl`` and ``session_attributions.jsonl`` are
-    populated.  This is best-effort — failures are logged and swallowed
-    so the dashboard never crashes due to import issues.
+    populated.  When usage data already exists but only attributions are
+    missing (e.g. a previous import crashed mid-way), rebuilds attributions
+    without re-importing host usage.
+
+    This is best-effort — failures are logged and swallowed so the dashboard
+    never crashes due to import issues.
     """
     if not _is_store_stale(output_dir):
         return
 
     try:
+        usage_file = output_dir / "session_usage.jsonl"
+        attr_file = output_dir / "session_attributions.jsonl"
+        usage_exists = usage_file.exists() and usage_file.stat().st_size > 0
+        attr_missing = not attr_file.exists() or attr_file.stat().st_size == 0
+
+        if usage_exists and attr_missing:
+            # Usage data is present but attributions are absent — rebuild
+            # attributions from existing data without re-scanning host usage.
+            attribute_sessions(output_dir=output_dir)
+            logger.info("Rebuilt missing attributions from existing usage data")
+            return
+
         result = import_usage_data(output_dir=output_dir)
         if result.sessions_imported > 0 or result.sessions_skipped > 0:
             attribute_sessions(output_dir=output_dir)

--- a/tests/unit/test_ops_token_economy.py
+++ b/tests/unit/test_ops_token_economy.py
@@ -28,6 +28,7 @@ from bid_euchre.ops.token_economy import (
     SessionRecord,
     ThroughputMetrics,
     UsageSummary,
+    _ensure_imported,
     _is_session_complete,
     _is_store_stale,
     attribute_sessions,
@@ -1437,6 +1438,45 @@ class TestAutoImport:
         output_dir.mkdir()
         result = dashboard_token_economy(output_dir=output_dir, auto_import=False)
         assert result == {}
+
+    def test_missing_attributions_rebuilds_without_reimport(
+        self, tmp_path: Path
+    ) -> None:
+        """When usage exists but attributions are missing, rebuild attributions
+        without re-importing host usage data (#1505)."""
+        from unittest.mock import patch
+
+        output_dir = tmp_path / "token_economy"
+        output_dir.mkdir()
+
+        # Write usage data as if a previous import succeeded
+        usage_file = output_dir / "session_usage.jsonl"
+        usage_file.write_text(
+            json.dumps(
+                {
+                    "session_id": "s1",
+                    "input_tokens": 100,
+                    "output_tokens": 400,
+                    "duration_minutes": 10,
+                    "project_path": "/tmp/test",
+                    "imported_at": "2026-03-20T10:00:00Z",
+                    "source_hash": "abc123",
+                }
+            )
+            + "\n"
+        )
+        # No attributions file — simulates a crashed previous import
+
+        with (
+            patch("bid_euchre.ops.token_economy.import_usage_data") as mock_import,
+            patch("bid_euchre.ops.token_economy.attribute_sessions") as mock_attr,
+        ):
+            _ensure_imported(output_dir)
+
+        # attribute_sessions should be called to rebuild attributions
+        mock_attr.assert_called_once_with(output_dir=output_dir)
+        # import_usage_data should NOT be called — usage data already exists
+        mock_import.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Plan
N/A — convention follow-up fix from autonomous review coordinator (#1505).

## Summary
- When usage data exists but attributions are missing (crashed previous import),
  `_ensure_imported()` now calls only `attribute_sessions()` — skips the full
  `import_usage_data()` host-usage scan
- Adds a targeted test verifying `import_usage_data` is NOT called in the
  attributions-only-missing path

## Why
Review coordinator finding from PR #1493: rebuilding missing attributions
should not re-import host usage data from `~/.claude/usage-data/`. The
previous code path re-ran the full import even when usage data was already
present, doing unnecessary I/O.

Closes #1505

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_token_economy.py -x -q  # 81 passed
make check-quiet                                                      # All checks passed
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_token_economy.py` (81 passed, 1 new)
- [x] `make check-quiet` (full validation)

## Expected impact
- Metrics impact: None
- Runtime impact: Avoids unnecessary host-usage scan when only attributions need rebuild

## Risk level
- [x] Low (convention fix + test)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
Bid-Euchre-steward-author  fix/convention-1505-attribution-rebuild
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)