### PR TITLE
ops: add steward-analyst to central-ops tmux layout (#1677)

### DIFF
--- a/.claude/rules/75_worktree_protection.md
+++ b/.claude/rules/75_worktree_protection.md
@@ -26,6 +26,7 @@ These worktrees are permanent and must not be deleted:
 - `Bid-Euchre-steward-flex-c`
 
 **Control plane:**
+- `Bid-Euchre-steward-analyst`
 - `Bid-Euchre-steward-review`
 - `Bid-Euchre-steward-ops`
 

--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -4,10 +4,11 @@
 #
 # Creates (or attaches to) a tmux session with 4 windows:
 #
-#   Window 1 — central-ops (3 panes, main-vertical layout)
-#     .1  orchestrator    -- single intake point (large left, ~66%)
-#     .2  ops             -- operator monitoring lane (top right)
-#     .3  review          -- independent review lane (bottom right)
+#   Window 1 — central-ops (4 panes, tiled layout)
+#     .1  orchestrator      -- single intake point
+#     .2  steward-analyst   -- shaping, triage, plan review
+#     .3  ops               -- operator monitoring lane
+#     .4  review            -- independent review lane
 #
 #   Window 2 — platform (4 panes, tiled)
 #     .1  author-a        -- primary platform author lane
@@ -88,6 +89,7 @@ FLEX_C="${PARENT_DIR}/${REPO_NAME}-steward-flex-c"
 # Control plane
 REVIEW="${PARENT_DIR}/${REPO_NAME}-steward-review"
 OPS="${PARENT_DIR}/${REPO_NAME}-steward-ops"
+ANALYST="${PARENT_DIR}/${REPO_NAME}-steward-analyst"
 MAIN_DIR="$(git -C "$MAIN_DIR" worktree list 2>/dev/null | head -1 | awk '{print $1}')"
 
 # ---------------------------------------------------------------------------
@@ -294,17 +296,19 @@ ensure_worktree "$FLEX_C" "codex/steward-flex-c"
 # Control plane
 ensure_detached_worktree "$REVIEW"
 ensure_detached_worktree "$OPS"
+ensure_detached_worktree "$ANALYST"
 
 # Write v2 registry metadata for each lane.
 # tmux_window = group name, tmux_pane = 1-based pane index within the window.
 # Pane target format: ${SESSION}:${tmux_window}.${tmux_pane}
 # Indices are 1-based to match tmux pane-base-index=1.
 
-# Central ops  (window: central-ops, panes 1-3, main-vertical layout)
+# Central ops  (window: central-ops, panes 1-4, tiled layout)
 # Note: pane indices are 1-based to match tmux pane-base-index=1.
 write_lane_metadata "orchestrator"   "orchestrator" "$MAIN_DIR"       "--"                              "central-ops" "1" "foreground" "Orchestrator"
-write_lane_metadata "ops"            "ops"          "$OPS"            "detached"                        "central-ops" "2" "foreground" "Ops"
-write_lane_metadata "review"         "review"       "$REVIEW"         "detached"                        "central-ops" "3" "foreground" "Review"
+write_lane_metadata "analyst"        "analyst"      "$ANALYST"        "detached"                        "central-ops" "2" "foreground" "Analyst"
+write_lane_metadata "ops"            "ops"          "$OPS"            "detached"                        "central-ops" "3" "foreground" "Ops"
+write_lane_metadata "review"         "review"       "$REVIEW"         "detached"                        "central-ops" "4" "foreground" "Review"
 
 # Platform workers  (window: platform, panes 1-4)
 write_lane_metadata "author-a"       "author"       "$AUTHOR_A"       "codex/steward-author"            "platform" "1" "background" "Author A"
@@ -340,12 +344,11 @@ if [ "$STEWARD_TELEGRAM_ENABLED" = "1" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Window + pane creation — 4 windows (central-ops: 3 panes, others: 4 panes)
+# Window + pane creation — 4 windows (central-ops: 4 panes tiled, others: 4 panes tiled)
 # ---------------------------------------------------------------------------
-# central-ops uses main-vertical: orchestrator large left, ops/review stacked right.
-# Worker windows use tiled: 4 equal quadrants.
+# All windows use tiled: 4 equal quadrants.
 
-# --- Window 1: central-ops (3 panes, main-vertical) ---
+# --- Window 1: central-ops (4 panes, tiled) ---
 tmux new-session -d -s "$SESSION" -n central-ops -c "$MAIN_DIR" \
     "$CLAUDE_BIN" --name orchestrator --agent steward-orchestrator $ORCH_CHANNEL_FLAGS
 
@@ -357,11 +360,13 @@ if [ -n "$STEWARD_CHANNELS" ]; then
 fi
 tmux set-environment -t "$SESSION" STEWARD_TELEGRAM_ENABLED "$STEWARD_TELEGRAM_ENABLED"
 
+tmux split-window -t "${SESSION}:central-ops" -c "$ANALYST" \
+    "$CLAUDE_BIN" --name analyst --agent steward-analyst
 tmux split-window -t "${SESSION}:central-ops" -c "$OPS" \
     "$CLAUDE_BIN" --name ops --agent steward-ops
 tmux split-window -t "${SESSION}:central-ops" -c "$REVIEW" \
     "$CLAUDE_BIN" --name review --agent steward-review
-tmux select-layout -t "${SESSION}:central-ops" main-vertical
+tmux select-layout -t "${SESSION}:central-ops" tiled
 
 # --- Window 2: platform ---
 tmux new-window -t "$SESSION" -n platform -c "$AUTHOR_A" \
@@ -399,11 +404,11 @@ tmux select-layout -t "${SESSION}:scratch" tiled
 # Auto-launch ops monitoring loop (SP-3-08).
 # Wait briefly for the claude process to initialize, then send the /loop
 # command.  Best-effort — if it fails the ops agent can start it manually.
-# Target: central-ops window, pane 2 (ops lane).
-# Note: pane-base-index=1, so orchestrator=.1, ops=.2, review=.3.
+# Target: central-ops window, pane 3 (ops lane).
+# Note: pane-base-index=1, so orchestrator=.1, analyst=.2, ops=.3, review=.4.
 (
     sleep 10
-    tmux send-keys -t "${SESSION}:central-ops.2" \
+    tmux send-keys -t "${SESSION}:central-ops.3" \
         "/loop 3m uv run python scripts/internal/ops.py monitor" Enter
 ) &
 
@@ -411,10 +416,10 @@ tmux select-layout -t "${SESSION}:scratch" tiled
 # Triggers the review agent's startup behavior: discover recent merges,
 # review diffs, triage findings, then poll every 15 minutes.
 # Best-effort — if it fails the review agent can start it manually.
-# Target: central-ops window, pane 3 (review lane).
+# Target: central-ops window, pane 4 (review lane).
 (
     sleep 15
-    tmux send-keys -t "${SESSION}:central-ops.3" \
+    tmux send-keys -t "${SESSION}:central-ops.4" \
         "Review recently merged PRs and triage findings. Set up a 15m recurring poll." Enter
 ) &
 

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -278,16 +278,17 @@ class TestStewardSessionScript:
 
 
 class TestWindowLayout:
-    """Validate the 4-window layout (central-ops: 3 panes, others: 4 panes)."""
+    """Validate the 4-window layout (all windows: 4 panes tiled)."""
 
     EXPECTED_WINDOWS = ["central-ops", "platform", "browser", "scratch"]
 
-    # Worker windows with 4 tiled panes each
-    TILED_WINDOWS = ["platform", "browser", "scratch"]
+    # All windows use 4 tiled panes
+    TILED_WINDOWS = ["central-ops", "platform", "browser", "scratch"]
 
     EXPECTED_LANES = [
-        # Central ops (3 panes)
+        # Central ops (4 panes)
         "orchestrator",
+        "analyst",
         "ops",
         "review",
         # Platform workers
@@ -309,7 +310,7 @@ class TestWindowLayout:
 
     # Lanes per window, in pane creation order (pane 1 = first, 1-based)
     WINDOW_PANES = {
-        "central-ops": ["orchestrator", "ops", "review"],
+        "central-ops": ["orchestrator", "analyst", "ops", "review"],
         "platform": ["author-a", "author-b", "author-c", "author-d"],
         "browser": [
             "brws-author-a",
@@ -363,20 +364,20 @@ class TestWindowLayout:
                 f"-n {window_name}" in content
             ), f"Expected window named '{window_name}'"
 
-    def test_central_ops_has_3_panes(self) -> None:
-        """central-ops must have 2 split-window commands (for 3 panes total)."""
+    def test_central_ops_has_4_panes(self) -> None:
+        """central-ops must have 3 split-window commands (for 4 panes total)."""
         content = STEWARD_SCRIPT.read_text()
         split_count = content.count('split-window -t "${SESSION}:central-ops"')
         assert (
-            split_count == 2
-        ), f"central-ops must have 2 split-window commands, found {split_count}"
+            split_count == 3
+        ), f"central-ops must have 3 split-window commands, found {split_count}"
 
-    def test_central_ops_main_vertical(self) -> None:
-        """central-ops must use main-vertical layout (orchestrator large left)."""
+    def test_central_ops_tiled(self) -> None:
+        """central-ops must use tiled layout (4 equal quadrants)."""
         content = STEWARD_SCRIPT.read_text()
         assert (
-            'select-layout -t "${SESSION}:central-ops" main-vertical' in content
-        ), "central-ops must use main-vertical layout"
+            'select-layout -t "${SESSION}:central-ops" tiled' in content
+        ), "central-ops must use tiled layout"
 
     def test_worker_windows_have_4_panes(self) -> None:
         """Each worker window must have 3 split-window commands (for 4 panes)."""
@@ -397,7 +398,7 @@ class TestWindowLayout:
             ), f"Window '{window_name}' must have select-layout tiled"
 
     def test_all_lanes_launched(self) -> None:
-        """All 15 lanes must appear in new-session, new-window, or split-window."""
+        """All 16 lanes must appear in new-session, new-window, or split-window."""
         content = STEWARD_SCRIPT.read_text()
         for lane in self.EXPECTED_LANES:
             assert (
@@ -442,7 +443,7 @@ class TestWindowLayout:
     def test_central_ops_foreground(self) -> None:
         """Central ops lanes must have foreground visibility."""
         metadata_lines = self._metadata_invocation_lines()
-        central_ops_lanes = {"orchestrator", "ops", "review"}
+        central_ops_lanes = {"orchestrator", "analyst", "ops", "review"}
         for line in metadata_lines:
             for lane in central_ops_lanes:
                 if f'"{lane}"' in line and line.index(f'"{lane}"') < 30:
@@ -475,20 +476,20 @@ class TestWindowLayout:
                     ), f"Worker lane must be background: {line.strip()}"
 
     def test_ops_monitoring_targets_correct_pane(self) -> None:
-        """The ops monitoring loop must target central-ops.2 (ops pane).
+        """The ops monitoring loop must target central-ops.3 (ops pane).
 
-        With pane-base-index=1: orchestrator=.1, ops=.2, review=.3.
+        With pane-base-index=1: orchestrator=.1, analyst=.2, ops=.3, review=.4.
         """
         content = STEWARD_SCRIPT.read_text()
-        assert "central-ops.2" in content, "Ops monitoring must target central-ops.2"
+        assert "central-ops.3" in content, "Ops monitoring must target central-ops.3"
 
     def test_review_loop_targets_correct_pane(self) -> None:
-        """The merged-PR review loop must target central-ops.3 (review pane).
+        """The merged-PR review loop must target central-ops.4 (review pane).
 
-        With pane-base-index=1: orchestrator=.1, ops=.2, review=.3.
+        With pane-base-index=1: orchestrator=.1, analyst=.2, ops=.3, review=.4.
         """
         content = STEWARD_SCRIPT.read_text()
-        assert "central-ops.3" in content, "Review loop must target central-ops.3"
+        assert "central-ops.4" in content, "Review loop must target central-ops.4"
 
     def test_review_pane_sends_natural_language_prompt(self) -> None:
         """The review pane auto-launch must send a natural-language prompt,
@@ -542,7 +543,7 @@ class TestWindowLayout:
         ), f"Ops metadata must use 'detached' branch: {line.strip()}"
 
     def test_ensure_detached_worktree_used_for_control_plane(self) -> None:
-        """Both review and ops worktrees must use ensure_detached_worktree."""
+        """Review, ops, and analyst worktrees must use ensure_detached_worktree."""
         content = STEWARD_SCRIPT.read_text()
         assert (
             'ensure_detached_worktree "$REVIEW"' in content
@@ -550,6 +551,9 @@ class TestWindowLayout:
         assert (
             'ensure_detached_worktree "$OPS"' in content
         ), "Ops worktree must use ensure_detached_worktree"
+        assert (
+            'ensure_detached_worktree "$ANALYST"' in content
+        ), "Analyst worktree must use ensure_detached_worktree"
 
     def test_browser_game_worktree_paths(self) -> None:
         """Script must define BRWS_A through BRWS_D worktree paths."""


### PR DESCRIPTION
## Summary
- Add `steward-analyst` as a 4th pane in the central-ops tmux window
- Switch central-ops from 3-pane `main-vertical` to 4-pane `tiled` layout (matching all other windows)
- Add `Bid-Euchre-steward-analyst` to the worktree protection list

## Why
The analyst service role (PR #1613) had no persistent lane in the tmux layout. The orchestrator rules reference routing work to `steward-analyst` but there was no visible pane to host it. This adds the analyst as a foreground control-plane lane.

## Changes
| File | Change |
|------|--------|
| `.claude/tmux/steward-session.sh` | Add `ANALYST` worktree var, `ensure_detached_worktree`, split-window, `write_lane_metadata`; switch central-ops to tiled; update auto-launch pane indices (ops→.3, review→.4) |
| `.claude/rules/75_worktree_protection.md` | Add `Bid-Euchre-steward-analyst` to control plane protected list |
| `tests/unit/test_steward_session.py` | Update all layout tests for 4-pane central-ops (expected lanes, pane counts, layout type, pane indices) |

## Proposed central-ops layout (after)
```
Window 1 — central-ops (4 panes, tiled)
  .1  orchestrator      -- single intake point
  .2  steward-analyst   -- shaping, triage, plan review
  .3  ops               -- operator monitoring
  .4  review            -- independent review
```

## Validation
```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/test_steward_session.py -v  # 56 passed

# Tier 2 — full validation
make check-quiet  # 6971 passed, 1 unrelated flaky failure (timing test)

# Bash syntax
bash -n .claude/tmux/steward-session.sh  # OK
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b
branch: ops/add-analyst-pane
```

Closes #1677

🤖 Generated with [Claude Code](https://claude.com/claude-code)