### PR TITLE
fix(deploy): add CORS, APP_URL, and model artifact env vars to render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -31,3 +31,11 @@ services:
         value: /app/models
       - key: DEFAULT_MODEL_ID
         value: bud_bot
+      - key: ALLOWED_ORIGINS
+        value: https://bideuchre-web.onrender.com
+      - key: APP_URL
+        value: https://bideuchre-web.onrender.com
+      - key: OLSA_ARTIFACT
+        value: /app/models/training_artifact_full_ols_av.json
+      - key: GBT_ARTIFACT
+        value: /app/models/training_artifact_gbt_av.json


### PR DESCRIPTION
## Summary
- Add `ALLOWED_ORIGINS` to restrict CORS to Render domain (was wildcard `*`)
- Add `APP_URL` for correct share link generation (was `localhost`)
- Add `OLSA_ARTIFACT` and `GBT_ARTIFACT` env var paths for in-container models

Fixes deployment blockers B2 and B3 from `plans/sessions/2026-04-02_deployment_readiness_audit.md`.

## Test plan
- [ ] Verify render.yaml has all 4 new env vars
- [ ] Deploy to Render and verify CORS headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)