### PR TITLE
fix(web): convert comment board timestamps to local timezone (#2135)

### DIFF
--- a/web/templates/comments.html
+++ b/web/templates/comments.html
@@ -174,4 +174,44 @@
         {% include "partials/comments_list.html" %}
     </div>
 </div>
+
+<script>
+    /**
+     * Convert comment timestamps from UTC to the user's local timezone.
+     *
+     * The server renders times with a "UTC" suffix as a no-JS fallback.
+     * This script replaces that text with a locale-formatted local time.
+     */
+    (function () {
+        var FORMAT_OPTIONS = {
+            month: 'short',
+            day: 'numeric',
+            year: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit'
+        };
+
+        function localizeCommentTimestamps() {
+            var times = document.querySelectorAll('.comments__time');
+            Array.prototype.forEach.call(times, function (el) {
+                var dt = el.getAttribute('datetime');
+                if (!dt) { return; }
+                var date = new Date(dt);
+                if (isNaN(date.getTime())) { return; }
+                el.textContent = date.toLocaleString(undefined, FORMAT_OPTIONS);
+            });
+        }
+
+        // Run on initial page load
+        localizeCommentTimestamps();
+
+        // Re-run after HTMX swaps the comments list (polling or post-submit)
+        document.body.addEventListener('htmx:afterSwap', function (event) {
+            var target = event.target;
+            if (target && target.id === 'comments-list') {
+                localizeCommentTimestamps();
+            }
+        });
+    })();
+</script>
 {% endblock %}

--- a/web/templates/partials/comments_list.html
+++ b/web/templates/partials/comments_list.html
@@ -14,8 +14,8 @@
     <li class="comments__item">
         <div class="comments__meta">
             <span class="comments__author">{{ comment.nickname or "Anonymous" }}</span>
-            <time class="comments__time" datetime="{{ comment.created_at.isoformat() }}">
-                {{ comment.created_at.strftime('%b %d, %Y %I:%M %p') }}
+            <time class="comments__time" datetime="{{ comment.created_at.strftime('%Y-%m-%dT%H:%M:%SZ') }}">
+                {{ comment.created_at.strftime('%b %d, %Y %I:%M %p') }} UTC
             </time>
         </div>
         <div class="comments__content">{{ comment.content }}</div>


### PR DESCRIPTION
## Summary

- Comment board timestamps now display in the user's local timezone instead of raw UTC
- Uses client-side JS (`toLocaleString()`) to parse the `<time>` `datetime` attribute and render in locale format
- Non-JS fallback shows the original server-rendered time with a "UTC" suffix

## Why

Issue #2135: Comment board timestamps display in UTC, which is confusing for users in other timezones.

## Changes

| File | Change |
|------|--------|
| `web/templates/partials/comments_list.html` | Use explicit UTC `datetime` attribute (`Z` suffix); add "UTC" text fallback |
| `web/templates/comments.html` | Add inline `<script>` that converts `<time>` elements to local time on load and after HTMX swaps |

## How it works

1. The `<time>` element's `datetime` attribute is formatted as `2026-04-02T15:30:00Z` (explicit UTC)
2. On page load, JS parses each `datetime` and replaces the text with `date.toLocaleString()` in the user's locale
3. After each HTMX swap (15s polling or post-submit refresh), the conversion re-runs
4. Without JS, users see the server-rendered time with "UTC" suffix

## Repro / Validation

```bash
uv run python -m pytest tests/unit/hosted_play/ -v
```

Manual: visit the comments page — timestamps should show in local time (e.g., "Apr 2, 2026, 7:30 PM" for EDT).

## Tests

```bash
uv run python -m pytest tests/unit/hosted_play/test_comments.py -v  # All pass
make check-quiet  # 3 pre-existing failures unrelated to this change
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: fix/comment-timestamps-est
```

Closes #2135

🤖 Generated with [Claude Code](https://claude.com/claude-code)