### PR TITLE
fix(web): abbreviate leaderboard column headers with glossary (#2187)

### DIFF
--- a/tests/unit/hosted_play/test_leaderboard.py
+++ b/tests/unit/hosted_play/test_leaderboard.py
@@ -941,7 +941,7 @@ class TestLeaderboardRoute:
             resp = client.get(f"/leaderboard/{player.link_uuid}")
             assert resp.status_code == 200
             assert "RankedPlayer" in resp.text
-            assert "Net EPPD" in resp.text
+            assert "EPPD" in resp.text
         finally:
             session.close()
 
@@ -982,7 +982,7 @@ class TestLeaderboardRoute:
 
             resp = client.get(f"/leaderboard/{player.link_uuid}")
             assert resp.status_code == 200
-            assert "Ranked by Net EPPD" in resp.text
+            assert "Ranked by EPPD" in resp.text
         finally:
             session.close()
 
@@ -999,7 +999,6 @@ class TestLeaderboardRoute:
             resp = client.get(f"/leaderboard/{player.link_uuid}")
             assert resp.status_code == 200
             assert "What do these stats mean?" in resp.text
-            assert "Metric Definitions" in resp.text
         finally:
             session.close()
 
@@ -1210,3 +1209,21 @@ class TestMetricDefinitions:
     def test_all_have_nonempty_label(self):
         for key, m in METRIC_DEFINITIONS.items():
             assert len(m.label) > 0, f"{key} has empty label"
+
+    def test_all_have_nonempty_full_label(self):
+        for key, m in METRIC_DEFINITIONS.items():
+            assert len(m.full_label) > 0, f"{key} has empty full_label"
+
+    def test_labels_are_abbreviated(self):
+        """Column headers should be short abbreviations (≤6 chars)."""
+        for key, m in METRIC_DEFINITIONS.items():
+            assert (
+                len(m.label) <= 6
+            ), f"{key} label {m.label!r} too long for abbreviated header"
+
+    def test_full_labels_are_longer_than_labels(self):
+        """Full labels should be more descriptive than abbreviated labels."""
+        for key, m in METRIC_DEFINITIONS.items():
+            assert len(m.full_label) >= len(
+                m.label
+            ), f"{key}: full_label {m.full_label!r} shorter than label {m.label!r}"

--- a/web/leaderboard.py
+++ b/web/leaderboard.py
@@ -36,7 +36,8 @@ _LEADERBOARD_MATCH_STATUSES = ("active", "complete")
 class MetricDef(NamedTuple):
     """Display metadata for a single leaderboard metric."""
 
-    label: str  # Short column header
+    label: str  # Abbreviated column header (e.g. "GP")
+    full_label: str  # Full name for glossary (e.g. "Games Played")
     tooltip: str  # Plain-English explanation
     format: str  # "pct" | "int" | "float1" | "float3" | "signed_float1"
     category: str  # "primary" | "default" | "secondary"
@@ -46,7 +47,8 @@ class MetricDef(NamedTuple):
 #: The template iterates these to build headers, tooltips, and formatting.
 METRIC_DEFINITIONS: dict[str, MetricDef] = {
     "net_eppd": MetricDef(
-        label="Net EPPD",
+        label="EPPD",
+        full_label="Net EPPD",
         tooltip=(
             "Net Expected Points Per Deal — your average point advantage "
             "per hand. Positive means you're outscoring opponents."
@@ -55,79 +57,92 @@ METRIC_DEFINITIONS: dict[str, MetricDef] = {
         category="primary",
     ),
     "matches_played": MetricDef(
-        label="Games Played",
+        label="GP",
+        full_label="Games Played",
         tooltip="Total completed games played.",
         format="int",
         category="default",
     ),
     "hands_played": MetricDef(
-        label="Hands",
+        label="HP",
+        full_label="Hands Played",
         tooltip="Total hands played across all matches (including in-progress).",
         format="int",
         category="default",
     ),
     "games_won": MetricDef(
-        label="Games Won",
+        label="GW",
+        full_label="Games Won",
         tooltip="Total games won.",
         format="int_games",
         category="default",
     ),
     "win_rate": MetricDef(
-        label="Win %",
+        label="W%",
+        full_label="Win %",
         tooltip="Percentage of completed games you won.",
         format="pct",
         category="default",
     ),
     "avg_match_margin": MetricDef(
-        label="Avg Margin",
+        label="Mgn",
+        full_label="Avg Margin",
         tooltip="Average score margin across all completed matches (positive = winning).",
         format="signed_float1",
         category="default",
     ),
     "avg_margin_victory": MetricDef(
-        label="Win Margin",
+        label="WMgn",
+        full_label="Win Margin",
         tooltip="Average score margin in games you won (points).",
         format="float1",
         category="secondary",
     ),
     "bid_rate": MetricDef(
-        label="Bid %",
+        label="Bid%",
+        full_label="Bid %",
         tooltip="Percentage of hands where your team won the auction and declared.",
         format="pct",
         category="secondary",
     ),
     "make_rate": MetricDef(
-        label="Make %",
+        label="Make%",
+        full_label="Make %",
         tooltip="Percentage of your contracts that made (took enough tricks).",
         format="pct",
         category="secondary",
     ),
     "avg_bid_level": MetricDef(
-        label="Avg Bid",
+        label="AvgB",
+        full_label="Avg Bid",
         tooltip="Average number of tricks bid when your team declares.",
         format="float1",
         category="secondary",
     ),
     "moon_call_rate": MetricDef(
-        label="Moon %",
+        label="Moon%",
+        full_label="Moon %",
         tooltip="Percentage of hands where you personally called a moon (bid all 10 tricks). AI partner moons are excluded.",
         format="pct",
         category="secondary",
     ),
     "moon_make_rate": MetricDef(
-        label="Moon Make",
+        label="M.Make",
+        full_label="Moon Make",
         tooltip="Percentage of your personal moon bids that were successfully made.",
         format="pct",
         category="secondary",
     ),
     "loner_call_rate": MetricDef(
-        label="Loner %",
+        label="Loner%",
+        full_label="Loner %",
         tooltip="Percentage of hands where you personally called a loner (solo play). AI partner loners are excluded.",
         format="pct",
         category="secondary",
     ),
     "loner_make_rate": MetricDef(
-        label="Loner Make",
+        label="L.Make",
+        full_label="Loner Make",
         tooltip="Percentage of your personal loner bids that were successfully made.",
         format="pct",
         category="secondary",

--- a/web/templates/leaderboard.html
+++ b/web/templates/leaderboard.html
@@ -203,7 +203,7 @@
         <h2 class="leaderboard__title">Leaderboard</h2>
     </div>
     <p class="leaderboard__ranking-info">
-        Ranked by Net EPPD — your average point advantage per hand.
+        Ranked by EPPD (Net Expected Points Per Deal) — your average point advantage per hand.
     </p>
 
     {% if rankings|length == 0 %}
@@ -254,14 +254,14 @@
     </div>
 
     <div class="leaderboard__help" id="help-panel" role="note" aria-label="Metric definitions">
-        <h3>Metric Definitions</h3>
+        <h3>What do these stats mean?</h3>
         <dl>
             {% set ns = namespace(prev_cat="") %}
             {% for key, m in metric_defs.items() %}
             {% if ns.prev_cat and ns.prev_cat != m.category %}
             <hr class="leaderboard__help-divider">
             {% endif %}
-            <dt>{{ m.label }}</dt>
+            <dt>{{ m.label }} — {{ m.full_label }}</dt>
             <dd>{{ m.tooltip }}</dd>
             {% set ns.prev_cat = m.category %}
             {% endfor %}


### PR DESCRIPTION
## Summary

- Abbreviate all leaderboard column headers to reduce horizontal space (Net EPPD→EPPD, Games Played→GP, Hands→HP, Games Won→GW, Win %→W%, Avg Margin→Mgn, etc.)
- Add `full_label` field to `MetricDef` NamedTuple so the glossary panel maps each abbreviation to its full name
- Update glossary heading to "What do these stats mean?" with dt format "EPPD — Net EPPD"

## Why

Issue #2187 — the leaderboard table uses full column names which takes too much horizontal space, especially on mobile. Abbreviated headers keep the table compact while the existing glossary panel provides full definitions.

## Changes

| File | Change |
|------|--------|
| `web/leaderboard.py` | Add `full_label` to `MetricDef`, abbreviate all `label` values |
| `web/templates/leaderboard.html` | Update glossary dt to show "label — full_label", update ranking info text |
| `tests/unit/hosted_play/test_leaderboard.py` | Add tests for `full_label` field, update assertions for new labels |

### Abbreviation Map

| Before | After | Metric |
|--------|-------|--------|
| Net EPPD | EPPD | Primary ranking metric |
| Games Played | GP | Default |
| Hands | HP | Default |
| Games Won | GW | Default |
| Win % | W% | Default |
| Avg Margin | Mgn | Default |
| Win Margin | WMgn | Secondary |
| Bid % | Bid% | Secondary |
| Make % | Make% | Secondary |
| Avg Bid | AvgB | Secondary |
| Moon % | Moon% | Secondary |
| Moon Make | M.Make | Secondary |
| Loner % | Loner% | Secondary |
| Loner Make | L.Make | Secondary |

## Repro / Validation

```bash
uv run python -m pytest tests/unit/hosted_play/test_leaderboard.py -v
# 63 passed
```

## Tests

- `uv run python -m pytest tests/unit/hosted_play/test_leaderboard.py -v` — 63 passed
- `make check-quiet` — 3 pre-existing failures (token_economy, telegram_filter), 0 new failures
- New tests: `test_all_have_nonempty_full_label`, `test_labels_are_abbreviated` (≤6 chars), `test_full_labels_are_longer_than_labels`

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
branch: fix/leaderboard-abbreviated-headers
```