### PR TITLE
docs(ops): mark Phase 5+ platform work POSTPONED INDEFINITELY

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,7 +252,7 @@ See `docs/01_core/RULES.md` for complete rules specification.
 |-----------|---------------|--------|
 | Arc D v2 (multi-model lineage) | `plans/arc_d_v2/lineage_plan.md` | COMPLETE |
 | Browser Game Hosting and Human Data Capture | `plans/browser_game/governing_plan.md` | ACTIVE |
-| Agentic Orchestration Platform | `plans/agent_ops/governing_plan.md` | ACTIVE |
+| Agentic Orchestration Platform | `plans/agent_ops/governing_plan.md` | PHASE 4 COMPLETE — POSTPONED |
 
 When starting work on a governed initiative, follow the Agent Execution Protocol.
 

--- a/plans/agent_ops/5_cross_model/scope_lock.md
+++ b/plans/agent_ops/5_cross_model/scope_lock.md
@@ -1,6 +1,6 @@
 # Platform-12: Cross-Model Service Lanes — Scope Lock
 
-**Status:** DRAFT (operator feedback incorporated)
+**Status:** POSTPONED INDEFINITELY (2026-04-01 operator decision — platform work postponed to focus on browser game product)
 **Author:** analyst lane
 **Date:** 2026-03-25
 **Updated:** 2026-03-25 (operator feedback round 1)

--- a/plans/agent_ops/5_extraction/scope_lock.md
+++ b/plans/agent_ops/5_extraction/scope_lock.md
@@ -1,6 +1,6 @@
 # Platform-13: Second-Project Extraction Proof — Scope Lock
 
-**Status:** SCOPE-LOCKED
+**Status:** POSTPONED INDEFINITELY (2026-04-01 operator decision — platform work postponed to focus on browser game product)
 **Author:** analyst lane, revised with operator feedback
 **Date:** 2026-03-25
 **Parent:** `plans/agent_ops/governing_plan.md` — Phase 6, Platform-13

--- a/plans/agent_ops/5_portability_and_learning/checkpoints.md
+++ b/plans/agent_ops/5_portability_and_learning/checkpoints.md
@@ -1,0 +1,86 @@
+# Portability and Learning Checkpoints
+
+**Phase:** 5 (`5_portability_and_learning`)
+**Status:** POSTPONED INDEFINITELY
+**Governing plan:** `plans/agent_ops/governing_plan.md`
+**Last updated:** 2026-04-01 by analyst-a (POSTPONED — operator decision to focus on browser game product)
+
+---
+
+### Step 1 — Platform-10: Complete core-vs-adapter portability layer
+
+**Status:** POSTPONED
+**Sub-plan:** SP-5-01 (`plans/agent_ops/5_portability_and_learning/sub/2026-04-01_platform-10-portability-completion.md`)
+**Depends on:** Phase 4 COMPLETE (satisfied 2026-04-01)
+**Done when:**
+- Lane topology (KNOWN_AUTHOR_LANES) is provided by adapter, not hardcoded in task_queue.py
+- Ops CLI primary commands (monitor, task, dispatch, controller) use ServiceProvider
+- Portability manifest documents all remaining Bid-Euchre-specific coupling
+- Hook callers use ServiceProvider or adapter imports
+
+| Step | Status | Date | Agent/Session | Notes |
+|------|--------|------|---------------|-------|
+| SP-5-01 PR1: Lane topology extraction | POSTPONED | — | — | — |
+| SP-5-01 PR2: ServiceProvider CLI migration | POSTPONED | — | — | — |
+| SP-5-01 PR3: Coupling manifest + audit script | POSTPONED | — | — | — |
+| SP-5-01 PR4: Hook migration + cleanup | POSTPONED | — | — | — |
+
+**Groundwork shipped (Phase 4):**
+- PR #1807 — Core ops ABCs (4 interfaces)
+- PR #1813 — Core ops extraction (controller, monitor wrappers)
+- PR #1817 — Repo adapter (TaskQueueService, WorkerPoolService)
+- PR #1950 — ServiceProvider wiring
+- PR #1954 — Core adapter contract tests (2256 LOC)
+
+### Step 2 — Platform-11: Skill learning loop
+
+**Status:** POSTPONED
+**Sub-plan:** SP-5-02 (`plans/agent_ops/5_portability_and_learning/sub/2026-04-01_platform-11-skill-learning-loop.md`)
+**Scope lock:** `plans/agent_ops/5_skill_learning/scope_lock.md`
+**Depends on:** Phase 4 COMPLETE (satisfied 2026-04-01)
+**Done when:**
+- Task type taxonomy and enriched outcome recording exist
+- Affinity model computed from outcomes log via EWMA
+- Dispatch advisor ranks lanes (advisory mode)
+- Anti-corruption guardrails enforce all 7 protections
+- Skill suggestion pipeline generates proposals through existing promotion gates
+- All existing tests pass
+
+| Step | Status | Date | Agent/Session | Notes |
+|------|--------|------|---------------|-------|
+| SP-5-02 PR1: Task type taxonomy + outcome schema | POSTPONED | — | — | — |
+| SP-5-02 PR2: Outcomes log + affinity model | POSTPONED | — | — | — |
+| SP-5-02 PR3: Dispatch advisor + guardrails | POSTPONED | — | — | — |
+| SP-5-02 PR4: Advisory wiring + outcome hook | POSTPONED | — | — | — |
+| SP-5-02 PR5: Skill suggestion pipeline | POSTPONED | — | — | — |
+
+### Step 3 — Phase 5 closeout and transition to Phase 6
+
+**Status:** POSTPONED
+**Depends on:** Steps 1 and 2 COMPLETE
+**Done when:**
+- Both Platform-10 and Platform-11 done-when criteria verified
+- Evaluation framework follow-up issue filed (deferred from SP-5-02)
+- Phase 5 checkpoints all COMPLETE
+- Sub-plan registry updated
+- Phase 6 unblocked
+
+**Status values:** `PENDING`, `IN_PROGRESS`, `COMPLETE`, `BLOCKED`, `SKIPPED`, `POSTPONED`
+
+## Active Sub-Plans
+
+| Sub-Plan ID | File | Status | Blocking Step |
+|-------------|------|--------|---------------|
+| SP-5-01 | `plans/agent_ops/5_portability_and_learning/sub/2026-04-01_platform-10-portability-completion.md` | postponed | Step 1 |
+| SP-5-02 | `plans/agent_ops/5_portability_and_learning/sub/2026-04-01_platform-11-skill-learning-loop.md` | postponed | Step 2 |
+
+## Blockers
+
+_(none)_
+
+## Session Log
+
+| Date | Summary |
+|------|---------|
+| 2026-04-01 | Phase 5 scaffolding created by analyst-a (task packet 3abba00f182e). Sub-plans SP-5-01 (Platform-10, 4 PRs, 6h) and SP-5-02 (Platform-11, 5 PRs, 9.5h) drafted. Total: 9 PRs, 15.5h. Platform-10 groundwork audit: ABCs + ServiceProvider + adapter + tests exist (5 PRs shipped), but no callers migrated yet. 196 repo-specific coupling occurrences across 34 ops files. |
+| 2026-04-01 | **POSTPONED INDEFINITELY** — operator decision to focus on browser game product. Phase 4 was the final delivered platform phase. All steps and sub-plans marked POSTPONED. |

--- a/plans/agent_ops/5_portability_and_learning/plan.md
+++ b/plans/agent_ops/5_portability_and_learning/plan.md
@@ -1,0 +1,81 @@
+# Phase 5: Portability and Learning
+
+**Phase:** 5 (`5_portability_and_learning`)
+**Status:** POSTPONED INDEFINITELY (2026-04-01 operator decision — platform work postponed to focus on browser game product. Phase 4 was the final delivered platform phase.)
+**Governing plan:** `plans/agent_ops/governing_plan.md`
+**Depends on:** Phase 3 (COMPLETE), Phase 4 (COMPLETE 2026-04-01)
+**Created:** 2026-04-01
+
+---
+
+## Scope
+
+Phase 5 covers two platform steps:
+
+| Step | Platform | Description | Scope Lock |
+|------|----------|-------------|------------|
+| Platform-10 | Portability Layer | Complete core-vs-adapter split; migrate callers to ServiceProvider; document remaining coupling | Groundwork shipped (PRs #1807, #1813, #1817, #1950, #1954) |
+| Platform-11 | Skill Learning Loop | Outcome-informed dispatch advisor; task type taxonomy; skill suggestion pipeline | `plans/agent_ops/5_skill_learning/scope_lock.md` |
+
+## Groundwork Already Shipped
+
+Platform-10 groundwork was shipped during Phase 4 as part of SP-4-10:
+
+- **PR #1807** — Core ops ABCs (`interfaces.py`: 4 ABCs)
+- **PR #1813** — Extract core ops (`controller.py`, `monitor.py` wrappers)
+- **PR #1817** — Repo adapter (`adapters/bid_euchre.py`)
+- **PR #1950** — ServiceProvider wiring (`provider.py`)
+- **PR #1954** — Core adapter contract tests (6 test files, 2256 LOC)
+
+The boundary exists but is not yet used by callers. Phase 5 completes the
+migration and adds the learning loop.
+
+## Sub-Plans
+
+| ID | Title | Platform | PRs | Est. Hours |
+|----|-------|----------|-----|------------|
+| SP-5-01 | Platform-10 Portability Completion | Platform-10 | 4 | 6h |
+| SP-5-02 | Platform-11 Skill Learning Loop | Platform-11 | 5 | 9.5h |
+
+## Execution Order
+
+Platform-10 and Platform-11 are **partially parallelizable:**
+
+```
+SP-5-01 PR1 (lane topology) ─────┐
+                                  ├──→ SP-5-01 PR3 (manifest) ──→ SP-5-01 PR4 (hooks)
+SP-5-01 PR2 (ServiceProvider CLI) ┘
+
+SP-5-02 PR1 (taxonomy) ──→ SP-5-02 PR2 (outcomes log) ──→ SP-5-02 PR3 (advisor) ──→ SP-5-02 PR4 (wiring)
+                                                                                    ↘ SP-5-02 PR5 (suggestions)
+```
+
+- SP-5-01 PR1 and PR2 can run in parallel
+- SP-5-02 PR1 can start immediately (no dependency on SP-5-01)
+- SP-5-02 PR4 (worker_pool wiring) should land after SP-5-01 PR1 (lane
+  topology extraction) to avoid conflicting changes in worker_pool.py
+
+**Recommended lane assignment:**
+- SP-5-01: 1 author lane (4 sequential PRs after initial parallel pair)
+- SP-5-02: 1 author lane (5 sequential PRs)
+- Cross-lane coordination needed only for SP-5-02 PR4 vs SP-5-01 PR1
+
+## Done-When
+
+### Platform-10
+- New orchestration code depends on adapter contracts rather than
+  Bid-Euchre-specific paths or docs
+- The refactor scope for existing `src/bid_euchre/ops/` assumptions is
+  documented and materially reduced
+
+### Platform-11
+- Repeated successful workflows can produce skill suggestions with provenance
+- Promotion/refinement cannot bypass review, context-safety, and rollback gates
+
+## Total Estimate
+
+| Sub-Plan | PRs | Lane-Hours |
+|----------|-----|------------|
+| SP-5-01 | 4 | 6h |
+| SP-5-02 | 5 | 9.5h |
+| **Total** | **9** | **15.5h** |

--- a/plans/agent_ops/5_portability_and_learning/sub/2026-04-01_platform-10-portability-completion.md
+++ b/plans/agent_ops/5_portability_and_learning/sub/2026-04-01_platform-10-portability-completion.md
@@ -1,0 +1,229 @@
+# SP-5-01: Platform-10 Portability Layer Completion
+
+**Status:** postponed (2026-04-01 operator decision — platform work postponed indefinitely)
+**Author:** analyst-a
+**Date:** 2026-04-01
+**Parent:** `plans/agent_ops/governing_plan.md` — Phase 5, Platform-10
+**Registry ID:** SP-5-01
+
+---
+
+## Problem Statement
+
+Platform-10 groundwork shipped during Phase 4 (PRs #1807, #1813, #1817,
+#1950, #1954) established the core-vs-adapter boundary:
+
+- 4 ABCs in `core/interfaces.py` (Controller, Monitor, TaskQueue, WorkerPool)
+- Concrete wrappers in `core/controller.py` and `core/monitor.py`
+- Bid-Euchre adapter in `adapters/bid_euchre.py` (TaskQueueService, WorkerPoolService)
+- ServiceProvider in `core/provider.py`
+- 2256 LOC of contract tests across 6 test files
+
+**The boundary exists but is not yet used.** All callers still bypass
+ServiceProvider and import directly from the concrete modules. The
+governing plan done-when requires:
+
+1. New orchestration code depends on adapter contracts rather than
+   Bid-Euchre-specific paths or docs
+2. The refactor scope for existing `src/bid_euchre/ops/` assumptions is
+   documented and materially reduced
+
+### Current Coupling Audit
+
+| Coupling Type | Occurrences | Primary Files |
+|---------------|-------------|---------------|
+| Direct module imports (bypassing ServiceProvider) | 13+ sites | `scripts/internal/ops.py`, `.claude/hooks/post-merge-notify.sh`, `.claude/hooks/inbound-channel-audit.py` |
+| `KNOWN_AUTHOR_LANES` hardcoded | 9 references | `task_queue.py`, `worker_pool.py`, `token_economy.py` |
+| `.claude/runtime` hardcoded paths | 7+ in monitor, 5+ in worker_pool | `monitor.py`, `worker_pool.py`, `control_plane.py` |
+| `steward-*` pane naming patterns | 24 references | `worker_pool.py` |
+| Bid-Euchre worktree conventions | 45 references | `worktrees.py` |
+| Total repo-specific occurrences | 196 across 34 files | All ops modules |
+
+### Modules WITHOUT ABCs (Secondary — Not Required for Platform-10)
+
+| Module | LOC | Portability Need |
+|--------|-----|-----------------|
+| `message_bus.py` | 1736 | Medium — generic messaging, minimal repo-specific coupling |
+| `events.py` | ~400 | Low — generic append-only event log |
+| `audit_trail.py` | 690 | Low — generic exchange audit |
+| `scheduler.py` | ~200 | Low — generic cron primitives |
+| `token_economy.py` | 1976 | High — heavily coupled to Bid-Euchre lane/pool names |
+| `skill_promotion.py` | 633 | Medium — generic pipeline, BE-specific paths |
+
+These do NOT need ABCs for Platform-10. Platform-13 (extraction proof) will
+discover which of these need abstraction through runtime testing.
+
+## Solution: 4-PR Completion Plan
+
+### PR1: Extract lane topology into adapter config
+
+**Scope:** Move `KNOWN_AUTHOR_LANES` and lane-to-pane mapping from hardcoded
+constants into the adapter contract.
+
+**Files changed:**
+
+| File | Change | Lines |
+|------|--------|-------|
+| `src/bid_euchre/ops/core/interfaces.py` | Add `lane_topology()` and `pane_name_for_lane()` to a new `AbstractLaneConfig` ABC (or extend existing ABCs) | ~40 |
+| `src/bid_euchre/ops/adapters/bid_euchre.py` | Implement `BidEuchreLaneConfig` with current hardcoded values | ~60 |
+| `src/bid_euchre/ops/task_queue.py` | Replace `KNOWN_AUTHOR_LANES` constant with adapter lookup (import from adapters or accept as parameter) | ~20 |
+| `src/bid_euchre/ops/worker_pool.py` | Replace `_lane_to_pane()` and `get_known_lanes()` with adapter calls | ~30 |
+| `tests/unit/test_ops_core_interfaces.py` | Test new ABC | ~30 |
+| `tests/unit/test_ops_adapter_migration.py` | Test adapter implements topology | ~40 |
+
+**Validation:**
+```bash
+uv run python -m pytest tests/unit/test_ops_core_interfaces.py tests/unit/test_ops_adapter_migration.py tests/unit/test_ops_task_queue.py tests/unit/test_ops_worker_pool.py -v
+```
+
+**Risk:** `KNOWN_AUTHOR_LANES` is used in validation logic (TaskPacket owner
+checks). Changing from a module constant to an adapter call requires
+threading the adapter through or using a module-level factory. Recommend a
+`get_known_lanes()` function that defaults to the Bid-Euchre set but can be
+overridden — preserves backward compat.
+
+### PR2: Wire ServiceProvider into ops CLI primary paths
+
+**Scope:** Migrate the main orchestration entry points in
+`scripts/internal/ops.py` to use `ServiceProvider.default()` instead of
+direct module imports. Focus on the four primary command groups: `monitor`,
+`task`, `dispatch`, and `controller`.
+
+**Files changed:**
+
+| File | Change | Lines |
+|------|--------|-------|
+| `scripts/internal/ops.py` | Add `_get_provider()` helper; refactor `cmd_monitor()`, `cmd_task_*()`, `cmd_dispatch()`, `cmd_controller_*()` to use provider | ~80 |
+| `tests/unit/test_ops_cli.py` or `tests/integration/test_ops_cli.py` | Add test that ops CLI commands use ServiceProvider (mock-based) | ~50 |
+
+**Validation:**
+```bash
+uv run python scripts/internal/ops.py status 2>&1 | head -5  # Smoke
+uv run python scripts/internal/ops.py task list 2>&1 | head -5  # Smoke
+uv run python -m pytest tests/unit/test_ops_cli.py -v  # If exists
+```
+
+**Risk:** The ops CLI has ~3200 LOC with many deferred imports. This PR
+should NOT attempt to migrate every import — only the primary orchestration
+paths (monitor, task, dispatch, controller). Secondary paths (dashboard,
+worktrees, reviews) are out of scope for this PR to keep the diff bounded.
+
+**Parallelism:** Can run in parallel with PR1 if PR2 does not touch
+task_queue.py or worker_pool.py directly. If PR1 lands first, PR2 can
+use the new adapter-based lane topology.
+
+### PR3: Document remaining coupling as refactor manifest
+
+**Scope:** Produce a machine-readable and human-readable coupling manifest
+that catalogs every Bid-Euchre-specific assumption remaining in the ops
+modules after PR1 and PR2 land. This satisfies the "documented" part of the
+done-when criterion.
+
+**Files changed:**
+
+| File | Change | Lines |
+|------|--------|-------|
+| `docs/02_agent/PORTABILITY_MANIFEST.md` | NEW — structured catalog of all remaining coupling points, categorized by severity (hard-block, soft-coupling, cosmetic) | ~200 |
+| `scripts/internal/audit_portability.py` | NEW — grep-based audit script that counts coupling occurrences and validates progress over time | ~100 |
+| `tests/unit/test_portability_audit.py` | NEW — regression test: run audit script, assert coupling count is below threshold | ~40 |
+
+**Validation:**
+```bash
+uv run python scripts/internal/audit_portability.py  # Produces report
+uv run python -m pytest tests/unit/test_portability_audit.py -v
+```
+
+**Risk:** Low — docs-only plus a simple audit script. Main risk is scope
+creep (temptation to start fixing coupling points discovered during audit).
+Resist: document only, fix later in Platform-13.
+
+### PR4: Hook migration + secondary caller cleanup
+
+**Scope:** Migrate the remaining high-traffic callers to use ServiceProvider
+or adapter imports: `.claude/hooks/post-merge-notify.sh` (Python inline),
+`.claude/hooks/inbound-channel-audit.py`, and `.claude/skills/park/SKILL.md`.
+
+**Files changed:**
+
+| File | Change | Lines |
+|------|--------|-------|
+| `.claude/hooks/post-merge-notify.sh` | Update Python inline to use ServiceProvider for task_queue operations | ~15 |
+| `.claude/hooks/inbound-channel-audit.py` | Use MonitorService instead of direct monitor import | ~10 |
+| `.claude/skills/park/SKILL.md` | Update import reference in code example | ~5 |
+| `tests/unit/test_ops_core_provider.py` | Add regression test: all hook imports resolve through provider | ~30 |
+
+**Validation:**
+```bash
+uv run python -m pytest tests/unit/test_ops_core_provider.py -v
+# Manual: verify hooks still work by triggering a merge in a test branch
+```
+
+**Risk:** Hook files use inline Python embedded in shell scripts. Testing is
+limited to import resolution — functional testing requires a live steward
+session. Accept this gap; Platform-13 will prove hooks work in a second
+project.
+
+## Dependency Graph
+
+```
+PR1 (lane topology) ─────┐
+                          ├──→ PR3 (coupling manifest) ──→ PR4 (hook cleanup)
+PR2 (ServiceProvider CLI) ┘
+```
+
+- PR1 and PR2 are **parallelizable** (independent file scopes)
+- PR3 depends on PR1+PR2 (audit must reflect post-migration state)
+- PR4 depends on PR3 (hook cleanup is informed by the manifest)
+
+## Implementation Estimate
+
+| PR | Lane-Hours | Description |
+|----|------------|-------------|
+| PR1 | 1.5h | Lane topology extraction |
+| PR2 | 2h | ServiceProvider CLI migration |
+| PR3 | 1.5h | Coupling manifest + audit script |
+| PR4 | 1h | Hook migration + cleanup |
+| **Total** | **6h** | |
+
+## Acceptance Criteria
+
+1. `ServiceProvider.default()` is the entry point for the ops CLI's primary
+   orchestration commands (monitor, task, dispatch, controller)
+2. `KNOWN_AUTHOR_LANES` is no longer a module-level constant in `task_queue.py`
+   — it is provided by the adapter
+3. A portability manifest exists documenting all remaining coupling points
+4. An audit script can be run to count coupling occurrences and track progress
+5. Hook callers use ServiceProvider or adapter imports instead of direct
+   module imports
+6. All existing tests pass (`make check`)
+
+## Done-When Verification
+
+From governing plan:
+
+> new orchestration code depends on adapter contracts rather than
+> Bid-Euchre-specific paths or docs
+
+**Verified by:** PR2 (CLI uses ServiceProvider) + PR4 (hooks use ServiceProvider)
+
+> the refactor scope for existing `src/bid_euchre/ops/` assumptions is
+> documented and materially reduced
+
+**Verified by:** PR1 (lane topology extracted = material reduction) + PR3
+(coupling manifest = documented)
+
+## Risks
+
+1. **Ops CLI complexity.** The CLI is 3200+ LOC with many deferred imports
+   and complex dispatch logic. PR2 must be surgical — migrate the 4 primary
+   command groups, not the entire file.
+
+2. **Backward compatibility.** External scripts or hooks may import
+   `KNOWN_AUTHOR_LANES` directly. PR1 should keep a deprecated re-export
+   that delegates to the adapter for backward compat.
+
+3. **ServiceProvider construction cost.** `ServiceProvider.default()` does
+   deferred imports; ensure it doesn't add measurable latency to CLI commands.
+
+4. **Hook inline Python.** Shell hooks with embedded Python are fragile.
+   PR4 changes should be minimal and tested by import resolution.

--- a/plans/agent_ops/5_portability_and_learning/sub/2026-04-01_platform-11-skill-learning-loop.md
+++ b/plans/agent_ops/5_portability_and_learning/sub/2026-04-01_platform-11-skill-learning-loop.md
@@ -1,0 +1,276 @@
+# SP-5-02: Platform-11 Skill Learning Loop
+
+**Status:** postponed (2026-04-01 operator decision — platform work postponed indefinitely)
+**Author:** analyst-a
+**Date:** 2026-04-01
+**Parent:** `plans/agent_ops/governing_plan.md` — Phase 5, Platform-11
+**Registry ID:** SP-5-02
+**Scope lock:** `plans/agent_ops/5_skill_learning/scope_lock.md`
+
+---
+
+## Problem Statement
+
+The steward dispatches work using static priority and manual lane assignment.
+Task completion outcomes are logged but never analyzed. There is no feedback
+loop to improve dispatch accuracy or detect lane-task affinity patterns.
+
+**Governing plan done-when:**
+> - Repeated successful workflows can produce skill suggestions with provenance
+> - Promotion/refinement cannot bypass review, context-safety, and rollback gates
+
+The scope lock (2026-03-25) contains a comprehensive design with operator
+feedback incorporated. This sub-plan translates that design into a concrete
+PR decomposition for dispatch.
+
+## Existing Infrastructure
+
+| Component | State | Notes |
+|-----------|-------|-------|
+| `events.py` | Ready | Has `task_completed` event type; extensible payload |
+| `task_queue.py` | Ready | `TaskPacket` is frozen dataclass; metadata dict available for new fields |
+| `worker_pool.py` | Ready | `select_worker()` and `dispatch_to_worker()` accept domain hints |
+| `skill_promotion.py` | Ready | Full lifecycle: propose → review → promote → disable. Context-safety scanning built in |
+| `token_economy.py` | Ready | Cost/token/lines-added metrics available |
+| `monitor.py` | Ready | Check registration pattern established |
+
+## Open Question Resolution
+
+The scope lock identifies two open questions. Recommended resolutions:
+
+**Q1: Claude Code native capabilities / prior art**
+→ **Skip investigation spike.** Claude Code's `/insights` feature and public
+repos (Open Claw, Hermes) are not mature enough to provide reusable learning
+loop components. The scope lock's MVP design (EWMA + task type taxonomy) is
+well-specified and doesn't depend on external prior art. Investigation would
+add 1h of lane time with low expected value.
+
+**Q2: Complexity estimation at dispatch**
+→ **Option A (orchestrator assigns manually) for MVP**, with Option B
+(heuristic from file count) as a documented follow-up. The orchestrator
+already assigns `priority` and `domain` at dispatch time; adding
+`complexity_estimate` (1-5 integer) is minimal friction.
+
+## PR Decomposition: 5 PRs
+
+### PR1: Task type taxonomy and enriched outcome recording
+
+**Scope:** Add `task_type` and `complexity_estimate` to TaskPacket metadata,
+define the task type taxonomy, and enrich `task_completed` events with
+structured outcome fields.
+
+**Files changed:**
+
+| File | Change | Lines |
+|------|--------|-------|
+| `src/bid_euchre/ops/learning.py` | NEW — Task type taxonomy enum/constants, outcome record dataclass, `TaskOutcome` with all fields from scope lock | ~120 |
+| `src/bid_euchre/ops/task_queue.py` | Add `task_type` and `complexity_estimate` as optional TaskPacket metadata fields (no schema break — stored in existing `metadata` dict) | ~15 |
+| `src/bid_euchre/ops/events.py` | Add `task_outcome_recorded` to VALID_EVENT_TYPES | ~3 |
+| `tests/unit/test_ops_learning.py` | NEW — taxonomy validation, outcome record construction, serialization | ~80 |
+| `tests/unit/test_ops_task_queue.py` | Test that task_type/complexity flow through metadata | ~20 |
+
+**Design decision:** `task_type` and `complexity_estimate` go into the
+existing `metadata` dict rather than as top-level TaskPacket fields. This
+avoids breaking the frozen dataclass schema and keeps the extension
+backward-compatible. The `learning.py` module provides accessor helpers:
+`get_task_type(packet)`, `get_complexity(packet)`.
+
+**Validation:**
+```bash
+uv run python -m pytest tests/unit/test_ops_learning.py tests/unit/test_ops_task_queue.py -v
+```
+
+### PR2: Append-only outcomes log and affinity model computation
+
+**Scope:** Implement the outcomes JSONL writer, affinity model computation
+from the log (EWMA), and rebuild-from-log capability.
+
+**Files changed:**
+
+| File | Change | Lines |
+|------|--------|-------|
+| `src/bid_euchre/ops/learning.py` | EXTEND — `OutcomeLogger` (JSONL append writer with flock), `AffinityModel` (EWMA computation, per-lane × task_type stats, confidence scoring), `rebuild_affinity()` function | ~230 |
+| `tests/unit/test_ops_learning.py` | EXTEND — JSONL round-trip, affinity computation from synthetic data, rebuild idempotency, EWMA decay validation | ~150 |
+
+**Storage paths (gitignored):**
+- `.claude/runtime/learning/outcomes.jsonl` — append-only event log
+- `.claude/runtime/learning/lane_affinity.json` — derived affinity model
+- `.claude/runtime/learning/snapshot_meta.json` — rebuild metadata
+
+**Key invariants:**
+- Affinity model is fully derivable from outcomes.jsonl (source of truth)
+- EWMA with α=0.3 for recency bias
+- Minimum N≥5 observations per task_type per lane before scoring
+- Confidence = `min(1.0, observations / 20)` per task_type
+
+**Validation:**
+```bash
+uv run python -m pytest tests/unit/test_ops_learning.py -v -k "affinity or outcome"
+```
+
+### PR3: Dispatch advisor with anti-corruption guardrails
+
+**Scope:** Build the dispatch advisor that ranks available lanes by affinity
+score, plus all anti-corruption guardrails from the scope lock.
+
+**Files changed:**
+
+| File | Change | Lines |
+|------|--------|-------|
+| `src/bid_euchre/ops/learning.py` | EXTEND — `DispatchAdvisor` class: `rank_lanes()` (complexity-adjusted scoring), exploration policy (constrained by complexity and confidence), skew monitoring (>60% monoculture alert), override tracking | ~150 |
+| `src/bid_euchre/ops/monitor.py` | Add `check_learning_health()` — data freshness warning (no outcomes in >24h), cold-start lane detection, skew alerts | ~30 |
+| `tests/unit/test_ops_learning.py` | EXTEND — advisor ranking, exploration rate decay, skew detection, cold-start fallback to round-robin, guardrail enforcement | ~120 |
+| `tests/unit/test_ops_monitor.py` | Test learning health check | ~20 |
+
+**Advisor scoring formula:**
+```
+score = clean_merge_rate * (1 / complexity_adjusted_minutes) * (1 - rework_rate)
+where complexity_adjusted_minutes = avg_minutes / avg_complexity
+```
+
+**Exploration policy:**
+- Only explore on tasks with complexity ≤ 3
+- Prefer exploration among top-3 ranked lanes (not fully random)
+- Rate: `max(0.05, 0.20 * (1 - confidence))`
+
+**Guardrails:**
+- Advisory-only (orchestrator retains final authority)
+- Minimum N≥5 and confidence > 0.3 before routing
+- Skew alert if lane handles >60% of a task type over rolling 20-task window
+- Override tracking with >30% rate triggering advisor quality review
+
+**Validation:**
+```bash
+uv run python -m pytest tests/unit/test_ops_learning.py tests/unit/test_ops_monitor.py -v
+```
+
+### PR4: Wire advisor into dispatch path (advisory mode)
+
+**Scope:** Integrate the dispatch advisor into the worker_pool dispatch flow
+as an advisory signal. The orchestrator sees the recommendation but retains
+override authority. Also wire outcome recording into the post-merge hook.
+
+**Files changed:**
+
+| File | Change | Lines |
+|------|--------|-------|
+| `src/bid_euchre/ops/worker_pool.py` | In `select_worker()`, consult `DispatchAdvisor.rank_lanes()` when affinity data is available; log recommendation vs actual selection; record overrides | ~40 |
+| `src/bid_euchre/ops/token_economy.py` | Add helper to extract cost/token metrics for outcome records | ~15 |
+| `.claude/hooks/post-merge-notify.sh` | After completing a task packet, also record a `TaskOutcome` to `outcomes.jsonl` with timing, review rounds, PR number | ~25 |
+| `scripts/internal/ops.py` | Add `learning` subcommand: `ops.py learning status` (show affinity model summary), `ops.py learning outcomes` (list recent outcomes) | ~60 |
+| `tests/unit/test_ops_worker_pool.py` | Test advisor consultation in select_worker | ~30 |
+| `tests/integration/test_learning_loop.py` | NEW — end-to-end: create packet with task_type → dispatch → complete → outcome recorded → affinity updated → next dispatch sees updated ranking | ~100 |
+
+**Validation:**
+```bash
+uv run python -m pytest tests/unit/test_ops_worker_pool.py tests/integration/test_learning_loop.py -v
+uv run python scripts/internal/ops.py learning status  # Smoke
+```
+
+### PR5: Skill suggestion pipeline
+
+**Scope:** Implement pattern detection in outcome data and evidence-based
+skill suggestion generation through the existing skill_promotion pipeline.
+
+**Files changed:**
+
+| File | Change | Lines |
+|------|--------|-------|
+| `src/bid_euchre/ops/learning.py` | EXTEND — `SkillSuggestionDetector`: scan outcomes for repeated patterns meeting evidence thresholds (N≥5, same task_type, low review churn ≤1.5 rounds, same file patterns), generate candidate SKILL.md with provenance | ~120 |
+| `src/bid_euchre/ops/skill_promotion.py` | Add `propose_from_learning()` function that accepts a learning-generated suggestion and runs it through the existing propose → review pipeline. Rate limit: max 2 suggestions per overnight run | ~50 |
+| `tests/unit/test_ops_learning.py` | EXTEND — pattern detection with synthetic outcome data, evidence threshold enforcement, rate limiting | ~80 |
+| `tests/unit/test_ops_skill_promotion.py` | Test learning-sourced proposals flow through existing pipeline with provenance | ~40 |
+
+**Evidence thresholds (all must be met):**
+- Repeated success: N≥5 on same task_type
+- Same major file or subsystem pattern across instances
+- Low review churn: avg review rounds ≤ 1.5
+- Consistent step sequence observable from outcome metadata
+
+**Validation:**
+```bash
+uv run python -m pytest tests/unit/test_ops_learning.py tests/unit/test_ops_skill_promotion.py -v -k "suggestion or learning"
+```
+
+## Dependency Graph
+
+```
+PR1 (taxonomy + outcome schema) ──→ PR2 (outcomes log + affinity) ──→ PR3 (advisor + guardrails) ──→ PR4 (wiring)
+                                                                                                   ↘
+                                                                                                    PR5 (skill suggestions)
+```
+
+- PR1 → PR2 → PR3 → PR4: strictly sequential (each builds on the prior)
+- PR5 depends on PR2 (needs outcome data) but is parallelizable with PR3/PR4
+
+## Implementation Estimate
+
+| PR | Lane-Hours | Description |
+|----|------------|-------------|
+| PR1 | 1.5h | Taxonomy + enriched outcome recording |
+| PR2 | 2h | Outcomes log + affinity model |
+| PR3 | 2h | Dispatch advisor + guardrails |
+| PR4 | 2h | Advisory wiring + outcome recording hook |
+| PR5 | 2h | Skill suggestion pipeline |
+| **Total** | **9.5h** | |
+
+## Acceptance Criteria
+
+1. `TaskPacket` metadata supports `task_type` and `complexity_estimate` fields
+2. Task completions are recorded to `outcomes.jsonl` with structured outcome
+   data (timing, review rounds, outcome granularity, cost metrics)
+3. Affinity model is computed from outcomes log using EWMA with α=0.3
+4. Dispatch advisor ranks lanes by affinity score, controlled for complexity
+5. All 7 anti-corruption guardrails from scope lock are implemented and tested
+6. Advisor is advisory-only — orchestrator can override with tracking
+7. Learning health monitoring is wired into the monitor cycle
+8. Repeated patterns meeting evidence thresholds generate skill suggestions
+   through the existing promotion pipeline
+9. Rate limit: max 2 skill suggestions per overnight run
+10. All existing tests pass (`make check`)
+
+## Done-When Verification
+
+From governing plan:
+
+> repeated successful workflows can produce skill suggestions with provenance
+
+**Verified by:** PR5 (skill suggestion detector with provenance metadata)
+
+> promotion/refinement cannot bypass review, context-safety, and rollback gates
+
+**Verified by:** PR5 uses existing `skill_promotion.py` pipeline which enforces
+propose → review → promote with context-safety scanning at both proposal and
+promotion time. No new bypass paths introduced.
+
+## Evaluation Framework (Deferred)
+
+The scope lock specifies a matched-cohort evaluation framework. This is
+deferred to a follow-up PR after the advisor has accumulated baseline data
+from 3+ overnight runs and 2+ daytime sessions (minimum 40 tasks across
+≥5 task types). Filing as a GitHub issue at Phase 5 closeout.
+
+## Risks
+
+1. **Cold start.** No historical data exists. The advisor will be inactive
+   (fallback to round-robin) until N≥5 per task_type accumulates. This may
+   take 2-3 overnight runs. Mitigation: not a problem, just slow ramp-up.
+
+2. **Outcome recording in hooks.** The post-merge hook is inline Python in a
+   shell script. Adding outcome recording adds another failure point.
+   Mitigation: wrap in try/except — outcome recording is best-effort; the
+   merge must never fail because of a learning log write error.
+
+3. **Schema evolution.** Adding fields to outcome records over time requires
+   backward-compatible reading. Mitigation: all new fields are optional with
+   defaults. The affinity rebuild function tolerates missing fields gracefully.
+
+4. **Skill suggestion noise.** Auto-generated suggestions may be low quality
+   during early ramp-up. Mitigation: rate limit (max 2 per overnight run),
+   evidence thresholds (N≥5, low churn), and operator review (filed as GitHub
+   issues with `skill-suggestion` label, never auto-promoted).
+
+5. **Affinity model accuracy.** EWMA with a single scoring formula may not
+   capture lane-task affinity well. Mitigation: the advisor is advisory-only;
+   the orchestrator retains final authority. Accuracy improves with data
+   volume and can be refined in Phase 2 (logistic regression, deferred).

--- a/plans/agent_ops/5_skill_learning/scope_lock.md
+++ b/plans/agent_ops/5_skill_learning/scope_lock.md
@@ -1,6 +1,6 @@
 # Platform-11: Skill Learning Loop — Scope Lock
 
-**Status:** DRAFT (operator feedback incorporated)
+**Status:** POSTPONED INDEFINITELY (2026-04-01 operator decision — platform work postponed to focus on browser game product)
 **Author:** analyst lane
 **Date:** 2026-03-25
 **Updated:** 2026-03-25 (operator feedback round 1)

--- a/plans/agent_ops/governing_plan.md
+++ b/plans/agent_ops/governing_plan.md
@@ -108,10 +108,10 @@ Each active phase maintains a checkpoint file at:
 
 Current active phase:
 
-- Phase 5 (`5_portability_and_learning`) is the next unentered phase.
-  Depends on Phase 3 completion (satisfied). Phase 4 completion (satisfied
-  2026-04-01) unblocks this phase. No scaffolding exists yet — scope lock
-  needed before entry.
+- Phase 5 (`5_portability_and_learning`) — **POSTPONED INDEFINITELY**.
+  2026-04-01: Operator decision — platform work postponed indefinitely to
+  focus on browser game product. Phase 4 was the final delivered platform
+  phase. All Phase 5+ scope locks and sub-plans marked POSTPONED.
 
 Completed phases:
 

--- a/plans/agent_ops/sub_plan_registry.md
+++ b/plans/agent_ops/sub_plan_registry.md
@@ -1,7 +1,7 @@
 # Sub-Plan Registry — Agentic Orchestration Platform
 
 **Governing plan:** `plans/agent_ops/governing_plan.md`
-**Last updated:** 2026-03-27 by author-c (SP-4-08 progress: monitor wiring PR #1944 merged)
+**Last updated:** 2026-04-01 by analyst-a (Phase 5+ POSTPONED — operator decision to focus on browser game)
 
 ---
 
@@ -31,18 +31,19 @@
 | SP-4-05 | Reactive control-loop hardening | Phase 4, Pre-Platform-8 lifecycle reactivity and control-plane hardening | completed | orchestrator | `plans/agent_ops/4_remote_channel/sub/2026-03-24_reactive-control-loop-hardening.md` | 2026-03-24 | 2026-03-24 (PRs #1500, #1491, #1474, #1490, #1507, #1486; lifecycle proven through fleet operation) |
 | SP-4-06 | Platform-8b repo-owned remote audit trail | Phase 4, Platform-8b audit trail for remote exchanges | completed | author-a | `plans/agent_ops/4_remote_channel/sub/2026-03-24_platform-8b-audit-trail.md` | 2026-03-24 | 2026-03-24 (PRs #1532, #1536, #1541, #1549) |
 | SP-4-07 | Controller-first control plane and transport evaluation | Phase 4, Pre-Platform-9 controller projection, hook enforcement, and transport proving | completed | orchestrator | `plans/agent_ops/4_remote_channel/sub/2026-03-24_controller-first-control-plane-and-transport-evaluation.md` | 2026-03-24 | 2026-03-25 (PR #1768; all 6 exit criteria met, all 5 proving runs passed) |
-| SP-4-08 | Platform-9a idle-attention alerts and remote acknowledgement loop | Phase 4, Step 4 (Platform-9a) | in_progress | overnight fleet + author-c | `plans/agent_ops/4_remote_channel/sub/2026-03-25_platform-9a-idle-attention-alerts.md` | 2026-03-25 | — (groundwork shipped: evaluator, adapter, ack parser, controller mutation, tests. Monitor wiring shipped: PR #1944 adds `evaluate_alert_push()` to monitor module. Remaining: MCP delivery, inbound ack consumer, real round-trip — see #1826) |
-| SP-4-09 | Platform-9b away-from-desk queue priority and away-mode | Phase 4, Step 5 (Platform-9b) | in_progress | overnight fleet | _(no sub-plan file — retroactive registration of shipped groundwork)_ | 2026-03-25 | — (groundwork shipped: queue priority scorer #1802, away-mode detection #1806, away-mode wiring #1815; E2E integration blocked on 9a) |
-| SP-4-10 | Platform-10 core ops extraction | Phase 4, Step 6 / Phase 5 bridge (Platform-10) | in_progress | overnight fleet | _(no sub-plan file — retroactive registration of shipped groundwork)_ | 2026-03-25 | — (groundwork shipped: core ops ABCs #1807, extract core ops #1813, repo adapter #1817; integration deferred to Phase 5) |
+| SP-4-08 | Platform-9a idle-attention alerts and remote acknowledgement loop | Phase 4, Step 4 (Platform-9a) | postponed | overnight fleet + author-c | `plans/agent_ops/4_remote_channel/sub/2026-03-25_platform-9a-idle-attention-alerts.md` | 2026-03-25 | — (groundwork shipped: evaluator, adapter, ack parser, controller mutation, tests. Monitor wiring shipped: PR #1944. **POSTPONED 2026-04-01** — platform work postponed indefinitely) |
+| SP-4-09 | Platform-9b away-from-desk queue priority and away-mode | Phase 4, Step 5 (Platform-9b) | postponed | overnight fleet | _(no sub-plan file — retroactive registration of shipped groundwork)_ | 2026-03-25 | — (groundwork shipped: queue priority scorer #1802, away-mode detection #1806, away-mode wiring #1815. **POSTPONED 2026-04-01** — platform work postponed indefinitely) |
+| SP-4-10 | Platform-10 core ops extraction | Phase 4, Step 6 / Phase 5 bridge (Platform-10) | postponed | overnight fleet | _(no sub-plan file — retroactive registration of shipped groundwork)_ | 2026-03-25 | — (groundwork shipped: core ops ABCs #1807, extract core ops #1813, repo adapter #1817. **POSTPONED 2026-04-01** — platform work postponed indefinitely) |
 
 ## Status Summary
 
 | Status | Count |
 |--------|-------|
 | proposed | 0 |
-| in_progress | 3 |
+| in_progress | 0 |
 | blocked | 0 |
 | completed | 21 |
+| postponed | 3 |
 | abandoned | 0 |
 | superseded | 1 |
 


### PR DESCRIPTION
## Summary

- Mark all Phase 5+ platform work as POSTPONED INDEFINITELY per operator decision (2026-04-01)
- Update governing plan, 3 scope locks, Phase 5 plan/checkpoints, sub-plan registry, and CLAUDE.md
- Add Phase 5 planning artifacts (plan.md, checkpoints.md, 2 sub-plans) — all created with POSTPONED status

## Why

Operator has decided to postpone all platform work indefinitely to focus on browser game product. Phase 4 was the final delivered platform phase. This PR records that decision durably across all planning artifacts.

## What Changed

| File | Change |
|------|--------|
| `CLAUDE.md` | Governing plans table: ACTIVE → PHASE 4 COMPLETE — POSTPONED |
| `plans/agent_ops/governing_plan.md` | Phase 5 checkpoint section: decision note with date |
| `plans/agent_ops/5_skill_learning/scope_lock.md` | Status: DRAFT → POSTPONED INDEFINITELY |
| `plans/agent_ops/5_cross_model/scope_lock.md` | Status: DRAFT → POSTPONED INDEFINITELY |
| `plans/agent_ops/5_extraction/scope_lock.md` | Status: SCOPE-LOCKED → POSTPONED INDEFINITELY |
| `plans/agent_ops/5_portability_and_learning/plan.md` | NEW — Phase 5 plan with POSTPONED status |
| `plans/agent_ops/5_portability_and_learning/checkpoints.md` | NEW — all steps POSTPONED |
| `plans/agent_ops/5_portability_and_learning/sub/*.md` | NEW — 2 sub-plans with postponed status |
| `plans/agent_ops/sub_plan_registry.md` | SP-4-08/09/10 → postponed; SP-5-01/02 not yet added (local only) |

## Scope Note

This does **not** affect browser game expansion work, which continues as the active initiative.

## Repro / Validation

```bash
make repo-lint     # passes
make docs-check    # passes
make lint          # passes (no Python changes)
```

## Worktree proof

Operating in `Bid-Euchre-steward-analyst` persistent worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)