### PR TITLE
fix(browser-game): use Counter for double-deck hand validation in validate_replay

### DIFF
--- a/tests/unit/hosted_play/test_export.py
+++ b/tests/unit/hosted_play/test_export.py
@@ -989,3 +989,151 @@ class TestValidateReplay:
         errors = validate_replay(path)
         # No trick winner errors
         assert not any("winner mismatch" in e for e in errors)
+
+    def test_double_deck_duplicate_cards_accepted(self, tmp_path):
+        """Hands with duplicate cards (double deck) must not false-negative.
+
+        Regression test for #1550: set() comparison collapsed duplicates,
+        causing valid hands with two copies of the same card to fail
+        deal-regeneration checks.
+
+        Uses seed=1, deal_id=1 where seat 0 is dealt two Club Jacks.
+        """
+        # seed=1, deal_id=1 → seat 0 has two C-J (Club Jack)
+        dup_seed = 1
+        dup_deal_id = 1
+        dup_match_uuid = "dupdup00-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+        # Full 10-card hand including duplicates (from generate_deal(1, 1))
+        dup_human_hand = [
+            ["D", "A"],
+            ["H", "T"],
+            ["C", "J"],
+            ["S", "Q"],
+            ["C", "K"],
+            ["D", "T"],
+            ["H", "Q"],
+            ["S", "A"],
+            ["C", "J"],  # second copy of Club Jack
+            ["C", "Q"],
+        ]
+
+        dup_game_state = {
+            "status": "active",
+            "winner": None,
+            "phase": "auction",
+            "dealer_seat": 0,
+            "current_seat": 1,
+            "turn_number": 0,
+            "human_hand": dup_human_hand,
+            "auction": [],
+            "contract_type": None,
+            "trump": None,
+            "current_trick": None,
+            "completed_tricks": [],
+            "tricks_team0": 0,
+            "tricks_team1": 0,
+        }
+
+        records = [
+            {
+                "schema_version": 1,
+                "event": "hosted_decision",
+                "match_uuid": dup_match_uuid,
+                "match_seed": dup_seed,
+                "hand_number": 1,
+                "deal_id": dup_deal_id,
+                "dealer_seat": 0,
+                "turn_number": 0,
+                "seat": 1,
+                "phase": "bid",
+                "actor_type": "ai",
+                "decision_source": "heuristic",
+                "ai_model": "heuristic",
+                "legal_actions": [{"n": 0}],
+                "chosen_action": {"n": 0},
+                "game_state": dup_game_state,
+                "decision_time_ms": 100,
+                "timestamp": "2026-03-24T06:00:00+00:00",
+            },
+        ]
+
+        path = tmp_path / "double_deck.jsonl"
+        _write_jsonl(path, records)
+
+        errors = validate_replay(path)
+        assert (
+            errors == []
+        ), f"Valid hand with duplicate cards should pass, got: {errors}"
+
+    def test_double_deck_extra_duplicate_detected(self, tmp_path):
+        """Three copies of a card (impossible in double deck) must be caught.
+
+        The multiset comparison must detect that the logged hand claims more
+        copies of a card than the dealt hand contains.
+        """
+        dup_seed = 1
+        dup_deal_id = 1
+        dup_match_uuid = "triples0-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+        # Tampered hand: THREE Club Jacks (dealt hand only has two)
+        bad_human_hand = [
+            ["D", "A"],
+            ["H", "T"],
+            ["C", "J"],
+            ["S", "Q"],
+            ["C", "K"],
+            ["D", "T"],
+            ["H", "Q"],
+            ["C", "J"],  # second copy (valid)
+            ["C", "J"],  # third copy (invalid!)
+            ["C", "Q"],
+        ]
+
+        bad_game_state = {
+            "status": "active",
+            "winner": None,
+            "phase": "auction",
+            "dealer_seat": 0,
+            "current_seat": 1,
+            "turn_number": 0,
+            "human_hand": bad_human_hand,
+            "auction": [],
+            "contract_type": None,
+            "trump": None,
+            "current_trick": None,
+            "completed_tricks": [],
+            "tricks_team0": 0,
+            "tricks_team1": 0,
+        }
+
+        records = [
+            {
+                "schema_version": 1,
+                "event": "hosted_decision",
+                "match_uuid": dup_match_uuid,
+                "match_seed": dup_seed,
+                "hand_number": 1,
+                "deal_id": dup_deal_id,
+                "dealer_seat": 0,
+                "turn_number": 0,
+                "seat": 1,
+                "phase": "bid",
+                "actor_type": "ai",
+                "decision_source": "heuristic",
+                "ai_model": "heuristic",
+                "legal_actions": [{"n": 0}],
+                "chosen_action": {"n": 0},
+                "game_state": bad_game_state,
+                "decision_time_ms": 100,
+                "timestamp": "2026-03-24T06:00:00+00:00",
+            },
+        ]
+
+        path = tmp_path / "triple_deck.jsonl"
+        _write_jsonl(path, records)
+
+        errors = validate_replay(path)
+        assert any(
+            "not in dealt hand" in e for e in errors
+        ), f"Three copies should be caught, got: {errors}"

--- a/web/export.py
+++ b/web/export.py
@@ -8,7 +8,7 @@ JSONL-exportable dict format defined in SP-4-01.  Also provides
 from __future__ import annotations
 
 import json
-from collections import defaultdict
+from collections import Counter, defaultdict
 from datetime import timezone
 from pathlib import Path
 from typing import Optional
@@ -264,9 +264,13 @@ def _parse_jsonl(
     return records
 
 
-def _card_tuples(card_list: list) -> set[tuple[str, str]]:
-    """Convert ``[[suit, rank], ...]`` to a set of ``(suit, rank)``."""
-    return {(c[0], c[1]) for c in card_list}
+def _card_tuples(card_list: list) -> list[tuple[str, str]]:
+    """Convert ``[[suit, rank], ...]`` to a list of ``(suit, rank)`` tuples.
+
+    Returns a list (not a set) so that duplicate cards in a double-deck
+    game are preserved.
+    """
+    return [(c[0], c[1]) for c in card_list]
 
 
 def _plays_from_list(plays_data: list) -> list[tuple[int, Card]]:
@@ -289,15 +293,16 @@ def _validate_hand_group(
 
     # --- 1. Deal regeneration -------------------------------------------------
     dealt_hands = generate_deal(match_seed, deal_id)
-    dealt_human_set = {(c.suit, c.rank) for c in dealt_hands[_HUMAN_SEAT]}
+    dealt_human_counts = Counter((c.suit, c.rank) for c in dealt_hands[_HUMAN_SEAT])
 
     gs_first = first_rec.get("game_state", {})
     if "human_hand" in gs_first and gs_first["human_hand"]:
-        logged_human = _card_tuples(gs_first["human_hand"])
-        if not logged_human.issubset(dealt_human_set):
-            extra = logged_human - dealt_human_set
+        logged_human_counts = Counter(_card_tuples(gs_first["human_hand"]))
+        # Each logged card must not exceed the dealt multiplicity (multiset subset).
+        extra = logged_human_counts - dealt_human_counts
+        if extra:
             errors.append(
-                f"{prefix}: human hand contains cards not in dealt hand: {extra}"
+                f"{prefix}: human hand contains cards not in dealt hand: {dict(extra)}"
             )
 
     # --- 2 & 3. Per-decision legality checks ----------------------------------


### PR DESCRIPTION
## Summary
- Replace `set()` comparison with `Counter` (multiset) in `_validate_hand_group` for deal-regeneration checks
- Change `_card_tuples` to return a `list` instead of `set` to preserve card duplicates
- Add 2 regression tests: valid duplicate hand passes, impossible triple detected

## Why
`validate_replay` used `set()` to compare dealt vs logged hands, which collapses duplicates. Bid Euchre uses a double deck (40 cards, 2 copies each), so a player CAN be dealt two copies of the same card (e.g., two Club Jacks). The set comparison silently dropped this multiplicity information, causing false negatives in the deal-regeneration check.

Fixes #1550.

## Repro / Validation
```bash
uv run python -m pytest tests/unit/hosted_play/test_export.py -v
# 34 tests pass, including:
#   test_double_deck_duplicate_cards_accepted — valid hand with 2× C-J passes
#   test_double_deck_extra_duplicate_detected — 3× C-J correctly caught
```

Regression test uses `generate_deal(seed=1, deal_id=1)` where seat 0 is dealt two Club Jacks.

## Tests
```bash
uv run python -m pytest tests/unit/hosted_play/test_export.py -v  # 34 passed
make check-quiet  # All checks passed
```

## Worktree proof
```
pwd: Bid-Euchre-steward-brws-author-a
branch: fix/validate-replay-double-deck
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)