### PR TITLE
fix(web): resolve P1-001 card play 400 desync with graceful recovery

### DIFF
--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -2558,3 +2558,138 @@ class TestTabNavigation:
         resp = client.get(f"/play/{link_uuid}")
         assert resp.status_code == 200
         assert 'role="tablist"' in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Test: State-desync graceful recovery (P1-001 fix)
+# ---------------------------------------------------------------------------
+
+
+class TestDesyncGracefulRecovery:
+    """Stale HTMX button clicks get the authoritative board instead of 400.
+
+    When HTMX's morph swap fails to fully update the DOM, the player may
+    click a stale card-play or bid button.  The server returns the current
+    game board (200) so HTMX can re-sync, instead of returning 400 which
+    requires a full page reload.
+    """
+
+    def test_play_card_during_pause_returns_board(self, client, app):
+        """POST /play-card while paused_after_trick returns 200 board."""
+        link_uuid = _setup_game(client)
+
+        for _ in range(40):  # safety limit
+            advance_pending_reveals(client, app, link_uuid)
+            result = get_match_state(app, link_uuid)
+            assert result is not None
+            state, match_row, session = result
+
+            hand = state.current_hand
+            if hand is None:
+                session.close()
+                break
+
+            if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+                session.close()
+                client.post(
+                    f"/play/{link_uuid}/bid",
+                    data={
+                        "turn_number": hand.turn_number,
+                        "bid_n": 0,
+                        "bid_contract": "",
+                    },
+                )
+                continue
+
+            if hand.phase == "trick_play" and hand.current_seat == HUMAN_SEAT:
+                # Artificially set paused_after_trick to simulate the desync
+                # scenario: stale card buttons in the DOM while the server
+                # expects a "Next" press.
+                hand.paused_after_trick = True
+                match_row.match_state_json = json.dumps(state.to_dict())
+                session.commit()
+                session.close()
+
+                # Attempt to play a card — should get 200 board, not 400
+                resp = client.post(
+                    f"/play/{link_uuid}/play-card",
+                    data={"turn_number": hand.turn_number, "card_index": 0},
+                )
+                assert resp.status_code == 200
+                # Response should contain the game board HTML
+                assert "game-board" in resp.text or "next-controls" in resp.text
+                return
+
+            session.close()
+
+        pytest.fail("Never reached trick play to test desync recovery")
+
+    def test_bid_during_trick_play_returns_board(self, client, app):
+        """POST /bid while in trick_play phase returns 200 board."""
+        link_uuid = _setup_game(client)
+
+        for _ in range(40):
+            advance_pending_reveals(client, app, link_uuid)
+            result = get_match_state(app, link_uuid)
+            assert result is not None
+            state, _, session = result
+
+            hand = state.current_hand
+            if hand is None:
+                session.close()
+                break
+
+            if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+                session.close()
+                client.post(
+                    f"/play/{link_uuid}/bid",
+                    data={
+                        "turn_number": hand.turn_number,
+                        "bid_n": 0,
+                        "bid_contract": "",
+                    },
+                )
+                continue
+
+            if hand.phase == "trick_play" and hand.current_seat == HUMAN_SEAT:
+                session.close()
+                # Stale bid button in DOM — should get 200 board, not 400
+                resp = client.post(
+                    f"/play/{link_uuid}/bid",
+                    data={
+                        "turn_number": hand.turn_number,
+                        "bid_n": 0,
+                        "bid_contract": "",
+                    },
+                )
+                assert resp.status_code == 200
+                assert "game-board" in resp.text or "trick" in resp.text
+                return
+
+            session.close()
+
+        pytest.fail("Never reached trick play to test cross-phase desync")
+
+    def test_play_card_wrong_phase_returns_board(self, client, app):
+        """POST /play-card while in auction phase returns 200 board."""
+        link_uuid = _setup_game(client)
+
+        advance_pending_reveals(client, app, link_uuid)
+        result = get_match_state(app, link_uuid)
+        assert result is not None
+        state, _, session = result
+
+        hand = state.current_hand
+        if hand is None or hand.phase != "auction" or hand.current_seat != HUMAN_SEAT:
+            session.close()
+            pytest.skip("Game did not start in expected auction state")
+
+        session.close()
+
+        # Stale play-card button from previous hand — should get 200 board
+        resp = client.post(
+            f"/play/{link_uuid}/play-card",
+            data={"turn_number": hand.turn_number, "card_index": 0},
+        )
+        assert resp.status_code == 200
+        assert "game-board" in resp.text or "auction" in resp.text.lower()

--- a/web/routes.py
+++ b/web/routes.py
@@ -982,15 +982,14 @@ async def submit_bid(
         if hand is None or turn_number < hand.turn_number:
             return HTMLResponse(_render_game_board(request, engine, state, link_uuid))
 
-        # Validate phase
+        # State-desync recovery — return the authoritative board for stale
+        # requests instead of 400 so HTMX can re-sync the DOM.
         if hand.phase != "auction":
-            raise HTTPException(status_code=400, detail="Not in auction phase")
+            return HTMLResponse(_render_game_board(request, engine, state, link_uuid))
         if hand.current_seat != HUMAN_SEAT:
-            raise HTTPException(status_code=400, detail="Not the human's turn")
+            return HTMLResponse(_render_game_board(request, engine, state, link_uuid))
         if _awaiting_next(hand):
-            raise HTTPException(
-                status_code=400, detail="Advance the reveal state first"
-            )
+            return HTMLResponse(_render_game_board(request, engine, state, link_uuid))
 
         # Build bid action
         if bid_n == 0:
@@ -1121,15 +1120,18 @@ async def submit_card(
         if hand is None or turn_number < hand.turn_number:
             return HTMLResponse(_render_game_board(request, engine, state, link_uuid))
 
-        # Validate phase
+        # State-desync recovery — if HTMX morph left stale card buttons in
+        # the DOM the player may click a card while the server is in a
+        # different phase or waiting for a reveal advance.  Rather than
+        # returning a 400 (which requires a full page reload to recover),
+        # re-render the authoritative board so HTMX can swap in the correct
+        # state.  True validation errors (illegal card) still return 400.
         if hand.phase != "trick_play":
-            raise HTTPException(status_code=400, detail="Not in trick play phase")
+            return HTMLResponse(_render_game_board(request, engine, state, link_uuid))
         if hand.current_seat != HUMAN_SEAT:
-            raise HTTPException(status_code=400, detail="Not the human's turn")
+            return HTMLResponse(_render_game_board(request, engine, state, link_uuid))
         if _awaiting_next(hand):
-            raise HTTPException(
-                status_code=400, detail="Advance the reveal state first"
-            )
+            return HTMLResponse(_render_game_board(request, engine, state, link_uuid))
 
         # Validate legality
         legal_plays = engine.get_legal_plays(state)

--- a/web/static/game.js
+++ b/web/static/game.js
@@ -354,7 +354,13 @@
         document.body.addEventListener('htmx:responseError', function (event) {
             var status = event.detail.xhr ? event.detail.xhr.status : 0;
             var message;
-            if (status === 404) {
+            if (status === 400) {
+                // State desync — reload the page to recover the authoritative
+                // server state.  This handles stale card-play buttons left by
+                // HTMX morph swap failures.
+                refreshGameBoard();
+                return;
+            } else if (status === 404) {
                 message = 'Game not found. It may have expired.';
             } else if (status === 429) {
                 message = 'Too many active matches. Complete or abandon one first.';


### PR DESCRIPTION
## Summary

- **Server-side**: Replace `HTTPException(400)` with authoritative board re-render (200) for state-desync checks in `submit_card()` and `submit_bid()` — wrong phase, wrong turn, and pending reveal all return the correct game board HTML so HTMX can swap it in seamlessly
- **Client-side**: Add 400 → page reload handler in `game.js` as a safety net for any residual desync scenarios
- **Tests**: Add `TestDesyncGracefulRecovery` class with 3 test cases covering pause-during-play, cross-phase bid, and wrong-phase card-play recovery

## Why

P1-001 bug (#2076): HTMX morph swaps can fail to fully update the DOM after trick completion, leaving stale card-play buttons visible. Clicking stale buttons sent requests the server rejected with 400, requiring a full page reload. ~70% of card play attempts were failing in proving sessions.

The fix is defense-in-depth:
1. Server returns the correct board HTML (200) instead of 400 for stale/desynced requests → HTMX re-syncs the DOM automatically
2. Client catches any remaining 400s and reloads as a last resort
3. True validation errors (illegal card index) still return 400

## Repro / Validation

```bash
# Run route tests (all 73 pass)
uv run python -m pytest tests/unit/hosted_play/test_routes.py -v

# Run just the new desync recovery tests
uv run python -m pytest tests/unit/hosted_play/test_routes.py::TestDesyncGracefulRecovery -v

# Full validation (3 pre-existing failures unrelated to this PR)
make check-quiet
```

## Tests

- `uv run python -m pytest tests/unit/hosted_play/test_routes.py` — 73 passed, 1 skipped
- `make check-quiet` — 10819 passed (3 pre-existing failures in `test_ops_token_economy` and `test_telegram_filter`)

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

Closes #2076

🤖 Generated with [Claude Code](https://claude.com/claude-code)