### PR TITLE
feat(web): add session reconnect with cookie-based active match detection

### DIFF
--- a/tests/unit/hosted_play/test_reconnect.py
+++ b/tests/unit/hosted_play/test_reconnect.py
@@ -1,0 +1,282 @@
+"""Tests for session reconnect — cookie-based active match detection.
+
+Covers:
+1. Middleware helpers: cookie extraction, player lookup, cookie setting
+2. Landing page reconnect detection (cookie present → reconnect prompt)
+3. Landing page fallback (no cookie or no active match → invite form)
+4. Cookie setting on successful code redemption
+5. Cookie setting on legacy /new route
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from starlette.testclient import TestClient
+
+from tests.unit.hosted_play.conftest import (
+    create_test_invite_code,
+    create_test_match,
+    create_test_player,
+    make_hosted_play_test_config,
+)
+from web.app import create_app
+from web.middleware import (
+    PLAYER_COOKIE_NAME,
+    lookup_active_match,
+    set_player_cookie,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def config(tmp_path):
+    """File-based SQLite config for test isolation."""
+    return make_hosted_play_test_config(tmp_path)
+
+
+@pytest.fixture()
+def app(config):
+    """FastAPI app configured with temp DB."""
+    return create_app(config=config)
+
+
+@pytest.fixture()
+def client(app):
+    """TestClient wrapping the test app."""
+    with TestClient(app) as c:
+        yield c
+
+
+def _get_session_factory(client):
+    """Get session_factory from a started app (via client)."""
+    return client.app.state.session_factory
+
+
+# ===================================================================
+# 1. Middleware Helpers — Unit Tests
+# ===================================================================
+
+
+class TestSetPlayerCookie:
+    """set_player_cookie attaches the correct cookie to a response."""
+
+    def test_cookie_is_set_on_response(self):
+        """Cookie appears in response with correct attributes."""
+        from fastapi.responses import JSONResponse
+
+        resp = JSONResponse(content={})
+        link = str(uuid.uuid4())
+        set_player_cookie(resp, link)
+
+        raw_headers = dict(resp.headers)
+        assert "set-cookie" in raw_headers
+        cookie_header = raw_headers["set-cookie"]
+        assert PLAYER_COOKIE_NAME in cookie_header
+        assert link in cookie_header
+        assert "httponly" in cookie_header.lower()
+        assert "samesite=lax" in cookie_header.lower()
+
+
+class TestLookupActiveMatch:
+    """lookup_active_match finds the player's active match from the DB."""
+
+    def test_returns_none_for_unknown_player(self, client):
+        """Unknown link_uuid → None."""
+        session = _get_session_factory(client)()
+        try:
+            result = lookup_active_match(session, "nonexistent-uuid")
+            assert result is None
+        finally:
+            session.close()
+
+    def test_returns_none_when_no_nickname(self, client):
+        """Player without nickname → None (incomplete onboarding)."""
+        session = _get_session_factory(client)()
+        try:
+            player = create_test_player(session, nickname=None)
+            create_test_match(session, player_id=player.id, status="active")
+            session.commit()
+
+            result = lookup_active_match(session, player.link_uuid)
+            assert result is None
+        finally:
+            session.close()
+
+    def test_returns_none_when_no_active_match(self, client):
+        """Player with only completed matches → None."""
+        session = _get_session_factory(client)()
+        try:
+            player = create_test_player(session, nickname="Alice")
+            create_test_match(session, player_id=player.id, status="complete")
+            session.commit()
+
+            result = lookup_active_match(session, player.link_uuid)
+            assert result is None
+        finally:
+            session.close()
+
+    def test_returns_match_info_when_active(self, client):
+        """Player with active match → dict with link_uuid, nickname, match_uuid."""
+        session = _get_session_factory(client)()
+        try:
+            player = create_test_player(session, nickname="Bob")
+            match = create_test_match(session, player_id=player.id, status="active")
+            session.commit()
+
+            result = lookup_active_match(session, player.link_uuid)
+            assert result is not None
+            assert result["link_uuid"] == player.link_uuid
+            assert result["nickname"] == "Bob"
+            assert result["match_uuid"] == match.match_uuid
+        finally:
+            session.close()
+
+
+# ===================================================================
+# 2. Landing Page — Reconnect Detection
+# ===================================================================
+
+
+class TestLandingReconnect:
+    """Landing page shows reconnect prompt when cookie indicates active match."""
+
+    def _setup_player_with_active_match(self, client):
+        """Create a player with nickname and active match, return link_uuid."""
+        session = _get_session_factory(client)()
+        try:
+            player = create_test_player(session, nickname="ReconnectPlayer")
+            create_test_match(session, player_id=player.id, status="active")
+            session.commit()
+            return player.link_uuid
+        finally:
+            session.close()
+
+    def test_reconnect_prompt_shown(self, client):
+        """Cookie with active match → reconnect prompt rendered."""
+        link_uuid = self._setup_player_with_active_match(client)
+        client.cookies.set(PLAYER_COOKIE_NAME, link_uuid)
+
+        resp = client.get("/")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "reconnect-prompt" in body
+        assert "Welcome back" in body
+        assert "ReconnectPlayer" in body
+        assert f"/play/{link_uuid}" in body
+
+    def test_invite_form_when_no_cookie(self, client):
+        """No cookie → standard invite code form."""
+        resp = client.get("/")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "invite-code-form" in body
+        assert "reconnect-prompt" not in body
+
+    def test_invite_form_when_stale_cookie(self, client):
+        """Cookie with unknown player → standard invite code form."""
+        client.cookies.set(PLAYER_COOKIE_NAME, "nonexistent-uuid-12345")
+        resp = client.get("/")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "invite-code-form" in body
+        assert "reconnect-prompt" not in body
+
+    def test_invite_form_when_no_active_match(self, client):
+        """Cookie for player with only completed matches → invite form."""
+        session = _get_session_factory(client)()
+        try:
+            player = create_test_player(session, nickname="DonePlayer")
+            create_test_match(session, player_id=player.id, status="complete")
+            session.commit()
+            link_uuid = player.link_uuid
+        finally:
+            session.close()
+
+        client.cookies.set(PLAYER_COOKIE_NAME, link_uuid)
+        resp = client.get("/")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "invite-code-form" in body
+        assert "reconnect-prompt" not in body
+
+    def test_reconnect_has_different_code_option(self, client):
+        """Reconnect prompt includes a 'Use Different Code' fallback."""
+        link_uuid = self._setup_player_with_active_match(client)
+        client.cookies.set(PLAYER_COOKIE_NAME, link_uuid)
+
+        resp = client.get("/")
+        body = resp.text
+        assert "invite-code-fallback" in body
+        assert "Use Different Code" in body
+
+
+# ===================================================================
+# 3. Cookie Setting on Code Redemption
+# ===================================================================
+
+
+class TestCookieOnRedemption:
+    """Invite code redemption sets the player session cookie."""
+
+    def test_cookie_set_on_new_code_entry(self, client):
+        """Entering a fresh invite code sets the player cookie."""
+        session = _get_session_factory(client)()
+        try:
+            invite = create_test_invite_code(session)
+            session.commit()
+            code = invite.code
+        finally:
+            session.close()
+
+        resp = client.post(
+            "/enter-code",
+            data={"code": code},
+            follow_redirects=False,
+        )
+        assert resp.status_code in (302, 200)
+        cookie_header = resp.headers.get("set-cookie", "")
+        assert PLAYER_COOKIE_NAME in cookie_header
+
+    def test_cookie_set_on_redeemed_code_reentry(self, client):
+        """Re-entering an already-redeemed code still sets the cookie."""
+        session = _get_session_factory(client)()
+        try:
+            player = create_test_player(session, nickname="ExistingPlayer")
+            invite = create_test_invite_code(
+                session,
+                status="redeemed",
+                player_id=player.id,
+            )
+            session.commit()
+            code = invite.code
+        finally:
+            session.close()
+
+        resp = client.post(
+            "/enter-code",
+            data={"code": code},
+            follow_redirects=False,
+        )
+        cookie_header = resp.headers.get("set-cookie", "")
+        assert PLAYER_COOKIE_NAME in cookie_header
+
+
+# ===================================================================
+# 4. Cookie Setting on Legacy /new Route
+# ===================================================================
+
+
+class TestCookieOnLegacyNew:
+    """Legacy /new route sets the player session cookie."""
+
+    def test_cookie_set_on_new(self, client):
+        """POST /new sets the player cookie on the redirect response."""
+        resp = client.post("/new", follow_redirects=False)
+        assert resp.status_code == 302
+        cookie_header = resp.headers.get("set-cookie", "")
+        assert PLAYER_COOKIE_NAME in cookie_header

--- a/web/middleware.py
+++ b/web/middleware.py
@@ -1,15 +1,27 @@
 """Middleware and guards for the Bid Euchre browser game.
 
-Rate-limiting and request-level guards that protect the hosted-play
-application from resource exhaustion during the pilot phase.
+Rate-limiting, session-tracking, and request-level guards that protect
+the hosted-play application from resource exhaustion during the pilot
+phase and support transparent session reconnection.
 """
 
 from __future__ import annotations
 
-from web.db import Match
+from typing import Optional
+
+from fastapi import Request
+from fastapi.responses import Response
+
+from web.db import Match, Player
 
 # Maximum number of active matches a single player may have concurrently.
 MAX_ACTIVE_MATCHES_PER_PLAYER = 5
+
+# Cookie name used to remember the player's link_uuid across visits.
+PLAYER_COOKIE_NAME = "bid_euchre_player"
+
+# Cookie max-age: 30 days (seconds).
+PLAYER_COOKIE_MAX_AGE = 30 * 24 * 60 * 60
 
 
 def check_match_limit(session, player_id: int) -> bool:
@@ -23,3 +35,57 @@ def check_match_limit(session, player_id: int) -> bool:
         session.query(Match).filter_by(player_id=player_id, status="active").count()
     )
     return active_count < MAX_ACTIVE_MATCHES_PER_PLAYER
+
+
+def get_player_link_from_cookie(request: Request) -> Optional[str]:
+    """Extract the player ``link_uuid`` from the session cookie.
+
+    Returns ``None`` when no cookie is set or the value is empty.
+    """
+    value = request.cookies.get(PLAYER_COOKIE_NAME, "").strip()
+    return value if value else None
+
+
+def set_player_cookie(response: Response, link_uuid: str) -> None:
+    """Attach the player session cookie to *response*.
+
+    The cookie is ``HttpOnly``, ``SameSite=Lax``, and valid for
+    :data:`PLAYER_COOKIE_MAX_AGE` seconds.  ``secure`` is omitted so the
+    cookie works over plain HTTP during local development.
+    """
+    response.set_cookie(
+        key=PLAYER_COOKIE_NAME,
+        value=link_uuid,
+        max_age=PLAYER_COOKIE_MAX_AGE,
+        httponly=True,
+        samesite="lax",
+        path="/",
+    )
+
+
+def lookup_active_match(session, link_uuid: str) -> Optional[dict]:
+    """Look up a player by *link_uuid* and return active-match info.
+
+    Returns a dict with keys ``link_uuid``, ``nickname``, and
+    ``match_uuid`` when a valid player with an active match is found.
+    Returns ``None`` otherwise (player not found, no nickname set, or no
+    active match).
+    """
+    player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+    if player is None or not player.nickname:
+        return None
+
+    match_row = (
+        session.query(Match)
+        .filter_by(player_id=player.id, status="active")
+        .order_by(Match.created_at.desc())
+        .first()
+    )
+    if match_row is None:
+        return None
+
+    return {
+        "link_uuid": link_uuid,
+        "nickname": player.nickname,
+        "match_uuid": match_row.match_uuid,
+    }

--- a/web/routes.py
+++ b/web/routes.py
@@ -31,7 +31,12 @@ from bid_euchre.strategy.bidding import BidAction
 from .ai_manager import AIManager
 from .db import Decision, Hand, InviteCode, Match, Player
 from .leaderboard import METRIC_DEFINITIONS, format_metric, get_leaderboard
-from .middleware import check_match_limit
+from .middleware import (
+    check_match_limit,
+    get_player_link_from_cookie,
+    lookup_active_match,
+    set_player_cookie,
+)
 
 router = APIRouter()
 
@@ -570,8 +575,28 @@ async def ready(request: Request):
 
 @router.get("/", response_class=HTMLResponse)
 async def landing(request: Request):
-    """Landing page — invite code entry form."""
+    """Landing page — invite code form or reconnect prompt.
+
+    When the player has a session cookie with an active match, renders a
+    reconnect partial so they can resume without re-entering their invite
+    code.  Falls through to the standard invite code form otherwise.
+    """
     templates = _get_templates(request)
+    link_uuid = get_player_link_from_cookie(request)
+    if link_uuid is not None:
+        session = _get_session(request)
+        try:
+            match_info = lookup_active_match(session, link_uuid)
+            if match_info is not None:
+                return templates.TemplateResponse(
+                    "landing.html",
+                    {
+                        "request": request,
+                        "reconnect": match_info,
+                    },
+                )
+        finally:
+            session.close()
     return templates.TemplateResponse("landing.html", {"request": request})
 
 
@@ -620,11 +645,15 @@ async def enter_code(
                 redirect_url = f"/play/{player.link_uuid}"
                 # HTMX-aware redirect
                 if request.headers.get("HX-Request"):
-                    return HTMLResponse(
+                    resp = HTMLResponse(
                         "",
                         headers={"HX-Redirect": redirect_url},
                     )
-                return RedirectResponse(url=redirect_url, status_code=302)
+                    set_player_cookie(resp, player.link_uuid)
+                    return resp
+                resp = RedirectResponse(url=redirect_url, status_code=302)
+                set_player_cookie(resp, player.link_uuid)
+                return resp
 
         # --- Active code — create player and redeem ---
         link_uuid = str(uuid.uuid4())
@@ -640,11 +669,15 @@ async def enter_code(
         redirect_url = f"/play/{link_uuid}"
         # HTMX-aware redirect
         if request.headers.get("HX-Request"):
-            return HTMLResponse(
+            resp = HTMLResponse(
                 "",
                 headers={"HX-Redirect": redirect_url},
             )
-        return RedirectResponse(url=redirect_url, status_code=302)
+            set_player_cookie(resp, link_uuid)
+            return resp
+        resp = RedirectResponse(url=redirect_url, status_code=302)
+        set_player_cookie(resp, link_uuid)
+        return resp
     finally:
         session.close()
 
@@ -662,7 +695,9 @@ async def create_game(request: Request):
         player = Player(link_uuid=link_uuid)
         session.add(player)
         session.commit()
-        return RedirectResponse(url=f"/play/{link_uuid}", status_code=302)
+        resp = RedirectResponse(url=f"/play/{link_uuid}", status_code=302)
+        set_player_cookie(resp, link_uuid)
+        return resp
     finally:
         session.close()
 

--- a/web/static/game.js
+++ b/web/static/game.js
@@ -287,6 +287,17 @@
         }
     }
 
+    function refreshGameBoard() {
+        // After reconnecting (online event), reload the current page to
+        // re-fetch the authoritative game state from the server.  This
+        // handles stale HTMX partial state that may have accumulated
+        // while the player was offline.
+        var gameBoard = document.getElementById('game-board');
+        if (gameBoard) {
+            window.location.reload();
+        }
+    }
+
     function attachErrorHandlers() {
         // HTMX response errors (server returned 4xx/5xx)
         document.body.addEventListener('htmx:responseError', function (event) {
@@ -326,6 +337,8 @@
         window.addEventListener('online', function () {
             hideOfflineBanner();
             dismissErrorToast();
+            // Refresh game board to recover from stale HTMX state
+            refreshGameBoard();
         });
     }
 

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -2669,7 +2669,74 @@ main {
 }
 
 /* --------------------------------------------------------------------------
-   21. Utilities
+   21. Session Reconnect Prompt
+   -------------------------------------------------------------------------- */
+
+.reconnect-prompt {
+    text-align: center;
+    padding: 1.5rem;
+    margin: 1.5rem auto;
+    max-width: 420px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius, 8px);
+}
+
+.reconnect-prompt__heading {
+    font-size: 1.25rem;
+    margin: 0 0 0.5rem;
+    color: var(--color-text);
+}
+
+.reconnect-prompt__message {
+    font-size: 0.95rem;
+    color: var(--color-text-muted);
+    margin: 0 0 1.25rem;
+    line-height: 1.4;
+}
+
+.reconnect-prompt__actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+.reconnect-prompt__resume {
+    width: 100%;
+    max-width: 260px;
+    text-align: center;
+    text-decoration: none;
+}
+
+.reconnect-prompt__new-code {
+    background: transparent;
+    border: 1px solid var(--color-border);
+    color: var(--color-text-muted);
+    font-size: 0.85rem;
+    padding: 0.5rem 1rem;
+    border-radius: var(--radius, 8px);
+    cursor: pointer;
+}
+
+.reconnect-prompt__new-code:hover {
+    color: var(--color-text);
+    border-color: var(--color-text-muted);
+}
+
+@media (max-width: 600px) {
+    .reconnect-prompt {
+        padding: 1rem;
+        margin: 1rem auto;
+    }
+
+    .reconnect-prompt__heading {
+        font-size: 1.1rem;
+    }
+}
+
+/* --------------------------------------------------------------------------
+   22. Utilities
    -------------------------------------------------------------------------- */
 
 .sr-only {

--- a/web/templates/landing.html
+++ b/web/templates/landing.html
@@ -15,6 +15,10 @@
         Double-deck, 10-to-Ace, with bowers. Play against AI opponents.
     </p>
 
-    {% include "partials/invite_code_form.html" %}
+    {% if reconnect %}
+        {% include "partials/reconnect.html" %}
+    {% else %}
+        {% include "partials/invite_code_form.html" %}
+    {% endif %}
 </div>
 {% endblock %}

--- a/web/templates/partials/reconnect.html
+++ b/web/templates/partials/reconnect.html
@@ -1,0 +1,30 @@
+{# Session reconnect prompt — shown when a returning player has an active match.
+   Context variables:
+     - reconnect.link_uuid: str — player's link UUID
+     - reconnect.nickname: str — player's display name
+     - reconnect.match_uuid: str — active match UUID
+#}
+<div id="reconnect-prompt" class="reconnect-prompt"
+     role="region" aria-label="Resume your game">
+    <h2 class="reconnect-prompt__heading">Welcome back, {{ reconnect.nickname }}!</h2>
+    <p class="reconnect-prompt__message">
+        You have a game in progress. Pick up where you left off?
+    </p>
+    <div class="reconnect-prompt__actions">
+        <a href="/play/{{ reconnect.link_uuid }}"
+           class="btn btn--play-again reconnect-prompt__resume"
+           role="button">
+            Resume Game
+        </a>
+        <button type="button"
+                class="btn btn--secondary reconnect-prompt__new-code"
+                onclick="document.getElementById('reconnect-prompt').style.display='none';document.getElementById('invite-code-fallback').style.display='block';"
+                aria-label="Enter a different invite code instead">
+            Use Different Code
+        </button>
+    </div>
+</div>
+
+<div id="invite-code-fallback" style="display:none;">
+    {% include "partials/invite_code_form.html" %}
+</div>


### PR DESCRIPTION
## Plan
N/A — standalone UX improvement from task packet `4d896e252030` / `0c202c23933d`

## Summary
- Add cookie-based player session tracking so returning players are recognized on the landing page
- Show a "Welcome back, {nickname}!" reconnect prompt with Resume Game / Use Different Code options
- Auto-refresh game board when browser comes back online to recover stale HTMX state

## Why
Players who refresh the browser or return later see the invite code form every time, even when they have an active game. This adds transparent session detection so they can resume with one click.

## Repro / Validation
**Command(s) run:**
```
uv run python -m pytest tests/unit/hosted_play/test_reconnect.py -v
uv run python -m pytest tests/unit/hosted_play/ -v
make check-quiet
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** All 13 new tests pass covering middleware helpers, landing page reconnect detection, cookie setting on code redemption, and legacy route compatibility
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_reconnect.py -v`
- **Expected result:** 13 passed

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_reconnect.py -v` — 13 passed
- [x] `uv run python -m pytest tests/unit/hosted_play/ -v` — 118 passed (13 new + 105 existing)
- [x] `make check-quiet` — 10,475 passed, 3 pre-existing failures (token economy, telegram filter — unrelated)

## Expected impact
- Metrics impact: None (UX-only change)
- Runtime impact: One additional DB query on landing page when cookie is present

## Risk level
- [x] Low (web UI only, no core logic changes)

## Worktree proof (required)
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b
```

`git worktree list` (flex-b entry):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b  d8f1cb35 [feat/web-session-reconnect]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)