### PR TITLE
fix(web): hide contract/trump indicator during auction phase (#2328)

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -2172,6 +2172,7 @@ class TestContractBar:
             bid_type="regular",
             contract_type="suit",
             trump="H",
+            phase="trick_play",
         )
         assert "contract-bar" in html
         assert "contract-bar--opp-team" in html
@@ -2190,6 +2191,7 @@ class TestContractBar:
             bid_type="regular",
             contract_type="high",
             trump=None,
+            phase="trick_play",
         )
         assert "7" in html
         assert "High" in html
@@ -2209,6 +2211,7 @@ class TestContractBar:
             bid_type="regular",
             contract_type="low",
             trump=None,
+            phase="trick_play",
         )
         assert "7" in html
         assert "Low" in html
@@ -2225,6 +2228,7 @@ class TestContractBar:
             bid_type="moon",
             contract_type="suit",
             trump="S",
+            phase="trick_play",
         )
         assert "Moon" in html
         assert "contract-bar__type--moon" in html
@@ -2242,6 +2246,7 @@ class TestContractBar:
             bid_type="loner",
             contract_type="suit",
             trump="D",
+            phase="trick_play",
         )
         assert "Loner" in html
         assert "contract-bar__type--loner" in html
@@ -2292,6 +2297,30 @@ class TestContractBar:
         )
         assert "contract-bar" not in html
 
+    def test_auction_settle_hides_contract(self, env):
+        """During auction settle pause, contract/trump is hidden (#2328).
+
+        After all bids are revealed but before the user clicks "Continue",
+        winning_bid and bidder_seat are set but phase is still "auction".
+        The contract bar should show the auction status, not the contract.
+        """
+        tmpl = env.get_template("partials/contract_bar.html")
+        html = tmpl.render(
+            winning_bid=6,
+            bidder_seat=1,
+            bid_type="regular",
+            contract_type="suit",
+            trump="H",
+            phase="auction",
+            current_high_bid=6,
+            high_bidder_seat=1,
+        )
+        # Must NOT show the "Current Contract" display
+        assert "Current Contract" not in html
+        # Must show auction status instead
+        assert "Auction:" in html
+        assert "High Bid: 6" in html
+
     def test_bidder_seat_zero_not_coerced(self, env):
         """bidder_seat=0 (human) must not be treated as falsy."""
         tmpl = env.get_template("partials/contract_bar.html")
@@ -2301,6 +2330,7 @@ class TestContractBar:
             bid_type="regular",
             contract_type="suit",
             trump="C",
+            phase="trick_play",
         )
         assert "contract-bar" in html
         assert "by You" in html
@@ -2316,6 +2346,7 @@ class TestContractBar:
             bid_type="regular",
             contract_type="suit",
             trump="S",
+            phase="trick_play",
         )
         assert 'class="ai-name">Ace</span>' in html
         assert "contract-bar--my-team" in html
@@ -2329,6 +2360,7 @@ class TestContractBar:
             bid_type="regular",
             contract_type="suit",
             trump="H",
+            phase="trick_play",
         )
         assert 'class="ai-name">Slim</span>' in html
         assert "contract-bar--opp-team" in html
@@ -2342,6 +2374,7 @@ class TestContractBar:
             bid_type="regular",
             contract_type="suit",
             trump="C",
+            phase="trick_play",
         )
         assert 'class="ai-name">Deuce</span>' in html
         assert "contract-bar--opp-team" in html
@@ -2355,6 +2388,7 @@ class TestContractBar:
             bid_type="regular",
             contract_type="suit",
             trump="H",
+            phase="trick_play",
         )
         assert "contract-bar__header" in html
         assert "Current Contract and Trump:" in html
@@ -2368,6 +2402,7 @@ class TestContractBar:
             bid_type="regular",
             contract_type="high",
             trump=None,
+            phase="trick_play",
         )
         assert "contract-bar__header" in html
         assert "Current Contract:" in html

--- a/web/templates/partials/contract_bar.html
+++ b/web/templates/partials/contract_bar.html
@@ -1,5 +1,7 @@
 {# Contract bar — persistent, sticky display of the current contract during
    trick play, and auction status during auction phase.
+   During the auction phase (including settle pause) the contract/trump
+   indicator is hidden; only the auction status line is shown (#2328).
    Always visible at the top of the game board so the player never has to
    scroll to see what was bid.
 
@@ -21,7 +23,7 @@
 {% set is_my_team = bidder_seat in [0, 2] if bidder_seat is not none else false %}
 {% set team_class = "contract-bar--my-team" if is_my_team else "contract-bar--opp-team" %}
 
-{% if winning_bid is not none and bidder_seat is not none %}
+{% if winning_bid is not none and bidder_seat is not none and phase is defined and phase != "auction" %}
 <div class="contract-bar {{ team_class }}" role="status" aria-label="Current contract">
     {# Header label — include "and Trump" only for suit contracts #}
     {% if contract_type == "suit" %}


### PR DESCRIPTION
## Summary

- Hide the "Current Contract and Trump" display during the auction phase (including the settle pause)
- During auction, the contract bar now shows only the auction status ("Auction: High Bid: X by Y")
- The contract/trump display appears only during trick play and later phases

## Why

During the auction settle pause (all bids revealed, user hasn't clicked "Continue to play"), `winning_bid` and `bidder_seat` leak through to the template context while `phase` is still `"auction"`. The contract bar's first condition (`winning_bid is not none and bidder_seat is not none`) was True, so it prematurely showed "Current Contract and Trump:" instead of the auction status.

Closes #2328

## Changes

| File | Change |
|------|--------|
| `web/templates/partials/contract_bar.html` | Add `phase != "auction"` guard to contract display condition |
| `tests/unit/hosted_play/test_partials.py` | Add `phase="trick_play"` to existing contract tests + new regression test |

## Repro / Validation

```bash
# Tier 1 — contract bar tests
uv run python -m pytest tests/unit/hosted_play/test_partials.py::TestContractBar -v
# 15 passed (including new test_auction_settle_hides_contract)

# Full hosted_play unit suite
uv run python -m pytest tests/unit/hosted_play/ -v --tb=short
# 3412 passed, 8 skipped

# Lint
make lint  # Clean
```

## Tests

- `test_auction_settle_hides_contract` — **new**: verifies that during auction settle pause (phase="auction", winning_bid set), the contract bar shows auction status, not the contract
- 11 existing contract bar tests updated with `phase="trick_play"` to match the new phase-aware condition
- All 15 TestContractBar tests pass

## Worktree proof

```
pwd: Bid-Euchre-steward-brws-author-a
branch: fix/hide-contract-auction
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>