### PR TITLE
feat(ops): wire inbound ack routing from Telegram (#1826)

### DIFF
--- a/.claude/hooks/inbound-channel-audit.py
+++ b/.claude/hooks/inbound-channel-audit.py
@@ -1,18 +1,25 @@
 #!/usr/bin/env python3
-"""UserPromptSubmit hook: audit inbound <channel> tags to the audit trail.
+"""UserPromptSubmit hook: audit inbound <channel> tags and route ack commands.
 
 When a Telegram message arrives via the plugin, it appears in the conversation
 as a ``<channel source="telegram" chat_id="..." ...>body</channel>`` tag.
-This hook intercepts those tags at the UserPromptSubmit seam and calls
-``audit_channel_tag()`` to durably record each inbound exchange.
+This hook intercepts those tags at the UserPromptSubmit seam and:
+
+1. Calls ``audit_channel_tag()`` to durably record each inbound exchange.
+2. Calls ``process_inbound_ack()`` to check if the message is an ack command
+   (e.g. ``ack abc1``, ``dismiss xyz``, ``mute foo``, ``clear``).
+3. If an ack command was detected, injects the reply text via
+   ``additionalContext`` so the orchestrator sends confirmation back to
+   Telegram.
 
 Design constraints:
-- Best-effort: audit failures never block prompt submission.
+- Best-effort: audit/ack failures never block prompt submission.
 - Fast guard in the bash wrapper skips Python entirely when no ``<channel``
   tag is present in the prompt (common case ~0ms).
-- Uses ``uv run`` to access project imports (bid_euchre.ops.audit_trail).
+- Uses ``uv run`` to access project imports (bid_euchre.ops).
+- Lazy imports for project modules to keep the fast-exit path stdlib-only.
 
-Closes #1752.
+Closes #1752.  Part of #1826.
 """
 
 from __future__ import annotations
@@ -38,6 +45,9 @@ _CHANNEL_RE = re.compile(
     r"(<channel\s[^>]*>)(.*?)</channel>",
     re.DOTALL,
 )
+
+# Attribute extraction for chat_id/message_id from tag text.
+_ATTR_RE = re.compile(r'(\w+)="([^"]*)"')
 
 
 def _neutralise_inline_code(m: re.Match[str]) -> str:
@@ -79,8 +89,39 @@ def extract_channel_blocks(text: str) -> list[tuple[str, str]]:
     return [(m.group(1), m.group(2).strip()) for m in _CHANNEL_RE.finditer(cleaned)]
 
 
+def _parse_tag_attrs(tag_text: str) -> dict[str, str]:
+    """Extract ``key="value"`` attributes from a ``<channel ...>`` tag."""
+    return dict(_ATTR_RE.findall(tag_text))
+
+
+def _route_ack(body: str, tag_text: str) -> str | None:
+    """Try to route *body* through :func:`process_inbound_ack`.
+
+    Returns a formatted reply instruction string if the body was an ack command
+    and produced a reply, or ``None`` otherwise.
+
+    This function performs lazy imports to avoid loading project modules on the
+    fast path.
+    """
+    from bid_euchre.ops.monitor import process_inbound_ack  # noqa: E402
+
+    result = process_inbound_ack(body)
+    if not result.is_ack_command or not result.reply_text:
+        return None
+
+    # Extract chat_id so the orchestrator knows which Telegram chat to reply to.
+    attrs = _parse_tag_attrs(tag_text)
+    chat_id = attrs.get("chat_id", "")
+
+    parts = [f"TELEGRAM ACK REPLY (chat_id={chat_id}):"]
+    parts.append(result.reply_text)
+    if chat_id:
+        parts.append(f"→ Reply to Telegram chat {chat_id} with the above confirmation.")
+    return "\n".join(parts)
+
+
 def main() -> int:
-    """Entry point.  Reads UserPromptSubmit JSON from stdin, audits channel tags."""
+    """Entry point.  Reads UserPromptSubmit JSON from stdin, audits and routes."""
     raw = sys.stdin.read()
     if not raw:
         return 0
@@ -102,7 +143,10 @@ def main() -> int:
     # free of project imports.
     from bid_euchre.ops.audit_trail import audit_channel_tag  # noqa: E402
 
+    ack_replies: list[str] = []
+
     for tag_text, body in blocks:
+        # --- Audit ---
         try:
             rec = audit_channel_tag(tag_text, body)
             if rec:
@@ -112,6 +156,20 @@ def main() -> int:
                 )
         except Exception:  # noqa: BLE001 — best-effort
             pass
+
+        # --- Ack routing ---
+        try:
+            reply = _route_ack(body, tag_text)
+            if reply:
+                ack_replies.append(reply)
+        except Exception:  # noqa: BLE001 — best-effort, never block prompt
+            pass
+
+    # If any ack commands were detected, inject reply instructions as
+    # additionalContext so the orchestrator can relay confirmations.
+    if ack_replies:
+        context = "\n\n".join(ack_replies)
+        print(json.dumps({"additionalContext": context}))
 
     return 0
 

--- a/tests/unit/test_inbound_channel_audit.py
+++ b/tests/unit/test_inbound_channel_audit.py
@@ -1,16 +1,22 @@
-"""Unit tests for the inbound-channel-audit hook (issue #1763).
+"""Unit tests for the inbound-channel-audit hook (issue #1763, #1826).
 
 Tests cover:
 - extract_channel_blocks: closed vs unclosed tags, code-fence filtering
 - _strip_code_blocks: markdown fences and inline code removal
+- _parse_tag_attrs: attribute extraction from channel tags
+- _route_ack: ack command routing through process_inbound_ack
+- main: end-to-end hook with ack additionalContext injection
 """
 
 from __future__ import annotations
 
 import importlib
+import io
+import json
 import sys
 from pathlib import Path
 from types import ModuleType
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -236,3 +242,258 @@ class TestRegressionUnclosedSwallow:
             assert (
                 len(body) < 200
             ), f"Unclosed tag swallowed too much content ({len(body)} chars)"
+
+
+# ---------------------------------------------------------------------------
+# _parse_tag_attrs
+# ---------------------------------------------------------------------------
+
+
+class TestParseTagAttrs:
+    def test_extracts_all_attrs(self, hook: ModuleType) -> None:
+        tag = '<channel source="telegram" chat_id="123" message_id="42" user="alice" ts="2026-03-24T06:00:00Z">'
+        attrs = hook._parse_tag_attrs(tag)
+        assert attrs["source"] == "telegram"
+        assert attrs["chat_id"] == "123"
+        assert attrs["message_id"] == "42"
+        assert attrs["user"] == "alice"
+
+    def test_empty_tag(self, hook: ModuleType) -> None:
+        attrs = hook._parse_tag_attrs("<channel>")
+        assert attrs == {}
+
+    def test_partial_attrs(self, hook: ModuleType) -> None:
+        tag = '<channel source="telegram" chat_id="999">'
+        attrs = hook._parse_tag_attrs(tag)
+        assert attrs["chat_id"] == "999"
+        assert "message_id" not in attrs
+
+
+# ---------------------------------------------------------------------------
+# _route_ack — ack command routing
+# ---------------------------------------------------------------------------
+
+
+class TestRouteAck:
+    """Test ack routing through process_inbound_ack."""
+
+    def test_ack_command_returns_reply(self, hook: ModuleType) -> None:
+        """An ack command body should produce a reply instruction string."""
+        mock_result = MagicMock()
+        mock_result.is_ack_command = True
+        mock_result.reply_text = "✅ Acked alert abc123"
+
+        with patch(
+            "bid_euchre.ops.monitor.process_inbound_ack",
+            return_value=mock_result,
+        ):
+            tag = '<channel source="telegram" chat_id="555" message_id="10" user="op" ts="t">'
+            reply = hook._route_ack("ack abc1", tag)
+
+        assert reply is not None
+        assert "TELEGRAM ACK REPLY" in reply
+        assert "chat_id=555" in reply
+        assert "✅ Acked alert abc123" in reply
+        assert "Reply to Telegram chat 555" in reply
+
+    def test_non_ack_message_returns_none(self, hook: ModuleType) -> None:
+        """Non-ack messages should return None (passthrough)."""
+        mock_result = MagicMock()
+        mock_result.is_ack_command = False
+        mock_result.reply_text = None
+
+        with patch(
+            "bid_euchre.ops.monitor.process_inbound_ack",
+            return_value=mock_result,
+        ):
+            tag = '<channel source="telegram" chat_id="555">'
+            reply = hook._route_ack("Hello, how are things?", tag)
+
+        assert reply is None
+
+    def test_ack_command_no_reply_text_returns_none(self, hook: ModuleType) -> None:
+        """Ack command that produces no reply text should return None."""
+        mock_result = MagicMock()
+        mock_result.is_ack_command = True
+        mock_result.reply_text = None
+
+        with patch(
+            "bid_euchre.ops.monitor.process_inbound_ack",
+            return_value=mock_result,
+        ):
+            tag = '<channel source="telegram" chat_id="555">'
+            reply = hook._route_ack("ack xyz", tag)
+
+        assert reply is None
+
+    def test_missing_chat_id_still_works(self, hook: ModuleType) -> None:
+        """Reply should still be generated even without a chat_id."""
+        mock_result = MagicMock()
+        mock_result.is_ack_command = True
+        mock_result.reply_text = "✅ Acked"
+
+        with patch(
+            "bid_euchre.ops.monitor.process_inbound_ack",
+            return_value=mock_result,
+        ):
+            tag = '<channel source="telegram">'
+            reply = hook._route_ack("ack abc1", tag)
+
+        assert reply is not None
+        assert "TELEGRAM ACK REPLY (chat_id=)" in reply
+        assert "✅ Acked" in reply
+        # No "Reply to Telegram chat" line when chat_id is empty
+        assert "Reply to Telegram chat" not in reply
+
+
+# ---------------------------------------------------------------------------
+# main — end-to-end hook with ack additionalContext injection
+# ---------------------------------------------------------------------------
+
+
+class TestMainAckRouting:
+    """Test the main() function produces additionalContext for ack commands."""
+
+    def _run_main(self, hook: ModuleType, prompt: str) -> tuple[int, str]:
+        """Run hook.main() with a given prompt, capturing stdout."""
+        data = json.dumps({"user_prompt": prompt})
+        captured = io.StringIO()
+        with (
+            patch("sys.stdin", io.StringIO(data)),
+            patch("sys.stdout", captured),
+        ):
+            rc = hook.main()
+        return rc, captured.getvalue()
+
+    def test_ack_command_injects_additional_context(self, hook: ModuleType) -> None:
+        """An ack command in a Telegram tag should produce additionalContext JSON."""
+        mock_ack_result = MagicMock()
+        mock_ack_result.is_ack_command = True
+        mock_ack_result.reply_text = "✅ Acked alert item_abc"
+
+        mock_audit_rec = MagicMock()
+        mock_audit_rec.exchange_id = "ex_001"
+
+        prompt = '<channel source="telegram" chat_id="42" message_id="7" user="op" ts="t">ack abc</channel>'
+
+        with (
+            patch(
+                "bid_euchre.ops.audit_trail.audit_channel_tag",
+                return_value=mock_audit_rec,
+            ),
+            patch(
+                "bid_euchre.ops.monitor.process_inbound_ack",
+                return_value=mock_ack_result,
+            ),
+        ):
+            rc, stdout = self._run_main(hook, prompt)
+
+        assert rc == 0
+        assert stdout.strip()  # Should have output
+        output = json.loads(stdout.strip())
+        assert "additionalContext" in output
+        ctx = output["additionalContext"]
+        assert "TELEGRAM ACK REPLY" in ctx
+        assert "chat_id=42" in ctx
+        assert "✅ Acked alert item_abc" in ctx
+
+    def test_non_ack_message_no_additional_context(self, hook: ModuleType) -> None:
+        """A regular (non-ack) Telegram message should not inject additionalContext."""
+        mock_ack_result = MagicMock()
+        mock_ack_result.is_ack_command = False
+        mock_ack_result.reply_text = None
+
+        mock_audit_rec = MagicMock()
+        mock_audit_rec.exchange_id = "ex_002"
+
+        prompt = '<channel source="telegram" chat_id="42" message_id="7" user="op" ts="t">Hello, checking in</channel>'
+
+        with (
+            patch(
+                "bid_euchre.ops.audit_trail.audit_channel_tag",
+                return_value=mock_audit_rec,
+            ),
+            patch(
+                "bid_euchre.ops.monitor.process_inbound_ack",
+                return_value=mock_ack_result,
+            ),
+        ):
+            rc, stdout = self._run_main(hook, prompt)
+
+        assert rc == 0
+        # No additionalContext output for non-ack messages
+        clean = stdout.strip()
+        if clean:
+            parsed = json.loads(clean)
+            assert "additionalContext" not in parsed
+
+    def test_no_channel_tags_fast_exit(self, hook: ModuleType) -> None:
+        """Prompts without channel tags should exit immediately with no output."""
+        rc, stdout = self._run_main(hook, "Just a normal prompt with no tags")
+        assert rc == 0
+        assert stdout.strip() == ""
+
+    def test_ack_routing_failure_does_not_block(self, hook: ModuleType) -> None:
+        """If process_inbound_ack raises, the hook should still return 0."""
+        mock_audit_rec = MagicMock()
+        mock_audit_rec.exchange_id = "ex_003"
+
+        prompt = '<channel source="telegram" chat_id="42" message_id="7" user="op" ts="t">ack abc</channel>'
+
+        with (
+            patch(
+                "bid_euchre.ops.audit_trail.audit_channel_tag",
+                return_value=mock_audit_rec,
+            ),
+            patch(
+                "bid_euchre.ops.monitor.process_inbound_ack",
+                side_effect=RuntimeError("Simulated failure"),
+            ),
+        ):
+            rc, stdout = self._run_main(hook, prompt)
+
+        assert rc == 0  # Best-effort — never block
+
+    def test_multiple_tags_one_ack(self, hook: ModuleType) -> None:
+        """Multiple channel tags where only one is an ack command."""
+        ack_result = MagicMock()
+        ack_result.is_ack_command = True
+        ack_result.reply_text = "✅ Dismissed alert xyz"
+
+        non_ack_result = MagicMock()
+        non_ack_result.is_ack_command = False
+        non_ack_result.reply_text = None
+
+        mock_audit_rec = MagicMock()
+        mock_audit_rec.exchange_id = "ex_004"
+
+        prompt = (
+            '<channel source="telegram" chat_id="10" message_id="1" user="a" ts="t">Hello</channel>\n'
+            '<channel source="telegram" chat_id="10" message_id="2" user="a" ts="t">dismiss xyz</channel>'
+        )
+
+        call_count = [0]
+
+        def mock_process(text, **kwargs):
+            call_count[0] += 1
+            if "dismiss" in text:
+                return ack_result
+            return non_ack_result
+
+        with (
+            patch(
+                "bid_euchre.ops.audit_trail.audit_channel_tag",
+                return_value=mock_audit_rec,
+            ),
+            patch(
+                "bid_euchre.ops.monitor.process_inbound_ack",
+                side_effect=mock_process,
+            ),
+        ):
+            rc, stdout = self._run_main(hook, prompt)
+
+        assert rc == 0
+        assert call_count[0] == 2  # Both bodies processed
+        output = json.loads(stdout.strip())
+        ctx = output["additionalContext"]
+        assert "✅ Dismissed alert xyz" in ctx


### PR DESCRIPTION
## Summary
- Wire Telegram ack commands (ack/dismiss/mute/clear) through `process_inbound_ack()` in the `inbound-channel-audit.py` UserPromptSubmit hook
- When an ack command is detected, inject reply text via `additionalContext` so the orchestrator relays confirmation back to Telegram
- Add 12 new unit tests covering `_parse_tag_attrs`, `_route_ack`, and end-to-end `main()` with ack routing

## Why
The inbound-channel-audit hook currently only audits incoming Telegram messages but does not route ack commands to `process_inbound_ack()`. This means remote ack/dismiss/mute/clear commands from Telegram are detected but never executed. This PR closes the gap by adding ack routing as a second processing step after audit, completing the inbound ack pipeline for #1826.

## Scope
- `.claude/hooks/inbound-channel-audit.py` — added `_parse_tag_attrs()`, `_route_ack()`, and ack routing in `main()`
- `tests/unit/test_inbound_channel_audit.py` — added `TestParseTagAttrs`, `TestRouteAck`, `TestMainAckRouting` classes

## How it works
1. After auditing each channel tag (existing behavior), call `_route_ack(body, tag_text)`
2. `_route_ack` lazy-imports `process_inbound_ack` from `bid_euchre.ops.monitor`
3. If the body is an ack command and produces a reply, format it with chat_id extracted from the tag
4. Collect all ack replies and output as `{"additionalContext": "..."}` JSON
5. All ack routing is best-effort — failures never block prompt submission

## Repro / Validation
```bash
# Tier 1 — targeted tests (31 pass, 0.14s)
uv run python -m pytest tests/unit/test_inbound_channel_audit.py -v

# Tier 2 — full validation
make check-quiet
# 2 pre-existing flaky failures in test_ops_token_economy.py (unrelated)
# 10312 passed, 56 skipped
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
branch: ops/wire-inbound-ack-routing
```

## Test criteria
- [ ] All 31 tests in `test_inbound_channel_audit.py` pass
- [ ] Ack command in Telegram tag produces `additionalContext` JSON on stdout
- [ ] Non-ack messages produce no `additionalContext` output
- [ ] Ack routing failures do not block prompt submission (best-effort)
- [ ] Multiple tags with mixed ack/non-ack handled correctly

Part of #1826.

🤖 Generated with [Claude Code](https://claude.com/claude-code)