### PR TITLE
feat(ops): add Telegram push adapter and monitor cycle wiring (Platform-9a PR3)

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -2360,6 +2360,36 @@ def cmd_monitor(args: argparse.Namespace) -> int:
             now_iso=getattr(args, "now", None),
         )
 
+    # --- Alert push cycle (Platform-9a) ---
+    # After reconcile, evaluate whether unresolved HIGH/URGENT items should
+    # be pushed to the operator's phone via Telegram.
+    no_push = getattr(args, "no_push", False)
+    if not no_reconcile and not no_push:
+        try:
+            from datetime import datetime as _dt
+
+            from bid_euchre.ops.telegram_push import run_push_cycle
+
+            audit_dir = args.runtime_dir / "audit_trail" if args.runtime_dir else None
+            push_result = run_push_cycle(
+                runtime_dir=args.runtime_dir,
+                audit_dir=audit_dir,
+                now=(
+                    _dt.fromisoformat(args.now) if getattr(args, "now", None) else None
+                ),
+            )
+            if push_result is not None:
+                print(
+                    f"\n📢 Alert push prepared ({len(push_result.items_pushed)} items)"
+                    f" → chat {push_result.chat_id}"
+                )
+                print(push_result.message)
+        except Exception:
+            # Push is best-effort — never block the monitor cycle.
+            import traceback
+
+            traceback.print_exc()
+
     # Exit 1 if any high-severity findings
     has_high = any(f.severity == "high" for f in findings)
     return 1 if has_high else 0
@@ -3705,6 +3735,11 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="ISO_TIMESTAMP",
         default=None,
         help="Override wall clock for reconcile (ISO-8601 timestamp, for testing)",
+    )
+    monitor_parser.add_argument(
+        "--no-push",
+        action="store_true",
+        help="Disable Telegram alert push after reconcile (for CI/testing)",
     )
 
     # fleet (SP-4-07: controller projection read-only view)

--- a/src/bid_euchre/ops/telegram_push.py
+++ b/src/bid_euchre/ops/telegram_push.py
@@ -1,0 +1,330 @@
+"""Telegram push adapter for alert delivery (Platform-9a, PR 3).
+
+Bridges the transport-agnostic alert push evaluator (``alert_push.py``)
+to the Telegram channel.  Responsibilities:
+
+1. **Format** controller items as Telegram-friendly messages with visible
+   ``item_id`` prefixes so the operator can reply ``ack <prefix>``.
+2. **Gate** on the ``STEWARD_TELEGRAM_ENABLED`` env var kill switch.
+3. **Orchestrate** a single push cycle: evaluate → format → record state →
+   audit trail.  The *actual* MCP ``reply`` call is the caller's job —
+   this module returns a :class:`PushResult` containing the ready-to-send
+   text and chat_id.
+
+.. note::
+
+   The MCP ``reply`` tool is only callable from an active Claude Code
+   conversation with the Telegram plugin enabled.  This adapter therefore
+   **prepares** the push payload but does not send it.  The orchestrator
+   skill (``/check-in`` or monitor cycle) is responsible for calling the
+   MCP tool with the returned payload.
+
+Usage::
+
+    from bid_euchre.ops.telegram_push import prepare_alert_push, is_push_enabled
+
+    if is_push_enabled():
+        result = prepare_alert_push(
+            fleet_status=status,
+            idle_status=idle,
+            push_state=ps,
+            chat_id=chat_id,
+        )
+        if result is not None:
+            # Caller sends result.message to result.chat_id via MCP reply
+            ...
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+from bid_euchre.ops.alert_push import (
+    PushState,
+    evaluate_push_needed,
+    load_push_state,
+    record_push,
+    save_push_state,
+)
+from bid_euchre.ops.audit_trail import append_record, create_record
+from bid_euchre.ops.control_plane import (
+    ActionableItem,
+    FleetStatus,
+    load_fleet_status,
+)
+from bid_euchre.ops.idle_detector import IdleStatus, is_fleet_idle
+
+logger = logging.getLogger("ops.telegram_push")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Env var checked by the push adapter.  The tmux launcher sets this based on
+# whether the Telegram plugin is installed (see .claude/tmux/steward-session.sh).
+TELEGRAM_ENABLED_ENV = "STEWARD_TELEGRAM_ENABLED"
+
+# Env var for the target Telegram chat ID.  Set in the tmux session or .env.
+ALERT_PUSH_CHAT_ID_ENV = "STEWARD_ALERT_PUSH_CHAT_ID"
+
+# Severity emoji mapping for Telegram messages.
+_SEVERITY_EMOJI: dict[str, str] = {
+    "urgent": "\U0001f6a8",  # 🚨
+    "high": "\u26a0\ufe0f",  # ⚠️
+}
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PushResult:
+    """Ready-to-send Telegram push payload.
+
+    Attributes:
+        chat_id: Telegram chat ID to send to.
+        message: Formatted Telegram message text.
+        items_pushed: The items included in this push (for state tracking).
+    """
+
+    chat_id: str
+    message: str
+    items_pushed: list[ActionableItem] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+
+def format_alert_push(items: list[ActionableItem]) -> str:
+    """Format actionable items as a Telegram-friendly alert message.
+
+    Each item shows its severity, truncated item_id (for ``ack <prefix>``
+    replies), summary, and recommended action.
+
+    Args:
+        items: The items to include in the message.
+
+    Returns:
+        A multi-line string suitable for Telegram delivery.
+    """
+    if not items:
+        return ""
+
+    lines: list[str] = []
+    lines.append(f"\U0001f4e2 Fleet Alert — {len(items)} item(s) need attention")
+    lines.append("")
+
+    for item in items:
+        emoji = _SEVERITY_EMOJI.get(item.severity, "\u2139\ufe0f")
+        prefix = item.item_id[:8]
+        lines.append(f"{emoji} [{item.severity.upper()}] {item.summary}")
+        lines.append(f"   ID: {prefix}")
+        if item.recommended_action:
+            lines.append(f"   → {item.recommended_action}")
+        if item.lane_id:
+            lines.append(f"   Lane: {item.lane_id}")
+        lines.append("")
+
+    lines.append("Reply: ack <id>, mute <id>, or clear <id>")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Gate check
+# ---------------------------------------------------------------------------
+
+
+def is_push_enabled() -> bool:
+    """Check if Telegram push is enabled via env var.
+
+    Returns ``True`` when ``STEWARD_TELEGRAM_ENABLED`` is set to ``"1"``.
+    Any other value (including unset) returns ``False``.
+    """
+    return os.environ.get(TELEGRAM_ENABLED_ENV, "0") == "1"
+
+
+def get_push_chat_id() -> str | None:
+    """Read the alert push chat ID from the environment.
+
+    Returns ``None`` if not configured.
+    """
+    val = os.environ.get(ALERT_PUSH_CHAT_ID_ENV, "").strip()
+    return val if val else None
+
+
+# ---------------------------------------------------------------------------
+# Push orchestration
+# ---------------------------------------------------------------------------
+
+
+def prepare_alert_push(
+    fleet_status: FleetStatus,
+    idle_status: IdleStatus,
+    push_state: PushState,
+    chat_id: str,
+    *,
+    cooldown_minutes: float | None = None,
+    now: datetime | None = None,
+    runtime_dir: Path | None = None,
+    audit_dir: Path | None = None,
+) -> PushResult | None:
+    """Evaluate, format, record, and return a push payload if needed.
+
+    This is the main entry point for the monitor cycle integration.
+    It performs the full push preparation pipeline:
+
+    1. Call ``evaluate_push_needed()`` to identify items that should be pushed.
+    2. Format the items as a Telegram message via ``format_alert_push()``.
+    3. Record each pushed item in the push state.
+    4. Save the push state to disk.
+    5. Audit the outbound push.
+
+    Returns ``None`` if no push is needed (fleet active, no eligible items,
+    or all items within cooldown).
+
+    The caller is responsible for sending ``result.message`` to
+    ``result.chat_id`` via the MCP ``reply`` tool.
+
+    Args:
+        fleet_status: Current controller projection.
+        idle_status: Current fleet idle determination.
+        push_state: Previously tracked push history (mutated in place).
+        chat_id: Telegram chat ID for the push.
+        cooldown_minutes: Override for push cooldown (default from alert_push).
+        now: Override current time (for testing).
+        runtime_dir: Override runtime directory for push state persistence.
+        audit_dir: Override audit trail directory.
+
+    Returns:
+        A :class:`PushResult` ready for sending, or ``None`` if no push needed.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    # Evaluate which items need pushing.
+    kwargs: dict = {"now": now}
+    if cooldown_minutes is not None:
+        kwargs["cooldown_minutes"] = cooldown_minutes
+
+    items_to_push = evaluate_push_needed(
+        fleet_status, idle_status, push_state, **kwargs
+    )
+
+    if not items_to_push:
+        logger.debug("No items need pushing — skipping alert push cycle")
+        return None
+
+    # Format the alert message.
+    message = format_alert_push(items_to_push)
+
+    # Record each item as pushed in the push state.
+    for item in items_to_push:
+        record_push(push_state, item.item_id, item.severity, now=now)
+
+    # Persist push state.
+    save_push_state(push_state, runtime_dir=runtime_dir)
+
+    # Audit the outbound push.
+    try:
+        audit_rec = create_record(
+            direction="outbound",
+            channel_source="telegram",
+            sender_identity="steward-ops",
+            exchange_type="reply",
+            content=message,
+            chat_id=chat_id,
+            metadata={
+                "purpose": "alert_push",
+                "item_count": len(items_to_push),
+                "item_ids": [i.item_id for i in items_to_push],
+            },
+        )
+        append_record(audit_rec, audit_dir=audit_dir)
+    except Exception:
+        logger.warning("Failed to audit alert push — continuing", exc_info=True)
+
+    logger.info(
+        "Prepared alert push: %d item(s) for chat %s",
+        len(items_to_push),
+        chat_id,
+    )
+
+    return PushResult(
+        chat_id=chat_id,
+        message=message,
+        items_pushed=list(items_to_push),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Convenience: full cycle from disk
+# ---------------------------------------------------------------------------
+
+
+def run_push_cycle(
+    *,
+    runtime_dir: Path | None = None,
+    audit_dir: Path | None = None,
+    cooldown_minutes: float | None = None,
+    now: datetime | None = None,
+    idle_threshold_minutes: float | None = None,
+) -> PushResult | None:
+    """Run a complete alert push cycle reading all state from disk.
+
+    Convenience wrapper that loads fleet status, idle status, and push state
+    from the standard runtime locations, then delegates to
+    :func:`prepare_alert_push`.
+
+    Returns ``None`` if:
+    - Telegram push is disabled (env var)
+    - No chat_id configured
+    - No fleet status on disk
+    - No push needed
+
+    This function is designed to be called from ``cmd_monitor()`` after
+    ``reconcile()`` completes.
+    """
+    if not is_push_enabled():
+        logger.debug("Telegram push disabled (env: %s)", TELEGRAM_ENABLED_ENV)
+        return None
+
+    chat_id = get_push_chat_id()
+    if not chat_id:
+        logger.debug(
+            "No alert push chat ID configured (env: %s)", ALERT_PUSH_CHAT_ID_ENV
+        )
+        return None
+
+    fleet_status = load_fleet_status(runtime_dir)
+    if fleet_status is None:
+        logger.debug("No fleet status available — skipping push cycle")
+        return None
+
+    idle_kwargs: dict = {}
+    if runtime_dir is not None:
+        idle_kwargs["runtime_dir"] = runtime_dir
+    if idle_threshold_minutes is not None:
+        idle_kwargs["threshold_minutes"] = idle_threshold_minutes
+
+    idle_status = is_fleet_idle(**idle_kwargs)
+
+    push_state = load_push_state(runtime_dir=runtime_dir)
+
+    return prepare_alert_push(
+        fleet_status=fleet_status,
+        idle_status=idle_status,
+        push_state=push_state,
+        chat_id=chat_id,
+        cooldown_minutes=cooldown_minutes,
+        now=now,
+        runtime_dir=runtime_dir,
+        audit_dir=audit_dir,
+    )

--- a/tests/integration/test_alert_push_integration.py
+++ b/tests/integration/test_alert_push_integration.py
@@ -1,0 +1,528 @@
+"""Integration tests for Platform-9a PR3 — Telegram alert push cycle.
+
+Tests the full push pipeline: seed findings → reconcile → evaluate push →
+format message → record push state → audit trail.  No actual Telegram calls —
+tests verify the state and audit artifacts produced by the push cycle.
+
+Covers exit criteria:
+- E1: Unresolved HIGH/URGENT items pushed when fleet is idle
+- E2: Push dedup prevents repeated alerts within cooldown
+- E3: Severity escalation triggers re-push within cooldown
+- E7: All pushes recorded in audit trail
+- E8: Push suppressed when STEWARD_TELEGRAM_ENABLED=0
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from bid_euchre.ops.alert_push import (
+    PushState,
+    load_push_state,
+    record_push,
+)
+from bid_euchre.ops.audit_trail import read_records
+from bid_euchre.ops.control_plane import (
+    SEVERITY_HIGH,
+    SEVERITY_URGENT,
+    STATE_OPEN,
+    ActionableItem,
+    FleetStatus,
+    reconcile,
+)
+from bid_euchre.ops.idle_detector import IdleStatus
+from bid_euchre.ops.telegram_push import (
+    PushResult,
+    format_alert_push,
+    is_push_enabled,
+    prepare_alert_push,
+    run_push_cycle,
+)
+
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 3, 25, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_item(
+    *,
+    item_id: str = "aabbccdd1234",
+    severity: str = SEVERITY_HIGH,
+    summary: str = "Approval stall on author-b",
+    lane_id: str = "author-b",
+    recommended_action: str = "Nudge author-b or re-dispatch",
+) -> ActionableItem:
+    return ActionableItem(
+        item_id=item_id,
+        severity=severity,
+        category="approval_stall",
+        source="monitor",
+        summary=summary,
+        first_seen_at=_NOW.isoformat(),
+        last_seen_at=_NOW.isoformat(),
+        state=STATE_OPEN,
+        lane_id=lane_id,
+        recommended_action=recommended_action,
+    )
+
+
+def _idle_status(idle: bool = True) -> IdleStatus:
+    return IdleStatus(
+        idle=idle,
+        idle_minutes=95.0 if idle else 5.0,
+        last_meaningful_event=_NOW - timedelta(minutes=95) if idle else _NOW,
+        active_lanes=[] if idle else ["author-a"],
+        reason="Fleet idle" if idle else "Fleet active",
+    )
+
+
+def _fleet_status(*items: ActionableItem) -> FleetStatus:
+    return FleetStatus(
+        items=list(items),
+        generated_at=_NOW.isoformat(),
+        cycle_count=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# E1: Push fires when idle + unresolved HIGH/URGENT items exist
+# ---------------------------------------------------------------------------
+
+
+class TestPushFiresWhenIdle:
+    """Full push cycle: idle fleet + HIGH item → push result produced."""
+
+    def test_push_prepares_message_for_high_item(self, tmp_path: Path) -> None:
+        """A single HIGH item in idle fleet produces a PushResult."""
+        item = _make_item()
+        status = _fleet_status(item)
+        idle = _idle_status(idle=True)
+        push_state = PushState()
+        audit_dir = tmp_path / "audit_trail"
+
+        result = prepare_alert_push(
+            fleet_status=status,
+            idle_status=idle,
+            push_state=push_state,
+            chat_id="12345",
+            now=_NOW,
+            runtime_dir=tmp_path,
+            audit_dir=audit_dir,
+        )
+
+        assert result is not None
+        assert isinstance(result, PushResult)
+        assert result.chat_id == "12345"
+        assert len(result.items_pushed) == 1
+        assert result.items_pushed[0].item_id == item.item_id
+        assert "aabbccdd" in result.message
+        assert "Approval stall" in result.message
+
+    def test_push_prepares_message_for_urgent_item(self, tmp_path: Path) -> None:
+        """URGENT items are also pushed."""
+        item = _make_item(severity=SEVERITY_URGENT)
+        status = _fleet_status(item)
+        idle = _idle_status(idle=True)
+        push_state = PushState()
+        audit_dir = tmp_path / "audit_trail"
+
+        result = prepare_alert_push(
+            fleet_status=status,
+            idle_status=idle,
+            push_state=push_state,
+            chat_id="12345",
+            now=_NOW,
+            runtime_dir=tmp_path,
+            audit_dir=audit_dir,
+        )
+
+        assert result is not None
+        assert len(result.items_pushed) == 1
+        assert "URGENT" in result.message
+
+    def test_no_push_when_fleet_active(self, tmp_path: Path) -> None:
+        """No push when the fleet is actively running."""
+        item = _make_item()
+        status = _fleet_status(item)
+        idle = _idle_status(idle=False)
+        push_state = PushState()
+
+        result = prepare_alert_push(
+            fleet_status=status,
+            idle_status=idle,
+            push_state=push_state,
+            chat_id="12345",
+            now=_NOW,
+            runtime_dir=tmp_path,
+        )
+
+        assert result is None
+
+    def test_no_push_for_empty_fleet(self, tmp_path: Path) -> None:
+        """No push when there are no items."""
+        status = _fleet_status()
+        idle = _idle_status(idle=True)
+        push_state = PushState()
+
+        result = prepare_alert_push(
+            fleet_status=status,
+            idle_status=idle,
+            push_state=push_state,
+            chat_id="12345",
+            now=_NOW,
+            runtime_dir=tmp_path,
+        )
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# E2: Push dedup prevents repeated alerts within cooldown
+# ---------------------------------------------------------------------------
+
+
+class TestPushDedup:
+    """After pushing, the same item is not re-pushed within cooldown."""
+
+    def test_no_repush_within_cooldown(self, tmp_path: Path) -> None:
+        """Item pushed 5 minutes ago is NOT re-pushed (cooldown=15m)."""
+        item = _make_item()
+        status = _fleet_status(item)
+        idle = _idle_status(idle=True)
+        push_state = PushState()
+        audit_dir = tmp_path / "audit_trail"
+
+        # First push — should succeed.
+        first_push_time = _NOW - timedelta(minutes=5)
+        result1 = prepare_alert_push(
+            fleet_status=status,
+            idle_status=idle,
+            push_state=push_state,
+            chat_id="12345",
+            now=first_push_time,
+            runtime_dir=tmp_path,
+            audit_dir=audit_dir,
+        )
+        assert result1 is not None
+
+        # Second push 5 minutes later — within cooldown, should be None.
+        result2 = prepare_alert_push(
+            fleet_status=status,
+            idle_status=idle,
+            push_state=push_state,
+            chat_id="12345",
+            now=_NOW,
+            cooldown_minutes=15.0,
+            runtime_dir=tmp_path,
+            audit_dir=audit_dir,
+        )
+        assert result2 is None
+
+    def test_repush_after_cooldown_expires(self, tmp_path: Path) -> None:
+        """Item pushed 20 minutes ago IS re-pushed (cooldown=15m)."""
+        item = _make_item()
+        status = _fleet_status(item)
+        idle = _idle_status(idle=True)
+        push_state = PushState()
+        audit_dir = tmp_path / "audit_trail"
+
+        # First push.
+        first_push_time = _NOW - timedelta(minutes=20)
+        result1 = prepare_alert_push(
+            fleet_status=status,
+            idle_status=idle,
+            push_state=push_state,
+            chat_id="12345",
+            now=first_push_time,
+            runtime_dir=tmp_path,
+            audit_dir=audit_dir,
+        )
+        assert result1 is not None
+
+        # Second push 20 minutes later — cooldown expired.
+        result2 = prepare_alert_push(
+            fleet_status=status,
+            idle_status=idle,
+            push_state=push_state,
+            chat_id="12345",
+            cooldown_minutes=15.0,
+            now=_NOW,
+            runtime_dir=tmp_path,
+            audit_dir=audit_dir,
+        )
+        assert result2 is not None
+
+
+# ---------------------------------------------------------------------------
+# E3: Severity escalation triggers re-push within cooldown
+# ---------------------------------------------------------------------------
+
+
+class TestSeverityEscalation:
+    """Severity escalation bypasses cooldown."""
+
+    def test_escalation_bypasses_cooldown(self, tmp_path: Path) -> None:
+        """Item pushed as HIGH 5m ago, now URGENT → re-push within cooldown."""
+        # First push with HIGH severity.
+        push_state = PushState()
+        record_push(
+            push_state, "aabbccdd1234", SEVERITY_HIGH, now=_NOW - timedelta(minutes=5)
+        )
+
+        # Now the item is URGENT.
+        item = _make_item(severity=SEVERITY_URGENT)
+        status = _fleet_status(item)
+        idle = _idle_status(idle=True)
+        audit_dir = tmp_path / "audit_trail"
+
+        result = prepare_alert_push(
+            fleet_status=status,
+            idle_status=idle,
+            push_state=push_state,
+            chat_id="12345",
+            cooldown_minutes=15.0,
+            now=_NOW,
+            runtime_dir=tmp_path,
+            audit_dir=audit_dir,
+        )
+        assert result is not None
+        assert len(result.items_pushed) == 1
+        assert result.items_pushed[0].severity == SEVERITY_URGENT
+
+
+# ---------------------------------------------------------------------------
+# E7: Audit trail records outbound pushes
+# ---------------------------------------------------------------------------
+
+
+class TestAuditTrail:
+    """Push cycle creates audit records for every outbound push."""
+
+    def test_audit_record_created_after_push(self, tmp_path: Path) -> None:
+        """After a push, the audit trail contains one outbound reply record."""
+        item = _make_item()
+        status = _fleet_status(item)
+        idle = _idle_status(idle=True)
+        push_state = PushState()
+        audit_dir = tmp_path / "audit_trail"
+
+        result = prepare_alert_push(
+            fleet_status=status,
+            idle_status=idle,
+            push_state=push_state,
+            chat_id="12345",
+            now=_NOW,
+            runtime_dir=tmp_path,
+            audit_dir=audit_dir,
+        )
+        assert result is not None
+
+        # Read audit records.
+        records = read_records(audit_dir=audit_dir)
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.direction == "outbound"
+        assert rec.channel_source == "telegram"
+        assert rec.exchange_type == "reply"
+        assert rec.chat_id == "12345"
+        assert rec.metadata.get("purpose") == "alert_push"
+        assert rec.metadata.get("item_count") == 1
+        assert item.item_id in rec.metadata.get("item_ids", [])
+
+    def test_push_state_persisted_after_push(self, tmp_path: Path) -> None:
+        """Push state is saved to disk after a push cycle."""
+        item = _make_item()
+        status = _fleet_status(item)
+        idle = _idle_status(idle=True)
+        push_state = PushState()
+        audit_dir = tmp_path / "audit_trail"
+
+        prepare_alert_push(
+            fleet_status=status,
+            idle_status=idle,
+            push_state=push_state,
+            chat_id="12345",
+            now=_NOW,
+            runtime_dir=tmp_path,
+            audit_dir=audit_dir,
+        )
+
+        # Reload from disk and verify.
+        reloaded = load_push_state(runtime_dir=tmp_path)
+        assert item.item_id in reloaded.items
+        rec = reloaded.items[item.item_id]
+        assert rec.push_count == 1
+        assert rec.severity_at_push == SEVERITY_HIGH
+
+
+# ---------------------------------------------------------------------------
+# E8: Push suppressed when STEWARD_TELEGRAM_ENABLED=0
+# ---------------------------------------------------------------------------
+
+
+class TestKillSwitch:
+    """Push is suppressed when the env var kill switch is off."""
+
+    def test_push_disabled_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When STEWARD_TELEGRAM_ENABLED is not set, push is disabled."""
+        monkeypatch.delenv("STEWARD_TELEGRAM_ENABLED", raising=False)
+        assert not is_push_enabled()
+
+    def test_push_disabled_when_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When STEWARD_TELEGRAM_ENABLED=0, push is disabled."""
+        monkeypatch.setenv("STEWARD_TELEGRAM_ENABLED", "0")
+        assert not is_push_enabled()
+
+    def test_push_enabled_when_one(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When STEWARD_TELEGRAM_ENABLED=1, push is enabled."""
+        monkeypatch.setenv("STEWARD_TELEGRAM_ENABLED", "1")
+        assert is_push_enabled()
+
+    def test_run_push_cycle_returns_none_when_disabled(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """run_push_cycle returns None immediately when Telegram is disabled."""
+        monkeypatch.setenv("STEWARD_TELEGRAM_ENABLED", "0")
+        result = run_push_cycle(runtime_dir=tmp_path)
+        assert result is None
+
+    def test_run_push_cycle_returns_none_when_no_chat_id(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """run_push_cycle returns None when no chat ID is configured."""
+        monkeypatch.setenv("STEWARD_TELEGRAM_ENABLED", "1")
+        monkeypatch.delenv("STEWARD_ALERT_PUSH_CHAT_ID", raising=False)
+        result = run_push_cycle(runtime_dir=tmp_path)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Format output
+# ---------------------------------------------------------------------------
+
+
+class TestFormatAlertPush:
+    """Tests for the alert message formatting."""
+
+    def test_empty_items_returns_empty(self) -> None:
+        assert format_alert_push([]) == ""
+
+    def test_format_includes_item_id_prefix(self) -> None:
+        item = _make_item(item_id="deadbeef0000")
+        msg = format_alert_push([item])
+        assert "deadbeef" in msg
+
+    def test_format_includes_severity(self) -> None:
+        item = _make_item(severity=SEVERITY_HIGH)
+        msg = format_alert_push([item])
+        assert "HIGH" in msg
+
+    def test_format_includes_ack_instructions(self) -> None:
+        item = _make_item()
+        msg = format_alert_push([item])
+        assert "ack" in msg.lower()
+        assert "mute" in msg.lower()
+
+    def test_format_includes_recommended_action(self) -> None:
+        item = _make_item(recommended_action="Re-nudge the lane")
+        msg = format_alert_push([item])
+        assert "Re-nudge the lane" in msg
+
+    def test_format_multiple_items(self) -> None:
+        items = [
+            _make_item(item_id="aaa111000000", summary="Issue 1"),
+            _make_item(item_id="bbb222000000", summary="Issue 2"),
+        ]
+        msg = format_alert_push(items)
+        assert "2 item(s)" in msg
+        assert "aaa11100" in msg
+        assert "bbb22200" in msg
+
+
+# ---------------------------------------------------------------------------
+# Full reconcile → push cycle
+# ---------------------------------------------------------------------------
+
+
+class TestFullReconcileToPush:
+    """End-to-end: reconcile produces fleet status → push cycle runs."""
+
+    def test_reconcile_then_push(self, tmp_path: Path) -> None:
+        """After reconcile seeds a HIGH item, the push cycle picks it up."""
+        from bid_euchre.ops.events import append_event
+
+        runtime_dir = tmp_path / "runtime"
+        runtime_dir.mkdir()
+        events_dir = runtime_dir / "events"
+        events_dir.mkdir()
+        audit_dir = runtime_dir / "audit_trail"
+
+        # Seed a meaningful event in the past so idle detector thinks we're idle.
+        append_event(
+            event_type="task_started",
+            source="test",
+            lane_id="author-a",
+            payload={"task_id": "test-task"},
+            events_dir=events_dir,
+        )
+
+        # Create a HIGH monitor finding to be reconciled.
+        from bid_euchre.ops.monitor import MonitorFinding
+
+        finding = MonitorFinding(
+            category="approval_stall",
+            severity="high",
+            summary="author-b has no pending review after 45m",
+            details={"lane": "author-b"},
+        )
+
+        # Reconcile to generate fleet_status.json.
+        reconcile(
+            runtime_dir=runtime_dir,
+            monitor_finding_objects=[finding],
+            now_iso=_NOW.isoformat(),
+        )
+
+        # Verify fleet status was created with at least one HIGH item.
+        from bid_euchre.ops.control_plane import load_fleet_status
+
+        status = load_fleet_status(runtime_dir)
+        assert status is not None
+        high_items = [
+            i
+            for i in status.items
+            if i.severity in (SEVERITY_HIGH, SEVERITY_URGENT) and i.state == STATE_OPEN
+        ]
+        assert len(high_items) >= 1
+
+        # Now run the push evaluator against the reconciled status.
+        idle = _idle_status(idle=True)
+        push_state = PushState()
+
+        result = prepare_alert_push(
+            fleet_status=status,
+            idle_status=idle,
+            push_state=push_state,
+            chat_id="99999",
+            now=_NOW,
+            runtime_dir=runtime_dir,
+            audit_dir=audit_dir,
+        )
+
+        assert result is not None
+        assert len(result.items_pushed) >= 1
+        assert result.chat_id == "99999"
+
+        # Verify audit record.
+        records = read_records(audit_dir=audit_dir)
+        assert any(
+            r.direction == "outbound" and r.metadata.get("purpose") == "alert_push"
+            for r in records
+        )


### PR DESCRIPTION
## Summary

- **New module** `src/bid_euchre/ops/telegram_push.py` — Telegram push adapter that bridges the transport-agnostic alert evaluator to the Telegram channel
- **Monitor cycle wiring** — push cycle runs after `reconcile()` in `cmd_monitor()`, gated by `STEWARD_TELEGRAM_ENABLED` env var and `--no-push` flag
- **21 integration tests** covering push fire, dedup/cooldown, severity escalation, audit trail, kill switch, and full reconcile-to-push cycle

## Why

Platform-9a PR3. The alert push evaluator (PR #1781) and remote ack parser (PR #1777) exist but nothing wires them into the monitor cycle or formats alerts for Telegram delivery. This PR adds the Telegram push adapter — the glue between the evaluator and the transport layer.

## Architecture

```
cmd_monitor() → reconcile() → fleet_status.json
                                    ↓
                           run_push_cycle()
                              ↓           ↓
                     is_push_enabled()  evaluate_push_needed()
                              ↓           ↓
                     format_alert_push() → PushResult
                              ↓
                     record push state + audit trail
                              ↓
                     Print payload (orchestrator sends via MCP)
```

Key design: `telegram_push.py` **prepares** push payloads but does not call the MCP `reply` tool directly. The MCP tool is only available in the orchestrator's conversation context — the caller is responsible for sending `result.message` to `result.chat_id`.

## Key Components

| Function | Purpose |
|----------|---------|
| `format_alert_push(items)` | Format items as Telegram message with item_id prefixes for ack replies |
| `prepare_alert_push(...)` | Full push pipeline: evaluate → format → record state → audit |
| `run_push_cycle(...)` | Convenience wrapper loading all state from disk |
| `is_push_enabled()` | Check `STEWARD_TELEGRAM_ENABLED` env var |
| `get_push_chat_id()` | Read `STEWARD_ALERT_PUSH_CHAT_ID` env var |

## Depends On

- PR #1781 (alert push evaluator) — merged ✅
- PR #1777 (remote ack parser) — merged ✅

## Repro / Validation

```bash
# Tier 1 — integration tests
uv run python -m pytest tests/integration/test_alert_push_integration.py -v

# Tier 2 — full validation
make check-quiet
```

## Tests

- `tests/integration/test_alert_push_integration.py` — 21 tests covering:
  - E1: Push fires when idle + HIGH/URGENT items exist
  - E2: Dedup prevents repeated alerts within cooldown
  - E3: Severity escalation bypasses cooldown
  - E7: Audit trail records outbound pushes
  - E8: Push suppressed when `STEWARD_TELEGRAM_ENABLED=0`
  - Format output: item_id prefixes, severity, ack instructions
  - Full reconcile → push end-to-end

## Worktree Proof

```
pwd: Bid-Euchre-steward-author (persistent author-a worktree)
Branch: ops/platform9a-telegram-push
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)