### PR TITLE
fix(ops): convention follow-ups from review (#1784 #1790 #1791 #1792)

### DIFF
--- a/.claude/hooks/inbound-channel-audit.py
+++ b/.claude/hooks/inbound-channel-audit.py
@@ -23,8 +23,9 @@ import sys
 
 # --- Tag extraction ----------------------------------------------------------
 
-# Strip markdown code fences and inline code before scanning for channel tags.
-# This prevents pasted <channel> examples from being audited as real ingress.
+# Strip markdown code fences and neutralise inline code before scanning for
+# channel tags.  This prevents pasted <channel> examples from being audited
+# as real ingress while preserving backtick content inside real channel bodies.
 _CODE_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
 _INLINE_CODE_RE = re.compile(r"`[^`]+`")
 
@@ -39,14 +40,29 @@ _CHANNEL_RE = re.compile(
 )
 
 
-def _strip_code_blocks(text: str) -> str:
-    """Remove markdown code fences and inline code spans from *text*.
+def _neutralise_inline_code(m: re.Match[str]) -> str:
+    """Replace ``<channel`` inside an inline-code match with a safe token.
 
-    Returns the text with code blocks replaced by empty strings so that
-    ``<channel>`` tags pasted as examples inside code are not matched.
+    The backtick delimiters and the rest of the span are preserved so that
+    real channel bodies containing inline code (e.g. ``use `git status` ``)
+    are not damaged.
+    """
+    span = m.group(0)
+    if "<channel" in span:
+        return span.replace("<channel", "&lt;channel")
+    return span
+
+
+def _strip_code_blocks(text: str) -> str:
+    """Remove fenced code blocks and neutralise ``<channel`` inside inline code.
+
+    Fenced blocks (triple-backtick) are removed entirely.  Inline backtick
+    spans are *preserved* but any ``<channel`` inside them is replaced with
+    ``&lt;channel`` so the tag regex will not match pasted examples, while
+    the surrounding backtick content is kept intact for real channel bodies.
     """
     text = _CODE_FENCE_RE.sub("", text)
-    return _INLINE_CODE_RE.sub("", text)
+    return _INLINE_CODE_RE.sub(_neutralise_inline_code, text)
 
 
 def extract_channel_blocks(text: str) -> list[tuple[str, str]]:

--- a/.claude/hooks/urgent-state-guard.py
+++ b/.claude/hooks/urgent-state-guard.py
@@ -27,7 +27,7 @@ GUARDED_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"^\s*gh\s+pr\s+merge\b"),
     re.compile(r"uv\s+run\s+python\s+scripts/internal/ops\.py\s+task\s+dispatch\b"),
     re.compile(r"uv\s+run\s+python\s+scripts/internal/ops\.py\s+workers\s+dispatch\b"),
-    re.compile(r"dispatch_to_worker\s*\("),
+    re.compile(r"(?:uv\s+run\s+)?python[3]?\s.*dispatch_to_worker\s*\("),
 ]
 
 

--- a/.claude/skills/check-in/SKILL.md
+++ b/.claude/skills/check-in/SKILL.md
@@ -132,7 +132,8 @@ monitoring infrastructure.
 11. **Send rebase nudge** to lanes at HIGH divergence:
     ```bash
     uv run python scripts/internal/ops.py message send \
-      --from orchestrator --to <lane> --type supervisor_alert \
+      --from orchestrator --to <lane> --type escalation \
+      --priority high \
       --summary "Branch diverged 16+ commits from main — rebase before continuing"
     ```
 

--- a/.claude/skills/start-task/SKILL.md
+++ b/.claude/skills/start-task/SKILL.md
@@ -96,6 +96,7 @@ decomposition (use `/executing-plans` for that).
      git rebase --abort
      uv run python scripts/internal/ops.py message send \
        --from <lane> --to orchestrator --type blocker \
+       --priority high \
        --summary "Rebase conflict on <branch>: <description>" \
        --task-id <PACKET_ID>
      ```

--- a/src/bid_euchre/ops/remote_ack.py
+++ b/src/bid_euchre/ops/remote_ack.py
@@ -250,7 +250,7 @@ def format_ack_confirmation(result: AckResult) -> str:
         lines.append("")
         lines.append("Candidates:")
         for cid in result.candidates:
-            lines.append(f"  {cid[:8]}")
+            lines.append(f"  {cid}")
         return "\n".join(lines)
 
     return f"\u274c {result.message}"

--- a/tests/unit/test_inbound_channel_audit.py
+++ b/tests/unit/test_inbound_channel_audit.py
@@ -60,12 +60,20 @@ class TestStripCodeBlocks:
         assert "Some text" in result
         assert "More text" in result
 
-    def test_removes_inline_code(self, hook: ModuleType) -> None:
+    def test_neutralises_channel_in_inline_code(self, hook: ModuleType) -> None:
+        """Inline backticks are preserved but <channel inside them is neutralised."""
         text = 'Use `<channel source="telegram">` to send messages'
         result = hook._strip_code_blocks(text)
         assert "<channel" not in result
+        assert "&lt;channel" in result
         assert "Use" in result
         assert "to send messages" in result
+
+    def test_preserves_inline_code_without_channel(self, hook: ModuleType) -> None:
+        """Inline backtick content with no <channel is left untouched."""
+        text = "Run `git status` to check"
+        result = hook._strip_code_blocks(text)
+        assert result == text
 
     def test_preserves_non_code_text(self, hook: ModuleType) -> None:
         text = "No code blocks here, just plain text."


### PR DESCRIPTION
## Summary

- **#1784**: Use CLI-supported `escalation` type (not `supervisor_alert`) for rebase nudges in check-in skill; add `--priority high` to rebase-conflict blocker in start-task skill
- **#1790**: Return full candidate IDs (not truncated 8-char prefix) in ambiguous remote ack replies so operators can copy-paste to resolve
- **#1791**: Restrict `dispatch_to_worker(` guard pattern to actual `python` invocations, preventing false matches in grep/echo/comments
- **#1792**: Preserve inline backtick content in channel audit hook — neutralise `<channel` inside inline code spans instead of stripping the entire span, so real channel bodies with backtick-formatted text are not damaged

## Why

Convention follow-ups from autonomous review coordinator findings on PRs #1776, #1777, #1779, #1780.

## Repro / Validation

```bash
make check-quiet   # All checks pass
uv run python -m pytest tests/unit/test_inbound_channel_audit.py tests/unit/test_urgent_state_guard.py -v
```

## Tests

- `tests/unit/test_inbound_channel_audit.py` — 17 passed (updated test for new neutralise behavior, added test for preserved inline code)
- `tests/unit/test_urgent_state_guard.py` — 30 passed

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: fix/convention-batch-1784-1790-1791-1792
```

Closes #1784, closes #1790, closes #1791, closes #1792

🤖 Generated with [Claude Code](https://claude.com/claude-code)