### PR TITLE
feat(web): add leaderboard route with player stats ranking

### DIFF
--- a/plans/browser_game_expansion/4_analytics_and_community/checkpoints.md
+++ b/plans/browser_game_expansion/4_analytics_and_community/checkpoints.md
@@ -16,8 +16,8 @@ the leaderboard and forum depend on.
 
 | Step | Status | Validates | Date | Agent/Session | Notes |
 |------|--------|-----------|------|---------------|-------|
-| Step 1: Leaderboard data model and backend | PENDING | Player stats aggregation queries return correct net_eppd, games_won, win_rate, avg_margin_victory, matches_played | -- | -- | SP-AC-01 |
-| Step 2: Leaderboard route and UI tab | PENDING | `/leaderboard` route renders ranked table within shared invited-user shell; invite-only gated | -- | -- | SP-AC-01 |
+| Step 1: Leaderboard data model and backend | COMPLETE | Player stats aggregation queries return correct net_eppd, games_won, win_rate, avg_margin_victory, matches_played | 2026-04-01 | brws-author-a | SP-AC-01 |
+| Step 2: Leaderboard route and UI tab | COMPLETE | `/leaderboard` route renders ranked table within shared invited-user shell; invite-only gated | 2026-04-01 | brws-author-a | SP-AC-01 |
 | Step 3: Forum data model and backend | PENDING | Post CRUD, category assignment, and hide/unhide moderation work at the DB layer | -- | -- | SP-AC-02 |
 | Step 4: Forum route and UI tab | PENDING | `/forum` route renders post list and create-post form within shared invited-user shell; invite-only gated | -- | -- | SP-AC-02 |
 | Step 5: Claude bot constraints | PENDING | Claude (bot) user is labeled automated, cannot admin invites, cannot moderate, cannot edit/delete others, respects rate limits (1 active match, 3 completed/24h, 3 forum posts/24h) | -- | -- | SP-AC-02 |

--- a/tests/unit/hosted_play/test_leaderboard.py
+++ b/tests/unit/hosted_play/test_leaderboard.py
@@ -1,0 +1,450 @@
+"""Tests for the leaderboard stats aggregation and route.
+
+Covers:
+- PlayerStats computation from completed match/hand data
+- Leaderboard ranking (sorted by net_eppd descending)
+- Default and secondary column partitioning
+- Access gating (404 for unknown UUIDs)
+- Route integration via the FastAPI test client
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from web.db import Hand, Match, Player
+from web.leaderboard import compute_player_stats, get_leaderboard
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_player(session, *, nickname: str = "TestPlayer") -> Player:
+    """Create a player with a unique link_uuid."""
+    player = Player(link_uuid=str(uuid.uuid4()), nickname=nickname)
+    session.add(player)
+    session.flush()
+    return player
+
+
+def _make_match(
+    session,
+    player: Player,
+    *,
+    status: str = "complete",
+    score_human: int = 52,
+    score_ai: int = 30,
+    hands_played: int = 10,
+) -> Match:
+    """Create a match for the given player."""
+    match = Match(
+        match_uuid=str(uuid.uuid4()),
+        player_id=player.id,
+        ai_model="heuristic",
+        status=status,
+        seed=42,
+        score_human=score_human,
+        score_ai=score_ai,
+        hands_played=hands_played,
+        match_state_json="{}",
+        completed_at=datetime.now(timezone.utc) if status == "complete" else None,
+    )
+    session.add(match)
+    session.flush()
+    return match
+
+
+def _make_hand(
+    session,
+    match: Match,
+    *,
+    hand_number: int = 0,
+    status: str = "complete",
+    bidder_seat: int | None = 0,
+    winning_bid_n: int | None = 6,
+    winning_bid_type: str | None = "regular",
+    tricks_team0: int = 7,
+    tricks_team1: int = 3,
+    points_team0: int = 6,
+    points_team1: int = 3,
+) -> Hand:
+    """Create a hand under the given match."""
+    hand = Hand(
+        match_id=match.id,
+        hand_number=hand_number,
+        deal_id=hand_number,
+        dealer_seat=0,
+        status=status,
+        bidder_seat=bidder_seat,
+        winning_bid_n=winning_bid_n,
+        winning_bid_type=winning_bid_type,
+        tricks_team0=tricks_team0,
+        tricks_team1=tricks_team1,
+        points_team0=points_team0,
+        points_team1=points_team1,
+        hand_state_json="{}",
+        completed_at=datetime.now(timezone.utc) if status == "complete" else None,
+    )
+    session.add(hand)
+    session.flush()
+    return hand
+
+
+# ---------------------------------------------------------------------------
+# compute_player_stats tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputePlayerStats:
+    """Unit tests for compute_player_stats."""
+
+    def test_returns_none_for_unknown_player(self, db_session):
+        result = compute_player_stats(db_session, player_id=999)
+        assert result is None
+
+    def test_returns_none_for_no_completed_matches(self, db_session):
+        player = _make_player(db_session)
+        _make_match(db_session, player, status="active")
+        result = compute_player_stats(db_session, player.id)
+        assert result is None
+
+    def test_basic_stats_single_match(self, db_session):
+        player = _make_player(db_session, nickname="Alice")
+        match = _make_match(
+            db_session, player, score_human=52, score_ai=30, hands_played=5
+        )
+
+        # 3 hands where human team (seats 0,2) declared and made
+        for i in range(3):
+            _make_hand(
+                db_session,
+                match,
+                hand_number=i,
+                bidder_seat=0,
+                winning_bid_n=6,
+                tricks_team0=7,
+                tricks_team1=3,
+                points_team0=6,
+                points_team1=3,
+            )
+        # 2 hands where AI team (seat 1) declared
+        for i in range(3, 5):
+            _make_hand(
+                db_session,
+                match,
+                hand_number=i,
+                bidder_seat=1,
+                winning_bid_n=5,
+                tricks_team0=4,
+                tricks_team1=6,
+                points_team0=4,
+                points_team1=5,
+            )
+
+        db_session.flush()
+        stats = compute_player_stats(db_session, player.id)
+
+        assert stats is not None
+        assert stats.nickname == "Alice"
+        assert stats.matches_played == 1
+        assert stats.games_won == 1  # 52 > 30
+        assert stats.win_rate == 1.0
+        assert stats.hands_played == 5
+
+        # net_eppd = (3*6 + 2*4 - 3*3 - 2*5) / 5 = (18+8-9-10)/5 = 7/5 = 1.4
+        assert stats.net_eppd == 1.4
+
+        # bid_rate = 3 declaring / 5 total
+        assert stats.bid_rate == 0.6
+
+        # make_rate = 3 made / 3 declaring (all made: 7 >= 6)
+        assert stats.make_rate == 1.0
+
+        # avg_bid_level = 6.0
+        assert stats.avg_bid_level == 6.0
+
+    def test_losing_match(self, db_session):
+        player = _make_player(db_session)
+        _make_match(db_session, player, score_human=20, score_ai=52)
+        _make_hand(
+            db_session,
+            db_session.query(Match).first(),
+            points_team0=-5,
+            points_team1=5,
+        )
+        db_session.flush()
+        stats = compute_player_stats(db_session, player.id)
+
+        assert stats is not None
+        assert stats.games_won == 0
+        assert stats.win_rate == 0.0
+        assert stats.avg_margin_victory == 0.0  # no wins
+        assert stats.net_eppd == -10.0  # (-5 - 5) / 1
+
+    def test_moon_and_loner_stats(self, db_session):
+        player = _make_player(db_session)
+        match = _make_match(db_session, player)
+
+        # Moon hand (human declares, makes)
+        _make_hand(
+            db_session,
+            match,
+            hand_number=0,
+            bidder_seat=0,
+            winning_bid_n=10,
+            winning_bid_type="moon",
+            tricks_team0=10,
+            tricks_team1=0,
+            points_team0=20,
+            points_team1=0,
+        )
+
+        # Loner hand (human declares, set)
+        _make_hand(
+            db_session,
+            match,
+            hand_number=1,
+            bidder_seat=2,  # partner seat, still team 0
+            winning_bid_n=10,
+            winning_bid_type="loner",
+            tricks_team0=5,
+            tricks_team1=5,
+            points_team0=-10,
+            points_team1=5,
+        )
+
+        # Regular hand
+        _make_hand(
+            db_session,
+            match,
+            hand_number=2,
+            bidder_seat=1,  # AI declares
+            winning_bid_n=5,
+            winning_bid_type="regular",
+            tricks_team0=4,
+            tricks_team1=6,
+            points_team0=4,
+            points_team1=5,
+        )
+
+        db_session.flush()
+        stats = compute_player_stats(db_session, player.id)
+
+        assert stats is not None
+        assert stats.hands_played == 3
+        assert stats.moon_call_rate == pytest.approx(1 / 3, abs=0.001)
+        assert stats.moon_make_rate == 1.0  # 1 moon called, 1 made
+        assert stats.loner_call_rate == pytest.approx(1 / 3, abs=0.001)
+        assert stats.loner_make_rate == 0.0  # 1 loner called, 0 made (5 < 10)
+
+    def test_multiple_matches(self, db_session):
+        player = _make_player(db_session)
+
+        # Match 1: win
+        m1 = _make_match(
+            db_session, player, score_human=52, score_ai=20, hands_played=5
+        )
+        for i in range(5):
+            _make_hand(
+                db_session,
+                m1,
+                hand_number=i,
+                points_team0=6,
+                points_team1=2,
+            )
+
+        # Match 2: loss
+        m2 = _make_match(
+            db_session, player, score_human=10, score_ai=52, hands_played=5
+        )
+        for i in range(5):
+            _make_hand(
+                db_session,
+                m2,
+                hand_number=i + 10,  # unique hand numbers
+                points_team0=-2,
+                points_team1=6,
+            )
+
+        db_session.flush()
+        stats = compute_player_stats(db_session, player.id)
+
+        assert stats is not None
+        assert stats.matches_played == 2
+        assert stats.games_won == 1
+        assert stats.win_rate == 0.5
+        assert stats.hands_played == 10
+
+        # net_eppd = (5*6 + 5*(-2) - 5*2 - 5*6) / 10 = (30-10-10-30)/10 = -2.0
+        assert stats.net_eppd == -2.0
+
+        # avg_match_margin: (52-20 + 10-52) / 2 = (32 + -42) / 2 = -5.0
+        assert stats.avg_match_margin == -5.0
+
+    def test_returns_dataclass_fields(self, db_session):
+        """Verify all expected fields are present on PlayerStats."""
+        player = _make_player(db_session)
+        match = _make_match(db_session, player)
+        _make_hand(db_session, match)
+        db_session.flush()
+
+        stats = compute_player_stats(db_session, player.id)
+        assert stats is not None
+
+        expected_fields = {
+            "player_id",
+            "nickname",
+            "net_eppd",
+            "games_won",
+            "win_rate",
+            "avg_margin_victory",
+            "matches_played",
+            "hands_played",
+            "avg_match_margin",
+            "bid_rate",
+            "make_rate",
+            "avg_bid_level",
+            "moon_call_rate",
+            "moon_make_rate",
+            "loner_call_rate",
+            "loner_make_rate",
+        }
+        actual_fields = {f.name for f in stats.__dataclass_fields__.values()}
+        assert expected_fields == actual_fields
+
+
+# ---------------------------------------------------------------------------
+# get_leaderboard tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetLeaderboard:
+    """Tests for the leaderboard ranking function."""
+
+    def test_empty_leaderboard(self, db_session):
+        rankings = get_leaderboard(db_session)
+        assert rankings == []
+
+    def test_sorts_by_net_eppd_descending(self, db_session):
+        # Player A: high net_eppd
+        player_a = _make_player(db_session, nickname="HighEppd")
+        match_a = _make_match(db_session, player_a, score_human=52, score_ai=10)
+        _make_hand(db_session, match_a, points_team0=10, points_team1=2)
+
+        # Player B: low net_eppd
+        player_b = _make_player(db_session, nickname="LowEppd")
+        match_b = _make_match(db_session, player_b, score_human=20, score_ai=52)
+        _make_hand(
+            db_session,
+            match_b,
+            hand_number=1,
+            points_team0=-5,
+            points_team1=5,
+        )
+
+        db_session.flush()
+        rankings = get_leaderboard(db_session)
+
+        assert len(rankings) == 2
+        assert rankings[0].nickname == "HighEppd"
+        assert rankings[1].nickname == "LowEppd"
+        assert rankings[0].net_eppd > rankings[1].net_eppd
+
+    def test_min_matches_filter(self, db_session):
+        # Player with 1 match
+        player = _make_player(db_session, nickname="OneMatch")
+        match = _make_match(db_session, player)
+        _make_hand(db_session, match)
+
+        db_session.flush()
+
+        # min_matches=1 includes them
+        assert len(get_leaderboard(db_session, min_matches=1)) == 1
+
+        # min_matches=2 excludes them
+        assert len(get_leaderboard(db_session, min_matches=2)) == 0
+
+    def test_excludes_active_only_players(self, db_session):
+        player = _make_player(db_session, nickname="ActiveOnly")
+        _make_match(db_session, player, status="active")
+        db_session.flush()
+
+        rankings = get_leaderboard(db_session)
+        assert len(rankings) == 0
+
+
+# ---------------------------------------------------------------------------
+# Route tests
+# ---------------------------------------------------------------------------
+
+
+class TestLeaderboardRoute:
+    """Route-level tests for GET /leaderboard/{link_uuid}."""
+
+    @pytest.fixture()
+    def app_and_client(self, tmp_path):
+        """FastAPI test client with lifespan (DB, templates, AI loaded)."""
+        from starlette.testclient import TestClient
+
+        from tests.unit.hosted_play.conftest import make_hosted_play_test_config
+        from web.app import create_app
+
+        config = make_hosted_play_test_config(tmp_path)
+        app = create_app(config)
+        with TestClient(app) as client:
+            yield app, client
+
+    def test_leaderboard_returns_200_for_valid_player(self, app_and_client):
+        app, client = app_and_client
+        session = app.state.session_factory()
+        try:
+            player = _make_player(session, nickname="Tester")
+            session.commit()
+            resp = client.get(f"/leaderboard/{player.link_uuid}")
+            assert resp.status_code == 200
+            assert "Leaderboard" in resp.text
+        finally:
+            session.close()
+
+    def test_leaderboard_returns_404_for_unknown_uuid(self, app_and_client):
+        _app, client = app_and_client
+        resp = client.get(f"/leaderboard/{uuid.uuid4()}")
+        assert resp.status_code == 404
+
+    def test_leaderboard_shows_rankings(self, app_and_client):
+        app, client = app_and_client
+        session = app.state.session_factory()
+        try:
+            player = _make_player(session, nickname="RankedPlayer")
+            match = _make_match(session, player, score_human=52, score_ai=20)
+            _make_hand(
+                session,
+                match,
+                points_team0=5,
+                points_team1=2,
+            )
+            session.commit()
+
+            resp = client.get(f"/leaderboard/{player.link_uuid}")
+            assert resp.status_code == 200
+            assert "RankedPlayer" in resp.text
+            assert "Net EPPD" in resp.text
+        finally:
+            session.close()
+
+    def test_leaderboard_shows_empty_message(self, app_and_client):
+        app, client = app_and_client
+        session = app.state.session_factory()
+        try:
+            player = _make_player(session, nickname="NewPlayer")
+            session.commit()
+
+            resp = client.get(f"/leaderboard/{player.link_uuid}")
+            assert resp.status_code == 200
+            assert "No completed matches yet" in resp.text
+        finally:
+            session.close()

--- a/web/leaderboard.py
+++ b/web/leaderboard.py
@@ -1,0 +1,191 @@
+"""Leaderboard stats aggregation for the browser game.
+
+Computes player performance metrics from completed match and hand data.
+All queries operate on the hosted-play SQLAlchemy models — no raw SQL.
+
+The leaderboard is a product-facing feature: metrics optimize for player
+comprehension and engagement, not research-report statistical fidelity.
+Research-parity optimization (bootstrap CIs, effect sizes, p-values) is
+explicitly out of scope.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from .db import Hand, Match, Player
+
+# Human is always seat 0; human's team is (seat 0, seat 2) = team 0.
+HUMAN_TEAM = 0
+
+
+@dataclass(frozen=True)
+class PlayerStats:
+    """Aggregated performance metrics for a single player."""
+
+    player_id: int
+    nickname: str | None
+
+    # Primary ranking metric
+    net_eppd: float  # net expected points per deal
+
+    # Default visible columns
+    games_won: int
+    win_rate: float  # 0.0–1.0
+    avg_margin_victory: float  # average score margin when winning
+    matches_played: int
+
+    # Secondary columns
+    hands_played: int
+    avg_match_margin: float  # average match score margin (all matches)
+    bid_rate: float  # fraction of hands where player's team won the bid
+    make_rate: float  # fraction of contracts made when declaring
+    avg_bid_level: float  # average bid level when declaring
+    moon_call_rate: float  # fraction of hands with a moon bid
+    moon_make_rate: float  # fraction of moon contracts made
+    loner_call_rate: float  # fraction of hands with a loner bid
+    loner_make_rate: float  # fraction of loner contracts made
+
+
+def compute_player_stats(session: Session, player_id: int) -> PlayerStats | None:
+    """Compute aggregated stats for a single player.
+
+    Returns ``None`` if the player has no completed matches.
+    """
+    player = session.query(Player).get(player_id)
+    if player is None:
+        return None
+
+    # Completed matches for this player
+    completed_matches = (
+        session.query(Match).filter_by(player_id=player_id, status="complete").all()
+    )
+
+    if not completed_matches:
+        return None
+
+    matches_played = len(completed_matches)
+    match_ids = [m.id for m in completed_matches]
+
+    # Win/loss from matches (human is team 0 — score_human vs score_ai)
+    games_won = sum(1 for m in completed_matches if m.score_human > m.score_ai)
+    win_rate = games_won / matches_played if matches_played > 0 else 0.0
+
+    # Score margins
+    margins = [m.score_human - m.score_ai for m in completed_matches]
+    avg_match_margin = sum(margins) / len(margins) if margins else 0.0
+    winning_margins = [mg for mg in margins if mg > 0]
+    avg_margin_victory = (
+        sum(winning_margins) / len(winning_margins) if winning_margins else 0.0
+    )
+
+    # Completed hands across all completed matches
+    completed_hands = (
+        session.query(Hand)
+        .filter(Hand.match_id.in_(match_ids), Hand.status == "complete")
+        .all()
+    )
+    hands_played = len(completed_hands)
+
+    # Net EPPD: total net points / total hands
+    if hands_played > 0:
+        total_net_points = sum(h.points_team0 - h.points_team1 for h in completed_hands)
+        net_eppd = total_net_points / hands_played
+    else:
+        net_eppd = 0.0
+
+    # Bidding stats — human team is team 0, bidder_seat in (0, 2)
+    declaring_hands = [
+        h
+        for h in completed_hands
+        if h.bidder_seat is not None and h.bidder_seat in (0, 2)
+    ]
+    bid_rate = len(declaring_hands) / hands_played if hands_played > 0 else 0.0
+
+    # Make rate: when declaring, did team 0 make the contract?
+    # Made = tricks_team0 >= winning_bid_n
+    made_contracts = [
+        h
+        for h in declaring_hands
+        if h.winning_bid_n is not None and h.tricks_team0 >= h.winning_bid_n
+    ]
+    make_rate = len(made_contracts) / len(declaring_hands) if declaring_hands else 0.0
+
+    # Average bid level when declaring
+    bid_levels = [
+        h.winning_bid_n for h in declaring_hands if h.winning_bid_n is not None
+    ]
+    avg_bid_level = sum(bid_levels) / len(bid_levels) if bid_levels else 0.0
+
+    # Moon stats
+    moon_hands = [h for h in completed_hands if h.winning_bid_type == "moon"]
+    moon_declaring = [h for h in moon_hands if h.bidder_seat in (0, 2)]
+    moon_call_rate = len(moon_declaring) / hands_played if hands_played > 0 else 0.0
+    moon_made = [
+        h
+        for h in moon_declaring
+        if h.winning_bid_n is not None and h.tricks_team0 >= h.winning_bid_n
+    ]
+    moon_make_rate = len(moon_made) / len(moon_declaring) if moon_declaring else 0.0
+
+    # Loner stats
+    loner_hands = [h for h in completed_hands if h.winning_bid_type == "loner"]
+    loner_declaring = [h for h in loner_hands if h.bidder_seat in (0, 2)]
+    loner_call_rate = len(loner_declaring) / hands_played if hands_played > 0 else 0.0
+    loner_made = [
+        h
+        for h in loner_declaring
+        if h.winning_bid_n is not None and h.tricks_team0 >= h.winning_bid_n
+    ]
+    loner_make_rate = len(loner_made) / len(loner_declaring) if loner_declaring else 0.0
+
+    return PlayerStats(
+        player_id=player_id,
+        nickname=player.nickname,
+        net_eppd=round(net_eppd, 3),
+        games_won=games_won,
+        win_rate=round(win_rate, 3),
+        avg_margin_victory=round(avg_margin_victory, 1),
+        matches_played=matches_played,
+        hands_played=hands_played,
+        avg_match_margin=round(avg_match_margin, 1),
+        bid_rate=round(bid_rate, 3),
+        make_rate=round(make_rate, 3),
+        avg_bid_level=round(avg_bid_level, 1),
+        moon_call_rate=round(moon_call_rate, 3),
+        moon_make_rate=round(moon_make_rate, 3),
+        loner_call_rate=round(loner_call_rate, 3),
+        loner_make_rate=round(loner_make_rate, 3),
+    )
+
+
+def get_leaderboard(
+    session: Session,
+    *,
+    min_matches: int = 1,
+) -> list[PlayerStats]:
+    """Return leaderboard rankings sorted by net_eppd descending.
+
+    Only includes players with at least *min_matches* completed matches.
+    """
+    # Find all players with completed matches
+    player_match_counts = (
+        session.query(Match.player_id, func.count(Match.id).label("n"))
+        .filter_by(status="complete")
+        .group_by(Match.player_id)
+        .having(func.count(Match.id) >= min_matches)
+        .all()
+    )
+
+    stats_list: list[PlayerStats] = []
+    for player_id, _count in player_match_counts:
+        stats = compute_player_stats(session, player_id)
+        if stats is not None:
+            stats_list.append(stats)
+
+    # Sort by net_eppd descending (primary ranking metric)
+    stats_list.sort(key=lambda s: s.net_eppd, reverse=True)
+    return stats_list

--- a/web/routes.py
+++ b/web/routes.py
@@ -26,6 +26,7 @@ from bid_euchre.strategy.bidding import BidAction
 
 from .ai_manager import AIManager
 from .db import Decision, Hand, InviteCode, Match, Player
+from .leaderboard import get_leaderboard
 from .middleware import check_match_limit
 
 router = APIRouter()
@@ -1210,6 +1211,41 @@ async def new_match(
                     "models": models,
                 }
             )
+        )
+    finally:
+        session.close()
+
+
+# ---------------------------------------------------------------------------
+# Leaderboard
+# ---------------------------------------------------------------------------
+
+
+@router.get("/leaderboard/{link_uuid}", response_class=HTMLResponse)
+async def leaderboard(request: Request, link_uuid: str):
+    """Leaderboard page — ranked table of player stats.
+
+    Gated behind invite-code auth: the ``link_uuid`` must correspond to a
+    valid player (created via invite code redemption).  Returns 404 for
+    unknown UUIDs.
+    """
+    templates = _get_templates(request)
+    session = _get_session(request)
+    try:
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+        if player is None:
+            raise HTTPException(status_code=404, detail="Player not found")
+
+        rankings = get_leaderboard(session)
+
+        return templates.TemplateResponse(
+            "leaderboard.html",
+            {
+                "request": request,
+                "link_uuid": link_uuid,
+                "nickname": player.nickname,
+                "rankings": rankings,
+            },
         )
     finally:
         session.close()

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -73,6 +73,29 @@ header h1 a:hover {
     text-decoration: underline;
 }
 
+.header-bar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1.5rem;
+}
+
+.header-nav {
+    display: flex;
+    gap: 1rem;
+}
+
+.header-nav a {
+    color: var(--color-text-muted);
+    text-decoration: none;
+    font-size: 0.85rem;
+}
+
+.header-nav a:hover {
+    color: var(--color-text);
+    text-decoration: underline;
+}
+
 /* --------------------------------------------------------------------------
    2. Main / Game Board Container
    -------------------------------------------------------------------------- */

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -25,7 +25,15 @@
 <body>
     <a href="#main-content" class="skip-link">Skip to game</a>
     <header role="banner">
-        <h1><a href="/" aria-label="Bid Euchre home">Bid Euchre</a></h1>
+        <div class="header-bar">
+            <h1><a href="/" aria-label="Bid Euchre home">Bid Euchre</a></h1>
+            {% if link_uuid is defined and link_uuid %}
+            <nav class="header-nav" aria-label="Main navigation">
+                <a href="/play/{{ link_uuid }}">Game</a>
+                <a href="/leaderboard/{{ link_uuid }}">Leaderboard</a>
+            </nav>
+            {% endif %}
+        </div>
     </header>
     <main id="main-content" role="main">
         {% block content %}{% endblock %}

--- a/web/templates/leaderboard.html
+++ b/web/templates/leaderboard.html
@@ -1,0 +1,203 @@
+{% extends "base.html" %}
+
+{% block title %}Bid Euchre — Leaderboard{% endblock %}
+
+{% block head %}
+<style>
+    .leaderboard {
+        max-width: 960px;
+        margin: 1rem auto;
+        padding: 0 1rem;
+    }
+
+    .leaderboard__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 1rem;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .leaderboard__title {
+        font-size: 1.5rem;
+        margin: 0;
+    }
+
+    .leaderboard__back {
+        color: var(--color-text-muted);
+        text-decoration: none;
+        font-size: 0.9rem;
+    }
+
+    .leaderboard__back:hover {
+        color: var(--color-text);
+        text-decoration: underline;
+    }
+
+    .leaderboard__empty {
+        text-align: center;
+        padding: 3rem 1rem;
+        color: var(--color-text-muted);
+    }
+
+    .leaderboard__table-wrap {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .leaderboard__table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.85rem;
+    }
+
+    .leaderboard__table th,
+    .leaderboard__table td {
+        padding: 0.5rem 0.75rem;
+        text-align: right;
+        white-space: nowrap;
+        border-bottom: 1px solid var(--color-surface-light);
+    }
+
+    .leaderboard__table th:first-child,
+    .leaderboard__table td:first-child {
+        text-align: center;
+        width: 2.5rem;
+    }
+
+    .leaderboard__table th:nth-child(2),
+    .leaderboard__table td:nth-child(2) {
+        text-align: left;
+    }
+
+    .leaderboard__table thead th {
+        background: var(--color-surface);
+        color: var(--color-text-muted);
+        font-weight: 600;
+        position: sticky;
+        top: 0;
+        z-index: 1;
+    }
+
+    .leaderboard__table tbody tr:hover {
+        background: var(--color-surface-light);
+    }
+
+    .leaderboard__table .rank-col { width: 2.5rem; }
+    .leaderboard__table .name-col { min-width: 8rem; }
+    .leaderboard__table .primary-col {
+        font-weight: 600;
+        color: var(--color-moon);
+    }
+
+    .leaderboard__table .positive { color: var(--color-positive); }
+    .leaderboard__table .negative { color: var(--color-negative); }
+
+    .leaderboard__toggle {
+        margin-top: 0.75rem;
+        text-align: center;
+    }
+
+    .leaderboard__toggle button {
+        background: var(--color-surface);
+        color: var(--color-text-muted);
+        border: 1px solid var(--color-surface-light);
+        padding: 0.4rem 1rem;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 0.8rem;
+    }
+
+    .leaderboard__toggle button:hover {
+        background: var(--color-surface-light);
+        color: var(--color-text);
+    }
+
+    /* Secondary columns hidden by default */
+    .secondary-col { display: none; }
+    .leaderboard__table.show-secondary .secondary-col { display: table-cell; }
+
+    @media (max-width: 600px) {
+        .leaderboard__table { font-size: 0.75rem; }
+        .leaderboard__table th,
+        .leaderboard__table td { padding: 0.35rem 0.4rem; }
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="leaderboard" role="region" aria-label="Player leaderboard">
+    <div class="leaderboard__header">
+        <h2 class="leaderboard__title">Leaderboard</h2>
+        <a href="/play/{{ link_uuid }}" class="leaderboard__back">Back to Game</a>
+    </div>
+
+    {% if rankings|length == 0 %}
+    <div class="leaderboard__empty">
+        <p>No completed matches yet. Play a game to appear on the leaderboard!</p>
+    </div>
+    {% else %}
+    <div class="leaderboard__table-wrap">
+        <table class="leaderboard__table" id="leaderboard-table"
+               role="table" aria-label="Player rankings">
+            <thead>
+                <tr>
+                    <th class="rank-col" scope="col">#</th>
+                    <th class="name-col" scope="col">Player</th>
+                    <th class="primary-col" scope="col" title="Net expected points per deal">Net EPPD</th>
+                    <th scope="col">Won</th>
+                    <th scope="col" title="Win percentage">Win %</th>
+                    <th scope="col" title="Average margin when winning">Avg Margin</th>
+                    <th scope="col">Matches</th>
+                    {# Secondary columns — toggled via JS #}
+                    <th class="secondary-col" scope="col">Hands</th>
+                    <th class="secondary-col" scope="col" title="Average match score margin">Match Margin</th>
+                    <th class="secondary-col" scope="col" title="Fraction of hands declaring">Bid %</th>
+                    <th class="secondary-col" scope="col" title="Fraction of contracts made">Make %</th>
+                    <th class="secondary-col" scope="col" title="Average bid level">Avg Bid</th>
+                    <th class="secondary-col" scope="col" title="Moon call rate">Moon %</th>
+                    <th class="secondary-col" scope="col" title="Moon make rate">Moon Make</th>
+                    <th class="secondary-col" scope="col" title="Loner call rate">Loner %</th>
+                    <th class="secondary-col" scope="col" title="Loner make rate">Loner Make</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for entry in rankings %}
+                <tr>
+                    <td class="rank-col">{{ loop.index }}</td>
+                    <td class="name-col">{{ entry.nickname or "Anonymous" }}</td>
+                    <td class="primary-col {% if entry.net_eppd > 0 %}positive{% elif entry.net_eppd < 0 %}negative{% endif %}">
+                        {{ "%.3f"|format(entry.net_eppd) }}
+                    </td>
+                    <td>{{ entry.games_won }}</td>
+                    <td>{{ "%.1f"|format(entry.win_rate * 100) }}%</td>
+                    <td>{{ "%.1f"|format(entry.avg_margin_victory) }}</td>
+                    <td>{{ entry.matches_played }}</td>
+                    {# Secondary columns #}
+                    <td class="secondary-col">{{ entry.hands_played }}</td>
+                    <td class="secondary-col {% if entry.avg_match_margin > 0 %}positive{% elif entry.avg_match_margin < 0 %}negative{% endif %}">
+                        {{ "%.1f"|format(entry.avg_match_margin) }}
+                    </td>
+                    <td class="secondary-col">{{ "%.1f"|format(entry.bid_rate * 100) }}%</td>
+                    <td class="secondary-col">{{ "%.1f"|format(entry.make_rate * 100) }}%</td>
+                    <td class="secondary-col">{{ "%.1f"|format(entry.avg_bid_level) }}</td>
+                    <td class="secondary-col">{{ "%.1f"|format(entry.moon_call_rate * 100) }}%</td>
+                    <td class="secondary-col">{{ "%.1f"|format(entry.moon_make_rate * 100) }}%</td>
+                    <td class="secondary-col">{{ "%.1f"|format(entry.loner_call_rate * 100) }}%</td>
+                    <td class="secondary-col">{{ "%.1f"|format(entry.loner_make_rate * 100) }}%</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <div class="leaderboard__toggle">
+        <button type="button" id="toggle-secondary"
+                onclick="document.getElementById('leaderboard-table').classList.toggle('show-secondary'); this.textContent = this.textContent === 'Show More Stats' ? 'Show Less' : 'Show More Stats'">
+            Show More Stats
+        </button>
+    </div>
+    {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary

- Add `web/leaderboard.py` with `PlayerStats` dataclass and `compute_player_stats()` / `get_leaderboard()` aggregation from completed match/hand data
- Add `GET /leaderboard/{link_uuid}` route gated behind invite-code auth (404 for unknown players)
- Add responsive leaderboard template with primary columns (net_eppd, games_won, win_rate, avg_margin, matches_played) and toggleable secondary columns (hands_played, bid_rate, make_rate, moon/loner stats)
- Add navigation bar (Game / Leaderboard tabs) to the shared base template for authenticated players
- 15 new tests covering stats aggregation, ranking sort, min_matches filtering, route auth gating, and template rendering

## Why

Closes #1916 — Phase 4 Steps 1-2 of the browser game expansion (SP-AC-01). Players with completed matches can now view a ranked leaderboard showing product-facing metrics.

## Repro / Validation

```bash
uv run python -m pytest tests/unit/hosted_play/test_leaderboard.py -v
# 15 passed

uv run python -m pytest tests/unit/hosted_play/ -q
# 2804 passed, 6 skipped
```

## Tests

- `tests/unit/hosted_play/test_leaderboard.py` — 15 tests:
  - `TestComputePlayerStats` (7): none/no-match, single/multi match, moon/loner, all fields
  - `TestGetLeaderboard` (4): empty, sort order, min_matches filter, active-only exclusion
  - `TestLeaderboardRoute` (4): 200 valid player, 404 unknown, rankings display, empty message

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
branch: feat/web-leaderboard-analytics
```

## Pre-existing failures

3 unrelated test failures exist on main (verified by stashing changes):
- `test_ops_token_economy.py::TestAutoImport::test_stale_usage_with_missing_attr_*` (2)
- `test_telegram_filter.py::TestIsTelegramReceiverEdgeCases::test_unset_env_empty_dir` (1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)