### PR TITLE
fix(test): improve go-live proving test robustness

### DIFF
--- a/tests/browser/test_go_live_proving.py
+++ b/tests/browser/test_go_live_proving.py
@@ -9,6 +9,8 @@ These tests are NOT included in ``make check``.  Run via::
 
 Issues proven:
 - #2331 — Auction log repositions below hand details during gameplay
+- #2462 — Detect auction state independently of human bid panel
+- #2463 — Handle auction reveal/redeal after test submits Pass
 """
 
 from __future__ import annotations
@@ -75,15 +77,18 @@ def test_auction_log_repositions_during_gameplay(
     # to advance through AI actions.
     _advance_next_steps(page)
 
-    # Wait for auction or trick-play phase to materialize
+    # Wait for auction or trick-play phase to materialize.
+    # Use #action-rail (always present) or #trick-area (trick play) rather
+    # than #bid-panel, which only renders on the human's turn to bid (#2462).
     page.wait_for_selector(
-        "#bid-panel, #trick-area, #human-hand",
+        "#action-rail, #trick-area, #human-hand",
         timeout=10000,
     )
 
-    # Check if we caught the auction phase
-    bid_panel = page.locator("#bid-panel")
-    auction_caught = bid_panel.count() > 0
+    # Detect auction phase via the action-rail data attribute — this is
+    # independent of the human bid panel visibility (#2462).
+    action_rail_auction = page.locator("#action-rail[data-phase='auction']")
+    auction_caught = action_rail_auction.count() > 0
 
     if auction_caught:
         # During auction: action-rail should be INSIDE .compass-layout
@@ -117,10 +122,15 @@ def test_auction_log_repositions_during_gameplay(
         """)
         assert is_open is True, "During auction, action-rail <details> should be open"
 
-        # Submit a pass bid to advance past auction
+        # Submit a pass bid to advance past auction.
+        # After Pass, the game may show an auction reveal (Next button),
+        # transition to trick play, or trigger a redeal if all players
+        # passed — wait for any of these states (#2463).
         page.click("button.pass-btn")
         page.wait_for_selector(
-            "#trick-area, #hand-result, #match-result",
+            "#trick-area, #hand-result, #match-result, "
+            "button.btn--next-step, "
+            "#action-rail[data-phase='trick_play']",
             timeout=10000,
         )
         _advance_next_steps(page)


### PR DESCRIPTION
## Plan
N/A — convention follow-up batch from review coordinator findings

## Summary
- Close #2449 and #2457 as false positives (reviewer found no issues)
- Fix #2462: detect auction state via `#action-rail[data-phase="auction"]` instead of `#bid-panel`
- Fix #2463: broaden post-Pass wait selector to handle auction reveals and redeals

## Why
The go-live proving test relied on `#bid-panel` to detect auction state, but
that element only renders when it's the human's turn to bid. This made
`auction_caught` falsely return `False` when an AI was the current bidder.
Similarly, after submitting Pass, the test only waited for final states
(`#trick-area`, `#hand-result`, `#match-result`) but not intermediate
transitions like auction reveal or redeal.

## Repro / Validation
**Command(s) run:**
```
make check-gated
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** `make check-gated` passes; the test file uses `#action-rail[data-phase]` for auction detection
- **Verification command:** `grep -c "action-rail\[data-phase" tests/browser/test_go_live_proving.py`
- **Expected result:** `2` (one for auction detection, one for post-Pass wait)

## Tests
- [x] `make check-gated` — all checks passed
- [ ] Browser smoke (not included in make check, requires Playwright)

## Expected impact
- Metrics impact: None
- Runtime impact: None

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git worktree list` (excerpt):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d   589627be [fix/convention-follow-up-batch]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Issue Linkage
Refs #2462
Refs #2463

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
- [x] Issue linkage uses correct keyword (`Fixes` vs `Refs`) per closure policy