### PR TITLE
feat(ops): add check_ack_status() and escalate_unacked() helpers (#1571)

### DIFF
--- a/src/bid_euchre/ops/message_bus.py
+++ b/src/bid_euchre/ops/message_bus.py
@@ -947,6 +947,129 @@ def resolve_message(
     return updated
 
 
+def check_ack_status(
+    message_id: str,
+    recipient_lane: str,
+    bus_root: Path | None = None,
+) -> str | None:
+    """Check if a message was acked by the recipient.
+
+    Looks up the latest record for *message_id* in *recipient_lane*'s inbox
+    and returns the current status string (``'pending'``, ``'acked'``,
+    ``'resolved'``, etc.) or ``None`` if the message is not found.
+
+    This lets a sender verify that the recipient has acknowledged a message
+    without reading the full inbox.
+
+    Args:
+        message_id: The ID of the message to check.
+        recipient_lane: The lane whose inbox to look in.
+        bus_root: Override for bus root directory.
+
+    Returns:
+        The current status string, or ``None`` if the message is not found.
+    """
+    root = shared_bus_root(bus_root)
+    raw = _read_inbox_raw(recipient_lane, root)
+
+    # Deduplicate: latest record per message_id wins
+    latest: dict[str, Any] | None = None
+    for rec in raw:
+        if rec.get("message_id") == message_id:
+            latest = rec
+
+    if latest is None:
+        return None
+
+    return latest.get("status", "pending")
+
+
+def escalate_unacked(
+    sender_lane: str,
+    recipient_lane: str,
+    max_age_minutes: int = 10,
+    bus_root: Path | None = None,
+    *,
+    events_dir: Path | None = None,
+) -> list[str]:
+    """Find unacked outbound messages older than *max_age_minutes* and escalate.
+
+    Scans the *recipient_lane*'s inbox for messages sent by *sender_lane*
+    that are still in ``pending`` or ``delivered`` status and whose
+    ``created_at`` timestamp is older than *max_age_minutes*.
+
+    For each such message an escalation message is created (priority ``urgent``,
+    type ``escalation``) referencing the original via ``parent_message_id``,
+    and sent to the recipient.
+
+    Args:
+        sender_lane: The lane that sent the original messages.
+        recipient_lane: The lane whose inbox to scan for unacked messages.
+        max_age_minutes: Age threshold in minutes before escalation fires.
+        bus_root: Override for bus root directory.
+        events_dir: Override for events directory (for testing).
+
+    Returns:
+        List of escalation message IDs sent.
+    """
+    root = shared_bus_root(bus_root)
+    raw = _read_inbox_raw(recipient_lane, root)
+
+    # Deduplicate: latest record per message_id wins
+    by_id: dict[str, dict[str, Any]] = {}
+    for rec in raw:
+        mid = rec.get("message_id")
+        if mid:
+            by_id[mid] = rec
+
+    cutoff_ts = time.time() - (max_age_minutes * 60)
+    unacked_statuses = {"pending", "delivered"}
+    escalation_ids: list[str] = []
+
+    for mid, rec in by_id.items():
+        # Only look at messages from the sender to the recipient
+        if rec.get("from_lane") != sender_lane:
+            continue
+        if rec.get("status") not in unacked_statuses:
+            continue
+        # Don't escalate escalation messages (avoid infinite chains)
+        if rec.get("message_type") == "escalation":
+            continue
+
+        created = rec.get("created_at", "")
+        try:
+            created_ts = datetime.fromisoformat(created).timestamp()
+        except (ValueError, TypeError):
+            continue
+
+        if created_ts > cutoff_ts:
+            continue  # Not old enough yet
+
+        # Create and send an escalation message
+        esc_msg = create_message(
+            from_lane=sender_lane,
+            to_lane=recipient_lane,
+            message_type="escalation",
+            summary=f"ESCALATION: unacked message {mid} (original: {rec.get('summary', '?')})",
+            priority="urgent",
+            parent_message_id=mid,
+            payload={
+                "original_message_id": mid,
+                "original_summary": rec.get("summary", ""),
+            },
+        )
+        esc_id = send_message(esc_msg, root, events_dir=events_dir)
+        escalation_ids.append(esc_id)
+        logger.info(
+            "Escalated unacked message %s from %s to %s",
+            mid,
+            sender_lane,
+            recipient_lane,
+        )
+
+    return escalation_ids
+
+
 def check_expired(
     bus_root: Path | None = None,
     *,

--- a/tests/unit/test_ops_message_bus.py
+++ b/tests/unit/test_ops_message_bus.py
@@ -34,11 +34,13 @@ from bid_euchre.ops.message_bus import (
     ack_message,
     append_message,
     bulk_ack_messages,
+    check_ack_status,
     check_dead_letters,
     check_expired,
     compact_all_inboxes,
     compact_inbox,
     create_message,
+    escalate_unacked,
     import_native_inbox,
     inbox_stats,
     mark_delivered,
@@ -1920,3 +1922,196 @@ class TestAutoCompaction:
         # so auto-compact doesn't fire — messages remain
         inbox = read_inbox(lane, bus_root, auto_compact=True, now=future)
         assert len(inbox) == 5
+
+
+# ---------------------------------------------------------------------------
+# check_ack_status
+# ---------------------------------------------------------------------------
+
+
+class TestCheckAckStatus:
+    """Test check_ack_status() helper for sender-side ack verification."""
+
+    def test_pending_status(self, bus_root: Path, events_dir: Path) -> None:
+        """A newly sent message should report 'pending' status."""
+        msg = create_message("ops", "orch", "progress", "Status update")
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        status = check_ack_status(msg.message_id, "orch", bus_root)
+        assert status == "pending"
+
+    def test_acked_status(self, bus_root: Path, events_dir: Path) -> None:
+        """After ack, check_ack_status should return 'acked'."""
+        msg = create_message("ops", "orch", "progress", "Status update")
+        send_message(msg, bus_root, events_dir=events_dir)
+        ack_message(msg.message_id, "orch", bus_root, events_dir=events_dir)
+
+        status = check_ack_status(msg.message_id, "orch", bus_root)
+        assert status == "acked"
+
+    def test_resolved_status(self, bus_root: Path, events_dir: Path) -> None:
+        """After resolve, check_ack_status should return 'resolved'."""
+        msg = create_message("ops", "orch", "progress", "Status update")
+        send_message(msg, bus_root, events_dir=events_dir)
+        ack_message(msg.message_id, "orch", bus_root, events_dir=events_dir)
+        resolve_message(msg.message_id, "orch", bus_root, events_dir=events_dir)
+
+        status = check_ack_status(msg.message_id, "orch", bus_root)
+        assert status == "resolved"
+
+    def test_delivered_status(self, bus_root: Path, events_dir: Path) -> None:
+        """After mark_delivered, check_ack_status should return 'delivered'."""
+        msg = create_message("ops", "orch", "progress", "Status update")
+        send_message(msg, bus_root, events_dir=events_dir)
+        mark_delivered(msg.message_id, "orch", bus_root, events_dir=events_dir)
+
+        status = check_ack_status(msg.message_id, "orch", bus_root)
+        assert status == "delivered"
+
+    def test_not_found_returns_none(self, bus_root: Path) -> None:
+        """Looking up a non-existent message returns None."""
+        status = check_ack_status("nonexistent_id", "orch", bus_root)
+        assert status is None
+
+    def test_wrong_lane_returns_none(self, bus_root: Path, events_dir: Path) -> None:
+        """Message sent to lane A is not found in lane B."""
+        msg = create_message("ops", "orch", "progress", "Status update")
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        status = check_ack_status(msg.message_id, "author-a", bus_root)
+        assert status is None
+
+
+# ---------------------------------------------------------------------------
+# escalate_unacked
+# ---------------------------------------------------------------------------
+
+
+class TestEscalateUnacked:
+    """Test escalate_unacked() helper for SLA-based escalation."""
+
+    def test_escalates_old_unacked_message(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Unacked messages past the SLA should produce escalation messages."""
+        msg = create_message("ops", "orch", "progress", "Check status")
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        # max_age_minutes=0 means any message is past SLA immediately
+        escalation_ids = escalate_unacked(
+            "ops", "orch", max_age_minutes=0, bus_root=bus_root, events_dir=events_dir
+        )
+        assert len(escalation_ids) == 1
+
+        # Verify escalation message exists in recipient inbox
+        inbox = read_inbox("orch", bus_root, auto_expire=False)
+        escalation = [m for m in inbox if m["message_id"] == escalation_ids[0]]
+        assert len(escalation) == 1
+        assert escalation[0]["priority"] == "urgent"
+        assert escalation[0]["message_type"] == "escalation"
+        assert escalation[0]["parent_message_id"] == msg.message_id
+
+    def test_skips_acked_messages(self, bus_root: Path, events_dir: Path) -> None:
+        """Acked messages should not be escalated."""
+        msg = create_message("ops", "orch", "progress", "Check status")
+        send_message(msg, bus_root, events_dir=events_dir)
+        ack_message(msg.message_id, "orch", bus_root, events_dir=events_dir)
+
+        escalation_ids = escalate_unacked(
+            "ops", "orch", max_age_minutes=0, bus_root=bus_root, events_dir=events_dir
+        )
+        assert len(escalation_ids) == 0
+
+    def test_skips_resolved_messages(self, bus_root: Path, events_dir: Path) -> None:
+        """Resolved messages should not be escalated."""
+        msg = create_message("ops", "orch", "progress", "Check status")
+        send_message(msg, bus_root, events_dir=events_dir)
+        ack_message(msg.message_id, "orch", bus_root, events_dir=events_dir)
+        resolve_message(msg.message_id, "orch", bus_root, events_dir=events_dir)
+
+        escalation_ids = escalate_unacked(
+            "ops", "orch", max_age_minutes=0, bus_root=bus_root, events_dir=events_dir
+        )
+        assert len(escalation_ids) == 0
+
+    def test_skips_messages_from_other_senders(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Only messages from the specified sender should be escalated."""
+        msg = create_message("author-a", "orch", "progress", "Check status")
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        # Escalate from ops — should find nothing since msg is from author-a
+        escalation_ids = escalate_unacked(
+            "ops", "orch", max_age_minutes=0, bus_root=bus_root, events_dir=events_dir
+        )
+        assert len(escalation_ids) == 0
+
+    def test_skips_young_messages(self, bus_root: Path, events_dir: Path) -> None:
+        """Messages not yet past the SLA should not be escalated."""
+        msg = create_message("ops", "orch", "progress", "Check status")
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        # High max_age means the fresh message is too young
+        escalation_ids = escalate_unacked(
+            "ops",
+            "orch",
+            max_age_minutes=9999,
+            bus_root=bus_root,
+            events_dir=events_dir,
+        )
+        assert len(escalation_ids) == 0
+
+    def test_does_not_escalate_escalation_messages(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Escalation messages themselves should never be re-escalated."""
+        # Send a normal message and escalate it
+        msg = create_message("ops", "orch", "progress", "Check status")
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        first_escalation = escalate_unacked(
+            "ops", "orch", max_age_minutes=0, bus_root=bus_root, events_dir=events_dir
+        )
+        assert len(first_escalation) == 1
+
+        # Now escalate again — only the original message should fire,
+        # not the escalation message itself. But the original is still
+        # pending, so it escalates again (just not the escalation).
+        second_escalation = escalate_unacked(
+            "ops", "orch", max_age_minutes=0, bus_root=bus_root, events_dir=events_dir
+        )
+        # Should still escalate the original (it's still unacked)
+        assert len(second_escalation) == 1
+        # But the escalation message IDs should be different
+        assert second_escalation[0] != first_escalation[0]
+
+    def test_multiple_unacked_messages(self, bus_root: Path, events_dir: Path) -> None:
+        """Multiple unacked messages should each get an escalation."""
+        msg1 = create_message("ops", "orch", "progress", "Task A")
+        msg2 = create_message("ops", "orch", "assignment", "Task B")
+        send_message(msg1, bus_root, events_dir=events_dir)
+        send_message(msg2, bus_root, events_dir=events_dir)
+
+        escalation_ids = escalate_unacked(
+            "ops", "orch", max_age_minutes=0, bus_root=bus_root, events_dir=events_dir
+        )
+        assert len(escalation_ids) == 2
+
+    def test_mixed_acked_and_unacked(self, bus_root: Path, events_dir: Path) -> None:
+        """Only unacked messages get escalated when mixed with acked."""
+        msg1 = create_message("ops", "orch", "progress", "Acked task")
+        msg2 = create_message("ops", "orch", "assignment", "Unacked task")
+        send_message(msg1, bus_root, events_dir=events_dir)
+        send_message(msg2, bus_root, events_dir=events_dir)
+        ack_message(msg1.message_id, "orch", bus_root, events_dir=events_dir)
+
+        escalation_ids = escalate_unacked(
+            "ops", "orch", max_age_minutes=0, bus_root=bus_root, events_dir=events_dir
+        )
+        assert len(escalation_ids) == 1
+
+        # Verify the escalation references the unacked message
+        inbox = read_inbox("orch", bus_root, auto_expire=False, limit=100)
+        esc = [m for m in inbox if m["message_id"] == escalation_ids[0]]
+        assert esc[0]["parent_message_id"] == msg2.message_id


### PR DESCRIPTION
## Plan
plans/sessions/2026-03-24_messaging-redesign.md §Q3 — Phase 1c

## Summary
- Add `check_ack_status()` — lets a sender check if a recipient has acked their message
- Add `escalate_unacked()` — finds unacked messages past SLA and sends urgent escalation messages
- 14 new tests covering all acceptance criteria from the task packet

## Why
Part of the bilateral ack feedback loop for the messaging redesign (#1571 Phase 1c).
These helpers enable the orchestrator and ops monitor to verify message delivery
and automatically escalate when lanes fail to acknowledge within SLA.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_message_bus.py::TestCheckAckStatus tests/unit/test_ops_message_bus.py::TestEscalateUnacked -v
make check-quiet
```

## Test Criteria
- **Pass condition:** All 14 new tests pass covering the 4 scenarios specified in the task packet
- **Verification command:** `uv run python -m pytest tests/unit/test_ops_message_bus.py -k "TestCheckAckStatus or TestEscalateUnacked" -v`
- **Expected result:** 14 passed, 0 failed

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_message_bus.py` — 128 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None (ops tooling only)
- Runtime impact: None (new functions, no existing behavior changed)

## Risk level
- [x] Low (ops tooling addition, no core changes)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

`git worktree list`:
```
Bid-Euchre-steward-author-c  748d3d4a [ops/ack-status-escalation]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)