### PR TITLE
ops: reject naive monitor now overrides

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -2325,6 +2325,22 @@ def cmd_monitor(args: argparse.Namespace) -> int:
     else:
         print(format_findings_text(findings))
 
+    parsed_now = None
+    if getattr(args, "now", None):
+        from datetime import datetime as _dt
+
+        try:
+            parsed_now = _dt.fromisoformat(args.now)
+        except ValueError:
+            print("error: --now must be a valid ISO-8601 timestamp", file=sys.stderr)
+            return 2
+        if parsed_now.tzinfo is None:
+            print(
+                "error: --now must include a timezone offset",
+                file=sys.stderr,
+            )
+            return 2
+
     # Update the controller projection so fleet_status.json reflects the
     # latest monitor findings, task queue, inbox, and audit state.
     if not no_reconcile:
@@ -2362,7 +2378,7 @@ def cmd_monitor(args: argparse.Namespace) -> int:
             task_packets=task_dicts,
             unacked_messages=inbox_msgs,
             audit_records=audit_dicts,
-            now_iso=getattr(args, "now", None),
+            now_iso=parsed_now.isoformat() if parsed_now else None,
         )
 
     # --- Alert push cycle (Platform-9a) ---
@@ -2371,17 +2387,13 @@ def cmd_monitor(args: argparse.Namespace) -> int:
     no_push = getattr(args, "no_push", False)
     if not no_reconcile and not no_push:
         try:
-            from datetime import datetime as _dt
-
             from bid_euchre.ops.telegram_push import run_push_cycle
 
             audit_dir = args.runtime_dir / "audit_trail" if args.runtime_dir else None
             push_result = run_push_cycle(
                 runtime_dir=args.runtime_dir,
                 audit_dir=audit_dir,
-                now=(
-                    _dt.fromisoformat(args.now) if getattr(args, "now", None) else None
-                ),
+                now=parsed_now,
             )
             if push_result is not None:
                 print(

--- a/tests/unit/test_ops_control_plane.py
+++ b/tests/unit/test_ops_control_plane.py
@@ -1736,6 +1736,35 @@ class TestMonitorReconcileWiring:
         # No fleet status file should exist.
         assert load_fleet_status(tmp_path) is None
 
+    def test_cli_monitor_rejects_naive_now_override(self, tmp_path: Path):
+        """CLI monitor requires a timezone-aware --now override."""
+        import subprocess
+
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "python",
+                "scripts/internal/ops.py",
+                "--runtime-dir",
+                str(tmp_path),
+                "monitor",
+                "--skip-pr-check",
+                "--no-notify",
+                "--no-recovery",
+                "--no-auto-dispatch",
+                "--now",
+                "2026-03-25T12:00:00",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+        assert result.returncode == 2
+        assert "--now must include a timezone offset" in result.stderr
+        assert load_fleet_status(tmp_path) is None
+
     def test_cli_monitor_reads_task_packets_from_task_queue_subdir(
         self, tmp_path: Path
     ):


### PR DESCRIPTION
Closes #1788

## Summary
- validate `ops.py monitor --now` once at the CLI boundary
- reject timezone-naive overrides before reconcile or alert-push logic runs
- add a subprocess regression test for the naive timestamp path

## Local verification
- uv run pytest tests/unit/test_ops_control_plane.py -k "monitor_rejects_naive_now_override or cli_monitor_reconcile_smoke or cli_no_reconcile_flag" -q