### PR TITLE
fix(convention): move pytestmark before helpers in test_controller_projection (#1713)

### DIFF
--- a/tests/integration/test_controller_projection.py
+++ b/tests/integration/test_controller_projection.py
@@ -44,6 +44,8 @@ from bid_euchre.ops.message_bus import (
     shared_bus_root,
 )
 
+pytestmark = pytest.mark.integration
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -75,9 +77,6 @@ def _old_urgent_message_dict(
         "created_at": created_at,
         "summary": summary,
     }
-
-
-pytestmark = pytest.mark.integration
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Move `pytestmark = pytest.mark.integration` from line 80 (after helper function) to line 47 (immediately after import block) in `test_controller_projection.py`

## Why

PR #1705 standardized pytestmark placement immediately after the import block across all 36 integration test files. PR #1707 introduced `test_controller_projection.py` with the marker placed after a 26-line helper function, breaking this convention.

## Repro / Validation

```bash
# Verify marker is at module top (before helpers)
grep -n "pytestmark" tests/integration/test_controller_projection.py
# Expected: line 47, before any function definitions

make check-quiet  # All checks pass
```

## Tests

```bash
make check-quiet  # ✓ All checks passed
uv run python -m pytest tests/integration/test_controller_projection.py --co -q  # 11 tests collected
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
branch: fix/pytestmark-placement-1713
```

Closes #1713

🤖 Generated with [Claude Code](https://claude.com/claude-code)