### PR TITLE
docs: add session handoff and results for 2026-03-24/25 fleet runs

### DIFF
--- a/plans/sessions/2026-03-24_dual-track-browser-phase5-platform-sp4-07-handoff.md
+++ b/plans/sessions/2026-03-24_dual-track-browser-phase5-platform-sp4-07-handoff.md
@@ -1,0 +1,302 @@
+# Session Handoff — Browser Phase 5 + Platform SP-4-07 Autonomous Run
+
+**Date:** 2026-03-24
+**Status:** READY FOR ORCHESTRATOR
+**Goal:** Drive both active governed tracks as far as possible in one autonomous run: Browser Game Phase 5 deployment/launch work and Platform Phase 4 controller-first control-plane hardening, while triaging blocking issues and using overflow lanes for high-value follow-ups.
+
+---
+
+## Current Governed State
+
+### Browser Game
+
+- Governing plan: `plans/browser_game/governing_plan.md`
+- Registry state: `SP-0-01` through `SP-4-01` are complete.
+- Effective phase state:
+  - Phase 0 COMPLETE
+  - Phase 1 COMPLETE
+  - Phase 2 COMPLETE
+  - Phase 3 COMPLETE
+  - Phase 4 COMPLETE
+  - Phase 5 not yet activated
+- Current checkpoint drift:
+  - `plans/browser_game/5_deployment_launch/checkpoints.md` still says Phases 3 and 4 are not complete.
+  - The governing plan is ahead of the Phase 5 checkpoint file.
+
+### Platform
+
+- Governing plan: `plans/agent_ops/governing_plan.md`
+- Active phase: `plans/agent_ops/4_remote_channel/checkpoints.md`
+- Effective phase state:
+  - Step 1 / Platform-8a COMPLETE
+  - Step 2 / Platform-8b reopened and IN_PROGRESS
+  - Step 3 / SP-4-07 controller-first control plane PENDING
+  - Steps 4-6 BLOCKED on Step 2 runtime wiring plus Step 3 controller work
+- Current governing context:
+  - `SP-4-06` is library-complete but runtime-incomplete
+  - `SP-4-07` is the next primary platform slice
+  - `plans/sessions/2026-03-24_controller-first-control-plane-handoff.md` is the controlling platform handoff
+
+### Live Repo / Issue Context
+
+- One open PR already exists:
+  - PR `#1616` `fix: move ops lane to detached worktree to fix Telegram inbound`
+- Open browser follow-ups worth using as filler or early closure:
+  - `#1574`
+  - `#1577`
+- Open platform/control-plane issues that align with SP-4-07:
+  - `#1570`
+  - `#1571`
+  - `#1573`
+  - `#1580`
+  - `#1581`
+  - `#1588`
+  - `#1595`
+  - `#1596`
+  - `#1597`
+  - `#1601`
+  - `#1602`
+  - `#1608`
+  - `#1609`
+  - `#1610`
+  - `#1611`
+  - `#1612`
+  - `#1614`
+
+---
+
+## Operating Mode
+
+Use rolling queues, not hard waves.
+
+- Primary queue: Browser Phase 5
+- Secondary queue: Platform Step 2 + SP-4-07
+- Overflow queue: issue closures, tests, docs, plan/checkpoint reconciliation
+
+Target output:
+
+- **Base target:** 24+ merged PRs
+- **Aggressive target:** 30+ merged PRs
+- **Stretch target:** 40 merged PRs
+
+Core rule:
+
+- Do not open unrelated new initiatives.
+- Keep work inside the two governed tracks plus directly related issue closures.
+- Use `steward-analyst` for ambiguous blockers, issue shaping, and restart handoffs.
+
+---
+
+## Startup Checklist
+
+Before dispatching any new work:
+
+1. Recover context and read:
+   - `plans/browser_game/governing_plan.md`
+   - `plans/browser_game/sub_plan_registry.md`
+   - `plans/browser_game/4_data_pipeline/checkpoints.md`
+   - `plans/browser_game/5_deployment_launch/checkpoints.md`
+   - `plans/agent_ops/governing_plan.md`
+   - `plans/agent_ops/sub_plan_registry.md`
+   - `plans/agent_ops/4_remote_channel/checkpoints.md`
+   - `plans/agent_ops/4_remote_channel/sub/2026-03-24_controller-first-control-plane-and-transport-evaluation.md`
+   - `plans/sessions/2026-03-24_controller-first-control-plane-handoff.md`
+2. Refresh idle lanes:
+   - `uv run python scripts/internal/ops.py lane refresh --all-idle`
+3. Sync hosted/browser dependencies before browser validation work:
+   - `uv sync --all-extras`
+4. Review open PR `#1616` immediately and decide merge / changes-request / follow-up.
+5. Triage the open issues listed above into:
+   - active-track blockers
+   - active-track follow-ups
+   - overflow-only cleanups
+
+---
+
+## Track A — Browser Queue (Phase 5 Deployment / Launch)
+
+### First governing move
+
+The first browser PR should be a scope-lock / doc-reconciliation slice:
+
+- activate Phase 5 from the true baseline
+- clear the stale blocker text in `5_deployment_launch/checkpoints.md`
+- decide whether Phase 5 now needs `SP-5-01`
+
+Recommendation:
+
+- Create `SP-5-01` if the orchestrator intends to split Phase 5 into more than a trivial 3-5 file change set.
+- Given the queue below, `SP-5-01` is appropriate.
+
+### Browser PR Queue
+
+| Queue ID | Slice | Likely Scope | Notes / Issues |
+|----------|-------|--------------|----------------|
+| B0 | Phase 5 activation + `SP-5-01` scope lock | `plans/browser_game/5_deployment_launch/checkpoints.md`, `plans/browser_game/sub_plan_registry.md`, new sub-plan | Must happen first |
+| B1 | Close docs drift in Phase 4 checkpoint | `plans/browser_game/4_data_pipeline/checkpoints.md` | Closes `#1574` |
+| B2 | Export ordering regression test | `tests/unit/hosted_play/test_export.py` | Closes `#1577` |
+| B3 | Production config contract | `web/config.py`, config tests/docs | DB URL, secrets, allowed origins, app URL, model path contract |
+| B4 | Hosted app startup entrypoint | new startup script or entry module | Stable production start command |
+| B5 | Health/readiness endpoints | `web/app.py`, `web/routes.py`, app tests | Needed for deploy smoke and health checks |
+| B6 | Dockerfile | `Dockerfile` | Keep thin, uvicorn + hosted extras only |
+| B7 | `.dockerignore` and image hygiene | `.dockerignore`, docs/tests if needed | Separate from Dockerfile for micro-PR size |
+| B8 | Render deployment config | `render.yaml` or repo-owned deploy doc/config | Use Render-first path from governing plan |
+| B9 | Environment template / launch contract doc | docs + possibly `.env.example` style artifact | Must match B3 exactly |
+| B10 | Local container smoke script | new script under `scripts/internal/` + tests/docs | Build, run, create match, hit health endpoint |
+| B11 | Postgres deployment smoke path | config/tests/scripts | Prefer one focused smoke harness, not full infra |
+| B12 | Deployment data-capture smoke | validate match creation, one hand flow, export still works | Use smallest reproducible path |
+| B13 | Launch checklist and operator runbook | phase docs, launch notes, session handoff input | Browser side closeout prep |
+| B14 | Phase 5 checkpoint closeout | checkpoints + registry + sub-plan outcome | Final browser closeout PR |
+
+### Browser Parallelism Rules
+
+- One active writer on `web/config.py`, `web/app.py`, and `web/routes.py`.
+- One active writer on deployment artifacts: `Dockerfile`, `.dockerignore`, `render.yaml`.
+- Tests/docs/support slices can run in parallel with implementation slices when file scope is disjoint.
+
+### Browser Lane Suggestions
+
+- `brws-author-a`: governing/doc activation, config/startup slices
+- `brws-author-b`: tests and smoke harnesses
+- `brws-author-c`: deploy artifacts and environment contract
+- `brws-author-d`: docs, health checks, runbook, overflow browser follow-ups
+
+---
+
+## Track B — Platform Queue (Step 2 Reopen + SP-4-07)
+
+### First governing move
+
+Platform should treat two things as immediate:
+
+1. resolve the open Telegram-inbound race via PR `#1616`
+2. execute SP-4-07 in controller-first order, not transport-first order
+
+### Platform PR Queue
+
+| Queue ID | Slice | Likely Scope | Notes / Issues |
+|----------|-------|--------------|----------------|
+| P0 | Review and land PR `#1616` if sound | `.claude/tmux/steward-session.sh`, session tests | Do not duplicate this work elsewhere |
+| P1 | Phase 4 docs/state reconciliation after P0 | checkpoints, sub-plan notes, handoff notes | Keep docs truthful about Telegram and Step 2/3 |
+| P2 | Message-bus TTL crash fix | `src/bid_euchre/ops/message_bus.py`, unit tests | `#1596` |
+| P3 | Repeat-escalation suppression | `src/bid_euchre/ops/message_bus.py`, tests | `#1610`, `#1601` |
+| P4 | Current-state stall verification | `src/bid_euchre/ops/monitor.py`, tests | `#1612` |
+| P5 | Lane shutdown cleanup hardening | `/park` surface, shutdown docs/tests | `#1580` |
+| P6 | `/check-in` command/docs drift fix | skill docs and/or CLI | `#1595` |
+| P7 | Prioritized inbox API test/doc cleanup | lifecycle test + real API use | `#1609`, `#1602` |
+| P8 | Bilateral messaging smoke expansion | integration tests | `#1570` |
+| P9 | Full orchestration lifecycle integration test | new `tests/integration/test_orchestration_lifecycle.py` | `#1597` |
+| P10 | Controller module scaffold | new `src/bid_euchre/ops/control_plane.py` or equivalent | Start SP-4-07 core |
+| P11 | Controller projection from monitor findings | control plane + tests | `#1571`, `#1569` |
+| P12 | Controller projection from task/lane state | control plane + status/dashboard | continue SP-4-07 |
+| P13 | Controller ack / clear / dedupe model | control plane + tests | should settle actionable-state semantics |
+| P14 | CLI/debug surface for controller state | `scripts/internal/ops.py`, docs, tests | expose `fleet_status.json` / `next_actions.json` |
+| P15 | Hook-fed urgent-state surfacing | `.claude/hooks/*`, settings, tests | `#1608` |
+| P16 | Guardrails for risky local actions | hooks + tests | block/warn dispatch/merge under unresolved P0 |
+| P17 | Runtime inbound audit wiring | actual inbound path + tests | `#1573` |
+| P18 | Runtime outbound audit wiring | actual outbound path + tests | `#1573` |
+| P19 | Controller + audit integration tests | integration suite | ties P17/P18 into SP-4-07 |
+| P20 | Transport comparison ADR / decision package | docs/session handoff, `#1289` output | compare bus, native, channels, hooks, tmux |
+| P21 | Step 2 / Step 3 checkpoint closeout | checkpoints, registry, sub-plan outcome | only after evidence exists |
+
+### Platform Parallelism Rules
+
+- One active writer on `src/bid_euchre/ops/message_bus.py`.
+- One active writer on `src/bid_euchre/ops/monitor.py`.
+- One active writer on `scripts/internal/ops.py`.
+- One active writer on hook/settings files.
+- `control_plane.py` can proceed in parallel once hot-file dependencies are explicit.
+- Audit runtime wiring should not begin until PR `#1616` is merged or otherwise superseded by a better verified fix.
+
+### Platform Lane Suggestions
+
+- `author-a`: P0/P1 governance + P10-P14 controller slices
+- `author-b`: message-bus correctness slices P2-P3
+- `author-c`: monitor/shutdown/lifecycle test slices P4-P9
+- `author-d`: audit runtime wiring P17-P19 after Telegram isolation is proven
+
+---
+
+## Overflow Queue — Issue Triage, Docs, and Clean Closures
+
+Use flex lanes and `author-scratch` for these only when the two primary tracks
+already have work in flight.
+
+| Queue ID | Slice | Notes / Issues |
+|----------|-------|----------------|
+| O1 | Pass/fail criteria policy hardening | `#1581` |
+| O2 | Idle detector valid-event cleanup | `#1588` |
+| O3 | Auto-shutoff truth/status reconcile | `#1587`, `#1572` |
+| O4 | Compact-inbox dead code cleanup | `#1611` |
+| O5 | Governing-plan pre-existing path refs | `#1614` |
+| O6 | Browser/platform checkpoint and session-log reconciliation | only if docs drift appears during run |
+| O7 | Analyst-shaped blocker issues discovered during run | use `steward-analyst` or scratch lane |
+
+Overflow rules:
+
+- Do not open new major initiatives.
+- Only take overflow work that is either:
+  - correctness debt in current tracks
+  - documentation drift blocking future sessions
+  - high-signal cleanup proven by review findings
+
+---
+
+## Issue-Triage Rules For This Run
+
+1. If a new issue blocks Browser Phase 5 or SP-4-07, route it to `steward-analyst` first.
+2. If a new issue is a small isolated fix in an already-touched file, dispatch directly.
+3. If review creates convention follow-ups that do not block the active tracks, park them in overflow.
+4. If an issue changes governed scope, update checkpoints or sub-plans before resuming implementation.
+5. If Telegram/channel behavior regresses again, stop remote-path expansion and keep working local controller slices.
+
+---
+
+## Validation Baseline
+
+### Browser
+
+- `uv sync --all-extras`
+- `uv run python -m pytest -q tests/unit/hosted_play/test_app.py tests/unit/hosted_play/test_config.py tests/unit/hosted_play/test_db.py`
+- `uv run python -m pytest -q tests/unit/hosted_play/test_routes.py tests/unit/hosted_play/test_export.py tests/unit/hosted_play/test_export_cli.py`
+
+### Platform
+
+- `uv run python scripts/internal/ops.py --json status`
+- `uv run python scripts/internal/ops.py --json dashboard`
+- `uv run python -m pytest -q tests/unit/test_steward_session.py`
+- `uv run python -m pytest -q tests/integration/test_bilateral_messaging.py`
+- `uv run python -m pytest -q tests/integration/test_orchestration_lifecycle.py`
+
+### Full-repo gate before any large closeout batch
+
+- `make check-quiet`
+
+---
+
+## Exit / Handoff Requirements
+
+Before ending the run, leave behind:
+
+- merged PR list grouped by Browser vs Platform vs Overflow
+- exact phase/checkpoint status for Browser Phase 5 and Platform Steps 2-3
+- open PRs still in flight
+- blocked slices with precise next action
+- any newly filed issues with reason they were filed
+- whether Browser Phase 5 is still active or complete
+- whether Platform Step 2 is truly complete and whether SP-4-07 moved to `in_progress` or `completed`
+
+If the run stalls early, prefer a precise durable handoff over speculative scope expansion.
+
+---
+
+## Short Recommendation To Orchestrator
+
+Operate as a dual-track queue manager:
+
+- Browser queue first activates Phase 5 and then pushes deployment/launch micro-PRs
+- Platform queue first resolves the Telegram race via the existing PR, then executes SP-4-07 in controller-first order
+- Flex capacity closes small but real follow-up issues that support those two tracks
+
+Do not wait for “waves” to finish. Keep both queues moving as long as file scope,
+tests, and governed sequence remain clean.

--- a/plans/sessions/2026-03-24_dual-track-fleet-run-results.md
+++ b/plans/sessions/2026-03-24_dual-track-fleet-run-results.md
@@ -1,0 +1,166 @@
+# Session Results — Dual-Track Fleet Run (2026-03-24d)
+
+**Date:** 2026-03-24
+**Duration:** ~3 hours
+**Operator:** Autonomous orchestrator
+**Handoff from:** `plans/sessions/2026-03-24_dual-track-browser-phase5-platform-sp4-07-handoff.md`
+
+---
+
+## Results Summary
+
+| Metric | Target | Actual |
+|--------|--------|--------|
+| PRs merged | 24 (base) / 30 (aggressive) / 40 (stretch) | **35** |
+| PRs open at end | — | 1 (#1665) |
+| PRs closed (conflicts) | — | 2 (#1624, #1628) |
+| Issues closed | — | **18** |
+| Lanes used | 12 | 12 (all active) |
+| Dispatch waves | — | ~8 |
+
+## Merged PRs (35)
+
+### Browser Game — Phase 5 Deployment (16 PRs)
+
+| PR | Title |
+|----|-------|
+| #1620 | fix(docs): replace exact test count in Phase 4 sub-plan |
+| #1622 | docs: activate Browser Phase 5 and create SP-5-01 scope lock |
+| #1625 | feat(web): add production config contract for hosted app |
+| #1627 | chore(docker): add .dockerignore for lean image builds |
+| #1629 | docs(web): add .env.example for browser game deployment |
+| #1634 | feat(web): add health and readiness endpoints for deploy probes |
+| #1636 | feat(web): add Render deployment config (Phase 5 Step 2) |
+| #1637 | feat(web): add local Docker smoke test script |
+| #1638 | feat(web): add Dockerfile for hosted browser game (Phase 5) |
+| #1642 | docs(web): update Phase 5 checkpoints — mark Steps 1-3 complete |
+| #1644 | docs(web): add launch checklist and operator runbook (Phase 5) |
+| #1645 | feat(web): add production startup entrypoint for hosted app |
+| #1646 | docs(web): add browser game deployment guide |
+| #1653 | test(web): add integration tests for deployment data-capture pipeline |
+| #1654 | feat(web): add Postgres deployment smoke tests |
+| #1655 | docs(web): close out Browser Game Phase 5 — all phases COMPLETE |
+
+### Platform — SP-4-07 Controller-First Control Plane (10 PRs)
+
+| PR | Title |
+|----|-------|
+| #1618 | fix(ops): stabilization gate — TTL expiry, escalation dedup, stall guard |
+| #1621 | docs: reconcile Phase 4 checkpoints after Telegram inbound fix |
+| #1633 | feat(ops): add controller projection module (SP-4-07 PR 2) |
+| #1648 | docs(ops): update Phase 4 checkpoints — SP-4-07 in_progress |
+| #1650 | docs: transport comparison ADR for #1289 decision (SP-4-07) |
+| #1656 | docs: update SP-4-07 sub-plan status to in_progress |
+| #1657 | feat(ops): integrate monitor findings into controller projection |
+| #1660 | fix(ops): honor TTL expiry in ack status and skip expired in escalation |
+| #1661 | feat(ops): wire audit trail into runtime paths and controller (SP-4-07 PR 4) |
+| #1662 | fix(docs): qualify ADR claims per review findings |
+
+### Platform — Overflow / Issue Closures (6 PRs)
+
+| PR | Title |
+|----|-------|
+| #1623 | fix(docs): resolve pre-existing P1 path references in governing_plan.md |
+| #1626 | fix(ops): remove unemittable session_started from idle detector (#1588) |
+| #1630 | fix(ops): wire fleet idle detection into monitor cycle |
+| #1631 | fix(ops): remove unreachable 24h P1 retention floor in compact_inbox |
+| #1639 | test: expand bilateral messaging integration tests (#1570) |
+| #1640 | fix(ops): replace stale _prioritized_inbox shim, forward --type/--thread |
+
+### Convention Follow-ups (3 PRs)
+
+| PR | Title |
+|----|-------|
+| #1663 | fix(web): correct .env.example comments for ALLOWED_ORIGINS and MODELS_DIR |
+| #1664 | fix(web): add non-root user to Dockerfile for runtime security |
+| #1649 | test(ops): add bilateral messaging end-to-end smoke test |
+
+## Issues Closed (18)
+
+Closed by merged PRs: #1573, #1574, #1577, #1580, #1587, #1588, #1595,
+#1596, #1597, #1601, #1602, #1609, #1610, #1611, #1612, #1614, #1615, #1647
+
+Additionally closed: #1521 (Telegram plugin reliability — resolved by #1616),
+#1632, #1651
+
+## Phase / Checkpoint Status
+
+### Browser Game
+
+**Status: ALL PHASES COMPLETE**
+
+- Phase 0 Foundation: COMPLETE
+- Phase 1 State Engine: COMPLETE
+- Phase 2 Backend API: COMPLETE
+- Phase 3 Frontend Product: COMPLETE
+- Phase 4 Data Pipeline: COMPLETE
+- Phase 5 Deployment & Launch: **COMPLETE** (this session)
+
+The browser game governing plan is fully delivered. Future work is incremental
+(real deployment to Render, UX polish, multi-player).
+
+### Platform — Agentic Orchestration (Phase 4)
+
+**Status: Phase 4 IN_PROGRESS — SP-4-07 substantially advanced**
+
+SP-4-07 deliverables status:
+1. ✅ Controller/reconciler module — `src/bid_euchre/ops/control_plane.py` (#1633)
+2. ✅ Monitor findings integration — controller reads monitor findings (#1657)
+3. ⬜ Hook-fed local enforcement — dispatched but not yet shipped (#1608)
+4. ✅ Platform-8b runtime wiring — audit trail wired into runtime (#1661)
+5. ✅ Transport comparison matrix — ADR written (#1650, closes #1289)
+
+SP-4-07 exit criteria progress:
+- [x] One repo-owned controller surface exists
+- [x] Controller derives actionable state from monitor/task/review/lane
+- [ ] Automated integration test for detect → surface → ack → clear
+- [ ] Unresolved urgent state surfaced mechanically (hook injection)
+- [x] Platform-8b runtime-wired
+- [ ] Real channel-backed remote loop proven end-to-end
+- [x] #1289 transport decision written
+
+**Next for SP-4-07:** Hook surfacing (#1608) is the main remaining gap.
+After that, proving runs 1-5 from the sub-plan need execution.
+
+## Open PRs at End
+
+| PR | Title | Status |
+|----|-------|--------|
+| #1665 | fix(web): honor CORS origins and MODELS_DIR | CI pending |
+
+## Blocked Slices
+
+| Slice | Blocker | Next Action |
+|-------|---------|-------------|
+| SP-4-07 hook surfacing | Hook needs controller on main (done) | Dispatch to a lane |
+| SP-4-07 proving runs | Need hook surfacing + controller | After hook PR lands |
+| Platform-9a scope lock | SP-4-07 completion | After SP-4-07 exits |
+
+## Remaining Open Issues (platform-aligned)
+
+- #1608 — hook-based alert injection (SP-4-07 PR 3 scope)
+- #1619 — run-fleet inbox polling safeguard
+- #1572 — idle-system auto-shutoff wiring
+- #1581 — pass/fail criteria policy
+- Convention follow-ups: #1578, #1589, #1593, #1594, #1607, #1635, #1641, #1652, #1658, #1659, #1666
+
+## Operational Findings
+
+1. **Permission prompt friction:** Lanes editing `.claude/skills/*/SKILL.md` get
+   stuck on permission prompts repeatedly. Option "2" (allow for session) helps
+   but doesn't persist across dispatches with `--reset`. Consider adding SKILL.md
+   to allowed edit paths in settings.
+
+2. **Merge conflict cascading:** Fast-merging PRs cause downstream branches to
+   conflict. GitHub API rebase often fails. Closing and recreating on fresh
+   branches is faster than debugging conflicts.
+
+3. **Dispatch rate:** ~12 PRs/hour at peak (first 90 min), dropping to ~6/hour
+   as tasks get more complex and CI queues lengthen.
+
+4. **Convention follow-up generation:** The review coordinator creates new
+   follow-up issues for every PR, which generates work faster than it's consumed.
+   This is sustainable for cleanup waves but shouldn't be the primary work stream.
+
+5. **MEMORY.md updated:** brws-author-a updated MEMORY.md to reflect Browser
+   Game completion and current platform state.

--- a/plans/sessions/2026-03-24_issue-backlog-autonomous-run-handoff.md
+++ b/plans/sessions/2026-03-24_issue-backlog-autonomous-run-handoff.md
@@ -1,0 +1,613 @@
+# Handoff — Issue Backlog Autonomous Run
+
+**Date:** 2026-03-24
+**Status:** READY FOR ORCHESTRATOR
+**Goal:** Work the current open issue backlog aggressively but safely, with a
+clear split between autonomous work and user-blocked proving.
+
+---
+
+## Use This As The Operating Contract
+
+Use the current repo state and open GitHub issue set as the source of truth for
+this session.
+
+This handoff is intentionally issue-driven first, but it must still respect the
+governing plans where they extend beyond the current issue list.
+
+The session should:
+
+- maximize safe, mergeable throughput across the open issue backlog
+- keep both browser and platform work moving where governed scope allows
+- close or supersede dead issues quickly after verification
+- stop cleanly at true user-proving boundaries
+- leave behind a clean next-wave handoff, not a half-implemented tangle
+
+User availability constraint:
+
+- **The user is unavailable during the session.**
+- Any slice that requires a real user proving step must be deferred until the
+  **end** of the run.
+- If a slice reaches that boundary earlier, mark it `USER PROVING PENDING`,
+  update the relevant plan/issue/session note, and continue all other unblocked
+  work.
+
+---
+
+## Governing State
+
+### Browser
+
+Browser Game phases 0-5 are complete in governed-plan terms.
+
+For this session, the browser track is **closeout and deployment hardening
+only**, not a new phase:
+
+- deployment correctness
+- smoke-test hardening
+- docs/env contract cleanup
+- small browser follow-up issues
+
+There is **no additional governed browser-plan work** to invent here.
+
+Do not:
+
+- open a new browser phase
+- create a speculative browser amendment
+- treat UX polish or real deployment execution as new governed scope unless a
+  new planning slice is explicitly created later
+
+Primary references:
+
+- `plans/browser_game/governing_plan.md`
+- `plans/browser_game/5_deployment_launch/checkpoints.md`
+
+### Platform
+
+Platform work is still active in **SP-4-07**:
+
+- controller-first control plane
+- hook-fed urgent-state surfacing
+- runtime adoption of controller/audit surfaces
+- proving runs
+
+Primary references:
+
+- `plans/agent_ops/4_remote_channel/checkpoints.md`
+- `plans/agent_ops/4_remote_channel/sub/2026-03-24_controller-first-control-plane-and-transport-evaluation.md`
+- `plans/sessions/2026-03-24_controller-first-control-plane-handoff.md`
+
+Current platform reality:
+
+- controller library exists
+- audit runtime wrappers exist
+- neither is yet fully consumed by live runtime paths
+- proving runs are only partially unblocked
+
+Additional governed platform work exists **beyond** the current issue list:
+
+- finish SP-4-07 as a real governed slice, not just a set of child issue fixes
+- if SP-4-07 becomes materially complete, prepare the next governed slice:
+  `Platform-9a` scope lock / sub-plan registration
+- do **not** start `Platform-9b` or `Platform-9c` implementation without the
+  required proving and user-availability boundary
+
+---
+
+## Current Open-Issue Landscape
+
+As of startup, the open issue list is:
+
+- `#1686` render health check path
+- `#1685` live audit hook/tool wiring
+- `#1684` live controller reconcile wiring
+- `#1683` SP-4-07 integration tests
+- `#1682` SP-4-07 proving run 2
+- `#1681` SP-4-07 proving run 1
+- `#1680` SP-4-07 proving run 5 (real Telegram)
+- `#1679` SP-4-07 proving run 4
+- `#1678` SP-4-07 proving run 3
+- `#1677` add `steward-analyst` pane/worktree
+- `#1676` follow-up for PR #1669
+- `#1673` orchestrator must `/park` ops/review before session end
+- `#1672` detect permission-stalled lanes
+- `#1671` SKILL.md edit permission
+- `#1668` follow-up for PR #1665
+- `#1667` stale `.env.example` comments
+- `#1666` follow-up for PR #1660
+- `#1659` follow-up for PR #1654
+- `#1658` follow-up for PR #1653
+- `#1652` follow-up for PR #1640
+- `#1641` follow-up for PR #1634
+- `#1619` restore dispatch-time inbox safeguard until replacement exists
+- `#1608` hook-fed urgent-state injection
+- `#1607` follow-up for PR #1603
+- `#1594` follow-up for PR #1592
+- `#1593` follow-up for PR #1590
+- `#1589` follow-up for PR #1584
+- `#1581` explicit pass/fail criteria policy
+- `#1572` idle-system auto-shutoff
+- `#1571` messaging re-evaluation umbrella
+- `#1570` bilateral messaging smoke/full tests
+- `#1569` inbox polling failure umbrella
+- `#1521` Telegram reliability
+- `#1337` dashboard live/cleanup follow-up
+- `#1288` Codex comment ingestion bridge
+
+---
+
+## Startup Triage — Close, Keep, Or Defer
+
+At startup, do a fast verification pass and classify each issue into one of
+these buckets.
+
+### Bucket A — Close Immediately If Verified
+
+These look already resolved or non-actionable. Verify on `main`, then close
+with a brief comment citing the current file/test evidence.
+
+- `#1607`
+  - current `recovering-context` already reads current lane inbox
+  - current `run-fleet` already deduplicates cron creation
+- `#1589`
+  - current `tests/integration/test_bilateral_messaging.py` is explicitly an
+    integration test module
+- `#1593`
+  - current `check-in` uses `--include-native` and no longer documents the
+    unsupported `ack-all --type` example
+- `#1619`
+  - current `run-fleet` already restores both the startup cron and the
+    mandatory dispatch-time inbox poll
+- `#1652`
+  - issue body contains no concrete actionable defect; close as no-op after
+    verification
+
+Candidate close after verification:
+
+- `#1570`
+  - if both the bilateral smoke test and the comprehensive bilateral messaging
+    test on `main` satisfy the issue acceptance criteria, close it
+
+### Bucket B — Autonomous Implementation Now
+
+These are in scope for this session and do **not** require user proving:
+
+Browser:
+
+- `#1686`
+- `#1667`
+- `#1668`
+- `#1641`
+- `#1658`
+- `#1659`
+
+Platform:
+
+- `#1684`
+- `#1685`
+- `#1608`
+- `#1683` (non-user-blocked parts)
+- `#1678`
+- `#1679`
+- `#1671`
+- `#1672`
+- `#1673`
+- `#1676`
+- `#1666`
+- `#1594`
+- `#1581`
+- `#1572`
+- `#1677`
+
+Secondary / overflow:
+
+- `#1337` (cleanup / scope-split / hygiene, not the already-shipped `--watch`)
+
+### Bucket C — User-Proving Or End-Of-Session Only
+
+Do not make these critical-path work during the main run:
+
+- `#1680` — real Telegram remote loop
+- `#1521` — final reliability disposition depends on real remote proving
+
+If time remains at the end and the system is otherwise healthy, prepare the
+exact proving packet and stop there.
+
+### Bucket D — Defer Unless Capacity Remains
+
+- `#1288` — not on the critical path for browser closeout or SP-4-07
+- `#1571` and `#1569` — umbrella issues; implement their child fixes, then
+  update/close them only when the runtime behavior is actually proven
+
+---
+
+## Governed Work Beyond The Issue List
+
+If the actionable issue queue thins or a governed slice needs explicit closeout
+work that is not yet captured by a narrow issue, continue with the governing
+plan directly.
+
+### Browser
+
+Do not create new governed browser work in this session.
+
+Allowed non-issue browser work:
+
+- plan/checkpoint/session-note reconciliation for already-completed Phase 5 work
+- operational deployment hardening that is clearly within the shipped Phase 5
+  contract
+
+### Platform
+
+Continue governed platform work in this order when issue-backed work is not
+enough to keep progress moving:
+
+1. Finish SP-4-07 deliverables and plan/checkpoint closeout work.
+2. Reconcile Phase 4 checkpoints/sub-plan state with the actual shipped runtime.
+3. If Step 2 (`Platform-8b`) and Step 3 (`SP-4-07`) are healthy enough, draft
+   the next governed scope lock for `Platform-9a`.
+
+`Platform-9a` scope lock is allowed in this session even if the implementation
+must wait.
+
+`Platform-9b` and `Platform-9c` should remain blocked on proving and user
+availability.
+
+---
+
+## Additional Work Not Yet In The Issue List
+
+Two browser follow-ups were flagged in review and should be handled even if no
+issue exists yet.
+
+1. **Docker startup should honor `$PORT`**
+- The dedicated startup entrypoint already reads `PORT`, but the Dockerfile
+  still hardcodes `--port 8000`.
+- If no issue exists, file a narrow bug with test criteria, then fix it.
+
+2. **Render should probe `/ready` not `/`**
+- This is already tracked by `#1686` and should be treated as a high-priority
+  browser hardening item.
+
+---
+
+## Lane Model
+
+Assume the normal 12 implementation lanes are available unless startup checks
+prove otherwise:
+
+- Browser: `brws-author-a`, `brws-author-b`, `brws-author-c`, `brws-author-d`
+- Platform: `author-a`, `author-b`, `author-c`, `author-d`
+- Flex: `author-scratch`, `flex-a`, `flex-b`, `flex-c`
+
+Central lanes (`orchestrator`, `ops`, `review`, and `steward-analyst` if
+available) are supervision/service lanes, not default implementation lanes.
+
+Use `steward-analyst` for:
+
+- issue shaping
+- wave planning
+- plan/checkpoint/task-list reconciliation
+- end-of-wave / end-of-session handoffs
+
+If `steward-analyst` does not yet have a visible pane, keep the role behavior
+but do not block implementation on the layout change.
+
+---
+
+## Throughput Target
+
+Target:
+
+- **Realistic:** 18-25 merged PRs plus issue closures
+- **Stretch:** 25-35 merged PRs if the session stays in micro-sliced mode
+
+Do **not** chase PR count by opening speculative or weakly scoped work.
+
+---
+
+## Phase 0 — Startup / Sanity Pass
+
+Before dispatching implementation:
+
+1. Review the governed-plan state for browser and SP-4-07.
+2. Review the current open issue list.
+3. Review active task lists and current session notes.
+4. Check lane health, dirty worktrees, stale packets, inbox backlog, and open PRs.
+5. Verify whether any issues in Bucket A are already resolved and close them if so.
+6. File a narrow browser deployment bug for Docker `$PORT` if no issue already exists.
+7. Update the session note with:
+   - issues closed as already resolved
+   - issues selected for Wave 1
+   - issues explicitly deferred to user proving
+
+Do not let Phase 0 balloon. It should be fast and decisive.
+
+---
+
+## Wave Plan
+
+Treat waves as rolling queues, not barriers.
+
+### Wave 1 — Fast Issue Closures And Browser Hardening
+
+Goal:
+
+- clean out dead issue backlog
+- ship the browser closeout fixes that are isolated and cheap
+
+Dispatch candidates:
+
+- verify and close `#1607`
+- verify and close `#1589`
+- verify and close `#1593`
+- verify and close `#1619`
+- verify and close `#1652`
+- browser fix: `#1686` Render `/ready`
+- browser docs fix: `#1667`
+- browser config/path fix: `#1668`
+- browser route/test fix: `#1641`
+- browser test hardening: `#1658`
+- browser smoke hardening: `#1659`
+- file and, if possible, immediately fix the Docker `$PORT` issue
+
+Notes:
+
+- Browser lanes should carry this wave.
+- Keep PRs narrow: one concept per PR.
+
+### Wave 2 — Platform Runtime Adoption Foundations
+
+Goal:
+
+- make the controller and audit surfaces live, not inert
+
+Dispatch candidates:
+
+- `#1684` live reconcile driver
+- `#1685` live audit hook/tool wiring
+- `#1666` urgent-message TTL follow-up
+- `#1671` SKILL.md edit permission fix
+- `#1673` shutdown `/park` wiring
+- `#1594` doc/contract cleanup around actual park transition
+
+Notes:
+
+- `#1673` and `#1594` may be combined only if file overlap makes that cleaner.
+- `#1684` and `#1685` are the highest-value platform slices.
+
+### Wave 3 — Hook Surfacing And Dispatch Safety
+
+Goal:
+
+- close the “write-only alert” gap mechanically
+
+Dispatch candidates:
+
+- `#1608` UserPromptSubmit urgent-state injection
+- `#1608` PreToolUse risky-action guardrail if the first slice lands cleanly
+- `#1672` permission-stall detection/recovery
+- `#1676` remaining analyst/check-in follow-up(s)
+
+Notes:
+
+- If `#1608` proves larger than expected, split it:
+  - projection reader
+  - prompt injection
+  - risky-action guard
+- Do not declare `#1569` or `#1571` solved yet. They are umbrellas until
+  runtime behavior is actually proven.
+
+### Wave 4 — Non-User Proving And Integration Tests
+
+Goal:
+
+- turn the new platform behavior into outcome-based evidence
+
+Dispatch candidates:
+
+- `#1678` controller persistence/dedupe proving
+- `#1679` false-stall proving
+- `#1681` unread-alert replay
+- `#1682` noise discrimination
+- `#1683` integration tests:
+  - lifecycle path
+  - remote exchange path
+  - alert-pipeline path once `#1608` lands
+
+Candidate close:
+
+- `#1570` if smoke/full bilateral coverage now satisfies the issue body
+
+Notes:
+
+- These are still autonomous.
+- They require live steward runtime, but not user participation.
+
+### Wave 5 — Platform Process / Policy Cleanup
+
+Goal:
+
+- remove known orchestration friction and codify better done-criteria
+
+Dispatch candidates:
+
+- `#1581` explicit pass/fail criteria policy + templates/docs
+- `#1572` idle auto-shutoff
+- `#1677` steward-analyst visible pane/worktree/layout
+
+Notes:
+
+- `#1677` is valuable but not on the critical path. Only pull it forward if
+  the core SP-4-07 slices are healthy.
+- `#1337` should only enter here if higher-value work is blocked or finished.
+
+### Wave 6 — Governed Platform Continuation
+
+Goal:
+
+- keep pushing governed Phase 4 work even when the explicit issue queue starts
+  to thin
+
+Dispatch candidates:
+
+- SP-4-07 closeout docs/checkpoints/sub-plan updates once its runtime exit
+  criteria are materially satisfied
+- narrow missing SP-4-07 deliverables not yet represented by child issues
+- `Platform-9a` scope lock and sub-plan registration if Step 2/3 are healthy
+
+Notes:
+
+- This is platform-only governed work.
+- Do **not** invent a new browser governed slice here.
+- Do **not** start `Platform-9b` implementation in this session.
+
+### Wave 7 — Dashboard And Remaining Cleanup
+
+Goal:
+
+- use remaining capacity for still-relevant but non-core cleanup
+
+Dispatch candidates:
+
+- `#1337`
+  - treat as stale-data / cleanup / classification issue, not a greenfield live-dashboard build
+- remaining convention follow-ups not yet closed
+- docs/checkpoint/task-list reconciliation
+
+Notes:
+
+- Because `ops.py dashboard --watch` already exists, do not spend a wave
+  “building live dashboard” from scratch.
+- Scope this as cleanup, hygiene, and closeout.
+
+### Wave 8 — End-Of-Session User-Proving Boundary
+
+Only at the end of the run, and only if the system is otherwise healthy:
+
+- prepare `#1680` proving packet
+- reassess `#1521`
+
+If the user is still unavailable:
+
+- mark both `USER PROVING PENDING`
+- update the relevant plan / issue / session note
+- produce a compact proving handoff with:
+  - what changed
+  - exactly what the user must test
+  - expected outcome
+  - what closure or next step depends on the result
+
+Do **not** block the rest of the session on these.
+
+---
+
+## Issue Closure Guidance
+
+Close issues only when the current repo and tests justify it.
+
+### Close Immediately After Verification
+
+- `#1607`
+- `#1589`
+- `#1593`
+- `#1619`
+- `#1652`
+
+### Close After Specific Work Lands
+
+- `#1686`, `#1667`, `#1668`, `#1641`, `#1658`, `#1659`
+- `#1684`, `#1685`, `#1608`
+- `#1678`, `#1679`, `#1681`, `#1682`, `#1683`
+- `#1671`, `#1672`, `#1673`, `#1594`, `#1676`
+- `#1666`
+- `#1572`
+- `#1677`
+
+### Keep Open Until Runtime Or User Proof Exists
+
+- `#1569`
+- `#1571`
+- `#1521`
+- `#1680`
+
+### Defer
+
+- `#1288`
+
+---
+
+## Dispatch Discipline
+
+Use the generic `/run-fleet` principles, but add these issue-specific rules:
+
+1. Before each new dispatch cycle:
+   - recheck the open issue list
+   - recheck which issues are already resolved by merged code
+   - close dead issues before opening new implementation work
+2. Prefer issue-backed work packets.
+   - Exception: governed platform continuation work is allowed when it is the
+     next explicit slice in the plan and the issue queue no longer captures the
+     needed closeout/scope-lock work.
+3. If a review finding is not represented by an issue yet and it matters, file
+   a narrow issue with test criteria before or alongside dispatch.
+4. One active writer per overlapping file set.
+5. If a slice overlaps with a proving or runtime boundary, split the code work
+   from the proving step.
+
+---
+
+## User-Proving Rule For This Session
+
+The user is unavailable.
+
+Therefore:
+
+- **Do not** block mainline autonomous work on real Telegram proving
+- **Do not** block on end-user browser proving
+- **Do** stop the specific dependent slice at the real proving boundary
+- **Do** mark `USER PROVING PENDING`
+- **Do** continue everything else
+
+User-attention items for the end only:
+
+- `#1680`
+- final disposition of `#1521`
+
+---
+
+## Reporting Requirements
+
+Maintain concise session notes throughout the run.
+
+Track explicitly:
+
+- issues closed as already resolved
+- issues implemented and merged
+- issues blocked on prerequisites
+- issues blocked on user proving
+- newly filed issues
+- any scope splits made to keep PRs small
+
+At the end, produce a handoff with:
+
+- merged PR count
+- issues closed
+- issues still open and why
+- user-proving items pending
+- recommended next wave
+
+---
+
+## Success Condition
+
+Success for this run is:
+
+- the stale/dead issue backlog is reduced
+- browser closeout bugs are cleaned up
+- no speculative new browser governed work is invented
+- SP-4-07 moves from inert infrastructure to live runtime behavior
+- if unblocked, Platform-9a scope lock is prepared
+- non-user proving is executed as far as possible
+- user-blocked proving is isolated cleanly
+- the repo ends the session with fewer open questions and a smaller, cleaner issue list

--- a/plans/sessions/2026-03-25_issue-backlog-autonomous-run-results.md
+++ b/plans/sessions/2026-03-25_issue-backlog-autonomous-run-results.md
@@ -1,0 +1,204 @@
+# Session Results — Issue Backlog Autonomous Run
+
+**Date:** 2026-03-25
+**Duration:** ~2.5 hours (00:04–02:30 UTC)
+**Operator:** Autonomous orchestrator (user unavailable)
+**Handoff from:** `plans/sessions/2026-03-24_issue-backlog-autonomous-run-handoff.md`
+
+---
+
+## Results Summary
+
+| Metric | Target | Actual |
+|--------|--------|--------|
+| PRs merged | 18-25 realistic / 25-35 stretch | **40** |
+| Issues closed during session | — | **46** |
+| Issues filed during session | — | **17** (16 closed same-session) |
+| Net backlog reduction | — | **28** (35 open → 7 remaining) |
+| Open PRs at end | 0 | **0** |
+| Lanes used | 12 | **12** (1 retired at context limit) |
+| Dispatch waves | — | ~8+ rolling |
+
+> **Note on issue metrics:** 46 issues were closed during the session. 17 new
+> issues were filed (mostly by the review coordinator as follow-ups to merged
+> PRs), of which 16 were closed same-session. The starting backlog was 35 open
+> issues; 7 remained at session end. Two additional issues (#1748, #1749) were
+> filed post-session during handoff.
+
+---
+
+## Merged PRs (40)
+
+### Wave 1 — Browser Hardening + Convention Follow-ups (8 PRs)
+
+| PR | Issue | Title | Merged |
+|----|-------|-------|--------|
+| #1687 | (pre-session) | fix(test): add pytestmark integration marker to bilateral messaging tests | 00:02 |
+| #1690 | #1641 | fix(web): add write capability check to /ready endpoint | 00:34 |
+| #1691 | #1659 | fix(test): isolate Postgres smoke DB per process + exercise startup entrypoint | 00:35 |
+| #1692 | #1686 | fix(web): point Render healthCheckPath to /ready endpoint | 00:31 |
+| #1693 | #1667 | fix(docs): update .env.example comments to reflect CORS/MODELS_DIR wiring | 00:31 |
+| #1694 | #1689 | fix(docker): use web/start.py entrypoint to honor $PORT | 00:31 |
+| #1695 | #1668 | fix(web): preserve relative artifact paths when MODELS_DIR is set | 00:38 |
+| #1697 | #1658 | fix(test): assert persisted play decision in data capture test | 00:39 |
+
+### Wave 2 — Platform Runtime Adoption (8 PRs)
+
+| PR | Issue | Title | Merged |
+|----|-------|-------|--------|
+| #1699 | #1684 | feat(ops): wire controller reconcile() into monitor cycle | 00:46 |
+| #1701 | #1672 | fix(ops): detect 'Do you want to make this edit' permission stalls | 00:53 |
+| #1702 | #1581 | docs: add explicit pass/fail criteria policy to templates | 00:48 |
+| #1703 | #1666 | fix(ops): honor urgent-message TTL exemption in check_ack_status | 00:54 |
+| #1704 | #1572 | feat(ops): add execute_shutoff() for fleet idle auto-shutoff | 00:55 |
+| #1705 | #1688 | fix(test): add pytestmark integration marker to all integration test files | 00:56 |
+| #1707 | #1683 | test(ops): add SP-4-07 controller projection integration tests | 00:58 |
+| #1708 | #1671 | fix(ops): add SKILL.md edit permission to prevent lane stalls | 00:54 |
+
+### Wave 3 — Hook Surfacing (2 PRs)
+
+| PR | Issue | Title | Merged |
+|----|-------|-------|--------|
+| #1715 | #1685 | fix(ops): wire audit_mcp_outbound into live PostToolUse hook | 01:19 |
+| #1719 | #1608 | feat(ops): add UserPromptSubmit hook for mechanical alert injection | 02:03 |
+
+### Wave 4 — Proving Runs (4 PRs)
+
+| PR | Issue | Run | Title | Merged |
+|----|-------|-----|-------|--------|
+| #1712 | #1678 | Run 3 | test(ops): prove controller persistence, dedup, and clear lifecycle | 01:08 |
+| #1714 | #1679 | Run 4 | test(ops): prove stall guard prevents false positives | 01:12 |
+| #1718 | #1681 | Run 1 | test(ops): prove unread-alert replay through controller projection | 01:22 |
+| #1730 | #1682 | Run 2 | test(ops): prove noise discrimination in controller projection | 01:46 |
+
+### Wave 5 — Process/Policy Cleanup (5 PRs)
+
+| PR | Issue | Title | Merged |
+|----|-------|-------|--------|
+| #1722 | #1673 | fix(ops): wire /park into orchestrator shutdown flow | 01:24 |
+| #1723 | #1676 | fix(docs): correct orchestrator shutdown and check-in native inbox handling | 01:25 |
+| #1733 | #1677 | ops: add steward-analyst to central-ops tmux layout | 01:50 |
+| #1735 | #1717 | feat(ops): add --max-age filter and bulk-ack alias to inbox ack-all | 02:00 |
+| #1720 | #1700 | fix(web): preserve models_dir fallback after CWD artifact load failure | 01:28 |
+
+### Wave 6 — Governed Closeout + Follow-ups (13 PRs)
+
+| PR | Issue | Title | Merged |
+|----|-------|-------|--------|
+| #1725 | #1698 | fix(ops): pass task queue root to list_packets in monitor reconciliation | 01:43 |
+| #1728 | #1710 | fix: add Write permission for SKILL.md to prevent lane stalls | 01:34 |
+| #1731 | #1710 | fix(config): add Write permission for SKILL.md (duplicate) | 01:43 |
+| #1734 | #1713 | fix(convention): move pytestmark before helpers in test_controller_projection | 01:50 |
+| #1736 | #1706 | fix(test): decouple controller projection tests from hardcoded clock | 02:29 |
+| #1737 | #1716 | feat(ops): add worktree registry bulk registration | 02:06 |
+| #1738 | #1727 | fix(convention): add missing pytestmark to test_unread_alert_replay | 02:06 |
+| #1739 | #1721 | fix(ops): implement download_attachment audit before registering it | 02:07 |
+| #1740 | (governed) | docs(ops): reconcile SP-4-07 checkpoints with runtime adoption progress | 02:01 |
+| #1741 | — | fix(convention): move pytestmark before helpers in test_controller_projection | 02:07 |
+| #1742 | — | fix(convention): add pytestmark integration marker to test_unread_alert_replay | 02:10 |
+| #1743 | — | fix(ops): decouple controller projection tests from wall-clock time | 02:11 |
+| #1746 | #1724 | fix(test): decouple noise discrimination tests from wall clock | 02:14 |
+
+---
+
+## Issues Closed (46)
+
+### Bucket A — Verified Already Resolved (6)
+
+#1607, #1589, #1593, #1619, #1652, #1570
+
+### Browser Hardening (7)
+
+#1686, #1667, #1668, #1641, #1658, #1659, #1689 (filed and closed same-session)
+
+### Platform Runtime (5)
+
+#1684, #1685, #1666, #1608, #1672
+
+### Proving Runs (5)
+
+#1678, #1679, #1681, #1682, #1683
+
+### Policy/Process (7)
+
+#1581, #1572, #1671, #1673, #1676, #1677, #1594
+
+### Convention Follow-ups (15)
+
+#1688, #1698, #1700, #1706, #1709, #1710, #1711, #1713, #1716, #1717, #1721,
+#1724, #1726, #1727, #1729
+
+### Other (1)
+
+#1337 (dashboard cleanup — closed by author-scratch as satisfied by current state)
+
+---
+
+## Issues Remaining (7 at session end, 8 post-handoff)
+
+| # | Category | Status |
+|---|----------|--------|
+| #1747 | Convention follow-up PR #1742 | Minor, next session |
+| #1680 | SP-4-07 real Telegram proving | **USER PROVING PENDING** |
+| #1571 | Messaging re-evaluation umbrella | Keep open until runtime proven |
+| #1569 | Inbox polling umbrella | Keep open until runtime proven |
+| #1521 | Telegram reliability | **USER PROVING PENDING** |
+| #1288 | Codex comment ingestion | Deferred — not on critical path |
+
+Post-session additions:
+
+| # | Category | Status |
+|---|----------|--------|
+| #1748 | tmux capture-pane skill | New — filed during handoff |
+| #1749 | Analyst lane activation + proving | New — filed during handoff |
+
+---
+
+## Operational Lessons
+
+1. **Permission prompt format matters.** The settings.json edit prompt is a
+   numbered menu (1/2/3), not y/n. Sending `y` had no effect. Correct response:
+   `Esc + 2` ("allow for session"). ~30min of platform lane capacity was lost
+   before this was diagnosed. Fixed by PR #1708 (SKILL.md edit permission in
+   settings.json).
+
+2. **Review coordinator generates follow-up issues faster than expected.** Each
+   merged PR generates 1-2 follow-up issues, creating a long tail. 17 follow-up
+   issues were filed during the session; 16 were closed same-session.
+
+3. **Merge conflicts increase with velocity.** At 40+ PRs, later PRs frequently
+   conflicted with earlier merges. 5 PRs needed rebases; 2 were closed and
+   recreated.
+
+4. **Context limits are real.** flex-a (139k tokens) effectively died.
+   author-b hit 135k. Lanes should be `/clear`ed and restarted when approaching
+   120k tokens.
+
+5. **GitHub API rate limits hit at high throughput.** ~5min outage around
+   T+86min from rate limiting on issue close/PR list operations.
+
+---
+
+## Session End State
+
+- All 14 worktrees updated to origin/main
+- All 12 author lanes cleared
+- Ops and review lanes parked (crons deleted) and cleared
+- Monitoring cron deleted
+- 0 open PRs
+- 0 dirty worktrees
+
+---
+
+## Recommended Next Session
+
+1. **Refresh analytics dashboard** — the dashboard data is stale after 40 PRs
+2. **Activate steward-analyst lane** (#1749) — worktree, tmux pane, proving run
+3. **Telegram user-proving** (#1680, #1521) — the user-blocked boundary
+4. **SP-4-07 closeout assessment** — all autonomous proving passed; evaluate
+   whether to mark SP-4-07 COMPLETE
+5. **Platform-9a scope lock** — if SP-4-07 is healthy, draft idle-attention
+   alert loop
+6. **tmux capture-pane skill** (#1748) — standardize lane inspection
+7. **#1747** — minor convention follow-up
+8. **MEMORY.md update** — record this session


### PR DESCRIPTION
## Summary
- Commit 4 session documents from two consecutive fleet runs
- 2026-03-24 dual-track run: 35 PRs merged, 18 issues closed (Browser Phase 5 + Platform SP-4-07)
- 2026-03-25 issue backlog run: 40 PRs merged, 46 issues closed (backlog 35 → 7)

## Why
Session history must be committed for cross-session continuity and handoff traceability.

## Repro / Validation
Docs-only PR — no code changes.

```
make check-quiet
```

## Test Criteria
- `make docs-check` passes
- Files are valid markdown
- No code changes included

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: docs/session-results-2026-03-25
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)