### PR TITLE
feat(web): add error handling and graceful reconnection for browser game

### DIFF
--- a/tests/unit/hosted_play/test_error_handling.py
+++ b/tests/unit/hosted_play/test_error_handling.py
@@ -1,0 +1,328 @@
+"""Tests for error handling and graceful reconnection features.
+
+Covers:
+1. HTMX-aware error responses (partial HTML for HTMX, full page for browser)
+2. Match state deserialization recovery (corrupt state → model selection)
+3. HTMX error partial template rendering
+4. Offline/reconnection JS behavior (structural — template includes JS)
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from starlette.testclient import TestClient
+
+from tests.unit.hosted_play.conftest import make_hosted_play_test_config
+from web.app import create_app
+from web.db import Match, Player
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def config(tmp_path):
+    """File-based SQLite config for test isolation."""
+    return make_hosted_play_test_config(tmp_path)
+
+
+@pytest.fixture()
+def app(config):
+    """FastAPI app configured with temp DB."""
+    return create_app(config=config)
+
+
+@pytest.fixture()
+def client(app):
+    """TestClient wrapping the test app."""
+    with TestClient(app) as c:
+        yield c
+
+
+def _create_player(session, nickname="TestPlayer") -> Player:
+    """Insert a Player row."""
+    player = Player(link_uuid=str(uuid.uuid4()), nickname=nickname)
+    session.add(player)
+    session.flush()
+    return player
+
+
+def _create_match(session, player_id: int, status: str = "active", **kw) -> Match:
+    """Insert a Match row with sensible defaults."""
+    defaults = {
+        "match_uuid": str(uuid.uuid4()),
+        "player_id": player_id,
+        "ai_model": "bud_bot",
+        "status": status,
+        "seed": 42,
+        "match_state_json": "{}",
+    }
+    defaults.update(kw)
+    match = Match(**defaults)
+    session.add(match)
+    session.flush()
+    return match
+
+
+# ===================================================================
+# 1. HTMX-Aware Error Responses
+# ===================================================================
+
+
+class TestHTMXErrorResponses:
+    """Verify error handlers return partials for HTMX, full pages for browser."""
+
+    def test_404_full_page_for_browser(self, client):
+        """Non-HTMX 404 returns full themed error page."""
+        resp = client.get("/nonexistent-page")
+        assert resp.status_code == 404
+        assert "<!DOCTYPE html>" in resp.text
+        assert "Hand Not Found" in resp.text
+
+    def test_404_partial_for_htmx(self, client):
+        """HTMX 404 returns inline error partial (no DOCTYPE)."""
+        resp = client.get(
+            "/nonexistent-page",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 404
+        assert "<!DOCTYPE html>" not in resp.text
+        assert "htmx-error" in resp.text
+        assert "Back to Table" in resp.text
+
+    def test_404_htmx_game_not_found(self, client):
+        """HTMX request for invalid game link returns inline error."""
+        fake_uuid = str(uuid.uuid4())
+        resp = client.get(
+            f"/play/{fake_uuid}",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 404
+        assert "htmx-error" in resp.text
+
+    def test_404_htmx_includes_detail(self, client):
+        """HTMX 404 includes the error detail message."""
+        fake_uuid = str(uuid.uuid4())
+        resp = client.get(
+            f"/play/{fake_uuid}",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 404
+        assert "Game not found" in resp.text or "Not found" in resp.text
+
+    def test_htmx_error_has_aria_alert(self, client):
+        """HTMX error partial has role=alert for accessibility."""
+        resp = client.get(
+            "/nonexistent-page",
+            headers={"HX-Request": "true"},
+        )
+        assert 'role="alert"' in resp.text
+
+
+# ===================================================================
+# 2. Match State Deserialization Recovery
+# ===================================================================
+
+
+class TestMatchStateRecovery:
+    """Corrupt match state is handled gracefully on page refresh."""
+
+    def test_corrupt_state_shows_model_select(self, app, client):
+        """Player with a corrupt match state is shown model selection."""
+        session = app.state.session_factory()
+        try:
+            player = _create_player(session)
+            # Create a match with invalid JSON state
+            _create_match(
+                session,
+                player.id,
+                match_state_json="THIS IS NOT VALID JSON",
+            )
+            session.commit()
+            link_uuid = player.link_uuid
+        finally:
+            session.close()
+
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        # Should show model selection, not crash
+        assert "model_select" in resp.text or "Choose" in resp.text
+
+    def test_corrupt_state_marks_match_abandoned(self, app, client):
+        """Corrupt match is marked as abandoned after recovery."""
+        session = app.state.session_factory()
+        try:
+            player = _create_player(session)
+            match = _create_match(
+                session,
+                player.id,
+                match_state_json="CORRUPT_DATA",
+            )
+            session.commit()
+            match_id = match.id
+            link_uuid = player.link_uuid
+        finally:
+            session.close()
+
+        # Trigger recovery
+        client.get(f"/play/{link_uuid}")
+
+        # Verify match is now abandoned
+        session = app.state.session_factory()
+        try:
+            match = session.query(Match).get(match_id)
+            assert match.status == "abandoned"
+            assert match.completed_at is not None
+        finally:
+            session.close()
+
+    def test_corrupt_state_second_visit_shows_model_select(self, app, client):
+        """After recovery, second visit still shows model selection."""
+        session = app.state.session_factory()
+        try:
+            player = _create_player(session)
+            _create_match(
+                session,
+                player.id,
+                match_state_json="BROKEN",
+            )
+            session.commit()
+            link_uuid = player.link_uuid
+        finally:
+            session.close()
+
+        # First visit triggers recovery
+        resp1 = client.get(f"/play/{link_uuid}")
+        assert resp1.status_code == 200
+
+        # Second visit — abandoned match is most recent, but player
+        # can see model selection again since no active match remains
+        resp2 = client.get(f"/play/{link_uuid}")
+        assert resp2.status_code == 200
+
+
+# ===================================================================
+# 3. HTMX Error Template Structure
+# ===================================================================
+
+
+class TestHTMXErrorTemplate:
+    """Verify the htmx_error.html template renders correctly."""
+
+    def test_htmx_error_contains_message(self, client):
+        """HTMX error partial includes the error message."""
+        resp = client.get(
+            "/nonexistent-page",
+            headers={"HX-Request": "true"},
+        )
+        assert "htmx-error__message" in resp.text
+
+    def test_htmx_error_contains_home_link(self, client):
+        """HTMX error partial includes a link back to the landing page."""
+        resp = client.get(
+            "/nonexistent-page",
+            headers={"HX-Request": "true"},
+        )
+        assert 'href="/"' in resp.text
+
+
+# ===================================================================
+# 4. Game JS Error Handling Structure
+# ===================================================================
+
+
+class TestGameJSErrorHandling:
+    """Verify game.js is loaded and contains error handling code."""
+
+    def test_game_js_included_in_base(self, client):
+        """Base template includes game.js for all pages."""
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert "game.js" in resp.text
+
+    def test_game_js_has_error_handling(self):
+        """game.js contains error handling event listeners."""
+        from pathlib import Path
+
+        js_path = (
+            Path(__file__).resolve().parent.parent.parent.parent
+            / "web"
+            / "static"
+            / "game.js"
+        )
+        content = js_path.read_text()
+        assert "htmx:responseError" in content
+        assert "htmx:sendError" in content
+        assert "htmx:timeout" in content
+        assert "showErrorToast" in content
+        assert "showOfflineBanner" in content
+        assert "hideOfflineBanner" in content
+
+    def test_game_js_has_online_offline_handlers(self):
+        """game.js registers online/offline event listeners."""
+        from pathlib import Path
+
+        js_path = (
+            Path(__file__).resolve().parent.parent.parent.parent
+            / "web"
+            / "static"
+            / "game.js"
+        )
+        content = js_path.read_text()
+        assert "'offline'" in content
+        assert "'online'" in content
+
+
+# ===================================================================
+# 5. Error CSS Structure
+# ===================================================================
+
+
+class TestErrorCSS:
+    """Verify error-related CSS classes exist in the stylesheet."""
+
+    def test_error_toast_css_exists(self):
+        """style.css defines error-toast classes."""
+        from pathlib import Path
+
+        css_path = (
+            Path(__file__).resolve().parent.parent.parent.parent
+            / "web"
+            / "static"
+            / "style.css"
+        )
+        content = css_path.read_text()
+        assert ".error-toast" in content
+        assert ".error-toast--visible" in content
+        assert ".error-toast__message" in content
+        assert ".error-toast__dismiss" in content
+
+    def test_offline_banner_css_exists(self):
+        """style.css defines offline-banner class."""
+        from pathlib import Path
+
+        css_path = (
+            Path(__file__).resolve().parent.parent.parent.parent
+            / "web"
+            / "static"
+            / "style.css"
+        )
+        content = css_path.read_text()
+        assert ".offline-banner" in content
+
+    def test_htmx_error_css_exists(self):
+        """style.css defines htmx-error classes for inline errors."""
+        from pathlib import Path
+
+        css_path = (
+            Path(__file__).resolve().parent.parent.parent.parent
+            / "web"
+            / "static"
+            / "style.css"
+        )
+        content = css_path.read_text()
+        assert ".htmx-error" in content
+        assert ".htmx-error__message" in content

--- a/web/app.py
+++ b/web/app.py
@@ -80,6 +80,7 @@ def _run_self_test(engine, templates_dir: Path, static_dir: Path) -> None:
                 "landing.html",
                 "errors/404.html",
                 "errors/500.html",
+                "errors/htmx_error.html",
             ):
                 test_templates.get_template(name)
         except Exception as exc:
@@ -173,9 +174,21 @@ def create_app(config: HostedPlayConfig | None = None) -> FastAPI:
 
     _error_templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
 
+    def _is_htmx(request: Request) -> bool:
+        """Return True when the request was initiated by HTMX."""
+        return request.headers.get("HX-Request") == "true"
+
     @app.exception_handler(404)
     async def not_found_handler(request: Request, exc: HTTPException) -> HTMLResponse:
-        """Render game-themed 404 page."""
+        """Render game-themed 404 page (partial for HTMX, full for browser)."""
+        if _is_htmx(request):
+            detail = getattr(exc, "detail", "Not found")
+            return HTMLResponse(
+                _error_templates.get_template("errors/htmx_error.html").render(
+                    {"request": request, "status_code": 404, "message": str(detail)}
+                ),
+                status_code=404,
+            )
         return HTMLResponse(
             _error_templates.get_template("errors/404.html").render(
                 {"request": request}
@@ -185,8 +198,19 @@ def create_app(config: HostedPlayConfig | None = None) -> FastAPI:
 
     @app.exception_handler(500)
     async def server_error_handler(request: Request, exc: Exception) -> HTMLResponse:
-        """Render game-themed 500 page."""
+        """Render game-themed 500 page (partial for HTMX, full for browser)."""
         logger.exception("Unhandled server error on %s %s", request.method, request.url)
+        if _is_htmx(request):
+            return HTMLResponse(
+                _error_templates.get_template("errors/htmx_error.html").render(
+                    {
+                        "request": request,
+                        "status_code": 500,
+                        "message": "Something went wrong. Please try again.",
+                    }
+                ),
+                status_code=500,
+            )
         return HTMLResponse(
             _error_templates.get_template("errors/500.html").render(
                 {"request": request}

--- a/web/routes.py
+++ b/web/routes.py
@@ -11,6 +11,7 @@ no rule/scoring logic lives here.
 from __future__ import annotations
 
 import json
+import logging
 import random
 import uuid
 from datetime import datetime, timezone
@@ -20,6 +21,8 @@ from fastapi import APIRouter, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from sqlalchemy import text
 from starlette.templating import Jinja2Templates
+
+logger = logging.getLogger(__name__)
 
 from bid_euchre.hosted_play.engine import HUMAN_SEAT, MatchEngine
 from bid_euchre.strategy.bidding import BidAction
@@ -697,7 +700,30 @@ async def game_page(request: Request, link_uuid: str):
         # Active or completed match — restore current state
         ai_manager = _get_ai_manager(request)
         engine = _build_engine(ai_manager, match_row.ai_model)
-        state = _deserialize_state(engine, match_row.match_state_json)
+        try:
+            state = _deserialize_state(engine, match_row.match_state_json)
+        except Exception:
+            logger.warning(
+                "Failed to deserialize match %s — marking abandoned",
+                match_row.match_uuid,
+                exc_info=True,
+            )
+            # Mark the corrupt match as abandoned and show model selection
+            match_row.status = "abandoned"
+            match_row.completed_at = datetime.now(timezone.utc)
+            session.commit()
+            models = ai_manager.list_available()
+            return templates.TemplateResponse(
+                "game.html",
+                {
+                    "request": request,
+                    "phase": "model_select",
+                    "link_uuid": link_uuid,
+                    "nickname": player.nickname,
+                    "models": models,
+                    "default_model_id": ai_manager.default_model_id,
+                },
+            )
         ctx = _build_game_context(engine, state, link_uuid)
         ctx["request"] = request
         ctx["nickname"] = player.nickname

--- a/web/static/game.js
+++ b/web/static/game.js
@@ -198,9 +198,141 @@
         }, true);
     }
 
+    /* ---------------------------------------------------------------
+     * Error handling — show user-friendly toast when HTMX requests
+     * fail (network error, server error, timeout).
+     * --------------------------------------------------------------- */
+
+    var ERROR_TOAST_ID = 'error-toast';
+    var OFFLINE_BANNER_ID = 'offline-banner';
+    var _errorDismissTimer = null;
+
+    function showErrorToast(message, persistent) {
+        var existing = document.getElementById(ERROR_TOAST_ID);
+        if (existing) {
+            existing.remove();
+        }
+
+        if (_errorDismissTimer) {
+            clearTimeout(_errorDismissTimer);
+            _errorDismissTimer = null;
+        }
+
+        var toast = document.createElement('div');
+        toast.id = ERROR_TOAST_ID;
+        toast.className = 'error-toast';
+        toast.setAttribute('role', 'alert');
+        toast.setAttribute('aria-live', 'assertive');
+
+        var msgSpan = document.createElement('span');
+        msgSpan.className = 'error-toast__message';
+        msgSpan.textContent = message;
+        toast.appendChild(msgSpan);
+
+        var dismissBtn = document.createElement('button');
+        dismissBtn.className = 'error-toast__dismiss';
+        dismissBtn.setAttribute('aria-label', 'Dismiss error');
+        dismissBtn.textContent = '\u00d7';
+        dismissBtn.addEventListener('click', function () {
+            dismissErrorToast();
+        });
+        toast.appendChild(dismissBtn);
+
+        document.body.appendChild(toast);
+
+        // Force reflow so the transition animates
+        toast.offsetHeight; // eslint-disable-line no-unused-expressions
+        toast.classList.add('error-toast--visible');
+
+        if (!persistent) {
+            _errorDismissTimer = setTimeout(function () {
+                dismissErrorToast();
+            }, 8000);
+        }
+    }
+
+    function dismissErrorToast() {
+        var toast = document.getElementById(ERROR_TOAST_ID);
+        if (toast) {
+            toast.classList.remove('error-toast--visible');
+            setTimeout(function () {
+                if (toast.parentNode) {
+                    toast.parentNode.removeChild(toast);
+                }
+            }, 300);
+        }
+        if (_errorDismissTimer) {
+            clearTimeout(_errorDismissTimer);
+            _errorDismissTimer = null;
+        }
+    }
+
+    function showOfflineBanner() {
+        if (document.getElementById(OFFLINE_BANNER_ID)) {
+            return;
+        }
+        var banner = document.createElement('div');
+        banner.id = OFFLINE_BANNER_ID;
+        banner.className = 'offline-banner';
+        banner.setAttribute('role', 'status');
+        banner.setAttribute('aria-live', 'polite');
+        banner.textContent = 'You are offline. Reconnecting\u2026';
+        document.body.insertBefore(banner, document.body.firstChild);
+    }
+
+    function hideOfflineBanner() {
+        var banner = document.getElementById(OFFLINE_BANNER_ID);
+        if (banner && banner.parentNode) {
+            banner.parentNode.removeChild(banner);
+        }
+    }
+
+    function attachErrorHandlers() {
+        // HTMX response errors (server returned 4xx/5xx)
+        document.body.addEventListener('htmx:responseError', function (event) {
+            var status = event.detail.xhr ? event.detail.xhr.status : 0;
+            var message;
+            if (status === 404) {
+                message = 'Game not found. It may have expired.';
+            } else if (status === 429) {
+                message = 'Too many active matches. Complete or abandon one first.';
+            } else if (status >= 500) {
+                message = 'Server error \u2014 please try again in a moment.';
+            } else {
+                message = 'Something went wrong. Please try again.';
+            }
+            showErrorToast(message, false);
+        });
+
+        // HTMX send errors (network failure, DNS, CORS, etc.)
+        document.body.addEventListener('htmx:sendError', function () {
+            if (!navigator.onLine) {
+                showOfflineBanner();
+            } else {
+                showErrorToast('Connection lost. Check your network and try again.', true);
+            }
+        });
+
+        // HTMX timeout
+        document.body.addEventListener('htmx:timeout', function () {
+            showErrorToast('Request timed out. Please try again.', false);
+        });
+
+        // Browser online/offline events
+        window.addEventListener('offline', function () {
+            showOfflineBanner();
+        });
+
+        window.addEventListener('online', function () {
+            hideOfflineBanner();
+            dismissErrorToast();
+        });
+    }
+
     function initialize() {
         attachDelegatedHandlers();
         attachTrickHistoryToggle();
+        attachErrorHandlers();
         var form = getCardPlayForm();
         clearCardSelection(form);
         syncCardPlayFormControls(form);

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -2158,7 +2158,105 @@ main {
 }
 
 /* --------------------------------------------------------------------------
-   20. Utilities
+   20. Error Toast & Offline Banner
+   -------------------------------------------------------------------------- */
+
+.error-toast {
+    position: fixed;
+    bottom: 1.5rem;
+    left: 50%;
+    transform: translateX(-50%) translateY(1rem);
+    opacity: 0;
+    background: var(--color-surface);
+    color: var(--color-text);
+    border: 2px solid var(--color-negative);
+    border-radius: 8px;
+    padding: 0.75rem 1.25rem;
+    max-width: 90vw;
+    width: auto;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    z-index: 9999;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    pointer-events: none;
+}
+
+.error-toast--visible {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+    pointer-events: auto;
+}
+
+.error-toast__message {
+    flex: 1;
+    font-size: 0.9rem;
+    line-height: 1.4;
+}
+
+.error-toast__dismiss {
+    background: none;
+    border: none;
+    color: var(--color-text-muted);
+    font-size: 1.25rem;
+    cursor: pointer;
+    padding: 0 0.25rem;
+    line-height: 1;
+    flex-shrink: 0;
+}
+
+.error-toast__dismiss:hover {
+    color: var(--color-text);
+}
+
+.offline-banner {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    background: var(--color-negative);
+    color: #fff;
+    text-align: center;
+    padding: 0.5rem 1rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    z-index: 10000;
+    letter-spacing: 0.02em;
+}
+
+.htmx-error {
+    text-align: center;
+    padding: 2rem 1rem;
+    max-width: 480px;
+    margin: 2rem auto;
+}
+
+.htmx-error__message {
+    font-size: 1rem;
+    color: var(--color-text-muted);
+    margin: 0 0 1.5rem;
+    line-height: 1.5;
+}
+
+.htmx-error__home {
+    display: inline-block;
+}
+
+@media (max-width: 600px) {
+    .error-toast {
+        bottom: 1rem;
+        max-width: 95vw;
+        padding: 0.625rem 1rem;
+    }
+
+    .error-toast__message {
+        font-size: 0.85rem;
+    }
+}
+
+/* --------------------------------------------------------------------------
+   21. Utilities
    -------------------------------------------------------------------------- */
 
 .sr-only {

--- a/web/templates/errors/htmx_error.html
+++ b/web/templates/errors/htmx_error.html
@@ -1,0 +1,15 @@
+{#
+    Inline error partial for HTMX swap targets.
+
+    Rendered inside the #game-board div when an HTMX request hits a
+    server error — keeps the page intact instead of replacing the full
+    document with a 404/500 error page.
+
+    Context variables:
+        status_code  — HTTP status code (int)
+        message      — human-readable error message (str)
+#}
+<div class="htmx-error" role="alert" aria-live="assertive">
+    <p class="htmx-error__message">{{ message }}</p>
+    <a href="/" class="btn btn--play-again htmx-error__home">Back to Table</a>
+</div>


### PR DESCRIPTION
## Summary

- **HTMX-aware error responses**: Error handlers now detect HTMX requests and return inline error partials (keeping the game page intact) vs. full themed error pages for browser navigation
- **Client-side error handling**: game.js now listens for `htmx:responseError`, `htmx:sendError`, and `htmx:timeout` events, showing user-friendly toast notifications with auto-dismiss
- **Online/offline detection**: Shows a persistent reconnection banner when the browser goes offline, auto-dismisses when connectivity returns
- **Match state recovery**: Gracefully handles corrupt/invalid match state on page refresh — marks the match as abandoned and shows model selection instead of crashing with a 500
- **New `htmx_error.html` partial**: Inline error display for HTMX swap targets with accessible markup
- **Error toast + offline banner CSS**: Animated toast with dismiss button, fixed-position offline banner

## Why

Production browser games need resilient error handling. Without this:
- HTMX request failures left blank/broken UI state
- Network disconnections provided no user feedback
- Corrupt match state caused 500 errors on page refresh
- Server errors during HTMX requests replaced the entire page with a 404/500 page

## Files Changed

| File | Change |
|------|--------|
| `web/app.py` | HTMX-aware 404/500 exception handlers, self-test includes new template |
| `web/routes.py` | Graceful match state deserialization with abandoned-match recovery |
| `web/static/game.js` | Error toast, offline banner, HTMX error event listeners |
| `web/static/style.css` | Error toast, offline banner, HTMX inline error styles |
| `web/templates/errors/htmx_error.html` | New inline error partial for HTMX responses |
| `tests/unit/hosted_play/test_error_handling.py` | 16 new tests |

## Repro / Validation

```bash
# Run the new error handling tests
uv run python -m pytest tests/unit/hosted_play/test_error_handling.py -v

# Run the full hosted_play test suite
uv run python -m pytest tests/unit/hosted_play/ -v

# Lint
uv run ruff check web/ tests/unit/hosted_play/test_error_handling.py
```

## Tests

- 16 new tests in `test_error_handling.py` covering:
  - HTMX vs browser 404 response format (5 tests)
  - Match state deserialization recovery (3 tests)
  - HTMX error template structure (2 tests)
  - game.js error handling code presence (3 tests)
  - CSS class existence (3 tests)
- All 26 existing `test_hardening.py` tests still pass
- All 12 existing `test_app.py` tests still pass

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b
branch: feat/web-error-handling
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>