### PR TITLE
fix(web): rewrite AI opponent descriptions to be player-friendly

### DIFF
--- a/web/ai_manager.py
+++ b/web/ai_manager.py
@@ -129,7 +129,10 @@ class AIManager:
                 self.available_models["olsa"] = ModelInfo(
                     id="olsa",
                     name="OLSa (Easy)",
-                    description=("Conservative action-value bidder — easier opponent."),
+                    description=(
+                        "A cautious bidder who plays it safe. "
+                        "Good for learning the game."
+                    ),
                     bidding_policy=ActionValueBidder(
                         artifact_path=path,
                         name="olsa",
@@ -162,7 +165,10 @@ class AIManager:
                 self.available_models["bud_bot"] = ModelInfo(
                     id="bud_bot",
                     name="Bud Bot",
-                    description=("Gradient-boosted bidder with Glutton card play."),
+                    description=(
+                        "A confident bidder who plays aggressively. "
+                        "Your toughest opponent."
+                    ),
                     bidding_policy=GBTActionValueBidder(
                         artifact_path=path,
                         name="bud_bot",


### PR DESCRIPTION
## Summary

- Replace ML jargon in AI opponent descriptions with player-friendly text
- Bud Bot: "A confident bidder who plays aggressively. Your toughest opponent."
- OLSa (Easy): "A cautious bidder who plays it safe. Good for learning the game."

## Why

Players see these descriptions on the model selection screen. Terms like
"Gradient-boosted bidder" and "Conservative action-value bidder" are meaningless
to non-technical players.

Closes #2083

## Repro / Validation

```bash
# Start the hosted game and inspect the model selection screen
uv run python -m web.main
# Visit http://localhost:8000/play/ and check AI descriptions
```

## Tests

```bash
uv run python -m pytest tests/unit/hosted_play/test_ai_manager.py -x -q  # 6 passed
make check-quiet  # 3 pre-existing failures in unrelated platform tests
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
branch: fix/ai-descriptions-2083
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)