### PR TITLE
fix(test): assert persisted play decision in data capture test (#1658)

### DIFF
--- a/tests/integration/hosted_play/test_data_capture.py
+++ b/tests/integration/hosted_play/test_data_capture.py
@@ -240,6 +240,12 @@ class TestDataCapturePipeline:
             human_decisions = [d for d in decisions if d.actor_type == "human"]
             assert len(human_decisions) > 0, "No human decision rows logged"
 
+            # At least one persisted play decision (not just bids)
+            human_play_decisions = [d for d in human_decisions if d.phase == "play"]
+            assert (
+                len(human_play_decisions) > 0
+            ), "No human play decision rows persisted in DB"
+
             # Verify decision row structure
             for d in human_decisions:
                 assert d.seat == HUMAN_SEAT


### PR DESCRIPTION
## Summary

- Add assertion that at least one human **play** decision (phase="play") is persisted in the DB in `test_human_decisions_logged_to_db`
- Previously the test only checked that human decisions existed, but could pass with only bid decisions and no play decisions

## Why

Follow-up from autonomous review coordinator finding on PR #1653. The data capture pipeline test should verify that play decisions — not just bids — are persisted, since play decisions exercise the card-play → DB logging path.

Closes #1658

## Repro / Validation

```bash
uv run python -m pytest tests/integration/hosted_play/test_data_capture.py -v
# All 7 tests pass, including the updated test_human_decisions_logged_to_db
```

## Tests

- Tier 1: `uv run python -m pytest tests/integration/hosted_play/test_data_capture.py -v` — 7/7 passed
- Tier 2: `make check` — all checks passed

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
branch: fix/assert-play-decision-1658
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)