### PR TITLE
feat(ops): add --max-age flag to inbox ack-all (#1717)

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -65,6 +65,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -1861,24 +1862,44 @@ def cmd_inbox(args: argparse.Namespace) -> int:
 
     elif action == "ack-all":
         import re
+        from datetime import datetime, timezone
 
         lane = getattr(args, "lane", None)
         if not lane:
             print(
-                "Usage: ops.py inbox ack-all --lane LANE [--filter-summary PATTERN]",
+                "Usage: ops.py inbox ack-all --lane LANE [--filter-summary PATTERN] [--max-age HOURS]",
                 file=sys.stderr,
             )
             return 1
+
+        # Build a list of predicates, then compose them
+        predicates: list[Callable[[dict], bool]] = []
+
         summary_pattern = getattr(args, "filter_summary", None)
         if summary_pattern:
             pat = re.compile(summary_pattern, re.IGNORECASE)
+            predicates.append(lambda msg: bool(pat.search(msg.get("summary", ""))))
 
-            def filter_fn(msg: dict) -> bool:
-                return bool(pat.search(msg.get("summary", "")))
-        else:
+        max_age_hours: float | None = getattr(args, "max_age", None)
+        if max_age_hours is not None:
+            cutoff = datetime.now(tz=timezone.utc).timestamp() - (
+                max_age_hours * 3600.0
+            )
 
-            def filter_fn(msg: dict) -> bool:
-                return True
+            def _age_filter(msg: dict) -> bool:
+                created = msg.get("created_at", "")
+                if not created:
+                    return False
+                try:
+                    created_ts = datetime.fromisoformat(created).timestamp()
+                except (ValueError, TypeError):
+                    return False
+                return created_ts < cutoff
+
+            predicates.append(_age_filter)
+
+        def filter_fn(msg: dict) -> bool:
+            return all(p(msg) for p in predicates)
 
         acked = bulk_ack_messages(lane, filter_fn, bus_root)
         if args.json:
@@ -3451,6 +3472,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--filter-summary",
         default=None,
         help="Regex pattern to match against message summary (case-insensitive)",
+    )
+    inbox_ack_all_parser.add_argument(
+        "--max-age",
+        type=float,
+        default=None,
+        help="Only ack messages older than N hours (based on created_at)",
     )
 
     inbox_purge_parser = inbox_sub.add_parser(

--- a/tests/unit/test_ops_message_bus.py
+++ b/tests/unit/test_ops_message_bus.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -1151,6 +1151,43 @@ class TestBulkAckMessages:
         ]
         assert len(ack_events) == 2
         assert all(ev["payload"].get("bulk") is True for ev in ack_events)
+
+    def test_bulk_ack_with_age_filter(self, bus_root: Path, events_dir: Path) -> None:
+        """Age-based filter acks only messages older than the cutoff."""
+        # Create two messages: one "old" (6 hours ago), one "recent" (now)
+        old_ts = datetime.now(tz=timezone.utc).replace(microsecond=0) - timedelta(
+            hours=6
+        )
+        m_old = create_message("a", "target", "assignment", "Old task")
+        # Patch created_at to be 6 hours ago
+        m_old = BusMessage(**{**m_old.__dict__, "created_at": old_ts.isoformat()})
+        m_new = create_message("a", "target", "assignment", "New task")
+
+        send_message(m_old, bus_root, events_dir=events_dir)
+        send_message(m_new, bus_root, events_dir=events_dir)
+
+        # Filter: only messages older than 4 hours
+        cutoff = datetime.now(tz=timezone.utc).timestamp() - (4 * 3600)
+
+        def age_filter(msg: dict) -> bool:
+            created = msg.get("created_at", "")
+            if not created:
+                return False
+            try:
+                created_ts = datetime.fromisoformat(created).timestamp()
+            except (ValueError, TypeError):
+                return False
+            return created_ts < cutoff
+
+        acked = bulk_ack_messages("target", age_filter, bus_root, events_dir=events_dir)
+        assert len(acked) == 1
+        assert acked[0]["summary"] == "Old task"
+
+        # The new message should still be unacked
+        inbox = read_inbox("target", bus_root)
+        unacked = [m for m in inbox if m.get("status") in ("pending", "delivered")]
+        assert len(unacked) == 1
+        assert unacked[0]["summary"] == "New task"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Plan
N/A — bounded follow-up from #1717

## Summary
- Adds `--max-age HOURS` flag to `inbox ack-all` CLI command
- Age filter composes with existing `--filter-summary` via AND logic
- Adds unit test for age-based bulk ack filtering

## Why
`author-a` accumulated ~2000 unacked inbox messages from prior sessions,
dominating the dashboard inbox panel. The existing `ack-all` command could
ack everything or filter by summary regex, but had no way to target only
stale messages while preserving current-session messages.

## Repro / Validation
**Command(s) run:**
```bash
# Verify CLI flag exists
uv run python scripts/internal/ops.py inbox ack-all --help

# Example usage (ack messages older than 4 hours)
uv run python scripts/internal/ops.py inbox ack-all --lane author-a --max-age 4
```

**Seed:** N/A

## Test Criteria
- **Pass condition:** `--max-age` flag visible in CLI help and age filter test passes
- **Verification command:** `uv run python -m pytest tests/unit/test_ops_message_bus.py::TestBulkAckMessages::test_bulk_ack_with_age_filter -xvs`
- **Expected result:** 1 test passes — old message acked, new message preserved

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_message_bus.py::TestBulkAckMessages -xvs` (6/6 pass)
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (ops tooling only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b
```

`git worktree list` (excerpt):
```
Bid-Euchre-steward-flex-b          dc422c76 [ops/inbox-bulk-ack-max-age]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

Closes #1717