### PR TITLE
feat(web): score labels Your Team/Opponent + rename Guide tab (#2288)

### DIFF
--- a/tests/browser/test_smoke_suite.py
+++ b/tests/browser/test_smoke_suite.py
@@ -158,10 +158,14 @@ def test_start_game_bid_play_verify_score(
     # Verify score bar is present during play
     score_bar = page.locator("#score-bar")
     if score_bar.count() > 0:
-        # Score bar should contain "You:" and "AI:" labels
+        # Score bar should contain "Your Team:" and "Opponent:" labels
         score_text = score_bar.inner_text()
-        assert "You:" in score_text, f"Expected 'You:' in score bar, got: {score_text}"
-        assert "AI:" in score_text, f"Expected 'AI:' in score bar, got: {score_text}"
+        assert (
+            "Your Team:" in score_text
+        ), f"Expected 'Your Team:' in score bar, got: {score_text}"
+        assert (
+            "Opponent:" in score_text
+        ), f"Expected 'Opponent:' in score bar, got: {score_text}"
 
     # If in trick play, play a card
     legal_cards = page.locator(".card--legal")

--- a/tests/e2e/hosted_play/test_smoke_placeholder.py
+++ b/tests/e2e/hosted_play/test_smoke_placeholder.py
@@ -483,8 +483,8 @@ class TestSeatLabels:
         tmpl = jinja_env.get_template("partials/score.html")
         html = tmpl.render(**ctx)
 
-        assert "You:" in html, "Expected 'You:' label in score bar"
-        assert "AI:" in html, "Expected 'AI:' label in score bar"
+        assert "Your Team:" in html, "Expected 'Your Team:' label in score bar"
+        assert "Opponent:" in html, "Expected 'Opponent:' label in score bar"
 
         # Dealer label should use the seat_labels mapping
         dealer_seat = ctx["dealer_seat"]

--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -179,22 +179,9 @@ class TestModelSelect:
             models=models,
             default_model_id="bud_bot",
         )
-        assert "quick-start-guide" in html
-        assert "New to Bid Euchre?" in html
-        assert "green border" in html
-        assert "/guide/abc-123" in html
-
-    def test_quick_start_guide_link_uses_link_uuid(self, env):
-        models = [ModelStub("bud_bot", "Bud Bot", "Gradient-boosted bidder")]
-        tmpl = env.get_template("partials/model_select.html")
-        html = tmpl.render(
-            link_uuid="my-uuid",
-            nickname="Bob",
-            models=models,
-            default_model_id="bud_bot",
-        )
-        assert "/guide/my-uuid" in html
-        assert "full guide" in html
+        # Quick-start guide was removed (#2288.8) — model select shows
+        # only the AI picker now; the Help / Guide tab serves this purpose.
+        assert "quick-start-guide" not in html
 
 
 # ---------------------------------------------------------------------------
@@ -949,8 +936,8 @@ class TestScore:
         assert "15" in html
         assert "-3" in html
         assert "Current Game Score" in html
-        assert "You:" in html
-        assert "AI:" in html
+        assert "Your Team:" in html
+        assert "Opponent:" in html
         # Hand details in collapsed dropdown
         assert "Hand 5" in html
         assert "Hand Details" in html
@@ -2590,7 +2577,7 @@ class TestAccessibilityScore:
             dealer_seat=3,
             phase="auction",
         )
-        assert "Current game score: You 15, AI -3" in html
+        assert "Current game score: Your Team 15, Opponent -3" in html
 
 
 class TestAccessibilityResults:

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1783,43 +1783,6 @@ main {
     margin: 0.25rem 0 0;
 }
 
-/* Quick start guide on model-select screen */
-.quick-start-guide {
-    margin-top: 1.5rem;
-    background: var(--color-surface);
-    border-radius: 8px;
-    padding: 1rem 1.25rem;
-    border-left: 4px solid var(--color-legal-glow);
-    text-align: left;
-}
-
-.quick-start-guide__title {
-    font-size: 1rem;
-    font-weight: 700;
-    margin: 0 0 0.5rem;
-    color: var(--color-legal-glow);
-}
-
-.quick-start-guide p {
-    margin: 0.3rem 0;
-    font-size: 0.88rem;
-    line-height: 1.5;
-}
-
-.quick-start-guide__link {
-    margin-top: 0.75rem !important;
-}
-
-.quick-start-guide__link a {
-    color: var(--color-legal-glow);
-    text-decoration: none;
-    font-weight: 600;
-    font-size: 0.88rem;
-}
-
-.quick-start-guide__link a:hover {
-    text-decoration: underline;
-}
 
 #nickname-form button,
 #model-select button {

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -101,7 +101,7 @@
                    hx-push-url="true"
                    class="header-nav__tab{% if _page == 'guide' %} header-nav__tab--active{% endif %}"
                    {% if _page == 'guide' %}aria-selected="true"{% else %}aria-selected="false"{% endif %}
-                   data-tab="guide">Guide</a>
+                   data-tab="guide">Help / Guide</a>
             </nav>
             {% endif %}
             <button id="text-size-toggle"

--- a/web/templates/partials/model_select.html
+++ b/web/templates/partials/model_select.html
@@ -36,15 +36,4 @@
         <p class="match-info">Expect <strong>6–12 hands</strong> per match — about 10–20 minutes.</p>
         <button type="submit" aria-label="Start match with selected AI">Start Match</button>
     </form>
-
-    <div class="quick-start-guide" role="region" aria-label="Quick start guide">
-        <h3 class="quick-start-guide__title">New to Bid Euchre?</h3>
-        <p>&#x1F0A1; You and your AI partner vs two AI opponents.</p>
-        <p>&#x270B; Bid how many tricks your team can win, or pass.</p>
-        <p>&#x1F3B4; Play cards by clicking them &mdash; <strong>green border</strong> = legal plays.</p>
-        <p>&#x1F3C6; First team to 52 points wins. Reaching &minus;52 means you lose!</p>
-        <p class="quick-start-guide__link">
-            <a href="/guide/{{ link_uuid }}">Read the full guide &rarr;</a>
-        </p>
-    </div>
 </div>

--- a/web/templates/partials/score.html
+++ b/web/templates/partials/score.html
@@ -11,15 +11,15 @@
 #}
 {% set seat_labels = seat_labels | default({0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}) %}
 
-<div id="score-bar" class="score-bar" role="status" aria-label="Current game score: You {{ score_human }}, AI {{ score_ai }}" aria-live="polite">
-    <div class="score-section" aria-label="Current game score: You {{ score_human }}, AI {{ score_ai }}">
+<div id="score-bar" class="score-bar" role="status" aria-label="Current game score: Your Team {{ score_human }}, Opponent {{ score_ai }}" aria-live="polite">
+    <div class="score-section" aria-label="Current game score: Your Team {{ score_human }}, Opponent {{ score_ai }}">
         <span class="score-header">Current Game Score:</span>
-        <span class="score-label score-label--human">You:</span>
+        <span class="score-label score-label--human">Your Team:</span>
         <span class="score-value score-value--human{% if score_human >= 0 %} score--positive{% else %} score--negative{% endif %}">
             {{ score_human }}
         </span>
         <span class="score-separator" aria-hidden="true">|</span>
-        <span class="score-label score-label--ai">AI:</span>
+        <span class="score-label score-label--ai">Opponent:</span>
         <span class="score-value score-value--ai{% if score_ai >= 0 %} score--positive{% else %} score--negative{% endif %}">
             {{ score_ai }}
         </span>


### PR DESCRIPTION
## Plan
N/A — bounded UI polish from issue #2288 items 5 and 8.

## Summary
- Score bar labels changed from "You:" / "AI:" to "Your Team:" / "Opponent:" for clarity
- Guide navigation tab renamed to "Help / Guide"
- Removed quick-start guide banner from model select screen (Help / Guide tab now serves this purpose)
- Cleaned up orphaned CSS for removed quick-start-guide component
- Updated all affected tests (unit, e2e, browser)

## Why
User review feedback (#2288) requested team-oriented score labels and consolidation of help content into the Guide tab instead of a separate in-game banner.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_partials.py -q  # 220 passed
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** Score template renders "Your Team:" and "Opponent:" labels; model_select no longer contains quick-start-guide; Guide tab text is "Help / Guide"
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_partials.py -q`
- **Expected result:** 220 passed, 0 failed

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_partials.py` — 220 passed
- [ ] Other: `make check-quiet` (running in background)

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git worktree list`:
```
(steward-brws-author-c worktree — persistent browser-game lane)
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)