### PR TITLE
fix(ops): downgrade fleet_idle alert from HIGH to WARN (#2262)

### DIFF
--- a/src/bid_euchre/ops/monitor.py
+++ b/src/bid_euchre/ops/monitor.py
@@ -1571,7 +1571,7 @@ def check_fleet_idle(
         findings.append(
             MonitorFinding(
                 category="fleet_idle",
-                severity=SEVERITY_HIGH,
+                severity=SEVERITY_WARN,
                 summary=(
                     f"Fleet idle for {recommendation.idle_status.idle_minutes:.0f}m — "
                     f"auto-shutoff recommended"

--- a/tests/unit/test_ops_monitor.py
+++ b/tests/unit/test_ops_monitor.py
@@ -3379,8 +3379,8 @@ class TestCheckOpenPRsReady:
 class TestCheckFleetIdle:
     """Tests for fleet-level idle check (auto-shutoff wiring)."""
 
-    def test_emits_high_finding_when_idle(self) -> None:
-        """Should emit HIGH severity finding when fleet is idle."""
+    def test_emits_warn_finding_when_idle(self) -> None:
+        """Should emit WARN severity finding when fleet is idle."""
         from bid_euchre.ops.idle_detector import IdleStatus, ShutoffRecommendation
 
         idle_rec = ShutoffRecommendation(
@@ -3405,14 +3405,14 @@ class TestCheckFleetIdle:
             ):
                 findings = check_fleet_idle()
 
-        high = [f for f in findings if f.severity == "high"]
-        assert len(high) == 1
-        assert high[0].category == "fleet_idle"
-        assert "120m" in high[0].summary
-        assert "shutoff" in high[0].summary.lower()
-        assert high[0].details["should_shutoff"] is True
-        assert high[0].details["idle_minutes"] == 120.0
-        assert len(high[0].details["recommended_actions"]) == 2
+        warn = [f for f in findings if f.severity == "warn"]
+        assert len(warn) == 1
+        assert warn[0].category == "fleet_idle"
+        assert "120m" in warn[0].summary
+        assert "shutoff" in warn[0].summary.lower()
+        assert warn[0].details["should_shutoff"] is True
+        assert warn[0].details["idle_minutes"] == 120.0
+        assert len(warn[0].details["recommended_actions"]) == 2
 
     def test_emits_info_when_active(self) -> None:
         """Should emit info finding when fleet is active."""


### PR DESCRIPTION
## Summary

- Downgrade `fleet_idle` monitor finding severity from `SEVERITY_HIGH` to `SEVERITY_WARN`
- Update corresponding test to assert `warn` instead of `high`

## Why

Fleet being idle is normal between dispatch waves. Using HIGH severity causes:
- Supervisor alert escalations every monitoring cycle
- Dispatch blocking via the urgent-state-guard
- Manual intervention required each check-in cycle

HIGH severity should be reserved for genuinely critical conditions (lane crashes, merge conflicts, permission stalls).

Closes #2262

## Repro / Validation

```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/test_ops_monitor.py::TestCheckFleetIdle -v

# Tier 2 — full validation
make check-quiet
```

All 3 `TestCheckFleetIdle` tests pass. Full `make check` shows 11102 passed with 3 pre-existing failures unrelated to this change (token_economy, telegram_filter).

## Test criteria

- `check_fleet_idle()` returns findings with `severity="warn"` (not `"high"`) when `should_shutoff=True`
- `check_fleet_idle()` returns findings with `severity="info"` when fleet is active (unchanged)
- `check_fleet_idle()` returns findings with `severity="warn"` on exception (unchanged)

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
worktree: Bid-Euchre-steward-author-b
branch: fix/fleet-idle-severity
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)