### PR TITLE
fix(docs): correct SP-4-06 PR 1 reference in sub_plan_registry

### DIFF
--- a/plans/agent_ops/sub_plan_registry.md
+++ b/plans/agent_ops/sub_plan_registry.md
@@ -29,7 +29,7 @@
 | SP-4-03 | Token economy observability and dashboard | Phase 4, Pre-Platform-8 token observability | completed | orchestrator | `plans/agent_ops/4_remote_channel/sub/2026-03-23_token-economy-observability-and-dashboard.md` | 2026-03-23 | 2026-03-24 (baseline report at `plans/sessions/2026-03-23_token-economy-baseline.md`; dashboard auto-import via PR #1466) |
 | SP-4-04 | Platform-8a Telegram transport configuration | Phase 4, Platform-8a transport proving | completed | flex-a | `plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8a-telegram-transport.md` | 2026-03-23 | 2026-03-24 (PRs #1436, #1451, #1452; proven end-to-end) |
 | SP-4-05 | Reactive control-loop hardening | Phase 4, Pre-Platform-8 lifecycle reactivity and control-plane hardening | completed | orchestrator | `plans/agent_ops/4_remote_channel/sub/2026-03-24_reactive-control-loop-hardening.md` | 2026-03-24 | 2026-03-24 (PRs #1500, #1491, #1474, #1490, #1507, #1486; lifecycle proven through fleet operation) |
-| SP-4-06 | Platform-8b repo-owned remote audit trail | Phase 4, Platform-8b audit trail for remote exchanges | completed | author-a | `plans/agent_ops/4_remote_channel/sub/2026-03-24_platform-8b-audit-trail.md` | 2026-03-24 | 2026-03-24 (PRs #1533, #1536, #1541, #1549) |
+| SP-4-06 | Platform-8b repo-owned remote audit trail | Phase 4, Platform-8b audit trail for remote exchanges | completed | author-a | `plans/agent_ops/4_remote_channel/sub/2026-03-24_platform-8b-audit-trail.md` | 2026-03-24 | 2026-03-24 (PRs #1532, #1536, #1541, #1549) |
 
 ## Status Summary
 


### PR DESCRIPTION
## Summary

- Fix incorrect PR reference for SP-4-06 PR 1 in `plans/agent_ops/sub_plan_registry.md`: `#1533` → `#1532`

## Why

PR #1533 is "test: add fixture factory helpers for hosted_play export tests" (browser-game), not an SP-4-06 audit trail PR. The actual SP-4-06 PR 1 (core audit trail writer) is #1532 ("feat(ops): add audit trail writer for remote channel exchanges").

Closes #1558

## Repro / Validation

```bash
git diff --stat  # 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Tests

Docs-only change — no code affected.

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: fix/sp4-06-pr-ref
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)