### PR TITLE
fix(web): extend team color classes to all player name contexts (#2346)

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -2262,8 +2262,8 @@ class TestContractBar:
         assert "Current Contract and Trump:" in html
         assert "6" in html
         assert "\u2665" in html  # Heart symbol
-        # AI declarer name wrapped in .ai-name span (#2288.4)
-        assert 'class="ai-name">Slim</span>' in html
+        # AI declarer name wrapped in .ai-name with team color (#2346)
+        assert 'class="ai-name player-name--ai">Slim</span>' in html
 
     def test_high_contract(self, env):
         """High (no-trump) contract by human shows 'by You'."""
@@ -2278,7 +2278,7 @@ class TestContractBar:
         )
         assert "7" in html
         assert "High" in html
-        assert "by You" in html
+        assert 'player-name--human">You</span>' in html
         assert "contract-bar--my-team" in html
         # Human name should NOT be wrapped in ai-name
         assert "ai-name" not in html
@@ -2298,8 +2298,8 @@ class TestContractBar:
         )
         assert "7" in html
         assert "Low" in html
-        # AI declarer name wrapped in .ai-name span (#2288.4)
-        assert 'class="ai-name">Ace</span>' in html
+        # Partner declarer name wrapped in .ai-name with human team color (#2346)
+        assert 'class="ai-name player-name--human">Ace</span>' in html
         assert "contract-bar--my-team" in html
 
     def test_moon_contract(self, env):
@@ -2316,8 +2316,8 @@ class TestContractBar:
         assert "Moon" in html
         assert "contract-bar__type--moon" in html
         assert "\u2660" in html  # Spade symbol
-        # AI declarer name wrapped in .ai-name span (#2288.4)
-        assert 'class="ai-name">Deuce</span>' in html
+        # AI declarer name wrapped in .ai-name with team color (#2346)
+        assert 'class="ai-name player-name--ai">Deuce</span>' in html
         assert "contract-bar--opp-team" in html
 
     def test_loner_contract(self, env):
@@ -2334,7 +2334,7 @@ class TestContractBar:
         assert "Loner" in html
         assert "contract-bar__type--loner" in html
         assert "\u2666" in html  # Diamond symbol
-        assert "by You" in html
+        assert 'player-name--human">You</span>' in html
         assert "contract-bar--my-team" in html
         # Human name should NOT be wrapped in ai-name
         assert "ai-name" not in html
@@ -2416,12 +2416,12 @@ class TestContractBar:
             phase="trick_play",
         )
         assert "contract-bar" in html
-        assert "by You" in html
+        assert 'player-name--human">You</span>' in html
         assert "\u2663" in html  # Club symbol
         assert "contract-bar--my-team" in html
 
     def test_partner_declarer_label(self, env):
-        """Partner (seat 2) shows 'by Ace' wrapped in ai-name."""
+        """Partner (seat 2) shows 'by Ace' with human team color."""
         tmpl = env.get_template("partials/contract_bar.html")
         html = tmpl.render(
             winning_bid=5,
@@ -2431,11 +2431,11 @@ class TestContractBar:
             trump="S",
             phase="trick_play",
         )
-        assert 'class="ai-name">Ace</span>' in html
+        assert 'class="ai-name player-name--human">Ace</span>' in html
         assert "contract-bar--my-team" in html
 
     def test_opponent_seat1_declarer_label(self, env):
-        """Left opponent (seat 1) shows 'by Slim' wrapped in ai-name."""
+        """Left opponent (seat 1) shows 'by Slim' with AI team color."""
         tmpl = env.get_template("partials/contract_bar.html")
         html = tmpl.render(
             winning_bid=5,
@@ -2445,11 +2445,11 @@ class TestContractBar:
             trump="H",
             phase="trick_play",
         )
-        assert 'class="ai-name">Slim</span>' in html
+        assert 'class="ai-name player-name--ai">Slim</span>' in html
         assert "contract-bar--opp-team" in html
 
     def test_opponent_seat3_declarer_label(self, env):
-        """Right opponent (seat 3) shows 'by Deuce' wrapped in ai-name."""
+        """Right opponent (seat 3) shows 'by Deuce' with AI team color."""
         tmpl = env.get_template("partials/contract_bar.html")
         html = tmpl.render(
             winning_bid=8,
@@ -2459,7 +2459,7 @@ class TestContractBar:
             trump="C",
             phase="trick_play",
         )
-        assert 'class="ai-name">Deuce</span>' in html
+        assert 'class="ai-name player-name--ai">Deuce</span>' in html
         assert "contract-bar--opp-team" in html
 
     def test_header_label_suit(self, env):

--- a/web/templates/partials/bid_panel.html
+++ b/web/templates/partials/bid_panel.html
@@ -30,7 +30,7 @@
                 {% for entry in auction %}
                 {% set entry_bid_type = entry.get("bid_type", "regular") %}
                 <tr{% if entry_bid_type == "moon" %} class="bid--moon"{% elif entry_bid_type == "loner" %} class="bid--loner"{% endif %}>
-                    <td>{% if entry.seat != 0 %}<span class="ai-name">{{ seat_labels.get(entry.seat, "Seat " ~ entry.seat) }}</span>{% else %}{{ seat_labels.get(entry.seat, "Seat " ~ entry.seat) }}{% endif %}</td>
+                    <td>{% if entry.seat != 0 %}<span class="ai-name player-name--{{ 'human' if entry.seat == 2 else 'ai' }}">{{ seat_labels.get(entry.seat, "Seat " ~ entry.seat) }}</span>{% else %}<span class="player-name--human">{{ seat_labels.get(entry.seat, "Seat " ~ entry.seat) }}</span>{% endif %}</td>
                     <td>
                         {% if entry.action == "pass" %}
                             Pass
@@ -129,7 +129,7 @@
         {% endif %}
     </p>
     {% endif %}
-    <p class="bid-info">Dealer: {% if dealer_seat != 0 %}<span class="ai-name">{{ seat_labels.get(dealer_seat, "Seat " ~ dealer_seat) }}</span>{% else %}{{ seat_labels.get(dealer_seat, "Seat " ~ dealer_seat) }}{% endif %}</p>
+    <p class="bid-info">Dealer: {% if dealer_seat != 0 %}<span class="ai-name player-name--{{ 'human' if dealer_seat == 2 else 'ai' }}">{{ seat_labels.get(dealer_seat, "Seat " ~ dealer_seat) }}</span>{% else %}<span class="player-name--human">{{ seat_labels.get(dealer_seat, "Seat " ~ dealer_seat) }}</span>{% endif %}</p>
 </div>
 
 <script>

--- a/web/templates/partials/bid_recap.html
+++ b/web/templates/partials/bid_recap.html
@@ -16,7 +16,7 @@
 {% if winning_bid is not none and bidder_seat is not none %}
 <div class="bid-recap" role="status" aria-label="Auction result">
     <span class="bid-recap__declarer">
-        {% if bidder_seat != 0 %}<span class="ai-name">{{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}</span>{% else %}{{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}{% endif %}
+        {% if bidder_seat != 0 %}<span class="ai-name player-name--{{ 'human' if bidder_seat == 2 else 'ai' }}">{{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}</span>{% else %}<span class="player-name--human">{{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}</span>{% endif %}
     </span>
     <span class="bid-recap__separator" aria-hidden="true">bid</span>
     <span class="bid-recap__contract">
@@ -45,7 +45,7 @@
     {# Use "is not none" (not truthy) — seat 0 is the human and is valid. #}
     {% if sitting_out_seat is not none %}
     <span class="bid-recap__sitting-out" aria-label="Sitting out: {{ seat_labels.get(sitting_out_seat, 'Seat ' ~ sitting_out_seat) }}">
-        ({% if sitting_out_seat != 0 %}<span class="ai-name">{{ seat_labels.get(sitting_out_seat, "Seat " ~ sitting_out_seat) }}</span>{% else %}{{ seat_labels.get(sitting_out_seat, "Seat " ~ sitting_out_seat) }}{% endif %} sits out)
+        ({% if sitting_out_seat != 0 %}<span class="ai-name player-name--{{ 'human' if sitting_out_seat == 2 else 'ai' }}">{{ seat_labels.get(sitting_out_seat, "Seat " ~ sitting_out_seat) }}</span>{% else %}<span class="player-name--human">{{ seat_labels.get(sitting_out_seat, "Seat " ~ sitting_out_seat) }}</span>{% endif %} sits out)
     </span>
     {% endif %}
 </div>

--- a/web/templates/partials/contract_bar.html
+++ b/web/templates/partials/contract_bar.html
@@ -54,9 +54,9 @@
         {% endif %}
     </span>
 
-    {# Declarer — "by Name" (AI names blue via .ai-name #2288.4) #}
+    {# Declarer — "by Name" with team color (#2346) #}
     <span class="contract-bar__declarer">
-        by {% if bidder_seat != 0 %}<span class="ai-name">{{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}</span>{% else %}{{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}{% endif %}
+        by {% if bidder_seat != 0 %}<span class="ai-name player-name--{{ 'human' if bidder_seat == 2 else 'ai' }}">{{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}</span>{% else %}<span class="player-name--human">{{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}</span>{% endif %}
     </span>
 </div>
 {% elif phase is defined and phase == "auction" %}
@@ -66,7 +66,7 @@
         {% if current_high_bid is defined and current_high_bid is not none and current_high_bid > 0 %}
             High Bid: {{ current_high_bid }}
             {% if high_bidder_seat is defined and high_bidder_seat is not none %}
-                by {{ seat_labels.get(high_bidder_seat, "Seat " ~ high_bidder_seat) }}
+                by {% if high_bidder_seat != 0 %}<span class="ai-name player-name--{{ 'human' if high_bidder_seat == 2 else 'ai' }}">{{ seat_labels.get(high_bidder_seat, "Seat " ~ high_bidder_seat) }}</span>{% else %}<span class="player-name--human">{{ seat_labels.get(high_bidder_seat, "Seat " ~ high_bidder_seat) }}</span>{% endif %}
             {% endif %}
         {% else %}
             Auction in Progress

--- a/web/templates/partials/hand_result.html
+++ b/web/templates/partials/hand_result.html
@@ -90,7 +90,7 @@
         {% endif %}
 
         <p class="result-detail">
-            {% if bidder_seat != 0 %}<span class="ai-name">{{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}</span>{% else %}{{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}{% endif %}
+            {% if bidder_seat != 0 %}<span class="ai-name player-name--{{ 'human' if bidder_seat == 2 else 'ai' }}">{{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}</span>{% else %}<span class="player-name--human">{{ seat_labels.get(bidder_seat, "Seat " ~ bidder_seat) }}</span>{% endif %}
             {% if hand_bid_type == "moon" %}
                 bid Moon
             {% elif hand_bid_type == "loner" %}
@@ -116,11 +116,11 @@
             <div class="result-exchange" aria-label="Moon exchange summary">
                 <p class="exchange-title"><strong>Moon Exchange</strong></p>
                 <p class="exchange-details">
-                    Given {{ exchange_given_cards|length }} to partner ({% if partner_seat != 0 %}<span class="ai-name">{{ partner_seat_label }}</span>{% else %}{{ partner_seat_label }}{% endif %}):
+                    Given {{ exchange_given_cards|length }} to partner ({% if partner_seat != 0 %}<span class="ai-name player-name--{{ 'human' if partner_seat == 2 else 'ai' }}">{{ partner_seat_label }}</span>{% else %}<span class="player-name--human">{{ partner_seat_label }}</span>{% endif %}):
                     {% for card in exchange_given_cards %}<span class="card-text" aria-label="{{ suit_symbols.get(card[0], card[0]) }}{{ card[1]|display_rank }}"><span class="suit-icon suit-icon--{{ suit_classes.get(card[0], 'spades') }}">{{ suit_symbols.get(card[0], card[0]) }}</span> {{ card[1]|display_rank }}</span>{% if not loop.last %}, {% endif %}{% endfor %}
                 </p>
                 <p class="exchange-details">
-                    Received {{ exchange_received_cards|length }} from partner ({% if partner_seat != 0 %}<span class="ai-name">{{ partner_seat_label }}</span>{% else %}{{ partner_seat_label }}{% endif %}):
+                    Received {{ exchange_received_cards|length }} from partner ({% if partner_seat != 0 %}<span class="ai-name player-name--{{ 'human' if partner_seat == 2 else 'ai' }}">{{ partner_seat_label }}</span>{% else %}<span class="player-name--human">{{ partner_seat_label }}</span>{% endif %}):
                     {% for card in exchange_received_cards %}<span class="card-text" aria-label="{{ suit_symbols.get(card[0], card[0]) }}{{ card[1]|display_rank }}"><span class="suit-icon suit-icon--{{ suit_classes.get(card[0], 'spades') }}">{{ suit_symbols.get(card[0], card[0]) }}</span> {{ card[1]|display_rank }}</span>{% if not loop.last %}, {% endif %}{% endfor %}
                 </p>
             </div>

--- a/web/templates/partials/moon_exchange.html
+++ b/web/templates/partials/moon_exchange.html
@@ -27,7 +27,7 @@
             <span aria-hidden="true">&#x1F319;</span> Moon Exchange
         </h2>
         <p class="moon-exchange__subtitle">
-            {% if bidder_seat != 0 %}<span class="ai-name">{{ mooner_label }}</span>{% else %}{{ mooner_label }}{% endif %} bid Moon
+            {% if bidder_seat != 0 %}<span class="ai-name player-name--{{ 'human' if bidder_seat == 2 else 'ai' }}">{{ mooner_label }}</span>{% else %}<span class="player-name--human">{{ mooner_label }}</span>{% endif %} bid Moon
             {% if contract_type == "suit" and trump %}
                 in <span class="suit-icon suit-icon--{{ suit_classes.get(trump, 'spades') }}">{{ suit_symbols.get(trump, trump) }}</span>
             {% elif contract_type == "high" %}
@@ -42,7 +42,7 @@
         {% if exchange_given_cards %}
             <div class="moon-exchange__group">
                 <h3 class="moon-exchange__group-title">
-                    Given to {% if partner_seat != 0 %}<span class="ai-name">{{ partner_label }}</span>{% else %}{{ partner_label }}{% endif %}
+                    Given to {% if partner_seat != 0 %}<span class="ai-name player-name--{{ 'human' if partner_seat == 2 else 'ai' }}">{{ partner_label }}</span>{% else %}<span class="player-name--human">{{ partner_label }}</span>{% endif %}
                 </h3>
                 <div class="moon-exchange__card-list" role="list">
                     {% for card in exchange_given_cards %}
@@ -65,7 +65,7 @@
         {% if exchange_received_cards %}
             <div class="moon-exchange__group">
                 <h3 class="moon-exchange__group-title">
-                    Received from {% if partner_seat != 0 %}<span class="ai-name">{{ partner_label }}</span>{% else %}{{ partner_label }}{% endif %}
+                    Received from {% if partner_seat != 0 %}<span class="ai-name player-name--{{ 'human' if partner_seat == 2 else 'ai' }}">{{ partner_label }}</span>{% else %}<span class="player-name--human">{{ partner_label }}</span>{% endif %}
                 </h3>
                 <div class="moon-exchange__card-list" role="list">
                     {% for card in exchange_received_cards %}

--- a/web/templates/partials/moon_exchange_select.html
+++ b/web/templates/partials/moon_exchange_select.html
@@ -22,7 +22,7 @@
             <span aria-hidden="true">&#x1F319;</span> Moon Exchange
         </h2>
         <p class="moon-exchange__subtitle">
-            {% if bidder_seat != 0 %}<span class="ai-name">{{ mooner_label }}</span>{% else %}{{ mooner_label }}{% endif %} bid Moon
+            {% if bidder_seat != 0 %}<span class="ai-name player-name--{{ 'human' if bidder_seat == 2 else 'ai' }}">{{ mooner_label }}</span>{% else %}<span class="player-name--human">{{ mooner_label }}</span>{% endif %} bid Moon
             {% if contract_type == "suit" and trump %}
                 in <span class="suit-icon suit-icon--{{ suit_classes.get(trump, 'spades') }}">{{ suit_symbols.get(trump, trump) }}</span>
             {% elif contract_type == "high" %}


### PR DESCRIPTION
## Summary
- Add `player-name--human` / `player-name--ai` team color classes to all remaining player name spans that previously used bare `.ai-name` (which renders all AI names in blue, even the partner on the human team)
- Affects: bid_panel, bid_recap, contract_bar, hand_result, moon_exchange, moon_exchange_select templates
- Update test assertions in `test_partials.py` to match the new class patterns

## Why
Prior PRs (#2370, #2411) added team color classes to compass seats and removed `.ai-card-count`, but missed several secondary templates. Player names in the auction log, bid recap, contract bar, hand result, and moon exchange still showed all non-human seats in blue (AI color) regardless of whether they're on the human's team (seat 2) or the opponent team (seats 1, 3).

## Changes
| Template | Fix |
|----------|-----|
| `bid_panel.html` | Auction transcript entries + dealer label |
| `bid_recap.html` | Declarer name + sitting-out name |
| `contract_bar.html` | Declarer name + auction high bidder |
| `hand_result.html` | Bidder name + partner exchange labels |
| `moon_exchange.html` | Mooner name + partner labels |
| `moon_exchange_select.html` | Mooner name |

Pattern applied consistently:
- Seat 0 (human): `<span class="player-name--human">` (green, no `.ai-name`)
- Seat 2 (partner): `<span class="ai-name player-name--human">` (green)
- Seats 1, 3 (opponents): `<span class="ai-name player-name--ai">` (blue)

## Repro / Validation
```bash
uv run python -m pytest tests/unit/hosted_play/ -x
make check-gated
```

## Tests
- `uv run python -m pytest tests/unit/hosted_play/` — 3462 passed, 8 skipped
- `make check-gated` — all checks passed
- Updated 8 test assertions in `test_partials.py` to verify team color classes

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
Branch: fix/web-player-name-styling
```

Refs #2346

🤖 Generated with [Claude Code](https://claude.com/claude-code)