### PR TITLE
feat(web): add icon/indicator legend to help drawer

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -696,6 +696,25 @@ class TestGameControls:
         assert "High/Low" in html
         assert "+52 or -52" in html
 
+    def test_game_controls_legend_icons(self, env):
+        """Help drawer includes an icon/indicator legend."""
+        tmpl = env.get_template("partials/game_controls.html")
+        html = tmpl.render()
+        assert "Icons &amp; Indicators" in html
+        # Each seat marker variant is present
+        assert "seat-marker--dealer" in html
+        assert "seat-marker--declarer" in html
+        assert "seat-marker--leader" in html
+        assert "seat-marker--turn" in html
+        assert "seat-marker--sitting-out" in html
+        # Green glow swatch
+        assert "help-legend__swatch--legal" in html
+        # Descriptions
+        assert "Dealer" in html
+        assert "Declarer" in html
+        assert "Sitting out" in html
+        assert "legal play" in html
+
 
 # ---------------------------------------------------------------------------
 # score.html

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -843,6 +843,59 @@ main {
     margin: 0.2rem 0;
 }
 
+/* Help legend — icon/indicator reference */
+.help-legend__heading {
+    margin: 0.6rem 0 0.25rem;
+    font-size: 0.82rem;
+    color: var(--color-text-muted);
+}
+
+.help-legend {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.3rem 0.75rem;
+    margin: 0;
+    padding: 0;
+}
+
+.help-legend__item {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.help-legend__item dt {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.6rem;
+}
+
+.help-legend__item dd {
+    margin: 0;
+    font-size: 0.78rem;
+    line-height: 1.3;
+    color: var(--color-text);
+}
+
+.help-legend__swatch {
+    display: inline-block;
+    width: 1.1rem;
+    height: 1.5rem;
+    border-radius: 3px;
+    border: 2px solid var(--color-legal-border);
+    box-shadow: 0 0 6px var(--color-legal-glow);
+    background: var(--color-surface-light);
+}
+
+/* Stack legend items single-column on narrow screens */
+@media (max-width: 420px) {
+    .help-legend {
+        grid-template-columns: 1fr;
+    }
+}
+
 /* --------------------------------------------------------------------------
    8. Bid Panel
    -------------------------------------------------------------------------- */

--- a/web/templates/partials/game_controls.html
+++ b/web/templates/partials/game_controls.html
@@ -17,6 +17,34 @@
                 <li><strong>Moon and loner:</strong> Moon triggers a partner exchange before play. Loner makes the declarer's partner sit out the tricks.</li>
                 <li><strong>Scoring:</strong> Teams play a running match to +52 or -52. Bid makers score their bid result, defenders score the tricks they take.</li>
             </ul>
+
+            <h4 class="help-legend__heading">Icons &amp; Indicators</h4>
+            <dl class="help-legend">
+                <div class="help-legend__item">
+                    <dt><span class="seat-marker seat-marker--dealer" aria-hidden="true">D</span></dt>
+                    <dd>Dealer &mdash; dealt the current hand</dd>
+                </div>
+                <div class="help-legend__item">
+                    <dt><span class="seat-marker seat-marker--declarer" aria-hidden="true">X</span></dt>
+                    <dd>Declarer &mdash; won the auction</dd>
+                </div>
+                <div class="help-legend__item">
+                    <dt><span class="seat-marker seat-marker--leader" aria-hidden="true">L</span></dt>
+                    <dd>Leader &mdash; led the current trick</dd>
+                </div>
+                <div class="help-legend__item">
+                    <dt><span class="seat-marker seat-marker--turn" aria-hidden="true">&#9654;</span></dt>
+                    <dd>Current turn &mdash; this player is next to act</dd>
+                </div>
+                <div class="help-legend__item">
+                    <dt><span class="seat-marker seat-marker--sitting-out" aria-hidden="true">SO</span></dt>
+                    <dd>Sitting out &mdash; partner sits out during a loner</dd>
+                </div>
+                <div class="help-legend__item">
+                    <dt><span class="help-legend__swatch help-legend__swatch--legal" aria-hidden="true"></span></dt>
+                    <dd>Green glow &mdash; card is a legal play (tap to select)</dd>
+                </div>
+            </dl>
         </div>
     </details>
 </div>


### PR DESCRIPTION
## Summary
- Add a reference legend to the help drawer explaining all seat marker badges
  (D=Dealer, X=Declarer, L=Leader, ▶=Current turn, SO=Sitting out) and the
  green glow indicating legal plays
- Uses a compact two-column `<dl>` grid that collapses to single column on
  screens narrower than 420px
- Includes the actual styled seat-marker spans so the legend items visually
  match the in-game badges

## Why
New players see badge abbreviations (D, X, SO, etc.) on seat labels during
gameplay but have no way to discover what they mean without external docs.
This legend makes the UI self-documenting inside the existing help drawer.

## Files Changed
| File | Change |
|------|--------|
| `web/templates/partials/game_controls.html` | Added `<dl class="help-legend">` section with 6 legend items |
| `web/static/style.css` | Added `.help-legend*` styles (grid layout, swatch, responsive) |
| `tests/unit/hosted_play/test_partials.py` | Added `test_game_controls_legend_icons` test |

## Validation
```bash
uv run python -m pytest tests/unit/hosted_play/test_partials.py::TestGameControls -xvs
```
All 2 tests pass (existing + new legend test).

## Worktree Proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: feat/help-drawer-legend
```

## Test Plan
- [x] `test_game_controls_legend_icons` verifies all 5 seat-marker variants and the
  green-glow swatch are present in rendered HTML
- [x] Pre-commit hooks pass (ruff, repo-lint, format)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)