### PR TITLE
feat(web): add back button to onboarding intro/dedication flow

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1937,8 +1937,9 @@ main {
 /* Action buttons */
 .onboarding__actions {
     display: flex;
-    flex-direction: column;
+    flex-wrap: wrap;
     gap: 0.5rem;
+    justify-content: center;
     align-items: center;
 }
 
@@ -1960,6 +1961,19 @@ main {
 
 .onboarding__btn--primary:hover {
     background: var(--color-legal-glow);
+}
+
+.onboarding__btn--back {
+    background: transparent;
+    color: var(--color-text-muted);
+    border: 1px solid var(--color-text-muted);
+    min-width: auto;
+    padding: 0.6rem 1.2rem;
+}
+
+.onboarding__btn--back:hover {
+    color: var(--color-text);
+    border-color: var(--color-text);
 }
 
 .onboarding__btn--skip {

--- a/web/templates/partials/onboarding_dedication.html
+++ b/web/templates/partials/onboarding_dedication.html
@@ -80,6 +80,14 @@
 
         <div class="onboarding__actions">
             <button type="button"
+                    class="onboarding__btn onboarding__btn--back"
+                    hx-get="/play/{{ link_uuid }}"
+                    hx-target="#game-board"
+                    hx-swap="morph:outerHTML"
+                    aria-label="Back to welcome">
+                &larr; Back
+            </button>
+            <button type="button"
                     class="onboarding__btn onboarding__btn--primary"
                     hx-post="/play/{{ link_uuid }}/onboarding/next"
                     hx-vals='{"step": 1}'

--- a/web/templates/partials/onboarding_guide.html
+++ b/web/templates/partials/onboarding_guide.html
@@ -92,6 +92,15 @@
         {# ---- Navigation buttons ---- #}
         <div class="onboarding__actions">
             <button type="button"
+                    class="onboarding__btn onboarding__btn--back"
+                    hx-post="/play/{{ link_uuid }}/onboarding/next"
+                    hx-vals='{"step": {{ onboarding_step - 2 }}}'
+                    hx-target="#game-board"
+                    hx-swap="morph:innerHTML"
+                    aria-label="Back to previous step">
+                &larr; Back
+            </button>
+            <button type="button"
                     class="onboarding__btn onboarding__btn--primary"
                     hx-post="/play/{{ link_uuid }}/onboarding/next"
                     hx-vals='{"step": {{ onboarding_step }}}'


### PR DESCRIPTION
## Summary
- Adds a back button to the **dedication page** and all three **How-to-Play guide steps** so users can navigate backward through the onboarding sequence
- Welcome page (first step) has no back button
- Template-only change — no `routes.py` modification needed

## Why
Users reported being unable to navigate backward through the onboarding intro sequence (#2470). The flow was forward-only, which is frustrating if a user wants to re-read something.

## How It Works

### Guide pages (steps 1-3)
The back button uses HTMX POST to `/onboarding/next` with `step={{ onboarding_step - 2 }}`, which reuses the existing route logic to render the previous step:
- Guide step 1 → back sends `step=0` → route renders dedication ✓
- Guide step 2 → back sends `step=1` → route renders guide step 1 ✓
- Guide step 3 → back sends `step=2` → route renders guide step 2 ✓

### Dedication page
The back button uses HTMX GET to `/play/{uuid}`. Since the player's `onboarding_complete` is still `0`, the server returns `game_content.html` with the welcome phase, giving a smooth morph-swap back to the welcome screen.

## Changes
| File | Change |
|------|--------|
| `web/templates/partials/onboarding_dedication.html` | Add back button (HTMX GET) |
| `web/templates/partials/onboarding_guide.html` | Add back button (HTMX POST with step offset) |
| `web/static/style.css` | New `--back` button variant + row layout for actions |

## Repro / Validation
```bash
# Tier 1 — onboarding tests
uv run python -m pytest tests/unit/hosted_play/ -x -k "onboarding"
# 11 passed ✓

# Tier 1 — full hosted_play suite
uv run python -m pytest tests/unit/hosted_play/ -x
# 3462 passed, 8 skipped ✓

# Tier 2 — full validation
make check-gated
# 11296 passed (3 pre-existing cpu_gate flakes unrelated)
```

## Worktree proof
```
pwd: Bid-Euchre-steward-brws-author-b
branch: feat/web-onboarding-back-button
```

Refs #2470

🤖 Generated with [Claude Code](https://claude.com/claude-code)