### PR TITLE
ops: harden inbound inline channel sanitizing

### DIFF
--- a/.claude/hooks/inbound-channel-audit.py
+++ b/.claude/hooks/inbound-channel-audit.py
@@ -41,7 +41,7 @@ _CHANNEL_RE = re.compile(
 
 
 def _neutralise_inline_code(m: re.Match[str]) -> str:
-    """Replace ``<channel`` inside an inline-code match with a safe token.
+    """Replace channel tag fragments inside inline code with safe tokens.
 
     The backtick delimiters and the rest of the span are preserved so that
     real channel bodies containing inline code (e.g. ``use `git status` ``)
@@ -49,17 +49,20 @@ def _neutralise_inline_code(m: re.Match[str]) -> str:
     """
     span = m.group(0)
     if "<channel" in span:
-        return span.replace("<channel", "&lt;channel")
+        span = span.replace("<channel", "&lt;channel")
+    if "</channel>" in span:
+        span = span.replace("</channel>", "&lt;/channel&gt;")
     return span
 
 
 def _strip_code_blocks(text: str) -> str:
-    """Remove fenced code blocks and neutralise ``<channel`` inside inline code.
+    """Remove fenced code blocks and neutralise channel tags in inline code.
 
     Fenced blocks (triple-backtick) are removed entirely.  Inline backtick
-    spans are *preserved* but any ``<channel`` inside them is replaced with
-    ``&lt;channel`` so the tag regex will not match pasted examples, while
-    the surrounding backtick content is kept intact for real channel bodies.
+    spans are *preserved* but any ``<channel`` or ``</channel>`` inside them
+    is replaced with HTML-safe tokens so the tag regex will not match pasted
+    examples or accidentally terminate a real channel body early, while the
+    surrounding backtick content is kept intact for real channel bodies.
     """
     text = _CODE_FENCE_RE.sub("", text)
     return _INLINE_CODE_RE.sub(_neutralise_inline_code, text)

--- a/tests/unit/test_inbound_channel_audit.py
+++ b/tests/unit/test_inbound_channel_audit.py
@@ -69,6 +69,13 @@ class TestStripCodeBlocks:
         assert "Use" in result
         assert "to send messages" in result
 
+    def test_neutralises_closing_channel_in_inline_code(self, hook: ModuleType) -> None:
+        """Inline closing tags must not terminate real channel blocks early."""
+        text = "Body contains `</channel>` literally"
+        result = hook._strip_code_blocks(text)
+        assert "</channel>" not in result
+        assert "&lt;/channel&gt;" in result
+
     def test_preserves_inline_code_without_channel(self, hook: ModuleType) -> None:
         """Inline backtick content with no <channel is left untouched."""
         text = "Run `git status` to check"
@@ -191,6 +198,20 @@ class TestExtractChannelBlocksCodeFiltering:
         )
         blocks = hook.extract_channel_blocks(text)
         assert len(blocks) == 0
+
+    def test_inline_closing_tag_inside_real_body_does_not_truncate(
+        self, hook: ModuleType
+    ) -> None:
+        """Inline ``</channel>`` inside a real body must stay literal."""
+        text = (
+            '<channel source="telegram" chat_id="123" message_id="77" user="alice" ts="t">'
+            "Please type `</channel>` literally before you continue."
+            "</channel>"
+        )
+        blocks = hook.extract_channel_blocks(text)
+        assert len(blocks) == 1
+        assert "Please type" in blocks[0][1]
+        assert "before you continue." in blocks[0][1]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1825

## Summary
- neutralize inline closing `</channel>` fragments in the inbound audit hook
- keep real channel bodies intact when they contain inline code examples
- add regression coverage for the inline closing-tag truncation case

## Local verification
- uv run pytest tests/unit/test_inbound_channel_audit.py -q