### PR TITLE
fix(ops): wire audit_mcp_outbound into live PostToolUse hook (#1685)

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -138,6 +138,22 @@ claude-work  # Uses auto-generated timestamp branch
 4. Changes to worktree directory
 5. Starts `claude` session in worktree
 
+### `post-telegram-audit.sh` (PostToolUse — MCP Telegram tools)
+
+**Trigger:** After any Telegram MCP tool call (reply, react, edit_message, download_attachment)
+
+**Purpose:** Wires `audit_mcp_outbound()` into the live PostToolUse path so outbound
+Telegram exchanges are recorded in the audit trail JSONL file.
+
+**Behavior:**
+1. Reads PostToolUse JSON payload from stdin
+2. Guards on tool name — exits immediately for non-Telegram tools
+3. Extracts `tool_input` arguments and passes them to `audit_mcp_outbound()`
+4. Best-effort: audit failures are silently swallowed (never blocks the agent)
+5. Suppresses TUI notification (audit is invisible background work)
+
+**Output:** `{"suppressOutput": true}` (silent)
+
 ### `pre-bash-dispatch.sh` (PreToolUse — Bash)
 
 **Trigger:** Before any Bash tool call
@@ -185,6 +201,7 @@ Hooks are registered across two files:
 - `PreToolUse` (Bash) → `pre-bash-dispatch.sh` (consolidated dispatcher)
 - `PostToolUse` (Write|Edit) → `post-write-check.sh`
 - `PostToolUse` (Bash) → `post-bash-dispatch.sh` (consolidated dispatcher)
+- `PostToolUse` (MCP Telegram tools) → `post-telegram-audit.sh` (audit trail)
 
 **`.claude/settings.local.json`** (gitignored, per-machine):
 - `SessionStart` → `worktree-reminder.sh`

--- a/.claude/hooks/post-telegram-audit.sh
+++ b/.claude/hooks/post-telegram-audit.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# post-telegram-audit.sh — PostToolUse hook: audit outbound Telegram MCP tool calls.
+#
+# Wires audit_mcp_outbound() into the live PostToolUse path for Telegram tools.
+# When any Telegram MCP tool (reply, react, edit_message) is invoked, this hook
+# appends an audit record to .claude/runtime/audit_trail/remote_exchanges.jsonl.
+#
+# Design:
+#   - Best-effort: audit failure never blocks the tool response
+#   - Lightweight guard: exits immediately for non-Telegram tools
+#   - Uses env vars (not shell args) to avoid injection from tool args
+#   - Same uv-run-python pattern as post-pr-review.sh
+#
+# Closes #1685 (runtime wiring for Platform-8b audit trail)
+set -euo pipefail
+
+# Read PostToolUse JSON payload from stdin
+INPUT=$(cat)
+
+# Extract tool name
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null || echo "")
+
+# Guard: only audit known Telegram outbound tools
+case "$TOOL_NAME" in
+    mcp__plugin_telegram_telegram__reply|\
+    mcp__plugin_telegram_telegram__react|\
+    mcp__plugin_telegram_telegram__edit_message|\
+    mcp__plugin_telegram_telegram__download_attachment)
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+
+# Extract tool arguments as JSON string
+TOOL_ARGS=$(echo "$INPUT" | jq -c '.tool_input // {}' 2>/dev/null || echo '{}')
+
+# Best-effort audit: call audit_mcp_outbound() via Python.
+# Failures are silently swallowed — auditing must not block the agent.
+AUDIT_TOOL_NAME="$TOOL_NAME" AUDIT_TOOL_ARGS="$TOOL_ARGS" \
+  uv run python -c "
+import os, json, sys
+from bid_euchre.ops.audit_trail import audit_mcp_outbound
+tool_name = os.environ['AUDIT_TOOL_NAME']
+tool_args = json.loads(os.environ['AUDIT_TOOL_ARGS'])
+record = audit_mcp_outbound(tool_name, tool_args)
+if record:
+    print(f'audit: {record.exchange_type} -> {record.exchange_id}', file=sys.stderr)
+" 2>/dev/null || true
+
+# Suppress TUI notification — audit is silent background work
+echo '{"suppressOutput": true}'
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -73,6 +73,16 @@
             "timeout": 45
           }
         ]
+      },
+      {
+        "matcher": "mcp__plugin_telegram_telegram__reply|mcp__plugin_telegram_telegram__react|mcp__plugin_telegram_telegram__edit_message|mcp__plugin_telegram_telegram__download_attachment",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-telegram-audit.sh",
+            "timeout": 10
+          }
+        ]
       }
     ]
   },

--- a/src/bid_euchre/ops/audit_trail.py
+++ b/src/bid_euchre/ops/audit_trail.py
@@ -436,7 +436,7 @@ def audit_inbound(
 _MCP_TOOL_MAP: dict[str, str] = {
     "mcp__plugin_telegram_telegram__reply": "reply",
     "mcp__plugin_telegram_telegram__react": "react",
-    "mcp__plugin_telegram_telegram__edit": "edit",
+    "mcp__plugin_telegram_telegram__edit_message": "edit",
 }
 
 

--- a/tests/integration/test_audit_trail_integration.py
+++ b/tests/integration/test_audit_trail_integration.py
@@ -737,7 +737,7 @@ class TestMcpOutboundWiring:
     def test_edit_tool_audited(self, tmp_path: Path) -> None:
         """MCP edit tool call produces an outbound edit audit record."""
         rec = audit_mcp_outbound(
-            tool_name="mcp__plugin_telegram_telegram__edit",
+            tool_name="mcp__plugin_telegram_telegram__edit_message",
             tool_args={
                 "chat_id": "123",
                 "message_id": "42",
@@ -799,7 +799,7 @@ class TestMcpOutboundWiring:
             audit_dir=tmp_path,
         )
         audit_mcp_outbound(
-            tool_name="mcp__plugin_telegram_telegram__edit",
+            tool_name="mcp__plugin_telegram_telegram__edit_message",
             tool_args={"chat_id": "123", "message_id": "2", "body": "Edited"},
             audit_dir=tmp_path,
         )


### PR DESCRIPTION
## Summary
- Wire `audit_mcp_outbound()` into a live PostToolUse hook that fires on Telegram MCP tool calls (reply, react, edit_message, download_attachment)
- Fix `_MCP_TOOL_MAP` tool name mismatch (`edit` → `edit_message`) to match the actual MCP tool name
- Add `post-telegram-audit.sh` hook script with best-effort, silent auditing

## Why
PR #1661 added the audit trail library functions (`audit_mcp_outbound()`, `audit_channel_tag()`) but no live caller existed — the functions were dead code outside of tests. This wires the outbound path so audit records are actually appended to `.claude/runtime/audit_trail/remote_exchanges.jsonl` when Telegram tools are used.

## Changes
| File | Change |
|------|--------|
| `.claude/hooks/post-telegram-audit.sh` | New hook: reads PostToolUse JSON, calls `audit_mcp_outbound()` via Python |
| `.claude/settings.json` | Register hook for MCP Telegram tool matchers |
| `src/bid_euchre/ops/audit_trail.py` | Fix `_MCP_TOOL_MAP`: `mcp__...edit` → `mcp__...edit_message` |
| `tests/integration/test_audit_trail_integration.py` | Update test tool names to match corrected map |
| `.claude/hooks/README.md` | Document the new hook |

## Repro / Validation
```bash
# Smoke test the hook directly
echo '{"tool_name":"mcp__plugin_telegram_telegram__reply","tool_input":{"chat_id":"12345","body":"Hello"}}' \
  | .claude/hooks/post-telegram-audit.sh
# Output: {"suppressOutput": true}
# Verify: cat .claude/runtime/audit_trail/remote_exchanges.jsonl

# Run audit trail tests
uv run python -m pytest tests/unit/test_audit_trail.py tests/integration/test_audit_trail_integration.py -q

# Full validation
make check-quiet
```

## Tests
- 83 unit tests pass (`tests/unit/test_audit_trail.py`)
- 42 integration tests pass (`tests/integration/test_audit_trail_integration.py`)
- `make check-quiet` passes (all checks green)

## Worktree proof
```
pwd: Bid-Euchre-steward-brws-author-a
branch: fix/wire-audit-entry-points
```

Closes #1685

🤖 Generated with [Claude Code](https://claude.com/claude-code)