### PR TITLE
fix(web): point Render healthCheckPath to /ready endpoint

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -18,7 +18,7 @@ services:
     branch: main
     plan: free
     dockerfilePath: ./Dockerfile
-    healthCheckPath: /
+    healthCheckPath: /ready
     autoDeploy: true
     envVars:
       - key: DATABASE_URL


### PR DESCRIPTION
## Plan
N/A — trivial config fix

## Summary
- Change `render.yaml` `healthCheckPath` from `/` to `/ready`

## Why
Render was probing `/` (the root route) for health checks instead of the
purpose-built `/ready` endpoint that checks database connectivity. This means
Render could mark the service as healthy even when the DB is unreachable.

## Repro / Validation
**Command(s) run:**
```bash
grep healthCheckPath render.yaml
# Output: healthCheckPath: /ready

uv run python -m pytest tests/unit/hosted_play/test_routes.py -k "health or ready" -v
# 5 passed

make check-quiet
# ✓ All checks passed
```

## Test Criteria
- **Pass condition:** `healthCheckPath` in render.yaml points to `/ready`
- **Verification command:** `grep healthCheckPath render.yaml`
- **Expected result:** `    healthCheckPath: /ready`

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_routes.py -k "health or ready"` — 5 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: none
- Runtime impact: Render health probes now hit `/ready` which validates DB connectivity

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git worktree list`:
```
Bid-Euchre-steward-brws-author-a   502f1452 [fix/render-healthcheck-path]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] PR is focused (one concept)

Closes #1686