### PR TITLE
fix(web): convention fixes — bid recap, exchange logging, RULES.md

### DIFF
--- a/docs/01_core/RULES.md
+++ b/docs/01_core/RULES.md
@@ -112,7 +112,7 @@ A bid is a tuple:
 - `bid_type`: one of `{"regular", "moon", "loner"}` (default `"regular"`)
 
 Where:
-- `tricks_bid = 0` means **PASS** (and `contract_type`/`trump`/`bid_type` are null).
+- `tricks_bid = 0` means **PASS** (`contract_type` and `trump` are null; `bid_type` defaults to `"regular"`).
 - A **bid** must have `tricks_bid >= 1`.
 - If `contract_type = "suit"`, `trump` must be provided.
 - If `contract_type ∈ {"high", "low"}`, `trump` must be null.

--- a/web/routes.py
+++ b/web/routes.py
@@ -1204,6 +1204,16 @@ async def next_step(
             return HTMLResponse(_render_game_board(request, engine, state, link_uuid))
 
         hand_row = _ensure_hand_row(session, match_row, hand, hand.deal_id)
+
+        # Log AI decisions captured during exchange-reveal auto-advance
+        _log_ai_decisions_after_advance(
+            session,
+            match_row,
+            hand_row,
+            engine,
+            state,
+        )
+
         hand_row.hand_state_json = json.dumps(hand.to_dict())
         _update_match_row(match_row, state)
         session.commit()
@@ -1250,6 +1260,16 @@ async def submit_exchange(
         state = engine.submit_exchange_selection(state, [card_index_0, card_index_1])
 
         hand_row = _ensure_hand_row(session, match_row, hand, hand.deal_id)
+
+        # Log AI decisions captured during exchange auto-advance
+        _log_ai_decisions_after_advance(
+            session,
+            match_row,
+            hand_row,
+            engine,
+            state,
+        )
+
         hand_row.hand_state_json = json.dumps(hand.to_dict())
         _update_match_row(match_row, state)
         session.commit()

--- a/web/templates/partials/bid_recap.html
+++ b/web/templates/partials/bid_recap.html
@@ -8,7 +8,7 @@
      - bid_type: str — "regular", "moon", or "loner"
      - contract_type: str | None — "suit", "high", or "low"
      - trump: str | None — trump suit letter if contract_type == "suit"
-     - sitting_out_seat: int | None — seat sitting out (loner bids)
+     - sitting_out_seat: int | None — seat sitting out (moon and loner bids)
 #}
 {% set suit_symbols = {"S": "\u2660", "H": "\u2665", "D": "\u2666", "C": "\u2663"} %}
 {% set seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"} %}
@@ -42,6 +42,7 @@
             <span class="bid-recap__no-trump">Low</span>
         {% endif %}
     </span>
+    {# Use "is not none" (not truthy) — seat 0 is the human and is valid. #}
     {% if sitting_out_seat is not none %}
     <span class="bid-recap__sitting-out" aria-label="Sitting out: {{ seat_labels.get(sitting_out_seat, 'Seat ' ~ sitting_out_seat) }}">
         ({{ seat_labels.get(sitting_out_seat, "Seat " ~ sitting_out_seat) }} sits out)


### PR DESCRIPTION
## Summary

- **#2019 — bid_recap.html**: Update template comment to include moon bids (was loner-only); add guard comment explaining `is not none` idiom preserves seat 0
- **#2000 — routes.py**: Add `_log_ai_decisions_after_advance()` calls in `submit_exchange` and `advance_next` route handlers — AI decisions from exchange auto-advance were silently dropped
- **#2002 — RULES.md line 115**: Fix PASS `bid_type` from "null" to `"regular"` to match `BidAction.pass_bid()` code enforcement

## Why

Review coordinator follow-ups from PRs #2017, #1999, and #2001. The exchange logging gap meant AI card-play decisions during moon exchange auto-advance were never persisted to the decision table.

## Scope Note

Declared scope was `bid_recap.html`, `engine.py`, `RULES.md`. The actual fix for #2000 (AI decision logging) lives in `routes.py` (where `_log_ai_decisions_after_advance` is called), not `engine.py` (which already correctly populates `last_ai_events`). Minor scope expansion — `engine.py` unchanged.

**Skipped #2002 line 192** (moon → 4-player trick play): Both `simulation.py` (`players_per_trick = 3`) and `engine.py` (`sitting_out_seat` set for moon) use 3-player trick play for moon. Changing the docs would contradict the code. Filed as questionable finding.

## Repro / Validation

```bash
# Tier 1 — impacted tests
uv run python -m pytest tests/unit/hosted_play/test_engine.py -q   # 91 passed
uv run python -m pytest tests/unit/hosted_play/test_routes.py -q   # 63 passed, 2 skipped

# Tier 2 — full validation
make check-quiet  # 10744 passed, 3 pre-existing failures (token economy, telegram filter)
```

## Tests

- [x] `tests/unit/hosted_play/test_engine.py` — 91 passed
- [x] `tests/unit/hosted_play/test_routes.py` — 63 passed, 2 skipped
- [x] `make check-quiet` — 3 pre-existing failures confirmed on main

## Test Criteria

1. `bid_recap.html` comment correctly mentions "moon and loner bids" (not just loner)
2. `bid_recap.html` has guard comment explaining `is not none` preserves seat 0
3. `submit_exchange` route handler calls `_log_ai_decisions_after_advance()` after `engine.submit_exchange_selection()`
4. `advance_next` route handler calls `_log_ai_decisions_after_advance()` after `engine.advance_after_exchange_reveal()`
5. RULES.md PASS bid_type says `"regular"` (not null), matching `BidAction.pass_bid()`

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
branch: fix/convention-engine
```

Closes #2019, closes #2000, partially addresses #2002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)