### PR TITLE
fix(web): harden POST handlers — corrupted state redirect + turn_number 409 (#2218, #2223)

### DIFF
--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -585,13 +585,14 @@ class TestIdempotentResubmission:
         )
         assert resp1.status_code == 200
 
-        # Same turn_number — idempotent
+        # Same turn_number — stale; returns 409 with authoritative board
         resp2 = client.post(
             f"/play/{link_uuid}/bid",
             data={"turn_number": turn, "bid_n": 0, "bid_contract": ""},
         )
-        assert resp2.status_code == 200
-        # Both should return valid responses (second is idempotent)
+        assert resp2.status_code == 409
+        # Body is the current board HTML so HTMX can re-sync
+        assert "game-board" in resp2.text
 
 
 # ---------------------------------------------------------------------------
@@ -1765,9 +1766,9 @@ class TestRefreshResumeSafety:
         state_json_1 = match_row1.match_state_json
         session1.close()
 
-        # "Double-click" — same turn_number
+        # "Double-click" — same turn_number → 409 Conflict (stale turn)
         resp2 = client.post(f"/play/{link_uuid}/bid", data=bid_data)
-        assert resp2.status_code == 200
+        assert resp2.status_code == 409
 
         # State must not have changed from the second submission
         result2 = get_match_state(app, link_uuid)
@@ -1825,9 +1826,9 @@ class TestRefreshResumeSafety:
         state_json_1 = match_row1.match_state_json
         session1.close()
 
-        # "Double-click" — same turn_number
+        # "Double-click" — same turn_number → 409 Conflict (stale turn)
         resp2 = client.post(f"/play/{link_uuid}/play-card", data=play_data)
-        assert resp2.status_code == 200
+        assert resp2.status_code == 409
 
         # State must not have changed from the second submission
         result2 = get_match_state(app, link_uuid)
@@ -3255,3 +3256,213 @@ class TestAuctionRevealUX:
                 advance_pending_reveals(client, app, link_uuid)
 
         pytest.skip("Seed did not produce a human-bids-last scenario")
+
+
+# ---------------------------------------------------------------------------
+# Corrupted match_state → POST returns redirect, not 500 (#2218)
+# ---------------------------------------------------------------------------
+
+
+class TestCorruptedMatchState:
+    """POST handlers return a redirect when match_state is corrupted (#2218).
+
+    The GET handler already marks corrupted matches as abandoned and shows
+    model selection.  These tests verify the same pattern in POST handlers.
+    """
+
+    def _corrupt_match(self, app, link_uuid: str) -> int:
+        """Corrupt the active match's state JSON. Returns the match row ID."""
+        session = app.state.session_factory()
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+        match_row = (
+            session.query(Match).filter_by(player_id=player.id, status="active").first()
+        )
+        assert match_row is not None
+        match_id = match_row.id
+        match_row.match_state_json = "NOT VALID JSON {{{{"
+        session.commit()
+        session.close()
+        return match_id
+
+    def _assert_abandoned(self, app, match_id: int) -> None:
+        """Assert the match is marked abandoned in the DB."""
+        session = app.state.session_factory()
+        match_row = session.query(Match).filter_by(id=match_id).first()
+        assert match_row is not None
+        assert match_row.status == "abandoned"
+        session.close()
+
+    def test_bid_with_corrupted_state_redirects(self, client, app):
+        """POST /bid with corrupted match_state returns HX-Redirect."""
+        link_uuid = _setup_game(client)
+        match_id = self._corrupt_match(app, link_uuid)
+
+        resp = client.post(
+            f"/play/{link_uuid}/bid",
+            data={"turn_number": 0, "bid_n": 0, "bid_contract": ""},
+        )
+        assert resp.status_code == 200
+        assert resp.headers.get("HX-Redirect") == f"/play/{link_uuid}"
+        self._assert_abandoned(app, match_id)
+
+    def test_play_card_with_corrupted_state_redirects(self, client, app):
+        """POST /play-card with corrupted match_state returns HX-Redirect."""
+        link_uuid = _setup_game(client)
+        match_id = self._corrupt_match(app, link_uuid)
+
+        resp = client.post(
+            f"/play/{link_uuid}/play-card",
+            data={"turn_number": 0, "card_index": 0},
+        )
+        assert resp.status_code == 200
+        assert resp.headers.get("HX-Redirect") == f"/play/{link_uuid}"
+        self._assert_abandoned(app, match_id)
+
+    def test_next_with_corrupted_state_redirects(self, client, app):
+        """POST /next with corrupted match_state returns HX-Redirect."""
+        link_uuid = _setup_game(client)
+        match_id = self._corrupt_match(app, link_uuid)
+
+        resp = client.post(f"/play/{link_uuid}/next")
+        assert resp.status_code == 200
+        assert resp.headers.get("HX-Redirect") == f"/play/{link_uuid}"
+        self._assert_abandoned(app, match_id)
+
+    def test_next_hand_with_corrupted_state_redirects(self, client, app):
+        """POST /next-hand with corrupted match_state returns HX-Redirect."""
+        link_uuid = _setup_game(client)
+        match_id = self._corrupt_match(app, link_uuid)
+
+        resp = client.post(f"/play/{link_uuid}/next-hand")
+        assert resp.status_code == 200
+        assert resp.headers.get("HX-Redirect") == f"/play/{link_uuid}"
+        self._assert_abandoned(app, match_id)
+
+    def test_exchange_with_corrupted_state_redirects(self, client, app):
+        """POST /exchange with corrupted match_state returns HX-Redirect."""
+        link_uuid = _setup_game(client)
+        match_id = self._corrupt_match(app, link_uuid)
+
+        resp = client.post(
+            f"/play/{link_uuid}/exchange",
+            data={"card_index_0": 0, "card_index_1": 1},
+        )
+        assert resp.status_code == 200
+        assert resp.headers.get("HX-Redirect") == f"/play/{link_uuid}"
+        self._assert_abandoned(app, match_id)
+
+
+# ---------------------------------------------------------------------------
+# Invalid turn_number → 409 Conflict (#2223)
+# ---------------------------------------------------------------------------
+
+
+class TestTurnNumberConflict:
+    """POST handlers return 409 when turn_number doesn't match (#2223).
+
+    Prevents race conditions from fast-clickers: the response body contains
+    the authoritative board HTML so HTMX can re-sync the DOM.
+    """
+
+    def test_play_card_stale_turn_returns_409(self, client, app):
+        """POST /play-card with stale turn_number returns 409 + board HTML."""
+        link_uuid = _setup_game(client)
+
+        # Navigate to trick play
+        for _ in range(20):
+            advance_pending_reveals(client, app, link_uuid)
+            result = get_match_state(app, link_uuid)
+            assert result is not None
+            state, _, session = result
+            session.close()
+
+            hand = state.current_hand
+            if hand is None:
+                break
+
+            if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+                client.post(
+                    f"/play/{link_uuid}/bid",
+                    data={
+                        "turn_number": hand.turn_number,
+                        "bid_n": 0,
+                        "bid_contract": "",
+                    },
+                )
+            elif hand.phase == "trick_play" and hand.current_seat == HUMAN_SEAT:
+                # Submit with wrong turn_number (stale)
+                resp = client.post(
+                    f"/play/{link_uuid}/play-card",
+                    data={
+                        "turn_number": hand.turn_number - 999,
+                        "card_index": 0,
+                    },
+                )
+                assert resp.status_code == 409
+                assert "game-board" in resp.text
+                return
+
+        pytest.fail("Never reached human's trick play turn")
+
+    def test_play_card_future_turn_returns_409(self, client, app):
+        """POST /play-card with future turn_number returns 409 + board HTML."""
+        link_uuid = _setup_game(client)
+
+        for _ in range(20):
+            advance_pending_reveals(client, app, link_uuid)
+            result = get_match_state(app, link_uuid)
+            assert result is not None
+            state, _, session = result
+            session.close()
+
+            hand = state.current_hand
+            if hand is None:
+                break
+
+            if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+                client.post(
+                    f"/play/{link_uuid}/bid",
+                    data={
+                        "turn_number": hand.turn_number,
+                        "bid_n": 0,
+                        "bid_contract": "",
+                    },
+                )
+            elif hand.phase == "trick_play" and hand.current_seat == HUMAN_SEAT:
+                resp = client.post(
+                    f"/play/{link_uuid}/play-card",
+                    data={
+                        "turn_number": hand.turn_number + 999,
+                        "card_index": 0,
+                    },
+                )
+                assert resp.status_code == 409
+                assert "game-board" in resp.text
+                return
+
+        pytest.fail("Never reached human's trick play turn")
+
+    def test_bid_stale_turn_returns_409(self, client, app):
+        """POST /bid with stale turn_number returns 409 + board HTML."""
+        link_uuid = _setup_game(client)
+        advance_pending_reveals(client, app, link_uuid)
+
+        result = get_match_state(app, link_uuid)
+        assert result is not None
+        state, _, session = result
+        session.close()
+
+        hand = state.current_hand
+        if hand is None or hand.phase != "auction" or hand.current_seat != HUMAN_SEAT:
+            pytest.skip("Human not in auction position")
+
+        resp = client.post(
+            f"/play/{link_uuid}/bid",
+            data={
+                "turn_number": hand.turn_number + 999,
+                "bid_n": 0,
+                "bid_contract": "",
+            },
+        )
+        assert resp.status_code == 409
+        assert "game-board" in resp.text

--- a/web/routes.py
+++ b/web/routes.py
@@ -569,6 +569,32 @@ def _render_game_board(
     return templates.get_template("partials/game_board.html").render(ctx)
 
 
+def _handle_corrupted_match(
+    request: Request,
+    session,
+    match_row: Match,
+    link_uuid: str,
+) -> HTMLResponse:
+    """Mark a match with corrupted state as abandoned and redirect.
+
+    Used by POST handlers when ``_deserialize_state`` fails.  Mirrors the
+    GET handler pattern (mark abandoned → show model selection) but returns
+    an ``HX-Redirect`` header so HTMX performs a full page navigation back
+    to ``/play/{link_uuid}``, which will render the model-select screen.
+
+    See :issue:`2218`.
+    """
+    match_row.status = "abandoned"
+    match_row.completed_at = datetime.now(timezone.utc)
+    session.commit()
+    redirect_url = f"/play/{link_uuid}"
+    return HTMLResponse(
+        content="",
+        status_code=200,
+        headers={"HX-Redirect": redirect_url},
+    )
+
+
 # ---------------------------------------------------------------------------
 # Health / Readiness
 # ---------------------------------------------------------------------------
@@ -1014,12 +1040,26 @@ async def submit_bid(
 
         ai_manager = _get_ai_manager(request)
         engine = _build_engine(ai_manager, match_row.ai_model)
-        state = _deserialize_state(engine, match_row.match_state_json)
+        try:
+            state = _deserialize_state(engine, match_row.match_state_json)
+        except Exception:
+            logger.warning(
+                "Failed to deserialize match %s on bid — marking abandoned",
+                match_row.match_uuid,
+                exc_info=True,
+            )
+            return _handle_corrupted_match(request, session, match_row, link_uuid)
 
-        # Idempotency check
+        # Turn-number conflict — return the authoritative board at 409 so
+        # HTMX can re-sync the DOM without re-submitting the stale action.
         hand = state.current_hand
-        if hand is None or turn_number < hand.turn_number:
+        if hand is None:
             return HTMLResponse(_render_game_board(request, engine, state, link_uuid))
+        if turn_number != hand.turn_number:
+            return HTMLResponse(
+                _render_game_board(request, engine, state, link_uuid),
+                status_code=409,
+            )
 
         # State-desync recovery — return the authoritative board for stale
         # requests instead of 400 so HTMX can re-sync the DOM.
@@ -1150,12 +1190,27 @@ async def submit_card(
 
         ai_manager = _get_ai_manager(request)
         engine = _build_engine(ai_manager, match_row.ai_model)
-        state = _deserialize_state(engine, match_row.match_state_json)
+        try:
+            state = _deserialize_state(engine, match_row.match_state_json)
+        except Exception:
+            logger.warning(
+                "Failed to deserialize match %s on play-card — marking abandoned",
+                match_row.match_uuid,
+                exc_info=True,
+            )
+            return _handle_corrupted_match(request, session, match_row, link_uuid)
 
-        # Idempotency check
+        # Turn-number conflict — return the authoritative board at 409 so
+        # HTMX can re-sync the DOM without re-submitting the stale action.
+        # Prevents race conditions from fast-clickers (#2223).
         hand = state.current_hand
-        if hand is None or turn_number < hand.turn_number:
+        if hand is None:
             return HTMLResponse(_render_game_board(request, engine, state, link_uuid))
+        if turn_number != hand.turn_number:
+            return HTMLResponse(
+                _render_game_board(request, engine, state, link_uuid),
+                status_code=409,
+            )
 
         # State-desync recovery — if HTMX morph left stale card buttons in
         # the DOM the player may click a card while the server is in a
@@ -1248,7 +1303,15 @@ async def next_step(
 
         ai_manager = _get_ai_manager(request)
         engine = _build_engine(ai_manager, match_row.ai_model)
-        state = _deserialize_state(engine, match_row.match_state_json)
+        try:
+            state = _deserialize_state(engine, match_row.match_state_json)
+        except Exception:
+            logger.warning(
+                "Failed to deserialize match %s on next — marking abandoned",
+                match_row.match_uuid,
+                exc_info=True,
+            )
+            return _handle_corrupted_match(request, session, match_row, link_uuid)
 
         hand = state.current_hand
         if hand is None:
@@ -1349,7 +1412,15 @@ async def submit_exchange(
 
         ai_manager = _get_ai_manager(request)
         engine = _build_engine(ai_manager, match_row.ai_model)
-        state = _deserialize_state(engine, match_row.match_state_json)
+        try:
+            state = _deserialize_state(engine, match_row.match_state_json)
+        except Exception:
+            logger.warning(
+                "Failed to deserialize match %s on exchange — marking abandoned",
+                match_row.match_uuid,
+                exc_info=True,
+            )
+            return _handle_corrupted_match(request, session, match_row, link_uuid)
 
         hand = state.current_hand
         if hand is None or hand.phase != "moon_exchange":
@@ -1419,7 +1490,15 @@ async def next_hand(
 
         ai_manager = _get_ai_manager(request)
         engine = _build_engine(ai_manager, match_row.ai_model)
-        state = _deserialize_state(engine, match_row.match_state_json)
+        try:
+            state = _deserialize_state(engine, match_row.match_state_json)
+        except Exception:
+            logger.warning(
+                "Failed to deserialize match %s on next-hand — marking abandoned",
+                match_row.match_uuid,
+                exc_info=True,
+            )
+            return _handle_corrupted_match(request, session, match_row, link_uuid)
 
         # If the match is already complete, render the result screen
         # immediately — do not advance to a new hand (P2-005).


### PR DESCRIPTION
## Summary

- **#2218:** Wrap `_deserialize_state` in try/except on all five POST handlers (`submit_bid`, `submit_card`, `next_step`, `submit_exchange`, `next_hand`). Corrupted `match_state_json` now returns an `HX-Redirect` to `/play/{link_uuid}` instead of an unhandled 500 traceback. The match is marked `abandoned` (matching the existing GET handler pattern).
- **#2223:** Change `turn_number` validation in `submit_bid` and `submit_card` from a silent 200 re-render to **409 Conflict** with the authoritative board HTML. This prevents race conditions from fast-clickers and lets HTMX re-sync the DOM.

## Why

Production users hitting corrupted match state on POST handlers got a raw 500 error with no recovery path. The GET handler already had the try/except + abandon pattern — POST handlers were missing it.

The turn_number issue allowed stale or future turn submissions to silently return 200, which masked race conditions from double-clicks and fast submissions.

## Changes

| File | Change |
|------|--------|
| `web/routes.py` | Added `_handle_corrupted_match()` helper; wrapped 5 POST handlers; changed turn_number check to 409 |
| `tests/unit/hosted_play/test_routes.py` | Added `TestCorruptedMatchState` (5 tests), `TestTurnNumberConflict` (3 tests); updated existing double-click/idempotent tests to expect 409 |

## Repro / Validation

```bash
# Targeted tests (Tier 1)
uv run python -m pytest tests/unit/hosted_play/test_routes.py -k "TestCorruptedMatchState or TestTurnNumberConflict" --no-header -q

# Full hosted_play suite
uv run python -m pytest tests/unit/hosted_play/ --no-header -q

# Full validation (Tier 2) — 3 pre-existing failures in unrelated modules
make check-quiet
```

## Tests

- `TestCorruptedMatchState`: 5 tests (one per POST handler) verify HX-Redirect + abandoned status
- `TestTurnNumberConflict`: 3 tests (stale play-card, future play-card, stale bid) verify 409 + board HTML
- Updated `TestIdempotentResubmission` and `TestRefreshResumeSafety` double-click tests to expect 409

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
branch: fix/post-handler-hardening-2218-2223
```

Closes #2218, closes #2223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)