### PR TITLE
feat(ops): add audit trail writer for remote channel exchanges

### DIFF
--- a/src/bid_euchre/ops/__init__.py
+++ b/src/bid_euchre/ops/__init__.py
@@ -26,6 +26,7 @@ Modules:
     supervisor  -- Supervisor routines and delta summaries (Platform-6)
     worker_pool -- Worker pool lifecycle management (Platform-7)
     token_economy -- Token economy observability (usage data import/rollups)
+    audit_trail -- Durable audit trail for remote channel exchanges (Platform-8b)
 """
 
 # Shared constant: GitHub status/check context names that represent

--- a/src/bid_euchre/ops/audit_trail.py
+++ b/src/bid_euchre/ops/audit_trail.py
@@ -1,0 +1,279 @@
+"""Durable audit trail for remote channel exchanges (Platform-8b).
+
+Records every inbound and outbound remote exchange (Telegram, future Discord)
+to a repo-owned JSONL file for cross-session traceability and incident forensics.
+
+Storage layout::
+
+    .claude/runtime/audit_trail/
+        remote_exchanges.jsonl    # Append-only audit log
+        .remote_exchanges.lock    # flock file
+
+The audit trail is separate from the lane-to-lane message bus. It captures
+external channel traffic (operator ↔ orchestrator via Telegram), not internal
+lane communication.
+
+Design decisions:
+- Content hash + preview (not full content) to limit sensitive data exposure
+- Reuses the flock+JSONL pattern from ``message_bus.py`` and ``events.py``
+- No event emission in v1 — append-only; dashboard integration deferred
+"""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import logging
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("ops.audit_trail")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_AUDIT_DIR = Path(".claude/runtime/audit_trail")
+EXCHANGES_FILE = "remote_exchanges.jsonl"
+LOCK_FILE = ".remote_exchanges.lock"
+
+VALID_DIRECTIONS = frozenset({"inbound", "outbound"})
+
+VALID_EXCHANGE_TYPES = frozenset(
+    {
+        "message",
+        "reply",
+        "react",
+        "edit",
+        "download_attachment",
+        "permission_relay_observed",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def content_hash(text: str) -> str:
+    """Return the SHA-256 hex digest of *text*.
+
+    >>> content_hash("hello")
+    '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
+    """
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def content_preview(text: str, max_len: int = 200) -> str:
+    """Return the first *max_len* characters of *text*, adding '…' if truncated.
+
+    >>> content_preview("short")
+    'short'
+    >>> len(content_preview("x" * 300)) <= 201  # 200 chars + ellipsis
+    True
+    """
+    if len(text) <= max_len:
+        return text
+    return text[:max_len] + "…"
+
+
+def _now_iso() -> str:
+    """Return current UTC time as ISO 8601 string."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AuditRecord:
+    """One recorded remote exchange.
+
+    All fields are set at creation time and never mutated.
+    """
+
+    exchange_id: str
+    timestamp: str
+    direction: str
+    channel_source: str
+    sender_identity: str
+    exchange_type: str
+    content_hash: str
+    content_preview: str
+    chat_id: str
+    message_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.direction not in VALID_DIRECTIONS:
+            raise ValueError(
+                f"Invalid direction {self.direction!r}. "
+                f"Must be one of: {sorted(VALID_DIRECTIONS)}"
+            )
+        if self.exchange_type not in VALID_EXCHANGE_TYPES:
+            raise ValueError(
+                f"Invalid exchange_type {self.exchange_type!r}. "
+                f"Must be one of: {sorted(VALID_EXCHANGE_TYPES)}"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain dict suitable for JSON encoding."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AuditRecord:
+        """Deserialize from a dict (e.g. parsed from JSONL)."""
+        return cls(**data)
+
+
+def create_record(
+    direction: str,
+    channel_source: str,
+    sender_identity: str,
+    exchange_type: str,
+    content: str,
+    chat_id: str,
+    message_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    timestamp: str | None = None,
+) -> AuditRecord:
+    """Create a new :class:`AuditRecord` with auto-generated ID, hash, and preview.
+
+    This is the preferred constructor — it computes ``exchange_id``,
+    ``content_hash``, and ``content_preview`` automatically.
+    """
+    return AuditRecord(
+        exchange_id=str(uuid.uuid4()),
+        timestamp=timestamp or _now_iso(),
+        direction=direction,
+        channel_source=channel_source,
+        sender_identity=sender_identity,
+        exchange_type=exchange_type,
+        content_hash=content_hash(content),
+        content_preview=content_preview(content),
+        chat_id=chat_id,
+        message_id=message_id,
+        metadata=metadata or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------------------
+
+
+def _append_jsonl(path: Path, data: dict[str, Any], lock_path: Path) -> None:
+    """Append a JSON line to a file under flock protection.
+
+    Same flock pattern as ``message_bus._append_jsonl()`` and
+    ``events.append_event()``.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "a") as lock_fh:
+        fcntl.flock(lock_fh, fcntl.LOCK_EX)
+        try:
+            with open(path, "a") as f:
+                f.write(json.dumps(data, sort_keys=True, default=str) + "\n")
+                f.flush()
+        finally:
+            fcntl.flock(lock_fh, fcntl.LOCK_UN)
+
+
+def append_record(record: AuditRecord, audit_dir: Path | None = None) -> None:
+    """Append an :class:`AuditRecord` to the audit trail JSONL file.
+
+    Args:
+        record: The audit record to persist.
+        audit_dir: Override for audit trail directory. Defaults to
+            ``.claude/runtime/audit_trail``.
+    """
+    if audit_dir is None:
+        audit_dir = DEFAULT_AUDIT_DIR
+
+    exchanges_path = audit_dir / EXCHANGES_FILE
+    lock_path = audit_dir / LOCK_FILE
+
+    _append_jsonl(exchanges_path, record.to_dict(), lock_path)
+    logger.debug(
+        "Audit record appended: %s (%s)", record.exchange_id, record.exchange_type
+    )
+
+
+def read_records(
+    audit_dir: Path | None = None,
+    *,
+    direction: str | None = None,
+    channel_source: str | None = None,
+    since: datetime | None = None,
+    limit: int | None = None,
+) -> list[AuditRecord]:
+    """Read audit records from the JSONL file with optional filtering.
+
+    Args:
+        audit_dir: Override for audit trail directory. Defaults to
+            ``.claude/runtime/audit_trail``.
+        direction: Filter by ``"inbound"`` or ``"outbound"``.
+        channel_source: Filter by channel (e.g. ``"telegram"``).
+        since: Only return records with timestamp >= this datetime.
+        limit: Maximum number of records to return (most recent first
+            after filtering; ``None`` means no limit).
+
+    Returns:
+        List of :class:`AuditRecord` instances matching the filters,
+        in chronological order (oldest first). If *limit* is specified,
+        returns the **last** *limit* records after filtering.
+    """
+    if audit_dir is None:
+        audit_dir = DEFAULT_AUDIT_DIR
+
+    exchanges_path = audit_dir / EXCHANGES_FILE
+
+    if not exchanges_path.exists():
+        return []
+
+    records: list[AuditRecord] = []
+    with open(exchanges_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("Skipping malformed JSONL line in audit trail")
+                continue
+
+            # Apply filters
+            if direction is not None and data.get("direction") != direction:
+                continue
+            if (
+                channel_source is not None
+                and data.get("channel_source") != channel_source
+            ):
+                continue
+            if since is not None:
+                record_ts = data.get("timestamp", "")
+                try:
+                    record_dt = datetime.fromisoformat(record_ts)
+                    if record_dt < since:
+                        continue
+                except (ValueError, TypeError):
+                    continue
+
+            try:
+                records.append(AuditRecord.from_dict(data))
+            except (TypeError, ValueError) as exc:
+                logger.warning("Skipping invalid audit record: %s", exc)
+                continue
+
+    if limit is not None and len(records) > limit:
+        records = records[-limit:]
+
+    return records

--- a/tests/unit/test_audit_trail.py
+++ b/tests/unit/test_audit_trail.py
@@ -1,0 +1,491 @@
+"""Unit tests for the remote exchange audit trail (Platform-8b, SP-4-06 PR 1)."""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from bid_euchre.ops.audit_trail import (
+    VALID_DIRECTIONS,
+    VALID_EXCHANGE_TYPES,
+    AuditRecord,
+    append_record,
+    content_hash,
+    content_preview,
+    create_record,
+    read_records,
+)
+
+# ---------------------------------------------------------------------------
+# content_hash
+# ---------------------------------------------------------------------------
+
+
+class TestContentHash:
+    def test_deterministic(self) -> None:
+        """Same input always produces same hash."""
+        assert content_hash("hello") == content_hash("hello")
+
+    def test_known_value(self) -> None:
+        """Verify against known SHA-256 digest."""
+        expected = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        assert content_hash("hello") == expected
+
+    def test_different_inputs(self) -> None:
+        """Different inputs produce different hashes."""
+        assert content_hash("hello") != content_hash("world")
+
+    def test_empty_string(self) -> None:
+        """Empty string is hashable."""
+        h = content_hash("")
+        assert isinstance(h, str)
+        assert len(h) == 64  # SHA-256 hex length
+
+
+# ---------------------------------------------------------------------------
+# content_preview
+# ---------------------------------------------------------------------------
+
+
+class TestContentPreview:
+    def test_short_text_unchanged(self) -> None:
+        assert content_preview("short") == "short"
+
+    def test_exact_limit(self) -> None:
+        text = "x" * 200
+        assert content_preview(text) == text  # No truncation
+
+    def test_truncation(self) -> None:
+        text = "x" * 300
+        result = content_preview(text)
+        assert result == "x" * 200 + "…"
+        assert len(result) == 201  # 200 chars + ellipsis
+
+    def test_custom_limit(self) -> None:
+        text = "hello world"
+        result = content_preview(text, max_len=5)
+        assert result == "hello…"
+
+    def test_empty_string(self) -> None:
+        assert content_preview("") == ""
+
+
+# ---------------------------------------------------------------------------
+# AuditRecord
+# ---------------------------------------------------------------------------
+
+
+class TestAuditRecord:
+    def _make_record(self, **overrides: object) -> AuditRecord:
+        defaults = {
+            "exchange_id": "test-id-1234",
+            "timestamp": "2026-03-24T06:00:00+00:00",
+            "direction": "inbound",
+            "channel_source": "telegram",
+            "sender_identity": "user123",
+            "exchange_type": "message",
+            "content_hash": content_hash("test message"),
+            "content_preview": "test message",
+            "chat_id": "8122530898",
+            "message_id": "42",
+            "metadata": {},
+        }
+        defaults.update(overrides)
+        return AuditRecord(**defaults)
+
+    def test_frozen(self) -> None:
+        record = self._make_record()
+        with pytest.raises(AttributeError):
+            record.direction = "outbound"  # type: ignore[misc]
+
+    def test_valid_directions(self) -> None:
+        for d in VALID_DIRECTIONS:
+            record = self._make_record(direction=d)
+            assert record.direction == d
+
+    def test_invalid_direction(self) -> None:
+        with pytest.raises(ValueError, match="Invalid direction"):
+            self._make_record(direction="sideways")
+
+    def test_valid_exchange_types(self) -> None:
+        for et in VALID_EXCHANGE_TYPES:
+            record = self._make_record(exchange_type=et)
+            assert record.exchange_type == et
+
+    def test_invalid_exchange_type(self) -> None:
+        with pytest.raises(ValueError, match="Invalid exchange_type"):
+            self._make_record(exchange_type="teleport")
+
+    def test_message_id_optional(self) -> None:
+        record = self._make_record(message_id=None)
+        assert record.message_id is None
+
+    def test_metadata_default_empty(self) -> None:
+        record = AuditRecord(
+            exchange_id="id",
+            timestamp="2026-01-01T00:00:00+00:00",
+            direction="inbound",
+            channel_source="telegram",
+            sender_identity="user",
+            exchange_type="message",
+            content_hash="abc",
+            content_preview="hello",
+            chat_id="123",
+        )
+        assert record.metadata == {}
+
+    def test_serialization_round_trip(self) -> None:
+        original = self._make_record(metadata={"reply_to": "99", "extra": True})
+        d = original.to_dict()
+        restored = AuditRecord.from_dict(d)
+        assert restored == original
+
+    def test_to_dict_types(self) -> None:
+        record = self._make_record()
+        d = record.to_dict()
+        assert isinstance(d, dict)
+        assert d["exchange_id"] == "test-id-1234"
+        assert d["direction"] == "inbound"
+        assert d["metadata"] == {}
+
+
+# ---------------------------------------------------------------------------
+# create_record helper
+# ---------------------------------------------------------------------------
+
+
+class TestCreateRecord:
+    def test_auto_fields(self) -> None:
+        record = create_record(
+            direction="outbound",
+            channel_source="telegram",
+            sender_identity="orchestrator",
+            exchange_type="reply",
+            content="Hello operator!",
+            chat_id="8122530898",
+        )
+        # Auto-generated fields
+        assert len(record.exchange_id) == 36  # UUID4
+        assert record.timestamp  # Non-empty
+        assert record.content_hash == content_hash("Hello operator!")
+        assert record.content_preview == "Hello operator!"
+        assert record.metadata == {}
+
+    def test_explicit_timestamp(self) -> None:
+        ts = "2026-03-24T12:00:00+00:00"
+        record = create_record(
+            direction="inbound",
+            channel_source="telegram",
+            sender_identity="user",
+            exchange_type="message",
+            content="test",
+            chat_id="123",
+            timestamp=ts,
+        )
+        assert record.timestamp == ts
+
+    def test_with_metadata(self) -> None:
+        meta = {"reply_to": "42", "files": ["/tmp/photo.jpg"]}
+        record = create_record(
+            direction="outbound",
+            channel_source="telegram",
+            sender_identity="orchestrator",
+            exchange_type="reply",
+            content="See attachment",
+            chat_id="123",
+            metadata=meta,
+        )
+        assert record.metadata == meta
+
+
+# ---------------------------------------------------------------------------
+# append_record + read_records
+# ---------------------------------------------------------------------------
+
+
+class TestAppendAndRead:
+    def test_append_and_read(self, tmp_path: Path) -> None:
+        record = create_record(
+            direction="inbound",
+            channel_source="telegram",
+            sender_identity="user123",
+            exchange_type="message",
+            content="Hello bot",
+            chat_id="8122530898",
+            message_id="1",
+        )
+        append_record(record, audit_dir=tmp_path)
+
+        records = read_records(audit_dir=tmp_path)
+        assert len(records) == 1
+        assert records[0] == record
+
+    def test_multiple_records(self, tmp_path: Path) -> None:
+        for i in range(5):
+            record = create_record(
+                direction="inbound" if i % 2 == 0 else "outbound",
+                channel_source="telegram",
+                sender_identity="user" if i % 2 == 0 else "orchestrator",
+                exchange_type="message" if i % 2 == 0 else "reply",
+                content=f"Message {i}",
+                chat_id="123",
+                message_id=str(i),
+            )
+            append_record(record, audit_dir=tmp_path)
+
+        records = read_records(audit_dir=tmp_path)
+        assert len(records) == 5
+
+    def test_empty_log(self, tmp_path: Path) -> None:
+        records = read_records(audit_dir=tmp_path)
+        assert records == []
+
+    def test_jsonl_format(self, tmp_path: Path) -> None:
+        record = create_record(
+            direction="outbound",
+            channel_source="telegram",
+            sender_identity="orchestrator",
+            exchange_type="reply",
+            content="hi",
+            chat_id="123",
+        )
+        append_record(record, audit_dir=tmp_path)
+
+        jsonl_path = tmp_path / "remote_exchanges.jsonl"
+        assert jsonl_path.exists()
+
+        lines = jsonl_path.read_text().strip().split("\n")
+        assert len(lines) == 1
+
+        data = json.loads(lines[0])
+        assert data["direction"] == "outbound"
+        assert data["exchange_type"] == "reply"
+
+    def test_creates_directory(self, tmp_path: Path) -> None:
+        nested = tmp_path / "deep" / "nested" / "audit"
+        record = create_record(
+            direction="inbound",
+            channel_source="telegram",
+            sender_identity="user",
+            exchange_type="message",
+            content="test",
+            chat_id="123",
+        )
+        append_record(record, audit_dir=nested)
+
+        records = read_records(audit_dir=nested)
+        assert len(records) == 1
+
+
+# ---------------------------------------------------------------------------
+# Filtering
+# ---------------------------------------------------------------------------
+
+
+class TestFiltering:
+    @pytest.fixture()
+    def populated_dir(self, tmp_path: Path) -> Path:
+        """Create an audit dir with mixed inbound/outbound records."""
+        records_data = [
+            (
+                "inbound",
+                "telegram",
+                "user1",
+                "message",
+                "Hello",
+                "2026-03-24T01:00:00+00:00",
+            ),
+            (
+                "outbound",
+                "telegram",
+                "orchestrator",
+                "reply",
+                "Hi there",
+                "2026-03-24T02:00:00+00:00",
+            ),
+            (
+                "inbound",
+                "telegram",
+                "user1",
+                "message",
+                "Status?",
+                "2026-03-24T03:00:00+00:00",
+            ),
+            (
+                "outbound",
+                "telegram",
+                "orchestrator",
+                "react",
+                "👍",
+                "2026-03-24T04:00:00+00:00",
+            ),
+            (
+                "outbound",
+                "telegram",
+                "orchestrator",
+                "reply",
+                "All good",
+                "2026-03-24T05:00:00+00:00",
+            ),
+        ]
+        for direction, source, sender, etype, content, ts in records_data:
+            record = create_record(
+                direction=direction,
+                channel_source=source,
+                sender_identity=sender,
+                exchange_type=etype,
+                content=content,
+                chat_id="123",
+                timestamp=ts,
+            )
+            append_record(record, audit_dir=tmp_path)
+        return tmp_path
+
+    def test_filter_by_direction_inbound(self, populated_dir: Path) -> None:
+        records = read_records(audit_dir=populated_dir, direction="inbound")
+        assert len(records) == 2
+        assert all(r.direction == "inbound" for r in records)
+
+    def test_filter_by_direction_outbound(self, populated_dir: Path) -> None:
+        records = read_records(audit_dir=populated_dir, direction="outbound")
+        assert len(records) == 3
+        assert all(r.direction == "outbound" for r in records)
+
+    def test_filter_by_channel_source(self, populated_dir: Path) -> None:
+        records = read_records(audit_dir=populated_dir, channel_source="telegram")
+        assert len(records) == 5  # All are telegram
+
+        records = read_records(audit_dir=populated_dir, channel_source="discord")
+        assert len(records) == 0
+
+    def test_filter_by_since(self, populated_dir: Path) -> None:
+        since = datetime(2026, 3, 24, 3, 0, 0, tzinfo=timezone.utc)
+        records = read_records(audit_dir=populated_dir, since=since)
+        assert len(records) == 3  # Records at 03:00, 04:00, 05:00
+
+    def test_filter_combined(self, populated_dir: Path) -> None:
+        since = datetime(2026, 3, 24, 2, 0, 0, tzinfo=timezone.utc)
+        records = read_records(
+            audit_dir=populated_dir,
+            direction="outbound",
+            since=since,
+        )
+        assert len(records) == 3  # Outbound at 02:00, 04:00, 05:00
+
+    def test_limit(self, populated_dir: Path) -> None:
+        records = read_records(audit_dir=populated_dir, limit=2)
+        assert len(records) == 2
+        # Should be the last 2 records (most recent)
+        assert records[0].content_preview == "👍"  # 04:00
+        assert records[1].content_preview == "All good"  # 05:00
+
+    def test_limit_larger_than_total(self, populated_dir: Path) -> None:
+        records = read_records(audit_dir=populated_dir, limit=100)
+        assert len(records) == 5
+
+
+# ---------------------------------------------------------------------------
+# Concurrent-write safety (flock)
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentWrite:
+    def test_concurrent_appends(self, tmp_path: Path) -> None:
+        """Multiple threads writing simultaneously should not corrupt the file."""
+        n_threads = 10
+        n_per_thread = 20
+        errors: list[Exception] = []
+
+        def writer(thread_id: int) -> None:
+            try:
+                for i in range(n_per_thread):
+                    record = create_record(
+                        direction="outbound",
+                        channel_source="telegram",
+                        sender_identity=f"thread-{thread_id}",
+                        exchange_type="reply",
+                        content=f"Thread {thread_id} message {i}",
+                        chat_id="123",
+                        message_id=f"{thread_id}-{i}",
+                    )
+                    append_record(record, audit_dir=tmp_path)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=writer, args=(t,)) for t in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Concurrent writes produced errors: {errors}"
+
+        # Verify all records are present and parseable
+        records = read_records(audit_dir=tmp_path)
+        assert len(records) == n_threads * n_per_thread
+
+        # Verify JSONL file is not corrupted (each line is valid JSON)
+        jsonl_path = tmp_path / "remote_exchanges.jsonl"
+        lines = jsonl_path.read_text().strip().split("\n")
+        assert len(lines) == n_threads * n_per_thread
+        for line_no, line in enumerate(lines, 1):
+            try:
+                json.loads(line)
+            except json.JSONDecodeError:
+                pytest.fail(f"Corrupted JSONL at line {line_no}: {line!r}")
+
+
+# ---------------------------------------------------------------------------
+# Malformed data resilience
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedData:
+    def test_malformed_jsonl_skipped(self, tmp_path: Path) -> None:
+        """Malformed lines in the JSONL file are skipped gracefully."""
+        jsonl_path = tmp_path / "remote_exchanges.jsonl"
+        jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Write a valid record, a corrupt line, and another valid record
+        valid_record = create_record(
+            direction="inbound",
+            channel_source="telegram",
+            sender_identity="user",
+            exchange_type="message",
+            content="valid",
+            chat_id="123",
+            timestamp="2026-03-24T01:00:00+00:00",
+        )
+        with open(jsonl_path, "w") as f:
+            f.write(json.dumps(valid_record.to_dict(), sort_keys=True) + "\n")
+            f.write("THIS IS NOT JSON\n")
+            f.write(json.dumps(valid_record.to_dict(), sort_keys=True) + "\n")
+
+        records = read_records(audit_dir=tmp_path)
+        # Both valid records should parse (they have the same exchange_id so
+        # they'll both come back); the corrupt line is skipped.
+        assert len(records) == 2
+
+    def test_empty_lines_skipped(self, tmp_path: Path) -> None:
+        jsonl_path = tmp_path / "remote_exchanges.jsonl"
+        jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+
+        valid_record = create_record(
+            direction="inbound",
+            channel_source="telegram",
+            sender_identity="user",
+            exchange_type="message",
+            content="valid",
+            chat_id="123",
+        )
+        with open(jsonl_path, "w") as f:
+            f.write("\n\n")
+            f.write(json.dumps(valid_record.to_dict(), sort_keys=True) + "\n")
+            f.write("\n")
+
+        records = read_records(audit_dir=tmp_path)
+        assert len(records) == 1


### PR DESCRIPTION
## Summary
- New `src/bid_euchre/ops/audit_trail.py` — core audit trail writer for Platform-8b
- New `tests/unit/test_audit_trail.py` — 36 unit tests covering all API surface
- Updated `src/bid_euchre/ops/__init__.py` — module listing

## Why
Platform-8b (SP-4-06) requires durable, repo-owned audit logging of all remote channel exchanges (Telegram → orchestrator and back). This is PR 1 of 4: the core writer/reader library that subsequent PRs will use for outbound wrappers (PR 2), inbound helpers (PR 3), and integration tests (PR 4).

**Plan reference:** `plans/agent_ops/4_remote_channel/sub/2026-03-24_platform-8b-audit-trail.md`

## What's included
- `AuditRecord` frozen dataclass with validated `direction` and `exchange_type` fields
- `content_hash(text)` — SHA-256 hex digest
- `content_preview(text, max_len=200)` — safe truncation with ellipsis
- `create_record(...)` — convenience constructor with auto-generated UUID, hash, preview
- `append_record(record, audit_dir)` — JSONL append with flock (reuses `message_bus.py` pattern)
- `read_records(audit_dir, *, direction, channel_source, since, limit)` — filtered reader
- Storage: `.claude/runtime/audit_trail/remote_exchanges.jsonl` (runtime, not committed)

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_audit_trail.py -v  # 36 passed
make check-quiet  # All checks passed
```

## Tests
- 36 unit tests: content hash, content preview, AuditRecord validation, serialization round-trip, append+read, filtering (direction/channel/since/limit), concurrent-write safety (10 threads × 20 writes), malformed-data resilience

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: ops/sp-4-06-audit-trail-writer
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)