### PR TITLE
fix(ops): add missing lanes + launch/task configs to VS Code workspace (#2227)

### DIFF
--- a/Bid-Euchre-agent-audit.code-workspace
+++ b/Bid-Euchre-agent-audit.code-workspace
@@ -29,6 +29,10 @@
       "path": "../Bid-Euchre-steward-author-d"
     },
     {
+      "name": "author-scratch [legacy]",
+      "path": "../Bid-Euchre-steward-author-scratch"
+    },
+    {
       "name": "brws-author-a [browser]",
       "path": "../Bid-Euchre-steward-brws-author-a"
     },
@@ -77,6 +81,119 @@
       "path": "../Bid-Euchre-steward-flex-d"
     }
   ],
+  "launch": {
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Run Web App (dev)",
+        "type": "debugpy",
+        "request": "launch",
+        "module": "uvicorn",
+        "args": [
+          "bid_euchre.web.app:create_app",
+          "--factory",
+          "--reload",
+          "--host", "127.0.0.1",
+          "--port", "8000"
+        ],
+        "cwd": "${workspaceFolder:main}",
+        "env": {
+          "PYTHONPATH": "${workspaceFolder:main}/src"
+        },
+        "console": "integratedTerminal"
+      },
+      {
+        "name": "Run Tests (unit)",
+        "type": "debugpy",
+        "request": "launch",
+        "module": "pytest",
+        "args": ["tests/unit/", "-x", "--tb=short"],
+        "cwd": "${workspaceFolder:main}",
+        "env": {
+          "PYTHONPATH": "${workspaceFolder:main}/src"
+        },
+        "console": "integratedTerminal"
+      },
+      {
+        "name": "Run Tests (web)",
+        "type": "debugpy",
+        "request": "launch",
+        "module": "pytest",
+        "args": ["tests/unit/web/", "-x", "--tb=short"],
+        "cwd": "${workspaceFolder:main}",
+        "env": {
+          "PYTHONPATH": "${workspaceFolder:main}/src"
+        },
+        "console": "integratedTerminal"
+      },
+      {
+        "name": "Run Experiment (quick_test, seed 42)",
+        "type": "debugpy",
+        "request": "launch",
+        "module": "bid_euchre",
+        "args": [
+          "experiments/run_experiment.py",
+          "--config", "experiments/configs/quick_test.yaml",
+          "--seed", "42"
+        ],
+        "cwd": "${workspaceFolder:main}",
+        "env": {
+          "PYTHONPATH": "${workspaceFolder:main}/src"
+        },
+        "console": "integratedTerminal"
+      }
+    ]
+  },
+  "tasks": {
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "make check",
+        "type": "shell",
+        "command": "make check",
+        "group": "test",
+        "options": { "cwd": "${workspaceFolder:main}" },
+        "problemMatcher": [],
+        "presentation": { "reveal": "always", "panel": "new" }
+      },
+      {
+        "label": "make check-quiet",
+        "type": "shell",
+        "command": "make check-quiet",
+        "group": { "kind": "test", "isDefault": true },
+        "options": { "cwd": "${workspaceFolder:main}" },
+        "problemMatcher": [],
+        "presentation": { "reveal": "always", "panel": "new" }
+      },
+      {
+        "label": "make lint",
+        "type": "shell",
+        "command": "make lint",
+        "group": "test",
+        "options": { "cwd": "${workspaceFolder:main}" },
+        "problemMatcher": [],
+        "presentation": { "reveal": "always", "panel": "shared" }
+      },
+      {
+        "label": "make test",
+        "type": "shell",
+        "command": "make test",
+        "group": "test",
+        "options": { "cwd": "${workspaceFolder:main}" },
+        "problemMatcher": [],
+        "presentation": { "reveal": "always", "panel": "new" }
+      },
+      {
+        "label": "make notebook-sync",
+        "type": "shell",
+        "command": "make notebook-sync",
+        "group": "build",
+        "options": { "cwd": "${workspaceFolder:main}" },
+        "problemMatcher": [],
+        "presentation": { "reveal": "always", "panel": "shared" }
+      }
+    ]
+  },
   "settings": {
     "files.exclude": {
       "**/.venv": true,


### PR DESCRIPTION
## Summary
- Add missing `author-scratch [legacy]` worktree folder to `Bid-Euchre-agent-audit.code-workspace` (19 → 20 folders)
- Add 4 debug launch configurations: web app (dev), unit tests, web tests, experiment runner
- Add 5 VS Code task definitions: `make check`, `make check-quiet`, `make lint`, `make test`, `make notebook-sync`

## Why
Issue #2227 reported the workspace was missing steward lanes and had no debug/task configs. The folder list was mostly complete from PR #1886 but was missing author-scratch. Launch configs and task definitions were entirely absent.

Closes #2227

## Validation
```bash
# Verify folder count and JSON validity
cat Bid-Euchre-agent-audit.code-workspace | python3 -c 'import sys,json; d=json.load(sys.stdin); print(len(d["folders"]),"folders")'
# Expected: 20 folders

# Verify all pools present
python3 -c "
import json
d = json.load(open('Bid-Euchre-agent-audit.code-workspace'))
names = [f['name'] for f in d['folders']]
assert any('control' in n for n in names), 'missing control'
assert any('platform' in n for n in names), 'missing platform'
assert any('browser' in n for n in names), 'missing browser'
assert any('analyst' in n for n in names), 'missing analyst'
assert any('flex' in n for n in names), 'missing flex'
assert any('legacy' in n for n in names), 'missing legacy'
assert 'launch' in d, 'missing launch configs'
assert 'tasks' in d, 'missing task definitions'
print('All pools + configs present')
"
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
branch: fix/vscode-workspace-all-lanes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)