### PR TITLE
fix(ops): add dirty-state guard before git reset --hard in worktree health (#2181, #2183)

### DIFF
--- a/scripts/internal/review_lane_runner.py
+++ b/scripts/internal/review_lane_runner.py
@@ -145,6 +145,19 @@ def _check_worktree_health(repo_root: Path) -> tuple[bool, str]:
                     timeout=30,
                 )
                 if pull.returncode != 0:
+                    # Before git reset --hard, check for dirty working tree
+                    # to avoid silently discarding uncommitted changes (#2181).
+                    dirty_check = subprocess.run(
+                        ["git", "status", "--porcelain"],
+                        capture_output=True,
+                        text=True,
+                        cwd=str(repo_root),
+                    )
+                    if dirty_check.returncode == 0 and dirty_check.stdout.strip():
+                        return False, (
+                            "Cannot reset to origin/main: working tree has "
+                            "uncommitted changes (ff-only pull also failed)"
+                        )
                     # Try reset instead of pull (handles diverged branches)
                     reset = subprocess.run(
                         ["git", "reset", "--hard", "origin/main"],

--- a/tests/unit/test_review_lane_runner.py
+++ b/tests/unit/test_review_lane_runner.py
@@ -688,6 +688,70 @@ class TestCheckWorktreeHealth:
         healthy, msg = _check_worktree_health(tmp_path)
         assert healthy is True
 
+    @patch("review_lane_runner.subprocess.run")
+    def test_pull_fails_clean_tree_resets(
+        self, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        """When ff-only pull fails and tree is clean, reset --hard succeeds."""
+        mock_run.side_effect = [
+            # symbolic-ref → on a branch
+            MagicMock(returncode=0, stdout="main\n"),
+            # fetch
+            MagicMock(returncode=0),
+            # rev-list count → 3 behind
+            MagicMock(returncode=0, stdout="3\n"),
+            # pull --ff-only → fails (diverged)
+            MagicMock(returncode=1, stderr="fatal: Not possible to fast-forward"),
+            # git status --porcelain → clean
+            MagicMock(returncode=0, stdout=""),
+            # git reset --hard → success
+            MagicMock(returncode=0),
+        ]
+        healthy, msg = _check_worktree_health(tmp_path)
+        assert healthy is True
+
+    @patch("review_lane_runner.subprocess.run")
+    def test_pull_fails_dirty_tree_refuses_reset(
+        self, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        """When ff-only pull fails and tree is dirty, refuse to reset (#2181)."""
+        mock_run.side_effect = [
+            # symbolic-ref → on a branch
+            MagicMock(returncode=0, stdout="main\n"),
+            # fetch
+            MagicMock(returncode=0),
+            # rev-list count → 2 behind
+            MagicMock(returncode=0, stdout="2\n"),
+            # pull --ff-only → fails
+            MagicMock(returncode=1, stderr="fatal: Not possible to fast-forward"),
+            # git status --porcelain → dirty
+            MagicMock(returncode=0, stdout=" M some_file.py\n"),
+        ]
+        healthy, msg = _check_worktree_health(tmp_path)
+        assert healthy is False
+        assert "uncommitted" in msg.lower()
+
+    @patch("review_lane_runner.subprocess.run")
+    def test_pull_fails_reset_fails(self, mock_run: MagicMock, tmp_path: Path) -> None:
+        """When ff-only pull fails and reset also fails, report error."""
+        mock_run.side_effect = [
+            # symbolic-ref → on a branch
+            MagicMock(returncode=0, stdout="main\n"),
+            # fetch
+            MagicMock(returncode=0),
+            # rev-list count → 1 behind
+            MagicMock(returncode=0, stdout="1\n"),
+            # pull --ff-only → fails
+            MagicMock(returncode=1, stderr="fatal: Not possible to fast-forward"),
+            # git status --porcelain → clean
+            MagicMock(returncode=0, stdout=""),
+            # git reset --hard → fails
+            MagicMock(returncode=1, stderr="error: could not reset"),
+        ]
+        healthy, msg = _check_worktree_health(tmp_path)
+        assert healthy is False
+        assert "could not sync" in msg.lower() or "reset" in msg.lower()
+
 
 class TestCleanupStaleLocks:
     """Tests for _cleanup_stale_locks()."""


### PR DESCRIPTION
## Summary
- Add dirty working tree guard before `git reset --hard origin/main` in `_check_worktree_health()` to prevent silent data loss
- Add three tests covering the reset fallback path (clean reset, dirty refusal, reset failure)

## Why
`_check_worktree_health()` fell through to `git reset --hard` when `git pull --ff-only` failed, without checking for uncommitted changes. This could silently discard work in the review lane worktree.

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_review_lane_runner.py -v
# 48 passed (3 new: test_pull_fails_clean_tree_resets, test_pull_fails_dirty_tree_refuses_reset, test_pull_fails_reset_fails)
```

## Tests
- `uv run python -m pytest tests/unit/test_review_lane_runner.py -v` — 48 passed
- `make check-quiet` — all passes (3 pre-existing failures in unrelated test_ops_token_economy and test_telegram_filter)

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
branch: fix/worktree-health-dirty-guard
```

Closes #2181, closes #2183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)