### PR TITLE
fix(ops): convention follow-ups for check-in and orchestrator docs

### DIFF
--- a/.claude/agents/steward-orchestrator.md
+++ b/.claude/agents/steward-orchestrator.md
@@ -169,9 +169,16 @@ context but leaves cron jobs running — they will continue firing on a
 lane the orchestrator considers stopped.
 
 Shutdown sequence:
-1. Send `/park` to the lane's tmux pane
-2. Wait for confirmation that all cron jobs are deleted
-3. Send `/clear` to reset conversation context
+1. Complete or reassign any active task packet for the lane:
+   ```bash
+   # If the lane has finished its work:
+   uv run python scripts/internal/ops.py task complete <PACKET_ID>
+   # If reassigning unfinished work:
+   uv run python scripts/internal/ops.py task update <PACKET_ID> --status pending --owner ""
+   ```
+2. Send `/park` to the lane's tmux pane (cleans up cron jobs)
+3. Wait for confirmation that all cron jobs are deleted
+4. Send `/clear` to reset conversation context
 
 ## Named Skills
 

--- a/.claude/skills/check-in/SKILL.md
+++ b/.claude/skills/check-in/SKILL.md
@@ -32,8 +32,10 @@ monitoring infrastructure.
 
 1. **Read pending inbox messages (priority-sorted):**
    ```bash
-   uv run python scripts/internal/ops.py inbox --lane orchestrator --status pending
+   uv run python scripts/internal/ops.py inbox --lane orchestrator --status pending --include-native
    ```
+   The `--include-native` flag imports any messages from the Claude native inbox
+   into the message bus before listing, so nothing is missed.
    Manually sort results by priority: P0 (`supervisor_alert`, `recovery`) first,
    then P1 (`completion`, `escalation`, `blocker`), then P2 (`ack`, `progress`).
 
@@ -55,8 +57,8 @@ monitoring infrastructure.
    # Ack individual high-priority messages after acting on them
    uv run python scripts/internal/ops.py inbox ack <MSG_ID> --lane orchestrator
 
-   # Bulk-ack low-priority informational messages
-   uv run python scripts/internal/ops.py inbox ack-all --lane orchestrator --type ack
+   # Bulk-ack low-priority informational messages (filter by summary pattern)
+   uv run python scripts/internal/ops.py inbox ack-all --lane orchestrator --filter-summary "Task received|progress"
    ```
 
 4. **Surface unacked HIGH alerts prominently.** If any `supervisor_alert` or


### PR DESCRIPTION
## Plan
N/A — convention follow-ups from review coordinator findings.

## Summary
- Add `--include-native` flag to inbox poll in check-in skill (#1593)
- Replace unsupported `ack-all --type` with valid `--filter-summary` syntax (#1593)
- Add task packet transition step to lane shutdown flow in orchestrator docs (#1594)

## Why
Review coordinator findings from PRs #1590 and #1592 identified three
docs/skill issues: missing native inbox import, invalid CLI flag in example,
and incomplete lane shutdown procedure.

## Repro / Validation
**Command(s) run:**
```bash
git diff --stat
# 2 files changed, 15 insertions(+), 6 deletions(-)
```

**Config (if applicable):** N/A — docs-only change

**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** All three findings addressed in the correct files
- **Verification command:** `grep -c "include-native" .claude/skills/check-in/SKILL.md && grep -c "filter-summary" .claude/skills/check-in/SKILL.md && grep -c "task complete" .claude/agents/steward-orchestrator.md`
- **Expected result:** Each grep returns 1 (one match per fix)

## Tests
- [x] Docs-only change — no Python tests affected

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
```

`git worktree list` (abbreviated):
```
Bid-Euchre-steward-flex-a  4c44a4c3 [fix/convention-followups-1593-1594]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

Closes #1593, closes #1594.