### PR TITLE
fix(ops): convention follow-ups and jq truncation bug

### DIFF
--- a/.claude/hooks/inbound-channel-audit.py
+++ b/.claude/hooks/inbound-channel-audit.py
@@ -105,18 +105,21 @@ def _route_ack(body: str, tag_text: str) -> str | None:
     """
     from bid_euchre.ops.monitor import process_inbound_ack  # noqa: E402
 
+    # Extract and validate chat_id before processing ack commands.
+    # A missing or empty chat_id means the tag is malformed or synthetic —
+    # we cannot route a reply without knowing the destination chat.
+    attrs = _parse_tag_attrs(tag_text)
+    chat_id = attrs.get("chat_id", "")
+    if not chat_id:
+        return None
+
     result = process_inbound_ack(body)
     if not result.is_ack_command or not result.reply_text:
         return None
 
-    # Extract chat_id so the orchestrator knows which Telegram chat to reply to.
-    attrs = _parse_tag_attrs(tag_text)
-    chat_id = attrs.get("chat_id", "")
-
     parts = [f"TELEGRAM ACK REPLY (chat_id={chat_id}):"]
     parts.append(result.reply_text)
-    if chat_id:
-        parts.append(f"→ Reply to Telegram chat {chat_id} with the above confirmation.")
+    parts.append(f"→ Reply to Telegram chat {chat_id} with the above confirmation.")
     return "\n".join(parts)
 
 

--- a/.claude/skills/check-in/SKILL.md
+++ b/.claude/skills/check-in/SKILL.md
@@ -168,8 +168,13 @@ Examples:
 
 13. **Run the monitoring cycle with push evaluation:**
     ```bash
-    uv run python scripts/internal/ops.py monitor
+    uv run python scripts/internal/ops.py monitor || true
     ```
+    **Note:** The monitor command exits non-zero when it finds HIGH-severity
+    items — this is expected behavior, not an error.  The `|| true` prevents
+    the shell from treating findings as a command failure.  Always parse the
+    full stdout regardless of exit code.
+
     The monitor command:
     - Collects lane, PR, and task findings
     - Updates the controller projection (`fleet_status.json`)

--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -120,10 +120,16 @@ merge_settings_local() {
     mkdir -p "$dir"
     if [ -f "$file_path" ]; then
         local merged
-        merged="$(jq --argjson frag "$fragment" '. + $frag' "$file_path")"
+        merged="$(jq --argjson frag "$fragment" '. * $frag' "$file_path")" || {
+            echo "merge_settings_local: jq merge failed for $file_path" >&2
+            return 1
+        }
         printf '%s\n' "$merged" > "$file_path"
     else
-        printf '%s\n' "$fragment" | jq '.' > "$file_path"
+        printf '%s\n' "$fragment" | jq '.' > "$file_path" || {
+            echo "merge_settings_local: jq format failed for $file_path" >&2
+            return 1
+        }
     fi
 }
 

--- a/tests/unit/test_inbound_channel_audit.py
+++ b/tests/unit/test_inbound_channel_audit.py
@@ -326,24 +326,14 @@ class TestRouteAck:
 
         assert reply is None
 
-    def test_missing_chat_id_still_works(self, hook: ModuleType) -> None:
-        """Reply should still be generated even without a chat_id."""
-        mock_result = MagicMock()
-        mock_result.is_ack_command = True
-        mock_result.reply_text = "✅ Acked"
+    def test_missing_chat_id_returns_none(self, hook: ModuleType) -> None:
+        """Missing chat_id should short-circuit — cannot route reply without destination."""
+        tag = '<channel source="telegram">'
+        reply = hook._route_ack("ack abc1", tag)
 
-        with patch(
-            "bid_euchre.ops.monitor.process_inbound_ack",
-            return_value=mock_result,
-        ):
-            tag = '<channel source="telegram">'
-            reply = hook._route_ack("ack abc1", tag)
-
-        assert reply is not None
-        assert "TELEGRAM ACK REPLY (chat_id=)" in reply
-        assert "✅ Acked" in reply
-        # No "Reply to Telegram chat" line when chat_id is empty
-        assert "Reply to Telegram chat" not in reply
+        # chat_id validation happens before process_inbound_ack is called,
+        # so no mock is needed — the function exits early.
+        assert reply is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Plan
N/A — housekeeping follow-ups from post-merge reviews

## Summary
- Guard `merge_settings_local` against jq failures that would truncate settings files
- Switch from shallow merge (`+`) to recursive merge (`*`) for nested JSON keys
- Validate `chat_id` before executing ack commands in the inbound channel audit hook
- Document monitor's expected non-zero exit code in check-in skill

## Why
Post-merge review findings from PRs #1963, #1968, #1969, #1971 identified
a bug and several convention improvements. The most critical is #1975 — if
`jq` fails parsing corrupt JSON, the settings file gets silently truncated
to empty, destroying all existing configuration.

Closes #1970, closes #1973, closes #1974, closes #1975

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_inbound_channel_audit.py -v  # 31 passed
make check-quiet  # 10335 passed, 2 pre-existing failures in test_ops_token_economy.py
```

## Test Criteria
- **Pass condition:** `test_missing_chat_id_returns_none` passes (verifies chat_id validation)
- **Verification command:** `uv run python -m pytest tests/unit/test_inbound_channel_audit.py::TestRouteAck::test_missing_chat_id_returns_none -v`
- **Expected result:** 1 passed

## Tests
- [x] `uv run python -m pytest tests/unit/test_inbound_channel_audit.py -v` — 31 passed
- [x] `make check-quiet` — 10335 passed (2 pre-existing failures unrelated to this PR)

## Expected impact
- Metrics impact: None
- Runtime impact: None — all changes are in tooling/hooks

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
```

`git worktree list` (truncated):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         620e98b6 [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a          1f14daae [fix/housekeeping-convention-followups]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)