### PR TITLE
fix(browser-game): match template contract_type to engine lowercase values

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -358,12 +358,13 @@ class TestScore:
         assert "Hand 1" in html
 
     def test_high_contract_display(self, env):
+        """Engine produces lowercase 'high' for no-trump high contracts."""
         tmpl = env.get_template("partials/score.html")
         html = tmpl.render(
             score_human=10,
             score_ai=5,
             hands_played=2,
-            contract_type="HIGH",
+            contract_type="high",
             trump=None,
             winning_bid=7,
             bidder_seat=1,
@@ -374,6 +375,25 @@ class TestScore:
         )
         assert "7" in html
         assert "High" in html
+
+    def test_low_contract_display(self, env):
+        """Engine produces lowercase 'low' for no-trump low contracts."""
+        tmpl = env.get_template("partials/score.html")
+        html = tmpl.render(
+            score_human=10,
+            score_ai=5,
+            hands_played=2,
+            contract_type="low",
+            trump=None,
+            winning_bid=7,
+            bidder_seat=1,
+            tricks_team0=0,
+            tricks_team1=0,
+            dealer_seat=2,
+            phase="trick_play",
+        )
+        assert "7" in html
+        assert "Low" in html
 
 
 # ---------------------------------------------------------------------------
@@ -418,6 +438,44 @@ class TestHandResult:
         )
         assert "Set!" in html
         assert "-8" in html  # points
+
+    def test_high_contract_result(self, env):
+        """Engine produces lowercase 'high' for no-trump high contracts."""
+        tmpl = env.get_template("partials/hand_result.html")
+        html = tmpl.render(
+            winning_bid=7,
+            bidder_seat=0,
+            contract_type="high",
+            trump=None,
+            tricks_team0=8,
+            tricks_team1=2,
+            points_team0=8,
+            points_team1=2,
+            score_human=8,
+            score_ai=2,
+            hands_played=1,
+        )
+        assert "Made it!" in html
+        assert "High" in html
+
+    def test_low_contract_result(self, env):
+        """Engine produces lowercase 'low' for no-trump low contracts."""
+        tmpl = env.get_template("partials/hand_result.html")
+        html = tmpl.render(
+            winning_bid=7,
+            bidder_seat=1,
+            contract_type="low",
+            trump=None,
+            tricks_team0=3,
+            tricks_team1=7,
+            points_team0=3,
+            points_team1=7,
+            score_human=3,
+            score_ai=7,
+            hands_played=1,
+        )
+        assert "Made it!" in html
+        assert "Low" in html
 
 
 # ---------------------------------------------------------------------------

--- a/web/templates/partials/hand_result.html
+++ b/web/templates/partials/hand_result.html
@@ -2,7 +2,7 @@
    Context variables:
      - winning_bid: int — the winning bid amount
      - bidder_seat: int — seat of the declarer
-     - contract_type: str — "suit", "HIGH", or "LOW"
+     - contract_type: str — "suit", "high", or "low"
      - trump: str | None — trump suit letter (if suit contract)
      - tricks_team0: int — tricks won by human team (seats 0, 2)
      - tricks_team1: int — tricks won by AI team (seats 1, 3)
@@ -29,9 +29,9 @@
                 {{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }} bid {{ winning_bid }}
                 {% if contract_type == "suit" and trump %}
                     {{ suit_symbols.get(trump, trump) }}
-                {% elif contract_type == "HIGH" %}
+                {% elif contract_type == "high" %}
                     High
-                {% elif contract_type == "LOW" %}
+                {% elif contract_type == "low" %}
                     Low
                 {% endif %}
                 and took {{ declarer_tricks }} tricks.
@@ -42,9 +42,9 @@
                 {{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }} bid {{ winning_bid }}
                 {% if contract_type == "suit" and trump %}
                     {{ suit_symbols.get(trump, trump) }}
-                {% elif contract_type == "HIGH" %}
+                {% elif contract_type == "high" %}
                     High
-                {% elif contract_type == "LOW" %}
+                {% elif contract_type == "low" %}
                     Low
                 {% endif %}
                 but only took {{ declarer_tricks }} tricks.

--- a/web/templates/partials/score.html
+++ b/web/templates/partials/score.html
@@ -3,7 +3,7 @@
      - score_human: int — human team's total match score
      - score_ai: int — AI team's total match score
      - hands_played: int — number of completed hands
-     - contract_type: str | None — "suit", "HIGH", or "LOW" (None if auction in progress)
+     - contract_type: str | None — "suit", "high", or "low" (None if auction in progress)
      - trump: str | None — trump suit letter if contract_type == "suit"
      - winning_bid: int | None — winning bid amount (None if auction in progress)
      - bidder_seat: int | None — seat of the declarer (None if auction in progress)
@@ -39,9 +39,9 @@
         <span>Contract: {{ winning_bid }}
             {% if contract_type == "suit" and trump %}
                 {{ suit_symbols.get(trump, trump) }}
-            {% elif contract_type == "HIGH" %}
+            {% elif contract_type == "high" %}
                 High
-            {% elif contract_type == "LOW" %}
+            {% elif contract_type == "low" %}
                 Low
             {% endif %}
         </span>


### PR DESCRIPTION
## Summary

- Fix `score.html` and `hand_result.html` templates to compare `contract_type` against lowercase `"high"` / `"low"` (matching the engine's `BidAction.to_contract_tuple()` output)
- Update template header comments to document the correct lowercase values
- Add test coverage for both `"high"` and `"low"` contract types in `score.html` and `hand_result.html`

## Why

The engine's `BidAction.to_contract_tuple()` returns lowercase contract types (`"high"`, `"low"`), but the templates compared against uppercase (`"HIGH"`, `"LOW"`). This caused no-trump contract type labels to render as blank in the score bar and hand result screens.

Note: `bid_panel.html` was NOT affected — it uses `entry.contract` (from `BidAction.contract`) which correctly uses uppercase.

Fixes #1504

## Repro / Validation

```bash
uv run python -m pytest tests/unit/hosted_play/test_partials.py -v
```

All 28 tests pass (including 3 new tests for high/low contract rendering).

## Tests

- `make check-quiet` ✅ — full validation passes
- `uv run python -m pytest tests/unit/hosted_play/test_partials.py -v` ✅ — 28/28 pass

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
branch: browser-game/fix-contract-type-case
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)