### PR TITLE
fix(web): deduplicate bid parsing + close stale convention issues

### DIFF
--- a/tests/e2e/hosted_play/conftest.py
+++ b/tests/e2e/hosted_play/conftest.py
@@ -22,6 +22,7 @@ from bid_euchre.hosted_play.engine import (
 from bid_euchre.hosted_play.state import MatchState
 from bid_euchre.strategy.base import Strategy
 from bid_euchre.strategy.bidding import BidAction, BiddingObservation, BiddingPolicy
+from web.routes import _build_seat_bids
 
 # ---------------------------------------------------------------------------
 # Deterministic AI stubs
@@ -250,37 +251,8 @@ def build_visible_context(
         ctx["opp_right_count"] = len(hand.hands[3]) if len(hand.hands) > 3 else 0
         ctx["action_rail"] = []
         # Build seat → bid text mapping for inline bid display
-        auction = visible.get("auction", [])
-        seat_bids: dict[int, str] = {}
-        for entry in auction:
-            s = entry.get("seat")
-            if s is None:
-                continue
-            s = int(s)
-            if entry.get("action") == "pass":
-                seat_bids[s] = "Pass"
-            else:
-                bt = entry.get("bid_type", "regular")
-                if bt == "moon":
-                    seat_bids[s] = "Moon"
-                elif bt == "loner":
-                    seat_bids[s] = "Loner"
-                else:
-                    n = entry.get("n", 0)
-                    c = entry.get("contract", "")
-                    sym_map = {
-                        "S": "\u2660",
-                        "H": "\u2665",
-                        "D": "\u2666",
-                        "C": "\u2663",
-                    }
-                    if c == "HIGH":
-                        seat_bids[s] = f"{n} Hi"
-                    elif c == "LOW":
-                        seat_bids[s] = f"{n} Lo"
-                    else:
-                        seat_bids[s] = f"{n}{sym_map.get(str(c), str(c))}"
-        ctx["seat_bids"] = seat_bids
+        # Uses the canonical parser from web/routes.py to avoid drift.
+        ctx["seat_bids"] = _build_seat_bids(visible.get("auction", []))
     else:
         ctx["winning_bid"] = None
         ctx["bidder_seat"] = None


### PR DESCRIPTION
## Plan
N/A — convention follow-up batch (issues #1988, #1995, #2054)

## Summary
- Deduplicate bid-to-text parsing in e2e conftest by importing `_build_seat_bids()` from `web/routes.py` instead of inlining a near-duplicate copy
- Close #1988 (already fixed by PR #1991 — truncation raised to 4096)
- Close #1995 (review finding explicitly found no regression — no-op)

## Why
The inline bid parsing in `tests/e2e/hosted_play/conftest.py` near-duplicated `_build_seat_bids()` from `web/routes.py`. If the display format changed in routes, the conftest copy would silently drift.

Closes #2054

## Repro / Validation
**Command(s) run:**
```
uv run python -m pytest tests/e2e/hosted_play/ -x -q  # 21 passed
uv run python -m pytest tests/ -k "route" -x -q       # 92 passed, 2 skipped
```

## Test Criteria
- **Pass condition:** conftest.py imports `_build_seat_bids` from `web.routes` and no longer contains inline bid parsing logic
- **Verification command:** `grep -c _build_seat_bids tests/e2e/hosted_play/conftest.py`
- **Expected result:** `2` (one import, one usage)

## Tests
- [x] `uv run python -m pytest tests/e2e/hosted_play/ -x -q` — 21 passed
- [x] `uv run python -m pytest tests/ -k "route" -x -q` — 92 passed

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b  701d865a [fix/convention-ops-batch]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

## Validation note
3 pre-existing test failures on main (unrelated to this PR):
- `test_ops_token_economy.py` — mock assertion count mismatch
- `test_telegram_filter.py` — edge case with empty dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)