### PR TITLE
feat(web): make win-condition text visible on all screen sizes

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1535,7 +1535,10 @@ main {
     }
 
     .score-bar .match-target {
-        display: none;
+        font-size: 0.6rem;
+        margin: 0;
+        padding: 0;
+        line-height: 1;
     }
 
     main {

--- a/web/templates/partials/model_select.html
+++ b/web/templates/partials/model_select.html
@@ -8,6 +8,7 @@
 <div id="model-select" role="region" aria-label="Choose AI opponent">
     <h2>Welcome, {{ nickname }}!</h2>
     <p>Choose your AI opponent:</p>
+    <p class="match-target">First to &plusmn;52 wins</p>
     <form method="post"
           action="/play/{{ link_uuid }}/select-ai"
           hx-post="/play/{{ link_uuid }}/select-ai"


### PR DESCRIPTION
## Summary
- Add "First to 52 wins" clarity text to game scoring display
- Ensure visibility across desktop and mobile viewports

## Test plan
- [ ] Verify "First to 52 wins" text visible during gameplay
- [ ] Check mobile and desktop layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)