### PR TITLE
fix(web): make mobile card tap play immediately instead of select-confirm

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -1562,7 +1562,7 @@ class TestAccessibilityHand:
             legal_plays=[0],
             phase="trick_play",
         )
-        assert 'aria-label="Select A of Spades"' in html
+        assert 'aria-label="Play A of Spades"' in html
 
     def test_illegal_card_has_aria_label(self, env):
         tmpl = env.get_template("partials/hand.html")

--- a/web/static/game.js
+++ b/web/static/game.js
@@ -2,8 +2,7 @@
  * Browser game interactions.
  *
  * Responsibilities:
- * - tap/select a legal card and submit as a single confirm form
- * - auto-submit card plays on non-touch devices
+ * - tap a legal card to play it immediately (all devices)
  * - keep card selection state in sync across HTMX swaps
  */
 (function () {
@@ -24,14 +23,6 @@
             return null;
         }
         return form.querySelector('#selected-card-index');
-    }
-
-    function isLikelyTouchDevice() {
-        return (
-            window.matchMedia('(hover: none), (pointer: coarse)').matches ||
-            ('ontouchstart' in window) ||
-            (typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0)
-        );
     }
 
     function clearCardSelection(form) {
@@ -56,7 +47,7 @@
         }
 
         if (help !== null) {
-            help.textContent = 'Tap a card to select it, then tap Play card.';
+            help.textContent = 'Tap a card to play it.';
         }
     }
 
@@ -105,11 +96,7 @@
 
         var help = form.querySelector('#card-play-help');
         if (help !== null) {
-            if (isLikelyTouchDevice()) {
-                help.textContent = 'Card selected. Tap Play card to submit.';
-            } else {
-                help.textContent = 'Card selected. Submitting...';
-            }
+            help.textContent = 'Playing card...';
         }
     }
 
@@ -158,10 +145,7 @@
             }
 
             selectCard(handForm, card);
-
-            if (!isLikelyTouchDevice()) {
-                submitForm(handForm);
-            }
+            submitForm(handForm);
         });
 
         document.body.addEventListener('htmx:afterSwap', function (event) {

--- a/web/templates/partials/hand.html
+++ b/web/templates/partials/hand.html
@@ -24,8 +24,8 @@
             {% if phase == "trick_play" and legal_plays is not none and idx in legal_plays %}
                 <button type="button"
                         class="card card--{{ suit_class }} card--legal"
-                        title="{{ rank }}{{ suit_sym }} (tap to select)"
-                        aria-label="Select {{ rank }} of {{ suit_name }}"
+                        title="{{ rank }}{{ suit_sym }} (tap to play)"
+                        aria-label="Play {{ rank }} of {{ suit_name }}"
                         data-card-index="{{ idx }}">
                     <span class="card__rank" aria-hidden="true">{{ rank }}</span>
                     <span class="card__suit" aria-hidden="true">{{ suit_sym }}</span>
@@ -59,7 +59,7 @@
                     disabled
                     aria-label="Play selected card">Play card</button>
             <p id="card-play-help" class="card-play-help" aria-live="polite">
-                Tap a card to select it, then tap Play card.
+                Tap a card to play it.
             </p>
         </form>
     {% endif %}


### PR DESCRIPTION
## Summary
- Remove the touch-device-specific select-then-confirm flow that caused cards to get stuck in a selected state on mobile Safari
- All devices now use **tap-to-play**: tapping a legal card immediately submits it, consistent with desktop behavior
- Update card titles, aria-labels, and help text to reflect the new interaction model

## Why
Mobile users reported three issues during proving: (1) cards sometimes played immediately without confirmation, (2) after selecting/deselecting, cards became unresponsive, and (3) there was no way to deselect a card. The root cause was competing touch/click handlers and the `isLikelyTouchDevice()` detection being unreliable across mobile browsers.

The operator recommended Option A (tap-to-play) for consistency with the desktop experience, which already works this way.

## Changes
- `web/static/game.js`: Removed `isLikelyTouchDevice()` function; always auto-submit after card selection; simplified help text
- `web/templates/partials/hand.html`: Updated card `title` from "tap to select" → "tap to play", `aria-label` from "Select" → "Play", help text from "select then confirm" → "tap to play"
- `tests/unit/hosted_play/test_partials.py`: Updated aria-label assertion to match new "Play X of Y" pattern

## Repro / Validation
1. Start the hosted game server: `uv run python -m bid_euchre.hosted_play.app`
2. Open on mobile device or mobile emulator
3. During trick play, tap a legal card → it should play immediately
4. No stuck/unresponsive states after any interaction
5. Desktop behavior unchanged (was already tap-to-play)

```bash
uv run python -m pytest tests/unit/hosted_play/test_partials.py -q  # 120 passed
```

## Tests
- `uv run python -m pytest tests/unit/hosted_play/test_partials.py` — 120 passed ✅
- `make check-quiet` — all pass except 3 pre-existing failures unrelated to this PR (token economy + telegram filter)

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
branch: fix/mobile-card-tap-to-play
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)