### PR TITLE
fix(ops): report save failures as ack failures in process_inbound_ack

### DIFF
--- a/src/bid_euchre/ops/monitor.py
+++ b/src/bid_euchre/ops/monitor.py
@@ -2078,6 +2078,16 @@ def process_inbound_ack(
                 "process_inbound_ack: failed to save fleet status after mutation",
                 exc_info=True,
             )
+            return InboundAckResult(
+                is_ack_command=True,
+                success=False,
+                reply_text=(
+                    "\u274c Ack processed but failed to persist — "
+                    "the change will be lost on next reload."
+                ),
+                item_id=ack_result.item_id,
+                action=cmd.action.value,
+            )
 
     # Step 5: Format confirmation.
     reply_text = format_ack_confirmation(ack_result)

--- a/tests/unit/test_ops_monitor.py
+++ b/tests/unit/test_ops_monitor.py
@@ -4067,3 +4067,25 @@ class TestProcessInboundAck:
         states = {i.item_id: i.state for i in reloaded.items}
         assert states["aaa111000000"] == "open"
         assert states["bbb222000000"] == "acked"
+
+    def test_save_failure_reports_ack_failure(self, tmp_path: Path) -> None:
+        """If save_fleet_status raises, process_inbound_ack returns failure."""
+        from unittest.mock import patch
+
+        from bid_euchre.ops.monitor import process_inbound_ack
+
+        self._write_fleet_status(
+            tmp_path,
+            [{"item_id": "abc123def456", "summary": "Stall on author-a"}],
+        )
+
+        with patch(
+            "bid_euchre.ops.control_plane.save_fleet_status",
+            side_effect=OSError("disk full"),
+        ):
+            result = process_inbound_ack("ack abc1", runtime_dir=tmp_path)
+
+        assert result.is_ack_command is True
+        assert result.success is False
+        assert "failed to persist" in (result.reply_text or "").lower()
+        assert result.item_id == "abc123def456"


### PR DESCRIPTION
## Summary

- Fix `process_inbound_ack()` to return `success=False` when `save_fleet_status()` raises, instead of silently confirming success
- Add test covering the persistence failure path

## Why

Codex review on PR #1959 identified a P1: if `save_fleet_status()` fails (disk full, permissions, etc.), the operator sees a ✅ confirmation for an ack that won't survive reload. The mutation is in-memory only and the same alert reappears on next cycle — a silent data loss.

This fix was committed to the PR #1959 branch but GitHub auto-merge squashed only the rebase commit before the fix landed. This is the follow-up PR for that missed fix.

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_ops_monitor.py::TestProcessInboundAck::test_save_failure_reports_ack_failure -v
```

## Tests

```
uv run python -m pytest tests/unit/test_ops_monitor.py -x -q
# 155 passed
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
git worktree list: (steward author-b persistent lane)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)