### PR TITLE
fix: move ops lane to detached worktree to fix Telegram inbound

### DIFF
--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -87,6 +87,7 @@ FLEX_C="${PARENT_DIR}/${REPO_NAME}-steward-flex-c"
 
 # Control plane
 REVIEW="${PARENT_DIR}/${REPO_NAME}-steward-review"
+OPS="${PARENT_DIR}/${REPO_NAME}-steward-ops"
 MAIN_DIR="$(git -C "$MAIN_DIR" worktree list 2>/dev/null | head -1 | awk '{print $1}')"
 
 # ---------------------------------------------------------------------------
@@ -137,12 +138,13 @@ ensure_worktree() {
     git -C "$MAIN_DIR" worktree add -b "$branch" "$path" main
 }
 
-ensure_review_worktree() {
-    validate_worktree_path "$REVIEW" || exit 1
-    if [ -d "$REVIEW" ]; then
+ensure_detached_worktree() {
+    local path="$1"
+    validate_worktree_path "$path" || exit 1
+    if [ -d "$path" ]; then
         return
     fi
-    git -C "$MAIN_DIR" worktree add --detach "$REVIEW" main
+    git -C "$MAIN_DIR" worktree add --detach "$path" main
 }
 
 update_last_active() {
@@ -290,7 +292,8 @@ ensure_worktree "$FLEX_B" "codex/steward-flex-b"
 ensure_worktree "$FLEX_C" "codex/steward-flex-c"
 
 # Control plane
-ensure_review_worktree
+ensure_detached_worktree "$REVIEW"
+ensure_detached_worktree "$OPS"
 
 # Write v2 registry metadata for each lane.
 # tmux_window = group name, tmux_pane = 1-based pane index within the window.
@@ -300,7 +303,7 @@ ensure_review_worktree
 # Central ops  (window: central-ops, panes 1-3, main-vertical layout)
 # Note: pane indices are 1-based to match tmux pane-base-index=1.
 write_lane_metadata "orchestrator"   "orchestrator" "$MAIN_DIR"       "--"                              "central-ops" "1" "foreground" "Orchestrator"
-write_lane_metadata "ops"            "ops"          "$MAIN_DIR"       "--"                              "central-ops" "2" "foreground" "Ops"
+write_lane_metadata "ops"            "ops"          "$OPS"            "detached"                        "central-ops" "2" "foreground" "Ops"
 write_lane_metadata "review"         "review"       "$REVIEW"         "detached"                        "central-ops" "3" "foreground" "Review"
 
 # Platform workers  (window: platform, panes 1-4)
@@ -354,7 +357,7 @@ if [ -n "$STEWARD_CHANNELS" ]; then
 fi
 tmux set-environment -t "$SESSION" STEWARD_TELEGRAM_ENABLED "$STEWARD_TELEGRAM_ENABLED"
 
-tmux split-window -t "${SESSION}:central-ops" -c "$MAIN_DIR" \
+tmux split-window -t "${SESSION}:central-ops" -c "$OPS" \
     "$CLAUDE_BIN" --name ops --agent steward-ops
 tmux split-window -t "${SESSION}:central-ops" -c "$REVIEW" \
     "$CLAUDE_BIN" --name review --agent steward-review

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -503,6 +503,54 @@ class TestWindowLayout:
             "to trigger the agent's startup behavior"
         )
 
+    def test_ops_lane_has_own_worktree(self) -> None:
+        """Ops lane must launch in its own detached worktree, not $MAIN_DIR.
+
+        When ops runs in the same directory as the orchestrator, competing
+        bun MCP server instances race on Telegram getUpdates, silently
+        consuming inbound messages. See #1615.
+        """
+        content = STEWARD_SCRIPT.read_text()
+        # OPS variable must be defined in the control plane section
+        assert 'OPS="' in content, "OPS worktree variable must be defined"
+        assert "steward-ops" in content, "OPS path must reference steward-ops"
+
+        # The ops tmux pane must launch in $OPS, not $MAIN_DIR
+        lines = content.split("\n")
+        for i, line in enumerate(lines):
+            if "--name ops" in line or "--agent steward-ops" in line:
+                # Check this line and the preceding line for the working dir
+                context = "\n".join(lines[max(0, i - 1) : i + 1])
+                assert (
+                    '"$OPS"' in context
+                ), f"Ops pane must launch in $OPS, not $MAIN_DIR: {context}"
+                break
+
+    def test_ops_metadata_uses_detached_branch(self) -> None:
+        """Ops lane metadata must specify 'detached' branch, not '--'."""
+        content = STEWARD_SCRIPT.read_text()
+        metadata_lines = [
+            line
+            for line in content.split("\n")
+            if line.strip().startswith('write_lane_metadata "ops"')
+        ]
+        assert len(metadata_lines) == 1, "Expected exactly one ops metadata line"
+        line = metadata_lines[0]
+        assert '"$OPS"' in line, f"Ops metadata must use $OPS path: {line.strip()}"
+        assert (
+            '"detached"' in line
+        ), f"Ops metadata must use 'detached' branch: {line.strip()}"
+
+    def test_ensure_detached_worktree_used_for_control_plane(self) -> None:
+        """Both review and ops worktrees must use ensure_detached_worktree."""
+        content = STEWARD_SCRIPT.read_text()
+        assert (
+            'ensure_detached_worktree "$REVIEW"' in content
+        ), "Review worktree must use ensure_detached_worktree"
+        assert (
+            'ensure_detached_worktree "$OPS"' in content
+        ), "Ops worktree must use ensure_detached_worktree"
+
     def test_browser_game_worktree_paths(self) -> None:
         """Script must define BRWS_A through BRWS_D worktree paths."""
         content = STEWARD_SCRIPT.read_text()


### PR DESCRIPTION
## Summary

- Move the ops lane from `$MAIN_DIR` to its own detached worktree (`Bid-Euchre-steward-ops`)
- Generalize `ensure_review_worktree()` → `ensure_detached_worktree(path)` for reuse by both review and ops
- Add 3 regression tests verifying ops worktree isolation

## Why

The ops lane was running in `$MAIN_DIR` (same directory as the orchestrator). Since the Telegram plugin is project-path-scoped, both spawned competing bun MCP server instances that raced on `getUpdates`. When the ops bun process won, inbound Telegram messages were silently consumed and never reached the orchestrator (#1615).

The fix mirrors the existing review lane pattern — a detached worktree in the sibling directory.

## Dependencies verified

- `shared_bus_root()` uses `git rev-parse --git-common-dir` → resolves to main checkout from any worktree ✅
- Agent config (`.claude/agents/steward-ops.md`) is git-tracked, visible in worktrees ✅
- `scripts/internal/ops.py` is git-tracked ✅
- `uv run` auto-bootstraps `.venv` in fresh worktrees ✅
- Plugin scope is per directory path → worktree won't spawn bun ✅
- Review lane is the precedent — same pattern already works ✅
- `Bid-Euchre-steward-ops` already in the protected worktree list ✅

## Repro / Validation

```bash
# Full validation
make check-quiet

# Targeted test
uv run python -m pytest tests/unit/test_steward_session.py -v -k "ops_lane or detached_worktree or ops_metadata"
```

## Tests

- `make check-quiet` ✅ — all checks pass
- 3 new tests in `test_steward_session.py`:
  - `test_ops_lane_has_own_worktree` — OPS var defined, pane launches in `$OPS`
  - `test_ops_metadata_uses_detached_branch` — metadata uses `$OPS` and `"detached"`
  - `test_ensure_detached_worktree_used_for_control_plane` — both review and ops use `ensure_detached_worktree`

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: fix/ops-lane-worktree
```

Closes #1615

🤖 Generated with [Claude Code](https://claude.com/claude-code)