### PR TITLE
fix(web): prevent card jumping on AI turn re-render

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -19,10 +19,11 @@
         }
     </style>
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
+    <script src="https://unpkg.com/idiomorph@0.3.0/dist/idiomorph-ext.min.js"></script>
     <script src="/static/game.js" defer></script>
     {% block head %}{% endblock %}
 </head>
-<body>
+<body hx-ext="morph">
     <a href="#main-content" class="skip-link">Skip to game</a>
     <header role="banner">
         <div class="header-bar">

--- a/web/templates/partials/bid_panel.html
+++ b/web/templates/partials/bid_panel.html
@@ -64,7 +64,7 @@
           action="/play/{{ link_uuid }}/bid"
           hx-post="/play/{{ link_uuid }}/bid"
           hx-target="#game-board"
-          hx-swap="innerHTML"
+          hx-swap="morph:innerHTML"
           aria-label="Submit your bid">
         <input type="hidden" name="turn_number" value="{{ turn_number }}">
 

--- a/web/templates/partials/hand.html
+++ b/web/templates/partials/hand.html
@@ -23,6 +23,7 @@
 
             {% if phase == "trick_play" and legal_plays is not none and idx in legal_plays %}
                 <button type="button"
+                        id="hand-card-{{ idx }}"
                         class="card card--{{ suit_class }} card--legal"
                         title="{{ rank }}{{ suit_sym }} (tap to select)"
                         aria-label="Select {{ rank }} of {{ suit_name }}"
@@ -32,7 +33,8 @@
                 </button>
             {% else %}
                 {# Illegal or non-play-phase card — plain div #}
-                <div class="card card--{{ suit_class }}{% if phase == 'trick_play' %} card--illegal{% endif %}"
+                <div id="hand-card-{{ idx }}"
+                     class="card card--{{ suit_class }}{% if phase == 'trick_play' %} card--illegal{% endif %}"
                      title="{{ rank }}{{ suit_sym }}"
                      role="img"
                      aria-label="{{ rank }} of {{ suit_name }}{% if phase == 'trick_play' %} (cannot play){% endif %}">
@@ -50,7 +52,7 @@
               action="/play/{{ link_uuid }}/play-card"
               hx-post="/play/{{ link_uuid }}/play-card"
               hx-target="#game-board"
-              hx-swap="innerHTML">
+              hx-swap="morph:innerHTML">
             <input type="hidden" name="turn_number" value="{{ turn_number }}">
             <input type="hidden" id="selected-card-index" name="card_index" value="">
             <button id="card-play-submit"

--- a/web/templates/partials/hand_result.html
+++ b/web/templates/partials/hand_result.html
@@ -145,7 +145,7 @@
           action="/play/{{ link_uuid | default("") }}/next-hand"
           hx-post="/play/{{ link_uuid | default("") }}/next-hand"
           hx-target="#game-board"
-          hx-swap="innerHTML"
+          hx-swap="morph:innerHTML"
           class="hand-result-controls"
           aria-label="Start next hand">
         <button type="submit" class="btn btn--next-hand">Next Hand</button>

--- a/web/templates/partials/match_result.html
+++ b/web/templates/partials/match_result.html
@@ -34,7 +34,7 @@
           action="/play/{{ link_uuid }}/new-match"
           hx-post="/play/{{ link_uuid }}/new-match"
           hx-target="#game-board"
-          hx-swap="innerHTML">
+          hx-swap="morph:innerHTML">
         <button type="submit" class="btn btn--play-again" aria-label="Start a new match">Play Again</button>
     </form>
 </div>

--- a/web/templates/partials/model_select.html
+++ b/web/templates/partials/model_select.html
@@ -12,7 +12,7 @@
           action="/play/{{ link_uuid }}/select-ai"
           hx-post="/play/{{ link_uuid }}/select-ai"
           hx-target="#game-board"
-          hx-swap="innerHTML"
+          hx-swap="morph:innerHTML"
           aria-label="Select AI model and start match">
         <label for="model-select-dropdown" class="sr-only">AI opponent</label>
         <select id="model-select-dropdown" name="model_id" required aria-label="AI opponent model">

--- a/web/templates/partials/moon_exchange.html
+++ b/web/templates/partials/moon_exchange.html
@@ -100,7 +100,7 @@
           action="/play/{{ link_uuid | default('') }}/next"
           hx-post="/play/{{ link_uuid | default('') }}/next"
           hx-target="#game-board"
-          hx-swap="innerHTML"
+          hx-swap="morph:innerHTML"
           class="moon-exchange__controls">
         <button type="submit" class="btn btn--next-step" aria-label="Continue to trick play">
             Start Trick Play

--- a/web/templates/partials/moon_exchange_select.html
+++ b/web/templates/partials/moon_exchange_select.html
@@ -66,7 +66,7 @@
           action="/play/{{ link_uuid | default('') }}/exchange"
           hx-post="/play/{{ link_uuid | default('') }}/exchange"
           hx-target="#game-board"
-          hx-swap="innerHTML">
+          hx-swap="morph:innerHTML">
         <input type="hidden" id="exchange-card-0" name="card_index_0" value="">
         <input type="hidden" id="exchange-card-1" name="card_index_1" value="">
         <p id="exchange-help" class="card-play-help" aria-live="polite">

--- a/web/templates/partials/next_controls.html
+++ b/web/templates/partials/next_controls.html
@@ -7,7 +7,7 @@
           action="/play/{{ link_uuid }}/next"
           hx-post="/play/{{ link_uuid }}/next"
           hx-target="#game-board"
-          hx-swap="innerHTML">
+          hx-swap="morph:innerHTML">
         <button type="submit" class="btn btn--next-step" aria-label="Advance to the next step">
             Next
         </button>

--- a/web/templates/partials/nickname_form.html
+++ b/web/templates/partials/nickname_form.html
@@ -8,7 +8,7 @@
           action="/play/{{ link_uuid }}/nickname"
           hx-post="/play/{{ link_uuid }}/nickname"
           hx-target="#game-board"
-          hx-swap="innerHTML"
+          hx-swap="morph:innerHTML"
           aria-label="Choose a display name">
         <label for="nickname-input">Nickname:</label>
         <input id="nickname-input"


### PR DESCRIPTION
## Summary

- **Bug:** Human hand cards visibly jump/shift positions on mobile Safari after every AI card play, even though no cards in the hand changed
- **Root cause:** HTMX `innerHTML` swap destroys and recreates all card DOM elements on every game board update, causing layout recalculation and visual disruption
- **Fix:** Add HTMX idiomorph extension for DOM-diffing morph swaps that update elements in-place rather than replacing them

## Changes

| File | Change |
|------|--------|
| `web/templates/base.html` | Load idiomorph@0.3.0 CDN, enable `hx-ext="morph"` on `<body>` |
| `web/templates/partials/hand.html` | Add stable `id="hand-card-{idx}"` to each card element |
| 8 partials (`bid_panel`, `hand_result`, `match_result`, `model_select`, `moon_exchange`, `moon_exchange_select`, `next_controls`, `nickname_form`) | Switch `hx-swap="innerHTML"` → `hx-swap="morph:innerHTML"` |

## How It Works

Idiomorph performs DOM diffing when swapping content:
1. **Matches elements by ID** — card elements with `id="hand-card-0"` through `hand-card-9` are matched across renders
2. **Updates in-place** — matching elements have their attributes updated without removing/recreating the DOM node
3. **Preserves layout** — since the DOM node persists, the browser doesn't recalculate layout, eliminating the visual jump
4. **Falls back gracefully** — when content changes dramatically (phase transitions), idiomorph falls back to full replacement

During AI turns, the human's hand hasn't changed at all, so all card IDs match perfectly and no DOM elements are recreated.

## Repro / Validation

**Before fix:** Open game on mobile Safari → start match → play through tricks → watch hand cards jump when AI plays

**After fix:**
```bash
# Run all hosted_play tests
uv run python -m pytest tests/unit/hosted_play/ -v  # 2809 passed
uv run python -m pytest tests/e2e/hosted_play/ -v   # 21 passed

# Full validation
make check-quiet  # 10397 passed, 3 pre-existing failures (unrelated ops/platform tests)
```

Manual verification: Play through several tricks on mobile — cards should remain stable when AI plays.

## Tests

- `uv run python -m pytest tests/unit/hosted_play/test_partials.py` — 120 passed
- `uv run python -m pytest tests/unit/hosted_play/test_routes.py` — 57 passed
- `uv run python -m pytest tests/unit/hosted_play/` — 2809 passed
- `make check-quiet` — 10397 passed (3 pre-existing failures on main)

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
branch: fix/mobile-card-jumping
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)