### PR TITLE
docs(ops): add fleet rebase protocol to start-task and check-in skills

### DIFF
--- a/.claude/skills/check-in/SKILL.md
+++ b/.claude/skills/check-in/SKILL.md
@@ -97,6 +97,49 @@ monitoring infrastructure.
    uv run python scripts/internal/ops.py task list
    ```
 
+### Phase 2b — Branch Divergence Detection
+
+> **Why:** Parallel author lanes branching off the same `origin/main` snapshot
+> diverge as other PRs merge. Catching divergence early (before PR creation)
+> avoids costly merge conflicts and wasted review cycles.
+
+9. **For each active author lane with a dispatched task**, check how far its
+   branch has diverged from `origin/main`:
+   ```bash
+   # From each lane's worktree, or using git directly:
+   git fetch origin main
+   git rev-list --count origin/main..<branch-name>   # commits ahead
+   git rev-list --count <branch-name>..origin/main   # commits behind
+   ```
+
+10. **Flag divergence warnings** using these thresholds:
+
+    | Commits Behind `origin/main` | Severity | Action |
+    |------------------------------|----------|--------|
+    | 0 | OK | No action needed |
+    | 1–5 | INFO | Note in check-in summary |
+    | 6–15 | WARN | Recommend lane rebase before PR |
+    | 16+ | HIGH | Send rebase nudge to the lane |
+
+    When severity is WARN or HIGH, include it in the check-in summary:
+    ```
+    DIVERGENCE:
+      author-a: 3 behind (OK)
+      author-b: 12 behind (WARN — recommend rebase)
+      author-d: 22 behind (HIGH — rebase nudge sent)
+    ```
+
+11. **Send rebase nudge** to lanes at HIGH divergence:
+    ```bash
+    uv run python scripts/internal/ops.py message send \
+      --from orchestrator --to <lane> --type supervisor_alert \
+      --summary "Branch diverged 16+ commits from main — rebase before continuing"
+    ```
+
+12. **Check for merge conflict potential** — if two active lanes are touching
+    overlapping files (visible from their task packet `scope_declared`), flag
+    this as a potential conflict even at low divergence counts.
+
 ### Phase 3 — PR and CI Health
 
 9. **List open PRs:**
@@ -128,12 +171,13 @@ monitoring infrastructure.
     ```
     CHECK-IN @ <timestamp>
     ────────────────────────
-    INBOX:  <N> pending (<M> HIGH-priority)
-    LANES:  <N> active, <M> idle, <K> stalled
-    PRs:    <N> open, <M> merged since last check
-    ISSUES: <N> open (<M> new since last check)
-    ALERTS: <list any unresolved HIGH alerts>
-    NEXT:   <recommended action>
+    INBOX:      <N> pending (<M> HIGH-priority)
+    LANES:      <N> active, <M> idle, <K> stalled
+    DIVERGENCE: <N> OK, <M> WARN, <K> HIGH (list HIGH lanes)
+    PRs:        <N> open, <M> merged since last check
+    ISSUES:     <N> open (<M> new since last check)
+    ALERTS:     <list any unresolved HIGH alerts>
+    NEXT:       <recommended action>
     ```
 
 ## Integration with /run-fleet

--- a/.claude/skills/start-task/SKILL.md
+++ b/.claude/skills/start-task/SKILL.md
@@ -72,6 +72,45 @@ decomposition (use `/executing-plans` for that).
    cat plans/agent_ops/<phase>/sub/<sub-plan>.md
    ```
 
+### Phase 2b — Pre-Implementation Rebase (Mandatory)
+
+> **Why:** Parallel author lanes frequently branch off the same `origin/main`
+> snapshot. If another lane's PR merges while you are working, your branch
+> diverges and the eventual PR hits merge conflicts. A mandatory rebase step
+> immediately before implementation catches these divergences early.
+
+7. **Rebase onto latest main before writing any code:**
+   ```bash
+   git fetch origin main
+   git rebase origin/main
+   ```
+   This is a no-op if you just created the branch (step 5 already used
+   `origin/main`), but it is **essential** when resuming work on an existing
+   branch or when time has passed since branch creation.
+
+8. **If the rebase produces conflicts:**
+   - Resolve them if they are trivial (e.g., import ordering, adjacent lines).
+   - If conflicts are non-trivial (overlapping logic changes), abort the
+     rebase and report a blocker to the orchestrator:
+     ```bash
+     git rebase --abort
+     uv run python scripts/internal/ops.py message send \
+       --from <lane> --to orchestrator --type blocker \
+       --summary "Rebase conflict on <branch>: <description>" \
+       --task-id <PACKET_ID>
+     ```
+   - Do **not** proceed with a diverged branch — the PR will fail to merge
+     cleanly and waste review cycles.
+
+9. **Pre-PR rebase reminder:** You must also rebase again just before running
+   `gh pr create`. This catches any merges that happened during your
+   implementation window:
+   ```bash
+   git fetch origin main && git rebase origin/main
+   make check-quiet   # Re-validate after rebase
+   gh pr create ...
+   ```
+
 ### Phase 3 — Scope Lock
 
 7. **Confirm file scope** matches the task packet's `scope_declared`:


### PR DESCRIPTION
## Summary

- Add mandatory **Phase 2b — Pre-Implementation Rebase** to `/start-task` skill with `git fetch origin main && git rebase origin/main` before any code changes
- Add **Phase 2b — Branch Divergence Detection** to `/check-in` skill with tiered thresholds (OK/INFO/WARN/HIGH) and automatic rebase nudge for lanes 16+ commits behind
- Update check-in summary template to include `DIVERGENCE` line

## Why

Parallel author lanes frequently hit merge conflicts because they branch off the same `origin/main` snapshot and diverge as other PRs merge. This was a recurring problem in the 40-PR session (#1556, #1560, #1561 all stalled on conflicts simultaneously) and again with PR #1755.

Closes #1756

## Repro / Validation

```bash
# Docs-only change — verify skill files parse correctly
cat .claude/skills/start-task/SKILL.md
cat .claude/skills/check-in/SKILL.md
make check-quiet  # 1 pre-existing flaky test on main (test_pty_runner); all other 7129 tests pass
```

## Tests

- `make check-quiet` — 7129 passed, 50 skipped, 1 pre-existing failure (`test_pty_runner.py::TestPTYTimeout::test_fast_command_no_timeout` — reproduces on clean main)
- Docs-only changes; no Python code modified

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: ops/fleet-rebase-protocol
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)