### PR TITLE
feat(web): add trick-by-trick game log to hand result screen

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -1133,6 +1133,121 @@ class TestHandResult:
         assert expected[seat] in html
         assert f"Seat {seat}" not in html
 
+    def test_trick_history_shown_with_completed_tricks(self, env):
+        """Hand result includes a collapsible trick-by-trick game log (#2006)."""
+        tricks = [
+            {
+                "leader": 0,
+                "plays": [
+                    [0, ["S", "A"]],
+                    [1, ["S", "K"]],
+                    [2, ["S", "Q"]],
+                    [3, ["S", "J"]],
+                ],
+                "winner": 0,
+            },
+            {
+                "leader": 0,
+                "plays": [
+                    [0, ["H", "A"]],
+                    [1, ["H", "K"]],
+                    [2, ["H", "Q"]],
+                    [3, ["H", "J"]],
+                ],
+                "winner": 0,
+            },
+        ]
+        html = env.get_template("partials/hand_result.html").render(
+            link_uuid="abc-123",
+            winning_bid=6,
+            bidder_seat=0,
+            contract_type="suit",
+            trump="S",
+            tricks_team0=7,
+            tricks_team1=3,
+            points_team0=7,
+            points_team1=3,
+            score_human=7,
+            score_ai=3,
+            hands_played=1,
+            completed_tricks=tricks,
+        )
+        # The trick history details element should be present
+        assert "trick-history" in html
+        assert "Cards Played" in html
+        # Card values rendered
+        assert "A" in html
+        assert "K" in html
+
+    def test_trick_history_absent_without_tricks(self, env):
+        """Hand result omits trick history when no tricks available (#2006)."""
+        html = env.get_template("partials/hand_result.html").render(
+            winning_bid=6,
+            bidder_seat=0,
+            contract_type="suit",
+            trump="S",
+            tricks_team0=0,
+            tricks_team1=0,
+            points_team0=0,
+            points_team1=0,
+            score_human=0,
+            score_ai=0,
+            hands_played=1,
+            completed_tricks=[],
+        )
+        # With empty completed_tricks, the trick-history section is not rendered
+        assert "trick-history" not in html
+
+    def test_trick_history_defaults_gracefully(self, env):
+        """Hand result renders without completed_tricks in context (#2006)."""
+        html = env.get_template("partials/hand_result.html").render(
+            winning_bid=6,
+            bidder_seat=0,
+            contract_type="suit",
+            trump="S",
+            tricks_team0=7,
+            tricks_team1=3,
+            points_team0=7,
+            points_team1=3,
+            score_human=7,
+            score_ai=3,
+            hands_played=1,
+        )
+        # Should render without error even when completed_tricks is not provided
+        assert "Made it!" in html
+        assert "trick-history" not in html
+
+    def test_trick_history_wrapper_has_class(self, env):
+        """The trick log wrapper uses the hand-result__trick-log class (#2006)."""
+        tricks = [
+            {
+                "leader": 1,
+                "plays": [
+                    [1, ["D", "10"]],
+                    [2, ["D", "J"]],
+                    [3, ["D", "Q"]],
+                    [0, ["D", "K"]],
+                ],
+                "winner": 0,
+            },
+        ]
+        html = env.get_template("partials/hand_result.html").render(
+            link_uuid="abc-123",
+            winning_bid=5,
+            bidder_seat=1,
+            contract_type="suit",
+            trump="D",
+            tricks_team0=6,
+            tricks_team1=4,
+            points_team0=6,
+            points_team1=4,
+            score_human=6,
+            score_ai=4,
+            hands_played=1,
+            completed_tricks=tricks,
+        )
+        assert "hand-result__trick-log" in html
+
 
 # ---------------------------------------------------------------------------
 # moon_exchange.html

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -939,6 +939,21 @@ main {
     font-size: 0.85rem;
 }
 
+/* Trick log inside hand result — collapsed by default, max-height for scroll */
+.hand-result__trick-log {
+    margin-top: 0.75rem;
+}
+
+.hand-result__trick-log .trick-history {
+    max-height: 260px;
+    overflow-y: auto;
+}
+
+.hand-result__trick-log .trick-history__toggle {
+    font-size: 0.82rem;
+    color: var(--color-text-muted);
+}
+
 .hand-result-controls {
     margin-top: 0.75rem;
 }

--- a/web/templates/partials/hand_result.html
+++ b/web/templates/partials/hand_result.html
@@ -141,6 +141,14 @@
         <p class="hands-count">Hands played: {{ hands_played }}</p>
     </div>
 
+    {# Trick-by-trick game log — reuses the same partial shown during play.
+       Default completed_tricks to [] for safety (always present in engine
+       context, but templates are rendered independently in tests). #}
+    {% set completed_tricks = completed_tricks | default([], true) %}
+    <div class="hand-result__trick-log">
+        {% include "partials/trick_history.html" %}
+    </div>
+
     <form method="post"
           action="/play/{{ link_uuid | default("") }}/next-hand"
           hx-post="/play/{{ link_uuid | default("") }}/next-hand"


### PR DESCRIPTION
## Summary
- Include the existing `trick_history.html` partial in the hand result screen so players can review all cards played per trick after each hand
- Trick log is collapsible (collapsed by default via `<details>`) and positioned between the match score and the "Next Hand" button
- Added CSS scoping (`.hand-result__trick-log`) with max-height scroll for the embedded trick history

## Why
Closes #2006 — Players have no way to review what happened during a hand after it completes. The trick-by-trick log was already shown during active play but disappeared at the hand result screen, making it impossible to review the hand.

## Changes
| File | Change |
|------|--------|
| `web/templates/partials/hand_result.html` | Include `trick_history.html` partial with defensive `completed_tricks` default |
| `web/static/style.css` | Add `.hand-result__trick-log` wrapper styles (margin, max-height scroll) |
| `tests/unit/hosted_play/test_partials.py` | 4 new tests: trick history shown, absent when empty, graceful default, wrapper class |

## Design Decisions
- **Reuses existing partial** — no code duplication; the same `trick_history.html` shown during play is included in the hand result
- **No engine changes needed** — `completed_tricks` is already exposed in `get_visible_state()` and flows through `_build_game_context()` to all templates
- **Defensive default** — `{% set completed_tricks = completed_tricks | default([], true) %}` handles isolated template rendering (tests use `StrictUndefined`)

## Repro / Validation
```bash
# Unit tests (Tier 1)
uv run python -m pytest tests/unit/hosted_play/test_partials.py::TestHandResult -q

# Full hosted_play tests
uv run python -m pytest tests/unit/hosted_play/ -q

# Full validation (Tier 2) — 3 pre-existing failures unrelated to this PR
make check-quiet
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
Branch: feat/hand-end-game-log
```

## Tests
- `tests/unit/hosted_play/test_partials.py::TestHandResult` — 26 tests pass (22 existing + 4 new)
- Full `tests/unit/hosted_play/` — 2818 passed, 5 skipped
- `make check-quiet` — 3 pre-existing failures (token economy, telegram filter), all unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)