### PR TITLE
fix(web): remove orphaned .ai-card-count responsive CSS (#2346)

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -2370,10 +2370,6 @@ main {
         display: none;
     }
 
-    .ai-hand-block--vertical .ai-card-count {
-        font-size: 0.58rem;
-    }
-
     /* Top partner — smaller card backs */
     .compass-top .card-back {
         width: 28px;
@@ -2572,18 +2568,6 @@ main {
     /* Side hand labels — ultra-compact on small phones */
     .ai-hand-block--vertical .ai-seat-label {
         font-size: 0.55rem;
-    }
-
-    .ai-hand-block--vertical .ai-card-count {
-        font-size: 0.55rem;
-        writing-mode: vertical-lr;
-        text-orientation: mixed;
-    }
-
-    .ai-card-count {
-        font-size: 0.65rem;
-        padding: 0.15rem 0.35rem;
-        line-height: 1;
     }
 
     /* Compass grid — tighter on small phones */


### PR DESCRIPTION
## Plan
N/A — targeted cleanup for #2346

## Summary
- Remove 3 orphaned `.ai-card-count` CSS rule blocks from responsive breakpoints
- These rules styled a class that was removed from HTML in PR #2370 but the responsive overrides were left behind

## Why
PR #2370 removed `.ai-card-count` from all HTML templates (completing the card-count removal per #2346), but left 3 responsive breakpoint rules styling the now-absent class. These are dead CSS that clutters the stylesheet and confuses future maintainers.

## Repro / Validation
**Command(s) run:**
- `grep -c 'ai-card-count' web/static/style.css` → 1 (only the removal comment)
- `grep -r 'ai-card-count' web/templates/` → 0 matches (class not in HTML)

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** No `.ai-card-count` CSS rule blocks remain in responsive breakpoints
- **Verification command:** `grep 'ai-card-count' web/static/style.css`
- **Expected result:** Only the historical removal comment on line 414, no active rule blocks

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/ --no-header -q` — 3436 passed
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None
- Runtime impact: None (removes ~16 lines of dead CSS)

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git worktree list` (lane entry):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d   b00ced08 [fix/player-name-cleanup-2346]
```

## Issue Linkage
Refs #2346

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
- [x] Issue linkage uses correct keyword (`Fixes` vs `Refs`) per closure policy