### PR TITLE
browser-game: fix convention follow-ups from PR #1498

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -363,7 +363,7 @@ class TestScore:
             score_human=10,
             score_ai=5,
             hands_played=2,
-            contract_type="HIGH",
+            contract_type="high",
             trump=None,
             winning_bid=7,
             bidder_seat=1,

--- a/web/app.py
+++ b/web/app.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 
 from .ai_manager import AIManager
@@ -23,8 +24,8 @@ from .config import HostedPlayConfig, get_config, override_config
 from .db import create_tables, init_engine, make_session_factory
 from .routes import router as game_router
 
-# Template directory lives at web/templates/ relative to this file
-_TEMPLATES_DIR = Path(__file__).resolve().parent / "templates"
+_WEB_DIR = Path(__file__).resolve().parent
+_TEMPLATES_DIR = _WEB_DIR / "templates"
 
 
 @asynccontextmanager
@@ -77,6 +78,9 @@ def create_app(config: HostedPlayConfig | None = None) -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    # Serve static assets (CSS, JS) from web/static/
+    app.mount("/static", StaticFiles(directory=str(_WEB_DIR / "static")), name="static")
 
     # Register game routes
     app.include_router(game_router)

--- a/web/templates/game.html
+++ b/web/templates/game.html
@@ -13,14 +13,14 @@
     Top-level context variables (passed by the route handler):
         link_uuid    — player's game link UUID
         nickname     — player's (HTML-escaped) display name
-        phase        — overall game phase:
-                         "nickname"     — need nickname input
-                         "model_select" — choosing AI opponent
-                         "auction"      — bidding in progress
-                         "trick_play"   — playing cards
-                         "hand_result"  — between hands, showing result
-                         "match_result" — match complete, win/loss screen
-                         "redeal"       — all-pass redeal notification
+        phase        — overall game phase (mapped from engine state by the route):
+                         "nickname"     — need nickname input     (player.nickname is None)
+                         "model_select" — choosing AI opponent    (no active match)
+                         "auction"      — bidding in progress     (hand.phase == "auction")
+                         "trick_play"   — playing cards           (hand.phase == "trick_play")
+                         "hand_result"  — between hands           (hand.phase == "complete")
+                         "match_result" — match complete          (state.status == "complete")
+                         "redeal"       — all-pass redeal         (hand.phase == "redeal")
 
     Each phase includes the relevant partials. The #game-board div is the
     primary HTMX swap target for all game-action responses.

--- a/web/templates/partials/hand_result.html
+++ b/web/templates/partials/hand_result.html
@@ -2,7 +2,7 @@
    Context variables:
      - winning_bid: int — the winning bid amount
      - bidder_seat: int — seat of the declarer
-     - contract_type: str — "suit", "HIGH", or "LOW"
+     - contract_type: str — "suit", "high", or "low"
      - trump: str | None — trump suit letter (if suit contract)
      - tricks_team0: int — tricks won by human team (seats 0, 2)
      - tricks_team1: int — tricks won by AI team (seats 1, 3)
@@ -29,9 +29,9 @@
                 {{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }} bid {{ winning_bid }}
                 {% if contract_type == "suit" and trump %}
                     {{ suit_symbols.get(trump, trump) }}
-                {% elif contract_type == "HIGH" %}
+                {% elif contract_type == "high" %}
                     High
-                {% elif contract_type == "LOW" %}
+                {% elif contract_type == "low" %}
                     Low
                 {% endif %}
                 and took {{ declarer_tricks }} tricks.
@@ -42,9 +42,9 @@
                 {{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }} bid {{ winning_bid }}
                 {% if contract_type == "suit" and trump %}
                     {{ suit_symbols.get(trump, trump) }}
-                {% elif contract_type == "HIGH" %}
+                {% elif contract_type == "high" %}
                     High
-                {% elif contract_type == "LOW" %}
+                {% elif contract_type == "low" %}
                     Low
                 {% endif %}
                 but only took {{ declarer_tricks }} tricks.

--- a/web/templates/partials/score.html
+++ b/web/templates/partials/score.html
@@ -3,7 +3,7 @@
      - score_human: int — human team's total match score
      - score_ai: int — AI team's total match score
      - hands_played: int — number of completed hands
-     - contract_type: str | None — "suit", "HIGH", or "LOW" (None if auction in progress)
+     - contract_type: str | None — "suit", "high", or "low" (None if auction in progress)
      - trump: str | None — trump suit letter if contract_type == "suit"
      - winning_bid: int | None — winning bid amount (None if auction in progress)
      - bidder_seat: int | None — seat of the declarer (None if auction in progress)
@@ -39,9 +39,9 @@
         <span>Contract: {{ winning_bid }}
             {% if contract_type == "suit" and trump %}
                 {{ suit_symbols.get(trump, trump) }}
-            {% elif contract_type == "HIGH" %}
+            {% elif contract_type == "high" %}
                 High
-            {% elif contract_type == "LOW" %}
+            {% elif contract_type == "low" %}
                 Low
             {% endif %}
         </span>


### PR DESCRIPTION
## Plan
N/A — convention follow-up from post-merge review of PR #1498.

## Summary
- Mount static files directory in `web/app.py` so `/static/style.css` and `/static/game.js` are served
- Fix contract_type casing in `score.html` and `hand_result.html` — templates checked uppercase `"HIGH"`/`"LOW"` but the engine returns lowercase `"high"`/`"low"`
- Add engine state mapping comments to `game.html` header documenting which engine states map to each template phase

## Why
Closes #1506 — three findings from the autonomous review coordinator's post-merge review of #1498 (game board template and landing page).

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/ -x -q   # 185 passed
make check-quiet                                          # All checks passed
uv run python -c "from web.app import create_app; app = create_app(); print([r.path for r in app.routes])"
# Confirms /static route is mounted
```

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/ -x -q` — 185 passed
- [x] `make check-quiet` — All checks passed

## Expected impact
- Metrics impact: None
- Runtime impact: None — static mount adds negligible overhead

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                       22210bbf [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a c081d564 [browser-game/fix-convention-1506]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)