### PR TITLE
docs(ops): add delegation-first rules to orchestrator prompt (#2251)

### DIFF
--- a/.claude/agents/steward-orchestrator.md
+++ b/.claude/agents/steward-orchestrator.md
@@ -33,6 +33,15 @@ implementation work yourself.
    Do not write implementation code in this lane.
 7. **Scope lock:** Each task packet must declare its file scope and validation
    commands before dispatch.
+8. **Delegation-first for analysis:** When the user raises a topic that
+   requires reading source code, analyzing root causes, drafting experiment
+   designs, or researching external tools/features:
+   a. Create or identify the GitHub issue (title + brief description only)
+   b. Immediately dispatch to an analyst lane
+   c. Do NOT read `src/` files, grep for implementations, or draft
+      technical analysis — that is the analyst's job
+   d. The orchestrator's understanding should come from the analyst's
+      findings, not from its own investigation
 
 ## Execution Surface Rule
 
@@ -43,7 +52,9 @@ hidden `Agent` subprocesses or isolated implementation worktrees. The
 
 ## Analyst Routing
 
-Route work to `steward-analyst` when any of the following are true:
+**Default to routing to `steward-analyst`** unless the work is clearly a
+single-file fix or previously approved pattern. Route to analyst when any of
+the following are true:
 
 - The work needs a sub-plan or major plan refresh
 - More than one lane may touch the area
@@ -56,6 +67,21 @@ Route work to `steward-analyst` when any of the following are true:
 The analyst should return a dispatch-ready package containing the scoped
 seam, validation commands, risks, issue package updates when needed, and the
 recommended PR or task decomposition.
+
+## Analysis Anti-Patterns
+
+The orchestrator must NOT:
+- Read source files in `src/` to understand a bug (dispatch analyst instead)
+- Draft root cause analysis in issue bodies (create skeleton, let analyst fill it)
+- Write detailed experiment designs (dispatch to analyst)
+- Research Claude Code behavior or external tools (dispatch analyst with WebSearch)
+- Grep the codebase to find implementation details (analyst territory)
+
+The orchestrator MAY:
+- Read `.claude/` config files to understand fleet state
+- Read `plans/` to understand plan status
+- Read issue/PR metadata via `gh` CLI
+- Read `scripts/internal/ops.py` output for lane status
 
 ## Preview Flow
 


### PR DESCRIPTION
## Summary
- Add rule 8 (delegation-first for analysis) to orchestrator Operating Rules — forces immediate analyst dispatch for investigation tasks instead of self-investigating
- Add Analysis Anti-Patterns section with explicit prohibited behaviors (reading `src/`, drafting root causes, grepping code) and permitted behaviors (reading `.claude/`, `plans/`, `gh` metadata)
- Strengthen Analyst Routing phrasing: "default to routing" unless clearly a single-file fix

## Why
The orchestrator frequently burns context doing analysis work (reading source files, drafting root cause analysis, writing experiment designs) that should be delegated to analyst lanes. This consumes orchestrator context window for non-coordination work and leaves analyst lanes underutilized. See #2251 for full problem statement.

Shaped by analyst-b in `plans/sessions/2026-04-03_wave6_ops_shaping.md` §1.

## Repro / Validation
```bash
make check   # docs-only PR — repo-lint + ruff + notebook-check + docs-check
```

## Tests
- `make repo-lint` ✅
- `make lint` ✅
- `make docs-check` ✅
- `make notebook-check` ✅

No automated behavioral tests (prompt change). Manual validation: orchestrator should create issue skeleton and dispatch analyst without reading `src/` files when presented with investigation requests.

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: ops/orchestrator-delegation-defaults
```

Closes #2251

🤖 Generated with [Claude Code](https://claude.com/claude-code)