### PR TITLE
feat(web): add match history page with completed match scores

### DIFF
--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -2371,3 +2371,125 @@ class TestMoonExchangeRoute:
                 f"after moon exchange — _advance_ai not called"
             )
         session_after.close()
+
+
+# ---------------------------------------------------------------------------
+# Match History
+# ---------------------------------------------------------------------------
+
+
+class TestMatchHistory:
+    """GET /history/{link_uuid} shows completed matches."""
+
+    def test_history_unknown_uuid_404(self, client):
+        resp = client.get("/history/nonexistent-uuid")
+        assert resp.status_code == 404
+
+    def test_history_empty_when_no_completed_matches(self, client):
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        resp = client.get(f"/history/{link_uuid}")
+        assert resp.status_code == 200
+        assert "No completed matches yet" in resp.text
+
+    def test_history_shows_completed_match(self, client, app):
+        """Create a completed match row directly and verify it appears."""
+        from datetime import datetime, timezone
+
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid, "HistoryTester")
+
+        # Directly insert a completed match for this player
+        session_factory = app.state.session_factory
+        session = session_factory()
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+        assert player is not None
+
+        import uuid as uuid_mod
+
+        completed_match = Match(
+            match_uuid=str(uuid_mod.uuid4()),
+            player_id=player.id,
+            ai_model="bud_bot",
+            status="complete",
+            seed=42,
+            score_human=52,
+            score_ai=38,
+            hands_played=7,
+            match_state_json="{}",
+            completed_at=datetime(2026, 3, 15, 12, 0, 0, tzinfo=timezone.utc),
+        )
+        session.add(completed_match)
+        session.commit()
+        session.close()
+
+        resp = client.get(f"/history/{link_uuid}")
+        assert resp.status_code == 200
+        assert "Match History" in resp.text
+        # Should show the AI opponent name
+        assert "Bud Bot" in resp.text
+        # Should show scores
+        assert "52" in resp.text
+        assert "38" in resp.text
+        # Should show win result
+        assert "Win" in resp.text
+        # Should show hands played
+        assert "7" in resp.text
+        # Should show formatted date
+        assert "Mar 15, 2026" in resp.text
+
+    def test_history_shows_loss(self, client, app):
+        """A match where AI wins should show 'Loss'."""
+        from datetime import datetime, timezone
+
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid, "Loser")
+
+        session_factory = app.state.session_factory
+        session = session_factory()
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+
+        import uuid as uuid_mod
+
+        lost_match = Match(
+            match_uuid=str(uuid_mod.uuid4()),
+            player_id=player.id,
+            ai_model="olsa",
+            status="complete",
+            seed=99,
+            score_human=30,
+            score_ai=54,
+            hands_played=9,
+            match_state_json="{}",
+            completed_at=datetime(2026, 4, 1, 8, 0, 0, tzinfo=timezone.utc),
+        )
+        session.add(lost_match)
+        session.commit()
+        session.close()
+
+        resp = client.get(f"/history/{link_uuid}")
+        assert resp.status_code == 200
+        assert "Loss" in resp.text
+        assert "OLSa" in resp.text
+
+    def test_history_excludes_active_matches(self, client, app):
+        """Active (in-progress) matches should NOT appear in history."""
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        # Select AI starts an active match
+        _select_ai(client, link_uuid)
+
+        resp = client.get(f"/history/{link_uuid}")
+        assert resp.status_code == 200
+        # Active match should not appear — show empty state
+        assert "No completed matches yet" in resp.text
+
+    def test_history_nav_link_present(self, client):
+        """The header nav should include a History link when link_uuid is set."""
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        _select_ai(client, link_uuid)
+
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        assert f"/history/{link_uuid}" in resp.text

--- a/web/routes.py
+++ b/web/routes.py
@@ -1268,6 +1268,62 @@ async def leaderboard(request: Request, link_uuid: str):
         session.close()
 
 
+@router.get("/history/{link_uuid}", response_class=HTMLResponse)
+async def match_history(request: Request, link_uuid: str):
+    """Match history page — list of completed matches with scores.
+
+    Shows all completed matches for the player identified by *link_uuid*,
+    ordered most-recent first.  Displays opponent AI name, final score,
+    win/loss result, date played, and number of hands.
+    """
+    templates = _get_templates(request)
+    session = _get_session(request)
+    try:
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+        if player is None:
+            raise HTTPException(status_code=404, detail="Player not found")
+
+        matches = (
+            session.query(Match)
+            .filter_by(player_id=player.id, status="complete")
+            .order_by(Match.completed_at.desc())
+            .all()
+        )
+
+        ai_manager = _get_ai_manager(request)
+        history_entries = []
+        for m in matches:
+            # Resolve AI display name from roster; fall back to raw model id
+            try:
+                ai_name = ai_manager.get_model_info(m.ai_model).name
+            except KeyError:
+                ai_name = m.ai_model
+
+            won = m.score_human > m.score_ai
+            history_entries.append(
+                {
+                    "ai_name": ai_name,
+                    "score_human": m.score_human,
+                    "score_ai": m.score_ai,
+                    "won": won,
+                    "hands_played": m.hands_played,
+                    "completed_at": m.completed_at,
+                }
+            )
+
+        return templates.TemplateResponse(
+            "history.html",
+            {
+                "request": request,
+                "link_uuid": link_uuid,
+                "nickname": player.nickname,
+                "matches": history_entries,
+            },
+        )
+    finally:
+        session.close()
+
+
 # ---------------------------------------------------------------------------
 # AI decision logging helper
 # ---------------------------------------------------------------------------

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -31,6 +31,7 @@
             {% if link_uuid is defined and link_uuid %}
             <nav class="header-nav" aria-label="Main navigation">
                 <a href="/play/{{ link_uuid }}">Game</a>
+                <a href="/history/{{ link_uuid }}">History</a>
                 <a href="/leaderboard/{{ link_uuid }}">Leaderboard</a>
             </nav>
             {% endif %}

--- a/web/templates/history.html
+++ b/web/templates/history.html
@@ -1,0 +1,139 @@
+{% extends "base.html" %}
+
+{% block title %}Bid Euchre — Match History{% endblock %}
+
+{% block head %}
+<style>
+    .history {
+        max-width: 960px;
+        margin: 1rem auto;
+        padding: 0 1rem;
+    }
+
+    .history__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 1rem;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .history__title {
+        font-size: 1.5rem;
+        margin: 0;
+    }
+
+    .history__back {
+        color: var(--color-text-muted);
+        text-decoration: none;
+        font-size: 0.9rem;
+    }
+
+    .history__back:hover {
+        color: var(--color-text);
+        text-decoration: underline;
+    }
+
+    .history__empty {
+        text-align: center;
+        padding: 3rem 1rem;
+        color: var(--color-text-muted);
+    }
+
+    .history__table-wrap {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .history__table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.85rem;
+    }
+
+    .history__table th,
+    .history__table td {
+        padding: 0.5rem 0.75rem;
+        text-align: right;
+        white-space: nowrap;
+        border-bottom: 1px solid var(--color-surface-light);
+    }
+
+    .history__table th:first-child,
+    .history__table td:first-child {
+        text-align: left;
+    }
+
+    .history__table thead th {
+        background: var(--color-surface);
+        color: var(--color-text-muted);
+        font-weight: 600;
+        position: sticky;
+        top: 0;
+        z-index: 1;
+    }
+
+    .history__table tbody tr:hover {
+        background: var(--color-surface-light);
+    }
+
+    .history__result--win {
+        color: var(--color-positive);
+        font-weight: 600;
+    }
+
+    .history__result--loss {
+        color: var(--color-negative);
+        font-weight: 600;
+    }
+
+    @media (max-width: 600px) {
+        .history__table { font-size: 0.75rem; }
+        .history__table th,
+        .history__table td { padding: 0.35rem 0.4rem; }
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="history" role="region" aria-label="Match history">
+    <div class="history__header">
+        <h2 class="history__title">Match History</h2>
+        <a href="/play/{{ link_uuid }}" class="history__back">Back to Game</a>
+    </div>
+
+    {% if matches|length == 0 %}
+    <div class="history__empty">
+        <p>No completed matches yet. Finish a game to see it here!</p>
+    </div>
+    {% else %}
+    <div class="history__table-wrap">
+        <table class="history__table" role="table" aria-label="Completed matches">
+            <thead>
+                <tr>
+                    <th scope="col">Opponent</th>
+                    <th scope="col">Result</th>
+                    <th scope="col">Score</th>
+                    <th scope="col">Hands</th>
+                    <th scope="col">Date</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for match in matches %}
+                <tr>
+                    <td>{{ match.ai_name }}</td>
+                    <td class="{% if match.won %}history__result--win{% else %}history__result--loss{% endif %}">
+                        {{ "Win" if match.won else "Loss" }}
+                    </td>
+                    <td>{{ match.score_human }} &ndash; {{ match.score_ai }}</td>
+                    <td>{{ match.hands_played }}</td>
+                    <td>{{ match.completed_at.strftime('%b %d, %Y') if match.completed_at else '—' }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add `GET /history/{link_uuid}` route showing completed matches with opponent AI name, final score (human vs AI), win/loss, date played, and hands count
- New `history.html` template with responsive table matching leaderboard styling conventions
- Add "History" link to global navigation bar in `base.html`
- 6 unit tests covering: 404 for unknown UUID, empty state, completed match display (win), loss display, active match exclusion, and nav link presence

## Why
Players need a way to review their past matches. This adds a match history page accessible from the main nav, filtering to only completed matches ordered by most recent.

## Repro / Validation

```bash
# Run history-specific tests
uv run python -m pytest tests/unit/hosted_play/test_routes.py::TestMatchHistory -v

# Run all hosted_play unit tests
uv run python -m pytest tests/unit/hosted_play/ -v

# Lint
make lint
```

## Tests
- `uv run python -m pytest tests/unit/hosted_play/ -v` — **2819 passed**, 6 skipped
- `make lint` — clean

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
branch: feat/web-match-history
```

## Files changed
| File | Change |
|------|--------|
| `web/routes.py` | New `match_history` route handler |
| `web/templates/history.html` | New template (responsive table) |
| `web/templates/base.html` | Add History nav link |
| `tests/unit/hosted_play/test_routes.py` | 6 new tests in `TestMatchHistory` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)