### PR TITLE
feat(web): add comments board backend and UI (#1916)

### DIFF
--- a/tests/unit/hosted_play/test_comments.py
+++ b/tests/unit/hosted_play/test_comments.py
@@ -1,0 +1,319 @@
+"""Tests for the comments board feature.
+
+Covers:
+- Comment model creation and constraints
+- GET /comments/{link_uuid} page rendering
+- GET /comments/{link_uuid}/list HTMX partial
+- POST /play/{link_uuid}/comment submission
+- Validation (empty, too long, unknown player)
+- Newest-first ordering
+"""
+
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+
+from tests.unit.hosted_play.conftest import (
+    create_test_player,
+    make_hosted_play_test_config,
+)
+from web.app import create_app
+from web.db import Comment
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def config(tmp_path):
+    return make_hosted_play_test_config(tmp_path)
+
+
+@pytest.fixture()
+def app(config):
+    return create_app(config=config)
+
+
+@pytest.fixture()
+def client(app):
+    with TestClient(app) as c:
+        yield c
+
+
+def _create_player(app, nickname: str | None = "Tester") -> str:
+    """Create a player directly in the DB, return link_uuid."""
+    session = app.state.session_factory()
+    try:
+        player = create_test_player(session, nickname=nickname)
+        session.commit()
+        return player.link_uuid
+    finally:
+        session.close()
+
+
+# ---------------------------------------------------------------------------
+# Comment model tests
+# ---------------------------------------------------------------------------
+
+
+class TestCommentModel:
+    """Test Comment DB model constraints."""
+
+    def test_create_comment(self, client, app):
+        """Comment with valid content is persisted."""
+        session = app.state.session_factory()
+        try:
+            player = create_test_player(session, nickname="Alice")
+            session.commit()
+
+            comment = Comment(player_id=player.id, content="Great game!")
+            session.add(comment)
+            session.commit()
+
+            saved = session.query(Comment).first()
+            assert saved is not None
+            assert saved.content == "Great game!"
+            assert saved.player_id == player.id
+            assert saved.created_at is not None
+            assert saved.match_id is None
+        finally:
+            session.close()
+
+    def test_comment_repr(self, client, app):
+        """Comment repr includes id and player_id."""
+        session = app.state.session_factory()
+        try:
+            player = create_test_player(session, nickname="Alice")
+            session.commit()
+
+            comment = Comment(player_id=player.id, content="Test")
+            session.add(comment)
+            session.commit()
+
+            assert "Comment" in repr(comment)
+            assert str(comment.player_id) in repr(comment)
+        finally:
+            session.close()
+
+
+# ---------------------------------------------------------------------------
+# GET /comments/{link_uuid} — full page
+# ---------------------------------------------------------------------------
+
+
+class TestCommentsPage:
+    """Test the comments page route."""
+
+    def test_comments_page_renders(self, client, app):
+        """Comments page renders for a valid player."""
+        link_uuid = _create_player(app, "Alice")
+        resp = client.get(f"/comments/{link_uuid}")
+        assert resp.status_code == 200
+        assert "Comments" in resp.text
+        assert "No comments yet" in resp.text
+
+    def test_comments_page_shows_comments(self, client, app):
+        """Comments page shows existing comments."""
+        link_uuid = _create_player(app, "Alice")
+
+        # Post a comment first
+        client.post(
+            f"/play/{link_uuid}/comment",
+            data={"content": "Hello world!"},
+        )
+
+        resp = client.get(f"/comments/{link_uuid}")
+        assert resp.status_code == 200
+        assert "Hello world!" in resp.text
+        assert "Alice" in resp.text
+
+    def test_comments_page_unknown_player(self, client):
+        """Unknown link_uuid returns 404."""
+        resp = client.get("/comments/nonexistent-uuid")
+        assert resp.status_code == 404
+
+    def test_comments_tab_active(self, client, app):
+        """Comments tab is marked active on comments page."""
+        link_uuid = _create_player(app, "Alice")
+        resp = client.get(f"/comments/{link_uuid}")
+        assert "header-nav__tab--active" in resp.text
+        # Check that the active tab is the Comments one
+        assert f'/comments/{link_uuid}"' in resp.text
+
+
+# ---------------------------------------------------------------------------
+# GET /comments/{link_uuid}/list — HTMX partial
+# ---------------------------------------------------------------------------
+
+
+class TestCommentsListPartial:
+    """Test the HTMX comments list partial."""
+
+    def test_empty_list(self, client, app):
+        """Empty comment list shows placeholder."""
+        link_uuid = _create_player(app, "Alice")
+        resp = client.get(f"/comments/{link_uuid}/list")
+        assert resp.status_code == 200
+        assert "No comments yet" in resp.text
+
+    def test_list_with_comments(self, client, app):
+        """Comment list shows posted comments."""
+        link_uuid = _create_player(app, "Alice")
+
+        # Post comments
+        client.post(f"/play/{link_uuid}/comment", data={"content": "First!"})
+        client.post(f"/play/{link_uuid}/comment", data={"content": "Second!"})
+
+        resp = client.get(f"/comments/{link_uuid}/list")
+        assert resp.status_code == 200
+        assert "First!" in resp.text
+        assert "Second!" in resp.text
+
+    def test_unknown_player_returns_404(self, client):
+        """Unknown link_uuid returns 404."""
+        resp = client.get("/comments/nonexistent-uuid/list")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /play/{link_uuid}/comment — submission
+# ---------------------------------------------------------------------------
+
+
+class TestPostComment:
+    """Test comment submission."""
+
+    def test_post_comment_success(self, client, app):
+        """Valid comment is saved and redirects (non-HTMX)."""
+        link_uuid = _create_player(app, "Alice")
+        resp = client.post(
+            f"/play/{link_uuid}/comment",
+            data={"content": "Nice hand!"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+        assert f"/comments/{link_uuid}" in resp.headers["location"]
+
+        # Verify comment was saved
+        session = app.state.session_factory()
+        try:
+            count = session.query(Comment).count()
+            assert count == 1
+            comment = session.query(Comment).first()
+            assert comment.content == "Nice hand!"
+        finally:
+            session.close()
+
+    def test_post_comment_htmx(self, client, app):
+        """HTMX submission returns the updated list partial."""
+        link_uuid = _create_player(app, "Alice")
+        resp = client.post(
+            f"/play/{link_uuid}/comment",
+            data={"content": "HTMX comment"},
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        assert "HTMX comment" in resp.text
+        assert "Alice" in resp.text
+
+    def test_post_comment_strips_whitespace(self, client, app):
+        """Leading/trailing whitespace is stripped."""
+        link_uuid = _create_player(app, "Alice")
+        client.post(
+            f"/play/{link_uuid}/comment",
+            data={"content": "  trimmed  "},
+            headers={"HX-Request": "true"},
+        )
+
+        session = app.state.session_factory()
+        try:
+            comment = session.query(Comment).first()
+            assert comment is not None
+            assert comment.content == "trimmed"
+        finally:
+            session.close()
+
+    def test_post_comment_too_long(self, client, app):
+        """Comment exceeding max length is rejected (no DB insert)."""
+        link_uuid = _create_player(app, "Alice")
+        long_content = "x" * 501
+        resp = client.post(
+            f"/play/{link_uuid}/comment",
+            data={"content": long_content},
+            headers={"HX-Request": "true"},
+        )
+        # Should still return 200 (HTMX) but not save
+        assert resp.status_code == 200
+
+        session = app.state.session_factory()
+        try:
+            assert session.query(Comment).count() == 0
+        finally:
+            session.close()
+
+    def test_post_empty_comment(self, client, app):
+        """Whitespace-only comment is rejected."""
+        link_uuid = _create_player(app, "Alice")
+        resp = client.post(
+            f"/play/{link_uuid}/comment",
+            data={"content": "   "},
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+
+        session = app.state.session_factory()
+        try:
+            assert session.query(Comment).count() == 0
+        finally:
+            session.close()
+
+    def test_post_comment_unknown_player(self, client):
+        """Comment from unknown player returns 404."""
+        resp = client.post(
+            "/play/nonexistent-uuid/comment",
+            data={"content": "Hello"},
+        )
+        assert resp.status_code == 404
+
+    def test_comments_newest_first(self, client, app):
+        """Comments are ordered newest first."""
+        link_uuid = _create_player(app, "Alice")
+
+        client.post(f"/play/{link_uuid}/comment", data={"content": "First"})
+        client.post(f"/play/{link_uuid}/comment", data={"content": "Second"})
+        client.post(f"/play/{link_uuid}/comment", data={"content": "Third"})
+
+        resp = client.get(f"/comments/{link_uuid}/list")
+        text = resp.text
+        # "Third" should appear before "First" in the HTML
+        assert text.index("Third") < text.index("First")
+
+    def test_comments_from_multiple_players(self, client, app):
+        """Comments from different players show correct nicknames."""
+        link_uuid_a = _create_player(app, "Alice")
+        link_uuid_b = _create_player(app, "Bob")
+
+        client.post(f"/play/{link_uuid_a}/comment", data={"content": "Hi from Alice"})
+        client.post(f"/play/{link_uuid_b}/comment", data={"content": "Hi from Bob"})
+
+        resp = client.get(f"/comments/{link_uuid_a}/list")
+        assert "Alice" in resp.text
+        assert "Bob" in resp.text
+        assert "Hi from Alice" in resp.text
+        assert "Hi from Bob" in resp.text
+
+    def test_anonymous_player_comment(self, client, app):
+        """Player without nickname shows as Anonymous."""
+        link_uuid = _create_player(app, nickname=None)
+
+        client.post(
+            f"/play/{link_uuid}/comment",
+            data={"content": "Anon here"},
+            headers={"HX-Request": "true"},
+        )
+
+        resp = client.get(f"/comments/{link_uuid}/list")
+        assert "Anonymous" in resp.text
+        assert "Anon here" in resp.text

--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -2665,18 +2665,19 @@ class TestTabNavigation:
         assert resp.status_code == 200
         assert "header-nav__tab--active" in resp.text
 
-    def test_comments_tab_disabled(self, client):
-        """Comments tab is present but disabled with 'Coming soon' tooltip."""
+    def test_comments_tab_active_link(self, client):
+        """Comments tab is an active navigation link (not disabled)."""
         link_uuid = _create_game(client)
         _set_nickname(client, link_uuid)
         _select_ai(client, link_uuid)
 
         resp = client.get(f"/play/{link_uuid}")
         assert resp.status_code == 200
-        assert "header-nav__tab--disabled" in resp.text
-        assert "Coming soon" in resp.text
         assert "Comments" in resp.text
-        assert 'aria-disabled="true"' in resp.text
+        assert f"/comments/{link_uuid}" in resp.text
+        # No longer disabled
+        assert "header-nav__tab--disabled" not in resp.text
+        assert 'aria-disabled="true"' not in resp.text
 
     def test_tab_bar_uses_tablist_role(self, client):
         """The nav element uses role=tablist for accessibility."""

--- a/web/db.py
+++ b/web/db.py
@@ -297,6 +297,46 @@ class InviteCode(Base):
         return f"<InviteCode id={self.id} code={self.code!r} status={self.status!r}>"
 
 
+class Comment(Base):
+    """Player comment on a game session.
+
+    Simple text-only comments, displayed newest first.  No threading,
+    editing, or deletion — a minimal community board for pilot users.
+    """
+
+    __tablename__ = "comments"
+
+    id = Column(Integer, primary_key=True)
+    player_id = Column(
+        Integer,
+        ForeignKey("players.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    match_id = Column(
+        Integer,
+        ForeignKey("matches.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    content = Column(
+        Text,
+        CheckConstraint("length(content) > 0"),
+        nullable=False,
+    )
+    created_at = Column(
+        DateTime,
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        Index("idx_comments_created", "created_at"),
+        Index("idx_comments_player", "player_id"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<Comment id={self.id} player={self.player_id}>"
+
+
 def generate_invite_code(
     length: int = INVITE_CODE_LENGTH,
     alphabet: str = INVITE_CODE_ALPHABET,

--- a/web/routes.py
+++ b/web/routes.py
@@ -29,7 +29,7 @@ from bid_euchre.hosted_play.engine import HUMAN_SEAT, MatchEngine
 from bid_euchre.strategy.bidding import BidAction
 
 from .ai_manager import AIManager
-from .db import Decision, Hand, InviteCode, Match, Player
+from .db import Comment, Decision, Hand, InviteCode, Match, Player
 from .leaderboard import METRIC_DEFINITIONS, format_metric, get_leaderboard
 from .middleware import (
     check_match_limit,
@@ -1573,6 +1573,146 @@ async def match_history(request: Request, link_uuid: str):
                 "matches": history_entries,
             },
         )
+    finally:
+        session.close()
+
+
+# ---------------------------------------------------------------------------
+# Comments board
+# ---------------------------------------------------------------------------
+
+# Maximum comment length (characters) and page size
+_COMMENT_MAX_LENGTH = 500
+_COMMENTS_PAGE_SIZE = 50
+
+
+def _fetch_comments(session, *, limit: int = _COMMENTS_PAGE_SIZE) -> list[dict]:
+    """Return recent comments with player nicknames, newest first."""
+    rows = (
+        session.query(Comment, Player.nickname)
+        .join(Player, Comment.player_id == Player.id)
+        .order_by(Comment.created_at.desc())
+        .limit(limit)
+        .all()
+    )
+    return [
+        {
+            "nickname": nickname,
+            "content": comment.content,
+            "created_at": comment.created_at,
+        }
+        for comment, nickname in rows
+    ]
+
+
+@router.get("/comments/{link_uuid}", response_class=HTMLResponse)
+async def comments_page(request: Request, link_uuid: str):
+    """Comments board page — community message board for all players.
+
+    Lists recent comments newest-first with a form to post new ones.
+    Gated behind invite-code auth: the ``link_uuid`` must correspond to
+    a valid player.
+    """
+    templates = _get_templates(request)
+    session = _get_session(request)
+    try:
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+        if player is None:
+            raise HTTPException(status_code=404, detail="Player not found")
+
+        comments = _fetch_comments(session)
+
+        return templates.TemplateResponse(
+            "comments.html",
+            {
+                "request": request,
+                "link_uuid": link_uuid,
+                "current_page": "comments",
+                "nickname": player.nickname,
+                "comments": comments,
+                "error": None,
+            },
+        )
+    finally:
+        session.close()
+
+
+@router.get("/comments/{link_uuid}/list", response_class=HTMLResponse)
+async def comments_list(request: Request, link_uuid: str):
+    """HTMX partial — return the comments list for polling refresh."""
+    templates = _get_templates(request)
+    session = _get_session(request)
+    try:
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+        if player is None:
+            raise HTTPException(status_code=404, detail="Player not found")
+
+        comments = _fetch_comments(session)
+
+        return HTMLResponse(
+            templates.get_template("partials/comments_list.html").render(
+                {"comments": comments}
+            )
+        )
+    finally:
+        session.close()
+
+
+@router.post("/play/{link_uuid}/comment", response_class=HTMLResponse)
+async def post_comment(
+    request: Request,
+    link_uuid: str,
+    content: str = Form(...),
+):
+    """Submit a new comment to the board.
+
+    For HTMX requests, returns the updated comments list partial.
+    For regular form submissions, redirects back to the comments page.
+    """
+    templates = _get_templates(request)
+    session = _get_session(request)
+    try:
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+        if player is None:
+            raise HTTPException(status_code=404, detail="Player not found")
+
+        # Validate content
+        content = content.strip()
+        if not content:
+            error = "Comment cannot be empty."
+        elif len(content) > _COMMENT_MAX_LENGTH:
+            error = f"Comment too long (max {_COMMENT_MAX_LENGTH} characters)."
+        else:
+            error = None
+
+        if error is None:
+            comment = Comment(
+                player_id=player.id,
+                content=content,
+            )
+            session.add(comment)
+            session.commit()
+
+        # HTMX request — return the updated list partial
+        is_htmx = request.headers.get("HX-Request") == "true"
+
+        comments = _fetch_comments(session)
+
+        if is_htmx:
+            return HTMLResponse(
+                templates.get_template("partials/comments_list.html").render(
+                    {"comments": comments}
+                )
+            )
+
+        # Non-HTMX fallback — redirect to comments page
+        return RedirectResponse(
+            url=f"/comments/{link_uuid}",
+            status_code=303,
+        )
+    except Exception:
+        session.rollback()
+        raise
     finally:
         session.close()
 

--- a/web/schema.sql
+++ b/web/schema.sql
@@ -114,3 +114,19 @@ CREATE INDEX IF NOT EXISTS idx_invite_codes_code
 
 CREATE INDEX IF NOT EXISTS idx_invite_codes_status
     ON invite_codes(status);
+
+-- Comments board (expansion Phase: comments feature).
+-- Simple text-only comments, newest first.  No threading or editing.
+CREATE TABLE IF NOT EXISTS comments (
+    id INTEGER PRIMARY KEY,
+    player_id INTEGER NOT NULL REFERENCES players(id) ON DELETE CASCADE,
+    match_id INTEGER REFERENCES matches(id) ON DELETE CASCADE,
+    content TEXT NOT NULL CHECK (length(content) > 0),
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_comments_created
+    ON comments(created_at);
+
+CREATE INDEX IF NOT EXISTS idx_comments_player
+    ON comments(player_id);

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -71,8 +71,9 @@
                 <a href="/leaderboard/{{ link_uuid }}" role="tab"
                    class="header-nav__tab{% if _page == 'leaderboard' %} header-nav__tab--active{% endif %}"
                    {% if _page == 'leaderboard' %}aria-selected="true"{% else %}aria-selected="false"{% endif %}>Leaderboard</a>
-                <span class="header-nav__tab header-nav__tab--disabled" role="tab"
-                      aria-disabled="true" title="Coming soon">Comments</span>
+                <a href="/comments/{{ link_uuid }}" role="tab"
+                   class="header-nav__tab{% if _page == 'comments' %} header-nav__tab--active{% endif %}"
+                   {% if _page == 'comments' %}aria-selected="true"{% else %}aria-selected="false"{% endif %}>Comments</a>
             </nav>
             {% endif %}
             <button id="text-size-toggle"

--- a/web/templates/comments.html
+++ b/web/templates/comments.html
@@ -1,0 +1,177 @@
+{% extends "base.html" %}
+
+{% block title %}Bid Euchre — Comments{% endblock %}
+
+{% block head %}
+<style>
+    .comments {
+        max-width: 720px;
+        margin: 1rem auto;
+        padding: 0 1rem;
+    }
+
+    .comments__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 1rem;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .comments__title {
+        font-size: 1.5rem;
+        margin: 0;
+    }
+
+    .comments__form {
+        margin-bottom: 1.5rem;
+        display: flex;
+        gap: 0.5rem;
+    }
+
+    .comments__input {
+        flex: 1;
+        padding: 0.6rem 0.75rem;
+        border: 1px solid var(--color-surface-light);
+        border-radius: 6px;
+        background: var(--color-surface);
+        color: var(--color-text);
+        font-size: 0.9rem;
+        font-family: inherit;
+        resize: none;
+        min-height: 2.5rem;
+        max-height: 6rem;
+    }
+
+    .comments__input::placeholder {
+        color: var(--color-text-muted);
+    }
+
+    .comments__input:focus {
+        outline: none;
+        border-color: var(--color-felt);
+        box-shadow: 0 0 0 2px rgba(46, 125, 50, 0.3);
+    }
+
+    .comments__submit {
+        padding: 0.6rem 1.25rem;
+        background: var(--color-felt);
+        color: var(--color-text);
+        border: none;
+        border-radius: 6px;
+        cursor: pointer;
+        font-size: 0.9rem;
+        font-weight: 600;
+        white-space: nowrap;
+        align-self: flex-end;
+    }
+
+    .comments__submit:hover {
+        background: var(--color-legal-glow);
+        color: var(--color-bg-dark);
+    }
+
+    .comments__submit:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+
+    .comments__empty {
+        text-align: center;
+        padding: 3rem 1rem;
+        color: var(--color-text-muted);
+    }
+
+    .comments__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    .comments__item {
+        padding: 0.75rem 0;
+        border-bottom: 1px solid var(--color-surface-light);
+    }
+
+    .comments__item:last-child {
+        border-bottom: none;
+    }
+
+    .comments__meta {
+        display: flex;
+        align-items: baseline;
+        gap: 0.5rem;
+        margin-bottom: 0.25rem;
+    }
+
+    .comments__author {
+        font-weight: 600;
+        font-size: 0.85rem;
+        color: var(--color-text);
+    }
+
+    .comments__time {
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+    }
+
+    .comments__content {
+        font-size: 0.9rem;
+        line-height: 1.4;
+        color: var(--color-text);
+        white-space: pre-wrap;
+        word-break: break-word;
+    }
+
+    .comments__error {
+        color: var(--color-negative);
+        font-size: 0.85rem;
+        margin-bottom: 0.75rem;
+        padding: 0.5rem 0.75rem;
+        background: rgba(198, 40, 40, 0.15);
+        border-radius: 4px;
+    }
+
+    @media (max-width: 600px) {
+        .comments__form {
+            flex-direction: column;
+        }
+        .comments__submit {
+            align-self: flex-end;
+        }
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="comments" role="region" aria-label="Comments board">
+    <div class="comments__header">
+        <h2 class="comments__title">Comments</h2>
+    </div>
+
+    {% if error %}
+    <div class="comments__error" role="alert">{{ error }}</div>
+    {% endif %}
+
+    <form class="comments__form" method="post" action="/play/{{ link_uuid }}/comment"
+          hx-post="/play/{{ link_uuid }}/comment"
+          hx-target="#comments-list"
+          hx-swap="innerHTML"
+          hx-on::after-request="if(event.detail.successful) this.reset()">
+        <textarea class="comments__input" name="content"
+                  placeholder="Share a thought about the game..."
+                  required minlength="1" maxlength="500"
+                  rows="1"
+                  aria-label="Write a comment"></textarea>
+        <button class="comments__submit" type="submit">Post</button>
+    </form>
+
+    <div id="comments-list"
+         hx-get="/comments/{{ link_uuid }}/list"
+         hx-trigger="every 15s"
+         hx-swap="innerHTML">
+        {% include "partials/comments_list.html" %}
+    </div>
+</div>
+{% endblock %}

--- a/web/templates/partials/comments_list.html
+++ b/web/templates/partials/comments_list.html
@@ -1,0 +1,25 @@
+{#
+    Comments list partial — rendered inside the #comments-list div.
+
+    Context variables:
+        comments — list of dicts with keys: nickname, content, created_at
+#}
+{% if comments|length == 0 %}
+<div class="comments__empty">
+    <p>No comments yet. Be the first to share your thoughts!</p>
+</div>
+{% else %}
+<ul class="comments__list" role="list" aria-label="Comment list">
+    {% for comment in comments %}
+    <li class="comments__item">
+        <div class="comments__meta">
+            <span class="comments__author">{{ comment.nickname or "Anonymous" }}</span>
+            <time class="comments__time" datetime="{{ comment.created_at.isoformat() }}">
+                {{ comment.created_at.strftime('%b %d, %Y %I:%M %p') }}
+            </time>
+        </div>
+        <div class="comments__content">{{ comment.content }}</div>
+    </li>
+    {% endfor %}
+</ul>
+{% endif %}


### PR DESCRIPTION
## Summary
- Add `Comment` DB model with player/match FK, content, and created_at
- Add GET `/comments/{link_uuid}` page route with comment form and list
- Add GET `/comments/{link_uuid}/list` HTMX partial for 15s polling refresh
- Add POST `/play/{link_uuid}/comment` with server-side validation (500 char max, whitespace stripping)
- Wire Comments tab from disabled placeholder to active navigation link

## Why
Closes the comments portion of #1916. The Comments tab was a disabled placeholder since PR #2101. This PR builds the full community comments feature — simple text-only, newest-first, no threading or editing.

## Repro / Validation

```bash
uv run python -m pytest tests/unit/hosted_play/test_comments.py -v  # 18 passed
uv run python -m pytest tests/unit/hosted_play/test_routes.py -q    # 77 passed, 1 skipped
make check-quiet  # 4 pre-existing failures in ops domain; all web tests pass
```

## Tests
18 new tests + updated existing disabled-tab test to active-link test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)