### PR TITLE
fix(ops): add Telegram lane routing filter (#1824)

### DIFF
--- a/.claude/hooks/inbound-channel-audit.sh
+++ b/.claude/hooks/inbound-channel-audit.sh
@@ -21,6 +21,20 @@ INPUT=$(cat)
 # This is the common case — most prompts have no Telegram messages.
 echo "$INPUT" | grep -q '<channel' || exit 0
 
+# Lane guard: only the orchestrator should process inbound Telegram messages.
+# Other lanes may receive messages due to competing plugin instances (#1824).
+# Check the explicit env var first (fastest), then fall back to dir detection.
+if [ "${STEWARD_TELEGRAM_RECEIVER:-}" = "0" ]; then
+    exit 0
+fi
+if [ "${STEWARD_TELEGRAM_RECEIVER:-}" != "1" ]; then
+    # No explicit env var — check project dir basename.
+    _BASENAME=$(basename "${CLAUDE_PROJECT_DIR:-}")
+    if [ "$_BASENAME" != "Bid-Euchre" ]; then
+        exit 0
+    fi
+fi
+
 # Audit inbound channel tags.  Best-effort: failures are silently swallowed.
 echo "$INPUT" | uv run python "$CLAUDE_PROJECT_DIR/.claude/hooks/inbound-channel-audit.py" 2>/dev/null || true
 

--- a/.claude/hooks/post-telegram-audit.sh
+++ b/.claude/hooks/post-telegram-audit.sh
@@ -17,6 +17,19 @@ set -euo pipefail
 # Read PostToolUse JSON payload from stdin
 INPUT=$(cat)
 
+# Lane guard: only the orchestrator should audit Telegram tool calls.
+# Other lanes should not call Telegram tools, but if they do (due to
+# competing plugin instances — #1824), skip auditing.
+if [ "${STEWARD_TELEGRAM_RECEIVER:-}" = "0" ]; then
+    exit 0
+fi
+if [ "${STEWARD_TELEGRAM_RECEIVER:-}" != "1" ]; then
+    _BASENAME=$(basename "${CLAUDE_PROJECT_DIR:-}")
+    if [ "$_BASENAME" != "Bid-Euchre" ]; then
+        exit 0
+    fi
+fi
+
 # Extract tool name
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null || echo "")
 

--- a/src/bid_euchre/ops/telegram_filter.py
+++ b/src/bid_euchre/ops/telegram_filter.py
@@ -1,0 +1,149 @@
+"""Telegram lane routing filter (issue #1824, part 2).
+
+When the steward fleet runs, every lane shares the same
+``.claude/settings.json`` which enables the Telegram plugin.  Each lane
+therefore spawns its own ``bun server.ts`` process that polls the same
+Telegram bot.  Only one instance receives each inbound message
+(non-deterministic), so non-orchestrator lanes may consume messages meant
+for the orchestrator.
+
+This module provides a lane-detection guard that hooks and library code
+use to **skip Telegram processing on non-orchestrator lanes**.  It is the
+code-level defence-in-depth complement to the config-level fix (part 1).
+
+Detection strategy (in priority order):
+
+1. **Explicit env var** ``STEWARD_TELEGRAM_RECEIVER=1`` — set by the tmux
+   launcher on the orchestrator pane only.  Fastest check, no path parsing.
+2. **Project directory** ``CLAUDE_PROJECT_DIR`` — falls back to matching the
+   directory basename against known orchestrator worktree names.
+
+Usage::
+
+    from bid_euchre.ops.telegram_filter import is_telegram_receiver
+
+    if not is_telegram_receiver():
+        return  # Skip Telegram processing on non-orchestrator lanes
+
+For shell hooks, use :func:`detect_lane_from_env` directly or check the
+env var in bash before invoking Python.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger("ops.telegram_filter")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Env var that, when ``"1"``, marks this lane as the Telegram receiver.
+#: Set by the tmux launcher on the orchestrator pane.
+TELEGRAM_RECEIVER_ENV = "STEWARD_TELEGRAM_RECEIVER"
+
+#: Worktree directory basenames that correspond to the orchestrator lane.
+#: The orchestrator typically runs from the main ``Bid-Euchre`` checkout
+#: or from ``Bid-Euchre-steward-ops`` when the ops lane owns Telegram.
+ORCHESTRATOR_WORKTREES: frozenset[str] = frozenset(
+    {
+        "Bid-Euchre",  # Main checkout — default orchestrator
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Lane detection
+# ---------------------------------------------------------------------------
+
+
+def detect_lane_from_env() -> str | None:
+    """Infer the current lane identity from environment variables.
+
+    Checks ``CLAUDE_PROJECT_DIR`` and extracts the directory basename.
+    Returns the basename if it looks like a steward worktree, the string
+    ``"main-checkout"`` if it matches the main ``Bid-Euchre`` directory,
+    or ``None`` if detection fails.
+    """
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
+    if not project_dir:
+        return None
+
+    basename = Path(project_dir).name
+
+    if basename == "Bid-Euchre":
+        return "main-checkout"
+
+    if "steward" in basename:
+        return basename
+
+    return None
+
+
+def is_telegram_receiver(
+    *,
+    receiver_env: str | None = None,
+    project_dir: str | None = None,
+) -> bool:
+    """Return ``True`` if the current lane should process Telegram messages.
+
+    This is the primary guard function.  Call it from hooks and library
+    code to skip Telegram processing on non-orchestrator lanes.
+
+    Detection order:
+
+    1. If ``STEWARD_TELEGRAM_RECEIVER`` env var is ``"1"`` → True.
+    2. If ``STEWARD_TELEGRAM_RECEIVER`` env var is ``"0"`` → False
+       (explicit opt-out, e.g. for testing).
+    3. If ``CLAUDE_PROJECT_DIR`` basename is in
+       :data:`ORCHESTRATOR_WORKTREES` → True.
+    4. Otherwise → False.
+
+    Args:
+        receiver_env: Override for the ``STEWARD_TELEGRAM_RECEIVER`` env var
+            value.  When ``None``, reads from the real environment.
+        project_dir: Override for ``CLAUDE_PROJECT_DIR``.  When ``None``,
+            reads from the real environment.
+
+    Returns:
+        ``True`` if this lane is the designated Telegram receiver.
+    """
+    # Check 1 & 2: explicit env var
+    env_val = (
+        receiver_env
+        if receiver_env is not None
+        else os.environ.get(TELEGRAM_RECEIVER_ENV, "")
+    )
+    if env_val == "1":
+        return True
+    if env_val == "0":
+        return False
+
+    # Check 3: project directory
+    dir_val = (
+        project_dir
+        if project_dir is not None
+        else os.environ.get("CLAUDE_PROJECT_DIR", "")
+    )
+    if not dir_val:
+        # No env var, no project dir — conservative: refuse to process.
+        logger.debug(
+            "telegram_filter: no %s or CLAUDE_PROJECT_DIR — defaulting to non-receiver",
+            TELEGRAM_RECEIVER_ENV,
+        )
+        return False
+
+    basename = Path(dir_val).name
+    is_orch = basename in ORCHESTRATOR_WORKTREES
+
+    if not is_orch:
+        logger.debug(
+            "telegram_filter: lane %r is not an orchestrator worktree — "
+            "skipping Telegram processing",
+            basename,
+        )
+
+    return is_orch

--- a/tests/unit/test_telegram_filter.py
+++ b/tests/unit/test_telegram_filter.py
@@ -1,0 +1,214 @@
+"""Unit tests for ops.telegram_filter (issue #1824, part 2).
+
+Tests cover:
+- is_telegram_receiver(): env var priority, project dir detection, edge cases
+- detect_lane_from_env(): lane identity inference from CLAUDE_PROJECT_DIR
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bid_euchre.ops.telegram_filter import (
+    ORCHESTRATOR_WORKTREES,
+    TELEGRAM_RECEIVER_ENV,
+    detect_lane_from_env,
+    is_telegram_receiver,
+)
+
+# ---------------------------------------------------------------------------
+# is_telegram_receiver — env var priority
+# ---------------------------------------------------------------------------
+
+
+class TestIsTelegramReceiverEnvVar:
+    """STEWARD_TELEGRAM_RECEIVER env var takes highest priority."""
+
+    def test_explicit_receiver_1(self) -> None:
+        assert is_telegram_receiver(receiver_env="1") is True
+
+    def test_explicit_receiver_0(self) -> None:
+        assert is_telegram_receiver(receiver_env="0") is False
+
+    def test_explicit_receiver_1_overrides_non_orchestrator_dir(self) -> None:
+        """Even on a non-orchestrator worktree, env=1 wins."""
+        assert (
+            is_telegram_receiver(
+                receiver_env="1",
+                project_dir="/some/path/Bid-Euchre-steward-author",
+            )
+            is True
+        )
+
+    def test_explicit_receiver_0_overrides_orchestrator_dir(self) -> None:
+        """Even on the orchestrator worktree, env=0 wins."""
+        assert (
+            is_telegram_receiver(
+                receiver_env="0",
+                project_dir="/some/path/Bid-Euchre",
+            )
+            is False
+        )
+
+
+# ---------------------------------------------------------------------------
+# is_telegram_receiver — project dir fallback
+# ---------------------------------------------------------------------------
+
+
+class TestIsTelegramReceiverProjectDir:
+    """When no explicit env var, project dir basename determines the answer."""
+
+    def test_main_checkout_is_receiver(self) -> None:
+        assert (
+            is_telegram_receiver(
+                receiver_env="",
+                project_dir="/Users/runner/Projects/Bid-Euchre-meta/Bid-Euchre",
+            )
+            is True
+        )
+
+    def test_author_lane_is_not_receiver(self) -> None:
+        assert (
+            is_telegram_receiver(
+                receiver_env="",
+                project_dir="/Users/runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author",
+            )
+            is False
+        )
+
+    def test_brws_author_lane_is_not_receiver(self) -> None:
+        assert (
+            is_telegram_receiver(
+                receiver_env="",
+                project_dir="/Users/runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d",
+            )
+            is False
+        )
+
+    def test_ops_lane_is_not_receiver(self) -> None:
+        assert (
+            is_telegram_receiver(
+                receiver_env="",
+                project_dir="/Users/runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-ops",
+            )
+            is False
+        )
+
+    def test_review_lane_is_not_receiver(self) -> None:
+        assert (
+            is_telegram_receiver(
+                receiver_env="",
+                project_dir="/Users/runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-review",
+            )
+            is False
+        )
+
+    def test_flex_lane_is_not_receiver(self) -> None:
+        assert (
+            is_telegram_receiver(
+                receiver_env="",
+                project_dir="/Users/runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a",
+            )
+            is False
+        )
+
+    def test_analyst_lane_is_not_receiver(self) -> None:
+        assert (
+            is_telegram_receiver(
+                receiver_env="",
+                project_dir="/Users/runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-analyst",
+            )
+            is False
+        )
+
+
+# ---------------------------------------------------------------------------
+# is_telegram_receiver — edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestIsTelegramReceiverEdgeCases:
+    def test_no_env_no_dir(self) -> None:
+        """No env var and no project dir → conservative: not a receiver."""
+        assert is_telegram_receiver(receiver_env="", project_dir="") is False
+
+    def test_unset_env_empty_dir(self) -> None:
+        assert is_telegram_receiver(receiver_env=None, project_dir="") is False
+
+    def test_trailing_slash_in_project_dir(self) -> None:
+        """Path.name handles trailing slashes correctly."""
+        assert (
+            is_telegram_receiver(
+                receiver_env="",
+                project_dir="/Users/runner/Projects/Bid-Euchre-meta/Bid-Euchre/",
+            )
+            is True
+        )
+
+    def test_unknown_env_value_falls_through(self) -> None:
+        """Env var values other than '0' or '1' fall through to dir check."""
+        assert (
+            is_telegram_receiver(
+                receiver_env="yes",
+                project_dir="/path/Bid-Euchre-steward-author",
+            )
+            is False
+        )
+
+    def test_orchestrator_worktrees_frozenset(self) -> None:
+        """Verify the constant contains the expected entries."""
+        assert "Bid-Euchre" in ORCHESTRATOR_WORKTREES
+
+
+# ---------------------------------------------------------------------------
+# detect_lane_from_env
+# ---------------------------------------------------------------------------
+
+
+class TestDetectLaneFromEnv:
+    def test_main_checkout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(
+            "CLAUDE_PROJECT_DIR",
+            "/Users/runner/Projects/Bid-Euchre-meta/Bid-Euchre",
+        )
+        assert detect_lane_from_env() == "main-checkout"
+
+    def test_steward_worktree(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(
+            "CLAUDE_PROJECT_DIR",
+            "/Users/runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author",
+        )
+        assert detect_lane_from_env() == "Bid-Euchre-steward-author"
+
+    def test_brws_worktree(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(
+            "CLAUDE_PROJECT_DIR",
+            "/path/to/Bid-Euchre-steward-brws-author-d",
+        )
+        assert detect_lane_from_env() == "Bid-Euchre-steward-brws-author-d"
+
+    def test_no_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        assert detect_lane_from_env() is None
+
+    def test_empty_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "")
+        assert detect_lane_from_env() is None
+
+    def test_unrecognised_project_dir(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/someone/SomeProject")
+        assert detect_lane_from_env() is None
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_receiver_env_name(self) -> None:
+        assert TELEGRAM_RECEIVER_ENV == "STEWARD_TELEGRAM_RECEIVER"
+
+    def test_orchestrator_worktrees_type(self) -> None:
+        assert isinstance(ORCHESTRATOR_WORKTREES, frozenset)


### PR DESCRIPTION
## Plan
N/A — bounded fix from issue #1824 (part 2).

## Summary
- Add `telegram_filter.py` module with `is_telegram_receiver()` guard that detects the orchestrator lane via `STEWARD_TELEGRAM_RECEIVER` env var or `CLAUDE_PROJECT_DIR` fallback
- Add lane guard to both Telegram hooks (`inbound-channel-audit.sh`, `post-telegram-audit.sh`) so non-orchestrator lanes skip Telegram processing
- 24 unit tests covering env var priority, directory detection, and edge cases

## Why
When the steward fleet runs, each lane spawns its own Telegram plugin instance that polls the same bot. Only one instance receives each inbound message (non-deterministic), so the orchestrator — the only lane that processes remote ack commands — may never see the message (#1824). This is the code-level defence-in-depth complement to the config-level fix (part 1, author-b).

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_telegram_filter.py tests/unit/test_inbound_channel_audit.py tests/unit/test_audit_trail.py -v
# 130 passed

make repo-lint
# Repo linter passed
```

## Test Criteria
- **Pass condition:** `is_telegram_receiver()` returns True only for the main checkout (orchestrator), False for all other lanes
- **Verification command:** `uv run python -m pytest tests/unit/test_telegram_filter.py -v`
- **Expected result:** 24 tests pass, covering env var override, directory fallback, and edge cases

## Tests
- [x] `uv run python -m pytest tests/unit/test_telegram_filter.py -v` — 24 passed
- [x] `uv run python -m pytest tests/unit/test_inbound_channel_audit.py -v` — 19 passed (existing, no regression)
- [x] `uv run python -m pytest tests/unit/test_audit_trail.py -v` — 87 passed (existing, no regression)
- [x] `make repo-lint` — passed

## Expected impact
- Metrics impact: None
- Runtime impact: Negligible — hooks exit ~0ms faster on non-orchestrator lanes (skip Python invocation entirely)

## Risk level
- [x] Low (hooks + new utility module, no core changes)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git worktree list` (abridged):
```
Bid-Euchre-steward-brws-author-d   3627367d [fix/telegram-lane-filter]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

## Related
- Issue: #1824 (this is part 2 — code-level filter)
- Part 1 (config-level): author-b branch `fix/telegram-single-receiver`