### PR TITLE
feat(ops): add UserPromptSubmit hook for mechanical alert injection (#1608)

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -202,6 +202,7 @@ Hooks are registered across two files:
 - `PostToolUse` (Write|Edit) → `post-write-check.sh`
 - `PostToolUse` (Bash) → `post-bash-dispatch.sh` (consolidated dispatcher)
 - `PostToolUse` (MCP Telegram tools) → `post-telegram-audit.sh` (audit trail)
+- `UserPromptSubmit` (all) → `alert-inject.sh` (fleet alert injection)
 
 **`.claude/settings.local.json`** (gitignored, per-machine):
 - `SessionStart` → `worktree-reminder.sh`
@@ -305,3 +306,23 @@ Since hooks can't change directories, the workflow is:
 4. User restarts Claude in new location
 
 This reduces friction from "manual branch creation + worktree creation + cd" to just "cd + restart".
+
+### `alert-inject.sh` / `alert-inject.py` (UserPromptSubmit)
+
+**Trigger:** Before every prompt submission (all lanes)
+
+**Purpose:** Mechanically inject unresolved HIGH/URGENT fleet alerts into
+conversation context so the orchestrator cannot miss them.
+
+**Behavior:**
+1. Reads `.claude/runtime/fleet_status.json` (written by controller/reconciler)
+2. Filters for open items with severity `high` or `urgent`
+3. If any found: outputs `{"additionalContext": "..."}` with alert summary
+4. If none found: exits cleanly with no output (exit 0)
+5. Never blocks prompt submission — advisory injection only
+
+**Speed:** ~100ms (stdlib-only Python, no project imports, no `uv` overhead)
+
+**Registration:** `.claude/settings.json` → `UserPromptSubmit` (timeout: 5s)
+
+**Related:** #1608, `src/bid_euchre/ops/control_plane.py`

--- a/.claude/hooks/alert-inject.py
+++ b/.claude/hooks/alert-inject.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""UserPromptSubmit hook: inject high/urgent fleet alerts as additionalContext.
+
+Reads ``.claude/runtime/fleet_status.json`` (written by the controller/reconciler)
+and injects open HIGH or URGENT items into the conversation context so the
+orchestrator cannot miss them.
+
+Design constraints:
+- stdlib-only (no project imports) for speed -- cold start ~100ms.
+- Outputs nothing (exit 0) when no actionable alerts exist.
+- Outputs ``{"additionalContext": "..."}`` when alerts are present.
+
+Closes #1608.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def read_fleet_status(path: Path) -> dict | None:
+    """Read and parse fleet_status.json.  Returns None on any failure."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+
+
+def extract_alerts(data: dict) -> list[dict]:
+    """Return open items with severity 'high' or 'urgent'."""
+    items = data.get("items", [])
+    return [
+        i
+        for i in items
+        if i.get("severity") in ("high", "urgent") and i.get("state") == "open"
+    ]
+
+
+def format_alert_context(alerts: list[dict]) -> str:
+    """Format alerts into a human-readable context string."""
+    lines = [f"FLEET ALERTS ({len(alerts)} unresolved):"]
+    for a in alerts:
+        sev = a.get("severity", "high").upper()
+        summary = a.get("summary", "(no summary)")
+        lines.append(f"  [{sev}] {summary}")
+        rec = a.get("recommended_action")
+        if rec:
+            lines.append(f"    -> {rec}")
+    return "\n".join(lines)
+
+
+def main(project_dir: str | None = None) -> int:
+    """Entry point.  Returns 0 always (never blocks prompt submission)."""
+    if project_dir is None:
+        project_dir = os.environ.get("CLAUDE_PROJECT_DIR", ".")
+
+    status_path = Path(project_dir) / ".claude" / "runtime" / "fleet_status.json"
+
+    if not status_path.exists():
+        return 0
+
+    data = read_fleet_status(status_path)
+    if data is None:
+        return 0
+
+    alerts = extract_alerts(data)
+    if not alerts:
+        return 0
+
+    context = format_alert_context(alerts)
+    print(json.dumps({"additionalContext": context}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/alert-inject.sh
+++ b/.claude/hooks/alert-inject.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# UserPromptSubmit hook: inject high/urgent fleet alerts as additionalContext.
+#
+# Reads .claude/runtime/fleet_status.json (written by the controller/reconciler)
+# and injects open HIGH or URGENT items so the orchestrator cannot miss them.
+#
+# Speed: ~100ms (stdlib-only Python, no project imports, no uv overhead).
+# Closes #1608.
+
+set -euo pipefail
+
+exec python3 "$CLAUDE_PROJECT_DIR/.claude/hooks/alert-inject.py"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -84,6 +84,17 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/alert-inject.sh",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   },
   "permissions": {

--- a/tests/unit/test_alert_inject_hook.py
+++ b/tests/unit/test_alert_inject_hook.py
@@ -1,0 +1,330 @@
+"""Unit tests for the alert-inject UserPromptSubmit hook.
+
+Tests the Python script directly (no shell wrapper) for speed and isolation.
+The hook reads .claude/runtime/fleet_status.json and injects high/urgent
+alerts as additionalContext.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_PY = REPO_ROOT / ".claude" / "hooks" / "alert-inject.py"
+HOOK_SH = REPO_ROOT / ".claude" / "hooks" / "alert-inject.sh"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_hook(project_dir: Path) -> subprocess.CompletedProcess[str]:
+    """Run the Python hook script with CLAUDE_PROJECT_DIR set."""
+    return subprocess.run(
+        [sys.executable, str(HOOK_PY)],
+        env={"CLAUDE_PROJECT_DIR": str(project_dir), "PATH": ""},
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+
+def _write_fleet_status(project_dir: Path, data: dict) -> Path:
+    """Write a fleet_status.json into the project dir structure."""
+    runtime_dir = project_dir / ".claude" / "runtime"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    path = runtime_dir / "fleet_status.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def _make_item(
+    *,
+    severity: str = "high",
+    state: str = "open",
+    summary: str = "Test alert",
+    recommended_action: str | None = "Fix it",
+    item_id: str = "abc123",
+    category: str = "lane_health",
+) -> dict:
+    """Create a minimal fleet status item dict."""
+    item = {
+        "item_id": item_id,
+        "severity": severity,
+        "state": state,
+        "summary": summary,
+        "category": category,
+        "source": "monitor",
+        "first_seen_at": "2026-03-24T22:00:00+00:00",
+        "last_seen_at": "2026-03-24T22:00:00+00:00",
+    }
+    if recommended_action is not None:
+        item["recommended_action"] = recommended_action
+    return item
+
+
+def _fleet_status(items: list[dict]) -> dict:
+    """Wrap items in a fleet status envelope."""
+    return {
+        "items": items,
+        "generated_at": "2026-03-24T22:00:00+00:00",
+        "cycle_count": 1,
+        "summary": {
+            "total": len(items),
+            "open": len([i for i in items if i.get("state") == "open"]),
+            "urgent": len(
+                [
+                    i
+                    for i in items
+                    if i.get("severity") == "urgent" and i.get("state") == "open"
+                ]
+            ),
+            "high": len(
+                [
+                    i
+                    for i in items
+                    if i.get("severity") in ("high", "urgent")
+                    and i.get("state") == "open"
+                ]
+            ),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: no output cases
+# ---------------------------------------------------------------------------
+
+
+class TestNoOutput:
+    """Cases where the hook should produce no output and exit 0."""
+
+    def test_no_fleet_status_file(self, tmp_path: Path) -> None:
+        """Hook exits cleanly when fleet_status.json does not exist."""
+        result = _run_hook(tmp_path)
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_empty_items_list(self, tmp_path: Path) -> None:
+        """Hook exits cleanly when items list is empty."""
+        _write_fleet_status(tmp_path, _fleet_status([]))
+        result = _run_hook(tmp_path)
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_only_info_items(self, tmp_path: Path) -> None:
+        """Hook exits cleanly when only info-severity items exist."""
+        items = [_make_item(severity="info", summary="All good")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path)
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_only_warn_items(self, tmp_path: Path) -> None:
+        """Hook exits cleanly when only warn-severity items exist."""
+        items = [_make_item(severity="warn", summary="Minor issue")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path)
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_high_but_cleared(self, tmp_path: Path) -> None:
+        """Hook exits cleanly when high items are cleared (not open)."""
+        items = [_make_item(severity="high", state="cleared")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path)
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_high_but_acked(self, tmp_path: Path) -> None:
+        """Hook exits cleanly when high items are acked (not open)."""
+        items = [_make_item(severity="high", state="acked")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path)
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_high_but_suppressed(self, tmp_path: Path) -> None:
+        """Hook exits cleanly when high items are suppressed."""
+        items = [_make_item(severity="high", state="suppressed")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path)
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_corrupt_json(self, tmp_path: Path) -> None:
+        """Hook exits cleanly on corrupt JSON."""
+        runtime_dir = tmp_path / ".claude" / "runtime"
+        runtime_dir.mkdir(parents=True)
+        (runtime_dir / "fleet_status.json").write_text("not json{{{")
+        result = _run_hook(tmp_path)
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# Tests: alert injection
+# ---------------------------------------------------------------------------
+
+
+class TestAlertInjection:
+    """Cases where the hook should inject additionalContext."""
+
+    def test_single_high_alert(self, tmp_path: Path) -> None:
+        """Hook injects context for a single high-severity open item."""
+        items = [_make_item(severity="high", summary="Lane author-a dead")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+
+        result = _run_hook(tmp_path)
+        assert result.returncode == 0
+
+        output = json.loads(result.stdout)
+        assert "additionalContext" in output
+        ctx = output["additionalContext"]
+        assert "FLEET ALERTS (1 unresolved)" in ctx
+        assert "[HIGH] Lane author-a dead" in ctx
+        assert "-> Fix it" in ctx
+
+    def test_single_urgent_alert(self, tmp_path: Path) -> None:
+        """Hook injects context for a single urgent-severity open item."""
+        items = [_make_item(severity="urgent", summary="CI broken on main")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+
+        result = _run_hook(tmp_path)
+        assert result.returncode == 0
+
+        output = json.loads(result.stdout)
+        ctx = output["additionalContext"]
+        assert "FLEET ALERTS (1 unresolved)" in ctx
+        assert "[URGENT] CI broken on main" in ctx
+
+    def test_multiple_alerts(self, tmp_path: Path) -> None:
+        """Hook injects all high/urgent open items."""
+        items = [
+            _make_item(
+                severity="high",
+                summary="PR #123 has merge conflict",
+                item_id="id1",
+            ),
+            _make_item(
+                severity="urgent",
+                summary="Lane stalled 45min",
+                item_id="id2",
+                recommended_action="Re-nudge lane",
+            ),
+            _make_item(severity="info", summary="Capacity OK", item_id="id3"),
+            _make_item(
+                severity="high",
+                summary="Cleared issue",
+                item_id="id4",
+                state="cleared",
+            ),
+        ]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+
+        result = _run_hook(tmp_path)
+        assert result.returncode == 0
+
+        output = json.loads(result.stdout)
+        ctx = output["additionalContext"]
+        assert "FLEET ALERTS (2 unresolved)" in ctx
+        assert "[HIGH] PR #123 has merge conflict" in ctx
+        assert "[URGENT] Lane stalled 45min" in ctx
+        assert "Capacity OK" not in ctx  # info item excluded
+        assert "Cleared issue" not in ctx  # cleared item excluded
+
+    def test_no_recommended_action(self, tmp_path: Path) -> None:
+        """Hook works when recommended_action is absent."""
+        items = [
+            _make_item(
+                severity="high",
+                summary="Something wrong",
+                recommended_action=None,
+            ),
+        ]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+
+        result = _run_hook(tmp_path)
+        assert result.returncode == 0
+
+        output = json.loads(result.stdout)
+        ctx = output["additionalContext"]
+        assert "[HIGH] Something wrong" in ctx
+        assert "->" not in ctx
+
+    def test_output_is_valid_json(self, tmp_path: Path) -> None:
+        """Hook output is always valid JSON when alerts exist."""
+        items = [_make_item(severity="high", summary='Alert with "quotes" & specials')]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+
+        result = _run_hook(tmp_path)
+        assert result.returncode == 0
+
+        # Must be parseable JSON
+        output = json.loads(result.stdout)
+        assert isinstance(output, dict)
+        assert "additionalContext" in output
+        assert isinstance(output["additionalContext"], str)
+
+
+# ---------------------------------------------------------------------------
+# Tests: hook infrastructure
+# ---------------------------------------------------------------------------
+
+
+class TestHookInfrastructure:
+    """Verify hook files exist and are properly configured."""
+
+    def test_python_script_exists(self) -> None:
+        assert HOOK_PY.exists(), f"Missing {HOOK_PY}"
+
+    def test_shell_wrapper_exists(self) -> None:
+        assert HOOK_SH.exists(), f"Missing {HOOK_SH}"
+
+    def test_shell_wrapper_executable(self) -> None:
+        import os
+        import stat
+
+        mode = os.stat(HOOK_SH).st_mode
+        assert mode & stat.S_IXUSR, f"{HOOK_SH} is not executable"
+
+    def test_python_script_executable(self) -> None:
+        import os
+        import stat
+
+        mode = os.stat(HOOK_PY).st_mode
+        assert mode & stat.S_IXUSR, f"{HOOK_PY} is not executable"
+
+    def test_hook_registered_in_settings(self) -> None:
+        settings_path = REPO_ROOT / ".claude" / "settings.json"
+        settings = json.loads(settings_path.read_text())
+        hooks = settings.get("hooks", {})
+        user_prompt = hooks.get("UserPromptSubmit", [])
+        assert len(user_prompt) > 0, "No UserPromptSubmit hooks registered"
+
+        # Find our hook
+        found = False
+        for entry in user_prompt:
+            for hook in entry.get("hooks", []):
+                if "alert-inject" in hook.get("command", ""):
+                    found = True
+                    assert hook["timeout"] <= 5, "Hook timeout must be <= 5s"
+        assert found, "alert-inject hook not found in UserPromptSubmit"
+
+    def test_hook_speed(self, tmp_path: Path) -> None:
+        """Hook completes in under 2 seconds even with alerts."""
+        import time
+
+        items = [_make_item(severity="high", summary=f"Alert {i}") for i in range(20)]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+
+        start = time.monotonic()
+        result = _run_hook(tmp_path)
+        elapsed = time.monotonic() - start
+
+        assert result.returncode == 0
+        assert elapsed < 2.0, f"Hook took {elapsed:.2f}s (must be < 2s)"


### PR DESCRIPTION
## Plan
- N/A (standalone issue #1608)

## Summary
- Add a `UserPromptSubmit` hook that reads `.claude/runtime/fleet_status.json` and injects open HIGH/URGENT fleet alerts as `additionalContext`
- Replaces advisory "please check inbox" with mechanical enforcement — the orchestrator cannot miss critical alerts
- stdlib-only Python script for speed (~100ms cold start, no project imports, no `uv` overhead)

## Why
During the overnight autonomous run, 25+ supervisor_alerts went unread for 7 hours. All existing fixes (skills, cron polling, escalation) are advisory — Claude can ignore them. Hooks fire mechanically on every prompt submission and cannot be skipped.

## Repro / Validation
**Command(s) run:**
```bash
# Unit tests (19 tests covering no-output, injection, and infrastructure)
uv run python -m pytest tests/unit/test_alert_inject_hook.py -v

# Manual smoke test:
mkdir -p .claude/runtime
echo '{"items": [{"severity": "high", "state": "open", "summary": "Test alert", "recommended_action": "Fix it", "item_id": "abc", "category": "test", "source": "test", "first_seen_at": "2026-01-01", "last_seen_at": "2026-01-01"}], "generated_at": "2026-01-01", "cycle_count": 1}' > .claude/runtime/fleet_status.json
CLAUDE_PROJECT_DIR=. python3 .claude/hooks/alert-inject.py
# Expected: {"additionalContext": "FLEET ALERTS (1 unresolved):\n  [HIGH] Test alert\n    -> Fix it"}
```

## Test Criteria
- **Pass condition:** All 19 unit tests pass; hook outputs valid JSON with `additionalContext` when HIGH/URGENT open items exist; hook outputs nothing for info/warn/cleared/acked items
- **Verification command:** `uv run python -m pytest tests/unit/test_alert_inject_hook.py -v`
- **Expected result:** 19 passed, 0 failed

## Tests
- [x] `uv run python -m pytest tests/unit/test_alert_inject_hook.py -v` (19 passed)
- [x] `uv run python -m pytest tests/unit/test_ops_control_plane.py -v` (100 passed)
- [x] `make repo-lint` (passed)
- [x] `make lint` (passed)

## Expected impact
- Metrics impact: None (hook infrastructure only)
- Runtime impact: ~100ms added to each prompt submission (file read + JSON parse)

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre  ec9f89ad [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c  4c831c38 [ops/alert-inject-hook]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)