### PR TITLE
fix(sim): make moon bids use 3-player trick play (partner sits out)

### DIFF
--- a/src/bid_euchre/sim/simulation.py
+++ b/src/bid_euchre/sim/simulation.py
@@ -542,11 +542,11 @@ def play_single_hand(
                 initial_leader = random.Random().randrange(4)
     leader = initial_leader
 
-    # Determine active seats for trick play (loner bids exclude declarer's partner)
+    # Determine active seats for trick play (loner/moon bids exclude declarer's partner)
     sitting_out_seat: Optional[int] = None
     if (
         winning_bid_action is not None
-        and winning_bid_action.bid_type == "loner"
+        and winning_bid_action.bid_type in {"loner", "moon"}
         and winning_bidder is not None
     ):
         # Partner sits out: partnerships are (0,2) and (1,3)

--- a/tests/integration/test_loner_game.py
+++ b/tests/integration/test_loner_game.py
@@ -267,8 +267,8 @@ class TestLonerTrickPlay:
                 tracker.plays_by_seat[seat] == 10
             ), f"Seat {seat} played {tracker.plays_by_seat[seat]} cards, expected 10"
 
-    def test_moon_game_still_4_players(self):
-        """Moon bids should still use 4-player trick play."""
+    def test_moon_game_3_players(self):
+        """Moon bids should use 3-player trick play (partner sits out after exchange)."""
         rng = random.Random(42)
         deck = create_deck()
         shuffle_deck(deck, rng=rng)
@@ -289,11 +289,85 @@ class TestLonerTrickPlay:
         t0, t1 = result[0], result[1]
         assert t0 + t1 == 10
 
-        # All 4 players should have played 10 cards each
+        # Partner (seat 2) should sit out — 0 cards played
+        partner_seat = _PARTNER[0]  # declarer=0, partner=2
+        assert tracker.plays_by_seat[partner_seat] == 0, (
+            f"Partner (seat {partner_seat}) played {tracker.plays_by_seat[partner_seat]} "
+            f"cards, expected 0 (should sit out in moon)"
+        )
+
+        # Active players should have played 10 cards each
         for seat in range(4):
+            if seat == partner_seat:
+                continue
             assert (
                 tracker.plays_by_seat[seat] == 10
-            ), f"Seat {seat} played {tracker.plays_by_seat[seat]} cards, expected 10"
+            ), f"Active seat {seat} played {tracker.plays_by_seat[seat]} cards, expected 10"
+
+        # Total plays should be 30 (3 players x 10 tricks)
+        total_plays = sum(tracker.plays_by_seat.values())
+        assert total_plays == 30, f"Expected 30 total plays, got {total_plays}"
+
+    @pytest.mark.parametrize("declarer_seat", [0, 1, 2, 3])
+    def test_moon_partner_sits_out(self, declarer_seat):
+        """Moon declarer's partner should sit out for all declarer seats."""
+        rng = random.Random(600 + declarer_seat)
+        deck = create_deck()
+        shuffle_deck(deck, rng=rng)
+        hands = deal_hands(deck, num_players=4, hand_size=10)
+
+        partner_seat = _PARTNER[declarer_seat]
+        tracker = TrackingStrategy()
+
+        play_single_hand(
+            contract_type=None,
+            bidding_policies=[AlwaysMoonPolicy(contract="H", seat_to_bid=declarer_seat)]
+            * 4,
+            strategy=tracker,
+            hands=hands,
+            initial_leader=declarer_seat,
+            deal_id=0,
+            rng=rng,
+        )
+
+        # Partner should never have played
+        assert tracker.plays_by_seat[partner_seat] == 0, (
+            f"Partner (seat {partner_seat}) played {tracker.plays_by_seat[partner_seat]} "
+            f"cards, expected 0"
+        )
+
+    @pytest.mark.parametrize("declarer_seat", [0, 1, 2, 3])
+    def test_moon_tricks_have_3_cards(self, declarer_seat):
+        """Each trick in a moon game should have exactly 3 cards."""
+        rng = random.Random(700 + declarer_seat)
+        deck = create_deck()
+        shuffle_deck(deck, rng=rng)
+        hands = deal_hands(deck, num_players=4, hand_size=10)
+
+        tracker = TrackingStrategy()
+
+        play_single_hand(
+            contract_type=None,
+            bidding_policies=[AlwaysMoonPolicy(contract="H", seat_to_bid=declarer_seat)]
+            * 4,
+            strategy=tracker,
+            hands=hands,
+            initial_leader=declarer_seat,
+            deal_id=0,
+            rng=rng,
+        )
+
+        tracker.finalize_trick_tracking()
+
+        assert (
+            len(tracker.trick_sizes) == 10
+        ), f"Expected 10 tricks, got {len(tracker.trick_sizes)}"
+        for i, size in enumerate(tracker.trick_sizes):
+            assert size == 3, f"Trick {i} had {size} cards, expected 3"
+
+        # Total plays should be 30
+        total_plays = sum(tracker.plays_by_seat.values())
+        assert total_plays == 30, f"Expected 30 total plays, got {total_plays}"
 
     def test_fixed_contract_still_4_players(self):
         """Fixed-contract mode (no auction) should still use 4-player tricks."""

--- a/tests/integration/test_r3_smoke.py
+++ b/tests/integration/test_r3_smoke.py
@@ -110,7 +110,7 @@ class TestMoonEndToEnd:
     """Validate moon bid through the simulation engine."""
 
     def test_moon_game_completes_with_exchange(self):
-        """Moon bid triggers card exchange and completes 10 tricks with 4 players."""
+        """Moon bid triggers card exchange and completes 10 tricks with 3 players."""
         rng = random.Random(42)
         deck = create_deck()
         shuffle_deck(deck, rng=rng)
@@ -164,10 +164,11 @@ class TestMoonEndToEnd:
         assert (
             len(exchange_received) == 2
         ), f"Expected 2 cards received, got {len(exchange_received)}"
-        # sitting_out should be None for moon (only loner)
+        # sitting_out should be partner seat (moon is 3-player like loner)
+        # declarer=seat 0, partner=seat 2
         assert (
-            sitting_out is None
-        ), f"sitting_out should be None for moon, got {sitting_out}"
+            sitting_out == 2
+        ), f"sitting_out should be 2 (partner) for moon, got {sitting_out}"
 
     def test_moon_scoring_made(self):
         """When declaring team wins all 10 tricks, they get +20."""


### PR DESCRIPTION
## Summary

- **Bug fix:** Moon bids in core sim played as 4-player games; now correctly use 3-player trick play (partner sits out after exchange), matching loner behavior
- **1-line sim change:** `bid_type == "loner"` → `bid_type in {"loner", "moon"}` in `simulation.py`
- **Test updates:** Renamed/added moon sit-out tests, fixed `test_r3_smoke` assertion

## Why

Moon bids are a research-critical contract type. Running moon as 4-player produces incorrect trick counts (40 plays instead of 30), wrong per-seat play distributions, and corrupted experiment data for any analysis involving moon bids.

Per game rules (RULES.md), moon — like loner — is a 3-player game after the exchange phase: the declarer's partner sits out.

## Repro / Validation

```bash
# Tier 1: targeted tests (all pass)
uv run python -m pytest tests/integration/test_loner_game.py -v
uv run python -m pytest tests/integration/test_r3_smoke.py::TestMoonEndToEnd -v
uv run python -m pytest tests/unit/test_scoring_points.py -v

# Tier 2: full suite
make check-quiet
# 4 failures — all pre-existing and unrelated:
# - test_ops_token_economy (×2) — mock call count issue
# - test_telegram_filter (×1) — env detection edge case
```

## Tests

- `test_moon_game_3_players` — partner sits out, 30 total plays, 3 active players × 10 cards
- `test_moon_partner_sits_out[0-3]` — parametrized across all 4 declarer seats
- `test_moon_tricks_have_3_cards[0-3]` — each trick has exactly 3 cards, 30 total
- `test_moon_game_completes_with_exchange` (r3_smoke) — sitting_out == partner seat
- All existing loner tests still pass (regression check)

## Scope

| File | Change |
|------|--------|
| `src/bid_euchre/sim/simulation.py` | 1-line condition fix + comment update |
| `tests/integration/test_loner_game.py` | Renamed test + 2 new parametrized test methods |
| `tests/integration/test_r3_smoke.py` | Updated assertion (sitting_out == 2, not None) |

## Follow-up

⚠️ The hosted_play engine (`src/bid_euchre/hosted_play/engine.py:704`) has the same bug — `hand.bid_type == "loner"` should also include `"moon"`. This is outside declared scope for this PR and should be fixed in a separate PR.

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: fix/moon-sit-out
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)