### PR TITLE
fix(docs): correct category totals and closure count in session audit (#2324)

### DIFF
--- a/plans/sessions/2026-04-04_session_audit.md
+++ b/plans/sessions/2026-04-04_session_audit.md
@@ -64,11 +64,11 @@
 
 | Category | Count | Key PRs |
 |----------|-------|---------|
-| Web features | 8 | #2280, #2284, #2294, #2302, #2314, #2316, #2319 |
-| Web fixes | 6 | #2270, #2274, #2298, #2308, #2315, #2321 |
+| Web features | 7 | #2280, #2284, #2294, #2302, #2314, #2316, #2319 |
+| Web fixes | 5 | #2270, #2274, #2298, #2308, #2315 |
 | Convention follow-ups | 3 | #2275, #2287, #2318 |
-| Ops features/fixes | 4 | #2268, #2273, #2292, #2295 |
-| Docs/plans | 5 | #2264, #2266, #2267, #2278, #2281, #2282, #2285 |
+| Ops features/fixes | 5 | #2268, #2273, #2277, #2292, #2295 |
+| Docs/plans | 7 | #2264, #2266, #2267, #2278, #2281, #2282, #2285 |
 | Chore (dashboard) | 2 | #2307, #2317 |
 | CI fix | 1 | #2321 |
 
@@ -111,7 +111,7 @@ The daytime session (#2263 handoff) left 29 issues that needed closing and
 | #2313 | tiered issue closure + DISABLE_MOUSE | fix:convention | OPEN |
 | #2320 | proving run checklist (Waves 3–5) | needs-verification | OPEN |
 
-### Issues Closed During Session (~49 closed)
+### Issues Closed During Session (49 closed)
 
 Most closures were catch-up from the daytime session's 29 unclosed issues
 (bulk-closed at 20:37 and 22:20–22:53 UTC). Additional closures:
@@ -120,7 +120,8 @@ Most closures were catch-up from the daytime session's 29 unclosed issues
   (#2202–#2229, #2205–#2244)
 - **Bulk wave 2 (22:20–22:53 UTC):** 20 issues — ops/convention issues from
   evening PRs (#2237–#2290)
-- **Individual closures:** #2231 (by #2294), #2289 (by #2298)
+- **Individual closures (5):** #2231 (by #2294), #2286 (convention fix),
+  #2289 (by #2298), #2290 (research concluded), #2297 (ops resolved)
 
 ### Net Issue Movement
 


### PR DESCRIPTION
## Summary

- Correct category summary totals in the 2026-04-04 session audit (line 67)
- Reconcile issue-closure count with enumerated closures (line 114)

## Why

Convention follow-up from PR #2322 review (#2324). The category summary had
four count/list mismatches (web features 8→7, web fixes 6→5, ops 4→5,
docs 5→7) and the issue-closure section was missing 3 individual closures.

## Changes

**Category summary (line 67):**
| Fix | Before | After | Reason |
|-----|--------|-------|--------|
| Web features | 8 | 7 | Count exceeded listed PRs |
| Web fixes | 6 | 5 | #2321 double-counted (also CI fix) |
| Ops features/fixes | 4 | 5 | Missing #2277 |
| Docs/plans | 5 | 7 | Count understated listed PRs |

Corrected total: 7+5+3+5+7+2+1 = 30 ✓

**Issue closures (line 114):**
- Added 3 missing individual closures: #2286, #2290, #2297
- Changed ~49 → 49 (now exact: 24+20+5=49)

## Repro / Validation

```bash
# Docs-only — verify totals manually
cat plans/sessions/2026-04-04_session_audit.md | grep -A8 "Category Summary"
```

## Tests

- `make lint` — passed (no Python changes)
- Docs-only PR — CI path-filter skips heavy jobs

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
branch: fix/convention-2322
```

Fixes #2324

🤖 Generated with [Claude Code](https://claude.com/claude-code)