### PR TITLE
fix: convention follow-ups (#2371, #2367)

### DIFF
--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -1474,9 +1474,10 @@ def nudge_inbox(
     message is written to a lane's inbox, calling this function wakes the lane
     so it reads the message promptly — even if the lane is idle at the prompt.
 
-    Uses the same two-step ``tmux send-keys`` pattern as :func:`nudge_pane`
-    (text first, then ``Enter`` after a paste-bracket delay) to avoid the
-    bracketed-paste issue described in #1834.
+    Uses the same three-step ``tmux send-keys`` pattern as :func:`nudge_pane`
+    (``Escape`` first to cancel in-progress input, then text, then ``Enter``
+    after a paste-bracket delay) to avoid the bracketed-paste issue described
+    in #1834 and the input corruption issue described in #2352.
 
     The nudge is best-effort: failures are reported in the returned
     :class:`PoolAction` but never raise.
@@ -1494,6 +1495,14 @@ def nudge_inbox(
     cmd = "/inbox-poll"
 
     try:
+        # Send Escape first to cancel any in-progress input.  See #2352.
+        subprocess.run(
+            ["tmux", "send-keys", "-t", target, "Escape"],
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
+        time.sleep(_ESCAPE_CANCEL_DELAY)
         subprocess.run(
             ["tmux", "send-keys", "-t", target, cmd],
             check=True,

--- a/tests/unit/hosted_play/test_engine.py
+++ b/tests/unit/hosted_play/test_engine.py
@@ -604,16 +604,32 @@ class TestSkipToNextDecision:
         assert {"fake": "event"} not in engine.last_ai_events
 
     def test_skip_at_hand_end(self, engine: MatchEngine) -> None:
-        """skip_to_next_decision returns immediately if hand is None."""
+        """skip_to_next_decision returns immediately if hand is complete/None."""
         state = engine.start_match(SEED, "heuristic")
 
-        # Play a full hand to get to the inter-hand boundary
+        # Play a full hand to completion
         state = _play_full_hand(engine, state)
+        hand = state.current_hand
 
-        # If current_hand is None, skip is a no-op
-        if state.current_hand is None:
+        # After _play_full_hand, the hand may be phase="complete" (hand
+        # finished but not yet advanced) or still in trick_play (human
+        # sitting out).  If it's complete, advance to get current_hand=None.
+        if hand is not None and hand.phase == "complete":
+            state = engine.advance_to_next_hand(state)
+
+        # Now either current_hand is None (inter-hand) or status=="complete"
+        # (match over).  In both cases skip should be a no-op.
+        if state.status == "complete":
+            state_after = engine.skip_to_next_decision(state)
+            assert state_after.status == "complete"
+        elif state.current_hand is None:
             state_after = engine.skip_to_next_decision(state)
             assert state_after.current_hand is None
+        else:
+            # Hand is still in progress (e.g. redeal or next hand started)
+            # — skip should still be safe to call
+            state_after = engine.skip_to_next_decision(state)
+            assert state_after is not None
 
     def test_skip_at_match_complete(self, engine: MatchEngine) -> None:
         """skip_to_next_decision returns immediately if match is complete."""

--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -4056,10 +4056,24 @@ class TestSkipRoute:
         resp = client.post(f"/play/{link_uuid}/skip")
         assert resp.status_code == 200
 
-        # Verify state persisted (match_state_json updated)
+        # Verify state persisted: round-trip the deserialized state and
+        # assert meaningful game properties (not just non-empty JSON).
         result = get_match_state(app, link_uuid)
         assert result is not None
         state_after, match_row, session = result
         assert match_row.match_state_json is not None
         assert len(match_row.match_state_json) > 2  # Not empty {}
+        # The persisted state must represent a valid, ongoing (or complete)
+        # game — verify the deserialized state has real game properties.
+        assert state_after.status in ("active", "complete")
+        hand_after = state_after.current_hand
+        if state_after.status == "active":
+            assert hand_after is not None, "Active match must have a current hand"
+            assert hand_after.phase in (
+                "auction",
+                "trick_play",
+                "complete",
+                "redeal",
+                "moon_exchange",
+            )
         session.close()

--- a/tests/unit/test_ops_worker_pool.py
+++ b/tests/unit/test_ops_worker_pool.py
@@ -2120,7 +2120,13 @@ class TestNudgeInbox:
         assert result.action == "inbox_nudge"
         assert result.error is None
         assert "/inbox-poll" in result.reason
-        assert mock_run.call_count == 2
+        assert mock_run.call_count == 3
+        mock_run.assert_any_call(
+            ["tmux", "send-keys", "-t", "steward:author-a", "Escape"],
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
         mock_run.assert_any_call(
             ["tmux", "send-keys", "-t", "steward:author-a", "/inbox-poll"],
             check=True,
@@ -2133,7 +2139,8 @@ class TestNudgeInbox:
             capture_output=True,
             timeout=5,
         )
-        mock_sleep.assert_called_once_with(_PASTE_BRACKET_DELAY)
+        mock_sleep.assert_any_call(_ESCAPE_CANCEL_DELAY)
+        mock_sleep.assert_any_call(_PASTE_BRACKET_DELAY)
 
     @patch(f"{_WORKER_POOL}._resolve_tmux_target", return_value="steward:author-a")
     @patch(f"{_WORKER_POOL}.subprocess.run")
@@ -2171,11 +2178,13 @@ class TestNudgeInbox:
 
     @patch(f"{_WORKER_POOL}._resolve_tmux_target", return_value="steward:author-a")
     def test_nudge_inbox_call_order(self, mock_resolve: MagicMock) -> None:
-        """nudge_inbox sends /inbox-poll, sleeps, then sends Enter — in order."""
+        """nudge_inbox sends Escape, sleeps, /inbox-poll, sleeps, Enter — in order."""
         call_log: list[str] = []
 
         def track_run(cmd: list[str], **_kw: object) -> MagicMock:
-            if cmd[-1] == "Enter":
+            if cmd[-1] == "Escape":
+                call_log.append("escape")
+            elif cmd[-1] == "Enter":
                 call_log.append("enter")
             else:
                 call_log.append("text")
@@ -2191,7 +2200,13 @@ class TestNudgeInbox:
             result = nudge_inbox("author-a")
             assert result.executed is True
 
-        assert call_log == ["text", f"sleep({_PASTE_BRACKET_DELAY})", "enter"]
+        assert call_log == [
+            "escape",
+            f"sleep({_ESCAPE_CANCEL_DELAY})",
+            "text",
+            f"sleep({_PASTE_BRACKET_DELAY})",
+            "enter",
+        ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **#2371**: Add escape-before-send pattern to `nudge_inbox()` matching `nudge_pane()` and `clear_session()` — prevents input corruption when target lane is mid-input
- **#2367**: Strengthen skip test assertions: verify valid game state properties in persistence test, exercise completed-hand path in `test_skip_at_hand_end`
- Update `test_nudge_inbox` tests for 3-step sequence (Escape → text → Enter)

## Why
Convention follow-up findings from reviews of PR #2369 and PR #2366. The `nudge_inbox()` function was added in PR #2364 just before PR #2369 established the escape-before-send protocol, so it was missed.

Refs #2371, Refs #2367

## Repro / Validation
```bash
uv run python -m pytest tests/unit/test_ops_worker_pool.py::TestNudgeInbox -v
uv run python -m pytest tests/unit/hosted_play/test_engine.py::TestSkipToNextDecision -v
uv run python -m pytest tests/unit/hosted_play/test_routes.py::TestSkipRoute -v
```

## Tests
- `make check-gated` — 11195 passed, 58 skipped. 3 flaky `test_cpu_gate` failures due to high system load (pass in isolation, unrelated to changes)
- All 17 directly affected tests pass

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: fix/convention-batch-3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)