### PR TITLE
ops: add fleet env flags to steward-session.sh (#2255)

### DIFF
--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -439,6 +439,31 @@ tmux new-session -d -s "$SESSION" -n central-ops -c "$MAIN_DIR" \
 # ---------------------------------------------------------------------------
 tmux set-environment -t "$SESSION" CLAUDE_CODE_AUTO_COMPACT_WINDOW "200000"
 
+# ---------------------------------------------------------------------------
+# Fleet environment flags (#2255, per #2244 + #2249 research).
+# Set via tmux set-environment so all panes inherit them.  Placed after the
+# orchestrator pane so the orchestrator is already running, but before all
+# other panes so every non-orchestrator lane inherits these flags.
+# ---------------------------------------------------------------------------
+
+# Fleet UX: suppress terminal title changes in 19-pane layout
+tmux set-environment -t "$SESSION" CLAUDE_CODE_DISABLE_TERMINAL_TITLE "1"
+
+# Fleet stability: prevent auto-updates during active sessions
+tmux set-environment -t "$SESSION" DISABLE_AUTOUPDATER "1"
+
+# Fleet autonomy: suppress interactive feedback surveys
+tmux set-environment -t "$SESSION" CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY "1"
+
+# Fleet autonomy: suppress cost warning messages
+tmux set-environment -t "$SESSION" DISABLE_COST_WARNINGS "1"
+
+# Fleet resilience: auto-resume interrupted turns
+tmux set-environment -t "$SESSION" CLAUDE_CODE_RESUME_INTERRUPTED_TURN "1"
+
+# Fleet resilience: non-blocking MCP connections for headless startup
+tmux set-environment -t "$SESSION" MCP_CONNECTION_NONBLOCKING "true"
+
 # Propagate channel config into the tmux session environment so all panes
 # can read it.  Shell `export` only affects the launcher process; tmux panes
 # are spawned by the tmux server and need `set-environment` instead.

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -1079,6 +1079,61 @@ class TestAutoCompactWindow:
         )
 
 
+class TestFleetEnvFlags:
+    """Tests for fleet environment flags in steward-session.sh (#2255)."""
+
+    # The six fleet flags and their expected values.
+    FLEET_FLAGS = {
+        "CLAUDE_CODE_DISABLE_TERMINAL_TITLE": "1",
+        "DISABLE_AUTOUPDATER": "1",
+        "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": "1",
+        "DISABLE_COST_WARNINGS": "1",
+        "CLAUDE_CODE_RESUME_INTERRUPTED_TURN": "1",
+        "MCP_CONNECTION_NONBLOCKING": "true",
+    }
+
+    @pytest.mark.parametrize("flag,value", FLEET_FLAGS.items())
+    def test_flag_set_via_tmux_env(self, flag: str, value: str) -> None:
+        """Each fleet flag must be propagated via tmux set-environment."""
+        content = _read_steward_script()
+        expected = f'tmux set-environment -t "$SESSION" {flag} "{value}"'
+        assert (
+            expected in content
+        ), f"{flag} must be set via tmux set-environment with value {value!r}"
+
+    @pytest.mark.parametrize("flag", FLEET_FLAGS)
+    def test_flag_set_after_orchestrator_pane(self, flag: str) -> None:
+        """Fleet flags must appear AFTER the orchestrator pane is created."""
+        content = _read_steward_script()
+        orch_pos = content.find("--agent steward-orchestrator")
+        flag_pos = content.find(flag)
+        assert orch_pos > 0, "Orchestrator pane launch must exist"
+        assert flag_pos > 0, f"{flag} must exist in the script"
+        assert (
+            flag_pos > orch_pos
+        ), f"{flag} must appear AFTER orchestrator pane creation"
+
+    @pytest.mark.parametrize("flag", FLEET_FLAGS)
+    def test_flag_set_before_non_orch_panes(self, flag: str) -> None:
+        """Fleet flags must appear BEFORE the first non-orchestrator pane (ops)."""
+        content = _read_steward_script()
+        flag_pos = content.find(flag)
+        ops_pos = content.find("--name ops")
+        assert flag_pos > 0, f"{flag} must exist in the script"
+        assert ops_pos > 0, "Ops pane launch must exist"
+        assert (
+            flag_pos < ops_pos
+        ), f"{flag} must appear BEFORE the first non-orch pane (ops)"
+
+    @pytest.mark.parametrize("flag", FLEET_FLAGS)
+    def test_flag_not_shell_export(self, flag: str) -> None:
+        """Must use tmux set-environment, not shell export."""
+        content = _read_steward_script()
+        assert (
+            f"export {flag}" not in content
+        ), f"{flag} must not use shell export (tmux panes don't inherit it)"
+
+
 class TestBoundaryValidation:
     """Tests for validate_worktree_path() in steward-session.sh."""
 


### PR DESCRIPTION
## Summary
- Add 6 fleet environment flags to `.claude/tmux/steward-session.sh` via `tmux set-environment`
- Flags suppress interactive noise, prevent mid-session updates, enable resilience features
- 24 parametrized regression tests lock presence, value, ordering, and propagation method

## Why
Issue #2255 — analyst research (#2244, #2249) identified 6 env flags that improve autonomous fleet operations. These flags eliminate interactive prompts/noise that disrupt headless lanes, prevent auto-updates during active sessions, and improve resilience to disconnects and MCP failures.

## Flags Added

| Flag | Value | Purpose |
|------|-------|---------|
| `CLAUDE_CODE_DISABLE_TERMINAL_TITLE` | `1` | Suppress title changes in 19-pane layout |
| `DISABLE_AUTOUPDATER` | `1` | Prevent auto-updates during active sessions |
| `CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY` | `1` | Suppress interactive feedback surveys |
| `DISABLE_COST_WARNINGS` | `1` | Suppress cost warning messages |
| `CLAUDE_CODE_RESUME_INTERRUPTED_TURN` | `1` | Auto-resume interrupted turns |
| `MCP_CONNECTION_NONBLOCKING` | `true` | Non-blocking MCP connections |

## Placement
Flags are set via `tmux set-environment` **after** the orchestrator pane (so orchestrator retains its own env) and **before** all non-orchestrator panes (so ops, review, analyst, author, browser, flex lanes all inherit them).

## Repro / Validation
```bash
bash -n .claude/tmux/steward-session.sh  # syntax check
uv run python -m pytest tests/unit/test_steward_session.py -v  # 107 tests, all pass
```

## Tests
- `uv run python -m pytest tests/unit/test_steward_session.py -v` — 107 passed
- `make check` — all pre-existing failures only (0 new failures)
- Pre-existing failures on main: test_routes, test_ops_token_economy (×2), test_ops_worker_pool, test_telegram_filter

## Worktree proof
```
pwd: Bid-Euchre-steward-author-b
branch: ops/fleet-env-flags
```

## References
- Closes #2255
- Research: `plans/sessions/2026-04-03_claude_code_env_flags_research.md` (#2244)
- Research: `plans/sessions/2026-04-03_claude_code_features_audit.md` (#2249)

🤖 Generated with [Claude Code](https://claude.com/claude-code)