### PR TITLE
fix(convention): harden post-merge-notify URL parsing and retry logic

### DIFF
--- a/.claude/hooks/post-merge-notify.sh
+++ b/.claude/hooks/post-merge-notify.sh
@@ -40,12 +40,14 @@ fi
 
 # Extract PR number for deduplication and messaging.
 # The first positional arg after "gh pr merge" can be a bare number (PR ID),
-# a branch name (e.g., "fix/issue-1234"), or a URL.  Only treat it as a PR
-# number when it is purely digits — otherwise fall back to stdout parsing.
+# a branch name (e.g., "fix/issue-1234"), or a URL.  Try bare digits first,
+# then /pull/<N> URL pattern, then fall back to stdout parsing.
 MERGE_ARG=$(echo "$COMMAND" | sed -n 's/.*gh pr merge[[:space:]]\{1,\}\([^[:space:]]\{1,\}\).*/\1/p')
 PR_NUM=""
 if [[ "$MERGE_ARG" =~ ^[0-9]+$ ]]; then
     PR_NUM="$MERGE_ARG"
+elif [[ "$MERGE_ARG" =~ /pull/([0-9]+) ]]; then
+    PR_NUM="${BASH_REMATCH[1]}"
 fi
 
 # Fallback: extract PR number from command stdout (e.g., "Merged pull request #1453")
@@ -204,8 +206,10 @@ if [[ "$COMMAND" == *"--auto"* ]]; then
                     # Only create sentinel on success so failures can retry.
                     if run_completion "$_LANE_ID" "$_PR_NUM" "$_PROJECT_DIR" "true"; then
                         touch "/tmp/.claude-post-merge-notify-${_PR_NUM}"
+                        exit 0
                     fi
-                    exit 0
+                    # Completion failed — continue polling to retry
+                    continue
                 elif [ "$STATE" = "CLOSED" ]; then
                     # PR closed without merging — nothing to do
                     exit 0

--- a/tests/unit/test_post_merge_notify_hook.py
+++ b/tests/unit/test_post_merge_notify_hook.py
@@ -150,6 +150,27 @@ class TestPRNumberExtraction:
             sentinel_real.unlink(missing_ok=True)
             sentinel_fake.unlink(missing_ok=True)
 
+    def test_pr_number_from_pull_url(self, tmp_path: Path) -> None:
+        """PR number should be extracted from /pull/<N> URL in command.
+
+        Regression test for issue #1520: `gh pr merge https://...pull/123`
+        should extract 123 via URL parsing before falling back to stdout.
+        """
+        pr_num = "6543"
+        sentinel = Path(f"/tmp/.claude-post-merge-notify-{pr_num}")
+        sentinel.unlink(missing_ok=True)
+        try:
+            result = _run_hook(
+                command=f"gh pr merge https://github.com/owner/repo/pull/{pr_num} --squash",
+                tmp_path=tmp_path,
+            )
+            assert result.returncode == 0
+            assert (
+                sentinel.exists()
+            ), "Sentinel should be created from /pull/<N> URL extraction"
+        finally:
+            sentinel.unlink(missing_ok=True)
+
     def test_pr_number_from_stdout_fallback(self, tmp_path: Path) -> None:
         """When command has no PR number, extract from stdout."""
         pr_num = "1111"


### PR DESCRIPTION
## Summary
- Parse `/pull/<N>` URLs before falling back to stdout extraction for PR number resolution
- Continue polling loop on failed auto-merge completion attempt instead of exiting (allows retry)
- Add regression test for URL-based PR number extraction

## Why
Review coordinator findings from PR #1516. The hook had two gaps:
1. When `gh pr merge` receives a full GitHub URL (e.g., `https://github.com/.../pull/123`), the PR number wasn't extracted from the URL path — it fell through to stdout parsing unnecessarily.
2. In the auto-merge watcher, when a completion attempt failed but the PR was already MERGED, the script exited instead of retrying on the next poll iteration.

Closes #1520

## Repro / Validation
```bash
bash -n .claude/hooks/post-merge-notify.sh  # syntax check
uv run python -m pytest tests/unit/test_post_merge_notify_hook.py -v  # 17 tests pass
make check-quiet  # full validation passes
```

## Tests
- `tests/unit/test_post_merge_notify_hook.py::TestPRNumberExtraction::test_pr_number_from_pull_url` — new regression test
- All 17 existing hook tests pass

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: fix/post-merge-notify-1520
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)