### PR TITLE
ops: refresh VS Code steward workspace surface

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -56,6 +56,54 @@
       "problemMatcher": []
     },
     {
+      "label": "Ops dashboard",
+      "type": "shell",
+      "command": "uv run python scripts/internal/ops.py dashboard",
+      "group": "none",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Ops dashboard (JSON)",
+      "type": "shell",
+      "command": "uv run python scripts/internal/ops.py dashboard --json",
+      "group": "none",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Ops monitor (JSON)",
+      "type": "shell",
+      "command": "uv run python scripts/internal/ops.py monitor --skip-pr-check --no-notify --no-recovery --no-auto-dispatch --json",
+      "group": "none",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Fleet status",
+      "type": "shell",
+      "command": "uv run python scripts/internal/ops.py fleet",
+      "group": "none",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      },
+      "problemMatcher": []
+    },
+    {
       "label": "Ruff lint",
       "type": "shell",
       "command": "uv run ruff check src/ tests/ scripts/ experiments/",

--- a/Bid-Euchre-agent-audit.code-workspace
+++ b/Bid-Euchre-agent-audit.code-workspace
@@ -5,6 +5,10 @@
       "path": "."
     },
     {
+      "name": "analyst-a",
+      "path": "../Bid-Euchre-steward-analyst"
+    },
+    {
       "name": "author-a",
       "path": "../Bid-Euchre-steward-author"
     },
@@ -21,17 +25,48 @@
       "path": "../Bid-Euchre-steward-author-d"
     },
     {
-      "name": "review",
-      "path": "../Bid-Euchre-steward-review"
+      "name": "browser-a",
+      "path": "../Bid-Euchre-steward-brws-author-a"
     },
     {
-      "name": "scratch",
-      "path": "../Bid-Euchre-steward-author-scratch"
+      "name": "browser-b",
+      "path": "../Bid-Euchre-steward-brws-author-b"
+    },
+    {
+      "name": "browser-c",
+      "path": "../Bid-Euchre-steward-brws-author-c"
+    },
+    {
+      "name": "browser-d",
+      "path": "../Bid-Euchre-steward-brws-author-d"
+    },
+    {
+      "name": "flex-a",
+      "path": "../Bid-Euchre-steward-flex-a"
+    },
+    {
+      "name": "flex-b",
+      "path": "../Bid-Euchre-steward-flex-b"
+    },
+    {
+      "name": "flex-c",
+      "path": "../Bid-Euchre-steward-flex-c"
+    },
+    {
+      "name": "ops",
+      "path": "../Bid-Euchre-steward-ops"
+    },
+    {
+      "name": "review",
+      "path": "../Bid-Euchre-steward-review"
     }
   ],
   "settings": {
     "files.exclude": {
       "**/.venv": true,
+      "**/.pytest_cache": true,
+      "**/.mypy_cache": true,
+      "**/.ruff_cache": true,
       "**/__pycache__": true,
       "data/runs": true,
       "data/artifacts": true,
@@ -39,23 +74,32 @@
       "data/reports": true,
       "data/training": true,
       "**/*.pyc": true,
+      ".claude/runtime": true,
       ".claude/worktrees": true
     },
     "search.exclude": {
       "**/.venv": true,
+      "**/.pytest_cache": true,
+      "**/.mypy_cache": true,
+      "**/.ruff_cache": true,
       "**/__pycache__": true,
       "data/runs": true,
       "data/artifacts": true,
       "data/models": true,
       "data/reports": true,
       "**/*.pyc": true,
+      ".claude/runtime": true,
       ".claude/worktrees": true
     },
     "files.watcherExclude": {
       "**/.venv/**": true,
+      "**/.pytest_cache/**": true,
+      "**/.mypy_cache/**": true,
+      "**/.ruff_cache/**": true,
       "data/runs/**": true,
       "data/artifacts/**": true,
       "data/models/**": true,
+      ".claude/runtime/**": true,
       ".claude/worktrees/**": true
     },
     "python.defaultInterpreterPath": ".venv/bin/python",
@@ -75,7 +119,10 @@
     "recommendations": [
       "charliermarsh.ruff",
       "ms-python.python",
-      "eamodio.gitlens"
+      "eamodio.gitlens",
+      "redhat.vscode-yaml",
+      "tamasfe.even-better-toml",
+      "samuelcolvin.jinjahtml"
     ]
   }
 }


### PR DESCRIPTION
Closes #1831

## Summary
- replace the stale workspace roots with the current analyst, browser, flex, ops, review, and author worktrees
- exclude runtime and cache-heavy directories from file/search/watch surfaces
- add VS Code tasks for `ops.py dashboard`, `ops.py monitor`, and `ops.py fleet`
- recommend YAML, TOML, and Jinja extensions alongside the existing Python toolchain

## Local verification
- python3 -m json.tool Bid-Euchre-agent-audit.code-workspace >/dev/null
- python3 -m json.tool .vscode/tasks.json >/dev/null