### PR TITLE
ci: keep auto-dashboard PRs auto-mergeable

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,11 +14,12 @@ permissions:
 jobs:
   enable-auto-merge:
     runs-on: ubuntu-latest
-    # pull_request events: must be owner-authored (gate immediately)
+    # pull_request events: owner-authored and auto-dashboard PRs are eligible
     # check_suite events: must have succeeded (eligibility checked in step)
     if: >-
       (github.event_name == 'pull_request' &&
-       github.event.pull_request.user.login == github.repository_owner)
+       (github.event.pull_request.user.login == github.repository_owner ||
+        startsWith(github.event.pull_request.head.ref, 'chore/auto-dashboard')))
       ||
       (github.event_name == 'check_suite' &&
        github.event.check_suite.conclusion == 'success')
@@ -45,12 +46,12 @@ jobs:
           elif [ "$EVENT_NAME" = "check_suite" ]; then
             echo "::group::Check suite completed for ${HEAD_SHA:0:12}"
 
-            # Find open, owner-authored PRs targeting main for this head SHA
+            # Find open, eligible PRs targeting main for this head SHA.
             prs=$(gh pr list \
               --state open \
               --base main \
-              --json number,author,headRefOid \
-              --jq ".[] | select(.headRefOid == \"${HEAD_SHA}\" and .author.login == \"${REPO_OWNER}\") | .number")
+              --json number,author,headRefName,headRefOid \
+              --jq ".[] | select(.headRefOid == \"${HEAD_SHA}\" and (.author.login == \"${REPO_OWNER}\" or (.headRefName | startswith(\"chore/auto-dashboard\")))) | .number")
 
             if [ -z "$prs" ]; then
               echo "No eligible open PRs found for SHA ${HEAD_SHA:0:12}"

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           git diff --quiet -- assets/dashboard/ && echo "changed=false" >> "$GITHUB_OUTPUT" || echo "changed=true" >> "$GITHUB_OUTPUT"
 
-      - name: Open dashboard update PR
+      - name: Open or update dashboard PR
         if: steps.changes.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -70,8 +70,12 @@ jobs:
               --base main \
               --head "$BRANCH")
             echo "Created PR: $PR_URL"
-            # Enable auto-merge if the repo setting allows it
-            gh pr merge "$BRANCH" --auto --squash --delete-branch 2>/dev/null || echo "Auto-merge not available — PR will need manual merge"
+            PR_NUMBER=$(gh pr view "$BRANCH" --json number -q '.number')
           else
             echo "PR #$EXISTING already exists — branch updated via force-push"
+            PR_NUMBER="$EXISTING"
           fi
+
+          # Re-queue auto-merge on every update so the dashboard PR can
+          # self-close once the lightweight required checks report.
+          gh pr merge "$PR_NUMBER" --auto --squash --delete-branch 2>/dev/null || echo "Auto-merge not available — PR will need manual merge"

--- a/tests/unit/test_auto_merge_workflow.py
+++ b/tests/unit/test_auto_merge_workflow.py
@@ -1,9 +1,9 @@
 """Regression tests for .github/workflows/auto-merge.yml structure.
 
-The auto-merge workflow enables GitHub auto-merge for owner-authored PRs.
-It fires on PR open/reopen/synchronize and retries after check suites
-complete. These tests verify the structural invariants that keep the
-workflow safe and correctly scoped.
+The auto-merge workflow enables GitHub auto-merge for owner-authored PRs
+and the auto-dashboard maintenance PRs. It fires on PR open/reopen/
+synchronize and retries after check suites complete. These tests verify
+the structural invariants that keep the workflow safe and correctly scoped.
 """
 
 from __future__ import annotations
@@ -36,11 +36,13 @@ class TestAutoMergeWorkflowStructure:
         cs_trigger = self.workflow[True]["check_suite"]
         assert "completed" in cs_trigger["types"]
 
-    def test_job_condition_gates_owner_for_pull_request(self) -> None:
-        """pull_request events must be gated to repo owner."""
+    def test_job_condition_gates_owner_and_dashboard_prs(self) -> None:
+        """pull_request events must allow the owner and auto-dashboard PRs."""
         job_if = self.jobs["enable-auto-merge"]["if"]
         assert "pull_request" in job_if
         assert "repository_owner" in job_if
+        assert "pull_request.head.ref" in job_if
+        assert "chore/auto-dashboard" in job_if
 
     def test_job_condition_gates_success_for_check_suite(self) -> None:
         """check_suite events must be gated to successful conclusions."""
@@ -66,13 +68,15 @@ class TestAutoMergeWorkflowStructure:
         assert "HEAD_SHA" in env
         assert "REPO_OWNER" in env
 
-    def test_check_suite_path_filters_owner_authored_prs(self) -> None:
-        """The check_suite retry path must filter to owner-authored PRs."""
+    def test_check_suite_path_filters_owner_and_dashboard_prs(self) -> None:
+        """The check_suite retry path must filter to eligible PRs only."""
         step = self.jobs["enable-auto-merge"]["steps"][0]
         script = step["run"]
-        # Must filter by author login matching repo owner
+        # Must filter by author login matching repo owner or the dashboard branch
         assert "author.login" in script
         assert "REPO_OWNER" in script
+        assert "headRefName" in script
+        assert "chore/auto-dashboard" in script
         # Must filter to open PRs targeting main
         assert "--state open" in script
         assert "--base main" in script

--- a/tests/unit/test_dashboard_workflow.py
+++ b/tests/unit/test_dashboard_workflow.py
@@ -53,6 +53,14 @@ class TestDashboardWorkflowStructure:
         pr_steps = [s for s in job["steps"] if "gh pr create" in str(s.get("run", ""))]
         assert len(pr_steps) >= 1, "Expected at least one step with 'gh pr create'"
 
+    def test_auto_merge_is_reasserted_for_existing_dashboard_prs(self) -> None:
+        """The workflow should queue auto-merge after every branch update."""
+        job = self.workflow["jobs"]["update-dashboard"]
+        step = next(s for s in job["steps"] if "gh pr create" in str(s.get("run", "")))
+        script = step["run"]
+        assert 'PR_NUMBER="$EXISTING"' in script
+        assert 'gh pr merge "$PR_NUMBER" --auto --squash --delete-branch' in script
+
     def test_dashboard_branch_is_not_main(self) -> None:
         """The commit target branch must not be 'main'."""
         job = self.workflow["jobs"]["update-dashboard"]


### PR DESCRIPTION
## Summary
- re-enable `gh pr merge --auto` on every dashboard branch update, not just on brand-new PR creation
- let the repo-wide auto-merge workflow treat `chore/auto-dashboard` PRs as eligible for the same retry path it already uses for owner-authored PRs
- add regression coverage for both workflow invariants so dashboard PRs keep moving without sitting in the queue

## Testing
- `uv run python -m pytest tests/unit/test_dashboard_workflow.py tests/unit/test_auto_merge_workflow.py -q`
- `uv run ruff check tests/unit/test_dashboard_workflow.py tests/unit/test_auto_merge_workflow.py`
