### PR TITLE
fix(web): use effective_suit for left bower lead suit display (#2158)

### DIFF
--- a/tests/e2e/hosted_play/conftest.py
+++ b/tests/e2e/hosted_play/conftest.py
@@ -23,7 +23,7 @@ from bid_euchre.hosted_play.state import MatchState
 from bid_euchre.strategy.base import Strategy
 from bid_euchre.strategy.bidding import BidAction, BiddingObservation, BiddingPolicy
 from web.routes import _build_seat_bids
-from web.template_filters import display_rank
+from web.template_filters import display_rank, effective_suit
 
 # ---------------------------------------------------------------------------
 # Deterministic AI stubs
@@ -108,6 +108,7 @@ def jinja_env() -> jinja2.Environment:
         undefined=jinja2.StrictUndefined,
     )
     environment.filters["display_rank"] = display_rank
+    environment.filters["effective_suit"] = effective_suit
     return environment
 
 

--- a/tests/unit/hosted_play/test_bid_outcome_matrix.py
+++ b/tests/unit/hosted_play/test_bid_outcome_matrix.py
@@ -22,7 +22,7 @@ import jinja2
 import pytest
 
 from bid_euchre.scoring import compute_points
-from web.template_filters import display_rank
+from web.template_filters import display_rank, effective_suit
 
 # ---------------------------------------------------------------------------
 # Template environment
@@ -47,6 +47,7 @@ def jinja_env():
         undefined=jinja2.StrictUndefined,
     )
     environment.filters["display_rank"] = display_rank
+    environment.filters["effective_suit"] = effective_suit
     return environment
 
 

--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -11,7 +11,7 @@ import os
 import jinja2
 import pytest
 
-from web.template_filters import display_rank
+from web.template_filters import display_rank, effective_suit
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -36,6 +36,7 @@ def env():
         undefined=jinja2.StrictUndefined,
     )
     environment.filters["display_rank"] = display_rank
+    environment.filters["effective_suit"] = effective_suit
     return environment
 
 
@@ -751,6 +752,84 @@ class TestTrick:
         )
         assert "lead-suit" in html
         assert "\u2665" in html  # ♥
+
+    def test_left_bower_lead_shows_trump_suit(self, env):
+        """Left bower lead displays trump suit, not printed suit (#2158).
+
+        When the left bower (J of same-color off-suit) leads in a suit
+        contract, the lead-suit indicator must show the trump suit.
+        Example: clubs contract, J♠ (left bower) led → shows ♣ not ♠.
+        """
+        tmpl = env.get_template("partials/trick.html")
+        # J♠ led in a clubs contract — left bower of clubs
+        html = tmpl.render(
+            current_trick={"leader": 0, "plays": [[0, ["S", "J"]]]},
+            completed_tricks=[],
+            dealer_seat=3,
+            bidder_seat=0,
+            current_seat=1,
+            sitting_out_seat=None,
+            tricks_team0=0,
+            tricks_team1=0,
+            contract_type="suit",
+            trump="C",
+        )
+        assert "lead-suit" in html
+        # ♣ (clubs) should appear, not ♠ (spades)
+        assert "\u2663" in html  # ♣
+        assert "lead-suit--clubs" in html
+        assert "lead-suit--spades" not in html
+
+    def test_right_bower_lead_shows_trump_suit(self, env):
+        """Right bower lead displays trump suit (trivial — printed suit matches)."""
+        tmpl = env.get_template("partials/trick.html")
+        # J♣ led in a clubs contract — right bower
+        html = tmpl.render(
+            current_trick={"leader": 0, "plays": [[0, ["C", "J"]]]},
+            completed_tricks=[],
+            dealer_seat=3,
+            bidder_seat=0,
+            current_seat=1,
+            sitting_out_seat=None,
+            tricks_team0=0,
+            tricks_team1=0,
+            contract_type="suit",
+            trump="C",
+        )
+        assert "lead-suit--clubs" in html
+
+    def test_non_bower_jack_lead_shows_printed_suit(self, env):
+        """Non-bower J lead shows its printed suit, not trump."""
+        tmpl = env.get_template("partials/trick.html")
+        # J♦ led in a clubs contract — not a bower (different color)
+        html = tmpl.render(
+            current_trick={"leader": 0, "plays": [[0, ["D", "J"]]]},
+            completed_tricks=[],
+            dealer_seat=3,
+            bidder_seat=0,
+            current_seat=1,
+            sitting_out_seat=None,
+            tricks_team0=0,
+            tricks_team1=0,
+            contract_type="suit",
+            trump="C",
+        )
+        assert "lead-suit--diamonds" in html
+
+    def test_lead_suit_no_contract_falls_back_to_printed(self, env):
+        """Without contract info, lead suit falls back to printed suit."""
+        tmpl = env.get_template("partials/trick.html")
+        html = tmpl.render(
+            current_trick={"leader": 0, "plays": [[0, ["S", "J"]]]},
+            completed_tricks=[],
+            dealer_seat=3,
+            bidder_seat=0,
+            current_seat=1,
+            sitting_out_seat=None,
+            tricks_team0=0,
+            tricks_team1=0,
+        )
+        assert "lead-suit--spades" in html
 
     def test_lead_suit_not_shown_when_no_plays(self, env):
         """Lead suit indicator not present when trick has no plays yet."""

--- a/tests/unit/hosted_play/test_scoring_matrix.py
+++ b/tests/unit/hosted_play/test_scoring_matrix.py
@@ -16,7 +16,7 @@ import jinja2
 import pytest
 
 from bid_euchre.scoring import compute_points
-from web.template_filters import display_rank
+from web.template_filters import display_rank, effective_suit
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -41,6 +41,7 @@ def env():
         undefined=jinja2.StrictUndefined,
     )
     environment.filters["display_rank"] = display_rank
+    environment.filters["effective_suit"] = effective_suit
     return environment
 
 

--- a/web/app.py
+++ b/web/app.py
@@ -37,7 +37,7 @@ from .db import (
     make_session_factory,
 )
 from .routes import router as game_router
-from .template_filters import display_rank
+from .template_filters import display_rank, effective_suit
 
 logger = logging.getLogger(__name__)
 
@@ -162,6 +162,8 @@ async def lifespan(app: FastAPI):
     templates.env.globals["app_url"] = config.app_url.rstrip("/")
     # Custom filter: display_rank converts internal 'T' to user-facing '10'
     templates.env.filters["display_rank"] = display_rank
+    # Custom filter: effective_suit resolves bower suits in suit contracts
+    templates.env.filters["effective_suit"] = effective_suit
 
     # 7. Stash on app.state for route access
     app.state.config = config

--- a/web/template_filters.py
+++ b/web/template_filters.py
@@ -6,6 +6,11 @@ and in test fixtures that render templates directly.
 
 from __future__ import annotations
 
+from typing import Optional
+
+from bid_euchre.core.cards import Card
+from bid_euchre.core.cards import effective_suit as _effective_suit
+
 
 def display_rank(rank: str) -> str:
     """Convert internal single-char rank to display string.
@@ -14,3 +19,25 @@ def display_rank(rank: str) -> str:
     All other ranks (``J``, ``Q``, ``K``, ``A``) pass through unchanged.
     """
     return "10" if rank == "T" else rank
+
+
+def effective_suit(
+    card: list[str],
+    trump: Optional[str] = None,
+    contract_type: Optional[str] = None,
+) -> str:
+    """Return the effective suit of a card given the current contract.
+
+    In suit contracts, bowers belong to the trump suit regardless of their
+    printed suit.  The left bower (J of the same-colour off-suit) is the
+    most visible case: e.g. J♠ in a clubs contract effectively belongs to
+    clubs.
+
+    Usage in Jinja2::
+
+        {{ card|effective_suit(trump, contract_type) }}
+
+    where *card* is a ``[suit, rank]`` list as stored in the play tuples.
+    """
+    suit, rank = card[0], card[1]
+    return _effective_suit(Card(suit, rank), trump, contract_type or "suit")

--- a/web/templates/partials/trick.html
+++ b/web/templates/partials/trick.html
@@ -82,7 +82,7 @@
         {{ display_heading }}
         {% if display_plays %}
             {% set lead_card = display_plays[0] %}
-            {% set lead_suit = lead_card[1][0] %}
+            {% set lead_suit = lead_card[1]|effective_suit(trump | default(None, true), contract_type | default(None, true)) %}
             <span class="lead-suit lead-suit--{{ suit_classes.get(lead_suit, 'spades') }}"
                   aria-label="Lead suit: {{ suit_names.get(lead_suit, lead_suit) }}">
                 {{ suit_symbols.get(lead_suit, lead_suit) }}


### PR DESCRIPTION
## Summary
- When the left bower is led in a suit contract, the trick header now shows the trump suit (effective suit) instead of the card's printed suit
- Adds `effective_suit` Jinja2 template filter wrapping `core.cards.effective_suit`
- Registers the filter in all template environments (app + test fixtures)

## Why
Fixes #2158 — cosmetic bug where leading with a left bower (e.g., J♠ in clubs contract) showed "Lead suit: Spades" instead of "Lead suit: Clubs". The legality enforcement was correct; only the display was wrong.

## Changes
| File | Change |
|------|--------|
| `web/template_filters.py` | New `effective_suit` filter wrapping `core.cards.effective_suit` |
| `web/app.py` | Register `effective_suit` filter on Jinja2 environment |
| `web/templates/partials/trick.html` | Use `effective_suit` filter for lead suit display (line 85) |
| `tests/unit/hosted_play/test_partials.py` | 4 new tests: left bower, right bower, non-bower J, no-contract fallback |
| `tests/*/conftest.py`, `test_*_matrix.py` | Register `effective_suit` filter in test Jinja2 environments |

## Repro / Validation
```bash
# Run targeted trick tests (all 14 pass including 4 new)
uv run python -m pytest tests/unit/hosted_play/test_partials.py::TestTrick -xvs

# Full hosted_play test suite (3307 pass)
uv run python -m pytest tests/unit/hosted_play/ -v

# Full validation
make check-quiet
# 3 pre-existing failures unrelated to this PR:
#   test_ops_token_economy.py (2), test_telegram_filter.py (1)
```

## Tests
- `test_left_bower_lead_shows_trump_suit` — J♠ led in clubs contract shows ♣ not ♠
- `test_right_bower_lead_shows_trump_suit` — J♣ led in clubs contract shows ♣
- `test_non_bower_jack_lead_shows_printed_suit` — J♦ led in clubs contract shows ♦ (not a bower)
- `test_lead_suit_no_contract_falls_back_to_printed` — Without contract info, shows printed suit

## Worktree proof
```
pwd: Bid-Euchre-steward-brws-author-b
branch: fix/left-bower-lead-suit-display
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)