### PR TITLE
fix(browser-game): add install hint and samefile guard to export CLI

### DIFF
--- a/scripts/internal/export_hosted_decisions.py
+++ b/scripts/internal/export_hosted_decisions.py
@@ -30,11 +30,20 @@ Export only human decisions::
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
-from web.db import init_engine, make_session_factory
-from web.export import export_decisions
+try:
+    from web.db import init_engine, make_session_factory
+    from web.export import export_decisions
+except ImportError:
+    print(
+        "Error: web package not found. Install the hosted extras:\n"
+        "  uv sync --extra hosted",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -74,6 +83,15 @@ def main(argv: list[str] | None = None) -> int:
     db_path: Path = args.db
     if not db_path.exists():
         print(f"Error: database not found: {db_path}", file=sys.stderr)
+        return 1
+
+    output_path: Path = args.output
+    if output_path.exists() and os.path.samefile(db_path, output_path):
+        print(
+            "Error: --output resolves to the same file as --db. "
+            "This would overwrite the database.",
+            file=sys.stderr,
+        )
         return 1
 
     database_url = f"sqlite:///{db_path.resolve()}"

--- a/tests/unit/hosted_play/test_export_cli.py
+++ b/tests/unit/hosted_play/test_export_cli.py
@@ -170,6 +170,27 @@ class TestMainCLI:
         assert code == 0
         assert output.exists()
 
+    def test_samefile_guard(self, tmp_path):
+        """--output that resolves to --db should return exit code 1."""
+        db_path = tmp_path / "test.db"
+        db_path.write_bytes(b"")  # create empty file
+
+        # Exact same path
+        code = main(["--db", str(db_path), "--output", str(db_path)])
+        assert code == 1
+
+    def test_samefile_guard_via_hardlink(self, tmp_path):
+        """--output pointing to a hard link of --db should be caught."""
+        import os
+
+        db_path = tmp_path / "test.db"
+        db_path.write_bytes(b"")
+        link_path = tmp_path / "alias.db"
+        os.link(db_path, link_path)
+
+        code = main(["--db", str(db_path), "--output", str(link_path)])
+        assert code == 1
+
     def test_help_flag(self):
         """--help should exit with code 0."""
         with pytest.raises(SystemExit) as exc_info:


### PR DESCRIPTION
## Plan
N/A — convention follow-up from review coordinator (#1559)

## Summary
- Wrap `web` package imports in `try/except` with helpful install hint pointing to `[hosted]` extras
- Add `os.path.samefile()` guard to prevent `--output` overwriting `--db` when they resolve to the same inode

## Why
Review coordinator flagged two defensive improvements for `export_hosted_decisions.py` after PR #1554. Bare `ImportError` gives no install guidance; missing samefile check could silently corrupt the database.

## Repro / Validation
**Command(s) run:**
```bash
uv run python scripts/internal/export_hosted_decisions.py --help
uv run python -m pytest tests/unit/hosted_play/test_export_cli.py -v
make check-quiet
```

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_export_cli.py -v` (6/6 passed)
- [x] `make check-quiet` ✓

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c  c8a2174b [browser-game/fix-1559-export-cli]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

Closes #1559