### PR TITLE
fix(web): clarify which team on MADE IT/SET hand result screen

### DIFF
--- a/tests/unit/hosted_play/test_bid_outcome_matrix.py
+++ b/tests/unit/hosted_play/test_bid_outcome_matrix.py
@@ -274,15 +274,18 @@ class TestDisplayConsistency:
 
     @pytest.mark.parametrize("case", MATRIX, ids=MATRIX_IDS)
     def test_banner_text(self, case: Case, jinja_env: jinja2.Environment) -> None:
-        """Correct banner (Made it! / Set! / Moon Made! / …) rendered."""
+        """Correct banner with team prefix rendered (#2439)."""
         html, _, _ = _render(jinja_env, case)
 
+        # Banner includes team prefix based on which team declared
+        team_prefix = "Your Team" if case.bidder_seat in (0, 2) else "Opponent"
         if case.bid_type == "moon":
-            expected = "Moon Made!" if case.outcome.made else "Moon Set!"
+            base = "Moon Made!" if case.outcome.made else "Moon Set!"
         elif case.bid_type == "loner":
-            expected = "Loner Made!" if case.outcome.made else "Loner Set!"
+            base = "Loner Made!" if case.outcome.made else "Loner Set!"
         else:
-            expected = "Made it!" if case.outcome.made else "Set!"
+            base = "Made It!" if case.outcome.made else "was Set!"
+        expected = f"{team_prefix} {base}"
 
         assert expected in html, f"Banner '{expected}' not found in HTML"
 

--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -1070,7 +1070,7 @@ class TestHandResult:
             score_ai=3,
             hands_played=1,
         )
-        assert "Made it!" in html
+        assert "Your Team Made It!" in html
         assert "7" in html  # tricks
         assert "\u2660" in html  # ♠
 
@@ -1089,7 +1089,7 @@ class TestHandResult:
             score_ai=5,
             hands_played=1,
         )
-        assert "Set!" in html
+        assert "Your Team was Set!" in html
         assert "-8" in html  # points
 
     def test_high_contract_result(self, env):
@@ -1108,7 +1108,7 @@ class TestHandResult:
             score_ai=2,
             hands_played=1,
         )
-        assert "Made it!" in html
+        assert "Your Team Made It!" in html
         assert "High" in html
 
     def test_low_contract_result(self, env):
@@ -1127,7 +1127,7 @@ class TestHandResult:
             score_ai=7,
             hands_played=1,
         )
-        assert "Made it!" in html
+        assert "Opponent Made It!" in html
         assert "Low" in html
 
     def test_moon_made_banner(self, env):
@@ -1147,13 +1147,13 @@ class TestHandResult:
             score_ai=0,
             hands_played=1,
         )
-        assert "Moon Made!" in html
+        assert "Your Team Moon Made!" in html
         assert "result--moon-made" in html
         assert "+20" in html
         assert "MOON" in html
         assert "MADE" in html
-        # Should NOT show regular "Made it!" text
-        assert "Made it!" not in html
+        # Should NOT show regular "Made It!" text
+        assert "Made It!" not in html
 
     def test_moon_set_banner(self, env):
         """Moon set shows special banner with negative score."""
@@ -1172,12 +1172,12 @@ class TestHandResult:
             score_ai=3,
             hands_played=1,
         )
-        assert "Moon Set!" in html
+        assert "Your Team Moon Set!" in html
         assert "result--moon-set" in html
         assert "-20" in html
         assert "SET" in html
-        # Should show moon-specific banner, not plain "Set!" alone
-        assert ">Set!<" not in html
+        # Should show moon-specific banner, not plain "was Set!" alone
+        assert "was Set!" not in html
 
     def test_loner_made_banner(self, env):
         """Loner made shows special banner."""
@@ -1196,7 +1196,7 @@ class TestHandResult:
             score_ai=0,
             hands_played=1,
         )
-        assert "Loner Made!" in html
+        assert "Your Team Loner Made!" in html
         assert "result--loner-made" in html
         assert "+20" in html
         assert "LONER" in html
@@ -1218,7 +1218,7 @@ class TestHandResult:
             score_ai=5,
             hands_played=1,
         )
-        assert "Loner Set!" in html
+        assert "Your Team Loner Set!" in html
         assert "result--loner-set" in html
         assert "-20" in html
 
@@ -1241,7 +1241,43 @@ class TestHandResult:
         )
         assert "result--moon" not in html
         assert "result--loner" not in html
-        assert "Made it!" in html
+        assert "Your Team Made It!" in html
+
+    def test_opponent_declared_made_shows_opponent_prefix(self, env):
+        """When AI team declares and makes, banner says 'Opponent Made It!' (#2439)."""
+        html = env.get_template("partials/hand_result.html").render(
+            winning_bid=6,
+            bidder_seat=1,
+            contract_type="suit",
+            trump="S",
+            tricks_team0=3,
+            tricks_team1=7,
+            points_team0=3,
+            points_team1=7,
+            score_human=3,
+            score_ai=7,
+            hands_played=1,
+        )
+        assert "Opponent Made It!" in html
+        assert "Your Team" not in html
+
+    def test_opponent_declared_set_shows_opponent_prefix(self, env):
+        """When AI team declares and is set, banner says 'Opponent was Set!' (#2439)."""
+        html = env.get_template("partials/hand_result.html").render(
+            winning_bid=8,
+            bidder_seat=3,
+            contract_type="suit",
+            trump="H",
+            tricks_team0=5,
+            tricks_team1=5,
+            points_team0=5,
+            points_team1=-8,
+            score_human=5,
+            score_ai=-8,
+            hands_played=1,
+        )
+        assert "Opponent was Set!" in html
+        assert "Your Team" not in html
 
     def test_moon_result_shows_exchange_summary(self, env):
         """Moon results include exchange card summary."""
@@ -1481,7 +1517,7 @@ class TestHandResult:
             hands_played=1,
         )
         # Should render without error even when completed_tricks is not provided
-        assert "Made it!" in html
+        assert "Your Team Made It!" in html
         assert "trick-history" not in html
 
     def test_trick_history_wrapper_has_class(self, env):
@@ -1791,7 +1827,7 @@ class TestGameBoardSeatZeroRegression:
     """
 
     def test_hand_result_via_game_board_seat0_set(self, env):
-        """Human (seat 0) bid and got set — banner must say 'Set!'."""
+        """Human (seat 0) bid and got set — banner must say 'Your Team was Set!'."""
         tmpl = env.get_template("partials/game_board.html")
         html = tmpl.render(
             phase="hand_result",
@@ -1812,14 +1848,14 @@ class TestGameBoardSeatZeroRegression:
             score_ai=6,
             hands_played=1,
         )
-        assert "Set!" in html
+        assert "Your Team was Set!" in html
         # Verify human is identified as the bidder
         assert "You" in html
-        # Should NOT say "Made it!"
-        assert "Made it!" not in html
+        # Should NOT say "Made It!"
+        assert "Made It!" not in html
 
     def test_hand_result_via_game_board_seat0_made(self, env):
-        """Human (seat 0) bid and made — banner must say 'Made it!'."""
+        """Human (seat 0) bid and made — banner must say 'Your Team Made It!'."""
         tmpl = env.get_template("partials/game_board.html")
         html = tmpl.render(
             phase="hand_result",
@@ -1840,7 +1876,7 @@ class TestGameBoardSeatZeroRegression:
             score_ai=3,
             hands_played=1,
         )
-        assert "Made it!" in html
+        assert "Your Team Made It!" in html
         assert "You" in html
 
     def test_dealer_seat_zero_preserved(self, env):

--- a/tests/unit/hosted_play/test_scoring_matrix.py
+++ b/tests/unit/hosted_play/test_scoring_matrix.py
@@ -311,7 +311,7 @@ class TestHandResultDisplay:
                 trump,
                 6,
                 7,
-                "Made it!",
+                "Made It!",
             )
         )
         DISPLAY_CASES.append(
@@ -321,7 +321,7 @@ class TestHandResultDisplay:
                 trump,
                 6,
                 5,
-                "Set!",
+                "was Set!",
             )
         )
 
@@ -402,8 +402,11 @@ class TestHandResultDisplay:
         )
         tmpl = env.get_template("partials/hand_result.html")
         html = tmpl.render(**ctx)
-        assert expected_banner in html, (
-            f"Expected '{expected_banner}' in HTML for "
+        # Banner includes team prefix based on which team declared (#2439)
+        team_prefix = "Your Team" if bidder_seat in (0, 2) else "Opponent"
+        full_banner = f"{team_prefix} {expected_banner}"
+        assert full_banner in html, (
+            f"Expected '{full_banner}' in HTML for "
             f"seat={bidder_seat} {bid_type}/{contract_type}"
         )
 

--- a/web/templates/partials/hand_result.html
+++ b/web/templates/partials/hand_result.html
@@ -55,24 +55,27 @@
         {# --- Contextual title class: green for human-positive, red for human-negative --- #}
         {% set title_mood = "result-title--positive" if is_good_for_human else "result-title--negative" %}
 
+        {# --- Team prefix: clarify which team the result applies to --- #}
+        {% set team_prefix = "Your Team" if human_declared else "Opponent" %}
+
         {# --- Moon / Loner special banners --- #}
         {% if hand_bid_type == "moon" %}
             {% if made %}
-                <h2 class="result-title {{ title_mood }}"><span aria-hidden="true">🌙</span> Moon Made!</h2>
+                <h2 class="result-title {{ title_mood }}"><span aria-hidden="true">🌙</span> {{ team_prefix }} Moon Made!</h2>
             {% else %}
-                <h2 class="result-title {{ title_mood }}"><span aria-hidden="true">🌙</span> Moon Set!</h2>
+                <h2 class="result-title {{ title_mood }}"><span aria-hidden="true">🌙</span> {{ team_prefix }} Moon Set!</h2>
             {% endif %}
         {% elif hand_bid_type == "loner" %}
             {% if made %}
-                <h2 class="result-title {{ title_mood }}"><span aria-hidden="true">🃏</span> Loner Made!</h2>
+                <h2 class="result-title {{ title_mood }}"><span aria-hidden="true">🃏</span> {{ team_prefix }} Loner Made!</h2>
             {% else %}
-                <h2 class="result-title {{ title_mood }}"><span aria-hidden="true">🃏</span> Loner Set!</h2>
+                <h2 class="result-title {{ title_mood }}"><span aria-hidden="true">🃏</span> {{ team_prefix }} Loner Set!</h2>
             {% endif %}
         {# --- Regular bid banners --- #}
         {% elif made %}
-            <h2 class="result-title {{ title_mood }}">Made it!</h2>
+            <h2 class="result-title {{ title_mood }}">{{ team_prefix }} Made It!</h2>
         {% else %}
-            <h2 class="result-title {{ title_mood }}">Set!</h2>
+            <h2 class="result-title {{ title_mood }}">{{ team_prefix }} was Set!</h2>
         {% endif %}
 
         {# Score delta emphasis for moon/loner #}


### PR DESCRIPTION
## Summary
- Hand result banner now shows **"Your Team Made It!"** / **"Opponent Made It!"** instead of ambiguous "Made it!"
- Set banners show **"Your Team was Set!"** / **"Opponent was Set!"** instead of ambiguous "Set!"
- Moon/Loner banners include team prefix: e.g., "Your Team Moon Made!" / "Opponent Loner Set!"

## Why
The hand result screen was ambiguous about which team the result applied to. During go-live playtesting (2026-04-04), it was unclear whether "Made it!" referred to the human team or the AI team. The color (green/red) gave a hint, but the text should be self-explanatory.

Refs #2439

## Repro / Validation
```bash
# Targeted tests (434 assertions across all bid/outcome/seat combos)
uv run python -m pytest tests/unit/hosted_play/test_partials.py::TestHandResult \
    tests/unit/hosted_play/test_scoring_matrix.py::TestHandResultDisplay \
    tests/unit/hosted_play/test_bid_outcome_matrix.py::TestDisplayConsistency::test_banner_text -v

# Full validation
make check-quiet
```

## Tests
- Updated existing banner text assertions in `test_partials.py`, `test_scoring_matrix.py`, `test_bid_outcome_matrix.py`
- Added two new tests: `test_opponent_declared_made_shows_opponent_prefix` and `test_opponent_declared_set_shows_opponent_prefix`
- Full exhaustive matrix (all seat × bid_type × contract_type × outcome) passes — 434 tests

## Worktree proof
```
pwd: Bid-Euchre-steward-brws-author-a
branch: fix/hand-result-team-clarity
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)