### PR TITLE
feat(web): leaderboard metric definitions, tooltips, and formatting

### DIFF
--- a/tests/unit/hosted_play/test_leaderboard.py
+++ b/tests/unit/hosted_play/test_leaderboard.py
@@ -5,6 +5,7 @@ Covers:
 - In-progress match hand inclusion (live updates)
 - Leaderboard ranking (sorted by net_eppd descending)
 - Default and secondary column partitioning
+- Metric definitions and formatting helpers
 - Access gating (404 for unknown UUIDs)
 - Route integration via the FastAPI test client
 """
@@ -17,7 +18,13 @@ from datetime import datetime, timezone
 import pytest
 
 from web.db import Hand, Match, Player
-from web.leaderboard import compute_player_stats, get_leaderboard
+from web.leaderboard import (
+    METRIC_DEFINITIONS,
+    PlayerStats,
+    compute_player_stats,
+    format_metric,
+    get_leaderboard,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -585,3 +592,176 @@ class TestLeaderboardRoute:
             assert 'hx-trigger="every 30s"' in resp.text
         finally:
             session.close()
+
+    def test_leaderboard_shows_ranking_explanation(self, app_and_client):
+        """Leaderboard page shows ranking explanation text."""
+        app, client = app_and_client
+        session = app.state.session_factory()
+        try:
+            player = _make_player(session, nickname="RankExplain")
+            session.commit()
+
+            resp = client.get(f"/leaderboard/{player.link_uuid}")
+            assert resp.status_code == 200
+            assert "Ranked by Net EPPD" in resp.text
+        finally:
+            session.close()
+
+    def test_leaderboard_shows_help_button(self, app_and_client):
+        """Leaderboard with data includes the help toggle button."""
+        app, client = app_and_client
+        session = app.state.session_factory()
+        try:
+            player = _make_player(session, nickname="HelpBtn")
+            match = _make_match(session, player)
+            _make_hand(session, match, points_team0=5, points_team1=2)
+            session.commit()
+
+            resp = client.get(f"/leaderboard/{player.link_uuid}")
+            assert resp.status_code == 200
+            assert "What do these stats mean?" in resp.text
+            assert "Metric Definitions" in resp.text
+        finally:
+            session.close()
+
+    def test_leaderboard_shows_tooltips(self, app_and_client):
+        """Column headers include tooltip text from metric definitions."""
+        app, client = app_and_client
+        session = app.state.session_factory()
+        try:
+            player = _make_player(session, nickname="Tooltips")
+            match = _make_match(session, player)
+            _make_hand(session, match, points_team0=5, points_team1=2)
+            session.commit()
+
+            resp = client.get(f"/leaderboard/{player.link_uuid}")
+            assert resp.status_code == 200
+            # Spot check key tooltips
+            assert "average point advantage" in resp.text.lower()
+            assert "Percentage of completed games" in resp.text
+        finally:
+            session.close()
+
+    def test_leaderboard_formats_percentages(self, app_and_client):
+        """Win rate and other rates render as percentages, not decimals."""
+        app, client = app_and_client
+        session = app.state.session_factory()
+        try:
+            player = _make_player(session, nickname="FmtTest")
+            match = _make_match(session, player, score_human=52, score_ai=20)
+            _make_hand(
+                session,
+                match,
+                bidder_seat=0,
+                winning_bid_n=6,
+                tricks_team0=7,
+                tricks_team1=3,
+                points_team0=6,
+                points_team1=3,
+            )
+            session.commit()
+
+            resp = client.get(f"/leaderboard/{player.link_uuid}")
+            assert resp.status_code == 200
+            # Win rate should be 100% not 1.0 or 1.000
+            assert "100%" in resp.text
+            # games_won should show "1 game"
+            assert "1 game" in resp.text
+        finally:
+            session.close()
+
+
+# ---------------------------------------------------------------------------
+# format_metric tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatMetric:
+    """Unit tests for the format_metric helper."""
+
+    def test_pct_formats_fraction_as_percentage(self):
+        assert format_metric(0.65, "pct") == "65%"
+        assert format_metric(1.0, "pct") == "100%"
+        assert format_metric(0.0, "pct") == "0%"
+
+    def test_pct_rounds_to_nearest(self):
+        assert format_metric(0.666, "pct") == "67%"
+        assert format_metric(0.334, "pct") == "33%"
+
+    def test_int_formats_as_integer(self):
+        assert format_metric(5, "int") == "5"
+        assert format_metric(0, "int") == "0"
+
+    def test_int_games_singular(self):
+        assert format_metric(1, "int_games") == "1 game"
+
+    def test_int_games_plural(self):
+        assert format_metric(0, "int_games") == "0 games"
+        assert format_metric(5, "int_games") == "5 games"
+
+    def test_float1(self):
+        assert format_metric(3.14, "float1") == "3.1"
+        assert format_metric(0.0, "float1") == "0.0"
+
+    def test_float3(self):
+        assert format_metric(1.2345, "float3") == "1.234"
+
+    def test_signed_float1_positive(self):
+        assert format_metric(3.2, "signed_float1") == "+3.2"
+
+    def test_signed_float1_negative(self):
+        assert format_metric(-2.5, "signed_float1") == "-2.5"
+
+    def test_signed_float1_zero(self):
+        assert format_metric(0.0, "signed_float1") == "0.0"
+
+    def test_signed_float3_positive(self):
+        assert format_metric(1.234, "signed_float3") == "+1.234"
+
+    def test_signed_float3_negative(self):
+        assert format_metric(-0.5, "signed_float3") == "-0.500"
+
+    def test_signed_float3_zero(self):
+        assert format_metric(0.0, "signed_float3") == "0.000"
+
+    def test_unknown_format_falls_back_to_str(self):
+        assert format_metric(42, "unknown") == "42"
+
+
+# ---------------------------------------------------------------------------
+# METRIC_DEFINITIONS tests
+# ---------------------------------------------------------------------------
+
+
+class TestMetricDefinitions:
+    """Tests for the METRIC_DEFINITIONS registry."""
+
+    def test_every_player_stats_field_has_definition(self):
+        """Every numeric field on PlayerStats has a matching metric def."""
+        skip = {"player_id", "nickname"}
+        stat_fields = {
+            f.name
+            for f in PlayerStats.__dataclass_fields__.values()
+            if f.name not in skip
+        }
+        assert stat_fields == set(METRIC_DEFINITIONS.keys())
+
+    def test_categories_are_valid(self):
+        valid = {"primary", "default", "secondary"}
+        for key, m in METRIC_DEFINITIONS.items():
+            assert m.category in valid, f"{key} has invalid category {m.category}"
+
+    def test_exactly_one_primary(self):
+        primaries = [
+            k for k, m in METRIC_DEFINITIONS.items() if m.category == "primary"
+        ]
+        assert len(primaries) == 1
+        assert primaries[0] == "net_eppd"
+
+    def test_all_have_nonempty_tooltip(self):
+        for key, m in METRIC_DEFINITIONS.items():
+            assert len(m.tooltip) > 10, f"{key} tooltip too short: {m.tooltip!r}"
+
+    def test_all_have_nonempty_label(self):
+        for key, m in METRIC_DEFINITIONS.items():
+            assert len(m.label) > 0, f"{key} has empty label"

--- a/web/leaderboard.py
+++ b/web/leaderboard.py
@@ -14,6 +14,7 @@ explicitly out of scope.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import NamedTuple
 
 from sqlalchemy import func
 from sqlalchemy.orm import Session
@@ -25,6 +26,144 @@ HUMAN_TEAM = 0
 
 # Match statuses that contribute hands to leaderboard stats.
 _LEADERBOARD_MATCH_STATUSES = ("active", "complete")
+
+
+# ---------------------------------------------------------------------------
+# Metric definitions — display metadata for the leaderboard UI
+# ---------------------------------------------------------------------------
+
+
+class MetricDef(NamedTuple):
+    """Display metadata for a single leaderboard metric."""
+
+    label: str  # Short column header
+    tooltip: str  # Plain-English explanation
+    format: str  # "pct" | "int" | "float1" | "float3" | "signed_float1"
+    category: str  # "primary" | "default" | "secondary"
+
+
+#: Metric definitions keyed by PlayerStats field name.
+#: The template iterates these to build headers, tooltips, and formatting.
+METRIC_DEFINITIONS: dict[str, MetricDef] = {
+    "net_eppd": MetricDef(
+        label="Net EPPD",
+        tooltip=(
+            "Net Expected Points Per Deal — your average point advantage "
+            "per hand. Positive means you're outscoring opponents."
+        ),
+        format="signed_float3",
+        category="primary",
+    ),
+    "games_won": MetricDef(
+        label="Won",
+        tooltip="Total games (matches) won.",
+        format="int_games",
+        category="default",
+    ),
+    "win_rate": MetricDef(
+        label="Win %",
+        tooltip="Percentage of completed games you won.",
+        format="pct",
+        category="default",
+    ),
+    "avg_margin_victory": MetricDef(
+        label="Avg Margin",
+        tooltip="Average score margin in games you won (points).",
+        format="float1",
+        category="default",
+    ),
+    "matches_played": MetricDef(
+        label="Matches",
+        tooltip="Total completed matches played.",
+        format="int",
+        category="default",
+    ),
+    "hands_played": MetricDef(
+        label="Hands",
+        tooltip="Total hands played across all matches (including in-progress).",
+        format="int",
+        category="secondary",
+    ),
+    "avg_match_margin": MetricDef(
+        label="Match Margin",
+        tooltip="Average score margin across all completed matches (positive = winning).",
+        format="signed_float1",
+        category="secondary",
+    ),
+    "bid_rate": MetricDef(
+        label="Bid %",
+        tooltip="Percentage of hands where your team won the auction and declared.",
+        format="pct",
+        category="secondary",
+    ),
+    "make_rate": MetricDef(
+        label="Make %",
+        tooltip="Percentage of your contracts that made (took enough tricks).",
+        format="pct",
+        category="secondary",
+    ),
+    "avg_bid_level": MetricDef(
+        label="Avg Bid",
+        tooltip="Average number of tricks bid when your team declares.",
+        format="float1",
+        category="secondary",
+    ),
+    "moon_call_rate": MetricDef(
+        label="Moon %",
+        tooltip="Percentage of hands where your team called a moon (bid all 10 tricks).",
+        format="pct",
+        category="secondary",
+    ),
+    "moon_make_rate": MetricDef(
+        label="Moon Make",
+        tooltip="Percentage of your moon bids that were successfully made.",
+        format="pct",
+        category="secondary",
+    ),
+    "loner_call_rate": MetricDef(
+        label="Loner %",
+        tooltip="Percentage of hands where your team called a loner (solo play).",
+        format="pct",
+        category="secondary",
+    ),
+    "loner_make_rate": MetricDef(
+        label="Loner Make",
+        tooltip="Percentage of your loner bids that were successfully made.",
+        format="pct",
+        category="secondary",
+    ),
+}
+
+
+def format_metric(value: int | float, fmt: str) -> str:
+    """Format a metric value for display using its format specifier.
+
+    Format codes:
+    - ``"pct"`` — fraction (0.0–1.0) → ``"65%"``
+    - ``"int"`` — integer count → ``"5"``
+    - ``"int_games"`` — integer game count → ``"5 games"`` / ``"1 game"``
+    - ``"float1"`` — one decimal → ``"3.2"``
+    - ``"float3"`` — three decimals → ``"1.234"``
+    - ``"signed_float1"`` — one decimal with +/- sign → ``"+3.2"``
+    - ``"signed_float3"`` — three decimals with +/- sign → ``"+1.234"``
+    """
+    if fmt == "pct":
+        return f"{value * 100:.0f}%"
+    elif fmt == "int":
+        return str(int(value))
+    elif fmt == "int_games":
+        n = int(value)
+        return f"{n} game" if n == 1 else f"{n} games"
+    elif fmt == "float1":
+        return f"{value:.1f}"
+    elif fmt == "float3":
+        return f"{value:.3f}"
+    elif fmt == "signed_float1":
+        return f"{value:+.1f}" if value != 0 else "0.0"
+    elif fmt == "signed_float3":
+        return f"{value:+.3f}" if value != 0 else "0.000"
+    else:
+        return str(value)
 
 
 @dataclass(frozen=True)

--- a/web/routes.py
+++ b/web/routes.py
@@ -26,7 +26,7 @@ from bid_euchre.strategy.bidding import BidAction
 
 from .ai_manager import AIManager
 from .db import Decision, Hand, InviteCode, Match, Player
-from .leaderboard import get_leaderboard
+from .leaderboard import METRIC_DEFINITIONS, format_metric, get_leaderboard
 from .middleware import check_match_limit
 
 router = APIRouter()
@@ -1262,6 +1262,8 @@ async def leaderboard(request: Request, link_uuid: str):
                 "link_uuid": link_uuid,
                 "nickname": player.nickname,
                 "rankings": rankings,
+                "metric_defs": METRIC_DEFINITIONS,
+                "format_metric": format_metric,
             },
         )
     finally:

--- a/web/templates/leaderboard.html
+++ b/web/templates/leaderboard.html
@@ -14,7 +14,7 @@
         display: flex;
         align-items: center;
         justify-content: space-between;
-        margin-bottom: 1rem;
+        margin-bottom: 0.25rem;
         flex-wrap: wrap;
         gap: 0.5rem;
     }
@@ -33,6 +33,12 @@
     .leaderboard__back:hover {
         color: var(--color-text);
         text-decoration: underline;
+    }
+
+    .leaderboard__ranking-info {
+        font-size: 0.8rem;
+        color: var(--color-text-muted);
+        margin: 0 0 1rem 0;
     }
 
     .leaderboard__empty {
@@ -80,6 +86,13 @@
         z-index: 1;
     }
 
+    .leaderboard__table thead th[title] {
+        cursor: help;
+        text-decoration: underline;
+        text-decoration-style: dotted;
+        text-underline-offset: 3px;
+    }
+
     .leaderboard__table tbody tr:hover {
         background: var(--color-surface-light);
     }
@@ -94,12 +107,16 @@
     .leaderboard__table .positive { color: var(--color-positive); }
     .leaderboard__table .negative { color: var(--color-negative); }
 
-    .leaderboard__toggle {
+    .leaderboard__controls {
         margin-top: 0.75rem;
-        text-align: center;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.75rem;
+        flex-wrap: wrap;
     }
 
-    .leaderboard__toggle button {
+    .leaderboard__controls button {
         background: var(--color-surface);
         color: var(--color-text-muted);
         border: 1px solid var(--color-surface-light);
@@ -109,7 +126,7 @@
         font-size: 0.8rem;
     }
 
-    .leaderboard__toggle button:hover {
+    .leaderboard__controls button:hover {
         background: var(--color-surface-light);
         color: var(--color-text);
     }
@@ -118,10 +135,60 @@
     .secondary-col { display: none; }
     .leaderboard__table.show-secondary .secondary-col { display: table-cell; }
 
+    /* Help panel */
+    .leaderboard__help {
+        display: none;
+        margin-top: 1rem;
+        padding: 1rem;
+        background: var(--color-surface);
+        border-radius: 6px;
+        font-size: 0.8rem;
+        line-height: 1.5;
+    }
+
+    .leaderboard__help.show { display: block; }
+
+    .leaderboard__help h3 {
+        margin: 0 0 0.75rem 0;
+        font-size: 0.9rem;
+        color: var(--color-text);
+    }
+
+    .leaderboard__help dl {
+        margin: 0;
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 0.3rem 1rem;
+    }
+
+    .leaderboard__help dt {
+        font-weight: 600;
+        color: var(--color-text);
+        white-space: nowrap;
+    }
+
+    .leaderboard__help dd {
+        margin: 0;
+        color: var(--color-text-muted);
+    }
+
+    .leaderboard__help-divider {
+        grid-column: 1 / -1;
+        border: 0;
+        border-top: 1px solid var(--color-surface-light);
+        margin: 0.5rem 0;
+    }
+
     @media (max-width: 600px) {
         .leaderboard__table { font-size: 0.75rem; }
         .leaderboard__table th,
         .leaderboard__table td { padding: 0.35rem 0.4rem; }
+        .leaderboard__help dl {
+            grid-template-columns: 1fr;
+        }
+        .leaderboard__help dt {
+            margin-top: 0.3rem;
+        }
     }
 </style>
 {% endblock %}
@@ -134,6 +201,9 @@
         <h2 class="leaderboard__title">Leaderboard</h2>
         <a href="/play/{{ link_uuid }}" class="leaderboard__back">Back to Game</a>
     </div>
+    <p class="leaderboard__ranking-info">
+        Ranked by Net EPPD — your average point advantage per hand.
+    </p>
 
     {% if rankings|length == 0 %}
     <div class="leaderboard__empty">
@@ -147,21 +217,10 @@
                 <tr>
                     <th class="rank-col" scope="col">#</th>
                     <th class="name-col" scope="col">Player</th>
-                    <th class="primary-col" scope="col" title="Net expected points per deal">Net EPPD</th>
-                    <th scope="col">Won</th>
-                    <th scope="col" title="Win percentage">Win %</th>
-                    <th scope="col" title="Average margin when winning">Avg Margin</th>
-                    <th scope="col">Matches</th>
-                    {# Secondary columns — toggled via JS #}
-                    <th class="secondary-col" scope="col">Hands</th>
-                    <th class="secondary-col" scope="col" title="Average match score margin">Match Margin</th>
-                    <th class="secondary-col" scope="col" title="Fraction of hands declaring">Bid %</th>
-                    <th class="secondary-col" scope="col" title="Fraction of contracts made">Make %</th>
-                    <th class="secondary-col" scope="col" title="Average bid level">Avg Bid</th>
-                    <th class="secondary-col" scope="col" title="Moon call rate">Moon %</th>
-                    <th class="secondary-col" scope="col" title="Moon make rate">Moon Make</th>
-                    <th class="secondary-col" scope="col" title="Loner call rate">Loner %</th>
-                    <th class="secondary-col" scope="col" title="Loner make rate">Loner Make</th>
+                    {% for key, m in metric_defs.items() %}
+                    <th{% if m.category == "secondary" %} class="secondary-col"{% endif %}{% if m.category == "primary" %} class="primary-col"{% endif %}
+                        scope="col" title="{{ m.tooltip }}">{{ m.label }}</th>
+                    {% endfor %}
                 </tr>
             </thead>
             <tbody>
@@ -169,36 +228,43 @@
                 <tr>
                     <td class="rank-col">{{ loop.index }}</td>
                     <td class="name-col">{{ entry.nickname or "Anonymous" }}</td>
-                    <td class="primary-col {% if entry.net_eppd > 0 %}positive{% elif entry.net_eppd < 0 %}negative{% endif %}">
-                        {{ "%.3f"|format(entry.net_eppd) }}
+                    {% for key, m in metric_defs.items() %}
+                    {% set val = entry[key] %}
+                    {% set formatted = format_metric(val, m.format) %}
+                    <td{% if m.category == "secondary" %} class="secondary-col{% if m.format.startswith("signed") %}{% if val > 0 %} positive{% elif val < 0 %} negative{% endif %}{% endif %}"{% elif m.category == "primary" %} class="primary-col{% if val > 0 %} positive{% elif val < 0 %} negative{% endif %}"{% elif m.format.startswith("signed") %} class="{% if val > 0 %}positive{% elif val < 0 %}negative{% endif %}"{% endif %}>
+                        {{ formatted }}
                     </td>
-                    <td>{{ entry.games_won }}</td>
-                    <td>{{ "%.1f"|format(entry.win_rate * 100) }}%</td>
-                    <td>{{ "%.1f"|format(entry.avg_margin_victory) }}</td>
-                    <td>{{ entry.matches_played }}</td>
-                    {# Secondary columns #}
-                    <td class="secondary-col">{{ entry.hands_played }}</td>
-                    <td class="secondary-col {% if entry.avg_match_margin > 0 %}positive{% elif entry.avg_match_margin < 0 %}negative{% endif %}">
-                        {{ "%.1f"|format(entry.avg_match_margin) }}
-                    </td>
-                    <td class="secondary-col">{{ "%.1f"|format(entry.bid_rate * 100) }}%</td>
-                    <td class="secondary-col">{{ "%.1f"|format(entry.make_rate * 100) }}%</td>
-                    <td class="secondary-col">{{ "%.1f"|format(entry.avg_bid_level) }}</td>
-                    <td class="secondary-col">{{ "%.1f"|format(entry.moon_call_rate * 100) }}%</td>
-                    <td class="secondary-col">{{ "%.1f"|format(entry.moon_make_rate * 100) }}%</td>
-                    <td class="secondary-col">{{ "%.1f"|format(entry.loner_call_rate * 100) }}%</td>
-                    <td class="secondary-col">{{ "%.1f"|format(entry.loner_make_rate * 100) }}%</td>
+                    {% endfor %}
                 </tr>
                 {% endfor %}
             </tbody>
         </table>
     </div>
 
-    <div class="leaderboard__toggle">
+    <div class="leaderboard__controls">
         <button type="button" id="toggle-secondary"
                 onclick="document.getElementById('leaderboard-table').classList.toggle('show-secondary'); this.textContent = this.textContent === 'Show More Stats' ? 'Show Less' : 'Show More Stats'">
             Show More Stats
         </button>
+        <button type="button" id="toggle-help"
+                onclick="var h=document.getElementById('help-panel'); h.classList.toggle('show'); this.textContent = h.classList.contains('show') ? 'Hide Help' : 'What do these stats mean?'">
+            What do these stats mean?
+        </button>
+    </div>
+
+    <div class="leaderboard__help" id="help-panel" role="note" aria-label="Metric definitions">
+        <h3>Metric Definitions</h3>
+        <dl>
+            {% set ns = namespace(prev_cat="") %}
+            {% for key, m in metric_defs.items() %}
+            {% if ns.prev_cat and ns.prev_cat != m.category %}
+            <hr class="leaderboard__help-divider">
+            {% endif %}
+            <dt>{{ m.label }}</dt>
+            <dd>{{ m.tooltip }}</dd>
+            {% set ns.prev_cat = m.category %}
+            {% endfor %}
+        </dl>
     </div>
     {% endif %}
 </div>


### PR DESCRIPTION
## Plan
N/A — standalone issue fix (#2010)

## Summary
- Add `METRIC_DEFINITIONS` registry mapping every PlayerStats field to display label, plain-English tooltip, format specifier, and category (primary/default/secondary)
- Add `format_metric()` helper: percentages (`65%` not `0.65`), game counts (`5 games`), signed floats (`+1.234`)
- Update leaderboard template: ranking explanation text, column header tooltips with dotted-underline hints, "What do these stats mean?" expandable help panel with all metric definitions

## Why
Issue #2010 — players see raw stats with no explanation. Metric labels like "Net EPPD" and decimal fractions (0.65) are confusing. This adds in-UI help text and human-friendly formatting.

Closes #2010

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_leaderboard.py -v
```
All 42 tests pass (19 existing + 23 new).

**Config:** N/A
**Seed:** N/A

## Test Criteria
- **Pass condition:** Leaderboard renders with tooltips on column headers, ranking explanation visible, help panel toggleable, percentages formatted as `65%` not `0.65`, game counts as `"5 games"`
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_leaderboard.py -v`
- **Expected result:** 42 tests pass including `test_leaderboard_shows_tooltips`, `test_leaderboard_formats_percentages`, `test_leaderboard_shows_ranking_explanation`, `test_leaderboard_shows_help_button`

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_leaderboard.py -q` — 42 passed
- [ ] Other: CI will run full suite

## Expected impact
- Metrics impact: None (display-only changes)
- Runtime impact: Negligible — format_metric is a simple string formatter

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre   42f6a315 [main]
...
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c  2defcf1b [feat/leaderboard-metrics-formatting]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)