### PR TITLE
feat(ops): integrate monitor findings into controller projection

### DIFF
--- a/src/bid_euchre/ops/control_plane.py
+++ b/src/bid_euchre/ops/control_plane.py
@@ -205,8 +205,65 @@ def _now_iso() -> str:
 
 
 # ---------------------------------------------------------------------------
+# MonitorFinding → dict bridge
+# ---------------------------------------------------------------------------
+
+
+def monitor_findings_to_dicts(
+    findings: list[Any],
+) -> list[dict[str, Any]]:
+    """Convert ``MonitorFinding`` dataclass instances to plain dicts.
+
+    Accepts a list of ``MonitorFinding`` frozen dataclasses (from
+    ``bid_euchre.ops.monitor``) and converts each to a plain dict
+    using ``dataclasses.asdict()``.
+
+    This bridges the monitor module's output type to the dict interface
+    used by the controller's derivation functions, avoiding a hard
+    import-time dependency on the monitor module.
+
+    Example::
+
+        from bid_euchre.ops.monitor import run_monitoring_cycle
+        from bid_euchre.ops.control_plane import (
+            monitor_findings_to_dicts, reconcile,
+        )
+
+        findings = run_monitoring_cycle(skip_pr_check=True)
+        status = reconcile(monitor_findings=monitor_findings_to_dicts(findings))
+    """
+    return [asdict(f) for f in findings]
+
+
+# ---------------------------------------------------------------------------
 # Derivation: monitor findings → actionable items
 # ---------------------------------------------------------------------------
+
+
+def _finding_stable_id(
+    category: str,
+    details: dict[str, Any],
+) -> str:
+    """Generate a deterministic item_id from a monitor finding.
+
+    Uses **category + key identifiers** (lane_id, pr_number, task_id)
+    rather than volatile text (summary) so that the same logical condition
+    maps to the same item_id even when details like check counts change.
+
+    Falls back to including a summary prefix only when no identifying key
+    is available, to avoid collapsing unrelated findings into one id.
+    """
+    lane_id = str(details.get("lane_id", ""))
+    pr_number = str(details.get("pr_number", details.get("number", "")))
+    task_id = str(details.get("task_id", ""))
+
+    # If we have at least one identifying key, use it for dedup.
+    if lane_id or pr_number or task_id:
+        return _stable_id(category, lane_id, pr_number, task_id)
+
+    # Fallback: include summary prefix for findings with no identifiers.
+    summary = str(details.get("summary", ""))
+    return _stable_id(category, summary[:60])
 
 
 def items_from_monitor_findings(
@@ -215,6 +272,9 @@ def items_from_monitor_findings(
     now_iso: str | None = None,
 ) -> list[ActionableItem]:
     """Convert monitor findings into actionable items.
+
+    Accepts findings as plain dicts (the output of
+    :func:`monitor_findings_to_dicts` or ``dataclasses.asdict``).
 
     Skips pure-info capacity summaries (routine noise).
     Maps monitor severities to control-plane severities.
@@ -233,12 +293,7 @@ def items_from_monitor_findings(
         if severity == SEVERITY_INFO and category == CAT_LANE_HEALTH:
             continue
 
-        item_id = _stable_id(
-            category,
-            str(details.get("lane_id", "")),
-            str(details.get("pr_number", details.get("number", ""))),
-            summary[:60],
-        )
+        item_id = _finding_stable_id(category, details)
 
         lane_id = details.get("lane_id")
         pr_number = details.get("pr_number") or details.get("number")
@@ -587,6 +642,7 @@ def save_fleet_status(
 def derive_items(
     *,
     monitor_findings: list[dict[str, Any]] | None = None,
+    monitor_finding_objects: list[Any] | None = None,
     task_packets: list[dict[str, Any]] | None = None,
     unacked_messages: list[dict[str, Any]] | None = None,
     now_iso: str | None = None,
@@ -596,14 +652,34 @@ def derive_items(
 
     This is a **pure function** — it takes pre-loaded data and returns items.
     No I/O, no side effects.
+
+    Args:
+        monitor_findings: Pre-converted dicts (legacy interface).
+        monitor_finding_objects: ``MonitorFinding`` dataclass instances
+            from the monitor module.  Automatically converted to dicts via
+            :func:`monitor_findings_to_dicts`.  If both ``monitor_findings``
+            and ``monitor_finding_objects`` are provided, they are combined.
+        task_packets: Task packet dicts.
+        unacked_messages: Bus message dicts.
+        now_iso: Override for current time (ISO 8601).
+        unacked_message_age_minutes: Age threshold for unacked messages.
     """
     if now_iso is None:
         now_iso = _now_iso()
 
     all_items: list[ActionableItem] = []
 
+    # Combine dict-based and object-based monitor findings.
+    combined_findings: list[dict[str, Any]] = []
     if monitor_findings:
-        all_items.extend(items_from_monitor_findings(monitor_findings, now_iso=now_iso))
+        combined_findings.extend(monitor_findings)
+    if monitor_finding_objects:
+        combined_findings.extend(monitor_findings_to_dicts(monitor_finding_objects))
+
+    if combined_findings:
+        all_items.extend(
+            items_from_monitor_findings(combined_findings, now_iso=now_iso)
+        )
 
     if task_packets:
         all_items.extend(items_from_task_packets(task_packets, now_iso=now_iso))
@@ -629,6 +705,7 @@ def reconcile(
     *,
     runtime_dir: Path | None = None,
     monitor_findings: list[dict[str, Any]] | None = None,
+    monitor_finding_objects: list[Any] | None = None,
     task_packets: list[dict[str, Any]] | None = None,
     unacked_messages: list[dict[str, Any]] | None = None,
     now_iso: str | None = None,
@@ -641,7 +718,11 @@ def reconcile(
     4. Persist the result.
     5. Return the new fleet status.
 
-    If ``monitor_findings`` etc. are not provided, the caller is responsible
+    Accepts monitor findings as either pre-converted dicts
+    (``monitor_findings``) or ``MonitorFinding`` dataclass instances
+    (``monitor_finding_objects``).  Both may be provided and are combined.
+
+    If neither monitor input is provided, the caller is responsible
     for running the monitor cycle first and passing the results.
     """
     if now_iso is None:
@@ -652,6 +733,7 @@ def reconcile(
 
     new_items = derive_items(
         monitor_findings=monitor_findings,
+        monitor_finding_objects=monitor_finding_objects,
         task_packets=task_packets,
         unacked_messages=unacked_messages,
         now_iso=now_iso,

--- a/tests/unit/test_ops_control_plane.py
+++ b/tests/unit/test_ops_control_plane.py
@@ -19,6 +19,7 @@ from bid_euchre.ops.control_plane import (
     STATE_SUPPRESSED,
     ActionableItem,
     FleetStatus,
+    _finding_stable_id,
     ack_item,
     clear_item,
     derive_items,
@@ -29,10 +30,12 @@ from bid_euchre.ops.control_plane import (
     items_from_unacked_messages,
     load_fleet_status,
     merge_with_previous,
+    monitor_findings_to_dicts,
     reconcile,
     save_fleet_status,
     suppress_item,
 )
+from bid_euchre.ops.monitor import MonitorFinding
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1061,3 +1064,295 @@ class TestEdgeCases:
         items = items_from_monitor_findings(findings, now_iso=NOW_ISO)
         assert len(items) == 2
         assert items[0].item_id != items[1].item_id
+
+
+# ---------------------------------------------------------------------------
+# MonitorFinding → dict bridge
+# ---------------------------------------------------------------------------
+
+
+class TestMonitorFindingsToDicts:
+    def test_converts_single_finding(self):
+        finding = MonitorFinding(
+            category="lane_health",
+            severity="high",
+            summary="Lane dead",
+            details={"lane_id": "author-a"},
+        )
+        result = monitor_findings_to_dicts([finding])
+        assert len(result) == 1
+        assert result[0]["category"] == "lane_health"
+        assert result[0]["severity"] == "high"
+        assert result[0]["summary"] == "Lane dead"
+        assert result[0]["details"]["lane_id"] == "author-a"
+
+    def test_converts_multiple_findings(self):
+        findings = [
+            MonitorFinding(
+                category="lane_health",
+                severity="high",
+                summary="Lane A dead",
+                details={"lane_id": "author-a"},
+            ),
+            MonitorFinding(
+                category="pr_status",
+                severity="warn",
+                summary="PR #42 failing",
+                details={"number": 42},
+            ),
+        ]
+        result = monitor_findings_to_dicts(findings)
+        assert len(result) == 2
+        assert result[0]["category"] == "lane_health"
+        assert result[1]["category"] == "pr_status"
+
+    def test_empty_list(self):
+        result = monitor_findings_to_dicts([])
+        assert result == []
+
+    def test_roundtrip_through_items_from_monitor_findings(self):
+        """MonitorFinding → dict → ActionableItem works end-to-end."""
+        finding = MonitorFinding(
+            category="stale_dispatch",
+            severity="warn",
+            summary="Stale dispatch for author-a",
+            details={"lane_id": "author-a", "task_id": "pkt001"},
+        )
+        dicts = monitor_findings_to_dicts([finding])
+        items = items_from_monitor_findings(dicts, now_iso=NOW_ISO)
+        assert len(items) == 1
+        assert items[0].category == "stale_dispatch"
+        assert items[0].severity == "warn"
+        assert items[0].lane_id == "author-a"
+        assert items[0].task_id == "pkt001"
+        assert items[0].source == "monitor"
+
+
+# ---------------------------------------------------------------------------
+# Stable ID robustness (dedup across cycles with changing details)
+# ---------------------------------------------------------------------------
+
+
+class TestFindingStableIdDedup:
+    def test_same_lane_different_summary_same_id(self):
+        """Same logical condition with changing summary text → same item_id."""
+        details = {"lane_id": "author-a"}
+        id1 = _finding_stable_id("lane_health", details)
+        id2 = _finding_stable_id("lane_health", details)
+        assert id1 == id2
+
+    def test_same_pr_different_check_count_same_id(self):
+        """PR findings with changing check counts → same item_id."""
+        details1 = {"number": 42, "failing_checks": 2}
+        details2 = {"number": 42, "failing_checks": 5}
+        id1 = _finding_stable_id("pr_status", details1)
+        id2 = _finding_stable_id("pr_status", details2)
+        assert id1 == id2
+
+    def test_different_lanes_different_ids(self):
+        d1 = {"lane_id": "author-a"}
+        d2 = {"lane_id": "author-b"}
+        assert _finding_stable_id("lane_health", d1) != _finding_stable_id(
+            "lane_health", d2
+        )
+
+    def test_different_categories_same_details_different_ids(self):
+        details = {"lane_id": "author-a"}
+        assert _finding_stable_id("lane_health", details) != _finding_stable_id(
+            "stalled_lane", details
+        )
+
+    def test_no_identifiers_uses_summary_fallback(self):
+        """Findings with no lane/PR/task keys fall back to summary-based id."""
+        d1 = {"summary": "Fleet idle for 90 minutes"}
+        d2 = {"summary": "Something completely different"}
+        id1 = _finding_stable_id("idle_lane", d1)
+        id2 = _finding_stable_id("idle_lane", d2)
+        assert id1 != id2
+
+    def test_finding_dedup_across_cycles_preserves_first_seen(self, tmp_path):
+        """Same logical finding across 2 cycles keeps first_seen_at."""
+        # Cycle 1: PR #50 has 2 failing checks.
+        findings_c1 = [
+            _monitor_finding(
+                category="pr_status",
+                severity="warn",
+                summary="PR #50 has 2 failing checks",
+                details={"number": 50, "failing_checks": 2},
+            )
+        ]
+        status1 = reconcile(
+            runtime_dir=tmp_path, monitor_findings=findings_c1, now_iso=NOW_ISO
+        )
+        assert len(status1.open_items) == 1
+        item_id_c1 = status1.items[0].item_id
+
+        # Cycle 2: Same PR, different check count text.
+        later = "2026-03-24T23:00:00+00:00"
+        findings_c2 = [
+            _monitor_finding(
+                category="pr_status",
+                severity="warn",
+                summary="PR #50 has 5 failing checks",
+                details={"number": 50, "failing_checks": 5},
+            )
+        ]
+        status2 = reconcile(
+            runtime_dir=tmp_path, monitor_findings=findings_c2, now_iso=later
+        )
+        # Same logical finding — should keep the same item_id.
+        item_id_c2 = [i for i in status2.items if i.state == STATE_OPEN][0].item_id
+        assert item_id_c1 == item_id_c2
+        # first_seen_at should be from cycle 1, not cycle 2.
+        open_items = [i for i in status2.items if i.state == STATE_OPEN]
+        assert open_items[0].first_seen_at == NOW_ISO
+
+
+# ---------------------------------------------------------------------------
+# derive_items / reconcile with MonitorFinding objects
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveItemsWithMonitorObjects:
+    def test_accepts_monitor_finding_objects(self):
+        findings = [
+            MonitorFinding(
+                category="stale_dispatch",
+                severity="warn",
+                summary="Stale dispatch",
+                details={"lane_id": "author-a"},
+            )
+        ]
+        items = derive_items(monitor_finding_objects=findings, now_iso=NOW_ISO)
+        assert len(items) == 1
+        assert items[0].source == "monitor"
+        assert items[0].category == "stale_dispatch"
+
+    def test_combines_dict_and_object_findings(self):
+        dict_findings = [
+            _monitor_finding(
+                severity="high",
+                summary="Lane A dead",
+                details={"lane_id": "author-a"},
+            )
+        ]
+        obj_findings = [
+            MonitorFinding(
+                category="pr_status",
+                severity="warn",
+                summary="PR #99 failing",
+                details={"number": 99},
+            )
+        ]
+        items = derive_items(
+            monitor_findings=dict_findings,
+            monitor_finding_objects=obj_findings,
+            now_iso=NOW_ISO,
+        )
+        categories = {i.category for i in items}
+        assert "lane_health" in categories
+        assert "pr_status" in categories
+        assert len(items) == 2
+
+    def test_none_objects_ignored(self):
+        items = derive_items(
+            monitor_finding_objects=None,
+            now_iso=NOW_ISO,
+        )
+        assert items == []
+
+
+class TestReconcileWithMonitorObjects:
+    def test_reconcile_with_monitor_finding_objects(self, tmp_path):
+        findings = [
+            MonitorFinding(
+                category="lane_health",
+                severity="high",
+                summary="Lane dead",
+                details={"lane_id": "author-b"},
+            )
+        ]
+        status = reconcile(
+            runtime_dir=tmp_path,
+            monitor_finding_objects=findings,
+            now_iso=NOW_ISO,
+        )
+        assert status.cycle_count == 1
+        assert len(status.open_items) == 1
+        assert status.items[0].lane_id == "author-b"
+
+    def test_reconcile_combines_dict_and_object(self, tmp_path):
+        dict_findings = [
+            _monitor_finding(
+                severity="warn",
+                summary="Stale dispatch",
+                category="stale_dispatch",
+                details={"lane_id": "flex-a"},
+            )
+        ]
+        obj_findings = [
+            MonitorFinding(
+                category="approval_stall",
+                severity="high",
+                summary="Lane blocked on approval",
+                details={"lane_id": "author-c"},
+            )
+        ]
+        status = reconcile(
+            runtime_dir=tmp_path,
+            monitor_findings=dict_findings,
+            monitor_finding_objects=obj_findings,
+            now_iso=NOW_ISO,
+        )
+        assert len(status.open_items) == 2
+        categories = {i.category for i in status.open_items}
+        assert "stale_dispatch" in categories
+        assert "approval_stall" in categories
+
+    def test_monitor_objects_auto_clear_across_cycles(self, tmp_path):
+        """MonitorFinding objects correctly participate in auto-clear lifecycle."""
+        findings_c1 = [
+            MonitorFinding(
+                category="lane_health",
+                severity="high",
+                summary="Lane dead",
+                details={"lane_id": "author-d"},
+            )
+        ]
+        reconcile(
+            runtime_dir=tmp_path,
+            monitor_finding_objects=findings_c1,
+            now_iso=NOW_ISO,
+        )
+        # Second cycle: finding gone → auto-cleared.
+        status2 = reconcile(runtime_dir=tmp_path, now_iso=NOW_ISO)
+        cleared = [i for i in status2.items if i.state == STATE_CLEARED]
+        assert len(cleared) == 1
+        assert cleared[0].lane_id == "author-d"
+
+    def test_monitor_objects_ack_preserved_across_cycles(self, tmp_path):
+        """Acked item from MonitorFinding stays acked when re-detected."""
+        findings = [
+            MonitorFinding(
+                category="stalled_lane",
+                severity="warn",
+                summary="Author-a stalled",
+                details={"lane_id": "author-a"},
+            )
+        ]
+        status1 = reconcile(
+            runtime_dir=tmp_path,
+            monitor_finding_objects=findings,
+            now_iso=NOW_ISO,
+        )
+        ack_item(status1, status1.items[0].item_id)
+        save_fleet_status(status1, tmp_path)
+
+        # Re-detect same finding.
+        status2 = reconcile(
+            runtime_dir=tmp_path,
+            monitor_finding_objects=findings,
+            now_iso=NOW_ISO,
+        )
+        target = [i for i in status2.items if i.lane_id == "author-a"]
+        assert target[0].state == STATE_ACKED


### PR DESCRIPTION
## Plan
`plans/sessions/2026-03-24_controller-first-control-plane-handoff.md` — PR 2 scope (controller projection).
Task packet `95c1f2198916` — SP-4-07 P11.

## Summary
- Add `monitor_findings_to_dicts()` bridge function to convert `MonitorFinding` dataclasses to the dict interface used by the controller
- Fix `_finding_stable_id()` to use category + key identifiers (lane_id, pr_number, task_id) instead of volatile summary text — prevents item churn when summaries change between cycles
- Extend `derive_items()` and `reconcile()` with `monitor_finding_objects` parameter that accepts `MonitorFinding` instances directly
- 17 new unit tests covering bridge conversion, dedup robustness, and full lifecycle (auto-clear, ack preservation)

## Why
The controller and monitor were loosely coupled through a raw dict interface with no type-safe bridge. The stable ID generation included volatile summary text, causing the same logical condition (e.g., "PR #42 has 2 failing checks" → "PR #42 has 5 failing checks") to create new items each cycle instead of updating the existing one. This lost `first_seen_at` tracking and created item churn.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_control_plane.py -v
make check-quiet
```

## Test Criteria
- **Pass condition:** 87 tests pass (70 existing + 17 new), no regressions
- **Verification command:** `uv run python -m pytest tests/unit/test_ops_control_plane.py -v`
- **Expected result:** `87 passed`

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_control_plane.py -v` — 87 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None (ops infrastructure only)
- Runtime impact: None (pure function changes, no I/O added)

## Risk level
- [x] Low (ops tooling)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c
```

`git worktree list` (relevant line):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c  99cbc53f [feat/controller-monitor-integration]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)