### PR TITLE
feat(web): collapsible auction log with phase-aware positioning (#2288)

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -2553,6 +2553,57 @@ class TestActionRail:
         assert "action-rail__item--trick" in html
         assert "action-rail__item--system" in html
 
+    def test_auction_log_open_during_auction(self, env):
+        """Auction log <details> should be open during auction phase (#2288)."""
+        tmpl = env.get_template("partials/action_rail.html")
+        html = tmpl.render(
+            action_rail=[{"kind": "auction", "text": "Slim bid 6"}],
+            phase="auction",
+        )
+        # <details> has open attribute during auction
+        assert "<details" in html
+        assert "open" in html
+        assert 'data-phase="auction"' in html
+
+    def test_auction_log_collapsed_during_trick_play(self, env):
+        """Auction log should be collapsed (no open attr) during trick play (#2288)."""
+        tmpl = env.get_template("partials/action_rail.html")
+        html = tmpl.render(
+            action_rail=[{"kind": "auction", "text": "Slim bid 6"}],
+            phase="trick_play",
+        )
+        assert "<details" in html
+        assert 'data-phase="trick_play"' in html
+        # The open attribute should NOT be present
+        # Parse carefully: "open" could appear in other contexts
+        import re
+
+        details_tag = re.search(r"<details[^>]*>", html).group(0)
+        assert "open" not in details_tag.split("data-phase")[0]
+
+    def test_auction_log_shows_event_count(self, env):
+        """Summary line should show item count when events exist (#2288)."""
+        tmpl = env.get_template("partials/action_rail.html")
+        html = tmpl.render(
+            action_rail=[
+                {"kind": "auction", "text": "Slim passed"},
+                {"kind": "auction", "text": "Ace bid 7"},
+            ],
+            phase="auction",
+        )
+        assert "(2)" in html
+
+    def test_auction_log_collapsible_toggle(self, env):
+        """Auction log uses <details>/<summary> for collapsibility (#2288)."""
+        tmpl = env.get_template("partials/action_rail.html")
+        html = tmpl.render(
+            action_rail=[{"kind": "auction", "text": "Test"}],
+            phase="trick_play",
+        )
+        assert "<summary" in html
+        assert "action-rail__toggle" in html
+        assert "action-rail__content" in html
+
 
 class TestNextControls:
     def test_next_controls_post_to_next_route(self, env):

--- a/web/static/game.js
+++ b/web/static/game.js
@@ -175,6 +175,7 @@
             clearCardSelection(getCardPlayForm());
             syncCardPlayFormControls(getCardPlayForm());
             restoreTrickHistoryState();
+            restoreAuctionLogState();
         }, true);
     }
 
@@ -283,6 +284,74 @@
         document.addEventListener('toggle', function (event) {
             if (event.target && event.target.id === 'trick-history') {
                 saveTrickHistoryState();
+            }
+        }, true);
+    }
+
+    /* ---------------------------------------------------------------
+     * Auction log toggle — persist open/closed state across HTMX
+     * swaps and auto-collapse when phase transitions from auction
+     * to trick play.
+     * --------------------------------------------------------------- */
+
+    var AUCTION_LOG_KEY = 'auctionLogOpen';
+    var AUCTION_LOG_PHASE_KEY = 'auctionLogPhase';
+
+    function saveAuctionLogState() {
+        var details = document.getElementById('action-rail');
+        if (details) {
+            try {
+                sessionStorage.setItem(AUCTION_LOG_KEY, details.open ? '1' : '0');
+            } catch (_) {
+                // sessionStorage unavailable — ignore
+            }
+        }
+    }
+
+    function restoreAuctionLogState() {
+        var details = document.getElementById('action-rail');
+        if (!details) { return; }
+
+        var currentPhase = details.getAttribute('data-phase') || 'auction';
+
+        try {
+            var previousPhase = sessionStorage.getItem(AUCTION_LOG_PHASE_KEY);
+            sessionStorage.setItem(AUCTION_LOG_PHASE_KEY, currentPhase);
+
+            // Auto-collapse: transition from auction to non-auction phase
+            if (previousPhase === 'auction' && currentPhase !== 'auction') {
+                details.open = false;
+                sessionStorage.setItem(AUCTION_LOG_KEY, '0');
+                return;
+            }
+
+            // During auction phase, default to open (server-rendered)
+            if (currentPhase === 'auction') {
+                var saved = sessionStorage.getItem(AUCTION_LOG_KEY);
+                // Only override server default if user explicitly closed it
+                if (saved === '0') {
+                    details.open = false;
+                }
+                return;
+            }
+
+            // During non-auction phases, restore saved state
+            var saved = sessionStorage.getItem(AUCTION_LOG_KEY);
+            if (saved === '1') {
+                details.open = true;
+            } else if (saved === '0') {
+                details.open = false;
+            }
+            // If no saved state, keep server-rendered default (closed)
+        } catch (_) {
+            // sessionStorage unavailable — keep server-rendered state
+        }
+    }
+
+    function attachAuctionLogToggle() {
+        document.addEventListener('toggle', function (event) {
+            if (event.target && event.target.id === 'action-rail') {
+                saveAuctionLogState();
             }
         }, true);
     }
@@ -572,12 +641,14 @@
         attachDelegatedHandlers();
         attachTabHandlers();
         attachTrickHistoryToggle();
+        attachAuctionLogToggle();
         attachTextSizeToggle();
         attachErrorHandlers();
         var form = getCardPlayForm();
         clearCardSelection(form);
         syncCardPlayFormControls(form);
         restoreTrickHistoryState();
+        restoreAuctionLogState();
     }
 
     initialize();

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1352,19 +1352,45 @@ main {
     min-width: 120px;
 }
 
-/* Auction log (CSS classes retain "action-rail" prefix for compatibility) */
+/* Auction log — collapsible <details> element.
+   Open during auction phase, auto-collapsed after auction ends.
+   CSS classes retain "action-rail" prefix for compatibility. */
 .action-rail {
     margin-top: 0.5rem;
     border: 1px solid #455a64;
     border-radius: 8px;
-    padding: 0.5rem 0.75rem;
     background: var(--color-surface);
+    overflow: hidden;
 }
 
-.action-rail h3 {
-    margin: 0 0 0.35rem;
+.action-rail__toggle {
+    cursor: pointer;
     font-size: 0.85rem;
     color: var(--color-text-muted);
+    padding: 0.5rem 0.75rem;
+    user-select: none;
+    list-style: none;
+    font-weight: 600;
+}
+
+.action-rail__toggle::-webkit-details-marker {
+    display: none;
+}
+
+.action-rail__toggle::before {
+    content: "\25b6";
+    display: inline-block;
+    margin-right: 0.35rem;
+    font-size: 0.65rem;
+    transition: transform 0.15s ease;
+}
+
+.action-rail[open] > .action-rail__toggle::before {
+    transform: rotate(90deg);
+}
+
+.action-rail__content {
+    padding: 0 0.75rem 0.5rem;
 }
 
 .action-rail__list {
@@ -2210,9 +2236,14 @@ main {
         display: none;
     }
 
-    /* Hide auction log on mobile — reclaim vertical space */
-    .action-rail {
+    /* Auction log on mobile — collapsed by default to reclaim vertical space.
+       The summary toggle remains visible so users can expand if needed. */
+    .action-rail:not([open]) .action-rail__content {
         display: none;
+    }
+
+    .action-rail[open] .action-rail__list {
+        max-height: 80px;
     }
 
     .bid-controls {

--- a/web/templates/partials/action_rail.html
+++ b/web/templates/partials/action_rail.html
@@ -1,24 +1,39 @@
 {# Auction log — compact event feed of auction bids, trick results, and
    system messages.  (Formerly called "Action Rail" in dev jargon.)
 
+   Collapsible: open during auction phase, auto-collapsed after auction ends.
+   Toggle state is persisted across HTMX swaps via sessionStorage (game.js).
+
    Context variables:
      - action_rail: list[dict] — ordered event objects:
          {"kind": "auction"|"trick"|"system", "text": str}
      - action_rail_label (optional): heading override
+     - phase: str — "auction", "trick_play", etc.
 #}
 {% set rail_items = action_rail | default([], true) %}
+{% set rail_phase = phase | default("auction") %}
 
-<aside id="action-rail" class="action-rail" role="region" aria-label="{{ action_rail_label | default('Auction log') }}" aria-live="polite">
-    <h3>{{ action_rail_label | default("Auction Log") }}</h3>
-    {% if rail_items %}
-        <ul class="action-rail__list">
-            {% for event in rail_items %}
-                <li class="action-rail__item action-rail__item--{{ event.kind | default('event') }}">
-                    {{ event.text }}
-                </li>
-            {% endfor %}
-        </ul>
-    {% else %}
-        <p class="action-rail__empty">Waiting for game actions.</p>
-    {% endif %}
-</aside>
+<details id="action-rail"
+         class="action-rail"
+         role="region"
+         aria-label="{{ action_rail_label | default('Auction log') }}"
+         data-phase="{{ rail_phase }}"
+         {% if rail_phase == "auction" %}open{% endif %}>
+    <summary class="action-rail__toggle">
+        {{ action_rail_label | default("Auction Log") }}
+        {% if rail_items %}({{ rail_items | length }}){% endif %}
+    </summary>
+    <div class="action-rail__content" aria-live="polite">
+        {% if rail_items %}
+            <ul class="action-rail__list">
+                {% for event in rail_items %}
+                    <li class="action-rail__item action-rail__item--{{ event.kind | default('event') }}">
+                        {{ event.text }}
+                    </li>
+                {% endfor %}
+            </ul>
+        {% else %}
+            <p class="action-rail__empty">Waiting for game actions.</p>
+        {% endif %}
+    </div>
+</details>

--- a/web/templates/partials/game_board.html
+++ b/web/templates/partials/game_board.html
@@ -111,6 +111,9 @@
             {# Contract bar — always visible with status #}
             {% include "partials/contract_bar.html" %}
 
+            {# Auction log — center-screen during auction, collapsible during play #}
+            {% include "partials/action_rail.html" %}
+
             {# Trick area — shown during trick play only (not during auction) #}
             {% if phase != "auction" %}
                 {% include "partials/trick.html" %}
@@ -173,7 +176,5 @@
 
     {# Score bar — outside compass grid, always at bottom #}
     {% include "partials/score.html" %}
-
-    {% include "partials/action_rail.html" %}
 
 {% endif %}


### PR DESCRIPTION
## Plan
N/A — bounded task from #2288 item 6

## Summary
- Convert auction log from static `<aside>` to collapsible `<details>` element
- Position auction log center-screen (inside compass-center) instead of at bottom of page
- Auto-collapse after auction phase ends; open by default during auction
- Persist toggle state across HTMX swaps via sessionStorage

## Why
Item 6 from UI polish issue #2288: the auction log should be collapsible and auto-minimize after the auction completes, reducing visual clutter during trick play while remaining accessible via a click.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_partials.py::TestActionRail -xvs
uv run python -m pytest tests/unit/hosted_play/test_partials.py -x
```

## Test Criteria
- **Pass condition:** Auction log renders as `<details>` element, open during auction phase, closed during trick_play phase
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_partials.py::TestActionRail -xvs`
- **Expected result:** 5 tests pass (1 existing + 4 new)

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_partials.py -x` — 225 passed
- [x] Ruff check + format: clean
- [x] Repo linter: passed
- [ ] Full `make check`: CI will validate (fleet CPU contention prevented local completion)

## Expected impact
- Metrics impact: None (UI-only change)
- Runtime impact: None

## Risk level
- [x] Low (UI template + CSS + JS only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d   dd038eb8 [fix/collapsible-auction-log]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)