### PR TITLE
fix: convention follow-ups (#2365, #2358, #2355)

### DIFF
--- a/plans/sessions/2026-04-04_session_audit.md
+++ b/plans/sessions/2026-04-04_session_audit.md
@@ -272,7 +272,7 @@ used consistently, and manual closure was forgotten in the rush of a
 ### L3: Proving Run Gaps
 
 **Problem:** Multiple feature PRs shipped without user-facing proving runs.
-The session merged 8 web features and 6 web fixes, but no manual browser
+The session merged 7 web features and 5 web fixes, but no manual browser
 testing was performed during this session.
 
 **Evidence:**

--- a/scripts/internal/cpu_gate.sh
+++ b/scripts/internal/cpu_gate.sh
@@ -36,6 +36,11 @@ get_ncpu() {
 }
 
 get_load_1m() {
+    # Allow tests to inject a deterministic load value via env var.
+    if [[ -n "${CPU_GATE_LOAD_OVERRIDE:-}" ]]; then
+        echo "$CPU_GATE_LOAD_OVERRIDE"
+        return
+    fi
     if [[ "$(uname)" == "Darwin" ]]; then
         sysctl -n vm.loadavg 2>/dev/null | awk '{print $2}'
     elif [[ -f /proc/loadavg ]]; then

--- a/tests/unit/hosted_play/test_app.py
+++ b/tests/unit/hosted_play/test_app.py
@@ -283,9 +283,12 @@ def _create_legacy_db(db_path) -> str:
                 "CREATE TABLE IF NOT EXISTS invite_codes ("
                 "  id INTEGER PRIMARY KEY,"
                 "  code VARCHAR NOT NULL UNIQUE,"
-                "  status VARCHAR NOT NULL DEFAULT 'active',"
+                "  status VARCHAR NOT NULL DEFAULT 'active'"
+                "    CHECK (status IN ('active', 'redeemed', 'revoked')),"
+                "  player_id INTEGER REFERENCES players(id) ON DELETE SET NULL,"
                 "  label VARCHAR,"
-                "  created_at DATETIME NOT NULL DEFAULT (datetime('now'))"
+                "  created_at DATETIME NOT NULL DEFAULT (datetime('now')),"
+                "  redeemed_at DATETIME"
                 ")"
             )
         )

--- a/tests/unit/test_cpu_gate.py
+++ b/tests/unit/test_cpu_gate.py
@@ -148,11 +148,16 @@ class TestCpuGateLoadAwareness:
     """Test CPU load threshold behavior."""
 
     def test_waits_when_load_exceeds_threshold(self) -> None:
-        """Gate should announce waiting when load threshold is very low."""
+        """Gate should announce waiting when load threshold is exceeded.
+
+        Uses CPU_GATE_LOAD_OVERRIDE to inject a deterministic load value,
+        making the test independent of actual host load.
+        """
         result = _run_gate(
             ["echo", "done"],
             env_overrides={
-                "CPU_GATE_MAX_LOAD": "0.01",  # Impossibly low
+                "CPU_GATE_LOAD_OVERRIDE": "50.0",  # Injected fake load
+                "CPU_GATE_MAX_LOAD": "1.0",  # Threshold well below fake load
                 "CPU_GATE_MAX_WAIT": "3",
                 "CPU_GATE_POLL_BASE": "1",
             },
@@ -164,10 +169,17 @@ class TestCpuGateLoadAwareness:
         assert "done" in result.stdout
 
     def test_proceeds_immediately_when_load_is_low(self) -> None:
-        """Gate should not wait when threshold is very high."""
+        """Gate should not wait when load is below threshold.
+
+        Uses CPU_GATE_LOAD_OVERRIDE to inject a deterministic load value,
+        making the test independent of actual host load.
+        """
         result = _run_gate(
             ["echo", "fast"],
-            env_overrides={"CPU_GATE_MAX_LOAD": "999.0"},
+            env_overrides={
+                "CPU_GATE_LOAD_OVERRIDE": "0.5",  # Injected low load
+                "CPU_GATE_MAX_LOAD": "999.0",
+            },
         )
         assert result.returncode == 0
         assert "fast" in result.stdout


### PR DESCRIPTION
## Summary

- Mirror full `invite_codes` schema (`player_id`, `redeemed_at`, CHECK constraint) in legacy DB test helper (#2365)
- Add `CPU_GATE_LOAD_OVERRIDE` env var to `cpu_gate.sh` so load-awareness tests are deterministic regardless of host load (#2358)
- Correct L3 proving-run lesson PR totals (8→7 web features, 6→5 web fixes) in session audit (#2355)

## Why

Convention follow-ups from the review coordinator for PRs #2360, #2357, and #2354.

## Changes

**`tests/unit/hosted_play/test_app.py`** — The `_create_legacy_db()` helper now
mirrors the production `invite_codes` schema from `web/schema.sql`, adding the
`player_id` foreign key, `redeemed_at` timestamp, and status CHECK constraint
that were previously missing.

**`scripts/internal/cpu_gate.sh`** — Added `CPU_GATE_LOAD_OVERRIDE` env var to
`get_load_1m()`. When set, the function returns this value instead of reading
the actual system load average. This is a test-only seam — production callers
never set it.

**`tests/unit/test_cpu_gate.py`** — Updated `test_waits_when_load_exceeds_threshold`
and `test_proceeds_immediately_when_load_is_low` to use `CPU_GATE_LOAD_OVERRIDE`
with deterministic fake load values (50.0 and 0.5 respectively), making both
tests independent of actual host CPU load.

**`plans/sessions/2026-04-04_session_audit.md`** — Fixed L3 lesson text from
"8 web features and 6 web fixes" to "7 web features and 5 web fixes" to match
the corrected category summary (fixed in PR #2354).

## Repro / Validation

```bash
# Tier 1 — affected tests (32 pass)
uv run python -m pytest tests/unit/test_cpu_gate.py tests/unit/hosted_play/test_app.py -v

# CPU gate load override specifically
CPU_GATE_LOAD_OVERRIDE=99.0 bash scripts/internal/cpu_gate.sh --status
# Should show load 1m: 99.0
```

## Tests

- `uv run python -m pytest tests/unit/test_cpu_gate.py` — 10 passed
- `uv run python -m pytest tests/unit/hosted_play/test_app.py` — 22 passed
- `make check-gated` — pre-existing failures in `test_sim_browser_parity` only (not related to this PR)

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
branch: fix/convention-batch-overnight
```

**Note:** `test_sim_browser_parity` failures are pre-existing on main — verified
by running the same test on `origin/main` directly.

Refs #2365, Refs #2358, Refs #2355

🤖 Generated with [Claude Code](https://claude.com/claude-code)