### PR TITLE
fix(ops): wire inbox + audit inputs into controller reconcile (#1751)

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -2321,7 +2321,7 @@ def cmd_monitor(args: argparse.Namespace) -> int:
         print(format_findings_text(findings))
 
     # Update the controller projection so fleet_status.json reflects the
-    # latest monitor findings and task queue state.
+    # latest monitor findings, task queue, inbox, and audit state.
     if not no_reconcile:
         try:
             task_dicts = [
@@ -2329,10 +2329,34 @@ def cmd_monitor(args: argparse.Namespace) -> int:
             ]
         except Exception:
             task_dicts = None
+
+        # Load unacked inbox messages for the orchestrator lane so the
+        # controller can surface stale urgent items in fleet_status.json.
+        try:
+            from bid_euchre.ops.message_bus import read_inbox
+
+            inbox_msgs = read_inbox("orchestrator", status="pending")
+            inbox_msgs += read_inbox("orchestrator", status="delivered")
+        except Exception:
+            inbox_msgs = None
+
+        # Load recent audit trail records so unanswered inbound remote
+        # exchanges are surfaced in the fleet projection.
+        try:
+            from bid_euchre.ops.audit_trail import read_records
+
+            audit_dir = args.runtime_dir / "audit_trail" if args.runtime_dir else None
+            raw_records = read_records(audit_dir=audit_dir)
+            audit_dicts = [r.to_dict() for r in raw_records]
+        except Exception:
+            audit_dicts = None
+
         _reconcile(
             runtime_dir=args.runtime_dir,
             monitor_finding_objects=findings,
             task_packets=task_dicts,
+            unacked_messages=inbox_msgs,
+            audit_records=audit_dicts,
         )
 
     # Exit 1 if any high-severity findings

--- a/tests/unit/test_ops_control_plane.py
+++ b/tests/unit/test_ops_control_plane.py
@@ -1798,6 +1798,113 @@ class TestMonitorReconcileWiring:
             f"items={[i.task_id for i in loaded.items]}"
         )
 
+    def test_cli_monitor_wires_inbox_and_audit_to_reconcile(self, tmp_path: Path):
+        """CLI monitor passes inbox messages and audit records to reconcile (#1751).
+
+        Regression: cmd_monitor only passed monitor_finding_objects and
+        task_packets to reconcile(), leaving fleet_status.json blind to stale
+        urgent inbox items and unanswered remote exchanges.
+
+        This test seeds both inputs and verifies they appear in the reconciled
+        fleet status after a monitor cycle.
+        """
+        import json as _json
+        import subprocess
+
+        # Seed an urgent pending inbox message in the bus directory.
+        # Use BID_EUCHRE_BUS_DIR env var to redirect shared_bus_root().
+        bus_dir = tmp_path / "bus"
+        inbox_dir = bus_dir / "inbox"
+        inbox_dir.mkdir(parents=True)
+        urgent_msg = {
+            "message_id": "urgent-test-1751",
+            "thread_id": None,
+            "task_id": None,
+            "from_lane": "ops",
+            "to_lane": "orchestrator",
+            "message_type": "blocker",
+            "priority": "urgent",
+            "status": "pending",
+            # 30 minutes old — well past the default 10-minute threshold.
+            "created_at": "2026-03-24T21:30:00Z",
+            "acked_at": None,
+            "resolved_at": None,
+            "requires_human": False,
+            "summary": "Test urgent message for #1751",
+            "payload": {"ttl_seconds": 86400},
+            "source_transport": "bus",
+            "parent_message_id": None,
+        }
+        (inbox_dir / "orchestrator.jsonl").write_text(_json.dumps(urgent_msg) + "\n")
+
+        # Seed an unanswered inbound audit record in runtime_dir/audit_trail.
+        audit_dir = tmp_path / "audit_trail"
+        audit_dir.mkdir(parents=True)
+        inbound_record = {
+            "exchange_id": "exc-test-1751",
+            "timestamp": "2026-03-24T21:50:00Z",
+            "direction": "inbound",
+            "channel_source": "telegram",
+            "sender_identity": "user@test",
+            "exchange_type": "message",
+            "content_hash": "abc123",
+            "content_preview": "Hello from Telegram",
+            "chat_id": "chat-1751",
+            "message_id": "msg-in-1751",
+            "metadata": {},
+        }
+        (audit_dir / "remote_exchanges.jsonl").write_text(
+            _json.dumps(inbound_record) + "\n"
+        )
+
+        env = {
+            **__import__("os").environ,
+            "BID_EUCHRE_BUS_DIR": str(bus_dir),
+        }
+
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "python",
+                "scripts/internal/ops.py",
+                "--runtime-dir",
+                str(tmp_path),
+                "monitor",
+                "--skip-pr-check",
+                "--no-notify",
+                "--no-recovery",
+                "--no-auto-dispatch",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+        )
+        assert result.returncode in (
+            0,
+            1,
+        ), f"Monitor crashed: stderr={result.stderr[:500]}"
+
+        loaded = load_fleet_status(tmp_path)
+        assert (
+            loaded is not None
+        ), f"reconcile() did not write fleet_status.json; stdout={result.stdout[:300]}"
+
+        # Verify the urgent inbox message surfaced as an unacked_message item.
+        unacked_items = [i for i in loaded.items if i.category == "unacked_message"]
+        assert len(unacked_items) >= 1, (
+            f"Expected unacked_message item from urgent inbox msg but found "
+            f"{len(unacked_items)}; categories={[i.category for i in loaded.items]}"
+        )
+
+        # Verify the unanswered audit record surfaced as an audit_exchange item.
+        audit_items = [i for i in loaded.items if i.category == "audit_exchange"]
+        assert len(audit_items) >= 1, (
+            f"Expected audit_exchange item from unanswered inbound but found "
+            f"{len(audit_items)}; categories={[i.category for i in loaded.items]}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Proving run 3 — persistence, deduplication, and clear lifecycle (#1678)


### PR DESCRIPTION
## Plan
N/A — issue-driven bugfix (#1751)

## Summary
- Load orchestrator inbox messages (pending + delivered) during the monitor/reconcile cycle
- Load audit trail records during the monitor/reconcile cycle
- Pass both to `reconcile()` so they surface in `fleet_status.json`

## Why
The live reconcile path in `cmd_monitor` only passed `monitor_finding_objects` and `task_packets` to `reconcile()`. The controller already supports `unacked_messages` and `audit_records` but they were never loaded at runtime, leaving `fleet_status.json` blind to stale urgent inbox items and unanswered remote exchanges. This broke the `UserPromptSubmit` alert injection hook (#1719) which only sees a partial control plane.

## Repro / Validation
**Command(s) run:**
```bash
# Seed an urgent message + inbound audit record, run monitor, check fleet
uv run python -m pytest tests/unit/test_ops_control_plane.py -k "test_cli_monitor_wires_inbox_and_audit" -v
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** Fleet status contains both `unacked_message` and `audit_exchange` items after monitor cycle with seeded inputs
- **Verification command:** `uv run python -m pytest tests/unit/test_ops_control_plane.py -k "test_cli_monitor_wires_inbox_and_audit" -v`
- **Expected result:** 1 passed

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_control_plane.py tests/unit/test_ops_monitor.py -x` (233 passed)
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None
- Runtime impact: Two additional I/O reads per monitor cycle (inbox + audit trail), both <1ms

## Risk level
- [x] Low (ops tooling, graceful fallback on error)

## Worktree proof (required)
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         a3bc4dd6 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author          07aeee1b [ops/wire-inbox-audit-reconcile]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

Closes #1751