### PR TITLE
fix(web): rename EPPD to Net PPD and add raw PPD column (#2265)

### DIFF
--- a/tests/unit/hosted_play/test_leaderboard.py
+++ b/tests/unit/hosted_play/test_leaderboard.py
@@ -478,6 +478,7 @@ class TestComputePlayerStats:
             "win_rate",
             "avg_margin_victory",
             "matches_played",
+            "ppd",
             "hands_played",
             "avg_match_margin",
             "bid_rate",
@@ -864,7 +865,7 @@ class TestLeaderboardWithAI:
             db_session, ai_display_names={"heuristic": "Test Bot"}
         )
         assert len(rankings) == 2
-        # Human has positive EPPD (10-2=8), AI has negative (-8)
+        # Human has positive Net PPD (10-2=8), AI has negative (-8)
         assert rankings[0].nickname == "Human"
         assert rankings[0].is_ai is False
         assert rankings[1].nickname == "Test Bot"
@@ -941,7 +942,7 @@ class TestLeaderboardRoute:
             resp = client.get(f"/leaderboard/{player.link_uuid}")
             assert resp.status_code == 200
             assert "RankedPlayer" in resp.text
-            assert "EPPD" in resp.text
+            assert "Net PPD" in resp.text
         finally:
             session.close()
 
@@ -982,7 +983,7 @@ class TestLeaderboardRoute:
 
             resp = client.get(f"/leaderboard/{player.link_uuid}")
             assert resp.status_code == 200
-            assert "Ranked by EPPD" in resp.text
+            assert "Ranked by Net PPD" in resp.text
         finally:
             session.close()
 
@@ -1215,10 +1216,10 @@ class TestMetricDefinitions:
             assert len(m.full_label) > 0, f"{key} has empty full_label"
 
     def test_labels_are_abbreviated(self):
-        """Column headers should be short abbreviations (≤6 chars)."""
+        """Column headers should be short abbreviations (≤7 chars)."""
         for key, m in METRIC_DEFINITIONS.items():
             assert (
-                len(m.label) <= 6
+                len(m.label) <= 7
             ), f"{key} label {m.label!r} too long for abbreviated header"
 
     def test_full_labels_are_longer_than_labels(self):

--- a/web/leaderboard.py
+++ b/web/leaderboard.py
@@ -47,10 +47,10 @@ class MetricDef(NamedTuple):
 #: The template iterates these to build headers, tooltips, and formatting.
 METRIC_DEFINITIONS: dict[str, MetricDef] = {
     "net_eppd": MetricDef(
-        label="EPPD",
-        full_label="Net EPPD",
+        label="Net PPD",
+        full_label="Net Points Per Deal",
         tooltip=(
-            "Net Expected Points Per Deal — your average point advantage "
+            "Net Points Per Deal — your average point advantage "
             "per hand. Positive means you're outscoring opponents."
         ),
         format="signed_float3",
@@ -84,12 +84,19 @@ METRIC_DEFINITIONS: dict[str, MetricDef] = {
         format="pct",
         category="default",
     ),
+    "ppd": MetricDef(
+        label="PPD",
+        full_label="Points Per Deal",
+        tooltip="Raw points your team earned per hand (before subtracting opponent points).",
+        format="float3",
+        category="default",
+    ),
     "avg_match_margin": MetricDef(
         label="Mgn",
         full_label="Avg Margin",
         tooltip="Average score margin across all completed matches (positive = winning).",
         format="signed_float1",
-        category="default",
+        category="secondary",
     ),
     "avg_margin_victory": MetricDef(
         label="WMgn",
@@ -200,13 +207,14 @@ class PlayerStats:
     nickname: str | None
 
     # Primary ranking metric
-    net_eppd: float  # net expected points per deal
+    net_eppd: float  # net points per deal (realized, not expected)
 
     # Default visible columns
     games_won: int
     win_rate: float  # 0.0–1.0
     avg_margin_victory: float  # average score margin when winning
     matches_played: int
+    ppd: float  # raw points per deal (team points / hands played)
 
     # Secondary columns
     hands_played: int
@@ -279,9 +287,13 @@ def compute_player_stats(session: Session, player_id: int) -> PlayerStats | None
 
     # --- Hand-level metrics (all completed hands) ---
 
-    # Net EPPD: total net points / total hands
+    # Net PPD: total net points / total hands
     total_net_points = sum(h.points_team0 - h.points_team1 for h in completed_hands)
     net_eppd = total_net_points / hands_played
+
+    # PPD: raw team points / total hands (before subtracting opponent)
+    total_team_points = sum(h.points_team0 for h in completed_hands)
+    ppd = total_team_points / hands_played
 
     # Bidding stats — human team is team 0, bidder_seat in (0, 2)
     declaring_hands = [
@@ -337,6 +349,7 @@ def compute_player_stats(session: Session, player_id: int) -> PlayerStats | None
         win_rate=round(win_rate, 3),
         avg_margin_victory=round(avg_margin_victory, 1),
         matches_played=matches_played,
+        ppd=round(ppd, 3),
         hands_played=hands_played,
         avg_match_margin=round(avg_match_margin, 1),
         bid_rate=round(bid_rate, 3),
@@ -358,7 +371,7 @@ def compute_ai_stats(
     """Compute aggregated stats for an AI opponent across all its matches.
 
     The AI team is team 1 (seats 1 and 3).  Stats are computed from the
-    AI's perspective — net EPPD, win rate, bid rate, etc. all reflect the
+    AI's perspective — net PPD, win rate, bid rate, etc. all reflect the
     AI opponent's performance, not the human's.
 
     Returns ``None`` if the AI has no completed hands.
@@ -407,9 +420,13 @@ def compute_ai_stats(
 
     # --- Hand-level metrics (all completed hands, AI = team 1) ---
 
-    # Net EPPD from AI perspective: (points_team1 - points_team0) / hands
+    # Net PPD from AI perspective: (points_team1 - points_team0) / hands
     total_net_points = sum(h.points_team1 - h.points_team0 for h in completed_hands)
     net_eppd = total_net_points / hands_played
+
+    # PPD: raw AI team points / total hands (before subtracting opponent)
+    total_team_points = sum(h.points_team1 for h in completed_hands)
+    ppd = total_team_points / hands_played
 
     # Bidding stats — AI team is team 1, seats (1, 3)
     declaring_hands = [
@@ -465,6 +482,7 @@ def compute_ai_stats(
         win_rate=round(win_rate, 3),
         avg_margin_victory=round(avg_margin_victory, 1),
         matches_played=matches_played,
+        ppd=round(ppd, 3),
         hands_played=hands_played,
         avg_match_margin=round(avg_match_margin, 1),
         bid_rate=round(bid_rate, 3),

--- a/web/templates/leaderboard.html
+++ b/web/templates/leaderboard.html
@@ -212,7 +212,7 @@
         <h2 class="leaderboard__title">Leaderboard</h2>
     </div>
     <p class="leaderboard__ranking-info">
-        Ranked by EPPD (Net Expected Points Per Deal) — your average point advantage per hand.
+        Ranked by Net PPD (Net Points Per Deal) — your average point advantage per hand.
     </p>
 
     {% if rankings|length == 0 %}


### PR DESCRIPTION
## Summary
- Rename "EPPD" column to "Net PPD" (Net Points Per Deal) — the value is realized, not expected
- Add new "PPD" column (raw Points Per Deal) as a default-visible metric
- Demote "Mgn" (Avg Margin) from default to secondary stats

Closes #2265

## Why
User feedback: "its not expected points per deal its realized ppd" and "we should also have ppd instead of mgn as a column in the leader board." The EPPD label was misleading because it implied a prediction when the value is computed from actual game data.

## Repro / Validation
```bash
uv run python -m pytest tests/unit/hosted_play/test_leaderboard.py -v
# 66 passed
```

## Tests
- `uv run python -m pytest tests/unit/hosted_play/test_leaderboard.py` — all 66 tests pass
- Updated `test_returns_dataclass_fields` for new `ppd` field
- Updated route tests for renamed column labels ("Net PPD", "Ranked by Net PPD")
- Updated label length constraint from ≤6 to ≤7 chars to accommodate "Net PPD"
- Existing PPD computation tests continue passing (human + AI perspective)

## Changes
| File | Change |
|------|--------|
| `web/leaderboard.py` | Rename EPPD→Net PPD labels; add `ppd` field+metric; demote Mgn to secondary; compute PPD in both human and AI stats |
| `web/templates/leaderboard.html` | Update ranking info text |
| `tests/unit/hosted_play/test_leaderboard.py` | Update assertions for renamed labels, new field, adjusted label length |

## Worktree proof
```
pwd: Bid-Euchre-steward-brws-author-a
branch: fix/rename-eppd-add-ppd-2265
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>