### PR TITLE
fix(web): remove red/black suit coloring from trick history table

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -844,19 +844,12 @@ main {
     color: rgba(255, 255, 255, 0.2);
 }
 
-/* Inline card rendering (for trick history table) */
+/* Inline card rendering (for trick history table) —
+   all cards white; suit symbols provide identification.
+   Leader underline and winner highlight remain via cell classes. */
 .card--inline {
     font-weight: 700;
     white-space: nowrap;
-}
-
-.card--inline.card--hearts,
-.card--inline.card--diamonds {
-    color: var(--color-red);
-}
-
-.card--inline.card--spades,
-.card--inline.card--clubs {
     color: var(--color-text);
 }
 

--- a/web/templates/partials/trick_history.html
+++ b/web/templates/partials/trick_history.html
@@ -5,7 +5,6 @@
      - tricks_team1: int — tricks won by AI team
 #}
 {% set suit_symbols = {"S": "\u2660", "H": "\u2665", "D": "\u2666", "C": "\u2663"} %}
-{% set suit_classes = {"S": "spades", "H": "hearts", "D": "diamonds", "C": "clubs"} %}
 {% set seat_labels = seat_labels | default({0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}) %}
 
 {% if completed_tricks %}
@@ -38,7 +37,7 @@
                                 {% if seat in ns.cards %}
                                     {% set card = ns.cards[seat] %}
                                     {% set suit = card[0] %}
-                                    <span class="card--inline card--{{ suit_classes.get(suit, 'spades') }}">{{ card[1] }}{{ suit_symbols.get(suit, suit) }}</span>
+                                    <span class="card--inline">{{ card[1] }}{{ suit_symbols.get(suit, suit) }}</span>
                                 {% else %}
                                     <span class="trick-history__absent" aria-label="Sitting out">&mdash;</span>
                                 {% endif %}


### PR DESCRIPTION
## Summary

- Remove red/black suit-specific coloring from the Cards Played (trick history) table
- All card text now renders in white (`--color-text`) regardless of suit
- Suit symbols (♥♦♠♣) are preserved for suit identification
- Leader underline and winner cell highlight are unchanged

## Why

Red/black suit coloring in the trick history creates a false visual impression
of winning/losing that doesn't exist — the colors are just suit indicators but
players may interpret red as "bad" and dark as "good" (or vice versa).

Closes #2116

## Changes

| File | Change |
|------|--------|
| `web/static/style.css` | Collapse `.card--inline.card--{suit}` rules into single `.card--inline` with `color: var(--color-text)` |
| `web/templates/partials/trick_history.html` | Remove unused `suit_classes` mapping and `card--{suit}` class from `<span>` |

## Scope

Trick history table only — card coloring in hand display and trick area is unaffected.

## Repro / Validation

```bash
make check-quiet
# 3 pre-existing failures (token_economy, telegram_filter) — unrelated to this change
```

Visual: start a game, play a few tricks, open the "Cards Played" collapsible — all card text should be white.

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: fix/trick-history-white-text-2116
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)