### PR TITLE
fix(strategy): clear stale inference on contract change in Glutton choose_card

### DIFF
--- a/src/bid_euchre/strategy/greedy.py
+++ b/src/bid_euchre/strategy/greedy.py
@@ -442,11 +442,17 @@ class GluttonStrategy(Strategy):
         # Defense-in-depth: sync contract context on every call so that
         # _choose_lead, _choose_discard, and helpers always use the
         # current hand's contract_type/trump_suit even if on_hand_start
-        # was never called.
+        # was never called.  When the contract changes, per-hand inference
+        # (_seen_counts, _void_suits_by_seat) is stale — reset it.
+        if contract_type != self._contract_type or trump_suit != self._trump_suit:
+            self._seen_counts = {}
+            self._void_suits_by_seat = {0: set(), 1: set(), 2: set(), 3: set()}
         self._contract_type = contract_type
         self._trump_suit = trump_suit
 
-        # Fallback reset if on_hand_start wasn't called (backward compatibility)
+        # Fallback reset if on_hand_start wasn't called (backward compatibility).
+        # Catches the edge case where consecutive hands share the same contract
+        # so the change-detection above doesn't fire.
         if len(hand) == 10 and not plays_so_far:
             self._seen_counts = {}
             self._void_suits_by_seat = {0: set(), 1: set(), 2: set(), 3: set()}
@@ -932,11 +938,17 @@ class GluttonIsolatedStrategy(Strategy):
         """Choose card with configurable feature flags."""
         # Defense-in-depth: sync contract context on every call so that
         # helpers always use the current hand's contract_type/trump_suit
-        # even if on_hand_start was never called.
+        # even if on_hand_start was never called.  When the contract
+        # changes, per-hand inference is stale — reset it.
+        if contract_type != self._contract_type or trump_suit != self._trump_suit:
+            self._seen_counts = {}
+            self._void_suits_by_seat = {0: set(), 1: set(), 2: set(), 3: set()}
         self._contract_type = contract_type
         self._trump_suit = trump_suit
 
-        # Fallback reset if on_hand_start wasn't called
+        # Fallback reset if on_hand_start wasn't called.
+        # Catches the edge case where consecutive hands share the same
+        # contract so the change-detection above doesn't fire.
         if len(hand) == 10 and not plays_so_far:
             self._seen_counts = {}
             self._void_suits_by_seat = {0: set(), 1: set(), 2: set(), 3: set()}

--- a/tests/unit/test_glutton.py
+++ b/tests/unit/test_glutton.py
@@ -1104,3 +1104,165 @@ class TestContractSyncDefenseInDepth:
         glutton.choose_card(hand, [], "suit", "H", 0)
         assert glutton._contract_type == "suit"
         assert glutton._trump_suit == "H"
+
+
+class TestStaleInferenceReset:
+    """Tests for stale inference reset when contract changes (#2139).
+
+    When on_hand_start() is never called, the defense-in-depth sync in
+    choose_card() should reset _seen_counts and _void_suits_by_seat when
+    the contract changes — stale inference from a previous hand could
+    cause incorrect decisions.
+    """
+
+    def test_glutton_inference_cleared_on_contract_change(self):
+        """GluttonStrategy clears inference when contract changes mid-stream.
+
+        Simulate: hand 1 under "high" accumulates inference, then hand 2
+        switches to "low" without on_hand_start.  The stale inference from
+        hand 1 must not persist into hand 2.
+        """
+        glutton = GluttonStrategy(debug=True)
+
+        # Simulate hand 1 under "high" with some observed plays
+        hand1 = [
+            Card("H", "A"),
+            Card("H", "K"),
+            Card("S", "T"),
+            Card("S", "J"),
+        ]
+        glutton.on_hand_start(hand1, "high", None, 0)
+        # Observe some plays to populate inference
+        glutton.observe_play(1, Card("C", "A"), [(1, Card("C", "A"))], "high", None)
+        glutton.observe_play(
+            2, Card("D", "T"), [(1, Card("C", "A")), (2, Card("D", "T"))], "high", None
+        )
+        assert len(glutton._seen_counts) > 0, "Precondition: inference populated"
+        assert any(
+            len(v) > 0 for v in glutton._void_suits_by_seat.values()
+        ), "Precondition: void inference populated"
+
+        # Hand 2 starts with a different contract but NO on_hand_start
+        hand2 = [Card("H", "T"), Card("H", "K"), Card("H", "A")]
+        glutton.choose_card(hand2, [], "low", None, 0)
+
+        # Inference should have been cleared by the contract change
+        assert (
+            glutton._seen_counts == {}
+        ), f"Stale _seen_counts not cleared on contract change: {glutton._seen_counts}"
+        assert all(
+            len(v) == 0 for v in glutton._void_suits_by_seat.values()
+        ), f"Stale _void_suits_by_seat not cleared: {glutton._void_suits_by_seat}"
+
+    def test_glutton_inference_preserved_within_hand(self):
+        """Inference should NOT be cleared on subsequent calls within the same hand."""
+        glutton = GluttonStrategy(debug=True)
+
+        hand = [
+            Card("H", "A"),
+            Card("H", "K"),
+            Card("S", "T"),
+            Card("S", "J"),
+            Card("S", "Q"),
+            Card("D", "A"),
+            Card("D", "K"),
+            Card("D", "Q"),
+            Card("C", "T"),
+            Card("C", "J"),
+        ]
+        glutton.on_hand_start(hand, "high", None, 0)
+
+        # Observe a play to populate inference
+        glutton.observe_play(
+            1, Card("C", "A"), [(0, Card("H", "A")), (1, Card("C", "A"))], "high", None
+        )
+        assert len(glutton._seen_counts) > 0
+
+        # Call choose_card with SAME contract — inference must be preserved
+        remaining = hand[1:]  # 9 cards
+        plays = [(1, Card("S", "A"))]
+        glutton.choose_card(remaining, plays, "high", None, 0)
+
+        assert (
+            len(glutton._seen_counts) > 0
+        ), "Inference should be preserved within the same hand/contract"
+
+    def test_glutton_trump_change_clears_inference(self):
+        """Changing trump_suit (same contract_type) also clears inference."""
+        glutton = GluttonStrategy(debug=True)
+
+        hand1 = [Card("H", "J"), Card("S", "T")]
+        glutton.on_hand_start(hand1, "suit", "H", 0)
+        glutton.observe_play(1, Card("D", "A"), [(1, Card("D", "A"))], "suit", "H")
+        assert len(glutton._seen_counts) > 0
+
+        # New hand with different trump, no on_hand_start
+        hand2 = [Card("S", "J"), Card("D", "T")]
+        glutton.choose_card(hand2, [], "suit", "S", 0)
+
+        assert (
+            glutton._seen_counts == {}
+        ), "Stale inference not cleared on trump_suit change"
+
+    def test_isolated_inference_cleared_on_contract_change(self):
+        """GluttonIsolatedStrategy clears inference when contract changes."""
+        glutton = GluttonIsolatedStrategy(
+            debug=True,
+            smart_leads=True,
+            partner_awareness=True,
+        )
+
+        # Hand 1 under "high" — accumulate inference
+        hand1 = [
+            Card("H", "A"),
+            Card("H", "K"),
+            Card("S", "T"),
+            Card("S", "J"),
+        ]
+        glutton.on_hand_start(hand1, "high", None, 0)
+        glutton.observe_play(1, Card("C", "A"), [(1, Card("C", "A"))], "high", None)
+        glutton.observe_play(
+            2, Card("D", "T"), [(1, Card("C", "A")), (2, Card("D", "T"))], "high", None
+        )
+        assert len(glutton._seen_counts) > 0
+
+        # Hand 2 with different contract, no on_hand_start
+        hand2 = [Card("H", "T"), Card("H", "K"), Card("H", "A")]
+        glutton.choose_card(hand2, [], "low", None, 0)
+
+        assert (
+            glutton._seen_counts == {}
+        ), f"Isolated: stale _seen_counts not cleared: {glutton._seen_counts}"
+        assert all(
+            len(v) == 0 for v in glutton._void_suits_by_seat.values()
+        ), f"Isolated: stale _void_suits_by_seat not cleared: {glutton._void_suits_by_seat}"
+
+    def test_isolated_inference_preserved_within_hand(self):
+        """Isolated variant preserves inference within the same hand."""
+        glutton = GluttonIsolatedStrategy(debug=True, partner_awareness=True)
+
+        hand = [
+            Card("H", "A"),
+            Card("H", "K"),
+            Card("S", "T"),
+            Card("S", "J"),
+            Card("S", "Q"),
+            Card("D", "A"),
+            Card("D", "K"),
+            Card("D", "Q"),
+            Card("C", "T"),
+            Card("C", "J"),
+        ]
+        glutton.on_hand_start(hand, "high", None, 0)
+        glutton.observe_play(
+            1, Card("C", "A"), [(0, Card("H", "A")), (1, Card("C", "A"))], "high", None
+        )
+        assert len(glutton._seen_counts) > 0
+
+        remaining = hand[1:]
+        plays = [(1, Card("S", "A"))]
+        glutton.choose_card(remaining, plays, "high", None, 0)
+
+        assert (
+            len(glutton._seen_counts) > 0
+        ), "Isolated: inference should be preserved within same hand/contract"


### PR DESCRIPTION
## Summary

- When `on_hand_start()` is not called between hands, the defense-in-depth contract sync in `choose_card()` now detects contract/trump changes and resets `_seen_counts` and `_void_suits_by_seat`
- Both `GluttonStrategy` (line 446) and `GluttonIsolatedStrategy` (line 936) are fixed with the same pattern
- 5 new tests verify inference is cleared on contract change and preserved within a hand

## Why

Review follow-up from PR #2137 (issue #2139). The defense-in-depth sync updated contract state but left stale per-hand inference (`_seen_counts`, `_void_suits_by_seat`) from a previous hand, which could cause incorrect card decisions when `on_hand_start()` was never called.

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_glutton.py tests/unit/test_greedy.py tests/unit/test_strategy_correctness.py -v
# 71 passed
```

## Tests

- `TestStaleInferenceReset::test_glutton_inference_cleared_on_contract_change` — verifies inference cleared when contract changes
- `TestStaleInferenceReset::test_glutton_inference_preserved_within_hand` — verifies inference preserved within same hand
- `TestStaleInferenceReset::test_glutton_trump_change_clears_inference` — verifies trump_suit change triggers reset
- `TestStaleInferenceReset::test_isolated_inference_cleared_on_contract_change` — same for GluttonIsolatedStrategy
- `TestStaleInferenceReset::test_isolated_inference_preserved_within_hand` — same for GluttonIsolatedStrategy

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: fix/glutton-stale-inference-reset
```

Closes #2139