### PR TITLE
feat(ops): add remote ack parser for Platform-9a

### DIFF
--- a/src/bid_euchre/ops/remote_ack.py
+++ b/src/bid_euchre/ops/remote_ack.py
@@ -1,0 +1,256 @@
+"""Remote ack parser and controller mutation (Platform-9a, PR 2).
+
+Parses ack/dismiss/mute/clear commands from inbound Telegram messages
+and applies them to the controller projection via the existing
+``control_plane.py`` mutation API.
+
+This module is **pure logic** -- it contains no Telegram-specific code,
+no I/O with Telegram, and no MCP tool calls.  It operates on text input
+and :class:`FleetStatus` objects, returning structured results.
+
+Usage::
+
+    from bid_euchre.ops.remote_ack import (
+        parse_ack_command,
+        execute_remote_ack,
+        format_ack_confirmation,
+    )
+
+    cmd = parse_ack_command("ack abc1")
+    if cmd is not None:
+        result = execute_remote_ack(cmd, fleet_status)
+        reply_text = format_ack_confirmation(result)
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+from bid_euchre.ops.control_plane import (
+    FleetStatus,
+    ack_item,
+    clear_item,
+    suppress_item,
+)
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+class AckAction(Enum):
+    """Recognized remote-ack actions."""
+
+    ACK = "ack"
+    DISMISS = "dismiss"
+    MUTE = "mute"
+    CLEAR = "clear"
+
+
+@dataclass(frozen=True)
+class AckCommand:
+    """A parsed ack command from inbound text.
+
+    Attributes:
+        action: The ack action (ack/dismiss/mute/clear).
+        prefix: The item_id prefix provided by the operator.
+    """
+
+    action: AckAction
+    prefix: str
+
+
+@dataclass(frozen=True)
+class AckResult:
+    """Result of executing a remote ack command.
+
+    Attributes:
+        success: Whether the mutation succeeded.
+        action: The action that was attempted.
+        item_id: The full item_id that was matched (or None on failure).
+        summary: The matched item's summary (or None on failure).
+        message: Human-readable result message.
+        candidates: On ambiguous prefix, the list of matching item_ids.
+    """
+
+    success: bool
+    action: AckAction
+    item_id: str | None = None
+    summary: str | None = None
+    message: str = ""
+    candidates: list[str] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Command patterns
+# ---------------------------------------------------------------------------
+
+# Matches: "ack <prefix>", "dismiss <prefix>", "mute <prefix>", "clear <prefix>"
+# Case-insensitive, whitespace-tolerant.
+_COMMAND_RE = re.compile(
+    r"^\s*(ack|dismiss|mute|clear)\s+([a-f0-9]+)\s*$",
+    re.IGNORECASE,
+)
+
+_ACTION_MAP: dict[str, AckAction] = {
+    "ack": AckAction.ACK,
+    "dismiss": AckAction.DISMISS,
+    "mute": AckAction.MUTE,
+    "clear": AckAction.CLEAR,
+}
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_ack_command(text: str) -> AckCommand | None:
+    """Parse a remote ack command from inbound message text.
+
+    Recognized patterns (case-insensitive, whitespace-tolerant)::
+
+        ack <hex-prefix>
+        dismiss <hex-prefix>
+        mute <hex-prefix>
+        clear <hex-prefix>
+
+    Returns ``None`` for non-command messages (free-form conversation),
+    allowing the caller to pass them through to normal handling.
+    """
+    match = _COMMAND_RE.match(text)
+    if match is None:
+        return None
+
+    action_str = match.group(1).lower()
+    prefix = match.group(2).lower()
+
+    return AckCommand(
+        action=_ACTION_MAP[action_str],
+        prefix=prefix,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Execution
+# ---------------------------------------------------------------------------
+
+
+def _find_items_by_prefix(status: FleetStatus, prefix: str) -> list[tuple[str, str]]:
+    """Find items whose item_id starts with the given prefix.
+
+    Returns a list of (item_id, summary) tuples.
+    """
+    return [
+        (item.item_id, item.summary)
+        for item in status.items
+        if item.item_id.startswith(prefix)
+    ]
+
+
+def execute_remote_ack(command: AckCommand, status: FleetStatus) -> AckResult:
+    """Execute a remote ack command against the fleet status projection.
+
+    Maps command actions to controller mutations:
+    - ``ack`` -> ``ack_item()``
+    - ``dismiss`` / ``mute`` -> ``suppress_item()``
+    - ``clear`` -> ``clear_item()``
+
+    Includes prefix-match ambiguity detection (same pattern as CLI).
+    Does NOT call ``save_fleet_status()`` -- the caller is responsible
+    for persistence after a successful mutation.
+
+    Args:
+        command: The parsed ack command.
+        status: The current fleet status (mutated in place on success).
+
+    Returns:
+        An ``AckResult`` with success status and human-readable message.
+    """
+    matches = _find_items_by_prefix(status, command.prefix)
+
+    if not matches:
+        return AckResult(
+            success=False,
+            action=command.action,
+            message=f"No item matching prefix '{command.prefix}'",
+        )
+
+    if len(matches) > 1:
+        return AckResult(
+            success=False,
+            action=command.action,
+            message=(
+                f"Ambiguous prefix '{command.prefix}' -- "
+                f"matches {len(matches)} items. "
+                f"Use a longer prefix."
+            ),
+            candidates=[item_id for item_id, _ in matches],
+        )
+
+    item_id, item_summary = matches[0]
+
+    # Map action to mutation function.
+    mutation_fn = {
+        AckAction.ACK: ack_item,
+        AckAction.DISMISS: suppress_item,
+        AckAction.MUTE: suppress_item,
+        AckAction.CLEAR: clear_item,
+    }[command.action]
+
+    ok = mutation_fn(status, item_id)
+
+    if not ok:
+        # Item exists but is not in a mutable state (e.g., already acked).
+        return AckResult(
+            success=False,
+            action=command.action,
+            item_id=item_id,
+            summary=item_summary,
+            message=(
+                f"Item {item_id[:8]} exists but cannot be "
+                f"{command.action.value}d (may already be "
+                f"acked/cleared/suppressed)"
+            ),
+        )
+
+    action_past = {
+        AckAction.ACK: "Acknowledged",
+        AckAction.DISMISS: "Suppressed",
+        AckAction.MUTE: "Suppressed",
+        AckAction.CLEAR: "Cleared",
+    }[command.action]
+
+    return AckResult(
+        success=True,
+        action=command.action,
+        item_id=item_id,
+        summary=item_summary,
+        message=f"{action_past} item {item_id[:8]} -- {item_summary}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Confirmation formatting
+# ---------------------------------------------------------------------------
+
+
+def format_ack_confirmation(result: AckResult) -> str:
+    """Format an ack result as a Telegram-friendly confirmation message.
+
+    Returns a human-readable string suitable for replying to the operator.
+    """
+    if result.success:
+        return f"\u2705 {result.message}"
+
+    if result.candidates:
+        lines = [f"\u274c {result.message}"]
+        lines.append("")
+        lines.append("Candidates:")
+        for cid in result.candidates:
+            lines.append(f"  {cid[:8]}")
+        return "\n".join(lines)
+
+    return f"\u274c {result.message}"

--- a/tests/unit/test_ops_remote_ack.py
+++ b/tests/unit/test_ops_remote_ack.py
@@ -1,0 +1,444 @@
+"""Tests for remote ack parser and controller mutation (Platform-9a, PR 2).
+
+Covers:
+- Parse valid commands with various prefix lengths
+- Parse case-insensitive variants
+- Reject non-command messages (return None)
+- Execute ack on matching item -> state changes to 'acked'
+- Execute suppress (dismiss/mute) on matching item -> state changes to 'suppressed'
+- Execute clear on matching item -> state changes to 'cleared'
+- Ambiguous prefix -> error result with candidate list
+- No matching item -> error result
+- Item already acked -> error result (idempotency note)
+- Confirmation formatting for success, error, and ambiguous results
+"""
+
+from __future__ import annotations
+
+from bid_euchre.ops.control_plane import (
+    STATE_ACKED,
+    STATE_CLEARED,
+    STATE_OPEN,
+    STATE_SUPPRESSED,
+    ActionableItem,
+    FleetStatus,
+)
+from bid_euchre.ops.remote_ack import (
+    AckAction,
+    AckCommand,
+    AckResult,
+    execute_remote_ack,
+    format_ack_confirmation,
+    parse_ack_command,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_item(
+    item_id: str = "abc123def456",
+    severity: str = "high",
+    state: str = STATE_OPEN,
+    summary: str = "Test alert on author-b",
+) -> ActionableItem:
+    return ActionableItem(
+        item_id=item_id,
+        severity=severity,
+        category="lane_health",
+        source="monitor",
+        summary=summary,
+        first_seen_at="2026-03-25T00:00:00Z",
+        last_seen_at="2026-03-25T00:00:00Z",
+        state=state,
+    )
+
+
+def _make_status(*items: ActionableItem) -> FleetStatus:
+    return FleetStatus(
+        items=list(items),
+        generated_at="2026-03-25T00:00:00Z",
+        cycle_count=1,
+    )
+
+
+# ===================================================================
+# Parsing tests
+# ===================================================================
+
+
+class TestParseAckCommand:
+    """Tests for parse_ack_command()."""
+
+    def test_parse_ack(self) -> None:
+        cmd = parse_ack_command("ack abc123")
+        assert cmd is not None
+        assert cmd.action == AckAction.ACK
+        assert cmd.prefix == "abc123"
+
+    def test_parse_dismiss(self) -> None:
+        cmd = parse_ack_command("dismiss abc123")
+        assert cmd is not None
+        assert cmd.action == AckAction.DISMISS
+        assert cmd.prefix == "abc123"
+
+    def test_parse_mute(self) -> None:
+        cmd = parse_ack_command("mute abc123")
+        assert cmd is not None
+        assert cmd.action == AckAction.MUTE
+        assert cmd.prefix == "abc123"
+
+    def test_parse_clear(self) -> None:
+        cmd = parse_ack_command("clear abc123")
+        assert cmd is not None
+        assert cmd.action == AckAction.CLEAR
+        assert cmd.prefix == "abc123"
+
+    def test_parse_short_prefix(self) -> None:
+        """Short prefix (4 chars) is valid."""
+        cmd = parse_ack_command("ack abc1")
+        assert cmd is not None
+        assert cmd.prefix == "abc1"
+
+    def test_parse_full_12_char_id(self) -> None:
+        """Full 12-char item_id is valid."""
+        cmd = parse_ack_command("ack abc123def456")
+        assert cmd is not None
+        assert cmd.prefix == "abc123def456"
+
+    def test_parse_case_insensitive_action(self) -> None:
+        """Action keyword is case-insensitive."""
+        for text in ["ACK abc1", "Ack abc1", "aCk abc1"]:
+            cmd = parse_ack_command(text)
+            assert cmd is not None, f"Failed to parse: {text!r}"
+            assert cmd.action == AckAction.ACK
+
+    def test_parse_case_insensitive_prefix(self) -> None:
+        """Hex prefix is normalized to lowercase."""
+        cmd = parse_ack_command("ack ABC123DEF")
+        assert cmd is not None
+        assert cmd.prefix == "abc123def"
+
+    def test_parse_leading_whitespace(self) -> None:
+        cmd = parse_ack_command("  ack abc1")
+        assert cmd is not None
+        assert cmd.action == AckAction.ACK
+
+    def test_parse_trailing_whitespace(self) -> None:
+        cmd = parse_ack_command("ack abc1   ")
+        assert cmd is not None
+        assert cmd.prefix == "abc1"
+
+    def test_parse_extra_inner_whitespace(self) -> None:
+        """Multiple spaces between action and prefix."""
+        cmd = parse_ack_command("ack   abc1")
+        assert cmd is not None
+        assert cmd.prefix == "abc1"
+
+    def test_reject_non_command_messages(self) -> None:
+        """Non-command messages return None (passthrough)."""
+        non_commands = [
+            "hello",
+            "how's the fleet doing?",
+            "acknowledged",
+            "ack",  # no prefix
+            "ack ",  # no prefix (trailing space)
+            "ack abc xyz",  # extra words
+            "please ack abc1",  # prefix before action
+            "123 ack",  # reversed order
+            "",
+            " ",
+        ]
+        for text in non_commands:
+            result = parse_ack_command(text)
+            assert result is None, f"Should have rejected: {text!r}"
+
+    def test_reject_non_hex_prefix(self) -> None:
+        """Prefix must be hex characters only."""
+        non_hex = [
+            "ack xyz123",  # non-hex letters
+            "ack hello",
+            "ack 12-34",  # dash
+            "ack 12_34",  # underscore
+        ]
+        for text in non_hex:
+            result = parse_ack_command(text)
+            assert result is None, f"Should have rejected non-hex: {text!r}"
+
+
+# ===================================================================
+# Execution tests
+# ===================================================================
+
+
+class TestExecuteRemoteAck:
+    """Tests for execute_remote_ack()."""
+
+    def test_ack_matching_item(self) -> None:
+        """Ack with matching prefix changes state to acked."""
+        item = _make_item(item_id="abc123def456")
+        status = _make_status(item)
+        cmd = AckCommand(action=AckAction.ACK, prefix="abc1")
+
+        result = execute_remote_ack(cmd, status)
+
+        assert result.success is True
+        assert result.action == AckAction.ACK
+        assert result.item_id == "abc123def456"
+        assert result.summary == "Test alert on author-b"
+        assert item.state == STATE_ACKED
+
+    def test_dismiss_matching_item(self) -> None:
+        """Dismiss changes state to suppressed."""
+        item = _make_item(item_id="abc123def456")
+        status = _make_status(item)
+        cmd = AckCommand(action=AckAction.DISMISS, prefix="abc1")
+
+        result = execute_remote_ack(cmd, status)
+
+        assert result.success is True
+        assert result.action == AckAction.DISMISS
+        assert item.state == STATE_SUPPRESSED
+
+    def test_mute_matching_item(self) -> None:
+        """Mute changes state to suppressed (same as dismiss)."""
+        item = _make_item(item_id="abc123def456")
+        status = _make_status(item)
+        cmd = AckCommand(action=AckAction.MUTE, prefix="abc1")
+
+        result = execute_remote_ack(cmd, status)
+
+        assert result.success is True
+        assert result.action == AckAction.MUTE
+        assert item.state == STATE_SUPPRESSED
+
+    def test_clear_matching_item(self) -> None:
+        """Clear changes state to cleared."""
+        item = _make_item(item_id="abc123def456")
+        status = _make_status(item)
+        cmd = AckCommand(action=AckAction.CLEAR, prefix="abc1")
+
+        result = execute_remote_ack(cmd, status)
+
+        assert result.success is True
+        assert result.action == AckAction.CLEAR
+        assert item.state == STATE_CLEARED
+
+    def test_no_matching_item(self) -> None:
+        """No item matching prefix -> error result."""
+        item = _make_item(item_id="abc123def456")
+        status = _make_status(item)
+        cmd = AckCommand(action=AckAction.ACK, prefix="fff")
+
+        result = execute_remote_ack(cmd, status)
+
+        assert result.success is False
+        assert "No item matching prefix" in result.message
+        assert result.item_id is None
+        assert result.candidates is None
+
+    def test_ambiguous_prefix(self) -> None:
+        """Ambiguous prefix -> error result with candidate list."""
+        item1 = _make_item(item_id="abc123000000", summary="Item 1")
+        item2 = _make_item(item_id="abc123ffffff", summary="Item 2")
+        status = _make_status(item1, item2)
+        cmd = AckCommand(action=AckAction.ACK, prefix="abc123")
+
+        result = execute_remote_ack(cmd, status)
+
+        assert result.success is False
+        assert "Ambiguous prefix" in result.message
+        assert result.candidates is not None
+        assert len(result.candidates) == 2
+        assert "abc123000000" in result.candidates
+        assert "abc123ffffff" in result.candidates
+
+    def test_already_acked_item(self) -> None:
+        """Acking an already-acked item -> error result."""
+        item = _make_item(item_id="abc123def456", state=STATE_ACKED)
+        status = _make_status(item)
+        cmd = AckCommand(action=AckAction.ACK, prefix="abc1")
+
+        result = execute_remote_ack(cmd, status)
+
+        assert result.success is False
+        assert result.item_id == "abc123def456"
+        assert "cannot be" in result.message
+        assert "acked" in result.message.lower() or "already" in result.message.lower()
+
+    def test_already_suppressed_item(self) -> None:
+        """Muting an already-suppressed item -> error result."""
+        item = _make_item(item_id="abc123def456", state=STATE_SUPPRESSED)
+        status = _make_status(item)
+        cmd = AckCommand(action=AckAction.MUTE, prefix="abc1")
+
+        result = execute_remote_ack(cmd, status)
+
+        assert result.success is False
+        assert result.item_id == "abc123def456"
+
+    def test_already_cleared_item(self) -> None:
+        """Clearing an already-cleared item -> error result."""
+        item = _make_item(item_id="abc123def456", state=STATE_CLEARED)
+        status = _make_status(item)
+        cmd = AckCommand(action=AckAction.CLEAR, prefix="abc1")
+
+        result = execute_remote_ack(cmd, status)
+
+        assert result.success is False
+        assert result.item_id == "abc123def456"
+
+    def test_exact_match_with_full_id(self) -> None:
+        """Full 12-char item_id as prefix matches exactly."""
+        item = _make_item(item_id="abc123def456")
+        status = _make_status(item)
+        cmd = AckCommand(action=AckAction.ACK, prefix="abc123def456")
+
+        result = execute_remote_ack(cmd, status)
+
+        assert result.success is True
+        assert result.item_id == "abc123def456"
+
+    def test_multiple_items_unique_prefix(self) -> None:
+        """Multiple items but unique prefix -> correct match."""
+        item1 = _make_item(item_id="abc123000000", summary="Item A")
+        item2 = _make_item(item_id="def456000000", summary="Item B")
+        status = _make_status(item1, item2)
+        cmd = AckCommand(action=AckAction.ACK, prefix="def4")
+
+        result = execute_remote_ack(cmd, status)
+
+        assert result.success is True
+        assert result.item_id == "def456000000"
+        assert result.summary == "Item B"
+        assert item2.state == STATE_ACKED
+        # item1 unchanged
+        assert item1.state == STATE_OPEN
+
+    def test_clear_acked_item(self) -> None:
+        """Clearing an acked item succeeds (acked -> cleared)."""
+        item = _make_item(item_id="abc123def456", state=STATE_ACKED)
+        status = _make_status(item)
+        cmd = AckCommand(action=AckAction.CLEAR, prefix="abc1")
+
+        result = execute_remote_ack(cmd, status)
+
+        assert result.success is True
+        assert item.state == STATE_CLEARED
+
+    def test_suppress_acked_item(self) -> None:
+        """Suppressing an acked item succeeds (acked -> suppressed)."""
+        item = _make_item(item_id="abc123def456", state=STATE_ACKED)
+        status = _make_status(item)
+        cmd = AckCommand(action=AckAction.DISMISS, prefix="abc1")
+
+        result = execute_remote_ack(cmd, status)
+
+        assert result.success is True
+        assert item.state == STATE_SUPPRESSED
+
+
+# ===================================================================
+# Confirmation formatting tests
+# ===================================================================
+
+
+class TestFormatAckConfirmation:
+    """Tests for format_ack_confirmation()."""
+
+    def test_success_message(self) -> None:
+        """Successful ack produces a checkmark message."""
+        result = AckResult(
+            success=True,
+            action=AckAction.ACK,
+            item_id="abc123def456",
+            summary="Approval stall on author-b",
+            message="Acknowledged item abc123de -- Approval stall on author-b",
+        )
+        text = format_ack_confirmation(result)
+        assert "\u2705" in text  # checkmark
+        assert "abc123de" in text
+
+    def test_error_message_no_match(self) -> None:
+        """No-match error produces a cross-mark message."""
+        result = AckResult(
+            success=False,
+            action=AckAction.ACK,
+            message="No item matching prefix 'fff'",
+        )
+        text = format_ack_confirmation(result)
+        assert "\u274c" in text  # cross mark
+        assert "No item" in text
+
+    def test_ambiguous_message_shows_candidates(self) -> None:
+        """Ambiguous prefix shows candidate list."""
+        result = AckResult(
+            success=False,
+            action=AckAction.ACK,
+            message="Ambiguous prefix 'abc1' -- matches 2 items.",
+            candidates=["abc123000000", "abc123ffffff"],
+        )
+        text = format_ack_confirmation(result)
+        assert "\u274c" in text
+        assert "Candidates:" in text
+        assert "abc12300" in text
+        assert "abc123ff" in text
+
+    def test_already_acked_message(self) -> None:
+        """Already-acked error produces a cross-mark message."""
+        result = AckResult(
+            success=False,
+            action=AckAction.ACK,
+            item_id="abc123def456",
+            summary="Some alert",
+            message="Item abc123de exists but cannot be ackd",
+        )
+        text = format_ack_confirmation(result)
+        assert "\u274c" in text
+        assert "cannot be" in text
+
+
+# ===================================================================
+# Integration-style: parse + execute round-trip
+# ===================================================================
+
+
+class TestParseAndExecuteRoundTrip:
+    """End-to-end parse -> execute -> format round-trips."""
+
+    def test_full_ack_round_trip(self) -> None:
+        """Parse 'ack abc1' -> execute -> format confirmation."""
+        item = _make_item(item_id="abc123def456", summary="Lane stall")
+        status = _make_status(item)
+
+        cmd = parse_ack_command("ack abc1")
+        assert cmd is not None
+
+        result = execute_remote_ack(cmd, status)
+        assert result.success is True
+        assert item.state == STATE_ACKED
+
+        text = format_ack_confirmation(result)
+        assert "\u2705" in text
+        assert "Lane stall" in text
+
+    def test_full_mute_round_trip(self) -> None:
+        """Parse 'mute abc1' -> execute -> format confirmation."""
+        item = _make_item(item_id="abc123def456")
+        status = _make_status(item)
+
+        cmd = parse_ack_command("MUTE ABC1")
+        assert cmd is not None
+
+        result = execute_remote_ack(cmd, status)
+        assert result.success is True
+        assert item.state == STATE_SUPPRESSED
+
+        text = format_ack_confirmation(result)
+        assert "\u2705" in text
+
+    def test_non_command_passthrough(self) -> None:
+        """Non-command text returns None from parser (passthrough)."""
+        cmd = parse_ack_command("How's the fleet?")
+        assert cmd is None


### PR DESCRIPTION
## Summary
- Add `src/bid_euchre/ops/remote_ack.py` with pure-logic parser for remote ack/dismiss/mute/clear commands
- Add `tests/unit/test_ops_remote_ack.py` with 33 unit tests covering all patterns, edge cases, and round-trips
- Parser uses case-insensitive hex prefix matching consistent with existing CLI (`ops.py fleet --ack`)

## Why
Platform-9a requires operators to acknowledge or dismiss alerts from Telegram
without being at the terminal. This PR adds the core parsing and mutation logic
(PR 2 of the 4-PR Platform-9a decomposition). The module is pure logic — no
Telegram code — so it can be tested and reviewed independently of the wiring PRs.

## Repro / Validation

```bash
# Tier 1: unit tests
uv run python -m pytest tests/unit/test_ops_remote_ack.py -v

# Tier 2: full validation
make check-quiet
```

## Test Criteria
- All 33 unit tests pass (parser, execution, formatting, round-trips)
- `parse_ack_command()` returns `None` for non-command messages (passthrough)
- `parse_ack_command()` handles case-insensitive actions, hex-only prefixes, whitespace tolerance
- `execute_remote_ack()` correctly maps ack→acked, dismiss/mute→suppressed, clear→cleared
- Ambiguous prefix returns error with candidate list
- No-match and already-acked cases return structured errors
- No Telegram-specific code in the module (pure logic)
- Uses existing `control_plane.py` API (`ack_item`, `suppress_item`, `clear_item`)

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: ops/platform9a-remote-ack
```

## Context
- Sub-plan: `plans/agent_ops/4_remote_channel/sub/2026-03-25_platform-9a-idle-attention-alerts.md`
- Task packet: `3bb69fe69e3e` (A1-PR2)
- PR 1 (alert push evaluator) and PR 2 (this) are independent — safe parallel
- PR 3 (Telegram wiring) depends on both; PR 4 (e2e) depends on PR 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)