### PR TITLE
feat(ops): wire controller reconcile() into monitor cycle (#1684)

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -2209,17 +2209,28 @@ def cmd_supervisor(args: argparse.Namespace) -> int:
 
 
 def cmd_monitor(args: argparse.Namespace) -> int:
-    """Run a single ops monitoring cycle (SP-3-08)."""
+    """Run a single ops monitoring cycle (SP-3-08).
+
+    After collecting findings, the controller projection is updated via
+    ``reconcile()`` so that ``fleet_status.json`` stays current.  Pass
+    ``--no-reconcile`` to skip the projection update (useful in tests or
+    when only findings output is needed).
+    """
+    from dataclasses import asdict as _asdict
+
+    from bid_euchre.ops.control_plane import reconcile as _reconcile
     from bid_euchre.ops.monitor import (
         format_findings_json,
         format_findings_text,
         run_monitoring_cycle,
     )
+    from bid_euchre.ops.task_queue import list_packets
 
     skip_pr = getattr(args, "skip_pr_check", False)
     no_notify = getattr(args, "no_notify", False)
     no_recovery = getattr(args, "no_recovery", False)
     no_auto_dispatch = getattr(args, "no_auto_dispatch", False)
+    no_reconcile = getattr(args, "no_reconcile", False)
 
     findings = run_monitoring_cycle(
         runtime_dir=args.runtime_dir,
@@ -2233,6 +2244,19 @@ def cmd_monitor(args: argparse.Namespace) -> int:
         print(json.dumps(format_findings_json(findings), indent=2))
     else:
         print(format_findings_text(findings))
+
+    # Update the controller projection so fleet_status.json reflects the
+    # latest monitor findings and task queue state.
+    if not no_reconcile:
+        try:
+            task_dicts = [_asdict(p) for p in list_packets(root=args.runtime_dir)]
+        except Exception:
+            task_dicts = None
+        _reconcile(
+            runtime_dir=args.runtime_dir,
+            monitor_finding_objects=findings,
+            task_packets=task_dicts,
+        )
 
     # Exit 1 if any high-severity findings
     has_high = any(f.severity == "high" for f in findings)
@@ -3555,6 +3579,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--no-auto-dispatch",
         action="store_true",
         help="Disable auto-dispatch of approved packets to idle lanes",
+    )
+    monitor_parser.add_argument(
+        "--no-reconcile",
+        action="store_true",
+        help="Skip controller projection update (fleet_status.json) after monitor sweep",
     )
 
     # fleet (SP-4-07: controller projection read-only view)

--- a/tests/unit/test_ops_control_plane.py
+++ b/tests/unit/test_ops_control_plane.py
@@ -1589,3 +1589,150 @@ class TestReconcileWithAudit:
             if i.category == CAT_AUDIT_EXCHANGE and i.state == "open"
         ]
         assert len(open_audit) == 0
+
+
+# ---------------------------------------------------------------------------
+# cmd_monitor → reconcile wiring (#1684)
+# ---------------------------------------------------------------------------
+
+
+class TestMonitorReconcileWiring:
+    """Verify that cmd_monitor calls reconcile() after the monitor cycle.
+
+    The ``cmd_monitor`` function lives in ``scripts/internal/ops.py`` which
+    has a top-level ``from _repo_utils import ...`` that only resolves when
+    run via ``uv run``.  Rather than importing the CLI module directly, we
+    test the wiring contract at the library level: the monitor cycle produces
+    ``MonitorFinding`` objects and these can be fed directly into
+    ``reconcile(monitor_finding_objects=...)``.  A subprocess smoke test
+    validates the full CLI path.
+    """
+
+    def test_monitor_findings_feed_into_reconcile(self, tmp_path: Path):
+        """Monitor findings fed into reconcile() produce fleet status."""
+        from bid_euchre.ops.monitor import MonitorFinding
+
+        finding = MonitorFinding(
+            category="pr_status",
+            severity="warn",
+            summary="PR #42 has failing checks",
+            details={"pr_number": 42},
+        )
+
+        status = reconcile(
+            runtime_dir=tmp_path,
+            monitor_finding_objects=[finding],
+        )
+
+        assert status.cycle_count == 1
+        assert len(status.items) >= 1
+        pr_items = [i for i in status.items if i.pr_number == 42]
+        assert len(pr_items) == 1
+        assert pr_items[0].summary == "PR #42 has failing checks"
+
+        # Fleet status file should exist on disk.
+        loaded = load_fleet_status(tmp_path)
+        assert loaded is not None
+        assert loaded.cycle_count == 1
+
+    def test_monitor_findings_plus_task_packets(self, tmp_path: Path):
+        """reconcile() combines monitor findings and task packets."""
+        from dataclasses import asdict
+
+        from bid_euchre.ops.monitor import MonitorFinding
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        finding = MonitorFinding(
+            category="lane_health",
+            severity="high",
+            summary="Lane author-a is unresponsive",
+            details={"lane_id": "author-a"},
+        )
+
+        packet = TaskPacket(
+            packet_id="abc123",
+            title="Test task",
+            description="A test",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-24T22:00:00Z",
+            status="approved",
+            priority="high",
+        )
+
+        status = reconcile(
+            runtime_dir=tmp_path,
+            monitor_finding_objects=[finding],
+            task_packets=[asdict(packet)],
+        )
+
+        assert status.cycle_count == 1
+        # Both sources should produce items.
+        lane_items = [i for i in status.items if i.lane_id == "author-a"]
+        task_items = [i for i in status.items if i.task_id == "abc123"]
+        assert len(lane_items) >= 1
+        assert len(task_items) == 1
+
+    def test_cli_monitor_reconcile_smoke(self, tmp_path: Path):
+        """CLI ``ops.py monitor --skip-pr-check`` updates fleet status."""
+        import subprocess
+
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "python",
+                "scripts/internal/ops.py",
+                "--runtime-dir",
+                str(tmp_path),
+                "monitor",
+                "--skip-pr-check",
+                "--no-notify",
+                "--no-recovery",
+                "--no-auto-dispatch",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        # Monitor should succeed (may exit 1 for high-severity findings
+        # but should not crash).
+        assert result.returncode in (
+            0,
+            1,
+        ), f"Monitor crashed: stderr={result.stderr[:500]}"
+
+        # Fleet status file should have been written by reconcile().
+        loaded = load_fleet_status(tmp_path)
+        assert (
+            loaded is not None
+        ), f"reconcile() did not write fleet_status.json; stdout={result.stdout[:300]}"
+        assert loaded.cycle_count >= 1
+
+    def test_cli_no_reconcile_flag(self, tmp_path: Path):
+        """CLI ``--no-reconcile`` skips fleet status update."""
+        import subprocess
+
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "python",
+                "scripts/internal/ops.py",
+                "--runtime-dir",
+                str(tmp_path),
+                "monitor",
+                "--skip-pr-check",
+                "--no-notify",
+                "--no-recovery",
+                "--no-auto-dispatch",
+                "--no-reconcile",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result.returncode in (0, 1)
+
+        # No fleet status file should exist.
+        assert load_fleet_status(tmp_path) is None


### PR DESCRIPTION
## Summary
- Wire `control_plane.reconcile()` into `cmd_monitor()` so the fleet status projection updates every monitor sweep (3-min cron)
- Feed both monitor findings (as `monitor_finding_objects`) and task packets into `reconcile()`
- Add `--no-reconcile` CLI flag to opt out of the projection update

## Why
The controller projection module had `reconcile()` but no runtime caller, leaving `fleet_status.json` perpetually stale. The monitor cycle is the natural home since it already runs on a 3-minute loop and produces exactly the data reconcile needs.

Closes #1684

## Repro / Validation
```bash
# Verify reconcile runs and writes fleet_status.json
uv run python scripts/internal/ops.py --runtime-dir /tmp/test-reconcile \
  monitor --skip-pr-check --no-notify --no-recovery --no-auto-dispatch
cat /tmp/test-reconcile/fleet_status.json  # should exist with cycle_count >= 1

# Verify --no-reconcile skips it
uv run python scripts/internal/ops.py --runtime-dir /tmp/test-no-reconcile \
  monitor --skip-pr-check --no-notify --no-recovery --no-auto-dispatch --no-reconcile
ls /tmp/test-no-reconcile/fleet_status.json  # should not exist
```

## Tests
```bash
uv run python -m pytest tests/unit/test_ops_control_plane.py -x  # 104 passed
uv run python -m pytest tests/unit/test_ops_monitor.py -x  # 111 passed
make check-quiet  # All checks passed
```

4 new tests in `TestMonitorReconcileWiring`:
- `test_monitor_findings_feed_into_reconcile` — library-level wiring
- `test_monitor_findings_plus_task_packets` — combined inputs
- `test_cli_monitor_reconcile_smoke` — CLI subprocess end-to-end
- `test_cli_no_reconcile_flag` — opt-out flag works

## Worktree proof
```
pwd: Bid-Euchre-steward-brws-author-d
branch: ops/wire-reconcile-to-monitor
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)