### PR TITLE
fix(convention): move pytestmark before helpers in test_controller_projection

### DIFF
--- a/tests/integration/test_controller_projection.py
+++ b/tests/integration/test_controller_projection.py
@@ -44,6 +44,8 @@ from bid_euchre.ops.message_bus import (
     shared_bus_root,
 )
 
+pytestmark = pytest.mark.integration
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -75,9 +77,6 @@ def _old_urgent_message_dict(
         "created_at": created_at,
         "summary": summary,
     }
-
-
-pytestmark = pytest.mark.integration
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Move `pytestmark = pytest.mark.integration` from line 80 (after helper function) to line 47 (immediately after import block)
- Aligns with convention established by PR #1705 across all 36 integration test files

## Why
PR #1707 introduced `test_controller_projection.py` with `pytestmark` placed after a helper function definition, breaking the convention standardized minutes earlier by PR #1705.

## Repro / Validation
```bash
# Verify pytestmark is immediately after imports (line 47)
grep -n "pytestmark" tests/integration/test_controller_projection.py

# Run the tests
uv run python -m pytest tests/integration/test_controller_projection.py -v

# Full validation
make check
```

## Tests
- `uv run python -m pytest tests/integration/test_controller_projection.py -v` — 11/11 passed
- `make check` — all checks passed
- No behavior change — only line placement

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-scratch
```

Closes #1713

🤖 Generated with [Claude Code](https://claude.com/claude-code)