### PR TITLE
fix(convention): clarify invite-code scope for hosted playtests

### DIFF
--- a/.claude/skills/playtesting/SKILL.md
+++ b/.claude/skills/playtesting/SKILL.md
@@ -26,11 +26,14 @@ the hosted web app. Logs observations per match for bug detection and research.
 
 ## Prerequisites
 
-1. **Invite code** -- obtain one from the operator or generate locally via:
+1. **Invite code** -- obtain one from the operator, or generate codes against
+   the **hosted** database:
    ```bash
-   bash scripts/internal/create_invite_codes.sh <count> <label>
+   DATABASE_URL="<hosted_db_url>" bash scripts/internal/create_invite_codes.sh <count> <label>
    ```
-   This runs against the local database (set `DATABASE_URL` for remote).
+   Without `DATABASE_URL`, the script writes to a local SQLite file, which
+   is only useful for local dev servers — those codes won't work on the
+   hosted deployment.
 2. **WebFetch tool** -- required for making HTTP requests to the game server
 3. **Game server running** -- the target URL must be reachable
 


### PR DESCRIPTION
## Plan
N/A — convention follow-up for PR #2433

## Summary
- Reword playtest skill prerequisite to clarify that locally generated invite codes only work against a local dev database, not the hosted deployment
- Lead with `DATABASE_URL` in the example command so agents target the correct database

## Why
Review coordinator found that the skill doc implied locally generated invite codes work on hosted playtests (issue #2434). Without `DATABASE_URL`, `create_invite_codes.sh` writes to a local SQLite file — codes created that way won't exist in the hosted database and will fail with 404.

## Repro / Validation
**Command(s) run:**
```bash
make check-gated
```

**Config (if applicable):** N/A

**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** Skill doc no longer says "generate locally" without caveat; `DATABASE_URL` appears in the example command
- **Verification command:** `grep -c 'DATABASE_URL' .claude/skills/playtesting/SKILL.md && grep -c 'local SQLite' .claude/skills/playtesting/SKILL.md`
- **Expected result:** Both return 1

## Tests
- [x] `make check-gated` — all checks passed
- [x] Other: verified wording against `scripts/internal/create_invite_codes.sh` default behavior

## Expected impact
- Metrics impact: None (docs only)
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)
- [ ] Medium (strategy/experiments)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author  510ef0cc [fix/playtest-skill-invite-codes]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Issue Linkage
Fixes #2434

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
- [x] Issue linkage uses correct keyword (`Fixes` vs `Refs`) per closure policy