### PR TITLE
fix(web): colored suit icons + match-end hand result (#2235, #2239)

### DIFF
--- a/web/routes.py
+++ b/web/routes.py
@@ -263,13 +263,26 @@ def _next_reason(hand) -> str | None:
     return None
 
 
-def _game_phase(state) -> str:
+def _game_phase(state, *, force_match_result: bool = False) -> str:
     """Map engine state to the template ``phase`` variable.
 
     The ``game.html`` template dispatches on this value to select which
     partials to include.
+
+    Parameters
+    ----------
+    force_match_result:
+        When *True*, skip the hand-result interstitial and go straight to
+        the match-result screen.  Used by the ``/next-hand`` handler after
+        the player has already seen the final hand result (#2239).
     """
     if state.status == "complete":
+        # Show the final hand result before the match-over screen so the
+        # player can review the last hand (#2239).  The hand_result partial
+        # renders a "See Match Results" CTA when match_status == "complete".
+        hand = state.current_hand
+        if not force_match_result and hand is not None and hand.phase == "complete":
+            return "hand_result"
         return "match_result"
     hand = state.current_hand
     if hand is None:
@@ -437,6 +450,8 @@ def _build_game_context(
     engine: MatchEngine,
     state,
     link_uuid: str,
+    *,
+    force_match_result: bool = False,
 ) -> dict[str, Any]:
     """Build the Jinja2 template context for the game board.
 
@@ -446,7 +461,7 @@ def _build_game_context(
     """
     visible = engine.get_visible_state(state)
     hand = state.current_hand
-    phase = _game_phase(state)
+    phase = _game_phase(state, force_match_result=force_match_result)
 
     # Defensive normalization: when the auction is settled (or we're past
     # auction), ensure revealed_auction_count covers the full auction.
@@ -590,6 +605,7 @@ def _render_game_board(
     link_uuid: str,
     *,
     error_message: str | None = None,
+    force_match_result: bool = False,
 ) -> str:
     """Render the game board composite partial as an HTML string.
 
@@ -602,9 +618,15 @@ def _render_game_board(
         Optional transient error string displayed as an inline alert
         above the board (e.g. "Illegal bid").  Cleared on the next
         normal render.
+    force_match_result:
+        When *True*, skip the hand-result interstitial and render the
+        match-result screen directly.  Used by the ``/next-hand`` handler
+        after the player has already seen the final hand result (#2239).
     """
     templates = _get_templates(request)
-    ctx = _build_game_context(engine, state, link_uuid)
+    ctx = _build_game_context(
+        engine, state, link_uuid, force_match_result=force_match_result
+    )
     ctx["request"] = request
     if error_message is not None:
         ctx["board_error"] = error_message
@@ -1569,10 +1591,15 @@ async def next_hand(
             )
             return _handle_corrupted_match(request, session, match_row, link_uuid)
 
-        # If the match is already complete, render the result screen
-        # immediately — do not advance to a new hand (P2-005).
+        # If the match is already complete, show the match-result screen.
+        # The player has already seen the final hand result (with the
+        # "See Match Results" CTA) and is now advancing (#2239).
         if state.status == "complete":
-            return HTMLResponse(_render_game_board(request, engine, state, link_uuid))
+            return HTMLResponse(
+                _render_game_board(
+                    request, engine, state, link_uuid, force_match_result=True
+                )
+            )
 
         hand = state.current_hand
         if hand is None:

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -927,11 +927,20 @@ main {
 }
 
 /* Inline card rendering (for trick history table) —
-   all cards white; suit symbols provide identification.
+   suit-colored text for red/black readability (#2235).
    Leader underline and winner highlight remain via cell classes. */
 .card--inline {
     font-weight: 700;
     white-space: nowrap;
+}
+
+.card--inline-hearts,
+.card--inline-diamonds {
+    color: var(--color-red);
+}
+
+.card--inline-spades,
+.card--inline-clubs {
     color: var(--color-text);
 }
 
@@ -1554,6 +1563,30 @@ main {
 .btn--next-hand:hover,
 .btn--next-step:hover {
     background: var(--color-legal-glow);
+}
+
+/* "See Match Results" CTA on the final hand result (#2239) */
+.btn--see-results {
+    background: linear-gradient(135deg, var(--color-felt), #1565c0);
+    color: #fff;
+    font-size: 1.1rem;
+    padding: 0.75rem 2rem;
+}
+
+.btn--see-results:hover {
+    background: linear-gradient(135deg, var(--color-legal-glow), #42a5f5);
+}
+
+/* Match-ending notice shown above the CTA on the final hand result (#2239) */
+.match-ending-notice {
+    text-align: center;
+    margin: 0.5rem 0;
+}
+
+.match-ending-notice__text {
+    font-size: 1.05rem;
+    color: var(--color-text);
+    margin: 0;
 }
 
 /* --------------------------------------------------------------------------
@@ -2776,6 +2809,23 @@ main {
 
 .card-text--spades,
 .card-text--clubs {
+    color: var(--color-text);
+}
+
+/* Reusable suit-icon utility — applies red/black to any inline suit symbol.
+   Use `suit-icon suit-icon--hearts` (or diamonds/spades/clubs) on a <span>
+   wrapping a suit symbol like ♠ ♥ ♦ ♣.  (#2235) */
+.suit-icon {
+    white-space: nowrap;
+}
+
+.suit-icon--hearts,
+.suit-icon--diamonds {
+    color: var(--color-red);
+}
+
+.suit-icon--spades,
+.suit-icon--clubs {
     color: var(--color-text);
 }
 

--- a/web/templates/partials/bid_panel.html
+++ b/web/templates/partials/bid_panel.html
@@ -9,6 +9,7 @@
      - bid_type: str — current winning bid type ("regular", "moon", or "loner")
 #}
 {% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
+{% set suit_classes = {"S": "spades", "H": "hearts", "D": "diamonds", "C": "clubs"} %}
 {% set seat_labels = seat_labels | default({0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}) %}
 {% set bid_type_labels = {"regular": "", "moon": " Moon", "loner": " Loner"} %}
 
@@ -44,7 +45,7 @@
                                 {{ entry.n }}
                             {% endif %}
                             {% if entry.contract in suit_symbols %}
-                                {{ suit_symbols[entry.contract] }}
+                                <span class="suit-icon suit-icon--{{ suit_classes.get(entry.contract, 'spades') }}">{{ suit_symbols[entry.contract] }}</span>
                             {% elif entry.contract == "HIGH" %}
                                 High
                             {% elif entry.contract == "LOW" %}

--- a/web/templates/partials/hand_result.html
+++ b/web/templates/partials/hand_result.html
@@ -14,6 +14,7 @@
      - hands_played: int — total hands completed
 #}
 {% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
+{% set suit_classes = {"S": "spades", "H": "hearts", "D": "diamonds", "C": "clubs"} %}
 {% set seat_labels = seat_labels | default({0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}) %}
 {% set bidder_seat = bidder_seat | int %}
 {% set hand_bid_type = bid_type | default("regular") %}
@@ -94,7 +95,7 @@
                 bid {{ winning_bid }}
             {% endif %}
             {% if contract_type == "suit" and trump %}
-                {{ suit_symbols.get(trump, trump) }}
+                <span class="suit-icon suit-icon--{{ suit_classes.get(trump, 'spades') }}">{{ suit_symbols.get(trump, trump) }}</span>
             {% elif contract_type == "high" %}
                 High
             {% elif contract_type == "low" %}
@@ -112,11 +113,11 @@
                 <p class="exchange-title"><strong>Moon Exchange</strong></p>
                 <p class="exchange-details">
                     Given {{ exchange_given_cards|length }} to partner ({{ partner_seat_label }}):
-                    {% for card in exchange_given_cards %}<span class="card-text" aria-label="{{ suit_symbols.get(card[0], card[0]) }}{{ card[1]|display_rank }}">{{ suit_symbols.get(card[0], card[0]) }} {{ card[1]|display_rank }}</span>{% if not loop.last %}, {% endif %}{% endfor %}
+                    {% for card in exchange_given_cards %}<span class="card-text card-text--{{ suit_classes.get(card[0], 'spades') }}" aria-label="{{ suit_symbols.get(card[0], card[0]) }}{{ card[1]|display_rank }}">{{ suit_symbols.get(card[0], card[0]) }} {{ card[1]|display_rank }}</span>{% if not loop.last %}, {% endif %}{% endfor %}
                 </p>
                 <p class="exchange-details">
                     Received {{ exchange_received_cards|length }} from partner ({{ partner_seat_label }}):
-                    {% for card in exchange_received_cards %}<span class="card-text" aria-label="{{ suit_symbols.get(card[0], card[0]) }}{{ card[1]|display_rank }}">{{ suit_symbols.get(card[0], card[0]) }} {{ card[1]|display_rank }}</span>{% if not loop.last %}, {% endif %}{% endfor %}
+                    {% for card in exchange_received_cards %}<span class="card-text card-text--{{ suit_classes.get(card[0], 'spades') }}" aria-label="{{ suit_symbols.get(card[0], card[0]) }}{{ card[1]|display_rank }}">{{ suit_symbols.get(card[0], card[0]) }} {{ card[1]|display_rank }}</span>{% if not loop.last %}, {% endif %}{% endfor %}
                 </p>
             </div>
         {% endif %}
@@ -156,20 +157,30 @@
         {% include "partials/trick_history.html" %}
     </div>
 
-    {# Defence-in-depth: if the match has ended but this partial is rendered
-       (e.g. stale HTMX morph, race condition), show the correct CTA.
-       Primary guard is _game_phase() returning "match_result" for complete
-       matches; this is a fallback (P2-005). #}
+    {# Match-ending hand: show the result here first so the player can
+       review the final hand before seeing the match-over screen (#2239).
+       _game_phase() returns "hand_result" when the match is complete but
+       the current hand is still available.  The "See Match Results" CTA
+       advances to the match_result phase via /next-hand. #}
     {% if match_status is defined and match_status == "complete" %}
+    <div class="match-ending-notice" role="status" aria-live="polite">
+        <p class="match-ending-notice__text">
+            {% if winner is defined and winner == "human" %}
+                🎉 Match over — <strong>You win!</strong>
+            {% else %}
+                Match over — <strong>AI wins.</strong>
+            {% endif %}
+        </p>
+    </div>
     <form method="post"
-          action="/play/{{ link_uuid | default("") }}/new-match"
-          hx-post="/play/{{ link_uuid | default("") }}/new-match"
+          action="/play/{{ link_uuid | default("") }}/next-hand"
+          hx-post="/play/{{ link_uuid | default("") }}/next-hand"
           hx-target="#game-board"
           hx-swap="morph:innerHTML"
           hx-timeout="15000"
           class="hand-result-controls"
-          aria-label="Start a new match">
-        <button type="submit" class="btn btn--play-again">Play Again</button>
+          aria-label="See match results">
+        <button type="submit" class="btn btn--see-results">See Match Results</button>
     </form>
     {% else %}
     <form method="post"

--- a/web/templates/partials/moon_exchange.html
+++ b/web/templates/partials/moon_exchange.html
@@ -29,7 +29,7 @@
         <p class="moon-exchange__subtitle">
             {{ mooner_label }} bid Moon
             {% if contract_type == "suit" and trump %}
-                in {{ suit_symbols.get(trump, trump) }}
+                in <span class="suit-icon suit-icon--{{ suit_classes.get(trump, 'spades') }}">{{ suit_symbols.get(trump, trump) }}</span>
             {% elif contract_type == "high" %}
                 High
             {% elif contract_type == "low" %}

--- a/web/templates/partials/moon_exchange_select.html
+++ b/web/templates/partials/moon_exchange_select.html
@@ -24,7 +24,7 @@
         <p class="moon-exchange__subtitle">
             {{ mooner_label }} bid Moon
             {% if contract_type == "suit" and trump %}
-                in {{ suit_symbols.get(trump, trump) }}
+                in <span class="suit-icon suit-icon--{{ suit_classes.get(trump, 'spades') }}">{{ suit_symbols.get(trump, trump) }}</span>
             {% elif contract_type == "high" %}
                 High
             {% elif contract_type == "low" %}

--- a/web/templates/partials/score.html
+++ b/web/templates/partials/score.html
@@ -13,6 +13,7 @@
      - phase: str — current hand phase
 #}
 {% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
+{% set suit_classes = {"S": "spades", "H": "hearts", "D": "diamonds", "C": "clubs"} %}
 {% set seat_labels = seat_labels | default({0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}) %}
 
 <div id="score-bar" class="score-bar" role="status" aria-label="Match score and hand information" aria-live="polite">
@@ -46,7 +47,7 @@
                 {{ winning_bid }}
             {% endif %}
             {% if contract_type == "suit" and trump %}
-                {{ suit_symbols.get(trump, trump) }}
+                <span class="suit-icon suit-icon--{{ suit_classes.get(trump, 'spades') }}">{{ suit_symbols.get(trump, trump) }}</span>
             {% elif contract_type == "high" %}
                 High
             {% elif contract_type == "low" %}

--- a/web/templates/partials/trick_history.html
+++ b/web/templates/partials/trick_history.html
@@ -5,6 +5,7 @@
      - tricks_team1: int — tricks won by AI team
 #}
 {% set suit_symbols = {"S": "\u2660", "H": "\u2665", "D": "\u2666", "C": "\u2663"} %}
+{% set suit_classes = {"S": "spades", "H": "hearts", "D": "diamonds", "C": "clubs"} %}
 {% set seat_labels = seat_labels | default({0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}) %}
 
 {% if completed_tricks %}
@@ -38,7 +39,7 @@
                                     {% set card = ns.cards[seat] %}
                                     {% set disp_suit = card|effective_suit(trump | default(None, true), contract_type | default(None, true)) %}
                                     {% set bower = card|is_bower(trump | default(None, true), contract_type | default(None, true)) %}
-                                    <span class="card--inline{% if bower %} card--inline-bower{% endif %}">{{ card[1]|display_rank }}{{ suit_symbols.get(disp_suit, disp_suit) }}{% if bower %}<sup class="bower-sup" title="{{ bower|capitalize }} bower">B</sup>{% endif %}</span>
+                                    <span class="card--inline card--inline-{{ suit_classes.get(disp_suit, 'spades') }}{% if bower %} card--inline-bower{% endif %}">{{ card[1]|display_rank }}{{ suit_symbols.get(disp_suit, disp_suit) }}{% if bower %}<sup class="bower-sup" title="{{ bower|capitalize }} bower">B</sup>{% endif %}</span>
                                 {% else %}
                                     <span class="trick-history__absent" aria-label="Sitting out">&mdash;</span>
                                 {% endif %}


### PR DESCRIPTION
## Summary

- **#2235 — Colored suit icons:** Suit symbols (♠♥♦♣) now display in
  red (hearts/diamonds) or black (spades/clubs) everywhere they appear
  inline — auction transcript, score bar, hand result, trick history,
  moon exchange, and contract info. Cards already had suit colors; this
  extends coloring to all textual suit references via `.suit-icon` and
  `.card--inline-{suit}` CSS utility classes.

- **#2239 — Match-end hand result:** When a match ends, the player now
  sees the final hand result screen first (with trick log, scoring
  summary, and a "See Match Results" button) before transitioning to
  the match-over win/loss screen. Previously `_game_phase()` returned
  `"match_result"` immediately, skipping the last hand review.

## Why

Playtest feedback: suit colors aid readability on the dark felt
background, and skipping the final hand result was disorienting
(players didn't see how the winning hand played out).

## Changes

| File | Change |
|------|--------|
| `web/routes.py` | `_game_phase()` returns `"hand_result"` when match is complete but final hand is available; `force_match_result` flag threads through `_build_game_context` / `_render_game_board`; `next_hand` handler uses the flag for the transition |
| `web/static/style.css` | `.suit-icon--{suit}` utility, `.card--inline-{suit}` colors, `.btn--see-results` and `.match-ending-notice` styles |
| `web/templates/partials/bid_panel.html` | Wrap auction suit symbols with `.suit-icon` |
| `web/templates/partials/hand_result.html` | Match-complete CTA: "See Match Results" + match-ending notice |
| `web/templates/partials/moon_exchange.html` | Wrap trump suit with `.suit-icon` |
| `web/templates/partials/moon_exchange_select.html` | Wrap trump suit with `.suit-icon` |
| `web/templates/partials/score.html` | Wrap contract suit with `.suit-icon` |
| `web/templates/partials/trick_history.html` | Add suit-specific class to `.card--inline` |

## Repro / Validation

```bash
# Tier 1: hosted_play tests (all 3370 pass)
uv run python -m pytest tests/unit/hosted_play/ --no-header -q

# Tier 2: full validation
make check-quiet
# 3 pre-existing failures in unrelated modules (token_economy, telegram_filter)
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
branch: fix/suit-colors-match-end-2235-2239
```

## Tests

- `tests/unit/hosted_play/test_routes.py` — 98 passed, 2 skipped
- `tests/unit/hosted_play/test_partials.py` — 219 passed
- Full hosted_play suite — 3370 passed, 6 skipped

Closes #2235
Closes #2239

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>