### PR TITLE
feat(web): color AI player names blue across all partials (#2288)

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -979,7 +979,10 @@ class TestScore:
             dealer_seat=2,
             phase="trick_play",
         )
-        assert "Dealer: Ace" in html
+        assert "Dealer:" in html
+        assert "Ace" in html
+        # AI dealer name wrapped in .ai-name span (#2288.4)
+        assert 'class="ai-name"' in html
 
     def test_no_contract_info_in_score_bar(self, env):
         """Contract info removed from score bar (shown in contract bar instead)."""
@@ -2128,7 +2131,8 @@ class TestContractBar:
         assert "Current Contract and Trump:" in html
         assert "6" in html
         assert "\u2665" in html  # Heart symbol
-        assert "by Slim" in html
+        # AI declarer name wrapped in .ai-name span (#2288.4)
+        assert 'class="ai-name">Slim</span>' in html
 
     def test_high_contract(self, env):
         """High (no-trump) contract by human shows 'by You'."""
@@ -2144,6 +2148,8 @@ class TestContractBar:
         assert "High" in html
         assert "by You" in html
         assert "contract-bar--my-team" in html
+        # Human name should NOT be wrapped in ai-name
+        assert "ai-name" not in html
         assert "Current Contract:" in html
         assert "and Trump" not in html
 
@@ -2159,7 +2165,8 @@ class TestContractBar:
         )
         assert "7" in html
         assert "Low" in html
-        assert "by Ace" in html
+        # AI declarer name wrapped in .ai-name span (#2288.4)
+        assert 'class="ai-name">Ace</span>' in html
         assert "contract-bar--my-team" in html
 
     def test_moon_contract(self, env):
@@ -2175,7 +2182,8 @@ class TestContractBar:
         assert "Moon" in html
         assert "contract-bar__type--moon" in html
         assert "\u2660" in html  # Spade symbol
-        assert "by Deuce" in html
+        # AI declarer name wrapped in .ai-name span (#2288.4)
+        assert 'class="ai-name">Deuce</span>' in html
         assert "contract-bar--opp-team" in html
 
     def test_loner_contract(self, env):
@@ -2193,6 +2201,8 @@ class TestContractBar:
         assert "\u2666" in html  # Diamond symbol
         assert "by You" in html
         assert "contract-bar--my-team" in html
+        # Human name should NOT be wrapped in ai-name
+        assert "ai-name" not in html
 
     def test_auction_in_progress_display(self, env):
         """During auction with no bid, shows 'Auction in Progress'."""
@@ -2251,7 +2261,7 @@ class TestContractBar:
         assert "contract-bar--my-team" in html
 
     def test_partner_declarer_label(self, env):
-        """Partner (seat 2) shows 'by Ace'."""
+        """Partner (seat 2) shows 'by Ace' wrapped in ai-name."""
         tmpl = env.get_template("partials/contract_bar.html")
         html = tmpl.render(
             winning_bid=5,
@@ -2260,11 +2270,11 @@ class TestContractBar:
             contract_type="suit",
             trump="S",
         )
-        assert "by Ace" in html
+        assert 'class="ai-name">Ace</span>' in html
         assert "contract-bar--my-team" in html
 
     def test_opponent_seat1_declarer_label(self, env):
-        """Left opponent (seat 1) shows 'by Slim'."""
+        """Left opponent (seat 1) shows 'by Slim' wrapped in ai-name."""
         tmpl = env.get_template("partials/contract_bar.html")
         html = tmpl.render(
             winning_bid=5,
@@ -2273,11 +2283,11 @@ class TestContractBar:
             contract_type="suit",
             trump="H",
         )
-        assert "by Slim" in html
+        assert 'class="ai-name">Slim</span>' in html
         assert "contract-bar--opp-team" in html
 
     def test_opponent_seat3_declarer_label(self, env):
-        """Right opponent (seat 3) shows 'by Deuce'."""
+        """Right opponent (seat 3) shows 'by Deuce' wrapped in ai-name."""
         tmpl = env.get_template("partials/contract_bar.html")
         html = tmpl.render(
             winning_bid=8,
@@ -2286,7 +2296,7 @@ class TestContractBar:
             contract_type="suit",
             trump="C",
         )
-        assert "by Deuce" in html
+        assert 'class="ai-name">Deuce</span>' in html
         assert "contract-bar--opp-team" in html
 
     def test_header_label_suit(self, env):
@@ -2771,9 +2781,11 @@ class TestGameTemplateAccessibility:
             bidder_seat=None,
         )
         assert 'class="ai-card-count" aria-hidden="true"' not in html
-        assert "Slim (10)" in html
-        assert "Ace (10)" in html
-        assert "Deuce (10)" in html
+        # AI names now wrapped in ai-name spans (#2288.4)
+        assert 'class="ai-name">Slim</span>' in html
+        assert "(10)" in html  # card count still present
+        assert 'class="ai-name">Ace</span>' in html
+        assert 'class="ai-name">Deuce</span>' in html
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -490,7 +490,9 @@ class TestNextRevealFlow:
         assert "card--played" not in resp.text
 
         # Slim (seat 1) hand count should show 10 (pre-play), not 9
-        assert "Slim (10)" in resp.text
+        # AI names wrapped in .ai-name span (#2288.4)
+        assert 'class="ai-name">Slim</span>' in resp.text
+        assert "(10)" in resp.text
 
         # No "Play card" button — still in auction reveal
         assert 'id="card-play-form"' not in resp.text

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -408,6 +408,11 @@ main {
     min-height: 1.4em;
 }
 
+/* AI player names — blue to distinguish from human player (#2288.4) */
+.ai-name {
+    color: #64b5f6;
+}
+
 .ai-hand-block--middle {
     flex: 1 1 auto;
 }

--- a/web/templates/partials/bid_panel.html
+++ b/web/templates/partials/bid_panel.html
@@ -30,7 +30,7 @@
                 {% for entry in auction %}
                 {% set entry_bid_type = entry.get("bid_type", "regular") %}
                 <tr{% if entry_bid_type == "moon" %} class="bid--moon"{% elif entry_bid_type == "loner" %} class="bid--loner"{% endif %}>
-                    <td>{{ seat_labels.get(entry.seat, "Seat " ~ entry.seat) }}</td>
+                    <td>{% if entry.seat != 0 %}<span class="ai-name">{{ seat_labels.get(entry.seat, "Seat " ~ entry.seat) }}</span>{% else %}{{ seat_labels.get(entry.seat, "Seat " ~ entry.seat) }}{% endif %}</td>
                     <td>
                         {% if entry.action == "pass" %}
                             Pass
@@ -129,7 +129,7 @@
         {% endif %}
     </p>
     {% endif %}
-    <p class="bid-info">Dealer: {{ seat_labels.get(dealer_seat, "Seat " ~ dealer_seat) }}</p>
+    <p class="bid-info">Dealer: {% if dealer_seat != 0 %}<span class="ai-name">{{ seat_labels.get(dealer_seat, "Seat " ~ dealer_seat) }}</span>{% else %}{{ seat_labels.get(dealer_seat, "Seat " ~ dealer_seat) }}{% endif %}</p>
 </div>
 
 <script>

--- a/web/templates/partials/bid_recap.html
+++ b/web/templates/partials/bid_recap.html
@@ -16,7 +16,7 @@
 {% if winning_bid is not none and bidder_seat is not none %}
 <div class="bid-recap" role="status" aria-label="Auction result">
     <span class="bid-recap__declarer">
-        {{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}
+        {% if bidder_seat != 0 %}<span class="ai-name">{{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}</span>{% else %}{{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}{% endif %}
     </span>
     <span class="bid-recap__separator" aria-hidden="true">bid</span>
     <span class="bid-recap__contract">
@@ -45,7 +45,7 @@
     {# Use "is not none" (not truthy) — seat 0 is the human and is valid. #}
     {% if sitting_out_seat is not none %}
     <span class="bid-recap__sitting-out" aria-label="Sitting out: {{ seat_labels.get(sitting_out_seat, 'Seat ' ~ sitting_out_seat) }}">
-        ({{ seat_labels.get(sitting_out_seat, "Seat " ~ sitting_out_seat) }} sits out)
+        ({% if sitting_out_seat != 0 %}<span class="ai-name">{{ seat_labels.get(sitting_out_seat, "Seat " ~ sitting_out_seat) }}</span>{% else %}{{ seat_labels.get(sitting_out_seat, "Seat " ~ sitting_out_seat) }}{% endif %} sits out)
     </span>
     {% endif %}
 </div>

--- a/web/templates/partials/contract_bar.html
+++ b/web/templates/partials/contract_bar.html
@@ -52,9 +52,9 @@
         {% endif %}
     </span>
 
-    {# Declarer — "by Name" #}
+    {# Declarer — "by Name" (AI names blue via .ai-name #2288.4) #}
     <span class="contract-bar__declarer">
-        by {{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}
+        by {% if bidder_seat != 0 %}<span class="ai-name">{{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}</span>{% else %}{{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}{% endif %}
     </span>
 </div>
 {% elif phase is defined and phase == "auction" %}

--- a/web/templates/partials/game_board.html
+++ b/web/templates/partials/game_board.html
@@ -63,7 +63,7 @@
         <div class="compass-top" role="region" aria-label="{{ seat_labels[2] }} hand">
             <div class="ai-hand-block">
                 <div class="ai-seat-label">
-                    {{ seat_labels[2] }}
+                    <span class="ai-name">{{ seat_labels[2] }}</span>
                     {# Phase-dependent word labels — one badge max per seat #}
                     {% if phase == "auction" and dealer_seat == 2 %}
                         <span class="seat-marker seat-marker--dealer" title="Dealer">Dealer</span>
@@ -79,7 +79,7 @@
                     <div class="card-back" aria-hidden="true"></div>
                     {% endfor %}
                 </div>
-                <span class="ai-card-count">{{ seat_labels[2] }} ({{ partner_count | default(0) }})</span>
+                <span class="ai-card-count"><span class="ai-name">{{ seat_labels[2] }}</span> ({{ partner_count | default(0) }})</span>
             </div>
         </div>
 
@@ -87,7 +87,7 @@
         <div class="compass-left" role="region" aria-label="{{ seat_labels[1] }} hand">
             <div class="ai-hand-block ai-hand-block--vertical">
                 <div class="ai-seat-label">
-                    {{ seat_labels[1] }}
+                    <span class="ai-name">{{ seat_labels[1] }}</span>
                     {% if phase == "auction" and dealer_seat == 1 %}
                         <span class="seat-marker seat-marker--dealer" title="Dealer">Dealer</span>
                     {% elif phase == "trick_play" and trick_leader == 1 %}
@@ -102,7 +102,7 @@
                     <div class="card-back" aria-hidden="true"></div>
                     {% endfor %}
                 </div>
-                <span class="ai-card-count">{{ seat_labels[1] }} ({{ opp_left_count | default(0) }})</span>
+                <span class="ai-card-count"><span class="ai-name">{{ seat_labels[1] }}</span> ({{ opp_left_count | default(0) }})</span>
             </div>
         </div>
 
@@ -133,7 +133,7 @@
         <div class="compass-right" role="region" aria-label="{{ seat_labels[3] }} hand">
             <div class="ai-hand-block ai-hand-block--vertical">
                 <div class="ai-seat-label">
-                    {{ seat_labels[3] }}
+                    <span class="ai-name">{{ seat_labels[3] }}</span>
                     {% if phase == "auction" and dealer_seat == 3 %}
                         <span class="seat-marker seat-marker--dealer" title="Dealer">Dealer</span>
                     {% elif phase == "trick_play" and trick_leader == 3 %}
@@ -148,7 +148,7 @@
                     <div class="card-back" aria-hidden="true"></div>
                     {% endfor %}
                 </div>
-                <span class="ai-card-count">{{ seat_labels[3] }} ({{ opp_right_count | default(0) }})</span>
+                <span class="ai-card-count"><span class="ai-name">{{ seat_labels[3] }}</span> ({{ opp_right_count | default(0) }})</span>
             </div>
         </div>
 

--- a/web/templates/partials/hand_result.html
+++ b/web/templates/partials/hand_result.html
@@ -20,7 +20,8 @@
 {% set hand_bid_type = bid_type | default("regular") %}
 {% set exchange_given_cards = exchange_given | default([], true) %}
 {% set exchange_received_cards = exchange_received | default([], true) %}
-{% set partner_seat_label = seat_labels.get((bidder_seat + 2) % 4, "Partner") %}
+{% set partner_seat = (bidder_seat + 2) % 4 %}
+{% set partner_seat_label = seat_labels.get(partner_seat, "Partner") %}
 
 {# Determine if the declaring team made their bid #}
 {% set declarer_team = 0 if bidder_seat in [0, 2] else 1 %}
@@ -86,7 +87,7 @@
         {% endif %}
 
         <p class="result-detail">
-            {{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}
+            {% if bidder_seat != 0 %}<span class="ai-name">{{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}</span>{% else %}{{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}{% endif %}
             {% if hand_bid_type == "moon" %}
                 bid Moon
             {% elif hand_bid_type == "loner" %}
@@ -112,11 +113,11 @@
             <div class="result-exchange" aria-label="Moon exchange summary">
                 <p class="exchange-title"><strong>Moon Exchange</strong></p>
                 <p class="exchange-details">
-                    Given {{ exchange_given_cards|length }} to partner ({{ partner_seat_label }}):
+                    Given {{ exchange_given_cards|length }} to partner ({% if partner_seat != 0 %}<span class="ai-name">{{ partner_seat_label }}</span>{% else %}{{ partner_seat_label }}{% endif %}):
                     {% for card in exchange_given_cards %}<span class="card-text" aria-label="{{ suit_symbols.get(card[0], card[0]) }}{{ card[1]|display_rank }}"><span class="suit-icon suit-icon--{{ suit_classes.get(card[0], 'spades') }}">{{ suit_symbols.get(card[0], card[0]) }}</span> {{ card[1]|display_rank }}</span>{% if not loop.last %}, {% endif %}{% endfor %}
                 </p>
                 <p class="exchange-details">
-                    Received {{ exchange_received_cards|length }} from partner ({{ partner_seat_label }}):
+                    Received {{ exchange_received_cards|length }} from partner ({% if partner_seat != 0 %}<span class="ai-name">{{ partner_seat_label }}</span>{% else %}{{ partner_seat_label }}{% endif %}):
                     {% for card in exchange_received_cards %}<span class="card-text" aria-label="{{ suit_symbols.get(card[0], card[0]) }}{{ card[1]|display_rank }}"><span class="suit-icon suit-icon--{{ suit_classes.get(card[0], 'spades') }}">{{ suit_symbols.get(card[0], card[0]) }}</span> {{ card[1]|display_rank }}</span>{% if not loop.last %}, {% endif %}{% endfor %}
                 </p>
             </div>

--- a/web/templates/partials/moon_exchange.html
+++ b/web/templates/partials/moon_exchange.html
@@ -27,7 +27,7 @@
             <span aria-hidden="true">&#x1F319;</span> Moon Exchange
         </h2>
         <p class="moon-exchange__subtitle">
-            {{ mooner_label }} bid Moon
+            {% if bidder_seat != 0 %}<span class="ai-name">{{ mooner_label }}</span>{% else %}{{ mooner_label }}{% endif %} bid Moon
             {% if contract_type == "suit" and trump %}
                 in <span class="suit-icon suit-icon--{{ suit_classes.get(trump, 'spades') }}">{{ suit_symbols.get(trump, trump) }}</span>
             {% elif contract_type == "high" %}
@@ -42,7 +42,7 @@
         {% if exchange_given_cards %}
             <div class="moon-exchange__group">
                 <h3 class="moon-exchange__group-title">
-                    Given to {{ partner_label }}
+                    Given to {% if partner_seat != 0 %}<span class="ai-name">{{ partner_label }}</span>{% else %}{{ partner_label }}{% endif %}
                 </h3>
                 <div class="moon-exchange__card-list" role="list">
                     {% for card in exchange_given_cards %}
@@ -65,7 +65,7 @@
         {% if exchange_received_cards %}
             <div class="moon-exchange__group">
                 <h3 class="moon-exchange__group-title">
-                    Received from {{ partner_label }}
+                    Received from {% if partner_seat != 0 %}<span class="ai-name">{{ partner_label }}</span>{% else %}{{ partner_label }}{% endif %}
                 </h3>
                 <div class="moon-exchange__card-list" role="list">
                     {% for card in exchange_received_cards %}

--- a/web/templates/partials/moon_exchange_select.html
+++ b/web/templates/partials/moon_exchange_select.html
@@ -22,7 +22,7 @@
             <span aria-hidden="true">&#x1F319;</span> Moon Exchange
         </h2>
         <p class="moon-exchange__subtitle">
-            {{ mooner_label }} bid Moon
+            {% if bidder_seat != 0 %}<span class="ai-name">{{ mooner_label }}</span>{% else %}{{ mooner_label }}{% endif %} bid Moon
             {% if contract_type == "suit" and trump %}
                 in <span class="suit-icon suit-icon--{{ suit_classes.get(trump, 'spades') }}">{{ suit_symbols.get(trump, trump) }}</span>
             {% elif contract_type == "high" %}

--- a/web/templates/partials/score.html
+++ b/web/templates/partials/score.html
@@ -30,7 +30,7 @@
         <div class="hand-details__content">
             <span>Hand {{ hands_played + 1 }}</span>
             <span class="info-separator" aria-hidden="true">&middot;</span>
-            <span>Dealer: {{ seat_labels.get(dealer_seat, "Seat " ~ dealer_seat) }}</span>
+            <span>Dealer: {% if dealer_seat != 0 %}<span class="ai-name">{{ seat_labels.get(dealer_seat, "Seat " ~ dealer_seat) }}</span>{% else %}{{ seat_labels.get(dealer_seat, "Seat " ~ dealer_seat) }}{% endif %}</span>
             <span class="info-separator" aria-hidden="true">&middot;</span>
             <span>First to 52 wins &middot; &minus;52 = loss</span>
         </div>

--- a/web/templates/partials/trick.html
+++ b/web/templates/partials/trick.html
@@ -70,7 +70,7 @@
     {% else %}
         <div class="{{ fallback_class }}" aria-label="{{ seat_labels[seat] }} waiting to play">
             {% if show_label %}
-                <span class="seat-label">{{ seat_labels[seat] }}</span>
+                <span class="seat-label">{% if seat != 0 %}<span class="ai-name">{{ seat_labels[seat] }}</span>{% else %}{{ seat_labels[seat] }}{% endif %}</span>
             {% endif %}
         </div>
     {% endif %}
@@ -125,7 +125,7 @@
     </div>
     {% if current_trick and trick_winning_seat is defined and trick_winning_seat is not none %}
         <p class="trick-current-winner" aria-live="polite">
-            {% if trick_winning_seat == 0 %}You are{% else %}{{ seat_labels[trick_winning_seat] }} is{% endif %} currently winning the trick
+            {% if trick_winning_seat == 0 %}You are{% else %}<span class="ai-name">{{ seat_labels[trick_winning_seat] }}</span> is{% endif %} currently winning the trick
         </p>
     {% endif %}
     {% if display_winner is not none %}
@@ -140,7 +140,7 @@
             {% if display_winner == 0 %}
                 You
             {% else %}
-                {{ seat_labels[display_winner] if display_winner in seat_labels else ("Seat " ~ display_winner) }}
+                <span class="ai-name">{{ seat_labels[display_winner] if display_winner in seat_labels else ("Seat " ~ display_winner) }}</span>
             {% endif %}
             won{% if winning_card %} with
                 {% set wc_suit = winning_card[0] %}

--- a/web/templates/partials/trick_history.html
+++ b/web/templates/partials/trick_history.html
@@ -19,9 +19,9 @@
                 <tr>
                     <th class="trick-history__th">#</th>
                     <th class="trick-history__th">You</th>
-                    <th class="trick-history__th">{{ seat_labels[1] }}</th>
-                    <th class="trick-history__th">{{ seat_labels[2] }}</th>
-                    <th class="trick-history__th">{{ seat_labels[3] }}</th>
+                    <th class="trick-history__th"><span class="ai-name">{{ seat_labels[1] }}</span></th>
+                    <th class="trick-history__th"><span class="ai-name">{{ seat_labels[2] }}</span></th>
+                    <th class="trick-history__th"><span class="ai-name">{{ seat_labels[3] }}</span></th>
                     <th class="trick-history__th">Won</th>
                 </tr>
             </thead>
@@ -46,7 +46,7 @@
                             </td>
                         {% endfor %}
                         <td class="trick-history__cell trick-history__cell--won">
-                            {{ seat_labels.get(trick.winner, "?") }}
+                            {% if trick.winner != 0 %}<span class="ai-name">{{ seat_labels.get(trick.winner, "?") }}</span>{% else %}{{ seat_labels.get(trick.winner, "?") }}{% endif %}
                         </td>
                     </tr>
                 {% endfor %}


### PR DESCRIPTION
## Plan
N/A — bounded UI polish task from #2288 items 3+4.

## Summary
- Wrap all AI player names (seats 1, 2, 3) in `.ai-name` spans with blue (`#64b5f6`) styling
- Human player (seat 0) is never wrapped — only AI opponents/partner get the blue treatment
- Covers 11 template partials: game board, trick, trick history, contract bar, bid panel, bid recap, score bar, hand result, moon exchange, moon exchange select

## Why
AI player names (Slim, Ace, Deuce) were visually indistinct from the human player label ("You"). Blue coloring provides an immediate visual cue that distinguishes AI players, improving game readability.

Addresses #2288 item 4 (AI name styling).

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_partials.py tests/unit/hosted_play/test_routes.py -x -q
```

**Result:** 338 passed, 2 skipped

## Test Criteria
- **Pass condition:** All AI names in templates are wrapped in `<span class="ai-name">`, human (seat 0) names are NOT wrapped
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_partials.py -k "ai_name or ai-name or declarer_label" -v`
- **Expected result:** All tests pass, assertions verify `.ai-name` class present for AI seats and absent for human seat

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_partials.py tests/unit/hosted_play/test_routes.py -x -q` — 338 passed, 2 skipped

## Expected impact
- Metrics impact: None (UI-only change)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
```

`git worktree list` (relevant line):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b   4d642563 [feat/web-ui-polish-suit-colors-ai-names]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)