### PR TITLE
fix(web): use team-human green for 'Your Hand' label

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -345,7 +345,7 @@ main {
 .hand h3 {
     margin: 0 0 0.5rem;
     font-size: 1rem;
-    color: var(--color-text-muted);
+    color: var(--team-human);
     text-align: center;
 }
 
@@ -3072,6 +3072,10 @@ main {
     color: var(--color-text-muted);
 }
 
+.moon-exchange__group-title--human {
+    color: var(--team-human);
+}
+
 .moon-exchange__card-list {
     display: flex;
     justify-content: center;
@@ -3321,6 +3325,10 @@ main {
     color: var(--color-text-muted);
     margin: 0 0 0.5rem;
     font-weight: 600;
+}
+
+.moon-exchange__group-title--human {
+    color: var(--team-human);
 }
 
 .moon-exchange__card-list {

--- a/web/templates/partials/moon_exchange.html
+++ b/web/templates/partials/moon_exchange.html
@@ -89,7 +89,7 @@
     {# Show current hand after exchange #}
     {% if human_hand %}
         <div class="moon-exchange__hand" role="region" aria-label="Your hand after exchange">
-            <h3 class="moon-exchange__group-title">Your Hand</h3>
+            <h3 class="moon-exchange__group-title moon-exchange__group-title--human">Your Hand</h3>
             <div class="moon-exchange__card-list" role="list">
                 {% for card in human_hand %}
                     {% set disp_suit = card[0] %}

--- a/web/templates/partials/moon_exchange_select.html
+++ b/web/templates/partials/moon_exchange_select.html
@@ -38,7 +38,7 @@
     </p>
 
     <div class="moon-exchange__hand" role="region" aria-label="Your hand - select 2 cards">
-        <h3 class="moon-exchange__group-title">Your Hand</h3>
+        <h3 class="moon-exchange__group-title moon-exchange__group-title--human">Your Hand</h3>
         <div class="card-fan card-fan--exchange" role="group"
              aria-label="Cards in your hand ({{ human_hand | length }}) - select 2 to give">
             {% for card in human_hand %}


### PR DESCRIPTION
## Summary

- Change the "Your Hand" heading color from `--color-text-muted` (gray) to `--team-human` (green) to match other team-colored UI elements
- Add `--human` modifier class to moon exchange "Your Hand" titles for consistent team-color styling
- No behavioral changes — purely visual consistency fix

## Why

The score bar, trick counts, contract bar, and player names all use `--team-human` green for the human team and `--team-ai` blue for the AI team. The "Your Hand" label was the only team-affiliated element still using generic muted text, breaking the color convention.

Fixes #2408

## Repro / Validation

```bash
# Launch the browser game and observe the "Your Hand" label renders in green
uv run python -m web.start

# All checks pass
make check-quiet
```

## Tests

```bash
uv run python -m pytest tests/ -k "template or css or static or style" --no-header -q
# 836 passed, 5 skipped
make check-quiet  # ✓ All checks passed
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
git rev-parse --show-toplevel: Bid-Euchre-steward-brws-author-a
```

## Files changed

| File | Change |
|------|--------|
| `web/static/style.css` | `.hand h3` color → `--team-human`; add `.moon-exchange__group-title--human` |
| `web/templates/partials/moon_exchange.html` | Add `--human` modifier class to "Your Hand" title |
| `web/templates/partials/moon_exchange_select.html` | Add `--human` modifier class to "Your Hand" title |

🤖 Generated with [Claude Code](https://claude.com/claude-code)