### PR TITLE
fix(web): left bower shows effective trump suit + fix Moon exchange morph (#2204, #2214)

### DIFF
--- a/tests/e2e/hosted_play/conftest.py
+++ b/tests/e2e/hosted_play/conftest.py
@@ -23,7 +23,7 @@ from bid_euchre.hosted_play.state import MatchState
 from bid_euchre.strategy.base import Strategy
 from bid_euchre.strategy.bidding import BidAction, BiddingObservation, BiddingPolicy
 from web.routes import _build_seat_bids
-from web.template_filters import display_rank, effective_suit
+from web.template_filters import display_rank, effective_suit, is_bower
 
 # ---------------------------------------------------------------------------
 # Deterministic AI stubs
@@ -109,6 +109,7 @@ def jinja_env() -> jinja2.Environment:
     )
     environment.filters["display_rank"] = display_rank
     environment.filters["effective_suit"] = effective_suit
+    environment.filters["is_bower"] = is_bower
     return environment
 
 

--- a/tests/unit/hosted_play/test_bid_outcome_matrix.py
+++ b/tests/unit/hosted_play/test_bid_outcome_matrix.py
@@ -22,7 +22,7 @@ import jinja2
 import pytest
 
 from bid_euchre.scoring import compute_points
-from web.template_filters import display_rank, effective_suit
+from web.template_filters import display_rank, effective_suit, is_bower
 
 # ---------------------------------------------------------------------------
 # Template environment
@@ -48,6 +48,7 @@ def jinja_env():
     )
     environment.filters["display_rank"] = display_rank
     environment.filters["effective_suit"] = effective_suit
+    environment.filters["is_bower"] = is_bower
     return environment
 
 

--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -11,7 +11,7 @@ import os
 import jinja2
 import pytest
 
-from web.template_filters import display_rank, effective_suit
+from web.template_filters import display_rank, effective_suit, is_bower
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -37,6 +37,7 @@ def env():
     )
     environment.filters["display_rank"] = display_rank
     environment.filters["effective_suit"] = effective_suit
+    environment.filters["is_bower"] = is_bower
     return environment
 
 
@@ -3185,6 +3186,250 @@ class TestTrickHistory:
         )
         assert 'role="region"' in html
         assert 'aria-label="Cards played history"' in html
+
+
+# ---------------------------------------------------------------------------
+# Bower suit display — left bower shows effective trump suit (#2204)
+# ---------------------------------------------------------------------------
+
+
+class TestBowerDisplay:
+    """Verify bower cards show effective trump suit + badge across all partials.
+
+    The left bower (J of same-colour off-suit) must display the trump suit,
+    not its physical suit.  A bower badge ("B") must be present.
+    Refs: #2204, #2158, #2180.
+    """
+
+    # -- trick.html: played card in trick area --
+
+    def test_left_bower_played_card_shows_trump_suit(self, env):
+        """Left bower in trick card_slot shows trump suit (effective), not physical."""
+        tmpl = env.get_template("partials/trick.html")
+        # J♠ played in a clubs contract — left bower of clubs
+        html = tmpl.render(
+            current_trick={
+                "leader": 1,
+                "plays": [[1, ["H", "A"]], [0, ["S", "J"]]],
+            },
+            completed_tricks=[],
+            dealer_seat=3,
+            bidder_seat=0,
+            current_seat=2,
+            sitting_out_seat=None,
+            tricks_team0=0,
+            tricks_team1=0,
+            contract_type="suit",
+            trump="C",
+        )
+        # The played card should show clubs (♣), not spades (♠)
+        assert "card--clubs" in html
+        assert "card--bower" in html
+        assert "bower-badge" in html.lower() or "bower" in html.lower()
+
+    def test_right_bower_played_card_shows_trump_suit(self, env):
+        """Right bower in trick card_slot shows trump suit (trivially correct)."""
+        tmpl = env.get_template("partials/trick.html")
+        # J♣ played in a clubs contract — right bower
+        html = tmpl.render(
+            current_trick={
+                "leader": 0,
+                "plays": [[0, ["C", "J"]]],
+            },
+            completed_tricks=[],
+            dealer_seat=3,
+            bidder_seat=0,
+            current_seat=1,
+            sitting_out_seat=None,
+            tricks_team0=0,
+            tricks_team1=0,
+            contract_type="suit",
+            trump="C",
+        )
+        assert "card--clubs" in html
+        assert "card--bower" in html
+
+    def test_non_bower_jack_no_badge(self, env):
+        """Non-bower J does not get a bower badge."""
+        tmpl = env.get_template("partials/trick.html")
+        # J♦ played in a clubs contract — not a bower (different color)
+        html = tmpl.render(
+            current_trick={
+                "leader": 0,
+                "plays": [[0, ["D", "J"]]],
+            },
+            completed_tricks=[],
+            dealer_seat=3,
+            bidder_seat=0,
+            current_seat=1,
+            sitting_out_seat=None,
+            tricks_team0=0,
+            tricks_team1=0,
+            contract_type="suit",
+            trump="C",
+        )
+        assert "card--diamonds" in html
+        assert "card--bower" not in html
+
+    # -- hand.html: card in player's hand --
+
+    def test_left_bower_in_hand_shows_trump_suit(self, env):
+        """Left bower in the hand shows trump suit and bower badge."""
+        tmpl = env.get_template("partials/hand.html")
+        # J♦ in a hearts contract — left bower of hearts
+        html = tmpl.render(
+            link_uuid="test-uuid",
+            turn_number=0,
+            human_hand=[["D", "J"], ["H", "A"]],
+            legal_plays=None,
+            phase="trick_play",
+            contract_type="suit",
+            trump="H",
+        )
+        # The J♦ card should show hearts (♥), not diamonds (♦)
+        assert "card--hearts" in html
+        assert "card--bower" in html
+        assert "bower" in html.lower()
+
+    def test_left_bower_legal_card_shows_trump_suit(self, env):
+        """Left bower as a legal play button shows trump suit."""
+        tmpl = env.get_template("partials/hand.html")
+        # J♠ legal in a clubs contract — left bower
+        html = tmpl.render(
+            link_uuid="test-uuid",
+            turn_number=5,
+            human_hand=[["S", "J"]],
+            legal_plays=[0],
+            phase="trick_play",
+            contract_type="suit",
+            trump="C",
+        )
+        # Should show clubs suit, with bower badge
+        assert "card--clubs" in html
+        assert "card--bower" in html
+        assert "(left bower)" in html
+
+    def test_hand_no_bower_without_trump(self, env):
+        """No bower badge when trump is not set (e.g. auction phase)."""
+        tmpl = env.get_template("partials/hand.html")
+        html = tmpl.render(
+            link_uuid="test-uuid",
+            turn_number=0,
+            human_hand=[["S", "J"]],
+            legal_plays=None,
+            phase="auction",
+        )
+        assert "card--bower" not in html
+
+    # -- trick_history.html: card in history table --
+
+    def test_left_bower_in_history_shows_trump_suit(self, env):
+        """Left bower in trick history shows trump suit."""
+        tmpl = env.get_template("partials/trick_history.html")
+        # J♠ in a clubs contract — left bower
+        html = tmpl.render(
+            completed_tricks=[
+                {
+                    "leader": 0,
+                    "plays": [
+                        [0, ["S", "J"]],  # left bower of clubs
+                        [1, ["C", "A"]],
+                        [2, ["C", "K"]],
+                        [3, ["C", "Q"]],
+                    ],
+                    "winner": 0,
+                },
+            ],
+            tricks_team0=1,
+            tricks_team1=0,
+            contract_type="suit",
+            trump="C",
+        )
+        # Should show ♣ for the left bower, not ♠
+        assert "\u2663" in html  # ♣
+        assert "bower-sup" in html
+
+    # -- moon_exchange.html: exchanged cards --
+
+    def test_left_bower_in_exchange_shows_trump_suit(self, env):
+        """Left bower in moon exchange given cards shows trump suit."""
+        tmpl = env.get_template("partials/moon_exchange.html")
+        html = tmpl.render(
+            bidder_seat=0,
+            exchange_given=[["S", "J"]],  # left bower of clubs
+            exchange_received=[["C", "A"]],
+            contract_type="suit",
+            trump="C",
+            link_uuid="test-uuid",
+            human_hand=[["C", "K"], ["C", "Q"]],
+        )
+        assert "card--clubs" in html
+        assert "card--bower" in html
+
+    # -- moon_exchange_select.html: selectable cards --
+
+    def test_left_bower_in_exchange_select_shows_trump_suit(self, env):
+        """Left bower in moon exchange selection shows trump suit."""
+        tmpl = env.get_template("partials/moon_exchange_select.html")
+        html = tmpl.render(
+            bidder_seat=0,
+            contract_type="suit",
+            trump="C",
+            link_uuid="test-uuid",
+            human_hand=[["S", "J"], ["C", "A"]],  # left bower + A♣
+            exchange_prompt="Choose 2 cards",
+            is_mooner=True,
+        )
+        assert "card--clubs" in html
+        assert "card--bower" in html
+
+
+class TestIsBowerFilter:
+    """Unit tests for the is_bower template filter."""
+
+    def test_left_bower(self):
+        assert is_bower(["S", "J"], "C", "suit") == "left"
+
+    def test_right_bower(self):
+        assert is_bower(["C", "J"], "C", "suit") == "right"
+
+    def test_non_bower_jack(self):
+        assert is_bower(["D", "J"], "C", "suit") == ""
+
+    def test_non_jack(self):
+        assert is_bower(["C", "A"], "C", "suit") == ""
+
+    def test_no_trump(self):
+        assert is_bower(["S", "J"], None, "suit") == ""
+
+    def test_high_contract(self):
+        assert is_bower(["S", "J"], "C", "high") == ""
+
+    def test_low_contract(self):
+        assert is_bower(["S", "J"], "C", "low") == ""
+
+
+# ---------------------------------------------------------------------------
+# Moon exchange morph — bid panel uses innerHTML swap (#2214)
+# ---------------------------------------------------------------------------
+
+
+class TestBidPanelSwapMode:
+    """Verify bid_panel uses innerHTML swap (not morph) to avoid TypeError (#2214)."""
+
+    def test_bid_panel_uses_innerhtml_swap(self, env):
+        """The bid panel form uses hx-swap='innerHTML' not 'morph:innerHTML'."""
+        tmpl = env.get_template("partials/bid_panel.html")
+        html = tmpl.render(
+            link_uuid="test-uuid",
+            turn_number=0,
+            auction=[],
+            current_high_bid=0,
+            dealer_seat=3,
+            bid_type="regular",
+        )
+        assert 'hx-swap="innerHTML"' in html
+        assert "morph" not in html
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/hosted_play/test_scoring_matrix.py
+++ b/tests/unit/hosted_play/test_scoring_matrix.py
@@ -16,7 +16,7 @@ import jinja2
 import pytest
 
 from bid_euchre.scoring import compute_points
-from web.template_filters import display_rank, effective_suit
+from web.template_filters import display_rank, effective_suit, is_bower
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -42,6 +42,7 @@ def env():
     )
     environment.filters["display_rank"] = display_rank
     environment.filters["effective_suit"] = effective_suit
+    environment.filters["is_bower"] = is_bower
     return environment
 
 

--- a/web/app.py
+++ b/web/app.py
@@ -37,7 +37,7 @@ from .db import (
     make_session_factory,
 )
 from .routes import router as game_router
-from .template_filters import display_rank, effective_suit
+from .template_filters import display_rank, effective_suit, is_bower
 
 logger = logging.getLogger(__name__)
 
@@ -164,6 +164,8 @@ async def lifespan(app: FastAPI):
     templates.env.filters["display_rank"] = display_rank
     # Custom filter: effective_suit resolves bower suits in suit contracts
     templates.env.filters["effective_suit"] = effective_suit
+    # Custom filter: is_bower returns 'left', 'right', or '' for bower status
+    templates.env.filters["is_bower"] = is_bower
 
     # 7. Stash on app.state for route access
     app.state.config = config

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -259,6 +259,34 @@ main {
     animation: winning-card-pulse 2s ease-in-out infinite;
 }
 
+/* Bower badge — small "B" indicator on bower cards (#2204) */
+.card--bower {
+    position: relative;
+}
+
+.card__bower-badge {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    font-size: 0.55rem;
+    font-weight: 700;
+    line-height: 1;
+    background: var(--color-trump, #ffd700);
+    color: #000;
+    border-radius: 3px;
+    padding: 1px 3px;
+    pointer-events: none;
+    opacity: 0.9;
+}
+
+/* Inline bower superscript in trick history */
+.bower-sup {
+    font-size: 0.65em;
+    font-weight: 700;
+    color: var(--color-trump, #ffd700);
+    margin-left: 1px;
+}
+
 /* "X is winning" text below the trick center during active tricks */
 .trick-current-winner {
     font-size: 0.85rem;

--- a/web/template_filters.py
+++ b/web/template_filters.py
@@ -10,6 +10,8 @@ from typing import Optional
 
 from bid_euchre.core.cards import Card
 from bid_euchre.core.cards import effective_suit as _effective_suit
+from bid_euchre.core.cards import is_left_bower as _is_left_bower
+from bid_euchre.core.cards import is_right_bower as _is_right_bower
 
 
 def display_rank(rank: str) -> str:
@@ -41,3 +43,30 @@ def effective_suit(
     """
     suit, rank = card[0], card[1]
     return _effective_suit(Card(suit, rank), trump, contract_type or "suit")
+
+
+def is_bower(
+    card: list[str],
+    trump: Optional[str] = None,
+    contract_type: Optional[str] = None,
+) -> str:
+    """Return ``'left'``, ``'right'``, or ``''`` indicating bower status.
+
+    In suit contracts, the right bower is the J of trump, and the left bower
+    is the J of the same-colour off-suit.  Returns an empty string for
+    non-bower cards or non-suit contracts.
+
+    Usage in Jinja2::
+
+        {% set bower = card|is_bower(trump, contract_type) %}
+        {% if bower %}...{% endif %}
+    """
+    if not trump or (contract_type or "suit") != "suit":
+        return ""
+    suit, rank = card[0], card[1]
+    c = Card(suit, rank)
+    if _is_right_bower(c, trump):
+        return "right"
+    if _is_left_bower(c, trump):
+        return "left"
+    return ""

--- a/web/templates/partials/bid_panel.html
+++ b/web/templates/partials/bid_panel.html
@@ -64,7 +64,7 @@
           action="/play/{{ link_uuid }}/bid"
           hx-post="/play/{{ link_uuid }}/bid"
           hx-target="#game-board"
-          hx-swap="morph:innerHTML"
+          hx-swap="innerHTML"
           hx-timeout="15000"
           aria-label="Submit your bid">
         <input type="hidden" name="turn_number" value="{{ turn_number }}">

--- a/web/templates/partials/hand.html
+++ b/web/templates/partials/hand.html
@@ -17,29 +17,37 @@
             {% set suit = card[0] %}
             {% set rank = card[1] %}
             {% set idx = loop.index0 %}
-            {% set suit_class = suit_classes.get(suit, "spades") %}
-            {% set suit_sym = suit_symbols.get(suit, suit) %}
-            {% set suit_name = suit_names.get(suit, suit) %}
+            {% set disp_suit = card|effective_suit(trump | default(None, true), contract_type | default(None, true)) %}
+            {% set bower = card|is_bower(trump | default(None, true), contract_type | default(None, true)) %}
+            {% set suit_class = suit_classes.get(disp_suit, "spades") %}
+            {% set suit_sym = suit_symbols.get(disp_suit, disp_suit) %}
+            {% set suit_name = suit_names.get(disp_suit, disp_suit) %}
 
             {% if phase == "trick_play" and legal_plays is not none and idx in legal_plays %}
                 <button type="button"
                         id="hand-card-{{ idx }}"
-                        class="card card--{{ suit_class }} card--legal"
-                        title="{{ rank|display_rank }}{{ suit_sym }} (tap to play)"
-                        aria-label="Play {{ rank|display_rank }} of {{ suit_name }}"
+                        class="card card--{{ suit_class }} card--legal{% if bower %} card--bower{% endif %}"
+                        title="{{ rank|display_rank }}{{ suit_sym }}{% if bower %} ({{ bower }} bower){% endif %} (tap to play)"
+                        aria-label="Play {{ rank|display_rank }} of {{ suit_name }}{% if bower %} ({{ bower }} bower){% endif %}"
                         data-card-index="{{ idx }}">
                     <span class="card__rank" aria-hidden="true">{{ rank|display_rank }}</span>
                     <span class="card__suit" aria-hidden="true">{{ suit_sym }}</span>
+                    {% if bower %}
+                        <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">B</span>
+                    {% endif %}
                 </button>
             {% else %}
                 {# Illegal or non-play-phase card — plain div #}
                 <div id="hand-card-{{ idx }}"
-                     class="card card--{{ suit_class }}{% if phase == 'trick_play' %} card--illegal{% endif %}"
-                     title="{{ rank|display_rank }}{{ suit_sym }}"
+                     class="card card--{{ suit_class }}{% if phase == 'trick_play' %} card--illegal{% endif %}{% if bower %} card--bower{% endif %}"
+                     title="{{ rank|display_rank }}{{ suit_sym }}{% if bower %} ({{ bower }} bower){% endif %}"
                      role="img"
-                     aria-label="{{ rank|display_rank }} of {{ suit_name }}{% if phase == 'trick_play' %} (cannot play){% endif %}">
+                     aria-label="{{ rank|display_rank }} of {{ suit_name }}{% if bower %} ({{ bower }} bower){% endif %}{% if phase == 'trick_play' %} (cannot play){% endif %}">
                     <span class="card__rank" aria-hidden="true">{{ rank|display_rank }}</span>
                     <span class="card__suit" aria-hidden="true">{{ suit_sym }}</span>
+                    {% if bower %}
+                        <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">B</span>
+                    {% endif %}
                 </div>
             {% endif %}
         {% endfor %}

--- a/web/templates/partials/moon_exchange.html
+++ b/web/templates/partials/moon_exchange.html
@@ -46,12 +46,16 @@
                 </h3>
                 <div class="moon-exchange__card-list" role="list">
                     {% for card in exchange_given_cards %}
-                        {% set suit = card[0] %}
-                        <div class="card card--{{ suit_classes.get(suit, 'spades') }} card--exchange"
+                        {% set disp_suit = card|effective_suit(trump | default(None, true), contract_type | default(None, true)) %}
+                        {% set bower = card|is_bower(trump | default(None, true), contract_type | default(None, true)) %}
+                        <div class="card card--{{ suit_classes.get(disp_suit, 'spades') }} card--exchange{% if bower %} card--bower{% endif %}"
                              role="listitem"
-                             aria-label="{{ card[1]|display_rank }} of {{ suit_names.get(suit, suit) }}">
+                             aria-label="{{ card[1]|display_rank }} of {{ suit_names.get(disp_suit, disp_suit) }}{% if bower %} ({{ bower }} bower){% endif %}">
                             <span class="card__rank" aria-hidden="true">{{ card[1]|display_rank }}</span>
-                            <span class="card__suit" aria-hidden="true">{{ suit_symbols.get(suit, suit) }}</span>
+                            <span class="card__suit" aria-hidden="true">{{ suit_symbols.get(disp_suit, disp_suit) }}</span>
+                            {% if bower %}
+                                <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">B</span>
+                            {% endif %}
                         </div>
                     {% endfor %}
                 </div>
@@ -65,12 +69,16 @@
                 </h3>
                 <div class="moon-exchange__card-list" role="list">
                     {% for card in exchange_received_cards %}
-                        {% set suit = card[0] %}
-                        <div class="card card--{{ suit_classes.get(suit, 'spades') }} card--exchange card--exchange-received"
+                        {% set disp_suit = card|effective_suit(trump | default(None, true), contract_type | default(None, true)) %}
+                        {% set bower = card|is_bower(trump | default(None, true), contract_type | default(None, true)) %}
+                        <div class="card card--{{ suit_classes.get(disp_suit, 'spades') }} card--exchange card--exchange-received{% if bower %} card--bower{% endif %}"
                              role="listitem"
-                             aria-label="{{ card[1]|display_rank }} of {{ suit_names.get(suit, suit) }}">
+                             aria-label="{{ card[1]|display_rank }} of {{ suit_names.get(disp_suit, disp_suit) }}{% if bower %} ({{ bower }} bower){% endif %}">
                             <span class="card__rank" aria-hidden="true">{{ card[1]|display_rank }}</span>
-                            <span class="card__suit" aria-hidden="true">{{ suit_symbols.get(suit, suit) }}</span>
+                            <span class="card__suit" aria-hidden="true">{{ suit_symbols.get(disp_suit, disp_suit) }}</span>
+                            {% if bower %}
+                                <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">B</span>
+                            {% endif %}
                         </div>
                     {% endfor %}
                 </div>
@@ -84,12 +92,16 @@
             <h3 class="moon-exchange__group-title">Your Hand</h3>
             <div class="moon-exchange__card-list" role="list">
                 {% for card in human_hand %}
-                    {% set suit = card[0] %}
-                    <div class="card card--{{ suit_classes.get(suit, 'spades') }} card--hand"
+                    {% set disp_suit = card|effective_suit(trump | default(None, true), contract_type | default(None, true)) %}
+                    {% set bower = card|is_bower(trump | default(None, true), contract_type | default(None, true)) %}
+                    <div class="card card--{{ suit_classes.get(disp_suit, 'spades') }} card--hand{% if bower %} card--bower{% endif %}"
                          role="listitem"
-                         aria-label="{{ card[1]|display_rank }} of {{ suit_names.get(suit, suit) }}">
+                         aria-label="{{ card[1]|display_rank }} of {{ suit_names.get(disp_suit, disp_suit) }}{% if bower %} ({{ bower }} bower){% endif %}">
                         <span class="card__rank" aria-hidden="true">{{ card[1]|display_rank }}</span>
-                        <span class="card__suit" aria-hidden="true">{{ suit_symbols.get(suit, suit) }}</span>
+                        <span class="card__suit" aria-hidden="true">{{ suit_symbols.get(disp_suit, disp_suit) }}</span>
+                        {% if bower %}
+                            <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">B</span>
+                        {% endif %}
                     </div>
                 {% endfor %}
             </div>

--- a/web/templates/partials/moon_exchange_select.html
+++ b/web/templates/partials/moon_exchange_select.html
@@ -45,16 +45,21 @@
                 {% set suit = card[0] %}
                 {% set rank = card[1] %}
                 {% set idx = loop.index0 %}
-                {% set suit_class = suit_classes.get(suit, "spades") %}
-                {% set suit_sym = suit_symbols.get(suit, suit) %}
-                {% set suit_name = suit_names.get(suit, suit) %}
+                {% set disp_suit = card|effective_suit(trump | default(None, true), contract_type | default(None, true)) %}
+                {% set bower = card|is_bower(trump | default(None, true), contract_type | default(None, true)) %}
+                {% set suit_class = suit_classes.get(disp_suit, "spades") %}
+                {% set suit_sym = suit_symbols.get(disp_suit, disp_suit) %}
+                {% set suit_name = suit_names.get(disp_suit, disp_suit) %}
                 <button type="button"
-                        class="card card--{{ suit_class }} card--exchange-selectable"
-                        title="{{ rank|display_rank }}{{ suit_sym }} (tap to select)"
-                        aria-label="Select {{ rank|display_rank }} of {{ suit_name }}"
+                        class="card card--{{ suit_class }} card--exchange-selectable{% if bower %} card--bower{% endif %}"
+                        title="{{ rank|display_rank }}{{ suit_sym }}{% if bower %} ({{ bower }} bower){% endif %} (tap to select)"
+                        aria-label="Select {{ rank|display_rank }} of {{ suit_name }}{% if bower %} ({{ bower }} bower){% endif %}"
                         data-exchange-index="{{ idx }}">
                     <span class="card__rank" aria-hidden="true">{{ rank|display_rank }}</span>
                     <span class="card__suit" aria-hidden="true">{{ suit_sym }}</span>
+                    {% if bower %}
+                        <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">B</span>
+                    {% endif %}
                 </button>
             {% endfor %}
         </div>

--- a/web/templates/partials/trick.html
+++ b/web/templates/partials/trick.html
@@ -55,13 +55,17 @@
 {% macro card_slot(seat, fallback_class="card-slot--empty", show_label=true) %}
     {% if seat in ns.cards %}
         {% set card = ns.cards[seat] %}
-        {% set suit = card[0] %}
+        {% set disp_suit = card|effective_suit(trump | default(None, true), contract_type | default(None, true)) %}
+        {% set bower = card|is_bower(trump | default(None, true), contract_type | default(None, true)) %}
         {% set is_winning = (current_trick is not none and trick_winning_seat is defined and trick_winning_seat == seat) %}
-        <div class="card card--{{ suit_classes.get(suit, 'spades') }} card--played{% if is_winning %} card--winning{% endif %}"
+        <div class="card card--{{ suit_classes.get(disp_suit, 'spades') }} card--played{% if is_winning %} card--winning{% endif %}{% if bower %} card--bower{% endif %}"
              role="img"
-             aria-label="{{ seat_labels[seat] }} played {{ card[1]|display_rank }} of {{ suit_names.get(suit, suit) }}{% if is_winning %} (currently winning){% endif %}">
+             aria-label="{{ seat_labels[seat] }} played {{ card[1]|display_rank }} of {{ suit_names.get(disp_suit, disp_suit) }}{% if bower %} ({{ bower }} bower){% endif %}{% if is_winning %} (currently winning){% endif %}">
             <span class="card__rank" aria-hidden="true">{{ card[1]|display_rank }}</span>
-            <span class="card__suit" aria-hidden="true">{{ suit_symbols.get(suit, suit) }}</span>
+            <span class="card__suit" aria-hidden="true">{{ suit_symbols.get(disp_suit, disp_suit) }}</span>
+            {% if bower %}
+                <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">B</span>
+            {% endif %}
         </div>
     {% else %}
         <div class="{{ fallback_class }}" aria-label="{{ seat_labels[seat] }} waiting to play">
@@ -136,8 +140,9 @@
                 {{ seat_labels[display_winner] if display_winner in seat_labels else ("Seat " ~ display_winner) }}
             {% endif %}
             won{% if winning_card %} with
-                <span class="card-text card-text--{{ suit_classes.get(winning_card[0], 'spades') }}"
-                      aria-label="{{ winning_card[1]|display_rank }} of {{ suit_names.get(winning_card[0], winning_card[0]) }}">{{ suit_symbols.get(winning_card[0], winning_card[0]) }}{{ winning_card[1]|display_rank }}</span>{% endif %}
+                {% set wc_suit = winning_card|effective_suit(trump | default(None, true), contract_type | default(None, true)) %}
+                <span class="card-text card-text--{{ suit_classes.get(wc_suit, 'spades') }}"
+                      aria-label="{{ winning_card[1]|display_rank }} of {{ suit_names.get(wc_suit, wc_suit) }}">{{ suit_symbols.get(wc_suit, wc_suit) }}{{ winning_card[1]|display_rank }}</span>{% endif %}
         </p>
     {% endif %}
 </div>

--- a/web/templates/partials/trick_history.html
+++ b/web/templates/partials/trick_history.html
@@ -36,8 +36,9 @@
                             <td class="trick-history__cell{% if seat == trick.winner %} trick-history__cell--winner{% endif %}{% if seat == trick.leader %} trick-history__cell--leader{% endif %}">
                                 {% if seat in ns.cards %}
                                     {% set card = ns.cards[seat] %}
-                                    {% set suit = card[0] %}
-                                    <span class="card--inline">{{ card[1]|display_rank }}{{ suit_symbols.get(suit, suit) }}</span>
+                                    {% set disp_suit = card|effective_suit(trump | default(None, true), contract_type | default(None, true)) %}
+                                    {% set bower = card|is_bower(trump | default(None, true), contract_type | default(None, true)) %}
+                                    <span class="card--inline{% if bower %} card--inline-bower{% endif %}">{{ card[1]|display_rank }}{{ suit_symbols.get(disp_suit, disp_suit) }}{% if bower %}<sup class="bower-sup" title="{{ bower|capitalize }} bower">B</sup>{% endif %}</span>
                                 {% else %}
                                     <span class="trick-history__absent" aria-label="Sitting out">&mdash;</span>
                                 {% endif %}


### PR DESCRIPTION
## Summary

- **Left bower card display (#2204):** Bower cards now show their effective trump suit
  (not physical suit) in all card display locations — player hand, trick area, trick
  history, and moon exchange partials. A "B" bower badge visually indicates bower status.
- **Moon exchange morph TypeError (#2214):** Changed bid panel `hx-swap` from
  `morph:innerHTML` to `innerHTML` to prevent JS TypeError when transitioning from
  auction DOM to structurally different moon exchange DOM.

## Why

During playtest, left bowers displayed their physical suit (e.g. J♠ showed ♠) while the
lead suit heading correctly showed the effective trump suit (e.g. ♣). This disconnect
confused players. The Moon exchange morph error occurred because HTMX morph couldn't
reconcile the fundamentally different DOM structures between auction and moon exchange.

## Changes

| File | Change |
|------|--------|
| `web/template_filters.py` | Added `is_bower` filter (returns 'left', 'right', or '') |
| `web/app.py` | Register `is_bower` filter on Jinja2 environment |
| `web/templates/partials/trick.html` | Use `effective_suit` + bower badge in card_slot macro and winning card |
| `web/templates/partials/hand.html` | Use `effective_suit` + bower badge for all hand cards |
| `web/templates/partials/trick_history.html` | Use `effective_suit` + bower superscript in history table |
| `web/templates/partials/moon_exchange.html` | Use `effective_suit` + bower badge for exchange cards |
| `web/templates/partials/moon_exchange_select.html` | Use `effective_suit` + bower badge for selectable cards |
| `web/templates/partials/bid_panel.html` | Changed `hx-swap` from `morph:innerHTML` to `innerHTML` |
| `web/static/style.css` | Added `.card--bower`, `.card__bower-badge`, `.bower-sup` styles |
| 4 test files | Register `is_bower` filter; 17 new tests for bower display + swap mode |

## Repro / Validation

```bash
# Run all hosted_play tests (3359 pass)
uv run python -m pytest tests/unit/hosted_play/ tests/e2e/hosted_play/ --no-header -q

# Run just the new bower + morph tests
uv run python -m pytest tests/unit/hosted_play/test_partials.py -k "Bower or IsBower or BidPanelSwap" -v
```

## Tests

- `make check-quiet` passes (3 unrelated pre-existing failures in token_economy/telegram_filter)
- 200 partial template tests pass (183 existing + 17 new)
- 3359 total hosted_play tests pass

## Worktree proof

```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

Closes #2204
Closes #2214

🤖 Generated with [Claude Code](https://claude.com/claude-code)