### PR TITLE
feat(web): add dev database reset script for go-live (#2087)

### DIFF
--- a/tests/unit/hosted_play/test_reset_dev_db.py
+++ b/tests/unit/hosted_play/test_reset_dev_db.py
@@ -1,0 +1,291 @@
+"""Tests for the dev database reset utility (web.reset_dev_db)."""
+
+from __future__ import annotations
+
+import pytest
+
+from web.db import Comment, Decision, Hand, InviteCode, Match, Player
+from web.reset_dev_db import ResetResult, get_counts, reset_game_data
+
+from .conftest import (
+    create_test_decision,
+    create_test_hand,
+    create_test_invite_code,
+    create_test_match,
+    create_test_player,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _add_decisions(session, match, hand, n: int) -> list:
+    """Add *n* decisions to a hand."""
+    decs = []
+    for _ in range(n):
+        decs.append(create_test_decision(session, match, hand))
+    return decs
+
+
+def _seed_full_db(session) -> dict[str, int]:
+    """Populate the DB with a realistic mix of game data and accounts.
+
+    Returns expected counts per table.
+    """
+    # Two players
+    p1 = create_test_player(session, nickname="Alice")
+    p2 = create_test_player(session, nickname="Bob")
+
+    # Two invite codes (one redeemed, one active)
+    create_test_invite_code(session, status="redeemed", player_id=p1.id)
+    create_test_invite_code(session, status="active")
+
+    # Player 1: complete match with 2 hands
+    m1 = create_test_match(session, player_id=p1.id, status="complete")
+    h1 = create_test_hand(session, m1, hand_number=0)
+    _add_decisions(session, m1, h1, 14)
+    h2 = create_test_hand(session, m1, hand_number=1)
+    _add_decisions(session, m1, h2, 10)
+
+    # Player 2: active match with 1 hand
+    m2 = create_test_match(session, player_id=p2.id, status="active")
+    h3 = create_test_hand(session, m2, hand_number=0)
+    _add_decisions(session, m2, h3, 6)
+
+    # A comment
+    comment = Comment(player_id=p1.id, match_id=m1.id, content="Great game!")
+    session.add(comment)
+    session.flush()
+
+    return {
+        "players": 2,
+        "invite_codes": 2,
+        "matches": 2,
+        "hands": 3,
+        "decisions": 14 + 10 + 6,
+        "comments": 1,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_counts
+# ---------------------------------------------------------------------------
+
+
+class TestGetCounts:
+    def test_empty_db(self, db_session):
+        counts = get_counts(db_session)
+        assert all(v == 0 for v in counts.values())
+
+    def test_populated_db(self, db_session):
+        expected = _seed_full_db(db_session)
+        counts = get_counts(db_session)
+        assert counts == expected
+
+
+# ---------------------------------------------------------------------------
+# Tests: reset_game_data (default — preserve accounts)
+# ---------------------------------------------------------------------------
+
+
+class TestResetGameDataDefault:
+    """Default mode: clear matches/hands/decisions/comments, keep players/codes."""
+
+    def test_clears_game_data(self, db_session):
+        _seed_full_db(db_session)
+        result = reset_game_data(db_session)
+
+        assert result.decisions == 30
+        assert result.hands == 3
+        assert result.matches == 2
+        assert result.comments == 1
+
+        # Game tables are empty
+        assert db_session.query(Decision).count() == 0
+        assert db_session.query(Hand).count() == 0
+        assert db_session.query(Match).count() == 0
+        assert db_session.query(Comment).count() == 0
+
+    def test_preserves_players(self, db_session):
+        _seed_full_db(db_session)
+        result = reset_game_data(db_session)
+
+        assert result.players == 0  # no players deleted
+        assert db_session.query(Player).count() == 2
+
+    def test_preserves_invite_codes(self, db_session):
+        _seed_full_db(db_session)
+        result = reset_game_data(db_session)
+
+        assert result.invite_codes == 0  # no codes deleted
+        assert db_session.query(InviteCode).count() == 2
+
+    def test_empty_db_is_noop(self, db_session):
+        result = reset_game_data(db_session)
+        assert result == ResetResult()
+
+    def test_returns_correct_counts(self, db_session):
+        expected = _seed_full_db(db_session)
+        result = reset_game_data(db_session)
+
+        assert result.decisions == expected["decisions"]
+        assert result.hands == expected["hands"]
+        assert result.matches == expected["matches"]
+        assert result.comments == expected["comments"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: reset_game_data (full — clear everything)
+# ---------------------------------------------------------------------------
+
+
+class TestResetGameDataFull:
+    """Full mode: clear all tables including players and invite codes."""
+
+    def test_clears_everything(self, db_session):
+        _seed_full_db(db_session)
+        reset_game_data(db_session, full=True)
+
+        # All tables empty
+        for model in (Decision, Hand, Match, Comment, InviteCode, Player):
+            assert db_session.query(model).count() == 0
+
+    def test_reports_all_deletions(self, db_session):
+        expected = _seed_full_db(db_session)
+        result = reset_game_data(db_session, full=True)
+
+        assert result.decisions == expected["decisions"]
+        assert result.hands == expected["hands"]
+        assert result.matches == expected["matches"]
+        assert result.comments == expected["comments"]
+        assert result.invite_codes == expected["invite_codes"]
+        assert result.players == expected["players"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: CLI (main)
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    """Test the CLI entry point via main().
+
+    CLI tests use a file-based temp SQLite DB because ``main()`` calls
+    ``engine.dispose()`` which destroys in-memory SQLite databases.
+    """
+
+    @pytest.fixture()
+    def _cli_db(self, tmp_path):
+        """Create a file-based temp DB and seed it. Return (db_url, engine)."""
+        from web.db import create_tables as _ct
+        from web.db import init_engine as _ie
+        from web.db import make_session_factory as _mf
+
+        db_path = tmp_path / "test_reset.db"
+        db_url = f"sqlite:///{db_path}"
+        engine = _ie(db_url)
+        _ct(engine)
+        factory = _mf(engine)
+        session = factory()
+        _seed_full_db(session)
+        session.commit()
+        session.close()
+        return db_url, engine
+
+    def _check_counts(self, db_url: str) -> dict[str, int]:
+        """Open a fresh session and return current row counts."""
+        from web.db import init_engine as _ie
+        from web.db import make_session_factory as _mf
+
+        engine = _ie(db_url)
+        factory = _mf(engine)
+        session = factory()
+        counts = get_counts(session)
+        session.close()
+        engine.dispose()
+        return counts
+
+    def test_dry_run_no_changes(self, _cli_db, monkeypatch):
+        """--dry-run should report counts but not delete anything."""
+        db_url, _ = _cli_db
+
+        from web.config import HostedPlayConfig
+
+        monkeypatch.setattr(
+            "web.reset_dev_db.get_config",
+            lambda: HostedPlayConfig(database_url=db_url),
+        )
+
+        from web.reset_dev_db import main
+
+        exit_code = main(["--dry-run"])
+        assert exit_code == 0
+
+        counts = self._check_counts(db_url)
+        assert counts["matches"] == 2
+        assert counts["players"] == 2
+
+    def test_yes_flag_no_prompt(self, _cli_db, monkeypatch):
+        """--yes should skip confirmation and delete game data."""
+        db_url, _ = _cli_db
+
+        from web.config import HostedPlayConfig
+
+        monkeypatch.setattr(
+            "web.reset_dev_db.get_config",
+            lambda: HostedPlayConfig(database_url=db_url),
+        )
+
+        from web.reset_dev_db import main
+
+        exit_code = main(["--yes"])
+        assert exit_code == 0
+
+        counts = self._check_counts(db_url)
+        assert counts["matches"] == 0
+        assert counts["players"] == 2
+        assert counts["invite_codes"] == 2
+
+    def test_full_yes_clears_all(self, _cli_db, monkeypatch):
+        """--full --yes should delete everything."""
+        db_url, _ = _cli_db
+
+        from web.config import HostedPlayConfig
+
+        monkeypatch.setattr(
+            "web.reset_dev_db.get_config",
+            lambda: HostedPlayConfig(database_url=db_url),
+        )
+
+        from web.reset_dev_db import main
+
+        exit_code = main(["--full", "--yes"])
+        assert exit_code == 0
+
+        counts = self._check_counts(db_url)
+        assert counts["matches"] == 0
+        assert counts["players"] == 0
+        assert counts["invite_codes"] == 0
+
+    def test_empty_db_exits_zero(self, tmp_path, monkeypatch):
+        """Empty database should exit 0 with 'nothing to reset' message."""
+        from web.config import HostedPlayConfig
+        from web.db import create_tables as _ct
+        from web.db import init_engine as _ie
+
+        db_path = tmp_path / "empty_reset.db"
+        db_url = f"sqlite:///{db_path}"
+        engine = _ie(db_url)
+        _ct(engine)
+        engine.dispose()
+
+        monkeypatch.setattr(
+            "web.reset_dev_db.get_config",
+            lambda: HostedPlayConfig(database_url=db_url),
+        )
+
+        from web.reset_dev_db import main
+
+        exit_code = main(["--yes"])
+        assert exit_code == 0

--- a/web/reset_dev_db.py
+++ b/web/reset_dev_db.py
@@ -1,0 +1,259 @@
+"""Dev database reset utility for the Bid Euchre browser game.
+
+Clears game data (matches, hands, decisions, comments) while preserving
+player accounts and invite codes.  Intended for pre-launch cleanup of
+test/bot data accumulated during development.
+
+Usage::
+
+    # Preview what would be deleted (dry run)
+    uv run python -m web.reset_dev_db --dry-run
+
+    # Reset game data, keep players and invite codes
+    uv run python -m web.reset_dev_db --yes
+
+    # Full nuke — clear everything including players and invite codes
+    uv run python -m web.reset_dev_db --full --yes
+
+    # Custom DATABASE_URL
+    DATABASE_URL=sqlite:///mydev.db uv run python -m web.reset_dev_db --yes
+
+Environment variables
+---------------------
+Uses the same ``DATABASE_URL`` as the web application (see ``web.config``).
+Defaults to ``sqlite:///hosted_play.db`` when unset.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from .config import get_config
+from .db import (
+    Comment,
+    Decision,
+    Hand,
+    InviteCode,
+    Match,
+    Player,
+    init_engine,
+    make_session_factory,
+)
+
+
+@dataclass
+class ResetResult:
+    """Counts of rows deleted per table."""
+
+    decisions: int = 0
+    hands: int = 0
+    comments: int = 0
+    matches: int = 0
+    invite_codes: int = 0
+    players: int = 0
+
+
+def get_counts(session: Session) -> dict[str, int]:
+    """Return row counts for all game-related tables."""
+    return {
+        "players": session.query(Player).count(),
+        "invite_codes": session.query(InviteCode).count(),
+        "matches": session.query(Match).count(),
+        "hands": session.query(Hand).count(),
+        "decisions": session.query(Decision).count(),
+        "comments": session.query(Comment).count(),
+    }
+
+
+def reset_game_data(session: Session, *, full: bool = False) -> ResetResult:
+    """Delete game data from the database.
+
+    Parameters
+    ----------
+    session:
+        An open SQLAlchemy session.  Caller is responsible for commit/rollback.
+    full:
+        If True, also delete players and invite codes (complete reset).
+        If False (default), only delete matches, hands, decisions, and
+        comments — preserving player accounts and invite codes.
+
+    Returns
+    -------
+    ResetResult
+        Counts of rows deleted from each table.
+    """
+    result = ResetResult()
+
+    # Delete in FK-safe order: children before parents
+    result.decisions = session.query(Decision).delete()
+    result.hands = session.query(Hand).delete()
+    result.comments = session.query(Comment).delete()
+    result.matches = session.query(Match).delete()
+
+    if full:
+        result.invite_codes = session.query(InviteCode).delete()
+        result.players = session.query(Player).delete()
+
+    return result
+
+
+def _reset_sqlite_sequences(session: Session, *, full: bool = False) -> None:
+    """Reset SQLite autoincrement counters for cleared tables.
+
+    SQLite tracks autoincrement via the ``sqlite_sequence`` table.  After
+    deleting all rows, resetting the sequence ensures new rows start from
+    ID 1 for a clean-slate feel.
+
+    No-op if ``sqlite_sequence`` does not exist (e.g. Postgres, or tables
+    that have never had an insert with AUTOINCREMENT).
+    """
+    game_tables = ["decisions", "hands", "comments", "matches"]
+    account_tables = ["invite_codes", "players"]
+    tables = game_tables + (account_tables if full else [])
+
+    try:
+        for table in tables:
+            session.execute(
+                text("DELETE FROM sqlite_sequence WHERE name = :name"),
+                {"name": table},
+            )
+    except Exception:
+        # sqlite_sequence may not exist — safe to ignore
+        pass
+
+
+def _format_result(result: ResetResult, *, full: bool) -> str:
+    """Format the reset result as a human-readable summary."""
+    lines = [
+        f"  decisions:    {result.decisions}",
+        f"  hands:        {result.hands}",
+        f"  comments:     {result.comments}",
+        f"  matches:      {result.matches}",
+    ]
+    if full:
+        lines.extend(
+            [
+                f"  invite_codes: {result.invite_codes}",
+                f"  players:      {result.players}",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def _format_counts(counts: dict[str, int]) -> str:
+    """Format table counts as a human-readable summary."""
+    return "\n".join(f"  {table}: {count}" for table, count in counts.items())
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for dev database reset."""
+    parser = argparse.ArgumentParser(
+        description="Reset the dev database — clear game data before go-live.",
+        epilog=(
+            "Default mode preserves player accounts and invite codes.\n"
+            "Use --full to clear everything."
+        ),
+    )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Also delete players and invite codes (complete reset)",
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip confirmation prompt",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be deleted without making changes",
+    )
+    args = parser.parse_args(argv)
+
+    # Use same config resolution as the web app
+    config = get_config()
+    db_url = config.database_url
+
+    print(f"Database: {db_url}")
+
+    engine = init_engine(db_url)
+    session_factory = make_session_factory(engine)
+    session = session_factory()
+
+    try:
+        counts = get_counts(session)
+        print(f"\nCurrent row counts:\n{_format_counts(counts)}")
+
+        game_total = (
+            counts["matches"]
+            + counts["hands"]
+            + counts["decisions"]
+            + counts["comments"]
+        )
+        if args.full:
+            game_total += counts["players"] + counts["invite_codes"]
+
+        if game_total == 0:
+            print("\nDatabase is already empty — nothing to reset.")
+            return 0
+
+        if args.dry_run:
+            mode = (
+                "FULL (including players and invite codes)"
+                if args.full
+                else "game data only"
+            )
+            print(f"\nDry run — would delete {game_total} rows ({mode}).")
+            return 0
+
+        # Confirmation gate
+        if not args.yes:
+            mode = (
+                "ALL data (including players and invite codes)"
+                if args.full
+                else "game data (preserving players and invite codes)"
+            )
+            prompt = f"\nThis will delete {mode}. Continue? [y/N] "
+            answer = input(prompt).strip().lower()
+            if answer not in ("y", "yes"):
+                print("Aborted.")
+                return 1
+
+        result = reset_game_data(session, full=args.full)
+
+        # Reset autoincrement counters for SQLite
+        if db_url.startswith("sqlite"):
+            _reset_sqlite_sequences(session, full=args.full)
+
+        session.commit()
+
+        mode = "Full reset" if args.full else "Game data reset"
+        print(f"\n{mode} complete. Rows deleted:")
+        print(_format_result(result, full=args.full))
+
+        # Show remaining data
+        remaining = get_counts(session)
+        if remaining["players"] > 0 or remaining["invite_codes"] > 0:
+            print(
+                f"\nPreserved:\n  players:      {remaining['players']}\n  invite_codes: {remaining['invite_codes']}"
+            )
+
+        return 0
+
+    except Exception as exc:
+        session.rollback()
+        print(f"\nError: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        session.close()
+        engine.dispose()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Plan
N/A — standalone ops task from issue #2087.

## Summary
- Add `web/reset_dev_db.py` management command to clear game data before production go-live
- Default mode preserves player accounts and invite codes while clearing matches, hands, decisions, and comments
- Supports `--full` (clear everything), `--dry-run` (preview), and `--yes` (skip confirmation)

## Why
Before go-live, the dev database contains test/bot data from development and Playwright proving
runs that would pollute the leaderboard and match history for real users. This script provides a
safe, selective reset that preserves account infrastructure while clearing gameplay data.

Closes #2087

## Repro / Validation
**Command(s) run:**
```bash
# Preview what would be deleted
uv run python -m web.reset_dev_db --dry-run

# Reset game data, keep accounts
uv run python -m web.reset_dev_db --yes

# Full reset
uv run python -m web.reset_dev_db --full --yes
```

## Test Criteria
- **Pass condition:** All 13 unit tests pass covering default mode, full mode, dry-run, and CLI
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_reset_dev_db.py -v`
- **Expected result:** `13 passed`

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_reset_dev_db.py -v` — 13/13 passed
- [x] `make check-quiet` — 3 pre-existing failures in unrelated ops modules, all reset tests pass

## Expected impact
- Metrics impact: None
- Runtime impact: None (offline management command)

## Risk level
- [x] Low (new utility script + tests, no changes to existing code)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git worktree list` (abbreviated):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a   e8fc5284 [ops/dev-db-reset]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)