### PR TITLE
feat(web): add bid recap overlay during trick play

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -303,6 +303,77 @@ main {
 }
 
 /* --------------------------------------------------------------------------
+   5b. Bid Recap Bar
+   -------------------------------------------------------------------------- */
+
+.bid-recap {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    background: var(--color-surface);
+    border-radius: 6px;
+    padding: 0.35rem 0.75rem;
+    margin: 0.35rem 0;
+    font-size: 0.85rem;
+    text-align: center;
+    flex-wrap: wrap;
+}
+
+.bid-recap__declarer {
+    font-weight: 700;
+    color: var(--color-text);
+}
+
+.bid-recap__separator {
+    color: var(--color-text-muted);
+    font-style: italic;
+}
+
+.bid-recap__level {
+    font-weight: 700;
+    font-size: 1rem;
+    color: var(--color-text);
+}
+
+.bid-recap__type {
+    font-weight: 700;
+}
+
+.bid-recap__type--moon {
+    color: var(--color-moon);
+}
+
+.bid-recap__type--loner {
+    color: var(--color-loner);
+}
+
+.bid-recap__suit {
+    font-size: 1rem;
+}
+
+.bid-recap__suit--h,
+.bid-recap__suit--d {
+    color: #ef5350;
+}
+
+.bid-recap__suit--s,
+.bid-recap__suit--c {
+    color: var(--color-text);
+}
+
+.bid-recap__no-trump {
+    color: var(--color-text-muted);
+    font-style: italic;
+}
+
+.bid-recap__sitting-out {
+    color: var(--color-text-muted);
+    font-size: 0.78rem;
+    font-style: italic;
+}
+
+/* --------------------------------------------------------------------------
    6. Trick Area
    -------------------------------------------------------------------------- */
 
@@ -1526,6 +1597,22 @@ main {
     .auction-table td {
         padding: 0.2rem 0.35rem;
         font-size: 0.75rem;
+    }
+
+    /* Bid recap — compact for small screens */
+    .bid-recap {
+        font-size: 0.72rem;
+        padding: 0.25rem 0.5rem;
+        margin: 0.2rem 0;
+        gap: 0.3rem;
+    }
+
+    .bid-recap__level {
+        font-size: 0.85rem;
+    }
+
+    .bid-recap__suit {
+        font-size: 0.85rem;
     }
 
     /* Score bar — ultra-compact */

--- a/web/templates/partials/bid_recap.html
+++ b/web/templates/partials/bid_recap.html
@@ -1,0 +1,51 @@
+{# Bid recap bar — persistent summary of the auction result during trick play.
+   Displayed between the AI hands and the trick area so players always know
+   who won the bid and what was bid.
+
+   Context variables (all already provided by _build_game_context):
+     - winning_bid: int | None — winning bid amount
+     - bidder_seat: int | None — seat of the declarer
+     - bid_type: str — "regular", "moon", or "loner"
+     - contract_type: str | None — "suit", "high", or "low"
+     - trump: str | None — trump suit letter if contract_type == "suit"
+     - sitting_out_seat: int | None — seat sitting out (loner bids)
+#}
+{% set suit_symbols = {"S": "\u2660", "H": "\u2665", "D": "\u2666", "C": "\u2663"} %}
+{% set seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"} %}
+
+{% if winning_bid is not none and bidder_seat is not none %}
+<div class="bid-recap" role="status" aria-label="Auction result">
+    <span class="bid-recap__declarer">
+        {{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}
+    </span>
+    <span class="bid-recap__separator" aria-hidden="true">bid</span>
+    <span class="bid-recap__contract">
+        {% set recap_bid_type = bid_type | default("regular") %}
+        {% if recap_bid_type == "moon" %}
+            <span class="bid-recap__type bid-recap__type--moon" aria-label="Moon bid">
+                <span aria-hidden="true">&#127769;</span> Moon
+            </span>
+        {% elif recap_bid_type == "loner" %}
+            <span class="bid-recap__type bid-recap__type--loner" aria-label="Loner bid">
+                <span aria-hidden="true">&#127183;</span> Loner
+            </span>
+        {% else %}
+            <span class="bid-recap__level">{{ winning_bid }}</span>
+        {% endif %}
+        {% if contract_type == "suit" and trump %}
+            <span class="bid-recap__suit bid-recap__suit--{{ trump | lower }}">
+                {{ suit_symbols.get(trump, trump) }}
+            </span>
+        {% elif contract_type == "high" %}
+            <span class="bid-recap__no-trump">High</span>
+        {% elif contract_type == "low" %}
+            <span class="bid-recap__no-trump">Low</span>
+        {% endif %}
+    </span>
+    {% if sitting_out_seat is not none %}
+    <span class="bid-recap__sitting-out" aria-label="Sitting out: {{ seat_labels.get(sitting_out_seat, 'Seat ' ~ sitting_out_seat) }}">
+        ({{ seat_labels.get(sitting_out_seat, "Seat " ~ sitting_out_seat) }} sits out)
+    </span>
+    {% endif %}
+</div>
+{% endif %}

--- a/web/templates/partials/game_board.html
+++ b/web/templates/partials/game_board.html
@@ -111,6 +111,11 @@
         </div>
     </div>
 
+    {# Bid recap bar — persistent auction result summary during trick play #}
+    {% if phase == "trick_play" %}
+        {% include "partials/bid_recap.html" %}
+    {% endif %}
+
     {# Trick area — always shown during active play #}
     {% include "partials/trick.html" %}
 


### PR DESCRIPTION
## Summary

- Add a persistent bid recap bar displayed between AI hands and trick area during trick play
- Shows auction winner (seat/name), bid level, bid type (moon/loner/regular), contract type (suit/high/low), and trump suit
- Includes responsive CSS for small screens (375px breakpoint)

## Why

During trick play, players need quick reference to the auction result — who won the bid, what level, and what contract type. The existing score bar at the bottom shows this but it's below the fold on many screens. A compact recap bar near the top of the game area keeps this info visible at all times.

## Changed Files

| File | Change |
|------|--------|
| `web/templates/partials/bid_recap.html` | **New** — bid recap partial with BEM-style classes, aria labels, suit symbols |
| `web/templates/partials/game_board.html` | Include bid_recap.html during trick_play phase |
| `web/static/style.css` | Styles for `.bid-recap` component + responsive overrides |

## Repro / Validation

```bash
# Unit tests (all hosted_play tests pass — 2814 passed)
uv run python -m pytest tests/unit/hosted_play/ -v

# Lint (clean)
make lint

# Full validation (3 pre-existing failures unrelated to this PR)
make check-quiet
```

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: feat/web-bid-recap-overlay
```

## Test Criteria

1. During trick play phase, a compact bar appears between AI hands row and trick area showing the auction result
2. Bar shows declarer name, bid level (or Moon/Loner badge), contract type, and trump suit symbol
3. For loner bids, shows which seat is sitting out
4. Bar is hidden during auction phase (only visible once trick play begins)
5. Bar does not appear when `winning_bid` or `bidder_seat` is None
6. Responsive styles reduce font size on screens ≤375px

🤖 Generated with [Claude Code](https://claude.com/claude-code)