### PR TITLE
fix(web): clarify scoring wording and correct bid range in guide

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -779,7 +779,8 @@ class TestGameControls:
         assert "Bowers" in html
         assert "Moon and loner" in html
         assert "High/Low" in html
-        assert "+52 or -52" in html
+        assert "+52 wins" in html
+        assert "52 means you lose" in html
 
     def test_game_controls_legend_icons(self, env):
         """Help drawer includes an icon/indicator legend."""

--- a/web/templates/guide.html
+++ b/web/templates/guide.html
@@ -131,7 +131,7 @@
         <p>&#x1F0A1; You and your AI partner vs two AI opponents.</p>
         <p>&#x270B; Bid how many tricks you think your team can win (or pass).</p>
         <p>&#x1F3B4; Play cards by clicking them &mdash; green border = legal plays.</p>
-        <p>&#x1F3C6; First team to &plusmn;52 points wins the match.</p>
+        <p>&#x1F3C6; First team to 52 points wins. Reaching &minus;52 means you lose!</p>
     </div>
 
     {# ---- The Basics ---- #}
@@ -144,7 +144,7 @@
         <ul>
             <li><strong>Deck:</strong> A 40-card double deck &mdash; ranks 10, J, Q, K, A in all four suits, with two copies of each card.</li>
             <li><strong>Deal:</strong> All 40 cards are dealt, so each player gets 10 cards and every hand has 10 tricks.</li>
-            <li><strong>Goal:</strong> Win tricks to score points. First team to reach +52 or &minus;52 points wins the match.</li>
+            <li><strong>Goal:</strong> Win tricks to score points. First team to +52 wins the match; if your score drops to &minus;52, you lose.</li>
         </ul>
     </div>
 
@@ -156,7 +156,7 @@
             player gets one chance to bid or pass.
         </p>
         <ul>
-            <li><strong>What to bid:</strong> Pick a number of tricks (4&ndash;10) and a contract type &mdash; a trump suit (&#9824; &#9829; &#9830; &#9827;), High (no-trump, Aces high), or Low (no-trump, Tens high).</li>
+            <li><strong>What to bid:</strong> Pick a number of tricks (1&ndash;10) and a contract type &mdash; a trump suit (&#9824; &#9829; &#9830; &#9827;), High (no-trump, Aces high), or Low (no-trump, Tens high).</li>
             <li><strong>Highest bid wins:</strong> The winning bidder&rsquo;s team declares the contract. Their team must take at least that many tricks.</li>
             <li><strong>All pass:</strong> If nobody bids, the hand is redealt and the dealer rotates.</li>
             <li><strong>Moon &amp; Loner:</strong> Special 10-trick bids. Moon triggers a card exchange with your partner. Loner makes your partner sit out.</li>
@@ -182,7 +182,7 @@
             <li><strong>Made bid:</strong> The declaring team scores the number of tricks they won.</li>
             <li><strong>Set (missed bid):</strong> The declaring team loses points equal to their bid.</li>
             <li><strong>Defenders:</strong> The defending team always scores the number of tricks they won.</li>
-            <li><strong>Match end:</strong> The match ends when either team reaches +52 or &minus;52 points. Expect 6&ndash;12 hands per match (about 10&ndash;20 minutes).</li>
+            <li><strong>Match end:</strong> The match ends when a team reaches +52 (win) or drops to &minus;52 (loss). Expect 6&ndash;12 hands per match (about 10&ndash;20 minutes).</li>
         </ul>
     </div>
 

--- a/web/templates/partials/game_controls.html
+++ b/web/templates/partials/game_controls.html
@@ -15,7 +15,7 @@
                 <li><strong>Bowers:</strong> In suit contracts, the jack of trump is the right bower and the same-color jack is the left bower. Both count as trump.</li>
                 <li><strong>Duplicates:</strong> Because it is a double deck, identical cards can appear in the same trick. If identical winning cards tie, the first one played wins the trick.</li>
                 <li><strong>Moon and loner:</strong> Moon triggers a partner exchange before play. Loner makes the declarer's partner sit out the tricks.</li>
-                <li><strong>Scoring:</strong> Teams play a running match to +52 or -52. Bid makers score their bid result, defenders score the tricks they take.</li>
+                <li><strong>Scoring:</strong> First team to +52 wins the match; dropping to &minus;52 means you lose. Bid makers score their bid result, defenders score the tricks they take.</li>
             </ul>
 
             <h4 class="help-legend__heading">Icons &amp; Indicators</h4>


### PR DESCRIPTION
## Summary

- **Scoring wording:** Updated Quick Start, Goal, Match end, and help drawer to
  explicitly separate +52 (win) from -52 (loss) instead of the ambiguous "±52" /
  "+52 or -52" phrasing
- **Bid range:** Corrected "4–10" to "1–10" in the bidding section (min_bid starts
  at 1 per `bidding.py` line 984)
- Updated test assertion in `test_partials.py` to match new help drawer wording

## Why

The existing phrasing implied ±52 were equivalent outcomes ("first to ±52 wins"),
which is confusing — reaching +52 means you win, reaching -52 means you lose.
The bid range of "4–10" was factually incorrect.

## Scope

| File | Change |
|------|--------|
| `web/templates/guide.html` | 4 text fixes (Quick Start, Goal, Bid range, Match end) |
| `web/templates/partials/game_controls.html` | 1 text fix (help drawer scoring) |
| `tests/unit/hosted_play/test_partials.py` | Updated test assertion |

## Validation

```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/hosted_play/test_partials.py tests/unit/hosted_play/test_routes.py -v
# 247 passed, 2 skipped

# Tier 2 — full validation
make check-quiet
# 10888 passed, 3 pre-existing failures (ops/telegram — unrelated)
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
branch: fix/guide-scoring-bid-range
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)