### PR TITLE
fix(web): standardize score display + highlight current player on leaderboard

### DIFF
--- a/tests/unit/hosted_play/test_leaderboard.py
+++ b/tests/unit/hosted_play/test_leaderboard.py
@@ -1227,3 +1227,64 @@ class TestMetricDefinitions:
             assert len(m.full_label) >= len(
                 m.label
             ), f"{key}: full_label {m.full_label!r} shorter than label {m.label!r}"
+
+
+# ---------------------------------------------------------------------------
+# Current player highlight (#2224)
+# ---------------------------------------------------------------------------
+
+
+class TestLeaderboardCurrentPlayerHighlight:
+    """Verify the current player's row is highlighted on the leaderboard."""
+
+    @pytest.fixture()
+    def app_and_client(self, tmp_path):
+        from starlette.testclient import TestClient
+
+        from tests.unit.hosted_play.conftest import make_hosted_play_test_config
+        from web.app import create_app
+
+        config = make_hosted_play_test_config(tmp_path)
+        app = create_app(config)
+        with TestClient(app) as client:
+            yield app, client
+
+    def test_current_player_row_has_highlight_class(self, app_and_client):
+        """The current player's row gets the leaderboard-row--current class."""
+        app, client = app_and_client
+        session = app.state.session_factory()
+        try:
+            player = _make_player(session, nickname="HighlightMe")
+            match = _make_match(session, player, score_human=52, score_ai=20)
+            _make_hand(session, match, points_team0=5, points_team1=2)
+            session.commit()
+
+            resp = client.get(f"/leaderboard/{player.link_uuid}")
+            assert resp.status_code == 200
+            assert "leaderboard-row--current" in resp.text
+            assert 'aria-current="true"' in resp.text
+        finally:
+            session.close()
+
+    def test_other_player_row_has_no_highlight(self, app_and_client):
+        """Other players' rows do not get the highlight class."""
+        app, client = app_and_client
+        session = app.state.session_factory()
+        try:
+            player1 = _make_player(session, nickname="Player1")
+            player2 = _make_player(session, nickname="Player2")
+            match1 = _make_match(session, player1, score_human=52, score_ai=20)
+            _make_hand(session, match1, points_team0=5, points_team1=2)
+            match2 = _make_match(session, player2, score_human=52, score_ai=30)
+            _make_hand(session, match2, points_team0=3, points_team1=4)
+            session.commit()
+
+            # View as player1 — only player1's row should be highlighted
+            resp = client.get(f"/leaderboard/{player1.link_uuid}")
+            assert resp.status_code == 200
+            # Exactly one <tr> should have the highlight class (CSS block also
+            # contains the string, so count on the attribute pattern instead)
+            assert resp.text.count('class="leaderboard-row--current"') == 1
+            assert resp.text.count('aria-current="true"') == 1
+        finally:
+            session.close()

--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -3559,3 +3559,73 @@ class TestDisplayRankFilter:
         assert ">Q<" in html
         assert ">K<" in html
         assert ">A<" in html
+
+
+# ---------------------------------------------------------------------------
+# Score display consistency (#2212)
+# ---------------------------------------------------------------------------
+
+
+class TestScoreDisplayConsistency:
+    """Verify score-value spans appear on hand-result and match-result pages."""
+
+    def test_hand_result_match_score_has_score_value_spans(self, env):
+        """Hand result match score line uses structured score-value spans."""
+        tmpl = env.get_template("partials/hand_result.html")
+        html = tmpl.render(
+            winning_bid=6,
+            bidder_seat=0,
+            contract_type="suit",
+            trump="S",
+            tricks_team0=7,
+            tricks_team1=3,
+            points_team0=7,
+            points_team1=3,
+            score_human=7,
+            score_ai=3,
+            hands_played=1,
+        )
+        assert "score-value" in html
+        assert "score--positive" in html
+
+    def test_hand_result_negative_score_has_negative_class(self, env):
+        """Negative match score renders with score--negative class."""
+        tmpl = env.get_template("partials/hand_result.html")
+        html = tmpl.render(
+            winning_bid=8,
+            bidder_seat=0,
+            contract_type="suit",
+            trump="H",
+            tricks_team0=5,
+            tricks_team1=5,
+            points_team0=-8,
+            points_team1=5,
+            score_human=-8,
+            score_ai=5,
+            hands_played=1,
+        )
+        assert "score--negative" in html
+
+    def test_match_result_score_has_positive_class(self, env):
+        """Match result final score uses score--positive for winning score."""
+        tmpl = env.get_template("partials/match_result.html")
+        html = tmpl.render(
+            link_uuid="x",
+            winner="human",
+            score_human=55,
+            score_ai=30,
+            hands_played=12,
+        )
+        assert "score--positive" in html
+
+    def test_match_result_negative_score_has_negative_class(self, env):
+        """Match result renders score--negative for negative final score."""
+        tmpl = env.get_template("partials/match_result.html")
+        html = tmpl.render(
+            link_uuid="x",
+            winner="ai",
+            score_human=-5,
+            score_ai=52,
+            hands_played=10,
+        )
+        assert "score--negative" in html

--- a/web/routes.py
+++ b/web/routes.py
@@ -1652,6 +1652,7 @@ async def leaderboard(request: Request, link_uuid: str):
                 "link_uuid": link_uuid,
                 "current_page": "leaderboard",
                 "nickname": player.nickname,
+                "current_player_id": player.id,
                 "rankings": rankings,
                 "metric_defs": METRIC_DEFINITIONS,
                 "format_metric": format_metric,

--- a/web/templates/leaderboard.html
+++ b/web/templates/leaderboard.html
@@ -86,6 +86,15 @@
         background: var(--color-surface-light);
     }
 
+    .leaderboard__table tbody tr.leaderboard-row--current {
+        background: rgba(255, 255, 255, 0.05);
+        border-left: 3px solid var(--color-moon);
+    }
+
+    .leaderboard__table tbody tr.leaderboard-row--current:hover {
+        background: rgba(255, 255, 255, 0.08);
+    }
+
     .leaderboard__table .rank-col { width: 2.5rem; }
     .leaderboard__table .name-col { min-width: 8rem; }
     .leaderboard__table .primary-col {
@@ -226,7 +235,7 @@
             </thead>
             <tbody>
                 {% for entry in rankings %}
-                <tr>
+                <tr{% if entry.player_id == current_player_id %} class="leaderboard-row--current" aria-current="true"{% endif %}>
                     <td class="rank-col">{{ loop.index }}</td>
                     <td class="name-col">{{ entry.nickname or "Anonymous" }}{% if entry.is_ai %}<span class="leaderboard__ai-badge" title="AI opponent">AI</span>{% endif %}</td>
                     {% for key, m in metric_defs.items() %}

--- a/web/templates/partials/hand_result.html
+++ b/web/templates/partials/hand_result.html
@@ -140,7 +140,11 @@
     </div>
 
     <div class="result-match-score">
-        <p>Match score: You {{ score_human }} &mdash; AI {{ score_ai }}</p>
+        <p>Match score:
+            You <span class="score-value{% if score_human >= 0 %} score--positive{% else %} score--negative{% endif %}">{{ score_human }}</span>
+            &mdash;
+            AI <span class="score-value{% if score_ai >= 0 %} score--positive{% else %} score--negative{% endif %}">{{ score_ai }}</span>
+        </p>
         <p class="hands-count">Hands played: {{ hands_played }}</p>
     </div>
 

--- a/web/templates/partials/match_result.html
+++ b/web/templates/partials/match_result.html
@@ -20,11 +20,11 @@
         <table class="score-table">
             <tr>
                 <td>Your team:</td>
-                <td class="score-final">{{ score_human }}</td>
+                <td class="score-final{% if score_human >= 0 %} score--positive{% else %} score--negative{% endif %}">{{ score_human }}</td>
             </tr>
             <tr>
                 <td>AI team:</td>
-                <td class="score-final">{{ score_ai }}</td>
+                <td class="score-final{% if score_ai >= 0 %} score--positive{% else %} score--negative{% endif %}">{{ score_ai }}</td>
             </tr>
         </table>
         <p class="hands-count">Hands played: {{ hands_played }}</p>


### PR DESCRIPTION
## Summary

- **#2212 — Standardize score display:** Add structured `score-value` spans with `score--positive`/`score--negative` CSS classes to the hand-result match score line and match-result final score table, matching the active-play score bar pattern.
- **#2224 — Highlight current player on leaderboard:** Pass `current_player_id` from the route handler to the leaderboard template. Add a `leaderboard-row--current` CSS class with subtle background highlight and left border accent. Includes `aria-current="true"` for accessibility.

## Why

Score display was inconsistent across game phases — the active-play score bar used structured semantic spans while the hand-result and match-result pages used plain text. The leaderboard had no visual differentiation for the current player's row, requiring users to scan all rows.

## Repro / Validation

```bash
# Run web tests
uv run python -m pytest tests/unit/hosted_play/ --no-header -q
# 3333 passed, 6 skipped

# Specific new tests
uv run python -m pytest tests/unit/hosted_play/test_partials.py::TestScoreDisplayConsistency tests/unit/hosted_play/test_leaderboard.py::TestLeaderboardCurrentPlayerHighlight -v
# 6 passed
```

## Tests

- `make check-quiet` — 11024 passed, 3 pre-existing failures (test_ops_token_economy, test_telegram_filter — unrelated platform ops tests)
- 4 new tests for score display consistency (hand-result positive/negative, match-result positive/negative)
- 2 new tests for leaderboard current player highlight (highlight present, uniqueness)

## Worktree proof

```
pwd: Bid-Euchre-steward-brws-author-c
branch: fix/ui-polish-score-leaderboard
```

## Files changed

| File | Change |
|------|--------|
| `web/templates/partials/hand_result.html` | Add `score-value` + `score--positive`/`score--negative` spans to match score line |
| `web/templates/partials/match_result.html` | Add `score--positive`/`score--negative` classes to `score-final` cells |
| `web/templates/leaderboard.html` | Add `leaderboard-row--current` CSS + conditional class on current player's `<tr>` |
| `web/routes.py` | Pass `current_player_id` to leaderboard template context |
| `tests/unit/hosted_play/test_partials.py` | 4 new tests for score display consistency |
| `tests/unit/hosted_play/test_leaderboard.py` | 2 new tests for current player highlight |

Closes #2212, closes #2224

🤖 Generated with [Claude Code](https://claude.com/claude-code)