### PR TITLE
fix(ops): emit valid JSON for lane peek and dashboard watch mode

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -52,6 +52,9 @@ Usage:
     uv run python scripts/internal/ops.py workers retire LANE_ID [--json]
     uv run python scripts/internal/ops.py workers dispatch PACKET_ID LANE_ID [--json]
     uv run python scripts/internal/ops.py workers maintain [--dry-run] [--json]
+    uv run python scripts/internal/ops.py lane refresh <LANE_ID|--all-idle> [--force] [--json]
+    uv run python scripts/internal/ops.py lane check-approvals [--json]
+    uv run python scripts/internal/ops.py lane peek LANE_ID [--lines N] [--json]
     uv run python scripts/internal/ops.py usage import [--usage-dir DIR] [--output-dir DIR] [--json]
     uv run python scripts/internal/ops.py usage attribute [--output-dir DIR] [--json]
     uv run python scripts/internal/ops.py usage summary [--output-dir DIR] [--json]
@@ -175,24 +178,31 @@ def cmd_dashboard(args: argparse.Namespace) -> int:
                 check_worktree=not getattr(args, "no_probe", False),
             )
 
-            if watch:
-                # Clear screen for clean refresh
-                print("\033[2J\033[H", end="", flush=True)
-
             if args.json:
-                print(json.dumps(format_dashboard_json(view), indent=2))
+                # In watch mode, emit compact NDJSON (one JSON object per line)
+                # so the output stream stays machine-parseable.
+                # In single-shot mode, emit indented JSON for readability.
+                if watch:
+                    print(json.dumps(format_dashboard_json(view)))
+                else:
+                    print(json.dumps(format_dashboard_json(view), indent=2))
             else:
+                if watch:
+                    # Clear screen for clean refresh (text mode only —
+                    # ANSI escapes would corrupt JSON output)
+                    print("\033[2J\033[H", end="", flush=True)
                 print(format_dashboard_text(view))
 
             if not watch:
                 break
 
-            print(f"\n--- Refreshing every {interval}s (Ctrl+C to stop) ---")
+            if not args.json:
+                print(f"\n--- Refreshing every {interval}s (Ctrl+C to stop) ---")
             sys.stdout.flush()
             time.sleep(interval)
     except KeyboardInterrupt:
         if watch:
-            print("\nWatch stopped.")
+            print("\nWatch stopped.", file=sys.stderr)
         return 0
 
     return 0
@@ -2419,10 +2429,60 @@ def cmd_lane(args: argparse.Namespace) -> int:
                 print("No lanes stuck on approval prompts.")
         return 1 if findings else 0
 
+    elif action == "peek":
+        import subprocess
+
+        lane_id = args.lane_id
+        lines = args.lines
+        tmux_session = "steward"
+
+        from bid_euchre.ops.worker_pool import _resolve_tmux_target
+
+        target = _resolve_tmux_target(
+            lane_id, tmux_session, runtime_dir=args.runtime_dir
+        )
+        try:
+            result = subprocess.run(
+                [
+                    "tmux",
+                    "capture-pane",
+                    "-t",
+                    target,
+                    "-p",
+                    "-S",
+                    str(-lines),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode != 0:
+                err = result.stderr.strip()
+                print(f"Error: tmux capture-pane failed: {err}", file=sys.stderr)
+                return 1
+            content = result.stdout
+            if args.json:
+                print(
+                    json.dumps(
+                        {"lane": lane_id, "content": content},
+                        indent=2,
+                    )
+                )
+            else:
+                print(content, end="")
+            return 0
+        except FileNotFoundError:
+            print("Error: tmux is not installed or not on PATH", file=sys.stderr)
+            return 1
+        except subprocess.TimeoutExpired:
+            print("Error: tmux capture-pane timed out", file=sys.stderr)
+            return 1
+
     else:
         print(
             "Usage: ops.py lane refresh <lane-id> | --all-idle\n"
-            "       ops.py lane check-approvals"
+            "       ops.py lane check-approvals\n"
+            "       ops.py lane peek <lane-id> [--lines N]"
         )
         return 1
 
@@ -3414,6 +3474,21 @@ def build_parser() -> argparse.ArgumentParser:
     lane_sub.add_parser(
         "check-approvals",
         help="Check for lanes stuck on tool-approval prompts",
+    )
+
+    lane_peek_parser = lane_sub.add_parser(
+        "peek",
+        help="Capture tmux pane content for a lane (large scrollback buffer)",
+    )
+    lane_peek_parser.add_argument(
+        "lane_id",
+        help="Lane ID to peek (e.g. author-a)",
+    )
+    lane_peek_parser.add_argument(
+        "--lines",
+        type=int,
+        default=80,
+        help="Number of scrollback lines to capture (default: 80)",
     )
 
     # workers (Platform-7: worker pool lifecycle management)

--- a/tests/unit/test_ops_cli.py
+++ b/tests/unit/test_ops_cli.py
@@ -4352,3 +4352,175 @@ class TestBusRootRegression:
             "Found worktree-local bus path(s) in ops.py — use shared_bus_root() instead:\n"
             + "\n".join(f"  L{n}: {l.strip()}" for n, l in hits)
         )
+
+
+class TestLanePeek:
+    """Tests for the lane peek subcommand."""
+
+    def test_peek_parser_registered(self) -> None:
+        """The 'lane peek' subcommand is registered in the parser."""
+        import ops
+
+        parser = ops.build_parser()
+        args = parser.parse_args(["lane", "peek", "author-a"])
+        assert args.lane_action == "peek"
+        assert args.lane_id == "author-a"
+        assert args.lines == 80  # default
+
+    def test_peek_custom_lines(self) -> None:
+        """--lines flag is parsed correctly."""
+        import ops
+
+        parser = ops.build_parser()
+        args = parser.parse_args(["lane", "peek", "author-a", "--lines", "200"])
+        assert args.lines == 200
+
+    def test_peek_text_output(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """lane peek without --json prints raw pane content."""
+        import subprocess
+
+        import ops
+
+        fake_output = "line1\nline2\nline3\n"
+        fake_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=fake_output, stderr=""
+        )
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake_result)
+        # Also mock _resolve_tmux_target
+        monkeypatch.setattr(
+            "bid_euchre.ops.worker_pool._resolve_tmux_target",
+            lambda *a, **kw: "steward:test.0",
+        )
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "lane",
+                "peek",
+                "author-a",
+            ]
+        )
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert captured.out == fake_output
+
+    def test_peek_json_output(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """lane peek --json wraps output in {lane, content} JSON object."""
+        import subprocess
+
+        import ops
+
+        fake_output = "hello world\n"
+        fake_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=fake_output, stderr=""
+        )
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake_result)
+        monkeypatch.setattr(
+            "bid_euchre.ops.worker_pool._resolve_tmux_target",
+            lambda *a, **kw: "steward:test.0",
+        )
+
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "lane",
+                "peek",
+                "author-a",
+            ]
+        )
+        assert rc == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["lane"] == "author-a"
+        assert data["content"] == fake_output
+
+    def test_peek_tmux_not_found(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """lane peek returns 1 when tmux is not found."""
+        import subprocess
+
+        import ops
+
+        def _raise_fnf(*a: object, **kw: object) -> None:
+            raise FileNotFoundError("tmux")
+
+        monkeypatch.setattr(subprocess, "run", _raise_fnf)
+        monkeypatch.setattr(
+            "bid_euchre.ops.worker_pool._resolve_tmux_target",
+            lambda *a, **kw: "steward:test.0",
+        )
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "lane",
+                "peek",
+                "author-a",
+            ]
+        )
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "tmux" in captured.err.lower()
+
+    def test_peek_tmux_failure(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """lane peek returns 1 when tmux capture-pane fails."""
+        import subprocess
+
+        import ops
+
+        fake_result = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="no such pane"
+        )
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake_result)
+        monkeypatch.setattr(
+            "bid_euchre.ops.worker_pool._resolve_tmux_target",
+            lambda *a, **kw: "steward:test.0",
+        )
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "lane",
+                "peek",
+                "author-a",
+            ]
+        )
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "no such pane" in captured.err

--- a/tests/unit/test_ops_dashboard.py
+++ b/tests/unit/test_ops_dashboard.py
@@ -835,3 +835,94 @@ class TestDashboardWatchFlag:
         output = stdout.decode()
         assert "Steward Dashboard" in output
         assert "Refreshing every 1s" in output
+
+    def test_single_shot_json_is_valid(self) -> None:
+        """Single-shot --json produces valid indented JSON."""
+        import subprocess
+
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "python",
+                "scripts/internal/ops.py",
+                "--json",
+                "dashboard",
+                "--no-probe",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert isinstance(data, dict)
+        # Indented output should contain newlines
+        assert "\n" in result.stdout
+
+    def test_watch_json_emits_ndjson(self) -> None:
+        """--watch --json produces compact NDJSON without ANSI escape codes."""
+        import signal
+        import subprocess
+        import time as time_mod
+
+        proc = subprocess.Popen(
+            [
+                "uv",
+                "run",
+                "python",
+                "scripts/internal/ops.py",
+                "--json",
+                "dashboard",
+                "--no-probe",
+                "--watch",
+                "--interval",
+                "1",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        # Give it time to print at least one iteration
+        time_mod.sleep(2)
+        proc.send_signal(signal.SIGINT)
+        stdout, _ = proc.communicate(timeout=5)
+        output = stdout.decode()
+
+        # No ANSI escape codes in JSON output
+        assert "\033[" not in output
+
+        # Each non-empty line should be valid JSON
+        lines = [ln for ln in output.strip().split("\n") if ln.strip()]
+        assert len(lines) >= 1
+        for line in lines:
+            data = json.loads(line)
+            assert isinstance(data, dict)
+
+    def test_watch_json_no_refresh_banner(self) -> None:
+        """--watch --json suppresses the 'Refreshing every Ns' banner."""
+        import signal
+        import subprocess
+        import time as time_mod
+
+        proc = subprocess.Popen(
+            [
+                "uv",
+                "run",
+                "python",
+                "scripts/internal/ops.py",
+                "--json",
+                "dashboard",
+                "--no-probe",
+                "--watch",
+                "--interval",
+                "1",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        time_mod.sleep(2)
+        proc.send_signal(signal.SIGINT)
+        stdout, _ = proc.communicate(timeout=5)
+        output = stdout.decode()
+
+        assert "Refreshing every" not in output


### PR DESCRIPTION
## Summary
- Add `lane peek` subcommand with `--json` support that wraps tmux pane output in `{"lane": ..., "content": ...}` JSON object
- Fix dashboard `--watch --json` to emit compact NDJSON (one JSON object per line) instead of corrupted multi-line output with ANSI escape codes
- Suppress "Refreshing every Ns" text banner in JSON watch mode

## Why
Three convention follow-up findings from the review coordinator:
- #1528: `lane peek` had no `--json` support — raw text was emitted regardless of the global `--json` flag
- #1539: Dashboard watch mode printed ANSI clear-screen codes (`\033[2J\033[H`) before JSON output, corrupting it
- #1540: Repeated `json.dumps(indent=2)` in watch mode produced invalid concatenated JSON; now emits compact NDJSON

## Relationship to PR #1531
This PR includes the full `lane peek` subcommand (with JSON support), superseding the implementation in PR #1531 (`ops/lane-peek-1526`). PR #1531 can be closed after this merges.

## Repro / Validation
```bash
# Single-shot JSON (indented, human-readable)
uv run python scripts/internal/ops.py --json dashboard --no-probe

# Watch mode JSON (compact NDJSON, no ANSI codes)
uv run python scripts/internal/ops.py --json dashboard --no-probe --watch --interval 2
# Ctrl+C to stop — each line is valid JSON

# Lane peek text
uv run python scripts/internal/ops.py lane peek author-a

# Lane peek JSON
uv run python scripts/internal/ops.py --json lane peek author-a
```

## Tests
```bash
uv run python -m pytest tests/unit/test_ops_dashboard.py::TestDashboardWatchFlag -v  # 6 tests
uv run python -m pytest tests/unit/test_ops_cli.py::TestLanePeek -v                 # 6 tests
make check-quiet                                                                      # ✓ full suite
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
branch: fix/ops-json-output
```

Closes #1528, #1539, #1540

🤖 Generated with [Claude Code](https://claude.com/claude-code)