### PR TITLE
feat(ops): wire outbound push delivery into check-in skill (#1826)

### DIFF
--- a/.claude/skills/check-in/SKILL.md
+++ b/.claude/skills/check-in/SKILL.md
@@ -159,6 +159,49 @@ Examples:
     overlapping files (visible from their task packet `scope_declared`), flag
     this as a potential conflict even at low divergence counts.
 
+### Phase 2c — Alert Push Delivery (Platform-9a)
+
+> The monitoring infrastructure evaluates unresolved HIGH/URGENT items and
+> prepares Telegram push payloads when the operator may be away. The check-in
+> must deliver those payloads — the Python code produces them but cannot call
+> the Telegram MCP tool itself.
+
+13. **Run the monitoring cycle with push evaluation:**
+    ```bash
+    uv run python scripts/internal/ops.py monitor
+    ```
+    The monitor command:
+    - Collects lane, PR, and task findings
+    - Updates the controller projection (`fleet_status.json`)
+    - Evaluates whether an alert push is warranted
+    - Prints the push payload if one is ready (prefixed with
+      `📢 Alert push prepared`)
+
+14. **If the output contains a push payload, deliver it via Telegram.**
+    Look for output matching:
+    ```
+    📢 Alert push prepared (N items) → chat <chat_id>
+    <message text follows on subsequent lines>
+    ```
+    Then call the Telegram MCP reply tool to actually send it:
+    ```
+    mcp__plugin_telegram_telegram__reply(
+        chat_id="<chat_id from the monitor output>",
+        text="<the formatted message text>"
+    )
+    ```
+
+    **Skip conditions** (do NOT send):
+    - The monitor output does **not** contain a push payload — the push
+      evaluator already suppresses when fleet is active, Telegram is
+      disabled, or no items are eligible. No action needed.
+    - You have already sent this exact alert text earlier in the current
+      check-in cycle (avoid duplicate pushes on retry).
+
+    **Audit:** The `post-telegram-audit.sh` PostToolUse hook automatically
+    records every outbound Telegram MCP call in the audit trail JSONL. No
+    manual audit step is needed.
+
 ### Phase 3 — PR and CI Health
 
 9. **List open PRs:**
@@ -228,5 +271,9 @@ summarizer. During autonomous operation:
 - `.claude/agents/steward-orchestrator.md` — orchestrator role and message bus
 - `.claude/agents/steward-ops.md` — ops monitor and supervisor alerts
 - `src/bid_euchre/ops/message_bus.py` — inbox message types and lifecycle
+- `src/bid_euchre/ops/telegram_push.py` — `PushResult` and `run_push_cycle` (Platform-9a)
+- `src/bid_euchre/ops/monitor.py` — `evaluate_alert_push` returns `MonitorCycleResult`
+- `.claude/hooks/post-telegram-audit.sh` — automatic outbound audit recording
 - Issue #1569 — root cause: orchestrator missed 25+ HIGH alerts during
   overnight run because inbox was never polled
+- Issue #1826 — alert→push→ack loop (this wiring closes the outbound path)


### PR DESCRIPTION
## Summary

- Add Phase 2c (Alert Push Delivery) to the `/check-in` skill, closing the outbound leg of the alert→push→ack loop (#1826)
- Instructs the orchestrator agent to run the monitor cycle, detect push payloads, and deliver them via `mcp__plugin_telegram_telegram__reply`
- Adds references to Platform-9a infrastructure (`telegram_push.py`, `monitor.py`, audit hook)

## Why

`run_push_cycle()` and `evaluate_alert_push()` produce a ready-to-send `PushResult` with `chat_id` and `message`, but nothing previously told the orchestrator agent to actually send it via the Telegram MCP tool. The push payloads were computed and printed but never delivered to the operator's phone. This skill-level wiring change closes that gap.

## Scope

- **Only file changed:** `.claude/skills/check-in/SKILL.md`
- This is a skill-level (documentation) change — no Python code modified

## Validation

```bash
# Verify the file is valid markdown and the skill renders correctly
cat .claude/skills/check-in/SKILL.md

# Full validation (2 pre-existing failures in test_ops_token_economy.py — unrelated)
make check-quiet
# Result: 10297 passed, 2 failed (pre-existing), 57 skipped
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: ops/wire-outbound-push-checkin
```

## Test criteria

1. Phase 2c section exists in the check-in skill with clear Telegram MCP wiring instructions
2. Skip conditions documented (no payload, duplicate push)
3. Audit trail handling documented (automatic via PostToolUse hook)
4. References section includes Platform-9a infrastructure links

🤖 Generated with [Claude Code](https://claude.com/claude-code)