### PR TITLE
feat(web): make moon exchange interactive for human-involved cases (#1893)

### DIFF
--- a/src/bid_euchre/hosted_play/engine.py
+++ b/src/bid_euchre/hosted_play/engine.py
@@ -15,7 +15,11 @@ from bid_euchre.core.cards import Card, effective_suit, is_left_bower, is_right_
 from bid_euchre.core.rules import get_legal_indices, trick_winner
 from bid_euchre.scoring import compute_points
 from bid_euchre.sim.deals import generate_deal
-from bid_euchre.sim.exchange import perform_exchange
+from bid_euchre.sim.exchange import (
+    perform_exchange,
+    select_mooner_discards,
+    select_partner_gifts,
+)
 from bid_euchre.strategy.base import Strategy
 from bid_euchre.strategy.bidding import (
     BidAction,
@@ -237,6 +241,97 @@ class MatchEngine:
         state = self._advance_ai(state)
         return state
 
+    def submit_exchange_selection(
+        self, state: MatchState, card_indices: list[int]
+    ) -> MatchState:
+        """Process the human's moon-exchange card selection.
+
+        The human selects exactly 2 cards from their hand to give.  When the
+        human is the mooner they give their 2 worst cards; when the human is
+        the partner they give their 2 best cards.  The AI counterpart's
+        selection is computed automatically.
+
+        After the exchange the hand transitions through the exchange-reveal
+        interstitial and then into trick play.
+        """
+        self.last_ai_events = []
+        hand = state.current_hand
+        assert hand is not None
+        assert hand.phase == "moon_exchange"
+        assert hand.exchange_phase == "selecting"
+
+        if len(card_indices) != 2:
+            raise ValueError("Must select exactly 2 cards for moon exchange")
+
+        human_hand = hand.hands[HUMAN_SEAT]
+        for idx in card_indices:
+            if idx < 0 or idx >= len(human_hand):
+                raise ValueError(f"Card index {idx} out of range")
+
+        if card_indices[0] == card_indices[1]:
+            raise ValueError("Must select 2 different cards")
+
+        mooner_seat = hand.bidder_seat
+        assert mooner_seat is not None
+        partner_seat = (mooner_seat + 2) % _NUM_PLAYERS
+        contract_type = hand.contract_type or "suit"
+        trump = hand.trump
+
+        # Extract human's chosen cards (pop in descending index order)
+        sorted_indices = sorted(card_indices, reverse=True)
+        human_cards = []
+        for idx in sorted_indices:
+            human_cards.append(human_hand.pop(idx))
+
+        if HUMAN_SEAT == mooner_seat:
+            # Human is mooner — gave 2 cards; AI partner gives 2 best
+            ai_hand = hand.hands[partner_seat]
+            ai_indices = select_partner_gifts(ai_hand, contract_type, trump)
+            ai_cards = []
+            for idx in ai_indices:
+                ai_cards.append(ai_hand.pop(idx))
+
+            # Swap: mooner gets partner's best, partner gets mooner's discards
+            human_hand.extend(ai_cards)
+            ai_hand.extend(human_cards)
+
+            cards_given = human_cards  # mooner gave these
+            cards_received = ai_cards  # mooner received these
+        else:
+            # Human is partner — gave 2 cards; AI mooner gives 2 worst
+            ai_hand = hand.hands[mooner_seat]
+            ai_indices = select_mooner_discards(ai_hand, contract_type, trump)
+            ai_cards = []
+            for idx in ai_indices:
+                ai_cards.append(ai_hand.pop(idx))
+
+            # Swap: mooner gets partner's cards, partner gets mooner's discards
+            ai_hand.extend(human_cards)
+            human_hand.extend(ai_cards)
+
+            cards_given = ai_cards  # mooner gave these (to partner/human)
+            cards_received = human_cards  # mooner received these (from partner/human)
+
+        # Validate post-conditions
+        assert len(hand.hands[mooner_seat]) == 10
+        assert len(hand.hands[partner_seat]) == 10
+
+        # Store exchange results (from mooner's perspective)
+        hand.exchange_given = [[c.suit, c.rank] for c in cards_given]
+        hand.exchange_received = [[c.suit, c.rank] for c in cards_received]
+        hand.exchange_phase = None
+
+        # Transition to trick play with exchange-reveal interstitial
+        hand.phase = "trick_play"
+        leader = hand.bidder_seat
+        hand.current_trick = TrickState(leader=leader)
+        hand.current_seat = leader
+
+        # Re-sort human hand with bower awareness
+        sort_hand_for_display(hand.hands[HUMAN_SEAT], hand.contract_type, hand.trump)
+
+        return state
+
     def get_legal_bids(self, state: MatchState) -> list[BidAction]:
         """Return legal bids for the current bidder.
 
@@ -313,6 +408,7 @@ class MatchEngine:
         result["sitting_out_seat"] = hand.sitting_out_seat
         result["exchange_given"] = hand.exchange_given
         result["exchange_received"] = hand.exchange_received
+        result["exchange_phase"] = hand.exchange_phase
         result["current_trick"] = (
             None
             if hand.current_trick is None
@@ -560,6 +656,19 @@ class MatchEngine:
         if hand.bid_type == "moon":
             mooner_seat = hand.bidder_seat
             partner_seat = (mooner_seat + 2) % _NUM_PLAYERS
+            human_involved = HUMAN_SEAT in (mooner_seat, partner_seat)
+
+            if human_involved:
+                # Interactive exchange: pause for human to select 2 cards
+                hand.phase = "moon_exchange"
+                hand.exchange_phase = "selecting"
+                # Re-sort human hand so they can see proper card values
+                sort_hand_for_display(
+                    hand.hands[HUMAN_SEAT], hand.contract_type, hand.trump
+                )
+                return state
+
+            # AI-only exchange: auto-resolve
             (
                 hand.hands[mooner_seat],
                 hand.hands[partner_seat],

--- a/src/bid_euchre/hosted_play/state.py
+++ b/src/bid_euchre/hosted_play/state.py
@@ -103,6 +103,7 @@ class HandState:
         None  # moon: cards received from partner
     )
     exchange_revealed: bool = False  # moon: True once exchange interstitial shown
+    exchange_phase: str | None = None  # "selecting" when human is choosing cards
     tricks_team0: int = 0
     tricks_team1: int = 0
     points_team0: int = 0
@@ -128,6 +129,7 @@ class HandState:
             "exchange_given": self.exchange_given,
             "exchange_received": self.exchange_received,
             "exchange_revealed": self.exchange_revealed,
+            "exchange_phase": self.exchange_phase,
             "current_trick": (
                 None if self.current_trick is None else self.current_trick.to_dict()
             ),
@@ -171,6 +173,7 @@ class HandState:
             exchange_given=data.get("exchange_given"),
             exchange_received=data.get("exchange_received"),
             exchange_revealed=bool(data.get("exchange_revealed", False)),
+            exchange_phase=data.get("exchange_phase"),
             current_trick=(
                 None
                 if data.get("current_trick") is None

--- a/tests/unit/hosted_play/test_engine.py
+++ b/tests/unit/hosted_play/test_engine.py
@@ -162,6 +162,18 @@ def loner_engine() -> MatchEngine:
     )
 
 
+def _auto_exchange(engine: MatchEngine, state: MatchState) -> MatchState:
+    """If in moon_exchange phase (selecting), auto-pick first 2 cards."""
+    hand = state.current_hand
+    if (
+        hand is not None
+        and hand.phase == "moon_exchange"
+        and hand.exchange_phase == "selecting"
+    ):
+        state = engine.submit_exchange_selection(state, [0, 1])
+    return state
+
+
 def _play_full_hand(
     engine: MatchEngine,
     state: MatchState,
@@ -188,6 +200,9 @@ def _play_full_hand(
         hand = state.current_hand
         if hand is None:
             return state
+
+    # Handle interactive moon exchange
+    state = _auto_exchange(engine, state)
 
     # Handle trick play phase (skip if human is sitting out)
     while (
@@ -226,6 +241,8 @@ def _play_until_match_end(engine: MatchEngine, state: MatchState) -> MatchState:
                 state = engine.submit_human_bid(state, BidAction.bid(5, "S"))
             else:
                 state = engine.submit_human_bid(state, BidAction.pass_bid())
+        elif hand.phase == "moon_exchange":
+            state = _auto_exchange(engine, state)
         elif hand.phase == "trick_play":
             if hand.current_seat == HUMAN_SEAT:
                 legal = engine.get_legal_plays(state)
@@ -1182,6 +1199,13 @@ class TestMoonExchange:
             hand = state.current_hand
             assert hand is not None
 
+            # Human is mooner — should enter interactive exchange phase
+            if hand.phase == "moon_exchange":
+                assert hand.exchange_phase == "selecting"
+                state = engine.submit_exchange_selection(state, [0, 1])
+                hand = state.current_hand
+                assert hand is not None
+
             if hand.phase == "trick_play":
                 # Exchange should have occurred
                 assert hand.exchange_given is not None
@@ -1212,12 +1236,254 @@ class TestMoonExchange:
             hand = state.current_hand
             assert hand is not None
 
+            # Handle interactive exchange
+            if hand.phase == "moon_exchange":
+                state = engine.submit_exchange_selection(state, [0, 1])
+                hand = state.current_hand
+                assert hand is not None
+
             if hand.phase == "trick_play" and hand.exchange_given is not None:
                 data = MatchEngine.serialize(state)
                 restored = MatchEngine.deserialize(data)
                 assert restored.current_hand is not None
                 assert restored.current_hand.exchange_given == hand.exchange_given
                 assert restored.current_hand.exchange_received == hand.exchange_received
+
+
+# ---------------------------------------------------------------------------
+# Test 14b: Interactive moon exchange
+# ---------------------------------------------------------------------------
+
+
+class TestInteractiveMoonExchange:
+    """Moon exchange pauses for human card selection when human is involved."""
+
+    def test_human_mooner_enters_exchange_phase(self) -> None:
+        """When human bids moon, engine enters moon_exchange selecting phase."""
+        engine = MatchEngine(
+            bidding_policy=AlwaysPassBidder(),
+            play_strategy=FirstLegalPlay(),
+        )
+        state = engine.start_match(SEED, "heuristic")
+        hand = state.current_hand
+        assert hand is not None
+
+        if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+            state = engine.submit_human_bid(state, BidAction.moon("S"))
+            hand = state.current_hand
+            assert hand is not None
+            assert hand.phase == "moon_exchange"
+            assert hand.exchange_phase == "selecting"
+            # Exchange not yet done
+            assert hand.exchange_given is None
+            assert hand.exchange_received is None
+            # Hand still has 10 cards
+            assert len(hand.hands[HUMAN_SEAT]) == 10
+
+    def test_human_mooner_exchange_selection(self) -> None:
+        """Human mooner selects 2 cards, exchange completes properly."""
+        engine = MatchEngine(
+            bidding_policy=AlwaysPassBidder(),
+            play_strategy=FirstLegalPlay(),
+        )
+        state = engine.start_match(SEED, "heuristic")
+        hand = state.current_hand
+        assert hand is not None
+
+        if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+            state = engine.submit_human_bid(state, BidAction.moon("S"))
+            hand = state.current_hand
+            assert hand is not None
+            assert hand.phase == "moon_exchange"
+
+            # Choose first two cards
+            chosen_0 = hand.hands[HUMAN_SEAT][0]
+            chosen_1 = hand.hands[HUMAN_SEAT][1]
+            state = engine.submit_exchange_selection(state, [0, 1])
+            hand = state.current_hand
+            assert hand is not None
+
+            # Should be in trick_play now
+            assert hand.phase == "trick_play"
+            assert hand.exchange_phase is None
+            assert hand.exchange_given is not None
+            assert hand.exchange_received is not None
+            assert len(hand.exchange_given) == 2
+            assert len(hand.exchange_received) == 2
+
+            # The cards human gave should be the ones at indices 0 and 1
+            given_cards = {tuple(c) for c in hand.exchange_given}
+            assert (chosen_0.suit, chosen_0.rank) in given_cards
+            assert (chosen_1.suit, chosen_1.rank) in given_cards
+
+            # Both hands still 10 cards
+            assert len(hand.hands[HUMAN_SEAT]) == 10
+            assert len(hand.hands[2]) == 10
+
+    def test_human_partner_exchange_phase(self) -> None:
+        """When AI partner bids moon, human (as partner) enters exchange."""
+        # MoonBidder bids moon if current_high_bid == 0.  Find a seed where
+        # AI Partner (seat 2) bids before the human and wins the auction.
+        engine = MatchEngine(
+            bidding_policy=MoonBidder(contract="S"),
+            play_strategy=FirstLegalPlay(),
+        )
+        for seed in range(500):
+            state = engine.start_match(seed, "heuristic")
+            hand = state.current_hand
+            if hand is None:
+                continue
+
+            # start_match already auto-advanced AI; if human turn, pass
+            if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+                # Check if there's already a moon bid from seat 2
+                has_moon_from_2 = any(
+                    e.get("action") == "bid"
+                    and e.get("bid_type") == "moon"
+                    and e.get("seat") == 2
+                    for e in hand.auction
+                )
+                if not has_moon_from_2:
+                    continue
+                # Human passes to let the auction finish
+                state = engine.submit_human_bid(state, BidAction.pass_bid())
+                hand = state.current_hand
+                if hand is None:
+                    continue
+
+            if hand.phase == "moon_exchange" and hand.bidder_seat == 2:
+                # Human is partner — should be in selecting phase
+                assert hand.exchange_phase == "selecting"
+                assert len(hand.hands[HUMAN_SEAT]) == 10
+
+                # Complete the exchange
+                state = engine.submit_exchange_selection(state, [0, 1])
+                hand = state.current_hand
+                assert hand is not None
+                assert hand.phase == "trick_play"
+                assert hand.exchange_given is not None
+                assert hand.exchange_received is not None
+                return  # Test passed
+
+        pytest.skip("No seed found where AI Partner bids moon first")
+
+    def test_ai_only_exchange_auto_resolves(self) -> None:
+        """When neither human is mooner nor partner, exchange is automatic."""
+        # Find a seed where AI Left (seat 1) or AI Right (seat 3) bids moon.
+        # Their partner is seat 3 or 1 respectively — human not involved.
+        engine = MatchEngine(
+            bidding_policy=MoonBidder(contract="S"),
+            play_strategy=FirstLegalPlay(),
+        )
+        for seed in range(500):
+            state = engine.start_match(seed, "heuristic")
+            hand = state.current_hand
+            if hand is None:
+                continue
+
+            # If it's human's turn during auction, pass
+            if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+                state = engine.submit_human_bid(state, BidAction.pass_bid())
+                hand = state.current_hand
+                if hand is None:
+                    continue
+
+            # Check if an AI from the opposing team (seat 1 or 3) won
+            if (
+                hand.phase == "trick_play"
+                and hand.bid_type == "moon"
+                and hand.bidder_seat in (1, 3)
+            ):
+                # Should have auto-resolved — no moon_exchange phase
+                assert hand.exchange_given is not None
+                assert hand.exchange_received is not None
+                assert hand.exchange_phase is None
+                return
+
+        pytest.skip("No seed found where opposing AI bids moon")
+
+    def test_exchange_selection_validates_card_count(self) -> None:
+        """Must select exactly 2 cards."""
+        engine = MatchEngine(
+            bidding_policy=AlwaysPassBidder(),
+            play_strategy=FirstLegalPlay(),
+        )
+        state = engine.start_match(SEED, "heuristic")
+        hand = state.current_hand
+        assert hand is not None
+
+        if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+            state = engine.submit_human_bid(state, BidAction.moon("S"))
+            hand = state.current_hand
+            assert hand is not None
+
+            if hand.phase == "moon_exchange":
+                with pytest.raises(ValueError, match="exactly 2"):
+                    engine.submit_exchange_selection(state, [0])
+                with pytest.raises(ValueError, match="exactly 2"):
+                    engine.submit_exchange_selection(state, [0, 1, 2])
+
+    def test_exchange_selection_validates_same_card(self) -> None:
+        """Cannot select the same card twice."""
+        engine = MatchEngine(
+            bidding_policy=AlwaysPassBidder(),
+            play_strategy=FirstLegalPlay(),
+        )
+        state = engine.start_match(SEED, "heuristic")
+        hand = state.current_hand
+        assert hand is not None
+
+        if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+            state = engine.submit_human_bid(state, BidAction.moon("S"))
+            hand = state.current_hand
+            assert hand is not None
+
+            if hand.phase == "moon_exchange":
+                with pytest.raises(ValueError, match="2 different"):
+                    engine.submit_exchange_selection(state, [3, 3])
+
+    def test_exchange_selection_validates_index_range(self) -> None:
+        """Card indices must be in range."""
+        engine = MatchEngine(
+            bidding_policy=AlwaysPassBidder(),
+            play_strategy=FirstLegalPlay(),
+        )
+        state = engine.start_match(SEED, "heuristic")
+        hand = state.current_hand
+        assert hand is not None
+
+        if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+            state = engine.submit_human_bid(state, BidAction.moon("S"))
+            hand = state.current_hand
+            assert hand is not None
+
+            if hand.phase == "moon_exchange":
+                with pytest.raises(ValueError, match="out of range"):
+                    engine.submit_exchange_selection(state, [0, 99])
+
+    def test_exchange_phase_serialization(self) -> None:
+        """Exchange selecting phase round-trips through serialization."""
+        engine = MatchEngine(
+            bidding_policy=AlwaysPassBidder(),
+            play_strategy=FirstLegalPlay(),
+        )
+        state = engine.start_match(SEED, "heuristic")
+        hand = state.current_hand
+        assert hand is not None
+
+        if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+            state = engine.submit_human_bid(state, BidAction.moon("S"))
+            hand = state.current_hand
+            assert hand is not None
+
+            if hand.phase == "moon_exchange":
+                data = MatchEngine.serialize(state)
+                restored = MatchEngine.deserialize(data)
+                r_hand = restored.current_hand
+                assert r_hand is not None
+                assert r_hand.phase == "moon_exchange"
+                assert r_hand.exchange_phase == "selecting"
+                assert r_hand.exchange_given is None  # Not yet exchanged
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -1213,6 +1213,80 @@ class TestMoonExchange:
 
 
 # ---------------------------------------------------------------------------
+# moon_exchange_select.html — interactive card selection
+# ---------------------------------------------------------------------------
+
+
+class TestMoonExchangeSelect:
+    """Tests for the interactive moon exchange card selection template."""
+
+    def test_renders_selectable_cards(self, env):
+        """Human hand rendered as selectable buttons."""
+        tmpl = env.get_template("partials/moon_exchange_select.html")
+        html = tmpl.render(
+            link_uuid="abc-123",
+            bidder_seat=0,
+            contract_type="suit",
+            trump="S",
+            human_hand=[["S", "A"], ["H", "K"], ["D", "Q"]],
+            exchange_prompt="Choose 2 cards to give to your partner",
+            is_mooner=True,
+        )
+        assert "Moon Exchange" in html
+        assert "Choose 2 cards" in html
+        assert 'data-exchange-index="0"' in html
+        assert 'data-exchange-index="1"' in html
+        assert 'data-exchange-index="2"' in html
+        assert "Confirm Exchange" in html
+        assert 'action="/play/abc-123/exchange"' in html
+
+    def test_partner_prompt(self, env):
+        """Partner sees correct prompt text."""
+        tmpl = env.get_template("partials/moon_exchange_select.html")
+        html = tmpl.render(
+            link_uuid="abc-123",
+            bidder_seat=2,
+            contract_type="suit",
+            trump="H",
+            human_hand=[["H", "J"]],
+            exchange_prompt="Choose 2 cards to give to the mooner",
+            is_mooner=False,
+        )
+        assert "Choose 2 cards to give to the mooner" in html
+        assert "AI Partner" in html  # mooner label for seat 2
+
+    def test_submit_button_disabled_by_default(self, env):
+        """Submit button starts disabled."""
+        tmpl = env.get_template("partials/moon_exchange_select.html")
+        html = tmpl.render(
+            link_uuid="abc-123",
+            bidder_seat=0,
+            contract_type="suit",
+            trump="S",
+            human_hand=[["S", "A"]],
+            exchange_prompt="Choose 2 cards",
+            is_mooner=True,
+        )
+        assert "disabled" in html
+
+    def test_form_targets_exchange_endpoint(self, env):
+        """Form submits to /play/<uuid>/exchange."""
+        tmpl = env.get_template("partials/moon_exchange_select.html")
+        html = tmpl.render(
+            link_uuid="test-uuid",
+            bidder_seat=0,
+            contract_type="high",
+            trump=None,
+            human_hand=[["S", "A"], ["H", "K"]],
+            exchange_prompt="Choose 2 cards",
+            is_mooner=True,
+        )
+        assert 'hx-post="/play/test-uuid/exchange"' in html
+        assert 'name="card_index_0"' in html
+        assert 'name="card_index_1"' in html
+
+
+# ---------------------------------------------------------------------------
 # trick.html — winning card display
 # ---------------------------------------------------------------------------
 

--- a/web/routes.py
+++ b/web/routes.py
@@ -233,9 +233,11 @@ def _game_phase(state) -> str:
         return "hand_result"
     if _has_hidden_auction(hand):
         return "auction"
+    if hand.phase == "moon_exchange" and hand.exchange_phase == "selecting":
+        return "moon_exchange_select"
     if _has_pending_exchange(hand):
         return "moon_exchange"
-    # "auction", "trick_play", or "redeal" pass through directly
+    # "auction", "trick_play", "moon_exchange", or "redeal" pass through
     return hand.phase
 
 
@@ -401,6 +403,16 @@ def _build_game_context(
             ctx["legal_plays"] = engine.get_legal_plays(state)
         else:
             ctx["legal_plays"] = None
+
+        # Moon exchange selection context
+        if phase == "moon_exchange_select":
+            mooner_seat = hand.bidder_seat
+            ctx["is_mooner"] = HUMAN_SEAT == mooner_seat
+            ctx["exchange_prompt"] = (
+                "Choose 2 cards to give to your partner"
+                if HUMAN_SEAT == mooner_seat
+                else "Choose 2 cards to give to the mooner"
+            )
 
         # AI hand card counts (face-down display)
         ctx["opp_left_count"] = len(hand.hands[1]) if len(hand.hands) > 1 else 0
@@ -1055,6 +1067,52 @@ async def next_step(
             hand.paused_after_trick = False
         else:
             return HTMLResponse(_render_game_board(request, engine, state, link_uuid))
+
+        hand_row = _ensure_hand_row(session, match_row, hand, hand.deal_id)
+        hand_row.hand_state_json = json.dumps(hand.to_dict())
+        _update_match_row(match_row, state)
+        session.commit()
+
+        return HTMLResponse(_render_game_board(request, engine, state, link_uuid))
+    finally:
+        session.close()
+
+
+@router.post("/play/{link_uuid}/exchange", response_class=HTMLResponse)
+async def submit_exchange(
+    request: Request,
+    link_uuid: str,
+    card_index_0: int = Form(...),
+    card_index_1: int = Form(...),
+):
+    """Submit the human's 2-card selection for moon exchange."""
+    session = _get_session(request)
+    try:
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+        if player is None:
+            raise HTTPException(status_code=404, detail="Game not found")
+
+        match_row = (
+            session.query(Match)
+            .filter_by(player_id=player.id, status="active")
+            .order_by(Match.created_at.desc())
+            .first()
+        )
+        if match_row is None:
+            raise HTTPException(status_code=404, detail="No active match")
+
+        ai_manager = _get_ai_manager(request)
+        engine = _build_engine(ai_manager, match_row.ai_model)
+        state = _deserialize_state(engine, match_row.match_state_json)
+
+        hand = state.current_hand
+        if hand is None or hand.phase != "moon_exchange":
+            return HTMLResponse(_render_game_board(request, engine, state, link_uuid))
+
+        if hand.exchange_phase != "selecting":
+            return HTMLResponse(_render_game_board(request, engine, state, link_uuid))
+
+        state = engine.submit_exchange_selection(state, [card_index_0, card_index_1])
 
         hand_row = _ensure_hand_row(session, match_row, hand, hand.deal_id)
         hand_row.hand_state_json = json.dumps(hand.to_dict())

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1826,7 +1826,113 @@ main {
 }
 
 /* --------------------------------------------------------------------------
-   19. Utilities
+   19. Moon Exchange
+   -------------------------------------------------------------------------- */
+
+.moon-exchange {
+    text-align: center;
+    padding: 1.5rem 1rem;
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+.moon-exchange__header {
+    margin-bottom: 1rem;
+}
+
+.moon-exchange__title {
+    font-size: 1.5rem;
+    color: var(--color-moon);
+    margin: 0 0 0.25rem;
+}
+
+.moon-exchange__subtitle {
+    font-size: 1rem;
+    color: var(--color-text-muted);
+    margin: 0;
+}
+
+.moon-exchange__prompt {
+    font-size: 1.1rem;
+    color: var(--color-text);
+    margin: 0.5rem 0 1rem;
+    font-weight: 600;
+}
+
+.moon-exchange__cards {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.moon-exchange__group {
+    min-width: 120px;
+}
+
+.moon-exchange__group-title {
+    font-size: 0.9rem;
+    color: var(--color-text-muted);
+    margin: 0 0 0.5rem;
+    font-weight: 600;
+}
+
+.moon-exchange__card-list {
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.moon-exchange__hand {
+    margin: 1.5rem 0;
+}
+
+.moon-exchange__controls {
+    margin-top: 1.5rem;
+}
+
+/* Exchange card selection — selectable cards glow on hover */
+.card--exchange-selectable {
+    cursor: pointer;
+    transition: transform 0.15s, box-shadow 0.15s;
+    background: none;
+    font-family: inherit;
+    font-weight: 700;
+    border: 2px solid var(--color-felt);
+}
+
+.card--exchange-selectable:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 0 6px rgba(255, 160, 0, 0.3);
+}
+
+/* Selected state for exchange cards */
+.card--exchange-selectable.card--selected {
+    box-shadow: 0 0 0 3px var(--color-moon-glow), 0 0 14px rgba(255, 160, 0, 0.55);
+    transform: translateY(-6px);
+    z-index: 20;
+    border-color: var(--color-moon);
+}
+
+.card-fan--exchange {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.35rem;
+}
+
+/* Exchange summary cards */
+.card--exchange {
+    border: 2px solid var(--color-moon);
+}
+
+.card--exchange-received {
+    border-color: var(--color-legal-border, #4caf50);
+}
+
+/* --------------------------------------------------------------------------
+   20. Utilities
    -------------------------------------------------------------------------- */
 
 .sr-only {

--- a/web/templates/game.html
+++ b/web/templates/game.html
@@ -45,7 +45,11 @@
     {% elif phase == "hand_result" %}
         {% include "partials/hand_result.html" %}
 
-    {# ---- Moon exchange interstitial ---- #}
+    {# ---- Moon exchange card selection (interactive) ---- #}
+    {% elif phase == "moon_exchange_select" %}
+        {% include "partials/game_board.html" %}
+
+    {# ---- Moon exchange interstitial (summary) ---- #}
     {% elif phase == "moon_exchange" %}
         {% include "partials/game_board.html" %}
 

--- a/web/templates/partials/game_board.html
+++ b/web/templates/partials/game_board.html
@@ -22,7 +22,11 @@
 {% elif phase == "hand_result" %}
     {% include "partials/hand_result.html" %}
 
-{# ---- Moon exchange interstitial ---- #}
+{# ---- Moon exchange card selection (interactive) ---- #}
+{% elif phase == "moon_exchange_select" %}
+    {% include "partials/moon_exchange_select.html" %}
+
+{# ---- Moon exchange interstitial (summary) ---- #}
 {% elif phase == "moon_exchange" %}
     {% include "partials/moon_exchange.html" %}
 

--- a/web/templates/partials/moon_exchange_select.html
+++ b/web/templates/partials/moon_exchange_select.html
@@ -1,0 +1,140 @@
+{# Moon exchange card selection — interactive phase where the human
+   chooses 2 cards to give during a moon exchange.
+
+   Context variables:
+     - bidder_seat: int — seat of the moon bidder
+     - contract_type: str — "suit", "high", or "low"
+     - trump: str | None — trump suit letter
+     - link_uuid: str — player game link UUID
+     - human_hand: list[[suit, rank]] — human's current hand
+     - exchange_prompt: str — instruction text for the selection
+     - is_mooner: bool — True if human is the moon bidder
+#}
+{% set suit_symbols = {"S": "\u2660", "H": "\u2665", "D": "\u2666", "C": "\u2663"} %}
+{% set suit_names = {"S": "Spades", "H": "Hearts", "D": "Diamonds", "C": "Clubs"} %}
+{% set suit_classes = {"S": "spades", "H": "hearts", "D": "diamonds", "C": "clubs"} %}
+{% set seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"} %}
+{% set mooner_label = seat_labels.get(bidder_seat | default(0), "Seat " ~ bidder_seat) %}
+
+<div id="moon-exchange-select" class="moon-exchange" role="region" aria-live="polite">
+    <div class="moon-exchange__header">
+        <h2 class="moon-exchange__title">
+            <span aria-hidden="true">&#x1F319;</span> Moon Exchange
+        </h2>
+        <p class="moon-exchange__subtitle">
+            {{ mooner_label }} bid Moon
+            {% if contract_type == "suit" and trump %}
+                in {{ suit_symbols.get(trump, trump) }}
+            {% elif contract_type == "high" %}
+                High
+            {% elif contract_type == "low" %}
+                Low
+            {% endif %}
+        </p>
+    </div>
+
+    <p class="moon-exchange__prompt" aria-live="polite">
+        {{ exchange_prompt | default("Choose 2 cards to exchange") }}
+    </p>
+
+    <div class="moon-exchange__hand" role="region" aria-label="Your hand - select 2 cards">
+        <h3 class="moon-exchange__group-title">Your Hand</h3>
+        <div class="card-fan card-fan--exchange" role="group"
+             aria-label="Cards in your hand ({{ human_hand | length }}) - select 2 to give">
+            {% for card in human_hand %}
+                {% set suit = card[0] %}
+                {% set rank = card[1] %}
+                {% set idx = loop.index0 %}
+                {% set suit_class = suit_classes.get(suit, "spades") %}
+                {% set suit_sym = suit_symbols.get(suit, suit) %}
+                {% set suit_name = suit_names.get(suit, suit) %}
+                <button type="button"
+                        class="card card--{{ suit_class }} card--exchange-selectable"
+                        title="{{ rank }}{{ suit_sym }} (tap to select)"
+                        aria-label="Select {{ rank }} of {{ suit_name }}"
+                        data-exchange-index="{{ idx }}">
+                    <span class="card__rank" aria-hidden="true">{{ rank }}</span>
+                    <span class="card__suit" aria-hidden="true">{{ suit_sym }}</span>
+                </button>
+            {% endfor %}
+        </div>
+    </div>
+
+    <form id="exchange-form"
+          class="moon-exchange__controls"
+          method="post"
+          action="/play/{{ link_uuid | default('') }}/exchange"
+          hx-post="/play/{{ link_uuid | default('') }}/exchange"
+          hx-target="#game-board"
+          hx-swap="innerHTML">
+        <input type="hidden" id="exchange-card-0" name="card_index_0" value="">
+        <input type="hidden" id="exchange-card-1" name="card_index_1" value="">
+        <p id="exchange-help" class="card-play-help" aria-live="polite">
+            Tap 2 cards to select them, then confirm.
+        </p>
+        <button id="exchange-submit"
+                type="submit"
+                class="btn btn--next-step"
+                disabled
+                aria-label="Confirm exchange">
+            Confirm Exchange
+        </button>
+    </form>
+</div>
+
+<script>
+(function() {
+    // Exchange card selection logic
+    var selected = [];
+    var cards = document.querySelectorAll('[data-exchange-index]');
+    var submitBtn = document.getElementById('exchange-submit');
+    var input0 = document.getElementById('exchange-card-0');
+    var input1 = document.getElementById('exchange-card-1');
+    var helpText = document.getElementById('exchange-help');
+
+    function updateUI() {
+        // Update selected visual state
+        cards.forEach(function(card) {
+            var idx = parseInt(card.getAttribute('data-exchange-index'), 10);
+            if (selected.indexOf(idx) !== -1) {
+                card.classList.add('card--selected');
+                card.setAttribute('aria-pressed', 'true');
+            } else {
+                card.classList.remove('card--selected');
+                card.setAttribute('aria-pressed', 'false');
+            }
+        });
+
+        // Update form state
+        if (selected.length === 2) {
+            input0.value = selected[0];
+            input1.value = selected[1];
+            submitBtn.disabled = false;
+            helpText.textContent = 'Cards selected. Tap Confirm Exchange to proceed.';
+        } else {
+            input0.value = '';
+            input1.value = '';
+            submitBtn.disabled = true;
+            helpText.textContent = 'Select ' + (2 - selected.length) + ' more card' +
+                (2 - selected.length !== 1 ? 's' : '') + '.';
+        }
+    }
+
+    cards.forEach(function(card) {
+        card.addEventListener('click', function() {
+            var idx = parseInt(this.getAttribute('data-exchange-index'), 10);
+            var pos = selected.indexOf(idx);
+            if (pos !== -1) {
+                // Deselect
+                selected.splice(pos, 1);
+            } else if (selected.length < 2) {
+                // Select
+                selected.push(idx);
+            }
+            updateUI();
+        });
+    });
+
+    updateUI();
+})();
+</script>


### PR DESCRIPTION
## Plan
- Issue #1893 — Make moon exchange interactive for all human-involved cases
- Browser Game Expansion governing plan, Phase 1 follow-up

## Summary
- When the human is the mooner or their partner, the engine now pauses in a `moon_exchange` phase with `exchange_phase="selecting"` so the player can choose which 2 cards to give
- Added interactive card selection UI template with tap-to-select JS and a confirm button
- AI-only moon exchanges (opposing team) still auto-resolve immediately with no UX change
- Added `/play/{link_uuid}/exchange` POST endpoint for the card selection submission

## Why
PR #1923 restored the moon exchange interstitial, but it only showed a read-only summary of an automatically resolved exchange. Issue #1893 requires the human to actually choose the 2 cards — whether they're the mooner (giving their worst) or the partner (giving their best).

## Repro / Validation
**Command(s) run:**
```
uv run python -m pytest tests/unit/hosted_play/test_engine.py -k moon -v
uv run python -m pytest tests/unit/hosted_play/test_partials.py -k "MoonExchange" -v
make repo-lint && make lint && make docs-check && make notebook-check
```

## Test Criteria
- **Pass condition:** All 26 moon-related engine tests pass (8 new interactive exchange tests), all 19 moon-related partials tests pass (4 new selection template tests)
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_engine.py -k moon -v && uv run python -m pytest tests/unit/hosted_play/test_partials.py -k MoonExchange -v`
- **Expected result:** 26 passed, 19 passed (0 failures)

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/ -x -q` — 717 passed, 6 skipped
- [x] `uv run python -m pytest tests/unit/hosted_play/test_engine.py -k moon -v` — 26 passed
- [x] `make repo-lint && make lint && make docs-check && make notebook-check` — all passed
- [x] Pre-existing ops test failure (`test_ops_token_economy.py::TestAutoImport`) confirmed unrelated

## Expected impact
- Metrics impact: None
- Runtime impact: None (one additional engine phase for human moon exchanges)

## Risk level
- [x] Medium (browser game engine + templates + routes)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
```

`git worktree list` (excerpt):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b  e1527090 [fix/moon-exchange-interactive]
```

## Checklist
- [x] No generated artifacts committed
- [x] Behavior changed, tests updated/added to lock it (12 new tests)
- [x] PR is focused (one concept: interactive moon exchange)