### PR TITLE
feat(ops): wire run_push_cycle into monitor module (#1826 part 1)

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -2300,6 +2300,7 @@ def cmd_monitor(args: argparse.Namespace) -> int:
 
     from bid_euchre.ops.control_plane import reconcile as _reconcile
     from bid_euchre.ops.monitor import (
+        evaluate_alert_push,
         format_findings_json,
         format_findings_text,
         run_monitoring_cycle,
@@ -2386,26 +2387,18 @@ def cmd_monitor(args: argparse.Namespace) -> int:
     # be pushed to the operator's phone via Telegram.
     no_push = getattr(args, "no_push", False)
     if not no_reconcile and not no_push:
-        try:
-            from bid_euchre.ops.telegram_push import run_push_cycle
-
-            audit_dir = args.runtime_dir / "audit_trail" if args.runtime_dir else None
-            push_result = run_push_cycle(
-                runtime_dir=args.runtime_dir,
-                audit_dir=audit_dir,
-                now=parsed_now,
+        cycle_result = evaluate_alert_push(
+            findings,
+            runtime_dir=args.runtime_dir,
+            now=parsed_now,
+        )
+        if cycle_result.push_result is not None:
+            pr = cycle_result.push_result
+            print(
+                f"\n📢 Alert push prepared ({len(pr.items_pushed)} items)"
+                f" → chat {pr.chat_id}"
             )
-            if push_result is not None:
-                print(
-                    f"\n📢 Alert push prepared ({len(push_result.items_pushed)} items)"
-                    f" → chat {push_result.chat_id}"
-                )
-                print(push_result.message)
-        except Exception:
-            # Push is best-effort — never block the monitor cycle.
-            import traceback
-
-            traceback.print_exc()
+            print(pr.message)
 
     # Exit 1 if any high-severity findings
     has_high = any(f.severity == "high" for f in findings)

--- a/src/bid_euchre/ops/monitor.py
+++ b/src/bid_euchre/ops/monitor.py
@@ -4,12 +4,24 @@ Runs a single monitoring sweep across lane health, open PRs, CI status,
 and stale dispatched packets.  Produces structured findings that are
 optionally sent to the orchestrator inbox via the message bus.
 
+After the monitoring sweep, callers may run :func:`evaluate_alert_push`
+to prepare a Telegram alert push for unresolved HIGH/URGENT items.
+The push evaluator reads the latest fleet status from disk (written by
+:func:`~bid_euchre.ops.control_plane.reconcile`) and returns a
+:class:`MonitorCycleResult` that bundles findings and push payload.
+
 Usage::
 
-    from bid_euchre.ops.monitor import run_monitoring_cycle
+    from bid_euchre.ops.monitor import run_monitoring_cycle, evaluate_alert_push
 
     findings = run_monitoring_cycle()
     # findings is a list of MonitorFinding dataclasses
+
+    # After reconcile(), evaluate alert push:
+    result = evaluate_alert_push(findings=findings)
+    if result.push_result is not None:
+        # Caller sends result.push_result.message via Telegram MCP reply
+        ...
 
 The CLI wrapper (``ops.py monitor``) calls this and formats the output.
 """
@@ -55,6 +67,25 @@ class MonitorFinding:
     severity: str  # "info", "warn", "high"
     summary: str
     details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class MonitorCycleResult:
+    """Complete result from a monitoring sweep plus optional alert push.
+
+    Bundles the monitoring findings with the push evaluator result so that
+    callers receive a single object with everything needed to act on the
+    cycle outcome.
+
+    Attributes:
+        findings: All findings from the monitoring sweep.
+        push_result: Alert push payload ready for Telegram delivery, or
+            ``None`` if no push is needed (Telegram disabled, fleet active,
+            no eligible items, etc.).
+    """
+
+    findings: list[MonitorFinding]
+    push_result: Any = None  # PushResult | None — typed as Any to avoid hard import
 
 
 # ---------------------------------------------------------------------------
@@ -1888,3 +1919,65 @@ def format_findings_json(findings: list[MonitorFinding]) -> dict[str, Any]:
         "info": sum(1 for f in findings if f.severity == SEVERITY_INFO),
         "findings": [asdict(f) for f in findings],
     }
+
+
+# ---------------------------------------------------------------------------
+# Alert push integration (Platform-9a)
+# ---------------------------------------------------------------------------
+
+
+def evaluate_alert_push(
+    findings: list[MonitorFinding],
+    *,
+    runtime_dir: Path | None = None,
+    audit_dir: Path | None = None,
+    now: datetime | None = None,
+) -> MonitorCycleResult:
+    """Evaluate alert push after a monitoring sweep and return a combined result.
+
+    This function bridges the monitoring cycle and the push evaluator from
+    :mod:`~bid_euchre.ops.telegram_push`.  It is designed to be called
+    **after** :func:`run_monitoring_cycle` and
+    :func:`~bid_euchre.ops.control_plane.reconcile`, so that the fleet
+    status on disk reflects the latest controller projection.
+
+    The push evaluator reads fleet status from disk, evaluates which
+    items need pushing (respecting cooldown, severity, and idle-gate),
+    formats a Telegram-ready message, and records the push in the audit
+    trail.  This function wraps that call with error handling (push is
+    best-effort — never blocks the monitor cycle) and returns a
+    :class:`MonitorCycleResult` that bundles findings + push payload.
+
+    The **caller** is responsible for actually sending
+    ``result.push_result.message`` to ``result.push_result.chat_id``
+    via the Telegram MCP ``reply`` tool.
+
+    Args:
+        findings: Findings from :func:`run_monitoring_cycle`.
+        runtime_dir: Override for the runtime directory root.
+        audit_dir: Override audit trail directory.  If ``None`` and
+            *runtime_dir* is set, defaults to ``runtime_dir / audit_trail``.
+        now: Override current time (for testing).
+
+    Returns:
+        A :class:`MonitorCycleResult` with the original findings and an
+        optional :class:`~bid_euchre.ops.telegram_push.PushResult`.
+    """
+    push_result = None
+    try:
+        from bid_euchre.ops.telegram_push import run_push_cycle
+
+        effective_audit_dir = audit_dir
+        if effective_audit_dir is None and runtime_dir is not None:
+            effective_audit_dir = runtime_dir / "audit_trail"
+
+        push_result = run_push_cycle(
+            runtime_dir=runtime_dir,
+            audit_dir=effective_audit_dir,
+            now=now,
+        )
+    except Exception:
+        # Push is best-effort — log and continue.
+        logger.warning("Alert push evaluation failed", exc_info=True)
+
+    return MonitorCycleResult(findings=findings, push_result=push_result)

--- a/tests/unit/test_ops_monitor.py
+++ b/tests/unit/test_ops_monitor.py
@@ -8,12 +8,15 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from bid_euchre.ops.monitor import (
     ESCALATION_AGE_MINUTES,
     MAX_AUTO_DISPATCH_PER_CYCLE,
     SEVERITY_HIGH,
     SEVERITY_INFO,
     SEVERITY_WARN,
+    MonitorCycleResult,
     MonitorFinding,
     _default_stall_state_path,
     _detect_active_work,
@@ -30,6 +33,7 @@ from bid_euchre.ops.monitor import (
     check_recently_merged_prs,
     check_stale_dispatches,
     check_stalled_lanes,
+    evaluate_alert_push,
     format_findings_json,
     format_findings_text,
     run_monitoring_cycle,
@@ -3410,3 +3414,137 @@ class TestMonitorCycleRobustness:
         assert "lane_health" in categories
         # Escalation check should produce a finding (info or warn).
         assert "escalation" in categories
+
+
+# ---------------------------------------------------------------------------
+# MonitorCycleResult tests
+# ---------------------------------------------------------------------------
+
+
+class TestMonitorCycleResult:
+    """Tests for the MonitorCycleResult dataclass."""
+
+    def test_default_push_result_is_none(self) -> None:
+        """Push result defaults to None."""
+        result = MonitorCycleResult(findings=[])
+        assert result.findings == []
+        assert result.push_result is None
+
+    def test_with_findings_and_push(self) -> None:
+        """Result carries both findings and push_result."""
+        finding = MonitorFinding(
+            category="lane_health",
+            severity="info",
+            summary="Pool: 2 active",
+        )
+        mock_push = MagicMock()
+        mock_push.chat_id = "12345"
+        mock_push.message = "Alert text"
+        mock_push.items_pushed = []
+
+        result = MonitorCycleResult(findings=[finding], push_result=mock_push)
+        assert len(result.findings) == 1
+        assert result.push_result is mock_push
+        assert result.push_result.chat_id == "12345"
+
+
+# ---------------------------------------------------------------------------
+# evaluate_alert_push tests
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateAlertPush:
+    """Tests for evaluate_alert_push() integration wrapper."""
+
+    def test_returns_cycle_result_with_none_when_disabled(
+        self, tmp_path: Path, monkeypatch: "pytest.MonkeyPatch"
+    ) -> None:
+        """When Telegram is disabled, push_result is None."""
+        monkeypatch.setenv("STEWARD_TELEGRAM_ENABLED", "0")
+        findings = [
+            MonitorFinding(category="lane_health", severity="info", summary="ok")
+        ]
+        result = evaluate_alert_push(findings, runtime_dir=tmp_path)
+        assert isinstance(result, MonitorCycleResult)
+        assert result.findings is findings
+        assert result.push_result is None
+
+    def test_returns_cycle_result_with_none_when_no_chat_id(
+        self, tmp_path: Path, monkeypatch: "pytest.MonkeyPatch"
+    ) -> None:
+        """When Telegram enabled but no chat ID, push_result is None."""
+        monkeypatch.setenv("STEWARD_TELEGRAM_ENABLED", "1")
+        monkeypatch.delenv("STEWARD_ALERT_PUSH_CHAT_ID", raising=False)
+        findings = [
+            MonitorFinding(category="lane_health", severity="info", summary="ok")
+        ]
+        result = evaluate_alert_push(findings, runtime_dir=tmp_path)
+        assert result.push_result is None
+
+    @patch("bid_euchre.ops.telegram_push.run_push_cycle")
+    def test_returns_push_result_when_available(
+        self, mock_push: MagicMock, tmp_path: Path
+    ) -> None:
+        """When run_push_cycle returns a result, it's in push_result."""
+        mock_pr = MagicMock()
+        mock_pr.chat_id = "999"
+        mock_pr.message = "🚨 Alert"
+        mock_pr.items_pushed = [MagicMock()]
+        mock_push.return_value = mock_pr
+
+        findings = [
+            MonitorFinding(category="stale_dispatch", severity="high", summary="stale")
+        ]
+        result = evaluate_alert_push(findings, runtime_dir=tmp_path)
+        assert result.push_result is mock_pr
+        assert result.findings is findings
+        mock_push.assert_called_once()
+
+    @patch("bid_euchre.ops.telegram_push.run_push_cycle")
+    def test_returns_none_push_on_exception(
+        self, mock_push: MagicMock, tmp_path: Path
+    ) -> None:
+        """When run_push_cycle raises, push_result is None (best-effort)."""
+        mock_push.side_effect = RuntimeError("boom")
+
+        findings = [
+            MonitorFinding(category="lane_health", severity="info", summary="ok")
+        ]
+        result = evaluate_alert_push(findings, runtime_dir=tmp_path)
+        assert result.push_result is None
+        assert result.findings is findings
+
+    @patch("bid_euchre.ops.telegram_push.run_push_cycle")
+    def test_passes_audit_dir_from_runtime_dir(
+        self, mock_push: MagicMock, tmp_path: Path
+    ) -> None:
+        """Audit dir defaults to runtime_dir/audit_trail when not explicit."""
+        mock_push.return_value = None
+        evaluate_alert_push([], runtime_dir=tmp_path)
+        call_kwargs = mock_push.call_args.kwargs
+        assert call_kwargs["audit_dir"] == tmp_path / "audit_trail"
+        assert call_kwargs["runtime_dir"] == tmp_path
+
+    @patch("bid_euchre.ops.telegram_push.run_push_cycle")
+    def test_explicit_audit_dir_overrides_default(
+        self, mock_push: MagicMock, tmp_path: Path
+    ) -> None:
+        """Explicit audit_dir takes precedence over runtime_dir-derived."""
+        mock_push.return_value = None
+        custom_audit = tmp_path / "custom_audit"
+        evaluate_alert_push([], runtime_dir=tmp_path, audit_dir=custom_audit)
+        call_kwargs = mock_push.call_args.kwargs
+        assert call_kwargs["audit_dir"] == custom_audit
+
+    @patch("bid_euchre.ops.telegram_push.run_push_cycle")
+    def test_passes_now_to_push_cycle(
+        self, mock_push: MagicMock, tmp_path: Path
+    ) -> None:
+        """The now parameter is forwarded to run_push_cycle."""
+        mock_push.return_value = None
+        from datetime import datetime, timezone
+
+        ts = datetime(2026, 3, 27, 12, 0, 0, tzinfo=timezone.utc)
+        evaluate_alert_push([], runtime_dir=tmp_path, now=ts)
+        call_kwargs = mock_push.call_args.kwargs
+        assert call_kwargs["now"] == ts


### PR DESCRIPTION
## Summary

- Add `MonitorCycleResult` dataclass to `monitor.py` bundling monitoring findings + push payload
- Add `evaluate_alert_push()` function that wraps `run_push_cycle` with error handling, making alert push evaluation a first-class monitor module concept
- Update `cmd_monitor()` in `ops.py` to use the new `evaluate_alert_push()` instead of inline `run_push_cycle` call

## Why

The push evaluator (`run_push_cycle`) existed in `telegram_push.py` but was called ad-hoc from the CLI handler in `ops.py` with inline error handling. This PR promotes push evaluation to a first-class concept in the monitor module so that:

1. The monitor module owns the complete cycle (monitoring + push evaluation)
2. Callers get a structured `MonitorCycleResult` with both findings and push payload
3. Error handling is centralized (best-effort, never blocks monitor cycle)

This is **part 1 of 4** for issue #1826 — subsequent parts will wire the MCP `reply` call for actual Telegram delivery and the inbound ack loop.

Closes part of #1826.

## Repro / Validation

```bash
# Targeted tests (9 new tests):
uv run python -m pytest tests/unit/test_ops_monitor.py -k "TestMonitorCycleResult or TestEvaluateAlertPush" -v

# Full monitor test suite (139 tests):
uv run python -m pytest tests/unit/test_ops_monitor.py -x -q

# Full validation:
make check-quiet
```

## Tests

- `uv run python -m pytest tests/unit/test_ops_monitor.py` — 139 passed ✅
- `make check-quiet` — 7994 passed, 6 pre-existing failures (dashboard watch, token economy, pty runner, timing test — all unrelated)
- Ruff check ✅, Ruff format ✅, Repo linter ✅

### New test cases
- `TestMonitorCycleResult::test_default_push_result_is_none`
- `TestMonitorCycleResult::test_with_findings_and_push`
- `TestEvaluateAlertPush::test_returns_cycle_result_with_none_when_disabled`
- `TestEvaluateAlertPush::test_returns_cycle_result_with_none_when_no_chat_id`
- `TestEvaluateAlertPush::test_returns_push_result_when_available`
- `TestEvaluateAlertPush::test_returns_none_push_on_exception`
- `TestEvaluateAlertPush::test_passes_audit_dir_from_runtime_dir`
- `TestEvaluateAlertPush::test_explicit_audit_dir_overrides_default`
- `TestEvaluateAlertPush::test_passes_now_to_push_cycle`

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
branch: ops/platform9a-wire-push-cycle
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)