### PR TITLE
feat(ops): add --watch flag to dashboard for auto-refresh

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -1,6 +1,7 @@
 """Operator CLI — single entrypoint for steward workspace health.
 
 Usage:
+    uv run python scripts/internal/ops.py dashboard [--watch] [--interval N] [--no-probe] [--json]
     uv run python scripts/internal/ops.py status [--json]
     uv run python scripts/internal/ops.py worktrees [--json]
     uv run python scripts/internal/ops.py events [--type TYPE] [--lane LANE] [--limit N] [--json]
@@ -141,6 +142,8 @@ def cmd_status(args: argparse.Namespace) -> int:
 
 def cmd_dashboard(args: argparse.Namespace) -> int:
     """Dashboard-first steward supervision surface."""
+    import time
+
     dashboard_action = getattr(args, "dashboard_action", None)
 
     if dashboard_action == "set-visibility":
@@ -162,15 +165,35 @@ def cmd_dashboard(args: argparse.Namespace) -> int:
         format_dashboard_text,
     )
 
-    view = build_dashboard_view(
-        args.runtime_dir,
-        check_worktree=not getattr(args, "no_probe", False),
-    )
+    watch = getattr(args, "watch", False)
+    interval = getattr(args, "interval", 30)
 
-    if args.json:
-        print(json.dumps(format_dashboard_json(view), indent=2))
-    else:
-        print(format_dashboard_text(view))
+    try:
+        while True:
+            view = build_dashboard_view(
+                args.runtime_dir,
+                check_worktree=not getattr(args, "no_probe", False),
+            )
+
+            if watch:
+                # Clear screen for clean refresh
+                print("\033[2J\033[H", end="", flush=True)
+
+            if args.json:
+                print(json.dumps(format_dashboard_json(view), indent=2))
+            else:
+                print(format_dashboard_text(view))
+
+            if not watch:
+                break
+
+            print(f"\n--- Refreshing every {interval}s (Ctrl+C to stop) ---")
+            sys.stdout.flush()
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        if watch:
+            print("\nWatch stopped.")
+        return 0
 
     return 0
 
@@ -2728,6 +2751,19 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         default=False,
         help="Skip dirty-worktree subprocess probes (faster)",
+    )
+    dash_parser.add_argument(
+        "--watch",
+        "-w",
+        action="store_true",
+        default=False,
+        help="Auto-refresh dashboard in a loop (Ctrl+C to stop)",
+    )
+    dash_parser.add_argument(
+        "--interval",
+        type=int,
+        default=30,
+        help="Refresh interval in seconds when --watch is active (default: 30)",
     )
     dash_sub = dash_parser.add_subparsers(dest="dashboard_action")
     set_vis = dash_sub.add_parser(

--- a/tests/unit/test_ops_dashboard.py
+++ b/tests/unit/test_ops_dashboard.py
@@ -761,3 +761,77 @@ class TestDashboardIntegration:
         text = format_dashboard_text(view, now=now)
         assert "Inbox" in text
         assert "unacked" in text
+
+
+# ---------------------------------------------------------------------------
+# Tests: --watch flag CLI integration
+# ---------------------------------------------------------------------------
+
+
+class TestDashboardWatchFlag:
+    """Tests for the --watch / --interval CLI flags on cmd_dashboard."""
+
+    def test_watch_args_parsed(self) -> None:
+        """--watch and --interval are accepted by the argument parser."""
+        import subprocess
+
+        result = subprocess.run(
+            ["uv", "run", "python", "scripts/internal/ops.py", "dashboard", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert "--watch" in result.stdout
+        assert "--interval" in result.stdout
+
+    def test_single_shot_runs_via_cli(self) -> None:
+        """Without --watch, dashboard prints once and exits with rc=0."""
+        import subprocess
+
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "python",
+                "scripts/internal/ops.py",
+                "dashboard",
+                "--no-probe",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0
+        assert "Steward Dashboard" in result.stdout
+
+    def test_watch_flag_accepted(self) -> None:
+        """--watch -w and --interval are accepted without error.
+
+        We start watch mode with a short interval and send SIGINT after
+        one iteration to verify the loop starts and exits cleanly.
+        """
+        import signal
+        import subprocess
+        import time as time_mod
+
+        proc = subprocess.Popen(
+            [
+                "uv",
+                "run",
+                "python",
+                "scripts/internal/ops.py",
+                "dashboard",
+                "--no-probe",
+                "--watch",
+                "--interval",
+                "1",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        # Give it time to print one iteration
+        time_mod.sleep(2)
+        proc.send_signal(signal.SIGINT)
+        stdout, _ = proc.communicate(timeout=5)
+        output = stdout.decode()
+        assert "Steward Dashboard" in output
+        assert "Refreshing every 1s" in output


### PR DESCRIPTION
## Summary
- Add `--watch` / `-w` flag to `ops.py dashboard` for live auto-refresh
- Add `--interval N` flag (default 30 seconds) to control refresh rate
- Ctrl+C exits cleanly with "Watch stopped." message

## Why
Operators monitoring the steward fleet need to leave a terminal with a
live-updating dashboard. Currently they must re-run the command manually.
This is the minimal useful slice of #1337 (full live-refresh is larger scope).

## Repro / Validation

```bash
# Single-shot (existing behavior, unchanged):
uv run python scripts/internal/ops.py dashboard --no-probe

# Watch mode:
uv run python scripts/internal/ops.py dashboard --no-probe --watch --interval 5

# Verify help:
uv run python scripts/internal/ops.py dashboard --help
```

## Tests

```bash
uv run python -m pytest tests/unit/test_ops_dashboard.py -v  # 39 pass (36 existing + 3 new)
make check-quiet                                              # All checks passed
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: ops/dashboard-watch-flag
```

Partially addresses #1337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)