### PR TITLE
fix(web): score bug (#1913) + lead indicator (#1914)

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -540,6 +540,71 @@ class TestTrick:
         assert 'title="Declarer"' in html
         assert 'title="Sitting out"' in html
 
+    def test_leader_marker_shown_for_trick_leader(self, env):
+        """Leader seat gets an 'L' marker during the current trick."""
+        tmpl = env.get_template("partials/trick.html")
+        html = tmpl.render(
+            current_trick={"leader": 1, "plays": [[1, ["H", "A"]]]},
+            completed_tricks=[],
+            dealer_seat=3,
+            bidder_seat=0,
+            current_seat=2,
+            sitting_out_seat=None,
+            tricks_team0=0,
+            tricks_team1=0,
+        )
+        assert "seat-marker--leader" in html
+        assert 'title="Lead"' in html
+
+    def test_leader_marker_shown_for_completed_trick(self, env):
+        """Leader marker renders when showing a completed trick (no current)."""
+        tmpl = env.get_template("partials/trick.html")
+        html = tmpl.render(
+            current_trick=None,
+            completed_tricks=[
+                {"leader": 2, "plays": [[2, ["S", "K"]]], "winner": 2},
+            ],
+            dealer_seat=0,
+            bidder_seat=1,
+            current_seat=3,
+            sitting_out_seat=None,
+            tricks_team0=0,
+            tricks_team1=1,
+        )
+        assert "seat-marker--leader" in html
+        assert 'title="Lead"' in html
+
+    def test_lead_suit_displayed(self, env):
+        """Lead suit symbol shown next to the trick heading."""
+        tmpl = env.get_template("partials/trick.html")
+        html = tmpl.render(
+            current_trick={"leader": 0, "plays": [[0, ["H", "A"]]]},
+            completed_tricks=[],
+            dealer_seat=3,
+            bidder_seat=0,
+            current_seat=1,
+            sitting_out_seat=None,
+            tricks_team0=0,
+            tricks_team1=0,
+        )
+        assert "lead-suit" in html
+        assert "\u2665" in html  # ♥
+
+    def test_lead_suit_not_shown_when_no_plays(self, env):
+        """Lead suit indicator not present when trick has no plays yet."""
+        tmpl = env.get_template("partials/trick.html")
+        html = tmpl.render(
+            current_trick={"leader": 0, "plays": []},
+            completed_tricks=[],
+            dealer_seat=3,
+            bidder_seat=0,
+            current_seat=0,
+            sitting_out_seat=None,
+            tricks_team0=0,
+            tricks_team1=0,
+        )
+        assert "lead-suit" not in html
+
 
 # ---------------------------------------------------------------------------
 # game_controls.html
@@ -1197,6 +1262,109 @@ class TestTrickWinnerCard:
         assert "with" in html
         assert "\u2660" in html  # spade symbol
         assert "A" in html
+
+
+# ---------------------------------------------------------------------------
+# game_board.html — seat-0 declarer regression (issue #1913)
+# ---------------------------------------------------------------------------
+
+
+class TestGameBoardSeatZeroRegression:
+    """Regression: bidder_seat=0 must not be coerced to -1 by default filter.
+
+    The old ``| default(-1, true)`` treated 0 as falsy, causing
+    ``hand_result.html`` to assign the wrong declarer team when the human
+    (seat 0) bid and was set.  See issue #1913.
+    """
+
+    def test_hand_result_via_game_board_seat0_set(self, env):
+        """Human (seat 0) bid and got set — banner must say 'Set!'."""
+        tmpl = env.get_template("partials/game_board.html")
+        html = tmpl.render(
+            phase="hand_result",
+            link_uuid="test-uuid",
+            winning_bid=6,
+            bidder_seat=0,
+            contract_type="suit",
+            trump="S",
+            bid_type="regular",
+            dealer_seat=3,
+            current_seat=0,
+            sitting_out_seat=None,
+            tricks_team0=4,
+            tricks_team1=6,
+            points_team0=-6,
+            points_team1=6,
+            score_human=-6,
+            score_ai=6,
+            hands_played=1,
+        )
+        assert "Set!" in html
+        # Verify human is identified as the bidder
+        assert "You" in html
+        # Should NOT say "Made it!"
+        assert "Made it!" not in html
+
+    def test_hand_result_via_game_board_seat0_made(self, env):
+        """Human (seat 0) bid and made — banner must say 'Made it!'."""
+        tmpl = env.get_template("partials/game_board.html")
+        html = tmpl.render(
+            phase="hand_result",
+            link_uuid="test-uuid",
+            winning_bid=6,
+            bidder_seat=0,
+            contract_type="suit",
+            trump="H",
+            bid_type="regular",
+            dealer_seat=3,
+            current_seat=0,
+            sitting_out_seat=None,
+            tricks_team0=7,
+            tricks_team1=3,
+            points_team0=7,
+            points_team1=3,
+            score_human=7,
+            score_ai=3,
+            hands_played=1,
+        )
+        assert "Made it!" in html
+        assert "You" in html
+
+    def test_dealer_seat_zero_preserved(self, env):
+        """dealer_seat=0 must not be coerced to -1."""
+        tmpl = env.get_template("partials/game_board.html")
+        html = tmpl.render(
+            phase="trick_play",
+            link_uuid="test-uuid",
+            dealer_seat=0,
+            bidder_seat=1,
+            current_seat=2,
+            sitting_out_seat=None,
+            current_trick={"leader": 1, "plays": [[1, ["H", "K"]]]},
+            completed_tricks=[],
+            human_hand=[["S", "A"], ["H", "Q"]],
+            auction=[],
+            contract_type="suit",
+            trump="H",
+            bid_type="regular",
+            winning_bid=5,
+            current_high_bid=5,
+            tricks_team0=0,
+            tricks_team1=0,
+            score_human=0,
+            score_ai=0,
+            hands_played=0,
+            legal_plays=None,
+            opp_left_count=10,
+            partner_count=10,
+            opp_right_count=10,
+            show_next=False,
+            next_reason=None,
+            show_bid_panel=False,
+            action_rail=[],
+        )
+        # The human (seat 0) should show the dealer marker
+        assert "seat-marker--dealer" in html
 
 
 # ---------------------------------------------------------------------------

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -350,6 +350,29 @@ main {
     color: #fff;
 }
 
+.seat-marker--leader {
+    background: #1565c0;
+    color: #fff;
+}
+
+/* Lead suit indicator shown next to trick heading */
+.lead-suit {
+    display: inline-block;
+    margin-left: 0.35rem;
+    font-size: 1.1em;
+    vertical-align: middle;
+}
+
+.lead-suit--hearts,
+.lead-suit--diamonds {
+    color: #c62828;
+}
+
+.lead-suit--spades,
+.lead-suit--clubs {
+    color: #222;
+}
+
 /* Top (partner) */
 .trick-slot--top {
     margin-bottom: 0.25rem;

--- a/web/templates/partials/game_board.html
+++ b/web/templates/partials/game_board.html
@@ -7,9 +7,9 @@
        - link_uuid: str — player's game link UUID
        - opp_left_count, partner_count, opp_right_count: int — AI hand card counts
 #}
-{% set dealer_seat = dealer_seat | default(-1, true) %}
-{% set bidder_seat = bidder_seat | default(-1, true) %}
-{% set current_seat = current_seat | default(-1, true) %}
+{% set dealer_seat = dealer_seat if (dealer_seat is defined and dealer_seat is not none) else -1 %}
+{% set bidder_seat = bidder_seat if (bidder_seat is defined and bidder_seat is not none) else -1 %}
+{% set current_seat = current_seat if (current_seat is defined and current_seat is not none) else -1 %}
 {% set sitting_out_seat = sitting_out_seat | default(None, true) %}
 {% set show_next = show_next | default(false, true) %}
 {% set show_bid_panel = show_bid_panel | default(false, true) %}

--- a/web/templates/partials/trick.html
+++ b/web/templates/partials/trick.html
@@ -15,21 +15,27 @@
 {% set seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"} %}
 {% set display_plays = [] %}
 {% set display_winner = None %}
+{% set display_leader = None %}
 {% set display_trick_number = (completed_tricks | length) + 1 %}
 {% set display_heading = "Trick " ~ display_trick_number ~ " of 10" %}
 
 {% if current_trick %}
     {% set display_plays = current_trick.plays %}
+    {% set display_leader = current_trick.get("leader") if current_trick is mapping else current_trick.leader %}
 {% elif completed_tricks %}
     {% set last = completed_tricks[-1] %}
     {% set display_plays = last.plays %}
     {% set display_winner = last.winner %}
+    {% set display_leader = last.get("leader") if last is mapping else last.leader %}
     {% set display_trick_number = completed_tricks | length %}
     {% set display_heading = "Trick " ~ display_trick_number ~ " of 10 complete" %}
 {% endif %}
 
-{% macro seat_markers(seat) %}
+{% macro seat_markers(seat, leader_seat=None) %}
     <div class="seat-markers">
+        {% if leader_seat is not none and leader_seat == seat %}
+            <span class="seat-marker seat-marker--leader" title="Lead">L</span>
+        {% endif %}
         {% if dealer_seat == seat %}
             <span class="seat-marker seat-marker--dealer" title="Dealer">D</span>
         {% endif %}
@@ -70,16 +76,26 @@
 {% endfor %}
 
 <div id="trick-area" class="trick-area" role="region" aria-label="Current trick" aria-live="polite">
-    <h3>{{ display_heading }}</h3>
+    <h3>
+        {{ display_heading }}
+        {% if display_plays %}
+            {% set lead_card = display_plays[0] %}
+            {% set lead_suit = lead_card[1][0] %}
+            <span class="lead-suit lead-suit--{{ suit_classes.get(lead_suit, 'spades') }}"
+                  aria-label="Lead suit: {{ suit_names.get(lead_suit, lead_suit) }}">
+                {{ suit_symbols.get(lead_suit, lead_suit) }}
+            </span>
+        {% endif %}
+    </h3>
     <div class="trick-table" role="group" aria-label="Cards played this trick, score {{ tricks_team0 }} to {{ tricks_team1 }}">
         <div class="trick-slot trick-slot--top">
-            {{ seat_markers(2) }}
+            {{ seat_markers(2, display_leader) }}
             {{ card_slot(2) }}
         </div>
 
         <div class="trick-row-middle">
             <div class="trick-slot trick-slot--left">
-                {{ seat_markers(1) }}
+                {{ seat_markers(1, display_leader) }}
                 {{ card_slot(1) }}
             </div>
 
@@ -88,13 +104,13 @@
             </div>
 
             <div class="trick-slot trick-slot--right">
-                {{ seat_markers(3) }}
+                {{ seat_markers(3, display_leader) }}
                 {{ card_slot(3) }}
             </div>
         </div>
 
         <div class="trick-slot trick-slot--bottom">
-            {{ seat_markers(0) }}
+            {{ seat_markers(0, display_leader) }}
             {{ card_slot(0) }}
         </div>
     </div>


### PR DESCRIPTION
## Summary

- **Fix score bug (#1913):** `game_board.html` used `| default(-1, true)` for seat variables, which treated `bidder_seat=0` (human seat) as falsy and coerced it to `-1`. This caused `hand_result.html` to assign the wrong `declarer_team` when the human was the declarer, showing incorrect made/set status.
- **Add lead indicator (#1914):** Show an "L" marker on the trick leader's seat and display the lead suit symbol next to the trick heading.

## Why

The score display was wrong when the human (seat 0) was the declarer because Jinja2's `default(value, true)` treats ANY falsy value as missing — including the integer `0`. Players seeing "Made it!" when they were set (or vice versa) is a critical UX bug.

The lead suit indicator addresses a gameplay need — knowing who led and what suit was led is essential for follow-suit decisions.

## Changes

| File | Change |
|------|--------|
| `web/templates/partials/game_board.html` | Replace `\| default(-1, true)` with `if (x is defined and x is not none) else -1` for `dealer_seat`, `bidder_seat`, `current_seat` |
| `web/templates/partials/trick.html` | Add `display_leader` variable, `leader_seat` param to `seat_markers` macro, lead suit display in heading |
| `web/static/style.css` | Add `.seat-marker--leader` and `.lead-suit` styles |
| `tests/unit/hosted_play/test_partials.py` | 7 new tests: 3 game_board seat-0 regression, 4 trick leader/lead-suit |

## Repro / Validation

```bash
# Tier 1 (targeted)
uv run python -m pytest tests/unit/hosted_play/test_partials.py -k "TestGameBoardSeatZeroRegression or test_leader or test_lead_suit" -v

# Tier 2 (full)
make check-quiet
# Result: 7726 passed, 3 pre-existing failures in ops module (not in scope)
```

## Test criteria

1. `test_hand_result_via_game_board_seat0_set` — human (seat 0) bid and got set → banner says "Set!", NOT "Made it!"
2. `test_hand_result_via_game_board_seat0_made` — human (seat 0) bid and made → banner says "Made it!"
3. `test_dealer_seat_zero_preserved` — dealer_seat=0 renders the dealer marker (not coerced to -1)
4. `test_leader_marker_shown_for_trick_leader` — "L" marker appears on the trick leader
5. `test_lead_suit_displayed` — lead suit symbol shown in trick heading

## Worktree proof

```
pwd: Bid-Euchre-steward-brws-author-a
branch: browser/score-bug-lead-indicator
```

Closes #1913
Closes #1914

🤖 Generated with [Claude Code](https://claude.com/claude-code)