### PR TITLE
fix(ops): decouple controller projection tests from wall-clock time

### DIFF
--- a/src/bid_euchre/ops/audit_trail.py
+++ b/src/bid_euchre/ops/audit_trail.py
@@ -276,6 +276,7 @@ def audit_reply(
     reply_to: str | None = None,
     files: list[str] | None = None,
     audit_dir: Path | None = None,
+    timestamp: str | None = None,
 ) -> AuditRecord:
     """Log an outbound reply to the audit trail.
 
@@ -288,6 +289,8 @@ def audit_reply(
         reply_to: Optional message ID being replied to.
         files: Optional list of file paths attached to the reply.
         audit_dir: Override for audit trail directory.
+        timestamp: Optional ISO 8601 timestamp override. Defaults to current
+            UTC time. Useful in tests to decouple from wall-clock time.
 
     Returns:
         The persisted :class:`AuditRecord`.
@@ -306,6 +309,7 @@ def audit_reply(
         content=body,
         chat_id=chat_id,
         metadata=metadata if metadata else None,
+        timestamp=timestamp,
     )
     append_record(record, audit_dir=audit_dir)
     return record
@@ -316,6 +320,7 @@ def audit_react(
     message_id: str,
     emoji: str,
     audit_dir: Path | None = None,
+    timestamp: str | None = None,
 ) -> AuditRecord:
     """Log an outbound reaction to the audit trail.
 
@@ -327,6 +332,8 @@ def audit_react(
         message_id: Message ID being reacted to.
         emoji: The emoji reaction.
         audit_dir: Override for audit trail directory.
+        timestamp: Optional ISO 8601 timestamp override. Defaults to current
+            UTC time. Useful in tests to decouple from wall-clock time.
 
     Returns:
         The persisted :class:`AuditRecord`.
@@ -340,6 +347,7 @@ def audit_react(
         chat_id=chat_id,
         message_id=message_id,
         metadata={"emoji": emoji},
+        timestamp=timestamp,
     )
     append_record(record, audit_dir=audit_dir)
     return record
@@ -350,6 +358,7 @@ def audit_edit(
     message_id: str,
     body: str,
     audit_dir: Path | None = None,
+    timestamp: str | None = None,
 ) -> AuditRecord:
     """Log an outbound message edit to the audit trail.
 
@@ -361,6 +370,8 @@ def audit_edit(
         message_id: Message ID being edited.
         body: The new message text after editing.
         audit_dir: Override for audit trail directory.
+        timestamp: Optional ISO 8601 timestamp override. Defaults to current
+            UTC time. Useful in tests to decouple from wall-clock time.
 
     Returns:
         The persisted :class:`AuditRecord`.
@@ -373,6 +384,7 @@ def audit_edit(
         content=body,
         chat_id=chat_id,
         message_id=message_id,
+        timestamp=timestamp,
     )
     append_record(record, audit_dir=audit_dir)
     return record
@@ -444,6 +456,7 @@ def audit_mcp_outbound(
     tool_name: str,
     tool_args: dict[str, Any],
     audit_dir: Path | None = None,
+    timestamp: str | None = None,
 ) -> AuditRecord | None:
     """Audit an outbound MCP tool call if it is an auditable Telegram exchange.
 
@@ -454,6 +467,8 @@ def audit_mcp_outbound(
         tool_name: The MCP tool name (e.g. ``"mcp__plugin_telegram_telegram__reply"``).
         tool_args: The arguments dict passed to the MCP tool.
         audit_dir: Override for audit trail directory.
+        timestamp: Optional ISO 8601 timestamp override. Defaults to current
+            UTC time. Useful in tests to decouple from wall-clock time.
 
     Returns:
         The :class:`AuditRecord` if an audit entry was written, or ``None``
@@ -478,6 +493,7 @@ def audit_mcp_outbound(
             reply_to=str(reply_to) if reply_to is not None else None,
             files=files,
             audit_dir=audit_dir,
+            timestamp=timestamp,
         )
 
     if exchange_type == "react":
@@ -488,6 +504,7 @@ def audit_mcp_outbound(
             message_id=message_id,
             emoji=emoji,
             audit_dir=audit_dir,
+            timestamp=timestamp,
         )
 
     if exchange_type == "edit":
@@ -498,6 +515,7 @@ def audit_mcp_outbound(
             message_id=message_id,
             body=str(body),
             audit_dir=audit_dir,
+            timestamp=timestamp,
         )
 
     return None  # pragma: no cover

--- a/src/bid_euchre/ops/control_plane.py
+++ b/src/bid_euchre/ops/control_plane.py
@@ -416,7 +416,9 @@ def items_from_unacked_messages(
         now_iso = _now_iso()
 
     items: list[ActionableItem] = []
-    now_ts = time.time()
+    # Derive now_ts from the authoritative now_iso so that tests can
+    # control the clock fully — no hidden dependency on time.time().
+    now_ts = datetime.fromisoformat(now_iso).timestamp()
 
     for msg in messages:
         priority = msg.get("priority", "normal")

--- a/tests/integration/test_controller_projection.py
+++ b/tests/integration/test_controller_projection.py
@@ -363,9 +363,10 @@ class TestAlertPipeline:
         assert any(m["message_id"] == msg_id for m in inbox)
 
         # Detect with max_age_minutes=0 (fresh message is still detected).
+        # Omit now_iso so it defaults to the current clock — this E2E test
+        # uses the real bus whose created_at is wall-clock time.
         items = items_from_unacked_messages(
             inbox,
-            now_iso="2026-03-24T08:00:00+00:00",
             max_age_minutes=0,
         )
         urgent = [i for i in items if i.severity == SEVERITY_URGENT]
@@ -410,7 +411,8 @@ class TestRemoteExchangeProjection:
         assert audit_items[0].state == STATE_OPEN
         assert "operator" in audit_items[0].summary
 
-        # 3. Outbound reply is sent.
+        # 3. Outbound reply is sent (fixed timestamp to stay in-band with
+        #    the deterministic now_iso values used by reconcile above).
         audit_mcp_outbound(
             tool_name="mcp__plugin_telegram_telegram__reply",
             tool_args={
@@ -419,6 +421,7 @@ class TestRemoteExchangeProjection:
                 "reply_to": "200",
             },
             audit_dir=audit_dir,
+            timestamp="2026-03-24T08:02:00+00:00",
         )
 
         # 4. Second reconcile cycle with updated audit records.
@@ -459,11 +462,12 @@ class TestRemoteExchangeProjection:
         )
         audit_channel_tag(tag_text=tag_b, content="Hello from B", audit_dir=audit_dir)
 
-        # Reply to Chat A only.
+        # Reply to Chat A only (fixed timestamp — see finding P3 from #1706).
         audit_mcp_outbound(
             tool_name="mcp__plugin_telegram_telegram__reply",
             tool_args={"chat_id": "AAA", "body": "Hi Alice!", "reply_to": "1"},
             audit_dir=audit_dir,
+            timestamp="2026-03-24T07:30:00+00:00",
         )
 
         # Reconcile — chat B should still be unanswered.

--- a/tests/unit/test_ops_control_plane.py
+++ b/tests/unit/test_ops_control_plane.py
@@ -6,8 +6,6 @@ Tests the pure-function derivation core and the side-effecting reconcile loop.
 from __future__ import annotations
 
 import json
-import time
-from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -86,9 +84,9 @@ def _bus_message(
     created_at: str | None = None,
 ) -> dict:
     if created_at is None:
-        # 30 minutes ago by default (well past the default 10-min threshold).
-        ts = time.time() - 1800
-        created_at = datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+        # 30 minutes before NOW_ISO — deterministic, decoupled from the
+        # runner clock (see #1706).
+        created_at = "2026-03-24T21:30:00+00:00"
     return {
         "id": message_id,
         "priority": priority,
@@ -410,7 +408,8 @@ class TestItemsFromUnackedMessages:
         assert items[0].severity == "urgent"
 
     def test_recent_message_is_filtered_out(self):
-        recent = datetime.now(timezone.utc).isoformat()
+        # 5 minutes before NOW_ISO — within the default 10-min threshold.
+        recent = "2026-03-24T21:55:00+00:00"
         msgs = [_bus_message(priority="high", created_at=recent)]
         items = items_from_unacked_messages(msgs, now_iso=NOW_ISO, max_age_minutes=10)
         assert len(items) == 0
@@ -1790,10 +1789,9 @@ class TestMonitorReconcileWiring:
 
         # Reconcile should have picked up the task packet.
         loaded = load_fleet_status(tmp_path)
-        assert loaded is not None, (
-            f"reconcile() did not write fleet_status.json; "
-            f"stdout={result.stdout[:300]}"
-        )
+        assert (
+            loaded is not None
+        ), f"reconcile() did not write fleet_status.json; stdout={result.stdout[:300]}"
         task_items = [i for i in loaded.items if i.task_id == "test-pkt-1698"]
         assert len(task_items) == 1, (
             f"Expected task packet in fleet status but found {len(task_items)}; "


### PR DESCRIPTION
## Summary

- Derive `now_ts` from `now_iso` in `items_from_unacked_messages()` instead of calling `time.time()`, removing hidden wall-clock dependency
- Thread `timestamp` parameter through `audit_reply`, `audit_react`, `audit_edit`, and `audit_mcp_outbound` so tests can control outbound record timestamps
- Convert unit/integration test timestamps from `time.time()`/`datetime.now()` to deterministic fixed values

## Why

Convention follow-up for PR #1699. Two P3 findings from autonomous review (#1706):
1. Unacked-message tests coupled to runner clock via `time.time()`
2. Integration tests mixed fixed `now_iso` with real-time audit outbound timestamps

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_ops_control_plane.py tests/integration/test_controller_projection.py tests/unit/test_audit_trail.py tests/integration/test_audit_trail_integration.py -v
# 248 passed
```

## Tests

- `make check-quiet` — 7041 passed, 50 skipped (1 flaky hook test unrelated to this change)
- Targeted: all 248 tests in control_plane + audit_trail unit and integration suites pass

## Worktree proof

```
pwd: Bid-Euchre-steward-brws-author-a
branch: fix/convention-follow-up-1706
```

Closes #1706