### PR TITLE
feat(browser-game): add export_hosted_decisions CLI script (SP-4-01)

### DIFF
--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -255,6 +255,7 @@ Every experiment run creates a standardized directory under `data/runs/<run_id>/
 | `scripts/internal/deterministic_prechecks.py` | Fast deterministic code checks (merge markers, RNG, imports) |
 | `scripts/internal/evaluate_diagnostic_tricks.py` | Diagnostic Ridge evaluation |
 | `scripts/internal/evaluate_gate_x3.py` | R1.5 Gate X3 offline ranking evaluation (action-value model vs oracle) |
+| `scripts/internal/export_hosted_decisions.py` | CLI wrapper for exporting hosted-play decisions to JSONL (SP-4-01 schema) |
 | `scripts/internal/extract_comparator_cis.py` | Bootstrap CIs for comparator battery metrics |
 | `scripts/internal/generate_action_value_dataset.py` | Counterfactual action-value dataset generator (R1.5) |
 | `scripts/internal/generate_advance_check.py` | Arc D v2 advance check generator (hypothesis + sufficiency + canary evaluation) |

--- a/scripts/internal/export_hosted_decisions.py
+++ b/scripts/internal/export_hosted_decisions.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+"""CLI wrapper for exporting hosted-play decisions to JSONL.
+
+Reads decisions from the hosted-play SQLite database and writes them
+as JSONL records matching the SP-4-01 schema (schema_version 1).
+
+Usage
+-----
+Export all decisions::
+
+    uv run python scripts/internal/export_hosted_decisions.py \
+        --db data/hosted/bideuchre.db \
+        --output data/hosted/export/decisions.jsonl
+
+Export decisions for a specific match::
+
+    uv run python scripts/internal/export_hosted_decisions.py \
+        --db data/hosted/bideuchre.db \
+        --match-uuid a1b2c3d4-... \
+        --output data/hosted/export/match_a1b2c3d4.jsonl
+
+Export only human decisions::
+
+    uv run python scripts/internal/export_hosted_decisions.py \
+        --db data/hosted/bideuchre.db \
+        --human-only \
+        --output data/hosted/export/human_decisions.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from web.db import Decision, Hand, Match, init_engine, make_session_factory
+from web.export import decision_to_jsonl
+
+
+def _build_query(
+    *,
+    match_uuid: str | None = None,
+    human_only: bool = False,
+):
+    """Build a SQLAlchemy select for decisions with match and hand context.
+
+    Returns a select() that yields (Decision, Match, Hand) tuples,
+    ordered by match_id, hand turn_number for deterministic output.
+    """
+    stmt = (
+        select(Decision, Match, Hand)
+        .join(Match, Decision.match_id == Match.id)
+        .join(Hand, Decision.hand_id == Hand.id)
+        .order_by(Decision.match_id, Decision.hand_id, Decision.turn_number)
+    )
+
+    if match_uuid is not None:
+        stmt = stmt.where(Match.match_uuid == match_uuid)
+
+    if human_only:
+        stmt = stmt.where(Decision.actor_type == "human")
+
+    return stmt
+
+
+def export_decisions(
+    session: Session,
+    output_path: Path,
+    *,
+    match_uuid: str | None = None,
+    human_only: bool = False,
+) -> int:
+    """Query decisions and write JSONL to *output_path*.
+
+    Parameters
+    ----------
+    session:
+        Active SQLAlchemy session.
+    output_path:
+        Destination file path. Parent directories are created if needed.
+    match_uuid:
+        If provided, restrict export to this match UUID.
+    human_only:
+        If True, restrict export to human decisions only.
+
+    Returns
+    -------
+    int
+        Number of records written.
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    stmt = _build_query(match_uuid=match_uuid, human_only=human_only)
+    rows = session.execute(stmt).all()
+
+    count = 0
+    with open(output_path, "w") as fh:
+        for decision_row, match_row, hand_row in rows:
+            record = decision_to_jsonl(decision_row, match_row, hand_row)
+            fh.write(json.dumps(record) + "\n")
+            count += 1
+
+    return count
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Export hosted-play decisions to JSONL (SP-4-01 schema).",
+    )
+    parser.add_argument(
+        "--db",
+        required=True,
+        type=Path,
+        help="Path to the SQLite database file.",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Output JSONL file path.",
+    )
+    parser.add_argument(
+        "--match-uuid",
+        default=None,
+        help="Filter to a specific match UUID.",
+    )
+    parser.add_argument(
+        "--human-only",
+        action="store_true",
+        default=False,
+        help="Export only human decisions (actor_type='human').",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the export CLI."""
+    args = _parse_args(argv)
+
+    db_path: Path = args.db
+    if not db_path.exists():
+        print(f"Error: database not found: {db_path}", file=sys.stderr)
+        return 1
+
+    database_url = f"sqlite:///{db_path.resolve()}"
+    engine = init_engine(database_url)
+    factory = make_session_factory(engine)
+    session = factory()
+
+    try:
+        count = export_decisions(
+            session,
+            args.output,
+            match_uuid=args.match_uuid,
+            human_only=args.human_only,
+        )
+    finally:
+        session.close()
+
+    print(f"{count} records exported to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/hosted_play/test_export_cli.py
+++ b/tests/unit/hosted_play/test_export_cli.py
@@ -1,0 +1,330 @@
+"""Tests for scripts/internal/export_hosted_decisions.py CLI.
+
+Tests the export_decisions() function and the CLI main() entry point
+using an in-memory SQLite database.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+
+# Import the CLI module's functions
+from scripts.internal.export_hosted_decisions import (
+    _build_query,
+    export_decisions,
+    main,
+)
+from web.db import (
+    Decision,
+    Hand,
+    Match,
+    Player,
+    create_tables,
+    init_engine,
+    make_session_factory,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures (reused pattern from test_export.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def engine():
+    """In-memory SQLite engine with tables created."""
+    eng = init_engine("sqlite:///:memory:")
+    create_tables(eng)
+    return eng
+
+
+@pytest.fixture()
+def session(engine):
+    """Scoped session that rolls back after each test."""
+    factory = make_session_factory(engine)
+    sess = factory()
+    yield sess
+    sess.rollback()
+    sess.close()
+
+
+def _make_player(session) -> Player:
+    player = Player(link_uuid=str(uuid.uuid4()), nickname="TestPlayer")
+    session.add(player)
+    session.flush()
+    return player
+
+
+def _make_match(session, player: Player, **overrides) -> Match:
+    defaults = {
+        "match_uuid": str(uuid.uuid4()),
+        "player_id": player.id,
+        "ai_model": "heuristic",
+        "status": "active",
+        "seed": 42,
+        "match_state_json": "{}",
+    }
+    defaults.update(overrides)
+    match = Match(**defaults)
+    session.add(match)
+    session.flush()
+    return match
+
+
+def _make_hand(session, match: Match, **overrides) -> Hand:
+    defaults = {
+        "match_id": match.id,
+        "hand_number": 1,
+        "deal_id": 7,
+        "dealer_seat": 2,
+        "status": "in_progress",
+        "hand_state_json": "{}",
+    }
+    defaults.update(overrides)
+    hand = Hand(**defaults)
+    session.add(hand)
+    session.flush()
+    return hand
+
+
+SAMPLE_LEGAL_ACTIONS = [{"n": 0}, {"n": 1, "contract": "S"}]
+SAMPLE_CHOSEN_ACTION = {"n": 1, "contract": "S"}
+SAMPLE_GAME_STATE = {"phase": "auction", "hand": [["S", "A"]]}
+
+
+def _make_decision(session, match: Match, hand: Hand, **overrides) -> Decision:
+    defaults = {
+        "match_id": match.id,
+        "hand_id": hand.id,
+        "turn_number": 0,
+        "seat": 0,
+        "phase": "bid",
+        "actor_type": "human",
+        "decision_source": "human",
+        "legal_actions_json": json.dumps(SAMPLE_LEGAL_ACTIONS),
+        "chosen_action_json": json.dumps(SAMPLE_CHOSEN_ACTION),
+        "game_state_json": json.dumps(SAMPLE_GAME_STATE),
+        "decision_time_ms": 4200,
+    }
+    defaults.update(overrides)
+    decision = Decision(**defaults)
+    session.add(decision)
+    session.flush()
+    return decision
+
+
+# ---------------------------------------------------------------------------
+# _build_query tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildQuery:
+    """Verify query filters work correctly."""
+
+    def test_unfiltered_returns_all(self, session):
+        player = _make_player(session)
+        match = _make_match(session, player)
+        hand = _make_hand(session, match)
+        _make_decision(session, match, hand, turn_number=0, actor_type="human")
+        _make_decision(session, match, hand, turn_number=1, actor_type="ai")
+        session.commit()
+
+        stmt = _build_query()
+        rows = session.execute(stmt).all()
+        assert len(rows) == 2
+
+    def test_match_uuid_filter(self, session):
+        player = _make_player(session)
+        target_uuid = str(uuid.uuid4())
+        match1 = _make_match(session, player, match_uuid=target_uuid)
+        match2 = _make_match(session, player)
+        hand1 = _make_hand(session, match1, hand_number=1)
+        hand2 = _make_hand(session, match2, hand_number=1)
+        _make_decision(session, match1, hand1, turn_number=0)
+        _make_decision(session, match2, hand2, turn_number=0)
+        session.commit()
+
+        stmt = _build_query(match_uuid=target_uuid)
+        rows = session.execute(stmt).all()
+        assert len(rows) == 1
+        assert rows[0][1].match_uuid == target_uuid
+
+    def test_human_only_filter(self, session):
+        player = _make_player(session)
+        match = _make_match(session, player)
+        hand = _make_hand(session, match)
+        _make_decision(session, match, hand, turn_number=0, actor_type="human")
+        _make_decision(session, match, hand, turn_number=1, actor_type="ai")
+        session.commit()
+
+        stmt = _build_query(human_only=True)
+        rows = session.execute(stmt).all()
+        assert len(rows) == 1
+        assert rows[0][0].actor_type == "human"
+
+    def test_combined_filters(self, session):
+        player = _make_player(session)
+        target_uuid = str(uuid.uuid4())
+        match1 = _make_match(session, player, match_uuid=target_uuid)
+        match2 = _make_match(session, player)
+        hand1 = _make_hand(session, match1, hand_number=1)
+        hand2 = _make_hand(session, match2, hand_number=1)
+        # Target match: one human, one AI
+        _make_decision(session, match1, hand1, turn_number=0, actor_type="human")
+        _make_decision(session, match1, hand1, turn_number=1, actor_type="ai")
+        # Other match: one human
+        _make_decision(session, match2, hand2, turn_number=0, actor_type="human")
+        session.commit()
+
+        stmt = _build_query(match_uuid=target_uuid, human_only=True)
+        rows = session.execute(stmt).all()
+        assert len(rows) == 1
+        assert rows[0][0].actor_type == "human"
+        assert rows[0][1].match_uuid == target_uuid
+
+
+# ---------------------------------------------------------------------------
+# export_decisions tests
+# ---------------------------------------------------------------------------
+
+
+class TestExportDecisions:
+    """Verify export_decisions writes correct JSONL files."""
+
+    def test_writes_jsonl_file(self, session, tmp_path):
+        player = _make_player(session)
+        match = _make_match(session, player)
+        hand = _make_hand(session, match)
+        _make_decision(session, match, hand, turn_number=0)
+        _make_decision(session, match, hand, turn_number=1, actor_type="ai")
+        session.commit()
+
+        output = tmp_path / "out.jsonl"
+        count = export_decisions(session, output)
+        assert count == 2
+        assert output.exists()
+
+        lines = output.read_text().strip().split("\n")
+        assert len(lines) == 2
+        for line in lines:
+            record = json.loads(line)
+            assert record["schema_version"] == 1
+
+    def test_empty_db_writes_empty_file(self, session, tmp_path):
+        session.commit()
+
+        output = tmp_path / "empty.jsonl"
+        count = export_decisions(session, output)
+        assert count == 0
+        assert output.exists()
+        assert output.read_text() == ""
+
+    def test_creates_parent_directories(self, session, tmp_path):
+        player = _make_player(session)
+        match = _make_match(session, player)
+        hand = _make_hand(session, match)
+        _make_decision(session, match, hand)
+        session.commit()
+
+        output = tmp_path / "nested" / "deep" / "out.jsonl"
+        count = export_decisions(session, output)
+        assert count == 1
+        assert output.exists()
+
+    def test_match_uuid_filter(self, session, tmp_path):
+        player = _make_player(session)
+        target_uuid = str(uuid.uuid4())
+        match1 = _make_match(session, player, match_uuid=target_uuid)
+        match2 = _make_match(session, player)
+        hand1 = _make_hand(session, match1, hand_number=1)
+        hand2 = _make_hand(session, match2, hand_number=1)
+        _make_decision(session, match1, hand1, turn_number=0)
+        _make_decision(session, match2, hand2, turn_number=0)
+        session.commit()
+
+        output = tmp_path / "filtered.jsonl"
+        count = export_decisions(session, output, match_uuid=target_uuid)
+        assert count == 1
+
+        record = json.loads(output.read_text().strip())
+        assert record["match_uuid"] == target_uuid
+
+    def test_human_only_filter(self, session, tmp_path):
+        player = _make_player(session)
+        match = _make_match(session, player)
+        hand = _make_hand(session, match)
+        _make_decision(session, match, hand, turn_number=0, actor_type="human")
+        _make_decision(session, match, hand, turn_number=1, actor_type="ai")
+        session.commit()
+
+        output = tmp_path / "human.jsonl"
+        count = export_decisions(session, output, human_only=True)
+        assert count == 1
+
+        record = json.loads(output.read_text().strip())
+        assert record["actor_type"] == "human"
+
+    def test_deterministic_ordering(self, session, tmp_path):
+        """Records are ordered by match_id, hand_id, turn_number."""
+        player = _make_player(session)
+        match = _make_match(session, player)
+        hand = _make_hand(session, match)
+        _make_decision(session, match, hand, turn_number=2, seat=2)
+        _make_decision(session, match, hand, turn_number=0, seat=0)
+        _make_decision(session, match, hand, turn_number=1, seat=1)
+        session.commit()
+
+        output = tmp_path / "ordered.jsonl"
+        export_decisions(session, output)
+
+        lines = output.read_text().strip().split("\n")
+        turns = [json.loads(line)["turn_number"] for line in lines]
+        assert turns == [0, 1, 2]
+
+
+# ---------------------------------------------------------------------------
+# CLI main() tests
+# ---------------------------------------------------------------------------
+
+
+class TestMainCLI:
+    """Test the main() entry point."""
+
+    def test_missing_db_returns_error(self, tmp_path):
+        """Non-existent DB file should return exit code 1."""
+        fake_db = tmp_path / "nonexistent.db"
+        output = tmp_path / "out.jsonl"
+        code = main(["--db", str(fake_db), "--output", str(output)])
+        assert code == 1
+
+    def test_export_from_real_db(self, tmp_path):
+        """End-to-end: create DB, populate, export via main()."""
+        db_path = tmp_path / "test.db"
+        engine = init_engine(f"sqlite:///{db_path}")
+        create_tables(engine)
+        factory = make_session_factory(engine)
+        sess = factory()
+
+        player = _make_player(sess)
+        match = _make_match(sess, player)
+        hand = _make_hand(sess, match)
+        _make_decision(sess, match, hand, turn_number=0)
+        _make_decision(sess, match, hand, turn_number=1, actor_type="ai")
+        sess.commit()
+        sess.close()
+
+        output = tmp_path / "export" / "decisions.jsonl"
+        code = main(["--db", str(db_path), "--output", str(output)])
+        assert code == 0
+        assert output.exists()
+
+        lines = output.read_text().strip().split("\n")
+        assert len(lines) == 2
+
+    def test_help_flag(self, capsys):
+        """--help should exit with code 0."""
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--help"])
+        assert exc_info.value.code == 0


### PR DESCRIPTION
## Summary
- Add `scripts/internal/export_hosted_decisions.py` — CLI wrapper that queries the hosted-play SQLite DB and writes decisions as JSONL (SP-4-01 schema)
- Supports `--db`, `--output`, `--match-uuid`, and `--human-only` flags
- 13 unit tests covering query building, JSONL output, filtering, ordering, and CLI error handling

## Why
SP-4-01 requires a standalone CLI tool for exporting hosted-play decisions to JSONL for downstream analysis. PR #1529 shipped `web/export.py` with `decision_to_jsonl()`; this PR adds the CLI wrapper that calls it.

## Repro / Validation
```bash
# Help output
uv run python scripts/internal/export_hosted_decisions.py --help

# Unit tests
uv run python -m pytest tests/unit/hosted_play/test_export_cli.py -v

# Full validation
make check-quiet
```

## Tests
- 13 new tests in `tests/unit/hosted_play/test_export_cli.py`
- `make check-quiet` passes (Tier 2)

## Worktree proof
```
pwd: Bid-Euchre-steward-brws-author-b
branch: browser-game/sp4-01-export-cli
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)