### PR TITLE
fix(ops): escape-before-send tmux pattern (#2352)

### DIFF
--- a/.claude/skills/delegate-task/SKILL.md
+++ b/.claude/skills/delegate-task/SKILL.md
@@ -120,18 +120,21 @@ multi-line string, tmux wraps it in `\e[200~...\e[201~` escape sequences. If
 `Enter` is appended in the same `send-keys` call, it is consumed inside the
 paste bracket and the text is **pasted but never submitted**.
 
-**Two-step pattern (required for reliable dispatch):**
+**Three-step pattern (required for reliable dispatch):**
 ```bash
-# Step 1: send the text (do NOT append Enter)
+# Step 1: send Escape to cancel any in-progress input (#2352)
+tmux send-keys -t <pane> Escape
+sleep 0.1
+# Step 2: send the text (do NOT append Enter)
 tmux send-keys -t <pane> 'message text'
-# Step 2: wait briefly, then send Enter separately
+# Step 3: wait briefly, then send Enter separately
 sleep 1
 tmux send-keys -t <pane> Enter
 ```
 
 This applies to all manual `tmux send-keys` invocations from the orchestrator.
-The `task dispatch` command uses `nudge_pane()` internally — see issue #1834
-for the code-level fix tracking.
+The `task dispatch` command uses `nudge_pane()` internally — see issues #1834
+(paste bracketing) and #2352 (escape-before-send).
 
 ## Gotchas
 

--- a/.claude/skills/park/SKILL.md
+++ b/.claude/skills/park/SKILL.md
@@ -87,15 +87,24 @@ decide when to clear context. The park skill's job is process + cron cleanup.
 The orchestrator can park a lane by sending this to its tmux pane:
 
 ```bash
-tmux send-keys -t <pane> '/park' Enter
+tmux send-keys -t <pane> Escape; sleep 0.1
+tmux send-keys -t <pane> '/park'
+sleep 1
+tmux send-keys -t <pane> Enter
 ```
 
 Or for a full shutdown sequence:
 
 ```bash
-tmux send-keys -t <pane> '/park' Enter
+tmux send-keys -t <pane> Escape; sleep 0.1
+tmux send-keys -t <pane> '/park'
+sleep 1
+tmux send-keys -t <pane> Enter
 # Wait for confirmation, then:
-tmux send-keys -t <pane> '/clear' Enter
+tmux send-keys -t <pane> Escape; sleep 0.1
+tmux send-keys -t <pane> '/clear'
+sleep 1
+tmux send-keys -t <pane> Enter
 ```
 
 ## Gotchas

--- a/.claude/skills/run-fleet/SKILL.md
+++ b/.claude/skills/run-fleet/SKILL.md
@@ -169,18 +169,21 @@ multi-line string (or any text that triggers paste detection), `Enter` appended
 in the same call is consumed inside the paste bracket — the text is pasted but
 **never submitted**.
 
-**Two-step pattern (required for reliable pane delivery):**
+**Three-step pattern (required for reliable pane delivery):**
 ```bash
-# Step 1: send the text (do NOT append Enter)
+# Step 1: send Escape to cancel any in-progress input (#2352)
+tmux send-keys -t <pane> Escape
+sleep 0.1
+# Step 2: send the text (do NOT append Enter)
 tmux send-keys -t <pane> 'message text'
-# Step 2: wait briefly, then send Enter separately
+# Step 3: wait briefly, then send Enter separately
 sleep 1
 tmux send-keys -t <pane> Enter
 ```
 
 This affects all manual `tmux send-keys` calls from the orchestrator, including
 analyst lane dispatch, `/park` and `/clear` commands, and any ad-hoc nudges.
-See issue #1834 for evidence and code-level fix tracking.
+See issues #1834 (paste bracketing) and #2352 (escape-before-send).
 
 ## Lane Discipline
 
@@ -316,12 +319,14 @@ orphaned cron jobs. `/clear` alone does **not** stop cron jobs — always
 
 1. **Park central lanes** — ops and review run persistent monitoring crons
    that must be stopped before the orchestrator exits.
-   Use the two-step pattern (see *Tmux Paste Bracketing Caveat* above):
+   Use the three-step pattern (see *Tmux Paste Bracketing Caveat* above):
    ```bash
+   tmux send-keys -t steward:ops Escape; sleep 0.1
    tmux send-keys -t steward:ops '/park'
    sleep 1
    tmux send-keys -t steward:ops Enter
    # Wait for "0 cron jobs" confirmation
+   tmux send-keys -t steward:review Escape; sleep 0.1
    tmux send-keys -t steward:review '/park'
    sleep 1
    tmux send-keys -t steward:review Enter
@@ -331,6 +336,7 @@ orphaned cron jobs. `/clear` alone does **not** stop cron jobs — always
 2. **Park idle author lanes** — any author lane with an active session but
    no dispatched work:
    ```bash
+   tmux send-keys -t steward:author-a Escape; sleep 0.1
    tmux send-keys -t steward:author-a '/park'
    sleep 1
    tmux send-keys -t steward:author-a Enter

--- a/.claude/skills/start-task/SKILL.md
+++ b/.claude/skills/start-task/SKILL.md
@@ -186,22 +186,27 @@ consumed inside the paste bracket and the command is **pasted but never
 submitted** — the lane appears stuck with text in the input buffer.
 
 **If you are manually nudging a lane** (e.g., dispatching to an analyst lane
-that is not in `KNOWN_AUTHOR_LANES`), always use the two-step pattern:
+that is not in `KNOWN_AUTHOR_LANES`), always use the three-step pattern:
 
 ```bash
-# Step 1: send the command text (do NOT append Enter)
+# Step 1: send Escape to cancel any in-progress input (#2352)
+tmux send-keys -t <pane> Escape
+sleep 0.1
+# Step 2: send the command text (do NOT append Enter)
 tmux send-keys -t <pane> '/start-task <packet_id>'
-# Step 2: wait briefly, then send Enter separately
+# Step 3: wait briefly, then send Enter separately
 sleep 1
 tmux send-keys -t <pane> Enter
 ```
 
-**Symptom of the bug:** The target pane shows `❯ [Pasted text ...]` but
-reports 0 tokens processed — the text was never submitted. Sending `Enter`
-separately resolves it.
+**Symptom of missing Escape:** Injected text corrupts whatever the lane is
+currently typing, producing garbled input.
 
-See issue #1834 for root cause analysis and code-level fix tracking in
-`nudge_pane()` / `clear_session()`.
+**Symptom of missing Enter delay:** The target pane shows `❯ [Pasted text ...]`
+but reports 0 tokens processed — the text was never submitted.
+
+See issue #1834 (paste bracketing) and #2352 (escape-before-send) for details.
+Both patterns are handled automatically by `nudge_pane()` / `clear_session()`.
 
 ## Auto-Completion on Merge
 

--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -77,6 +77,11 @@ POOL_STATUSES: frozenset[str] = frozenset({"active", "idle", "parked", "retired"
 #: bracket before Enter arrives.  See issue #1834.
 _PASTE_BRACKET_DELAY: float = 0.1
 
+#: Delay (seconds) after sending Escape before injecting the command text.
+#: Escape cancels any in-progress input the lane might have, preventing
+#: injected messages from corrupting the current input buffer.  See #2352.
+_ESCAPE_CANCEL_DELAY: float = 0.1
+
 #: Default domain assignment for each managed lane.
 #: Lanes with ``None`` are "flex" — available to any domain when same-domain
 #: lanes are exhausted.
@@ -1331,6 +1336,14 @@ def clear_session(
     target = _resolve_tmux_target(lane_id, tmux_session, runtime_dir)
 
     try:
+        # Send Escape first to cancel any in-progress input.  See #2352.
+        subprocess.run(
+            ["tmux", "send-keys", "-t", target, "Escape"],
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
+        time.sleep(_ESCAPE_CANCEL_DELAY)
         subprocess.run(
             ["tmux", "send-keys", "-t", target, "/clear"],
             check=True,
@@ -1401,6 +1414,14 @@ def nudge_pane(
     cmd = f"/start-task {packet_id}"
 
     try:
+        # Send Escape first to cancel any in-progress input.  See #2352.
+        subprocess.run(
+            ["tmux", "send-keys", "-t", target, "Escape"],
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
+        time.sleep(_ESCAPE_CANCEL_DELAY)
         subprocess.run(
             ["tmux", "send-keys", "-t", target, cmd],
             check=True,

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -11,6 +11,7 @@ import pytest
 
 from bid_euchre.ops.worker_pool import (
     _CLEANUP_PROCESS_PATTERNS,
+    _ESCAPE_CANCEL_DELAY,
     _PASTE_BRACKET_DELAY,
     DEFAULT_TMUX_SESSION,
     IDLE_PARK_MINUTES,
@@ -1901,7 +1902,13 @@ class TestNudgePane:
         assert result.error is None
         assert "/start-task pkt123" in result.reason
         assert "steward:author-a" in result.reason
-        assert mock_run.call_count == 2
+        assert mock_run.call_count == 3
+        mock_run.assert_any_call(
+            ["tmux", "send-keys", "-t", "steward:author-a", "Escape"],
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
         mock_run.assert_any_call(
             ["tmux", "send-keys", "-t", "steward:author-a", "/start-task pkt123"],
             check=True,
@@ -1914,8 +1921,10 @@ class TestNudgePane:
             capture_output=True,
             timeout=5,
         )
-        # Verify paste-bracket delay between text and Enter (#1834)
-        mock_sleep.assert_called_once_with(_PASTE_BRACKET_DELAY)
+        # Verify escape-cancel delay (#2352) + paste-bracket delay (#1834)
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_any_call(_ESCAPE_CANCEL_DELAY)
+        mock_sleep.assert_any_call(_PASTE_BRACKET_DELAY)
 
     @patch(f"{_WORKER_POOL}._resolve_tmux_target", return_value="custom:author-b")
     @patch(f"{_WORKER_POOL}.time.sleep")
@@ -1926,7 +1935,13 @@ class TestNudgePane:
         mock_run.return_value = MagicMock(returncode=0)
         result = nudge_pane("author-b", "pkt456", tmux_session="custom")
         assert result.executed is True
-        assert mock_run.call_count == 2
+        assert mock_run.call_count == 3
+        mock_run.assert_any_call(
+            ["tmux", "send-keys", "-t", "custom:author-b", "Escape"],
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
         mock_run.assert_any_call(
             ["tmux", "send-keys", "-t", "custom:author-b", "/start-task pkt456"],
             check=True,
@@ -1939,7 +1954,9 @@ class TestNudgePane:
             capture_output=True,
             timeout=5,
         )
-        mock_sleep.assert_called_once_with(_PASTE_BRACKET_DELAY)
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_any_call(_ESCAPE_CANCEL_DELAY)
+        mock_sleep.assert_any_call(_PASTE_BRACKET_DELAY)
 
     @patch(f"{_WORKER_POOL}._resolve_tmux_target", return_value="steward:author-a")
     @patch(f"{_WORKER_POOL}.subprocess.run")
@@ -1991,10 +2008,9 @@ class TestNudgePane:
             result = nudge_pane("author-a", "pkt789", runtime_dir=tmp_path)
             assert result.executed is True
             assert "steward:platform.1" in result.reason
-            first_call = mock_run.call_args_list[0][0][0]
-            second_call = mock_run.call_args_list[1][0][0]
-            assert first_call[3] == "steward:platform.1"
-            assert second_call[3] == "steward:platform.1"
+            # All 3 calls (Escape, text, Enter) target the same pane
+            for call in mock_run.call_args_list:
+                assert call[0][0][3] == "steward:platform.1"
 
     def test_nudge_uses_default_runtime_registry(
         self,
@@ -2021,12 +2037,13 @@ class TestPasteBracketDelay:
 
     @patch(f"{_WORKER_POOL}._resolve_tmux_target", return_value="steward:author-a")
     def test_nudge_call_order(self, mock_resolve: MagicMock) -> None:
-        """nudge_pane sends text, sleeps, then sends Enter — in that order."""
+        """nudge_pane sends Escape, sleeps, text, sleeps, Enter — in that order."""
         call_log: list[str] = []
 
         def track_run(cmd: list[str], **_kw: object) -> MagicMock:
-            # Record whether we're sending text or Enter
-            if cmd[-1] == "Enter":
+            if cmd[-1] == "Escape":
+                call_log.append("escape")
+            elif cmd[-1] == "Enter":
                 call_log.append("enter")
             else:
                 call_log.append("text")
@@ -2042,15 +2059,23 @@ class TestPasteBracketDelay:
             result = nudge_pane("author-a", "pkt123")
             assert result.executed is True
 
-        assert call_log == ["text", f"sleep({_PASTE_BRACKET_DELAY})", "enter"]
+        assert call_log == [
+            "escape",
+            f"sleep({_ESCAPE_CANCEL_DELAY})",
+            "text",
+            f"sleep({_PASTE_BRACKET_DELAY})",
+            "enter",
+        ]
 
     @patch(f"{_WORKER_POOL}._resolve_tmux_target", return_value="steward:author-a")
     def test_clear_session_call_order(self, mock_resolve: MagicMock) -> None:
-        """clear_session sends /clear, sleeps, then sends Enter — in that order."""
+        """clear_session sends Escape, sleeps, /clear, sleeps, Enter — in order."""
         call_log: list[str] = []
 
         def track_run(cmd: list[str], **_kw: object) -> MagicMock:
-            if cmd[-1] == "Enter":
+            if cmd[-1] == "Escape":
+                call_log.append("escape")
+            elif cmd[-1] == "Enter":
                 call_log.append("enter")
             else:
                 call_log.append("text")
@@ -2066,7 +2091,13 @@ class TestPasteBracketDelay:
             result = clear_session("author-a")
             assert result.executed is True
 
-        assert call_log == ["text", f"sleep({_PASTE_BRACKET_DELAY})", "enter"]
+        assert call_log == [
+            "escape",
+            f"sleep({_ESCAPE_CANCEL_DELAY})",
+            "text",
+            f"sleep({_PASTE_BRACKET_DELAY})",
+            "enter",
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -2414,7 +2445,13 @@ class TestClearSession:
         assert result.action == "clear_session"
         assert result.error is None
         assert "/clear" in result.reason
-        assert mock_run.call_count == 2
+        assert mock_run.call_count == 3
+        mock_run.assert_any_call(
+            ["tmux", "send-keys", "-t", "steward:author-a", "Escape"],
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
         mock_run.assert_any_call(
             ["tmux", "send-keys", "-t", "steward:author-a", "/clear"],
             check=True,
@@ -2427,8 +2464,10 @@ class TestClearSession:
             capture_output=True,
             timeout=5,
         )
-        # Verify paste-bracket delay between text and Enter (#1834)
-        mock_sleep.assert_called_once_with(_PASTE_BRACKET_DELAY)
+        # Verify escape-cancel delay (#2352) + paste-bracket delay (#1834)
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_any_call(_ESCAPE_CANCEL_DELAY)
+        mock_sleep.assert_any_call(_PASTE_BRACKET_DELAY)
 
     @patch(f"{_WORKER_POOL}._resolve_tmux_target", return_value="custom:author-b")
     @patch(f"{_WORKER_POOL}.time.sleep")
@@ -2439,11 +2478,13 @@ class TestClearSession:
         mock_run.return_value = MagicMock(returncode=0)
         result = clear_session("author-b", tmux_session="custom")
         assert result.executed is True
-        first_call = mock_run.call_args_list[0][0][0]
-        second_call = mock_run.call_args_list[1][0][0]
-        assert first_call[3] == "custom:author-b"
-        assert second_call[3] == "custom:author-b"
-        mock_sleep.assert_called_once_with(_PASTE_BRACKET_DELAY)
+        # All 3 calls (Escape, /clear, Enter) target the custom session
+        assert mock_run.call_count == 3
+        for call in mock_run.call_args_list:
+            assert call[0][0][3] == "custom:author-b"
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_any_call(_ESCAPE_CANCEL_DELAY)
+        mock_sleep.assert_any_call(_PASTE_BRACKET_DELAY)
 
     @patch(f"{_WORKER_POOL}._resolve_tmux_target", return_value="steward:author-a")
     @patch(f"{_WORKER_POOL}.subprocess.run")


### PR DESCRIPTION
## Plan
N/A — single bounded fix from issue #2352.

## Summary
- Send `Escape` keystroke before injecting commands via `tmux send-keys` in `nudge_pane()` and `clear_session()`
- Add `_ESCAPE_CANCEL_DELAY` constant (0.1s) between Escape and command text
- Update skill docs (start-task, delegate-task, run-fleet, park) to document the three-step pattern

## Why
When a lane has in-progress input (e.g., the user or agent is mid-typing), injected
messages via `tmux send-keys` corrupt the current input buffer. Sending Escape first
cancels any partial input, ensuring the injected command arrives on a clean line.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_worker_pool.py -k "nudge or clear_session" -v
```

**Config (if applicable):** N/A

**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** `test_nudge_call_order` and `test_clear_session_call_order` verify the sequence: `escape → sleep(0.1) → text → sleep(0.1) → enter`
- **Verification command:** `uv run python -m pytest tests/unit/test_ops_worker_pool.py -k "call_order" -v`
- **Expected result:** Both tests pass, confirming Escape is sent before command text

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_worker_pool.py -k "nudge or clear_session"` — 23 passed
- [x] `uv run python -m pytest tests/unit/test_ops_adapter_migration.py -k "nudge"` — 3 passed
- [x] `make check-gated` — all pre-existing failures only (sim-browser parity, cpu_gate, token_economy, telegram_filter); zero failures in worker_pool tests

## Expected impact
- Metrics impact: None
- Runtime impact: +0.1s per tmux command injection (Escape + delay)

## Risk level
- [x] Low (ops infrastructure only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-d
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-d  0c8e47ce [fix/escape-before-send]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Issue Linkage
Refs #2352

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
- [x] Issue linkage uses correct keyword (`Fixes` vs `Refs`) per closure policy