### PR TITLE
fix(docker): set UV_CACHE_DIR for non-root app user in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,10 @@ RUN uv sync --frozen --no-dev --extra hosted
 RUN addgroup --system app && adduser --system --ingroup app app \
     && chown -R app:app /app
 
+# uv cache must be writable by the non-root user; the default
+# ~/.cache/uv resolves to /nonexistent/.cache/uv which doesn't exist.
+ENV UV_CACHE_DIR=/tmp/uv-cache
+
 USER app
 
 EXPOSE 8000


### PR DESCRIPTION
## Summary

- Add `ENV UV_CACHE_DIR=/tmp/uv-cache` before the `USER app` directive in the Dockerfile
- Fixes the "Permission denied" error when `uv run` tries to create a cache at `/nonexistent/.cache/uv`

## Why

The Dockerfile creates a non-root `app` user whose home is `/nonexistent`. When `uv run` executes at container startup, it fails because the default cache path (`~/.cache/uv`) is unwritable. Setting `UV_CACHE_DIR` to a writable location fixes this.

Closes #1765

## Repro / Validation

```bash
# Build and verify uv runs without error as non-root user
docker build -t bideuchre-web .
docker run --rm -e DATABASE_URL=sqlite:///test.db bideuchre-web uv run python -c 'print("ok")'
# Should print "ok" without any cache errors
```

## Tests

```bash
make check-quiet  # ✓ All checks passed
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: fix/dockerfile-uv-cache
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)