### PR TITLE
fix(web): hide LB/RB bower badges during auction phase

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -3635,6 +3635,29 @@ class TestBowerDisplay:
         )
         assert "card--bower" not in html
 
+    def test_hand_no_bower_during_auction_even_with_trump_set(self, env):
+        """No bower badge during auction settle pause when trump leaks (#2473).
+
+        During the auction settle interstitial, the engine may have already
+        resolved the contract (setting trump/contract_type), but the template
+        phase is still "auction".  Bower badges must not appear.
+        """
+        tmpl = env.get_template("partials/hand.html")
+        # J♣ would be right bower of clubs — but phase is auction
+        html = tmpl.render(
+            link_uuid="test-uuid",
+            turn_number=0,
+            human_hand=[["C", "J"], ["S", "J"], ["H", "A"]],
+            legal_plays=None,
+            phase="auction",
+            contract_type="suit",
+            trump="C",
+        )
+        assert "card--bower" not in html
+        assert ">RB<" not in html
+        assert ">LB<" not in html
+        assert "bower" not in html.lower().replace("is_bower", "")
+
     # -- trick_history.html: card in history table --
 
     def test_left_bower_in_history_shows_printed_suit(self, env):

--- a/web/templates/partials/hand.html
+++ b/web/templates/partials/hand.html
@@ -26,7 +26,9 @@
             {% set rank = card[1] %}
             {% set idx = loop.index0 %}
             {% set disp_suit = card[0] %}
-            {% set bower = card|is_bower(trump | default(None, true), contract_type | default(None, true)) %}
+            {# Suppress bower badges during auction — trump is undecided so
+               bower status is unknown (#2473). #}
+            {% set bower = card|is_bower(trump | default(None, true), contract_type | default(None, true)) if phase != "auction" else "" %}
             {% set suit_class = suit_classes.get(disp_suit, "spades") %}
             {% set suit_sym = suit_symbols.get(disp_suit, disp_suit) %}
             {% set suit_name = suit_names.get(disp_suit, disp_suit) %}


### PR DESCRIPTION
## Summary
- Suppress bower badge (LB/RB) computation on hand cards when the game phase is `auction`
- Add regression test covering the auction-settle-pause scenario where trump/contract_type leak into the template context

## Why
During the auction settle pause, the engine has already resolved the contract (setting `trump` and `contract_type`), but the template phase is still `"auction"`. The `is_bower` filter was evaluating with the leaked trump value, causing LB/RB badges to appear on hand cards before the player has seen the auction result. Bower status is unknown until trump is decided — badges must only appear during play.

Fixes #2473

## Root Cause
`_build_game_context` in `routes.py` overrides `trump`/`contract_type` to `None` during the hidden-auction-reveal state (lines 535-536), but does NOT override them during the settle-pause state (lines 548-562). The hand template received real trump values and rendered bower badges.

## Fix
Template-level guard in `hand.html`: the `is_bower` filter is bypassed (returns `""`) when `phase == "auction"`, regardless of whether `trump`/`contract_type` are set in the context.

## Repro / Validation
```bash
# Targeted bower display tests
uv run python -m pytest tests/unit/hosted_play/test_partials.py -k "TestBowerDisplay" -v

# Full hosted play suite
uv run python -m pytest tests/unit/hosted_play/ -x

# Tier 2 validation
make check-gated
```

## Tests
- `test_hand_no_bower_during_auction_even_with_trump_set` — new test covering the exact bug scenario (auction phase with trump/contract_type set)
- Existing `test_hand_no_bower_without_trump` — continues to pass
- All 10 `TestBowerDisplay` tests pass
- `make check-gated` passes (1 unrelated flaky test in `test_post_merge_review_hook.py`)

## Worktree Proof
```
pwd: Bid-Euchre-steward-brws-author-c
branch: fix/web-hide-bower-badges-auction
```