### PR TITLE
fix(web): prevent mobile card jump on initial render

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -161,9 +161,14 @@ main {
     cursor: pointer;
 }
 
-.card--legal:hover {
-    transform: translateY(-12px);
-    box-shadow: 0 0 12px var(--color-legal-glow);
+/* Hover raise only on devices with a real pointer — prevents sticky
+   :hover on mobile after HTMX swaps which makes a card appear "jumped"
+   on initial render (see fix/mobile-card-raised-initial). */
+@media (hover: hover) {
+    .card--legal:hover {
+        transform: translateY(-12px);
+        box-shadow: 0 0 12px var(--color-legal-glow);
+    }
 }
 
 /* Illegal card — dimmed, no interaction */
@@ -2218,9 +2223,11 @@ main {
     border: 2px solid var(--color-felt);
 }
 
-.card--exchange-selectable:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 0 6px rgba(255, 160, 0, 0.3);
+@media (hover: hover) {
+    .card--exchange-selectable:hover {
+        transform: translateY(-3px);
+        box-shadow: 0 0 6px rgba(255, 160, 0, 0.3);
+    }
 }
 
 /* Selected state for exchange cards */


### PR DESCRIPTION
## Plan
N/A — targeted UX bug fix.

## Summary
- Wrap `.card--legal:hover` and `.card--exchange-selectable:hover` CSS transforms in `@media (hover: hover)` to prevent sticky `:hover` on mobile touch devices
- On desktop (mouse), hover-raise behavior is unchanged

## Why
On mobile, after an HTMX morph swap (e.g., after AI plays a card), the browser retains a "sticky" `:hover` state on the card at the previous touch position. This causes a card to appear raised/jumped (`translateY(-12px)`) on initial render — before the player makes any selection — creating confusing UX that looks like the game is suggesting a card.

The CSS `@media (hover: hover)` media query limits hover transforms to devices with a real pointer (mouse/trackpad), eliminating the false raise on touch devices.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/ -v  # 2813 passed
make lint  # clean
make check-quiet  # 3 pre-existing failures (ops modules), 0 new failures
```

**Config (if applicable):** N/A

**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** `.card--legal:hover` transform is inside `@media (hover: hover)` block
- **Verification command:** `grep -A3 '@media (hover: hover)' web/static/style.css`
- **Expected result:** Shows both `.card--legal:hover` and `.card--exchange-selectable:hover` wrapped in the media query

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/ -v` — 2813 passed
- [x] `make lint` — clean
- [x] `make check-quiet` — 3 pre-existing failures in ops modules (test_ops_token_economy, test_telegram_filter), 0 new failures

## Expected impact
- Metrics impact: None (CSS-only)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre    [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b  fix/mobile-card-raised-initial
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)