### PR TITLE
fix(web): add HTMX timeout + retry to card play form (#2157)

### DIFF
--- a/tests/unit/hosted_play/test_error_handling.py
+++ b/tests/unit/hosted_play/test_error_handling.py
@@ -265,6 +265,25 @@ class TestGameJSErrorHandling:
         assert "showOfflineBanner" in content
         assert "hideOfflineBanner" in content
 
+    def test_game_js_has_card_play_retry(self):
+        """game.js contains card-play timeout retry functions."""
+        from pathlib import Path
+
+        js_path = (
+            Path(__file__).resolve().parent.parent.parent.parent
+            / "web"
+            / "static"
+            / "game.js"
+        )
+        content = js_path.read_text()
+        assert "isCardPlayRequest" in content
+        assert "setCardPlayInFlight" in content
+        assert "resetCardPlayForm" in content
+        assert "card-play-form--in-flight" in content
+        assert "htmx:beforeRequest" in content
+        assert "htmx:afterRequest" in content
+        assert "Tap Play card to retry." in content
+
     def test_game_js_has_online_offline_handlers(self):
         """game.js registers online/offline event listeners."""
         from pathlib import Path

--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -532,6 +532,18 @@ class TestHand:
         assert 'name="card_index" value=""' in html
         assert "card--legal" in html
 
+    def test_card_play_form_has_timeout(self, env):
+        """Card play form has hx-timeout for retry on stalled requests."""
+        tmpl = env.get_template("partials/hand.html")
+        html = tmpl.render(
+            link_uuid="abc-123",
+            turn_number=8,
+            human_hand=[["S", "A"], ["H", "K"]],
+            legal_plays=[0, 1],
+            phase="trick_play",
+        )
+        assert 'hx-timeout="10000"' in html
+
     def test_illegal_cards_are_divs(self, env):
         """During trick play, illegal cards are plain divs."""
         tmpl = env.get_template("partials/hand.html")

--- a/web/static/game.js
+++ b/web/static/game.js
@@ -96,7 +96,7 @@
 
         var help = form.querySelector('#card-play-help');
         if (help !== null) {
-            help.textContent = 'Playing card...';
+            help.textContent = 'Playing card\u2026';
         }
     }
 
@@ -349,7 +349,81 @@
         }
     }
 
+    /* ---------------------------------------------------------------
+     * Card-play request lifecycle — manage in-flight state and
+     * recovery so that stalled requests don't leave the player stuck.
+     * --------------------------------------------------------------- */
+
+    function isCardPlayRequest(event) {
+        var elt = event.detail && event.detail.elt;
+        return elt && (elt.id === 'card-play-form' || (elt.closest && elt.closest('#card-play-form')));
+    }
+
+    function setCardPlayInFlight(form) {
+        if (!(form instanceof HTMLFormElement)) {
+            return;
+        }
+        form.classList.add('card-play-form--in-flight');
+
+        var submitButton = form.querySelector('#card-play-submit');
+        if (submitButton) {
+            submitButton.disabled = true;
+            submitButton.textContent = 'Playing card\u2026';
+        }
+
+        var help = form.querySelector('#card-play-help');
+        if (help) {
+            help.textContent = 'Playing card\u2026';
+        }
+    }
+
+    function resetCardPlayForm() {
+        var form = getCardPlayForm();
+        if (!(form instanceof HTMLFormElement)) {
+            return;
+        }
+        form.classList.remove('card-play-form--in-flight');
+
+        var submitButton = form.querySelector('#card-play-submit');
+        if (submitButton) {
+            submitButton.textContent = 'Play card';
+        }
+
+        // Re-enable the button if a card is still selected
+        var input = getSelectedCardInput(form);
+        var hasSelection = input !== null && input.value !== '';
+        if (submitButton) {
+            submitButton.disabled = !hasSelection;
+        }
+
+        var help = form.querySelector('#card-play-help');
+        if (help) {
+            help.textContent = hasSelection
+                ? 'Tap Play card to retry.'
+                : 'Tap a card to play it.';
+        }
+    }
+
     function attachErrorHandlers() {
+        // Card-play request starts — lock the form UI
+        document.body.addEventListener('htmx:beforeRequest', function (event) {
+            if (isCardPlayRequest(event)) {
+                setCardPlayInFlight(getCardPlayForm());
+            }
+        });
+
+        // Card-play request completed (any status) — reset form if error
+        document.body.addEventListener('htmx:afterRequest', function (event) {
+            if (!isCardPlayRequest(event)) {
+                return;
+            }
+            // On success the board swaps (htmx:afterSwap handles cleanup).
+            // On failure, reset the form so the player can retry.
+            if (event.detail.failed || event.detail.successful === false) {
+                resetCardPlayForm();
+            }
+        });
+
         // HTMX response errors (server returned 4xx/5xx)
         document.body.addEventListener('htmx:responseError', function (event) {
             var status = event.detail.xhr ? event.detail.xhr.status : 0;
@@ -373,7 +447,10 @@
         });
 
         // HTMX send errors (network failure, DNS, CORS, etc.)
-        document.body.addEventListener('htmx:sendError', function () {
+        document.body.addEventListener('htmx:sendError', function (event) {
+            if (isCardPlayRequest(event)) {
+                resetCardPlayForm();
+            }
             if (!navigator.onLine) {
                 showOfflineBanner();
             } else {
@@ -381,8 +458,11 @@
             }
         });
 
-        // HTMX timeout
-        document.body.addEventListener('htmx:timeout', function () {
+        // HTMX timeout — reset card-play form for retry
+        document.body.addEventListener('htmx:timeout', function (event) {
+            if (isCardPlayRequest(event)) {
+                resetCardPlayForm();
+            }
             showErrorToast('Request timed out. Please try again.', false);
         });
 

--- a/web/templates/partials/hand.html
+++ b/web/templates/partials/hand.html
@@ -52,7 +52,8 @@
               action="/play/{{ link_uuid }}/play-card"
               hx-post="/play/{{ link_uuid }}/play-card"
               hx-target="#game-board"
-              hx-swap="morph:innerHTML">
+              hx-swap="morph:innerHTML"
+              hx-timeout="10000">
             <input type="hidden" name="turn_number" value="{{ turn_number }}">
             <input type="hidden" id="selected-card-index" name="card_index" value="">
             <button id="card-play-submit"


### PR DESCRIPTION
## Plan
N/A — bug fix from issue #2157

## Summary
- Add `hx-timeout="10000"` (10s) to the card-play form in `hand.html`
- Add card-play request lifecycle handlers (`htmx:beforeRequest`, `htmx:afterRequest`) that manage in-flight UI state
- Reset card-play form to retryable state on timeout, send error, or failed response — user sees "Tap Play card to retry" instead of permanent spinner

## Why
On Render free tier, card play POST requests occasionally stall (~1 in 20). Without a timeout, the user is stuck with "Playing card…" and must manually refresh the page to recover. This adds a 10-second timeout with automatic form recovery.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/ -v
uv run python -m pytest tests/e2e/ -v
```

**Config (if applicable):** N/A

**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** Card play form includes `hx-timeout="10000"` and game.js includes retry recovery functions
- **Verification command:** `grep 'hx-timeout' web/templates/partials/hand.html && grep 'resetCardPlayForm' web/static/game.js`
- **Expected result:** Both commands return matching lines

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/ -v` — 3305 passed
- [x] `uv run python -m pytest tests/e2e/ -v` — 19 passed
- [x] `make check` — 10959 passed (3 pre-existing failures in unrelated ops modules)

## Expected impact
- Metrics impact: None
- Runtime impact: None (client-side JS only)

## Risk level
- [x] Low (UI/UX improvement only)

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)