### PR TITLE
feat(ops): add --max-age filter and bulk-ack alias to inbox ack-all (#1717)

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -1859,22 +1859,49 @@ def cmd_inbox(args: argparse.Namespace) -> int:
             print(f"  Status: {result.get('status', '?')}")
         return 0
 
-    elif action == "ack-all":
+    elif action in ("ack-all", "bulk-ack"):
         import re
+        from datetime import datetime, timezone
 
         lane = getattr(args, "lane", None)
         if not lane:
             print(
-                "Usage: ops.py inbox ack-all --lane LANE [--filter-summary PATTERN]",
+                "Usage: ops.py inbox ack-all --lane LANE"
+                " [--filter-summary PATTERN] [--max-age HOURS]",
                 file=sys.stderr,
             )
             return 1
+
+        # Build composable filter predicates
+        predicates: list = []
+
         summary_pattern = getattr(args, "filter_summary", None)
         if summary_pattern:
             pat = re.compile(summary_pattern, re.IGNORECASE)
+            predicates.append(lambda msg: bool(pat.search(msg.get("summary", ""))))
+
+        max_age_hours = getattr(args, "max_age", None)
+        if max_age_hours is not None:
+            cutoff = datetime.now(timezone.utc).timestamp() - max_age_hours * 3600
+
+            def _older_than_cutoff(msg: dict) -> bool:
+                created = msg.get("created_at", "")
+                if not created:
+                    return False
+                try:
+                    ts = datetime.fromisoformat(
+                        created.replace("Z", "+00:00")
+                    ).timestamp()
+                except (ValueError, TypeError):
+                    return False
+                return ts < cutoff
+
+            predicates.append(_older_than_cutoff)
+
+        if predicates:
 
             def filter_fn(msg: dict) -> bool:
-                return bool(pat.search(msg.get("summary", "")))
+                return all(p(msg) for p in predicates)
         else:
 
             def filter_fn(msg: dict) -> bool:
@@ -3442,7 +3469,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     inbox_ack_all_parser = inbox_sub.add_parser(
-        "ack-all", help="Bulk-acknowledge inbox messages"
+        "ack-all",
+        aliases=["bulk-ack"],
+        help="Bulk-acknowledge inbox messages",
     )
     inbox_ack_all_parser.add_argument(
         "--lane", required=True, help="Lane whose inbox to bulk-ack"
@@ -3451,6 +3480,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--filter-summary",
         default=None,
         help="Regex pattern to match against message summary (case-insensitive)",
+    )
+    inbox_ack_all_parser.add_argument(
+        "--max-age",
+        type=float,
+        default=None,
+        help="Only ack messages older than N hours (based on created_at)",
     )
 
     inbox_purge_parser = inbox_sub.add_parser(

--- a/tests/unit/test_ops_message_bus.py
+++ b/tests/unit/test_ops_message_bus.py
@@ -1152,6 +1152,53 @@ class TestBulkAckMessages:
         assert len(ack_events) == 2
         assert all(ev["payload"].get("bulk") is True for ev in ack_events)
 
+    def test_bulk_ack_with_age_filter(self, bus_root: Path, events_dir: Path) -> None:
+        """Only messages older than cutoff are acked when age filter is used."""
+        from datetime import datetime, timezone
+
+        m1 = create_message("a", "target", "assignment", "Old task")
+        m2 = create_message("a", "target", "progress", "New task")
+        send_message(m1, bus_root, events_dir=events_dir)
+        send_message(m2, bus_root, events_dir=events_dir)
+
+        # Patch m1's created_at to be very old by rewriting the inbox
+        inbox_path = bus_root / "inbox" / "target.jsonl"
+        lines = inbox_path.read_text().strip().split("\n")
+        patched: list[str] = []
+        old_ts = datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        for line in lines:
+            rec = json.loads(line)
+            if rec.get("message_id") == m1.message_id:
+                rec["created_at"] = old_ts
+            patched.append(json.dumps(rec))
+        inbox_path.write_text("\n".join(patched) + "\n")
+
+        # Cutoff: 4 hours — only m1 (very old) should match
+        cutoff_ts = datetime.now(timezone.utc).timestamp() - 4 * 3600
+
+        def older_than_cutoff(msg: dict) -> bool:
+            created = msg.get("created_at", "")
+            if not created:
+                return False
+            try:
+                ts = datetime.fromisoformat(created.replace("Z", "+00:00")).timestamp()
+            except (ValueError, TypeError):
+                return False
+            return ts < cutoff_ts
+
+        acked = bulk_ack_messages(
+            "target", older_than_cutoff, bus_root, events_dir=events_dir
+        )
+        assert len(acked) == 1
+        assert acked[0]["message_id"] == m1.message_id
+
+        # m2 (new) remains pending
+        inbox = read_inbox("target", bus_root, status="pending")
+        assert len(inbox) == 1
+        assert inbox[0]["message_id"] == m2.message_id
+
 
 # ---------------------------------------------------------------------------
 # TTL auto-expire on read


### PR DESCRIPTION
## Summary
- Add `--max-age HOURS` option to `inbox ack-all` CLI command to filter messages by age
- Add `bulk-ack` as a CLI alias for `ack-all` (matching the interface proposed in #1717)
- Composable filters: `--filter-summary` and `--max-age` can be used together

## Why
author-a accumulated ~2000 unacked inbox messages from prior sessions, dominating the dashboard. The existing ack-all has no way to selectively ack only stale messages while preserving recent ones.

## Repro / Validation
```bash
uv run python scripts/internal/ops.py inbox bulk-ack --lane author-a --max-age 4
uv run python scripts/internal/ops.py inbox ack-all --lane author-a --max-age 4 --filter-summary "Task dispatched"
```

## Tests
```bash
uv run python -m pytest tests/unit/test_ops_message_bus.py::TestBulkAckMessages -xvs
# All 6 tests pass including new test_bulk_ack_with_age_filter
```

## Worktree proof
Working in `Bid-Euchre-steward-author-c` worktree on branch `ops/bulk-ack-max-age`.

## Test criteria
- `inbox bulk-ack --help` shows `--max-age` option
- `inbox ack-all --lane X --max-age 4` only acks messages older than 4h
- New messages within the age window are preserved
- `--filter-summary` and `--max-age` compose correctly

Closes #1717