### PR TITLE
fix(ops): convention follow-ups for monitor and events tests (#1962, #1960)

### DIFF
--- a/src/bid_euchre/ops/monitor.py
+++ b/src/bid_euchre/ops/monitor.py
@@ -2082,8 +2082,8 @@ def process_inbound_ack(
                 is_ack_command=True,
                 success=False,
                 reply_text=(
-                    "\u274c Ack processed but failed to persist — "
-                    "the change will be lost on next reload."
+                    f"\u274c Ack {cmd.action.value} processed but failed to persist"
+                    " — the change will be lost on next reload."
                 ),
                 item_id=ack_result.item_id,
                 action=cmd.action.value,

--- a/tests/unit/test_ops_events.py
+++ b/tests/unit/test_ops_events.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import threading
-import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -273,25 +272,37 @@ class TestDrainEvents:
 
         Appends that start during drain must complete after drain releases
         the lock, ensuring the appended event survives.
+
+        Uses an Event signal from inside the drain's critical section (via
+        a patched Path.rename) so the append is guaranteed to start while
+        the drain holds the lock — no timing-dependent sleep.
         """
+        from unittest.mock import patch
+
         # Write initial events
         for i in range(3):
             append_event("task_completed", "test", "ops", {"i": i}, events_dir)
 
-        drain_started = threading.Event()
+        lock_held = threading.Event()
         drain_done = threading.Event()
         append_done = threading.Event()
 
+        _original_rename = Path.rename
+
+        def _signaling_rename(self_path: Path, target: str | Path) -> Path:
+            """Wrap Path.rename to signal that drain holds the lock."""
+            lock_held.set()
+            return _original_rename(self_path, target)
+
         def do_drain() -> None:
-            drain_started.set()
-            drain_events(events_dir)
+            with patch.object(Path, "rename", _signaling_rename):
+                drain_events(events_dir)
             drain_done.set()
 
         def do_append() -> None:
-            # Wait for drain to start, then try appending
-            drain_started.wait(timeout=5)
-            # Small delay to let drain acquire lock — generous for slow CI.
-            time.sleep(0.2)
+            # Wait until drain has acquired the lock (signaled from inside
+            # the critical section at the rename step).
+            lock_held.wait(timeout=5)
             append_event(
                 "ci_failure", "concurrent", "ops", {"concurrent": True}, events_dir
             )


### PR DESCRIPTION
## Plan
N/A — convention follow-up fixes from review findings.

## Summary
- Include `cmd.action.value` in the persistence-failure reply text so operators know which ack action failed (#1962)
- Replace sleep-based timing in `test_drain_serializes_with_concurrent_append` with deterministic Event-based coordination from inside the drain's critical section (#1960)

## Why
- The reply text omitted the action name, making it hard for operators to diagnose which ack failed
- The test used `time.sleep(0.2)` to hope the drain thread had acquired the lock — timing-dependent and flaky on slow CI

## Repro / Validation
**Command(s) run:**
```
uv run python -m pytest tests/unit/test_ops_events.py tests/unit/test_ops_monitor.py -x -v
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** Reply text includes action name; drain test uses Event signals instead of sleep
- **Verification command:** `uv run python -m pytest tests/unit/test_ops_events.py::TestEventDrainConcurrency::test_drain_serializes_with_concurrent_append tests/unit/test_ops_monitor.py::TestProcessInboundAck::test_save_failure_reports_ack_failure -x -v`
- **Expected result:** Both tests pass; grep for `time.sleep` in `test_ops_events.py` should find 0 results; grep for `cmd.action.value` in monitor.py reply_text should find 1 result

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_events.py tests/unit/test_ops_monitor.py -x` — 179 passed
- [x] `make check-quiet` — 2 pre-existing failures in `test_ops_token_economy.py` (unrelated, also fail on main)
- [ ] Other: N/A

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author  40e781be [fix/convention-followups-1962-1960]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

Closes #1962
Closes #1960

🤖 Generated with [Claude Code](https://claude.com/claude-code)