### PR TITLE
fix(convention): add pytestmark integration marker to test_unread_alert_replay (#1724)

### DIFF
--- a/tests/integration/test_unread_alert_replay.py
+++ b/tests/integration/test_unread_alert_replay.py
@@ -22,6 +22,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.integration
+
 from bid_euchre.ops.control_plane import (
     SEVERITY_HIGH,
     SEVERITY_URGENT,


### PR DESCRIPTION
## Summary
- Add missing `pytestmark = pytest.mark.integration` to `test_unread_alert_replay.py`
- This file was added in PR #1718 after the convention was established in #1705

## Why
PR #1718 introduced `tests/integration/test_unread_alert_replay.py` (10 tests)
without the module-level `pytestmark = pytest.mark.integration` marker. This
meant the tests were not selectable via `-m integration`, breaking the
convention established by #1705 and the follow-up fix in #1734.

## Repro / Validation
```bash
# Before: 0 collected with -m integration (test_unread_alert_replay.py excluded)
# After: 10 collected
uv run python -m pytest tests/integration/test_unread_alert_replay.py -m integration --co -q
```

## Tests
```bash
make check-quiet  # ✓ All checks passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
worktree: Bid-Euchre-steward-author (persistent author-a lane)
```

Closes #1724