### PR TITLE
ops: add durable skills for ops/review crons + update VS Code workspace (#2226, #2227)

### DIFF
--- a/.claude/skills/check-reviews/SKILL.md
+++ b/.claude/skills/check-reviews/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: check-reviews
+description: Checks for merged PRs needing post-merge review, runs the review driver on unreviewed PRs, and updates the high-water mark. Use from the review lane via durable cron (/loop 10m /check-reviews).
+---
+
+# /check-reviews -- Review Lane PR Sweep
+
+Check for recently merged PRs that need post-merge review, run the review
+driver on any unreviewed PRs, and update the high-water mark. Designed for
+durable cron invocation (`/loop 10m /check-reviews`) that survives `/clear`.
+
+## When to Use
+
+- You are the review lane and need to run a periodic review sweep
+- The orchestrator has set up `/loop 10m /check-reviews` as a durable cron
+- After a `/clear`, the review lane needs to resume its review duties
+- You want a one-shot check of unreviewed merged PRs
+
+## Arguments
+
+None. Uses sensible defaults for production review sweeps.
+
+## Workflow
+
+### Step 1 -- Check for unreviewed merged PRs
+
+```bash
+uv run python scripts/internal/ops.py review-check --limit 10
+```
+
+This scans recently merged PRs and identifies those that:
+- Have no post-merge review verdict on file
+- Were merged since the last high-water mark
+- Touch code paths (not docs/plans-only)
+
+### Step 2 -- Run the review driver on each unreviewed PR
+
+For each PR identified in Step 1, the review driver runs:
+
+```bash
+python scripts/internal/review_driver.py --pr <N> --trigger post-merge
+```
+
+The review driver performs:
+- **Deterministic prechecks:** C1/C2/C5/N1/N2/N3/T1/X2/X3 pattern checks
+- **Codex CLI review:** `codex review --base main` (if available)
+- **Auto-fix:** Applies deterministic fixes for convention patterns
+- **Verdict writing:** Records pass/block/warn verdict to review queue
+- **Status publishing:** Updates the advisory `reviewing-changes` status
+- **Follow-up issues:** Creates GitHub issues for non-blocking findings
+
+### Step 3 -- Update the high-water mark
+
+After processing all identified PRs, the high-water mark is updated so the
+next cycle only checks newer merges.
+
+### Step 4 -- Report findings
+
+If any PRs had blocking findings, send an alert:
+
+```bash
+uv run python scripts/internal/ops.py message send \
+  --from review --to orchestrator --type supervisor_alert \
+  --priority high \
+  --summary "Post-merge review: PR #NNN has blocking findings"
+```
+
+For non-blocking findings, the review driver creates follow-up issues
+automatically.
+
+## Manual Review of a Specific PR
+
+To manually review a specific PR (outside the cron cycle):
+
+```bash
+# Check review queue state
+uv run python scripts/internal/ops.py queue
+
+# Run review driver on a specific PR
+python scripts/internal/review_driver.py --pr <N> --trigger manual
+
+# Check verdict
+cat .claude/runtime/review_queue/pr_<N>/verdict.json
+```
+
+## Durable Cron Setup
+
+The review lane should run this skill on a repeating schedule:
+
+```
+/loop 10m /check-reviews
+```
+
+This survives `/clear` because the skill is registered in `.claude/skills/`
+and the cron job references it by name.
+
+## Gotchas
+
+- This skill is for the **review lane only**. Other lanes should not run
+  review sweeps.
+- The review driver has a 15-minute max runtime per PR. If multiple PRs are
+  queued, they are processed sequentially.
+- Codex CLI requires a ChatGPT subscription. If unavailable, the driver falls
+  back to deterministic prechecks only.
+- Permission prompts can stall the review lane. The skill handles this
+  gracefully by using only registered CLI commands.
+- Docs/plans-only PRs are skipped (no code to review).
+
+## References
+
+- `scripts/internal/review_driver.py` -- canonical review coordinator
+- `scripts/internal/ops.py review-check` -- merged PR scanner
+- `.claude/rules/deferred/60_review_gate.md` -- review gate rules and verdicts
+- `.claude/skills/monitor-pr/SKILL.md` -- single-PR health check (ops lane)

--- a/.claude/skills/fleet-check/SKILL.md
+++ b/.claude/skills/fleet-check/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: fleet-check
+description: Consolidated orchestrator cron — polls inbox, checks CPU load, detects task completions, dispatches new work, and runs a full check-in cycle. Use via durable cron (/loop 8m /fleet-check).
+---
+
+# /fleet-check -- Orchestrator Consolidated Cron
+
+Single consolidated skill for the orchestrator's periodic duties. Replaces
+the previous pattern of three separate cron jobs (CPU check, analyst completion
+check, and `/check-in`). Designed for durable cron invocation
+(`/loop 8m /fleet-check`) that survives `/clear`.
+
+## When to Use
+
+- You are the orchestrator and need a single durable cron for fleet management
+- After a `/clear`, the orchestrator needs to resume periodic duties
+- You want to consolidate scattered monitoring into one invocation
+
+## Arguments
+
+None. Runs all sub-checks in sequence.
+
+## Workflow
+
+This skill runs the following checks in order. Each step is independent --
+a failure in one step does not block subsequent steps.
+
+### Step 1 -- Inbox Poll (MANDATORY FIRST)
+
+**Always poll the inbox first.** This is the only channel through which ops,
+authors, and the review lane can escalate to the orchestrator.
+
+```bash
+uv run python scripts/internal/ops.py inbox --lane orchestrator --status pending --include-native --prioritized
+```
+
+Process messages by priority tier:
+- **P0** (`supervisor_alert`, `recovery`): Handle immediately
+- **P1** (`completion`, `escalation`, `blocker`): Process and ack
+- **P2** (`ack`, `progress`): Note and ack
+
+Ack all processed messages:
+```bash
+uv run python scripts/internal/ops.py inbox ack <MSG_ID> --lane orchestrator
+```
+
+### Step 2 -- CPU Load Check
+
+Check system CPU load and park lanes if overloaded:
+
+```bash
+# Check load average
+sysctl -n vm.loadavg 2>/dev/null || uptime
+
+# If load > threshold (e.g., > 8 on 10-core), consider parking a lane:
+# uv run python scripts/internal/ops.py lane park <lane-id>
+```
+
+### Step 3 -- Task Completion Check
+
+Check for completed tasks and dispatch new work:
+
+```bash
+# Check task queue for completed items
+uv run python scripts/internal/ops.py task list
+
+# Check fleet status for idle lanes
+uv run python scripts/internal/ops.py fleet
+```
+
+For each completed task:
+1. Verify the PR was merged (or note if still open)
+2. Update any governing plan checkpoints
+3. Identify the next dispatchable task
+
+For each idle lane:
+1. Check if there are approved task packets in the queue
+2. Dispatch if scope is clear and lane is healthy
+
+### Step 4 -- Full Check-In
+
+Run the standard check-in cycle for situational awareness:
+
+```bash
+# Lane health via dashboard
+uv run python scripts/internal/ops.py dashboard
+
+# Open PRs status
+gh pr list --state open --json number,title,headRefName --limit 20
+
+# Any stuck lanes
+# (Use /capture-pane --stuck if needed)
+```
+
+### Step 5 -- Remote Status Update (Optional)
+
+If operator away-mode is active and Telegram is configured, push a status
+summary:
+
+```bash
+uv run python scripts/internal/ops.py away --check
+```
+
+If away, the monitor cycle (run by ops lane) handles Telegram push. The
+orchestrator only needs to ensure the ops lane is running.
+
+## Durable Cron Setup
+
+The orchestrator should run this skill on a repeating schedule:
+
+```
+/loop 8m /fleet-check
+```
+
+This replaces the previous three-cron pattern:
+- ~~`/loop 12m` CPU-aware fleet check~~ -> Step 2
+- ~~`/loop 6m` analyst completion check~~ -> Step 3
+- ~~`/loop 8m /check-in`~~ -> Steps 1 + 4
+
+## Gotchas
+
+- **Inbox first, always.** The 2026-03-24 overnight run proved that skipping
+  the inbox causes 25+ HIGH alerts to go unread for hours.
+- This skill is for the **orchestrator only**. Ops uses `/monitor`, review
+  uses `/check-reviews`.
+- If CPU load is high, park flex lanes first (they are lowest priority).
+- Task dispatch should respect scope isolation -- never dispatch two tasks
+  that touch overlapping file patterns to different lanes.
+- Keep the check cycle under 2 minutes to avoid overlapping with the next
+  cron invocation.
+
+## References
+
+- `.claude/skills/check-in/SKILL.md` -- the original check-in skill (now
+  subsumed by Step 1 + Step 4 of this skill)
+- `.claude/skills/monitor/SKILL.md` -- ops lane monitoring (complementary)
+- `.claude/skills/delegate-task/SKILL.md` -- task dispatch workflow
+- `.claude/skills/lane-status/SKILL.md` -- lane health assessment

--- a/.claude/skills/inbox-poll/SKILL.md
+++ b/.claude/skills/inbox-poll/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: inbox-poll
+description: Lightweight inbox check for any lane — reads pending messages, processes orchestrator directives, and acks. Use when a lane needs to check for new assignments or alerts without a full monitoring sweep.
+---
+
+# /inbox-poll -- Lane Inbox Check
+
+Lightweight skill for any lane to check its inbox for orchestrator messages.
+Designed for quick, low-overhead invocation -- no fleet-wide scanning, no
+GitHub API calls, just inbox read + ack.
+
+## When to Use
+
+- Any lane needs to check for new orchestrator assignments
+- A lane has been idle and wants to see if work was dispatched
+- After a `/clear`, a lane needs to pick up any missed messages
+- As a building block for other skills that need inbox awareness
+
+## Arguments
+
+- `[lane-id]` (optional) -- The lane to check. If omitted, infers from the
+  current worktree directory name or `CLAUDE_AGENT_NAME` env var.
+
+## Workflow
+
+### Step 1 -- Determine lane identity
+
+```bash
+# Auto-detect from env or directory
+LANE="${CLAUDE_AGENT_NAME:-$(basename "$CLAUDE_PROJECT_DIR" | sed 's/Bid-Euchre-steward-//')}"
+echo "Polling inbox for: $LANE"
+```
+
+### Step 2 -- Read pending messages
+
+```bash
+uv run python scripts/internal/ops.py inbox --lane <LANE> --status pending --include-native
+```
+
+### Step 3 -- Process messages by type
+
+| Message Type | Action |
+|-------------|--------|
+| `assignment` | New task dispatched -- invoke `/start-task <packet_id>` |
+| `supervisor_alert` | Urgent -- read and act immediately |
+| `recovery` | Lane recovery directive -- follow instructions |
+| `blocker` | Another lane is blocked on you -- prioritize |
+| `progress` | Info only -- note and ack |
+| `ack` | Confirmation -- ack |
+| `completion` | Task completed -- ack |
+
+### Step 4 -- Ack processed messages
+
+```bash
+uv run python scripts/internal/ops.py inbox ack <MSG_ID> --lane <LANE>
+```
+
+Or bulk-ack old messages:
+```bash
+uv run python scripts/internal/ops.py inbox ack --bulk --max-age 1h --lane <LANE>
+```
+
+## Quick One-Liner
+
+For a fast inbox check without the full skill workflow:
+
+```bash
+uv run python scripts/internal/ops.py inbox --lane <LANE> --status pending
+```
+
+## Gotchas
+
+- This skill does NOT run monitoring, fleet checks, or GitHub API calls.
+  It is inbox-only, designed to be fast (<5s).
+- The `--include-native` flag imports Claude native inbox messages into the
+  message bus. Always include it to avoid missing messages.
+- If no messages are pending, report "Inbox empty" and return -- do not
+  escalate or create busywork.
+- Lane identity detection falls back to directory name parsing if
+  `CLAUDE_AGENT_NAME` is not set.
+
+## References
+
+- `scripts/internal/ops.py inbox` -- inbox CLI implementation
+- `.claude/skills/start-task/SKILL.md` -- task bootstrap (invoked on assignment)
+- `.claude/skills/check-in/SKILL.md` -- orchestrator check-in (uses inbox poll
+  as mandatory first step)

--- a/.claude/skills/monitor/SKILL.md
+++ b/.claude/skills/monitor/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: monitor
+description: Runs a single ops monitoring cycle — lane health, stall detection, alert push, and fleet reconciliation. Use from the ops lane via durable cron (/loop 8m /monitor).
+---
+
+# /monitor -- Ops Monitoring Cycle
+
+Run a single ops monitoring sweep: check lane health, detect stalls, push
+alerts, and reconcile fleet state. Designed for durable cron invocation
+(`/loop 8m /monitor`) that survives `/clear`.
+
+## When to Use
+
+- You are the ops lane and need to run a periodic monitoring sweep
+- The orchestrator has set up `/loop 8m /monitor` as a durable cron
+- You want a one-shot health sweep of the fleet
+- After a `/clear`, the ops lane needs to resume monitoring
+
+## Arguments
+
+None. All options use sensible defaults for production monitoring.
+
+For testing/debugging, invoke the CLI directly with flags:
+```bash
+uv run python scripts/internal/ops.py monitor --skip-pr-check --no-notify
+```
+
+## Workflow
+
+### Step 1 -- Run the monitoring cycle
+
+```bash
+uv run python scripts/internal/ops.py monitor
+```
+
+This single command performs all monitoring sub-tasks:
+- **Lane health scan:** Checks all registered worktrees for dirty state, stale
+  branches, and inactive sessions
+- **PR status check:** Queries GitHub for open PRs and their CI/review status
+- **Stall detection:** Identifies lanes with permission prompts or stuck
+  processes, attempts auto-recovery (re-nudge)
+- **Alert push:** Sends supervisor alerts for critical findings and pushes
+  urgent alerts via Telegram (if configured)
+- **Fleet reconciliation:** Updates `fleet_status.json` controller projection
+  with current lane states, task assignments, and health metrics
+- **Auto-dispatch:** Dispatches approved task packets to idle lanes (if any
+  are queued)
+
+### Step 2 -- Interpret findings
+
+The monitor outputs a structured summary:
+
+| Finding Type | Severity | Action |
+|-------------|----------|--------|
+| Lane stall (permission prompt) | HIGH | Auto-recovery attempted; escalate if retry fails |
+| PR CI failure | MEDIUM | Report to orchestrator inbox |
+| Lane idle > 30min | LOW | Candidate for new task dispatch |
+| Telegram push failure | LOW | Logged; retry next cycle |
+
+### Step 3 -- Escalate if needed
+
+If critical findings are detected, the monitor sends supervisor alerts to the
+orchestrator inbox automatically. For manual escalation:
+
+```bash
+uv run python scripts/internal/ops.py message send \
+  --from ops --to orchestrator --type supervisor_alert \
+  --priority high \
+  --summary "Monitor found: <description>"
+```
+
+## CLI Flags Reference
+
+| Flag | Effect |
+|------|--------|
+| `--skip-pr-check` | Skip `gh pr list` (for offline/testing) |
+| `--no-notify` | Don't send findings to orchestrator inbox |
+| `--no-recovery` | Report stalls but don't attempt re-nudge |
+| `--no-auto-dispatch` | Don't dispatch queued tasks to idle lanes |
+| `--no-reconcile` | Skip fleet_status.json update |
+| `--no-push` | Disable Telegram alert push |
+
+## Durable Cron Setup
+
+The ops lane should run this skill on a repeating schedule:
+
+```
+/loop 8m /monitor
+```
+
+This survives `/clear` because the skill is registered in `.claude/skills/`
+and the cron job references it by name, not by inline command.
+
+## Gotchas
+
+- This skill is for the **ops lane only**. The orchestrator uses `/fleet-check`
+  or `/check-in` for its own monitoring.
+- The monitor cycle takes 10-30s depending on fleet size and GitHub API latency.
+- If `gh` CLI is not authenticated, `--skip-pr-check` avoids blocking the
+  entire cycle.
+- Telegram push requires `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` env vars.
+
+## References
+
+- `scripts/internal/ops.py monitor` -- CLI implementation
+- `.claude/skills/check-in/SKILL.md` -- orchestrator-side periodic check
+- `.claude/skills/fleet-check/SKILL.md` -- orchestrator consolidated cron
+- `.claude/rules/deferred/60_review_gate.md` -- review status context

--- a/Bid-Euchre-agent-audit.code-workspace
+++ b/Bid-Euchre-agent-audit.code-workspace
@@ -5,60 +5,76 @@
       "path": "."
     },
     {
-      "name": "analyst-a",
-      "path": "../Bid-Euchre-steward-analyst"
-    },
-    {
-      "name": "author-a",
-      "path": "../Bid-Euchre-steward-author"
-    },
-    {
-      "name": "author-b",
-      "path": "../Bid-Euchre-steward-author-b"
-    },
-    {
-      "name": "author-c",
-      "path": "../Bid-Euchre-steward-author-c"
-    },
-    {
-      "name": "author-d",
-      "path": "../Bid-Euchre-steward-author-d"
-    },
-    {
-      "name": "browser-a",
-      "path": "../Bid-Euchre-steward-brws-author-a"
-    },
-    {
-      "name": "browser-b",
-      "path": "../Bid-Euchre-steward-brws-author-b"
-    },
-    {
-      "name": "browser-c",
-      "path": "../Bid-Euchre-steward-brws-author-c"
-    },
-    {
-      "name": "browser-d",
-      "path": "../Bid-Euchre-steward-brws-author-d"
-    },
-    {
-      "name": "flex-a",
-      "path": "../Bid-Euchre-steward-flex-a"
-    },
-    {
-      "name": "flex-b",
-      "path": "../Bid-Euchre-steward-flex-b"
-    },
-    {
-      "name": "flex-c",
-      "path": "../Bid-Euchre-steward-flex-c"
-    },
-    {
-      "name": "ops",
+      "name": "orchestrator/ops [control]",
       "path": "../Bid-Euchre-steward-ops"
     },
     {
-      "name": "review",
+      "name": "review [control]",
       "path": "../Bid-Euchre-steward-review"
+    },
+    {
+      "name": "author-a [platform]",
+      "path": "../Bid-Euchre-steward-author"
+    },
+    {
+      "name": "author-b [platform]",
+      "path": "../Bid-Euchre-steward-author-b"
+    },
+    {
+      "name": "author-c [platform]",
+      "path": "../Bid-Euchre-steward-author-c"
+    },
+    {
+      "name": "author-d [platform]",
+      "path": "../Bid-Euchre-steward-author-d"
+    },
+    {
+      "name": "brws-author-a [browser]",
+      "path": "../Bid-Euchre-steward-brws-author-a"
+    },
+    {
+      "name": "brws-author-b [browser]",
+      "path": "../Bid-Euchre-steward-brws-author-b"
+    },
+    {
+      "name": "brws-author-c [browser]",
+      "path": "../Bid-Euchre-steward-brws-author-c"
+    },
+    {
+      "name": "brws-author-d [browser]",
+      "path": "../Bid-Euchre-steward-brws-author-d"
+    },
+    {
+      "name": "analyst-a [analyst]",
+      "path": "../Bid-Euchre-steward-analyst"
+    },
+    {
+      "name": "analyst-b [analyst]",
+      "path": "../Bid-Euchre-steward-analyst-b"
+    },
+    {
+      "name": "analyst-c [analyst]",
+      "path": "../Bid-Euchre-steward-analyst-c"
+    },
+    {
+      "name": "analyst-d [analyst]",
+      "path": "../Bid-Euchre-steward-analyst-d"
+    },
+    {
+      "name": "flex-a [flex]",
+      "path": "../Bid-Euchre-steward-flex-a"
+    },
+    {
+      "name": "flex-b [flex]",
+      "path": "../Bid-Euchre-steward-flex-b"
+    },
+    {
+      "name": "flex-c [flex]",
+      "path": "../Bid-Euchre-steward-flex-c"
+    },
+    {
+      "name": "flex-d [flex]",
+      "path": "../Bid-Euchre-steward-flex-d"
     }
   ],
   "settings": {
@@ -120,9 +136,11 @@
       "charliermarsh.ruff",
       "ms-python.python",
       "eamodio.gitlens",
+      "mhutchie.git-graph",
       "redhat.vscode-yaml",
       "tamasfe.even-better-toml",
-      "samuelcolvin.jinjahtml"
+      "samuelcolvin.jinjahtml",
+      "alexcvzz.vscode-sqlite"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Register 4 new durable skills (`/monitor`, `/check-reviews`, `/fleet-check`, `/inbox-poll`) that survive `/clear` for cron invocation
- Update VS Code workspace to cover all 19 steward worktree folders (was 15), add pool tags to folder names, add Git Graph + SQLite Viewer extensions

## Why
Ops and review lane cron loops repeatedly break after `/clear` because the ad-hoc commands lose registration. Durable skills in `.claude/skills/` are discovered automatically by the Claude Code harness. The workspace was also missing analyst-b/c/d and flex-d worktrees (#2227).

Closes #2226, closes #2227.

## Changes

### New skills (#2226)
| Skill | Lane | Purpose |
|-------|------|---------|
| `/monitor` | ops | Single monitoring cycle: lane health, stall detection, alert push, fleet reconciliation |
| `/check-reviews` | review | Post-merge review sweep: scan merged PRs, run review driver, update high-water mark |
| `/fleet-check` | orchestrator | Consolidated cron replacing 3 separate jobs: inbox poll, CPU check, dispatch, check-in |
| `/inbox-poll` | any | Lightweight inbox read + ack for any lane |

### VS Code workspace (#2227)
- Added 4 missing folders: `analyst-b`, `analyst-c`, `analyst-d`, `flex-d`
- Renamed all folders with pool tags (e.g., `author-a [platform]`, `brws-author-a [browser]`)
- Added extension recommendations: `mhutchie.git-graph`, `alexcvzz.vscode-sqlite`

## Repro / Validation
```bash
# Verify skills exist and have valid frontmatter
for skill in monitor check-reviews fleet-check inbox-poll; do
  head -3 .claude/skills/$skill/SKILL.md
done

# Verify workspace JSON is valid and has 19 folders
python3 -m json.tool Bid-Euchre-agent-audit.code-workspace > /dev/null
python3 -c "import json; ws=json.load(open('Bid-Euchre-agent-audit.code-workspace')); print(f'Folders: {len(ws[\"folders\"])}')"
```

## Tests
- Pre-commit hooks pass (repo-linter, trim whitespace, fix end of files)
- Workspace JSON validates cleanly
- All 4 skills visible in Claude Code skill registry after creation

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
branch: ops/skills-workspace
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)