### PR TITLE
feat(web): leaderboard live updates — include active match hands, auto-refresh

### DIFF
--- a/tests/unit/hosted_play/test_leaderboard.py
+++ b/tests/unit/hosted_play/test_leaderboard.py
@@ -1,7 +1,8 @@
 """Tests for the leaderboard stats aggregation and route.
 
 Covers:
-- PlayerStats computation from completed match/hand data
+- PlayerStats computation from match/hand data (active + completed matches)
+- In-progress match hand inclusion (live updates)
 - Leaderboard ranking (sorted by net_eppd descending)
 - Default and secondary column partitioning
 - Access gating (404 for unknown UUIDs)
@@ -106,7 +107,8 @@ class TestComputePlayerStats:
         result = compute_player_stats(db_session, player_id=999)
         assert result is None
 
-    def test_returns_none_for_no_completed_matches(self, db_session):
+    def test_returns_none_for_no_completed_hands(self, db_session):
+        """Active match with no completed hands → None."""
         player = _make_player(db_session)
         _make_match(db_session, player, status="active")
         result = compute_player_stats(db_session, player.id)
@@ -285,6 +287,105 @@ class TestComputePlayerStats:
         # avg_match_margin: (52-20 + 10-52) / 2 = (32 + -42) / 2 = -5.0
         assert stats.avg_match_margin == -5.0
 
+    def test_includes_hands_from_active_match(self, db_session):
+        """Hands from an active (in-progress) match are included in stats."""
+        player = _make_player(db_session, nickname="InProgress")
+        match = _make_match(
+            db_session, player, status="active", score_human=0, score_ai=0
+        )
+
+        _make_hand(
+            db_session,
+            match,
+            hand_number=0,
+            bidder_seat=0,
+            winning_bid_n=6,
+            tricks_team0=7,
+            tricks_team1=3,
+            points_team0=6,
+            points_team1=3,
+        )
+        _make_hand(
+            db_session,
+            match,
+            hand_number=1,
+            bidder_seat=1,
+            winning_bid_n=5,
+            tricks_team0=4,
+            tricks_team1=6,
+            points_team0=4,
+            points_team1=5,
+        )
+
+        db_session.flush()
+        stats = compute_player_stats(db_session, player.id)
+
+        assert stats is not None
+        assert stats.nickname == "InProgress"
+        assert stats.hands_played == 2
+        # No completed matches → match-level stats are zero
+        assert stats.matches_played == 0
+        assert stats.games_won == 0
+        assert stats.win_rate == 0.0
+        assert stats.avg_match_margin == 0.0
+
+        # Hand-level stats are computed from the active match's hands
+        # net_eppd = ((6 - 3) + (4 - 5)) / 2 = (3 + -1) / 2 = 1.0
+        assert stats.net_eppd == 1.0
+        # bid_rate = 1 declaring / 2 total
+        assert stats.bid_rate == 0.5
+
+    def test_mixes_active_and_completed_match_hands(self, db_session):
+        """Hands from both active and completed matches combine in stats."""
+        player = _make_player(db_session, nickname="MixedPlayer")
+
+        # Completed match
+        m1 = _make_match(
+            db_session,
+            player,
+            status="complete",
+            score_human=52,
+            score_ai=30,
+            hands_played=1,
+        )
+        _make_hand(
+            db_session,
+            m1,
+            hand_number=0,
+            points_team0=6,
+            points_team1=2,
+        )
+
+        # Active match (in progress)
+        m2 = _make_match(
+            db_session,
+            player,
+            status="active",
+            score_human=0,
+            score_ai=0,
+            hands_played=1,
+        )
+        _make_hand(
+            db_session,
+            m2,
+            hand_number=10,
+            points_team0=4,
+            points_team1=5,
+        )
+
+        db_session.flush()
+        stats = compute_player_stats(db_session, player.id)
+
+        assert stats is not None
+        # Both hands counted
+        assert stats.hands_played == 2
+        # Only completed match for match-level stats
+        assert stats.matches_played == 1
+        assert stats.games_won == 1
+
+        # net_eppd includes both: ((6-2) + (4-5)) / 2 = (4 + -1) / 2 = 1.5
+        assert stats.net_eppd == 1.5
+
     def test_returns_dataclass_fields(self, db_session):
         """Verify all expected fields are present on PlayerStats."""
         player = _make_player(db_session)
@@ -354,27 +455,49 @@ class TestGetLeaderboard:
         assert rankings[1].nickname == "LowEppd"
         assert rankings[0].net_eppd > rankings[1].net_eppd
 
-    def test_min_matches_filter(self, db_session):
-        # Player with 1 match
-        player = _make_player(db_session, nickname="OneMatch")
+    def test_min_hands_filter(self, db_session):
+        # Player with 1 completed hand
+        player = _make_player(db_session, nickname="OneHand")
         match = _make_match(db_session, player)
         _make_hand(db_session, match)
 
         db_session.flush()
 
-        # min_matches=1 includes them
-        assert len(get_leaderboard(db_session, min_matches=1)) == 1
+        # min_hands=1 (default) includes them
+        assert len(get_leaderboard(db_session, min_hands=1)) == 1
 
-        # min_matches=2 excludes them
-        assert len(get_leaderboard(db_session, min_matches=2)) == 0
+        # min_hands=2 excludes them
+        assert len(get_leaderboard(db_session, min_hands=2)) == 0
 
-    def test_excludes_active_only_players(self, db_session):
-        player = _make_player(db_session, nickname="ActiveOnly")
+    def test_excludes_active_match_with_no_hands(self, db_session):
+        """Active match but zero completed hands → excluded."""
+        player = _make_player(db_session, nickname="ActiveNoHands")
         _make_match(db_session, player, status="active")
         db_session.flush()
 
         rankings = get_leaderboard(db_session)
         assert len(rankings) == 0
+
+    def test_includes_active_match_with_completed_hands(self, db_session):
+        """Active match with completed hands → included on leaderboard."""
+        player = _make_player(db_session, nickname="ActiveWithHands")
+        match = _make_match(db_session, player, status="active")
+        _make_hand(
+            db_session,
+            match,
+            hand_number=0,
+            points_team0=6,
+            points_team1=3,
+        )
+
+        db_session.flush()
+        rankings = get_leaderboard(db_session)
+
+        assert len(rankings) == 1
+        assert rankings[0].nickname == "ActiveWithHands"
+        assert rankings[0].hands_played == 1
+        assert rankings[0].matches_played == 0  # no completed matches yet
+        assert rankings[0].games_won == 0
 
 
 # ---------------------------------------------------------------------------
@@ -445,6 +568,20 @@ class TestLeaderboardRoute:
 
             resp = client.get(f"/leaderboard/{player.link_uuid}")
             assert resp.status_code == 200
-            assert "No completed matches yet" in resp.text
+            assert "No hands played yet" in resp.text
+        finally:
+            session.close()
+
+    def test_leaderboard_has_auto_refresh(self, app_and_client):
+        """Leaderboard page includes HTMX polling for live updates."""
+        app, client = app_and_client
+        session = app.state.session_factory()
+        try:
+            player = _make_player(session, nickname="RefreshTest")
+            session.commit()
+
+            resp = client.get(f"/leaderboard/{player.link_uuid}")
+            assert resp.status_code == 200
+            assert 'hx-trigger="every 30s"' in resp.text
         finally:
             session.close()

--- a/web/leaderboard.py
+++ b/web/leaderboard.py
@@ -1,6 +1,8 @@
 """Leaderboard stats aggregation for the browser game.
 
-Computes player performance metrics from completed match and hand data.
+Computes player performance metrics from match and hand data, including
+hands from in-progress matches so stats update after every hand.
+
 All queries operate on the hosted-play SQLAlchemy models — no raw SQL.
 
 The leaderboard is a product-facing feature: metrics optimize for player
@@ -21,6 +23,9 @@ from .db import Hand, Match, Player
 # Human is always seat 0; human's team is (seat 0, seat 2) = team 0.
 HUMAN_TEAM = 0
 
+# Match statuses that contribute hands to leaderboard stats.
+_LEADERBOARD_MATCH_STATUSES = ("active", "complete")
+
 
 @dataclass(frozen=True)
 class PlayerStats:
@@ -40,7 +45,7 @@ class PlayerStats:
 
     # Secondary columns
     hands_played: int
-    avg_match_margin: float  # average match score margin (all matches)
+    avg_match_margin: float  # average match score margin (completed matches)
     bid_rate: float  # fraction of hands where player's team won the bid
     make_rate: float  # fraction of contracts made when declaring
     avg_bid_level: float  # average bid level when declaring
@@ -53,28 +58,50 @@ class PlayerStats:
 def compute_player_stats(session: Session, player_id: int) -> PlayerStats | None:
     """Compute aggregated stats for a single player.
 
-    Returns ``None`` if the player has no completed matches.
+    Returns ``None`` if the player has no completed hands.
+
+    Hand-level metrics (net_eppd, bid_rate, make_rate, etc.) include hands
+    from both active and completed matches so the leaderboard updates after
+    every hand.  Match-level metrics (games_won, win_rate, margins) use
+    completed matches only — you can't "win" an in-progress game.
     """
     player = session.query(Player).get(player_id)
     if player is None:
         return None
 
-    # Completed matches for this player
-    completed_matches = (
-        session.query(Match).filter_by(player_id=player_id, status="complete").all()
+    # All matches that contribute hands (active + complete)
+    all_matches = (
+        session.query(Match)
+        .filter(
+            Match.player_id == player_id,
+            Match.status.in_(_LEADERBOARD_MATCH_STATUSES),
+        )
+        .all()
     )
 
-    if not completed_matches:
+    if not all_matches:
         return None
 
-    matches_played = len(completed_matches)
-    match_ids = [m.id for m in completed_matches]
+    all_match_ids = [m.id for m in all_matches]
 
-    # Win/loss from matches (human is team 0 — score_human vs score_ai)
+    # Completed hands across active + completed matches
+    completed_hands = (
+        session.query(Hand)
+        .filter(Hand.match_id.in_(all_match_ids), Hand.status == "complete")
+        .all()
+    )
+    hands_played = len(completed_hands)
+
+    if hands_played == 0:
+        return None
+
+    # --- Match-level metrics (completed matches only) ---
+    completed_matches = [m for m in all_matches if m.status == "complete"]
+    matches_played = len(completed_matches)
+
     games_won = sum(1 for m in completed_matches if m.score_human > m.score_ai)
     win_rate = games_won / matches_played if matches_played > 0 else 0.0
 
-    # Score margins
     margins = [m.score_human - m.score_ai for m in completed_matches]
     avg_match_margin = sum(margins) / len(margins) if margins else 0.0
     winning_margins = [mg for mg in margins if mg > 0]
@@ -82,20 +109,11 @@ def compute_player_stats(session: Session, player_id: int) -> PlayerStats | None
         sum(winning_margins) / len(winning_margins) if winning_margins else 0.0
     )
 
-    # Completed hands across all completed matches
-    completed_hands = (
-        session.query(Hand)
-        .filter(Hand.match_id.in_(match_ids), Hand.status == "complete")
-        .all()
-    )
-    hands_played = len(completed_hands)
+    # --- Hand-level metrics (all completed hands) ---
 
     # Net EPPD: total net points / total hands
-    if hands_played > 0:
-        total_net_points = sum(h.points_team0 - h.points_team1 for h in completed_hands)
-        net_eppd = total_net_points / hands_played
-    else:
-        net_eppd = 0.0
+    total_net_points = sum(h.points_team0 - h.points_team1 for h in completed_hands)
+    net_eppd = total_net_points / hands_played
 
     # Bidding stats — human team is team 0, bidder_seat in (0, 2)
     declaring_hands = [
@@ -165,23 +183,30 @@ def compute_player_stats(session: Session, player_id: int) -> PlayerStats | None
 def get_leaderboard(
     session: Session,
     *,
-    min_matches: int = 1,
+    min_hands: int = 1,
 ) -> list[PlayerStats]:
     """Return leaderboard rankings sorted by net_eppd descending.
 
-    Only includes players with at least *min_matches* completed matches.
+    Only includes players with at least *min_hands* completed hands
+    (across both active and completed matches).  This means players
+    appear on the leaderboard after their very first completed hand,
+    even during their first match.
     """
-    # Find all players with completed matches
-    player_match_counts = (
-        session.query(Match.player_id, func.count(Match.id).label("n"))
-        .filter_by(status="complete")
+    # Find all players with enough completed hands across active+complete matches
+    player_hand_counts = (
+        session.query(Match.player_id, func.count(Hand.id).label("n"))
+        .join(Hand, Hand.match_id == Match.id)
+        .filter(
+            Match.status.in_(_LEADERBOARD_MATCH_STATUSES),
+            Hand.status == "complete",
+        )
         .group_by(Match.player_id)
-        .having(func.count(Match.id) >= min_matches)
+        .having(func.count(Hand.id) >= min_hands)
         .all()
     )
 
     stats_list: list[PlayerStats] = []
-    for player_id, _count in player_match_counts:
+    for player_id, _count in player_hand_counts:
         stats = compute_player_stats(session, player_id)
         if stats is not None:
             stats_list.append(stats)

--- a/web/templates/leaderboard.html
+++ b/web/templates/leaderboard.html
@@ -127,7 +127,9 @@
 {% endblock %}
 
 {% block content %}
-<div class="leaderboard" role="region" aria-label="Player leaderboard">
+<div class="leaderboard" role="region" aria-label="Player leaderboard"
+     hx-get="/leaderboard/{{ link_uuid }}" hx-trigger="every 30s"
+     hx-select=".leaderboard" hx-swap="outerHTML">
     <div class="leaderboard__header">
         <h2 class="leaderboard__title">Leaderboard</h2>
         <a href="/play/{{ link_uuid }}" class="leaderboard__back">Back to Game</a>
@@ -135,7 +137,7 @@
 
     {% if rankings|length == 0 %}
     <div class="leaderboard__empty">
-        <p>No completed matches yet. Play a game to appear on the leaderboard!</p>
+        <p>No hands played yet. Start a game to appear on the leaderboard!</p>
     </div>
     {% else %}
     <div class="leaderboard__table-wrap">


### PR DESCRIPTION
## Plan
N/A — standalone improvement task dispatched by orchestrator.

## Summary
- Include hands from in-progress matches in leaderboard stats so the page updates after every completed hand
- Add HTMX polling (every 30s) for automatic page refresh
- Change filtering from `min_matches` to `min_hands` so players appear on the leaderboard after their very first hand

## Why
Previously the leaderboard only showed stats from completed matches. Players had to finish an entire match before appearing, and stats were stale until the next page load. This makes the leaderboard feel alive during gameplay.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_leaderboard.py -v
make check-quiet
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** Active match with completed hands appears on leaderboard; completed-match-only metrics (games_won, win_rate) remain zero until match completes
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_leaderboard.py -v -k "active"`
- **Expected result:** 3 tests pass: `test_includes_hands_from_active_match`, `test_mixes_active_and_completed_match_hands`, `test_includes_active_match_with_completed_hands`

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_leaderboard.py -v` — 19 passed
- [x] `make check-quiet` — all passing (3 pre-existing failures in unrelated ops tests)

## Expected impact
- Metrics impact: None (product feature, not research metrics)
- Runtime impact: Slightly wider query (active+complete matches), negligible for typical player counts

## Risk level
- [x] Low (web feature, no core rules/sim changes)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d   8bb11c35 [web/leaderboard-live-updates]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)