### PR TITLE
fix(web): default bid selector to next possible bid (#2310)

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -287,11 +287,71 @@ class TestBidPanel:
         bid_options = bid_select.group(1)
         for n in range(1, 6):
             assert f'value="{n}">{n}' not in bid_options
-        # Should have bid levels 6-10
+        # Should have bid levels 6-10 (first may have 'selected' attr)
         for n in range(6, 11):
-            assert f'value="{n}">{n}' in bid_options
+            assert f'value="{n}"' in bid_options
         # Pass is always available
         assert "Pass" in bid_options
+
+    def test_default_selection_is_next_bid(self, env):
+        """Bid selector defaults to next possible bid, not pass (#2310)."""
+        import re
+
+        tmpl = env.get_template("partials/bid_panel.html")
+        # current_high_bid=5 → first legal bid is 6, should be selected
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=0,
+            auction=[],
+            current_high_bid=5,
+            dealer_seat=3,
+        )
+        bid_select = re.search(
+            r'<select id="bid-level"[^>]*>(.*?)</select>', html, re.DOTALL
+        )
+        assert bid_select is not None
+        bid_options = bid_select.group(1)
+        assert 'value="6" selected' in bid_options
+        assert 'value="7" selected' not in bid_options
+
+    def test_default_selection_first_bid_when_no_bids(self, env):
+        """When no bids yet (current_high_bid=0), bid 1 is selected."""
+        import re
+
+        tmpl = env.get_template("partials/bid_panel.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=0,
+            auction=[],
+            current_high_bid=0,
+            dealer_seat=3,
+        )
+        bid_select = re.search(
+            r'<select id="bid-level"[^>]*>(.*?)</select>', html, re.DOTALL
+        )
+        assert bid_select is not None
+        bid_options = bid_select.group(1)
+        assert 'value="1" selected' in bid_options
+
+    def test_default_selection_pass_when_all_bids_exhausted(self, env):
+        """When current_high_bid=10, no numeric bids available; pass is default."""
+        import re
+
+        tmpl = env.get_template("partials/bid_panel.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=0,
+            auction=[],
+            current_high_bid=10,
+            dealer_seat=3,
+        )
+        bid_select = re.search(
+            r'<select id="bid-level"[^>]*>(.*?)</select>', html, re.DOTALL
+        )
+        assert bid_select is not None
+        bid_options = bid_select.group(1)
+        # No selected attribute on any option → browser defaults to first (Pass)
+        assert "selected" not in bid_options
 
     def test_shows_all_contract_types(self, env):
         tmpl = env.get_template("partials/bid_panel.html")

--- a/web/templates/partials/bid_panel.html
+++ b/web/templates/partials/bid_panel.html
@@ -91,7 +91,7 @@
                 <select id="bid-level" name="bid_n" aria-label="Bid level">
                     <option value="0">Pass</option>
                     {% for n in range(current_high_bid + 1, 11) %}
-                    <option value="{{ n }}">{{ n }}</option>
+                    <option value="{{ n }}"{% if loop.first %} selected{% endif %}>{{ n }}</option>
                     {% endfor %}
                 </select>
             </span>


### PR DESCRIPTION
## Plan
N/A — single-issue fix

## Summary
- Change the bid level dropdown to default-select the next possible numeric bid (minimum legal bid) instead of "pass"
- Add 3 unit tests covering default selection behavior for normal, fresh auction, and exhausted bid states

## Why
The bid dropdown defaulted to "pass" even though there's a dedicated Pass button, requiring an extra click for players who want to bid. Fixes #2310.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_partials.py::TestBidPanel -v
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** First numeric bid option has `selected` attribute in rendered HTML
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_partials.py::TestBidPanel::test_default_selection_is_next_bid -v`
- **Expected result:** Test passes — confirms `value="6" selected` present when `current_high_bid=5`

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_partials.py::TestBidPanel -v` (16 passed)
- [x] `uv run python -m pytest tests/unit/hosted_play/test_partials.py -v` (228 passed)
- [ ] `make check-quiet` — pre-existing failures in match engine integration tests (unrelated to this change)

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a   9a3bb698 [fix/bid-selector-default]
```

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)