### PR TITLE
fix(convention): remove dead Edit/Write(.claude/runtime/**) permission entries (#2407)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -156,8 +156,6 @@
       "Write(.claude/settings.json)",
       "Edit(.claude/hooks/**)",
       "Write(.claude/hooks/**)",
-      "Edit(.claude/runtime/**)",
-      "Write(.claude/runtime/**)",
       "Edit(MEMORY.md)",
       "Write(MEMORY.md)",
       "Edit(plans/**)",


### PR DESCRIPTION
## Summary
- Remove dead `Edit(.claude/runtime/**)` and `Write(.claude/runtime/**)` entries from `.claude/settings.json` `permissions.allow`

## Why
PR #2398 added a `block-runtime-writes.sh` PreToolUse hook that intercepts all Edit/Write operations targeting `.claude/runtime/` paths **before** `permissions.allow` is evaluated. The hook's own comment notes that Claude Code's platform-level `.claude/` path protection also fires before allow-list entries. These two entries are therefore dead code that mislead readers into thinking they're effective.

The same PR removed the narrower `Edit/Write(.claude/runtime/review_state/**)` entries but left the broader ones. This completes the cleanup.

## Repro / Validation
```bash
# Verify the entries are removed
grep -c "runtime" .claude/settings.json  # → 1 (only the hook ref, was 3)
```

## Tests
```bash
make check-gated   # 11,231 passed, 3 pre-existing cpu_gate timeouts (unrelated)
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: fix/remove-dead-permission-entries-2407
```

Fixes #2407