### PR TITLE
fix(web): return validation errors for invalid comments (#2129)

### DIFF
--- a/tests/unit/hosted_play/test_comments.py
+++ b/tests/unit/hosted_play/test_comments.py
@@ -253,6 +253,19 @@ class TestPostComment:
         finally:
             session.close()
 
+    def test_post_comment_too_long_returns_error(self, client, app):
+        """Too-long comment returns validation error in HTMX response."""
+        link_uuid = _create_player(app, "Alice")
+        long_content = "x" * 501
+        resp = client.post(
+            f"/play/{link_uuid}/comment",
+            data={"content": long_content},
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        assert "Comment too long" in resp.text
+        assert 'role="alert"' in resp.text
+
     def test_post_empty_comment(self, client, app):
         """Whitespace-only comment is rejected."""
         link_uuid = _create_player(app, "Alice")
@@ -268,6 +281,32 @@ class TestPostComment:
             assert session.query(Comment).count() == 0
         finally:
             session.close()
+
+    def test_post_empty_comment_returns_error(self, client, app):
+        """Empty comment returns validation error in HTMX response."""
+        link_uuid = _create_player(app, "Alice")
+        resp = client.post(
+            f"/play/{link_uuid}/comment",
+            data={"content": "   "},
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        assert "Comment cannot be empty" in resp.text
+        assert 'role="alert"' in resp.text
+
+    def test_post_comment_too_long_non_htmx_returns_error(self, client, app):
+        """Non-HTMX submission with validation error renders full page with error."""
+        link_uuid = _create_player(app, "Alice")
+        long_content = "x" * 501
+        resp = client.post(
+            f"/play/{link_uuid}/comment",
+            data={"content": long_content},
+            follow_redirects=False,
+        )
+        # Should render full page (200) instead of redirecting
+        assert resp.status_code == 200
+        assert "Comment too long" in resp.text
+        assert "Comments" in resp.text  # full page rendered
 
     def test_post_comment_unknown_player(self, client):
         """Comment from unknown player returns 404."""

--- a/web/routes.py
+++ b/web/routes.py
@@ -1699,13 +1699,25 @@ async def post_comment(
         comments = _fetch_comments(session)
 
         if is_htmx:
+            ctx: dict = {"comments": comments}
+            if error is not None:
+                ctx["error"] = error
             return HTMLResponse(
-                templates.get_template("partials/comments_list.html").render(
-                    {"comments": comments}
-                )
+                templates.get_template("partials/comments_list.html").render(ctx)
             )
 
-        # Non-HTMX fallback — redirect to comments page
+        # Non-HTMX fallback — render full page with error (if any)
+        if error is not None:
+            return HTMLResponse(
+                templates.get_template("comments.html").render(
+                    {
+                        "request": request,
+                        "link_uuid": link_uuid,
+                        "comments": comments,
+                        "error": error,
+                    }
+                )
+            )
         return RedirectResponse(
             url=f"/comments/{link_uuid}",
             status_code=303,

--- a/web/templates/partials/comments_list.html
+++ b/web/templates/partials/comments_list.html
@@ -3,7 +3,11 @@
 
     Context variables:
         comments — list of dicts with keys: nickname, content, created_at
+        error    — (optional) validation error message to display
 #}
+{% if error %}
+<div class="comments__error" role="alert">{{ error }}</div>
+{% endif %}
 {% if comments|length == 0 %}
 <div class="comments__empty">
     <p>No comments yet. Be the first to share your thoughts!</p>


### PR DESCRIPTION
## Summary

- Return validation error messages to users when comment submission fails
  (empty content or exceeding max length), instead of silently swallowing them.
- HTMX responses now include a `role="alert"` error banner in the comments
  list partial; non-HTMX fallback renders the full page with the error instead
  of redirecting.

## Why

PR #2124 (comments board) swallowed validation errors — when a user submitted
an empty or too-long comment, no feedback was shown. This is the convention
follow-up from issue #2129.

## Changes

| File | Change |
|------|--------|
| `web/routes.py` | Pass `error` to HTMX partial context; render full page with error for non-HTMX fallback |
| `web/templates/partials/comments_list.html` | Add optional `error` variable rendering with `role="alert"` banner |
| `tests/unit/hosted_play/test_comments.py` | 3 new tests: error message in HTMX too-long, HTMX empty, non-HTMX too-long |

## Repro / Validation

```bash
uv run python -m pytest tests/unit/hosted_play/test_comments.py -v
# 21 passed (18 existing + 3 new)
```

## Tests

- `make check-quiet` — 3 pre-existing failures in `test_ops_token_economy` and
  `test_telegram_filter` (outside `web/` scope); all web tests pass.

## Worktree proof

```
pwd: Bid-Euchre-steward-brws-author-a
branch: fix/convention-followup-2124
```

Closes #2129

🤖 Generated with [Claude Code](https://claude.com/claude-code)