### PR TITLE
feat(web): add tabbed navigation with active state and comments placeholder (#1916)

### DIFF
--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -2502,3 +2502,59 @@ class TestMatchHistory:
         resp = client.get(f"/play/{link_uuid}")
         assert resp.status_code == 200
         assert f"/history/{link_uuid}" in resp.text
+
+
+class TestTabNavigation:
+    """Header tab navigation — active state, accessibility, and placeholder."""
+
+    def test_game_tab_active_on_game_page(self, client):
+        """Game tab is active when viewing the game page."""
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        _select_ai(client, link_uuid)
+
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        # The Game tab should have the active class
+        assert "header-nav__tab--active" in resp.text
+        # Game tab link should be the one marked active (contains Game and active)
+        assert "header-nav__tab header-nav__tab--active" in resp.text
+
+    def test_leaderboard_tab_active_on_leaderboard_page(self, client):
+        """Leaderboard tab is active when viewing the leaderboard."""
+        link_uuid = _create_game(client)
+        resp = client.get(f"/leaderboard/{link_uuid}")
+        assert resp.status_code == 200
+        assert "header-nav__tab--active" in resp.text
+        # Should contain aria-selected="true" for the leaderboard tab
+        assert 'aria-selected="true"' in resp.text
+
+    def test_history_tab_active_on_history_page(self, client):
+        """History tab is active when viewing the history page."""
+        link_uuid = _create_game(client)
+        resp = client.get(f"/history/{link_uuid}")
+        assert resp.status_code == 200
+        assert "header-nav__tab--active" in resp.text
+
+    def test_comments_tab_disabled(self, client):
+        """Comments tab is present but disabled with 'Coming soon' tooltip."""
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        _select_ai(client, link_uuid)
+
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        assert "header-nav__tab--disabled" in resp.text
+        assert "Coming soon" in resp.text
+        assert "Comments" in resp.text
+        assert 'aria-disabled="true"' in resp.text
+
+    def test_tab_bar_uses_tablist_role(self, client):
+        """The nav element uses role=tablist for accessibility."""
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        _select_ai(client, link_uuid)
+
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        assert 'role="tablist"' in resp.text

--- a/web/routes.py
+++ b/web/routes.py
@@ -420,6 +420,7 @@ def _build_game_context(
 
     ctx: dict[str, Any] = {
         "link_uuid": link_uuid,
+        "current_page": "game",
         "match_status": state.status,
         **visible,
     }
@@ -773,6 +774,7 @@ async def game_page(request: Request, link_uuid: str):
                         "request": request,
                         "phase": "nickname",
                         "link_uuid": link_uuid,
+                        "current_page": "game",
                     },
                 )
             )
@@ -805,6 +807,7 @@ async def game_page(request: Request, link_uuid: str):
                         "request": request,
                         "phase": "model_select",
                         "link_uuid": link_uuid,
+                        "current_page": "game",
                         "nickname": player.nickname,
                         "models": models,
                         "default_model_id": ai_manager.default_model_id,
@@ -1427,6 +1430,7 @@ async def leaderboard(request: Request, link_uuid: str):
             {
                 "request": request,
                 "link_uuid": link_uuid,
+                "current_page": "leaderboard",
                 "nickname": player.nickname,
                 "rankings": rankings,
                 "metric_defs": METRIC_DEFINITIONS,
@@ -1485,6 +1489,7 @@ async def match_history(request: Request, link_uuid: str):
             {
                 "request": request,
                 "link_uuid": link_uuid,
+                "current_page": "history",
                 "nickname": player.nickname,
                 "matches": history_entries,
             },

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -82,18 +82,42 @@ header h1 a:hover {
 
 .header-nav {
     display: flex;
-    gap: 1rem;
+    gap: 0.25rem;
 }
 
-.header-nav a {
+.header-nav__tab {
     color: var(--color-text-muted);
     text-decoration: none;
-    font-size: 0.85rem;
+    font-size: 0.8rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 4px 4px 0 0;
+    border-bottom: 2px solid transparent;
+    transition: color 0.15s ease, border-color 0.15s ease,
+                background-color 0.15s ease;
+    cursor: pointer;
 }
 
-.header-nav a:hover {
+.header-nav__tab:hover {
     color: var(--color-text);
-    text-decoration: underline;
+    background: var(--color-surface-light);
+}
+
+.header-nav__tab--active {
+    color: var(--color-text);
+    border-bottom-color: var(--color-felt);
+    font-weight: 600;
+}
+
+.header-nav__tab--disabled {
+    color: var(--color-surface-light);
+    cursor: default;
+    font-size: 0.8rem;
+    font-style: italic;
+}
+
+.header-nav__tab--disabled:hover {
+    color: var(--color-surface-light);
+    background: transparent;
 }
 
 /* --------------------------------------------------------------------------

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -60,10 +60,19 @@
         <div class="header-bar">
             <h1><a href="/" aria-label="Bid Euchre home">Bid Euchre</a></h1>
             {% if link_uuid is defined and link_uuid %}
-            <nav class="header-nav" aria-label="Main navigation">
-                <a href="/play/{{ link_uuid }}">Game</a>
-                <a href="/history/{{ link_uuid }}">History</a>
-                <a href="/leaderboard/{{ link_uuid }}">Leaderboard</a>
+            {% set _page = current_page | default("") %}
+            <nav class="header-nav" role="tablist" aria-label="Main navigation">
+                <a href="/play/{{ link_uuid }}" role="tab"
+                   class="header-nav__tab{% if _page == 'game' %} header-nav__tab--active{% endif %}"
+                   {% if _page == 'game' %}aria-selected="true"{% else %}aria-selected="false"{% endif %}>Game</a>
+                <a href="/history/{{ link_uuid }}" role="tab"
+                   class="header-nav__tab{% if _page == 'history' %} header-nav__tab--active{% endif %}"
+                   {% if _page == 'history' %}aria-selected="true"{% else %}aria-selected="false"{% endif %}>History</a>
+                <a href="/leaderboard/{{ link_uuid }}" role="tab"
+                   class="header-nav__tab{% if _page == 'leaderboard' %} header-nav__tab--active{% endif %}"
+                   {% if _page == 'leaderboard' %}aria-selected="true"{% else %}aria-selected="false"{% endif %}>Leaderboard</a>
+                <span class="header-nav__tab header-nav__tab--disabled" role="tab"
+                      aria-disabled="true" title="Coming soon">Comments</span>
             </nav>
             {% endif %}
             <button id="text-size-toggle"

--- a/web/templates/history.html
+++ b/web/templates/history.html
@@ -24,17 +24,6 @@
         margin: 0;
     }
 
-    .history__back {
-        color: var(--color-text-muted);
-        text-decoration: none;
-        font-size: 0.9rem;
-    }
-
-    .history__back:hover {
-        color: var(--color-text);
-        text-decoration: underline;
-    }
-
     .history__empty {
         text-align: center;
         padding: 3rem 1rem;
@@ -100,7 +89,6 @@
 <div class="history" role="region" aria-label="Match history">
     <div class="history__header">
         <h2 class="history__title">Match History</h2>
-        <a href="/play/{{ link_uuid }}" class="history__back">Back to Game</a>
     </div>
 
     {% if matches|length == 0 %}

--- a/web/templates/leaderboard.html
+++ b/web/templates/leaderboard.html
@@ -24,17 +24,6 @@
         margin: 0;
     }
 
-    .leaderboard__back {
-        color: var(--color-text-muted);
-        text-decoration: none;
-        font-size: 0.9rem;
-    }
-
-    .leaderboard__back:hover {
-        color: var(--color-text);
-        text-decoration: underline;
-    }
-
     .leaderboard__ranking-info {
         font-size: 0.8rem;
         color: var(--color-text-muted);
@@ -199,7 +188,6 @@
      hx-select=".leaderboard" hx-swap="outerHTML">
     <div class="leaderboard__header">
         <h2 class="leaderboard__title">Leaderboard</h2>
-        <a href="/play/{{ link_uuid }}" class="leaderboard__back">Back to Game</a>
     </div>
     <p class="leaderboard__ranking-info">
         Ranked by Net EPPD — your average point advantage per hand.


### PR DESCRIPTION
## Summary
- Convert header nav links to a tab-styled navigation bar with CSS active state highlighting per page
- Add disabled "Comments" tab with "Coming soon" tooltip as placeholder for future chat feature
- Remove redundant "Back to Game" links from History/Leaderboard pages (tabs now serve this purpose)

## Why
Issue #1916 requested tabs for comments and leaderboard. The comments feature needs design decisions (data model, scope, visibility) that are still TBD, so this PR implements the tab navigation infrastructure and marks Comments as "coming soon". The leaderboard and history pages are now properly integrated into the tab bar with active state.

Closes #1916

## Changes
| File | Change |
|------|--------|
| `web/templates/base.html` | Convert nav to `role=tablist` with `header-nav__tab` classes and `current_page` active state |
| `web/static/style.css` | Add tab CSS: active underline, hover state, disabled italic style |
| `web/routes.py` | Pass `current_page` ("game"/"history"/"leaderboard") in all page-level template contexts |
| `web/templates/leaderboard.html` | Remove "Back to Game" link and unused CSS |
| `web/templates/history.html` | Remove "Back to Game" link and unused CSS |
| `tests/unit/hosted_play/test_routes.py` | Add 5 tests for tab active state, disabled comments, tablist role |

## Repro / Validation
```bash
# Run hosted_play tests (all 3205 pass)
uv run python -m pytest tests/unit/hosted_play/ -q

# Run tab-specific tests
uv run python -m pytest tests/unit/hosted_play/test_routes.py::TestTabNavigation -v
```

## Tests
- `uv run python -m pytest tests/unit/hosted_play/test_routes.py` — 114 passed, 2 skipped
- `uv run python -m pytest tests/unit/hosted_play/` — 3205 passed, 6 skipped
- `make check-quiet` — all browser-game tests green (3 pre-existing platform test failures unrelated)

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
branch: web/game-tabs-1916
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)