### PR TITLE
feat(web): contextual hand-result coloring + contrast + colorblind fixes

### DIFF
--- a/tests/unit/hosted_play/test_bid_outcome_matrix.py
+++ b/tests/unit/hosted_play/test_bid_outcome_matrix.py
@@ -345,6 +345,19 @@ class TestCSSClasses:
         elif p0 < 0:
             assert "points--negative" in html
 
+    @pytest.mark.parametrize("case", MATRIX, ids=MATRIX_IDS)
+    def test_title_mood_class(self, case: Case, jinja_env: jinja2.Environment) -> None:
+        """Result title has contextual positive/negative class (2c)."""
+        html, _, _ = _render(jinja_env, case)
+        human_declared = case.bidder_seat in (0, 2)
+        is_good_for_human = (case.outcome.made and human_declared) or (
+            not case.outcome.made and not human_declared
+        )
+        expected = (
+            "result-title--positive" if is_good_for_human else "result-title--negative"
+        )
+        assert expected in html, f"Title mood class '{expected}' not in HTML"
+
 
 # ---------------------------------------------------------------------------
 # 4. Moon/loner score-delta emphasis

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -19,7 +19,7 @@
     --color-positive: #2e7d32;
     --color-negative: #c62828;
     --color-text: #fafafa;
-    --color-text-muted: #d0d0d0;
+    --color-text-muted: #dadada;
     --color-surface: #263238;
     --color-surface-light: #37474f;
     --card-width: 60px;
@@ -1245,6 +1245,10 @@ main {
 .points--negative {
     color: var(--color-negative);
     font-weight: 700;
+    /* Redundant encoding for colorblind users (3d) */
+    text-decoration: underline;
+    text-decoration-color: var(--color-negative);
+    text-underline-offset: 0.15em;
 }
 
 .result-match-score {
@@ -2374,6 +2378,22 @@ main {
 .result--loner-made .result-title,
 .result--loner-set .result-title {
     color: var(--color-loner);
+}
+
+/* Contextual title overrides — ensure human-perspective coloring takes
+   precedence over moon/loner defaults (2c).  Placed after the theme-color
+   rules so equal-specificity source-order wins. */
+.hand-result .result-title--positive {
+    color: var(--color-positive);
+    text-shadow: 0 0 12px rgba(46, 125, 50, 0.5);
+}
+
+.hand-result .result-title--negative {
+    color: var(--color-negative);
+    text-shadow: 0 0 12px rgba(198, 40, 40, 0.5);
+    text-decoration: underline;
+    text-decoration-color: var(--color-negative);
+    text-underline-offset: 0.15em;
 }
 
 /* Score delta emphasis in result banner */

--- a/web/templates/partials/hand_result.html
+++ b/web/templates/partials/hand_result.html
@@ -50,24 +50,27 @@
 <div id="hand-result" class="hand-result hand-result--animated {{ result_class }}"
      role="alert" aria-live="assertive">
     <div class="result-banner">
+        {# --- Contextual title class: green for human-positive, red for human-negative --- #}
+        {% set title_mood = "result-title--positive" if is_good_for_human else "result-title--negative" %}
+
         {# --- Moon / Loner special banners --- #}
         {% if hand_bid_type == "moon" %}
             {% if made %}
-                <h2 class="result-title"><span aria-hidden="true">🌙</span> Moon Made!</h2>
+                <h2 class="result-title {{ title_mood }}"><span aria-hidden="true">🌙</span> Moon Made!</h2>
             {% else %}
-                <h2 class="result-title"><span aria-hidden="true">🌙</span> Moon Set!</h2>
+                <h2 class="result-title {{ title_mood }}"><span aria-hidden="true">🌙</span> Moon Set!</h2>
             {% endif %}
         {% elif hand_bid_type == "loner" %}
             {% if made %}
-                <h2 class="result-title"><span aria-hidden="true">🃏</span> Loner Made!</h2>
+                <h2 class="result-title {{ title_mood }}"><span aria-hidden="true">🃏</span> Loner Made!</h2>
             {% else %}
-                <h2 class="result-title"><span aria-hidden="true">🃏</span> Loner Set!</h2>
+                <h2 class="result-title {{ title_mood }}"><span aria-hidden="true">🃏</span> Loner Set!</h2>
             {% endif %}
         {# --- Regular bid banners --- #}
         {% elif made %}
-            <h2 class="result-title">Made it!</h2>
+            <h2 class="result-title {{ title_mood }}">Made it!</h2>
         {% else %}
-            <h2 class="result-title">Set!</h2>
+            <h2 class="result-title {{ title_mood }}">Set!</h2>
         {% endif %}
 
         {# Score delta emphasis for moon/loner #}


### PR DESCRIPTION
## Summary

- **(2c)** Hand-result title color now reflects human perspective: green when
  the outcome is good for the human player, red when bad — applies uniformly
  to regular, moon, and loner bid types (previously moon/loner titles always
  used theme color regardless of whether outcome was good or bad for human)
- **(3c)** Bumped `--color-text-muted` from `#d0d0d0` to `#dadada` for
  improved WCAG AA contrast ratio
- **(3d)** Added underline redundant encoding on negative result titles and
  negative point cells so colorblind users can distinguish good/bad outcomes
  without relying on color alone

## Why

UX audit items 2c, 3c, 3d — accessibility and visual clarity improvements
for the browser game hand result display.

## Changes

| File | Change |
|------|--------|
| `web/templates/partials/hand_result.html` | Added `result-title--positive` / `result-title--negative` class to all `<h2>` result titles based on `is_good_for_human` |
| `web/static/style.css` | Added contextual title color rules (placed after moon/loner defaults for correct specificity), bumped `--color-text-muted`, added underline on negative elements |
| `tests/unit/hosted_play/test_bid_outcome_matrix.py` | Added `test_title_mood_class` — verifies contextual class across full bid/outcome/seat matrix |

## Repro / Validation

```bash
# Targeted tests (Tier 1)
uv run python -m pytest tests/unit/hosted_play/test_bid_outcome_matrix.py \
  tests/unit/hosted_play/test_scoring_matrix.py -x -q
# → 2569 passed, 4 skipped

# Full validation (Tier 2)
make check-quiet
# → 10745 passed; 3 pre-existing failures in unrelated modules
```

## Tests

- `uv run python -m pytest tests/unit/hosted_play/test_bid_outcome_matrix.py -x -q` — 1584 passed
- `uv run python -m pytest tests/unit/hosted_play/test_scoring_matrix.py -x -q` — 985 passed, 4 skipped
- `make check-quiet` — 3 pre-existing failures (token_economy, telegram_filter), 0 new failures

## Worktree proof

```
pwd: Bid-Euchre-steward-brws-author-b
branch: ux/hand-result-contrast
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)