### PR TITLE
feat(web): add production startup entrypoint for hosted app (Phase 5)

### DIFF
--- a/scripts/start_hosted.sh
+++ b/scripts/start_hosted.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Production startup wrapper for the Bid Euchre browser game.
+#
+# This script is the Docker CMD / Render start command. It:
+#   1. Prints diagnostic info (Python version, key env vars)
+#   2. Delegates to the Python entrypoint (web.start) which handles
+#      DB init (via the FastAPI lifespan) and uvicorn startup.
+#
+# Environment variables consumed by this script or web.start:
+#   HOST          — bind address   (default: 0.0.0.0)
+#   PORT          — bind port      (default: 8000, Render injects $PORT)
+#   WEB_WORKERS   — worker count   (default: 1)
+#   LOG_LEVEL     — uvicorn level  (default: info)
+#   DATABASE_URL  — SQLAlchemy DSN (default: sqlite:///hosted_play.db)
+#
+# Usage:
+#   ./scripts/start_hosted.sh          # direct
+#   docker run -p 8000:8000 bideuchre  # via Dockerfile CMD
+
+set -euo pipefail
+
+echo "=== Bid Euchre Hosted Game Startup ==="
+echo "Python: $(python --version 2>&1)"
+echo "Host:   ${HOST:-0.0.0.0}"
+echo "Port:   ${PORT:-8000}"
+echo "Workers: ${WEB_WORKERS:-1}"
+echo "DB URL: ${DATABASE_URL:-(sqlite default)}"
+echo "======================================="
+
+exec python -m web.start

--- a/tests/unit/hosted_play/test_start.py
+++ b/tests/unit/hosted_play/test_start.py
@@ -1,0 +1,72 @@
+"""Tests for web.start — production startup entrypoint."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from web.start import main
+
+
+class TestMain:
+    """Verify main() reads environment and calls uvicorn correctly."""
+
+    def test_default_settings(self):
+        """Default env → host=0.0.0.0, port=8000, workers=1, log_level=info."""
+        with patch.dict("os.environ", {}, clear=True), patch("uvicorn.run") as mock_run:
+            main()
+            mock_run.assert_called_once_with(
+                "web.app:create_app",
+                factory=True,
+                host="0.0.0.0",
+                port=8000,
+                workers=1,
+                log_level="info",
+            )
+
+    def test_env_override(self):
+        """Environment variables override defaults."""
+        env = {
+            "HOST": "127.0.0.1",
+            "PORT": "9090",
+            "WEB_WORKERS": "4",
+            "LOG_LEVEL": "WARNING",
+        }
+        with (
+            patch.dict("os.environ", env, clear=True),
+            patch("uvicorn.run") as mock_run,
+        ):
+            main()
+            mock_run.assert_called_once_with(
+                "web.app:create_app",
+                factory=True,
+                host="127.0.0.1",
+                port=9090,
+                workers=4,
+                log_level="warning",
+            )
+
+    def test_invalid_workers_exits(self):
+        """WEB_WORKERS < 1 should exit with code 1."""
+        env = {"WEB_WORKERS": "0"}
+        with (
+            patch.dict("os.environ", env, clear=True),
+            pytest.raises(SystemExit) as exc,
+        ):
+            main()
+        assert exc.value.code == 1
+
+    def test_module_runnable(self):
+        """``python -m web.start --help`` equivalent: module is importable."""
+        # Just verify the module can be imported without side effects
+        result = subprocess.run(
+            [sys.executable, "-c", "from web.start import main; print('OK')"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+        assert "OK" in result.stdout

--- a/web/start.py
+++ b/web/start.py
@@ -1,0 +1,68 @@
+"""Production startup entrypoint for the Bid Euchre browser game.
+
+Launches uvicorn with the :func:`web.app.create_app` factory, reading
+host/port/worker configuration from environment variables.
+
+Environment variables
+---------------------
+
+====================  ===========  ========================================
+Variable              Default      Purpose
+====================  ===========  ========================================
+``HOST``              ``0.0.0.0``  Bind address
+``PORT``              ``8000``     Bind port (Render injects ``$PORT``)
+``WEB_WORKERS``       ``1``        Uvicorn worker count
+``LOG_LEVEL``         ``info``     Uvicorn log level
+====================  ===========  ========================================
+
+Usage::
+
+    # Direct execution
+    python -m web.start
+
+    # Via module path
+    uv run python -m web.start
+
+    # Render/Docker (PORT injected by platform)
+    python -m web.start
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> None:
+    """Parse environment and launch uvicorn."""
+    # Lazy import so the module can be imported without triggering
+    # uvicorn installation checks at import time.
+    import uvicorn
+
+    host = os.environ.get("HOST", "0.0.0.0")
+    port = int(os.environ.get("PORT", "8000"))
+    workers = int(os.environ.get("WEB_WORKERS", "1"))
+    log_level = os.environ.get("LOG_LEVEL", "info").lower()
+
+    # Validate workers — uvicorn requires >= 1
+    if workers < 1:
+        print(f"WEB_WORKERS must be >= 1, got {workers}", file=sys.stderr)
+        sys.exit(1)
+
+    print(
+        f"Starting Bid Euchre web server: "
+        f"host={host} port={port} workers={workers} log_level={log_level}"
+    )
+
+    uvicorn.run(
+        "web.app:create_app",
+        factory=True,
+        host=host,
+        port=port,
+        workers=workers,
+        log_level=log_level,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Plan
`plans/browser_game/governing_plan.md` — Phase 5 (Deployment & Launch)

## Summary
- Add `web/start.py` — Python module that launches uvicorn with the `create_app()` factory, reading HOST/PORT/WEB_WORKERS/LOG_LEVEL from environment
- Add `scripts/start_hosted.sh` — shell wrapper that prints diagnostics and delegates to `python -m web.start` (Docker CMD / Render start command)
- Add unit tests for the startup module

## Why
Phase 5 deployment requires a production entrypoint that Render/Docker can invoke. The Dockerfile and render.yaml already exist but had no startup script to call. This bridges that gap.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -c 'from web.app import create_app; app = create_app(); print("OK")'
uv run python -c 'from web.start import main; print("Import OK")'
uv run python -m pytest tests/unit/hosted_play/test_start.py -v
make check-quiet
```

## Test Criteria
- **Pass condition:** `web.start.main()` correctly parses env vars and calls `uvicorn.run` with expected args
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_start.py -v`
- **Expected result:** 4/4 tests pass (default settings, env override, invalid workers exit, module importable)

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_start.py -v` — 4/4 pass
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None (new infrastructure only)
- Runtime impact: None (entrypoint only used in production deployment)

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git worktree list` (relevant entry):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a  87f873d6 [brws/phase5-startup-entrypoint]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)