### PR TITLE
fix(web): show overall avg margin on leaderboard instead of victory-only (#2118)

### DIFF
--- a/web/leaderboard.py
+++ b/web/leaderboard.py
@@ -66,10 +66,10 @@ METRIC_DEFINITIONS: dict[str, MetricDef] = {
         format="pct",
         category="default",
     ),
-    "avg_margin_victory": MetricDef(
+    "avg_match_margin": MetricDef(
         label="Avg Margin",
-        tooltip="Average score margin in games you won (points).",
-        format="float1",
+        tooltip="Average score margin across all completed matches (positive = winning).",
+        format="signed_float1",
         category="default",
     ),
     "matches_played": MetricDef(
@@ -84,10 +84,10 @@ METRIC_DEFINITIONS: dict[str, MetricDef] = {
         format="int",
         category="secondary",
     ),
-    "avg_match_margin": MetricDef(
-        label="Match Margin",
-        tooltip="Average score margin across all completed matches (positive = winning).",
-        format="signed_float1",
+    "avg_margin_victory": MetricDef(
+        label="Win Margin",
+        tooltip="Average score margin in games you won (points).",
+        format="float1",
         category="secondary",
     ),
     "bid_rate": MetricDef(


### PR DESCRIPTION
## Summary

- **Swap leaderboard "Avg Margin" metric** from `avg_margin_victory` (wins only) to `avg_match_margin` (all completed matches) in the default-visible columns
- Demote `avg_margin_victory` to secondary column with label "Win Margin"
- Update tooltip to "Average score margin across all completed matches (positive = winning)"

## Why

Players with 0 wins showed "Avg Margin: 0.0" which is misleading — they may have large negative margins from losses. The overall match margin is a more informative default metric that correctly shows negative values for losing players.

## Repro / Validation

```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/hosted_play/test_leaderboard.py -x -q
# 59 passed

# Full hosted_play suite
uv run python -m pytest tests/unit/hosted_play/ -x -q
# 3226 passed, 6 skipped
```

## Tests

- All 59 leaderboard tests pass (including MetricDefinitions tests that validate field↔def alignment)
- All 3226 hosted_play tests pass
- `make check-quiet`: 3 pre-existing failures in unrelated ops modules (token_economy, telegram_filter)

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
show-toplevel: Bid-Euchre-steward-brws-author-a
```

Closes #2118

🤖 Generated with [Claude Code](https://claude.com/claude-code)