### PR TITLE
docs(ops): add Phase 4 operator runbook and handoff docs

### DIFF
--- a/docs/02_agent/PHASE4_HANDOFF.md
+++ b/docs/02_agent/PHASE4_HANDOFF.md
@@ -1,0 +1,246 @@
+# Phase 4 Handoff — Remote Channel Implementation
+
+> **Phase:** 4 (`4_remote_channel`)
+> **Governing plan:** `plans/agent_ops/governing_plan.md`
+> **Status:** IN_PROGRESS (Platform-8a/8b complete, Platform-9a in progress)
+> **Last updated:** 2026-03-25
+
+---
+
+## Summary
+
+Phase 4 adds a **remote operator channel** to the steward platform, enabling
+the human operator to monitor fleet status and interact with the orchestrator
+from a phone (Telegram) when away from the desk.
+
+The implementation follows a layered architecture:
+
+1. **Transport layer** (Platform-8a) — Telegram plugin configuration and
+   bidirectional message delivery
+2. **Audit layer** (Platform-8b) — Durable repo-owned recording of all
+   remote exchanges
+3. **Control plane** (SP-4-07) — Controller projection as single source of
+   truth for fleet state, with hook-based alert injection and guardrails
+4. **Alert push** (Platform-9a) — Proactive push of unresolved alerts to
+   Telegram with dedup, backoff, and remote acknowledgement
+
+---
+
+## What Was Built
+
+### Platform-8a: Telegram Transport (COMPLETE)
+
+**Sub-plan:** `plans/agent_ops/4_remote_channel/sub/2026-03-23_platform-8a-telegram-transport.md`
+
+Configured the official Claude Code Channels plugin for Telegram as the
+remote transport. Key deliverables:
+
+| Component | Description |
+|-----------|-------------|
+| Plugin config | Telegram plugin enabled in `.claude/settings.json` |
+| tmux launcher | `STEWARD_TELEGRAM_ENABLED` env var + auto-detect in `.claude/tmux/steward-session.sh` |
+| Kill switch | `STEWARD_TELEGRAM_ENABLED=0` disables without code changes |
+| Orchestrator-only | Only the orchestrator pane receives `--channels`; author lanes stay tmux-only |
+| Pairing | Proven with user `8122530898` via `/telegram:access` |
+
+**Key PRs:** #1436, #1451, #1452
+
+### Platform-8b: Audit Trail (COMPLETE)
+
+**Sub-plan:** `plans/agent_ops/4_remote_channel/sub/2026-03-24_platform-8b-audit-trail.md`
+
+Durable recording of all inbound and outbound remote exchanges in a
+repo-owned JSONL file.
+
+| Component | Location | Description |
+|-----------|----------|-------------|
+| Core library | `src/bid_euchre/ops/audit_trail.py` | `append_record()`, `create_record()`, `audit_channel_tag()`, `audit_mcp_outbound()` |
+| Outbound hook | `.claude/hooks/post-telegram-audit.sh` | PostToolUse hook for MCP reply/react/edit tools |
+| Inbound hook | `.claude/hooks/inbound-channel-audit.sh` + `.py` | UserPromptSubmit hook for `<channel>` tag extraction |
+| Storage | **.claude/runtime/audit_trail/remote_exchanges.jsonl** | Append-only JSONL with flock safety |
+
+**Key PRs:** #1532, #1536, #1541, #1715, #1760
+
+### SP-4-07: Controller-First Control Plane (COMPLETE)
+
+**Sub-plan:** `plans/agent_ops/4_remote_channel/sub/2026-03-24_controller-first-control-plane-and-transport-evaluation.md`
+
+The largest single sub-plan in Phase 4 (25+ PRs). Established the controller
+projection as the canonical actionable-state surface.
+
+| Component | Location | Description |
+|-----------|----------|-------------|
+| Controller module | `src/bid_euchre/ops/control_plane.py` | `reconcile()`, `load_fleet_status()`, item mutations (`ack_item`, `clear_item`, `suppress_item`) |
+| Alert injection | `.claude/hooks/alert-inject.py` | UserPromptSubmit hook: injects HIGH/URGENT items into orchestrator context |
+| Urgent-state guard | `.claude/hooks/urgent-state-guard.py` | PreToolUse hook: blocks merge/dispatch when unresolved urgent state |
+| Monitor integration | `src/bid_euchre/ops/monitor.py` | `reconcile()` called during each monitor cycle |
+| Fleet CLI | `scripts/internal/ops.py` | Human-friendly projection reader and mutation commands |
+
+**Key exit criteria proven:**
+1. Unread-alert replay through controller projection (10 tests)
+2. Noise discrimination in controller projection (proving run 2)
+3. Persistence, dedup, and clear lifecycle (7 tests)
+4. False-stall prevention via stall guard (6 tests)
+5. Outbound audit wired into PostToolUse hook
+6. Telegram e2e remote loop (messages 83-86)
+
+**Key PRs:** #1618, #1633, #1699, #1701, #1703, #1704, #1712, #1714, #1715,
+#1718, #1719, #1730, #1755, #1760, #1764
+
+### Platform-9a: Alert Push (IN PROGRESS)
+
+**Sub-plan:** `plans/agent_ops/4_remote_channel/sub/2026-03-25_platform-9a-idle-attention-alerts.md`
+
+Proactive push of unresolved alerts to the operator's Telegram when the
+fleet is idle.
+
+| Component | Location | Description |
+|-----------|----------|-------------|
+| Alert push evaluator | `src/bid_euchre/ops/alert_push.py` | Pure-function evaluator: filters items, applies dedup/backoff |
+| Push state | **.claude/runtime/alert_push_state.json** | Tracks per-item push timestamps and counts |
+| Remote ack parser | `src/bid_euchre/ops/remote_ack.py` | Parses `ack`/`dismiss`/`mute`/`clear` from inbound text |
+| Telegram push adapter | `src/bid_euchre/ops/telegram_push.py` | Formats messages, gates on kill switch, orchestrates push cycle |
+| Idle detector | `src/bid_euchre/ops/idle_detector.py` | Determines fleet idle state from event log |
+
+**Key PRs (merged so far):** #1777 (remote ack parser), #1781 (alert push evaluator)
+
+---
+
+## Architecture Decisions
+
+### Transport Choice: Telegram via Claude Channels
+
+**Decision:** Use the official Claude Code Channels plugin for Telegram
+rather than building a custom transport.
+
+**Rationale:** The Channels plugin provides bidirectional message delivery,
+pairing/access control, and MCP tool integration out of the box. Custom
+transport would duplicate this and require ongoing maintenance.
+
+**Trade-off:** Dependency on Claude Code plugin ecosystem. Mitigated by
+keeping the audit trail and controller projection repo-owned.
+
+### Controller as Single Truth
+
+**Decision:** All actionable state flows through the controller projection.
+Hooks, dashboards, and remote adapters consume this projection — they do
+not build their own views of urgency.
+
+**Rationale:** Without a single truth, different surfaces (local terminal,
+Telegram, dashboard) would disagree on fleet state. The controller's
+`reconcile()` function merges all signal sources into one coherent view.
+
+### Orchestrator-Only Ingress
+
+**Decision:** Only the orchestrator pane processes inbound Telegram messages.
+Author lanes remain tmux-only.
+
+**Rationale:** The orchestrator is the dispatch authority. Allowing direct
+remote control of author lanes would bypass task dispatch, scope lock, and
+review gates.
+
+### Audit Before Trust
+
+**Decision:** Every remote exchange is durably recorded before the message
+is processed or the response is sent.
+
+**Rationale:** Remote channels introduce an external trust boundary. The
+audit trail provides forensic traceability for incident review and enables
+post-hoc verification that the remote channel was not misused.
+
+---
+
+## Hook Registration Map
+
+| Hook | Event | File | Purpose |
+|------|-------|------|---------|
+| Alert injection | UserPromptSubmit | `.claude/hooks/alert-inject.sh` + `.py` | Inject HIGH/URGENT alerts into orchestrator context |
+| Inbound audit | UserPromptSubmit | `.claude/hooks/inbound-channel-audit.sh` + `.py` | Record inbound `<channel>` tags to audit trail |
+| Outbound audit | PostToolUse (Telegram tools) | `.claude/hooks/post-telegram-audit.sh` | Record outbound MCP tool calls to audit trail |
+| Urgent-state guard | PreToolUse (Bash) | `.claude/hooks/urgent-state-guard.py` | Block merge/dispatch when urgent state unresolved |
+
+All hooks are registered in `.claude/settings.json`.
+
+---
+
+## File Inventory
+
+### Source Code (under `src/bid_euchre/ops/`)
+
+| File | Platform | Description |
+|------|----------|-------------|
+| `control_plane.py` | SP-4-07 | Controller projection: reconcile, load, mutations |
+| `alert_push.py` | 9a | Alert push evaluator with dedup/backoff |
+| `remote_ack.py` | 9a | Parse and execute remote ack commands |
+| `telegram_push.py` | 9a | Telegram-specific push adapter |
+| `audit_trail.py` | 8b | Durable audit trail for remote exchanges |
+| `idle_detector.py` | 9a | Fleet idle detection from event log |
+| `monitor.py` | SP-4-07 | Monitor with controller integration and stall detection |
+| `message_bus.py` | Pre-4 | Lane-to-lane messaging (used by controller inputs) |
+| `events.py` | Pre-4 | Durable event log (used by idle detector) |
+
+### Hooks (under `.claude/hooks/`)
+
+| File | Phase 4 Role |
+|------|-------------|
+| `alert-inject.sh` + `.py` | Local alert injection into orchestrator |
+| `urgent-state-guard.py` | Merge/dispatch guard on urgent state |
+| `inbound-channel-audit.sh` + `.py` | Inbound Telegram audit |
+| `post-telegram-audit.sh` | Outbound Telegram audit |
+| `pre-bash-dispatch.sh` | Consolidated PreToolUse dispatcher (orchestrates guards) |
+
+### Runtime State (under `.claude/runtime/`)
+
+| File | Owner | Description |
+|------|-------|-------------|
+| fleet_status.json | Controller | Canonical actionable-state projection |
+| alert_push_state.json | Alert push | Per-item push timestamps and counts |
+| **audit_trail/remote_exchanges.jsonl** | Audit trail | Append-only remote exchange log |
+| stall_state.json | Monitor | Cross-cycle stall detection state |
+| approval_stall_state.json | Monitor | Approval prompt detection state |
+
+---
+
+## Remaining Work
+
+### Platform-9a Completion (Step 4)
+
+- [ ] Telegram wiring: integrate `prepare_alert_push()` into orchestrator
+  monitor/check-in cycle
+- [ ] E2e loop proving: push alert -> operator acks from phone -> item
+  state changes in projection
+
+### Platform-9b: Away-from-Desk Queue Moving (Step 5)
+
+- [ ] Operator can review and approve task dispatches from Telegram
+- [ ] Operator can trigger `/check-in` and receive status summary remotely
+- [ ] Queue-moving proving run: dispatch, monitor, ack cycle without desktop
+
+### Platform-9c: First Hardening Pass (Step 6)
+
+- [ ] Fix real proving-run issues discovered in 9a/9b
+- [ ] Update operator documentation with lessons learned
+- [ ] Record known gaps and deferred items
+- [ ] Phase 4 handoff: mark COMPLETE, update governing plan
+
+---
+
+## Known Gaps and Debt
+
+| Item | Severity | Description |
+|------|----------|-------------|
+| Two messaging transports | Low | Internal bus and Telegram coexist but are not consolidated (#1289 ADR written) |
+| Permission stalls | Medium | Settings self-edit prompt is platform-hardcoded; workaround is Esc+2 (#1759) |
+| Token economy telemetry | Low | Pipeline broken after Claude Code v2.1.80+ format change (#1770) |
+| Analyst pool dispatch | Low | Analyst lane not in KNOWN_AUTHOR_LANES; dispatch via tmux only (#1769) |
+| Multiple operators | Deferred | v1 supports single operator only |
+| Discord | Deferred | Telegram only in v1 |
+
+---
+
+## Operator Reference
+
+For day-to-day operation, see:
+- **Runbook:** `docs/02_agent/PHASE4_OPERATOR_RUNBOOK.md`
+- **Autonomous workflow:** `docs/02_agent/AUTONOMOUS_OPERATOR_WORKFLOW.md`
+- **Review loop:** `docs/02_agent/AUTONOMOUS_REVIEW_LOOP.md`

--- a/docs/02_agent/PHASE4_OPERATOR_RUNBOOK.md
+++ b/docs/02_agent/PHASE4_OPERATOR_RUNBOOK.md
@@ -1,0 +1,375 @@
+# Phase 4 Operator Runbook — Remote Channel
+
+> **Audience:** Human operator managing the steward fleet
+> **Last updated:** 2026-03-25
+
+---
+
+## 1. Remote Channel Overview
+
+Phase 4 adds a **Telegram remote channel** so the operator can monitor and
+interact with the steward fleet from a phone when away from the desk.
+
+### Architecture
+
+```
+Operator (phone)
+    |
+    | Telegram Bot API
+    v
+Claude Channels Plugin (orchestrator pane only)
+    |
+    +-- Inbound: <channel> tag in UserPromptSubmit -> orchestrator processes
+    +-- Outbound: MCP reply tool -> operator's Telegram chat
+    |
+    +-- Audit trail: .claude/runtime/audit_trail/remote_exchanges.jsonl
+    +-- Controller: .claude/runtime/fleet_status.json (single source of truth)
+```
+
+### Key Principles
+
+- **Orchestrator-only ingress:** Only the orchestrator pane receives Telegram
+  messages. Author lanes remain tmux-only.
+- **Controller is truth:** The controller projection (fleet_status.json) is
+  the canonical state. Telegram is a transport adapter, not a state store.
+- **Audit everything:** Every inbound and outbound remote exchange is
+  recorded in the repo-owned audit trail.
+- **Kill switch:** The `STEWARD_TELEGRAM_ENABLED` env var controls whether
+  Telegram is active. Set to `0` to disable without code changes.
+
+### Telegram Setup
+
+1. **Bot token:** Configured via the Telegram plugin (`claude plugins`).
+   The bot token is stored in Claude Code's plugin keychain, not in repo files.
+
+2. **Pairing:** The operator sends a message to the bot from their Telegram
+   account. The first message triggers a pairing request that must be
+   approved via `/telegram:access` in the terminal.
+
+3. **Kill switch:** The tmux launcher (`.claude/tmux/steward-session.sh`)
+   auto-detects whether the Telegram plugin is installed and enabled.
+   Override with:
+   ```bash
+   STEWARD_TELEGRAM_ENABLED=0 .claude/tmux/steward-session.sh  # Disable
+   STEWARD_TELEGRAM_ENABLED=1 .claude/tmux/steward-session.sh  # Force enable
+   ```
+
+4. **Channel flag:** When enabled, the orchestrator pane launches with
+   `--channels plugin:telegram@claude-plugins-official`. Other panes do not
+   receive this flag.
+
+---
+
+## 2. Controller Projection Reference
+
+The controller projection is the single control-plane truth for the steward
+platform. It lives at **.claude/runtime/fleet_status.json**.
+
+### Reading the Projection
+
+```bash
+# CLI view (human-friendly)
+uv run python scripts/internal/ops.py fleet status
+
+# Raw JSON
+cat .claude/runtime/fleet_status.json | jq '.items[] | {item_id, severity, category, summary, state}'
+```
+
+### Item Structure
+
+Each item in the projection has:
+
+| Field | Description |
+|-------|-------------|
+| `item_id` | Stable hash-based ID for tracking across cycles |
+| `severity` | `info`, `warn`, `high`, or `urgent` |
+| `category` | Grouping: `lane_health`, `pr_status`, `stalled_lane`, `approval_stall`, `idle_lane`, `stale_dispatch`, `merged_pr`, etc. |
+| `source` | Which subsystem produced it (`monitor`, `task_queue`, etc.) |
+| `summary` | Human-readable one-liner |
+| `state` | `open`, `acked`, `cleared`, or `suppressed` |
+| `recommended_action` | Suggested next step |
+| `first_seen_at` | ISO 8601 timestamp of first detection |
+
+### Severity Levels
+
+| Severity | Meaning | Push to Telegram? | Blocks merge/dispatch? |
+|----------|---------|-------------------|----------------------|
+| `info` | Informational | No | No |
+| `warn` | Needs attention soon | No | No |
+| `high` | Requires action | Yes (when idle) | Yes (urgent-state-guard) |
+| `urgent` | Escalated / critical | Yes (when idle) | Yes (urgent-state-guard) |
+
+### Mutation Commands
+
+```bash
+# Acknowledge an item (stops push reminders, keeps in projection)
+uv run python scripts/internal/ops.py fleet --ack <item_id_or_prefix>
+
+# Clear an item (resolved, remove from active view)
+uv run python scripts/internal/ops.py fleet --clear <item_id_or_prefix>
+
+# Suppress an item (won't resurface in future cycles)
+uv run python scripts/internal/ops.py fleet --suppress <item_id_or_prefix>
+```
+
+### Remote Ack Commands (via Telegram)
+
+When an alert is pushed to Telegram, reply with:
+
+| Command | Effect | Example |
+|---------|--------|---------|
+| `ack <prefix>` | Acknowledge item | `ack a1b2` |
+| `dismiss <prefix>` | Clear/resolve item | `dismiss a1b2` |
+| `mute <prefix>` | Suppress item permanently | `mute a1b2` |
+| `clear <prefix>` | Same as dismiss | `clear a1b2` |
+
+The `<prefix>` is the first 4+ characters of the `item_id` shown in the
+alert message. Prefix must uniquely match one item; if ambiguous, the
+system returns the list of candidates.
+
+### Reconcile Cycle
+
+The controller runs during each monitor cycle:
+
+1. Monitor collects findings (lane health, stalls, CI, PRs, etc.)
+2. `reconcile()` merges findings with task state, review verdicts, messages,
+   and audit records into the controller projection
+3. Items carry stable `item_id` values across cycles (hash-based dedup)
+4. Existing items preserve their state (`acked`, `cleared`, etc.)
+5. Items not seen in the current cycle are expired after a grace period
+
+---
+
+## 3. Alert Push Behavior
+
+### Push Flow
+
+```
+Monitor cycle
+  -> reconcile() writes fleet_status.json
+  -> evaluate_push_needed(fleet_status, idle_status, push_state)
+  -> Filter: only HIGH/URGENT + state=open
+  -> Filter: idle gate (fleet must be idle)
+  -> Filter: dedup (cooldown not elapsed, severity not escalated)
+  -> prepare_alert_push() formats Telegram message
+  -> Orchestrator sends via MCP reply tool
+  -> record_push() updates push state
+  -> Audit trail records the outbound exchange
+```
+
+### Push State
+
+Push state is persisted at **.claude/runtime/alert_push_state.json** and
+tracks per-item:
+
+| Field | Description |
+|-------|-------------|
+| `last_pushed_at` | ISO 8601 timestamp of last push |
+| `push_count` | Number of times this item has been pushed |
+| `last_severity` | Severity at time of last push |
+
+### Idle Gating
+
+Alerts are only pushed when the fleet is idle (no meaningful events within
+the idle threshold, default 90 minutes). This prevents spamming the
+operator while lanes are actively working.
+
+The idle detector (`src/bid_euchre/ops/idle_detector.py`) reads the event
+log and checks for meaningful events (task starts/completions, CI outcomes,
+review verdicts). Control-plane lanes (orchestrator, ops, review) are
+excluded from the activity check.
+
+### Dedup and Backoff
+
+An item is re-pushed only when:
+
+1. **New item:** Never been pushed before
+2. **Cooldown elapsed:** More than 15 minutes since last push (configurable
+   via `DEFAULT_COOLDOWN_MINUTES`)
+3. **Severity escalated:** Item severity increased since last push (e.g.,
+   `high` -> `urgent`)
+
+### Telegram Message Format
+
+Pushed alerts include:
+- Severity emoji (urgent: alarm, high: warning)
+- Item ID prefix (for ack commands)
+- Summary text
+- Recommended action (if available)
+
+---
+
+## 4. Troubleshooting
+
+### Common Failure Modes
+
+#### Telegram messages not arriving
+
+1. **Check kill switch:** Verify `STEWARD_TELEGRAM_ENABLED` is set:
+   ```bash
+   tmux show-environment -t steward STEWARD_TELEGRAM_ENABLED
+   ```
+
+2. **Check plugin status:**
+   ```bash
+   claude plugins list  # Should show telegram as enabled
+   ```
+
+3. **Check pairing:** The bot must be paired with the operator's Telegram
+   account. If unpaired, messages are silently dropped.
+
+4. **Check orchestrator pane:** Only the orchestrator receives `--channels`.
+   Verify the orchestrator is running and not stalled.
+
+#### Alerts not being pushed
+
+1. **Fleet not idle:** Alerts only push when idle. Check:
+   ```bash
+   uv run python -c "from bid_euchre.ops.idle_detector import is_fleet_idle; r = is_fleet_idle(); print(f'idle={r.idle}, minutes={r.idle_minutes:.0f}')"
+   ```
+
+2. **No HIGH/URGENT items:** Only high and urgent items are pushed:
+   ```bash
+   uv run python scripts/internal/ops.py fleet status  # Check for high/urgent
+   ```
+
+3. **All items acked:** Acked items are not pushed:
+   ```bash
+   cat .claude/runtime/fleet_status.json | jq '[.items[] | select(.state == "open" and (.severity == "high" or .severity == "urgent"))] | length'
+   ```
+
+4. **Push state cooldown:** Items within the 15-minute cooldown won't be
+   re-pushed:
+   ```bash
+   cat .claude/runtime/alert_push_state.json | jq .
+   ```
+
+#### Remote ack not working
+
+1. **Syntax:** The ack command must be one of: `ack <prefix>`,
+   `dismiss <prefix>`, `mute <prefix>`, `clear <prefix>`
+
+2. **Prefix ambiguity:** If the prefix matches multiple items, the system
+   returns candidates instead of acking. Use a longer prefix.
+
+3. **Item already acked:** If the item is already acked/cleared/suppressed,
+   the mutation returns false. Check item state in the projection.
+
+#### Lanes stalling on permission prompts
+
+See `plans/sessions/2026-03-25_permission-stalls-investigation.md` for the
+full investigation. Short version: the settings self-edit prompt is
+platform-hardcoded. Workaround: send `Esc + 2` to the tmux pane, or add
+`--dangerously-skip-permissions` to author lane launch commands.
+
+#### Audit trail issues
+
+1. **Check audit trail exists:**
+   ```bash
+   wc -l .claude/runtime/audit_trail/remote_exchanges.jsonl
+   ```
+
+2. **Check recent entries:**
+   ```bash
+   tail -5 .claude/runtime/audit_trail/remote_exchanges.jsonl | jq .
+   ```
+
+3. **Lock contention:** The audit trail uses `flock` for concurrent-write
+   safety. If writes seem stuck, check for stale lock files:
+   ```bash
+   ls -la .claude/runtime/audit_trail/.remote_exchanges.lock
+   ```
+
+### Recovery Steps
+
+#### Controller projection stale or corrupt
+
+```bash
+# Force a fresh reconcile
+uv run python -c "from bid_euchre.ops.control_plane import reconcile; reconcile()"
+
+# Or delete and let the next monitor cycle regenerate
+rm .claude/runtime/fleet_status.json
+```
+
+#### Push state stale
+
+```bash
+# Reset push state (all items become eligible for push again)
+rm .claude/runtime/alert_push_state.json
+```
+
+#### Orchestrator not processing Telegram messages
+
+```bash
+# Check if orchestrator pane is alive
+tmux capture-pane -t steward:central-ops.1 -p | tail -10
+
+# Check for stall patterns
+tmux capture-pane -t steward:central-ops.1 -p | grep -i "permission\|stall\|error"
+
+# If stalled, try sending a simple prompt
+tmux send-keys -t steward:central-ops.1 "status" Enter
+```
+
+#### Complete remote channel reset
+
+```bash
+# 1. Kill the steward session
+tmux kill-session -t steward
+
+# 2. Clear runtime state
+rm -f .claude/runtime/fleet_status.json
+rm -f .claude/runtime/alert_push_state.json
+
+# 3. Restart with Telegram
+STEWARD_TELEGRAM_ENABLED=1 .claude/tmux/steward-session.sh
+```
+
+---
+
+## 5. Morning Proving Checklist
+
+Use this checklist when resuming after an overnight autonomous run to verify
+the remote channel is working end-to-end.
+
+### Pre-Checks
+
+- [ ] Steward session is running: `tmux has-session -t steward`
+- [ ] Orchestrator pane is active (not stalled): capture and inspect pane
+- [ ] Telegram plugin enabled: `claude plugins list | grep telegram`
+- [ ] Kill switch on: `tmux show-environment -t steward STEWARD_TELEGRAM_ENABLED`
+
+### Remote Round-Trip Test
+
+1. **Outbound test:** From the orchestrator, send a message to Telegram:
+   - Trigger a `/check-in` or monitor cycle that produces a HIGH item
+   - Verify the alert appears on the operator's phone
+
+2. **Inbound test:** Reply to the alert from Telegram:
+   - Send `ack <prefix>` from the phone
+   - Verify the orchestrator receives and processes the ack
+   - Verify the item state changes in fleet_status.json
+
+3. **Audit test:** Verify both directions were recorded:
+   ```bash
+   tail -5 .claude/runtime/audit_trail/remote_exchanges.jsonl | jq '.direction'
+   ```
+   Should show both `"outbound"` and `"inbound"` entries.
+
+### Health Checks
+
+- [ ] Controller projection fresh: check `generated_at` in fleet_status.json
+- [ ] No stale HIGH/URGENT items lingering from overnight
+- [ ] Push state reasonable: not hundreds of stale entries
+- [ ] Audit trail growing: `wc -l .claude/runtime/audit_trail/remote_exchanges.jsonl`
+
+### Quick Fixes
+
+| Symptom | Fix |
+|---------|-----|
+| No Telegram messages | Check `STEWARD_TELEGRAM_ENABLED`, restart orchestrator pane |
+| Alert spam | Check push state cooldown, ack items, increase cooldown |
+| Ack not working | Check prefix length, verify item exists and is `open` |
+| Stale projection | Run manual `reconcile()`, check monitor cron |
+| Audit trail empty | Check hook registration in `.claude/settings.json` |


### PR DESCRIPTION
## Summary
- Add PHASE4_OPERATOR_RUNBOOK.md — day-to-day operator reference for the remote channel
- Add PHASE4_HANDOFF.md — implementation summary covering all Phase 4 slices

## Why
Phase 4 (Remote Channel) has shipped 25+ PRs across Platform-8a/8b and SP-4-07. The operator needs consolidated documentation to understand and operate the remote channel system.

## Validation
```bash
make check-quiet  # All checks passed
```

## Worktree proof
```
pwd: Bid-Euchre-steward-author-c
branch: docs/phase4-operator-handoff
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)