### PR TITLE
feat(web): give AI players character names instead of positional labels

### DIFF
--- a/tests/e2e/hosted_play/test_smoke_placeholder.py
+++ b/tests/e2e/hosted_play/test_smoke_placeholder.py
@@ -200,7 +200,7 @@ class TestTrickWinnerDisplay:
         assert "won" in html, "Expected 'won' text in trick winner display"
 
         # Verify the correct seat label appears
-        seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"}
+        seat_labels = {0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}
         expected_label = seat_labels[winner_seat]
         assert (
             expected_label in html
@@ -439,7 +439,7 @@ class TestHandSorting:
 class TestSeatLabels:
     """Verify seat labels render correctly across all templates."""
 
-    EXPECTED_LABELS = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"}
+    EXPECTED_LABELS = {0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}
 
     @pytest.mark.e2e
     def test_seat_labels_in_trick_area(
@@ -507,11 +507,9 @@ class TestSeatLabels:
         tmpl = jinja_env.get_template("partials/game_board.html")
         html = tmpl.render(**ctx)
 
-        assert "AI Left" in html, "Expected 'AI Left' in game board"
-        assert (
-            "AI Partner" in html or "Partner" in html
-        ), "Expected 'AI Partner' or 'Partner' in game board"
-        assert "AI Right" in html, "Expected 'AI Right' in game board"
+        assert "Slim" in html, "Expected 'Slim' in game board"
+        assert "Ace" in html, "Expected 'Ace' in game board"
+        assert "Deuce" in html, "Expected 'Deuce' in game board"
 
     @pytest.mark.e2e
     def test_seat_labels_in_trick_history(
@@ -535,8 +533,8 @@ class TestSeatLabels:
         html = tmpl.render(**ctx)
 
         winner = ctx["completed_tricks"][-1]["winner"]
-        # Trick history uses shortened labels
-        history_labels = {0: "You", 1: "Left", 2: "Partner", 3: "Right"}
+        # Trick history now uses character names
+        history_labels = {0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}
         expected = history_labels[winner]
         assert expected in html, f"Expected winner label '{expected}' in trick history"
 

--- a/tests/unit/hosted_play/test_bid_outcome_matrix.py
+++ b/tests/unit/hosted_play/test_bid_outcome_matrix.py
@@ -65,7 +65,7 @@ CONTRACTS: list[tuple[str, str | None]] = [
 
 SUIT_SYMBOLS = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"}
 
-SEAT_LABELS = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"}
+SEAT_LABELS = {0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}
 
 
 # ---------------------------------------------------------------------------
@@ -297,7 +297,7 @@ class TestDisplayConsistency:
 
     @pytest.mark.parametrize("case", MATRIX, ids=MATRIX_IDS)
     def test_seat_label(self, case: Case, jinja_env: jinja2.Environment) -> None:
-        """Correct seat label (You / AI Left / AI Partner / AI Right)."""
+        """Correct seat label (You / Slim / Ace / Deuce)."""
         html, _, _ = _render(jinja_env, case)
         expected = SEAT_LABELS[case.bidder_seat]
         assert expected in html, f"Seat label '{expected}' not in HTML"

--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -582,12 +582,12 @@ class TestTrick:
             tricks_team1=1,
         )
         assert "Trick 1 of 10 complete" in html
-        assert "AI Left" in html
-        assert "AI Partner" in html
-        assert "AI Right" in html
+        assert "Slim" in html
+        assert "Ace" in html
+        assert "Deuce" in html
         assert "\u2666" in html  # ♦
         assert "\u2660" in html  # ♠
-        assert "AI Partner" in html
+        assert "Ace" in html
         assert "won" in html
         assert "Last Trick" not in html
 
@@ -1161,8 +1161,8 @@ class TestHandResult:
             exchange_received=[["C", "J"], ["D", "9"]],
         )
         assert "Moon Exchange" in html
-        assert "AI Left" in html
-        assert "AI Right" in html
+        assert "Slim" in html
+        assert "Deuce" in html
         assert "♠A" in html
         assert "♥K" in html
         assert "♣J" in html
@@ -1170,7 +1170,7 @@ class TestHandResult:
 
     @pytest.mark.parametrize(
         "seat_val,expected_label",
-        [("0", "You"), ("1", "AI Left"), ("2", "AI Partner"), ("3", "AI Right")],
+        [("0", "You"), ("1", "Slim"), ("2", "Ace"), ("3", "Deuce")],
         ids=["str_seat0", "str_seat1", "str_seat2", "str_seat3"],
     )
     def test_string_bidder_seat_coerced_to_label(self, env, seat_val, expected_label):
@@ -1194,7 +1194,7 @@ class TestHandResult:
     @pytest.mark.parametrize("seat", [0, 1, 2, 3])
     def test_int_bidder_seat_still_works(self, env, seat):
         """Int bidder_seat values continue to resolve to correct labels (#1928)."""
-        expected = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"}
+        expected = {0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}
         html = env.get_template("partials/hand_result.html").render(
             winning_bid=6,
             bidder_seat=seat,
@@ -1372,8 +1372,8 @@ class TestMoonExchange:
             exchange_received=[["H", "A"], ["C", "K"]],
             human_hand=[],
         )
-        assert "AI Left" in html
-        assert "AI Right" in html  # partner of seat 1
+        assert "Slim" in html
+        assert "Deuce" in html  # partner of seat 1
 
     def test_shows_contract_info(self, env):
         """Trump suit is displayed in subtitle."""
@@ -1460,7 +1460,7 @@ class TestMoonExchangeSelect:
             is_mooner=False,
         )
         assert "Choose 2 cards to give to the mooner" in html
-        assert "AI Partner" in html  # mooner label for seat 2
+        assert "Ace" in html  # mooner label for seat 2
 
     def test_submit_button_disabled_by_default(self, env):
         """Submit button starts disabled."""
@@ -1524,7 +1524,7 @@ class TestTrickWinnerCard:
             tricks_team0=0,
             tricks_team1=1,
         )
-        assert "AI Left" in html
+        assert "Slim" in html
         assert "won" in html
         assert "with" in html
         assert "\u2666" in html  # diamond symbol
@@ -1726,11 +1726,11 @@ class TestGameBoardSeatZeroRegression:
         # Compact badge container present
         assert 'class="ai-hands-compact"' in html
         # Badges with correct card counts
-        assert "L:8" in html
-        assert "P:7" in html
-        assert "R:9" in html
+        assert "S:8" in html  # Slim (seat 1)
+        assert "A:7" in html  # Ace (seat 2)
+        assert "D:9" in html  # Deuce (seat 3)
         # Seat markers present inside compact badges
-        # dealer at seat 1 → L badge; declarer at seat 2 → P badge; turn at seat 3 → R badge
+        # dealer at seat 1 → Slim badge; declarer at seat 2 → Ace badge; turn at seat 3 → Deuce badge
         assert "ai-badge" in html
 
     def test_compact_badges_auction_phase(self, env):
@@ -1768,9 +1768,9 @@ class TestGameBoardSeatZeroRegression:
             action_rail=[],
         )
         assert 'class="ai-hands-compact"' in html
-        assert "L:10" in html
-        assert "P:10" in html
-        assert "R:10" in html
+        assert "S:10" in html  # Slim (seat 1)
+        assert "A:10" in html  # Ace (seat 2)
+        assert "D:10" in html  # Deuce (seat 3)
 
 
 # ---------------------------------------------------------------------------
@@ -1794,7 +1794,7 @@ class TestContractBar:
         assert "contract-bar" in html
         assert "6" in html
         assert "\u2665" in html  # Heart symbol
-        assert "AI Left" in html
+        assert "Slim" in html
 
     def test_high_contract(self, env):
         """High (no-trump) contract displays 'High' label."""
@@ -1822,7 +1822,7 @@ class TestContractBar:
         )
         assert "7" in html
         assert "Low" in html
-        assert "AI Partner" in html
+        assert "Ace" in html
 
     def test_moon_contract(self, env):
         """Moon bid shows moon emoji and label."""
@@ -1837,7 +1837,7 @@ class TestContractBar:
         assert "Moon" in html
         assert "contract-bar__type--moon" in html
         assert "\u2660" in html  # Spade symbol
-        assert "AI Right" in html
+        assert "Deuce" in html
 
     def test_loner_contract(self, env):
         """Loner bid shows loner emoji and label."""
@@ -2075,7 +2075,7 @@ class TestAccessibilityTrick:
             tricks_team0=0,
             tricks_team1=0,
         )
-        assert "AI Left played A of Hearts" in html
+        assert "Slim played A of Hearts" in html
 
     def test_empty_slot_has_waiting_label(self, env):
         tmpl = env.get_template("partials/trick.html")
@@ -2102,7 +2102,7 @@ class TestActionRail:
         tmpl = env.get_template("partials/action_rail.html")
         html = tmpl.render(
             action_rail=[
-                {"kind": "auction", "text": "AI Left passed"},
+                {"kind": "auction", "text": "Slim passed"},
                 {"kind": "trick", "text": "Your team won Trick 1"},
                 {"kind": "system", "text": "Hand starts"},
             ],
@@ -2110,7 +2110,7 @@ class TestActionRail:
         )
         assert 'id="action-rail"' in html
         assert "Auction Log" in html
-        assert "AI Left passed" in html
+        assert "Slim passed" in html
         assert "Your team won Trick 1" in html
         assert "Hand starts" in html
         assert "action-rail__item--auction" in html
@@ -2347,9 +2347,9 @@ class TestGameTemplateAccessibility:
             bidder_seat=None,
         )
         assert 'class="ai-card-count" aria-hidden="true"' not in html
-        assert "AI Left (10)" in html
-        assert "Partner (10)" in html
-        assert "AI Right (10)" in html
+        assert "Slim (10)" in html
+        assert "Ace (10)" in html
+        assert "Deuce (10)" in html
 
 
 # ---------------------------------------------------------------------------
@@ -2520,16 +2520,16 @@ class TestBidRecap:
             sitting_out_seat=2,
         )
         assert "bid-recap__sitting-out" in html
-        assert "AI Partner" in html
+        assert "Ace" in html
         assert "sits out" in html
 
     def test_loner_sitting_out_seat_labels(self, env):
         """Sitting-out uses correct seat labels for each seat."""
         for seat, label in [
             (0, "You"),
-            (1, "AI Left"),
-            (2, "AI Partner"),
-            (3, "AI Right"),
+            (1, "Slim"),
+            (2, "Ace"),
+            (3, "Deuce"),
         ]:
             html = self._render(
                 env,
@@ -2588,7 +2588,7 @@ class TestBidRecap:
 
     def test_seat_labels_correct(self, env):
         """Declarer label matches the seat label mapping."""
-        labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"}
+        labels = {0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}
         for seat, expected_label in labels.items():
             html = self._render(
                 env,
@@ -2732,7 +2732,7 @@ class TestTrickHistory:
             completed_tricks=completed_tricks, tricks_team0=1, tricks_team1=1
         )
         assert "You" in html  # Trick 1 won by seat 0
-        assert "Left" in html  # Trick 2 won by seat 1
+        assert "Slim" in html  # Trick 2 won by seat 1
 
     def test_has_table_headers(self, env, completed_tricks):
         """Table has column headers for seat labels."""
@@ -2740,8 +2740,8 @@ class TestTrickHistory:
         html = tmpl.render(
             completed_tricks=completed_tricks, tricks_team0=1, tricks_team1=1
         )
-        assert "Partner" in html
-        assert "Right" in html
+        assert "Ace" in html
+        assert "Deuce" in html
         assert "Won" in html
 
     def test_sitting_out_seat_shows_dash(self, env):

--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -479,8 +479,8 @@ class TestNextRevealFlow:
         # D♦ / A would appear as card rank+suit in the trick area
         assert "card--played" not in resp.text
 
-        # AI Left hand count should show 10 (pre-play), not 9
-        assert "AI Left (10)" in resp.text
+        # Slim (seat 1) hand count should show 10 (pre-play), not 9
+        assert "Slim (10)" in resp.text
 
         # No "Play card" button — still in auction reveal
         assert 'id="card-play-form"' not in resp.text
@@ -1162,9 +1162,9 @@ class TestXSSPrevention:
         resp = client.get(f"/play/{link_uuid}")
         assert resp.status_code == 200
         # Count labels should be present on first render.
-        assert "AI Left" in resp.text
-        assert "AI Partner" in resp.text
-        assert "AI Right" in resp.text
+        assert "Slim" in resp.text
+        assert "Ace" in resp.text
+        assert "Deuce" in resp.text
         # Ensure accessibility-related count labels are not excluded.
         assert 'class="ai-card-count" aria-hidden="true"' not in resp.text
 

--- a/tests/unit/hosted_play/test_scoring_matrix.py
+++ b/tests/unit/hosted_play/test_scoring_matrix.py
@@ -481,9 +481,9 @@ class TestSeatLabelDisplay:
 
     EXPECTED_LABELS = {
         0: "You",
-        1: "AI Left",
-        2: "AI Partner",
-        3: "AI Right",
+        1: "Slim",
+        2: "Ace",
+        3: "Deuce",
     }
 
     @pytest.mark.parametrize("bidder_seat", ALL_SEATS, ids=lambda s: f"seat{s}")

--- a/web/routes.py
+++ b/web/routes.py
@@ -41,6 +41,18 @@ from .middleware import (
 router = APIRouter()
 
 # ---------------------------------------------------------------------------
+# AI character names — replace positional labels with personality
+# ---------------------------------------------------------------------------
+# Positional info is conveyed by seat position on the board.  Character names
+# add flavour to the card-game feel.
+SEAT_LABELS: dict[int, str] = {
+    0: "You",
+    1: "Slim",  # left opponent
+    2: "Ace",  # partner
+    3: "Deuce",  # right opponent
+}
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -256,8 +268,7 @@ def _game_phase(state) -> str:
 
 def _format_auction_event(seat: int | None, action: dict[str, Any]) -> str:
     """Format a single auction event for the auction log."""
-    seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"}
-    seat_label = seat_labels.get(int(seat), f"Seat {seat}")
+    seat_label = SEAT_LABELS.get(int(seat), f"Seat {seat}")
 
     if action.get("action") == "pass":
         return f"{seat_label} passed"
@@ -325,7 +336,6 @@ def _build_action_rail(visible: dict[str, Any], state) -> list[dict[str, str]]:
     if hand is None:
         return []
 
-    seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"}
     events: list[dict[str, str]] = []
 
     # Auction activity (in order).
@@ -358,7 +368,7 @@ def _build_action_rail(visible: dict[str, Any], state) -> list[dict[str, str]]:
 
     # Hand-complete outcomes (compact summary).
     if hand.phase == "complete":
-        bidder = seat_labels.get(hand.bidder_seat, f"Seat {hand.bidder_seat}")
+        bidder = SEAT_LABELS.get(hand.bidder_seat, f"Seat {hand.bidder_seat}")
         if hand.contract_type == "suit" and hand.trump is not None:
             contract = hand.trump
         elif hand.contract_type == "high":
@@ -425,6 +435,7 @@ def _build_game_context(
         "link_uuid": link_uuid,
         "current_page": "game",
         "match_status": state.status,
+        "seat_labels": SEAT_LABELS,
         **visible,
     }
     ctx["phase"] = phase

--- a/web/templates/partials/bid_panel.html
+++ b/web/templates/partials/bid_panel.html
@@ -9,7 +9,7 @@
      - bid_type: str — current winning bid type ("regular", "moon", or "loner")
 #}
 {% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
-{% set seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"} %}
+{% set seat_labels = seat_labels | default({0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}) %}
 {% set bid_type_labels = {"regular": "", "moon": " Moon", "loner": " Loner"} %}
 
 <div id="bid-panel" role="region" aria-label="Auction panel">

--- a/web/templates/partials/bid_recap.html
+++ b/web/templates/partials/bid_recap.html
@@ -11,7 +11,7 @@
      - sitting_out_seat: int | None — seat sitting out (moon and loner bids)
 #}
 {% set suit_symbols = {"S": "\u2660", "H": "\u2665", "D": "\u2666", "C": "\u2663"} %}
-{% set seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"} %}
+{% set seat_labels = seat_labels | default({0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}) %}
 
 {% if winning_bid is not none and bidder_seat is not none %}
 <div class="bid-recap" role="status" aria-label="Auction result">

--- a/web/templates/partials/contract_bar.html
+++ b/web/templates/partials/contract_bar.html
@@ -10,7 +10,7 @@
      - trump: str | None — trump suit letter if contract_type == "suit"
 #}
 {% set suit_symbols = {"S": "\u2660", "H": "\u2665", "D": "\u2666", "C": "\u2663"} %}
-{% set seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"} %}
+{% set seat_labels = seat_labels | default({0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}) %}
 
 {% if winning_bid is not none and bidder_seat is not none %}
 <div class="contract-bar" role="status" aria-label="Current contract">

--- a/web/templates/partials/game_board.html
+++ b/web/templates/partials/game_board.html
@@ -13,6 +13,7 @@
 {% set sitting_out_seat = sitting_out_seat | default(None, true) %}
 {% set show_next = show_next | default(false, true) %}
 {% set show_bid_panel = show_bid_panel | default(false, true) %}
+{% set seat_labels = seat_labels | default({0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}) %}
 
 {# ---- Match result (win/loss screen) ---- #}
 {% if phase == "match_result" %}
@@ -35,22 +36,22 @@
 
     {# AI hands — compact badges (mobile only, hidden on desktop via CSS) #}
     <div class="ai-hands-compact" role="region" aria-label="AI opponent hands">
-        <span class="ai-badge" aria-label="AI Left: {{ opp_left_count | default(0) }} cards">
-            L:{{ opp_left_count | default(0) }}
+        <span class="ai-badge" aria-label="{{ seat_labels[1] }}: {{ opp_left_count | default(0) }} cards">
+            {{ seat_labels[1][0] }}:{{ opp_left_count | default(0) }}
             {%- if dealer_seat == 1 %}<span class="seat-marker seat-marker--dealer" title="Dealer">D</span>{% endif -%}
             {%- if bidder_seat == 1 %}<span class="seat-marker seat-marker--declarer" title="Declarer">X</span>{% endif -%}
             {%- if current_seat == 1 %}<span class="seat-marker seat-marker--turn" title="Current turn">▶</span>{% endif -%}
             {%- if sitting_out_seat == 1 %}<span class="seat-marker seat-marker--sitting-out" title="Sitting out">SO</span>{% endif -%}
         </span>
-        <span class="ai-badge" aria-label="Partner: {{ partner_count | default(0) }} cards">
-            P:{{ partner_count | default(0) }}
+        <span class="ai-badge" aria-label="{{ seat_labels[2] }}: {{ partner_count | default(0) }} cards">
+            {{ seat_labels[2][0] }}:{{ partner_count | default(0) }}
             {%- if dealer_seat == 2 %}<span class="seat-marker seat-marker--dealer" title="Dealer">D</span>{% endif -%}
             {%- if bidder_seat == 2 %}<span class="seat-marker seat-marker--declarer" title="Declarer">X</span>{% endif -%}
             {%- if current_seat == 2 %}<span class="seat-marker seat-marker--turn" title="Current turn">▶</span>{% endif -%}
             {%- if sitting_out_seat == 2 %}<span class="seat-marker seat-marker--sitting-out" title="Sitting out">SO</span>{% endif -%}
         </span>
-        <span class="ai-badge" aria-label="AI Right: {{ opp_right_count | default(0) }} cards">
-            R:{{ opp_right_count | default(0) }}
+        <span class="ai-badge" aria-label="{{ seat_labels[3] }}: {{ opp_right_count | default(0) }} cards">
+            {{ seat_labels[3][0] }}:{{ opp_right_count | default(0) }}
             {%- if dealer_seat == 3 %}<span class="seat-marker seat-marker--dealer" title="Dealer">D</span>{% endif -%}
             {%- if bidder_seat == 3 %}<span class="seat-marker seat-marker--declarer" title="Declarer">X</span>{% endif -%}
             {%- if current_seat == 3 %}<span class="seat-marker seat-marker--turn" title="Current turn">▶</span>{% endif -%}
@@ -58,14 +59,14 @@
         </span>
     </div>
 
-    {# Compass-rose grid: Partner top, AI Left left, AI Right right, Human bottom #}
+    {# Compass-rose grid: Ace (partner) top, Slim left, Deuce right, Human bottom #}
     <div class="compass-layout" role="region" aria-label="Game table">
 
         {# Top — Partner (seat 2) #}
-        <div class="compass-top" role="region" aria-label="Partner hand">
+        <div class="compass-top" role="region" aria-label="{{ seat_labels[2] }} hand">
             <div class="ai-hand-block">
                 <div class="ai-seat-label">
-                    {{ "AI Partner" }}
+                    {{ seat_labels[2] }}
                     {% if dealer_seat == 2 %}
                         <span class="seat-marker seat-marker--dealer" title="Dealer">D</span>
                     {% endif %}
@@ -82,20 +83,20 @@
                         <span class="bid-tag" title="Bid: {{ seat_bids[2] }}">{{ seat_bids[2] }}</span>
                     {% endif %}
                 </div>
-                <div class="ai-hand" role="img" aria-label="Partner has {{ partner_count | default(0) }} cards">
+                <div class="ai-hand" role="img" aria-label="{{ seat_labels[2] }} has {{ partner_count | default(0) }} cards">
                     {% for _ in range(partner_count | default(0)) %}
                     <div class="card-back" aria-hidden="true"></div>
                     {% endfor %}
                 </div>
-                <span class="ai-card-count">Partner ({{ partner_count | default(0) }})</span>
+                <span class="ai-card-count">{{ seat_labels[2] }} ({{ partner_count | default(0) }})</span>
             </div>
         </div>
 
-        {# Left — AI Left opponent (seat 1) — vertical orientation #}
-        <div class="compass-left" role="region" aria-label="AI Left hand">
+        {# Left — Slim opponent (seat 1) — vertical orientation #}
+        <div class="compass-left" role="region" aria-label="{{ seat_labels[1] }} hand">
             <div class="ai-hand-block ai-hand-block--vertical">
                 <div class="ai-seat-label">
-                    {{ "AI Left" }}
+                    {{ seat_labels[1] }}
                     {% if dealer_seat == 1 %}
                         <span class="seat-marker seat-marker--dealer" title="Dealer">D</span>
                     {% endif %}
@@ -112,12 +113,12 @@
                         <span class="bid-tag" title="Bid: {{ seat_bids[1] }}">{{ seat_bids[1] }}</span>
                     {% endif %}
                 </div>
-                <div class="ai-hand ai-hand--vertical" role="img" aria-label="AI Left has {{ opp_left_count | default(0) }} cards">
+                <div class="ai-hand ai-hand--vertical" role="img" aria-label="{{ seat_labels[1] }} has {{ opp_left_count | default(0) }} cards">
                     {% for _ in range(opp_left_count | default(0)) %}
                     <div class="card-back" aria-hidden="true"></div>
                     {% endfor %}
                 </div>
-                <span class="ai-card-count">AI Left ({{ opp_left_count | default(0) }})</span>
+                <span class="ai-card-count">{{ seat_labels[1] }} ({{ opp_left_count | default(0) }})</span>
             </div>
         </div>
 
@@ -144,11 +145,11 @@
             {% endif %}
         </div>
 
-        {# Right — AI Right opponent (seat 3) — vertical orientation #}
-        <div class="compass-right" role="region" aria-label="AI Right hand">
+        {# Right — Deuce opponent (seat 3) — vertical orientation #}
+        <div class="compass-right" role="region" aria-label="{{ seat_labels[3] }} hand">
             <div class="ai-hand-block ai-hand-block--vertical">
                 <div class="ai-seat-label">
-                    {{ "AI Right" }}
+                    {{ seat_labels[3] }}
                     {% if dealer_seat == 3 %}
                         <span class="seat-marker seat-marker--dealer" title="Dealer">D</span>
                     {% endif %}
@@ -165,12 +166,12 @@
                         <span class="bid-tag" title="Bid: {{ seat_bids[3] }}">{{ seat_bids[3] }}</span>
                     {% endif %}
                 </div>
-                <div class="ai-hand ai-hand--vertical" role="img" aria-label="AI Right has {{ opp_right_count | default(0) }} cards">
+                <div class="ai-hand ai-hand--vertical" role="img" aria-label="{{ seat_labels[3] }} has {{ opp_right_count | default(0) }} cards">
                     {% for _ in range(opp_right_count | default(0)) %}
                     <div class="card-back" aria-hidden="true"></div>
                     {% endfor %}
                 </div>
-                <span class="ai-card-count">AI Right ({{ opp_right_count | default(0) }})</span>
+                <span class="ai-card-count">{{ seat_labels[3] }} ({{ opp_right_count | default(0) }})</span>
             </div>
         </div>
 

--- a/web/templates/partials/hand_result.html
+++ b/web/templates/partials/hand_result.html
@@ -14,7 +14,7 @@
      - hands_played: int — total hands completed
 #}
 {% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
-{% set seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"} %}
+{% set seat_labels = seat_labels | default({0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}) %}
 {% set bidder_seat = bidder_seat | int %}
 {% set hand_bid_type = bid_type | default("regular") %}
 {% set exchange_given_cards = exchange_given | default([], true) %}

--- a/web/templates/partials/moon_exchange.html
+++ b/web/templates/partials/moon_exchange.html
@@ -14,7 +14,7 @@
 {% set suit_symbols = {"S": "\u2660", "H": "\u2665", "D": "\u2666", "C": "\u2663"} %}
 {% set suit_names = {"S": "Spades", "H": "Hearts", "D": "Diamonds", "C": "Clubs"} %}
 {% set suit_classes = {"S": "spades", "H": "hearts", "D": "diamonds", "C": "clubs"} %}
-{% set seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"} %}
+{% set seat_labels = seat_labels | default({0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}) %}
 {% set mooner_label = seat_labels.get(bidder_seat | default(0), "Seat " ~ bidder_seat) %}
 {% set partner_seat = (bidder_seat + 2) % 4 if bidder_seat is defined else 2 %}
 {% set partner_label = seat_labels.get(partner_seat, "Seat " ~ partner_seat) %}

--- a/web/templates/partials/moon_exchange_select.html
+++ b/web/templates/partials/moon_exchange_select.html
@@ -13,7 +13,7 @@
 {% set suit_symbols = {"S": "\u2660", "H": "\u2665", "D": "\u2666", "C": "\u2663"} %}
 {% set suit_names = {"S": "Spades", "H": "Hearts", "D": "Diamonds", "C": "Clubs"} %}
 {% set suit_classes = {"S": "spades", "H": "hearts", "D": "diamonds", "C": "clubs"} %}
-{% set seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"} %}
+{% set seat_labels = seat_labels | default({0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}) %}
 {% set mooner_label = seat_labels.get(bidder_seat | default(0), "Seat " ~ bidder_seat) %}
 
 <div id="moon-exchange-select" class="moon-exchange" role="region" aria-live="polite">

--- a/web/templates/partials/score.html
+++ b/web/templates/partials/score.html
@@ -13,7 +13,7 @@
      - phase: str — current hand phase
 #}
 {% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
-{% set seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"} %}
+{% set seat_labels = seat_labels | default({0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}) %}
 
 <div id="score-bar" class="score-bar" role="status" aria-label="Match score and hand information" aria-live="polite">
     <div class="score-section" aria-label="Match score: You {{ score_human }}, AI {{ score_ai }}">

--- a/web/templates/partials/trick.html
+++ b/web/templates/partials/trick.html
@@ -13,7 +13,7 @@
 {% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
 {% set suit_names = {"S": "Spades", "H": "Hearts", "D": "Diamonds", "C": "Clubs"} %}
 {% set suit_classes = {"S": "spades", "H": "hearts", "D": "diamonds", "C": "clubs"} %}
-{% set seat_labels = {0: "You", 1: "AI Left", 2: "AI Partner", 3: "AI Right"} %}
+{% set seat_labels = seat_labels | default({0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}) %}
 {% set display_plays = [] %}
 {% set display_winner = None %}
 {% set display_leader = None %}

--- a/web/templates/partials/trick_history.html
+++ b/web/templates/partials/trick_history.html
@@ -6,7 +6,7 @@
 #}
 {% set suit_symbols = {"S": "\u2660", "H": "\u2665", "D": "\u2666", "C": "\u2663"} %}
 {% set suit_classes = {"S": "spades", "H": "hearts", "D": "diamonds", "C": "clubs"} %}
-{% set seat_labels = {0: "You", 1: "Left", 2: "Partner", 3: "Right"} %}
+{% set seat_labels = seat_labels | default({0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}) %}
 
 {% if completed_tricks %}
 <details id="trick-history" class="trick-history" role="region" aria-label="Cards played history">
@@ -19,9 +19,9 @@
                 <tr>
                     <th class="trick-history__th">#</th>
                     <th class="trick-history__th">You</th>
-                    <th class="trick-history__th">Left</th>
-                    <th class="trick-history__th">Partner</th>
-                    <th class="trick-history__th">Right</th>
+                    <th class="trick-history__th">{{ seat_labels[1] }}</th>
+                    <th class="trick-history__th">{{ seat_labels[2] }}</th>
+                    <th class="trick-history__th">{{ seat_labels[3] }}</th>
                     <th class="trick-history__th">Won</th>
                 </tr>
             </thead>


### PR DESCRIPTION
## Summary
- Replace positional labels ('AI Left', 'AI Right', 'AI Partner') with character names (Slim, Deuce, Ace) across all game templates and routes
- Define `SEAT_LABELS` constant in `routes.py` as single source of truth, passed through template context with `| default(...)` fallback
- Update all test assertions (3,245 hosted-play tests pass)

## Why
Positional labels ("AI Left", "AI Right") feel like debug labels, not opponents in a card game. The seat position on the board already conveys left/right/partner, so the labels can carry personality instead.

Closes #2096

## Repro / Validation
```bash
# Targeted tests (all pass)
uv run python -m pytest tests/unit/hosted_play/ tests/e2e/hosted_play/ -q

# Full validation
make check-quiet  # 10,825 passed, 3 pre-existing failures in unrelated modules
```

## Scope
| File | Change |
|------|--------|
| `web/routes.py` | Add `SEAT_LABELS` constant, use in `_format_auction_event`, `_build_event_feed`, pass through `_build_game_context` |
| `web/templates/partials/*.html` (9 files) | Replace hardcoded seat_labels dicts with character names + `\| default(...)` fallback |
| `tests/unit/hosted_play/test_partials.py` | Update 20+ assertions for new names |
| `tests/unit/hosted_play/test_routes.py` | Update assertions for new names |
| `tests/unit/hosted_play/test_bid_outcome_matrix.py` | Update SEAT_LABELS constant |
| `tests/unit/hosted_play/test_scoring_matrix.py` | Update EXPECTED_LABELS |
| `tests/e2e/hosted_play/test_smoke_placeholder.py` | Update label expectations |

## Character Names
| Seat | Old Label | New Name |
|------|-----------|----------|
| 0 (human) | You | You |
| 1 (left) | AI Left | Slim |
| 2 (partner) | AI Partner | Ace |
| 3 (right) | AI Right | Deuce |

## Worktree Proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
branch: feat/ai-character-names-2096
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)