### PR TITLE
feat(web): reposition auction log below hand details during gameplay

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -2156,6 +2156,90 @@ class TestGameBoardSeatZeroRegression:
 
 
 # ---------------------------------------------------------------------------
+# game_board.html — auction log repositioning (#2331)
+# ---------------------------------------------------------------------------
+
+
+class TestAuctionLogRepositioning:
+    """Auction log renders inside compass-center during auction, but moves
+    below the score bar (hand details) during trick play.  Issue #2331."""
+
+    @staticmethod
+    def _board_ctx(phase, **overrides):
+        ctx = dict(
+            phase=phase,
+            link_uuid="test-uuid",
+            dealer_seat=1,
+            bidder_seat=2,
+            current_seat=3,
+            sitting_out_seat=None,
+            current_trick={"leader": 1, "plays": [[1, ["H", "K"]]]},
+            completed_tricks=[],
+            human_hand=[["S", "A"], ["H", "Q"]],
+            auction=[],
+            contract_type="suit",
+            trump="H",
+            bid_type="regular",
+            winning_bid=6,
+            current_high_bid=6,
+            tricks_team0=0,
+            tricks_team1=0,
+            score_human=0,
+            score_ai=0,
+            hands_played=0,
+            legal_plays=None,
+            opp_left_count=10,
+            partner_count=10,
+            opp_right_count=10,
+            show_next=False,
+            next_reason=None,
+            show_bid_panel=False,
+            action_rail=[{"kind": "auction", "text": "Slim bid 6"}],
+        )
+        ctx.update(overrides)
+        return ctx
+
+    def test_auction_log_inside_compass_center_during_auction(self, env):
+        """During auction, the action-rail is inside .compass-center."""
+        tmpl = env.get_template("partials/game_board.html")
+        html = tmpl.render(
+            **self._board_ctx("auction", show_bid_panel=True, turn_number=0)
+        )
+        center_pos = html.index("compass-center")
+        rail_pos = html.index('id="action-rail"')
+        score_pos = html.index("score-bar")
+        assert center_pos < rail_pos < score_pos
+
+    def test_auction_log_below_score_bar_during_trick_play(self, env):
+        """During trick play, the action-rail is below .score-bar (#2331)."""
+        tmpl = env.get_template("partials/game_board.html")
+        html = tmpl.render(**self._board_ctx("trick_play"))
+        score_pos = html.index("score-bar")
+        rail_pos = html.index('id="action-rail"')
+        assert rail_pos > score_pos
+
+    def test_auction_log_below_score_bar_during_redeal(self, env):
+        """During redeal phase, the action-rail is below .score-bar (#2331)."""
+        tmpl = env.get_template("partials/game_board.html")
+        html = tmpl.render(**self._board_ctx("redeal"))
+        score_pos = html.index("score-bar")
+        rail_pos = html.index('id="action-rail"')
+        assert rail_pos > score_pos
+
+    def test_auction_log_not_duplicated(self, env):
+        """Auction log should appear exactly once in each phase."""
+        tmpl = env.get_template("partials/game_board.html")
+        for phase in ("auction", "trick_play", "redeal"):
+            ctx = self._board_ctx(phase)
+            if phase == "auction":
+                ctx["show_bid_panel"] = True
+                ctx["turn_number"] = 0
+            html = tmpl.render(**ctx)
+            count = html.count('id="action-rail"')
+            assert count == 1, f"Expected 1 action-rail in {phase}, found {count}"
+
+
+# ---------------------------------------------------------------------------
 # contract_bar.html — sticky contract info bar during trick play
 # ---------------------------------------------------------------------------
 

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1457,6 +1457,12 @@ main {
     color: var(--color-text-muted);
 }
 
+/* When the auction log is repositioned below the score bar during gameplay,
+   the sibling combinator adds breathing room between the two blocks. */
+.score-bar + .action-rail {
+    margin-top: 0.75rem;
+}
+
 .result-banner .result-title {
     font-size: 1.5rem;
     margin: 0 0 0.5rem;

--- a/web/templates/partials/game_board.html
+++ b/web/templates/partials/game_board.html
@@ -111,8 +111,11 @@
             {# Contract bar — always visible with status #}
             {% include "partials/contract_bar.html" %}
 
-            {# Auction log — center-screen during auction, collapsible during play #}
-            {% include "partials/action_rail.html" %}
+            {# Auction log — center-screen during auction only.
+               During trick play it repositions below the score bar (see below). #}
+            {% if phase == "auction" %}
+                {% include "partials/action_rail.html" %}
+            {% endif %}
 
             {# Trick area — shown during trick play only (not during auction) #}
             {% if phase != "auction" %}
@@ -176,5 +179,11 @@
 
     {# Score bar — outside compass grid, always at bottom #}
     {% include "partials/score.html" %}
+
+    {# Auction log — repositioned below hand details during gameplay.
+       During auction it appears in the compass center (see above). #}
+    {% if phase != "auction" %}
+        {% include "partials/action_rail.html" %}
+    {% endif %}
 
 {% endif %}


### PR DESCRIPTION
## Plan
N/A — bounded UI fix from issue #2331

## Summary
- During auction: auction log stays in compass center (unchanged)
- During trick play / redeal: auction log moves below the score bar (hand details pane)
- CSS adds spacing rule for the repositioned auction log below score bar

## Why
The auction log clutters the primary gameplay area during trick play. Repositioning it below the hand details pane keeps it accessible as a reference while freeing the compass center for trick area and controls.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_partials.py::TestAuctionLogRepositioning -v
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** Auction log renders inside compass-center during auction, below score-bar during trick_play/redeal, and appears exactly once in each phase.
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_partials.py::TestAuctionLogRepositioning -v`
- **Expected result:** 4 tests pass (position during auction, trick_play, redeal, and no-duplication check)

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_partials.py -v` — 235 passed
- [x] `make check-quiet` — only pre-existing `test_sim_browser_parity` failures (confirmed on main)
- [x] Other: Targeted `TestAuctionLogRepositioning` (4 new tests), `TestActionRail` (5 tests), `TestGameBoardSeatZeroRegression` (10 tests) all pass

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git worktree list` (excerpt):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c   d159194f [feat/web-auction-log-reposition]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Issue Linkage
Fixes #2331

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
- [x] Issue linkage uses correct keyword (`Fixes` vs `Refs`) per closure policy