### PR TITLE
docs: activate Browser Phase 5 and create SP-5-01 scope lock

### DIFF
--- a/plans/browser_game/5_deployment_launch/checkpoints.md
+++ b/plans/browser_game/5_deployment_launch/checkpoints.md
@@ -2,7 +2,7 @@
 
 **Governing plan:** `plans/browser_game/governing_plan.md`
 **Phase/Rung:** `5_deployment_launch`
-**Last updated:** 2026-03-15
+**Last updated:** 2026-03-24
 
 ---
 
@@ -10,7 +10,7 @@
 
 | Step | Status | Date | Agent/Session | Notes |
 |------|--------|------|---------------|-------|
-| Step 0: Verify Phases 3 and 4 are complete | PENDING | -- | -- | Both must be merged before deployment. |
+| Step 0: Verify Phases 3 and 4 are complete | COMPLETE | 2026-03-24 | brws-author-a | Phase 3 COMPLETE (PRs #1475, #1489, #1495, #1498, #1501). Phase 4 COMPLETE (PRs #1529, #1533, #1535, #1538, #1545). |
 | Step 1: Write Dockerfile | PENDING | -- | -- | Python 3.12, copy src/ + web/, uvicorn entrypoint. |
 | Step 2: Write deployment config | PENDING | -- | -- | Render web service config plus managed Postgres wiring. |
 | Step 3: Configure environment variables | PENDING | -- | -- | DATABASE_URL, MODELS_DIR or explicit artifact paths, SECRET_KEY (for cookies). |
@@ -23,12 +23,11 @@
 
 | Sub-Plan ID | File | Status | Blocking Step |
 |-------------|------|--------|---------------|
-
-No sub-plan needed — Phase 5 is ≤5 files with documented deployment steps.
+| SP-5-01 | `5_deployment_launch/sub/2026-03-24_deployment-and-launch.md` | active | Steps 1-7 |
 
 ## Blockers
 
-- [ ] Phases 3 and 4 not complete.
+- [x] ~~Phases 3 and 4 not complete.~~ Phase 3 CLOSED 2026-03-24 (5 PRs). Phase 4 CLOSED 2026-03-24 (5 PRs).
 
 ## Session Log
 
@@ -39,3 +38,9 @@ No sub-plan needed — Phase 5 is ≤5 files with documented deployment steps.
 ### 2026-03-15 — Codex
 - Completed: Locked Render as the default hosting target and removed Fly.io as the default plan path.
 - Next: When Phase 5 starts, target Render-first deployment docs and Postgres-backed smoke validation.
+
+### 2026-03-24 — brws-author-a (Phase 5 activation)
+- Completed: Step 0 verified — Phase 3 COMPLETE (5 PRs) and Phase 4 COMPLETE (5 PRs). Blocker cleared.
+- Created: SP-5-01 sub-plan for Steps 1-7 (Dockerfile, Render config, env vars, Docker test, deploy, smoke, share link).
+- Registered: SP-5-01 in sub_plan_registry.md.
+- Next: Step 1 — Write Dockerfile.

--- a/plans/browser_game/5_deployment_launch/sub/2026-03-24_deployment-and-launch.md
+++ b/plans/browser_game/5_deployment_launch/sub/2026-03-24_deployment-and-launch.md
@@ -1,0 +1,205 @@
+# SP-5-01: Deployment and Launch
+
+**ID:** SP-5-01
+**Parent:** Phase 5 — Deployment and Launch Validation
+**Status:** active
+**Governing plan:** `plans/browser_game/governing_plan.md`
+**Created:** 2026-03-24
+
+---
+
+## Goal
+
+Deploy the browser game to Render with managed Postgres, validate the full
+match flow in production, and share the first private link. This sub-plan
+covers Steps 1-7 of the Phase 5 checkpoints.
+
+## Prerequisites
+
+- Phase 3 (Frontend Product): COMPLETE — PRs #1475, #1489, #1495, #1498, #1501
+- Phase 4 (Data Pipeline): COMPLETE — PRs #1529, #1533, #1535, #1538, #1545
+- Hosting target: Render (locked in 2026-03-15 checkpoint update)
+- Persistence: Postgres for production, SQLite for local dev
+
+## Architecture Context
+
+The web application is a FastAPI app (`web/app.py`) with:
+- Jinja2 server-rendered templates (`web/templates/`)
+- Static assets (`web/static/`)
+- SQLAlchemy models (`web/db.py`) supporting both SQLite and Postgres
+- Environment-driven config (`web/config.py`): `DATABASE_URL`, `DEFAULT_MODEL_ID`,
+  `HYBRID_OLSA_ARTIFACT`, `DEBUG`
+- AI model management (`web/ai_manager.py`)
+- Decision export (`web/export.py`)
+- HTMX partial responses (`web/routes.py`)
+
+The `hosted` optional dependency group in `pyproject.toml` includes: fastapi,
+uvicorn, jinja2, python-multipart, sqlalchemy, and supporting packages.
+
+## Steps
+
+### Step 1: Write Dockerfile
+
+**Files to create:**
+
+| File | Lines (est.) | Purpose |
+|------|-------------|---------|
+| `Dockerfile` | ~40 | Multi-stage build: Python 3.12, install hosted deps, copy src/ + web/, uvicorn entrypoint |
+| `.dockerignore` | ~15 | Exclude data/, .git/, tests/, notebooks/, __pycache__/ |
+
+**Dockerfile requirements:**
+- Base image: `python:3.12-slim`
+- Install only `hosted` dependency group: `pip install .[hosted]`
+- Copy `src/` and `web/` (no tests, notebooks, or data)
+- Expose port 8000
+- Entrypoint: `uvicorn web.app:create_app --host 0.0.0.0 --port 8000 --factory`
+- Non-root user for security
+
+**Validation:**
+```bash
+docker build -t bideuchre-web .
+docker run --rm -p 8000:8000 bideuchre-web  # Verify startup, no crashes
+```
+
+### Step 2: Write deployment config
+
+**Files to create:**
+
+| File | Lines (est.) | Purpose |
+|------|-------------|---------|
+| `render.yaml` | ~30 | Render Blueprint: web service + managed Postgres |
+
+**render.yaml requirements:**
+- Web service: Docker runtime, auto-deploy from main
+- Managed Postgres database
+- Health check endpoint: `GET /` (landing page returns 200)
+- Environment variable references for `DATABASE_URL` (from Render Postgres),
+  `SECRET_KEY`, `DEFAULT_MODEL_ID`
+
+**Validation:**
+```bash
+# Verify render.yaml is valid YAML
+python -c "import yaml; yaml.safe_load(open('render.yaml'))"
+```
+
+### Step 3: Configure environment variables
+
+**Files to create/modify:**
+
+| File | Lines (est.) | Purpose |
+|------|-------------|---------|
+| `web/config.py` | ~5 modified | Add SECRET_KEY field for cookie signing |
+| `.env.example` | ~10 | Document all env vars with defaults |
+
+**Environment variable contract:**
+
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `DATABASE_URL` | Yes (prod) | `sqlite:///hosted_play.db` | Postgres connection string |
+| `DEFAULT_MODEL_ID` | No | `heuristic` | Default AI bidding model |
+| `HYBRID_OLSA_ARTIFACT` | No | None | Path to hybrid OLSa model artifact |
+| `SECRET_KEY` | Yes (prod) | None | Cookie/session signing key |
+| `DEBUG` | No | `false` | Enable debug mode |
+| `PORT` | No | `8000` | Server port (Render sets this) |
+
+**Validation:**
+```bash
+# Verify config loads with all env vars
+DATABASE_URL=sqlite:///test.db SECRET_KEY=test \
+  python -c "from web.config import HostedPlayConfig; c = HostedPlayConfig.from_env(); print(c)"
+```
+
+### Step 4: Test local Docker build
+
+**No new files** — this is a validation step.
+
+**Procedure:**
+1. `docker build -t bideuchre-web .`
+2. `docker run --rm -p 8000:8000 -e SECRET_KEY=dev-test bideuchre-web`
+3. Open `http://localhost:8000` — landing page loads
+4. Create a match via the UI — verify private link works
+5. Play one hand — verify bid + card play flow completes
+6. Verify no errors in container logs
+
+**Validation:**
+```bash
+docker build -t bideuchre-web . && \
+  docker run --rm -d -p 8000:8000 -e SECRET_KEY=dev-test --name bideuchre-test bideuchre-web && \
+  sleep 3 && \
+  curl -s http://localhost:8000 | grep -q "Bid Euchre" && \
+  echo "PASS: Landing page loads" && \
+  docker stop bideuchre-test
+```
+
+### Step 5: Deploy to hosting service
+
+**No new files** — this is an operational step.
+
+**Procedure:**
+1. Push `render.yaml` to `main` (via merged PR)
+2. Create Render account and link GitHub repo
+3. Deploy via Render Blueprint — creates web service + Postgres
+4. Verify the deployed app starts successfully
+5. Verify database tables are created (SQLAlchemy `create_tables` runs on startup)
+
+**Validation:**
+```bash
+# Verify deployed app responds
+curl -s https://<render-url>/ | grep -q "Bid Euchre" && echo "PASS: Deployed"
+```
+
+### Step 6: Smoke validation
+
+**No new files** — this is a validation step.
+
+**Procedure:**
+1. Create a match on the deployed instance
+2. Play one full hand (bid + all 10 tricks)
+3. Verify decision rows are present in the database
+4. Run export CLI against production DB to verify JSONL export works
+5. Document results in the session log
+
+**Validation criteria:**
+- Match creation returns a private link
+- Bidding UI works (submit bid, AI bids auto-resolve)
+- Card play UI works (click card, trick resolves)
+- Score updates correctly after hand completion
+- Decisions table has rows for all bids + plays
+
+### Step 7: Share first private link
+
+**No new files** — this is an operational step.
+
+**Procedure:**
+1. Generate a new match UUID link on the deployed instance
+2. Share the link for user testing
+3. Document the link and initial feedback in the session log
+
+## PR Boundaries
+
+This sub-plan is expected to land in 1-2 PRs:
+
+| PR | Scope | Steps Covered |
+|----|-------|---------------|
+| PR-A | Dockerfile, .dockerignore, render.yaml, .env.example, config.py SECRET_KEY | Steps 1-3 |
+| PR-B (optional) | Any fixes discovered during Steps 4-7 validation | Steps 4-7 |
+
+Steps 4-7 are operational validation — they produce evidence in checkpoints
+and session logs rather than committed code artifacts.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Postgres schema incompatibility with SQLite-developed models | SQLAlchemy abstracts dialect; `create_tables()` is idempotent. Test with Docker + Postgres locally before deploy. |
+| Missing static assets in Docker image | `.dockerignore` must not exclude `web/static/` or `web/templates/`. Verify with local Docker test. |
+| Environment variable misconfiguration on Render | Document all vars in `.env.example`. Health check catches startup failures. |
+| CORS issues in production | Current config allows all origins; tighten post-launch. |
+
+## Outcome
+
+_To be filled after implementation._
+
+- Result: --
+- PRs: --
+- Notes: --

--- a/plans/browser_game/sub_plan_registry.md
+++ b/plans/browser_game/sub_plan_registry.md
@@ -1,7 +1,7 @@
 # Sub-Plan Registry — Browser Game Hosting and Human Data Capture
 
 **Governing plan:** `plans/browser_game/governing_plan.md`
-**Last updated:** 2026-03-24
+**Last updated:** 2026-03-24 (Phase 5 activation)
 
 ---
 
@@ -15,13 +15,14 @@
 | SP-3-01 | HTMX Game UI (design reference) | Phase 3 — Frontend Product | superseded | -- | `3_frontend_product/sub/2026-03-14_htmx_game_ui.md` | 2026-03-14 | -- |
 | SP-3-02 | Browser UI Implementation | Phase 3 — Frontend Product | completed | brws-author-a | `3_frontend_product/sub/2026-03-24_browser-ui.md` | 2026-03-24 | 2026-03-24 |
 | SP-4-01 | Export & Replay Validation | Phase 4 — Data Pipeline | completed | brws-author-a | `4_data_pipeline/sub/2026-03-14_export_replay.md` | 2026-03-14 | 2026-03-24 |
+| SP-5-01 | Deployment and Launch | Phase 5 — Deployment and Launch Validation | active | brws-author-a | `5_deployment_launch/sub/2026-03-24_deployment-and-launch.md` | 2026-03-24 | -- |
 
 ## Status Summary
 
 | Status | Count |
 |--------|-------|
 | proposed | 0 |
-| active | 0 |
+| active | 1 |
 | blocked | 0 |
 | completed | 5 |
 | abandoned | 0 |


### PR DESCRIPTION
## Summary
- Mark Phase 5 Step 0 COMPLETE — Phases 3 and 4 are both fully delivered
- Create SP-5-01 sub-plan covering deployment Steps 1-7 (Dockerfile, Render config, env vars, Docker test, deploy, smoke, share link)
- Register SP-5-01 in sub_plan_registry.md

## Why
Phase 3 (5 PRs: #1475, #1489, #1495, #1498, #1501) and Phase 4 (5 PRs: #1529, #1533, #1535, #1538, #1545) are both complete. This activates Phase 5 by clearing the blocker and creating the implementation scope lock.

## Repro / Validation
```bash
git diff --stat  # 3 files changed: checkpoints.md, sub_plan_registry.md, SP-5-01 sub-plan
```

Docs-only PR — no code changes.

## Test criteria
- [ ] checkpoints.md Step 0 is COMPLETE with Phase 3/4 PR evidence
- [ ] Blocker is cleared (checked off)
- [ ] SP-5-01 sub-plan exists with Steps 1-7 detailed
- [ ] sub_plan_registry.md has SP-5-01 entry with status=active

## Tests
No code changes — `make check` not required (docs-only).

## Worktree proof
```
pwd: Bid-Euchre-steward-brws-author-a
branch: brws/phase5-activation
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)