### PR TITLE
feat(ops): add repo adapter and migration tests (Platform-10 PR3)

### DIFF
--- a/src/bid_euchre/ops/adapters/__init__.py
+++ b/src/bid_euchre/ops/adapters/__init__.py
@@ -1,0 +1,38 @@
+"""Repo-specific adapters implementing the core ops ABCs.
+
+This package contains concrete implementations of the four core ops ABCs
+(:class:`~bid_euchre.ops.core.interfaces.AbstractController`,
+:class:`~bid_euchre.ops.core.interfaces.AbstractMonitor`,
+:class:`~bid_euchre.ops.core.interfaces.AbstractTaskQueue`,
+:class:`~bid_euchre.ops.core.interfaces.AbstractWorkerPool`)
+that delegate to the existing module-level functions in
+``bid_euchre.ops.{control_plane,monitor,task_queue,worker_pool}``.
+
+Platform-10 PR3 completes the core-vs-adapter split by providing the
+final two adapters (TaskQueueService, WorkerPoolService) alongside the
+existing two (ControlPlaneController, MonitorService).
+
+The ``bid_euchre`` adapter module is the project-specific wiring layer.
+A second project reusing the core ABCs would provide its own adapter
+module with different backing implementations.
+
+Usage::
+
+    from bid_euchre.ops.adapters import (
+        ControlPlaneController,
+        MonitorService,
+        TaskQueueService,
+        WorkerPoolService,
+    )
+"""
+
+from bid_euchre.ops.adapters.bid_euchre import TaskQueueService, WorkerPoolService
+from bid_euchre.ops.core.controller import ControlPlaneController
+from bid_euchre.ops.core.monitor import MonitorService
+
+__all__ = [
+    "ControlPlaneController",
+    "MonitorService",
+    "TaskQueueService",
+    "WorkerPoolService",
+]

--- a/src/bid_euchre/ops/adapters/bid_euchre.py
+++ b/src/bid_euchre/ops/adapters/bid_euchre.py
@@ -1,0 +1,322 @@
+"""Bid Euchre repo-specific adapters for AbstractTaskQueue and AbstractWorkerPool.
+
+Completes the Platform-10 core-vs-adapter split by providing concrete
+implementations of the remaining two ABCs that delegate to the existing
+module-level functions in ``bid_euchre.ops.task_queue`` and
+``bid_euchre.ops.worker_pool``.
+
+These adapters follow the same pattern established by
+:class:`~bid_euchre.ops.core.controller.ControlPlaneController` and
+:class:`~bid_euchre.ops.core.monitor.MonitorService` (Platform-10 PR2):
+
+- Encapsulate a ``runtime_dir`` parameter
+- Use deferred imports to avoid circular dependencies
+- Delegate to the existing module-level functions
+- Convert repo-specific dataclasses to plain dicts at the ABC boundary
+
+Usage::
+
+    from bid_euchre.ops.adapters.bid_euchre import TaskQueueService, WorkerPoolService
+
+    tq = TaskQueueService()
+    pkt = tq.create_packet("Fix bug", "Description of fix")
+    tq.save_packet(pkt)
+
+    wp = WorkerPoolService()
+    snap = wp.take_snapshot()
+    lane = wp.select_worker(snap, domain="platform")
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from bid_euchre.ops.core.interfaces import AbstractTaskQueue, AbstractWorkerPool
+
+
+class TaskQueueService(AbstractTaskQueue):
+    """Concrete task queue backed by the task_queue module.
+
+    Encapsulates a ``queue_root`` and delegates to the existing
+    module-level functions in ``bid_euchre.ops.task_queue``.
+
+    Args:
+        queue_root: Path to the task queue directory (defaults to
+            ``.claude/runtime/task_queue``).
+    """
+
+    def __init__(self, queue_root: Path | None = None) -> None:
+        self._queue_root = queue_root
+
+    # -- AbstractTaskQueue interface -----------------------------------------
+
+    def create_packet(
+        self,
+        title: str,
+        description: str,
+        *,
+        owner: str | None = None,
+        scope_declared: list[str] | None = None,
+        validation: list[str] | None = None,
+        priority: str = "normal",
+        domain: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Any:
+        """Create a new task packet.
+
+        Delegates to :func:`bid_euchre.ops.task_queue.create_packet`.
+        """
+        from bid_euchre.ops.task_queue import create_packet
+
+        return create_packet(
+            title=title,
+            description=description,
+            owner=owner,
+            scope_declared=scope_declared,
+            validation=validation,
+            priority=priority,
+            domain=domain,
+            metadata=metadata,
+        )
+
+    def save_packet(self, packet: Any) -> Any:
+        """Persist a task packet to durable storage.
+
+        Delegates to :func:`bid_euchre.ops.task_queue.save_packet`.
+        """
+        from bid_euchre.ops.task_queue import save_packet
+
+        return save_packet(packet, self._queue_root)
+
+    def load_packet(self, packet_id: str) -> Any | None:
+        """Load a task packet by ID.
+
+        Delegates to :func:`bid_euchre.ops.task_queue.load_packet`.
+        """
+        from bid_euchre.ops.task_queue import load_packet
+
+        return load_packet(packet_id, self._queue_root)
+
+    def list_packets(
+        self,
+        *,
+        status: str | None = None,
+        owner: str | None = None,
+    ) -> list[Any]:
+        """List task packets with optional filtering.
+
+        Delegates to :func:`bid_euchre.ops.task_queue.list_packets`.
+        """
+        from bid_euchre.ops.task_queue import list_packets
+
+        return list_packets(
+            self._queue_root,
+            status_filter=status,
+            owner_filter=owner,
+        )
+
+    def transition_status(
+        self,
+        packet_id: str,
+        new_status: str,
+        *,
+        owner: str | None = None,
+    ) -> Any:
+        """Transition a packet to a new status.
+
+        Delegates to :func:`bid_euchre.ops.task_queue.transition_status`.
+        If *owner* is provided, updates the packet's metadata with
+        the owner assignment after the status transition.
+        """
+        from bid_euchre.ops.task_queue import transition_status, update_packet_metadata
+
+        pkt = transition_status(packet_id, new_status, self._queue_root)
+        if pkt is not None and owner is not None:
+            pkt = update_packet_metadata(
+                packet_id,
+                {"dispatched_owner": owner},
+                self._queue_root,
+            )
+        return pkt
+
+    def archive_packet(self, packet_id: str) -> bool:
+        """Archive a completed/rejected packet.
+
+        Delegates to :func:`bid_euchre.ops.task_queue.archive_packet`.
+        """
+        from bid_euchre.ops.task_queue import archive_packet
+
+        return archive_packet(packet_id, self._queue_root)
+
+    def complete_packet(
+        self,
+        packet_id: str,
+        *,
+        summary: str = "",
+        pr_number: int | None = None,
+        completed_by: str = "",
+    ) -> Any:
+        """Complete a packet with a result record.
+
+        Delegates to :func:`bid_euchre.ops.task_queue.complete_packet`
+        by constructing a :class:`~bid_euchre.ops.task_queue.TaskResult`
+        and passing it to the module-level function.
+        """
+        from bid_euchre.ops.task_queue import complete_packet, create_result
+
+        result = create_result(
+            packet_id=packet_id,
+            status="completed",
+            summary=summary,
+            pr_number=pr_number,
+            completed_by=completed_by,
+        )
+        return complete_packet(result, self._queue_root)
+
+    def queue_summary(self) -> dict[str, Any]:
+        """Get a summary of queue state.
+
+        Delegates to :func:`bid_euchre.ops.task_queue.queue_summary`.
+        """
+        from bid_euchre.ops.task_queue import queue_summary
+
+        return queue_summary(self._queue_root)
+
+
+class WorkerPoolService(AbstractWorkerPool):
+    """Concrete worker pool backed by the worker_pool module.
+
+    Encapsulates ``runtime_dir`` and ``tmux_session`` and delegates
+    to the existing module-level functions in
+    ``bid_euchre.ops.worker_pool``.
+
+    Args:
+        runtime_dir: Path to the runtime directory (defaults to
+            ``.claude/runtime``).
+        tmux_session: tmux session name (defaults to ``"steward"``).
+    """
+
+    def __init__(
+        self,
+        runtime_dir: Path | None = None,
+        tmux_session: str = "steward",
+    ) -> None:
+        self._runtime_dir = runtime_dir
+        self._tmux_session = tmux_session
+
+    @staticmethod
+    def _action_to_dict(action: Any) -> dict[str, Any]:
+        """Convert a PoolAction dataclass to a plain dict.
+
+        The ABC contract returns adapter-defined types; we preserve
+        the PoolAction as-is since it is already a concrete type that
+        callers can use directly.  This method is available for cases
+        where dict serialization is needed.
+        """
+        return asdict(action)
+
+    # -- AbstractWorkerPool interface ----------------------------------------
+
+    def take_snapshot(self) -> Any:
+        """Build a point-in-time worker pool snapshot.
+
+        Delegates to :func:`bid_euchre.ops.worker_pool.take_pool_snapshot`.
+        """
+        from bid_euchre.ops.worker_pool import take_pool_snapshot
+
+        return take_pool_snapshot(
+            runtime_dir=self._runtime_dir,
+            tmux_session=self._tmux_session,
+        )
+
+    def select_worker(
+        self,
+        snapshot: Any,
+        *,
+        preferred_lane: str | None = None,
+        domain: str | None = None,
+    ) -> str | None:
+        """Choose the best lane for new work.
+
+        Delegates to :func:`bid_euchre.ops.worker_pool.select_worker`.
+        """
+        from bid_euchre.ops.worker_pool import select_worker
+
+        return select_worker(
+            snapshot,
+            preferred_lane=preferred_lane,
+            domain=domain,
+        )
+
+    def dispatch_to_worker(
+        self,
+        packet_id: str,
+        lane_id: str,
+    ) -> Any:
+        """Dispatch a task packet to a worker lane.
+
+        Delegates to :func:`bid_euchre.ops.worker_pool.dispatch_to_worker`.
+        """
+        from bid_euchre.ops.worker_pool import dispatch_to_worker
+
+        return dispatch_to_worker(
+            packet_id,
+            lane_id,
+            tmux_session=self._tmux_session,
+            runtime_dir=self._runtime_dir,
+        )
+
+    def wake_worker(self, lane_id: str) -> Any:
+        """Wake a parked or retired worker lane.
+
+        Delegates to :func:`bid_euchre.ops.worker_pool.wake_worker`.
+        """
+        from bid_euchre.ops.worker_pool import wake_worker
+
+        return wake_worker(
+            lane_id,
+            tmux_session=self._tmux_session,
+            runtime_dir=self._runtime_dir,
+        )
+
+    def park_worker(self, lane_id: str) -> Any:
+        """Park an idle worker lane.
+
+        Delegates to :func:`bid_euchre.ops.worker_pool.park_worker`.
+        """
+        from bid_euchre.ops.worker_pool import park_worker
+
+        return park_worker(
+            lane_id,
+            tmux_session=self._tmux_session,
+            runtime_dir=self._runtime_dir,
+        )
+
+    def nudge_pane(self, lane_id: str, text: str) -> bool:
+        """Send a text nudge to a lane's tmux pane.
+
+        Delegates to :func:`bid_euchre.ops.worker_pool.nudge_pane`.
+        The module-level function uses a ``packet_id`` parameter rather
+        than raw text; this adapter extracts the packet_id from the text
+        if it follows the ``/start-task <id>`` pattern, otherwise passes
+        the text as-is.
+
+        Note: The underlying module function returns a PoolAction, but
+        the ABC contract returns a bool.  We convert accordingly.
+        """
+        from bid_euchre.ops.worker_pool import nudge_pane as _nudge
+
+        # Extract packet_id from "/start-task <id>" if present
+        packet_id = text
+        if text.startswith("/start-task "):
+            packet_id = text.split(maxsplit=1)[1] if " " in text else text
+
+        action = _nudge(
+            lane_id,
+            packet_id,
+            tmux_session=self._tmux_session,
+            runtime_dir=self._runtime_dir,
+        )
+        return action.executed

--- a/tests/unit/test_ops_adapter_migration.py
+++ b/tests/unit/test_ops_adapter_migration.py
@@ -1,0 +1,499 @@
+"""Tests for the Bid Euchre repo-specific ops adapters.
+
+Platform-10 PR3: verifies that TaskQueueService and WorkerPoolService
+correctly implement the core ABCs and delegate to the existing module-level
+functions in ``bid_euchre.ops.task_queue`` and ``bid_euchre.ops.worker_pool``.
+
+Test categories:
+1. **ABC compliance** — adapters are subclasses and can be instantiated.
+2. **Delegation** — adapter methods correctly call through to module functions.
+3. **Package exports** — ``adapters/__init__.py`` re-exports all four adapters.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bid_euchre.ops.core.interfaces import (
+    AbstractTaskQueue,
+    AbstractWorkerPool,
+)
+
+# =========================================================================
+# TaskQueueService
+# =========================================================================
+
+
+class TestTaskQueueServiceABCCompliance:
+    """TaskQueueService properly implements AbstractTaskQueue."""
+
+    def test_is_subclass(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import TaskQueueService
+
+        assert issubclass(TaskQueueService, AbstractTaskQueue)
+
+    def test_can_instantiate(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import TaskQueueService
+
+        tq = TaskQueueService()
+        assert isinstance(tq, AbstractTaskQueue)
+
+    def test_custom_queue_root(self, tmp_path: Path) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import TaskQueueService
+
+        tq = TaskQueueService(queue_root=tmp_path)
+        assert tq._queue_root == tmp_path
+
+
+class TestTaskQueueServiceDelegation:
+    """TaskQueueService methods delegate to task_queue module functions."""
+
+    def test_create_packet_delegates(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import TaskQueueService
+
+        tq = TaskQueueService()
+        pkt = tq.create_packet("Test Task", "Test description")
+        # Should return a TaskPacket from the module
+        assert hasattr(pkt, "packet_id")
+        assert pkt.title == "Test Task"
+        assert pkt.description == "Test description"
+        assert pkt.status == "pending"
+
+    def test_create_packet_with_kwargs(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import TaskQueueService
+
+        tq = TaskQueueService()
+        pkt = tq.create_packet(
+            "Test Task",
+            "Description",
+            owner="author-a",
+            scope_declared=["src/foo.py"],
+            validation=["make check"],
+            priority="high",
+            domain="platform",
+            metadata={"key": "value"},
+        )
+        assert pkt.owner == "author-a"
+        assert pkt.scope_declared == ["src/foo.py"]
+        assert pkt.validation == ["make check"]
+        assert pkt.priority == "high"
+        assert pkt.domain == "platform"
+        assert pkt.metadata == {"key": "value"}
+
+    def test_save_and_load_packet(self, tmp_path: Path) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import TaskQueueService
+
+        tq = TaskQueueService(queue_root=tmp_path)
+        pkt = tq.create_packet("Save Test", "Test saving")
+        tq.save_packet(pkt)
+
+        loaded = tq.load_packet(pkt.packet_id)
+        assert loaded is not None
+        assert loaded.title == "Save Test"
+        assert loaded.packet_id == pkt.packet_id
+
+    def test_load_packet_not_found(self, tmp_path: Path) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import TaskQueueService
+
+        tq = TaskQueueService(queue_root=tmp_path)
+        assert tq.load_packet("nonexistent") is None
+
+    def test_list_packets_empty(self, tmp_path: Path) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import TaskQueueService
+
+        tq = TaskQueueService(queue_root=tmp_path)
+        assert tq.list_packets() == []
+
+    def test_list_packets_with_filter(self, tmp_path: Path) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import TaskQueueService
+
+        tq = TaskQueueService(queue_root=tmp_path)
+
+        pkt1 = tq.create_packet("Task 1", "Desc 1", owner="author-a")
+        pkt2 = tq.create_packet("Task 2", "Desc 2", owner="author-b")
+        tq.save_packet(pkt1)
+        tq.save_packet(pkt2)
+
+        all_packets = tq.list_packets()
+        assert len(all_packets) == 2
+
+        filtered = tq.list_packets(owner="author-a")
+        assert len(filtered) == 1
+        assert filtered[0].owner == "author-a"
+
+        status_filtered = tq.list_packets(status="pending")
+        assert len(status_filtered) == 2
+
+    def test_transition_status(self, tmp_path: Path) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import TaskQueueService
+
+        tq = TaskQueueService(queue_root=tmp_path)
+        pkt = tq.create_packet("Trans Test", "Description")
+        tq.save_packet(pkt)
+
+        updated = tq.transition_status(pkt.packet_id, "approved")
+        assert updated is not None
+        assert updated.status == "approved"
+
+    def test_transition_status_invalid(self, tmp_path: Path) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import TaskQueueService
+
+        tq = TaskQueueService(queue_root=tmp_path)
+        pkt = tq.create_packet("Trans Test", "Description")
+        tq.save_packet(pkt)
+
+        # pending -> dispatched is not a valid transition
+        with pytest.raises(ValueError, match="Invalid transition"):
+            tq.transition_status(pkt.packet_id, "dispatched")
+
+    def test_transition_status_with_owner(self, tmp_path: Path) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import TaskQueueService
+
+        tq = TaskQueueService(queue_root=tmp_path)
+        pkt = tq.create_packet("Owner Test", "Description")
+        tq.save_packet(pkt)
+
+        updated = tq.transition_status(pkt.packet_id, "approved", owner="author-a")
+        assert updated is not None
+        # owner metadata should be set
+        assert updated.metadata.get("dispatched_owner") == "author-a"
+
+    def test_archive_packet(self, tmp_path: Path) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import TaskQueueService
+
+        tq = TaskQueueService(queue_root=tmp_path)
+        pkt = tq.create_packet("Archive Test", "Description")
+        tq.save_packet(pkt)
+
+        result = tq.archive_packet(pkt.packet_id)
+        assert result is True
+
+        # Should no longer be in active queue
+        assert tq.load_packet(pkt.packet_id) is None
+
+    def test_archive_packet_not_found(self, tmp_path: Path) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import TaskQueueService
+
+        tq = TaskQueueService(queue_root=tmp_path)
+        assert tq.archive_packet("nonexistent") is False
+
+    def test_complete_packet(self, tmp_path: Path) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import TaskQueueService
+
+        tq = TaskQueueService(queue_root=tmp_path)
+        pkt = tq.create_packet("Complete Test", "Description")
+        tq.save_packet(pkt)
+        # Must transition through valid states first
+        tq.transition_status(pkt.packet_id, "approved")
+        tq.transition_status(pkt.packet_id, "dispatched")
+
+        tq.complete_packet(
+            pkt.packet_id,
+            summary="Done",
+            pr_number=42,
+            completed_by="author-a",
+        )
+        # complete_packet archives by default, so load returns None
+        assert tq.load_packet(pkt.packet_id) is None
+
+    def test_queue_summary(self, tmp_path: Path) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import TaskQueueService
+
+        tq = TaskQueueService(queue_root=tmp_path)
+
+        summary = tq.queue_summary()
+        assert summary["total"] == 0
+
+        pkt = tq.create_packet("Summary Test", "Description")
+        tq.save_packet(pkt)
+
+        summary = tq.queue_summary()
+        assert summary["total"] == 1
+        assert summary["by_status"]["pending"] == 1
+
+
+# =========================================================================
+# WorkerPoolService
+# =========================================================================
+
+
+class TestWorkerPoolServiceABCCompliance:
+    """WorkerPoolService properly implements AbstractWorkerPool."""
+
+    def test_is_subclass(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import WorkerPoolService
+
+        assert issubclass(WorkerPoolService, AbstractWorkerPool)
+
+    def test_can_instantiate(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import WorkerPoolService
+
+        wp = WorkerPoolService()
+        assert isinstance(wp, AbstractWorkerPool)
+
+    def test_custom_params(self, tmp_path: Path) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import WorkerPoolService
+
+        wp = WorkerPoolService(runtime_dir=tmp_path, tmux_session="test")
+        assert wp._runtime_dir == tmp_path
+        assert wp._tmux_session == "test"
+
+
+class TestWorkerPoolServiceDelegation:
+    """WorkerPoolService methods delegate to worker_pool module functions."""
+
+    def test_take_snapshot_delegates(self) -> None:
+        """Verify take_snapshot calls through to take_pool_snapshot."""
+        from bid_euchre.ops.adapters.bid_euchre import WorkerPoolService
+
+        wp = WorkerPoolService(tmux_session="test-session")
+
+        with patch("bid_euchre.ops.worker_pool.take_pool_snapshot") as mock_snap:
+            mock_snap.return_value = MagicMock(workers=[], active_count=0, idle_count=0)
+            result = wp.take_snapshot()
+            mock_snap.assert_called_once_with(
+                runtime_dir=None,
+                tmux_session="test-session",
+            )
+            assert result is mock_snap.return_value
+
+    def test_select_worker_delegates(self) -> None:
+        """Verify select_worker calls through to module function."""
+        from bid_euchre.ops.adapters.bid_euchre import WorkerPoolService
+
+        wp = WorkerPoolService()
+        mock_snapshot = MagicMock()
+
+        with patch("bid_euchre.ops.worker_pool.select_worker") as mock_select:
+            mock_select.return_value = "author-a"
+            result = wp.select_worker(
+                mock_snapshot, preferred_lane="author-a", domain="platform"
+            )
+            mock_select.assert_called_once_with(
+                mock_snapshot,
+                preferred_lane="author-a",
+                domain="platform",
+            )
+            assert result == "author-a"
+
+    def test_select_worker_returns_none(self) -> None:
+        """Verify select_worker returns None when no capacity."""
+        from bid_euchre.ops.adapters.bid_euchre import WorkerPoolService
+
+        wp = WorkerPoolService()
+        mock_snapshot = MagicMock()
+
+        with patch("bid_euchre.ops.worker_pool.select_worker") as mock_select:
+            mock_select.return_value = None
+            result = wp.select_worker(mock_snapshot)
+            assert result is None
+
+    def test_dispatch_to_worker_delegates(self) -> None:
+        """Verify dispatch_to_worker calls through to module function."""
+        from bid_euchre.ops.adapters.bid_euchre import WorkerPoolService
+
+        wp = WorkerPoolService(tmux_session="test-session")
+
+        with patch("bid_euchre.ops.worker_pool.dispatch_to_worker") as mock_dispatch:
+            mock_dispatch.return_value = MagicMock(action="dispatch", executed=True)
+            result = wp.dispatch_to_worker("pkt123", "author-a")
+            mock_dispatch.assert_called_once_with(
+                "pkt123",
+                "author-a",
+                tmux_session="test-session",
+                runtime_dir=None,
+            )
+            assert result is mock_dispatch.return_value
+
+    def test_wake_worker_delegates(self) -> None:
+        """Verify wake_worker calls through to module function."""
+        from bid_euchre.ops.adapters.bid_euchre import WorkerPoolService
+
+        wp = WorkerPoolService(tmux_session="test-session")
+
+        with patch("bid_euchre.ops.worker_pool.wake_worker") as mock_wake:
+            mock_wake.return_value = MagicMock(action="wake", executed=True)
+            result = wp.wake_worker("author-b")
+            mock_wake.assert_called_once_with(
+                "author-b",
+                tmux_session="test-session",
+                runtime_dir=None,
+            )
+            assert result is mock_wake.return_value
+
+    def test_park_worker_delegates(self) -> None:
+        """Verify park_worker calls through to module function."""
+        from bid_euchre.ops.adapters.bid_euchre import WorkerPoolService
+
+        wp = WorkerPoolService(tmux_session="test-session")
+
+        with patch("bid_euchre.ops.worker_pool.park_worker") as mock_park:
+            mock_park.return_value = MagicMock(action="park", executed=True)
+            result = wp.park_worker("author-c")
+            mock_park.assert_called_once_with(
+                "author-c",
+                tmux_session="test-session",
+                runtime_dir=None,
+            )
+            assert result is mock_park.return_value
+
+    def test_nudge_pane_delegates(self) -> None:
+        """Verify nudge_pane calls through to module function."""
+        from bid_euchre.ops.adapters.bid_euchre import WorkerPoolService
+
+        wp = WorkerPoolService(tmux_session="test-session")
+
+        with patch("bid_euchre.ops.worker_pool.nudge_pane") as mock_nudge:
+            mock_nudge.return_value = MagicMock(executed=True)
+            result = wp.nudge_pane("author-a", "/start-task abc123")
+            mock_nudge.assert_called_once_with(
+                "author-a",
+                "abc123",
+                tmux_session="test-session",
+                runtime_dir=None,
+            )
+            assert result is True
+
+    def test_nudge_pane_returns_false_on_failure(self) -> None:
+        """Verify nudge_pane returns False when execution fails."""
+        from bid_euchre.ops.adapters.bid_euchre import WorkerPoolService
+
+        wp = WorkerPoolService()
+
+        with patch("bid_euchre.ops.worker_pool.nudge_pane") as mock_nudge:
+            mock_nudge.return_value = MagicMock(executed=False)
+            result = wp.nudge_pane("author-a", "/start-task xyz")
+            assert result is False
+
+    def test_nudge_pane_raw_text(self) -> None:
+        """Verify nudge_pane handles non-start-task text."""
+        from bid_euchre.ops.adapters.bid_euchre import WorkerPoolService
+
+        wp = WorkerPoolService()
+
+        with patch("bid_euchre.ops.worker_pool.nudge_pane") as mock_nudge:
+            mock_nudge.return_value = MagicMock(executed=True)
+            wp.nudge_pane("author-a", "some-raw-text")
+            mock_nudge.assert_called_once_with(
+                "author-a",
+                "some-raw-text",
+                tmux_session="steward",
+                runtime_dir=None,
+            )
+
+    def test_action_to_dict_helper(self) -> None:
+        """Verify the static _action_to_dict helper works."""
+        from bid_euchre.ops.adapters.bid_euchre import WorkerPoolService
+        from bid_euchre.ops.worker_pool import PoolAction
+
+        action = PoolAction(
+            action="test",
+            lane_id="author-a",
+            reason="testing",
+            executed=True,
+        )
+        result = WorkerPoolService._action_to_dict(action)
+        assert isinstance(result, dict)
+        assert result["action"] == "test"
+        assert result["lane_id"] == "author-a"
+        assert result["executed"] is True
+
+
+# =========================================================================
+# Package exports
+# =========================================================================
+
+
+class TestAdapterPackageExports:
+    """Verify adapters/__init__.py re-exports all four adapter classes."""
+
+    def test_all_four_adapters_exported(self) -> None:
+        import bid_euchre.ops.adapters as adapters
+
+        expected = {
+            "ControlPlaneController",
+            "MonitorService",
+            "TaskQueueService",
+            "WorkerPoolService",
+        }
+        assert expected == set(adapters.__all__)
+
+    def test_controller_from_adapters(self) -> None:
+        from bid_euchre.ops.adapters import ControlPlaneController
+        from bid_euchre.ops.core.controller import (
+            ControlPlaneController as Direct,
+        )
+
+        assert ControlPlaneController is Direct
+
+    def test_monitor_from_adapters(self) -> None:
+        from bid_euchre.ops.adapters import MonitorService
+        from bid_euchre.ops.core.monitor import MonitorService as Direct
+
+        assert MonitorService is Direct
+
+    def test_task_queue_from_adapters(self) -> None:
+        from bid_euchre.ops.adapters import TaskQueueService
+        from bid_euchre.ops.adapters.bid_euchre import (
+            TaskQueueService as Direct,
+        )
+
+        assert TaskQueueService is Direct
+
+    def test_worker_pool_from_adapters(self) -> None:
+        from bid_euchre.ops.adapters import WorkerPoolService
+        from bid_euchre.ops.adapters.bid_euchre import (
+            WorkerPoolService as Direct,
+        )
+
+        assert WorkerPoolService is Direct
+
+
+# =========================================================================
+# Cross-cutting: isinstance checks across the full adapter set
+# =========================================================================
+
+
+class TestAllAdaptersImplementABCs:
+    """All four adapters are instances of their respective ABCs."""
+
+    def test_all_four_are_abc_subclasses(self) -> None:
+        from bid_euchre.ops.adapters import (
+            ControlPlaneController,
+            MonitorService,
+            TaskQueueService,
+            WorkerPoolService,
+        )
+        from bid_euchre.ops.core import (
+            AbstractController,
+            AbstractMonitor,
+            AbstractTaskQueue,
+            AbstractWorkerPool,
+        )
+
+        assert issubclass(ControlPlaneController, AbstractController)
+        assert issubclass(MonitorService, AbstractMonitor)
+        assert issubclass(TaskQueueService, AbstractTaskQueue)
+        assert issubclass(WorkerPoolService, AbstractWorkerPool)
+
+    def test_all_four_can_instantiate(self) -> None:
+        from bid_euchre.ops.adapters import (
+            ControlPlaneController,
+            MonitorService,
+            TaskQueueService,
+            WorkerPoolService,
+        )
+
+        # All should instantiate without error
+        ctrl = ControlPlaneController()
+        mon = MonitorService()
+        tq = TaskQueueService()
+        wp = WorkerPoolService()
+
+        assert ctrl is not None
+        assert mon is not None
+        assert tq is not None
+        assert wp is not None


### PR DESCRIPTION
## Plan
`plans/agent_ops/governing_plan.md` — Platform-10 (Core Extraction), Step 3

## Summary
- Create `src/bid_euchre/ops/adapters/` package with `TaskQueueService` and `WorkerPoolService` implementing the remaining two core ABCs
- Re-export all four adapters (including `ControlPlaneController` and `MonitorService` from PR2) through `adapters/__init__.py`
- Add 36 tests covering ABC compliance, delegation correctness, and package exports

## Why
Completes the Platform-10 core-vs-adapter split. With all four ABCs now backed by concrete adapters, the orchestration loop can be programmed against the abstract interfaces while the `adapters/bid_euchre` module provides the project-specific wiring. A second project reusing the core ABCs would provide its own adapter module.

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/test_ops_adapter_migration.py -v` (36 passed)
- `uv run python -m pytest tests/unit/test_ops_core_interfaces.py tests/unit/test_ops_core_controller.py tests/unit/test_ops_core_monitor.py -v` (55 passed, no regressions)
- `make check-quiet` (all checks passed)

## Test Criteria
- **Pass condition:** All 36 adapter migration tests pass; all four adapters are ABC-compliant subclasses
- **Verification command:** `uv run python -m pytest tests/unit/test_ops_adapter_migration.py -v`
- **Expected result:** 36 passed, 0 failed

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_adapter_migration.py -v`
- [x] `make check-quiet`

## Expected impact
- Metrics impact: None (new code, no existing behavior changed)
- Runtime impact: None (adapter classes are thin delegation wrappers)

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
```

`git worktree list` (relevant line):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d  d6e42adf [ops/platform10-core-extraction]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)