### PR TITLE
fix(ops): harden fleet-check autostart guard (#2375)

### DIFF
--- a/.claude/hooks/fleet-check-autostart.sh
+++ b/.claude/hooks/fleet-check-autostart.sh
@@ -16,20 +16,26 @@ trap 'exit 0' ERR
 # Guard: only act on the orchestrator lane
 # --------------------------------------------------------------------------
 # CLAUDE_AGENT_NAME is set by the --name flag (e.g., "orchestrator").
+# We require an explicit agent name — do not fall back to directory-based
+# detection, because ad-hoc sessions in the main checkout are not the
+# orchestrator.  Refs #2375.
 AGENT_NAME="${CLAUDE_AGENT_NAME:-}"
-
-if [[ -z "$AGENT_NAME" ]]; then
-    # Fallback: detect from project directory name
-    PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-    DIR_NAME="$(basename "$PROJECT_DIR")"
-    # The main checkout (Bid-Euchre) is where the orchestrator runs
-    if [[ "$DIR_NAME" == "Bid-Euchre" ]]; then
-        AGENT_NAME="orchestrator"
-    fi
-fi
 
 # Only the orchestrator needs fleet-check
 if [[ "$AGENT_NAME" != "orchestrator" ]]; then
+    exit 0
+fi
+
+# --------------------------------------------------------------------------
+# Guard: skip autostart after an intentional park
+# --------------------------------------------------------------------------
+# The /park skill (or park_worker()) can drop this marker to suppress
+# fleet-check autostart on the next session start.  Remove the marker
+# manually or via /fleet-check to re-enable autostart.  Refs #2375.
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+INHIBIT_FILE="$PROJECT_DIR/.claude/runtime/fleet-check-inhibit"
+
+if [[ -f "$INHIBIT_FILE" ]]; then
     exit 0
 fi
 

--- a/tests/unit/test_fleet_check_autostart.py
+++ b/tests/unit/test_fleet_check_autostart.py
@@ -1,0 +1,103 @@
+"""Tests for fleet-check-autostart.sh SessionStart hook.
+
+Validates the two guards added in #2375:
+1. Only fires when CLAUDE_AGENT_NAME=orchestrator (no directory fallback).
+2. Skips when the inhibit marker file exists (respects intentional park).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+HOOKS_DIR = Path(__file__).resolve().parents[2] / ".claude" / "hooks"
+SCRIPT = HOOKS_DIR / "fleet-check-autostart.sh"
+
+
+def _run_autostart(
+    agent_name: str | None = None,
+    project_dir: str | None = None,
+) -> tuple[int, str]:
+    """Run the fleet-check-autostart hook and return (exit_code, stdout)."""
+    env = os.environ.copy()
+    if agent_name is not None:
+        env["CLAUDE_AGENT_NAME"] = agent_name
+    else:
+        env.pop("CLAUDE_AGENT_NAME", None)
+
+    if project_dir is not None:
+        env["CLAUDE_PROJECT_DIR"] = project_dir
+    else:
+        # Use a temp-like path that won't match "Bid-Euchre"
+        env["CLAUDE_PROJECT_DIR"] = "/tmp/test-project"
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=5,
+    )
+    return result.returncode, result.stdout.strip()
+
+
+class TestOrchestratorGuard:
+    """Only the orchestrator lane should receive the directive."""
+
+    def test_orchestrator_gets_directive(self):
+        rc, stdout = _run_autostart(agent_name="orchestrator")
+        assert rc == 0
+        assert "FLEET-CHECK AUTO-START" in stdout
+
+    def test_non_orchestrator_skips(self):
+        rc, stdout = _run_autostart(agent_name="author-a")
+        assert rc == 0
+        assert stdout == ""
+
+    def test_empty_agent_name_skips(self):
+        """No CLAUDE_AGENT_NAME set — should NOT fallback to directory."""
+        rc, stdout = _run_autostart(agent_name="")
+        assert rc == 0
+        assert stdout == ""
+
+    def test_unset_agent_name_skips(self):
+        """CLAUDE_AGENT_NAME not in env at all — should NOT fallback."""
+        rc, stdout = _run_autostart(agent_name=None)
+        assert rc == 0
+        assert stdout == ""
+
+    def test_main_checkout_without_agent_name_skips(self):
+        """Session in Bid-Euchre directory but no agent name — not orchestrator."""
+        rc, stdout = _run_autostart(
+            agent_name=None, project_dir="/some/path/Bid-Euchre"
+        )
+        assert rc == 0
+        assert stdout == ""
+
+
+class TestInhibitMarker:
+    """The inhibit marker suppresses autostart after intentional park."""
+
+    def test_inhibit_marker_suppresses_directive(self, tmp_path: Path):
+        # Set up a fake project dir with the inhibit marker
+        runtime_dir = tmp_path / ".claude" / "runtime"
+        runtime_dir.mkdir(parents=True)
+        (runtime_dir / "fleet-check-inhibit").touch()
+
+        rc, stdout = _run_autostart(
+            agent_name="orchestrator", project_dir=str(tmp_path)
+        )
+        assert rc == 0
+        assert stdout == ""
+
+    def test_no_inhibit_marker_allows_directive(self, tmp_path: Path):
+        # Set up a fake project dir without the inhibit marker
+        runtime_dir = tmp_path / ".claude" / "runtime"
+        runtime_dir.mkdir(parents=True)
+
+        rc, stdout = _run_autostart(
+            agent_name="orchestrator", project_dir=str(tmp_path)
+        )
+        assert rc == 0
+        assert "FLEET-CHECK AUTO-START" in stdout


### PR DESCRIPTION
## Summary

- Remove directory-based orchestrator fallback from `fleet-check-autostart.sh` — require explicit `CLAUDE_AGENT_NAME=orchestrator` instead of inferring from `Bid-Euchre` directory name
- Add inhibit marker check (`fleet-check-inhibit`) so intentional `/park` operations are not undone by the next session start
- Add 7 regression tests covering both guards

## Why

Convention follow-up from PR #2373. Two findings from autonomous review:
1. The directory-based fallback falsely classified ad-hoc sessions in the main checkout as the orchestrator
2. No mechanism to suppress autostart after intentional park

Refs #2375

## Repro / Validation

```bash
# Run targeted tests
uv run python -m pytest tests/unit/test_fleet_check_autostart.py -v

# Manual hook tests
CLAUDE_AGENT_NAME=orchestrator bash .claude/hooks/fleet-check-autostart.sh  # should emit directive
CLAUDE_AGENT_NAME= bash .claude/hooks/fleet-check-autostart.sh              # should be silent
```

## Tests

```bash
uv run python -m pytest tests/unit/test_fleet_check_autostart.py -v  # 7 passed
make check-gated  # ✓ All checks passed
```

## Worktree proof

```
pwd: Bid-Euchre-steward-brws-author-d
branch: fix/convention-2373
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)