### PR TITLE
fix(ops): add SKILL.md edit permission to prevent lane stalls (#1671)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -76,6 +76,11 @@
       }
     ]
   },
+  "permissions": {
+    "allow": [
+      "Edit(.claude/skills/**/SKILL.md)"
+    ]
+  },
   "enabledPlugins": {
     "telegram@claude-plugins-official": true
   }


### PR DESCRIPTION
## Summary

- Add a scoped `Edit(.claude/skills/**/SKILL.md)` permission to `.claude/settings.json`
- Prevents lanes from stalling on interactive permission prompts during fleet runs after `--reset`

## Why

During the 2026-03-24d fleet run, ~25% of lane capacity was lost because lanes kept hitting interactive "Do you want to make this edit to SKILL.md?" prompts. Each `task dispatch --reset` clears session permissions, restarting the cycle. This adds the permission at the project level so it persists across resets.

## Repro / Validation

```bash
# Verify the permission entry exists
python3 -c "import json; d=json.load(open('.claude/settings.json')); print(d['permissions'])"
# {'allow': ['Edit(.claude/skills/**/SKILL.md)']}

# Full validation
make check-quiet  # ✓ All checks passed
```

## Tests

- `make check-quiet` — all checks passed

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: fix/skill-md-edit-permission
```

Closes #1671

🤖 Generated with [Claude Code](https://claude.com/claude-code)