### PR TITLE
feat(web): replace model select dropdown with radio cards

### DIFF
--- a/tests/browser/test_mobile.py
+++ b/tests/browser/test_mobile.py
@@ -62,7 +62,7 @@ def test_mobile_viewport_tap_targets(
         enter_game(mobile_page, live_server, invite_code, "MobileTester")
 
         # Start a match
-        mobile_page.select_option("select[name='model_id']", "olsa")
+        mobile_page.click("input[name='model_id'][value='olsa']")
         mobile_page.click("button:has-text('Start Match')")
         mobile_page.wait_for_selector("#game-board", timeout=10000)
 

--- a/tests/browser/test_smoke_suite.py
+++ b/tests/browser/test_smoke_suite.py
@@ -111,7 +111,7 @@ def test_start_game_bid_play_verify_score(
     enter_game(page, live_server, invite_code, "SmokePlayer")
 
     # Select the default OLSa AI model and start match
-    page.select_option("select[name='model_id']", "olsa")
+    page.click("input[name='model_id'][value='olsa']")
     page.click("button:has-text('Start Match')")
 
     # Wait for the game board to show auction or trick play
@@ -200,7 +200,7 @@ def test_moon_bid_ui_available(
     enter_game(page, live_server, invite_code, "MoonTester")
 
     # Start a match
-    page.select_option("select[name='model_id']", "olsa")
+    page.click("input[name='model_id'][value='olsa']")
     page.click("button:has-text('Start Match')")
     _advance_next_steps(page)
     page.wait_for_function(
@@ -321,7 +321,7 @@ def test_full_hand_verify_transition(
     enter_game(page, live_server, invite_code, "HandFlowTester")
 
     # Start a match
-    page.select_option("select[name='model_id']", "olsa")
+    page.click("input[name='model_id'][value='olsa']")
     page.click("button:has-text('Start Match')")
     initial_hand_number = _wait_for_hand_number(page)
 

--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -70,7 +70,7 @@ class ModelStub:
 
 
 class TestModelSelect:
-    def test_renders_models_dropdown(self, env):
+    def test_renders_radio_cards(self, env):
         models = [
             ModelStub("bud_bot", "Bud Bot", "Gradient-boosted bidder"),
             ModelStub("olsa", "OLSa (Easy)", "Conservative action-value bidder"),
@@ -88,10 +88,39 @@ class TestModelSelect:
         assert "Bud Bot" in html
         assert "Alice" in html
         assert 'action="/play/abc-123/select-ai"' in html
+        # Radio cards instead of select dropdown
+        assert 'type="radio"' in html
+        assert 'name="model_id"' in html
+        assert "model-card" in html
         # Bud Bot should be pre-selected as default
-        assert 'value="bud_bot" selected' in html
-        # OLSa should NOT be pre-selected
-        assert 'value="olsa" selected' not in html
+        assert 'value="bud_bot"' in html
+        # Check that checked attribute is on the default model's radio
+        # (bud_bot checked, olsa not)
+        assert 'id="model-bud_bot"' in html
+        assert 'id="model-olsa"' in html
+
+    def test_default_model_checked(self, env):
+        models = [
+            ModelStub("bud_bot", "Bud Bot", "Gradient-boosted bidder"),
+            ModelStub("olsa", "OLSa (Easy)", "Conservative action-value bidder"),
+        ]
+        tmpl = env.get_template("partials/model_select.html")
+        html = tmpl.render(
+            link_uuid="abc-123",
+            nickname="Alice",
+            models=models,
+            default_model_id="bud_bot",
+        )
+        # The radio input spans multiple lines; extract each <input ...> block
+        import re
+
+        inputs = re.findall(r"<input[^>]+>", html, re.DOTALL)
+        bud_bot_inputs = [i for i in inputs if 'value="bud_bot"' in i]
+        olsa_inputs = [i for i in inputs if 'value="olsa"' in i]
+        assert len(bud_bot_inputs) == 1
+        assert "checked" in bud_bot_inputs[0]
+        assert len(olsa_inputs) == 1
+        assert "checked" not in olsa_inputs[0]
 
     def test_renders_single_model(self, env):
         models = [ModelStub("bud_bot", "Bud Bot", "Gradient-boosted bidder")]
@@ -104,6 +133,36 @@ class TestModelSelect:
         )
         assert 'value="bud_bot"' in html
         assert "Start Match" in html
+        assert 'type="radio"' in html
+
+    def test_shows_match_info(self, env):
+        models = [ModelStub("bud_bot", "Bud Bot", "Gradient-boosted bidder")]
+        tmpl = env.get_template("partials/model_select.html")
+        html = tmpl.render(
+            link_uuid="x",
+            nickname="Bob",
+            models=models,
+            default_model_id="bud_bot",
+        )
+        assert "6–12 hands" in html
+        assert "match-info" in html
+
+    def test_model_descriptions_shown(self, env):
+        models = [
+            ModelStub("bud_bot", "Bud Bot", "Gradient-boosted bidder"),
+            ModelStub("olsa", "OLSa (Easy)", "Conservative action-value bidder"),
+        ]
+        tmpl = env.get_template("partials/model_select.html")
+        html = tmpl.render(
+            link_uuid="abc-123",
+            nickname="Alice",
+            models=models,
+            default_model_id="bud_bot",
+        )
+        assert "Gradient-boosted bidder" in html
+        assert "Conservative action-value bidder" in html
+        assert "model-card-desc" in html
+        assert "model-card-name" in html
 
 
 # ---------------------------------------------------------------------------

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1201,21 +1201,72 @@ main {
     text-align: center;
 }
 
-#nickname-form input[type="text"]:focus,
-#model-select select:focus {
+#nickname-form input[type="text"]:focus {
     outline: 2px solid var(--color-legal-glow);
     outline-offset: 1px;
 }
 
-#model-select select {
+/* Radio card model picker */
+.model-cards {
+    border: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
     width: 100%;
-    max-width: 320px;
-    padding: 0.5rem 0.75rem;
-    border: 1px solid #555;
-    border-radius: 4px;
+}
+
+.model-card {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.85rem 1rem;
+    border: 2px solid #555;
+    border-radius: 8px;
     background: var(--color-surface-light);
+    cursor: pointer;
+    transition: border-color 0.15s, box-shadow 0.15s;
+    text-align: left;
+}
+
+.model-card:hover {
+    border-color: var(--color-felt);
+}
+
+.model-card:has(input:checked) {
+    border-color: var(--color-legal-glow);
+    box-shadow: 0 0 0 1px var(--color-legal-glow);
+}
+
+.model-card input[type="radio"] {
+    margin-top: 0.2rem;
+    accent-color: var(--color-legal-glow);
+    flex-shrink: 0;
+}
+
+.model-card-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+}
+
+.model-card-name {
+    font-weight: 600;
+    font-size: 1rem;
     color: var(--color-text);
-    font-size: 0.95rem;
+}
+
+.model-card-desc {
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+    line-height: 1.3;
+}
+
+.match-info {
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+    margin: 0.25rem 0 0;
 }
 
 #nickname-form button,

--- a/web/templates/partials/model_select.html
+++ b/web/templates/partials/model_select.html
@@ -1,4 +1,4 @@
-{# AI model picker partial.
+{# AI model picker partial — radio card variant.
    Context variables:
      - link_uuid: str — player's game link UUID
      - nickname: str — player's (escaped) nickname
@@ -15,12 +15,24 @@
           hx-target="#game-board"
           hx-swap="morph:innerHTML"
           aria-label="Select AI model and start match">
-        <label for="model-select-dropdown" class="sr-only">AI opponent</label>
-        <select id="model-select-dropdown" name="model_id" required aria-label="AI opponent model">
+        <fieldset class="model-cards" role="radiogroup" aria-label="AI opponent model">
+            <legend class="sr-only">AI opponent model</legend>
             {% for model in models %}
-            <option value="{{ model.id }}"{% if model.id == default_model_id %} selected{% endif %}>{{ model.name }} &mdash; {{ model.description }}</option>
+            <label class="model-card" for="model-{{ model.id }}">
+                <input type="radio"
+                       id="model-{{ model.id }}"
+                       name="model_id"
+                       value="{{ model.id }}"
+                       {% if model.id == default_model_id %}checked{% endif %}
+                       required>
+                <span class="model-card-content">
+                    <span class="model-card-name">{{ model.name }}</span>
+                    <span class="model-card-desc">{{ model.description }}</span>
+                </span>
+            </label>
             {% endfor %}
-        </select>
+        </fieldset>
+        <p class="match-info">Expect <strong>6–12 hands</strong> per match — about 10–20 minutes.</p>
         <button type="submit" aria-label="Start match with selected AI">Start Match</button>
     </form>
 </div>


### PR DESCRIPTION
## Summary
- Replace `<select>` dropdown with radio card components for AI model selection
- Each card shows model name and 1-line description at a glance
- Add "what to expect" match length note (6–12 hands, ~10–20 min)
- Update browser tests (Playwright) and expand unit test coverage

## Why
UX audit item 2a: For only 2 choices (OLSa, Bud Bot), a dropdown is the wrong
UI primitive — it hides options behind a click. Radio cards show all options
immediately with full descriptions, improving discoverability.

## Repro / Validation
```bash
uv run python -m pytest tests/unit/hosted_play/test_partials.py -v -k "ModelSelect"
make lint
```

## Tests
- `tests/unit/hosted_play/test_partials.py::TestModelSelect` — 5 tests covering
  radio card rendering, default checked state, match info, descriptions
- `tests/unit/hosted_play/test_partials.py::TestAccessibilityForms::test_model_select_has_region`
- Browser tests updated: `select_option` → radio button `click`

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
branch: feat/model-radio-cards
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)