### PR TITLE
docs(ops): add analyst issue-comment delivery mode (#2257)

### DIFF
--- a/.claude/agents/steward-analyst.md
+++ b/.claude/agents/steward-analyst.md
@@ -120,6 +120,41 @@ Every handoff you draft should state:
 - Do not silently expand scope; record scope changes in the plan or issue.
 - Do not spawn hidden subprocess agents from this lane.
 
+## Delivery Modes
+
+### Issue-Comment Mode (default for research tasks)
+
+When the task packet references a parent issue and the deliverable is
+analysis/investigation/research:
+
+1. Post findings as a structured comment on the parent issue
+2. Use the comment format below
+3. Do NOT create a branch, commit files, or open a PR
+4. The orchestrator reviews the comment and decides next steps
+
+**Comment structure:**
+- `## Findings` — evidence, root cause, code references
+- `## Proposed Changes` — file scope, change description, acceptance criteria
+- `## Validation` — commands, gates, smoke tests
+- `## Risks` — scope traps, coordination hazards
+- `## Recommended PRs` — decomposition for author dispatch
+
+### PR Mode (for durable artifacts)
+
+Create a branch and PR when the deliverable requires version control:
+- Governing plans or sub-plans
+- Checkpoint or state file updates
+- `.claude/` config changes (skills, rules, settings)
+- Session handoff documents that other automation reads
+
+### Mode Selection
+
+The task packet should specify the delivery mode. If unspecified:
+- Task references a GitHub issue → **issue-comment mode**
+- Task references a plan or checkpoint → **PR mode**
+- Ambiguous → default to **issue-comment mode** and escalate if
+  the findings warrant committed artifacts
+
 ## Success Criteria
 
 - The orchestrator spends less time reconstructing context

--- a/.claude/skills/delegate-task/SKILL.md
+++ b/.claude/skills/delegate-task/SKILL.md
@@ -31,6 +31,14 @@ intake-to-dispatch flow into a reusable workflow.
    - **priority:** low / normal / high
    - **domain:** Execution domain for routing — `platform` or `browser-game`.
      Determines which worker pool the task routes to. Omit for flex/unspecified.
+   - **delivery_mode:** `issue-comment` (default for analyst research) or
+     `pr` (for durable artifacts). Controls whether the analyst posts
+     findings as an issue comment or creates a branch and PR. Optional —
+     defaults to `pr` for author lanes, `issue-comment` for analyst lanes
+     with a `parent_issue`.
+   - **parent_issue:** GitHub issue number for issue-comment delivery.
+     Required when `delivery_mode` is `issue-comment`. The analyst posts
+     findings as a structured comment on this issue.
 
 2. **Choose the target lane** using the delegation guidelines:
 

--- a/.claude/skills/start-task/SKILL.md
+++ b/.claude/skills/start-task/SKILL.md
@@ -54,6 +54,27 @@ decomposition (use `/executing-plans` for that).
 4. If scope is ambiguous, ask the orchestrator for clarification before
    proceeding. Do not guess at scope boundaries.
 
+### Phase 1.5 — Delivery Mode Check (Analyst Lanes)
+
+If you are an analyst lane and the task is research/investigation:
+
+4b. **Check delivery mode** in the task packet:
+    - If `delivery_mode` is `issue-comment` (or the task references a parent
+      issue and doesn't require committed artifacts) → skip branch setup,
+      skip PR creation
+    - Post findings directly as a comment on the parent issue using
+      `gh issue comment <number> --body "<structured findings>"`
+    - After posting, send a completion message to the orchestrator:
+      ```bash
+      uv run python scripts/internal/ops.py message send \
+        --from <lane> --to orchestrator --type completion \
+        --summary "Done: findings posted on #<issue>" --task-id <PACKET_ID>
+      ```
+    - If you discover the work needs committed artifacts, proceed to
+      Phase 2 (Branch Setup) and note the mode change
+
+5b. **Skip to Phase 4** (investigation) without branch setup.
+
 ### Phase 2 — Branch Setup
 
 5. **Ensure you are in your dedicated author worktree** (not the main checkout).


### PR DESCRIPTION
## Plan
plans/sessions/2026-04-03_wave6_ops_shaping.md §2

## Summary
- Add Delivery Modes section to `steward-analyst.md` with issue-comment (default for research) and PR mode (for durable artifacts)
- Add Phase 1.5 analyst delivery mode check to `start-task` skill — analysts skip branch setup for research tasks
- Add `delivery_mode` and `parent_issue` fields to `delegate-task` skill packet schema

## Why
Analyst lanes default to the author-lane PR workflow for research findings. This creates CI noise, merge conflicts, auto-merge races, and git history clutter. Issue-comment delivery is the natural output for investigation tasks — durable, reviewable, and zero-overhead.

Closes #2257

## Repro / Validation
**Command(s) run:**
```bash
make check-quiet
```

**Config (if applicable):** N/A

**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** All three files contain the new sections; no code changes; CI passes (docs-only path)
- **Verification command:** `git diff --stat origin/main`
- **Expected result:** 3 files changed (all `.md`), ~64 insertions

## Tests
- [x] `make check-quiet` — 3 pre-existing failures unrelated to this PR (token_economy mock counts, telegram filter edge case). All 11,095 other tests pass.
- [x] Docs-only change — no behavior-affecting code modified

## Expected impact
- Metrics impact: None
- Runtime impact: None — docs-only

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b  a39bc4da [ops/analyst-issue-comment-default]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)