### PR TITLE
fix(ops): clear lane session before dispatching new work (#1793)

### DIFF
--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -1236,6 +1236,8 @@ def dispatch_to_worker(
     4b. Copy dispatched packet JSON to the target worktree's task_queue
         so the author lane can discover it via ``/start-task``.
     5. Write inbox message via message_bus (audit trail).
+    5b. Send ``/clear`` to the lane pane if not already cleared by steps
+        3a/3b, and the pane is alive.  Waits 3s for session reset.
     6. Nudge the target pane with ``/start-task <packet_id>``.
     7. Record delivery outcome (update inbox message status).
     8. Set lane visibility to "foreground".
@@ -1339,6 +1341,9 @@ def dispatch_to_worker(
                 error=f"wake_failed:{wake_result.error}",
             )
 
+    # Track whether /clear was already sent to avoid double-clearing.
+    session_cleared = False
+
     # 3a. Auto-refresh stale worktrees
     #     Skip if caller already requested explicit reset (step 3b does the same
     #     thing) or if auto-refresh is disabled.
@@ -1356,6 +1361,7 @@ def dispatch_to_worker(
             )
             if auto_refresh.executed:
                 logger.info("Auto-refresh succeeded for %s", lane_id)
+                session_cleared = True
                 import time
 
                 # Brief pause to let /clear complete before sending /start-task
@@ -1385,6 +1391,7 @@ def dispatch_to_worker(
                 lane_id,
                 clear_result.reason,
             )
+        session_cleared = True
         import time
 
         # Brief pause to let /clear complete before sending /start-task
@@ -1469,6 +1476,32 @@ def dispatch_to_worker(
             packet_id,
             exc,
         )
+
+    # 5b. Clear stale context before nudging (unless already cleared above).
+    #     Prevents the lane from carrying 70-150k tokens of old task context
+    #     into a new task.  Skipped if the pane is not alive (fresh boot).
+    if not session_cleared:
+        pane_alive = _probe_tmux_pane(lane_id, tmux_session, runtime_dir=runtime_dir)
+        if pane_alive:
+            clear_result = clear_session(
+                lane_id, tmux_session=tmux_session, runtime_dir=runtime_dir
+            )
+            if clear_result.executed:
+                import time
+
+                # Pause to let /clear complete before sending /start-task
+                time.sleep(3)
+            else:
+                logger.warning(
+                    "Pre-nudge session clear failed for %s: %s (continuing)",
+                    lane_id,
+                    clear_result.reason,
+                )
+        else:
+            logger.info(
+                "Lane %s has no active pane; skipping pre-nudge /clear",
+                lane_id,
+            )
 
     # 6. Nudge the target pane
     nudge_result = nudge_pane(lane_id, packet_id, tmux_session=tmux_session)

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -2270,7 +2270,10 @@ class TestDispatchWithReset:
         mock_vis: MagicMock,
         runtime_dir: Path,
     ) -> None:
-        """Dispatch with reset=False (default) should NOT call reset_worktree."""
+        """Dispatch with reset=False (default) should NOT call reset_worktree.
+
+        The pre-nudge /clear is still called via the session_cleared path.
+        """
         from bid_euchre.ops.task_queue import TaskPacket
 
         mock_load.return_value = TaskPacket(
@@ -2293,13 +2296,22 @@ class TestDispatchWithReset:
         with (
             patch(f"{_WORKER_POOL}.reset_worktree") as mock_reset,
             patch(f"{_WORKER_POOL}.clear_session") as mock_clear,
+            patch(f"{_WORKER_POOL}._probe_tmux_pane", return_value=True),
+            patch("time.sleep"),
         ):
+            mock_clear.return_value = PoolAction(
+                action="clear_session",
+                lane_id="author-a",
+                reason="Clear OK",
+                executed=True,
+            )
             result = dispatch_to_worker(
                 "pkt1", "author-a", runtime_dir=runtime_dir, reset=False
             )
             assert result.executed is True
             mock_reset.assert_not_called()
-            mock_clear.assert_not_called()
+            # Pre-nudge /clear IS called (for stale context prevention)
+            mock_clear.assert_called_once()
 
     @patch(f"{_DASHBOARD}.set_lane_visibility")
     @patch(f"{_WORKER_POOL}.nudge_pane")
@@ -2592,6 +2604,9 @@ class TestDispatchAutoRefresh:
 
     @patch(f"{_DASHBOARD}.set_lane_visibility")
     @patch(f"{_WORKER_POOL}.nudge_pane")
+    @patch("time.sleep")
+    @patch(f"{_WORKER_POOL}.clear_session")
+    @patch(f"{_WORKER_POOL}._probe_tmux_pane")
     @patch(f"{_WORKER_POOL}.refresh_worker")
     @patch(f"{_WORKER_POOL}._is_worktree_stale")
     @patch(f"{_WORKER_POOL}.take_pool_snapshot")
@@ -2606,11 +2621,18 @@ class TestDispatchAutoRefresh:
         mock_snapshot: MagicMock,
         mock_stale: MagicMock,
         mock_refresh: MagicMock,
+        mock_probe: MagicMock,
+        mock_clear: MagicMock,
+        mock_sleep: MagicMock,
         mock_nudge: MagicMock,
         mock_vis: MagicMock,
         runtime_dir: Path,
     ) -> None:
-        """Dispatch should succeed even when auto-refresh fails."""
+        """Dispatch should succeed even when auto-refresh fails.
+
+        When auto-refresh fails, session_cleared stays False so the
+        pre-nudge /clear path fires.
+        """
         from bid_euchre.ops.task_queue import TaskPacket
 
         mock_load.return_value = TaskPacket(
@@ -2631,6 +2653,13 @@ class TestDispatchAutoRefresh:
             executed=False,
             error="dirty_worktree",
         )
+        mock_probe.return_value = True
+        mock_clear.return_value = PoolAction(
+            action="clear_session",
+            lane_id="author-a",
+            reason="Clear OK",
+            executed=True,
+        )
         mock_nudge.return_value = PoolAction(
             action="nudge",
             lane_id="author-a",
@@ -2642,6 +2671,250 @@ class TestDispatchAutoRefresh:
         # Dispatch should still succeed despite refresh failure
         assert result.executed is True
         mock_refresh.assert_called_once()
+        # Pre-nudge /clear fires because auto-refresh didn't clear
+        mock_clear.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Pre-nudge /clear
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchPreNudgeClear:
+    """Test pre-nudge /clear behavior in dispatch_to_worker()."""
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}.nudge_pane")
+    @patch("time.sleep")
+    @patch(f"{_WORKER_POOL}.clear_session")
+    @patch(f"{_WORKER_POOL}._probe_tmux_pane")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.transition_status")
+    @patch(f"{_TASK_QUEUE}.save_packet")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_clears_session_before_nudge(
+        self,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_transition: MagicMock,
+        mock_snapshot: MagicMock,
+        mock_probe: MagicMock,
+        mock_clear: MagicMock,
+        mock_sleep: MagicMock,
+        mock_nudge: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """Normal dispatch (no reset, not stale) sends /clear before /start-task."""
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test Task",
+            description="Do the thing",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool([_make_worker("author-a", "idle")])
+        mock_probe.return_value = True
+        mock_clear.return_value = PoolAction(
+            action="clear_session",
+            lane_id="author-a",
+            reason="Clear OK",
+            executed=True,
+        )
+        mock_nudge.return_value = PoolAction(
+            action="nudge",
+            lane_id="author-a",
+            reason="Nudge OK",
+            executed=True,
+        )
+
+        result = dispatch_to_worker("pkt1", "author-a", runtime_dir=runtime_dir)
+        assert result.executed is True
+
+        # Pre-nudge /clear should have been called
+        mock_clear.assert_called_once()
+        mock_probe.assert_called_once()
+        # Sleep 3s for session reset
+        mock_sleep.assert_called_once_with(3)
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}.nudge_pane")
+    @patch("time.sleep")
+    @patch(f"{_WORKER_POOL}.clear_session")
+    @patch(f"{_WORKER_POOL}._probe_tmux_pane")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.transition_status")
+    @patch(f"{_TASK_QUEUE}.save_packet")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_skips_clear_when_pane_not_alive(
+        self,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_transition: MagicMock,
+        mock_snapshot: MagicMock,
+        mock_probe: MagicMock,
+        mock_clear: MagicMock,
+        mock_sleep: MagicMock,
+        mock_nudge: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """Pre-nudge /clear is skipped when the pane is not alive (fresh boot)."""
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test Task",
+            description="Do the thing",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool([_make_worker("author-a", "idle")])
+        mock_probe.return_value = False  # No active pane
+        mock_nudge.return_value = PoolAction(
+            action="nudge",
+            lane_id="author-a",
+            reason="Nudge OK",
+            executed=True,
+        )
+
+        result = dispatch_to_worker("pkt1", "author-a", runtime_dir=runtime_dir)
+        assert result.executed is True
+
+        # /clear should NOT have been called — pane is not alive
+        mock_clear.assert_not_called()
+        mock_sleep.assert_not_called()
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}.nudge_pane")
+    @patch("time.sleep")
+    @patch(f"{_WORKER_POOL}.clear_session")
+    @patch(f"{_WORKER_POOL}._probe_tmux_pane")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.transition_status")
+    @patch(f"{_TASK_QUEUE}.save_packet")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_skips_pre_nudge_clear_when_reset_already_cleared(
+        self,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_transition: MagicMock,
+        mock_snapshot: MagicMock,
+        mock_probe: MagicMock,
+        mock_clear: MagicMock,
+        mock_sleep: MagicMock,
+        mock_nudge: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """When reset=True clears the session, pre-nudge /clear is skipped."""
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test Task",
+            description="Do the thing",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool([_make_worker("author-a", "idle")])
+        mock_nudge.return_value = PoolAction(
+            action="nudge",
+            lane_id="author-a",
+            reason="Nudge OK",
+            executed=True,
+        )
+
+        with patch(f"{_WORKER_POOL}.reset_worktree") as mock_reset:
+            mock_reset.return_value = PoolAction(
+                action="reset_worktree",
+                lane_id="author-a",
+                reason="Reset OK",
+                executed=True,
+            )
+            mock_clear.return_value = PoolAction(
+                action="clear_session",
+                lane_id="author-a",
+                reason="Clear OK",
+                executed=True,
+            )
+
+            result = dispatch_to_worker(
+                "pkt1", "author-a", runtime_dir=runtime_dir, reset=True
+            )
+            assert result.executed is True
+
+            # clear_session called once (by reset path), NOT twice
+            mock_clear.assert_called_once()
+            # _probe_tmux_pane should NOT be checked — session already cleared
+            mock_probe.assert_not_called()
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}.nudge_pane")
+    @patch("time.sleep")
+    @patch(f"{_WORKER_POOL}.clear_session")
+    @patch(f"{_WORKER_POOL}._probe_tmux_pane")
+    @patch(f"{_WORKER_POOL}.take_pool_snapshot")
+    @patch(f"{_TASK_QUEUE}.transition_status")
+    @patch(f"{_TASK_QUEUE}.save_packet")
+    @patch(f"{_TASK_QUEUE}.load_packet")
+    def test_dispatch_continues_if_pre_nudge_clear_fails(
+        self,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_transition: MagicMock,
+        mock_snapshot: MagicMock,
+        mock_probe: MagicMock,
+        mock_clear: MagicMock,
+        mock_sleep: MagicMock,
+        mock_nudge: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """Dispatch succeeds even if the pre-nudge /clear fails (best-effort)."""
+        from bid_euchre.ops.task_queue import TaskPacket
+
+        mock_load.return_value = TaskPacket(
+            packet_id="pkt1",
+            title="Test Task",
+            description="Do the thing",
+            owner=None,
+            created_by="orchestrator",
+            created_at="2026-03-22T12:00:00Z",
+            status="approved",
+        )
+        mock_snapshot.return_value = _make_pool([_make_worker("author-a", "idle")])
+        mock_probe.return_value = True
+        mock_clear.return_value = PoolAction(
+            action="clear_session",
+            lane_id="author-a",
+            reason="Clear failed: tmux timeout",
+            executed=False,
+            error="clear_failed",
+        )
+        mock_nudge.return_value = PoolAction(
+            action="nudge",
+            lane_id="author-a",
+            reason="Nudge OK",
+            executed=True,
+        )
+
+        result = dispatch_to_worker("pkt1", "author-a", runtime_dir=runtime_dir)
+        assert result.executed is True
+
+        # /clear was attempted but failed — no sleep
+        mock_clear.assert_called_once()
+        mock_sleep.assert_not_called()
+        # nudge still fires
+        mock_nudge.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Plan
N/A — single-issue fix

## Summary
- Task dispatch now sends `/clear` to the lane's tmux pane before `/start-task` to prevent stale context accumulation
- Skips the clear if the session was already cleared by the reset or auto-refresh paths, or if the pane has no active session (fresh boot)
- Adds 4 new tests covering the pre-nudge clear behavior (normal clear, skip on dead pane, skip on already-cleared, best-effort on failure)

## Why
When `task dispatch` sends new work to a lane that previously completed a different task, the lane's Claude Code session still has the old task's context loaded (potentially 70-150k tokens of stale context). This wastes tokens and risks the lane confusing old and new task context. Closes #1793.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_worker_pool.py -k "dispatch" -v
make check-quiet
```

## Test Criteria
- **Pass condition:** All 29 dispatch tests pass, including 4 new pre-nudge clear tests
- **Verification command:** `uv run python -m pytest tests/unit/test_ops_worker_pool.py -k "PreNudgeClear" -v`
- **Expected result:** 4 tests pass: `test_dispatch_clears_session_before_nudge`, `test_dispatch_skips_clear_when_pane_not_alive`, `test_dispatch_skips_pre_nudge_clear_when_reset_already_cleared`, `test_dispatch_continues_if_pre_nudge_clear_fails`

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_worker_pool.py` (175 passed)
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None
- Runtime impact: Adds ~3s delay per dispatch (for `/clear` to complete) — intentional and documented in #1793

## Risk level
- [x] Low (ops tooling only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c  98218368 [fix/dispatch-clear-session-1793]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)