### PR TITLE
fix(web): add write capability check to /ready endpoint

### DIFF
--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -1555,3 +1555,31 @@ class TestReadyEndpoint:
             assert body == {"status": "unavailable"}
         finally:
             app.state.session_factory = original_factory
+
+    def test_ready_returns_503_when_write_fails(self, client):
+        """When the DB is read-only, /ready returns 503."""
+        from unittest.mock import MagicMock
+
+        app = client.app
+        original_factory = app.state.session_factory
+
+        def read_only_factory():
+            session = MagicMock()
+
+            def execute_side_effect(stmt, *args, **kwargs):
+                sql = str(stmt).upper()
+                if sql.startswith("SELECT"):
+                    return MagicMock()
+                raise Exception("read-only filesystem")
+
+            session.execute.side_effect = execute_side_effect
+            return session
+
+        app.state.session_factory = read_only_factory
+        try:
+            resp = client.get("/ready")
+            assert resp.status_code == 503
+            body = resp.json()
+            assert body == {"status": "unavailable"}
+        finally:
+            app.state.session_factory = original_factory

--- a/web/routes.py
+++ b/web/routes.py
@@ -276,14 +276,21 @@ async def health():
 
 @router.get("/ready")
 async def ready(request: Request):
-    """Readiness probe — checks DB connectivity.
+    """Readiness probe — checks DB read and write capability.
 
-    Returns 200 if the database is reachable, 503 otherwise.
+    Returns 200 if the database supports both reads and writes, 503 otherwise.
     """
     try:
         session = _get_session(request)
         try:
+            # Read check
             session.execute(text("SELECT 1"))
+            # Write check — session-scoped temp table, cleaned up on close
+            session.execute(
+                text("CREATE TEMPORARY TABLE IF NOT EXISTS _ready_check (v INTEGER)")
+            )
+            session.execute(text("INSERT INTO _ready_check (v) VALUES (1)"))
+            session.execute(text("DELETE FROM _ready_check"))
         finally:
             session.close()
     except Exception:


### PR DESCRIPTION
## Plan
N/A — follow-up from PR #1634

## Summary
- `/ready` endpoint now verifies both read **and** write DB capability
- Uses session-scoped temp table (CREATE, INSERT, DELETE) for write check
- Added test for write-failure scenario (read succeeds but write fails → 503)

## Why
The readiness probe previously only did `SELECT 1`, which can succeed even on
a read-only filesystem or when write permissions are revoked. A deployment probe
should verify full operational capability.

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/hosted_play/test_routes.py -k ready -v`
- `make check-quiet`

**Config (if applicable):** N/A

**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** 4 ready-endpoint tests pass, including the new write-failure test
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_routes.py -k ready -v`
- **Expected result:** 4 passed

## Tests
- [x] `uv run python -m pytest -m "not slow" tests/`
- [ ] Integration (if engine/rules changed): N/A
- [x] Other: `make check-quiet` — all checks passed

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): Negligible — adds 3 trivial SQL statements to readiness probe

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d   c6f9e4fa [fix/ready-endpoint-write-check]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

Closes #1641