### PR TITLE
feat(web): add Render deployment config (Phase 5 Step 2)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,33 @@
+# Render Blueprint — Bid Euchre browser game
+# https://docs.render.com/blueprint-spec
+#
+# Deploy via: connect GitHub repo on Render dashboard, select this blueprint.
+# Render auto-deploys on pushes to main.
+
+databases:
+  - name: bideuchre-db
+    plan: free
+    databaseName: bideuchre
+    user: bideuchre
+
+services:
+  - type: web
+    name: bideuchre-web
+    runtime: docker
+    repo: https://github.com/Questuart/Bid-Euchre
+    branch: main
+    plan: free
+    dockerfilePath: ./Dockerfile
+    healthCheckPath: /
+    autoDeploy: true
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: bideuchre-db
+          property: connectionString
+      - key: SECRET_KEY
+        generateValue: true
+      - key: MODELS_DIR
+        value: /app/models
+      - key: DEFAULT_MODEL_ID
+        value: heuristic


### PR DESCRIPTION
## Summary

- Add `render.yaml` Render Blueprint defining the `bideuchre-web` Docker web service and managed Postgres database
- Wire `DATABASE_URL` (from Render Postgres), auto-generated `SECRET_KEY`, `MODELS_DIR`, and `DEFAULT_MODEL_ID` env vars
- Enable auto-deploy on pushes to `main`

## Why

Phase 5 Step 2 of the browser game governing plan. This config file is required for Render Blueprint deployment — it tells Render how to build and run the web service and what infrastructure (Postgres) to provision.

## Repro / Validation

```bash
# Verify valid YAML with correct structure
python -c "import yaml; d = yaml.safe_load(open('render.yaml')); assert len(d['services']) == 1; assert len(d['databases']) == 1; print('PASS')"
```

## Tests

- YAML validity verified via `check yaml` pre-commit hook
- `make check-quiet` passes (all checks green)

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
worktree: Bid-Euchre-steward-flex-a
branch: browser-game/render-deploy-config
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)