### PR TITLE
fix: add Write permission for SKILL.md to prevent lane stalls (#1710)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -88,7 +88,8 @@
   },
   "permissions": {
     "allow": [
-      "Edit(.claude/skills/**/SKILL.md)"
+      "Edit(.claude/skills/**/SKILL.md)",
+      "Write(.claude/skills/**/SKILL.md)"
     ]
   },
   "enabledPlugins": {


### PR DESCRIPTION
## Summary
- Add `Write(.claude/skills/**/SKILL.md)` permission alongside the existing `Edit` permission in `.claude/settings.json`

## Why
Convention follow-up from PR #1708. The Edit permission prevents interactive prompts when lanes modify existing SKILL.md files, but `Write` is needed when lanes create new SKILL.md files (e.g., after a `--reset`). Without this, lanes stall on interactive permission prompts.

## Test Criteria
- **Pass:** `jq -e ".permissions.allow" .claude/settings.json` shows both Edit and Write permissions
- **Fail:** Missing Write permission causes lane stalls on SKILL.md creation

## Repro / Validation
```bash
jq -e ".permissions.allow" .claude/settings.json
# ["Edit(.claude/skills/**/SKILL.md)", "Write(.claude/skills/**/SKILL.md)"]
```

## Tests
- Docs/config-only change — no code tests needed
- `make check-quiet` — all checks passed (previous branch)

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
branch: fix/skill-md-write-permission-1710
```

Closes #1710

🤖 Generated with [Claude Code](https://claude.com/claude-code)