### PR TITLE
Skip governance/CI checks for dashboard chore PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
     if: >-
       always() && !cancelled() &&
       (github.event_name == 'push' ||
+       (github.event_name == 'pull_request' &&
+        !(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
+          startsWith(github.head_ref, 'chore/auto-dashboard')))) &&
+      (github.event_name == 'push' ||
        needs.changes.outputs.code_changed == 'true' ||
        needs.changes.outputs.notebooks_changed == 'true')
     runs-on: ubuntu-latest
@@ -90,6 +94,10 @@ jobs:
     if: >-
       always() && !cancelled() &&
       (github.event_name == 'push' ||
+       (github.event_name == 'pull_request' &&
+        !(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
+          startsWith(github.head_ref, 'chore/auto-dashboard')))) &&
+      (github.event_name == 'push' ||
        needs.changes.outputs.code_changed == 'true')
     runs-on: ubuntu-latest
     strategy:
@@ -126,6 +134,10 @@ jobs:
     if: >-
       always() && !cancelled() &&
       (github.event_name == 'push' ||
+       (github.event_name == 'pull_request' &&
+        !(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
+          startsWith(github.head_ref, 'chore/auto-dashboard')))) &&
+      (github.event_name == 'push' ||
        needs.changes.outputs.notebooks_changed == 'true')
     runs-on: ubuntu-latest
     steps:
@@ -156,6 +168,10 @@ jobs:
     needs: [changes]
     if: >-
       always() && !cancelled() &&
+      (github.event_name == 'push' ||
+       (github.event_name == 'pull_request' &&
+        !(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
+          startsWith(github.head_ref, 'chore/auto-dashboard')))) &&
       (github.event_name == 'push' ||
        needs.changes.outputs.code_changed == 'true') &&
       contains(github.event.pull_request.labels.*.name, 'promotion')
@@ -200,7 +216,12 @@ jobs:
   #   - Passes when all upstreams are success or skipped
   tests:
     needs: [changes, checks, tests-shard, notebooks, promotion-gate]
-    if: always()
+    if: >-
+      always() &&
+      (github.event_name == 'push' ||
+       (github.event_name == 'pull_request' &&
+        !(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
+          startsWith(github.head_ref, 'chore/auto-dashboard'))))
     runs-on: ubuntu-latest
     steps:
       - name: Skip notice

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -12,6 +12,10 @@ concurrency:
 jobs:
   governance:
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request' &&
+      !(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
+        startsWith(github.head_ref, 'chore/auto-dashboard'))
 
     steps:
       - name: Checkout

--- a/tests/unit/test_ci_workflow.py
+++ b/tests/unit/test_ci_workflow.py
@@ -51,6 +51,23 @@ class TestCIWorkflowStructure:
         # Always runs (to post a status even on docs-only PRs)
         assert "always()" in str(tests_job.get("if", ""))
 
+    def test_dashboard_chore_prs_are_skipped_by_ci_gates(self) -> None:
+        """Dashboard chore PRs should short-circuit heavy CI jobs."""
+        skip_marker = "chore: update PR analytics dashboard"
+        branch_marker = "startsWith(github.head_ref, 'chore/auto-dashboard')"
+
+        for job_name in (
+            "checks",
+            "tests-shard",
+            "notebooks",
+            "promotion-gate",
+            "tests",
+        ):
+            if_expr = str(self.jobs[job_name].get("if", ""))
+            assert skip_marker in if_expr, f"{job_name} missing skip marker"
+            assert branch_marker in if_expr, f"{job_name} missing branch marker"
+            assert "github.event_name == 'push'" in if_expr
+
     def test_tests_shard_is_2way_pytest_split(self) -> None:
         """The shard job uses a 2-group matrix with pytest-split."""
         shard_job = self.jobs["tests-shard"]

--- a/tests/unit/test_governance_workflow.py
+++ b/tests/unit/test_governance_workflow.py
@@ -1,0 +1,23 @@
+"""Regression tests for the governance workflow structure."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GOVERNANCE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "governance.yml"
+
+
+class TestGovernanceWorkflowStructure:
+    """Validate governance short-circuiting for dashboard chores."""
+
+    def setup_method(self) -> None:
+        self.workflow = yaml.safe_load(GOVERNANCE_WORKFLOW.read_text())
+
+    def test_dashboard_chore_prs_are_skipped(self) -> None:
+        job = self.workflow["jobs"]["governance"]
+        job_if = str(job.get("if", ""))
+        assert "chore: update PR analytics dashboard" in job_if
+        assert "startsWith(github.head_ref, 'chore/auto-dashboard')" in job_if


### PR DESCRIPTION
## Summary
- Add explicit short-circuit guards for PRs generated by the dashboard chore ( / ) in CI and governance workflows.
- Skip , , , , , and  jobs for these PRs.
- Add workflow structure regression tests for both CI skip gating and governance skip guarding.

## Scope
- Only PRs matching the dashboard chore title/branch pattern are affected.
- All other PR types keep existing CI/governance requirements.

## Testing
- Added regression tests in  and .
