### PR TITLE
fix(web): prevent reconnect cookie clobbering on /play/ visits

### DIFF
--- a/tests/unit/hosted_play/test_reconnect.py
+++ b/tests/unit/hosted_play/test_reconnect.py
@@ -280,3 +280,78 @@ class TestCookieOnLegacyNew:
         assert resp.status_code == 302
         cookie_header = resp.headers.get("set-cookie", "")
         assert PLAYER_COOKIE_NAME in cookie_header
+
+
+# ===================================================================
+# 5. Cookie Clobber Protection (Fixes #2069)
+# ===================================================================
+
+
+class TestCookieClobberProtection:
+    """Visiting /play/{link_uuid} should not clobber an existing cookie
+    belonging to a different player.
+
+    Uses players with nicknames but no matches — the cookie logic fires
+    before match rendering, so model_select is sufficient to test the
+    cookie behavior.
+    """
+
+    def test_no_clobber_when_different_cookie_exists(self, client):
+        """Existing cookie for player A is NOT overwritten when visiting player B's game page."""
+        session = _get_session_factory(client)()
+        try:
+            player_a = create_test_player(session, nickname="Alice")
+            player_b = create_test_player(session, nickname="Bob")
+            session.commit()
+            link_a = player_a.link_uuid
+            link_b = player_b.link_uuid
+        finally:
+            session.close()
+
+        # Alice has her cookie set
+        client.cookies.set(PLAYER_COOKIE_NAME, link_a)
+
+        # Alice visits Bob's game page (e.g. shared link)
+        resp = client.get(f"/play/{link_b}", follow_redirects=False)
+        assert resp.status_code == 200
+
+        # The response should NOT set a cookie (no clobbering)
+        cookie_header = resp.headers.get("set-cookie", "")
+        assert (
+            link_b not in cookie_header
+        ), "Cookie should not be clobbered with a different player's link"
+
+    def test_cookie_set_when_no_existing_cookie(self, client):
+        """Cookie IS set when visiting /play/ with no existing cookie."""
+        session = _get_session_factory(client)()
+        try:
+            player = create_test_player(session, nickname="Charlie")
+            session.commit()
+            link = player.link_uuid
+        finally:
+            session.close()
+
+        # No cookie set — visiting the game page should backfill it
+        resp = client.get(f"/play/{link}", follow_redirects=False)
+        assert resp.status_code == 200
+        cookie_header = resp.headers.get("set-cookie", "")
+        assert link in cookie_header, "Cookie should be set for first-time visitors"
+
+    def test_cookie_preserved_when_same_player(self, client):
+        """Cookie IS refreshed when visiting own game page."""
+        session = _get_session_factory(client)()
+        try:
+            player = create_test_player(session, nickname="Diana")
+            session.commit()
+            link = player.link_uuid
+        finally:
+            session.close()
+
+        # Diana has her own cookie and visits her own game
+        client.cookies.set(PLAYER_COOKIE_NAME, link)
+        resp = client.get(f"/play/{link}", follow_redirects=False)
+        assert resp.status_code == 200
+        cookie_header = resp.headers.get("set-cookie", "")
+        assert (
+            link in cookie_header
+        ), "Cookie should be refreshed for same-player visits"

--- a/web/routes.py
+++ b/web/routes.py
@@ -753,8 +753,15 @@ async def game_page(request: Request, link_uuid: str):
         # Backfill the reconnect cookie so returning visitors see the
         # reconnect prompt on the landing page even if they arrived here
         # via a direct link or bookmark (not the invite-code flow).
+        # Only set the cookie when no existing cookie is present — avoid
+        # clobbering a different player's session if someone follows a
+        # shared /play/ link.  (Fixes #2069)
+        existing_cookie = get_player_link_from_cookie(request)
+        should_set_cookie = existing_cookie is None or existing_cookie == link_uuid
+
         def _with_cookie(resp: HTMLResponse) -> HTMLResponse:
-            set_player_cookie(resp, link_uuid)
+            if should_set_cookie:
+                set_player_cookie(resp, link_uuid)
             return resp
 
         # No nickname yet — show nickname prompt


### PR DESCRIPTION
## Summary
- Only set the player session cookie on `/play/{link_uuid}` when no existing cookie is present or the cookie already matches the current link_uuid
- Prevents a shared URL from overwriting another player's reconnect session

## Why
When player A follows a shared link to player B's game page (`/play/{B_link}`), the unconditional `set_player_cookie()` call overwrites A's cookie with B's link_uuid. On next visit to the landing page, A sees B's reconnect prompt instead of their own.

Closes #2069

## Repro / Validation
```bash
uv run python -m pytest tests/unit/hosted_play/test_reconnect.py -v
```

## Tests
- 3 new tests in `TestCookieClobberProtection`:
  - `test_no_clobber_when_different_cookie_exists` — visiting another player's page does NOT overwrite existing cookie
  - `test_cookie_set_when_no_existing_cookie` — first-time visitors still get cookie backfill
  - `test_cookie_preserved_when_same_player` — visiting own game page refreshes cookie normally
- All 16 reconnect tests pass

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: fix/web-cookie-clobber
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)