### PR TITLE
feat(ops): add execute_shutoff() for fleet idle auto-shutoff (#1572)

### DIFF
--- a/src/bid_euchre/ops/events.py
+++ b/src/bid_euchre/ops/events.py
@@ -60,6 +60,7 @@ VALID_EVENT_TYPES = frozenset(
         "message_resolved",
         "message_expired",
         "message_dead_lettered",
+        "fleet_idle_shutoff",
     }
 )
 

--- a/src/bid_euchre/ops/idle_detector.py
+++ b/src/bid_euchre/ops/idle_detector.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
-from bid_euchre.ops.events import read_events
+from bid_euchre.ops.events import append_event, read_events
 
 logger = logging.getLogger("ops.idle_detector")
 
@@ -291,5 +291,148 @@ def recommend_shutoff(
     return ShutoffRecommendation(
         should_shutoff=True,
         idle_status=status,
+        recommended_actions=actions,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shutoff execution
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ShutoffResult:
+    """Result of executing the fleet idle shutoff sequence.
+
+    Attributes:
+        executed: True if the shutoff was actually executed (event logged).
+            False when the fleet is not idle or when running in dry-run mode.
+        idle_status: The underlying :class:`IdleStatus` determination that
+            informed the decision.
+        event_logged: Whether a ``fleet_idle_shutoff`` event was appended
+            to the durable event log.
+        summary: Human-readable summary of the outcome.
+        recommended_actions: Concrete actions for the caller to execute.
+            The caller (typically the orchestrator) is responsible for:
+            - Cancelling cron jobs (via CronDelete)
+            - Producing a session handoff summary
+            - Notifying the user (via Telegram or durable log)
+    """
+
+    executed: bool
+    idle_status: IdleStatus
+    event_logged: bool
+    summary: str
+    recommended_actions: list[str]
+
+
+def execute_shutoff(
+    threshold_minutes: float = DEFAULT_THRESHOLD_MINUTES,
+    *,
+    events_dir: Path | None = None,
+    runtime_dir: Path | None = None,
+    now: datetime | None = None,
+    dry_run: bool = False,
+) -> ShutoffResult:
+    """Check fleet idle status and execute shutoff if warranted.
+
+    This is the top-level entry point for the auto-shutoff sequence.  It:
+
+    1. Checks whether the fleet is idle via :func:`is_fleet_idle`.
+    2. If idle past the threshold, appends a ``fleet_idle_shutoff`` event
+       to the durable event log (unless ``dry_run`` is True).
+    3. Returns a :class:`ShutoffResult` with the recommended actions for
+       the caller to execute.
+
+    The caller is responsible for executing the recommended actions:
+
+    - **Cancel cron jobs** — stop polling / check-in crons to prevent
+      token waste.
+    - **Produce a session handoff** — summarize what shipped, what's
+      stuck, and recommended next steps.
+    - **Notify the user** — via Telegram (if available) or durable log.
+    - **Log the shutoff** — the event is logged here, but the caller
+      should also record the shutoff in its session notes.
+
+    This function is idempotent — calling it multiple times produces
+    multiple events but the same recommendation.  The caller should
+    gate on a "shutoff already executed" flag to avoid duplicate actions.
+
+    Args:
+        threshold_minutes: Minutes threshold for idle detection.
+        events_dir: Override for the events directory.
+        runtime_dir: Override for the runtime directory.
+        now: Override for current time (for testing).
+        dry_run: If True, check idle status but do not log the event.
+            Useful for previewing the shutoff recommendation.
+
+    Returns:
+        A :class:`ShutoffResult` describing the outcome.
+    """
+    status = is_fleet_idle(
+        threshold_minutes=threshold_minutes,
+        events_dir=events_dir,
+        runtime_dir=runtime_dir,
+        now=now,
+    )
+
+    if not status.idle:
+        return ShutoffResult(
+            executed=False,
+            idle_status=status,
+            event_logged=False,
+            summary=f"Fleet is active — no shutoff needed. {status.reason}",
+            recommended_actions=[],
+        )
+
+    # Fleet is idle — prepare the shutoff
+    actions = [
+        "Cancel all active cron jobs (CronList → CronDelete each)",
+        "Produce a session handoff summary (what shipped, what's stuck, next steps)",
+        "Notify the user via Telegram or durable log",
+        "Stop autonomous dispatch and monitoring (do NOT exit the session)",
+    ]
+
+    event_logged = False
+    if not dry_run:
+        try:
+            append_event(
+                event_type="fleet_idle_shutoff",
+                source="ops.idle_detector",
+                lane_id="orchestrator",
+                payload={
+                    "idle_minutes": status.idle_minutes,
+                    "threshold_minutes": threshold_minutes,
+                    "last_meaningful_event": (
+                        status.last_meaningful_event.isoformat()
+                        if status.last_meaningful_event
+                        else None
+                    ),
+                    "active_lanes": status.active_lanes,
+                    "reason": status.reason,
+                },
+                events_dir=events_dir,
+            )
+            event_logged = True
+        except Exception as exc:
+            logger.error("Failed to log fleet_idle_shutoff event: %s", exc)
+
+    idle_mins = status.idle_minutes
+    summary = (
+        f"Fleet idle shutoff {'executed' if event_logged else 'recommended'}: "
+        f"no meaningful activity for {idle_mins:.0f}m "
+        f"(threshold: {threshold_minutes:.0f}m). "
+        f"{status.reason}"
+    )
+    if dry_run:
+        summary = f"[DRY RUN] {summary}"
+
+    logger.warning("Fleet idle shutoff: %s", summary)
+
+    return ShutoffResult(
+        executed=event_logged,
+        idle_status=status,
+        event_logged=event_logged,
+        summary=summary,
         recommended_actions=actions,
     )

--- a/tests/unit/test_ops_idle_detector.py
+++ b/tests/unit/test_ops_idle_detector.py
@@ -14,8 +14,10 @@ from bid_euchre.ops.idle_detector import (
     MEANINGFUL_EVENT_TYPES,
     IdleStatus,
     ShutoffRecommendation,
+    ShutoffResult,
     _find_last_meaningful_event,
     _get_active_lane_ids,
+    execute_shutoff,
     is_fleet_idle,
     recommend_shutoff,
 )
@@ -438,3 +440,181 @@ class TestRecommendShutoff:
         assert isinstance(rec.should_shutoff, bool)
         assert isinstance(rec.idle_status, IdleStatus)
         assert isinstance(rec.recommended_actions, list)
+
+
+# ---------------------------------------------------------------------------
+# Tests: execute_shutoff
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteShutoff:
+    """Tests for the execute_shutoff() top-level entry point."""
+
+    def test_executes_when_fleet_idle(
+        self, events_dir: Path, runtime_dir: Path
+    ) -> None:
+        """Should execute shutoff and log event when fleet is idle."""
+        now = datetime(2026, 3, 24, 15, 0, 0, tzinfo=timezone.utc)
+        old_ts = now - timedelta(minutes=120)
+        _write_event(events_dir, "task_completed", old_ts)
+
+        result = execute_shutoff(
+            threshold_minutes=90,
+            events_dir=events_dir,
+            runtime_dir=runtime_dir,
+            now=now,
+        )
+        assert isinstance(result, ShutoffResult)
+        assert result.executed is True
+        assert result.event_logged is True
+        assert result.idle_status.idle is True
+        assert result.idle_status.idle_minutes == pytest.approx(120.0, abs=0.1)
+        assert len(result.recommended_actions) > 0
+        assert "cron" in " ".join(result.recommended_actions).lower()
+        assert "shutoff executed" in result.summary.lower()
+
+    def test_no_execution_when_fleet_active(
+        self, events_dir: Path, runtime_dir: Path
+    ) -> None:
+        """Should not execute when fleet is active."""
+        now = datetime(2026, 3, 24, 15, 0, 0, tzinfo=timezone.utc)
+        recent_ts = now - timedelta(minutes=10)
+        _write_event(events_dir, "task_completed", recent_ts)
+
+        result = execute_shutoff(
+            threshold_minutes=90,
+            events_dir=events_dir,
+            runtime_dir=runtime_dir,
+            now=now,
+        )
+        assert result.executed is False
+        assert result.event_logged is False
+        assert result.idle_status.idle is False
+        assert result.recommended_actions == []
+        assert "active" in result.summary.lower()
+
+    def test_no_execution_when_lanes_active(
+        self, events_dir: Path, runtime_dir: Path
+    ) -> None:
+        """Active lanes prevent shutoff even when events are old."""
+        now = datetime(2026, 3, 24, 15, 0, 0, tzinfo=timezone.utc)
+        old_ts = now - timedelta(minutes=120)
+        _write_event(events_dir, "task_completed", old_ts)
+        _register_lane(runtime_dir, "author-a", session_id="sess-live")
+
+        result = execute_shutoff(
+            threshold_minutes=90,
+            events_dir=events_dir,
+            runtime_dir=runtime_dir,
+            now=now,
+        )
+        assert result.executed is False
+        assert result.event_logged is False
+        assert "author-a" in result.idle_status.active_lanes
+
+    def test_dry_run_does_not_log_event(
+        self, events_dir: Path, runtime_dir: Path
+    ) -> None:
+        """Dry run should check status but not log any event."""
+        now = datetime(2026, 3, 24, 15, 0, 0, tzinfo=timezone.utc)
+        old_ts = now - timedelta(minutes=120)
+        _write_event(events_dir, "task_completed", old_ts)
+
+        result = execute_shutoff(
+            threshold_minutes=90,
+            events_dir=events_dir,
+            runtime_dir=runtime_dir,
+            now=now,
+            dry_run=True,
+        )
+        assert result.executed is False  # dry_run => not executed
+        assert result.event_logged is False
+        assert result.idle_status.idle is True
+        assert len(result.recommended_actions) > 0  # actions still recommended
+        assert "DRY RUN" in result.summary
+
+    def test_event_logged_to_event_log(
+        self, events_dir: Path, runtime_dir: Path
+    ) -> None:
+        """Verify the fleet_idle_shutoff event is actually in the event log."""
+        now = datetime(2026, 3, 24, 15, 0, 0, tzinfo=timezone.utc)
+        old_ts = now - timedelta(minutes=120)
+        _write_event(events_dir, "task_completed", old_ts)
+
+        execute_shutoff(
+            threshold_minutes=90,
+            events_dir=events_dir,
+            runtime_dir=runtime_dir,
+            now=now,
+        )
+
+        # Read the event log and find our shutoff event
+        events_file = events_dir / EVENTS_FILE
+        lines = events_file.read_text().strip().split("\n")
+        shutoff_events = [
+            json.loads(line) for line in lines if "fleet_idle_shutoff" in line
+        ]
+        assert len(shutoff_events) == 1
+        evt = shutoff_events[0]
+        assert evt["event_type"] == "fleet_idle_shutoff"
+        assert evt["source"] == "ops.idle_detector"
+        assert evt["lane_id"] == "orchestrator"
+        assert evt["payload"]["idle_minutes"] == pytest.approx(120.0, abs=0.1)
+        assert evt["payload"]["threshold_minutes"] == 90
+
+    def test_idempotent_execution(self, events_dir: Path, runtime_dir: Path) -> None:
+        """Calling execute_shutoff twice should produce two events."""
+        now = datetime(2026, 3, 24, 15, 0, 0, tzinfo=timezone.utc)
+        old_ts = now - timedelta(minutes=120)
+        _write_event(events_dir, "task_completed", old_ts)
+
+        r1 = execute_shutoff(
+            threshold_minutes=90,
+            events_dir=events_dir,
+            runtime_dir=runtime_dir,
+            now=now,
+        )
+        r2 = execute_shutoff(
+            threshold_minutes=90,
+            events_dir=events_dir,
+            runtime_dir=runtime_dir,
+            now=now,
+        )
+        assert r1.executed is True
+        assert r2.executed is True
+
+        # Both events in the log
+        events_file = events_dir / EVENTS_FILE
+        lines = events_file.read_text().strip().split("\n")
+        shutoff_events = [line for line in lines if "fleet_idle_shutoff" in line]
+        assert len(shutoff_events) == 2
+
+    def test_result_fields(self, events_dir: Path, runtime_dir: Path) -> None:
+        """ShutoffResult has all expected fields."""
+        now = datetime(2026, 3, 24, 15, 0, 0, tzinfo=timezone.utc)
+        result = execute_shutoff(
+            events_dir=events_dir,
+            runtime_dir=runtime_dir,
+            now=now,
+        )
+        assert isinstance(result, ShutoffResult)
+        assert isinstance(result.executed, bool)
+        assert isinstance(result.idle_status, IdleStatus)
+        assert isinstance(result.event_logged, bool)
+        assert isinstance(result.summary, str)
+        assert isinstance(result.recommended_actions, list)
+
+    def test_no_events_triggers_shutoff(
+        self, events_dir: Path, runtime_dir: Path
+    ) -> None:
+        """Empty fleet with no events should trigger shutoff."""
+        now = datetime(2026, 3, 24, 15, 0, 0, tzinfo=timezone.utc)
+        result = execute_shutoff(
+            threshold_minutes=90,
+            events_dir=events_dir,
+            runtime_dir=runtime_dir,
+            now=now,
+        )
+        assert result.executed is True
+        assert result.event_logged is True
+        assert result.idle_status.idle is True


### PR DESCRIPTION
## Summary

- Add `execute_shutoff()` function to `idle_detector.py` — the shutoff executor that completes the idle detection pipeline
- Add `fleet_idle_shutoff` event type to the durable event log
- Add `ShutoffResult` dataclass with structured execution status and recommended actions
- Add 8 tests covering all execution paths (idle, active, dry-run, idempotent, event log)

## Why

Issue #1572: During the overnight run of 2026-03-24, the orchestrator continued polling for ~7 hours after all dispatchable work was exhausted. The idle detection layer (`is_fleet_idle`, `recommend_shutoff`) and monitor integration (`check_fleet_idle`) already existed, but there was no **execution** layer for the orchestrator to call. This PR adds `execute_shutoff()` which logs the shutoff event and returns structured actions (cancel crons, produce handoff, notify user).

## Repro / Validation

```bash
# Run targeted tests
uv run python -m pytest tests/unit/test_ops_idle_detector.py -v

# Full validation
make check-quiet
```

## Tests

- `make check-quiet` — all checks pass
- `tests/unit/test_ops_idle_detector.py` — 34 tests (26 existing + 8 new), all passing

### New test coverage:
- `test_executes_when_fleet_idle` — verifies shutoff when idle > threshold
- `test_no_execution_when_fleet_active` — no action when fleet is active
- `test_no_execution_when_lanes_active` — active lanes prevent shutoff
- `test_dry_run_does_not_log_event` — dry_run mode preview
- `test_event_logged_to_event_log` — verifies event payload in durable log
- `test_idempotent_execution` — calling twice produces two events
- `test_result_fields` — dataclass field validation
- `test_no_events_triggers_shutoff` — empty fleet triggers shutoff

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
branch: ops/idle-shutoff-executor-1572
```

Closes #1572

🤖 Generated with [Claude Code](https://claude.com/claude-code)