### PR TITLE
docs: sync Phase 4 plan statuses with sub-plan truth

### DIFF
--- a/plans/agent_ops/4_remote_channel/checkpoints.md
+++ b/plans/agent_ops/4_remote_channel/checkpoints.md
@@ -49,10 +49,10 @@ implementation.
 
 | File | Primary Owner | Secondary Owner(s) | Serialization Rule |
 |------|---------------|---------------------|-------------------|
-| `scripts/internal/ops.py` | SP-4-05 | SP-4-03, SP-4-04 | SP-4-03 is already complete; SP-4-05 owns any new actionable lifecycle views or helper wiring; SP-4-04 may add channel status CLI only after SP-4-05 lands |
-| `src/bid_euchre/ops/dashboard.py` | SP-4-03 | SP-4-05, SP-4-04 | SP-4-03 owns token panels; SP-4-05 may add lifecycle projections but should avoid broad dashboard redesign; SP-4-04 channel status indicator remains optional |
-| `src/bid_euchre/ops/monitor.py` | SP-4-05 | SP-4-04 | SP-4-05 owns typed lifecycle findings, persistent loop behavior, and routine-state reconciliation; SP-4-04 channel health check remains deferred to Platform-9c |
-| `src/bid_euchre/ops/message_bus.py` | SP-4-05 | SP-4-04 | SP-4-05 owns sender dedupe and actionable operator read flow; SP-4-04 should not change bus semantics in Platform-8a |
+| `scripts/internal/ops.py` | SP-4-05 | SP-4-02, SP-4-03, SP-4-04 | SP-4-02 and SP-4-03 are already complete; SP-4-05 owns any new actionable lifecycle views or helper wiring; SP-4-04 may add channel status CLI only after SP-4-05 lands |
+| `src/bid_euchre/ops/dashboard.py` | SP-4-03 | SP-4-02, SP-4-05, SP-4-04 | SP-4-02 and SP-4-03 are complete; SP-4-05 may add lifecycle projections but should avoid broad dashboard redesign; SP-4-04 channel status indicator remains optional |
+| `src/bid_euchre/ops/monitor.py` | SP-4-05 | SP-4-02, SP-4-04 | SP-4-02 is complete; SP-4-05 owns typed lifecycle findings, persistent loop behavior, and routine-state reconciliation; SP-4-04 channel health check remains deferred to Platform-9c |
+| `src/bid_euchre/ops/message_bus.py` | SP-4-05 | SP-4-02, SP-4-04 | SP-4-02 is complete; SP-4-05 owns sender dedupe and actionable operator read flow; SP-4-04 should not change bus semantics in Platform-8a |
 | `.claude/hooks/post-merge-notify.sh` | SP-4-05 | — | SP-4-05 owns merge-completion helper extraction and hook parity fixes |
 | `.claude/tmux/steward-session.sh` | SP-4-04 | — | SP-4-04 adds `--channels plugin:telegram@claude-plugins-official` flag and channel env vars; no other SP modifies the launcher |
 

--- a/plans/agent_ops/4_remote_channel/plan.md
+++ b/plans/agent_ops/4_remote_channel/plan.md
@@ -54,7 +54,7 @@ treats the remote channel as a thin transport into `orchestrator`.
 
 | Slice | Goal | Status | Batch | Depends On |
 |-------|------|--------|-------|------------|
-| `Platform-8a` | Channel preflight, Telegram transport skeleton, kill/mute/fallback hooks | READY FOR SCOPE LOCK | E | Phase 3, Amendment A5 |
+| `Platform-8a` | Channel preflight, Telegram transport skeleton, kill/mute/fallback hooks | READY FOR SCOPE LOCK | E | Phase 3, Amendment A5, SP-4-05 |
 | `Platform-8b` | Repo-owned audit trail for inbound/outbound remote exchanges | READY FOR SCOPE LOCK | E | Platform-3, Platform-8a |
 | `Platform-9a` | Idle-attention alerts and remote acknowledgement loop | READY FOR SCOPE LOCK | E | Platform-6, Platform-8b |
 | `Platform-9b` | Away-from-desk queue-moving supervision through `orchestrator` | READY FOR SCOPE LOCK | E | Platform-2, Platform-8b, Platform-9a |
@@ -107,10 +107,10 @@ Before treating Phase 5 as ready, verify Batch E (Platform-8 + Platform-9):
 | ID | Title | Status | File |
 |----|-------|--------|------|
 | SP-4-01 | Platform-8 scope lock | completed | `plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8-scope-lock.md` |
-| SP-4-02 | Remote-ops preflight hardening | in_progress | `plans/agent_ops/4_remote_channel/sub/2026-03-23_remote-ops-preflight-hardening.md` |
+| SP-4-02 | Remote-ops preflight hardening | completed | `plans/agent_ops/4_remote_channel/sub/2026-03-23_remote-ops-preflight-hardening.md` |
 | SP-4-03 | Token economy observability and dashboard | completed | `plans/agent_ops/4_remote_channel/sub/2026-03-23_token-economy-observability-and-dashboard.md` |
-| SP-4-04 | Platform-8a Telegram transport configuration | in_progress | `plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8a-telegram-transport.md` |
-| SP-4-05 | Reactive control-loop hardening | proposed | `plans/agent_ops/4_remote_channel/sub/2026-03-24_reactive-control-loop-hardening.md` |
+| SP-4-04 | Platform-8a Telegram transport configuration | completed | `plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8a-telegram-transport.md` |
+| SP-4-05 | Reactive control-loop hardening | in_progress | `plans/agent_ops/4_remote_channel/sub/2026-03-24_reactive-control-loop-hardening.md` |
 
 ## Step Sequence
 


### PR DESCRIPTION
## Summary
- Update `plan.md` Sub-Plans table: SP-4-02 and SP-4-04 → `completed`, SP-4-05 → `in_progress` (matching their sub-plan headers)
- Add SP-4-05 as a dependency gate for Platform-8a in the Slices table
- Restore SP-4-02 as secondary owner in `checkpoints.md` shared-surface ownership map

## Why
Review follow-up from PR #1499 (issue #1503). Three plan doc inconsistencies: sub-plan statuses in plan.md were stale, Platform-8a slice was missing the SP-4-05 gate, and SP-4-02 was dropped from the ownership map despite having touched the shared files.

## Plan reference
`plans/agent_ops/4_remote_channel/plan.md`, `plans/agent_ops/4_remote_channel/checkpoints.md`

## Repro / Validation
```bash
make docs-check   # passes
```

## Tests
Docs-only change — no code or test changes.

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
branch: fix/convention-follow-up-1503
```

## Review override note
Review coordinator flagged 2 pre-existing P1 findings (not in this PR's diff):
- `monitor.py` path reference → exists at `src/bid_euchre/ops/monitor.py`
- `~/.claude/hooks/cmux-notify.sh` → exists at user level (not a repo path)
Both are false positives from path-checking pre-existing session log entries.

Closes #1503

🤖 Generated with [Claude Code](https://claude.com/claude-code)