### PR TITLE
fix(ops): skip acked messages in TTL auto-expiry (#1596)

### DIFF
--- a/src/bid_euchre/ops/message_bus.py
+++ b/src/bid_euchre/ops/message_bus.py
@@ -421,10 +421,10 @@ def _expire_stale_on_read(
     Only non-terminal messages with a numeric ``ttl_seconds`` are checked.
     """
     current_time = now if now is not None else time.time()
-    terminal = {"resolved", "expired", "dead_lettered"}
+    skip = {"resolved", "expired", "dead_lettered", "acked"}
 
     for mid, rec in list(by_id.items()):
-        if rec.get("status") in terminal:
+        if rec.get("status") in skip:
             continue
         ttl = rec.get("payload", {}).get("ttl_seconds")
         if ttl is None:

--- a/tests/unit/test_ops_message_bus.py
+++ b/tests/unit/test_ops_message_bus.py
@@ -1197,6 +1197,32 @@ class TestTTLAutoExpireOnRead:
         assert len(inbox) == 1
         assert inbox[0]["status"] == "resolved"
 
+    def test_auto_expire_skips_acked_messages(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Acked messages must not be auto-expired — acked→expired is invalid.
+
+        Regression test for #1596: _expire_stale_on_read() crashed with
+        ValueError when it encountered an acked message past its TTL,
+        because acked→expired is not a valid transition.
+        """
+        msg = create_message(
+            "a",
+            "target",
+            "assignment",
+            "Acked task",
+            payload={"ttl_seconds": 1},
+        )
+        send_message(msg, bus_root, events_dir=events_dir)
+        ack_message(msg.message_id, "target", bus_root, events_dir=events_dir)
+
+        # Read well past the TTL — must NOT raise ValueError
+        future_time = time.time() + 100  # well past 1s TTL
+        inbox = read_inbox("target", bus_root, now=future_time)
+        acked = [m for m in inbox if m["message_id"] == msg.message_id]
+        assert len(acked) == 1
+        assert acked[0]["status"] == "acked"
+
     def test_no_ttl_never_auto_expires(self, bus_root: Path, events_dir: Path) -> None:
         """Messages with ttl_seconds=None are never auto-expired on read."""
         msg = create_message(


### PR DESCRIPTION
## Plan
N/A — targeted bugfix

## Summary
- Fix `ValueError` crash in `_expire_stale_on_read()` when encountering acked messages past their TTL
- Add regression test proving the exact crash scenario from #1596

## Why
`_expire_stale_on_read()` skipped terminal states (resolved/expired/dead_lettered) but not acked messages. Since `acked→expired` is not a valid transition, the function crashed with `ValueError` when it encountered an acked message past its TTL. This caused `read_inbox()` and the `inbox` CLI command to fail on any lane with old acked messages.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_message_bus.py::TestTTLAutoExpireOnRead::test_auto_expire_skips_acked_messages -xvs
make check-quiet
```

**Config:** N/A
**Seed:** N/A

## Test Criteria
- **Pass condition:** `read_inbox()` with `auto_expire=True` does not crash when acked messages are past their TTL; acked message remains in "acked" status (not expired)
- **Verification command:** `uv run python -m pytest tests/unit/test_ops_message_bus.py::TestTTLAutoExpireOnRead::test_auto_expire_skips_acked_messages -xvs`
- **Expected result:** Test passes — acked message stays "acked", no ValueError

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_message_bus.py` — 115 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None
- Runtime impact: None — trivial set membership check

## Risk level
- [x] Low (ops infra only — no game logic)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre  812c3983 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author  63675fae [fix/acked-expired-crash]
(+ 21 other worktrees)
```

## Infra Incident
- Issue: #1596
- First occurrence or repeat: first
- Regression test: `tests/unit/test_ops_message_bus.py::TestTTLAutoExpireOnRead::test_auto_expire_skips_acked_messages`
- Detection/logging note: Detected during fleet run when orchestrator inbox read crashed on acked messages past 24h TTL

## Checklist
- [x] No generated artifacts committed
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)