### PR TITLE
fix(web): auction-to-play boundary guard + HTMX timeout on all forms (#2208, #2202)

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -542,7 +542,7 @@ class TestHand:
             legal_plays=[0, 1],
             phase="trick_play",
         )
-        assert 'hx-timeout="10000"' in html
+        assert 'hx-timeout="15000"' in html
 
     def test_illegal_cards_are_divs(self, env):
         """During trick play, illegal cards are plain divs."""

--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -1207,6 +1207,56 @@ class TestHxPostUrl:
         assert "{link_uuid}" not in resp.text
 
 
+class TestHxTimeout:
+    """Verify all HTMX forms have hx-timeout for stall recovery (#2202)."""
+
+    def test_nickname_form_has_timeout(self, client):
+        """Nickname form should have hx-timeout."""
+        link_uuid = _create_game(client)
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        assert 'hx-timeout="15000"' in resp.text
+
+    def test_next_controls_has_timeout(self, client, app):
+        """Next button form should have hx-timeout."""
+        link_uuid = _setup_game(client)
+
+        result = get_match_state(app, link_uuid)
+        assert result is not None
+        state, _, session = result
+
+        hand = state.current_hand
+        assert hand is not None
+
+        # Inject state that shows the Next button (hidden auction)
+        hand.phase = "auction"
+        hand.current_seat = HUMAN_SEAT
+        hand.auction = [
+            {"seat": 1, "n": 0, "action": "pass"},
+        ]
+        hand.revealed_auction_count = 0
+
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+        match_row = (
+            session.query(Match).filter_by(player_id=player.id, status="active").first()
+        )
+        ai_manager = app.state.ai_manager
+        info = ai_manager.get_model_info(match_row.ai_model)
+        engine = MatchEngine(
+            bidding_policy=info.bidding_policy,
+            play_strategy=info.play_strategy,
+        )
+        match_row.match_state_json = json.dumps(engine.serialize(state))
+        session.commit()
+        session.close()
+
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        # The next_controls partial should have hx-timeout
+        assert 'hx-post="/play/' in resp.text
+        assert 'hx-timeout="15000"' in resp.text
+
+
 # ---------------------------------------------------------------------------
 # Test: AI decision content quality
 # ---------------------------------------------------------------------------
@@ -3165,6 +3215,75 @@ class TestAuctionRevealUX:
         hand3 = state3.current_hand
         assert hand3 is not None
         assert hand3.auction_settled is True
+
+    def test_settle_pause_hides_trick_play_state(self, client, app):
+        """During settle pause, trick-play data is hidden even if engine advanced (#2208).
+
+        When the engine auto-advances past the auction into trick play (AI
+        leads first trick), the settle pause screen must NOT show the trick
+        plays.  The user should see "Auction complete" without any trick cards.
+        """
+        link_uuid = _setup_game(client)
+
+        result = get_match_state(app, link_uuid)
+        assert result is not None
+        state, _, session = result
+
+        hand = state.current_hand
+        assert hand is not None
+
+        # Inject state: auction ended, engine already in trick_play with AI
+        # cards played.  Settle pause active (auction_settled=False).
+        hand.phase = "trick_play"
+        hand.auction = [
+            {
+                "seat": 1,
+                "n": 5,
+                "action": "bid",
+                "contract": "S",
+                "bid_type": "regular",
+            },
+            {"seat": 2, "n": 0, "action": "pass"},
+            {"seat": 3, "n": 0, "action": "pass"},
+            {"seat": 0, "n": 0, "action": "pass"},
+        ]
+        hand.revealed_auction_count = 4  # all bids revealed
+        hand.auction_settled = False  # settle pause active
+        hand.contract_type = "suit"
+        hand.trump = "S"
+        hand.winning_bid = 5
+        hand.bidder_seat = 1
+        hand.current_high_bid = 5
+        # Simulate AI having already played 2 cards in first trick
+        hand.current_trick = TrickState(leader=1)
+        hand.current_trick.plays = [
+            (1, Card("S", "A")),
+            (2, Card("S", "K")),
+        ]
+        hand.current_seat = 3
+
+        # Persist injected state
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+        match_row = (
+            session.query(Match).filter_by(player_id=player.id, status="active").first()
+        )
+        ai_manager = app.state.ai_manager
+        info = ai_manager.get_model_info(match_row.ai_model)
+        engine = MatchEngine(
+            bidding_policy=info.bidding_policy,
+            play_strategy=info.play_strategy,
+        )
+        match_row.match_state_json = json.dumps(engine.serialize(state))
+        session.commit()
+        session.close()
+
+        # The settle pause screen should NOT show trick cards
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        assert "Auction complete" in resp.text
+        # Trick area should not show AI-played cards during settle pause
+        # The A♠ and K♠ from the injected trick should be hidden
+        assert "trick-card" not in resp.text or "current-trick" not in resp.text
 
     def test_no_settle_pause_when_human_bids_last(self, client, app):
         """When the human is the last bidder, no settle pause is needed (#2134).

--- a/web/routes.py
+++ b/web/routes.py
@@ -452,6 +452,17 @@ def _build_game_context(
         visible["completed_tricks"] = []
         visible["tricks_team0"] = 0
         visible["tricks_team1"] = 0
+    elif hand is not None and not hand.auction_settled:
+        # Settle pause — all bids revealed but the user hasn't dismissed
+        # the auction-complete interstitial yet.  The engine may have
+        # already auto-advanced into trick play (processing AI trick cards
+        # during the submit_bid call), but the user hasn't seen the
+        # auction result.  Hide trick-play state so the transition screen
+        # shows a clean "Auction complete" view (#2208).
+        visible["current_trick"] = None
+        visible["completed_tricks"] = []
+        visible["tricks_team0"] = 0
+        visible["tricks_team1"] = 0
     if hand is not None and hand.phase == "trick_play" and hand.paused_after_trick:
         visible["current_trick"] = None
 

--- a/web/templates/comments.html
+++ b/web/templates/comments.html
@@ -158,6 +158,7 @@
           hx-post="/play/{{ link_uuid }}/comment"
           hx-target="#comments-list"
           hx-swap="innerHTML"
+          hx-timeout="15000"
           hx-on::after-request="if(event.detail.successful) this.reset()">
         <textarea class="comments__input" name="content"
                   placeholder="Share a thought about the game..."

--- a/web/templates/partials/bid_panel.html
+++ b/web/templates/partials/bid_panel.html
@@ -65,6 +65,7 @@
           hx-post="/play/{{ link_uuid }}/bid"
           hx-target="#game-board"
           hx-swap="morph:innerHTML"
+          hx-timeout="15000"
           aria-label="Submit your bid">
         <input type="hidden" name="turn_number" value="{{ turn_number }}">
 

--- a/web/templates/partials/hand.html
+++ b/web/templates/partials/hand.html
@@ -53,7 +53,7 @@
               hx-post="/play/{{ link_uuid }}/play-card"
               hx-target="#game-board"
               hx-swap="morph:innerHTML"
-              hx-timeout="10000">
+              hx-timeout="15000">
             <input type="hidden" name="turn_number" value="{{ turn_number }}">
             <input type="hidden" id="selected-card-index" name="card_index" value="">
             <button id="card-play-submit"

--- a/web/templates/partials/hand_result.html
+++ b/web/templates/partials/hand_result.html
@@ -162,6 +162,7 @@
           hx-post="/play/{{ link_uuid | default("") }}/new-match"
           hx-target="#game-board"
           hx-swap="morph:innerHTML"
+          hx-timeout="15000"
           class="hand-result-controls"
           aria-label="Start a new match">
         <button type="submit" class="btn btn--play-again">Play Again</button>
@@ -172,6 +173,7 @@
           hx-post="/play/{{ link_uuid | default("") }}/next-hand"
           hx-target="#game-board"
           hx-swap="morph:innerHTML"
+          hx-timeout="15000"
           class="hand-result-controls"
           aria-label="Start next hand">
         <button type="submit" class="btn btn--next-hand">Next Hand</button>

--- a/web/templates/partials/invite_code_form.html
+++ b/web/templates/partials/invite_code_form.html
@@ -20,6 +20,7 @@
           hx-post="/enter-code"
           hx-target="#invite-code-form"
           hx-swap="outerHTML"
+          hx-timeout="15000"
           aria-label="Enter invite code">
         <div class="invite-code-form__fields">
             <label for="invite-code-input" class="sr-only">Invite code</label>

--- a/web/templates/partials/match_result.html
+++ b/web/templates/partials/match_result.html
@@ -34,7 +34,8 @@
           action="/play/{{ link_uuid }}/new-match"
           hx-post="/play/{{ link_uuid }}/new-match"
           hx-target="#game-board"
-          hx-swap="morph:innerHTML">
+          hx-swap="morph:innerHTML"
+          hx-timeout="15000">
         <button type="submit" class="btn btn--play-again" aria-label="Start a new match">Play Again</button>
     </form>
 </div>

--- a/web/templates/partials/model_select.html
+++ b/web/templates/partials/model_select.html
@@ -14,6 +14,7 @@
           hx-post="/play/{{ link_uuid }}/select-ai"
           hx-target="#game-board"
           hx-swap="morph:innerHTML"
+          hx-timeout="15000"
           aria-label="Select AI model and start match">
         <fieldset class="model-cards" role="radiogroup" aria-label="AI opponent model">
             <legend class="sr-only">AI opponent model</legend>

--- a/web/templates/partials/moon_exchange.html
+++ b/web/templates/partials/moon_exchange.html
@@ -101,6 +101,7 @@
           hx-post="/play/{{ link_uuid | default('') }}/next"
           hx-target="#game-board"
           hx-swap="morph:innerHTML"
+          hx-timeout="15000"
           class="moon-exchange__controls">
         <button type="submit" class="btn btn--next-step" aria-label="Continue to trick play">
             Start Trick Play

--- a/web/templates/partials/moon_exchange_select.html
+++ b/web/templates/partials/moon_exchange_select.html
@@ -66,7 +66,8 @@
           action="/play/{{ link_uuid | default('') }}/exchange"
           hx-post="/play/{{ link_uuid | default('') }}/exchange"
           hx-target="#game-board"
-          hx-swap="morph:innerHTML">
+          hx-swap="morph:innerHTML"
+          hx-timeout="15000">
         <input type="hidden" id="exchange-card-0" name="card_index_0" value="">
         <input type="hidden" id="exchange-card-1" name="card_index_1" value="">
         <p id="exchange-help" class="card-play-help" aria-live="polite">

--- a/web/templates/partials/next_controls.html
+++ b/web/templates/partials/next_controls.html
@@ -7,7 +7,8 @@
           action="/play/{{ link_uuid }}/next"
           hx-post="/play/{{ link_uuid }}/next"
           hx-target="#game-board"
-          hx-swap="morph:innerHTML">
+          hx-swap="morph:innerHTML"
+          hx-timeout="15000">
         <button type="submit" class="btn btn--next-step" aria-label="Advance to the next step">
             Next
         </button>

--- a/web/templates/partials/nickname_form.html
+++ b/web/templates/partials/nickname_form.html
@@ -9,6 +9,7 @@
           hx-post="/play/{{ link_uuid }}/nickname"
           hx-target="#game-board"
           hx-swap="morph:innerHTML"
+          hx-timeout="15000"
           aria-label="Choose a display name">
         <label for="nickname-input">Nickname:</label>
         <input id="nickname-input"


### PR DESCRIPTION
## Summary

- **#2208 — Auction-to-play boundary skip:** Hide trick-play state during the auction settle pause so the user always sees the "Auction complete" interstitial before any trick cards appear. The engine auto-advances AI trick plays during `submit_bid`, but the UI now masks them until the settle pause is dismissed.
- **#2202 — HTMX stall on all endpoints:** Add `hx-timeout="15000"` to all HTMX forms. Previously only the play-card form had a timeout (10s, now 15s). The existing `htmx:timeout` JS handler shows a toast and resets the card-play form for retry.

## Why

During playtesting on Render free-tier, two UX issues were observed:
1. When AI bids resolve quickly, a single "Next" click jumps from auction to 2+ cards already played in trick 1, skipping the auction conclusion screen
2. HTMX requests to `/next` and other endpoints could stall permanently when the server sleeps mid-request, with no recovery mechanism

## Changes

### #2208 fix (routes.py)
Added an `elif` branch in `_build_game_context` that detects the settle-pause state (all bids revealed, `auction_settled=False`) and hides trick-play data (`current_trick`, `completed_tricks`, `tricks_team0/1`) — same masking pattern already used for hidden auction bids.

### #2202 fix (12 templates)
Added `hx-timeout="15000"` to all HTMX forms:
- `next_controls.html`, `bid_panel.html`, `model_select.html`
- `moon_exchange_select.html`, `moon_exchange.html`
- `hand_result.html` (both next-hand and new-match forms)
- `match_result.html`, `nickname_form.html`, `invite_code_form.html`
- `comments.html`, `hand.html` (bumped from 10s to 15s)

## Repro / Validation

```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/hosted_play/test_routes.py::TestAuctionRevealUX::test_settle_pause_hides_trick_play_state -xvs
uv run python -m pytest tests/unit/hosted_play/test_routes.py::TestHxTimeout -xvs

# Tier 2 — full suite (3 pre-existing failures on main excluded)
make check-quiet
```

## Tests

- `TestAuctionRevealUX::test_settle_pause_hides_trick_play_state` — verifies trick data is hidden during settle pause
- `TestHxTimeout::test_nickname_form_has_timeout` — verifies nickname form has hx-timeout
- `TestHxTimeout::test_next_controls_has_timeout` — verifies next controls have hx-timeout
- Updated `TestHand::test_card_play_form_has_timeout` — bumped expected value 10000→15000

## Worktree proof

```
pwd: Bid-Euchre-steward-brws-author-b
branch: fix/auction-boundary-htmx-retry
```

Closes #2208
Closes #2202

🤖 Generated with [Claude Code](https://claude.com/claude-code)