### PR TITLE
fix(web): wire strategy lifecycle hooks so Glutton ranks bowers correctly (#2113)

### DIFF
--- a/src/bid_euchre/hosted_play/engine.py
+++ b/src/bid_euchre/hosted_play/engine.py
@@ -370,6 +370,10 @@ class MatchEngine:
         # Re-sort human hand with bower awareness
         sort_hand_for_display(hand.hands[HUMAN_SEAT], hand.contract_type, hand.trump)
 
+        # Fire on_hand_start hook (same as _process_auction_end; moon exchange
+        # reaches trick play through a different path).
+        self._fire_on_hand_start(hand)
+
         # Auto-advance AI just like submit_human_bid/submit_human_card.
         # Without this, the game is stuck when the leader (bidder) is an AI
         # seat because no mechanism triggers AI card play after exchange.
@@ -811,7 +815,54 @@ class MatchEngine:
         # Re-sort human hand with bower awareness now that trump is known
         sort_hand_for_display(hand.hands[HUMAN_SEAT], hand.contract_type, hand.trump)
 
+        # Fire on_hand_start hook so the strategy knows the contract type and
+        # trump suit.  Without this, GluttonStrategy's internal helpers use
+        # stale defaults and mis-rank bowers (see #2113).
+        self._fire_on_hand_start(hand)
+
         return state
+
+    # ------------------------------------------------------------------
+    # Internal — strategy lifecycle hooks
+    # ------------------------------------------------------------------
+
+    def _fire_on_hand_start(self, hand: HandState) -> None:
+        """Notify the play strategy of a new hand's contract info.
+
+        Called once at the start of trick play (after auction ends or after
+        moon exchange completes) so that GluttonStrategy resets its per-hand
+        tracking and sets ``_contract_type`` / ``_trump_suit`` correctly.
+        Without this, bowers are mis-ranked in card-value calculations (#2113).
+        """
+        if type(self.play_strategy).on_hand_start is not Strategy.on_hand_start:
+            # Pick any active AI seat (not human seat 0, not sitting out).
+            ai_seat = 1
+            for s in (1, 2, 3):
+                if s != hand.sitting_out_seat:
+                    ai_seat = s
+                    break
+            self.play_strategy.on_hand_start(
+                starting_hand=list(hand.hands[ai_seat]),
+                contract_type=hand.contract_type or "high",
+                trump_suit=hand.trump,
+                player_index=ai_seat,
+            )
+
+    def _fire_observe_play(self, hand: HandState, seat: int, card: Card) -> None:
+        """Notify the play strategy that a card was played.
+
+        Called after every card play (human and AI) so that the strategy can
+        track seen cards and infer voids for informed decisions.
+        """
+        if type(self.play_strategy).observe_play is not Strategy.observe_play:
+            assert hand.current_trick is not None
+            self.play_strategy.observe_play(
+                player_index=seat,
+                card=card,
+                trick_plays=list(hand.current_trick.plays),
+                contract_type=hand.contract_type or "high",
+                trump_suit=hand.trump,
+            )
 
     # ------------------------------------------------------------------
     # Internal — card play
@@ -829,6 +880,9 @@ class MatchEngine:
         card = hand.hands[seat].pop(card_index)
         hand.current_trick.plays.append((seat, card))
         hand.turn_number += 1
+
+        # Notify strategy of the play (card tracking, void inference)
+        self._fire_observe_play(hand, seat, card)
 
         # Check if trick is complete (3 plays for moon/loner, 4 otherwise)
         ppt = _players_per_trick(hand.sitting_out_seat)

--- a/tests/unit/hosted_play/test_engine.py
+++ b/tests/unit/hosted_play/test_engine.py
@@ -45,6 +45,7 @@ from bid_euchre.hosted_play.state import MatchState
 from bid_euchre.scoring import compute_points
 from bid_euchre.strategy.base import Strategy
 from bid_euchre.strategy.bidding import BidAction, BiddingObservation, BiddingPolicy
+from bid_euchre.strategy.greedy import GluttonStrategy
 
 # ---------------------------------------------------------------------------
 # Test helpers — deterministic AI stubs
@@ -2230,3 +2231,120 @@ class TestSortHandForDisplay:
                 seen_suits.append(card.suit)
         # No suit should appear more than once in the seen list
         assert len(seen_suits) == len(set(seen_suits))
+
+
+# ---------------------------------------------------------------------------
+# Glutton bower-sorting fix (#2113)
+# ---------------------------------------------------------------------------
+
+
+class TestGluttonBowerFix:
+    """Regression tests for #2113: engine must call on_hand_start so
+    GluttonStrategy knows the contract type and trump suit."""
+
+    def test_on_hand_start_called_after_auction(self) -> None:
+        """After auction ends, GluttonStrategy._contract_type and
+        _trump_suit must reflect the won contract — not the defaults."""
+        glutton = GluttonStrategy()
+        engine = MatchEngine(
+            bidding_policy=FixedBidder(n=5, contract="S"),
+            play_strategy=glutton,
+        )
+        state = engine.start_match(42, "heuristic")
+        hand = state.current_hand
+        assert hand is not None
+
+        # Submit human bid (pass) so AI wins auction
+        state = engine.submit_human_bid(state, BidAction.pass_bid())
+
+        hand = state.current_hand
+        assert hand is not None
+        assert hand.phase == "trick_play"
+        # The engine should have called on_hand_start, setting trump info
+        assert glutton._contract_type == hand.contract_type
+        assert glutton._trump_suit == hand.trump
+
+    def test_on_hand_start_called_after_moon_exchange(self) -> None:
+        """Moon exchange path must also call on_hand_start."""
+        glutton = GluttonStrategy()
+        engine = MatchEngine(
+            bidding_policy=MoonBidder(contract="S"),
+            play_strategy=glutton,
+        )
+        state = engine.start_match(42, "heuristic")
+        hand = state.current_hand
+        assert hand is not None
+
+        # Submit human bid (pass) so AI wins with moon
+        state = engine.submit_human_bid(state, BidAction.pass_bid())
+
+        hand = state.current_hand
+        assert hand is not None
+        # Moon goes through exchange phase first
+        if hand.phase == "moon_exchange":
+            state = engine.submit_exchange_selection(state, [0, 1])
+            hand = state.current_hand
+            assert hand is not None
+
+        assert hand.phase == "trick_play"
+        assert glutton._contract_type == hand.contract_type
+        assert glutton._trump_suit == hand.trump
+
+    def test_observe_play_fires_on_card_play(self) -> None:
+        """Each card play must notify the strategy via observe_play.
+
+        After the auction, AI auto-advances and plays cards, which populates
+        _seen_counts. Then the human plays, adding more observations.
+        We verify the total observation count increases after the human play.
+        """
+        glutton = GluttonStrategy()
+        engine = MatchEngine(
+            bidding_policy=FixedBidder(n=5, contract="S"),
+            play_strategy=glutton,
+        )
+        state = engine.start_match(42, "heuristic")
+        # Submit human pass so AI wins
+        state = engine.submit_human_bid(state, BidAction.pass_bid())
+        hand = state.current_hand
+        assert hand is not None
+        assert hand.phase == "trick_play"
+
+        # AI auto-advance may have already tracked some plays
+        initial_total = sum(glutton._seen_counts.values())
+
+        # Play the human card
+        if hand.current_seat == HUMAN_SEAT:
+            legal = get_legal_indices(
+                hand.hands[HUMAN_SEAT],
+                list(hand.current_trick.plays) if hand.current_trick else [],
+                hand.contract_type or "high",
+                hand.trump,
+            )
+            state = engine.submit_human_card(state, legal[0])
+
+        # Total observation count must have increased
+        final_total = sum(glutton._seen_counts.values())
+        assert final_total > initial_total
+
+    def test_bower_values_correct_with_fix(self) -> None:
+        """With on_hand_start called, right bower is valued higher than ace."""
+        from bid_euchre.strategy.base import card_value_for_dump
+
+        # Without the fix, _contract_type="high" and _trump_suit=None
+        # would make J♥ value < A♥.  With the fix, J♥ (right bower) > A♥.
+        right_bower = Card("H", "J")
+        ace_of_trump = Card("H", "A")
+
+        # Correct values with bower awareness
+        rb_val = card_value_for_dump(right_bower, "suit", "H")
+        ace_val = card_value_for_dump(ace_of_trump, "suit", "H")
+        assert (
+            rb_val > ace_val
+        ), f"Right bower ({rb_val}) must be valued higher than ace ({ace_val})"
+
+        # Bug scenario: without trump info, J is low
+        rb_no_trump = card_value_for_dump(right_bower, "high", None)
+        ace_no_trump = card_value_for_dump(ace_of_trump, "high", None)
+        assert (
+            rb_no_trump < ace_no_trump
+        ), "Without trump info, J should be valued lower than A (the bug)"


### PR DESCRIPTION
## Plan
N/A — hotfix for production bug

## Summary
- Wire `on_hand_start()` and `observe_play()` lifecycle hooks from `MatchEngine` to the play strategy (GluttonStrategy) in the hosted-play paths
- Add `_fire_on_hand_start()` helper called after auction end and after moon exchange
- Add `_fire_observe_play()` helper called after every card play (human and AI)
- Add 4 regression tests proving the hooks fire correctly and bower values are correct

## Why
GluttonStrategy was not being notified of the contract type and trump suit in the hosted-play engine. Without `on_hand_start()`, it defaults to `contract_type="high"` / `trump_suit=None`, causing bowers (Jacks of trump/same-color) to be valued as LOW cards instead of the HIGHEST trump. The AI was "discarding" right and left bowers on tricks already won by partner, leading to absurdly lopsided games (human winning 8-2 routinely).

Closes #2113

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_engine.py -k TestGluttonBowerFix -v
```

**Seed:** 42 (used in tests)

## Test Criteria
- **Pass condition:** All 4 `TestGluttonBowerFix` tests pass, proving `on_hand_start` fires with correct contract/trump info
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_engine.py -k TestGluttonBowerFix -v`
- **Expected result:** 4 passed

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_engine.py` (95 passed)
- [x] `make check-quiet` (3 pre-existing failures in unrelated modules: test_ops_token_economy, test_telegram_filter)
- [x] Other: `uv run ruff check` and `uv run ruff format --check` clean

## Expected impact
- Metrics impact: AI bower play corrected — AI should now win more tricks in suit contracts
- Runtime impact: Negligible (two lightweight method calls per hand start and per card play)

## Risk level
- [ ] Low (docs/tests only)
- [x] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

`git worktree list`:
```
Bid-Euchre-steward-author-c  be43c808 [fix/glutton-bower-sorting]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)