### PR TITLE
feat(ops): wire away-mode and queue-priority into orchestrator CLI (#1806)

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -58,6 +58,8 @@ Usage:
     uv run python scripts/internal/ops.py usage lanes [--output-dir DIR] [--json]
     uv run python scripts/internal/ops.py usage throughput [--output-dir DIR] [--json]
     uv run python scripts/internal/ops.py usage anti-patterns [--output-dir DIR] [--json]
+    uv run python scripts/internal/ops.py away status [--last-interaction ISO] [--idle N] [--away N] [--extended-away N] [--json]
+    uv run python scripts/internal/ops.py away reorder [--preferred-lane LANE] [--status STATUS] [--json]
 """
 
 from __future__ import annotations
@@ -3039,6 +3041,190 @@ def cmd_usage(args: argparse.Namespace) -> int:
         return 1
 
 
+def cmd_away(args: argparse.Namespace) -> int:
+    """Operator away-mode detection and queue priority reorder (Platform-9b)."""
+    action = getattr(args, "away_action", None)
+
+    if action == "status":
+        from datetime import datetime as _dt
+
+        from bid_euchre.ops.away_mode import (
+            EscalationThresholds,
+            detect_operator_state,
+        )
+
+        # Parse --now override
+        now = None
+        if getattr(args, "now", None):
+            now = _dt.fromisoformat(args.now)
+            if now.tzinfo is None:
+                from datetime import timezone as _tz
+
+                now = now.replace(tzinfo=_tz.utc)
+
+        # Parse --last-interaction or auto-detect from events
+        last_interaction = None
+        if getattr(args, "last_interaction", None):
+            last_interaction = _dt.fromisoformat(args.last_interaction)
+            if last_interaction.tzinfo is None:
+                from datetime import timezone as _tz
+
+                last_interaction = last_interaction.replace(tzinfo=_tz.utc)
+        else:
+            # Auto-detect: find the most recent UserPromptSubmit event
+            try:
+                from bid_euchre.ops.events import read_events
+
+                events_dir = args.runtime_dir / "events" if args.runtime_dir else None
+                events = read_events(events_dir, limit=200)
+                for evt in events:
+                    if evt.get("event_type") == "user_prompt":
+                        ts = evt.get("timestamp", "")
+                        if ts:
+                            last_interaction = _dt.fromisoformat(ts)
+                            break
+            except Exception:
+                pass  # No events found — last_interaction stays None
+
+        # Build thresholds (override individual values if provided)
+        thresholds = None
+        idle_m = getattr(args, "idle", None)
+        away_m = getattr(args, "away_minutes", None)
+        ext_m = getattr(args, "extended_away_minutes", None)
+        if idle_m is not None or away_m is not None or ext_m is not None:
+            from bid_euchre.ops.away_mode import (
+                DEFAULT_AWAY_MINUTES,
+                DEFAULT_EXTENDED_AWAY_MINUTES,
+                DEFAULT_IDLE_MINUTES,
+            )
+
+            thresholds = EscalationThresholds(
+                idle_minutes=idle_m if idle_m is not None else DEFAULT_IDLE_MINUTES,
+                away_minutes=away_m if away_m is not None else DEFAULT_AWAY_MINUTES,
+                extended_away_minutes=(
+                    ext_m if ext_m is not None else DEFAULT_EXTENDED_AWAY_MINUTES
+                ),
+            )
+
+        result = detect_operator_state(
+            last_interaction,
+            thresholds=thresholds,
+            now=now,
+        )
+
+        if args.json:
+            data = {
+                "state": result.state.value,
+                "escalation_tier": result.escalation_tier,
+                "minutes_inactive": round(result.minutes_inactive, 1),
+                "last_interaction": (
+                    result.last_interaction.isoformat()
+                    if result.last_interaction
+                    else None
+                ),
+                "thresholds": {
+                    "idle_minutes": result.thresholds.idle_minutes,
+                    "away_minutes": result.thresholds.away_minutes,
+                    "extended_away_minutes": result.thresholds.extended_away_minutes,
+                },
+                "reason": result.reason,
+            }
+            print(json.dumps(data, indent=2))
+        else:
+            tier_labels = {
+                0: "PRESENT",
+                1: "IDLE",
+                2: "AWAY",
+                3: "EXTENDED_AWAY",
+            }
+            label = tier_labels.get(result.escalation_tier, "UNKNOWN")
+            print(f"Operator State: {label} (tier {result.escalation_tier})")
+            print(f"  Minutes inactive: {result.minutes_inactive:.0f}")
+            if result.last_interaction:
+                print(f"  Last interaction: {result.last_interaction.isoformat()}")
+            else:
+                print("  Last interaction: (unknown)")
+            print(f"  Reason: {result.reason}")
+            print(
+                f"  Thresholds: idle={result.thresholds.idle_minutes:.0f}m, "
+                f"away={result.thresholds.away_minutes:.0f}m, "
+                f"extended={result.thresholds.extended_away_minutes:.0f}m"
+            )
+        return 0
+
+    elif action == "reorder":
+        from datetime import datetime as _dt
+
+        from bid_euchre.ops.queue_priority import reorder_queue
+        from bid_euchre.ops.task_queue import list_packets
+
+        task_queue_root = args.runtime_dir / "task_queue"
+
+        # Parse --now override
+        now = None
+        if getattr(args, "now", None):
+            now = _dt.fromisoformat(args.now)
+            if now.tzinfo is None:
+                from datetime import timezone as _tz
+
+                now = now.replace(tzinfo=_tz.utc)
+
+        preferred_lane = getattr(args, "preferred_lane", None)
+        status_filter = getattr(args, "status_filter", "pending")
+
+        # Load all packets (unfiltered), let reorder_queue handle status filtering
+        packets = list_packets(task_queue_root)
+        ordered = reorder_queue(
+            packets,
+            now=now,
+            preferred_lane=preferred_lane,
+            status_filter=status_filter,
+        )
+
+        if args.json:
+            items = []
+            for pkt, score in ordered:
+                items.append(
+                    {
+                        "packet_id": pkt.packet_id,
+                        "title": pkt.title,
+                        "priority": pkt.priority,
+                        "owner": pkt.owner,
+                        "status": pkt.status,
+                        "score": {
+                            "total": round(score.total, 2),
+                            "age": round(score.age_score, 2),
+                            "priority": round(score.priority_score, 2),
+                            "dependency": round(score.dependency_score, 2),
+                            "affinity": round(score.affinity_score, 2),
+                        },
+                    }
+                )
+            print(json.dumps(items, indent=2))
+        else:
+            if not ordered:
+                print(f"No {status_filter} packets to reorder.")
+            else:
+                print(f"Queue Priority Order ({len(ordered)} packets):\n")
+                for rank, (pkt, score) in enumerate(ordered, 1):
+                    owner_str = pkt.owner or "(unassigned)"
+                    print(
+                        f"  {rank}. [{score.total:6.1f}]  {pkt.packet_id}  "
+                        f"{pkt.priority:6s}  {owner_str:15s}  {pkt.title}"
+                    )
+                    print(
+                        f"     age={score.age_score:.1f}  "
+                        f"priority={score.priority_score:.1f}  "
+                        f"dep={score.dependency_score:.1f}  "
+                        f"affinity={score.affinity_score:.1f}"
+                    )
+        return 0
+
+    else:
+        print("Usage: ops.py away {status|reorder}", file=sys.stderr)
+        return 1
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the argument parser."""
     parser = argparse.ArgumentParser(
@@ -3948,6 +4134,77 @@ def build_parser() -> argparse.ArgumentParser:
         help="Token economy store directory (default: .claude/runtime/token_economy/)",
     )
 
+    # away (Platform-9b: operator away-mode detection and queue reorder)
+    away_parser = subparsers.add_parser(
+        "away", help="Operator away-mode detection and queue priority reorder"
+    )
+    away_sub = away_parser.add_subparsers(dest="away_action")
+
+    away_status_parser = away_sub.add_parser(
+        "status", help="Detect current operator presence state"
+    )
+    away_status_parser.add_argument(
+        "--last-interaction",
+        metavar="ISO_TIMESTAMP",
+        default=None,
+        help=(
+            "ISO-8601 timestamp of the last operator interaction. "
+            "If omitted, reads the most recent UserPromptSubmit event."
+        ),
+    )
+    away_status_parser.add_argument(
+        "--idle",
+        type=float,
+        metavar="MINUTES",
+        default=None,
+        help="Override idle threshold (minutes)",
+    )
+    away_status_parser.add_argument(
+        "--away",
+        type=float,
+        metavar="MINUTES",
+        default=None,
+        dest="away_minutes",
+        help="Override away threshold (minutes)",
+    )
+    away_status_parser.add_argument(
+        "--extended-away",
+        type=float,
+        metavar="MINUTES",
+        default=None,
+        dest="extended_away_minutes",
+        help="Override extended-away threshold (minutes)",
+    )
+    away_status_parser.add_argument(
+        "--now",
+        metavar="ISO_TIMESTAMP",
+        default=None,
+        help="Override current time (ISO-8601, for testing)",
+    )
+
+    away_reorder_parser = away_sub.add_parser(
+        "reorder", help="Score and reorder pending task packets by priority"
+    )
+    away_reorder_parser.add_argument(
+        "--preferred-lane",
+        metavar="LANE",
+        default=None,
+        help="Lane to apply affinity bonus for",
+    )
+    away_reorder_parser.add_argument(
+        "--status",
+        metavar="STATUS",
+        default="pending",
+        dest="status_filter",
+        help="Only include packets with this status (default: pending)",
+    )
+    away_reorder_parser.add_argument(
+        "--now",
+        metavar="ISO_TIMESTAMP",
+        default=None,
+        help="Override current time (ISO-8601, for testing)",
+    )
+
     return parser
 
 
@@ -4009,6 +4266,7 @@ def main(argv: list[str] | None = None) -> int:
         "lane": cmd_lane,
         "workers": cmd_workers,
         "usage": cmd_usage,
+        "away": cmd_away,
     }
 
     handler = commands.get(args.command)

--- a/tests/integration/test_away_mode_integration.py
+++ b/tests/integration/test_away_mode_integration.py
@@ -1,0 +1,658 @@
+"""Integration tests for away-mode orchestrator wiring (Platform-9b PR3).
+
+Proves the full integration between away_mode state detection, queue_priority
+scoring, and the task queue dispatch pipeline.  Tests exercise the real modules
+against temporary file-backed state — no mocking of core logic.
+
+Covers:
+1. Full cycle: idle detection -> away mode -> priority reorder -> dispatch order
+2. Away-mode state transitions (present -> idle -> away -> extended_away)
+3. Priority scorer correctly reorders pending packets by age+priority+affinity
+4. Escalation threshold triggers on extended_away
+
+Closes task c7b1f20cae80.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+from bid_euchre.ops.away_mode import (
+    EscalationThresholds,
+    OperatorPresence,
+    detect_operator_state,
+    is_operator_away,
+    minutes_until_escalation,
+)
+from bid_euchre.ops.queue_priority import (
+    pick_next,
+    reorder_queue,
+)
+from bid_euchre.ops.task_queue import (
+    TaskPacket,
+    create_packet,
+    list_packets,
+    save_packet,
+    shared_task_root,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+NOW = datetime(2026, 3, 25, 12, 0, 0, tzinfo=timezone.utc)
+
+# Tight thresholds for fast test cycles (minutes).
+TIGHT_THRESHOLDS = EscalationThresholds(
+    idle_minutes=5,
+    away_minutes=15,
+    extended_away_minutes=30,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def task_queue_root(tmp_path: Path) -> Path:
+    """Create a temporary task queue directory."""
+    return shared_task_root(tmp_path / "task_queue")
+
+
+def _replace_created_at(pkt: TaskPacket, created_at: str) -> TaskPacket:
+    """Replace created_at on a frozen TaskPacket by reconstructing it."""
+    data = asdict(pkt)
+    data["created_at"] = created_at
+    return TaskPacket(**data)
+
+
+def _make_saved_packet(
+    queue_root: Path,
+    title: str,
+    *,
+    priority: str = "normal",
+    owner: str | None = None,
+    minutes_ago: float = 0,
+    status: str = "pending",
+    domain: str | None = "platform",
+    metadata: dict | None = None,
+) -> TaskPacket:
+    """Create and save a TaskPacket to the queue directory."""
+    pkt = create_packet(
+        title=title,
+        description=f"Test packet: {title}",
+        priority=priority,
+        owner=owner,
+        domain=domain,
+        metadata=metadata or {},
+    )
+    # Replace created_at with controlled timestamp
+    created_at = (NOW - timedelta(minutes=minutes_ago)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    pkt = _replace_created_at(pkt, created_at)
+
+    # Replace status if not pending (need to reconstruct)
+    if status != "pending":
+        data = asdict(pkt)
+        data["status"] = status
+        pkt = TaskPacket(**data)
+
+    save_packet(pkt, queue_root)
+    return pkt
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Full cycle — idle detection -> away mode -> priority reorder -> dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestFullAwayModeCycle:
+    """Prove the full integration: detect idle -> assess away state -> reorder queue."""
+
+    def test_idle_detection_triggers_reorder(self, task_queue_root: Path) -> None:
+        """When the operator is away, pending packets should be reordered
+        by priority score for autonomous dispatch.
+        """
+        # 1. Create pending packets with varying ages and priorities
+        _make_saved_packet(
+            task_queue_root,
+            "Old low-priority task",
+            priority="low",
+            minutes_ago=120,
+        )
+        recent_high = _make_saved_packet(
+            task_queue_root,
+            "Recent high-priority task",
+            priority="high",
+            minutes_ago=5,
+        )
+        _make_saved_packet(
+            task_queue_root,
+            "Mid-age normal task",
+            priority="normal",
+            minutes_ago=60,
+        )
+
+        # 2. Detect operator state — simulate 2 hours of absence
+        last_interaction = NOW - timedelta(minutes=120)
+        state = detect_operator_state(last_interaction, now=NOW)
+
+        # Verify operator is in AWAY or EXTENDED_AWAY
+        assert state.state in (OperatorPresence.AWAY, OperatorPresence.EXTENDED_AWAY)
+        assert state.escalation_tier >= 2
+
+        # 3. Since operator is away, reorder the queue by priority
+        packets = list_packets(task_queue_root, status_filter="pending")
+        assert len(packets) == 3
+
+        ordered = reorder_queue(packets, now=NOW)
+        assert len(ordered) == 3
+
+        # 4. Verify reorder: high-priority recent task should be first
+        #    (priority=10.0 + age=0.08h ~ 10.1 > normal+1h=6.0 > low+2h=3.0)
+        ranked_ids = [pkt.packet_id for pkt, _ in ordered]
+        assert (
+            ranked_ids[0] == recent_high.packet_id
+        ), "High-priority packet should rank first"
+
+    def test_present_operator_no_autonomous_reorder_needed(
+        self, task_queue_root: Path
+    ) -> None:
+        """When operator is present, queue reorder still works but
+        no autonomous action should be taken (escalation_tier == 0).
+        """
+        _make_saved_packet(
+            task_queue_root,
+            "Task A",
+            priority="normal",
+            minutes_ago=10,
+        )
+
+        last_interaction = NOW - timedelta(minutes=2)
+        state = detect_operator_state(last_interaction, now=NOW)
+
+        assert state.state == OperatorPresence.PRESENT
+        assert state.escalation_tier == 0
+
+        # Queue reorder still produces valid results
+        packets = list_packets(task_queue_root, status_filter="pending")
+        ordered = reorder_queue(packets, now=NOW)
+        assert len(ordered) == 1
+
+    def test_escalation_drives_dispatch_urgency(self, task_queue_root: Path) -> None:
+        """Higher escalation tiers justify more aggressive dispatch.
+
+        At tier 3 (extended_away), the system should be willing to
+        dispatch all eligible packets without waiting for operator review.
+        """
+        # Create 3 approved packets ready for dispatch
+        for i in range(3):
+            _make_saved_packet(
+                task_queue_root,
+                f"Approved task {i}",
+                priority="normal",
+                minutes_ago=30 * (i + 1),
+                status="approved",
+            )
+
+        # Simulate extended away
+        last_interaction = NOW - timedelta(minutes=180)
+        state = detect_operator_state(
+            last_interaction,
+            thresholds=TIGHT_THRESHOLDS,
+            now=NOW,
+        )
+        assert state.state == OperatorPresence.EXTENDED_AWAY
+        assert state.escalation_tier == 3
+
+        # All approved packets can be ranked
+        packets = list_packets(task_queue_root, status_filter="approved")
+        ordered = reorder_queue(packets, now=NOW, status_filter="approved")
+        assert len(ordered) == 3
+
+        # Oldest packet should rank highest (most age points)
+        oldest = ordered[0]
+        assert oldest[1].age_score > ordered[1][1].age_score
+        assert oldest[1].age_score > ordered[2][1].age_score
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Away-mode state transitions
+# ---------------------------------------------------------------------------
+
+
+class TestAwayModeStateTransitions:
+    """Prove state transitions work correctly in integration with queue state."""
+
+    def test_full_state_progression(self) -> None:
+        """Walk through all four states as time progresses."""
+        interaction = NOW
+
+        transitions = [
+            (0, OperatorPresence.PRESENT, 0),
+            (TIGHT_THRESHOLDS.idle_minutes, OperatorPresence.IDLE, 1),
+            (TIGHT_THRESHOLDS.away_minutes, OperatorPresence.AWAY, 2),
+            (TIGHT_THRESHOLDS.extended_away_minutes, OperatorPresence.EXTENDED_AWAY, 3),
+        ]
+
+        for elapsed_min, expected_state, expected_tier in transitions:
+            check_time = NOW + timedelta(minutes=elapsed_min)
+            result = detect_operator_state(
+                interaction,
+                thresholds=TIGHT_THRESHOLDS,
+                now=check_time,
+            )
+            assert result.state == expected_state, (
+                f"At +{elapsed_min}m: expected {expected_state.value}, "
+                f"got {result.state.value}"
+            )
+            assert result.escalation_tier == expected_tier
+
+    def test_state_transitions_are_monotonic(self) -> None:
+        """Escalation tier never decreases as time progresses."""
+        interaction = NOW
+        prev_tier = -1
+
+        for minutes_later in range(0, 61):
+            check_time = NOW + timedelta(minutes=minutes_later)
+            result = detect_operator_state(
+                interaction,
+                thresholds=TIGHT_THRESHOLDS,
+                now=check_time,
+            )
+            assert result.escalation_tier >= prev_tier, (
+                f"Tier decreased at +{minutes_later}m: "
+                f"{prev_tier} -> {result.escalation_tier}"
+            )
+            prev_tier = result.escalation_tier
+
+    def test_is_away_respects_thresholds(self) -> None:
+        """is_operator_away returns True only at AWAY or higher."""
+        interaction = NOW
+
+        # Just before away threshold → not away
+        check_time = NOW + timedelta(minutes=TIGHT_THRESHOLDS.away_minutes - 1)
+        assert not is_operator_away(
+            interaction,
+            thresholds=TIGHT_THRESHOLDS,
+            now=check_time,
+        )
+
+        # At away threshold → away
+        check_time = NOW + timedelta(minutes=TIGHT_THRESHOLDS.away_minutes)
+        assert is_operator_away(
+            interaction,
+            thresholds=TIGHT_THRESHOLDS,
+            now=check_time,
+        )
+
+    def test_minutes_until_escalation_decreases(self) -> None:
+        """The scheduling helper returns decreasing minutes as time passes."""
+        interaction = NOW
+
+        remaining_at_0 = minutes_until_escalation(
+            interaction,
+            thresholds=TIGHT_THRESHOLDS,
+            now=NOW,
+        )
+        remaining_at_3 = minutes_until_escalation(
+            interaction,
+            thresholds=TIGHT_THRESHOLDS,
+            now=NOW + timedelta(minutes=3),
+        )
+
+        assert remaining_at_0 is not None
+        assert remaining_at_3 is not None
+        assert remaining_at_3 < remaining_at_0
+
+    def test_extended_away_returns_none_for_escalation(self) -> None:
+        """At max tier, no further escalation is possible."""
+        interaction = NOW - timedelta(minutes=60)
+
+        remaining = minutes_until_escalation(
+            interaction,
+            thresholds=TIGHT_THRESHOLDS,
+            now=NOW,
+        )
+        assert remaining is None
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Priority scorer reorders packets correctly
+# ---------------------------------------------------------------------------
+
+
+class TestPriorityScorerReorder:
+    """Prove the priority scorer correctly integrates age, priority, and affinity."""
+
+    def test_priority_dominates_age_for_recent_packets(
+        self, task_queue_root: Path
+    ) -> None:
+        """A high-priority recent packet outranks a low-priority older packet."""
+        low_old = _make_saved_packet(
+            task_queue_root,
+            "Low old",
+            priority="low",
+            minutes_ago=60,
+        )
+        high_new = _make_saved_packet(
+            task_queue_root,
+            "High new",
+            priority="high",
+            minutes_ago=5,
+        )
+
+        packets = list_packets(task_queue_root, status_filter="pending")
+        ordered = reorder_queue(packets, now=NOW)
+
+        assert ordered[0][0].packet_id == high_new.packet_id
+        assert ordered[1][0].packet_id == low_old.packet_id
+
+    def test_age_breaks_ties_among_same_priority(self, task_queue_root: Path) -> None:
+        """Among equal-priority packets, older ones rank higher."""
+        old = _make_saved_packet(
+            task_queue_root,
+            "Older",
+            priority="normal",
+            minutes_ago=120,
+        )
+        new = _make_saved_packet(
+            task_queue_root,
+            "Newer",
+            priority="normal",
+            minutes_ago=10,
+        )
+
+        packets = list_packets(task_queue_root, status_filter="pending")
+        ordered = reorder_queue(packets, now=NOW)
+
+        assert ordered[0][0].packet_id == old.packet_id
+        assert ordered[1][0].packet_id == new.packet_id
+
+    def test_lane_affinity_bonus_applied(self, task_queue_root: Path) -> None:
+        """Packets matching the preferred lane get an affinity bonus."""
+        # Two packets with same priority and age, but different owners
+        pkt_a = _make_saved_packet(
+            task_queue_root,
+            "Owned by author-a",
+            priority="normal",
+            minutes_ago=30,
+            owner="author-a",
+        )
+        _make_saved_packet(
+            task_queue_root,
+            "Owned by author-b",
+            priority="normal",
+            minutes_ago=30,
+            owner="author-b",
+        )
+
+        packets = list_packets(task_queue_root, status_filter="pending")
+
+        # With affinity for author-a
+        ordered = reorder_queue(packets, now=NOW, preferred_lane="author-a")
+
+        # author-a's packet should rank first due to affinity bonus
+        assert ordered[0][0].packet_id == pkt_a.packet_id
+        assert ordered[0][1].affinity_score > 0.0
+        assert ordered[1][1].affinity_score == 0.0
+
+    def test_dependency_depth_penalizes_deep_chains(
+        self, task_queue_root: Path
+    ) -> None:
+        """Packets with deeper dependency chains rank lower."""
+        shallow = _make_saved_packet(
+            task_queue_root,
+            "Shallow",
+            priority="normal",
+            minutes_ago=30,
+            metadata={"chain_depth": 0},
+        )
+        _make_saved_packet(
+            task_queue_root,
+            "Deep chain",
+            priority="normal",
+            minutes_ago=30,
+            metadata={"chain_depth": 5},
+        )
+
+        packets = list_packets(task_queue_root, status_filter="pending")
+        ordered = reorder_queue(packets, now=NOW)
+
+        assert ordered[0][0].packet_id == shallow.packet_id
+        assert ordered[0][1].dependency_score == 0.0
+        assert ordered[1][1].dependency_score < 0.0
+
+    def test_pick_next_selects_highest_scored(self, task_queue_root: Path) -> None:
+        """pick_next returns the single highest-scored packet."""
+        _make_saved_packet(
+            task_queue_root,
+            "Low",
+            priority="low",
+            minutes_ago=10,
+        )
+        high = _make_saved_packet(
+            task_queue_root,
+            "High",
+            priority="high",
+            minutes_ago=10,
+        )
+
+        packets = list_packets(task_queue_root, status_filter="pending")
+        result = pick_next(packets, now=NOW)
+
+        assert result is not None
+        assert result[0].packet_id == high.packet_id
+
+    def test_empty_queue_returns_none(self) -> None:
+        """pick_next returns None for an empty queue."""
+        result = pick_next([], now=NOW)
+        assert result is None
+
+    def test_status_filter_excludes_non_pending(self, task_queue_root: Path) -> None:
+        """Only pending packets are scored when status_filter='pending'."""
+        _make_saved_packet(
+            task_queue_root,
+            "Pending",
+            priority="high",
+            minutes_ago=10,
+        )
+        _make_saved_packet(
+            task_queue_root,
+            "Dispatched",
+            priority="high",
+            minutes_ago=10,
+            status="dispatched",
+            owner="author-a",
+        )
+
+        packets = list_packets(task_queue_root)  # All statuses
+        ordered = reorder_queue(packets, now=NOW, status_filter="pending")
+
+        assert len(ordered) == 1
+        assert ordered[0][0].title == "Pending"
+
+    def test_score_breakdown_is_consistent(self, task_queue_root: Path) -> None:
+        """The total score equals the sum of component scores."""
+        _make_saved_packet(
+            task_queue_root,
+            "Test",
+            priority="high",
+            minutes_ago=60,
+            metadata={"chain_depth": 2},
+        )
+
+        packets = list_packets(task_queue_root, status_filter="pending")
+        ordered = reorder_queue(packets, now=NOW, preferred_lane="author-a")
+
+        assert len(ordered) == 1
+        _, score = ordered[0]
+
+        expected_total = (
+            score.age_score
+            + score.priority_score
+            + score.dependency_score
+            + score.affinity_score
+        )
+        assert score.total == pytest.approx(expected_total, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Escalation threshold triggers on extended_away
+# ---------------------------------------------------------------------------
+
+
+class TestEscalationTriggers:
+    """Prove that extended_away state correctly triggers escalation behavior."""
+
+    def test_extended_away_at_exact_threshold(self) -> None:
+        """At exactly the extended_away threshold, state should be EXTENDED_AWAY."""
+        interaction = NOW - timedelta(minutes=TIGHT_THRESHOLDS.extended_away_minutes)
+        result = detect_operator_state(
+            interaction,
+            thresholds=TIGHT_THRESHOLDS,
+            now=NOW,
+        )
+        assert result.state == OperatorPresence.EXTENDED_AWAY
+        assert result.escalation_tier == 3
+
+    def test_extended_away_well_past_threshold(self) -> None:
+        """Well past extended_away threshold, state is still EXTENDED_AWAY."""
+        interaction = NOW - timedelta(minutes=300)
+        result = detect_operator_state(
+            interaction,
+            thresholds=TIGHT_THRESHOLDS,
+            now=NOW,
+        )
+        assert result.state == OperatorPresence.EXTENDED_AWAY
+        assert result.escalation_tier == 3
+        assert result.minutes_inactive == pytest.approx(300.0, abs=0.1)
+
+    def test_no_interaction_implies_extended_away(self) -> None:
+        """None interaction (no known activity) implies max escalation."""
+        result = detect_operator_state(
+            None,
+            thresholds=TIGHT_THRESHOLDS,
+            now=NOW,
+        )
+        assert result.state == OperatorPresence.EXTENDED_AWAY
+        assert result.escalation_tier == 3
+
+    def test_extended_away_enables_all_packet_dispatch(
+        self, task_queue_root: Path
+    ) -> None:
+        """At escalation tier 3, all eligible packets should be dispatchable.
+
+        This test proves that the priority scorer works on all pending packets
+        when the operator is at extended_away, enabling the orchestrator to
+        dispatch aggressively without waiting for operator input.
+        """
+        # Create a mix of packets
+        packets_created = []
+        for i, priority in enumerate(["low", "normal", "high", "high", "normal"]):
+            pkt = _make_saved_packet(
+                task_queue_root,
+                f"Task {i} ({priority})",
+                priority=priority,
+                minutes_ago=10 * (i + 1),
+            )
+            packets_created.append(pkt)
+
+        # Confirm extended away
+        result = detect_operator_state(
+            None,
+            thresholds=TIGHT_THRESHOLDS,
+            now=NOW,
+        )
+        assert result.escalation_tier == 3
+
+        # All pending packets should be rankable
+        packets = list_packets(task_queue_root, status_filter="pending")
+        ordered = reorder_queue(packets, now=NOW)
+        assert len(ordered) == 5
+
+        # Verify ordering is deterministic and well-formed
+        scores = [score.total for _, score in ordered]
+        assert scores == sorted(
+            scores, reverse=True
+        ), "Scores should be in descending order"
+
+    def test_transition_through_all_tiers_with_queue_state(
+        self, task_queue_root: Path
+    ) -> None:
+        """Full lifecycle: packets accumulate while operator transitions through tiers.
+
+        Simulates a realistic scenario where packets arrive over time and the
+        operator goes through present -> idle -> away -> extended_away.
+        """
+        interaction = NOW
+
+        # T+0: Operator present, one packet arrives
+        _make_saved_packet(
+            task_queue_root,
+            "Initial task",
+            priority="normal",
+            minutes_ago=0,
+        )
+
+        state = detect_operator_state(
+            interaction,
+            thresholds=TIGHT_THRESHOLDS,
+            now=NOW,
+        )
+        assert state.state == OperatorPresence.PRESENT
+
+        # T+5: Operator goes idle, a high-priority packet arrives
+        t_idle = NOW + timedelta(minutes=TIGHT_THRESHOLDS.idle_minutes)
+        _make_saved_packet(
+            task_queue_root,
+            "Urgent task",
+            priority="high",
+            minutes_ago=-int(TIGHT_THRESHOLDS.idle_minutes),
+        )
+
+        state = detect_operator_state(
+            interaction,
+            thresholds=TIGHT_THRESHOLDS,
+            now=t_idle,
+        )
+        assert state.state == OperatorPresence.IDLE
+
+        # T+15: Operator goes away
+        t_away = NOW + timedelta(minutes=TIGHT_THRESHOLDS.away_minutes)
+        state = detect_operator_state(
+            interaction,
+            thresholds=TIGHT_THRESHOLDS,
+            now=t_away,
+        )
+        assert state.state == OperatorPresence.AWAY
+        assert is_operator_away(
+            interaction,
+            thresholds=TIGHT_THRESHOLDS,
+            now=t_away,
+        )
+
+        # T+30: Extended away — full autonomous dispatch justified
+        t_ext = NOW + timedelta(minutes=TIGHT_THRESHOLDS.extended_away_minutes)
+        state = detect_operator_state(
+            interaction,
+            thresholds=TIGHT_THRESHOLDS,
+            now=t_ext,
+        )
+        assert state.state == OperatorPresence.EXTENDED_AWAY
+
+        # Queue should still be fully reorderable
+        packets = list_packets(task_queue_root, status_filter="pending")
+        ordered = reorder_queue(packets, now=t_ext)
+        assert len(ordered) >= 2
+        # Confirm pick_next returns the highest-scored packet
+        top = pick_next(packets, now=t_ext)
+        assert top is not None
+        assert top[0].packet_id == ordered[0][0].packet_id


### PR DESCRIPTION
## Summary
- Add `away status` and `away reorder` CLI subcommands to `scripts/internal/ops.py`
- Create 21 integration tests at `tests/integration/test_away_mode_integration.py`
- Wire `away_mode.py` (PR #1806) and `queue_priority.py` (PR #1802) into the orchestrator surface

## Why
Platform-9b PR3: The away-mode detection and queue priority modules exist as pure logic
but have no CLI entry points for the orchestrator to invoke. This PR completes the wiring
so the orchestrator can check operator presence and reorder the dispatch queue during
away-from-desk autonomous operation.

## Changes

### CLI (`scripts/internal/ops.py`)
- `away status` — detect current operator presence state (present/idle/away/extended_away)
  with configurable thresholds, auto-detection from event log, JSON output
- `away reorder` — score and rank pending task packets by priority, age, dependency depth,
  and lane affinity; supports status filtering and preferred-lane bonus

### Integration Tests (`tests/integration/test_away_mode_integration.py`)
4 test classes, 21 tests:
1. **TestFullAwayModeCycle** (3 tests) — full idle→away→reorder→dispatch cycle
2. **TestAwayModeStateTransitions** (5 tests) — state progression, monotonicity, is_away, escalation scheduling
3. **TestPriorityScorerReorder** (8 tests) — age, priority, affinity, dependency depth, pick_next, status filter, score consistency
4. **TestEscalationTriggers** (5 tests) — threshold boundaries, no-interaction, tier-3 dispatch, full lifecycle with queue state

## Repro / Validation

```bash
# CLI smoke tests
uv run python scripts/internal/ops.py away status --last-interaction "2026-03-25T10:00:00Z" --now "2026-03-25T12:30:00Z"
uv run python scripts/internal/ops.py --json away status --last-interaction "2026-03-25T12:25:00Z" --now "2026-03-25T12:30:00Z"
uv run python scripts/internal/ops.py away reorder --now "2026-03-25T12:30:00Z"

# Integration tests
uv run python -m pytest tests/integration/test_away_mode_integration.py -v

# Full validation
make check-quiet
```

## Tests
- `uv run python -m pytest tests/integration/test_away_mode_integration.py -v` — 21 passed
- `uv run python -m pytest tests/unit/test_ops_away_mode.py tests/unit/test_ops_queue_priority.py -v` — 81 passed
- `make check-quiet` — all checks passed

## Worktree proof
```
pwd: Bid-Euchre-steward-brws-author-b
branch: ops/platform9b-pr3-away-wiring
```

## Dependencies
- PR #1802 (queue_priority.py) — merged ✅
- PR #1806 (away_mode.py) — merged ✅

## Task
Packet: c7b1f20cae80 (A8-PR3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)