### PR TITLE
fix(ops): replace stale _prioritized_inbox shim, forward --type/--thread flags

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -1986,6 +1986,26 @@ def cmd_inbox(args: argparse.Namespace) -> int:
             bus_root,
             status=status_filter,
         )
+
+        # Forward --type and --thread filters (read_inbox_prioritized does
+        # not accept these natively, so post-filter each tier).
+        if type_filter is not None or thread_filter is not None:
+            allowed_types = (
+                ({type_filter} if isinstance(type_filter, str) else set(type_filter))
+                if type_filter is not None
+                else None
+            )
+
+            def _match(msg: dict) -> bool:
+                if allowed_types and msg.get("message_type") not in allowed_types:
+                    return False
+                if thread_filter and msg.get("thread_id") != thread_filter:
+                    return False
+                return True
+
+            p0 = [m for m in p0 if _match(m)]
+            p1 = [m for m in p1 if _match(m)]
+            p2 = [m for m in p2 if _match(m)]
         if args.json:
             print(
                 json.dumps(

--- a/tests/integration/test_orchestration_lifecycle.py
+++ b/tests/integration/test_orchestration_lifecycle.py
@@ -47,43 +47,6 @@ def events_dir(tmp_path: Path) -> Path:
 
 
 # ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-# Priority tiers for inbox triage (mirrors the planned
-# read_inbox_prioritized contract from the messaging-redesign plan).
-_PRIORITY_TIERS = {
-    "P0": {"urgent"},
-    "P1": {"high"},
-    "P2": {"normal", "low"},
-}
-
-
-def _prioritized_inbox(
-    lane_id: str,
-    bus_root: Path,
-) -> tuple[list[dict], list[dict], list[dict]]:
-    """Triage a lane's pending inbox into P0/P1/P2 buckets.
-
-    This is a test-local shim for the planned ``read_inbox_prioritized()``
-    convenience wrapper.  Once that function ships in Phase 1b, this helper
-    can be replaced by a direct call.
-    """
-    msgs = read_inbox(
-        lane_id,
-        bus_root=bus_root,
-        status="pending",
-        auto_expire=False,
-        auto_compact=False,
-        limit=200,
-    )
-    p0 = [m for m in msgs if m.get("priority") in _PRIORITY_TIERS["P0"]]
-    p1 = [m for m in msgs if m.get("priority") in _PRIORITY_TIERS["P1"]]
-    p2 = [m for m in msgs if m.get("priority") in _PRIORITY_TIERS["P2"]]
-    return p0, p1, p2
-
-
-# ---------------------------------------------------------------------------
 # Test: Full orchestration lifecycle
 # ---------------------------------------------------------------------------
 
@@ -149,7 +112,9 @@ class TestOrchestrationLifecycle:
         complete_id = send_message(complete, bus_root=bus_root, events_dir=events_dir)
 
         # 7. Orchestrator reads prioritized inbox — completion should be P1
-        p0, p1, p2 = _prioritized_inbox("orchestrator", bus_root=bus_root)
+        p0, p1, p2 = read_inbox_prioritized(
+            "orchestrator", bus_root=bus_root, auto_expire=False, auto_compact=False
+        )
         assert any(m["message_id"] == complete_id for m in p1), (
             f"Completion {complete_id} should be in P1 (high). "
             f"P0={[m['message_id'] for m in p0]}, "


### PR DESCRIPTION
## Summary
- Remove the test-local `_prioritized_inbox()` shim and `_PRIORITY_TIERS` constant from `test_orchestration_lifecycle.py` — replaced by direct calls to the real `read_inbox_prioritized()` that shipped in Phase 1b
- Forward `--type` and `--thread` CLI flags in the `--prioritized` inbox path of `ops.py` by post-filtering each priority tier

## Why
- **#1609:** The test shim duplicated logic that now lives in `read_inbox_prioritized()` — dead code that could drift from the real implementation
- **#1602:** `ops.py inbox --lane X --prioritized --type completion` silently ignored `--type` and `--thread`, returning unfiltered results

## Repro / Validation
```bash
uv run python -m pytest tests/integration/test_orchestration_lifecycle.py tests/unit/test_ops_message_bus.py -v
make check-quiet
```

## Tests
- `tests/integration/test_orchestration_lifecycle.py` — 18 tests pass (lifecycle, escalation, cross-pool, resolve)
- `tests/unit/test_ops_message_bus.py` — 140 tests pass (includes prioritized inbox tests)
- Full `make check-quiet` passes

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: fix/replace-prioritized-inbox-shim
```

Closes #1609, closes #1602.

🤖 Generated with [Claude Code](https://claude.com/claude-code)