### PR TITLE
fix(config): add Write permission for SKILL.md (#1710)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -78,7 +78,8 @@
   },
   "permissions": {
     "allow": [
-      "Edit(.claude/skills/**/SKILL.md)"
+      "Edit(.claude/skills/**/SKILL.md)",
+      "Write(.claude/skills/**/SKILL.md)"
     ]
   },
   "enabledPlugins": {


### PR DESCRIPTION
## Summary

- Add `Write(.claude/skills/**/SKILL.md)` to `.claude/settings.json` permissions
- Complements the existing `Edit` permission added in PR #1708

## Why

PR #1708 added `Edit(.claude/skills/**/SKILL.md)` to prevent lane stalls on permission prompts. The review coordinator identified that `Write` is also needed — lanes creating new SKILL.md files (not just editing existing ones) hit the same interactive prompt, stalling fleet runs after `--reset`.

## Repro / Validation

```bash
# Verify both permissions exist
python3 -c "import json; d=json.load(open('.claude/settings.json')); print(d['permissions'])"
# {'allow': ['Edit(.claude/skills/**/SKILL.md)', 'Write(.claude/skills/**/SKILL.md)']}

# Full validation
make check-quiet  # 7009 passed, 1 flaky timing test (pre-existing, unrelated)
```

## Tests

- `make check-quiet` — 7009 passed, 49 skipped, 1 pre-existing flaky timing test (`test_script_runs_quickly` — 2.70s vs 2.0s limit, unrelated to this change)

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: fix/skill-md-write-permission
```

Closes #1710

🤖 Generated with [Claude Code](https://claude.com/claude-code)