### PR TITLE
fix(web): rename LEAD TRICK to LEADER + add RB/LB legend tooltip (#2288)

### DIFF
--- a/tests/e2e/hosted_play/test_smoke_placeholder.py
+++ b/tests/e2e/hosted_play/test_smoke_placeholder.py
@@ -94,7 +94,7 @@ class TestLeadIndicator:
     def test_leader_seat_marker_present(
         self, engine: MatchEngine, jinja_env: jinja2.Environment
     ) -> None:
-        """The 'Lead Trick' marker renders next to the trick leader's seat."""
+        """The 'Leader' marker renders next to the trick leader's seat."""
         state = engine.start_match(SEED, "test")
         state = advance_to_trick_play(engine, state)
 
@@ -107,9 +107,7 @@ class TestLeadIndicator:
         html = tmpl.render(**ctx)
 
         assert "seat-marker--leader" in html, "Expected leader marker in trick HTML"
-        assert (
-            'title="Lead Trick"' in html
-        ), "Expected 'Lead Trick' title attribute on marker"
+        assert 'title="Leader"' in html, "Expected 'Leader' title attribute on marker"
 
     @pytest.mark.e2e
     def test_lead_suit_matches_first_card_suit(

--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -695,7 +695,7 @@ class TestTrick:
         assert "Last Trick" not in html
 
     def test_markers_for_dealer_turn_declarer_and_sitout(self, env):
-        """Phase-dependent markers: only Lead Trick and Sitting Out in trick area.
+        """Phase-dependent markers: only Leader and Sitting Out in trick area.
 
         Dealer/turn/declarer markers removed from trick area per #2200 UI cleanup.
         Dealer shown on compass seats during auction only; declarer in contract bar.
@@ -712,9 +712,9 @@ class TestTrick:
             tricks_team0=0,
             tricks_team1=0,
         )
-        # Lead Trick and Sitting Out are shown
+        # Leader and Sitting Out are shown
         assert "seat-marker--leader" in html
-        assert 'title="Lead Trick"' in html
+        assert 'title="Leader"' in html
         assert "seat-marker--sitting-out" in html
         assert 'title="Sitting out"' in html
         # Dealer, turn, and declarer markers removed from trick area
@@ -723,7 +723,7 @@ class TestTrick:
         assert "seat-marker--declarer" not in html
 
     def test_leader_marker_shown_for_trick_leader(self, env):
-        """Leader seat gets a 'Lead Trick' word label during trick play."""
+        """Leader seat gets a 'Leader' word label during trick play."""
         tmpl = env.get_template("partials/trick.html")
         html = tmpl.render(
             current_trick={"leader": 1, "plays": [[1, ["H", "A"]]]},
@@ -737,8 +737,8 @@ class TestTrick:
             tricks_team1=0,
         )
         assert "seat-marker--leader" in html
-        assert 'title="Lead Trick"' in html
-        assert "Lead Trick" in html
+        assert 'title="Leader"' in html
+        assert "Leader" in html
 
     def test_leader_marker_shown_for_completed_trick(self, env):
         """Leader marker renders when showing a completed trick (no current)."""
@@ -757,7 +757,7 @@ class TestTrick:
             tricks_team1=1,
         )
         assert "seat-marker--leader" in html
-        assert 'title="Lead Trick"' in html
+        assert 'title="Leader"' in html
 
     def test_dealer_marker_shown_during_auction(self, env):
         """Dealer marker appears in trick area during auction phase."""
@@ -3193,6 +3193,54 @@ class TestTrickHistory:
         )
         assert 'role="region"' in html
         assert 'aria-label="Cards played history"' in html
+
+    def test_bower_legend_shown_for_suit_contract(self, env, completed_tricks):
+        """Bower abbreviation legend appears when contract_type is 'suit' (#2288)."""
+        tmpl = env.get_template("partials/trick_history.html")
+        html = tmpl.render(
+            completed_tricks=completed_tricks,
+            tricks_team0=1,
+            tricks_team1=1,
+            contract_type="suit",
+            trump="H",
+        )
+        assert "trick-history__legend" in html
+        assert "RB" in html
+        assert "LB" in html
+        assert "Right Bower" in html
+        assert "Left Bower" in html
+
+    def test_bower_legend_hidden_for_high_contract(self, env, completed_tricks):
+        """No bower legend when contract_type is 'high' (no bowers) (#2288)."""
+        tmpl = env.get_template("partials/trick_history.html")
+        html = tmpl.render(
+            completed_tricks=completed_tricks,
+            tricks_team0=1,
+            tricks_team1=1,
+            contract_type="high",
+        )
+        assert "trick-history__legend" not in html
+
+    def test_bower_legend_hidden_for_low_contract(self, env, completed_tricks):
+        """No bower legend when contract_type is 'low' (no bowers) (#2288)."""
+        tmpl = env.get_template("partials/trick_history.html")
+        html = tmpl.render(
+            completed_tricks=completed_tricks,
+            tricks_team0=1,
+            tricks_team1=1,
+            contract_type="low",
+        )
+        assert "trick-history__legend" not in html
+
+    def test_bower_legend_hidden_when_no_contract(self, env, completed_tricks):
+        """No bower legend when contract_type is unset (#2288)."""
+        tmpl = env.get_template("partials/trick_history.html")
+        html = tmpl.render(
+            completed_tricks=completed_tricks,
+            tricks_team0=1,
+            tricks_team1=1,
+        )
+        assert "trick-history__legend" not in html
 
 
 # ---------------------------------------------------------------------------

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -960,6 +960,22 @@ main {
     color: rgba(255, 255, 255, 0.2);
 }
 
+/* Bower abbreviation legend (RB/LB) — shown in suit contracts only */
+.trick-history__legend {
+    margin: 0.4rem 0 0;
+    font-size: 0.68rem;
+    color: var(--color-text-muted);
+    text-align: right;
+}
+
+.trick-history__legend abbr {
+    font-weight: 700;
+    color: var(--color-trump, #ffd700);
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+    cursor: help;
+}
+
 /* Inline card rendering (for trick history table) —
    rank text stays default (white); suit icon colored via .suit-icon utility
    (#2235, #2289).  Leader underline and winner highlight remain via cell

--- a/web/templates/partials/game_board.html
+++ b/web/templates/partials/game_board.html
@@ -28,7 +28,7 @@
 {% set show_next = show_next | default(false, true) %}
 {% set show_bid_panel = show_bid_panel | default(false, true) %}
 {% set seat_labels = seat_labels | default({0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}) %}
-{# Trick leader for phase-dependent "Lead Trick" labels on compass seats #}
+{# Trick leader for phase-dependent "Leader" labels on compass seats #}
 {% set trick_leader = None %}
 {% if current_trick is defined and current_trick %}
     {% set trick_leader = current_trick.get("leader") if current_trick is mapping else current_trick.leader %}
@@ -68,7 +68,7 @@
                     {% if phase == "auction" and dealer_seat == 2 %}
                         <span class="seat-marker seat-marker--dealer" title="Dealer">Dealer</span>
                     {% elif phase == "trick_play" and trick_leader == 2 %}
-                        <span class="seat-marker seat-marker--leader" title="Lead Trick">Lead Trick</span>
+                        <span class="seat-marker seat-marker--leader" title="Leader">Leader</span>
                     {% endif %}
                     {% if sitting_out_seat == 2 %}
                         <span class="seat-marker seat-marker--sitting-out" title="Sitting out">Sitting Out</span>
@@ -91,7 +91,7 @@
                     {% if phase == "auction" and dealer_seat == 1 %}
                         <span class="seat-marker seat-marker--dealer" title="Dealer">Dealer</span>
                     {% elif phase == "trick_play" and trick_leader == 1 %}
-                        <span class="seat-marker seat-marker--leader" title="Lead Trick">Lead Trick</span>
+                        <span class="seat-marker seat-marker--leader" title="Leader">Leader</span>
                     {% endif %}
                     {% if sitting_out_seat == 1 %}
                         <span class="seat-marker seat-marker--sitting-out" title="Sitting out">Sitting Out</span>
@@ -137,7 +137,7 @@
                     {% if phase == "auction" and dealer_seat == 3 %}
                         <span class="seat-marker seat-marker--dealer" title="Dealer">Dealer</span>
                     {% elif phase == "trick_play" and trick_leader == 3 %}
-                        <span class="seat-marker seat-marker--leader" title="Lead Trick">Lead Trick</span>
+                        <span class="seat-marker seat-marker--leader" title="Leader">Leader</span>
                     {% endif %}
                     {% if sitting_out_seat == 3 %}
                         <span class="seat-marker seat-marker--sitting-out" title="Sitting out">Sitting Out</span>
@@ -162,7 +162,7 @@
             {% elif phase == "trick_play" and trick_leader == 0 %}
                 <div class="human-seat-label" role="status" aria-label="You lead this trick">
                     You
-                    <span class="seat-marker seat-marker--leader" title="Lead Trick">Lead Trick</span>
+                    <span class="seat-marker seat-marker--leader" title="Leader">Leader</span>
                 </div>
             {% endif %}
             {# Human hand — always shown during active play #}

--- a/web/templates/partials/trick.html
+++ b/web/templates/partials/trick.html
@@ -37,9 +37,9 @@
 
 {% macro seat_markers(seat, leader_seat=None, cur_phase="trick_play") %}
     <div class="seat-markers">
-        {# Lead Trick — shown during trick play only, word label #}
+        {# Leader — shown during trick play only, word label #}
         {% if cur_phase == "trick_play" and leader_seat is not none and leader_seat == seat %}
-            <span class="seat-marker seat-marker--leader" title="Lead Trick">Lead Trick</span>
+            <span class="seat-marker seat-marker--leader" title="Leader">Leader</span>
         {% endif %}
         {# Dealer — shown during auction only, word label #}
         {% if cur_phase == "auction" and dealer_seat == seat %}

--- a/web/templates/partials/trick_history.html
+++ b/web/templates/partials/trick_history.html
@@ -52,6 +52,12 @@
                 {% endfor %}
             </tbody>
         </table>
+        {% if contract_type | default(None, true) == "suit" %}
+        <p class="trick-history__legend" aria-label="Bower abbreviation legend">
+            <abbr title="Right Bower — Jack of trump, highest card">RB</abbr> = Right Bower&ensp;
+            <abbr title="Left Bower — Jack of same color, second highest card">LB</abbr> = Left Bower
+        </p>
+        {% endif %}
     </div>
 </details>
 {% endif %}


### PR DESCRIPTION
## Summary

- Rename "Lead Trick" seat marker label to "Leader" across compass seats and trick area — aligns with standard card game terminology (Bridge, Euchre, Spades all use "leader")
- Add RB/LB abbreviation legend in trick history for suit contracts, explaining "RB = Right Bower" and "LB = Left Bower" for new players
- Legend uses `<abbr>` elements with hover tooltips for accessible explanation

## Why

Items 1 and 2 from #2288 (UI polish round 4). "Lead Trick" is verbose and non-standard; "Leader" is the conventional card game term. New players don't know what RB/LB abbreviations mean in trick history.

## Changes

| File | Change |
|------|--------|
| `web/templates/partials/game_board.html` | "Lead Trick" → "Leader" on all 4 compass seats |
| `web/templates/partials/trick.html` | "Lead Trick" → "Leader" in trick area seat_markers macro |
| `web/templates/partials/trick_history.html` | Add bower abbreviation legend (suit contracts only) |
| `web/static/style.css` | Add `.trick-history__legend` and abbr styles |
| `tests/unit/hosted_play/test_partials.py` | Update assertions + 4 new bower legend tests |
| `tests/e2e/hosted_play/test_smoke_placeholder.py` | Update assertion text |

## Repro / Validation

```bash
# Tier 1 — targeted tests (all pass)
uv run python -m pytest tests/unit/hosted_play/test_partials.py -k "test_markers_for_dealer_turn or test_leader_marker or test_bower_legend" -v
uv run python -m pytest tests/e2e/hosted_play/test_smoke_placeholder.py -k "test_leader_seat_marker" -v

# Full partials suite (225 passed)
uv run python -m pytest tests/unit/hosted_play/test_partials.py -v
```

## Tests

- 225/225 partials tests pass
- 1/1 e2e leader marker test passes
- 4 new tests for bower legend (suit/high/low/unset contract types)

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
branch: fix/leader-rename-bower-legend
```

Closes #2288 items 1 and 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>