### PR TITLE
fix(ops): honor TTL expiry in ack status and skip expired in escalation

### DIFF
--- a/src/bid_euchre/ops/message_bus.py
+++ b/src/bid_euchre/ops/message_bus.py
@@ -1006,12 +1006,18 @@ def check_ack_status(
     message_id: str,
     recipient_lane: str,
     bus_root: Path | None = None,
+    *,
+    now: float | None = None,
 ) -> str | None:
     """Check if a message was acked by the recipient.
 
     Looks up the latest record for *message_id* in *recipient_lane*'s inbox
     and returns the current status string (``'pending'``, ``'acked'``,
     ``'resolved'``, etc.) or ``None`` if the message is not found.
+
+    If the message is still in a non-terminal status (``pending`` or
+    ``delivered``) but its ``payload.ttl_seconds`` has elapsed, returns
+    ``'expired'`` instead of the raw status (#1601).
 
     This lets a sender verify that the recipient has acknowledged a message
     without reading the full inbox.
@@ -1020,6 +1026,7 @@ def check_ack_status(
         message_id: The ID of the message to check.
         recipient_lane: The lane whose inbox to look in.
         bus_root: Override for bus root directory.
+        now: Override for current time as Unix timestamp (for testing).
 
     Returns:
         The current status string, or ``None`` if the message is not found.
@@ -1036,7 +1043,23 @@ def check_ack_status(
     if latest is None:
         return None
 
-    return latest.get("status", "pending")
+    status = latest.get("status", "pending")
+
+    # Honor TTL expiry: if the message is non-terminal and its TTL has
+    # elapsed, report "expired" rather than the stale status (#1601).
+    if status in ("pending", "delivered"):
+        ttl = latest.get("payload", {}).get("ttl_seconds")
+        if ttl is not None:
+            created = latest.get("created_at", "")
+            try:
+                created_ts = datetime.fromisoformat(created).timestamp()
+                current_time = now if now is not None else time.time()
+                if current_time - created_ts > ttl:
+                    return "expired"
+            except (ValueError, TypeError):
+                pass
+
+    return status
 
 
 def escalate_unacked(
@@ -1046,6 +1069,7 @@ def escalate_unacked(
     bus_root: Path | None = None,
     *,
     events_dir: Path | None = None,
+    now: float | None = None,
 ) -> list[str]:
     """Find unacked outbound messages older than *max_age_minutes* and escalate.
 
@@ -1057,12 +1081,16 @@ def escalate_unacked(
     type ``escalation``) referencing the original via ``parent_message_id``,
     and sent to the recipient.
 
+    Messages whose ``payload.ttl_seconds`` has already elapsed are skipped —
+    expired messages should not trigger escalation (#1601).
+
     Args:
         sender_lane: The lane that sent the original messages.
         recipient_lane: The lane whose inbox to scan for unacked messages.
         max_age_minutes: Age threshold in minutes before escalation fires.
         bus_root: Override for bus root directory.
         events_dir: Override for events directory (for testing).
+        now: Override for current time as Unix timestamp (for testing).
 
     Returns:
         List of escalation message IDs sent.
@@ -1077,7 +1105,8 @@ def escalate_unacked(
         if mid:
             by_id[mid] = rec
 
-    cutoff_ts = time.time() - (max_age_minutes * 60)
+    current_time = now if now is not None else time.time()
+    cutoff_ts = current_time - (max_age_minutes * 60)
     unacked_statuses = {"pending", "delivered"}
     escalation_ids: list[str] = []
 
@@ -1115,6 +1144,12 @@ def escalate_unacked(
 
         if created_ts > cutoff_ts:
             continue  # Not old enough yet
+
+        # Skip messages whose TTL has already elapsed (#1601) — expired
+        # messages should not trigger escalation.
+        ttl = rec.get("payload", {}).get("ttl_seconds")
+        if ttl is not None and current_time - created_ts > ttl:
+            continue
 
         # Create and send an escalation message
         esc_msg = create_message(

--- a/tests/integration/test_bilateral_messaging.py
+++ b/tests/integration/test_bilateral_messaging.py
@@ -23,7 +23,7 @@ Closes #1570.
 from __future__ import annotations
 
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -1351,9 +1351,10 @@ class TestEscalation:
         self, bus_root: Path, events_dir: Path
     ) -> None:
         """An unacked message older than threshold triggers escalation."""
-        # Send a message with an old created_at timestamp
-        old_time = (
-            datetime.now(timezone.utc).replace(year=2025).strftime("%Y-%m-%dT%H:%M:%SZ")
+        # Send a message with a created_at 30 minutes in the past — old enough
+        # to trigger escalation but within the default 24-hour TTL (#1601).
+        old_time = (datetime.now(timezone.utc) - timedelta(minutes=30)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
         )
         msg = BusMessage(
             message_id="old_msg_001",

--- a/tests/unit/test_ops_message_bus.py
+++ b/tests/unit/test_ops_message_bus.py
@@ -2024,6 +2024,56 @@ class TestCheckAckStatus:
         status = check_ack_status(msg.message_id, "author-a", bus_root)
         assert status is None
 
+    def test_ttl_expired_reports_expired(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """A pending message past its TTL should report 'expired' (#1601)."""
+        msg = create_message("ops", "orch", "progress", "Status update")
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        # Advance time past the default TTL
+        future = time.time() + DEFAULT_TTL_SECONDS + 1
+        status = check_ack_status(msg.message_id, "orch", bus_root, now=future)
+        assert status == "expired"
+
+    def test_ttl_not_expired_reports_pending(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """A pending message within its TTL should still report 'pending'."""
+        msg = create_message("ops", "orch", "progress", "Status update")
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        # Time within the TTL window
+        status = check_ack_status(
+            msg.message_id, "orch", bus_root, now=time.time() + 10
+        )
+        assert status == "pending"
+
+    def test_acked_message_not_affected_by_ttl(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """An acked message should remain 'acked' even past TTL (#1601)."""
+        msg = create_message("ops", "orch", "progress", "Status update")
+        send_message(msg, bus_root, events_dir=events_dir)
+        ack_message(msg.message_id, "orch", bus_root, events_dir=events_dir)
+
+        # Advance time past TTL — acked status should be preserved
+        future = time.time() + DEFAULT_TTL_SECONDS + 1
+        status = check_ack_status(msg.message_id, "orch", bus_root, now=future)
+        assert status == "acked"
+
+    def test_delivered_ttl_expired_reports_expired(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """A delivered (but not acked) message past TTL reports 'expired' (#1601)."""
+        msg = create_message("ops", "orch", "progress", "Status update")
+        send_message(msg, bus_root, events_dir=events_dir)
+        mark_delivered(msg.message_id, "orch", bus_root, events_dir=events_dir)
+
+        future = time.time() + DEFAULT_TTL_SECONDS + 1
+        status = check_ack_status(msg.message_id, "orch", bus_root, now=future)
+        assert status == "expired"
+
 
 # ---------------------------------------------------------------------------
 # escalate_unacked
@@ -2182,6 +2232,41 @@ class TestEscalateUnacked:
         inbox = read_inbox("orch", bus_root, auto_expire=False, limit=100)
         esc = [m for m in inbox if m["message_id"] == escalation_ids[0]]
         assert esc[0]["parent_message_id"] == msg2.message_id
+
+    def test_skips_ttl_expired_messages(self, bus_root: Path, events_dir: Path) -> None:
+        """Messages past their TTL should not be escalated (#1601)."""
+        msg = create_message("ops", "orch", "progress", "Check status")
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        # Advance time past the default TTL — message is expired even though
+        # its status hasn't been formally updated yet.
+        future = time.time() + DEFAULT_TTL_SECONDS + 1
+        escalation_ids = escalate_unacked(
+            "ops",
+            "orch",
+            max_age_minutes=0,
+            bus_root=bus_root,
+            events_dir=events_dir,
+            now=future,
+        )
+        assert len(escalation_ids) == 0
+
+    def test_escalates_within_ttl(self, bus_root: Path, events_dir: Path) -> None:
+        """Messages within their TTL should still be escalated normally."""
+        msg = create_message("ops", "orch", "progress", "Check status")
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        # Time within the TTL window — should still escalate
+        soon = time.time() + 10
+        escalation_ids = escalate_unacked(
+            "ops",
+            "orch",
+            max_age_minutes=0,
+            bus_root=bus_root,
+            events_dir=events_dir,
+            now=soon,
+        )
+        assert len(escalation_ids) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `check_ack_status` now returns `"expired"` for messages whose `payload.ttl_seconds` has elapsed, instead of the stale `pending`/`delivered` status
- `escalate_unacked` skips messages whose TTL has expired before creating escalation messages (avoids escalating dead messages)
- Both functions gain a `now` parameter for testability
- Integration test updated to use a 30-minute-old timestamp (within TTL) instead of year-old timestamp (past TTL)

## Why
Convention follow-up from PR #1599 review. Three edge cases in message bus TTL/escalation handling:
1. `check_ack_status` ignored TTL expiry — callers saw stale "pending" for expired messages
2. `escalate_unacked` created escalation messages for already-expired messages
3. Repeat escalation suppression (already fixed by #1610)

Closes #1601

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_ops_message_bus.py -v -k "ttl_expired or escalates_within_ttl"
uv run python -m pytest tests/integration/test_bilateral_messaging.py::TestEscalation -v
make check-quiet  # All 6892 tests pass
```

## Tests
- 6 new unit tests: TTL-expired status reporting, delivered+expired, acked unaffected, escalation skip, escalation within TTL
- 1 integration test updated to use valid TTL window
- `make check-quiet` passes (153 message_bus unit tests, full suite green)

## Worktree proof
```
pwd: Bid-Euchre-steward-author-d
branch: fix/ttl-escalation-edge-cases
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)