### PR TITLE
ops: switch to dontAsk permission mode + fill Bash pattern gaps (#2254)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -116,6 +116,7 @@
     ]
   },
   "permissions": {
+    "defaultMode": "dontAsk",
     "allow": [
       "Edit(.claude/skills/**)",
       "Write(.claude/skills/**)",
@@ -150,7 +151,16 @@
       "Bash(uv sync *)",
       "Bash(ruff *)",
       "Bash(codex *)",
+      "Bash(cat *)",
+      "Bash(head *)",
+      "Bash(tail *)",
+      "Bash(diff *)",
+      "Bash(echo *)",
+      "Bash(env *)",
       "Bash(pwd *)",
+      "Bash(python *)",
+      "Bash(sleep *)",
+      "Bash(tmux *)",
       "Bash(ls *)",
       "Bash(wc *)",
       "Bash(mkdir *)"


### PR DESCRIPTION
## Summary

- Switch `permissions.defaultMode` to `"dontAsk"` so unlisted tools are silently denied instead of blocking on permission prompts
- Add 9 missing Bash patterns: `cat`, `head`, `tail`, `diff`, `echo`, `env`, `python`, `sleep`, `tmux`

## Why

For a 19-lane autonomous fleet with no human watching, `dontAsk` is strictly better than the default behavior:
- **Default (no `defaultMode`):** Prompts the user for unlisted tools → lanes stall indefinitely
- **`dontAsk`:** Silently denies unlisted tools → agent gets an error it can react to, never stalls

The Bash pattern gaps were identified in the CC features audit (plans/sessions/2026-04-03_claude_code_features_audit.md, Section 1.2).

## Repro / Validation

```bash
# Verify settings.json is valid JSON and contains dontAsk
python -c "import json; d=json.load(open('.claude/settings.json')); assert d['permissions']['defaultMode'] == 'dontAsk'; print('OK')"
```

```bash
make check-quiet
# 4 pre-existing failures on main (test_routes, test_ops_token_economy, test_telegram_filter)
# 11070 passed — no new failures introduced
```

## Tests

- `make check-quiet` — 11070 passed, 4 pre-existing failures (confirmed on main)
- No new test files needed — this is a config-only change

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: ops/dontask-permission-mode
```

Closes #2254

🤖 Generated with [Claude Code](https://claude.com/claude-code)