### PR TITLE
feat(web): make Bud Bot default AI, label OLSa as Easy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,7 +43,7 @@ APP_URL=http://localhost:8000
 # Supported browser values:
 # - "olsa" for the R3 full_ols_av ActionValueBidder
 # - "bud_bot" for the R3 GBTActionValueBidder
-DEFAULT_MODEL_ID=olsa
+DEFAULT_MODEL_ID=bud_bot
 
 # Directory containing model artifact files (optional).
 # Used by AIManager to resolve relative artifact paths at runtime.

--- a/docs/01_core/DEPLOYMENT.md
+++ b/docs/01_core/DEPLOYMENT.md
@@ -67,7 +67,7 @@ full contract with defaults. The authoritative source is `web/config.py`
 | `SECRET_KEY` | Yes | Random per-process (dev) | Cookie/session signing |
 | `ALLOWED_ORIGINS` | No | `*` | Comma-separated CORS allowlist |
 | `APP_URL` | No | `http://localhost:8000` | Public base URL for share links |
-| `DEFAULT_MODEL_ID` | No | `olsa` | AI bidding model (`olsa` or `bud_bot`) |
+| `DEFAULT_MODEL_ID` | No | `bud_bot` | AI bidding model (`bud_bot` or `olsa`) |
 | `MODELS_DIR` | No | None | Directory for model artifacts |
 | `OLSA_ARTIFACT` | No | `data/artifacts/arc_d_v2/r3/training_artifact_full_ols_av.json` | Path to OLSa (ActionValueBidder) artifact |
 | `GBT_ARTIFACT` | No | `data/artifacts/arc_d_v2/r3/training_artifact_gbt_av.json` | Path to Bud Bot (GBTActionValueBidder) artifact |

--- a/render.yaml
+++ b/render.yaml
@@ -30,4 +30,4 @@ services:
       - key: MODELS_DIR
         value: /app/models
       - key: DEFAULT_MODEL_ID
-        value: olsa
+        value: bud_bot

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -116,7 +116,7 @@ def live_server(_db_path: str) -> Generator[str, None, None]:
         secret_key="test-browser-secret",
         allowed_origins=["*"],
         app_url=f"http://127.0.0.1:{port}",
-        default_model_id="olsa",
+        default_model_id="bud_bot",
         olsa_artifact=olsa_artifact,
         gbt_artifact=gbt_artifact,
         debug=True,

--- a/tests/unit/hosted_play/conftest.py
+++ b/tests/unit/hosted_play/conftest.py
@@ -207,7 +207,7 @@ def make_hosted_play_test_config(tmp_path: Path, **overrides: Any) -> HostedPlay
     olsa_artifact, gbt_artifact = create_browser_ai_test_artifacts(tmp_path)
     defaults: dict[str, Any] = {
         "database_url": f"sqlite:///{db_path}",
-        "default_model_id": "olsa",
+        "default_model_id": "bud_bot",
         "olsa_artifact": olsa_artifact,
         "gbt_artifact": gbt_artifact,
     }

--- a/tests/unit/hosted_play/test_ai_manager.py
+++ b/tests/unit/hosted_play/test_ai_manager.py
@@ -57,10 +57,10 @@ class TestBrowserRoster:
             )
         )
 
-        assert list(mgr.available_models) == ["olsa", "bud_bot"]
+        assert list(mgr.available_models) == ["bud_bot", "olsa"]
 
         olsa = mgr.get_model_info("olsa")
-        assert olsa.name == "OLSa"
+        assert olsa.name == "OLSa (Easy)"
         assert isinstance(olsa.bidding_policy, ActionValueBidder)
         assert isinstance(olsa.play_strategy, GluttonStrategy)
 
@@ -77,7 +77,7 @@ class TestBrowserRoster:
                 gbt_artifact=gbt_artifact,
             )
         )
-        assert [model.id for model in mgr.list_available()] == ["olsa", "bud_bot"]
+        assert [model.id for model in mgr.list_available()] == ["bud_bot", "olsa"]
 
     def test_default_model_must_be_in_roster(self, tmp_path):
         olsa_artifact, gbt_artifact = create_browser_ai_test_artifacts(tmp_path)

--- a/tests/unit/hosted_play/test_config.py
+++ b/tests/unit/hosted_play/test_config.py
@@ -25,7 +25,7 @@ class TestHostedPlayConfigDefaults:
 
     def test_default_model_id(self):
         cfg = HostedPlayConfig()
-        assert cfg.default_model_id == "olsa"
+        assert cfg.default_model_id == "bud_bot"
 
     def test_default_olsa_artifact(self):
         cfg = HostedPlayConfig()
@@ -215,7 +215,7 @@ class TestFromEnv:
         assert cfg.secret_key.startswith("dev-insecure-")
         assert cfg.allowed_origins == ["*"]
         assert cfg.app_url == "http://localhost:8000"
-        assert cfg.default_model_id == "olsa"
+        assert cfg.default_model_id == "bud_bot"
         assert (
             cfg.olsa_artifact
             == "data/artifacts/arc_d_v2/r3/training_artifact_full_ols_av.json"

--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -72,23 +72,37 @@ class ModelStub:
 class TestModelSelect:
     def test_renders_models_dropdown(self, env):
         models = [
-            ModelStub("olsa", "OLSa", "Action-value bidder"),
             ModelStub("bud_bot", "Bud Bot", "Gradient-boosted bidder"),
+            ModelStub("olsa", "OLSa (Easy)", "Conservative action-value bidder"),
         ]
         tmpl = env.get_template("partials/model_select.html")
-        html = tmpl.render(link_uuid="abc-123", nickname="Alice", models=models)
+        html = tmpl.render(
+            link_uuid="abc-123",
+            nickname="Alice",
+            models=models,
+            default_model_id="bud_bot",
+        )
         assert 'value="olsa"' in html
-        assert "OLSa" in html
+        assert "OLSa (Easy)" in html
         assert 'value="bud_bot"' in html
         assert "Bud Bot" in html
         assert "Alice" in html
         assert 'action="/play/abc-123/select-ai"' in html
+        # Bud Bot should be pre-selected as default
+        assert 'value="bud_bot" selected' in html
+        # OLSa should NOT be pre-selected
+        assert 'value="olsa" selected' not in html
 
     def test_renders_single_model(self, env):
-        models = [ModelStub("olsa", "OLSa", "Action-value bidder")]
+        models = [ModelStub("bud_bot", "Bud Bot", "Gradient-boosted bidder")]
         tmpl = env.get_template("partials/model_select.html")
-        html = tmpl.render(link_uuid="x", nickname="Bob", models=models)
-        assert 'value="olsa"' in html
+        html = tmpl.render(
+            link_uuid="x",
+            nickname="Bob",
+            models=models,
+            default_model_id="bud_bot",
+        )
+        assert 'value="bud_bot"' in html
         assert "Start Match" in html
 
 
@@ -1825,9 +1839,14 @@ class TestAccessibilityForms:
         assert 'aria-label="Set your nickname"' in html
 
     def test_model_select_has_region(self, env):
-        models = [ModelStub("olsa", "OLSa", "Action-value bidder")]
+        models = [ModelStub("bud_bot", "Bud Bot", "Gradient-boosted bidder")]
         tmpl = env.get_template("partials/model_select.html")
-        html = tmpl.render(link_uuid="x", nickname="Bob", models=models)
+        html = tmpl.render(
+            link_uuid="x",
+            nickname="Bob",
+            models=models,
+            default_model_id="bud_bot",
+        )
         assert 'role="region"' in html
         assert 'aria-label="Choose AI opponent"' in html
 

--- a/web/ai_manager.py
+++ b/web/ai_manager.py
@@ -68,9 +68,13 @@ class AIManager:
     # ------------------------------------------------------------------
 
     def _load_models(self, config: HostedPlayConfig) -> None:
-        """Register and preload the approved browser roster."""
-        self._try_load_olsa(config)
+        """Register and preload the approved browser roster.
+
+        Bud Bot is loaded first so it appears first in the UI dropdown
+        (default opponent).  OLSa follows as the "Easy" alternative.
+        """
         self._try_load_bud_bot(config)
+        self._try_load_olsa(config)
 
         expected_roster = {"olsa", "bud_bot"}
         missing_models = sorted(expected_roster - self.available_models.keys())
@@ -124,8 +128,8 @@ class AIManager:
 
                 self.available_models["olsa"] = ModelInfo(
                     id="olsa",
-                    name="OLSa",
-                    description=("Action-value bidder with Glutton card play."),
+                    name="OLSa (Easy)",
+                    description=("Conservative action-value bidder — easier opponent."),
                     bidding_policy=ActionValueBidder(
                         artifact_path=path,
                         name="olsa",

--- a/web/config.py
+++ b/web/config.py
@@ -68,7 +68,7 @@ class HostedPlayConfig:
     app_url: str = "http://localhost:8000"
 
     # AI model roster ---------------------------------------------------
-    default_model_id: str = "olsa"
+    default_model_id: str = "bud_bot"
     olsa_artifact: str | None = _DEFAULT_OLSA_ARTIFACT
     gbt_artifact: str | None = _DEFAULT_GBT_ARTIFACT
     models_dir: str | None = None
@@ -91,7 +91,7 @@ class HostedPlayConfig:
             secret_key=os.environ.get("SECRET_KEY", _default_secret_key()),
             allowed_origins=_parse_origins(raw_origins),
             app_url=os.environ.get("APP_URL", "http://localhost:8000"),
-            default_model_id=os.environ.get("DEFAULT_MODEL_ID", "olsa"),
+            default_model_id=os.environ.get("DEFAULT_MODEL_ID", "bud_bot"),
             olsa_artifact=os.environ.get("OLSA_ARTIFACT", _DEFAULT_OLSA_ARTIFACT),
             gbt_artifact=os.environ.get("GBT_ARTIFACT", _DEFAULT_GBT_ARTIFACT),
             models_dir=os.environ.get("MODELS_DIR"),

--- a/web/routes.py
+++ b/web/routes.py
@@ -676,6 +676,7 @@ async def game_page(request: Request, link_uuid: str):
                     "link_uuid": link_uuid,
                     "nickname": player.nickname,
                     "models": models,
+                    "default_model_id": ai_manager.default_model_id,
                 },
             )
 
@@ -718,6 +719,7 @@ async def set_nickname(
                     "link_uuid": link_uuid,
                     "nickname": nickname,
                     "models": models,
+                    "default_model_id": ai_manager.default_model_id,
                 }
             )
         )
@@ -1209,6 +1211,7 @@ async def new_match(
                     "link_uuid": link_uuid,
                     "nickname": player.nickname or "Player",
                     "models": models,
+                    "default_model_id": ai_manager.default_model_id,
                 }
             )
         )

--- a/web/templates/partials/model_select.html
+++ b/web/templates/partials/model_select.html
@@ -3,6 +3,7 @@
      - link_uuid: str — player's game link UUID
      - nickname: str — player's (escaped) nickname
      - models: list[ModelInfo] — available AI models (each has .id, .name, .description)
+     - default_model_id: str — ID of the default (pre-selected) model
 #}
 <div id="model-select" role="region" aria-label="Choose AI opponent">
     <h2>Welcome, {{ nickname }}!</h2>
@@ -16,7 +17,7 @@
         <label for="model-select-dropdown" class="sr-only">AI opponent</label>
         <select id="model-select-dropdown" name="model_id" required aria-label="AI opponent model">
             {% for model in models %}
-            <option value="{{ model.id }}">{{ model.name }} &mdash; {{ model.description }}</option>
+            <option value="{{ model.id }}"{% if model.id == default_model_id %} selected{% endif %}>{{ model.name }} &mdash; {{ model.description }}</option>
             {% endfor %}
         </select>
         <button type="submit" aria-label="Start match with selected AI">Start Match</button>


### PR DESCRIPTION
## Summary

- Switch default AI opponent from OLSa to Bud Bot (user proving feedback)
- Label OLSa as "OLSa (Easy)" with "Conservative action-value bidder" description
- Bud Bot loads first in roster → appears first in dropdown
- Pre-select default model in the `<select>` dropdown via `selected` attribute

## Why

User proving showed Bud Bot is the more engaging default opponent. OLSa is a
conservative (easier) alternative that should be clearly labeled as such.

## Changed Files

| File | Change |
|------|--------|
| `web/config.py` | `default_model_id` default: `olsa` → `bud_bot` |
| `web/ai_manager.py` | OLSa name/desc updated; roster load order swapped |
| `web/routes.py` | Pass `default_model_id` to all model_select template renders |
| `web/templates/partials/model_select.html` | Add `selected` attr for default |
| `.env.example` | Update documented default |
| `render.yaml` | Update Render deploy default |
| `docs/01_core/DEPLOYMENT.md` | Update env var table |
| `tests/` | Update assertions for new default, order, and labels |

## Repro / Validation

```bash
# Unit tests
uv run python -m pytest tests/unit/hosted_play/ -q
# 2804 passed, 6 skipped

# Full validation (3 pre-existing failures in ops domain, unrelated)
make check-quiet
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
branch: web/bud-bot-default
```

## Test plan
- [x] Start fresh match — Bud Bot is pre-selected/default in dropdown
- [x] OLSa option visible with "Easy" label
- [x] All hosted_play unit tests pass (2804 passed)
- [x] Template tests verify `selected` attribute on Bud Bot option
- [x] Config tests verify new default_model_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)