### PR TITLE
fix(web): remove create_tables() DDL from render_admin.py (#2303)

### DIFF
--- a/scripts/internal/render_admin.py
+++ b/scripts/internal/render_admin.py
@@ -66,7 +66,6 @@ try:
         InviteCode,
         Match,
         Player,
-        create_tables,
         generate_invite_code,
         init_engine,
         make_session_factory,
@@ -116,10 +115,14 @@ def _mask_url(url: str) -> str:
 
 
 def _get_session():
-    """Create a DB session from the production URL."""
+    """Create a DB session from the production URL.
+
+    Does NOT call ``create_tables()`` — schema is managed through deployment,
+    not through admin CLI invocations.  Running DDL on every admin query risks
+    creating tables for ORM models that haven't been deployed yet.
+    """
     database_url = _get_database_url()
     engine = init_engine(database_url)
-    create_tables(engine)
     factory = make_session_factory(engine)
     return factory(), database_url
 

--- a/tests/unit/hosted_play/test_render_admin.py
+++ b/tests/unit/hosted_play/test_render_admin.py
@@ -101,6 +101,26 @@ def test_no_url_exits(monkeypatch):
         mod._get_database_url()
 
 
+def test_get_session_does_not_call_create_tables(monkeypatch):
+    """_get_session must NOT call create_tables — schema is managed via deployment."""
+    mod = _import_render_admin()
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+    monkeypatch.delenv("RENDER_DATABASE_URL", raising=False)
+
+    # Patch create_tables into web.db so we can detect if it's called
+    call_count = 0
+
+    def _spy_create_tables(engine):
+        nonlocal call_count
+        call_count += 1
+
+    monkeypatch.setattr("web.db.create_tables", _spy_create_tables)
+
+    session, url = mod._get_session()
+    session.close()
+    assert call_count == 0, "create_tables() must not be called by _get_session()"
+
+
 def test_manage_invite_codes_render_url_priority(monkeypatch):
     """manage_invite_codes.py _get_session uses RENDER_DATABASE_URL when set."""
     monkeypatch.setenv("RENDER_DATABASE_URL", "sqlite:///:memory:")


### PR DESCRIPTION
## Summary
- Remove `create_tables(engine)` call from `_get_session()` in `render_admin.py`
- Remove unused `create_tables` import from `web.db`
- Add test verifying `_get_session` does NOT call `create_tables`

## Why
The admin CLI called `create_tables(engine)` on every session creation, executing
DDL (`CREATE TABLE IF NOT EXISTS`) on the production database. This risked creating
tables for ORM models not yet deployed and violated least-privilege for a read/query
tool. Schema management belongs in the deployment pipeline, not the admin CLI.

Closes #2303

## Repro / Validation
```bash
uv run python -m pytest tests/unit/hosted_play/test_render_admin.py -v
# 8 passed including new test_get_session_does_not_call_create_tables
```

## Tests
- `uv run python -m pytest tests/unit/hosted_play/test_render_admin.py -v` — 8/8 pass
- Full suite: 9058 passed, 1 pre-existing failure in unrelated `test_ops_token_economy.py`

## Worktree proof
```
pwd: Bid-Euchre-steward-brws-author-d
branch: fix/render-admin-no-ddl
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)