### PR TITLE
test(ops): add core adapter contract and integration tests (Platform-10 PR4)

### DIFF
--- a/tests/unit/test_ops_core_adapters.py
+++ b/tests/unit/test_ops_core_adapters.py
@@ -1,0 +1,389 @@
+"""Tests for core ops adapter contract conformance and cross-adapter integration.
+
+Platform-10 PR4: verifies that all four concrete adapters correctly satisfy
+their ABC contracts from the *core* perspective — polymorphism, method
+signature conformance, and integration between adapters (controller consuming
+monitor output).
+
+This complements the per-class tests in ``test_ops_core_controller.py``,
+``test_ops_core_monitor.py``, and ``test_ops_adapter_migration.py`` by
+focusing on cross-cutting properties that hold across the full adapter set.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bid_euchre.ops.core.interfaces import (
+    AbstractController,
+    AbstractMonitor,
+    AbstractTaskQueue,
+    AbstractWorkerPool,
+)
+
+# ---------------------------------------------------------------------------
+# ABC ↔ adapter pairings for parametric tests
+# ---------------------------------------------------------------------------
+
+_ADAPTER_PAIRS: list[tuple[type, str, str]] = [
+    (
+        AbstractController,
+        "bid_euchre.ops.core.controller",
+        "ControlPlaneController",
+    ),
+    (
+        AbstractMonitor,
+        "bid_euchre.ops.core.monitor",
+        "MonitorService",
+    ),
+    (
+        AbstractTaskQueue,
+        "bid_euchre.ops.adapters.bid_euchre",
+        "TaskQueueService",
+    ),
+    (
+        AbstractWorkerPool,
+        "bid_euchre.ops.adapters.bid_euchre",
+        "WorkerPoolService",
+    ),
+]
+
+
+def _import_adapter(module_path: str, class_name: str) -> type:
+    """Import an adapter class by module path and class name."""
+    import importlib
+
+    mod = importlib.import_module(module_path)
+    return getattr(mod, class_name)
+
+
+# ---------------------------------------------------------------------------
+# Test: Method signature conformance — adapter signatures match ABCs
+# ---------------------------------------------------------------------------
+
+
+class TestMethodSignatureConformance:
+    """Every adapter's public methods match the ABC method signatures.
+
+    This catches signature drift: if an adapter renames a parameter, drops
+    a keyword argument, or changes a default value, the test fails.
+    """
+
+    @pytest.mark.parametrize(
+        "abc_cls,module_path,class_name",
+        _ADAPTER_PAIRS,
+        ids=["Controller", "Monitor", "TaskQueue", "WorkerPool"],
+    )
+    def test_all_abstract_methods_present(
+        self,
+        abc_cls: type,
+        module_path: str,
+        class_name: str,
+    ) -> None:
+        """Adapter implements every abstract method declared by the ABC."""
+        adapter_cls = _import_adapter(module_path, class_name)
+
+        abstract_methods = {
+            name
+            for name, _ in inspect.getmembers(abc_cls, predicate=inspect.isfunction)
+            if getattr(getattr(abc_cls, name, None), "__isabstractmethod__", False)
+        }
+
+        for method_name in abstract_methods:
+            assert hasattr(
+                adapter_cls, method_name
+            ), f"{class_name} missing abstract method {method_name!r}"
+
+    @pytest.mark.parametrize(
+        "abc_cls,module_path,class_name",
+        _ADAPTER_PAIRS,
+        ids=["Controller", "Monitor", "TaskQueue", "WorkerPool"],
+    )
+    def test_parameter_names_match(
+        self,
+        abc_cls: type,
+        module_path: str,
+        class_name: str,
+    ) -> None:
+        """Adapter method parameter names match the ABC's parameter names."""
+        adapter_cls = _import_adapter(module_path, class_name)
+
+        abstract_methods = {
+            name
+            for name, _ in inspect.getmembers(abc_cls, predicate=inspect.isfunction)
+            if getattr(getattr(abc_cls, name, None), "__isabstractmethod__", False)
+        }
+
+        for method_name in abstract_methods:
+            abc_sig = inspect.signature(getattr(abc_cls, method_name))
+            adapter_sig = inspect.signature(getattr(adapter_cls, method_name))
+
+            abc_params = list(abc_sig.parameters.keys())
+            adapter_params = list(adapter_sig.parameters.keys())
+
+            assert abc_params == adapter_params, (
+                f"{class_name}.{method_name}: parameter names differ — "
+                f"ABC has {abc_params}, adapter has {adapter_params}"
+            )
+
+    @pytest.mark.parametrize(
+        "abc_cls,module_path,class_name",
+        _ADAPTER_PAIRS,
+        ids=["Controller", "Monitor", "TaskQueue", "WorkerPool"],
+    )
+    def test_parameter_kinds_match(
+        self,
+        abc_cls: type,
+        module_path: str,
+        class_name: str,
+    ) -> None:
+        """Adapter parameter kinds (POSITIONAL, KEYWORD_ONLY, etc.) match ABC."""
+        adapter_cls = _import_adapter(module_path, class_name)
+
+        abstract_methods = {
+            name
+            for name, _ in inspect.getmembers(abc_cls, predicate=inspect.isfunction)
+            if getattr(getattr(abc_cls, name, None), "__isabstractmethod__", False)
+        }
+
+        for method_name in abstract_methods:
+            abc_sig = inspect.signature(getattr(abc_cls, method_name))
+            adapter_sig = inspect.signature(getattr(adapter_cls, method_name))
+
+            for param_name in abc_sig.parameters:
+                abc_kind = abc_sig.parameters[param_name].kind
+                adapter_kind = adapter_sig.parameters[param_name].kind
+                assert abc_kind == adapter_kind, (
+                    f"{class_name}.{method_name}({param_name}): "
+                    f"kind differs — ABC={abc_kind.name}, adapter={adapter_kind.name}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Test: Polymorphism — adapters work through ABC references
+# ---------------------------------------------------------------------------
+
+
+def _accept_controller(ctrl: AbstractController) -> Any:
+    """Helper: call controller methods through the ABC type."""
+    return ctrl.load_status()
+
+
+def _accept_monitor(mon: AbstractMonitor) -> list[dict[str, Any]]:
+    """Helper: call monitor methods through the ABC type."""
+    return mon.check_lane_health()
+
+
+class TestPolymorphism:
+    """Concrete adapters can be used polymorphically through ABC references."""
+
+    def test_controller_through_abc_ref(self, tmp_path: Path) -> None:
+        from bid_euchre.ops.core.controller import ControlPlaneController
+
+        ctrl: AbstractController = ControlPlaneController(runtime_dir=tmp_path)
+        result = _accept_controller(ctrl)
+        assert result is None  # no file yet
+
+    def test_monitor_through_abc_ref(self) -> None:
+        from bid_euchre.ops.core.monitor import MonitorService
+
+        mon: AbstractMonitor = MonitorService()
+        with patch("bid_euchre.ops.monitor.check_lane_health") as mock_check:
+            mock_check.return_value = []
+            result = _accept_monitor(mon)
+        assert result == []
+
+    def test_task_queue_through_abc_ref(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import TaskQueueService
+
+        tq: AbstractTaskQueue = TaskQueueService()
+        pkt = tq.create_packet("Poly test", "Testing polymorphism")
+        assert hasattr(pkt, "packet_id")
+        assert pkt.title == "Poly test"
+
+    def test_worker_pool_through_abc_ref(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import WorkerPoolService
+
+        wp: AbstractWorkerPool = WorkerPoolService()
+        with patch("bid_euchre.ops.worker_pool.take_pool_snapshot") as mock_snap:
+            mock_snap.return_value = MagicMock(workers=[], active_count=0)
+            snap = wp.take_snapshot()
+        assert snap is not None
+
+
+# ---------------------------------------------------------------------------
+# Test: Controller ↔ Monitor integration
+# ---------------------------------------------------------------------------
+
+
+class TestControllerMonitorIntegration:
+    """Controller consumes monitor output — the core adapter contract."""
+
+    def test_monitor_findings_feed_controller_reconcile(self, tmp_path: Path) -> None:
+        """MonitorService output (list[dict]) is valid input to reconcile()."""
+        from bid_euchre.ops.core.controller import ControlPlaneController
+        from bid_euchre.ops.core.monitor import MonitorService
+        from bid_euchre.ops.monitor import MonitorFinding
+
+        # Monitor produces findings
+        mon = MonitorService()
+        with patch("bid_euchre.ops.monitor.check_lane_health") as mock_check:
+            mock_check.return_value = [
+                MonitorFinding(
+                    category="lane_health",
+                    severity="high",
+                    summary="Lane degraded",
+                    details={"lane_id": "author-a"},
+                ),
+                MonitorFinding(
+                    category="lane_health",
+                    severity="warn",
+                    summary="Lane idle 30m",
+                    details={"lane_id": "author-b"},
+                ),
+            ]
+            findings = mon.check_lane_health()
+
+        # Controller consumes them
+        ctrl = ControlPlaneController(runtime_dir=tmp_path)
+        status = ctrl.reconcile(monitor_findings=findings)
+
+        # Verify integration: controller produced items from findings
+        assert len(status.items) == 2
+        categories = {item.category for item in status.items}
+        assert "lane_health" in categories
+
+    def test_empty_monitor_output_produces_empty_reconcile(
+        self, tmp_path: Path
+    ) -> None:
+        """Empty monitor findings produce no controller items."""
+        from bid_euchre.ops.core.controller import ControlPlaneController
+        from bid_euchre.ops.core.monitor import MonitorService
+
+        mon = MonitorService()
+        with patch("bid_euchre.ops.monitor.run_monitoring_cycle") as mock_cycle:
+            mock_cycle.return_value = []
+            findings = mon.run_cycle()
+
+        ctrl = ControlPlaneController(runtime_dir=tmp_path)
+        status = ctrl.reconcile(monitor_findings=findings)
+        assert status.items == []
+
+    def test_monitor_findings_round_trip_preserves_details(
+        self, tmp_path: Path
+    ) -> None:
+        """Details dict survives monitor -> dict -> controller round-trip."""
+        from bid_euchre.ops.core.controller import ControlPlaneController
+        from bid_euchre.ops.core.monitor import MonitorService
+        from bid_euchre.ops.monitor import MonitorFinding
+
+        details = {
+            "packet_id": "pkt-abc",
+            "owner": "author-c",
+            "elapsed_minutes": 45,
+        }
+
+        mon = MonitorService()
+        with patch("bid_euchre.ops.monitor.check_stale_dispatches") as mock_check:
+            mock_check.return_value = [
+                MonitorFinding(
+                    category="stale_dispatch",
+                    severity="high",
+                    summary="Stale 45m",
+                    details=details,
+                ),
+            ]
+            findings = mon.check_stale_dispatches()
+
+        # Verify the dict layer preserved details
+        assert findings[0]["details"] == details
+
+        # Controller also consumes it
+        ctrl = ControlPlaneController(runtime_dir=tmp_path)
+        status = ctrl.reconcile(monitor_findings=findings)
+        assert len(status.items) == 1
+        assert status.items[0].details == details
+
+
+# ---------------------------------------------------------------------------
+# Test: Default construction
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterDefaultConstruction:
+    """All adapters can be constructed with zero arguments (default config)."""
+
+    def test_controller_default(self) -> None:
+        from bid_euchre.ops.core.controller import ControlPlaneController
+
+        ctrl = ControlPlaneController()
+        assert ctrl._runtime_dir is None
+
+    def test_monitor_default(self) -> None:
+        from bid_euchre.ops.core.monitor import MonitorService
+
+        mon = MonitorService()
+        assert mon._runtime_dir is None
+
+    def test_task_queue_default(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import TaskQueueService
+
+        tq = TaskQueueService()
+        assert tq._queue_root is None
+
+    def test_worker_pool_default(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import WorkerPoolService
+
+        wp = WorkerPoolService()
+        assert wp._runtime_dir is None
+        assert wp._tmux_session == "steward"
+
+
+# ---------------------------------------------------------------------------
+# Test: isinstance checks propagate correctly
+# ---------------------------------------------------------------------------
+
+
+class TestIsinstanceChecks:
+    """isinstance() works correctly for all adapter / ABC pairs."""
+
+    def test_controller_isinstance(self) -> None:
+        from bid_euchre.ops.core.controller import ControlPlaneController
+
+        ctrl = ControlPlaneController()
+        assert isinstance(ctrl, AbstractController)
+        assert not isinstance(ctrl, AbstractMonitor)
+        assert not isinstance(ctrl, AbstractTaskQueue)
+        assert not isinstance(ctrl, AbstractWorkerPool)
+
+    def test_monitor_isinstance(self) -> None:
+        from bid_euchre.ops.core.monitor import MonitorService
+
+        mon = MonitorService()
+        assert isinstance(mon, AbstractMonitor)
+        assert not isinstance(mon, AbstractController)
+        assert not isinstance(mon, AbstractTaskQueue)
+        assert not isinstance(mon, AbstractWorkerPool)
+
+    def test_task_queue_isinstance(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import TaskQueueService
+
+        tq = TaskQueueService()
+        assert isinstance(tq, AbstractTaskQueue)
+        assert not isinstance(tq, AbstractController)
+        assert not isinstance(tq, AbstractMonitor)
+        assert not isinstance(tq, AbstractWorkerPool)
+
+    def test_worker_pool_isinstance(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import WorkerPoolService
+
+        wp = WorkerPoolService()
+        assert isinstance(wp, AbstractWorkerPool)
+        assert not isinstance(wp, AbstractController)
+        assert not isinstance(wp, AbstractMonitor)
+        assert not isinstance(wp, AbstractTaskQueue)

--- a/tests/unit/test_ops_core_controller.py
+++ b/tests/unit/test_ops_core_controller.py
@@ -192,3 +192,138 @@ class TestAckClearSuppress:
         assert status is not None
         item = next(i for i in status.items if i.item_id == "item-001")
         assert item.state == "suppressed"
+
+    def test_double_ack_returns_false(
+        self, ctrl_with_items: ControlPlaneController
+    ) -> None:
+        """Acking an already-acked item returns False (not in open state)."""
+        assert ctrl_with_items.ack_item("item-001") is True
+        assert ctrl_with_items.ack_item("item-001") is False
+
+    def test_clear_already_cleared_returns_false(
+        self, ctrl_with_items: ControlPlaneController
+    ) -> None:
+        """Clearing an already-cleared item returns False."""
+        assert ctrl_with_items.clear_item("item-001") is True
+        assert ctrl_with_items.clear_item("item-001") is False
+
+    def test_suppress_already_suppressed_returns_false(
+        self, ctrl_with_items: ControlPlaneController
+    ) -> None:
+        """Suppressing an already-suppressed item returns False."""
+        assert ctrl_with_items.suppress_item("item-001") is True
+        assert ctrl_with_items.suppress_item("item-001") is False
+
+    def test_clear_after_suppress_returns_false(
+        self, ctrl_with_items: ControlPlaneController
+    ) -> None:
+        """Cannot clear a suppressed item (only open/acked can be cleared)."""
+        ctrl_with_items.suppress_item("item-001")
+        assert ctrl_with_items.clear_item("item-001") is False
+
+    def test_suppress_after_clear_returns_false(
+        self, ctrl_with_items: ControlPlaneController
+    ) -> None:
+        """Cannot suppress a cleared item (only open/acked can be suppressed)."""
+        ctrl_with_items.clear_item("item-001")
+        assert ctrl_with_items.suppress_item("item-001") is False
+
+    def test_operations_on_different_items(
+        self, ctrl_with_items: ControlPlaneController
+    ) -> None:
+        """Operations on one item don't affect another."""
+        ctrl_with_items.ack_item("item-001")
+        ctrl_with_items.suppress_item("item-002")
+
+        status = ctrl_with_items.load_status()
+        assert status is not None
+
+        item1 = next(i for i in status.items if i.item_id == "item-001")
+        item2 = next(i for i in status.items if i.item_id == "item-002")
+        assert item1.state == "acked"
+        assert item2.state == "suppressed"
+
+
+class TestReconcileMultipleInputs:
+    """Verify reconcile() with multiple input source combinations."""
+
+    def test_reconcile_all_none(self, tmp_path: Path) -> None:
+        """Reconcile with all inputs explicitly None produces empty status."""
+        ctrl = ControlPlaneController(runtime_dir=tmp_path)
+        status = ctrl.reconcile(
+            monitor_findings=None,
+            task_packets=None,
+            unacked_messages=None,
+            audit_records=None,
+        )
+        assert isinstance(status, FleetStatus)
+        assert status.items == []
+
+    def test_reconcile_with_task_packets(self, tmp_path: Path) -> None:
+        """Reconcile processes task packet input."""
+        ctrl = ControlPlaneController(runtime_dir=tmp_path)
+        packets = [
+            {
+                "packet_id": "pkt-001",
+                "status": "dispatched",
+                "owner": "author-a",
+                "title": "Test task",
+            }
+        ]
+        status = ctrl.reconcile(task_packets=packets)
+        assert isinstance(status, FleetStatus)
+
+    def test_reconcile_with_unacked_messages(self, tmp_path: Path) -> None:
+        """Reconcile processes unacked message input."""
+        ctrl = ControlPlaneController(runtime_dir=tmp_path)
+        messages = [
+            {
+                "message_id": "msg-001",
+                "from_lane": "author-a",
+                "type": "blocker",
+                "summary": "Help needed",
+            }
+        ]
+        status = ctrl.reconcile(unacked_messages=messages)
+        assert isinstance(status, FleetStatus)
+
+    def test_reconcile_with_audit_records(self, tmp_path: Path) -> None:
+        """Reconcile processes audit record input."""
+        ctrl = ControlPlaneController(runtime_dir=tmp_path)
+        audits = [
+            {
+                "type": "outbound_exchange",
+                "timestamp": "2026-01-01T00:00:00Z",
+                "details": {"tool": "Bash"},
+            }
+        ]
+        status = ctrl.reconcile(audit_records=audits)
+        assert isinstance(status, FleetStatus)
+
+    def test_reconcile_combined_inputs(self, tmp_path: Path) -> None:
+        """Reconcile handles all input sources simultaneously."""
+        ctrl = ControlPlaneController(runtime_dir=tmp_path)
+        findings = [
+            {
+                "category": "stale_dispatch",
+                "severity": "high",
+                "summary": "Stale",
+                "details": {},
+            }
+        ]
+        packets = [
+            {
+                "packet_id": "pkt-002",
+                "status": "dispatched",
+                "owner": "author-b",
+                "title": "Another task",
+            }
+        ]
+        status = ctrl.reconcile(
+            monitor_findings=findings,
+            task_packets=packets,
+            unacked_messages=[],
+            audit_records=[],
+        )
+        assert isinstance(status, FleetStatus)
+        assert status.cycle_count >= 1

--- a/tests/unit/test_ops_core_monitor.py
+++ b/tests/unit/test_ops_core_monitor.py
@@ -191,6 +191,117 @@ class TestFindingsToDicts:
         assert MonitorService._findings_to_dicts([]) == []
 
 
+class TestRunCycleMultipleFindings:
+    """Verify run_cycle() correctly converts multiple findings."""
+
+    @patch("bid_euchre.ops.monitor.run_monitoring_cycle")
+    def test_multiple_categories(self, mock_cycle: MagicMock) -> None:
+        """Multiple findings from different categories all convert correctly."""
+        mock_cycle.return_value = [
+            MonitorFinding(
+                category="lane_health",
+                severity="high",
+                summary="Lane degraded",
+                details={"lane_id": "author-a"},
+            ),
+            MonitorFinding(
+                category="stale_dispatch",
+                severity="warn",
+                summary="Stale 30m",
+                details={"packet_id": "pkt-1", "elapsed": 30},
+            ),
+            MonitorFinding(
+                category="idle_lane",
+                severity="info",
+                summary="Lane idle",
+                details={"lane_id": "author-c"},
+            ),
+        ]
+        mon = MonitorService()
+        result = mon.run_cycle()
+
+        assert len(result) == 3
+        categories = [d["category"] for d in result]
+        assert categories == ["lane_health", "stale_dispatch", "idle_lane"]
+
+    @patch("bid_euchre.ops.monitor.run_monitoring_cycle")
+    def test_findings_are_independent_dicts(self, mock_cycle: MagicMock) -> None:
+        """Each finding converts to an independent dict (no shared references)."""
+        mock_cycle.return_value = [
+            MonitorFinding(
+                category="test",
+                severity="info",
+                summary="A",
+                details={"key": "val1"},
+            ),
+            MonitorFinding(
+                category="test",
+                severity="info",
+                summary="B",
+                details={"key": "val2"},
+            ),
+        ]
+        mon = MonitorService()
+        result = mon.run_cycle()
+
+        # Mutating one dict shouldn't affect the other
+        result[0]["details"]["key"] = "mutated"
+        assert result[1]["details"]["key"] == "val2"
+
+
+class TestFindingsFieldPreservation:
+    """Verify that all MonitorFinding fields survive dict conversion."""
+
+    def test_all_fields_present_in_dict(self) -> None:
+        """Every MonitorFinding field appears in the converted dict."""
+        finding = MonitorFinding(
+            category="stale_dispatch",
+            severity="high",
+            summary="Stale packet pkt-abc",
+            details={"packet_id": "pkt-abc", "owner": "author-d"},
+        )
+        result = MonitorService._findings_to_dicts([finding])
+        d = result[0]
+
+        assert d["category"] == "stale_dispatch"
+        assert d["severity"] == "high"
+        assert d["summary"] == "Stale packet pkt-abc"
+        assert d["details"]["packet_id"] == "pkt-abc"
+        assert d["details"]["owner"] == "author-d"
+
+    def test_empty_details_produces_empty_dict(self) -> None:
+        """A finding with default (empty) details converts to empty dict."""
+        finding = MonitorFinding(
+            category="test",
+            severity="info",
+            summary="No details",
+        )
+        result = MonitorService._findings_to_dicts([finding])
+        assert result[0]["details"] == {}
+
+    def test_nested_details_preserved(self) -> None:
+        """Nested structures in details survive conversion."""
+        nested = {
+            "lane_id": "author-a",
+            "checks": [
+                {"name": "health", "passed": True},
+                {"name": "stale", "passed": False},
+            ],
+            "metadata": {"inner": {"deep": 42}},
+        }
+        finding = MonitorFinding(
+            category="complex",
+            severity="warn",
+            summary="Nested details",
+            details=nested,
+        )
+        result = MonitorService._findings_to_dicts([finding])
+        d = result[0]["details"]
+
+        assert d["checks"][1]["passed"] is False
+        assert d["metadata"]["inner"]["deep"] == 42
+
+
 class TestModuleExports:
     """Verify core __init__.py exports include the new classes."""
 


### PR DESCRIPTION
## Plan
Platform-10 extraction — PR4 per task packet be0e17aced25

## Summary
- Add `test_ops_core_adapters.py` with 27 new tests covering ABC method signature conformance, adapter polymorphism, controller-monitor integration, isinstance exclusivity, and default construction
- Extend `test_ops_core_controller.py` with 12 edge cases: double-ack, clear-after-suppress, suppress-after-clear, operations on different items, reconcile with multiple input sources (task_packets, unacked_messages, audit_records, combined)
- Extend `test_ops_core_monitor.py` with 5 tests: multiple findings conversion, independent dict mutation, field preservation, empty details, nested details survival

## Why
The core ops ABCs and concrete adapters (Platform-10 PRs 1-3) had basic delegation tests but lacked cross-adapter integration tests, contract conformance checks, and state machine edge cases. These tests lock down the ABC boundary contract so future adapter changes are caught early.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_core_adapters.py tests/unit/test_ops_core_controller.py tests/unit/test_ops_core_monitor.py tests/unit/test_ops_core_interfaces.py tests/unit/test_ops_adapter_migration.py -v
```

## Test Criteria
- **Pass condition:** All 134 ops core tests pass (80 in the 3 changed files + 54 in existing files)
- **Verification command:** `uv run python -m pytest tests/unit/test_ops_core* tests/unit/test_ops_adapter_migration.py -q`
- **Expected result:** `134 passed`

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_core* -v` — 80 passed
- [x] `uv run python -m pytest tests/unit/test_ops_core* tests/unit/test_ops_adapter_migration.py -q` — 134 passed
- [x] `make lint` — passed
- [x] `make repo-lint` — passed
- [x] `make check-quiet` — OOM-killed (Error 137) at ~80% in unrelated test (test_bid_outcome_matrix); all ops core tests pass independently

## Expected impact
- Metrics impact: None
- Runtime impact: None — test-only change

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git worktree list` (excerpt):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c   fde5e8b8 [ops/platform10-pr4-core-adapter-tests]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)