### PR TITLE
feat(web): show AI opponents on leaderboard

### DIFF
--- a/tests/unit/hosted_play/test_leaderboard.py
+++ b/tests/unit/hosted_play/test_leaderboard.py
@@ -21,6 +21,7 @@ from web.db import Hand, Match, Player
 from web.leaderboard import (
     METRIC_DEFINITIONS,
     PlayerStats,
+    compute_ai_stats,
     compute_player_stats,
     format_metric,
     get_leaderboard,
@@ -406,6 +407,7 @@ class TestComputePlayerStats:
         expected_fields = {
             "player_id",
             "nickname",
+            "is_ai",
             "net_eppd",
             "games_won",
             "win_rate",
@@ -505,6 +507,318 @@ class TestGetLeaderboard:
         assert rankings[0].hands_played == 1
         assert rankings[0].matches_played == 0  # no completed matches yet
         assert rankings[0].games_won == 0
+
+
+# ---------------------------------------------------------------------------
+# AI stats tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeAiStats:
+    """Unit tests for compute_ai_stats (AI opponent perspective)."""
+
+    def test_returns_none_for_unknown_model(self, db_session):
+        result = compute_ai_stats(db_session, "nonexistent_model")
+        assert result is None
+
+    def test_returns_none_for_no_completed_hands(self, db_session):
+        """AI model with no completed hands → None."""
+        player = _make_player(db_session)
+        _make_match(db_session, player, status="active")
+        result = compute_ai_stats(db_session, "heuristic")
+        assert result is None
+
+    def test_basic_ai_stats(self, db_session):
+        """AI stats computed from team 1 perspective."""
+        player = _make_player(db_session, nickname="Alice")
+        match = _make_match(
+            db_session,
+            player,
+            score_human=30,
+            score_ai=52,
+            hands_played=5,
+        )
+
+        # 3 hands where human team declared
+        for i in range(3):
+            _make_hand(
+                db_session,
+                match,
+                hand_number=i,
+                bidder_seat=0,
+                winning_bid_n=6,
+                tricks_team0=7,
+                tricks_team1=3,
+                points_team0=6,
+                points_team1=3,
+            )
+        # 2 hands where AI team declared and made
+        for i in range(3, 5):
+            _make_hand(
+                db_session,
+                match,
+                hand_number=i,
+                bidder_seat=1,
+                winning_bid_n=5,
+                tricks_team0=4,
+                tricks_team1=6,
+                points_team0=4,
+                points_team1=5,
+            )
+
+        db_session.flush()
+        stats = compute_ai_stats(db_session, "heuristic", display_name="Test Bot")
+
+        assert stats is not None
+        assert stats.is_ai is True
+        assert stats.nickname == "Test Bot"
+        assert stats.matches_played == 1
+        assert stats.games_won == 1  # score_ai > score_human
+        assert stats.win_rate == 1.0
+        assert stats.hands_played == 5
+
+        # net_eppd from AI (team1) perspective:
+        # (3*3 + 2*5 - 3*6 - 2*4) / 5 = (9+10-18-8)/5 = -7/5 = -1.4
+        assert stats.net_eppd == -1.4
+
+        # bid_rate = 2 declaring (seat 1) / 5 total
+        assert stats.bid_rate == 0.4
+
+        # make_rate = 2 made (6 >= 5) / 2 declaring
+        assert stats.make_rate == 1.0
+
+    def test_ai_stats_aggregate_across_players(self, db_session):
+        """AI stats aggregate across matches from different human players."""
+        player_a = _make_player(db_session, nickname="A")
+        player_b = _make_player(db_session, nickname="B")
+
+        # Match 1: AI wins
+        m1 = _make_match(
+            db_session, player_a, score_human=20, score_ai=52, hands_played=2
+        )
+        _make_hand(
+            db_session,
+            m1,
+            hand_number=0,
+            bidder_seat=1,
+            winning_bid_n=5,
+            tricks_team0=3,
+            tricks_team1=7,
+            points_team0=3,
+            points_team1=5,
+        )
+        _make_hand(
+            db_session,
+            m1,
+            hand_number=1,
+            bidder_seat=0,
+            winning_bid_n=6,
+            tricks_team0=4,
+            tricks_team1=6,
+            points_team0=-6,
+            points_team1=6,
+        )
+
+        # Match 2: AI loses
+        m2 = _make_match(
+            db_session, player_b, score_human=52, score_ai=10, hands_played=2
+        )
+        _make_hand(
+            db_session,
+            m2,
+            hand_number=10,
+            bidder_seat=0,
+            winning_bid_n=6,
+            tricks_team0=8,
+            tricks_team1=2,
+            points_team0=6,
+            points_team1=2,
+        )
+        _make_hand(
+            db_session,
+            m2,
+            hand_number=11,
+            bidder_seat=3,
+            winning_bid_n=5,
+            tricks_team0=6,
+            tricks_team1=4,
+            points_team0=6,
+            points_team1=-5,
+        )
+
+        db_session.flush()
+        stats = compute_ai_stats(db_session, "heuristic")
+
+        assert stats is not None
+        assert stats.hands_played == 4  # across both matches
+        assert stats.matches_played == 2
+        assert stats.games_won == 1  # only m1 won
+        assert stats.win_rate == 0.5
+
+        # net_eppd: (5+6+2+(-5) - 3+(-6)+6+6) / 4 = (8 - 9) / 4 = -0.25
+        # team1 points: 5+6+2+(-5) = 8
+        # team0 points: 3+(-6)+6+6 = 9
+        assert stats.net_eppd == -0.25
+
+    def test_ai_stats_uses_display_name(self, db_session):
+        """display_name overrides the raw model id."""
+        player = _make_player(db_session)
+        match = _make_match(db_session, player)
+        _make_hand(db_session, match)
+        db_session.flush()
+
+        stats = compute_ai_stats(db_session, "heuristic", display_name="Bud Bot")
+        assert stats is not None
+        assert stats.nickname == "Bud Bot"
+
+    def test_ai_stats_defaults_to_model_id(self, db_session):
+        """Without display_name, nickname falls back to model id."""
+        player = _make_player(db_session)
+        match = _make_match(db_session, player)
+        _make_hand(db_session, match)
+        db_session.flush()
+
+        stats = compute_ai_stats(db_session, "heuristic")
+        assert stats is not None
+        assert stats.nickname == "heuristic"
+
+    def test_ai_stats_player_id_sentinel(self, db_session):
+        """AI entries use -1 as player_id sentinel."""
+        player = _make_player(db_session)
+        match = _make_match(db_session, player)
+        _make_hand(db_session, match)
+        db_session.flush()
+
+        stats = compute_ai_stats(db_session, "heuristic")
+        assert stats is not None
+        assert stats.player_id == -1
+
+    def test_ai_moon_and_loner_stats(self, db_session):
+        """Moon/loner stats computed from AI team perspective."""
+        player = _make_player(db_session)
+        match = _make_match(db_session, player)
+
+        # Moon hand — AI team declares, makes all 10
+        _make_hand(
+            db_session,
+            match,
+            hand_number=0,
+            bidder_seat=1,
+            winning_bid_n=10,
+            winning_bid_type="moon",
+            tricks_team0=0,
+            tricks_team1=10,
+            points_team0=0,
+            points_team1=20,
+        )
+
+        # Loner hand — AI team declares, fails
+        _make_hand(
+            db_session,
+            match,
+            hand_number=1,
+            bidder_seat=3,
+            winning_bid_n=10,
+            winning_bid_type="loner",
+            tricks_team0=5,
+            tricks_team1=5,
+            points_team0=5,
+            points_team1=-10,
+        )
+
+        # Regular hand — human declares
+        _make_hand(
+            db_session,
+            match,
+            hand_number=2,
+            bidder_seat=0,
+            winning_bid_n=5,
+            winning_bid_type="regular",
+            tricks_team0=6,
+            tricks_team1=4,
+            points_team0=5,
+            points_team1=4,
+        )
+
+        db_session.flush()
+        stats = compute_ai_stats(db_session, "heuristic")
+
+        assert stats is not None
+        assert stats.hands_played == 3
+        assert stats.moon_call_rate == pytest.approx(1 / 3, abs=0.001)
+        assert stats.moon_make_rate == 1.0  # 1 moon, all 10 tricks
+        assert stats.loner_call_rate == pytest.approx(1 / 3, abs=0.001)
+        assert stats.loner_make_rate == 0.0  # 1 loner, only 5 tricks
+
+
+class TestLeaderboardWithAI:
+    """Tests for get_leaderboard with AI opponent entries included."""
+
+    def test_includes_ai_when_display_names_provided(self, db_session):
+        """AI entries appear when ai_display_names is passed."""
+        player = _make_player(db_session, nickname="Human")
+        match = _make_match(db_session, player)
+        _make_hand(db_session, match, points_team0=5, points_team1=3)
+        db_session.flush()
+
+        rankings = get_leaderboard(
+            db_session, ai_display_names={"heuristic": "Test Bot"}
+        )
+        assert len(rankings) == 2
+        nicknames = {r.nickname for r in rankings}
+        assert "Human" in nicknames
+        assert "Test Bot" in nicknames
+
+    def test_excludes_ai_when_no_display_names(self, db_session):
+        """Without ai_display_names, only human players appear."""
+        player = _make_player(db_session, nickname="Human")
+        match = _make_match(db_session, player)
+        _make_hand(db_session, match, points_team0=5, points_team1=3)
+        db_session.flush()
+
+        rankings = get_leaderboard(db_session)
+        assert len(rankings) == 1
+        assert rankings[0].nickname == "Human"
+        assert rankings[0].is_ai is False
+
+    def test_ai_and_human_sorted_by_net_eppd(self, db_session):
+        """AI and human entries sort together by net_eppd."""
+        player = _make_player(db_session, nickname="Human")
+        match = _make_match(db_session, player, score_human=52, score_ai=20)
+
+        # Human team wins big: high positive eppd for human, negative for AI
+        _make_hand(
+            db_session,
+            match,
+            points_team0=10,
+            points_team1=2,
+        )
+        db_session.flush()
+
+        rankings = get_leaderboard(
+            db_session, ai_display_names={"heuristic": "Test Bot"}
+        )
+        assert len(rankings) == 2
+        # Human has positive EPPD (10-2=8), AI has negative (-8)
+        assert rankings[0].nickname == "Human"
+        assert rankings[0].is_ai is False
+        assert rankings[1].nickname == "Test Bot"
+        assert rankings[1].is_ai is True
+
+    def test_ai_respects_min_hands_filter(self, db_session):
+        """AI entries also respect the min_hands threshold."""
+        player = _make_player(db_session, nickname="Human")
+        match = _make_match(db_session, player)
+        _make_hand(db_session, match, points_team0=5, points_team1=3)
+        db_session.flush()
+
+        # min_hands=2 excludes both (only 1 hand each)
+        rankings = get_leaderboard(
+            db_session,
+            min_hands=2,
+            ai_display_names={"heuristic": "Test Bot"},
+        )
+        assert len(rankings) == 0
 
 
 # ---------------------------------------------------------------------------
@@ -670,6 +984,55 @@ class TestLeaderboardRoute:
         finally:
             session.close()
 
+    def test_leaderboard_shows_ai_opponents(self, app_and_client):
+        """AI opponents appear on the leaderboard with an AI badge."""
+        app, client = app_and_client
+        session = app.state.session_factory()
+        try:
+            player = _make_player(session, nickname="HumanPlayer")
+            # Match uses an AI model that the test roster provides
+            match = _make_match(
+                session,
+                player,
+                score_human=52,
+                score_ai=20,
+            )
+            # Override ai_model to match the test roster
+            match.ai_model = "bud_bot"
+            _make_hand(
+                session,
+                match,
+                points_team0=5,
+                points_team1=2,
+            )
+            session.commit()
+
+            resp = client.get(f"/leaderboard/{player.link_uuid}")
+            assert resp.status_code == 200
+            # Human player present
+            assert "HumanPlayer" in resp.text
+            # AI opponent present with badge
+            assert "Bud Bot" in resp.text
+            assert "AI" in resp.text
+            assert "leaderboard__ai-badge" in resp.text
+        finally:
+            session.close()
+
+    def test_leaderboard_no_ai_badge_for_humans(self, app_and_client):
+        """Human players do not have the AI badge in table rows."""
+        app, client = app_and_client
+        session = app.state.session_factory()
+        try:
+            player = _make_player(session, nickname="JustHuman")
+            session.commit()
+
+            resp = client.get(f"/leaderboard/{player.link_uuid}")
+            assert resp.status_code == 200
+            # Empty leaderboard — no table body, no AI badge in rows
+            assert 'title="AI opponent"' not in resp.text
+        finally:
+            session.close()
+
 
 # ---------------------------------------------------------------------------
 # format_metric tests
@@ -755,7 +1118,7 @@ class TestMetricDefinitions:
 
     def test_every_player_stats_field_has_definition(self):
         """Every numeric field on PlayerStats has a matching metric def."""
-        skip = {"player_id", "nickname"}
+        skip = {"player_id", "nickname", "is_ai"}
         stat_fields = {
             f.name
             for f in PlayerStats.__dataclass_fields__.values()

--- a/web/leaderboard.py
+++ b/web/leaderboard.py
@@ -204,6 +204,9 @@ class PlayerStats:
     loner_call_rate: float  # fraction of hands with a loner bid
     loner_make_rate: float  # fraction of loner contracts made
 
+    # AI indicator (must be last — has default value)
+    is_ai: bool = False  # True for AI opponent aggregate entries
+
 
 def compute_player_stats(session: Session, player_id: int) -> PlayerStats | None:
     """Compute aggregated stats for a single player.
@@ -330,10 +333,139 @@ def compute_player_stats(session: Session, player_id: int) -> PlayerStats | None
     )
 
 
+def compute_ai_stats(
+    session: Session,
+    ai_model: str,
+    *,
+    display_name: str | None = None,
+) -> PlayerStats | None:
+    """Compute aggregated stats for an AI opponent across all its matches.
+
+    The AI team is team 1 (seats 1 and 3).  Stats are computed from the
+    AI's perspective — net EPPD, win rate, bid rate, etc. all reflect the
+    AI opponent's performance, not the human's.
+
+    Returns ``None`` if the AI has no completed hands.
+    """
+    # All matches involving this AI model (active + complete)
+    all_matches = (
+        session.query(Match)
+        .filter(
+            Match.ai_model == ai_model,
+            Match.status.in_(_LEADERBOARD_MATCH_STATUSES),
+        )
+        .all()
+    )
+
+    if not all_matches:
+        return None
+
+    all_match_ids = [m.id for m in all_matches]
+
+    # Completed hands across active + completed matches
+    completed_hands = (
+        session.query(Hand)
+        .filter(Hand.match_id.in_(all_match_ids), Hand.status == "complete")
+        .all()
+    )
+    hands_played = len(completed_hands)
+
+    if hands_played == 0:
+        return None
+
+    # --- Match-level metrics (completed matches only) ---
+    completed_matches = [m for m in all_matches if m.status == "complete"]
+    matches_played = len(completed_matches)
+
+    # AI wins when score_ai > score_human
+    games_won = sum(1 for m in completed_matches if m.score_ai > m.score_human)
+    win_rate = games_won / matches_played if matches_played > 0 else 0.0
+
+    # Margins from AI perspective: score_ai - score_human
+    margins = [m.score_ai - m.score_human for m in completed_matches]
+    avg_match_margin = sum(margins) / len(margins) if margins else 0.0
+    winning_margins = [mg for mg in margins if mg > 0]
+    avg_margin_victory = (
+        sum(winning_margins) / len(winning_margins) if winning_margins else 0.0
+    )
+
+    # --- Hand-level metrics (all completed hands, AI = team 1) ---
+
+    # Net EPPD from AI perspective: (points_team1 - points_team0) / hands
+    total_net_points = sum(h.points_team1 - h.points_team0 for h in completed_hands)
+    net_eppd = total_net_points / hands_played
+
+    # Bidding stats — AI team is team 1, seats (1, 3)
+    declaring_hands = [
+        h
+        for h in completed_hands
+        if h.bidder_seat is not None and h.bidder_seat in (1, 3)
+    ]
+    bid_rate = len(declaring_hands) / hands_played if hands_played > 0 else 0.0
+
+    # Make rate: when AI declares, did team 1 make the contract?
+    made_contracts = [
+        h
+        for h in declaring_hands
+        if h.winning_bid_n is not None and h.tricks_team1 >= h.winning_bid_n
+    ]
+    make_rate = len(made_contracts) / len(declaring_hands) if declaring_hands else 0.0
+
+    # Average bid level when declaring
+    bid_levels = [
+        h.winning_bid_n for h in declaring_hands if h.winning_bid_n is not None
+    ]
+    avg_bid_level = sum(bid_levels) / len(bid_levels) if bid_levels else 0.0
+
+    # Moon stats (AI team declaring)
+    moon_hands = [h for h in completed_hands if h.winning_bid_type == "moon"]
+    moon_declaring = [h for h in moon_hands if h.bidder_seat in (1, 3)]
+    moon_call_rate = len(moon_declaring) / hands_played if hands_played > 0 else 0.0
+    moon_made = [
+        h
+        for h in moon_declaring
+        if h.winning_bid_n is not None and h.tricks_team1 >= h.winning_bid_n
+    ]
+    moon_make_rate = len(moon_made) / len(moon_declaring) if moon_declaring else 0.0
+
+    # Loner stats (AI team declaring)
+    loner_hands = [h for h in completed_hands if h.winning_bid_type == "loner"]
+    loner_declaring = [h for h in loner_hands if h.bidder_seat in (1, 3)]
+    loner_call_rate = len(loner_declaring) / hands_played if hands_played > 0 else 0.0
+    loner_made = [
+        h
+        for h in loner_declaring
+        if h.winning_bid_n is not None and h.tricks_team1 >= h.winning_bid_n
+    ]
+    loner_make_rate = len(loner_made) / len(loner_declaring) if loner_declaring else 0.0
+
+    # Use a negative player_id sentinel for AI entries (no real player row)
+    return PlayerStats(
+        player_id=-1,
+        nickname=display_name or ai_model,
+        is_ai=True,
+        net_eppd=round(net_eppd, 3),
+        games_won=games_won,
+        win_rate=round(win_rate, 3),
+        avg_margin_victory=round(avg_margin_victory, 1),
+        matches_played=matches_played,
+        hands_played=hands_played,
+        avg_match_margin=round(avg_match_margin, 1),
+        bid_rate=round(bid_rate, 3),
+        make_rate=round(make_rate, 3),
+        avg_bid_level=round(avg_bid_level, 1),
+        moon_call_rate=round(moon_call_rate, 3),
+        moon_make_rate=round(moon_make_rate, 3),
+        loner_call_rate=round(loner_call_rate, 3),
+        loner_make_rate=round(loner_make_rate, 3),
+    )
+
+
 def get_leaderboard(
     session: Session,
     *,
     min_hands: int = 1,
+    ai_display_names: dict[str, str] | None = None,
 ) -> list[PlayerStats]:
     """Return leaderboard rankings sorted by net_eppd descending.
 
@@ -341,6 +473,10 @@ def get_leaderboard(
     (across both active and completed matches).  This means players
     appear on the leaderboard after their very first completed hand,
     even during their first match.
+
+    When *ai_display_names* is provided (``{model_id: display_name}``),
+    AI opponent aggregate entries are included alongside human players.
+    Pass ``None`` (default) to show only human players.
     """
     # Find all players with enough completed hands across active+complete matches
     player_hand_counts = (
@@ -360,6 +496,27 @@ def get_leaderboard(
         stats = compute_player_stats(session, player_id)
         if stats is not None:
             stats_list.append(stats)
+
+    # Add AI opponent aggregate entries
+    if ai_display_names is not None:
+        # Find distinct AI models with enough completed hands
+        ai_hand_counts = (
+            session.query(Match.ai_model, func.count(Hand.id).label("n"))
+            .join(Hand, Hand.match_id == Match.id)
+            .filter(
+                Match.status.in_(_LEADERBOARD_MATCH_STATUSES),
+                Hand.status == "complete",
+            )
+            .group_by(Match.ai_model)
+            .having(func.count(Hand.id) >= min_hands)
+            .all()
+        )
+
+        for ai_model, _n in ai_hand_counts:
+            display_name = ai_display_names.get(ai_model, ai_model)
+            ai_stats = compute_ai_stats(session, ai_model, display_name=display_name)
+            if ai_stats is not None:
+                stats_list.append(ai_stats)
 
     # Sort by net_eppd descending (primary ranking metric)
     stats_list.sort(key=lambda s: s.net_eppd, reverse=True)

--- a/web/routes.py
+++ b/web/routes.py
@@ -1420,7 +1420,14 @@ async def leaderboard(request: Request, link_uuid: str):
         if player is None:
             raise HTTPException(status_code=404, detail="Player not found")
 
-        rankings = get_leaderboard(session)
+        # Build AI display name mapping from the roster
+        ai_manager = _get_ai_manager(request)
+        ai_display_names = {
+            model_id: info.name
+            for model_id, info in ai_manager.available_models.items()
+        }
+
+        rankings = get_leaderboard(session, ai_display_names=ai_display_names)
 
         return templates.TemplateResponse(
             "leaderboard.html",

--- a/web/templates/leaderboard.html
+++ b/web/templates/leaderboard.html
@@ -104,6 +104,19 @@
         color: var(--color-moon);
     }
 
+    .leaderboard__ai-badge {
+        display: inline-block;
+        font-size: 0.65rem;
+        font-weight: 600;
+        background: var(--color-surface-light);
+        color: var(--color-text-muted);
+        padding: 0.1rem 0.35rem;
+        border-radius: 3px;
+        margin-left: 0.35rem;
+        vertical-align: middle;
+        letter-spacing: 0.03em;
+    }
+
     .leaderboard__table .positive { color: var(--color-positive); }
     .leaderboard__table .negative { color: var(--color-negative); }
 
@@ -227,7 +240,7 @@
                 {% for entry in rankings %}
                 <tr>
                     <td class="rank-col">{{ loop.index }}</td>
-                    <td class="name-col">{{ entry.nickname or "Anonymous" }}</td>
+                    <td class="name-col">{{ entry.nickname or "Anonymous" }}{% if entry.is_ai %}<span class="leaderboard__ai-badge" title="AI opponent">AI</span>{% endif %}</td>
                     {% for key, m in metric_defs.items() %}
                     {% set val = entry[key] %}
                     {% set formatted = format_metric(val, m.format) %}


### PR DESCRIPTION
## Summary

- Add AI opponent aggregate entries (Bud Bot, OLSa) to the leaderboard alongside human players
- Compute AI stats from team 1's perspective (net EPPD, win rate, bid rate, etc.) across all matches
- Distinguish AI entries with a styled "AI" badge in the player name column
- Add `is_ai` field to `PlayerStats` dataclass and `compute_ai_stats()` function
- Pass `ai_display_names` mapping from the route handler to resolve model IDs to display names

## Why

The leaderboard only tracked human players. In a single-player-vs-AI game, players had no way to compare their performance against the AI opponents they were playing. This adds that context.

Closes #2079

## Repro / Validation

```bash
# Run targeted leaderboard tests (59 tests)
uv run python -m pytest tests/unit/hosted_play/test_leaderboard.py -v

# Full validation
make check-quiet
```

## Tests

- `TestComputeAiStats` — 7 tests covering AI stats from team 1 perspective, cross-player aggregation, display name mapping, moon/loner stats
- `TestLeaderboardWithAI` — 4 tests for AI+human mixed ranking, min_hands filter, display name passthrough
- `TestLeaderboardRoute.test_leaderboard_shows_ai_opponents` — route-level test verifying AI badge renders in HTML
- `TestLeaderboardRoute.test_leaderboard_no_ai_badge_for_humans` — confirms no AI badge for human-only leaderboards
- All 59 leaderboard tests pass; 3 pre-existing failures in unrelated modules (token_economy, telegram_filter)

## Worktree proof

```
pwd: Bid-Euchre-steward-brws-author-a
branch: feat/ai-leaderboard-2079
```

## Test plan

- [x] AI entries appear on leaderboard with "AI" badge
- [x] AI stats computed from team 1 perspective (inverted from human)
- [x] AI and human entries sorted together by net EPPD
- [x] AI display names resolved from ai_manager roster
- [x] min_hands filter applies to AI entries
- [x] No AI badge on human entries
- [x] Backwards compatible — omitting ai_display_names shows only humans

🤖 Generated with [Claude Code](https://claude.com/claude-code)