### PR TITLE
fix(web): rank text white, only suit icon colored (#2289)

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -1214,10 +1214,12 @@ class TestHandResult:
         assert "Moon exchange" in html
         assert "Given 2 to partner" in html
         assert "Received 2 from partner" in html
-        assert "♠ 10" in html
-        assert "♦ J" in html
-        assert "♥ Q" in html
-        assert "♣ A" in html
+        # Rank and suit are in separate spans: <span class="suit-icon ...">♠</span> 10
+        assert "♠" in html
+        assert ">♠</span> 10" in html
+        assert ">♦</span> J" in html
+        assert ">♥</span> Q" in html
+        assert ">♣</span> A" in html
 
     def test_hand_result_shows_next_hand_button(self, env):
         """Hand results should include an action to advance to the next hand."""
@@ -3523,7 +3525,9 @@ class TestDisplayRankFilter:
         ]
         tmpl = env.get_template("partials/trick_history.html")
         html = tmpl.render(completed_tricks=tricks, tricks_team0=1, tricks_team1=0)
-        assert "10♠" in html
+        # Rank and suit are in separate spans (#2289)
+        assert "10<span" in html
+        assert ">♠</span>" in html
 
     def test_moon_exchange_renders_ten_as_10(self, env):
         """Ten cards in moon_exchange.html show '10'."""

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -961,20 +961,12 @@ main {
 }
 
 /* Inline card rendering (for trick history table) —
-   suit-colored text for red/black readability (#2235).
-   Leader underline and winner highlight remain via cell classes. */
+   rank text stays default (white); suit icon colored via .suit-icon utility
+   (#2235, #2289).  Leader underline and winner highlight remain via cell
+   classes. */
 .card--inline {
     font-weight: 700;
     white-space: nowrap;
-}
-
-.card--inline-hearts,
-.card--inline-diamonds {
-    color: var(--color-red);
-}
-
-.card--inline-spades,
-.card--inline-clubs {
     color: var(--color-text);
 }
 
@@ -2824,18 +2816,11 @@ main {
     color: var(--color-text-muted);
 }
 
+/* Card text in exchange summaries — rank stays default (white); suit icon
+   colored via .suit-icon utility (#2289). */
 .card-text {
     font-weight: 700;
     white-space: nowrap;
-}
-
-.card-text--hearts,
-.card-text--diamonds {
-    color: var(--color-red);
-}
-
-.card-text--spades,
-.card-text--clubs {
     color: var(--color-text);
 }
 

--- a/web/templates/partials/hand_result.html
+++ b/web/templates/partials/hand_result.html
@@ -113,11 +113,11 @@
                 <p class="exchange-title"><strong>Moon Exchange</strong></p>
                 <p class="exchange-details">
                     Given {{ exchange_given_cards|length }} to partner ({{ partner_seat_label }}):
-                    {% for card in exchange_given_cards %}<span class="card-text card-text--{{ suit_classes.get(card[0], 'spades') }}" aria-label="{{ suit_symbols.get(card[0], card[0]) }}{{ card[1]|display_rank }}">{{ suit_symbols.get(card[0], card[0]) }} {{ card[1]|display_rank }}</span>{% if not loop.last %}, {% endif %}{% endfor %}
+                    {% for card in exchange_given_cards %}<span class="card-text" aria-label="{{ suit_symbols.get(card[0], card[0]) }}{{ card[1]|display_rank }}"><span class="suit-icon suit-icon--{{ suit_classes.get(card[0], 'spades') }}">{{ suit_symbols.get(card[0], card[0]) }}</span> {{ card[1]|display_rank }}</span>{% if not loop.last %}, {% endif %}{% endfor %}
                 </p>
                 <p class="exchange-details">
                     Received {{ exchange_received_cards|length }} from partner ({{ partner_seat_label }}):
-                    {% for card in exchange_received_cards %}<span class="card-text card-text--{{ suit_classes.get(card[0], 'spades') }}" aria-label="{{ suit_symbols.get(card[0], card[0]) }}{{ card[1]|display_rank }}">{{ suit_symbols.get(card[0], card[0]) }} {{ card[1]|display_rank }}</span>{% if not loop.last %}, {% endif %}{% endfor %}
+                    {% for card in exchange_received_cards %}<span class="card-text" aria-label="{{ suit_symbols.get(card[0], card[0]) }}{{ card[1]|display_rank }}"><span class="suit-icon suit-icon--{{ suit_classes.get(card[0], 'spades') }}">{{ suit_symbols.get(card[0], card[0]) }}</span> {{ card[1]|display_rank }}</span>{% if not loop.last %}, {% endif %}{% endfor %}
                 </p>
             </div>
         {% endif %}

--- a/web/templates/partials/trick_history.html
+++ b/web/templates/partials/trick_history.html
@@ -39,7 +39,7 @@
                                     {% set card = ns.cards[seat] %}
                                     {% set disp_suit = card[0] %}
                                     {% set bower = card|is_bower(trump | default(None, true), contract_type | default(None, true)) %}
-                                    <span class="card--inline card--inline-{{ suit_classes.get(disp_suit, 'spades') }}{% if bower %} card--inline-bower{% endif %}">{{ card[1]|display_rank }}{{ suit_symbols.get(disp_suit, disp_suit) }}{% if bower %}<sup class="bower-sup" title="{{ bower|capitalize }} bower">{{ "RB" if bower == "right" else "LB" }}</sup>{% endif %}</span>
+                                    <span class="card--inline{% if bower %} card--inline-bower{% endif %}">{{ card[1]|display_rank }}<span class="suit-icon suit-icon--{{ suit_classes.get(disp_suit, 'spades') }}">{{ suit_symbols.get(disp_suit, disp_suit) }}</span>{% if bower %}<sup class="bower-sup" title="{{ bower|capitalize }} bower">{{ "RB" if bower == "right" else "LB" }}</sup>{% endif %}</span>
                                 {% else %}
                                     <span class="trick-history__absent" aria-label="Sitting out">&mdash;</span>
                                 {% endif %}


### PR DESCRIPTION
## Summary

- Split card rank and suit symbol into separate `<span>` elements in trick history table and moon exchange summary
- Rank text (A, K, Q, J, 10) stays white (default text color); only the suit icon (♠♥♦♣) is colored
- Reuses existing `.suit-icon` CSS utility; removes now-unused `.card--inline-{suit}` and `.card-text--{suit}` variant classes

## Why

Issue #2289: On the hand result trick history, the entire card text was colored by suit. The fix separates rank from suit icon so only the icon carries the color.

Closes #2289

## Repro / Validation

```bash
# Tier 1 — targeted template tests
uv run python -m pytest tests/unit/hosted_play/test_partials.py -x -q
# 219 passed

# Tier 2 — full validation
make check-quiet
# 3 pre-existing failures (test_ops_token_economy, test_telegram_filter) — unrelated to this change
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

## Files changed

| File | Change |
|------|--------|
| `web/templates/partials/trick_history.html` | Split rank + suit into separate spans |
| `web/templates/partials/hand_result.html` | Same split in moon exchange summary |
| `web/static/style.css` | Remove suit-color variant classes; set base color to `--color-text` |
| `tests/unit/hosted_play/test_partials.py` | Update assertions for new HTML structure |

🤖 Generated with [Claude Code](https://claude.com/claude-code)