### PR TITLE
fix: convention follow-ups batch 2 (#2353, #2344, #2341)

### DIFF
--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -465,7 +465,10 @@ tmux set-environment -t "$SESSION" CLAUDE_CODE_RESUME_INTERRUPTED_TURN "1"
 tmux set-environment -t "$SESSION" MCP_CONNECTION_NONBLOCKING "true"
 
 # Fleet stability: disable mouse capture to prevent tmux scroll interference (#2249)
-tmux set-environment -t "$SESSION" CLAUDE_CODE_DISABLE_MOUSE "1"
+# Gated behind opt-in — set STEWARD_DISABLE_MOUSE=1 to enable.  (#2341)
+if [ "${STEWARD_DISABLE_MOUSE:-0}" = "1" ]; then
+    tmux set-environment -t "$SESSION" CLAUDE_CODE_DISABLE_MOUSE "1"
+fi
 
 # Propagate channel config into the tmux session environment so all panes
 # can read it.  Shell `export` only affects the launcher process; tmux panes

--- a/docs/02_agent/ISSUE_TRIAGE_WORKFLOW.md
+++ b/docs/02_agent/ISSUE_TRIAGE_WORKFLOW.md
@@ -213,7 +213,8 @@ Once an issue passes the eligibility contract:
 
 - Title prefix: `fix(repair): <short description>`
 - Label: `follow-up`
-- Body must reference: the issue number (`Fixes #N`) and the source PR
+- Body must reference: the issue number (`Refs #N` by default; use `Fixes #N`
+  only for Tier 1 single-bounded fixes — see [Tiered Issue Closure](#tiered-issue-closure)) and the source PR
 - Scope must stay within the issue's identified subsystem
 
 ### Lane Ownership

--- a/plans/sessions/2026-04-05_go_live_checklist.md
+++ b/plans/sessions/2026-04-05_go_live_checklist.md
@@ -53,7 +53,7 @@ merge" in #2320 but need explicit proving steps.
 ### A2. Bid Selector Default (#2327)
 
 - [ ] **A2a.** Start a fresh auction. Verify the bid dropdown **defaults to
-  the minimum legal bid** (e.g., "6"), NOT "Pass"
+  the minimum legal bid** (e.g., "1" at the start of the auction), NOT "Pass"
 - [ ] **A2b.** After another player bids (e.g., 7), verify your dropdown
   **defaults to the next legal bid** (e.g., 8), not pass
 - [ ] **A2c.** When all bids up to 10 are taken, verify the dropdown defaults

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -2238,7 +2238,13 @@ main {
     }
 
     /* Auction log on mobile — collapsed by default to reclaim vertical space.
-       The summary toggle remains visible so users can expand if needed. */
+       The summary toggle remains visible so users can expand if needed.
+       order: 3 keeps it below score bar (order: 1) and compass (order: 2)
+       after the flex reorder above.  (#2353) */
+    .action-rail {
+        order: 3;
+    }
+
     .action-rail:not([open]) .action-rail__content {
         display: none;
     }


### PR DESCRIPTION
## Summary
- **Mobile auction log ordering**: Add explicit `order: 3` to `.action-rail` in mobile media query so it stays below score bar (was defaulting to `order: 0`, appearing above everything) (#2353)
- **Go-live checklist accuracy**: Correct opening bid example from `"6"` to `"1" at start of auction` — the bid panel template defaults to `current_high_bid + 1` which is 1 when no bids placed (#2344)
- **Mouse disable opt-in**: Gate `CLAUDE_CODE_DISABLE_MOUSE` behind `STEWARD_DISABLE_MOUSE` env var instead of setting unconditionally (#2341)
- **Repair guidance alignment**: Propagate `Refs #N` default to repair PR conventions section, with cross-reference to tiered closure policy (#2341)

## Why
Convention follow-ups from review coordinator findings on PRs #2348, #2343, #2339.

## Repro / Validation
```bash
# Verify mobile auction log CSS ordering
grep -A2 "order: 3" web/static/style.css
# Verify checklist correction
grep "A2a" plans/sessions/2026-04-05_go_live_checklist.md
# Verify mouse disable gating
grep -A3 "STEWARD_DISABLE_MOUSE" .claude/tmux/steward-session.sh
# Verify repair guidance
grep "Refs #N" docs/02_agent/ISSUE_TRIAGE_WORKFLOW.md
```

## Tests
```bash
make check-gated  # 11166 passed, 30 pre-existing failures (unrelated)
```
All 30 failures are pre-existing on main (sim-browser parity, ops token economy, telegram filter). This PR touches only CSS, docs, markdown, and shell — no Python code changed.

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
branch: fix/convention-batch-2-overnight
```

Refs #2353, Refs #2344, Refs #2341