### PR TITLE
feat(ops): add inbox completion injection hook (#1986)

### DIFF
--- a/.claude/hooks/inbox-completion-inject.py
+++ b/.claude/hooks/inbox-completion-inject.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""UserPromptSubmit hook: inject unacked completion messages as additionalContext.
+
+When author/analyst lanes complete tasks, they send ``completion`` messages to
+the orchestrator's inbox via the message bus.  This hook reads those messages,
+formats a summary, injects it as ``additionalContext``, and auto-acks the
+injected messages so they are not re-injected on the next prompt.
+
+Design constraints:
+- Best-effort: failures never block prompt submission.
+- Uses ``uv run`` to access project imports (bid_euchre.ops.message_bus).
+- Lazy imports for project modules to keep the fast-exit path lightweight.
+- Auto-acks injected messages to prevent re-injection.
+
+Closes #1986.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main() -> int:
+    """Entry point.  Returns 0 always (never blocks prompt submission)."""
+    # Lazy import — only load project modules when we actually run
+    try:
+        from bid_euchre.ops.message_bus import ack_message, read_inbox
+    except ImportError:
+        return 0
+
+    # Read the orchestrator inbox for unacked completion messages.
+    # Status "delivered" or "pending" are the actionable states.
+    completions: list[dict] = []
+    for status in ("delivered", "pending"):
+        msgs = read_inbox(
+            "orchestrator",
+            status=status,
+            message_type="completion",
+            limit=20,
+            auto_expire=True,
+            auto_compact=False,  # Don't compact on every prompt
+        )
+        completions.extend(msgs)
+
+    if not completions:
+        return 0
+
+    # Format the completion summary
+    lines = [f"LANE COMPLETIONS ({len(completions)} unacked):"]
+    acked_ids: list[str] = []
+
+    for msg in completions:
+        from_lane = msg.get("from_lane", "unknown")
+        summary = msg.get("summary", "(no summary)")
+        task_id = msg.get("task_id", "")
+        msg_id = msg.get("message_id", "")
+
+        task_suffix = f" [task:{task_id[:12]}]" if task_id else ""
+        lines.append(f"  [{from_lane}] {summary}{task_suffix}")
+
+        if msg_id:
+            acked_ids.append(msg_id)
+
+    lines.append("")
+    lines.append(
+        "These lanes have finished their tasks. Consider reviewing their PRs "
+        "and dispatching new work."
+    )
+
+    context = "\n".join(lines)
+
+    # Auto-ack the injected messages so they don't re-inject on the next prompt.
+    for mid in acked_ids:
+        try:
+            ack_message(mid, "orchestrator")
+        except Exception:  # noqa: BLE001 — best-effort
+            pass
+
+    # Output the additionalContext payload
+    print(json.dumps({"additionalContext": context}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/inbox-completion-inject.sh
+++ b/.claude/hooks/inbox-completion-inject.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# inbox-completion-inject.sh — UserPromptSubmit hook: surface unacked
+# completion messages from the orchestrator inbox.
+#
+# When author/analyst lanes complete tasks, they send completion messages
+# to the orchestrator's inbox.  This hook checks for unacked completions
+# and injects them as additionalContext so the orchestrator sees them
+# immediately — no polling needed.
+#
+# Design:
+#   - Best-effort: failures never block prompt submission
+#   - Fast guard: exits immediately (~0ms) when no inbox file or no completions
+#   - Delegates to inbox-completion-inject.py for inbox reading + ack
+#   - Only fires on the orchestrator lane (lane guard)
+#
+# Closes #1986.
+set -euo pipefail
+
+# Lane guard: only the orchestrator needs completion injection.
+# Check the explicit env var first (fastest), then fall back to dir detection.
+_LANE="${CLAUDE_AGENT_NAME:-}"
+if [ -z "$_LANE" ]; then
+    _LANE=$(basename "${CLAUDE_PROJECT_DIR:-}")
+fi
+
+# The orchestrator lane lives in the "Bid-Euchre" directory (the main checkout).
+case "$_LANE" in
+    orchestrator|Bid-Euchre) ;;
+    *) exit 0 ;;
+esac
+
+# Fast guard: check if the orchestrator inbox file exists and contains any
+# "completion" messages in a deliverable state.  This avoids Python startup
+# (~200ms) on every prompt when no completions are pending.
+_BUS_ROOT="${BID_EUCHRE_BUS_DIR:-}"
+if [ -z "$_BUS_ROOT" ]; then
+    _BUS_ROOT=$(git -C "${CLAUDE_PROJECT_DIR:-.}" rev-parse --git-common-dir 2>/dev/null)/message_bus
+fi
+
+_INBOX_FILE="$_BUS_ROOT/inboxes/orchestrator.jsonl"
+if [ ! -f "$_INBOX_FILE" ]; then
+    exit 0
+fi
+
+# Quick grep: does the inbox contain any completion messages that aren't resolved/expired?
+# This is a heuristic — the Python script does the accurate filtering.
+grep -q '"completion"' "$_INBOX_FILE" || exit 0
+
+# Delegate to Python for accurate inbox reading, formatting, and auto-ack.
+# Best-effort: failures are silently swallowed.
+uv run python "$CLAUDE_PROJECT_DIR/.claude/hooks/inbox-completion-inject.py" 2>/dev/null || true
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -103,6 +103,15 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/inbox-completion-inject.sh",
+            "timeout": 10
+          }
+        ]
       }
     ]
   },

--- a/tests/unit/test_inbox_completion_inject.py
+++ b/tests/unit/test_inbox_completion_inject.py
@@ -1,0 +1,373 @@
+"""Unit tests for the inbox-completion-inject UserPromptSubmit hook.
+
+Tests the Python script directly (imported by path) with mocked message bus
+functions.  The hook reads the orchestrator inbox for unacked completion
+messages and injects them as additionalContext.
+
+Closes #1986.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_PY = REPO_ROOT / ".claude" / "hooks" / "inbox-completion-inject.py"
+HOOK_SH = REPO_ROOT / ".claude" / "hooks" / "inbox-completion-inject.sh"
+
+
+@pytest.fixture(scope="module")
+def hook() -> ModuleType:
+    """Import the hook script as a module."""
+    spec = importlib.util.spec_from_file_location("inbox_completion_inject", HOOK_PY)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["inbox_completion_inject"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_completion_msg(
+    *,
+    from_lane: str = "author-a",
+    summary: str = "Done: PR #100 opened",
+    task_id: str = "abc123def456",
+    message_id: str = "msg001",
+    status: str = "delivered",
+) -> dict:
+    """Create a minimal completion message dict as returned by read_inbox."""
+    return {
+        "message_id": message_id,
+        "from_lane": from_lane,
+        "to_lane": "orchestrator",
+        "message_type": "completion",
+        "summary": summary,
+        "task_id": task_id,
+        "status": status,
+        "priority": "normal",
+        "created_at": "2026-04-01T12:00:00Z",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: no output cases
+# ---------------------------------------------------------------------------
+
+
+class TestNoOutput:
+    """Cases where the hook should produce no output and exit 0."""
+
+    def test_no_completions(
+        self, hook: ModuleType, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Hook exits cleanly when no unacked completions exist."""
+        mock_read = MagicMock(return_value=[])
+        mock_ack = MagicMock()
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "bid_euchre.ops.message_bus": MagicMock(
+                    read_inbox=mock_read, ack_message=mock_ack
+                ),
+            },
+        ):
+            # Re-import to pick up the mock
+            result = hook.main()
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert captured.out.strip() == ""
+
+    def test_import_error_graceful(
+        self, hook: ModuleType, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Hook exits cleanly if bid_euchre.ops.message_bus can't be imported."""
+        # Setting a sys.modules entry to None causes ImportError on `from ... import`
+        with patch.dict("sys.modules", {"bid_euchre.ops.message_bus": None}):
+            result = hook.main()
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert captured.out.strip() == ""
+
+
+class TestCompletionInjection:
+    """Cases where the hook should inject additionalContext."""
+
+    def test_single_completion(
+        self, hook: ModuleType, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Hook injects context for a single completion message."""
+        msgs = [_make_completion_msg()]
+
+        with (
+            patch(
+                "bid_euchre.ops.message_bus.read_inbox",
+                side_effect=lambda *a, **kw: msgs
+                if kw.get("status") == "delivered"
+                else [],
+            ),
+            patch("bid_euchre.ops.message_bus.ack_message"),
+        ):
+            result = hook.main()
+
+        assert result == 0
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+        ctx = output["additionalContext"]
+        assert "LANE COMPLETIONS (1 unacked)" in ctx
+        assert "[author-a] Done: PR #100 opened" in ctx
+        assert "[task:abc123def456]" in ctx
+
+    def test_multiple_completions(
+        self, hook: ModuleType, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Hook injects all unacked completions."""
+        msgs = [
+            _make_completion_msg(
+                from_lane="author-a",
+                summary="Done: PR #100 opened",
+                message_id="msg001",
+            ),
+            _make_completion_msg(
+                from_lane="author-b",
+                summary="Done: PR #101 opened",
+                message_id="msg002",
+                task_id="def789ghi012",
+            ),
+        ]
+
+        with (
+            patch(
+                "bid_euchre.ops.message_bus.read_inbox",
+                side_effect=lambda *a, **kw: msgs
+                if kw.get("status") == "delivered"
+                else [],
+            ),
+            patch("bid_euchre.ops.message_bus.ack_message"),
+        ):
+            result = hook.main()
+
+        assert result == 0
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+        ctx = output["additionalContext"]
+        assert "LANE COMPLETIONS (2 unacked)" in ctx
+        assert "[author-a]" in ctx
+        assert "[author-b]" in ctx
+        assert "PR #100" in ctx
+        assert "PR #101" in ctx
+
+    def test_auto_acks_injected_messages(
+        self, hook: ModuleType, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Hook auto-acks messages after injecting them."""
+        msgs = [
+            _make_completion_msg(message_id="msg001"),
+            _make_completion_msg(message_id="msg002", from_lane="author-b"),
+        ]
+
+        with (
+            patch(
+                "bid_euchre.ops.message_bus.read_inbox",
+                side_effect=lambda *a, **kw: msgs
+                if kw.get("status") == "delivered"
+                else [],
+            ),
+            patch("bid_euchre.ops.message_bus.ack_message") as mock_ack,
+        ):
+            result = hook.main()
+
+        assert result == 0
+        # Verify both messages were acked
+        assert mock_ack.call_count == 2
+        acked_ids = {call.args[0] for call in mock_ack.call_args_list}
+        assert acked_ids == {"msg001", "msg002"}
+        # All acks should target the orchestrator lane
+        for call in mock_ack.call_args_list:
+            assert call.args[1] == "orchestrator"
+
+    def test_ack_failure_does_not_block(
+        self, hook: ModuleType, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Hook still outputs context even if ack_message raises."""
+        msgs = [_make_completion_msg(message_id="msg001")]
+
+        with (
+            patch(
+                "bid_euchre.ops.message_bus.read_inbox",
+                side_effect=lambda *a, **kw: msgs
+                if kw.get("status") == "delivered"
+                else [],
+            ),
+            patch(
+                "bid_euchre.ops.message_bus.ack_message",
+                side_effect=Exception("ack failed"),
+            ),
+        ):
+            result = hook.main()
+
+        assert result == 0
+        captured = capsys.readouterr()
+        # Should still output the context despite ack failure
+        output = json.loads(captured.out)
+        assert "LANE COMPLETIONS" in output["additionalContext"]
+
+    def test_no_task_id_omits_suffix(
+        self, hook: ModuleType, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Hook omits [task:...] suffix when task_id is empty."""
+        msgs = [_make_completion_msg(task_id="")]
+
+        with (
+            patch(
+                "bid_euchre.ops.message_bus.read_inbox",
+                side_effect=lambda *a, **kw: msgs
+                if kw.get("status") == "delivered"
+                else [],
+            ),
+            patch("bid_euchre.ops.message_bus.ack_message"),
+        ):
+            result = hook.main()
+
+        assert result == 0
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+        ctx = output["additionalContext"]
+        assert "[task:" not in ctx
+
+    def test_pending_status_also_captured(
+        self, hook: ModuleType, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Hook captures messages in both 'delivered' and 'pending' states."""
+        delivered_msgs = [_make_completion_msg(message_id="msg001", status="delivered")]
+        pending_msgs = [
+            _make_completion_msg(
+                message_id="msg002",
+                from_lane="author-c",
+                summary="Done: PR #102 opened",
+                status="pending",
+            )
+        ]
+
+        def mock_read(*a, **kw):
+            if kw.get("status") == "delivered":
+                return delivered_msgs
+            elif kw.get("status") == "pending":
+                return pending_msgs
+            return []
+
+        with (
+            patch(
+                "bid_euchre.ops.message_bus.read_inbox",
+                side_effect=mock_read,
+            ),
+            patch("bid_euchre.ops.message_bus.ack_message"),
+        ):
+            result = hook.main()
+
+        assert result == 0
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+        ctx = output["additionalContext"]
+        assert "LANE COMPLETIONS (2 unacked)" in ctx
+        assert "[author-a]" in ctx
+        assert "[author-c]" in ctx
+
+    def test_output_is_valid_json(
+        self, hook: ModuleType, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Hook output is always valid JSON when completions exist."""
+        msgs = [_make_completion_msg(summary='Done: PR #100 with "quotes" & specials')]
+
+        with (
+            patch(
+                "bid_euchre.ops.message_bus.read_inbox",
+                side_effect=lambda *a, **kw: msgs
+                if kw.get("status") == "delivered"
+                else [],
+            ),
+            patch("bid_euchre.ops.message_bus.ack_message"),
+        ):
+            result = hook.main()
+
+        assert result == 0
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+        assert isinstance(output, dict)
+        assert "additionalContext" in output
+        assert isinstance(output["additionalContext"], str)
+
+    def test_dispatch_hint_in_context(
+        self, hook: ModuleType, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Hook includes a hint to review PRs and dispatch new work."""
+        msgs = [_make_completion_msg()]
+
+        with (
+            patch(
+                "bid_euchre.ops.message_bus.read_inbox",
+                side_effect=lambda *a, **kw: msgs
+                if kw.get("status") == "delivered"
+                else [],
+            ),
+            patch("bid_euchre.ops.message_bus.ack_message"),
+        ):
+            result = hook.main()
+
+        assert result == 0
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+        ctx = output["additionalContext"]
+        assert "reviewing their PRs" in ctx or "dispatch" in ctx.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests: hook infrastructure
+# ---------------------------------------------------------------------------
+
+
+class TestHookInfrastructure:
+    """Verify hook files exist and are properly configured."""
+
+    def test_python_script_exists(self) -> None:
+        assert HOOK_PY.exists(), f"Missing {HOOK_PY}"
+
+    def test_shell_wrapper_exists(self) -> None:
+        assert HOOK_SH.exists(), f"Missing {HOOK_SH}"
+
+    def test_shell_wrapper_executable(self) -> None:
+        import os
+        import stat
+
+        mode = os.stat(HOOK_SH).st_mode
+        assert mode & stat.S_IXUSR, f"{HOOK_SH} is not executable"
+
+    def test_hook_registered_in_settings(self) -> None:
+        settings_path = REPO_ROOT / ".claude" / "settings.json"
+        settings = json.loads(settings_path.read_text())
+        hooks = settings.get("hooks", {})
+        user_prompt = hooks.get("UserPromptSubmit", [])
+        assert len(user_prompt) > 0, "No UserPromptSubmit hooks registered"
+
+        # Find our hook
+        found = False
+        for entry in user_prompt:
+            for hook_entry in entry.get("hooks", []):
+                if "inbox-completion-inject" in hook_entry.get("command", ""):
+                    found = True
+                    assert hook_entry["timeout"] <= 10, "Hook timeout must be <= 10s"
+        assert found, "inbox-completion-inject hook not found in UserPromptSubmit"


### PR DESCRIPTION
## Summary

- Add `UserPromptSubmit` hook (`inbox-completion-inject.sh`/`.py`) that surfaces unacked completion messages from the orchestrator inbox as `additionalContext`
- Auto-acks injected messages to prevent re-injection on subsequent prompts
- Register the new hook in `.claude/settings.json`

## Why

When author/analyst lanes complete tasks, they send completion messages to the orchestrator's inbox. Without this hook, the orchestrator relies on manual polling or cron jobs, creating minutes of idle time before discovering finished work. This hook provides push-based notification — completions appear immediately on the next prompt.

## Design

Follows the established `inbound-channel-audit.sh`/`.py` pattern:
- **Bash wrapper** (`inbox-completion-inject.sh`): Fast guard exits in ~0ms when no completions pending. Lane guard ensures only the orchestrator lane runs the hook.
- **Python script** (`inbox-completion-inject.py`): Reads inbox for unacked completion messages in `delivered`/`pending` states, formats a summary, auto-acks, outputs `{"additionalContext": "..."}`.
- **Best-effort**: All failures are silently swallowed — hook never blocks prompt submission.

## Scope

| File | Change |
|------|--------|
| `.claude/hooks/inbox-completion-inject.sh` | New: bash wrapper with fast guard + lane guard |
| `.claude/hooks/inbox-completion-inject.py` | New: read inbox, format, auto-ack, inject |
| `.claude/settings.json` | Register new hook in UserPromptSubmit array |
| `tests/unit/test_inbox_completion_inject.py` | New: 14 unit tests |

## Validation

```bash
# Tier 1 — all 14 hook-specific tests pass
uv run python -m pytest tests/unit/test_inbox_completion_inject.py -v
# 14 passed

# Tier 2 — make check-quiet
make check-quiet
# 3 pre-existing failures (token_economy, telegram_filter) — unrelated, confirmed on main

# JSON validation
python3 -c "import json; json.load(open('.claude/settings.json'))"
# Valid JSON ✓
```

## Repro

```bash
# Verify hook exists and is executable
ls -la .claude/hooks/inbox-completion-inject.*

# Run tests
uv run python -m pytest tests/unit/test_inbox_completion_inject.py -v
```

## Worktree Proof

```
pwd: Bid-Euchre-steward-author-d
branch: feat/inbox-completion-inject
```

Closes #1986

🤖 Generated with [Claude Code](https://claude.com/claude-code)