### PR TITLE
feat(ops): add worktree registry bulk registration (#1716)

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -215,6 +215,8 @@ def cmd_worktrees(args: argparse.Namespace) -> int:
         return cmd_worktrees_quarantine(args)
     if wt_action == "archive":
         return cmd_worktrees_archive(args)
+    if wt_action == "register-all":
+        return cmd_worktrees_register_all(args)
 
     from bid_euchre.ops.worktrees import (
         list_worktrees_git,
@@ -285,6 +287,52 @@ def cmd_worktrees(args: argparse.Namespace) -> int:
             print(f"\nWarnings: {len(report.warnings)}")
             for w in report.warnings:
                 print(f"  ⚠ {w}")
+
+    return 0
+
+
+def cmd_worktrees_register_all(args: argparse.Namespace) -> int:
+    """Scan git worktrees and create/update registry entries for steward lanes."""
+    from bid_euchre.ops.worktrees import register_all_worktrees
+
+    registry_dir = args.runtime_dir / "worktree_registry"
+    results = register_all_worktrees(registry_dir)
+
+    if args.json:
+        data = [
+            {
+                "lane_id": r.lane_id,
+                "worktree_path": r.worktree_path,
+                "action": r.action,
+                "reason": r.reason,
+            }
+            for r in results
+        ]
+        print(json.dumps(data, indent=2))
+    else:
+        created = [r for r in results if r.action == "created"]
+        updated = [r for r in results if r.action == "updated"]
+        skipped = [r for r in results if r.action == "skipped"]
+
+        print(
+            f"Registered {len(created)} new, updated {len(updated)}, skipped {len(skipped)}"
+        )
+        print()
+
+        if created:
+            print("Created:")
+            for r in created:
+                print(f"  {r.lane_id:20s} {r.worktree_path}")
+
+        if updated:
+            print("Updated:")
+            for r in updated:
+                print(f"  {r.lane_id:20s} {r.reason}")
+
+        if skipped:
+            print(f"\nSkipped ({len(skipped)}):")
+            for r in skipped:
+                print(f"  {r.lane_id:20s} {r.reason}")
 
     return 0
 
@@ -3005,6 +3053,11 @@ def build_parser() -> argparse.ArgumentParser:
     archive_parser.add_argument("path", type=str, help="Worktree path to archive")
     archive_parser.add_argument(
         "--force", action="store_true", help="Force removal even if dirty"
+    )
+
+    wt_sub.add_parser(
+        "register-all",
+        help="Scan git worktrees and register all steward lanes",
     )
 
     # events (with nested "drain" subcommand)

--- a/src/bid_euchre/ops/worktrees.py
+++ b/src/bid_euchre/ops/worktrees.py
@@ -876,3 +876,242 @@ def archive_worktree(
         )
     except Exception:  # noqa: BLE001
         logger.warning("Failed to emit archive event for %s", worktree_path)
+
+
+# ---------------------------------------------------------------------------
+# Bulk registration: scan git worktrees → populate registry
+# ---------------------------------------------------------------------------
+
+#: Explicit mapping from steward worktree directory names to lane_ids.
+#: The primary author lane uses a bare suffix ("author") which maps to
+#: "author-a"; all others strip the "Bid-Euchre-steward-" prefix.
+_STEWARD_DIR_TO_LANE: dict[str, str] = {
+    "Bid-Euchre-steward-author": "author-a",
+    "Bid-Euchre-steward-author-b": "author-b",
+    "Bid-Euchre-steward-author-c": "author-c",
+    "Bid-Euchre-steward-author-d": "author-d",
+    "Bid-Euchre-steward-author-scratch": "author-scratch",
+    "Bid-Euchre-steward-brws-author-a": "brws-author-a",
+    "Bid-Euchre-steward-brws-author-b": "brws-author-b",
+    "Bid-Euchre-steward-brws-author-c": "brws-author-c",
+    "Bid-Euchre-steward-brws-author-d": "brws-author-d",
+    "Bid-Euchre-steward-flex-a": "flex-a",
+    "Bid-Euchre-steward-flex-b": "flex-b",
+    "Bid-Euchre-steward-flex-c": "flex-c",
+    "Bid-Euchre-steward-review": "review",
+    "Bid-Euchre-steward-ops": "ops",
+}
+
+
+def derive_lane_id(worktree_dir_name: str) -> str | None:
+    """Derive a lane_id from a worktree directory name.
+
+    Uses an explicit mapping for known steward worktrees. Falls back to
+    stripping the ``Bid-Euchre-steward-`` prefix for unknown steward
+    worktrees. Returns None for non-steward worktrees (main checkout,
+    ephemeral ``work-*`` worktrees, etc.).
+
+    Args:
+        worktree_dir_name: The basename of the worktree directory
+            (e.g., ``"Bid-Euchre-steward-author-b"``).
+
+    Returns:
+        Lane identifier string, or None if the worktree is not a
+        recognized steward lane.
+    """
+    # Exact match in the known mapping.
+    if worktree_dir_name in _STEWARD_DIR_TO_LANE:
+        return _STEWARD_DIR_TO_LANE[worktree_dir_name]
+
+    # Fallback: strip prefix for unknown steward worktrees.
+    prefix = "Bid-Euchre-steward-"
+    if worktree_dir_name.startswith(prefix):
+        suffix = worktree_dir_name[len(prefix) :]
+        if suffix:
+            return suffix
+
+    return None
+
+
+def derive_lane_class(lane_id: str) -> str:
+    """Derive the functional lane class from a lane_id.
+
+    Args:
+        lane_id: Lane identifier (e.g., ``"author-b"``, ``"ops"``).
+
+    Returns:
+        One of ``"ops"``, ``"review"``, ``"scratch"``, ``"author"``.
+    """
+    if lane_id == "ops":
+        return "ops"
+    if lane_id == "review":
+        return "review"
+    if lane_id.endswith("-scratch"):
+        return "scratch"
+    # author-*, brws-author-*, flex-* are all author-class lanes.
+    return "author"
+
+
+def derive_visibility(lane_id: str) -> str:
+    """Derive the default visibility for a lane.
+
+    Foreground lanes are supervisory roles visible in the dashboard's
+    primary pane. Background lanes are author/flex workers displayed
+    in the secondary section.
+
+    Args:
+        lane_id: Lane identifier.
+
+    Returns:
+        ``"foreground"`` or ``"background"``.
+    """
+    if lane_id in ("ops", "review", "orchestrator", "dashboard", "issues"):
+        return "foreground"
+    return "background"
+
+
+@dataclass
+class RegistrationResult:
+    """Result of registering one worktree."""
+
+    lane_id: str
+    worktree_path: str
+    action: str  # "created" | "updated" | "skipped"
+    reason: str
+
+
+def register_all_worktrees(
+    registry_dir: Path | None = None,
+    *,
+    git_worktrees: list[GitWorktree] | None = None,
+    now_iso: str | None = None,
+) -> list[RegistrationResult]:
+    """Scan git worktrees and create/update registry entries for steward lanes.
+
+    For each git worktree whose directory name maps to a known steward
+    lane, creates a v2 registry JSON file if none exists, or updates the
+    existing entry's ``last_active`` and ``branch`` fields.
+
+    Skips:
+    - The main checkout (bare or ``.git`` is a directory)
+    - Non-steward worktrees (no lane_id derivable)
+    - Worktrees that already have a current registry entry (unless
+      branch has changed)
+
+    Args:
+        registry_dir: Override for registry directory. Defaults to
+            ``.claude/runtime/worktree_registry``.
+        git_worktrees: Pre-loaded list of git worktrees. If None,
+            calls ``list_worktrees_git()`` to discover them.
+        now_iso: Override for the current timestamp (ISO 8601).
+
+    Returns:
+        List of ``RegistrationResult`` describing what was done for each
+        worktree.
+    """
+    if registry_dir is None:
+        registry_dir = DEFAULT_REGISTRY_DIR
+    registry_dir.mkdir(parents=True, exist_ok=True)
+
+    if git_worktrees is None:
+        git_worktrees = list_worktrees_git()
+
+    if now_iso is None:
+        now_iso = datetime.now(timezone.utc).isoformat()
+
+    # Load existing registry entries by lane_id for dedup.
+    existing_by_lane: dict[str, dict[str, Any]] = {}
+    for entry in list_worktrees_registry(registry_dir):
+        lid = entry.get("lane_id", "")
+        if lid:
+            existing_by_lane[lid] = entry
+
+    results: list[RegistrationResult] = []
+
+    for git_wt in git_worktrees:
+        # Skip bare and main checkout.
+        if git_wt.bare or is_main_worktree(git_wt.path):
+            continue
+
+        dir_name = Path(git_wt.path).name
+        lane_id = derive_lane_id(dir_name)
+
+        if lane_id is None:
+            results.append(
+                RegistrationResult(
+                    lane_id=dir_name,
+                    worktree_path=git_wt.path,
+                    action="skipped",
+                    reason="Not a recognized steward lane",
+                )
+            )
+            continue
+
+        lane_class = derive_lane_class(lane_id)
+        visibility = derive_visibility(lane_id)
+
+        # Check if already registered.
+        existing = existing_by_lane.get(lane_id)
+        if existing is not None:
+            # Update branch and last_active if branch changed.
+            if existing.get("branch") != git_wt.branch:
+                existing["branch"] = git_wt.branch
+                existing["last_active"] = now_iso
+                entry_file = registry_dir / f"{lane_id}.json"
+                entry_file.write_text(json.dumps(existing, indent=2) + "\n")
+                results.append(
+                    RegistrationResult(
+                        lane_id=lane_id,
+                        worktree_path=git_wt.path,
+                        action="updated",
+                        reason=f"Branch updated to {git_wt.branch}",
+                    )
+                )
+            else:
+                results.append(
+                    RegistrationResult(
+                        lane_id=lane_id,
+                        worktree_path=git_wt.path,
+                        action="skipped",
+                        reason="Already registered with current branch",
+                    )
+                )
+            continue
+
+        # Create new registry entry.
+        entry_data: dict[str, Any] = {
+            "schema_version": 2,
+            "lane_id": lane_id,
+            "lane_class": lane_class,
+            "worktree_path": git_wt.path,
+            "branch": git_wt.branch,
+            "class": "persistent",
+            "created_at": now_iso,
+            "last_active": now_iso,
+            "session_id": None,
+            "ttl_hours": None,
+            "display_name": None,
+            "tmux_session": "steward",
+            "tmux_window": None,
+            "tmux_pane": None,
+            "cmux_workspace_ref": None,
+            "cmux_surface_ref": None,
+            "legacy_role": None,
+            "session_handle": f"steward:{lane_id}",
+            "visibility": visibility,
+        }
+
+        entry_file = registry_dir / f"{lane_id}.json"
+        entry_file.write_text(json.dumps(entry_data, indent=2) + "\n")
+
+        results.append(
+            RegistrationResult(
+                lane_id=lane_id,
+                worktree_path=git_wt.path,
+                action="created",
+                reason="New registry entry",
+            )
+        )
+        logger.info("Registered lane %r from %s", lane_id, git_wt.path)
+
+    return results

--- a/tests/unit/test_ops_worktrees.py
+++ b/tests/unit/test_ops_worktrees.py
@@ -13,11 +13,15 @@ from bid_euchre.ops.worktrees import (
     GitWorktree,
     _update_registry_cleanup_state,
     classify_cleanup_candidates,
+    derive_lane_class,
+    derive_lane_id,
+    derive_visibility,
     is_main_worktree,
     is_protected,
     is_worktree_dirty,
     list_worktrees_registry,
     reconcile,
+    register_all_worktrees,
 )
 
 
@@ -1252,3 +1256,291 @@ class TestUpdateRegistryCleanupState:
             tmp_path / "no_such_dir", "/tmp/wt", "quarantined"
         )
         assert result is False
+
+
+# ---------------------------------------------------------------------------
+# derive_lane_id / derive_lane_class / derive_visibility
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveLaneId:
+    """Tests for derive_lane_id()."""
+
+    @pytest.mark.parametrize(
+        ("dir_name", "expected"),
+        [
+            ("Bid-Euchre-steward-author", "author-a"),
+            ("Bid-Euchre-steward-author-b", "author-b"),
+            ("Bid-Euchre-steward-author-c", "author-c"),
+            ("Bid-Euchre-steward-author-d", "author-d"),
+            ("Bid-Euchre-steward-author-scratch", "author-scratch"),
+            ("Bid-Euchre-steward-brws-author-a", "brws-author-a"),
+            ("Bid-Euchre-steward-brws-author-b", "brws-author-b"),
+            ("Bid-Euchre-steward-brws-author-c", "brws-author-c"),
+            ("Bid-Euchre-steward-brws-author-d", "brws-author-d"),
+            ("Bid-Euchre-steward-flex-a", "flex-a"),
+            ("Bid-Euchre-steward-flex-b", "flex-b"),
+            ("Bid-Euchre-steward-flex-c", "flex-c"),
+            ("Bid-Euchre-steward-review", "review"),
+            ("Bid-Euchre-steward-ops", "ops"),
+        ],
+    )
+    def test_known_steward_lanes(self, dir_name: str, expected: str) -> None:
+        assert derive_lane_id(dir_name) == expected
+
+    def test_unknown_steward_fallback(self) -> None:
+        """Unknown steward prefix still derives a lane_id via suffix stripping."""
+        assert derive_lane_id("Bid-Euchre-steward-custom-lane") == "custom-lane"
+
+    def test_non_steward_returns_none(self) -> None:
+        assert derive_lane_id("Bid-Euchre") is None
+        assert derive_lane_id("some-other-dir") is None
+        assert derive_lane_id("work-fix-bug") is None
+
+    def test_bare_prefix_returns_none(self) -> None:
+        """Just the prefix with nothing after returns None."""
+        assert derive_lane_id("Bid-Euchre-steward-") is None
+
+
+class TestDeriveLaneClass:
+    """Tests for derive_lane_class()."""
+
+    @pytest.mark.parametrize(
+        ("lane_id", "expected"),
+        [
+            ("ops", "ops"),
+            ("review", "review"),
+            ("author-scratch", "scratch"),
+            ("author-a", "author"),
+            ("author-b", "author"),
+            ("brws-author-a", "author"),
+            ("flex-a", "author"),
+        ],
+    )
+    def test_class_derivation(self, lane_id: str, expected: str) -> None:
+        assert derive_lane_class(lane_id) == expected
+
+
+class TestDeriveVisibility:
+    """Tests for derive_visibility()."""
+
+    def test_foreground_lanes(self) -> None:
+        for lane_id in ("ops", "review", "orchestrator", "dashboard", "issues"):
+            assert derive_visibility(lane_id) == "foreground"
+
+    def test_background_lanes(self) -> None:
+        for lane_id in (
+            "author-a",
+            "author-b",
+            "brws-author-a",
+            "flex-a",
+            "author-scratch",
+        ):
+            assert derive_visibility(lane_id) == "background"
+
+
+# ---------------------------------------------------------------------------
+# register_all_worktrees
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterAllWorktrees:
+    """Tests for register_all_worktrees()."""
+
+    @pytest.fixture()
+    def registry_dir(self, tmp_path: Path) -> Path:
+        d = tmp_path / "worktree_registry"
+        d.mkdir()
+        return d
+
+    def _make_git_worktrees(self, tmp_path: Path) -> list[GitWorktree]:
+        """Create fake git worktrees with realistic directory names.
+
+        Creates actual directories with .git files (linked worktree style)
+        so is_main_worktree() returns False for them.
+        """
+        worktrees = []
+        names = [
+            "Bid-Euchre-steward-author",
+            "Bid-Euchre-steward-author-b",
+            "Bid-Euchre-steward-brws-author-a",
+            "Bid-Euchre-steward-ops",
+            "Bid-Euchre-steward-review",
+            "Bid-Euchre-steward-flex-a",
+        ]
+        for name in names:
+            wt_dir = tmp_path / name
+            wt_dir.mkdir()
+            # Write a .git file (not directory) to simulate a linked worktree.
+            (wt_dir / ".git").write_text("gitdir: /fake/.git/worktrees/x\n")
+            worktrees.append(
+                GitWorktree(
+                    path=str(wt_dir),
+                    head="abc123",
+                    branch=f"feature/{name}",
+                )
+            )
+        return worktrees
+
+    def test_creates_entries_for_all_steward_lanes(
+        self, registry_dir: Path, tmp_path: Path
+    ) -> None:
+        """Creates registry entries for all recognized steward worktrees."""
+        git_wts = self._make_git_worktrees(tmp_path)
+
+        results = register_all_worktrees(
+            registry_dir,
+            git_worktrees=git_wts,
+            now_iso="2026-03-24T12:00:00+00:00",
+        )
+
+        created = [r for r in results if r.action == "created"]
+        assert len(created) == 6
+
+        # Verify files were written.
+        json_files = sorted(registry_dir.glob("*.json"))
+        assert len(json_files) == 6
+
+        # Verify specific lane.
+        data = json.loads((registry_dir / "author-a.json").read_text())
+        assert data["lane_id"] == "author-a"
+        assert data["lane_class"] == "author"
+        assert data["visibility"] == "background"
+        assert data["schema_version"] == 2
+        assert data["class"] == "persistent"
+        assert data["session_handle"] == "steward:author-a"
+
+    def test_ops_and_review_are_foreground(
+        self, registry_dir: Path, tmp_path: Path
+    ) -> None:
+        """Ops and review lanes get foreground visibility."""
+        git_wts = self._make_git_worktrees(tmp_path)
+
+        register_all_worktrees(
+            registry_dir,
+            git_worktrees=git_wts,
+            now_iso="2026-03-24T12:00:00+00:00",
+        )
+
+        ops_data = json.loads((registry_dir / "ops.json").read_text())
+        assert ops_data["visibility"] == "foreground"
+
+        review_data = json.loads((registry_dir / "review.json").read_text())
+        assert review_data["visibility"] == "foreground"
+
+    def test_skips_already_registered(self, registry_dir: Path, tmp_path: Path) -> None:
+        """Skips worktrees that already have a matching registry entry."""
+        # Pre-register author-a.
+        _write_registry_entry(
+            registry_dir,
+            "author-a.json",
+            lane_id="author-a",
+            worktree_path="/old/path",
+            branch="feature/Bid-Euchre-steward-author",
+        )
+
+        git_wts = self._make_git_worktrees(tmp_path)
+
+        results = register_all_worktrees(
+            registry_dir,
+            git_worktrees=git_wts,
+            now_iso="2026-03-24T12:00:00+00:00",
+        )
+
+        author_a = [r for r in results if r.lane_id == "author-a"]
+        assert len(author_a) == 1
+        assert author_a[0].action == "skipped"
+
+    def test_updates_branch_when_changed(
+        self, registry_dir: Path, tmp_path: Path
+    ) -> None:
+        """Updates existing entry when branch has changed."""
+        # Pre-register with old branch.
+        _write_registry_entry(
+            registry_dir,
+            "ops.json",
+            lane_id="ops",
+            worktree_path="/old/path",
+            branch="old-branch",
+        )
+
+        # Create the ops worktree with a new branch.
+        wt_dir = tmp_path / "Bid-Euchre-steward-ops"
+        wt_dir.mkdir()
+        (wt_dir / ".git").write_text("gitdir: /fake/.git/worktrees/x\n")
+        git_wts = [GitWorktree(path=str(wt_dir), head="abc123", branch="new-branch")]
+
+        results = register_all_worktrees(
+            registry_dir,
+            git_worktrees=git_wts,
+            now_iso="2026-03-24T12:00:00+00:00",
+        )
+
+        ops_result = [r for r in results if r.lane_id == "ops"]
+        assert len(ops_result) == 1
+        assert ops_result[0].action == "updated"
+
+        data = json.loads((registry_dir / "ops.json").read_text())
+        assert data["branch"] == "new-branch"
+
+    def test_skips_main_checkout(self, registry_dir: Path, tmp_path: Path) -> None:
+        """Skips the main checkout (has .git directory, not file)."""
+        main_dir = tmp_path / "Bid-Euchre"
+        main_dir.mkdir()
+        # Main checkout has a .git directory.
+        (main_dir / ".git").mkdir()
+
+        git_wts = [GitWorktree(path=str(main_dir), head="abc", branch="main")]
+
+        results = register_all_worktrees(
+            registry_dir,
+            git_worktrees=git_wts,
+            now_iso="2026-03-24T12:00:00+00:00",
+        )
+
+        assert len(results) == 0
+
+    def test_skips_non_steward_worktrees(
+        self, registry_dir: Path, tmp_path: Path
+    ) -> None:
+        """Non-steward worktrees are skipped with an appropriate reason."""
+        wt_dir = tmp_path / "work-fix-bug"
+        wt_dir.mkdir()
+        (wt_dir / ".git").write_text("gitdir: /fake/.git/worktrees/x\n")
+
+        git_wts = [GitWorktree(path=str(wt_dir), head="abc", branch="fix/bug")]
+
+        results = register_all_worktrees(
+            registry_dir,
+            git_worktrees=git_wts,
+            now_iso="2026-03-24T12:00:00+00:00",
+        )
+
+        assert len(results) == 1
+        assert results[0].action == "skipped"
+        assert "Not a recognized steward lane" in results[0].reason
+
+    def test_idempotent_on_second_run(self, registry_dir: Path, tmp_path: Path) -> None:
+        """Running register-all twice produces no new created entries."""
+        git_wts = self._make_git_worktrees(tmp_path)
+
+        # First run.
+        results1 = register_all_worktrees(
+            registry_dir,
+            git_worktrees=git_wts,
+            now_iso="2026-03-24T12:00:00+00:00",
+        )
+        created1 = [r for r in results1 if r.action == "created"]
+        assert len(created1) == 6
+
+        # Second run.
+        results2 = register_all_worktrees(
+            registry_dir,
+            git_worktrees=git_wts,
+            now_iso="2026-03-24T12:05:00+00:00",
+        )
+        created2 = [r for r in results2 if r.action == "created"]
+        assert len(created2) == 0
+        # All should be skipped (same branch).
+        skipped = [r for r in results2 if r.action == "skipped"]
+        assert len(skipped) == 6


### PR DESCRIPTION
## Summary

- Add `register_all_worktrees()` to scan git worktrees and create v2 registry entries for steward lanes
- Add `ops.py worktrees register-all` CLI subcommand
- Add derivation functions for lane_id, lane_class, visibility from directory names

## Why

Dashboard shows 0 lanes because worktree registry is empty. Provides one-shot registration command.

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_ops_worktrees.py -v -k "DeriveLane or DeriveVisibility or RegisterAll"
make check-quiet
```

## Validation Performed

- ✅ 95/95 worktree tests pass
- ✅ `make check-quiet` passes

Closes #1716.

🤖 Generated with [Claude Code](https://claude.com/claude-code)