### PR TITLE
fix(docs): update .env.example comments to reflect CORS/MODELS_DIR wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,10 +23,9 @@ DATABASE_URL=sqlite:///hosted_play.db
 # ---------------------------------------------------------------------------
 # CORS
 # ---------------------------------------------------------------------------
-# Comma-separated origin allowlist (read into HostedPlayConfig).
-# NOTE: not yet wired to CORSMiddleware — the middleware currently
-# hardcodes allow_origins=["*"].  Set this now so it's ready when the
-# CORS middleware is updated to use cfg.allowed_origins.
+# Comma-separated origin allowlist passed to CORSMiddleware via
+# HostedPlayConfig.allowed_origins (wired in app.py).
+# In production, restrict to your domain(s).
 # Example: https://bideuchre.example.com,https://staging.bideuchre.example.com
 ALLOWED_ORIGINS=*
 
@@ -44,7 +43,7 @@ APP_URL=http://localhost:8000
 DEFAULT_MODEL_ID=heuristic
 
 # Directory containing model artifact files (optional).
-# Reserved for future model auto-discovery; not yet used at runtime.
+# Used by AIManager to resolve relative artifact paths at runtime.
 # MODELS_DIR=
 
 # Path to a specific hybrid-OLSA model artifact file (optional).


### PR DESCRIPTION
## Summary
- Updated `.env.example` CORS comment: removed "not yet wired to CORSMiddleware" language, now accurately states origins are passed to CORSMiddleware via `HostedPlayConfig.allowed_origins`
- Updated `MODELS_DIR` comment: replaced "reserved for future model auto-discovery; not yet used at runtime" with "used by AIManager to resolve relative artifact paths at runtime"

## Why
PR #1665 wired `ALLOWED_ORIGINS` to `CORSMiddleware` and `MODELS_DIR` to `AIManager`, but the `.env.example` comments were not updated to reflect the new runtime behavior. Stale "not yet wired" comments mislead operators configuring production deployments.

Closes #1667

## Repro / Validation
```bash
# Verify no stale "not yet wired" or "reserved for future" language remains
grep -E "not yet wired|reserved for future|not yet used" .env.example
# (should return nothing)

# Verify wiring in source
grep "allow_origins=cfg.allowed_origins" web/app.py
grep "config.models_dir" web/ai_manager.py
```

## Tests
```bash
make check-quiet  # ✓ All checks passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
branch: fix/stale-env-example-comments
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)