### PR TITLE
feat(web): add Dockerfile for hosted browser game (Phase 5)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Dockerfile — Bid Euchre Browser Game
+#
+# Thin production image: Python 3.12, hosted extras only, uvicorn entrypoint.
+# No dev deps, no data/runs, no experiment infrastructure.
+#
+# Build:  docker build -t bideuchre-web .
+# Run:    docker run -p 8000:8000 -e DATABASE_URL=sqlite:///hosted_play.db bideuchre-web
+
+FROM python:3.12-slim AS base
+
+# Prevent .pyc files and enable unbuffered output for logging
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# --- Install uv for fast, deterministic dependency resolution ---
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# --- Install dependencies first (cache-friendly layer ordering) ---
+COPY pyproject.toml uv.lock ./
+
+# Install only the hosted extras (no dev deps)
+RUN uv sync --frozen --no-dev --extra hosted --no-install-project
+
+# --- Copy application source ---
+COPY src/ src/
+COPY web/ web/
+
+# Install the project itself (editable not needed in production)
+RUN uv sync --frozen --no-dev --extra hosted
+
+EXPOSE 8000
+
+# Uvicorn entrypoint — create_app() is a factory function
+CMD ["uv", "run", "uvicorn", "web.app:create_app", "--factory", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Plan
`plans/browser_game/governing_plan.md` — Phase 5: deployment configuration and startup command

## Summary
- Add production `Dockerfile` using Python 3.12-slim + uv for deterministic dependency resolution
- Uvicorn entrypoint runs `web.app:create_app()` factory on port 8000
- Two-stage `uv sync` for cache-friendly layer ordering (deps first, then project)

## Why
Phase 5 Step 1 requires a deployment-ready container image. PR #1628 was closed due to `.dockerignore` conflict — `.dockerignore` was merged separately in #1627. This is the clean Dockerfile-only recreation.

## Repro / Validation
**Command(s) run:**
- `make check-quiet` — ✅ all checks passed
- `docker build -t bideuchre-web .` (requires Docker runtime — manual validation)

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** `docker build -t bideuchre-web .` completes without error; container starts and responds on port 8000
- **Verification command:** `docker build -t bideuchre-web . && docker run --rm -d -p 8000:8000 -e DATABASE_URL=sqlite:///hosted_play.db --name bideuchre-test bideuchre-web && sleep 2 && curl -s http://localhost:8000/ && docker stop bideuchre-test`
- **Expected result:** Build succeeds, uvicorn starts, HTTP response from landing page

## Tests
- [x] `make check-quiet` — all checks passed
- [ ] Docker build (requires Docker runtime — manual validation)

## Expected impact
- Metrics impact: None
- Runtime impact: None (new file only)

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                        63e72e52 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d  8ca2a2ec [brws/dockerfile-clean]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)