### PR TITLE
fix(web): replace ambiguous ±52 wording with clear win/loss language (#2177)

### DIFF
--- a/web/templates/guide.html
+++ b/web/templates/guide.html
@@ -228,7 +228,7 @@
         <div class="guide__tip"><strong>Support your partner.</strong> If your partner is winning the trick, play your lowest card to conserve.</div>
         <div class="guide__tip"><strong>Low contracts flip the ranks.</strong> Tens are high and Aces are low &mdash; adjust your play accordingly.</div>
         <div class="guide__tip"><strong>Don&rsquo;t overbid.</strong> Getting set costs you your entire bid as negative points.</div>
-        <div class="guide__tip"><strong>Watch the score bar.</strong> If you&rsquo;re close to &plusmn;52, bid conservatively.</div>
+        <div class="guide__tip"><strong>Watch the score bar.</strong> If either team is close to 52 (or &minus;52), bid conservatively.</div>
     </div>
 
     {# ---- Basic Strategies ---- #}

--- a/web/templates/partials/model_select.html
+++ b/web/templates/partials/model_select.html
@@ -8,7 +8,7 @@
 <div id="model-select" role="region" aria-label="Choose AI opponent">
     <h2>Welcome, {{ nickname }}!</h2>
     <p>Choose your AI opponent:</p>
-    <p class="match-target">First to &plusmn;52 wins</p>
+    <p class="match-target">First to 52 wins &middot; &minus;52 = loss</p>
     <form method="post"
           action="/play/{{ link_uuid }}/select-ai"
           hx-post="/play/{{ link_uuid }}/select-ai"
@@ -41,7 +41,7 @@
         <p>&#x1F0A1; You and your AI partner vs two AI opponents.</p>
         <p>&#x270B; Bid how many tricks your team can win, or pass.</p>
         <p>&#x1F3B4; Play cards by clicking them &mdash; <strong>green border</strong> = legal plays.</p>
-        <p>&#x1F3C6; First team to &plusmn;52 points wins the match.</p>
+        <p>&#x1F3C6; First team to 52 points wins. Reaching &minus;52 means you lose!</p>
         <p class="quick-start-guide__link">
             <a href="/guide/{{ link_uuid }}">Read the full guide &rarr;</a>
         </p>

--- a/web/templates/partials/score.html
+++ b/web/templates/partials/score.html
@@ -66,7 +66,7 @@
     </div>
     {% endif %}
 
-    <div class="match-target" aria-label="First team to plus or minus 52 points wins">
-        First to &plusmn;52 wins
+    <div class="match-target" aria-label="First team to 52 points wins. Reaching minus 52 means you lose.">
+        First to 52 wins &middot; &minus;52 = loss
     </div>
 </div>


### PR DESCRIPTION
## Summary

- Replace "First to ±52 wins" with "First to 52 wins · −52 = loss" in score bar and model select screen
- Update guide tip to say "close to 52 (or −52)" instead of "close to ±52"
- `game_controls.html` help drawer already had correct wording (from #2161) — no change needed

## Why

The ±52 notation confuses new players who don't understand what the ± means
in context. The new wording clearly distinguishes winning (reaching 52 points)
from losing (dropping to −52 points), matching the corrected help drawer copy
from PR #2161.

## Files Changed

| File | Change |
|------|--------|
| `web/templates/partials/score.html` | Score bar text + aria-label |
| `web/templates/partials/model_select.html` | Match target line + quick start guide |
| `web/templates/guide.html` | Tips & Tricks section |

## Repro / Validation

```bash
# Tier 1 — hosted_play tests (3303 passed)
uv run python -m pytest tests/unit/hosted_play/ -v

# Tier 2 — make check (3 pre-existing failures in unrelated ops tests)
make check-quiet

# Verify no stale ±52 wording in web templates
grep -r 'plusmn;52' web/templates/
# Should return 0 results
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

Closes #2177

🤖 Generated with [Claude Code](https://claude.com/claude-code)