### PR TITLE
docs(ops): add web research defaults to analyst prompt (#2252)

### DIFF
--- a/.claude/agents/steward-analyst.md
+++ b/.claude/agents/steward-analyst.md
@@ -18,7 +18,9 @@ implementation. Your job is to make complex work easier to execute safely.
 ## Core Responsibilities
 
 1. **Investigate first.** Read the active governing plan, checkpoints,
-   sub-plans, issue context, and repo state before recommending a path.
+   sub-plans, issue context, and repo state. Use WebSearch for external best
+   practices and prior art. Recommend a path grounded in both local evidence
+   and external research.
 2. **Find the seam.** Identify the real subsystem, file scope, and execution
    boundary rather than packaging vague work.
 3. **Draft durable artifacts.** Produce sub-plans, execution briefs, issue
@@ -101,6 +103,40 @@ Every handoff you draft should state:
    part of the problem.
 6. If the plan is non-trivial, prepare it for independent plan review.
 7. Hand the finished package back to the orchestrator for dispatch.
+
+## Research Protocol
+
+Every investigation task should include external research as a default step,
+not just local codebase analysis.
+
+### Default Research Steps
+
+1. **Local investigation:** Read relevant source files, plans, issues, and
+   repo state to understand the current implementation
+2. **External research:** Use `WebSearch` to find:
+   - How other projects/teams solve similar problems
+   - Best practices and patterns from the broader ecosystem
+   - Relevant tool documentation, blog posts, and GitHub discussions
+   - Novel approaches not yet represented in the codebase
+3. **Synthesis:** Combine local evidence with external findings to produce
+   a more complete analysis
+
+### When to Skip Web Research
+
+- The task is purely about internal state reconciliation (checkpoint drift,
+  task list audit, plan refresh)
+- The investigation is about a bug in our own code with no external analog
+- Time pressure explicitly noted in the task packet
+
+### Search Strategy
+
+When using WebSearch, search from multiple angles:
+- `"<problem domain> best practices"` — established patterns
+- `"<tool name> <specific feature>"` — tool documentation
+- `"<error message or pattern>"` — community solutions
+- `"<alternative approach> vs <current approach>"` — comparative analysis
+
+Cite external sources in findings with URLs when available.
 
 ## Issue Handling
 


### PR DESCRIPTION
## Plan
- Shaped output: plans/sessions/2026-04-03_wave6_ops_shaping.md §3
- Issue comment: https://github.com/Questuart/Bid-Euchre/issues/2252#issuecomment-4185237379

## Summary
- Add Research Protocol section to `.claude/agents/steward-analyst.md` with default web research steps, skip conditions, and search strategy guidance
- Update Core Responsibilities item 1 to reference WebSearch explicitly

## Why
Analyst lanes only investigate the local codebase. WebSearch is available but never prompted for. This change makes external research a default step so analyst findings include best practices and prior art from the broader ecosystem.

Closes #2252

## Repro / Validation
**Command(s) run:**
- `make check-quiet`

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** `steward-analyst.md` contains "Research Protocol" section and "WebSearch" in Core Responsibilities
- **Verification command:** `grep -c WebSearch .claude/agents/steward-analyst.md`
- **Expected result:** `2` (one in Core Responsibilities, one in Research Protocol)

## Tests
- [x] Other: `make check-quiet` (docs-only change, no Python tests needed)

## Expected impact
- Metrics impact: None (docs-only)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

`git worktree list` (abbreviated):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c  0ce66f74 [ops/analyst-web-research-defaults]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)