### PR TITLE
feat(ops): add alert push evaluator and push state tracking (Platform-9a PR1)

### DIFF
--- a/src/bid_euchre/ops/alert_push.py
+++ b/src/bid_euchre/ops/alert_push.py
@@ -1,0 +1,306 @@
+"""Alert push evaluator and push state tracking (Platform-9a, PR 1).
+
+Decides when to push unresolved HIGH/URGENT controller items to the
+operator's remote channel (e.g., Telegram) when the fleet is idle or
+unattended.  This module is **transport-agnostic** — it never imports
+Telegram, MCP, or any I/O library.  The caller is responsible for
+actually sending the alert.
+
+Key design points:
+
+- ``evaluate_push_needed()`` is a **pure function**: no I/O, no side
+  effects.  It takes pre-loaded data and returns a list of items that
+  should be pushed.
+- Push state tracks per-item-id last-pushed timestamps, push counts,
+  and severity at time of push to enable dedup and backoff.
+- Re-push triggers: (a) new item never pushed, (b) cooldown elapsed,
+  (c) severity escalated since last push.
+
+Usage::
+
+    from bid_euchre.ops.alert_push import (
+        evaluate_push_needed,
+        load_push_state,
+        record_push,
+        save_push_state,
+    )
+
+    items_to_push = evaluate_push_needed(fleet_status, idle_status, push_state)
+    for item in items_to_push:
+        # ... send via Telegram or other transport ...
+        record_push(push_state, item.item_id, item.severity)
+    save_push_state(push_state)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from bid_euchre.ops.control_plane import (
+    SEVERITY_HIGH,
+    SEVERITY_URGENT,
+    STATE_OPEN,
+    ActionableItem,
+    FleetStatus,
+)
+from bid_euchre.ops.idle_detector import IdleStatus
+
+logger = logging.getLogger("ops.alert_push")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_RUNTIME_DIR = Path(".claude/runtime")
+PUSH_STATE_FILE = "alert_push_state.json"
+
+# Default cooldown: don't re-push the same item within this many minutes.
+DEFAULT_COOLDOWN_MINUTES = 15.0
+
+# Severities eligible for push (only HIGH and URGENT).
+PUSHABLE_SEVERITIES = frozenset({SEVERITY_HIGH, SEVERITY_URGENT})
+
+# Severity ranking for escalation detection.
+_SEVERITY_RANK: dict[str, int] = {
+    "info": 0,
+    "warn": 1,
+    "high": 2,
+    "urgent": 3,
+}
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PushItemRecord:
+    """Tracking record for a single item's push history.
+
+    Attributes:
+        item_id: The controller item_id being tracked.
+        last_pushed_at: ISO 8601 timestamp of the most recent push.
+        push_count: Total number of times this item has been pushed.
+        severity_at_push: The severity level at the time of the last push.
+    """
+
+    item_id: str
+    last_pushed_at: str
+    push_count: int = 0
+    severity_at_push: str = ""
+
+
+@dataclass
+class PushState:
+    """Complete push tracking state.
+
+    Stored at ``.claude/runtime/alert_push_state.json``.  Each entry in
+    ``items`` tracks a single item_id's push history.
+    """
+
+    items: dict[str, PushItemRecord] = field(default_factory=dict)
+    last_evaluation_at: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "items": {k: asdict(v) for k, v in self.items.items()},
+            "last_evaluation_at": self.last_evaluation_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PushState:
+        items: dict[str, PushItemRecord] = {}
+        for k, v in data.get("items", {}).items():
+            items[k] = PushItemRecord(**v)
+        return cls(
+            items=items,
+            last_evaluation_at=data.get("last_evaluation_at", ""),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pure evaluation
+# ---------------------------------------------------------------------------
+
+
+def _severity_escalated(previous: str, current: str) -> bool:
+    """Return True if ``current`` severity is higher than ``previous``."""
+    return _SEVERITY_RANK.get(current, 0) > _SEVERITY_RANK.get(previous, 0)
+
+
+def evaluate_push_needed(
+    fleet_status: FleetStatus,
+    idle_status: IdleStatus,
+    push_state: PushState,
+    *,
+    cooldown_minutes: float = DEFAULT_COOLDOWN_MINUTES,
+    now: datetime | None = None,
+) -> list[ActionableItem]:
+    """Determine which items need to be pushed to the remote channel.
+
+    This is a **pure function** — no I/O, no Telegram calls.
+
+    Rules:
+    1. If the fleet is **not idle**, return empty (operator is at terminal).
+    2. Only consider **open** items with severity HIGH or URGENT.
+    3. For each eligible item:
+       a. If never pushed → include.
+       b. If severity escalated since last push → include (bypass cooldown).
+       c. If cooldown elapsed since last push → include.
+       d. Otherwise → skip (dedup).
+
+    Args:
+        fleet_status: Current controller projection.
+        idle_status: Current fleet idle determination.
+        push_state: Previously tracked push history.
+        cooldown_minutes: Minimum minutes between re-pushes for the same item.
+        now: Override for current time (for testing).
+
+    Returns:
+        List of ``ActionableItem`` instances that should be pushed.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    # Rule 1: No push when fleet is active.
+    if not idle_status.idle:
+        return []
+
+    now_ts = now.timestamp()
+    to_push: list[ActionableItem] = []
+
+    for item in fleet_status.items:
+        # Rule 2: Only open HIGH/URGENT items.
+        if item.state != STATE_OPEN:
+            continue
+        if item.severity not in PUSHABLE_SEVERITIES:
+            continue
+
+        record = push_state.items.get(item.item_id)
+
+        if record is None:
+            # Rule 3a: Never pushed → include.
+            to_push.append(item)
+            continue
+
+        # Rule 3b: Severity escalated → include (bypass cooldown).
+        if _severity_escalated(record.severity_at_push, item.severity):
+            to_push.append(item)
+            continue
+
+        # Rule 3c: Cooldown elapsed → include.
+        try:
+            last_ts = datetime.fromisoformat(record.last_pushed_at).timestamp()
+        except (ValueError, TypeError):
+            # Corrupt timestamp — treat as never pushed.
+            to_push.append(item)
+            continue
+
+        elapsed_minutes = (now_ts - last_ts) / 60.0
+        if elapsed_minutes >= cooldown_minutes:
+            to_push.append(item)
+            continue
+
+        # Rule 3d: Within cooldown, same severity → skip.
+
+    return to_push
+
+
+# ---------------------------------------------------------------------------
+# Push state mutation
+# ---------------------------------------------------------------------------
+
+
+def record_push(
+    push_state: PushState,
+    item_id: str,
+    severity: str,
+    *,
+    now: datetime | None = None,
+) -> None:
+    """Record that an item was pushed to the remote channel.
+
+    Updates the push state in place (does NOT persist to disk — the caller
+    should call ``save_push_state()`` after all pushes).
+
+    Args:
+        push_state: The mutable push state to update.
+        item_id: The item that was pushed.
+        severity: The severity of the item at push time.
+        now: Override for current time (for testing).
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    existing = push_state.items.get(item_id)
+    count = (existing.push_count if existing else 0) + 1
+
+    push_state.items[item_id] = PushItemRecord(
+        item_id=item_id,
+        last_pushed_at=now.isoformat(),
+        push_count=count,
+        severity_at_push=severity,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def _push_state_path(runtime_dir: Path | None = None) -> Path:
+    if runtime_dir is None:
+        runtime_dir = DEFAULT_RUNTIME_DIR
+    return runtime_dir / PUSH_STATE_FILE
+
+
+def load_push_state(runtime_dir: Path | None = None) -> PushState:
+    """Load push state from disk.
+
+    Returns a fresh ``PushState`` if the file doesn't exist or is corrupt.
+    """
+    path = _push_state_path(runtime_dir)
+    if not path.exists():
+        return PushState()
+    try:
+        data = json.loads(path.read_text())
+        return PushState.from_dict(data)
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        logger.warning("Could not load push state from %s: %s", path, exc)
+        return PushState()
+
+
+def save_push_state(
+    push_state: PushState,
+    runtime_dir: Path | None = None,
+) -> Path:
+    """Atomically write push state to disk."""
+    path = _push_state_path(runtime_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    data = push_state.to_dict()
+    # Atomic write via temp file + rename.
+    fd, tmp = tempfile.mkstemp(
+        dir=str(path.parent), suffix=".tmp", prefix="alert_push_state_"
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+        os.replace(tmp, str(path))
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+    return path

--- a/tests/unit/test_ops_alert_push.py
+++ b/tests/unit/test_ops_alert_push.py
@@ -1,0 +1,480 @@
+"""Tests for alert push evaluator and push state tracking (Platform-9a, PR 1).
+
+Covers:
+- Push needed when idle + open HIGH/URGENT items exist
+- Push skipped when fleet is active (not idle)
+- Push skipped when item already pushed within cooldown
+- Push triggered when severity escalates (HIGH → URGENT)
+- Push state persistence round-trip
+- Empty fleet status produces no pushes
+- Cooldown reset on severity change
+- Corrupt / missing push state file handling
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from bid_euchre.ops.alert_push import (
+    DEFAULT_COOLDOWN_MINUTES,
+    PUSH_STATE_FILE,
+    PUSHABLE_SEVERITIES,
+    PushItemRecord,
+    PushState,
+    evaluate_push_needed,
+    load_push_state,
+    record_push,
+    save_push_state,
+)
+from bid_euchre.ops.control_plane import (
+    SEVERITY_HIGH,
+    SEVERITY_INFO,
+    SEVERITY_URGENT,
+    SEVERITY_WARN,
+    STATE_ACKED,
+    STATE_OPEN,
+    STATE_SUPPRESSED,
+    ActionableItem,
+    FleetStatus,
+)
+from bid_euchre.ops.idle_detector import IdleStatus
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+NOW = datetime(2026, 3, 25, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _idle(idle: bool = True) -> IdleStatus:
+    """Create an IdleStatus for testing."""
+    return IdleStatus(
+        idle=idle,
+        idle_minutes=120.0 if idle else 5.0,
+        last_meaningful_event=NOW - timedelta(hours=2)
+        if idle
+        else NOW - timedelta(minutes=5),
+        active_lanes=[] if idle else ["author-a"],
+        reason="test fixture",
+    )
+
+
+def _item(
+    item_id: str = "abc123def456",
+    severity: str = SEVERITY_HIGH,
+    state: str = STATE_OPEN,
+) -> ActionableItem:
+    """Create an ActionableItem for testing."""
+    return ActionableItem(
+        item_id=item_id,
+        severity=severity,
+        category="lane_health",
+        source="monitor",
+        summary=f"Test item {item_id[:8]}",
+        first_seen_at=NOW.isoformat(),
+        last_seen_at=NOW.isoformat(),
+        state=state,
+    )
+
+
+def _fleet(*items: ActionableItem) -> FleetStatus:
+    """Create a FleetStatus from items."""
+    return FleetStatus(
+        items=list(items),
+        generated_at=NOW.isoformat(),
+        cycle_count=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# evaluate_push_needed — core logic
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluatePushNeeded:
+    """Test the pure evaluation function."""
+
+    def test_push_needed_when_idle_with_high_items(self) -> None:
+        """Push is needed when fleet is idle and open HIGH items exist."""
+        fleet = _fleet(_item(severity=SEVERITY_HIGH))
+        result = evaluate_push_needed(fleet, _idle(True), PushState(), now=NOW)
+        assert len(result) == 1
+        assert result[0].item_id == "abc123def456"
+
+    def test_push_needed_when_idle_with_urgent_items(self) -> None:
+        """Push is needed when fleet is idle and open URGENT items exist."""
+        fleet = _fleet(_item(severity=SEVERITY_URGENT))
+        result = evaluate_push_needed(fleet, _idle(True), PushState(), now=NOW)
+        assert len(result) == 1
+
+    def test_push_skipped_when_fleet_active(self) -> None:
+        """No push when fleet is active (operator at terminal)."""
+        fleet = _fleet(_item(severity=SEVERITY_HIGH))
+        result = evaluate_push_needed(fleet, _idle(False), PushState(), now=NOW)
+        assert result == []
+
+    def test_push_skipped_for_info_items(self) -> None:
+        """INFO items are never pushed."""
+        fleet = _fleet(_item(severity=SEVERITY_INFO))
+        result = evaluate_push_needed(fleet, _idle(True), PushState(), now=NOW)
+        assert result == []
+
+    def test_push_skipped_for_warn_items(self) -> None:
+        """WARN items are never pushed."""
+        fleet = _fleet(_item(severity=SEVERITY_WARN))
+        result = evaluate_push_needed(fleet, _idle(True), PushState(), now=NOW)
+        assert result == []
+
+    def test_push_skipped_for_acked_items(self) -> None:
+        """Acked items are not pushed even if HIGH/URGENT."""
+        fleet = _fleet(_item(severity=SEVERITY_HIGH, state=STATE_ACKED))
+        result = evaluate_push_needed(fleet, _idle(True), PushState(), now=NOW)
+        assert result == []
+
+    def test_push_skipped_for_suppressed_items(self) -> None:
+        """Suppressed items are not pushed."""
+        fleet = _fleet(_item(severity=SEVERITY_HIGH, state=STATE_SUPPRESSED))
+        result = evaluate_push_needed(fleet, _idle(True), PushState(), now=NOW)
+        assert result == []
+
+    def test_empty_fleet_produces_no_pushes(self) -> None:
+        """Empty fleet status produces no pushes."""
+        fleet = _fleet()
+        result = evaluate_push_needed(fleet, _idle(True), PushState(), now=NOW)
+        assert result == []
+
+    def test_push_skipped_within_cooldown(self) -> None:
+        """Push is skipped when same item was pushed within cooldown window."""
+        pushed_at = NOW - timedelta(minutes=5)  # 5 min ago, well within 15m cooldown
+        state = PushState(
+            items={
+                "abc123def456": PushItemRecord(
+                    item_id="abc123def456",
+                    last_pushed_at=pushed_at.isoformat(),
+                    push_count=1,
+                    severity_at_push=SEVERITY_HIGH,
+                ),
+            }
+        )
+        fleet = _fleet(_item(severity=SEVERITY_HIGH))
+        result = evaluate_push_needed(fleet, _idle(True), state, now=NOW)
+        assert result == []
+
+    def test_push_after_cooldown_elapsed(self) -> None:
+        """Push is allowed once the cooldown has elapsed."""
+        pushed_at = NOW - timedelta(minutes=20)  # 20 min ago, past 15m cooldown
+        state = PushState(
+            items={
+                "abc123def456": PushItemRecord(
+                    item_id="abc123def456",
+                    last_pushed_at=pushed_at.isoformat(),
+                    push_count=1,
+                    severity_at_push=SEVERITY_HIGH,
+                ),
+            }
+        )
+        fleet = _fleet(_item(severity=SEVERITY_HIGH))
+        result = evaluate_push_needed(fleet, _idle(True), state, now=NOW)
+        assert len(result) == 1
+
+    def test_push_on_severity_escalation_bypasses_cooldown(self) -> None:
+        """Severity escalation triggers push even within cooldown window."""
+        pushed_at = NOW - timedelta(minutes=5)  # Within cooldown
+        state = PushState(
+            items={
+                "abc123def456": PushItemRecord(
+                    item_id="abc123def456",
+                    last_pushed_at=pushed_at.isoformat(),
+                    push_count=1,
+                    severity_at_push=SEVERITY_HIGH,  # Was HIGH
+                ),
+            }
+        )
+        # Now it's URGENT
+        fleet = _fleet(_item(severity=SEVERITY_URGENT))
+        result = evaluate_push_needed(fleet, _idle(True), state, now=NOW)
+        assert len(result) == 1
+
+    def test_no_push_on_severity_downgrade(self) -> None:
+        """Severity downgrade within cooldown does NOT trigger push."""
+        pushed_at = NOW - timedelta(minutes=5)
+        state = PushState(
+            items={
+                "abc123def456": PushItemRecord(
+                    item_id="abc123def456",
+                    last_pushed_at=pushed_at.isoformat(),
+                    push_count=1,
+                    severity_at_push=SEVERITY_URGENT,  # Was URGENT
+                ),
+            }
+        )
+        # Now it's HIGH (downgrade)
+        fleet = _fleet(_item(severity=SEVERITY_HIGH))
+        result = evaluate_push_needed(fleet, _idle(True), state, now=NOW)
+        assert result == []
+
+    def test_multiple_items_mixed_push_decisions(self) -> None:
+        """Multiple items: some pushed, some skipped."""
+        pushed_at = NOW - timedelta(minutes=5)
+        state = PushState(
+            items={
+                "item_already_ok": PushItemRecord(
+                    item_id="item_already_ok",
+                    last_pushed_at=pushed_at.isoformat(),
+                    push_count=1,
+                    severity_at_push=SEVERITY_HIGH,
+                ),
+            }
+        )
+        fleet = _fleet(
+            _item(item_id="item_already_ok", severity=SEVERITY_HIGH),
+            _item(item_id="item_new_high", severity=SEVERITY_HIGH),
+            _item(item_id="item_new_urgent", severity=SEVERITY_URGENT),
+            _item(item_id="item_info_skip", severity=SEVERITY_INFO),
+        )
+        result = evaluate_push_needed(fleet, _idle(True), state, now=NOW)
+        pushed_ids = {i.item_id for i in result}
+        assert "item_new_high" in pushed_ids
+        assert "item_new_urgent" in pushed_ids
+        assert "item_already_ok" not in pushed_ids  # Within cooldown
+        assert "item_info_skip" not in pushed_ids  # INFO not pushable
+
+    def test_custom_cooldown_minutes(self) -> None:
+        """Custom cooldown is respected."""
+        pushed_at = NOW - timedelta(minutes=10)
+        state = PushState(
+            items={
+                "abc123def456": PushItemRecord(
+                    item_id="abc123def456",
+                    last_pushed_at=pushed_at.isoformat(),
+                    push_count=1,
+                    severity_at_push=SEVERITY_HIGH,
+                ),
+            }
+        )
+        fleet = _fleet(_item(severity=SEVERITY_HIGH))
+        # Default 15m → should skip (10m < 15m)
+        result_default = evaluate_push_needed(fleet, _idle(True), state, now=NOW)
+        assert result_default == []
+        # Custom 5m → should push (10m > 5m)
+        result_custom = evaluate_push_needed(
+            fleet, _idle(True), state, cooldown_minutes=5.0, now=NOW
+        )
+        assert len(result_custom) == 1
+
+    def test_corrupt_timestamp_treated_as_never_pushed(self) -> None:
+        """Corrupt last_pushed_at timestamp results in re-push."""
+        state = PushState(
+            items={
+                "abc123def456": PushItemRecord(
+                    item_id="abc123def456",
+                    last_pushed_at="not-a-timestamp",
+                    push_count=1,
+                    severity_at_push=SEVERITY_HIGH,
+                ),
+            }
+        )
+        fleet = _fleet(_item(severity=SEVERITY_HIGH))
+        result = evaluate_push_needed(fleet, _idle(True), state, now=NOW)
+        assert len(result) == 1
+
+    def test_warn_to_high_escalation_triggers_push(self) -> None:
+        """Escalation from WARN → HIGH triggers push (crosses pushable threshold)."""
+        pushed_at = NOW - timedelta(minutes=5)
+        state = PushState(
+            items={
+                "abc123def456": PushItemRecord(
+                    item_id="abc123def456",
+                    last_pushed_at=pushed_at.isoformat(),
+                    push_count=1,
+                    severity_at_push=SEVERITY_WARN,
+                ),
+            }
+        )
+        fleet = _fleet(_item(severity=SEVERITY_HIGH))
+        result = evaluate_push_needed(fleet, _idle(True), state, now=NOW)
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# record_push
+# ---------------------------------------------------------------------------
+
+
+class TestRecordPush:
+    """Test push state mutation."""
+
+    def test_record_first_push(self) -> None:
+        """Recording a push for a new item creates the record."""
+        state = PushState()
+        record_push(state, "item_1", SEVERITY_HIGH, now=NOW)
+        assert "item_1" in state.items
+        assert state.items["item_1"].push_count == 1
+        assert state.items["item_1"].severity_at_push == SEVERITY_HIGH
+        assert state.items["item_1"].last_pushed_at == NOW.isoformat()
+
+    def test_record_subsequent_push_increments_count(self) -> None:
+        """Recording multiple pushes increments the count."""
+        state = PushState()
+        record_push(state, "item_1", SEVERITY_HIGH, now=NOW)
+        record_push(state, "item_1", SEVERITY_HIGH, now=NOW + timedelta(minutes=20))
+        assert state.items["item_1"].push_count == 2
+
+    def test_record_push_updates_severity(self) -> None:
+        """Recording a push with new severity updates severity_at_push."""
+        state = PushState()
+        record_push(state, "item_1", SEVERITY_HIGH, now=NOW)
+        record_push(state, "item_1", SEVERITY_URGENT, now=NOW + timedelta(minutes=5))
+        assert state.items["item_1"].severity_at_push == SEVERITY_URGENT
+
+    def test_record_push_updates_timestamp(self) -> None:
+        """Recording a push updates last_pushed_at."""
+        state = PushState()
+        t1 = NOW
+        t2 = NOW + timedelta(minutes=20)
+        record_push(state, "item_1", SEVERITY_HIGH, now=t1)
+        record_push(state, "item_1", SEVERITY_HIGH, now=t2)
+        assert state.items["item_1"].last_pushed_at == t2.isoformat()
+
+    def test_record_push_separate_items(self) -> None:
+        """Recording pushes for different items tracks them independently."""
+        state = PushState()
+        record_push(state, "item_a", SEVERITY_HIGH, now=NOW)
+        record_push(state, "item_b", SEVERITY_URGENT, now=NOW)
+        assert len(state.items) == 2
+        assert state.items["item_a"].severity_at_push == SEVERITY_HIGH
+        assert state.items["item_b"].severity_at_push == SEVERITY_URGENT
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+class TestPersistence:
+    """Test push state load/save round-trip."""
+
+    def test_round_trip(self, tmp_path: Path) -> None:
+        """Push state survives save + load cycle."""
+        state = PushState()
+        record_push(state, "item_1", SEVERITY_HIGH, now=NOW)
+        record_push(state, "item_2", SEVERITY_URGENT, now=NOW)
+        state.last_evaluation_at = NOW.isoformat()
+
+        save_push_state(state, runtime_dir=tmp_path)
+        loaded = load_push_state(runtime_dir=tmp_path)
+
+        assert loaded.last_evaluation_at == NOW.isoformat()
+        assert len(loaded.items) == 2
+        assert loaded.items["item_1"].push_count == 1
+        assert loaded.items["item_1"].severity_at_push == SEVERITY_HIGH
+        assert loaded.items["item_2"].push_count == 1
+        assert loaded.items["item_2"].severity_at_push == SEVERITY_URGENT
+
+    def test_load_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        """Loading from a missing file returns a fresh PushState."""
+        state = load_push_state(runtime_dir=tmp_path)
+        assert state.items == {}
+        assert state.last_evaluation_at == ""
+
+    def test_load_corrupt_file_returns_empty(self, tmp_path: Path) -> None:
+        """Loading from a corrupt file returns a fresh PushState."""
+        path = tmp_path / PUSH_STATE_FILE
+        path.write_text("not valid json{{{")
+        state = load_push_state(runtime_dir=tmp_path)
+        assert state.items == {}
+
+    def test_save_creates_parent_dirs(self, tmp_path: Path) -> None:
+        """Save creates intermediate directories if needed."""
+        deep_dir = tmp_path / "nested" / "runtime"
+        save_push_state(PushState(), runtime_dir=deep_dir)
+        assert (deep_dir / PUSH_STATE_FILE).exists()
+
+    def test_save_is_valid_json(self, tmp_path: Path) -> None:
+        """Saved file is valid JSON with expected structure."""
+        state = PushState()
+        record_push(state, "item_x", SEVERITY_HIGH, now=NOW)
+        save_push_state(state, runtime_dir=tmp_path)
+
+        raw = (tmp_path / PUSH_STATE_FILE).read_text()
+        data = json.loads(raw)
+        assert "items" in data
+        assert "item_x" in data["items"]
+        assert data["items"]["item_x"]["push_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration: evaluate + record + re-evaluate
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateRecordCycle:
+    """Test the full evaluate → record → re-evaluate cycle."""
+
+    def test_full_cycle_dedup(self) -> None:
+        """After recording a push, re-evaluation skips the item within cooldown."""
+        fleet = _fleet(
+            _item(item_id="item_a", severity=SEVERITY_HIGH),
+            _item(item_id="item_b", severity=SEVERITY_URGENT),
+        )
+        state = PushState()
+
+        # First evaluation: both items should be pushed.
+        result = evaluate_push_needed(fleet, _idle(True), state, now=NOW)
+        assert len(result) == 2
+
+        # Record pushes.
+        for item in result:
+            record_push(state, item.item_id, item.severity, now=NOW)
+
+        # Re-evaluate within cooldown: nothing to push.
+        result2 = evaluate_push_needed(
+            fleet, _idle(True), state, now=NOW + timedelta(minutes=5)
+        )
+        assert result2 == []
+
+        # Re-evaluate after cooldown: both items pushed again.
+        result3 = evaluate_push_needed(
+            fleet, _idle(True), state, now=NOW + timedelta(minutes=20)
+        )
+        assert len(result3) == 2
+
+    def test_escalation_mid_cooldown(self) -> None:
+        """Severity escalation triggers re-push even within cooldown."""
+        item = _item(item_id="item_a", severity=SEVERITY_HIGH)
+        fleet = _fleet(item)
+        state = PushState()
+
+        # Push the HIGH item.
+        result = evaluate_push_needed(fleet, _idle(True), state, now=NOW)
+        assert len(result) == 1
+        record_push(state, "item_a", SEVERITY_HIGH, now=NOW)
+
+        # Escalate to URGENT and re-evaluate within cooldown.
+        escalated_item = _item(item_id="item_a", severity=SEVERITY_URGENT)
+        fleet2 = _fleet(escalated_item)
+        result2 = evaluate_push_needed(
+            fleet2, _idle(True), state, now=NOW + timedelta(minutes=5)
+        )
+        assert len(result2) == 1
+        assert result2[0].severity == SEVERITY_URGENT
+
+
+# ---------------------------------------------------------------------------
+# Default cooldown constant
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    """Verify exported constants."""
+
+    def test_default_cooldown(self) -> None:
+        assert DEFAULT_COOLDOWN_MINUTES == 15.0
+
+    def test_pushable_severities(self) -> None:
+        assert SEVERITY_HIGH in PUSHABLE_SEVERITIES
+        assert SEVERITY_URGENT in PUSHABLE_SEVERITIES
+        assert SEVERITY_INFO not in PUSHABLE_SEVERITIES
+        assert SEVERITY_WARN not in PUSHABLE_SEVERITIES


### PR DESCRIPTION
## Plan
`plans/agent_ops/4_remote_channel/sub/2026-03-25_platform-9a-idle-attention-alerts.md` — PR 1 of 4

## Summary
- Add `src/bid_euchre/ops/alert_push.py` with transport-agnostic alert push evaluation logic
- Add `tests/unit/test_ops_alert_push.py` with 30 unit tests covering all push decision paths
- Pure function `evaluate_push_needed()` decides when to push alerts based on idle state, cooldown, dedup, and severity escalation

## Why
Platform-9a enables proactive push of unresolved HIGH/URGENT controller items to the operator's phone when the fleet is idle. This PR provides the core evaluation layer — no I/O, no Telegram — so that the transport adapter (PR 3) can be wired separately.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_alert_push.py -v
make check-quiet
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** All 30 unit tests pass covering: push when idle, skip when active, cooldown dedup, severity escalation bypass, persistence round-trip, empty fleet, corrupt state recovery
- **Verification command:** `uv run python -m pytest tests/unit/test_ops_alert_push.py -v`
- **Expected result:** `30 passed` with no failures

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_alert_push.py -v` — 30 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None (new module, no existing behavior changed)
- Runtime impact: None (not wired into monitor cycle yet — that's PR 3)

## Risk level
- [x] Low (new module with tests, no existing code modified)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         f4537c22 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author          c9daabca [ops/platform9a-alert-push]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)