### PR TITLE
fix(browser-game): narrow CLI import guard to ModuleNotFoundError (#1566)

### DIFF
--- a/scripts/internal/export_hosted_decisions.py
+++ b/scripts/internal/export_hosted_decisions.py
@@ -37,7 +37,7 @@ from pathlib import Path
 try:
     from web.db import init_engine, make_session_factory
     from web.export import export_decisions
-except ImportError:
+except ModuleNotFoundError:
     print(
         "Error: web package not found. Install the hosted extras:\n"
         "  uv sync --extra hosted",

--- a/tests/unit/hosted_play/test_export_cli.py
+++ b/tests/unit/hosted_play/test_export_cli.py
@@ -196,3 +196,37 @@ class TestMainCLI:
         with pytest.raises(SystemExit) as exc_info:
             main(["--help"])
         assert exc_info.value.code == 0
+
+
+class TestImportGuard:
+    """Verify the import guard catches only ModuleNotFoundError (#1566)."""
+
+    def test_guard_uses_module_not_found_error(self):
+        """The import guard should be ModuleNotFoundError, not broad ImportError."""
+        import ast
+        from pathlib import Path
+
+        src = Path("scripts/internal/export_hosted_decisions.py").read_text()
+        tree = ast.parse(src)
+
+        # Find the module-level try/except that guards the web imports
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Try):
+                # Check if this try block imports from web.*
+                has_web_import = any(
+                    isinstance(stmt, (ast.Import, ast.ImportFrom))
+                    and getattr(stmt, "module", "") is not None
+                    and "web" in (getattr(stmt, "module", "") or "")
+                    for stmt in node.body
+                )
+                if has_web_import:
+                    for handler in node.handlers:
+                        assert handler.type is not None
+                        assert isinstance(handler.type, ast.Name)
+                        assert handler.type.id == "ModuleNotFoundError", (
+                            f"Import guard should catch ModuleNotFoundError, "
+                            f"not {handler.type.id}"
+                        )
+                    return
+
+        pytest.fail("Could not find the web import try/except block")


### PR DESCRIPTION
## Summary
- Narrow the import guard in `export_hosted_decisions.py` from broad `except ImportError` to `except ModuleNotFoundError`
- Add AST-based regression test verifying the guard exception type

## Why
The broad `except ImportError` could mask internal import bugs within the `web` package (e.g., a broken import *inside* `web.db`). `ModuleNotFoundError` fires only when a module itself is missing (e.g., sqlalchemy not installed), which is the intended guard behavior.

Convention follow-up from review coordinator on PR #1564.

## Repro / Validation
```bash
uv run python scripts/internal/export_hosted_decisions.py --help
uv run python -m pytest tests/unit/hosted_play/test_export_cli.py -v
make check-quiet
```

## Tests
- `tests/unit/hosted_play/test_export_cli.py::TestImportGuard::test_guard_uses_module_not_found_error` — AST-based regression test
- Full `make check-quiet` passes

## Worktree proof
```
pwd: Bid-Euchre-steward-author-c
branch: fix/narrow-cli-import-guard-1566
```

Closes #1566