### PR TITLE
fix(convention): restrict README.md exemption to tracked schema docs (#2431)

### DIFF
--- a/.claude/hooks/block-runtime-writes.sh
+++ b/.claude/hooks/block-runtime-writes.sh
@@ -29,11 +29,32 @@ fi
 
 # Check if the path targets .claude/runtime/
 # Handle both absolute and relative paths
+#
+# README.md exemption: only the 6 git-tracked schema docs are exempt.
+# An arbitrary new README.md under .claude/runtime/ is NOT exempt — the
+# allowlist must be updated when a new tracked README is added.
+# Tracked README.md files (as of PR #2425):
+#   .claude/runtime/README.md
+#   .claude/runtime/events/README.md
+#   .claude/runtime/scheduler/README.md
+#   .claude/runtime/session_metadata/README.md
+#   .claude/runtime/task_state/README.md
+#   .claude/runtime/worktree_registry/README.md
+_TRACKED_DIRS="events scheduler session_metadata task_state worktree_registry"
 case "$FILE_PATH" in
-  */.claude/runtime/*/README.md|.claude/runtime/*/README.md|*/.claude/runtime/README.md|.claude/runtime/README.md)
-    # Checked-in schema docs (README.md) are safe to edit — exempt them
+  */.claude/runtime/README.md|.claude/runtime/README.md)
+    # Top-level runtime README.md — tracked schema doc
     exit 0
     ;;
+esac
+for _dir in $_TRACKED_DIRS; do
+  case "$FILE_PATH" in
+    */.claude/runtime/"$_dir"/README.md|.claude/runtime/"$_dir"/README.md)
+      exit 0
+      ;;
+  esac
+done
+case "$FILE_PATH" in
   */.claude/runtime/*|.claude/runtime/*)
     cat <<BLOCK
 BLOCKED: Edit/Write to .claude/runtime/ is not allowed.

--- a/tests/unit/test_block_runtime_writes_hook.py
+++ b/tests/unit/test_block_runtime_writes_hook.py
@@ -55,6 +55,18 @@ class TestBlockedPaths:
         assert r.returncode == 2
         assert "BLOCKED" in r.stdout
 
+    def test_arbitrary_subdir_readme_blocked(self) -> None:
+        """README.md in an untracked subdirectory must be blocked (#2431)."""
+        r = _run_hook(".claude/runtime/arbitrary_new_dir/README.md")
+        assert r.returncode == 2
+        assert "BLOCKED" in r.stdout
+
+    def test_absolute_arbitrary_subdir_readme_blocked(self) -> None:
+        """Absolute path to README.md in untracked subdir must be blocked (#2431)."""
+        r = _run_hook("/home/user/project/.claude/runtime/unknown_dir/README.md")
+        assert r.returncode == 2
+        assert "BLOCKED" in r.stdout
+
 
 # ---------------------------------------------------------------------------
 # Exempt paths — checked-in README.md docs (exit 0)


### PR DESCRIPTION
## Plan
N/A — convention follow-up from PR #2425 review

## Summary
- Replace wildcard README.md exemption in `block-runtime-writes.sh` with an
  enumerated allowlist of the 6 git-tracked schema docs
- Add 2 regression tests ensuring README.md in arbitrary/untracked subdirs is blocked

## Why

The original wildcard pattern `*/.claude/runtime/*/README.md` exempted any
README.md under `.claude/runtime/`, which could be exploited to bypass the
write blocker by creating a README.md in an arbitrary new subdirectory. The
allowlist approach only exempts the 6 known tracked schema docs and requires
explicit updates when new tracked README.md files are added.

## Repro / Validation

```bash
# Arbitrary subdir README.md is now blocked
echo '{"tool_input":{"file_path":".claude/runtime/arbitrary_new_dir/README.md"}}' \
  | bash .claude/hooks/block-runtime-writes.sh; echo "Exit: $?"
# → BLOCKED, Exit: 2

# Tracked schema docs still exempt
echo '{"tool_input":{"file_path":".claude/runtime/events/README.md"}}' \
  | bash .claude/hooks/block-runtime-writes.sh; echo "Exit: $?"
# → Exit: 0
```

## Test Criteria
- **Pass condition:** README.md in untracked subdirectories is blocked (exit 2), tracked schema docs are exempt (exit 0)
- **Verification command:** `uv run python -m pytest tests/unit/test_block_runtime_writes_hook.py -v`
- **Expected result:** 16 passed (including 2 new arbitrary-subdir tests)

## Tests
- [x] `uv run python -m pytest tests/unit/test_block_runtime_writes_hook.py -v` — 16 passed
- [x] `make check-quiet` — 11,257 passed (3 pre-existing flaky cpu_gate failures, unrelated)

## Expected impact
- Metrics impact: None
- Runtime impact: None — hook overhead unchanged

## Risk level
- [x] Low (convention/security hardening only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git worktree list` (relevant entry):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a   10405ef5 [fix/restrict-readme-exemption]
```

## Issue Linkage
Fixes #2431

## Checklist
- [x] No generated artifacts committed
- [x] Behavior changed, tests updated (2 new tests for arbitrary-subdir blocking)
- [x] PR is focused (one concept)
- [x] Issue linkage uses correct keyword (`Fixes` — this fully resolves the convention follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)