### PR TITLE
fix(web): preserve relative artifact paths when MODELS_DIR is set

### DIFF
--- a/tests/unit/hosted_play/test_ai_manager.py
+++ b/tests/unit/hosted_play/test_ai_manager.py
@@ -113,6 +113,48 @@ class TestHybridOlsa:
         # File found at absolute path (not resolved via models_dir)
         assert "hybrid_olsa" not in mgr.available_models
 
+    def test_hybrid_olsa_relative_path_preserved_when_exists(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """A relative artifact path that already exists from CWD is preserved.
+
+        When MODELS_DIR is set but the relative path already resolves from the
+        working directory, the original relative path is used (not overridden
+        with models_dir prefix).  Regression test for #1668.
+        """
+        # Create artifact in CWD-relative location
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        rel_dir = workdir / "rel"
+        rel_dir.mkdir()
+        artifact = rel_dir / "hybrid.json"
+        artifact.write_text(json.dumps({"artifact_type": "wrong"}))
+
+        # Create a *different* directory for models_dir (no artifact here)
+        models_dir = tmp_path / "elsewhere"
+        models_dir.mkdir()
+
+        # Run from workdir so "rel/hybrid.json" is a valid relative path
+        monkeypatch.chdir(workdir)
+        config = HostedPlayConfig(
+            hybrid_olsa_artifact="rel/hybrid.json",
+            models_dir=str(models_dir),
+        )
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="web.ai_manager"):
+            mgr = AIManager(config)
+
+        # The file was found at its original relative path and loading was
+        # attempted (producing a warning because the content is invalid).
+        # If models_dir had been prepended, the file would NOT be found
+        # and no loading attempt (warning) would occur.
+        assert "hybrid_olsa" not in mgr.available_models
+        assert any(
+            "Failed to load hybrid_olsa from rel/hybrid.json" in m
+            for m in caplog.messages
+        )
+
     def test_hybrid_olsa_relative_without_models_dir_not_resolved(self):
         """A relative artifact with no models_dir stays relative (likely not found)."""
         config = HostedPlayConfig(

--- a/web/ai_manager.py
+++ b/web/ai_manager.py
@@ -77,9 +77,11 @@ class AIManager:
 
         # 2. hybrid_olsa — available when artifact path is set and exists
         artifact_path = config.hybrid_olsa_artifact
-        # Resolve relative artifact paths against models_dir when configured
+        # Resolve relative artifact paths against models_dir when configured,
+        # but only if the path doesn't already resolve from the working directory.
         if artifact_path and config.models_dir and not os.path.isabs(artifact_path):
-            artifact_path = os.path.join(config.models_dir, artifact_path)
+            if not os.path.isfile(artifact_path):
+                artifact_path = os.path.join(config.models_dir, artifact_path)
         if artifact_path and os.path.isfile(artifact_path):
             try:
                 from bid_euchre.strategy.bidding import HybridOLSaBidder


### PR DESCRIPTION
## Plan
N/A — convention follow-up from review of PR #1665.

## Summary
- When `MODELS_DIR` is configured, only resolve a relative artifact path against it if the path doesn't already exist from the working directory
- Adds regression test verifying CWD-relative paths are preserved when `MODELS_DIR` points elsewhere

## Why
PR #1665 added `MODELS_DIR` resolution for relative artifact paths, but unconditionally
prepended `models_dir` to any relative path. This broke the case where the artifact path
is already valid relative to the working directory (e.g., `data/models/hybrid.json` from
the app root). The fix checks whether the relative path already resolves before falling
back to `models_dir` resolution.

Closes #1668

## Repro / Validation
**Command(s) run:**
```
uv run python -m pytest tests/unit/hosted_play/test_ai_manager.py -v
make check-quiet
```

## Test Criteria
- **Pass condition:** Relative artifact paths that already exist from CWD are preserved when MODELS_DIR is set
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_ai_manager.py::TestHybridOlsa::test_hybrid_olsa_relative_path_preserved_when_exists -v`
- **Expected result:** Test passes — loading is attempted from the original relative path (not the models_dir-prefixed path)

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_ai_manager.py -v` — 16 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: none
- Runtime impact: none

## Risk level
- [x] Low (bugfix + test)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)