### PR TITLE
fix: convention follow-ups for #2268, #2270, #2275, #2278

### DIFF
--- a/.claude/agents/steward-orchestrator.md
+++ b/.claude/agents/steward-orchestrator.md
@@ -140,6 +140,7 @@ all orchestrator-created tasks should follow this convention.
 | Single-file bugfix | No | Any idle author in matching pool | Infer from scope |
 | Multi-file feature | Yes | author-a or author-b | platform |
 | Architectural change | Yes + analyst + plan review | author-a | platform |
+| Investigation / analysis | No | steward-analyst (see Analyst Routing) | (analyst) |
 | Exploratory analysis | No | author-scratch or flex-* | (flex) |
 | Overflow / parallel work | Yes | author-c, author-d, or flex-* | Match source |
 | Browser-game work | Yes | brws-author-a through brws-author-d | browser-game |

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -116,7 +116,7 @@
     ]
   },
   "permissions": {
-    "defaultMode": "dontAsk",
+    "defaultMode": "acceptEdits",
     "allow": [
       "Edit(.claude/skills/**)",
       "Write(.claude/skills/**)",

--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -2142,6 +2142,8 @@ class TestContractBar:
         assert "High" in html
         assert "by You" in html
         assert "contract-bar--my-team" in html
+        assert "Current Contract:" in html
+        assert "and Trump" not in html
 
     def test_low_contract(self, env):
         """Low (no-trump) contract by partner shows 'by Ace'."""
@@ -2202,8 +2204,22 @@ class TestContractBar:
             phase="auction",
         )
         assert "contract-bar" in html
-        assert "Current Contract and Trump:" in html
+        assert "Auction:" in html
         assert "Auction in Progress" in html
+
+    def test_auction_shows_high_bid(self, env):
+        """During auction with a current high bid, shows the bid amount."""
+        tmpl = env.get_template("partials/contract_bar.html")
+        html = tmpl.render(
+            winning_bid=None,
+            bidder_seat=None,
+            bid_type="regular",
+            contract_type=None,
+            trump=None,
+            phase="auction",
+            current_high_bid=6,
+        )
+        assert "High Bid: 6" in html
 
     def test_hidden_when_no_bid_no_phase(self, env):
         """No output when winning_bid is None and phase is not auction."""
@@ -2271,8 +2287,8 @@ class TestContractBar:
         assert "by Deuce" in html
         assert "contract-bar--opp-team" in html
 
-    def test_header_label_present(self, env):
-        """Contract bar shows 'Current Contract and Trump:' header label."""
+    def test_header_label_suit(self, env):
+        """Suit contract shows 'Current Contract and Trump:' header."""
         tmpl = env.get_template("partials/contract_bar.html")
         html = tmpl.render(
             winning_bid=5,
@@ -2283,6 +2299,20 @@ class TestContractBar:
         )
         assert "contract-bar__header" in html
         assert "Current Contract and Trump:" in html
+
+    def test_header_label_no_trump(self, env):
+        """No-trump contract shows neutral 'Current Contract:' header."""
+        tmpl = env.get_template("partials/contract_bar.html")
+        html = tmpl.render(
+            winning_bid=7,
+            bidder_seat=0,
+            bid_type="regular",
+            contract_type="high",
+            trump=None,
+        )
+        assert "contract-bar__header" in html
+        assert "Current Contract:" in html
+        assert "and Trump" not in html
 
 
 # ---------------------------------------------------------------------------

--- a/web/static/game.js
+++ b/web/static/game.js
@@ -119,6 +119,9 @@
             if (status) {
                 gameBoard.setAttribute('data-match-status', status);
             }
+        } else {
+            // Setup partials omit the carrier — clear stale status (#2276)
+            gameBoard.removeAttribute('data-match-status');
         }
     }
 

--- a/web/templates/partials/contract_bar.html
+++ b/web/templates/partials/contract_bar.html
@@ -23,8 +23,12 @@
 
 {% if winning_bid is not none and bidder_seat is not none %}
 <div class="contract-bar {{ team_class }}" role="status" aria-label="Current contract">
-    {# Header label — spelled out per user direction #}
+    {# Header label — include "and Trump" only for suit contracts #}
+    {% if contract_type == "suit" %}
     <span class="contract-bar__header">Current Contract and Trump:</span>
+    {% else %}
+    <span class="contract-bar__header">Current Contract:</span>
+    {% endif %}
 
     {# Contract display #}
     <span class="contract-bar__contract">
@@ -55,7 +59,13 @@
 </div>
 {% elif phase is defined and phase == "auction" %}
 <div class="contract-bar" role="status" aria-label="Auction in progress">
-    <span class="contract-bar__header">Current Contract and Trump:</span>
-    <span class="contract-bar__auction-status">Auction in Progress</span>
+    <span class="contract-bar__header">Auction:</span>
+    <span class="contract-bar__auction-status">
+        {% if current_high_bid is defined and current_high_bid is not none and current_high_bid > 0 %}
+            High Bid: {{ current_high_bid }}
+        {% else %}
+            Auction in Progress
+        {% endif %}
+    </span>
 </div>
 {% endif %}


### PR DESCRIPTION
## Summary

- **settings.json:** Replace unsupported `defaultMode` "dontAsk" with `acceptEdits` per CC features audit (#2269)
- **contract_bar.html:** Use neutral "Current Contract:" header for no-trump contracts; show current high bid in auction status bar (#2272)
- **game.js:** Clear stale `data-match-status` when carrier element is absent from setup partials (#2276)
- **steward-orchestrator.md:** Add investigation/analysis row to delegation guidelines table for analyst routing (#2279)

## Why

Review coordinator flagged convention findings on 4 merged PRs. Batched into single PR since all are small, independent fixes.

## Repro / Validation

```bash
# Verify settings.json
python -c "import json; d=json.load(open('.claude/settings.json')); assert d['permissions']['defaultMode'] == 'acceptEdits'; print('OK')"

# Targeted tests
uv run python -m pytest tests/unit/hosted_play/test_partials.py -v -k "contract_bar"

# Full validation
make check-quiet
# 11104 passed, 3 pre-existing failures (test_ops_token_economy, test_telegram_filter)
```

## Tests

- `uv run python -m pytest tests/unit/hosted_play/test_partials.py` — 221 passed (3 new tests added)
- `make check-quiet` — 11104 passed, 3 pre-existing failures

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: fix/convention-followups-2269-2272-2276-2279
```

Closes #2269, closes #2272, closes #2276, closes #2279

🤖 Generated with [Claude Code](https://claude.com/claude-code)