### PR TITLE
ops: restructure tmux layout — analyst pool window, retire scratch (#1769)

### DIFF
--- a/.claude/rules/75_worktree_protection.md
+++ b/.claude/rules/75_worktree_protection.md
@@ -12,7 +12,6 @@ These worktrees are permanent and must not be deleted:
 - `Bid-Euchre-steward-author-b`
 - `Bid-Euchre-steward-author-c`
 - `Bid-Euchre-steward-author-d`
-- `Bid-Euchre-steward-author-scratch`
 
 **Browser-game pool:**
 - `Bid-Euchre-steward-brws-author-a`
@@ -20,15 +19,23 @@ These worktrees are permanent and must not be deleted:
 - `Bid-Euchre-steward-brws-author-c`
 - `Bid-Euchre-steward-brws-author-d`
 
+**Analyst pool:**
+- `Bid-Euchre-steward-analyst` (analyst-a)
+- `Bid-Euchre-steward-analyst-b`
+- `Bid-Euchre-steward-analyst-c`
+- `Bid-Euchre-steward-analyst-d`
+
 **Flex pool:**
 - `Bid-Euchre-steward-flex-a`
 - `Bid-Euchre-steward-flex-b`
 - `Bid-Euchre-steward-flex-c`
 
 **Control plane:**
-- `Bid-Euchre-steward-analyst`
 - `Bid-Euchre-steward-review`
 - `Bid-Euchre-steward-ops`
+
+**Legacy (retired from active layout but still protected):**
+- `Bid-Euchre-steward-author-scratch`
 
 ## Cleanup Rules
 

--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -1,32 +1,36 @@
 #!/bin/bash
-# Canonical steward session bootstrap — 4-window layout.
+# Canonical steward session bootstrap — 5-window layout.
 # Usage: steward-session.sh [session-name]
 #
-# Creates (or attaches to) a tmux session with 4 windows:
+# Creates (or attaches to) a tmux session with 5 windows:
 #
-#   Window 1 — central-ops (4 panes, tiled layout)
-#     .1  orchestrator      -- single intake point
-#     .2  steward-analyst   -- shaping, triage, plan review
-#     .3  ops               -- operator monitoring lane
-#     .4  review            -- independent review lane
+#   Window 1 — central-ops (3 panes, main-vertical layout)
+#     .1  orchestrator      -- single intake point (large left pane)
+#     .2  ops               -- operator monitoring lane
+#     .3  review            -- independent review lane
 #
-#   Window 2 — platform (4 panes, tiled)
+#   Window 2 — analyst (4 panes, tiled)
+#     .1  analyst-a        -- primary analyst lane (shaping, triage)
+#     .2  analyst-b        -- secondary analyst lane
+#     .3  analyst-c        -- overflow analyst lane
+#     .4  analyst-d        -- overflow analyst lane
+#
+#   Window 3 — platform (4 panes, tiled)
 #     .1  author-a        -- primary platform author lane
 #     .2  author-b        -- secondary platform author lane
 #     .3  author-c        -- overflow platform author lane
 #     .4  author-d        -- overflow platform author lane
 #
-#   Window 3 — browser (4 panes, tiled)
+#   Window 4 — browser (4 panes, tiled)
 #     .1  brws-author-a   -- primary browser-game author lane
 #     .2  brws-author-b   -- secondary browser-game author lane
 #     .3  brws-author-c   -- overflow browser-game author lane
 #     .4  brws-author-d   -- overflow browser-game author lane
 #
-#   Window 4 — scratch (4 panes, tiled)
-#     .1  author-scratch  -- exploratory Claude lane
-#     .2  flex-a          -- domain-agnostic overflow lane
-#     .3  flex-b          -- domain-agnostic overflow lane
-#     .4  flex-c          -- domain-agnostic overflow lane
+#   Window 5 — flex (3 panes, tiled)
+#     .1  flex-a          -- domain-agnostic overflow lane
+#     .2  flex-b          -- domain-agnostic overflow lane
+#     .3  flex-c          -- domain-agnostic overflow lane
 #
 # Writes v2 worktree registry metadata for each launched lane.
 # See docs/02_agent/AUTONOMOUS_OPERATOR_WORKFLOW.md for the full model.
@@ -73,13 +77,18 @@ AUTHOR_A="${PARENT_DIR}/${REPO_NAME}-steward-author"
 AUTHOR_B="${PARENT_DIR}/${REPO_NAME}-steward-author-b"
 AUTHOR_C="${PARENT_DIR}/${REPO_NAME}-steward-author-c"
 AUTHOR_D="${PARENT_DIR}/${REPO_NAME}-steward-author-d"
-AUTHOR_SCRATCH="${PARENT_DIR}/${REPO_NAME}-steward-author-scratch"
 
 # Browser-game pool worktrees
 BRWS_A="${PARENT_DIR}/${REPO_NAME}-steward-brws-author-a"
 BRWS_B="${PARENT_DIR}/${REPO_NAME}-steward-brws-author-b"
 BRWS_C="${PARENT_DIR}/${REPO_NAME}-steward-brws-author-c"
 BRWS_D="${PARENT_DIR}/${REPO_NAME}-steward-brws-author-d"
+
+# Analyst pool worktrees (analyst-a reuses existing steward-analyst)
+ANALYST_A="${PARENT_DIR}/${REPO_NAME}-steward-analyst"
+ANALYST_B="${PARENT_DIR}/${REPO_NAME}-steward-analyst-b"
+ANALYST_C="${PARENT_DIR}/${REPO_NAME}-steward-analyst-c"
+ANALYST_D="${PARENT_DIR}/${REPO_NAME}-steward-analyst-d"
 
 # Flex pool worktrees
 FLEX_A="${PARENT_DIR}/${REPO_NAME}-steward-flex-a"
@@ -89,7 +98,6 @@ FLEX_C="${PARENT_DIR}/${REPO_NAME}-steward-flex-c"
 # Control plane
 REVIEW="${PARENT_DIR}/${REPO_NAME}-steward-review"
 OPS="${PARENT_DIR}/${REPO_NAME}-steward-ops"
-ANALYST="${PARENT_DIR}/${REPO_NAME}-steward-analyst"
 MAIN_DIR="$(git -C "$MAIN_DIR" worktree list 2>/dev/null | head -1 | awk '{print $1}')"
 
 # ---------------------------------------------------------------------------
@@ -280,13 +288,18 @@ ensure_worktree "$AUTHOR_A" "codex/steward-author"
 ensure_worktree "$AUTHOR_B" "codex/steward-author-b"
 ensure_worktree "$AUTHOR_C" "codex/steward-author-c"
 ensure_worktree "$AUTHOR_D" "codex/steward-author-d"
-ensure_worktree "$AUTHOR_SCRATCH" "codex/steward-author-scratch"
 
 # Browser-game pool
 ensure_worktree "$BRWS_A" "codex/steward-brws-author-a"
 ensure_worktree "$BRWS_B" "codex/steward-brws-author-b"
 ensure_worktree "$BRWS_C" "codex/steward-brws-author-c"
 ensure_worktree "$BRWS_D" "codex/steward-brws-author-d"
+
+# Analyst pool (detached — shaping lanes, not code-authoring)
+ensure_detached_worktree "$ANALYST_A"
+ensure_detached_worktree "$ANALYST_B"
+ensure_detached_worktree "$ANALYST_C"
+ensure_detached_worktree "$ANALYST_D"
 
 # Flex pool
 ensure_worktree "$FLEX_A" "codex/steward-flex-a"
@@ -296,19 +309,23 @@ ensure_worktree "$FLEX_C" "codex/steward-flex-c"
 # Control plane
 ensure_detached_worktree "$REVIEW"
 ensure_detached_worktree "$OPS"
-ensure_detached_worktree "$ANALYST"
 
 # Write v2 registry metadata for each lane.
 # tmux_window = group name, tmux_pane = 1-based pane index within the window.
 # Pane target format: ${SESSION}:${tmux_window}.${tmux_pane}
 # Indices are 1-based to match tmux pane-base-index=1.
 
-# Central ops  (window: central-ops, panes 1-4, tiled layout)
+# Central ops  (window: central-ops, panes 1-3, main-vertical layout)
 # Note: pane indices are 1-based to match tmux pane-base-index=1.
 write_lane_metadata "orchestrator"   "orchestrator" "$MAIN_DIR"       "--"                              "central-ops" "1" "foreground" "Orchestrator"
-write_lane_metadata "analyst"        "analyst"      "$ANALYST"        "detached"                        "central-ops" "2" "foreground" "Analyst"
-write_lane_metadata "ops"            "ops"          "$OPS"            "detached"                        "central-ops" "3" "foreground" "Ops"
-write_lane_metadata "review"         "review"       "$REVIEW"         "detached"                        "central-ops" "4" "foreground" "Review"
+write_lane_metadata "ops"            "ops"          "$OPS"            "detached"                        "central-ops" "2" "foreground" "Ops"
+write_lane_metadata "review"         "review"       "$REVIEW"         "detached"                        "central-ops" "3" "foreground" "Review"
+
+# Analyst pool  (window: analyst, panes 1-4, tiled)
+write_lane_metadata "analyst-a"      "analyst"      "$ANALYST_A"      "detached"                        "analyst" "1" "background" "Analyst A"
+write_lane_metadata "analyst-b"      "analyst"      "$ANALYST_B"      "detached"                        "analyst" "2" "background" "Analyst B"
+write_lane_metadata "analyst-c"      "analyst"      "$ANALYST_C"      "detached"                        "analyst" "3" "background" "Analyst C"
+write_lane_metadata "analyst-d"      "analyst"      "$ANALYST_D"      "detached"                        "analyst" "4" "background" "Analyst D"
 
 # Platform workers  (window: platform, panes 1-4)
 write_lane_metadata "author-a"       "author"       "$AUTHOR_A"       "codex/steward-author"            "platform" "1" "background" "Author A"
@@ -322,11 +339,10 @@ write_lane_metadata "brws-author-b"  "author"       "$BRWS_B"         "codex/ste
 write_lane_metadata "brws-author-c"  "author"       "$BRWS_C"         "codex/steward-brws-author-c"     "browser" "3" "background" "Brws Author C"
 write_lane_metadata "brws-author-d"  "author"       "$BRWS_D"         "codex/steward-brws-author-d"     "browser" "4" "background" "Brws Author D"
 
-# Scratch / flex  (window: scratch, panes 1-4)
-write_lane_metadata "author-scratch" "scratch"      "$AUTHOR_SCRATCH"  "codex/steward-author-scratch"   "scratch" "1" "background" "Scratch"
-write_lane_metadata "flex-a"         "flex"          "$FLEX_A"          "codex/steward-flex-a"           "scratch" "2" "background" "Flex A"
-write_lane_metadata "flex-b"         "flex"          "$FLEX_B"          "codex/steward-flex-b"           "scratch" "3" "background" "Flex B"
-write_lane_metadata "flex-c"         "flex"          "$FLEX_C"          "codex/steward-flex-c"           "scratch" "4" "background" "Flex C"
+# Flex pool  (window: flex, panes 1-3, tiled)
+write_lane_metadata "flex-a"         "flex"          "$FLEX_A"          "codex/steward-flex-a"           "flex" "1" "background" "Flex A"
+write_lane_metadata "flex-b"         "flex"          "$FLEX_B"          "codex/steward-flex-b"           "flex" "2" "background" "Flex B"
+write_lane_metadata "flex-c"         "flex"          "$FLEX_C"          "codex/steward-flex-c"           "flex" "3" "background" "Flex C"
 
 # ---------------------------------------------------------------------------
 # Orchestrator channel flags (Platform-8a)
@@ -344,11 +360,15 @@ if [ "$STEWARD_TELEGRAM_ENABLED" = "1" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Window + pane creation — 4 windows (central-ops: 4 panes tiled, others: 4 panes tiled)
+# Window + pane creation — 5 windows
+#   central-ops: 3 panes main-vertical
+#   analyst: 4 panes tiled
+#   platform: 4 panes tiled
+#   browser: 4 panes tiled
+#   flex: 3 panes tiled
 # ---------------------------------------------------------------------------
-# All windows use tiled: 4 equal quadrants.
 
-# --- Window 1: central-ops (4 panes, tiled) ---
+# --- Window 1: central-ops (3 panes, main-vertical) ---
 tmux new-session -d -s "$SESSION" -n central-ops -c "$MAIN_DIR" \
     "$CLAUDE_BIN" --name orchestrator --agent steward-orchestrator $ORCH_CHANNEL_FLAGS
 
@@ -360,15 +380,24 @@ if [ -n "$STEWARD_CHANNELS" ]; then
 fi
 tmux set-environment -t "$SESSION" STEWARD_TELEGRAM_ENABLED "$STEWARD_TELEGRAM_ENABLED"
 
-tmux split-window -t "${SESSION}:central-ops" -c "$ANALYST" \
-    "$CLAUDE_BIN" --name analyst --agent steward-analyst
 tmux split-window -t "${SESSION}:central-ops" -c "$OPS" \
     "$CLAUDE_BIN" --name ops --agent steward-ops
 tmux split-window -t "${SESSION}:central-ops" -c "$REVIEW" \
     "$CLAUDE_BIN" --name review --agent steward-review
-tmux select-layout -t "${SESSION}:central-ops" tiled
+tmux select-layout -t "${SESSION}:central-ops" main-vertical
 
-# --- Window 2: platform ---
+# --- Window 2: analyst (4 panes, tiled) ---
+tmux new-window -t "$SESSION" -n analyst -c "$ANALYST_A" \
+    "$CLAUDE_BIN" --name analyst-a --agent steward-analyst
+tmux split-window -t "${SESSION}:analyst" -c "$ANALYST_B" \
+    "$CLAUDE_BIN" --name analyst-b --agent steward-analyst
+tmux split-window -t "${SESSION}:analyst" -c "$ANALYST_C" \
+    "$CLAUDE_BIN" --name analyst-c --agent steward-analyst
+tmux split-window -t "${SESSION}:analyst" -c "$ANALYST_D" \
+    "$CLAUDE_BIN" --name analyst-d --agent steward-analyst
+tmux select-layout -t "${SESSION}:analyst" tiled
+
+# --- Window 3: platform ---
 tmux new-window -t "$SESSION" -n platform -c "$AUTHOR_A" \
     "$CLAUDE_BIN" --name author-a --agent steward-author-a
 tmux split-window -t "${SESSION}:platform" -c "$AUTHOR_B" \
@@ -379,7 +408,7 @@ tmux split-window -t "${SESSION}:platform" -c "$AUTHOR_D" \
     "$CLAUDE_BIN" --name author-d --agent steward-author-d
 tmux select-layout -t "${SESSION}:platform" tiled
 
-# --- Window 3: browser ---
+# --- Window 4: browser ---
 tmux new-window -t "$SESSION" -n browser -c "$BRWS_A" \
     "$CLAUDE_BIN" --name brws-author-a --agent steward-brws-author-a
 tmux split-window -t "${SESSION}:browser" -c "$BRWS_B" \
@@ -390,25 +419,23 @@ tmux split-window -t "${SESSION}:browser" -c "$BRWS_D" \
     "$CLAUDE_BIN" --name brws-author-d --agent steward-brws-author-d
 tmux select-layout -t "${SESSION}:browser" tiled
 
-# --- Window 4: scratch ---
-tmux new-window -t "$SESSION" -n scratch -c "$AUTHOR_SCRATCH" \
-    "$CLAUDE_BIN" --name author-scratch --agent steward-author-scratch
-tmux split-window -t "${SESSION}:scratch" -c "$FLEX_A" \
+# --- Window 5: flex (3 panes, tiled) ---
+tmux new-window -t "$SESSION" -n flex -c "$FLEX_A" \
     "$CLAUDE_BIN" --name flex-a --agent steward-flex-a
-tmux split-window -t "${SESSION}:scratch" -c "$FLEX_B" \
+tmux split-window -t "${SESSION}:flex" -c "$FLEX_B" \
     "$CLAUDE_BIN" --name flex-b --agent steward-flex-b
-tmux split-window -t "${SESSION}:scratch" -c "$FLEX_C" \
+tmux split-window -t "${SESSION}:flex" -c "$FLEX_C" \
     "$CLAUDE_BIN" --name flex-c --agent steward-flex-c
-tmux select-layout -t "${SESSION}:scratch" tiled
+tmux select-layout -t "${SESSION}:flex" tiled
 
 # Auto-launch ops monitoring loop (SP-3-08).
 # Wait briefly for the claude process to initialize, then send the /loop
 # command.  Best-effort — if it fails the ops agent can start it manually.
-# Target: central-ops window, pane 3 (ops lane).
-# Note: pane-base-index=1, so orchestrator=.1, analyst=.2, ops=.3, review=.4.
+# Target: central-ops window, pane 2 (ops lane).
+# Note: pane-base-index=1, so orchestrator=.1, ops=.2, review=.3.
 (
     sleep 10
-    tmux send-keys -t "${SESSION}:central-ops.3" \
+    tmux send-keys -t "${SESSION}:central-ops.2" \
         "/loop 3m uv run python scripts/internal/ops.py monitor" Enter
 ) &
 
@@ -416,10 +443,10 @@ tmux select-layout -t "${SESSION}:scratch" tiled
 # Triggers the review agent's startup behavior: discover recent merges,
 # review diffs, triage findings, then poll every 15 minutes.
 # Best-effort — if it fails the review agent can start it manually.
-# Target: central-ops window, pane 4 (review lane).
+# Target: central-ops window, pane 3 (review lane).
 (
     sleep 15
-    tmux send-keys -t "${SESSION}:central-ops.4" \
+    tmux send-keys -t "${SESSION}:central-ops.3" \
         "Review recently merged PRs and triage findings. Set up a 15m recurring poll." Enter
 ) &
 

--- a/src/bid_euchre/ops/monitor.py
+++ b/src/bid_euchre/ops/monitor.py
@@ -1112,12 +1112,16 @@ _CHECKABLE_LANES: tuple[str, ...] = (
     "author-b",
     "author-c",
     "author-d",
-    "author-scratch",
     # Browser-game pool
     "brws-author-a",
     "brws-author-b",
     "brws-author-c",
     "brws-author-d",
+    # Analyst pool
+    "analyst-a",
+    "analyst-b",
+    "analyst-c",
+    "analyst-d",
     # Flex pool
     "flex-a",
     "flex-b",

--- a/src/bid_euchre/ops/recovery.py
+++ b/src/bid_euchre/ops/recovery.py
@@ -334,6 +334,11 @@ PERSISTENT_LANES: tuple[str, ...] = (
     "brws-author-b",
     "brws-author-c",
     "brws-author-d",
+    # Analyst pool
+    "analyst-a",
+    "analyst-b",
+    "analyst-c",
+    "analyst-d",
     # Flex pool
     "flex-a",
     "flex-b",

--- a/src/bid_euchre/ops/task_queue.py
+++ b/src/bid_euchre/ops/task_queue.py
@@ -56,20 +56,24 @@ VALID_ACK_ACTIONS = frozenset({"approve", "edit", "redirect", "reject"})
 VALID_RESULT_STATUSES = frozenset({"completed", "failed", "blocked"})
 
 # Known author lanes that can receive dispatched work.
-# Platform pool, browser-game pool, and flex lanes.
+# Platform pool, browser-game pool, analyst pool, and flex lanes.
 KNOWN_AUTHOR_LANES = frozenset(
     {
-        # Platform pool (original)
+        # Platform pool
         "author-a",
         "author-b",
         "author-c",
         "author-d",
-        "author-scratch",
         # Browser-game pool
         "brws-author-a",
         "brws-author-b",
         "brws-author-c",
         "brws-author-d",
+        # Analyst pool (shaping, triage, plan review, investigation)
+        "analyst-a",
+        "analyst-b",
+        "analyst-c",
+        "analyst-d",
         # Flex pool (domain-agnostic overflow)
         "flex-a",
         "flex-b",

--- a/src/bid_euchre/ops/token_economy.py
+++ b/src/bid_euchre/ops/token_economy.py
@@ -523,12 +523,16 @@ _WORKTREE_TO_LANE: dict[str, str] = {
     "Bid-Euchre-steward-author-b": "author-b",
     "Bid-Euchre-steward-author-c": "author-c",
     "Bid-Euchre-steward-author-d": "author-d",
-    "Bid-Euchre-steward-author-scratch": "author-scratch",
     # Browser-game pool
     "Bid-Euchre-steward-brws-author-a": "brws-author-a",
     "Bid-Euchre-steward-brws-author-b": "brws-author-b",
     "Bid-Euchre-steward-brws-author-c": "brws-author-c",
     "Bid-Euchre-steward-brws-author-d": "brws-author-d",
+    # Analyst pool (analyst-a reuses the original steward-analyst worktree)
+    "Bid-Euchre-steward-analyst": "analyst-a",
+    "Bid-Euchre-steward-analyst-b": "analyst-b",
+    "Bid-Euchre-steward-analyst-c": "analyst-c",
+    "Bid-Euchre-steward-analyst-d": "analyst-d",
     # Flex pool
     "Bid-Euchre-steward-flex-a": "flex-a",
     "Bid-Euchre-steward-flex-b": "flex-b",
@@ -536,12 +540,15 @@ _WORKTREE_TO_LANE: dict[str, str] = {
     # Control plane
     "Bid-Euchre-steward-review": "review",
     "Bid-Euchre-steward-ops": "ops",
+    # Legacy (retired from active layout, kept for attribution)
+    "Bid-Euchre-steward-author-scratch": "author-scratch",
 }
 
 #: Worktree class categorization by lane prefix.
 _LANE_POOL: dict[str, str] = {
     "author-": "platform",
     "brws-author-": "browser-game",
+    "analyst-": "analyst",
     "flex-": "flex",
     "review": "control",
     "ops": "control",

--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -49,9 +49,9 @@ logger = logging.getLogger("ops.worker_pool")
 # ---------------------------------------------------------------------------
 
 #: Maximum number of simultaneously active (non-idle) author lanes.
-#: Matches the dual-domain layout in steward-session.sh:
-#: 4 platform + 4 browser-game + 1 scratch + 3 flex = 12 worker lanes.
-MAX_ACTIVE_AUTHORS: int = 12
+#: Matches the 5-window layout in steward-session.sh:
+#: 4 platform + 4 browser-game + 4 analyst + 3 flex = 15 worker lanes.
+MAX_ACTIVE_AUTHORS: int = 15
 
 #: Idle threshold (minutes) before a lane is eligible for parking.
 IDLE_PARK_MINUTES: int = 15
@@ -69,17 +69,21 @@ POOL_STATUSES: frozenset[str] = frozenset({"active", "idle", "parked", "retired"
 #: Lanes with ``None`` are "flex" — available to any domain when same-domain
 #: lanes are exhausted.
 LANE_DOMAINS: dict[str, str | None] = {
-    # Platform pool (original)
+    # Platform pool
     "author-a": "platform",
     "author-b": "platform",
     "author-c": "platform",
     "author-d": "platform",
-    "author-scratch": None,  # flex
     # Browser-game pool
     "brws-author-a": "browser-game",
     "brws-author-b": "browser-game",
     "brws-author-c": "browser-game",
     "brws-author-d": "browser-game",
+    # Analyst pool (flex — accepts any domain)
+    "analyst-a": None,
+    "analyst-b": None,
+    "analyst-c": None,
+    "analyst-d": None,
     # Flex pool (domain-agnostic overflow)
     "flex-a": None,
     "flex-b": None,
@@ -361,10 +365,18 @@ def _create_tmux_window(
 def _resolve_agent_name(lane_id: str) -> str:
     """Map lane_id to the canonical agent profile name.
 
+    Most lanes follow the pattern ``steward-{lane_id}``.  Analyst lanes are
+    the exception — all analyst-a through analyst-d share a single agent
+    definition (``steward-analyst``).
+
     Examples:
-        "author-a"       -> "steward-author-a"
-        "author-scratch" -> "steward-author-scratch"
+        "author-a"   -> "steward-author-a"
+        "analyst-a"  -> "steward-analyst"
+        "analyst-d"  -> "steward-analyst"
+        "flex-a"     -> "steward-flex-a"
     """
+    if lane_id.startswith("analyst-"):
+        return "steward-analyst"
     return f"steward-{lane_id}"
 
 

--- a/src/bid_euchre/ops/worktrees.py
+++ b/src/bid_euchre/ops/worktrees.py
@@ -29,12 +29,16 @@ PROTECTED_WORKTREE_NAMES = frozenset(
         "Bid-Euchre-steward-author-b",
         "Bid-Euchre-steward-author-c",
         "Bid-Euchre-steward-author-d",
-        "Bid-Euchre-steward-author-scratch",
         # Browser-game pool
         "Bid-Euchre-steward-brws-author-a",
         "Bid-Euchre-steward-brws-author-b",
         "Bid-Euchre-steward-brws-author-c",
         "Bid-Euchre-steward-brws-author-d",
+        # Analyst pool (analyst-a reuses the original steward-analyst worktree)
+        "Bid-Euchre-steward-analyst",
+        "Bid-Euchre-steward-analyst-b",
+        "Bid-Euchre-steward-analyst-c",
+        "Bid-Euchre-steward-analyst-d",
         # Flex pool
         "Bid-Euchre-steward-flex-a",
         "Bid-Euchre-steward-flex-b",
@@ -42,6 +46,8 @@ PROTECTED_WORKTREE_NAMES = frozenset(
         # Control plane
         "Bid-Euchre-steward-review",
         "Bid-Euchre-steward-ops",
+        # Legacy (retired from active layout, still protected)
+        "Bid-Euchre-steward-author-scratch",
     }
 )
 
@@ -890,16 +896,22 @@ _STEWARD_DIR_TO_LANE: dict[str, str] = {
     "Bid-Euchre-steward-author-b": "author-b",
     "Bid-Euchre-steward-author-c": "author-c",
     "Bid-Euchre-steward-author-d": "author-d",
-    "Bid-Euchre-steward-author-scratch": "author-scratch",
     "Bid-Euchre-steward-brws-author-a": "brws-author-a",
     "Bid-Euchre-steward-brws-author-b": "brws-author-b",
     "Bid-Euchre-steward-brws-author-c": "brws-author-c",
     "Bid-Euchre-steward-brws-author-d": "brws-author-d",
+    # Analyst pool (analyst-a reuses the original steward-analyst worktree)
+    "Bid-Euchre-steward-analyst": "analyst-a",
+    "Bid-Euchre-steward-analyst-b": "analyst-b",
+    "Bid-Euchre-steward-analyst-c": "analyst-c",
+    "Bid-Euchre-steward-analyst-d": "analyst-d",
     "Bid-Euchre-steward-flex-a": "flex-a",
     "Bid-Euchre-steward-flex-b": "flex-b",
     "Bid-Euchre-steward-flex-c": "flex-c",
     "Bid-Euchre-steward-review": "review",
     "Bid-Euchre-steward-ops": "ops",
+    # Legacy (retired from active layout, kept for derivation)
+    "Bid-Euchre-steward-author-scratch": "author-scratch",
 }
 
 
@@ -940,12 +952,14 @@ def derive_lane_class(lane_id: str) -> str:
         lane_id: Lane identifier (e.g., ``"author-b"``, ``"ops"``).
 
     Returns:
-        One of ``"ops"``, ``"review"``, ``"scratch"``, ``"author"``.
+        One of ``"ops"``, ``"review"``, ``"analyst"``, ``"scratch"``, ``"author"``.
     """
     if lane_id == "ops":
         return "ops"
     if lane_id == "review":
         return "review"
+    if lane_id.startswith("analyst-"):
+        return "analyst"
     if lane_id.endswith("-scratch"):
         return "scratch"
     # author-*, brws-author-*, flex-* are all author-class lanes.

--- a/tests/unit/test_ops_token_economy.py
+++ b/tests/unit/test_ops_token_economy.py
@@ -472,10 +472,22 @@ class TestInferLaneFromPath:
         assert lane == "author-b"
         assert wt == "Bid-Euchre-steward-author-b"
 
-    def test_platform_author_scratch(self) -> None:
+    def test_legacy_author_scratch(self) -> None:
+        """Legacy author-scratch worktree is still detected for attribution."""
         path = "/Users/foo/Bid-Euchre-meta/Bid-Euchre-steward-author-scratch"
         lane, wt = infer_lane_from_path(path)
         assert lane == "author-scratch"
+
+    def test_analyst_pool(self) -> None:
+        path = "/Users/foo/Bid-Euchre-meta/Bid-Euchre-steward-analyst"
+        lane, wt = infer_lane_from_path(path)
+        assert lane == "analyst-a"
+        assert wt == "Bid-Euchre-steward-analyst"
+
+    def test_analyst_b(self) -> None:
+        path = "/Users/foo/Bid-Euchre-meta/Bid-Euchre-steward-analyst-b"
+        lane, wt = infer_lane_from_path(path)
+        assert lane == "analyst-b"
 
     def test_browser_game_pool(self) -> None:
         path = "/Users/foo/meta/Bid-Euchre-steward-brws-author-a"
@@ -528,7 +540,7 @@ class TestInferLaneFromPath:
         assert wt == "Bid-Euchre-steward-author"
 
     def test_all_known_lanes_covered(self) -> None:
-        """Every known author lane maps from at least one worktree path."""
+        """Every known lane maps from at least one worktree path."""
         from bid_euchre.ops.token_economy import _WORKTREE_TO_LANE
 
         expected_lanes = {
@@ -536,16 +548,21 @@ class TestInferLaneFromPath:
             "author-b",
             "author-c",
             "author-d",
-            "author-scratch",
             "brws-author-a",
             "brws-author-b",
             "brws-author-c",
             "brws-author-d",
+            "analyst-a",
+            "analyst-b",
+            "analyst-c",
+            "analyst-d",
             "flex-a",
             "flex-b",
             "flex-c",
             "review",
             "ops",
+            # Legacy (retired but still in mapping for attribution)
+            "author-scratch",
         }
         assert set(_WORKTREE_TO_LANE.values()) == expected_lanes
 

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -134,7 +134,7 @@ class TestConstants:
     """Test module-level constants."""
 
     def test_max_active_authors(self) -> None:
-        assert MAX_ACTIVE_AUTHORS == 12
+        assert MAX_ACTIVE_AUTHORS == 15
 
     def test_idle_park_minutes(self) -> None:
         assert IDLE_PARK_MINUTES == 15
@@ -152,10 +152,10 @@ class TestConstants:
         lanes = _managed_lanes()
         assert "author-a" in lanes
         assert "author-b" in lanes
-        assert "author-scratch" in lanes
+        assert "analyst-a" in lanes
         assert "brws-author-a" in lanes
         assert "flex-a" in lanes
-        assert len(lanes) == 12
+        assert len(lanes) == 15
 
 
 class TestResolveAgentName:
@@ -164,8 +164,12 @@ class TestResolveAgentName:
     def test_author_a(self) -> None:
         assert _resolve_agent_name("author-a") == "steward-author-a"
 
-    def test_author_scratch(self) -> None:
-        assert _resolve_agent_name("author-scratch") == "steward-author-scratch"
+    def test_analyst_uses_shared_agent(self) -> None:
+        """All analyst lanes share the steward-analyst agent definition."""
+        assert _resolve_agent_name("analyst-a") == "steward-analyst"
+        assert _resolve_agent_name("analyst-b") == "steward-analyst"
+        assert _resolve_agent_name("analyst-c") == "steward-analyst"
+        assert _resolve_agent_name("analyst-d") == "steward-analyst"
 
     def test_author_b(self) -> None:
         assert _resolve_agent_name("author-b") == "steward-author-b"
@@ -603,17 +607,20 @@ class TestSelectWorker:
 
     def test_no_capacity(self) -> None:
         """At MAX_ACTIVE_AUTHORS, returns None."""
-        # Create 12 active workers to fill the dual-domain layout capacity
+        # Create 15 active workers to fill the full layout capacity
         lane_ids = [
             "author-a",
             "author-b",
             "author-c",
             "author-d",
-            "author-scratch",
             "brws-author-a",
             "brws-author-b",
             "brws-author-c",
             "brws-author-d",
+            "analyst-a",
+            "analyst-b",
+            "analyst-c",
+            "analyst-d",
             "flex-a",
             "flex-b",
             "flex-c",
@@ -676,7 +683,7 @@ class TestDomainRouting:
     def test_get_lane_domain(self) -> None:
         """get_lane_domain returns configured domain or None."""
         assert get_lane_domain("author-a") == "platform"
-        assert get_lane_domain("author-scratch") is None
+        assert get_lane_domain("analyst-a") is None
         assert get_lane_domain("brws-author-a") == "browser-game"
         assert get_lane_domain("flex-a") is None
         assert get_lane_domain("unknown-lane") is None
@@ -691,7 +698,7 @@ class TestDomainRouting:
         """Same-domain lane selected over flex lane."""
         pool = _make_pool(
             [
-                _make_worker("author-scratch", "idle", domain=None),  # flex
+                _make_worker("analyst-a", "idle", domain=None),  # flex
                 _make_worker("author-a", "idle", domain="platform"),
             ]
         )
@@ -704,10 +711,10 @@ class TestDomainRouting:
                 _make_worker(
                     "author-a", "active", domain="platform", current_task_id="t1"
                 ),
-                _make_worker("author-scratch", "idle", domain=None),  # flex
+                _make_worker("analyst-a", "idle", domain=None),  # flex
             ]
         )
-        assert select_worker(pool, domain="platform") == "author-scratch"
+        assert select_worker(pool, domain="platform") == "analyst-a"
 
     def test_cross_domain_rejected_by_default(self) -> None:
         """Cross-domain lanes not selected without allow_cross_domain."""
@@ -754,11 +761,11 @@ class TestDomainRouting:
         pool = _make_pool(
             [
                 _make_worker("author-a", "parked", domain="platform"),
-                _make_worker("author-scratch", "idle", domain=None),
+                _make_worker("analyst-a", "idle", domain=None),
             ]
         )
         # Idle (any domain-compatible) should beat parked
-        assert select_worker(pool, domain="platform") == "author-scratch"
+        assert select_worker(pool, domain="platform") == "analyst-a"
 
     def test_preferred_lane_domain_incompatible(self) -> None:
         """Preferred lane skipped if domain-incompatible."""
@@ -788,43 +795,50 @@ class TestDomainRouting:
         pool = _make_pool(
             [
                 _make_worker("author-a", "idle", domain="platform"),
-                _make_worker("author-scratch", "idle", domain=None),
+                _make_worker("analyst-a", "idle", domain=None),
             ]
         )
-        result = select_worker(
-            pool, preferred_lane="author-scratch", domain="browser-game"
-        )
-        assert result == "author-scratch"
+        result = select_worker(pool, preferred_lane="analyst-a", domain="browser-game")
+        assert result == "analyst-a"
 
     def test_worker_state_domain_field(self) -> None:
         """WorkerState has domain field."""
         w = _make_worker("author-a", "idle", domain="platform")
         assert w.domain == "platform"
-        w_flex = _make_worker("author-scratch", "idle", domain=None)
+        w_flex = _make_worker("analyst-a", "idle", domain=None)
         assert w_flex.domain is None
 
 
 class TestLaneExpansion:
-    """Test expanded lane identity (SP-3-05 PR 2)."""
+    """Test expanded lane identity."""
 
-    def test_known_lanes_include_browser_and_flex(self) -> None:
+    def test_known_lanes_include_all_pools(self) -> None:
         from bid_euchre.ops.task_queue import KNOWN_AUTHOR_LANES
 
         # Browser-game pool
         assert "brws-author-a" in KNOWN_AUTHOR_LANES
         assert "brws-author-d" in KNOWN_AUTHOR_LANES
+        # Analyst pool
+        assert "analyst-a" in KNOWN_AUTHOR_LANES
+        assert "analyst-d" in KNOWN_AUTHOR_LANES
         # Flex pool
         assert "flex-a" in KNOWN_AUTHOR_LANES
         assert "flex-c" in KNOWN_AUTHOR_LANES
-        # Original platform pool still present
+        # Platform pool
         assert "author-a" in KNOWN_AUTHOR_LANES
-        assert "author-scratch" in KNOWN_AUTHOR_LANES
+        assert "author-d" in KNOWN_AUTHOR_LANES
 
     def test_browser_lanes_have_browser_game_domain(self) -> None:
         assert get_lane_domain("brws-author-a") == "browser-game"
         assert get_lane_domain("brws-author-b") == "browser-game"
         assert get_lane_domain("brws-author-c") == "browser-game"
         assert get_lane_domain("brws-author-d") == "browser-game"
+
+    def test_analyst_lanes_have_none_domain(self) -> None:
+        assert get_lane_domain("analyst-a") is None
+        assert get_lane_domain("analyst-b") is None
+        assert get_lane_domain("analyst-c") is None
+        assert get_lane_domain("analyst-d") is None
 
     def test_flex_lanes_have_none_domain(self) -> None:
         assert get_lane_domain("flex-a") is None

--- a/tests/unit/test_ops_worktrees.py
+++ b/tests/unit/test_ops_worktrees.py
@@ -1273,16 +1273,21 @@ class TestDeriveLaneId:
             ("Bid-Euchre-steward-author-b", "author-b"),
             ("Bid-Euchre-steward-author-c", "author-c"),
             ("Bid-Euchre-steward-author-d", "author-d"),
-            ("Bid-Euchre-steward-author-scratch", "author-scratch"),
             ("Bid-Euchre-steward-brws-author-a", "brws-author-a"),
             ("Bid-Euchre-steward-brws-author-b", "brws-author-b"),
             ("Bid-Euchre-steward-brws-author-c", "brws-author-c"),
             ("Bid-Euchre-steward-brws-author-d", "brws-author-d"),
+            ("Bid-Euchre-steward-analyst", "analyst-a"),
+            ("Bid-Euchre-steward-analyst-b", "analyst-b"),
+            ("Bid-Euchre-steward-analyst-c", "analyst-c"),
+            ("Bid-Euchre-steward-analyst-d", "analyst-d"),
             ("Bid-Euchre-steward-flex-a", "flex-a"),
             ("Bid-Euchre-steward-flex-b", "flex-b"),
             ("Bid-Euchre-steward-flex-c", "flex-c"),
             ("Bid-Euchre-steward-review", "review"),
             ("Bid-Euchre-steward-ops", "ops"),
+            # Legacy (retired but still in mapping)
+            ("Bid-Euchre-steward-author-scratch", "author-scratch"),
         ],
     )
     def test_known_steward_lanes(self, dir_name: str, expected: str) -> None:
@@ -1310,6 +1315,8 @@ class TestDeriveLaneClass:
         [
             ("ops", "ops"),
             ("review", "review"),
+            ("analyst-a", "analyst"),
+            ("analyst-d", "analyst"),
             ("author-scratch", "scratch"),
             ("author-a", "author"),
             ("author-b", "author"),
@@ -1334,6 +1341,8 @@ class TestDeriveVisibility:
             "author-b",
             "brws-author-a",
             "flex-a",
+            "analyst-a",
+            "analyst-d",
             "author-scratch",
         ):
             assert derive_visibility(lane_id) == "background"

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -278,19 +278,23 @@ class TestStewardSessionScript:
 
 
 class TestWindowLayout:
-    """Validate the 4-window layout (all windows: 4 panes tiled)."""
+    """Validate the 5-window layout."""
 
-    EXPECTED_WINDOWS = ["central-ops", "platform", "browser", "scratch"]
+    EXPECTED_WINDOWS = ["central-ops", "analyst", "platform", "browser", "flex"]
 
-    # All windows use 4 tiled panes
-    TILED_WINDOWS = ["central-ops", "platform", "browser", "scratch"]
+    # Windows that use 4 tiled panes
+    TILED_4_WINDOWS = ["analyst", "platform", "browser"]
 
     EXPECTED_LANES = [
-        # Central ops (4 panes)
+        # Central ops (3 panes)
         "orchestrator",
-        "analyst",
         "ops",
         "review",
+        # Analyst pool (4 panes)
+        "analyst-a",
+        "analyst-b",
+        "analyst-c",
+        "analyst-d",
         # Platform workers
         "author-a",
         "author-b",
@@ -301,8 +305,7 @@ class TestWindowLayout:
         "brws-author-b",
         "brws-author-c",
         "brws-author-d",
-        # Scratch / flex
-        "author-scratch",
+        # Flex pool
         "flex-a",
         "flex-b",
         "flex-c",
@@ -310,7 +313,8 @@ class TestWindowLayout:
 
     # Lanes per window, in pane creation order (pane 1 = first, 1-based)
     WINDOW_PANES = {
-        "central-ops": ["orchestrator", "analyst", "ops", "review"],
+        "central-ops": ["orchestrator", "ops", "review"],
+        "analyst": ["analyst-a", "analyst-b", "analyst-c", "analyst-d"],
         "platform": ["author-a", "author-b", "author-c", "author-d"],
         "browser": [
             "brws-author-a",
@@ -318,7 +322,7 @@ class TestWindowLayout:
             "brws-author-c",
             "brws-author-d",
         ],
-        "scratch": ["author-scratch", "flex-a", "flex-b", "flex-c"],
+        "flex": ["flex-a", "flex-b", "flex-c"],
     }
 
     def test_no_dashboard_window(self) -> None:
@@ -346,8 +350,28 @@ class TestWindowLayout:
             "issues=" not in content
         ), "stale 'issues=' reference in pane-index comment"
 
-    def test_four_windows_created(self) -> None:
-        """Exactly 4 tmux windows must be created (1 new-session + 3 new-window)."""
+    def test_no_scratch_window(self) -> None:
+        """The scratch window must not exist (retired in analyst pool restructure)."""
+        content = STEWARD_SCRIPT.read_text()
+        # No scratch window creation
+        assert "-n scratch" not in content, "scratch window must be retired"
+
+    def test_no_author_scratch_lane(self) -> None:
+        """The author-scratch lane must not be launched (retired)."""
+        content = STEWARD_SCRIPT.read_text()
+        assert (
+            "--name author-scratch" not in content
+        ), "author-scratch lane must not be launched"
+        # No metadata entry for author-scratch
+        metadata_lines = [
+            line
+            for line in content.split("\n")
+            if line.strip().startswith('write_lane_metadata "author-scratch"')
+        ]
+        assert len(metadata_lines) == 0, "author-scratch metadata must be removed"
+
+    def test_five_windows_created(self) -> None:
+        """Exactly 5 tmux windows must be created (1 new-session + 4 new-window)."""
         content = STEWARD_SCRIPT.read_text()
         lines = content.split("\n")
         window_cmds = [
@@ -357,32 +381,62 @@ class TestWindowLayout:
             and ("new-session" in line or "new-window" in line)
         ]
         assert (
-            len(window_cmds) == 4
-        ), f"Expected 4 window creation commands, found {len(window_cmds)}"
+            len(window_cmds) == 5
+        ), f"Expected 5 window creation commands, found {len(window_cmds)}"
         for window_name in self.EXPECTED_WINDOWS:
             assert (
                 f"-n {window_name}" in content
             ), f"Expected window named '{window_name}'"
 
-    def test_central_ops_has_4_panes(self) -> None:
-        """central-ops must have 3 split-window commands (for 4 panes total)."""
+    def test_central_ops_has_3_panes(self) -> None:
+        """central-ops must have 2 split-window commands (for 3 panes total)."""
         content = STEWARD_SCRIPT.read_text()
         split_count = content.count('split-window -t "${SESSION}:central-ops"')
         assert (
-            split_count == 3
-        ), f"central-ops must have 3 split-window commands, found {split_count}"
+            split_count == 2
+        ), f"central-ops must have 2 split-window commands, found {split_count}"
 
-    def test_central_ops_tiled(self) -> None:
-        """central-ops must use tiled layout (4 equal quadrants)."""
+    def test_central_ops_main_vertical(self) -> None:
+        """central-ops must use main-vertical layout (orchestrator gets big left pane)."""
         content = STEWARD_SCRIPT.read_text()
         assert (
-            'select-layout -t "${SESSION}:central-ops" tiled' in content
-        ), "central-ops must use tiled layout"
+            'select-layout -t "${SESSION}:central-ops" main-vertical' in content
+        ), "central-ops must use main-vertical layout"
+
+    def test_analyst_window_has_4_panes(self) -> None:
+        """analyst window must have 3 split-window commands (for 4 panes total)."""
+        content = STEWARD_SCRIPT.read_text()
+        split_count = content.count('split-window -t "${SESSION}:analyst"')
+        assert (
+            split_count == 3
+        ), f"analyst window must have 3 split-window commands, found {split_count}"
+
+    def test_analyst_window_tiled(self) -> None:
+        """analyst window must use tiled layout."""
+        content = STEWARD_SCRIPT.read_text()
+        assert (
+            'select-layout -t "${SESSION}:analyst" tiled' in content
+        ), "analyst window must use tiled layout"
+
+    def test_analyst_lanes_use_analyst_agent(self) -> None:
+        """All analyst lanes must use the steward-analyst agent definition."""
+        content = STEWARD_SCRIPT.read_text()
+        for lane in ["analyst-a", "analyst-b", "analyst-c", "analyst-d"]:
+            assert (
+                f"--name {lane}" in content
+            ), f"Analyst lane '{lane}' must be launched"
+            # Each analyst lane launch line should reference steward-analyst agent
+            lines = content.split("\n")
+            for line in lines:
+                if f"--name {lane}" in line:
+                    assert (
+                        "--agent steward-analyst" in line
+                    ), f"Analyst lane '{lane}' must use --agent steward-analyst"
 
     def test_worker_windows_have_4_panes(self) -> None:
-        """Each worker window must have 3 split-window commands (for 4 panes)."""
+        """Each 4-pane worker window must have 3 split-window commands."""
         content = STEWARD_SCRIPT.read_text()
-        for window_name in self.TILED_WINDOWS:
+        for window_name in self.TILED_4_WINDOWS:
             split_count = content.count(f'split-window -t "${{SESSION}}:{window_name}"')
             assert split_count == 3, (
                 f"Window '{window_name}' must have 3 split-window commands, "
@@ -390,15 +444,30 @@ class TestWindowLayout:
             )
 
     def test_worker_windows_tiled(self) -> None:
-        """Worker windows must use tiled layout."""
+        """4-pane worker windows must use tiled layout."""
         content = STEWARD_SCRIPT.read_text()
-        for window_name in self.TILED_WINDOWS:
+        for window_name in self.TILED_4_WINDOWS:
             assert (
                 f'select-layout -t "${{SESSION}}:{window_name}" tiled' in content
             ), f"Window '{window_name}' must have select-layout tiled"
 
+    def test_flex_window_has_3_panes(self) -> None:
+        """flex window must have 2 split-window commands (for 3 panes total)."""
+        content = STEWARD_SCRIPT.read_text()
+        split_count = content.count('split-window -t "${SESSION}:flex"')
+        assert (
+            split_count == 2
+        ), f"flex window must have 2 split-window commands, found {split_count}"
+
+    def test_flex_window_tiled(self) -> None:
+        """flex window must use tiled layout."""
+        content = STEWARD_SCRIPT.read_text()
+        assert (
+            'select-layout -t "${SESSION}:flex" tiled' in content
+        ), "flex window must use tiled layout"
+
     def test_all_lanes_launched(self) -> None:
-        """All 16 lanes must appear in new-session, new-window, or split-window."""
+        """All 19 lanes must appear in new-session, new-window, or split-window."""
         content = STEWARD_SCRIPT.read_text()
         for lane in self.EXPECTED_LANES:
             assert (
@@ -415,24 +484,29 @@ class TestWindowLayout:
             if line.strip().startswith('write_lane_metadata "')
         ]
 
-    def test_metadata_pane_indices(self) -> None:
-        """All lanes must have valid 1-based pane indices in their metadata.
-
-        Pane indices are 1-based to match tmux pane-base-index=1.
-        """
+    def test_metadata_count(self) -> None:
+        """Must have exactly one metadata entry per lane."""
         metadata_lines = self._metadata_invocation_lines()
         assert len(metadata_lines) == len(self.EXPECTED_LANES), (
             f"Expected {len(self.EXPECTED_LANES)} write_lane_metadata calls, "
             f"found {len(metadata_lines)}"
         )
+
+    def test_metadata_pane_indices(self) -> None:
+        """All lanes must have valid pane indices in their metadata.
+
+        Pane indices are 1-based to match tmux pane-base-index=1.
+        3-pane windows use indices 1-3; 4-pane windows use 1-4.
+        """
+        metadata_lines = self._metadata_invocation_lines()
         for line in metadata_lines:
             has_pane_idx = any(f'"{i}"' in line for i in range(1, 5))
             assert (
                 has_pane_idx
-            ), f"Lane metadata must have a 1-based pane index (1-4): {line.strip()}"
+            ), f"Lane metadata must have a 1-based pane index: {line.strip()}"
 
     def test_metadata_window_names(self) -> None:
-        """All metadata must reference one of the 4 group window names."""
+        """All metadata must reference one of the 5 window names."""
         metadata_lines = self._metadata_invocation_lines()
         for line in metadata_lines:
             has_window = any(f'"{w}"' in line for w in self.EXPECTED_WINDOWS)
@@ -443,7 +517,7 @@ class TestWindowLayout:
     def test_central_ops_foreground(self) -> None:
         """Central ops lanes must have foreground visibility."""
         metadata_lines = self._metadata_invocation_lines()
-        central_ops_lanes = {"orchestrator", "analyst", "ops", "review"}
+        central_ops_lanes = {"orchestrator", "ops", "review"}
         for line in metadata_lines:
             for lane in central_ops_lanes:
                 if f'"{lane}"' in line and line.index(f'"{lane}"') < 30:
@@ -452,9 +526,13 @@ class TestWindowLayout:
                     ), f"Central ops lane must be foreground: {line.strip()}"
 
     def test_worker_lanes_background(self) -> None:
-        """Worker lanes must have background visibility."""
+        """Worker and analyst lanes must have background visibility."""
         metadata_lines = self._metadata_invocation_lines()
         worker_lanes = {
+            "analyst-a",
+            "analyst-b",
+            "analyst-c",
+            "analyst-d",
             "author-a",
             "author-b",
             "author-c",
@@ -463,7 +541,6 @@ class TestWindowLayout:
             "brws-author-b",
             "brws-author-c",
             "brws-author-d",
-            "author-scratch",
             "flex-a",
             "flex-b",
             "flex-c",
@@ -476,20 +553,20 @@ class TestWindowLayout:
                     ), f"Worker lane must be background: {line.strip()}"
 
     def test_ops_monitoring_targets_correct_pane(self) -> None:
-        """The ops monitoring loop must target central-ops.3 (ops pane).
+        """The ops monitoring loop must target central-ops.2 (ops pane).
 
-        With pane-base-index=1: orchestrator=.1, analyst=.2, ops=.3, review=.4.
+        With pane-base-index=1: orchestrator=.1, ops=.2, review=.3.
         """
         content = STEWARD_SCRIPT.read_text()
-        assert "central-ops.3" in content, "Ops monitoring must target central-ops.3"
+        assert "central-ops.2" in content, "Ops monitoring must target central-ops.2"
 
     def test_review_loop_targets_correct_pane(self) -> None:
-        """The merged-PR review loop must target central-ops.4 (review pane).
+        """The merged-PR review loop must target central-ops.3 (review pane).
 
-        With pane-base-index=1: orchestrator=.1, analyst=.2, ops=.3, review=.4.
+        With pane-base-index=1: orchestrator=.1, ops=.2, review=.3.
         """
         content = STEWARD_SCRIPT.read_text()
-        assert "central-ops.4" in content, "Review loop must target central-ops.4"
+        assert "central-ops.3" in content, "Review loop must target central-ops.3"
 
     def test_review_pane_sends_natural_language_prompt(self) -> None:
         """The review pane auto-launch must send a natural-language prompt,
@@ -543,7 +620,7 @@ class TestWindowLayout:
         ), f"Ops metadata must use 'detached' branch: {line.strip()}"
 
     def test_ensure_detached_worktree_used_for_control_plane(self) -> None:
-        """Review, ops, and analyst worktrees must use ensure_detached_worktree."""
+        """Review and ops worktrees must use ensure_detached_worktree."""
         content = STEWARD_SCRIPT.read_text()
         assert (
             'ensure_detached_worktree "$REVIEW"' in content
@@ -551,9 +628,14 @@ class TestWindowLayout:
         assert (
             'ensure_detached_worktree "$OPS"' in content
         ), "Ops worktree must use ensure_detached_worktree"
-        assert (
-            'ensure_detached_worktree "$ANALYST"' in content
-        ), "Analyst worktree must use ensure_detached_worktree"
+
+    def test_ensure_detached_worktree_used_for_analysts(self) -> None:
+        """All analyst worktrees must use ensure_detached_worktree."""
+        content = STEWARD_SCRIPT.read_text()
+        for var in ["$ANALYST_A", "$ANALYST_B", "$ANALYST_C", "$ANALYST_D"]:
+            assert (
+                f'ensure_detached_worktree "{var}"' in content
+            ), f"Analyst worktree {var} must use ensure_detached_worktree"
 
     def test_browser_game_worktree_paths(self) -> None:
         """Script must define BRWS_A through BRWS_D worktree paths."""
@@ -566,6 +648,12 @@ class TestWindowLayout:
         content = STEWARD_SCRIPT.read_text()
         for var in ["FLEX_A", "FLEX_B", "FLEX_C"]:
             assert var in content, f"Missing worktree path variable: {var}"
+
+    def test_analyst_worktree_paths(self) -> None:
+        """Script must define ANALYST_A through ANALYST_D worktree paths."""
+        content = STEWARD_SCRIPT.read_text()
+        for var in ["ANALYST_A", "ANALYST_B", "ANALYST_C", "ANALYST_D"]:
+            assert f'{var}="' in content, f"Missing worktree path variable: {var}"
 
 
 class TestTelegramChannelConfig:


### PR DESCRIPTION
## Summary

- Restructure steward session from 4 windows to 5: central-ops (3 panes, main-vertical), analyst (4 panes, tiled), platform (4 tiled), browser (4 tiled), flex (3 panes, tiled)
- Register analyst-a through analyst-d lanes across all lane registries (task_queue, worker_pool, recovery, worktrees, token_economy, monitor)
- Retire scratch window and author-scratch from active layout; worktree remains protected as legacy

## Why

Issue #1769: The single analyst pane in central-ops became a bottleneck — one shaping task consumed 90K+ tokens while other shaping-eligible work waited. A dedicated analyst pool enables parallel shaping, triage, and plan review.

## Changes

| File | Change |
|------|--------|
| `.claude/tmux/steward-session.sh` | 5-window layout: central-ops (3-pane main-vertical), new analyst window (4-pane tiled), flex window (3-pane tiled), retire scratch |
| `src/bid_euchre/ops/task_queue.py` | Add analyst-a through analyst-d to KNOWN_AUTHOR_LANES, remove author-scratch |
| `src/bid_euchre/ops/worker_pool.py` | Add analyst lanes to LANE_DOMAINS (flex domain), fix `_resolve_agent_name` for shared steward-analyst agent, update MAX_ACTIVE_AUTHORS 12→15 |
| `src/bid_euchre/ops/recovery.py` | Add analyst lanes to PERSISTENT_LANES |
| `src/bid_euchre/ops/worktrees.py` | Add analyst worktrees to PROTECTED_WORKTREE_NAMES and _STEWARD_DIR_TO_LANE, add analyst lane class |
| `src/bid_euchre/ops/token_economy.py` | Add analyst worktree-to-lane mappings and analyst pool category |
| `src/bid_euchre/ops/monitor.py` | Add analyst lanes to _CHECKABLE_LANES |
| `.claude/rules/75_worktree_protection.md` | Add analyst pool section, move author-scratch to legacy |
| `tests/unit/test_steward_session.py` | Full rewrite for 5-window, 19-lane layout |
| `tests/unit/test_ops_worker_pool.py` | Update lane counts (12→15), replace author-scratch with analyst-a in routing tests |
| `tests/unit/test_ops_worktrees.py` | Add analyst lane derivation and visibility tests |
| `tests/unit/test_ops_token_economy.py` | Add analyst attribution tests |

## Key Design Decisions

1. **analyst-a reuses existing steward-analyst worktree** — no worktree rename needed
2. **All analyst lanes share `--agent steward-analyst`** — `_resolve_agent_name()` special-cases `analyst-*` prefix
3. **author-scratch kept in legacy protection** — worktree not deleted, just retired from active tmux layout
4. **Analyst lanes are flex-domain** — they accept work from any domain (platform, browser-game, etc.)

## Repro / Validation

```bash
# Tier 1 — targeted tests (492 passed)
uv run python -m pytest tests/unit/test_steward_session.py tests/unit/test_ops_task_queue.py tests/unit/test_ops_worker_pool.py tests/unit/test_ops_worktrees.py tests/unit/test_ops_token_economy.py -x -q

# Tier 2 — full validation
make check-quiet

# Shell syntax
bash -n .claude/tmux/steward-session.sh
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
branch: ops/analyst-pool-restructure
```

Closes #1769

🤖 Generated with [Claude Code](https://claude.com/claude-code)