### PR TITLE
chore: gitignore Playwright MCP artifacts directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,6 +203,9 @@ secrets.*
 CLAUDE.local.md
 .claude/settings.local.json
 
+# Playwright MCP artifacts (screenshots, snapshots, console logs)
+.playwright-mcp/
+
 # Autonomous review loop and agent ops runtime state
 # Ignore all runtime contents, but track README.md schema docs in metadata dirs.
 # Git requires un-ignoring parent dirs before un-ignoring children.


### PR DESCRIPTION
## Summary
- Add `.playwright-mcp/` to `.gitignore` to prevent generated artifacts from dirtying worktrees
- Investigated Playwright MCP loading — tools load and work correctly via `.mcp.json`

## Why
The Playwright MCP server (shipped in PRs #2026/#2029) creates a `.playwright-mcp/` directory
containing screenshots, accessibility snapshots, and console logs during browser tool usage.
Without gitignore coverage, these artifacts dirty every lane worktree that exercises MCP
browser tools — which is now every lane in the fleet.

## Investigation Results (#1852)

The task packet asked to diagnose "Playwright MCP tools don't load in Claude Code sessions."
Investigation on `author-b` proves everything works:

| Capability | Status | Evidence |
|-----------|--------|----------|
| Tools appear in ToolSearch | ✅ | All `mcp__playwright__*` in deferred tools list |
| `browser_navigate` | ✅ | Navigated to example.com, got page title |
| `browser_snapshot` | ✅ | Accessibility tree captured |
| `browser_take_screenshot` | ✅ | PNG screenshot with vision confirmed |
| `.mcp.json` location | ✅ | Project root is correct, Claude Code reads it |
| Headless mode | ✅ | Works in tmux without display |

The original issue (#1852) appears resolved by PRs #2026/#2029.
The remaining gap was the missing gitignore entry for MCP output artifacts.

## Repro / Validation
```bash
# In any worktree with .mcp.json:
# 1. Use ToolSearch to fetch mcp__playwright__browser_navigate
# 2. Navigate to any URL
# 3. Verify .playwright-mcp/ is created but ignored by git
git check-ignore .playwright-mcp/  # Should print the path (ignored)
```

## Tests
```bash
make check-quiet  # 10504 passed; 3 pre-existing failures (token_economy, telegram_filter)
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: fix/playwright-mcp-loading
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)