### PR TITLE
feat(ops): auto-start fleet-check cron on orchestrator boot (#2333)

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -60,6 +60,22 @@ Then restart your Claude session in that directory.
      cd ../Bid-Euchre-<branch-name>
 ```
 
+### `fleet-check-autostart.sh` (SessionStart)
+
+**Trigger:** When any Claude session starts (init, clear, compact)
+
+**Purpose:** Auto-starts the fleet-check durable cron on the orchestrator lane
+
+**Behavior:**
+1. Checks if the current lane is the orchestrator (via `CLAUDE_AGENT_NAME`
+   or project directory fallback)
+2. If not orchestrator: exits silently (no output, no cost)
+3. If orchestrator: outputs a directive instructing the agent to verify and
+   start the `/loop 8m /fleet-check` cron with dedup (check CronList first)
+4. Always exits 0 (never blocks session start)
+
+**Refs:** #2333
+
 ### `post-pr-review.sh` (PostToolUse)
 
 **Trigger:** After any Bash tool call
@@ -219,6 +235,7 @@ Hooks are registered across two files:
 **`.claude/settings.json`** (committed, shared):
 - `SessionStart` (compact) → `compact-context.sh`
 - `SessionStart` (all) → `session-sync-worktree.sh` (no matcher — fires on init, clear, compact)
+- `SessionStart` (all) → `fleet-check-autostart.sh` (no matcher — auto-starts fleet-check cron on orchestrator)
 - `PreToolUse` (Edit|Write) → `rule-loader.sh`
 - `PreToolUse` (Bash) → `pre-bash-dispatch.sh` (consolidated dispatcher)
 - `PostToolUse` (Write|Edit) → `post-write-check.sh`

--- a/.claude/hooks/fleet-check-autostart.sh
+++ b/.claude/hooks/fleet-check-autostart.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# SessionStart hook: auto-start fleet-check cron on orchestrator boot.
+#
+# Fires on all session starts (init, clear, compact).  When the current lane
+# is the orchestrator, outputs a directive that the agent processes to create
+# (or verify) the fleet-check durable cron.
+#
+# Must NEVER exit non-zero — a failing SessionStart hook leaves the session
+# at a blank prompt with 0 tokens and no context.
+#
+# Refs #2333.
+
+trap 'exit 0' ERR
+
+# --------------------------------------------------------------------------
+# Guard: only act on the orchestrator lane
+# --------------------------------------------------------------------------
+# CLAUDE_AGENT_NAME is set by the --name flag (e.g., "orchestrator").
+AGENT_NAME="${CLAUDE_AGENT_NAME:-}"
+
+if [[ -z "$AGENT_NAME" ]]; then
+    # Fallback: detect from project directory name
+    PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+    DIR_NAME="$(basename "$PROJECT_DIR")"
+    # The main checkout (Bid-Euchre) is where the orchestrator runs
+    if [[ "$DIR_NAME" == "Bid-Euchre" ]]; then
+        AGENT_NAME="orchestrator"
+    fi
+fi
+
+# Only the orchestrator needs fleet-check
+if [[ "$AGENT_NAME" != "orchestrator" ]]; then
+    exit 0
+fi
+
+# --------------------------------------------------------------------------
+# Emit directive for the orchestrator agent
+# --------------------------------------------------------------------------
+cat <<'DIRECTIVE'
+FLEET-CHECK AUTO-START: The orchestrator fleet-check cron must be running.
+
+Action required:
+1. Run CronList to check for an existing fleet-check cron
+2. If a fleet-check cron already exists, no action needed
+3. If no fleet-check cron exists, run: /loop 8m /fleet-check
+
+This ensures periodic inbox polling, CPU checks, task completion detection,
+and lane health monitoring continue after /clear or session restart.
+DIRECTIVE
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -41,6 +41,15 @@
             "timeout": 15
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/fleet-check-autostart.sh",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PostToolUse": [


### PR DESCRIPTION
## Summary

- Add `fleet-check-autostart.sh` SessionStart hook that detects the orchestrator lane and injects a directive to start the fleet-check durable cron
- Register the hook in `.claude/settings.json` (no matcher — fires on init, clear, compact)
- Document the hook in `.claude/hooks/README.md`

## Why

The orchestrator currently requires manual `/loop 8m /fleet-check` after each `/clear`. The ops and review lanes both have auto-launch patterns — the orchestrator should too. This hook ensures the fleet-check cron is always running without manual intervention.

## How It Works

1. **SessionStart fires** on init, clear, and compact
2. **Lane detection**: Hook checks `CLAUDE_AGENT_NAME` (set to `"orchestrator"` by `--name` flag), with fallback to project directory name detection
3. **Non-orchestrator lanes**: Silent exit 0 (no output, no cost)
4. **Orchestrator lane**: Outputs a directive the agent processes to:
   - Check CronList for existing fleet-check crons (dedup)
   - Create `/loop 8m /fleet-check` if none exists

## Repro / Validation

```bash
# Hook produces directive for orchestrator
CLAUDE_AGENT_NAME="orchestrator" bash .claude/hooks/fleet-check-autostart.sh
# → outputs FLEET-CHECK AUTO-START directive

# Hook is silent for non-orchestrator lanes
CLAUDE_AGENT_NAME="author-d" bash .claude/hooks/fleet-check-autostart.sh
# → no output

# Directory fallback works for main checkout
CLAUDE_AGENT_NAME="" CLAUDE_PROJECT_DIR="/path/to/Bid-Euchre" bash .claude/hooks/fleet-check-autostart.sh
# → outputs directive
```

## Tests

- Bash syntax validation: `bash -n .claude/hooks/fleet-check-autostart.sh`
- JSON validation: `python3 -c "import json; json.load(open('.claude/settings.json'))"`
- Pre-commit hooks pass (repo-linter, trim whitespace)
- Note: Two pre-existing test failures unrelated to this PR exist on main:
  `test_sim_browser_parity.py` (MatchEngine empty results) and
  `test_ops_token_economy.py` (mock count mismatch)

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: ops/fleet-check-autostart
```

Refs #2333

🤖 Generated with [Claude Code](https://claude.com/claude-code)