### PR TITLE
fix(token_economy): don't let missing attributions hide stale store

### DIFF
--- a/src/bid_euchre/ops/token_economy.py
+++ b/src/bid_euchre/ops/token_economy.py
@@ -1381,9 +1381,13 @@ def _ensure_imported(output_dir: Path) -> None:
 
     Runs ``import_usage_data`` followed by ``attribute_sessions`` so that
     both ``session_usage.jsonl`` and ``session_attributions.jsonl`` are
-    populated.  When usage data already exists but only attributions are
-    missing (e.g. a previous import crashed mid-way), rebuilds attributions
-    without re-importing host usage.
+    populated.  When usage data already exists *and is fresh* but only
+    attributions are missing (e.g. a previous import crashed mid-way),
+    rebuilds attributions without re-importing host usage (#1505).
+
+    When attributions are missing *and* usage data is stale, a full
+    re-import is performed instead — the missing attributions must not
+    hide a genuinely stale store (#1514).
 
     This is best-effort — failures are logged and swallowed so the dashboard
     never crashes due to import issues.
@@ -1398,14 +1402,24 @@ def _ensure_imported(output_dir: Path) -> None:
         attr_missing = not attr_file.exists() or attr_file.stat().st_size == 0
 
         if usage_exists and attr_missing:
-            # Usage data is present but attributions are absent — rebuild
-            # attributions from existing data without re-scanning host usage.
-            attribute_sessions(output_dir=output_dir)
-            logger.info("Rebuilt missing attributions from existing usage data")
-            return
+            # Usage data is present but attributions are absent.  Only
+            # rebuild attributions in-place when the usage data itself is
+            # still fresh — otherwise the missing attributions may be
+            # hiding a genuinely stale store (#1514).
+            usage_age = (
+                datetime.now(timezone.utc).timestamp() - usage_file.stat().st_mtime
+            )
+            if usage_age <= _STALE_THRESHOLD_SECONDS:
+                # Fresh usage, missing attr — rebuild without re-import (#1505)
+                attribute_sessions(output_dir=output_dir)
+                logger.info("Rebuilt missing attributions from existing usage data")
+                return
+            # Usage data is also stale — fall through to full re-import
 
         result = import_usage_data(output_dir=output_dir)
-        if result.sessions_imported > 0 or result.sessions_skipped > 0:
+        # Always attribute when attributions were missing, even if the
+        # re-import found no new sessions (data may already be present).
+        if result.sessions_imported > 0 or result.sessions_skipped > 0 or attr_missing:
             attribute_sessions(output_dir=output_dir)
         logger.info(
             "Auto-imported token economy data: %d new, %d skipped",

--- a/tests/unit/test_ops_token_economy.py
+++ b/tests/unit/test_ops_token_economy.py
@@ -1478,6 +1478,105 @@ class TestAutoImport:
         # import_usage_data should NOT be called — usage data already exists
         mock_import.assert_not_called()
 
+    def test_stale_usage_with_missing_attr_does_full_reimport(
+        self, tmp_path: Path
+    ) -> None:
+        """When usage exists but is stale AND attributions are missing,
+        do a full re-import rather than rebuilding from stale data (#1514)."""
+        import os
+        from datetime import datetime, timezone
+        from unittest.mock import MagicMock, patch
+
+        output_dir = tmp_path / "token_economy"
+        output_dir.mkdir()
+
+        # Write usage data
+        usage_file = output_dir / "session_usage.jsonl"
+        usage_file.write_text(
+            json.dumps(
+                {
+                    "session_id": "s1",
+                    "input_tokens": 100,
+                    "output_tokens": 400,
+                    "duration_minutes": 10,
+                    "project_path": "/tmp/test",
+                    "imported_at": "2026-03-20T10:00:00Z",
+                    "source_hash": "abc123",
+                }
+            )
+            + "\n"
+        )
+        # Make usage file look stale (> 1 hour old)
+        old_mtime = datetime.now(timezone.utc).timestamp() - 7200  # 2 hours ago
+        os.utime(usage_file, (old_mtime, old_mtime))
+        # No attributions file — simulates crashed import on stale data
+
+        mock_result = MagicMock()
+        mock_result.sessions_imported = 1
+        mock_result.sessions_skipped = 0
+
+        with (
+            patch(
+                "bid_euchre.ops.token_economy.import_usage_data",
+                return_value=mock_result,
+            ) as mock_import,
+            patch("bid_euchre.ops.token_economy.attribute_sessions") as mock_attr,
+        ):
+            _ensure_imported(output_dir)
+
+        # Should do full re-import, not just rebuild attributions
+        mock_import.assert_called_once_with(output_dir=output_dir)
+        mock_attr.assert_called_once_with(output_dir=output_dir)
+
+    def test_stale_usage_with_missing_attr_rebuilds_even_if_no_new_sessions(
+        self, tmp_path: Path
+    ) -> None:
+        """When full re-import finds 0 new sessions but attributions were
+        missing, still rebuild attributions (#1514)."""
+        import os
+        from datetime import datetime, timezone
+        from unittest.mock import MagicMock, patch
+
+        output_dir = tmp_path / "token_economy"
+        output_dir.mkdir()
+
+        usage_file = output_dir / "session_usage.jsonl"
+        usage_file.write_text(
+            json.dumps(
+                {
+                    "session_id": "s1",
+                    "input_tokens": 100,
+                    "output_tokens": 400,
+                    "duration_minutes": 10,
+                    "project_path": "/tmp/test",
+                    "imported_at": "2026-03-20T10:00:00Z",
+                    "source_hash": "abc123",
+                }
+            )
+            + "\n"
+        )
+        old_mtime = datetime.now(timezone.utc).timestamp() - 7200
+        os.utime(usage_file, (old_mtime, old_mtime))
+
+        mock_result = MagicMock()
+        mock_result.sessions_imported = 0
+        mock_result.sessions_skipped = 0
+
+        with (
+            patch(
+                "bid_euchre.ops.token_economy.import_usage_data",
+                return_value=mock_result,
+            ) as mock_import,
+            patch("bid_euchre.ops.token_economy.attribute_sessions") as mock_attr,
+        ):
+            _ensure_imported(output_dir)
+
+        # Full re-import was attempted
+        mock_import.assert_called_once()
+        # attr_missing is True → attribute_sessions should still be called
+        # even though no new sessions were imported
+        mock_attr.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # Incomplete session exclusion tests


### PR DESCRIPTION
## Plan
N/A — convention follow-up fixes from review findings.

## Summary
- When usage data is fresh but attributions are missing, rebuild attributions without re-importing host usage (#1505)
- When usage data is stale AND attributions are missing, do a full re-import instead of returning early (#1514)
- Ensure `attribute_sessions` runs after re-import when attributions were missing, even if 0 new sessions were imported

## Why
The `_ensure_imported` function had a logic gap: missing attributions always
triggered an early return that rebuilt them from existing usage data — even when
that usage data was itself stale (>1 hour old). This masked genuine staleness
and could produce attributions from outdated session records.

Closes #1505
Closes #1514

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_token_economy.py -v
```

**Config:** N/A
**Seed:** N/A

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_token_economy.py -v` — 83 passed
- [x] Added 2 new tests:
  - `test_stale_usage_with_missing_attr_does_full_reimport` — verifies stale usage + missing attr → full re-import
  - `test_stale_usage_with_missing_attr_rebuilds_even_if_no_new_sessions` — verifies attr rebuild after 0-session re-import

## Expected impact
- Metrics impact: None (ops/dashboard only)
- Runtime impact: None

## Risk level
- [x] Low (ops utility, no core logic)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre  c7ce0600 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c  9cb5fe1c [fix/token-economy-attribution-stale-1505-1514]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)