### PR TITLE
feat(web): add first-time player onboarding flow (#2225)

### DIFF
--- a/tests/unit/hosted_play/conftest.py
+++ b/tests/unit/hosted_play/conftest.py
@@ -219,10 +219,13 @@ def create_test_player(session: Session, **overrides: Any) -> Player:
     """Insert a Player with sensible defaults.
 
     Override any column by passing keyword arguments.
+    Default ``onboarding_complete=1`` so tests bypass onboarding unless
+    explicitly testing it.
     """
     defaults: dict[str, Any] = {
         "link_uuid": str(uuid.uuid4()),
         "nickname": "TestPlayer",
+        "onboarding_complete": 1,
     }
     defaults.update(overrides)
     player = Player(**defaults)

--- a/tests/unit/hosted_play/test_error_handling.py
+++ b/tests/unit/hosted_play/test_error_handling.py
@@ -43,8 +43,12 @@ def client(app):
 
 
 def _create_player(session, nickname="TestPlayer") -> Player:
-    """Insert a Player row."""
-    player = Player(link_uuid=str(uuid.uuid4()), nickname=nickname)
+    """Insert a Player row (onboarding already complete)."""
+    player = Player(
+        link_uuid=str(uuid.uuid4()),
+        nickname=nickname,
+        onboarding_complete=1,
+    )
     session.add(player)
     session.flush()
     return player

--- a/tests/unit/hosted_play/test_hardening.py
+++ b/tests/unit/hosted_play/test_hardening.py
@@ -58,8 +58,12 @@ def client(app):
 
 
 def _create_player(session, nickname="TestPlayer") -> Player:
-    """Insert a Player row."""
-    player = Player(link_uuid=str(uuid.uuid4()), nickname=nickname)
+    """Insert a Player row (onboarding already complete)."""
+    player = Player(
+        link_uuid=str(uuid.uuid4()),
+        nickname=nickname,
+        onboarding_complete=1,
+    )
     session.add(player)
     session.flush()
     return player

--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -8,6 +8,7 @@ bid → play-card → match completion → decision logging.
 from __future__ import annotations
 
 import json
+import uuid
 
 import pytest
 from starlette.testclient import TestClient
@@ -71,6 +72,11 @@ def _set_nickname(client: TestClient, link_uuid: str, nickname: str = "Tester"):
     )
 
 
+def _skip_onboarding(client: TestClient, link_uuid: str):
+    """Skip onboarding flow and return the response (model_select partial)."""
+    return client.post(f"/play/{link_uuid}/onboarding/skip")
+
+
 def _select_ai(client: TestClient, link_uuid: str, model_id: str = "olsa"):
     """Select AI model and return the response."""
     return client.post(
@@ -80,9 +86,10 @@ def _select_ai(client: TestClient, link_uuid: str, model_id: str = "olsa"):
 
 
 def _setup_game(client: TestClient) -> str:
-    """Create game, set nickname, select AI, return link_uuid."""
+    """Create game, set nickname, skip onboarding, select AI, return link_uuid."""
     link_uuid = _create_game(client)
     _set_nickname(client, link_uuid)
+    _skip_onboarding(client, link_uuid)
     _select_ai(client, link_uuid)
     return link_uuid
 
@@ -138,6 +145,7 @@ class TestSelectAI:
     def test_select_ai_creates_match(self, client, app):
         link_uuid = _create_game(client)
         _set_nickname(client, link_uuid)
+        _skip_onboarding(client, link_uuid)
         resp = _select_ai(client, link_uuid, "olsa")
         assert resp.status_code == 200
 
@@ -158,6 +166,7 @@ class TestSelectAI:
     def test_select_invalid_model_rejected(self, client):
         link_uuid = _create_game(client)
         _set_nickname(client, link_uuid)
+        _skip_onboarding(client, link_uuid)
         resp = _select_ai(client, link_uuid, "nonexistent_model")
         assert resp.status_code == 400
 
@@ -171,6 +180,7 @@ class TestSelectAI:
             for _ in range(2):
                 link_uuid = _create_game(c)
                 _set_nickname(c, link_uuid)
+                _skip_onboarding(c, link_uuid)
                 resp = _select_ai(c, link_uuid, "olsa")
                 assert resp.status_code == 200
 
@@ -952,6 +962,7 @@ class TestRedealPersistence:
         client, app = allpass_client
         link_uuid = _create_game(client)
         _set_nickname(client, link_uuid)
+        _skip_onboarding(client, link_uuid)
         _select_ai(client, link_uuid)
         advance_pending_reveals(client, app, link_uuid)
 
@@ -1032,6 +1043,7 @@ class TestRedealPersistence:
         client, app = allpass_client
         link_uuid = _create_game(client)
         _set_nickname(client, link_uuid)
+        _skip_onboarding(client, link_uuid)
         _select_ai(client, link_uuid)
         advance_pending_reveals(client, app, link_uuid)
 
@@ -2719,6 +2731,7 @@ class TestMatchHistory:
         """The header nav should include a History link when link_uuid is set."""
         link_uuid = _create_game(client)
         _set_nickname(client, link_uuid)
+        _skip_onboarding(client, link_uuid)
         _select_ai(client, link_uuid)
 
         resp = client.get(f"/play/{link_uuid}")
@@ -2733,6 +2746,7 @@ class TestTabNavigation:
         """Game tab is active when viewing the game page."""
         link_uuid = _create_game(client)
         _set_nickname(client, link_uuid)
+        _skip_onboarding(client, link_uuid)
         _select_ai(client, link_uuid)
 
         resp = client.get(f"/play/{link_uuid}")
@@ -2762,6 +2776,7 @@ class TestTabNavigation:
         """Comments tab is an active navigation link (not disabled)."""
         link_uuid = _create_game(client)
         _set_nickname(client, link_uuid)
+        _skip_onboarding(client, link_uuid)
         _select_ai(client, link_uuid)
 
         resp = client.get(f"/play/{link_uuid}")
@@ -2776,6 +2791,7 @@ class TestTabNavigation:
         """The nav element uses role=tablist for accessibility."""
         link_uuid = _create_game(client)
         _set_nickname(client, link_uuid)
+        _skip_onboarding(client, link_uuid)
         _select_ai(client, link_uuid)
 
         resp = client.get(f"/play/{link_uuid}")
@@ -2786,6 +2802,7 @@ class TestTabNavigation:
         """Tab links should have hx-get, hx-target, hx-push-url for HTMX swaps."""
         link_uuid = _create_game(client)
         _set_nickname(client, link_uuid)
+        _skip_onboarding(client, link_uuid)
         _select_ai(client, link_uuid)
 
         resp = client.get(f"/play/{link_uuid}")
@@ -2800,6 +2817,7 @@ class TestTabNavigation:
         """The #tab-content wrapper div exists for HTMX target."""
         link_uuid = _create_game(client)
         _set_nickname(client, link_uuid)
+        _skip_onboarding(client, link_uuid)
         _select_ai(client, link_uuid)
 
         resp = client.get(f"/play/{link_uuid}")
@@ -2871,6 +2889,7 @@ class TestHtmxTabPartials:
         """GET /play with HX-Request returns partial game content."""
         link_uuid = _create_game(client)
         _set_nickname(client, link_uuid)
+        _skip_onboarding(client, link_uuid)
         _select_ai(client, link_uuid)
         resp = client.get(
             f"/play/{link_uuid}",
@@ -2941,6 +2960,7 @@ class TestGuide:
         """The header nav should include a Guide link when link_uuid is set."""
         link_uuid = _create_game(client)
         _set_nickname(client, link_uuid)
+        _skip_onboarding(client, link_uuid)
         _select_ai(client, link_uuid)
         resp = client.get(f"/play/{link_uuid}")
         assert resp.status_code == 200
@@ -3717,6 +3737,7 @@ class TestAuctionLogPersistence:
         """
         link_uuid = _create_game(client)
         _set_nickname(client, link_uuid)
+        _skip_onboarding(client, link_uuid)
         _select_ai(client, link_uuid)
 
         # Advance through the hidden auction reveals
@@ -3744,3 +3765,134 @@ class TestAuctionLogPersistence:
             assert (
                 seat_label in resp.text
             ), f"Auction entry for {seat_label} missing from page refresh response"
+
+
+# ===================================================================
+# Onboarding Flow Tests
+# ===================================================================
+
+
+class TestOnboarding:
+    """Tests for first-time player onboarding flow (#2225)."""
+
+    def test_new_player_sees_welcome_after_nickname(self, client, app):
+        """Setting a nickname for a new player returns the welcome letter."""
+        link_uuid = _create_game(client)
+        resp = _set_nickname(client, link_uuid)
+        assert resp.status_code == 200
+        assert "onboarding_welcome" in resp.text or "Welcome" in resp.text
+
+    def test_game_page_shows_onboarding_for_incomplete_player(self, client, app):
+        """GET /play/<uuid> shows onboarding for player with onboarding_complete=0."""
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        # Player has nickname but onboarding_complete=0
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        assert "onboarding_welcome" in resp.text or "Welcome" in resp.text
+
+    def test_onboarding_next_advances_to_guide_step(self, client, app):
+        """POST /onboarding/next with step=0 shows the first guide step."""
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        resp = client.post(
+            f"/play/{link_uuid}/onboarding/next",
+            data={"step": "0"},
+        )
+        assert resp.status_code == 200
+        assert "onboarding_guide" in resp.text or "guide" in resp.text.lower()
+
+    def test_onboarding_next_advances_through_all_steps(self, client, app):
+        """Walking through all 3 guide steps completes onboarding."""
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        # Step 0 → guide step 1
+        resp = client.post(
+            f"/play/{link_uuid}/onboarding/next",
+            data={"step": "0"},
+        )
+        assert resp.status_code == 200
+        # Step 1 → guide step 2
+        resp = client.post(
+            f"/play/{link_uuid}/onboarding/next",
+            data={"step": "1"},
+        )
+        assert resp.status_code == 200
+        # Step 2 → guide step 3
+        resp = client.post(
+            f"/play/{link_uuid}/onboarding/next",
+            data={"step": "2"},
+        )
+        assert resp.status_code == 200
+        # Step 3 → completes onboarding, shows model_select
+        resp = client.post(
+            f"/play/{link_uuid}/onboarding/next",
+            data={"step": "3"},
+        )
+        assert resp.status_code == 200
+        assert "model_select" in resp.text or "Choose" in resp.text
+
+    def test_onboarding_skip_marks_complete(self, client, app):
+        """POST /onboarding/skip sets onboarding_complete=1 and shows model select."""
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        resp = client.post(f"/play/{link_uuid}/onboarding/skip")
+        assert resp.status_code == 200
+        assert "model_select" in resp.text or "Choose" in resp.text
+
+    def test_returning_player_skips_onboarding(self, client, app):
+        """Player with onboarding_complete=1 never sees onboarding."""
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        _skip_onboarding(client, link_uuid)
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        # Should see model select, not onboarding
+        assert "model_select" in resp.text or "Choose" in resp.text
+        assert "onboarding_welcome" not in resp.text
+
+    def test_game_page_shows_model_select_for_completed_player(self, client, app):
+        """After completing onboarding, game page shows model selection."""
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        # Complete onboarding via skip
+        client.post(f"/play/{link_uuid}/onboarding/skip")
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        assert "model_select" in resp.text or "Choose" in resp.text
+
+    def test_onboarding_next_unknown_player_404(self, client, app):
+        """POST /onboarding/next for unknown UUID returns 404."""
+        fake_uuid = str(uuid.uuid4())
+        resp = client.post(
+            f"/play/{fake_uuid}/onboarding/next",
+            data={"step": "0"},
+        )
+        assert resp.status_code == 404
+
+    def test_onboarding_skip_unknown_player_404(self, client, app):
+        """POST /onboarding/skip for unknown UUID returns 404."""
+        fake_uuid = str(uuid.uuid4())
+        resp = client.post(f"/play/{fake_uuid}/onboarding/skip")
+        assert resp.status_code == 404
+
+    def test_onboarding_complete_persists_after_next_finishes(self, client, app):
+        """After walking through all steps, onboarding_complete=1 in DB."""
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        # Walk through all steps
+        for step in range(4):
+            client.post(
+                f"/play/{link_uuid}/onboarding/next",
+                data={"step": str(step)},
+            )
+        # Verify DB state
+        session = app.state.session_factory()
+        try:
+            from web.db import Player
+
+            player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+            assert player is not None
+            assert player.onboarding_complete == 1
+        finally:
+            session.close()

--- a/web/app.py
+++ b/web/app.py
@@ -22,6 +22,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy import inspect as sa_inspect
+from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 from starlette.templating import Jinja2Templates
 
@@ -112,6 +113,29 @@ async def lifespan(app: FastAPI):
     engine = init_engine(config.database_url)
     create_tables(engine)
     session_factory = make_session_factory(engine)
+
+    # 1b. Migrate: add onboarding_complete column for existing databases.
+    # create_tables only creates new tables — it does not ALTER existing ones.
+    # On a fresh DB the column already exists; on an existing DB we add it
+    # and mark all players who already have a nickname as onboarding-complete
+    # so they are not forced through the onboarding flow.
+    inspector = sa_inspect(engine)
+    player_cols = {c["name"] for c in inspector.get_columns("players")}
+    if "onboarding_complete" not in player_cols:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "ALTER TABLE players "
+                    "ADD COLUMN onboarding_complete INTEGER NOT NULL DEFAULT 0"
+                )
+            )
+            conn.execute(
+                text(
+                    "UPDATE players SET onboarding_complete = 1 "
+                    "WHERE nickname IS NOT NULL"
+                )
+            )
+        logger.info("Migration: added onboarding_complete column to players")
 
     # 2. Auto-seed invite code on fresh database (atomic: skip if another
     #    instance already seeded between our check and insert)

--- a/web/db.py
+++ b/web/db.py
@@ -53,6 +53,7 @@ class Player(Base):
     id = Column(Integer, primary_key=True)
     link_uuid = Column(String, nullable=False, unique=True)
     nickname = Column(String, nullable=True)
+    onboarding_complete = Column(Integer, nullable=False, default=0)
     created_at = Column(
         DateTime,
         nullable=False,

--- a/web/routes.py
+++ b/web/routes.py
@@ -921,6 +921,20 @@ async def game_page(request: Request, link_uuid: str):
                 )
             )
 
+        # Onboarding not yet complete — show welcome letter
+        if not player.onboarding_complete:
+            return _with_cookie(
+                _render_game(
+                    {
+                        "request": request,
+                        "phase": "onboarding_welcome",
+                        "link_uuid": link_uuid,
+                        "nickname": player.nickname,
+                        "current_page": "game",
+                    },
+                )
+            )
+
         # Prefer the most recent *active* match so the reconnect prompt
         # on the landing page and the game page agree.  Fall back to any
         # match (e.g. completed) when no active match exists.  (#2056)
@@ -1009,7 +1023,19 @@ async def set_nickname(
         player.nickname = nickname
         session.commit()
 
-        # Return model selection form (HTMX partial)
+        # New player → show onboarding welcome letter
+        if not player.onboarding_complete:
+            return HTMLResponse(
+                templates.get_template("partials/onboarding_welcome.html").render(
+                    {
+                        "request": request,
+                        "link_uuid": link_uuid,
+                        "nickname": nickname,
+                    }
+                )
+            )
+
+        # Returning player (onboarding already complete) → model selection
         ai_manager = _get_ai_manager(request)
         models = ai_manager.list_available()
         return HTMLResponse(
@@ -1018,6 +1044,99 @@ async def set_nickname(
                     "request": request,
                     "link_uuid": link_uuid,
                     "nickname": nickname,
+                    "models": models,
+                    "default_model_id": ai_manager.default_model_id,
+                }
+            )
+        )
+    finally:
+        session.close()
+
+
+# Total number of onboarding guide steps (0-indexed pages within the guide).
+_ONBOARDING_GUIDE_STEPS = 3
+
+
+@router.post("/play/{link_uuid}/onboarding/next", response_class=HTMLResponse)
+async def onboarding_next(
+    request: Request,
+    link_uuid: str,
+    step: int = Form(0),
+):
+    """Advance through onboarding steps.
+
+    Step 0 = welcome letter (already shown) → returns guide step 1.
+    Steps 1..N = guide walkthrough pages.
+    After the last guide step, marks onboarding complete and returns model
+    selection.
+    """
+    templates = _get_templates(request)
+    session = _get_session(request)
+    try:
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+        if player is None:
+            raise HTTPException(status_code=404, detail="Game not found")
+
+        next_step = step + 1
+
+        # Past the last guide step → complete onboarding
+        if next_step > _ONBOARDING_GUIDE_STEPS:
+            player.onboarding_complete = 1
+            session.commit()
+            ai_manager = _get_ai_manager(request)
+            models = ai_manager.list_available()
+            return HTMLResponse(
+                templates.get_template("partials/model_select.html").render(
+                    {
+                        "request": request,
+                        "link_uuid": link_uuid,
+                        "nickname": player.nickname,
+                        "models": models,
+                        "default_model_id": ai_manager.default_model_id,
+                    }
+                )
+            )
+
+        # Show the next guide step
+        return HTMLResponse(
+            templates.get_template("partials/onboarding_guide.html").render(
+                {
+                    "request": request,
+                    "link_uuid": link_uuid,
+                    "nickname": player.nickname,
+                    "step": next_step,
+                    "total_steps": _ONBOARDING_GUIDE_STEPS,
+                }
+            )
+        )
+    finally:
+        session.close()
+
+
+@router.post("/play/{link_uuid}/onboarding/skip", response_class=HTMLResponse)
+async def onboarding_skip(
+    request: Request,
+    link_uuid: str,
+):
+    """Skip remaining onboarding and go directly to model selection."""
+    templates = _get_templates(request)
+    session = _get_session(request)
+    try:
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+        if player is None:
+            raise HTTPException(status_code=404, detail="Game not found")
+
+        player.onboarding_complete = 1
+        session.commit()
+
+        ai_manager = _get_ai_manager(request)
+        models = ai_manager.list_available()
+        return HTMLResponse(
+            templates.get_template("partials/model_select.html").render(
+                {
+                    "request": request,
+                    "link_uuid": link_uuid,
+                    "nickname": player.nickname,
                     "models": models,
                     "default_model_id": ai_manager.default_model_id,
                 }

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1821,6 +1821,188 @@ main {
 }
 
 /* --------------------------------------------------------------------------
+   12a. Onboarding Flow (welcome letter + guide walkthrough)
+   -------------------------------------------------------------------------- */
+
+.onboarding {
+    max-width: 480px;
+    margin: 2rem auto;
+    text-align: center;
+}
+
+.onboarding__card {
+    background: var(--color-surface);
+    padding: 2rem 1.5rem;
+    border-radius: 12px;
+}
+
+.onboarding__title {
+    margin: 0 0 1rem;
+    font-size: 1.3rem;
+    color: var(--color-text);
+}
+
+.onboarding__letter {
+    text-align: left;
+    margin-bottom: 1.5rem;
+}
+
+.onboarding__letter p {
+    font-size: 0.9rem;
+    line-height: 1.6;
+    color: var(--color-text-muted);
+    margin: 0.5rem 0;
+}
+
+.onboarding__letter p:first-child {
+    color: var(--color-text);
+    font-weight: 600;
+}
+
+/* Guide content within onboarding re-uses .guide__* styles from the
+   full guide page.  These overrides constrain the layout. */
+.onboarding__content {
+    text-align: left;
+    margin-bottom: 1.5rem;
+}
+
+.onboarding__content .guide__quickstart {
+    border-left: 4px solid var(--color-legal-glow);
+    background: var(--color-surface-light);
+    border-radius: 8px;
+    padding: 0.75rem 1rem;
+    margin-bottom: 1rem;
+}
+
+.onboarding__content .guide__quickstart-title {
+    font-size: 0.95rem;
+    font-weight: 700;
+    margin: 0 0 0.4rem;
+    color: var(--color-legal-glow);
+}
+
+.onboarding__content .guide__quickstart p {
+    margin: 0.25rem 0;
+    font-size: 0.85rem;
+    line-height: 1.5;
+}
+
+.onboarding__content .guide__section {
+    margin-bottom: 1rem;
+}
+
+.onboarding__content .guide__section-title {
+    font-size: 1rem;
+    margin: 0 0 0.4rem;
+    color: var(--color-legal-glow);
+}
+
+.onboarding__content .guide__section p,
+.onboarding__content .guide__section li {
+    font-size: 0.85rem;
+    line-height: 1.5;
+    color: var(--color-text);
+}
+
+.onboarding__content .guide__section ul {
+    margin: 0.4rem 0;
+    padding-left: 1.25rem;
+}
+
+.onboarding__content .guide__section li {
+    margin-bottom: 0.35rem;
+}
+
+/* Progress indicator */
+.onboarding__progress {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+}
+
+.onboarding__dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--color-surface-light);
+    border: 2px solid #555;
+    transition: background 0.2s, border-color 0.2s;
+}
+
+.onboarding__dot--active {
+    background: var(--color-legal-glow);
+    border-color: var(--color-legal-glow);
+}
+
+.onboarding__dot--done {
+    background: var(--color-felt);
+    border-color: var(--color-felt);
+}
+
+.onboarding__step-label {
+    font-size: 0.8rem;
+    color: var(--color-text-muted);
+    margin-left: 0.5rem;
+}
+
+/* Action buttons */
+.onboarding__actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.onboarding__btn {
+    padding: 0.6rem 1.5rem;
+    border: none;
+    border-radius: 4px;
+    font-weight: 600;
+    cursor: pointer;
+    font-size: 1rem;
+    transition: background 0.15s;
+    min-width: 200px;
+}
+
+.onboarding__btn--primary {
+    background: var(--color-felt);
+    color: #fff;
+}
+
+.onboarding__btn--primary:hover {
+    background: var(--color-legal-glow);
+}
+
+.onboarding__btn--skip {
+    background: transparent;
+    color: var(--color-text-muted);
+    font-size: 0.85rem;
+    font-weight: 400;
+    padding: 0.4rem 1rem;
+}
+
+.onboarding__btn--skip:hover {
+    color: var(--color-text);
+}
+
+@media (max-width: 600px) {
+    .onboarding {
+        margin: 1rem auto;
+        padding: 0 0.5rem;
+    }
+    .onboarding__card {
+        padding: 1.25rem 1rem;
+    }
+    .onboarding__content .guide__section p,
+    .onboarding__content .guide__section li,
+    .onboarding__content .guide__quickstart p {
+        font-size: 0.82rem;
+    }
+}
+
+/* --------------------------------------------------------------------------
    12b. Landing Page & Invite Code Form
    -------------------------------------------------------------------------- */
 

--- a/web/templates/partials/game_content.html
+++ b/web/templates/partials/game_content.html
@@ -14,9 +14,15 @@
 <div id="game-board" role="region" aria-label="Game board" aria-live="polite"
      data-match-status="{{ match_status | default('setup') }}">
 
-    {# ---- Setup phases: nickname & model selection ---- #}
+    {# ---- Setup phases: nickname, onboarding & model selection ---- #}
     {% if phase == "nickname" %}
         {% include "partials/nickname_form.html" %}
+
+    {% elif phase == "onboarding_welcome" %}
+        {% include "partials/onboarding_welcome.html" %}
+
+    {% elif phase == "onboarding_guide" %}
+        {% include "partials/onboarding_guide.html" %}
 
     {% elif phase == "model_select" %}
         {% include "partials/model_select.html" %}

--- a/web/templates/partials/onboarding_guide.html
+++ b/web/templates/partials/onboarding_guide.html
@@ -1,0 +1,117 @@
+{# Onboarding guide walkthrough partial — step-by-step game introduction.
+   Content is extracted from guide_content.html to avoid duplication.
+
+   Context variables:
+     - link_uuid: str — player's game link UUID
+     - nickname: str — player's display nickname
+     - step: int — current step (1-indexed: 1, 2, or 3)
+     - total_steps: int — total number of guide steps (3)
+#}
+<div id="onboarding" class="onboarding" role="region"
+     aria-label="Game guide step {{ step }} of {{ total_steps }}">
+    <div class="onboarding__card">
+        <h2 class="onboarding__title">How to Play</h2>
+
+        {# ---- Progress dots ---- #}
+        <div class="onboarding__progress" role="progressbar"
+             aria-valuenow="{{ step }}" aria-valuemin="1"
+             aria-valuemax="{{ total_steps }}"
+             aria-label="Guide progress">
+            {% for i in range(1, total_steps + 1) %}
+            <span class="onboarding__dot{% if i == step %} onboarding__dot--active{% elif i < step %} onboarding__dot--done{% endif %}"
+                  aria-hidden="true"></span>
+            {% endfor %}
+            <span class="onboarding__step-label">Step {{ step }} of {{ total_steps }}</span>
+        </div>
+
+        {# ---- Step content ---- #}
+        <div class="onboarding__content">
+
+            {% if step == 1 %}
+            {# Step 1: Quick Start + The Basics #}
+            <div class="guide__quickstart">
+                <div class="guide__quickstart-title">Quick Start</div>
+                <p>&#x1F0A1; You and your AI partner vs two AI opponents.</p>
+                <p>&#x270B; Bid how many tricks you think your team can win (or pass).</p>
+                <p>&#x1F3B4; Play cards by clicking them &mdash; green border = legal plays.</p>
+                <p>&#x1F3C6; First team to 52 points wins. Reaching &minus;52 means you lose!</p>
+            </div>
+            <div class="guide__section">
+                <h3 class="guide__section-title">The Basics</h3>
+                <p>
+                    Bid Euchre is a 4-player partnership card game. You sit across from your
+                    AI partner, and the two AI opponents sit on your left and right.
+                </p>
+                <ul>
+                    <li><strong>Deck:</strong> A 40-card double deck &mdash; ranks 10, J, Q, K, A in all four suits, with two copies of each card.</li>
+                    <li><strong>Deal:</strong> All 40 cards are dealt, so each player gets 10 cards and every hand has 10 tricks.</li>
+                    <li><strong>Goal:</strong> Win tricks to score points. A match ends when either team reaches +52 (win) or &minus;52 (loss).</li>
+                </ul>
+            </div>
+
+            {% elif step == 2 %}
+            {# Step 2: Bidding #}
+            <div class="guide__section">
+                <h3 class="guide__section-title">Bidding</h3>
+                <p>
+                    Each hand starts with an auction. Starting left of the dealer, each
+                    player gets one chance to bid or pass.
+                </p>
+                <ul>
+                    <li><strong>What to bid:</strong> Pick a number of tricks (1&ndash;10) and a contract type &mdash; a trump suit (&#9824; &#9829; &#9830; &#9827;), High (no-trump, Aces high), or Low (no-trump, Tens high).</li>
+                    <li><strong>Highest bid wins:</strong> The winning bidder&rsquo;s team declares the contract. Their team must take at least that many tricks.</li>
+                    <li><strong>All pass:</strong> If nobody bids, the hand is redealt and the dealer rotates.</li>
+                    <li><strong>Moon &amp; Loner:</strong> Special 10-trick bids. Moon triggers a card exchange with your partner. Loner makes your partner sit out.</li>
+                </ul>
+            </div>
+
+            {% elif step == 3 %}
+            {# Step 3: Card Play + Scoring #}
+            <div class="guide__section">
+                <h3 class="guide__section-title">Card Play</h3>
+                <ul>
+                    <li><strong>Follow suit:</strong> You must play a card matching the suit that was led, if you can.</li>
+                    <li><strong>Trump wins:</strong> In suit contracts, any trump card beats any non-trump card.</li>
+                    <li><strong>Bowers:</strong> The Jack of trump (right bower) and the Jack of the same color (left bower) are the two strongest cards.</li>
+                    <li><strong>Duplicates:</strong> Identical cards can appear in the same trick. If they tie, the first one played wins.</li>
+                </ul>
+            </div>
+            <div class="guide__section">
+                <h3 class="guide__section-title">Scoring</h3>
+                <ul>
+                    <li><strong>Made bid:</strong> The declaring team scores the number of tricks they won.</li>
+                    <li><strong>Set (missed bid):</strong> The declaring team loses points equal to their bid.</li>
+                    <li><strong>Defenders:</strong> The defending team always scores the tricks they won.</li>
+                    <li><strong>Match end:</strong> First to +52 wins; dropping to &minus;52 is a loss. Expect 6&ndash;12 hands per match (about 10&ndash;20 minutes).</li>
+                </ul>
+            </div>
+            {% endif %}
+
+        </div>
+
+        {# ---- Navigation buttons ---- #}
+        <div class="onboarding__actions">
+            <button type="button"
+                    class="onboarding__btn onboarding__btn--primary"
+                    hx-post="/play/{{ link_uuid }}/onboarding/next"
+                    hx-vals='{"step": {{ step }}}'
+                    hx-target="#game-board"
+                    hx-swap="morph:innerHTML"
+                    aria-label="{% if step == total_steps %}Finish guide and start playing{% else %}Continue to next step{% endif %}">
+                {% if step == total_steps %}
+                    Let's Play!
+                {% else %}
+                    Next &rarr;
+                {% endif %}
+            </button>
+            <button type="button"
+                    class="onboarding__btn onboarding__btn--skip"
+                    hx-post="/play/{{ link_uuid }}/onboarding/skip"
+                    hx-target="#game-board"
+                    hx-swap="morph:innerHTML"
+                    aria-label="Skip remaining guide steps">
+                Skip
+            </button>
+        </div>
+    </div>
+</div>

--- a/web/templates/partials/onboarding_welcome.html
+++ b/web/templates/partials/onboarding_welcome.html
@@ -1,0 +1,51 @@
+{# Onboarding welcome letter partial — first-time player greeting.
+   Shown after nickname is set for new players (onboarding_complete == 0).
+
+   Context variables:
+     - link_uuid: str — player's game link UUID
+     - nickname: str — player's display nickname
+#}
+<div id="onboarding" class="onboarding" role="region" aria-label="Welcome">
+    <div class="onboarding__card">
+        <h2 class="onboarding__title">Welcome, {{ nickname }}!</h2>
+
+        <div class="onboarding__letter">
+            <p>Thanks for joining the Bid Euchre pilot!</p>
+            <p>
+                You're about to play a classic Midwestern card game against
+                AI opponents. Your partner is an AI too &mdash; together
+                you'll bid, play tricks, and race to 52 points.
+            </p>
+            <p>
+                This is an early version of the game, so your feedback
+                matters. If something feels off or confusing, let us know
+                in the comments section.
+            </p>
+            <p>
+                Before your first game, we'll walk you through the basics.
+                It only takes a minute &mdash; or you can skip ahead if you
+                already know how to play.
+            </p>
+        </div>
+
+        <div class="onboarding__actions">
+            <button type="button"
+                    class="onboarding__btn onboarding__btn--primary"
+                    hx-post="/play/{{ link_uuid }}/onboarding/next"
+                    hx-vals='{"step": 0}'
+                    hx-target="#game-board"
+                    hx-swap="morph:innerHTML"
+                    aria-label="Continue to game guide">
+                Show Me How to Play
+            </button>
+            <button type="button"
+                    class="onboarding__btn onboarding__btn--skip"
+                    hx-post="/play/{{ link_uuid }}/onboarding/skip"
+                    hx-target="#game-board"
+                    hx-swap="morph:innerHTML"
+                    aria-label="Skip guide and start playing">
+                I Know How to Play &mdash; Skip
+            </button>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Plan
- plans/sessions/2026-04-03_onboarding-flow-assessment.md (analyst shaping)
- Task packet 968872739b45

## Summary
- Add a first-time player onboarding flow: welcome letter → 3-step guided walkthrough → model selection
- New `onboarding_complete` column on Player with startup migration for existing DBs
- Two new routes (`/onboarding/next`, `//onboarding/skip`) with HTMX partials
- 10 new tests in TestOnboarding class; all existing tests retrofitted with `_skip_onboarding` helper

## Why
New players landing in the browser game had no introduction to Bid Euchre rules before playing.
This guided onboarding (welcome letter + 3 quick walkthrough pages covering basics, bidding, and
card play/scoring) gives first-time players context without blocking experienced users who can
skip at any point. Closes #2225.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_routes.py::TestOnboarding -v
make check-quiet
```

**Config (if applicable):** N/A

**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** All 10 TestOnboarding tests pass, all existing hosted-play tests still pass
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/ -v --tb=short`
- **Expected result:** 0 failures in hosted_play test suite

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_routes.py::TestOnboarding -v` — 10/10 pass
- [x] `make check-quiet` — 3 pre-existing failures only (token economy × 2, telegram filter × 1), all unrelated

## Expected impact
- Metrics impact: None — onboarding is UI-only, no game engine changes
- Runtime impact: Negligible — one extra column check at startup, one additional DB query per new player

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
```

`git worktree list` (abridged):
```
Bid-Euchre-steward-brws-author-b   422d4459 [feat/web-onboarding-flow]
```

## Validation Performed
```
$ uv run python -m pytest tests/unit/hosted_play/test_routes.py::TestOnboarding -v
10 passed in 0.71s

$ make check-quiet
3 failed (pre-existing), 11123 passed, 58 skipped in 321.85s
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)