### PR TITLE
fix(web): use suit symbols in auction log instead of letter abbreviations

### DIFF
--- a/tests/unit/hosted_play/test_format_auction_event.py
+++ b/tests/unit/hosted_play/test_format_auction_event.py
@@ -1,0 +1,67 @@
+"""Unit tests for _format_auction_event() in web/routes.py.
+
+Verifies that auction log entries use Unicode suit symbols (♠, ♥, ♦, ♣)
+instead of letter abbreviations (S, H, D, C).
+
+Fix for issue #2417.
+"""
+
+from __future__ import annotations
+
+from web.routes import _format_auction_event
+
+
+class TestFormatAuctionEventPass:
+    """Pass actions render as '<Name> passed'."""
+
+    def test_pass(self):
+        assert _format_auction_event(1, {"action": "pass"}) == "Slim passed"
+
+
+class TestFormatAuctionEventMoonLoner:
+    """Moon and loner bids render without suit."""
+
+    def test_moon(self):
+        result = _format_auction_event(
+            0, {"bid_type": "moon", "n": 10, "contract": "S"}
+        )
+        assert result == "You bid Moon"
+
+    def test_loner(self):
+        result = _format_auction_event(
+            3, {"bid_type": "loner", "n": 10, "contract": "H"}
+        )
+        assert result == "Deuce bid Loner"
+
+
+class TestFormatAuctionEventHighLow:
+    """HIGH and LOW contracts render as words."""
+
+    def test_high(self):
+        result = _format_auction_event(2, {"n": 6, "contract": "HIGH"})
+        assert result == "Ace bid 6 High"
+
+    def test_low(self):
+        result = _format_auction_event(1, {"n": 5, "contract": "LOW"})
+        assert result == "Slim bid 5 Low"
+
+
+class TestFormatAuctionEventSuitSymbols:
+    """Suit contracts use Unicode symbols, not letter abbreviations (#2417)."""
+
+    def test_spades(self):
+        result = _format_auction_event(1, {"n": 5, "contract": "S"})
+        assert result == "Slim bid 5 ♠"
+        assert "S" not in result.split("bid")[1]  # no raw letter after "bid"
+
+    def test_hearts(self):
+        result = _format_auction_event(0, {"n": 6, "contract": "H"})
+        assert result == "You bid 6 ♥"
+
+    def test_diamonds(self):
+        result = _format_auction_event(2, {"n": 8, "contract": "D"})
+        assert result == "Ace bid 8 ♦"
+
+    def test_clubs(self):
+        result = _format_auction_event(3, {"n": 7, "contract": "C"})
+        assert result == "Deuce bid 7 ♣"

--- a/web/routes.py
+++ b/web/routes.py
@@ -334,7 +334,7 @@ def _format_auction_event(seat: int | None, action: dict[str, Any]) -> str:
     elif contract == "LOW":
         contract_label = "Low"
     else:
-        contract_label = str(contract)
+        contract_label = _SUIT_SYMBOLS.get(str(contract), str(contract))
     return f"{seat_label} bid {n} {contract_label}"
 
 


### PR DESCRIPTION
## Plan
N/A — bounded cosmetic fix

## Summary
- Replace raw letter abbreviations (S, H, D, C) with Unicode suit symbols (♠, ♥, ♦, ♣) in the auction log's `_format_auction_event()` function
- Add comprehensive unit tests for all branches of `_format_auction_event()`

## Why
The auction log was the only UI element still showing raw letter abbreviations for suits. All other elements (trick history, contract bar, hand result) already use Unicode symbols. This inconsistency was found during go-live checklist proving.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_format_auction_event.py -v
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** All 4 suit contracts in `_format_auction_event()` return Unicode symbols, not letters
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_format_auction_event.py::TestFormatAuctionEventSuitSymbols -v`
- **Expected result:** 4 tests pass — spades (♠), hearts (♥), diamonds (♦), clubs (♣)

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_format_auction_event.py -v` (9 passed)
- [x] `uv run python -m pytest tests/unit/hosted_play/test_seat_bids.py tests/unit/hosted_play/test_partials.py -v` (257 passed)
- [x] `make check-gated` (11,254 passed, 4 pre-existing infra flakes unrelated to change)

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author  a1cf359b [fix/auction-log-suit-symbols]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Issue Linkage
Fixes #2417

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
- [x] Issue linkage uses correct keyword (`Fixes` vs `Refs`) per closure policy