### PR TITLE
fix(web): hide declarer markers and trick heading during auction (#2203, #2206)

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -1953,6 +1953,169 @@ class TestGameBoardSeatZeroRegression:
         assert "A:10" in html  # Ace (seat 2)
         assert "D:10" in html  # Deuce (seat 3)
 
+    def test_declarer_marker_hidden_during_auction(self, env):
+        """Declarer ★ markers must not appear during auction phase (#2203).
+
+        When a player has placed a bid during the auction, bidder_seat is set
+        to their seat, but the ★ Declarer marker should only render after the
+        auction is complete (during trick_play).
+        """
+        tmpl = env.get_template("partials/game_board.html")
+        html = tmpl.render(
+            phase="auction",
+            link_uuid="test-uuid",
+            dealer_seat=0,
+            bidder_seat=2,  # seat 2 has the current high bid during auction
+            current_seat=3,
+            sitting_out_seat=None,
+            current_trick=None,
+            completed_tricks=[],
+            human_hand=[["S", "A"], ["H", "Q"]],
+            auction=[[1, 5], [2, 6]],
+            contract_type=None,
+            trump=None,
+            bid_type=None,
+            winning_bid=6,
+            current_high_bid=6,
+            tricks_team0=0,
+            tricks_team1=0,
+            score_human=0,
+            score_ai=0,
+            hands_played=0,
+            legal_plays=None,
+            opp_left_count=10,
+            partner_count=10,
+            opp_right_count=10,
+            show_next=False,
+            next_reason=None,
+            show_bid_panel=False,
+            action_rail=[],
+        )
+        # Declarer marker must NOT appear on any seat during auction.
+        # The icon legend contains a decorative "seat-marker--declarer"
+        # with aria-hidden="true" — that's always present. We check that
+        # no *active* declarer marker (with title="Declarer") appears.
+        assert 'title="Declarer"' not in html
+        # Dealer marker SHOULD still appear
+        assert "seat-marker--dealer" in html
+
+    def test_declarer_marker_shown_during_trick_play(self, env):
+        """Declarer ★ markers appear normally during trick play (#2203)."""
+        tmpl = env.get_template("partials/game_board.html")
+        html = tmpl.render(
+            phase="trick_play",
+            link_uuid="test-uuid",
+            dealer_seat=0,
+            bidder_seat=2,
+            current_seat=1,
+            sitting_out_seat=None,
+            current_trick={"leader": 1, "plays": [[1, ["H", "K"]]]},
+            completed_tricks=[],
+            human_hand=[["S", "A"], ["H", "Q"]],
+            auction=[],
+            contract_type="suit",
+            trump="H",
+            bid_type="regular",
+            winning_bid=6,
+            current_high_bid=6,
+            tricks_team0=0,
+            tricks_team1=0,
+            score_human=0,
+            score_ai=0,
+            hands_played=0,
+            legal_plays=None,
+            opp_left_count=10,
+            partner_count=10,
+            opp_right_count=10,
+            show_next=False,
+            next_reason=None,
+            show_bid_panel=False,
+            action_rail=[],
+        )
+        # Declarer marker SHOULD appear during trick play
+        assert "seat-marker--declarer" in html
+        assert 'title="Declarer"' in html
+
+    def test_trick_heading_hidden_during_auction(self, env):
+        """'Trick N of 10' heading must not appear during auction (#2206).
+
+        The trick area partial should only render during trick play, not
+        during the auction phase where it would misleadingly show
+        'Trick 1 of 10'.
+        """
+        tmpl = env.get_template("partials/game_board.html")
+        html = tmpl.render(
+            phase="auction",
+            link_uuid="test-uuid",
+            dealer_seat=3,
+            bidder_seat=-1,
+            current_seat=0,
+            sitting_out_seat=None,
+            current_trick=None,
+            completed_tricks=[],
+            human_hand=[["S", "A"]],
+            auction=[],
+            contract_type=None,
+            trump=None,
+            bid_type=None,
+            winning_bid=0,
+            current_high_bid=0,
+            tricks_team0=0,
+            tricks_team1=0,
+            score_human=0,
+            score_ai=0,
+            hands_played=0,
+            legal_plays=None,
+            opp_left_count=10,
+            partner_count=10,
+            opp_right_count=10,
+            show_next=False,
+            next_reason=None,
+            show_bid_panel=True,
+            turn_number=0,
+            action_rail=[],
+        )
+        # Trick heading must NOT appear during auction
+        assert "Trick 1 of 10" not in html
+        assert "trick-area" not in html
+
+    def test_trick_heading_shown_during_trick_play(self, env):
+        """'Trick N of 10' heading appears normally during trick play (#2206)."""
+        tmpl = env.get_template("partials/game_board.html")
+        html = tmpl.render(
+            phase="trick_play",
+            link_uuid="test-uuid",
+            dealer_seat=0,
+            bidder_seat=1,
+            current_seat=2,
+            sitting_out_seat=None,
+            current_trick={"leader": 1, "plays": [[1, ["H", "K"]]]},
+            completed_tricks=[],
+            human_hand=[["S", "A"], ["H", "Q"]],
+            auction=[],
+            contract_type="suit",
+            trump="H",
+            bid_type="regular",
+            winning_bid=5,
+            current_high_bid=5,
+            tricks_team0=0,
+            tricks_team1=0,
+            score_human=0,
+            score_ai=0,
+            hands_played=0,
+            legal_plays=None,
+            opp_left_count=10,
+            partner_count=10,
+            opp_right_count=10,
+            show_next=False,
+            next_reason=None,
+            show_bid_panel=False,
+            action_rail=[],
+        )
+        # Trick heading SHOULD appear during trick play
+        assert "Trick 1 of 10" in html
+        assert "trick-area" in html
+
 
 # ---------------------------------------------------------------------------
 # contract_bar.html — sticky contract info bar during trick play

--- a/web/templates/partials/game_board.html
+++ b/web/templates/partials/game_board.html
@@ -39,21 +39,21 @@
         <span class="ai-badge" aria-label="{{ seat_labels[1] }}: {{ opp_left_count | default(0) }} cards">
             {{ seat_labels[1][0] }}:{{ opp_left_count | default(0) }}
             {%- if dealer_seat == 1 %}<span class="seat-marker seat-marker--dealer" title="Dealer">D</span>{% endif -%}
-            {%- if bidder_seat == 1 %}<span class="seat-marker seat-marker--declarer" title="Declarer">★</span>{% endif -%}
+            {%- if phase != "auction" and bidder_seat == 1 %}<span class="seat-marker seat-marker--declarer" title="Declarer">★</span>{% endif -%}
             {%- if current_seat == 1 %}<span class="seat-marker seat-marker--turn" title="Current turn">▶</span>{% endif -%}
             {%- if sitting_out_seat == 1 %}<span class="seat-marker seat-marker--sitting-out" title="Sitting out">SO</span>{% endif -%}
         </span>
         <span class="ai-badge" aria-label="{{ seat_labels[2] }}: {{ partner_count | default(0) }} cards">
             {{ seat_labels[2][0] }}:{{ partner_count | default(0) }}
             {%- if dealer_seat == 2 %}<span class="seat-marker seat-marker--dealer" title="Dealer">D</span>{% endif -%}
-            {%- if bidder_seat == 2 %}<span class="seat-marker seat-marker--declarer" title="Declarer">★</span>{% endif -%}
+            {%- if phase != "auction" and bidder_seat == 2 %}<span class="seat-marker seat-marker--declarer" title="Declarer">★</span>{% endif -%}
             {%- if current_seat == 2 %}<span class="seat-marker seat-marker--turn" title="Current turn">▶</span>{% endif -%}
             {%- if sitting_out_seat == 2 %}<span class="seat-marker seat-marker--sitting-out" title="Sitting out">SO</span>{% endif -%}
         </span>
         <span class="ai-badge" aria-label="{{ seat_labels[3] }}: {{ opp_right_count | default(0) }} cards">
             {{ seat_labels[3][0] }}:{{ opp_right_count | default(0) }}
             {%- if dealer_seat == 3 %}<span class="seat-marker seat-marker--dealer" title="Dealer">D</span>{% endif -%}
-            {%- if bidder_seat == 3 %}<span class="seat-marker seat-marker--declarer" title="Declarer">★</span>{% endif -%}
+            {%- if phase != "auction" and bidder_seat == 3 %}<span class="seat-marker seat-marker--declarer" title="Declarer">★</span>{% endif -%}
             {%- if current_seat == 3 %}<span class="seat-marker seat-marker--turn" title="Current turn">▶</span>{% endif -%}
             {%- if sitting_out_seat == 3 %}<span class="seat-marker seat-marker--sitting-out" title="Sitting out">SO</span>{% endif -%}
         </span>
@@ -70,7 +70,7 @@
                     {% if dealer_seat == 2 %}
                         <span class="seat-marker seat-marker--dealer" title="Dealer">D</span>
                     {% endif %}
-                    {% if bidder_seat == 2 %}
+                    {% if phase != "auction" and bidder_seat == 2 %}
                         <span class="seat-marker seat-marker--declarer" title="Declarer">★</span>
                     {% endif %}
                     {% if current_seat == 2 %}
@@ -100,7 +100,7 @@
                     {% if dealer_seat == 1 %}
                         <span class="seat-marker seat-marker--dealer" title="Dealer">D</span>
                     {% endif %}
-                    {% if bidder_seat == 1 %}
+                    {% if phase != "auction" and bidder_seat == 1 %}
                         <span class="seat-marker seat-marker--declarer" title="Declarer">★</span>
                     {% endif %}
                     {% if current_seat == 1 %}
@@ -129,11 +129,13 @@
                 {% include "partials/contract_bar.html" %}
             {% endif %}
 
-            {# Trick area — always shown during active play #}
-            {% include "partials/trick.html" %}
+            {# Trick area — shown during trick play only (not during auction) #}
+            {% if phase != "auction" %}
+                {% include "partials/trick.html" %}
 
-            {# Collapsible trick history — shows cards played in completed tricks #}
-            {% include "partials/trick_history.html" %}
+                {# Collapsible trick history — shows cards played in completed tricks #}
+                {% include "partials/trick_history.html" %}
+            {% endif %}
 
             {% if show_next %}
                 {% include "partials/next_controls.html" %}
@@ -153,7 +155,7 @@
                     {% if dealer_seat == 3 %}
                         <span class="seat-marker seat-marker--dealer" title="Dealer">D</span>
                     {% endif %}
-                    {% if bidder_seat == 3 %}
+                    {% if phase != "auction" and bidder_seat == 3 %}
                         <span class="seat-marker seat-marker--declarer" title="Declarer">★</span>
                     {% endif %}
                     {% if current_seat == 3 %}


### PR DESCRIPTION
## Plan
N/A — bug fix for playtest findings

## Summary
- Gate declarer (★) markers in compact badges and compass seat labels with `phase != "auction"` so they only appear during trick play
- Gate `trick.html` and `trick_history.html` includes to skip auction phase, preventing misleading "Trick 1 of 10" heading
- Add 4 template rendering tests for both fixes (positive and negative)

## Why
During the auction phase, the game board was prematurely showing declarer markers on seats and rendering "Trick 1 of 10" before any tricks started. Both were misleading to players.

Closes #2203
Closes #2206

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_partials.py -k "auction or declarer or trick_heading" --no-header -q
```

## Test Criteria
- **Pass condition:** Declarer markers absent during auction, present during trick play; trick heading absent during auction, present during trick play
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_partials.py -k "declarer_marker_hidden or trick_heading_hidden or declarer_marker_shown or trick_heading_shown" -v`
- **Expected result:** 4 tests pass, specifically:
  - `test_declarer_marker_hidden_during_auction` — `title="Declarer"` not in rendered auction HTML
  - `test_declarer_marker_shown_during_trick_play` — `title="Declarer"` present in trick_play HTML
  - `test_trick_heading_hidden_during_auction` — `Trick 1 of 10` not in rendered auction HTML
  - `test_trick_heading_shown_during_trick_play` — `Trick 1 of 10` present in trick_play HTML

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_partials.py` — 187 passed
- [x] `uv run python -m pytest tests/unit/hosted_play/` — 3317 passed, 5 skipped
- [x] `ruff check . && ruff format --check tests/unit/hosted_play/test_partials.py` — clean

## Expected impact
- Metrics impact: None
- Runtime impact: None — template-only changes

## Risk level
- [x] Low (template phase guards only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git worktree list` (relevant line):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c   a4731d7b [fix/template-phase-guards]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)