### PR TITLE
feat(ops): wire inbound ack parsing into monitor module (#1826)

### DIFF
--- a/src/bid_euchre/ops/monitor.py
+++ b/src/bid_euchre/ops/monitor.py
@@ -1981,3 +1981,111 @@ def evaluate_alert_push(
         logger.warning("Alert push evaluation failed", exc_info=True)
 
     return MonitorCycleResult(findings=findings, push_result=push_result)
+
+
+# ---------------------------------------------------------------------------
+# Inbound ack integration (Platform-9a)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class InboundAckResult:
+    """Result of processing an inbound message for ack commands.
+
+    Attributes:
+        is_ack_command: Whether the inbound text was a recognized ack command.
+        success: Whether the ack mutation succeeded (False for non-commands).
+        reply_text: Formatted confirmation/error text for replying to the
+            operator, or ``None`` if the message was not an ack command.
+        item_id: The full item_id that was matched (if any).
+        action: The action string (ack/dismiss/mute/clear) or ``None``.
+    """
+
+    is_ack_command: bool
+    success: bool = False
+    reply_text: str | None = None
+    item_id: str | None = None
+    action: str | None = None
+
+
+def process_inbound_ack(
+    text: str,
+    *,
+    runtime_dir: Path | None = None,
+) -> InboundAckResult:
+    """Process an inbound Telegram message for ack/dismiss/mute/clear commands.
+
+    This function bridges the inbound Telegram message path and the remote ack
+    parser from :mod:`~bid_euchre.ops.remote_ack`.  It is designed to be called
+    when the orchestrator receives an inbound message that may contain an ack
+    command (e.g., ``ack abc1``).
+
+    The full pipeline:
+
+    1. Parse the inbound text via :func:`~bid_euchre.ops.remote_ack.parse_ack_command`.
+    2. If not a command, return immediately (passthrough for free-form conversation).
+    3. Load the fleet status from disk.
+    4. Execute the ack mutation via :func:`~bid_euchre.ops.remote_ack.execute_remote_ack`.
+    5. If the mutation succeeded, save the updated fleet status to disk.
+    6. Format a confirmation message via :func:`~bid_euchre.ops.remote_ack.format_ack_confirmation`.
+
+    The **caller** is responsible for:
+    - Auditing the inbound message (via :func:`~bid_euchre.ops.audit_trail.audit_channel_tag`).
+    - Sending ``result.reply_text`` back to the operator via Telegram MCP ``reply``.
+    - Auditing the outbound confirmation (via :func:`~bid_euchre.ops.audit_trail.audit_reply`).
+
+    Args:
+        text: The inbound message text to parse.
+        runtime_dir: Override for the runtime directory root (for fleet status I/O).
+
+    Returns:
+        An :class:`InboundAckResult` indicating whether the message was an ack
+        command, whether the mutation succeeded, and the reply text.
+    """
+    from bid_euchre.ops.remote_ack import (
+        execute_remote_ack,
+        format_ack_confirmation,
+        parse_ack_command,
+    )
+
+    # Step 1: Parse the ack command.
+    cmd = parse_ack_command(text)
+    if cmd is None:
+        return InboundAckResult(is_ack_command=False)
+
+    # Step 2: Load the fleet status from disk.
+    from bid_euchre.ops.control_plane import load_fleet_status, save_fleet_status
+
+    fleet_status = load_fleet_status(runtime_dir)
+    if fleet_status is None:
+        logger.warning("process_inbound_ack: no fleet status available")
+        return InboundAckResult(
+            is_ack_command=True,
+            success=False,
+            reply_text="\u274c No fleet status available — cannot process ack command.",
+            action=cmd.action.value,
+        )
+
+    # Step 3: Execute the ack mutation.
+    ack_result = execute_remote_ack(cmd, fleet_status)
+
+    # Step 4: Save if mutation succeeded.
+    if ack_result.success:
+        try:
+            save_fleet_status(fleet_status, runtime_dir=runtime_dir)
+        except Exception:
+            logger.warning(
+                "process_inbound_ack: failed to save fleet status after mutation",
+                exc_info=True,
+            )
+
+    # Step 5: Format confirmation.
+    reply_text = format_ack_confirmation(ack_result)
+
+    return InboundAckResult(
+        is_ack_command=True,
+        success=ack_result.success,
+        reply_text=reply_text,
+        item_id=ack_result.item_id,
+        action=cmd.action.value,
+    )

--- a/tests/unit/test_ops_monitor.py
+++ b/tests/unit/test_ops_monitor.py
@@ -3837,3 +3837,233 @@ class TestAlertPushAckE2E:
         r2 = execute_remote_ack(cmd, status2)
         assert not r2.success
         assert "cannot be" in r2.message.lower() or "already" in r2.message.lower()
+
+
+# ---------------------------------------------------------------------------
+# process_inbound_ack tests (Platform-9a — inbound ack wiring)
+# ---------------------------------------------------------------------------
+
+
+class TestProcessInboundAck:
+    """Tests for process_inbound_ack() — the monitor-level ack handler."""
+
+    @staticmethod
+    def _write_fleet_status(runtime_dir: Path, items: list[dict]) -> None:
+        """Write a minimal fleet_status.json to disk."""
+        from bid_euchre.ops.control_plane import (
+            ActionableItem,
+            FleetStatus,
+            save_fleet_status,
+        )
+
+        fleet_items = []
+        for raw in items:
+            fleet_items.append(
+                ActionableItem(
+                    item_id=raw["item_id"],
+                    severity=raw.get("severity", "high"),
+                    category=raw.get("category", "lane_health"),
+                    source=raw.get("source", "monitor"),
+                    summary=raw.get("summary", "Test alert"),
+                    first_seen_at="2026-03-27T00:00:00Z",
+                    last_seen_at="2026-03-27T00:00:00Z",
+                    state=raw.get("state", "open"),
+                )
+            )
+        status = FleetStatus(
+            items=fleet_items,
+            generated_at="2026-03-27T00:00:00Z",
+            cycle_count=1,
+        )
+        save_fleet_status(status, runtime_dir=runtime_dir)
+
+    def test_non_command_passthrough(self, tmp_path: Path) -> None:
+        """Free-form text returns is_ack_command=False, no reply_text."""
+        from bid_euchre.ops.monitor import process_inbound_ack
+
+        result = process_inbound_ack("How's the fleet?", runtime_dir=tmp_path)
+        assert result.is_ack_command is False
+        assert result.success is False
+        assert result.reply_text is None
+
+    def test_ack_command_mutates_and_persists(self, tmp_path: Path) -> None:
+        """'ack <prefix>' mutates fleet status and saves to disk."""
+        from bid_euchre.ops.control_plane import load_fleet_status
+        from bid_euchre.ops.monitor import process_inbound_ack
+
+        self._write_fleet_status(
+            tmp_path,
+            [{"item_id": "abc123def456", "summary": "Stall on author-b"}],
+        )
+
+        result = process_inbound_ack("ack abc1", runtime_dir=tmp_path)
+
+        assert result.is_ack_command is True
+        assert result.success is True
+        assert result.item_id == "abc123def456"
+        assert result.action == "ack"
+        assert result.reply_text is not None
+        assert "\u2705" in result.reply_text  # checkmark
+        assert "Stall on author-b" in result.reply_text
+
+        # Verify persistence — reload from disk.
+        reloaded = load_fleet_status(tmp_path)
+        assert reloaded is not None
+        acked = [i for i in reloaded.items if i.state == "acked"]
+        assert len(acked) == 1
+        assert acked[0].item_id == "abc123def456"
+
+    def test_dismiss_command(self, tmp_path: Path) -> None:
+        """'dismiss <prefix>' suppresses the item."""
+        from bid_euchre.ops.control_plane import load_fleet_status
+        from bid_euchre.ops.monitor import process_inbound_ack
+
+        self._write_fleet_status(
+            tmp_path,
+            [{"item_id": "abc123def456", "summary": "CI flaky"}],
+        )
+
+        result = process_inbound_ack("dismiss abc1", runtime_dir=tmp_path)
+
+        assert result.is_ack_command is True
+        assert result.success is True
+        assert result.action == "dismiss"
+
+        reloaded = load_fleet_status(tmp_path)
+        assert reloaded is not None
+        suppressed = [i for i in reloaded.items if i.state == "suppressed"]
+        assert len(suppressed) == 1
+
+    def test_mute_command(self, tmp_path: Path) -> None:
+        """'mute <prefix>' suppresses the item (same as dismiss)."""
+        from bid_euchre.ops.monitor import process_inbound_ack
+
+        self._write_fleet_status(
+            tmp_path,
+            [{"item_id": "abc123def456"}],
+        )
+
+        result = process_inbound_ack("mute abc1", runtime_dir=tmp_path)
+
+        assert result.is_ack_command is True
+        assert result.success is True
+        assert result.action == "mute"
+
+    def test_clear_command(self, tmp_path: Path) -> None:
+        """'clear <prefix>' clears the item."""
+        from bid_euchre.ops.control_plane import load_fleet_status
+        from bid_euchre.ops.monitor import process_inbound_ack
+
+        self._write_fleet_status(
+            tmp_path,
+            [{"item_id": "abc123def456"}],
+        )
+
+        result = process_inbound_ack("clear abc1", runtime_dir=tmp_path)
+
+        assert result.is_ack_command is True
+        assert result.success is True
+        assert result.action == "clear"
+
+        reloaded = load_fleet_status(tmp_path)
+        assert reloaded is not None
+        cleared = [i for i in reloaded.items if i.state == "cleared"]
+        assert len(cleared) == 1
+
+    def test_no_fleet_status_returns_error(self, tmp_path: Path) -> None:
+        """Ack command with no fleet status on disk returns error reply."""
+        from bid_euchre.ops.monitor import process_inbound_ack
+
+        result = process_inbound_ack("ack abc1", runtime_dir=tmp_path)
+
+        assert result.is_ack_command is True
+        assert result.success is False
+        assert result.reply_text is not None
+        assert "No fleet status" in result.reply_text
+
+    def test_no_matching_item(self, tmp_path: Path) -> None:
+        """Ack with non-matching prefix returns error with cross-mark."""
+        from bid_euchre.ops.monitor import process_inbound_ack
+
+        self._write_fleet_status(
+            tmp_path,
+            [{"item_id": "abc123def456"}],
+        )
+
+        result = process_inbound_ack("ack fff000", runtime_dir=tmp_path)
+
+        assert result.is_ack_command is True
+        assert result.success is False
+        assert result.reply_text is not None
+        assert "\u274c" in result.reply_text
+
+    def test_ambiguous_prefix(self, tmp_path: Path) -> None:
+        """Ambiguous prefix returns error with candidates."""
+        from bid_euchre.ops.monitor import process_inbound_ack
+
+        self._write_fleet_status(
+            tmp_path,
+            [
+                {"item_id": "abc123000000", "summary": "Item 1"},
+                {"item_id": "abc123ffffff", "summary": "Item 2"},
+            ],
+        )
+
+        result = process_inbound_ack("ack abc123", runtime_dir=tmp_path)
+
+        assert result.is_ack_command is True
+        assert result.success is False
+        assert "Ambiguous" in (result.reply_text or "")
+
+    def test_already_acked_item(self, tmp_path: Path) -> None:
+        """Acking an already-acked item returns error."""
+        from bid_euchre.ops.monitor import process_inbound_ack
+
+        self._write_fleet_status(
+            tmp_path,
+            [{"item_id": "abc123def456", "state": "acked"}],
+        )
+
+        result = process_inbound_ack("ack abc1", runtime_dir=tmp_path)
+
+        assert result.is_ack_command is True
+        assert result.success is False
+        assert "cannot be" in (result.reply_text or "")
+
+    def test_case_insensitive(self, tmp_path: Path) -> None:
+        """Commands are case-insensitive."""
+        from bid_euchre.ops.monitor import process_inbound_ack
+
+        self._write_fleet_status(
+            tmp_path,
+            [{"item_id": "abc123def456"}],
+        )
+
+        result = process_inbound_ack("ACK ABC1", runtime_dir=tmp_path)
+
+        assert result.is_ack_command is True
+        assert result.success is True
+
+    def test_selective_ack_preserves_other_items(self, tmp_path: Path) -> None:
+        """Acking one item leaves others unchanged."""
+        from bid_euchre.ops.control_plane import load_fleet_status
+        from bid_euchre.ops.monitor import process_inbound_ack
+
+        self._write_fleet_status(
+            tmp_path,
+            [
+                {"item_id": "aaa111000000", "summary": "Item A"},
+                {"item_id": "bbb222000000", "summary": "Item B"},
+            ],
+        )
+
+        result = process_inbound_ack("ack bbb2", runtime_dir=tmp_path)
+
+        assert result.success is True
+        assert result.item_id == "bbb222000000"
+
+        reloaded = load_fleet_status(tmp_path)
+        assert reloaded is not None
+        states = {i.item_id: i.state for i in reloaded.items}
+        assert states["aaa111000000"] == "open"
+        assert states["bbb222000000"] == "acked"


### PR DESCRIPTION
## Summary

- Add `process_inbound_ack()` to `monitor.py` — the monitor-level handler that bridges inbound Telegram messages to the `remote_ack` parser and controller mutations
- Add `InboundAckResult` dataclass for structured return type
- Add 11 unit tests covering all ack command variants, error paths, and persistence

## Why

The push side of Platform-9a was wired in PR #1944 (`evaluate_alert_push()`), but the ack side had no monitor-level integration. The remote_ack module (`parse_ack_command`, `execute_remote_ack`, `format_ack_confirmation`) existed as pure logic, but nothing in the monitor loaded fleet status from disk, executed the mutation, saved it back, and returned a reply. This PR adds that missing glue function.

Closes the E4/E7 exit criteria gap from issue #1826: "live inbound ack consumer for `execute_remote_ack()`."

## What `process_inbound_ack()` does

1. Parses inbound text via `parse_ack_command()`
2. Returns immediately for non-command messages (passthrough)
3. Loads fleet status from disk via `load_fleet_status()`
4. Executes ack mutation via `execute_remote_ack()`
5. Saves mutated fleet status to disk if mutation succeeded
6. Returns `InboundAckResult` with `reply_text` the caller sends via Telegram

The caller is responsible for auditing (inbound + outbound) and sending the reply via MCP `reply` tool.

## Repro / Validation

```bash
# Targeted tests (Tier 1)
uv run python -m pytest tests/unit/test_ops_monitor.py::TestProcessInboundAck -xvs

# All remote ack tests
uv run python -m pytest tests/unit/test_ops_remote_ack.py tests/integration/test_remote_ack_loop.py tests/unit/test_ops_monitor.py::TestProcessInboundAck -xvs

# Full validation (Tier 2)
make check-quiet
```

## Tests

- 11 new unit tests in `TestProcessInboundAck`:
  - `test_non_command_passthrough` — free-form text returns `is_ack_command=False`
  - `test_ack_command_mutates_and_persists` — ack mutates state and saves to disk
  - `test_dismiss_command` — dismiss suppresses item
  - `test_mute_command` — mute suppresses item
  - `test_clear_command` — clear clears item
  - `test_no_fleet_status_returns_error` — no fleet status on disk returns error
  - `test_no_matching_item` — non-matching prefix returns error
  - `test_ambiguous_prefix` — ambiguous prefix returns error with candidates
  - `test_already_acked_item` — already-acked returns error
  - `test_case_insensitive` — commands are case-insensitive
  - `test_selective_ack_preserves_other_items` — acking one item leaves others open
- All 50 existing remote ack tests pass (unit + integration)
- 2 pre-existing failures in `test_ops_token_economy.py` (unrelated, reproducible on main)

## Worktree proof

```
pwd: Bid-Euchre-steward-author-b
Branch: ops/platform-9a-inbound-ack-wiring
```

## Scope

| File | Change |
|------|--------|
| `src/bid_euchre/ops/monitor.py` | Add `InboundAckResult` dataclass and `process_inbound_ack()` function |
| `tests/unit/test_ops_monitor.py` | Add `TestProcessInboundAck` class with 11 tests |

🤖 Generated with [Claude Code](https://claude.com/claude-code)