### PR TITLE
fix(ops): exempt checked-in runtime README.md from write blocker (#2400)

### DIFF
--- a/.claude/hooks/block-runtime-writes.sh
+++ b/.claude/hooks/block-runtime-writes.sh
@@ -30,6 +30,10 @@ fi
 # Check if the path targets .claude/runtime/
 # Handle both absolute and relative paths
 case "$FILE_PATH" in
+  */.claude/runtime/*/README.md|.claude/runtime/*/README.md|*/.claude/runtime/README.md|.claude/runtime/README.md)
+    # Checked-in schema docs (README.md) are safe to edit — exempt them
+    exit 0
+    ;;
   */.claude/runtime/*|.claude/runtime/*)
     cat <<BLOCK
 BLOCKED: Edit/Write to .claude/runtime/ is not allowed.

--- a/tests/unit/test_block_runtime_writes_hook.py
+++ b/tests/unit/test_block_runtime_writes_hook.py
@@ -1,0 +1,138 @@
+"""Unit tests for the block-runtime-writes PreToolUse hook.
+
+The hook blocks Edit/Write tool calls targeting .claude/runtime/ paths
+to prevent permission stalls in autonomous fleet operation. Checked-in
+README.md schema docs are exempted.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_SH = REPO_ROOT / ".claude" / "hooks" / "block-runtime-writes.sh"
+
+
+def _run_hook(file_path: str) -> subprocess.CompletedProcess[str]:
+    """Run the hook with a simulated tool_input payload."""
+    payload = json.dumps({"tool_input": {"file_path": file_path}})
+    return subprocess.run(
+        ["bash", str(HOOK_SH)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Blocked paths (exit 2)
+# ---------------------------------------------------------------------------
+
+
+class TestBlockedPaths:
+    """Runtime state files must be blocked."""
+
+    def test_relative_runtime_file(self) -> None:
+        r = _run_hook(".claude/runtime/review_state/last_merged_pr.txt")
+        assert r.returncode == 2
+        assert "BLOCKED" in r.stdout
+
+    def test_absolute_runtime_file(self) -> None:
+        r = _run_hook("/home/user/project/.claude/runtime/task_queue/packet.json")
+        assert r.returncode == 2
+        assert "BLOCKED" in r.stdout
+
+    def test_runtime_root_file(self) -> None:
+        r = _run_hook(".claude/runtime/permission_denials.jsonl")
+        assert r.returncode == 2
+        assert "BLOCKED" in r.stdout
+
+    def test_deeply_nested_runtime_file(self) -> None:
+        r = _run_hook(".claude/runtime/review_loops/pr_42/state.json")
+        assert r.returncode == 2
+        assert "BLOCKED" in r.stdout
+
+
+# ---------------------------------------------------------------------------
+# Exempt paths — checked-in README.md docs (exit 0)
+# ---------------------------------------------------------------------------
+
+
+class TestExemptReadmePaths:
+    """Checked-in README.md schema docs should pass through."""
+
+    def test_top_level_readme(self) -> None:
+        r = _run_hook(".claude/runtime/README.md")
+        assert r.returncode == 0
+        assert r.stdout == ""
+
+    def test_subdirectory_readme(self) -> None:
+        r = _run_hook(".claude/runtime/events/README.md")
+        assert r.returncode == 0
+        assert r.stdout == ""
+
+    def test_worktree_registry_readme(self) -> None:
+        r = _run_hook(".claude/runtime/worktree_registry/README.md")
+        assert r.returncode == 0
+        assert r.stdout == ""
+
+    def test_absolute_path_readme(self) -> None:
+        r = _run_hook("/home/user/project/.claude/runtime/session_metadata/README.md")
+        assert r.returncode == 0
+        assert r.stdout == ""
+
+    def test_absolute_top_level_readme(self) -> None:
+        r = _run_hook("/home/user/project/.claude/runtime/README.md")
+        assert r.returncode == 0
+        assert r.stdout == ""
+
+
+# ---------------------------------------------------------------------------
+# Allowed non-runtime paths (exit 0)
+# ---------------------------------------------------------------------------
+
+
+class TestAllowedPaths:
+    """Paths outside .claude/runtime/ should always be allowed."""
+
+    def test_source_file(self) -> None:
+        r = _run_hook("src/bid_euchre/ops/foo.py")
+        assert r.returncode == 0
+        assert r.stdout == ""
+
+    def test_claude_settings(self) -> None:
+        r = _run_hook(".claude/settings.json")
+        assert r.returncode == 0
+        assert r.stdout == ""
+
+    def test_claude_rules(self) -> None:
+        r = _run_hook(".claude/rules/10_workflow.md")
+        assert r.returncode == 0
+        assert r.stdout == ""
+
+    def test_empty_path(self) -> None:
+        """Empty file_path should exit 0 (not our concern)."""
+        payload = json.dumps({"tool_input": {"file_path": ""}})
+        r = subprocess.run(
+            ["bash", str(HOOK_SH)],
+            input=payload,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        assert r.returncode == 0
+
+    def test_missing_file_path(self) -> None:
+        """Missing file_path key should exit 0."""
+        payload = json.dumps({"tool_input": {}})
+        r = subprocess.run(
+            ["bash", str(HOOK_SH)],
+            input=payload,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        assert r.returncode == 0


### PR DESCRIPTION
## Summary

- Adds a README.md exemption pattern to `block-runtime-writes.sh` so checked-in
  schema docs under `.claude/runtime/` can be edited via Edit/Write tools
- Adds 14 regression tests covering blocked, exempt, and allowed path categories

## Why

The `block-runtime-writes.sh` PreToolUse hook (PR #2398) blocks all Edit/Write
to `.claude/runtime/` paths to prevent permission stalls. However, README.md
schema docs under `.claude/runtime/` are tracked in git (6 files total) and
should remain editable. The broad block pattern was catching these legitimate
writes.

## How it works

A new `case` branch matches `*/README.md` within `.claude/runtime/` (both
relative and absolute paths) and exits 0 before the general block pattern fires.
Order matters — specific exemption first, then general block.

## Repro / Validation

```bash
# Exempt: checked-in README.md passes through (exit 0)
echo '{"tool_input":{"file_path":".claude/runtime/events/README.md"}}' \
  | .claude/hooks/block-runtime-writes.sh; echo "Exit: $?"
# → Exit: 0

# Blocked: runtime state file is blocked (exit 2)
echo '{"tool_input":{"file_path":".claude/runtime/review_state/last_merged_pr.txt"}}' \
  | .claude/hooks/block-runtime-writes.sh; echo "Exit: $?"
# → BLOCKED message, Exit: 2

# Allowed: non-runtime path passes through (exit 0)
echo '{"tool_input":{"file_path":"src/bid_euchre/ops/foo.py"}}' \
  | .claude/hooks/block-runtime-writes.sh; echo "Exit: $?"
# → Exit: 0
```

## Tests

```bash
uv run python -m pytest tests/unit/test_block_runtime_writes_hook.py -v
# 14 passed in 0.67s
```

Note: `make check-gated` passes except for 3 pre-existing flaky failures in
`tests/unit/test_cpu_gate.py` (timeout under high CPU load — confirmed on
clean main, unrelated to this change).

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
branch: fix/runtime-docs-write-exemption
```

Fixes #2400

🤖 Generated with [Claude Code](https://claude.com/claude-code)