### PR TITLE
Improve hosted-play UI surface: trick feed, pacing, card selection

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -287,6 +287,30 @@ class TestBidPanel:
         )
         assert "bid-type-badge--loner" in html
 
+    def test_bid_panel_includes_ai_pace_controls(self, env):
+        tmpl = env.get_template("partials/bid_panel.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=0,
+            auction=[],
+            current_high_bid=0,
+            dealer_seat=0,
+        )
+        assert 'id="ai-pace-control"' in html
+        assert 'name="ai_pace"' in html
+
+    def test_bid_form_is_paced(self, env):
+        tmpl = env.get_template("partials/bid_panel.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=0,
+            auction=[],
+            current_high_bid=0,
+            dealer_seat=0,
+        )
+        assert 'id="bid-form"' in html
+        assert 'data-paced="true"' in html
+
 
 # ---------------------------------------------------------------------------
 # hand.html
@@ -312,8 +336,8 @@ class TestHand:
         # No card--legal or card--illegal during auction (plain cards)
         assert "card--legal" not in html
 
-    def test_legal_cards_are_form_buttons(self, env):
-        """During trick play, legal cards are form buttons."""
+    def test_legal_cards_use_shared_play_form(self, env):
+        """During trick play, legal cards submit via shared play form."""
         tmpl = env.get_template("partials/hand.html")
         html = tmpl.render(
             link_uuid="abc-123",
@@ -322,11 +346,19 @@ class TestHand:
             legal_plays=[0, 2],  # First and third cards are legal
             phase="trick_play",
         )
-        # Legal cards have form with hx-post
+        # Shared play-card form with hidden turn/card inputs
+        assert 'id="play-card-form"' in html
         assert 'hx-post="/play/abc-123/play-card"' in html
-        assert 'name="card_index" value="0"' in html
-        assert 'name="card_index" value="2"' in html
+        assert 'id="selected-card-index" name="card_index" value=""' in html
+        assert 'id="play-card-submit"' in html
+        # Selectable legal cards carry positional metadata
+        assert 'data-card-index="0"' in html
+        assert 'data-card-index="2"' in html
         assert "card--legal" in html
+        assert "card--playable" in html
+        # No per-card form payloads should remain.
+        assert 'name="card_index" value="0"' not in html
+        assert 'name="card_index" value="2"' not in html
 
     def test_illegal_cards_are_divs(self, env):
         """During trick play, illegal cards are plain divs."""
@@ -340,7 +372,7 @@ class TestHand:
         )
         assert "card--illegal" in html
         # card_index=1 should NOT appear in a form
-        assert 'name="card_index" value="1"' not in html
+        assert 'data-card-index="1"' not in html
 
     def test_turn_number_in_forms(self, env):
         tmpl = env.get_template("partials/hand.html")
@@ -352,6 +384,17 @@ class TestHand:
             phase="trick_play",
         )
         assert 'name="turn_number" value="42"' in html
+
+    def test_play_form_shows_selection_help(self, env):
+        tmpl = env.get_template("partials/hand.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=8,
+            human_hand=[["S", "A"], ["H", "K"]],
+            legal_plays=[0],
+            phase="trick_play",
+        )
+        assert "Tap a legal card to select, then confirm." in html
 
 
 # ---------------------------------------------------------------------------
@@ -411,6 +454,60 @@ class TestTrick:
             tricks_team1=2,
         )
         assert "trick-area" in html
+
+    def test_trick_shows_seat_markers(self, env):
+        tmpl = env.get_template("partials/trick.html")
+        html = tmpl.render(
+            current_trick={"leader": 2, "plays": [[2, ["H", "A"]]]},
+            completed_tricks=[],
+            tricks_team0=0,
+            tricks_team1=0,
+            bidder_seat=0,
+            dealer_seat=3,
+            current_seat=1,
+            sitting_out_seat=1,
+        )
+        assert "DEC" in html
+        assert "D" in html
+        assert "TURN" in html
+        assert "SIT" in html
+
+
+class TestActionFeed:
+    """Verify action feed component content."""
+
+    def test_action_feed_shows_auction(self, env):
+        tmpl = env.get_template("partials/action_feed.html")
+        html = tmpl.render(
+            auction=[
+                {
+                    "seat": 0,
+                    "action": "bid",
+                    "n": 8,
+                    "bid_type": "moon",
+                    "contract": "S",
+                },
+                {"seat": 1, "action": "pass"},
+            ],
+            completed_tricks=[],
+            current_trick={"leader": 1, "plays": []},
+            phase="trick_play",
+        )
+        assert "Action feed" in html
+        assert "You" in html
+        assert "bid 8 moon" in html
+        assert "passed" in html
+        assert "Current trick in progress" in html
+
+    def test_action_feed_starts_empty(self, env):
+        tmpl = env.get_template("partials/action_feed.html")
+        html = tmpl.render(
+            auction=[],
+            completed_tricks=[],
+            current_trick=None,
+            phase="auction",
+        )
+        assert "Auction starting" in html
 
 
 # ---------------------------------------------------------------------------
@@ -770,6 +867,35 @@ class TestHandResult:
             hands_played=1,
         )
         assert "hand-result--animated" in html
+
+    def test_hand_result_includes_last_trick(self, env):
+        html = env.get_template("partials/hand_result.html").render(
+            winning_bid=6,
+            bidder_seat=0,
+            contract_type="suit",
+            trump="S",
+            tricks_team0=7,
+            tricks_team1=3,
+            points_team0=7,
+            points_team1=3,
+            score_human=7,
+            score_ai=3,
+            hands_played=1,
+            completed_tricks=[
+                {
+                    "leader": 0,
+                    "plays": [
+                        [0, ["S", "A"]],
+                        [1, ["H", "K"]],
+                        [2, ["D", "J"]],
+                        [3, ["C", "Q"]],
+                    ],
+                    "winner": 0,
+                }
+            ],
+        )
+        assert "Last trick" in html
+        assert "Trick 1 of 10" in html
 
 
 # ---------------------------------------------------------------------------

--- a/web/static/css/accessibility.css
+++ b/web/static/css/accessibility.css
@@ -57,6 +57,12 @@ button.card--legal:focus-visible {
     box-shadow: 0 0 0 6px rgba(76, 175, 80, 0.3);
 }
 
+button.card--playable:focus-visible {
+    outline: 3px solid var(--color-legal-glow, #4caf50);
+    outline-offset: 3px;
+    box-shadow: 0 0 0 6px rgba(76, 175, 80, 0.3);
+}
+
 /* Bid controls — visible ring on selects and buttons */
 .bid-controls select:focus-visible,
 .bid-controls button:focus-visible {
@@ -84,6 +90,12 @@ select:focus-visible {
     box-shadow: 0 0 0 6px rgba(76, 175, 80, 0.3);
 }
 
+.btn--play-card:focus-visible {
+    outline: 3px solid var(--color-legal-glow, #4caf50);
+    outline-offset: 3px;
+    box-shadow: 0 0 0 6px rgba(76, 175, 80, 0.3);
+}
+
 /* --------------------------------------------------------------------------
    3. Touch Target Minimums (44x44px per WCAG 2.5.5)
    --------------------------------------------------------------------------
@@ -104,6 +116,11 @@ select:focus-visible {
         min-height: 44px;
         min-width: 44px;
         padding: 0.6rem 1.25rem;
+    }
+
+    .card--playable {
+        min-width: 44px;
+        min-height: 44px;
     }
 
     /* Select dropdowns */
@@ -132,6 +149,18 @@ select:focus-visible {
         min-height: 48px;
         padding: 0.75rem 2rem;
     }
+
+    #play-card-submit,
+    .btn--play-card {
+        min-height: 44px;
+        padding-top: 0.55rem;
+        padding-bottom: 0.55rem;
+    }
+
+    #ai-pace-control {
+        min-height: 44px;
+        min-width: 110px;
+    }
 }
 
 /* --------------------------------------------------------------------------
@@ -148,6 +177,10 @@ select:focus-visible {
         transform: none;
     }
 
+    .card--playable:hover {
+        transform: none;
+    }
+
     /* Suppress button hover lift */
     .btn:hover {
         transform: none;
@@ -157,6 +190,7 @@ select:focus-visible {
     .card,
     .btn,
     .bid-controls button,
+    .btn--play-card,
     #nickname-form button,
     #model-select button {
         transition: none;

--- a/web/static/game.js
+++ b/web/static/game.js
@@ -1,14 +1,10 @@
 /**
  * Bid Euchre Browser Game — Client-side JavaScript
  *
- * Minimal vanilla JS (no build tooling):
- * 1. Decision timer — records how long the human takes to act
- * 2. HTMX swap hooks — resets timer on new decision prompts
- * 3. Card click handler — visual feedback on interaction
- * 4. AI response pacing — configurable delay for moon/loner bids
- *
- * The decision_time_ms hidden input is injected into every bid/play form
- * submission so the server can record human decision latency.
+ * - Decision timer logging
+ * - Card tap-select + confirm for human hand play
+ * - AI pacing controls + adjustable delay profiles
+ * - Optional pacing indicator during delayed AI response simulation
  */
 
 (function () {
@@ -18,55 +14,37 @@
     // Configuration
     // -----------------------------------------------------------------------
 
-    /**
-     * AI pacing delay range in milliseconds.
-     * After a human submits a moon or loner bid, a brief delay is added
-     * before the HTMX response is processed to give a sense of AI
-     * deliberation.  Regular bids get a shorter delay.
-     */
-    var PACING = {
-        moonMinMs: 800,
-        moonMaxMs: 1500,
-        lonerMinMs: 1000,
-        lonerMaxMs: 2000,
-        regularMinMs: 300,
-        regularMaxMs: 600
+    /** Storage key for AI pacing profile preference. */
+    var STORAGE_KEY = "bid_euchre_ai_pace";
+
+    /** Delay presets (milliseconds, before card resolution request is sent). */
+    var PACING_PRESETS = {
+        instant: { multiplier: 0, regularMinMs: 0, regularMaxMs: 0, moonMinMs: 0, moonMaxMs: 0, lonerMinMs: 0, lonerMaxMs: 0 },
+        fast: { multiplier: 0.6, regularMinMs: 200, regularMaxMs: 450, moonMinMs: 450, moonMaxMs: 800, lonerMinMs: 550, lonerMaxMs: 1100 },
+        normal: { multiplier: 1.0, regularMinMs: 300, regularMaxMs: 600, moonMinMs: 800, moonMaxMs: 1500, lonerMinMs: 1000, lonerMaxMs: 2000 },
+        slow: { multiplier: 1.5, regularMinMs: 500, regularMaxMs: 950, moonMinMs: 1200, moonMaxMs: 2200, lonerMinMs: 1400, lonerMaxMs: 2800 },
     };
+
+    // -----------------------------------------------------------------------
+    // State
+    // -----------------------------------------------------------------------
+
+    var decisionStart = Date.now();
 
     // -----------------------------------------------------------------------
     // Decision Timer
     // -----------------------------------------------------------------------
 
-    /** Timestamp (ms) when the current decision prompt was loaded. */
-    var decisionStart = Date.now();
-
-    /**
-     * Reset the decision timer.  Called on page load and after each HTMX swap
-     * that delivers a new decision prompt.
-     */
     function resetTimer() {
         decisionStart = Date.now();
     }
 
-    /**
-     * Inject a hidden `decision_time_ms` input into the form that is about to
-     * submit.  HTMX fires `htmx:beforeRequest` on the element with the
-     * `hx-post` attribute — which may be a <form> or a child <button>.
-     *
-     * We walk up to the enclosing <form> to ensure the input is added in the
-     * right place.  If a previous hidden input already exists (e.g. from a
-     * duplicate event), we update its value rather than creating a second one.
-     *
-     * @param {CustomEvent} evt — htmx:beforeRequest event
-     */
     function injectDecisionTime(evt) {
         var form = evt.target.closest("form");
         if (!form) {
             return;
         }
-
         var elapsed = Date.now() - decisionStart;
-
         var existing = form.querySelector('input[name="decision_time_ms"]');
         if (existing) {
             existing.value = elapsed;
@@ -80,72 +58,80 @@
     }
 
     // -----------------------------------------------------------------------
-    // AI Response Pacing
+    // Pace controls
     // -----------------------------------------------------------------------
 
-    /**
-     * Return a random integer in [min, max].
-     */
-    function randInt(min, max) {
-        return Math.floor(Math.random() * (max - min + 1)) + min;
+    function getPaceMode() {
+        var select = document.getElementById("ai-pace-control");
+        if (select && select.value in PACING_PRESETS) {
+            return select.value;
+        }
+        return "normal";
     }
 
-    /**
-     * Get the pacing delay for the current bid type.
-     * Reads the bid_type select value from the bid form if present.
-     *
-     * @param {Element} form — the form being submitted
-     * @returns {number} delay in milliseconds (0 for card plays)
-     */
-    function getPacingDelay(form) {
-        var action = form.getAttribute("action") || "";
+    function initPaceControl() {
+        var select = document.getElementById("ai-pace-control");
+        if (!select) {
+            return;
+        }
+        var saved = "normal";
+        try {
+            saved = window.localStorage.getItem(STORAGE_KEY) || "normal";
+        } catch (err) {
+            // localStorage may be unavailable in privacy modes.
+            saved = "normal";
+        }
+        if (saved in PACING_PRESETS) {
+            select.value = saved;
+        }
+    }
 
-        // Only pace bid submissions, not card plays
-        if (action.indexOf("/bid") === -1) {
+    function getPacingDelay(form) {
+        if (!(form && form.dataset && form.dataset.paced === "true")) {
+            return 0;
+        }
+        var mode = getPaceMode();
+        var preset = PACING_PRESETS[mode] || PACING_PRESETS.normal;
+        if (preset.multiplier === 0) {
             return 0;
         }
 
         var bidTypeSelect = form.querySelector('[name="bid_type"]');
-        if (!bidTypeSelect) {
-            return randInt(PACING.regularMinMs, PACING.regularMaxMs);
+        var bidType = bidTypeSelect ? bidTypeSelect.value : "regular";
+        var minMs = preset.regularMinMs;
+        var maxMs = preset.regularMaxMs;
+        if (bidType === "moon") {
+            minMs = preset.moonMinMs;
+            maxMs = preset.moonMaxMs;
+        } else if (bidType === "loner") {
+            minMs = preset.lonerMinMs;
+            maxMs = preset.lonerMaxMs;
         }
 
-        var bidType = bidTypeSelect.value;
-        if (bidType === "moon") {
-            return randInt(PACING.moonMinMs, PACING.moonMaxMs);
-        } else if (bidType === "loner") {
-            return randInt(PACING.lonerMinMs, PACING.lonerMaxMs);
-        }
-        return randInt(PACING.regularMinMs, PACING.regularMaxMs);
+        var scaledMin = Math.max(0, Math.round(minMs * preset.multiplier));
+        var scaledMax = Math.max(scaledMin, Math.round(maxMs * preset.multiplier));
+        return Math.floor(Math.random() * (scaledMax - scaledMin + 1)) + scaledMin;
     }
 
-    /**
-     * Show a pacing indicator during the AI delay.
-     * Creates a temporary element that displays "AI is thinking..." style
-     * text while the delayed response is pending.
-     */
     function showPacingIndicator() {
         var existing = document.getElementById("pacing-indicator");
         if (existing) {
             existing.classList.add("active");
             return existing;
         }
-
+        var control = document.querySelector(".pacing-controls");
         var indicator = document.createElement("div");
         indicator.id = "pacing-indicator";
         indicator.className = "pacing-indicator active";
         indicator.innerHTML = 'AI is considering<span class="pacing-dots"></span>';
-
-        var bidPanel = document.getElementById("bid-panel");
-        if (bidPanel) {
-            bidPanel.appendChild(indicator);
+        if (control) {
+            control.appendChild(indicator);
+            return indicator;
         }
+        document.body.appendChild(indicator);
         return indicator;
     }
 
-    /**
-     * Hide and remove the pacing indicator.
-     */
     function hidePacingIndicator() {
         var indicator = document.getElementById("pacing-indicator");
         if (indicator) {
@@ -153,75 +139,230 @@
         }
     }
 
-    /**
-     * Handle HTMX beforeSwap to apply pacing delay for bid submissions.
-     * This delays the DOM swap to create a deliberation effect.
-     *
-     * @param {CustomEvent} evt — htmx:beforeSwap event
-     */
-    function handlePacingBeforeRequest(evt) {
-        var form = evt.target.closest("form");
+    function clearPacingState(form) {
         if (!form) {
             return;
         }
+        if (form.dataset && form.dataset.queued === "1") {
+            form.dataset.queued = "0";
+            delete form.dataset.queued;
+        }
+    }
 
+    function onPaceModeChange(evt) {
+        var select = evt.target;
+        if (!select || !select.value) {
+            return;
+        }
+        if (!(select.value in PACING_PRESETS)) {
+            select.value = "normal";
+        }
+        try {
+            window.localStorage.setItem(STORAGE_KEY, select.value);
+        } catch (err) {
+            // Ignore — privacy mode might block storage writes.
+        }
+    }
+
+    function queuePacedSubmit(form) {
+        if (!form || form.dataset.queued === "1") {
+            return;
+        }
         var delay = getPacingDelay(form);
-        if (delay > 0) {
-            showPacingIndicator();
+        if (delay <= 0) {
+            form.dataset.queued = "1";
+            htmx.trigger(form, "submit");
+            return;
+        }
+
+        form.dataset.queued = "1";
+        showPacingIndicator();
+        setTimeout(function () {
+            htmx.trigger(form, "submit");
+        }, delay);
+    }
+
+    // -----------------------------------------------------------------------
+    // Card selection / play panel
+    // -----------------------------------------------------------------------
+
+    function isPlayCardForm(form) {
+        return form && form.id === "play-card-form";
+    }
+
+    function selectedCardLabel(form, value) {
+        if (!form) {
+            return null;
+        }
+        var buttons = form.querySelectorAll(".card--playable");
+        for (var i = 0; i < buttons.length; i += 1) {
+            if (buttons[i].getAttribute("data-card-index") === value) {
+                return buttons[i].getAttribute("data-card-text") || null;
+            }
+        }
+        return null;
+    }
+
+    function updatePlayState(form) {
+        if (!form) {
+            return;
+        }
+        var selected = form.querySelector("#selected-card-index");
+        var submit = form.querySelector("#play-card-submit");
+        var help = form.querySelector("#card-selection-help");
+        var idx = selected ? selected.value : "";
+        var hasSelection = idx !== "";
+
+        if (submit) {
+            submit.disabled = !hasSelection;
+        }
+
+        if (help) {
+            if (hasSelection) {
+                var label = selectedCardLabel(form, idx);
+                if (label) {
+                    help.textContent = "Selected: " + label + ".";
+                }
+            } else {
+                help.textContent = "Tap a legal card to select, then confirm.";
+            }
+        }
+    }
+
+    function clearSelectedCard(form) {
+        if (!form) {
+            return;
+        }
+        var cards = form.querySelectorAll(".card--playable");
+        for (var i = 0; i < cards.length; i += 1) {
+            cards[i].classList.remove("card--selected");
+        }
+        var selected = form.querySelector("#selected-card-index");
+        if (selected) {
+            selected.value = "";
+        }
+        updatePlayState(form);
+    }
+
+    function setSelectedCard(form, button, cardIndex) {
+        if (!form) {
+            return;
+        }
+        var selected = form.querySelector("#selected-card-index");
+        if (!selected) {
+            return;
+        }
+
+        var currentIdx = selected.value;
+        if (currentIdx) {
+            var prev = form.querySelector('[data-card-index="' + currentIdx + '"]');
+            if (prev) {
+                prev.classList.remove("card--selected");
+            }
+        }
+
+        button.classList.add("card--selected");
+        selected.value = cardIndex;
+        updatePlayState(form);
+    }
+
+    function onCardPlayableClick(evt) {
+        var target = evt.target.closest(".card--playable");
+        if (!target) {
+            return;
+        }
+        var form = document.getElementById("play-card-form");
+        var idx = target.getAttribute("data-card-index");
+        if (!form || !idx) {
+            return;
+        }
+        evt.preventDefault();
+        setSelectedCard(form, target, idx);
+    }
+
+    // -----------------------------------------------------------------------
+    // Event binding
+    // -----------------------------------------------------------------------
+
+    function bindCardControls() {
+        var cards = document.querySelectorAll(".card--playable");
+        for (var i = 0; i < cards.length; i += 1) {
+            cards[i].addEventListener("click", onCardPlayableClick);
+        }
+        var playForm = document.getElementById("play-card-form");
+        if (playForm) {
+            var selected = playForm.querySelector("#selected-card-index");
+            if (selected && selected.value === "") {
+                clearSelectedCard(playForm);
+            } else {
+                updatePlayState(playForm);
+            }
         }
     }
 
     // -----------------------------------------------------------------------
-    // Card Click Feedback
+    // HTMX lifecycle events
     // -----------------------------------------------------------------------
 
-    /**
-     * Add a brief pressed effect when a legal card button is clicked.
-     * The actual form submission is handled by HTMX — this is purely visual.
-     *
-     * @param {Event} evt — click event on a .card--legal button
-     */
-    function onCardClick(evt) {
-        var card = evt.currentTarget;
-        card.style.transform = "translateY(-4px) scale(0.95)";
-        // Let HTMX handle the rest; the card will be replaced on swap.
-    }
-
-    // -----------------------------------------------------------------------
-    // Event Binding
-    // -----------------------------------------------------------------------
-
-    /**
-     * Bind click handlers to all legal card buttons currently in the DOM.
-     * Called on page load and after each HTMX swap.
-     */
-    function bindCardHandlers() {
-        var cards = document.querySelectorAll("button.card--legal");
-        for (var i = 0; i < cards.length; i++) {
-            cards[i].addEventListener("click", onCardClick);
+    // Delay paced forms (currently bid form) to simulate AI thought time.
+    document.body.addEventListener("submit", function (evt) {
+        var form = evt.target.closest("form");
+        if (!form || form.dataset.paced !== "true" || form.dataset.queued === "1") {
+            return;
         }
-    }
-
-    // Listen for HTMX events on the document body (delegated).
-    // htmx:beforeRequest fires before any HTMX request — inject timer value
-    // and show pacing indicator.
-    document.body.addEventListener("htmx:beforeRequest", function (evt) {
-        injectDecisionTime(evt);
-        handlePacingBeforeRequest(evt);
+        evt.preventDefault();
+        queuePacedSubmit(form);
     });
 
-    // htmx:afterSwap fires after HTMX replaces content — reset timer,
-    // hide pacing indicator, and rebind card handlers for the new DOM content.
+    // Inject decision timings and clear pacing state before the request fires.
+    document.body.addEventListener("htmx:beforeRequest", function (evt) {
+        injectDecisionTime(evt);
+        var form = evt.target.closest("form");
+        if (form && form.dataset && form.dataset.queued === "1") {
+            clearPacingState(form);
+            hidePacingIndicator();
+        }
+    });
+
+    // Reset UI and timing after board swaps.
     document.body.addEventListener("htmx:afterSwap", function () {
         hidePacingIndicator();
         resetTimer();
-        bindCardHandlers();
+        clearSelectedCard(document.getElementById("play-card-form"));
+        initPaceControl();
+        bindCardControls();
+        var paceSelect = document.getElementById("ai-pace-control");
+        if (paceSelect) {
+            paceSelect.addEventListener("change", onPaceModeChange);
+        }
     });
 
-    // Initial binding on page load.
-    if (document.readyState === "loading") {
-        document.addEventListener("DOMContentLoaded", bindCardHandlers);
-    } else {
-        bindCardHandlers();
+    // Hide indicator and clear any queued state if request errors.
+    document.body.addEventListener("htmx:responseError", function (evt) {
+        hidePacingIndicator();
+        clearPacingState(evt.target.closest("form"));
+    });
+
+    // Initial boot.
+    initPaceControl();
+    if (!document.getElementById("play-card-form")) {
+        var placeholderSubmit = document.getElementById("play-card-submit");
+        if (placeholderSubmit) {
+            placeholderSubmit.disabled = true;
+        }
     }
+    var paceSelect = document.getElementById("ai-pace-control");
+    if (paceSelect) {
+        paceSelect.addEventListener("change", onPaceModeChange);
+    }
+    resetTimer();
+    bindCardControls();
+
+    // Ensure submit helper remains global for existing onclick handlers in templates.
+    window.__bidEuchreSubmitPass = function (btn) {
+        var form = btn.closest("form");
+        if (form) {
+            htmx.trigger(form, "submit");
+        }
+    };
 })();

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -185,8 +185,35 @@ main {
     z-index: 1;
 }
 
+.card-fan--interactive {
+    flex-wrap: wrap;
+    gap: 0.3rem;
+}
+
 .card-fan .card:hover {
     z-index: 10;
+}
+
+/* Clickable cards in trick-play phase */
+.card--playable {
+    cursor: pointer;
+    border-style: solid;
+    transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.card--playable:hover {
+    transform: translateY(-8px);
+    box-shadow: 0 0 12px var(--color-legal-glow);
+}
+
+.card--playable:active {
+    transform: translateY(-4px);
+}
+
+.card--selected {
+    border-color: #fff;
+    box-shadow: 0 0 0 3px #fff, 0 0 12px var(--color-legal-glow);
+    transform: translateY(-12px);
 }
 
 /* Card form wrapping each legal card — inline so fan layout works */
@@ -205,6 +232,51 @@ main {
     font-family: inherit;
     font-weight: 700;
     border: 2px solid var(--color-legal-border);
+}
+
+.card-play-form {
+    margin-top: 0.75rem;
+}
+
+.play-card-controls {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.45rem;
+}
+
+.card-selection-help {
+    margin: 0;
+    color: var(--color-text-muted);
+    text-align: center;
+    min-height: 1.1rem;
+    font-size: 0.85rem;
+}
+
+.btn--play-card {
+    border: none;
+    border-radius: 999px;
+    background: var(--color-felt);
+    color: #fff;
+    font-weight: 700;
+    padding: 0.55rem 1.35rem;
+    cursor: pointer;
+    transition: background 0.15s ease, transform 0.1s ease;
+}
+
+.btn--play-card:hover {
+    background: var(--color-legal-glow);
+    transform: translateY(-1px);
+}
+
+.btn--play-card:active {
+    transform: none;
+}
+
+.btn--play-card:disabled {
+    cursor: not-allowed;
+    background: #616161;
+    opacity: 0.55;
 }
 
 /* --------------------------------------------------------------------------
@@ -262,6 +334,28 @@ main {
     justify-content: center;
     min-width: 70px;
     min-height: 90px;
+}
+
+.seat-marker-row {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.25rem;
+    margin-top: 0.3rem;
+}
+
+.seat-marker {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.65rem;
+    font-weight: 700;
+    line-height: 1;
+    text-transform: uppercase;
+    padding: 0.12rem 0.35rem;
+    border-radius: 999px;
+    color: var(--color-text);
+    background: rgba(0, 0, 0, 0.35);
 }
 
 /* Top (partner) */
@@ -463,6 +557,130 @@ main {
     margin: 0.5rem 0 0;
     font-size: 0.8rem;
     color: var(--color-text-muted);
+}
+
+/* --------------------------------------------------------------------------
+   9b. Pacing controls / board layout
+   -------------------------------------------------------------------------- */
+
+.game-board {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.game-board__row {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-start;
+}
+
+.game-board__row--with-feed {
+    display: grid;
+    grid-template-columns: minmax(0, 1.05fr) minmax(220px, 0.75fr);
+    align-items: start;
+    gap: 1rem;
+}
+
+.game-board__main {
+    min-width: 0;
+}
+
+.game-board__rail {
+    min-width: 0;
+}
+
+.ai-hands-row {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+    align-items: center;
+    flex: 1;
+}
+
+.ai-hand-cluster {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.ai-hand-cluster--center {
+    margin: 0 0.25rem;
+}
+
+.pacing-controls {
+    margin-left: auto;
+    margin-right: auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.8rem;
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.15);
+}
+
+.pacing-controls label {
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+    white-space: nowrap;
+}
+
+.pacing-controls select {
+    border-radius: 4px;
+    border: 1px solid #555;
+    background: var(--color-surface-light);
+    color: var(--color-text);
+    padding: 0.35rem 0.55rem;
+    font-size: 0.85rem;
+}
+
+.action-feed {
+    background: rgba(0, 0, 0, 0.22);
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    padding: 0.75rem;
+    max-height: 320px;
+    overflow: hidden;
+}
+
+.action-feed h3 {
+    margin: 0 0 0.45rem;
+    font-size: 0.95rem;
+    color: var(--color-text-muted);
+}
+
+.action-feed__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    max-height: 260px;
+    overflow-y: auto;
+    font-size: 0.8rem;
+}
+
+.action-feed__item {
+    padding: 0.3rem 0.35rem;
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.04);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+}
+
+.action-feed__seat {
+    font-weight: 700;
+}
+
+.action-feed__item--muted {
+    color: var(--color-text-muted);
+    font-style: italic;
+    background: transparent;
 }
 
 /* --------------------------------------------------------------------------
@@ -757,6 +975,24 @@ main {
         align-items: stretch;
     }
 
+    .game-board__row--with-feed {
+        grid-template-columns: 1fr;
+        gap: 0.75rem;
+    }
+
+    .pacing-controls {
+        margin-top: 0.25rem;
+        margin-left: 0;
+    }
+
+    .action-feed {
+        max-height: none;
+    }
+
+    .action-feed__list {
+        max-height: none;
+    }
+
     .match-result .result-title {
         font-size: 1.5rem;
     }
@@ -977,6 +1213,27 @@ main {
     .auction-table td {
         padding: 0.2rem 0.35rem;
         font-size: 0.75rem;
+    }
+
+    .game-board {
+        gap: 0.75rem;
+    }
+
+    .game-board__row {
+        gap: 0.6rem;
+    }
+
+    .action-feed {
+        padding: 0.55rem;
+    }
+
+    .action-feed h3 {
+        font-size: 0.9rem;
+    }
+
+    .action-feed__list {
+        font-size: 0.76rem;
+        gap: 0.25rem;
     }
 
     /* Score bar — ultra-compact */

--- a/web/templates/game.html
+++ b/web/templates/game.html
@@ -46,53 +46,64 @@
     {# ---- Active game phases: auction and trick play ---- #}
     {% elif phase in ("auction", "trick_play", "redeal") %}
 
-        {# AI hands — face-down card backs with counts #}
-        <div class="ai-hands-row" style="display:flex; justify-content:space-between; align-items:flex-start; gap:0.5rem;"
-             role="region" aria-label="AI opponent hands">
-            {# Left opponent (seat 1) #}
-            <div style="text-align:center; flex:0 0 auto;">
-                <div class="ai-hand" role="img" aria-label="AI Left has {{ opp_left_count | default(0) }} cards">
-                    {% for _ in range(opp_left_count | default(0)) %}
-                    <div class="card-back" aria-hidden="true"></div>
-                    {% endfor %}
+        <div class="game-board">
+            <div class="game-board__row">
+                <div class="ai-hands-row">
+                    {# Left opponent (seat 1) #}
+                    <div class="ai-hand-cluster">
+                        <div class="ai-hand" role="img" aria-label="AI Left has {{ opp_left_count | default(0) }} cards">
+                            {% for _ in range(opp_left_count | default(0)) %}
+                            <div class="card-back" aria-hidden="true"></div>
+                            {% endfor %}
+                        </div>
+                        <span class="ai-card-count" aria-hidden="true">AI Left ({{ opp_left_count | default(0) }})</span>
+                    </div>
+
+                    {# Partner (seat 2) #}
+                    <div class="ai-hand-cluster ai-hand-cluster--center">
+                        <div class="ai-hand" role="img" aria-label="Partner has {{ partner_count | default(0) }} cards">
+                            {% for _ in range(partner_count | default(0)) %}
+                            <div class="card-back" aria-hidden="true"></div>
+                            {% endfor %}
+                        </div>
+                        <span class="ai-card-count" aria-hidden="true">Partner ({{ partner_count | default(0) }})</span>
+                    </div>
+
+                    {# Right opponent (seat 3) #}
+                    <div class="ai-hand-cluster">
+                        <div class="ai-hand" role="img" aria-label="AI Right has {{ opp_right_count | default(0) }} cards">
+                            {% for _ in range(opp_right_count | default(0)) %}
+                            <div class="card-back" aria-hidden="true"></div>
+                            {% endfor %}
+                        </div>
+                        <span class="ai-card-count" aria-hidden="true">AI Right ({{ opp_right_count | default(0) }})</span>
+                    </div>
                 </div>
-                <span class="ai-card-count" aria-hidden="true">AI Left ({{ opp_left_count | default(0) }})</span>
+
+                {% include "partials/pacing_controls.html" %}
             </div>
 
-            {# Partner (seat 2) #}
-            <div style="text-align:center; flex:1 1 auto;">
-                <div class="ai-hand" role="img" aria-label="Partner has {{ partner_count | default(0) }} cards">
-                    {% for _ in range(partner_count | default(0)) %}
-                    <div class="card-back" aria-hidden="true"></div>
-                    {% endfor %}
+            <div class="game-board__row game-board__row--with-feed">
+                <div class="game-board__main">
+                    {% include "partials/trick.html" %}
                 </div>
-                <span class="ai-card-count" aria-hidden="true">Partner ({{ partner_count | default(0) }})</span>
+                <div class="game-board__rail">
+                    {% include "partials/action_feed.html" %}
+                </div>
             </div>
 
-            {# Right opponent (seat 3) #}
-            <div style="text-align:center; flex:0 0 auto;">
-                <div class="ai-hand" role="img" aria-label="AI Right has {{ opp_right_count | default(0) }} cards">
-                    {% for _ in range(opp_right_count | default(0)) %}
-                    <div class="card-back" aria-hidden="true"></div>
-                    {% endfor %}
-                </div>
-                <span class="ai-card-count" aria-hidden="true">AI Right ({{ opp_right_count | default(0) }})</span>
+            {% if phase == "auction" %}
+                {% include "partials/bid_panel.html" %}
+            {% endif %}
+
+            <div class="game-board__row">
+                {% include "partials/hand.html" %}
+            </div>
+
+            <div class="game-board__row">
+                {% include "partials/score.html" %}
             </div>
         </div>
-
-        {# Trick area — always shown during active play #}
-        {% include "partials/trick.html" %}
-
-        {# Bid panel — auction phase only, when it's the human's turn #}
-        {% if phase == "auction" %}
-            {% include "partials/bid_panel.html" %}
-        {% endif %}
-
-        {# Human hand — always shown during active play #}
-        {% include "partials/hand.html" %}
-
-        {# Score bar — always shown during active play #}
-        {% include "partials/score.html" %}
 
     {% endif %}
 

--- a/web/templates/partials/action_feed.html
+++ b/web/templates/partials/action_feed.html
@@ -1,0 +1,65 @@
+{# Action feed — compact chronological feed for current hand events.
+   Context variables:
+     - auction: list[dict] — bid/seat history
+     - completed_tricks: list[dict] — completed trick payloads with winner and plays
+     - current_trick: dict | None — active trick, if any
+     - phase: str — current hand phase
+#}
+{% set seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"} %}
+{% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
+{% set auction = auction | default([]) %}
+{% set completed_tricks = completed_tricks | default([]) %}
+{% set current_trick = current_trick | default(None) %}
+{% set phase = phase | default("") %}
+
+<aside id="action-feed" class="action-feed" role="region" aria-label="Action feed">
+    <h3>Action feed</h3>
+    <ul class="action-feed__list">
+        {% if auction %}
+            {% for entry in auction %}
+                {% set entry_bid_type = entry.get("bid_type", "regular") %}
+                <li class="action-feed__item">
+                    <span class="action-feed__seat">{{ seat_labels.get(entry.seat, "Seat " ~ entry.seat) }}</span>
+                    {% if entry.action == "pass" %}
+                        passed
+                    {% else %}
+                        bid {{ entry.n }}{% if entry_bid_type == "moon" %} moon{% elif entry_bid_type == "loner" %} loner{% endif %}
+                        {% if entry.contract in suit_symbols %}
+                            of {{ suit_symbols.get(entry.contract) }}
+                        {% elif entry.contract == "HIGH" %}
+                            (high)
+                        {% elif entry.contract == "LOW" %}
+                            (low)
+                        {% endif %}
+                    {% endif %}
+                </li>
+            {% endfor %}
+        {% else %}
+            <li class="action-feed__item action-feed__item--muted">Auction starting</li>
+        {% endif %}
+
+        {% if phase == "trick_play" %}
+            {% if current_trick is not none %}
+                <li class="action-feed__item action-feed__item--muted">Current trick in progress</li>
+            {% endif %}
+
+            {% if completed_tricks %}
+                {% for completed in completed_tricks[-3:] %}
+                    {% set winner = completed.get("winner") %}
+                    <li class="action-feed__item">
+                        <span class="action-feed__seat">{{ seat_labels.get(winner, "Seat " ~ winner) }}</span>
+                        won trick {{ loop.revindex0 + 1 }}{{ " / now" if loop.first else "" }}
+                    </li>
+                {% endfor %}
+            {% endif %}
+        {% elif phase == "complete" %}
+            {% if completed_tricks %}
+                {% set last = completed_tricks[-1] %}
+                {% set winner = last.get("winner") %}
+                <li class="action-feed__item action-feed__item--muted">
+                    Final trick won by {{ seat_labels.get(winner, "Seat " ~ winner) }}
+                </li>
+            {% endif %}
+        {% endif %}
+    </ul>
+</aside>

--- a/web/templates/partials/bid_panel.html
+++ b/web/templates/partials/bid_panel.html
@@ -15,6 +15,8 @@
 <div id="bid-panel" role="region" aria-label="Auction panel">
     <h3 id="auction-heading">Auction</h3>
 
+    {% include "partials/pacing_controls.html" %}
+
     {# Show auction transcript so far #}
     {% if auction %}
     <div class="auction-transcript" aria-label="Bidding history" aria-live="polite">
@@ -61,6 +63,8 @@
 
     {# Bid form — only shown when it's the human's turn #}
     <form method="post"
+          id="bid-form"
+          data-paced="true"
           action="/play/{{ link_uuid }}/bid"
           hx-post="/play/{{ link_uuid }}/bid"
           hx-target="#game-board"
@@ -79,8 +83,8 @@
                 >Regular</option>
                 <option value="moon"
                     {% if bid_type|default("regular") == "loner" %}disabled{% endif %}
-                >Moon (10)</option>
-                <option value="loner">Loner (10)</option>
+                >Moon (20 pts)</option>
+                <option value="loner">Loner (40 pts)</option>
             </select>
 
             {# Bid level — only for regular bids #}

--- a/web/templates/partials/game_board.html
+++ b/web/templates/partials/game_board.html
@@ -6,6 +6,8 @@
        - phase: str — "auction", "trick_play", "hand_result", "match_result", "redeal"
        - link_uuid: str — player's game link UUID
        - opp_left_count, partner_count, opp_right_count: int — AI hand card counts
+       - completed_tricks, current_trick, tricks_team0, tricks_team1
+       - bidder_seat, dealer_seat, current_seat, sitting_out_seat
 #}
 
 {# ---- Match result (win/loss screen) ---- #}
@@ -19,51 +21,63 @@
 {# ---- Active game phases: auction and trick play ---- #}
 {% elif phase in ("auction", "trick_play", "redeal") %}
 
-    {# AI hands — face-down card backs with counts #}
-    <div style="display:flex; justify-content:space-between; align-items:flex-start; gap:0.5rem;">
-        {# Left opponent (seat 1) #}
-        <div style="text-align:center; flex:0 0 auto;">
-            <div class="ai-hand">
-                {% for _ in range(opp_left_count | default(0)) %}
-                <div class="card-back"></div>
-                {% endfor %}
+    <div class="game-board">
+        <div class="game-board__row">
+            <div class="ai-hands-row">
+                {# Left opponent (seat 1) #}
+                <div class="ai-hand-cluster">
+                    <div class="ai-hand" role="img" aria-label="AI Left has {{ opp_left_count | default(0) }} cards">
+                        {% for _ in range(opp_left_count | default(0)) %}
+                        <div class="card-back" aria-hidden="true"></div>
+                        {% endfor %}
+                    </div>
+                    <span class="ai-card-count" aria-hidden="true">AI Left ({{ opp_left_count | default(0) }})</span>
+                </div>
+
+                {# Partner (seat 2) #}
+                <div class="ai-hand-cluster ai-hand-cluster--center">
+                    <div class="ai-hand" role="img" aria-label="Partner has {{ partner_count | default(0) }} cards">
+                        {% for _ in range(partner_count | default(0)) %}
+                        <div class="card-back" aria-hidden="true"></div>
+                        {% endfor %}
+                    </div>
+                    <span class="ai-card-count" aria-hidden="true">Partner ({{ partner_count | default(0) }})</span>
+                </div>
+
+                {# Right opponent (seat 3) #}
+                <div class="ai-hand-cluster">
+                    <div class="ai-hand" role="img" aria-label="AI Right has {{ opp_right_count | default(0) }} cards">
+                        {% for _ in range(opp_right_count | default(0)) %}
+                        <div class="card-back" aria-hidden="true"></div>
+                        {% endfor %}
+                    </div>
+                    <span class="ai-card-count" aria-hidden="true">AI Right ({{ opp_right_count | default(0) }})</span>
+                </div>
             </div>
-            <span class="ai-card-count">AI Left ({{ opp_left_count | default(0) }})</span>
+
+            {% include "partials/pacing_controls.html" %}
         </div>
 
-        {# Partner (seat 2) #}
-        <div style="text-align:center; flex:1 1 auto;">
-            <div class="ai-hand">
-                {% for _ in range(partner_count | default(0)) %}
-                <div class="card-back"></div>
-                {% endfor %}
+        <div class="game-board__row game-board__row--with-feed">
+            <div class="game-board__main">
+                {% include "partials/trick.html" %}
             </div>
-            <span class="ai-card-count">Partner ({{ partner_count | default(0) }})</span>
+            <div class="game-board__rail">
+                {% include "partials/action_feed.html" %}
+            </div>
         </div>
 
-        {# Right opponent (seat 3) #}
-        <div style="text-align:center; flex:0 0 auto;">
-            <div class="ai-hand">
-                {% for _ in range(opp_right_count | default(0)) %}
-                <div class="card-back"></div>
-                {% endfor %}
-            </div>
-            <span class="ai-card-count">AI Right ({{ opp_right_count | default(0) }})</span>
+        {% if phase == "auction" %}
+            {% include "partials/bid_panel.html" %}
+        {% endif %}
+
+        <div class="game-board__row">
+            {% include "partials/hand.html" %}
+        </div>
+
+        <div class="game-board__row">
+            {% include "partials/score.html" %}
         </div>
     </div>
-
-    {# Trick area — always shown during active play #}
-    {% include "partials/trick.html" %}
-
-    {# Bid panel — auction phase only, when it's the human's turn #}
-    {% if phase == "auction" %}
-        {% include "partials/bid_panel.html" %}
-    {% endif %}
-
-    {# Human hand — always shown during active play #}
-    {% include "partials/hand.html" %}
-
-    {# Score bar — always shown during active play #}
-    {% include "partials/score.html" %}
 
 {% endif %}

--- a/web/templates/partials/hand.html
+++ b/web/templates/partials/hand.html
@@ -1,4 +1,5 @@
-{# Player's hand partial — legal cards as form buttons, illegal as plain divs.
+{# Player's hand partial — tap-select/confirm card play during trick_play,
+   plain cards at all other times.
    Context variables:
      - link_uuid: str — player's game link UUID
      - turn_number: int — current turn for idempotency
@@ -9,10 +10,12 @@
 {% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
 {% set suit_names = {"S": "Spades", "H": "Hearts", "D": "Diamonds", "C": "Clubs"} %}
 {% set suit_classes = {"S": "spades", "H": "hearts", "D": "diamonds", "C": "clubs"} %}
+{% set in_trick_play = phase == "trick_play" and legal_plays is not none %}
 
 <div id="human-hand" class="hand" role="region" aria-label="Your hand">
     <h3>Your Hand</h3>
-    <div class="card-fan" role="group" aria-label="Cards in your hand ({{ human_hand | length }})">
+    <div class="card-fan{% if in_trick_play %} card-fan--interactive{% endif %}"
+         role="group" aria-label="Cards in your hand ({{ human_hand | length }})">
         {% for card in human_hand %}
             {% set suit = card[0] %}
             {% set rank = card[1] %}
@@ -21,24 +24,17 @@
             {% set suit_sym = suit_symbols.get(suit, suit) %}
             {% set suit_name = suit_names.get(suit, suit) %}
 
-            {% if phase == "trick_play" and legal_plays is not none and idx in legal_plays %}
-                {# Legal card — clickable form button #}
-                <form method="post"
-                      action="/play/{{ link_uuid }}/play-card"
-                      hx-post="/play/{{ link_uuid }}/play-card"
-                      hx-target="#game-board"
-                      hx-swap="innerHTML"
-                      class="card-form">
-                    <input type="hidden" name="turn_number" value="{{ turn_number }}">
-                    <input type="hidden" name="card_index" value="{{ idx }}">
-                    <button type="submit"
-                            class="card card--{{ suit_class }} card--legal"
-                            title="{{ rank }}{{ suit_sym }} (click to play)"
-                            aria-label="Play {{ rank }} of {{ suit_name }}">
-                        <span class="card__rank" aria-hidden="true">{{ rank }}</span>
-                        <span class="card__suit" aria-hidden="true">{{ suit_sym }}</span>
-                    </button>
-                </form>
+            {% if in_trick_play and idx in legal_plays %}
+                {# Legal card — tap-to-select or click-to-play #}
+                <button type="button"
+                        class="card card--{{ suit_class }} card--legal card--playable"
+                        title="{{ rank }}{{ suit_sym }} (tap to select)"
+                        data-card-index="{{ idx }}"
+                        aria-label="Play {{ rank }} of {{ suit_name }}"
+                        data-card-text="{{ rank }} {{ suit_name }}">
+                    <span class="card__rank" aria-hidden="true">{{ rank }}</span>
+                    <span class="card__suit" aria-hidden="true">{{ suit_sym }}</span>
+                </button>
             {% else %}
                 {# Illegal or non-play-phase card — plain div #}
                 <div class="card card--{{ suit_class }}{% if phase == 'trick_play' %} card--illegal{% endif %}"
@@ -51,4 +47,25 @@
             {% endif %}
         {% endfor %}
     </div>
+
+    {% if in_trick_play %}
+    <form id="play-card-form"
+          class="card-play-form"
+          method="post"
+          action="/play/{{ link_uuid }}/play-card"
+          hx-post="/play/{{ link_uuid }}/play-card"
+          hx-target="#game-board"
+          hx-swap="innerHTML">
+        <input type="hidden" name="turn_number" value="{{ turn_number }}">
+        <input type="hidden" id="selected-card-index" name="card_index" value="">
+        <div class="play-card-controls">
+            <p id="card-selection-help" class="card-selection-help" aria-live="polite">
+                Tap a legal card to select, then confirm.
+            </p>
+            <button id="play-card-submit" class="btn btn--play-card" type="submit" disabled aria-label="Play selected card">
+                Play card
+            </button>
+        </div>
+    </form>
+    {% endif %}
 </div>

--- a/web/templates/partials/hand_result.html
+++ b/web/templates/partials/hand_result.html
@@ -15,6 +15,12 @@
 #}
 {% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
 {% set seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"} %}
+{% set completed_tricks = completed_tricks | default([]) %}
+{% set bidder_seat = bidder_seat | default(none) %}
+{% set dealer_seat = dealer_seat | default(none) %}
+{% set current_seat = current_seat | default(none) %}
+{% set sitting_out_seat = sitting_out_seat | default(none) %}
+{% set link_uuid = link_uuid | default(none) %}
 {% set hand_bid_type = bid_type | default("regular") %}
 
 {# Determine if the declaring team made their bid #}
@@ -122,4 +128,59 @@
         <p>Match score: You {{ score_human }} &mdash; AI {{ score_ai }}</p>
         <p class="hands-count">Hands played: {{ hands_played }}</p>
     </div>
+
+    {% if completed_tricks %}
+        <section class="hand-result-trick hand-result-trick" aria-label="Final trick">
+            <h3>Last trick</h3>
+            {% with
+                current_trick=completed_tricks[-1],
+                completed_tricks=completed_tricks,
+                trick_number_override=completed_tricks|length,
+                bidder_seat=bidder_seat,
+                dealer_seat=dealer_seat,
+                current_seat=current_seat,
+                sitting_out_seat=sitting_out_seat
+            %}
+                {% include "partials/trick.html" %}
+            {% endwith %}
+        </section>
+    {% endif %}
+
+    {% set moon_exchange_given = exchange_given | default([], true) %}
+    {% set moon_exchange_received = exchange_received | default([], true) %}
+    {% if hand_bid_type == "moon" and moon_exchange_given and moon_exchange_received %}
+        <div class="moon-exchange" role="status" aria-live="polite">
+            <h3>Moon exchange</h3>
+            <p>
+                {% if human_declared %}
+                    You gave:
+                {% else %}
+                    {{ seat_labels.get(bidder_seat, "Bidder") }} gave:
+                {% endif %}
+                {% for card in moon_exchange_given %}
+                    <span class="exchange-card">{{ suit_symbols.get(card[0], card[0]) }}{{ card[1] }}</span>
+                {% endfor %}
+            </p>
+            <p>
+                {% if human_declared %}
+                    You received:
+                {% else %}
+                    {{ seat_labels.get(bidder_seat, "Bidder") }} received:
+                {% endif %}
+                {% for card in moon_exchange_received %}
+                    <span class="exchange-card">{{ suit_symbols.get(card[0], card[0]) }}{{ card[1] }}</span>
+                {% endfor %}
+            </p>
+        </div>
+    {% endif %}
+
+    {% if link_uuid %}
+        <form method="post"
+              action="/play/{{ link_uuid }}/next-hand"
+              hx-post="/play/{{ link_uuid }}/next-hand"
+              hx-target="#game-board"
+              hx-swap="innerHTML">
+            <button type="submit" class="btn btn--primary">Next Hand</button>
+        </form>
+    {% endif %}
 </div>

--- a/web/templates/partials/pacing_controls.html
+++ b/web/templates/partials/pacing_controls.html
@@ -1,0 +1,12 @@
+{# AI pace controls for card-showing and bid pacing.
+   User preference is persisted in localStorage (pace = normal|fast|slow|instant).
+#}
+<div id="pacing-controls" class="pacing-controls" role="region" aria-label="AI pace controls">
+    <label for="ai-pace-control">AI pace</label>
+    <select id="ai-pace-control" name="ai_pace">
+        <option value="instant">Instant</option>
+        <option value="fast">Fast</option>
+        <option value="normal" selected>Normal</option>
+        <option value="slow">Slow</option>
+    </select>
+</div>

--- a/web/templates/partials/trick.html
+++ b/web/templates/partials/trick.html
@@ -4,23 +4,61 @@
      - completed_tricks: list[dict] — completed tricks for reference count
      - tricks_team0: int — tricks won by human's team (seats 0, 2)
      - tricks_team1: int — tricks won by AI team (seats 1, 3)
+     - bidder_seat: int | None — current declarer seat
+     - dealer_seat: int | None — current dealer seat
+     - current_seat: int | None — seat to act next
+     - sitting_out_seat: int | None — seat sitting out on loner hands
+     - trick_number_override: int | None — manual trick number override (e.g. hand_result)
 #}
 {% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
 {% set suit_names = {"S": "Spades", "H": "Hearts", "D": "Diamonds", "C": "Clubs"} %}
 {% set suit_classes = {"S": "spades", "H": "hearts", "D": "diamonds", "C": "clubs"} %}
 {% set seat_labels = {0: "You", 1: "AI Left", 2: "Partner", 3: "AI Right"} %}
+{% set current_trick = current_trick | default(None) %}
+{% set completed_tricks = completed_tricks | default([]) %}
+{% set bidder_seat = bidder_seat | default(none) %}
+{% set dealer_seat = dealer_seat | default(none) %}
+{% set current_seat = current_seat | default(none) %}
+{% set sitting_out_seat = sitting_out_seat | default(none) %}
 
-{# Build a dict mapping seat -> card for the current trick.
-   Uses namespace to work around Jinja2 for-loop scoping. #}
+{# If there is no active trick but there are completed tricks, show the last one.
+   This preserves the visible trick when a hand transitions to hand_result. #}
+{% set ns = namespace(current= current_trick) %}
+{% set trick_num = trick_number_override | default(completed_tricks | length + 1) %}
+{% if not current_trick and completed_tricks %}
+    {% set ns.current = completed_tricks[-1] %}
+    {% set trick_num = completed_tricks | length %}
+{% endif %}
+{% set trick_data = ns.current %}
+
+{% set marker_data = {
+    0: [],
+    1: [],
+    2: [],
+    3: [],
+} %}
+{% if bidder_seat is not none %}
+    {% set _ = marker_data[bidder_seat].append("DEC") %}
+{% endif %}
+{% if dealer_seat is not none %}
+    {% set _ = marker_data[dealer_seat].append("D") %}
+{% endif %}
+{% if current_seat is not none %}
+    {% set _ = marker_data[current_seat].append("TURN") %}
+{% endif %}
+{% if sitting_out_seat is not none %}
+    {% set _ = marker_data[sitting_out_seat].append("SIT") %}
+{% endif %}
+
 {% set ns = namespace(cards={}) %}
-{% if current_trick %}
-    {% for play in current_trick.plays %}
+{% if trick_data %}
+    {% for play in trick_data.plays %}
         {% set _ = ns.cards.update({play[0]: play[1]}) %}
     {% endfor %}
 {% endif %}
 
 <div id="trick-area" class="trick-area" role="region" aria-label="Current trick" aria-live="polite">
-    <h3>Trick {{ (completed_tricks | length) + 1 }} of 10</h3>
+    <h3>Trick {{ trick_num }} of 10{% if not current_trick and completed_tricks %} (last){% endif %}</h3>
     <div class="trick-table" role="group" aria-label="Cards played this trick, score {{ tricks_team0 }} to {{ tricks_team1 }}">
         {# Top — seat 2 (partner) #}
         <div class="trick-slot trick-slot--top">
@@ -36,6 +74,13 @@
             {% else %}
                 <div class="card-slot card-slot--empty" aria-label="{{ seat_labels[2] }}, waiting to play">
                     <span class="seat-label">{{ seat_labels[2] }}</span>
+                </div>
+            {% endif %}
+            {% if marker_data[2] %}
+                <div class="seat-marker-row">
+                    {% for flag in marker_data[2] %}
+                        <span class="seat-marker">{{ flag }}</span>
+                    {% endfor %}
                 </div>
             {% endif %}
         </div>
@@ -55,6 +100,13 @@
                 {% else %}
                     <div class="card-slot card-slot--empty" aria-label="{{ seat_labels[1] }}, waiting to play">
                         <span class="seat-label">{{ seat_labels[1] }}</span>
+                    </div>
+                {% endif %}
+                {% if marker_data[1] %}
+                    <div class="seat-marker-row">
+                        {% for flag in marker_data[1] %}
+                            <span class="seat-marker">{{ flag }}</span>
+                        {% endfor %}
                     </div>
                 {% endif %}
             </div>
@@ -78,6 +130,13 @@
                         <span class="seat-label">{{ seat_labels[3] }}</span>
                     </div>
                 {% endif %}
+                {% if marker_data[3] %}
+                    <div class="seat-marker-row">
+                        {% for flag in marker_data[3] %}
+                            <span class="seat-marker">{{ flag }}</span>
+                        {% endfor %}
+                    </div>
+                {% endif %}
             </div>
         </div>
 
@@ -95,6 +154,13 @@
             {% else %}
                 <div class="card-slot card-slot--empty" aria-label="{{ seat_labels[0] }}, waiting to play">
                     <span class="seat-label">{{ seat_labels[0] }}</span>
+                </div>
+            {% endif %}
+            {% if marker_data[0] %}
+                <div class="seat-marker-row">
+                    {% for flag in marker_data[0] %}
+                        <span class="seat-marker">{{ flag }}</span>
+                    {% endfor %}
                 </div>
             {% endif %}
         </div>


### PR DESCRIPTION
## Summary
- Reworked hosted-play templates and partials for clearer action visibility and layout
- Added action feed and pacing controls partials
- Unified card play flow through selection + confirm step and added AI pacing timing controls
- Adjusted accessibility and visual styling, including mobile-friendly targets

## Validation
- Targeted: tests/unit/hosted_play/test_partials.py
- Full suite previously passed in main worktree with all chunks applied: 7707 passed, 56 skipped