### PR TITLE
docs(ops): complete SP-4-06 handoff artifacts

### DIFF
--- a/plans/agent_ops/4_remote_channel/checkpoints.md
+++ b/plans/agent_ops/4_remote_channel/checkpoints.md
@@ -24,7 +24,7 @@ sub-plan registry, and update checkpoints. Docs-only — no code changes.
 |------|--------|------|---------------|-------|
 | Step 0: Phase 4 scope lock and sub-plan registration | COMPLETE | 2026-03-23 | author-scratch | SP-4-01 created and registered. |
 | Step 1: Platform-8a preflight and Telegram transport skeleton | COMPLETE | 2026-03-24 | flex-b | SP-4-04 all steps proven. PRs #1436, #1451, #1452 merged. Pairing confirmed (user 8122530898), messages flow both ways, kill switch verified. |
-| Step 2: Platform-8b repo-owned remote audit trail, kill switch, and operator fallback | COMPLETE | 2026-03-24 | author-a | SP-4-06 all 4 PRs shipped: core writer (#1533), outbound wrappers (#1536), inbound helper (#1541), integration tests (PR 4). |
+| Step 2: Platform-8b repo-owned remote audit trail, kill switch, and operator fallback | COMPLETE | 2026-03-24 | author-a | SP-4-06 all 4 PRs shipped: core writer (#1533), outbound wrappers (#1536), inbound helper (#1541), integration tests (#1549). |
 | Step 3: Platform-9a idle-attention alerts and acknowledgement loop | PENDING | -- | -- | Prove one useful alert path with dedupe, rate limiting, and ack behavior. |
 | Step 4: Platform-9b away-from-desk queue-moving proving run | PENDING | -- | -- | Demonstrate status, reroute, review request, and blocker inspection through `orchestrator`. |
 | Step 5: Platform-9c first hardening pass and Phase 4 handoff | PENDING | -- | -- | Fix real proving-run issues, update docs, and record known gaps. |

--- a/plans/agent_ops/4_remote_channel/sub/2026-03-24_platform-8b-audit-trail.md
+++ b/plans/agent_ops/4_remote_channel/sub/2026-03-24_platform-8b-audit-trail.md
@@ -3,7 +3,7 @@
 **ID:** SP-4-06
 **Date:** 2026-03-24
 **Parent:** `plans/agent_ops/governing_plan.md` -- Phase 4, Platform-8b
-**Status:** ready
+**Status:** completed
 **Owner:** author-a
 
 ---
@@ -252,14 +252,14 @@ make check-quiet
 
 ## Exit Criteria
 
-- [ ] `AuditRecord` dataclass and JSONL writer/reader are implemented and tested
-- [ ] Outbound wrappers (`audit_reply`, `audit_react`, `audit_edit`) are implemented and tested
-- [ ] Inbound helper (`audit_inbound`, `parse_channel_tag`) is implemented and tested
-- [ ] Integration tests verify full round-trip and concurrent-write safety
-- [ ] All tests pass (`make check-quiet` green)
-- [ ] No changes to existing bus, monitor, or dashboard modules
-- [ ] Seam wiring documentation describes how orchestrator uses the audit trail
-- [ ] Phase 4 checkpoints updated (Step 2 progressed toward COMPLETE)
+- [x] `AuditRecord` dataclass and JSONL writer/reader are implemented and tested
+- [x] Outbound wrappers (`audit_reply`, `audit_react`, `audit_edit`) are implemented and tested
+- [x] Inbound helper (`audit_inbound`, `parse_channel_tag`) is implemented and tested
+- [x] Integration tests verify full round-trip and concurrent-write safety
+- [x] All tests pass (`make check-quiet` green)
+- [x] No changes to existing bus, monitor, or dashboard modules
+- [x] Seam wiring documentation describes how orchestrator uses the audit trail
+- [x] Phase 4 checkpoints updated (Step 2 progressed toward COMPLETE)
 
 ## Known Gaps (deferred to Platform-9c hardening)
 
@@ -272,10 +272,10 @@ make check-quiet
 
 ## Validation
 
-- [ ] Sub-plan follows template structure
-- [ ] Registered in sub-plan registry
-- [ ] Checkpoints updated with Step 2 IN_PROGRESS
-- [ ] `git diff --stat` shows only declared scope files
+- [x] Sub-plan follows template structure
+- [x] Registered in sub-plan registry
+- [x] Checkpoints updated with Step 2 COMPLETE
+- [x] `git diff --stat` shows only declared scope files
 
 ## Planned Outputs
 
@@ -285,8 +285,17 @@ make check-quiet
 
 ## Observed Outputs
 
-_(To be filled after implementation)_
+- `src/bid_euchre/ops/audit_trail.py` — Core module: `AuditRecord` dataclass, `create_record()`, `append_record()`, `read_records()`, `content_hash()`, `content_preview()`, `parse_channel_tag()`, outbound wrappers (`audit_reply`, `audit_react`, `audit_edit`), inbound helper (`audit_inbound`)
+- `tests/unit/test_audit_trail.py` — Unit tests for serialization, append/read, filtering, content hashing, tag parsing, concurrent-write safety
+- `tests/integration/test_audit_trail_integration.py` — 20 integration tests across 4 categories: full round-trip (4), concurrent writers (3), large volume (4), mixed direction filtering (9)
+- `src/bid_euchre/ops/__init__.py` — Updated to export `audit_trail` module
 
 ## Outcome
 
-_(To be filled after implementation)_
+All 4 PRs shipped on 2026-03-24:
+- PR 1: Core writer + unit tests (#1533)
+- PR 2: Outbound wrappers (#1536)
+- PR 3: Inbound helper + channel tag parser (#1541)
+- PR 4: Integration tests + checkpoints update (#1549)
+
+All exit criteria met. 20 integration tests + unit test suite passing. `make check-quiet` green. No changes to existing bus, monitor, or dashboard modules.

--- a/plans/agent_ops/sub_plan_registry.md
+++ b/plans/agent_ops/sub_plan_registry.md
@@ -1,7 +1,7 @@
 # Sub-Plan Registry — Agentic Orchestration Platform
 
 **Governing plan:** `plans/agent_ops/governing_plan.md`
-**Last updated:** 2026-03-24 by author-a (SP-4-06 proposed)
+**Last updated:** 2026-03-24 by author-a (SP-4-06 completed)
 
 ---
 
@@ -29,16 +29,16 @@
 | SP-4-03 | Token economy observability and dashboard | Phase 4, Pre-Platform-8 token observability | completed | orchestrator | `plans/agent_ops/4_remote_channel/sub/2026-03-23_token-economy-observability-and-dashboard.md` | 2026-03-23 | 2026-03-24 (baseline report at `plans/sessions/2026-03-23_token-economy-baseline.md`; dashboard auto-import via PR #1466) |
 | SP-4-04 | Platform-8a Telegram transport configuration | Phase 4, Platform-8a transport proving | completed | flex-a | `plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8a-telegram-transport.md` | 2026-03-23 | 2026-03-24 (PRs #1436, #1451, #1452; proven end-to-end) |
 | SP-4-05 | Reactive control-loop hardening | Phase 4, Pre-Platform-8 lifecycle reactivity and control-plane hardening | completed | orchestrator | `plans/agent_ops/4_remote_channel/sub/2026-03-24_reactive-control-loop-hardening.md` | 2026-03-24 | 2026-03-24 (PRs #1500, #1491, #1474, #1490, #1507, #1486; lifecycle proven through fleet operation) |
-| SP-4-06 | Platform-8b repo-owned remote audit trail | Phase 4, Platform-8b audit trail for remote exchanges | proposed | (unassigned) | `plans/agent_ops/4_remote_channel/sub/2026-03-24_platform-8b-audit-trail.md` | 2026-03-24 | — |
+| SP-4-06 | Platform-8b repo-owned remote audit trail | Phase 4, Platform-8b audit trail for remote exchanges | completed | author-a | `plans/agent_ops/4_remote_channel/sub/2026-03-24_platform-8b-audit-trail.md` | 2026-03-24 | 2026-03-24 (PRs #1533, #1536, #1541, #1549) |
 
 ## Status Summary
 
 | Status | Count |
 |--------|-------|
-| proposed | 1 |
+| proposed | 0 |
 | in_progress | 0 |
 | blocked | 0 |
-| completed | 19 |
+| completed | 20 |
 | abandoned | 0 |
 | superseded | 1 |
 


### PR DESCRIPTION
## Summary

- Update SP-4-06 sub-plan with observed outputs, outcome, and checked exit criteria
- Fix checkpoints.md Step 2 to reference PR #1549 instead of "(PR 4)"
- Update sub_plan_registry.md to mark SP-4-06 as `completed` (was `proposed`)

## Why

Convention follow-up from review of PR #1549. SP-4-06 was marked COMPLETE in
checkpoints but the sub-plan's handoff artifacts (Observed Outputs, Outcome,
exit criteria checkboxes) were left as placeholder text, and the sub-plan
registry still showed `proposed` status.

Closes #1552.

## Plan Reference

`plans/agent_ops/4_remote_channel/sub/2026-03-24_platform-8b-audit-trail.md` (SP-4-06)

## Repro / Validation

```bash
# Docs-only — no code changes
make check-quiet
```

## Tests

- [x] `make check-quiet` — all checks passed

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: fix/sp-4-06-handoff-artifacts
```

## Review Note

The 8 P1 path findings are false positives — the path checker flags module names
(`message_bus.py`, `monitor.py`, `audit_trail.py`, `fcntl.flock`) that appear in
pre-existing technical prose within plan documents. These are inline module/function
references in documentation, not file path links. All pre-date this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)