### PR TITLE
feat(web): enhance contract bar UX — header, team labels, color coding (#2166)

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -1872,7 +1872,7 @@ class TestContractBar:
     """Verify the contract bar partial renders correctly for all contract types."""
 
     def test_suit_contract_shows_trump_symbol(self, env):
-        """Suit contract shows bid level and trump suit symbol."""
+        """Suit contract shows bid level, trump symbol, and opponent label."""
         tmpl = env.get_template("partials/contract_bar.html")
         html = tmpl.render(
             winning_bid=6,
@@ -1882,12 +1882,17 @@ class TestContractBar:
             trump="H",
         )
         assert "contract-bar" in html
+        assert "contract-bar--opp-team" in html
+        assert "Contract:" in html
         assert "6" in html
         assert "\u2665" in html  # Heart symbol
         assert "Slim" in html
+        assert "(Opponent)" in html
+        # Em dash separator
+        assert "\u2014" in html or "&mdash;" in html
 
     def test_high_contract(self, env):
-        """High (no-trump) contract displays 'High' label."""
+        """High (no-trump) contract by human shows 'You' with no relationship."""
         tmpl = env.get_template("partials/contract_bar.html")
         html = tmpl.render(
             winning_bid=7,
@@ -1899,9 +1904,13 @@ class TestContractBar:
         assert "7" in html
         assert "High" in html
         assert "You" in html
+        assert "contract-bar--my-team" in html
+        # No relationship label for "You"
+        assert "(Partner)" not in html
+        assert "(Opponent)" not in html
 
     def test_low_contract(self, env):
-        """Low (no-trump) contract displays 'Low' label."""
+        """Low (no-trump) contract by partner shows 'Ace (Partner)'."""
         tmpl = env.get_template("partials/contract_bar.html")
         html = tmpl.render(
             winning_bid=7,
@@ -1913,9 +1922,11 @@ class TestContractBar:
         assert "7" in html
         assert "Low" in html
         assert "Ace" in html
+        assert "(Partner)" in html
+        assert "contract-bar--my-team" in html
 
     def test_moon_contract(self, env):
-        """Moon bid shows moon emoji and label."""
+        """Moon bid by opponent shows moon emoji and (Opponent) label."""
         tmpl = env.get_template("partials/contract_bar.html")
         html = tmpl.render(
             winning_bid=10,
@@ -1928,9 +1939,11 @@ class TestContractBar:
         assert "contract-bar__type--moon" in html
         assert "\u2660" in html  # Spade symbol
         assert "Deuce" in html
+        assert "(Opponent)" in html
+        assert "contract-bar--opp-team" in html
 
     def test_loner_contract(self, env):
-        """Loner bid shows loner emoji and label."""
+        """Loner bid by human shows loner emoji, 'You', no relationship."""
         tmpl = env.get_template("partials/contract_bar.html")
         html = tmpl.render(
             winning_bid=10,
@@ -1943,6 +1956,9 @@ class TestContractBar:
         assert "contract-bar__type--loner" in html
         assert "\u2666" in html  # Diamond symbol
         assert "You" in html
+        assert "contract-bar--my-team" in html
+        assert "(Partner)" not in html
+        assert "(Opponent)" not in html
 
     def test_hidden_when_no_bid(self, env):
         """No output when winning_bid is None (auction not resolved)."""
@@ -1969,6 +1985,62 @@ class TestContractBar:
         assert "contract-bar" in html
         assert "You" in html
         assert "\u2663" in html  # Club symbol
+        assert "contract-bar--my-team" in html
+
+    def test_partner_relationship_label(self, env):
+        """Partner (seat 2) shows '(Partner)' relationship label."""
+        tmpl = env.get_template("partials/contract_bar.html")
+        html = tmpl.render(
+            winning_bid=5,
+            bidder_seat=2,
+            bid_type="regular",
+            contract_type="suit",
+            trump="S",
+        )
+        assert "Ace" in html
+        assert "(Partner)" in html
+        assert "contract-bar--my-team" in html
+
+    def test_opponent_seat1_relationship_label(self, env):
+        """Left opponent (seat 1) shows '(Opponent)' relationship label."""
+        tmpl = env.get_template("partials/contract_bar.html")
+        html = tmpl.render(
+            winning_bid=5,
+            bidder_seat=1,
+            bid_type="regular",
+            contract_type="suit",
+            trump="H",
+        )
+        assert "Slim" in html
+        assert "(Opponent)" in html
+        assert "contract-bar--opp-team" in html
+
+    def test_opponent_seat3_relationship_label(self, env):
+        """Right opponent (seat 3) shows '(Opponent)' relationship label."""
+        tmpl = env.get_template("partials/contract_bar.html")
+        html = tmpl.render(
+            winning_bid=8,
+            bidder_seat=3,
+            bid_type="regular",
+            contract_type="suit",
+            trump="C",
+        )
+        assert "Deuce" in html
+        assert "(Opponent)" in html
+        assert "contract-bar--opp-team" in html
+
+    def test_header_label_present(self, env):
+        """Contract bar shows 'Contract:' header label."""
+        tmpl = env.get_template("partials/contract_bar.html")
+        html = tmpl.render(
+            winning_bid=5,
+            bidder_seat=0,
+            bid_type="regular",
+            contract_type="suit",
+            trump="H",
+        )
+        assert "contract-bar__header" in html
+        assert "Contract:" in html
 
 
 # ---------------------------------------------------------------------------

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -502,6 +502,22 @@ main {
     flex-wrap: wrap;
 }
 
+.contract-bar--my-team {
+    border-bottom-color: #43a047;
+}
+
+.contract-bar--opp-team {
+    border-bottom-color: #f9a825;
+}
+
+.contract-bar__header {
+    color: var(--color-text-muted);
+    font-size: 0.8rem;
+    font-weight: 400;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
 .contract-bar__contract {
     display: flex;
     align-items: center;
@@ -548,12 +564,27 @@ main {
 
 .contract-bar__separator {
     color: var(--color-text-muted);
-    font-size: 0.8rem;
+    font-size: 0.85rem;
 }
 
 .contract-bar__declarer {
-    color: var(--color-text-muted);
-    font-size: 0.82rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.contract-bar--my-team .contract-bar__declarer {
+    color: #66bb6a;
+}
+
+.contract-bar--opp-team .contract-bar__declarer {
+    color: #fdd835;
+}
+
+.contract-bar__relationship {
+    font-weight: 400;
+    font-size: 0.78rem;
+    margin-left: 0.2em;
+    opacity: 0.85;
 }
 
 /* --------------------------------------------------------------------------
@@ -2210,6 +2241,14 @@ main {
 
     .contract-bar__suit {
         font-size: 0.95rem;
+    }
+
+    .contract-bar__header {
+        font-size: 0.7rem;
+    }
+
+    .contract-bar__relationship {
+        font-size: 0.68rem;
     }
 
     /* Icon legend — hide on small phones (vertical space critical) */

--- a/web/templates/partials/contract_bar.html
+++ b/web/templates/partials/contract_bar.html
@@ -12,8 +12,22 @@
 {% set suit_symbols = {"S": "\u2660", "H": "\u2665", "D": "\u2666", "C": "\u2663"} %}
 {% set seat_labels = seat_labels | default({0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}) %}
 
+{# Team relationship: seats 0 & 2 are the human's team (team 0) #}
+{% set is_my_team = bidder_seat in [0, 2] if bidder_seat is not none else false %}
+{% set team_class = "contract-bar--my-team" if is_my_team else "contract-bar--opp-team" %}
+{% if bidder_seat == 0 %}
+    {% set relationship = "" %}
+{% elif bidder_seat == 2 %}
+    {% set relationship = "(Partner)" %}
+{% else %}
+    {% set relationship = "(Opponent)" %}
+{% endif %}
+
 {% if winning_bid is not none and bidder_seat is not none %}
-<div class="contract-bar" role="status" aria-label="Current contract">
+<div class="contract-bar {{ team_class }}" role="status" aria-label="Current contract">
+    {# Header label #}
+    <span class="contract-bar__header">Contract:</span>
+
     {# Trump / contract type indicator #}
     <span class="contract-bar__contract">
         {% set bar_bid_type = bid_type | default("regular") %}
@@ -40,11 +54,12 @@
         {% endif %}
     </span>
 
-    <span class="contract-bar__separator" aria-hidden="true">&middot;</span>
+    <span class="contract-bar__separator" aria-hidden="true">&mdash;</span>
 
-    {# Declarer name #}
+    {# Declarer name + relationship #}
     <span class="contract-bar__declarer">
         {{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}
+        {% if relationship %}<span class="contract-bar__relationship">{{ relationship }}</span>{% endif %}
     </span>
 </div>
 {% endif %}


### PR DESCRIPTION
## Summary

- Add "Contract:" header label to the contract bar for clarity
- Add relationship labels: (Partner) or (Opponent) after the declarer name; omit for "You"
- Color-code the declarer name: green for your team (seats 0,2), warm amber for opponents (seats 1,3)
- Change separator from middot (·) to em dash (—)
- Add green/amber border-bottom color accent per team
- Add mobile-responsive sizing for new elements

## Why

User feedback and analyst spec (#2166) requested more descriptive context in the
contract bar. The existing bar showed only "5♣ · Ace" with no indication of
whether Ace is your partner or opponent. The enhanced bar shows
"Contract: 5♣ — Ace (Partner)" with green coloring, making the team relationship
immediately clear during trick play.

## Repro / Validation

```bash
# Tier 1 — contract bar tests (11 tests)
uv run python -m pytest tests/unit/hosted_play/test_partials.py::TestContractBar -v

# Tier 2 — full validation
make check-quiet
```

All 11 contract bar tests pass. 3 pre-existing failures in unrelated modules
(test_ops_token_economy, test_telegram_filter) confirmed on main.

## Visual examples (expected rendering)

| Scenario | Rendered |
|----------|----------|
| Partner suit bid | Contract: 5♣ — Ace (Partner) [green] |
| Opponent suit bid | Contract: 7♠ — Slim (Opponent) [amber] |
| You bid | Contract: 5♦ — You [green] |
| Moon by partner | Contract: 🌙 Moon ♥ — Ace (Partner) [green] |
| Loner by opponent | Contract: 🃏 Loner ♠ — Slim (Opponent) [amber] |

## Tests

- Updated 7 existing `TestContractBar` tests to verify new header, relationship labels, and team classes
- Added 4 new tests: `test_partner_relationship_label`, `test_opponent_seat1_relationship_label`, `test_opponent_seat3_relationship_label`, `test_header_label_present`

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
branch: fix/contract-bar-ux-2166
```

Closes #2166

🤖 Generated with [Claude Code](https://claude.com/claude-code)