### PR TITLE
feat(ops): wire escalation check into monitor cycle (#1571 Phase 2b)

### DIFF
--- a/src/bid_euchre/ops/monitor.py
+++ b/src/bid_euchre/ops/monitor.py
@@ -37,6 +37,10 @@ MAX_AUTO_DISPATCH_PER_CYCLE: int = 2
 STALL_THRESHOLD_MINUTES: int = 10
 STALL_CONSECUTIVE_CYCLES: int = 2
 
+# Escalation: unacked alerts older than this are escalated to urgent priority.
+# Default is 2 monitor cycles at 3 min each.
+ESCALATION_AGE_MINUTES: int = 6
+
 # Severity levels for findings.
 SEVERITY_INFO = "info"
 SEVERITY_WARN = "warn"
@@ -413,6 +417,76 @@ def check_idle_lanes(
                     details={"lane_id": lane_id},
                 )
             )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Escalation check — unacked alerts from previous cycles
+# ---------------------------------------------------------------------------
+
+
+def check_escalations(
+    *,
+    bus_root: Path | None = None,
+    events_dir: Path | None = None,
+    max_age_minutes: int = ESCALATION_AGE_MINUTES,
+) -> list[MonitorFinding]:
+    """Check for unacked ops→orchestrator alerts and escalate if stale.
+
+    Calls :func:`~bid_euchre.ops.message_bus.escalate_unacked` to find
+    outbound ``supervisor_alert`` messages from ``ops`` to ``orchestrator``
+    that remain unacknowledged after *max_age_minutes*.  For each such
+    message an urgent escalation is created by the message bus.
+
+    Args:
+        bus_root: Override for the message bus root directory.
+        events_dir: Override for the events directory (for testing).
+        max_age_minutes: Age threshold in minutes before escalation fires.
+
+    Returns:
+        List of findings — one per escalation sent plus a summary.
+    """
+    findings: list[MonitorFinding] = []
+
+    try:
+        from bid_euchre.ops.message_bus import escalate_unacked
+
+        escalation_ids = escalate_unacked(
+            sender_lane="ops",
+            recipient_lane="orchestrator",
+            max_age_minutes=max_age_minutes,
+            bus_root=bus_root,
+            events_dir=events_dir,
+        )
+    except Exception as exc:
+        findings.append(
+            MonitorFinding(
+                category="escalation",
+                severity=SEVERITY_WARN,
+                summary=f"Could not check for unacked alerts: {exc}",
+            )
+        )
+        return findings
+
+    if escalation_ids:
+        logger.warning("Escalated %d unacked alerts to P0", len(escalation_ids))
+        findings.append(
+            MonitorFinding(
+                category="escalation",
+                severity=SEVERITY_HIGH,
+                summary=(f"Escalated {len(escalation_ids)} unacked alert(s) to urgent"),
+                details={"escalation_ids": escalation_ids},
+            )
+        )
+    else:
+        findings.append(
+            MonitorFinding(
+                category="escalation",
+                severity=SEVERITY_INFO,
+                summary="No unacked alerts to escalate.",
+            )
+        )
 
     return findings
 
@@ -1582,6 +1656,7 @@ def run_monitoring_cycle(
     """Run a single monitoring sweep.
 
     Collects findings from:
+    0. Escalation check — escalate unacked alerts from previous cycles
     1. Lane pool health snapshot
     2. Open PR status and CI-ready detection (via ``gh``)
     3. Stale dispatched packet detection
@@ -1607,6 +1682,9 @@ def run_monitoring_cycle(
         List of all findings from the sweep.
     """
     findings: list[MonitorFinding] = []
+
+    # 0. Escalation check — escalate unacked alerts from previous cycles
+    findings.extend(check_escalations())
 
     # 1. Lane health
     findings.extend(check_lane_health(runtime_dir))

--- a/tests/unit/test_ops_monitor.py
+++ b/tests/unit/test_ops_monitor.py
@@ -9,6 +9,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 from bid_euchre.ops.monitor import (
+    ESCALATION_AGE_MINUTES,
     MAX_AUTO_DISPATCH_PER_CYCLE,
     SEVERITY_HIGH,
     SEVERITY_INFO,
@@ -20,6 +21,7 @@ from bid_euchre.ops.monitor import (
     _save_stall_state,
     check_approval_stalls,
     check_auto_dispatch,
+    check_escalations,
     check_idle_lanes,
     check_lane_health,
     check_merged_dispatches,
@@ -1170,6 +1172,159 @@ class TestCheckMergedDispatches:
         assert len(findings) == 1
         assert findings[0].severity == SEVERITY_WARN
         assert "Failed to auto-complete" in findings[0].summary
+
+
+# ---------------------------------------------------------------------------
+# check_escalations tests (#1571 Phase 2b)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckEscalations:
+    """Tests for the escalation check wired into the monitoring cycle."""
+
+    def test_no_escalation_when_no_unacked(self) -> None:
+        """Returns info finding when escalate_unacked returns empty list."""
+        with patch(
+            "bid_euchre.ops.message_bus.escalate_unacked",
+            return_value=[],
+        ):
+            findings = check_escalations()
+
+        assert len(findings) == 1
+        assert findings[0].severity == SEVERITY_INFO
+        assert findings[0].category == "escalation"
+        assert "No unacked" in findings[0].summary
+
+    def test_escalation_when_unacked_alerts_exist(self) -> None:
+        """Returns HIGH finding with escalation IDs when alerts are unacked."""
+        with patch(
+            "bid_euchre.ops.message_bus.escalate_unacked",
+            return_value=["esc-001", "esc-002"],
+        ):
+            findings = check_escalations()
+
+        assert len(findings) == 1
+        assert findings[0].severity == SEVERITY_HIGH
+        assert findings[0].category == "escalation"
+        assert "2 unacked alert(s)" in findings[0].summary
+        assert findings[0].details["escalation_ids"] == ["esc-001", "esc-002"]
+
+    def test_custom_max_age_passed_through(self) -> None:
+        """max_age_minutes parameter is forwarded to escalate_unacked."""
+        with patch(
+            "bid_euchre.ops.message_bus.escalate_unacked",
+            return_value=[],
+        ) as mock_esc:
+            check_escalations(max_age_minutes=42)
+
+        mock_esc.assert_called_once()
+        call_kwargs = mock_esc.call_args
+        assert call_kwargs[1]["max_age_minutes"] == 42
+
+    def test_custom_bus_root_passed_through(self, tmp_path: Path) -> None:
+        """bus_root parameter is forwarded to escalate_unacked."""
+        with patch(
+            "bid_euchre.ops.message_bus.escalate_unacked",
+            return_value=[],
+        ) as mock_esc:
+            check_escalations(bus_root=tmp_path)
+
+        mock_esc.assert_called_once()
+        call_kwargs = mock_esc.call_args
+        assert call_kwargs[1]["bus_root"] == tmp_path
+
+    def test_graceful_on_escalate_failure(self) -> None:
+        """Returns WARN finding when escalate_unacked raises."""
+        with patch(
+            "bid_euchre.ops.message_bus.escalate_unacked",
+            side_effect=OSError("bus root missing"),
+        ):
+            findings = check_escalations()
+
+        assert len(findings) == 1
+        assert findings[0].severity == SEVERITY_WARN
+        assert findings[0].category == "escalation"
+        assert "Could not check" in findings[0].summary
+
+    def test_default_age_minutes_matches_constant(self) -> None:
+        """Default max_age_minutes uses the ESCALATION_AGE_MINUTES constant."""
+        with patch(
+            "bid_euchre.ops.message_bus.escalate_unacked",
+            return_value=[],
+        ) as mock_esc:
+            check_escalations()
+
+        call_kwargs = mock_esc.call_args
+        assert call_kwargs[1]["max_age_minutes"] == ESCALATION_AGE_MINUTES
+
+    def test_integration_with_real_bus(self, tmp_path: Path) -> None:
+        """End-to-end: ops sends alert, don't ack, verify escalation fires."""
+        from bid_euchre.ops.message_bus import (
+            create_message,
+            send_message,
+        )
+
+        bus_root = tmp_path / "bus"
+        events_dir = tmp_path / "events"
+
+        # ops sends an alert to orchestrator
+        msg = create_message(
+            from_lane="ops",
+            to_lane="orchestrator",
+            message_type="supervisor_alert",
+            priority="high",
+            summary="3 HIGH findings",
+        )
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        # Run check_escalations with max_age_minutes=0 so it fires immediately
+        findings = check_escalations(
+            bus_root=bus_root,
+            events_dir=events_dir,
+            max_age_minutes=0,
+        )
+
+        # Should have escalated
+        assert len(findings) == 1
+        assert findings[0].severity == SEVERITY_HIGH
+        assert findings[0].category == "escalation"
+        assert len(findings[0].details["escalation_ids"]) >= 1
+
+    def test_integration_no_escalation_when_acked(self, tmp_path: Path) -> None:
+        """End-to-end: ops sends alert, ack it, verify no escalation."""
+        from bid_euchre.ops.message_bus import (
+            ack_message,
+            create_message,
+            send_message,
+        )
+
+        bus_root = tmp_path / "bus"
+        events_dir = tmp_path / "events"
+
+        # ops sends an alert to orchestrator
+        msg = create_message(
+            from_lane="ops",
+            to_lane="orchestrator",
+            message_type="supervisor_alert",
+            priority="high",
+            summary="3 HIGH findings",
+        )
+        mid = send_message(msg, bus_root, events_dir=events_dir)
+
+        # orchestrator acks it
+        ack_message(mid, "orchestrator", bus_root=bus_root)
+
+        # Run check_escalations with max_age_minutes=0
+        findings = check_escalations(
+            bus_root=bus_root,
+            events_dir=events_dir,
+            max_age_minutes=0,
+        )
+
+        # Should NOT have escalated — info finding instead
+        assert len(findings) == 1
+        assert findings[0].severity == SEVERITY_INFO
+        assert "No unacked" in findings[0].summary
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `check_escalations()` function that calls `escalate_unacked()` from the message bus to detect stale ops→orchestrator alerts
- Wire it into `run_monitoring_cycle()` as step 0 (runs before all other checks)
- Add `ESCALATION_AGE_MINUTES` constant (default 6 min = 2 monitor cycles)

## Why
The orchestrator was not acking ops monitor alerts (#1571), causing them to silently accumulate. This wires the escalation machinery (from PR #1599) into the monitor cycle so stale alerts are automatically promoted to urgent priority.

## Test Criteria
```bash
# 8 new tests covering:
# - No escalation when alerts are acked (INFO finding)
# - Escalation fires when alerts are unacked (HIGH finding)
# - Custom parameters forwarded correctly
# - Graceful error handling
# - Integration with real message bus (end-to-end)
uv run python -m pytest tests/unit/test_ops_monitor.py::TestCheckEscalations -v
```

**Pass:** All 8 tests pass. Existing 97 monitor tests still pass (105 total).

## Repro / Validation
```bash
# Targeted tests
uv run python -m pytest tests/unit/test_ops_monitor.py -v

# Full validation
make check-quiet
```

## Tests
- `make check-quiet` — ✅ all passed
- `uv run python -m pytest tests/unit/test_ops_monitor.py` — 105 passed

## Worktree Proof
- Worktree: `Bid-Euchre-steward-brws-author-a`
- Branch: `ops/wire-escalation-monitor`

## Scope
- `src/bid_euchre/ops/monitor.py` — new `check_escalations()` + wiring
- `tests/unit/test_ops_monitor.py` — 8 new tests

Part of #1571 implementation (messaging redesign Phase 2b).
Depends on #1599 (`check_ack_status` + `escalate_unacked` in message bus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)