### PR TITLE
fix(ops): add flex-d to lane registry + check-gated Makefile target (#2024, #2048)

### DIFF
--- a/.claude/rules/15_testing_tiers.md
+++ b/.claude/rules/15_testing_tiers.md
@@ -22,7 +22,8 @@ Widen to Tier 2 early if you changed:
 
 Run full validation **once** before opening the PR:
 
-    make check-quiet    # Minimal output, logs to tmpfile
+    make check-gated    # Preferred for fleet runs (caps to 3 concurrent)
+    make check-quiet    # Minimal output, logs to tmpfile (no concurrency cap)
     make check          # Full output (for debugging)
 
 ## After Review Fixes

--- a/.claude/rules/75_worktree_protection.md
+++ b/.claude/rules/75_worktree_protection.md
@@ -30,6 +30,7 @@ These worktrees are permanent and must not be deleted:
 - `Bid-Euchre-steward-flex-b`
 - `Bid-Euchre-steward-flex-c`
 - `Bid-Euchre-steward-flex-d`
+- `Bid-Euchre-steward-flex-d`
 
 **Control plane:**
 - `Bid-Euchre-steward-review`

--- a/.claude/skills/start-task/SKILL.md
+++ b/.claude/skills/start-task/SKILL.md
@@ -108,7 +108,7 @@ decomposition (use `/executing-plans` for that).
    implementation window:
    ```bash
    git fetch origin main && git rebase origin/main
-   make check-quiet   # Re-validate after rebase
+   make check-gated   # Re-validate after rebase (concurrency-safe)
    gh pr create ...
    ```
 

--- a/.claude/skills/validating-changes/SKILL.md
+++ b/.claude/skills/validating-changes/SKILL.md
@@ -37,7 +37,8 @@ Skip straight to `make check` if you changed:
 Run full validation **once** before opening the PR:
 
 ```bash
-make check-quiet    # Minimal output, logs to tmpfile (preferred)
+make check-gated    # Preferred for fleet runs — caps concurrent validation to 3 lanes
+make check-quiet    # Minimal output, logs to tmpfile (no concurrency cap)
 make check          # Full output (use when debugging failures)
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help sync ensure-venv repo-lint lint test check check-quiet notebook-sync notebook-check notebook-run notebook-run-full notebook-run-arc-d review-smoke review-quick review-full promotion-gate bid-train-teachers bid-eval-tiny bid-loop bidless-diagnostics docs-check browser-smoke
+.PHONY: help sync ensure-venv repo-lint lint test check check-quiet check-gated notebook-sync notebook-check notebook-run notebook-run-full notebook-run-arc-d review-smoke review-quick review-full promotion-gate bid-train-teachers bid-eval-tiny bid-loop bidless-diagnostics docs-check browser-smoke
 .DEFAULT_GOAL := help
 
 PYTHON ?= uv run python
@@ -20,6 +20,7 @@ help:
 	@echo "Gold path targets:"
 	@echo "  make check              - repo-lint + ruff + tests"
 	@echo "  make check-quiet        - full check, minimal output (logs to tmpfile)"
+	@echo "  make check-gated        - check-quiet with concurrency cap (max 3 lanes)"
 	@echo "  make repo-lint          - repo linter (diff vs origin/main)"
 	@echo "  make lint               - ruff check ."
 	@echo "  make test               - pytest fast suite"
@@ -77,6 +78,30 @@ check-quiet:
 		grep -n -i -A 3 'FAILED\|ERROR\|error:\|failed' "$$CHECK_LOG" | head -40; \
 		exit 1; \
 	fi
+
+# --- Gated check (caps concurrent make check across lanes) ---
+CHECK_SEMAPHORE_DIR ?= /tmp/make-check-slots
+MAX_CHECK_CONCURRENT ?= 3
+
+check-gated:
+	@mkdir -p $(CHECK_SEMAPHORE_DIR); \
+	SLOT_FILE=$(CHECK_SEMAPHORE_DIR)/$$$$; \
+	WAIT_COUNT=0; \
+	while [ $$(ls $(CHECK_SEMAPHORE_DIR)/ 2>/dev/null | wc -l | tr -d ' ') -ge $(MAX_CHECK_CONCURRENT) ]; do \
+		if [ $$WAIT_COUNT -eq 0 ]; then \
+			echo ">>> Waiting for validation slot ($$(ls $(CHECK_SEMAPHORE_DIR)/ | wc -l | tr -d ' ')/$(MAX_CHECK_CONCURRENT) in use)..."; \
+		fi; \
+		WAIT_COUNT=$$((WAIT_COUNT + 1)); \
+		sleep $$(( (RANDOM % 10) + 5 )); \
+	done; \
+	if [ $$WAIT_COUNT -gt 0 ]; then \
+		echo ">>> Slot acquired after ~$$((WAIT_COUNT * 7))s wait"; \
+	fi; \
+	touch "$$SLOT_FILE"; \
+	EXIT_CODE=0; \
+	$(MAKE) check-quiet || EXIT_CODE=$$?; \
+	rm -f "$$SLOT_FILE"; \
+	exit $$EXIT_CODE
 
 notebook-sync:
 	@echo ">>> Jupytext sync (notebooks)"

--- a/src/bid_euchre/ops/monitor.py
+++ b/src/bid_euchre/ops/monitor.py
@@ -1157,6 +1157,7 @@ _CHECKABLE_LANES: tuple[str, ...] = (
     "flex-a",
     "flex-b",
     "flex-c",
+    "flex-d",
 )
 
 

--- a/src/bid_euchre/ops/recovery.py
+++ b/src/bid_euchre/ops/recovery.py
@@ -343,6 +343,7 @@ PERSISTENT_LANES: tuple[str, ...] = (
     "flex-a",
     "flex-b",
     "flex-c",
+    "flex-d",
 )
 
 # Default retry cap per task

--- a/src/bid_euchre/ops/task_queue.py
+++ b/src/bid_euchre/ops/task_queue.py
@@ -78,6 +78,7 @@ KNOWN_AUTHOR_LANES = frozenset(
         "flex-a",
         "flex-b",
         "flex-c",
+        "flex-d",
     }
 )
 

--- a/src/bid_euchre/ops/token_economy.py
+++ b/src/bid_euchre/ops/token_economy.py
@@ -931,6 +931,7 @@ _WORKTREE_TO_LANE: dict[str, str] = {
     "Bid-Euchre-steward-flex-a": "flex-a",
     "Bid-Euchre-steward-flex-b": "flex-b",
     "Bid-Euchre-steward-flex-c": "flex-c",
+    "Bid-Euchre-steward-flex-d": "flex-d",
     # Control plane
     "Bid-Euchre-steward-review": "review",
     "Bid-Euchre-steward-ops": "ops",

--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -100,6 +100,7 @@ LANE_DOMAINS: dict[str, str | None] = {
     "flex-a": None,
     "flex-b": None,
     "flex-c": None,
+    "flex-d": None,
 }
 
 

--- a/src/bid_euchre/ops/worktrees.py
+++ b/src/bid_euchre/ops/worktrees.py
@@ -43,6 +43,7 @@ PROTECTED_WORKTREE_NAMES = frozenset(
         "Bid-Euchre-steward-flex-a",
         "Bid-Euchre-steward-flex-b",
         "Bid-Euchre-steward-flex-c",
+        "Bid-Euchre-steward-flex-d",
         # Control plane
         "Bid-Euchre-steward-review",
         "Bid-Euchre-steward-ops",
@@ -908,6 +909,7 @@ _STEWARD_DIR_TO_LANE: dict[str, str] = {
     "Bid-Euchre-steward-flex-a": "flex-a",
     "Bid-Euchre-steward-flex-b": "flex-b",
     "Bid-Euchre-steward-flex-c": "flex-c",
+    "Bid-Euchre-steward-flex-d": "flex-d",
     "Bid-Euchre-steward-review": "review",
     "Bid-Euchre-steward-ops": "ops",
     # Legacy (retired from active layout, kept for derivation)

--- a/tests/unit/test_ops_token_economy.py
+++ b/tests/unit/test_ops_token_economy.py
@@ -560,6 +560,7 @@ class TestInferLaneFromPath:
             "flex-a",
             "flex-b",
             "flex-c",
+            "flex-d",
             "review",
             "ops",
             # Legacy (retired but still in mapping for attribution)

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -160,7 +160,7 @@ class TestConstants:
         assert "analyst-a" in lanes
         assert "brws-author-a" in lanes
         assert "flex-a" in lanes
-        assert len(lanes) == 15
+        assert len(lanes) == 16
 
 
 class TestResolveAgentName:
@@ -865,6 +865,7 @@ class TestLaneExpansion:
         # Flex pool
         assert "flex-a" in KNOWN_AUTHOR_LANES
         assert "flex-c" in KNOWN_AUTHOR_LANES
+        assert "flex-d" in KNOWN_AUTHOR_LANES
         # Platform pool
         assert "author-a" in KNOWN_AUTHOR_LANES
         assert "author-d" in KNOWN_AUTHOR_LANES
@@ -885,6 +886,7 @@ class TestLaneExpansion:
         assert get_lane_domain("flex-a") is None
         assert get_lane_domain("flex-b") is None
         assert get_lane_domain("flex-c") is None
+        assert get_lane_domain("flex-d") is None
 
     def test_persistent_lanes_include_new_pools(self) -> None:
         from bid_euchre.ops.recovery import PERSISTENT_LANES


### PR DESCRIPTION
## Plan
N/A — two targeted ops fixes from issue backlog.

## Summary
- Register `flex-d` in all lane registries so the orchestrator can dispatch work to it (#2024)
- Add `make check-gated` Makefile target with file-based semaphore to cap concurrent `make check` to 3 lanes (#2048)

## Why
- `flex-d` exists as a worktree and is listed in worktree protection rules, but was missing from `KNOWN_AUTHOR_LANES` and related registries, so `--owner flex-d` failed at dispatch time.
- Fleet CPU oversubscription: when 6-10 lanes hit `make check` simultaneously, the system thrashes (load avg ~81 on 10 cores). The semaphore caps concurrent validation to 3.

## Repro / Validation
**Command(s) run:**
```bash
# Verify flex-d registration
uv run python -c "from bid_euchre.ops.task_queue import KNOWN_AUTHOR_LANES; assert 'flex-d' in KNOWN_AUTHOR_LANES; print('flex-d registered')"

# Verify check-gated target exists
make help | grep check-gated

# Run impacted tests
uv run python -m pytest tests/unit/test_ops_worker_pool.py -k "domain or LaneExpansion or managed_lanes" -v
uv run python -m pytest tests/unit/test_ops_token_economy.py::TestInferLaneFromPath::test_all_known_lanes_covered -v
```

## Test Criteria
- **Pass condition:** `flex-d` in KNOWN_AUTHOR_LANES, LANE_DOMAINS, _WORKTREE_TO_LANE, PROTECTED_WORKTREE_NAMES, PERSISTENT_LANES, and monitor ALL_LANES
- **Verification command:** `uv run python -m pytest tests/unit/test_ops_worker_pool.py::TestLaneExpansion tests/unit/test_ops_worker_pool.py::TestConstants::test_managed_lanes tests/unit/test_ops_token_economy.py::TestInferLaneFromPath::test_all_known_lanes_covered -v`
- **Expected result:** All 13 tests pass

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_worker_pool.py -k "domain or LaneExpansion or managed_lanes"` — 29 passed
- [x] `uv run python -m pytest tests/unit/test_ops_task_queue.py` — 69 passed
- [x] `uv run python -m pytest tests/unit/test_ops_token_economy.py::TestInferLaneFromPath::test_all_known_lanes_covered` — passed
- [x] `make check-quiet` — 5 pre-existing failures (unrelated: 2× test_stale_usage, 1× test_telegram_filter), 0 new failures

## Expected impact
- Metrics impact: None
- Runtime impact: None (registry constants, Makefile target)

## Risk level
- [x] Low (ops registry + Makefile)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git worktree list` (excerpt):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a   c890e2b5 [fix/ops-flex-d-and-stagger]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept — ops lane infrastructure)

Closes #2024
Closes #2048

🤖 Generated with [Claude Code](https://claude.com/claude-code)