### PR TITLE
fix(web): scope mobile card-help hiding + localStorage fallback

### DIFF
--- a/web/static/game.js
+++ b/web/static/game.js
@@ -210,7 +210,8 @@
         try {
             return localStorage.getItem(TEXT_SIZE_KEY) || 'default';
         } catch (_) {
-            return 'default';
+            // localStorage unavailable — fall back to document state
+            return document.documentElement.getAttribute('data-text-size') || 'default';
         }
     }
 

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1736,9 +1736,10 @@ main {
         font-size: 0.8rem;
     }
 
-    /* Hide Play card button and help text — vestigial after tap-to-play */
+    /* Hide Play card button and help text — vestigial after tap-to-play.
+       Scoped to .card-play-form so moon-exchange guidance stays visible. */
     .btn--play-card,
-    .card-play-help {
+    .card-play-form .card-play-help {
         display: none;
     }
 


### PR DESCRIPTION
## Plan
N/A — convention follow-ups from review coordinator (#2061, #2055)

## Summary
- Scope `.card-play-help` `display:none` on mobile to `.card-play-form` context only, so moon-exchange guidance remains visible
- Fall back to `document.documentElement.getAttribute('data-text-size')` in `getTextSize()` when `localStorage` is unavailable

## Why
1. **#2061:** The mobile media query hid all `.card-play-help` elements, including the moon-exchange selection guidance ("Tap 2 cards to select them, then confirm"). Only the trick-play help text should be hidden (it's vestigial after tap-to-play).
2. **#2055:** When `localStorage` is unavailable (private browsing, storage quota), `getTextSize()` returned `'default'` ignoring the current document attribute. This broke the text-size toggle — it would always think current size is 'default' and try to set 'large', never toggling back.

## Repro / Validation
**Command(s) run:**
```bash
make check-quiet
```

**Config:** N/A
**Seed:** N/A

## Test Criteria
- **Pass condition:** Moon exchange guidance visible on mobile; text-size toggle works without localStorage
- **Verification command:** `grep -n 'card-play-form .card-play-help' web/static/style.css` and `grep -n "getAttribute('data-text-size')" web/static/game.js`
- **Expected result:** Both greps return matches confirming the scoped selector and document fallback

## Tests
- [x] `make check-quiet` — 10744 passed, 3 pre-existing failures (unrelated: test_ops_token_economy, test_telegram_filter)
- Static CSS/JS — no Python unit tests applicable

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         66de146d [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a   33a83b47 [fix/convention-css-js]
```

## Checklist
- [x] No generated artifacts committed
- [x] If behavior changed, tests updated/added to lock it (N/A — CSS/JS convention fixes)
- [x] PR is focused (one concept)

Closes #2061
Closes #2055