### PR TITLE
fix(ops): emit valid JSON for lane peek and dashboard watch

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -175,24 +175,31 @@ def cmd_dashboard(args: argparse.Namespace) -> int:
                 check_worktree=not getattr(args, "no_probe", False),
             )
 
-            if watch:
-                # Clear screen for clean refresh
-                print("\033[2J\033[H", end="", flush=True)
-
             if args.json:
-                print(json.dumps(format_dashboard_json(view), indent=2))
+                # In watch mode, emit compact NDJSON (one JSON object per line)
+                # so the output stream stays machine-parseable.
+                # In single-shot mode, emit indented JSON for readability.
+                if watch:
+                    print(json.dumps(format_dashboard_json(view)))
+                else:
+                    print(json.dumps(format_dashboard_json(view), indent=2))
             else:
+                if watch:
+                    # Clear screen for clean refresh (text mode only —
+                    # ANSI escapes would corrupt JSON output)
+                    print("\033[2J\033[H", end="", flush=True)
                 print(format_dashboard_text(view))
 
             if not watch:
                 break
 
-            print(f"\n--- Refreshing every {interval}s (Ctrl+C to stop) ---")
+            if not args.json:
+                print(f"\n--- Refreshing every {interval}s (Ctrl+C to stop) ---")
             sys.stdout.flush()
             time.sleep(interval)
     except KeyboardInterrupt:
         if watch:
-            print("\nWatch stopped.")
+            print("\nWatch stopped.", file=sys.stderr)
         return 0
 
     return 0
@@ -2450,7 +2457,16 @@ def cmd_lane(args: argparse.Namespace) -> int:
                 err = result.stderr.strip()
                 print(f"Error: tmux capture-pane failed: {err}", file=sys.stderr)
                 return 1
-            print(result.stdout, end="")
+            content = result.stdout
+            if args.json:
+                print(
+                    json.dumps(
+                        {"lane": lane_id, "content": content},
+                        indent=2,
+                    )
+                )
+            else:
+                print(content, end="")
             return 0
         except FileNotFoundError:
             print("Error: tmux is not installed or not on PATH", file=sys.stderr)

--- a/tests/unit/test_ops_cli.py
+++ b/tests/unit/test_ops_cli.py
@@ -4467,6 +4467,39 @@ class TestCmdLanePeek:
         captured = capsys.readouterr()
         assert "timed out" in captured.err
 
+    def test_peek_json_output(
+        self, runtime_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--json flag emits valid JSON with lane and content keys."""
+        from unittest.mock import MagicMock, patch
+
+        import ops
+
+        mock_result = MagicMock(returncode=0, stdout="line1\nline2\n")
+        with (
+            patch("subprocess.run", return_value=mock_result),
+            patch(
+                "bid_euchre.ops.worker_pool._resolve_tmux_target",
+                return_value="steward:platform.1",
+            ),
+        ):
+            rc = ops.main(
+                [
+                    "--runtime-dir",
+                    str(runtime_dir),
+                    "--json",
+                    "lane",
+                    "peek",
+                    "author-a",
+                ]
+            )
+        assert rc == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["lane"] == "author-a"
+        assert "line1" in data["content"]
+        assert "line2" in data["content"]
+
     def test_peek_parser_registered(self) -> None:
         """The 'lane peek' subparser is registered in build_parser."""
         import ops

--- a/tests/unit/test_ops_dashboard.py
+++ b/tests/unit/test_ops_dashboard.py
@@ -835,3 +835,67 @@ class TestDashboardWatchFlag:
         output = stdout.decode()
         assert "Steward Dashboard" in output
         assert "Refreshing every 1s" in output
+
+    def test_single_shot_json_is_valid(self) -> None:
+        """Single-shot --json emits indented, parseable JSON."""
+        import subprocess
+
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "python",
+                "scripts/internal/ops.py",
+                "--json",
+                "dashboard",
+                "--no-probe",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert "summary" in data
+        # Indented output contains newlines
+        assert "\n" in result.stdout
+
+    def test_watch_json_emits_ndjson(self) -> None:
+        """--watch --json emits compact NDJSON (no ANSI escapes, no footer)."""
+        import signal
+        import subprocess
+        import time as time_mod
+
+        proc = subprocess.Popen(
+            [
+                "uv",
+                "run",
+                "python",
+                "scripts/internal/ops.py",
+                "--json",
+                "dashboard",
+                "--no-probe",
+                "--watch",
+                "--interval",
+                "1",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        # Give it time to emit at least one line
+        time_mod.sleep(2)
+        proc.send_signal(signal.SIGINT)
+        stdout, stderr = proc.communicate(timeout=5)
+        output = stdout.decode()
+        # Should NOT contain ANSI escape sequences
+        assert "\033[2J" not in output
+        # Should NOT contain text-mode footer
+        assert "Refreshing every" not in output
+        # Each non-empty line should be valid JSON
+        lines = [ln for ln in output.strip().split("\n") if ln.strip()]
+        assert len(lines) >= 1
+        for line in lines:
+            data = json.loads(line)
+            assert "summary" in data
+        # "Watch stopped." should go to stderr, not stdout
+        assert "Watch stopped." not in output


### PR DESCRIPTION
## Plan
N/A — follow-up fix for review findings #1528, #1539, #1540

## Summary
- `lane peek --json` now emits valid JSON (`{"lane": ..., "content": ...}`) instead of raw text
- `dashboard --watch --json` emits compact NDJSON (one JSON object per line) instead of indented JSON corrupted by ANSI escape sequences
- ANSI screen-clear and text-mode footer are suppressed in JSON mode
- "Watch stopped." message redirected to stderr to keep stdout clean

## Why
Three review coordinator findings identified that JSON output from `ops.py` was broken:
- #1528: `lane peek` ignored `--json` flag, emitting raw tmux capture
- #1539: `dashboard --watch --json` injected ANSI escape sequences (`\033[2J\033[H`) into JSON output, making it unparseable
- #1540: No valid streaming format for `--watch --json` — indented multi-line JSON objects concatenated without delimiters

Supersedes PR #1561 which was closed due to merge conflicts (#1568).

## Repro / Validation
**Command(s) run:**
```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/test_ops_cli.py::TestCmdLanePeek -v
uv run python -m pytest tests/unit/test_ops_dashboard.py::TestDashboardWatchFlag -v

# Tier 2 — full validation
make check-quiet
```

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_cli.py::TestCmdLanePeek` — 8 passed (including new JSON test)
- [x] `uv run python -m pytest tests/unit/test_ops_dashboard.py::TestDashboardWatchFlag` — 5 passed (including 2 new JSON tests)
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (ops tooling only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
```

`git worktree list` (truncated):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a  e3d499ab [fix/ops-json-output-v2]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)