### PR TITLE
fix: convention follow-ups from review coordinator (#1593, #1594, #1589)

### DIFF
--- a/.claude/agents/steward-orchestrator.md
+++ b/.claude/agents/steward-orchestrator.md
@@ -169,9 +169,12 @@ context but leaves cron jobs running — they will continue firing on a
 lane the orchestrator considers stopped.
 
 Shutdown sequence:
-1. Send `/park` to the lane's tmux pane
-2. Wait for confirmation that all cron jobs are deleted
-3. Send `/clear` to reset conversation context
+1. If the lane has a dispatched task packet, transition it:
+   - Merged PR → `uv run python scripts/internal/ops.py task complete <PACKET_ID>`
+   - Incomplete work → return packet to pending for reassignment
+2. Send `/park` to the lane's tmux pane (cleans up cron jobs)
+3. Wait for confirmation that all cron jobs are deleted
+4. Send `/clear` to reset conversation context
 
 ## Named Skills
 

--- a/.claude/skills/check-in/SKILL.md
+++ b/.claude/skills/check-in/SKILL.md
@@ -32,10 +32,12 @@ monitoring infrastructure.
 
 1. **Read pending inbox messages (priority-sorted):**
    ```bash
-   uv run python scripts/internal/ops.py inbox --lane orchestrator --status pending
+   uv run python scripts/internal/ops.py inbox --lane orchestrator --status pending --include-native
    ```
-   Manually sort results by priority: P0 (`supervisor_alert`, `recovery`) first,
-   then P1 (`completion`, `escalation`, `blocker`), then P2 (`ack`, `progress`).
+   The `--include-native` flag imports Claude native inbox messages alongside
+   custom bus messages. Manually sort results by priority: P0 (`supervisor_alert`,
+   `recovery`) first, then P1 (`completion`, `escalation`, `blocker`), then P2
+   (`ack`, `progress`).
 
 2. **Filter for high-priority message types** — process these BEFORE any other
    status checks:
@@ -56,7 +58,7 @@ monitoring infrastructure.
    uv run python scripts/internal/ops.py inbox ack <MSG_ID> --lane orchestrator
 
    # Bulk-ack low-priority informational messages
-   uv run python scripts/internal/ops.py inbox ack-all --lane orchestrator --type ack
+   uv run python scripts/internal/ops.py inbox ack-all --lane orchestrator --filter-summary "^(ack|progress)"
    ```
 
 4. **Surface unacked HIGH alerts prominently.** If any `supervisor_alert` or

--- a/tests/integration/test_bilateral_messaging.py
+++ b/tests/integration/test_bilateral_messaging.py
@@ -28,6 +28,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.integration
+
 from bid_euchre.ops.message_bus import (
     VALID_MESSAGE_PRIORITIES,
     VALID_MESSAGE_STATUSES,


### PR DESCRIPTION
## Summary

- **#1593**: Fix check-in skill — add `--include-native` to inbox poll, replace unsupported `ack-all --type` with `--filter-summary`
- **#1594**: Add task packet transition step to lane shutdown flow in orchestrator agent doc
- **#1589**: Add `pytestmark = pytest.mark.integration` to bilateral messaging test module

## Why

Convention follow-ups flagged by the review coordinator on PRs #1590, #1592, and #1584. These are documentation and test convention fixes.

**Note:** #1578 (`web/export.py` ORDER BY concern) is already addressed — the file has an inline comment explaining the tradeoff (lines 169-176, referencing `#1578`). Closing separately.

## Repro / Validation

```bash
uv run python -m pytest tests/integration/test_bilateral_messaging.py -v
# Expected: 85 passed
```

## Tests

```bash
uv run python -m pytest tests/integration/test_bilateral_messaging.py -v  # 85 passed
uv run ruff check tests/integration/test_bilateral_messaging.py           # All checks passed
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-scratch
branch: fix/convention-followups-batch
```

Closes #1593, closes #1594, closes #1589

🤖 Generated with [Claude Code](https://claude.com/claude-code)