### PR TITLE
fix: address reviewed PR regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,12 +216,7 @@ jobs:
   #   - Passes when all upstreams are success or skipped
   tests:
     needs: [changes, checks, tests-shard, notebooks, promotion-gate]
-    if: >-
-      always() &&
-      (github.event_name == 'push' ||
-       (github.event_name == 'pull_request' &&
-        !(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
-          startsWith(github.head_ref, 'chore/auto-dashboard'))))
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Skip notice
@@ -230,7 +225,12 @@ jobs:
           needs.checks.result == 'skipped' &&
           needs.tests-shard.result == 'skipped' &&
           needs.notebooks.result == 'skipped'
-        run: echo "::notice::Docs/plans-only PR — all heavy jobs skipped"
+        run: |
+          if [[ "${{ contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') || startsWith(github.head_ref, 'chore/auto-dashboard') }}" == "true" ]]; then
+            echo "::notice::Dashboard chore PR — heavy CI jobs skipped, required gate preserved"
+          else
+            echo "::notice::Docs/plans-only PR — all heavy jobs skipped"
+          fi
 
       - name: Evaluate upstream results
         run: |

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -12,18 +12,26 @@ concurrency:
 jobs:
   governance:
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'pull_request' &&
-      !(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
-        startsWith(github.head_ref, 'chore/auto-dashboard'))
 
     steps:
+      - name: Skip notice for dashboard chore PRs
+        if: >-
+          contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
+          startsWith(github.head_ref, 'chore/auto-dashboard')
+        run: echo "::notice::Dashboard chore PR — governance reduced to a no-op pass"
+
       - name: Checkout
+        if: >-
+          !(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
+            startsWith(github.head_ref, 'chore/auto-dashboard'))
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: PR metadata check
+        if: >-
+          !(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
+            startsWith(github.head_ref, 'chore/auto-dashboard'))
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
@@ -33,6 +41,9 @@ jobs:
           fi
 
       - name: Plan file lint
+        if: >-
+          !(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
+            startsWith(github.head_ref, 'chore/auto-dashboard'))
         run: |
           PLAN_FILES=$(git diff --name-only origin/main...HEAD -- 'plans/*.md' 'plans/**/*.md' 2>/dev/null || true)
           if [ -n "$PLAN_FILES" ]; then
@@ -55,11 +66,17 @@ jobs:
           fi
 
       - name: Set up Python
+        if: >-
+          !(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
+            startsWith(github.head_ref, 'chore/auto-dashboard'))
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
       - name: Infra PR metadata check (advisory)
+        if: >-
+          !(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
+            startsWith(github.head_ref, 'chore/auto-dashboard'))
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
@@ -73,4 +90,7 @@ jobs:
           fi
 
       - name: Governance passed
+        if: >-
+          !(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
+            startsWith(github.head_ref, 'chore/auto-dashboard'))
         run: echo "All governance checks passed"

--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -290,11 +290,7 @@ def _probe_tmux_pane(
     Returns:
         True if the lane's tmux pane exists and is running.
     """
-    target = (
-        _resolve_tmux_target(lane_id, tmux_session, runtime_dir)
-        if runtime_dir is not None
-        else f"{tmux_session}:{lane_id}"
-    )
+    target = _resolve_tmux_target(lane_id, tmux_session, runtime_dir)
     try:
         result = subprocess.run(
             ["tmux", "display-message", "-t", target, "-p", "#{pane_pid}"],
@@ -612,7 +608,9 @@ def take_pool_snapshot(
 
         visibility = effective_visibility(lane)
         health = health_by_lane.get(lane.lane_id, "idle")
-        tmux_alive = _probe_tmux_pane(lane.lane_id, tmux_session)
+        tmux_alive = _probe_tmux_pane(
+            lane.lane_id, tmux_session, runtime_dir=runtime_dir
+        )
         task_id = _get_lane_task_id(lane.lane_id, runtime_dir)
 
         pool_status = _classify_pool_status(
@@ -785,7 +783,7 @@ def wake_worker(
         runtime_dir = Path(".claude/runtime")
 
     # Check if already alive
-    if _probe_tmux_pane(lane_id, tmux_session):
+    if _probe_tmux_pane(lane_id, tmux_session, runtime_dir=runtime_dir):
         # Already running -- just ensure visibility
         set_lane_visibility(lane_id, "foreground", runtime_dir)
         return PoolAction(
@@ -931,14 +929,15 @@ def retire_worker(
     set_lane_visibility(lane_id, "hidden", runtime_dir)
 
     # Terminate the tmux pane if alive
-    if _probe_tmux_pane(lane_id, tmux_session):
+    if _probe_tmux_pane(lane_id, tmux_session, runtime_dir=runtime_dir):
+        target = _resolve_tmux_target(lane_id, tmux_session, runtime_dir)
         try:
             subprocess.run(
                 [
                     "tmux",
                     "kill-window",
                     "-t",
-                    f"{tmux_session}:{lane_id}",
+                    target,
                 ],
                 capture_output=True,
                 text=True,
@@ -1126,11 +1125,7 @@ def clear_session(
         A :class:`PoolAction` with ``action="clear_session"`` describing the
         outcome.
     """
-    target = (
-        _resolve_tmux_target(lane_id, tmux_session, runtime_dir)
-        if runtime_dir is not None
-        else f"{tmux_session}:{lane_id}"
-    )
+    target = _resolve_tmux_target(lane_id, tmux_session, runtime_dir)
 
     try:
         subprocess.run(
@@ -1189,11 +1184,7 @@ def nudge_pane(
     Returns:
         A :class:`PoolAction` with ``action="nudge"`` describing the outcome.
     """
-    target = (
-        _resolve_tmux_target(lane_id, tmux_session, runtime_dir)
-        if runtime_dir is not None
-        else f"{tmux_session}:{lane_id}"
-    )
+    target = _resolve_tmux_target(lane_id, tmux_session, runtime_dir)
     cmd = f"/start-task {packet_id}"
 
     try:
@@ -1516,7 +1507,9 @@ def dispatch_to_worker(
             )
 
     # 6. Nudge the target pane
-    nudge_result = nudge_pane(lane_id, packet_id, tmux_session=tmux_session)
+    nudge_result = nudge_pane(
+        lane_id, packet_id, tmux_session=tmux_session, runtime_dir=runtime_dir
+    )
 
     # 7. Record delivery outcome
     if message_id is not None:

--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -1172,3 +1172,38 @@ class TestAccessibilityBaseTemplate:
         tmpl = env.get_template("base.html")
         html = tmpl.render()
         assert "viewport-fit=cover" in html
+
+
+class TestGameTemplateAccessibility:
+    """Verify accessibility-sensitive behavior in the full-page game template."""
+
+    def test_mobile_ai_counts_remain_in_accessibility_tree(self, env):
+        tmpl = env.get_template("game.html")
+        html = tmpl.render(
+            phase="auction",
+            link_uuid="abc-123",
+            opp_left_count=10,
+            partner_count=10,
+            opp_right_count=10,
+            current_trick=None,
+            completed_tricks=[],
+            tricks_team0=0,
+            tricks_team1=0,
+            human_hand=[["S", "A"]],
+            legal_plays=None,
+            turn_number=0,
+            auction=[],
+            current_high_bid=0,
+            dealer_seat=0,
+            score_human=0,
+            score_ai=0,
+            hands_played=0,
+            contract_type=None,
+            trump=None,
+            winning_bid=None,
+            bidder_seat=None,
+        )
+        assert 'class="ai-card-count" aria-hidden="true"' not in html
+        assert "AI Left (10)" in html
+        assert "Partner (10)" in html
+        assert "AI Right (10)" in html

--- a/tests/unit/test_ci_workflow.py
+++ b/tests/unit/test_ci_workflow.py
@@ -51,22 +51,21 @@ class TestCIWorkflowStructure:
         # Always runs (to post a status even on docs-only PRs)
         assert "always()" in str(tests_job.get("if", ""))
 
-    def test_dashboard_chore_prs_are_skipped_by_ci_gates(self) -> None:
-        """Dashboard chore PRs should short-circuit heavy CI jobs."""
+    def test_dashboard_chore_prs_keep_tests_gate_but_skip_heavy_jobs(self) -> None:
+        """Dashboard chore PRs should preserve the required tests gate only."""
         skip_marker = "chore: update PR analytics dashboard"
         branch_marker = "startsWith(github.head_ref, 'chore/auto-dashboard')"
 
-        for job_name in (
-            "checks",
-            "tests-shard",
-            "notebooks",
-            "promotion-gate",
-            "tests",
-        ):
+        for job_name in ("checks", "tests-shard", "notebooks", "promotion-gate"):
             if_expr = str(self.jobs[job_name].get("if", ""))
             assert skip_marker in if_expr, f"{job_name} missing skip marker"
             assert branch_marker in if_expr, f"{job_name} missing branch marker"
             assert "github.event_name == 'push'" in if_expr
+
+        tests_if = str(self.jobs["tests"].get("if", ""))
+        assert tests_if == "always()"
+        assert skip_marker not in tests_if
+        assert branch_marker not in tests_if
 
     def test_tests_shard_is_2way_pytest_split(self) -> None:
         """The shard job uses a 2-group matrix with pytest-split."""

--- a/tests/unit/test_governance_workflow.py
+++ b/tests/unit/test_governance_workflow.py
@@ -11,13 +11,22 @@ GOVERNANCE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "governance.yml"
 
 
 class TestGovernanceWorkflowStructure:
-    """Validate governance short-circuiting for dashboard chores."""
+    """Validate governance required-check behavior for dashboard chores."""
 
     def setup_method(self) -> None:
         self.workflow = yaml.safe_load(GOVERNANCE_WORKFLOW.read_text())
 
-    def test_dashboard_chore_prs_are_skipped(self) -> None:
+    def test_governance_job_has_no_dashboard_skip(self) -> None:
         job = self.workflow["jobs"]["governance"]
         job_if = str(job.get("if", ""))
-        assert "chore: update PR analytics dashboard" in job_if
-        assert "startsWith(github.head_ref, 'chore/auto-dashboard')" in job_if
+        assert "chore: update PR analytics dashboard" not in job_if
+        assert "startsWith(github.head_ref, 'chore/auto-dashboard')" not in job_if
+
+    def test_dashboard_chore_prs_emit_skip_notice(self) -> None:
+        steps = self.workflow["jobs"]["governance"]["steps"]
+        notice = next(
+            s for s in steps if s.get("name") == "Skip notice for dashboard chore PRs"
+        )
+        notice_if = str(notice.get("if", ""))
+        assert "chore: update PR analytics dashboard" in notice_if
+        assert "startsWith(github.head_ref, 'chore/auto-dashboard')" in notice_if

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -542,6 +542,25 @@ class TestProbeTmuxPane:
             call_args = mock_run.call_args[0][0]
             assert "steward:platform.1" in call_args
 
+    def test_without_runtime_dir_uses_default_registry(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Default .claude/runtime registry should be honored when present."""
+        registry_dir = tmp_path / ".claude" / "runtime" / "worktree_registry"
+        registry_dir.mkdir(parents=True)
+        entry = {"tmux_window": "platform", "tmux_pane": "1"}
+        (registry_dir / "author-a.json").write_text(json.dumps(entry))
+        monkeypatch.chdir(tmp_path)
+
+        with patch(f"{_WORKER_POOL}.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="12345\n")
+            result = _probe_tmux_pane("author-a", "steward")
+            assert result is True
+            call_args = mock_run.call_args[0][0]
+            assert call_args[3] == "steward:platform.1"
+
 
 # ---------------------------------------------------------------------------
 # Select worker
@@ -1096,6 +1115,31 @@ class TestRetireWorker:
         assert result.executed is True
         mock_vis.assert_called_once_with("author-a", "hidden", runtime_dir)
 
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    @patch(f"{_WORKER_POOL}._probe_tmux_pane", return_value=True)
+    @patch(f"{_WORKER_POOL}._get_lane_task_id", return_value=None)
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    def test_retire_uses_registry_target(
+        self,
+        mock_vis: MagicMock,
+        mock_task: MagicMock,
+        mock_probe: MagicMock,
+        mock_subprocess: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        registry_dir = runtime_dir / "worktree_registry"
+        registry_dir.mkdir(parents=True, exist_ok=True)
+        (registry_dir / "author-a.json").write_text(
+            json.dumps({"tmux_window": "platform", "tmux_pane": "1"})
+        )
+        mock_subprocess.return_value = MagicMock(returncode=0)
+
+        result = retire_worker("author-a", runtime_dir=runtime_dir)
+
+        assert result.executed is True
+        call_args = mock_subprocess.call_args[0][0]
+        assert call_args[3] == "steward:platform.1"
+
     @patch(f"{_WORKER_POOL}._probe_tmux_pane", return_value=False)
     @patch(f"{_WORKER_POOL}._get_lane_task_id", return_value=None)
     @patch(f"{_DASHBOARD}.set_lane_visibility")
@@ -1220,7 +1264,9 @@ class TestTakePoolSnapshot:
         mock_vis.side_effect = lambda lane: (
             "foreground" if lane.lane_id == "author-a" else "background"
         )
-        mock_probe.side_effect = lambda lid, _: lid == "author-a"
+        mock_probe.side_effect = lambda lid, _session, runtime_dir=None: (
+            lid == "author-a"
+        )
         mock_task.side_effect = lambda lid, rd=None: (
             "pkt1" if lid == "author-a" else None
         )
@@ -1881,6 +1927,25 @@ class TestNudgePane:
             call_args = mock_run.call_args[0][0]
             assert call_args[3] == "steward:platform.1"
 
+    def test_nudge_uses_default_runtime_registry(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Default .claude/runtime registry should be used when available."""
+        registry_dir = tmp_path / ".claude" / "runtime" / "worktree_registry"
+        registry_dir.mkdir(parents=True)
+        entry = {"tmux_window": "platform", "tmux_pane": "1"}
+        (registry_dir / "author-a.json").write_text(json.dumps(entry))
+        monkeypatch.chdir(tmp_path)
+
+        with patch(f"{_WORKER_POOL}.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            result = nudge_pane("author-a", "pkt789")
+            assert result.executed is True
+            call_args = mock_run.call_args[0][0]
+            assert call_args[3] == "steward:platform.1"
+
 
 # ---------------------------------------------------------------------------
 # Reset worktree
@@ -2178,6 +2243,25 @@ class TestClearSession:
             result = clear_session("author-b", runtime_dir=tmp_path)
             assert result.executed is True
             assert "steward:platform.1" in result.reason
+            call_args = mock_run.call_args[0][0]
+            assert call_args[3] == "steward:platform.1"
+
+    def test_clear_uses_default_runtime_registry(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Default .claude/runtime registry should be used when available."""
+        registry_dir = tmp_path / ".claude" / "runtime" / "worktree_registry"
+        registry_dir.mkdir(parents=True)
+        entry = {"tmux_window": "platform", "tmux_pane": "1"}
+        (registry_dir / "author-a.json").write_text(json.dumps(entry))
+        monkeypatch.chdir(tmp_path)
+
+        with patch(f"{_WORKER_POOL}.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            result = clear_session("author-a")
+            assert result.executed is True
             call_args = mock_run.call_args[0][0]
             assert call_args[3] == "steward:platform.1"
 
@@ -3042,7 +3126,10 @@ class TestDispatchNudgeIntegration:
 
         assert result.executed is True
         mock_nudge.assert_called_once_with(
-            "author-a", "pkt1", tmux_session=DEFAULT_TMUX_SESSION
+            "author-a",
+            "pkt1",
+            tmux_session=DEFAULT_TMUX_SESSION,
+            runtime_dir=runtime_dir,
         )
 
     @patch(f"{_DASHBOARD}.set_lane_visibility")

--- a/web/templates/game.html
+++ b/web/templates/game.html
@@ -56,7 +56,7 @@
                     <div class="card-back" aria-hidden="true"></div>
                     {% endfor %}
                 </div>
-                <span class="ai-card-count" aria-hidden="true">AI Left ({{ opp_left_count | default(0) }})</span>
+                <span class="ai-card-count">AI Left ({{ opp_left_count | default(0) }})</span>
             </div>
 
             {# Partner (seat 2) #}
@@ -66,7 +66,7 @@
                     <div class="card-back" aria-hidden="true"></div>
                     {% endfor %}
                 </div>
-                <span class="ai-card-count" aria-hidden="true">Partner ({{ partner_count | default(0) }})</span>
+                <span class="ai-card-count">Partner ({{ partner_count | default(0) }})</span>
             </div>
 
             {# Right opponent (seat 3) #}
@@ -76,7 +76,7 @@
                     <div class="card-back" aria-hidden="true"></div>
                     {% endfor %}
                 </div>
-                <span class="ai-card-count" aria-hidden="true">AI Right ({{ opp_right_count | default(0) }})</span>
+                <span class="ai-card-count">AI Right ({{ opp_right_count | default(0) }})</span>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- restore worker-pool tmux targeting so default `.claude/runtime` registry resolution is honored across probe, clear, nudge, dispatch, and retire paths
- preserve the required `tests` and `governance` check contexts for dashboard chore PRs while still skipping the heavy workflow body for that narrow case
- expose mobile AI hand counts to assistive tech on the initial full-page render and add regression coverage for the accessibility-sensitive template path

## Testing
- `uv run python -m pytest tests/unit/test_ops_worker_pool.py tests/unit/test_ci_workflow.py tests/unit/test_governance_workflow.py tests/unit/hosted_play/test_partials.py -q`
- `uv run ruff check src/bid_euchre/ops/worker_pool.py tests/unit/test_ops_worker_pool.py tests/unit/test_ci_workflow.py tests/unit/test_governance_workflow.py tests/unit/hosted_play/test_partials.py`

## Closes
- closes #1872
- closes #1873
- closes #1874

## Follow-up
- refs #1875 for the still-open Playwright mobile browser suite run
