### PR TITLE
fix(test): harden flaky tests against timing and filesystem assumptions

### DIFF
--- a/tests/integration/test_compare_runs.py
+++ b/tests/integration/test_compare_runs.py
@@ -8,7 +8,6 @@ import json
 import os
 import subprocess
 import tempfile
-import time
 from pathlib import Path
 
 import pytest
@@ -73,30 +72,28 @@ def run_compare(
 def test_compare_runs_identical_runs():
     """Comparing two identical runs should show no significant differences."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        # Run same config twice with same seed
+        # Use separate run dirs so runs never collide on timestamp-based
+        # run_id — eliminates the need for a 1-second sleep between runs.
+        run_dir_1 = os.path.join(tmpdir, "run1")
+        run_dir_2 = os.path.join(tmpdir, "run2")
+
         result1 = run_experiment(
             "experiments/configs/quick_test.yaml",
             ["--seed", "42", "--n_per", "100"],
-            run_dir=tmpdir,
+            run_dir=run_dir_1,
         )
         assert result1.returncode == 0, f"Run 1 failed: {result1.stderr}"
-
-        # Wait 1 second to ensure different timestamp in run_id
-        time.sleep(1)
 
         result2 = run_experiment(
             "experiments/configs/quick_test.yaml",
             ["--seed", "42", "--n_per", "100"],
-            run_dir=tmpdir,
+            run_dir=run_dir_2,
         )
         assert result2.returncode == 0, f"Run 2 failed: {result2.stderr}"
 
-        # Find run directories
-        run_dirs = sorted(Path(tmpdir).glob("*"))
-        assert len(run_dirs) == 2, f"Expected 2 run directories, found {len(run_dirs)}"
-
-        baseline_dir = run_dirs[0]
-        candidate_dir = run_dirs[1]
+        # Each run dir has exactly one sub-directory
+        baseline_dir = next(Path(run_dir_1).iterdir())
+        candidate_dir = next(Path(run_dir_2).iterdir())
 
         # Compare runs
         result = run_compare(baseline_dir, candidate_dir, format="json")
@@ -132,31 +129,29 @@ def test_compare_runs_identical_runs():
 def test_compare_runs_different_strategies():
     """Comparing different strategies should detect significant differences."""
     with tempfile.TemporaryDirectory() as tmpdir:
+        # Use separate run dirs to avoid timestamp-based run_id collision.
+        run_dir_1 = os.path.join(tmpdir, "run1")
+        run_dir_2 = os.path.join(tmpdir, "run2")
+
         # Run same config (quick_test) with different seeds to get different results
         # Both runs have same scenarios (greedy/high and greedy/suit_H), so comparison works
         result1 = run_experiment(
             "experiments/configs/quick_test.yaml",
             ["--seed", "100", "--n_per", "200"],
-            run_dir=tmpdir,
+            run_dir=run_dir_1,
         )
         assert result1.returncode == 0, f"Run 1 failed: {result1.stderr}"
-
-        # Wait 1 second to ensure different timestamp
-        time.sleep(1)
 
         result2 = run_experiment(
             "experiments/configs/quick_test.yaml",
             ["--seed", "999", "--n_per", "200"],
-            run_dir=tmpdir,
+            run_dir=run_dir_2,
         )
         assert result2.returncode == 0, f"Run 2 failed: {result2.stderr}"
 
-        # Find run directories
-        run_dirs = sorted(Path(tmpdir).glob("*"))
-        assert len(run_dirs) == 2, f"Expected 2 run directories, found {len(run_dirs)}"
-
-        baseline_dir = run_dirs[0]
-        candidate_dir = run_dirs[1]
+        # Each run dir has exactly one sub-directory
+        baseline_dir = next(Path(run_dir_1).iterdir())
+        candidate_dir = next(Path(run_dir_2).iterdir())
 
         # Compare runs
         result = run_compare(baseline_dir, candidate_dir, format="json")

--- a/tests/performance/test_performance.py
+++ b/tests/performance/test_performance.py
@@ -20,9 +20,9 @@ class TestPerformanceRegression:
 
         duration = end_time - start_time
 
-        # Should complete in reasonable time (adjust threshold as needed)
-        # On a typical modern machine, 1000 hands should take < 5 seconds
-        assert duration < 10.0, f"{duration:.2f}"
+        # Should complete in reasonable time — generous for slow CI runners.
+        # On a typical modern machine, 1000 hands should take < 5 seconds.
+        assert duration < 30.0, f"1000 hands took {duration:.2f}s (must be < 30s)"
 
         # Verify result is still correct
         assert result["hands"] == 1000

--- a/tests/unit/test_alert_inject_hook.py
+++ b/tests/unit/test_alert_inject_hook.py
@@ -327,4 +327,4 @@ class TestHookInfrastructure:
         elapsed = time.monotonic() - start
 
         assert result.returncode == 0
-        assert elapsed < 2.0, f"Hook took {elapsed:.2f}s (must be < 2s)"
+        assert elapsed < 5.0, f"Hook took {elapsed:.2f}s (must be < 5s)"

--- a/tests/unit/test_ops_events.py
+++ b/tests/unit/test_ops_events.py
@@ -290,8 +290,8 @@ class TestDrainEvents:
         def do_append() -> None:
             # Wait for drain to start, then try appending
             drain_started.wait(timeout=5)
-            # Small delay to let drain acquire lock
-            time.sleep(0.05)
+            # Small delay to let drain acquire lock — generous for slow CI.
+            time.sleep(0.2)
             append_event(
                 "ci_failure", "concurrent", "ops", {"concurrent": True}, events_dir
             )
@@ -301,8 +301,8 @@ class TestDrainEvents:
         t2 = threading.Thread(target=do_append)
         t1.start()
         t2.start()
-        t1.join(timeout=5)
-        t2.join(timeout=5)
+        t1.join(timeout=10)
+        t2.join(timeout=10)
 
         assert drain_done.is_set(), "drain should complete"
         assert append_done.is_set(), "append should complete"

--- a/tests/unit/test_ops_index.py
+++ b/tests/unit/test_ops_index.py
@@ -903,7 +903,7 @@ class TestStalenessCache:
         self, index_dir: Path, runtime_dir: Path, plans_dir: Path
     ) -> None:
         """After modifying a source file, staleness should be detected."""
-        import time as _time
+        import os
 
         build_index(index_dir, runtime_dir=runtime_dir, plans_dir=plans_dir)
 
@@ -911,12 +911,16 @@ class TestStalenessCache:
         stats = get_stats(index_dir)
         assert stats.stale_sources == 0
 
-        # Modify a source file — ensure mtime advances
+        # Modify a source file — use explicit mtime advancement instead of
+        # sleeping, which is flaky on systems with coarse mtime resolution.
         events_file = runtime_dir / "events" / "events.jsonl"
-        _time.sleep(0.05)  # ensure mtime resolution
         events_file.write_text(
             events_file.read_text() + '{"event_type":"new","timestamp":"2026-12-31"}\n'
         )
+        # Bump mtime 1 second into the future to guarantee staleness detection
+        # regardless of filesystem timestamp granularity.
+        st = events_file.stat()
+        os.utime(events_file, (st.st_atime, st.st_mtime + 1.0))
 
         # Cache should be invalidated for this query (build just ran, but
         # we need to force expiry to see the modification)

--- a/tests/unit/test_ops_worktrees.py
+++ b/tests/unit/test_ops_worktrees.py
@@ -922,9 +922,29 @@ class TestQuarantineWorktree:
     ) -> None:
         """Repeated quarantines produce different diff files (F2)."""
         import subprocess as sp
-        import time
+        from datetime import datetime as real_datetime
+        from datetime import timezone
 
         from bid_euchre.ops import worktrees as wt_mod
+
+        # Use fake timestamps to avoid a 1+ second sleep.  The production code
+        # formats timestamps at second resolution (%Y%m%dT%H%M%S), so we need
+        # two datetimes that differ by at least 1 second.
+        _call_count = 0
+        _fake_times = [
+            real_datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            real_datetime(2026, 1, 1, 0, 0, 5, tzinfo=timezone.utc),
+        ]
+
+        class _FakeDatetime(real_datetime):
+            @classmethod  # type: ignore[override]
+            def now(cls, tz=None):  # noqa: ANN001, ANN206
+                nonlocal _call_count
+                idx = min(_call_count, len(_fake_times) - 1)
+                _call_count += 1
+                return _fake_times[idx]
+
+        monkeypatch.setattr(wt_mod, "datetime", _FakeDatetime)
 
         monkeypatch.setattr(
             sp,
@@ -938,9 +958,6 @@ class TestQuarantineWorktree:
             runtime_dir,
             events_dir=tmp_path / "events",
         )
-
-        # Ensure at least 1 second passes for distinct timestamp
-        time.sleep(1.1)
 
         monkeypatch.setattr(
             sp,

--- a/tests/unit/test_post_push_ci_check_hook.py
+++ b/tests/unit/test_post_push_ci_check_hook.py
@@ -33,13 +33,13 @@ def _write_executable(path: Path, content: str) -> None:
     path.chmod(0o755)
 
 
-def _wait_for_file(path: Path, timeout_s: float = 3.0) -> None:
+def _wait_for_file(path: Path, timeout_s: float = 10.0) -> None:
     deadline = time.time() + timeout_s
     while time.time() < deadline:
         if path.exists():
             return
         time.sleep(0.05)
-    raise AssertionError(f"Timed out waiting for {path}")
+    raise AssertionError(f"Timed out waiting for {path} after {timeout_s}s")
 
 
 def test_post_push_hook_uses_project_dir_and_sanitizes_branch(

--- a/tests/unit/test_pty_runner.py
+++ b/tests/unit/test_pty_runner.py
@@ -54,7 +54,7 @@ class TestPTYTimeout:
         elapsed = time.monotonic() - start
 
         assert rc is None  # None = killed by timeout
-        assert elapsed < 5  # Should complete in ~2s, not 30s
+        assert elapsed < 10  # Should complete in ~2s; generous for slow CI
 
     def test_timeout_captures_partial_output(self):
         """Output produced before timeout is captured."""
@@ -73,7 +73,7 @@ class TestPTYTimeout:
 
         assert rc == 0
         assert "fast" in output
-        assert elapsed < 5  # Should be near-instant
+        assert elapsed < 10  # Should be near-instant; generous for slow CI
 
 
 class TestPTYEdgeCases:

--- a/tests/unit/test_rung_orchestrator.py
+++ b/tests/unit/test_rung_orchestrator.py
@@ -1219,7 +1219,7 @@ class TestWriteHeartbeat:
             assert hb_path.exists()
             ts = float(hb_path.read_text().strip())
             # Should be within the last few seconds
-            assert time.time() - ts < 5
+            assert time.time() - ts < 30  # generous for slow CI runners
 
 
 class TestCheckHeartbeatFresh:

--- a/tests/unit/test_teacher_roster_manifest_validation.py
+++ b/tests/unit/test_teacher_roster_manifest_validation.py
@@ -23,15 +23,15 @@ class TestTeacherRosterManifestValidation:
                 "id": "strict_raiser",
                 "import_path": "bid_euchre.strategy.bidding.StrictRaiserBidder",
                 "kind": "policy",
-                "params": {}
+                "params": {},
             },
             {
                 "id": "always_pass",
                 "import_path": "bid_euchre.strategy.bidding.AlwaysPassBidder",
                 "kind": "policy",
-                "params": {}
-            }
-        ]
+                "params": {},
+            },
+        ],
     }
 
     def test_valid_manifest_passes_validation(self, tmp_path):
@@ -41,12 +41,15 @@ class TestTeacherRosterManifestValidation:
         fixture_dst = tmp_path / "data" / "fixtures" / "bidding_artifact_v1_tiny.json"
         fixture_dst.parent.mkdir(parents=True, exist_ok=True)
         import shutil
+
         shutil.copy(fixture_src, fixture_dst)
 
         # Create a temporary manifest file
-        manifest_path = tmp_path / "experiments" / "baselines" / "teacher_roster_v1.yaml"
+        manifest_path = (
+            tmp_path / "experiments" / "baselines" / "teacher_roster_v1.yaml"
+        )
         manifest_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(manifest_path, 'w') as f:
+        with open(manifest_path, "w") as f:
             yaml.dump(self.VALID_MANIFEST, f)
 
         # Run the validation script
@@ -56,7 +59,7 @@ class TestTeacherRosterManifestValidation:
             cwd=tmp_path,
             capture_output=True,
             text=True,
-            env={**os.environ, "PYTHONPATH": str(Path.cwd() / "src")}
+            env={**os.environ, "PYTHONPATH": str(Path.cwd() / "src")},
         )
 
         # Should succeed
@@ -66,17 +69,21 @@ class TestTeacherRosterManifestValidation:
     def test_duplicate_baseline_ids_fail(self, tmp_path):
         """Test that manifests with duplicate baseline IDs are rejected."""
         invalid_manifest = deepcopy(self.VALID_MANIFEST)
-        invalid_manifest["baselines"].append({
-            "id": "strict_raiser",  # Duplicate ID
-            "import_path": "bid_euchre.strategy.bidding.AlwaysPassBidder",
-            "kind": "policy",
-            "params": {}
-        })
+        invalid_manifest["baselines"].append(
+            {
+                "id": "strict_raiser",  # Duplicate ID
+                "import_path": "bid_euchre.strategy.bidding.AlwaysPassBidder",
+                "kind": "policy",
+                "params": {},
+            }
+        )
 
         # Create a temporary manifest file
-        manifest_path = tmp_path / "experiments" / "baselines" / "teacher_roster_v1.yaml"
+        manifest_path = (
+            tmp_path / "experiments" / "baselines" / "teacher_roster_v1.yaml"
+        )
         manifest_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(manifest_path, 'w') as f:
+        with open(manifest_path, "w") as f:
             yaml.dump(invalid_manifest, f)
 
         # Run the validation script
@@ -86,7 +93,7 @@ class TestTeacherRosterManifestValidation:
             cwd=tmp_path,
             capture_output=True,
             text=True,
-            env={**os.environ, "PYTHONPATH": str(Path.cwd() / "src")}
+            env={**os.environ, "PYTHONPATH": str(Path.cwd() / "src")},
         )
 
         # Should fail
@@ -97,9 +104,11 @@ class TestTeacherRosterManifestValidation:
         """Test that manifests missing required top-level keys are rejected."""
         invalid_manifest = {"baselines": []}  # Missing roster_version
 
-        manifest_path = tmp_path / "experiments" / "baselines" / "teacher_roster_v1.yaml"
+        manifest_path = (
+            tmp_path / "experiments" / "baselines" / "teacher_roster_v1.yaml"
+        )
         manifest_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(manifest_path, 'w') as f:
+        with open(manifest_path, "w") as f:
             yaml.dump(invalid_manifest, f)
 
         script_path = Path.cwd() / "scripts" / "validate_teacher_roster.py"
@@ -108,7 +117,7 @@ class TestTeacherRosterManifestValidation:
             cwd=tmp_path,
             capture_output=True,
             text=True,
-            env={**os.environ, "PYTHONPATH": str(Path.cwd() / "src")}
+            env={**os.environ, "PYTHONPATH": str(Path.cwd() / "src")},
         )
 
         assert result.returncode != 0
@@ -119,9 +128,11 @@ class TestTeacherRosterManifestValidation:
         invalid_manifest = deepcopy(self.VALID_MANIFEST)
         invalid_manifest["roster_version"] = 2
 
-        manifest_path = tmp_path / "experiments" / "baselines" / "teacher_roster_v1.yaml"
+        manifest_path = (
+            tmp_path / "experiments" / "baselines" / "teacher_roster_v1.yaml"
+        )
         manifest_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(manifest_path, 'w') as f:
+        with open(manifest_path, "w") as f:
             yaml.dump(invalid_manifest, f)
 
         script_path = Path.cwd() / "scripts" / "validate_teacher_roster.py"
@@ -130,7 +141,7 @@ class TestTeacherRosterManifestValidation:
             cwd=tmp_path,
             capture_output=True,
             text=True,
-            env={**os.environ, "PYTHONPATH": str(Path.cwd() / "src")}
+            env={**os.environ, "PYTHONPATH": str(Path.cwd() / "src")},
         )
 
         assert result.returncode != 0
@@ -141,9 +152,11 @@ class TestTeacherRosterManifestValidation:
         invalid_manifest = deepcopy(self.VALID_MANIFEST)
         invalid_manifest["baselines"] = []
 
-        manifest_path = tmp_path / "experiments" / "baselines" / "teacher_roster_v1.yaml"
+        manifest_path = (
+            tmp_path / "experiments" / "baselines" / "teacher_roster_v1.yaml"
+        )
         manifest_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(manifest_path, 'w') as f:
+        with open(manifest_path, "w") as f:
             yaml.dump(invalid_manifest, f)
 
         script_path = Path.cwd() / "scripts" / "validate_teacher_roster.py"
@@ -152,7 +165,7 @@ class TestTeacherRosterManifestValidation:
             cwd=tmp_path,
             capture_output=True,
             text=True,
-            env={**os.environ, "PYTHONPATH": str(Path.cwd() / "src")}
+            env={**os.environ, "PYTHONPATH": str(Path.cwd() / "src")},
         )
 
         assert result.returncode != 0
@@ -163,9 +176,11 @@ class TestTeacherRosterManifestValidation:
         invalid_manifest = deepcopy(self.VALID_MANIFEST)
         invalid_manifest["baselines"][0] = {"id": "test"}  # Missing import_path
 
-        manifest_path = tmp_path / "experiments" / "baselines" / "teacher_roster_v1.yaml"
+        manifest_path = (
+            tmp_path / "experiments" / "baselines" / "teacher_roster_v1.yaml"
+        )
         manifest_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(manifest_path, 'w') as f:
+        with open(manifest_path, "w") as f:
             yaml.dump(invalid_manifest, f)
 
         script_path = Path.cwd() / "scripts" / "validate_teacher_roster.py"
@@ -174,7 +189,7 @@ class TestTeacherRosterManifestValidation:
             cwd=tmp_path,
             capture_output=True,
             text=True,
-            env={**os.environ, "PYTHONPATH": str(Path.cwd() / "src")}
+            env={**os.environ, "PYTHONPATH": str(Path.cwd() / "src")},
         )
 
         assert result.returncode != 0
@@ -187,12 +202,14 @@ class TestTeacherRosterManifestValidation:
             "id": "nonexistent",
             "import_path": "bid_euchre.strategy.bidding.NonExistentClass",
             "kind": "policy",
-            "params": {}
+            "params": {},
         }
 
-        manifest_path = tmp_path / "experiments" / "baselines" / "teacher_roster_v1.yaml"
+        manifest_path = (
+            tmp_path / "experiments" / "baselines" / "teacher_roster_v1.yaml"
+        )
         manifest_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(manifest_path, 'w') as f:
+        with open(manifest_path, "w") as f:
             yaml.dump(invalid_manifest, f)
 
         script_path = Path.cwd() / "scripts" / "validate_teacher_roster.py"
@@ -201,11 +218,14 @@ class TestTeacherRosterManifestValidation:
             cwd=tmp_path,
             capture_output=True,
             text=True,
-            env={**os.environ, "PYTHONPATH": str(Path.cwd() / "src")}
+            env={**os.environ, "PYTHONPATH": str(Path.cwd() / "src")},
         )
 
         assert result.returncode != 0
-        assert "Class 'NonExistentClass' not found in module 'bid_euchre.strategy.bidding'" in result.stderr
+        assert (
+            "Class 'NonExistentClass' not found in module 'bid_euchre.strategy.bidding'"
+            in result.stderr
+        )
 
     def test_missing_artifact_file_fails(self, tmp_path):
         """Test that manifests referencing non-existent artifact files are rejected."""
@@ -214,21 +234,24 @@ class TestTeacherRosterManifestValidation:
         fixture_dst = tmp_path / "data" / "fixtures" / "bidding_artifact_v1_tiny.json"
         fixture_dst.parent.mkdir(parents=True, exist_ok=True)
         import shutil
+
         shutil.copy(fixture_src, fixture_dst)
 
         invalid_manifest = deepcopy(self.VALID_MANIFEST)
-        invalid_manifest["baselines"].append({
-            "id": "artifact_bidder",
-            "import_path": "bid_euchre.strategy.bidding.ArtifactBidder",
-            "kind": "artifact_policy",
-            "params": {
-                "artifact_path": "nonexistent.json"
+        invalid_manifest["baselines"].append(
+            {
+                "id": "artifact_bidder",
+                "import_path": "bid_euchre.strategy.bidding.ArtifactBidder",
+                "kind": "artifact_policy",
+                "params": {"artifact_path": "nonexistent.json"},
             }
-        })
+        )
 
-        manifest_path = tmp_path / "experiments" / "baselines" / "teacher_roster_v1.yaml"
+        manifest_path = (
+            tmp_path / "experiments" / "baselines" / "teacher_roster_v1.yaml"
+        )
         manifest_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(manifest_path, 'w') as f:
+        with open(manifest_path, "w") as f:
             yaml.dump(invalid_manifest, f)
 
         script_path = Path.cwd() / "scripts" / "validate_teacher_roster.py"
@@ -237,7 +260,7 @@ class TestTeacherRosterManifestValidation:
             cwd=tmp_path,
             capture_output=True,
             text=True,
-            env={**os.environ, "PYTHONPATH": str(Path.cwd() / "src")}
+            env={**os.environ, "PYTHONPATH": str(Path.cwd() / "src")},
         )
 
         assert result.returncode != 0
@@ -250,6 +273,7 @@ class TestTeacherRosterManifestValidation:
         fixture_dst = tmp_path / "data" / "fixtures" / "bidding_artifact_v1_tiny.json"
         fixture_dst.parent.mkdir(parents=True, exist_ok=True)
         import shutil
+
         shutil.copy(fixture_src, fixture_dst)
 
         # Don't create the manifest file
@@ -259,13 +283,16 @@ class TestTeacherRosterManifestValidation:
             cwd=tmp_path,
             capture_output=True,
             text=True,
-            env={**os.environ, "PYTHONPATH": str(Path.cwd() / "src")}
+            env={**os.environ, "PYTHONPATH": str(Path.cwd() / "src")},
         )
 
         # Should succeed with a warning (not fail)
         assert result.returncode == 0
         assert "Teacher roster manifest not found" in result.stdout
-        assert "roster manifest validation will activate once manifest is created" in result.stdout
+        assert (
+            "roster manifest validation will activate once manifest is created"
+            in result.stdout
+        )
         assert "Bidding artifact schema v1 invariants preserved" in result.stdout
 
     def test_script_runs_quickly(self, tmp_path):
@@ -277,12 +304,15 @@ class TestTeacherRosterManifestValidation:
         fixture_dst = tmp_path / "data" / "fixtures" / "bidding_artifact_v1_tiny.json"
         fixture_dst.parent.mkdir(parents=True, exist_ok=True)
         import shutil
+
         shutil.copy(fixture_src, fixture_dst)
 
         # Create a valid manifest file
-        manifest_path = tmp_path / "experiments" / "baselines" / "teacher_roster_v1.yaml"
+        manifest_path = (
+            tmp_path / "experiments" / "baselines" / "teacher_roster_v1.yaml"
+        )
         manifest_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(manifest_path, 'w') as f:
+        with open(manifest_path, "w") as f:
             yaml.dump(self.VALID_MANIFEST, f)
 
         script_path = Path.cwd() / "scripts" / "validate_teacher_roster.py"
@@ -293,10 +323,12 @@ class TestTeacherRosterManifestValidation:
             cwd=tmp_path,
             capture_output=True,
             text=True,
-            env={**os.environ, "PYTHONPATH": str(Path.cwd() / "src")}
+            env={**os.environ, "PYTHONPATH": str(Path.cwd() / "src")},
         )
         end_time = time.time()
 
         assert result.returncode == 0
         execution_time = end_time - start_time
-        assert execution_time < 2.0, f"Script took {execution_time:.2f}s, should be < 2.0s"
+        assert (
+            execution_time < 10.0
+        ), f"Script took {execution_time:.2f}s, should be < 10s"

--- a/tests/unit/test_urgent_state_guard.py
+++ b/tests/unit/test_urgent_state_guard.py
@@ -405,4 +405,4 @@ class TestHookInfrastructure:
         elapsed = time.monotonic() - start
 
         assert result.returncode == 2
-        assert elapsed < 2.0, f"Hook took {elapsed:.2f}s (must be < 2s)"
+        assert elapsed < 5.0, f"Hook took {elapsed:.2f}s (must be < 5s)"


### PR DESCRIPTION
## Summary
- Eliminate wall-clock sleeps in unit tests by using monkeypatched timestamps and explicit mtime manipulation
- Replace timestamp-collision avoidance sleeps in integration tests with separate run directories
- Widen timing-bound assertions for slow CI runners across 6 test files

## Why
Tests using `time.sleep()` for timestamp uniqueness or tight timing assertions (`< 2s`, `< 5s`) are inherently flaky on overloaded CI runners and systems with coarse filesystem timestamp resolution. These changes make the test suite deterministic and CI-resilient.

## Changes by Category

### Sleep elimination (deterministic fixes)
| File | Pattern | Fix |
|------|---------|-----|
| `test_ops_worktrees.py` | `time.sleep(1.1)` for timestamp uniqueness | Monkeypatch `datetime.now()` with controlled timestamps |
| `test_compare_runs.py` | `time.sleep(1)` ×2 for run_id collision | Use separate `--run-dir` per experiment |
| `test_ops_index.py` | `time.sleep(0.05)` for mtime resolution | Use `os.utime()` to explicitly bump mtime |

### Timing threshold widening (CI resilience)
| File | Old | New |
|------|-----|-----|
| `test_pty_runner.py` | `< 5s` | `< 10s` |
| `test_rung_orchestrator.py` | `< 5s` | `< 30s` |
| `test_alert_inject_hook.py` | `< 2s` | `< 5s` |
| `test_urgent_state_guard.py` | `< 2s` | `< 5s` |
| `test_teacher_roster_manifest_validation.py` | `< 2s` | `< 10s` |
| `test_performance.py` | `< 10s` | `< 30s` |
| `test_post_push_ci_check_hook.py` | `3s` timeout | `10s` timeout |
| `test_ops_events.py` | `0.05s` / `5s` join | `0.2s` / `10s` join |

## Repro / Validation
```bash
# Targeted tests (all changed files pass)
uv run python -m pytest tests/unit/test_ops_worktrees.py::TestQuarantineWorktree::test_quarantine_diff_filename_has_timestamp -xvs
uv run python -m pytest tests/unit/test_ops_index.py -k "staleness_detected_after_file" -xvs
uv run python -m pytest tests/unit/test_pty_runner.py -xvs
uv run python -m pytest tests/unit/test_ops_events.py -k "test_drain_serializes" -xvs

# Full suite (2 pre-existing failures in test_ops_token_economy.py, unrelated)
make check
```

## Test Criteria
- **Pass condition:** All 11 modified test files pass; no new test failures introduced
- **Verification:** `make check` — 10,151 passed, 56 skipped, 2 failed (pre-existing in `test_ops_token_economy.py`)

## Tests
- [x] Tier 1: All modified test files pass individually
- [x] Tier 2: `make check` — all tests pass except 2 pre-existing failures

## Expected impact
- Metrics impact: None (test-only changes)
- Runtime impact: Eliminates ~3.2s of wall-clock sleeps from unit/integration tests

## Risk level
- [x] Low (tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)