### PR TITLE
fix(web): use most-recent match query in /next-hand to avoid stale active matches

### DIFF
--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -3252,6 +3252,77 @@ class TestMatchResultGuards:
         assert "match-result" in resp.text
         assert "You Lose" in resp.text
 
+    def test_next_hand_prefers_recent_match_over_stale_active(self, client, app):
+        """POST /next-hand finds the just-completed match, not a stale active one.
+
+        Regression test for #2446: when a completed match exists alongside a
+        stale active match from a previous session, /next-hand must return the
+        match-result screen for the recently completed match — not resume the
+        stale active match.
+        """
+        link_uuid = _setup_game(client)
+
+        session_factory = app.state.session_factory
+        session = session_factory()
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+        assert player is not None
+
+        # The _setup_game helper created one active match.  Fetch it and force
+        # it to "complete" to simulate a finished match.
+        current_match = (
+            session.query(Match).filter_by(player_id=player.id, status="active").first()
+        )
+        assert current_match is not None
+
+        ai_manager = app.state.ai_manager
+        info = ai_manager.get_model_info(current_match.ai_model)
+        engine = MatchEngine(
+            bidding_policy=info.bidding_policy,
+            play_strategy=info.play_strategy,
+        )
+        state = engine.deserialize(json.loads(current_match.match_state_json))
+        state.status = "complete"
+        state.winner = "human"
+        state.score_human = 54
+        state.score_ai = 22
+        state.hands_played = 5
+        current_match.match_state_json = json.dumps(engine.serialize(state))
+        current_match.status = "complete"
+        session.commit()
+
+        # Now insert a *stale* active match with an older created_at to
+        # simulate a leftover from a previous session.
+        from datetime import datetime, timedelta, timezone
+
+        stale_match = Match(
+            match_uuid=str(uuid.uuid4()),
+            player_id=player.id,
+            ai_model=current_match.ai_model,
+            status="active",
+            seed=99,
+            match_state_json=current_match.match_state_json,  # content irrelevant
+            score_human=9,
+            score_ai=32,
+            hands_played=2,
+        )
+        session.add(stale_match)
+        session.flush()
+
+        # Force the stale match to have an older created_at.
+        stale_match.created_at = datetime.now(timezone.utc) - timedelta(hours=1)
+        session.commit()
+        session.close()
+
+        # POST /next-hand should find the COMPLETED (most recent) match and
+        # render match-result — NOT the stale active match.
+        resp = client.post(f"/play/{link_uuid}/next-hand")
+        assert resp.status_code == 200
+        assert "match-result" in resp.text, (
+            "Expected match-result screen but got active match content; "
+            "stale active match was returned instead of the completed match"
+        )
+        assert "You Win" in resp.text
+
 
 # ---------------------------------------------------------------------------
 # Auction UX fixes (#2133, #2134)

--- a/web/routes.py
+++ b/web/routes.py
@@ -1803,22 +1803,17 @@ async def next_hand(
         if player is None:
             raise HTTPException(status_code=404, detail="Game not found")
 
-        # Look for an active match first; fall back to the most recent
-        # completed match so that a stale "Next Hand" click renders the
-        # match-result screen instead of a 404 (P2-005 defensive fix).
+        # Find the player's most recently created non-abandoned match.
+        # Previous logic prioritized active matches, which returned stale
+        # active matches from earlier sessions instead of the just-completed
+        # match the player is actually advancing from (#2446).
         match_row = (
             session.query(Match)
-            .filter_by(player_id=player.id, status="active")
+            .filter_by(player_id=player.id)
+            .filter(Match.status.in_(["active", "complete"]))
             .order_by(Match.created_at.desc())
             .first()
         )
-        if match_row is None:
-            match_row = (
-                session.query(Match)
-                .filter_by(player_id=player.id, status="complete")
-                .order_by(Match.created_at.desc())
-                .first()
-            )
         if match_row is None:
             raise HTTPException(status_code=404, detail="No active match")
 


### PR DESCRIPTION
## Plan
N/A — targeted bug fix from issue #2446

## Summary
- Replace the two-step active-first/complete-fallback match lookup in `/next-hand` with a single query for the most recently created non-abandoned match
- Add regression test proving stale active matches don't shadow the just-completed match

## Why
When a match completes (score reaches ±52), the `/next-hand` handler should show the match-result screen. Instead, it was picking up stale active matches from earlier sessions because the query prioritized `status="active"` over recency. The match result screen was never shown.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_routes.py -k "next_hand" -v
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** New regression test `test_next_hand_prefers_recent_match_over_stale_active` passes — creates a completed match alongside a stale active match and verifies `/next-hand` returns the match-result screen
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_routes.py::TestMatchResultGuards::test_next_hand_prefers_recent_match_over_stale_active -v`
- **Expected result:** 1 passed

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_routes.py -k "next_hand" -v` — 6 passed
- [x] `uv run python -m pytest tests/unit/hosted_play/ -v` — 3453 passed
- [x] `make check-quiet` — 3 pre-existing failures in unrelated `test_cpu_gate.py` (timeout on busy machine)

## Expected impact
- Metrics impact: None
- Runtime impact: None — query is equivalent complexity (single query instead of two sequential queries)

## Risk level
- [ ] Low (docs/tests only)
- [x] Medium (web route handler)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)
`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
```

`git worktree list` (excerpt):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b   66c1bf45 [fix/match-result-stale-2446]
```

## Issue Linkage
Refs #2446

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
- [x] Issue linkage uses correct keyword (`Fixes` vs `Refs`) per closure policy