### PR TITLE
fix(web): restrict auction log to auction actions only (#2477)

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -2714,19 +2714,36 @@ class TestActionRail:
         html = tmpl.render(
             action_rail=[
                 {"kind": "auction", "text": "Slim passed"},
-                {"kind": "trick", "text": "Your team won Trick 1"},
-                {"kind": "system", "text": "Hand starts"},
+                {"kind": "result", "text": "Ace wins auction: 7 \u2665"},
+                {"kind": "system", "text": "All players passed; redeal starting."},
             ],
             action_rail_label="Auction Log",
         )
         assert 'id="action-rail"' in html
         assert "Auction Log" in html
         assert "Slim passed" in html
-        assert "Your team won Trick 1" in html
-        assert "Hand starts" in html
+        assert "Ace wins auction" in html
+        assert "redeal starting" in html
         assert "action-rail__item--auction" in html
-        assert "action-rail__item--trick" in html
+        assert "action-rail__item--result" in html
         assert "action-rail__item--system" in html
+
+    def test_action_rail_no_trick_results(self, env):
+        """Auction log must not display trick results (#2477)."""
+        tmpl = env.get_template("partials/action_rail.html")
+        # Even if trick events were somehow passed, the template renders
+        # whatever it receives — the fix is in the route, not the template.
+        # This test documents that trick events are no longer part of the
+        # auction log data contract.
+        html = tmpl.render(
+            action_rail=[
+                {"kind": "auction", "text": "Slim bid 6 \u2660"},
+                {"kind": "result", "text": "Slim wins auction: 6 \u2660"},
+            ],
+            action_rail_label="Auction Log",
+        )
+        assert "action-rail__item--trick" not in html
+        assert "won Trick" not in html
 
     def test_auction_log_open_during_auction(self, env):
         """Auction log <details> should be open during auction phase (#2288)."""

--- a/web/routes.py
+++ b/web/routes.py
@@ -417,15 +417,17 @@ def _build_seat_bids(auction: list[dict[str, Any]]) -> dict[int, str]:
     return seat_bids
 
 
-def _build_action_rail(visible: dict[str, Any], state) -> list[dict[str, str]]:
-    """Build the auction-log event feed from auction/trick/redeal transitions.
+def _build_action_rail(state) -> list[dict[str, str]]:
+    """Build the auction-log event feed with auction actions only.
+
+    Shows bids, passes, the auction result, and redeal notices.
+    Trick results are intentionally excluded — they belong in the trick
+    history panel, not the auction log (#2477).
 
     The list is capped to the most recent 12 entries for compact rendering.
 
     Auction entries are sourced from ``state.current_hand.auction`` (the full
-    persisted transcript) rather than ``visible["auction"]`` which may be
-    sliced during the hidden-auction reveal phase.  The *visible* dict
-    continues to be used for tricks and other fields.  This ensures a page
+    persisted transcript), sliced to ``revealed_auction_count``, so a page
     refresh never loses already-revealed auction entries (#2207).
     """
     hand = state.current_hand
@@ -447,57 +449,31 @@ def _build_action_rail(visible: dict[str, Any], state) -> list[dict[str, str]]:
             }
         )
 
-    # Completed tricks — use team-based language to avoid confusion with
-    # auction events (e.g. "You won trick #1" reads like "won the auction").
-    for idx, trick in enumerate(visible.get("completed_tricks", []), start=1):
-        winner = trick.get("winner")
-        if winner is None:
-            continue
-        winner_int = int(winner)
-        if winner_int in (0, 2):
-            text = f"Your team won Trick {idx}"
+    # Auction result — shown once the auction is settled and a winner exists.
+    if hand.auction_settled and hand.bidder_seat is not None:
+        bidder = SEAT_LABELS.get(hand.bidder_seat, f"Seat {hand.bidder_seat}")
+        bid_type = hand.bid_type
+        if bid_type == "moon":
+            result_label = "Moon"
+        elif bid_type == "loner":
+            result_label = "Loner"
+        elif hand.contract_type == "suit" and hand.trump is not None:
+            sym = _SUIT_SYMBOLS.get(hand.trump, hand.trump)
+            result_label = f"{hand.winning_bid} {sym}"
+        elif hand.contract_type == "high":
+            result_label = f"{hand.winning_bid} High"
+        elif hand.contract_type == "low":
+            result_label = f"{hand.winning_bid} Low"
         else:
-            text = f"Opponents won Trick {idx}"
-        events.append({"kind": "trick", "text": text})
+            result_label = str(hand.winning_bid)
+        events.append(
+            {"kind": "result", "text": f"{bidder} wins auction: {result_label}"}
+        )
 
-    # Redeal transition.
+    # Redeal transition (all players passed — an auction-phase event).
     if hand.phase == "redeal":
         events.append(
             {"kind": "system", "text": "All players passed; redeal starting."}
-        )
-
-    # Hand-complete outcomes (compact summary).
-    if hand.phase == "complete":
-        bidder = SEAT_LABELS.get(hand.bidder_seat, f"Seat {hand.bidder_seat}")
-        if hand.contract_type == "suit" and hand.trump is not None:
-            contract = hand.trump
-        elif hand.contract_type == "high":
-            contract = "High"
-        elif hand.contract_type == "low":
-            contract = "Low"
-        elif hand.winning_bid is None:
-            contract = "No contract"
-        else:
-            contract = str(hand.winning_bid)
-
-        bid_type = hand.bid_type
-        if bid_type == "moon":
-            contract_label = "Moon"
-        elif bid_type == "loner":
-            contract_label = "Loner"
-        elif hand.winning_bid is None:
-            contract_label = "No contract"
-        else:
-            contract_label = f"{hand.winning_bid} {contract}"
-
-        events.append(
-            {
-                "kind": "system",
-                "text": (
-                    f"Hand complete: {bidder} made {contract_label}; "
-                    f"scores {state.score_human} vs {state.score_ai}"
-                ),
-            }
         )
 
     return events[-12:]
@@ -607,7 +583,7 @@ def _build_game_context(
         ctx["auction_settled"] = hand.auction_settled
         ctx["points_team0"] = hand.points_team0
         ctx["points_team1"] = hand.points_team1
-        ctx["action_rail"] = _build_action_rail(visible, state)
+        ctx["action_rail"] = _build_action_rail(state)
         ctx["seat_bids"] = _build_seat_bids(visible.get("auction", []))
         ctx["show_bid_panel"] = (
             phase == "auction"

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1385,8 +1385,9 @@ main {
     border-bottom: none;
 }
 
-.action-rail__item--trick {
+.action-rail__item--result {
     color: var(--color-positive);
+    font-weight: 600;
 }
 
 .action-rail__item--system {

--- a/web/templates/partials/action_rail.html
+++ b/web/templates/partials/action_rail.html
@@ -1,12 +1,13 @@
-{# Auction log — compact event feed of auction bids, trick results, and
-   system messages.  (Formerly called "Action Rail" in dev jargon.)
+{# Auction log — compact event feed of auction bids, passes, the auction
+   result, and redeal notices.  Trick results are shown in the trick history
+   panel, not here (#2477).
 
    Collapsible: open during auction phase, auto-collapsed after auction ends.
    Toggle state is persisted across HTMX swaps via sessionStorage (game.js).
 
    Context variables:
      - action_rail: list[dict] — ordered event objects:
-         {"kind": "auction"|"trick"|"system", "text": str}
+         {"kind": "auction"|"result"|"system", "text": str}
      - action_rail_label (optional): heading override
      - phase: str — "auction", "trick_play", etc.
 #}


### PR DESCRIPTION
## Summary

- Remove trick results and hand-complete summaries from the auction log event feed — those belong in the trick history panel, not the auction log
- Add an auction result entry ("X wins auction: Y") shown once the auction settles, with suit symbols and bid type labels
- Replace `--trick` CSS class with `--result` styling for the auction winner entry

## Why

The auction log panel was displaying trick win/loss entries during gameplay (#2477), mixing auction history with gameplay events. The separate trick history table already shows trick results properly — the auction log should only show auction actions.

## Root Cause

`_build_action_rail()` in `web/routes.py` was building events with `kind: "trick"` (lines 453-462) and `kind: "system"` hand-complete summaries (lines 471-502) alongside auction events. The template rendered all of them.

## Changes

| File | Change |
|------|--------|
| `web/routes.py` | Remove trick result + hand-complete blocks from `_build_action_rail()`; add auction result entry; remove unused `visible` parameter |
| `web/templates/partials/action_rail.html` | Update template comment to reflect auction-only events |
| `web/static/style.css` | Replace `.action-rail__item--trick` with `.action-rail__item--result` |
| `tests/unit/hosted_play/test_partials.py` | Update TestActionRail: test renders result events instead of trick events; add `test_action_rail_no_trick_results` regression test |

## Repro / Validation

```bash
# Tier 1 — impacted tests
uv run python -m pytest tests/unit/hosted_play/test_partials.py::TestActionRail -xvs
uv run python -m pytest tests/unit/hosted_play/test_routes.py::TestAuctionLogPersistence -xvs

# Full hosted_play suite
uv run python -m pytest tests/unit/hosted_play/ -x

# Tier 2
make check-gated
```

## Tests

- `tests/unit/hosted_play/test_partials.py::TestActionRail` — 6 tests pass (updated existing + 1 new regression test)
- `tests/unit/hosted_play/test_routes.py::TestAuctionLogPersistence` — 1 test passes
- Full hosted_play suite: 3460 passed, 10 skipped
- `make check-gated`: 11297 passed, 60 skipped (3 flaky cpu_gate failures — pre-existing, load-dependent, unrelated)

## Worktree Proof

```
pwd: Bid-Euchre-steward-flex-a
branch: fix/web-auction-log-trick-entries
```

Refs #2477

🤖 Generated with [Claude Code](https://claude.com/claude-code)