### PR TITLE
plans(ops): incorporate operator feedback into Platform-13 scope lock

### DIFF
--- a/plans/agent_ops/5_extraction/scope_lock.md
+++ b/plans/agent_ops/5_extraction/scope_lock.md
@@ -1,7 +1,7 @@
 # Platform-13: Second-Project Extraction Proof — Scope Lock
 
-**Status:** DRAFT (pending morning review)
-**Author:** analyst lane
+**Status:** SCOPE-LOCKED
+**Author:** analyst lane, revised with operator feedback
 **Date:** 2026-03-25
 **Parent:** `plans/agent_ops/governing_plan.md` — Phase 6, Platform-13
 **Registry ID:** (to be assigned)
@@ -31,9 +31,32 @@ the steward on a second project.
 >   entire Bid-Euchre control plane
 > - At least one adapter seam is validated against a real non-Bid-Euchre use
 
-## Proposed Solution
+## Core Principle
 
-### Extraction Boundary (from Platform-10)
+> "Platform-13 proves the boundary by running on a second project."
+>
+> Not docs, not architecture diagrams — execution in a foreign environment. If
+> this works, you've built a reusable orchestration system. If it fails, you've
+> exposed hidden coupling. Both are wins.
+>
+> — Operator feedback
+
+## Success Criteria (Non-Negotiable)
+
+Platform-13 is **DONE** when all four conditions are met:
+
+1. **A second repo runs steward without modifying `core/`** — zero patches to
+   core modules to make the second project work
+2. **Adapter is ≤ ~150–250 LOC** — if it balloons past this, the abstraction
+   boundary is wrong (too much leaked from core, or adapter is compensating for
+   missing core features)
+3. **No Bid-Euchre strings appear in core runtime logs** — runtime log output
+   from core modules must be project-agnostic when running the second project
+4. **System survives failure cases** — at minimum: 1 failed test cycle, 1
+   rejected PR, 1 retry loop. If Platform-13 doesn't include failure cases,
+   it certifies a brittle system
+
+## Extraction Boundary (from Platform-10)
 
 Platform-10 splits `src/bid_euchre/ops/` into:
 
@@ -57,16 +80,48 @@ src/bid_euchre/ops/adapters/      # Bid-Euchre-specific policy
 Platform-13 proves this boundary by implementing a **second adapter** for a
 different project and booting the steward against it.
 
-### Adapter Contract Specification
+### Where the Boundary Will Break (Expected)
 
-A project adapter must implement:
+The adapter contract as designed is too clean. In practice, expect:
+
+- **Hidden filesystem assumptions** — hardcoded paths, `.claude/` layout
+  expectations, branch naming patterns baked into core
+- **Implicit repo structure dependencies** — core modules that assume specific
+  directory layouts, PR flow timing, or test output formats
+- **Hardcoded expectations** — lane naming conventions, worktree base directory
+  assumptions, CI check name patterns
+
+These breakages are the point. They prove the boundary needs work.
+
+### High-Risk Core Modules
+
+Modules most likely to leak Bid-Euchre assumptions through the boundary:
+
+| Module | Risk | Expected Leakage |
+|--------|------|------------------|
+| `task_queue.py` | High | Lane semantics and naming patterns |
+| `monitor.py` | High | PR/CI expectations, check name parsing |
+| `worker_pool.py` | High | Worktree + repo structure coupling |
+| `watchdogs.py` | Medium | Plan/checkpoint path assumptions |
+| `token_economy.py` | Medium | Project directory slug parsing |
+
+**Better than grep audit:** Run the hello project and **log every adapter
+call**. If core ever branches on project behavior or assumes structure not
+provided by the adapter, that's a leak.
+
+## Adapter Contract Specification
+
+A project adapter must implement the base protocol, plus a **translation layer**
+for real-world mismatches:
+
+### Base Protocol
 
 ```python
 class ProjectAdapter(Protocol):
     """Contract for project-specific steward configuration."""
 
     # Identity
-    project_name: str                          # "bid-euchre", "chess-engine"
+    project_name: str                          # "bid-euchre", "rin-balance"
     repo_url: str                              # GitHub URL
 
     # Lane topology
@@ -91,176 +146,261 @@ class ProjectAdapter(Protocol):
     def custom_watchdogs(self) -> list[WatchdogCheck]: ...
 ```
 
-### Second-Project Candidate Evaluation
+### Translation Layer (Required)
 
-| Candidate | Complexity | Existing Tests | CI | Benefit |
-|-----------|-----------|---------------|-----|---------|
-| **Chess engine (Python)** | Medium | Yes | GitHub Actions | Similar to Bid-Euchre (game domain, Python, experiments) |
-| **Data pipeline (Python)** | Low-Medium | Partial | GitHub Actions | Different domain, proves non-game portability |
-| **Web scraper (Python)** | Low | Minimal | None | Minimal, doesn't stress orchestration features |
-| **Rust CLI tool** | Medium-High | Yes | GitHub Actions | Proves language-agnosticism but adds complexity |
-| **Bid-Euchre browser game (subproject)** | Low | Yes | Shared CI | Already exists, minimal extraction proof |
+The clean protocol above won't survive contact with real projects. The adapter
+must also handle format mismatches between what the project produces and what
+core expects:
 
-**Recommendation:** A small-to-medium Python project with existing tests and
-GitHub Actions CI. A chess engine or data pipeline provides the strongest proof
-because:
-- Different domain (non-game or different game)
-- Similar toolchain (Python, pytest, GitHub)
-- Enough complexity to exercise dispatch, review, and monitoring
-- Not so complex that the extraction proof becomes a multi-week project
+```python
+class ProjectAdapter(Protocol):
+    # ... base protocol above ...
 
-**Alternative: Synthetic proof project.** Create a minimal "hello-steward"
-project with a trivial test suite, a Makefile, and 2-3 source files. This
-proves the adapter interface works without the overhead of a real second project.
-Faster (~2h) but weaker proof.
-
-### Packaging Strategy
-
-| Strategy | Pros | Cons | Recommendation |
-|----------|------|------|----------------|
-| **PyPI package** | Clean distribution, versioning, pip install | Requires publish infra, semver discipline | Phase 2 |
-| **Git submodule** | Simple, no publish step | Submodule UX is painful, version pinning is fragile | Not recommended |
-| **Monorepo workspace** | Single repo, unified CI | Doesn't prove extraction at all | Not recommended |
-| **Copy + adapt** | Fastest to prove, zero infra | Diverges immediately, no shared updates | MVP proof only |
-| **pip install from git** | Moderate setup, works without PyPI | Slower installs, no proper versioning | Acceptable MVP |
-
-**Recommended MVP:** `pip install from git` — the core ops package is
-installable directly from the Bid-Euchre repo's `src/bid_euchre/ops/core/`
-path. The second project's `pyproject.toml` includes:
-
-```toml
-[project.optional-dependencies]
-steward = ["bid-euchre-steward-core @ git+https://github.com/..."]
+    # Translation — normalize project outputs into core-expected formats
+    def normalize_test_output(self, raw_output: str) -> TestResult: ...
+    def resolve_repo_paths(self) -> RepoLayout: ...
+    def pr_creation_strategy(self) -> PRStrategy: ...
 ```
 
-**Recommended production:** PyPI package (`steward-core`) once the API stabilizes
-post-Platform-14.
+Without the translation layer, Bid-Euchre assumptions sneak back into `core/`
+as "generic" parsing logic that only works for one project.
 
-### Proof-of-Concept Plan
+## Second-Project Candidates (Decided)
 
-**Minimal viable extraction proof (MVP):**
+### Step 1 — Smoke Test: `hello-steward`
 
-1. Create a `steward-hello` repo with:
-   - 3 Python source files (a simple calculator library)
-   - `pytest` test suite (10 tests)
-   - `Makefile` with `check`, `test`, `lint` targets
-   - GitHub Actions CI
-   - `.claude/` directory with steward config
+Synthetic proof project. Create a minimal repo with:
+- A trivial test suite
+- A Makefile with `check`, `test`, `lint` targets
+- 2–3 source files
 
-2. Implement a `HelloAdapter` that satisfies the `ProjectAdapter` protocol:
-   - 2 lanes: `hello-author-a`, `hello-author-b`
-   - 1 control-plane lane: `hello-orchestrator`
-   - Validation: `make check`
-   - No governed plans or checkpoints (optional features)
+**Purpose:** Proves the adapter interface works without real project overhead.
+Fast fail (~2h). Catches structural problems (boot, dispatch, PR loop) before
+investing in a real project.
 
-3. Boot the steward with the hello adapter:
-   - `steward-session.sh` with 3 tmux panes
-   - Dispatch a simple task ("add a new function + test")
-   - Verify: task packet created, dispatched to lane, PR opened, review runs,
-     merge completes
+**What it proves:** Boot works, dispatch works, PR loop works.
 
-4. Document adapter implementation experience:
-   - What was easy? What was confusing?
-   - Which core assumptions leaked through?
-   - What docs were missing?
+**What it does NOT prove:** Monitoring robustness, failure handling, scheduling,
+concurrency edge cases.
 
-### Shared Infrastructure Requirements
+### Step 2 — Full Test: RIN Commodities Balance Sheet
+
+**Project:** A commodities balance sheet built from publicly available RIN
+(Renewable Identification Number) data.
+
+- Operator will define data sources and methodology
+- Only need an MVP for proving — scrape, build balance sheet, etc. is enough
+- 20–50 files, non-trivial tests, at least one failing edge case
+- This is where abstractions crack under real-world pressure
+
+**Purpose:** Forces the adapter to handle a "slightly annoying" real project.
+Stresses monitoring, failure handling, and the translation layer in ways the
+hello project cannot.
+
+### Step 3 — Outside Validation
+
+Ship to a friend to see if they can use the steward for their project by
+downloading from GitHub.
+
+**Purpose:** The ultimate extraction proof. If a third party can boot the
+steward against their own project using only published adapter docs + the
+GitHub repo, the extraction is real. If they can't, the extraction is
+self-referential.
+
+### Two-Step Proof (Non-Negotiable)
+
+Both the smoke test AND the full test are required. Skipping the full test
+and declaring victory from hello-steward alone would certify a brittle system.
+
+## Multi-Repo Runtime Isolation
+
+> **Biggest hidden risk:** Claude Code multi-repo operation is more serious
+> than initially treated.
+
+The system assumes one repo context, one working directory, one
+`.claude/runtime`. Cross-repo introduces path ambiguity and state separation
+problems.
+
+### Requirements
+
+| Requirement | Description |
+|-------------|-------------|
+| **Explicit repo root scoping** | Core modules must accept a `repo_root: Path` parameter, never derive it from assumptions |
+| **Strict runtime isolation** | Each project gets its own `.claude/runtime/` — no shared state files across projects |
+| **No reliance on `cwd`** | Core must never call `os.getcwd()` or `Path(".")` to infer project identity |
+
+### Anti-Leak Testing
+
+Beyond grep audits, the primary leak detection method is **runtime logging**:
+
+1. Boot the hello project
+2. Log every adapter call from core → adapter
+3. Assert: core never branches on project-specific behavior or assumes
+   structure not provided through the adapter protocol
+4. Assert: core runtime logs contain zero Bid-Euchre strings
+
+Any adapter call that requires project-specific knowledge not in the protocol
+is a leak that must be fixed in core, not worked around in the adapter.
+
+## Packaging Strategy (Simplified)
+
+Per operator guidance: premature to think about PyPI/git install/versioning.
+
+**The only question now:** Can core run outside the original repo without hacks?
+
+**Recommendation:** `pip install -e ../core`. Hardcode the editable install
+path. Ignore distribution concerns for Platform-13. Packaging is a
+Platform-14+ concern.
+
+### Analyst Note
+
+The original scope lock proposed a tiered packaging strategy (PyPI, git
+submodule, monorepo workspace, etc.). The operator correctly identifies this as
+premature. The extraction proof's value is in proving the boundary, not in
+solving distribution. An editable install is the minimum viable packaging that
+doesn't add noise to the signal we're measuring.
+
+## Open Questions — Resolved
+
+| # | Question | Operator Answer | Implication |
+|---|----------|-----------------|-------------|
+| 1 | Which ops modules are truly project-agnostic? | Agent should audit and assess the bid-euchre assumptions built into the platform boundary | Post-Platform-10 audit required; don't trust the module split until runtime-proven |
+| 2 | What adapter interface does a second project need? | Use judgement — refine and tweak once established | Protocol is a starting point; expect it to evolve during hello/RIN proving |
+| 3 | Mono-repo or multi-repo extraction? | Agree (multi-repo) | Confirmed: multi-repo is the proof topology |
+| 4 | How to share tmux session layouts? | Option B — auto-generated from adapter | Core generates layout from `lane_pools()`; no manual layout maintenance |
+| 5 | CI/CD: shared workflows or per-project? | Makes sense for reusable workflows | Core provides callable workflow templates; projects invoke with adapter config |
+| 6 | Which second project? | Hello-steward (smoke) + RIN balance sheet (full) + outside GH validation | Three-tier proving: synthetic → real → external |
+
+## Implementation Plan (Tightened)
+
+The original scope lock proposed a 5-PR / ~9h implementation estimate with a
+linear structure. The operator's feedback tightens this to a 4-phase plan that
+front-loads the risky work:
+
+### Phase 1 — Brutal Extraction (2–3h)
+
+Move everything "probably generic" into `core/`. Don't overthink the interface.
+Just make Bid-Euchre work via its adapter.
+
+**Key constraint:** This is a mechanical move, not a design exercise. The
+interface will be wrong — that's expected. Get the split done so Phases 2–3
+can break it.
+
+- Extract core modules from `src/bid_euchre/ops/` → `src/bid_euchre/ops/core/`
+- Create `adapters/bid_euchre.py` with all project-specific config
+- Verify Bid-Euchre steward still boots and operates correctly via adapter
+- PRs: 1–2 (extraction + adapter wiring)
+
+### Phase 2 — Hello Project (2h)
+
+Create `hello-steward` repo. Write minimal adapter. Expect it to break.
+Patch the interface until it runs clean.
+
+- Create hello-steward repo on GitHub
+- Implement `HelloAdapter` (2 author lanes, 1 orchestrator lane)
+- Boot steward, dispatch a task, verify lifecycle: task → dispatch → PR → merge
+- Log every adapter call; check for leaks
+- PRs: 1 (adapter) + external repo setup
+
+### Phase 3 — Stress Test (3–4h)
+
+RIN balance sheet project. Force: failure, retry, PR rejection.
+
+- Operator provides data sources and methodology
+- Build MVP: scrape + balance sheet (enough to have real tests)
+- Create `RINAdapter` and boot steward against it
+- **Mandatory failure cases:**
+  - 1 failed test cycle (test suite breaks, steward handles recovery)
+  - 1 rejected PR (review finds issues, steward retries)
+  - 1 retry loop (transient failure, steward recovers)
+- Document every adapter call that required protocol expansion
+- PRs: 1–2 (adapter + core fixes from leak discoveries)
+
+### Phase 4 — Formalize Interface (1–2h)
+
+Only now, after Phases 1–3 have beaten the interface into shape, lock the
+`ProjectAdapter` protocol.
+
+- Finalize protocol with translation layer methods proven needed
+- Document adapter implementation guide
+- Write extraction experience report: what was easy, what broke, what's missing
+- PRs: 1 (protocol lock + docs)
+
+**Total estimate:** ~8–11h across 5–7 PRs (this repo) + 2 external repos
+
+### Analyst Pushback
+
+The operator's 4-phase plan is stronger than the original linear structure. Two
+areas where the analyst perspective adds nuance:
+
+1. **Phase 1 "brutal extraction" vs. Platform-10 dependency.** The governing
+   plan places Platform-13 after Platform-10. If Platform-10 has already
+   performed the core/adapter split, Phase 1 becomes "verify and extend" rather
+   than "move everything." If Platform-10 has NOT landed, Phase 1 becomes the
+   extraction itself, which is Platform-10's job. Recommendation: Platform-13
+   Phase 1 should adapt to whatever state Platform-10 leaves the codebase in,
+   not re-do the split.
+
+2. **Phase 3 scope.** The RIN balance sheet project requires operator input
+   (data sources, methodology). This creates a dependency that could block
+   Phase 3. Recommendation: Phase 2 (hello-steward) should be considered the
+   minimum viable proof for Platform-13 COMPLETE status. Phase 3 can proceed
+   as a strengthening exercise once operator provides the RIN project spec, but
+   should not gate completion of the platform step if it's blocked on operator
+   availability.
+
+## Shared Infrastructure Requirements
 
 | Infrastructure | Shared or Per-Project | Notes |
 |----------------|----------------------|-------|
-| tmux session layout | Per-project (generated from adapter) | Template in core, customized by adapter |
-| CI workflows | Per-project | Core provides workflow templates, project customizes |
-| Review loop | Shared (core) | Same Codex CLI review, different repo target |
-| Message bus | Per-project (separate `.claude/runtime/`) | Same code, different runtime directory |
+| tmux session layout | Per-project (generated from adapter `lane_pools()`) | Template in core, customized by adapter |
+| CI workflows | Per-project (from core templates) | Core provides callable workflows, project customizes |
+| Review loop | Shared (core) | Same review machinery, different repo target |
+| Message bus | Per-project (separate `.claude/runtime/`) | Same code, isolated runtime directory |
 | Token economy | Shared aggregation, per-project data | Cross-project dashboard possible |
 | Skill files | Per-project (`.claude/skills/`) | Core promotion pipeline, project-specific skills |
 
-## Open Questions (for operator)
-
-1. **Which ops modules are truly project-agnostic?**
-   - Needs an audit against Platform-10's boundary. Some modules that seem
-     generic may have subtle Bid-Euchre assumptions.
-   - **Action:** After Platform-10 lands, run a grep-based dependency audit
-     of core/ imports to verify no adapter leakage.
-
-2. **What adapter interface does a second project need to implement?**
-   - The `ProjectAdapter` protocol above is a proposal. Needs review against
-     actual core module consumption patterns.
-   - **Action:** Draft the protocol, then validate by checking every place
-     core modules access project-specific config.
-
-3. **Mono-repo or multi-repo extraction?**
-   - **Recommendation:** Multi-repo. The whole point is proving the boundary
-     works across repo boundaries. A mono-repo extraction proves nothing.
-
-4. **How to share tmux session layouts across projects?**
-   - Option A: Template in core, project fills in lane names/counts
-   - Option B: Core generates layout from adapter's `lane_pools()` method
-   - **Recommendation:** Option B — auto-generated from adapter config. Less
-     manual maintenance, proves the adapter contract covers layout needs.
-
-5. **CI/CD: shared workflows or per-project?**
-   - Core can provide reusable GitHub Actions (workflow_call) that projects
-     invoke with project-specific inputs
-   - **Recommendation:** Reusable workflows. The core provides
-     `.github/workflows/steward-ci.yml` as a callable workflow. Projects
-     invoke it with their adapter config.
-
-6. **Candidate second project — which one?**
-   - This is the biggest decision. Determines the scope and duration of the
-     extraction proof.
-   - **Recommendation:** Start with synthetic `steward-hello` (2h proof),
-     then graduate to a real project if the hello proof passes. This avoids
-     spending days on extraction proof only to find the adapter interface is
-     wrong.
-
 ## Dependencies
 
-- **Platform-10 (required):** Core-vs-adapter split must be complete before
-  extraction can be validated. Platform-13 literally depends on Platform-10's
-  output.
-- **Platform-11 (optional):** Learning loop data portability would be nice to
-  prove but not required for MVP.
+- **Platform-10 (required):** Core-vs-adapter split must be at least partially
+  complete before extraction can be validated. Platform-13 depends on
+  Platform-10's output. If Platform-10 has already landed the split, Phase 1
+  is verification. If not, Phase 1 must be sequenced after Platform-10.
+- **Platform-11 (optional):** Learning loop data portability would strengthen
+  the proof but is not required for MVP.
 - **Platform-12 (optional):** Cross-model routing portability would strengthen
   the proof but is not required for MVP.
-
-## Implementation Estimate
-
-| Slice | PRs | Lane-hours | Description |
-|-------|-----|------------|-------------|
-| Adapter protocol definition | 1 | 1.5h | `ProjectAdapter` protocol, type stubs, validation |
-| Bid-Euchre adapter (extract from inline) | 1 | 2h | Move hardcoded values to `adapters/bid_euchre.py` |
-| steward-hello repo setup | 0 (external) | 1h | Create the proof-of-concept repo |
-| Hello adapter implementation | 1 | 1.5h | `adapters/hello.py` implementing full protocol |
-| E2E boot + dispatch proof | 1 | 2h | Boot steward-hello, dispatch task, verify lifecycle |
-| Extraction experience report | 1 | 1h | Document gaps, pain points, missing docs |
-| **Total** | **5 PRs** (this repo) + external repo | **~9h** | |
+- **Operator (Phase 3):** RIN balance sheet data sources and methodology
+  definition. Phase 3 cannot start without this.
 
 ## Risks
 
 1. **Platform-10 boundary is wrong.** If the core-vs-adapter split from
    Platform-10 doesn't cleanly separate concerns, Platform-13 will discover
-   leaky abstractions. This is actually the desired outcome — the extraction
-   proof is specifically designed to find these leaks. But it means Platform-13
-   may generate follow-up work for Platform-10/14.
+   leaky abstractions. This is the desired outcome — the extraction proof is
+   specifically designed to find these leaks. But it means Platform-13 may
+   generate follow-up work for Platform-10/14.
 
-2. **External repo management overhead.** Creating and maintaining a second repo
-   adds operational burden. Mitigation: keep `steward-hello` minimal (3 source
-   files, 10 tests). It's a proof, not a real project.
+2. **External repo management overhead.** Two external repos (hello-steward,
+   RIN balance sheet) add operational burden. Mitigation: hello-steward is
+   minimal (3 source files, 10 tests). RIN balance sheet is MVP only.
 
 3. **Claude Code multi-repo limitations.** Claude Code sessions are typically
    scoped to one repo. Running steward across two repos may require creative
-   worktree management or multiple Claude instances. Mitigation: the steward
-   already manages multiple worktrees within one repo — cross-repo is an
-   extension of the same pattern.
+   worktree management or multiple Claude instances. Mitigation: explicit repo
+   root scoping and runtime isolation (see Multi-Repo Runtime Isolation above).
 
-4. **Adapter interface instability.** The protocol may change as Platform-10
-   evolves, invalidating early Platform-13 work. Mitigation: Platform-13
-   should wait until Platform-10 reaches COMPLETE before starting
-   implementation.
+4. **Adapter interface instability.** The protocol will change during Phases
+   2–3. This is expected and correct — the interface should be shaped by
+   contact with real projects, not by upfront design.
 
-5. **Scope creep into a real second project.** The extraction proof should be
-   minimal and bounded. A real chess engine or data pipeline has its own
-   complexity that could distract from the extraction signal. Mitigation: start
-   with `steward-hello`, only escalate to a real project if the hello proof
-   passes cleanly.
+5. **Operator dependency for Phase 3.** The RIN balance sheet project requires
+   operator-provided data sources and methodology. If operator availability is
+   limited, Phase 3 may be delayed. Mitigation: Phase 2 (hello-steward) is the
+   minimum viable proof; Phase 3 strengthens but does not gate completion.
+
+6. **"Core is generic" — probably not yet.** The most dangerous risk is
+   believing the abstraction is clean before proving it. The anti-leak testing
+   methodology (log every adapter call, assert no project-specific branching in
+   core) is the primary mitigation. Don't fall into: "We designed a clean
+   abstraction, therefore it is clean."

--- a/platform13_feedback.md
+++ b/platform13_feedback.md
@@ -1,0 +1,107 @@
+# Operator Feedback on Platform-13 Second-Project Extraction Scope Lock
+
+## Second Project Candidate Evaluation
+
+### Smoke Test
+Synthetic proof project. Create a minimal "hello-steward" project with a trivial test suite, a Makefile, and 2-3 source files. Proves the adapter interface works without real project overhead.
+
+### Full Test
+Project: Build a Commodities Balance Sheet based on Publicly Available RIN Data.
+- User will define data sources and methodology
+- Only need an MVP for proving — scrape, build balance sheet, etc. is enough
+
+### Outside Validation
+Ship to a friend to see if they can use it for their project by downloading from GH.
+
+## Point-by-Point on Open Questions
+
+1. Agent should review and assess the bid-euchre assumptions built into the platform boundary
+2. Use judgement for the project adapter protocol — refine and tweak once established
+3. Agree
+4. Option B
+5. Makes sense for reusable workflows
+
+## Core Strength — Don't Lose This
+
+"Platform-13 proves the boundary by running on a second project."
+
+That's the right forcing function. Not docs, not architecture diagrams — execution in a foreign environment. If this works, you've built a reusable orchestration system. If it fails, you've exposed hidden coupling. Both are wins.
+
+## Where This Will Break (Expect It)
+
+### 1. Adapter Contract is Too Clean
+In practice you'll hit:
+- Hidden filesystem assumptions
+- Implicit repo structure dependencies
+- Hardcoded expectations about .claude/ layout, PR flow timing, branch naming, test output formats
+
+The adapter will need to TRANSLATE mismatches:
+```
+def normalize_test_output(self, raw_output: str) -> TestResult: ...
+def resolve_repo_paths(self) -> RepoLayout: ...
+def pr_creation_strategy(self) -> PRStrategy: ...
+```
+Without this, Bid-Euchre assumptions sneak back into core/.
+
+### 2. "Core is Generic" — Probably Not Yet
+High-risk modules that likely leak project assumptions:
+- task_queue.py → lane semantics and naming
+- monitor.py → PR/CI expectations
+- worker_pool.py → worktree + repo structure coupling
+
+Better test than grep audit: Run the hello project and LOG EVERY ADAPTER CALL. If core ever branches on project behavior or assumes structure not provided by adapter → that's a leak.
+
+### 3. Hello Project — Correct but Incomplete
+Toy project proves: boot works, dispatch works, PR loop works.
+Does NOT prove: monitoring robustness, failure handling, scheduling, concurrency edge cases.
+
+**Two-step proof (non-negotiable):**
+1. Hello project (fast fail)
+2. One "slightly annoying" real project — 20-50 files, non-trivial tests, at least one failing edge case. That's where abstractions crack.
+
+### 4. Packaging — Too Far Ahead
+Premature to think about PyPI/git install/versioning. Only question now: Can core run outside the original repo without hacks?
+
+**Recommendation:** Hardcode `pip install -e ../core`. Ignore distribution for Platform-13.
+
+### 5. Biggest Hidden Risk: Claude Code Multi-Repo
+More serious than treated. System assumes one repo context, one working directory, one .claude/runtime. Cross-repo introduces path ambiguity, state separation.
+
+Need:
+- Explicit repo root scoping in core
+- Strict runtime isolation per project
+- No reliance on cwd
+
+### Missing: Clear Success Criteria
+
+"task → PR → review → merge works" is not enough.
+
+**Platform-13 is DONE when:**
+- A second repo runs steward without modifying core/
+- Adapter is ≤ ~150-250 LOC
+- No Bid-Euchre strings appear in core runtime logs
+- System survives: 1 failed test cycle, 1 rejected PR, 1 retry loop
+
+If you don't include failure cases, you certify a brittle system.
+
+## Recommended Tightened Plan
+
+### Phase 1 — Brutal Extraction (2-3h)
+Move everything "probably generic" into core. Don't overthink interface. Just make Bid-Euchre work via adapter.
+
+### Phase 2 — Hello Project (2h)
+Minimal adapter. Expect it to break. Patch interface until it runs clean.
+
+### Phase 3 — Stress Test (3-4h)
+Slightly real project. Force: failure, retry, PR rejection.
+
+### Phase 4 — Only Then Formalize Interface
+Lock ProjectAdapter. Document it.
+
+## Bottom Line
+
+Don't fall into: "We designed a clean abstraction, therefore it is clean."
+
+This platform only becomes legitimate if the second project forces changes to core, and you accept and integrate those changes. If Platform-13 doesn't hurt a little, it didn't do its job.
+
+**Analyst should review and push back where it disagrees.**


### PR DESCRIPTION
## Summary
Updates the Platform-13 second-project extraction scope lock with the operator feedback round captured on 2026-03-25.

## Details
- tightens success criteria around second-repo execution
- emphasizes boundary-proof through real adapter pressure and failure cases
- sequences hello-project proof before the more realistic second project
- includes the operator feedback note for traceability

## Validation
Plan/doc update only.

## Notes
Draft PR for auditability and follow-through on the active Author-c lane.