### PR TITLE
fix(browser-game): add export ordering tests and document streaming safety

### DIFF
--- a/tests/unit/hosted_play/test_export.py
+++ b/tests/unit/hosted_play/test_export.py
@@ -504,6 +504,63 @@ class TestExportDecisions:
         assert record["match_uuid"] == target_uuid
         assert record["actor_type"] == "human"
 
+    def test_export_orders_by_hand_number(self, db_session, tmp_path):
+        """Records are ordered by hand_number regardless of DB insertion order.
+
+        Regression test for #1575 / #1577: export_decisions must ORDER BY
+        Hand.hand_number (logical order), not Hand.id (insertion order).
+        We insert hand_number=2 before hand_number=1 so the DB auto-increment
+        ids are reversed relative to logical hand order.
+        """
+        player = create_test_player(db_session)
+        match = create_test_match(db_session, player_id=player.id)
+
+        # Insert hand_number=2 first (gets lower hand.id)
+        hand_2 = create_test_hand(db_session, match, hand_number=2)
+        # Insert hand_number=1 second (gets higher hand.id)
+        hand_1 = create_test_hand(db_session, match, hand_number=1)
+
+        # One decision per hand
+        create_test_decision(db_session, match, hand_2, turn_number=0)
+        create_test_decision(db_session, match, hand_1, turn_number=0)
+        db_session.commit()
+
+        output = tmp_path / "ordered.jsonl"
+        count = export_decisions(db_session, output)
+
+        assert count == 2
+        lines = output.read_text().strip().splitlines()
+        records = [json.loads(line) for line in lines]
+
+        # hand_number=1 must come before hand_number=2
+        assert records[0]["hand_number"] == 1
+        assert records[1]["hand_number"] == 2
+
+    def test_export_orders_by_turn_within_hand(self, db_session, tmp_path):
+        """Within the same hand, records are ordered by turn_number.
+
+        Companion to test_export_orders_by_hand_number — verifies the
+        secondary sort key (turn_number) within a hand.
+        """
+        player = create_test_player(db_session)
+        match = create_test_match(db_session, player_id=player.id)
+        hand = create_test_hand(db_session, match, hand_number=1)
+
+        # Insert turn_number=2 before turn_number=0
+        create_test_decision(db_session, match, hand, turn_number=2, seat=2)
+        create_test_decision(db_session, match, hand, turn_number=0, seat=0)
+        create_test_decision(db_session, match, hand, turn_number=1, seat=1)
+        db_session.commit()
+
+        output = tmp_path / "turn_ordered.jsonl"
+        count = export_decisions(db_session, output)
+
+        assert count == 3
+        lines = output.read_text().strip().splitlines()
+        records = [json.loads(line) for line in lines]
+
+        assert [r["turn_number"] for r in records] == [0, 1, 2]
+
     def test_output_lines_are_valid_json(self, db_session, tmp_path):
         """Every line in the output file is valid JSON with schema fields."""
         player = create_test_player(db_session)

--- a/web/export.py
+++ b/web/export.py
@@ -168,6 +168,12 @@ def export_decisions(
 
     # Order by logical hand number (not internal hand_id FK) for
     # deterministic, semantically meaningful output (#1537).
+    #
+    # The ORDER BY is evaluated by the database engine before cursor
+    # iteration begins; yield_per() still batches cursor reads without
+    # materializing all rows into Python memory.  For the expected data
+    # volumes (hundreds to low-thousands of decisions per export) the
+    # sort is negligible.  See #1578.
     query = query.order_by(Decision.match_id, Hand.hand_number, Decision.turn_number)
 
     count = 0


### PR DESCRIPTION
## Plan
N/A — follow-up from PR #1575 review findings.

## Summary
- Add two tests locking hand_number and turn_number ordering in `export_decisions()` (#1577)
- Document why `ORDER BY` on joined column is compatible with `yield_per()` streaming (#1578)

## Why
PR #1575 changed the `ORDER BY` from `Decision.hand_id` (internal FK) to `Hand.hand_number` (logical order), but no test verified the ordering behavior. The review also flagged a concern about ORDER BY defeating streaming — this is addressed with a clarifying comment.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_export.py -v -k "order"
uv run python -m pytest tests/unit/hosted_play/test_export.py -v
make check-quiet
```

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_export.py -v` — 36 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git worktree list`:
```
Bid-Euchre-steward-brws-author-a  f7a82ff2 [fix/export-ordering-test-streaming]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

Fixes #1577, fixes #1578