### PR TITLE
fix: preserve bower leads for smart_leads configs + review lane permissions (#2201, #2238)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -127,6 +127,8 @@
       "Write(.claude/hooks/**)",
       "Edit(.claude/runtime/**)",
       "Write(.claude/runtime/**)",
+      "Edit(.claude/runtime/review_state/**)",
+      "Write(.claude/runtime/review_state/**)",
       "Edit(MEMORY.md)",
       "Write(MEMORY.md)",
       "Edit(plans/**)",

--- a/src/bid_euchre/strategy/greedy.py
+++ b/src/bid_euchre/strategy/greedy.py
@@ -640,7 +640,9 @@ class GluttonIsolatedStrategy(Strategy):
     - partner_check: Skip 3rd-seat aggression when partner winning (PR#227)
     - trump_gating: Only aggressive trump if hand ≤6 or trump ≥3 (PR#227)
     - probabilistic_trump_in: Trump to protect partner from void 4th seat (PR#228)
-    - lead_bower: Lead right bower when holding both bowers + 5+ trump (PR#2167)
+    - lead_bower: Lead right bower when holding both bowers + 5+ trump (PR#2167).
+      Defaults to smart_leads when not explicitly set, so configs with
+      smart_leads=True keep bower leads. Set False explicitly to isolate.
 
     With all features disabled, this behaves identically to GreedyStrategy.
     """
@@ -658,7 +660,7 @@ class GluttonIsolatedStrategy(Strategy):
         partner_check: bool = False,
         trump_gating: bool = False,
         probabilistic_trump_in: bool = False,
-        lead_bower: bool = False,
+        lead_bower: Optional[bool] = None,
     ):
         super().__init__(name)
         self.debug = debug
@@ -673,7 +675,9 @@ class GluttonIsolatedStrategy(Strategy):
         self._partner_check = partner_check
         self._trump_gating = trump_gating
         self._probabilistic_trump_in = probabilistic_trump_in
-        self._lead_bower = lead_bower
+        # Default lead_bower to smart_leads when not explicitly set,
+        # so existing configs with smart_leads=True keep bower leads (#2201).
+        self._lead_bower = lead_bower if lead_bower is not None else smart_leads
 
         # Double-deck aware tracking (each card exists 0-2 times)
         self._seen_counts: Dict[Card, int] = {}


### PR DESCRIPTION
## Summary
- Default `lead_bower` to `smart_leads` when not explicitly set in `GluttonIsolatedStrategy`, so existing configs with `smart_leads=True` keep bower-lead behavior after PR #2199 gated it behind a separate flag (#2201)
- Add explicit `review_state/**` permission patterns to `.claude/settings.json` to prevent review lane stalls on write prompts (#2238)

## Why
PR #2199 introduced `lead_bower` as an isolation flag defaulting to `False`, but this silently broke backward compatibility — configs with `smart_leads=True` lost bower leads that were previously unconditional. The fix uses `Optional[bool] = None` and derives the default from `smart_leads`, preserving both backward compat and explicit isolation (`lead_bower=False`).

The review lane stalls because permission prompts block autonomous operation when writing to `.claude/runtime/review_state/`. While `runtime/**` patterns exist, adding explicit `review_state/**` patterns provides belt-and-suspenders coverage.

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_greedy.py tests/unit/test_glutton.py tests/unit/test_leading_fix.py -x -q --no-header
# 69 passed
```

## Tests
- `tests/unit/test_greedy.py` — 10 passed
- `tests/unit/test_glutton.py` — 50 passed
- `tests/unit/test_leading_fix.py` — 9 passed
- `make check` — 11,014 passed, 6 pre-existing failures (unrelated)

## Worktree proof
```
pwd: Bid-Euchre-steward-flex-a
branch: fix/convention-2201-review-stall-2238
```

Closes #2201
Closes #2238

🤖 Generated with [Claude Code](https://claude.com/claude-code)