### PR TITLE
fix(ops): demote individual stale-lane alerts to low, add fleet-wide HIGH (#1775)

### DIFF
--- a/src/bid_euchre/ops/dashboard.py
+++ b/src/bid_euchre/ops/dashboard.py
@@ -209,6 +209,12 @@ class DashboardView:
 # ---------------------------------------------------------------------------
 
 
+#: Lane classes considered "worker" lanes for fleet-wide idle detection.
+#: Control-plane lanes (ops, review) are excluded — their idleness is normal
+#: and should not contribute to a fleet-stuck determination.
+_WORKER_LANE_CLASSES: frozenset[str] = frozenset({"author", "analyst", "scratch"})
+
+
 def _derive_attention_items(
     report: StatusReport,
 ) -> list[AttentionItem]:
@@ -216,8 +222,14 @@ def _derive_attention_items(
 
     Priority order:
     - blocked lanes/tasks -> high
-    - stale lanes -> medium
+    - all worker lanes idle/stale -> high (fleet stuck)
+    - stale lanes -> low (informational)
     - idle persistent lanes -> low
+
+    Individual lane staleness is ``low`` (informational) — it is normal for
+    some lanes to sit idle during fleet runs.  A ``high`` fleet-level alert
+    fires only when **all** author/analyst/scratch lanes are idle or stale,
+    indicating the entire fleet may be stuck (#1775).
 
     Args:
         report: Aggregated status report.
@@ -243,12 +255,14 @@ def _derive_attention_items(
                 )
             )
         elif lane.state == "stale" or ("stale" in reason.lower() if reason else False):
+            # Individual stale lanes are informational — it's normal for some
+            # lanes to be unused during fleet runs (#1775).
             items.append(
                 AttentionItem(
                     lane_id=lane.lane_id,
-                    severity="medium",
+                    severity="low",
                     reason=reason,
-                    suggested_action="check if agent died",
+                    suggested_action="check if agent died (informational)",
                 )
             )
         else:
@@ -257,6 +271,28 @@ def _derive_attention_items(
                     lane_id=lane.lane_id,
                     severity="low",
                     reason=reason,
+                )
+            )
+
+    # Fleet-wide idle check: if ALL worker lanes are idle or stale, the
+    # entire fleet may be stuck — escalate to high (#1775).
+    worker_lanes = [
+        lane for lane in report.lanes if lane.lane_class in _WORKER_LANE_CLASSES
+    ]
+    if worker_lanes:
+        all_idle_or_stale = all(
+            lane.state in ("idle", "stale") for lane in worker_lanes
+        )
+        if all_idle_or_stale:
+            items.append(
+                AttentionItem(
+                    lane_id="fleet",
+                    severity="high",
+                    reason=(
+                        f"All {len(worker_lanes)} worker lanes are idle or "
+                        f"stale — fleet may be stuck"
+                    ),
+                    suggested_action="check if fleet is stuck; consider dispatch or shutoff",
                 )
             )
 

--- a/tests/unit/test_ops_dashboard.py
+++ b/tests/unit/test_ops_dashboard.py
@@ -43,6 +43,21 @@ def _write_json(directory: Path, filename: str, data: dict) -> None:
     (directory / filename).write_text(json.dumps(data, indent=2))
 
 
+def _derive_test_lane_class(lane_id: str) -> str:
+    """Mirror ``worktrees.derive_lane_class`` logic for test helpers."""
+    if lane_id == "ops":
+        return "ops"
+    if lane_id == "review":
+        return "review"
+    if lane_id.startswith("analyst"):
+        return "analyst"
+    if lane_id.endswith("-scratch"):
+        return "scratch"
+    if lane_id.startswith("author") or lane_id.startswith("flex"):
+        return "author"
+    return lane_id
+
+
 def _make_lane(
     lane_id: str,
     *,
@@ -62,7 +77,7 @@ def _make_lane(
     """Create a LaneStatus for testing."""
     return LaneStatus(
         lane_id=lane_id,
-        lane_class="author" if lane_id.startswith("author") else lane_id,
+        lane_class=_derive_test_lane_class(lane_id),
         worktree_path=f"/tmp/{lane_id}",
         branch=branch,
         lifecycle_class="persistent",
@@ -198,7 +213,8 @@ class TestDeriveAttentionItems:
         assert items[0].severity == "high"
         assert items[0].lane_id == "author-a"
 
-    def test_stale_lane_is_medium(self) -> None:
+    def test_stale_lane_is_low(self) -> None:
+        """Individual stale lanes are low severity, not medium (#1775)."""
         report = StatusReport(
             lanes=[
                 _make_lane(
@@ -210,8 +226,10 @@ class TestDeriveAttentionItems:
             ]
         )
         items = _derive_attention_items(report)
-        assert len(items) == 1
-        assert items[0].severity == "medium"
+        # Individual stale → low; fleet-wide all-stale → high
+        low_items = [i for i in items if i.severity == "low"]
+        assert len(low_items) == 1
+        assert low_items[0].lane_id == "author-b"
 
     def test_idle_lane_is_low(self) -> None:
         report = StatusReport(
@@ -229,6 +247,7 @@ class TestDeriveAttentionItems:
         assert items[0].severity == "low"
 
     def test_severity_ordering(self) -> None:
+        """Blocked → high; stale/idle → low.  Fleet alert also high (#1775)."""
         report = StatusReport(
             lanes=[
                 _make_lane(
@@ -252,20 +271,129 @@ class TestDeriveAttentionItems:
             ]
         )
         items = _derive_attention_items(report)
-        assert len(items) == 3
+        # blocked author-a → high, stale author-b → low, idle review → low
+        # Plus: author-a is blocked (not idle/stale) so not all worker lanes
+        # are idle — no fleet alert.
+        high_items = [i for i in items if i.severity == "high"]
+        low_items = [i for i in items if i.severity == "low"]
+        assert len(high_items) == 1
+        assert high_items[0].lane_id == "author-a"
+        assert len(low_items) == 2
+        # High items come first in sort order
         assert items[0].severity == "high"
-        assert items[1].severity == "medium"
-        assert items[2].severity == "low"
 
     def test_no_attention_lanes_skipped(self) -> None:
         report = StatusReport(
             lanes=[
                 _make_lane("ops", state="active", attention_needed=False),
-                _make_lane("author-a", state="idle", attention_needed=False),
+                _make_lane("author-a", state="active", attention_needed=False),
             ]
         )
         items = _derive_attention_items(report)
         assert items == []
+
+    def test_all_worker_lanes_idle_triggers_fleet_alert(self) -> None:
+        """HIGH fleet alert when ALL author/analyst lanes are idle/stale (#1775)."""
+        report = StatusReport(
+            lanes=[
+                _make_lane(
+                    "author-a",
+                    state="stale",
+                    attention_needed=True,
+                    attention_reason="stale heartbeat",
+                ),
+                _make_lane(
+                    "author-b",
+                    state="idle",
+                    attention_needed=True,
+                    attention_reason="persistent lane idle",
+                ),
+            ]
+        )
+        items = _derive_attention_items(report)
+        fleet_items = [i for i in items if i.lane_id == "fleet"]
+        assert len(fleet_items) == 1
+        assert fleet_items[0].severity == "high"
+        assert "worker lanes" in fleet_items[0].reason
+
+    def test_some_active_worker_lanes_no_fleet_alert(self) -> None:
+        """No fleet alert when some worker lanes are active (#1775)."""
+        report = StatusReport(
+            lanes=[
+                _make_lane(
+                    "author-a",
+                    state="active",
+                    attention_needed=False,
+                ),
+                _make_lane(
+                    "author-b",
+                    state="stale",
+                    attention_needed=True,
+                    attention_reason="stale heartbeat",
+                ),
+            ]
+        )
+        items = _derive_attention_items(report)
+        fleet_items = [i for i in items if i.lane_id == "fleet"]
+        assert len(fleet_items) == 0
+
+    def test_control_plane_excluded_from_fleet_check(self) -> None:
+        """Control-plane lanes (ops, review) don't count for fleet alert (#1775)."""
+        report = StatusReport(
+            lanes=[
+                # Control-plane lanes — idle, but shouldn't trigger fleet alert
+                _make_lane(
+                    "ops",
+                    state="idle",
+                    attention_needed=True,
+                    attention_reason="persistent lane idle",
+                ),
+                _make_lane(
+                    "review",
+                    state="idle",
+                    attention_needed=True,
+                    attention_reason="persistent lane idle",
+                ),
+            ]
+        )
+        items = _derive_attention_items(report)
+        fleet_items = [i for i in items if i.lane_id == "fleet"]
+        # ops (lane_class="ops") and review (lane_class="review") are not
+        # worker-class lanes, so no fleet alert should fire.
+        assert len(fleet_items) == 0
+
+    def test_analyst_lanes_included_in_fleet_check(self) -> None:
+        """Analyst lanes are worker-class and count for fleet alert (#1775)."""
+        report = StatusReport(
+            lanes=[
+                _make_lane(
+                    "analyst-a",
+                    state="stale",
+                    attention_needed=True,
+                    attention_reason="stale heartbeat",
+                ),
+            ]
+        )
+        items = _derive_attention_items(report)
+        fleet_items = [i for i in items if i.lane_id == "fleet"]
+        assert len(fleet_items) == 1
+        assert fleet_items[0].severity == "high"
+
+    def test_no_worker_lanes_no_fleet_alert(self) -> None:
+        """No fleet alert when there are no worker lanes at all (#1775)."""
+        report = StatusReport(
+            lanes=[
+                _make_lane(
+                    "ops",
+                    state="idle",
+                    attention_needed=True,
+                    attention_reason="persistent lane idle",
+                ),
+            ]
+        )
+        items = _derive_attention_items(report)
+        fleet_items = [i for i in items if i.lane_id == "fleet"]
+        assert len(fleet_items) == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Demote individual stale-lane attention items from `medium` to `low` severity
- Add fleet-wide `high` alert when ALL worker lanes (author/analyst/scratch) are idle or stale
- Control-plane lanes (ops, review) excluded from fleet-wide check

## Why

During normal fleet operations, it's common for some lanes to sit idle — they may not have work assigned yet or their work is complete. The previous `medium` severity for individual lane staleness created 14+ noise items in the dashboard Attention section, drowning out real issues. Individual staleness should be informational; only fleet-wide idleness warrants operator attention.

Closes #1775

## Changes

| File | Change |
|------|--------|
| `src/bid_euchre/ops/dashboard.py` | `_derive_attention_items()`: stale lanes → `low`; new fleet-wide idle check → `high` |
| `tests/unit/test_ops_dashboard.py` | Updated 3 existing tests, added 6 new tests for fleet alert behavior |

## Repro / Validation

```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/test_ops_dashboard.py -v

# Tier 2 — full validation
make check-quiet
```

## Tests

- `test_stale_lane_is_low` — individual stale lane → low (was medium)
- `test_severity_ordering` — updated: blocked=high, stale/idle=low
- `test_no_attention_lanes_skipped` — updated: active worker lane, no items
- `test_all_worker_lanes_idle_triggers_fleet_alert` — all idle/stale → high fleet alert
- `test_some_active_worker_lanes_no_fleet_alert` — mixed states → no fleet alert
- `test_control_plane_excluded_from_fleet_check` — ops/review don't trigger fleet alert
- `test_analyst_lanes_included_in_fleet_check` — analyst lanes are worker-class
- `test_no_worker_lanes_no_fleet_alert` — no worker lanes → no fleet alert

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-scratch
branch: fix/stale-lane-severity-1775
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)