### PR TITLE
fix(web): hide trick-play state during auction bid reveal

### DIFF
--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -414,6 +414,77 @@ class TestNextRevealFlow:
         assert hand_after.phase == "trick_play"
         session_after.close()
 
+    def test_hidden_auction_hides_trick_play_state(self, client, app):
+        """Trick data must not render while auction bids are still hidden.
+
+        Regression test: when the engine auto-advances from auction into
+        trick play (AI bids completing the auction + AI leading the first
+        trick), the route-level game context must suppress trick-play state
+        until all auction entries are revealed via /next.
+        """
+        link_uuid = _setup_game(client)
+
+        result = get_match_state(app, link_uuid)
+        assert result is not None
+        state, match_row, session = result
+
+        hand = state.current_hand
+        assert hand is not None
+
+        # Simulate: engine finished auction → trick_play, but only 1 of 4
+        # auction bids has been revealed to the user.
+        hand.phase = "trick_play"
+        hand.dealer_seat = 3
+        hand.current_seat = HUMAN_SEAT
+        hand.turn_number = 5  # 4 bids + 1 AI card play
+        hand.bidder_seat = 1
+        hand.winning_bid = 5
+        hand.bid_type = "regular"
+        hand.contract_type = "suit"
+        hand.trump = "S"
+        hand.auction = [
+            {
+                "seat": 0,
+                "n": 5,
+                "action": "bid",
+                "contract": "S",
+                "bid_type": "regular",
+            },
+            {"seat": 1, "n": 0, "action": "pass"},
+            {"seat": 2, "n": 0, "action": "pass"},
+            {"seat": 3, "n": 0, "action": "pass"},
+        ]
+        hand.revealed_auction_count = 1  # Only human's bid revealed
+
+        # AI already played a card into the trick (engine auto-advance)
+        hand.current_trick = TrickState(
+            leader=1,
+            plays=[(1, Card("D", "A"))],
+        )
+        # AI hand now has 9 cards (one played)
+        hand.hands[1] = hand.hands[1][:9]
+
+        match_row.match_state_json = json.dumps(state.to_dict())
+        session.commit()
+        session.close()
+
+        # Render the game page — should show auction reveal, NOT trick data
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+
+        # The "Next" button should be visible (auction reveal in progress)
+        assert f'hx-post="/play/{link_uuid}/next"' in resp.text
+
+        # Trick area should NOT show the AI's played card
+        # D♦ / A would appear as card rank+suit in the trick area
+        assert "card--played" not in resp.text
+
+        # AI Left hand count should show 10 (pre-play), not 9
+        assert "AI Left (10)" in resp.text
+
+        # No "Play card" button — still in auction reveal
+        assert 'id="card-play-form"' not in resp.text
+
 
 # ---------------------------------------------------------------------------
 # Test 5: Submit card → state advances

--- a/web/routes.py
+++ b/web/routes.py
@@ -364,6 +364,12 @@ def _build_game_context(
         visible["auction"] = visible.get("auction", [])[: hand.revealed_auction_count]
         visible["contract_type"] = None
         visible["trump"] = None
+        # Hide trick-play state leaked by engine auto-advance — the user
+        # hasn't finished revealing auction bids yet.
+        visible["current_trick"] = None
+        visible["completed_tricks"] = []
+        visible["tricks_team0"] = 0
+        visible["tricks_team1"] = 0
     if hand is not None and hand.phase == "trick_play" and hand.paused_after_trick:
         visible["current_trick"] = None
 
@@ -415,10 +421,18 @@ def _build_game_context(
                 else "Choose 2 cards to give to the mooner"
             )
 
-        # AI hand card counts (face-down display)
-        ctx["opp_left_count"] = len(hand.hands[1]) if len(hand.hands) > 1 else 0
-        ctx["partner_count"] = len(hand.hands[2]) if len(hand.hands) > 2 else 0
-        ctx["opp_right_count"] = len(hand.hands[3]) if len(hand.hands) > 3 else 0
+        # AI hand card counts (face-down display).
+        # During hidden-auction reveal the engine may have auto-advanced
+        # into trick play (reducing AI hand sizes), but the user hasn't
+        # seen the auction result yet — show pre-play counts.
+        if _has_hidden_auction(hand):
+            ctx["opp_left_count"] = 10
+            ctx["partner_count"] = 10
+            ctx["opp_right_count"] = 10
+        else:
+            ctx["opp_left_count"] = len(hand.hands[1]) if len(hand.hands) > 1 else 0
+            ctx["partner_count"] = len(hand.hands[2]) if len(hand.hands) > 2 else 0
+            ctx["opp_right_count"] = len(hand.hands[3]) if len(hand.hands) > 3 else 0
     else:
         ctx["winning_bid"] = None
         ctx["bidder_seat"] = None


### PR DESCRIPTION
## Plan
N/A — bug fix from user proving run

## Summary
- Fix game context leaking trick-play state (played cards, trick counts, reduced AI hand sizes) while auction bids are still being revealed via the Next button
- Add regression test proving trick data is hidden during auction reveal

## Why
When the engine auto-advances from auction into trick play (AI bids completing the auction + AI leading the first trick), the rendered game board showed cards played in the trick area and reduced AI card-back counts while the user was still clicking "Next" to reveal auction bids. This made it look like cards were being played during the auction.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_routes.py::TestNextRevealFlow::test_hidden_auction_hides_trick_play_state -xvs
uv run python -m pytest tests/unit/hosted_play/ -x -q  # 2805 passed
make check-quiet  # 3 pre-existing failures in unrelated modules
```

## Test Criteria
- **Pass condition:** When engine phase is `trick_play` but `revealed_auction_count < len(auction)`, the rendered HTML must NOT contain `card--played` class and AI hand counts must show 10
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_routes.py::TestNextRevealFlow::test_hidden_auction_hides_trick_play_state -xvs`
- **Expected result:** Test passes — no trick cards rendered, AI Left shows 10 cards, no play-card form

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/ -x -q` — 2805 passed
- [x] `make check-quiet` — 3 pre-existing failures in unrelated modules (token_economy, telegram_filter)

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [ ] Low (docs/tests only)
- [x] Medium (web routes / game rendering)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git worktree list` (relevant line):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c   9d4250df [fix/auction-first-hand-cards]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)