### PR TITLE
fix(web): rewrite postgresql:// to psycopg dialect in DATABASE_URL (#2088)

### DIFF
--- a/tests/unit/hosted_play/test_config.py
+++ b/tests/unit/hosted_play/test_config.py
@@ -128,10 +128,23 @@ class TestFromEnv:
         ):
             monkeypatch.delenv(key, raising=False)
 
-    def test_reads_database_url(self, monkeypatch):
+    def test_reads_database_url_postgres_dialect_rewrite(self, monkeypatch):
+        """Render passes postgresql:// but we use psycopg v3, not psycopg2."""
         monkeypatch.setenv("DATABASE_URL", "postgresql://localhost/test")
         cfg = HostedPlayConfig.from_env()
-        assert cfg.database_url == "postgresql://localhost/test"
+        assert cfg.database_url == "postgresql+psycopg://localhost/test"
+
+    def test_database_url_already_psycopg_unchanged(self, monkeypatch):
+        """If the URL already specifies +psycopg, don't double-rewrite."""
+        monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://localhost/test")
+        cfg = HostedPlayConfig.from_env()
+        assert cfg.database_url == "postgresql+psycopg://localhost/test"
+
+    def test_database_url_sqlite_unchanged(self, monkeypatch):
+        """SQLite URLs pass through untouched."""
+        monkeypatch.setenv("DATABASE_URL", "sqlite:///my.db")
+        cfg = HostedPlayConfig.from_env()
+        assert cfg.database_url == "sqlite:///my.db"
 
     def test_reads_default_model_id(self, monkeypatch):
         monkeypatch.setenv("DEFAULT_MODEL_ID", "olsa")

--- a/web/config.py
+++ b/web/config.py
@@ -86,8 +86,15 @@ class HostedPlayConfig:
         """Build config from environment variables."""
         raw_origins = os.environ.get("ALLOWED_ORIGINS", "*")
 
+        # Render provides postgresql:// but we use psycopg v3, not psycopg2.
+        # Transform to the explicit psycopg dialect so SQLAlchemy loads the
+        # correct driver.
+        db_url = os.environ.get("DATABASE_URL", "sqlite:///hosted_play.db")
+        if db_url.startswith("postgresql://"):
+            db_url = db_url.replace("postgresql://", "postgresql+psycopg://", 1)
+
         return cls(
-            database_url=os.environ.get("DATABASE_URL", "sqlite:///hosted_play.db"),
+            database_url=db_url,
             secret_key=os.environ.get("SECRET_KEY", _default_secret_key()),
             allowed_origins=_parse_origins(raw_origins),
             app_url=os.environ.get("APP_URL", "http://localhost:8000"),


### PR DESCRIPTION
## Plan
N/A — single-file deploy blocker fix.

## Summary
- Rewrites `postgresql://` → `postgresql+psycopg://` in `from_env()` so SQLAlchemy loads the psycopg v3 driver instead of the missing psycopg2
- Adds 3 test cases: dialect rewrite, idempotent pass-through for already-correct URLs, SQLite pass-through

## Why
Render passes `DATABASE_URL` as `postgresql://...` which causes SQLAlchemy to default to the legacy `psycopg2` driver. Since the Dockerfile installs `psycopg` (v3), the app fails at startup with `ModuleNotFoundError: No module named 'psycopg2'`. This is a deploy blocker.

Closes #2088

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_config.py -v
```

**Config:** N/A
**Seed:** N/A

## Test Criteria
- **Pass condition:** `from_env()` transforms `postgresql://` URLs to `postgresql+psycopg://`
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_config.py::TestFromEnv::test_reads_database_url_postgres_dialect_rewrite -v`
- **Expected result:** Test passes, asserting `postgresql+psycopg://localhost/test`

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_config.py` — 39 passed
- [x] `uv run python -m pytest tests/unit/hosted_play/` — 3200 passed, 6 skipped
- [x] `make repo-lint && make lint` — clean

## Expected impact
- Metrics impact: None
- Runtime impact: None (string replace at startup only)

## Risk level
- [x] Low (config plumbing only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre                         66de146d [main]
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author          (fix/render-psycopg-dialect)
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)