### PR TITLE
fix(test): add pytestmark integration marker to bilateral messaging tests

### DIFF
--- a/tests/integration/test_bilateral_messaging.py
+++ b/tests/integration/test_bilateral_messaging.py
@@ -28,6 +28,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.integration
+
 from bid_euchre.ops.message_bus import (
     VALID_MESSAGE_PRIORITIES,
     VALID_MESSAGE_STATUSES,


### PR DESCRIPTION
## Summary
- Add `pytestmark = pytest.mark.integration` to `test_bilateral_messaging.py`
- Ensures the module is properly marked for marker-based test selection, consistent with other integration test modules

## Why
Follow-up from review coordinator finding on PR #1584. The test module was missing the standard integration marker.

Note: PR #1670 was closed because #1669 already merged the fixes for #1593 and #1594. This PR contains only the remaining fix for #1589.

Closes #1589.

## Repro / Validation
```bash
# Verify pytestmark is present and tests pass
uv run python -m pytest tests/integration/test_bilateral_messaging.py -v
# 85 passed
```

## Tests
- `uv run python -m pytest tests/integration/test_bilateral_messaging.py -v` — 85 passed
- `make check-quiet` — passes (1 flaky failure in unrelated test_hook_dispatchers.py, passes on rerun)

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-scratch
git worktree: Bid-Euchre-steward-author-scratch
branch: fix/pytestmark-bilateral
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)