### PR TITLE
fix(ops): make check-gated the default Tier 2 validation command

### DIFF
--- a/.claude/agents/repair.md
+++ b/.claude/agents/repair.md
@@ -34,7 +34,7 @@ file issues — you fix them.
 
 6. **Validate thoroughly.**
    - Tier 1: Run targeted tests for the affected module
-   - Tier 2: Run `make check-quiet` before opening the PR
+   - Tier 2: Run `make check-gated` before opening the PR
 
 7. **Use repair PR conventions.**
    - Title: `fix(repair): <short description>`

--- a/.claude/agents/steward-author-a.md
+++ b/.claude/agents/steward-author-a.md
@@ -45,7 +45,7 @@ clarification before starting.
 1. **Scope lock** — read the plan or sub-plan (if referenced), confirm file
    scope matches the task packet
 2. **Implement** — make changes within declared scope only
-3. **Validate** — Tier 1 tests during development, Tier 2 (`make check-quiet`)
+3. **Validate** — Tier 1 tests during development, Tier 2 (`make check-gated`)
    before PR
 4. **PR** — open with worktree proof, repro command, and validation evidence
 5. **Handoff** — update checkpoints / MEMORY.md as appropriate
@@ -97,5 +97,5 @@ surfaces your state to the operator.
 ## Validation Expectations
 
 - **Tier 1 (during dev):** `uv run python -m pytest tests/unit/test_<module>.py`
-- **Tier 2 (before PR):** `make check-quiet`
+- **Tier 2 (before PR):** `make check-gated`
 - See `.claude/rules/15_testing_tiers.md` for the full policy.

--- a/.claude/agents/steward-author-b.md
+++ b/.claude/agents/steward-author-b.md
@@ -45,7 +45,7 @@ clarification before starting.
 1. **Scope lock** — read the plan or sub-plan (if referenced), confirm file
    scope matches the task packet
 2. **Implement** — make changes within declared scope only
-3. **Validate** — Tier 1 tests during development, Tier 2 (`make check-quiet`)
+3. **Validate** — Tier 1 tests during development, Tier 2 (`make check-gated`)
    before PR
 4. **PR** — open with worktree proof, repro command, and validation evidence
 5. **Handoff** — update checkpoints / MEMORY.md as appropriate
@@ -97,5 +97,5 @@ surfaces your state to the operator.
 ## Validation Expectations
 
 - **Tier 1 (during dev):** `uv run python -m pytest tests/unit/test_<module>.py`
-- **Tier 2 (before PR):** `make check-quiet`
+- **Tier 2 (before PR):** `make check-gated`
 - See `.claude/rules/15_testing_tiers.md` for the full policy.

--- a/.claude/agents/steward-author-c.md
+++ b/.claude/agents/steward-author-c.md
@@ -45,7 +45,7 @@ clarification before starting.
 1. **Scope lock** — read the plan or sub-plan (if referenced), confirm file
    scope matches the task packet
 2. **Implement** — make changes within declared scope only
-3. **Validate** — Tier 1 tests during development, Tier 2 (`make check-quiet`)
+3. **Validate** — Tier 1 tests during development, Tier 2 (`make check-gated`)
    before PR
 4. **PR** — open with worktree proof, repro command, and validation evidence
 5. **Handoff** — update checkpoints / MEMORY.md as appropriate
@@ -97,5 +97,5 @@ surfaces your state to the operator.
 ## Validation Expectations
 
 - **Tier 1 (during dev):** `uv run python -m pytest tests/unit/test_<module>.py`
-- **Tier 2 (before PR):** `make check-quiet`
+- **Tier 2 (before PR):** `make check-gated`
 - See `.claude/rules/15_testing_tiers.md` for the full policy.

--- a/.claude/agents/steward-author-d.md
+++ b/.claude/agents/steward-author-d.md
@@ -45,7 +45,7 @@ clarification before starting.
 1. **Scope lock** — read the plan or sub-plan (if referenced), confirm file
    scope matches the task packet
 2. **Implement** — make changes within declared scope only
-3. **Validate** — Tier 1 tests during development, Tier 2 (`make check-quiet`)
+3. **Validate** — Tier 1 tests during development, Tier 2 (`make check-gated`)
    before PR
 4. **PR** — open with worktree proof, repro command, and validation evidence
 5. **Handoff** — update checkpoints / MEMORY.md as appropriate
@@ -97,5 +97,5 @@ surfaces your state to the operator.
 ## Validation Expectations
 
 - **Tier 1 (during dev):** `uv run python -m pytest tests/unit/test_<module>.py`
-- **Tier 2 (before PR):** `make check-quiet`
+- **Tier 2 (before PR):** `make check-gated`
 - See `.claude/rules/15_testing_tiers.md` for the full policy.

--- a/.claude/agents/steward-brws-author-a.md
+++ b/.claude/agents/steward-brws-author-a.md
@@ -47,7 +47,7 @@ clarification before starting.
 1. **Scope lock** — read the plan or sub-plan (if referenced), confirm file
    scope matches the task packet
 2. **Implement** — make changes within declared scope only
-3. **Validate** — Tier 1 tests during development, Tier 2 (`make check-quiet`)
+3. **Validate** — Tier 1 tests during development, Tier 2 (`make check-gated`)
    before PR
 4. **PR** — open with worktree proof, repro command, and validation evidence
 5. **Handoff** — update checkpoints / MEMORY.md as appropriate
@@ -99,5 +99,5 @@ surfaces your state to the operator.
 ## Validation Expectations
 
 - **Tier 1 (during dev):** `uv run python -m pytest tests/unit/test_<module>.py`
-- **Tier 2 (before PR):** `make check-quiet`
+- **Tier 2 (before PR):** `make check-gated`
 - See `.claude/rules/15_testing_tiers.md` for the full policy.

--- a/.claude/agents/steward-brws-author-b.md
+++ b/.claude/agents/steward-brws-author-b.md
@@ -47,7 +47,7 @@ clarification before starting.
 1. **Scope lock** — read the plan or sub-plan (if referenced), confirm file
    scope matches the task packet
 2. **Implement** — make changes within declared scope only
-3. **Validate** — Tier 1 tests during development, Tier 2 (`make check-quiet`)
+3. **Validate** — Tier 1 tests during development, Tier 2 (`make check-gated`)
    before PR
 4. **PR** — open with worktree proof, repro command, and validation evidence
 5. **Handoff** — update checkpoints / MEMORY.md as appropriate
@@ -99,5 +99,5 @@ surfaces your state to the operator.
 ## Validation Expectations
 
 - **Tier 1 (during dev):** `uv run python -m pytest tests/unit/test_<module>.py`
-- **Tier 2 (before PR):** `make check-quiet`
+- **Tier 2 (before PR):** `make check-gated`
 - See `.claude/rules/15_testing_tiers.md` for the full policy.

--- a/.claude/agents/steward-brws-author-c.md
+++ b/.claude/agents/steward-brws-author-c.md
@@ -47,7 +47,7 @@ clarification before starting.
 1. **Scope lock** — read the plan or sub-plan (if referenced), confirm file
    scope matches the task packet
 2. **Implement** — make changes within declared scope only
-3. **Validate** — Tier 1 tests during development, Tier 2 (`make check-quiet`)
+3. **Validate** — Tier 1 tests during development, Tier 2 (`make check-gated`)
    before PR
 4. **PR** — open with worktree proof, repro command, and validation evidence
 5. **Handoff** — update checkpoints / MEMORY.md as appropriate
@@ -99,5 +99,5 @@ surfaces your state to the operator.
 ## Validation Expectations
 
 - **Tier 1 (during dev):** `uv run python -m pytest tests/unit/test_<module>.py`
-- **Tier 2 (before PR):** `make check-quiet`
+- **Tier 2 (before PR):** `make check-gated`
 - See `.claude/rules/15_testing_tiers.md` for the full policy.

--- a/.claude/agents/steward-brws-author-d.md
+++ b/.claude/agents/steward-brws-author-d.md
@@ -47,7 +47,7 @@ clarification before starting.
 1. **Scope lock** — read the plan or sub-plan (if referenced), confirm file
    scope matches the task packet
 2. **Implement** — make changes within declared scope only
-3. **Validate** — Tier 1 tests during development, Tier 2 (`make check-quiet`)
+3. **Validate** — Tier 1 tests during development, Tier 2 (`make check-gated`)
    before PR
 4. **PR** — open with worktree proof, repro command, and validation evidence
 5. **Handoff** — update checkpoints / MEMORY.md as appropriate
@@ -99,5 +99,5 @@ surfaces your state to the operator.
 ## Validation Expectations
 
 - **Tier 1 (during dev):** `uv run python -m pytest tests/unit/test_<module>.py`
-- **Tier 2 (before PR):** `make check-quiet`
+- **Tier 2 (before PR):** `make check-gated`
 - See `.claude/rules/15_testing_tiers.md` for the full policy.

--- a/.claude/agents/steward-flex-a.md
+++ b/.claude/agents/steward-flex-a.md
@@ -47,7 +47,7 @@ clarification before starting.
 1. **Scope lock** — read the plan or sub-plan (if referenced), confirm file
    scope matches the task packet
 2. **Implement** — make changes within declared scope only
-3. **Validate** — Tier 1 tests during development, Tier 2 (`make check-quiet`)
+3. **Validate** — Tier 1 tests during development, Tier 2 (`make check-gated`)
    before PR
 4. **PR** — open with worktree proof, repro command, and validation evidence
 5. **Handoff** — update checkpoints / MEMORY.md as appropriate
@@ -86,5 +86,5 @@ operator attention unless all dedicated pools are exhausted.
 ## Validation Expectations
 
 - **Tier 1 (during dev):** `uv run python -m pytest tests/unit/test_<module>.py`
-- **Tier 2 (before PR):** `make check-quiet`
+- **Tier 2 (before PR):** `make check-gated`
 - See `.claude/rules/15_testing_tiers.md` for the full policy.

--- a/.claude/agents/steward-flex-b.md
+++ b/.claude/agents/steward-flex-b.md
@@ -47,7 +47,7 @@ clarification before starting.
 1. **Scope lock** — read the plan or sub-plan (if referenced), confirm file
    scope matches the task packet
 2. **Implement** — make changes within declared scope only
-3. **Validate** — Tier 1 tests during development, Tier 2 (`make check-quiet`)
+3. **Validate** — Tier 1 tests during development, Tier 2 (`make check-gated`)
    before PR
 4. **PR** — open with worktree proof, repro command, and validation evidence
 5. **Handoff** — update checkpoints / MEMORY.md as appropriate
@@ -86,5 +86,5 @@ operator attention unless all dedicated pools are exhausted.
 ## Validation Expectations
 
 - **Tier 1 (during dev):** `uv run python -m pytest tests/unit/test_<module>.py`
-- **Tier 2 (before PR):** `make check-quiet`
+- **Tier 2 (before PR):** `make check-gated`
 - See `.claude/rules/15_testing_tiers.md` for the full policy.

--- a/.claude/agents/steward-flex-c.md
+++ b/.claude/agents/steward-flex-c.md
@@ -47,7 +47,7 @@ clarification before starting.
 1. **Scope lock** — read the plan or sub-plan (if referenced), confirm file
    scope matches the task packet
 2. **Implement** — make changes within declared scope only
-3. **Validate** — Tier 1 tests during development, Tier 2 (`make check-quiet`)
+3. **Validate** — Tier 1 tests during development, Tier 2 (`make check-gated`)
    before PR
 4. **PR** — open with worktree proof, repro command, and validation evidence
 5. **Handoff** — update checkpoints / MEMORY.md as appropriate
@@ -86,5 +86,5 @@ operator attention unless all dedicated pools are exhausted.
 ## Validation Expectations
 
 - **Tier 1 (during dev):** `uv run python -m pytest tests/unit/test_<module>.py`
-- **Tier 2 (before PR):** `make check-quiet`
+- **Tier 2 (before PR):** `make check-gated`
 - See `.claude/rules/15_testing_tiers.md` for the full policy.

--- a/.claude/hooks/compact-context.sh
+++ b/.claude/hooks/compact-context.sh
@@ -6,7 +6,7 @@ cat <<'CONTEXT'
 ## Critical Context (re-injected after compaction)
 
 1. **Worktree-only workflow**: All code changes MUST happen in git worktrees, never on main in the shared checkout. Pre-commit hooks enforce this.
-2. **make check composition**: repo-lint + ruff + pytest + notebook-check + docs-check (all 5 must pass before PRs; use `make check-quiet` for minimal output)
+2. **make check composition**: repo-lint + ruff + pytest + notebook-check + docs-check (all 5 must pass before PRs; use `make check-gated` for concurrency-capped fleet runs)
 3. **Python runner**: Always use `uv run` (not raw `python` or `pip`)
 4. **Seed required**: Experiments need `--seed <int>` for determinism
 5. **Data policy**: Never commit `data/runs/`, `data/reports/`, `data/models/`

--- a/.claude/rules/10_workflow.md
+++ b/.claude/rules/10_workflow.md
@@ -7,7 +7,8 @@
 Before any PR (Tier 2):
 
     git fetch origin main && git rebase origin/main   # Avoid stale-base conflicts
-    make check-quiet    # Full validation, minimal output (logs to tmpfile)
+    make check-gated    # Full validation with concurrency cap (default for fleet)
+    make check-quiet    # Same validation, no concurrency cap (single-lane debugging)
     make check          # Full validation, full output
 
 During implementation (Tier 1):
@@ -21,7 +22,7 @@ See @.claude/rules/15_testing_tiers.md for the full 2-tier testing policy.
 
 - **Diffs**: Default to `git diff --stat` for PR scope overview; read targeted hunks only when needed.
 - **File reads**: Avoid unnecessary re-reads of files already loaded in context (re-read after rebases, generated changes, or concurrent edits).
-- **Validation**: Use `make check-quiet` (not `make check`) as the default pre-PR command.
+- **Validation**: Use `make check-gated` (not `make check`) as the default pre-PR command.
 
 ## Smoke Experiment (Optional)
 
@@ -37,6 +38,6 @@ uv run python experiments/run_experiment.py \
 1. **Use canonical runner only** — `experiments/run_experiment.py` + YAML configs
 2. **Do not create new top-level directories** without explicit instruction
 3. **Library code in `src/`** — CLI scripts go in `scripts/` or `experiments/`
-4. **Run `make check` (or `make check-quiet`) before claiming PR is done**
+4. **Run `make check-gated` (or `make check`) before claiming PR is done**
 
 See @docs/02_agent/AGENTS.md for full workflow details.

--- a/.claude/rules/deferred/40_prs.md
+++ b/.claude/rules/deferred/40_prs.md
@@ -21,7 +21,7 @@ From @docs/02_agent/REVIEW_CHECKLIST.md:
 
 - [ ] Branch based on main
 - [ ] Scope lock — only touched declared files
-- [ ] `make check` (or `make check-quiet`) passes
+- [ ] `make check-gated` (or `make check`) passes
 - [ ] No artifacts in `data/runs/` or `data/reports/`
 - [ ] Exact repro command in PR description
 - [ ] Contract compliance (if touching rules/logging/metrics)

--- a/.claude/skills/debugging-ci/SKILL.md
+++ b/.claude/skills/debugging-ci/SKILL.md
@@ -56,7 +56,7 @@ See [SYMPTOM_TABLE.md](SYMPTOM_TABLE.md) for the full lookup table. Quick refere
 ## Gotchas
 
 - `make check` runs 5 sub-checks sequentially (repo-lint, ruff, pytest, notebook-check, docs-check) — read the output to identify WHICH one failed
-- `make check-quiet` logs to a tmpfile — on failure, read that file for details
+- `make check-gated` / `make check-quiet` log to a tmpfile — on failure, read that file for details
 - Review loop crashes are silent — always check state.json when status is stuck
 - `set_review_status.sh` requires the PR's HEAD SHA — it reads it automatically from git
 - Don't retry the same command hoping for a different result — diagnose the root cause

--- a/.claude/skills/lane-status/SKILL.md
+++ b/.claude/skills/lane-status/SKILL.md
@@ -130,7 +130,7 @@ done
 
 - ❌ Reading only `tail -8` or `tail -12` of pane capture (hits status bar)
 - ❌ Assuming idle prompt = lane is idle (status bar always shows `❯`)
-- ❌ Nudging a lane that's mid-`make check-quiet` (interrupts validation)
+- ❌ Nudging a lane that's mid-`make check-gated` (interrupts validation)
 - ❌ Treating "Sautéed for Xm" as idle without checking if a new tool call follows
 - ❌ Checking worktree state without checking pane state (dirty could mean mid-work)
 

--- a/.claude/skills/reviewing-changes/SKILL.md
+++ b/.claude/skills/reviewing-changes/SKILL.md
@@ -53,7 +53,7 @@ If the script is not found, skip and note in the handoff.
 The autonomous review loop is triggered by the PostToolUse hook (`post-pr-review-loop.sh`).
 It runs asynchronously and handles:
 - Deterministic prechecks (C1/C2/N1/N2/N3/X2/X3)
-- `make check-quiet`
+- `make check-gated`
 - Codex CLI review + auto-fix loop (max 3 iterations)
 - Final status publishing (success/failure)
 - Follow-up issue creation for P2 findings

--- a/.claude/skills/start-task/SKILL.md
+++ b/.claude/skills/start-task/SKILL.md
@@ -134,12 +134,12 @@ If you are an analyst lane and the task is research/investigation:
    ```
 
 > **⚠ Run validation in foreground — never background.**
-> `make check-quiet` redirects all output to a tmpfile. If you run it as a
-> background task, the background capture sees 0 bytes of output. The lane
-> then interprets this as "nothing happened" and starts a second foreground
-> `make check`, causing duplicate processes that double CPU/IO load and
-> inflate validation from ~8 min to 28+ min. Always run `make check-quiet`
-> or `make check-gated` as a **foreground** Bash command.
+> `make check-gated` and `make check-quiet` redirect all output to a tmpfile.
+> If you run either as a background task, the background capture sees 0 bytes
+> of output. The lane then interprets this as "nothing happened" and starts a
+> second foreground `make check`, causing duplicate processes that double
+> CPU/IO load and inflate validation from ~8 min to 28+ min. Always run
+> `make check-gated` (or `make check-quiet`) as a **foreground** Bash command.
 
 ### Phase 3 — Scope Lock
 
@@ -233,7 +233,7 @@ back to `CLAUDE_PROJECT_DIR` directory name parsing.
   the orchestrator to fill it in
 - Author lanes are background in the dashboard — the operator sees your status
   automatically; focus on the task, not on reporting visibility
-- **Never run `make check-quiet` or `make check-gated` as a background task.**
+- **Never run `make check-gated` or `make check-quiet` as a background task.**
   These variants redirect output to tmpfiles — background capture gets 0 bytes,
   which causes the lane to spawn a duplicate foreground process. Always run
   validation in foreground. (See #2271 for the incident report.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Bid Euchre AI Research Framework — a Python framework for deterministic simula
 ### Pre-Commit Checklist
 
 - Run `git fetch origin main && git rebase origin/main` before opening a PR to avoid stale-base conflicts.
-- Run full `make check` (or equivalent test suite) before creating any PR.
+- Run full `make check-gated` (or `make check`) before creating any PR.
 - Verify no uncommitted notebook changes that would trigger git diff checks.
 - Run linter (`ruff check --fix`) and formatter (`ruff format`) on all changed files.
 
@@ -76,8 +76,9 @@ make sync               # Install dependencies (uses uv sync)
 ```
 
 ```bash
-make check              # Full validation: repo-lint + ruff + pytest + notebook-check + docs-check (run before PRs)
-make check-quiet        # Same validation, minimal output (logs to tmpfile)
+make check-gated        # Full validation with concurrency cap (default for fleet — run before PRs)
+make check-quiet        # Same validation, minimal output, no concurrency cap (single-lane debugging)
+make check              # Full validation, full output (interactive debugging)
 make test               # Pytest fast suite only
 make lint               # Ruff check only
 make repo-lint          # Repo boundary linter only
@@ -202,7 +203,7 @@ All code changes MUST happen in dedicated git worktrees, never on `main` in the 
 
 ### PR Requirements
 - One concept per PR
-- Run `make check` before opening
+- Run `make check-gated` before opening
 - Include exact repro command with seed in PR description
 - Use the PR template from `.github/pull_request_template.md`
 - **Define test criteria** — every PR must include specific, verifiable pass/fail conditions (not just "tests pass"). State what observable outcome proves the feature works, with exact commands and expected results.

--- a/tests/unit/test_compact_context.py
+++ b/tests/unit/test_compact_context.py
@@ -1,0 +1,23 @@
+"""Verify compact-context.sh re-injects the correct default validation command."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+HOOKS_DIR = Path(__file__).resolve().parents[2] / ".claude" / "hooks"
+
+
+def test_compact_context_mentions_check_gated():
+    """Compact context should recommend make check-gated (not check-quiet) as
+    the default validation command, matching the fleet convention."""
+    result = subprocess.run(
+        ["bash", str(HOOKS_DIR / "compact-context.sh")],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0
+    assert (
+        "make check-gated" in result.stdout
+    ), "compact-context.sh should mention make check-gated as the default"


### PR DESCRIPTION
## Summary
- Replace `make check-quiet` with `make check-gated` as the recommended default Tier 2 validation command across 20 files: rules, skills, agent configs, hooks, and CLAUDE.md
- `check-gated` caps concurrent validation to 3 lanes via semaphore, preventing CPU spikes when 4+ lanes validate simultaneously
- `check-quiet` remains available as a single-lane debugging fallback

## Why
Fleet session on 2026-04-04 hit CPU load 22.9 when 4+ lanes ran `make check-quiet` simultaneously. `make check-gated` already existed with concurrency caps but wasn't the documented default — the orchestrator had to override it in every task description.

## Files Changed

| Category | Files | Change |
|----------|-------|--------|
| Root | `CLAUDE.md` | Listed `check-gated` first in Essential Commands, Pre-Commit Checklist, PR Requirements |
| Rules | `10_workflow.md`, `15_testing_tiers.md` (already correct), `40_prs.md` | Default validation command |
| Skills | `start-task`, `reviewing-changes`, `lane-status`, `debugging-ci` | Updated references |
| Agent configs | 11 files (`steward-author-*`, `steward-brws-author-*`, `steward-flex-*`, `repair`) | Lifecycle + validation expectations |
| Hooks | `compact-context.sh` | Re-injection text |
| Tests | `test_compact_context.py` | New — regression test for hook output |

## Repro / Validation
```bash
# Verify the test passes
uv run python -m pytest tests/unit/test_compact_context.py -v

# Full validation
make check-gated
```

## Test Criteria
- `make check-gated` passes ✅
- `uv run python -m pytest tests/unit/test_compact_context.py -v` passes ✅
- `grep -rl 'make check-quiet' .claude/rules/ .claude/agents/ .claude/hooks/` returns only files where check-quiet appears as a secondary/fallback option, not as the default

## Worktree Proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
branch: fix/check-gated-default-2416
```

Refs #2416

🤖 Generated with [Claude Code](https://claude.com/claude-code)