### PR TITLE
feat(web): add PWA manifest for mobile home screen install

### DIFF
--- a/web/static/icons/icon-192.svg
+++ b/web/static/icons/icon-192.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" width="192" height="192">
+  <rect width="192" height="192" rx="32" fill="#1b5e20"/>
+  <!-- Spade suit -->
+  <g transform="translate(96,100)" fill="#fafafa">
+    <!-- Spade body -->
+    <path d="M0-52 C-4-48-40-20-40 8 C-40 28-24 40-12 40 C-6 40-2 36 0 30 C2 36 6 40 12 40 C24 40 40 28 40 8 C40-20 4-48 0-52Z"/>
+    <!-- Spade stem -->
+    <rect x="-6" y="30" width="12" height="24" rx="2"/>
+  </g>
+</svg>

--- a/web/static/icons/icon-512.svg
+++ b/web/static/icons/icon-512.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" rx="80" fill="#1b5e20"/>
+  <!-- Four card suits arranged in a 2x2 grid -->
+  <g fill="#fafafa">
+    <!-- Spade (top-left) -->
+    <g transform="translate(160,150) scale(0.8)">
+      <path d="M0-52 C-4-48-40-20-40 8 C-40 28-24 40-12 40 C-6 40-2 36 0 30 C2 36 6 40 12 40 C24 40 40 28 40 8 C40-20 4-48 0-52Z"/>
+      <rect x="-6" y="30" width="12" height="24" rx="2"/>
+    </g>
+    <!-- Heart (top-right) -->
+    <g transform="translate(352,150) scale(0.8)">
+      <path d="M0 44 C-4 40-44 8-44-16 C-44-36-28-48-12-48 C-2-48 0-40 0-34 C0-40 2-48 12-48 C28-48 44-36 44-16 C44 8 4 40 0 44Z"/>
+    </g>
+    <!-- Diamond (bottom-left) -->
+    <g transform="translate(160,352) scale(0.8)">
+      <path d="M0-52 L32 0 L0 52 L-32 0Z"/>
+    </g>
+    <!-- Club (bottom-right) -->
+    <g transform="translate(352,352) scale(0.8)">
+      <circle cx="0" cy="-24" r="22"/>
+      <circle cx="-22" cy="8" r="22"/>
+      <circle cx="22" cy="8" r="22"/>
+      <rect x="-6" y="16" width="12" height="28" rx="2"/>
+    </g>
+  </g>
+</svg>

--- a/web/static/manifest.json
+++ b/web/static/manifest.json
@@ -1,0 +1,23 @@
+{
+  "name": "Bid Euchre",
+  "short_name": "Bid Euchre",
+  "description": "Play Bid Euchre against AI opponents in your browser",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0d3d0f",
+  "theme_color": "#1b5e20",
+  "icons": [
+    {
+      "src": "/static/icons/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/static/icons/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -4,6 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>{% block title %}Bid Euchre{% endblock %}</title>
+    <link rel="manifest" href="/static/manifest.json">
+    <link rel="icon" type="image/svg+xml" href="/static/icons/icon-192.svg">
+    <link rel="apple-touch-icon" href="/static/icons/icon-192.svg">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="Bid Euchre">
+    <meta name="theme-color" content="#1b5e20">
     <link rel="stylesheet" href="/static/style.css">
     <link rel="stylesheet" href="/static/css/accessibility.css">
     <style>


### PR DESCRIPTION
## Plan
N/A — standalone browser expansion task

## Summary
- Add `web/static/manifest.json` with PWA metadata (name, display:standalone, theme colors)
- Add SVG card-suit icons (192px spade, 512px four-suit grid) in `web/static/icons/`
- Add `<link rel="manifest">`, favicon, Apple mobile web app meta tags to `base.html`

## Why
Mobile users should be able to "Add to Home Screen" and get a standalone app-like
experience without browser chrome, matching the dark green felt theme.

## Repro / Validation
**Command(s) run:**
```
uv run python -m pytest tests/unit/hosted_play/ -v   # 2841 passed, 5 skipped
make lint                                              # clean
```

## Test Criteria
- **Pass condition:** `base.html` contains `<link rel="manifest">` and Apple meta tags; `manifest.json` has correct theme colors
- **Verification command:** `grep -c 'rel="manifest"' web/templates/base.html && cat web/static/manifest.json | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['display']=='standalone' and d['theme_color']=='#1b5e20'; print('OK')"`
- **Expected result:** `1` and `OK`

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/ -v` — 2841 passed, 5 skipped
- [x] `make lint` — clean

## Expected impact
- Metrics impact: None
- Runtime impact: None — static files only

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c
```

`git worktree list` (relevant line):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c  de5561e8 [feat/pwa-manifest]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)