### PR TITLE
feat(ops): add PermissionDenied hook for observability (#2256)

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -224,6 +224,7 @@ Hooks are registered across two files:
 - `PostToolUse` (Write|Edit) → `post-write-check.sh`
 - `PostToolUse` (Bash) → `post-bash-dispatch.sh` (consolidated dispatcher)
 - `PostToolUse` (MCP Telegram tools) → `post-telegram-audit.sh` (audit trail)
+- `PermissionDenied` (all) → `permission-denied-log.sh` (denial observability)
 - `UserPromptSubmit` (all) → `alert-inject.sh` (fleet alert injection)
 - `UserPromptSubmit` (all) → `inbound-channel-audit.sh` (inbound Telegram audit)
 
@@ -329,6 +330,34 @@ Since hooks can't change directories, the workflow is:
 4. User restarts Claude in new location
 
 This reduces friction from "manual branch creation + worktree creation + cd" to just "cd + restart".
+
+### `permission-denied-log.sh` (PermissionDenied)
+
+**Trigger:** When the auto-mode classifier denies a tool call (Claude Code v2.1.89+)
+
+**Purpose:** Logs permission denials for ops observability — identifies allowlist
+gaps and monitors for unexpected denials.
+
+**Behavior:**
+1. Reads PermissionDenied JSON payload from stdin (tool_name, reason, tool_input, session_id)
+2. Constructs a JSONL record with timestamp, lane, tool_name, reason, session_id, tool_input
+3. Appends to `.claude/runtime/permission_denials.jsonl` (gitignored)
+4. Returns `retry: false` (lets the denial stand — never overrides safety)
+5. Always exits 0 — never blocks, never crashes
+
+**Limitations:**
+- Only fires in **auto mode** (Team/Enterprise plan). Does NOT fire for:
+  - Manual user denial of permission dialogs
+  - PreToolUse hook blocks (exit 2)
+  - `dontAsk` mode allowlist misses
+  - `permissions.deny` rule matches
+- Forward-looking: useful when the fleet adopts auto mode
+
+**Speed:** ~50ms (bash + jq only, no Python)
+
+**Registration:** `.claude/settings.json` → `PermissionDenied` (timeout: 5s)
+
+**Related:** #2256
 
 ### `alert-inject.sh` / `alert-inject.py` (UserPromptSubmit)
 

--- a/.claude/hooks/permission-denied-log.sh
+++ b/.claude/hooks/permission-denied-log.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# permission-denied-log.sh — PermissionDenied hook: log auto-mode denials for observability.
+#
+# Fires when the auto-mode classifier denies a tool call (Claude Code v2.1.89+).
+# Appends a JSONL record to .claude/runtime/permission_denials.jsonl.
+#
+# Limitations:
+#   - Only fires in auto mode (Team/Enterprise plan). Does NOT fire for:
+#     - Manual user denial of permission dialogs
+#     - PreToolUse hook blocks (exit 2)
+#     - dontAsk mode allowlist misses
+#     - permissions.deny rule matches
+#   - Useful as forward-looking observability for when the fleet adopts auto mode.
+#
+# Design:
+#   - Never crashes — all operations wrapped in defensive guards
+#   - Never blocks — always exits 0, returns retry: false
+#   - Lightweight — uses only bash builtins + jq (no Python, no uv)
+#
+# Closes #2256.
+set -euo pipefail
+
+# Read PermissionDenied JSON payload from stdin
+INPUT=$(cat)
+
+# Extract fields (defensive: default to empty string on parse failure)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // "unknown"' 2>/dev/null || echo "unknown")
+REASON=$(echo "$INPUT" | jq -r '.reason // "no reason provided"' 2>/dev/null || echo "no reason provided")
+TOOL_INPUT=$(echo "$INPUT" | jq -c '.tool_input // {}' 2>/dev/null || echo '{}')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null || echo "unknown")
+
+# Derive lane name from project dir
+LANE="unknown"
+if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
+    LANE=$(basename "$CLAUDE_PROJECT_DIR" | sed 's/^Bid-Euchre-steward-//' | sed 's/^Bid-Euchre/main/')
+fi
+
+# Ensure runtime directory exists
+RUNTIME_DIR="${CLAUDE_PROJECT_DIR:-.}/.claude/runtime"
+mkdir -p "$RUNTIME_DIR" 2>/dev/null || true
+
+# Construct JSONL record
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "unknown")
+RECORD=$(jq -nc \
+    --arg ts "$TIMESTAMP" \
+    --arg lane "$LANE" \
+    --arg tool "$TOOL_NAME" \
+    --arg reason "$REASON" \
+    --arg session "$SESSION_ID" \
+    --argjson tool_input "$TOOL_INPUT" \
+    '{timestamp: $ts, lane: $lane, tool_name: $tool, reason: $reason, session_id: $session, tool_input: $tool_input}' \
+    2>/dev/null || echo "{\"timestamp\":\"$TIMESTAMP\",\"lane\":\"$LANE\",\"tool_name\":\"$TOOL_NAME\",\"reason\":\"$REASON\"}")
+
+# Append to JSONL log (best-effort)
+echo "$RECORD" >> "$RUNTIME_DIR/permission_denials.jsonl" 2>/dev/null || true
+
+# Return hook response: do not retry (let denial stand for safety)
+echo '{"hookSpecificOutput": {"hookEventName": "PermissionDenied", "retry": false}}'
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -85,6 +85,17 @@
         ]
       }
     ],
+    "PermissionDenied": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/permission-denied-log.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [


### PR DESCRIPTION
## Summary

- Add `.claude/hooks/permission-denied-log.sh` — logs auto-mode permission denials to JSONL
- Register `PermissionDenied` hook in `.claude/settings.json`
- Document the hook in `.claude/hooks/README.md`

## Why

With dontAsk mode, denied tools fail silently from the orchestrator's perspective. A hook that logs denials provides observability into allowlist gaps and unexpected denials, especially as the fleet moves toward auto mode.

## Implementation

- **Hook script** (bash + jq, ~50ms): reads denial payload from stdin, extracts tool_name/reason/tool_input/session_id, appends JSONL record to `.claude/runtime/permission_denials.jsonl` (gitignored)
- **Each log entry**: timestamp, lane, tool_name, reason, session_id, tool_input
- **Safety**: never blocks (exit 0), returns `retry: false`, graceful on malformed input
- **Limitation**: only fires in auto mode (Team/Enterprise). Does NOT fire for dontAsk allowlist misses, PreToolUse blocks, or manual denials

## Repro / Validation

```bash
# Smoke test the hook directly
echo '{"tool_name":"Bash","reason":"test denial","tool_input":{"command":"rm -rf /"},"session_id":"test123"}' \
  | CLAUDE_PROJECT_DIR="$(pwd)" .claude/hooks/permission-denied-log.sh
# Expected output: {"hookSpecificOutput":{"hookEventName":"PermissionDenied","retry":false}}

# Verify JSONL entry
cat .claude/runtime/permission_denials.jsonl | jq .

# Malformed input graceful handling
echo 'not json' | CLAUDE_PROJECT_DIR="$(pwd)" .claude/hooks/permission-denied-log.sh
# Expected: exits 0 with retry:false, logs entry with "unknown" defaults
```

## Tests

- `make check-quiet` — 3 pre-existing failures on main (unrelated: `test_ops_token_economy`, `test_telegram_filter`); no new failures
- Manual smoke test: valid JSON → correct JSONL entry with all fields
- Manual smoke test: malformed input → graceful degradation to "unknown" defaults

## Worktree proof

```
pwd: Bid-Euchre-steward-author-c
branch: ops/permission-denied-hook
```

Closes #2256

🤖 Generated with [Claude Code](https://claude.com/claude-code)