### PR TITLE
fix(docs): replace exact test count in Phase 4 checkpoints

### DIFF
--- a/plans/browser_game/4_data_pipeline/checkpoints.md
+++ b/plans/browser_game/4_data_pipeline/checkpoints.md
@@ -16,7 +16,7 @@
 | Step 2: Implement export CLI (`scripts/internal/export_hosted_decisions.py`) | COMPLETE | 2026-03-24 | brws-author-a | PR #1538. --db, --output, --match-uuid, --human-only flags. |
 | Step 3: Implement replay validation | COMPLETE | 2026-03-24 | brws-author-a | PR #1545. `validate_replay` JSONL correctness verifier. |
 | Step 4: Write tests | COMPLETE | 2026-03-24 | brws-author-a | PR #1533 (fixture helpers) + tests in PRs #1529, #1535, #1545. All 6 required tests covered. |
-| Step 5: Run validation | COMPLETE | 2026-03-24 | brws-author-a | 233 tests pass (`tests/unit/hosted_play/`). Full `make check-quiet` green. |
+| Step 5: Run validation | COMPLETE | 2026-03-24 | brws-author-a | All hosted_play tests pass (`tests/unit/hosted_play/`). Full `make check-quiet` green. |
 
 ## Active Sub-Plans
 
@@ -36,7 +36,7 @@ Phase 4 depends on Phase 2 (not Phase 3). Can run in parallel with Phase 3.
 
 ### 2026-03-24 — brws-author-a (SP-4-01 closeout)
 - All 5 steps COMPLETE. PRs: #1529, #1533, #1535, #1538, #1545.
-- Validation pass: 233/233 tests pass in `tests/unit/hosted_play/`.
+- Validation pass: all hosted_play tests pass in `tests/unit/hosted_play/`.
 - SP-4-01 status: active → completed.
 - Phase 4 data pipeline is fully delivered.
 


### PR DESCRIPTION
## Summary
- Replace hardcoded "233 tests pass" with "all hosted_play tests pass" in browser Phase 4 checkpoints
- Prevents checkpoint staleness as tests are added/removed over time

## Why
The exact count "233" becomes stale whenever hosted_play tests are added, removed, or consolidated (e.g., PR #1579 just consolidated fixtures). Using approximate language avoids false staleness signals.

## Plan
N/A — single-file docs fix per task packet 91bb33271cfc

## Scope
- `plans/browser_game/4_data_pipeline/checkpoints.md` only

## Validation
```bash
# No "233" remains
grep -c "233" plans/browser_game/4_data_pipeline/checkpoints.md  # → 0

# New wording present
grep "all.*tests pass" plans/browser_game/4_data_pipeline/checkpoints.md  # → match

# Full validation
make check-quiet  # ✓ All checks passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b
branch: fix/phase4-checkpoint-test-count
```

## Review notes
Precheck P1 findings about `4_data_pipeline/sub/2026-03-14_export_replay.md` are false positives — the file exists at `plans/browser_game/4_data_pipeline/sub/2026-03-14_export_replay.md`. The relative path references are pre-existing and not modified by this PR.

Fixes #1574

🤖 Generated with [Claude Code](https://claude.com/claude-code)