### PR TITLE
docs: standardize Telegram elapsed-time guidance

### DIFF
--- a/.claude/skills/check-in/SKILL.md
+++ b/.claude/skills/check-in/SKILL.md
@@ -28,6 +28,24 @@ monitoring infrastructure.
 
 ## Workflow
 
+### Session Timing Rule
+
+Record a single `fleet_start_time` at the beginning of the run and reuse it for
+every later Telegram or remote status update. Do not hand-estimate elapsed
+times.
+
+When a check-in summary is relayed outside the local terminal:
+
+1. Reuse the original UTC start timestamp for the run.
+2. Compute `elapsed = now - fleet_start_time`.
+3. Format it consistently as `T+<hours>h<minutes:02d>m`.
+
+Examples:
+
+- `T+0h05m`
+- `T+1h20m`
+- `T+2h00m`
+
 ### Phase 1 — Inbox Poll (MANDATORY FIRST STEP)
 
 1. **Read pending inbox messages (priority-sorted):**
@@ -180,6 +198,10 @@ monitoring infrastructure.
     ALERTS:     <list any unresolved HIGH alerts>
     NEXT:       <recommended action>
     ```
+
+15. **If you send the summary to Telegram or another remote channel,**
+   prefix it with the computed elapsed value from `fleet_start_time`, not a
+   manually estimated string.
 
 ## Integration with /run-fleet
 

--- a/.claude/skills/run-fleet/SKILL.md
+++ b/.claude/skills/run-fleet/SKILL.md
@@ -19,7 +19,16 @@ mergeable throughput across all defined tracks.
 Before entering the main dispatch loop:
 
 1. Recover context (`/recovering-context` or read MEMORY.md)
-2. **Set up inbox polling cron** — ensures inbox is read even if the
+2. **Record `fleet_start_time` once for the whole run** — use a single
+   timezone-aware UTC timestamp and keep reusing it in every Telegram or remote
+   status update.
+   ```
+   fleet_start_time = <UTC timestamp captured at session start>
+   elapsed = now - fleet_start_time
+   format elapsed as T+<hours>h<minutes:02d>m
+   ```
+   Never hand-estimate elapsed strings like `T+50min` or `T+2h`.
+3. **Set up inbox polling cron** — ensures inbox is read even if the
    orchestrator gets absorbed in a long task and skips check-in cycles.
    **Deduplicate first:** list existing crons and delete any stale
    inbox-poll cron before creating a new one (prevents duplicates when
@@ -34,14 +43,14 @@ Before entering the main dispatch loop:
    ```
    This is the backup mechanism. The primary mechanism is step 0 of every
    dispatch cycle (see Dispatch Discipline below).
-3. Check dashboard health: `uv run python scripts/internal/ops.py dashboard --json`
-4. Bulk-refresh idle lanes:
+4. Check dashboard health: `uv run python scripts/internal/ops.py dashboard --json`
+5. Bulk-refresh idle lanes:
    ```bash
    uv run python scripts/internal/ops.py lane refresh --all-idle
    ```
-5. Triage inbox and open issues; route ambiguous or multi-PR shaping work to
+6. Triage inbox and open issues; route ambiguous or multi-PR shaping work to
    `steward-analyst`
-6. Define Wave 1 candidates
+7. Define Wave 1 candidates
 
 ## Primary Goal
 


### PR DESCRIPTION
Closes #1829

Follow-up proving run: #1887

## Summary
- require `/run-fleet` to record a single `fleet_start_time` at session start
- require `/check-in` to format remote elapsed time from that recorded timestamp as `T+<hours>h<minutes:02d>m`
- explicitly ban hand-estimated elapsed strings in Telegram status updates

## Local verification
- no automated local test path exists for live Telegram message timing; proving is tracked in #1887