### PR TITLE
fix(web): convert match history timestamps to local timezone (#2151)

### DIFF
--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -2622,6 +2622,45 @@ class TestMatchHistory:
         # Active match should not appear — show empty state
         assert "No completed matches yet" in resp.text
 
+    def test_history_timestamps_use_time_element(self, client, app):
+        """Match dates use <time> elements with datetime attrs for JS localization."""
+        from datetime import datetime, timezone
+
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid, "TimeTest")
+
+        session_factory = app.state.session_factory
+        session = session_factory()
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+
+        import uuid as uuid_mod
+
+        completed_match = Match(
+            match_uuid=str(uuid_mod.uuid4()),
+            player_id=player.id,
+            ai_model="bud_bot",
+            status="complete",
+            seed=42,
+            score_human=52,
+            score_ai=38,
+            hands_played=7,
+            match_state_json="{}",
+            completed_at=datetime(2026, 3, 15, 14, 30, 0, tzinfo=timezone.utc),
+        )
+        session.add(completed_match)
+        session.commit()
+        session.close()
+
+        resp = client.get(f"/history/{link_uuid}")
+        assert resp.status_code == 200
+        # <time> element has ISO datetime attribute for JS localization
+        assert 'datetime="2026-03-15T14:30:00Z"' in resp.text
+        assert "history__time" in resp.text
+        # Server-rendered fallback includes "UTC" suffix
+        assert "UTC" in resp.text
+        # Localization script is present
+        assert "localizeHistoryTimestamps" in resp.text
+
     def test_history_nav_link_present(self, client):
         """The header nav should include a History link when link_uuid is set."""
         link_uuid = _create_game(client)

--- a/web/templates/history.html
+++ b/web/templates/history.html
@@ -116,7 +116,15 @@
                     </td>
                     <td>{{ match.score_human }} &ndash; {{ match.score_ai }}</td>
                     <td>{{ match.hands_played }}</td>
-                    <td>{{ match.completed_at.strftime('%b %d, %Y') if match.completed_at else '—' }}</td>
+                    <td>
+                        {% if match.completed_at %}
+                        <time class="history__time" datetime="{{ match.completed_at.strftime('%Y-%m-%dT%H:%M:%SZ') }}">
+                            {{ match.completed_at.strftime('%b %d, %Y %I:%M %p') }} UTC
+                        </time>
+                        {% else %}
+                        —
+                        {% endif %}
+                    </td>
                 </tr>
                 {% endfor %}
             </tbody>
@@ -124,4 +132,36 @@
     </div>
     {% endif %}
 </div>
+
+<script>
+    /**
+     * Convert match-history timestamps from UTC to the user's local timezone.
+     *
+     * The server renders times with a "UTC" suffix as a no-JS fallback.
+     * This script replaces that text with a locale-formatted local time.
+     */
+    (function () {
+        var FORMAT_OPTIONS = {
+            month: 'short',
+            day: 'numeric',
+            year: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit'
+        };
+
+        function localizeHistoryTimestamps() {
+            var times = document.querySelectorAll('.history__time');
+            Array.prototype.forEach.call(times, function (el) {
+                var dt = el.getAttribute('datetime');
+                if (!dt) { return; }
+                var date = new Date(dt);
+                if (isNaN(date.getTime())) { return; }
+                el.textContent = date.toLocaleString(undefined, FORMAT_OPTIONS);
+            });
+        }
+
+        // Run on initial page load
+        localizeHistoryTimestamps();
+    })();
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary

- Extends the local-timezone pattern from PR #2143 (comment timestamps) to the match history page
- History date column now uses `<time>` elements with ISO `datetime` attributes + JavaScript localization
- Server-rendered fallback shows "UTC" suffix for no-JS users

## Why

Closes #2151. The history page was showing dates in UTC, which could confuse users in other timezones and shift displayed dates by a day near midnight.

## Changes

| File | Change |
|------|--------|
| `web/templates/history.html` | Wrap date in `<time>` element with `datetime` attr; add JS localization script |
| `tests/unit/hosted_play/test_routes.py` | Add test verifying `<time>` element, `datetime` attr, UTC fallback, and script presence |

## Scope audit

- **Leaderboard**: No timestamps — shows metrics only ✓
- **Hand result**: No timestamps ✓
- **Match result**: No timestamps ✓
- **Game / Landing**: No timestamps ✓
- **Comments**: Already localized (PR #2143) ✓
- **History**: ← Fixed in this PR

## Repro / Validation

```bash
# Tier 1 — targeted
uv run python -m pytest tests/unit/hosted_play/test_routes.py::TestMatchHistory -v

# Tier 2 — full suite
make check-quiet
# 3 pre-existing failures in test_ops_token_economy.py and test_telegram_filter.py (unrelated)
# All 3272 hosted_play tests pass
```

## Worktree proof

```
pwd: Bid-Euchre-steward-brws-author-b
branch: fix/local-timezone-all-timestamps
```

## Test criteria

- `<time class="history__time" datetime="...Z">` element present for completed matches
- Server fallback text includes "UTC" suffix
- `localizeHistoryTimestamps` JS function present in page
- All existing history tests continue to pass (substring match on date still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)