### PR TITLE
fix(test): decouple noise discrimination tests from wall clock (#1724)

### DIFF
--- a/src/bid_euchre/ops/control_plane.py
+++ b/src/bid_euchre/ops/control_plane.py
@@ -845,6 +845,7 @@ def reconcile(
     unacked_messages: list[dict[str, Any]] | None = None,
     audit_records: list[dict[str, Any]] | None = None,
     now_iso: str | None = None,
+    unacked_message_age_minutes: int = 10,
 ) -> FleetStatus:
     """Run one reconciliation cycle.
 
@@ -860,6 +861,11 @@ def reconcile(
 
     If neither monitor input is provided, the caller is responsible
     for running the monitor cycle first and passing the results.
+
+    Args:
+        unacked_message_age_minutes: Age threshold in minutes for unacked
+            message detection. Messages younger than this are ignored.
+            Default 10. Pass 0 in tests to bypass wall-clock coupling.
     """
     if now_iso is None:
         now_iso = _now_iso()
@@ -874,6 +880,7 @@ def reconcile(
         unacked_messages=unacked_messages,
         audit_records=audit_records,
         now_iso=now_iso,
+        unacked_message_age_minutes=unacked_message_age_minutes,
     )
 
     merged = merge_with_previous(new_items, previous)

--- a/tests/integration/test_noise_discrimination.py
+++ b/tests/integration/test_noise_discrimination.py
@@ -140,7 +140,12 @@ def _urgent_finding() -> dict:
 
 
 def _urgent_bus_message() -> dict:
-    """A fabricated urgent bus message with an old timestamp."""
+    """A fabricated urgent bus message.
+
+    All callers pass ``unacked_message_age_minutes=0`` to bypass the
+    wall-clock age check, so the ``created_at`` value is irrelevant
+    for detection — it only needs to be a valid ISO 8601 timestamp.
+    """
     return {
         "message_id": "urgent-noise-test-001",
         "from_lane": "author-c",
@@ -201,6 +206,7 @@ class TestNoiseDiscrimination:
             monitor_findings=findings,
             unacked_messages=[urgent_msg],
             now_iso=NOW_ISO,
+            unacked_message_age_minutes=0,
         )
         status = FleetStatus(items=items, generated_at=NOW_ISO, cycle_count=1)
 
@@ -221,6 +227,7 @@ class TestNoiseDiscrimination:
             monitor_findings=findings,
             unacked_messages=[urgent_msg],
             now_iso=NOW_ISO,
+            unacked_message_age_minutes=0,
         )
         status = FleetStatus(items=items, generated_at=NOW_ISO, cycle_count=1)
 
@@ -242,6 +249,7 @@ class TestNoiseDiscrimination:
             monitor_findings=findings,
             unacked_messages=[urgent_msg],
             now_iso=NOW_ISO,
+            unacked_message_age_minutes=0,
         )
         status = FleetStatus(items=items, generated_at=NOW_ISO, cycle_count=1)
 
@@ -321,6 +329,7 @@ class TestNoiseDiscriminationPersistence:
             monitor_findings=findings,
             unacked_messages=[urgent_msg],
             now_iso=NOW_ISO,
+            unacked_message_age_minutes=0,
         )
 
         assert len(status.urgent_items) == 1
@@ -341,6 +350,7 @@ class TestNoiseDiscriminationPersistence:
             monitor_findings=findings,
             unacked_messages=[urgent_msg],
             now_iso=NOW_ISO,
+            unacked_message_age_minutes=0,
         )
 
         d = status.to_dict()
@@ -368,6 +378,7 @@ class TestNoiseDiscriminationCLI:
             monitor_findings=findings,
             unacked_messages=[urgent_msg],
             now_iso=NOW_ISO,
+            unacked_message_age_minutes=0,
         )
         status = FleetStatus(items=items, generated_at=NOW_ISO, cycle_count=5)
 
@@ -410,6 +421,7 @@ class TestNoiseDiscriminationCLI:
             monitor_findings=findings,
             unacked_messages=[urgent_msg],
             now_iso=NOW_ISO,
+            unacked_message_age_minutes=0,
         )
         status = FleetStatus(items=items, generated_at=NOW_ISO, cycle_count=3)
 


### PR DESCRIPTION
## Summary

- Thread `unacked_message_age_minutes` parameter through `reconcile()` (backward-compatible, default 10)
- Pass `unacked_message_age_minutes=0` in all 7 test callsites that use fabricated bus messages
- Update `_urgent_bus_message()` docstring to document clock-independent usage

## Why

Follow-up from review of PR #1718. The bus message tests depended on `time.time()` being "after" hardcoded `created_at` timestamps, creating a fragile wall-clock coupling. Now tests explicitly bypass the age check.

## Repro / Validation

```bash
uv run python -m pytest tests/integration/test_noise_discrimination.py tests/unit/test_ops_control_plane.py tests/integration/test_controller_projection.py -v
make check-quiet
```

## Validation Performed

- ✅ 123 tests pass (noise discrimination + control plane + controller projection)
- ✅ `make check-quiet` passes

Closes #1724.

🤖 Generated with [Claude Code](https://claude.com/claude-code)