### PR TITLE
fix(docker): use web/start.py entrypoint to honor $PORT (#1689)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 # Dockerfile — Bid Euchre Browser Game
 #
-# Thin production image: Python 3.12, hosted extras only, uvicorn entrypoint.
+# Thin production image: Python 3.12, hosted extras only, web/start.py entrypoint.
 # No dev deps, no data/runs, no experiment infrastructure.
 #
 # Build:  docker build -t bideuchre-web .
 # Run:    docker run -p 8000:8000 -e DATABASE_URL=sqlite:///hosted_play.db bideuchre-web
+# Custom: docker run -e PORT=9999 -p 9999:9999 bideuchre-web
 
 FROM python:3.12-slim AS base
 
@@ -38,5 +39,5 @@ USER app
 
 EXPOSE 8000
 
-# Uvicorn entrypoint — create_app() is a factory function
-CMD ["uv", "run", "uvicorn", "web.app:create_app", "--factory", "--host", "0.0.0.0", "--port", "8000"]
+# Production entrypoint — reads $PORT, $HOST, $WEB_WORKERS, $LOG_LEVEL
+CMD ["uv", "run", "python", "web/start.py"]


### PR DESCRIPTION
## Summary
- **Dockerfile CMD** changed from hardcoded `uvicorn ... --port 8000` to `uv run python web/start.py`
- The startup entrypoint reads `$PORT`, `$HOST`, `$WEB_WORKERS`, and `$LOG_LEVEL` from environment
- Default behavior unchanged (still binds to 0.0.0.0:8000 when no env vars set)

## Why
The Dockerfile CMD bypassed the `web/start.py` entrypoint that was specifically built to honor `$PORT` injected by Render and other PaaS platforms. Running `docker run -e PORT=9999` had no effect — the container always bound to 8000.

## Repro / Validation
```bash
# Verify CMD in Dockerfile
grep CMD Dockerfile
# Expected: CMD ["uv", "run", "python", "web/start.py"]

# Conceptual validation (no Docker needed):
# PORT=9999 would be read by web/start.py and passed to uvicorn
grep -A5 'def main' web/start.py
```

## Tests
```bash
make check-quiet  # ✓ All checks passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c
toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c
```

Closes #1689

🤖 Generated with [Claude Code](https://claude.com/claude-code)