### PR TITLE
fix(ops): harden audit_trail channel tag parsing and timestamp normalization

### DIFF
--- a/src/bid_euchre/ops/audit_trail.py
+++ b/src/bid_euchre/ops/audit_trail.py
@@ -88,6 +88,27 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def normalize_timestamp(ts: str) -> str:
+    """Normalize an ISO 8601 timestamp to UTC with ``+00:00`` offset.
+
+    Handles common variants:
+    - ``"2026-03-24T06:00:00Z"`` → ``"2026-03-24T06:00:00+00:00"``
+    - ``"2026-03-24T06:00:00+00:00"`` → unchanged
+    - ``"2026-03-24T06:00:00"`` → treated as UTC, adds ``+00:00``
+
+    Returns the input unchanged if parsing fails.
+    """
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        # Treat naive datetimes as UTC
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        # Convert to UTC and format with +00:00
+        return dt.astimezone(timezone.utc).isoformat()
+    except (ValueError, AttributeError):
+        return ts
+
+
 # Regex for extracting attributes from a <channel ...> XML-style tag.
 # Matches key="value" pairs (double-quoted only, no nested quotes).
 _ATTR_RE = re.compile(r'(\w+)="([^"]*)"')
@@ -103,6 +124,10 @@ def parse_channel_tag(tag_text: str) -> dict[str, str]:
 
     The closing ``>`` is optional (self-closing ``/>`` is also accepted).
 
+    Only attributes within the opening ``<channel ... >`` tag are parsed.
+    Any body text after the closing ``>`` is ignored, preventing false
+    matches from quoted strings in message content.
+
     Args:
         tag_text: Raw tag text, e.g. from a system-reminder message.
 
@@ -113,6 +138,11 @@ def parse_channel_tag(tag_text: str) -> dict[str, str]:
     tag_text = tag_text.strip()
     if not tag_text.startswith("<channel"):
         return {}
+    # Limit parsing to the opening tag only (up to first '>') to avoid
+    # extracting key="value" patterns from body text.
+    gt_pos = tag_text.find(">")
+    if gt_pos >= 0:
+        tag_text = tag_text[: gt_pos + 1]
     return dict(_ATTR_RE.findall(tag_text))
 
 
@@ -381,6 +411,8 @@ def audit_inbound(
     Returns:
         The persisted :class:`AuditRecord`.
     """
+    # Normalize inbound timestamps to consistent UTC ISO 8601 format.
+    normalized_ts = normalize_timestamp(ts) if ts else ts
     record = create_record(
         direction="inbound",
         channel_source=channel_source,
@@ -390,7 +422,7 @@ def audit_inbound(
         chat_id=chat_id,
         message_id=message_id,
         metadata=metadata,
-        timestamp=ts,
+        timestamp=normalized_ts,
     )
     append_record(record, audit_dir=audit_dir)
     return record

--- a/tests/unit/test_audit_trail.py
+++ b/tests/unit/test_audit_trail.py
@@ -21,6 +21,7 @@ from bid_euchre.ops.audit_trail import (
     content_hash,
     content_preview,
     create_record,
+    normalize_timestamp,
     parse_channel_tag,
     read_records,
 )
@@ -767,6 +768,76 @@ class TestParseChannelTag:
         result = parse_channel_tag(tag)
         assert result["image_path"] == "/tmp/photo.jpg"
 
+    def test_body_text_not_parsed_as_attributes(self) -> None:
+        """Quoted key=value patterns in body text must not be extracted as tag attrs."""
+        tag = (
+            '<channel source="telegram" chat_id="123">'
+            'Body with some="value" and key="other" inside'
+            "</channel>"
+        )
+        result = parse_channel_tag(tag)
+        assert result == {"source": "telegram", "chat_id": "123"}
+        assert "some" not in result
+        assert "key" not in result
+
+    def test_body_with_angle_brackets(self) -> None:
+        """Body text containing angle brackets should not confuse the parser."""
+        tag = (
+            '<channel source="telegram" chat_id="42">'
+            'User says: 2 > 1 and foo="bar" is valid'
+            "</channel>"
+        )
+        result = parse_channel_tag(tag)
+        assert result == {"source": "telegram", "chat_id": "42"}
+
+    def test_tag_without_body(self) -> None:
+        """A tag with no body and closing > still parses correctly."""
+        tag = '<channel source="telegram" chat_id="100" user="bob">'
+        result = parse_channel_tag(tag)
+        assert result == {"source": "telegram", "chat_id": "100", "user": "bob"}
+
+
+# ---------------------------------------------------------------------------
+# normalize_timestamp
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeTimestamp:
+    def test_z_suffix_to_offset(self) -> None:
+        assert (
+            normalize_timestamp("2026-03-24T06:00:00Z") == "2026-03-24T06:00:00+00:00"
+        )
+
+    def test_offset_unchanged(self) -> None:
+        assert (
+            normalize_timestamp("2026-03-24T06:00:00+00:00")
+            == "2026-03-24T06:00:00+00:00"
+        )
+
+    def test_non_utc_offset_converted(self) -> None:
+        """Timestamps with non-UTC offsets are converted to UTC."""
+        # +05:00 means 06:00 local = 01:00 UTC
+        result = normalize_timestamp("2026-03-24T06:00:00+05:00")
+        assert result == "2026-03-24T01:00:00+00:00"
+
+    def test_naive_treated_as_utc(self) -> None:
+        """Naive timestamps (no tz) are treated as UTC."""
+        result = normalize_timestamp("2026-03-24T06:00:00")
+        assert result == "2026-03-24T06:00:00+00:00"
+
+    def test_with_microseconds(self) -> None:
+        result = normalize_timestamp("2026-03-24T06:00:00.123456Z")
+        assert result == "2026-03-24T06:00:00.123456+00:00"
+
+    def test_invalid_string_passthrough(self) -> None:
+        """Invalid timestamps are returned unchanged."""
+        assert normalize_timestamp("not-a-date") == "not-a-date"
+        assert normalize_timestamp("") == ""
+
+    def test_non_string_passthrough(self) -> None:
+        """Non-string values don't crash."""
+        assert normalize_timestamp(None) is None  # type: ignore[arg-type]
+
 
 # ---------------------------------------------------------------------------
 # audit_inbound (SP-4-06 PR 3)
@@ -885,6 +956,44 @@ class TestAuditInbound:
         persisted = read_records(audit_dir=tmp_path)
         assert len(persisted) == 1
         assert returned == persisted[0]
+
+    def test_z_suffix_normalized_to_offset(self, tmp_path: Path) -> None:
+        """Inbound ts with Z suffix is normalized to +00:00."""
+        record = audit_inbound(
+            chat_id="123",
+            message_id="1",
+            user="user1",
+            content="test",
+            ts="2026-03-24T06:00:00Z",
+            audit_dir=tmp_path,
+        )
+        assert record.timestamp == "2026-03-24T06:00:00+00:00"
+
+    def test_offset_timestamp_unchanged(self, tmp_path: Path) -> None:
+        """Inbound ts already in +00:00 form is unchanged."""
+        ts = "2026-03-24T10:30:00+00:00"
+        record = audit_inbound(
+            chat_id="123",
+            message_id="1",
+            user="user1",
+            content="test",
+            ts=ts,
+            audit_dir=tmp_path,
+        )
+        assert record.timestamp == ts
+
+    def test_no_ts_uses_auto_timestamp(self, tmp_path: Path) -> None:
+        """When ts is None, auto-generated timestamp is used."""
+        record = audit_inbound(
+            chat_id="123",
+            message_id="1",
+            user="user1",
+            content="test",
+            audit_dir=tmp_path,
+        )
+        # Auto-generated timestamp should be parseable and in UTC
+        dt = datetime.fromisoformat(record.timestamp)
+        assert dt.tzinfo is not None
 
     def test_inbound_outbound_coexist(self, tmp_path: Path) -> None:
         """Inbound and outbound records coexist in the same log."""


### PR DESCRIPTION
## Summary

- Fix `parse_channel_tag()` to limit regex scanning to the opening `<channel>` tag only, preventing `key="value"` patterns in body text from being incorrectly extracted as attributes
- Add `normalize_timestamp()` helper to convert inbound timestamps to consistent UTC ISO 8601 format (`+00:00` offset), handling Z suffix, naive datetimes, and non-UTC offsets
- Wire `normalize_timestamp()` into `audit_inbound()` so all inbound timestamps are stored consistently

## Why

Issue #1543 finding 1: `parse_channel_tag()` applied the attribute regex to the full input string, so body content containing `key="value"` patterns would be extracted as spurious attributes.

Issue #1543 finding 2 + #1548: Inbound timestamps could arrive in inconsistent formats (Z suffix, offset, naive). Without normalization, the stored records have mixed formats that complicate downstream filtering and comparison.

Closes #1543
Closes #1548

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_audit_trail.py -v
make check-quiet
```

## Tests

- 10 new tests added (83 total, all passing):
  - `TestParseChannelTag::test_body_text_not_parsed_as_attributes` — verifies body `key="value"` patterns are ignored
  - `TestParseChannelTag::test_body_with_angle_brackets` — body with `>` chars
  - `TestParseChannelTag::test_tag_without_body` — tag-only input still works
  - `TestNormalizeTimestamp` (7 tests) — Z suffix, offset, non-UTC, naive, microseconds, invalid, non-string
  - `TestAuditInbound::test_z_suffix_normalized_to_offset`
  - `TestAuditInbound::test_offset_timestamp_unchanged`
  - `TestAuditInbound::test_no_ts_uses_auto_timestamp`

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: fix/audit-trail-parsing-timestamps
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)