### PR TITLE
feat(web): add Dockerfile for hosted web app (Phase 5 Step 1)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,43 @@
+# Keep Docker context minimal — only src/, web/, pyproject.toml, uv.lock needed.
+
+# Version control
+.git/
+.gitignore
+
+# Python artifacts
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+.venv/
+venv/
+
+# Data and experiment outputs (never ship)
+data/
+experiments/
+notebooks/
+
+# Development tooling
+tests/
+scripts/
+docs/
+plans/
+plots/
+
+# IDE / editor
+.vscode/
+.cursor/
+.idea/
+
+# Claude Code / agent infrastructure
+.claude/
+CLAUDE.md
+MEMORY.md
+
+# OS files
+.DS_Store
+*.log
+
+# Docker (prevent recursive context)
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Dockerfile — Bid Euchre Browser Game
+#
+# Thin production image: Python 3.12, hosted extras only, uvicorn entrypoint.
+# No dev deps, no data/runs, no experiment infrastructure.
+#
+# Build:  docker build -t bideuchre-web .
+# Run:    docker run -p 8000:8000 -e DATABASE_URL=sqlite:///hosted_play.db bideuchre-web
+
+FROM python:3.12-slim AS base
+
+# Prevent .pyc files and enable unbuffered output for logging
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# --- Install uv for fast, deterministic dependency resolution ---
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# --- Install dependencies first (cache-friendly layer ordering) ---
+COPY pyproject.toml uv.lock ./
+
+# Install only the hosted extras (no dev deps)
+RUN uv sync --frozen --no-dev --extra hosted --no-install-project
+
+# --- Copy application source ---
+COPY src/ src/
+COPY web/ web/
+
+# Install the project itself (editable not needed in production)
+RUN uv sync --frozen --no-dev --extra hosted
+
+EXPOSE 8000
+
+# Uvicorn entrypoint — create_app() is a factory function
+CMD ["uv", "run", "uvicorn", "web.app:create_app", "--factory", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Plan
`plans/browser_game/governing_plan.md` — Phase 5: deployment configuration and startup command

## Summary
- Add production `Dockerfile` using Python 3.12-slim + uv for deterministic dependency resolution
- Add `.dockerignore` to keep build context minimal (excludes data/, experiments/, tests/, docs/, agent infra)
- Uvicorn entrypoint runs `web.app:create_app()` factory on port 8000

## Why
Phase 5 Step 1 requires a deployment-ready container image. This Dockerfile installs only the `hosted` extras (no dev deps), copies only `src/` and `web/`, and uses a two-stage `uv sync` for cache-friendly layer ordering.

## Repro / Validation
**Command(s) run:**
- `docker build -t bideuchre-web .` (Docker not available in CI/author env — requires manual validation)
- `make check-quiet` — ✅ all checks passed

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** `docker build -t bideuchre-web .` completes without error; container starts and responds on port 8000
- **Verification command:** `docker build -t bideuchre-web . && docker run --rm -d -p 8000:8000 -e DATABASE_URL=sqlite:///hosted_play.db --name bideuchre-test bideuchre-web && sleep 2 && curl -s http://localhost:8000/ && docker stop bideuchre-test`
- **Expected result:** Build succeeds, uvicorn starts, HTTP response from landing page

## Tests
- [x] `make check-quiet` — all checks passed
- [ ] Docker build (requires Docker runtime — manual validation)

## Expected impact
- Metrics impact: None
- Runtime impact: None (new file only)

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                     63e72e52 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a eae4f478 [brws/phase5-dockerfile]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)