### PR TITLE
fix(ops): address urgent-state-guard review follow-ups (#1766)

### DIFF
--- a/.claude/hooks/urgent-state-guard.py
+++ b/.claude/hooks/urgent-state-guard.py
@@ -26,7 +26,8 @@ from pathlib import Path
 GUARDED_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"^\s*gh\s+pr\s+merge\b"),
     re.compile(r"uv\s+run\s+python\s+scripts/internal/ops\.py\s+task\s+dispatch\b"),
-    re.compile(r"dispatch_to_worker"),
+    re.compile(r"uv\s+run\s+python\s+scripts/internal/ops\.py\s+workers\s+dispatch\b"),
+    re.compile(r"dispatch_to_worker\s*\("),
 ]
 
 
@@ -71,7 +72,7 @@ def format_block_message(alerts: list[dict]) -> str:
         [
             "",
             "Resolve or ack alerts before running risky commands:",
-            "  uv run python scripts/internal/ops.py fleet ack <item_id>",
+            "  uv run python scripts/internal/ops.py fleet --ack <item_id>",
         ]
     )
     return "\n".join(lines)

--- a/tests/unit/test_urgent_state_guard.py
+++ b/tests/unit/test_urgent_state_guard.py
@@ -193,6 +193,22 @@ class TestAllowCases:
         assert result.returncode == 0
         assert result.stdout.strip() == ""
 
+    def test_dispatch_to_worker_in_grep_not_blocked(self, tmp_path: Path) -> None:
+        """Hook allows grep/cat of dispatch_to_worker (not a real invocation)."""
+        items = [_make_item(severity="high", summary="Alert")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path, "grep -r dispatch_to_worker src/")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_dispatch_to_worker_in_cat_not_blocked(self, tmp_path: Path) -> None:
+        """Hook allows reading files that contain dispatch_to_worker."""
+        items = [_make_item(severity="high", summary="Alert")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(tmp_path, "cat src/bid_euchre/ops/worker_pool.py")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
 
 # ---------------------------------------------------------------------------
 # Tests: block cases (exit 2)
@@ -220,7 +236,7 @@ class TestBlockCases:
         assert "BLOCKED" in result.stdout
         assert "[URGENT] CI broken on main" in result.stdout
 
-    def test_blocks_dispatch_command(self, tmp_path: Path) -> None:
+    def test_blocks_task_dispatch_command(self, tmp_path: Path) -> None:
         """Hook blocks task dispatch when open high alert exists."""
         items = [_make_item(severity="high", summary="Stalled lane")]
         _write_fleet_status(tmp_path, _fleet_status(items))
@@ -231,8 +247,19 @@ class TestBlockCases:
         assert result.returncode == 2
         assert "BLOCKED" in result.stdout
 
-    def test_blocks_dispatch_to_worker(self, tmp_path: Path) -> None:
-        """Hook blocks dispatch_to_worker calls."""
+    def test_blocks_workers_dispatch_command(self, tmp_path: Path) -> None:
+        """Hook blocks workers dispatch when open high alert exists."""
+        items = [_make_item(severity="high", summary="Stalled lane")]
+        _write_fleet_status(tmp_path, _fleet_status(items))
+        result = _run_hook(
+            tmp_path,
+            "uv run python scripts/internal/ops.py workers dispatch 6f2985cfd01b author-a",
+        )
+        assert result.returncode == 2
+        assert "BLOCKED" in result.stdout
+
+    def test_blocks_dispatch_to_worker_call(self, tmp_path: Path) -> None:
+        """Hook blocks dispatch_to_worker() function calls."""
         items = [_make_item(severity="high", summary="Stalled lane")]
         _write_fleet_status(tmp_path, _fleet_status(items))
         result = _run_hook(
@@ -287,12 +314,12 @@ class TestBlockCases:
         assert "Capacity OK" not in result.stdout  # info excluded
 
     def test_block_message_includes_remediation(self, tmp_path: Path) -> None:
-        """Block message shows how to resolve."""
+        """Block message shows the real fleet --ack command."""
         items = [_make_item(severity="high", summary="Alert")]
         _write_fleet_status(tmp_path, _fleet_status(items))
         result = _run_hook(tmp_path, "gh pr merge 123 --squash")
         assert result.returncode == 2
-        assert "fleet ack" in result.stdout
+        assert "fleet --ack" in result.stdout
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Guard the `workers dispatch` CLI path alongside `task dispatch`
- Narrow `dispatch_to_worker` pattern to actual function calls (`dispatch_to_worker(`) — grep/cat no longer false-positive
- Fix block message to print the real `fleet --ack <item_id>` command (was `fleet ack`)

## Why

Closes #1766. Convention follow-ups from the PR #1764 review (urgent state guard). The guard had three gaps: missing `workers dispatch` coverage, overly broad `dispatch_to_worker` matching, and incorrect ack command in remediation output.

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_urgent_state_guard.py -x -v  # 30 passed
make check-quiet                                                       # all checks passed
```

## Tests

- 30 tests total (3 new: `workers dispatch` block, grep allow, cat allow)
- All 27 original tests still pass

## Worktree Proof

```
pwd: Bid-Euchre-steward-author-scratch
branch: fix/urgent-state-guard-followup
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)