### PR TITLE
fix(ops): implement download_attachment audit before registering it (#1721)

### DIFF
--- a/src/bid_euchre/ops/audit_trail.py
+++ b/src/bid_euchre/ops/audit_trail.py
@@ -378,6 +378,41 @@ def audit_edit(
     return record
 
 
+def audit_download_attachment(
+    file_id: str,
+    chat_id: str = "",
+    audit_dir: Path | None = None,
+) -> AuditRecord:
+    """Log an outbound attachment download to the audit trail.
+
+    Creates an :class:`AuditRecord` with ``direction="outbound"`` and
+    ``exchange_type="download_attachment"``, appends it, and returns it.
+
+    The ``download_attachment`` MCP tool fetches a file by ``file_id``.
+    The ``chat_id`` is optional — Telegram's ``getFile`` API does not
+    require it, but callers may supply it for traceability if known.
+
+    Args:
+        file_id: Telegram file ID being downloaded.
+        chat_id: Optional Telegram chat ID for traceability.
+        audit_dir: Override for audit trail directory.
+
+    Returns:
+        The persisted :class:`AuditRecord`.
+    """
+    record = create_record(
+        direction="outbound",
+        channel_source="telegram",
+        sender_identity="orchestrator",
+        exchange_type="download_attachment",
+        content=file_id,
+        chat_id=chat_id,
+        metadata={"file_id": file_id},
+    )
+    append_record(record, audit_dir=audit_dir)
+    return record
+
+
 # ---------------------------------------------------------------------------
 # Inbound audit wrappers
 # ---------------------------------------------------------------------------
@@ -437,6 +472,7 @@ _MCP_TOOL_MAP: dict[str, str] = {
     "mcp__plugin_telegram_telegram__reply": "reply",
     "mcp__plugin_telegram_telegram__react": "react",
     "mcp__plugin_telegram_telegram__edit_message": "edit",
+    "mcp__plugin_telegram_telegram__download_attachment": "download_attachment",
 }
 
 
@@ -462,6 +498,20 @@ def audit_mcp_outbound(
     exchange_type = _MCP_TOOL_MAP.get(tool_name)
     if exchange_type is None:
         return None
+
+    # download_attachment uses file_id, not chat_id — handle before the
+    # chat_id guard so it isn't rejected for missing chat context.
+    if exchange_type == "download_attachment":
+        file_id = str(tool_args.get("file_id", tool_args.get("fileId", "")))
+        if not file_id:
+            logger.warning("audit_mcp_outbound: no file_id in args for %s", tool_name)
+            return None
+        chat_id = str(tool_args.get("chat_id", tool_args.get("chatId", "")))
+        return audit_download_attachment(
+            file_id=file_id,
+            chat_id=chat_id,
+            audit_dir=audit_dir,
+        )
 
     chat_id = str(tool_args.get("chat_id", tool_args.get("chatId", "")))
     if not chat_id:

--- a/tests/integration/test_audit_trail_integration.py
+++ b/tests/integration/test_audit_trail_integration.py
@@ -752,6 +752,44 @@ class TestMcpOutboundWiring:
         assert rec.exchange_type == "edit"
         assert rec.message_id == "42"
 
+    def test_download_attachment_tool_audited(self, tmp_path: Path) -> None:
+        """MCP download_attachment tool call produces an audit record."""
+        rec = audit_mcp_outbound(
+            tool_name="mcp__plugin_telegram_telegram__download_attachment",
+            tool_args={"file_id": "AgACAgIAAxkBAAIBZ"},
+            audit_dir=tmp_path,
+        )
+        assert rec is not None
+        assert rec.direction == "outbound"
+        assert rec.exchange_type == "download_attachment"
+        assert rec.metadata.get("file_id") == "AgACAgIAAxkBAAIBZ"
+        # chat_id is optional for download_attachment
+        assert rec.chat_id == ""
+
+        records = read_records(audit_dir=tmp_path)
+        assert len(records) == 1
+
+    def test_download_attachment_with_chat_id(self, tmp_path: Path) -> None:
+        """download_attachment passes through optional chat_id if provided."""
+        rec = audit_mcp_outbound(
+            tool_name="mcp__plugin_telegram_telegram__download_attachment",
+            tool_args={"file_id": "AgACAgIAAxkBAAIBZ", "chat_id": "999"},
+            audit_dir=tmp_path,
+        )
+        assert rec is not None
+        assert rec.chat_id == "999"
+
+    def test_download_attachment_missing_file_id_returns_none(
+        self, tmp_path: Path
+    ) -> None:
+        """download_attachment without file_id is skipped."""
+        rec = audit_mcp_outbound(
+            tool_name="mcp__plugin_telegram_telegram__download_attachment",
+            tool_args={},
+            audit_dir=tmp_path,
+        )
+        assert rec is None
+
     def test_unknown_tool_returns_none(self, tmp_path: Path) -> None:
         """Non-Telegram MCP tools are silently skipped."""
         rec = audit_mcp_outbound(
@@ -805,10 +843,20 @@ class TestMcpOutboundWiring:
             tool_args={"chat_id": "123", "message_id": "2", "body": "Edited"},
             audit_dir=tmp_path,
         )
+        audit_mcp_outbound(
+            tool_name="mcp__plugin_telegram_telegram__download_attachment",
+            tool_args={"file_id": "file-seq-001"},
+            audit_dir=tmp_path,
+        )
 
         records = read_records(audit_dir=tmp_path)
-        assert len(records) == 3
-        assert [r.exchange_type for r in records] == ["reply", "react", "edit"]
+        assert len(records) == 4
+        assert [r.exchange_type for r in records] == [
+            "reply",
+            "react",
+            "edit",
+            "download_attachment",
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_audit_trail.py
+++ b/tests/unit/test_audit_trail.py
@@ -14,6 +14,7 @@ from bid_euchre.ops.audit_trail import (
     VALID_EXCHANGE_TYPES,
     AuditRecord,
     append_record,
+    audit_download_attachment,
     audit_edit,
     audit_inbound,
     audit_react,
@@ -655,19 +656,56 @@ class TestAuditEdit:
         assert record.content_hash == content_hash(long_body)
 
 
+class TestAuditDownloadAttachment:
+    def test_basic_download(self, tmp_path: Path) -> None:
+        record = audit_download_attachment(
+            file_id="AgACAgIAAxkBAAIBZ",
+            audit_dir=tmp_path,
+        )
+        assert record.direction == "outbound"
+        assert record.exchange_type == "download_attachment"
+        assert record.channel_source == "telegram"
+        assert record.sender_identity == "orchestrator"
+        assert record.chat_id == ""
+        assert record.metadata == {"file_id": "AgACAgIAAxkBAAIBZ"}
+        assert record.content_hash == content_hash("AgACAgIAAxkBAAIBZ")
+
+    def test_download_with_chat_id(self, tmp_path: Path) -> None:
+        record = audit_download_attachment(
+            file_id="AgACAgIAAxkBAAIBZ",
+            chat_id="8122530898",
+            audit_dir=tmp_path,
+        )
+        assert record.chat_id == "8122530898"
+
+    def test_download_persisted(self, tmp_path: Path) -> None:
+        audit_download_attachment(file_id="file-001", audit_dir=tmp_path)
+        records = read_records(audit_dir=tmp_path)
+        assert len(records) == 1
+        assert records[0].exchange_type == "download_attachment"
+        assert records[0].direction == "outbound"
+
+    def test_download_returns_record(self, tmp_path: Path) -> None:
+        returned = audit_download_attachment(file_id="file-002", audit_dir=tmp_path)
+        persisted = read_records(audit_dir=tmp_path)
+        assert len(persisted) == 1
+        assert returned == persisted[0]
+
+
 class TestOutboundWrapperIntegration:
     """Cross-wrapper tests verifying they coexist in the same audit log."""
 
     def test_mixed_outbound_sequence(self, tmp_path: Path) -> None:
-        """All three wrapper types write to the same log and can be read back."""
+        """All four wrapper types write to the same log and can be read back."""
         audit_reply(chat_id="123", body="Hello", audit_dir=tmp_path)
         audit_react(chat_id="123", message_id="1", emoji="👍", audit_dir=tmp_path)
         audit_edit(chat_id="123", message_id="2", body="Updated", audit_dir=tmp_path)
+        audit_download_attachment(file_id="file-X", audit_dir=tmp_path)
 
         records = read_records(audit_dir=tmp_path)
-        assert len(records) == 3
+        assert len(records) == 4
         types = [r.exchange_type for r in records]
-        assert types == ["reply", "react", "edit"]
+        assert types == ["reply", "react", "edit", "download_attachment"]
         assert all(r.direction == "outbound" for r in records)
 
     def test_outbound_filter(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add `audit_download_attachment()` wrapper to `audit_trail.py` with optional `chat_id` (Telegram's `getFile` API doesn't require it)
- Register `download_attachment` in `_MCP_TOOL_MAP` and handle in `audit_mcp_outbound()` before the `chat_id` guard
- Add 4 unit tests and 3 integration tests covering the new handler

## Why
The `post-telegram-audit.sh` hook (PR #1715) registered `download_attachment` in its case statement, but `audit_mcp_outbound()` had no handler — the tool call would match the hook guard but then be silently dropped by the Python code because `_MCP_TOOL_MAP` didn't map it. This implements the handler so all four audited tool types are consistently wired end-to-end.

## Repro / Validation
```bash
# Targeted tests
uv run python -m pytest tests/unit/test_audit_trail.py -k download -v
uv run python -m pytest tests/integration/test_audit_trail_integration.py -k download -v

# Full validation
make check-quiet
```

## Tests
- 87 unit tests pass (`tests/unit/test_audit_trail.py`)
- 45 integration tests pass (`tests/integration/test_audit_trail_integration.py`)
- `make check-quiet` passes (7002 passed, 50 skipped)

## Worktree proof
```
pwd: Bid-Euchre-steward-author-b
branch: fix/convention-1721-download-attachment-audit
```

Closes #1721

🤖 Generated with [Claude Code](https://claude.com/claude-code)