### PR TITLE
fix(test): resolve 30 test failures across 3 test files (#2362)

### DIFF
--- a/src/bid_euchre/ops/token_economy.py
+++ b/src/bid_euchre/ops/token_economy.py
@@ -1820,8 +1820,11 @@ def _ensure_imported(output_dir: Path) -> None:
 
         result = import_usage_data(output_dir=output_dir)
 
-        # Also scan per-project JSONL telemetry (v2.1.80+ format)
-        jsonl_result = import_project_jsonl(output_dir=output_dir, force=True)
+        # Also scan per-project JSONL telemetry (v2.1.80+ format).
+        # Use force=False here — _ensure_imported manages its own
+        # attribute_sessions call below, and force=True would trigger a
+        # redundant attribution inside import_project_jsonl (#2362).
+        jsonl_result = import_project_jsonl(output_dir=output_dir, force=False)
 
         # Always attribute when attributions were missing, even if the
         # re-import found no new sessions (data may already be present).

--- a/tests/integration/test_sim_browser_parity.py
+++ b/tests/integration/test_sim_browser_parity.py
@@ -342,6 +342,9 @@ def _run_engine_hand(
                 raise AssertionError("Unexpected moon_exchange in forced-contract test")
             else:
                 break  # Unexpected phase
+        elif hand.paused_after_play:
+            # Per-card pacing pause — skip the reveal delay and continue.
+            state = engine.resume_after_play(state)
         elif hand.paused_after_trick:
             state = engine.resume_ai(state)
         else:

--- a/tests/unit/test_ops_token_economy.py
+++ b/tests/unit/test_ops_token_economy.py
@@ -1602,10 +1602,15 @@ class TestAutoImport:
         # even though no new sessions were imported
         mock_attr.assert_called_once()
 
-    def test_stale_full_import_uses_force_for_project_jsonl(
+    def test_stale_full_import_does_not_force_project_jsonl(
         self, tmp_path: Path
     ) -> None:
-        """Project JSONL import is forced so stale runs rebuild all telemetry."""
+        """Project JSONL import uses force=False to avoid double attribution.
+
+        _ensure_imported manages its own attribute_sessions call, so
+        import_project_jsonl must not use force=True which would trigger
+        a redundant internal attribution (#2362).
+        """
         import os
         from datetime import datetime, timezone
         from unittest.mock import MagicMock, patch
@@ -1653,7 +1658,7 @@ class TestAutoImport:
             _ensure_imported(output_dir)
 
         mock_import_usage.assert_called_once_with(output_dir=output_dir)
-        mock_import_project.assert_called_once_with(output_dir=output_dir, force=True)
+        mock_import_project.assert_called_once_with(output_dir=output_dir, force=False)
         mock_attr.assert_called_once_with(output_dir=output_dir)
 
 

--- a/tests/unit/test_telegram_filter.py
+++ b/tests/unit/test_telegram_filter.py
@@ -133,7 +133,10 @@ class TestIsTelegramReceiverEdgeCases:
         """No env var and no project dir → conservative: not a receiver."""
         assert is_telegram_receiver(receiver_env="", project_dir="") is False
 
-    def test_unset_env_empty_dir(self) -> None:
+    def test_unset_env_empty_dir(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When receiver_env is None (read from real env), ensure env var is
+        unset so the test is environment-independent."""
+        monkeypatch.delenv(TELEGRAM_RECEIVER_ENV, raising=False)
         assert is_telegram_receiver(receiver_env=None, project_dir="") is False
 
     def test_trailing_slash_in_project_dir(self) -> None:


### PR DESCRIPTION
## Summary

- **27 in test_sim_browser_parity.py**: Per-card pacing (#2231) added `paused_after_play` to MatchEngine but the parity test only handled `paused_after_trick`, causing the engine to break out of its play loop immediately. Added `resume_after_play` handling.
- **2 in test_ops_token_economy.py**: `_ensure_imported` called `import_project_jsonl(force=True)` which internally calls `attribute_sessions`, then called it again. Changed to `force=False` since `_ensure_imported` manages its own attribution call.
- **1 in test_telegram_filter.py**: `test_unset_env_empty_dir` passed `receiver_env=None` (read real env) but didn't monkeypatch `STEWARD_TELEGRAM_RECEIVER`, which is set to "1" on fleet machines. Added monkeypatch.

## Why

33 tests failing on main @ 5b74949e. CI runs Python 3.12 (unaffected by some), but these 30 are version-independent and fail on both 3.12 and 3.14. The remaining 3 cpu_gate failures are test-isolation-only (pass individually, intermittent in suite) and not addressed here.

## Repro / Validation

```bash
# Before fix (on main @ 5b74949e):
uv run python -m pytest tests/integration/test_sim_browser_parity.py  # 27 FAILED
uv run python -m pytest tests/unit/test_telegram_filter.py            # 1 FAILED
uv run python -m pytest tests/unit/test_ops_token_economy.py          # 2 FAILED

# After fix:
make check-quiet  # ✓ All checks passed
```

## Tests

- `make check-quiet` — all checks passed

## Worktree Proof

```
pwd: Bid-Euchre-steward-brws-author-c
branch: fix/test-failures-main
```

Refs #2362