### PR TITLE
feat(web): sort hand by suit/bower rank + add trick history toggle

### DIFF
--- a/src/bid_euchre/hosted_play/engine.py
+++ b/src/bid_euchre/hosted_play/engine.py
@@ -11,6 +11,7 @@ import random
 from dataclasses import dataclass
 from typing import Any
 
+from bid_euchre.core.cards import Card, effective_suit, is_left_bower, is_right_bower
 from bid_euchre.core.rules import get_legal_indices, trick_winner
 from bid_euchre.scoring import compute_points
 from bid_euchre.sim.deals import generate_deal
@@ -35,6 +36,66 @@ MATCH_TARGET = 52
 # Seats in bidding order relative to dealer: (dealer+1), (dealer+2), (dealer+3), dealer
 _NUM_PLAYERS = 4
 _TRICKS_PER_HAND = 10
+
+
+# Display suit order: Spades, Hearts, Diamonds, Clubs
+_SUIT_DISPLAY_ORDER: dict[str, int] = {"S": 0, "H": 1, "D": 2, "C": 3}
+
+# Within-suit rank order: J highest, then A-K-Q-T
+_RANK_DISPLAY_ORDER: dict[str, int] = {"J": 0, "A": 1, "K": 2, "Q": 3, "T": 4}
+
+# Low-contract rank order: T highest, then J-Q-K-A
+_RANK_DISPLAY_ORDER_LOW: dict[str, int] = {"T": 0, "J": 1, "Q": 2, "K": 3, "A": 4}
+
+
+def sort_hand_for_display(
+    hand: list[Card],
+    contract_type: str | None = None,
+    trump: str | None = None,
+) -> None:
+    """Sort a hand **in-place** for human display.
+
+    Grouping:
+    - Cards are grouped by effective suit (bowers move to trump group in suit
+      contracts).
+    - When trump is active, the trump suit appears first; remaining suits
+      follow standard order (S > H > D > C).
+
+    Within-suit ordering:
+    - Suit contracts: right bower > left bower > A > K > Q > (non-bower J) > T
+    - High / auction (no trump): J > A > K > Q > T
+    - Low contracts: T > J > Q > K > A
+    """
+
+    def _sort_key(card: Card) -> tuple[int, int]:
+        # Effective suit for grouping
+        if contract_type == "suit" and trump:
+            eff = effective_suit(card, trump, contract_type)
+        else:
+            eff = card.suit
+
+        # Suit ordering — trump first when active
+        if contract_type == "suit" and trump and eff == trump:
+            suit_key = -1
+        else:
+            suit_key = _SUIT_DISPLAY_ORDER.get(eff, 99)
+
+        # Rank ordering within suit
+        if contract_type == "suit" and trump and eff == trump:
+            if is_right_bower(card, trump):
+                rank_key = -2
+            elif is_left_bower(card, trump):
+                rank_key = -1
+            else:
+                rank_key = _RANK_DISPLAY_ORDER.get(card.rank, 99)
+        elif contract_type == "low":
+            rank_key = _RANK_DISPLAY_ORDER_LOW.get(card.rank, 99)
+        else:
+            rank_key = _RANK_DISPLAY_ORDER.get(card.rank, 99)
+
+        return (suit_key, rank_key)
+
+    hand.sort(key=_sort_key)
 
 
 def _bid_order(dealer_seat: int) -> list[int]:
@@ -420,6 +481,10 @@ class MatchEngine:
             turn_number=0,
         )
         state.current_hand = hand
+
+        # Sort human hand for display (no trump known yet during auction)
+        sort_hand_for_display(hand.hands[HUMAN_SEAT])
+
         return state
 
     # ------------------------------------------------------------------
@@ -519,6 +584,9 @@ class MatchEngine:
         leader = hand.bidder_seat
         hand.current_trick = TrickState(leader=leader)
         hand.current_seat = leader
+
+        # Re-sort human hand with bower awareness now that trump is known
+        sort_hand_for_display(hand.hands[HUMAN_SEAT], hand.contract_type, hand.trump)
 
         return state
 

--- a/tests/unit/hosted_play/test_engine.py
+++ b/tests/unit/hosted_play/test_engine.py
@@ -39,6 +39,7 @@ from bid_euchre.hosted_play.engine import (
     _bid_order,
     _next_active_seat,
     _players_per_trick,
+    sort_hand_for_display,
 )
 from bid_euchre.hosted_play.state import MatchState
 from bid_euchre.scoring import compute_points
@@ -1603,3 +1604,162 @@ class TestTrickWinnerDisplay:
                 return
 
         pytest.fail("Could not find a moon exchange in 100 seeds")
+
+
+# ---------------------------------------------------------------------------
+# 20. sort_hand_for_display
+# ---------------------------------------------------------------------------
+
+
+class TestSortHandForDisplay:
+    """Tests for the display-sorting helper."""
+
+    def test_groups_by_suit(self) -> None:
+        """Cards are grouped by printed suit when no trump is active."""
+        hand = [
+            Card("H", "A"),
+            Card("S", "K"),
+            Card("D", "Q"),
+            Card("S", "A"),
+            Card("H", "T"),
+            Card("C", "J"),
+        ]
+        sort_hand_for_display(hand)
+        suits = [c.suit for c in hand]
+        # S group first, then H, D, C
+        assert suits == ["S", "S", "H", "H", "D", "C"]
+
+    def test_within_suit_rank_order(self) -> None:
+        """Within a suit: J > A > K > Q > T (no trump)."""
+        hand = [
+            Card("H", "T"),
+            Card("H", "A"),
+            Card("H", "J"),
+            Card("H", "Q"),
+            Card("H", "K"),
+        ]
+        sort_hand_for_display(hand)
+        ranks = [c.rank for c in hand]
+        assert ranks == ["J", "A", "K", "Q", "T"]
+
+    def test_trump_suit_first(self) -> None:
+        """With trump active, trump group appears before other suits."""
+        hand = [
+            Card("S", "A"),
+            Card("H", "A"),
+            Card("D", "A"),
+            Card("C", "A"),
+        ]
+        sort_hand_for_display(hand, contract_type="suit", trump="D")
+        suits = [c.suit for c in hand]
+        assert suits[0] == "D"  # Trump first
+        # Remaining suits in standard order: S, H, C
+        assert suits[1:] == ["S", "H", "C"]
+
+    def test_right_bower_highest_in_trump(self) -> None:
+        """Right bower (J of trump) sorts highest in trump group."""
+        hand = [
+            Card("H", "A"),
+            Card("H", "J"),  # Right bower
+            Card("H", "K"),
+        ]
+        sort_hand_for_display(hand, contract_type="suit", trump="H")
+        ranks = [c.rank for c in hand]
+        assert ranks == ["J", "A", "K"]  # J (right bower) first
+
+    def test_left_bower_moves_to_trump_group(self) -> None:
+        """Left bower (J of same color) moves from its printed suit to trump."""
+        hand = [
+            Card("H", "A"),  # Trump
+            Card("D", "J"),  # Left bower (same color as H)
+            Card("H", "J"),  # Right bower
+            Card("D", "A"),  # Non-trump D (J removed)
+        ]
+        sort_hand_for_display(hand, contract_type="suit", trump="H")
+        # Trump group: right bower J♥, left bower J♦, A♥
+        # Then remaining: D♦ A
+        result = [(c.suit, c.rank) for c in hand]
+        assert result == [
+            ("H", "J"),  # right bower
+            ("D", "J"),  # left bower (effective suit = H)
+            ("H", "A"),  # trump A
+            ("D", "A"),  # non-trump D
+        ]
+
+    def test_low_contract_rank_order(self) -> None:
+        """Low contract: T > J > Q > K > A (10 is high)."""
+        hand = [
+            Card("S", "A"),
+            Card("S", "T"),
+            Card("S", "K"),
+            Card("S", "J"),
+            Card("S", "Q"),
+        ]
+        sort_hand_for_display(hand, contract_type="low")
+        ranks = [c.rank for c in hand]
+        assert ranks == ["T", "J", "Q", "K", "A"]
+
+    def test_high_contract_no_bower_awareness(self) -> None:
+        """High contract: no bowers, standard J-A-K-Q-T order."""
+        hand = [
+            Card("H", "J"),
+            Card("D", "J"),
+            Card("H", "A"),
+        ]
+        sort_hand_for_display(hand, contract_type="high")
+        # Both Js stay in their printed suits, no bower movement
+        result = [(c.suit, c.rank) for c in hand]
+        assert result == [
+            ("H", "J"),
+            ("H", "A"),
+            ("D", "J"),
+        ]
+
+    def test_sort_is_stable_idempotent(self) -> None:
+        """Sorting an already-sorted hand produces the same order."""
+        hand = [
+            Card("S", "J"),
+            Card("S", "A"),
+            Card("H", "K"),
+            Card("D", "Q"),
+        ]
+        sort_hand_for_display(hand)
+        first_pass = list(hand)
+        sort_hand_for_display(hand)
+        assert hand == first_pass
+
+    def test_duplicate_cards_handled(self) -> None:
+        """Double-deck duplicates don't cause errors."""
+        hand = [
+            Card("H", "A"),
+            Card("H", "A"),
+            Card("S", "K"),
+            Card("S", "K"),
+        ]
+        sort_hand_for_display(hand)
+        result = [(c.suit, c.rank) for c in hand]
+        assert result == [
+            ("S", "K"),
+            ("S", "K"),
+            ("H", "A"),
+            ("H", "A"),
+        ]
+
+    def test_engine_sorts_after_deal(self) -> None:
+        """After starting a match, the human hand is sorted by suit."""
+        engine = MatchEngine(
+            bidding_policy=AlwaysPassBidder(),
+            play_strategy=FirstLegalPlay(),
+        )
+        state = engine.start_match(SEED, "heuristic")
+        hand = state.current_hand
+        assert hand is not None
+
+        human_cards = hand.hands[HUMAN_SEAT]
+        # Verify grouped by suit: each suit's cards are contiguous
+        seen_suits: list[str] = []
+        for card in human_cards:
+            if not seen_suits or seen_suits[-1] != card.suit:
+                seen_suits.append(card.suit)
+        # No suit should appear more than once in the seen list
+        assert len(seen_suits) == len(set(seen_suits))

--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -1799,3 +1799,135 @@ class TestGameTemplateAccessibility:
         assert "AI Left (10)" in html
         assert "Partner (10)" in html
         assert "AI Right (10)" in html
+
+
+# ---------------------------------------------------------------------------
+# trick_history.html
+# ---------------------------------------------------------------------------
+
+
+class TestTrickHistory:
+    """Tests for the collapsible trick history partial."""
+
+    @pytest.fixture()
+    def completed_tricks(self):
+        """Two completed tricks for testing."""
+        return [
+            {
+                "leader": 0,
+                "plays": [
+                    [0, ["S", "A"]],
+                    [1, ["S", "K"]],
+                    [2, ["S", "Q"]],
+                    [3, ["S", "T"]],
+                ],
+                "winner": 0,
+            },
+            {
+                "leader": 0,
+                "plays": [
+                    [0, ["H", "J"]],
+                    [1, ["H", "A"]],
+                    [2, ["H", "K"]],
+                    [3, ["H", "Q"]],
+                ],
+                "winner": 1,
+            },
+        ]
+
+    def test_renders_empty_when_no_tricks(self, env):
+        """No output when completed_tricks is empty."""
+        tmpl = env.get_template("partials/trick_history.html")
+        html = tmpl.render(completed_tricks=[], tricks_team0=0, tricks_team1=0)
+        assert "trick-history" not in html
+
+    def test_renders_details_element(self, env, completed_tricks):
+        """Renders a <details> element with correct id."""
+        tmpl = env.get_template("partials/trick_history.html")
+        html = tmpl.render(
+            completed_tricks=completed_tricks, tricks_team0=1, tricks_team1=1
+        )
+        assert 'id="trick-history"' in html
+        assert "Cards Played (2/10)" in html
+
+    def test_shows_card_values(self, env, completed_tricks):
+        """Card values appear in the history table."""
+        tmpl = env.get_template("partials/trick_history.html")
+        html = tmpl.render(
+            completed_tricks=completed_tricks, tricks_team0=1, tricks_team1=1
+        )
+        # Suit symbols and ranks should appear
+        assert "\u2660" in html  # ♠
+        assert "\u2665" in html  # ♥
+        assert "A" in html
+        assert "K" in html
+
+    def test_shows_trick_numbers(self, env, completed_tricks):
+        """Each trick row has its number."""
+        tmpl = env.get_template("partials/trick_history.html")
+        html = tmpl.render(
+            completed_tricks=completed_tricks, tricks_team0=1, tricks_team1=1
+        )
+        # Trick numbers appear in cells
+        assert "trick-history__cell--num" in html
+
+    def test_winner_cell_highlighted(self, env, completed_tricks):
+        """Winner's card cell gets the winner class."""
+        tmpl = env.get_template("partials/trick_history.html")
+        html = tmpl.render(
+            completed_tricks=completed_tricks, tricks_team0=1, tricks_team1=1
+        )
+        assert "trick-history__cell--winner" in html
+
+    def test_leader_cell_marked(self, env, completed_tricks):
+        """Leader's card cell gets the leader class."""
+        tmpl = env.get_template("partials/trick_history.html")
+        html = tmpl.render(
+            completed_tricks=completed_tricks, tricks_team0=1, tricks_team1=1
+        )
+        assert "trick-history__cell--leader" in html
+
+    def test_won_column_shows_seat_label(self, env, completed_tricks):
+        """Won column shows human-readable seat labels."""
+        tmpl = env.get_template("partials/trick_history.html")
+        html = tmpl.render(
+            completed_tricks=completed_tricks, tricks_team0=1, tricks_team1=1
+        )
+        assert "You" in html  # Trick 1 won by seat 0
+        assert "Left" in html  # Trick 2 won by seat 1
+
+    def test_has_table_headers(self, env, completed_tricks):
+        """Table has column headers for seat labels."""
+        tmpl = env.get_template("partials/trick_history.html")
+        html = tmpl.render(
+            completed_tricks=completed_tricks, tricks_team0=1, tricks_team1=1
+        )
+        assert "Partner" in html
+        assert "Right" in html
+        assert "Won" in html
+
+    def test_sitting_out_seat_shows_dash(self, env):
+        """When a seat is sitting out (loner), its cell shows a dash."""
+        tricks = [
+            {
+                "leader": 0,
+                "plays": [
+                    [0, ["H", "A"]],
+                    [1, ["H", "K"]],
+                    [3, ["H", "Q"]],
+                ],
+                "winner": 0,
+            },
+        ]
+        tmpl = env.get_template("partials/trick_history.html")
+        html = tmpl.render(completed_tricks=tricks, tricks_team0=1, tricks_team1=0)
+        assert "trick-history__absent" in html
+
+    def test_has_aria_attributes(self, env, completed_tricks):
+        """Trick history has accessibility attributes."""
+        tmpl = env.get_template("partials/trick_history.html")
+        html = tmpl.render(
+            completed_tricks=completed_tricks, tricks_team0=1, tricks_team1=1
+        )
+        assert 'role="region"' in html
+        assert 'aria-label="Cards played history"' in html

--- a/web/static/game.js
+++ b/web/static/game.js
@@ -171,14 +171,56 @@
             }
             clearCardSelection(getCardPlayForm());
             syncCardPlayFormControls(getCardPlayForm());
+            restoreTrickHistoryState();
+        }, true);
+    }
+
+    /* ---------------------------------------------------------------
+     * Trick history toggle — persist open/closed state across HTMX
+     * swaps so the panel doesn't collapse every time the board updates.
+     * --------------------------------------------------------------- */
+
+    var TRICK_HISTORY_KEY = 'trickHistoryOpen';
+
+    function saveTrickHistoryState() {
+        var details = document.getElementById('trick-history');
+        if (details) {
+            try {
+                sessionStorage.setItem(TRICK_HISTORY_KEY, details.open ? '1' : '0');
+            } catch (_) {
+                // sessionStorage unavailable — ignore
+            }
+        }
+    }
+
+    function restoreTrickHistoryState() {
+        var details = document.getElementById('trick-history');
+        if (!details) { return; }
+        try {
+            var saved = sessionStorage.getItem(TRICK_HISTORY_KEY);
+            if (saved === '1') {
+                details.open = true;
+            }
+        } catch (_) {
+            // sessionStorage unavailable — ignore
+        }
+    }
+
+    function attachTrickHistoryToggle() {
+        document.addEventListener('toggle', function (event) {
+            if (event.target && event.target.id === 'trick-history') {
+                saveTrickHistoryState();
+            }
         }, true);
     }
 
     function initialize() {
         attachDelegatedHandlers();
+        attachTrickHistoryToggle();
         var form = getCardPlayForm();
         clearCardSelection(form);
         syncCardPlayFormControls(form);
+        restoreTrickHistoryState();
     }
 
     initialize();

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -427,6 +427,103 @@ main {
     margin-top: 0.25rem;
 }
 
+/* Trick history (collapsible) */
+.trick-history {
+    background: var(--color-surface);
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.trick-history__toggle {
+    cursor: pointer;
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+    padding: 0.5rem 0.75rem;
+    user-select: none;
+    list-style: none;
+}
+
+.trick-history__toggle::-webkit-details-marker {
+    display: none;
+}
+
+.trick-history__toggle::before {
+    content: "\25b6";
+    display: inline-block;
+    margin-right: 0.35rem;
+    font-size: 0.65rem;
+    transition: transform 0.15s ease;
+}
+
+.trick-history[open] > .trick-history__toggle::before {
+    transform: rotate(90deg);
+}
+
+.trick-history__content {
+    padding: 0 0.75rem 0.5rem;
+}
+
+.trick-history__table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.78rem;
+}
+
+.trick-history__th {
+    text-align: center;
+    color: var(--color-text-muted);
+    font-weight: 600;
+    padding: 0.2rem 0.35rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+    font-size: 0.72rem;
+}
+
+.trick-history__cell {
+    text-align: center;
+    padding: 0.2rem 0.35rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.trick-history__cell--num {
+    color: var(--color-text-muted);
+    font-size: 0.72rem;
+}
+
+.trick-history__cell--winner {
+    font-weight: 700;
+}
+
+.trick-history__cell--leader {
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    text-underline-offset: 2px;
+}
+
+.trick-history__cell--won {
+    color: var(--color-text-muted);
+    font-size: 0.72rem;
+}
+
+.trick-history__absent {
+    color: rgba(255, 255, 255, 0.2);
+}
+
+/* Inline card rendering (for trick history table) */
+.card--inline {
+    font-weight: 700;
+    white-space: nowrap;
+}
+
+.card--inline.card--hearts,
+.card--inline.card--diamonds {
+    color: var(--color-red);
+}
+
+.card--inline.card--spades,
+.card--inline.card--clubs {
+    color: var(--color-text);
+}
+
 /* Empty card slot placeholder */
 .card-slot {
     width: var(--card-width);

--- a/web/templates/partials/game_board.html
+++ b/web/templates/partials/game_board.html
@@ -110,6 +110,9 @@
     {# Trick area — always shown during active play #}
     {% include "partials/trick.html" %}
 
+    {# Collapsible trick history — shows cards played in completed tricks #}
+    {% include "partials/trick_history.html" %}
+
     {% if show_next %}
         {% include "partials/next_controls.html" %}
     {% endif %}

--- a/web/templates/partials/trick_history.html
+++ b/web/templates/partials/trick_history.html
@@ -1,0 +1,56 @@
+{# Trick history (collapsible) — shows cards played in completed tricks.
+   Context variables:
+     - completed_tricks: list[dict] — {leader, plays: [[seat, [suit, rank]]], winner}
+     - tricks_team0: int — tricks won by human's team
+     - tricks_team1: int — tricks won by AI team
+#}
+{% set suit_symbols = {"S": "\u2660", "H": "\u2665", "D": "\u2666", "C": "\u2663"} %}
+{% set suit_classes = {"S": "spades", "H": "hearts", "D": "diamonds", "C": "clubs"} %}
+{% set seat_labels = {0: "You", 1: "Left", 2: "Partner", 3: "Right"} %}
+
+{% if completed_tricks %}
+<details id="trick-history" class="trick-history" role="region" aria-label="Cards played history">
+    <summary class="trick-history__toggle">
+        Cards Played ({{ completed_tricks | length }}/10)
+    </summary>
+    <div class="trick-history__content">
+        <table class="trick-history__table" aria-label="Trick-by-trick card history">
+            <thead>
+                <tr>
+                    <th class="trick-history__th">#</th>
+                    <th class="trick-history__th">You</th>
+                    <th class="trick-history__th">Left</th>
+                    <th class="trick-history__th">Partner</th>
+                    <th class="trick-history__th">Right</th>
+                    <th class="trick-history__th">Won</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for trick in completed_tricks %}
+                    {% set ns = namespace(cards={}) %}
+                    {% for play in trick.plays %}
+                        {% set _ = ns.cards.update({play[0]: play[1]}) %}
+                    {% endfor %}
+                    <tr class="trick-history__row">
+                        <td class="trick-history__cell trick-history__cell--num">{{ loop.index }}</td>
+                        {% for seat in [0, 1, 2, 3] %}
+                            <td class="trick-history__cell{% if seat == trick.winner %} trick-history__cell--winner{% endif %}{% if seat == trick.leader %} trick-history__cell--leader{% endif %}">
+                                {% if seat in ns.cards %}
+                                    {% set card = ns.cards[seat] %}
+                                    {% set suit = card[0] %}
+                                    <span class="card--inline card--{{ suit_classes.get(suit, 'spades') }}">{{ card[1] }}{{ suit_symbols.get(suit, suit) }}</span>
+                                {% else %}
+                                    <span class="trick-history__absent" aria-label="Sitting out">&mdash;</span>
+                                {% endif %}
+                            </td>
+                        {% endfor %}
+                        <td class="trick-history__cell trick-history__cell--won">
+                            {{ seat_labels.get(trick.winner, "?") }}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</details>
+{% endif %}


### PR DESCRIPTION
## Plan
Closes #1911, closes #1892

## Summary
- Sort player hand left-to-right by suit with bower-aware ranking (J-A-K-Q-T)
- Add collapsible "Cards Played" trick history panel showing per-trick card plays
- Persist trick history toggle state across HTMX page swaps

## Why
Players expect their hand to be organized by suit for quick assessment. The card-by-card
trick history gives players visibility into what has been played without cluttering the
main trick area.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/ -q
```

**Result:** 420 passed, 2 skipped

## Test Criteria
- **Pass condition:** `sort_hand_for_display` groups cards by suit, puts trump first, bowers sort into trump group
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_engine.py::TestSortHandForDisplay -v`
- **Expected result:** 10 tests pass covering suit grouping, bower movement, low/high contracts, duplicates, and engine integration

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/ -q` — 420 passed
- [x] `make lint` — clean
- [x] `make check-quiet` — 3 pre-existing failures in ops (unrelated: test_ops_snapshots, test_ops_token_economy)
- [x] Other: Pre-commit hooks (ruff, ruff-format, repo-linter) all pass

## Expected impact
- Metrics impact: None (display-only change)
- Runtime impact: Negligible (in-place sort of 10-card list)

## Risk level
- [x] Low (web UI + tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git worktree list` (abridged):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre  main
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c  web/hand-sort-trick-history
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept: hand sorting + trick history for card visibility)