### PR TITLE
docs(ops): enforce inbox-first contract in run-fleet and recovering-context skills

### DIFF
--- a/.claude/skills/check-in/SKILL.md
+++ b/.claude/skills/check-in/SKILL.md
@@ -30,10 +30,12 @@ monitoring infrastructure.
 
 ### Phase 1 — Inbox Poll (MANDATORY FIRST STEP)
 
-1. **Read pending inbox messages:**
+1. **Read pending inbox messages (priority-sorted):**
    ```bash
    uv run python scripts/internal/ops.py inbox --lane orchestrator --status pending
    ```
+   Manually sort results by priority: P0 (`supervisor_alert`, `recovery`) first,
+   then P1 (`completion`, `escalation`, `blocker`), then P2 (`ack`, `progress`).
 
 2. **Filter for high-priority message types** — process these BEFORE any other
    status checks:

--- a/.claude/skills/recovering-context/SKILL.md
+++ b/.claude/skills/recovering-context/SKILL.md
@@ -13,14 +13,39 @@ Start every session by recovering project context from MEMORY.md before beginnin
    - Load the complete project memory file
    - Parse current project state and recent completions
 
-2. **Summarize key context** in three parts:
+2. **Scan inbox for carry-forward alerts** (orchestrator lanes only):
+   ```bash
+   uv run python scripts/internal/ops.py inbox --lane orchestrator --status pending
+   ```
+   If unacked P0/P1 messages exist from a previous session, surface them
+   **before any other work**. These represent conditions the previous session
+   failed to address — merge conflicts, lane stalls, supervisor alerts, or
+   escalations that were never processed.
+
+   Priority classification:
+   - **P0 (urgent):** `supervisor_alert`, `recovery` — surface immediately
+   - **P1 (high):** `completion`, `escalation`, `blocker` — surface before planning
+   - **P2 (normal/low):** `ack`, `progress` — note in summary
+
+   If the inbox command fails (e.g., state machine bug), note the failure and
+   proceed — do not block session recovery on inbox availability.
+
+3. **Summarize key context** in three parts:
    - **Last completed**: What was most recently finished (PRs merged, features shipped, bugs fixed)
    - **PR status**: Which PRs are open, merged, or in progress (with PR numbers)
    - **Next planned work**: What's queued up or in progress
 
-3. **Present summary** to the user in a clear, scannable format
+4. **Present summary** to the user in a clear, scannable format.
+   If carry-forward alerts were found in step 2, present them prominently
+   at the top of the summary:
+   ```
+   ⚠ CARRY-FORWARD ALERTS (from previous session)
+   - [N] unacked supervisor_alerts (oldest: <age>)
+   - [N] unacked escalations
+   → Process these before starting new work.
+   ```
 
-4. **Ask for direction**: "What would you like to work on?"
+5. **Ask for direction**: "What would you like to work on?"
 
 ## Output Format
 

--- a/.claude/skills/run-fleet/SKILL.md
+++ b/.claude/skills/run-fleet/SKILL.md
@@ -19,13 +19,22 @@ mergeable throughput across all defined tracks.
 Before entering the main dispatch loop:
 
 1. Recover context (`/recovering-context` or read MEMORY.md)
-2. Check dashboard health: `uv run python scripts/internal/ops.py dashboard --json`
-3. Bulk-refresh idle lanes:
+2. **Set up inbox polling cron** — ensures inbox is read even if the
+   orchestrator gets absorbed in a long task and skips check-in cycles:
+   ```
+   CronCreate: every 2 minutes, run:
+     uv run python scripts/internal/ops.py inbox --lane orchestrator --status pending
+     If P0 messages found, surface them immediately.
+   ```
+   This is the backup mechanism. The primary mechanism is step 0 of every
+   dispatch cycle (see Dispatch Discipline below).
+3. Check dashboard health: `uv run python scripts/internal/ops.py dashboard --json`
+4. Bulk-refresh idle lanes:
    ```bash
    uv run python scripts/internal/ops.py lane refresh --all-idle
    ```
-4. Triage inbox and open issues
-5. Define Wave 1 candidates
+5. Triage inbox and open issues
+6. Define Wave 1 candidates
 
 ## Primary Goal
 
@@ -60,6 +69,24 @@ Maximize safe, mergeable throughput across all defined tracks.
 ## Dispatch Discipline
 
 Before each dispatch cycle:
+
+0. **MANDATORY: Poll inbox for P0/P1 messages**
+   ```bash
+   uv run python scripts/internal/ops.py inbox --lane orchestrator --status pending
+   ```
+   Scan pending messages and classify by priority:
+   - **P0 (urgent):** `supervisor_alert`, `recovery` — **STOP. Process these
+     before dispatching any new work.** These represent active incidents that
+     may invalidate planned dispatches.
+   - **P1 (high):** `completion`, `escalation`, `blocker` — process completions
+     (to free lanes) and escalations (to unblock lanes) before evaluating new
+     dispatch candidates.
+   - **P2 (normal/low):** `ack`, `progress` — note and continue.
+
+   If you skip this step, you risk dispatching into broken lanes, missing
+   merge-conflict alerts, or duplicating work that another lane already
+   completed. The overnight run of 2026-03-24 proved this: 25+ HIGH alerts
+   went unread for 7 hours because the orchestrator never polled its inbox.
 
 1. Check lane health, dirty worktrees, stale packets, inbox backlog, open
    PRs, newly opened or updated GitHub issues, current task lists, and


### PR DESCRIPTION
## Plan
Part of #1571 (messaging system re-evaluation), Phase 1d

## Summary
- Add mandatory inbox polling as step 0 of every dispatch cycle in `/run-fleet`
- Add inbox scan for carry-forward alerts during `/recovering-context` session recovery
- Document boot cron for backup inbox polling in `/run-fleet` startup checklist
- Add priority-sorted scanning guidance in `/check-in`

## Why
The overnight run of 2026-03-24 proved that the orchestrator never polled its inbox,
causing 25+ HIGH supervisor alerts to go unread for 7 hours. These skill updates
encode the inbox-first contract as instructions so the orchestrator cannot skip inbox
polling during dispatch cycles or session recovery.

## Repro / Validation
**Command(s) run:**
```bash
# run-fleet mandates inbox before dispatch
grep -A2 "MANDATORY" .claude/skills/run-fleet/SKILL.md | grep -c "inbox"
# Expected: >= 1

# run-fleet blocks dispatch on P0
grep -c "P0.*STOP\|STOP.*P0\|urgent.*stop\|stop.*dispatch\|STOP.*Process" .claude/skills/run-fleet/SKILL.md
# Expected: >= 1

# recovering-context includes inbox scan
grep -c "inbox" .claude/skills/recovering-context/SKILL.md
# Expected: >= 1

# Boot cron documented
grep -c "CronCreate\|cron.*inbox\|inbox.*cron" .claude/skills/run-fleet/SKILL.md
# Expected: >= 1

make check-quiet  # All checks pass
```

## Test Criteria
- **Pass condition:** All four grep checks return >= 1; `make check-quiet` passes
- **Verification command:** See Repro / Validation above
- **Expected result:** Counts of 2, 1, 4, 2 respectively; all checks pass ✓

## Tests
- [x] `make check-quiet` passes (docs-only PR, no Python changes)
- [x] Content verification via grep checks (all 4 pass)

## Expected impact
- Metrics impact: None (skill docs only)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
```

`git worktree list` (abridged):
```
Bid-Euchre                   812c3983 [main]
Bid-Euchre-steward-flex-a    6c13073f [ops/skill-inbox-contract]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)