### PR TITLE
ops: add Playwright MCP server for Claude-direct browser testing (#1852)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@0.0.70",
+        "--headless",
+        "--caps",
+        "vision",
+        "--viewport-size",
+        "1280x720"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Register `@playwright/mcp` v0.0.70 as an MCP server in `.mcp.json`
- Configured headless with vision capabilities and 1280x720 viewport
- Enables Claude lanes to interactively navigate, click, screenshot, and emulate mobile viewports

## Why
Issue #1852: The governing plan (§5.6) requires Claude to test the browser game
directly through browser automation. PR #1821 shipped headless Playwright for CI,
but no MCP tooling existed for Claude to interactively control a browser from a
conversation. This closes that gap.

## Configuration
```json
{
  "mcpServers": {
    "playwright": {
      "command": "npx",
      "args": [
        "@playwright/mcp@0.0.70",
        "--headless",
        "--caps", "vision",
        "--viewport-size", "1280x720"
      ]
    }
  }
}
```

Key flags:
- `--headless` — steward lanes run in tmux without display
- `--caps vision` — enables screenshot reading (acceptance criteria)
- `--viewport-size 1280x720` — standard desktop viewport

## Repro / Validation
```bash
# Verify .mcp.json is valid JSON
python3 -c "import json; json.load(open('.mcp.json'))"

# Start a new Claude Code session — Playwright MCP tools should appear
# Then use browser_navigate, browser_screenshot, etc.
```

## Tests
- JSON validation: ✅ valid
- `make check-quiet`: config-only change, no Python code touched
- Pre-commit hooks: all passed

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
branch: ops/playwright-mcp
```

Closes #1852

🤖 Generated with [Claude Code](https://claude.com/claude-code)