### PR TITLE
fix(ops): honor urgent-message TTL exemption in check_ack_status (#1666)

### DIFF
--- a/src/bid_euchre/ops/message_bus.py
+++ b/src/bid_euchre/ops/message_bus.py
@@ -1017,7 +1017,9 @@ def check_ack_status(
 
     If the message is still in a non-terminal status (``pending`` or
     ``delivered``) but its ``payload.ttl_seconds`` has elapsed, returns
-    ``'expired'`` instead of the raw status (#1601).
+    ``'expired'`` instead of the raw status (#1601).  P0 (urgent)
+    messages are exempt from TTL expiry and never report ``'expired'``
+    (#1666).
 
     This lets a sender verify that the recipient has acknowledged a message
     without reading the full inbox.
@@ -1047,7 +1049,8 @@ def check_ack_status(
 
     # Honor TTL expiry: if the message is non-terminal and its TTL has
     # elapsed, report "expired" rather than the stale status (#1601).
-    if status in ("pending", "delivered"):
+    # P0 (urgent) messages never auto-expire via TTL (#1666).
+    if status in ("pending", "delivered") and latest.get("priority") != "urgent":
         ttl = latest.get("payload", {}).get("ttl_seconds")
         if ttl is not None:
             created = latest.get("created_at", "")
@@ -1147,8 +1150,13 @@ def escalate_unacked(
 
         # Skip messages whose TTL has already elapsed (#1601) — expired
         # messages should not trigger escalation.
+        # P0 (urgent) messages are TTL-exempt — always eligible (#1666).
         ttl = rec.get("payload", {}).get("ttl_seconds")
-        if ttl is not None and current_time - created_ts > ttl:
+        if (
+            ttl is not None
+            and rec.get("priority") != "urgent"
+            and current_time - created_ts > ttl
+        ):
             continue
 
         # Create and send an escalation message
@@ -1219,6 +1227,9 @@ def check_expired(
             # Skip terminal states AND acked — only pending/delivered can expire.
             # acked → expired is not a valid transition (#1596).
             if status in ("acked", "resolved", "expired", "dead_lettered"):
+                continue
+            # P0 (urgent) messages never auto-expire via TTL (#1666)
+            if rec.get("priority") == "urgent":
                 continue
 
             ttl = rec.get("payload", {}).get("ttl_seconds")

--- a/tests/unit/test_ops_message_bus.py
+++ b/tests/unit/test_ops_message_bus.py
@@ -803,6 +803,25 @@ class TestCheckExpired:
         expired = check_expired(bus_root, events_dir=events_dir, now=0.0)
         assert len(expired) == 0
 
+    def test_check_expired_skips_urgent_messages(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """P0 (urgent) messages are never expired by check_expired (#1666)."""
+        msg = create_message(
+            "a",
+            "b",
+            "escalation",
+            "Critical alert",
+            priority="urgent",
+            payload={"ttl_seconds": 1},
+        )
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        # Time well past the 1s TTL — should NOT expire the urgent message
+        future = time.time() + 100
+        expired = check_expired(bus_root=bus_root, events_dir=events_dir, now=future)
+        assert not any(e["message_id"] == msg.message_id for e in expired)
+
 
 # ---------------------------------------------------------------------------
 # Dead-letter handling
@@ -2074,6 +2093,44 @@ class TestCheckAckStatus:
         status = check_ack_status(msg.message_id, "orch", bus_root, now=future)
         assert status == "expired"
 
+    def test_urgent_message_not_expired_by_ttl(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Urgent messages are TTL-exempt in check_ack_status (#1666)."""
+        msg = create_message(
+            "ops",
+            "orch",
+            "escalation",
+            "Critical alert",
+            priority="urgent",
+            payload={"ttl_seconds": 1},
+        )
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        # Time well past the 1s TTL — should still report pending, not expired
+        future = time.time() + 100
+        status = check_ack_status(msg.message_id, "orch", bus_root, now=future)
+        assert status == "pending"
+
+    def test_urgent_delivered_not_expired_by_ttl(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Urgent delivered messages are also TTL-exempt (#1666)."""
+        msg = create_message(
+            "ops",
+            "orch",
+            "escalation",
+            "Critical alert",
+            priority="urgent",
+            payload={"ttl_seconds": 1},
+        )
+        send_message(msg, bus_root, events_dir=events_dir)
+        mark_delivered(msg.message_id, "orch", bus_root, events_dir=events_dir)
+
+        future = time.time() + 100
+        status = check_ack_status(msg.message_id, "orch", bus_root, now=future)
+        assert status == "delivered"
+
 
 # ---------------------------------------------------------------------------
 # escalate_unacked
@@ -2265,6 +2322,32 @@ class TestEscalateUnacked:
             bus_root=bus_root,
             events_dir=events_dir,
             now=soon,
+        )
+        assert len(escalation_ids) == 1
+
+    def test_escalates_urgent_message_past_ttl(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Urgent messages past TTL still get escalated (#1666)."""
+        msg = create_message(
+            "ops",
+            "orch",
+            "assignment",
+            "Critical task",
+            priority="urgent",
+            payload={"ttl_seconds": 1},
+        )
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        # Time well past the 1s TTL — urgent messages are TTL-exempt
+        future = time.time() + 100
+        escalation_ids = escalate_unacked(
+            "ops",
+            "orch",
+            max_age_minutes=0,
+            bus_root=bus_root,
+            events_dir=events_dir,
+            now=future,
         )
         assert len(escalation_ids) == 1
 


### PR DESCRIPTION
## Plan
plans/sessions/2026-03-24_urgent-ttl-exemption-1666.md

## Summary
- `check_ack_status` now skips TTL expiry check for P0 (urgent) messages, matching the existing exemption in `_expire_stale_messages`
- `check_expired` now skips urgent messages during its standalone expiry sweep
- `escalate_unacked` now preserves urgent messages as escalation-eligible even past TTL

## Why
Follow-up from PR #1660. That PR added TTL-expiry awareness to `check_ack_status` and `escalate_unacked` but didn't carry over the urgent-message TTL exemption that `_expire_stale_messages` already implements (line 429–431). This caused three inconsistencies where urgent messages could be reported as expired or skipped from escalation.

Closes #1666

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_message_bus.py -v -k "urgent"
make check-quiet
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** All 4 new urgent-TTL tests pass, plus 3 pre-existing urgent tests
- **Verification command:** `uv run python -m pytest tests/unit/test_ops_message_bus.py -v -k "urgent"`
- **Expected result:** 7 passed (4 new: `test_urgent_message_not_expired_by_ttl`, `test_urgent_delivered_not_expired_by_ttl`, `test_check_expired_skips_urgent_messages`, `test_escalates_urgent_message_past_ttl`)

## Tests
- [x] `uv run python -m pytest -m "not slow" tests/`
- [x] Other: `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None — urgent messages now correctly survive TTL checks across all code paths
- Runtime impact: Negligible — one additional dict lookup per non-terminal message

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-scratch
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-scratch
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-scratch  9ff2ca24 [fix/urgent-ttl-exemption]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)