### PR TITLE
docs: add explicit pass/fail criteria policy to templates (#1581)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: "fix: "
+labels: "fix:bug"
+assignees: ""
+---
+
+## Summary
+
+What went wrong? One paragraph.
+
+## Repro Steps
+
+1. Step 1
+2. Step 2
+3. ...
+
+**Repro command (if applicable):**
+```bash
+uv run python ... --seed 42
+```
+
+## Expected Behavior
+
+What should have happened.
+
+## Actual Behavior
+
+What actually happened. Include error messages or incorrect output.
+
+## Test Criteria
+
+<!-- Define how to verify the fix. Required before implementation starts. -->
+- **Pass condition:** <!-- e.g., "test_X passes where it previously failed" -->
+- **Verification command:** <!-- exact command to run -->
+- **Expected result:** <!-- what the output should look like -->
+
+## Environment
+
+- Branch/commit:
+- Python version:
+- OS:

--- a/.github/ISSUE_TEMPLATE/convention_followup.md
+++ b/.github/ISSUE_TEMPLATE/convention_followup.md
@@ -1,0 +1,29 @@
+---
+name: Convention Follow-Up
+about: Address a convention finding from code review
+title: "fix(convention): "
+labels: "follow-up, fix:convention"
+assignees: ""
+---
+
+## Finding
+
+<!-- What was found during review? Reference the source PR. -->
+- Source PR: #
+- Check ID: <!-- e.g., C4, T1, N1 -->
+- Severity: <!-- WARN / INFO -->
+
+## What to Fix
+
+Describe the specific change needed.
+
+## Test Criteria
+
+<!-- Define how to verify the fix. Not just "fix line N" — include a verification command. -->
+- **Pass condition:** <!-- e.g., "ruff check src/bid_euchre/foo.py reports 0 errors" -->
+- **Verification command:** <!-- exact command to run -->
+- **Expected result:** <!-- what the output should look like -->
+
+## Files
+
+- `path/to/file.py` — what changes

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature Request
+about: Propose a new feature or enhancement
+title: "feat: "
+labels: ""
+assignees: ""
+---
+
+## Summary
+
+What feature or enhancement is needed? One paragraph.
+
+## Motivation
+
+Why is this needed? What problem does it solve?
+
+## Proposed Approach
+
+High-level description of the implementation approach.
+
+## Test Criteria
+
+<!-- Define how to verify the feature works. Required before implementation starts. -->
+- **Pass condition:** <!-- e.g., "new CLI flag --export produces valid JSONL output" -->
+- **Verification command:** <!-- exact command to run -->
+- **Expected result:** <!-- what the output should look like -->
+
+## Alternatives Considered
+
+Other approaches and why they were not chosen (if applicable).

--- a/docs/02_agent/AGENTS.md
+++ b/docs/02_agent/AGENTS.md
@@ -250,27 +250,34 @@ uv run python scripts/compare_runs.py \
 A PR is “done” only when all of these are true:
 
 1) **Tests are green**
-   - At minimum: `pytest -m "not slow"`
+   - At minimum: `pytest -m “not slow”`
    - If you touched rules/legality/scoring or the simulation loop: run integration too.
 
-2) **Reproduce command and tests run are documented**
+2) **Test criteria defined and verified**
+   - Every PR must define specific, verifiable pass/fail conditions — not just
+     “tests pass” but what observable outcome proves the feature works.
+   - Include at least one verification command with expected result in the PR
+     description's `## Test Criteria` section.
+   - These criteria must be verified before claiming the PR is done.
+
+3) **Reproduce command and tests run are documented**
    - Provide the exact command you ran (include config paths and `--seed` where relevant).
    - List every test command you executed so reviewers can rerun them.
 
-3) **The PR description includes the PR URL and supporting context**
+4) **The PR description includes the PR URL and supporting context**
    - Record the PR URL as reported by `gh`; do not claim a PR exists before you can cite the URL.
    - Summarize the reproduce command + tests run in the PR description (can be the same text as above).
 
-4) **Worktree-only workflow**
+5) **Worktree-only workflow**
    - All edits must happen inside a dedicated worktree; never switch branches on the shared checkout or commit from `main`.
 
-5) **No generated artifacts committed**
+6) **No generated artifacts committed**
    - Do **not** commit `data/runs/` or `data/reports/` (ignored by design).
 
-6) **Behavior changes are intentional**
+7) **Behavior changes are intentional**
    - If you changed core rules or outcomes, you must add/adjust tests to lock behavior (see Testing Expectations).
 
-7) **METRICS.md compliance verified (if touching evaluation/reporting)**
+8) **METRICS.md compliance verified (if touching evaluation/reporting)**
    - If you changed evaluation, reporting, or logged fields, verify compliance with `docs/01_core/METRICS.md`
    - Check required fields (Section 2), breakouts (Section 6), uncertainty statistics (Section 7)
    - Cross-reference with `docs/03_TODO/CODEBASE_CONSISTENCY.md` for known gaps
@@ -524,7 +531,7 @@ for a single step but subordinate to the governing plan.
 | `assumptions` | Conditions assumed true; if violated, escalate |
 | `dependencies` | Other sub-plans or steps that must complete first |
 | `planned changes` | Files to be modified or created |
-| `validation` | How to verify correctness |
+| `validation` | How to verify correctness (must include specific pass/fail criteria) |
 | `planned outputs` | Artifacts to be produced |
 | `observed outputs` | Filled during/after execution |
 | `outcome` | Final status, PR link, deviations |

--- a/docs/02_agent/AGENT_EXECUTION_PROTOCOL.md
+++ b/docs/02_agent/AGENT_EXECUTION_PROTOCOL.md
@@ -40,6 +40,8 @@ An agent determines what to do next by reading the checkpoint file:
 
 **What blocks progression:**
 - A step's `Validates` conditions fail
+- A step's pass/fail criteria are not defined (every step must have specific,
+  observable verification conditions before implementation begins)
 - A required sub-plan is `blocked`
 - A predecessor step is not `COMPLETE`
 - A hard dependency declared in the governing plan is unmet
@@ -65,7 +67,10 @@ When an agent completes a step:
 
 1. Update `checkpoints.md`: set step status to `COMPLETE`, record date and session
 2. If a sub-plan was involved, update its status in the sub-plan registry
-3. Verify the step's `Validates` conditions are met
+3. Verify the step's `Validates` conditions are met — every step must have
+   specific pass/fail criteria defined in the `Validates` column. A step
+   cannot be marked `COMPLETE` without running its verification command(s)
+   and confirming the expected result.
 4. Proceed to the next step per the governing plan sequence
 
 When an agent completes a phase:

--- a/docs/02_agent/REVIEW_CHECKLIST.md
+++ b/docs/02_agent/REVIEW_CHECKLIST.md
@@ -10,6 +10,7 @@ Before claiming a PR is "done," ensure ALL of these are true:
 - [ ] **No Artifacts**: No generated files under `data/runs/` or `data/reports/` committed
 - [ ] **PR Template Complete**: ALL "##" headers from `.github/pull_request_template.md` present in PR body
 - [ ] **Repro Command**: Exact reproduction command with seed/config included in PR description
+- [ ] **Test Criteria Defined**: PR body `## Test Criteria` section includes specific pass/fail conditions with verification commands and expected results — not just "tests pass"
 - [ ] **Clean Main Ready**: Can `git checkout main && git pull --ff-only origin main` successfully
 - [ ] **Contract Compliance**: Changes to core rules/logging/metrics comply with `docs/01_core/` docs
 

--- a/plans/_templates/checkpoints.md
+++ b/plans/_templates/checkpoints.md
@@ -8,13 +8,18 @@
 
 ## Step Progress
 
-| Step | Status | Date | Agent/Session | Notes |
-|------|--------|------|---------------|-------|
-| Step 0: <name> | PENDING | -- | -- | -- |
-| Step 1: <name> | PENDING | -- | -- | -- |
-| Step 2: <name> | PENDING | -- | -- | -- |
+| Step | Status | Validates | Date | Agent/Session | Notes |
+|------|--------|-----------|------|---------------|-------|
+| Step 0: <name> | PENDING | `<verification command>` → `<expected result>` | -- | -- | -- |
+| Step 1: <name> | PENDING | `<verification command>` → `<expected result>` | -- | -- | -- |
+| Step 2: <name> | PENDING | `<verification command>` → `<expected result>` | -- | -- | -- |
 
 **Status values:** `PENDING`, `IN_PROGRESS`, `COMPLETE`, `BLOCKED`, `SKIPPED`
+
+**Validates column:** Every step must define at least one specific, observable
+pass/fail condition — not just "tests pass" but a concrete verification command
+and expected result. A step cannot be marked `COMPLETE` unless its Validates
+condition has been verified.
 
 ## Active Sub-Plans
 

--- a/plans/_templates/governing_plan.md
+++ b/plans/_templates/governing_plan.md
@@ -37,6 +37,14 @@ sequence here. For each step, specify:
 
 - **Commands:** Exact CLI commands to run
 - **Validates:** Conditions that must hold before proceeding
+- **Pass/Fail Criteria:** Specific, observable conditions that prove the step
+  is done — not just "tests pass" but what outcome proves the feature works.
+  Each step must include at least one verification command and expected result.
+  Example:
+  ```
+  - `uv run python -m pytest tests/unit/test_audit.py -v` passes (≥8 tests)
+  - `grep -c audit_reply src/bid_euchre/ops/*.py` returns ≥ 1
+  ```
 - **Error recovery:** What to do when something fails
 - **Outputs:** Artifacts produced
 

--- a/plans/_templates/sub_plan.md
+++ b/plans/_templates/sub_plan.md
@@ -47,11 +47,22 @@ Other sub-plans or steps that must complete first.
 
 ## Validation
 
-How to verify correctness before marking COMPLETE.
+How to verify correctness before marking COMPLETE. Every sub-plan must
+include at least one **integration-level** verification — not just "unit
+tests pass" but proof the feature works end-to-end.
 
-- [ ] Test command: `uv run python -m pytest tests/unit/test_X.py`
-- [ ] Smoke check: description
-- [ ] Manual verification: description
+### Pass/Fail Criteria
+
+Define specific, observable conditions that prove the work is done:
+
+- [ ] **Test command:** `uv run python -m pytest tests/unit/test_X.py -v`
+  - Expected: ≥N tests pass, 0 failures
+- [ ] **Integration check:** `<command that exercises the feature end-to-end>`
+  - Expected: `<specific output or behavior>`
+- [ ] **Wiring proof (for library code):** `grep -c <function_name> src/bid_euchre/<caller>.py`
+  - Expected: ≥ 1 (at least one non-test caller exists)
+- [ ] **Smoke check:** description
+- [ ] `make check` passes
 
 ## Planned Outputs
 

--- a/plans/sessions/TEMPLATE.md
+++ b/plans/sessions/TEMPLATE.md
@@ -9,6 +9,12 @@
 ## Files
 - `path/to/file.py` — what changes
 
+## Test Criteria
+<!-- Define before implementation starts. What proves this work is done? -->
+- **Pass condition:** <!-- e.g., "new test_X.py has ≥5 tests, all green" -->
+- **Verification command:** <!-- exact command to run -->
+- **Expected result:** <!-- what the output should look like -->
+
 ## Outcome
 <!-- Filled after implementation -->
 - PR: #NNN / abandoned / deferred


### PR DESCRIPTION
## Plan
- #1581

## Summary
- Add required Pass/Fail Criteria section to governing plan step template, sub-plan validation template, checkpoints template, and session plan template
- Create GitHub issue templates (bug_report, feature_request, convention_followup) with required Test Criteria sections
- Update agent docs: add test criteria to Definition of Done, reference in execution protocol, add review checklist check

## Why
Platform-8b was marked COMPLETE despite the audit trail not being runtime-wired (#1573). The sub-plan had exit criteria but they were library-focused ("unit tests pass") rather than outcome-focused. Well-defined integration-level pass/fail criteria would have caught this. This policy ensures every plan step, sub-plan, and issue defines observable verification conditions before implementation starts.

## Repro / Validation
**Command(s) run:**
- `make check-quiet` — all checks pass

**Config (if applicable):**
- N/A (docs/templates only)

**Seed (if applicable):**
- N/A

## Test Criteria
- **Pass condition:** All plan templates include a Pass/Fail Criteria or Test Criteria section; issue templates exist with Test Criteria; agent docs reference the requirement
- **Verification command:** `grep -c "Pass/Fail Criteria\|Test Criteria" plans/_templates/*.md plans/sessions/TEMPLATE.md .github/ISSUE_TEMPLATE/*.md docs/02_agent/REVIEW_CHECKLIST.md`
- **Expected result:** Every file returns ≥1 match (10 files total, all contain the criteria section)

## Tests
- [x] `make check-quiet` passes (docs-only change, no Python code modified)
- [ ] Other: Visual inspection of template rendering on GitHub

## Expected impact
- Metrics impact (if any): None
- Runtime impact (if any): None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
```

`git worktree list`:
```
(steward flex-a persistent worktree)
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)