### PR TITLE
fix(ops): detect 'Do you want to make this edit' permission stalls (#1672)

### DIFF
--- a/src/bid_euchre/ops/monitor.py
+++ b/src/bid_euchre/ops/monitor.py
@@ -1100,6 +1100,7 @@ _APPROVAL_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"\[Y\]es,?\s*always", re.IGNORECASE),
     re.compile(r"Permission required", re.IGNORECASE),
     re.compile(r"Do you want to proceed", re.IGNORECASE),
+    re.compile(r"Do you want to make this edit", re.IGNORECASE),
     re.compile(r"approve.*deny", re.IGNORECASE),
 ]
 

--- a/tests/unit/test_ops_monitor.py
+++ b/tests/unit/test_ops_monitor.py
@@ -2115,6 +2115,41 @@ class TestCheckApprovalStalls:
         assert len(approval_findings) >= 1
         assert "flex-a" in approval_findings[0].summary
 
+    def test_detects_do_you_want_to_make_this_edit(self, tmp_path: Path) -> None:
+        """Catches 'Do you want to make this edit' prompts (#1672)."""
+        pane_content = {
+            "brws-author-a": (
+                "Editing SKILL.md...\n"
+                "Do you want to make this edit to SKILL.md?\n"
+                ">\n"
+            ),
+        }
+
+        def capture_fn(lane_id: str) -> str | None:
+            return pane_content.get(lane_id)
+
+        notifications: list[tuple[str, str, str]] = []
+
+        def notify_fn(lane_id: str, prompt_text: str, target: str) -> None:
+            notifications.append((lane_id, prompt_text, target))
+
+        with patch(
+            "bid_euchre.ops.worker_pool._resolve_tmux_target",
+            return_value="steward:browser.1",
+        ):
+            findings = check_approval_stalls(
+                runtime_dir=tmp_path,
+                _capture_fn=capture_fn,
+                _notify_fn=notify_fn,
+            )
+
+        assert len(findings) == 1
+        assert findings[0].severity == SEVERITY_HIGH
+        assert findings[0].category == "approval_stall"
+        assert "brws-author-a" in findings[0].summary
+        assert "Do you want to make this edit" in findings[0].summary
+        assert len(notifications) == 1
+
     def test_no_false_positive_on_normal_output(self, tmp_path: Path) -> None:
         """Normal pane output does not trigger false positives."""
         pane_content = {
@@ -2255,6 +2290,20 @@ class TestMatchApprovalPrompt:
 
     def test_matches_yes_always(self) -> None:
         content = "prompt\n  [Y]es, always allow\n"
+        result = _match_approval_prompt(content)
+        assert result is not None
+
+    def test_matches_do_you_want_to_make_this_edit(self) -> None:
+        """Catches 'Do you want to make this edit' permission prompts (#1672)."""
+        content = (
+            "Working on SKILL.md...\n" "Do you want to make this edit to SKILL.md?\n"
+        )
+        result = _match_approval_prompt(content)
+        assert result is not None
+        assert "Do you want to make this edit" in result
+
+    def test_matches_do_you_want_to_make_this_edit_case_insensitive(self) -> None:
+        content = "output\ndo you want to make this edit to settings.json?\n"
         result = _match_approval_prompt(content)
         assert result is not None
 


### PR DESCRIPTION
## Summary

- Add `Do you want to make this edit` regex pattern to the monitor's `_APPROVAL_PATTERNS` list so `check_approval_stalls()` catches file-edit permission prompts
- Add 3 new tests: pattern-level matching (exact + case-insensitive) and full `check_approval_stalls` integration test through `_capture_fn`

## Why

During the 2026-03-24d fleet run, lanes were stuck for hours on "Do you want to make this edit" permission prompts without being detected. The existing approval-stall detector covered `Allow Bash/Edit/…`, `[A]llow`, `[Y]es, always`, `Permission required`, `Do you want to proceed`, and `approve…deny` — but not the specific file-edit confirmation prompt.

Closes #1672

## Repro / Validation

```bash
# Targeted tests
uv run python -m pytest tests/unit/test_ops_monitor.py -k "approval" -v

# Full validation
make check-quiet
```

## Tests

- `TestMatchApprovalPrompt::test_matches_do_you_want_to_make_this_edit` — pattern match
- `TestMatchApprovalPrompt::test_matches_do_you_want_to_make_this_edit_case_insensitive` — case insensitivity
- `TestCheckApprovalStalls::test_detects_do_you_want_to_make_this_edit` — full check_approval_stalls pipeline produces HIGH finding with correct category, summary, and notification

## Worktree proof

```
pwd: Bid-Euchre-steward-brws-author-b
branch: fix/permission-stall-detection
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)