### PR TITLE
fix(ci): add schedule + dispatch triggers for main validation (#2363)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,15 @@ on:
     # gating, and the `tests` aggregation gate passes on all-skipped upstream.
   push:
     branches: [ "main" ]
+  schedule:
+    # Daily at 06:00 UTC — safety-net validation for main.
+    # Why: GitHub's auto-merge uses GITHUB_TOKEN, and push events from
+    # GITHUB_TOKEN do not trigger workflows (anti-recursion rule). When the
+    # fleet auto-merges PRs, no push-to-main CI runs. This schedule ensures
+    # main is validated at least daily. See #2363.
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+    # Manual trigger for on-demand main validation (e.g., after fleet runs).
 
 concurrency:
   group: ci-${{ github.event_name == 'push' && github.sha || github.event.pull_request.number || github.ref }}
@@ -48,13 +57,11 @@ jobs:
     needs: [changes]
     if: >-
       always() && !cancelled() &&
-      (github.event_name == 'push' ||
-       (github.event_name == 'pull_request' &&
-        !(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
-          startsWith(github.head_ref, 'chore/auto-dashboard')))) &&
-      (github.event_name == 'push' ||
-       needs.changes.outputs.code_changed == 'true' ||
-       needs.changes.outputs.notebooks_changed == 'true')
+      (github.event_name != 'pull_request' ||
+       (!(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
+          startsWith(github.head_ref, 'chore/auto-dashboard')) &&
+        (needs.changes.outputs.code_changed == 'true' ||
+         needs.changes.outputs.notebooks_changed == 'true')))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -93,12 +100,10 @@ jobs:
     needs: [changes]
     if: >-
       always() && !cancelled() &&
-      (github.event_name == 'push' ||
-       (github.event_name == 'pull_request' &&
-        !(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
-          startsWith(github.head_ref, 'chore/auto-dashboard')))) &&
-      (github.event_name == 'push' ||
-       needs.changes.outputs.code_changed == 'true')
+      (github.event_name != 'pull_request' ||
+       (!(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
+          startsWith(github.head_ref, 'chore/auto-dashboard')) &&
+        needs.changes.outputs.code_changed == 'true'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -134,12 +139,10 @@ jobs:
     needs: [changes]
     if: >-
       always() && !cancelled() &&
-      (github.event_name == 'push' ||
-       (github.event_name == 'pull_request' &&
-        !(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
-          startsWith(github.head_ref, 'chore/auto-dashboard')))) &&
-      (github.event_name == 'push' ||
-       needs.changes.outputs.notebooks_changed == 'true')
+      (github.event_name != 'pull_request' ||
+       (!(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
+          startsWith(github.head_ref, 'chore/auto-dashboard')) &&
+        needs.changes.outputs.notebooks_changed == 'true'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -169,12 +172,10 @@ jobs:
     needs: [changes]
     if: >-
       always() && !cancelled() &&
-      (github.event_name == 'push' ||
-       (github.event_name == 'pull_request' &&
-        !(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
-          startsWith(github.head_ref, 'chore/auto-dashboard')))) &&
-      (github.event_name == 'push' ||
-       needs.changes.outputs.code_changed == 'true') &&
+      (github.event_name != 'pull_request' ||
+       (!(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
+          startsWith(github.head_ref, 'chore/auto-dashboard')) &&
+        needs.changes.outputs.code_changed == 'true')) &&
       contains(github.event.pull_request.labels.*.name, 'promotion')
     runs-on: ubuntu-latest
     steps:
@@ -222,10 +223,9 @@ jobs:
     needs: [changes, checks, tests-shard, notebooks, promotion-gate]
     if: >-
       always() &&
-      (github.event_name == 'push' ||
-       (github.event_name == 'pull_request' &&
-        !(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
-          startsWith(github.head_ref, 'chore/auto-dashboard'))))
+      (github.event_name != 'pull_request' ||
+       !(contains(github.event.pull_request.title, 'chore: update PR analytics dashboard') ||
+         startsWith(github.head_ref, 'chore/auto-dashboard')))
     runs-on: ubuntu-latest
     steps:
       - name: Skip notice

--- a/tests/unit/test_ci_workflow.py
+++ b/tests/unit/test_ci_workflow.py
@@ -66,8 +66,13 @@ class TestCIWorkflowStructure:
             if_expr = str(self.jobs[job_name].get("if", ""))
             assert skip_marker in if_expr, f"{job_name} missing skip marker"
             assert branch_marker in if_expr, f"{job_name} missing branch marker"
+            # Non-PR events (push, schedule, workflow_dispatch) run
+            # unconditionally — the if condition must distinguish PR events
             if job_name != "tests":
-                assert "github.event_name == 'push'" in if_expr
+                assert (
+                    "github.event_name != 'pull_request'" in if_expr
+                    or "github.event_name == 'push'" in if_expr
+                ), f"{job_name} missing event-type guard"
 
     def test_tests_shard_is_2_way_matrix(self) -> None:
         """tests-shard uses a 2-way matrix split via pytest-split."""
@@ -125,6 +130,22 @@ class TestCIWorkflowStructure:
             assert "install" not in name.lower()
             assert "checkout" not in name.lower()
             assert "setup" not in name.lower()
+
+    def test_schedule_and_dispatch_triggers_exist(self) -> None:
+        """CI must have schedule + workflow_dispatch for main validation.
+
+        GitHub's auto-merge uses GITHUB_TOKEN, and push events from
+        GITHUB_TOKEN do not trigger workflows (anti-recursion). The
+        schedule trigger ensures main is validated at least daily, and
+        workflow_dispatch allows on-demand runs. See #2363.
+        """
+        triggers = self.workflow[True]  # 'on' key parsed as True by yaml
+        assert "schedule" in triggers, "Missing schedule trigger"
+        assert "workflow_dispatch" in triggers, "Missing workflow_dispatch trigger"
+        # Schedule must have a cron entry
+        schedules = triggers["schedule"]
+        assert len(schedules) >= 1
+        assert "cron" in schedules[0]
 
     def test_concurrency_group_unique_per_push(self) -> None:
         """Push events to main must get unique concurrency groups (#2363).


### PR DESCRIPTION
## Summary

- Add daily `schedule` trigger (06:00 UTC) and `workflow_dispatch` trigger to CI workflow
- Simplify all job `if` conditions to handle non-PR events uniformly
- Update CI workflow structure tests for the new patterns

## Why

GitHub's auto-merge uses `GITHUB_TOKEN`, and **push events from `GITHUB_TOKEN` do not trigger workflows** (GitHub's anti-recursion rule). When the fleet auto-merges PRs via `github-actions[bot]`, no push-to-main CI runs occur. Evidence:

| Merged by | Push CI triggers? |
|-----------|------------------|
| `Questuart` (human) | ✅ Yes |
| `github-actions[bot]` (auto-merge) | ❌ No |

This has left 30+ commits on main without post-merge CI validation since 2026-04-04.

### Root cause

The `auto-merge.yml` workflow enables squash auto-merge using `secrets.GITHUB_TOKEN`. When GitHub's auto-merge feature merges the PR, the resulting push to main comes from `github-actions[bot]`, which triggers GitHub's [anti-recursion rule](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow):

> Events triggered by the GITHUB_TOKEN will not create a new workflow run.

### Fix

1. **`schedule` trigger** — daily at 06:00 UTC ensures main is validated at least daily
2. **`workflow_dispatch` trigger** — allows on-demand CI runs after fleet operations
3. **Simplified `if` conditions** — changed `github.event_name == 'push'` to `github.event_name != 'pull_request'` so push, schedule, and workflow_dispatch all run jobs unconditionally

## Repro / Validation

```bash
# Verify YAML syntax
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"

# Run CI workflow structure tests
uv run python -m pytest tests/unit/test_ci_workflow.py -v
# → 12 passed

# Verify no regression in full suite
make check-gated
```

## Tests

- `tests/unit/test_ci_workflow.py` — all 12 tests pass (including new `test_schedule_and_dispatch_triggers_exist`)
- Updated `test_dashboard_chore_prs_skip_ci_jobs` for new `if` pattern

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
git rev-parse --show-toplevel: .../Bid-Euchre-steward-author-d
Branch: fix/ci-scheduled-main-validation
```

Refs #2363

🤖 Generated with [Claude Code](https://claude.com/claude-code)