### PR TITLE
feat(web): highlight winning card in active trick

### DIFF
--- a/web/routes.py
+++ b/web/routes.py
@@ -24,6 +24,7 @@ from starlette.templating import Jinja2Templates
 
 logger = logging.getLogger(__name__)
 
+from bid_euchre.core.rules import trick_winner
 from bid_euchre.hosted_play.engine import HUMAN_SEAT, MatchEngine
 from bid_euchre.strategy.bidding import BidAction
 
@@ -414,6 +415,19 @@ def _build_game_context(
         else:
             ctx["legal_plays"] = None
 
+        # Currently winning seat in the active trick (for highlight).
+        trick = hand.current_trick if hand.current_trick is not None else None
+        if (
+            trick is not None
+            and len(trick.plays) >= 1
+            and hand.contract_type is not None
+        ):
+            ctx["trick_winning_seat"] = trick_winner(
+                trick.plays, hand.contract_type, hand.trump
+            )
+        else:
+            ctx["trick_winning_seat"] = None
+
         # Moon exchange selection context
         if phase == "moon_exchange_select":
             mooner_seat = hand.bidder_seat
@@ -443,6 +457,7 @@ def _build_game_context(
         ctx["points_team0"] = 0
         ctx["points_team1"] = 0
         ctx["legal_plays"] = None
+        ctx["trick_winning_seat"] = None
         ctx["opp_left_count"] = 0
         ctx["partner_count"] = 0
         ctx["opp_right_count"] = 0

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -193,6 +193,12 @@ main {
     font-size: 0.95rem;
 }
 
+/* Highlight the currently winning card in an active trick */
+.card--winning {
+    box-shadow: 0 0 8px 2px rgba(255, 215, 0, 0.7);
+    border-color: #ffd700;
+}
+
 /* --------------------------------------------------------------------------
    4. Card Fan (Human Hand)
    -------------------------------------------------------------------------- */

--- a/web/templates/partials/trick.html
+++ b/web/templates/partials/trick.html
@@ -8,6 +8,7 @@
      - sitting_out_seat: int | None — loner sit-out seat
      - tricks_team0: int — tricks won by human's team (seats 0, 2)
      - tricks_team1: int — tricks won by AI team (seats 1, 3)
+     - trick_winning_seat: int | None — seat currently winning the active trick
 #}
 {% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
 {% set suit_names = {"S": "Spades", "H": "Hearts", "D": "Diamonds", "C": "Clubs"} %}
@@ -55,9 +56,10 @@
     {% if seat in ns.cards %}
         {% set card = ns.cards[seat] %}
         {% set suit = card[0] %}
-        <div class="card card--{{ suit_classes.get(suit, 'spades') }} card--played"
+        {% set is_winning = (current_trick is not none and trick_winning_seat is defined and trick_winning_seat == seat) %}
+        <div class="card card--{{ suit_classes.get(suit, 'spades') }} card--played{% if is_winning %} card--winning{% endif %}"
              role="img"
-             aria-label="{{ seat_labels[seat] }} played {{ card[1] }} of {{ suit_names.get(suit, suit) }}">
+             aria-label="{{ seat_labels[seat] }} played {{ card[1] }} of {{ suit_names.get(suit, suit) }}{% if is_winning %} (currently winning){% endif %}">
             <span class="card__rank" aria-hidden="true">{{ card[1] }}</span>
             <span class="card__suit" aria-hidden="true">{{ suit_symbols.get(suit, suit) }}</span>
         </div>


### PR DESCRIPTION
## Summary
- During trick play, the card currently winning the trick gets a subtle gold glow highlight
- Computed server-side using `trick_winner()` and passed to the template as `trick_winning_seat`
- Highlight updates automatically as each card is played (via HTMX partial swap)
- Includes accessible aria-label "(currently winning)" for screen readers

## Why
Helps players see which card they need to beat during trick play, improving game UX.

## Changes
| File | Change |
|------|--------|
| `web/routes.py` | Import `trick_winner`, compute `trick_winning_seat` in game context |
| `web/templates/partials/trick.html` | Apply `card--winning` CSS class to winning card |
| `web/static/style.css` | Add `.card--winning` gold glow style |

## Repro / Validation
```bash
# Start a game and play through to trick play phase — the winning card
# in each active trick should have a gold glow border.

# Unit tests (63 route tests + 28 rules tests pass):
uv run python -m pytest tests/unit/hosted_play/test_routes.py -x -q
uv run python -m pytest tests/unit/test_rules.py -x -q
```

## Tests
- `tests/unit/hosted_play/test_routes.py` — 63 passed, 2 skipped
- `tests/unit/test_rules.py` — 28 passed
- Pre-commit hooks: all passed (ruff, format, repo-linter)

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c
branch: feat/trick-winning-highlight
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)