### PR TITLE
fix(ops): clarify message send is advisory, not away-mode toggle (#2395)

### DIFF
--- a/.claude/skills/away-mode/SKILL.md
+++ b/.claude/skills/away-mode/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: away-mode
-description: Check operator away-mode status, toggle manually, configure Telegram push preferences, and view push history. Use from the orchestrator or ops lane to manage operator presence and remote notifications.
+description: Check operator away-mode status, send advisory toggle notifications, configure Telegram push preferences, and view push history. Use from the orchestrator or ops lane to manage operator presence and remote notifications.
 ---
 
 # /away-mode -- Operator Away-Mode Management
 
-Check, toggle, and configure the operator's away-mode detection and Telegram
-push notification settings. Wraps the `ops.py away` CLI and Telegram push
-infrastructure into a single operator-facing skill.
+Check status, send advisory toggle notifications, and configure the operator's
+away-mode detection and Telegram push notification settings. Wraps the
+`ops.py away` CLI and Telegram push infrastructure into a single
+operator-facing skill.
 
 ## When to Use
 
@@ -57,9 +58,10 @@ operator (or to the orchestrator if running from ops lane).
 
 When the operator announces they are leaving:
 
-1. **Notify the orchestrator** so the fleet treats the operator as away.
-   (There is no dedicated `event emit` CLI — the away detector infers
-   state from interaction timestamps automatically.)
+1. **Send an advisory notification** to the orchestrator so it knows the
+   operator intends to be away. This does **not** change the detected
+   away-mode state — the threshold-based detector infers state from
+   interaction timestamps automatically.
 
    ```bash
    uv run python scripts/internal/ops.py message send \
@@ -73,17 +75,19 @@ When the operator announces they are leaving:
    uv run python scripts/internal/ops.py away status
    ```
 
-> **Note:** Manual toggle is advisory — it sends a message bus notification
-> but does not override the threshold-based detector. The operator will
-> transition back to `present` automatically when they next interact
-> with any Claude Code session (UserPromptSubmit events are tracked by the
-> event system).
+> **Note:** This notification is advisory only — it does not override the
+> threshold-based detector. The detector will transition to `away` on its
+> own once the idle threshold is reached. The operator will transition back
+> to `present` automatically when they next interact with any Claude Code
+> session (UserPromptSubmit events are tracked by the event system).
 
 ### Action: Manual Toggle Off (`off`)
 
 When the operator announces they have returned:
 
-1. **Notify the orchestrator** that the operator has returned:
+1. **Send an advisory notification** that the operator has returned. The
+   detector will transition to `present` automatically once it sees a
+   fresh interaction event; this message is informational only.
 
    ```bash
    uv run python scripts/internal/ops.py message send \


### PR DESCRIPTION
## Summary

- Reword away-mode skill's manual toggle sections to clarify that `message send` is an advisory notification, not a state-changing toggle
- Update frontmatter description and header to match the advisory semantics
- Strengthen the Note block to explain the detector transitions independently

## Why

PR #2394 replaced broken `event emit` references with working `message send` commands, but the surrounding prose still described the messages as if they change the operator's detected away state. The threshold-based detector infers state from interaction timestamps — messages are purely informational.

Fixes #2395

## Repro / Validation

```bash
# Docs-only change — no code modified
git diff --stat origin/main
#  .claude/skills/away-mode/SKILL.md | 30 +++++++++++++++++-------------
#  1 file changed, 17 insertions(+), 13 deletions(-)

# Full validation (11,230 passed; 4 pre-existing flakes in cpu_gate/post_push tests)
make check-gated
```

## Tests

- `make check-gated` — 11,230 passed, 4 pre-existing flakes (test_cpu_gate timeout under load, test_post_push_ci_check_hook temp file timeout)
- No Python code changed — docs-only skill file

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: fix/2395-away-mode-skill-convention
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)