### PR TITLE
fix(web): add _advance_ai after moon exchange to prevent game stuck (#1910)

### DIFF
--- a/src/bid_euchre/hosted_play/engine.py
+++ b/src/bid_euchre/hosted_play/engine.py
@@ -342,6 +342,11 @@ class MatchEngine:
         # Re-sort human hand with bower awareness
         sort_hand_for_display(hand.hands[HUMAN_SEAT], hand.contract_type, hand.trump)
 
+        # Auto-advance AI just like submit_human_bid/submit_human_card.
+        # Without this, the game is stuck when the leader (bidder) is an AI
+        # seat because no mechanism triggers AI card play after exchange.
+        state = self._advance_ai(state)
+
         return state
 
     def get_legal_bids(self, state: MatchState) -> list[BidAction]:

--- a/tests/unit/hosted_play/test_engine.py
+++ b/tests/unit/hosted_play/test_engine.py
@@ -1487,6 +1487,140 @@ class TestInteractiveMoonExchange:
 
 
 # ---------------------------------------------------------------------------
+# Test 14c: Moon exchange — AI advance after exchange (#1910)
+# ---------------------------------------------------------------------------
+
+
+class TestMoonExchangeAIAdvance:
+    """After moon exchange, AI auto-advances when the leader is an AI seat.
+
+    Regression tests for #1910: the game was stuck after a moon exchange
+    when the bidder (who leads the first trick) was an AI, because
+    ``submit_exchange_selection`` did not call ``_advance_ai``.
+    """
+
+    def test_ai_mooner_advances_after_partner_exchange(self) -> None:
+        """When an AI bids moon and human is the partner, AI leads after exchange.
+
+        After submit_exchange_selection, the engine must auto-advance AI
+        so that the game isn't stuck on the AI leader's turn.
+        """
+        engine = MatchEngine(
+            bidding_policy=MoonBidder(contract="S"),
+            play_strategy=FirstLegalPlay(),
+        )
+        # Find a seed where seat 2 (AI Partner) bids moon.
+        # The human (seat 0) is the partner — exchange is interactive.
+        for seed in range(1000):
+            state = engine.start_match(seed, "heuristic")
+            hand = state.current_hand
+            if hand is None:
+                continue
+
+            # If human's turn in auction, pass (so AI partner can bid)
+            if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+                state = engine.submit_human_bid(state, BidAction.pass_bid())
+                hand = state.current_hand
+                if hand is None:
+                    continue
+
+            # Look for interactive exchange where seat 2 is the mooner
+            if hand.phase == "moon_exchange" and hand.bidder_seat == 2:
+                assert hand.exchange_phase == "selecting"
+
+                # Human is the partner — select 2 cards to give
+                state = engine.submit_exchange_selection(state, [0, 1])
+                hand = state.current_hand
+                assert hand is not None
+
+                # After exchange + AI advance, the game must be playable:
+                # sitting_out_seat is None (moon, not loner)
+                assert hand.sitting_out_seat is None
+
+                # If trick play: current_seat should be HUMAN_SEAT
+                # (the AI leader and subsequent AI seats should have
+                # already played via _advance_ai)
+                if hand.phase == "trick_play":
+                    assert hand.current_seat == HUMAN_SEAT, (
+                        f"Game stuck on AI seat {hand.current_seat}; "
+                        f"_advance_ai did not run after exchange"
+                    )
+                    # AI should have played cards already
+                    assert hand.current_trick is not None
+                    assert len(hand.current_trick.plays) > 0
+                return
+
+        pytest.skip("No seed found where AI Partner (seat 2) bids moon")
+
+    def test_moon_no_sitting_out_after_exchange(self) -> None:
+        """Moon bids must never set sitting_out_seat — all 4 players play.
+
+        This is the core invariant that distinguishes moon from loner.
+        """
+        engine = MatchEngine(
+            bidding_policy=MoonBidder(contract="S"),
+            play_strategy=FirstLegalPlay(),
+        )
+        found = False
+        for seed in range(500):
+            state = engine.start_match(seed, "heuristic")
+            hand = state.current_hand
+            if hand is None:
+                continue
+
+            # Pass if it's the human's turn
+            if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+                state = engine.submit_human_bid(state, BidAction.pass_bid())
+                hand = state.current_hand
+                if hand is None:
+                    continue
+
+            # Handle interactive exchange
+            if hand.phase == "moon_exchange":
+                state = engine.submit_exchange_selection(state, [0, 1])
+                hand = state.current_hand
+                assert hand is not None
+
+            if hand.bid_type == "moon":
+                assert hand.sitting_out_seat is None, (
+                    f"Moon bid should never set sitting_out_seat, "
+                    f"got {hand.sitting_out_seat}"
+                )
+                found = True
+
+        assert found, "No moon bid occurred across 500 seeds"
+
+    def test_human_mooner_leads_after_exchange(self) -> None:
+        """When human bids moon and is the leader, no AI advance is needed."""
+        engine = MatchEngine(
+            bidding_policy=AlwaysPassBidder(),
+            play_strategy=FirstLegalPlay(),
+        )
+        state = engine.start_match(SEED, "heuristic")
+        hand = state.current_hand
+        assert hand is not None
+
+        if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+            state = engine.submit_human_bid(state, BidAction.moon("S"))
+            hand = state.current_hand
+            assert hand is not None
+
+            if hand.phase == "moon_exchange":
+                state = engine.submit_exchange_selection(state, [0, 1])
+                hand = state.current_hand
+                assert hand is not None
+
+                # Human bid moon → human leads → current_seat is HUMAN_SEAT
+                if hand.phase == "trick_play":
+                    assert hand.current_seat == HUMAN_SEAT
+                    assert hand.bidder_seat == HUMAN_SEAT
+                    assert hand.sitting_out_seat is None
+                    # No AI plays yet — human leads
+                    assert hand.current_trick is not None
+                    assert len(hand.current_trick.plays) == 0
+
+
+# ---------------------------------------------------------------------------
 # Test 15: Loner sit-out trick flow
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -2150,3 +2150,153 @@ class TestInviteCodeFlow:
         resp = client.post("/new", follow_redirects=False)
         assert resp.status_code == 302
         assert "/play/" in resp.headers["location"]
+
+
+# ---------------------------------------------------------------------------
+# Test: Moon exchange route — AI leads after exchange (#1910)
+# ---------------------------------------------------------------------------
+
+
+class TestMoonExchangeRoute:
+    """Route-level tests for moon exchange flow.
+
+    Regression test for #1910: when an AI bids moon, the game was stuck
+    after the exchange because ``submit_exchange_selection`` did not call
+    ``_advance_ai``.  The human saw trick play but no AI had played,
+    making it appear as if the partner was "sitting out".
+    """
+
+    def test_ai_mooner_exchange_then_trick_play(self, client, app):
+        """After AI moon exchange + reveal, the game is in a playable state.
+
+        Sets up a state where AI Partner (seat 2) bid moon and the human
+        is the exchange partner.  After submitting the exchange and clicking
+        "Start Trick Play", the board must show trick play with the human's
+        turn (AI should have already played via _advance_ai).
+        """
+        link_uuid = _setup_game(client)
+
+        result = get_match_state(app, link_uuid)
+        assert result is not None
+        state, match_row, session = result
+
+        hand = state.current_hand
+        assert hand is not None
+
+        # Simulate: AI Partner (seat 2) bid moon, auction complete.
+        # Human (seat 0) is the exchange partner — interactive exchange.
+        hand.phase = "moon_exchange"
+        hand.exchange_phase = "selecting"
+        hand.current_seat = HUMAN_SEAT
+        hand.turn_number = 6
+        hand.bidder_seat = 2  # AI Partner is the mooner
+        hand.winning_bid = 10
+        hand.bid_type = "moon"
+        hand.contract_type = "suit"
+        hand.trump = "S"
+        hand.sitting_out_seat = None  # Moon = no sit-out
+        hand.revealed_auction_count = len(hand.auction)
+        hand.exchange_given = None
+        hand.exchange_received = None
+        hand.exchange_revealed = False
+        # Give everyone valid 10-card hands (ranks use "T" for 10)
+        hand.hands = [
+            [
+                Card("S", "A"),
+                Card("S", "K"),
+                Card("S", "Q"),
+                Card("S", "J"),
+                Card("S", "T"),
+                Card("H", "A"),
+                Card("H", "K"),
+                Card("H", "Q"),
+                Card("H", "J"),
+                Card("H", "T"),
+            ],
+            [
+                Card("D", "A"),
+                Card("D", "K"),
+                Card("D", "Q"),
+                Card("D", "J"),
+                Card("D", "T"),
+                Card("C", "A"),
+                Card("C", "K"),
+                Card("C", "Q"),
+                Card("C", "J"),
+                Card("C", "T"),
+            ],
+            [
+                Card("S", "A"),
+                Card("S", "K"),
+                Card("S", "Q"),
+                Card("S", "J"),
+                Card("S", "T"),
+                Card("H", "A"),
+                Card("H", "K"),
+                Card("H", "Q"),
+                Card("H", "J"),
+                Card("H", "T"),
+            ],
+            [
+                Card("D", "A"),
+                Card("D", "K"),
+                Card("D", "Q"),
+                Card("D", "J"),
+                Card("D", "T"),
+                Card("C", "A"),
+                Card("C", "K"),
+                Card("C", "Q"),
+                Card("C", "J"),
+                Card("C", "T"),
+            ],
+        ]
+
+        match_row.match_state_json = json.dumps(state.to_dict())
+        session.commit()
+        session.close()
+
+        # Step 1: GET shows moon exchange selection form
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        assert "exchange" in resp.text.lower()
+
+        # Step 2: Submit exchange — human gives 2 cards
+        resp = client.post(
+            f"/play/{link_uuid}/exchange",
+            data={"card_index_0": 0, "card_index_1": 1},
+        )
+        assert resp.status_code == 200
+
+        # Step 3: After exchange, we should see the exchange interstitial
+        # (exchange_revealed is False at this point)
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        assert "Moon Exchange" in resp.text
+        assert "Start Trick Play" in resp.text
+
+        # Step 4: Click "Start Trick Play" to reveal the exchange
+        resp = client.post(f"/play/{link_uuid}/next")
+        assert resp.status_code == 200
+        # After reveal, exchange interstitial should be gone
+        assert "Moon Exchange" not in resp.text
+
+        # Step 5: Verify the game state is playable (not stuck)
+        result_after = get_match_state(app, link_uuid)
+        assert result_after is not None
+        state_after, _, session_after = result_after
+        hand_after = state_after.current_hand
+        assert hand_after is not None
+        assert hand_after.phase == "trick_play"
+        assert hand_after.exchange_revealed is True
+        assert (
+            hand_after.sitting_out_seat is None
+        ), "Moon bid must not set sitting_out_seat"
+        # AI should have advanced — current_seat must be HUMAN_SEAT
+        # (or the hand might have completed if AI played through).
+        # The key assertion: the game is NOT stuck on an AI seat.
+        if hand_after.phase == "trick_play":
+            assert hand_after.current_seat == HUMAN_SEAT, (
+                f"Game stuck on AI seat {hand_after.current_seat} "
+                f"after moon exchange — _advance_ai not called"
+            )
+        session_after.close()


### PR DESCRIPTION
## Plan
N/A — bugfix from user proving run (#1910)

## Summary
- `submit_exchange_selection()` now calls `_advance_ai()` after transitioning to trick play, matching `submit_human_bid()` and `submit_human_card()`
- Added 3 engine-level tests verifying AI advances after exchange, moon never sets sitting_out, and human mooner leads correctly
- Added 1 route-level integration test verifying the full exchange → reveal → trick play flow when an AI is the moon bidder

## Why
When an AI bid moon and was the trick leader after exchange, the game froze because no mechanism triggered AI card play. The user saw trick play but couldn't interact — it appeared as if the partner was "sitting out" (loner behavior) when it should have been a moon (all 4 players play).

Root cause: `submit_exchange_selection()` was the only public engine method that did not call `_advance_ai()` after modifying game state.

Core sim (`src/bid_euchre/sim/simulation.py`) is unaffected — it processes all turns in a single loop without interactive pause points.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_engine.py -k "TestMoonExchangeAIAdvance" -v
uv run python -m pytest tests/unit/hosted_play/test_routes.py -k "TestMoonExchangeRoute" -v
uv run python -m pytest tests/unit/hosted_play/ -q
make check-quiet  # 3 pre-existing failures in ops token economy + telegram filter
```

**Config (if applicable):** N/A

**Seed (if applicable):** N/A (seed search in tests finds relevant scenarios automatically)

## Test Criteria
- **Pass condition:** `test_ai_mooner_advances_after_partner_exchange` asserts `current_seat == HUMAN_SEAT` after exchange when AI bids moon (would fail without the fix)
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_engine.py::TestMoonExchangeAIAdvance -v`
- **Expected result:** 3/3 tests pass

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/ -q` — 2809 passed, 5 skipped
- [x] `make check-quiet` — all green except 3 pre-existing failures in unrelated modules
- [ ] Other: Core sim verified clean (moon exchange + loner sit-out are separate code paths)

## Expected impact
- Metrics impact (if any): None — fix only affects hosted_play browser game
- Runtime impact (if any): Negligible — one additional `_advance_ai()` call during exchange

## Risk level
- [ ] Low (docs/tests only)
- [x] Medium (strategy/experiments) — hosted_play engine change
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre  [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b  fix/moon-bid-partner-sit-out
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)