### PR TITLE
fix(convention): add missing pytestmark to test_unread_alert_replay (#1727)

### DIFF
--- a/tests/integration/test_unread_alert_replay.py
+++ b/tests/integration/test_unread_alert_replay.py
@@ -38,6 +38,8 @@ from bid_euchre.ops.message_bus import (
     shared_bus_root,
 )
 
+pytestmark = pytest.mark.integration
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `pytestmark = pytest.mark.integration` to `tests/integration/test_unread_alert_replay.py`
- File was added in PR #1718 without the module-level marker standardized in PR #1705

## Why

Without the marker, the 10 tests in this file are not excluded by
`pytest -m "not integration"`, violating the convention enforced across
all 36 other integration test files.

## Repro / Validation

```bash
# Before fix: 10 tests collected (should be 0)
uv run python -m pytest tests/integration/test_unread_alert_replay.py -m "not integration" -v

# After fix: 10 deselected, 0 selected ✓
uv run python -m pytest tests/integration/test_unread_alert_replay.py -m "not integration" -v
```

## Tests

```bash
uv run python -m pytest tests/integration/test_unread_alert_replay.py -v  # 10 passed ✓
make check-quiet  # All checks passed ✓
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
worktree: Bid-Euchre-steward-author-d
branch: fix/pytestmark-unread-alert-1727
```

Closes #1727

🤖 Generated with [Claude Code](https://claude.com/claude-code)