### PR TITLE
fix: resolve moon sit-out contradiction — stale comments and logic bug (#2004)

### DIFF
--- a/scripts/internal/generate_action_value_dataset.py
+++ b/scripts/internal/generate_action_value_dataset.py
@@ -431,7 +431,7 @@ def simulate_moon_counterfactual(
     contract_type: str,
     trump_suit: str | None,
 ) -> tuple[float, float]:
-    """Simulate a moon bid: exchange cards with partner, play 4-player tricks.
+    """Simulate a moon bid: exchange cards with partner, play 3-player tricks.
 
     Moon scoring: +20 if declaring team wins all 10 tricks, -20 otherwise.
     Defending team gets their tricks won.
@@ -454,8 +454,10 @@ def simulate_moon_counterfactual(
     exchanged_hands[focal_seat] = mooner_hand
     exchanged_hands[partner_seat] = partner_hand
 
-    # Play tricks with mooner leading (auction winner leads)
-    t0, t1 = _play_tricks(exchanged_hands, focal_seat, contract_type, trump_suit)
+    # Play 3-player tricks (partner sits out, mooner leads)
+    t0, t1 = _play_tricks_loner(
+        exchanged_hands, focal_seat, partner_seat, contract_type, trump_suit
+    )
 
     # Compute points with moon scoring
     # focal_seat is the bidder

--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -2313,7 +2313,7 @@ class TestMoonExchangeRoute:
         hand.bid_type = "moon"
         hand.contract_type = "suit"
         hand.trump = "S"
-        hand.sitting_out_seat = None  # Moon = no sit-out
+        hand.sitting_out_seat = None  # Not set yet — exchange sets it
         hand.revealed_auction_count = len(hand.auction)
         hand.exchange_given = None
         hand.exchange_received = None


### PR DESCRIPTION
## Summary

- Fixed stale comment in `test_routes.py` that said "Moon = no sit-out" (changed to "Not set yet — exchange sets it")
- Fixed `simulate_moon_counterfactual()` in `generate_action_value_dataset.py`:
  - Updated docstring from "play 4-player tricks" to "play 3-player tricks"
  - Changed logic from `_play_tricks` (4-player) to `_play_tricks_loner` (3-player) to match the established moon rule

## Why

Issue #2004 was filed when RULES.md §3.6.2 (moon partner sits out, 3-player tricks) contradicted the engine implementation (moon = all 4 play). PRs #2005 and #2015 already fixed the engine to match RULES.md. This PR cleans up two stale artifacts that still reflected the old behavior.

Closes #2004

## Repro / Validation

```bash
# Verify all hosted_play tests pass (including moon sit-out assertions)
uv run python -m pytest tests/unit/hosted_play/ tests/integration/test_r3_smoke.py -x -q
# Result: 3274 passed, 6 skipped

# Verify engine moon sit-out behavior
uv run python -m pytest tests/unit/hosted_play/test_engine.py -k "moon" -v
```

## Tests

```bash
uv run python -m pytest tests/unit/hosted_play/ tests/integration/test_r3_smoke.py -x -q
# 3274 passed, 6 skipped
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
branch: fix/moon-sitout-docs-2004
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)