### PR TITLE
fix(web): coerce bidder_seat to int in hand result template (#1928)

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -1011,6 +1011,49 @@ class TestHandResult:
         assert "♣J" in html
         assert "♦9" in html
 
+    @pytest.mark.parametrize(
+        "seat_val,expected_label",
+        [("0", "You"), ("1", "AI Left"), ("2", "AI Partner"), ("3", "AI Right")],
+        ids=["str_seat0", "str_seat1", "str_seat2", "str_seat3"],
+    )
+    def test_string_bidder_seat_coerced_to_label(self, env, seat_val, expected_label):
+        """String bidder_seat values are coerced to int for label lookup (#1928)."""
+        html = env.get_template("partials/hand_result.html").render(
+            winning_bid=6,
+            bidder_seat=seat_val,
+            contract_type="suit",
+            trump="S",
+            tricks_team0=7,
+            tricks_team1=3,
+            points_team0=7,
+            points_team1=3,
+            score_human=7,
+            score_ai=3,
+            hands_played=1,
+        )
+        assert expected_label in html
+        assert f"Seat {seat_val}" not in html
+
+    @pytest.mark.parametrize("seat", [0, 1, 2, 3])
+    def test_int_bidder_seat_still_works(self, env, seat):
+        """Int bidder_seat values continue to resolve to correct labels (#1928)."""
+        expected = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"}
+        html = env.get_template("partials/hand_result.html").render(
+            winning_bid=6,
+            bidder_seat=seat,
+            contract_type="suit",
+            trump="H",
+            tricks_team0=7,
+            tricks_team1=3,
+            points_team0=7,
+            points_team1=3,
+            score_human=7,
+            score_ai=3,
+            hands_played=1,
+        )
+        assert expected[seat] in html
+        assert f"Seat {seat}" not in html
+
 
 # ---------------------------------------------------------------------------
 # moon_exchange.html

--- a/web/templates/partials/hand_result.html
+++ b/web/templates/partials/hand_result.html
@@ -15,6 +15,7 @@
 #}
 {% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
 {% set seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"} %}
+{% set bidder_seat = bidder_seat | int %}
 {% set hand_bid_type = bid_type | default("regular") %}
 {% set exchange_given_cards = exchange_given | default([], true) %}
 {% set exchange_received_cards = exchange_received | default([], true) %}


### PR DESCRIPTION
## Summary

- Add `| int` filter to `bidder_seat` in `hand_result.html` template so string-typed seat values (e.g., `"0"` from deserialization edge cases) correctly resolve to friendly labels instead of falling through to the `"Seat N"` fallback
- Add 8 parametrized tests covering string-to-int coercion and int-type stability for all 4 seats

## Why

The `seat_labels` dict uses integer keys `{0: "You", 1: "AI Left", ...}`. If `bidder_seat` arrives as a string type, the `.get()` lookup misses and the user sees raw "Seat 0" instead of "You" (issue #1928).

## Repro / Validation

```bash
# Targeted tests (0.3s)
uv run python -m pytest tests/unit/hosted_play/test_partials.py -k "string_bidder_seat or int_bidder_seat" -v

# Full partial + scoring matrix suite (358 tests, ~59s)
uv run python -m pytest tests/unit/hosted_play/test_partials.py tests/unit/hosted_play/test_scoring_matrix.py -x --tb=short
```

## Tests

- `uv run python -m pytest tests/unit/hosted_play/test_partials.py` — 99 tests pass ✅
- `uv run python -m pytest tests/unit/hosted_play/test_scoring_matrix.py` — 259 tests pass ✅
- `make lint` — ✅
- `make repo-lint` — ✅

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
branch: fix/seat-labels-hand-result
```

Closes #1928

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>