### PR TITLE
fix(web): make moon bids use 3-player trick play in hosted engine

### DIFF
--- a/src/bid_euchre/hosted_play/engine.py
+++ b/src/bid_euchre/hosted_play/engine.py
@@ -201,9 +201,12 @@ class MatchEngine:
     turn to act (bid or play) and auto-advances through all AI turns.
 
     Moon/loner support:
-    - Moon bids trigger a 2-card exchange with the partner before trick play.
+    - Moon bids trigger a 2-card exchange with the partner, then the partner
+      sits out during trick play (3-player tricks).
     - Loner bids cause the declarer's partner to sit out during trick play
-      (3-player tricks).
+      (3-player tricks), with no exchange.
+    - Both moon and loner use 3-player trick play; the difference is the
+      exchange step.
     - Overcall hierarchy: regular 1-10 < moon < loner.
     """
 
@@ -333,6 +336,10 @@ class MatchEngine:
         hand.exchange_received = [[c.suit, c.rank] for c in cards_received]
         hand.exchange_phase = None
 
+        # Moon: partner sits out during trick play (3-player tricks),
+        # just like loner, but exchange happens first.
+        hand.sitting_out_seat = (hand.bidder_seat + 2) % _NUM_PLAYERS
+
         # Transition to trick play with exchange-reveal interstitial
         hand.phase = "trick_play"
         leader = hand.bidder_seat
@@ -345,8 +352,27 @@ class MatchEngine:
         # Auto-advance AI just like submit_human_bid/submit_human_card.
         # Without this, the game is stuck when the leader (bidder) is an AI
         # seat because no mechanism triggers AI card play after exchange.
-        state = self._advance_ai(state)
+        # However, when the human is sitting out (partner bid moon), defer
+        # AI advancement until after the exchange-reveal interstitial —
+        # otherwise _advance_ai plays all 10 tricks and the interstitial
+        # never shows.  The route layer calls advance_after_exchange_reveal()
+        # to trigger the deferred advancement.
+        if hand.sitting_out_seat != HUMAN_SEAT:
+            state = self._advance_ai(state)
 
+        return state
+
+    def advance_after_exchange_reveal(self, state: MatchState) -> MatchState:
+        """Trigger AI advancement after the exchange-reveal interstitial.
+
+        Called by the route layer when ``exchange_revealed`` is set to True.
+        For moon hands where the human is sitting out (partner of the mooner),
+        AI advancement was deferred from ``submit_exchange_selection`` to allow
+        the exchange interstitial to display first.  This method completes the
+        deferred advancement.
+        """
+        self.last_ai_events = []
+        state = self._advance_ai(state)
         return state
 
     def get_legal_bids(self, state: MatchState) -> list[BidAction]:
@@ -477,8 +503,8 @@ class MatchEngine:
         Populates ``self.last_ai_events`` with exact decision data for every
         AI action taken during this advance cycle.
 
-        For loner hands where the human is sitting out (partner bid loner),
-        auto-advances through all trick play without pausing.
+        For moon/loner hands where the human is sitting out (partner bid
+        moon or loner), auto-advances through all trick play without pausing.
         """
         while True:
             # Match finished — nothing to advance
@@ -493,7 +519,7 @@ class MatchEngine:
             if hand.current_seat == HUMAN_SEAT:
                 if hand.sitting_out_seat != HUMAN_SEAT:
                     return state
-                # Human is sitting out (partner bid loner) — skip is handled
+                # Human is sitting out (partner bid moon/loner) — skip is handled
                 # by _next_active_seat in trick play.  If we reach here during
                 # auction, it's the human's normal turn.
                 if hand.phase == "auction":
@@ -700,8 +726,9 @@ class MatchEngine:
             hand.exchange_given = [[c.suit, c.rank] for c in cards_given]
             hand.exchange_received = [[c.suit, c.rank] for c in cards_received]
 
-        # Loner: partner sits out during trick play
-        if hand.bid_type == "loner":
+        # Moon and loner: partner sits out during trick play (3-player tricks).
+        # For moon, this happens AFTER the exchange above.
+        if hand.bid_type in ("moon", "loner"):
             hand.sitting_out_seat = (hand.bidder_seat + 2) % _NUM_PLAYERS
 
         # Contract set — transition to trick play
@@ -733,7 +760,7 @@ class MatchEngine:
         hand.current_trick.plays.append((seat, card))
         hand.turn_number += 1
 
-        # Check if trick is complete (3 plays for loner, 4 otherwise)
+        # Check if trick is complete (3 plays for moon/loner, 4 otherwise)
         ppt = _players_per_trick(hand.sitting_out_seat)
         if len(hand.current_trick.plays) >= ppt:
             state = self._process_trick_end(state)

--- a/tests/unit/hosted_play/test_engine.py
+++ b/tests/unit/hosted_play/test_engine.py
@@ -204,7 +204,7 @@ def _play_full_hand(
     # Handle interactive moon exchange
     state = _auto_exchange(engine, state)
 
-    # Handle trick play phase (skip if human is sitting out)
+    # Handle trick play phase (skip if human is sitting out for moon/loner)
     while (
         state.status == "active"
         and state.current_hand is not None
@@ -248,7 +248,7 @@ def _play_until_match_end(engine: MatchEngine, state: MatchState) -> MatchState:
                 legal = engine.get_legal_plays(state)
                 state = engine.submit_human_card(state, legal[0])
             else:
-                # In normal rounds, only human may sit out during loner hands.
+                # In normal rounds, only human may sit out during moon/loner hands.
                 state = engine._advance_ai(state)
         elif hand.phase == "complete":
             state = engine.advance_to_next_hand(state)
@@ -1360,9 +1360,22 @@ class TestInteractiveMoonExchange:
                 state = engine.submit_exchange_selection(state, [0, 1])
                 hand = state.current_hand
                 assert hand is not None
+                # Human sits out — AI advancement is deferred for the
+                # exchange-reveal interstitial
                 assert hand.phase == "trick_play"
+                assert hand.sitting_out_seat == HUMAN_SEAT
                 assert hand.exchange_given is not None
                 assert hand.exchange_received is not None
+
+                # Simulate the exchange reveal step (route layer)
+                hand.exchange_revealed = True
+                state = engine.advance_after_exchange_reveal(state)
+                hand = state.current_hand
+                assert hand is not None
+                # Now AI auto-plays all 10 tricks → hand complete
+                assert (
+                    hand.phase == "complete"
+                ), f"Expected 'complete' after reveal, got '{hand.phase}'"
                 return  # Test passed
 
         pytest.skip("No seed found where AI Partner bids moon first")
@@ -1533,29 +1546,33 @@ class TestMoonExchangeAIAdvance:
                 hand = state.current_hand
                 assert hand is not None
 
-                # After exchange + AI advance, the game must be playable:
-                # sitting_out_seat is None (moon, not loner)
-                assert hand.sitting_out_seat is None
+                # Moon partner sits out (3-player trick play).
+                # Seat 2 bids moon → partner is seat 0 (HUMAN_SEAT).
+                # AI advancement is deferred for the exchange interstitial.
+                partner_seat = (hand.bidder_seat + 2) % 4
+                assert hand.sitting_out_seat == partner_seat
+                assert partner_seat == HUMAN_SEAT
+                assert hand.phase == "trick_play"
 
-                # If trick play: current_seat should be HUMAN_SEAT
-                # (the AI leader and subsequent AI seats should have
-                # already played via _advance_ai)
-                if hand.phase == "trick_play":
-                    assert hand.current_seat == HUMAN_SEAT, (
-                        f"Game stuck on AI seat {hand.current_seat}; "
-                        f"_advance_ai did not run after exchange"
-                    )
-                    # AI should have played cards already
-                    assert hand.current_trick is not None
-                    assert len(hand.current_trick.plays) > 0
+                # Simulate exchange reveal (route layer)
+                hand.exchange_revealed = True
+                state = engine.advance_after_exchange_reveal(state)
+                hand = state.current_hand
+                assert hand is not None
+
+                # Human sits out → AI auto-plays everything → hand complete
+                assert (
+                    hand.phase == "complete"
+                ), f"Expected 'complete' after reveal, got '{hand.phase}'"
                 return
 
         pytest.skip("No seed found where AI Partner (seat 2) bids moon")
 
-    def test_moon_no_sitting_out_after_exchange(self) -> None:
-        """Moon bids must never set sitting_out_seat — all 4 players play.
+    def test_moon_sets_sitting_out_after_exchange(self) -> None:
+        """Moon bids set sitting_out_seat — partner sits out, 3-player tricks.
 
-        This is the core invariant that distinguishes moon from loner.
+        Moon = exchange THEN partner sits out.  Same 3-player trick play as
+        loner; the difference is moon has a card exchange first.
         """
         engine = MatchEngine(
             bidding_policy=MoonBidder(contract="S"),
@@ -1582,9 +1599,10 @@ class TestMoonExchangeAIAdvance:
                 assert hand is not None
 
             if hand.bid_type == "moon":
-                assert hand.sitting_out_seat is None, (
-                    f"Moon bid should never set sitting_out_seat, "
-                    f"got {hand.sitting_out_seat}"
+                expected_sitting_out = (hand.bidder_seat + 2) % 4
+                assert hand.sitting_out_seat == expected_sitting_out, (
+                    f"Moon bid should set sitting_out_seat to partner "
+                    f"(seat {expected_sitting_out}), got {hand.sitting_out_seat}"
                 )
                 found = True
 
@@ -1611,10 +1629,11 @@ class TestMoonExchangeAIAdvance:
                 assert hand is not None
 
                 # Human bid moon → human leads → current_seat is HUMAN_SEAT
+                # Partner (seat 2) sits out — 3-player trick play
                 if hand.phase == "trick_play":
                     assert hand.current_seat == HUMAN_SEAT
                     assert hand.bidder_seat == HUMAN_SEAT
-                    assert hand.sitting_out_seat is None
+                    assert hand.sitting_out_seat == 2  # Human's partner
                     # No AI plays yet — human leads
                     assert hand.current_trick is not None
                     assert len(hand.current_trick.plays) == 0

--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -2345,29 +2345,25 @@ class TestMoonExchangeRoute:
         assert "Moon Exchange" in resp.text
         assert "Start Trick Play" in resp.text
 
-        # Step 4: Click "Start Trick Play" to reveal the exchange
+        # Step 4: Click "Start Trick Play" to reveal the exchange.
+        # Human is the partner (seat 0) and sits out for moon — after
+        # the reveal, _advance_ai auto-plays all 10 tricks, completing
+        # the hand.  The response shows the hand result.
         resp = client.post(f"/play/{link_uuid}/next")
         assert resp.status_code == 200
-        # After reveal, exchange interstitial should be gone
-        assert "Moon Exchange" not in resp.text
 
-        # Step 5: Verify the game state is playable (not stuck)
+        # Step 5: Verify the hand completed (human sat out)
         result_after = get_match_state(app, link_uuid)
         assert result_after is not None
         state_after, _, session_after = result_after
         hand_after = state_after.current_hand
         assert hand_after is not None
-        assert hand_after.phase == "trick_play"
         assert hand_after.exchange_revealed is True
         assert (
-            hand_after.sitting_out_seat is None
-        ), "Moon bid must not set sitting_out_seat"
-        # AI should have advanced — current_seat must be HUMAN_SEAT
-        # (or the hand might have completed if AI played through).
-        # The key assertion: the game is NOT stuck on an AI seat.
-        if hand_after.phase == "trick_play":
-            assert hand_after.current_seat == HUMAN_SEAT, (
-                f"Game stuck on AI seat {hand_after.current_seat} "
-                f"after moon exchange — _advance_ai not called"
-            )
+            hand_after.sitting_out_seat == HUMAN_SEAT
+        ), "Moon partner (human) should sit out"
+        # Human sat out → AI auto-played all tricks → hand complete
+        assert (
+            hand_after.phase == "complete"
+        ), f"Expected 'complete' (human sits out), got '{hand_after.phase}'"
         session_after.close()

--- a/web/routes.py
+++ b/web/routes.py
@@ -1080,6 +1080,10 @@ async def next_step(
             hand.revealed_auction_count += 1
         elif _has_pending_exchange(hand):
             hand.exchange_revealed = True
+            # Moon: trigger deferred AI advancement.  When the human is
+            # sitting out (partner of the mooner), submit_exchange_selection
+            # deferred _advance_ai so the interstitial could display first.
+            state = engine.advance_after_exchange_reveal(state)
         elif hand.phase == "trick_play" and hand.paused_after_trick:
             hand.paused_after_trick = False
         else:


### PR DESCRIPTION
## Plan
N/A — bugfix aligned with PR #2005 (simulation-side fix)

## Summary
- Engine now sets `sitting_out_seat` for moon bids (partner sits out after exchange)
- Added `advance_after_exchange_reveal()` to defer AI trick play until after the exchange interstitial
- Route `/next` handler triggers deferred AI advancement after exchange reveal
- Updated all tests that incorrectly asserted `sitting_out_seat is None` for moon

## Why
The hosted-play engine did not set `sitting_out_seat` for moon bids, causing 4-player trick play. The correct rule (from RULES.md) is: **moon = exchange THEN partner sits out** (3-player tricks). This is the same as loner except moon has the card exchange step first. PR #2005 already fixed the simulation; this PR fixes the hosted engine to match.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/ -k moon -q
uv run python -m pytest tests/unit/hosted_play/ -q
make check-quiet
```

**Seed (if applicable):** N/A (tests use multiple seeds)

## Test Criteria
- **Pass condition:** All moon engine tests pass with sitting_out_seat correctly set for moon bids
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_engine.py -k "moon_sets_sitting_out or human_mooner_leads or ai_mooner_advances" -v`
- **Expected result:** 3 tests pass, all verifying `sitting_out_seat == partner_seat` for moon bids

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/ -q` — 2813 passed, 6 skipped
- [x] `make check-quiet` — 3 pre-existing failures in unrelated modules (ops_token_economy, telegram_filter)

## Worktree Proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
branch: fix/moon-engine-exchange-then-sitout
```

## Files Changed
| File | Change |
|------|--------|
| `src/bid_euchre/hosted_play/engine.py` | Set `sitting_out_seat` for moon in both `_process_auction_end` and `submit_exchange_selection`; add `advance_after_exchange_reveal()`; defer `_advance_ai` when human sits out |
| `web/routes.py` | Call `advance_after_exchange_reveal()` after exchange interstitial |
| `tests/unit/hosted_play/test_engine.py` | Update 4 tests: moon now sets sitting_out_seat; add exchange reveal step for deferred advancement |
| `tests/unit/hosted_play/test_routes.py` | Update route test: after exchange reveal, human sits out → hand completes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)