### PR TITLE
fix(test): add unit tests for _build_seat_bids and bid_recap partial

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -2325,6 +2325,293 @@ class TestGameTemplateAccessibility:
 # ---------------------------------------------------------------------------
 
 
+class TestBidRecap:
+    """Tests for partials/bid_recap.html — auction result summary bar.
+
+    Follow-up from PR #2017 review finding (issue #2021).
+    Covers: regular suit/high/low bids, moon, loner, sitting-out seat,
+    no-output guard, and seat label rendering.
+    """
+
+    def _render(self, env, **ctx):
+        """Render bid_recap.html with the given context variables."""
+        tmpl = env.get_template("partials/bid_recap.html")
+        return tmpl.render(**ctx)
+
+    # --- Regular bids ---
+
+    def test_regular_suit_bid(self, env):
+        """Regular suit bid shows level + suit symbol."""
+        html = self._render(
+            env,
+            winning_bid=6,
+            bidder_seat=0,
+            bid_type="regular",
+            contract_type="suit",
+            trump="S",
+            sitting_out_seat=None,
+        )
+        assert "bid-recap__level" in html
+        assert ">6<" in html
+        # Spade symbol (♠ = &#9824; or raw unicode)
+        assert "\u2660" in html
+        assert "bid-recap__suit--s" in html
+
+    def test_regular_hearts_bid(self, env):
+        html = self._render(
+            env,
+            winning_bid=7,
+            bidder_seat=1,
+            bid_type="regular",
+            contract_type="suit",
+            trump="H",
+            sitting_out_seat=None,
+        )
+        assert ">7<" in html
+        assert "\u2665" in html  # ♥
+        assert "bid-recap__suit--h" in html
+
+    def test_regular_diamonds_bid(self, env):
+        html = self._render(
+            env,
+            winning_bid=8,
+            bidder_seat=2,
+            bid_type="regular",
+            contract_type="suit",
+            trump="D",
+            sitting_out_seat=None,
+        )
+        assert "\u2666" in html  # ♦
+
+    def test_regular_clubs_bid(self, env):
+        html = self._render(
+            env,
+            winning_bid=9,
+            bidder_seat=3,
+            bid_type="regular",
+            contract_type="suit",
+            trump="C",
+            sitting_out_seat=None,
+        )
+        assert "\u2663" in html  # ♣
+
+    def test_high_contract_no_trump(self, env):
+        """HIGH contract shows level + 'High' text."""
+        html = self._render(
+            env,
+            winning_bid=6,
+            bidder_seat=0,
+            bid_type="regular",
+            contract_type="high",
+            trump=None,
+            sitting_out_seat=None,
+        )
+        assert ">6<" in html
+        assert "bid-recap__no-trump" in html
+        assert "High" in html
+
+    def test_low_contract_no_trump(self, env):
+        """LOW contract shows level + 'Low' text."""
+        html = self._render(
+            env,
+            winning_bid=6,
+            bidder_seat=0,
+            bid_type="regular",
+            contract_type="low",
+            trump=None,
+            sitting_out_seat=None,
+        )
+        assert ">6<" in html
+        assert "bid-recap__no-trump" in html
+        assert "Low" in html
+
+    # --- Moon bids ---
+
+    def test_moon_bid_with_emoji(self, env):
+        """Moon bid shows moon emoji + 'Moon' text."""
+        html = self._render(
+            env,
+            winning_bid=10,
+            bidder_seat=0,
+            bid_type="moon",
+            contract_type="suit",
+            trump="S",
+            sitting_out_seat=None,
+        )
+        assert "bid-recap__type--moon" in html
+        assert "Moon" in html
+        # Moon emoji (🌙 = &#127769;)
+        assert "&#127769;" in html
+        # Moon bids should NOT show the numeric level
+        assert "bid-recap__level" not in html
+
+    def test_moon_bid_with_suit_symbol(self, env):
+        """Moon bid still shows the trump suit symbol."""
+        html = self._render(
+            env,
+            winning_bid=10,
+            bidder_seat=0,
+            bid_type="moon",
+            contract_type="suit",
+            trump="H",
+            sitting_out_seat=None,
+        )
+        assert "\u2665" in html  # ♥
+
+    # --- Loner bids ---
+
+    def test_loner_bid(self, env):
+        """Loner bid shows card emoji + 'Loner' text."""
+        html = self._render(
+            env,
+            winning_bid=10,
+            bidder_seat=0,
+            bid_type="loner",
+            contract_type="suit",
+            trump="S",
+            sitting_out_seat=2,
+        )
+        assert "bid-recap__type--loner" in html
+        assert "Loner" in html
+        # Playing card emoji (🃏 = &#127183;)
+        assert "&#127183;" in html
+
+    def test_loner_shows_sitting_out(self, env):
+        """Loner bid shows which seat is sitting out."""
+        html = self._render(
+            env,
+            winning_bid=10,
+            bidder_seat=0,
+            bid_type="loner",
+            contract_type="suit",
+            trump="S",
+            sitting_out_seat=2,
+        )
+        assert "bid-recap__sitting-out" in html
+        assert "AI Partner" in html
+        assert "sits out" in html
+
+    def test_loner_sitting_out_seat_labels(self, env):
+        """Sitting-out uses correct seat labels for each seat."""
+        for seat, label in [
+            (0, "You"),
+            (1, "AI Left"),
+            (2, "AI Partner"),
+            (3, "AI Right"),
+        ]:
+            html = self._render(
+                env,
+                winning_bid=10,
+                bidder_seat=1,
+                bid_type="loner",
+                contract_type="suit",
+                trump="S",
+                sitting_out_seat=seat,
+            )
+            assert label in html
+
+    # --- No-output guards ---
+
+    def test_no_output_without_winning_bid(self, env):
+        """No bid-recap div when winning_bid is None."""
+        html = self._render(
+            env,
+            winning_bid=None,
+            bidder_seat=0,
+            bid_type="regular",
+            contract_type="suit",
+            trump="S",
+            sitting_out_seat=None,
+        )
+        assert "bid-recap" not in html
+
+    def test_no_output_without_bidder_seat(self, env):
+        """No bid-recap div when bidder_seat is None."""
+        html = self._render(
+            env,
+            winning_bid=6,
+            bidder_seat=None,
+            bid_type="regular",
+            contract_type="suit",
+            trump="S",
+            sitting_out_seat=None,
+        )
+        assert "bid-recap" not in html
+
+    def test_no_sitting_out_for_regular_bid(self, env):
+        """Regular bids with sitting_out_seat=None show no sits-out text."""
+        html = self._render(
+            env,
+            winning_bid=6,
+            bidder_seat=0,
+            bid_type="regular",
+            contract_type="suit",
+            trump="S",
+            sitting_out_seat=None,
+        )
+        assert "bid-recap__sitting-out" not in html
+        assert "sits out" not in html
+
+    # --- Seat labels ---
+
+    def test_seat_labels_correct(self, env):
+        """Declarer label matches the seat label mapping."""
+        labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"}
+        for seat, expected_label in labels.items():
+            html = self._render(
+                env,
+                winning_bid=6,
+                bidder_seat=seat,
+                bid_type="regular",
+                contract_type="suit",
+                trump="S",
+                sitting_out_seat=None,
+            )
+            assert expected_label in html
+
+    # --- Accessibility ---
+
+    def test_has_role_status(self, env):
+        """Bid recap bar has role=status for screen readers."""
+        html = self._render(
+            env,
+            winning_bid=6,
+            bidder_seat=0,
+            bid_type="regular",
+            contract_type="suit",
+            trump="S",
+            sitting_out_seat=None,
+        )
+        assert 'role="status"' in html
+        assert 'aria-label="Auction result"' in html
+
+    def test_moon_has_aria_label(self, env):
+        """Moon type span has an aria-label."""
+        html = self._render(
+            env,
+            winning_bid=10,
+            bidder_seat=0,
+            bid_type="moon",
+            contract_type="suit",
+            trump="S",
+            sitting_out_seat=None,
+        )
+        assert 'aria-label="Moon bid"' in html
+
+    def test_loner_has_aria_label(self, env):
+        """Loner type span has an aria-label."""
+        html = self._render(
+            env,
+            winning_bid=10,
+            bidder_seat=0,
+            bid_type="loner",
+            contract_type="suit",
+            trump="S",
+            sitting_out_seat=2,
+        )
+        assert 'aria-label="Loner bid"' in html
+
+
 class TestTrickHistory:
     """Tests for the collapsible trick history partial."""
 

--- a/tests/unit/hosted_play/test_seat_bids.py
+++ b/tests/unit/hosted_play/test_seat_bids.py
@@ -1,0 +1,161 @@
+"""Unit tests for _build_seat_bids() in web/routes.py.
+
+Covers every rendering branch: pass, moon, loner, suit contracts (with symbol),
+HIGH, LOW, missing seat entries, and last-bid-wins semantics.
+
+Follow-up from PR #2040 review finding (issue #2053).
+"""
+
+from __future__ import annotations
+
+from web.routes import _build_seat_bids
+
+
+class TestBuildSeatBidsPass:
+    """Pass action renders as 'Pass'."""
+
+    def test_single_pass(self):
+        auction = [{"seat": 0, "action": "pass"}]
+        assert _build_seat_bids(auction) == {0: "Pass"}
+
+    def test_all_pass(self):
+        auction = [{"seat": s, "action": "pass"} for s in range(4)]
+        assert _build_seat_bids(auction) == {0: "Pass", 1: "Pass", 2: "Pass", 3: "Pass"}
+
+
+class TestBuildSeatBidsMoon:
+    """Moon bids render as 'Moon'."""
+
+    def test_moon_bid(self):
+        auction = [
+            {"seat": 0, "action": "bid", "bid_type": "moon", "n": 10, "contract": "S"},
+        ]
+        assert _build_seat_bids(auction) == {0: "Moon"}
+
+    def test_moon_overrides_earlier_regular(self):
+        auction = [
+            {
+                "seat": 0,
+                "action": "bid",
+                "bid_type": "regular",
+                "n": 6,
+                "contract": "S",
+            },
+            {"seat": 0, "action": "bid", "bid_type": "moon", "n": 10, "contract": "S"},
+        ]
+        assert _build_seat_bids(auction) == {0: "Moon"}
+
+
+class TestBuildSeatBidsLoner:
+    """Loner bids render as 'Loner'."""
+
+    def test_loner_bid(self):
+        auction = [
+            {"seat": 1, "action": "bid", "bid_type": "loner", "n": 10, "contract": "H"},
+        ]
+        assert _build_seat_bids(auction) == {1: "Loner"}
+
+
+class TestBuildSeatBidsSuitContract:
+    """Suit-contract regular bids render with suit symbol."""
+
+    def test_spades(self):
+        auction = [{"seat": 0, "action": "bid", "n": 6, "contract": "S"}]
+        result = _build_seat_bids(auction)
+        assert result == {0: "6\u2660"}  # 6♠
+
+    def test_hearts(self):
+        auction = [{"seat": 1, "action": "bid", "n": 7, "contract": "H"}]
+        result = _build_seat_bids(auction)
+        assert result == {1: "7\u2665"}  # 7♥
+
+    def test_diamonds(self):
+        auction = [{"seat": 2, "action": "bid", "n": 8, "contract": "D"}]
+        result = _build_seat_bids(auction)
+        assert result == {2: "8\u2666"}  # 8♦
+
+    def test_clubs(self):
+        auction = [{"seat": 3, "action": "bid", "n": 9, "contract": "C"}]
+        result = _build_seat_bids(auction)
+        assert result == {3: "9\u2663"}  # 9♣
+
+
+class TestBuildSeatBidsHighLow:
+    """HIGH and LOW contracts render as 'Hi' and 'Lo'."""
+
+    def test_high_contract(self):
+        auction = [{"seat": 0, "action": "bid", "n": 6, "contract": "HIGH"}]
+        assert _build_seat_bids(auction) == {0: "6 Hi"}
+
+    def test_low_contract(self):
+        auction = [{"seat": 0, "action": "bid", "n": 6, "contract": "LOW"}]
+        assert _build_seat_bids(auction) == {0: "6 Lo"}
+
+
+class TestBuildSeatBidsEdgeCases:
+    """Edge cases: empty auction, missing seat, last-bid-wins."""
+
+    def test_empty_auction(self):
+        assert _build_seat_bids([]) == {}
+
+    def test_entry_without_seat_is_skipped(self):
+        auction = [{"action": "pass"}]
+        assert _build_seat_bids(auction) == {}
+
+    def test_seat_none_is_skipped(self):
+        auction = [{"seat": None, "action": "pass"}]
+        assert _build_seat_bids(auction) == {}
+
+    def test_last_bid_wins_for_same_seat(self):
+        """When a seat bids multiple times, the most recent entry wins."""
+        auction = [
+            {"seat": 0, "action": "bid", "n": 6, "contract": "S"},
+            {"seat": 0, "action": "bid", "n": 7, "contract": "H"},
+        ]
+        result = _build_seat_bids(auction)
+        assert result == {0: "7\u2665"}  # last bid: 7♥
+
+    def test_pass_overwrites_earlier_bid(self):
+        """A later pass overwrites an earlier bid for the same seat."""
+        auction = [
+            {"seat": 0, "action": "bid", "n": 6, "contract": "S"},
+            {"seat": 0, "action": "pass"},
+        ]
+        assert _build_seat_bids(auction) == {0: "Pass"}
+
+
+class TestBuildSeatBidsMultiSeat:
+    """Multi-seat auction with mixed bid types."""
+
+    def test_mixed_auction(self):
+        auction = [
+            {"seat": 0, "action": "bid", "n": 6, "contract": "S"},
+            {"seat": 1, "action": "pass"},
+            {"seat": 2, "action": "bid", "n": 7, "contract": "HIGH"},
+            {"seat": 3, "action": "bid", "bid_type": "moon", "n": 10, "contract": "H"},
+        ]
+        result = _build_seat_bids(auction)
+        assert result == {
+            0: "6\u2660",  # 6♠
+            1: "Pass",
+            2: "7 Hi",
+            3: "Moon",
+        }
+
+    def test_bid_type_defaults_to_regular(self):
+        """Missing bid_type key defaults to 'regular' behavior."""
+        auction = [{"seat": 0, "action": "bid", "n": 6, "contract": "D"}]
+        result = _build_seat_bids(auction)
+        assert result == {0: "6\u2666"}  # 6♦
+
+    def test_unknown_contract_passes_through(self):
+        """Unknown contract string is used as-is (no symbol mapping)."""
+        auction = [{"seat": 0, "action": "bid", "n": 6, "contract": "WEIRD"}]
+        result = _build_seat_bids(auction)
+        assert result == {0: "6WEIRD"}
+
+    def test_seat_as_string_is_coerced(self):
+        """Seat values that come as strings are coerced to int keys."""
+        auction = [{"seat": "2", "action": "pass"}]
+        result = _build_seat_bids(auction)
+        assert result == {2: "Pass"}


### PR DESCRIPTION
## Plan
N/A — follow-up test issues from review findings

## Summary
- Add 20 unit tests for `_build_seat_bids()` route function (new file `test_seat_bids.py`)
- Add 18 template tests for `bid_recap.html` partial (in existing `test_partials.py`)
- Issue #2010 (leaderboard metrics) is already fully addressed by existing code — see note below

## Why
PR #2040 and PR #2017 review findings identified untested behavior (T1 severity).
Each rendering branch of `_build_seat_bids()` and `bid_recap.html` now has
dedicated tests to lock behavior and catch regressions.

## Note on #2010
Issue #2010 requested leaderboard metric definitions, tooltips, formatting, and
a help panel. All four items are already implemented:
- `METRIC_DEFINITIONS` dict in `web/leaderboard.py` with tooltips and categories
- `format_metric()` helper for display formatting (pct, int, float, signed)
- Leaderboard template has "What do these stats mean?" help panel
- Ranking explanation: "Ranked by Net EPPD — your average point advantage per hand."
- Existing tests in `test_leaderboard.py` cover all of the above

Recommend closing #2010 as already implemented.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_seat_bids.py -v
uv run python -m pytest tests/unit/hosted_play/test_partials.py::TestBidRecap -v
```

## Test Criteria
- **Pass condition:** All 20 seat-bid tests and 18 bid-recap tests pass
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_seat_bids.py tests/unit/hosted_play/test_partials.py::TestBidRecap -v`
- **Expected result:** 38 passed, 0 failed

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_seat_bids.py -v` — 20 passed
- [x] `uv run python -m pytest tests/unit/hosted_play/test_partials.py::TestBidRecap -v` — 18 passed
- [x] `make check` — passed (3 pre-existing failures in unrelated files: test_ops_token_economy.py, test_telegram_filter.py)

## Expected impact
- Metrics impact: None (test-only)
- Runtime impact: None (test-only)

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b
```

`git worktree list` (relevant line):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b  32d34f58 [fix/test-follow-ups-and-metrics]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

Closes #2053
Closes #2021