### PR TITLE
fix(web): exclude AI partner moon/loner from player stats (#2152)

### DIFF
--- a/tests/unit/hosted_play/test_leaderboard.py
+++ b/tests/unit/hosted_play/test_leaderboard.py
@@ -218,7 +218,7 @@ class TestComputePlayerStats:
             db_session,
             match,
             hand_number=1,
-            bidder_seat=2,  # partner seat, still team 0
+            bidder_seat=0,  # human seat
             winning_bid_n=10,
             winning_bid_type="loner",
             tricks_team0=5,
@@ -250,6 +250,70 @@ class TestComputePlayerStats:
         assert stats.moon_make_rate == 1.0  # 1 moon called, 1 made
         assert stats.loner_call_rate == pytest.approx(1 / 3, abs=0.001)
         assert stats.loner_make_rate == 0.0  # 1 loner called, 0 made (5 < 10)
+
+    def test_ai_partner_moon_loner_excluded_from_player_stats(self, db_session):
+        """Moon/loner declared by AI partner (seat 2) must NOT count toward
+        the human player's personal moon/loner stats (#2152)."""
+        player = _make_player(db_session)
+        match = _make_match(db_session, player)
+
+        # AI partner declares moon (seat 2) — should NOT count for human
+        _make_hand(
+            db_session,
+            match,
+            hand_number=0,
+            bidder_seat=2,  # AI partner
+            winning_bid_n=10,
+            winning_bid_type="moon",
+            tricks_team0=10,
+            tricks_team1=0,
+            points_team0=20,
+            points_team1=0,
+        )
+
+        # AI partner declares loner (seat 2) — should NOT count for human
+        _make_hand(
+            db_session,
+            match,
+            hand_number=1,
+            bidder_seat=2,  # AI partner
+            winning_bid_n=10,
+            winning_bid_type="loner",
+            tricks_team0=8,
+            tricks_team1=2,
+            points_team0=10,
+            points_team1=2,
+        )
+
+        # Regular hand by human (baseline)
+        _make_hand(
+            db_session,
+            match,
+            hand_number=2,
+            bidder_seat=0,
+            winning_bid_n=6,
+            winning_bid_type="regular",
+            tricks_team0=7,
+            tricks_team1=3,
+            points_team0=6,
+            points_team1=3,
+        )
+
+        db_session.flush()
+        stats = compute_player_stats(db_session, player.id)
+
+        assert stats is not None
+        assert stats.hands_played == 3
+
+        # AI partner moons/loners excluded — human declared neither
+        assert stats.moon_call_rate == 0.0
+        assert stats.moon_make_rate == 0.0
+        assert stats.loner_call_rate == 0.0
+        assert stats.loner_make_rate == 0.0
+
+        # But team-level bid stats still include partner (seat 2)
+        # Declaring hands: seats 2, 2, 0 — all team 0 = 3/3
+        assert stats.bid_rate == 1.0
 
     def test_multiple_matches(self, db_session):
         player = _make_player(db_session)

--- a/web/leaderboard.py
+++ b/web/leaderboard.py
@@ -110,25 +110,25 @@ METRIC_DEFINITIONS: dict[str, MetricDef] = {
     ),
     "moon_call_rate": MetricDef(
         label="Moon %",
-        tooltip="Percentage of hands where your team called a moon (bid all 10 tricks).",
+        tooltip="Percentage of hands where you personally called a moon (bid all 10 tricks). AI partner moons are excluded.",
         format="pct",
         category="secondary",
     ),
     "moon_make_rate": MetricDef(
         label="Moon Make",
-        tooltip="Percentage of your moon bids that were successfully made.",
+        tooltip="Percentage of your personal moon bids that were successfully made.",
         format="pct",
         category="secondary",
     ),
     "loner_call_rate": MetricDef(
         label="Loner %",
-        tooltip="Percentage of hands where your team called a loner (solo play).",
+        tooltip="Percentage of hands where you personally called a loner (solo play). AI partner loners are excluded.",
         format="pct",
         category="secondary",
     ),
     "loner_make_rate": MetricDef(
         label="Loner Make",
-        tooltip="Percentage of your loner bids that were successfully made.",
+        tooltip="Percentage of your personal loner bids that were successfully made.",
         format="pct",
         category="secondary",
     ),
@@ -291,9 +291,9 @@ def compute_player_stats(session: Session, player_id: int) -> PlayerStats | None
     ]
     avg_bid_level = sum(bid_levels) / len(bid_levels) if bid_levels else 0.0
 
-    # Moon stats
+    # Moon stats — personal only (human = seat 0, excludes AI partner seat 2)
     moon_hands = [h for h in completed_hands if h.winning_bid_type == "moon"]
-    moon_declaring = [h for h in moon_hands if h.bidder_seat in (0, 2)]
+    moon_declaring = [h for h in moon_hands if h.bidder_seat == 0]
     moon_call_rate = len(moon_declaring) / hands_played if hands_played > 0 else 0.0
     moon_made = [
         h
@@ -302,9 +302,9 @@ def compute_player_stats(session: Session, player_id: int) -> PlayerStats | None
     ]
     moon_make_rate = len(moon_made) / len(moon_declaring) if moon_declaring else 0.0
 
-    # Loner stats
+    # Loner stats — personal only (human = seat 0, excludes AI partner seat 2)
     loner_hands = [h for h in completed_hands if h.winning_bid_type == "loner"]
-    loner_declaring = [h for h in loner_hands if h.bidder_seat in (0, 2)]
+    loner_declaring = [h for h in loner_hands if h.bidder_seat == 0]
     loner_call_rate = len(loner_declaring) / hands_played if hands_played > 0 else 0.0
     loner_made = [
         h


### PR DESCRIPTION
## Plan
N/A — targeted bug fix

## Summary
- Moon and loner call/make rates in `compute_player_stats()` now count only hands where the **human player** (seat 0) declared, excluding AI partner (seat 2) declarations
- Updated metric tooltips to clarify personal-only semantics ("you personally called" instead of "your team called")
- Added regression test proving AI partner moon/loner hands are excluded from player stats

## Why
When an AI partner declares a moon or loner contract, the stats were incorrectly attributed to the human player on the leaderboard. The filter used `bidder_seat in (0, 2)` (team 0) instead of `bidder_seat == 0` (human only) for moon/loner metrics.

Closes #2152

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_leaderboard.py -v
```

**Seed:** N/A (unit tests, no randomness)

## Test Criteria
- **Pass condition:** New test `test_ai_partner_moon_loner_excluded_from_player_stats` verifies AI partner (seat 2) moon/loner hands yield 0.0 rates for the human player, while team-level bid_rate still includes partner
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_leaderboard.py::TestComputePlayerStats::test_ai_partner_moon_loner_excluded_from_player_stats -v`
- **Expected result:** 1 passed

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_leaderboard.py -v` — 60 passed
- [x] `make check-quiet` — 3 pre-existing failures (ops/telegram), 0 new failures

## Expected impact
- Metrics impact: Moon/loner rates on leaderboard will decrease for players whose AI partners had been inflating their stats
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
```

`git worktree list` (abbreviated):
```
Bid-Euchre-steward-brws-author-b   7025a2ea [fix/ai-partner-moon-loner-stats]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)