### PR TITLE
docs(browser-game): close SP-4-01 checkpoints and mark Phase 4 complete

### DIFF
--- a/plans/browser_game/4_data_pipeline/checkpoints.md
+++ b/plans/browser_game/4_data_pipeline/checkpoints.md
@@ -3,7 +3,7 @@
 **Governing plan:** `plans/browser_game/governing_plan.md`
 **Phase/Rung:** `4_data_pipeline`
 **Sub-plan:** `SP-4-01` → `4_data_pipeline/sub/2026-03-14_export_replay.md`
-**Last updated:** 2026-03-24
+**Last updated:** 2026-03-24 (closeout)
 
 ---
 
@@ -11,18 +11,18 @@
 
 | Step | Status | Date | Agent/Session | Notes |
 |------|--------|------|---------------|-------|
-| Step 0: Read sub-plan SP-4-01 and verify Phase 2 complete | PENDING | -- | -- | Phase 2 COMPLETE (PRs #1430, #1435). Ready to start. |
-| Step 1: Implement export logic (`web/export.py`) | PENDING | -- | -- | decision_to_jsonl(), export_decisions(), validate_replay(). |
-| Step 2: Implement export CLI (`scripts/internal/export_hosted_decisions.py`) | PENDING | -- | -- | --db, --output, --match-uuid, --human-only flags. |
-| Step 3: Implement replay validation | PENDING | -- | -- | Regenerate deal from seed+deal_id, replay all decisions, verify legality + outcomes. |
-| Step 4: Write tests | PENDING | -- | -- | 6 required tests listed in SP-4-01 §Required Tests. |
-| Step 5: Run validation | PENDING | -- | -- | `uv run python -m pytest tests/unit/hosted_play/test_export.py -v` |
+| Step 0: Read sub-plan SP-4-01 and verify Phase 2 complete | COMPLETE | 2026-03-24 | brws-author-a | Phase 2 COMPLETE (PRs #1430, #1435). Ready to start. |
+| Step 1: Implement export logic (`web/export.py`) | COMPLETE | 2026-03-24 | brws-author-a | `decision_to_jsonl` (PR #1529), `export_decisions` (PR #1535). |
+| Step 2: Implement export CLI (`scripts/internal/export_hosted_decisions.py`) | COMPLETE | 2026-03-24 | brws-author-a | PR #1538. --db, --output, --match-uuid, --human-only flags. |
+| Step 3: Implement replay validation | COMPLETE | 2026-03-24 | brws-author-a | PR #1545. `validate_replay` JSONL correctness verifier. |
+| Step 4: Write tests | COMPLETE | 2026-03-24 | brws-author-a | PR #1533 (fixture helpers) + tests in PRs #1529, #1535, #1545. All 6 required tests covered. |
+| Step 5: Run validation | COMPLETE | 2026-03-24 | brws-author-a | 233 tests pass (`tests/unit/hosted_play/`). Full `make check-quiet` green. |
 
 ## Active Sub-Plans
 
 | Sub-Plan ID | File | Status | Blocking Step |
 |-------------|------|--------|---------------|
-| SP-4-01 | `4_data_pipeline/sub/2026-03-14_export_replay.md` | active | Step 0 |
+| SP-4-01 | `4_data_pipeline/sub/2026-03-14_export_replay.md` | completed | -- |
 
 ## Blockers
 
@@ -33,6 +33,12 @@
 Phase 4 depends on Phase 2 (not Phase 3). Can run in parallel with Phase 3.
 
 ## Session Log
+
+### 2026-03-24 — brws-author-a (SP-4-01 closeout)
+- All 5 steps COMPLETE. PRs: #1529, #1533, #1535, #1538, #1545.
+- Validation pass: 233/233 tests pass in `tests/unit/hosted_play/`.
+- SP-4-01 status: active → completed.
+- Phase 4 data pipeline is fully delivered.
 
 ### 2026-03-24 — brws-author-a (Phase 4 activation)
 - Phase 2 blocker cleared (PRs #1430, #1435 merged).

--- a/plans/browser_game/4_data_pipeline/sub/2026-03-14_export_replay.md
+++ b/plans/browser_game/4_data_pipeline/sub/2026-03-14_export_replay.md
@@ -2,7 +2,7 @@
 
 **ID:** SP-4-01
 **Parent:** Phase 4 — Data Pipeline
-**Status:** proposed
+**Status:** completed
 **Governing plan:** `plans/browser_game/governing_plan.md`
 **Created:** 2026-03-14
 
@@ -154,4 +154,14 @@ These are noted for context but explicitly deferred:
 
 ## Outcome
 
-_To be filled after implementation._
+**Completed 2026-03-24.** All deliverables shipped across 5 PRs:
+
+| PR | Deliverable |
+|----|-------------|
+| #1529 | `decision_to_jsonl` export function + schema tests |
+| #1533 | Fixture factory helpers for hosted_play export tests |
+| #1535 | `export_decisions` batch export with filter support |
+| #1538 | `export_hosted_decisions` CLI script |
+| #1545 | `validate_replay` JSONL correctness verifier |
+
+Validation: 233/233 tests pass in `tests/unit/hosted_play/`.

--- a/plans/browser_game/sub_plan_registry.md
+++ b/plans/browser_game/sub_plan_registry.md
@@ -14,16 +14,16 @@
 | SP-2-01 | FastAPI App & Persistence | Phase 2 — Backend API | completed | brws-author-b | `2_backend_api/sub/2026-03-14_fastapi_app.md` | 2026-03-14 | 2026-03-24 |
 | SP-3-01 | HTMX Game UI (design reference) | Phase 3 — Frontend Product | superseded | -- | `3_frontend_product/sub/2026-03-14_htmx_game_ui.md` | 2026-03-14 | -- |
 | SP-3-02 | Browser UI Implementation | Phase 3 — Frontend Product | completed | brws-author-a | `3_frontend_product/sub/2026-03-24_browser-ui.md` | 2026-03-24 | 2026-03-24 |
-| SP-4-01 | Export & Replay Validation | Phase 4 — Data Pipeline | active | -- | `4_data_pipeline/sub/2026-03-14_export_replay.md` | 2026-03-14 | -- |
+| SP-4-01 | Export & Replay Validation | Phase 4 — Data Pipeline | completed | brws-author-a | `4_data_pipeline/sub/2026-03-14_export_replay.md` | 2026-03-14 | 2026-03-24 |
 
 ## Status Summary
 
 | Status | Count |
 |--------|-------|
 | proposed | 0 |
-| active | 1 |
+| active | 0 |
 | blocked | 0 |
-| completed | 4 |
+| completed | 5 |
 | abandoned | 0 |
 | superseded | 1 |
 


### PR DESCRIPTION
## Plan
`plans/browser_game/4_data_pipeline/sub/2026-03-14_export_replay.md` (SP-4-01)

## Summary
- Mark all 5 SP-4-01 steps COMPLETE with PR references (#1529, #1533, #1535, #1538, #1545)
- Update sub_plan_registry.md: SP-4-01 status → completed
- Fill in Outcome section of the sub-plan with delivered PR table

## Why
Phase 4 data pipeline (export + replay validation) is fully delivered. This PR closes the
checkpoint bookkeeping so the governing plan accurately reflects completion.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/ -v  # 233/233 pass
make check-quiet                                      # All checks pass
```

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/ -v` — 233 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None (docs-only)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a  56a9d2dd [browser-game/sp4-01-closeout]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)