### PR TITLE
fix(ops): add paste-bracket delay for tmux send-keys (#1834)

### DIFF
--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import logging
 import shutil
 import subprocess
+import time
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -64,6 +65,14 @@ DEFAULT_TMUX_SESSION: str = "steward"
 
 #: Pool status values.
 POOL_STATUSES: frozenset[str] = frozenset({"active", "idle", "parked", "retired"})
+
+#: Delay (seconds) between sending text and Enter via tmux send-keys.
+#: Modern terminals use bracketed paste mode, which wraps pasted text in
+#: escape sequences (``\e[200~...\e[201~``).  If Enter follows immediately,
+#: it lands inside the paste bracket and is consumed as pasted text rather
+#: than acting as a submit key.  A short delay lets the terminal close the
+#: bracket before Enter arrives.  See issue #1834.
+_PASTE_BRACKET_DELAY: float = 0.1
 
 #: Default domain assignment for each managed lane.
 #: Lanes with ``None`` are "flex" — available to any domain when same-domain
@@ -1136,6 +1145,10 @@ def clear_session(
             capture_output=True,
             timeout=5,
         )
+        # Delay to let the terminal close its paste bracket before Enter
+        # arrives.  Without this, Enter is consumed inside the bracket and
+        # the command is pasted but never submitted.  See #1834.
+        time.sleep(_PASTE_BRACKET_DELAY)
         subprocess.run(
             ["tmux", "send-keys", "-t", target, "Enter"],
             check=True,
@@ -1202,6 +1215,10 @@ def nudge_pane(
             capture_output=True,
             timeout=5,
         )
+        # Delay to let the terminal close its paste bracket before Enter
+        # arrives.  Without this, Enter is consumed inside the bracket and
+        # the command is pasted but never submitted.  See #1834.
+        time.sleep(_PASTE_BRACKET_DELAY)
         subprocess.run(
             ["tmux", "send-keys", "-t", target, "Enter"],
             check=True,
@@ -1379,7 +1396,6 @@ def dispatch_to_worker(
             if auto_refresh.executed:
                 logger.info("Auto-refresh succeeded for %s", lane_id)
                 session_cleared = True
-                import time
 
                 # Brief pause to let /clear complete before sending /start-task
                 time.sleep(2)
@@ -1409,7 +1425,6 @@ def dispatch_to_worker(
                 clear_result.reason,
             )
         session_cleared = True
-        import time
 
         # Brief pause to let /clear complete before sending /start-task
         time.sleep(2)
@@ -1504,8 +1519,6 @@ def dispatch_to_worker(
                 lane_id, tmux_session=tmux_session, runtime_dir=runtime_dir
             )
             if clear_result.executed:
-                import time
-
                 # Pause to let /clear complete before sending /start-task
                 time.sleep(3)
             else:

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from bid_euchre.ops.worker_pool import (
+    _PASTE_BRACKET_DELAY,
     DEFAULT_TMUX_SESSION,
     IDLE_PARK_MINUTES,
     LANE_DOMAINS,
@@ -1881,8 +1882,11 @@ class TestNudgePane:
     """Test nudge_pane() with mocked subprocess."""
 
     @patch(f"{_WORKER_POOL}._resolve_tmux_target", return_value="steward:author-a")
+    @patch(f"{_WORKER_POOL}.time.sleep")
     @patch(f"{_WORKER_POOL}.subprocess.run")
-    def test_nudge_success(self, mock_run: MagicMock, mock_resolve: MagicMock) -> None:
+    def test_nudge_success(
+        self, mock_run: MagicMock, mock_sleep: MagicMock, mock_resolve: MagicMock
+    ) -> None:
         mock_run.return_value = MagicMock(returncode=0)
         result = nudge_pane("author-a", "pkt123")
         assert result.executed is True
@@ -1903,11 +1907,14 @@ class TestNudgePane:
             capture_output=True,
             timeout=5,
         )
+        # Verify paste-bracket delay between text and Enter (#1834)
+        mock_sleep.assert_called_once_with(_PASTE_BRACKET_DELAY)
 
     @patch(f"{_WORKER_POOL}._resolve_tmux_target", return_value="custom:author-b")
+    @patch(f"{_WORKER_POOL}.time.sleep")
     @patch(f"{_WORKER_POOL}.subprocess.run")
     def test_nudge_custom_session(
-        self, mock_run: MagicMock, mock_resolve: MagicMock
+        self, mock_run: MagicMock, mock_sleep: MagicMock, mock_resolve: MagicMock
     ) -> None:
         mock_run.return_value = MagicMock(returncode=0)
         result = nudge_pane("author-b", "pkt456", tmux_session="custom")
@@ -1925,6 +1932,7 @@ class TestNudgePane:
             capture_output=True,
             timeout=5,
         )
+        mock_sleep.assert_called_once_with(_PASTE_BRACKET_DELAY)
 
     @patch(f"{_WORKER_POOL}._resolve_tmux_target", return_value="steward:author-a")
     @patch(f"{_WORKER_POOL}.subprocess.run")
@@ -1999,6 +2007,59 @@ class TestNudgePane:
             assert result.executed is True
             call_args = mock_run.call_args[0][0]
             assert call_args[3] == "steward:platform.1"
+
+
+class TestPasteBracketDelay:
+    """Verify text → sleep → Enter ordering for paste-bracket fix (#1834)."""
+
+    @patch(f"{_WORKER_POOL}._resolve_tmux_target", return_value="steward:author-a")
+    def test_nudge_call_order(self, mock_resolve: MagicMock) -> None:
+        """nudge_pane sends text, sleeps, then sends Enter — in that order."""
+        call_log: list[str] = []
+
+        def track_run(cmd: list[str], **_kw: object) -> MagicMock:
+            # Record whether we're sending text or Enter
+            if cmd[-1] == "Enter":
+                call_log.append("enter")
+            else:
+                call_log.append("text")
+            return MagicMock(returncode=0)
+
+        def track_sleep(seconds: float) -> None:
+            call_log.append(f"sleep({seconds})")
+
+        with (
+            patch(f"{_WORKER_POOL}.subprocess.run", side_effect=track_run),
+            patch(f"{_WORKER_POOL}.time.sleep", side_effect=track_sleep),
+        ):
+            result = nudge_pane("author-a", "pkt123")
+            assert result.executed is True
+
+        assert call_log == ["text", f"sleep({_PASTE_BRACKET_DELAY})", "enter"]
+
+    @patch(f"{_WORKER_POOL}._resolve_tmux_target", return_value="steward:author-a")
+    def test_clear_session_call_order(self, mock_resolve: MagicMock) -> None:
+        """clear_session sends /clear, sleeps, then sends Enter — in that order."""
+        call_log: list[str] = []
+
+        def track_run(cmd: list[str], **_kw: object) -> MagicMock:
+            if cmd[-1] == "Enter":
+                call_log.append("enter")
+            else:
+                call_log.append("text")
+            return MagicMock(returncode=0)
+
+        def track_sleep(seconds: float) -> None:
+            call_log.append(f"sleep({seconds})")
+
+        with (
+            patch(f"{_WORKER_POOL}.subprocess.run", side_effect=track_run),
+            patch(f"{_WORKER_POOL}.time.sleep", side_effect=track_sleep),
+        ):
+            result = clear_session("author-a")
+            assert result.executed is True
+
+        assert call_log == ["text", f"sleep({_PASTE_BRACKET_DELAY})", "enter"]
 
 
 # ---------------------------------------------------------------------------
@@ -2241,8 +2302,11 @@ class TestClearSession:
     """Test clear_session() with mocked subprocess."""
 
     @patch(f"{_WORKER_POOL}._resolve_tmux_target", return_value="steward:author-a")
+    @patch(f"{_WORKER_POOL}.time.sleep")
     @patch(f"{_WORKER_POOL}.subprocess.run")
-    def test_clear_success(self, mock_run: MagicMock, mock_resolve: MagicMock) -> None:
+    def test_clear_success(
+        self, mock_run: MagicMock, mock_sleep: MagicMock, mock_resolve: MagicMock
+    ) -> None:
         mock_run.return_value = MagicMock(returncode=0)
         result = clear_session("author-a")
         assert result.executed is True
@@ -2262,11 +2326,14 @@ class TestClearSession:
             capture_output=True,
             timeout=5,
         )
+        # Verify paste-bracket delay between text and Enter (#1834)
+        mock_sleep.assert_called_once_with(_PASTE_BRACKET_DELAY)
 
     @patch(f"{_WORKER_POOL}._resolve_tmux_target", return_value="custom:author-b")
+    @patch(f"{_WORKER_POOL}.time.sleep")
     @patch(f"{_WORKER_POOL}.subprocess.run")
     def test_clear_custom_session(
-        self, mock_run: MagicMock, mock_resolve: MagicMock
+        self, mock_run: MagicMock, mock_sleep: MagicMock, mock_resolve: MagicMock
     ) -> None:
         mock_run.return_value = MagicMock(returncode=0)
         result = clear_session("author-b", tmux_session="custom")
@@ -2275,6 +2342,7 @@ class TestClearSession:
         second_call = mock_run.call_args_list[1][0][0]
         assert first_call[3] == "custom:author-b"
         assert second_call[3] == "custom:author-b"
+        mock_sleep.assert_called_once_with(_PASTE_BRACKET_DELAY)
 
     @patch(f"{_WORKER_POOL}._resolve_tmux_target", return_value="steward:author-a")
     @patch(f"{_WORKER_POOL}.subprocess.run")


### PR DESCRIPTION
## Plan
N/A — bug fix from issue #1834

## Summary
- Add a 0.1s delay (`_PASTE_BRACKET_DELAY`) between sending command text and Enter via `tmux send-keys` in `nudge_pane()` and `clear_session()`
- Consolidate inline `import time` statements into a single top-level import
- Add ordering tests that verify text → sleep → Enter sequence

## Why
Modern terminals use bracketed paste mode which wraps pasted text in escape sequences (`\e[200~...\e[201~`). Without a delay between the text and Enter send-keys calls, Enter arrives while the terminal is still processing the paste bracket, gets consumed inside it, and the command is pasted but never submitted. This caused analyst lane dispatch failures observed 3 times during the overnight fleet run.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_worker_pool.py -k "nudge or clear_session or PasteBracket" -v
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** `_PASTE_BRACKET_DELAY` constant exists and is used in both `nudge_pane()` and `clear_session()`
- **Verification command:** `uv run python -m pytest tests/unit/test_ops_worker_pool.py -k "PasteBracket" -v`
- **Expected result:** 2 tests pass — `test_nudge_call_order` and `test_clear_session_call_order` verify the text → sleep(0.1) → Enter ordering

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_worker_pool.py` — 182 passed
- [x] `make check-quiet` — all 7989+ passed (3-5 pre-existing failures in unrelated tests due to machine load)
- [x] Other: New `TestPasteBracketDelay` class with ordering verification tests

## Expected impact
- Metrics impact: None
- Runtime impact: Adds 0.1s delay per `tmux send-keys` dispatch — negligible vs the 2-3s delays already present in dispatch

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author  587508e8 [fix/tmux-paste-bracketing-1834]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

Closes #1834