### PR TITLE
fix(ops): exclude control-plane lanes from fleet idle detection (#1774)

### DIFF
--- a/src/bid_euchre/ops/idle_detector.py
+++ b/src/bid_euchre/ops/idle_detector.py
@@ -33,6 +33,11 @@ logger = logging.getLogger("ops.idle_detector")
 # Default idle threshold in minutes.
 DEFAULT_THRESHOLD_MINUTES = 90
 
+# Control-plane lanes that are always running (crons, monitoring, review
+# polling) and should NOT count when determining fleet idleness.  Only
+# implementation lanes (author, browser-author, flex, analyst) matter.
+CONTROL_PLANE_LANES = frozenset({"orchestrator", "ops", "review"})
+
 # Event types that reset the idle timer.  These represent genuine fleet-level
 # progress, not infrastructure bookkeeping.  Every type here MUST be in
 # VALID_EVENT_TYPES (events.py) AND emitted by at least one production path.
@@ -93,6 +98,11 @@ def _find_last_meaningful_event(
 
     for event in events:  # Already sorted most-recent-first
         etype = event.get("event_type", "")
+        lane = event.get("lane_id", "")
+        # Skip events emitted by control-plane lanes — they run crons that
+        # generate infrastructure events and should not reset the idle timer.
+        if lane in CONTROL_PLANE_LANES:
+            continue
         if etype in MEANINGFUL_EVENT_TYPES:
             try:
                 return datetime.fromisoformat(event["timestamp"])
@@ -127,7 +137,7 @@ def _get_active_lane_ids(
             continue
         lane_id = data.get("lane_id", "")
         session_id = data.get("session_id")
-        if session_id and lane_id:
+        if session_id and lane_id and lane_id not in CONTROL_PLANE_LANES:
             active.append(lane_id)
 
     return active

--- a/tests/unit/test_ops_idle_detector.py
+++ b/tests/unit/test_ops_idle_detector.py
@@ -10,6 +10,7 @@ import pytest
 
 from bid_euchre.ops.events import EVENTS_FILE
 from bid_euchre.ops.idle_detector import (
+    CONTROL_PLANE_LANES,
     DEFAULT_THRESHOLD_MINUTES,
     MEANINGFUL_EVENT_TYPES,
     IdleStatus,
@@ -145,6 +146,56 @@ class TestGetActiveLaneIds:
         _register_lane(runtime_dir, "author-c", session_id=None)
         result = _get_active_lane_ids(runtime_dir)
         assert sorted(result) == ["author-a", "author-b"]
+
+    def test_control_plane_lanes_excluded(self, runtime_dir: Path) -> None:
+        """Control-plane lanes (orchestrator, ops, review) must be excluded."""
+        for lane in CONTROL_PLANE_LANES:
+            _register_lane(runtime_dir, lane, session_id=f"sess-{lane}")
+        assert _get_active_lane_ids(runtime_dir) == []
+
+    def test_control_plane_excluded_but_impl_included(self, runtime_dir: Path) -> None:
+        """Implementation lanes still detected alongside control-plane lanes."""
+        _register_lane(runtime_dir, "orchestrator", session_id="sess-orch")
+        _register_lane(runtime_dir, "ops", session_id="sess-ops")
+        _register_lane(runtime_dir, "author-a", session_id="sess-001")
+        result = _get_active_lane_ids(runtime_dir)
+        assert result == ["author-a"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: _find_last_meaningful_event — control-plane filtering
+# ---------------------------------------------------------------------------
+
+
+class TestFindLastMeaningfulEventControlPlane:
+    """Events from control-plane lanes must not reset the idle timer."""
+
+    def test_event_from_orchestrator_ignored(self, events_dir: Path) -> None:
+        ts = datetime(2026, 3, 24, 14, 0, 0, tzinfo=timezone.utc)
+        _write_event(events_dir, "task_completed", ts, lane_id="orchestrator")
+        assert _find_last_meaningful_event(events_dir) is None
+
+    def test_event_from_ops_ignored(self, events_dir: Path) -> None:
+        ts = datetime(2026, 3, 24, 14, 0, 0, tzinfo=timezone.utc)
+        _write_event(events_dir, "ci_success", ts, lane_id="ops")
+        assert _find_last_meaningful_event(events_dir) is None
+
+    def test_event_from_review_ignored(self, events_dir: Path) -> None:
+        ts = datetime(2026, 3, 24, 14, 0, 0, tzinfo=timezone.utc)
+        _write_event(events_dir, "review_verdict", ts, lane_id="review")
+        assert _find_last_meaningful_event(events_dir) is None
+
+    def test_impl_event_found_despite_later_control_plane_event(
+        self, events_dir: Path
+    ) -> None:
+        """An implementation lane event should be found even when a newer
+        control-plane event exists."""
+        ts_impl = datetime(2026, 3, 24, 12, 0, 0, tzinfo=timezone.utc)
+        ts_cp = datetime(2026, 3, 24, 14, 0, 0, tzinfo=timezone.utc)
+        _write_event(events_dir, "task_completed", ts_impl, lane_id="author-a")
+        _write_event(events_dir, "task_completed", ts_cp, lane_id="orchestrator")
+        result = _find_last_meaningful_event(events_dir)
+        assert result == ts_impl
 
 
 # ---------------------------------------------------------------------------
@@ -294,6 +345,81 @@ class TestIsFleetIdle:
             now=now,
         )
         assert result.idle is True
+
+    def test_control_plane_lanes_do_not_prevent_idle(
+        self, events_dir: Path, runtime_dir: Path
+    ) -> None:
+        """Issue #1774: control-plane crons running must not mask fleet idle.
+
+        With all implementation lanes idle and ops/review/orchestrator crons
+        running, is_fleet_idle(threshold_minutes=30) must return idle=True.
+        """
+        now = datetime(2026, 3, 24, 15, 0, 0, tzinfo=timezone.utc)
+        old_ts = now - timedelta(minutes=120)
+        _write_event(events_dir, "task_completed", old_ts, lane_id="author-a")
+
+        # Control-plane lanes are all "active" (have sessions)
+        _register_lane(runtime_dir, "orchestrator", session_id="sess-orch")
+        _register_lane(runtime_dir, "ops", session_id="sess-ops")
+        _register_lane(runtime_dir, "review", session_id="sess-review")
+
+        result = is_fleet_idle(
+            threshold_minutes=30,
+            events_dir=events_dir,
+            runtime_dir=runtime_dir,
+            now=now,
+        )
+        assert result.idle is True
+        assert result.active_lanes == []
+
+    def test_impl_lane_active_prevents_idle_with_control_plane(
+        self, events_dir: Path, runtime_dir: Path
+    ) -> None:
+        """Issue #1774: one implementation lane active → not idle, even with
+        control-plane lanes also active."""
+        now = datetime(2026, 3, 24, 15, 0, 0, tzinfo=timezone.utc)
+        old_ts = now - timedelta(minutes=120)
+        _write_event(events_dir, "task_completed", old_ts, lane_id="author-a")
+
+        # Control-plane lanes active
+        _register_lane(runtime_dir, "orchestrator", session_id="sess-orch")
+        _register_lane(runtime_dir, "ops", session_id="sess-ops")
+        # Plus one implementation lane active
+        _register_lane(runtime_dir, "author-b", session_id="sess-impl")
+
+        result = is_fleet_idle(
+            threshold_minutes=30,
+            events_dir=events_dir,
+            runtime_dir=runtime_dir,
+            now=now,
+        )
+        assert result.idle is False
+        assert "author-b" in result.active_lanes
+        assert "orchestrator" not in result.active_lanes
+        assert "ops" not in result.active_lanes
+
+    def test_control_plane_events_do_not_reset_timer(
+        self, events_dir: Path, runtime_dir: Path
+    ) -> None:
+        """Events from control-plane lanes should not reset the idle timer."""
+        now = datetime(2026, 3, 24, 15, 0, 0, tzinfo=timezone.utc)
+
+        # Old implementation event (120m ago)
+        old_ts = now - timedelta(minutes=120)
+        _write_event(events_dir, "task_completed", old_ts, lane_id="author-a")
+
+        # Recent control-plane event (5m ago) — should NOT reset timer
+        recent_ts = now - timedelta(minutes=5)
+        _write_event(events_dir, "task_completed", recent_ts, lane_id="orchestrator")
+
+        result = is_fleet_idle(
+            threshold_minutes=90,
+            events_dir=events_dir,
+            runtime_dir=runtime_dir,
+            now=now,
+        )
+        assert result.idle is True
+        assert result.idle_minutes == pytest.approx(120.0, abs=0.1)
 
     def test_idle_status_dataclass_fields(
         self, events_dir: Path, runtime_dir: Path


### PR DESCRIPTION
## Summary

- Add `CONTROL_PLANE_LANES` frozenset (`orchestrator`, `ops`, `review`) to the idle detector
- Filter control-plane lanes from `_get_active_lane_ids()` so always-running crons don't mask fleet idle state
- Filter events from control-plane lanes in `_find_last_meaningful_event()` so orchestrator-generated events don't reset the idle timer

## Why

The idle detector counted control-plane lane activity (orchestrator check-in cron, ops monitoring cron, review polling loop) as "fleet is working," which prevented shutoff even when all implementation lanes were done. This broke unattended overnight runs where control-plane crons are always active. Fixes #1774.

## Repro / Validation

```bash
# Tier 1 — targeted tests (43 pass, 7 new)
uv run python -m pytest tests/unit/test_ops_idle_detector.py -v

# Tier 2 — full validation
make check-quiet
```

### Pass/fail criteria from issue:
1. ✅ With all implementation lanes idle and ops/review/orchestrator crons running, `is_fleet_idle(threshold_minutes=30)` returns `idle=True`
2. ✅ With one implementation lane active, returns `idle=False`
3. ✅ `make check` passes

## Tests

- `test_control_plane_lanes_excluded` — control-plane lanes filtered from active lane list
- `test_control_plane_excluded_but_impl_included` — impl lanes still detected alongside control-plane
- `test_event_from_orchestrator_ignored` / `test_event_from_ops_ignored` / `test_event_from_review_ignored` — events from each control-plane lane excluded
- `test_impl_event_found_despite_later_control_plane_event` — impl event found even with newer control-plane event
- `test_control_plane_lanes_do_not_prevent_idle` — integration: all CP lanes active, fleet still idle
- `test_impl_lane_active_prevents_idle_with_control_plane` — integration: impl lane + CP lanes, fleet not idle
- `test_control_plane_events_do_not_reset_timer` — integration: CP event doesn't reset idle timer

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
branch: fix/idle-detector-exclude-control-plane-1774
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)