### PR TITLE
fix(web): hide Skip button from game UI, keep backend logic (#2332)

### DIFF
--- a/web/templates/partials/next_controls.html
+++ b/web/templates/partials/next_controls.html
@@ -14,6 +14,8 @@
                 Next
             </button>
         </form>
+        {# Skip button hidden per #2332 — backend skip logic preserved for
+           future reintroduction. Only the Next button is visible to players.
         {% if show_skip | default(false) %}
         <form method="post"
               action="/play/{{ link_uuid }}/skip"
@@ -26,5 +28,6 @@
             </button>
         </form>
         {% endif %}
+        #}
     </div>
 </div>


### PR DESCRIPTION
## Summary
- Wrap the Skip button block in `next_controls.html` inside a Jinja comment (`{# ... #}`)
- Only the Next button is now visible to players
- Backend skip functionality (route handler, engine logic) is completely untouched

## Why
Issue #2332 — the UI should only show the Next button. Skip functionality may be reintroduced later, so the markup and backend logic are preserved.

## Scope
- `web/templates/partials/next_controls.html` — only file changed

## Repro / Validation
```bash
# Start the app and play a game — only Next button visible, no Skip
uv run python -m pytest tests/unit/hosted_play/test_partials.py::TestNextControls -xvs
uv run python -m pytest tests/unit/hosted_play/test_routes.py -k next_controls -xvs
uv run python -m pytest tests/e2e/hosted_play/ -x -q
```

## Tests
- `tests/unit/hosted_play/test_partials.py::TestNextControls` — 1 passed ✅
- `tests/unit/hosted_play/test_routes.py -k next_controls` — 1 passed ✅
- `tests/e2e/hosted_play/` — 24 passed ✅
- `make check-quiet` — pre-existing parity test failure only (unrelated, on main)

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
branch: fix/hide-skip-button
```

Closes #2332

🤖 Generated with [Claude Code](https://claude.com/claude-code)