### PR TITLE
docs(ops): document tmux paste bracketing pattern in dispatch skills (#1834)

### DIFF
--- a/.claude/skills/delegate-task/SKILL.md
+++ b/.claude/skills/delegate-task/SKILL.md
@@ -103,6 +103,26 @@ intake-to-dispatch flow into a reusable workflow.
    uv run python scripts/internal/ops.py task list
    ```
 
+## Tmux Paste Bracketing Caveat
+
+Modern terminals use **bracketed paste mode**. When `tmux send-keys` sends a
+multi-line string, tmux wraps it in `\e[200~...\e[201~` escape sequences. If
+`Enter` is appended in the same `send-keys` call, it is consumed inside the
+paste bracket and the text is **pasted but never submitted**.
+
+**Two-step pattern (required for reliable dispatch):**
+```bash
+# Step 1: send the text (do NOT append Enter)
+tmux send-keys -t <pane> 'message text'
+# Step 2: wait briefly, then send Enter separately
+sleep 1
+tmux send-keys -t <pane> Enter
+```
+
+This applies to all manual `tmux send-keys` invocations from the orchestrator.
+The `task dispatch` command uses `nudge_pane()` internally — see issue #1834
+for the code-level fix tracking.
+
 ## Gotchas
 
 - Do not bypass preview for non-trivial work — the user must see and approve
@@ -116,6 +136,8 @@ intake-to-dispatch flow into a reusable workflow.
   worker-pool summary
 - Always use `task dispatch` for the final dispatch step — do not use
   `workers dispatch` (low-level) or `Agent` (hidden subprocess delegation)
+- When manually nudging lanes via `tmux send-keys`, always use the two-step
+  pattern described above to avoid paste bracketing issues
 
 ## References
 

--- a/.claude/skills/run-fleet/SKILL.md
+++ b/.claude/skills/run-fleet/SKILL.md
@@ -138,6 +138,26 @@ Expected analyst outputs:
 - PR roadmap / safe-parallelism guidance
 - restart-ready handoff
 
+## Tmux Paste Bracketing Caveat
+
+Modern terminals use **bracketed paste mode**. When `tmux send-keys` sends a
+multi-line string (or any text that triggers paste detection), `Enter` appended
+in the same call is consumed inside the paste bracket — the text is pasted but
+**never submitted**.
+
+**Two-step pattern (required for reliable pane delivery):**
+```bash
+# Step 1: send the text (do NOT append Enter)
+tmux send-keys -t <pane> 'message text'
+# Step 2: wait briefly, then send Enter separately
+sleep 1
+tmux send-keys -t <pane> Enter
+```
+
+This affects all manual `tmux send-keys` calls from the orchestrator, including
+analyst lane dispatch, `/park` and `/clear` commands, and any ad-hoc nudges.
+See issue #1834 for evidence and code-level fix tracking.
+
 ## Lane Discipline
 
 - Respect the lane/track affinity defined in the handoff
@@ -271,18 +291,25 @@ orphaned cron jobs. `/clear` alone does **not** stop cron jobs — always
 `/park` first.
 
 1. **Park central lanes** — ops and review run persistent monitoring crons
-   that must be stopped before the orchestrator exits:
+   that must be stopped before the orchestrator exits.
+   Use the two-step pattern (see *Tmux Paste Bracketing Caveat* above):
    ```bash
-   tmux send-keys -t steward:ops '/park' Enter
+   tmux send-keys -t steward:ops '/park'
+   sleep 1
+   tmux send-keys -t steward:ops Enter
    # Wait for "0 cron jobs" confirmation
-   tmux send-keys -t steward:review '/park' Enter
+   tmux send-keys -t steward:review '/park'
+   sleep 1
+   tmux send-keys -t steward:review Enter
    # Wait for confirmation
    ```
 
 2. **Park idle author lanes** — any author lane with an active session but
    no dispatched work:
    ```bash
-   tmux send-keys -t steward:author-a '/park' Enter
+   tmux send-keys -t steward:author-a '/park'
+   sleep 1
+   tmux send-keys -t steward:author-a Enter
    # ... repeat for each idle lane with an active session
    ```
 

--- a/.claude/skills/start-task/SKILL.md
+++ b/.claude/skills/start-task/SKILL.md
@@ -140,6 +140,32 @@ following happens automatically:
 The nudge is best-effort — if it fails, the task remains in durable state
 and you can pick it up manually via `task list`.
 
+### Tmux Paste Bracketing Caveat
+
+Modern terminals use **bracketed paste mode**. When the orchestrator sends
+a nudge via `tmux send-keys`, the terminal wraps the text in paste escape
+sequences. If `Enter` is included in the same `send-keys` call, it gets
+consumed inside the paste bracket and the command is **pasted but never
+submitted** — the lane appears stuck with text in the input buffer.
+
+**If you are manually nudging a lane** (e.g., dispatching to an analyst lane
+that is not in `KNOWN_AUTHOR_LANES`), always use the two-step pattern:
+
+```bash
+# Step 1: send the command text (do NOT append Enter)
+tmux send-keys -t <pane> '/start-task <packet_id>'
+# Step 2: wait briefly, then send Enter separately
+sleep 1
+tmux send-keys -t <pane> Enter
+```
+
+**Symptom of the bug:** The target pane shows `❯ [Pasted text ...]` but
+reports 0 tokens processed — the text was never submitted. Sending `Enter`
+separately resolves it.
+
+See issue #1834 for root cause analysis and code-level fix tracking in
+`nudge_pane()` / `clear_session()`.
+
 ## Auto-Completion on Merge
 
 When you merge a PR via `gh pr merge`, the `post-merge-notify.sh` hook


### PR DESCRIPTION
## Summary

- Document the tmux paste bracketing caveat in three dispatch skill files
- Fix `run-fleet` shutdown examples to use two-step `send-keys` pattern
- Add root cause explanation, symptom description, and workaround pattern

## Why

When `tmux send-keys` sends multi-line text with `Enter` appended in the
same call, bracketed paste mode wraps everything including the Enter key —
the text is pasted but never submitted. This caused analyst lane stalls
3 times during the overnight fleet run (session 2026-03-25c).

## Changes

| File | Change |
|------|--------|
| `.claude/skills/delegate-task/SKILL.md` | New "Tmux Paste Bracketing Caveat" section + gotcha bullet |
| `.claude/skills/run-fleet/SKILL.md` | New caveat section + fixed shutdown examples to two-step |
| `.claude/skills/start-task/SKILL.md` | New subsection under "Nudge-Based Dispatch" with symptom + workaround |

## Out of Scope (noted for follow-up)

- `src/bid_euchre/ops/worker_pool.py` — `nudge_pane()` and `clear_session()`
  use the single-call pattern in code. A separate code-fix PR should split
  the subprocess call into two steps. Tracked in #1834.

## Repro / Validation

```bash
make check-quiet   # ✓ All checks passed
```

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b
branch: docs/tmux-paste-bracketing-1834
```

Closes #1834

🤖 Generated with [Claude Code](https://claude.com/claude-code)