### PR TITLE
feat(web): enhance current high play indicator during trick play (#2178)

### DIFF
--- a/tests/e2e/hosted_play/conftest.py
+++ b/tests/e2e/hosted_play/conftest.py
@@ -14,7 +14,7 @@ import jinja2
 import pytest
 
 from bid_euchre.core.cards import Card
-from bid_euchre.core.rules import get_legal_indices
+from bid_euchre.core.rules import get_legal_indices, trick_winner
 from bid_euchre.hosted_play.engine import (
     HUMAN_SEAT,
     MatchEngine,
@@ -250,6 +250,19 @@ def build_visible_context(
         else:
             ctx["legal_plays"] = None
 
+        # Compute trick_winning_seat (mirrors routes.py logic)
+        trick = hand.current_trick if hand.current_trick is not None else None
+        if (
+            trick is not None
+            and len(trick.plays) >= 1
+            and hand.contract_type is not None
+        ):
+            ctx["trick_winning_seat"] = trick_winner(
+                trick.plays, hand.contract_type, hand.trump
+            )
+        else:
+            ctx["trick_winning_seat"] = None
+
         ctx["opp_left_count"] = len(hand.hands[1]) if len(hand.hands) > 1 else 0
         ctx["partner_count"] = len(hand.hands[2]) if len(hand.hands) > 2 else 0
         ctx["opp_right_count"] = len(hand.hands[3]) if len(hand.hands) > 3 else 0
@@ -264,6 +277,7 @@ def build_visible_context(
         ctx["points_team0"] = 0
         ctx["points_team1"] = 0
         ctx["legal_plays"] = None
+        ctx["trick_winning_seat"] = None
         ctx["opp_left_count"] = 0
         ctx["partner_count"] = 0
         ctx["opp_right_count"] = 0

--- a/tests/e2e/hosted_play/test_smoke_placeholder.py
+++ b/tests/e2e/hosted_play/test_smoke_placeholder.py
@@ -673,3 +673,124 @@ class TestCrossFeatureIntegration:
         assert "result-table" in html, "Expected scoring table"
         assert "result-match-score" in html, "Expected match score display"
         assert "Next Hand" in html, "Expected 'Next Hand' button"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Current high play indicator
+# ---------------------------------------------------------------------------
+
+
+class TestCurrentHighPlayIndicator:
+    """Verify card--winning class and trick-current-winner text render mid-trick.
+
+    The engine auto-advances AI after human plays, which may complete the
+    trick.  To test mid-trick rendering we look for states where AIs have
+    already played (AI-led trick) before the human's turn — giving us an
+    active trick with plays but not yet complete.  If the human leads,
+    we play the human card first to establish a lead, then check whether
+    the trick still has plays (it may auto-complete via AI).
+    """
+
+    @staticmethod
+    def _get_mid_trick_ctx(
+        engine: MatchEngine,
+    ) -> dict | None:
+        """Try multiple tricks to find a mid-trick state with plays.
+
+        Returns a (ctx, state) tuple or None if no mid-trick found.
+        """
+        state = engine.start_match(SEED, "test")
+        state = advance_to_trick_play(engine, state)
+
+        # Try up to 10 tricks to find a mid-trick state
+        for _ in range(10):
+            hand = state.current_hand
+            if hand is None or hand.phase != "trick_play":
+                return None
+
+            trick = hand.current_trick
+            if trick is not None and len(trick.plays) >= 1:
+                # AI has already played — we have mid-trick state
+                return build_visible_context(engine, state)
+
+            # Human is the leader with 0 plays — play our card
+            if hand.current_seat == HUMAN_SEAT:
+                legal = engine.get_legal_plays(state)
+                state = engine.submit_human_card(state, legal[0])
+
+                hand = state.current_hand
+                if hand is None:
+                    return None
+
+                # Check if we now have a mid-trick (human played but
+                # AI hasn't finished the trick yet)
+                trick = hand.current_trick
+                if trick is not None and len(trick.plays) >= 1:
+                    return build_visible_context(engine, state)
+
+                # Trick completed — try next trick
+                continue
+
+        return None
+
+    @pytest.mark.e2e
+    def test_winning_card_highlight_mid_trick(
+        self, engine: MatchEngine, jinja_env: jinja2.Environment
+    ) -> None:
+        """card--winning class appears on the currently winning card during active trick."""
+        ctx = self._get_mid_trick_ctx(engine)
+        if ctx is None:
+            pytest.skip("Could not reach mid-trick state with this seed")
+
+        tmpl = jinja_env.get_template("partials/trick.html")
+        html = tmpl.render(**ctx)
+
+        assert (
+            "card--winning" in html
+        ), "Expected card--winning class on the currently winning card"
+
+    @pytest.mark.e2e
+    def test_winning_text_label_mid_trick(
+        self, engine: MatchEngine, jinja_env: jinja2.Environment
+    ) -> None:
+        """trick-current-winner text appears during active trick."""
+        ctx = self._get_mid_trick_ctx(engine)
+        if ctx is None:
+            pytest.skip("Could not reach mid-trick state with this seed")
+
+        tmpl = jinja_env.get_template("partials/trick.html")
+        html = tmpl.render(**ctx)
+
+        assert (
+            "trick-current-winner" in html
+        ), "Expected trick-current-winner element in trick HTML"
+        assert (
+            "is winning" in html
+        ), "Expected 'is winning' text in current high play indicator"
+
+    @pytest.mark.e2e
+    def test_no_winning_indicator_on_completed_trick(
+        self, engine: MatchEngine, jinja_env: jinja2.Environment
+    ) -> None:
+        """Winning indicator does not appear on completed tricks."""
+        state = engine.start_match(SEED, "test")
+        state = advance_to_trick_play(engine, state)
+
+        hand = state.current_hand
+        if hand is None or hand.phase != "trick_play":
+            pytest.skip("Seed produced no trick play")
+
+        # Complete one trick
+        state = play_one_trick(engine, state)
+
+        ctx = build_visible_context(engine, state)
+
+        # Render with current_trick=None (showing completed trick)
+        render_ctx = dict(ctx)
+        render_ctx["current_trick"] = None
+        tmpl = jinja_env.get_template("partials/trick.html")
+        html = tmpl.render(**render_ctx)
+
+        assert (
+            "trick-current-winner" not in html
+        ), "trick-current-winner should not appear on completed tricks"

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -242,8 +242,19 @@ main {
 
 /* Highlight the currently winning card in an active trick */
 .card--winning {
-    box-shadow: 0 0 8px 2px rgba(255, 215, 0, 0.7);
-    border-color: #ffd700;
+    box-shadow: 0 0 10px 3px rgba(255, 215, 0, 0.8);
+    border: 2px solid #ffd700;
+    animation: winning-card-pulse 2s ease-in-out infinite;
+}
+
+/* "X is winning" text below the trick center during active tricks */
+.trick-current-winner {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: #ffd700;
+    text-align: center;
+    margin: 0.25rem 0 0;
+    opacity: 0.9;
 }
 
 /* --------------------------------------------------------------------------
@@ -2513,6 +2524,11 @@ main {
     50% { box-shadow: 0 0 15px rgba(76, 175, 80, 0.8); }
 }
 
+@keyframes winning-card-pulse {
+    0%, 100% { box-shadow: 0 0 8px 2px rgba(255, 215, 0, 0.5); }
+    50% { box-shadow: 0 0 14px 4px rgba(255, 215, 0, 0.9); }
+}
+
 .hand-result--animated {
     animation: banner-slide-in 0.4s ease-out;
 }
@@ -2755,6 +2771,10 @@ main {
     }
 
     .trick-slot--winner .card {
+        animation: none;
+    }
+
+    .card--winning {
         animation: none;
     }
 }

--- a/web/templates/partials/trick.html
+++ b/web/templates/partials/trick.html
@@ -116,6 +116,11 @@
             {{ card_slot(0) }}
         </div>
     </div>
+    {% if current_trick and trick_winning_seat is defined and trick_winning_seat is not none %}
+        <p class="trick-current-winner" aria-live="polite">
+            {% if trick_winning_seat == 0 %}You are{% else %}{{ seat_labels[trick_winning_seat] }} is{% endif %} winning
+        </p>
+    {% endif %}
     {% if display_winner is not none %}
         {% set winning_card = None %}
         {% if completed_tricks %}


### PR DESCRIPTION
## Plan
Analyst report: `plans/sessions/2026-04-03_current-high-play-indicator.md` (analyst lane)

## Summary
- Strengthen the gold highlight on the currently winning card (brighter glow + pulse animation)
- Add "X is winning" text label below the trick center during active tricks
- Wire `trick_winning_seat` into test conftest and add 3 E2E tests

## Why
The existing `.card--winning` style was too subtle — just a faint gold box-shadow on a small card. Players (especially new ones) couldn't easily tell which card was currently winning the trick. This enhances visibility with a stronger glow, pulse animation, and explicit text label.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/e2e/hosted_play/ -v
make check-quiet
```

**Config (if applicable):** N/A
**Seed (if applicable):** 42 (used in E2E tests)

## Test Criteria
- **Pass condition:** `card--winning` class renders on the currently winning card mid-trick, `trick-current-winner` text appears with seat label, neither appears on completed tricks
- **Verification command:** `uv run python -m pytest tests/e2e/hosted_play/test_smoke_placeholder.py::TestCurrentHighPlayIndicator -v`
- **Expected result:** 3 tests pass (highlight, text label, no-indicator-on-completed)

## Tests
- [x] `uv run python -m pytest tests/e2e/hosted_play/ -v` — 22 passed, 2 skipped
- [x] `make check-quiet` — 10966 passed (3 pre-existing failures in ops domain, unrelated)
- [x] Other: 3 new tests in `TestCurrentHighPlayIndicator`

## Expected impact
- Metrics impact: None (CSS/template only)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git worktree list`:
```
Bid-Euchre-steward-brws-author-a   4ff80728 [feat/high-play-indicator-2178]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)