### PR TITLE
feat(ops): add PreToolUse guardrail that blocks risky actions when urgent state unresolved (#1753)

### DIFF
--- a/.claude/hooks/pre-bash-dispatch.sh
+++ b/.claude/hooks/pre-bash-dispatch.sh
@@ -4,9 +4,10 @@
 # Runs all PreToolUse hooks for Bash in a single invocation to minimize
 # "Async hook completed" TUI messages (issue #1255). Dispatches to:
 #   1. pre-worktree-cleanup.sh — blocks dangerous rm/worktree commands
-#   2. pre-merge-review-guard.sh — blocks merge without review verdict
-#   3. scope-drift-guard.sh — warns/blocks commit when staged files exceed task scope
-#   4. rule-loader.sh — progressive rule disclosure (context injection)
+#   2. urgent-state-guard.py — blocks merge/dispatch when fleet alerts unresolved
+#   3. pre-merge-review-guard.sh — blocks merge without review verdict
+#   4. scope-drift-guard.sh — warns/blocks commit when staged files exceed task scope
+#   5. rule-loader.sh — progressive rule disclosure (context injection)
 #
 # Guards run first: if either blocks (exit 2), we propagate immediately.
 # Rule-loader runs last since context injection is only useful if the
@@ -33,7 +34,18 @@ if [ -x "$HOOKS_DIR/pre-worktree-cleanup.sh" ]; then
     fi
 fi
 
-# --- 2. Merge review guard (may block with exit 2) ---
+# --- 2. Urgent state guard (may block with exit 2) ---
+if [ -x "$HOOKS_DIR/urgent-state-guard.py" ]; then
+    USG_OUTPUT=""
+    USG_EXIT=0
+    USG_OUTPUT=$(echo "$INPUT" | python3 "$HOOKS_DIR/urgent-state-guard.py" 2>/dev/null) || USG_EXIT=$?
+    if [ "$USG_EXIT" -ne 0 ]; then
+        echo "$USG_OUTPUT"
+        exit "$USG_EXIT"
+    fi
+fi
+
+# --- 3. Merge review guard (may block with exit 2) ---
 if [ -x "$HOOKS_DIR/pre-merge-review-guard.sh" ]; then
     MRG_OUTPUT=""
     MRG_EXIT=0
@@ -44,7 +56,7 @@ if [ -x "$HOOKS_DIR/pre-merge-review-guard.sh" ]; then
     fi
 fi
 
-# --- 3. Scope drift guard (may block with exit 2 or warn) ---
+# --- 4. Scope drift guard (may block with exit 2 or warn) ---
 if [ -x "$HOOKS_DIR/scope-drift-guard.sh" ]; then
     SDG_OUTPUT=""
     SDG_EXIT=0
@@ -63,7 +75,7 @@ if [ -x "$HOOKS_DIR/scope-drift-guard.sh" ]; then
     fi
 fi
 
-# --- 4. Rule loader (never blocks, may return additionalContext) ---
+# --- 5. Rule loader (never blocks, may return additionalContext) ---
 if [ -x "$HOOKS_DIR/rule-loader.sh" ]; then
     RULE_OUTPUT=""
     RULE_OUTPUT=$(echo "$INPUT" | "$HOOKS_DIR/rule-loader.sh" 2>/dev/null) || true

--- a/.claude/hooks/urgent-state-guard.py
+++ b/.claude/hooks/urgent-state-guard.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""PreToolUse guard: block risky actions when fleet has unresolved urgent state.
+
+Reads ``.claude/runtime/fleet_status.json`` and blocks merge/dispatch commands
+when open HIGH or URGENT items exist.  Integrates into the ``pre-bash-dispatch``
+pipeline as a sub-hook.
+
+Design constraints:
+- stdlib-only (no project imports) for speed — cold start ~100ms.
+- Reads command JSON from stdin (PreToolUse hook contract).
+- Exit 0 = allow, exit 2 = block (Claude Code PreToolUse convention).
+- Outputs blocking message on stdout when blocking.
+
+Closes #1753.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# Commands that are blocked when urgent state is unresolved.
+GUARDED_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"^\s*gh\s+pr\s+merge\b"),
+    re.compile(r"uv\s+run\s+python\s+scripts/internal/ops\.py\s+task\s+dispatch\b"),
+    re.compile(r"dispatch_to_worker"),
+]
+
+
+def read_fleet_status(path: Path) -> dict | None:
+    """Read and parse fleet_status.json.  Returns None on any failure."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+
+
+def extract_urgent_alerts(data: dict) -> list[dict]:
+    """Return open items with severity 'high' or 'urgent'."""
+    items = data.get("items", [])
+    return [
+        i
+        for i in items
+        if i.get("severity") in ("high", "urgent") and i.get("state") == "open"
+    ]
+
+
+def is_guarded_command(command: str) -> bool:
+    """Check if the command matches any guarded pattern."""
+    return any(pattern.search(command) for pattern in GUARDED_PATTERNS)
+
+
+def format_block_message(alerts: list[dict]) -> str:
+    """Format a blocking message for the user."""
+    lines = [
+        f"BLOCKED: {len(alerts)} unresolved fleet alert(s) — resolve before proceeding.",
+        "",
+        "Unresolved alerts:",
+    ]
+    for a in alerts:
+        sev = a.get("severity", "high").upper()
+        summary = a.get("summary", "(no summary)")
+        lines.append(f"  [{sev}] {summary}")
+        rec = a.get("recommended_action")
+        if rec:
+            lines.append(f"    -> {rec}")
+    lines.extend(
+        [
+            "",
+            "Resolve or ack alerts before running risky commands:",
+            "  uv run python scripts/internal/ops.py fleet ack <item_id>",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main(stdin_text: str | None = None, project_dir: str | None = None) -> int:
+    """Entry point.  Returns 0 to allow, 2 to block.
+
+    Parameters are injectable for testing; production callers leave them None.
+    """
+    raw = stdin_text if stdin_text is not None else sys.stdin.read()
+
+    # Parse hook input from stdin
+    try:
+        hook_input = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return 0  # Can't parse input — allow by default
+
+    command = ""
+    tool_input = hook_input.get("tool_input", {})
+    if isinstance(tool_input, dict):
+        command = tool_input.get("command", "")
+
+    if not command or not is_guarded_command(command):
+        return 0
+
+    if project_dir is None:
+        project_dir = os.environ.get("CLAUDE_PROJECT_DIR", ".")
+
+    status_path = Path(project_dir) / ".claude" / "runtime" / "fleet_status.json"
+
+    if not status_path.exists():
+        return 0
+
+    data = read_fleet_status(status_path)
+    if data is None:
+        return 0
+
+    alerts = extract_urgent_alerts(data)
+    if not alerts:
+        return 0
+
+    # Block the action
+    print(format_block_message(alerts))
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_urgent_state_guard.py
+++ b/tests/unit/test_urgent_state_guard.py
@@ -1,0 +1,381 @@
+"""Unit tests for the urgent-state-guard PreToolUse hook.
+
+Tests the Python script directly for speed and isolation.
+The hook reads .claude/runtime/fleet_status.json and blocks risky commands
+(merge, dispatch) when unresolved HIGH/URGENT alerts exist.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_PY = REPO_ROOT / ".claude" / "hooks" / "urgent-state-guard.py"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_hook(
+    project_dir: Path,
+    command: str,
+    *,
+    tool_name: str = "Bash",
+) -> subprocess.CompletedProcess[str]:
+    """Run the Python hook with simulated PreToolUse JSON on stdin."""
+    hook_input = json.dumps(
+        {"tool_name": tool_name, "tool_input": {"command": command}}
+    )
+    return subprocess.run(
+        [sys.executable, str(HOOK_PY)],
+        input=hook_input,
+        env={"CLAUDE_PROJECT_DIR": str(project_dir), "PATH": ""},
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+
+def _write_fleet_status(project_dir: Path, data: dict) -> Path:
+    """Write a fleet_status.json into the project dir structure."""
+    runtime_dir = project_dir / ".claude" / "runtime"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    path = runtime_dir / "fleet_status.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def _make_item(
+    *,
+    severity: str = "high",
+    state: str = "open",
+    summary: str = "Test alert",
+    recommended_action: str | None = "Fix it",
+    item_id: str = "abc123",
+    category: str = "lane_health",
+) -> dict:
+    """Create a minimal fleet status item dict."""
+    item = {
+        "item_id": item_id,
+        "severity": severity,
+        "state": state,
+        "summary": summary,
+        "category": category,
+        "source": "monitor",
+        "first_seen_at": "2026-03-24T22:00:00+00:00",
+        "last_seen_at": "2026-03-24T22:00:00+00:00",
+    }
+    if recommended_action is not None:
+        item["recommended_action"] = recommended_action
+    return item
+
+
+def _fleet_status(items: list[dict]) -> dict:
+    """Wrap items in a fleet status envelope."""
+    return {
+        "items": items,
+        "generated_at": "2026-03-24T22:00:00+00:00",
+        "cycle_count": 1,
+        "summary": {
+            "total": len(items),
+            "open": len([i for i in items if i.get("state") == "open"]),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: allow cases (exit 0)
+# ---------------------------------------------------------------------------
+
+
+class TestAllowCases:
+    """Cases where the hook should allow the command (exit 0, no output)."""
+
+    def test_no_fleet_status_file(self, tmp_path: Path) -> None:
+        """Hook allows when fleet_status.json does not exist."""
+        result = _run_hook(tmp_path, "gh pr merge 123 --squash")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_empty_items_list(self, tmp_path: Path) -> None:
+        """Hook allows when items list is empty."""
+        _write_fleet_status(tmp_path, _fleet_status([]))
+        result = _run_hook(tmp_path, "gh pr merge 123 --squash")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_only_info_items(self, tmp_path: Path) -> None:
+        """Hook allows when only info-severity items exist."""
+        items = [_make_item(severity="info", summary="All good")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path, "gh pr merge 123 --squash")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_only_warn_items(self, tmp_path: Path) -> None:
+        """Hook allows when only warn-severity items exist."""
+        items = [_make_item(severity="warn", summary="Minor issue")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path, "gh pr merge 123 --squash")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_high_but_cleared(self, tmp_path: Path) -> None:
+        """Hook allows when high items are cleared."""
+        items = [_make_item(severity="high", state="cleared")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path, "gh pr merge 123 --squash")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_high_but_acked(self, tmp_path: Path) -> None:
+        """Hook allows when high items are acked."""
+        items = [_make_item(severity="high", state="acked")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path, "gh pr merge 123 --squash")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_high_but_suppressed(self, tmp_path: Path) -> None:
+        """Hook allows when high items are suppressed."""
+        items = [_make_item(severity="high", state="suppressed")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path, "gh pr merge 123 --squash")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_non_guarded_command(self, tmp_path: Path) -> None:
+        """Hook allows non-guarded commands even with active alerts."""
+        items = [_make_item(severity="urgent", summary="Critical!")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path, "git status")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_non_guarded_git_push(self, tmp_path: Path) -> None:
+        """Hook allows git push even with active alerts."""
+        items = [_make_item(severity="high", summary="Something bad")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path, "git push -u origin feature-branch")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_corrupt_json(self, tmp_path: Path) -> None:
+        """Hook allows on corrupt JSON (fail-open)."""
+        runtime_dir = tmp_path / ".claude" / "runtime"
+        runtime_dir.mkdir(parents=True)
+        (runtime_dir / "fleet_status.json").write_text("not json{{{")
+        result = _run_hook(tmp_path, "gh pr merge 123 --squash")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_empty_command(self, tmp_path: Path) -> None:
+        """Hook allows when command is empty."""
+        items = [_make_item(severity="high", summary="Alert")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path, "")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_merge_substring_in_non_merge_command(self, tmp_path: Path) -> None:
+        """Hook allows commands that mention merge but aren't gh pr merge."""
+        items = [_make_item(severity="high", summary="Alert")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path, "git merge main")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# Tests: block cases (exit 2)
+# ---------------------------------------------------------------------------
+
+
+class TestBlockCases:
+    """Cases where the hook should block the command (exit 2)."""
+
+    def test_blocks_merge_with_high_alert(self, tmp_path: Path) -> None:
+        """Hook blocks gh pr merge when open high alert exists."""
+        items = [_make_item(severity="high", summary="Lane author-a dead")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path, "gh pr merge 123 --squash")
+        assert result.returncode == 2
+        assert "BLOCKED" in result.stdout
+        assert "Lane author-a dead" in result.stdout
+
+    def test_blocks_merge_with_urgent_alert(self, tmp_path: Path) -> None:
+        """Hook blocks gh pr merge when open urgent alert exists."""
+        items = [_make_item(severity="urgent", summary="CI broken on main")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path, "gh pr merge 123 --squash")
+        assert result.returncode == 2
+        assert "BLOCKED" in result.stdout
+        assert "[URGENT] CI broken on main" in result.stdout
+
+    def test_blocks_dispatch_command(self, tmp_path: Path) -> None:
+        """Hook blocks task dispatch when open high alert exists."""
+        items = [_make_item(severity="high", summary="Stalled lane")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(
+            tmp_path,
+            "uv run python scripts/internal/ops.py task dispatch 6f2985cfd01b --lane author-a",
+        )
+        assert result.returncode == 2
+        assert "BLOCKED" in result.stdout
+
+    def test_blocks_dispatch_to_worker(self, tmp_path: Path) -> None:
+        """Hook blocks dispatch_to_worker calls."""
+        items = [_make_item(severity="high", summary="Stalled lane")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(
+            tmp_path,
+            "uv run python -c 'from bid_euchre.ops.worker_pool import dispatch_to_worker; dispatch_to_worker(...)'",
+        )
+        assert result.returncode == 2
+        assert "BLOCKED" in result.stdout
+
+    def test_blocks_merge_url_form(self, tmp_path: Path) -> None:
+        """Hook blocks gh pr merge with URL argument."""
+        items = [_make_item(severity="high", summary="Alert")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(
+            tmp_path,
+            "gh pr merge https://github.com/Questuart/Bid-Euchre/pull/123 --squash",
+        )
+        assert result.returncode == 2
+        assert "BLOCKED" in result.stdout
+
+    def test_blocks_merge_no_args(self, tmp_path: Path) -> None:
+        """Hook blocks bare gh pr merge (current branch)."""
+        items = [_make_item(severity="high", summary="Alert")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path, "gh pr merge --squash")
+        assert result.returncode == 2
+        assert "BLOCKED" in result.stdout
+
+    def test_block_message_includes_all_alerts(self, tmp_path: Path) -> None:
+        """Block message shows all unresolved alerts."""
+        items = [
+            _make_item(
+                severity="high",
+                summary="PR conflict",
+                item_id="id1",
+            ),
+            _make_item(
+                severity="urgent",
+                summary="Main broken",
+                item_id="id2",
+                recommended_action="Fix CI first",
+            ),
+            _make_item(severity="info", summary="Capacity OK", item_id="id3"),
+        ]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path, "gh pr merge 123 --squash")
+        assert result.returncode == 2
+        assert "2 unresolved fleet alert(s)" in result.stdout
+        assert "[HIGH] PR conflict" in result.stdout
+        assert "[URGENT] Main broken" in result.stdout
+        assert "Fix CI first" in result.stdout
+        assert "Capacity OK" not in result.stdout  # info excluded
+
+    def test_block_message_includes_remediation(self, tmp_path: Path) -> None:
+        """Block message shows how to resolve."""
+        items = [_make_item(severity="high", summary="Alert")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path, "gh pr merge 123 --squash")
+        assert result.returncode == 2
+        assert "fleet ack" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Tests: resolve-then-retry lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRetryLifecycle:
+    """Verify the block → resolve → allow lifecycle."""
+
+    def test_resolve_by_clearing(self, tmp_path: Path) -> None:
+        """After clearing alerts, the hook allows."""
+        # Step 1: Seed urgent alert — should block
+        items = [_make_item(severity="urgent", summary="CI broken")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path, "gh pr merge 123 --squash")
+        assert result.returncode == 2
+
+        # Step 2: Clear the alert — should allow
+        items[0]["state"] = "cleared"
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path, "gh pr merge 123 --squash")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_resolve_by_acking(self, tmp_path: Path) -> None:
+        """After acking alerts, the hook allows."""
+        items = [_make_item(severity="high", summary="Lane stalled")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path, "gh pr merge 123 --squash")
+        assert result.returncode == 2
+
+        # Ack the alert
+        items[0]["state"] = "acked"
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path, "gh pr merge 123 --squash")
+        assert result.returncode == 0
+
+    def test_resolve_by_removing(self, tmp_path: Path) -> None:
+        """After removing the fleet_status.json, the hook allows."""
+        items = [_make_item(severity="high", summary="Alert")]
+        status_path = _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path, "gh pr merge 123 --squash")
+        assert result.returncode == 2
+
+        # Remove the file
+        status_path.unlink()
+        result = _run_hook(tmp_path, "gh pr merge 123 --squash")
+        assert result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: hook infrastructure
+# ---------------------------------------------------------------------------
+
+
+class TestHookInfrastructure:
+    """Verify hook file exists and is properly configured."""
+
+    def test_python_script_exists(self) -> None:
+        assert HOOK_PY.exists(), f"Missing {HOOK_PY}"
+
+    def test_python_script_executable(self) -> None:
+        mode = os.stat(HOOK_PY).st_mode
+        assert mode & stat.S_IXUSR, f"{HOOK_PY} is not executable"
+
+    def test_registered_in_dispatcher(self) -> None:
+        """Verify the guard is called from pre-bash-dispatch.sh."""
+        dispatcher = REPO_ROOT / ".claude" / "hooks" / "pre-bash-dispatch.sh"
+        content = dispatcher.read_text()
+        assert "urgent-state-guard.py" in content
+
+    def test_hook_speed(self, tmp_path: Path) -> None:
+        """Hook completes in under 2 seconds even with many alerts."""
+        items = [
+            _make_item(severity="high", summary=f"Alert {i}", item_id=f"id{i}")
+            for i in range(20)
+        ]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+
+        start = time.monotonic()
+        result = _run_hook(tmp_path, "gh pr merge 123 --squash")
+        elapsed = time.monotonic() - start
+
+        assert result.returncode == 2
+        assert elapsed < 2.0, f"Hook took {elapsed:.2f}s (must be < 2s)"


### PR DESCRIPTION
## Summary

- Add `urgent-state-guard.py` PreToolUse hook that reads `fleet_status.json` and blocks `gh pr merge` / task dispatch commands when open HIGH or URGENT alerts exist
- Integrate the guard into `pre-bash-dispatch.sh` as step 2 (between worktree cleanup and merge review guards)
- 27 unit tests covering allow, block, resolve-then-retry lifecycle, and infrastructure checks

## Why

Closes #1753. The session shipped alert *visibility* (UserPromptSubmit injects unresolved alerts as context) but not pre-tool *guardrails*. An operator could merge or dispatch while critical alerts were unacknowledged. This adds the "dispatch safety" half of SP-4-07's hook surfacing.

## Guarded Commands

| Pattern | Example |
|---------|---------|
| `gh pr merge` | `gh pr merge 123 --squash` |
| `task dispatch` | `uv run python scripts/internal/ops.py task dispatch ...` |
| `dispatch_to_worker` | Python inline calls |

## Pass/Fail Criteria

1. ✅ Seed `fleet_status.json` with open urgent item → `gh pr merge` blocked (exit 2)
2. ✅ Resolve alert (clear/ack) → retry succeeds (exit 0)
3. ✅ Non-guarded commands pass even with active alerts
4. ✅ Corrupt/missing fleet_status.json → fail-open (exit 0)
5. ✅ `make check` passes

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_urgent_state_guard.py -x -v  # 27 passed
make check-quiet                                                       # all checks passed
```

## Worktree Proof

```
pwd: Bid-Euchre-steward-author-c
branch: ops/urgent-state-guard
```

## Files Changed

- `.claude/hooks/urgent-state-guard.py` (new) — stdlib-only guard logic
- `.claude/hooks/pre-bash-dispatch.sh` (modified) — integrated guard as step 2
- `tests/unit/test_urgent_state_guard.py` (new) — 27 unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)