### PR TITLE
docs: add test criteria policy to templates and CLAUDE.md

### DIFF
--- a/.claude/skills/executing-plans/WORK_UNIT_TEMPLATE.md
+++ b/.claude/skills/executing-plans/WORK_UNIT_TEMPLATE.md
@@ -19,10 +19,16 @@ Each agent receives instructions in this format:
 7. Create PR with plan reference
 8. Update MEMORY.md with completion status
 
+**Test Criteria**:
+<!-- Specific, verifiable conditions — not just "tests pass" -->
+- [Exact verification command and expected output]
+- [Observable outcome that proves the feature works end-to-end]
+
 **Exit Criteria**:
 - All changes implemented
+- Test criteria verified (see above)
 - `make check` passing
-- PR created
+- PR created with test criteria in description
 - MEMORY.md updated
 ```
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,13 @@
 **Seed (if applicable):**
 -
 
+## Test Criteria
+<!-- Define specific, verifiable conditions that prove this PR is done.
+     Not just "tests pass" — what observable outcome proves the feature works? -->
+- **Pass condition:** <!-- e.g., "grep -c audit_reply src/bid_euchre/ops/*.py returns >= 1" -->
+- **Verification command:** <!-- exact command to run -->
+- **Expected result:** <!-- what the output should look like -->
+
 ## Tests
 - [ ] `PYTHONPATH=src python -m pytest -m "not slow" tests/`
 - [ ] Integration (if engine/rules changed): `PYTHONPATH=src python -m pytest tests/integration/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,7 @@ All code changes MUST happen in dedicated git worktrees, never on `main` in the 
 - Run `make check` before opening
 - Include exact repro command with seed in PR description
 - Use the PR template from `.github/pull_request_template.md`
+- **Define test criteria** — every PR must include specific, verifiable pass/fail conditions (not just "tests pass"). State what observable outcome proves the feature works, with exact commands and expected results.
 - After `reviewing-changes` passes, wait for Codex pre-merge review before merging (see `docs/02_agent/CODEX_GITHUB_REVIEW.md`)
 
 ### Post-Merge Review


### PR DESCRIPTION
## Plan
N/A — standalone task from issue #1581

## Summary
- Added `## Test Criteria` section to PR template (`.github/pull_request_template.md`)
- Added test criteria requirement to PR Requirements in `CLAUDE.md`
- Added `**Test Criteria**` section to work unit template (`.claude/skills/executing-plans/WORK_UNIT_TEMPLATE.md`)

## Why
During the overnight run (2026-03-24), Platform-8b was marked COMPLETE despite missing runtime wiring (#1573). Explicit test criteria would have caught this — "tests pass" is insufficient, PRs need specific observable outcomes.

## Test Criteria
- `grep -c "Test Criteria" .github/pull_request_template.md` returns ≥ 1
- `grep -ci "test criteria" CLAUDE.md` returns ≥ 1
- `make check-quiet` passes

## Repro / Validation
**Command(s) run:**
```
grep -c "Test Criteria" .github/pull_request_template.md  # → 1
grep -ci "test criteria" CLAUDE.md                        # → 1
make check-quiet                                          # → all checks passed
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Tests
- [x] `make check-quiet` passes (docs-only change, no Python tests affected)

## Expected impact
- Metrics impact: none
- Runtime impact: none

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
```

`git worktree list`:
```
(persistent steward flex-a worktree)
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

Fixes #1581

🤖 Generated with [Claude Code](https://claude.com/claude-code)