### PR TITLE
fix(docs): replace exact test count in Phase 4 sub-plan

### DIFF
--- a/plans/browser_game/4_data_pipeline/sub/2026-03-14_export_replay.md
+++ b/plans/browser_game/4_data_pipeline/sub/2026-03-14_export_replay.md
@@ -164,4 +164,4 @@ These are noted for context but explicitly deferred:
 | #1538 | `export_hosted_decisions` CLI script |
 | #1545 | `validate_replay` JSONL correctness verifier |
 
-Validation: 233/233 tests pass in `tests/unit/hosted_play/`.
+Validation: all hosted_play tests pass (`tests/unit/hosted_play/`).


### PR DESCRIPTION
## Summary
- Replace hardcoded "233/233 tests pass" with "all hosted_play tests pass" in Phase 4 sub-plan outcome section
- Complements PR #1582 which fixed the same drift in `checkpoints.md`

## Why
Issue #1574 identified that pinning exact test counts in docs causes drift as tests are added/removed. PR #1582 fixed `checkpoints.md` but the sub-plan file (`2026-03-14_export_replay.md`) still had the stale count.

## Repro / Validation
```bash
git diff --stat  # 1 file, 1 line changed
grep -n "tests pass" plans/browser_game/4_data_pipeline/sub/2026-03-14_export_replay.md
# Should show "all hosted_play tests pass" (no exact count)
```

## Tests
Docs-only change — no test commands needed.

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
branch: fix/phase4-subplan-test-count
```

## Note
Phase 2 checkpoints also have exact test counts (17/17, 60 tests) — filed as a potential follow-up but out of scope for this PR.

Closes #1574

🤖 Generated with [Claude Code](https://claude.com/claude-code)