### PR TITLE
fix(web): restore card-text suit variant CSS for trick winner display (#2441)

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -3111,11 +3111,24 @@ main {
     color: var(--color-text-muted);
 }
 
-/* Card text in exchange summaries — rank stays default (white); suit icon
-   colored via .suit-icon utility (#2289). */
+/* Card text in exchange summaries and trick winner — rank stays default
+   (white); suit icon colored via .suit-icon utility where available (#2289).
+   Variant classes provide suit coloring for contexts where the suit symbol
+   is inline (e.g. trick.html "won with" text) rather than wrapped in a
+   .suit-icon span (#2441). */
 .card-text {
     font-weight: 700;
     white-space: nowrap;
+    color: var(--color-text);
+}
+
+.card-text--hearts,
+.card-text--diamonds {
+    color: var(--color-red);
+}
+
+.card-text--spades,
+.card-text--clubs {
     color: var(--color-text);
 }
 


### PR DESCRIPTION
## Plan
N/A — bounded CSS fix for #2441

## Summary
- Restore `.card-text--hearts/.card-text--diamonds` (red) and `.card-text--spades/.card-text--clubs` (white) CSS rules that were removed in PR #2298
- These rules provide suit-specific coloring for the trick winner "won with" text in `trick.html`

## Why
PR #2298 refactored `trick_history.html` to use `.suit-icon` wrappers for suit symbols but removed the `.card-text--{suit}` variant CSS rules. The "won with" text in `trick.html` (line 149) still references `card-text--spades/clubs/hearts/diamonds` classes without an inner `.suit-icon` span, so it lost suit-specific coloring. Hearts/diamonds rendered white instead of red, and spades/clubs had no explicit styling rule.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/ -q  # 3443 passed
make check-gated                                      # All checks passed
```

**CSS verification:**
```bash
grep "card-text--" web/static/style.css
# .card-text--hearts, .card-text--diamonds → color: var(--color-red)
# .card-text--spades, .card-text--clubs → color: var(--color-text)
```

## Test Criteria
- **Pass condition:** `.card-text--hearts/diamonds` use `var(--color-red)` and `.card-text--spades/clubs` use `var(--color-text)` in `web/static/style.css`
- **Verification command:** `grep -A1 "card-text--hearts" web/static/style.css` shows `color: var(--color-red)`; `grep -A1 "card-text--spades" web/static/style.css` shows `color: var(--color-text)`
- **Expected result:** Trick winner "won with" text renders suit symbols with correct coloring on dark backgrounds

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/ -q` — 3443 passed, 8 skipped
- [x] `make check-gated` — all checks passed

## Expected impact
- Metrics impact: None (CSS-only change)
- Runtime impact: None

## Risk
Low — restores CSS rules that existed before PR #2298, only affects inline card-text rendering

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
branch: fix/trick-log-suit-icons
```

Refs #2441

🤖 Generated with [Claude Code](https://claude.com/claude-code)