### PR TITLE
plans(ops): incorporate operator feedback into Platform-11 scope lock

### DIFF
--- a/plans/agent_ops/5_skill_learning/scope_lock.md
+++ b/plans/agent_ops/5_skill_learning/scope_lock.md
@@ -1,8 +1,9 @@
 # Platform-11: Skill Learning Loop — Scope Lock
 
-**Status:** DRAFT (pending morning review)
+**Status:** DRAFT (operator feedback incorporated)
 **Author:** analyst lane
 **Date:** 2026-03-25
+**Updated:** 2026-03-25 (operator feedback round 1)
 **Parent:** `plans/agent_ops/governing_plan.md` — Phase 5, Platform-11
 **Registry ID:** (to be assigned)
 
@@ -22,6 +23,9 @@ accuracy, task estimation, or lane-task affinity.
 - Worker pool assignment (`worker_pool.py`) is round-robin or explicit lane targeting
 - Task completion outcomes are logged to the event system but never analyzed
 - No mechanism to detect that "author-a is 2x faster at convention fixes" or "flex lanes consistently fail on complex refactors"
+- Token economy tracking (`token_economy.py`) exists but is not connected to
+  dispatch outcomes — cost, token usage, and lines-added metrics are available
+  but not used for routing decisions
 
 **Governing plan done-when:**
 > - Repeated successful workflows can produce skill suggestions with provenance
@@ -32,7 +36,9 @@ accuracy, task estimation, or lane-task affinity.
 ### Data Model
 
 **Task Outcome Records** — extend the existing event system to capture structured
-completion data:
+completion data. The outcome model must be rich enough to control for task
+difficulty — fast completion alone does not indicate good routing if one lane
+mostly receives easy work.
 
 ```
 {
@@ -40,112 +46,299 @@ completion data:
   "lane_id": "author-a",
   "task_id": "...",
   "domain": "platform",
-  "task_type": "convention_fix",        // NEW: categorized task type
-  "elapsed_minutes": 28,                // NEW: wall-clock duration
-  "review_rounds": 1,                   // NEW: how many review iterations
-  "files_changed": 3,                   // NEW: scope proxy
-  "outcome": "merged",                  // NEW: terminal outcome
-  "pr_number": 1801                     // existing
+  "task_type": "convention_fix",        // NEW: categorized task type (see taxonomy)
+  "complexity_estimate_at_dispatch": 2, // NEW: 1-5 scale, assigned at dispatch time
+  "elapsed_minutes": 28,               // NEW: wall-clock duration
+  "review_rounds": 1,                  // NEW: how many review iterations
+  "files_changed": 3,                  // NEW: scope proxy
+  "lines_added": 45,                   // NEW: from economy tracking
+  "token_usage": 12500,                // NEW: from economy tracking
+  "estimated_cost_usd": 0.15,          // NEW: from economy tracking
+  "session_type": "overnight",         // NEW: overnight | daytime | interactive
+  "requires_review_gate": true,        // NEW: was review gate required?
+  "outcome": "merged",                 // NEW: terminal outcome (see below)
+  "rollback_or_rework_required": false, // NEW: was rework needed post-merge?
+  "acceptance_without_major_rewrite": true, // NEW: merged without major rewrite?
+  "operator_override": false,          // NEW: did operator override advisor?
+  "pr_number": 1801                    // existing
 }
 ```
 
-**Lane Affinity Model** — per-lane success metrics aggregated from outcomes:
+**Outcome granularity:** `"merged"` is too coarse — a task can merge after
+painful cleanup and still look like success. Valid outcome values:
+
+| Value | Meaning |
+|-------|---------|
+| `merged_clean` | Merged with ≤1 review round, no rework |
+| `merged_with_rework` | Merged but required significant revision |
+| `abandoned` | Task was abandoned or reassigned |
+| `rolled_back` | Merged then reverted |
+| `blocked` | Could not proceed, escalated |
+
+**Lane Affinity Model** — per-lane success metrics aggregated from outcomes,
+controlled for task complexity:
 
 ```
 {
   "lane_id": "author-a",
   "task_type_stats": {
-    "convention_fix": {"count": 12, "avg_minutes": 22, "success_rate": 0.92},
-    "complex_refactor": {"count": 3, "avg_minutes": 95, "success_rate": 0.67}
+    "convention_fix": {
+      "count": 12,
+      "avg_minutes": 22,
+      "avg_complexity": 1.8,
+      "clean_merge_rate": 0.83,
+      "rework_rate": 0.08,
+      "avg_review_rounds": 1.1,
+      "avg_token_usage": 8500,
+      "avg_cost_usd": 0.12
+    },
+    "cross_module_refactor": {
+      "count": 3,
+      "avg_minutes": 95,
+      "avg_complexity": 4.0,
+      "clean_merge_rate": 0.67,
+      "rework_rate": 0.33,
+      "avg_review_rounds": 2.3,
+      "avg_token_usage": 45000,
+      "avg_cost_usd": 0.58
+    }
   },
+  "confidence": 0.72,
   "last_updated": "..."
 }
 ```
 
-### Learning Algorithm
+### Adaptive Dispatch Heuristics
 
-**Phase 1 (MVP):** Moving-average statistics per lane × task_type. No ML.
+> **Naming convention:** This is not a "learning algorithm." Phase 1 implements
+> outcome-informed dispatch heuristics. Reserve "learning" for the broader
+> platform capability when genuine model-based prediction is warranted.
+
+**Phase 1 (MVP): Outcome-Informed Dispatch Advisor.** Moving-average statistics
+per lane × task_type, controlled for complexity. No ML.
+
 - Exponentially weighted moving average (EWMA) with α=0.3 for recency bias
-- Simple affinity score: `score = success_rate * (1 / avg_minutes)`
-- Dispatch advisor: given a task_type, rank available lanes by affinity score
+- Affinity score controlled for complexity:
+  `score = clean_merge_rate * (1 / complexity_adjusted_minutes) * (1 - rework_rate)`
+  where `complexity_adjusted_minutes = avg_minutes / avg_complexity`
+- Dispatch advisor: given a task_type + complexity estimate, rank available
+  lanes by affinity score
 - Falls back to round-robin when no history exists (cold start)
+- **Advisor is advisory only** — orchestrator retains final dispatch authority
+  until the advisor is validated against baseline (see Evaluation section)
+
+**Exploration policy** (replaces naive 20% random):
+- Only explore on tasks below a risk threshold (complexity ≤ 3)
+- Never explore on high-blast-radius tasks (complexity 4-5)
+- Prefer exploration among plausible lanes (top-3 ranked), not fully random
+- Decay exploration rate as confidence increases:
+  `explore_rate = max(0.05, 0.20 * (1 - confidence))`
+- Log all exploration decisions for evaluation
 
 **Phase 2 (deferred):** Lightweight logistic regression on feature vectors
 (task_type, domain, file_count, estimated_complexity) → predicted best lane.
-Only justified when Phase 1 data shows clear lane differentiation.
+Only justified when Phase 1 data shows clear lane differentiation and
+the heuristic advisor has been validated against baseline.
 
 ### Skill Suggestion Pipeline
 
-When a workflow pattern repeats successfully N times (N=5 default):
-1. Extract the common steps from task outcome records
-2. Generate a candidate SKILL.md with provenance (source task IDs, success count)
-3. Submit as a skill promotion proposal via `skill_promotion.py`
-4. Require review-gate approval before activation (existing gate)
-5. Track suggestion acceptance/rejection rate as feedback
+Task outcome records alone usually don't contain enough procedural detail to
+reconstruct reliable skills — they capture outcomes, not method. Candidate
+skill suggestions must draw from richer evidence.
+
+**Evidence sources for skill suggestions:**
+- Task metadata (type, domain, complexity, file patterns)
+- Artifacts touched (which files, modules, test paths)
+- Structured operator notes or traces (when available)
+- Review comments and correction patterns (from review coordinator)
+- Source task provenance (which tasks contributed to the pattern)
+
+**Minimum evidence threshold** — all must be met before generating a suggestion:
+- Repeated success (N≥5) on same task type
+- Same major file or subsystem pattern across instances
+- Low review churn (avg review rounds ≤ 1.5)
+- Consistent step sequence observable from traces or notes
+
+**Pipeline:**
+1. Detect repeated pattern meeting all evidence thresholds above
+2. Extract procedural steps from traces, review comments, and artifact patterns
+3. Generate a candidate SKILL.md with full provenance (source task IDs,
+   success count, evidence summary)
+4. Submit as a skill promotion proposal via `skill_promotion.py`
+5. **No auto-promotion** — require review-gate approval before activation
+6. Track suggestion acceptance/rejection rate as feedback
+7. Rate-limit: max 2 suggestions per overnight run to control noise
+8. File accepted suggestions as GitHub issues with `skill-suggestion` label,
+   low priority — operator reviews in batch during morning check-in
 
 ### Integration Points
 
 | Component | Integration | Change Type |
 |-----------|------------|-------------|
-| `task_queue.py` | Add `task_type` field to TaskPacket | Schema extension |
-| `worker_pool.py` | Consume lane affinity model for dispatch ranking | New advisor input |
-| `events.py` | Add outcome fields to `task_completed` events | Schema extension |
+| `task_queue.py` | Add `task_type` + `complexity_estimate_at_dispatch` to TaskPacket | Schema extension |
+| `worker_pool.py` | Consume lane affinity model for dispatch ranking (advisory) | New advisor input |
+| `events.py` | Add enriched outcome fields to `task_completed` events | Schema extension |
+| `token_economy.py` | Supply cost, token usage, lines-added metrics to outcomes | Read integration |
 | `skill_promotion.py` | Accept auto-generated suggestions with provenance | New suggestion source |
-| `monitor.py` | Surface learning-loop health (data freshness, cold-start lanes) | New monitoring check |
+| `monitor.py` | Surface learning-loop health (data freshness, cold-start lanes, skew alerts) | New monitoring checks |
 
 ### Storage
 
-Lane affinity model persists at `.claude/runtime/learning/lane_affinity.json`.
+JSON files consistent with existing ops patterns. No SQLite or external
+dependencies for MVP. Structured as append-only log + derived state:
+
+| File | Purpose | Format |
+|------|---------|--------|
+| `.claude/runtime/learning/outcomes.jsonl` | Append-only event log of all task outcomes | JSONL, one record per completed task |
+| `.claude/runtime/learning/lane_affinity.json` | Derived affinity model, rebuilt from log | JSON, regenerated on demand |
+| `.claude/runtime/learning/snapshot_meta.json` | Version metadata for derived state | JSON, tracks rebuild timestamp + log offset |
+
+**Design rationale:** The append-only outcomes log is the source of truth.
+`lane_affinity.json` is a derived cache that can be rebuilt from the log at
+any time. This gives full auditability (every outcome is preserved) and
+rebuild capability (if the derived model is corrupted or the scoring formula
+changes, regenerate from the log).
+
 Task type taxonomy defined in a new `src/bid_euchre/ops/learning.py` module.
-No SQLite or external dependencies — JSON files consistent with existing ops patterns.
 
-## Open Questions (for operator)
+## Operator Decisions (from feedback round 1)
 
-1. **What feedback signals matter most?**
-   - PR merge time (wall clock from dispatch to merge)?
-   - Review rounds (fewer = better)?
-   - Lane idle time between tasks (lower = better throughput)?
-   - **Recommendation:** Start with merge time + review rounds. Idle time is harder to attribute to lane quality vs work availability.
+1. **Feedback signals:** Focus on merge time + review rounds for dispatch
+   decisions. But **track all available metrics from the start** (cost, token
+   usage, lines added, idle time) to create robust data for future iterations.
+   Borrow metrics from economy tracking (`token_economy.py`).
 
-2. **Where does learning state live?**
-   - JSON file in `.claude/runtime/learning/` (consistent with ops patterns)
-   - SQLite (more query-friendly, but adds a dependency)
-   - In-memory only (lost on session restart — bad for multi-session learning)
-   - **Recommendation:** JSON file. Consistent with existing ops patterns. Can migrate to SQLite later if query needs grow.
+2. **Storage:** JSON files in `.claude/runtime/learning/`. Append-only log +
+   derived state (see Storage section above).
 
-3. **How to avoid overfitting to overnight run patterns?**
-   - Overnight runs have different task mix (more convention fixes, fewer complex refactors)
-   - Time-of-day bias: overnight lanes may be faster because there's less contention
-   - **Recommendation:** Include `session_type` (overnight/daytime/interactive) in outcome records. Weight daytime observations higher for dispatch decisions. Require minimum N=5 observations per task_type before using affinity scores.
+3. **Session type bias:** Include `session_type` in outcome records. Weight
+   daytime observations higher. Require N≥5 observations per task_type before
+   using affinity scores.
 
-4. **Task type taxonomy — who defines it?**
-   - Option A: Manual taxonomy in config (convention_fix, complex_refactor, investigation, etc.)
-   - Option B: Auto-derived from file paths and PR descriptions
-   - **Recommendation:** Option A for MVP. ~8-10 categories based on existing dispatch patterns. Auto-derivation is a Phase 2 enhancement.
+4. **Taxonomy:** Manual for MVP (see Task Type Taxonomy below). ~9 categories
+   based on existing dispatch patterns. Auto-derivation is Phase 2.
 
-5. **Evaluation criteria — how do we know the loop improved dispatch quality?**
-   - Before/after comparison of: avg merge time, review rounds, lane idle time
-   - Need baseline measurement BEFORE enabling the learning loop
-   - **Recommendation:** Capture 2 full overnight runs of baseline statistics before activating dispatch advisor. Compare with 2 post-activation runs. Require >20 tasks per run for meaningful comparison.
+5. **Evaluation:** Matched-cohort evaluation required (see Evaluation section
+   below). Simple before/after comparison is insufficient.
 
-6. **Should skill suggestions be auto-filed as GitHub issues?**
-   - Pro: Durable, reviewable, fits existing workflow
-   - Con: Issue noise, may create false sense of urgency
-   - **Recommendation:** File as issues with `skill-suggestion` label, low priority. Operator reviews in batch during morning check-in.
+6. **Skill suggestions:** File as GitHub issues with `skill-suggestion` label,
+   low priority. Operator reviews in batch during morning check-in.
+
+## Open Questions (remaining)
+
+1. **Claude Code native capabilities:** How do Claude Code's built-in skills
+   and `/insights` function work? Can we leverage them for the learning loop?
+   Are there public repos for similar agentic development (Open Claw, Hermes,
+   etc.) with skill learning loops we can draw from?
+   **Action:** Investigation spike needed before implementation begins.
+
+2. **Complexity estimation at dispatch:** Who assigns `complexity_estimate_at_dispatch`?
+   - Option A: Orchestrator assigns manually (reliable but adds dispatch friction)
+   - Option B: Heuristic from file count + scope_declared patterns (automated but noisy)
+   - **Recommendation:** Option A for MVP with Option B as fallback when orchestrator omits it.
+
+3. **Confidence threshold for advisory → active:** At what confidence level does
+   the advisor transition from "shown to orchestrator" to "used for automatic
+   ranking"? Needs operational experience to calibrate.
+
+## Task Type Taxonomy (MVP)
+
+Manual taxonomy based on observed dispatch patterns. The category
+`ambiguous_or_open_ended` is critical — routing failures come from ambiguity
+in task definition, not technical complexity alone.
+
+| Task Type | Description | Typical Complexity |
+|-----------|-------------|-------------------|
+| `convention_fix` | Style, naming, import ordering, lint fixes | 1-2 |
+| `focused_bugfix` | Single-cause bug with clear repro | 2-3 |
+| `test_repair` | Fix broken tests, add missing coverage | 1-3 |
+| `doc_update` | Documentation, plans, scope locks, MEMORY.md | 1-2 |
+| `investigation` | Root-cause analysis, spike, feasibility study | 2-4 |
+| `small_feature` | Bounded feature, ≤3 files, clear spec | 2-3 |
+| `cross_module_refactor` | Multi-file structural change, API migration | 3-5 |
+| `infra_or_tooling_change` | CI, hooks, scripts, build system | 2-4 |
+| `ambiguous_or_open_ended` | Underspecified scope, requires clarification | 3-5 |
+
+**Taxonomy rules:**
+- Every dispatched task must have a `task_type` assigned at dispatch time
+- If the orchestrator is unsure, use `ambiguous_or_open_ended` — this is data,
+  not a failure
+- Taxonomy is versioned; changes require a migration note in `snapshot_meta.json`
+
+## Anti-Corruption Guardrails
+
+Explicit guardrails to prevent the dispatch advisor from creating perverse
+incentives or feedback loops:
+
+1. **Advisory-only until validated:** The dispatch advisor is informational
+   until it has been evaluated against baseline metrics (see Evaluation).
+   The orchestrator retains final dispatch authority.
+
+2. **No auto-promotion of skills:** All skill suggestions require review-gate
+   approval. The learning loop cannot bypass `skill_promotion.py` gates.
+
+3. **No lane ranking as prestige scoreboard:** Affinity scores are dispatch
+   signals, not performance reviews. They must not be surfaced as lane
+   "rankings" or used for lane deprecation decisions.
+
+4. **Minimum observation threshold:** No routing based on fewer than N=5
+   observations per task_type per lane AND minimum confidence > 0.3. Below
+   this, fall back to round-robin.
+
+5. **Skew monitoring:** Monitor for one lane taking a disproportionate share
+   of one task type (lane monoculture). Alert if any lane handles >60% of
+   a task type's volume over a rolling 20-task window.
+
+6. **Exploration constraints:** See exploration policy in Adaptive Dispatch
+   Heuristics section — never explore on high-blast-radius tasks.
+
+7. **Operator override tracking:** Every operator override of the advisor is
+   logged. High override rate (>30%) triggers review of advisor quality.
+
+## Evaluation Framework
+
+> Operator feedback: "2 overnight runs before and 2 after" is too flimsy.
+
+**Matched-cohort design:** Compare advisor-recommended vs actual routing on
+matched task cohorts — same task types, session types, and similar complexity
+buckets.
+
+**Baseline capture (before activating advisor):**
+- Minimum 3 overnight runs + 2 daytime sessions
+- Minimum 40 tasks total with representation across ≥5 task types
+- Record all outcome fields even before advisor exists (creates training data)
+
+**Evaluation metrics:**
+
+| Metric | Description | Better = |
+|--------|-------------|----------|
+| Time to accepted completion | Dispatch → clean merge | Lower |
+| Review rounds | Number of review iterations | Lower |
+| Rework rate | % of tasks requiring major revision post-review | Lower |
+| Rollback rate | % of tasks reverted after merge | Lower |
+| Operator override rate | % of advisor recommendations overridden | Lower (but > 0 is healthy) |
+| Advisor acceptance rate | % of recommendations followed | Higher |
+| Clean merge rate | % of tasks merged with ≤1 review round | Higher |
+| Cost per task (by type) | Token cost from economy tracking | Lower |
+
+**Activation criteria:** Advisor transitions from advisory to active ranking
+only when evaluation shows statistically significant improvement on ≥2 of the
+above metrics (p < 0.05, paired comparison on matched cohorts).
 
 ## File Scope (estimated)
 
 | File | Status | Lines |
 |------|--------|-------|
-| `src/bid_euchre/ops/learning.py` | NEW | ~250 |
-| `src/bid_euchre/ops/task_queue.py` | MODIFY | ~20 (add task_type field) |
-| `src/bid_euchre/ops/worker_pool.py` | MODIFY | ~30 (consume affinity advisor) |
-| `src/bid_euchre/ops/events.py` | MODIFY | ~10 (add outcome fields to VALID_EVENT_TYPES) |
-| `src/bid_euchre/ops/skill_promotion.py` | MODIFY | ~40 (auto-suggestion source) |
-| `src/bid_euchre/ops/monitor.py` | MODIFY | ~20 (learning health check) |
-| `tests/unit/test_ops_learning.py` | NEW | ~200 |
+| `src/bid_euchre/ops/learning.py` | NEW | ~350 (affinity model, EWMA, exploration policy, log rebuild) |
+| `src/bid_euchre/ops/task_queue.py` | MODIFY | ~25 (add task_type + complexity_estimate fields) |
+| `src/bid_euchre/ops/worker_pool.py` | MODIFY | ~40 (consume affinity advisor, log overrides) |
+| `src/bid_euchre/ops/events.py` | MODIFY | ~15 (add enriched outcome fields) |
+| `src/bid_euchre/ops/token_economy.py` | MODIFY | ~15 (expose cost/token metrics for outcome records) |
+| `src/bid_euchre/ops/skill_promotion.py` | MODIFY | ~50 (evidence-based suggestion source) |
+| `src/bid_euchre/ops/monitor.py` | MODIFY | ~30 (learning health check + skew alerts) |
+| `tests/unit/test_ops_learning.py` | NEW | ~300 (affinity, exploration, guardrails, rebuild) |
 | `tests/unit/test_ops_task_queue.py` | MODIFY | ~30 |
-| `tests/integration/test_learning_loop.py` | NEW | ~100 |
+| `tests/integration/test_learning_loop.py` | NEW | ~150 (end-to-end: outcome → affinity → dispatch) |
 
 ## Dependencies
 
@@ -159,12 +352,15 @@ No SQLite or external dependencies — JSON files consistent with existing ops p
 
 | Slice | PRs | Lane-hours | Description |
 |-------|-----|------------|-------------|
-| Data model + outcome recording | 1 | 1.5h | Extend TaskPacket + events with task_type, outcome fields |
-| Lane affinity model | 1 | 2h | `learning.py` — EWMA computation, persistence, cold-start fallback |
-| Dispatch advisor wiring | 1 | 1.5h | Wire affinity scores into worker_pool dispatch ranking |
-| Skill suggestion pipeline | 1 | 2h | Pattern detection + auto-suggestion via skill_promotion |
-| Monitoring + evaluation baseline | 1 | 1h | Health check, baseline capture, evaluation report |
-| **Total** | **5 PRs** | **~8h** | |
+| Investigation spike | 1 | 1h | Claude Code /insights, public repo survey for prior art |
+| Data model + outcome recording | 1 | 2h | Enrich TaskPacket + events, wire economy metrics, outcome granularity |
+| Append-only log + rebuild | 1 | 1.5h | `outcomes.jsonl` writer, affinity model rebuild from log |
+| Adaptive dispatch heuristics | 1 | 2h | `learning.py` — EWMA, complexity-controlled scoring, exploration policy |
+| Anti-corruption guardrails | 1 | 1.5h | Skew monitor, override tracking, observation thresholds |
+| Dispatch advisor wiring | 1 | 1.5h | Wire affinity scores into worker_pool (advisory mode) |
+| Skill suggestion pipeline | 1 | 2h | Evidence-based pattern detection + suggestion via skill_promotion |
+| Baseline capture + evaluation | 1 | 1.5h | Matched-cohort evaluation framework, baseline recording |
+| **Total** | **~8 PRs** | **~13h** | |
 
 ## Risks
 

--- a/platform11_feedback.md
+++ b/platform11_feedback.md
@@ -1,0 +1,110 @@
+# Operator Feedback on Platform-11 Skill Learning Scope Lock
+
+## Point-by-Point Feedback
+
+### 1. Metrics
+Borrow metrics from economy tracking: cost, token usage, lines added. Beef up tracking early but only implement skills on a few parameters to reduce degrees of freedom.
+
+### Erratum: Claude Code Skills & /insights
+- How does Claude Code skills and /insights work?
+- Can we leverage the /insights function?
+- Are there native skill learning tools in Claude Code we can borrow from?
+- Are there public repos for similar agentic development (Open Claw, Hermes, etc) with skill learning loops we can draw from?
+
+### 2. Focus Areas
+Agree with approach — focus on merge time and review rounds for now. But start tracking ALL metrics we can so we create robust data for future skill loops.
+
+### 3. Time of Day
+Great idea — will need to track that.
+
+### 4. MVP Approach
+Makes sense for MVP.
+
+### 5. See Erratum above
+
+### 6. Issues Workflow
+Agree with the issues workflow.
+
+## Major Structural Feedback
+
+### Outcome Model is Too Shallow
+`success_rate * (1 / avg_minutes)` is fine as toy score but misleads unless you control for task difficulty. Fast completion != good routing if author-a mostly gets easy work and flex lanes get ugly edge cases.
+
+**Add at minimum:**
+- `complexity_estimate_at_dispatch`
+- `session_type`
+- `requires_review_gate` or severity class
+- `rollback_or_rework_required`
+- `acceptance_without_major_rewrite` flag
+
+"Merged" is too coarse — a task can merge after painful cleanup and still look like success.
+
+### Taxonomy is Make-or-Break
+Manual taxonomy for MVP is right. But if mushy, whole thing becomes fake precision.
+
+**Use these categories instead:**
+- `convention_fix`
+- `focused_bugfix`
+- `test_repair`
+- `doc_update`
+- `investigation`
+- `small_feature`
+- `cross_module_refactor`
+- `infra_or_tooling_change`
+- `ambiguous_or_open_ended` (this one matters — routing failures come from ambiguity, not technical complexity)
+
+### Exploration Policy
+20% random exploration is too dumb operationally. Constrain it:
+- Only explore below a risk threshold
+- Never explore on high-blast-radius tasks
+- Prefer exploration among plausible lanes, not fully random
+- Decay exploration once confidence is high
+
+### Skill Suggestion Pipeline Needs Stricter "Pattern" Definition
+Task outcome records usually don't contain enough procedural detail to reconstruct reliable skills. They capture outcomes, not method.
+
+**Candidate skill suggestions should use:**
+- Task metadata
+- Artifacts touched
+- Structured operator notes or traces
+- Review comments and correction patterns
+- Source task provenance
+
+**Minimum evidence threshold:**
+- Repeated success on same task type
+- Same major file or subsystem pattern
+- Low review churn
+- Consistent step sequence from traces or notes
+
+### Baseline/Evaluation Too Thin
+"2 overnight runs before and 2 after" is too flimsy. Define evaluation in matched cohorts:
+- Same task types, session types, similar complexity buckets
+
+**Measure:**
+- Time to accepted completion
+- Review rounds
+- Rework rate
+- Rollback rate
+- Operator override rate
+- Advisor recommendation acceptance rate (important — if operators constantly ignore advisor, problem may be trust not model quality)
+
+### Storage
+JSON is right for MVP. But structure as:
+- Append-only outcomes event log
+- Derived `lane_affinity.json`
+- Optional snapshot/version metadata
+
+Gives auditability and rebuild capability.
+
+### Anti-Corruption Guardrails (Missing)
+Add explicit guardrails:
+- Dispatch advisor is advisory until validated
+- No auto-promotion of skills
+- No lane ranking shown as prestige scoreboard
+- No routing based on fewer than N observations + minimum confidence
+- Monitor for skew: one lane taking too much of one task type (no lane monocultures)
+
+### Naming
+Do NOT call Phase 1 a "learning algorithm." Call it:
+- **Adaptive Dispatch Heuristics** or **Outcome-Informed Dispatch Advisor**
+- Reserve "learning" for the broader platform capability


### PR DESCRIPTION
## Summary
Updates the Platform-11 skill-learning scope lock with the operator feedback round captured on 2026-03-25.

## Details
- enriches the outcome model and task taxonomy
- reframes Phase 1 as outcome-informed dispatch heuristics rather than a learning algorithm
- adds guardrails, exploration constraints, and matched-cohort evaluation
- includes the operator feedback note for traceability

## Validation
Plan/doc update only.

## Notes
Draft PR for auditability and follow-through on the active Author-b lane.