### PR TITLE
feat(web): add dedication page to new player onboarding flow

### DIFF
--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -3906,8 +3906,8 @@ class TestOnboarding:
         assert resp.status_code == 200
         assert "onboarding_welcome" in resp.text or "Welcome" in resp.text
 
-    def test_onboarding_next_advances_to_guide_step(self, client, app):
-        """POST /onboarding/next with step=0 shows the first guide step."""
+    def test_onboarding_next_step0_shows_dedication(self, client, app):
+        """POST /onboarding/next with step=0 shows the dedication page."""
         link_uuid = _create_game(client)
         _set_nickname(client, link_uuid)
         resp = client.post(
@@ -3915,34 +3915,52 @@ class TestOnboarding:
             data={"step": "0"},
         )
         assert resp.status_code == 200
-        assert "onboarding_guide" in resp.text or "guide" in resp.text.lower()
+        assert "dedication" in resp.text.lower()
 
-    def test_onboarding_next_advances_through_all_steps(self, client, app):
-        """Walking through all 3 guide steps completes onboarding."""
+    def test_onboarding_next_step1_shows_guide(self, client, app):
+        """POST /onboarding/next with step=1 advances from dedication to guide."""
         link_uuid = _create_game(client)
         _set_nickname(client, link_uuid)
-        # Step 0 → guide step 1
-        resp = client.post(
-            f"/play/{link_uuid}/onboarding/next",
-            data={"step": "0"},
-        )
-        assert resp.status_code == 200
-        # Step 1 → guide step 2
         resp = client.post(
             f"/play/{link_uuid}/onboarding/next",
             data={"step": "1"},
         )
         assert resp.status_code == 200
-        # Step 2 → guide step 3
+        assert "onboarding_guide" in resp.text or "How to Play" in resp.text
+
+    def test_onboarding_next_advances_through_all_steps(self, client, app):
+        """Walking through dedication + 3 guide steps completes onboarding."""
+        link_uuid = _create_game(client)
+        _set_nickname(client, link_uuid)
+        # Step 0 → dedication
+        resp = client.post(
+            f"/play/{link_uuid}/onboarding/next",
+            data={"step": "0"},
+        )
+        assert resp.status_code == 200
+        assert "dedication" in resp.text.lower()
+        # Step 1 → guide step 1
+        resp = client.post(
+            f"/play/{link_uuid}/onboarding/next",
+            data={"step": "1"},
+        )
+        assert resp.status_code == 200
+        # Step 2 → guide step 2
         resp = client.post(
             f"/play/{link_uuid}/onboarding/next",
             data={"step": "2"},
         )
         assert resp.status_code == 200
-        # Step 3 → completes onboarding, shows model_select
+        # Step 3 → guide step 3
         resp = client.post(
             f"/play/{link_uuid}/onboarding/next",
             data={"step": "3"},
+        )
+        assert resp.status_code == 200
+        # Step 4 → completes onboarding, shows model_select
+        resp = client.post(
+            f"/play/{link_uuid}/onboarding/next",
+            data={"step": "4"},
         )
         assert resp.status_code == 200
         assert "model_select" in resp.text or "Choose" in resp.text
@@ -3995,8 +4013,8 @@ class TestOnboarding:
         """After walking through all steps, onboarding_complete=1 in DB."""
         link_uuid = _create_game(client)
         _set_nickname(client, link_uuid)
-        # Walk through all steps
-        for step in range(4):
+        # Walk through all steps (dedication at step 1 + 3 guide steps)
+        for step in range(5):
             client.post(
                 f"/play/{link_uuid}/onboarding/next",
                 data={"step": str(step)},

--- a/web/routes.py
+++ b/web/routes.py
@@ -1117,8 +1117,15 @@ async def set_nickname(
         session.close()
 
 
-# Total number of onboarding guide steps (0-indexed pages within the guide).
-_ONBOARDING_GUIDE_STEPS = 3
+# Onboarding flow step layout:
+#   step 0 = welcome letter (already shown on page load)
+#   step 1 = dedication page
+#   steps 2..4 = guide walkthrough (3 steps)
+# After step 4 → model selection.
+_ONBOARDING_DEDICATION_STEP = 1
+_ONBOARDING_GUIDE_FIRST_STEP = 2
+_ONBOARDING_GUIDE_STEPS = 3  # number of guide walkthrough steps
+_ONBOARDING_LAST_STEP = _ONBOARDING_GUIDE_FIRST_STEP + _ONBOARDING_GUIDE_STEPS - 1
 
 
 @router.post("/play/{link_uuid}/onboarding/next", response_class=HTMLResponse)
@@ -1129,8 +1136,9 @@ async def onboarding_next(
 ):
     """Advance through onboarding steps.
 
-    Step 0 = welcome letter (already shown) → returns guide step 1.
-    Steps 1..N = guide walkthrough pages.
+    Step 0 = welcome letter (already shown) → returns dedication page.
+    Step 1 = dedication page → returns guide step 1.
+    Steps 2..4 = guide walkthrough pages.
     After the last guide step, marks onboarding complete and returns model
     selection.
     """
@@ -1144,7 +1152,7 @@ async def onboarding_next(
         next_step = step + 1
 
         # Past the last guide step → complete onboarding
-        if next_step > _ONBOARDING_GUIDE_STEPS:
+        if next_step > _ONBOARDING_LAST_STEP:
             player.onboarding_complete = 1
             session.commit()
             ai_manager = _get_ai_manager(request)
@@ -1161,15 +1169,28 @@ async def onboarding_next(
                 )
             )
 
+        # Dedication page
+        if next_step == _ONBOARDING_DEDICATION_STEP:
+            return HTMLResponse(
+                templates.get_template("partials/onboarding_dedication.html").render(
+                    {
+                        "request": request,
+                        "link_uuid": link_uuid,
+                    }
+                )
+            )
+
         # Show the next guide step
+        guide_step = next_step - _ONBOARDING_GUIDE_FIRST_STEP + 1
         return HTMLResponse(
             templates.get_template("partials/onboarding_guide.html").render(
                 {
                     "request": request,
                     "link_uuid": link_uuid,
                     "nickname": player.nickname,
-                    "step": next_step,
+                    "step": guide_step,
                     "total_steps": _ONBOARDING_GUIDE_STEPS,
+                    "onboarding_step": next_step,
                 }
             )
         )

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -2101,6 +2101,51 @@ main {
     }
 }
 
+/* Dedication page — generous typography for a meaningful pause */
+.onboarding--dedication {
+    max-width: 560px;
+}
+
+.onboarding__card--dedication {
+    padding: 2.5rem 2rem;
+}
+
+.onboarding__dedication {
+    text-align: left;
+    margin-bottom: 2rem;
+}
+
+.onboarding__dedication p {
+    font-size: 1rem;
+    line-height: 1.8;
+    color: var(--color-text-muted);
+    margin: 0 0 1.25rem;
+}
+
+.onboarding__dedication .dedication__opening {
+    font-size: 1.15rem;
+    font-weight: 600;
+    font-style: italic;
+    color: var(--color-text);
+    margin-bottom: 1.5rem;
+}
+
+@media (max-width: 600px) {
+    .onboarding--dedication {
+        max-width: 100%;
+    }
+    .onboarding__card--dedication {
+        padding: 1.5rem 1rem;
+    }
+    .onboarding__dedication p {
+        font-size: 0.92rem;
+        line-height: 1.7;
+    }
+    .onboarding__dedication .dedication__opening {
+        font-size: 1.05rem;
+    }
+}
+
 /* --------------------------------------------------------------------------
    12b. Landing Page & Invite Code Form
    -------------------------------------------------------------------------- */

--- a/web/templates/partials/onboarding_dedication.html
+++ b/web/templates/partials/onboarding_dedication.html
@@ -1,0 +1,93 @@
+{# Onboarding dedication page partial — meaningful pause in new player flow.
+   Shown after the welcome letter and before the How to Play guide.
+
+   Context variables:
+     - link_uuid: str — player's game link UUID
+#}
+<div id="onboarding" class="onboarding onboarding--dedication" role="region"
+     aria-label="Dedication">
+    <div class="onboarding__card onboarding__card--dedication">
+        <div class="onboarding__dedication">
+            <p class="dedication__opening">
+                This game is dedicated to Bud and Barbara.
+            </p>
+
+            <p>
+                After a long day turning vines in the field, my
+                grandparents&rsquo; dining table had a rhythm to it. Freshly
+                sliced cantaloupe, a couple of Oreos, and a card game that I
+                didn&rsquo;t fully understand yet but couldn&rsquo;t get enough
+                of. That game was Bid Euchre, and it belonged to my
+                grandparents, Bud and Barbara.
+            </p>
+
+            <p>
+                My family is funny. We know less about each other&rsquo;s lives
+                than we do about how each other plays cards. So-and-so always
+                bids conservative. So-and-so plays aggressive and then yells at
+                their partner when it goes sideways. Whether it&rsquo;s
+                Christmas, Thanksgiving, or a funeral, idle kitchen chit-chat
+                will eventually be broken up by hooting and hollering from the
+                other room. Somebody just shot the moon and made it.
+            </p>
+
+            <p>
+                I didn&rsquo;t realize how much this game meant to me until I
+                went home last Thanksgiving. Each time we sit down to play, I
+                think we all feel a little closer to Bud and Barbara.
+            </p>
+
+            <p>
+                This isn&rsquo;t the Euchre people play to pass an afternoon.
+                What makes this version different is the bidding round.
+                That&rsquo;s the part that separates the veterans from the
+                newcomers we swear we&rsquo;ll go easy on. As far as I can
+                tell, this exact ruleset is something only my family plays.
+                There are similar variants out there, but I haven&rsquo;t found
+                this one in the wild. I&rsquo;ll write up the full rules in a
+                future post.
+            </p>
+
+            <p>
+                For now, the game is here. Try it out, climb the leaderboard,
+                and leave a comment if you find bugs or anything that feels off.
+            </p>
+
+            <p>
+                The bots are real competition, but they&rsquo;re not perfect
+                yet. They&rsquo;ll make bad bids. They&rsquo;ll misplay a hand.
+                The best way to sharpen them is to put them up against real
+                people, and that&rsquo;s where you come in. Play the game. Yell
+                at the bot when it messed up, just like you would across the
+                table.
+            </p>
+
+            <p>
+                One thing worth knowing upfront: when you play, you&rsquo;re
+                helping me collect gameplay data, including hands, bids, plays,
+                and outcomes. The goal is to use that to improve the bots over
+                time, and eventually share some insights that might help us all
+                play a little better.
+            </p>
+
+            <p>
+                Have fun. My hope is that this becomes something we can all play
+                to stay connected, and something worth sharing with anyone
+                who&rsquo;s never had the pleasure of learning this silly,
+                wonderful game.
+            </p>
+        </div>
+
+        <div class="onboarding__actions">
+            <button type="button"
+                    class="onboarding__btn onboarding__btn--primary"
+                    hx-post="/play/{{ link_uuid }}/onboarding/next"
+                    hx-vals='{"step": 1}'
+                    hx-target="#game-board"
+                    hx-swap="morph:innerHTML"
+                    aria-label="Continue to game guide">
+                Continue
+            </button>
+        </div>
+    </div>
+</div>

--- a/web/templates/partials/onboarding_guide.html
+++ b/web/templates/partials/onboarding_guide.html
@@ -94,23 +94,15 @@
             <button type="button"
                     class="onboarding__btn onboarding__btn--primary"
                     hx-post="/play/{{ link_uuid }}/onboarding/next"
-                    hx-vals='{"step": {{ step }}}'
+                    hx-vals='{"step": {{ onboarding_step }}}'
                     hx-target="#game-board"
                     hx-swap="morph:innerHTML"
                     aria-label="{% if step == total_steps %}Finish guide and start playing{% else %}Continue to next step{% endif %}">
                 {% if step == total_steps %}
-                    Let's Play!
+                    Let&rsquo;s Play!
                 {% else %}
                     Next &rarr;
                 {% endif %}
-            </button>
-            <button type="button"
-                    class="onboarding__btn onboarding__btn--skip"
-                    hx-post="/play/{{ link_uuid }}/onboarding/skip"
-                    hx-target="#game-board"
-                    hx-swap="morph:innerHTML"
-                    aria-label="Skip remaining guide steps">
-                Skip
             </button>
         </div>
     </div>

--- a/web/templates/partials/onboarding_welcome.html
+++ b/web/templates/partials/onboarding_welcome.html
@@ -23,8 +23,7 @@
             </p>
             <p>
                 Before your first game, we'll walk you through the basics.
-                It only takes a minute &mdash; or you can skip ahead if you
-                already know how to play.
+                It only takes a minute.
             </p>
         </div>
 
@@ -35,16 +34,8 @@
                     hx-vals='{"step": 0}'
                     hx-target="#game-board"
                     hx-swap="morph:innerHTML"
-                    aria-label="Continue to game guide">
-                Show Me How to Play
-            </button>
-            <button type="button"
-                    class="onboarding__btn onboarding__btn--skip"
-                    hx-post="/play/{{ link_uuid }}/onboarding/skip"
-                    hx-target="#game-board"
-                    hx-swap="morph:innerHTML"
-                    aria-label="Skip guide and start playing">
-                I Know How to Play &mdash; Skip
+                    aria-label="Continue to dedication">
+                Continue
             </button>
         </div>
     </div>


### PR DESCRIPTION
## Plan
N/A — operator-requested feature (issue #2455)

## Summary
- Add a dedication page between welcome and how-to-play guide in the new player onboarding flow
- Remove "I know how to play, skip" button from welcome page and "Skip" buttons from guide pages
- New flow: welcome → **dedication** → how to play (3 steps) → model select

## Why
The dedication page is a meaningful personal note from the game's creator, honoring the grandparents who inspired the game. It should be part of every new player's first experience. The skip option is removed so new players engage with the full onboarding flow.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_routes.py::TestOnboarding -v
make check-gated
```

**Config (if applicable):** N/A

**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** `onboarding_next(step=0)` returns dedication page, full 5-step flow completes to model_select, no skip buttons in templates
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_routes.py::TestOnboarding -v`
- **Expected result:** All 11 tests pass including new `test_onboarding_next_step0_shows_dedication` and `test_onboarding_next_step1_shows_guide`

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_routes.py -x -q` — 126 passed, 2 skipped
- [x] `make check-gated` — 11,285 passed (3 pre-existing cpu_gate failures under fleet load)

## Expected impact
- Metrics impact: None (onboarding flow only)
- Runtime impact: None

## Risk level
- [x] Low (UI change, no engine/rules impact)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d  e9c36930 [feat/dedication-page]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Issue Linkage
Refs #2455

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
- [x] Issue linkage uses correct keyword (`Fixes` vs `Refs`) per closure policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)