### PR TITLE
fix(web): preserve models_dir fallback after CWD artifact load failure (#1700)

### DIFF
--- a/tests/unit/hosted_play/test_ai_manager.py
+++ b/tests/unit/hosted_play/test_ai_manager.py
@@ -155,6 +155,56 @@ class TestHybridOlsa:
             for m in caplog.messages
         )
 
+    def test_hybrid_olsa_cwd_failure_falls_back_to_models_dir(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """When CWD artifact exists but fails to load, models_dir is tried.
+
+        Regression test for #1700: if the CWD-relative path exists but the
+        artifact is corrupt/invalid, the loader should fall back to the
+        models_dir copy if one exists.
+        """
+        # Create a bad artifact in CWD-relative location.
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        cwd_artifact_dir = workdir / "data" / "models"
+        cwd_artifact_dir.mkdir(parents=True)
+        cwd_artifact = cwd_artifact_dir / "hybrid.json"
+        cwd_artifact.write_text(json.dumps({"artifact_type": "wrong"}))
+
+        # Create the same relative name in models_dir (also bad — we just
+        # want to verify the fallback attempt happens).
+        models_dir = tmp_path / "shared_models"
+        models_dir.mkdir()
+        fallback_artifact = models_dir / "data" / "models" / "hybrid.json"
+        fallback_artifact.parent.mkdir(parents=True)
+        fallback_artifact.write_text(json.dumps({"artifact_type": "also_wrong"}))
+
+        monkeypatch.chdir(workdir)
+        config = HostedPlayConfig(
+            hybrid_olsa_artifact="data/models/hybrid.json",
+            models_dir=str(models_dir),
+        )
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="web.ai_manager"):
+            mgr = AIManager(config)
+
+        # Neither artifact is valid, so hybrid_olsa is not loaded.
+        assert "hybrid_olsa" not in mgr.available_models
+
+        # Both load attempts should be logged — CWD first, then models_dir.
+        warning_messages = [
+            r.message for r in caplog.records if r.levelno >= logging.WARNING
+        ]
+        assert any(
+            "Failed to load hybrid_olsa from data/models/hybrid.json" in m
+            for m in warning_messages
+        ), f"Expected CWD attempt warning; got: {warning_messages}"
+        assert any(
+            str(models_dir) in m and "Failed to load" in m for m in warning_messages
+        ), f"Expected models_dir fallback attempt warning; got: {warning_messages}"
+
     def test_hybrid_olsa_relative_without_models_dir_not_resolved(self):
         """A relative artifact with no models_dir stays relative (likely not found)."""
         config = HostedPlayConfig(

--- a/web/ai_manager.py
+++ b/web/ai_manager.py
@@ -76,13 +76,45 @@ class AIManager:
         )
 
         # 2. hybrid_olsa — available when artifact path is set and exists
+        self._try_load_hybrid_olsa(config)
+
+        # Validate default_model_id is available
+        if self.default_model_id not in self.available_models:
+            logger.warning(
+                "Default model %r not in roster; falling back to 'heuristic'",
+                self.default_model_id,
+            )
+            self.default_model_id = "heuristic"
+
+    def _try_load_hybrid_olsa(self, config: HostedPlayConfig) -> None:
+        """Attempt to load hybrid_olsa, resolving artifact path with fallback.
+
+        Resolution order for relative paths when ``models_dir`` is configured:
+        1. Try the CWD-relative path first (preserve existing local artifacts).
+        2. If CWD path doesn't exist **or** loading from it fails, fall back to
+           ``models_dir / artifact_path``.
+        """
         artifact_path = config.hybrid_olsa_artifact
-        # Resolve relative artifact paths against models_dir when configured,
-        # but only if the path doesn't already resolve from the working directory.
-        if artifact_path and config.models_dir and not os.path.isabs(artifact_path):
-            if not os.path.isfile(artifact_path):
-                artifact_path = os.path.join(config.models_dir, artifact_path)
-        if artifact_path and os.path.isfile(artifact_path):
+        if not artifact_path:
+            return
+
+        # Build ordered list of candidate paths to try.
+        candidates: list[str] = []
+        if config.models_dir and not os.path.isabs(artifact_path):
+            if os.path.isfile(artifact_path):
+                # CWD path exists — try it first, models_dir as fallback.
+                candidates.append(artifact_path)
+                candidates.append(os.path.join(config.models_dir, artifact_path))
+            else:
+                # CWD path missing — try models_dir only.
+                candidates.append(os.path.join(config.models_dir, artifact_path))
+        else:
+            # Absolute path or no models_dir — use as-is.
+            candidates.append(artifact_path)
+
+        for path in candidates:
+            if not os.path.isfile(path):
+                continue
             try:
                 from bid_euchre.strategy.bidding import HybridOLSaBidder
 
@@ -93,26 +125,19 @@ class AIManager:
                         "Statistical bidder (OLS payoff model with "
                         "risk-aware evaluation) and greedy play."
                     ),
-                    bidding_policy=HybridOLSaBidder(artifact_path=artifact_path),
+                    bidding_policy=HybridOLSaBidder(artifact_path=path),
                     play_strategy=GluttonStrategy(),
                 )
-                logger.info("Loaded hybrid_olsa model from %s", artifact_path)
+                logger.info("Loaded hybrid_olsa model from %s", path)
+                return
             except Exception:
                 logger.warning(
                     "Failed to load hybrid_olsa from %s",
-                    artifact_path,
+                    path,
                     exc_info=True,
                 )
-        elif artifact_path:
-            logger.info(
-                "hybrid_olsa artifact configured but file not found: %s",
-                artifact_path,
-            )
 
-        # Validate default_model_id is available
-        if self.default_model_id not in self.available_models:
-            logger.warning(
-                "Default model %r not in roster; falling back to 'heuristic'",
-                self.default_model_id,
-            )
-            self.default_model_id = "heuristic"
+        logger.info(
+            "hybrid_olsa artifact configured but not loadable: %s",
+            artifact_path,
+        )


### PR DESCRIPTION
## Summary
- Extract hybrid_olsa loading into `_try_load_hybrid_olsa` with candidate-path iteration
- When a CWD-relative artifact exists but fails to load (e.g., corrupt file), the loader now falls back to the `models_dir` copy instead of silently giving up
- Add regression test verifying both CWD and models_dir load attempts are logged

## Why
Review coordinator follow-up from PR #1695. The original fix preserved CWD-relative paths
but did not try the models_dir fallback when the CWD artifact existed but failed to load.

## Test Criteria
- **Pass:** `test_hybrid_olsa_cwd_failure_falls_back_to_models_dir` — verifies both CWD and models_dir paths are attempted when CWD artifact is invalid
- **Pass:** All 16 existing ai_manager tests continue to pass (no regressions)
- **Fail:** If only the CWD path is tried (no fallback warning logged for models_dir)

## Repro / Validation
```bash
uv run python -m pytest tests/unit/hosted_play/test_ai_manager.py -v
```

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_ai_manager.py -v` — 17 passed
- [x] `make check-quiet` — all checks passed

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
branch: fix/ai-manager-models-dir-fallback-1700
```

Closes #1700

🤖 Generated with [Claude Code](https://claude.com/claude-code)