### PR TITLE
test: expand bilateral messaging integration tests (#1570)

### DIFF
--- a/tests/integration/test_bilateral_messaging.py
+++ b/tests/integration/test_bilateral_messaging.py
@@ -8,19 +8,46 @@ Proves end-to-end bilateral messaging works across all lane pool types:
 Each test exercises the full send → deliver → read → ack cycle using
 the real message_bus module against a temporary bus root.
 
+Expanded coverage includes:
+- Priority-aware delivery (read_inbox_prioritized)
+- Messages surviving compaction
+- Full lifecycle transitions (delivered → acked → resolved)
+- Error cases (invalid types, invalid transitions, duplicate IDs)
+- Escalation, TTL expiry, and dead-letter mechanics
+- Bulk operations and content dedup
+- Inbox statistics
+
 Closes #1570.
 """
 
 from __future__ import annotations
 
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
 from bid_euchre.ops.message_bus import (
+    VALID_MESSAGE_PRIORITIES,
+    VALID_MESSAGE_STATUSES,
+    VALID_MESSAGE_TRANSITIONS,
+    VALID_MESSAGE_TYPES,
+    BusMessage,
     ack_message,
+    bulk_ack_messages,
+    check_ack_status,
+    check_dead_letters,
+    check_expired,
+    compact_inbox,
     create_message,
+    escalate_unacked,
+    inbox_stats,
+    mark_delivered,
+    query_unresolved,
     read_inbox,
+    read_inbox_prioritized,
+    resolve_message,
     send_message,
     shared_bus_root,
 )
@@ -675,3 +702,1023 @@ class TestMessageTypeFiltering:
         )
         assert len(acks) == 1
         assert acks[0]["from_lane"] == "author-a"
+
+
+# ---------------------------------------------------------------------------
+# Test: Priority-aware delivery (read_inbox_prioritized)
+# ---------------------------------------------------------------------------
+
+
+class TestPriorityAwareDelivery:
+    """Verify priority-grouped inbox reading (P0/P1/P2 tiers)."""
+
+    def test_urgent_in_p0_tier(self, bus_root: Path, events_dir: Path) -> None:
+        """Urgent messages appear in the P0 tier."""
+        msg = create_message(
+            from_lane="ops",
+            to_lane="orchestrator",
+            message_type="supervisor_alert",
+            summary="Critical: lane down",
+            priority="urgent",
+        )
+        send_message(msg, bus_root=bus_root, events_dir=events_dir)
+
+        p0, p1, p2 = read_inbox_prioritized(
+            "orchestrator",
+            bus_root=bus_root,
+            auto_expire=False,
+            auto_compact=False,
+        )
+        assert len(p0) == 1
+        assert p0[0]["priority"] == "urgent"
+        assert len(p1) == 0
+        assert len(p2) == 0
+
+    def test_high_in_p1_tier(self, bus_root: Path, events_dir: Path) -> None:
+        """High-priority messages appear in the P1 tier."""
+        msg = create_message(
+            from_lane="ops",
+            to_lane="orchestrator",
+            message_type="supervisor_alert",
+            summary="CI red on 2 lanes",
+            priority="high",
+        )
+        send_message(msg, bus_root=bus_root, events_dir=events_dir)
+
+        p0, p1, p2 = read_inbox_prioritized(
+            "orchestrator",
+            bus_root=bus_root,
+            auto_expire=False,
+            auto_compact=False,
+        )
+        assert len(p0) == 0
+        assert len(p1) == 1
+        assert p1[0]["priority"] == "high"
+        assert len(p2) == 0
+
+    def test_normal_and_low_in_p2_tier(self, bus_root: Path, events_dir: Path) -> None:
+        """Normal and low priority messages both appear in P2 tier."""
+        for prio in ("normal", "low"):
+            msg = create_message(
+                from_lane="author-a",
+                to_lane="orchestrator",
+                message_type="progress",
+                summary=f"Update ({prio} priority)",
+                priority=prio,
+            )
+            send_message(msg, bus_root=bus_root, events_dir=events_dir)
+
+        p0, p1, p2 = read_inbox_prioritized(
+            "orchestrator",
+            bus_root=bus_root,
+            auto_expire=False,
+            auto_compact=False,
+        )
+        assert len(p0) == 0
+        assert len(p1) == 0
+        assert len(p2) == 2
+
+    def test_mixed_priorities_sorted_into_tiers(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Messages of different priorities are correctly bucketed."""
+        priorities = ["urgent", "high", "normal", "low", "urgent"]
+        for i, prio in enumerate(priorities):
+            msg = create_message(
+                from_lane="author-a",
+                to_lane="orchestrator",
+                message_type="progress",
+                summary=f"Msg {i} ({prio})",
+                priority=prio,
+            )
+            send_message(msg, bus_root=bus_root, events_dir=events_dir)
+
+        p0, p1, p2 = read_inbox_prioritized(
+            "orchestrator",
+            bus_root=bus_root,
+            auto_expire=False,
+            auto_compact=False,
+        )
+        assert len(p0) == 2  # 2 urgent
+        assert len(p1) == 1  # 1 high
+        assert len(p2) == 2  # 1 normal + 1 low
+
+
+# ---------------------------------------------------------------------------
+# Test: Messages survive compaction
+# ---------------------------------------------------------------------------
+
+
+class TestCompactionSurvival:
+    """Active messages survive inbox compaction; old terminal ones are purged."""
+
+    def test_pending_messages_survive_compaction(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Pending (active) messages are always retained after compaction."""
+        msg = create_message(
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="assignment",
+            summary="Active task",
+        )
+        mid = send_message(msg, bus_root=bus_root, events_dir=events_dir)
+
+        result = compact_inbox("author-a", bus_root=bus_root)
+        assert result["removed"] == 0
+
+        inbox = read_inbox(
+            "author-a",
+            bus_root=bus_root,
+            auto_expire=False,
+            auto_compact=False,
+        )
+        assert any(m["message_id"] == mid for m in inbox)
+
+    def test_delivered_messages_survive_compaction(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Delivered (active) messages are always retained."""
+        msg = create_message(
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="assignment",
+            summary="Delivered task",
+        )
+        mid = send_message(msg, bus_root=bus_root, events_dir=events_dir)
+        mark_delivered(mid, "author-a", bus_root=bus_root, events_dir=events_dir)
+
+        result = compact_inbox("author-a", bus_root=bus_root)
+        assert result["removed"] == 0
+
+    def test_old_resolved_messages_purged(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Old resolved messages are removed by compaction."""
+        msg = create_message(
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="assignment",
+            summary="Ancient resolved task",
+        )
+        mid = send_message(msg, bus_root=bus_root, events_dir=events_dir)
+        ack_message(mid, "author-a", bus_root=bus_root, events_dir=events_dir)
+        resolve_message(mid, "author-a", bus_root=bus_root, events_dir=events_dir)
+
+        # Compact with now far in the future so the message is "old"
+        future_time = time.time() + 48 * 3600  # 48 hours from now
+        result = compact_inbox("author-a", bus_root=bus_root, now=future_time)
+        assert result["removed"] >= 1
+
+        inbox = read_inbox(
+            "author-a",
+            bus_root=bus_root,
+            auto_expire=False,
+            auto_compact=False,
+        )
+        assert not any(m["message_id"] == mid for m in inbox)
+
+    def test_recent_acked_messages_kept(self, bus_root: Path, events_dir: Path) -> None:
+        """Recently acked messages are retained (within retention window)."""
+        msg = create_message(
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="assignment",
+            summary="Recently acked",
+        )
+        mid = send_message(msg, bus_root=bus_root, events_dir=events_dir)
+        ack_message(mid, "author-a", bus_root=bus_root, events_dir=events_dir)
+
+        # Compact at current time — acked message is recent, should survive
+        result = compact_inbox("author-a", bus_root=bus_root)
+        assert result["removed"] == 0
+
+        inbox = read_inbox(
+            "author-a",
+            bus_root=bus_root,
+            status="acked",
+            auto_expire=False,
+            auto_compact=False,
+        )
+        assert any(m["message_id"] == mid for m in inbox)
+
+
+# ---------------------------------------------------------------------------
+# Test: Full lifecycle transitions
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycleTransitions:
+    """Verify the complete message lifecycle: pending → delivered → acked → resolved."""
+
+    def test_full_lifecycle(self, bus_root: Path, events_dir: Path) -> None:
+        """Walk through all four lifecycle states."""
+        msg = create_message(
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="assignment",
+            summary="Full lifecycle test",
+        )
+        mid = send_message(msg, bus_root=bus_root, events_dir=events_dir)
+
+        # pending → delivered
+        delivered = mark_delivered(
+            mid, "author-a", bus_root=bus_root, events_dir=events_dir
+        )
+        assert delivered is not None
+        assert delivered["status"] == "delivered"
+
+        # delivered → acked
+        acked = ack_message(mid, "author-a", bus_root=bus_root, events_dir=events_dir)
+        assert acked is not None
+        assert acked["status"] == "acked"
+        assert acked["acked_at"] is not None
+
+        # acked → resolved
+        resolved = resolve_message(
+            mid, "author-a", bus_root=bus_root, events_dir=events_dir
+        )
+        assert resolved is not None
+        assert resolved["status"] == "resolved"
+        assert resolved["resolved_at"] is not None
+
+    def test_check_ack_status_tracks_transitions(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """check_ack_status reflects the current lifecycle stage."""
+        msg = create_message(
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="assignment",
+            summary="Status tracking test",
+        )
+        mid = send_message(msg, bus_root=bus_root, events_dir=events_dir)
+
+        assert check_ack_status(mid, "author-a", bus_root=bus_root) == "pending"
+
+        mark_delivered(mid, "author-a", bus_root=bus_root, events_dir=events_dir)
+        assert check_ack_status(mid, "author-a", bus_root=bus_root) == "delivered"
+
+        ack_message(mid, "author-a", bus_root=bus_root, events_dir=events_dir)
+        assert check_ack_status(mid, "author-a", bus_root=bus_root) == "acked"
+
+        resolve_message(mid, "author-a", bus_root=bus_root, events_dir=events_dir)
+        assert check_ack_status(mid, "author-a", bus_root=bus_root) == "resolved"
+
+    def test_check_ack_status_nonexistent(self, bus_root: Path) -> None:
+        """check_ack_status returns None for unknown message IDs."""
+        assert check_ack_status("nonexistent_id", "author-a", bus_root=bus_root) is None
+
+    def test_mark_delivered_nonexistent(self, bus_root: Path, events_dir: Path) -> None:
+        """mark_delivered returns None for unknown message IDs."""
+        result = mark_delivered(
+            "nonexistent_id", "author-a", bus_root=bus_root, events_dir=events_dir
+        )
+        assert result is None
+
+    def test_resolve_nonexistent(self, bus_root: Path, events_dir: Path) -> None:
+        """resolve_message returns None for unknown message IDs."""
+        result = resolve_message(
+            "nonexistent_id", "author-a", bus_root=bus_root, events_dir=events_dir
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Test: Error cases
+# ---------------------------------------------------------------------------
+
+
+class TestErrorCases:
+    """Verify that invalid operations raise appropriate errors."""
+
+    def test_invalid_message_type_raises(self) -> None:
+        """Creating a message with an invalid type raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid message_type"):
+            create_message(
+                from_lane="author-a",
+                to_lane="orchestrator",
+                message_type="invalid_type",
+                summary="Should fail",
+            )
+
+    def test_invalid_priority_raises(self) -> None:
+        """Creating a message with an invalid priority raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid priority"):
+            create_message(
+                from_lane="author-a",
+                to_lane="orchestrator",
+                message_type="ack",
+                summary="Should fail",
+                priority="critical",  # not a valid priority
+            )
+
+    def test_invalid_status_on_bus_message_raises(self) -> None:
+        """Direct BusMessage construction with invalid status raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid status"):
+            BusMessage(
+                message_id="test123",
+                thread_id=None,
+                task_id=None,
+                from_lane="author-a",
+                to_lane="orchestrator",
+                message_type="ack",
+                priority="normal",
+                status="invalid_status",
+                created_at="2026-01-01T00:00:00Z",
+                acked_at=None,
+                resolved_at=None,
+                requires_human=False,
+                summary="Should fail",
+            )
+
+    def test_invalid_transition_acked_to_acked(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Acking an already-acked message raises ValueError."""
+        msg = create_message(
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="assignment",
+            summary="Double ack test",
+        )
+        mid = send_message(msg, bus_root=bus_root, events_dir=events_dir)
+        ack_message(mid, "author-a", bus_root=bus_root, events_dir=events_dir)
+
+        with pytest.raises(ValueError, match="Invalid transition"):
+            ack_message(mid, "author-a", bus_root=bus_root, events_dir=events_dir)
+
+    def test_invalid_transition_resolved_to_acked(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Cannot ack a resolved (terminal) message."""
+        msg = create_message(
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="assignment",
+            summary="Terminal transition test",
+        )
+        mid = send_message(msg, bus_root=bus_root, events_dir=events_dir)
+        ack_message(mid, "author-a", bus_root=bus_root, events_dir=events_dir)
+        resolve_message(mid, "author-a", bus_root=bus_root, events_dir=events_dir)
+
+        with pytest.raises(ValueError, match="Invalid transition"):
+            ack_message(mid, "author-a", bus_root=bus_root, events_dir=events_dir)
+
+    def test_invalid_transition_pending_to_resolved(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Cannot resolve a message that hasn't been acked first."""
+        msg = create_message(
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="assignment",
+            summary="Skip-ack test",
+        )
+        mid = send_message(msg, bus_root=bus_root, events_dir=events_dir)
+
+        with pytest.raises(ValueError, match="Invalid transition"):
+            resolve_message(mid, "author-a", bus_root=bus_root, events_dir=events_dir)
+
+    def test_duplicate_message_id_raises(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Sending a message with a duplicate ID raises ValueError."""
+        msg = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="ack",
+            summary="First send",
+        )
+        send_message(msg, bus_root=bus_root, events_dir=events_dir)
+
+        # Attempt to re-send the exact same BusMessage object (same message_id)
+        with pytest.raises(ValueError, match="Duplicate message_id"):
+            send_message(msg, bus_root=bus_root, events_dir=events_dir)
+
+    def test_valid_message_types_are_exhaustive(self) -> None:
+        """Smoke: all expected message types are in the valid set."""
+        expected = {
+            "assignment",
+            "ack",
+            "progress",
+            "blocker",
+            "completion",
+            "escalation",
+            "recovery",
+            "supervisor_alert",
+        }
+        assert VALID_MESSAGE_TYPES == expected
+
+    def test_valid_priorities_are_exhaustive(self) -> None:
+        """Smoke: all expected priorities are in the valid set."""
+        expected = {"low", "normal", "high", "urgent"}
+        assert VALID_MESSAGE_PRIORITIES == expected
+
+
+# ---------------------------------------------------------------------------
+# Test: Bulk ack
+# ---------------------------------------------------------------------------
+
+
+class TestBulkAck:
+    """Verify bulk_ack_messages works with filter predicates."""
+
+    def test_bulk_ack_by_message_type(self, bus_root: Path, events_dir: Path) -> None:
+        """Bulk-ack all assignment messages in a lane's inbox."""
+        # Send 2 assignments and 1 progress to author-a
+        for summary in ("Task A", "Task B"):
+            msg = create_message(
+                from_lane="orchestrator",
+                to_lane="author-a",
+                message_type="assignment",
+                summary=summary,
+            )
+            send_message(msg, bus_root=bus_root, events_dir=events_dir)
+
+        progress = create_message(
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="progress",
+            summary="Status update",
+        )
+        send_message(progress, bus_root=bus_root, events_dir=events_dir)
+
+        # Bulk-ack only assignments
+        acked = bulk_ack_messages(
+            "author-a",
+            lambda m: m.get("message_type") == "assignment",
+            bus_root=bus_root,
+            events_dir=events_dir,
+        )
+        assert len(acked) == 2
+        assert all(a["status"] == "acked" for a in acked)
+
+        # Progress message should still be pending
+        pending = read_inbox(
+            "author-a",
+            bus_root=bus_root,
+            status="pending",
+            auto_expire=False,
+            auto_compact=False,
+        )
+        assert len(pending) == 1
+        assert pending[0]["message_type"] == "progress"
+
+    def test_bulk_ack_skips_already_acked(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Bulk-ack does not re-ack already-acked messages."""
+        msg = create_message(
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="assignment",
+            summary="Already acked",
+        )
+        mid = send_message(msg, bus_root=bus_root, events_dir=events_dir)
+        ack_message(mid, "author-a", bus_root=bus_root, events_dir=events_dir)
+
+        # Bulk-ack should return empty (nothing ackable)
+        acked = bulk_ack_messages(
+            "author-a",
+            lambda m: True,
+            bus_root=bus_root,
+            events_dir=events_dir,
+        )
+        assert len(acked) == 0
+
+    def test_bulk_ack_empty_inbox(self, bus_root: Path, events_dir: Path) -> None:
+        """Bulk-ack on empty inbox returns empty list."""
+        acked = bulk_ack_messages(
+            "author-a",
+            lambda m: True,
+            bus_root=bus_root,
+            events_dir=events_dir,
+        )
+        assert acked == []
+
+
+# ---------------------------------------------------------------------------
+# Test: Query unresolved
+# ---------------------------------------------------------------------------
+
+
+class TestQueryUnresolved:
+    """Verify query_unresolved returns only non-terminal messages."""
+
+    def test_returns_pending_and_acked(self, bus_root: Path, events_dir: Path) -> None:
+        """query_unresolved includes pending and acked messages."""
+        msg1 = create_message(
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="assignment",
+            summary="Pending msg",
+        )
+        mid1 = send_message(msg1, bus_root=bus_root, events_dir=events_dir)
+
+        msg2 = create_message(
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="assignment",
+            summary="Acked msg",
+        )
+        mid2 = send_message(msg2, bus_root=bus_root, events_dir=events_dir)
+        ack_message(mid2, "author-a", bus_root=bus_root, events_dir=events_dir)
+
+        unresolved = query_unresolved("author-a", bus_root=bus_root)
+        unresolved_ids = [m["message_id"] for m in unresolved]
+        assert mid1 in unresolved_ids
+        assert mid2 in unresolved_ids
+
+    def test_excludes_resolved(self, bus_root: Path, events_dir: Path) -> None:
+        """query_unresolved excludes resolved messages."""
+        msg = create_message(
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="assignment",
+            summary="Will be resolved",
+        )
+        mid = send_message(msg, bus_root=bus_root, events_dir=events_dir)
+        ack_message(mid, "author-a", bus_root=bus_root, events_dir=events_dir)
+        resolve_message(mid, "author-a", bus_root=bus_root, events_dir=events_dir)
+
+        unresolved = query_unresolved("author-a", bus_root=bus_root)
+        unresolved_ids = [m["message_id"] for m in unresolved]
+        assert mid not in unresolved_ids
+
+
+# ---------------------------------------------------------------------------
+# Test: TTL expiry
+# ---------------------------------------------------------------------------
+
+
+class TestTTLExpiry:
+    """Verify messages expire after their TTL."""
+
+    def test_expired_message_transitions(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """A message past its TTL is marked expired by check_expired."""
+        msg = create_message(
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="assignment",
+            summary="Short-lived message",
+            payload={"ttl_seconds": 60},  # 60 second TTL
+        )
+        send_message(msg, bus_root=bus_root, events_dir=events_dir)
+
+        # Check with current time — should not be expired yet
+        expired = check_expired(bus_root=bus_root, events_dir=events_dir)
+        assert len(expired) == 0
+
+        # Check with time far in the future
+        future = time.time() + 3600  # 1 hour from now
+        expired = check_expired(bus_root=bus_root, events_dir=events_dir, now=future)
+        assert len(expired) == 1
+        assert expired[0]["status"] == "expired"
+
+    def test_non_expired_message_untouched(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """A message within its TTL is not expired."""
+        msg = create_message(
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="assignment",
+            summary="Long-lived message",
+            payload={"ttl_seconds": 86400},  # 24 hour TTL
+        )
+        mid = send_message(msg, bus_root=bus_root, events_dir=events_dir)
+
+        # Check at current time — should not expire
+        expired = check_expired(bus_root=bus_root, events_dir=events_dir)
+        assert len(expired) == 0
+
+        status = check_ack_status(mid, "author-a", bus_root=bus_root)
+        assert status == "pending"
+
+
+# ---------------------------------------------------------------------------
+# Test: Dead letters
+# ---------------------------------------------------------------------------
+
+
+class TestDeadLetters:
+    """Verify messages exceeding max_retries are dead-lettered."""
+
+    def test_dead_letter_on_max_retries(self, bus_root: Path, events_dir: Path) -> None:
+        """A message at max_retries is marked dead_lettered."""
+        msg = create_message(
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="assignment",
+            summary="Failed delivery",
+            payload={"max_retries": 3, "retry_count": 3},
+        )
+        send_message(msg, bus_root=bus_root, events_dir=events_dir)
+
+        dead = check_dead_letters(bus_root=bus_root, events_dir=events_dir)
+        assert len(dead) == 1
+        assert dead[0]["status"] == "dead_lettered"
+
+    def test_below_max_retries_not_dead_lettered(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """A message below max_retries is not dead-lettered."""
+        msg = create_message(
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="assignment",
+            summary="Retrying delivery",
+            payload={"max_retries": 3, "retry_count": 2},
+        )
+        send_message(msg, bus_root=bus_root, events_dir=events_dir)
+
+        dead = check_dead_letters(bus_root=bus_root, events_dir=events_dir)
+        assert len(dead) == 0
+
+
+# ---------------------------------------------------------------------------
+# Test: Escalation
+# ---------------------------------------------------------------------------
+
+
+class TestEscalation:
+    """Verify unacked message escalation creates urgent follow-ups."""
+
+    def test_escalate_old_unacked_message(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """An unacked message older than threshold triggers escalation."""
+        # Send a message with an old created_at timestamp
+        old_time = (
+            datetime.now(timezone.utc).replace(year=2025).strftime("%Y-%m-%dT%H:%M:%SZ")
+        )
+        msg = BusMessage(
+            message_id="old_msg_001",
+            thread_id=None,
+            task_id=None,
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="assignment",
+            priority="normal",
+            status="pending",
+            created_at=old_time,
+            acked_at=None,
+            resolved_at=None,
+            requires_human=False,
+            summary="Ancient unacked task",
+            payload={"max_retries": 3, "retry_count": 0, "ttl_seconds": 86400},
+        )
+        send_message(msg, bus_root=bus_root, events_dir=events_dir)
+
+        # Escalate with a short threshold (0 minutes = escalate everything)
+        esc_ids = escalate_unacked(
+            "orchestrator",
+            "author-a",
+            max_age_minutes=0,
+            bus_root=bus_root,
+            events_dir=events_dir,
+        )
+        assert len(esc_ids) == 1
+
+        # Verify the escalation message is in the inbox
+        inbox = read_inbox(
+            "author-a",
+            bus_root=bus_root,
+            message_type="escalation",
+            auto_expire=False,
+            auto_compact=False,
+        )
+        assert len(inbox) == 1
+        assert inbox[0]["priority"] == "urgent"
+        assert "old_msg_001" in inbox[0]["summary"]
+
+    def test_escalation_does_not_re_escalate_escalations(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Escalation messages themselves are not re-escalated."""
+        old_time = (
+            datetime.now(timezone.utc).replace(year=2025).strftime("%Y-%m-%dT%H:%M:%SZ")
+        )
+        # Send an escalation message (from orchestrator → author-a)
+        esc = BusMessage(
+            message_id="esc_msg_001",
+            thread_id=None,
+            task_id=None,
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="escalation",
+            priority="urgent",
+            status="pending",
+            created_at=old_time,
+            acked_at=None,
+            resolved_at=None,
+            requires_human=False,
+            summary="Already escalated",
+            payload={"max_retries": 3, "retry_count": 0, "ttl_seconds": 86400},
+        )
+        send_message(esc, bus_root=bus_root, events_dir=events_dir)
+
+        # Should not create another escalation
+        esc_ids = escalate_unacked(
+            "orchestrator",
+            "author-a",
+            max_age_minutes=0,
+            bus_root=bus_root,
+            events_dir=events_dir,
+        )
+        assert len(esc_ids) == 0
+
+    def test_no_escalation_for_recently_sent(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Recent messages are not escalated."""
+        msg = create_message(
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="assignment",
+            summary="Fresh message",
+        )
+        send_message(msg, bus_root=bus_root, events_dir=events_dir)
+
+        # Use a long threshold (no recent message should be old enough)
+        esc_ids = escalate_unacked(
+            "orchestrator",
+            "author-a",
+            max_age_minutes=60,
+            bus_root=bus_root,
+            events_dir=events_dir,
+        )
+        assert len(esc_ids) == 0
+
+
+# ---------------------------------------------------------------------------
+# Test: Content dedup
+# ---------------------------------------------------------------------------
+
+
+class TestContentDedup:
+    """Verify content-based dedup suppresses duplicate sends."""
+
+    def test_dedup_suppresses_identical_content(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Sending the same content twice with deduplicate=True returns existing ID."""
+        msg1 = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="ack",
+            summary="Task received",
+        )
+        mid1 = send_message(
+            msg1, bus_root=bus_root, events_dir=events_dir, deduplicate=True
+        )
+
+        msg2 = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="ack",
+            summary="Task received",
+        )
+        mid2 = send_message(
+            msg2, bus_root=bus_root, events_dir=events_dir, deduplicate=True
+        )
+
+        # Should return the first message's ID, not create a new one
+        assert mid2 == mid1
+
+    def test_dedup_off_allows_duplicates(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Without deduplicate=True, identical content creates separate messages."""
+        msg1 = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="ack",
+            summary="Task received (no dedup)",
+        )
+        mid1 = send_message(msg1, bus_root=bus_root, events_dir=events_dir)
+
+        msg2 = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="ack",
+            summary="Task received (no dedup)",
+        )
+        mid2 = send_message(msg2, bus_root=bus_root, events_dir=events_dir)
+
+        assert mid2 != mid1
+
+    def test_dedup_allows_escalation_duplicates(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Escalation messages bypass content dedup even when deduplicate=True."""
+        msg1 = create_message(
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="escalation",
+            summary="ESCALATION: unacked msg",
+        )
+        mid1 = send_message(
+            msg1, bus_root=bus_root, events_dir=events_dir, deduplicate=True
+        )
+
+        msg2 = create_message(
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="escalation",
+            summary="ESCALATION: unacked msg",
+        )
+        mid2 = send_message(
+            msg2, bus_root=bus_root, events_dir=events_dir, deduplicate=True
+        )
+
+        # Each escalation should be delivered separately
+        assert mid2 != mid1
+
+
+# ---------------------------------------------------------------------------
+# Test: Inbox statistics
+# ---------------------------------------------------------------------------
+
+
+class TestInboxStats:
+    """Verify inbox_stats returns accurate per-lane counts."""
+
+    def test_stats_reflect_message_states(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """inbox_stats correctly counts messages by status."""
+        # Create 2 pending and 1 acked message for author-a
+        for summary in ("Task 1", "Task 2"):
+            msg = create_message(
+                from_lane="orchestrator",
+                to_lane="author-a",
+                message_type="assignment",
+                summary=summary,
+            )
+            send_message(msg, bus_root=bus_root, events_dir=events_dir)
+
+        msg3 = create_message(
+            from_lane="orchestrator",
+            to_lane="author-a",
+            message_type="assignment",
+            summary="Task 3 (will ack)",
+        )
+        mid3 = send_message(msg3, bus_root=bus_root, events_dir=events_dir)
+        ack_message(mid3, "author-a", bus_root=bus_root, events_dir=events_dir)
+
+        stats = inbox_stats(bus_root=bus_root)
+        lane_data = next(
+            lane for lane in stats["lanes"] if lane["lane_id"] == "author-a"
+        )
+        assert lane_data["total"] == 3
+        assert lane_data["by_status"].get("pending", 0) == 2
+        assert lane_data["by_status"].get("acked", 0) == 1
+
+    def test_stats_empty_bus(self, bus_root: Path) -> None:
+        """inbox_stats on empty bus returns empty lanes list."""
+        stats = inbox_stats(bus_root=bus_root)
+        assert stats["lanes"] == []
+
+    def test_stats_multiple_lanes(self, bus_root: Path, events_dir: Path) -> None:
+        """inbox_stats reports on all lanes with messages."""
+        for lane in ("author-a", "brws-author-a", "orchestrator"):
+            msg = create_message(
+                from_lane="ops",
+                to_lane=lane,
+                message_type="supervisor_alert",
+                summary=f"Alert for {lane}",
+            )
+            send_message(msg, bus_root=bus_root, events_dir=events_dir)
+
+        stats = inbox_stats(bus_root=bus_root)
+        lane_ids = {lane["lane_id"] for lane in stats["lanes"]}
+        assert "author-a" in lane_ids
+        assert "brws-author-a" in lane_ids
+        assert "orchestrator" in lane_ids
+
+
+# ---------------------------------------------------------------------------
+# Test: create_message factory defaults
+# ---------------------------------------------------------------------------
+
+
+class TestCreateMessageDefaults:
+    """Verify create_message populates expected default fields."""
+
+    def test_default_priority_is_normal(self) -> None:
+        """Default priority is 'normal'."""
+        msg = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="ack",
+            summary="Test",
+        )
+        assert msg.priority == "normal"
+
+    def test_default_status_is_pending(self) -> None:
+        """Default status is 'pending'."""
+        msg = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="ack",
+            summary="Test",
+        )
+        assert msg.status == "pending"
+
+    def test_delivery_policy_defaults_in_payload(self) -> None:
+        """Payload includes max_retries, retry_count, ttl_seconds."""
+        msg = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="ack",
+            summary="Test",
+        )
+        assert msg.payload["max_retries"] == 3
+        assert msg.payload["retry_count"] == 0
+        assert msg.payload["ttl_seconds"] == 86400
+
+    def test_custom_payload_preserved(self) -> None:
+        """Custom payload fields are merged with defaults."""
+        msg = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="ack",
+            summary="Test",
+            payload={"custom_key": "custom_value"},
+        )
+        assert msg.payload["custom_key"] == "custom_value"
+        assert "max_retries" in msg.payload  # default still present
+
+    def test_message_id_is_hex(self) -> None:
+        """Message ID is a 16-char hex string."""
+        msg = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="ack",
+            summary="Test",
+        )
+        assert len(msg.message_id) == 16
+        int(msg.message_id, 16)  # Should not raise
+
+    def test_optional_fields_default_none(self) -> None:
+        """Thread ID, task ID, acked_at, resolved_at default to None."""
+        msg = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="ack",
+            summary="Test",
+        )
+        assert msg.thread_id is None
+        assert msg.task_id is None
+        assert msg.acked_at is None
+        assert msg.resolved_at is None
+
+    def test_source_transport_default(self) -> None:
+        """Default source_transport is 'bus'."""
+        msg = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="ack",
+            summary="Test",
+        )
+        assert msg.source_transport == "bus"
+
+    def test_requires_human_default_false(self) -> None:
+        """Default requires_human is False."""
+        msg = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="ack",
+            summary="Test",
+        )
+        assert msg.requires_human is False
+
+
+# ---------------------------------------------------------------------------
+# Test: Valid constants (smoke)
+# ---------------------------------------------------------------------------
+
+
+class TestValidConstants:
+    """Smoke tests for valid message bus constants."""
+
+    def test_all_statuses_have_transitions(self) -> None:
+        """Every valid status has an entry in the transition map."""
+        for status in VALID_MESSAGE_STATUSES:
+            assert status in VALID_MESSAGE_TRANSITIONS
+
+    def test_transition_targets_are_valid_statuses(self) -> None:
+        """All transition targets are valid statuses."""
+        for _source, targets in VALID_MESSAGE_TRANSITIONS.items():
+            for target in targets:
+                assert target in VALID_MESSAGE_STATUSES
+
+    def test_terminal_states_have_no_transitions(self) -> None:
+        """Terminal states (resolved, expired, dead_lettered) cannot transition."""
+        terminal = {"resolved", "expired", "dead_lettered"}
+        for state in terminal:
+            assert len(VALID_MESSAGE_TRANSITIONS[state]) == 0


### PR DESCRIPTION
## Summary
- Add 51 new integration tests to `tests/integration/test_bilateral_messaging.py` (34 → 85 total)
- Covers priority-aware delivery, compaction survival, full lifecycle transitions, error cases, escalation, TTL expiry, dead letters, bulk ack, content dedup, inbox stats, and factory defaults
- Closes #1570

## Why
The bilateral messaging system had only basic send/receive/ack coverage. This PR adds comprehensive tests for the full message_bus API surface — lifecycle transitions, delivery semantics, error handling, and operational features (compaction, escalation, dead letters).

## Test Coverage Added

| Test Class | Tests | What it covers |
|-----------|-------|---------------|
| `TestPriorityAwareDelivery` | 4 | `read_inbox_prioritized` P0/P1/P2 tier bucketing |
| `TestCompactionSurvival` | 4 | Active messages survive `compact_inbox`; old terminal purged |
| `TestLifecycleTransitions` | 5 | `pending → delivered → acked → resolved` + `check_ack_status` |
| `TestErrorCases` | 9 | Invalid types/priorities/statuses, invalid transitions, duplicate IDs |
| `TestBulkAck` | 3 | `bulk_ack_messages` with filter, skip-already-acked, empty inbox |
| `TestQueryUnresolved` | 2 | `query_unresolved` includes pending/acked, excludes resolved |
| `TestTTLExpiry` | 2 | `check_expired` with time override |
| `TestDeadLetters` | 2 | `check_dead_letters` at/below max_retries |
| `TestEscalation` | 3 | `escalate_unacked`, no re-escalation of escalations |
| `TestContentDedup` | 3 | `deduplicate=True` suppression, escalation bypass |
| `TestInboxStats` | 3 | `inbox_stats` per-lane counts, empty bus, multi-lane |
| `TestCreateMessageDefaults` | 8 | Factory defaults for all BusMessage fields |
| `TestValidConstants` | 3 | Transition map consistency, terminal states |

## Repro / Validation

```bash
uv run python -m pytest tests/integration/test_bilateral_messaging.py -v
# 85 passed in 0.25s
make check-quiet  # ✓ All checks passed
```

## Tests
- `uv run python -m pytest tests/integration/test_bilateral_messaging.py -v` — 85 passed
- `make check-quiet` — all checks passed

## Worktree proof
- Worktree: `Bid-Euchre-steward-author`
- Branch: `test/bilateral-messaging-coverage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)