### PR TITLE
fix(ops): add pre-flight health checks to review lane runner (#2075)

### DIFF
--- a/scripts/internal/review_driver.py
+++ b/scripts/internal/review_driver.py
@@ -1040,6 +1040,68 @@ def _step_waiting_for_ci(
     return loop_state
 
 
+def _ensure_branch_checkout(branch: str) -> bool:
+    """Ensure the working directory is on the correct branch for review.
+
+    If the worktree is on a detached HEAD or different branch, attempts
+    to check out the target branch. This prevents stale-worktree issues
+    where the Codex CLI reviews the wrong diff.
+
+    Args:
+        branch: Target branch name (from the PR).
+
+    Returns:
+        True if the checkout succeeded or was already correct,
+        False if the checkout failed.
+    """
+    try:
+        current = subprocess.run(
+            ["git", "symbolic-ref", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+        )
+        if current.returncode == 0 and current.stdout.strip() == branch:
+            return True  # Already on the right branch
+
+        # Detached HEAD or wrong branch — attempt checkout
+        if current.returncode != 0:
+            logger.warning(
+                "Worktree is on detached HEAD — checking out branch %s",
+                branch,
+            )
+        else:
+            logger.info(
+                "Worktree on %s, checking out %s for review",
+                current.stdout.strip(),
+                branch,
+            )
+
+        # Fetch first to ensure the branch ref is available
+        subprocess.run(
+            ["git", "fetch", "origin", branch],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        checkout = subprocess.run(
+            ["git", "checkout", branch],
+            capture_output=True,
+            text=True,
+        )
+        if checkout.returncode != 0:
+            logger.warning(
+                "Could not checkout branch %s: %s",
+                branch,
+                checkout.stderr.strip(),
+            )
+            return False
+        return True
+    except Exception as exc:
+        logger.warning("Branch checkout check failed: %s", exc)
+        return False  # Non-fatal — proceed with current state
+
+
 def _step_waiting_for_codex(
     loop_state: ReviewLoopState,
     base_dir: Path | None,
@@ -1052,10 +1114,21 @@ def _step_waiting_for_codex(
     Auth failures are treated as non-retryable — the review stops immediately
     instead of burning 3 × 10min timeout cycles waiting for interactive auth
     that cannot complete unattended.
+
+    Before invoking Codex CLI, ensures the working directory is on the
+    correct branch to prevent stale-worktree review issues.
     """
     from codex_review_adapter import invoke_codex_cli, save_review_result
 
     iteration = loop_state.iteration_count + 1
+
+    # Ensure we're on the right branch before Codex review
+    if not _ensure_branch_checkout(loop_state.branch):
+        logger.warning(
+            "PR #%d: could not checkout branch %s — proceeding on current HEAD",
+            loop_state.pr_number,
+            loop_state.branch,
+        )
 
     _publish_status(
         loop_state.pr_number,

--- a/scripts/internal/review_lane_runner.py
+++ b/scripts/internal/review_lane_runner.py
@@ -57,6 +57,250 @@ GH_TIMEOUT_SECONDS = 30
 POLL_INTERVAL_SECONDS = 30
 MAX_POLL_CYCLES = 30  # 30 * 30s = 15 min max runtime
 
+# Stale lock files to clean up before processing.
+# These are left behind by crashed scheduled tasks and block clean operation.
+_STALE_LOCK_PATTERNS = [
+    ".claude/scheduled_tasks.lock",
+]
+
+# Maximum age (seconds) for a lock file before it's considered stale.
+_LOCK_STALENESS_SECONDS = 300  # 5 minutes
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight health checks
+# ---------------------------------------------------------------------------
+
+
+def _check_worktree_health(repo_root: Path) -> tuple[bool, str]:
+    """Verify the review lane worktree is on a usable branch.
+
+    Detects detached HEAD state (commonly caused by stale worktrees that
+    haven't been refreshed after PR merges) and attempts to recover by
+    checking out ``main``.
+
+    Args:
+        repo_root: Repository root directory.
+
+    Returns:
+        Tuple of (healthy, message).
+    """
+    try:
+        # Check for detached HEAD
+        result = subprocess.run(
+            ["git", "symbolic-ref", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=str(repo_root),
+        )
+        if result.returncode != 0:
+            # Detached HEAD — attempt recovery
+            logger.warning(
+                "Review lane worktree is on detached HEAD — attempting to checkout main"
+            )
+            checkout = subprocess.run(
+                ["git", "checkout", "main"],
+                capture_output=True,
+                text=True,
+                cwd=str(repo_root),
+            )
+            if checkout.returncode != 0:
+                return False, (
+                    f"Detached HEAD and checkout main failed: {checkout.stderr.strip()}"
+                )
+            logger.info("Recovered from detached HEAD — now on main")
+
+        # Refresh to latest main
+        fetch = subprocess.run(
+            ["git", "fetch", "origin", "main"],
+            capture_output=True,
+            text=True,
+            cwd=str(repo_root),
+            timeout=30,
+        )
+        if fetch.returncode != 0:
+            logger.warning("git fetch origin main failed: %s", fetch.stderr.strip())
+            # Non-fatal — can still process with stale main
+            return True, "Worktree OK but fetch failed (using stale main)"
+
+        # Check if behind origin/main and pull if needed
+        behind = subprocess.run(
+            ["git", "rev-list", "--count", "HEAD..origin/main"],
+            capture_output=True,
+            text=True,
+            cwd=str(repo_root),
+        )
+        if behind.returncode == 0:
+            count = behind.stdout.strip()
+            if count != "0":
+                logger.info(
+                    "Review lane worktree is %s commits behind main — pulling",
+                    count,
+                )
+                pull = subprocess.run(
+                    ["git", "pull", "--ff-only", "origin", "main"],
+                    capture_output=True,
+                    text=True,
+                    cwd=str(repo_root),
+                    timeout=30,
+                )
+                if pull.returncode != 0:
+                    # Try reset instead of pull (handles diverged branches)
+                    reset = subprocess.run(
+                        ["git", "reset", "--hard", "origin/main"],
+                        capture_output=True,
+                        text=True,
+                        cwd=str(repo_root),
+                    )
+                    if reset.returncode != 0:
+                        return False, (
+                            f"Could not sync to origin/main: {reset.stderr.strip()}"
+                        )
+                    logger.info("Reset to origin/main (ff-only pull failed)")
+
+        return True, "Worktree healthy and up to date"
+
+    except subprocess.TimeoutExpired:
+        logger.warning("Worktree health check timed out")
+        return True, "Health check timed out (proceeding anyway)"
+    except Exception as exc:
+        logger.warning("Worktree health check error: %s", exc)
+        return True, f"Health check error: {exc} (proceeding anyway)"
+
+
+def _cleanup_stale_locks(repo_root: Path) -> int:
+    """Remove stale lock files that block clean operation.
+
+    Lock files are considered stale if they are older than
+    ``_LOCK_STALENESS_SECONDS``.
+
+    Args:
+        repo_root: Repository root directory.
+
+    Returns:
+        Number of stale lock files removed.
+    """
+    removed = 0
+    now = time.time()
+
+    for pattern in _STALE_LOCK_PATTERNS:
+        lock_path = repo_root / pattern
+        if not lock_path.exists():
+            continue
+
+        try:
+            age = now - lock_path.stat().st_mtime
+            if age > _LOCK_STALENESS_SECONDS:
+                lock_path.unlink()
+                removed += 1
+                logger.info(
+                    "Removed stale lock file: %s (age: %.0fs)",
+                    lock_path,
+                    age,
+                )
+            else:
+                logger.debug(
+                    "Lock file %s is recent (%.0fs old) — keeping",
+                    lock_path,
+                    age,
+                )
+        except OSError as exc:
+            logger.warning("Could not remove lock file %s: %s", lock_path, exc)
+
+    return removed
+
+
+def _check_codex_auth() -> tuple[bool, str]:
+    """Pre-flight check for Codex CLI authentication.
+
+    Reuses the auth check logic from ``codex_review_adapter``. Falls back
+    to a direct ``codex login status`` check if the adapter is not importable
+    (e.g., running outside the scripts/internal PYTHONPATH).
+
+    Returns:
+        Tuple of (authenticated, message).
+    """
+    try:
+        # Try importing from the adapter (same PYTHONPATH)
+        from codex_review_adapter import check_codex_auth
+
+        return check_codex_auth()
+    except ImportError:
+        pass
+
+    # Direct fallback
+    import shutil
+
+    if shutil.which("codex"):
+        cmd = ["codex", "login", "status"]
+    else:
+        cmd = ["npx", "@openai/codex", "login", "status"]
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        output = (result.stdout + result.stderr).strip()
+        if result.returncode == 0:
+            lower = output.lower()
+            if any(p in lower for p in ("not logged in", "logged out", "no session")):
+                return False, f"Auth inactive: {output}"
+            return True, output
+        return False, f"Auth check failed (exit {result.returncode}): {output}"
+    except FileNotFoundError:
+        return False, "Codex CLI not found"
+    except subprocess.TimeoutExpired:
+        return False, "Auth check timed out"
+    except Exception as exc:
+        return False, f"Auth check error: {exc}"
+
+
+def preflight_health_check(
+    repo_root: Path | None = None,
+    *,
+    skip_auth: bool = False,
+) -> list[tuple[str, bool, str]]:
+    """Run all pre-flight health checks for the review lane.
+
+    Returns a list of (check_name, passed, message) tuples. Non-fatal
+    check failures are logged but do not prevent processing — the review
+    lane should degrade gracefully rather than refusing to start.
+
+    Args:
+        repo_root: Repository root directory.
+        skip_auth: Skip Codex CLI auth check (for testing).
+
+    Returns:
+        List of (check_name, passed, message) tuples.
+    """
+    if repo_root is None:
+        repo_root = _REPO_ROOT
+
+    results: list[tuple[str, bool, str]] = []
+
+    # 1. Worktree health
+    healthy, msg = _check_worktree_health(repo_root)
+    results.append(("worktree_health", healthy, msg))
+    if not healthy:
+        logger.error("Worktree health check FAILED: %s", msg)
+
+    # 2. Stale lock cleanup
+    removed = _cleanup_stale_locks(repo_root)
+    results.append(("lock_cleanup", True, f"Removed {removed} stale lock(s)"))
+
+    # 3. Codex CLI auth (optional — non-fatal for shadow-mode runner)
+    if not skip_auth:
+        auth_ok, auth_msg = _check_codex_auth()
+        results.append(("codex_auth", auth_ok, auth_msg))
+        if not auth_ok:
+            logger.warning(
+                "Codex CLI auth check failed: %s — review lane may "
+                "encounter auth stalls. Fix: run 'codex login' "
+                "interactively.",
+                auth_msg,
+            )
+
+    return results
+
+
 # ---------------------------------------------------------------------------
 # GitHub helpers
 # ---------------------------------------------------------------------------
@@ -531,12 +775,33 @@ def run_once(
     *,
     dry_run: bool = False,
     events_dir: Path | None = None,
+    skip_preflight: bool = False,
 ) -> list[ReviewVerdict]:
     """Scan the queue and process all pending requests.
+
+    Runs pre-flight health checks before processing to detect and recover
+    from common stall causes (detached HEAD, stale locks, expired auth).
+
+    Args:
+        queue_dir: Override for queue root directory.
+        dry_run: Skip actual review invocation.
+        events_dir: Override for events directory.
+        skip_preflight: Skip pre-flight health checks (for testing).
 
     Returns:
         List of verdicts written during this cycle.
     """
+    if not skip_preflight:
+        checks = preflight_health_check(skip_auth=dry_run)
+        failed = [c for c in checks if not c[1]]
+        if failed:
+            logger.warning(
+                "Pre-flight check(s) failed: %s",
+                "; ".join(f"{name}: {msg}" for name, _, msg in failed),
+            )
+            # Non-fatal: log and proceed. The individual check handlers
+            # already attempted recovery where possible.
+
     pending = find_pending_requests(queue_dir)
     if not pending:
         logger.debug("No pending review requests found")
@@ -563,7 +828,8 @@ def run_loop(
 ) -> None:
     """Run the review lane in a polling loop.
 
-    Processes pending requests each cycle, then sleeps.
+    Runs pre-flight health checks on the first cycle, then processes
+    pending requests each cycle with a sleep between cycles.
     Exits after ``max_cycles`` iterations or when interrupted.
     """
     logger.info(
@@ -571,9 +837,16 @@ def run_loop(
         max_cycles,
         poll_interval,
     )
+
     for cycle in range(1, max_cycles + 1):
         logger.debug("Poll cycle %d/%d", cycle, max_cycles)
-        verdicts = run_once(queue_dir, dry_run=dry_run, events_dir=events_dir)
+        # Pre-flight on first cycle only (worktree refresh, lock cleanup, auth)
+        verdicts = run_once(
+            queue_dir,
+            dry_run=dry_run,
+            events_dir=events_dir,
+            skip_preflight=(cycle > 1),
+        )
         if verdicts:
             logger.info(
                 "Cycle %d: processed %d request(s) — %s",

--- a/src/bid_euchre/ops/recovery.py
+++ b/src/bid_euchre/ops/recovery.py
@@ -108,6 +108,37 @@ RECOVERY_TEMPLATES: dict[str, RecoveryTemplate] = {
         ],
         auto_remediable=False,
     ),
+    "auth_failure": RecoveryTemplate(
+        name="Auth Failure",
+        description="Codex CLI or review tool authentication expired or invalid",
+        steps=[
+            "Run `codex login status` to check current auth state",
+            "If expired, run `codex login` interactively to refresh tokens",
+            "Verify with `codex login status` after re-authentication",
+            "Re-trigger the review: `python scripts/internal/review_driver.py "
+            "--pr <N> --trigger manual`",
+        ],
+        auto_remediable=False,
+    ),
+    "review_lane_stall": RecoveryTemplate(
+        name="Review Lane Stall",
+        description="The review lane agent is stuck (detached HEAD, stale lock, "
+        "or permission prompt)",
+        steps=[
+            "Check review lane worktree state: "
+            "`git -C ../Bid-Euchre-steward-review status`",
+            "If detached HEAD: "
+            "`git -C ../Bid-Euchre-steward-review checkout main && "
+            "git -C ../Bid-Euchre-steward-review pull`",
+            "Remove stale lock files: "
+            "`rm -f ../Bid-Euchre-steward-review/.claude/scheduled_tasks.lock`",
+            "Clear the review lane session: "
+            "`tmux send-keys -t steward:review '/clear' Enter`",
+            "Re-nudge the review lane or restart the runner: "
+            "`python scripts/internal/review_lane_runner.py --once`",
+        ],
+        auto_remediable=True,
+    ),
 }
 
 # Map event types to failure severity defaults
@@ -118,6 +149,8 @@ _SEVERITY_MAP: dict[str, str] = {
     "heartbeat_stale": "critical",
     "worktree_quarantined": "warning",
     "escalation": "critical",
+    "auth_failure": "warning",
+    "review_lane_stall": "warning",
 }
 
 # Event types that represent active failures needing attention
@@ -129,6 +162,8 @@ _FAILURE_EVENT_TYPES = frozenset(
         "heartbeat_stale",
         "worktree_quarantined",
         "escalation",
+        "auth_failure",
+        "review_lane_stall",
     }
 )
 
@@ -140,6 +175,8 @@ _RESOLUTION_MAP: dict[str, frozenset[str]] = {
     "heartbeat_ok": frozenset({"heartbeat_stale"}),
     "worktree_archived": frozenset({"worktree_quarantined"}),
     "recovery_action": frozenset({"escalation"}),
+    "auth_recovered": frozenset({"auth_failure"}),
+    "review_lane_recovered": frozenset({"review_lane_stall"}),
 }
 
 

--- a/tests/unit/test_ops_recovery.py
+++ b/tests/unit/test_ops_recovery.py
@@ -49,6 +49,8 @@ class TestRecoveryTemplates:
             "heartbeat_stale",
             "worktree_quarantined",
             "escalation",
+            "auth_failure",
+            "review_lane_stall",
         }
         assert expected == set(RECOVERY_TEMPLATES.keys())
 

--- a/tests/unit/test_review_driver.py
+++ b/tests/unit/test_review_driver.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "intern
 
 from review_driver import (
     _create_follow_up_issues,
+    _ensure_branch_checkout,
     _format_review_comment,
     _parse_plan_files,
     _should_timeout,
@@ -1675,3 +1676,71 @@ class TestAuthFailureEarlyTermination:
         assert (
             result.current_state != ReviewState.STOPPED_REVIEW_FAILURE
         ), "Normal errors with budget remaining should not stop"
+
+
+# ---------------------------------------------------------------------------
+# _ensure_branch_checkout (#2075)
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureBranchCheckout:
+    """Tests for _ensure_branch_checkout()."""
+
+    @patch("review_driver.subprocess.run")
+    def test_already_on_correct_branch(self, mock_run: MagicMock) -> None:
+        """Returns True immediately when already on the target branch."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="feat/foo\n")
+        result = _ensure_branch_checkout("feat/foo")
+        assert result is True
+        # Only one call (symbolic-ref check)
+        assert mock_run.call_count == 1
+
+    @patch("review_driver.subprocess.run")
+    def test_detached_head_recovery(self, mock_run: MagicMock) -> None:
+        """Detached HEAD triggers fetch + checkout of target branch."""
+        mock_run.side_effect = [
+            # symbolic-ref → detached HEAD
+            MagicMock(returncode=128, stdout="", stderr="fatal"),
+            # fetch origin branch
+            MagicMock(returncode=0),
+            # checkout branch
+            MagicMock(returncode=0),
+        ]
+        result = _ensure_branch_checkout("fix/review-stall")
+        assert result is True
+        assert mock_run.call_count == 3
+
+    @patch("review_driver.subprocess.run")
+    def test_checkout_failure(self, mock_run: MagicMock) -> None:
+        """Returns False when checkout fails."""
+        mock_run.side_effect = [
+            # symbolic-ref → detached HEAD
+            MagicMock(returncode=128, stdout="", stderr="fatal"),
+            # fetch
+            MagicMock(returncode=0),
+            # checkout → fail
+            MagicMock(returncode=1, stderr="error"),
+        ]
+        result = _ensure_branch_checkout("nonexistent-branch")
+        assert result is False
+
+    @patch("review_driver.subprocess.run")
+    def test_wrong_branch_switches(self, mock_run: MagicMock) -> None:
+        """When on a different branch, checks out the target."""
+        mock_run.side_effect = [
+            # symbolic-ref → on "main"
+            MagicMock(returncode=0, stdout="main\n"),
+            # fetch
+            MagicMock(returncode=0),
+            # checkout
+            MagicMock(returncode=0),
+        ]
+        result = _ensure_branch_checkout("feat/new-feature")
+        assert result is True
+
+    @patch("review_driver.subprocess.run")
+    def test_exception_returns_false(self, mock_run: MagicMock) -> None:
+        """Unexpected exceptions return False (non-fatal)."""
+        mock_run.side_effect = OSError("git not found")
+        result = _ensure_branch_checkout("main")
+        assert result is False

--- a/tests/unit/test_review_lane_runner.py
+++ b/tests/unit/test_review_lane_runner.py
@@ -17,9 +17,12 @@ if str(_SCRIPTS_DIR) not in sys.path:
 # Import the runner under test (after path setup)
 from review_lane_runner import (
     LANE_ID,
+    _check_worktree_health,
+    _cleanup_stale_locks,
     _parse_review_output,
     _write_error_verdict,
     find_pending_requests,
+    preflight_health_check,
     process_request,
     run_once,
 )
@@ -607,3 +610,194 @@ class TestStuckRunningReclaim:
 
         pending = find_pending_requests(tmp_path)
         assert len(pending) == 0
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight health checks (#2075)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckWorktreeHealth:
+    """Tests for _check_worktree_health()."""
+
+    @patch("review_lane_runner.subprocess.run")
+    def test_healthy_worktree_on_branch(
+        self, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        """Normal branch (not detached) with no commits behind."""
+        mock_run.side_effect = [
+            # symbolic-ref → on a branch
+            MagicMock(returncode=0, stdout="main\n"),
+            # fetch origin main
+            MagicMock(returncode=0),
+            # rev-list count behind
+            MagicMock(returncode=0, stdout="0\n"),
+        ]
+        healthy, msg = _check_worktree_health(tmp_path)
+        assert healthy is True
+        assert "healthy" in msg.lower() or "up to date" in msg.lower()
+
+    @patch("review_lane_runner.subprocess.run")
+    def test_detached_head_recovers(self, mock_run: MagicMock, tmp_path: Path) -> None:
+        """Detached HEAD with successful checkout main recovery."""
+        mock_run.side_effect = [
+            # symbolic-ref → detached HEAD
+            MagicMock(
+                returncode=128,
+                stdout="",
+                stderr="fatal: ref HEAD is not a symbolic ref",
+            ),
+            # checkout main → success
+            MagicMock(returncode=0),
+            # fetch origin main
+            MagicMock(returncode=0),
+            # rev-list count
+            MagicMock(returncode=0, stdout="0\n"),
+        ]
+        healthy, msg = _check_worktree_health(tmp_path)
+        assert healthy is True
+
+    @patch("review_lane_runner.subprocess.run")
+    def test_detached_head_checkout_fails(
+        self, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        """Detached HEAD with failed checkout reports unhealthy."""
+        mock_run.side_effect = [
+            # symbolic-ref → detached HEAD
+            MagicMock(returncode=128, stdout="", stderr="fatal"),
+            # checkout main → fail
+            MagicMock(returncode=1, stderr="error: pathspec 'main' not found"),
+        ]
+        healthy, msg = _check_worktree_health(tmp_path)
+        assert healthy is False
+        assert "detached" in msg.lower() or "checkout" in msg.lower()
+
+    @patch("review_lane_runner.subprocess.run")
+    def test_behind_main_pulls(self, mock_run: MagicMock, tmp_path: Path) -> None:
+        """Worktree behind main triggers a pull."""
+        mock_run.side_effect = [
+            # symbolic-ref
+            MagicMock(returncode=0, stdout="main\n"),
+            # fetch
+            MagicMock(returncode=0),
+            # rev-list count → 5 behind
+            MagicMock(returncode=0, stdout="5\n"),
+            # pull --ff-only → success
+            MagicMock(returncode=0),
+        ]
+        healthy, msg = _check_worktree_health(tmp_path)
+        assert healthy is True
+
+
+class TestCleanupStaleLocks:
+    """Tests for _cleanup_stale_locks()."""
+
+    def test_no_lock_files(self, tmp_path: Path) -> None:
+        removed = _cleanup_stale_locks(tmp_path)
+        assert removed == 0
+
+    def test_stale_lock_removed(self, tmp_path: Path) -> None:
+        """Lock file older than threshold is removed."""
+        import os
+
+        lock_dir = tmp_path / ".claude"
+        lock_dir.mkdir()
+        lock_path = lock_dir / "scheduled_tasks.lock"
+        lock_path.touch()
+        # Age the file to be clearly stale
+        old_time = os.path.getmtime(str(lock_path)) - 600
+        os.utime(str(lock_path), (old_time, old_time))
+
+        removed = _cleanup_stale_locks(tmp_path)
+        assert removed == 1
+        assert not lock_path.exists()
+
+    def test_fresh_lock_kept(self, tmp_path: Path) -> None:
+        """Lock file newer than threshold is preserved."""
+        lock_dir = tmp_path / ".claude"
+        lock_dir.mkdir()
+        lock_path = lock_dir / "scheduled_tasks.lock"
+        lock_path.touch()
+        # File is just created — should be fresh
+
+        removed = _cleanup_stale_locks(tmp_path)
+        assert removed == 0
+        assert lock_path.exists()
+
+
+class TestPreflightHealthCheck:
+    """Tests for preflight_health_check()."""
+
+    @patch("review_lane_runner._check_codex_auth")
+    @patch("review_lane_runner._check_worktree_health")
+    def test_all_checks_pass(
+        self,
+        mock_wt: MagicMock,
+        mock_auth: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        mock_wt.return_value = (True, "Worktree healthy and up to date")
+        mock_auth.return_value = (True, "Logged in")
+
+        results = preflight_health_check(tmp_path)
+        assert len(results) == 3  # worktree, locks, auth
+        assert all(passed for _, passed, _ in results)
+
+    @patch("review_lane_runner._check_codex_auth")
+    @patch("review_lane_runner._check_worktree_health")
+    def test_auth_failure_is_non_fatal(
+        self,
+        mock_wt: MagicMock,
+        mock_auth: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Auth failure is logged but doesn't block processing."""
+        mock_wt.return_value = (True, "OK")
+        mock_auth.return_value = (False, "Not logged in")
+
+        results = preflight_health_check(tmp_path)
+        auth_results = [r for r in results if r[0] == "codex_auth"]
+        assert len(auth_results) == 1
+        assert auth_results[0][1] is False
+
+    @patch("review_lane_runner._check_worktree_health")
+    def test_skip_auth(
+        self,
+        mock_wt: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """skip_auth=True omits the Codex auth check."""
+        mock_wt.return_value = (True, "OK")
+
+        results = preflight_health_check(tmp_path, skip_auth=True)
+        check_names = {name for name, _, _ in results}
+        assert "codex_auth" not in check_names
+
+
+class TestRunOnceWithPreflight:
+    """Verify run_once integrates pre-flight checks."""
+
+    @patch("review_lane_runner.preflight_health_check")
+    def test_run_once_calls_preflight(
+        self,
+        mock_preflight: MagicMock,
+        queue_dir: Path,
+    ) -> None:
+        """run_once calls preflight_health_check by default."""
+        mock_preflight.return_value = [
+            ("worktree_health", True, "OK"),
+            ("lock_cleanup", True, "0 locks"),
+            ("codex_auth", True, "OK"),
+        ]
+        run_once(queue_dir, dry_run=True)
+        mock_preflight.assert_called_once()
+
+    @patch("review_lane_runner.preflight_health_check")
+    def test_run_once_skips_preflight(
+        self,
+        mock_preflight: MagicMock,
+        queue_dir: Path,
+    ) -> None:
+        """run_once with skip_preflight=True does not call preflight."""
+        run_once(queue_dir, dry_run=True, skip_preflight=True)
+        mock_preflight.assert_not_called()


### PR DESCRIPTION
## Summary
- Add systematic pre-flight health checks to `review_lane_runner.py` that detect and auto-recover from detached HEAD, stale lock files, and expired Codex CLI auth tokens
- Add `_ensure_branch_checkout()` to `review_driver.py` to verify correct branch before Codex CLI invocation
- Add `auth_failure` and `review_lane_stall` recovery templates to `recovery.py` with resolution mappings

## Why
The review lane repeatedly gets stuck on auth/permissions stalls requiring manual intervention (#2075). Root causes:
1. Worktree falls behind main or lands on detached HEAD after PR merges
2. Stale `.claude/scheduled_tasks.lock` files block clean operation
3. Codex CLI auth tokens expire between sessions with no pre-check
4. Review driver doesn't verify branch checkout before Codex invocation

## Changes

### `scripts/internal/review_lane_runner.py`
- `_check_worktree_health()`: Detects detached HEAD, attempts `checkout main`, syncs to `origin/main`
- `_cleanup_stale_locks()`: Removes lock files older than 5 minutes
- `_check_codex_auth()`: Pre-flight Codex CLI auth validation (reuses adapter or direct fallback)
- `preflight_health_check()`: Orchestrates all checks, returns structured results
- `run_once()` and `run_loop()`: Wire pre-flight checks (first cycle only in loop mode)

### `scripts/internal/review_driver.py`
- `_ensure_branch_checkout()`: Verifies working directory is on correct branch before Codex review, auto-recovers from detached HEAD

### `src/bid_euchre/ops/recovery.py`
- New `auth_failure` template: steps for Codex CLI re-authentication
- New `review_lane_stall` template: steps for worktree recovery, lock cleanup, session restart
- Updated severity map and resolution mappings (`auth_recovered`, `review_lane_recovered`)

## Repro / Validation

```bash
# All affected tests pass
uv run python -m pytest tests/unit/test_review_driver.py tests/unit/test_review_lane_runner.py tests/unit/test_ops_recovery.py -q

# 183 passed
```

## Tests
- 5 new tests for `_ensure_branch_checkout` (already on branch, detached HEAD recovery, checkout failure, wrong branch switch, exception handling)
- 4 new tests for `_check_worktree_health` (healthy, detached HEAD recovery, checkout failure, behind main)
- 2 new tests for `_cleanup_stale_locks` (stale lock removed, fresh lock kept)
- 4 new tests for `preflight_health_check` (all pass, auth failure non-fatal, skip_auth)
- 2 new tests for `run_once` preflight integration

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: fix/review-lane-auth-stalls
```

## Plan
N/A

Closes #2075

🤖 Generated with [Claude Code](https://claude.com/claude-code)