### PR TITLE
fix(web): compact mobile active-game layout

### DIFF
--- a/tests/browser/test_mobile.py
+++ b/tests/browser/test_mobile.py
@@ -71,6 +71,19 @@ def test_mobile_viewport_tap_targets(
             body_width <= viewport_width + 20
         ), f"Page overflows viewport: body={body_width}px, viewport={viewport_width}px"
 
+        # --- Check the auction/trick/hand/score surfaces remain on-screen together ---
+        selectors = ["#trick-area", "#human-hand", "#score-bar", "#bid-panel"]
+        for selector in selectors:
+            locator = mobile_page.locator(selector)
+            if locator.count() > 0:
+                box = locator.first.bounding_box()
+                if box is None:
+                    continue
+                assert box["y"] >= 0, f"{selector} should be above viewport top: {box}"
+                assert (
+                    box["y"] + box["height"] <= MOBILE_VIEWPORT["height"] + 5
+                ), f"{selector} overflows vertical viewport on mobile: {box}"
+
         # --- Check card sizes ---
         cards = mobile_page.locator(".card")
         card_count = cards.count()

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -233,6 +233,25 @@ main {
     margin-left: 0.5rem;
 }
 
+.ai-hands-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.5rem;
+}
+
+.ai-hand-block {
+    text-align: center;
+}
+
+.ai-hand-block--middle {
+    flex: 1 1 auto;
+}
+
+.ai-hand-block--edge {
+    flex: 0 0 auto;
+}
+
 /* --------------------------------------------------------------------------
    6. Trick Area
    -------------------------------------------------------------------------- */
@@ -896,6 +915,10 @@ main {
         padding: 0.25rem;
     }
 
+    #game-board {
+        gap: 0.5rem;
+    }
+
     header h1 {
         font-size: 1rem;
     }
@@ -928,13 +951,31 @@ main {
         margin: 0 -3px;
     }
 
+    .ai-hands-row {
+        align-items: center;
+        gap: 0.35rem;
+    }
+
+    .ai-hand {
+        display: none;
+    }
+
     .ai-card-count {
-        font-size: 0.7rem;
+        margin-left: 0;
+        font-size: 0.65rem;
+        line-height: 1;
+    }
+
+    .trick-area h3,
+    .hand h3,
+    #bid-panel h3 {
+        margin-bottom: 0.35rem;
+        font-size: 0.85rem;
     }
 
     .trick-table {
         padding: 0.5rem;
-        min-height: 160px;
+        min-height: 136px;
         border-radius: 8px;
     }
 
@@ -983,6 +1024,35 @@ main {
     .score-bar {
         padding: 0.4rem 0.5rem;
         font-size: 0.7rem;
+        position: sticky;
+        bottom: 0.25rem;
+        z-index: 1;
+    }
+
+    #bid-panel {
+        padding: 0.5rem;
+        max-height: 170px;
+        overflow: auto;
+    }
+
+    .auction-transcript {
+        max-height: 58px;
+        margin-bottom: 0.5rem;
+        overflow-y: auto;
+    }
+
+    .auction-table th,
+    .auction-table td {
+        padding: 0.12rem 0.3rem;
+        font-size: 0.7rem;
+    }
+
+    .trick-area h3 {
+        font-size: 0.75rem;
+    }
+
+    .trick-table {
+        min-height: 112px;
     }
 
     .score-value {

--- a/web/templates/game.html
+++ b/web/templates/game.html
@@ -47,10 +47,10 @@
     {% elif phase in ("auction", "trick_play", "redeal") %}
 
         {# AI hands — face-down card backs with counts #}
-        <div class="ai-hands-row" style="display:flex; justify-content:space-between; align-items:flex-start; gap:0.5rem;"
+        <div class="ai-hands-row"
              role="region" aria-label="AI opponent hands">
             {# Left opponent (seat 1) #}
-            <div style="text-align:center; flex:0 0 auto;">
+            <div class="ai-hand-block ai-hand-block--edge">
                 <div class="ai-hand" role="img" aria-label="AI Left has {{ opp_left_count | default(0) }} cards">
                     {% for _ in range(opp_left_count | default(0)) %}
                     <div class="card-back" aria-hidden="true"></div>
@@ -60,7 +60,7 @@
             </div>
 
             {# Partner (seat 2) #}
-            <div style="text-align:center; flex:1 1 auto;">
+            <div class="ai-hand-block ai-hand-block--middle">
                 <div class="ai-hand" role="img" aria-label="Partner has {{ partner_count | default(0) }} cards">
                     {% for _ in range(partner_count | default(0)) %}
                     <div class="card-back" aria-hidden="true"></div>
@@ -70,7 +70,7 @@
             </div>
 
             {# Right opponent (seat 3) #}
-            <div style="text-align:center; flex:0 0 auto;">
+            <div class="ai-hand-block ai-hand-block--edge">
                 <div class="ai-hand" role="img" aria-label="AI Right has {{ opp_right_count | default(0) }} cards">
                     {% for _ in range(opp_right_count | default(0)) %}
                     <div class="card-back" aria-hidden="true"></div>

--- a/web/templates/partials/game_board.html
+++ b/web/templates/partials/game_board.html
@@ -20,9 +20,9 @@
 {% elif phase in ("auction", "trick_play", "redeal") %}
 
     {# AI hands — face-down card backs with counts #}
-    <div style="display:flex; justify-content:space-between; align-items:flex-start; gap:0.5rem;">
+    <div class="ai-hands-row">
         {# Left opponent (seat 1) #}
-        <div style="text-align:center; flex:0 0 auto;">
+        <div class="ai-hand-block ai-hand-block--edge">
             <div class="ai-hand">
                 {% for _ in range(opp_left_count | default(0)) %}
                 <div class="card-back"></div>
@@ -32,7 +32,7 @@
         </div>
 
         {# Partner (seat 2) #}
-        <div style="text-align:center; flex:1 1 auto;">
+        <div class="ai-hand-block ai-hand-block--middle">
             <div class="ai-hand">
                 {% for _ in range(partner_count | default(0)) %}
                 <div class="card-back"></div>
@@ -42,7 +42,7 @@
         </div>
 
         {# Right opponent (seat 3) #}
-        <div style="text-align:center; flex:0 0 auto;">
+        <div class="ai-hand-block ai-hand-block--edge">
             <div class="ai-hand">
                 {% for _ in range(opp_right_count | default(0)) %}
                 <div class="card-back"></div>


### PR DESCRIPTION
## Summary
- Collapse AI hand area to compact seat counts on narrow screens.
- Bound mobile bid panel height so trick/hand/score stay visible without excessive vertical overflow.
- Add responsive layout checks in the mobile Playwright suite for on-screen auction/hand/score elements.

## Testing
- uv run python -m pytest tests/browser/test_mobile.py::test_mobile_viewport_tap_targets -q
- uv run python -m pytest tests/browser/test_mobile.py::test_mobile_invite_code_input tests/browser/test_smoke_suite.py::test_full_hand_verify_transition -q
- uv run python -m pytest tests/browser -q

## Closes
- closes #1851