### PR TITLE
feat(web): persistent contract display bar during trick play

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -1692,6 +1692,114 @@ class TestGameBoardSeatZeroRegression:
 
 
 # ---------------------------------------------------------------------------
+# contract_bar.html — sticky contract info bar during trick play
+# ---------------------------------------------------------------------------
+
+
+class TestContractBar:
+    """Verify the contract bar partial renders correctly for all contract types."""
+
+    def test_suit_contract_shows_trump_symbol(self, env):
+        """Suit contract shows bid level and trump suit symbol."""
+        tmpl = env.get_template("partials/contract_bar.html")
+        html = tmpl.render(
+            winning_bid=6,
+            bidder_seat=1,
+            bid_type="regular",
+            contract_type="suit",
+            trump="H",
+        )
+        assert "contract-bar" in html
+        assert "6" in html
+        assert "\u2665" in html  # Heart symbol
+        assert "AI Left" in html
+
+    def test_high_contract(self, env):
+        """High (no-trump) contract displays 'High' label."""
+        tmpl = env.get_template("partials/contract_bar.html")
+        html = tmpl.render(
+            winning_bid=7,
+            bidder_seat=0,
+            bid_type="regular",
+            contract_type="high",
+            trump=None,
+        )
+        assert "7" in html
+        assert "High" in html
+        assert "You" in html
+
+    def test_low_contract(self, env):
+        """Low (no-trump) contract displays 'Low' label."""
+        tmpl = env.get_template("partials/contract_bar.html")
+        html = tmpl.render(
+            winning_bid=7,
+            bidder_seat=2,
+            bid_type="regular",
+            contract_type="low",
+            trump=None,
+        )
+        assert "7" in html
+        assert "Low" in html
+        assert "AI Partner" in html
+
+    def test_moon_contract(self, env):
+        """Moon bid shows moon emoji and label."""
+        tmpl = env.get_template("partials/contract_bar.html")
+        html = tmpl.render(
+            winning_bid=10,
+            bidder_seat=3,
+            bid_type="moon",
+            contract_type="suit",
+            trump="S",
+        )
+        assert "Moon" in html
+        assert "contract-bar__type--moon" in html
+        assert "\u2660" in html  # Spade symbol
+        assert "AI Right" in html
+
+    def test_loner_contract(self, env):
+        """Loner bid shows loner emoji and label."""
+        tmpl = env.get_template("partials/contract_bar.html")
+        html = tmpl.render(
+            winning_bid=10,
+            bidder_seat=0,
+            bid_type="loner",
+            contract_type="suit",
+            trump="D",
+        )
+        assert "Loner" in html
+        assert "contract-bar__type--loner" in html
+        assert "\u2666" in html  # Diamond symbol
+        assert "You" in html
+
+    def test_hidden_when_no_bid(self, env):
+        """No output when winning_bid is None (auction not resolved)."""
+        tmpl = env.get_template("partials/contract_bar.html")
+        html = tmpl.render(
+            winning_bid=None,
+            bidder_seat=None,
+            bid_type="regular",
+            contract_type=None,
+            trump=None,
+        )
+        assert "contract-bar" not in html
+
+    def test_bidder_seat_zero_not_coerced(self, env):
+        """bidder_seat=0 (human) must not be treated as falsy."""
+        tmpl = env.get_template("partials/contract_bar.html")
+        html = tmpl.render(
+            winning_bid=5,
+            bidder_seat=0,
+            bid_type="regular",
+            contract_type="suit",
+            trump="C",
+        )
+        assert "contract-bar" in html
+        assert "You" in html
+        assert "\u2663" in html  # Club symbol
+
+
+# ---------------------------------------------------------------------------
 # match_result.html
 # ---------------------------------------------------------------------------
 

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -434,6 +434,80 @@ main {
 }
 
 /* --------------------------------------------------------------------------
+   5c. Contract Bar — Sticky info bar (always visible during trick play)
+   -------------------------------------------------------------------------- */
+
+.contract-bar {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    background: var(--color-surface);
+    border-bottom: 2px solid var(--color-felt);
+    padding: 0.35rem 0.75rem;
+    font-size: 0.9rem;
+    text-align: center;
+    flex-wrap: wrap;
+}
+
+.contract-bar__contract {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-weight: 700;
+}
+
+.contract-bar__level {
+    font-size: 1.1rem;
+    font-weight: 800;
+    color: var(--color-text);
+}
+
+.contract-bar__type {
+    font-weight: 700;
+}
+
+.contract-bar__type--moon {
+    color: var(--color-moon);
+}
+
+.contract-bar__type--loner {
+    color: var(--color-loner);
+}
+
+.contract-bar__suit {
+    font-size: 1.15rem;
+}
+
+.contract-bar__suit--h,
+.contract-bar__suit--d {
+    color: #ef5350;
+}
+
+.contract-bar__suit--s,
+.contract-bar__suit--c {
+    color: var(--color-text);
+}
+
+.contract-bar__no-trump {
+    color: var(--color-text-muted);
+    font-style: italic;
+}
+
+.contract-bar__separator {
+    color: var(--color-text-muted);
+    font-size: 0.8rem;
+}
+
+.contract-bar__declarer {
+    color: var(--color-text-muted);
+    font-size: 0.82rem;
+}
+
+/* --------------------------------------------------------------------------
    6. Trick Area
    -------------------------------------------------------------------------- */
 
@@ -1916,6 +1990,21 @@ main {
 
     .bid-recap__suit {
         font-size: 0.85rem;
+    }
+
+    /* Contract bar — compact for small screens */
+    .contract-bar {
+        font-size: 0.78rem;
+        padding: 0.25rem 0.5rem;
+        gap: 0.35rem;
+    }
+
+    .contract-bar__level {
+        font-size: 0.95rem;
+    }
+
+    .contract-bar__suit {
+        font-size: 0.95rem;
     }
 
     /* Score bar — ultra-compact */

--- a/web/templates/partials/contract_bar.html
+++ b/web/templates/partials/contract_bar.html
@@ -1,0 +1,50 @@
+{# Contract bar — persistent, sticky display of the current contract during
+   trick play.  Always visible at the top of the game board so the player
+   never has to scroll to see what was bid.
+
+   Context variables (already provided by _build_game_context):
+     - winning_bid: int | None — winning bid amount
+     - bidder_seat: int | None — seat of the declarer
+     - bid_type: str — "regular", "moon", or "loner"
+     - contract_type: str | None — "suit", "high", or "low"
+     - trump: str | None — trump suit letter if contract_type == "suit"
+#}
+{% set suit_symbols = {"S": "\u2660", "H": "\u2665", "D": "\u2666", "C": "\u2663"} %}
+{% set seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"} %}
+
+{% if winning_bid is not none and bidder_seat is not none %}
+<div class="contract-bar" role="status" aria-label="Current contract">
+    {# Trump / contract type indicator #}
+    <span class="contract-bar__contract">
+        {% set bar_bid_type = bid_type | default("regular") %}
+        {% if bar_bid_type == "moon" %}
+            <span class="contract-bar__type contract-bar__type--moon" aria-label="Moon">
+                <span aria-hidden="true">&#127769;</span> Moon
+            </span>
+        {% elif bar_bid_type == "loner" %}
+            <span class="contract-bar__type contract-bar__type--loner" aria-label="Loner">
+                <span aria-hidden="true">&#127183;</span> Loner
+            </span>
+        {% else %}
+            <span class="contract-bar__level">{{ winning_bid }}</span>
+        {% endif %}
+        {% if contract_type == "suit" and trump %}
+            <span class="contract-bar__suit contract-bar__suit--{{ trump | lower }}"
+                  aria-label="{{ trump }} trump">
+                {{ suit_symbols.get(trump, trump) }}
+            </span>
+        {% elif contract_type == "high" %}
+            <span class="contract-bar__no-trump">High</span>
+        {% elif contract_type == "low" %}
+            <span class="contract-bar__no-trump">Low</span>
+        {% endif %}
+    </span>
+
+    <span class="contract-bar__separator" aria-hidden="true">&middot;</span>
+
+    {# Declarer name #}
+    <span class="contract-bar__declarer">
+        {{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}
+    </span>
+</div>
+{% endif %}

--- a/web/templates/partials/game_board.html
+++ b/web/templates/partials/game_board.html
@@ -92,9 +92,9 @@
 
         {# Center — trick area, controls, bid panel #}
         <div class="compass-center">
-            {# Bid recap bar — persistent auction result summary during trick play #}
+            {# Contract bar — sticky, always-visible contract info during trick play #}
             {% if phase == "trick_play" %}
-                {% include "partials/bid_recap.html" %}
+                {% include "partials/contract_bar.html" %}
             {% endif %}
 
             {# Trick area — always shown during active play #}


### PR DESCRIPTION
## Summary
- Add persistent contract info bar during trick play phase
- Shows: winning bid level, bid type, trump suit (with symbol), declarer name
- Always visible at top of trick area, not scrollable

## Why
User feedback: during trick play, players need to know "what's trump?" and "who declared?" without scrolling to the action rail.

## Files changed
- `web/templates/partials/contract_bar.html` — new partial with contract info
- `web/templates/partials/game_board.html` — include contract bar
- `web/static/style.css` — contract bar styling
- `tests/unit/hosted_play/test_partials.py` — test updates

## Test plan
- [ ] Contract bar visible during trick play with correct bid info
- [ ] Bar hides during auction phase
- [ ] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)