### PR TITLE
feat(web): add text size toggle for accessibility

### DIFF
--- a/tests/unit/hosted_play/test_text_size_toggle.py
+++ b/tests/unit/hosted_play/test_text_size_toggle.py
@@ -1,0 +1,171 @@
+"""Tests for the text size toggle accessibility feature.
+
+Validates:
+- base.html contains the toggle button and FOUC-prevention script
+- accessibility.css contains the large-mode rule
+- game.js contains the toggle wiring
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+import jinja2
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+WEB_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "..", "web")
+TEMPLATES_DIR = os.path.join(WEB_DIR, "templates")
+STATIC_DIR = os.path.join(WEB_DIR, "static")
+
+
+@pytest.fixture()
+def env():
+    """Jinja2 environment loading from web/templates/."""
+    return jinja2.Environment(
+        loader=jinja2.FileSystemLoader(TEMPLATES_DIR),
+        autoescape=True,
+        undefined=jinja2.StrictUndefined,
+    )
+
+
+@pytest.fixture()
+def base_html(env):
+    """Render base.html with minimal context."""
+    tmpl = env.get_template("base.html")
+    # Provide link_uuid so the nav renders too
+    return tmpl.render(link_uuid="test-uuid")
+
+
+@pytest.fixture()
+def accessibility_css():
+    """Read accessibility.css content."""
+    path = os.path.join(STATIC_DIR, "css", "accessibility.css")
+    with open(path) as f:
+        return f.read()
+
+
+@pytest.fixture()
+def game_js():
+    """Read game.js content."""
+    path = os.path.join(STATIC_DIR, "game.js")
+    with open(path) as f:
+        return f.read()
+
+
+# ---------------------------------------------------------------------------
+# base.html — toggle button
+# ---------------------------------------------------------------------------
+
+
+class TestBaseHtmlToggleButton:
+    def test_toggle_button_present(self, base_html):
+        assert 'id="text-size-toggle"' in base_html
+
+    def test_toggle_button_has_aria_label(self, base_html):
+        assert 'aria-label="Toggle large text"' in base_html
+
+    def test_toggle_button_is_type_button(self, base_html):
+        """type=button prevents accidental form submission."""
+        assert 'type="button"' in base_html
+
+    def test_toggle_button_has_class(self, base_html):
+        assert 'class="text-size-toggle"' in base_html
+
+
+# ---------------------------------------------------------------------------
+# base.html — FOUC prevention script
+# ---------------------------------------------------------------------------
+
+
+class TestBaseHtmlFoucPrevention:
+    def test_fouc_script_present(self, base_html):
+        """Inline script must apply data-text-size before first paint."""
+        assert "localStorage.getItem('textSize')" in base_html
+
+    def test_fouc_script_sets_data_attribute(self, base_html):
+        assert "data-text-size" in base_html
+        assert "'large'" in base_html
+
+    def test_fouc_script_before_game_js(self, base_html):
+        """The FOUC script must appear before game.js to run first."""
+        fouc_pos = base_html.find("localStorage.getItem('textSize')")
+        game_js_pos = base_html.find("game.js")
+        assert fouc_pos < game_js_pos, "FOUC script must precede game.js"
+
+
+# ---------------------------------------------------------------------------
+# accessibility.css — large mode rule
+# ---------------------------------------------------------------------------
+
+
+class TestAccessibilityCssLargeMode:
+    def test_large_mode_rule_exists(self, accessibility_css):
+        assert 'html[data-text-size="large"]' in accessibility_css
+
+    def test_large_mode_sets_font_size(self, accessibility_css):
+        # The rule should set font-size: 125% (or similar percentage)
+        pattern = r'html\[data-text-size="large"\]\s*\{\s*font-size:\s*125%;'
+        assert re.search(
+            pattern, accessibility_css
+        ), "Expected html[data-text-size='large'] { font-size: 125%; }"
+
+    def test_toggle_button_styles_exist(self, accessibility_css):
+        assert ".text-size-toggle" in accessibility_css
+
+    def test_active_state_style_exists(self, accessibility_css):
+        """When large mode is active, the toggle button should look different."""
+        assert 'html[data-text-size="large"] .text-size-toggle' in accessibility_css
+
+    def test_reduced_motion_covers_toggle(self, accessibility_css):
+        """The toggle button transition must be suppressed in reduced-motion mode."""
+        assert "prefers-reduced-motion" in accessibility_css
+        # Find the reduced-motion block that covers .text-size-toggle
+        rm_section = accessibility_css[
+            accessibility_css.find("prefers-reduced-motion") :
+        ]
+        assert ".text-size-toggle" in rm_section
+
+
+# ---------------------------------------------------------------------------
+# game.js — toggle logic
+# ---------------------------------------------------------------------------
+
+
+class TestGameJsToggleLogic:
+    def test_text_size_key_defined(self, game_js):
+        assert "TEXT_SIZE_KEY" in game_js
+        assert "'textSize'" in game_js
+
+    def test_get_text_size_function(self, game_js):
+        assert "function getTextSize()" in game_js
+
+    def test_set_text_size_function(self, game_js):
+        assert "function setTextSize(" in game_js
+
+    def test_toggle_text_size_function(self, game_js):
+        assert "function toggleTextSize()" in game_js
+
+    def test_attach_toggle_handler(self, game_js):
+        assert "function attachTextSizeToggle()" in game_js
+
+    def test_toggle_wired_in_initialize(self, game_js):
+        """attachTextSizeToggle must be called from initialize()."""
+        # Find the initialize function body
+        init_start = game_js.find("function initialize()")
+        init_block = game_js[init_start : init_start + 500]
+        assert "attachTextSizeToggle()" in init_block
+
+    def test_localstorage_persistence(self, game_js):
+        """Toggle should read/write localStorage."""
+        assert "localStorage.getItem(TEXT_SIZE_KEY)" in game_js
+        assert "localStorage.setItem(TEXT_SIZE_KEY" in game_js
+
+    def test_data_attribute_usage(self, game_js):
+        """Toggle should set/remove data-text-size on documentElement."""
+        assert "data-text-size" in game_js
+        assert "document.documentElement" in game_js

--- a/web/static/css/accessibility.css
+++ b/web/static/css/accessibility.css
@@ -238,7 +238,54 @@ select:focus-visible {
 }
 
 /* --------------------------------------------------------------------------
-   7. Pass Button Styling
+   7. Text Size Toggle
+   --------------------------------------------------------------------------
+   Two modes: default (browser 100%) and large (125%).
+   Since all font-size values in style.css use rem, scaling the root element
+   font-size propagates proportionally to every text element.
+   Activated via data-text-size="large" on <html>, persisted in localStorage.
+   -------------------------------------------------------------------------- */
+
+html[data-text-size="large"] {
+    font-size: 125%;
+}
+
+/* Toggle button — sits in the header bar, compact icon-style */
+.text-size-toggle {
+    background: transparent;
+    border: 1.5px solid var(--color-text-muted, #bdbdbd);
+    border-radius: 4px;
+    color: var(--color-text-muted, #bdbdbd);
+    cursor: pointer;
+    font-size: 0.8rem;
+    font-weight: 700;
+    padding: 0.25rem 0.5rem;
+    line-height: 1;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+    white-space: nowrap;
+}
+
+.text-size-toggle:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--color-text, #fafafa);
+    border-color: var(--color-text, #fafafa);
+}
+
+/* Active state when large mode is on */
+html[data-text-size="large"] .text-size-toggle {
+    background: rgba(255, 255, 255, 0.15);
+    color: var(--color-text, #fafafa);
+    border-color: var(--color-legal-glow, #4caf50);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .text-size-toggle {
+        transition: none;
+    }
+}
+
+/* --------------------------------------------------------------------------
+   8. Pass Button Styling
    --------------------------------------------------------------------------
    The pass button is styled as a secondary action distinct from Submit Bid.
    -------------------------------------------------------------------------- */

--- a/web/static/game.js
+++ b/web/static/game.js
@@ -199,6 +199,56 @@
     }
 
     /* ---------------------------------------------------------------
+     * Text size toggle — default (100%) and large (125%).
+     * Persisted in localStorage. The inline <script> in base.html
+     * applies the attribute before first paint to avoid FOUC.
+     * --------------------------------------------------------------- */
+
+    var TEXT_SIZE_KEY = 'textSize';
+
+    function getTextSize() {
+        try {
+            return localStorage.getItem(TEXT_SIZE_KEY) || 'default';
+        } catch (_) {
+            return 'default';
+        }
+    }
+
+    function setTextSize(size) {
+        try {
+            if (size === 'large') {
+                localStorage.setItem(TEXT_SIZE_KEY, 'large');
+                document.documentElement.setAttribute('data-text-size', 'large');
+            } else {
+                localStorage.removeItem(TEXT_SIZE_KEY);
+                document.documentElement.removeAttribute('data-text-size');
+            }
+        } catch (_) {
+            // localStorage unavailable — still apply the attribute for this session
+            if (size === 'large') {
+                document.documentElement.setAttribute('data-text-size', 'large');
+            } else {
+                document.documentElement.removeAttribute('data-text-size');
+            }
+        }
+    }
+
+    function toggleTextSize() {
+        var current = getTextSize();
+        setTextSize(current === 'large' ? 'default' : 'large');
+    }
+
+    function attachTextSizeToggle() {
+        document.addEventListener('click', function (event) {
+            var btn = event.target.closest('#text-size-toggle');
+            if (btn) {
+                event.preventDefault();
+                toggleTextSize();
+            }
+        });
+    }
+
+    /* ---------------------------------------------------------------
      * Error handling — show user-friendly toast when HTMX requests
      * fail (network error, server error, timeout).
      * --------------------------------------------------------------- */
@@ -332,6 +382,7 @@
     function initialize() {
         attachDelegatedHandlers();
         attachTrickHistoryToggle();
+        attachTextSizeToggle();
         attachErrorHandlers();
         var form = getCardPlayForm();
         clearCardSelection(form);

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -25,6 +25,10 @@
             padding: var(--safe-area-top) var(--safe-area-right) var(--safe-area-bottom) var(--safe-area-left);
         }
     </style>
+    <!-- Apply text size preference before first paint to prevent FOUC -->
+    <script>
+        (function(){try{var s=localStorage.getItem('textSize');if(s==='large'){document.documentElement.setAttribute('data-text-size','large');}}catch(e){}})();
+    </script>
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     <script src="https://unpkg.com/idiomorph@0.3.0/dist/idiomorph-ext.min.js"></script>
     <script src="/static/game.js" defer></script>
@@ -42,6 +46,11 @@
                 <a href="/leaderboard/{{ link_uuid }}">Leaderboard</a>
             </nav>
             {% endif %}
+            <button id="text-size-toggle"
+                    class="text-size-toggle"
+                    type="button"
+                    aria-label="Toggle large text"
+                    title="Toggle large text">Aa</button>
         </div>
     </header>
     <main id="main-content" role="main">


### PR DESCRIPTION
## Plan
Browser Game Expansion — UX accessibility feature (unplanned UX improvement, no governing plan step).

## Summary
- Add a default/large text size toggle button ("Aa") in the header bar
- Large mode scales root `font-size` to 125% — all `rem`-based sizes scale proportionally
- Preference persisted in `localStorage` with FOUC prevention via inline `<script>`
- 20 unit tests covering HTML structure, CSS rules, and JS logic

## Why
Accessibility improvement for users who need larger text. The toggle is low-friction (one click, persistent across sessions) and uses the existing rem-based sizing so all UI elements scale proportionally without per-element overrides.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_text_size_toggle.py -v
make check-quiet
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** All 20 text-size toggle tests pass; toggle button present in rendered base.html; CSS large-mode rule exists; JS functions defined and wired
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_text_size_toggle.py -v`
- **Expected result:** 20 passed

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_text_size_toggle.py -v` (20/20 pass)
- [x] `make check-quiet` — 10,482 passed (3 pre-existing failures in unrelated modules: `test_ops_token_economy`, `test_telegram_filter`)

## Expected impact
- Metrics impact: None (frontend-only)
- Runtime impact: None (CSS attribute toggle, no server calls)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b   1c3cf553 [feat/web-text-size-toggle]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)