### PR TITLE
feat(web): add mobile viewport and accessibility improvements (Browser Expansion PR-5)

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -817,3 +817,296 @@ class TestMatchResult:
         )
         assert 'action="/play/test-id/new-match"' in html
         assert 'hx-target="#game-board"' in html
+
+
+# ---------------------------------------------------------------------------
+# Accessibility — ARIA attributes
+# ---------------------------------------------------------------------------
+
+
+class TestAccessibilityHand:
+    """Verify ARIA attributes on card elements in hand.html."""
+
+    def test_legal_card_has_aria_label(self, env):
+        tmpl = env.get_template("partials/hand.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=0,
+            human_hand=[["S", "A"]],
+            legal_plays=[0],
+            phase="trick_play",
+        )
+        assert 'aria-label="Play A of Spades"' in html
+
+    def test_illegal_card_has_aria_label(self, env):
+        tmpl = env.get_template("partials/hand.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=0,
+            human_hand=[["H", "K"]],
+            legal_plays=[],
+            phase="trick_play",
+        )
+        assert 'aria-label="K of Hearts (cannot play)"' in html
+
+    def test_auction_card_has_aria_label(self, env):
+        tmpl = env.get_template("partials/hand.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=0,
+            human_hand=[["D", "10"]],
+            legal_plays=None,
+            phase="auction",
+        )
+        assert 'aria-label="10 of Diamonds"' in html
+
+    def test_hand_region_has_aria_label(self, env):
+        tmpl = env.get_template("partials/hand.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=0,
+            human_hand=[["C", "J"]],
+            legal_plays=None,
+            phase="auction",
+        )
+        assert 'aria-label="Your hand"' in html
+
+    def test_card_fan_has_group_role(self, env):
+        tmpl = env.get_template("partials/hand.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=0,
+            human_hand=[["S", "A"], ["H", "K"]],
+            legal_plays=None,
+            phase="auction",
+        )
+        assert 'role="group"' in html
+        assert "Cards in your hand (2)" in html
+
+
+class TestAccessibilityBidPanel:
+    """Verify ARIA attributes on bid panel controls."""
+
+    def test_bid_panel_has_region_role(self, env):
+        tmpl = env.get_template("partials/bid_panel.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=0,
+            auction=[],
+            current_high_bid=0,
+            dealer_seat=0,
+        )
+        assert 'role="region"' in html
+        assert 'aria-label="Auction panel"' in html
+
+    def test_bid_form_has_aria_label(self, env):
+        tmpl = env.get_template("partials/bid_panel.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=0,
+            auction=[],
+            current_high_bid=0,
+            dealer_seat=0,
+        )
+        assert 'aria-label="Submit your bid"' in html
+
+    def test_submit_button_has_aria_label(self, env):
+        tmpl = env.get_template("partials/bid_panel.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=0,
+            auction=[],
+            current_high_bid=0,
+            dealer_seat=0,
+        )
+        assert 'aria-label="Submit bid"' in html
+
+    def test_pass_button_has_aria_label(self, env):
+        tmpl = env.get_template("partials/bid_panel.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=0,
+            auction=[],
+            current_high_bid=0,
+            dealer_seat=0,
+        )
+        assert 'aria-label="Pass on this bid"' in html
+
+
+class TestAccessibilityTrick:
+    """Verify ARIA attributes on trick area."""
+
+    def test_trick_area_has_region(self, env):
+        tmpl = env.get_template("partials/trick.html")
+        html = tmpl.render(
+            current_trick={"leader": 0, "plays": []},
+            completed_tricks=[],
+            tricks_team0=0,
+            tricks_team1=0,
+        )
+        assert 'role="region"' in html
+        assert 'aria-label="Current trick"' in html
+
+    def test_played_card_has_aria_label(self, env):
+        tmpl = env.get_template("partials/trick.html")
+        html = tmpl.render(
+            current_trick={
+                "leader": 1,
+                "plays": [[1, ["H", "A"]]],
+            },
+            completed_tricks=[],
+            tricks_team0=0,
+            tricks_team1=0,
+        )
+        assert "AI Left played A of Hearts" in html
+
+    def test_empty_slot_has_waiting_label(self, env):
+        tmpl = env.get_template("partials/trick.html")
+        html = tmpl.render(
+            current_trick={"leader": 0, "plays": []},
+            completed_tricks=[],
+            tricks_team0=0,
+            tricks_team1=0,
+        )
+        assert "waiting to play" in html
+
+
+class TestAccessibilityScore:
+    """Verify ARIA attributes on score bar."""
+
+    def test_score_bar_has_status_role(self, env):
+        tmpl = env.get_template("partials/score.html")
+        html = tmpl.render(
+            score_human=10,
+            score_ai=5,
+            hands_played=2,
+            contract_type=None,
+            trump=None,
+            winning_bid=None,
+            bidder_seat=None,
+            tricks_team0=0,
+            tricks_team1=0,
+            dealer_seat=0,
+            phase="auction",
+        )
+        assert 'role="status"' in html
+
+    def test_score_section_has_aria_label(self, env):
+        tmpl = env.get_template("partials/score.html")
+        html = tmpl.render(
+            score_human=15,
+            score_ai=-3,
+            hands_played=4,
+            contract_type=None,
+            trump=None,
+            winning_bid=None,
+            bidder_seat=None,
+            tricks_team0=0,
+            tricks_team1=0,
+            dealer_seat=3,
+            phase="auction",
+        )
+        assert "Match score: You 15, AI -3" in html
+
+
+class TestAccessibilityResults:
+    """Verify ARIA attributes on result screens."""
+
+    def test_hand_result_has_alert_role(self, env):
+        tmpl = env.get_template("partials/hand_result.html")
+        html = tmpl.render(
+            winning_bid=6,
+            bidder_seat=0,
+            contract_type="suit",
+            trump="S",
+            tricks_team0=7,
+            tricks_team1=3,
+            points_team0=7,
+            points_team1=3,
+            score_human=7,
+            score_ai=3,
+            hands_played=1,
+        )
+        assert 'role="alert"' in html
+
+    def test_match_result_has_alert_role(self, env):
+        tmpl = env.get_template("partials/match_result.html")
+        html = tmpl.render(
+            link_uuid="x",
+            winner="human",
+            score_human=55,
+            score_ai=30,
+            hands_played=12,
+        )
+        assert 'role="alert"' in html
+
+    def test_play_again_has_aria_label(self, env):
+        tmpl = env.get_template("partials/match_result.html")
+        html = tmpl.render(
+            link_uuid="x",
+            winner="human",
+            score_human=55,
+            score_ai=30,
+            hands_played=12,
+        )
+        assert 'aria-label="Start a new match"' in html
+
+
+class TestAccessibilityForms:
+    """Verify ARIA attributes on setup form partials."""
+
+    def test_nickname_form_has_region(self, env):
+        tmpl = env.get_template("partials/nickname_form.html")
+        html = tmpl.render(link_uuid="x")
+        assert 'role="region"' in html
+        assert 'aria-label="Set your nickname"' in html
+
+    def test_model_select_has_region(self, env):
+        models = [ModelStub("heuristic", "Heuristic", "Rule-based")]
+        tmpl = env.get_template("partials/model_select.html")
+        html = tmpl.render(link_uuid="x", nickname="Bob", models=models)
+        assert 'role="region"' in html
+        assert 'aria-label="Choose AI opponent"' in html
+
+    def test_invite_code_has_sr_only_label(self, env):
+        tmpl = env.get_template("partials/invite_code_form.html")
+        html = tmpl.render(error=None)
+        assert 'class="sr-only"' in html
+        assert 'for="invite-code-input"' in html
+
+    def test_invite_error_has_alert_role(self, env):
+        tmpl = env.get_template("partials/invite_code_form.html")
+        html = tmpl.render(error="Invalid code")
+        assert 'role="alert"' in html
+        assert "Invalid code" in html
+
+
+class TestAccessibilityBaseTemplate:
+    """Verify accessibility features in base.html."""
+
+    def test_skip_link_present(self, env):
+        tmpl = env.get_template("base.html")
+        html = tmpl.render()
+        assert 'class="skip-link"' in html
+        assert 'href="#main-content"' in html
+
+    def test_main_has_id_for_skip(self, env):
+        tmpl = env.get_template("base.html")
+        html = tmpl.render()
+        assert 'id="main-content"' in html
+        assert 'role="main"' in html
+
+    def test_header_has_banner_role(self, env):
+        tmpl = env.get_template("base.html")
+        html = tmpl.render()
+        assert 'role="banner"' in html
+
+    def test_accessibility_css_linked(self, env):
+        tmpl = env.get_template("base.html")
+        html = tmpl.render()
+        assert "/static/css/accessibility.css" in html
+
+    def test_viewport_has_viewport_fit(self, env):
+        tmpl = env.get_template("base.html")
+        html = tmpl.render()
+        assert "viewport-fit=cover" in html

--- a/web/static/css/accessibility.css
+++ b/web/static/css/accessibility.css
@@ -1,0 +1,226 @@
+/* ==========================================================================
+   Bid Euchre Browser Game — Accessibility Stylesheet
+   Focus management, touch targets, keyboard navigation, and a11y utilities.
+   Loaded after style.css to layer accessibility enhancements.
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Skip Navigation Link
+   -------------------------------------------------------------------------- */
+
+.skip-link {
+    position: absolute;
+    top: -100%;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1000;
+    padding: 0.75rem 1.5rem;
+    background: var(--color-surface, #263238);
+    color: #fff;
+    font-size: 1rem;
+    font-weight: 600;
+    border-radius: 0 0 8px 8px;
+    text-decoration: none;
+    transition: top 0.2s ease;
+}
+
+.skip-link:focus {
+    top: 0;
+    outline: 3px solid var(--color-legal-glow, #4caf50);
+    outline-offset: 2px;
+}
+
+/* --------------------------------------------------------------------------
+   2. Focus Visible — Keyboard-Only Focus Rings
+   -------------------------------------------------------------------------- */
+
+/*
+ * :focus-visible targets keyboard focus only (not mouse/touch clicks).
+ * This keeps the UI clean for pointer users while ensuring keyboard users
+ * can always see where focus is.
+ */
+
+:focus-visible {
+    outline: 3px solid var(--color-legal-glow, #4caf50);
+    outline-offset: 2px;
+}
+
+/* Remove default outlines since we handle them via :focus-visible */
+:focus:not(:focus-visible) {
+    outline: none;
+}
+
+/* Card buttons — bright green ring on keyboard focus */
+button.card--legal:focus-visible {
+    outline: 3px solid var(--color-legal-glow, #4caf50);
+    outline-offset: 3px;
+    box-shadow: 0 0 0 6px rgba(76, 175, 80, 0.3);
+}
+
+/* Bid controls — visible ring on selects and buttons */
+.bid-controls select:focus-visible,
+.bid-controls button:focus-visible {
+    outline: 3px solid var(--color-legal-glow, #4caf50);
+    outline-offset: 2px;
+}
+
+/* Pass button */
+.pass-btn:focus-visible {
+    outline: 3px solid var(--color-legal-glow, #4caf50);
+    outline-offset: 2px;
+}
+
+/* Form inputs */
+input[type="text"]:focus-visible,
+select:focus-visible {
+    outline: 3px solid var(--color-legal-glow, #4caf50);
+    outline-offset: 1px;
+}
+
+/* Play Again and other action buttons */
+.btn:focus-visible {
+    outline: 3px solid var(--color-legal-glow, #4caf50);
+    outline-offset: 3px;
+    box-shadow: 0 0 0 6px rgba(76, 175, 80, 0.3);
+}
+
+/* --------------------------------------------------------------------------
+   3. Touch Target Minimums (44x44px per WCAG 2.5.5)
+   --------------------------------------------------------------------------
+   These rules enforce minimum interactive target sizes for touch devices.
+   Applied via media query so desktop pointer users keep compact layouts.
+   -------------------------------------------------------------------------- */
+
+@media (pointer: coarse) {
+    /* Card buttons — already large enough at default, but enforce min on small screens */
+    button.card--legal {
+        min-width: 44px;
+        min-height: 44px;
+    }
+
+    /* Bid control buttons */
+    .bid-controls button,
+    .pass-btn {
+        min-height: 44px;
+        min-width: 44px;
+        padding: 0.6rem 1.25rem;
+    }
+
+    /* Select dropdowns */
+    .bid-controls select,
+    #model-select select {
+        min-height: 44px;
+        padding: 0.5rem 0.75rem;
+    }
+
+    /* Form submit buttons (nickname, model select, invite code) */
+    #nickname-form button,
+    #model-select button,
+    .btn {
+        min-height: 44px;
+        min-width: 44px;
+    }
+
+    /* Text inputs */
+    #nickname-form input[type="text"],
+    #invite-code-input {
+        min-height: 44px;
+    }
+
+    /* Play Again button */
+    .btn--play-again {
+        min-height: 48px;
+        padding: 0.75rem 2rem;
+    }
+}
+
+/* --------------------------------------------------------------------------
+   4. Reduced Motion — Extended Coverage
+   --------------------------------------------------------------------------
+   Supplements the base reduced-motion rules in style.css.
+   Covers card hover transforms, button transitions, and any motion
+   that style.css does not already suppress.
+   -------------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+    /* Suppress card hover lift */
+    .card--legal:hover {
+        transform: none;
+    }
+
+    /* Suppress button hover lift */
+    .btn:hover {
+        transform: none;
+    }
+
+    /* Suppress all CSS transitions */
+    .card,
+    .btn,
+    .bid-controls button,
+    #nickname-form button,
+    #model-select button {
+        transition: none;
+    }
+
+    /* Skip link — no transition */
+    .skip-link {
+        transition: none;
+    }
+}
+
+/* --------------------------------------------------------------------------
+   5. High Contrast Mode Support
+   -------------------------------------------------------------------------- */
+
+@media (forced-colors: active) {
+    .card--legal {
+        border: 3px solid LinkText;
+    }
+
+    .card--illegal {
+        opacity: 0.6;
+    }
+
+    .skip-link:focus {
+        outline: 3px solid LinkText;
+    }
+}
+
+/* --------------------------------------------------------------------------
+   6. ARIA Live Region Styling
+   --------------------------------------------------------------------------
+   Elements marked with aria-live get a subtle visual treatment to signal
+   that content updates dynamically.
+   -------------------------------------------------------------------------- */
+
+[aria-live="polite"] {
+    /* No visual treatment by default — this selector exists as a hook
+       for future visual indicators of dynamic content updates. */
+}
+
+/* --------------------------------------------------------------------------
+   7. Pass Button Styling
+   --------------------------------------------------------------------------
+   The pass button is styled as a secondary action distinct from Submit Bid.
+   -------------------------------------------------------------------------- */
+
+.bid-pass {
+    margin-top: 0.5rem;
+}
+
+.pass-btn {
+    padding: 0.5rem 1.25rem;
+    border: 2px solid var(--color-text-muted, #bdbdbd);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--color-text-muted, #bdbdbd);
+    font-weight: 600;
+    cursor: pointer;
+    font-size: 0.9rem;
+    transition: background 0.15s, color 0.15s;
+}
+
+.pass-btn:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--color-text, #fafafa);
+}

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -711,7 +711,7 @@ main {
 }
 
 /* --------------------------------------------------------------------------
-   13. Responsive Basics
+   13. Responsive — Tablet / Small Desktop (max-width: 600px)
    -------------------------------------------------------------------------- */
 
 @media (max-width: 600px) {
@@ -765,6 +765,272 @@ main {
     #model-select {
         margin: 1rem;
         padding: 1.25rem;
+    }
+}
+
+/* --------------------------------------------------------------------------
+   13a. Responsive — iPhone Plus / Pro (max-width: 414px)
+   -------------------------------------------------------------------------- */
+
+@media (max-width: 414px) {
+    :root {
+        --card-width: 44px;
+        --card-height: 66px;
+        --card-overlap: -6px;
+    }
+
+    main {
+        padding: 0.5rem;
+    }
+
+    header {
+        padding: 0.4rem 0.75rem;
+    }
+
+    header h1 {
+        font-size: 1.1rem;
+    }
+
+    .card__rank {
+        font-size: 0.95rem;
+    }
+
+    .card__suit {
+        font-size: 0.85rem;
+    }
+
+    .card--played {
+        width: 38px;
+        height: 56px;
+    }
+
+    .card--played .card__rank {
+        font-size: 0.85rem;
+    }
+
+    .card--played .card__suit {
+        font-size: 0.75rem;
+    }
+
+    .trick-table {
+        padding: 0.75rem;
+        min-height: 200px;
+    }
+
+    .trick-row-middle {
+        gap: 0.75rem;
+    }
+
+    .trick-slot {
+        min-width: 50px;
+        min-height: 70px;
+    }
+
+    .trick-count {
+        font-size: 1.25rem;
+    }
+
+    /* Bid panel — tighter spacing */
+    #bid-panel {
+        padding: 0.75rem;
+    }
+
+    .auction-transcript {
+        max-height: 120px;
+    }
+
+    .auction-table {
+        font-size: 0.8rem;
+    }
+
+    /* Score bar — compact single-column */
+    .score-bar {
+        padding: 0.5rem 0.75rem;
+        font-size: 0.75rem;
+        gap: 0.25rem;
+    }
+
+    /* Hand result — tighter padding */
+    .hand-result {
+        padding: 1rem;
+    }
+
+    .result-banner .result-title {
+        font-size: 1.25rem;
+    }
+
+    .score-delta {
+        font-size: 1.4rem;
+    }
+
+    /* Match result — tighter */
+    .match-result {
+        padding: 1.5rem 1rem;
+    }
+
+    .match-result .result-title {
+        font-size: 1.3rem;
+    }
+
+    /* Setup forms — full width */
+    #nickname-form,
+    #model-select {
+        margin: 0.75rem;
+        padding: 1rem;
+        max-width: none;
+    }
+}
+
+/* --------------------------------------------------------------------------
+   13b. Responsive — iPhone SE / Small Phones (max-width: 375px)
+   -------------------------------------------------------------------------- */
+
+@media (max-width: 375px) {
+    :root {
+        --card-width: 38px;
+        --card-height: 57px;
+        --card-overlap: -5px;
+    }
+
+    main {
+        padding: 0.25rem;
+    }
+
+    header h1 {
+        font-size: 1rem;
+    }
+
+    .card__rank {
+        font-size: 0.85rem;
+    }
+
+    .card__suit {
+        font-size: 0.75rem;
+    }
+
+    .card--played {
+        width: 34px;
+        height: 50px;
+    }
+
+    .card--played .card__rank {
+        font-size: 0.8rem;
+    }
+
+    .card--played .card__suit {
+        font-size: 0.7rem;
+    }
+
+    /* Card backs — smaller for narrow screens */
+    .card-back {
+        width: 28px;
+        height: 40px;
+        margin: 0 -3px;
+    }
+
+    .ai-card-count {
+        font-size: 0.7rem;
+    }
+
+    .trick-table {
+        padding: 0.5rem;
+        min-height: 160px;
+        border-radius: 8px;
+    }
+
+    .trick-row-middle {
+        gap: 0.5rem;
+    }
+
+    .trick-slot {
+        min-width: 44px;
+        min-height: 60px;
+    }
+
+    .card-slot {
+        width: var(--card-width);
+        height: var(--card-height);
+    }
+
+    .seat-label {
+        font-size: 0.65rem;
+    }
+
+    .trick-count {
+        font-size: 1.1rem;
+    }
+
+    /* Bid controls — stack fully */
+    .bid-controls label {
+        font-size: 0.8rem;
+    }
+
+    .bid-controls select {
+        font-size: 0.85rem;
+    }
+
+    .bid-controls button {
+        font-size: 0.85rem;
+    }
+
+    .auction-table th,
+    .auction-table td {
+        padding: 0.2rem 0.35rem;
+        font-size: 0.75rem;
+    }
+
+    /* Score bar — ultra-compact */
+    .score-bar {
+        padding: 0.4rem 0.5rem;
+        font-size: 0.7rem;
+    }
+
+    .score-value {
+        font-size: 0.9rem;
+    }
+
+    .match-target {
+        font-size: 0.7rem;
+    }
+
+    /* Result screens — compact */
+    .hand-result {
+        padding: 0.75rem;
+    }
+
+    .result-banner .result-title {
+        font-size: 1.1rem;
+    }
+
+    .score-delta {
+        font-size: 1.2rem;
+    }
+
+    .result-table {
+        font-size: 0.85rem;
+    }
+
+    .result-detail {
+        font-size: 0.85rem;
+    }
+
+    .match-result {
+        padding: 1rem;
+    }
+
+    .match-result .result-title {
+        font-size: 1.1rem;
+    }
+
+    .score-table {
+        font-size: 0.95rem;
+    }
+
+    /* Invite code input — narrower */
+    #invite-code-input {
+        font-size: 1.1rem;
+        width: 12rem;
+        letter-spacing: 0.1em;
     }
 }
 

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -2,18 +2,20 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>{% block title %}Bid Euchre{% endblock %}</title>
     <link rel="stylesheet" href="/static/style.css">
+    <link rel="stylesheet" href="/static/css/accessibility.css">
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     <script src="/static/game.js" defer></script>
     {% block head %}{% endblock %}
 </head>
 <body>
-    <header>
-        <h1><a href="/">Bid Euchre</a></h1>
+    <a href="#main-content" class="skip-link">Skip to game</a>
+    <header role="banner">
+        <h1><a href="/" aria-label="Bid Euchre home">Bid Euchre</a></h1>
     </header>
-    <main>
+    <main id="main-content" role="main">
         {% block content %}{% endblock %}
     </main>
 </body>

--- a/web/templates/game.html
+++ b/web/templates/game.html
@@ -26,7 +26,7 @@
     primary HTMX swap target for all game-action responses.
 #}
 
-<div id="game-board">
+<div id="game-board" role="region" aria-label="Game board" aria-live="polite">
 
     {# ---- Setup phases: nickname & model selection ---- #}
     {% if phase == "nickname" %}
@@ -47,35 +47,36 @@
     {% elif phase in ("auction", "trick_play", "redeal") %}
 
         {# AI hands — face-down card backs with counts #}
-        <div style="display:flex; justify-content:space-between; align-items:flex-start; gap:0.5rem;">
+        <div class="ai-hands-row" style="display:flex; justify-content:space-between; align-items:flex-start; gap:0.5rem;"
+             role="region" aria-label="AI opponent hands">
             {# Left opponent (seat 1) #}
             <div style="text-align:center; flex:0 0 auto;">
-                <div class="ai-hand">
+                <div class="ai-hand" role="img" aria-label="AI Left has {{ opp_left_count | default(0) }} cards">
                     {% for _ in range(opp_left_count | default(0)) %}
-                    <div class="card-back"></div>
+                    <div class="card-back" aria-hidden="true"></div>
                     {% endfor %}
                 </div>
-                <span class="ai-card-count">AI Left ({{ opp_left_count | default(0) }})</span>
+                <span class="ai-card-count" aria-hidden="true">AI Left ({{ opp_left_count | default(0) }})</span>
             </div>
 
             {# Partner (seat 2) #}
             <div style="text-align:center; flex:1 1 auto;">
-                <div class="ai-hand">
+                <div class="ai-hand" role="img" aria-label="Partner has {{ partner_count | default(0) }} cards">
                     {% for _ in range(partner_count | default(0)) %}
-                    <div class="card-back"></div>
+                    <div class="card-back" aria-hidden="true"></div>
                     {% endfor %}
                 </div>
-                <span class="ai-card-count">Partner ({{ partner_count | default(0) }})</span>
+                <span class="ai-card-count" aria-hidden="true">Partner ({{ partner_count | default(0) }})</span>
             </div>
 
             {# Right opponent (seat 3) #}
             <div style="text-align:center; flex:0 0 auto;">
-                <div class="ai-hand">
+                <div class="ai-hand" role="img" aria-label="AI Right has {{ opp_right_count | default(0) }} cards">
                     {% for _ in range(opp_right_count | default(0)) %}
-                    <div class="card-back"></div>
+                    <div class="card-back" aria-hidden="true"></div>
                     {% endfor %}
                 </div>
-                <span class="ai-card-count">AI Right ({{ opp_right_count | default(0) }})</span>
+                <span class="ai-card-count" aria-hidden="true">AI Right ({{ opp_right_count | default(0) }})</span>
             </div>
         </div>
 

--- a/web/templates/landing.html
+++ b/web/templates/landing.html
@@ -3,7 +3,7 @@
 {% block title %}Bid Euchre — Play Online{% endblock %}
 
 {% block content %}
-<div style="text-align:center; padding:3rem 1rem;">
+<div style="text-align:center; padding:3rem 1rem;" role="region" aria-label="Welcome to Bid Euchre">
     <h2 style="font-size:2rem; margin-bottom:0.5rem;">Bid Euchre</h2>
     <p style="color:var(--color-text-muted, #bdbdbd); margin-bottom:2rem; font-size:1.1rem;">
         Double-deck, 10-to-Ace, with bowers. Play against AI opponents.

--- a/web/templates/partials/bid_panel.html
+++ b/web/templates/partials/bid_panel.html
@@ -12,17 +12,17 @@
 {% set seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"} %}
 {% set bid_type_labels = {"regular": "", "moon": " Moon", "loner": " Loner"} %}
 
-<div id="bid-panel">
-    <h3>Auction</h3>
+<div id="bid-panel" role="region" aria-label="Auction panel">
+    <h3 id="auction-heading">Auction</h3>
 
     {# Show auction transcript so far #}
     {% if auction %}
-    <div class="auction-transcript">
-        <table class="auction-table">
+    <div class="auction-transcript" aria-label="Bidding history" aria-live="polite">
+        <table class="auction-table" aria-describedby="auction-heading">
             <thead>
                 <tr>
-                    <th>Player</th>
-                    <th>Bid</th>
+                    <th scope="col">Player</th>
+                    <th scope="col">Bid</th>
                 </tr>
             </thead>
             <tbody>
@@ -35,10 +35,10 @@
                             Pass
                         {% else %}
                             {% if entry_bid_type == "moon" %}
-                                🌙 Moon
+                                <span aria-hidden="true">🌙</span> Moon
                                 <span class="bid-type-badge bid-type-badge--moon">Moon</span>
                             {% elif entry_bid_type == "loner" %}
-                                🃏 Loner
+                                <span aria-hidden="true">🃏</span> Loner
                                 <span class="bid-type-badge bid-type-badge--loner">Loner</span>
                             {% else %}
                                 {{ entry.n }}
@@ -64,27 +64,29 @@
           action="/play/{{ link_uuid }}/bid"
           hx-post="/play/{{ link_uuid }}/bid"
           hx-target="#game-board"
-          hx-swap="innerHTML">
+          hx-swap="innerHTML"
+          aria-label="Submit your bid">
         <input type="hidden" name="turn_number" value="{{ turn_number }}">
 
         <div class="bid-controls">
             {# Bid type selector #}
             <label for="bid-type">Type:</label>
             <select id="bid-type" name="bid_type"
+                    aria-label="Bid type"
                     onchange="updateBidControls(this.value)">
                 <option value="regular"
                     {% if bid_type|default("regular") not in ["regular"] %}disabled{% endif %}
                 >Regular</option>
                 <option value="moon"
                     {% if bid_type|default("regular") == "loner" %}disabled{% endif %}
-                >🌙 Moon (10)</option>
-                <option value="loner">🃏 Loner (10)</option>
+                >Moon (10)</option>
+                <option value="loner">Loner (10)</option>
             </select>
 
             {# Bid level — only for regular bids #}
             <span id="bid-level-wrapper">
                 <label for="bid-level">Bid:</label>
-                <select id="bid-level" name="bid_n">
+                <select id="bid-level" name="bid_n" aria-label="Bid level">
                     <option value="0">Pass</option>
                     {% for n in range(current_high_bid + 1, 11) %}
                     <option value="{{ n }}">{{ n }}</option>
@@ -93,7 +95,7 @@
             </span>
 
             <label for="bid-contract">Contract:</label>
-            <select id="bid-contract" name="bid_contract">
+            <select id="bid-contract" name="bid_contract" aria-label="Contract suit">
                 <option value="S">♠ Spades</option>
                 <option value="H">♥ Hearts</option>
                 <option value="D">♦ Diamonds</option>
@@ -102,19 +104,20 @@
                 <option value="LOW">Low (no trump)</option>
             </select>
 
-            <button type="submit">Submit Bid</button>
+            <button type="submit" aria-label="Submit bid">Submit Bid</button>
         </div>
 
         {# Pass button — always visible as a quick action #}
         <div class="bid-pass">
             <button type="button"
                     onclick="submitPass(this)"
-                    class="pass-btn">Pass</button>
+                    class="pass-btn"
+                    aria-label="Pass on this bid">Pass</button>
         </div>
     </form>
 
     {% if current_high_bid > 0 %}
-    <p class="bid-info">
+    <p class="bid-info" aria-live="polite">
         Current high bid: {{ current_high_bid }}
         {{ bid_type_labels.get(bid_type|default("regular"), "") }}
         {% if bid_type|default("regular") == "moon" %}

--- a/web/templates/partials/hand.html
+++ b/web/templates/partials/hand.html
@@ -7,17 +7,19 @@
      - phase: str — current hand phase ("auction", "trick_play", "complete", "redeal")
 #}
 {% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
+{% set suit_names = {"S": "Spades", "H": "Hearts", "D": "Diamonds", "C": "Clubs"} %}
 {% set suit_classes = {"S": "spades", "H": "hearts", "D": "diamonds", "C": "clubs"} %}
 
-<div id="human-hand" class="hand">
+<div id="human-hand" class="hand" role="region" aria-label="Your hand">
     <h3>Your Hand</h3>
-    <div class="card-fan">
+    <div class="card-fan" role="group" aria-label="Cards in your hand ({{ human_hand | length }})">
         {% for card in human_hand %}
             {% set suit = card[0] %}
             {% set rank = card[1] %}
             {% set idx = loop.index0 %}
             {% set suit_class = suit_classes.get(suit, "spades") %}
             {% set suit_sym = suit_symbols.get(suit, suit) %}
+            {% set suit_name = suit_names.get(suit, suit) %}
 
             {% if phase == "trick_play" and legal_plays is not none and idx in legal_plays %}
                 {# Legal card — clickable form button #}
@@ -31,17 +33,20 @@
                     <input type="hidden" name="card_index" value="{{ idx }}">
                     <button type="submit"
                             class="card card--{{ suit_class }} card--legal"
-                            title="{{ rank }}{{ suit_sym }} (click to play)">
-                        <span class="card__rank">{{ rank }}</span>
-                        <span class="card__suit">{{ suit_sym }}</span>
+                            title="{{ rank }}{{ suit_sym }} (click to play)"
+                            aria-label="Play {{ rank }} of {{ suit_name }}">
+                        <span class="card__rank" aria-hidden="true">{{ rank }}</span>
+                        <span class="card__suit" aria-hidden="true">{{ suit_sym }}</span>
                     </button>
                 </form>
             {% else %}
                 {# Illegal or non-play-phase card — plain div #}
                 <div class="card card--{{ suit_class }}{% if phase == 'trick_play' %} card--illegal{% endif %}"
-                     title="{{ rank }}{{ suit_sym }}">
-                    <span class="card__rank">{{ rank }}</span>
-                    <span class="card__suit">{{ suit_sym }}</span>
+                     title="{{ rank }}{{ suit_sym }}"
+                     role="img"
+                     aria-label="{{ rank }} of {{ suit_name }}{% if phase == 'trick_play' %} (cannot play){% endif %}">
+                    <span class="card__rank" aria-hidden="true">{{ rank }}</span>
+                    <span class="card__suit" aria-hidden="true">{{ suit_sym }}</span>
                 </div>
             {% endif %}
         {% endfor %}

--- a/web/templates/partials/hand_result.html
+++ b/web/templates/partials/hand_result.html
@@ -43,20 +43,21 @@
     {% set result_class = "result--set" %}
 {% endif %}
 
-<div id="hand-result" class="hand-result hand-result--animated {{ result_class }}">
+<div id="hand-result" class="hand-result hand-result--animated {{ result_class }}"
+     role="alert" aria-live="assertive">
     <div class="result-banner">
         {# --- Moon / Loner special banners --- #}
         {% if hand_bid_type == "moon" %}
             {% if made %}
-                <h2 class="result-title">🌙 Moon Made!</h2>
+                <h2 class="result-title"><span aria-hidden="true">🌙</span> Moon Made!</h2>
             {% else %}
-                <h2 class="result-title">🌙 Moon Set!</h2>
+                <h2 class="result-title"><span aria-hidden="true">🌙</span> Moon Set!</h2>
             {% endif %}
         {% elif hand_bid_type == "loner" %}
             {% if made %}
-                <h2 class="result-title">🃏 Loner Made!</h2>
+                <h2 class="result-title"><span aria-hidden="true">🃏</span> Loner Made!</h2>
             {% else %}
-                <h2 class="result-title">🃏 Loner Set!</h2>
+                <h2 class="result-title"><span aria-hidden="true">🃏</span> Loner Set!</h2>
             {% endif %}
         {# --- Regular bid banners --- #}
         {% elif made %}
@@ -68,7 +69,8 @@
         {# Score delta emphasis for moon/loner #}
         {% if hand_bid_type in ("moon", "loner") %}
             {% set human_delta = points_team0 %}
-            <div class="score-delta {% if human_delta > 0 %}score-delta--{{ hand_bid_type }}{% elif human_delta < 0 %}score-delta--negative{% endif %}">
+            <div class="score-delta {% if human_delta > 0 %}score-delta--{{ hand_bid_type }}{% elif human_delta < 0 %}score-delta--negative{% endif %}"
+                 aria-label="Score change: {{ human_delta }} points">
                 {{ "+" if human_delta > 0 }}{{ human_delta }}
                 {% if hand_bid_type == "moon" %}MOON{% else %}LONER{% endif %}
                 {% if made %}MADE{% else %}SET{% endif %}
@@ -99,7 +101,7 @@
         </p>
     </div>
 
-    <div class="result-scoring">
+    <div class="result-scoring" role="table" aria-label="Hand scoring summary">
         <table class="result-table">
             <tr>
                 <td>Your team:</td>

--- a/web/templates/partials/invite_code_form.html
+++ b/web/templates/partials/invite_code_form.html
@@ -2,14 +2,16 @@
    Context variables:
      - error (optional): str — error message to display
 #}
-<div id="invite-code-form" style="text-align:center; padding:2rem 1rem;">
+<div id="invite-code-form" style="text-align:center; padding:2rem 1rem;"
+     role="region" aria-label="Invite code entry">
     <h2 style="font-size:1.5rem; margin-bottom:0.5rem;">Enter Invite Code</h2>
     <p style="color:var(--color-text-muted, #bdbdbd); margin-bottom:1.5rem; font-size:0.95rem;">
         Enter your invite code to access the game.
     </p>
 
     {% if error %}
-    <div class="invite-error" style="color:#e53935; margin-bottom:1rem; font-size:0.9rem;">
+    <div class="invite-error" role="alert"
+         style="color:#e53935; margin-bottom:1rem; font-size:0.9rem;">
         {{ error }}
     </div>
     {% endif %}
@@ -18,8 +20,10 @@
           action="/enter-code"
           hx-post="/enter-code"
           hx-target="#invite-code-form"
-          hx-swap="outerHTML">
+          hx-swap="outerHTML"
+          aria-label="Enter invite code">
         <div style="display:flex; flex-direction:column; align-items:center; gap:0.75rem;">
+            <label for="invite-code-input" class="sr-only">Invite code</label>
             <input id="invite-code-input"
                    name="code"
                    type="text"
@@ -30,10 +34,13 @@
                    autocapitalize="characters"
                    spellcheck="false"
                    placeholder="e.g. A3X7KP9Q"
+                   aria-label="Invite code"
+                   aria-describedby="invite-code-hint"
                    style="text-transform:uppercase; text-align:center; font-size:1.3rem;
                           letter-spacing:0.15em; padding:0.6rem 1rem; width:14rem;
                           font-family:monospace;">
-            <button type="submit" class="btn btn--play-again">Enter Game</button>
+            <span id="invite-code-hint" class="sr-only">Enter the 8-character invite code you received</span>
+            <button type="submit" class="btn btn--play-again" aria-label="Submit invite code">Enter Game</button>
         </div>
     </form>
 </div>

--- a/web/templates/partials/match_result.html
+++ b/web/templates/partials/match_result.html
@@ -6,16 +6,17 @@
      - score_ai: int — final AI team score
      - hands_played: int — total hands played in the match
 #}
-<div id="match-result" class="match-result {% if winner == 'human' %}result--win{% else %}result--loss{% endif %}">
+<div id="match-result" class="match-result {% if winner == 'human' %}result--win{% else %}result--loss{% endif %}"
+     role="alert" aria-live="assertive">
     <div class="result-banner">
         {% if winner == "human" %}
-            <h1 class="result-title">You Win! 🎉</h1>
+            <h1 class="result-title">You Win! <span aria-hidden="true">🎉</span></h1>
         {% else %}
             <h1 class="result-title">You Lose</h1>
         {% endif %}
     </div>
 
-    <div class="final-score">
+    <div class="final-score" role="table" aria-label="Final match score">
         <table class="score-table">
             <tr>
                 <td>Your team:</td>
@@ -34,6 +35,6 @@
           hx-post="/play/{{ link_uuid }}/new-match"
           hx-target="#game-board"
           hx-swap="innerHTML">
-        <button type="submit" class="btn btn--play-again">Play Again</button>
+        <button type="submit" class="btn btn--play-again" aria-label="Start a new match">Play Again</button>
     </form>
 </div>

--- a/web/templates/partials/model_select.html
+++ b/web/templates/partials/model_select.html
@@ -4,19 +4,21 @@
      - nickname: str — player's (escaped) nickname
      - models: list[ModelInfo] — available AI models (each has .id, .name, .description)
 #}
-<div id="model-select">
+<div id="model-select" role="region" aria-label="Choose AI opponent">
     <h2>Welcome, {{ nickname }}!</h2>
     <p>Choose your AI opponent:</p>
     <form method="post"
           action="/play/{{ link_uuid }}/select-ai"
           hx-post="/play/{{ link_uuid }}/select-ai"
           hx-target="#game-board"
-          hx-swap="innerHTML">
-        <select name="model_id" required>
+          hx-swap="innerHTML"
+          aria-label="Select AI model and start match">
+        <label for="model-select-dropdown" class="sr-only">AI opponent</label>
+        <select id="model-select-dropdown" name="model_id" required aria-label="AI opponent model">
             {% for model in models %}
             <option value="{{ model.id }}">{{ model.name }} &mdash; {{ model.description }}</option>
             {% endfor %}
         </select>
-        <button type="submit">Start Match</button>
+        <button type="submit" aria-label="Start match with selected AI">Start Match</button>
     </form>
 </div>

--- a/web/templates/partials/nickname_form.html
+++ b/web/templates/partials/nickname_form.html
@@ -2,13 +2,14 @@
    Context variables:
      - link_uuid: str — player's game link UUID
 #}
-<div id="nickname-form">
+<div id="nickname-form" role="region" aria-label="Set your nickname">
     <h2>Enter your nickname</h2>
     <form method="post"
           action="/play/{{ link_uuid }}/nickname"
           hx-post="/play/{{ link_uuid }}/nickname"
           hx-target="#game-board"
-          hx-swap="innerHTML">
+          hx-swap="innerHTML"
+          aria-label="Choose a display name">
         <label for="nickname-input">Nickname:</label>
         <input id="nickname-input"
                name="nickname"
@@ -16,7 +17,8 @@
                maxlength="30"
                required
                autofocus
-               placeholder="Your name">
-        <button type="submit">Set Nickname</button>
+               placeholder="Your name"
+               aria-label="Your display nickname">
+        <button type="submit" aria-label="Set nickname and continue">Set Nickname</button>
     </form>
 </div>

--- a/web/templates/partials/score.html
+++ b/web/templates/partials/score.html
@@ -15,13 +15,13 @@
 {% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
 {% set seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"} %}
 
-<div id="score-bar" class="score-bar">
-    <div class="score-section">
+<div id="score-bar" class="score-bar" role="status" aria-label="Match score and hand information" aria-live="polite">
+    <div class="score-section" aria-label="Match score: You {{ score_human }}, AI {{ score_ai }}">
         <span class="score-label">You:</span>
         <span class="score-value{% if score_human >= 0 %} score--positive{% else %} score--negative{% endif %}">
             {{ score_human }}
         </span>
-        <span class="score-separator">|</span>
+        <span class="score-separator" aria-hidden="true">|</span>
         <span class="score-label">AI:</span>
         <span class="score-value{% if score_ai >= 0 %} score--positive{% else %} score--negative{% endif %}">
             {{ score_ai }}
@@ -30,7 +30,7 @@
 
     <div class="hand-info">
         <span>Hand {{ hands_played + 1 }}</span>
-        <span class="info-separator">&middot;</span>
+        <span class="info-separator" aria-hidden="true">&middot;</span>
         <span>Dealer: {{ seat_labels.get(dealer_seat, "Seat " ~ dealer_seat) }}</span>
     </div>
 
@@ -39,9 +39,9 @@
         {% set score_bid_type = bid_type | default("regular") %}
         <span>Contract:
             {% if score_bid_type == "moon" %}
-                <span class="contract-bid-type contract-bid-type--moon">🌙 Moon</span>
+                <span class="contract-bid-type contract-bid-type--moon"><span aria-hidden="true">🌙</span> Moon</span>
             {% elif score_bid_type == "loner" %}
-                <span class="contract-bid-type contract-bid-type--loner">🃏 Loner</span>
+                <span class="contract-bid-type contract-bid-type--loner"><span aria-hidden="true">🃏</span> Loner</span>
             {% else %}
                 {{ winning_bid }}
             {% endif %}
@@ -53,10 +53,10 @@
                 Low
             {% endif %}
         </span>
-        <span class="info-separator">&middot;</span>
+        <span class="info-separator" aria-hidden="true">&middot;</span>
         <span>Declarer: {{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}</span>
         {% if phase == "trick_play" %}
-        <span class="info-separator">&middot;</span>
+        <span class="info-separator" aria-hidden="true">&middot;</span>
         <span>Tricks: {{ tricks_team0 }}&ndash;{{ tricks_team1 }}</span>
         {% endif %}
     </div>
@@ -66,7 +66,7 @@
     </div>
     {% endif %}
 
-    <div class="match-target">
+    <div class="match-target" aria-label="First team to plus or minus 52 points wins">
         First to &plusmn;52 wins
     </div>
 </div>

--- a/web/templates/partials/trick.html
+++ b/web/templates/partials/trick.html
@@ -6,6 +6,7 @@
      - tricks_team1: int — tricks won by AI team (seats 1, 3)
 #}
 {% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
+{% set suit_names = {"S": "Spades", "H": "Hearts", "D": "Diamonds", "C": "Clubs"} %}
 {% set suit_classes = {"S": "spades", "H": "hearts", "D": "diamonds", "C": "clubs"} %}
 {% set seat_labels = {0: "You", 1: "AI Left", 2: "Partner", 3: "AI Right"} %}
 
@@ -18,20 +19,22 @@
     {% endfor %}
 {% endif %}
 
-<div id="trick-area" class="trick-area">
+<div id="trick-area" class="trick-area" role="region" aria-label="Current trick" aria-live="polite">
     <h3>Trick {{ (completed_tricks | length) + 1 }} of 10</h3>
-    <div class="trick-table">
+    <div class="trick-table" role="group" aria-label="Cards played this trick, score {{ tricks_team0 }} to {{ tricks_team1 }}">
         {# Top — seat 2 (partner) #}
         <div class="trick-slot trick-slot--top">
             {% if 2 in ns.cards %}
                 {% set card = ns.cards[2] %}
                 {% set suit = card[0] %}
-                <div class="card card--{{ suit_classes.get(suit, 'spades') }} card--played">
-                    <span class="card__rank">{{ card[1] }}</span>
-                    <span class="card__suit">{{ suit_symbols.get(suit, suit) }}</span>
+                <div class="card card--{{ suit_classes.get(suit, 'spades') }} card--played"
+                     role="img"
+                     aria-label="{{ seat_labels[2] }} played {{ card[1] }} of {{ suit_names.get(suit, suit) }}">
+                    <span class="card__rank" aria-hidden="true">{{ card[1] }}</span>
+                    <span class="card__suit" aria-hidden="true">{{ suit_symbols.get(suit, suit) }}</span>
                 </div>
             {% else %}
-                <div class="card-slot card-slot--empty">
+                <div class="card-slot card-slot--empty" aria-label="{{ seat_labels[2] }}, waiting to play">
                     <span class="seat-label">{{ seat_labels[2] }}</span>
                 </div>
             {% endif %}
@@ -43,31 +46,35 @@
                 {% if 1 in ns.cards %}
                     {% set card = ns.cards[1] %}
                     {% set suit = card[0] %}
-                    <div class="card card--{{ suit_classes.get(suit, 'spades') }} card--played">
-                        <span class="card__rank">{{ card[1] }}</span>
-                        <span class="card__suit">{{ suit_symbols.get(suit, suit) }}</span>
+                    <div class="card card--{{ suit_classes.get(suit, 'spades') }} card--played"
+                         role="img"
+                         aria-label="{{ seat_labels[1] }} played {{ card[1] }} of {{ suit_names.get(suit, suit) }}">
+                        <span class="card__rank" aria-hidden="true">{{ card[1] }}</span>
+                        <span class="card__suit" aria-hidden="true">{{ suit_symbols.get(suit, suit) }}</span>
                     </div>
                 {% else %}
-                    <div class="card-slot card-slot--empty">
+                    <div class="card-slot card-slot--empty" aria-label="{{ seat_labels[1] }}, waiting to play">
                         <span class="seat-label">{{ seat_labels[1] }}</span>
                     </div>
                 {% endif %}
             </div>
 
-            <div class="trick-center">
-                <span class="trick-count">{{ tricks_team0 }}&ndash;{{ tricks_team1 }}</span>
+            <div class="trick-center" aria-label="Tricks won: your team {{ tricks_team0 }}, AI team {{ tricks_team1 }}">
+                <span class="trick-count" aria-hidden="true">{{ tricks_team0 }}&ndash;{{ tricks_team1 }}</span>
             </div>
 
             <div class="trick-slot trick-slot--right">
                 {% if 3 in ns.cards %}
                     {% set card = ns.cards[3] %}
                     {% set suit = card[0] %}
-                    <div class="card card--{{ suit_classes.get(suit, 'spades') }} card--played">
-                        <span class="card__rank">{{ card[1] }}</span>
-                        <span class="card__suit">{{ suit_symbols.get(suit, suit) }}</span>
+                    <div class="card card--{{ suit_classes.get(suit, 'spades') }} card--played"
+                         role="img"
+                         aria-label="{{ seat_labels[3] }} played {{ card[1] }} of {{ suit_names.get(suit, suit) }}">
+                        <span class="card__rank" aria-hidden="true">{{ card[1] }}</span>
+                        <span class="card__suit" aria-hidden="true">{{ suit_symbols.get(suit, suit) }}</span>
                     </div>
                 {% else %}
-                    <div class="card-slot card-slot--empty">
+                    <div class="card-slot card-slot--empty" aria-label="{{ seat_labels[3] }}, waiting to play">
                         <span class="seat-label">{{ seat_labels[3] }}</span>
                     </div>
                 {% endif %}
@@ -79,12 +86,14 @@
             {% if 0 in ns.cards %}
                 {% set card = ns.cards[0] %}
                 {% set suit = card[0] %}
-                <div class="card card--{{ suit_classes.get(suit, 'spades') }} card--played">
-                    <span class="card__rank">{{ card[1] }}</span>
-                    <span class="card__suit">{{ suit_symbols.get(suit, suit) }}</span>
+                <div class="card card--{{ suit_classes.get(suit, 'spades') }} card--played"
+                     role="img"
+                     aria-label="{{ seat_labels[0] }} played {{ card[1] }} of {{ suit_names.get(suit, suit) }}">
+                    <span class="card__rank" aria-hidden="true">{{ card[1] }}</span>
+                    <span class="card__suit" aria-hidden="true">{{ suit_symbols.get(suit, suit) }}</span>
                 </div>
             {% else %}
-                <div class="card-slot card-slot--empty">
+                <div class="card-slot card-slot--empty" aria-label="{{ seat_labels[0] }}, waiting to play">
                     <span class="seat-label">{{ seat_labels[0] }}</span>
                 </div>
             {% endif %}


### PR DESCRIPTION
## Summary

- Add responsive CSS breakpoints for iPhone SE (375px) and iPhone Plus/Pro (414px) viewports with progressively scaled card sizes, trick area, and layout spacing
- Add ARIA labels on all interactive elements: cards, bid controls, trick area, score bar, result screens, and setup forms
- Add touch-friendly 44px minimum tap targets (WCAG 2.5.5) via `@media (pointer: coarse)`
- Add keyboard-only focus rings via `:focus-visible`, skip navigation link, and `forced-colors` support
- Extend `prefers-reduced-motion` coverage to suppress card hover transforms and button transitions
- Add 26 new accessibility test assertions covering ARIA attributes, roles, and landmark structure

## Why

Browser Expansion PR-5 — Phase 2 product experience. Makes the browser game playable and accessible on mobile Safari/Chrome (iPhone SE through Pro Max) and for assistive technology users. Required for pilot readiness per the governing plan's validation contract.

## Files Changed

**New:**
- `web/static/css/accessibility.css` — Focus management, touch targets, reduced motion, skip-nav, high contrast

**Modified:**
- `web/static/style.css` — Added 414px and 375px responsive breakpoints (sections 13a, 13b)
- `web/templates/base.html` — Added accessibility.css link, skip-nav, `viewport-fit=cover`, ARIA landmarks
- `web/templates/game.html` — ARIA `role="region"` on game board and AI hands area
- `web/templates/landing.html` — ARIA landmark on welcome section
- `web/templates/partials/hand.html` — `aria-label` on card buttons (suit names), `role="group"` on card fan
- `web/templates/partials/bid_panel.html` — ARIA labels on bid controls, live region on auction transcript
- `web/templates/partials/trick.html` — ARIA labels on played cards and empty slots, `role="region"`
- `web/templates/partials/score.html` — `role="status"`, `aria-live="polite"` on score bar
- `web/templates/partials/hand_result.html` — `role="alert"` for hand result announcements
- `web/templates/partials/match_result.html` — `role="alert"`, `aria-label` on Play Again
- `web/templates/partials/invite_code_form.html` — `sr-only` label, `role="alert"` on errors, `aria-describedby`
- `web/templates/partials/nickname_form.html` — `role="region"`, ARIA labels
- `web/templates/partials/model_select.html` — `role="region"`, `sr-only` label, ARIA labels
- `tests/unit/hosted_play/test_partials.py` — 26 new accessibility test assertions

## Repro / Validation

```bash
# Tier 1 — targeted (68 tests, all pass)
uv run python -m pytest tests/unit/hosted_play/test_partials.py -v

# Route integration (50 tests, all pass)
uv run python -m pytest tests/unit/hosted_play/test_routes.py -v

# Tier 2 — full validation (7603 pass, 1 unrelated flaky)
make check-quiet
```

## Tests

- `uv run python -m pytest tests/unit/hosted_play/test_partials.py` — 68 passed (42 existing + 26 new accessibility)
- `uv run python -m pytest tests/unit/hosted_play/test_routes.py` — 50 passed
- `make check-quiet` — 7603 passed, 1 unrelated flaky (hook dispatcher test affected by stale review loop daemon)

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
branch: browser/expansion-mobile-accessibility
worktree: Bid-Euchre-steward-brws-author-a (persistent browser lane)
```

## Governing Plan Reference

- **Initiative:** Browser Game Expansion (`plans/browser_game_expansion/governing_plan.md`)
- **Phase:** 2 — Product Experience
- **PR sequence:** PR-5 (Mobile, accessibility, and telemetry)
- **Depends on:** PR #1809 (PR-4: Moon/loner UI and pacing) ✅ merged