### PR TITLE
fix(ops): use explicit false to disable Telegram plugin on non-orchestrator lanes

### DIFF
--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -411,7 +411,7 @@ if [ "$STEWARD_TELEGRAM_ENABLED" = "1" ]; then
                "$REVIEW" "$OPS"; do
         if [ -d "$_wt" ]; then
             merge_settings_local "$_wt/.claude/settings.local.json" \
-                '{"enabledPlugins":{}}'
+                '{"enabledPlugins":{"telegram@claude-plugins-official":false}}'
         fi
     done
     unset _wt

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -835,12 +835,11 @@ class TestTelegramSingleReceiver:
             assert (
                 f'"{var}"' in content
             ), f"Non-orchestrator worktree {var} must be covered by plugin disablement"
-        # Must write empty enabledPlugins
+        # Must explicitly disable the Telegram plugin
         assert (
-            '"enabledPlugins":{}' in content
-            or "'enabledPlugins':{}'" in content
-            or '"enabledPlugins": {}' in content
-        ), "Non-orchestrator worktrees must receive empty enabledPlugins"
+            '"telegram@claude-plugins-official":false' in content
+            or '"telegram@claude-plugins-official": false' in content
+        ), "Non-orchestrator worktrees must explicitly disable the Telegram plugin"
 
     def test_negative_enforcement_inside_enabled_guard(self) -> None:
         """Bug 2: Plugin disablement loop must be inside STEWARD_TELEGRAM_ENABLED=1 guard."""
@@ -857,7 +856,8 @@ class TestTelegramSingleReceiver:
                     break
         guard_text = "\n".join(guard_body)
         assert (
-            '"enabledPlugins":{}' in guard_text or '"enabledPlugins": {}' in guard_text
+            '"telegram@claude-plugins-official":false' in guard_text
+            or '"telegram@claude-plugins-official": false' in guard_text
         ), "Non-orchestrator plugin disablement must be inside the TELEGRAM_ENABLED=1 guard"
 
     def test_telegram_receiver_env_set(self) -> None:
@@ -953,8 +953,8 @@ cat "{target}"
         assert data["enabledPlugins"]["telegram@claude-plugins-official"] is True
         assert data["someOtherKey"] == 42, "Existing keys must be preserved"
 
-    def test_merge_settings_local_empty_plugins(self, tmp_path: Path) -> None:
-        """Functional test: merging empty enabledPlugins overrides existing plugins."""
+    def test_merge_settings_local_explicit_disable(self, tmp_path: Path) -> None:
+        """Functional test: explicit false overrides existing plugin enable via deep merge."""
         target = tmp_path / ".claude" / "settings.local.json"
         # Pre-populate with a plugin enabled
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -975,13 +975,13 @@ merge_settings_local() {{
     mkdir -p "$dir"
     if [ -f "$file_path" ]; then
         local merged
-        merged="$(jq --argjson frag "$fragment" '. + $frag' "$file_path")"
+        merged="$(jq --argjson frag "$fragment" '. * $frag' "$file_path")"
         printf '%s\\n' "$merged" > "$file_path"
     else
         printf '%s\\n' "$fragment" | jq '.' > "$file_path"
     fi
 }}
-merge_settings_local "{target}" '{{"enabledPlugins":{{}}}}'
+merge_settings_local "{target}" '{{"enabledPlugins":{{"telegram@claude-plugins-official":false}}}}'
 cat "{target}"
 """,
             ],
@@ -991,8 +991,8 @@ cat "{target}"
         assert result.returncode == 0, f"stderr: {result.stderr}"
         data = json.loads(target.read_text())
         assert (
-            data["enabledPlugins"] == {}
-        ), "Empty enabledPlugins must override existing plugins"
+            data["enabledPlugins"]["telegram@claude-plugins-official"] is False
+        ), "Explicit false must override existing plugin enable"
 
 
 class TestBoundaryValidation:


### PR DESCRIPTION
## Summary

- Change `steward-session.sh` to write `"telegram@claude-plugins-official": false` (not empty `{}`) to non-orchestrator `settings.local.json`
- Fix functional test to use `. * $frag` (deep merge, matching production) instead of `. + $frag` (shallow merge)
- Update 4 test assertions to validate explicit `false` instead of empty object

## Why

An empty `enabledPlugins: {}` is a no-op under deep merge — it preserves the
user-level `true`, causing 19 competing bun processes to spawn instead of 1.
Three bugs were layered: wrong override value (PR #1971), jq operator change
(PR #1980), and test/production drift. This fix addresses all three.

See `plans/sessions/2026-04-01_telegram-single-receiver-root-cause.md` for the
full root cause analysis.

Closes #1824.

## Repro / Validation

```bash
# Tier 1: steward-session tests (78/78 pass)
uv run python -m pytest tests/unit/test_steward_session.py -v

# Tier 2: make check-quiet (3 pre-existing failures unrelated to this PR)
make check-quiet

# Manual smoke (after session restart):
ps aux | grep '[b]un.*telegram' | wc -l  # Expect: 1
```

## Tests

- `test_non_orchestrator_worktrees_get_empty_plugins` — verifies script contains explicit `false`
- `test_negative_enforcement_inside_enabled_guard` — verifies disablement is inside the Telegram guard
- `test_merge_settings_local_explicit_disable` — functional test proving deep merge with explicit `false` works
- All 78 tests in `test_steward_session.py` pass

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
branch: fix/telegram-single-receiver-explicit-false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)