### PR TITLE
feat(web): template/CSS cleanup — extract inline styles, fix button hover, add missing rules

### DIFF
--- a/web/static/css/accessibility.css
+++ b/web/static/css/accessibility.css
@@ -123,7 +123,8 @@ select:focus-visible {
 
     /* Text inputs */
     #nickname-form input[type="text"],
-    #invite-code-input {
+    #invite-code-input,
+    .invite-code-form__input {
         min-height: 44px;
     }
 

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -26,6 +26,10 @@
     --card-height: 90px;
     --card-radius: 8px;
     --card-overlap: -10px;
+    --color-moon: #ffa000;
+    --color-moon-glow: #ffca28;
+    --color-loner: #7e57c2;
+    --color-loner-glow: #b39ddb;
 }
 
 *,
@@ -1023,11 +1027,19 @@ main {
     padding: 0.75rem 2rem;
 }
 
-.btn--play-again:hover,
+.btn--play-again:hover {
+    background: var(--color-legal-glow);
+}
+
 .btn--next-hand,
 .btn--next-step {
-    background: var(--color-legal-glow);
+    background: var(--color-felt);
     color: #fff;
+}
+
+.btn--next-hand:hover,
+.btn--next-step:hover {
+    background: var(--color-legal-glow);
 }
 
 /* --------------------------------------------------------------------------
@@ -1113,6 +1125,69 @@ main {
 #nickname-form button:hover,
 #model-select button:hover {
     background: var(--color-legal-glow);
+}
+
+/* --------------------------------------------------------------------------
+   12b. Landing Page & Invite Code Form
+   -------------------------------------------------------------------------- */
+
+.landing-hero {
+    text-align: center;
+    padding: 3rem 1rem;
+}
+
+.landing-hero__title {
+    font-size: 2rem;
+    margin: 0 0 0.5rem;
+}
+
+.landing-hero__subtitle {
+    color: var(--color-text-muted);
+    margin: 0 0 2rem;
+    font-size: 1.1rem;
+}
+
+.invite-code-form {
+    text-align: center;
+    padding: 2rem 1rem;
+}
+
+.invite-code-form__heading {
+    font-size: 1.5rem;
+    margin: 0 0 0.5rem;
+}
+
+.invite-code-form__hint {
+    color: var(--color-text-muted);
+    margin: 0 0 1.5rem;
+    font-size: 0.95rem;
+}
+
+.invite-error {
+    color: #e53935;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+}
+
+.invite-code-form__fields {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.invite-code-form__input {
+    text-transform: uppercase;
+    text-align: center;
+    font-size: 1.3rem;
+    letter-spacing: 0.15em;
+    padding: 0.6rem 1rem;
+    width: 14rem;
+    font-family: monospace;
+    background: var(--color-surface-light);
+    color: var(--color-text);
+    border: 1px solid #555;
+    border-radius: 4px;
 }
 
 /* --------------------------------------------------------------------------
@@ -1547,7 +1622,8 @@ main {
     }
 
     /* Invite code input — narrower */
-    #invite-code-input {
+    #invite-code-input,
+    .invite-code-form__input {
         font-size: 1.1rem;
         width: 12rem;
         letter-spacing: 0.1em;
@@ -1572,13 +1648,6 @@ main {
 /* --------------------------------------------------------------------------
    15. Moon / Loner — Bid Display
    -------------------------------------------------------------------------- */
-
-:root {
-    --color-moon: #ffa000;
-    --color-moon-glow: #ffca28;
-    --color-loner: #7e57c2;
-    --color-loner-glow: #b39ddb;
-}
 
 /* Auction transcript row emphasis */
 .bid--moon td {
@@ -1721,6 +1790,125 @@ main {
 
 .score-delta--loner {
     color: var(--color-loner);
+}
+
+/* --------------------------------------------------------------------------
+   16b. Moon Exchange Interstitial
+   -------------------------------------------------------------------------- */
+
+.moon-exchange {
+    text-align: center;
+    padding: 1.5rem;
+    border-radius: 12px;
+    background: var(--color-surface);
+    border: 2px solid var(--color-moon);
+}
+
+.moon-exchange__header {
+    margin-bottom: 1.25rem;
+}
+
+.moon-exchange__title {
+    font-size: 1.5rem;
+    margin: 0 0 0.25rem;
+    color: var(--color-moon);
+}
+
+.moon-exchange__subtitle {
+    color: var(--color-text-muted);
+    font-size: 0.95rem;
+    margin: 0;
+}
+
+.moon-exchange__cards {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1.25rem;
+    margin-bottom: 1rem;
+}
+
+.moon-exchange__group {
+    flex: 0 1 auto;
+}
+
+.moon-exchange__group-title {
+    margin: 0 0 0.5rem;
+    font-size: 0.9rem;
+    color: var(--color-text-muted);
+}
+
+.moon-exchange__card-list {
+    display: flex;
+    justify-content: center;
+    gap: 0.35rem;
+    flex-wrap: wrap;
+}
+
+.card--exchange {
+    width: 50px;
+    height: 75px;
+    font-size: 1rem;
+}
+
+.card--exchange-received {
+    border-color: var(--color-moon);
+    box-shadow: 0 0 4px var(--color-moon-glow);
+}
+
+.card--hand {
+    width: var(--card-width);
+    height: var(--card-height);
+}
+
+.moon-exchange__hand {
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.moon-exchange__controls {
+    margin-top: 1.25rem;
+}
+
+/* --------------------------------------------------------------------------
+   16c. Hand Result — Exchange & Card Text
+   -------------------------------------------------------------------------- */
+
+.result-exchange {
+    margin: 0.75rem auto;
+    max-width: 400px;
+    text-align: left;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 8px;
+    padding: 0.5rem 0.75rem;
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.exchange-title {
+    margin: 0 0 0.35rem;
+    font-size: 0.9rem;
+}
+
+.exchange-details {
+    margin: 0.15rem 0;
+    font-size: 0.82rem;
+    color: var(--color-text-muted);
+}
+
+.card-text {
+    font-weight: 700;
+    white-space: nowrap;
+}
+
+.card-text--hearts,
+.card-text--diamonds {
+    color: var(--color-red);
+}
+
+.card-text--spades,
+.card-text--clubs {
+    color: var(--color-text);
 }
 
 /* --------------------------------------------------------------------------

--- a/web/templates/landing.html
+++ b/web/templates/landing.html
@@ -3,9 +3,9 @@
 {% block title %}Bid Euchre — Play Online{% endblock %}
 
 {% block content %}
-<div style="text-align:center; padding:3rem 1rem;" role="region" aria-label="Welcome to Bid Euchre">
-    <h2 style="font-size:2rem; margin-bottom:0.5rem;">Bid Euchre</h2>
-    <p style="color:var(--color-text-muted, #bdbdbd); margin-bottom:2rem; font-size:1.1rem;">
+<div class="landing-hero" role="region" aria-label="Welcome to Bid Euchre">
+    <h2 class="landing-hero__title">Bid Euchre</h2>
+    <p class="landing-hero__subtitle">
         Double-deck, 10-to-Ace, with bowers. Play against AI opponents.
     </p>
 

--- a/web/templates/partials/invite_code_form.html
+++ b/web/templates/partials/invite_code_form.html
@@ -2,16 +2,15 @@
    Context variables:
      - error (optional): str — error message to display
 #}
-<div id="invite-code-form" style="text-align:center; padding:2rem 1rem;"
+<div id="invite-code-form" class="invite-code-form"
      role="region" aria-label="Invite code entry">
-    <h2 style="font-size:1.5rem; margin-bottom:0.5rem;">Enter Invite Code</h2>
-    <p style="color:var(--color-text-muted, #bdbdbd); margin-bottom:1.5rem; font-size:0.95rem;">
+    <h2 class="invite-code-form__heading">Enter Invite Code</h2>
+    <p class="invite-code-form__hint">
         Enter your invite code to access the game.
     </p>
 
     {% if error %}
-    <div class="invite-error" role="alert"
-         style="color:#e53935; margin-bottom:1rem; font-size:0.9rem;">
+    <div class="invite-error" role="alert">
         {{ error }}
     </div>
     {% endif %}
@@ -22,7 +21,7 @@
           hx-target="#invite-code-form"
           hx-swap="outerHTML"
           aria-label="Enter invite code">
-        <div style="display:flex; flex-direction:column; align-items:center; gap:0.75rem;">
+        <div class="invite-code-form__fields">
             <label for="invite-code-input" class="sr-only">Invite code</label>
             <input id="invite-code-input"
                    name="code"
@@ -36,9 +35,7 @@
                    placeholder="e.g. A3X7KP9Q"
                    aria-label="Invite code"
                    aria-describedby="invite-code-hint"
-                   style="text-transform:uppercase; text-align:center; font-size:1.3rem;
-                          letter-spacing:0.15em; padding:0.6rem 1rem; width:14rem;
-                          font-family:monospace;">
+                   class="invite-code-form__input">
             <span id="invite-code-hint" class="sr-only">Enter the 8-character invite code you received</span>
             <button type="submit" class="btn btn--play-again" aria-label="Submit invite code">Enter Game</button>
         </div>


### PR DESCRIPTION
## Summary

- Extract inline styles from `landing.html` and `invite_code_form.html` into
  proper CSS classes (`landing-hero`, `invite-code-form` BEM hierarchy)
- Merge duplicate `:root` block — moon/loner CSS custom properties were in a
  second `:root` at line 1576; consolidated into the single declaration block
- Fix button hover grouping bug: `.btn--next-hand` and `.btn--next-step` were
  permanently styled with the hover background color due to incorrect selector
  grouping with `.btn--play-again:hover`; now correctly apply on `:hover` only
- Add missing moon-exchange interstitial CSS (`moon-exchange__*` BEM classes
  used in `moon_exchange.html` but previously unstyled)
- Add missing `.result-exchange`, `.exchange-title`, `.exchange-details`, and
  `.card-text` CSS for hand result moon exchange display
- Update `accessibility.css` selectors to cover new `.invite-code-form__input`

## Why

The browser game templates had accumulated inline `style` attributes (landing
page, invite code form), an incorrectly grouped CSS selector that applied hover
colors permanently, and several template partials using CSS classes that had no
corresponding rules. This polish pass brings consistency and correctness.

## Repro / Validation

```bash
# Tier 1 — template rendering
uv run python -m pytest tests/unit/hosted_play/test_partials.py -q
# 116 passed

# Full hosted_play tests
uv run python -m pytest tests/unit/hosted_play/ -q
# 2776 passed, 5 skipped

# Linting
make lint && make repo-lint
# Both pass
```

## Test plan

- [x] All 116 template partial tests pass (Jinja rendering)
- [x] All 2776 hosted_play unit tests pass
- [x] `make lint` + `make repo-lint` pass
- [x] Pre-existing flaky test (`test_ops_token_economy.py::TestAutoImport`) confirmed
  unrelated — fails identically on `main`

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
branch: browser/template-css-polish
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)