### PR TITLE
fix(test): restore hand-end skip assertion (#2380)

### DIFF
--- a/tests/unit/hosted_play/test_engine.py
+++ b/tests/unit/hosted_play/test_engine.py
@@ -629,7 +629,15 @@ class TestSkipToNextDecision:
             # Hand is still in progress (e.g. redeal or next hand started)
             # — skip should still be safe to call
             state_after = engine.skip_to_next_decision(state)
-            assert state_after is not None
+            assert state_after.status in ("active", "complete")
+            if state_after.current_hand is not None:
+                assert state_after.current_hand.phase in (
+                    "auction",
+                    "trick_play",
+                    "complete",
+                    "redeal",
+                    "moon_exchange",
+                )
 
     def test_skip_at_match_complete(self, engine: MatchEngine) -> None:
         """skip_to_next_decision returns immediately if match is complete."""


### PR DESCRIPTION
## Summary
- Strengthen the `else` branch assertion in `test_skip_at_hand_end` from trivially-true `is not None` to validating real game-state properties (`status` and hand `phase`)
- Matches the assertion rigor of the other two branches in the same test

## Why
Convention follow-up from PR #2378 — the reviewer flagged [P3] that the hand-end skip assertion was weakened to `assert state_after is not None`, which proves nothing meaningful.

## Validation
```bash
uv run python -m pytest tests/unit/hosted_play/test_engine.py::TestSkipToNextDecision -xvs
# 7 passed

make check  # ✓ All checks passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

Fixes #2380

🤖 Generated with [Claude Code](https://claude.com/claude-code)