### PR TITLE
docs(ops): route investigation work through analyst lanes

### DIFF
--- a/.claude/skills/delegate-task/SKILL.md
+++ b/.claude/skills/delegate-task/SKILL.md
@@ -24,7 +24,8 @@ intake-to-dispatch flow into a reusable workflow.
    - **description:** Full task description with acceptance criteria
    - **owner:** Target worker lane. Platform pool: `author-a` through
      `author-d`. Browser-game pool: `brws-author-a` through `brws-author-d`.
-     Flex pool: `author-scratch`, `flex-a`, `flex-b`, `flex-c`.
+     Analyst pool: `analyst-a` through `analyst-d`.
+     Flex pool: `flex-a`, `flex-b`, `flex-c`.
    - **scope_declared:** File patterns that will be touched
    - **validation:** Commands the author must run (e.g., specific test files)
    - **priority:** low / normal / high
@@ -38,7 +39,8 @@ intake-to-dispatch flow into a reusable workflow.
    | Single-file bugfix | No | Any idle author in matching pool | Infer |
    | Multi-file feature | Yes | author-a or author-b | platform |
    | Architectural change | Yes + plan review | author-a | platform |
-   | Exploratory analysis | No | author-scratch or flex-* | (flex) |
+   | Investigation / shaping | No | analyst-a through analyst-d | (flex) |
+   | Plan review / triage | No | analyst-a through analyst-d | (flex) |
    | Overflow / parallel work | Yes | author-c, author-d, or flex-* | Match source |
    | Browser-game work | Yes | brws-author-a through brws-author-d | browser-game |
 

--- a/.claude/skills/run-fleet/SKILL.md
+++ b/.claude/skills/run-fleet/SKILL.md
@@ -120,7 +120,8 @@ Rules:
 
 ## Analyst Routing
 
-Use `steward-analyst` when work needs deeper shaping before execution:
+Use analyst lanes (`analyst-a` through `analyst-d`) when work needs deeper
+shaping before execution:
 
 - new sub-plans or major plan refreshes
 - unclear implementation seams
@@ -128,6 +129,20 @@ Use `steward-analyst` when work needs deeper shaping before execution:
 - complex issue bundles that need richer evidence and PR decomposition
 - restart or end-of-run handoffs
 - plan/checkpoint/task-list drift relative to repo state
+
+**Dispatch method:** Use `task dispatch` for analyst lanes — they are fully
+registered in `KNOWN_AUTHOR_LANES` and support the same dispatch lifecycle as
+author lanes (auto-refresh, /clear, /start-task nudge). Do NOT fall back to
+raw `tmux send-keys` for analyst dispatch — this bypasses /clear, inbox
+tracking, and task lifecycle management.
+
+```bash
+# Correct: use task dispatch (same as author lanes)
+uv run python scripts/internal/ops.py task dispatch <packet_id> analyst-a --approve
+
+# Wrong: raw tmux send-keys (bypasses /clear and task lifecycle)
+tmux send-keys -t steward:analyst.1 "investigate X" Enter
+```
 
 Expected analyst outputs:
 


### PR DESCRIPTION
## Summary
Documents the analyst-lane routing change so investigation, shaping, and plan review work flow through analyst lanes instead of ad-hoc dispatch.

## Details
- updates dispatch guidance to point investigation/triage work to analyst lanes
- clarifies analyst dispatch expectations in the fleet-running skill

## Validation
Docs update only.

## Notes
Draft PR for auditability and follow-through on the active Flex-c lane.