### PR TITLE
feat(ops): create /away-mode skill for operator presence management

### DIFF
--- a/.claude/skills/away-mode/SKILL.md
+++ b/.claude/skills/away-mode/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: away-mode
+description: Check operator away-mode status, toggle manually, configure Telegram push preferences, and view push history. Use from the orchestrator or ops lane to manage operator presence and remote notifications.
+---
+
+# /away-mode -- Operator Away-Mode Management
+
+Check, toggle, and configure the operator's away-mode detection and Telegram
+push notification settings. Wraps the `ops.py away` CLI and Telegram push
+infrastructure into a single operator-facing skill.
+
+## When to Use
+
+- You want to check whether the operator is currently present, idle, or away
+- You need to manually toggle away-mode (e.g., operator announces they are
+  leaving or returning)
+- You want to configure which alert severities trigger Telegram push
+- You want to review recent Telegram push history
+- The `/fleet-check` Step 5 needs a manual override of away detection
+
+## Arguments
+
+Optional positional argument controlling the action:
+
+| Argument | Description |
+|----------|-------------|
+| (none) | Show current status (default) |
+| `status` | Same as no argument -- show detailed status |
+| `on` | Manually mark operator as away |
+| `off` | Manually mark operator as returned/present |
+| `config` | Show current Telegram push configuration |
+| `history` | Show recent Telegram push history |
+
+## Workflow
+
+### Action: Check Status (default)
+
+Run the away-mode detector against the latest operator interaction event:
+
+```bash
+uv run python scripts/internal/ops.py away status --json
+```
+
+Interpret the result:
+
+| State | Tier | Meaning | Action |
+|-------|------|---------|--------|
+| `present` | 0 | Operator active within last 15m | No action needed |
+| `idle` | 1 | No interaction for 15-45m | Monitor, no push yet |
+| `away` | 2 | No interaction for 45-120m | Telegram push eligible |
+| `extended_away` | 3 | No interaction for 120m+ | Full autonomous mode |
+
+Report the state, minutes inactive, and last interaction time to the
+operator (or to the orchestrator if running from ops lane).
+
+### Action: Manual Toggle On (`on`)
+
+When the operator announces they are leaving:
+
+1. **Record an away marker event** so the detector does not need to rely
+   solely on interaction timestamps:
+
+   ```bash
+   uv run python scripts/internal/ops.py event emit \
+     --type operator_away --detail "manual toggle via /away-mode on"
+   ```
+
+2. **Verify** the new state:
+
+   ```bash
+   uv run python scripts/internal/ops.py away status
+   ```
+
+3. **Notify** the orchestrator if running from ops lane:
+
+   ```bash
+   uv run python scripts/internal/ops.py message send \
+     --from <lane> --to orchestrator --type progress \
+     --summary "Operator marked as away (manual toggle)"
+   ```
+
+> **Note:** The manual toggle supplements automatic detection. The operator
+> will transition back to `present` automatically when they next interact
+> with any Claude Code session (UserPromptSubmit events are tracked by the
+> event system).
+
+### Action: Manual Toggle Off (`off`)
+
+When the operator announces they have returned:
+
+1. **Record a return event:**
+
+   ```bash
+   uv run python scripts/internal/ops.py event emit \
+     --type operator_returned --detail "manual toggle via /away-mode off"
+   ```
+
+2. **Verify** the state has returned to `present`:
+
+   ```bash
+   uv run python scripts/internal/ops.py away status
+   ```
+
+3. **Notify** the orchestrator:
+
+   ```bash
+   uv run python scripts/internal/ops.py message send \
+     --from <lane> --to orchestrator --type progress \
+     --summary "Operator returned (manual toggle)"
+   ```
+
+### Action: Show Push Configuration (`config`)
+
+Display the current Telegram push settings:
+
+```bash
+# Check if Telegram push is enabled
+echo "STEWARD_TELEGRAM_ENABLED=${STEWARD_TELEGRAM_ENABLED:-unset}"
+
+# Show push state (cooldowns, per-item tracking)
+cat .claude/runtime/push_state.json 2>/dev/null || echo "(no push state file)"
+
+# Show escalation thresholds
+uv run python scripts/internal/ops.py away status --json | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+t = data['thresholds']
+print(f\"Idle threshold:          {t['idle_minutes']:.0f}m\")
+print(f\"Away threshold:          {t['away_minutes']:.0f}m\")
+print(f\"Extended-away threshold: {t['extended_away_minutes']:.0f}m\")
+"
+```
+
+**Configurable thresholds** can be overridden per-invocation:
+
+```bash
+# Example: shorter idle window for daytime operation
+uv run python scripts/internal/ops.py away status --idle 10 --away 30 --extended-away 90
+```
+
+The defaults are:
+- Idle: 15 minutes
+- Away: 45 minutes
+- Extended away: 120 minutes
+
+### Action: Show Push History (`history`)
+
+Review recent Telegram push events from the audit trail:
+
+```bash
+# Recent push events (last 20)
+uv run python scripts/internal/ops.py audit list --type push --limit 20
+
+# Or check the push state for per-item history
+cat .claude/runtime/push_state.json 2>/dev/null | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+items = data.get('items', {})
+if not items:
+    print('No push history recorded.')
+else:
+    print(f'Push history ({len(items)} items):\n')
+    for item_id, info in sorted(items.items(), key=lambda x: x[1].get('last_pushed', ''), reverse=True):
+        print(f\"  {item_id}:\")
+        print(f\"    Last pushed: {info.get('last_pushed', 'unknown')}\")
+        print(f\"    Push count:  {info.get('push_count', 0)}\")
+        print(f\"    Severity:    {info.get('severity', 'unknown')}\")
+"
+```
+
+## Telegram Push Flow
+
+The away-mode skill integrates with the following push infrastructure:
+
+```
+UserPromptSubmit events
+        |
+        v
+  away_mode.py  ---------> detect_operator_state()
+  (pure logic)               |
+                             v
+                    OperatorPresence: PRESENT | IDLE | AWAY | EXTENDED_AWAY
+                             |
+                             v  (if AWAY or EXTENDED_AWAY)
+                    alert_push.py  --> evaluate_push_needed()
+                    (transport-agnostic)
+                             |
+                             v
+                    telegram_push.py  --> prepare_alert_push()
+                    (formats message)
+                             |
+                             v
+                    MCP reply tool  --> Telegram delivery
+                    (called by orchestrator/ops skill)
+```
+
+**Key files:**
+- `src/bid_euchre/ops/away_mode.py` -- Pure state detection logic
+- `src/bid_euchre/ops/alert_push.py` -- Transport-agnostic push evaluation
+- `src/bid_euchre/ops/telegram_push.py` -- Telegram message formatting
+- `src/bid_euchre/ops/queue_priority.py` -- Away-mode-aware queue reorder
+- `scripts/internal/ops.py` -- CLI entry point (`away status`, `away reorder`)
+
+## Integration with Fleet Operations
+
+- **`/fleet-check` Step 5** checks away status to decide whether to push
+  a status summary via Telegram
+- **`/monitor`** (ops lane) runs the full alert push cycle including away
+  detection, push evaluation, and Telegram delivery
+- **Queue reorder** (`ops.py away reorder`) adjusts task queue priority
+  based on operator presence -- higher autonomy when operator is away
+
+## Gotchas
+
+- **Manual toggle is advisory.** The `operator_away` event helps the
+  detector but does not override the threshold logic. If the operator
+  interacts with a session after toggling `on`, the detector will
+  correctly transition back to `present`.
+- **Telegram push requires `STEWARD_TELEGRAM_ENABLED=1`.** If this env
+  var is not set, all push operations are silently skipped.
+- **Push state is per-item.** Each controller item has its own cooldown
+  and push count. Re-pushing only happens on cooldown expiry or severity
+  escalation.
+- **Clock skew safety.** If `last_interaction` is in the future (clock
+  skew), the detector treats the operator as `present` to be safe.
+
+## References
+
+- `src/bid_euchre/ops/away_mode.py` -- Core detection module (Platform-9b)
+- `src/bid_euchre/ops/telegram_push.py` -- Push adapter (Platform-9a PR3)
+- `src/bid_euchre/ops/alert_push.py` -- Push evaluator (Platform-9a PR1)
+- `.claude/skills/fleet-check/SKILL.md` -- Orchestrator cron (Step 5)
+- `.claude/skills/monitor/SKILL.md` -- Ops monitoring cycle
+- Issue #2338 -- Feature request for this skill


### PR DESCRIPTION
## Summary

- Create `/away-mode` skill at `.claude/skills/away-mode/SKILL.md`
- Wraps existing `away_mode.py`, `alert_push.py`, and `telegram_push.py` infrastructure into an operator-facing workflow
- Supports: status check, manual on/off toggle, push configuration display, and Telegram push history

## Why

The away-mode detection exists (PR #1806) but there was no corresponding skill for operators to check, toggle, or configure it. The `/fleet-check` skill references `ops.py away --check` but operators had no clean way to manage away-mode interactively.

Refs #2338

## Validation

```bash
# Skill is discoverable in skills list
ls .claude/skills/away-mode/SKILL.md

# Underlying CLI works
uv run python scripts/internal/ops.py away status --json
```

## Worktree Proof

```
pwd: Bid-Euchre-steward-brws-author-b
branch: feat/away-mode-skill
```

## Test Criteria

- [x] Skill file exists at `.claude/skills/away-mode/SKILL.md`
- [x] Skill appears in Claude Code skill list (confirmed: `away-mode` visible)
- [x] All CLI commands referenced in skill are valid (`ops.py away status`, `ops.py away reorder`)
- [x] Pre-commit hooks pass (repo-linter, trailing whitespace, etc.)
- [x] Docs-only change — no Python code modified, CI path-filter will skip heavy jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)