### PR TITLE
feat(ops): create /playtest skill for automated browser game proving

### DIFF
--- a/.claude/skills/playtesting/SKILL.md
+++ b/.claude/skills/playtesting/SKILL.md
@@ -1,0 +1,347 @@
+---
+name: playtesting
+description: Play the browser game via HTTP endpoints to find bugs, test UX, and generate match data. Use from flex lanes for automated game proving and research.
+---
+
+# /playtest -- Automated Browser Game Playtesting
+
+Play complete matches of the Bid Euchre browser game via direct HTTP calls to
+the hosted web app. Logs observations per match for bug detection and research.
+
+## When to Use
+
+- You want to play through complete matches on the live game to find bugs
+- You want to generate match data for research or quality assurance
+- The orchestrator has assigned a playtesting task to your lane
+- You want to verify game flow end-to-end after a deployment
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `--url <render_url>` | Base URL of the hosted game (e.g., `https://bid-euchre.onrender.com`) |
+| `--code <invite_code>` | Invite code for game access |
+| `--nickname <name>` | Player nickname (default: `PlaytestBot`) |
+| `--matches <N>` | Number of matches to play (default: `1`) |
+
+## Prerequisites
+
+1. **Invite code** -- obtain one from the operator or generate via:
+   ```bash
+   bash scripts/internal/create_invite_codes.sh <render_url> <count>
+   ```
+2. **WebFetch tool** -- required for making HTTP requests to the game server
+3. **Game server running** -- the target URL must be reachable
+
+## Game Flow Overview
+
+The browser game uses HTMX with server-rendered HTML partials. Each action is
+a POST request with form data. The server returns HTML that we parse to
+determine the current game phase and available actions.
+
+### Phase Progression
+
+```
+enter-code -> nickname -> onboarding/skip -> select-ai -> [game loop] -> match result
+```
+
+### Game Loop Phases
+
+Within a match, the game cycles through hands. Each hand follows:
+
+```
+auction (bid/pass) -> trick_play (play cards) -> hand_result -> next-hand
+```
+
+Paused states (requiring POST /next to advance):
+- AI auction bids being revealed one at a time
+- AI card plays being revealed one at a time (per-card pacing)
+- Trick completion interstitials
+- Redeal (all players passed)
+
+## Execution Steps
+
+### Step 1: Enter Invite Code
+
+```
+POST {url}/enter-code
+Content-Type: application/x-www-form-urlencoded
+
+code={invite_code}
+```
+
+**Response:** 302 redirect to `/play/{link_uuid}` (or HX-Redirect header if
+sending `HX-Request: true`). Extract `link_uuid` from the redirect URL.
+
+**Important:** Do NOT send `HX-Request: true` on this first request. Use a
+plain POST so you get a 302 redirect. Extract the `link_uuid` from the
+`Location` header or response URL.
+
+### Step 2: Set Nickname
+
+```
+POST {url}/play/{link_uuid}/nickname
+Content-Type: application/x-www-form-urlencoded
+
+nickname={nickname}
+```
+
+**Response:** HTML partial -- either the onboarding welcome letter (new
+player) or model selection (returning player).
+
+### Step 3: Skip Onboarding
+
+If the response from Step 2 contains `onboarding` or `Welcome`, skip it:
+
+```
+POST {url}/play/{link_uuid}/onboarding/skip
+```
+
+**Response:** HTML partial with model selection form.
+
+### Step 4: Select AI Model and Start Match
+
+```
+POST {url}/play/{link_uuid}/select-ai
+Content-Type: application/x-www-form-urlencoded
+
+model_id=bud_bot
+```
+
+**Response:** HTML partial with the game board. Parse the phase from
+the HTML to determine the initial state.
+
+### Step 5: Game Loop
+
+Repeat until match result is reached:
+
+#### Detecting the Current Phase
+
+Parse the HTML response for phase indicators:
+
+| HTML Indicator | Phase | Action |
+|----------------|-------|--------|
+| `id="bid-panel"` | Auction (human turn) | Submit a bid |
+| `id="match-result"` | Match complete | Log result, exit loop |
+| `id="hand-result"` | Hand complete | POST next-hand |
+| `class="next-controls"` | Paused reveal | POST next |
+| `id="card-play-form"` | Trick play (human turn) | Play a card |
+| `id="model-select"` | Model selection | POST select-ai |
+| `class="moon-exchange"` or `id="exchange-form"` | Moon exchange | POST exchange (select first N cards) |
+
+#### 5a: Auction Phase -- Submit Bid (Always Pass for MVP)
+
+When `id="bid-panel"` is found in the HTML:
+
+1. Extract `turn_number` from the hidden input: `name="turn_number" value="N"`
+2. Submit a pass:
+
+```
+POST {url}/play/{link_uuid}/bid
+Content-Type: application/x-www-form-urlencoded
+
+turn_number={N}&bid_n=0&bid_type=regular
+```
+
+#### 5b: Trick Play -- Play a Card
+
+When `id="card-play-form"` is found in the HTML:
+
+1. Extract `turn_number` from: `name="turn_number" value="N"`
+2. Find legal card buttons: `class="card card--* card--legal"` with
+   `data-card-index="N"`
+3. Pick the first legal card index (MVP strategy)
+4. Submit:
+
+```
+POST {url}/play/{link_uuid}/play-card
+Content-Type: application/x-www-form-urlencoded
+
+turn_number={N}&card_index={first_legal_index}
+```
+
+#### 5c: Paused Reveal -- Advance
+
+When `class="next-controls"` is found but none of the above action forms:
+
+```
+POST {url}/play/{link_uuid}/next
+```
+
+This advances AI bid reveals, AI card reveals, trick interstitials, and
+redeal transitions.
+
+#### 5d: Hand Result -- Next Hand
+
+When `id="hand-result"` is found:
+
+1. Log the hand result (parse scores from the HTML)
+2. Advance:
+
+```
+POST {url}/play/{link_uuid}/next-hand
+```
+
+#### 5e: Match Result -- Log and Finish
+
+When `id="match-result"` is found:
+
+1. Parse winner from: `class="result-title"` (contains "You Win!" or "You Lose")
+2. Parse final scores from: `class="score-final"` elements
+3. Parse hands played from: `class="hands-count"` text
+4. Log the match observation
+5. If more matches remain, start a new match:
+
+```
+POST {url}/play/{link_uuid}/new-match
+```
+
+Then re-enter the game loop from Step 4 (select-ai).
+
+#### 5f: Moon Exchange (if encountered)
+
+When `id="exchange-form"` or moon exchange selection is detected:
+
+1. Extract the form and available card checkboxes
+2. Select the first N cards (MVP: no strategic selection)
+3. Submit the exchange form
+
+```
+POST {url}/play/{link_uuid}/exchange
+Content-Type: application/x-www-form-urlencoded
+
+card_indices=0,1,2  (comma-separated indices to give to partner)
+```
+
+### Step 6: Log Observations
+
+After each match, log observations to a session file.
+
+**Output file:** `plans/sessions/playtest_{YYYY-MM-DD}_{HHmmss}.md`
+
+**Schema per match:**
+
+```markdown
+## Match {N}
+
+- **Match ID:** {link_uuid}
+- **Duration:** {seconds}s
+- **Final Score:** You {score_human} -- AI {score_ai}
+- **Winner:** {human|ai}
+- **Hands Played:** {N}
+- **AI Model:** bud_bot
+
+### Anomalies
+- {any HTTP errors, unexpected phases, stuck states}
+
+### Strategy Notes
+- Always passed in auction (MVP)
+- Always played first legal card (MVP)
+```
+
+## HTML Parsing Guide
+
+The game returns server-rendered HTML. Key parsing patterns:
+
+### Extract turn_number
+```
+Look for: <input type="hidden" name="turn_number" value="(\d+)">
+```
+
+### Extract legal card indices
+```
+Look for: data-card-index="(\d+)" on elements with class containing "card--legal"
+```
+
+### Extract scores from hand_result
+```
+Look for: class="score-value--human">{score}</span>
+Look for: class="score-value--ai">{score}</span>
+```
+
+### Extract match status
+```
+Look for: data-match-status="(setup|active|complete)"
+```
+
+### Detect phase from game_board
+Priority order (check in this order):
+1. `id="match-result"` -> match complete
+2. `id="hand-result"` -> hand complete
+3. `id="bid-panel"` -> auction (human's turn to bid)
+4. `id="card-play-form"` -> trick play (human's turn to play)
+5. `class="next-controls"` -> paused, needs /next to advance
+6. `id="model-select"` -> needs model selection
+7. `id="exchange-form"` or `moon-exchange-select` -> moon exchange
+
+## Error Handling
+
+### HTTP Errors
+- **404:** Game not found -- link_uuid may be invalid. Log and abort.
+- **429:** Match limit reached -- wait or abandon stale matches.
+- **409:** Turn conflict -- re-fetch the game page and retry with fresh state.
+- **500:** Server error -- log, wait 5s, retry once. If persistent, abort.
+
+### Stuck State Detection
+If the same phase repeats more than 20 times without progress (no score
+changes, no turn_number changes), the game is stuck. Log the anomaly and
+abort the match.
+
+### Cookie Handling
+The game sets a `player_link` cookie after entering an invite code. If
+using WebFetch, cookies may not persist between requests. As a workaround,
+always include the `link_uuid` in the URL path (which the game uses as the
+primary player identifier).
+
+## Implementation Notes for WebFetch
+
+When using the WebFetch tool to make requests:
+
+1. **Content-Type:** Always set `Content-Type: application/x-www-form-urlencoded`
+   for POST requests
+2. **Follow redirects:** The enter-code endpoint returns a 302 redirect.
+   WebFetch may auto-follow; check the final URL for the link_uuid
+3. **Parse HTML text:** The response body is HTML. Use string matching or
+   regex patterns (not a DOM parser) to detect phases and extract values
+4. **No HX-Request header:** Do not send `HX-Request: true` unless you want
+   HTMX partial responses. For playtesting, either mode works, but full
+   page responses are easier to parse for phase detection
+
+## Observation Categories
+
+### Bug Indicators (file as issues)
+- HTTP 500 errors
+- Unexpected phase transitions (e.g., trick_play before auction)
+- Score calculation errors (tricks won != expected based on card plays)
+- Game stuck in a phase for >20 iterations
+- Server returns empty/malformed HTML
+
+### UX Notes (log for research)
+- How many /next clicks are needed per hand (pacing friction)
+- Time to complete a match
+- Frequency of redeals
+- Moon/loner occurrences
+
+### Strategy Notes (log for research)
+- Observed AI bidding patterns
+- Trump suit distribution
+- How often the AI team makes their bid
+- Score trajectories
+
+## Example Invocation
+
+```
+/playtest --url https://bid-euchre.onrender.com --code ABC12345 --nickname TestBot --matches 3
+```
+
+This plays 3 complete matches, logging observations after each. Total
+expected time: 15-30 minutes depending on hand count per match.
+
+## NOT in MVP Scope
+
+- Playwright/browser automation mode
+- Strategic bidding (bid > 0)
+- Strategic card selection (anything beyond first legal card)
+- Auto-filing GitHub issues for detected bugs
+- Overnight cron loop integration
+- Context clear and resume between matches

--- a/scripts/internal/create_invite_codes.sh
+++ b/scripts/internal/create_invite_codes.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# create_invite_codes.sh — Batch-create invite codes for the browser game.
+#
+# Usage:
+#   bash scripts/internal/create_invite_codes.sh [count] [label]
+#
+# Arguments:
+#   count   Number of codes to create (default: 5)
+#   label   Optional label for the batch (default: "playtest")
+#
+# Environment:
+#   DATABASE_URL  Database URL (default: sqlite:///hosted_play.db)
+#
+# Examples:
+#   # Create 5 playtest codes on local dev DB
+#   bash scripts/internal/create_invite_codes.sh 5 playtest
+#
+#   # Create 10 codes on a remote Postgres DB
+#   DATABASE_URL="postgresql://..." bash scripts/internal/create_invite_codes.sh 10 batch-2026-04
+#
+# Output:
+#   Prints each generated code to stdout (one per line), suitable for
+#   piping to a file or clipboard.
+
+set -euo pipefail
+
+COUNT="${1:-5}"
+LABEL="${2:-playtest}"
+
+# Use inline Python to leverage the existing web.db module
+uv run python -c "
+import sys
+sys.path.insert(0, '.')
+from web.db import (
+    Base, InviteCode, generate_invite_code,
+    init_engine, make_session_factory,
+)
+from web.config import get_config
+
+config = get_config()
+engine = init_engine(config.database_url)
+Base.metadata.create_all(engine)
+SessionFactory = make_session_factory(engine)
+session = SessionFactory()
+
+count = int('${COUNT}')
+label = '${LABEL}'
+codes = []
+
+try:
+    for _ in range(count):
+        code = generate_invite_code()
+        invite = InviteCode(code=code, status='active', label=label)
+        session.add(invite)
+        codes.append(code)
+    session.commit()
+    for c in codes:
+        print(c)
+    print(f'--- Created {count} invite codes (label={label}) ---', file=sys.stderr)
+except Exception as e:
+    session.rollback()
+    print(f'Error: {e}', file=sys.stderr)
+    sys.exit(1)
+finally:
+    session.close()
+    engine.dispose()
+"


### PR DESCRIPTION
## Plan
N/A — task packet 7bc51fcbe056, session plan §4

## Summary
- Add `/playtest` Claude Code skill for automated browser game proving via HTTP endpoints
- Add `scripts/internal/create_invite_codes.sh` helper for batch invite code creation
- MVP: always-pass bidding, first-legal-card play, per-match observation logging

## Why
Enables flex lanes to autonomously play the browser game to find bugs, test UX, and
generate match data without manual operator intervention.

## Repro / Validation
**Command(s) run:**
```bash
# Validate skill file exists and is well-formed
cat .claude/skills/playtesting/SKILL.md | head -5

# Validate shell script syntax
bash -n scripts/internal/create_invite_codes.sh

# Full validation
make check-gated
```

**Config (if applicable):** N/A

**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** Skill file is registered and invokable; shell script parses without errors
- **Verification command:** `bash -n scripts/internal/create_invite_codes.sh && test -f .claude/skills/playtesting/SKILL.md`
- **Expected result:** Both commands succeed (exit 0)

## Tests
- [x] `bash -n scripts/internal/create_invite_codes.sh` — script syntax valid
- [x] `make check-gated` — full suite (3 pre-existing failures in test_partials.py, unrelated to this PR)
- [x] Other: manual verification that skill appears in /skills list

## Expected impact
- Metrics impact: None (skill + shell script only)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d  04148d3d [feat/playtesting-skill-mvp]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Issue Linkage
Refs #2198

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
- [x] Issue linkage uses correct keyword (`Fixes` vs `Refs`) per closure policy