### PR TITLE
fix(browser-game): harden export CLI ordering and safety guards

### DIFF
--- a/scripts/internal/export_hosted_decisions.py
+++ b/scripts/internal/export_hosted_decisions.py
@@ -34,11 +34,20 @@ import json
 import sys
 from pathlib import Path
 
-from sqlalchemy import select
-from sqlalchemy.orm import Session
+try:
+    from sqlalchemy import select
+    from sqlalchemy.orm import Session
 
-from web.db import Decision, Hand, Match, init_engine, make_session_factory
-from web.export import decision_to_jsonl
+    from web.db import Decision, Hand, Match, init_engine, make_session_factory
+    from web.export import decision_to_jsonl
+except ImportError as exc:
+    print(
+        "Error: missing dependencies for export CLI.\n"
+        "Install the web extras:  uv sync --extra web\n"
+        f"  ({exc})",
+        file=sys.stderr,
+    )
+    raise SystemExit(1) from exc
 
 
 def _build_query(
@@ -55,7 +64,7 @@ def _build_query(
         select(Decision, Match, Hand)
         .join(Match, Decision.match_id == Match.id)
         .join(Hand, Decision.hand_id == Hand.id)
-        .order_by(Decision.match_id, Decision.hand_id, Decision.turn_number)
+        .order_by(Decision.match_id, Hand.hand_number, Decision.turn_number)
     )
 
     if match_uuid is not None:
@@ -95,11 +104,11 @@ def export_decisions(
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     stmt = _build_query(match_uuid=match_uuid, human_only=human_only)
-    rows = session.execute(stmt).all()
+    result = session.execute(stmt).yield_per(500)
 
     count = 0
     with open(output_path, "w") as fh:
-        for decision_row, match_row, hand_row in rows:
+        for decision_row, match_row, hand_row in result:
             record = decision_to_jsonl(decision_row, match_row, hand_row)
             fh.write(json.dumps(record) + "\n")
             count += 1
@@ -142,8 +151,18 @@ def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
 
     db_path: Path = args.db
+    output_path: Path = args.output
+
     if not db_path.exists():
         print(f"Error: database not found: {db_path}", file=sys.stderr)
+        return 1
+
+    if db_path.resolve() == output_path.resolve():
+        print(
+            "Error: --output resolves to the same path as --db; "
+            "refusing to overwrite the source database.",
+            file=sys.stderr,
+        )
         return 1
 
     database_url = f"sqlite:///{db_path.resolve()}"
@@ -154,14 +173,14 @@ def main(argv: list[str] | None = None) -> int:
     try:
         count = export_decisions(
             session,
-            args.output,
+            output_path,
             match_uuid=args.match_uuid,
             human_only=args.human_only,
         )
     finally:
         session.close()
 
-    print(f"{count} records exported to {args.output}")
+    print(f"{count} records exported to {output_path}")
     return 0
 
 

--- a/tests/unit/hosted_play/test_export_cli.py
+++ b/tests/unit/hosted_play/test_export_cli.py
@@ -267,7 +267,7 @@ class TestExportDecisions:
         assert record["actor_type"] == "human"
 
     def test_deterministic_ordering(self, session, tmp_path):
-        """Records are ordered by match_id, hand_id, turn_number."""
+        """Records are ordered by match_id, hand_number, turn_number."""
         player = _make_player(session)
         match = _make_match(session, player)
         hand = _make_hand(session, match)
@@ -282,6 +282,26 @@ class TestExportDecisions:
         lines = output.read_text().strip().split("\n")
         turns = [json.loads(line)["turn_number"] for line in lines]
         assert turns == [0, 1, 2]
+
+    def test_ordering_by_hand_number(self, session, tmp_path):
+        """Decisions are ordered by logical hand_number, not hand PK."""
+        player = _make_player(session)
+        match = _make_match(session, player)
+        # Create hands with non-sequential hand_numbers inserted out of order
+        hand3 = _make_hand(session, match, hand_number=3)
+        hand1 = _make_hand(session, match, hand_number=1)
+        hand2 = _make_hand(session, match, hand_number=2)
+        _make_decision(session, match, hand3, turn_number=0, seat=0)
+        _make_decision(session, match, hand1, turn_number=0, seat=0)
+        _make_decision(session, match, hand2, turn_number=0, seat=0)
+        session.commit()
+
+        output = tmp_path / "hand_order.jsonl"
+        export_decisions(session, output)
+
+        lines = output.read_text().strip().split("\n")
+        hand_numbers = [json.loads(line)["hand_number"] for line in lines]
+        assert hand_numbers == [1, 2, 3]
 
 
 # ---------------------------------------------------------------------------
@@ -322,6 +342,22 @@ class TestMainCLI:
 
         lines = output.read_text().strip().split("\n")
         assert len(lines) == 2
+
+    def test_overwrite_guard_rejects_same_path(self, tmp_path):
+        """--output same as --db should return exit code 1."""
+        db_path = tmp_path / "test.db"
+        db_path.touch()
+        code = main(["--db", str(db_path), "--output", str(db_path)])
+        assert code == 1
+
+    def test_overwrite_guard_rejects_symlink(self, tmp_path):
+        """--output symlink pointing to --db should return exit code 1."""
+        db_path = tmp_path / "test.db"
+        db_path.touch()
+        link_path = tmp_path / "link.db"
+        link_path.symlink_to(db_path)
+        code = main(["--db", str(db_path), "--output", str(link_path)])
+        assert code == 1
 
     def test_help_flag(self, capsys):
         """--help should exit with code 0."""


### PR DESCRIPTION
## Summary
- Order exported decisions by `Hand.hand_number` (logical hand number) instead of `Hand.id` (internal PK) for deterministic, semantically correct ordering across hands (#1537)
- Wrap `web`/`sqlalchemy` imports in `try/except` with a helpful install message so the CLI fails gracefully from a default `uv sync` environment (#1546)
- Guard against `--output` resolving to the same path as `--db` to prevent overwriting the source database (#1546)
- Stream query results with `yield_per(500)` instead of materializing all rows for large exports (#1546)

## Why
Post-merge review findings from PRs #1533 and #1538 identified four improvements to the `export_hosted_decisions.py` CLI: logical ordering, environment safety, path safety, and memory efficiency.

Closes #1537, closes #1546.

## Scope
- `scripts/internal/export_hosted_decisions.py` — all 4 fixes
- `tests/unit/hosted_play/test_export_cli.py` — 3 new tests

## Repro / Validation
```bash
uv run python -m pytest tests/unit/hosted_play/test_export_cli.py -v
make check-quiet
```

## Tests
- `test_ordering_by_hand_number` — verifies decisions across hands with non-sequential hand_numbers are ordered by hand_number
- `test_overwrite_guard_rejects_same_path` — verifies `--output == --db` returns exit code 1
- `test_overwrite_guard_rejects_symlink` — verifies symlink to `--db` is also rejected
- All 16 tests pass, `make check-quiet` clean

## Worktree proof
```
pwd: Bid-Euchre-steward-brws-author-b
branch: fix/1537-1546-export-cli-guards
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)