### PR TITLE
fix(ops): wire /park into orchestrator shutdown flow (#1673)

### DIFF
--- a/.claude/agents/steward-orchestrator.md
+++ b/.claude/agents/steward-orchestrator.md
@@ -168,7 +168,8 @@ When parking a lane (no more work to assign), always use `/park` before
 context but leaves cron jobs running — they will continue firing on a
 lane the orchestrator considers stopped.
 
-Shutdown sequence:
+### Parking an Author Lane
+
 1. Complete or reassign any active task packet for the lane:
    ```bash
    # If the lane has finished its work:
@@ -179,6 +180,35 @@ Shutdown sequence:
 2. Send `/park` to the lane's tmux pane (cleans up cron jobs)
 3. Wait for confirmation that all cron jobs are deleted
 4. Send `/clear` to reset conversation context
+
+### Session-End Shutdown (Orchestrator Exit)
+
+Before the orchestrator ends its own session, it **must** park the ops and
+review lanes to prevent orphaned cron jobs. These lanes run persistent
+monitoring and polling crons that continue firing after the orchestrator
+stops reading them.
+
+Orchestrator exit sequence:
+1. Park **ops** lane: send `/park` to its tmux pane, wait for confirmation
+2. Park **review** lane: send `/park` to its tmux pane, wait for confirmation
+3. Park any **idle author lanes** that still have active sessions
+4. Verify all parked lanes report zero active cron jobs
+5. Write the session handoff document
+6. Park the orchestrator's own cron jobs (run `/park` locally)
+
+```bash
+# Park central lanes
+tmux send-keys -t steward:ops '/park' Enter
+# Wait for "0 cron jobs" confirmation, then:
+tmux send-keys -t steward:review '/park' Enter
+# Wait for confirmation, then park idle authors:
+tmux send-keys -t steward:author-a '/park' Enter
+# ... repeat for each idle author lane with an active session
+```
+
+**Critical rule:** Do not write a session handoff while ops or review lanes
+still have active cron jobs. The handoff signals "session ended" — but
+orphaned crons mean the session is still consuming resources.
 
 ## Named Skills
 

--- a/.claude/skills/run-fleet/SKILL.md
+++ b/.claude/skills/run-fleet/SKILL.md
@@ -264,6 +264,39 @@ At the end of the run, produce a compact handoff:
 - What is blocked
 - Recommended next wave
 
+## Shutdown Sequence
+
+Before ending the fleet run, park all lanes with active sessions to prevent
+orphaned cron jobs. `/clear` alone does **not** stop cron jobs — always
+`/park` first.
+
+1. **Park central lanes** — ops and review run persistent monitoring crons
+   that must be stopped before the orchestrator exits:
+   ```bash
+   tmux send-keys -t steward:ops '/park' Enter
+   # Wait for "0 cron jobs" confirmation
+   tmux send-keys -t steward:review '/park' Enter
+   # Wait for confirmation
+   ```
+
+2. **Park idle author lanes** — any author lane with an active session but
+   no dispatched work:
+   ```bash
+   tmux send-keys -t steward:author-a '/park' Enter
+   # ... repeat for each idle lane with an active session
+   ```
+
+3. **Verify cleanup** — confirm all parked lanes report zero active cron jobs
+
+4. **Write session handoff** — only after all lanes are parked
+
+5. **Park orchestrator** — run `/park` locally to clean up the orchestrator's
+   own cron jobs (e.g., the inbox-polling cron from the Startup Checklist)
+
+**Critical rule:** Do not write the session handoff while ops or review lanes
+still have active cron jobs. Orphaned crons burn tokens and send alerts to
+an orchestrator that has stopped reading them.
+
 ## Success Condition
 
 - Maximize safe, observable, mergeable progress across all active tracks


### PR DESCRIPTION
## Summary

- Add "Session-End Shutdown (Orchestrator Exit)" subsection to `steward-orchestrator.md` documenting that the orchestrator must `/park` ops and review lanes before writing session handoffs
- Add "Shutdown Sequence" section to `/run-fleet` SKILL.md with explicit steps to park central lanes, idle authors, and the orchestrator itself before exit

## Why

Orphaned cron jobs on ops and review lanes continue firing after the orchestrator session ends, burning tokens and sending alerts to an inbox nobody reads. This was observed at the end of the 2026-03-24d fleet run. The `/park` skill exists but wasn't wired into the orchestrator's exit flow.

## Repro / Validation

```bash
make repo-lint   # Passes
make docs-check  # Passes
```

Docs-only change — no Python code modified.

## Tests

- `make repo-lint` — passes
- `make docs-check` — passes

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
branch: fix/park-orchestrator-shutdown
```

Closes #1673

🤖 Generated with [Claude Code](https://claude.com/claude-code)