### PR TITLE
fix(web): show original suit + RB/LB labels for bowers (#2261)

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -3189,22 +3189,22 @@ class TestTrickHistory:
 
 
 # ---------------------------------------------------------------------------
-# Bower suit display — left bower shows effective trump suit (#2204)
+# Bower suit display — show printed suit + RB/LB labels (#2261)
 # ---------------------------------------------------------------------------
 
 
 class TestBowerDisplay:
-    """Verify bower cards show effective trump suit + badge across all partials.
+    """Verify bower cards show original printed suit + RB/LB badge.
 
-    The left bower (J of same-colour off-suit) must display the trump suit,
-    not its physical suit.  A bower badge ("B") must be present.
-    Refs: #2204, #2158, #2180.
+    Bowers must display their printed (physical) suit with an RB (right bower)
+    or LB (left bower) badge.  The effective suit should NOT be used for display.
+    Refs: #2261, #2204, #2158, #2180.
     """
 
     # -- trick.html: played card in trick area --
 
-    def test_left_bower_played_card_shows_trump_suit(self, env):
-        """Left bower in trick card_slot shows trump suit (effective), not physical."""
+    def test_left_bower_played_card_shows_printed_suit(self, env):
+        """Left bower in trick card_slot shows printed suit, not trump suit (#2261)."""
         tmpl = env.get_template("partials/trick.html")
         # J♠ played in a clubs contract — left bower of clubs
         html = tmpl.render(
@@ -3222,13 +3222,13 @@ class TestBowerDisplay:
             contract_type="suit",
             trump="C",
         )
-        # The played card should show clubs (♣), not spades (♠)
-        assert "card--clubs" in html
+        # The played card should show spades (♠) — its printed suit
+        assert "card--spades" in html
         assert "card--bower" in html
-        assert "bower-badge" in html.lower() or "bower" in html.lower()
+        assert ">LB<" in html  # left bower badge
 
-    def test_right_bower_played_card_shows_trump_suit(self, env):
-        """Right bower in trick card_slot shows trump suit (trivially correct)."""
+    def test_right_bower_played_card_shows_printed_suit(self, env):
+        """Right bower in trick card_slot shows printed suit (same as trump)."""
         tmpl = env.get_template("partials/trick.html")
         # J♣ played in a clubs contract — right bower
         html = tmpl.render(
@@ -3248,6 +3248,7 @@ class TestBowerDisplay:
         )
         assert "card--clubs" in html
         assert "card--bower" in html
+        assert ">RB<" in html  # right bower badge
 
     def test_non_bower_jack_no_badge(self, env):
         """Non-bower J does not get a bower badge."""
@@ -3273,8 +3274,8 @@ class TestBowerDisplay:
 
     # -- hand.html: card in player's hand --
 
-    def test_left_bower_in_hand_shows_trump_suit(self, env):
-        """Left bower in the hand shows trump suit and bower badge."""
+    def test_left_bower_in_hand_shows_printed_suit(self, env):
+        """Left bower in the hand shows printed suit and LB badge (#2261)."""
         tmpl = env.get_template("partials/hand.html")
         # J♦ in a hearts contract — left bower of hearts
         html = tmpl.render(
@@ -3286,13 +3287,13 @@ class TestBowerDisplay:
             contract_type="suit",
             trump="H",
         )
-        # The J♦ card should show hearts (♥), not diamonds (♦)
-        assert "card--hearts" in html
+        # The J♦ card should show diamonds (♦) — its printed suit
+        assert "card--diamonds" in html
         assert "card--bower" in html
-        assert "bower" in html.lower()
+        assert ">LB<" in html
 
-    def test_left_bower_legal_card_shows_trump_suit(self, env):
-        """Left bower as a legal play button shows trump suit."""
+    def test_left_bower_legal_card_shows_printed_suit(self, env):
+        """Left bower as a legal play button shows printed suit + LB badge."""
         tmpl = env.get_template("partials/hand.html")
         # J♠ legal in a clubs contract — left bower
         html = tmpl.render(
@@ -3304,10 +3305,11 @@ class TestBowerDisplay:
             contract_type="suit",
             trump="C",
         )
-        # Should show clubs suit, with bower badge
-        assert "card--clubs" in html
+        # Should show spades suit (printed), with LB bower badge
+        assert "card--spades" in html
         assert "card--bower" in html
         assert "(left bower)" in html
+        assert ">LB<" in html
 
     def test_hand_no_bower_without_trump(self, env):
         """No bower badge when trump is not set (e.g. auction phase)."""
@@ -3323,8 +3325,8 @@ class TestBowerDisplay:
 
     # -- trick_history.html: card in history table --
 
-    def test_left_bower_in_history_shows_trump_suit(self, env):
-        """Left bower in trick history shows trump suit."""
+    def test_left_bower_in_history_shows_printed_suit(self, env):
+        """Left bower in trick history shows printed suit + LB badge (#2261)."""
         tmpl = env.get_template("partials/trick_history.html")
         # J♠ in a clubs contract — left bower
         html = tmpl.render(
@@ -3345,14 +3347,15 @@ class TestBowerDisplay:
             contract_type="suit",
             trump="C",
         )
-        # Should show ♣ for the left bower, not ♠
-        assert "\u2663" in html  # ♣
+        # Should show ♠ for the left bower (printed suit), not ♣
+        assert "\u2660" in html  # ♠
         assert "bower-sup" in html
+        assert ">LB<" in html
 
     # -- moon_exchange.html: exchanged cards --
 
-    def test_left_bower_in_exchange_shows_trump_suit(self, env):
-        """Left bower in moon exchange given cards shows trump suit."""
+    def test_left_bower_in_exchange_shows_printed_suit(self, env):
+        """Left bower in moon exchange given cards shows printed suit (#2261)."""
         tmpl = env.get_template("partials/moon_exchange.html")
         html = tmpl.render(
             bidder_seat=0,
@@ -3363,13 +3366,15 @@ class TestBowerDisplay:
             link_uuid="test-uuid",
             human_hand=[["C", "K"], ["C", "Q"]],
         )
-        assert "card--clubs" in html
+        # Should show spades (♠) — printed suit of J♠
+        assert "card--spades" in html
         assert "card--bower" in html
+        assert ">LB<" in html
 
     # -- moon_exchange_select.html: selectable cards --
 
-    def test_left_bower_in_exchange_select_shows_trump_suit(self, env):
-        """Left bower in moon exchange selection shows trump suit."""
+    def test_left_bower_in_exchange_select_shows_printed_suit(self, env):
+        """Left bower in moon exchange selection shows printed suit (#2261)."""
         tmpl = env.get_template("partials/moon_exchange_select.html")
         html = tmpl.render(
             bidder_seat=0,
@@ -3380,8 +3385,10 @@ class TestBowerDisplay:
             exchange_prompt="Choose 2 cards",
             is_mooner=True,
         )
-        assert "card--clubs" in html
+        # Should show spades (♠) — printed suit of J♠
+        assert "card--spades" in html
         assert "card--bower" in html
+        assert ">LB<" in html
 
 
 class TestIsBowerFilter:

--- a/web/templates/partials/hand.html
+++ b/web/templates/partials/hand.html
@@ -25,7 +25,7 @@
             {% set suit = card[0] %}
             {% set rank = card[1] %}
             {% set idx = loop.index0 %}
-            {% set disp_suit = card|effective_suit(trump | default(None, true), contract_type | default(None, true)) %}
+            {% set disp_suit = card[0] %}
             {% set bower = card|is_bower(trump | default(None, true), contract_type | default(None, true)) %}
             {% set suit_class = suit_classes.get(disp_suit, "spades") %}
             {% set suit_sym = suit_symbols.get(disp_suit, disp_suit) %}
@@ -48,7 +48,7 @@
                     <span class="card__rank" aria-hidden="true">{{ rank|display_rank }}</span>
                     <span class="card__suit" aria-hidden="true">{{ suit_sym }}</span>
                     {% if bower %}
-                        <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">B</span>
+                        <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">{{ "RB" if bower == "right" else "LB" }}</span>
                     {% endif %}
                 </button>
             {% else %}
@@ -61,7 +61,7 @@
                     <span class="card__rank" aria-hidden="true">{{ rank|display_rank }}</span>
                     <span class="card__suit" aria-hidden="true">{{ suit_sym }}</span>
                     {% if bower %}
-                        <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">B</span>
+                        <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">{{ "RB" if bower == "right" else "LB" }}</span>
                     {% endif %}
                 </div>
             {% endif %}

--- a/web/templates/partials/moon_exchange.html
+++ b/web/templates/partials/moon_exchange.html
@@ -46,7 +46,7 @@
                 </h3>
                 <div class="moon-exchange__card-list" role="list">
                     {% for card in exchange_given_cards %}
-                        {% set disp_suit = card|effective_suit(trump | default(None, true), contract_type | default(None, true)) %}
+                        {% set disp_suit = card[0] %}
                         {% set bower = card|is_bower(trump | default(None, true), contract_type | default(None, true)) %}
                         <div class="card card--{{ suit_classes.get(disp_suit, 'spades') }} card--exchange{% if bower %} card--bower{% endif %}"
                              role="listitem"
@@ -54,7 +54,7 @@
                             <span class="card__rank" aria-hidden="true">{{ card[1]|display_rank }}</span>
                             <span class="card__suit" aria-hidden="true">{{ suit_symbols.get(disp_suit, disp_suit) }}</span>
                             {% if bower %}
-                                <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">B</span>
+                                <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">{{ "RB" if bower == "right" else "LB" }}</span>
                             {% endif %}
                         </div>
                     {% endfor %}
@@ -69,7 +69,7 @@
                 </h3>
                 <div class="moon-exchange__card-list" role="list">
                     {% for card in exchange_received_cards %}
-                        {% set disp_suit = card|effective_suit(trump | default(None, true), contract_type | default(None, true)) %}
+                        {% set disp_suit = card[0] %}
                         {% set bower = card|is_bower(trump | default(None, true), contract_type | default(None, true)) %}
                         <div class="card card--{{ suit_classes.get(disp_suit, 'spades') }} card--exchange card--exchange-received{% if bower %} card--bower{% endif %}"
                              role="listitem"
@@ -77,7 +77,7 @@
                             <span class="card__rank" aria-hidden="true">{{ card[1]|display_rank }}</span>
                             <span class="card__suit" aria-hidden="true">{{ suit_symbols.get(disp_suit, disp_suit) }}</span>
                             {% if bower %}
-                                <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">B</span>
+                                <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">{{ "RB" if bower == "right" else "LB" }}</span>
                             {% endif %}
                         </div>
                     {% endfor %}
@@ -92,7 +92,7 @@
             <h3 class="moon-exchange__group-title">Your Hand</h3>
             <div class="moon-exchange__card-list" role="list">
                 {% for card in human_hand %}
-                    {% set disp_suit = card|effective_suit(trump | default(None, true), contract_type | default(None, true)) %}
+                    {% set disp_suit = card[0] %}
                     {% set bower = card|is_bower(trump | default(None, true), contract_type | default(None, true)) %}
                     <div class="card card--{{ suit_classes.get(disp_suit, 'spades') }} card--hand{% if bower %} card--bower{% endif %}"
                          role="listitem"
@@ -100,7 +100,7 @@
                         <span class="card__rank" aria-hidden="true">{{ card[1]|display_rank }}</span>
                         <span class="card__suit" aria-hidden="true">{{ suit_symbols.get(disp_suit, disp_suit) }}</span>
                         {% if bower %}
-                            <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">B</span>
+                            <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">{{ "RB" if bower == "right" else "LB" }}</span>
                         {% endif %}
                     </div>
                 {% endfor %}

--- a/web/templates/partials/moon_exchange_select.html
+++ b/web/templates/partials/moon_exchange_select.html
@@ -45,7 +45,7 @@
                 {% set suit = card[0] %}
                 {% set rank = card[1] %}
                 {% set idx = loop.index0 %}
-                {% set disp_suit = card|effective_suit(trump | default(None, true), contract_type | default(None, true)) %}
+                {% set disp_suit = card[0] %}
                 {% set bower = card|is_bower(trump | default(None, true), contract_type | default(None, true)) %}
                 {% set suit_class = suit_classes.get(disp_suit, "spades") %}
                 {% set suit_sym = suit_symbols.get(disp_suit, disp_suit) %}
@@ -58,7 +58,7 @@
                     <span class="card__rank" aria-hidden="true">{{ rank|display_rank }}</span>
                     <span class="card__suit" aria-hidden="true">{{ suit_sym }}</span>
                     {% if bower %}
-                        <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">B</span>
+                        <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">{{ "RB" if bower == "right" else "LB" }}</span>
                     {% endif %}
                 </button>
             {% endfor %}

--- a/web/templates/partials/trick.html
+++ b/web/templates/partials/trick.html
@@ -55,7 +55,7 @@
 {% macro card_slot(seat, fallback_class="card-slot--empty", show_label=true) %}
     {% if seat in ns.cards %}
         {% set card = ns.cards[seat] %}
-        {% set disp_suit = card|effective_suit(trump | default(None, true), contract_type | default(None, true)) %}
+        {% set disp_suit = card[0] %}
         {% set bower = card|is_bower(trump | default(None, true), contract_type | default(None, true)) %}
         {% set is_winning = (current_trick is not none and trick_winning_seat is defined and trick_winning_seat == seat) %}
         <div class="card card--{{ suit_classes.get(disp_suit, 'spades') }} card--played{% if is_winning %} card--winning{% endif %}{% if bower %} card--bower{% endif %}"
@@ -64,7 +64,7 @@
             <span class="card__rank" aria-hidden="true">{{ card[1]|display_rank }}</span>
             <span class="card__suit" aria-hidden="true">{{ suit_symbols.get(disp_suit, disp_suit) }}</span>
             {% if bower %}
-                <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">B</span>
+                <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">{{ "RB" if bower == "right" else "LB" }}</span>
             {% endif %}
         </div>
     {% else %}
@@ -140,9 +140,10 @@
                 {{ seat_labels[display_winner] if display_winner in seat_labels else ("Seat " ~ display_winner) }}
             {% endif %}
             won{% if winning_card %} with
-                {% set wc_suit = winning_card|effective_suit(trump | default(None, true), contract_type | default(None, true)) %}
+                {% set wc_suit = winning_card[0] %}
+                {% set wc_bower = winning_card|is_bower(trump | default(None, true), contract_type | default(None, true)) %}
                 <span class="card-text card-text--{{ suit_classes.get(wc_suit, 'spades') }}"
-                      aria-label="{{ winning_card[1]|display_rank }} of {{ suit_names.get(wc_suit, wc_suit) }}">{{ suit_symbols.get(wc_suit, wc_suit) }}{{ winning_card[1]|display_rank }}</span>{% endif %}
+                      aria-label="{{ winning_card[1]|display_rank }} of {{ suit_names.get(wc_suit, wc_suit) }}{% if wc_bower %} ({{ wc_bower }} bower){% endif %}">{{ suit_symbols.get(wc_suit, wc_suit) }}{{ winning_card[1]|display_rank }}{% if wc_bower %}<sup class="bower-sup" title="{{ wc_bower|capitalize }} bower">{{ "RB" if wc_bower == "right" else "LB" }}</sup>{% endif %}</span>{% endif %}
         </p>
     {% endif %}
 </div>

--- a/web/templates/partials/trick_history.html
+++ b/web/templates/partials/trick_history.html
@@ -37,9 +37,9 @@
                             <td class="trick-history__cell{% if seat == trick.winner %} trick-history__cell--winner{% endif %}{% if seat == trick.leader %} trick-history__cell--leader{% endif %}">
                                 {% if seat in ns.cards %}
                                     {% set card = ns.cards[seat] %}
-                                    {% set disp_suit = card|effective_suit(trump | default(None, true), contract_type | default(None, true)) %}
+                                    {% set disp_suit = card[0] %}
                                     {% set bower = card|is_bower(trump | default(None, true), contract_type | default(None, true)) %}
-                                    <span class="card--inline card--inline-{{ suit_classes.get(disp_suit, 'spades') }}{% if bower %} card--inline-bower{% endif %}">{{ card[1]|display_rank }}{{ suit_symbols.get(disp_suit, disp_suit) }}{% if bower %}<sup class="bower-sup" title="{{ bower|capitalize }} bower">B</sup>{% endif %}</span>
+                                    <span class="card--inline card--inline-{{ suit_classes.get(disp_suit, 'spades') }}{% if bower %} card--inline-bower{% endif %}">{{ card[1]|display_rank }}{{ suit_symbols.get(disp_suit, disp_suit) }}{% if bower %}<sup class="bower-sup" title="{{ bower|capitalize }} bower">{{ "RB" if bower == "right" else "LB" }}</sup>{% endif %}</span>
                                 {% else %}
                                     <span class="trick-history__absent" aria-label="Sitting out">&mdash;</span>
                                 {% endif %}


### PR DESCRIPTION
## Summary

- Bowers now display their **original printed suit** (e.g. J♥ stays J♥) instead of the effective trump suit
- Badge changed from generic "B" to **"RB"** (right bower) or **"LB"** (left bower) to distinguish between them
- Lead-suit indicator still uses `effective_suit` (game logic — tells players what suit to follow)

## Why

PR #2234 changed bower display to show the effective (trump) suit, making bowers indistinguishable. In a 6♦ contract, both J♦ (right bower) and J♥ (left bower) displayed as `J♦ᴮ` — the user couldn't tell which card they were looking at. Fixes #2261.

## Changes

| File | Change |
|------|--------|
| `web/templates/partials/hand.html` | Use `card[0]` for display suit; badge → RB/LB |
| `web/templates/partials/trick.html` | Use `card[0]` for played cards; badge → RB/LB; winning card shows printed suit + bower label |
| `web/templates/partials/trick_history.html` | Use `card[0]` for display suit; badge → RB/LB |
| `web/templates/partials/moon_exchange.html` | Use `card[0]` for display suit; badge → RB/LB |
| `web/templates/partials/moon_exchange_select.html` | Use `card[0]` for display suit; badge → RB/LB |
| `tests/unit/hosted_play/test_partials.py` | Updated `TestBowerDisplay` to verify printed suit + RB/LB labels |

## Repro / Validation

```bash
# Targeted bower tests
uv run python -m pytest tests/unit/hosted_play/test_partials.py -k "bower" -xvs

# Full partials suite
uv run python -m pytest tests/unit/hosted_play/test_partials.py -x
```

## Tests

- `TestBowerDisplay` (9 tests): All pass — verify printed suit and RB/LB labels across trick, hand, history, exchange, and exchange-select partials
- `TestTrick` lead-suit tests (6 tests): All pass — lead indicator still uses effective_suit
- `TestIsBowerFilter` (7 tests): All pass — filter logic unchanged
- Full `test_partials.py` suite: 219 passed

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: fix/bower-display-original-suit
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)