### PR TITLE
feat(ops): add read_inbox_prioritized() with P0/P1/P2 tiers (#1571)

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -38,7 +38,7 @@ Usage:
     uv run python scripts/internal/ops.py task approve PACKET_ID [--json]
     uv run python scripts/internal/ops.py task dispatch PACKET_ID LANE_ID [--approve] [--json]
     uv run python scripts/internal/ops.py task accept PACKET_ID --lane LANE [--json]
-    uv run python scripts/internal/ops.py inbox [--lane LANE] [--status STATUS] [--type TYPE] [--thread THREAD] [--json]
+    uv run python scripts/internal/ops.py inbox [--lane LANE] [--status STATUS] [--type TYPE] [--thread THREAD] [--prioritized] [--json]
     uv run python scripts/internal/ops.py inbox stats [--json]
     uv run python scripts/internal/ops.py inbox ack MSG_ID --lane LANE [--json]
     uv run python scripts/internal/ops.py message show MSG_ID [--json]
@@ -1819,6 +1819,7 @@ def cmd_inbox(args: argparse.Namespace) -> int:
         import_native_inbox,
         inbox_stats,
         read_inbox,
+        read_inbox_prioritized,
         shared_bus_root,
     )
 
@@ -1977,6 +1978,45 @@ def cmd_inbox(args: argparse.Namespace) -> int:
                     print(f"  {ln['lane_id']:20s}  {total} msg  ({pending} unresolved)")
         return 0
 
+    # --prioritized: group messages by P0/P1/P2 tiers
+    use_prioritized = getattr(args, "prioritized", False)
+    if use_prioritized:
+        p0, p1, p2 = read_inbox_prioritized(
+            lane,
+            bus_root,
+            status=status_filter,
+        )
+        if args.json:
+            print(
+                json.dumps(
+                    {"p0": p0, "p1": p1, "p2": p2},
+                    indent=2,
+                    default=str,
+                )
+            )
+        else:
+            total = len(p0) + len(p1) + len(p2)
+            if total == 0:
+                print(f"No messages in {lane} inbox.")
+            else:
+                print(f"Inbox for {lane}: {total} message(s) (prioritized)")
+                for label, tier in [
+                    ("P0 (urgent)", p0),
+                    ("P1 (high)", p1),
+                    ("P2 (normal/low)", p2),
+                ]:
+                    print()
+                    print(f"  {label}: {len(tier)} message(s)")
+                    for msg in tier:
+                        print(
+                            f"    {msg.get('message_id', '?'):16s}  "
+                            f"[{msg.get('status', '?'):14s}]  "
+                            f"{msg.get('message_type', '?'):18s}  "
+                            f"from={msg.get('from_lane', '?'):12s}  "
+                            f"{msg.get('summary', '')[:50]}"
+                        )
+        return 0
+
     messages = read_inbox(
         lane,
         bus_root,
@@ -2024,6 +2064,7 @@ def cmd_message(args: argparse.Namespace) -> int:
             summary=args.summary,
             task_id=getattr(args, "task_id", None),
             thread_id=getattr(args, "thread_id", None),
+            priority=getattr(args, "priority", "normal"),
         )
         try:
             msg_id = send_message(msg, bus_root)
@@ -3336,6 +3377,12 @@ def build_parser() -> argparse.ArgumentParser:
         default=False,
         help="Import Claude native inbox messages before listing (requires --lane)",
     )
+    inbox_parser.add_argument(
+        "--prioritized",
+        action="store_true",
+        default=False,
+        help="Group messages by priority tier (P0/P1/P2). Requires --lane.",
+    )
 
     # message (Platform-3 audit trail)
     message_parser = subparsers.add_parser(
@@ -3377,6 +3424,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     message_send_parser.add_argument(
         "--thread", default=None, dest="thread_id", help="Thread ID for conversation"
+    )
+    message_send_parser.add_argument(
+        "--priority",
+        default="normal",
+        choices=["low", "normal", "high", "urgent"],
+        help="Message priority (default: normal)",
     )
 
     # supervisor (Platform-6: supervisor routines and delta summaries)

--- a/src/bid_euchre/ops/message_bus.py
+++ b/src/bid_euchre/ops/message_bus.py
@@ -538,6 +538,57 @@ def read_inbox(
     return result
 
 
+# ---------------------------------------------------------------------------
+# Priority-grouped inbox read
+# ---------------------------------------------------------------------------
+
+# Mapping from priority field values to tier indices (P0/P1/P2).
+_PRIORITY_TO_TIER: dict[str, int] = {
+    "urgent": 0,  # P0 — interrupt-worthy
+    "high": 1,  # P1 — next-cycle processing
+    "normal": 2,  # P2 — batch processing
+    "low": 2,  # P2 — batch processing
+}
+
+
+def read_inbox_prioritized(
+    lane_id: str,
+    bus_root: Path | None = None,
+    *,
+    status: str | None = "pending",
+    auto_expire: bool = True,
+    auto_compact: bool = True,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Read inbox grouped by priority tier.
+
+    Returns ``(p0, p1, p2)`` where:
+
+    - **p0** = ``urgent`` priority messages (interrupt-worthy)
+    - **p1** = ``high`` priority messages (next-cycle processing)
+    - **p2** = ``normal`` / ``low`` priority messages (batch processing)
+
+    Each tier list is ordered most-recent-first, matching ``read_inbox()``.
+    """
+    messages = read_inbox(
+        lane_id,
+        bus_root,
+        status=status,
+        auto_expire=auto_expire,
+        auto_compact=auto_compact,
+    )
+
+    p0: list[dict[str, Any]] = []
+    p1: list[dict[str, Any]] = []
+    p2: list[dict[str, Any]] = []
+    buckets = (p0, p1, p2)
+
+    for msg in messages:
+        tier = _PRIORITY_TO_TIER.get(msg.get("priority", "normal"), 2)
+        buckets[tier].append(msg)
+
+    return p0, p1, p2
+
+
 def query_unresolved(
     lane_id: str,
     bus_root: Path | None = None,

--- a/tests/unit/test_ops_cli.py
+++ b/tests/unit/test_ops_cli.py
@@ -3899,6 +3899,135 @@ class TestInboxAck:
         assert "Acknowledged" in out
         assert msg_id in out
 
+    def test_inbox_prioritized_json(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """--prioritized --json returns P0/P1/P2 structure."""
+        import ops
+
+        # Isolate bus root to temp dir to avoid real project bus data
+        bus_dir = runtime_dir / "message_bus"
+        bus_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("BID_EUCHRE_BUS_DIR", str(bus_dir))
+
+        # Send messages at different priorities
+        for prio, msg_type, summary in [
+            ("urgent", "blocker", "Lane crash"),
+            ("high", "completion", "PR merged"),
+            ("normal", "progress", "Tests running"),
+        ]:
+            rc = ops.main(
+                [
+                    "--json",
+                    "--runtime-dir",
+                    str(runtime_dir),
+                    "--plans-dir",
+                    str(plans_dir),
+                    "message",
+                    "send",
+                    "--from",
+                    "ops",
+                    "--to",
+                    "orchestrator",
+                    "--type",
+                    msg_type,
+                    "--summary",
+                    summary,
+                    "--priority",
+                    prio,
+                ]
+            )
+            # Capture and discard send output
+            capsys.readouterr()
+
+        # Now read with --prioritized --json (status=None to get all, since
+        # messages are in "pending" status after send)
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "inbox",
+                "--lane",
+                "orchestrator",
+                "--prioritized",
+            ]
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert "p0" in data
+        assert "p1" in data
+        assert "p2" in data
+        assert len(data["p0"]) == 1
+        assert len(data["p1"]) == 1
+        assert len(data["p2"]) == 1
+        assert data["p0"][0]["priority"] == "urgent"
+
+    def test_inbox_prioritized_text(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """--prioritized text output shows tier headers."""
+        import ops
+
+        # Isolate bus root to temp dir
+        bus_dir = runtime_dir / "message_bus"
+        bus_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("BID_EUCHRE_BUS_DIR", str(bus_dir))
+
+        # Send one urgent message
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "message",
+                "send",
+                "--from",
+                "ops",
+                "--to",
+                "test-lane",
+                "--type",
+                "blocker",
+                "--summary",
+                "Urgent test",
+                "--priority",
+                "urgent",
+            ]
+        )
+        capsys.readouterr()
+
+        # Read in text mode
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "inbox",
+                "--lane",
+                "test-lane",
+                "--prioritized",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "prioritized" in out
+        assert "P0 (urgent)" in out
+        assert "P1 (high)" in out
+        assert "P2 (normal/low)" in out
+
 
 # ---------------------------------------------------------------------------
 # review-check

--- a/tests/unit/test_ops_message_bus.py
+++ b/tests/unit/test_ops_message_bus.py
@@ -46,6 +46,7 @@ from bid_euchre.ops.message_bus import (
     mark_delivered,
     query_unresolved,
     read_inbox,
+    read_inbox_prioritized,
     read_messages,
     resolve_message,
     send_message,
@@ -2141,3 +2142,186 @@ class TestEscalateUnacked:
         inbox = read_inbox("orch", bus_root, auto_expire=False, limit=100)
         esc = [m for m in inbox if m["message_id"] == escalation_ids[0]]
         assert esc[0]["parent_message_id"] == msg2.message_id
+
+
+# ---------------------------------------------------------------------------
+# Priority-grouped inbox read (read_inbox_prioritized)
+# ---------------------------------------------------------------------------
+
+
+class TestReadInboxPrioritized:
+    """Test read_inbox_prioritized() priority tier grouping."""
+
+    def test_groups_all_four_priorities(self, bus_root: Path, events_dir: Path) -> None:
+        """Messages at all four priority levels land in the correct tiers."""
+        lane = "orchestrator"
+        # Send one message at each priority level
+        for prio in ("urgent", "high", "normal", "low"):
+            msg = create_message(
+                "ops",
+                lane,
+                "supervisor_alert",
+                f"Alert at {prio}",
+                priority=prio,
+            )
+            send_message(msg, bus_root, events_dir=events_dir)
+
+        p0, p1, p2 = read_inbox_prioritized(
+            lane,
+            bus_root,
+            auto_expire=False,
+            auto_compact=False,
+        )
+        assert len(p0) == 1, "urgent → P0"
+        assert len(p1) == 1, "high → P1"
+        assert len(p2) == 2, "normal + low → P2"
+
+        assert p0[0]["priority"] == "urgent"
+        assert p1[0]["priority"] == "high"
+        p2_priorities = {m["priority"] for m in p2}
+        assert p2_priorities == {"normal", "low"}
+
+    def test_empty_tiers(self, bus_root: Path, events_dir: Path) -> None:
+        """When only one priority is present, the other tiers are empty."""
+        lane = "orchestrator"
+        msg = create_message(
+            "ops",
+            lane,
+            "completion",
+            "Done",
+            priority="high",
+        )
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        p0, p1, p2 = read_inbox_prioritized(
+            lane,
+            bus_root,
+            auto_expire=False,
+            auto_compact=False,
+        )
+        assert len(p0) == 0
+        assert len(p1) == 1
+        assert len(p2) == 0
+
+    def test_all_tiers_empty_when_no_messages(self, bus_root: Path) -> None:
+        """A lane with no messages returns three empty lists."""
+        p0, p1, p2 = read_inbox_prioritized(
+            "empty-lane",
+            bus_root,
+            auto_expire=False,
+            auto_compact=False,
+        )
+        assert p0 == []
+        assert p1 == []
+        assert p2 == []
+
+    def test_status_filter_respected(self, bus_root: Path, events_dir: Path) -> None:
+        """The status filter is passed through to read_inbox."""
+        lane = "orchestrator"
+        # One pending, one acked (both urgent)
+        msg1 = create_message(
+            "ops",
+            lane,
+            "blocker",
+            "Blocker 1",
+            priority="urgent",
+        )
+        send_message(msg1, bus_root, events_dir=events_dir)
+
+        msg2 = create_message(
+            "ops",
+            lane,
+            "blocker",
+            "Blocker 2",
+            priority="urgent",
+        )
+        send_message(msg2, bus_root, events_dir=events_dir)
+        ack_message(msg2.message_id, lane, bus_root, events_dir=events_dir)
+
+        # Default status="pending" — only msg1 should appear
+        p0, p1, p2 = read_inbox_prioritized(
+            lane,
+            bus_root,
+            auto_expire=False,
+            auto_compact=False,
+        )
+        assert len(p0) == 1
+        assert p0[0]["message_id"] == msg1.message_id
+
+        # status=None — both should appear
+        p0_all, _, _ = read_inbox_prioritized(
+            lane,
+            bus_root,
+            status=None,
+            auto_expire=False,
+            auto_compact=False,
+        )
+        assert len(p0_all) == 2
+
+    def test_unknown_priority_falls_to_p2(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """A message with an unrecognised priority value lands in P2."""
+        lane = "test-lane"
+        # Manually write a record with a non-standard priority
+        inbox_path = bus_root / "inbox" / f"{lane}.jsonl"
+        inbox_path.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "message_id": "custom001",
+            "thread_id": None,
+            "task_id": None,
+            "from_lane": "ops",
+            "to_lane": lane,
+            "message_type": "progress",
+            "priority": "critical",  # not in VALID_MESSAGE_PRIORITIES
+            "status": "pending",
+            "created_at": "2026-03-24T00:00:00Z",
+            "acked_at": None,
+            "resolved_at": None,
+            "requires_human": False,
+            "summary": "Custom priority message",
+            "payload": {"ttl_seconds": 86400, "max_retries": 3, "retry_count": 0},
+            "source_transport": "bus",
+            "parent_message_id": None,
+        }
+        with open(inbox_path, "a") as f:
+            f.write(json.dumps(record) + "\n")
+
+        p0, p1, p2 = read_inbox_prioritized(
+            lane,
+            bus_root,
+            auto_expire=False,
+            auto_compact=False,
+        )
+        assert len(p0) == 0
+        assert len(p1) == 0
+        assert len(p2) == 1
+        assert p2[0]["priority"] == "critical"
+
+    def test_multiple_messages_per_tier_ordered(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Multiple messages in the same tier preserve read_inbox ordering."""
+        lane = "orchestrator"
+        ids = []
+        for i in range(3):
+            msg = create_message(
+                "ops",
+                lane,
+                "supervisor_alert",
+                f"Alert {i}",
+                priority="high",
+            )
+            send_message(msg, bus_root, events_dir=events_dir)
+            ids.append(msg.message_id)
+
+        _, p1, _ = read_inbox_prioritized(
+            lane,
+            bus_root,
+            auto_expire=False,
+            auto_compact=False,
+        )
+        assert len(p1) == 3
+        # read_inbox returns most-recent first; our function preserves that order
+        returned_ids = [m["message_id"] for m in p1]
+        assert returned_ids == list(reversed(ids))


### PR DESCRIPTION
## Plan
plans/sessions/2026-03-24_messaging-redesign.md — Phase 1b

## Summary
- Add `read_inbox_prioritized()` to message_bus.py that groups messages by P0/P1/P2 priority tiers
- Add `--prioritized` CLI flag to `inbox` command for tier-grouped display
- Add `--priority` flag to `message send` CLI for setting message priority
- 8 new tests (6 unit + 2 CLI integration)

## Why
The orchestrator needs to process urgent messages (lane crashes, merge blockers) before batch traffic (progress acks, info-only alerts). The priority field already exists on every BusMessage but `read_inbox()` treats all messages equally. This adds the grouping layer that enables priority-aware processing in the dispatch loop.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_message_bus.py::TestReadInboxPrioritized -v
uv run python -m pytest tests/unit/test_ops_cli.py -k "prioritized" -v
make check-quiet
```

## Test Criteria
- **Pass condition:** `read_inbox_prioritized()` correctly groups messages: urgent→P0, high→P1, normal+low→P2
- **Verification command:** `uv run python -m pytest tests/unit/test_ops_message_bus.py::TestReadInboxPrioritized -v`
- **Expected result:** 6 tests pass, including tier grouping, empty tiers, status filter passthrough, unknown priority fallback to P2, and ordering preservation

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_message_bus.py` — 120 passed
- [x] `uv run python -m pytest tests/unit/test_ops_cli.py -k "prioritized"` — 2 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None
- Runtime impact: None (thin wrapper over existing read_inbox)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git worktree list` (truncated):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b  5cc48835 [ops/prioritized-inbox]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)