### PR TITLE
fix(docs): resolve pre-existing P1 path references in governing_plan.md

### DIFF
--- a/plans/agent_ops/governing_plan.md
+++ b/plans/agent_ops/governing_plan.md
@@ -61,7 +61,7 @@ surface.
 Each phase follows this standard sequence:
 
 1. **Scope lock**
-   - **Commands:** read `CLAUDE.md`, this governing plan, the active phase `checkpoints.md`, and any active sub-plans.
+   - **Commands:** read `CLAUDE.md`, this governing plan, the active phase checkpoint file (`plans/agent_ops/<phase>/checkpoints.md`), and any active sub-plans.
    - **Validates:** the next step is unambiguous and the phase boundary still matches the roadmap.
    - **Error recovery:** if the work needs new design choices or touches more than three files, create a sub-plan before implementation.
    - **Outputs:** updated checkpoint target and, when needed, a registered sub-plan.
@@ -1287,7 +1287,7 @@ These are the short names future handoffs should use.
   - verify plugin/runtime prerequisites before proving (for example Bun for
     official plugins)
 - channel-aware startup path:
-  - the tmux launcher (`steward-session.sh`) gains an optional
+  - the tmux launcher (`.claude/tmux/steward-session.sh`) gains an optional
     `STEWARD_CHANNELS` environment variable (e.g.,
     `STEWARD_CHANNELS="telegram"` or `STEWARD_CHANNELS="telegram,discord"`)
   - when `STEWARD_CHANNELS` is set, the launcher runs a preflight check


### PR DESCRIPTION
## Summary

- Replace bare `checkpoints.md` with full template path `plans/agent_ops/<phase>/checkpoints.md`
- Replace bare `steward-session.sh` with actual location `.claude/tmux/steward-session.sh`

## Why

The review coordinator path checker flagged 2 pre-existing P1 findings in the governing plan where bare filenames don't resolve from the repo root. These are documentation references, not runtime issues. Closes #1614.

## Repro / Validation

```bash
git diff --stat origin/main
# Expected: 1 file changed, 2 insertions(+), 2 deletions(-)
```

## Tests

Docs-only change — no code modified. CI path-filter will skip heavy jobs.

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-scratch
branch: fix/governing-plan-path-refs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)