### PR TITLE
fix(web): color player names by team and remove duplicate name/count lines (#2346)

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -1028,8 +1028,9 @@ class TestScore:
         )
         assert "Dealer:" in html
         assert "Ace" in html
-        # AI dealer name wrapped in .ai-name span (#2288.4)
-        assert 'class="ai-name"' in html
+        # AI dealer name with team color class (#2288.4, #2346)
+        # Seat 2 is partner (human team)
+        assert "player-name--human" in html
 
     def test_no_contract_info_in_score_bar(self, env):
         """Contract info removed from score bar (shown in contract bar instead)."""
@@ -2997,12 +2998,12 @@ class TestGameTemplateAccessibility:
             winning_bid=None,
             bidder_seat=None,
         )
-        assert 'class="ai-card-count" aria-hidden="true"' not in html
-        # AI names now wrapped in ai-name spans (#2288.4)
-        assert 'class="ai-name">Slim</span>' in html
-        assert "(10)" in html  # card count still present
-        assert 'class="ai-name">Ace</span>' in html
-        assert 'class="ai-name">Deuce</span>' in html
+        # Duplicate card-count lines removed; names shown once with team colors (#2346)
+        assert "ai-card-count" not in html
+        # AI names with team-color classes (#2346)
+        assert 'player-name--ai">Slim</span>' in html
+        assert 'player-name--human">Ace</span>' in html
+        assert 'player-name--ai">Deuce</span>' in html
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -489,10 +489,8 @@ class TestNextRevealFlow:
         # D♦ / A would appear as card rank+suit in the trick area
         assert "card--played" not in resp.text
 
-        # Slim (seat 1) hand count should show 10 (pre-play), not 9
-        # AI names wrapped in .ai-name span (#2288.4)
-        assert 'class="ai-name">Slim</span>' in resp.text
-        assert "(10)" in resp.text
+        # Slim (seat 1) should appear with team color class (#2346)
+        assert 'player-name--ai">Slim</span>' in resp.text
 
         # No "Play card" button — still in auction reveal
         assert 'id="card-play-form"' not in resp.text

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -379,12 +379,8 @@ main {
     margin: 0 -4px;
 }
 
-.ai-card-count {
-    font-size: 0.8rem;
-    color: var(--color-text-muted);
-    text-align: center;
-    display: block;
-}
+/* .ai-card-count removed — duplicate name + card count below hands
+   eliminated in #2346.  Responsive overrides kept as no-ops for safety. */
 
 /* Legacy horizontal row (kept for non-compass contexts) */
 .ai-hands-row {
@@ -414,9 +410,18 @@ main {
     min-height: 1.4em;
 }
 
-/* AI player names — blue to distinguish from human player (#2288.4) */
+/* AI player names — default to AI team color for non-compass contexts */
 .ai-name {
-    color: #64b5f6;
+    color: var(--team-ai);
+}
+
+/* Team-colored player names — used on compass seats for team distinction (#2346) */
+.player-name--human {
+    color: var(--team-human);
+}
+
+.player-name--ai {
+    color: var(--team-ai);
 }
 
 .ai-hand-block--middle {

--- a/web/templates/partials/game_board.html
+++ b/web/templates/partials/game_board.html
@@ -63,7 +63,7 @@
         <div class="compass-top" role="region" aria-label="{{ seat_labels[2] }} hand">
             <div class="ai-hand-block">
                 <div class="ai-seat-label">
-                    <span class="ai-name">{{ seat_labels[2] }}</span>
+                    <span class="ai-name player-name--human">{{ seat_labels[2] }}</span>
                     {# Phase-dependent word labels — one badge max per seat #}
                     {% if phase == "auction" and dealer_seat == 2 %}
                         <span class="seat-marker seat-marker--dealer" title="Dealer">Dealer</span>
@@ -79,7 +79,6 @@
                     <div class="card-back" aria-hidden="true"></div>
                     {% endfor %}
                 </div>
-                <span class="ai-card-count"><span class="ai-name">{{ seat_labels[2] }}</span> ({{ partner_count | default(0) }})</span>
             </div>
         </div>
 
@@ -87,7 +86,7 @@
         <div class="compass-left" role="region" aria-label="{{ seat_labels[1] }} hand">
             <div class="ai-hand-block ai-hand-block--vertical">
                 <div class="ai-seat-label">
-                    <span class="ai-name">{{ seat_labels[1] }}</span>
+                    <span class="ai-name player-name--ai">{{ seat_labels[1] }}</span>
                     {% if phase == "auction" and dealer_seat == 1 %}
                         <span class="seat-marker seat-marker--dealer" title="Dealer">Dealer</span>
                     {% elif phase == "trick_play" and trick_leader == 1 %}
@@ -102,7 +101,6 @@
                     <div class="card-back" aria-hidden="true"></div>
                     {% endfor %}
                 </div>
-                <span class="ai-card-count"><span class="ai-name">{{ seat_labels[1] }}</span> ({{ opp_left_count | default(0) }})</span>
             </div>
         </div>
 
@@ -139,7 +137,7 @@
         <div class="compass-right" role="region" aria-label="{{ seat_labels[3] }} hand">
             <div class="ai-hand-block ai-hand-block--vertical">
                 <div class="ai-seat-label">
-                    <span class="ai-name">{{ seat_labels[3] }}</span>
+                    <span class="ai-name player-name--ai">{{ seat_labels[3] }}</span>
                     {% if phase == "auction" and dealer_seat == 3 %}
                         <span class="seat-marker seat-marker--dealer" title="Dealer">Dealer</span>
                     {% elif phase == "trick_play" and trick_leader == 3 %}
@@ -154,7 +152,6 @@
                     <div class="card-back" aria-hidden="true"></div>
                     {% endfor %}
                 </div>
-                <span class="ai-card-count"><span class="ai-name">{{ seat_labels[3] }}</span> ({{ opp_right_count | default(0) }})</span>
             </div>
         </div>
 
@@ -162,12 +159,12 @@
         <div class="compass-bottom">
             {% if phase == "auction" and dealer_seat == 0 %}
                 <div class="human-seat-label" role="status" aria-label="You are the dealer">
-                    You
+                    <span class="player-name--human">You</span>
                     <span class="seat-marker seat-marker--dealer" title="Dealer">Dealer</span>
                 </div>
             {% elif phase == "trick_play" and trick_leader == 0 %}
                 <div class="human-seat-label" role="status" aria-label="You lead this trick">
-                    You
+                    <span class="player-name--human">You</span>
                     <span class="seat-marker seat-marker--leader" title="Leader">Leader</span>
                 </div>
             {% endif %}

--- a/web/templates/partials/score.html
+++ b/web/templates/partials/score.html
@@ -30,7 +30,7 @@
         <div class="hand-details__content">
             <span>Hand {{ hands_played + 1 }}</span>
             <span class="info-separator" aria-hidden="true">&middot;</span>
-            <span>Dealer: {% if dealer_seat != 0 %}<span class="ai-name">{{ seat_labels.get(dealer_seat, "Seat " ~ dealer_seat) }}</span>{% else %}{{ seat_labels.get(dealer_seat, "Seat " ~ dealer_seat) }}{% endif %}</span>
+            <span>Dealer: {% if dealer_seat != 0 %}<span class="ai-name player-name--{{ 'human' if dealer_seat == 2 else 'ai' }}">{{ seat_labels.get(dealer_seat, "Seat " ~ dealer_seat) }}</span>{% else %}<span class="player-name--human">{{ seat_labels.get(dealer_seat, "Seat " ~ dealer_seat) }}</span>{% endif %}</span>
             <span class="info-separator" aria-hidden="true">&middot;</span>
             <span>First to 52 wins &middot; &minus;52 = loss</span>
         </div>

--- a/web/templates/partials/trick.html
+++ b/web/templates/partials/trick.html
@@ -70,7 +70,7 @@
     {% else %}
         <div class="{{ fallback_class }}" aria-label="{{ seat_labels[seat] }} waiting to play">
             {% if show_label %}
-                <span class="seat-label">{% if seat != 0 %}<span class="ai-name">{{ seat_labels[seat] }}</span>{% else %}{{ seat_labels[seat] }}{% endif %}</span>
+                <span class="seat-label">{% if seat != 0 %}<span class="ai-name player-name--{{ 'human' if seat == 2 else 'ai' }}">{{ seat_labels[seat] }}</span>{% else %}<span class="player-name--human">{{ seat_labels[seat] }}</span>{% endif %}</span>
             {% endif %}
         </div>
     {% endif %}
@@ -125,7 +125,7 @@
     </div>
     {% if current_trick and trick_winning_seat is defined and trick_winning_seat is not none %}
         <p class="trick-current-winner" aria-live="polite">
-            {% if trick_winning_seat == 0 %}You are{% else %}<span class="ai-name">{{ seat_labels[trick_winning_seat] }}</span> is{% endif %} currently winning the trick
+            {% if trick_winning_seat == 0 %}<span class="player-name--human">You</span> are{% else %}<span class="ai-name player-name--{{ 'human' if trick_winning_seat == 2 else 'ai' }}">{{ seat_labels[trick_winning_seat] }}</span> is{% endif %} currently winning the trick
         </p>
     {% endif %}
     {% if display_winner is not none %}
@@ -138,9 +138,9 @@
         {% endif %}
         <p class="trick-winner" aria-live="polite">
             {% if display_winner == 0 %}
-                You
+                <span class="player-name--human">You</span>
             {% else %}
-                <span class="ai-name">{{ seat_labels[display_winner] if display_winner in seat_labels else ("Seat " ~ display_winner) }}</span>
+                <span class="ai-name player-name--{{ 'human' if display_winner == 2 else 'ai' }}">{{ seat_labels[display_winner] if display_winner in seat_labels else ("Seat " ~ display_winner) }}</span>
             {% endif %}
             won{% if winning_card %} with
                 {% set wc_suit = winning_card[0] %}

--- a/web/templates/partials/trick_history.html
+++ b/web/templates/partials/trick_history.html
@@ -18,10 +18,10 @@
             <thead>
                 <tr>
                     <th class="trick-history__th">#</th>
-                    <th class="trick-history__th">You</th>
-                    <th class="trick-history__th"><span class="ai-name">{{ seat_labels[1] }}</span></th>
-                    <th class="trick-history__th"><span class="ai-name">{{ seat_labels[2] }}</span></th>
-                    <th class="trick-history__th"><span class="ai-name">{{ seat_labels[3] }}</span></th>
+                    <th class="trick-history__th"><span class="player-name--human">You</span></th>
+                    <th class="trick-history__th"><span class="ai-name player-name--ai">{{ seat_labels[1] }}</span></th>
+                    <th class="trick-history__th"><span class="ai-name player-name--human">{{ seat_labels[2] }}</span></th>
+                    <th class="trick-history__th"><span class="ai-name player-name--ai">{{ seat_labels[3] }}</span></th>
                     <th class="trick-history__th">Won</th>
                 </tr>
             </thead>
@@ -46,7 +46,7 @@
                             </td>
                         {% endfor %}
                         <td class="trick-history__cell trick-history__cell--won">
-                            {% if trick.winner != 0 %}<span class="ai-name">{{ seat_labels.get(trick.winner, "?") }}</span>{% else %}{{ seat_labels.get(trick.winner, "?") }}{% endif %}
+                            {% if trick.winner != 0 %}<span class="ai-name player-name--{{ 'human' if trick.winner == 2 else 'ai' }}">{{ seat_labels.get(trick.winner, "?") }}</span>{% else %}<span class="player-name--human">{{ seat_labels.get(trick.winner, "?") }}</span>{% endif %}
                         </td>
                     </tr>
                 {% endfor %}


### PR DESCRIPTION
## Summary
- Player names around the game board now use team colors: green (`--team-human`) for You/partner (seats 0,2), blue (`--team-ai`) for opponents (seats 1,3)
- Removed duplicate `ai-card-count` spans that showed player names + card counts below each AI hand
- Extended team coloring to trick area, trick history, and score bar for visual consistency

## Why
Player names were all a single blue color with no team distinction, and names appeared redundantly both above and below AI hands with unnecessary card counts. Refs #2346.

## Changes
| File | Change |
|------|--------|
| `web/templates/partials/game_board.html` | Add `player-name--human`/`player-name--ai` classes to compass seat names; remove `ai-card-count` spans |
| `web/templates/partials/trick.html` | Add team-color classes to seat labels and winner displays |
| `web/templates/partials/trick_history.html` | Add team-color classes to column headers and winner column |
| `web/templates/partials/score.html` | Add team-color class to dealer name in hand details |
| `web/static/style.css` | Add `.player-name--human`/`.player-name--ai` classes using existing CSS variables; update `.ai-name` default |
| `tests/unit/hosted_play/test_partials.py` | Update assertions for new class names and removed card-count elements |
| `tests/unit/hosted_play/test_routes.py` | Update assertion for new team-color class |

## Repro / Validation
```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/hosted_play/test_partials.py -q  # 236 passed
uv run python -m pytest tests/unit/hosted_play/test_routes.py -q   # 117 passed, 2 skipped

# Tier 2 — full validation
make check-gated  # Only pre-existing failures (sim_browser_parity)
```

## Tests
- `tests/unit/hosted_play/test_partials.py` — 236 passed
- `tests/unit/hosted_play/test_routes.py` — 117 passed, 2 skipped

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
branch: fix/player-name-styling
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)