### PR TITLE
fix(web): auction log persistence + 422 handler + stale match cleanup (#2207, #2219, #2211)

### DIFF
--- a/tests/unit/hosted_play/test_error_handling.py
+++ b/tests/unit/hosted_play/test_error_handling.py
@@ -126,6 +126,71 @@ class TestHTMXErrorResponses:
         assert 'role="alert"' in resp.text
 
 
+class TestValidationErrorHandler:
+    """Verify 422 (RequestValidationError) returns HTML for HTMX, JSON for API (#2219)."""
+
+    def test_422_htmx_returns_html_partial(self, client):
+        """HTMX request with missing form fields returns HTML error, not JSON."""
+        # POST to /bid without required form fields triggers RequestValidationError
+        link_uuid = str(uuid.uuid4())
+        # Create a player so the 404 guard doesn't fire first
+        session = client.app.state.session_factory()
+        try:
+            player = _create_player(session)
+            link_uuid = player.link_uuid
+            session.commit()
+        finally:
+            session.close()
+
+        resp = client.post(
+            f"/play/{link_uuid}/bid",
+            headers={"HX-Request": "true"},
+            # Intentionally missing required fields (turn_number, bid_n)
+        )
+        # HTMX partial returns 200 for swap
+        assert resp.status_code == 200
+        assert "htmx-error" in resp.text
+        assert "Invalid request" in resp.text
+        # Must NOT contain JSON
+        assert '"detail"' not in resp.text
+
+    def test_422_non_htmx_returns_json(self, client):
+        """Non-HTMX request with missing form fields returns JSON 422."""
+        link_uuid = str(uuid.uuid4())
+        session = client.app.state.session_factory()
+        try:
+            player = _create_player(session)
+            link_uuid = player.link_uuid
+            session.commit()
+        finally:
+            session.close()
+
+        resp = client.post(
+            f"/play/{link_uuid}/bid",
+            # No HX-Request header — standard API client
+        )
+        assert resp.status_code == 422
+        body = resp.json()
+        assert "detail" in body
+
+    def test_422_htmx_has_aria_alert(self, client):
+        """HTMX 422 partial includes role=alert for accessibility."""
+        session = client.app.state.session_factory()
+        try:
+            player = _create_player(session)
+            link_uuid = player.link_uuid
+            session.commit()
+        finally:
+            session.close()
+
+        resp = client.post(
+            f"/play/{link_uuid}/bid",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        assert 'role="alert"' in resp.text
+
+
 # ===================================================================
 # 2. Match State Deserialization Recovery
 # ===================================================================

--- a/tests/unit/hosted_play/test_hardening.py
+++ b/tests/unit/hosted_play/test_hardening.py
@@ -18,7 +18,12 @@ from starlette.testclient import TestClient
 
 from tests.unit.hosted_play.conftest import make_hosted_play_test_config
 from web.app import _run_self_test, create_app
-from web.cleanup import DEFAULT_MAX_MATCH_AGE, expire_stale_matches
+from web.cleanup import (
+    DEFAULT_MAX_MATCH_AGE,
+    PLAYER_STALE_MATCH_AGE,
+    expire_player_stale_matches,
+    expire_stale_matches,
+)
 from web.db import (
     Match,
     Player,
@@ -449,3 +454,100 @@ class TestStartupCleanup:
                 assert match.status == "abandoned"
             finally:
                 session.close()
+
+
+# ===================================================================
+# 4. Per-Player Stale Match Cleanup (#2211)
+# ===================================================================
+
+
+class TestPlayerStaleMatchCleanup:
+    """Per-player stale match cleanup on match creation."""
+
+    def test_expire_player_stale_matches_basic(self):
+        """Stale matches for a specific player are abandoned."""
+        engine = init_engine("sqlite:///:memory:")
+        create_tables(engine)
+        sf = make_session_factory(engine)
+        session = sf()
+
+        player = _create_player(session)
+        # Create a stale match (3 hours old — exceeds 2h threshold)
+        stale = _create_match(session, player.id)
+        stale.created_at = datetime.now(timezone.utc) - timedelta(hours=3)
+        # Create a fresh match (30 min old — within threshold)
+        fresh = _create_match(session, player.id)
+        fresh.created_at = datetime.now(timezone.utc) - timedelta(minutes=30)
+        session.commit()
+
+        count = expire_player_stale_matches(session, player.id)
+        session.commit()
+
+        assert count == 1
+        session.refresh(stale)
+        session.refresh(fresh)
+        assert stale.status == "abandoned"
+        assert fresh.status == "active"
+        session.close()
+
+    def test_expire_player_stale_only_affects_own_matches(self):
+        """Cleanup only affects the target player's matches."""
+        engine = init_engine("sqlite:///:memory:")
+        create_tables(engine)
+        sf = make_session_factory(engine)
+        session = sf()
+
+        player_a = _create_player(session)
+        player_b = _create_player(session)
+        # Both have stale matches
+        stale_a = _create_match(session, player_a.id)
+        stale_a.created_at = datetime.now(timezone.utc) - timedelta(hours=3)
+        stale_b = _create_match(session, player_b.id)
+        stale_b.created_at = datetime.now(timezone.utc) - timedelta(hours=3)
+        session.commit()
+
+        # Expire only player_a's matches
+        count = expire_player_stale_matches(session, player_a.id)
+        session.commit()
+
+        assert count == 1
+        session.refresh(stale_a)
+        session.refresh(stale_b)
+        assert stale_a.status == "abandoned"
+        assert stale_b.status == "active"  # Untouched
+        session.close()
+
+    def test_player_cleanup_default_threshold(self):
+        """Default threshold is 2 hours."""
+        assert PLAYER_STALE_MATCH_AGE == timedelta(hours=2)
+
+    def test_cleanup_runs_before_rate_limit_on_select_ai(self, tmp_path):
+        """Stale matches are cleaned up before rate limit check in select_ai (#2211)."""
+        db_path = tmp_path / "test.db"
+        db_url = f"sqlite:///{db_path}"
+
+        # Pre-populate: create a player with MAX active matches, all stale
+        db_engine = init_engine(db_url)
+        create_tables(db_engine)
+        sf = make_session_factory(db_engine)
+        session = sf()
+        player = _create_player(session)
+        for _ in range(MAX_ACTIVE_MATCHES_PER_PLAYER):
+            m = _create_match(session, player.id)
+            m.created_at = datetime.now(timezone.utc) - timedelta(hours=3)
+        session.commit()
+        link_uuid = player.link_uuid
+        session.close()
+        db_engine.dispose()
+
+        # Start the app and try to select AI — should succeed because stale
+        # matches are cleaned up before the rate limit check.
+        config = make_hosted_play_test_config(tmp_path, database_url=db_url)
+        app = create_app(config=config)
+        with TestClient(app) as client:
+            resp = client.post(
+                f"/play/{link_uuid}/select-ai",
+                data={"model_id": "bud_bot"},
+            )
+            # Should succeed (200), not be rate-limited (429)
+            assert resp.status_code == 200

--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -3588,3 +3588,42 @@ class TestTurnNumberConflict:
         )
         assert resp.status_code == 409
         assert "game-board" in resp.text
+
+
+class TestAuctionLogPersistence:
+    """Auction log preserves all entries across page refresh (#2207)."""
+
+    def test_auction_log_survives_page_refresh(self, client, app):
+        """Full auction log is shown after a full page GET refresh.
+
+        Verifies that the action rail built from persisted state includes
+        all auction entries — the first entry must not be lost (#2207).
+        """
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        _select_ai(client, link_uuid)
+
+        # Advance through the hidden auction reveals
+        state = advance_pending_reveals(client, app, link_uuid)
+        hand = state.current_hand
+        if hand is None:
+            pytest.skip("No hand available after reveal")
+
+        auction_count = len(hand.auction)
+        assert auction_count > 0, "Auction should have entries"
+
+        # Simulate a full page refresh (GET)
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+
+        # The action rail should contain ALL auction entries.
+        # Each entry produces a text like "Slim bid 5♠" or "You passed"
+        # Count how many auction-kind entries are in the response.
+        for entry in hand.auction:
+            seat = entry.get("seat")
+            seat_label = {0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}.get(
+                int(seat), f"Seat {seat}"
+            )
+            assert (
+                seat_label in resp.text
+            ), f"Auction entry for {seat_label} missing from page refresh response"

--- a/web/app.py
+++ b/web/app.py
@@ -17,9 +17,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import FastAPI, Request
-from fastapi.exceptions import HTTPException
+from fastapi.exceptions import HTTPException, RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.exc import IntegrityError
@@ -266,6 +266,33 @@ def create_app(config: HostedPlayConfig | None = None) -> FastAPI:
                 {"request": request}
             ),
             status_code=500,
+        )
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_error_handler(
+        request: Request, exc: RequestValidationError
+    ) -> HTMLResponse | JSONResponse:
+        """Return an HTML error for HTMX requests, JSON for API clients.
+
+        FastAPI's default 422 handler returns JSON, which HTMX swaps into
+        the game board as raw text.  This handler intercepts validation
+        errors and returns a user-friendly HTML partial for HTMX
+        requests (#2219).
+        """
+        if _is_htmx(request):
+            return HTMLResponse(
+                _error_templates.get_template("errors/htmx_error.html").render(
+                    {
+                        "request": request,
+                        "status_code": 422,
+                        "message": "Invalid request. Please refresh the page.",
+                    }
+                ),
+                status_code=200,
+            )
+        return JSONResponse(
+            {"detail": exc.errors()},
+            status_code=422,
         )
 
     return app

--- a/web/cleanup.py
+++ b/web/cleanup.py
@@ -19,6 +19,11 @@ logger = logging.getLogger(__name__)
 # Default threshold: matches active for more than 24 hours are abandoned.
 DEFAULT_MAX_MATCH_AGE = timedelta(hours=24)
 
+# Per-player on-create cleanup: abandon a player's matches idle for >2 hours
+# when they create a new one.  Shorter than the startup threshold because
+# this runs per-request and should catch recent orphans quickly (#2211).
+PLAYER_STALE_MATCH_AGE = timedelta(hours=2)
+
 
 def expire_stale_matches(
     session: Session,
@@ -55,5 +60,60 @@ def expire_stale_matches(
     count = len(stale)
     if count > 0:
         logger.info("Expired %d stale match(es) older than %s", count, max_age)
+
+    return count
+
+
+def expire_player_stale_matches(
+    session: Session,
+    player_id: int,
+    *,
+    max_age: timedelta = PLAYER_STALE_MATCH_AGE,
+) -> int:
+    """Abandon a specific player's active matches older than *max_age*.
+
+    Called when a player creates a new match to self-heal orphaned matches
+    from previous sessions (browser closed, network loss, etc.).  This
+    prevents the per-player rate limit from permanently blocking players
+    who accumulated abandoned matches (#2211).
+
+    Parameters
+    ----------
+    session:
+        An open SQLAlchemy session (caller is responsible for commit).
+    player_id:
+        The player whose matches to inspect.
+    max_age:
+        Maximum age for the player's active matches (default 2 hours).
+
+    Returns
+    -------
+    int
+        Number of matches expired for this player.
+    """
+    cutoff = datetime.now(timezone.utc) - max_age
+    stale = (
+        session.query(Match)
+        .filter(
+            Match.player_id == player_id,
+            Match.status == "active",
+            Match.created_at < cutoff,
+        )
+        .all()
+    )
+
+    now = datetime.now(timezone.utc)
+    for match in stale:
+        match.status = "abandoned"
+        match.completed_at = now
+
+    count = len(stale)
+    if count > 0:
+        logger.info(
+            "Expired %d stale match(es) for player %d (older than %s)",
+            count,
+            player_id,
+            max_age,
+        )
 
     return count

--- a/web/routes.py
+++ b/web/routes.py
@@ -30,6 +30,7 @@ from bid_euchre.hosted_play.engine import HUMAN_SEAT, MatchEngine, sort_hand_for
 from bid_euchre.strategy.bidding import BidAction
 
 from .ai_manager import AIManager
+from .cleanup import expire_player_stale_matches
 from .db import Comment, Decision, Hand, InviteCode, Match, Player
 from .leaderboard import METRIC_DEFINITIONS, format_metric, get_leaderboard
 from .middleware import (
@@ -350,6 +351,12 @@ def _build_action_rail(visible: dict[str, Any], state) -> list[dict[str, str]]:
     """Build the auction-log event feed from auction/trick/redeal transitions.
 
     The list is capped to the most recent 12 entries for compact rendering.
+
+    Auction entries are sourced from ``state.current_hand.auction`` (the full
+    persisted transcript) rather than ``visible["auction"]`` which may be
+    sliced during the hidden-auction reveal phase.  The *visible* dict
+    continues to be used for tricks and other fields.  This ensures a page
+    refresh never loses already-revealed auction entries (#2207).
     """
     hand = state.current_hand
     if hand is None:
@@ -358,7 +365,11 @@ def _build_action_rail(visible: dict[str, Any], state) -> list[dict[str, str]]:
     events: list[dict[str, str]] = []
 
     # Auction activity (in order).
-    for entry in visible.get("auction", []):
+    # Use the full persisted auction from the hand state, sliced to the
+    # revealed count, so a page refresh cannot drop entries (#2207).
+    full_auction = list(hand.auction)
+    revealed = full_auction[: hand.revealed_auction_count]
+    for entry in revealed:
         events.append(
             {
                 "kind": "auction",
@@ -436,6 +447,15 @@ def _build_game_context(
     visible = engine.get_visible_state(state)
     hand = state.current_hand
     phase = _game_phase(state)
+
+    # Defensive normalization: when the auction is settled (or we're past
+    # auction), ensure revealed_auction_count covers the full auction.
+    # Without this a stale revealed_auction_count could cause _build_action_rail
+    # to omit entries that were already shown before a page refresh (#2207).
+    if hand is not None and hand.auction_settled and not _has_hidden_auction(hand):
+        hand.revealed_auction_count = max(
+            hand.revealed_auction_count, len(hand.auction)
+        )
 
     if hand is not None and _has_hidden_auction(hand):
         visible["auction"] = visible.get("auction", [])[: hand.revealed_auction_count]
@@ -986,6 +1006,11 @@ async def select_ai(
         player = session.query(Player).filter_by(link_uuid=link_uuid).first()
         if player is None:
             raise HTTPException(status_code=404, detail="Game not found")
+
+        # Clean up stale matches before the rate-limit check so orphaned
+        # matches from previous sessions don't permanently block the player
+        # from starting new games (#2211).
+        expire_player_stale_matches(session, player.id)
 
         # Rate limit — max active matches per player
         if not check_match_limit(session, player_id=player.id):


### PR DESCRIPTION
## Summary

Three backend/routes fixes batched into one PR:

- **#2207 — Auction log loses first entry after page refresh:** `_build_action_rail` now reads from the full persisted auction transcript (`hand.auction[:revealed_count]`) instead of the potentially-sliced `visible["auction"]` dict. Added defensive normalization to ensure `revealed_auction_count` covers the full auction when settled.

- **#2219 — Custom 422 handler for HTMX validation errors:** Added `RequestValidationError` exception handler in `app.py` that returns an HTML error partial for HTMX requests instead of raw JSON. Non-HTMX clients still receive JSON 422.

- **#2211 — Automatic cleanup for abandoned active matches:** Added `expire_player_stale_matches()` (2h threshold) that runs before the rate-limit check in `select_ai`, so orphaned sessions from previous browser closures don't permanently block new games.

## Why

These three issues were all observed during production playtesting and affect the browser game UX:
1. Missing auction log entries confuse players about what happened during bidding
2. Raw JSON error text in the game board breaks the visual experience
3. Abandoned matches accumulate and eventually block new game creation

## Repro / Validation

```bash
uv run python -m pytest tests/unit/hosted_play/ -x --no-header -q
# 3352 passed, 6 skipped
```

## Tests

- `tests/unit/hosted_play/test_routes.py` — new `TestAuctionLogPersistence` class (auction survives page refresh)
- `tests/unit/hosted_play/test_error_handling.py` — new `TestValidationErrorHandler` class (422 HTMX/JSON split)
- `tests/unit/hosted_play/test_hardening.py` — new `TestPlayerStaleMatchCleanup` class (per-player cleanup + select-ai integration)

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
branch: fix/wave3b-routes-fixes
```

Closes #2207, closes #2219, closes #2211

🤖 Generated with [Claude Code](https://claude.com/claude-code)