### PR TITLE
fix(web): show final trick result before hand-result screen

### DIFF
--- a/src/bid_euchre/hosted_play/engine.py
+++ b/src/bid_euchre/hosted_play/engine.py
@@ -281,8 +281,10 @@ class MatchEngine:
         hand_after = state.current_hand
         if hand_after is not None and len(hand_after.completed_tricks) > pre_tricks:
             # Human's card completed a trick — pause to show the result
-            # before any further AI play.
-            if hand_after.phase == "trick_play":
+            # before any further AI play.  This includes trick 10 (hand
+            # complete) so the player sees the final trick result before
+            # the hand-result screen (#2210).
+            if hand_after.phase in ("trick_play", "complete"):
                 hand_after.paused_after_trick = True
             return state
 
@@ -721,12 +723,14 @@ class MatchEngine:
                 # After an AI card play, always pause for per-card reveal.
                 # If the trick just completed, use paused_after_trick; otherwise
                 # use paused_after_play so the UI reveals one card at a time.
+                # Includes trick 10 (hand complete) so the final trick result
+                # is shown before the hand-result screen (#2210).
                 hand_after = state.current_hand
                 if (
                     hand_after is not None
                     and len(hand_after.completed_tricks) > pre_tricks
                 ):
-                    if hand_after.phase == "trick_play":
+                    if hand_after.phase in ("trick_play", "complete"):
                         hand_after.paused_after_trick = True
                     return state
 

--- a/tests/unit/hosted_play/test_engine.py
+++ b/tests/unit/hosted_play/test_engine.py
@@ -2822,3 +2822,69 @@ class TestGluttonBowerFix:
         assert (
             rb_no_trump < ace_no_trump
         ), "Without trump info, J should be valued lower than A (the bug)"
+
+
+# ---------------------------------------------------------------------------
+# Trick 10 pause — final trick result interstitial (#2210)
+# ---------------------------------------------------------------------------
+
+
+class TestFinalTrickPause:
+    """After trick 10, paused_after_trick must be True so the UI shows the
+    final trick result before the hand-result screen (#2210)."""
+
+    def test_trick_10_sets_paused_after_trick(self) -> None:
+        """When the last card of trick 10 completes the hand, the engine
+        sets paused_after_trick=True so the route layer can show the trick
+        result interstitial before the hand-result screen."""
+        engine = MatchEngine(
+            bidding_policy=FixedBidder(5, "S"),
+            play_strategy=FirstLegalPlay(),
+        )
+
+        # Use _play_full_hand which drives through auction + tricks.
+        # After our fix, the hand should end with paused_after_trick=True.
+        for seed in range(50):
+            state = engine.start_match(seed, "heuristic")
+            state = _play_full_hand(engine, state)
+            hand = state.current_hand
+            if hand is not None and hand.phase == "complete":
+                # Key assertion: after trick 10, paused_after_trick must be
+                # True so the UI shows the final trick result.
+                assert hand.paused_after_trick, (
+                    f"seed={seed}: trick 10 completed the hand but "
+                    f"paused_after_trick is False — the final trick result "
+                    f"interstitial would be skipped"
+                )
+                assert len(hand.completed_tricks) == 10
+                return  # Test passed
+
+        pytest.skip("No seed produced a normal hand completion in range(50)")
+
+    def test_clearing_pause_on_complete_hand(self) -> None:
+        """After clearing paused_after_trick on a complete hand, the hand
+        remains in phase='complete' and paused_after_trick=False, ready
+        for the hand-result screen."""
+        engine = MatchEngine(
+            bidding_policy=FixedBidder(5, "S"),
+            play_strategy=FirstLegalPlay(),
+        )
+
+        for seed in range(50):
+            state = engine.start_match(seed, "heuristic")
+            state = _play_full_hand(engine, state)
+            hand = state.current_hand
+            if hand is None or hand.phase != "complete":
+                continue
+
+            if hand.paused_after_trick:
+                # Simulate what the /next route handler does: clear the flag
+                hand.paused_after_trick = False
+
+                # Hand should still be complete
+                assert hand.phase == "complete"
+                assert not hand.paused_after_trick
+                assert len(hand.completed_tricks) == 10
+                return  # Test passed
+
+        pytest.skip("No seed produced a complete hand with paused_after_trick")

--- a/web/routes.py
+++ b/web/routes.py
@@ -275,6 +275,7 @@ def _awaiting_next(hand) -> bool:
         or _has_pending_exchange(hand)
         or (hand.phase == "trick_play" and hand.paused_after_play)
         or (hand.phase == "trick_play" and hand.paused_after_trick)
+        or (hand.phase == "complete" and hand.paused_after_trick)
         or hand.phase == "redeal"
     )
 
@@ -302,6 +303,8 @@ def _next_reason(hand) -> str | None:
         return "Reveal the next card."
     if hand.phase == "trick_play" and hand.paused_after_trick:
         return "Continue to the next trick."
+    if hand.phase == "complete" and hand.paused_after_trick:
+        return "See the hand result."
     if hand.phase == "redeal":
         return "All players passed. Deal a new hand."
     return None
@@ -320,15 +323,26 @@ def _game_phase(state, *, force_match_result: bool = False) -> str:
         the match-result screen.  Used by the ``/next-hand`` handler after
         the player has already seen the final hand result (#2239).
     """
+    hand = state.current_hand
+
+    # Trick-result interstitial: when the last trick just completed and
+    # paused_after_trick is set (including trick 10 where hand.phase is
+    # already "complete"), show the trick_play board so the player sees
+    # the final trick result before advancing to hand_result (#2210).
+    if (
+        hand is not None
+        and hand.paused_after_trick
+        and hand.phase in ("trick_play", "complete")
+    ):
+        return "trick_play"
+
     if state.status == "complete":
         # Show the final hand result before the match-over screen so the
         # player can review the last hand (#2239).  The hand_result partial
         # renders a "See Match Results" CTA when match_status == "complete".
-        hand = state.current_hand
         if not force_match_result and hand is not None and hand.phase == "complete":
             return "hand_result"
         return "match_result"
-    hand = state.current_hand
     if hand is None:
         return "model_select"
     if hand.phase == "complete":
@@ -546,7 +560,15 @@ def _build_game_context(
         # trick-play turn after auto-advance, which is misleading during the
         # auction-settle interstitial (#2237).
         visible["current_seat"] = None
-    if hand is not None and hand.phase == "trick_play" and hand.paused_after_trick:
+    if (
+        hand is not None
+        and hand.paused_after_trick
+        and hand.phase
+        in (
+            "trick_play",
+            "complete",
+        )
+    ):
         visible["current_trick"] = None
 
     ctx: dict[str, Any] = {
@@ -1737,6 +1759,16 @@ async def next_step(
             .order_by(Match.created_at.desc())
             .first()
         )
+        # Fallback: when the final trick completed AND ended the match,
+        # the match is already "complete" in the DB but paused_after_trick
+        # still needs to be cleared for the trick-result interstitial (#2210).
+        if match_row is None:
+            match_row = (
+                session.query(Match)
+                .filter_by(player_id=player.id, status="complete")
+                .order_by(Match.created_at.desc())
+                .first()
+            )
         if match_row is None:
             raise HTTPException(status_code=404, detail="No active match")
 
@@ -1788,6 +1820,10 @@ async def next_step(
             # The engine will play one AI card (with per-card pacing),
             # reach the human's turn, or hit hand/match end.
             state = engine.resume_ai(state)
+        elif hand.phase == "complete" and hand.paused_after_trick:
+            # Final trick (trick 10) result dismissed — clear the pause
+            # flag so the game shows the hand-result screen (#2210).
+            hand.paused_after_trick = False
         elif hand.phase == "redeal":
             next_sub = "redeal"
             # All players passed — persist the terminal redeal hand,


### PR DESCRIPTION
## Plan
N/A — isolated bug fix.

## Summary
- When trick 10 completed, the game jumped directly to the hand-result screen without showing the final trick's cards and winner
- Now the final trick result is shown with a "Next" button, just like every other trick

## Why
After the last card on trick 10 was played, `paused_after_trick` was only set when `hand.phase == "trick_play"`, but trick 10 transitions the hand to `phase="complete"` immediately. This caused the trick-result interstitial to be skipped for the final trick of every hand.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_engine.py::TestFinalTrickPause -xvs
uv run python -m pytest tests/unit/hosted_play/test_routes.py -x
uv run python -m pytest tests/unit/hosted_play/ -x
make check  # full validation
```

## Test Criteria
- **Pass condition:** After trick 10, `hand.paused_after_trick` is `True` even when `hand.phase == "complete"`
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_engine.py::TestFinalTrickPause -xvs`
- **Expected result:** 2 tests pass — `test_trick_10_sets_paused_after_trick` and `test_clearing_pause_on_complete_hand`

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_engine.py -x` — 107 passed, 2 skipped
- [x] `uv run python -m pytest tests/unit/hosted_play/test_routes.py -x` — 124 passed, 2 skipped
- [x] `uv run python -m pytest tests/e2e/hosted_play/ -x` — 24 passed
- [x] Full test suite: 11287 passed, 59 skipped

## Expected impact
- Metrics impact: None (UI pacing only)
- Runtime impact: None

## Risk level
- [ ] Low (docs/tests only)
- [x] Medium (web routes + hosted play engine)
- [ ] High (core rules/sim/scoring)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
```

`git worktree list` (relevant line):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c  f91dbdd9 [fix/trick-10-skip-to-endgame-2210]
```

## Issue Linkage
Refs #2210

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
- [x] Issue linkage uses correct keyword (`Fixes` vs `Refs`) per closure policy