### PR TITLE
feat(web): add new player guide — walkthrough, tips, and strategies (#2132)

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -164,6 +164,91 @@ class TestModelSelect:
         assert "model-card-desc" in html
         assert "model-card-name" in html
 
+    def test_quick_start_guide_shown(self, env):
+        models = [ModelStub("bud_bot", "Bud Bot", "Gradient-boosted bidder")]
+        tmpl = env.get_template("partials/model_select.html")
+        html = tmpl.render(
+            link_uuid="abc-123",
+            nickname="Alice",
+            models=models,
+            default_model_id="bud_bot",
+        )
+        assert "quick-start-guide" in html
+        assert "New to Bid Euchre?" in html
+        assert "green border" in html
+        assert "/guide/abc-123" in html
+
+    def test_quick_start_guide_link_uses_link_uuid(self, env):
+        models = [ModelStub("bud_bot", "Bud Bot", "Gradient-boosted bidder")]
+        tmpl = env.get_template("partials/model_select.html")
+        html = tmpl.render(
+            link_uuid="my-uuid",
+            nickname="Bob",
+            models=models,
+            default_model_id="bud_bot",
+        )
+        assert "/guide/my-uuid" in html
+        assert "full guide" in html
+
+
+# ---------------------------------------------------------------------------
+# guide.html
+# ---------------------------------------------------------------------------
+
+
+class TestGuideTemplate:
+    def test_renders_title(self, env):
+        tmpl = env.get_template("guide.html")
+        html = tmpl.render(
+            link_uuid="abc-123",
+            current_page="guide",
+            nickname="Alice",
+        )
+        assert "How to Play" in html
+
+    def test_contains_all_sections(self, env):
+        tmpl = env.get_template("guide.html")
+        html = tmpl.render(
+            link_uuid="abc-123",
+            current_page="guide",
+            nickname="Alice",
+        )
+        assert "Quick Start" in html
+        assert "The Basics" in html
+        assert "Bidding" in html
+        assert "Card Play" in html
+        assert "Scoring" in html
+        assert "Tips" in html
+        assert "Basic Strategies" in html
+
+    def test_icon_legend_present(self, env):
+        tmpl = env.get_template("guide.html")
+        html = tmpl.render(
+            link_uuid="abc-123",
+            current_page="guide",
+            nickname="Alice",
+        )
+        assert "Dealer" in html
+        assert "Declarer" in html
+        assert "Leader" in html
+
+    def test_back_link_uses_link_uuid(self, env):
+        tmpl = env.get_template("guide.html")
+        html = tmpl.render(
+            link_uuid="my-uuid",
+            current_page="guide",
+            nickname="Bob",
+        )
+        assert "/play/my-uuid" in html
+        assert "Back to Game" in html
+
+    def test_renders_without_link_uuid(self, env):
+        """Guide renders without back link when link_uuid is not set."""
+        tmpl = env.get_template("guide.html")
+        html = tmpl.render(current_page="guide", nickname="Bob")
+        assert "How to Play" in html
+        assert "Back to Game" not in html
+
 
 # ---------------------------------------------------------------------------
 # bid_panel.html

--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -2691,6 +2691,62 @@ class TestTabNavigation:
 
 
 # ---------------------------------------------------------------------------
+# Test: Guide page
+# ---------------------------------------------------------------------------
+
+
+class TestGuide:
+    """GET /guide/{link_uuid} — new player guide page."""
+
+    def test_guide_unknown_uuid_404(self, client):
+        resp = client.get("/guide/nonexistent-uuid")
+        assert resp.status_code == 404
+
+    def test_guide_renders_for_valid_player(self, client):
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        resp = client.get(f"/guide/{link_uuid}")
+        assert resp.status_code == 200
+        assert "How to Play" in resp.text
+
+    def test_guide_contains_key_sections(self, client):
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        resp = client.get(f"/guide/{link_uuid}")
+        assert resp.status_code == 200
+        assert "The Basics" in resp.text
+        assert "Bidding" in resp.text
+        assert "Card Play" in resp.text
+        assert "Scoring" in resp.text
+        assert "Tips" in resp.text
+        assert "Basic Strategies" in resp.text
+
+    def test_guide_tab_active_on_guide_page(self, client):
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        resp = client.get(f"/guide/{link_uuid}")
+        assert resp.status_code == 200
+        assert "header-nav__tab--active" in resp.text
+
+    def test_guide_tab_present_in_nav(self, client):
+        """The header nav should include a Guide link when link_uuid is set."""
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        _select_ai(client, link_uuid)
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        assert f"/guide/{link_uuid}" in resp.text
+        assert "Guide" in resp.text
+
+    def test_guide_has_back_to_game_link(self, client):
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        resp = client.get(f"/guide/{link_uuid}")
+        assert resp.status_code == 200
+        assert f"/play/{link_uuid}" in resp.text
+
+
+# ---------------------------------------------------------------------------
 # Test: State-desync graceful recovery (P1-001 fix)
 # ---------------------------------------------------------------------------
 

--- a/web/routes.py
+++ b/web/routes.py
@@ -1730,6 +1730,38 @@ async def post_comment(
 
 
 # ---------------------------------------------------------------------------
+# Guide
+# ---------------------------------------------------------------------------
+
+
+@router.get("/guide/{link_uuid}", response_class=HTMLResponse)
+async def guide(request: Request, link_uuid: str):
+    """New player guide — rules walkthrough, tips, and strategies.
+
+    Gated behind invite-code auth: the ``link_uuid`` must correspond to
+    a valid player.  Returns 404 for unknown UUIDs.
+    """
+    templates = _get_templates(request)
+    session = _get_session(request)
+    try:
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+        if player is None:
+            raise HTTPException(status_code=404, detail="Player not found")
+
+        return templates.TemplateResponse(
+            "guide.html",
+            {
+                "request": request,
+                "link_uuid": link_uuid,
+                "current_page": "guide",
+                "nickname": player.nickname,
+            },
+        )
+    finally:
+        session.close()
+
+
+# ---------------------------------------------------------------------------
 # AI decision logging helper
 # ---------------------------------------------------------------------------
 

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1592,6 +1592,44 @@ main {
     margin: 0.25rem 0 0;
 }
 
+/* Quick start guide on model-select screen */
+.quick-start-guide {
+    margin-top: 1.5rem;
+    background: var(--color-surface);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+    border-left: 4px solid var(--color-legal-glow);
+    text-align: left;
+}
+
+.quick-start-guide__title {
+    font-size: 1rem;
+    font-weight: 700;
+    margin: 0 0 0.5rem;
+    color: var(--color-legal-glow);
+}
+
+.quick-start-guide p {
+    margin: 0.3rem 0;
+    font-size: 0.88rem;
+    line-height: 1.5;
+}
+
+.quick-start-guide__link {
+    margin-top: 0.75rem !important;
+}
+
+.quick-start-guide__link a {
+    color: var(--color-legal-glow);
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.88rem;
+}
+
+.quick-start-guide__link a:hover {
+    text-decoration: underline;
+}
+
 #nickname-form button,
 #model-select button {
     padding: 0.5rem 1.5rem;

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -74,6 +74,9 @@
                 <a href="/comments/{{ link_uuid }}" role="tab"
                    class="header-nav__tab{% if _page == 'comments' %} header-nav__tab--active{% endif %}"
                    {% if _page == 'comments' %}aria-selected="true"{% else %}aria-selected="false"{% endif %}>Comments</a>
+                <a href="/guide/{{ link_uuid }}" role="tab"
+                   class="header-nav__tab{% if _page == 'guide' %} header-nav__tab--active{% endif %}"
+                   {% if _page == 'guide' %}aria-selected="true"{% else %}aria-selected="false"{% endif %}>Guide</a>
             </nav>
             {% endif %}
             <button id="text-size-toggle"

--- a/web/templates/guide.html
+++ b/web/templates/guide.html
@@ -1,0 +1,252 @@
+{% extends "base.html" %}
+
+{% block title %}Bid Euchre — How to Play{% endblock %}
+
+{% block head %}
+<style>
+    .guide {
+        max-width: 720px;
+        margin: 1rem auto;
+        padding: 0 1rem 3rem;
+    }
+
+    .guide__title {
+        font-size: 1.5rem;
+        margin: 0 0 1rem;
+    }
+
+    .guide__section {
+        margin-bottom: 1.5rem;
+    }
+
+    .guide__section-title {
+        font-size: 1.15rem;
+        margin: 0 0 0.5rem;
+        color: var(--color-legal-glow);
+    }
+
+    .guide__section p,
+    .guide__section li {
+        font-size: 0.9rem;
+        line-height: 1.5;
+        color: var(--color-text);
+    }
+
+    .guide__section ul,
+    .guide__section ol {
+        margin: 0.5rem 0;
+        padding-left: 1.5rem;
+    }
+
+    .guide__section li {
+        margin-bottom: 0.4rem;
+    }
+
+    .guide__quickstart {
+        background: var(--color-surface);
+        border-radius: 8px;
+        padding: 1rem 1.25rem;
+        margin-bottom: 1.5rem;
+        border-left: 4px solid var(--color-legal-glow);
+    }
+
+    .guide__quickstart p {
+        margin: 0.3rem 0;
+        font-size: 0.9rem;
+        line-height: 1.5;
+    }
+
+    .guide__quickstart-title {
+        font-size: 1rem;
+        font-weight: 700;
+        margin: 0 0 0.5rem;
+        color: var(--color-legal-glow);
+    }
+
+    .guide__icon-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.85rem;
+        margin: 0.5rem 0;
+    }
+
+    .guide__icon-table td {
+        padding: 0.35rem 0.5rem;
+        border-bottom: 1px solid var(--color-surface-light);
+        vertical-align: middle;
+    }
+
+    .guide__icon-table td:first-child {
+        width: 3rem;
+        text-align: center;
+        font-weight: 600;
+    }
+
+    .guide__tip {
+        background: var(--color-surface);
+        border-radius: 6px;
+        padding: 0.6rem 0.9rem;
+        margin-bottom: 0.5rem;
+        font-size: 0.88rem;
+        line-height: 1.45;
+    }
+
+    .guide__tip strong {
+        color: var(--color-legal-glow);
+    }
+
+    .guide__back {
+        display: inline-block;
+        margin-top: 1rem;
+        padding: 0.5rem 1rem;
+        background: var(--color-felt);
+        color: var(--color-text);
+        border-radius: 6px;
+        text-decoration: none;
+        font-size: 0.9rem;
+        font-weight: 600;
+    }
+
+    .guide__back:hover {
+        background: var(--color-legal-glow);
+        color: var(--color-bg-dark);
+    }
+
+    @media (max-width: 600px) {
+        .guide { padding: 0 0.75rem 2rem; }
+        .guide__section p,
+        .guide__section li,
+        .guide__tip { font-size: 0.85rem; }
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="guide" role="region" aria-label="How to play Bid Euchre">
+    <h2 class="guide__title">How to Play</h2>
+
+    {# ---- Quick Start ---- #}
+    <div class="guide__quickstart">
+        <div class="guide__quickstart-title">Quick Start</div>
+        <p>&#x1F0A1; You and your AI partner vs two AI opponents.</p>
+        <p>&#x270B; Bid how many tricks you think your team can win (or pass).</p>
+        <p>&#x1F3B4; Play cards by clicking them &mdash; green border = legal plays.</p>
+        <p>&#x1F3C6; First team to &plusmn;52 points wins the match.</p>
+    </div>
+
+    {# ---- The Basics ---- #}
+    <div class="guide__section">
+        <h3 class="guide__section-title">The Basics</h3>
+        <p>
+            Bid Euchre is a 4-player partnership card game. You sit across from your
+            AI partner, and the two AI opponents sit on your left and right.
+        </p>
+        <ul>
+            <li><strong>Deck:</strong> A 40-card double deck &mdash; ranks 10, J, Q, K, A in all four suits, with two copies of each card.</li>
+            <li><strong>Deal:</strong> All 40 cards are dealt, so each player gets 10 cards and every hand has 10 tricks.</li>
+            <li><strong>Goal:</strong> Win tricks to score points. First team to reach +52 or &minus;52 points wins the match.</li>
+        </ul>
+    </div>
+
+    {# ---- Bidding ---- #}
+    <div class="guide__section">
+        <h3 class="guide__section-title">Bidding</h3>
+        <p>
+            Each hand starts with an auction. Starting left of the dealer, each
+            player gets one chance to bid or pass.
+        </p>
+        <ul>
+            <li><strong>What to bid:</strong> Pick a number of tricks (4&ndash;10) and a contract type &mdash; a trump suit (&#9824; &#9829; &#9830; &#9827;), High (no-trump, Aces high), or Low (no-trump, Tens high).</li>
+            <li><strong>Highest bid wins:</strong> The winning bidder&rsquo;s team declares the contract. Their team must take at least that many tricks.</li>
+            <li><strong>All pass:</strong> If nobody bids, the hand is redealt and the dealer rotates.</li>
+            <li><strong>Moon &amp; Loner:</strong> Special 10-trick bids. Moon triggers a card exchange with your partner. Loner makes your partner sit out.</li>
+        </ul>
+    </div>
+
+    {# ---- Card Play ---- #}
+    <div class="guide__section">
+        <h3 class="guide__section-title">Card Play</h3>
+        <ul>
+            <li><strong>Follow suit:</strong> You must play a card matching the suit that was led, if you can.</li>
+            <li><strong>Trump wins:</strong> In suit contracts, any trump card beats any non-trump card. Play trump when you can&rsquo;t follow suit.</li>
+            <li><strong>Bowers:</strong> In suit contracts, the Jack of trump (right bower) and the Jack of the same color (left bower) are the two strongest cards. The left bower counts as trump, not its printed suit.</li>
+            <li><strong>Duplicates:</strong> Since it&rsquo;s a double deck, identical cards can appear in the same trick. If they tie for the win, the first one played takes it.</li>
+            <li><strong>High/Low contracts:</strong> No trump suit. In High, Aces are highest. In Low, Tens are highest &mdash; the rank order is reversed.</li>
+        </ul>
+    </div>
+
+    {# ---- Scoring ---- #}
+    <div class="guide__section">
+        <h3 class="guide__section-title">Scoring</h3>
+        <ul>
+            <li><strong>Made bid:</strong> The declaring team scores the number of tricks they won.</li>
+            <li><strong>Set (missed bid):</strong> The declaring team loses points equal to their bid.</li>
+            <li><strong>Defenders:</strong> The defending team always scores the number of tricks they won.</li>
+            <li><strong>Match end:</strong> The match ends when either team reaches +52 or &minus;52 points. Expect 6&ndash;12 hands per match (about 10&ndash;20 minutes).</li>
+        </ul>
+    </div>
+
+    {# ---- Icons & Indicators ---- #}
+    <div class="guide__section">
+        <h3 class="guide__section-title">Icons &amp; Indicators</h3>
+        <table class="guide__icon-table" role="table" aria-label="Game icon legend">
+            <tbody>
+                <tr>
+                    <td><span class="seat-marker seat-marker--dealer" aria-hidden="true">D</span></td>
+                    <td>Dealer &mdash; dealt the current hand</td>
+                </tr>
+                <tr>
+                    <td><span class="seat-marker seat-marker--declarer" aria-hidden="true">&#9733;</span></td>
+                    <td>Declarer &mdash; won the auction</td>
+                </tr>
+                <tr>
+                    <td><span class="seat-marker seat-marker--leader" aria-hidden="true">L</span></td>
+                    <td>Leader &mdash; led the current trick</td>
+                </tr>
+                <tr>
+                    <td><span class="seat-marker seat-marker--turn" aria-hidden="true">&#9654;</span></td>
+                    <td>Your turn &mdash; this player is next to act</td>
+                </tr>
+                <tr>
+                    <td><span class="seat-marker seat-marker--sitting-out" aria-hidden="true">SO</span></td>
+                    <td>Sitting out &mdash; partner sits out during a loner</td>
+                </tr>
+                <tr>
+                    <td><span style="display:inline-block;width:1.2rem;height:1.2rem;border:2px solid var(--color-legal-border);border-radius:3px;box-shadow:0 0 6px var(--color-legal-glow);" aria-hidden="true"></span></td>
+                    <td>Green glow &mdash; card is a legal play (click to select)</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+    {# ---- Tips & Tricks ---- #}
+    <div class="guide__section">
+        <h3 class="guide__section-title">Tips &amp; Tricks</h3>
+        <div class="guide__tip"><strong>Count your sure tricks</strong> before bidding. Only bid what your team can reliably win.</div>
+        <div class="guide__tip"><strong>Lead with strength.</strong> Play your strongest suit early to draw out opponents&rsquo; cards.</div>
+        <div class="guide__tip"><strong>Save your bowers.</strong> The Jacks (right and left bower) are the two strongest trump cards &mdash; save them for key tricks.</div>
+        <div class="guide__tip"><strong>Support your partner.</strong> If your partner is winning the trick, play your lowest card to conserve.</div>
+        <div class="guide__tip"><strong>Low contracts flip the ranks.</strong> Tens are high and Aces are low &mdash; adjust your play accordingly.</div>
+        <div class="guide__tip"><strong>Don&rsquo;t overbid.</strong> Getting set costs you your entire bid as negative points.</div>
+        <div class="guide__tip"><strong>Watch the score bar.</strong> If you&rsquo;re close to &plusmn;52, bid conservatively.</div>
+    </div>
+
+    {# ---- Basic Strategies ---- #}
+    <div class="guide__section">
+        <h3 class="guide__section-title">Basic Strategies</h3>
+        <ul>
+            <li><strong>When to bid suit:</strong> You have 3+ trump cards including a bower, or a long strong suit you can force through.</li>
+            <li><strong>When to bid High:</strong> You have multiple Aces across different suits &mdash; you can win tricks without needing trump.</li>
+            <li><strong>When to bid Low:</strong> You have several Tens and low cards &mdash; in Low contracts the rank order is reversed.</li>
+            <li><strong>When to pass:</strong> Your hand is weak or scattered. Let someone else take the risk.</li>
+            <li><strong>Trump management:</strong> Don&rsquo;t burn all your trump early. Use them strategically to win key tricks or cut opponents&rsquo; strong suits.</li>
+            <li><strong>Read the auction:</strong> Opponents&rsquo; bids tell you about their hands. If an opponent bids high in spades, they likely have strong spades.</li>
+            <li><strong>Partnership play:</strong> Your partner&rsquo;s bid gives you information. If they bid 6 in hearts, support their contract &mdash; don&rsquo;t compete unless you have a clearly stronger hand.</li>
+        </ul>
+    </div>
+
+    {% if link_uuid is defined and link_uuid %}
+    <a href="/play/{{ link_uuid }}" class="guide__back">Back to Game</a>
+    {% endif %}
+</div>
+{% endblock %}

--- a/web/templates/partials/model_select.html
+++ b/web/templates/partials/model_select.html
@@ -35,4 +35,15 @@
         <p class="match-info">Expect <strong>6–12 hands</strong> per match — about 10–20 minutes.</p>
         <button type="submit" aria-label="Start match with selected AI">Start Match</button>
     </form>
+
+    <div class="quick-start-guide" role="region" aria-label="Quick start guide">
+        <h3 class="quick-start-guide__title">New to Bid Euchre?</h3>
+        <p>&#x1F0A1; You and your AI partner vs two AI opponents.</p>
+        <p>&#x270B; Bid how many tricks your team can win, or pass.</p>
+        <p>&#x1F3B4; Play cards by clicking them &mdash; <strong>green border</strong> = legal plays.</p>
+        <p>&#x1F3C6; First team to &plusmn;52 points wins the match.</p>
+        <p class="quick-start-guide__link">
+            <a href="/guide/{{ link_uuid }}">Read the full guide &rarr;</a>
+        </p>
+    </div>
 </div>


### PR DESCRIPTION
## Summary

- Add a comprehensive "How to Play" guide page accessible from game navigation
- Add quick-start callout on the AI opponent selection screen with link to full guide
- Add "Guide" tab to the header navigation alongside Game, History, Leaderboard, Comments

## Why

New players arriving at the game have no onboarding — the invite code screen goes straight to opponent selection, and the only help is the collapsible rules reference, which is too dense for beginners. This adds a beginner-friendly guide with rules walkthrough, tips, and basic strategies.

## Changes

| File | Change |
|------|--------|
| `web/templates/guide.html` | New full guide page: quick start, basics, bidding, card play, scoring, icons, tips, strategies |
| `web/routes.py` | New `GET /guide/{link_uuid}` route (auth-gated) |
| `web/templates/base.html` | Guide tab added to header navigation |
| `web/templates/partials/model_select.html` | Quick-start guide section with link to full guide |
| `web/static/style.css` | CSS for quick-start callout component |
| `tests/unit/hosted_play/test_partials.py` | Template tests for guide.html and quick-start on model_select |
| `tests/unit/hosted_play/test_routes.py` | Route tests: 404, rendering, sections, nav tab, back link |

## Repro / Validation

```bash
# Run guide-specific tests
uv run python -m pytest tests/unit/hosted_play/test_routes.py -k "Guide" -v
uv run python -m pytest tests/unit/hosted_play/test_partials.py -k "guide" -v

# Full hosted_play suite (3271 pass)
uv run python -m pytest tests/unit/hosted_play/ -x

# Full validation
make check-quiet
```

## Tests

- 6 new route tests (TestGuide class): 404 for unknown UUID, renders for valid player, contains all sections, guide tab active, guide tab in nav, back-to-game link
- 5 new template tests (TestGuideTemplate + TestModelSelect additions): title, all sections, icon legend, back link with UUID, renders without link_uuid
- All 3271 hosted_play tests pass
- 3 pre-existing failures in unrelated modules (test_ops_token_economy, test_telegram_filter)

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
branch: feat/new-player-guide-2132
```

Closes #2132

🤖 Generated with [Claude Code](https://claude.com/claude-code)