### PR TITLE
docs(ops): add issue 1775 triage handoff

### DIFF
--- a/plans/sessions/2026-03-25_issue-1775-triage.md
+++ b/plans/sessions/2026-03-25_issue-1775-triage.md
@@ -1,0 +1,144 @@
+# Triage: Issue #1775 — Stale-Lane Alert Severity
+
+**Date:** 2026-03-25
+**Issue:** ops: raise stale-lane alert to HIGH only when ALL author/analyst lanes idle >90min
+**Triaged by:** analyst lane
+
+---
+
+## Problem Statement
+
+The dashboard and supervisor raise a `[medium]` (HIGH) attention item for
+**every** individual lane that is stale >30 min. During normal fleet operation,
+unused lanes are stale by design. This floods the orchestrator inbox with ~14
+false-positive `supervisor_alert` messages per monitor cycle, drowning out real
+issues.
+
+## Interaction with #1774 (Idle Detector Control-Plane Exclusion)
+
+**#1774** targets `idle_detector.py` — the fleet-level *shutoff* decision. It
+asks: "does `is_fleet_idle()` correctly exclude control-plane lanes
+(orchestrator, ops, review) from the idle calculation?"
+
+**#1775** targets the *dashboard/supervisor attention severity* logic. It asks:
+"should a single idle lane produce HIGH or just WARN?"
+
+These are **adjacent but disjoint**:
+
+| Issue | Subsystem | Function | Change |
+|-------|-----------|----------|--------|
+| #1774 | `idle_detector.py` | `_get_active_lane_ids()` | Filter out control-plane lanes from `active_lanes` list |
+| #1775 | `dashboard.py` + `status.py` | `_derive_attention_items()` + `synthesize_lane_activity()` | Change per-lane stale severity from `medium` → `low`; add new all-lanes-idle check at `medium` |
+
+**Recommendation:** Implement as two separate PRs. They share no file edits.
+#1774 should land first since #1775's "all author lanes idle" check implicitly
+depends on knowing which lanes are implementation vs control-plane.
+
+## Implementation Seam
+
+### Files to change
+
+| File | Change | Risk |
+|------|--------|------|
+| `src/bid_euchre/ops/dashboard.py` | `_derive_attention_items()` — change stale lanes from `severity="medium"` to `severity="low"`. Add new aggregate check: if ALL implementation lanes are stale >90min, emit `severity="medium"` | Low — localized function |
+| `src/bid_euchre/ops/status.py` | `synthesize_lane_activity()` — potentially adjust `attention_needed` flag for stale lanes (currently True for stale), or leave True and let dashboard downgrade severity | Low — only if severity needs to change at source |
+| `src/bid_euchre/ops/supervisor.py` | `_build_recommendations()` — verify `"degraded"` health for stale lanes doesn't produce excessively noisy recommendations. May not need changes. | Low |
+
+### Key code locations
+
+**`dashboard.py:_derive_attention_items()` (lines 212-267):**
+This is the primary target. Current logic:
+
+```python
+elif lane.state == "stale" or ("stale" in reason.lower() if reason else False):
+    items.append(
+        AttentionItem(
+            lane_id=lane.lane_id,
+            severity="medium",   # <-- change to "low"
+            reason=reason,
+            suggested_action="check if agent died",
+        )
+    )
+```
+
+**New aggregate check needed (after the per-lane loop):**
+
+```python
+# After building per-lane items, check if ALL implementation lanes are stale
+impl_lanes = [l for l in report.lanes if l.lane_id in IMPLEMENTATION_LANE_IDS]
+if impl_lanes and all(l.state == "stale" for l in impl_lanes):
+    # Check if the staleness exceeds the fleet-wide threshold (90min)
+    # This requires accessing lane ages or idle_detector
+    items.append(AttentionItem(
+        lane_id="_fleet",
+        severity="medium",
+        reason="All implementation lanes idle >90min",
+        suggested_action="check if fleet is stuck",
+    ))
+```
+
+**Dependency: lane classification.**
+There is no existing `IMPLEMENTATION_LANE_IDS` constant. The closest are:
+- `task_queue.KNOWN_AUTHOR_LANES` — exact match for implementation lanes
+- `monitor._CHECKABLE_LANES` — same set as a tuple
+- `dashboard.FOREGROUND_LANE_IDS` — control-plane lanes (inverse)
+
+Best option: import `KNOWN_AUTHOR_LANES` from `task_queue.py` in `dashboard.py`
+for the aggregate check. This is already the canonical lane classification.
+
+### STALE_MINUTES threshold
+
+The per-lane staleness threshold is `STALE_MINUTES = 30` in `status.py` (line 28).
+The fleet-wide threshold for #1775 is 90 minutes.
+
+**Recommendation:** Add `ALL_STALE_THRESHOLD_MINUTES = 90` to `dashboard.py` or
+pass it through `_derive_attention_items()`. Do NOT change `STALE_MINUTES` in
+`status.py` — that still controls when individual lanes are classified as stale.
+
+## Acceptance Criteria (from issue, refined)
+
+- [ ] Individual stale lanes produce `severity="low"` in dashboard attention
+- [ ] `severity="medium"` fires only when ALL author/analyst lanes (from `KNOWN_AUTHOR_LANES`) are stale >90min
+- [ ] Control-plane lanes (orchestrator, ops, review) are NOT counted in the aggregate check
+- [ ] Dashboard `format_dashboard_text()` correctly renders `[low]` and `[medium]` items
+- [ ] Existing tests updated or new tests added for both severity levels
+- [ ] `make check` passes
+
+## Validation Commands
+
+```bash
+# Tier 1 — during implementation
+uv run python -m pytest tests/unit/test_ops_dashboard.py -v
+uv run python -m pytest tests/unit/test_ops_status.py -v -k "stale"
+
+# Tier 2 — before PR
+make check-quiet
+```
+
+## Known Risks
+
+1. **Supervisor noise may persist.** `supervisor.py:_build_recommendations()`
+   also classifies stale lanes as `"degraded"` and may emit recovery
+   recommendations. Verify whether the recommendation severity should also be
+   downgraded from `"medium"` to `"low"` for individual stale lanes.
+
+2. **Dashboard `warning_count` metric.** Verify that the `warning_count` in
+   `DashboardView` still reflects the correct count after severity changes.
+
+3. **`supervisor_alert` messages.** The monitor cycle sends `supervisor_alert`
+   messages to the orchestrator inbox for attention items. Confirm these also
+   use the new severity so inbox noise is reduced.
+
+## Recommended PR Decomposition
+
+**Single PR** — scope is small (1-2 files, ~30 lines changed). No need to decompose.
+
+**PR title:** `fix(ops): downgrade individual stale-lane alerts to WARN, add fleet-wide HIGH`
+
+**Estimated time:** 30-45 min (implementation + tests)
+**Lane assignment:** Any available author/flex lane
+
+## Dependency Order
+
+1. #1774 first (adds control-plane lane filtering to idle_detector)
+2. #1775 second (changes severity logic in dashboard, can use lane classification)


### PR DESCRIPTION
## Summary
Adds the analyst triage note for issue #1775 so the stale-lane severity follow-up has a durable handoff artifact in the PR/CI trail.

## Details
- documents the issue split between #1774 and #1775
- identifies the likely implementation seam in dashboard/status/supervisor
- records acceptance criteria, risks, and validation commands

## Validation
Docs note only.

## Notes
Small draft PR for auditability of the analyst handoff artifact.