### PR TITLE
docs: reconcile browser Phase 3 checkpoints and activate Phase 4

### DIFF
--- a/plans/browser_game/3_frontend_product/checkpoints.md
+++ b/plans/browser_game/3_frontend_product/checkpoints.md
@@ -13,17 +13,17 @@
 | Step | Status | Date | Agent/Session | Notes |
 |------|--------|------|---------------|-------|
 | Step 0: Verify Phase 2 complete and read SP-3-02 | COMPLETE | 2026-03-24 | brws-author-a | Phase 2 CLOSED (PRs #1430, #1435). SP-3-02 created (#1447). |
-| Step 1: Game board template (HTML/CSS for card display, bid UI, play UI) | IN_PROGRESS | 2026-03-24 | brws-author-a | `game.html`, `landing.html`, `style.css`. CSS-only card rendering with Unicode suits. |
+| Step 1: Game board template (HTML/CSS for card display, bid UI, play UI) | COMPLETE | 2026-03-24 | brws-author-a | PR #1498 merged. `game.html`, `landing.html`, `style.css`. CSS-only card rendering with Unicode suits. |
 | Step 2: Template partials for HTMX responses (bid result, card play result, trick complete) | COMPLETE | 2026-03-24 | brws-author-b | PR #1475 merged. 8 HTMX partials: nickname, model-select, bid, hand, trick, score, hand-result, match-result. |
-| Step 3: Static assets (CSS, minimal JS for HTMX) | IN_PROGRESS | 2026-03-24 | brws-author-d | `style.css`, `game.js`. Decision timer, card click handler, HTMX enhancements. |
-| Step 4: End-to-end local vertical slice (uvicorn + browser test) | PENDING | -- | -- | Full match flow: create → nickname → select AI → bid → play → score → win/loss. |
-| Step 5: Refresh/resume proof (browser refresh preserves game state) | PENDING | -- | -- | Idempotent submissions + persisted state survive refresh at any point. |
+| Step 3: Static assets (CSS, minimal JS for HTMX) | COMPLETE | 2026-03-24 | brws-author-d | PR #1489 merged. `style.css`, `game.js`. Decision timer, card click handler, HTMX enhancements. |
+| Step 4: End-to-end local vertical slice (uvicorn + browser test) | COMPLETE | 2026-03-24 | brws-author-a | PR #1495 merged. Jinja2 templates wired into routes.py. Full match flow: create → nickname → select AI → bid → play → score → win/loss. |
+| Step 5: Refresh/resume proof (browser refresh preserves game state) | COMPLETE | 2026-03-24 | brws-author-a | PR #1501 merged. Idempotent submissions + persisted state survive refresh at any point. |
 
 ## Active Sub-Plans
 
 | Sub-Plan ID | File | Status | Blocking Step |
 |-------------|------|--------|---------------|
-| SP-3-02 | `3_frontend_product/sub/2026-03-24_browser-ui.md` | active | Steps 1-3 |
+| SP-3-02 | `3_frontend_product/sub/2026-03-24_browser-ui.md` | completed | -- |
 | SP-3-01 | `3_frontend_product/sub/2026-03-14_htmx_game_ui.md` | superseded | -- |
 
 ## Blockers
@@ -41,6 +41,16 @@ Phase 3 and Phase 4 can execute in parallel after Phase 2 merges.
 If two agents are available, launch both simultaneously.
 
 ## Session Log
+
+### 2026-03-24 — brws-author-a (Phase 3 reconciliation)
+- ALL 5 STEPS COMPLETE. Phase 3 Frontend Product is DONE.
+- Step 1: PR #1498 (game.html, landing.html, style.css)
+- Step 2: PR #1475 (8 HTMX template partials)
+- Step 3: PR #1489 (style.css, game.js, decision timer)
+- Step 4: PR #1495 (Jinja2 templates wired into routes.py)
+- Step 5: PR #1501 (idempotent submissions + state persistence)
+- SP-3-02 status: active → completed.
+- Phase 4 Data Pipeline now unblocked.
 
 ### 2026-03-24 — orchestrator (checkpoint update)
 - Step 0: COMPLETE — Phase 2 verified, SP-3-02 created (PR #1447).

--- a/plans/browser_game/4_data_pipeline/checkpoints.md
+++ b/plans/browser_game/4_data_pipeline/checkpoints.md
@@ -3,7 +3,7 @@
 **Governing plan:** `plans/browser_game/governing_plan.md`
 **Phase/Rung:** `4_data_pipeline`
 **Sub-plan:** `SP-4-01` → `4_data_pipeline/sub/2026-03-14_export_replay.md`
-**Last updated:** 2026-03-14
+**Last updated:** 2026-03-24
 
 ---
 
@@ -11,7 +11,7 @@
 
 | Step | Status | Date | Agent/Session | Notes |
 |------|--------|------|---------------|-------|
-| Step 0: Read sub-plan SP-4-01 and verify Phase 2 complete | PENDING | -- | -- | Depends on Phase 2 (not Phase 3). Can run parallel with Phase 3. |
+| Step 0: Read sub-plan SP-4-01 and verify Phase 2 complete | PENDING | -- | -- | Phase 2 COMPLETE (PRs #1430, #1435). Ready to start. |
 | Step 1: Implement export logic (`web/export.py`) | PENDING | -- | -- | decision_to_jsonl(), export_decisions(), validate_replay(). |
 | Step 2: Implement export CLI (`scripts/internal/export_hosted_decisions.py`) | PENDING | -- | -- | --db, --output, --match-uuid, --human-only flags. |
 | Step 3: Implement replay validation | PENDING | -- | -- | Regenerate deal from seed+deal_id, replay all decisions, verify legality + outcomes. |
@@ -22,17 +22,23 @@
 
 | Sub-Plan ID | File | Status | Blocking Step |
 |-------------|------|--------|---------------|
-| SP-4-01 | `4_data_pipeline/sub/2026-03-14_export_replay.md` | proposed | Step 0 |
+| SP-4-01 | `4_data_pipeline/sub/2026-03-14_export_replay.md` | active | Step 0 |
 
 ## Blockers
 
-- [ ] Phase 2 not complete.
+- [x] ~~Phase 2 not complete.~~ Phase 2 CLOSED 2026-03-24 (PRs #1430, #1435). Phase 3 also COMPLETE.
 
 ## Note on Parallelism
 
 Phase 4 depends on Phase 2 (not Phase 3). Can run in parallel with Phase 3.
 
 ## Session Log
+
+### 2026-03-24 — brws-author-a (Phase 4 activation)
+- Phase 2 blocker cleared (PRs #1430, #1435 merged).
+- Phase 3 also COMPLETE (PRs #1475, #1489, #1495, #1498, #1501).
+- SP-4-01 status: proposed → active.
+- Phase 4 is now fully unblocked and ready to start.
 
 ### 2026-03-14 — Claude
 - Completed: Sub-plan SP-4-01 created with JSONL export format, CLI tool, replay validation, and 6 required tests.

--- a/plans/browser_game/sub_plan_registry.md
+++ b/plans/browser_game/sub_plan_registry.md
@@ -13,17 +13,17 @@
 | SP-1-01 | Stepwise Match Engine | Phase 1 — State Engine | completed | brws-author-a | `1_state_engine/sub/2026-03-14_stepwise_engine.md` | 2026-03-14 | 2026-03-23 |
 | SP-2-01 | FastAPI App & Persistence | Phase 2 — Backend API | completed | brws-author-b | `2_backend_api/sub/2026-03-14_fastapi_app.md` | 2026-03-14 | 2026-03-24 |
 | SP-3-01 | HTMX Game UI (design reference) | Phase 3 — Frontend Product | superseded | -- | `3_frontend_product/sub/2026-03-14_htmx_game_ui.md` | 2026-03-14 | -- |
-| SP-3-02 | Browser UI Implementation | Phase 3 — Frontend Product | proposed | -- | `3_frontend_product/sub/2026-03-24_browser-ui.md` | 2026-03-24 | -- |
-| SP-4-01 | Export & Replay Validation | Phase 4 — Data Pipeline | proposed | -- | `4_data_pipeline/sub/2026-03-14_export_replay.md` | 2026-03-14 | -- |
+| SP-3-02 | Browser UI Implementation | Phase 3 — Frontend Product | completed | brws-author-a | `3_frontend_product/sub/2026-03-24_browser-ui.md` | 2026-03-24 | 2026-03-24 |
+| SP-4-01 | Export & Replay Validation | Phase 4 — Data Pipeline | active | -- | `4_data_pipeline/sub/2026-03-14_export_replay.md` | 2026-03-14 | -- |
 
 ## Status Summary
 
 | Status | Count |
 |--------|-------|
-| proposed | 2 |
-| in_progress | 0 |
+| proposed | 0 |
+| active | 1 |
 | blocked | 0 |
-| completed | 3 |
+| completed | 4 |
 | abandoned | 0 |
 | superseded | 1 |
 


### PR DESCRIPTION
## Summary

- Mark all 5 Phase 3 Frontend Product steps as COMPLETE with merged PR refs (#1475, #1489, #1495, #1498, #1501)
- Update SP-3-02 status from proposed → completed in sub-plan registry
- Clear Phase 2 blocker on Phase 4 Data Pipeline and activate SP-4-01
- Add session log entries to both Phase 3 and Phase 4 checkpoints

## Why

Phase 3 shipped across the 2026-03-24 fleet run (5 PRs merged by 4 browser lanes), but the checkpoints were not reconciled. This closes the Phase 3 bookkeeping and unblocks Phase 4 Data Pipeline work.

## Repro / Validation

```bash
git diff --stat   # 3 files, all in plans/browser_game/
make check-quiet  # passes (docs-only)
```

## Tests

```
make check-quiet → ✓ All checks passed
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
branch: browser-game/reconcile-phase3-checkpoints
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)