### PR TITLE
fix(web): render spade/club suit icons as solid filled shapes (#2329)

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -30,12 +30,6 @@
     --color-moon-glow: #ffca28;
     --color-loner: #7e57c2;
     --color-loner-glow: #b39ddb;
-    /* Black-suit text-shadow for visibility on dark backgrounds (#2329) */
-    --suit-black-shadow:
-        -1px -1px 0 rgba(255, 255, 255, 0.55),
-         1px -1px 0 rgba(255, 255, 255, 0.55),
-        -1px  1px 0 rgba(255, 255, 255, 0.55),
-         1px  1px 0 rgba(255, 255, 255, 0.55);
     /* Team colors — consistent across score, trick count, contract bar */
     --team-human: #66bb6a;
     --team-ai: #42a5f5;
@@ -570,8 +564,7 @@ main {
 
 .bid-recap__suit--s,
 .bid-recap__suit--c {
-    color: var(--color-black);
-    text-shadow: var(--suit-black-shadow);
+    color: var(--color-text);
 }
 
 .bid-recap__no-trump {
@@ -657,8 +650,7 @@ main {
 
 .contract-bar__suit--s,
 .contract-bar__suit--c {
-    color: var(--color-black);
-    text-shadow: var(--suit-black-shadow);
+    color: var(--color-text);
 }
 
 .contract-bar__no-trump {
@@ -838,8 +830,7 @@ main {
 
 .lead-suit--spades,
 .lead-suit--clubs {
-    color: var(--color-black);
-    text-shadow: var(--suit-black-shadow);
+    color: var(--color-text);
 }
 
 /* Top (partner) */
@@ -2152,8 +2143,7 @@ main {
 
 .landing-hero__suit--spade,
 .landing-hero__suit--club {
-    color: var(--color-black);
-    text-shadow: var(--suit-black-shadow);
+    color: var(--color-text);
 }
 
 .landing-hero__suit--heart,
@@ -3126,9 +3116,11 @@ main {
     color: var(--color-text);
 }
 
-/* Reusable suit-icon utility — applies red/black to any inline suit symbol.
-   Use `suit-icon suit-icon--hearts` (or diamonds/spades/clubs) on a <span>
-   wrapping a suit symbol like ♠ ♥ ♦ ♣.  (#2235) */
+/* Reusable suit-icon utility — applies red/white to any inline suit symbol
+   on dark backgrounds.  Red for hearts/diamonds, white (--color-text) for
+   spades/clubs so they render as solid filled shapes, not invisible dark
+   outlines (#2329).  Use `suit-icon suit-icon--hearts` (or
+   diamonds/spades/clubs) on a <span> wrapping ♠ ♥ ♦ ♣.  (#2235) */
 .suit-icon {
     white-space: nowrap;
 }
@@ -3140,8 +3132,7 @@ main {
 
 .suit-icon--spades,
 .suit-icon--clubs {
-    color: var(--color-black);
-    text-shadow: var(--suit-black-shadow);
+    color: var(--color-text);
 }
 
 /* --------------------------------------------------------------------------


### PR DESCRIPTION
## Plan
N/A — bounded CSS fix for #2329

## Summary
- Change dark-background suit icon styling from `color: var(--color-black)` (#212121) + white text-shadow to `color: var(--color-text)` (#fafafa)
- Remove `--suit-black-shadow` CSS variable (no longer needed)
- Card faces (white background) retain existing dark color unchanged

## Why
On dark game backgrounds, spade/club suit symbols (♠ ♣) were styled with near-black color (#212121) plus a white outline text-shadow. This made the dark fill invisible and only the white outline visible, creating the appearance of **white outlined (unfilled)** symbols. Hearts/diamonds appeared as solid red shapes while spades/clubs appeared hollow.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/ -q  # 3437 passed
make check-quiet                                      # All checks passed
```

**Visual verification:** Grep confirms all 5 dark-background suit contexts now use `var(--color-text)`:
- `.bid-recap__suit--s/c` (bid recap bar)
- `.contract-bar__suit--s/c` (contract bar)
- `.lead-suit--spades/clubs` (lead suit indicator)
- `.suit-icon--spades/clubs` (reusable inline utility)
- `.landing-hero__suit--spade/club` (landing page hero)

Card faces (`.card--spades, .card--clubs`) remain `var(--color-black)` on white background.

## Test Criteria
- **Pass condition:** All dark-background black-suit CSS rules use `var(--color-text)` instead of `var(--color-black)` + text-shadow
- **Verification command:** `grep -c "suit-black-shadow" web/static/style.css` returns 0; `grep -c "color-text" web/static/style.css` shows increased count
- **Expected result:** No remaining `suit-black-shadow` references; spade/club icons render as solid white shapes on dark backgrounds

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/ -q` — 3437 passed, 8 skipped
- [x] `make check-quiet` — all checks passed

## Expected impact
- Metrics impact: None (CSS-only change)
- Runtime impact: None

## Risk level
- [x] Low (CSS styling only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git worktree list` (relevant line):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c   28e7d446 [fix/suit-icon-fill-2329]
```

## Issue Linkage
Fixes #2329

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it (CSS-only, no behavior change)
- [x] PR is focused (one concept)
- [x] Issue linkage uses correct keyword (`Fixes` vs `Refs`) per closure policy