### PR TITLE
fix(web): clarify bid badges in icon legend (#2109)

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1079,6 +1079,11 @@ main {
     font-size: 0.7rem;
 }
 
+.icon-legend__item .bid-tag {
+    font-size: 0.6rem;
+    padding: 0.08rem 0.25rem;
+}
+
 .icon-legend__sep {
     color: rgba(255, 255, 255, 0.25);
 }

--- a/web/templates/partials/game_board.html
+++ b/web/templates/partials/game_board.html
@@ -206,6 +206,8 @@
         <span class="icon-legend__item"><span class="seat-marker seat-marker--leader" aria-hidden="true">L</span> Lead</span>
         <span class="icon-legend__sep" aria-hidden="true">&middot;</span>
         <span class="icon-legend__item"><span class="seat-marker seat-marker--turn" aria-hidden="true">▶</span> Turn</span>
+        <span class="icon-legend__sep" aria-hidden="true">&middot;</span>
+        <span class="icon-legend__item"><span class="bid-tag" aria-hidden="true">5♠</span> Bid</span>
     </div>
 
     {% include "partials/action_rail.html" %}


### PR DESCRIPTION
## Summary
- Add a bid badge entry (`5♠ Bid`) to the on-board icon legend so new players understand what the badges next to player names mean
- Add a CSS rule to scale the bid-tag appropriately inside the legend

## Why
New players see "5♠" or "Pass" next to player names but have no
explanation of what they mean. The icon legend already explains D, X, L,
and ▶ — bid badges should be included too.

Closes #2109

## Repro / Validation
```bash
# Start a game and look at the icon legend below the game board
uv run python -m pytest tests/unit/hosted_play/test_partials.py -x -q
```

## Tests
```
uv run python -m pytest tests/unit/hosted_play/test_partials.py -x -q  # 158 passed
make check-quiet  # 3 pre-existing failures (token_economy, telegram_filter), unrelated
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
git rev-parse --show-toplevel: Bid-Euchre-steward-author-c
Branch: fix/bid-badge-legend
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)