### PR TITLE
fix(ops): wire fleet idle detection into monitor cycle

### DIFF
--- a/src/bid_euchre/ops/idle_detector.py
+++ b/src/bid_euchre/ops/idle_detector.py
@@ -214,3 +214,81 @@ def is_fleet_idle(
             f"(threshold: {threshold_minutes:.0f}m)"
         ),
     )
+
+
+# ---------------------------------------------------------------------------
+# Shutoff recommendation
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ShutoffRecommendation:
+    """Structured recommendation from the fleet idle check.
+
+    When ``should_shutoff`` is True, the caller should act on the
+    recommended actions (cancel cron jobs, notify user, produce handoff).
+
+    Attributes:
+        should_shutoff: Whether the fleet should shut off autonomous operation.
+        idle_status: The underlying :class:`IdleStatus` determination.
+        recommended_actions: Human-readable list of actions to take.
+    """
+
+    should_shutoff: bool
+    idle_status: IdleStatus
+    recommended_actions: list[str]
+
+
+def recommend_shutoff(
+    threshold_minutes: float = DEFAULT_THRESHOLD_MINUTES,
+    *,
+    events_dir: Path | None = None,
+    runtime_dir: Path | None = None,
+    now: datetime | None = None,
+) -> ShutoffRecommendation:
+    """Check fleet idle status and produce a shutoff recommendation.
+
+    Wraps :func:`is_fleet_idle` and translates the result into a structured
+    recommendation with concrete action items for the caller to execute.
+
+    Args:
+        threshold_minutes: Minutes threshold for idle detection.
+        events_dir: Override for the events directory.
+        runtime_dir: Override for the runtime directory.
+        now: Override for current time (for testing).
+
+    Returns:
+        A :class:`ShutoffRecommendation` with actions if shutoff is warranted.
+    """
+    status = is_fleet_idle(
+        threshold_minutes=threshold_minutes,
+        events_dir=events_dir,
+        runtime_dir=runtime_dir,
+        now=now,
+    )
+
+    if not status.idle:
+        return ShutoffRecommendation(
+            should_shutoff=False,
+            idle_status=status,
+            recommended_actions=[],
+        )
+
+    actions = [
+        "Cancel all active cron jobs to stop burning tokens",
+        "Produce a session handoff summary (what shipped, what's stuck, next steps)",
+        "Log the shutoff event for operational traceability",
+    ]
+
+    # Include the idle duration for context
+    logger.warning(
+        "Fleet idle shutoff recommended: %s (idle %.0fm)",
+        status.reason,
+        status.idle_minutes,
+    )
+
+    return ShutoffRecommendation(
+        should_shutoff=True,
+        idle_status=status,
+        recommended_actions=actions,
+    )

--- a/src/bid_euchre/ops/monitor.py
+++ b/src/bid_euchre/ops/monitor.py
@@ -1373,6 +1373,96 @@ def _notify_approval_stall(
 
 
 # ---------------------------------------------------------------------------
+# Fleet-level idle check — auto-shutoff recommendation (#1572 / #1587)
+# ---------------------------------------------------------------------------
+
+
+def check_fleet_idle(
+    runtime_dir: Path | None = None,
+    *,
+    now: datetime | None = None,
+    threshold_minutes: float = 90,
+) -> list[MonitorFinding]:
+    """Check whether the entire fleet has been idle beyond the shutoff threshold.
+
+    Calls :func:`~bid_euchre.ops.idle_detector.recommend_shutoff` and translates
+    the result into a HIGH-severity finding when shutoff is recommended.  The
+    finding's ``details`` include the structured recommendation so the
+    orchestrator can act on it (cancel cron jobs, produce handoff, etc.).
+
+    Args:
+        runtime_dir: Override for the runtime directory root.
+        now: Override for current time (for testing).
+        threshold_minutes: Minutes threshold before idle shutoff is recommended.
+
+    Returns:
+        List of findings (0 or 1).
+    """
+    findings: list[MonitorFinding] = []
+
+    try:
+        from bid_euchre.ops.idle_detector import recommend_shutoff
+
+        recommendation = recommend_shutoff(
+            threshold_minutes=threshold_minutes,
+            runtime_dir=runtime_dir,
+            now=now,
+        )
+    except Exception as exc:
+        logger.warning("Fleet idle check failed: %s", exc)
+        findings.append(
+            MonitorFinding(
+                category="fleet_idle",
+                severity=SEVERITY_WARN,
+                summary=f"Could not check fleet idle status: {exc}",
+            )
+        )
+        return findings
+
+    if recommendation.should_shutoff:
+        actions_text = "; ".join(recommendation.recommended_actions)
+        findings.append(
+            MonitorFinding(
+                category="fleet_idle",
+                severity=SEVERITY_HIGH,
+                summary=(
+                    f"Fleet idle for {recommendation.idle_status.idle_minutes:.0f}m — "
+                    f"auto-shutoff recommended"
+                ),
+                details={
+                    "should_shutoff": True,
+                    "idle_minutes": recommendation.idle_status.idle_minutes,
+                    "threshold_minutes": threshold_minutes,
+                    "recommended_actions": recommendation.recommended_actions,
+                    "reason": recommendation.idle_status.reason,
+                },
+            )
+        )
+        logger.warning(
+            "Fleet idle shutoff finding emitted: %.0fm idle. Actions: %s",
+            recommendation.idle_status.idle_minutes,
+            actions_text,
+        )
+    else:
+        # Emit an info-level finding for observability
+        status = recommendation.idle_status
+        findings.append(
+            MonitorFinding(
+                category="fleet_idle",
+                severity=SEVERITY_INFO,
+                summary=(f"Fleet active — {status.reason}"),
+                details={
+                    "should_shutoff": False,
+                    "idle_minutes": status.idle_minutes,
+                    "active_lanes": status.active_lanes,
+                },
+            )
+        )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
 # Auto-dispatch: assign approved packets to idle lanes (SP-4-02 Step 6)
 # ---------------------------------------------------------------------------
 
@@ -1687,6 +1777,7 @@ def run_monitoring_cycle(
     7. Recently merged PR detection (new merges since last cycle)
     8. Auto-complete dispatched packets whose PRs were merged externally
     9. Auto-dispatch approved packets to idle lanes
+    10. Fleet-level idle check — auto-shutoff recommendation (#1572)
 
     Optionally sends a summary to the orchestrator inbox.
 
@@ -1740,7 +1831,10 @@ def run_monitoring_cycle(
     if not no_auto_dispatch:
         findings.extend(check_auto_dispatch(runtime_dir, current_findings=findings))
 
-    # 10. Notify orchestrator
+    # 10. Fleet-level idle check — auto-shutoff recommendation (#1572)
+    findings.extend(check_fleet_idle(runtime_dir, now=now))
+
+    # 11. Notify orchestrator
     if notify_orchestrator:
         _send_findings_to_orchestrator(findings)
 

--- a/tests/unit/test_ops_idle_detector.py
+++ b/tests/unit/test_ops_idle_detector.py
@@ -13,9 +13,11 @@ from bid_euchre.ops.idle_detector import (
     DEFAULT_THRESHOLD_MINUTES,
     MEANINGFUL_EVENT_TYPES,
     IdleStatus,
+    ShutoffRecommendation,
     _find_last_meaningful_event,
     _get_active_lane_ids,
     is_fleet_idle,
+    recommend_shutoff,
 )
 
 # ---------------------------------------------------------------------------
@@ -338,3 +340,86 @@ class TestMeaningfulEventTypes:
 
     def test_default_threshold_is_90(self) -> None:
         assert DEFAULT_THRESHOLD_MINUTES == 90
+
+
+# ---------------------------------------------------------------------------
+# Tests: recommend_shutoff
+# ---------------------------------------------------------------------------
+
+
+class TestRecommendShutoff:
+    """Tests for the recommend_shutoff() wrapper."""
+
+    def test_recommends_shutoff_when_fleet_idle(
+        self, events_dir: Path, runtime_dir: Path
+    ) -> None:
+        """Should recommend shutoff when fleet has been idle past threshold."""
+        now = datetime(2026, 3, 24, 15, 0, 0, tzinfo=timezone.utc)
+        old_ts = now - timedelta(minutes=120)
+        _write_event(events_dir, "task_completed", old_ts)
+
+        rec = recommend_shutoff(
+            threshold_minutes=90,
+            events_dir=events_dir,
+            runtime_dir=runtime_dir,
+            now=now,
+        )
+        assert isinstance(rec, ShutoffRecommendation)
+        assert rec.should_shutoff is True
+        assert rec.idle_status.idle is True
+        assert len(rec.recommended_actions) > 0
+        # Actions should include cron cancellation and session handoff
+        actions_text = " ".join(rec.recommended_actions)
+        assert "cron" in actions_text.lower()
+        assert "handoff" in actions_text.lower()
+
+    def test_does_not_recommend_when_active(
+        self, events_dir: Path, runtime_dir: Path
+    ) -> None:
+        """Should not recommend shutoff when fleet is active."""
+        now = datetime(2026, 3, 24, 15, 0, 0, tzinfo=timezone.utc)
+        recent_ts = now - timedelta(minutes=10)
+        _write_event(events_dir, "task_completed", recent_ts)
+
+        rec = recommend_shutoff(
+            threshold_minutes=90,
+            events_dir=events_dir,
+            runtime_dir=runtime_dir,
+            now=now,
+        )
+        assert rec.should_shutoff is False
+        assert rec.idle_status.idle is False
+        assert rec.recommended_actions == []
+
+    def test_does_not_recommend_when_lanes_active(
+        self, events_dir: Path, runtime_dir: Path
+    ) -> None:
+        """Active lanes prevent shutoff even with old events."""
+        now = datetime(2026, 3, 24, 15, 0, 0, tzinfo=timezone.utc)
+        old_ts = now - timedelta(minutes=120)
+        _write_event(events_dir, "task_completed", old_ts)
+        _register_lane(runtime_dir, "author-a", session_id="sess-live")
+
+        rec = recommend_shutoff(
+            threshold_minutes=90,
+            events_dir=events_dir,
+            runtime_dir=runtime_dir,
+            now=now,
+        )
+        assert rec.should_shutoff is False
+        assert "author-a" in rec.idle_status.active_lanes
+
+    def test_shutoff_recommendation_fields(
+        self, events_dir: Path, runtime_dir: Path
+    ) -> None:
+        """ShutoffRecommendation has expected fields."""
+        now = datetime(2026, 3, 24, 15, 0, 0, tzinfo=timezone.utc)
+        rec = recommend_shutoff(
+            events_dir=events_dir,
+            runtime_dir=runtime_dir,
+            now=now,
+        )
+        assert isinstance(rec, ShutoffRecommendation)
+        assert isinstance(rec.should_shutoff, bool)
+        assert isinstance(rec.idle_status, IdleStatus)
+        assert isinstance(rec.recommended_actions, list)

--- a/tests/unit/test_ops_monitor.py
+++ b/tests/unit/test_ops_monitor.py
@@ -22,6 +22,7 @@ from bid_euchre.ops.monitor import (
     check_approval_stalls,
     check_auto_dispatch,
     check_escalations,
+    check_fleet_idle,
     check_idle_lanes,
     check_lane_health,
     check_merged_dispatches,
@@ -2767,3 +2768,87 @@ class TestCheckOpenPRsReady:
 
         ready = [f for f in findings if f.category == "pr_ready"]
         assert len(ready) == 0
+
+
+# ---------------------------------------------------------------------------
+# check_fleet_idle tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckFleetIdle:
+    """Tests for fleet-level idle check (auto-shutoff wiring)."""
+
+    def test_emits_high_finding_when_idle(self) -> None:
+        """Should emit HIGH severity finding when fleet is idle."""
+        from bid_euchre.ops.idle_detector import IdleStatus, ShutoffRecommendation
+
+        idle_rec = ShutoffRecommendation(
+            should_shutoff=True,
+            idle_status=IdleStatus(
+                idle=True,
+                idle_minutes=120.0,
+                last_meaningful_event=None,
+                active_lanes=[],
+                reason="No meaningful activity for 120m (threshold: 90m)",
+            ),
+            recommended_actions=["Cancel cron jobs", "Produce handoff"],
+        )
+
+        with patch(
+            "bid_euchre.ops.monitor.check_fleet_idle.__module__",
+            create=True,
+        ):
+            with patch(
+                "bid_euchre.ops.idle_detector.recommend_shutoff",
+                return_value=idle_rec,
+            ):
+                findings = check_fleet_idle()
+
+        high = [f for f in findings if f.severity == "high"]
+        assert len(high) == 1
+        assert high[0].category == "fleet_idle"
+        assert "120m" in high[0].summary
+        assert "shutoff" in high[0].summary.lower()
+        assert high[0].details["should_shutoff"] is True
+        assert high[0].details["idle_minutes"] == 120.0
+        assert len(high[0].details["recommended_actions"]) == 2
+
+    def test_emits_info_when_active(self) -> None:
+        """Should emit info finding when fleet is active."""
+        from bid_euchre.ops.idle_detector import IdleStatus, ShutoffRecommendation
+
+        active_rec = ShutoffRecommendation(
+            should_shutoff=False,
+            idle_status=IdleStatus(
+                idle=False,
+                idle_minutes=10.0,
+                last_meaningful_event=None,
+                active_lanes=["author-a"],
+                reason="Active lanes: author-a",
+            ),
+            recommended_actions=[],
+        )
+
+        with patch(
+            "bid_euchre.ops.idle_detector.recommend_shutoff",
+            return_value=active_rec,
+        ):
+            findings = check_fleet_idle()
+
+        info = [f for f in findings if f.severity == "info"]
+        assert len(info) == 1
+        assert info[0].category == "fleet_idle"
+        assert info[0].details["should_shutoff"] is False
+        assert "author-a" in info[0].details["active_lanes"]
+
+    def test_handles_exception_gracefully(self) -> None:
+        """Should emit warn finding if idle check raises."""
+        with patch(
+            "bid_euchre.ops.idle_detector.recommend_shutoff",
+            side_effect=RuntimeError("events dir missing"),
+        ):
+            findings = check_fleet_idle()
+
+        warn = [f for f in findings if f.severity == "warn"]
+        assert len(warn) == 1
+        assert "Could not check fleet idle status" in warn[0].summary


### PR DESCRIPTION
## Summary
- Wire `is_fleet_idle()` into the ops monitoring cycle so idle detection actually runs
- Add `recommend_shutoff()` to `idle_detector.py` — structured recommendation with concrete actions
- Add `check_fleet_idle()` to `monitor.py` as step 10 of `run_monitoring_cycle()`
- When fleet idle ≥90m, emit HIGH-severity `fleet_idle` finding to orchestrator inbox

## Why
PR #1585 added idle detection (`is_fleet_idle()`) but never wired it into anything — the function was dead code. Issue #1572 was prematurely closed. This PR closes the gap so the monitor actually checks fleet idle status on every cycle.

Closes #1587

## What Changed

### `idle_detector.py`
- Added `ShutoffRecommendation` dataclass with `should_shutoff`, `idle_status`, and `recommended_actions`
- Added `recommend_shutoff()` — wraps `is_fleet_idle()` and translates to actionable recommendation

### `monitor.py`
- Added `check_fleet_idle()` — calls `recommend_shutoff()`, emits HIGH finding when shutoff is warranted, INFO when active
- Wired into `run_monitoring_cycle()` as step 10 (after auto-dispatch, before notify)

### Tests
- 4 new tests for `recommend_shutoff()` in `test_ops_idle_detector.py`
- 3 new tests for `check_fleet_idle()` in `test_ops_monitor.py`

## Repro / Validation
```bash
# Targeted tests (Tier 1)
uv run python -m pytest tests/unit/test_ops_idle_detector.py -v  # 25 passed
uv run python -m pytest tests/unit/test_ops_monitor.py::TestCheckFleetIdle -v  # 3 passed

# Full validation (Tier 2)
make check-quiet  # ✓ All checks passed
```

## Worktree proof
```
pwd: Bid-Euchre-steward-author-d
branch: fix/fleet-idle-monitor-wiring
```

## Scope
Only touched declared files:
- `src/bid_euchre/ops/idle_detector.py`
- `src/bid_euchre/ops/monitor.py`
- `tests/unit/test_ops_idle_detector.py`
- `tests/unit/test_ops_monitor.py`

## Note on remaining gap
The actual shutoff **actions** (cancel cron jobs, produce session handoff, notify via Telegram) remain orchestrator-level concerns. The monitor now surfaces the recommendation as a HIGH finding — the orchestrator/check-in skill must act on it. This is consistent with the monitor's existing pattern (e.g., stall recovery, auto-dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)