### PR TITLE
fix(web): convention fixes — cookie backfill, HTMX error swap, pct rounding (#2056, #2038, #2018)

### DIFF
--- a/tests/unit/hosted_play/test_app.py
+++ b/tests/unit/hosted_play/test_app.py
@@ -142,3 +142,11 @@ class TestRouterInclusion:
         with TestClient(app) as client:
             resp = client.get("/nonexistent")
             assert resp.status_code == 404
+
+    def test_htmx_404_returns_200_for_swap(self, tmp_path):
+        """HTMX 1.x ignores non-2xx; error partials must return 200."""
+        app = _make_app(tmp_path)
+        with TestClient(app) as client:
+            resp = client.get("/nonexistent", headers={"HX-Request": "true"})
+            assert resp.status_code == 200
+            assert "htmx-error" in resp.text

--- a/tests/unit/hosted_play/test_error_handling.py
+++ b/tests/unit/hosted_play/test_error_handling.py
@@ -83,34 +83,38 @@ class TestHTMXErrorResponses:
         assert "Hand Not Found" in resp.text
 
     def test_404_partial_for_htmx(self, client):
-        """HTMX 404 returns inline error partial (no DOCTYPE)."""
+        """HTMX 404 returns inline error partial with 200 status.
+
+        HTMX 1.x ignores non-2xx responses by default, so error partials
+        are returned with 200 to ensure the swap occurs.
+        """
         resp = client.get(
             "/nonexistent-page",
             headers={"HX-Request": "true"},
         )
-        assert resp.status_code == 404
+        assert resp.status_code == 200
         assert "<!DOCTYPE html>" not in resp.text
         assert "htmx-error" in resp.text
         assert "Back to Table" in resp.text
 
     def test_404_htmx_game_not_found(self, client):
-        """HTMX request for invalid game link returns inline error."""
+        """HTMX request for invalid game link returns inline error (200)."""
         fake_uuid = str(uuid.uuid4())
         resp = client.get(
             f"/play/{fake_uuid}",
             headers={"HX-Request": "true"},
         )
-        assert resp.status_code == 404
+        assert resp.status_code == 200
         assert "htmx-error" in resp.text
 
     def test_404_htmx_includes_detail(self, client):
-        """HTMX 404 includes the error detail message."""
+        """HTMX 404 includes the error detail message (200 for swap)."""
         fake_uuid = str(uuid.uuid4())
         resp = client.get(
             f"/play/{fake_uuid}",
             headers={"HX-Request": "true"},
         )
-        assert resp.status_code == 404
+        assert resp.status_code == 200
         assert "Game not found" in resp.text or "Not found" in resp.text
 
     def test_htmx_error_has_aria_alert(self, client):

--- a/tests/unit/hosted_play/test_leaderboard.py
+++ b/tests/unit/hosted_play/test_leaderboard.py
@@ -688,6 +688,23 @@ class TestFormatMetric:
         assert format_metric(0.666, "pct") == "67%"
         assert format_metric(0.334, "pct") == "33%"
 
+    def test_pct_avoids_false_zero(self):
+        """Non-zero rates should never display as '0%'."""
+        assert format_metric(0.004, "pct") == "<1%"
+        assert format_metric(0.001, "pct") == "<1%"
+        assert format_metric(0.009, "pct") == "<1%"
+
+    def test_pct_avoids_false_hundred(self):
+        """Non-perfect rates should never display as '100%'."""
+        assert format_metric(0.996, "pct") == ">99%"
+        assert format_metric(0.999, "pct") == ">99%"
+        assert format_metric(0.995, "pct") == ">99%"
+
+    def test_pct_boundary_values(self):
+        """Values at exactly 1% and 99% use normal rounding."""
+        assert format_metric(0.01, "pct") == "1%"
+        assert format_metric(0.99, "pct") == "99%"
+
     def test_int_formats_as_integer(self):
         assert format_metric(5, "int") == "5"
         assert format_metric(0, "int") == "0"

--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -1108,6 +1108,19 @@ class TestXSSPrevention:
         assert '<img src=x onerror="alert(1)">' not in resp.text
         assert "&lt;img" in resp.text
 
+    def test_game_page_backfills_player_cookie(self, client):
+        """Visiting /play/{link_uuid} directly should set the session cookie
+        so reconnect works on subsequent landing-page visits."""
+        from web.middleware import PLAYER_COOKIE_NAME
+
+        link_uuid = _create_game(client)
+        # Clear cookies to simulate a direct visit (bookmark/shared link)
+        client.cookies.clear()
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        # The response should set the player cookie
+        assert PLAYER_COOKIE_NAME in resp.cookies
+
     def test_game_page_includes_ai_hand_counts_for_accessibility(self, client):
         """Initial GET render should expose AI hand-count labels to screen readers."""
         link_uuid = _setup_game(client)

--- a/web/app.py
+++ b/web/app.py
@@ -180,14 +180,19 @@ def create_app(config: HostedPlayConfig | None = None) -> FastAPI:
 
     @app.exception_handler(404)
     async def not_found_handler(request: Request, exc: HTTPException) -> HTMLResponse:
-        """Render game-themed 404 page (partial for HTMX, full for browser)."""
+        """Render game-themed 404 page (partial for HTMX, full for browser).
+
+        HTMX 1.x ignores non-2xx responses by default, so HTMX partials
+        are returned with status 200 to ensure the swap occurs.  The error
+        content itself conveys the problem to the user.
+        """
         if _is_htmx(request):
             detail = getattr(exc, "detail", "Not found")
             return HTMLResponse(
                 _error_templates.get_template("errors/htmx_error.html").render(
                     {"request": request, "status_code": 404, "message": str(detail)}
                 ),
-                status_code=404,
+                status_code=200,
             )
         return HTMLResponse(
             _error_templates.get_template("errors/404.html").render(
@@ -198,7 +203,11 @@ def create_app(config: HostedPlayConfig | None = None) -> FastAPI:
 
     @app.exception_handler(500)
     async def server_error_handler(request: Request, exc: Exception) -> HTMLResponse:
-        """Render game-themed 500 page (partial for HTMX, full for browser)."""
+        """Render game-themed 500 page (partial for HTMX, full for browser).
+
+        HTMX 1.x ignores non-2xx responses by default, so HTMX partials
+        are returned with status 200 to ensure the swap occurs.
+        """
         logger.exception("Unhandled server error on %s %s", request.method, request.url)
         if _is_htmx(request):
             return HTMLResponse(
@@ -209,7 +218,7 @@ def create_app(config: HostedPlayConfig | None = None) -> FastAPI:
                         "message": "Something went wrong. Please try again.",
                     }
                 ),
-                status_code=500,
+                status_code=200,
             )
         return HTMLResponse(
             _error_templates.get_template("errors/500.html").render(

--- a/web/leaderboard.py
+++ b/web/leaderboard.py
@@ -148,7 +148,18 @@ def format_metric(value: int | float, fmt: str) -> str:
     - ``"signed_float3"`` — three decimals with +/- sign → ``"+1.234"``
     """
     if fmt == "pct":
-        return f"{value * 100:.0f}%"
+        # Avoid displaying non-perfect rates as 0% or 100%.
+        # Only exact 0.0 should show "0%" and exact 1.0 should show "100%".
+        if value == 0.0:
+            return "0%"
+        if value == 1.0:
+            return "100%"
+        pct = value * 100
+        if pct < 1:
+            return "<1%"
+        if pct > 99:
+            return ">99%"
+        return f"{pct:.0f}%"
     elif fmt == "int":
         return str(int(value))
     elif fmt == "int_games":

--- a/web/routes.py
+++ b/web/routes.py
@@ -750,15 +750,24 @@ async def game_page(request: Request, link_uuid: str):
         if player is None:
             raise HTTPException(status_code=404, detail="Game not found")
 
+        # Backfill the reconnect cookie so returning visitors see the
+        # reconnect prompt on the landing page even if they arrived here
+        # via a direct link or bookmark (not the invite-code flow).
+        def _with_cookie(resp: HTMLResponse) -> HTMLResponse:
+            set_player_cookie(resp, link_uuid)
+            return resp
+
         # No nickname yet — show nickname prompt
         if not player.nickname:
-            return templates.TemplateResponse(
-                "game.html",
-                {
-                    "request": request,
-                    "phase": "nickname",
-                    "link_uuid": link_uuid,
-                },
+            return _with_cookie(
+                templates.TemplateResponse(
+                    "game.html",
+                    {
+                        "request": request,
+                        "phase": "nickname",
+                        "link_uuid": link_uuid,
+                    },
+                )
             )
 
         # Show the latest match for this player, including completed matches.
@@ -773,16 +782,18 @@ async def game_page(request: Request, link_uuid: str):
             # No usable match — show model selection
             ai_manager = _get_ai_manager(request)
             models = ai_manager.list_available()
-            return templates.TemplateResponse(
-                "game.html",
-                {
-                    "request": request,
-                    "phase": "model_select",
-                    "link_uuid": link_uuid,
-                    "nickname": player.nickname,
-                    "models": models,
-                    "default_model_id": ai_manager.default_model_id,
-                },
+            return _with_cookie(
+                templates.TemplateResponse(
+                    "game.html",
+                    {
+                        "request": request,
+                        "phase": "model_select",
+                        "link_uuid": link_uuid,
+                        "nickname": player.nickname,
+                        "models": models,
+                        "default_model_id": ai_manager.default_model_id,
+                    },
+                )
             )
 
         # Active or completed match — restore current state
@@ -801,21 +812,23 @@ async def game_page(request: Request, link_uuid: str):
             match_row.completed_at = datetime.now(timezone.utc)
             session.commit()
             models = ai_manager.list_available()
-            return templates.TemplateResponse(
-                "game.html",
-                {
-                    "request": request,
-                    "phase": "model_select",
-                    "link_uuid": link_uuid,
-                    "nickname": player.nickname,
-                    "models": models,
-                    "default_model_id": ai_manager.default_model_id,
-                },
+            return _with_cookie(
+                templates.TemplateResponse(
+                    "game.html",
+                    {
+                        "request": request,
+                        "phase": "model_select",
+                        "link_uuid": link_uuid,
+                        "nickname": player.nickname,
+                        "models": models,
+                        "default_model_id": ai_manager.default_model_id,
+                    },
+                )
             )
         ctx = _build_game_context(engine, state, link_uuid)
         ctx["request"] = request
         ctx["nickname"] = player.nickname
-        return templates.TemplateResponse("game.html", ctx)
+        return _with_cookie(templates.TemplateResponse("game.html", ctx))
     finally:
         session.close()
 


### PR DESCRIPTION
## Summary

Three convention follow-ups from review coordinator findings:

- **Cookie backfill (#2056):** Backfill player session cookie on direct `/play/{link_uuid}` visits so the reconnect prompt works for bookmarked/shared links (previously only set during invite-code flow)
- **HTMX error swap (#2038):** Return 200 for HTMX error partials — HTMX 1.x ignores non-2xx responses by default, so 404/500 error content was silently discarded instead of being swapped into the DOM
- **Percentage rounding (#2018):** Avoid rounding non-perfect rates to 0% or 100% in leaderboard — use `<1%` / `>99%` for near-boundary values so players aren't confused by false perfect/zero rates

## Why

Review coordinator flagged these three convention issues across PRs #2051, #2033, and #2016. Bundled as a single PR since all are small, independent fixes in the web layer.

## Repro / Validation

```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/hosted_play/test_routes.py tests/unit/hosted_play/test_app.py tests/unit/hosted_play/test_leaderboard.py tests/unit/hosted_play/test_error_handling.py -x -q

# Tier 2 — full validation
make check-quiet
```

### Test criteria

1. **Cookie backfill:** `test_game_page_backfills_player_cookie` — verifies the `bid_euchre_player` cookie is set when visiting `/play/{uuid}` directly (no prior cookie)
2. **HTMX error swap:** `test_htmx_404_returns_200_for_swap` + updated `test_404_partial_for_htmx` / `test_404_htmx_game_not_found` — all HTMX error responses return 200
3. **Pct rounding:** `test_pct_avoids_false_zero` / `test_pct_avoids_false_hundred` / `test_pct_boundary_values` — near-zero shows `<1%`, near-100 shows `>99%`, exact boundaries work

## Tests

- `tests/unit/hosted_play/test_routes.py` — 65 passed, 2 skipped
- `tests/unit/hosted_play/test_app.py` — 13 passed
- `tests/unit/hosted_play/test_leaderboard.py` — 45 passed
- `tests/unit/hosted_play/test_error_handling.py` — 16 passed

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
branch: fix/convention-routes
```

Closes #2056, closes #2038, closes #2018

🤖 Generated with [Claude Code](https://claude.com/claude-code)