### PR TITLE
feat(web): replace hybrid_olsa with OLSa roster for browser expansion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,14 +40,18 @@ APP_URL=http://localhost:8000
 # AI Model Roster
 # ---------------------------------------------------------------------------
 # Default AI model identifier for new matches.
-DEFAULT_MODEL_ID=heuristic
+# "olsa" is the R3 full_ols_av ActionValueBidder (moon/loner-capable).
+# Falls back to "heuristic" if the artifact is not loadable.
+DEFAULT_MODEL_ID=olsa
 
 # Directory containing model artifact files (optional).
 # Used by AIManager to resolve relative artifact paths at runtime.
 # MODELS_DIR=
 
-# Path to a specific hybrid-OLSA model artifact file (optional).
-# HYBRID_OLSA_ARTIFACT=
+# Path to the OLSa (ActionValueBidder) artifact file (optional).
+# Expected schema: action_value_olsa_v1
+# Example: data/artifacts/arc_d_v2/r3/training_artifact_full_ols_av.json
+# OLSA_ARTIFACT=
 
 # ---------------------------------------------------------------------------
 # Server

--- a/docs/01_core/DEPLOYMENT.md
+++ b/docs/01_core/DEPLOYMENT.md
@@ -67,9 +67,9 @@ full contract with defaults. The authoritative source is `web/config.py`
 | `SECRET_KEY` | Yes | Random per-process (dev) | Cookie/session signing |
 | `ALLOWED_ORIGINS` | No | `*` | Comma-separated CORS allowlist |
 | `APP_URL` | No | `http://localhost:8000` | Public base URL for share links |
-| `DEFAULT_MODEL_ID` | No | `heuristic` | AI bidding model |
+| `DEFAULT_MODEL_ID` | No | `olsa` | AI bidding model (falls back to `heuristic` if artifact unavailable) |
 | `MODELS_DIR` | No | None | Directory for model artifacts |
-| `HYBRID_OLSA_ARTIFACT` | No | None | Path to hybrid-OLSA artifact |
+| `OLSA_ARTIFACT` | No | None | Path to OLSa (ActionValueBidder) artifact |
 | `DEBUG` | No | `false` | Enable debug mode (`1`/`true`/`yes`) |
 | `PORT` | No | `8000` | Server bind port (Render sets this) |
 

--- a/tests/unit/hosted_play/test_ai_manager.py
+++ b/tests/unit/hosted_play/test_ai_manager.py
@@ -57,87 +57,87 @@ class TestHeuristicModel:
 
 
 # ---------------------------------------------------------------------------
-# AIManager — hybrid_olsa conditional loading
+# AIManager — olsa conditional loading
 # ---------------------------------------------------------------------------
 
 
-class TestHybridOlsa:
-    """hybrid_olsa is loaded only when the artifact path exists and is valid."""
+class TestOlsa:
+    """olsa is loaded only when the artifact path exists and is valid."""
 
-    def test_hybrid_olsa_skipped_when_no_artifact(self):
-        config = HostedPlayConfig(hybrid_olsa_artifact=None)
+    def test_olsa_skipped_when_no_artifact(self):
+        config = HostedPlayConfig(olsa_artifact=None)
         mgr = AIManager(config)
-        assert "hybrid_olsa" not in mgr.available_models
+        assert "olsa" not in mgr.available_models
 
-    def test_hybrid_olsa_skipped_when_artifact_missing(self, tmp_path):
+    def test_olsa_skipped_when_artifact_missing(self, tmp_path):
         missing = str(tmp_path / "does_not_exist.json")
-        config = HostedPlayConfig(hybrid_olsa_artifact=missing)
+        config = HostedPlayConfig(olsa_artifact=missing)
         mgr = AIManager(config)
-        assert "hybrid_olsa" not in mgr.available_models
+        assert "olsa" not in mgr.available_models
 
-    def test_hybrid_olsa_skipped_on_invalid_artifact(self, tmp_path):
-        """An artifact file that exists but has wrong format → not loaded."""
+    def test_olsa_skipped_on_invalid_artifact(self, tmp_path):
+        """An artifact file that exists but has wrong format -> not loaded."""
         bad_artifact = tmp_path / "bad.json"
         bad_artifact.write_text(json.dumps({"artifact_type": "wrong"}))
-        config = HostedPlayConfig(hybrid_olsa_artifact=str(bad_artifact))
+        config = HostedPlayConfig(olsa_artifact=str(bad_artifact))
         mgr = AIManager(config)
-        # Should not crash, but hybrid_olsa should not be available
-        assert "hybrid_olsa" not in mgr.available_models
+        # Should not crash, but olsa should not be available
+        assert "olsa" not in mgr.available_models
 
-    def test_hybrid_olsa_relative_path_resolved_via_models_dir(self, tmp_path):
+    def test_olsa_relative_path_resolved_via_models_dir(self, tmp_path):
         """When artifact path is relative and models_dir is set, resolve against it."""
         models_dir = tmp_path / "models"
         models_dir.mkdir()
         # Create a bad artifact (won't load, but tests path resolution)
-        bad_artifact = models_dir / "hybrid.json"
+        bad_artifact = models_dir / "olsa.json"
         bad_artifact.write_text(json.dumps({"artifact_type": "wrong"}))
         config = HostedPlayConfig(
-            hybrid_olsa_artifact="hybrid.json",
+            olsa_artifact="olsa.json",
             models_dir=str(models_dir),
         )
         mgr = AIManager(config)
-        # File found (resolution worked) but content is invalid → not loaded
-        assert "hybrid_olsa" not in mgr.available_models
+        # File found (resolution worked) but content is invalid -> not loaded
+        assert "olsa" not in mgr.available_models
 
-    def test_hybrid_olsa_absolute_path_ignores_models_dir(self, tmp_path):
+    def test_olsa_absolute_path_ignores_models_dir(self, tmp_path):
         """An absolute artifact path should be used as-is, ignoring models_dir."""
         models_dir = tmp_path / "models"
         models_dir.mkdir()
         abs_artifact = tmp_path / "absolute.json"
         abs_artifact.write_text(json.dumps({"artifact_type": "wrong"}))
         config = HostedPlayConfig(
-            hybrid_olsa_artifact=str(abs_artifact),
+            olsa_artifact=str(abs_artifact),
             models_dir=str(models_dir),
         )
         mgr = AIManager(config)
         # File found at absolute path (not resolved via models_dir)
-        assert "hybrid_olsa" not in mgr.available_models
+        assert "olsa" not in mgr.available_models
 
-    def test_hybrid_olsa_relative_path_preserved_when_exists(
+    def test_olsa_relative_path_preserved_when_exists(
         self, tmp_path, monkeypatch, caplog
     ):
         """A relative artifact path that already exists from CWD is preserved.
 
         When MODELS_DIR is set but the relative path already resolves from the
         working directory, the original relative path is used (not overridden
-        with models_dir prefix).  Regression test for #1668.
+        with models_dir prefix).
         """
         # Create artifact in CWD-relative location
         workdir = tmp_path / "workdir"
         workdir.mkdir()
         rel_dir = workdir / "rel"
         rel_dir.mkdir()
-        artifact = rel_dir / "hybrid.json"
+        artifact = rel_dir / "olsa.json"
         artifact.write_text(json.dumps({"artifact_type": "wrong"}))
 
         # Create a *different* directory for models_dir (no artifact here)
         models_dir = tmp_path / "elsewhere"
         models_dir.mkdir()
 
-        # Run from workdir so "rel/hybrid.json" is a valid relative path
+        # Run from workdir so "rel/olsa.json" is a valid relative path
         monkeypatch.chdir(workdir)
         config = HostedPlayConfig(
-            hybrid_olsa_artifact="rel/hybrid.json",
+            olsa_artifact="rel/olsa.json",
             models_dir=str(models_dir),
         )
         import logging
@@ -149,40 +149,38 @@ class TestHybridOlsa:
         # attempted (producing a warning because the content is invalid).
         # If models_dir had been prepended, the file would NOT be found
         # and no loading attempt (warning) would occur.
-        assert "hybrid_olsa" not in mgr.available_models
+        assert "olsa" not in mgr.available_models
         assert any(
-            "Failed to load hybrid_olsa from rel/hybrid.json" in m
-            for m in caplog.messages
+            "Failed to load OLSa from rel/olsa.json" in m for m in caplog.messages
         )
 
-    def test_hybrid_olsa_cwd_failure_falls_back_to_models_dir(
+    def test_olsa_cwd_failure_falls_back_to_models_dir(
         self, tmp_path, monkeypatch, caplog
     ):
         """When CWD artifact exists but fails to load, models_dir is tried.
 
-        Regression test for #1700: if the CWD-relative path exists but the
-        artifact is corrupt/invalid, the loader should fall back to the
-        models_dir copy if one exists.
+        If the CWD-relative path exists but the artifact is corrupt/invalid,
+        the loader should fall back to the models_dir copy if one exists.
         """
         # Create a bad artifact in CWD-relative location.
         workdir = tmp_path / "workdir"
         workdir.mkdir()
         cwd_artifact_dir = workdir / "data" / "models"
         cwd_artifact_dir.mkdir(parents=True)
-        cwd_artifact = cwd_artifact_dir / "hybrid.json"
+        cwd_artifact = cwd_artifact_dir / "olsa.json"
         cwd_artifact.write_text(json.dumps({"artifact_type": "wrong"}))
 
         # Create the same relative name in models_dir (also bad — we just
         # want to verify the fallback attempt happens).
         models_dir = tmp_path / "shared_models"
         models_dir.mkdir()
-        fallback_artifact = models_dir / "data" / "models" / "hybrid.json"
+        fallback_artifact = models_dir / "data" / "models" / "olsa.json"
         fallback_artifact.parent.mkdir(parents=True)
         fallback_artifact.write_text(json.dumps({"artifact_type": "also_wrong"}))
 
         monkeypatch.chdir(workdir)
         config = HostedPlayConfig(
-            hybrid_olsa_artifact="data/models/hybrid.json",
+            olsa_artifact="data/models/olsa.json",
             models_dir=str(models_dir),
         )
         import logging
@@ -190,29 +188,29 @@ class TestHybridOlsa:
         with caplog.at_level(logging.WARNING, logger="web.ai_manager"):
             mgr = AIManager(config)
 
-        # Neither artifact is valid, so hybrid_olsa is not loaded.
-        assert "hybrid_olsa" not in mgr.available_models
+        # Neither artifact is valid, so olsa is not loaded.
+        assert "olsa" not in mgr.available_models
 
         # Both load attempts should be logged — CWD first, then models_dir.
         warning_messages = [
             r.message for r in caplog.records if r.levelno >= logging.WARNING
         ]
         assert any(
-            "Failed to load hybrid_olsa from data/models/hybrid.json" in m
+            "Failed to load OLSa from data/models/olsa.json" in m
             for m in warning_messages
         ), f"Expected CWD attempt warning; got: {warning_messages}"
         assert any(
             str(models_dir) in m and "Failed to load" in m for m in warning_messages
         ), f"Expected models_dir fallback attempt warning; got: {warning_messages}"
 
-    def test_hybrid_olsa_relative_without_models_dir_not_resolved(self):
+    def test_olsa_relative_without_models_dir_not_resolved(self):
         """A relative artifact with no models_dir stays relative (likely not found)."""
         config = HostedPlayConfig(
-            hybrid_olsa_artifact="nonexistent/hybrid.json",
+            olsa_artifact="nonexistent/olsa.json",
             models_dir=None,
         )
         mgr = AIManager(config)
-        assert "hybrid_olsa" not in mgr.available_models
+        assert "olsa" not in mgr.available_models
 
 
 # ---------------------------------------------------------------------------
@@ -223,8 +221,14 @@ class TestHybridOlsa:
 class TestDefaultModelFallback:
     """default_model_id falls back to heuristic if not in roster."""
 
-    def test_default_is_heuristic(self):
+    def test_default_is_heuristic_when_explicitly_set(self):
         config = HostedPlayConfig(default_model_id="heuristic")
+        mgr = AIManager(config)
+        assert mgr.default_model_id == "heuristic"
+
+    def test_default_olsa_falls_back_when_no_artifact(self):
+        """Default is 'olsa', but without artifact it falls back to heuristic."""
+        config = HostedPlayConfig(default_model_id="olsa")
         mgr = AIManager(config)
         assert mgr.default_model_id == "heuristic"
 

--- a/tests/unit/hosted_play/test_config.py
+++ b/tests/unit/hosted_play/test_config.py
@@ -25,11 +25,11 @@ class TestHostedPlayConfigDefaults:
 
     def test_default_model_id(self):
         cfg = HostedPlayConfig()
-        assert cfg.default_model_id == "heuristic"
+        assert cfg.default_model_id == "olsa"
 
-    def test_default_hybrid_olsa_artifact(self):
+    def test_default_olsa_artifact(self):
         cfg = HostedPlayConfig()
-        assert cfg.hybrid_olsa_artifact is None
+        assert cfg.olsa_artifact is None
 
     def test_default_debug(self):
         cfg = HostedPlayConfig()
@@ -111,7 +111,7 @@ class TestFromEnv:
             "ALLOWED_ORIGINS",
             "APP_URL",
             "DEFAULT_MODEL_ID",
-            "HYBRID_OLSA_ARTIFACT",
+            "OLSA_ARTIFACT",
             "MODELS_DIR",
             "DEBUG",
         ):
@@ -123,14 +123,14 @@ class TestFromEnv:
         assert cfg.database_url == "postgresql://localhost/test"
 
     def test_reads_default_model_id(self, monkeypatch):
-        monkeypatch.setenv("DEFAULT_MODEL_ID", "hybrid_olsa")
+        monkeypatch.setenv("DEFAULT_MODEL_ID", "olsa")
         cfg = HostedPlayConfig.from_env()
-        assert cfg.default_model_id == "hybrid_olsa"
+        assert cfg.default_model_id == "olsa"
 
-    def test_reads_hybrid_olsa_artifact(self, monkeypatch):
-        monkeypatch.setenv("HYBRID_OLSA_ARTIFACT", "/path/to/artifact.json")
+    def test_reads_olsa_artifact(self, monkeypatch):
+        monkeypatch.setenv("OLSA_ARTIFACT", "/path/to/artifact.json")
         cfg = HostedPlayConfig.from_env()
-        assert cfg.hybrid_olsa_artifact == "/path/to/artifact.json"
+        assert cfg.olsa_artifact == "/path/to/artifact.json"
 
     def test_debug_true_values(self, monkeypatch):
         for val in ("1", "true", "yes", "True", "YES"):
@@ -199,8 +199,8 @@ class TestFromEnv:
         assert cfg.secret_key.startswith("dev-insecure-")
         assert cfg.allowed_origins == ["*"]
         assert cfg.app_url == "http://localhost:8000"
-        assert cfg.default_model_id == "heuristic"
-        assert cfg.hybrid_olsa_artifact is None
+        assert cfg.default_model_id == "olsa"
+        assert cfg.olsa_artifact is None
         assert cfg.models_dir is None
         assert cfg.debug is False
 
@@ -221,7 +221,7 @@ class TestOverrideGetConfig:
             "ALLOWED_ORIGINS",
             "APP_URL",
             "DEFAULT_MODEL_ID",
-            "HYBRID_OLSA_ARTIFACT",
+            "OLSA_ARTIFACT",
             "MODELS_DIR",
             "DEBUG",
         ):
@@ -257,14 +257,14 @@ class TestOverrideGetConfig:
     def test_round_trip(self):
         original = HostedPlayConfig(
             database_url="sqlite:///test.db",
-            default_model_id="hybrid_olsa",
+            default_model_id="olsa",
             debug=True,
         )
         override_config(original)
         try:
             retrieved = get_config()
             assert retrieved.database_url == "sqlite:///test.db"
-            assert retrieved.default_model_id == "hybrid_olsa"
+            assert retrieved.default_model_id == "olsa"
             assert retrieved.debug is True
         finally:
             override_config(None)

--- a/tests/unit/hosted_play/test_state.py
+++ b/tests/unit/hosted_play/test_state.py
@@ -300,7 +300,7 @@ class TestMatchState:
     def test_round_trip_with_nested_hand_state(self) -> None:
         state = MatchState(
             seed=42,
-            ai_model="hybrid_olsa",
+            ai_model="olsa",
             score_human=12,
             score_ai=-3,
             hands_played=4,
@@ -425,7 +425,7 @@ class TestMatchState:
         """Full MatchState with nested hand survives json.dumps/loads."""
         state = MatchState(
             seed=42,
-            ai_model="hybrid_olsa",
+            ai_model="olsa",
             score_human=5,
             score_ai=3,
             hands_played=2,

--- a/web/ai_manager.py
+++ b/web/ai_manager.py
@@ -1,9 +1,14 @@
 """AI model roster management for hosted play.
 
-V1 roster: ``heuristic`` (always available) and ``hybrid_olsa`` (available
-when an artifact path is configured).  Models are preloaded once at app
-startup and cached in ``app.state.ai_manager``.  Routes never load
-artifacts on demand.
+Expansion roster: ``heuristic`` (always available, smoke/fallback) and
+``olsa`` (R3 ``full_ols_av`` ``ActionValueBidder``, available when an
+artifact path is configured).  Models are preloaded once at app startup
+and cached in ``app.state.ai_manager``.  Routes never load artifacts on
+demand.
+
+The V1 ``hybrid_olsa`` roster entry has been removed because
+``HybridOLSaBidder`` only produces regular bids and is not moon/loner-
+capable.  See ``plans/browser_game_expansion/governing_plan.md`` §5.2.
 """
 
 from __future__ import annotations
@@ -35,9 +40,11 @@ class ModelInfo:
 class AIManager:
     """Preloads approved bidding policies and play strategies at startup.
 
-    The V1 roster is configuration-backed (no database ``model_registry``
-    table).  ``heuristic`` is always available; ``hybrid_olsa`` is loaded
-    when ``config.hybrid_olsa_artifact`` points to a valid artifact file.
+    The expansion roster is configuration-backed (no database
+    ``model_registry`` table).  ``heuristic`` is always available as a
+    smoke/fallback model; ``olsa`` is loaded when
+    ``config.olsa_artifact`` points to a valid ``action_value_olsa_v1``
+    artifact file.
     """
 
     def __init__(self, config: HostedPlayConfig) -> None:
@@ -65,8 +72,8 @@ class AIManager:
     # ------------------------------------------------------------------
 
     def _load_models(self, config: HostedPlayConfig) -> None:
-        """Register and preload the approved V1 roster."""
-        # 1. heuristic — always available
+        """Register and preload the approved expansion roster."""
+        # 1. heuristic — always available (smoke/fallback)
         self.available_models["heuristic"] = ModelInfo(
             id="heuristic",
             name="Heuristic",
@@ -75,8 +82,9 @@ class AIManager:
             play_strategy=GluttonStrategy(),
         )
 
-        # 2. hybrid_olsa — available when artifact path is set and exists
-        self._try_load_hybrid_olsa(config)
+        # 2. olsa — R3 full_ols_av ActionValueBidder, available when artifact
+        #    path is set and the artifact loads successfully.
+        self._try_load_olsa(config)
 
         # Validate default_model_id is available
         if self.default_model_id not in self.available_models:
@@ -86,15 +94,15 @@ class AIManager:
             )
             self.default_model_id = "heuristic"
 
-    def _try_load_hybrid_olsa(self, config: HostedPlayConfig) -> None:
-        """Attempt to load hybrid_olsa, resolving artifact path with fallback.
+    def _try_load_olsa(self, config: HostedPlayConfig) -> None:
+        """Attempt to load the OLSa model (ActionValueBidder).
 
         Resolution order for relative paths when ``models_dir`` is configured:
         1. Try the CWD-relative path first (preserve existing local artifacts).
         2. If CWD path doesn't exist **or** loading from it fails, fall back to
            ``models_dir / artifact_path``.
         """
-        artifact_path = config.hybrid_olsa_artifact
+        artifact_path = config.olsa_artifact
         if not artifact_path:
             return
 
@@ -116,28 +124,32 @@ class AIManager:
             if not os.path.isfile(path):
                 continue
             try:
-                from bid_euchre.strategy.bidding import HybridOLSaBidder
+                from bid_euchre.strategy.bidding import ActionValueBidder
 
-                self.available_models["hybrid_olsa"] = ModelInfo(
-                    id="hybrid_olsa",
-                    name="Hybrid OLSa",
+                self.available_models["olsa"] = ModelInfo(
+                    id="olsa",
+                    name="OLSa",
                     description=(
-                        "Statistical bidder (OLS payoff model with "
-                        "risk-aware evaluation) and greedy play."
+                        "Action-value bidder (R3 full_ols_av) with "
+                        "greedy play strategy."
                     ),
-                    bidding_policy=HybridOLSaBidder(artifact_path=path),
+                    bidding_policy=ActionValueBidder(
+                        artifact_path=path,
+                        name="olsa",
+                        skip_behavioral_check=True,
+                    ),
                     play_strategy=GluttonStrategy(),
                 )
-                logger.info("Loaded hybrid_olsa model from %s", path)
+                logger.info("Loaded OLSa model from %s", path)
                 return
             except Exception:
                 logger.warning(
-                    "Failed to load hybrid_olsa from %s",
+                    "Failed to load OLSa from %s",
                     path,
                     exc_info=True,
                 )
 
         logger.info(
-            "hybrid_olsa artifact configured but not loadable: %s",
+            "OLSa artifact configured but not loadable: %s",
             artifact_path,
         )

--- a/web/config.py
+++ b/web/config.py
@@ -4,8 +4,8 @@ Settings are loaded from environment variables with sensible defaults
 for local development.  Production deployments override via env vars
 (e.g. ``DATABASE_URL`` for Postgres).
 
-Environment variable contract (Phase 5 §5.2)
----------------------------------------------
+Environment variable contract (Expansion §5.2)
+-----------------------------------------------
 
 =========================================  =============================================
 Variable                                   Purpose
@@ -16,7 +16,7 @@ Variable                                   Purpose
 ``APP_URL``                                Public base URL for generated links
 ``MODELS_DIR``                             Directory containing model artifacts
 ``DEFAULT_MODEL_ID``                       Default AI model identifier
-``HYBRID_OLSA_ARTIFACT``                   Path to hybrid-OLSA artifact file
+``OLSA_ARTIFACT``                          Path to OLSa (ActionValueBidder) artifact file
 ``DEBUG``                                  Enable debug mode (``1``/``true``/``yes``)
 =========================================  =============================================
 """
@@ -64,8 +64,8 @@ class HostedPlayConfig:
     app_url: str = "http://localhost:8000"
 
     # AI model roster ---------------------------------------------------
-    default_model_id: str = "heuristic"
-    hybrid_olsa_artifact: str | None = None
+    default_model_id: str = "olsa"
+    olsa_artifact: str | None = None
     models_dir: str | None = None
 
     # App ---------------------------------------------------------------
@@ -81,8 +81,8 @@ class HostedPlayConfig:
             secret_key=os.environ.get("SECRET_KEY", _default_secret_key()),
             allowed_origins=_parse_origins(raw_origins),
             app_url=os.environ.get("APP_URL", "http://localhost:8000"),
-            default_model_id=os.environ.get("DEFAULT_MODEL_ID", "heuristic"),
-            hybrid_olsa_artifact=os.environ.get("HYBRID_OLSA_ARTIFACT"),
+            default_model_id=os.environ.get("DEFAULT_MODEL_ID", "olsa"),
+            olsa_artifact=os.environ.get("OLSA_ARTIFACT"),
             models_dir=os.environ.get("MODELS_DIR"),
             debug=os.environ.get("DEBUG", "").lower() in ("1", "true", "yes"),
         )


### PR DESCRIPTION
## Plan
`plans/browser_game_expansion/governing_plan.md` §5.2 (Model Serving Contract)
`plans/browser_game_expansion/pr_roadmap.md` PR-2

## Summary
- Replace the V1 `hybrid_olsa` browser model roster entry with the R3 `full_ols_av` `ActionValueBidder`, exposed as "OLSa"
- Rename env var `HYBRID_OLSA_ARTIFACT` → `OLSA_ARTIFACT`, default model `heuristic` → `olsa`
- Graceful fallback: when no artifact is configured, `olsa` default falls back to `heuristic`
- Update deployment docs, .env.example, and all hosted-play tests

## Why
The expansion governing plan (§5.2) requires replacing `HybridOLSaBidder` with
`ActionValueBidder` because the hybrid bidder only produces regular bids and is
not moon/loner-capable. The `full_ols_av` artifact is the R3-promoted model.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/ -v   # 269 passed
```

**Config:** N/A (config migration, no experiment)
**Seed:** N/A

## Test Criteria
- **Pass condition:** All hosted-play tests pass with renamed config fields and model IDs
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/ -v`
- **Expected result:** 269 passed, 0 failed

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/ -v` — 269 passed
- [x] `make check-quiet` — 7233 passed, 1 pre-existing failure in unrelated `test_hook_dispatchers.py`
- [x] Pre-commit hooks pass (ruff, ruff-format, repo-linter)

## Expected impact
- Metrics impact: None (config/roster migration only)
- Runtime impact: None (ActionValueBidder has same startup cost as HybridOLSaBidder when artifact exists)

## Risk level
- [x] Low (config + test migration, no rule/scoring changes)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git worktree list` (truncated):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a   8177cead [browser/expansion-olsa-roster]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)