### PR TITLE
fix(web): return HTML board on illegal bid/play + fix mobile text overflow

### DIFF
--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -635,7 +635,10 @@ class TestInvalidMove:
                         "card_index": 99,  # invalid index
                     },
                 )
-                assert resp.status_code == 400
+                # Returns 200 with the game board + inline error message
+                # instead of a JSON 400 (see #2217).
+                assert resp.status_code == 200
+                assert "Illegal card play" in resp.text
                 return
 
         pytest.fail("Never reached human's trick play turn for invalid move test")

--- a/web/routes.py
+++ b/web/routes.py
@@ -557,15 +557,26 @@ def _render_game_board(
     engine: MatchEngine,
     state,
     link_uuid: str,
+    *,
+    error_message: str | None = None,
 ) -> str:
     """Render the game board composite partial as an HTML string.
 
     Returns the inner HTML for the ``#game-board`` div — used by HTMX
     partial POST responses.
+
+    Parameters
+    ----------
+    error_message:
+        Optional transient error string displayed as an inline alert
+        above the board (e.g. "Illegal bid").  Cleared on the next
+        normal render.
     """
     templates = _get_templates(request)
     ctx = _build_game_context(engine, state, link_uuid)
     ctx["request"] = request
+    if error_message is not None:
+        ctx["board_error"] = error_message
     return templates.get_template("partials/game_board.html").render(ctx)
 
 
@@ -1035,8 +1046,14 @@ async def submit_bid(
             bid = BidAction.pass_bid()
         else:
             if bid_contract is None:
-                raise HTTPException(
-                    status_code=400, detail="bid_contract required for non-pass bids"
+                return HTMLResponse(
+                    _render_game_board(
+                        request,
+                        engine,
+                        state,
+                        link_uuid,
+                        error_message="Please select a contract type for your bid.",
+                    )
                 )
             if bid_type == "moon":
                 bid = BidAction.moon(bid_contract)
@@ -1051,7 +1068,15 @@ async def submit_bid(
             b.n == bid.n and b.contract == bid.contract and b.bid_type == bid.bid_type
             for b in legal_bids
         ):
-            raise HTTPException(status_code=400, detail="Illegal bid")
+            return HTMLResponse(
+                _render_game_board(
+                    request,
+                    engine,
+                    state,
+                    link_uuid,
+                    error_message="Illegal bid — please choose a valid bid.",
+                )
+            )
 
         # Record pre-action state for decision logging
         pre_turn = hand.turn_number
@@ -1173,7 +1198,15 @@ async def submit_card(
         # Validate legality
         legal_plays = engine.get_legal_plays(state)
         if card_index not in legal_plays:
-            raise HTTPException(status_code=400, detail="Illegal card play")
+            return HTMLResponse(
+                _render_game_board(
+                    request,
+                    engine,
+                    state,
+                    link_uuid,
+                    error_message="Illegal card play — please choose a valid card.",
+                )
+            )
 
         # Record pre-action state for decision logging
         pre_turn = hand.turn_number

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -38,6 +38,10 @@
     box-sizing: border-box;
 }
 
+html {
+    overflow-x: hidden;
+}
+
 body {
     margin: 0;
     padding: 0;
@@ -46,6 +50,7 @@ body {
     background: var(--color-bg-dark);
     color: var(--color-text);
     min-height: 100vh;
+    overflow-x: hidden;
 }
 
 /* --------------------------------------------------------------------------
@@ -57,6 +62,8 @@ header {
     padding: 0.5rem 1rem;
     text-align: center;
     border-bottom: 2px solid var(--color-felt);
+    max-width: 100vw;
+    overflow-x: hidden;
 }
 
 header h1 {
@@ -77,12 +84,16 @@ header h1 a:hover {
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 1.5rem;
+    flex-wrap: wrap;
+    gap: 0.5rem 1.5rem;
 }
 
 .header-nav {
     display: flex;
     gap: 0.25rem;
+    flex-wrap: wrap;
+    justify-content: center;
+    max-width: 100%;
 }
 
 .header-nav__tab {
@@ -128,6 +139,7 @@ main {
     max-width: 900px;
     margin: 0 auto;
     padding: 1rem;
+    overflow-x: hidden;
 }
 
 #game-board {
@@ -1803,6 +1815,16 @@ main {
         --card-overlap: -8px;
     }
 
+    /* Header nav — compact tabs to prevent overflow at large text */
+    .header-nav__tab {
+        font-size: 0.7rem;
+        padding: 0.3rem 0.5rem;
+    }
+
+    .header-bar {
+        gap: 0.4rem 1rem;
+    }
+
     /* Compass layout — compact for mobile */
     .compass-layout {
         gap: 0.25rem 0.35rem;
@@ -2087,6 +2109,12 @@ main {
 
     header h1 {
         font-size: 1rem;
+    }
+
+    /* Header nav — extra-compact on small phones / large text */
+    .header-nav__tab {
+        font-size: 0.65rem;
+        padding: 0.25rem 0.4rem;
     }
 
     .card__rank {
@@ -3029,6 +3057,25 @@ main {
 
 .htmx-error__home {
     display: inline-block;
+}
+
+/* Board-level inline error banner (illegal bid / illegal play).
+   Displayed at the top of #game-board and auto-dismissed after 5s. */
+.board-error {
+    background: var(--color-negative);
+    color: #fff;
+    text-align: center;
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+    animation: board-error-fade 5s ease-in-out forwards;
+}
+
+@keyframes board-error-fade {
+    0%, 80% { opacity: 1; }
+    100%    { opacity: 0; }
 }
 
 @media (max-width: 600px) {

--- a/web/templates/partials/game_board.html
+++ b/web/templates/partials/game_board.html
@@ -6,7 +6,16 @@
        - phase: str — "auction", "trick_play", "hand_result", "match_result", "redeal"
        - link_uuid: str — player's game link UUID
        - opp_left_count, partner_count, opp_right_count: int — AI hand card counts
+       - board_error: str (optional) — transient error message to display
 #}
+
+{# ---- Transient error banner (illegal bid / illegal play) ---- #}
+{% if board_error is defined and board_error %}
+<div class="board-error" role="alert" aria-live="assertive">
+    {{ board_error }}
+</div>
+{% endif %}
+
 {% set dealer_seat = dealer_seat if (dealer_seat is defined and dealer_seat is not none) else -1 %}
 {% set bidder_seat = bidder_seat if (bidder_seat is defined and bidder_seat is not none) else -1 %}
 {% set current_seat = current_seat if (current_seat is defined and current_seat is not none) else -1 %}


### PR DESCRIPTION
## Summary

- **#2217** — Illegal bid/play now returns an HTML board re-render with an inline error banner instead of a JSON 400 response that HTMX couldn't swap
- **#2221** — Large text mode (200% zoom) on mobile no longer overflows horizontally; all tabs remain reachable

## Why

When a player submits an invalid bid or plays an illegal card, the server was returning `HTTPException(status_code=400)` which FastAPI renders as JSON. HTMX ignores non-2xx responses by default, so the page appeared stuck. Now the endpoints return 200 with the board re-rendered plus a transient error message that auto-fades after 5 seconds.

For the mobile overflow, users with large text / accessibility zoom found the layout pushed off-screen, making the Game tab unreachable. This was caused by the header-bar and header-nav not wrapping, combined with no overflow-x containment on the page.

## Changes

### Backend (routes.py)
- `_render_game_board()` now accepts an optional `error_message` kwarg, passed as `board_error` to the template context
- `submit_bid()`: illegal bid → board re-render with error message (was `HTTPException(400)`)
- `submit_bid()`: missing `bid_contract` → board re-render with error message (was `HTTPException(400)`)
- `submit_card()`: illegal card play → board re-render with error message (was `HTTPException(400)`)

### Frontend (templates, CSS)
- `game_board.html`: added transient error banner at top of board (role="alert", aria-live="assertive")
- `style.css`: `.board-error` styles with fade-out animation
- `style.css`: `overflow-x: hidden` on html, body, header, main
- `style.css`: `flex-wrap` on `.header-bar` and `.header-nav`
- `style.css`: responsive tab sizing at 600px and 375px breakpoints

### Tests
- Updated `test_invalid_card_rejected` to expect 200 + error text instead of 400

## Repro / Validation

```bash
# Run hosted play tests
uv run python -m pytest tests/unit/hosted_play/ --no-header -q
# 3313 passed, 5 skipped

# Full validation (3 pre-existing failures unrelated to this PR)
make check-quiet
```

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
branch: fix/bid-json-400-and-text-overflow
```

Fixes #2217
Fixes #2221

🤖 Generated with [Claude Code](https://claude.com/claude-code)