### PR TITLE
fix(test): decouple monitor CLI test from wall clock (#1758)

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -2357,6 +2357,7 @@ def cmd_monitor(args: argparse.Namespace) -> int:
             task_packets=task_dicts,
             unacked_messages=inbox_msgs,
             audit_records=audit_dicts,
+            now_iso=getattr(args, "now", None),
         )
 
     # Exit 1 if any high-severity findings
@@ -3698,6 +3699,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--no-reconcile",
         action="store_true",
         help="Skip controller projection update (fleet_status.json) after monitor sweep",
+    )
+    monitor_parser.add_argument(
+        "--now",
+        metavar="ISO_TIMESTAMP",
+        default=None,
+        help="Override wall clock for reconcile (ISO-8601 timestamp, for testing)",
     )
 
     # fleet (SP-4-07: controller projection read-only view)

--- a/tests/unit/test_ops_control_plane.py
+++ b/tests/unit/test_ops_control_plane.py
@@ -1875,6 +1875,8 @@ class TestMonitorReconcileWiring:
                 "--no-notify",
                 "--no-recovery",
                 "--no-auto-dispatch",
+                "--now",
+                NOW_ISO,
             ],
             capture_output=True,
             text=True,


### PR DESCRIPTION
## Summary

- Add `--now ISO_TIMESTAMP` CLI flag to the `monitor` subcommand that forwards to `reconcile(now_iso=...)`
- Update `test_cli_monitor_wires_inbox_and_audit_to_reconcile` to pass `--now` with the deterministic `NOW_ISO` constant
- Prevents TTL-expiry failures as hardcoded fixture timestamps age past their 24h TTL

## Why

Issue #1758: The integration test used hardcoded absolute timestamps (2026-03-24) but called `cmd_monitor` without a time override, so `reconcile()` used the wall clock. Once `now` drifts past the fixture's TTL window, the inbox message expires and the assertion fails. This is the same anti-pattern fixed in PRs #1736, #1743, #1746.

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_ops_control_plane.py -v -k "test_cli_monitor_wires_inbox_and_audit"
make check-quiet
```

## Tests

- `uv run python -m pytest tests/unit/test_ops_control_plane.py -v -k "test_cli_monitor_wires_inbox_and_audit"` → PASSED
- `make check-quiet` → All checks passed

## Worktree proof

```
Worktree: Bid-Euchre-steward-flex-a
Branch: fix/decouple-monitor-test-wallclock-1758
```

Closes #1758

🤖 Generated with [Claude Code](https://claude.com/claude-code)