### PR TITLE
fix(ops): add PreToolUse guard to prevent .claude/runtime/ write stalls (#2238)

### DIFF
--- a/.claude/hooks/block-runtime-writes.sh
+++ b/.claude/hooks/block-runtime-writes.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# PreToolUse hook — blocks Edit/Write to .claude/runtime/ paths.
+#
+# Claude Code has a platform-level protection on .claude/ paths that
+# prompts for confirmation.  This check fires BEFORE permissions.allow
+# is evaluated, so allow-list entries for .claude/runtime/** are
+# ineffective (see issue #2238, upstream issues #38806, #37765, #36168).
+#
+# In autonomous fleet operation no human watches the prompt, causing the
+# lane to stall indefinitely.  This hook intercepts the tool call BEFORE
+# the platform check fires, returning a clear error with CLI alternatives.
+#
+# Alternatives for writing .claude/runtime/ state:
+#   Review HWM:   uv run python scripts/internal/ops.py review-hwm set <N>
+#   General file: uv run python -c "from pathlib import Path; ..."
+#   Shell hook:   echo '...' > .claude/runtime/<file>  (Bash tool, not Edit/Write)
+#
+# Refs: #2238, #2249, analyst plan 2026-04-03_review_state_permission_fix.md
+set -uo pipefail
+
+INPUT=$(cat)
+
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""' 2>/dev/null || echo "")
+
+# No file path — not our concern (shouldn't happen for Edit/Write, but be safe)
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Check if the path targets .claude/runtime/
+# Handle both absolute and relative paths
+case "$FILE_PATH" in
+  */.claude/runtime/*|.claude/runtime/*)
+    cat <<BLOCK
+BLOCKED: Edit/Write to .claude/runtime/ is not allowed.
+
+Claude Code's platform-level protection on .claude/ paths causes permission
+stalls in autonomous fleet operation.  Use subprocess-based alternatives:
+
+  Review HWM:     uv run python scripts/internal/ops.py review-hwm set <N>
+  Arbitrary file:  uv run python -c "from pathlib import Path; p=Path('.claude/runtime/...'); p.parent.mkdir(parents=True, exist_ok=True); p.write_text('...')"
+  Shell redirect:  echo '...' > .claude/runtime/<path>
+
+See issue #2238 for details.
+BLOCK
+    exit 2
+    ;;
+esac
+
+# Path is not in .claude/runtime/ — allow
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,16 @@
   "hooks": {
     "PreToolUse": [
       {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/block-runtime-writes.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Edit|Write|Read",
         "hooks": [
           {
@@ -148,8 +158,6 @@
       "Write(.claude/hooks/**)",
       "Edit(.claude/runtime/**)",
       "Write(.claude/runtime/**)",
-      "Edit(.claude/runtime/review_state/**)",
-      "Write(.claude/runtime/review_state/**)",
       "Edit(MEMORY.md)",
       "Write(MEMORY.md)",
       "Edit(plans/**)",


### PR DESCRIPTION
## Summary

- Adds a PreToolUse hook (`block-runtime-writes.sh`) that intercepts Edit/Write
  tool calls targeting `.claude/runtime/` paths, blocking them with `exit 2`
  before Claude Code's platform-level protection can fire a permission prompt
- Removes redundant `Edit/Write(.claude/runtime/review_state/**)` entries from
  `permissions.allow` (subsumed by `runtime/**` patterns)

## Why

The review lane (and any lane writing to `.claude/runtime/`) stalls indefinitely
when Claude Code prompts for confirmation on `.claude/` path writes. This
platform-level protection fires **before** `permissions.allow` is evaluated,
making allow-list entries and `bypassPermissions` mode ineffective for these
paths (see upstream issues #38806, #37765, #36168).

The existing CLI workaround (`review-hwm` command) handles the specific
`last_merged_pr.txt` case, but this hook provides a general guardrail for ANY
`.claude/runtime/` write attempt via Edit/Write tools.

## How it works

1. New PreToolUse hook (`Edit|Write` matcher) checks if `file_path` matches
   `.claude/runtime/*` (both relative and absolute paths)
2. If matched: blocks with `exit 2` and prints guidance to use subprocess-based
   alternatives (review-hwm CLI, Python file I/O, shell redirects)
3. If not matched: exits 0, allowing the tool call to proceed
4. Runs before the rule-loader hook (positioned first in PreToolUse array)

## Defense layers (cumulative)

| Layer | Mechanism | Status |
|-------|-----------|--------|
| Instruction | Agent docs say to use CLI workarounds | Already done |
| Permission | `bypassPermissions` mode + allow patterns | Ineffective for `.claude/` |
| **Hook guard** | **PreToolUse blocks before platform check** | **This PR** |

## Repro / Validation

```bash
# Hook blocks .claude/runtime/ writes
echo '{"tool_input":{"file_path":".claude/runtime/review_state/last_merged_pr.txt"}}' \
  | .claude/hooks/block-runtime-writes.sh; echo "Exit: $?"
# → BLOCKED message, Exit: 2

# Hook allows non-runtime writes
echo '{"tool_input":{"file_path":"src/bid_euchre/ops/foo.py"}}' \
  | .claude/hooks/block-runtime-writes.sh; echo "Exit: $?"
# → Exit: 0

# Hook allows .claude/settings.json
echo '{"tool_input":{"file_path":".claude/settings.json"}}' \
  | .claude/hooks/block-runtime-writes.sh; echo "Exit: $?"
# → Exit: 0
```

## Tests

```bash
make check-quiet  # ✓ All checks passed
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: fix/review-permission-stalls
```

Refs #2238

🤖 Generated with [Claude Code](https://claude.com/claude-code)