### PR TITLE
fix(ci): demote claude-review to advisory with continue-on-error (#1757)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,6 +34,11 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
+        # Advisory: infrastructure failures (max-turns, auth, timeout) should not
+        # red-mark the PR.  The local review coordinator (Codex CLI) handles
+        # merge-gating; this action is supplementary.  `outcome` still reflects
+        # the real result for downstream steps even with continue-on-error.
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -100,6 +105,9 @@ jobs:
             # Threshold alerting: count recent consecutive blank-execution runs
             # by querying workflow run conclusions. If >= BLANK_EXEC_THRESHOLD
             # consecutive failures, escalate to an issue instead of just warning.
+            # NOTE: With continue-on-error on the action step, job conclusion is
+            # always "success", so this threshold effectively never triggers.
+            # Kept for future use if the advisory policy is ever reversed.
             BLANK_EXEC_THRESHOLD=3
             RECENT_RUNS=$(gh run list \
               --workflow "claude-code-review.yml" \
@@ -118,7 +126,7 @@ jobs:
               EXISTING=$(gh issue list --search "claude-review: consecutive blank-execution" --state open --limit 1 --json number --jq '.[0].number' 2>/dev/null || echo "")
               if [ -n "$EXISTING" ]; then
                 echo "::warning::Infra issue #$EXISTING already open — skipping duplicate"
-                exit 1
+                exit 0
               fi
 
               gh issue create \
@@ -131,8 +139,8 @@ jobs:
 
           Investigate: OOM, token expiry, auth failure, or action version regression." \
                 --label "follow-up"
-              # Exit non-zero so the check stays failed as a visible signal
-              exit 1
+              # Advisory workflow — issue created for visibility, don't fail the check
+              exit 0
             fi
 
             echo "::warning::claude-review exited without execution_file (likely max-turns exhaustion)"
@@ -165,6 +173,6 @@ jobs:
           **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
           This is a reviewer infrastructure issue, not a code review finding.
-          The \`claude-review\` check remains failed on the PR as a visible signal." \
+          The \`claude-review\` check is advisory and does not block merges." \
             --label "follow-up"
           echo "::warning::claude-review infra failure (subtype=$SUBTYPE, denials=$DENIALS) — issue created"

--- a/tests/unit/test_claude_review_workflow.py
+++ b/tests/unit/test_claude_review_workflow.py
@@ -47,10 +47,15 @@ class TestClaudeReviewWorkflow:
             "--max-turns 15" in claude_args
         ), f"expected '--max-turns 15' in claude_args, got {claude_args!r}"
 
-    def test_no_continue_on_error(self):
-        """Review step must NOT use continue-on-error — failures must be visible."""
+    def test_continue_on_error_advisory(self):
+        """Review step must use continue-on-error — check is advisory (#1757).
+
+        The local review coordinator (Codex CLI) handles merge-gating. This
+        GitHub Action is supplementary; infra failures (max-turns, auth,
+        timeout) should not red-mark the PR.
+        """
         step = self._review_step()
-        assert step.get("continue-on-error") is not True
+        assert step.get("continue-on-error") is True
 
     def test_no_allowed_tools_input(self):
         """allowed_tools is not a valid action input — must not be present.
@@ -182,11 +187,11 @@ class TestClaudeReviewWorkflow:
         assert "GH_TOKEN" in str(flag_step.get("env", {}))
 
     def test_classifier_suppresses_blank_execution_file(self):
-        """Blank EXECUTION_FILE below threshold must warn and exit 0.
+        """Blank EXECUTION_FILE must always exit 0 — check is advisory (#1757).
 
         The action does not set execution_file on error_max_turns exits.
-        Below the threshold, blank files exit 0 (suppressed). Above the
-        threshold, consecutive failures escalate to an issue (#1092).
+        Both below-threshold (warn) and above-threshold (issue created) paths
+        exit 0 because the workflow is advisory and should never fail the job.
         """
         flag_step = self._flag_step()
         script = flag_step["run"]
@@ -194,19 +199,17 @@ class TestClaudeReviewWorkflow:
         assert (
             '-z "$EXECUTION_FILE"' in script
         ), "classifier must check for blank EXECUTION_FILE"
-        # The blank-execution branch must contain both:
-        # - exit 0 (below threshold, suppress)
-        # - exit 1 (above threshold, escalate)
+        # The blank-execution branch must exit 0 in all paths (advisory)
         blank_idx = script.index('-z "$EXECUTION_FILE"')
         # Find the elif that ends the blank-execution branch
         elif_idx = script.index("elif", blank_idx)
         blank_section = script[blank_idx:elif_idx]
         assert (
             "exit 0" in blank_section
-        ), "blank EXECUTION_FILE path must exit 0 below threshold"
+        ), "blank EXECUTION_FILE path must exit 0 (advisory workflow)"
         assert (
-            "exit 1" in blank_section
-        ), "blank EXECUTION_FILE path must exit 1 above threshold"
+            "exit 1" not in blank_section
+        ), "blank EXECUTION_FILE path must not exit 1 (advisory workflow, #1757)"
 
     def test_classifier_suppresses_max_turns(self):
         """error_max_turns must warn and exit 0, not create an issue.


### PR DESCRIPTION
## Plan
N/A — bounded issue fix

## Summary
- Add `continue-on-error: true` to the claude-review GitHub Action step so infrastructure failures (max-turns, auth, timeout) produce a green (advisory) check instead of a red X
- Update all exit codes in the infra failure classifier to `exit 0` (advisory workflow)
- Update tests to assert the new advisory behavior

## Why
Issue #1757: The `claude-code-review` GitHub Action frequently fails without producing actionable feedback, showing red X failures on PRs. Since the local review coordinator (Codex CLI) already handles merge-gating and `claude-review` is not a required branch protection check, these failures create pure noise. This PR makes the check fully advisory.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_claude_review_workflow.py -v
make check-quiet
```

## Test Criteria
- **Pass condition:** `continue-on-error: true` present on claude-review step; all exit paths in classifier use `exit 0`
- **Verification command:** `uv run python -m pytest tests/unit/test_claude_review_workflow.py -v`
- **Expected result:** 23 tests pass including `test_continue_on_error_advisory` and updated `test_classifier_suppresses_blank_execution_file`

## Tests
- [x] `uv run python -m pytest tests/unit/test_claude_review_workflow.py -v` — 23/23 passed
- [x] `make check-quiet` — All checks passed

## Expected impact
- Metrics impact: None
- Runtime impact: None — workflow still runs, just doesn't fail the job on infra errors

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
```

`git worktree list`:
```
Bid-Euchre-steward-author-d  2f180108 [fix/claude-review-reliability]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

Closes #1757

🤖 Generated with [Claude Code](https://claude.com/claude-code)