### PR TITLE
web: add safe-area support to base template

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -1380,6 +1380,14 @@ class TestAccessibilityBaseTemplate:
         html = tmpl.render()
         assert "viewport-fit=cover" in html
 
+    def test_safe_area_css_present(self, env):
+        tmpl = env.get_template("base.html")
+        html = tmpl.render()
+        assert "safe-area-inset-top" in html
+        assert "safe-area-inset-right" in html
+        assert "safe-area-inset-bottom" in html
+        assert "safe-area-inset-left" in html
+
 
 class TestGameTemplateAccessibility:
     """Verify accessibility-sensitive behavior in the full-page game template."""

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -6,6 +6,18 @@
     <title>{% block title %}Bid Euchre{% endblock %}</title>
     <link rel="stylesheet" href="/static/style.css">
     <link rel="stylesheet" href="/static/css/accessibility.css">
+    <style>
+        :root {
+            --safe-area-top: env(safe-area-inset-top, 0px);
+            --safe-area-right: env(safe-area-inset-right, 0px);
+            --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+            --safe-area-left: env(safe-area-inset-left, 0px);
+        }
+
+        body {
+            padding: var(--safe-area-top) var(--safe-area-right) var(--safe-area-bottom) var(--safe-area-left);
+        }
+    </style>
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     <script src="/static/game.js" defer></script>
     {% block head %}{% endblock %}


### PR DESCRIPTION
Closes #1819

## Summary
- add safe-area inset variables to the shared base template used with `viewport-fit=cover`
- pad the page body by the reported notch/home-indicator insets
- add a template regression test for the safe-area CSS

## Local verification
- uv run pytest tests/unit/hosted_play/test_partials.py -k "AccessibilityBaseTemplate" -q