### PR TITLE
fix(web): show X declarer badge in icon legend to match board markers

### DIFF
--- a/web/templates/partials/game_board.html
+++ b/web/templates/partials/game_board.html
@@ -201,7 +201,7 @@
     <div class="icon-legend" role="note" aria-label="Badge legend">
         <span class="icon-legend__item"><span class="seat-marker seat-marker--dealer" aria-hidden="true">D</span> Dealer</span>
         <span class="icon-legend__sep" aria-hidden="true">&middot;</span>
-        <span class="icon-legend__item"><span class="seat-marker seat-marker--declarer" aria-hidden="true">★</span> Declarer</span>
+        <span class="icon-legend__item"><span class="seat-marker seat-marker--declarer" aria-hidden="true">X</span> Declarer</span>
         <span class="icon-legend__sep" aria-hidden="true">&middot;</span>
         <span class="icon-legend__item"><span class="seat-marker seat-marker--leader" aria-hidden="true">L</span> Lead</span>
         <span class="icon-legend__sep" aria-hidden="true">&middot;</span>


### PR DESCRIPTION
## Summary
- The compact icon legend showed ★ for the declarer badge, but the game board seat labels use X
- Updated the legend to show X, matching what players actually see next to seat names
- The ★ symbol is only used in the trick view (trick.html), not on board seat markers

## Why
The icon legend should reflect the actual badges visible on the game board. The board's seat markers (both mobile compact badges and desktop compass labels) all use `X` for the declarer. The legend incorrectly showed `★`.

## Validation
```bash
uv run python -m pytest tests/unit/hosted_play/ --no-header -q
# 3200 passed, 6 skipped
```

Full `make check-quiet` passes (3 pre-existing failures on main unrelated to this change — `test_ops_token_economy` and `test_telegram_filter`).

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: fix/web-icon-legend-declarer-badge
```

Closes #2093

🤖 Generated with [Claude Code](https://claude.com/claude-code)