### PR TITLE
fix(web): prefer active matches in game_page route

### DIFF
--- a/tests/unit/hosted_play/test_reconnect.py
+++ b/tests/unit/hosted_play/test_reconnect.py
@@ -136,6 +136,28 @@ class TestLookupActiveMatch:
         finally:
             session.close()
 
+    def test_prefers_active_over_completed(self, client):
+        """When both active and completed matches exist, returns the active one.
+
+        Mirrors the game_page query fix (#2056): the landing page reconnect
+        and the game page must agree on which match to show.
+        """
+        session = _get_session_factory(client)()
+        try:
+            player = create_test_player(session, nickname="Eve")
+            active_match = create_test_match(
+                session, player_id=player.id, status="active"
+            )
+            # Create a newer completed match
+            create_test_match(session, player_id=player.id, status="complete")
+            session.commit()
+
+            result = lookup_active_match(session, player.link_uuid)
+            assert result is not None
+            assert result["match_uuid"] == active_match.match_uuid
+        finally:
+            session.close()
+
 
 # ===================================================================
 # 2. Landing Page — Reconnect Detection

--- a/web/routes.py
+++ b/web/routes.py
@@ -770,13 +770,22 @@ async def game_page(request: Request, link_uuid: str):
                 )
             )
 
-        # Show the latest match for this player, including completed matches.
+        # Prefer the most recent *active* match so the reconnect prompt
+        # on the landing page and the game page agree.  Fall back to any
+        # match (e.g. completed) when no active match exists.  (#2056)
         match_row = (
             session.query(Match)
-            .filter_by(player_id=player.id)
+            .filter_by(player_id=player.id, status="active")
             .order_by(Match.created_at.desc())
             .first()
         )
+        if match_row is None:
+            match_row = (
+                session.query(Match)
+                .filter_by(player_id=player.id)
+                .order_by(Match.created_at.desc())
+                .first()
+            )
 
         if match_row is None:
             # No usable match — show model selection


### PR DESCRIPTION
## Summary
- Game page now queries for active matches first, falling back to any match only when no active match exists
- Ensures the landing page reconnect prompt and the game page agree on which match to show

## Why
Before this fix, the game page query (`filter_by(player_id=...).order_by(created_at.desc())`) could select a newer *completed* match over an older *active* match. The landing page reconnect prompt correctly finds the active match, but following the "Resume Game" link would show the completed match instead — a confusing mismatch.

The cookie backfill finding (second item in #2056) was already addressed in PR #2068.

Closes #2056

## Repro / Validation
```bash
uv run python -m pytest tests/unit/hosted_play/test_reconnect.py tests/unit/hosted_play/test_routes.py -v
```

## Tests
- 1 new test `test_prefers_active_over_completed` in `TestLookupActiveMatch` — verifies active match is returned when both active and completed matches exist
- All 91 hosted play unit tests pass (77 routes + 14 reconnect)

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: fix/web-reconnect-active-match
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)