### PR TITLE
fix(web): keep auction log open until Next after final bid (#2438)

### DIFF
--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -3538,11 +3538,12 @@ class TestAuctionRevealUX:
         # The A♠ and K♠ from the injected trick should be hidden
         assert "trick-card" not in resp.text or "current-trick" not in resp.text
 
-    def test_no_settle_pause_when_human_bids_last(self, client, app):
-        """When the human is the last bidder, no settle pause is needed (#2134).
+    def test_settle_pause_when_human_bids_last(self, client, app):
+        """When the human bids last, a settle pause still appears (#2438).
 
-        If the human bids last (as dealer), revealed_auction_count == len(auction)
-        immediately after submit_bid, so auction_settled stays True.
+        Even though no hidden bids remain (the human's bid was the final
+        auction action), auction_settled is set to False so the player can
+        review the auction result before trick play begins.
         """
         link_uuid = _setup_game(client)
 
@@ -3562,25 +3563,10 @@ class TestAuctionRevealUX:
                 client.post(f"/play/{link_uuid}/next")
                 continue
 
-            # Check if auction just settled without a pause
-            if (
-                not has_hidden
-                and hand.auction_settled
-                and hand.phase
-                in (
-                    "trick_play",
-                    "moon_exchange",
-                )
-            ):
-                # No settle pause was needed — the human bid last.
-                # Verify we can immediately play (or see exchange).
-                return  # Test passed
-
             if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
                 # Check if human is the last bidder (dealer position).
-                # The dealer bids last in the auction rotation.
                 if hand.dealer_seat == HUMAN_SEAT:
-                    # Human IS the dealer — bid and check for no settle
+                    # Human IS the dealer — bid and verify settle pause
                     if hand.current_high_bid < 3:
                         client.post(
                             f"/play/{link_uuid}/bid",
@@ -3600,7 +3586,6 @@ class TestAuctionRevealUX:
                             },
                         )
 
-                    # After dealer bids, check: no hidden bids, settled = True
                     result2 = get_match_state(app, link_uuid)
                     assert result2 is not None
                     state2, _, session2 = result2
@@ -3609,8 +3594,26 @@ class TestAuctionRevealUX:
                     if hand2 is not None and not (
                         hand2.revealed_auction_count < len(hand2.auction)
                     ):
-                        # Human bid last — no hidden bids remain
-                        assert hand2.auction_settled is True
+                        if hand2.phase == "redeal":
+                            # All passed — redeal has its own interstitial,
+                            # no settle pause expected.
+                            return
+
+                        # Human bid last — no hidden bids remain.
+                        # Settle pause should be active so the player
+                        # can see the auction result (#2438).
+                        assert hand2.auction_settled is False
+
+                        # Dismiss the settle pause
+                        client.post(f"/play/{link_uuid}/next")
+
+                        result3 = get_match_state(app, link_uuid)
+                        assert result3 is not None
+                        state3, _, session3 = result3
+                        session3.close()
+                        hand3 = state3.current_hand
+                        if hand3 is not None:
+                            assert hand3.auction_settled is True
                         return  # Test passed
                 else:
                     # Not dealer, just pass
@@ -3627,6 +3630,105 @@ class TestAuctionRevealUX:
                 advance_pending_reveals(client, app, link_uuid)
 
         pytest.skip("Seed did not produce a human-bids-last scenario")
+
+    def test_settle_pause_when_human_bids_last_injected(self, client, app):
+        """Deterministic test: settle pause fires when human bids last (#2438).
+
+        Uses state injection to guarantee the human-dealer scenario:
+        three AI bids already revealed, human (seat 0) about to bid last.
+        After the human bids, auction_settled must be False so the player
+        can review the auction result before trick play.
+        """
+        link_uuid = _setup_game(client)
+
+        result = get_match_state(app, link_uuid)
+        assert result is not None
+        state, _, session = result
+
+        hand = state.current_hand
+        assert hand is not None
+
+        # Inject state: auction in progress, human is the dealer (bids last),
+        # three AI bids already revealed, human's turn next.
+        hand.phase = "auction"
+        hand.dealer_seat = HUMAN_SEAT
+        hand.auction = [
+            {
+                "seat": 1,
+                "n": 3,
+                "action": "bid",
+                "contract": "H",
+                "bid_type": "regular",
+            },
+            {"seat": 2, "n": 0, "action": "pass"},
+            {"seat": 3, "n": 0, "action": "pass"},
+        ]
+        hand.revealed_auction_count = 3  # all AI bids revealed
+        hand.auction_settled = True  # default — no hidden bids
+        hand.current_high_bid = 3
+        hand.bidder_seat = 1
+        hand.winning_bid = 3
+        hand.contract_type = "suit"
+        hand.trump = "H"
+        hand.current_seat = HUMAN_SEAT
+        hand.turn_number = 3
+
+        # Persist injected state
+        player = session.query(Player).filter_by(link_uuid=link_uuid).first()
+        match_row = (
+            session.query(Match).filter_by(player_id=player.id, status="active").first()
+        )
+        ai_manager = app.state.ai_manager
+        info = ai_manager.get_model_info(match_row.ai_model)
+        engine = MatchEngine(
+            bidding_policy=info.bidding_policy,
+            play_strategy=info.play_strategy,
+        )
+        match_row.match_state_json = json.dumps(engine.serialize(state))
+        session.commit()
+        session.close()
+
+        # Human bids last (passes as dealer) — no hidden bids will remain
+        resp = client.post(
+            f"/play/{link_uuid}/bid",
+            data={
+                "turn_number": 3,
+                "bid_n": 0,
+                "bid_contract": "",
+            },
+        )
+        assert resp.status_code == 200
+
+        # Verify: settle pause is active (auction_settled = False)
+        result2 = get_match_state(app, link_uuid)
+        assert result2 is not None
+        state2, _, session2 = result2
+        session2.close()
+        hand2 = state2.current_hand
+        assert hand2 is not None
+        # No hidden bids — all 4 are revealed
+        assert hand2.revealed_auction_count == len(hand2.auction)
+        # But settle pause IS active so the user can see the result
+        assert hand2.auction_settled is False
+
+        # The board should show the settle pause interstitial
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        assert "Auction complete" in resp.text
+
+        # Dismiss the settle pause
+        resp = client.post(f"/play/{link_uuid}/next")
+        assert resp.status_code == 200
+
+        result3 = get_match_state(app, link_uuid)
+        assert result3 is not None
+        state3, _, session3 = result3
+        session3.close()
+        hand3 = state3.current_hand
+        assert hand3 is not None
+        assert hand3.auction_settled is True
+        # Now in trick play (or moon exchange if bid was moon)
+        assert hand3.phase in ("trick_play", "moon_exchange")
 
 
 # ---------------------------------------------------------------------------

--- a/web/routes.py
+++ b/web/routes.py
@@ -1378,10 +1378,18 @@ async def submit_bid(
                 len(current_hand.auction),
                 pre_auction_count + 1,
             )
-            # Activate settle pause when hidden bids remain after auto-advance.
-            # When the human bids last (no hidden bids), settle stays True and
-            # play proceeds immediately — no extra click needed (#2134).
+            # Activate settle pause so the user can review the auction
+            # result before play begins.  Two cases:
+            # 1. Hidden bids remain (AI bid after the human) — reveal one
+            #    at a time, then show the settle interstitial.
+            # 2. No hidden bids but auction just completed (human bid last)
+            #    — still pause so the user sees who won and what was bid
+            #    before trick play starts (#2438).
+            # Redeals (all passed) skip the settle pause because the redeal
+            # interstitial already communicates the outcome.
             if _has_hidden_auction(current_hand):
+                current_hand.auction_settled = False
+            elif current_hand.phase != "auction" and current_hand.phase != "redeal":
                 current_hand.auction_settled = False
 
         # Log AI decisions captured during auto-advance


### PR DESCRIPTION
## Plan
N/A — single bug fix.

## Summary
- When the human bids last (e.g. as dealer), the auction log panel collapsed immediately and trick play began without showing the auction result
- Now activates the settle pause after all auction completions (except redeals), so the player always sees who won the bid and what was bid before play starts
- Added a deterministic state-injection test to guarantee coverage of the human-bids-last scenario

## Why
Go-live user proving found that the auction log closes immediately after the user's action when they bid last. The player never sees the full auction result (who won, what contract) before cards start playing. This hurts UX because the player needs that context to plan their play.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_routes.py::TestAuctionRevealUX -xvs
uv run python -m pytest tests/unit/hosted_play/ tests/integration/hosted_play/ -x -q
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A (deterministic state injection test)

## Test Criteria
- **Pass condition:** `test_settle_pause_when_human_bids_last_injected` passes — verifies `auction_settled=False` after human bids last, "Auction complete" text shown, and dismiss transitions to trick play
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_routes.py::TestAuctionRevealUX::test_settle_pause_when_human_bids_last_injected -xvs`
- **Expected result:** 1 passed

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/ -x -q` — 3443 passed, 9 skipped
- [x] `uv run python -m pytest tests/unit/hosted_play/ tests/integration/hosted_play/ -x -q` — 3490 passed, 15 skipped
- [x] `make lint` — clean

## Expected impact
- Metrics impact: None
- Runtime impact: One additional "Next" click per hand when human is the dealer — negligible

## Risk level
- [x] Medium (browser game UX flow change)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
```

`git worktree list` (relevant line):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c   07c97899 [fix/auction-log-closes-early-2438]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Issue Linkage
Refs #2438

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
- [x] Issue linkage uses correct keyword (`Fixes` vs `Refs`) per closure policy