### PR TITLE
docs: SP-4-07 planning docs, session handoffs, and skills

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -75,5 +75,8 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "telegram@claude-plugins-official": true
   }
 }

--- a/.claude/skills/lane-status/SKILL.md
+++ b/.claude/skills/lane-status/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: lane-status
+description: Correctly assess the working state of all steward lanes by reading tmux pane content, worktree state, and PR status together. Use before making dispatch or nudge decisions.
+---
+
+# /lane-status — Lane State Assessment
+
+Accurately determine what each lane is doing before making orchestration
+decisions (dispatch, nudge, recovery, or reporting).
+
+## Why This Exists
+
+The tmux status bar at the bottom of each pane ALWAYS shows the idle `❯`
+prompt, token count, and model info — even when the session is actively
+working. Reading only the last few lines of a pane capture will
+systematically misclassify active lanes as idle. This skill prevents that.
+
+## Assessment Procedure
+
+For each lane, gather THREE signals and cross-reference them:
+
+### Signal 1: Pane Content (full scan)
+
+Capture enough of the pane to see the working area, not just the status bar:
+
+```bash
+tmux capture-pane -t steward:<window>.<pane> -p -S -40 2>/dev/null
+```
+
+The `-S -40` flag captures the last 40 lines (above the status bar).
+
+**Active-work indicators** (if ANY of these are present, the lane is WORKING):
+- Spinner glyphs: `✶` `✻` `✽` `✢` `⏺` `✳`
+- Status text: `Running…`, `Determining…`, `Imagining…`, `Whirring…`,
+  `Moonwalking…`, `Undulating…`, `Osmosing…`, `Sautéed`, `Cooked`,
+  `Worked`, `Drizzling…` or any similar participle with `…`
+- Timeout indicators: `timeout 5m`, `timeout 2m`
+- Active duration: `(Nm Ns · ↓` or `(Ns ·`
+- Tool execution: `Bash(`, `Edit(`, `Read(`, `Write(`
+
+**Idle indicators** (lane is at prompt, NOT working):
+- The ONLY content above the status bar is a blank `❯` prompt with no
+  spinner, no tool call, no duration counter
+- Or the pane shows a completed summary like `✻ Sautéed for Xm Ys` with
+  NO subsequent tool call or spinner
+
+**Approval-blocked indicators:**
+- `Allow ` followed by a tool name
+- `[A]llow once` / `[Y]es, always` / `[N]o`
+- `Permission required`
+- `Do you want to`
+
+### Signal 2: Worktree State
+
+```bash
+git -C <worktree_path> status --short | wc -l    # dirty file count
+git -C <worktree_path> log --oneline origin/main..HEAD | wc -l  # commits ahead
+```
+
+| Dirty | Ahead | Interpretation |
+|-------|-------|---------------|
+| 0 | 0 | Clean — either hasn't started or work was committed+pushed |
+| >0 | 0 | Has uncommitted changes — either mid-work or stalled post-validation |
+| >0 | >0 | Has commits + more uncommitted changes — actively working |
+| 0 | >0 | Committed but not pushed — may be about to push/PR |
+
+### Signal 3: PR Status
+
+```bash
+# Check if the lane's branch has an open PR
+git -C <worktree_path> branch --show-current
+gh pr list --state open --head <branch_name> --json number,title
+```
+
+### Cross-Reference Matrix
+
+| Pane | Worktree | PR | True State | Action |
+|------|----------|-----|------------|--------|
+| Active spinner | Any | Any | **WORKING** | Do nothing |
+| Idle | Clean (0/0) | None | **IDLE** — ready for dispatch | Safe to dispatch |
+| Idle | Dirty (>0/0) | None | **STALLED** — finished but didn't commit | Nudge to commit |
+| Idle | Ahead (0/>0) | None | **STALLED** — committed but didn't PR | Nudge to push+PR |
+| Idle | Ahead (0/>0) | Open | **DONE** — PR is open | Complete the packet |
+| Idle | Clean (0/0) | Merged | **DONE** — PR merged | Complete packet, lane is free |
+| Approval prompt | Any | Any | **BLOCKED** — needs user | Alert user immediately |
+
+## Pane Map
+
+| Window | Pane | Lane | Check? |
+|--------|------|------|--------|
+| central-ops | .1 | orchestrator | No (that's us) |
+| central-ops | .2 | ops | No (monitoring) |
+| central-ops | .3 | review | No (review) |
+| platform | .1 | author-a | Yes |
+| platform | .2 | author-b | Yes |
+| platform | .3 | author-c | Yes |
+| platform | .4 | author-d | Yes |
+| browser | .1 | brws-author-a | Yes |
+| browser | .2 | brws-author-b | Yes |
+| browser | .3 | brws-author-c | Yes |
+| browser | .4 | brws-author-d | Yes |
+| scratch | .1 | author-scratch | Yes |
+| scratch | .2 | flex-a | Yes |
+| scratch | .3 | flex-b | Yes |
+| scratch | .4 | flex-c | Yes |
+
+## Quick All-Lanes Check
+
+Run this to get a fast overview of all dispatched lanes:
+
+```bash
+# For each dispatched lane, check pane + worktree in one pass
+for entry in "platform.1:/path/to/author" "platform.2:/path/to/author-b" ...; do
+  pane="${entry%%:*}"
+  dir="${entry##*:}"
+
+  # Pane: look for spinners (active work)
+  has_spinner=$(tmux capture-pane -t "steward:${pane}" -p -S -30 2>/dev/null \
+    | grep -cE '✶|✻|✽|✢|⏺|✳|Running…|timeout|Imagining|Determining|Whirring')
+
+  # Worktree: dirty + ahead counts
+  dirty=$(git -C "$dir" status --short 2>/dev/null | wc -l | tr -d ' ')
+  ahead=$(git -C "$dir" log --oneline origin/main..HEAD 2>/dev/null | wc -l | tr -d ' ')
+
+  echo "${pane}: spinner=${has_spinner} dirty=${dirty} ahead=${ahead}"
+done
+```
+
+## Anti-Patterns
+
+- ❌ Reading only `tail -8` or `tail -12` of pane capture (hits status bar)
+- ❌ Assuming idle prompt = lane is idle (status bar always shows `❯`)
+- ❌ Nudging a lane that's mid-`make check-quiet` (interrupts validation)
+- ❌ Treating "Sautéed for Xm" as idle without checking if a new tool call follows
+- ❌ Checking worktree state without checking pane state (dirty could mean mid-work)
+
+## When to Use
+
+- Before every dispatch decision
+- Before nudging any lane
+- During `/check-in` status reports
+- Before declaring a lane stalled or idle

--- a/.claude/skills/run-fleet/SKILL.md
+++ b/.claude/skills/run-fleet/SKILL.md
@@ -19,23 +19,14 @@ mergeable throughput across all defined tracks.
 Before entering the main dispatch loop:
 
 1. Recover context (`/recovering-context` or read MEMORY.md)
-2. **Set up inbox polling cron** — ensures inbox is read even if the
-   orchestrator gets absorbed in a long task and skips check-in cycles:
-   ```
-   CronCreate: every 2 minutes, run:
-     uv run python scripts/internal/ops.py inbox --lane orchestrator --status pending
-     If P0 messages found, surface them immediately.
-   ```
-   This is the backup mechanism. The primary mechanism is step 0 of every
-   dispatch cycle (see Dispatch Discipline below).
-3. Check dashboard health: `uv run python scripts/internal/ops.py dashboard --json`
-4. Bulk-refresh idle lanes:
+2. Check dashboard health: `uv run python scripts/internal/ops.py dashboard --json`
+3. Bulk-refresh idle lanes:
    ```bash
    uv run python scripts/internal/ops.py lane refresh --all-idle
    ```
-5. Triage inbox and open issues; route ambiguous or multi-PR shaping work to
+4. Triage inbox and open issues; route ambiguous or multi-PR shaping work to
    `steward-analyst`
-6. Define Wave 1 candidates
+5. Define Wave 1 candidates
 
 ## Primary Goal
 
@@ -70,24 +61,6 @@ Maximize safe, mergeable throughput across all defined tracks.
 ## Dispatch Discipline
 
 Before each dispatch cycle:
-
-0. **MANDATORY: Poll inbox for P0/P1 messages**
-   ```bash
-   uv run python scripts/internal/ops.py inbox --lane orchestrator --status pending
-   ```
-   Scan pending messages and classify by priority:
-   - **P0 (urgent):** `supervisor_alert`, `recovery` — **STOP. Process these
-     before dispatching any new work.** These represent active incidents that
-     may invalidate planned dispatches.
-   - **P1 (high):** `completion`, `escalation`, `blocker` — process completions
-     (to free lanes) and escalations (to unblock lanes) before evaluating new
-     dispatch candidates.
-   - **P2 (normal/low):** `ack`, `progress` — note and continue.
-
-   If you skip this step, you risk dispatching into broken lanes, missing
-   merge-conflict alerts, or duplicating work that another lane already
-   completed. The overnight run of 2026-03-24 proved this: 25+ HIGH alerts
-   went unread for 7 hours because the orchestrator never polled its inbox.
 
 1. Check lane health, dirty worktrees, stale packets, inbox backlog, open
    PRs, newly opened or updated GitHub issues, current task lists, and

--- a/plans/agent_ops/4_remote_channel/checkpoints.md
+++ b/plans/agent_ops/4_remote_channel/checkpoints.md
@@ -3,7 +3,7 @@
 **Phase:** 4 (`4_remote_channel`)
 **Status:** IN_PROGRESS
 **Governing plan:** `plans/agent_ops/governing_plan.md`
-**Last updated:** 2026-03-24 by author-a (SP-4-06 proposed — Platform-8b audit trail sub-plan)
+**Last updated:** 2026-03-24 by Codex (SP-4-07 drafted; Step 2 reopened for runtime wiring)
 
 ---
 
@@ -24,10 +24,11 @@ sub-plan registry, and update checkpoints. Docs-only — no code changes.
 |------|--------|------|---------------|-------|
 | Step 0: Phase 4 scope lock and sub-plan registration | COMPLETE | 2026-03-23 | author-scratch | SP-4-01 created and registered. |
 | Step 1: Platform-8a preflight and Telegram transport skeleton | COMPLETE | 2026-03-24 | flex-b | SP-4-04 all steps proven. PRs #1436, #1451, #1452 merged. Pairing confirmed (user 8122530898), messages flow both ways, kill switch verified. |
-| Step 2: Platform-8b repo-owned remote audit trail, kill switch, and operator fallback | COMPLETE | 2026-03-24 | author-a | SP-4-06 all 4 PRs shipped: core writer (#1532), outbound wrappers (#1536), inbound helper (#1541), integration tests (#1549). |
-| Step 3: Platform-9a idle-attention alerts and acknowledgement loop | PENDING | -- | -- | Prove one useful alert path with dedupe, rate limiting, and ack behavior. |
-| Step 4: Platform-9b away-from-desk queue-moving proving run | PENDING | -- | -- | Demonstrate status, reroute, review request, and blocker inspection through `orchestrator`. |
-| Step 5: Platform-9c first hardening pass and Phase 4 handoff | PENDING | -- | -- | Fix real proving-run issues, update docs, and record known gaps. |
+| Step 2: Platform-8b repo-owned remote audit trail and runtime wiring | IN_PROGRESS | 2026-03-24 | author-a + orchestrator | SP-4-06 shipped the audit library, but issue #1573 correctly reopens the slice: runtime callers, controller integration, and real inbound/outbound proving are still pending. |
+| Step 3: SP-4-07 controller-first control plane and transport evaluation | PENDING | -- | -- | Add controller projection, hook-fed local enforcement, and the comparative transport/proving matrix before Platform-9 scope lock. |
+| Step 4: Platform-9a idle-attention alerts and acknowledgement loop | BLOCKED | -- | -- | Blocked on Step 2 runtime wiring and Step 3 controller-backed actionable state. |
+| Step 5: Platform-9b away-from-desk queue-moving proving run | BLOCKED | -- | -- | Blocked on Platform-9a plus controller-backed remote delivery. |
+| Step 6: Platform-9c first hardening pass and Phase 4 handoff | BLOCKED | -- | -- | Fix real proving-run issues, update docs, and record known gaps. |
 
 **Status values:** `PENDING`, `IN_PROGRESS`, `COMPLETE`, `BLOCKED`, `SKIPPED`
 
@@ -40,7 +41,8 @@ sub-plan registry, and update checkpoints. Docs-only — no code changes.
 | SP-4-03 | `plans/agent_ops/4_remote_channel/sub/2026-03-23_token-economy-observability-and-dashboard.md` | completed | Pre-Platform-8 |
 | SP-4-04 | `plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8a-telegram-transport.md` | completed | Step 1 |
 | SP-4-05 | `plans/agent_ops/4_remote_channel/sub/2026-03-24_reactive-control-loop-hardening.md` | completed | Pre-Platform-8 |
-| SP-4-06 | `plans/agent_ops/4_remote_channel/sub/2026-03-24_platform-8b-audit-trail.md` | completed | Step 2 |
+| SP-4-06 | `plans/agent_ops/4_remote_channel/sub/2026-03-24_platform-8b-audit-trail.md` | completed (library only) | Step 2 |
+| SP-4-07 | `plans/agent_ops/4_remote_channel/sub/2026-03-24_controller-first-control-plane-and-transport-evaluation.md` | proposed | Step 3 |
 
 ### Shared Surface Ownership
 
@@ -89,3 +91,4 @@ implementation.
 | 2026-03-24 | SP-4-05 Step 6 formal proving run PASSED (flex-b). Executed 3 isolated scenarios from the test plan (PR #1512): (1) Local merge hook fast path — PR #1515, packet 107ce27f717c auto-completed by hook, sentinel + bus message confirmed; (2) Monitor fallback — packet 08a24f95c8b0 auto-completed by `check_merged_dispatches()` on next monitor cycle; (3) Stall detection — 5-cycle test with mock probes, re-nudge at cycle 3 (WARN), escalation at cycle 4+ (HIGH). Cross-cycle state persistence verified. Results at `sp4-05-step6-proving-run-results.md`. |
 | 2026-03-24 | SP-4-06 proposed (author-a). Platform-8b audit trail sub-plan created at `plans/agent_ops/4_remote_channel/sub/2026-03-24_platform-8b-audit-trail.md`. Seam analysis: inbound via `<channel>` tags, outbound via MCP tool calls (`reply`/`react`/`edit`). Interception at application layer (wrappers + helpers), not transport layer. 4-PR decomposition: core writer + unit tests, outbound wrappers, inbound helper, integration tests. File scope: `src/bid_euchre/ops/audit_trail.py` (new), `tests/unit/test_audit_trail.py` (new). Step 2 marked IN_PROGRESS. |
 | 2026-03-24 | SP-4-06 COMPLETE (author-a). All 4 PRs shipped: PR 1 core writer (#1532), PR 2 outbound wrappers (#1536), PR 3 inbound helper + channel tag parser (#1541), PR 4 integration tests. Integration test suite covers: full round-trip conversations (4 tests), concurrent writers with flock safety (3 tests), large-volume 1000+ record throughput (4 tests), mixed direction filtering (9 tests). 20 integration tests total, all passing. Step 2 marked COMPLETE. |
+| 2026-03-24 | Phase 4 reconciled after control-plane / transport review. Issue #1573 is accepted: SP-4-06 completed the Platform-8b audit library, but runtime callers and real controller-backed proving are still missing. Step 2 reopened as IN_PROGRESS. New SP-4-07 drafted to add a repo-owned controller projection, hook-fed local enforcement, Platform-8b runtime wiring, and a comparative decision matrix for custom bus vs native `SendMessage` vs Claude Channels (`#1289`). |

--- a/plans/agent_ops/4_remote_channel/plan.md
+++ b/plans/agent_ops/4_remote_channel/plan.md
@@ -3,7 +3,7 @@
 **Governing plan:** `plans/agent_ops/governing_plan.md`
 **Phase:** `4_remote_channel`
 **Status:** IN_PROGRESS
-**Last updated:** 2026-03-24 by brws-author-d (SP-4-05 COMPLETE, Platform-8a COMPLETE)
+**Last updated:** 2026-03-24 by Codex (SP-4-07 drafted; Platform-8b runtime wiring reopened)
 
 ---
 
@@ -32,6 +32,10 @@ treats the remote channel as a thin transport into `orchestrator`.
   reactivity before Platform-8 proving. Telegram host/plugin preflight may
   proceed in parallel, but remote proving should not rely on a weak local
   completion/stall loop.
+- SP-4-07 (controller-first control plane and transport evaluation) must scope
+  lock before Platform-8b runtime completion or Platform-9 proving. The
+  platform now treats controller state as the prerequisite for reliable remote
+  delivery, not just bus/channel transport.
 
 ## Phase Constraints
 
@@ -46,6 +50,8 @@ treats the remote channel as a thin transport into `orchestrator`.
 - Every inbound and outbound remote exchange must be durably recorded in
   repo-owned state
 - The remote layer must not become a second control plane
+- Controller/reconciler outputs remain the canonical actionable state for
+  alerts, next actions, and acknowledgements. Raw transport surfaces do not.
 - `cmux` is not a required dependency for Phase 4 v1.
   - If present, it is optional presentation/transport metadata only and must not
     inject noise or lifecycle coupling into steward tmux sessions
@@ -55,10 +61,10 @@ treats the remote channel as a thin transport into `orchestrator`.
 | Slice | Goal | Status | Batch | Depends On |
 |-------|------|--------|-------|------------|
 | `Platform-8a` | Channel preflight, Telegram transport skeleton, kill/mute/fallback hooks | COMPLETE | E | Phase 3, Amendment A5, SP-4-05 |
-| `Platform-8b` | Repo-owned audit trail for inbound/outbound remote exchanges | READY FOR SCOPE LOCK | E | Platform-3, Platform-8a |
-| `Platform-9a` | Idle-attention alerts and remote acknowledgement loop | READY FOR SCOPE LOCK | E | Platform-6, Platform-8b |
-| `Platform-9b` | Away-from-desk queue-moving supervision through `orchestrator` | READY FOR SCOPE LOCK | E | Platform-2, Platform-8b, Platform-9a |
-| `Platform-9c` | First hardening pass from real remote use | READY FOR SCOPE LOCK | E | Platform-9b |
+| `Platform-8b` | Repo-owned audit trail for inbound/outbound remote exchanges | IN_PROGRESS (library complete, runtime wiring pending) | E | Platform-3, Platform-8a, SP-4-07 |
+| `Platform-9a` | Idle-attention alerts and remote acknowledgement loop | BLOCKED | E | Platform-6, Platform-8b, SP-4-07 |
+| `Platform-9b` | Away-from-desk queue-moving supervision through `orchestrator` | BLOCKED | E | Platform-2, Platform-8b, Platform-9a, SP-4-07 |
+| `Platform-9c` | First hardening pass from real remote use | BLOCKED | E | Platform-9b |
 
 ## Batch E Pass Gate
 
@@ -66,6 +72,8 @@ Before treating Phase 5 as ready, verify Batch E (Platform-8 + Platform-9):
 
 - [ ] Telegram proving run works end-to-end for one remote operator
 - [ ] Every inbound and outbound remote exchange is recorded in repo-owned state
+- [ ] One controller-backed actionable-state surface exists and is the source
+  for alerts / next actions / acknowledgement state
 - [ ] Kill switch and mute path work without needing desktop intervention
 - [ ] At least one alert path is proven with acknowledgement, dedupe, and
   backoff behavior
@@ -79,11 +87,14 @@ Before treating Phase 5 as ready, verify Batch E (Platform-8 + Platform-9):
 
 1. Scope lock plus local control-loop preflight
 2. Telegram host/plugin preflight and token baseline
-3. Telegram transport plus repo-owned logging
-4. Kill switch, mute, and operator fallback
-5. Alert / acknowledgement loop
-6. Queue-moving remote workflows through `orchestrator`
-7. First hardening pass from real use
+3. Stabilization gate plus lifecycle integration coverage
+4. Controller / actionable-state projection
+5. Hook surfacing and local guardrails
+6. Platform-8b runtime wiring against repo-owned state
+7. Alert / acknowledgement loop
+8. Queue-moving remote workflows through `orchestrator`
+9. First hardening pass from real use
+10. Transport consolidation reassessment (`#1289`)
 
 ## High-Value Workflows To Prove
 
@@ -111,6 +122,8 @@ Before treating Phase 5 as ready, verify Batch E (Platform-8 + Platform-9):
 | SP-4-03 | Token economy observability and dashboard | completed | `plans/agent_ops/4_remote_channel/sub/2026-03-23_token-economy-observability-and-dashboard.md` |
 | SP-4-04 | Platform-8a Telegram transport configuration | completed | `plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8a-telegram-transport.md` |
 | SP-4-05 | Reactive control-loop hardening | completed | `plans/agent_ops/4_remote_channel/sub/2026-03-24_reactive-control-loop-hardening.md` |
+| SP-4-06 | Platform-8b audit-trail library | completed | `plans/agent_ops/4_remote_channel/sub/2026-03-24_platform-8b-audit-trail.md` |
+| SP-4-07 | Controller-first control plane and transport evaluation | proposed | `plans/agent_ops/4_remote_channel/sub/2026-03-24_controller-first-control-plane-and-transport-evaluation.md` |
 
 ## Step Sequence
 

--- a/plans/agent_ops/4_remote_channel/sub/2026-03-24_controller-first-control-plane-and-transport-evaluation.md
+++ b/plans/agent_ops/4_remote_channel/sub/2026-03-24_controller-first-control-plane-and-transport-evaluation.md
@@ -1,0 +1,429 @@
+# Controller-First Control Plane And Transport Evaluation
+
+**ID:** SP-4-07
+**Date:** 2026-03-24
+**Parent:** `plans/agent_ops/governing_plan.md` -- Phase 4, Pre-Platform-9 / transport-consolidation follow-up
+**Status:** proposed
+**Owner:** orchestrator
+
+---
+
+## Problem Statement
+
+The steward platform now has multiple transport surfaces:
+
+- repo-owned task packets, events, review verdicts, and the custom message bus
+- Claude native inboxes populated by `SendMessage`
+- Claude Channels for remote/plugin delivery
+- hooks that can inject or block at local execution boundaries
+- tmux pane nudges as the current live-session fallback
+
+The platform's current failure mode is not lack of storage. It is lack of one
+authoritative controller that decides:
+
+- what changed
+- what is urgent
+- what can wait
+- what action is next
+- when an alert has been acknowledged or cleared
+
+Without that controller, transport debates (`SendMessage` vs custom bus vs
+Channels vs hooks) collapse into current-system bias. The platform keeps adding
+delivery mechanisms without settling what the canonical actionable state is.
+
+This sub-plan fixes that by introducing a controller-first control plane and a
+comparative proving path for the available delivery adapters.
+
+## Goals
+
+1. Make repo-owned reconciled state the only control-plane truth.
+2. Keep the custom bus as durable coordination/audit transport, not the primary
+   alert brain.
+3. Use hooks for local surfacing and guardrails.
+4. Use Claude Channels as the preferred remote/live-session push adapter if the
+   proving data supports it.
+5. Keep native `SendMessage` / native inboxes as optional conversational signal
+   sources until `#1289` is resolved with evidence.
+
+## Inputs
+
+- `plans/agent_ops/governing_plan.md`
+- `plans/agent_ops/4_remote_channel/plan.md`
+- `plans/agent_ops/4_remote_channel/checkpoints.md`
+- `plans/agent_ops/4_remote_channel/sub/2026-03-24_reactive-control-loop-hardening.md`
+- `plans/agent_ops/4_remote_channel/sub/2026-03-24_platform-8b-audit-trail.md`
+- `plans/sessions/2026-03-23_operator-hardening.md`
+- Issue `#1289` -- transport consolidation reassessment
+- Issue `#1571` -- messaging re-evaluation
+- Issue `#1573` -- Platform-8b runtime wiring gap
+- Issue `#1597` -- missing orchestration lifecycle integration test
+- Issue `#1581` -- pass/fail criteria requirement
+- `src/bid_euchre/ops/monitor.py`
+- `src/bid_euchre/ops/message_bus.py`
+- `src/bid_euchre/ops/scheduler.py`
+- `src/bid_euchre/ops/dashboard.py`
+- `scripts/internal/ops.py`
+
+## Scope
+
+This sub-plan covers:
+
+- a repo-owned controller/reconciler that derives actionable state
+- a stable machine-readable control-plane projection
+- hook-based local surfacing and guardrails fed from that projection
+- Platform-8b runtime wiring against the controller, not only raw transport
+- comparative evaluation of custom bus, native inbox bridge, and Channels
+- outcome-based smoke/full/proving gates for transport decisions
+
+This sub-plan does **not** cover:
+
+- replacing task packets, review verdicts, or the current review gate
+- moving authoritative workflow state into Claude-native inboxes or Channels
+- enabling author lanes for direct remote ingress
+- making tmux nudges the primary control-plane mechanism
+- final Discord rollout
+
+## Locked Architectural Decisions
+
+- **Repo-owned state is canonical.**
+  - Task packets, review verdicts, lifecycle events, lane state, and the
+    controller projection remain the only workflow truth.
+- **The custom bus stays.**
+  - It remains the durable lane-to-lane transport and audit record.
+  - It is not the sole urgent-alert consumption path.
+- **Native `SendMessage` stays optional.**
+  - Native inboxes may be imported into the repo-owned surface.
+  - Native inboxes are not promoted to canonical workflow truth in this slice.
+- **Claude Channels are the preferred remote push adapter.**
+  - If remote proving succeeds, Channels become the preferred way to push into
+    the running orchestrator session.
+  - Channels remain adapters on top of repo-owned state.
+- **Hooks enforce local boundaries.**
+  - Hooks may surface unresolved urgent state or block unsafe actions.
+  - Hooks do not become the authoritative state store.
+- **tmux nudges remain fallback-only.**
+  - They may wake or re-nudge a live pane, but they do not define control-plane
+    truth.
+
+## Deliverables
+
+### 1. Controller / reconciler module
+
+Add a repo-owned module, likely one of:
+
+- `src/bid_euchre/ops/control_plane.py`
+- `src/bid_euchre/ops/attention_state.py`
+
+It should read:
+
+- monitor findings
+- task packets / task lifecycle state
+- review verdict state
+- lane/session registry and lane activity state
+- message bus records
+- native inbox imports when enabled
+- remote audit records when relevant
+
+It should write:
+
+- `.claude/runtime/fleet_status.json`
+- optional `.claude/runtime/next_actions.json`
+
+Minimum fields per item:
+
+- stable `item_id`
+- `severity`
+- `category`
+- `source`
+- `first_seen_at`
+- `last_seen_at`
+- `state` (`open`, `acked`, `cleared`, `suppressed`)
+- related lane / task / PR identifiers
+- recommended action
+- escalation metadata if applicable
+
+### 2. Hook-fed local enforcement
+
+Add hook behavior driven by the controller projection:
+
+- `UserPromptSubmit` -- inject unresolved P0/P1 state into orchestrator context
+- `PreToolUse` -- warn or block risky actions (dispatch, merge, similar) when
+  unresolved P0 exists
+- `Stop` / `TaskCompleted` -- prevent false completion when required checks or
+  unresolved critical state remain
+
+### 3. Platform-8b runtime wiring
+
+Finish remote audit and runtime integration by ensuring:
+
+- inbound remote messages update the controller and audit surfaces
+- outbound replies/reacts/edits update the controller and audit surfaces
+- controller state, not raw transport, decides alert visibility
+
+### 4. Transport comparison matrix
+
+Produce a short architecture decision record covering:
+
+- custom bus
+- native `SendMessage` / native inbox bridge
+- Claude Channels
+- hooks
+- tmux nudges
+
+Criteria:
+
+- latency to surface urgent state
+- durability / replayability
+- structured metadata support
+- ack / clear compatibility
+- auditability
+- operator usability
+- implementation and maintenance cost
+
+## PR Roadmap
+
+### PR 1 -- Stabilization gate and lifecycle test baseline
+
+**Goal:** Remove obvious substrate bugs and add the missing end-to-end
+orchestration lifecycle test.
+
+**Scope:**
+
+- fix open correctness debt that would poison the controller layer
+- add `tests/integration/test_orchestration_lifecycle.py`
+- align Phase 4 docs with actual runtime wiring state
+
+**Likely files:**
+
+- `src/bid_euchre/ops/message_bus.py`
+- `src/bid_euchre/ops/monitor.py`
+- `.claude/skills/park/SKILL.md`
+- `tests/integration/test_orchestration_lifecycle.py`
+- `tests/unit/test_ops_message_bus.py`
+- `tests/unit/test_ops_monitor.py`
+
+**Primary issues:**
+
+- `#1596`
+- `#1610`
+- `#1612`
+- `#1580`
+- `#1597`
+- `#1573`
+
+### PR 2 -- Controller projection
+
+**Goal:** Publish one canonical actionable-state projection.
+
+**Scope:**
+
+- add controller/reconciler module
+- derive controller state from monitor/task/review/lane surfaces
+- write `fleet_status.json` / `next_actions.json`
+- expose read-only CLI/debug surface if useful
+
+**Likely files:**
+
+- `src/bid_euchre/ops/control_plane.py` or `attention_state.py`
+- `src/bid_euchre/ops/monitor.py`
+- `src/bid_euchre/ops/status.py`
+- `src/bid_euchre/ops/dashboard.py`
+- `scripts/internal/ops.py`
+- `tests/unit/test_ops_control_plane.py` (new)
+
+**Primary issues:**
+
+- `#1571`
+- `#1569`
+
+### PR 3 -- Hook surfacing and local guardrails
+
+**Goal:** Make unresolved urgent state mechanically visible and block unsafe
+local actions where appropriate.
+
+**Scope:**
+
+- `UserPromptSubmit` surfacing for unresolved P0/P1
+- `PreToolUse` guardrails for risky actions
+- `Stop` / `TaskCompleted` completion checks where they reduce false "done"
+
+**Likely files:**
+
+- `.claude/settings.json`
+- `.claude/settings.local.json` or repo-shared equivalent if promoted
+- new hook scripts under `.claude/hooks/`
+- `tests/unit/test_hook_dispatchers.py`
+- `tests/unit/test_daemon_notify.py`
+
+**Primary issues:**
+
+- `#1608`
+- `#1581`
+
+### PR 4 -- Platform-8b runtime wiring and controller-backed remote path
+
+**Goal:** Move Platform-8b from library-complete to runtime-complete.
+
+**Scope:**
+
+- wire inbound/outbound remote exchanges into the controller path
+- ensure repo-owned audit is updated in all real runtime paths
+- keep channel/plugin transport as adapter only
+
+**Likely files:**
+
+- `src/bid_euchre/ops/audit_trail.py`
+- orchestrator-facing remote wrappers / helpers
+- `scripts/internal/ops.py`
+- `.claude/tmux/steward-session.sh`
+- `tests/integration/test_audit_trail_integration.py`
+
+**Primary issues:**
+
+- `#1573`
+- `#1521`
+
+### PR 5 -- Comparative transport proving and `#1289` decision
+
+**Goal:** Decide the long-term role of native inboxes with proving data.
+
+**Scope:**
+
+- run the proving matrix across bus, native bridge, hooks, and Channels
+- write the decision note for `#1289`
+- update the governing plan only after the matrix is complete
+
+**Likely files:**
+
+- this sub-plan closeout
+- `plans/agent_ops/governing_plan.md`
+- `plans/agent_ops/amendments.md`
+- `plans/sessions/...` proving reports
+
+**Primary issue:**
+
+- `#1289`
+
+## Test Strategy
+
+### Unit tests
+
+Controller:
+
+- derive actionable items from monitor/task/review/lane inputs
+- dedupe repeated items
+- preserve stable IDs across cycles
+- clear items when acked/resolved
+- do not promote routine state to urgent incorrectly
+
+Hooks:
+
+- inject context only for unresolved P0/P1
+- remain silent for empty/low-priority state
+- fail safely on malformed projection state
+- block guarded actions only when policy requires it
+
+Transport boundary:
+
+- bus records still round-trip correctly
+- native inbox import remains idempotent
+- runtime wiring updates audit + controller state consistently
+
+### Smoke tests
+
+Controller smoke:
+
+- seed one urgent finding
+- run the controller once
+- verify `fleet_status.json` contains one actionable item
+
+Hook smoke:
+
+- seed unresolved urgent state
+- submit a prompt in orchestrator
+- verify injected context appears once
+- clear it and verify surfacing stops
+
+Remote audit smoke:
+
+- send one inbound remote message
+- verify inbound audit record and controller update
+- send one outbound reply
+- verify outbound audit record
+
+### Full integration tests
+
+- dispatch -> accept -> progress -> completion -> ack -> clear
+- monitor finding -> controller projection -> hook surfacing -> ack -> clear
+- unresolved urgent state survives restart/compaction and resurfaces correctly
+- `/park` / shutdown removes cron jobs before clear
+- remote inbound -> orchestrator handling -> outbound reply -> audit -> controller update
+
+## Proving Runs
+
+### Proving run 1 -- unread-alert replay
+
+Recreate the original failure shape where `ops` detects a blocker and the
+orchestrator does not manually poll raw inbox state.
+
+**Pass when:**
+
+- the urgent state is surfaced through the controller/hook path
+- no manual raw-inbox scan is required to notice it
+
+### Proving run 2 -- noise discrimination
+
+Generate many info/warn findings plus one real blocker.
+
+**Pass when:**
+
+- only the blocker becomes interrupt-like
+- routine findings remain visible but do not spam operator flow
+
+### Proving run 3 -- persistence and dedupe
+
+Run several monitor/controller cycles with one unresolved urgent item.
+
+**Pass when:**
+
+- the item is not lost across restart/compaction
+- repeated cycles do not create alert floods
+- ack/resolve clears the item cleanly
+
+### Proving run 4 -- false-stall regression
+
+Keep one lane actively working while earlier observations suggest trouble.
+
+**Pass when:**
+
+- current-state verification prevents false stall reports
+
+### Proving run 5 -- real remote loop
+
+Run one real remote exchange through the chosen channel path.
+
+**Pass when:**
+
+- inbound delivery works
+- outbound reply works
+- both directions are durably audited
+- controller state reflects the exchange correctly
+
+## Exit Criteria
+
+This sub-plan is complete only when:
+
+- one repo-owned controller surface exists and is the documented actionable
+  truth for urgent/routine operator state
+- one automated integration test proves `detect -> surface -> ack -> clear`
+- unresolved urgent state can no longer be silently ignored at normal
+  orchestrator interaction boundaries
+- Platform-8b is runtime-wired, not library-only
+- one real channel-backed remote loop is proven end to end
+- `#1289` has a decision note backed by the transport comparison matrix
+
+## Notes
+
+- The intent is not to rewrite the entire platform around Channels or native
+  inboxes.
+- The intent is to make transport choice subordinate to control-plane truth.

--- a/plans/agent_ops/amendments.md
+++ b/plans/agent_ops/amendments.md
@@ -1,7 +1,7 @@
 # Agentic Orchestration Platform — Amendments
 
 **Governing plan:** `plans/agent_ops/governing_plan.md`
-**Last updated:** 2026-03-23 (A8 remote-ops v1 shaping)
+**Last updated:** 2026-03-24 (A9 controller-first control plane and transport evaluation)
 
 ---
 
@@ -233,3 +233,35 @@ future sessions from having to reconstruct intent from chat history.
 multiplier because it reduces idle time while the operator is away from the
 desk. The cheapest reliable first version is a dumb transport into the
 existing orchestrator workflow, not a smarter remote-only control surface.
+
+---
+
+## A9 — Controller-first control plane and transport evaluation (2026-03-24)
+
+**PR:** pending follow-up
+
+**What changed:**
+1. **Controller-first truth made explicit** — The governing plan now states
+   that routine operator state should be materialized as a compact repo-owned
+   projection (for example `fleet_status.json` / `next_actions.json`) with
+   stable IDs, severity, state, and recommended action. This projection is the
+   preferred feed for hooks, dashboard views, and remote delivery.
+2. **Channels elevated as the preferred push adapter** — The delivery-adapter
+   roadmap now names Claude Channels as the preferred `v2` push mechanism for
+   live-session delivery once proving supports it. This keeps Channels in the
+   target architecture without making them canonical truth.
+3. **Native `SendMessage` kept as optional imported signal** — The governing
+   plan now records that Claude native inboxes may remain imported signal
+   sources, but should not replace repo-owned task/review/control state unless
+   a later proving matrix demonstrates semantic parity and lower operational
+   cost.
+4. **Transport consolidation explicitly deferred to evidence** — The plan now
+   says the choice among custom bus, native `SendMessage`, and Channels remains
+   open until comparative proving is complete. This prevents current-system
+   bias from locking in transport prematurely.
+
+**Rationale:** The platform has multiple viable transport surfaces, but the
+observed failures are control-loop failures, not storage failures. The most
+effective architecture is to settle canonical actionable state first, then
+choose transports based on measured fit rather than on whichever mechanism was
+implemented earliest.

--- a/plans/agent_ops/governing_plan.md
+++ b/plans/agent_ops/governing_plan.md
@@ -601,6 +601,13 @@ Hooks may provide low-latency hints, but routine lifecycle truth should come
 from a repo-owned reconciler/monitor path. Inboxes, dashboards, and remote
 channels are operator projections of that state, not the primary controller.
 
+The reconciled surface should be materialized as a compact repo-owned
+projection, for example `fleet_status.json` and/or `next_actions.json`, with
+stable item IDs, severity, first/last seen timestamps, current state
+(`open`, `acked`, `cleared`, `suppressed`), related lane/task/PR identifiers,
+and recommended action. This projection is the preferred feed for hooks,
+dashboard summaries, and remote delivery adapters.
+
 ## Remote Operator Channels
 
 The platform should support an official Claude Code plugin path for:
@@ -1325,11 +1332,15 @@ These are the short names future handoffs should use.
 - delivery-adapter upgrade path:
   - the Platform-7 tmux nudge remains the compatibility baseline until a
     channel-backed adapter proves stable
-  - a local channel sidecar may replace the pane-nudge adapter once the steward
-    session is launched with the required Claude Channels support and the
+  - a local Claude Channels sidecar is the preferred `v2` adapter once the
+    steward session is launched with the required Channels support and the
     repo-owned task/message contract remains canonical
   - any channel-backed lane delivery path must be treated as an adapter on top
     of repo-owned state, not as a second source of task truth
+  - Claude native `SendMessage` / team inboxes may remain imported signal
+    sources, but they should not replace repo-owned task, review, or control
+    state unless a later proving matrix shows semantic parity and lower
+    operational cost
 - local control-loop prerequisite:
   - before Platform-8 proving claims away-from-desk supervision is ready, the
     local platform must already reconcile routine lifecycle transitions without
@@ -1343,6 +1354,10 @@ These are the short names future handoffs should use.
     first place the system discovers them
   - optional presentation/transport integrations such as `cmux` must not be
     required for this control loop and must not degrade steward tmux sessions
+  - transport consolidation between the custom bus, native `SendMessage`, and
+    Claude Channels remains an explicit follow-up decision after comparative
+    proving; the platform should not assume the current transport layout is the
+    final one until that evaluation is complete
 - done when:
   - one remote channel can deliver summarized alerts and accept bounded replies
   - the implementation path is validated against either an official plugin or a

--- a/plans/agent_ops/sub_plan_registry.md
+++ b/plans/agent_ops/sub_plan_registry.md
@@ -1,7 +1,7 @@
 # Sub-Plan Registry — Agentic Orchestration Platform
 
 **Governing plan:** `plans/agent_ops/governing_plan.md`
-**Last updated:** 2026-03-24 by author-a (SP-4-06 completed)
+**Last updated:** 2026-03-24 by Codex (SP-4-07 proposed)
 
 ---
 
@@ -30,12 +30,13 @@
 | SP-4-04 | Platform-8a Telegram transport configuration | Phase 4, Platform-8a transport proving | completed | flex-a | `plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8a-telegram-transport.md` | 2026-03-23 | 2026-03-24 (PRs #1436, #1451, #1452; proven end-to-end) |
 | SP-4-05 | Reactive control-loop hardening | Phase 4, Pre-Platform-8 lifecycle reactivity and control-plane hardening | completed | orchestrator | `plans/agent_ops/4_remote_channel/sub/2026-03-24_reactive-control-loop-hardening.md` | 2026-03-24 | 2026-03-24 (PRs #1500, #1491, #1474, #1490, #1507, #1486; lifecycle proven through fleet operation) |
 | SP-4-06 | Platform-8b repo-owned remote audit trail | Phase 4, Platform-8b audit trail for remote exchanges | completed | author-a | `plans/agent_ops/4_remote_channel/sub/2026-03-24_platform-8b-audit-trail.md` | 2026-03-24 | 2026-03-24 (PRs #1532, #1536, #1541, #1549) |
+| SP-4-07 | Controller-first control plane and transport evaluation | Phase 4, Pre-Platform-9 controller projection, hook enforcement, and transport proving | proposed | orchestrator | `plans/agent_ops/4_remote_channel/sub/2026-03-24_controller-first-control-plane-and-transport-evaluation.md` | 2026-03-24 | — |
 
 ## Status Summary
 
 | Status | Count |
 |--------|-------|
-| proposed | 0 |
+| proposed | 1 |
 | in_progress | 0 |
 | blocked | 0 |
 | completed | 20 |

--- a/plans/sessions/2026-03-24_controller-first-control-plane-handoff.md
+++ b/plans/sessions/2026-03-24_controller-first-control-plane-handoff.md
@@ -1,0 +1,406 @@
+# Session Handoff — SP-4-07 Controller-First Control Plane
+
+**Date:** 2026-03-24
+**Status:** READY TO DISPATCH
+**Primary owner:** orchestrator
+**Parent sub-plan:** `plans/agent_ops/4_remote_channel/sub/2026-03-24_controller-first-control-plane-and-transport-evaluation.md`
+
+---
+
+## Executive Summary
+
+The next platform step is not another inbox tweak or another transport layer.
+It is a controller-first refactor.
+
+The current Platform OS can store events and alerts, but it does not yet have
+one repo-owned component that decides:
+
+- what changed
+- what is urgent
+- what can wait
+- what action is next
+- when an item is acknowledged or cleared
+
+That gap is why transport debates keep recurring:
+
+- custom message bus
+- native `SendMessage` / team inboxes
+- Claude Channels
+- hooks
+- tmux nudges
+
+This handoff makes `SP-4-07` the governing slice that settles control-plane
+truth first, then evaluates delivery adapters against that truth.
+
+## Key Decisions
+
+### 1. Canonical truth stays repo-owned
+
+Do not move workflow truth into Channels, native inboxes, or hook state.
+
+Canonical state remains:
+
+- task packets / task lifecycle state
+- review verdict state
+- monitor findings
+- lane/session state
+- repo-owned controller projection
+
+### 2. The custom bus stays, but its role narrows
+
+Keep the custom bus as:
+
+- durable lane-to-lane transport
+- audit trail
+- sender attribution surface
+
+Do not keep expanding it as the main urgent-alert brain.
+
+### 3. Native `SendMessage` is not the answer by itself
+
+Native inboxes are real and should remain available as an imported signal
+source, but they are currently too thin to replace repo-owned workflow state.
+
+### 4. Claude Channels are the preferred remote push adapter
+
+Channels are the best candidate for remote and live-session delivery if they
+prove reliable in this repo.
+
+They should sit on top of repo-owned state, not replace it.
+
+### 5. Hooks are enforcement surfaces, not the controller
+
+Use hooks to surface or block at local boundaries.
+
+Do not treat hooks as the only control loop or the primary source of state.
+
+## Problem Frame
+
+The main platform problem is reaction, not storage.
+
+Evidence already in repo history and planning:
+
+- monitor findings can be persisted without being acted on in time
+- inbox volume obscures high-signal action items
+- remote audit/runtime wiring is incomplete
+- some lifecycle claims are still tested only indirectly or not at all
+
+This means the platform currently over-invests in transports and under-invests
+in a shared actionable-state controller.
+
+## Primary Issues / Inputs
+
+- `#1289` -- reassess custom vs native messaging transport
+- `#1569` -- orchestrator unread inbox / alert surfacing gap
+- `#1571` -- messaging and control-plane re-evaluation
+- `#1573` -- Platform-8b runtime audit wiring gap
+- `#1580` -- `/clear` / shutdown hygiene gap
+- `#1581` -- pass/fail criteria requirement
+- `#1596` -- inbox/bus correctness edge case
+- `#1597` -- missing orchestration lifecycle integration test
+- `#1608` -- hook-based attention surfacing
+- `#1610` -- escalation flood risk
+- `#1612` -- stale / false lane-status reporting
+
+## Required Reading Before Implementation
+
+- `plans/agent_ops/governing_plan.md`
+- `plans/agent_ops/4_remote_channel/plan.md`
+- `plans/agent_ops/4_remote_channel/checkpoints.md`
+- `plans/agent_ops/4_remote_channel/sub/2026-03-24_controller-first-control-plane-and-transport-evaluation.md`
+- `plans/agent_ops/4_remote_channel/sub/2026-03-24_reactive-control-loop-hardening.md`
+- `plans/sessions/2026-03-23_operator-hardening.md`
+- `src/bid_euchre/ops/message_bus.py`
+- `src/bid_euchre/ops/monitor.py`
+- `src/bid_euchre/ops/dashboard.py`
+- `src/bid_euchre/ops/scheduler.py`
+- `scripts/internal/ops.py`
+
+## Implementation Sequence
+
+### PR 1 — Stabilization gate and lifecycle baseline
+
+**Goal:** remove correctness noise that would invalidate the controller slice.
+
+**Scope:**
+
+- fix known message-bus / monitor / stall-reporting correctness debt
+- fix cleanup/shutdown hygiene that leaves background behavior behind
+- add the missing orchestration lifecycle integration test
+- keep planning docs honest about Platform-8b runtime state
+
+**Likely files:**
+
+- `src/bid_euchre/ops/message_bus.py`
+- `src/bid_euchre/ops/monitor.py`
+- `.claude/skills/park/SKILL.md`
+- `tests/integration/test_orchestration_lifecycle.py`
+- `tests/unit/test_ops_message_bus.py`
+- `tests/unit/test_ops_monitor.py`
+
+**Primary issues:**
+
+- `#1596`
+- `#1610`
+- `#1612`
+- `#1580`
+- `#1597`
+- `#1573`
+
+### PR 2 — Controller projection
+
+**Goal:** publish one canonical actionable-state surface.
+
+**Scope:**
+
+- add `src/bid_euchre/ops/control_plane.py` or equivalent
+- reconcile monitor findings, task state, review state, lane state, and bus data
+- write `.claude/runtime/fleet_status.json`
+- optionally write `.claude/runtime/next_actions.json`
+- add a read-only CLI view if it materially helps operations
+
+**Minimum output fields:**
+
+- `item_id`
+- `severity`
+- `category`
+- `source`
+- `first_seen_at`
+- `last_seen_at`
+- `state`
+- related lane / task / PR identifiers
+- recommended action
+
+**Likely files:**
+
+- `src/bid_euchre/ops/control_plane.py`
+- `src/bid_euchre/ops/monitor.py`
+- `src/bid_euchre/ops/status.py`
+- `src/bid_euchre/ops/dashboard.py`
+- `scripts/internal/ops.py`
+- `tests/unit/test_ops_control_plane.py`
+
+**Primary issues:**
+
+- `#1571`
+- `#1569`
+
+### PR 3 — Hook surfacing and local guardrails
+
+**Goal:** make unresolved urgent state mechanically visible.
+
+**Scope:**
+
+- `UserPromptSubmit` injection for unresolved P0/P1
+- `PreToolUse` warnings or blocks for risky actions under unresolved P0
+- `Stop` or `TaskCompleted` checks where they materially reduce false "done"
+
+**Likely files:**
+
+- `.claude/settings.json`
+- `.claude/hooks/*`
+- `tests/unit/test_hook_dispatchers.py`
+- `tests/unit/test_daemon_notify.py`
+
+**Primary issues:**
+
+- `#1608`
+
+### PR 4 — Platform-8b runtime wiring
+
+**Goal:** finish real remote audit/runtime integration against the controller.
+
+**Scope:**
+
+- wire inbound remote messages into audit plus controller state
+- wire outbound replies/reacts/edits into audit plus controller state
+- ensure alert visibility is driven by the controller, not raw transport
+
+**Likely files:**
+
+- runtime paths that actually invoke `audit_inbound`, `audit_reply`,
+  `audit_react`, `audit_edit`
+- remote channel integration points
+- controller/audit tests
+
+**Primary issues:**
+
+- `#1573`
+- remote audit follow-up under Platform-8b
+
+### PR 5 — Transport comparison and `#1289` decision
+
+**Goal:** choose transport roles from proving data, not intuition.
+
+**Compare:**
+
+- custom bus
+- native `SendMessage` / native inbox bridge
+- Claude Channels
+- hooks
+- tmux nudges
+
+**Decision output:**
+
+- what remains canonical truth
+- what remains durable transport
+- what becomes preferred push adapter
+- what stays fallback-only
+
+## Test Plan
+
+### Unit tests
+
+1. Controller derivation
+- reconcile multiple raw findings into one actionable item
+- dedupe repeated alerts
+- clear items on ack/resolve
+- keep low-priority routine state out of urgent surfacing
+
+2. Hook behavior
+- inject urgent context only when unresolved P0/P1 exists
+- stay silent for empty or low-priority state
+- fail safely on malformed projection files
+- block guarded actions only when policy requires it
+
+3. Bus/controller boundary
+- bus records still round-trip correctly
+- controller projection derives from existing repo-owned state
+- ack/resolve transitions clear surfaced urgent items
+
+4. Freshness / stall correctness
+- stale observations do not override current lane state
+- active work is not surfaced as stalled
+
+### Smoke tests
+
+1. Controller smoke
+- synthesize one urgent finding
+- run controller once
+- verify `fleet_status.json` contains one actionable item
+
+2. Hook smoke
+- seed controller output
+- submit prompt in orchestrator session
+- verify urgent context appears exactly once
+
+3. Guard smoke
+- leave unresolved P0 present
+- attempt guarded dispatch or merge path
+- verify warn/block behavior matches policy
+
+4. Native import smoke
+- seed a native inbox entry
+- verify bridge import works and dedupes on rerun
+
+5. Channel smoke
+- send one real channel message
+- verify orchestrator receives it
+- verify inbound/outbound audit records are written
+
+### Full integration tests
+
+1. Lifecycle
+- dispatch -> accept -> progress -> completion -> ack -> clear
+
+2. Alert loop
+- monitor finding -> controller projection -> hook surfacing -> ack -> clear
+
+3. Restart persistence
+- unresolved urgent state survives restart/compaction
+- next boundary still surfaces it
+
+4. Remote loop
+- inbound remote message -> orchestrator handling -> outbound reply -> audit
+  trail -> controller update
+
+5. Shutdown hygiene
+- `/park` or equivalent cleanup removes background cron/process state before
+  clear/restart
+
+## Required Proving Runs
+
+### 1. Unread-alert replay
+
+Recreate the original blind-spot shape.
+
+**Pass if:**
+
+- `ops` detects a real blocker
+- orchestrator does not manually inspect raw inboxes
+- the blocker is still surfaced mechanically within one normal interaction
+  boundary
+
+### 2. Noise discrimination run
+
+Generate many routine findings and one real blocker.
+
+**Pass if:**
+
+- only the blocker becomes interrupt-like
+- routine status stays available without prompt spam
+
+### 3. Persistence / dedupe run
+
+Keep one urgent item open across multiple cycles and a restart.
+
+**Pass if:**
+
+- no duplicate flood
+- no lost urgent item
+- ack/resolve clears it cleanly
+
+### 4. False-stall regression run
+
+Keep one lane actively working while older observations suggest a stall.
+
+**Pass if:**
+
+- current-state verification prevents false stall surfacing
+
+### 5. Real remote loop proving run
+
+Use the actual preferred remote adapter candidate.
+
+**Pass if:**
+
+- inbound arrives
+- reply succeeds
+- audit records both directions
+- controller reflects the interaction correctly
+
+## Acceptance Gates
+
+Do not close `SP-4-07` or claim transport convergence unless all are true:
+
+1. One automated integration test covers `detect -> surface -> ack -> clear`.
+2. One controller-backed actionable-state file exists and is stable.
+3. Unresolved urgent state cannot be silently ignored at normal orchestrator
+   interaction boundaries.
+4. Resolved urgent state stops surfacing immediately.
+5. Platform-8b runtime audit wiring is real, not library-only.
+6. One real Channels-backed remote loop is proven if Channels remain the
+   preferred remote adapter.
+7. The `#1289` transport decision is written as an explicit comparison, not an
+   assumption.
+
+## Non-Goals
+
+Do not broaden this slice into:
+
+- replacing task packets or review verdicts
+- making author lanes directly remote-addressable
+- replacing the custom bus outright
+- moving workflow truth into native Claude inboxes
+- final Discord rollout
+
+## Closeout Requirements
+
+When this sequence lands, leave a closeout note with:
+
+- PR numbers
+- issues closed or narrowed
+- final controller file/location
+- whether Channels proved reliable enough to remain preferred
+- whether native inbox import stays enabled
+- any residual follow-up issue needed after `#1289`

--- a/plans/sessions/2026-03-24_issue-triage-handoff.md
+++ b/plans/sessions/2026-03-24_issue-triage-handoff.md
@@ -1,0 +1,143 @@
+# Next Session Handoff — Issue Triage and Resolution
+
+**Date:** 2026-03-24
+**Status:** READY FOR NEXT SESSION
+**Primary goal:** Triage all open issues, define test criteria for each, and resolve them
+
+---
+
+## Current State
+
+### What just shipped (Session 2026-03-24c)
+- 28 PRs merged across Browser Phase 4 + Platform-8b + convention sweep
+- Browser Phase 4 (SP-4-01 export/replay): COMPLETE
+- Platform-8b (SP-4-06 audit trail): library complete, runtime wiring pending
+- Session plan: `plans/sessions/2026-03-24_overnight-autonomous-run.md`
+
+### Open PRs
+- #1576 (ops JSON modes) — in CI, should auto-merge
+- #1579 (test fixture consolidation rebase) — in CI, should auto-merge
+
+### Steward State
+- All 12 worker lanes cleared and idle
+- Ops and review crons killed, contexts cleared
+- Orchestrator inbox acked
+- No dispatched task packets
+
+---
+
+## Primary Goal: Issue Triage and Resolution
+
+Triage all 15 open issues. For each one:
+1. Read the issue
+2. Define explicit pass/fail test criteria (per #1581 policy)
+3. Classify: fix now / defer / close
+4. If fixing: create task packet with test criteria in the description
+5. Dispatch to appropriate lane
+
+### New Policy (#1581)
+Every task packet MUST include test criteria before dispatch. Not just
+"run make check" but specific, verifiable conditions. The orchestrator
+should refuse to dispatch without them.
+
+---
+
+## Open Issues — Pre-Triage
+
+### Tier 1: Autonomous Operations Hardening (fix before next fleet run)
+
+| # | Title | Scope | Test Criteria (draft) |
+|---|-------|-------|----------------------|
+| **#1571** | Messaging system re-evaluation | Architecture/design | Produce design doc with bilateral messaging spec |
+| **#1569** | Orchestrator must poll inbox | Orchestrator check-in skill | Send test message → verify orchestrator reads it within 1 cycle |
+| **#1568** | Merge-conflict stall detection | Orchestrator monitoring | Open PR with conflict → verify orchestrator detects within 2 cycles |
+| **#1572** | Idle auto-shutoff after 90min | Orchestrator session mgmt | Simulate 90min idle → verify shutoff triggers |
+| **#1570** | Bilateral messaging tests | Test infrastructure | Smoke test: send+receive across all lane types in <30s |
+| **#1580** | /clear doesn't kill crons | Lane shutdown procedure | /park a lane → verify CronList returns empty |
+| **#1581** | Test criteria policy | Process/docs | Verify CLAUDE.md, templates, and dispatch enforce criteria |
+
+### Tier 2: Platform-8b Completion
+
+| # | Title | Scope | Test Criteria (draft) |
+|---|-------|-------|----------------------|
+| **#1573** | Audit trail not runtime-wired | Orchestrator + audit_trail.py | Send Telegram msg → verify entry in remote_exchanges.jsonl |
+
+### Tier 3: Convention Follow-ups
+
+| # | Title | Scope | Test Criteria (draft) |
+|---|-------|-------|----------------------|
+| **#1578** | Follow-up for PR #1575 | scripts/internal/export_hosted_decisions.py | TBD — read issue |
+| **#1577** | Export ordering assertion | tests/ | TBD — read issue |
+| **#1574** | Browser checkpoint test count | plans/browser_game/ | Checkpoint says "all tests pass" not exact count |
+
+### Tier 4: Infrastructure (defer unless idle capacity)
+
+| # | Title | Scope | Notes |
+|---|-------|-------|-------|
+| #1521 | Telegram plugin unreliable | External plugin | Needs user smoke test |
+| #1337 | Dashboard auto-refresh | ops/dashboard.py | Partially addressed by #1534 |
+| #1289 | Transport consolidation | Assessment only | Defer |
+| #1288 | Comment ingestion bridge | ops/ | Defer |
+
+---
+
+## Execution Model
+
+### Phase 1: Triage Pass (orchestrator-only, no dispatch)
+1. Read each issue
+2. Define test criteria
+3. Update issue with test criteria comment
+4. Classify into tiers
+5. Identify file-scope overlaps
+
+### Phase 2: Tier 3 Quick Fixes (parallel dispatch)
+Small convention fixes with clear test criteria. 3-4 lanes, parallel.
+These are easy wins that reduce the issue count fast.
+
+### Phase 3: Tier 1 Design Work
+- #1571 messaging re-evaluation needs a design doc first, not code
+- #1581 policy needs CLAUDE.md + template updates
+- #1580 needs a /park skill or shutdown procedure
+
+### Phase 4: Tier 1 Implementation
+Once design is locked:
+- #1569 inbox polling (orchestrator check-in skill update)
+- #1568 merge-conflict detection (orchestrator monitoring update)
+- #1572 idle auto-shutoff
+- #1570 bilateral messaging tests
+
+### Phase 5: Tier 2 (Platform-8b wiring)
+Only after Tier 1 is solid:
+- #1573 runtime wiring of audit trail
+- Depends on Telegram being functional (#1521) for end-to-end proof
+
+---
+
+## Monitoring Improvements for This Session
+
+Based on overnight findings, the orchestrator MUST:
+
+1. **Poll inbox every check-in:** `uv run python scripts/internal/ops.py inbox --lane orchestrator`
+2. **Check PR mergeable status:** `gh pr view N --json mergeable` for every open PR
+3. **Track last_meaningful_change:** If nothing changes for 30 minutes, investigate (don't just keep polling)
+4. **Check ops pane:** Include ops lane in every status capture
+5. **Verify facts before stating them:** Don't guess token counts, PR counts, or completion status
+
+---
+
+## Hard Constraints
+
+- Do not start Platform-9a until Platform-8b wiring (#1573) is proven
+- Do not start Telegram proving until #1521 is resolved
+- Every dispatched task MUST have test criteria (#1581)
+- One writer per overlapping file set
+- Defer #1288, #1289 unless all tiers 1-3 are complete
+
+---
+
+## What To Read At Session Start
+
+1. This handoff
+2. `plans/sessions/2026-03-24_overnight-autonomous-run.md` (for context on what shipped)
+3. MEMORY.md (updated with session results)
+4. Each open issue (15 total) — read before triaging

--- a/plans/sessions/2026-03-24_next-session-browser-platform-handoff.md
+++ b/plans/sessions/2026-03-24_next-session-browser-platform-handoff.md
@@ -1,0 +1,206 @@
+# Next Session Handoff — Browser Phase 4 + Platform-8b
+
+**Date:** 2026-03-24
+**Status:** READY FOR NEXT SESSION
+**Primary tracks:** Browser Game Phase 4 data pipeline, Phase 4 Platform-8b remote audit trail
+
+---
+
+## Current State
+
+### Browser lane
+
+- The Phase 3 browser product is materially shipped in code on `main`:
+  - `web/templates/game.html`
+  - `web/templates/landing.html`
+  - `web/templates/partials/*`
+  - `web/static/style.css`
+  - `web/static/game.js`
+  - route wiring in `web/routes.py`
+- Browser route and resume behavior are implemented and covered in the hosted-play
+  route suite, but the local workspace cannot currently collect that suite because
+  hosted deps are not fully installed.
+- Browser planning metadata is behind the actual shipped code:
+  - `plans/browser_game/3_frontend_product/checkpoints.md` still shows Steps 1 and 3
+    `IN_PROGRESS`, Steps 4 and 5 `PENDING`
+  - `plans/browser_game/4_data_pipeline/checkpoints.md` still treats Phase 4 as fully
+    pending from a 2026-03-14 baseline
+  - `plans/browser_game/sub_plan_registry.md` still shows `SP-3-02` and `SP-4-01`
+    as `proposed`
+
+### Platform lane
+
+- Local control-loop hardening is complete:
+  - `SP-4-05` is complete
+  - `Platform-8a` Telegram setup/proving is complete
+- The old `SP-4-05` session handoff is now stale and should be treated as
+  architecture history only, not as the next dispatch brief.
+- The next governed Phase 4 platform slice is:
+  - `Platform-8b` repo-owned remote audit trail (`#1324`)
+- Remote proving through Telegram should follow `Platform-8b`, not replace it.
+
+### Runtime state
+
+- `uv run python scripts/internal/ops.py --json status` currently reports stale
+  lanes and warnings, but no active packets.
+- `uv run python scripts/internal/ops.py --json dashboard` currently reports a
+  large unacked inbox backlog.
+- Start the next session with a cleanup/reset pass before new platform proving.
+
+---
+
+## Recommended Session Order
+
+### Track 1 (PRIMARY): Browser Game Phase 4 — Data Pipeline
+
+This is the best primary implementation track for the next session.
+
+#### Step 0: Closure and verification pass first
+
+Spend the first 20-30 minutes on these exact tasks:
+
+1. Sync hosted/dev dependencies so browser route tests are runnable.
+2. Rerun the hosted-play browser test suite:
+   - `uv run python -m pytest -q tests/unit/hosted_play/test_routes.py`
+   - `uv run python -m pytest -q tests/unit/hosted_play/test_engine.py tests/unit/hosted_play/test_partials.py`
+3. Update browser planning metadata so the durable repo state matches shipped code:
+   - `plans/browser_game/3_frontend_product/checkpoints.md`
+   - `plans/browser_game/4_data_pipeline/checkpoints.md`
+   - `plans/browser_game/sub_plan_registry.md`
+
+#### Browser note on current test status
+
+- In this workspace, route-test collection currently fails with:
+  - `ModuleNotFoundError: starlette`
+- The non-route browser tests do run:
+  - `tests/unit/hosted_play/test_engine.py`
+  - `tests/unit/hosted_play/test_partials.py`
+  - result: 62 tests passed
+
+#### Step 1: Start Phase 4 implementation
+
+After the closure pass, move directly into `SP-4-01` export/replay work.
+
+Recommended implementation order:
+
+1. Add `web/export.py`
+2. Add `tests/unit/hosted_play/test_export.py`
+3. Implement and lock tests for:
+   - `decision_to_jsonl()`
+   - `export_decisions()`
+4. Add `validate_replay()` once the exported decision schema is test-locked
+5. Add the CLI wrapper last:
+   - `scripts/internal/export_hosted_decisions.py`
+
+Why this order:
+
+- It locks the replay/export contract in tests before CLI work expands scope.
+- It uses the now-fixed decision rows and redeal persistence as the data baseline.
+
+### Track 2 (SECONDARY): Phase 4 Platform lane — Platform-8b remote audit trail
+
+This is the correct next platform slice for the next session.
+
+#### Step 0: Platform cleanup/reset
+
+Before new platform implementation:
+
+1. Restart the steward session cleanly
+2. Run:
+   - `uv run python scripts/internal/ops.py lane refresh --all-idle`
+3. Compact or purge handled inbox noise if needed
+4. Verify stale execution-surface warnings are either cleared or intentionally ignored
+
+#### Step 1: Start Platform-8b, not more SP-4-05 work
+
+Do **not** spend platform lanes on more local control-loop work unless a fresh
+runtime issue proves otherwise.
+
+The next platform implementation target is:
+
+- `#1324` — repo-owned audit trail for remote channel exchanges
+
+Recommended first actions:
+
+1. Create/register the next Phase 4 platform sub-plan for `Platform-8b`
+   (expected next ID: `SP-4-06`)
+2. Scope the slice around durable logging for every remote exchange:
+   - inbound operator -> orchestrator
+   - outbound orchestrator -> operator
+   - alerts
+   - permission-relay prompts
+3. Log, at minimum:
+   - timestamp
+   - direction
+   - channel source
+   - sender identity
+   - content or content hash
+
+#### Step 2: Defer remote proving until after Platform-8b
+
+Telegram away-from-desk proving is still valuable, but it should be treated as
+the next user-smoke-test-gated step after the audit trail lands.
+
+That means:
+
+- do `Platform-8b` first
+- then move to idle-attention alerts / acknowledgement loop
+- then do away-from-desk queue-moving proving
+
+### Track 3 (TERTIARY): Deferred platform follow-ups
+
+Only use idle platform/scratch capacity here after Tracks 1-2 are unblocked:
+
+- `#1337` — live dashboard auto-refresh
+- `#1289` — transport consolidation reassessment
+- `#1288` — comment-ingestion bridge activation
+- small convention follow-ups:
+  - `#1505`
+  - `#1514`
+  - `#1520`
+
+---
+
+## What To Read At Session Start
+
+### Browser
+
+- `plans/browser_game/governing_plan.md`
+- `plans/browser_game/3_frontend_product/checkpoints.md`
+- `plans/browser_game/4_data_pipeline/checkpoints.md`
+- `plans/browser_game/4_data_pipeline/sub/2026-03-14_export_replay.md`
+- `plans/browser_game/sub_plan_registry.md`
+
+### Platform
+
+- `plans/agent_ops/4_remote_channel/plan.md`
+- `plans/agent_ops/4_remote_channel/checkpoints.md`
+- `plans/agent_ops/4_remote_channel/sub/2026-03-24_reactive-control-loop-hardening.md`
+- `plans/sessions/2026-03-24_sp4-05-reactive-control-loop-handoff.md`
+  - read for architecture decisions only, not as the next dispatch brief
+
+---
+
+## Validations
+
+### Browser
+
+- `uv run python -m pytest -q tests/unit/hosted_play/test_routes.py`
+- `uv run python -m pytest -q tests/unit/hosted_play/test_engine.py tests/unit/hosted_play/test_partials.py`
+- `uv run python -m pytest -q tests/unit/hosted_play/test_export.py`
+
+### Platform
+
+- `uv run python scripts/internal/ops.py --json status`
+- `uv run python scripts/internal/ops.py --json dashboard`
+
+---
+
+## Key Decisions For The Next Session
+
+- Browser Phase 4 is the best primary implementation target.
+- The browser lane should begin by reconciling planning metadata to shipped code.
+- Platform should not return to `SP-4-05`; that slice is complete.
+- The next governed platform slice is `Platform-8b` / `#1324`.
+- Telegram away-from-desk proving is not the first next platform task.
+- Ignore unrelated untracked `.claude/*` repo state unless it directly interferes.

--- a/plans/sessions/2026-03-24_overnight-autonomous-run.md
+++ b/plans/sessions/2026-03-24_overnight-autonomous-run.md
@@ -1,0 +1,269 @@
+# Overnight Autonomous Run — 2026-03-24
+
+**Status:** EXECUTING
+**Target:** 20-30+ merged PRs across Browser Phase 4 + Platform-8b
+**Plan location:** `plans/sessions/2026-03-24_overnight-autonomous-run.md`
+**Compaction recovery:** Re-read THIS FILE after any compaction. It is the source of truth.
+
+---
+
+## Phase 0 — Bootstrap (COMPLETE)
+
+- [x] Lane refresh: all 12 idle lanes refreshed to origin/main
+- [x] Inbox cleanup: all lanes acked, orchestrator clean
+- [x] Hosted deps: `uv sync --extra dev --extra hosted` in main + all worktrees — starlette available
+- [x] Browser tests: 95 pass (62 engine/partials + 33 routes)
+- [x] Route tests: now collect after dep sync
+- [x] Telegram: filed #1521, deferred (not critical path)
+- [x] Issue triage: 7 open issues triaged
+
+---
+
+## Operating Model
+
+Three rolling queues, not hard barriers:
+1. **Browser queue** — Browser Phase 4 SP-4-01 export/replay (PRIMARY)
+2. **Platform queue** — Platform-8b #1324 audit trail (SECONDARY)
+3. **Overflow queue** — convention fixes, docs, validation, handoff
+
+Pipeline rule: while one slice is in CI/review, next slice is already in flight.
+One active writer per overlapping file set.
+
+---
+
+## Queue Assignments
+
+### Browser Queue (brws-author-a through brws-author-d)
+
+**STRICT OWNERSHIP (review finding P1):**
+- **brws-author-a** — SOLE owner of `web/export.py` until module shape stabilizes
+- **brws-author-a** — SOLE owner of `tests/unit/hosted_play/test_export.py`
+- **brws-author-b** — owns `scripts/internal/export_hosted_decisions.py` (CLI, queued after export module)
+- **brws-author-c**, **brws-author-d** — validation, docs, fixtures, review support ONLY
+- No other lane may write to `web/export.py` during this session
+
+### Platform Queue (author-a through author-d)
+
+Primary chain owner: **author-a** (owns src/bid_euchre/ops/audit_trail.py)
+Test owner: **author-b** (owns tests for audit trail)
+Convention fixes: **author-c** (token_economy.py), **author-b** (#1520)
+Support: **author-d** (seam analysis, docs, reviews)
+
+### Overflow Queue (flex-a, flex-b, flex-c, author-scratch)
+
+Runtime hygiene, review support, docs, checkpoint updates, handoff prep.
+
+---
+
+## Dispatch Queue — Micro-PR Slices
+
+### Wave 1 — Metadata + Convention Cleanup
+
+| ID | Lane | Task | Scope | Status |
+|----|------|------|-------|--------|
+| W1-1 | brws-author-a | Close Phase 3 checkpoints, activate Phase 4, update registry | plans/browser_game/ (3 files) | MERGED PR #1522 ✅ |
+| W1-2 | author-a | Create SP-4-06 for Platform-8b, register, update checkpoints | plans/agent_ops/4_remote_channel/ (3-4 files) | MERGED PR #1523 ✅ |
+| W1-3 | author-b | Fix #1520: post-merge-notify.sh hardening | .claude/hooks/post-merge-notify.sh | PR #1524 (in CI) |
+| W1-4 | author-c | Fix #1505 + #1514: token_economy.py | src/bid_euchre/ops/token_economy.py | PR #1525 (in CI) |
+
+### Wave 2 — Browser Export Foundation + Platform Seam Decision Gate
+
+**GATE (review finding P1):** Platform-8b implementation queue does NOT open until
+the seam analysis produces an explicit interception decision. Wave 2 platform work
+is planning only.
+
+| ID | Lane | Task | Scope | Depends |
+|----|------|------|-------|---------|
+| W2-1 | brws-author-a | Implement decision_to_jsonl() + schema compliance test + round-trip test | web/export.py (SOLE OWNER), tests/unit/hosted_play/test_export.py | W1-1 |
+| W2-2 | author-a | Platform-8b SEAM DECISION: explicit interception point analysis, document in SP-4-06. Must answer: where do ALL remote exchanges pass through? | plans/agent_ops/4_remote_channel/sub/ | W1-2 |
+| W2-3 | brws-author-b | Browser test fixture helpers + export docs/examples (NOT web/export.py) | tests/unit/hosted_play/ helpers | W1-1 |
+| W2-4 | author-d | Platform-8b read-only seam analysis support: review message_bus.py, identify all send/receive paths | (read-only analysis, feed into W2-2) | W1-2 |
+
+### Wave 3 — Core Export + Audit Writer (SEAM GATED)
+
+**GATE:** W3-3 and W3-4 only start after W2-2 seam decision is committed and reviewed.
+First implementation PR serialized through author-a to prove the contract before splitting.
+
+| ID | Lane | Task | Scope | Depends |
+|----|------|------|-------|---------|
+| W3-1 | brws-author-a | Add export_decisions() + human-only filter test + match filter test + empty DB test | web/export.py (SOLE OWNER), tests/unit/hosted_play/test_export.py | W2-1 |
+| W3-2 | brws-author-c | Verify all browser tests still pass after export module changes | tests/unit/hosted_play/ (read + run) | W2-1 |
+| W3-3 | author-a | Platform-8b core: implement audit_trail.py (AuditLogger + write_entry + read_entries) + unit tests in same PR to prove contract | src/bid_euchre/ops/audit_trail.py (new), tests/unit/test_audit_trail.py (new) | W2-2 SEAM DECISION |
+| W3-4 | author-b | (QUEUED) Platform-8b additional tests — only after W3-3 proves the contract | tests/unit/test_audit_trail.py | W3-3 |
+
+### Wave 4 — Replay Validation + Audit Wiring
+
+| ID | Lane | Task | Scope | Depends |
+|----|------|------|-------|---------|
+| W4-1 | brws-author-a | Add validate_replay() + replay correctness test | web/export.py, tests/unit/hosted_play/test_export.py | W3-1 |
+| W4-2 | brws-author-b | CLI skeleton: scripts/internal/export_hosted_decisions.py (--db, --output flags) | scripts/internal/export_hosted_decisions.py (new) | W3-1 |
+| W4-3 | author-a | Wire audit trail into inbound remote message path | src/bid_euchre/ops/message_bus.py, audit_trail.py | W3-3 |
+| W4-4 | author-b | Wire audit trail into outbound remote message path | src/bid_euchre/ops/message_bus.py, audit_trail.py | W3-3 |
+
+NOTE: W4-3 and W4-4 touch the same files — serialize author-a first, author-b second.
+
+### Wave 5 — CLI Completion + Audit Tests
+
+| ID | Lane | Task | Scope | Depends |
+|----|------|------|-------|---------|
+| W5-1 | brws-author-b | CLI flags: --match-uuid, --human-only filtering | scripts/internal/export_hosted_decisions.py | W4-2 |
+| W5-2 | brws-author-a | Full browser Phase 4 validation pass | tests/unit/hosted_play/ (all) | W4-1 |
+| W5-3 | author-a | Alert + permission-relay audit logging seams | src/bid_euchre/ops/audit_trail.py | W4-3 |
+| W5-4 | author-b | Integration tests for Platform-8b | tests/integration/ or tests/unit/ | W4-4 |
+
+### Wave 6 — Closeout
+
+| ID | Lane | Task | Scope | Depends |
+|----|------|------|-------|---------|
+| W6-1 | brws-author-a | Update Phase 4 checkpoints, registry, session notes | plans/browser_game/ | W5-2 |
+| W6-2 | author-a | Mark SP-4-06 complete, update Phase 4 checkpoints Step 2 COMPLETE | plans/agent_ops/ | W5-3 |
+| W6-3 | flex-a | Update MEMORY.md with session results | MEMORY.md | W6-1, W6-2 |
+| W6-4 | brws-author-b | Phase 4 CLI validation pass | (run + verify) | W5-1 |
+
+### Wave 7 — If Primary Tracks Complete (CONDITIONAL)
+
+Only if Waves 1-6 are effectively done.
+
+**GATE (review finding P1):** Platform-9a SCOPE LOCK ONLY. Do NOT start alert-path
+implementation until Platform-8b Step 2 is marked COMPLETE (not just "in CI").
+
+| ID | Lane | Task | Scope | Depends |
+|----|------|------|-------|---------|
+| W7-1 | author-a | Create SP-4-07 for Platform-9a (idle-attention alerts), SCOPE LOCK ONLY — no implementation | plans/agent_ops/ | W6-2 (Step 2 COMPLETE, not just in CI) |
+| W7-2 | author-b | (BLOCKED until W7-1 merged AND Platform-8b COMPLETE) One narrow alert path | src/bid_euchre/ops/ | W7-1 + Platform-8b COMPLETE |
+| W7-3 | flex-* | Small #1337 freshness improvement if clearly isolated | src/bid_euchre/ops/dashboard.py | Independent |
+
+### Wave 8 — Handoff Prep (ALWAYS)
+
+| ID | Lane | Task |
+|----|------|------|
+| W8-1 | orchestrator | Produce compact session handoff with shipped PRs, in-flight work, blockers |
+| W8-2 | flex-* | Final MEMORY.md update |
+| W8-3 | flex-* | Validation reruns on any changed modules |
+
+---
+
+## Compaction Recovery Protocol
+
+If this session compacts, the orchestrator MUST:
+
+1. Re-read THIS FILE: `plans/sessions/2026-03-24_overnight-autonomous-run.md`
+2. Check progress markers in the dispatch queue (PENDING/DISPATCHED/MERGED/BLOCKED)
+3. Run `uv run python scripts/internal/ops.py dashboard` to see lane state
+4. Run `uv run python scripts/internal/ops.py task list` to see active packets
+5. Run `uv run python scripts/internal/ops.py inbox stats` to check for author responses
+6. Resume from the first PENDING slice in the dispatch queue
+
+Key context to preserve across compaction:
+- **Plan file:** `plans/sessions/2026-03-24_overnight-autonomous-run.md`
+- **Browser DB schema:** web/db.py has Player, Match, Hand, Decision models
+- **SP-4-01 export spec:** `plans/browser_game/4_data_pipeline/sub/2026-03-14_export_replay.md`
+- **Phase 4 remote plan:** `plans/agent_ops/4_remote_channel/plan.md`
+- **All 95 browser tests pass** after `uv sync --extra dev --extra hosted`
+
+---
+
+## Hard Constraints
+
+- No #1288, #1289, or full #1337 tonight
+- No more SP-4-05 work
+- No Telegram proving on critical path
+- One writer per file set
+- Small mergeable PRs over large speculative ones
+- Mark USER SMOKE TEST PENDING and continue other tracks if needed
+
+---
+
+## PR Tracking
+
+Update this section as PRs ship:
+
+| PR | Title | Lane | Wave | Status |
+|----|-------|------|------|--------|
+| #1522 | docs: reconcile browser Phase 3 + activate Phase 4 | brws-author-a | W1 | MERGED ✅ |
+| #1523 | docs: create SP-4-06 for Platform-8b audit trail | author-a | W1 | MERGED ✅ |
+| #1524 | fix: post-merge-notify URL parsing + retry | author-b | W1 | MERGED ✅ |
+| #1525 | fix: token_economy attribution + stale store | author-c | W1 | MERGED ✅ |
+| #1527 | docs: verify SP-4-06 seam analysis | author-a | W2 | MERGED ✅ |
+| #1529 | feat: decision_to_jsonl export + schema tests | brws-author-a | W2 | MERGED ✅ |
+| #1531 | feat: lane peek subcommand | flex-a | Overflow | In CI |
+| #1532 | feat: audit trail writer | author-a | W3 | MERGED ✅ |
+| #1533 | test: fixture factory helpers | brws-author-b | W2 | MERGED ✅ |
+| #1534 | feat: dashboard --watch flag | author-d | Overflow | MERGED ✅ |
+| #1535 | feat: export_decisions batch export | brws-author-a | W3 | MERGED ✅ |
+| #1536 | feat: outbound audit wrappers | author-a | W4 | MERGED ✅ |
+| #1538 | feat: export CLI script | brws-author-b | W4 | MERGED ✅ |
+| #1541 | feat: inbound audit helper | author-a | W5 | MERGED ✅ |
+| #1545 | feat: validate_replay verifier | brws-author-a | W4 | MERGED ✅ |
+| #1549 | feat: audit trail integration tests | author-a | W6 | MERGED ✅ |
+| #1551 | docs: close SP-4-01 Phase 4 complete | brws-author-a | W6 | MERGED ✅ |
+
+---
+
+## Monitoring
+
+- `/check-in` every 15-20 minutes
+- Watch ops and review tmux panes for stalls
+- Check `uv run python scripts/internal/ops.py dashboard` between waves
+- Check `uv run python scripts/internal/ops.py inbox --lane orchestrator` for author responses
+- If a lane stalls >10 min with no output growth, attempt recovery
+
+---
+
+## Session Log
+
+### Phase 0 — Bootstrap
+- All lanes refreshed, inbox clean, hosted deps synced, 95 browser tests green
+- Filed #1521 for Telegram plugin unreliability (deferred)
+- Triaged 7 open issues: #1324 (primary), #1520/#1505/#1514 (Wave 1), #1337 (overflow), #1288/#1289 (deferred)
+- Installed hosted deps in all worktrees (background: `uv sync --extra dev --extra hosted`)
+
+### Review Findings Applied
+Review handoff with 4 findings incorporated:
+- [P1] Wave 7 Platform-9a: scope lock only, no implementation until Platform-8b COMPLETE
+- [P1] web/export.py: brws-author-a is SOLE owner, no other lane may write
+- [P1] Platform-8b: explicit seam decision gate before implementation queue opens
+- [P2] Phase 0: bootstrap command pinned to `uv sync --extra dev --extra hosted`
+
+### Wave 1 — COMPLETE ✅
+- 4/4 PRs merged: #1522, #1523, #1524, #1525
+- Issues closed: #1520, #1514, #1505
+- Lessons: lanes stall at idle prompt after work — need explicit nudge to commit/PR
+
+### Wave 2 — IN PROGRESS
+- PR #1527 (SP-4-06 seam analysis) — MERGED ✅
+- PR #1529 (decision_to_jsonl export) — open, CI running
+- brws-author-b test fixtures — in validation (make check-quiet)
+- flex-a lane-peek #1526 — in validation
+- author-d dashboard --watch — in validation
+- author-a audit trail core writer — in validation (~33% tests)
+
+### SESSION COMPLETE — 16 PRs MERGED
+
+**Browser Phase 4 (SP-4-01 Export/Replay):** COMPLETE ✅
+- #1522 docs: reconcile Phase 3 + activate Phase 4
+- #1529 feat: decision_to_jsonl export + schema tests
+- #1533 test: fixture factory helpers
+- #1535 feat: export_decisions batch export
+- #1538 feat: export CLI script
+- #1545 feat: validate_replay JSONL verifier
+- #1551 docs: close SP-4-01 checkpoints, mark Phase 4 complete
+
+**Platform-8b (SP-4-06 Audit Trail):** COMPLETE ✅
+- #1523 docs: create SP-4-06 sub-plan
+- #1527 docs: verify seam analysis
+- #1532 feat: core audit trail writer
+- #1536 feat: outbound audit wrappers
+- #1541 feat: inbound audit helper + channel tag parser
+- #1549 feat: integration tests + mark SP-4-06 complete
+
+**Convention Fixes:** COMPLETE ✅
+- #1524 fix: post-merge-notify hardening (#1520)
+- #1525 fix: token_economy attribution + stale store (#1505, #1514)
+
+**Overflow:**
+- #1534 feat: dashboard --watch flag (merged)
+- #1531 feat: lane-peek subcommand (BLOCKED — CI failure, needs fix)
+
+**Issues closed:** #1520, #1514, #1505
+**Issues filed:** #1521 (Telegram), #1526 (capture buffer), #1528 (convention)

--- a/plans/sessions/2026-03-24_overnight-run-reply-handoff.md
+++ b/plans/sessions/2026-03-24_overnight-run-reply-handoff.md
@@ -1,0 +1,325 @@
+# Reply Handoff — Revise Overnight Run For Higher Throughput
+
+**Date:** 2026-03-24
+**Status:** FEED THIS BACK TO ORCHESTRATOR
+**Purpose:** Accept the proposed overnight run in spirit, but revise it to keep
+throughput high without pulling later-scope platform work forward.
+
+---
+
+## Response To The Proposed 4-Wave Plan
+
+Proceed, but revise the plan as follows:
+
+- Do **not** spend lanes on Telegram/plugin verification tonight unless the
+  primary tracks block. No `<channel>` tag in this session is noted, but it is
+  not on the critical path for the overnight run.
+- Keep the two main tracks:
+  - Browser Game Phase 4 (`SP-4-01` export/replay)
+  - Platform Phase 4 `Platform-8b` (`#1324` repo-owned audit trail)
+- Remove or defer these from the overnight implementation run:
+  - `#1288`
+  - `#1289`
+  - full `#1337`
+- Treat hosted dependency sync as **startup/bootstrap**, not as a dedicated lane.
+- Convert the 4-wave plan into a **rolling queue / micro-PR plan**.
+  - The goal tonight is not just 8-12 PRs.
+  - The goal is to maximize merged PR throughput across the two primary tracks.
+
+---
+
+## Operating Mode
+
+Use **three rolling queues**, not four hard barriers:
+
+1. **Browser queue** — primary
+2. **Platform queue** — secondary but continuous
+3. **Overflow queue** — small fixes, tests, docs, validation, handoff prep
+
+While one micro-slice is in review/CI, the next micro-slice should already be in
+flight. Keep a 2-wave lookahead and do not wait for full-wave completion if the
+next safe slice is already unblocked.
+
+Target tonight:
+
+- **Aggressive target:** 20+ PRs
+- **Stretch target:** 30+ PRs
+
+That target is realistic only if work stays concentrated in the two primary
+tracks and is split into small mergeable slices.
+
+---
+
+## Hard Constraints
+
+- Do **not** open new late-scope platform work tonight:
+  - `#1288` stays deferred
+  - `#1289` stays deferred
+  - `#1337` stays overflow-only
+- Do **not** spend platform lanes on more `SP-4-05` work unless a fresh runtime
+  issue proves it is necessary.
+- Do **not** make Telegram proving a critical-path task tonight.
+- One active writer per overlapping file set.
+- If a slice reaches a user smoke-test boundary, mark `USER SMOKE TEST PENDING`
+  and continue all other tracks.
+
+---
+
+## Phase 0 — Startup / Bootstrap (Not A Lane)
+
+Do this before Wave 1:
+
+1. Restart/refresh the steward runtime.
+2. Run:
+   - `uv run python scripts/internal/ops.py lane refresh --all-idle`
+3. Sync hosted/dev dependencies so browser route tests are actually runnable.
+4. Recheck:
+   - `uv run python -m pytest -q tests/unit/hosted_play/test_routes.py`
+   - `uv run python -m pytest -q tests/unit/hosted_play/test_engine.py tests/unit/hosted_play/test_partials.py`
+5. If route-test collection still fails after dependency sync, isolate it as a
+   setup issue and continue browser export work anyway.
+
+---
+
+## Revised Wave Plan
+
+## Wave 1 — Metadata, Scope Lock, And Small Fixes
+
+Keep these:
+
+- `brws-author-a`
+  - Reconcile browser planning metadata:
+    - close Phase 3 checkpoints
+    - activate Phase 4 checkpoints
+    - update browser sub-plan registry
+- `author-a`
+  - Create/register `SP-4-06` for `Platform-8b`
+  - update Phase 4 checkpoints Step 2 -> `IN_PROGRESS`
+- `author-b`
+  - Close `#1520`
+- `author-c`
+  - Close `#1505` + `#1514`
+
+Revise this:
+
+- `brws-author-b`
+  - Do **not** spend the lane on read-only verification only
+  - After Phase 0 dependency sync, either:
+    - confirm route tests collect and report status, or
+    - start Phase 4 export test scaffolding if route setup is already clean
+
+Overflow:
+
+- Use flex lanes for runtime cleanup, issue triage, and review support
+- Do not start `#1288` or `#1337`
+
+---
+
+## Wave 2 — Browser And Platform Foundations
+
+### Browser
+
+Start the export/replay track, but split it into mergeable slices:
+
+- `brws-author-a`
+  - export test contract in `tests/unit/hosted_play/test_export.py`
+- `brws-author-b`
+  - serializer core in `web/export.py`:
+    - `decision_to_jsonl()`
+- `brws-author-c`
+  - export selection/query behavior in `web/export.py`:
+    - `export_decisions()`
+  - only if file ownership is clear; otherwise queue behind the serializer PR
+- `brws-author-d`
+  - fixture/help code or export docs/examples if needed
+  - otherwise validation support or review support
+
+### Platform
+
+- `author-a`
+  - `Platform-8b` contract/schema decision first
+  - answer the seam question before broad implementation:
+    - where do we intercept **all** remote exchanges so audit logging is complete?
+- `author-d`
+  - support `author-a` with tests, docs, or read-only seam analysis
+  - do not start `#1337`
+
+Important:
+
+- If the audit interception seam is not locked, do **not** split platform coding
+  across multiple overlapping implementation lanes yet.
+
+---
+
+## Wave 3 — First Real Code Slices
+
+### Browser
+
+Once the export contract is locked:
+
+- PR: `decision_to_jsonl()` implementation
+- PR: `export_decisions()` implementation
+- PR: replay happy-path validation
+
+### Platform
+
+Once `SP-4-06` locks the seam:
+
+- PR: core audit writer / logger
+- PR: unit tests for audit writer
+
+Overflow:
+
+- remaining flex capacity can help with:
+  - browser validation support
+  - review support
+  - docs/checkpoint updates
+
+---
+
+## Wave 4 — Wiring
+
+### Browser
+
+- PR: replay mismatch/error validation
+- PR: CLI skeleton
+
+### Platform
+
+- PR: inbound remote logging seam
+- PR: outbound remote logging seam
+
+Important:
+
+- alerts and permission-relay prompts may be separate follow-up PRs if that
+  keeps the slices smaller and safer.
+
+---
+
+## Wave 5 — More Wiring And Tests
+
+### Browser
+
+- PR: CLI flags / filtering behavior
+- PR: browser Phase 4 validation pass
+
+### Platform
+
+- PR: alert logging seam
+- PR: permission-relay logging seam
+- PR: integration tests for `Platform-8b`
+
+At this point, if `Platform-8b` is landing cleanly, begin preparing the next
+scope lock rather than pulling unrelated backlog forward.
+
+---
+
+## Wave 6 — Closeout
+
+### Browser
+
+- update Phase 4 checkpoints
+- update registry / docs / session notes
+- produce a clean browser handoff
+
+### Platform
+
+- mark `SP-4-06` complete if exit criteria are met
+- update Phase 4 checkpoints Step 2
+- produce the next platform handoff
+
+---
+
+## Wave 7 — Only If Both Primary Tracks Are Healthy
+
+If Browser Phase 4 and Platform-8b are both effectively complete or in clean
+CI-only finalization, then unlock the next governed platform slice:
+
+- create the next sub-plan for `Platform-9a`
+- implement one narrow alert path only
+- add ack/dedupe/backoff behavior
+
+Good first alert candidates:
+
+- stale packet
+- idle lane needing attention
+
+Do not turn this into full remote proving yet.
+
+---
+
+## Wave 8 — Overflow Only
+
+Only if primary tracks are quiet:
+
+- narrow runtime hygiene
+- small docs polish
+- validation reruns
+- handoff prep
+- a **small** freshness improvement for `#1337` if and only if it is clearly
+  isolated and non-disruptive
+
+Still defer:
+
+- `#1288`
+- `#1289`
+- full `#1337`
+- away-from-desk Telegram proving
+
+---
+
+## Queue Backlog Guidance
+
+To maximize overnight throughput, prefer these kinds of PRs:
+
+### Good PRs tonight
+
+- docs/checkpoint closure
+- single-file convention fixes
+- one-function implementation slices
+- isolated tests
+- narrow wiring seams
+- closeout PRs that mark a governed slice complete
+
+### Bad PRs tonight
+
+- broad “refactor everything” PRs
+- cross-cutting backlog enhancements
+- assessment-only work that does not unblock current tracks
+- user-smoke-test-gated work on the critical path
+
+---
+
+## Issue Handling Tonight
+
+### Actively in scope
+
+- `#1324`
+- `#1520`
+- `#1505`
+- `#1514`
+
+### Overflow only
+
+- `#1337`
+
+### Deferred
+
+- `#1288`
+- `#1289`
+
+---
+
+## Final Instruction To Orchestrator
+
+Use the earlier 4-wave plan as a starting point, but revise execution to:
+
+- keep work concentrated in Browser Phase 4 and Platform-8b
+- convert the run into rolling micro-slices
+- use flex/scratch for review, cleanup, validation, and docs
+- avoid spending good lanes on later-scope platform backlog
+- maximize merged PR throughput without breaking governed sequence
+
+If both primary tracks land early, unlock `Platform-9a` scope lock and one
+narrow alert path before morning. Otherwise, leave behind a clean handoff rather
+than forcing tertiary work.

--- a/plans/sessions/2026-03-24_steward-analyst-implementation-handoff.md
+++ b/plans/sessions/2026-03-24_steward-analyst-implementation-handoff.md
@@ -1,0 +1,200 @@
+# Handoff — `steward-analyst` Role Refactor
+
+**Date:** 2026-03-24
+**Status:** READY FOR ORCHESTRATOR
+**Goal:** Replace the old narrow `issues` role with `steward-analyst`, a
+planning / handoff / issue-packaging service lane that reduces orchestrator
+context load on non-trivial work.
+
+---
+
+## Intent
+
+This slice is a **documentation and operating-contract refactor**, not a
+runtime lane-launcher change.
+
+The new role should be understood as:
+
+- investigates complex work and flagged issues
+- drafts plans, issue packages, and restart-ready handoffs
+- reconciles checkpoints / task lists / plan drift when needed
+- returns shaped work to `orchestrator` for dispatch
+- does **not** become a second orchestrator
+- does **not** implement fixes
+
+The point is to move context-heavy shaping work out of `orchestrator` without
+reintroducing a narrow standalone issue bot.
+
+---
+
+## Current Working-Tree Draft
+
+The repo already contains a draft implementation of this refactor in the
+current worktree.
+
+### Added
+
+- `.claude/agents/steward-analyst.md`
+
+### Removed
+
+- `.claude/agents/issues.md`
+
+### Updated
+
+- `.claude/agents/README.md`
+- `.claude/agents/steward-orchestrator.md`
+- `.claude/agents/steward-review.md`
+- `.claude/agents/repair.md`
+- `.claude/skills/run-fleet/SKILL.md`
+- `docs/02_agent/AUTONOMOUS_OPERATOR_WORKFLOW.md`
+- `docs/02_agent/ISSUE_TRIAGE_WORKFLOW.md`
+- `docs/02_agent/PROMPT_FIRST_WORKFLOW.md`
+- `plans/agent_ops/governing_plan.md`
+
+---
+
+## What The Draft Currently Does
+
+### 1. Defines the new lane
+
+`steward-analyst` is documented as a service lane that:
+
+- investigates ambiguous work and flagged issues
+- drafts sub-plans / execution briefs / issue packages
+- defines tests, gates, risks, and smoke-test boundaries
+- owns restart-ready handoffs
+- hands shaped work back to orchestrator
+
+### 2. Reframes orchestrator usage
+
+`steward-orchestrator.md` now says:
+
+- route ambiguous, multi-PR, or plan-heavy work to `steward-analyst`
+- keep dispatch authority in orchestrator
+- require analyst involvement for architectural work before plan review /
+  author dispatch
+
+### 3. Updates the steward operating model
+
+The governing plan now describes:
+
+- `analyst` as the optional service lane in the visible steward model
+- message flow `analyst -> orchestrator`
+- canonical prompts for `analyst`
+- success criteria phrased as `review` + `analyst` service lanes
+
+### 4. Updates adjacent role boundaries
+
+- `review` can still file simple follow-up issues directly, but may route more
+  complex issue packages to analyst
+- `repair` no longer points at a triage-only agent; it now treats analyst as
+  the non-implementation shaping lane
+- `/run-fleet` explicitly routes plan-heavy work and restart handoffs through
+  analyst
+
+### 5. Updates live operator docs
+
+The operator-facing docs under `docs/02_agent/` now refer to `analyst`
+instead of the old `issues` role in the active workflow.
+
+---
+
+## What Is Intentionally Out Of Scope
+
+Do **not** expand this slice into runtime/platform work unless a concrete live
+dependency is discovered.
+
+Out of scope for this PR:
+
+- adding a new tmux pane or launcher slot for analyst
+- changing `steward-session.sh`
+- changing runtime registry schemas
+- changing `ops.py`
+- changing GitHub labels or issue automation behavior beyond documentation
+- historical/archive/session-doc cleanup outside the live operating surface
+
+If a later slice wants analyst as a first-class always-on visible lane, do that
+as a separate follow-up.
+
+---
+
+## Orchestrator Task
+
+Take the current draft to completion as a clean, mergeable documentation slice.
+
+### Required steps
+
+1. Review the current working-tree diff carefully.
+2. Confirm the role contract is coherent across:
+   - agent prompt
+   - orchestrator prompt
+   - review / repair boundaries
+   - live operator docs
+   - governing plan
+3. Check for any remaining **live** references to the old `issues` role in the
+   active steward operating surface.
+4. Tighten wording if needed, but keep the role boundaries:
+   - not a second orchestrator
+   - not an implementation lane
+   - not a pure issue bot
+5. Ship the refactor as a docs/agent-contract PR.
+
+### Boundaries
+
+- Do not reopen the naming question unless the current draft is clearly broken.
+- Do not turn this into a broader governance rewrite.
+- Do not pull in unrelated platform backlog.
+
+---
+
+## Validation
+
+Run at minimum:
+
+```bash
+git diff --check
+```
+
+```bash
+rg -n 'issues lane|\.claude/agents/issues\.md|optional `issues`|`issues`' \
+  .claude/agents .claude/skills docs/02_agent plans/agent_ops/governing_plan.md
+```
+
+Expected result:
+
+- `git diff --check` clean
+- no remaining live references to the old `issues` lane in the active steward
+  operating docs
+
+Optional but recommended:
+
+- have `plan-reviewer` review the governing-plan wording change if the
+  orchestrator considers the plan edits non-trivial
+
+---
+
+## Desired PR Shape
+
+Prefer one bounded PR with a title similar to:
+
+- `docs: replace issues lane with steward-analyst service role`
+
+The PR body should explain:
+
+- why the old `issues` framing was too narrow
+- what `steward-analyst` now owns
+- what remains intentionally out of scope
+
+---
+
+## Handoff Closeout
+
+If shipped successfully, leave behind a short closeout note with:
+
+- PR number
+- files changed
+- whether any live references to the old role remain
+- whether launcher/runtime follow-up is needed later
+
+If blocked, leave a narrow blocker note instead of broad redesign suggestions.


### PR DESCRIPTION
## Summary
- Add SP-4-07 controller-first control plane sub-plan and session handoff
- Add lane-status skill, update run-fleet skill for fleet operations
- Update governing plan, amendments, checkpoints, and sub-plan registry for Phase 4 progress
- Add 5 session handoff docs from 2026-03-24 sessions (overnight run, issue triage, browser/platform, steward-analyst, controller-first handoff)
- Enable Telegram plugin in project settings.json

## Why
Uncommitted planning artifacts from multiple 2026-03-24 sessions need to be persisted. SP-4-07 sub-plan provides the implementation roadmap for the controller-first control plane refactor.

## Repro / Validation
Docs-only PR — no code changes. CI path-filter will skip heavy jobs.

## Tests
N/A — docs/plans only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)