### PR TITLE
feat(web): add request logging middleware with JSON formatter

### DIFF
--- a/tests/integration/hosted_play/test_request_logging.py
+++ b/tests/integration/hosted_play/test_request_logging.py
@@ -1,0 +1,310 @@
+"""Integration tests for RequestLoggingMiddleware and JSON log formatter.
+
+Verifies:
+- Every HTTP request produces request_start and request_complete log entries
+- Each entry includes request_id, method, path, status_code, duration_ms
+- request_id is available via contextvars to route handlers
+- JSON format activatable via LOG_FORMAT=json
+- Health/ready endpoints are excluded from INFO-level logging (DEBUG only)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from starlette.testclient import TestClient
+
+from tests.unit.hosted_play.conftest import make_hosted_play_test_config
+from web.app import create_app
+from web.log_config import JSONFormatter, configure_logging
+from web.middleware import get_request_id, request_id_var
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_test_client(tmp_path):
+    """Create a test app + client."""
+    config = make_hosted_play_test_config(tmp_path)
+    app = create_app(config=config)
+    return TestClient(app), app
+
+
+# ---------------------------------------------------------------------------
+# RequestLoggingMiddleware
+# ---------------------------------------------------------------------------
+
+
+class TestRequestLoggingMiddleware:
+    """Verify the request logging middleware produces structured log entries."""
+
+    def test_request_produces_start_and_complete_logs(self, tmp_path, caplog):
+        """Every HTTP request must emit request_start and request_complete."""
+        client, _ = _make_test_client(tmp_path)
+        with caplog.at_level(logging.DEBUG, logger="web.middleware"):
+            client.get("/health")
+
+        messages = [r.message for r in caplog.records if r.name == "web.middleware"]
+        start_msgs = [m for m in messages if "request_start" in m]
+        complete_msgs = [m for m in messages if "request_complete" in m]
+
+        assert len(start_msgs) >= 1, f"No request_start log found. Messages: {messages}"
+        assert (
+            len(complete_msgs) >= 1
+        ), f"No request_complete log found. Messages: {messages}"
+
+    def test_log_entry_contains_required_fields(self, tmp_path, caplog):
+        """Log entries must include method, path, and request_id."""
+        client, _ = _make_test_client(tmp_path)
+        with caplog.at_level(logging.DEBUG, logger="web.middleware"):
+            client.get("/health")
+
+        start_records = [
+            r
+            for r in caplog.records
+            if r.name == "web.middleware" and "request_start" in r.message
+        ]
+        assert start_records, "No request_start record found"
+        start_msg = start_records[0].message
+        assert "method=GET" in start_msg
+        assert "path=/health" in start_msg
+        assert "request_id=" in start_msg
+
+        complete_records = [
+            r
+            for r in caplog.records
+            if r.name == "web.middleware" and "request_complete" in r.message
+        ]
+        assert complete_records, "No request_complete record found"
+        complete_msg = complete_records[0].message
+        assert "status_code=" in complete_msg
+        assert "duration_ms=" in complete_msg
+
+    def test_request_id_is_consistent_across_start_and_complete(self, tmp_path, caplog):
+        """The same request_id must appear in both start and complete entries."""
+        client, _ = _make_test_client(tmp_path)
+        with caplog.at_level(logging.DEBUG, logger="web.middleware"):
+            client.get("/health")
+
+        middleware_records = [r for r in caplog.records if r.name == "web.middleware"]
+
+        def _extract_rid(msg: str) -> str:
+            for part in msg.split():
+                if part.startswith("request_id="):
+                    return part.split("=", 1)[1]
+            return ""
+
+        rids = {_extract_rid(r.message) for r in middleware_records}
+        # Remove empty strings (shouldn't happen, but be defensive)
+        rids.discard("")
+        assert len(rids) == 1, f"Expected exactly one request_id, got {rids}"
+
+    def test_health_endpoint_logged_at_debug(self, tmp_path, caplog):
+        """Health/ready paths must log at DEBUG, not INFO."""
+        client, _ = _make_test_client(tmp_path)
+        with caplog.at_level(logging.DEBUG, logger="web.middleware"):
+            client.get("/health")
+            client.get("/ready")
+
+        health_records = [
+            r
+            for r in caplog.records
+            if r.name == "web.middleware" and "/health" in r.message
+        ]
+        ready_records = [
+            r
+            for r in caplog.records
+            if r.name == "web.middleware" and "/ready" in r.message
+        ]
+
+        for rec in health_records:
+            assert (
+                rec.levelno == logging.DEBUG
+            ), f"/health logged at {rec.levelname}, expected DEBUG"
+        for rec in ready_records:
+            assert (
+                rec.levelno == logging.DEBUG
+            ), f"/ready logged at {rec.levelname}, expected DEBUG"
+
+    def test_non_health_endpoint_logged_at_info(self, tmp_path, caplog):
+        """Non-health paths must log at INFO level.
+
+        Uses the full lifespan context (``with TestClient(...)``) so that
+        ``app.state.templates`` is populated and the landing route can render.
+        """
+        config = make_hosted_play_test_config(tmp_path)
+        app = create_app(config=config)
+        with TestClient(app) as client:
+            with caplog.at_level(logging.DEBUG, logger="web.middleware"):
+                # Landing page — should be INFO
+                client.get("/")
+
+        landing_records = [
+            r
+            for r in caplog.records
+            if r.name == "web.middleware"
+            and "request_start" in r.message
+            and "path=/" in r.message
+            # Exclude /health, /ready which also start with /
+            and "/health" not in r.message
+            and "/ready" not in r.message
+        ]
+        assert landing_records, "No INFO-level record for landing page"
+        for rec in landing_records:
+            assert (
+                rec.levelno == logging.INFO
+            ), f"Landing logged at {rec.levelname}, expected INFO"
+
+    def test_request_id_resets_between_requests(self, tmp_path, caplog):
+        """Each request must get a unique request_id."""
+        client, _ = _make_test_client(tmp_path)
+        with caplog.at_level(logging.DEBUG, logger="web.middleware"):
+            client.get("/health")
+            client.get("/ready")
+
+        def _extract_rid(msg: str) -> str:
+            for part in msg.split():
+                if part.startswith("request_id="):
+                    return part.split("=", 1)[1]
+            return ""
+
+        start_records = [
+            r
+            for r in caplog.records
+            if r.name == "web.middleware" and "request_start" in r.message
+        ]
+        rids = [_extract_rid(r.message) for r in start_records]
+        assert len(rids) >= 2, f"Expected 2+ start records, got {len(rids)}"
+        assert rids[0] != rids[1], "Different requests got the same request_id"
+
+
+# ---------------------------------------------------------------------------
+# get_request_id() — context variable access
+# ---------------------------------------------------------------------------
+
+
+class TestGetRequestId:
+    """Verify get_request_id() returns the correct value."""
+
+    def test_returns_empty_outside_request(self):
+        """Outside a request context, get_request_id() returns empty string."""
+        assert get_request_id() == ""
+
+    def test_returns_value_after_set(self):
+        """After setting the ContextVar, get_request_id() returns the value."""
+        token = request_id_var.set("test-rid-123")
+        try:
+            assert get_request_id() == "test-rid-123"
+        finally:
+            request_id_var.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# JSONFormatter
+# ---------------------------------------------------------------------------
+
+
+class TestJSONFormatter:
+    """Verify the JSON formatter produces valid, structured output."""
+
+    def test_format_produces_valid_json(self):
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            name="test.logger",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="hello %s",
+            args=("world",),
+            exc_info=None,
+        )
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        assert parsed["message"] == "hello world"
+        assert parsed["level"] == "INFO"
+        assert parsed["logger"] == "test.logger"
+        assert "timestamp" in parsed
+
+    def test_includes_request_id_when_present(self):
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            name="test.logger",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="with request id",
+            args=(),
+            exc_info=None,
+        )
+        record.request_id = "abc-123"  # type: ignore[attr-defined]
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        assert parsed["request_id"] == "abc-123"
+
+    def test_omits_request_id_when_empty(self):
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            name="test.logger",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="no request id",
+            args=(),
+            exc_info=None,
+        )
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        assert "request_id" not in parsed
+
+    def test_includes_exception_info(self):
+        formatter = JSONFormatter()
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            import sys
+
+            exc_info = sys.exc_info()
+
+        record = logging.LogRecord(
+            name="test.logger",
+            level=logging.ERROR,
+            pathname="",
+            lineno=0,
+            msg="error occurred",
+            args=(),
+            exc_info=exc_info,
+        )
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        assert "exception" in parsed
+        assert "ValueError" in parsed["exception"]
+        assert "boom" in parsed["exception"]
+
+
+# ---------------------------------------------------------------------------
+# configure_logging
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureLogging:
+    """Verify configure_logging wires the correct formatter."""
+
+    def test_json_format_installs_json_formatter(self):
+        configure_logging(log_format="json", log_level="INFO")
+        root = logging.getLogger()
+        try:
+            assert any(
+                isinstance(h.formatter, JSONFormatter) for h in root.handlers
+            ), "JSONFormatter not found on root logger handlers"
+        finally:
+            # Restore default text logging to avoid polluting other tests
+            configure_logging(log_format="text", log_level="INFO")
+
+    def test_text_format_does_not_use_json_formatter(self):
+        configure_logging(log_format="text", log_level="INFO")
+        root = logging.getLogger()
+        assert not any(
+            isinstance(h.formatter, JSONFormatter) for h in root.handlers
+        ), "JSONFormatter should not be present for text format"

--- a/web/app.py
+++ b/web/app.py
@@ -37,6 +37,7 @@ from .db import (
     init_engine,
     make_session_factory,
 )
+from .middleware import RequestLoggingMiddleware
 from .routes import router as game_router
 from .template_filters import display_rank, effective_suit, is_bower
 
@@ -228,6 +229,12 @@ def create_app(config: HostedPlayConfig | None = None) -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    # Request logging — structured request_start/request_complete events
+    # with per-request correlation IDs.  Must be added *after* CORS so
+    # that the logging middleware wraps the inner app and sees the final
+    # response status (Starlette middleware order is LIFO).
+    app.add_middleware(RequestLoggingMiddleware)
 
     # Serve static assets (CSS, JS) from web/static/
     app.mount("/static", StaticFiles(directory=str(_WEB_DIR / "static")), name="static")

--- a/web/log_config.py
+++ b/web/log_config.py
@@ -1,0 +1,70 @@
+"""Structured JSON log formatter for production deployment.
+
+Provides a :class:`JSONFormatter` that emits one JSON object per log
+record, and a :func:`configure_logging` helper that wires it into the
+root logger when ``LOG_FORMAT=json`` is set.
+
+The formatter is intentionally minimal — stdlib ``logging`` only, no
+third-party dependencies (structlog, loguru, etc.).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+
+
+class JSONFormatter(logging.Formatter):
+    """Emit log records as single-line JSON objects.
+
+    Includes ``request_id`` from the record's extras when present (set by
+    :class:`web.middleware.RequestLoggingMiddleware` via a
+    :class:`~logging.Filter`).
+    """
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: A003
+        log_data: dict[str, object] = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        # Include request_id when the middleware filter injects it.
+        request_id = getattr(record, "request_id", "")
+        if request_id:
+            log_data["request_id"] = request_id
+
+        if record.exc_info and record.exc_info[0] is not None:
+            log_data["exception"] = self.formatException(record.exc_info)
+
+        return json.dumps(log_data, default=str)
+
+
+def configure_logging(log_format: str = "text", log_level: str = "INFO") -> None:
+    """Set up root logger with the appropriate formatter.
+
+    Parameters
+    ----------
+    log_format:
+        ``"json"`` for structured JSON output (production),
+        ``"text"`` for human-readable output (development).
+    log_level:
+        Standard Python log level name (``DEBUG``, ``INFO``, etc.).
+    """
+    root = logging.getLogger()
+    root.setLevel(getattr(logging, log_level.upper(), logging.INFO))
+
+    # Remove existing handlers to avoid duplicate output when called
+    # multiple times (e.g. tests calling create_app repeatedly).
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
+
+    handler = logging.StreamHandler()
+    if log_format.lower() == "json":
+        handler.setFormatter(JSONFormatter())
+    else:
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s %(levelname)-8s %(name)s  %(message)s")
+        )
+    root.addHandler(handler)

--- a/web/middleware.py
+++ b/web/middleware.py
@@ -3,16 +3,117 @@
 Rate-limiting, session-tracking, and request-level guards that protect
 the hosted-play application from resource exhaustion during the pilot
 phase and support transparent session reconnection.
+
+Includes :class:`RequestLoggingMiddleware` for structured request-level
+logging with per-request correlation IDs.
 """
 
 from __future__ import annotations
 
+import contextvars
+import logging
+import time
+import uuid
 from typing import Optional
 
 from fastapi import Request
 from fastapi.responses import Response
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from web.db import Match, Player
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Request-ID context variable — available to all route handlers via
+# get_request_id() for log correlation.
+# ---------------------------------------------------------------------------
+
+request_id_var: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "request_id", default=""
+)
+
+
+def get_request_id() -> str:
+    """Return the current request's correlation ID (empty outside a request)."""
+    return request_id_var.get()
+
+
+class _RequestIdFilter(logging.Filter):
+    """Inject ``request_id`` into every log record for the JSON formatter."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = request_id_var.get()  # type: ignore[attr-defined]
+        return True
+
+
+# Attach the filter to the root logger so all loggers inherit it.
+logging.getLogger().addFilter(_RequestIdFilter())
+
+# Paths to exclude from verbose request logging (health probes generate
+# high-frequency traffic that would drown out meaningful entries).
+_QUIET_PATHS: frozenset[str] = frozenset({"/health", "/ready"})
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    """Log structured request_start / request_complete events for every HTTP request.
+
+    * Assigns a UUID4 ``request_id`` to each request via :data:`request_id_var`.
+    * Logs ``request_start`` on entry with method, path, and client IP.
+    * Logs ``request_complete`` on exit with status code and duration in ms.
+    * Health and readiness probe paths are logged at DEBUG level to reduce
+      noise on free-tier log providers.
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        rid = str(uuid.uuid4())
+        token = request_id_var.set(rid)
+
+        path = request.url.path
+        method = request.method
+        client_ip = request.client.host if request.client else ""
+
+        # Use DEBUG for noisy health-check paths, INFO for everything else.
+        level = logging.DEBUG if path in _QUIET_PATHS else logging.INFO
+
+        logger.log(
+            level,
+            "request_start method=%s path=%s client_ip=%s request_id=%s",
+            method,
+            path,
+            client_ip,
+            rid,
+        )
+
+        start = time.monotonic()
+        try:
+            response = await call_next(request)
+        except Exception:
+            duration_ms = round((time.monotonic() - start) * 1000, 1)
+            logger.log(
+                logging.ERROR,
+                "request_error method=%s path=%s duration_ms=%.1f request_id=%s",
+                method,
+                path,
+                duration_ms,
+                rid,
+            )
+            raise
+        finally:
+            request_id_var.reset(token)
+
+        duration_ms = round((time.monotonic() - start) * 1000, 1)
+        logger.log(
+            level,
+            "request_complete method=%s path=%s status_code=%d duration_ms=%.1f request_id=%s",
+            method,
+            path,
+            response.status_code,
+            duration_ms,
+            rid,
+        )
+        return response
+
 
 # Maximum number of active matches a single player may have concurrently.
 MAX_ACTIVE_MATCHES_PER_PLAYER = 5

--- a/web/start.py
+++ b/web/start.py
@@ -13,6 +13,7 @@ Variable              Default      Purpose
 ``PORT``              ``8000``     Bind port (Render injects ``$PORT``)
 ``WEB_WORKERS``       ``1``        Uvicorn worker count
 ``LOG_LEVEL``         ``info``     Uvicorn log level
+``LOG_FORMAT``        ``text``     ``text`` or ``json`` (structured output)
 ====================  ===========  ========================================
 
 Usage::
@@ -39,10 +40,16 @@ def main() -> None:
     # uvicorn installation checks at import time.
     import uvicorn
 
+    from web.log_config import configure_logging
+
     host = os.environ.get("HOST", "0.0.0.0")
     port = int(os.environ.get("PORT", "8000"))
     workers = int(os.environ.get("WEB_WORKERS", "1"))
     log_level = os.environ.get("LOG_LEVEL", "info").lower()
+    log_format = os.environ.get("LOG_FORMAT", "text").lower()
+
+    # Configure structured logging before uvicorn starts.
+    configure_logging(log_format=log_format, log_level=log_level)
 
     # Validate workers — uvicorn requires >= 1
     if workers < 1:


### PR DESCRIPTION
## Plan
plans/sessions/2026-04-05_gameplay-logging-design.md (PR-1 of 3)

## Summary
- Add `RequestLoggingMiddleware` in `web/middleware.py` with per-request UUID4 correlation IDs via `contextvars`
- Add `JSONFormatter` in new `web/log_config.py` (stdlib `logging` only — no new dependencies)
- Wire `LOG_FORMAT=json` env var in `web/start.py` for production structured output
- Health/ready endpoints logged at DEBUG level to reduce noise on free-tier log providers

## Why
The browser game lacks request-level logging needed for go-live debugging. During proving, a TEST player got stuck (match 94, turn 33) and we couldn't distinguish client-side vs server-side vs deploy-timing issues. This PR adds the foundational request logging layer — every HTTP request now produces structured `request_start` and `request_complete` entries with a correlation ID available to downstream route handlers.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/integration/hosted_play/test_request_logging.py -v
make check-gated
```

## Test Criteria
- **Pass condition:** 14 integration tests cover middleware lifecycle, JSON formatter, and configuration
- **Verification command:** `uv run python -m pytest tests/integration/hosted_play/test_request_logging.py -v`
- **Expected result:** 14 passed, 0 failed

## Tests
- [x] `uv run python -m pytest tests/integration/hosted_play/test_request_logging.py -v` — 14 passed
- [x] `uv run python -m pytest tests/unit/hosted_play/test_app.py -v` — 22 passed (no regressions)
- [x] `make check-gated` — all checks passed

## Expected impact
- Metrics impact: None (logging only)
- Runtime impact: <1ms overhead per request (stdlib UUID4 + logging)

## Risk level
- [ ] Low (docs/tests only)
- [x] Medium (web middleware — touches request path)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git worktree list` (relevant line):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d   faf24e78 [feat/request-logging-middleware]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Issue Linkage
Refs #2444

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
- [x] Issue linkage uses correct keyword (`Fixes` vs `Refs`) per closure policy