### PR TITLE
fix(test): disable age-based pruning in per-worktree-cap snapshot test

### DIFF
--- a/tests/unit/test_ops_snapshots.py
+++ b/tests/unit/test_ops_snapshots.py
@@ -458,7 +458,9 @@ class TestPruneSnapshots:
                 timestamp=f"2026-03-20T{10 + i}:00:00+00:00",
             )
 
-        pruned = prune_snapshots(snapshots_dir, max_per_worktree=3)
+        pruned = prune_snapshots(
+            snapshots_dir, max_per_worktree=3, max_age_hours=999999
+        )
         assert len(pruned) == 2
         # Oldest two should be pruned
         assert "snap-000" in pruned


### PR DESCRIPTION
## Summary
- Fix `test_prunes_beyond_per_worktree_cap` which started failing on 2026-03-27 due to hardcoded timestamps aging past the 7-day `DEFAULT_MAX_AGE_HOURS` threshold
- Add `max_age_hours=999999` to isolate the per-worktree cap test from age-based pruning, matching the existing pattern in `test_per_worktree_cap_is_independent`

## Why
This test failure blocks CI for all open browser PRs (#1922–#1925). The root cause is a time-dependent test: snapshots dated 2026-03-20 became >168h old on 2026-03-27, so the age rule pruned all 5 instead of just the 2 beyond the cap.

The second originally-reported failure (`test_three_consecutive_dispatch_cycles_with_reset`) already passes on main — no change needed.

## Note: Additional Pre-Existing Failures
Two additional pre-existing failures were discovered in `test_ops_token_economy.py` (outside this PR's scope):
- `TestAutoImport::test_stale_usage_with_missing_attr_does_full_reimport`
- `TestAutoImport::test_stale_usage_with_missing_attr_rebuilds_even_if_no_new_sessions`

These exist on main before this PR and need a separate fix.

## Repro / Validation
```bash
# Before fix (fails)
uv run python -m pytest tests/unit/test_ops_snapshots.py::TestPruneSnapshots::test_prunes_beyond_per_worktree_cap -v

# After fix (passes)
uv run python -m pytest tests/unit/test_ops_snapshots.py -v  # all 48 pass
```

## Tests
```bash
uv run python -m pytest tests/unit/test_ops_snapshots.py tests/unit/test_ops_worker_pool.py::TestDispatchRedispatchCycles::test_three_consecutive_dispatch_cycles_with_reset -v
# 49 passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: fix/pre-existing-test-failures
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)