### PR TITLE
fix(ops): extract git_commits from JSONL sessions in token economy scanner

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -2863,24 +2863,45 @@ def cmd_usage(args: argparse.Namespace) -> int:
     action = getattr(args, "usage_action", None)
 
     if action == "import":
-        from bid_euchre.ops.token_economy import import_usage_data
+        from bid_euchre.ops.token_economy import (
+            import_project_jsonl,
+            import_usage_data,
+        )
+
+        force = getattr(args, "force", False)
+        out_dir = getattr(args, "output_dir", None)
 
         result = import_usage_data(
             usage_dir=getattr(args, "usage_dir", None),
-            output_dir=getattr(args, "output_dir", None),
+            output_dir=out_dir,
         )
+
+        # Also import per-project JSONL telemetry (v2.1.80+ format)
+        jsonl_result = import_project_jsonl(output_dir=out_dir, force=force)
 
         if args.json:
             from dataclasses import asdict
 
-            print(json.dumps(asdict(result), indent=2, default=str))
+            combined = {
+                "session_meta": asdict(result),
+                "project_jsonl": asdict(jsonl_result),
+            }
+            print(json.dumps(combined, indent=2, default=str))
         else:
             print("Import complete:")
-            print(f"  Sessions imported: {result.sessions_imported}")
-            print(f"  Sessions skipped:  {result.sessions_skipped}")
-            print(f"  Sessions failed:   {result.sessions_failed}")
-            print(f"  Total sessions:    {result.total_sessions}")
-            print(f"  Output dir:        {result.output_dir}")
+            print(f"  Session-meta imported: {result.sessions_imported}")
+            print(f"  Session-meta skipped:  {result.sessions_skipped}")
+            print(f"  Session-meta failed:   {result.sessions_failed}")
+            print(f"  Session-meta total:    {result.total_sessions}")
+            print(f"  Project-JSONL imported: {jsonl_result.sessions_imported}")
+            print(f"  Project-JSONL skipped:  {jsonl_result.sessions_skipped}")
+            print(f"  Project-JSONL failed:   {jsonl_result.sessions_failed}")
+            print(f"  Project-JSONL scanned:  {jsonl_result.total_files_scanned}")
+            if force:
+                print(
+                    "  (force mode: project-jsonl records were purged and re-imported)"
+                )
+            print(f"  Output dir:            {result.output_dir}")
         return 0
 
     elif action == "attribute":
@@ -4082,6 +4103,11 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         default=None,
         help="Output directory (default: .claude/runtime/token_economy/)",
+    )
+    usage_import_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Purge existing project-jsonl records and re-import (backfills git_commits)",
     )
 
     usage_attr_parser = usage_sub.add_parser(

--- a/src/bid_euchre/ops/token_economy.py
+++ b/src/bid_euchre/ops/token_economy.py
@@ -342,6 +342,8 @@ class _JNLSessionAgg:
     last_timestamp: str = ""
     cwd: str = ""
     git_branch: str = ""
+    git_commits: int = 0
+    git_pushes: int = 0
 
 
 def _scan_jsonl_file(path: Path) -> _JNLSessionAgg | None:
@@ -404,7 +406,7 @@ def _scan_jsonl_file(path: Path) -> _JNLSessionAgg | None:
                 if msg_type == "user" and not obj.get("isMeta"):
                     agg.user_message_count += 1
 
-                # Extract token data from assistant messages
+                # Extract token data and tool usage from assistant messages
                 if msg_type == "assistant":
                     agg.assistant_message_count += 1
                     msg = obj.get("message")
@@ -420,6 +422,21 @@ def _scan_jsonl_file(path: Path) -> _JNLSessionAgg | None:
                             agg.cache_read_tokens += _safe_int(
                                 usage.get("cache_read_input_tokens")
                             )
+
+                        # Count git commits/pushes from Bash tool_use blocks
+                        content = msg.get("content")
+                        if isinstance(content, list):
+                            for block in content:
+                                if (
+                                    isinstance(block, dict)
+                                    and block.get("type") == "tool_use"
+                                    and block.get("name") == "Bash"
+                                ):
+                                    cmd = (block.get("input") or {}).get("command", "")
+                                    if "git commit" in cmd:
+                                        agg.git_commits += 1
+                                    if "git push" in cmd:
+                                        agg.git_pushes += 1
 
     except OSError as exc:
         logger.warning("Cannot read JSONL file %s: %s", path, exc)
@@ -480,6 +497,8 @@ def _build_record_from_jsonl(
         assistant_message_count=agg.assistant_message_count,
         input_tokens=agg.input_tokens,
         output_tokens=agg.output_tokens,
+        git_commits=agg.git_commits if agg.git_commits > 0 else None,
+        git_pushes=agg.git_pushes if agg.git_pushes > 0 else None,
     )
 
     # Store lane_id in project_path if we inferred it from slug but
@@ -488,6 +507,37 @@ def _build_record_from_jsonl(
         rec.project_path = f"<inferred-lane:{lane_id}>"
 
     return rec
+
+
+def _purge_jsonl_records(output_dir: Path) -> int:
+    """Remove all ``project-jsonl`` records from session_usage.jsonl.
+
+    Rewrites the file in-place, keeping only records whose ``source_type``
+    is NOT ``project-jsonl``.  Returns the number of records removed.
+    """
+    usage_file = output_dir / "session_usage.jsonl"
+    if not usage_file.exists():
+        return 0
+
+    kept: list[str] = []
+    removed = 0
+    for line in usage_file.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            rec = json.loads(stripped)
+        except json.JSONDecodeError:
+            kept.append(stripped)
+            continue
+        if rec.get("source_type") == "project-jsonl":
+            removed += 1
+        else:
+            kept.append(stripped)
+
+    usage_file.write_text("\n".join(kept) + ("\n" if kept else ""), encoding="utf-8")
+    logger.info("Purged %d project-jsonl records from store (force reimport)", removed)
+    return removed
 
 
 @dataclass
@@ -506,12 +556,14 @@ def import_project_jsonl(
     *,
     projects_dir: Path | None = None,
     output_dir: Path | None = None,
+    force: bool = False,
 ) -> ProjectImportResult:
     """Import per-project JSONL telemetry into the token economy store.
 
     Scans ``~/.claude/projects/<slug>/*.jsonl`` files produced by Claude
     v2.1.80+. Each JSONL file is streamed line-by-line to aggregate token
-    usage from assistant messages.
+    usage from assistant messages and count git commits/pushes from Bash
+    tool invocations.
 
     Parameters
     ----------
@@ -519,6 +571,10 @@ def import_project_jsonl(
         Path to ``~/.claude/projects/``. Defaults to :data:`DEFAULT_PROJECTS_DIR`.
     output_dir
         Path to the token economy output store. Defaults to repo runtime path.
+    force
+        When True, purge existing ``project-jsonl`` records from the store
+        before re-importing. Use after scanner improvements to backfill
+        fields (e.g., ``git_commits``) that earlier imports missed.
 
     Returns
     -------
@@ -543,6 +599,10 @@ def import_project_jsonl(
             directories_scanned=0,
             output_dir=str(resolved_output),
         )
+
+    # Force mode: purge existing project-jsonl records so they get re-scanned
+    if force:
+        _purge_jsonl_records(resolved_output)
 
     # Load existing session IDs for idempotent import
     existing_ids = _load_existing_ids(resolved_output)

--- a/tests/unit/test_token_economy.py
+++ b/tests/unit/test_token_economy.py
@@ -16,6 +16,7 @@ from bid_euchre.ops.token_economy import (
     _compute_duration_minutes,
     _infer_lane_from_slug,
     _JNLSessionAgg,
+    _purge_jsonl_records,
     _safe_int,
     _scan_jsonl_file,
     import_project_jsonl,
@@ -225,6 +226,40 @@ def _make_user_msg(
     return json.dumps(obj)
 
 
+def _make_assistant_msg_with_tool(
+    session_id: str,
+    tool_name: str,
+    command: str,
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+    timestamp: str = "2026-03-25T10:05:00.000Z",
+) -> str:
+    """Create a JSONL line for an assistant message containing a tool_use block."""
+    obj = {
+        "type": "assistant",
+        "sessionId": session_id,
+        "timestamp": timestamp,
+        "cwd": "/Users/test/Bid-Euchre-steward-author",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Running command..."},
+                {
+                    "type": "tool_use",
+                    "id": "tool-001",
+                    "name": tool_name,
+                    "input": {"command": command},
+                },
+            ],
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            },
+        },
+    }
+    return json.dumps(obj)
+
+
 def _make_system_msg(session_id: str) -> str:
     """Create a JSONL line for a system message."""
     obj = {
@@ -355,6 +390,104 @@ class TestScanJsonlFile:
         f = tmp_path / "does-not-exist.jsonl"
         assert _scan_jsonl_file(f) is None
 
+    def test_git_commits_counted(self, tmp_path: Path):
+        """Scanner counts git commit tool_use blocks."""
+        sid = "sess-gc-1"
+        lines = [
+            _make_assistant_msg(sid),
+            _make_assistant_msg_with_tool(
+                sid, "Bash", 'git commit -m "fix: something"'
+            ),
+            _make_assistant_msg_with_tool(sid, "Bash", 'git commit -m "feat: another"'),
+        ]
+        f = tmp_path / "sess-gc-1.jsonl"
+        f.write_text("\n".join(lines) + "\n")
+
+        agg = _scan_jsonl_file(f)
+        assert agg is not None
+        assert agg.git_commits == 2
+        assert agg.git_pushes == 0
+
+    def test_git_pushes_counted(self, tmp_path: Path):
+        """Scanner counts git push tool_use blocks."""
+        sid = "sess-gc-2"
+        lines = [
+            _make_assistant_msg(sid),
+            _make_assistant_msg_with_tool(
+                sid, "Bash", "git push -u origin fix/something"
+            ),
+        ]
+        f = tmp_path / "sess-gc-2.jsonl"
+        f.write_text("\n".join(lines) + "\n")
+
+        agg = _scan_jsonl_file(f)
+        assert agg is not None
+        assert agg.git_commits == 0
+        assert agg.git_pushes == 1
+
+    def test_git_commit_and_push_in_single_command(self, tmp_path: Path):
+        """A chained command with both git commit and git push counts both."""
+        sid = "sess-gc-3"
+        lines = [
+            _make_assistant_msg(sid),
+            _make_assistant_msg_with_tool(
+                sid,
+                "Bash",
+                'git commit -m "fix: thing" && git push -u origin branch',
+            ),
+        ]
+        f = tmp_path / "sess-gc-3.jsonl"
+        f.write_text("\n".join(lines) + "\n")
+
+        agg = _scan_jsonl_file(f)
+        assert agg is not None
+        assert agg.git_commits == 1
+        assert agg.git_pushes == 1
+
+    def test_non_bash_tool_not_counted(self, tmp_path: Path):
+        """Only Bash tool invocations are checked for git commands."""
+        sid = "sess-gc-4"
+        # A non-Bash tool with "git commit" in its input should not count
+        obj = {
+            "type": "assistant",
+            "sessionId": sid,
+            "timestamp": "2026-03-25T10:00:00Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tool-x",
+                        "name": "Edit",
+                        "input": {"command": "git commit -m 'edit'"},
+                    }
+                ],
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+            },
+        }
+        lines = [json.dumps(obj)]
+        f = tmp_path / "sess-gc-4.jsonl"
+        f.write_text("\n".join(lines) + "\n")
+
+        agg = _scan_jsonl_file(f)
+        assert agg is not None
+        assert agg.git_commits == 0
+
+    def test_zero_commits_when_no_tool_use(self, tmp_path: Path):
+        """Sessions without tool_use blocks have zero git_commits."""
+        sid = "sess-gc-5"
+        lines = [
+            _make_user_msg(sid),
+            _make_assistant_msg(sid),
+        ]
+        f = tmp_path / "sess-gc-5.jsonl"
+        f.write_text("\n".join(lines) + "\n")
+
+        agg = _scan_jsonl_file(f)
+        assert agg is not None
+        assert agg.git_commits == 0
+        assert agg.git_pushes == 0
+
 
 # ---------------------------------------------------------------------------
 # _build_record_from_jsonl
@@ -405,6 +538,89 @@ class TestBuildRecordFromJsonl:
             lane_id="author-b",
         )
         assert rec.project_path == "<inferred-lane:author-b>"
+
+    def test_git_commits_propagated(self, tmp_path: Path):
+        """Git commit counts from the scanner flow through to the record."""
+        agg = _JNLSessionAgg(
+            session_id="sess-102",
+            input_tokens=500,
+            output_tokens=200,
+            git_commits=3,
+            git_pushes=2,
+        )
+        rec = _build_record_from_jsonl(
+            agg,
+            source_path=tmp_path / "test.jsonl",
+            source_hash="ghi789",
+            now="2026-03-25T12:00:00Z",
+            lane_id="author-a",
+        )
+        assert rec.git_commits == 3
+        assert rec.git_pushes == 2
+
+    def test_zero_git_commits_stored_as_none(self, tmp_path: Path):
+        """Sessions with zero commits store git_commits as None (sparse)."""
+        agg = _JNLSessionAgg(
+            session_id="sess-103",
+            input_tokens=100,
+            output_tokens=50,
+            git_commits=0,
+            git_pushes=0,
+        )
+        rec = _build_record_from_jsonl(
+            agg,
+            source_path=tmp_path / "test.jsonl",
+            source_hash="jkl012",
+            now="2026-03-25T12:00:00Z",
+            lane_id=None,
+        )
+        assert rec.git_commits is None
+        assert rec.git_pushes is None
+
+
+# ---------------------------------------------------------------------------
+# _purge_jsonl_records
+# ---------------------------------------------------------------------------
+
+
+class TestPurgeJsonlRecords:
+    def test_purges_project_jsonl_keeps_session_meta(self, tmp_path: Path):
+        """Purge removes project-jsonl records but keeps session-meta."""
+        usage_file = tmp_path / "session_usage.jsonl"
+        records = [
+            json.dumps({"session_id": "s1", "source_type": "session-meta"}),
+            json.dumps({"session_id": "s2", "source_type": "project-jsonl"}),
+            json.dumps({"session_id": "s3", "source_type": "project-jsonl"}),
+            json.dumps({"session_id": "s4", "source_type": "session-meta"}),
+        ]
+        usage_file.write_text("\n".join(records) + "\n")
+
+        removed = _purge_jsonl_records(tmp_path)
+        assert removed == 2
+
+        remaining = [
+            json.loads(line) for line in usage_file.read_text().strip().splitlines()
+        ]
+        assert len(remaining) == 2
+        assert all(r["source_type"] == "session-meta" for r in remaining)
+
+    def test_purge_empty_store(self, tmp_path: Path):
+        """Purge on empty store returns 0."""
+        assert _purge_jsonl_records(tmp_path) == 0
+
+    def test_purge_no_jsonl_records(self, tmp_path: Path):
+        """Purge when all records are session-meta removes nothing."""
+        usage_file = tmp_path / "session_usage.jsonl"
+        records = [
+            json.dumps({"session_id": "s1", "source_type": "session-meta"}),
+        ]
+        usage_file.write_text("\n".join(records) + "\n")
+
+        removed = _purge_jsonl_records(tmp_path)
+        assert removed == 0
+
+        remaining = usage_file.read_text().strip().splitlines()
+        assert len(remaining) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fix JSONL project scanner to count `git commit`/`git push` from Bash tool_use blocks during import
- Add `--force` flag to `ops.py usage import` to purge and re-import project-jsonl records (backfills missing `git_commits`)
- Wire `import_project_jsonl` into the CLI import action (was previously only called during dashboard auto-import, not the manual CLI)

## Why

The dashboard Token Economy section showed stale commit data (244 commits) because the JSONL scanner (`_scan_jsonl_file`) never extracted git commit counts from tool_use blocks. All 1002 JSONL-imported sessions had `git_commits=None`, so only the 308 legacy session-meta sessions contributed to the total.

After this fix + force reimport: **244 → 1,685 commits** now reflected.

## Changes

| File | Change |
|------|--------|
| `src/bid_euchre/ops/token_economy.py` | Add `git_commits`/`git_pushes` to `_JNLSessionAgg`, count in scanner, propagate through `_build_record_from_jsonl`, add `_purge_jsonl_records()` and `force` param |
| `scripts/internal/ops.py` | Wire `import_project_jsonl` into CLI import action, add `--force` flag |
| `tests/unit/test_token_economy.py` | 8 new tests: scanner git counting, record propagation, purge logic |

## Repro / Validation

```bash
# Before fix: dashboard shows 244 commits
uv run python scripts/internal/ops.py dashboard --no-probe | grep "commits"

# Force reimport with fix applied
uv run python scripts/internal/ops.py usage import --force

# After fix: dashboard shows ~1685 commits
uv run python scripts/internal/ops.py dashboard --no-probe | grep "commits"
```

## Tests

```bash
uv run python -m pytest tests/unit/test_token_economy.py -v  # 59 passed (8 new)
make check-quiet  # All checks passed
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
branch: fix/token-economy-jsonl-git-commits
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)