### PR TITLE
feat(web): add pilot launch hardening (Browser Expansion PR-8)

### DIFF
--- a/tests/unit/hosted_play/test_hardening.py
+++ b/tests/unit/hosted_play/test_hardening.py
@@ -1,0 +1,452 @@
+"""Tests for B8 pilot launch hardening features.
+
+Covers:
+1. Rate limiting on match creation (max 5 active per player)
+2. Custom error pages (404, 500)
+3. Session cleanup (expire stale matches)
+4. Enhanced /health endpoint (metrics)
+5. Startup self-test (DB, static, templates)
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from starlette.testclient import TestClient
+
+from web.app import _run_self_test, create_app
+from web.cleanup import DEFAULT_MAX_MATCH_AGE, expire_stale_matches
+from web.config import HostedPlayConfig
+from web.db import (
+    Match,
+    Player,
+    create_tables,
+    init_engine,
+    make_session_factory,
+)
+from web.middleware import MAX_ACTIVE_MATCHES_PER_PLAYER, check_match_limit
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def config(tmp_path):
+    """File-based SQLite config for test isolation."""
+    db_path = tmp_path / "test.db"
+    return HostedPlayConfig(database_url=f"sqlite:///{db_path}")
+
+
+@pytest.fixture()
+def app(config):
+    """FastAPI app configured with temp DB."""
+    return create_app(config=config)
+
+
+@pytest.fixture()
+def client(app):
+    """TestClient wrapping the test app."""
+    with TestClient(app) as c:
+        yield c
+
+
+def _create_player(session, nickname="TestPlayer") -> Player:
+    """Insert a Player row."""
+    player = Player(link_uuid=str(uuid.uuid4()), nickname=nickname)
+    session.add(player)
+    session.flush()
+    return player
+
+
+def _create_match(session, player_id: int, status: str = "active", **kw) -> Match:
+    """Insert a Match row with sensible defaults."""
+    match = Match(
+        match_uuid=str(uuid.uuid4()),
+        player_id=player_id,
+        ai_model="heuristic",
+        status=status,
+        seed=42,
+        match_state_json="{}",
+        **kw,
+    )
+    session.add(match)
+    session.flush()
+    return match
+
+
+# ===================================================================
+# 1. Rate Limiting — check_match_limit
+# ===================================================================
+
+
+class TestMatchRateLimit:
+    """Rate limiting: max 5 active matches per player."""
+
+    def test_under_limit_returns_true(self, app, client):
+        """Player with fewer than MAX active matches is allowed."""
+        session = app.state.session_factory()
+        try:
+            player = _create_player(session)
+            for _ in range(MAX_ACTIVE_MATCHES_PER_PLAYER - 1):
+                _create_match(session, player.id)
+            session.commit()
+            assert check_match_limit(session, player.id) is True
+        finally:
+            session.close()
+
+    def test_at_limit_returns_false(self, app, client):
+        """Player with MAX active matches is rejected."""
+        session = app.state.session_factory()
+        try:
+            player = _create_player(session)
+            for _ in range(MAX_ACTIVE_MATCHES_PER_PLAYER):
+                _create_match(session, player.id)
+            session.commit()
+            assert check_match_limit(session, player.id) is False
+        finally:
+            session.close()
+
+    def test_completed_matches_not_counted(self, app, client):
+        """Completed matches don't count toward the limit."""
+        session = app.state.session_factory()
+        try:
+            player = _create_player(session)
+            for _ in range(MAX_ACTIVE_MATCHES_PER_PLAYER):
+                _create_match(session, player.id, status="complete")
+            session.commit()
+            assert check_match_limit(session, player.id) is True
+        finally:
+            session.close()
+
+    def test_route_returns_429_when_limit_reached(self, client, app):
+        """POST /play/{uuid}/select-ai returns 429 when limit exceeded."""
+        session = app.state.session_factory()
+        try:
+            player = _create_player(session)
+            for _ in range(MAX_ACTIVE_MATCHES_PER_PLAYER):
+                _create_match(session, player.id)
+            session.commit()
+            link_uuid = player.link_uuid
+        finally:
+            session.close()
+
+        resp = client.post(
+            f"/play/{link_uuid}/select-ai",
+            data={"model_id": "heuristic"},
+        )
+        assert resp.status_code == 429
+        assert "limit" in resp.text.lower() or "Match limit" in resp.text
+
+
+# ===================================================================
+# 2. Custom Error Pages
+# ===================================================================
+
+
+class TestCustomErrorPages:
+    """Custom 404 and 500 error pages with game theming."""
+
+    def test_404_returns_themed_html(self, client):
+        """Non-existent route returns a themed 404 page."""
+        resp = client.get("/nonexistent-page-that-does-not-exist")
+        assert resp.status_code == 404
+        assert "Hand Not Found" in resp.text
+        assert "Back to Table" in resp.text
+
+    def test_404_game_link_not_found(self, client):
+        """Invalid game link returns 404."""
+        resp = client.get(f"/play/{uuid.uuid4()}")
+        assert resp.status_code == 404
+
+    def test_error_pages_extend_base_template(self, client):
+        """Error pages inherit from base.html (have DOCTYPE, CSS link)."""
+        resp = client.get("/nonexistent-page-that-does-not-exist")
+        assert "<!DOCTYPE html>" in resp.text
+        assert "style.css" in resp.text
+
+
+# ===================================================================
+# 3. Session Cleanup
+# ===================================================================
+
+
+class TestSessionCleanup:
+    """expire_stale_matches marks old active matches as abandoned."""
+
+    def test_expire_old_matches(self, app, client):
+        """Matches older than max_age are marked abandoned."""
+        session = app.state.session_factory()
+        try:
+            player = _create_player(session)
+            old_time = datetime.now(timezone.utc) - timedelta(hours=25)
+            match = _create_match(session, player.id)
+            match.created_at = old_time
+            session.commit()
+
+            count = expire_stale_matches(session)
+            session.commit()
+
+            assert count == 1
+            session.refresh(match)
+            assert match.status == "abandoned"
+            assert match.completed_at is not None
+        finally:
+            session.close()
+
+    def test_recent_matches_not_expired(self, app, client):
+        """Matches younger than max_age are untouched."""
+        session = app.state.session_factory()
+        try:
+            player = _create_player(session)
+            _create_match(session, player.id)
+            session.commit()
+
+            count = expire_stale_matches(session)
+            session.commit()
+
+            assert count == 0
+        finally:
+            session.close()
+
+    def test_completed_matches_not_expired(self, app, client):
+        """Already-completed matches are not re-expired."""
+        session = app.state.session_factory()
+        try:
+            player = _create_player(session)
+            old_time = datetime.now(timezone.utc) - timedelta(hours=25)
+            match = _create_match(session, player.id, status="complete")
+            match.created_at = old_time
+            session.commit()
+
+            count = expire_stale_matches(session)
+            session.commit()
+
+            assert count == 0
+            session.refresh(match)
+            assert match.status == "complete"
+        finally:
+            session.close()
+
+    def test_custom_max_age(self, app, client):
+        """Custom max_age is respected."""
+        session = app.state.session_factory()
+        try:
+            player = _create_player(session)
+            match = _create_match(session, player.id)
+            match.created_at = datetime.now(timezone.utc) - timedelta(hours=2)
+            session.commit()
+
+            # 1-hour max_age should catch this
+            count = expire_stale_matches(session, max_age=timedelta(hours=1))
+            session.commit()
+
+            assert count == 1
+            session.refresh(match)
+            assert match.status == "abandoned"
+        finally:
+            session.close()
+
+    def test_default_max_age_is_24h(self):
+        """Default threshold is 24 hours."""
+        assert DEFAULT_MAX_MATCH_AGE == timedelta(hours=24)
+
+
+# ===================================================================
+# 4. Enhanced Health Endpoint
+# ===================================================================
+
+
+class TestEnhancedHealth:
+    """Enhanced /health endpoint reports operational metrics."""
+
+    def test_health_returns_200(self, client):
+        """Health endpoint always returns 200."""
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+    def test_health_includes_status_ok(self, client):
+        """Response includes top-level status field."""
+        data = client.get("/health").json()
+        assert data["status"] == "ok"
+
+    def test_health_includes_active_matches(self, client):
+        """Response includes active_matches count."""
+        data = client.get("/health").json()
+        assert "active_matches" in data
+        assert data["active_matches"] == 0
+
+    def test_health_includes_total_players(self, client):
+        """Response includes total_players count."""
+        data = client.get("/health").json()
+        assert "total_players" in data
+        assert data["total_players"] == 0
+
+    def test_health_includes_db_size(self, client):
+        """Response includes db_size_bytes."""
+        data = client.get("/health").json()
+        assert "db_size_bytes" in data
+        # SQLite file should have a positive size
+        assert data["db_size_bytes"] > 0
+
+    def test_health_includes_uptime(self, client):
+        """Response includes uptime_seconds."""
+        data = client.get("/health").json()
+        assert "uptime_seconds" in data
+        assert data["uptime_seconds"] >= 0
+
+    def test_health_counts_matches_correctly(self, app, client):
+        """active_matches reflects actual DB state."""
+        session = app.state.session_factory()
+        try:
+            player = _create_player(session)
+            _create_match(session, player.id, status="active")
+            _create_match(session, player.id, status="active")
+            _create_match(session, player.id, status="complete")
+            session.commit()
+        finally:
+            session.close()
+
+        data = client.get("/health").json()
+        assert data["active_matches"] == 2
+        assert data["total_players"] == 1
+
+
+# ===================================================================
+# 5. Startup Self-Test
+# ===================================================================
+
+
+class TestStartupSelfTest:
+    """Startup self-test verifies DB, static assets, and templates."""
+
+    def test_self_test_passes_normal(self, tmp_path):
+        """Self-test passes with a properly set up environment."""
+        # Set up a real engine with tables
+        db_path = tmp_path / "test.db"
+        engine = init_engine(f"sqlite:///{db_path}")
+        create_tables(engine)
+
+        from pathlib import Path
+
+        web_dir = Path(__file__).resolve().parent.parent.parent.parent / "web"
+        templates_dir = web_dir / "templates"
+        static_dir = web_dir / "static"
+
+        # Should not raise
+        _run_self_test(engine, templates_dir, static_dir)
+        engine.dispose()
+
+    def test_self_test_fails_missing_tables(self, tmp_path):
+        """Self-test fails when DB tables are missing."""
+        db_path = tmp_path / "empty.db"
+        engine = init_engine(f"sqlite:///{db_path}")
+        # Don't create tables!
+
+        from pathlib import Path
+
+        web_dir = Path(__file__).resolve().parent.parent.parent.parent / "web"
+        templates_dir = web_dir / "templates"
+        static_dir = web_dir / "static"
+
+        with pytest.raises(RuntimeError, match="Missing DB tables"):
+            _run_self_test(engine, templates_dir, static_dir)
+        engine.dispose()
+
+    def test_self_test_fails_missing_static(self, tmp_path):
+        """Self-test fails when static directory is missing."""
+        db_path = tmp_path / "test.db"
+        engine = init_engine(f"sqlite:///{db_path}")
+        create_tables(engine)
+
+        from pathlib import Path
+
+        web_dir = Path(__file__).resolve().parent.parent.parent.parent / "web"
+        templates_dir = web_dir / "templates"
+        fake_static = tmp_path / "no_such_dir"
+
+        with pytest.raises(RuntimeError, match="Static assets directory missing"):
+            _run_self_test(engine, templates_dir, fake_static)
+        engine.dispose()
+
+    def test_self_test_fails_missing_templates(self, tmp_path):
+        """Self-test fails when templates directory is missing."""
+        db_path = tmp_path / "test.db"
+        engine = init_engine(f"sqlite:///{db_path}")
+        create_tables(engine)
+
+        from pathlib import Path
+
+        web_dir = Path(__file__).resolve().parent.parent.parent.parent / "web"
+        static_dir = web_dir / "static"
+        fake_templates = tmp_path / "no_such_dir"
+
+        with pytest.raises(RuntimeError, match="Templates directory missing"):
+            _run_self_test(engine, templates_dir=fake_templates, static_dir=static_dir)
+        engine.dispose()
+
+    def test_self_test_fails_missing_style_css(self, tmp_path):
+        """Self-test fails when style.css is missing from static dir."""
+        db_path = tmp_path / "test.db"
+        engine = init_engine(f"sqlite:///{db_path}")
+        create_tables(engine)
+
+        from pathlib import Path
+
+        web_dir = Path(__file__).resolve().parent.parent.parent.parent / "web"
+        templates_dir = web_dir / "templates"
+
+        # Create static dir without style.css
+        empty_static = tmp_path / "static"
+        empty_static.mkdir()
+
+        with pytest.raises(RuntimeError, match="style.css not found"):
+            _run_self_test(engine, templates_dir, empty_static)
+        engine.dispose()
+
+    def test_app_lifespan_runs_self_test(self, client):
+        """The full app starts without self-test failure."""
+        # If we get a valid response, the self-test passed during startup
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+
+# ===================================================================
+# 6. Integration — Cleanup runs on startup
+# ===================================================================
+
+
+class TestStartupCleanup:
+    """Verify cleanup runs during app startup."""
+
+    def test_stale_matches_cleaned_on_startup(self, tmp_path):
+        """Stale matches are cleaned up when the app starts."""
+        db_path = tmp_path / "test.db"
+        db_url = f"sqlite:///{db_path}"
+
+        # Pre-populate DB with a stale match
+        engine = init_engine(db_url)
+        create_tables(engine)
+        sf = make_session_factory(engine)
+        session = sf()
+        player = _create_player(session)
+        stale_match = _create_match(session, player.id)
+        stale_match.created_at = datetime.now(timezone.utc) - timedelta(hours=25)
+        session.commit()
+        match_id = stale_match.id
+        session.close()
+        engine.dispose()
+
+        # Now start the app — cleanup should fire
+        config = HostedPlayConfig(database_url=db_url)
+        app = create_app(config=config)
+        with TestClient(app) as _client:
+            # Verify the match was marked abandoned
+            session = app.state.session_factory()
+            try:
+                match = session.query(Match).get(match_id)
+                assert match.status == "abandoned"
+            finally:
+                session.close()

--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -1513,7 +1513,12 @@ class TestHealthEndpoint:
         resp = client.get("/health")
         assert resp.status_code == 200
         body = resp.json()
-        assert body == {"status": "ok"}
+        assert body["status"] == "ok"
+        # Enhanced health includes metrics (B8 hardening)
+        assert "active_matches" in body
+        assert "total_players" in body
+        assert "db_size_bytes" in body
+        assert "uptime_seconds" in body
 
     def test_health_content_type_json(self, client):
         resp = client.get("/health")

--- a/web/app.py
+++ b/web/app.py
@@ -11,21 +11,86 @@ Routes are defined in :mod:`web.routes` and registered via ``include_router``.
 
 from __future__ import annotations
 
+import logging
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.exceptions import HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
+from sqlalchemy import inspect as sa_inspect
 from starlette.templating import Jinja2Templates
 
 from .ai_manager import AIManager
+from .cleanup import expire_stale_matches
 from .config import HostedPlayConfig, get_config, override_config
-from .db import create_tables, init_engine, make_session_factory
+from .db import Base, create_tables, init_engine, make_session_factory
 from .routes import router as game_router
+
+logger = logging.getLogger(__name__)
 
 _WEB_DIR = Path(__file__).resolve().parent
 _TEMPLATES_DIR = _WEB_DIR / "templates"
+_STATIC_DIR = _WEB_DIR / "static"
+
+
+def _run_self_test(engine, templates_dir: Path, static_dir: Path) -> None:
+    """Verify critical resources are available at startup.
+
+    Checks:
+    1. Database tables exist (migrations applied).
+    2. Static assets directory exists and contains ``style.css``.
+    3. Template directory exists and key templates render without error.
+
+    Raises :class:`RuntimeError` if any check fails — the application
+    should not start in a broken state.
+    """
+    errors: list[str] = []
+
+    # 1. DB tables
+    try:
+        inspector = sa_inspect(engine)
+        existing_tables = set(inspector.get_table_names())
+        required_tables = {t.name for t in Base.metadata.sorted_tables}
+        missing = required_tables - existing_tables
+        if missing:
+            errors.append(f"Missing DB tables: {sorted(missing)}")
+    except Exception as exc:
+        errors.append(f"DB inspection failed: {exc}")
+
+    # 2. Static assets
+    if not static_dir.is_dir():
+        errors.append(f"Static assets directory missing: {static_dir}")
+    else:
+        if not (static_dir / "style.css").is_file():
+            errors.append("style.css not found in static directory")
+
+    # 3. Templates
+    if not templates_dir.is_dir():
+        errors.append(f"Templates directory missing: {templates_dir}")
+    else:
+        try:
+            test_templates = Jinja2Templates(directory=str(templates_dir))
+            # Verify key templates can be loaded (not full render — just load)
+            for name in (
+                "base.html",
+                "landing.html",
+                "errors/404.html",
+                "errors/500.html",
+            ):
+                test_templates.get_template(name)
+        except Exception as exc:
+            errors.append(f"Template load failed: {exc}")
+
+    if errors:
+        msg = "Startup self-test FAILED:\n" + "\n".join(f"  - {e}" for e in errors)
+        logger.error(msg)
+        raise RuntimeError(msg)
+
+    logger.info("Startup self-test passed")
 
 
 @asynccontextmanager
@@ -37,18 +102,36 @@ async def lifespan(app: FastAPI):
     engine = init_engine(config.database_url)
     create_tables(engine)
 
-    # 2. AI models
+    # 2. Cleanup stale matches from previous runs
+    session_factory = make_session_factory(engine)
+    cleanup_session = session_factory()
+    try:
+        expired = expire_stale_matches(cleanup_session)
+        cleanup_session.commit()
+        if expired:
+            logger.info("Startup cleanup: expired %d stale match(es)", expired)
+    except Exception:
+        cleanup_session.rollback()
+        logger.warning("Startup cleanup failed — continuing", exc_info=True)
+    finally:
+        cleanup_session.close()
+
+    # 3. Startup self-test — fail fast on broken deployment
+    _run_self_test(engine, _TEMPLATES_DIR, _STATIC_DIR)
+
+    # 4. AI models
     ai_manager = AIManager(config)
 
-    # 3. Templates
+    # 5. Templates
     templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
 
-    # 4. Stash on app.state for route access
+    # 6. Stash on app.state for route access
     app.state.config = config
     app.state.engine = engine
-    app.state.session_factory = make_session_factory(engine)
+    app.state.session_factory = session_factory
     app.state.ai_manager = ai_manager
     app.state.templates = templates
+    app.state.started_at = datetime.now(timezone.utc)
 
     yield
 
@@ -85,5 +168,30 @@ def create_app(config: HostedPlayConfig | None = None) -> FastAPI:
 
     # Register game routes
     app.include_router(game_router)
+
+    # ---- Custom error pages ----
+
+    _error_templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
+
+    @app.exception_handler(404)
+    async def not_found_handler(request: Request, exc: HTTPException) -> HTMLResponse:
+        """Render game-themed 404 page."""
+        return HTMLResponse(
+            _error_templates.get_template("errors/404.html").render(
+                {"request": request}
+            ),
+            status_code=404,
+        )
+
+    @app.exception_handler(500)
+    async def server_error_handler(request: Request, exc: Exception) -> HTMLResponse:
+        """Render game-themed 500 page."""
+        logger.exception("Unhandled server error on %s %s", request.method, request.url)
+        return HTMLResponse(
+            _error_templates.get_template("errors/500.html").render(
+                {"request": request}
+            ),
+            status_code=500,
+        )
 
     return app

--- a/web/cleanup.py
+++ b/web/cleanup.py
@@ -1,0 +1,59 @@
+"""Session cleanup utilities for the Bid Euchre browser game.
+
+Expires stale matches that have been active for longer than the configured
+timeout.  Designed to be called periodically (e.g. on startup, via a
+background task, or an admin endpoint).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from .db import Match
+
+logger = logging.getLogger(__name__)
+
+# Default threshold: matches active for more than 24 hours are abandoned.
+DEFAULT_MAX_MATCH_AGE = timedelta(hours=24)
+
+
+def expire_stale_matches(
+    session: Session,
+    *,
+    max_age: timedelta = DEFAULT_MAX_MATCH_AGE,
+) -> int:
+    """Mark active matches older than *max_age* as ``'abandoned'``.
+
+    Parameters
+    ----------
+    session:
+        An open SQLAlchemy session (caller is responsible for commit).
+    max_age:
+        Maximum age for active matches.  Matches whose ``created_at``
+        is older than ``now - max_age`` will be marked abandoned.
+
+    Returns
+    -------
+    int
+        Number of matches expired.
+    """
+    cutoff = datetime.now(timezone.utc) - max_age
+    stale = (
+        session.query(Match)
+        .filter(Match.status == "active", Match.created_at < cutoff)
+        .all()
+    )
+
+    now = datetime.now(timezone.utc)
+    for match in stale:
+        match.status = "abandoned"
+        match.completed_at = now
+
+    count = len(stale)
+    if count > 0:
+        logger.info("Expired %d stale match(es) older than %s", count, max_age)
+
+    return count

--- a/web/middleware.py
+++ b/web/middleware.py
@@ -1,0 +1,25 @@
+"""Middleware and guards for the Bid Euchre browser game.
+
+Rate-limiting and request-level guards that protect the hosted-play
+application from resource exhaustion during the pilot phase.
+"""
+
+from __future__ import annotations
+
+from web.db import Match
+
+# Maximum number of active matches a single player may have concurrently.
+MAX_ACTIVE_MATCHES_PER_PLAYER = 5
+
+
+def check_match_limit(session, player_id: int) -> bool:
+    """Return True if the player is within the active match limit.
+
+    Counts matches with ``status='active'`` for the given *player_id*.
+    Returns ``False`` (limit exceeded) when the count reaches or exceeds
+    :data:`MAX_ACTIVE_MATCHES_PER_PLAYER`.
+    """
+    active_count = (
+        session.query(Match).filter_by(player_id=player_id, status="active").count()
+    )
+    return active_count < MAX_ACTIVE_MATCHES_PER_PLAYER

--- a/web/routes.py
+++ b/web/routes.py
@@ -26,6 +26,7 @@ from bid_euchre.strategy.bidding import BidAction
 
 from .ai_manager import AIManager
 from .db import Decision, Hand, InviteCode, Match, Player
+from .middleware import check_match_limit
 
 router = APIRouter()
 
@@ -271,9 +272,51 @@ def _render_game_board(
 
 
 @router.get("/health")
-async def health():
-    """Liveness probe — always returns 200 OK."""
-    return JSONResponse({"status": "ok"})
+async def health(request: Request):
+    """Liveness probe with operational metrics.
+
+    Always returns 200 OK.  Includes ``active_matches``,
+    ``total_players``, ``db_size_bytes`` (SQLite only, -1 otherwise),
+    and ``uptime_seconds`` for operational observability.
+    """
+    info: dict[str, Any] = {"status": "ok"}
+
+    try:
+        session = _get_session(request)
+        try:
+            info["active_matches"] = (
+                session.query(Match).filter_by(status="active").count()
+            )
+            info["total_players"] = session.query(Player).count()
+
+            # DB file size — only meaningful for SQLite file-based databases
+            db_url = str(request.app.state.engine.url)
+            if db_url.startswith("sqlite:///") and ":memory:" not in db_url:
+                import os
+
+                db_path = db_url.replace("sqlite:///", "")
+                try:
+                    info["db_size_bytes"] = os.path.getsize(db_path)
+                except OSError:
+                    info["db_size_bytes"] = -1
+            else:
+                info["db_size_bytes"] = -1
+        finally:
+            session.close()
+    except Exception:
+        info["active_matches"] = -1
+        info["total_players"] = -1
+        info["db_size_bytes"] = -1
+
+    # Uptime
+    started_at = getattr(request.app.state, "started_at", None)
+    if started_at is not None:
+        delta = datetime.now(timezone.utc) - started_at
+        info["uptime_seconds"] = int(delta.total_seconds())
+    else:
+        info["uptime_seconds"] = -1
+
+    return JSONResponse(info)
 
 
 @router.get("/ready")
@@ -505,6 +548,13 @@ async def select_ai(
         player = session.query(Player).filter_by(link_uuid=link_uuid).first()
         if player is None:
             raise HTTPException(status_code=404, detail="Game not found")
+
+        # Rate limit — max active matches per player
+        if not check_match_limit(session, player_id=player.id):
+            raise HTTPException(
+                status_code=429,
+                detail="Match limit reached — complete or abandon an existing match first",
+            )
 
         ai_manager = _get_ai_manager(request)
         try:

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1248,7 +1248,65 @@ main {
 }
 
 /* --------------------------------------------------------------------------
-   18. Utilities
+   18. Error Pages
+   -------------------------------------------------------------------------- */
+
+.error-page {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 60vh;
+    padding: 2rem 1rem;
+}
+
+.error-card {
+    text-align: center;
+    background: var(--color-surface);
+    border-radius: 12px;
+    padding: 3rem 2rem;
+    max-width: 480px;
+    width: 100%;
+    border: 2px solid var(--color-felt);
+}
+
+.error-title {
+    font-size: 4rem;
+    font-weight: 800;
+    margin: 0 0 0.25rem;
+    color: var(--color-text-muted);
+    line-height: 1;
+}
+
+.error-subtitle {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 0 0 1rem;
+    color: var(--color-text);
+}
+
+.error-detail {
+    font-size: 1rem;
+    color: var(--color-text-muted);
+    margin: 0 0 2rem;
+    line-height: 1.5;
+}
+
+@media (max-width: 600px) {
+    .error-card {
+        padding: 2rem 1.25rem;
+    }
+
+    .error-title {
+        font-size: 3rem;
+    }
+
+    .error-subtitle {
+        font-size: 1.25rem;
+    }
+}
+
+/* --------------------------------------------------------------------------
+   19. Utilities
    -------------------------------------------------------------------------- */
 
 .sr-only {

--- a/web/templates/errors/404.html
+++ b/web/templates/errors/404.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block title %}404 — Hand Not Found{% endblock %}
+
+{% block content %}
+<div class="error-page" role="alert" aria-label="Page not found">
+    <div class="error-card">
+        <h2 class="error-title">404</h2>
+        <p class="error-subtitle">Hand Not Found</p>
+        <p class="error-detail">
+            That game link doesn't exist or has expired.
+            The cards may have been shuffled elsewhere.
+        </p>
+        <a href="/" class="btn btn--play-again">Back to Table</a>
+    </div>
+</div>
+{% endblock %}

--- a/web/templates/errors/500.html
+++ b/web/templates/errors/500.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block title %}500 — Bad Deal{% endblock %}
+
+{% block content %}
+<div class="error-page" role="alert" aria-label="Server error">
+    <div class="error-card">
+        <h2 class="error-title">500</h2>
+        <p class="error-subtitle">Bad Deal</p>
+        <p class="error-detail">
+            Something went wrong on our end.
+            The deck got stuck — please try again in a moment.
+        </p>
+        <a href="/" class="btn btn--play-again">Back to Table</a>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary

- **Rate limiting:** Max 5 active matches per player session; returns 429 when exceeded
- **Custom error pages:** Game-themed 404 ("Hand Not Found") and 500 ("Bad Deal") pages extending base template
- **Session cleanup:** `expire_stale_matches()` marks active matches >24h as abandoned; runs on startup
- **Enhanced /health:** Reports `active_matches`, `total_players`, `db_size_bytes`, `uptime_seconds`
- **Startup self-test:** Verifies DB tables exist, static assets present, templates load — fail-fast on broken deployments

## Why

Final pre-launch hardening for the browser game pilot. These five features protect against resource exhaustion, provide operational observability, and ensure the deployment environment is valid before serving traffic.

## Repro / Validation

```bash
# Run hardening tests
uv run python -m pytest tests/unit/hosted_play/test_hardening.py -v

# Run all hosted_play tests (387 pass)
uv run python -m pytest tests/unit/hosted_play/ -v

# Full validation
make check-quiet
```

## Tests

- `tests/unit/hosted_play/test_hardening.py` — 26 new tests covering all 5 features
- `tests/unit/hosted_play/test_routes.py` — updated health endpoint test for enhanced response

## Files Changed

| File | Change |
|------|--------|
| `web/middleware.py` | **New** — rate limiting guard (`check_match_limit`) |
| `web/cleanup.py` | **New** — session cleanup (`expire_stale_matches`) |
| `web/templates/errors/404.html` | **New** — themed 404 page |
| `web/templates/errors/500.html` | **New** — themed 500 page |
| `web/app.py` | Startup self-test, cleanup on startup, error handlers, uptime tracking |
| `web/routes.py` | Rate limit in select_ai, enhanced /health endpoint |
| `web/static/style.css` | Error page styling |
| `tests/unit/hosted_play/test_hardening.py` | **New** — 26 tests for all hardening features |
| `tests/unit/hosted_play/test_routes.py` | Updated health endpoint test |

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
branch: web/browser-expansion-pr8-pilot-hardening
```

## Depends On

Soft dependency on PR #1821 (B7 — Playwright smoke suite). No code overlap — B7 touches only `tests/browser/`, `Makefile`, `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)