### PR TITLE
fix(web): add next-driven hosted play flow and moon exchange

### DIFF
--- a/src/bid_euchre/hosted_play/engine.py
+++ b/src/bid_euchre/hosted_play/engine.py
@@ -14,7 +14,11 @@ from typing import Any
 from bid_euchre.core.rules import get_legal_indices, trick_winner
 from bid_euchre.scoring import compute_points
 from bid_euchre.sim.deals import generate_deal
-from bid_euchre.sim.exchange import perform_exchange
+from bid_euchre.sim.exchange import (
+    perform_exchange,
+    select_mooner_discards,
+    select_partner_gifts,
+)
 from bid_euchre.strategy.base import Strategy
 from bid_euchre.strategy.bidding import (
     BidAction,
@@ -176,6 +180,31 @@ class MatchEngine:
         state = self._advance_ai(state)
         return state
 
+    def submit_human_moon_exchange(
+        self,
+        state: MatchState,
+        card_indices: list[int],
+    ) -> MatchState:
+        """Process the human side of a moon exchange."""
+        self.last_ai_events = []
+        hand = state.current_hand
+        assert hand is not None
+        assert hand.phase == "moon_exchange"
+        assert hand.current_seat == HUMAN_SEAT
+
+        state = self._process_moon_exchange(state, card_indices)
+        return state
+
+    def advance_after_moon_review(self, state: MatchState) -> MatchState:
+        """Continue from the moon review phase into trick play."""
+        hand = state.current_hand
+        if hand is None or hand.phase != "moon_exchange_review":
+            return state
+
+        self._start_trick_play(hand)
+        state = self._advance_ai(state)
+        return state
+
     def get_legal_bids(self, state: MatchState) -> list[BidAction]:
         """Return legal bids for the current bidder.
 
@@ -252,6 +281,7 @@ class MatchEngine:
         result["sitting_out_seat"] = hand.sitting_out_seat
         result["exchange_given"] = hand.exchange_given
         result["exchange_received"] = hand.exchange_received
+        result["exchange_step"] = hand.exchange_step
         result["current_trick"] = (
             None
             if hand.current_trick is None
@@ -487,10 +517,52 @@ class MatchEngine:
             hand.phase = "redeal"
             return state
 
-        # Moon exchange: mooner gives 2 worst cards, receives partner's 2 best
         if hand.bid_type == "moon":
-            mooner_seat = hand.bidder_seat
-            partner_seat = (mooner_seat + 2) % _NUM_PLAYERS
+            return self._start_moon_exchange(state)
+
+        # Loner: partner sits out during trick play
+        if hand.bid_type == "loner":
+            hand.sitting_out_seat = (hand.bidder_seat + 2) % _NUM_PLAYERS
+
+        self._start_trick_play(hand)
+        return state
+
+    def _start_trick_play(self, hand: HandState) -> None:
+        """Transition a resolved contract into trick play."""
+        hand.phase = "trick_play"
+        hand.exchange_step = None
+        leader = hand.bidder_seat
+        hand.current_trick = TrickState(leader=leader)
+        hand.current_seat = leader
+
+    def _move_cards(
+        self,
+        source_hand: list,
+        target_hand: list,
+        indices: list[int],
+    ) -> list:
+        """Move cards from source to target using descending indices."""
+        moved = []
+        for idx in sorted(indices, reverse=True):
+            moved.append(source_hand.pop(idx))
+        target_hand.extend(moved)
+        return moved
+
+    def _start_moon_exchange(self, state: MatchState) -> MatchState:
+        """Enter the appropriate moon exchange phase."""
+        hand = state.current_hand
+        assert hand is not None
+        assert hand.bidder_seat is not None
+
+        mooner_seat = hand.bidder_seat
+        partner_seat = (mooner_seat + 2) % _NUM_PLAYERS
+        contract_type = hand.contract_type or "suit"
+
+        hand.current_trick = None
+        hand.exchange_given = None
+        hand.exchange_received = None
+
+        if HUMAN_SEAT not in (mooner_seat, partner_seat):
             (
                 hand.hands[mooner_seat],
                 hand.hands[partner_seat],
@@ -499,23 +571,95 @@ class MatchEngine:
             ) = perform_exchange(
                 mooner_hand=hand.hands[mooner_seat],
                 partner_hand=hand.hands[partner_seat],
-                contract_type=hand.contract_type or "suit",
+                contract_type=contract_type,
                 trump_suit=hand.trump,
             )
             hand.exchange_given = [[c.suit, c.rank] for c in cards_given]
             hand.exchange_received = [[c.suit, c.rank] for c in cards_received]
+            hand.phase = "moon_exchange_review"
+            hand.exchange_step = None
+            hand.current_seat = HUMAN_SEAT
+            return state
 
-        # Loner: partner sits out during trick play
-        if hand.bid_type == "loner":
-            hand.sitting_out_seat = (hand.bidder_seat + 2) % _NUM_PLAYERS
+        hand.phase = "moon_exchange"
+        hand.current_seat = HUMAN_SEAT
 
-        # Contract set — transition to trick play
-        hand.phase = "trick_play"
-        # Declarer leads first trick (RULES.md §5.1)
-        leader = hand.bidder_seat
-        hand.current_trick = TrickState(leader=leader)
-        hand.current_seat = leader
+        if partner_seat == HUMAN_SEAT:
+            hand.exchange_step = "partner_to_mooner"
+            return state
 
+        partner_gift_indices = select_partner_gifts(
+            hand.hands[partner_seat],
+            contract_type,
+            hand.trump,
+        )
+        partner_gifts = self._move_cards(
+            hand.hands[partner_seat],
+            hand.hands[mooner_seat],
+            partner_gift_indices,
+        )
+        hand.exchange_received = [[c.suit, c.rank] for c in partner_gifts]
+        hand.exchange_step = "mooner_to_partner"
+        return state
+
+    def _process_moon_exchange(
+        self,
+        state: MatchState,
+        card_indices: list[int],
+    ) -> MatchState:
+        """Resolve a human moon exchange choice."""
+        hand = state.current_hand
+        assert hand is not None
+        assert hand.bidder_seat is not None
+        assert hand.phase == "moon_exchange"
+        assert hand.exchange_step in ("partner_to_mooner", "mooner_to_partner")
+
+        if len(card_indices) != 2 or len(set(card_indices)) != 2:
+            raise ValueError("Moon exchange requires exactly two distinct cards")
+
+        mooner_seat = hand.bidder_seat
+        partner_seat = (mooner_seat + 2) % _NUM_PLAYERS
+        contract_type = hand.contract_type or "suit"
+
+        if hand.exchange_step == "partner_to_mooner":
+            if any(
+                idx < 0 or idx >= len(hand.hands[partner_seat]) for idx in card_indices
+            ):
+                raise ValueError("Moon exchange indices out of range")
+            partner_gifts = self._move_cards(
+                hand.hands[partner_seat],
+                hand.hands[mooner_seat],
+                card_indices,
+            )
+            hand.exchange_received = [[c.suit, c.rank] for c in partner_gifts]
+
+            mooner_return_indices = select_mooner_discards(
+                hand.hands[mooner_seat],
+                contract_type,
+                hand.trump,
+            )
+            mooner_discards = self._move_cards(
+                hand.hands[mooner_seat],
+                hand.hands[partner_seat],
+                mooner_return_indices,
+            )
+            hand.exchange_given = [[c.suit, c.rank] for c in mooner_discards]
+        else:
+            if any(
+                idx < 0 or idx >= len(hand.hands[mooner_seat]) for idx in card_indices
+            ):
+                raise ValueError("Moon exchange indices out of range")
+            mooner_discards = self._move_cards(
+                hand.hands[mooner_seat],
+                hand.hands[partner_seat],
+                card_indices,
+            )
+            hand.exchange_given = [[c.suit, c.rank] for c in mooner_discards]
+
+        hand.turn_number += 1
+        hand.phase = "moon_exchange_review"
+        hand.exchange_step = None
+        hand.current_seat = HUMAN_SEAT
         return state
 
     # ------------------------------------------------------------------

--- a/src/bid_euchre/hosted_play/state.py
+++ b/src/bid_euchre/hosted_play/state.py
@@ -100,6 +100,9 @@ class HandState:
     exchange_received: list[list[str]] | None = (
         None  # moon: cards received from partner
     )
+    exchange_step: str | None = None  # "partner_to_mooner" | "mooner_to_partner"
+    revealed_auction_count: int = 0
+    revealed_trick_count: int = 0
     tricks_team0: int = 0
     tricks_team1: int = 0
     points_team0: int = 0
@@ -123,6 +126,9 @@ class HandState:
             "sitting_out_seat": self.sitting_out_seat,
             "exchange_given": self.exchange_given,
             "exchange_received": self.exchange_received,
+            "exchange_step": self.exchange_step,
+            "revealed_auction_count": self.revealed_auction_count,
+            "revealed_trick_count": self.revealed_trick_count,
             "current_trick": (
                 None if self.current_trick is None else self.current_trick.to_dict()
             ),
@@ -163,6 +169,9 @@ class HandState:
             ),
             exchange_given=data.get("exchange_given"),
             exchange_received=data.get("exchange_received"),
+            exchange_step=data.get("exchange_step"),
+            revealed_auction_count=int(data.get("revealed_auction_count", 0)),
+            revealed_trick_count=int(data.get("revealed_trick_count", 0)),
             current_trick=(
                 None
                 if data.get("current_trick") is None

--- a/src/bid_euchre/sim/exchange.py
+++ b/src/bid_euchre/sim/exchange.py
@@ -177,6 +177,26 @@ def _select_partner_gifts(
     return sorted(indices, reverse=True)
 
 
+def select_mooner_discards(
+    hand: List[Card],
+    contract_type: str,
+    trump_suit: Optional[str],
+    n_cards: int = 2,
+) -> List[int]:
+    """Public wrapper for selecting the mooner's discard indices."""
+    return _select_mooner_discards(hand, contract_type, trump_suit, n_cards=n_cards)
+
+
+def select_partner_gifts(
+    hand: List[Card],
+    contract_type: str,
+    trump_suit: Optional[str],
+    n_cards: int = 2,
+) -> List[int]:
+    """Public wrapper for selecting the partner's gift indices."""
+    return _select_partner_gifts(hand, contract_type, trump_suit, n_cards=n_cards)
+
+
 def perform_exchange(
     mooner_hand: List[Card],
     partner_hand: List[Card],

--- a/tests/unit/hosted_play/test_db.py
+++ b/tests/unit/hosted_play/test_db.py
@@ -461,6 +461,25 @@ class TestDecisionCRUD:
         with pytest.raises(Exception):
             session.flush()
 
+    def test_decision_accepts_moon_exchange_phase(self, session):
+        match, hand = self._make_hand(session)
+        decision = Decision(
+            match_id=match.id,
+            hand_id=hand.id,
+            turn_number=0,
+            seat=0,
+            phase="moon_exchange",
+            actor_type="human",
+            decision_source="human",
+            legal_actions_json="[]",
+            chosen_action_json="[0, 1]",
+            game_state_json="{}",
+        )
+        session.add(decision)
+        session.flush()
+
+        assert decision.id is not None
+
     def test_decision_seat_constraint(self, session):
         match, hand = self._make_hand(session)
         d = Decision(

--- a/tests/unit/hosted_play/test_engine.py
+++ b/tests/unit/hosted_play/test_engine.py
@@ -188,6 +188,17 @@ def _play_full_hand(
         if hand is None:
             return state
 
+    while (
+        state.current_hand is not None and state.current_hand.phase == "moon_exchange"
+    ):
+        state = engine.submit_human_moon_exchange(state, [0, 1])
+
+    while (
+        state.current_hand is not None
+        and state.current_hand.phase == "moon_exchange_review"
+    ):
+        state = engine.advance_after_moon_review(state)
+
     # Handle trick play phase (skip if human is sitting out)
     while (
         state.status == "active"
@@ -225,6 +236,10 @@ def _play_until_match_end(engine: MatchEngine, state: MatchState) -> MatchState:
                 state = engine.submit_human_bid(state, BidAction.bid(5, "S"))
             else:
                 state = engine.submit_human_bid(state, BidAction.pass_bid())
+        elif hand.phase == "moon_exchange":
+            state = engine.submit_human_moon_exchange(state, [0, 1])
+        elif hand.phase == "moon_exchange_review":
+            state = engine.advance_after_moon_review(state)
         elif hand.phase == "trick_play":
             if hand.current_seat == HUMAN_SEAT:
                 legal = engine.get_legal_plays(state)
@@ -1162,8 +1177,8 @@ class TestOvercallHierarchy:
 class TestMoonExchange:
     """Moon win triggers a 2-card exchange before trick play."""
 
-    def test_moon_exchange_happens(self) -> None:
-        """After a moon bid wins, hands are modified by exchange."""
+    def test_human_mooner_must_choose_return_cards(self) -> None:
+        """Human declarer enters an interactive moon exchange phase."""
         engine = MatchEngine(
             bidding_policy=AlwaysPassBidder(),
             play_strategy=FirstLegalPlay(),
@@ -1173,28 +1188,58 @@ class TestMoonExchange:
         assert hand is not None
 
         if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
-            # Capture pre-exchange hands
-            hand_before_human = list(hand.hands[HUMAN_SEAT])
-            hand_before_partner = list(hand.hands[2])
-
             state = engine.submit_human_bid(state, BidAction.moon("S"))
             hand = state.current_hand
             assert hand is not None
+            assert hand.phase == "moon_exchange"
+            assert hand.exchange_step == "mooner_to_partner"
+            assert hand.exchange_received is not None
+            assert len(hand.exchange_received) == 2
+            assert len(hand.hands[HUMAN_SEAT]) == 12
 
-            if hand.phase == "trick_play":
-                # Exchange should have occurred
+            state = engine.submit_human_moon_exchange(state, [0, 1])
+            hand = state.current_hand
+            assert hand is not None
+            assert hand.phase == "moon_exchange_review"
+            assert hand.exchange_given is not None
+            assert len(hand.exchange_given) == 2
+            assert len(hand.hands[HUMAN_SEAT]) == 10
+            assert len(hand.hands[2]) == 10
+
+    def test_human_partner_must_choose_gift_cards(self) -> None:
+        """Human partner enters an interactive moon exchange phase."""
+        engine = MatchEngine(
+            bidding_policy=MoonBidder(contract="S"),
+            play_strategy=FirstLegalPlay(),
+        )
+
+        for seed in range(1, 40):
+            state = engine.start_match(seed, "heuristic")
+            hand = state.current_hand
+            if (
+                hand is not None
+                and hand.phase == "auction"
+                and hand.current_seat == HUMAN_SEAT
+                and hand.bid_type == "moon"
+                and hand.bidder_seat == 2
+            ):
+                state = engine.submit_human_bid(state, BidAction.pass_bid())
+                hand = state.current_hand
+                assert hand is not None
+                assert hand.phase == "moon_exchange"
+                assert hand.exchange_step == "partner_to_mooner"
+                assert hand.current_seat == HUMAN_SEAT
+
+                state = engine.submit_human_moon_exchange(state, [0, 1])
+                hand = state.current_hand
+                assert hand is not None
+                assert hand.phase == "moon_exchange_review"
                 assert hand.exchange_given is not None
                 assert hand.exchange_received is not None
-                assert len(hand.exchange_given) == 2
-                assert len(hand.exchange_received) == 2
-
-                # Hands should have changed (extremely unlikely to be same)
-                assert hand.hands[HUMAN_SEAT] != hand_before_human
-                assert hand.hands[2] != hand_before_partner
-
-                # Both hands should still have 10 cards
                 assert len(hand.hands[HUMAN_SEAT]) == 10
-                assert len(hand.hands[2]) == 10
+                return
+
+        pytest.fail("Could not find a seed where AI partner declares moon")
 
     def test_moon_exchange_state_persists(self) -> None:
         """Exchange metadata survives serialization."""
@@ -1211,12 +1256,18 @@ class TestMoonExchange:
             hand = state.current_hand
             assert hand is not None
 
-            if hand.phase == "trick_play" and hand.exchange_given is not None:
+            if hand.phase == "moon_exchange":
+                state = engine.submit_human_moon_exchange(state, [0, 1])
+                hand = state.current_hand
+                assert hand is not None
+
+            if hand.phase == "moon_exchange_review" and hand.exchange_given is not None:
                 data = MatchEngine.serialize(state)
                 restored = MatchEngine.deserialize(data)
                 assert restored.current_hand is not None
                 assert restored.current_hand.exchange_given == hand.exchange_given
                 assert restored.current_hand.exchange_received == hand.exchange_received
+                assert restored.current_hand.exchange_step == hand.exchange_step
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -500,9 +500,8 @@ class TestTrick:
         assert "AI Left" in html
         assert "AI Partner" in html
         assert "AI Right" in html
-        assert "\u2666" in html  # ♦
-        assert "\u2660" in html  # ♠
-        assert "AI Partner" in html
+        assert "\u2666" in html
+        assert "\u2660" in html
         assert "won" in html
 
     def test_markers_for_dealer_turn_declarer_and_sitout(self, env):
@@ -544,6 +543,41 @@ class TestGameControls:
         assert "Moon and loner" in html
         assert "High/Low" in html
         assert "+52 or -52" in html
+
+
+class TestMoonExchange:
+    def test_moon_exchange_selection_renders_form(self, env):
+        tmpl = env.get_template("partials/moon_exchange.html")
+        html = tmpl.render(
+            phase="moon_exchange",
+            link_uuid="abc-123",
+            turn_number=7,
+            bidder_seat=0,
+            human_hand=[["S", "A"], ["H", "K"], ["D", "Q"]],
+            exchange_step="mooner_to_partner",
+            exchange_received=[["S", "J"], ["C", "A"]],
+            exchange_given=None,
+        )
+        assert 'action="/play/abc-123/moon-exchange"' in html
+        assert 'name="card_indices"' in html
+        assert 'value="0"' in html
+        assert "Confirm Exchange" in html
+
+    def test_moon_exchange_review_renders_next(self, env):
+        tmpl = env.get_template("partials/moon_exchange.html")
+        html = tmpl.render(
+            phase="moon_exchange_review",
+            link_uuid="abc-123",
+            turn_number=8,
+            bidder_seat=0,
+            human_hand=[],
+            exchange_step=None,
+            exchange_received=[["S", "J"], ["C", "A"]],
+            exchange_given=[["D", "T"], ["H", "Q"]],
+        )
+        assert "Moon Exchange Complete" in html
+        assert 'action="/play/abc-123/next"' in html
+        assert "Next" in html
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -686,6 +686,23 @@ def regular_ai_client(config):
         yield c, application
 
 
+@pytest.fixture()
+def moon_exchange_client(config):
+    """TestClient whose AI always passes so the human can declare moon."""
+    application = create_app(config=config)
+    with TestClient(application) as c:
+        ai_manager: AIManager = application.state.ai_manager
+        info = ai_manager.available_models["olsa"]
+        ai_manager.available_models["olsa"] = ModelInfo(
+            id=info.id,
+            name=info.name,
+            description=info.description,
+            bidding_policy=_AlwaysPassBidder(),
+            play_strategy=info.play_strategy,
+        )
+        yield c, application
+
+
 class TestRedealPersistence:
     """All-pass redeal creates a Hand row marked 'redeal' with correct metadata."""
 
@@ -722,7 +739,7 @@ class TestRedealPersistence:
         )
         assert resp.status_code == 200
 
-        # Verify the hand row for the redealt hand
+        # Verify the current hand row is marked redeal and no new hand exists yet
         session = app.state.session_factory()
         try:
             redeal_hand = (
@@ -733,22 +750,19 @@ class TestRedealPersistence:
             assert redeal_hand.deal_id == original_deal_id
             assert redeal_hand.dealer_seat == original_dealer
 
-            # Verify a new hand row exists for the next deal
+            # The next deal should not start until the player clicks Next
             next_hand = (
                 session.query(Hand)
                 .filter_by(match_id=match_id)
                 .filter(Hand.deal_id > original_deal_id)
                 .first()
             )
-            assert next_hand is not None, "Expected Hand row for the post-redeal hand"
-            assert next_hand.status == "in_progress"
-            assert next_hand.deal_id == original_deal_id + 1
-            assert next_hand.dealer_seat == (original_dealer + 1) % 4
+            assert next_hand is None
         finally:
             session.close()
 
-    def test_match_state_has_new_hand_after_redeal(self, allpass_client):
-        """After redeal, serialized match state shows the new hand (not redeal)."""
+    def test_next_advances_to_new_hand_after_redeal(self, allpass_client):
+        """Redeal pauses until /next, then serialized state shows the new hand."""
         client, app = allpass_client
         link_uuid = _create_game(client)
         _set_nickname(client, link_uuid)
@@ -776,12 +790,112 @@ class TestRedealPersistence:
         assert result2 is not None
         state2, _, session2 = result2
 
-        # Match state should show the new hand in auction phase
-        new_hand = state2.current_hand
-        assert new_hand is not None
-        assert new_hand.phase == "auction"
+        redeal_hand = state2.current_hand
+        assert redeal_hand is not None
+        assert redeal_hand.phase == "redeal"
         assert state2.hands_played == 0  # Redeals don't count
         session2.close()
+
+        for _ in range(4):
+            client.post(f"/play/{link_uuid}/next")
+            result3 = _get_match_state(app, link_uuid)
+            assert result3 is not None
+            state3, _, session3 = result3
+            try:
+                new_hand = state3.current_hand
+                assert new_hand is not None
+                if new_hand.phase == "auction":
+                    assert new_hand.deal_id == hand.deal_id + 1
+                    break
+            finally:
+                session3.close()
+        else:
+            pytest.fail("Expected /next to advance from redeal to the next hand")
+
+
+class TestMoonExchangeRoutes:
+    def test_human_moon_bid_renders_exchange_form(self, moon_exchange_client):
+        client, app = moon_exchange_client
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        _select_ai(client, link_uuid)
+
+        result = _get_match_state(app, link_uuid)
+        assert result is not None
+        state, _, session = result
+        session.close()
+
+        hand = state.current_hand
+        assert hand is not None
+        assert hand.phase == "auction"
+        assert hand.current_seat == HUMAN_SEAT
+
+        resp = client.post(
+            f"/play/{link_uuid}/bid",
+            data={
+                "turn_number": hand.turn_number,
+                "bid_n": 10,
+                "bid_contract": "S",
+                "bid_type": "moon",
+            },
+        )
+        assert resp.status_code == 200
+        assert "Moon Exchange" in resp.text
+        assert "/moon-exchange" in resp.text
+
+    def test_submit_moon_exchange_moves_to_review(self, moon_exchange_client):
+        client, app = moon_exchange_client
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        _select_ai(client, link_uuid)
+
+        result = _get_match_state(app, link_uuid)
+        assert result is not None
+        state, _, session = result
+        session.close()
+
+        hand = state.current_hand
+        assert hand is not None
+
+        client.post(
+            f"/play/{link_uuid}/bid",
+            data={
+                "turn_number": hand.turn_number,
+                "bid_n": 10,
+                "bid_contract": "S",
+                "bid_type": "moon",
+            },
+        )
+
+        result2 = _get_match_state(app, link_uuid)
+        assert result2 is not None
+        state2, _, session2 = result2
+        session2.close()
+        hand2 = state2.current_hand
+        assert hand2 is not None
+        assert hand2.phase == "moon_exchange"
+
+        resp = client.post(
+            f"/play/{link_uuid}/moon-exchange",
+            data={
+                "turn_number": hand2.turn_number,
+                "card_indices": ["0", "1"],
+            },
+        )
+        assert resp.status_code == 200
+        assert "Moon Exchange Complete" in resp.text
+
+        result3 = _get_match_state(app, link_uuid)
+        assert result3 is not None
+        state3, _, session3 = result3
+        try:
+            hand3 = state3.current_hand
+            assert hand3 is not None
+            assert hand3.phase == "moon_exchange_review"
+            assert hand3.exchange_given is not None
+            assert hand3.exchange_received is not None
+        finally:
+            session3.close()
 
 
 # ---------------------------------------------------------------------------

--- a/web/db.py
+++ b/web/db.py
@@ -216,7 +216,7 @@ class Decision(Base):
     )
     phase = Column(
         String,
-        CheckConstraint("phase IN ('bid', 'play')"),
+        CheckConstraint("phase IN ('bid', 'play', 'moon_exchange')"),
         nullable=False,
     )
     actor_type = Column(

--- a/web/routes.py
+++ b/web/routes.py
@@ -196,6 +196,109 @@ def _game_phase(state) -> str:
     return hand.phase
 
 
+def _has_hidden_auction(hand) -> bool:
+    return hand.revealed_auction_count < len(hand.auction)
+
+
+def _has_hidden_tricks(hand) -> bool:
+    if hand.phase == "complete":
+        return False
+    return hand.revealed_trick_count < len(hand.completed_tricks)
+
+
+def _reveal_initial_step(state) -> None:
+    """Reveal the first pending hidden step so a new board is not blank."""
+    hand = state.current_hand
+    if hand is None:
+        return
+    if len(hand.auction) > 0 and hand.revealed_auction_count == 0:
+        hand.revealed_auction_count = 1
+    elif len(hand.completed_tricks) > 0 and hand.revealed_trick_count == 0:
+        hand.revealed_trick_count = 1
+
+
+def _reveal_after_human_action(
+    state,
+    *,
+    prior_auction_count: int,
+    prior_revealed_auction_count: int,
+    prior_trick_count: int,
+    prior_revealed_trick_count: int,
+) -> None:
+    """Reveal the human's own newly created action/trick immediately."""
+    hand = state.current_hand
+    if hand is None:
+        return
+
+    if len(hand.auction) > prior_auction_count:
+        hand.revealed_auction_count = min(
+            prior_revealed_auction_count + 1,
+            len(hand.auction),
+        )
+
+    if len(hand.completed_tricks) > prior_trick_count:
+        hand.revealed_trick_count = min(
+            prior_revealed_trick_count + 1,
+            len(hand.completed_tricks),
+        )
+
+
+def _reveal_next_step(state) -> bool:
+    """Advance one hidden reveal step if any exist."""
+    hand = state.current_hand
+    if hand is None:
+        return False
+    if _has_hidden_auction(hand):
+        hand.revealed_auction_count += 1
+        return True
+    if _has_hidden_tricks(hand):
+        hand.revealed_trick_count += 1
+        return True
+    return False
+
+
+def _display_phase(state) -> str:
+    """Map engine state plus reveal cursors to the UI phase."""
+    if state.status == "complete":
+        return "match_result"
+
+    hand = state.current_hand
+    if hand is None:
+        return "model_select"
+    if hand.phase == "complete":
+        return "hand_result"
+    if hand.phase in {"moon_exchange", "moon_exchange_review"}:
+        return hand.phase
+    if _has_hidden_auction(hand) or hand.phase == "redeal":
+        return "auction"
+    if _has_hidden_tricks(hand):
+        return "trick_play"
+    return hand.phase
+
+
+def _summarize_auction(entries: list[dict[str, Any]]) -> tuple[int, str]:
+    """Return (current_high_bid, bid_type) for the revealed auction only."""
+    current_high_bid = 0
+    current_bid_type = "regular"
+
+    for entry in entries:
+        if entry.get("action") == "pass":
+            continue
+        bid_type = entry.get("bid_type", "regular")
+        n = int(entry.get("n", 0))
+        if bid_type == "regular":
+            current_high_bid = max(current_high_bid, n)
+            current_bid_type = "regular"
+        elif bid_type == "moon":
+            current_high_bid = 10
+            current_bid_type = "moon"
+        elif bid_type == "loner":
+            current_high_bid = 10
+            current_bid_type = "loner"
+
+    return current_high_bid, current_bid_type
+
+
 def _format_auction_event(seat: int | None, action: dict[str, Any]) -> str:
     """Format a single auction event for the action rail."""
     seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"}
@@ -233,9 +336,16 @@ def _build_action_rail(visible: dict[str, Any], state) -> list[dict[str, str]]:
 
     seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"}
     events: list[dict[str, str]] = []
+    revealed_auction = visible.get("auction", [])[: hand.revealed_auction_count]
+    revealed_trick_count = (
+        len(visible.get("completed_tricks", []))
+        if hand.phase == "complete"
+        else hand.revealed_trick_count
+    )
+    revealed_tricks = visible.get("completed_tricks", [])[:revealed_trick_count]
 
     # Auction activity (in order).
-    for entry in visible.get("auction", []):
+    for entry in revealed_auction:
         events.append(
             {
                 "kind": "auction",
@@ -244,7 +354,7 @@ def _build_action_rail(visible: dict[str, Any], state) -> list[dict[str, str]]:
         )
 
     # Completed tricks so the user can inspect a simple event log.
-    for idx, trick in enumerate(visible.get("completed_tricks", []), start=1):
+    for idx, trick in enumerate(revealed_tricks, start=1):
         winner = trick.get("winner")
         if winner is None:
             continue
@@ -257,13 +367,13 @@ def _build_action_rail(visible: dict[str, Any], state) -> list[dict[str, str]]:
         )
 
     # Redeal transition.
-    if hand.phase == "redeal":
+    if hand.phase == "redeal" and not _has_hidden_auction(hand):
         events.append(
             {"kind": "system", "text": "All players passed; redeal starting."}
         )
 
     # Hand-complete outcomes (compact summary).
-    if hand.phase == "complete":
+    if hand.phase == "complete" and not _has_hidden_tricks(hand):
         bidder = seat_labels.get(hand.bidder_seat, f"Seat {hand.bidder_seat}")
         if hand.contract_type == "suit" and hand.trump is not None:
             contract = hand.trump
@@ -318,19 +428,62 @@ def _build_game_context(
         "match_status": state.status,
         **visible,
     }
-    ctx["phase"] = _game_phase(state)
+    ctx["phase"] = _display_phase(state)
 
     # Fields only available from hand state (not in visible dict)
     if hand is not None:
+        revealed_auction = visible.get("auction", [])[: hand.revealed_auction_count]
+        revealed_trick_count = (
+            len(visible.get("completed_tricks", []))
+            if hand.phase == "complete"
+            else hand.revealed_trick_count
+        )
+        revealed_tricks = visible.get("completed_tricks", [])[:revealed_trick_count]
+        has_hidden_auction = _has_hidden_auction(hand)
+        has_hidden_tricks = _has_hidden_tricks(hand)
+        current_high_bid, current_bid_type = _summarize_auction(revealed_auction)
+
+        ctx["auction"] = revealed_auction
+        ctx["completed_tricks"] = revealed_tricks
+        if has_hidden_auction or has_hidden_tricks or ctx["phase"] == "auction":
+            ctx["current_trick"] = None
         ctx["winning_bid"] = hand.winning_bid
         ctx["bidder_seat"] = hand.bidder_seat
-        ctx["current_high_bid"] = hand.current_high_bid
+        ctx["current_high_bid"] = (
+            current_high_bid if has_hidden_auction else hand.current_high_bid
+        )
+        ctx["bid_type"] = current_bid_type if has_hidden_auction else hand.bid_type
         ctx["points_team0"] = hand.points_team0
         ctx["points_team1"] = hand.points_team1
         ctx["action_rail"] = _build_action_rail(visible, state)
+        ctx["show_next"] = (
+            has_hidden_auction or has_hidden_tricks or hand.phase == "redeal"
+        )
+        ctx["next_reason"] = (
+            "auction"
+            if has_hidden_auction
+            else "trick"
+            if has_hidden_tricks
+            else "redeal"
+            if hand.phase == "redeal"
+            else None
+        )
+        ctx["show_turn_marker"] = not ctx["show_next"]
+        ctx["can_submit_bid"] = (
+            ctx["phase"] == "auction"
+            and hand.phase == "auction"
+            and hand.current_seat == HUMAN_SEAT
+            and not has_hidden_auction
+        )
+        ctx["can_play_card"] = (
+            ctx["phase"] == "trick_play"
+            and hand.phase == "trick_play"
+            and hand.current_seat == HUMAN_SEAT
+            and not has_hidden_tricks
+        )
 
         # Legal plays for the hand partial
-        if hand.phase == "trick_play" and hand.current_seat == HUMAN_SEAT:
+        if ctx["can_play_card"]:
             ctx["legal_plays"] = engine.get_legal_plays(state)
         else:
             ctx["legal_plays"] = None
@@ -346,6 +499,11 @@ def _build_game_context(
         ctx["points_team0"] = 0
         ctx["points_team1"] = 0
         ctx["legal_plays"] = None
+        ctx["show_next"] = False
+        ctx["next_reason"] = None
+        ctx["show_turn_marker"] = True
+        ctx["can_submit_bid"] = False
+        ctx["can_play_card"] = False
         ctx["opp_left_count"] = 0
         ctx["partner_count"] = 0
         ctx["opp_right_count"] = 0
@@ -671,6 +829,7 @@ async def select_ai(
         engine = _build_engine(ai_manager, model_id)
         seed = random.Random().randint(0, 2**31 - 1)
         state = engine.start_match(seed=seed, ai_model=model_id)
+        _reveal_initial_step(state)
 
         match_uuid = str(uuid.uuid4())
         match_row = Match(
@@ -764,6 +923,10 @@ async def submit_bid(
 
         # Record pre-action state for decision logging
         pre_turn = hand.turn_number
+        prior_auction_count = len(hand.auction)
+        prior_revealed_auction_count = hand.revealed_auction_count
+        prior_trick_count = len(hand.completed_tricks)
+        prior_revealed_trick_count = hand.revealed_trick_count
 
         # Ensure hand row exists (keyed by deal_id for redeal-safe uniqueness)
         hand_row = _ensure_hand_row(session, match_row, hand, hand.deal_id)
@@ -802,21 +965,17 @@ async def submit_bid(
             state,
         )
 
+        _reveal_after_human_action(
+            state,
+            prior_auction_count=prior_auction_count,
+            prior_revealed_auction_count=prior_revealed_auction_count,
+            prior_trick_count=prior_trick_count,
+            prior_revealed_trick_count=prior_revealed_trick_count,
+        )
+
         # Update hand row if hand completed or redealt
         current_hand = state.current_hand
-        if current_hand is not None and current_hand.phase == "redeal":
-            # Persist the terminal redeal state before dealing next hand
-            _update_hand_row(hand_row, current_hand)
-            state = engine.deal_after_redeal(state)
-            # Create a hand row for the newly dealt hand
-            if state.current_hand is not None:
-                _ensure_hand_row(
-                    session,
-                    match_row,
-                    state.current_hand,
-                    state.current_hand.deal_id,
-                )
-        elif current_hand is not None and current_hand.phase == "complete":
+        if current_hand is not None and current_hand.phase in ("complete", "redeal"):
             _update_hand_row(hand_row, current_hand)
         elif current_hand is not None:
             hand_row.hand_state_json = json.dumps(current_hand.to_dict())
@@ -874,6 +1033,10 @@ async def submit_card(
 
         # Record pre-action state for decision logging
         pre_turn = hand.turn_number
+        prior_auction_count = len(hand.auction)
+        prior_revealed_auction_count = hand.revealed_auction_count
+        prior_trick_count = len(hand.completed_tricks)
+        prior_revealed_trick_count = hand.revealed_trick_count
 
         # Ensure hand row exists (keyed by deal_id for redeal-safe uniqueness)
         hand_row = _ensure_hand_row(session, match_row, hand, hand.deal_id)
@@ -905,12 +1068,89 @@ async def submit_card(
             state,
         )
 
+        _reveal_after_human_action(
+            state,
+            prior_auction_count=prior_auction_count,
+            prior_revealed_auction_count=prior_revealed_auction_count,
+            prior_trick_count=prior_trick_count,
+            prior_revealed_trick_count=prior_revealed_trick_count,
+        )
+
         # Update hand row if hand completed (redeals cannot occur during
         # card play, but keep the check consistent)
         current_hand = state.current_hand
         if current_hand is not None and current_hand.phase == "complete":
             _update_hand_row(hand_row, current_hand)
         elif current_hand is not None:
+            hand_row.hand_state_json = json.dumps(current_hand.to_dict())
+
+        _update_match_row(match_row, state)
+        session.commit()
+
+        return HTMLResponse(_render_game_board(request, engine, state, link_uuid))
+    finally:
+        session.close()
+
+
+@router.post("/play/{link_uuid}/moon-exchange", response_class=HTMLResponse)
+async def submit_moon_exchange(
+    request: Request,
+    link_uuid: str,
+    turn_number: int = Form(...),
+    card_indices: list[int] = Form(...),
+):
+    """Submit the human side of a moon exchange."""
+    session = _get_session(request)
+    try:
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+        if player is None:
+            raise HTTPException(status_code=404, detail="Game not found")
+
+        match_row = (
+            session.query(Match)
+            .filter_by(player_id=player.id, status="active")
+            .order_by(Match.created_at.desc())
+            .first()
+        )
+        if match_row is None:
+            raise HTTPException(status_code=404, detail="No active match")
+
+        ai_manager = _get_ai_manager(request)
+        engine = _build_engine(ai_manager, match_row.ai_model)
+        state = _deserialize_state(engine, match_row.match_state_json)
+
+        hand = state.current_hand
+        if hand is None or turn_number < hand.turn_number:
+            return HTMLResponse(_render_game_board(request, engine, state, link_uuid))
+
+        if hand.phase != "moon_exchange":
+            raise HTTPException(status_code=400, detail="Not in moon exchange phase")
+        if hand.current_seat != HUMAN_SEAT:
+            raise HTTPException(status_code=400, detail="Not the human's turn")
+
+        hand_row = _ensure_hand_row(session, match_row, hand, hand.deal_id)
+
+        _log_decision(
+            session,
+            match_row,
+            hand_row,
+            turn_number=hand.turn_number,
+            seat=HUMAN_SEAT,
+            phase="moon_exchange",
+            actor_type="human",
+            decision_source="human",
+            legal_actions=list(range(len(hand.hands[HUMAN_SEAT]))),
+            chosen_action=sorted(card_indices),
+            game_state=engine.get_visible_state(state),
+        )
+
+        try:
+            state = engine.submit_human_moon_exchange(state, card_indices)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+
+        current_hand = state.current_hand
+        if current_hand is not None:
             hand_row.hand_state_json = json.dumps(current_hand.to_dict())
 
         _update_match_row(match_row, state)
@@ -957,6 +1197,7 @@ async def next_hand(
 
         # Only start a new hand when we are paused on a completed hand
         state = engine.advance_to_next_hand(state)
+        _reveal_initial_step(state)
 
         if state.current_hand is not None:
             next_hand_row = _ensure_hand_row(
@@ -973,6 +1214,80 @@ async def next_hand(
                     engine,
                     state,
                 )
+
+        _update_match_row(match_row, state)
+        session.commit()
+
+        return HTMLResponse(_render_game_board(request, engine, state, link_uuid))
+    finally:
+        session.close()
+
+
+@router.post("/play/{link_uuid}/next", response_class=HTMLResponse)
+async def next_step(
+    request: Request,
+    link_uuid: str,
+):
+    """Advance one hidden reveal step or continue after a redeal pause."""
+    session = _get_session(request)
+    try:
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+        if player is None:
+            raise HTTPException(status_code=404, detail="Game not found")
+
+        match_row = (
+            session.query(Match)
+            .filter_by(player_id=player.id, status="active")
+            .order_by(Match.created_at.desc())
+            .first()
+        )
+        if match_row is None:
+            raise HTTPException(status_code=404, detail="No active match")
+
+        ai_manager = _get_ai_manager(request)
+        engine = _build_engine(ai_manager, match_row.ai_model)
+        state = _deserialize_state(engine, match_row.match_state_json)
+
+        hand = state.current_hand
+        if hand is None:
+            return HTMLResponse(_render_game_board(request, engine, state, link_uuid))
+
+        hand_row = _ensure_hand_row(session, match_row, hand, hand.deal_id)
+
+        if _reveal_next_step(state):
+            hand_row.hand_state_json = json.dumps(state.current_hand.to_dict())
+        elif hand.phase == "moon_exchange_review":
+            state = engine.advance_after_moon_review(state)
+            _reveal_initial_step(state)
+            _log_ai_decisions_after_advance(
+                session,
+                match_row,
+                hand_row,
+                engine,
+                state,
+            )
+            if state.current_hand is not None:
+                hand_row.hand_state_json = json.dumps(state.current_hand.to_dict())
+        elif hand.phase == "redeal":
+            _update_hand_row(hand_row, hand)
+            state = engine.deal_after_redeal(state)
+            _reveal_initial_step(state)
+            if state.current_hand is not None:
+                next_hand_row = _ensure_hand_row(
+                    session,
+                    match_row,
+                    state.current_hand,
+                    state.current_hand.deal_id,
+                )
+                _log_ai_decisions_after_advance(
+                    session,
+                    match_row,
+                    next_hand_row,
+                    engine,
+                    state,
+                )
+        else:
+            return HTMLResponse(_render_game_board(request, engine, state, link_uuid))
 
         _update_match_row(match_row, state)
         session.commit()

--- a/web/schema.sql
+++ b/web/schema.sql
@@ -74,7 +74,7 @@ CREATE TABLE IF NOT EXISTS decisions (
     hand_id INTEGER NOT NULL REFERENCES hands(id) ON DELETE CASCADE,
     turn_number INTEGER NOT NULL CHECK (turn_number >= 0),
     seat INTEGER NOT NULL CHECK (seat BETWEEN 0 AND 3),
-    phase TEXT NOT NULL CHECK (phase IN ('bid', 'play')),
+    phase TEXT NOT NULL CHECK (phase IN ('bid', 'play', 'moon_exchange')),
     actor_type TEXT NOT NULL CHECK (actor_type IN ('human', 'ai')),
     decision_source TEXT NOT NULL,
     legal_actions_json TEXT NOT NULL,

--- a/web/static/game.js
+++ b/web/static/game.js
@@ -3,8 +3,8 @@
  *
  * Responsibilities:
  * - tap/select a legal card and submit as a single confirm form
- * - optional AI pace control (localStorage-backed)
- * - delayed submission for pace profiles without breaking HTMX flow
+ * - auto-submit on desktop after selection
+ * - reset hand form state after HTMX swaps
  */
 (function () {
     if (typeof window === 'undefined' || typeof document === 'undefined') {
@@ -15,159 +15,12 @@
         return;
     }
 
-    var PACE_STORAGE_KEY = 'be:ai-pace-profile';
-    var DEFAULT_PACE = 'normal';
-    var PACE_DELAYS_MS = {
-        off: 0,
-        fast: 250,
-        normal: 700,
-        slow: 1300,
-    };
-
-    /**
-     * Read persisted pace profile.
-     */
-    function getStoredPace() {
-        try {
-            var value = window.localStorage.getItem(PACE_STORAGE_KEY);
-            if (value === 'off' || value === 'fast' || value === 'normal' || value === 'slow') {
-                return value;
-            }
-        } catch (_err) {
-            // localStorage unavailable in some privacy-restricted modes.
-        }
-        return DEFAULT_PACE;
-    }
-
-    /**
-     * Persist selected pace profile.
-     */
-    function setStoredPace(profile) {
-        try {
-            window.localStorage.setItem(PACE_STORAGE_KEY, profile);
-        } catch (_err) {
-            // Non-blocking; still keep behavior in-memory.
-        }
-    }
-
-    var currentPace = getStoredPace();
-
-    /**
-     * Resolve form pace setting from currently selected mode.
-     */
-    function paceDelayForCurrent() {
-        var delay = PACE_DELAYS_MS[currentPace] || PACE_DELAYS_MS.normal;
-        return delay;
-    }
-
-    /**
-     * Whether a form should be sent through paced submission.
-     */
-    function shouldPaceForm(form) {
-        if (!(form instanceof HTMLFormElement)) {
-            return false;
-        }
-
-        if (!form.action) {
-            return false;
-        }
-
-        return /\/play\/[0-9a-f-]+\/(bid|play-card|next-hand)$/.test(form.action);
-    }
-
-    /**
-     * Touch-capable device heuristic.
-     */
     function isLikelyTouchDevice() {
         return (
             window.matchMedia('(hover: none), (pointer: coarse)').matches ||
             ('ontouchstart' in window) ||
             (typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0)
         );
-    }
-
-    /**
-     * Busy state used while delay timer is active.
-     */
-    function setFormBusy(form, busy) {
-        if (!(form instanceof HTMLFormElement)) {
-            return;
-        }
-
-        var submitButton = form.querySelector('button[type="submit"], input[type="submit"]');
-        if (submitButton === null) {
-            return;
-        }
-
-        if (busy) {
-            submitButton.dataset.autoDisabled = submitButton.disabled ? '0' : '1';
-            submitButton.disabled = true;
-            if (submitButton.dataset.labelBusy !== '1') {
-                submitButton.dataset.labelBusy = submitButton.textContent;
-                submitButton.textContent = 'Applying...';
-            }
-            return;
-        }
-
-        if (submitButton.dataset.autoDisabled === '1') {
-            submitButton.disabled = false;
-        }
-        if (submitButton.dataset.labelBusy) {
-            submitButton.textContent = submitButton.dataset.labelBusy;
-        }
-        delete submitButton.dataset.autoDisabled;
-        delete submitButton.dataset.labelBusy;
-    }
-
-    function clearFormPacingState(form) {
-        if (!(form instanceof HTMLFormElement)) {
-            return;
-        }
-
-        delete form.dataset.pacingBusy;
-        delete form.dataset.pacingSkip;
-        delete form.dataset.pacingArmed;
-        setFormBusy(form, false);
-    }
-
-    /**
-     * Queue HTMX form submit with pacing delay.
-     */
-    function schedulePacedSubmit(form) {
-        if (!(form instanceof HTMLFormElement)) {
-            return;
-        }
-
-        if (form.dataset.pacingBusy === '1') {
-            return;
-        }
-
-        var delay = paceDelayForCurrent();
-        if (!shouldPaceForm(form) || delay <= 0) {
-            form.dataset.pacingSkip = '1';
-            htmx.trigger(form, 'submit');
-            return;
-        }
-
-        form.dataset.pacingBusy = '1';
-        form.dataset.pacingArmed = '1';
-        setFormBusy(form, true);
-
-        window.setTimeout(function () {
-            if (!form.isConnected) {
-                clearFormPacingState(form);
-                return;
-            }
-
-            if (form.dataset.pacingArmed !== '1') {
-                clearFormPacingState(form);
-                return;
-            }
-
-            form.dataset.pacingSkip = '1';
-            htmx.trigger(form, 'submit');
-            delete form.dataset.pacingArmed;
-        }, delay);
     }
 
     function getCardPlayForm() {
@@ -261,29 +114,6 @@
         }
     }
 
-    function initPaceControl() {
-        var select = document.getElementById('pace-profile');
-        if (!(select instanceof HTMLSelectElement)) {
-            return;
-        }
-
-        if (['off', 'fast', 'normal', 'slow'].indexOf(currentPace) === -1) {
-            currentPace = DEFAULT_PACE;
-        }
-
-        select.value = currentPace;
-
-        select.addEventListener('change', function (event) {
-            var newValue = event.target.value;
-            if (newValue !== 'off' && newValue !== 'fast' && newValue !== 'normal' && newValue !== 'slow') {
-                currentPace = DEFAULT_PACE;
-            } else {
-                currentPace = newValue;
-            }
-            setStoredPace(currentPace);
-        });
-    }
-
     function attachDelegatedHandlers() {
         document.addEventListener('click', function (event) {
             var target = event.target;
@@ -291,12 +121,12 @@
             var submitButton = target.closest('#card-play-submit');
             if (submitButton !== null) {
                 event.preventDefault();
-                var form = getCardPlayForm();
-                if (form === null) {
+                var submitForm = getCardPlayForm();
+                if (submitForm === null) {
                     return;
                 }
-                var input = getSelectedCardInput(form);
-                var help = form.querySelector('#card-play-help');
+                var input = getSelectedCardInput(submitForm);
+                var help = submitForm.querySelector('#card-play-help');
 
                 if (input === null || input.value === '') {
                     if (help !== null) {
@@ -305,7 +135,7 @@
                     return;
                 }
 
-                schedulePacedSubmit(form);
+                htmx.trigger(submitForm, 'submit');
                 return;
             }
 
@@ -320,63 +150,12 @@
             }
 
             event.preventDefault();
-
             selectCard(handForm, card);
 
             if (!isLikelyTouchDevice()) {
-                schedulePacedSubmit(handForm);
-                return;
+                htmx.trigger(handForm, 'submit');
             }
         });
-
-        document.addEventListener('submit', function (event) {
-            var form = event.target;
-            if (!(form instanceof HTMLFormElement)) {
-                return;
-            }
-
-            if (form.dataset.pacingSkip === '1') {
-                delete form.dataset.pacingSkip;
-                return;
-            }
-
-            if (!shouldPaceForm(form)) {
-                return;
-            }
-
-            event.preventDefault();
-            schedulePacedSubmit(form);
-        }, true);
-
-        document.addEventListener('htmx:afterRequest', function (event) {
-            var form = event.detail && event.detail.elt ? event.detail.elt : event.target;
-            if (form instanceof Element) {
-                form = form.closest('form') || form;
-            }
-            if (form instanceof HTMLFormElement) {
-                clearFormPacingState(form);
-            }
-        }, true);
-
-        document.addEventListener('htmx:sendError', function (event) {
-            var form = event.detail && event.detail.elt ? event.detail.elt : event.target;
-            if (form instanceof Element) {
-                form = form.closest('form') || form;
-            }
-            if (form instanceof HTMLFormElement) {
-                clearFormPacingState(form);
-            }
-        }, true);
-
-        document.addEventListener('htmx:responseError', function (event) {
-            var form = event.detail && event.detail.elt ? event.detail.elt : event.target;
-            if (form instanceof Element) {
-                form = form.closest('form') || form;
-            }
-            if (form instanceof HTMLFormElement) {
-                clearFormPacingState(form);
-            }
-        }, true);
 
         document.body.addEventListener('htmx:afterSwap', function (event) {
             var target = event.target;
@@ -386,21 +165,12 @@
             clearCardSelection(getCardPlayForm());
             syncCardPlayFormControls(getCardPlayForm());
         }, true);
-
-        document.addEventListener('DOMContentLoaded', function () {
-            var form = getCardPlayForm();
-            syncCardPlayFormControls(form);
-            initPaceControl();
-        });
     }
 
     function initialize() {
-        initPaceControl();
         attachDelegatedHandlers();
-
-        var form = getCardPlayForm();
-        clearCardSelection(form);
-        syncCardPlayFormControls(form);
+        clearCardSelection(getCardPlayForm());
+        syncCardPlayFormControls(getCardPlayForm());
     }
 
     initialize();

--- a/web/templates/game.html
+++ b/web/templates/game.html
@@ -46,7 +46,7 @@
         {% include "partials/hand_result.html" %}
 
     {# ---- Active game phases: auction and trick play ---- #}
-    {% elif phase in ("auction", "trick_play", "redeal") %}
+    {% elif phase in ("auction", "trick_play", "redeal", "moon_exchange", "moon_exchange_review") %}
         {% include "partials/game_board.html" %}
 
     {% endif %}

--- a/web/templates/partials/game_board.html
+++ b/web/templates/partials/game_board.html
@@ -3,7 +3,8 @@
 
    Context variables:
      All variables required by the included partials, plus:
-       - phase: str — "auction", "trick_play", "hand_result", "match_result", "redeal"
+       - phase: str — "auction", "trick_play", "moon_exchange", "moon_exchange_review",
+                      "hand_result", "match_result", "redeal"
        - link_uuid: str — player's game link UUID
        - opp_left_count, partner_count, opp_right_count: int — AI hand card counts
 #}
@@ -11,6 +12,9 @@
 {% set bidder_seat = bidder_seat | default(-1, true) %}
 {% set current_seat = current_seat | default(-1, true) %}
 {% set sitting_out_seat = sitting_out_seat | default(None, true) %}
+{% set show_next = show_next | default(false, true) %}
+{% set can_submit_bid = can_submit_bid | default(false, true) %}
+{% set can_play_card = can_play_card | default(false, true) %}
 
 {# ---- Match result (win/loss screen) ---- #}
 {% if phase == "match_result" %}
@@ -21,7 +25,7 @@
     {% include "partials/hand_result.html" %}
 
 {# ---- Active game phases: auction and trick play ---- #}
-{% elif phase in ("auction", "trick_play", "redeal") %}
+{% elif phase in ("auction", "trick_play", "moon_exchange", "moon_exchange_review", "redeal") %}
 
     {# AI hands — face-down card backs with counts #}
     <div class="ai-hands-row" role="region" aria-label="AI opponent hands">
@@ -101,20 +105,23 @@
         </div>
     </div>
 
-    {# Trick area — always shown during active play #}
-    {% include "partials/trick.html" %}
+    {% if phase in ("auction", "trick_play", "redeal") %}
+        {% include "partials/trick.html" %}
 
-    {# Bid panel — auction phase only, when it's the human's turn #}
-    {% if phase == "auction" %}
-        {% include "partials/bid_panel.html" %}
+        {% if show_next %}
+            {% include "partials/next_controls.html" %}
+        {% endif %}
+
+        {% if phase == "auction" and can_submit_bid %}
+            {% include "partials/bid_panel.html" %}
+        {% endif %}
+
+        {% include "partials/hand.html" %}
+    {% elif phase in ("moon_exchange", "moon_exchange_review") %}
+        {% include "partials/moon_exchange.html" %}
     {% endif %}
 
-    {# Human hand — always shown during active play #}
-    {% include "partials/hand.html" %}
-
-    {# Score bar — always shown during active play #}
     {% include "partials/score.html" %}
-
     {% include "partials/action_rail.html" %}
 
 {% endif %}

--- a/web/templates/partials/hand.html
+++ b/web/templates/partials/hand.html
@@ -44,6 +44,8 @@
     </div>
 
     {% if phase == "trick_play" %}
+        {% set can_play_card = can_play_card | default(legal_plays is not none, true) %}
+        {% if can_play_card %}
         <form id="card-play-form"
               class="card-play-form"
               method="post"
@@ -62,5 +64,6 @@
                 Tap a card to select it, then tap Play card.
             </p>
         </form>
+        {% endif %}
     {% endif %}
 </div>

--- a/web/templates/partials/moon_exchange.html
+++ b/web/templates/partials/moon_exchange.html
@@ -1,0 +1,106 @@
+{# Moon exchange interaction / review partial.
+   Context variables:
+     - phase: str — "moon_exchange" or "moon_exchange_review"
+     - link_uuid: str — player's game link UUID
+     - turn_number: int — current turn for idempotency
+     - bidder_seat: int — moon declarer seat
+     - human_hand: list[list[str, str]] — human-visible hand
+     - exchange_step: str | None — "partner_to_mooner" | "mooner_to_partner"
+     - exchange_given: list[list[str]] | None — cards given by mooner
+     - exchange_received: list[list[str]] | None — cards received by mooner
+#}
+{% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
+{% set suit_names = {"S": "Spades", "H": "Hearts", "D": "Diamonds", "C": "Clubs"} %}
+{% set suit_classes = {"S": "spades", "H": "hearts", "D": "diamonds", "C": "clubs"} %}
+{% set seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"} %}
+{% set partner_seat = ((bidder_seat | int) + 2) % 4 %}
+{% set you_are_mooner = (bidder_seat | int) == 0 %}
+{% set given_cards = exchange_given | default([], true) %}
+{% set received_cards = exchange_received | default([], true) %}
+
+{% if phase == "moon_exchange" %}
+    {% if exchange_step == "partner_to_mooner" %}
+        {% set exchange_title = "Moon Exchange: Choose 2 Cards to Send" %}
+        {% set exchange_text = "Your partner declared moon. Choose the 2 cards you will send to them." %}
+    {% else %}
+        {% set exchange_title = "Moon Exchange: Choose 2 Cards to Return" %}
+        {% set exchange_text = "You have received 2 cards from your partner. Choose the 2 cards you will return." %}
+    {% endif %}
+
+    <section id="moon-exchange" class="hand" role="region" aria-label="Moon exchange">
+        <h3>{{ exchange_title }}</h3>
+        <p class="bid-info">{{ exchange_text }}</p>
+
+        {% if received_cards and exchange_step == "mooner_to_partner" %}
+            <p class="bid-info">
+                Received:
+                {% for card in received_cards %}
+                    <span class="card-text">{{ suit_symbols.get(card[0], card[0]) }} {{ card[1] }}</span>{% if not loop.last %}, {% endif %}
+                {% endfor %}
+            </p>
+        {% endif %}
+
+        <form method="post"
+              action="/play/{{ link_uuid }}/moon-exchange"
+              hx-post="/play/{{ link_uuid }}/moon-exchange"
+              hx-target="#game-board"
+              hx-swap="innerHTML"
+              aria-label="Choose two moon exchange cards">
+            <input type="hidden" name="turn_number" value="{{ turn_number }}">
+            <div class="card-fan" role="group" aria-label="Select exactly 2 cards">
+                {% for card in human_hand %}
+                    {% set suit = card[0] %}
+                    {% set rank = card[1] %}
+                    {% set suit_class = suit_classes.get(suit, "spades") %}
+                    {% set suit_sym = suit_symbols.get(suit, suit) %}
+                    {% set suit_name = suit_names.get(suit, suit) %}
+                    <label class="card card--{{ suit_class }}">
+                        <input type="checkbox" name="card_indices" value="{{ loop.index0 }}">
+                        <span class="card__rank" aria-hidden="true">{{ rank }}</span>
+                        <span class="card__suit" aria-hidden="true">{{ suit_sym }}</span>
+                        <span class="sr-only">{{ rank }} of {{ suit_name }}</span>
+                    </label>
+                {% endfor %}
+            </div>
+            <button type="submit" class="btn btn--play-card">Confirm Exchange</button>
+        </form>
+    </section>
+{% else %}
+    {% if you_are_mooner %}
+        {% set review_given = given_cards %}
+        {% set review_received = received_cards %}
+        {% set review_intro = "You declared moon." %}
+    {% elif partner_seat == 0 %}
+        {% set review_given = received_cards %}
+        {% set review_received = given_cards %}
+        {% set review_intro = "Your partner declared moon." %}
+    {% else %}
+        {% set review_given = given_cards %}
+        {% set review_received = received_cards %}
+        {% set review_intro = seat_labels.get(bidder_seat, "Declarer") ~ " declared moon." %}
+    {% endif %}
+
+    <section id="moon-exchange-review" class="hand" role="region" aria-label="Moon exchange review">
+        <h3>Moon Exchange Complete</h3>
+        <p class="bid-info">{{ review_intro }}</p>
+        <p class="bid-info">
+            Given:
+            {% for card in review_given %}
+                <span class="card-text">{{ suit_symbols.get(card[0], card[0]) }} {{ card[1] }}</span>{% if not loop.last %}, {% endif %}
+            {% endfor %}
+        </p>
+        <p class="bid-info">
+            Received:
+            {% for card in review_received %}
+                <span class="card-text">{{ suit_symbols.get(card[0], card[0]) }} {{ card[1] }}</span>{% if not loop.last %}, {% endif %}
+            {% endfor %}
+        </p>
+        <form method="post"
+              action="/play/{{ link_uuid }}/next"
+              hx-post="/play/{{ link_uuid }}/next"
+              hx-target="#game-board"
+              hx-swap="innerHTML">
+            <button type="submit" class="btn btn--next-step">Next</button>
+        </form>
+    </section>
+{% endif %}

--- a/web/templates/partials/next_controls.html
+++ b/web/templates/partials/next_controls.html
@@ -1,0 +1,25 @@
+{# Unified reveal progression control.
+   Context variables:
+     - link_uuid: str — player's game link UUID
+     - next_reason: str | None — "auction" | "trick" | "redeal"
+#}
+{% if next_reason == "auction" %}
+    {% set next_text = "Auction paused after the latest action." %}
+{% elif next_reason == "trick" %}
+    {% set next_text = "Trick complete. Reveal the next trick when ready." %}
+{% elif next_reason == "redeal" %}
+    {% set next_text = "All players passed. Continue to the redeal." %}
+{% else %}
+    {% set next_text = "Continue when ready." %}
+{% endif %}
+
+<div id="next-controls" class="game-control-panel next-controls" role="region" aria-label="Continue game flow">
+    <p class="next-controls__text">{{ next_text }}</p>
+    <form method="post"
+          action="/play/{{ link_uuid }}/next"
+          hx-post="/play/{{ link_uuid }}/next"
+          hx-target="#game-board"
+          hx-swap="innerHTML">
+        <button type="submit" class="btn btn--next-step">Next</button>
+    </form>
+</div>

--- a/web/templates/partials/trick.html
+++ b/web/templates/partials/trick.html
@@ -22,7 +22,7 @@
         {% if bidder_seat == seat %}
             <span class="seat-marker seat-marker--declarer" title="Declarer">X</span>
         {% endif %}
-        {% if current_seat == seat %}
+        {% if show_turn_marker | default(true, true) and current_seat == seat %}
             <span class="seat-marker seat-marker--turn" title="Current turn">▶</span>
         {% endif %}
         {% if sitting_out_seat == seat %}
@@ -100,7 +100,6 @@
     <div id="last-trick" class="trick-area last-trick" role="region" aria-label="Last completed trick">
         <h3>Last Trick</h3>
         <div class="trick-table trick-table--compact">
-            {# Top: AI Partner #}
             <div class="trick-slot trick-slot--top">
                 {% if 2 in last_ns.cards %}
                     {% set card = last_ns.cards[2] %}


### PR DESCRIPTION
## Plan
- N/A

## Summary
- replace the misleading pace control with a unified `Next`-driven reveal flow for hosted play
- pause redeals and completed-trick/auction reveals until the player advances them
- add interactive moon exchange handling and persistence for human-involved moon bids

## Why
- the previous pace control did not control visible AI progression
- the browser game needed explicit reveal pacing at auction/trick boundaries
- moon exchange needed a real interaction phase instead of an invisible backend swap

## Repro / Validation
**Command(s) run:**
- `uv run python -m pytest tests/unit/hosted_play/test_routes.py -q`
- `uv run python -m pytest tests/unit/hosted_play/test_engine.py -k 'moon or loner' -q`
- `uv run python -m pytest tests/unit/hosted_play/test_db.py -k decision -q`
- `uv run python -m pytest tests/unit/hosted_play/test_state.py tests/unit/hosted_play/test_partials.py -q`

**Config (if applicable):**
- N/A

**Seed (if applicable):**
- N/A

## Test Criteria
- **Pass condition:** hosted play pauses on reveal boundaries with a single `Next` action, redeals no longer auto-skip, and moon exchange is interactive and persisted/logged correctly.
- **Verification command:** run the four pytest commands listed above.
- **Expected result:** all selected tests pass with no failures.

## Tests
- [ ] `PYTHONPATH=src python -m pytest -m "not slow" tests/`
- [ ] Integration (if engine/rules changed): `PYTHONPATH=src python -m pytest tests/integration/`
- [x] Other:
  - targeted hosted-play unit coverage listed in `## Repro / Validation`

## Expected impact
- Metrics impact (if any): none
- Runtime impact (if any): minimal hosted-play UI flow overhead only

## Risk level
- [ ] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [x] High (core rules/sim/scoring)

## Worktree proof (required)
**Paste outputs; PRs missing this may be rejected.**

`pwd`:
```
/private/tmp/bid-euchre-pr2
```

`git rev-parse --show-toplevel`:
```
/private/tmp/bid-euchre-pr2
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         23a7ca36 [codex/browser-game-changes]
/private/tmp/bid-euchre-dashboard-automerge                                      dc02680b [codex/dashboard-automerge]
/private/tmp/bid-euchre-dashboard-checkruns                                      d440df53 [codex/dashboard-check-runs]
/private/tmp/bid-euchre-fix-pr-regressions                                       ebca6f97 [codex/fix-reviewed-pr-regressions]
/private/tmp/bid-euchre-pr1                                                      3b2b2fac [codex/web-browser-roster-rules-dealer]
/private/tmp/bid-euchre-pr2                                                      3aba23cb [codex/web-hosted-play-interactions]
/private/tmp/bid-euchre-pr3                                                      2f595504 [codex/web-played-cards-polish]
/private/tmp/bid-euchre-review-main                                              aab05619 (detached HEAD)
/private/tmp/c1_artifacts2/review-main-2                                         3082df7c (detached HEAD)
/private/tmp/c1_artifacts3/review-20260325                                       3082df7c (detached HEAD)
/private/tmp/c1_artifacts4/review-main                                           a70ac02f (detached HEAD)
/private/tmp/worktree-reconcile-1836                                             2549692a [fix/reconcile-checkpoint-drift-1836]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-analyst         fb2e9267 [codex/issue-1775-triage-note-20260325]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author          3772a160 [plans/browser-phase4-review]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b        050da189 [codex/platform11-restart-20260325]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c        b27b8f9d [codex/platform13-restart-20260325]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d        7849d043 [ops/platform10-core-extraction]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-scratch  7849d043 [fix/stale-lane-severity-1775]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a   7849d043 [browser/expansion-mobile-accessibility]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b   7849d043 [ops/platform9b-pr3-away-wiring]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c   cab1f8c6 [codex/browser-smoke-full-hand-fix-20260325]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d   7849d043 [web/browser-expansion-pr8-pilot-hardening]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a          7849d043 [fix/token-economy-jsonl-git-commits]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b          05545b28 [docs/tmux-paste-bracketing-1834]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c          23c905d0 [codex/analyst-dispatch-parity-restart-20260325]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-ops             3082df7c (detached HEAD)
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-review          3082df7c (detached HEAD)
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-work-20260324-172018    ec9f89ad [work-20260324-172018]
```

## Review Loop
- [x] Autonomous review loop completed (Codex CLI)
- [x] Blocking findings addressed
- [x] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

Refs #1891
Refs #1893
