### PR TITLE
fix(web): use black fill for clubs/spades suit icons (#2329)

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -30,6 +30,12 @@
     --color-moon-glow: #ffca28;
     --color-loner: #7e57c2;
     --color-loner-glow: #b39ddb;
+    /* Black-suit text-shadow for visibility on dark backgrounds (#2329) */
+    --suit-black-shadow:
+        -1px -1px 0 rgba(255, 255, 255, 0.55),
+         1px -1px 0 rgba(255, 255, 255, 0.55),
+        -1px  1px 0 rgba(255, 255, 255, 0.55),
+         1px  1px 0 rgba(255, 255, 255, 0.55);
     /* Team colors — consistent across score, trick count, contract bar */
     --team-human: #66bb6a;
     --team-ai: #42a5f5;
@@ -527,7 +533,8 @@ main {
 
 .bid-recap__suit--s,
 .bid-recap__suit--c {
-    color: var(--color-text);
+    color: var(--color-black);
+    text-shadow: var(--suit-black-shadow);
 }
 
 .bid-recap__no-trump {
@@ -613,7 +620,8 @@ main {
 
 .contract-bar__suit--s,
 .contract-bar__suit--c {
-    color: var(--color-text);
+    color: var(--color-black);
+    text-shadow: var(--suit-black-shadow);
 }
 
 .contract-bar__no-trump {
@@ -793,7 +801,8 @@ main {
 
 .lead-suit--spades,
 .lead-suit--clubs {
-    color: #222;
+    color: var(--color-black);
+    text-shadow: var(--suit-black-shadow);
 }
 
 /* Top (partner) */
@@ -2077,7 +2086,8 @@ main {
 
 .landing-hero__suit--spade,
 .landing-hero__suit--club {
-    color: var(--color-text);
+    color: var(--color-black);
+    text-shadow: var(--suit-black-shadow);
 }
 
 .landing-hero__suit--heart,
@@ -3070,7 +3080,8 @@ main {
 
 .suit-icon--spades,
 .suit-icon--clubs {
-    color: var(--color-text);
+    color: var(--color-black);
+    text-shadow: var(--suit-black-shadow);
 }
 
 /* --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Clubs (♣) and spades (♠) suit icons were rendered in white (`var(--color-text)` = #fafafa) on dark backgrounds — they now use `var(--color-black)` (#212121) with a subtle white `text-shadow` outline for visibility on the dark felt
- Introduces a `--suit-black-shadow` CSS variable for the 4-direction white outline, keeping the approach DRY across 5 affected selectors
- Cards on white backgrounds (`.card--spades`, `.card--clubs`) were already correct and are unchanged

## Why

Issue #2329: clubs and spades should use black fill to match standard card conventions (♥♦ = red, ♠♣ = black). The dark felt background requires a text-shadow technique to make near-black text visible.

## Affected selectors

| Selector | Context | Before | After |
|----------|---------|--------|-------|
| `.suit-icon--spades/clubs` | Reusable utility (hand result, exchange, bid panel) | White | Black + shadow |
| `.bid-recap__suit--s/c` | Auction log recap | White | Black + shadow |
| `.contract-bar__suit--s/c` | Active contract display | White | Black + shadow |
| `.lead-suit--spades/clubs` | Trick area lead suit indicator | `#222` (invisible) | Black + shadow |
| `.landing-hero__suit--spade/club` | Landing page hero | White | Black + shadow |

## Repro / Validation

```bash
# Start the browser game and observe suit icons in any game view
uv run python -m web.app
# Visit http://localhost:8000 — start a game, observe auction log, trick area, hand
```

## Tests

```bash
# Template rendering tests (231 pass)
uv run python -m pytest tests/unit/hosted_play/test_partials.py -q
# Full suite (30 pre-existing failures unrelated to CSS — parity, token economy, telegram)
make check
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
branch: fix/black-suit-icons
```

Closes #2329

🤖 Generated with [Claude Code](https://claude.com/claude-code)