### PR TITLE
fix: batch convention follow-ups (#2195, #2192)

### DIFF
--- a/scripts/internal/review_lane_runner.py
+++ b/scripts/internal/review_lane_runner.py
@@ -153,7 +153,14 @@ def _check_worktree_health(repo_root: Path) -> tuple[bool, str]:
                         text=True,
                         cwd=str(repo_root),
                     )
-                    if dirty_check.returncode == 0 and dirty_check.stdout.strip():
+                    # Exclude pure untracked files (??) — git reset --hard
+                    # does not touch them, so they are not at risk of loss.
+                    tracked_dirty = [
+                        line
+                        for line in dirty_check.stdout.splitlines()
+                        if line and not line.startswith("??")
+                    ]
+                    if dirty_check.returncode == 0 and tracked_dirty:
                         return False, (
                             "Cannot reset to origin/main: working tree has "
                             "uncommitted changes (ff-only pull also failed)"

--- a/src/bid_euchre/strategy/greedy.py
+++ b/src/bid_euchre/strategy/greedy.py
@@ -640,6 +640,7 @@ class GluttonIsolatedStrategy(Strategy):
     - partner_check: Skip 3rd-seat aggression when partner winning (PR#227)
     - trump_gating: Only aggressive trump if hand ≤6 or trump ≥3 (PR#227)
     - probabilistic_trump_in: Trump to protect partner from void 4th seat (PR#228)
+    - lead_bower: Lead right bower when holding both bowers + 5+ trump (PR#2167)
 
     With all features disabled, this behaves identically to GreedyStrategy.
     """
@@ -657,6 +658,7 @@ class GluttonIsolatedStrategy(Strategy):
         partner_check: bool = False,
         trump_gating: bool = False,
         probabilistic_trump_in: bool = False,
+        lead_bower: bool = False,
     ):
         super().__init__(name)
         self.debug = debug
@@ -671,6 +673,7 @@ class GluttonIsolatedStrategy(Strategy):
         self._partner_check = partner_check
         self._trump_gating = trump_gating
         self._probabilistic_trump_in = probabilistic_trump_in
+        self._lead_bower = lead_bower
 
         # Double-deck aware tracking (each card exists 0-2 times)
         self._seen_counts: Dict[Card, int] = {}
@@ -795,7 +798,7 @@ class GluttonIsolatedStrategy(Strategy):
         if self._contract_type == "suit" and self._trump_suit is not None:
             from ..core.cards import is_left_bower, is_right_bower
 
-            # 0. Both bowers + 5+ trump → lead right bower to draw trump
+            # Compute trump shape (used by steps 0 and 2)
             trump_count = self._count_effective_suit(hand, self._trump_suit)
             trump_indices = [
                 idx
@@ -809,7 +812,9 @@ class GluttonIsolatedStrategy(Strategy):
             has_left = any(
                 is_left_bower(hand[idx], self._trump_suit) for idx in trump_indices
             )
-            if has_right and has_left and trump_count >= 5:
+
+            # 0. Both bowers + 5+ trump → lead right bower to draw trump
+            if self._lead_bower and has_right and has_left and trump_count >= 5:
                 right_bower_idx = next(
                     idx
                     for idx in trump_indices
@@ -836,7 +841,6 @@ class GluttonIsolatedStrategy(Strategy):
                 return min(non_trump_aces, key=ace_priority)
 
             # 2. Draw trump if holding >= 4 trumps and NOT holding both bowers
-            # (trump_count, trump_indices, has_right, has_left computed in Step 0)
             if trump_count >= 4 and trump_indices:
                 if not (has_right and has_left):
                     return min(trump_indices, key=card_value)

--- a/tests/unit/test_review_lane_runner.py
+++ b/tests/unit/test_review_lane_runner.py
@@ -732,6 +732,49 @@ class TestCheckWorktreeHealth:
         assert "uncommitted" in msg.lower()
 
     @patch("review_lane_runner.subprocess.run")
+    def test_pull_fails_untracked_only_allows_reset(
+        self, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        """Untracked files (??) should not block reset — they survive it (#2195)."""
+        mock_run.side_effect = [
+            # symbolic-ref → on a branch
+            MagicMock(returncode=0, stdout="main\n"),
+            # fetch
+            MagicMock(returncode=0),
+            # rev-list count → 1 behind
+            MagicMock(returncode=0, stdout="1\n"),
+            # pull --ff-only → fails
+            MagicMock(returncode=1, stderr="fatal: Not possible to fast-forward"),
+            # git status --porcelain → only untracked files
+            MagicMock(returncode=0, stdout="?? new_file.py\n?? another.txt\n"),
+            # git reset --hard → succeeds
+            MagicMock(returncode=0),
+        ]
+        healthy, msg = _check_worktree_health(tmp_path)
+        assert healthy is True
+
+    @patch("review_lane_runner.subprocess.run")
+    def test_pull_fails_mixed_dirty_and_untracked_refuses_reset(
+        self, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        """Mixed modified + untracked should still block reset (#2195)."""
+        mock_run.side_effect = [
+            # symbolic-ref → on a branch
+            MagicMock(returncode=0, stdout="main\n"),
+            # fetch
+            MagicMock(returncode=0),
+            # rev-list count → 1 behind
+            MagicMock(returncode=0, stdout="1\n"),
+            # pull --ff-only → fails
+            MagicMock(returncode=1, stderr="fatal: Not possible to fast-forward"),
+            # git status --porcelain → modified + untracked
+            MagicMock(returncode=0, stdout="?? new_file.py\n M dirty.py\n"),
+        ]
+        healthy, msg = _check_worktree_health(tmp_path)
+        assert healthy is False
+        assert "uncommitted" in msg.lower()
+
+    @patch("review_lane_runner.subprocess.run")
     def test_pull_fails_reset_fails(self, mock_run: MagicMock, tmp_path: Path) -> None:
         """When ff-only pull fails and reset also fails, report error."""
         mock_run.side_effect = [


### PR DESCRIPTION
## Summary
- Exclude pure untracked files (`??`) from the dirty-state guard in `review_lane_runner.py` — `git reset --hard` does not touch untracked files, so they should not block the reset safety check (#2195)
- Add `lead_bower` isolation flag to `GluttonIsolatedStrategy` so the bower-lead heuristic (both bowers + 5+ trump → lead right bower) can be independently toggled for A/B testing (#2192)
- Add regression tests for untracked-file exclusion (pure untracked passes, mixed still blocks)

## Why
Convention follow-ups from autonomous review of PRs #2193 and #2190. The dirty-state guard false-positives on untracked files, and the bower-lead heuristic was not independently testable via the isolation strategy.

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_review_lane_runner.py tests/unit/test_greedy.py tests/unit/test_glutton.py tests/unit/test_leading_fix.py -x -q
```

## Tests
- `tests/unit/test_review_lane_runner.py` — 50 tests pass (2 new)
- `tests/unit/test_greedy.py` — 10 tests pass
- `tests/unit/test_glutton.py` — 50 tests pass
- `tests/unit/test_leading_fix.py` — 9 tests pass
- `make check-quiet` — 3 pre-existing failures unrelated to this PR (confirmed on clean main)

## Worktree proof
```
pwd: Bid-Euchre-steward-author-b
branch: fix/convention-followups-2195-2192
```

Closes #2195
Closes #2192

🤖 Generated with [Claude Code](https://claude.com/claude-code)