### PR TITLE
fix(web): preserve models_dir fallback after CWD artifact load failure

### DIFF
--- a/tests/unit/hosted_play/test_ai_manager.py
+++ b/tests/unit/hosted_play/test_ai_manager.py
@@ -155,6 +155,55 @@ class TestHybridOlsa:
             for m in caplog.messages
         )
 
+    def test_hybrid_olsa_falls_back_to_models_dir_on_cwd_load_failure(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """When CWD-relative artifact exists but fails to load, fall back to models_dir.
+
+        Regression test for #1700: if the CWD-relative file is found but
+        invalid, the loader should still try the models_dir candidate before
+        giving up.
+        """
+        # CWD has a bad artifact
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        rel_dir = workdir / "rel"
+        rel_dir.mkdir()
+        bad_artifact = rel_dir / "hybrid.json"
+        bad_artifact.write_text('{"artifact_type": "wrong"}')
+
+        # models_dir also has a bad artifact (we can't create a *valid* one
+        # easily in unit tests, but we can verify both paths are attempted)
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        models_rel = models_dir / "rel"
+        models_rel.mkdir()
+        also_bad = models_rel / "hybrid.json"
+        also_bad.write_text('{"artifact_type": "also_wrong"}')
+
+        monkeypatch.chdir(workdir)
+        config = HostedPlayConfig(
+            hybrid_olsa_artifact="rel/hybrid.json",
+            models_dir=str(models_dir),
+        )
+
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="web.ai_manager"):
+            mgr = AIManager(config)
+
+        assert "hybrid_olsa" not in mgr.available_models
+        # Both candidates should have been tried
+        assert any(
+            "Failed to load hybrid_olsa from rel/hybrid.json" in m
+            for m in caplog.messages
+        ), f"Expected CWD-relative attempt in logs: {caplog.messages}"
+        expected_fallback = str(models_dir / "rel" / "hybrid.json")
+        assert any(
+            f"Failed to load hybrid_olsa from {expected_fallback}" in m
+            for m in caplog.messages
+        ), f"Expected models_dir fallback attempt in logs: {caplog.messages}"
+
     def test_hybrid_olsa_relative_without_models_dir_not_resolved(self):
         """A relative artifact with no models_dir stays relative (likely not found)."""
         config = HostedPlayConfig(

--- a/web/ai_manager.py
+++ b/web/ai_manager.py
@@ -75,14 +75,43 @@ class AIManager:
             play_strategy=GluttonStrategy(),
         )
 
-        # 2. hybrid_olsa — available when artifact path is set and exists
-        artifact_path = config.hybrid_olsa_artifact
-        # Resolve relative artifact paths against models_dir when configured,
-        # but only if the path doesn't already resolve from the working directory.
-        if artifact_path and config.models_dir and not os.path.isabs(artifact_path):
-            if not os.path.isfile(artifact_path):
-                artifact_path = os.path.join(config.models_dir, artifact_path)
-        if artifact_path and os.path.isfile(artifact_path):
+        # 2. hybrid_olsa — available when artifact path is set and loadable
+        self._try_load_hybrid_olsa(config)
+
+        # Validate default_model_id is available
+        if self.default_model_id not in self.available_models:
+            logger.warning(
+                "Default model %r not in roster; falling back to 'heuristic'",
+                self.default_model_id,
+            )
+            self.default_model_id = "heuristic"
+
+    def _try_load_hybrid_olsa(self, config: HostedPlayConfig) -> None:
+        """Attempt to load hybrid_olsa from candidate paths.
+
+        Candidate priority:
+        1. CWD-relative (if the path is relative and the file exists)
+        2. models_dir-relative (if models_dir is configured)
+        3. The raw path as-is (absolute paths, or sole relative candidate)
+        """
+        raw_path = config.hybrid_olsa_artifact
+        if not raw_path:
+            return
+
+        # Build candidate paths in priority order
+        candidates: list[str] = []
+        if os.path.isabs(raw_path):
+            candidates.append(raw_path)
+        else:
+            candidates.append(raw_path)  # CWD-relative first
+            if config.models_dir:
+                models_dir_path = os.path.join(config.models_dir, raw_path)
+                if models_dir_path != raw_path:
+                    candidates.append(models_dir_path)
+
+        for path in candidates:
+            if not os.path.isfile(path):
+                continue
             try:
                 from bid_euchre.strategy.bidding import HybridOLSaBidder
 
@@ -93,26 +122,19 @@ class AIManager:
                         "Statistical bidder (OLS payoff model with "
                         "risk-aware evaluation) and greedy play."
                     ),
-                    bidding_policy=HybridOLSaBidder(artifact_path=artifact_path),
+                    bidding_policy=HybridOLSaBidder(artifact_path=path),
                     play_strategy=GluttonStrategy(),
                 )
-                logger.info("Loaded hybrid_olsa model from %s", artifact_path)
+                logger.info("Loaded hybrid_olsa model from %s", path)
+                return
             except Exception:
                 logger.warning(
                     "Failed to load hybrid_olsa from %s",
-                    artifact_path,
+                    path,
                     exc_info=True,
                 )
-        elif artifact_path:
-            logger.info(
-                "hybrid_olsa artifact configured but file not found: %s",
-                artifact_path,
-            )
 
-        # Validate default_model_id is available
-        if self.default_model_id not in self.available_models:
-            logger.warning(
-                "Default model %r not in roster; falling back to 'heuristic'",
-                self.default_model_id,
-            )
-            self.default_model_id = "heuristic"
+        logger.info(
+            "hybrid_olsa artifact configured but not loadable: %s",
+            raw_path,
+        )


### PR DESCRIPTION
## Plan
N/A — convention follow-up from review of PR #1695.

## Summary
- Refactored hybrid_olsa loading to try candidate paths in priority order (CWD-relative → models_dir)
- When a CWD-relative artifact file exists but fails to load, the loader now falls back to the models_dir-resolved path before giving up
- Extracted `_try_load_hybrid_olsa` method for clarity

## Why
PR #1695 fixed CWD-relative path preservation when `MODELS_DIR` is set, but the
review coordinator (#1700) identified that if the CWD-relative file exists but
fails to load (e.g., corrupt format), the models_dir fallback was never tried.
The candidate-based approach ensures both paths are attempted in order.

Closes #1700

## Repro / Validation
**Command(s) run:**
```
uv run python -m pytest tests/unit/hosted_play/test_ai_manager.py -v
make check-quiet
```

## Test Criteria
- **Pass condition:** Both CWD-relative and models_dir paths are attempted when CWD-relative load fails
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_ai_manager.py::TestHybridOlsa::test_hybrid_olsa_falls_back_to_models_dir_on_cwd_load_failure -v`
- **Expected result:** Test passes — both candidate paths are attempted (verified via log messages)

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_ai_manager.py -v` — 17 passed
- [x] `make check-quiet` — 7015 passed, 50 skipped, 1 pre-existing flaky timing failure (unrelated `test_script_runs_quickly`)

## Expected impact
- Metrics impact: none
- Runtime impact: none

## Risk level
- [x] Low (bugfix + test)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)