### PR TITLE
fix(docs): recovering-context reads current lane inbox, run-fleet deduplicates cron

### DIFF
--- a/.claude/skills/recovering-context/SKILL.md
+++ b/.claude/skills/recovering-context/SKILL.md
@@ -13,9 +13,11 @@ Start every session by recovering project context from MEMORY.md before beginnin
    - Load the complete project memory file
    - Parse current project state and recent completions
 
-2. **Scan inbox for carry-forward alerts** (orchestrator lanes only):
+2. **Scan inbox for carry-forward alerts** (all lanes):
    ```bash
-   uv run python scripts/internal/ops.py inbox --lane orchestrator --status pending
+   # Detect current lane from CLAUDE_AGENT_NAME or worktree directory name
+   LANE="${CLAUDE_AGENT_NAME:-$(basename "$PWD" | sed 's/^Bid-Euchre-steward-//')}"
+   uv run python scripts/internal/ops.py inbox --lane "$LANE" --status pending
    ```
    If unacked P0/P1 messages exist from a previous session, surface them
    **before any other work**. These represent conditions the previous session

--- a/.claude/skills/run-fleet/SKILL.md
+++ b/.claude/skills/run-fleet/SKILL.md
@@ -19,14 +19,29 @@ mergeable throughput across all defined tracks.
 Before entering the main dispatch loop:
 
 1. Recover context (`/recovering-context` or read MEMORY.md)
-2. Check dashboard health: `uv run python scripts/internal/ops.py dashboard --json`
-3. Bulk-refresh idle lanes:
+2. **Set up inbox polling cron** — ensures inbox is read even if the
+   orchestrator gets absorbed in a long task and skips check-in cycles.
+   **Deduplicate first:** list existing crons and delete any stale
+   inbox-poll cron before creating a new one (prevents duplicates when
+   `/run-fleet` is re-invoked or the session is resumed):
+   ```
+   CronList  → scan for any cron whose command contains "ops.py inbox"
+   CronDelete <id>  → remove each matching cron
+
+   CronCreate: every 2 minutes, run:
+     uv run python scripts/internal/ops.py inbox --lane orchestrator --status pending
+     If P0 messages found, surface them immediately.
+   ```
+   This is the backup mechanism. The primary mechanism is step 0 of every
+   dispatch cycle (see Dispatch Discipline below).
+3. Check dashboard health: `uv run python scripts/internal/ops.py dashboard --json`
+4. Bulk-refresh idle lanes:
    ```bash
    uv run python scripts/internal/ops.py lane refresh --all-idle
    ```
-4. Triage inbox and open issues; route ambiguous or multi-PR shaping work to
+5. Triage inbox and open issues; route ambiguous or multi-PR shaping work to
    `steward-analyst`
-5. Define Wave 1 candidates
+6. Define Wave 1 candidates
 
 ## Primary Goal
 
@@ -61,6 +76,24 @@ Maximize safe, mergeable throughput across all defined tracks.
 ## Dispatch Discipline
 
 Before each dispatch cycle:
+
+0. **MANDATORY: Poll inbox for P0/P1 messages**
+   ```bash
+   uv run python scripts/internal/ops.py inbox --lane orchestrator --status pending
+   ```
+   Scan pending messages and classify by priority:
+   - **P0 (urgent):** `supervisor_alert`, `recovery` — **STOP. Process these
+     before dispatching any new work.** These represent active incidents that
+     may invalidate planned dispatches.
+   - **P1 (high):** `completion`, `escalation`, `blocker` — process completions
+     (to free lanes) and escalations (to unblock lanes) before evaluating new
+     dispatch candidates.
+   - **P2 (normal/low):** `ack`, `progress` — note and continue.
+
+   If you skip this step, you risk dispatching into broken lanes, missing
+   merge-conflict alerts, or duplicating work that another lane already
+   completed. The overnight run of 2026-03-24 proved this: 25+ HIGH alerts
+   went unread for 7 hours because the orchestrator never polled its inbox.
 
 1. Check lane health, dirty worktrees, stale packets, inbox backlog, open
    PRs, newly opened or updated GitHub issues, current task lists, and


### PR DESCRIPTION
## Summary
- Make `/recovering-context` detect the current lane dynamically (via `CLAUDE_AGENT_NAME` or worktree directory name) instead of hardcoding `--lane orchestrator`
- Add `CronList` / `CronDelete` dedup step before `CronCreate` in `/run-fleet` startup checklist (prevents duplicate crons on re-invocation)
- Restore the inbox-poll cron step and mandatory dispatch step 0 that were accidentally reverted by PR #1617

## Why
PR #1603 added inbox-first contract enforcement to these skills, but:
1. The review found `recovering-context` should work for all lanes, not just orchestrator (#1607)
2. The review found `run-fleet` should deduplicate crons before creating (#1607)
3. PR #1617 accidentally reverted both run-fleet additions (cron step + dispatch step 0)

Closes #1607

## Repro / Validation
```bash
# recovering-context uses dynamic lane detection
grep -c 'CLAUDE_AGENT_NAME' .claude/skills/recovering-context/SKILL.md
# Expected: 1

# run-fleet has cron dedup
grep -c 'CronList\|CronDelete' .claude/skills/run-fleet/SKILL.md
# Expected: 2

# run-fleet has mandatory dispatch step 0
grep -c 'MANDATORY.*Poll inbox' .claude/skills/run-fleet/SKILL.md
# Expected: 1

make check-quiet  # All checks pass
```

## Test Criteria
- **Pass condition:** All three grep checks return >= 1; `make check-quiet` passes
- **Verification:** See Repro / Validation above

## Tests
- [x] `make check-quiet` passes (docs-only PR, no Python changes)
- [x] Content verification via grep checks (all pass)

## Expected impact
- Metrics impact: None (skill docs only)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)