### PR TITLE
feat(web): auto-seed default invite code on fresh database startup

### DIFF
--- a/tests/unit/hosted_play/test_app.py
+++ b/tests/unit/hosted_play/test_app.py
@@ -11,6 +11,7 @@ from tests.unit.hosted_play.conftest import make_hosted_play_test_config
 from web.ai_manager import AIManager
 from web.app import create_app
 from web.config import HostedPlayConfig
+from web.db import InviteCode
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -115,6 +116,41 @@ class TestLifespan:
             pool.checkedout() == 0
         ), f"Expected 0 checked-out, got {pool.checkedout()}"
         assert pool.checkedin() == 0, f"Expected 0 checked-in, got {pool.checkedin()}"
+
+    def test_auto_seeds_invite_code_on_fresh_db(self, tmp_path):
+        """Fresh database should get one auto-seeded invite code."""
+        app = _make_app(tmp_path)
+        with TestClient(app):
+            session = app.state.session_factory()
+            try:
+                codes = session.query(InviteCode).all()
+                assert len(codes) == 1
+                assert codes[0].status == "active"
+                assert codes[0].label == "auto-seed"
+                assert len(codes[0].code) > 0
+            finally:
+                session.close()
+
+    def test_auto_seed_is_idempotent(self, tmp_path):
+        """If invite codes already exist, no new ones are seeded."""
+        app = _make_app(tmp_path)
+        # First startup: creates the seed code
+        with TestClient(app):
+            session = app.state.session_factory()
+            try:
+                count_after_first = session.query(InviteCode).count()
+                assert count_after_first == 1
+            finally:
+                session.close()
+        # Second startup on same DB: should not add another code
+        app2 = create_app(config=make_hosted_play_test_config(tmp_path))
+        with TestClient(app2):
+            session2 = app2.state.session_factory()
+            try:
+                count_after_second = session2.query(InviteCode).count()
+                assert count_after_second == 1
+            finally:
+                session2.close()
 
 
 # ---------------------------------------------------------------------------

--- a/web/app.py
+++ b/web/app.py
@@ -2,7 +2,7 @@
 
 Handles startup/shutdown lifecycle:
 1. Load configuration from environment
-2. Initialize database (create tables if needed)
+2. Initialize database (create tables if needed, auto-seed invite code)
 3. Preload approved V1 AI models via :class:`AIManager`
 4. Store manager and session factory in ``app.state``
 
@@ -27,7 +27,14 @@ from starlette.templating import Jinja2Templates
 from .ai_manager import AIManager
 from .cleanup import expire_stale_matches
 from .config import HostedPlayConfig, get_config, override_config
-from .db import Base, create_tables, init_engine, make_session_factory
+from .db import (
+    Base,
+    InviteCode,
+    create_tables,
+    generate_invite_code,
+    init_engine,
+    make_session_factory,
+)
 from .routes import router as game_router
 
 logger = logging.getLogger(__name__)
@@ -102,9 +109,23 @@ async def lifespan(app: FastAPI):
     # 1. Database
     engine = init_engine(config.database_url)
     create_tables(engine)
-
-    # 2. Cleanup stale matches from previous runs
     session_factory = make_session_factory(engine)
+
+    # 2. Auto-seed invite code on fresh database
+    seed_session = session_factory()
+    try:
+        if seed_session.query(InviteCode).count() == 0:
+            code = generate_invite_code()
+            seed_session.add(InviteCode(code=code, status="active", label="auto-seed"))
+            seed_session.commit()
+            logger.info("Auto-seeded invite code: %s", code)
+    except Exception:
+        seed_session.rollback()
+        logger.warning("Invite code auto-seed failed — continuing", exc_info=True)
+    finally:
+        seed_session.close()
+
+    # 3. Cleanup stale matches from previous runs
     cleanup_session = session_factory()
     try:
         expired = expire_stale_matches(cleanup_session)
@@ -117,19 +138,19 @@ async def lifespan(app: FastAPI):
     finally:
         cleanup_session.close()
 
-    # 3. Startup self-test — fail fast on broken deployment
+    # 4. Startup self-test — fail fast on broken deployment
     _run_self_test(engine, _TEMPLATES_DIR, _STATIC_DIR)
 
-    # 4. AI models
+    # 5. AI models
     ai_manager = AIManager(config)
 
-    # 5. Templates
+    # 6. Templates
     templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
     # Expose app_url as a Jinja2 global so templates can build absolute
     # URLs (required for og:image and other meta tags that crawlers fetch).
     templates.env.globals["app_url"] = config.app_url.rstrip("/")
 
-    # 6. Stash on app.state for route access
+    # 7. Stash on app.state for route access
     app.state.config = config
     app.state.engine = engine
     app.state.session_factory = session_factory


### PR DESCRIPTION
## Summary
- On first startup with an empty database, auto-generate one default invite code and log it to stdout
- Idempotent: skips seeding if any invite codes already exist (safe on restart)
- Non-fatal: logs warning and continues if seeding fails

## Why
Fresh production deployments start with zero invite codes, requiring operators to manually run CLI commands against the remote database before the game is playable. This eliminates that friction by seeding a default code automatically.

Closes #2100

## Repro / Validation
```bash
uv run python -m pytest tests/unit/hosted_play/test_app.py -v -k "auto_seed"
```

## Tests
- `test_auto_seeds_invite_code_on_fresh_db` — verifies a fresh DB gets one active auto-seed code
- `test_auto_seed_is_idempotent` — verifies second startup does not duplicate the code

```bash
uv run python -m pytest tests/unit/hosted_play/test_app.py -v
make check-quiet  # 10812 passed; 3 pre-existing failures (token_economy, telegram_filter)
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: feat/auto-seed-invite-code
```

## Scope
- `web/app.py` — auto-seed logic in lifespan, updated step numbers and imports
- `tests/unit/hosted_play/test_app.py` — 2 new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)