### PR TITLE
feat(web): sort hand with alternating red/black suits (#2288)

### DIFF
--- a/src/bid_euchre/hosted_play/engine.py
+++ b/src/bid_euchre/hosted_play/engine.py
@@ -45,8 +45,17 @@ _NUM_PLAYERS = 4
 _TRICKS_PER_HAND = 10
 
 
-# Display suit order: Spades, Hearts, Diamonds, Clubs
-_SUIT_DISPLAY_ORDER: dict[str, int] = {"S": 0, "H": 1, "D": 2, "C": 3}
+# Display suit order: alternating black/red — S(♠), H(♥), C(♣), D(♦)
+_SUIT_DISPLAY_ORDER: dict[str, int] = {"S": 0, "H": 1, "C": 2, "D": 3}
+
+# Trump-aware alternating orders: trump first, then alternate starting with
+# the opposite color.  Pre-computed for all four possible trump suits.
+_SUIT_DISPLAY_ORDER_TRUMP: dict[str, dict[str, int]] = {
+    "S": {"S": 0, "H": 1, "C": 2, "D": 3},  # B R B R
+    "H": {"H": 0, "S": 1, "D": 2, "C": 3},  # R B R B
+    "C": {"C": 0, "H": 1, "S": 2, "D": 3},  # B R B R
+    "D": {"D": 0, "S": 1, "H": 2, "C": 3},  # R B R B
+}
 
 # Within-suit rank order: J highest, then A-K-Q-T (auction / trump suit)
 _RANK_DISPLAY_ORDER: dict[str, int] = {"J": 0, "A": 1, "K": 2, "Q": 3, "T": 4}
@@ -68,8 +77,10 @@ def sort_hand_for_display(
     Grouping:
     - Cards are grouped by effective suit (bowers move to trump group in suit
       contracts).
+    - Suits alternate black/red for visual clarity.
     - When trump is active, the trump suit appears first; remaining suits
-      follow standard order (S > H > D > C).
+      alternate starting with the opposite color of trump.
+    - Without trump: S(♠) H(♥) C(♣) D(♦).
 
     Within-suit ordering:
     - Suit contracts (trump suit): right bower > left bower > A > K > Q > (non-bower J) > T
@@ -86,9 +97,11 @@ def sort_hand_for_display(
         else:
             eff = card.suit
 
-        # Suit ordering — trump first when active
-        if contract_type == "suit" and trump and eff == trump:
-            suit_key = -1
+        # Suit ordering — alternating black/red; trump first when active
+        if contract_type == "suit" and trump:
+            suit_key = _SUIT_DISPLAY_ORDER_TRUMP.get(trump, _SUIT_DISPLAY_ORDER).get(
+                eff, 99
+            )
         else:
             suit_key = _SUIT_DISPLAY_ORDER.get(eff, 99)
 

--- a/tests/e2e/hosted_play/test_smoke_placeholder.py
+++ b/tests/e2e/hosted_play/test_smoke_placeholder.py
@@ -282,7 +282,7 @@ class TestHandSorting:
 
     @pytest.mark.e2e
     def test_suit_grouping_no_trump(self) -> None:
-        """Cards group by suit in S > H > D > C order without trump."""
+        """Cards group by suit in alternating black/red order without trump."""
         hand = [
             Card("C", "A"),
             Card("H", "K"),
@@ -295,9 +295,9 @@ class TestHandSorting:
         assert suits == [
             "S",
             "H",
-            "D",
             "C",
-        ], f"Expected S > H > D > C order, got {suits}"
+            "D",
+        ], f"Expected S > H > C > D (alternating B/R) order, got {suits}"
 
     @pytest.mark.e2e
     def test_suit_grouping_with_trump(self) -> None:

--- a/tests/unit/hosted_play/test_engine.py
+++ b/tests/unit/hosted_play/test_engine.py
@@ -2242,8 +2242,8 @@ class TestSortHandForDisplay:
         ]
         sort_hand_for_display(hand)
         suits = [c.suit for c in hand]
-        # S group first, then H, D, C
-        assert suits == ["S", "S", "H", "H", "D", "C"]
+        # S group first, then H, C, D — alternating black/red
+        assert suits == ["S", "S", "H", "H", "C", "D"]
 
     def test_within_suit_rank_order(self) -> None:
         """Within a suit: J > A > K > Q > T (no trump)."""
@@ -2269,8 +2269,21 @@ class TestSortHandForDisplay:
         sort_hand_for_display(hand, contract_type="suit", trump="D")
         suits = [c.suit for c in hand]
         assert suits[0] == "D"  # Trump first
-        # Remaining suits in standard order: S, H, C
+        # Remaining suits alternate black/red: S, H, C
         assert suits[1:] == ["S", "H", "C"]
+
+    def test_trump_alternates_remaining_suits(self) -> None:
+        """Non-trump suits alternate black/red after trump group."""
+        hand = [
+            Card("S", "A"),
+            Card("H", "A"),
+            Card("D", "A"),
+            Card("C", "A"),
+        ]
+        # Trump = C (black): remaining should be H(red), S(black), D(red)
+        sort_hand_for_display(hand, contract_type="suit", trump="C")
+        suits = [c.suit for c in hand]
+        assert suits == ["C", "H", "S", "D"]
 
     def test_right_bower_highest_in_trump(self) -> None:
         """Right bower (J of trump) sorts highest in trump group."""


### PR DESCRIPTION
## Summary
- Change hand display sort order to alternate black/red suits: S(♠)→H(♥)→C(♣)→D(♦)
- With trump active, trump suit appears first; remaining suits alternate starting with the opposite color
- Left bower continues to sort with the trump group (no change to bower handling)

## Why
Item 10 from #2288: visual grouping of same-color suits adjacent to each other makes it harder to distinguish suits at a glance. Alternating black/red provides clearer visual separation.

## Changes
| File | Change |
|------|--------|
| `src/bid_euchre/hosted_play/engine.py` | New `_SUIT_DISPLAY_ORDER_TRUMP` lookup table; updated `_SUIT_DISPLAY_ORDER` from S-H-D-C to S-H-C-D; simplified suit_key computation |
| `tests/unit/hosted_play/test_engine.py` | Updated `test_groups_by_suit` assertion; added `test_trump_alternates_remaining_suits` |
| `tests/e2e/hosted_play/test_smoke_placeholder.py` | Updated `test_suit_grouping_no_trump` assertion |

## Trump-specific orderings
| Trump | Full Order | Colors |
|-------|-----------|--------|
| None | S H C D | B R B R |
| S (♠) | S H C D | B R B R |
| H (♥) | H S D C | R B R B |
| C (♣) | C H S D | B R B R |
| D (♦) | D S H C | R B R B |

## Repro / Validation
```bash
uv run python -m pytest tests/unit/hosted_play/test_engine.py::TestSortHandForDisplay -v
uv run python -m pytest tests/e2e/hosted_play/test_smoke_placeholder.py::TestHandSorting -v
make check-quiet  # 11,111 passed; 30 pre-existing failures in unrelated tests
```

## Tests
- `make check-quiet` — all 11,111 tests pass; 30 failures are pre-existing (27 sim/browser parity + 3 unrelated unit tests)
- 12 unit tests for `sort_hand_for_display` pass (including new alternating test)
- 6 e2e hand sorting tests pass

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
branch: feat/hand-sort-alternating-suits
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)