### PR TITLE
fix(web): deepcopy GluttonStrategy per match to prevent cross-match state leak

### DIFF
--- a/tests/unit/test_glutton.py
+++ b/tests/unit/test_glutton.py
@@ -9,6 +9,8 @@ NOTE: GluttonStrategy also has hooks (on_hand_start, observe_play) for state
 tracking, though the simplified version doesn't use them for decision-making.
 """
 
+import copy
+
 from bid_euchre.core.cards import Card
 from bid_euchre.strategy import GluttonIsolatedStrategy, GluttonStrategy, GreedyStrategy
 
@@ -1343,3 +1345,116 @@ class TestStaleInferenceReset:
         assert (
             len(glutton._seen_counts) > 0
         ), "Isolated: inference should be preserved within same hand/contract"
+
+
+class TestCrossMatchIsolation:
+    """Prove that deepcopy-per-match prevents shared-state contamination.
+
+    Regression test for #2168: AIManager stored ONE GluttonStrategy instance
+    per model.  All concurrent matches shared that instance, leaking
+    seen_counts, void_suits, contract_type, and trump_suit across games.
+    The fix deepcopies the strategy at engine-build time.
+    """
+
+    def test_deepcopy_isolates_seen_counts(self):
+        """Two cloned strategies must not share _seen_counts."""
+        shared = GluttonStrategy()
+        a = copy.deepcopy(shared)
+        b = copy.deepcopy(shared)
+
+        # Match A is a suit/Hearts contract
+        a.on_hand_start(
+            [Card("H", "A"), Card("H", "K"), Card("S", "T")],
+            "suit",
+            "H",
+            player_index=1,
+        )
+        a.observe_play(
+            0,
+            Card("H", "Q"),
+            [(0, Card("H", "Q"))],
+            "suit",
+            "H",
+        )
+
+        # Match B is a high (no-trump) contract — sees completely different cards
+        b.on_hand_start(
+            [Card("D", "A"), Card("D", "K"), Card("C", "T")],
+            "high",
+            None,
+            player_index=2,
+        )
+        b.observe_play(
+            1,
+            Card("C", "A"),
+            [(1, Card("C", "A"))],
+            "high",
+            None,
+        )
+
+        # Match A should only know about H-Q, not C-A
+        assert Card("H", "Q") in a._seen_counts
+        assert (
+            Card("C", "A") not in a._seen_counts
+        ), "Match A leaked seen_counts from Match B"
+
+        # Match B should only know about C-A, not H-Q
+        assert Card("C", "A") in b._seen_counts
+        assert (
+            Card("H", "Q") not in b._seen_counts
+        ), "Match B leaked seen_counts from Match A"
+
+        # Original shared instance must be untouched
+        assert (
+            len(shared._seen_counts) == 0
+        ), "Shared prototype was mutated by a cloned match"
+
+    def test_deepcopy_isolates_void_suits(self):
+        """Void-suit inference must not leak between cloned strategies."""
+        shared = GluttonStrategy()
+        a = copy.deepcopy(shared)
+        b = copy.deepcopy(shared)
+
+        a.on_hand_start(
+            [Card("H", "A"), Card("S", "K")],
+            "suit",
+            "H",
+            player_index=1,
+        )
+        # Player 2 fails to follow clubs → void in clubs
+        a.observe_play(
+            2,
+            Card("H", "T"),
+            [(0, Card("C", "A")), (1, Card("C", "K")), (2, Card("H", "T"))],
+            "suit",
+            "H",
+        )
+
+        b.on_hand_start(
+            [Card("D", "A"), Card("C", "T")],
+            "high",
+            None,
+            player_index=3,
+        )
+
+        assert "C" in a._void_suits_by_seat[2], "Match A should infer seat 2 void in C"
+        assert (
+            "C" not in b._void_suits_by_seat[2]
+        ), "Match B should not inherit void inference from Match A"
+
+    def test_deepcopy_isolates_contract_context(self):
+        """Contract type and trump suit must not leak between clones."""
+        shared = GluttonStrategy()
+        a = copy.deepcopy(shared)
+        b = copy.deepcopy(shared)
+
+        a.on_hand_start([Card("H", "A")], "suit", "H", player_index=0)
+        b.on_hand_start([Card("D", "A")], "low", None, player_index=0)
+
+        assert a._contract_type == "suit"
+        assert a._trump_suit == "H"
+        assert b._contract_type == "low"
+        assert b._trump_suit is None
+        # Shared prototype retains its default
+        assert shared._contract_type == "high"
+        assert shared._trump_suit is None

--- a/web/routes.py
+++ b/web/routes.py
@@ -10,6 +10,7 @@ no rule/scoring logic lives here.
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import random
@@ -78,11 +79,17 @@ def _get_session(request: Request):
 
 
 def _build_engine(ai_manager: AIManager, model_id: str) -> MatchEngine:
-    """Instantiate a MatchEngine for the given *model_id*."""
+    """Instantiate a MatchEngine for the given *model_id*.
+
+    The play strategy is deep-copied so each match gets its own mutable
+    state (seen_counts, void_suits, contract context).  Without this,
+    concurrent matches sharing a single GluttonStrategy instance would
+    contaminate each other's tracking state.  See #2168.
+    """
     info = ai_manager.get_model_info(model_id)
     return MatchEngine(
         bidding_policy=info.bidding_policy,
-        play_strategy=info.play_strategy,
+        play_strategy=copy.deepcopy(info.play_strategy),
     )
 
 


### PR DESCRIPTION
## Summary

- Deep-copy `GluttonStrategy` at engine-build time so each match gets its own mutable state
- Prevents cross-match contamination of `seen_counts`, `void_suits_by_seat`, and contract context
- Adds 3 isolation tests proving cloned instances don't share state

## Why

Closes #2168. `AIManager` creates one `GluttonStrategy()` per model at startup, shared across all concurrent matches via `_build_engine`. Since `GluttonStrategy` carries mutable per-hand state (`_seen_counts`, `_void_suits_by_seat`, `_contract_type`, `_trump_suit`), concurrent matches contaminate each other's tracking. The defense-in-depth fix (#2141) mitigates `contract_type`/`trump_suit`, but `seen_counts` and `void_suits` remain vulnerable.

## Changes

| File | Change |
|------|--------|
| `web/routes.py` | `import copy`; `_build_engine` now passes `copy.deepcopy(info.play_strategy)` to `MatchEngine` |
| `tests/unit/test_glutton.py` | New `TestCrossMatchIsolation` class with 3 tests |

## Repro / Validation

```bash
# Targeted tests (Tier 1)
uv run python -m pytest tests/unit/test_glutton.py -v -k TestCrossMatchIsolation
uv run python -m pytest tests/unit/test_glutton.py -v   # 47 passed
uv run python -m pytest tests/unit/hosted_play/ -q       # 3309 passed, 6 skipped

# Full validation (Tier 2)
make check  # 10976 passed (3 pre-existing failures in unrelated modules)
```

## Tests

- `test_deepcopy_isolates_seen_counts` — two cloned strategies track different cards without leaking
- `test_deepcopy_isolates_void_suits` — void-suit inference stays isolated per clone
- `test_deepcopy_isolates_contract_context` — contract type and trump suit don't leak between clones

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
worktree: Bid-Euchre-steward-author (author-a persistent lane)
branch: fix/glutton-shared-mutable
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)