### PR TITLE
feat(ops): add outbound audit wrappers (SP-4-06 PR 2)

### DIFF
--- a/src/bid_euchre/ops/audit_trail.py
+++ b/src/bid_euchre/ops/audit_trail.py
@@ -206,6 +206,119 @@ def append_record(record: AuditRecord, audit_dir: Path | None = None) -> None:
     )
 
 
+# ---------------------------------------------------------------------------
+# Outbound audit wrappers
+# ---------------------------------------------------------------------------
+
+
+def audit_reply(
+    chat_id: str,
+    body: str,
+    reply_to: str | None = None,
+    files: list[str] | None = None,
+    audit_dir: Path | None = None,
+) -> AuditRecord:
+    """Log an outbound reply to the audit trail.
+
+    Creates an :class:`AuditRecord` with ``direction="outbound"`` and
+    ``exchange_type="reply"``, appends it, and returns it.
+
+    Args:
+        chat_id: Telegram chat ID the reply is sent to.
+        body: The reply text content.
+        reply_to: Optional message ID being replied to.
+        files: Optional list of file paths attached to the reply.
+        audit_dir: Override for audit trail directory.
+
+    Returns:
+        The persisted :class:`AuditRecord`.
+    """
+    metadata: dict[str, Any] = {}
+    if reply_to is not None:
+        metadata["reply_to"] = reply_to
+    if files:
+        metadata["files"] = files
+
+    record = create_record(
+        direction="outbound",
+        channel_source="telegram",
+        sender_identity="orchestrator",
+        exchange_type="reply",
+        content=body,
+        chat_id=chat_id,
+        metadata=metadata if metadata else None,
+    )
+    append_record(record, audit_dir=audit_dir)
+    return record
+
+
+def audit_react(
+    chat_id: str,
+    message_id: str,
+    emoji: str,
+    audit_dir: Path | None = None,
+) -> AuditRecord:
+    """Log an outbound reaction to the audit trail.
+
+    Creates an :class:`AuditRecord` with ``direction="outbound"`` and
+    ``exchange_type="react"``, appends it, and returns it.
+
+    Args:
+        chat_id: Telegram chat ID.
+        message_id: Message ID being reacted to.
+        emoji: The emoji reaction.
+        audit_dir: Override for audit trail directory.
+
+    Returns:
+        The persisted :class:`AuditRecord`.
+    """
+    record = create_record(
+        direction="outbound",
+        channel_source="telegram",
+        sender_identity="orchestrator",
+        exchange_type="react",
+        content=emoji,
+        chat_id=chat_id,
+        message_id=message_id,
+        metadata={"emoji": emoji},
+    )
+    append_record(record, audit_dir=audit_dir)
+    return record
+
+
+def audit_edit(
+    chat_id: str,
+    message_id: str,
+    body: str,
+    audit_dir: Path | None = None,
+) -> AuditRecord:
+    """Log an outbound message edit to the audit trail.
+
+    Creates an :class:`AuditRecord` with ``direction="outbound"`` and
+    ``exchange_type="edit"``, appends it, and returns it.
+
+    Args:
+        chat_id: Telegram chat ID.
+        message_id: Message ID being edited.
+        body: The new message text after editing.
+        audit_dir: Override for audit trail directory.
+
+    Returns:
+        The persisted :class:`AuditRecord`.
+    """
+    record = create_record(
+        direction="outbound",
+        channel_source="telegram",
+        sender_identity="orchestrator",
+        exchange_type="edit",
+        content=body,
+        chat_id=chat_id,
+        message_id=message_id,
+    )
+    append_record(record, audit_dir=audit_dir)
+    return record
+
+
 def read_records(
     audit_dir: Path | None = None,
     *,

--- a/tests/unit/test_audit_trail.py
+++ b/tests/unit/test_audit_trail.py
@@ -14,6 +14,9 @@ from bid_euchre.ops.audit_trail import (
     VALID_EXCHANGE_TYPES,
     AuditRecord,
     append_record,
+    audit_edit,
+    audit_react,
+    audit_reply,
     content_hash,
     content_preview,
     create_record,
@@ -489,3 +492,201 @@ class TestMalformedData:
 
         records = read_records(audit_dir=tmp_path)
         assert len(records) == 1
+
+
+# ---------------------------------------------------------------------------
+# Outbound audit wrappers (SP-4-06 PR 2)
+# ---------------------------------------------------------------------------
+
+
+class TestAuditReply:
+    def test_basic_reply(self, tmp_path: Path) -> None:
+        record = audit_reply(
+            chat_id="8122530898",
+            body="Hello operator!",
+            audit_dir=tmp_path,
+        )
+        assert record.direction == "outbound"
+        assert record.exchange_type == "reply"
+        assert record.channel_source == "telegram"
+        assert record.sender_identity == "orchestrator"
+        assert record.chat_id == "8122530898"
+        assert record.content_hash == content_hash("Hello operator!")
+        assert record.content_preview == "Hello operator!"
+        assert record.metadata == {}
+
+    def test_reply_with_reply_to(self, tmp_path: Path) -> None:
+        record = audit_reply(
+            chat_id="123",
+            body="Got it",
+            reply_to="42",
+            audit_dir=tmp_path,
+        )
+        assert record.metadata["reply_to"] == "42"
+
+    def test_reply_with_files(self, tmp_path: Path) -> None:
+        record = audit_reply(
+            chat_id="123",
+            body="See attached",
+            files=["/tmp/photo.jpg", "/tmp/doc.pdf"],
+            audit_dir=tmp_path,
+        )
+        assert record.metadata["files"] == ["/tmp/photo.jpg", "/tmp/doc.pdf"]
+
+    def test_reply_with_reply_to_and_files(self, tmp_path: Path) -> None:
+        record = audit_reply(
+            chat_id="123",
+            body="Here you go",
+            reply_to="99",
+            files=["/tmp/report.pdf"],
+            audit_dir=tmp_path,
+        )
+        assert record.metadata["reply_to"] == "99"
+        assert record.metadata["files"] == ["/tmp/report.pdf"]
+
+    def test_reply_persisted(self, tmp_path: Path) -> None:
+        """Verify the record is actually appended to the JSONL file."""
+        audit_reply(chat_id="123", body="test", audit_dir=tmp_path)
+        records = read_records(audit_dir=tmp_path)
+        assert len(records) == 1
+        assert records[0].exchange_type == "reply"
+        assert records[0].direction == "outbound"
+
+    def test_reply_returns_record(self, tmp_path: Path) -> None:
+        """audit_reply returns the same record that was persisted."""
+        returned = audit_reply(chat_id="123", body="check", audit_dir=tmp_path)
+        persisted = read_records(audit_dir=tmp_path)
+        assert len(persisted) == 1
+        assert returned == persisted[0]
+
+    def test_reply_long_body_preview_truncated(self, tmp_path: Path) -> None:
+        long_body = "x" * 500
+        record = audit_reply(chat_id="123", body=long_body, audit_dir=tmp_path)
+        assert record.content_preview == "x" * 200 + "…"
+        assert record.content_hash == content_hash(long_body)
+
+
+class TestAuditReact:
+    def test_basic_react(self, tmp_path: Path) -> None:
+        record = audit_react(
+            chat_id="8122530898",
+            message_id="42",
+            emoji="👍",
+            audit_dir=tmp_path,
+        )
+        assert record.direction == "outbound"
+        assert record.exchange_type == "react"
+        assert record.channel_source == "telegram"
+        assert record.sender_identity == "orchestrator"
+        assert record.chat_id == "8122530898"
+        assert record.message_id == "42"
+        assert record.metadata["emoji"] == "👍"
+        assert record.content_hash == content_hash("👍")
+        assert record.content_preview == "👍"
+
+    def test_react_persisted(self, tmp_path: Path) -> None:
+        audit_react(chat_id="123", message_id="10", emoji="🎉", audit_dir=tmp_path)
+        records = read_records(audit_dir=tmp_path)
+        assert len(records) == 1
+        assert records[0].exchange_type == "react"
+        assert records[0].metadata["emoji"] == "🎉"
+
+    def test_react_returns_record(self, tmp_path: Path) -> None:
+        returned = audit_react(
+            chat_id="123", message_id="10", emoji="✅", audit_dir=tmp_path
+        )
+        persisted = read_records(audit_dir=tmp_path)
+        assert len(persisted) == 1
+        assert returned == persisted[0]
+
+
+class TestAuditEdit:
+    def test_basic_edit(self, tmp_path: Path) -> None:
+        record = audit_edit(
+            chat_id="8122530898",
+            message_id="42",
+            body="Updated message text",
+            audit_dir=tmp_path,
+        )
+        assert record.direction == "outbound"
+        assert record.exchange_type == "edit"
+        assert record.channel_source == "telegram"
+        assert record.sender_identity == "orchestrator"
+        assert record.chat_id == "8122530898"
+        assert record.message_id == "42"
+        assert record.content_hash == content_hash("Updated message text")
+        assert record.content_preview == "Updated message text"
+
+    def test_edit_persisted(self, tmp_path: Path) -> None:
+        audit_edit(
+            chat_id="123",
+            message_id="10",
+            body="corrected text",
+            audit_dir=tmp_path,
+        )
+        records = read_records(audit_dir=tmp_path)
+        assert len(records) == 1
+        assert records[0].exchange_type == "edit"
+        assert records[0].direction == "outbound"
+
+    def test_edit_returns_record(self, tmp_path: Path) -> None:
+        returned = audit_edit(
+            chat_id="123",
+            message_id="10",
+            body="fixed",
+            audit_dir=tmp_path,
+        )
+        persisted = read_records(audit_dir=tmp_path)
+        assert len(persisted) == 1
+        assert returned == persisted[0]
+
+    def test_edit_long_body_preview_truncated(self, tmp_path: Path) -> None:
+        long_body = "y" * 400
+        record = audit_edit(
+            chat_id="123",
+            message_id="5",
+            body=long_body,
+            audit_dir=tmp_path,
+        )
+        assert record.content_preview == "y" * 200 + "…"
+        assert record.content_hash == content_hash(long_body)
+
+
+class TestOutboundWrapperIntegration:
+    """Cross-wrapper tests verifying they coexist in the same audit log."""
+
+    def test_mixed_outbound_sequence(self, tmp_path: Path) -> None:
+        """All three wrapper types write to the same log and can be read back."""
+        audit_reply(chat_id="123", body="Hello", audit_dir=tmp_path)
+        audit_react(chat_id="123", message_id="1", emoji="👍", audit_dir=tmp_path)
+        audit_edit(chat_id="123", message_id="2", body="Updated", audit_dir=tmp_path)
+
+        records = read_records(audit_dir=tmp_path)
+        assert len(records) == 3
+        types = [r.exchange_type for r in records]
+        assert types == ["reply", "react", "edit"]
+        assert all(r.direction == "outbound" for r in records)
+
+    def test_outbound_filter(self, tmp_path: Path) -> None:
+        """Outbound wrappers can be filtered from a mixed log."""
+        # Add an inbound record manually
+        inbound = create_record(
+            direction="inbound",
+            channel_source="telegram",
+            sender_identity="user",
+            exchange_type="message",
+            content="operator says hi",
+            chat_id="123",
+        )
+        append_record(inbound, audit_dir=tmp_path)
+
+        # Add outbound via wrappers
+        audit_reply(chat_id="123", body="reply text", audit_dir=tmp_path)
+        audit_react(chat_id="123", message_id="1", emoji="🎉", audit_dir=tmp_path)
+
+        all_records = read_records(audit_dir=tmp_path)
+        assert len(all_records) == 3
+
+        outbound = read_records(audit_dir=tmp_path, direction="outbound")
+        assert len(outbound) == 2
+        assert all(r.direction == "outbound" for r in outbound)


### PR DESCRIPTION
## Plan
`plans/agent_ops/4_remote_channel/sub/2026-03-24_platform-8b-audit-trail.md` — SP-4-06, PR 2

## Summary
- Add `audit_reply()`, `audit_react()`, and `audit_edit()` outbound wrappers to `audit_trail.py`
- Each creates an `AuditRecord` with `direction="outbound"` and appropriate `exchange_type`, appends to the JSONL log, and returns the record
- Add 16 new unit tests covering field correctness, metadata, persistence round-trips, content truncation, and cross-wrapper integration

## Why
Platform-8b requires every outbound remote exchange to be durably recorded. These wrappers provide a clean API for the orchestrator to call instead of raw MCP tool calls, ensuring outbound replies/reacts/edits are captured in the repo-owned audit trail.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_audit_trail.py -v  # 52 passed
make check-quiet                                            # All checks passed
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_audit_trail.py -v` — 52 passed (36 existing + 16 new)
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None (new internal ops module, no game engine changes)
- Runtime impact: None (audit wrappers only invoked during Telegram interactions)

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author  0f30426e [ops/sp-4-06-outbound-wrappers]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)