### PR TITLE
fix(web): Ace-high rank order + remove redundant test wait

### DIFF
--- a/src/bid_euchre/hosted_play/engine.py
+++ b/src/bid_euchre/hosted_play/engine.py
@@ -45,8 +45,11 @@ _TRICKS_PER_HAND = 10
 # Display suit order: Spades, Hearts, Diamonds, Clubs
 _SUIT_DISPLAY_ORDER: dict[str, int] = {"S": 0, "H": 1, "D": 2, "C": 3}
 
-# Within-suit rank order: J highest, then A-K-Q-T
+# Within-suit rank order: J highest, then A-K-Q-T (auction / trump suit)
 _RANK_DISPLAY_ORDER: dict[str, int] = {"J": 0, "A": 1, "K": 2, "Q": 3, "T": 4}
+
+# High-contract / non-trump rank order: A highest, then K-Q-J-T
+_RANK_DISPLAY_ORDER_HIGH: dict[str, int] = {"A": 0, "K": 1, "Q": 2, "J": 3, "T": 4}
 
 # Low-contract rank order: T highest, then J-Q-K-A
 _RANK_DISPLAY_ORDER_LOW: dict[str, int] = {"T": 0, "J": 1, "Q": 2, "K": 3, "A": 4}
@@ -66,8 +69,10 @@ def sort_hand_for_display(
       follow standard order (S > H > D > C).
 
     Within-suit ordering:
-    - Suit contracts: right bower > left bower > A > K > Q > (non-bower J) > T
-    - High / auction (no trump): J > A > K > Q > T
+    - Suit contracts (trump suit): right bower > left bower > A > K > Q > (non-bower J) > T
+    - Suit contracts (non-trump suits): A > K > Q > J > T
+    - High contracts (no trump, A high): A > K > Q > J > T
+    - Auction (no contract set): J > A > K > Q > T
     - Low contracts: T > J > Q > K > A
     """
 
@@ -94,7 +99,14 @@ def sort_hand_for_display(
                 rank_key = _RANK_DISPLAY_ORDER.get(card.rank, 99)
         elif contract_type == "low":
             rank_key = _RANK_DISPLAY_ORDER_LOW.get(card.rank, 99)
+        elif contract_type == "high" or (
+            contract_type == "suit" and trump and eff != trump
+        ):
+            # A-high: HIGH contracts have no bowers; non-trump suits in
+            # suit contracts also rank A above J.
+            rank_key = _RANK_DISPLAY_ORDER_HIGH.get(card.rank, 99)
         else:
+            # Auction (contract_type is None) — J-high default
             rank_key = _RANK_DISPLAY_ORDER.get(card.rank, 99)
 
         return (suit_key, rank_key)

--- a/tests/browser/test_smoke_suite.py
+++ b/tests/browser/test_smoke_suite.py
@@ -146,16 +146,14 @@ def test_start_game_bid_play_verify_score(
     # If in auction, submit a pass bid
     if has_bid_panel:
         page.click("button.pass-btn")
-        # Wait for the board to update after bid submission (HTMX swap)
+        # Wait for post-auction state — exclude #bid-panel since it is
+        # already visible and would make the wait resolve immediately
+        # before the HTMX swap completes.
         page.wait_for_selector(
-            "#trick-area, #hand-result, #match-result, #bid-panel",
+            "#trick-area, #hand-result, #match-result",
             timeout=10000,
         )
         _advance_next_steps(page)
-
-    # After passing (or if AI already completed auction), we should see
-    # either trick play or the hand result if AI wrapped up everything
-    page.wait_for_selector("#score-bar, #hand-result, #trick-area", timeout=15000)
 
     # Verify score bar is present during play
     score_bar = page.locator("#score-bar")

--- a/tests/unit/hosted_play/test_engine.py
+++ b/tests/unit/hosted_play/test_engine.py
@@ -1965,21 +1965,36 @@ class TestSortHandForDisplay:
         ranks = [c.rank for c in hand]
         assert ranks == ["T", "J", "Q", "K", "A"]
 
-    def test_high_contract_no_bower_awareness(self) -> None:
-        """High contract: no bowers, standard J-A-K-Q-T order."""
+    def test_high_contract_ace_high_order(self) -> None:
+        """High contract: no bowers, A-high order (A > K > Q > J > T)."""
         hand = [
             Card("H", "J"),
             Card("D", "J"),
             Card("H", "A"),
         ]
         sort_hand_for_display(hand, contract_type="high")
-        # Both Js stay in their printed suits, no bower movement
+        # Both Js stay in their printed suits, no bower movement.
+        # Ace ranks above J in HIGH contracts.
         result = [(c.suit, c.rank) for c in hand]
         assert result == [
-            ("H", "J"),
             ("H", "A"),
+            ("H", "J"),
             ("D", "J"),
         ]
+
+    def test_non_trump_suit_ace_high_in_suit_contract(self) -> None:
+        """Non-trump suits in suit contracts use A-high order."""
+        hand = [
+            Card("S", "J"),
+            Card("S", "A"),
+            Card("S", "T"),
+            Card("S", "K"),
+            Card("S", "Q"),
+        ]
+        sort_hand_for_display(hand, contract_type="suit", trump="H")
+        # Non-trump Spades: A > K > Q > J > T
+        ranks = [c.rank for c in hand]
+        assert ranks == ["A", "K", "Q", "J", "T"]
 
     def test_sort_is_stable_idempotent(self) -> None:
         """Sorting an already-sorted hand produces the same order."""


### PR DESCRIPTION
## Summary

- **#1940:** `sort_hand_for_display()` now uses A-high ordering (`A > K > Q > J > T`) for HIGH contracts and non-trump suits in suit contracts. Previously, J was always ranked highest regardless of context. Adds `_RANK_DISPLAY_ORDER_HIGH` constant.
- **#1938:** Removed `#bid-panel` from `wait_for_selector` after clicking pass in `test_smoke_suite.py` — the element was already visible, making the wait resolve immediately before the HTMX swap completed.

## Why

Convention follow-ups from prior browser game PRs. The rank display ordering was incorrect for non-bower contexts (HIGH contracts show A as highest rank, and non-trump suits in suit contracts have no bowers). The test wait was a no-op that could mask timing issues.

## Changes

| File | Change |
|------|--------|
| `src/bid_euchre/hosted_play/engine.py` | Add `_RANK_DISPLAY_ORDER_HIGH`, branch sort key logic for HIGH/non-trump |
| `tests/unit/hosted_play/test_engine.py` | Update HIGH test, add non-trump suit ordering test |
| `tests/browser/test_smoke_suite.py` | Remove `#bid-panel` from post-pass wait selector |

## Repro / Validation

```bash
# Tier 1: sort display tests
uv run python -m pytest tests/unit/hosted_play/test_engine.py -x -k "TestSortHand" -v

# Tier 2: full validation
make check-quiet
# 3 pre-existing failures in ops tests, 10,297 passed
```

## Tests

- `test_high_contract_ace_high_order` — verifies A ranks above J in HIGH contracts
- `test_non_trump_suit_ace_high_in_suit_contract` — verifies non-trump suits use A-high in suit contracts
- Existing tests (`test_within_suit_rank_order`, `test_right_bower_highest_in_trump`, etc.) still pass, confirming no regression

## Worktree proof

```
pwd: Bid-Euchre-steward-brws-author-a
branch: fix/browser-convention-followups-1940-1938
```

Closes #1940
Closes #1938

🤖 Generated with [Claude Code](https://claude.com/claude-code)