### PR TITLE
fix(web): exclude abandoned matches from GET /play fallback query

### DIFF
--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -1128,6 +1128,46 @@ class TestEdgeCases:
         )
         assert resp.status_code == 404
 
+    def test_abandoned_match_shows_model_select(self, client, app):
+        """Player whose only match is abandoned should see model-select, not
+        a stale game board that POST handlers will reject (#2410)."""
+        link_uuid = _setup_game(client)
+        # Mark the active match as abandoned (simulates cleanup / corruption)
+        session = app.state.session_factory()
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+        match_row = (
+            session.query(Match).filter_by(player_id=player.id, status="active").first()
+        )
+        assert match_row is not None
+        match_row.status = "abandoned"
+        session.commit()
+        session.close()
+
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        assert "model_select" in resp.text or "Choose" in resp.text
+
+    def test_complete_match_still_shown_as_fallback(self, client, app):
+        """Player whose only match is complete should see the match result
+        (not model-select), preserving the 'Play Again' flow (#2056)."""
+        link_uuid = _setup_game(client)
+        # Mark the active match as complete
+        session = app.state.session_factory()
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+        match_row = (
+            session.query(Match).filter_by(player_id=player.id, status="active").first()
+        )
+        assert match_row is not None
+        match_row.status = "complete"
+        session.commit()
+        session.close()
+
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        # Should NOT show model_select — should render the completed match
+        # (the response will contain game context, not the selection screen)
+        assert "model_select" not in resp.text
+
 
 # ---------------------------------------------------------------------------
 # XSS prevention (issue #1438)

--- a/web/routes.py
+++ b/web/routes.py
@@ -967,8 +967,11 @@ async def game_page(request: Request, link_uuid: str):
             )
 
         # Prefer the most recent *active* match so the reconnect prompt
-        # on the landing page and the game page agree.  Fall back to any
-        # match (e.g. completed) when no active match exists.  (#2056)
+        # on the landing page and the game page agree.  Fall back to a
+        # *complete* match when no active match exists so the player can
+        # see the result screen / "Play Again".  Abandoned matches are
+        # excluded — they would render a stale board whose POST handlers
+        # reject non-active state with 404.  (#2056, #2410)
         match_row = (
             session.query(Match)
             .filter_by(player_id=player.id, status="active")
@@ -978,7 +981,7 @@ async def game_page(request: Request, link_uuid: str):
         if match_row is None:
             match_row = (
                 session.query(Match)
-                .filter_by(player_id=player.id)
+                .filter_by(player_id=player.id, status="complete")
                 .order_by(Match.created_at.desc())
                 .first()
             )


### PR DESCRIPTION
## Summary

- The fallback match query in `game_page()` fetched the most recent match regardless of status
- When a player's only match was abandoned (via cleanup or corruption), this returned a stale game board that POST handlers rejected with 404 — trapping the player
- Now the fallback only returns `complete` matches, so players with only abandoned matches land on model-select

## Why

The TEST player (id=1) was blocked from playing — their abandoned match 40 was being served by the route fallback, and all POST actions (Next, bid, play card) rejected the non-active match state with 404 "No active match". Player could not start a new game.

## Changes

- `web/routes.py`: Add `status="complete"` filter to fallback query (line ~981)
- `tests/unit/hosted_play/test_routes.py`: Two new tests:
  - `test_abandoned_match_shows_model_select` — abandoned-only player sees model-select
  - `test_complete_match_still_shown_as_fallback` — complete match still shows result screen

## Validation

```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/hosted_play/test_routes.py -k "abandoned_match or complete_match_still" -v
# Result: 2 passed

# Full route test suite
uv run python -m pytest tests/unit/hosted_play/test_routes.py -v
# Result: 125 passed, 1 skipped

# Tier 2 — make check-gated
make check-gated
# Result: 11236 passed, 59 skipped, 3 failed (all in test_cpu_gate.py — pre-existing load-dependent failures)
```

## Acceptance Criteria

1. ✅ TEST player with abandoned match → sees model-select (not stale board)
2. ✅ Player with active match → sees game board (unchanged behavior)
3. ✅ Player with complete match → sees match result with "Play Again" (unchanged behavior)
4. ✅ New player with no matches → sees model-select (unchanged behavior)

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-analyst
branch: fix/web-abandoned-match-fallback
```

Refs #2410