### PR TITLE
fix(ci): prevent concurrency group collision on main pushes (#2363)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ on:
     branches: [ "main" ]
 
 concurrency:
-  group: ci-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.event_name == 'push' && github.sha || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # ── Change detection (PR only, ~5s) ───────────────────────────────

--- a/tests/unit/test_ci_workflow.py
+++ b/tests/unit/test_ci_workflow.py
@@ -126,6 +126,30 @@ class TestCIWorkflowStructure:
             assert "checkout" not in name.lower()
             assert "setup" not in name.lower()
 
+    def test_concurrency_group_unique_per_push(self) -> None:
+        """Push events to main must get unique concurrency groups (#2363).
+
+        If all pushes to main share a single concurrency group with
+        cancel-in-progress, each merge cancels the previous CI run and
+        CI never completes under high merge frequency.
+        """
+        concurrency = self.workflow["concurrency"]
+        group_expr = str(concurrency["group"])
+        cancel_expr = str(concurrency["cancel-in-progress"])
+
+        # The group must use github.sha (or equivalent unique value) for
+        # push events so each merge gets its own non-colliding group.
+        assert (
+            "github.sha" in group_expr
+        ), "Concurrency group must include github.sha for push-unique groups"
+
+        # cancel-in-progress must NOT be unconditionally true — push events
+        # to main must not cancel each other.
+        assert cancel_expr.lower() != "true", (
+            "cancel-in-progress must not be unconditionally true; "
+            "push events to main would cancel each other (#2363)"
+        )
+
     def test_aggregator_evaluates_all_upstream_jobs(self) -> None:
         """The gate must check every upstream job including ``changes``.
 


### PR DESCRIPTION
## Summary

- Use `github.sha` for push events so each merge to main gets a unique concurrency group instead of all sharing `ci-refs/heads/main`
- PR runs still cancel-in-progress for the same PR number (unchanged behavior)
- Adds regression test locking both invariants

## Why

CI on main has been cancelled for 3+ days (192 commits merged without post-merge CI). Every push to main shared concurrency group `ci-refs/heads/main` with `cancel-in-progress: true`, so each merge cancelled the previous run before it could complete.

## Change

**Before:**
```yaml
concurrency:
  group: ci-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

**After:**
```yaml
concurrency:
  group: ci-${{ github.event_name == 'push' && github.sha || github.event.pull_request.number || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

For push events: `github.sha` gives each run a unique group → no cancellation.
For PR events: `github.event.pull_request.number` groups by PR → cancel-in-progress works as before.

## Repro / Validation

```bash
# Regression test passes
uv run python -m pytest tests/unit/test_ci_workflow.py -v

# All 11 tests pass including new test_concurrency_group_unique_per_push
```

## Tests

- `uv run python -m pytest tests/unit/test_ci_workflow.py` — 11/11 passed
- `make lint` — passed
- `make repo-lint` — passed
- Full test suite: 11,166 passed (3 pre-existing failures in unrelated modules)

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c
branch: fix/ci-concurrency-group
```

Refs #2363