### PR TITLE
fix(ops): add process cleanup to park and task completion (#1951)

### DIFF
--- a/.claude/hooks/post-merge-notify.sh
+++ b/.claude/hooks/post-merge-notify.sh
@@ -152,7 +152,18 @@ except Exception as exc:
     print(f'post-merge-notify: task transition failed: {exc}', file=sys.stderr)
     _transition_failed = True
 
-# 2. Send completion message to orchestrator via message bus (advisory)
+# 2. Clean up orphaned build/test processes from this lane's worktree.
+#    Prevents pytest/make/uv accumulation across fleet task cycles (#1951).
+if lane_id:
+    try:
+        from bid_euchre.ops.worker_pool import cleanup_lane_processes
+        killed = cleanup_lane_processes(lane_id)
+        if killed:
+            print(f'post-merge-notify: cleaned up {len(killed)} orphaned process(es)', file=sys.stderr)
+    except Exception as exc:
+        print(f'post-merge-notify: process cleanup failed: {exc}', file=sys.stderr)
+
+# 3. Send completion message to orchestrator via message bus (advisory)
 from_lane = lane_id or 'unknown'
 suffix = ' (auto-merge)' if auto_merge else ''
 payload = {'pr_number': pr_num, 'packet_id': packet_id}

--- a/.claude/skills/park/SKILL.md
+++ b/.claude/skills/park/SKILL.md
@@ -25,13 +25,33 @@ and sending alerts to an orchestrator that has stopped reading them.
 
 ## Workflow
 
-### Step 1 — List Active Cron Jobs
+### Step 1 — Kill Orphaned Build/Test Processes
+
+Before cleaning up cron jobs, kill any orphaned pytest, make, or uv processes
+that were spawned from this lane's worktree. These accumulate during fleet runs
+and exhaust system memory if not cleaned up.
+
+```bash
+uv run python -c "
+from bid_euchre.ops.worker_pool import cleanup_lane_processes
+killed = cleanup_lane_processes('<lane_id>')
+print(f'Killed {len(killed)} orphaned process(es)')
+"
+```
+
+Replace `<lane_id>` with the lane identity (e.g., `author-a`, `brws-author-b`).
+This is safe to run even if no orphaned processes exist (returns empty list).
+
+**Note:** `park_worker()` also calls this automatically when invoked
+programmatically, so this step is primarily for manual `/park` usage.
+
+### Step 2 — List Active Cron Jobs
 
 Use `CronList` to see all active cron jobs in this session.
 
-If no cron jobs are listed, skip to Step 3.
+If no cron jobs are listed, skip to Step 4.
 
-### Step 2 — Delete Each Cron Job
+### Step 3 — Delete Each Cron Job
 
 For **every** cron job returned by CronList, call `CronDelete` with its ID
 to stop it. Do not skip any — even jobs that look harmless will continue
@@ -46,20 +66,21 @@ CronDelete job_id_1
 CronDelete job_id_2
 ```
 
-### Step 3 — Verify Cleanup
+### Step 4 — Verify Cleanup
 
 Call `CronList` again to confirm the list is empty. If any jobs remain,
-repeat Step 2 for the stragglers.
+repeat Step 3 for the stragglers.
 
-### Step 4 — Confirm Parked
+### Step 5 — Confirm Parked
 
 Report the shutdown result:
+- How many orphaned processes were killed (Step 1)
 - How many cron jobs were deleted
 - Confirmation that CronList is now empty
 - The lane is safe to `/clear`
 
 Do **not** automatically run `/clear` — let the operator or orchestrator
-decide when to clear context. The park skill's job is cron cleanup only.
+decide when to clear context. The park skill's job is process + cron cleanup.
 
 ## Orchestrator Usage
 

--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -24,6 +24,7 @@ Usage::
         dispatch_to_worker,
         nudge_pane,
         run_pool_maintenance,
+        cleanup_lane_processes,
     )
 
     pool = take_pool_snapshot()
@@ -35,7 +36,9 @@ Usage::
 from __future__ import annotations
 
 import logging
+import os
 import shutil
+import signal
 import subprocess
 import time
 from dataclasses import asdict, dataclass, field
@@ -411,6 +414,186 @@ def _resolve_worktree_path(
     for lane in report.lanes:
         if lane.lane_id == lane_id:
             return lane.worktree_path
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Process cleanup
+# ---------------------------------------------------------------------------
+
+#: Process name patterns eligible for cleanup.  Only processes whose command
+#: line matches one of these AND contains the worktree path are killed.
+_CLEANUP_PROCESS_PATTERNS: tuple[str, ...] = ("pytest", "make", "python", "uv")
+
+
+def cleanup_lane_processes(
+    lane_id: str,
+    *,
+    runtime_dir: Path | None = None,
+    dry_run: bool = False,
+) -> list[int]:
+    """Kill orphaned build/test processes spawned from a lane's worktree.
+
+    Finds ``pytest``, ``make``, ``python``, and ``uv`` processes whose command
+    line contains the lane's worktree path, then sends SIGTERM.  The current
+    process (PID) and its parent are excluded to avoid self-termination.
+
+    This is called automatically during :func:`park_worker` and from the
+    post-merge notification hook to prevent process accumulation during
+    fleet runs.
+
+    Args:
+        lane_id: Lane whose orphaned processes should be cleaned up.
+        runtime_dir: Override for the runtime directory root.
+        dry_run: If True, identify processes but do not kill them.
+
+    Returns:
+        List of PIDs that were killed (or would be killed in dry_run mode).
+    """
+    if runtime_dir is None:
+        runtime_dir = Path(".claude/runtime")
+
+    worktree_path = _resolve_worktree_path(lane_id, runtime_dir)
+    if not worktree_path:
+        logger.debug(
+            "cleanup_lane_processes: no worktree path for %s, skipping",
+            lane_id,
+        )
+        return []
+
+    # Normalise so we match regardless of trailing slash
+    wt_path = str(Path(worktree_path).resolve())
+
+    own_pid = os.getpid()
+    parent_pid = os.getppid()
+    exclude_pids = {own_pid, parent_pid}
+
+    killed: list[int] = []
+
+    for pattern in _CLEANUP_PROCESS_PATTERNS:
+        pids = _find_matching_pids(pattern, wt_path, exclude_pids)
+        for pid in pids:
+            if dry_run:
+                logger.info(
+                    "cleanup_lane_processes [dry-run]: would kill PID %d "
+                    "(pattern=%s, lane=%s)",
+                    pid,
+                    pattern,
+                    lane_id,
+                )
+            else:
+                try:
+                    os.kill(pid, signal.SIGTERM)
+                    logger.info(
+                        "cleanup_lane_processes: killed PID %d (pattern=%s, lane=%s)",
+                        pid,
+                        pattern,
+                        lane_id,
+                    )
+                except (ProcessLookupError, PermissionError) as exc:
+                    logger.debug(
+                        "cleanup_lane_processes: could not kill PID %d: %s",
+                        pid,
+                        exc,
+                    )
+                    continue
+            killed.append(pid)
+
+    if killed:
+        logger.info(
+            "cleanup_lane_processes: %s %d process(es) for lane %s",
+            "would kill" if dry_run else "killed",
+            len(killed),
+            lane_id,
+        )
+    return killed
+
+
+def _find_matching_pids(
+    process_pattern: str,
+    worktree_path: str,
+    exclude_pids: set[int],
+) -> list[int]:
+    """Find PIDs matching a process pattern whose cmdline contains the worktree path.
+
+    Uses ``pgrep -f`` for a two-stage match: the process pattern narrows
+    candidates, then the worktree path filters to lane-specific processes.
+
+    Args:
+        process_pattern: Process name pattern (e.g., ``"pytest"``).
+        worktree_path: Resolved worktree path to match in command lines.
+        exclude_pids: PIDs to skip (self and parent).
+
+    Returns:
+        List of matching PIDs, excluding those in *exclude_pids*.
+    """
+    # pgrep -f matches against the full command line.  We search for the
+    # process pattern first, then filter by worktree path in a second pass
+    # using /proc or ps to read the full command line.
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", process_pattern],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        # pgrep exits 1 when no processes match — not an error.
+        if result.returncode not in (0, 1):
+            return []
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return []
+
+    candidate_pids: list[int] = []
+    for line in result.stdout.strip().splitlines():
+        line = line.strip()
+        if line.isdigit():
+            pid = int(line)
+            if pid not in exclude_pids:
+                candidate_pids.append(pid)
+
+    if not candidate_pids:
+        return []
+
+    # Second pass: verify each candidate's command line contains the worktree path.
+    matched: list[int] = []
+    for pid in candidate_pids:
+        cmdline = _read_cmdline(pid)
+        if cmdline and worktree_path in cmdline:
+            matched.append(pid)
+    return matched
+
+
+def _read_cmdline(pid: int) -> str | None:
+    """Read the full command line for a PID.
+
+    Tries ``/proc/<pid>/cmdline`` first (Linux), falls back to
+    ``ps -p <pid> -o args=`` (macOS/BSD).
+
+    Returns:
+        The command line as a string, or None if unreadable.
+    """
+    # Try /proc (Linux)
+    proc_path = Path(f"/proc/{pid}/cmdline")
+    try:
+        raw = proc_path.read_bytes()
+        if raw:
+            return raw.replace(b"\x00", b" ").decode("utf-8", errors="replace")
+    except (FileNotFoundError, PermissionError, OSError):
+        pass
+
+    # Fallback: ps (macOS/BSD)
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "args="],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+
     return None
 
 
@@ -880,13 +1063,21 @@ def park_worker(
             error="has_active_task",
         )
 
+    # Clean up orphaned build/test processes before parking.
+    # This prevents pytest/make/uv processes from accumulating across
+    # fleet runs when lanes are parked and re-dispatched.
+    killed_pids = cleanup_lane_processes(lane_id, runtime_dir=runtime_dir)
+    cleanup_note = (
+        f"; killed {len(killed_pids)} orphaned process(es)" if killed_pids else ""
+    )
+
     # Set visibility to hidden
     set_lane_visibility(lane_id, "hidden", runtime_dir)
 
     return PoolAction(
         action="park",
         lane_id=lane_id,
-        reason="Set visibility to hidden; tmux pane left running",
+        reason=f"Set visibility to hidden; tmux pane left running{cleanup_note}",
         executed=True,
     )
 

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from bid_euchre.ops.worker_pool import (
+    _CLEANUP_PROCESS_PATTERNS,
     _PASTE_BRACKET_DELAY,
     DEFAULT_TMUX_SESSION,
     IDLE_PARK_MINUTES,
@@ -22,13 +23,16 @@ from bid_euchre.ops.worker_pool import (
     WorkerState,
     _classify_pool_status,
     _dynamic_pane_lookup,
+    _find_matching_pids,
     _get_lane_task_id,
     _is_worktree_stale,
     _managed_lanes,
     _minutes_since,
     _probe_tmux_pane,
+    _read_cmdline,
     _resolve_agent_name,
     _resolve_tmux_target,
+    cleanup_lane_processes,
     clear_session,
     dispatch_to_worker,
     format_action_text,
@@ -3960,3 +3964,235 @@ class TestRefreshAllIdle:
         mock_refresh.assert_called_once_with(
             "flex-a", force=True, tmux_session="steward", runtime_dir=None
         )
+
+
+# ---------------------------------------------------------------------------
+# Process cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupLaneProcesses:
+    """Test cleanup_lane_processes() and helper functions."""
+
+    def test_patterns_include_expected(self) -> None:
+        """Verify cleanup targets the expected process types."""
+        assert "pytest" in _CLEANUP_PROCESS_PATTERNS
+        assert "make" in _CLEANUP_PROCESS_PATTERNS
+        assert "python" in _CLEANUP_PROCESS_PATTERNS
+        assert "uv" in _CLEANUP_PROCESS_PATTERNS
+
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path", return_value=None)
+    def test_no_worktree_returns_empty(
+        self,
+        mock_resolve: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """When worktree path can't be resolved, return empty list."""
+        result = cleanup_lane_processes("author-a", runtime_dir=runtime_dir)
+        assert result == []
+
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path", return_value="/tmp/fake-wt")
+    @patch(f"{_WORKER_POOL}._find_matching_pids", return_value=[])
+    def test_no_matching_processes(
+        self,
+        mock_find: MagicMock,
+        mock_resolve: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """When no matching processes, return empty list."""
+        result = cleanup_lane_processes("author-a", runtime_dir=runtime_dir)
+        assert result == []
+
+    @patch(f"{_WORKER_POOL}.os.kill")
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path", return_value="/tmp/fake-wt")
+    @patch(f"{_WORKER_POOL}._find_matching_pids")
+    def test_kills_matching_processes(
+        self,
+        mock_find: MagicMock,
+        mock_resolve: MagicMock,
+        mock_kill: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """Matching PIDs are sent SIGTERM."""
+        import signal
+
+        # Return PIDs for the first pattern, empty for the rest
+        mock_find.side_effect = [[42, 99], [], [], []]
+        result = cleanup_lane_processes("author-a", runtime_dir=runtime_dir)
+        assert result == [42, 99]
+        assert mock_kill.call_count == 2
+        mock_kill.assert_any_call(42, signal.SIGTERM)
+        mock_kill.assert_any_call(99, signal.SIGTERM)
+
+    @patch(f"{_WORKER_POOL}.os.kill")
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path", return_value="/tmp/fake-wt")
+    @patch(f"{_WORKER_POOL}._find_matching_pids")
+    def test_dry_run_does_not_kill(
+        self,
+        mock_find: MagicMock,
+        mock_resolve: MagicMock,
+        mock_kill: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """dry_run=True identifies but does not kill processes."""
+        mock_find.side_effect = [[42], [], [], []]
+        result = cleanup_lane_processes(
+            "author-a", runtime_dir=runtime_dir, dry_run=True
+        )
+        assert result == [42]
+        mock_kill.assert_not_called()
+
+    @patch(f"{_WORKER_POOL}.os.kill", side_effect=ProcessLookupError)
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path", return_value="/tmp/fake-wt")
+    @patch(f"{_WORKER_POOL}._find_matching_pids")
+    def test_handles_dead_process(
+        self,
+        mock_find: MagicMock,
+        mock_resolve: MagicMock,
+        mock_kill: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """ProcessLookupError (race condition) is handled gracefully."""
+        mock_find.side_effect = [[42], [], [], []]
+        result = cleanup_lane_processes("author-a", runtime_dir=runtime_dir)
+        # PID not added to killed list because the kill failed
+        assert result == []
+
+    @patch(f"{_WORKER_POOL}.os.kill", side_effect=PermissionError)
+    @patch(f"{_WORKER_POOL}._resolve_worktree_path", return_value="/tmp/fake-wt")
+    @patch(f"{_WORKER_POOL}._find_matching_pids")
+    def test_handles_permission_error(
+        self,
+        mock_find: MagicMock,
+        mock_resolve: MagicMock,
+        mock_kill: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """PermissionError is handled gracefully."""
+        mock_find.side_effect = [[42], [], [], []]
+        result = cleanup_lane_processes("author-a", runtime_dir=runtime_dir)
+        assert result == []
+
+
+class TestFindMatchingPids:
+    """Test _find_matching_pids() with mocked subprocess."""
+
+    @patch(f"{_WORKER_POOL}._read_cmdline")
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_filters_by_worktree_path(
+        self,
+        mock_run: MagicMock,
+        mock_cmdline: MagicMock,
+    ) -> None:
+        """Only PIDs whose cmdline contains the worktree path are returned."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="100\n200\n300\n",
+        )
+        mock_cmdline.side_effect = [
+            "python -m pytest /tmp/wt-author-a/tests",
+            "python /other/path/script.py",
+            "uv run /tmp/wt-author-a/experiments/run.py",
+        ]
+        result = _find_matching_pids("pytest", "/tmp/wt-author-a", set())
+        assert result == [100, 300]
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_pgrep_no_match(
+        self,
+        mock_run: MagicMock,
+    ) -> None:
+        """pgrep exit code 1 (no matches) returns empty list."""
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        result = _find_matching_pids("pytest", "/tmp/wt", set())
+        assert result == []
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_excludes_specified_pids(
+        self,
+        mock_run: MagicMock,
+    ) -> None:
+        """PIDs in exclude_pids are filtered out before cmdline check."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="100\n200\n",
+        )
+        result = _find_matching_pids("pytest", "/tmp/wt", {100, 200})
+        assert result == []
+
+    @patch(f"{_WORKER_POOL}.subprocess.run", side_effect=FileNotFoundError)
+    def test_pgrep_not_found(
+        self,
+        mock_run: MagicMock,
+    ) -> None:
+        """Missing pgrep binary returns empty list."""
+        result = _find_matching_pids("pytest", "/tmp/wt", set())
+        assert result == []
+
+
+class TestReadCmdline:
+    """Test _read_cmdline() with mocked filesystem/subprocess."""
+
+    @patch(f"{_WORKER_POOL}.subprocess.run")
+    def test_falls_back_to_ps(
+        self,
+        mock_run: MagicMock,
+    ) -> None:
+        """On macOS (no /proc), falls back to ps command."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="python -m pytest /tmp/wt/tests",
+        )
+        # /proc won't exist in test env (macOS), so ps fallback should work
+        result = _read_cmdline(99999)
+        # Either /proc read succeeds or ps fallback is called
+        # In test env, ps will likely fail for a non-existent PID
+        # The function handles both gracefully
+        assert result is None or isinstance(result, str)
+
+    @patch(
+        f"{_WORKER_POOL}.subprocess.run",
+        side_effect=FileNotFoundError,
+    )
+    def test_both_methods_fail_returns_none(
+        self,
+        mock_run: MagicMock,
+    ) -> None:
+        """When both /proc and ps fail, return None."""
+        result = _read_cmdline(99999)
+        assert result is None
+
+
+class TestParkWorkerWithCleanup:
+    """Test park_worker() calls cleanup_lane_processes."""
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}.cleanup_lane_processes", return_value=[42, 99])
+    @patch(f"{_WORKER_POOL}._get_lane_task_id", return_value=None)
+    def test_park_reports_cleaned_processes(
+        self,
+        mock_task: MagicMock,
+        mock_cleanup: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """park_worker calls cleanup and reports count in reason."""
+        result = park_worker("author-a", runtime_dir=runtime_dir)
+        assert result.executed is True
+        mock_cleanup.assert_called_once_with("author-a", runtime_dir=runtime_dir)
+        assert "killed 2 orphaned" in result.reason
+
+    @patch(f"{_DASHBOARD}.set_lane_visibility")
+    @patch(f"{_WORKER_POOL}.cleanup_lane_processes", return_value=[])
+    @patch(f"{_WORKER_POOL}._get_lane_task_id", return_value=None)
+    def test_park_no_processes_no_cleanup_note(
+        self,
+        mock_task: MagicMock,
+        mock_cleanup: MagicMock,
+        mock_vis: MagicMock,
+        runtime_dir: Path,
+    ) -> None:
+        """When no processes are cleaned, reason does not mention cleanup."""
+        result = park_worker("author-a", runtime_dir=runtime_dir)
+        assert result.executed is True
+        assert "orphaned" not in result.reason


### PR DESCRIPTION
## Summary
- Add `cleanup_lane_processes()` to `worker_pool.py` — finds and SIGTERMs orphaned `pytest`/`make`/`python`/`uv` processes whose command line matches a lane's worktree path
- Integrate into `park_worker()` — automatically cleans up before parking
- Integrate into `post-merge-notify.sh` — cleans up after task completion
- Update `/park` skill to document process cleanup as Step 1

## Why
Orphaned pytest/make processes accumulate during fleet runs (#1951). With 15+ lanes running 5+ hour fleet sessions, 33+ orphaned processes were observed, exhausting system memory. This adds cleanup at both lifecycle points where processes should be reaped: parking and task completion.

## Implementation Details
- `cleanup_lane_processes(lane_id)` resolves the lane's worktree path, then uses `pgrep` + cmdline inspection to find matching processes
- Excludes current PID and parent PID to avoid self-termination
- Uses `/proc/cmdline` on Linux with `ps` fallback for macOS
- `dry_run=True` mode for safe inspection without killing
- Graceful handling of `ProcessLookupError` (race condition) and `PermissionError`

## Repro / Validation
```bash
# Tier 1 — targeted tests (15 new, 197 total)
uv run python -m pytest tests/unit/test_ops_worker_pool.py -x -v

# Tier 2 — full suite
make check-quiet
# 10,315 passed (2 pre-existing failures in test_ops_token_economy.py, unrelated)
```

## Worktree proof
```
pwd: Bid-Euchre-steward-author-b
branch: fix/process-cleanup-park
```

## Tests
- 15 new tests across 4 test classes:
  - `TestCleanupLaneProcesses` (7 tests): no worktree, no match, kill, dry-run, dead process, permission error
  - `TestFindMatchingPids` (4 tests): path filtering, no match, exclude PIDs, missing pgrep
  - `TestReadCmdline` (2 tests): ps fallback, both-fail
  - `TestParkWorkerWithCleanup` (2 tests): cleanup integration, no-cleanup-note
- All 197 worker_pool tests pass
- All pre-existing park_worker tests still pass (no mock changes needed)

Closes #1951

🤖 Generated with [Claude Code](https://claude.com/claude-code)