### PR TITLE
feat(ops): add worktree registry bulk registration (#1716)

### DIFF
--- a/src/bid_euchre/ops/worktrees.py
+++ b/src/bid_euchre/ops/worktrees.py
@@ -40,6 +40,7 @@ PROTECTED_WORKTREE_NAMES = frozenset(
         "Bid-Euchre-steward-flex-b",
         "Bid-Euchre-steward-flex-c",
         # Control plane
+        "Bid-Euchre-steward-analyst",
         "Bid-Euchre-steward-review",
         "Bid-Euchre-steward-ops",
     }
@@ -898,6 +899,7 @@ _STEWARD_DIR_TO_LANE: dict[str, str] = {
     "Bid-Euchre-steward-flex-a": "flex-a",
     "Bid-Euchre-steward-flex-b": "flex-b",
     "Bid-Euchre-steward-flex-c": "flex-c",
+    "Bid-Euchre-steward-analyst": "analyst",
     "Bid-Euchre-steward-review": "review",
     "Bid-Euchre-steward-ops": "ops",
 }
@@ -946,6 +948,8 @@ def derive_lane_class(lane_id: str) -> str:
         return "ops"
     if lane_id == "review":
         return "review"
+    if lane_id == "analyst":
+        return "analyst"
     if lane_id.endswith("-scratch"):
         return "scratch"
     # author-*, brws-author-*, flex-* are all author-class lanes.
@@ -965,7 +969,7 @@ def derive_visibility(lane_id: str) -> str:
     Returns:
         ``"foreground"`` or ``"background"``.
     """
-    if lane_id in ("ops", "review", "orchestrator", "dashboard", "issues"):
+    if lane_id in ("ops", "review", "analyst", "orchestrator", "dashboard", "issues"):
         return "foreground"
     return "background"
 

--- a/tests/unit/test_ops_worktrees.py
+++ b/tests/unit/test_ops_worktrees.py
@@ -1281,6 +1281,7 @@ class TestDeriveLaneId:
             ("Bid-Euchre-steward-flex-a", "flex-a"),
             ("Bid-Euchre-steward-flex-b", "flex-b"),
             ("Bid-Euchre-steward-flex-c", "flex-c"),
+            ("Bid-Euchre-steward-analyst", "analyst"),
             ("Bid-Euchre-steward-review", "review"),
             ("Bid-Euchre-steward-ops", "ops"),
         ],
@@ -1310,6 +1311,7 @@ class TestDeriveLaneClass:
         [
             ("ops", "ops"),
             ("review", "review"),
+            ("analyst", "analyst"),
             ("author-scratch", "scratch"),
             ("author-a", "author"),
             ("author-b", "author"),
@@ -1325,7 +1327,14 @@ class TestDeriveVisibility:
     """Tests for derive_visibility()."""
 
     def test_foreground_lanes(self) -> None:
-        for lane_id in ("ops", "review", "orchestrator", "dashboard", "issues"):
+        for lane_id in (
+            "ops",
+            "review",
+            "analyst",
+            "orchestrator",
+            "dashboard",
+            "issues",
+        ):
             assert derive_visibility(lane_id) == "foreground"
 
     def test_background_lanes(self) -> None:
@@ -1364,6 +1373,7 @@ class TestRegisterAllWorktrees:
             "Bid-Euchre-steward-author",
             "Bid-Euchre-steward-author-b",
             "Bid-Euchre-steward-brws-author-a",
+            "Bid-Euchre-steward-analyst",
             "Bid-Euchre-steward-ops",
             "Bid-Euchre-steward-review",
             "Bid-Euchre-steward-flex-a",
@@ -1395,11 +1405,11 @@ class TestRegisterAllWorktrees:
         )
 
         created = [r for r in results if r.action == "created"]
-        assert len(created) == 6
+        assert len(created) == 7
 
         # Verify files were written.
         json_files = sorted(registry_dir.glob("*.json"))
-        assert len(json_files) == 6
+        assert len(json_files) == 7
 
         # Verify specific lane.
         data = json.loads((registry_dir / "author-a.json").read_text())
@@ -1410,10 +1420,10 @@ class TestRegisterAllWorktrees:
         assert data["class"] == "persistent"
         assert data["session_handle"] == "steward:author-a"
 
-    def test_ops_and_review_are_foreground(
+    def test_ops_review_analyst_are_foreground(
         self, registry_dir: Path, tmp_path: Path
     ) -> None:
-        """Ops and review lanes get foreground visibility."""
+        """Ops, review, and analyst lanes get foreground visibility."""
         git_wts = self._make_git_worktrees(tmp_path)
 
         register_all_worktrees(
@@ -1427,6 +1437,10 @@ class TestRegisterAllWorktrees:
 
         review_data = json.loads((registry_dir / "review.json").read_text())
         assert review_data["visibility"] == "foreground"
+
+        analyst_data = json.loads((registry_dir / "analyst.json").read_text())
+        assert analyst_data["visibility"] == "foreground"
+        assert analyst_data["lane_class"] == "analyst"
 
     def test_skips_already_registered(self, registry_dir: Path, tmp_path: Path) -> None:
         """Skips worktrees that already have a matching registry entry."""
@@ -1531,7 +1545,7 @@ class TestRegisterAllWorktrees:
             now_iso="2026-03-24T12:00:00+00:00",
         )
         created1 = [r for r in results1 if r.action == "created"]
-        assert len(created1) == 6
+        assert len(created1) == 7
 
         # Second run.
         results2 = register_all_worktrees(
@@ -1543,4 +1557,4 @@ class TestRegisterAllWorktrees:
         assert len(created2) == 0
         # All should be skipped (same branch).
         skipped = [r for r in results2 if r.action == "skipped"]
-        assert len(skipped) == 6
+        assert len(skipped) == 7


### PR DESCRIPTION
## Plan
N/A — standalone issue (#1716)

## Summary
- Add `register_all_worktrees()` to scan `git worktree list` and create/update v2 registry JSON entries for all recognized steward lanes
- Add `worktrees register-all` CLI subcommand for operator use
- Add `derive_lane_id`, `derive_lane_class`, `derive_visibility` helper functions
- Include the steward-analyst lane (added in #1733) in all registries: `PROTECTED_WORKTREE_NAMES`, `_STEWARD_DIR_TO_LANE`, and derive helpers

## Why
The worktree registry directory was empty — no JSON entries. The dashboard
(`build_dashboard_view`) reads from the registry to show lane status, so the
dashboard showed no lanes. This also means cleanup policy, reconciliation,
and lane visibility could not function. The `steward-session.sh` script writes
registry entries when launching tmux, but a programmatic `register-all` path
was missing for recovery and operator use.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_worktrees.py -x -q   # 97 passed
make check-quiet                                                    # All checks passed
```

## Test Criteria
- **Pass condition:** `register_all_worktrees()` creates entries for all steward lanes including analyst; `derive_visibility("analyst")` returns `"foreground"`
- **Verification command:** `uv run python -m pytest tests/unit/test_ops_worktrees.py -k "TestRegisterAll or TestDeriveLaneId or TestDeriveLaneClass or TestDeriveVisibility" -v`
- **Expected result:** 15 tests pass covering all lane mappings, visibility, idempotency

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_worktrees.py` — 97 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: none (ops tooling only)
- Runtime impact: none (on-demand registration, no hot path)

## Risk level
- [x] Low (ops tooling + tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         ec9f89ad [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b   22a9d43c [ops/populate-worktree-registry-v2]
(... 14 more steward worktrees)
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)