### PR TITLE
fix(web): use engine winner for tied-score match history display

### DIFF
--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -2481,6 +2481,89 @@ class TestMatchHistory:
         assert "Loss" in resp.text
         assert "OLSa" in resp.text
 
+    def test_history_tied_score_uses_engine_winner(self, client, app):
+        """When scores are tied (e.g. 55-55), the result comes from the
+        engine's winner field in match_state_json, not from score comparison.
+
+        Regression test for P2-003: tied scores were always shown as 'Loss'
+        because the history route used ``score_human > score_ai``.
+        """
+        import json
+        from datetime import datetime, timezone
+
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid, "TiedScore")
+
+        session_factory = app.state.session_factory
+        session = session_factory()
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+        assert player is not None
+
+        import uuid as uuid_mod
+
+        # Both teams crossed 52 in the same hand — engine declared human winner
+        tied_match = Match(
+            match_uuid=str(uuid_mod.uuid4()),
+            player_id=player.id,
+            ai_model="bud_bot",
+            status="complete",
+            seed=42,
+            score_human=55,
+            score_ai=55,
+            hands_played=8,
+            match_state_json=json.dumps({"winner": "human"}),
+            completed_at=datetime(2026, 4, 2, 10, 0, 0, tzinfo=timezone.utc),
+        )
+        session.add(tied_match)
+        session.commit()
+        session.close()
+
+        resp = client.get(f"/history/{link_uuid}")
+        assert resp.status_code == 200
+        # Should show "Win" because the engine declared human as winner,
+        # even though scores are tied
+        assert "Win" in resp.text
+        assert "55" in resp.text
+
+    def test_history_tied_score_ai_winner(self, client, app):
+        """When scores are tied and engine declared AI winner, show 'Loss'.
+
+        This covers the negative-threshold tiebreak case (e.g. both at -55).
+        """
+        import json
+        from datetime import datetime, timezone
+
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid, "TiedLoss")
+
+        session_factory = app.state.session_factory
+        session = session_factory()
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+        assert player is not None
+
+        import uuid as uuid_mod
+
+        tied_match = Match(
+            match_uuid=str(uuid_mod.uuid4()),
+            player_id=player.id,
+            ai_model="bud_bot",
+            status="complete",
+            seed=42,
+            score_human=55,
+            score_ai=55,
+            hands_played=8,
+            match_state_json=json.dumps({"winner": "ai"}),
+            completed_at=datetime(2026, 4, 2, 10, 0, 0, tzinfo=timezone.utc),
+        )
+        session.add(tied_match)
+        session.commit()
+        session.close()
+
+        resp = client.get(f"/history/{link_uuid}")
+        assert resp.status_code == 200
+        assert "Loss" in resp.text
+        assert "55" in resp.text
+
     def test_history_excludes_active_matches(self, client, app):
         """Active (in-progress) matches should NOT appear in history."""
         link_uuid = _create_game(client)

--- a/web/routes.py
+++ b/web/routes.py
@@ -1479,7 +1479,17 @@ async def match_history(request: Request, link_uuid: str):
             except KeyError:
                 ai_name = m.ai_model
 
-            won = m.score_human > m.score_ai
+            # Use the authoritative winner from match state rather than
+            # naive score comparison — tied scores (e.g. 55-55) are decided
+            # by the declaring-team rule and the engine records the correct
+            # winner in match_state_json.  Fall back to score comparison for
+            # legacy rows missing the winner field.
+            match_data = json.loads(m.match_state_json)
+            winner = match_data.get("winner")
+            if winner is not None:
+                won = winner == "human"
+            else:
+                won = m.score_human > m.score_ai
             history_entries.append(
                 {
                     "ai_name": ai_name,


### PR DESCRIPTION
## Summary
- Fix P2-003: match history showed "Loss" for tied scores (e.g. 55-55) even when the human team actually won
- The history route now extracts the authoritative `winner` from `match_state_json` instead of using naive `score_human > score_ai` comparison
- Falls back to score comparison for legacy rows missing the `winner` field

## Why
When both teams cross the ±52 threshold in the same hand, the engine correctly determines the winner (human team is checked first). But the history route re-derived the result using `score_human > score_ai`, which returns `False` for tied scores — always showing "Loss" regardless of who actually won.

## Root Cause
In `web/routes.py` line 1478, `won = m.score_human > m.score_ai` ignores the engine's `winner` field stored in `match_state_json`. For tied scores like 55-55, this always evaluates to `False` → "Loss".

## Fix
Parse `match_state_json` to extract the `winner` field set by the engine. Fall back to score comparison only for legacy match rows that lack the `winner` field.

## Scope Note
`web/leaderboard.py:252` has the same bug (`games_won = sum(1 for m in completed_matches if m.score_human > m.score_ai)`). This is outside declared scope — filed as a follow-up note.

## Repro / Validation
```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/hosted_play/test_routes.py::TestMatchHistory -x -q

# New regression tests for P2-003
uv run python -m pytest tests/unit/hosted_play/test_routes.py::TestMatchHistory::test_history_tied_score_uses_engine_winner -x -v
uv run python -m pytest tests/unit/hosted_play/test_routes.py::TestMatchHistory::test_history_tied_score_ai_winner -x -v

# Tier 2 — full validation
make check-quiet  # 3 pre-existing failures in unrelated tests (test_ops_token_economy, test_telegram_filter)
```

## Tests
- `test_history_tied_score_uses_engine_winner` — tied 55-55 with engine winner="human" → shows "Win"
- `test_history_tied_score_ai_winner` — tied 55-55 with engine winner="ai" → shows "Loss"
- All 8 TestMatchHistory tests pass (6 existing + 2 new)
- All 3216 hosted_play tests pass

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
git rev-parse --show-toplevel: Bid-Euchre-steward-brws-author-b
branch: fix/p2-003-tied-score-history
```

Addresses P2-003 from #2076

🤖 Generated with [Claude Code](https://claude.com/claude-code)