### PR TITLE
fix(ops): output JSON additionalContext from fleet-check autostart hook

### DIFF
--- a/.claude/hooks/fleet-check-autostart.sh
+++ b/.claude/hooks/fleet-check-autostart.sh
@@ -40,18 +40,24 @@ if [[ -f "$INHIBIT_FILE" ]]; then
 fi
 
 # --------------------------------------------------------------------------
-# Emit directive for the orchestrator agent
+# Emit directive for the orchestrator agent (JSON additionalContext format)
 # --------------------------------------------------------------------------
-cat <<'DIRECTIVE'
-FLEET-CHECK AUTO-START: The orchestrator fleet-check cron must be running.
-
-Action required:
-1. Run CronList to check for an existing fleet-check cron
-2. If a fleet-check cron already exists, no action needed
-3. If no fleet-check cron exists, run: /loop 8m /fleet-check
-
-This ensures periodic inbox polling, CPU checks, task completion detection,
-and lane health monitoring continue after /clear or session restart.
-DIRECTIVE
+# The Claude Code hook framework requires JSON output with an additionalContext
+# field.  Plain text is logged as "OK" and never reaches the agent.  Refs #2333.
+python3 -c "
+import json, sys
+msg = (
+    'FLEET-CHECK AUTO-START: The orchestrator fleet-check cron must be running.\n'
+    '\n'
+    'Action required:\n'
+    '1. Run CronList to check for an existing fleet-check cron\n'
+    '2. If a fleet-check cron already exists, no action needed\n'
+    '3. If no fleet-check cron exists, run: /loop 8m /fleet-check\n'
+    '\n'
+    'This ensures periodic inbox polling, CPU checks, task completion detection,\n'
+    'and lane health monitoring continue after /clear or session restart.'
+)
+json.dump({'additionalContext': msg}, sys.stdout)
+"
 
 exit 0

--- a/tests/unit/test_fleet_check_autostart.py
+++ b/tests/unit/test_fleet_check_autostart.py
@@ -1,12 +1,14 @@
 """Tests for fleet-check-autostart.sh SessionStart hook.
 
-Validates the two guards added in #2375:
-1. Only fires when CLAUDE_AGENT_NAME=orchestrator (no directory fallback).
-2. Skips when the inhibit marker file exists (respects intentional park).
+Validates:
+1. Only fires when CLAUDE_AGENT_NAME=orchestrator (no directory fallback) (#2375).
+2. Skips when the inhibit marker file exists (respects intentional park) (#2375).
+3. Output is valid JSON with additionalContext key (#2333).
 """
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -48,7 +50,9 @@ class TestOrchestratorGuard:
     def test_orchestrator_gets_directive(self):
         rc, stdout = _run_autostart(agent_name="orchestrator")
         assert rc == 0
-        assert "FLEET-CHECK AUTO-START" in stdout
+        data = json.loads(stdout)
+        assert "additionalContext" in data
+        assert "FLEET-CHECK AUTO-START" in data["additionalContext"]
 
     def test_non_orchestrator_skips(self):
         rc, stdout = _run_autostart(agent_name="author-a")
@@ -100,4 +104,28 @@ class TestInhibitMarker:
             agent_name="orchestrator", project_dir=str(tmp_path)
         )
         assert rc == 0
-        assert "FLEET-CHECK AUTO-START" in stdout
+        data = json.loads(stdout)
+        assert "FLEET-CHECK AUTO-START" in data["additionalContext"]
+
+
+class TestJsonOutput:
+    """Hook output must be valid JSON with additionalContext (#2333)."""
+
+    def test_output_is_valid_json(self):
+        rc, stdout = _run_autostart(agent_name="orchestrator")
+        assert rc == 0
+        data = json.loads(stdout)
+        assert isinstance(data, dict)
+
+    def test_output_has_additional_context_key(self):
+        rc, stdout = _run_autostart(agent_name="orchestrator")
+        assert rc == 0
+        data = json.loads(stdout)
+        assert set(data.keys()) == {"additionalContext"}
+
+    def test_additional_context_contains_action_items(self):
+        rc, stdout = _run_autostart(agent_name="orchestrator")
+        assert rc == 0
+        ctx = json.loads(stdout)["additionalContext"]
+        assert "CronList" in ctx
+        assert "/loop 8m /fleet-check" in ctx


### PR DESCRIPTION
## Summary

- Fix fleet-check-autostart.sh SessionStart hook to emit JSON `{"additionalContext": "..."}` instead of plain text
- Add `TestJsonOutput` test class verifying output is valid JSON with correct key and action items

## Why

The Claude Code hook framework requires JSON output with an `additionalContext` field for the agent to see hook directives. The hook was using a plain-text heredoc (`cat <<'DIRECTIVE'`), which the framework logs as "OK" and discards — the orchestrator never receives the fleet-check autostart instruction.

## Changes

| File | Change |
|------|--------|
| `.claude/hooks/fleet-check-autostart.sh` | Replace heredoc with `python3 -c "import json; json.dump(...)"`  |
| `tests/unit/test_fleet_check_autostart.py` | Add `TestJsonOutput` class (3 tests), update existing assertions to parse JSON |

## Repro / Validation

```bash
# Hook output is valid JSON with additionalContext:
CLAUDE_AGENT_NAME=orchestrator bash .claude/hooks/fleet-check-autostart.sh
# → {"additionalContext": "FLEET-CHECK AUTO-START: ..."}

# Non-orchestrator lanes get silent exit 0:
CLAUDE_AGENT_NAME=author-a bash .claude/hooks/fleet-check-autostart.sh
# → (no output)

# Targeted tests pass:
uv run python -m pytest tests/unit/test_fleet_check_autostart.py -v
# → 10 passed
```

## Tests

```bash
uv run python -m pytest tests/unit/test_fleet_check_autostart.py -v  # 10 passed
make check-quiet  # ✓ All checks passed (11234 passed, 59 skipped)
```

## Worktree proof

```
pwd: Bid-Euchre-steward-brws-author-b
branch: fix/fleet-check-hook-json
```

Refs #2333

🤖 Generated with [Claude Code](https://claude.com/claude-code)