### PR TITLE
feat(web): add health and readiness endpoints for deploy probes

### DIFF
--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -1498,3 +1498,60 @@ class TestRefreshResumeSafety:
         # A completed match has no active match → shows model selection
         # (per game_page handler logic: no active match → model selection)
         assert "Start Match" in resp.text or "score_human" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Health & Readiness endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestHealthEndpoint:
+    """GET /health — liveness probe."""
+
+    def test_health_returns_ok(self, client):
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body == {"status": "ok"}
+
+    def test_health_content_type_json(self, client):
+        resp = client.get("/health")
+        assert "application/json" in resp.headers["content-type"]
+
+
+class TestReadyEndpoint:
+    """GET /ready — readiness probe (DB connectivity)."""
+
+    def test_ready_returns_ready(self, client):
+        """With a healthy DB, /ready returns 200."""
+        resp = client.get("/ready")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body == {"status": "ready"}
+
+    def test_ready_content_type_json(self, client):
+        resp = client.get("/ready")
+        assert "application/json" in resp.headers["content-type"]
+
+    def test_ready_returns_503_when_db_unavailable(self, client):
+        """When the DB is unreachable, /ready returns 503."""
+        from unittest.mock import MagicMock
+
+        app = client.app
+
+        # Replace session_factory with one that raises on execute
+        original_factory = app.state.session_factory
+
+        def broken_factory():
+            session = MagicMock()
+            session.execute.side_effect = Exception("DB connection failed")
+            return session
+
+        app.state.session_factory = broken_factory
+        try:
+            resp = client.get("/ready")
+            assert resp.status_code == 503
+            body = resp.json()
+            assert body == {"status": "unavailable"}
+        finally:
+            app.state.session_factory = original_factory

--- a/web/routes.py
+++ b/web/routes.py
@@ -17,7 +17,8 @@ from datetime import datetime, timezone
 from typing import Any
 
 from fastapi import APIRouter, Form, HTTPException, Request
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from sqlalchemy import text
 from starlette.templating import Jinja2Templates
 
 from bid_euchre.hosted_play.engine import HUMAN_SEAT, MatchEngine
@@ -260,6 +261,34 @@ def _render_game_board(
     ctx = _build_game_context(engine, state, link_uuid)
     ctx["request"] = request
     return templates.get_template("partials/game_board.html").render(ctx)
+
+
+# ---------------------------------------------------------------------------
+# Health / Readiness
+# ---------------------------------------------------------------------------
+
+
+@router.get("/health")
+async def health():
+    """Liveness probe — always returns 200 OK."""
+    return JSONResponse({"status": "ok"})
+
+
+@router.get("/ready")
+async def ready(request: Request):
+    """Readiness probe — checks DB connectivity.
+
+    Returns 200 if the database is reachable, 503 otherwise.
+    """
+    try:
+        session = _get_session(request)
+        try:
+            session.execute(text("SELECT 1"))
+        finally:
+            session.close()
+    except Exception:
+        return JSONResponse({"status": "unavailable"}, status_code=503)
+    return JSONResponse({"status": "ready"})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Plan
- `plans/browser_game/governing_plan.md` — Phase 5 Step 5

## Summary
- Add `GET /health` liveness endpoint (always 200 OK)
- Add `GET /ready` readiness endpoint (checks DB connectivity, 200 or 503)
- Add 5 tests covering happy path, content type, and DB failure simulation

## Why
Render (and container orchestration in general) needs health check endpoints
to determine if the app is alive and ready to serve traffic. These are
standard deploy probes needed for Phase 5 deployment.

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/hosted_play/test_routes.py -v -k "ready or health"`
- `make check-quiet`

## Test Criteria
- **Pass condition:** 5 new tests pass (2 health, 3 readiness including DB failure)
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_routes.py -v -k "ready or health"`
- **Expected result:** `5 passed`

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_routes.py -v -k "ready or health"` — 5 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None
- Runtime impact: None (two lightweight endpoints)

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
```

`git worktree list` (abbreviated):
```
Bid-Euchre-steward-brws-author-b  803e822d [brws/health-endpoints]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)