### PR TITLE
fix(web): auto-advance AI card reveals for natural gameplay pacing (#2442, #2386)

### DIFF
--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -353,6 +353,153 @@ class TestNextRevealFlow:
         assert state_after.current_hand.paused_after_trick is False
         session_after.close()
 
+    def test_auto_advance_present_for_ai_card_reveal(self, client, app):
+        """paused_after_play with AI last play renders auto-advance data attr.
+
+        When an AI card was just revealed (paused_after_play and last card
+        played by a non-human seat), the next-controls should include a
+        data-auto-advance attribute so that client JS auto-triggers the
+        Next endpoint after the CSS animation delay (#2442, #2386).
+        """
+        link_uuid = _setup_game(client)
+
+        result = get_match_state(app, link_uuid)
+        assert result is not None
+        state, match_row, session = result
+
+        hand = state.current_hand
+        assert hand is not None
+        hand.phase = "trick_play"
+        hand.current_seat = HUMAN_SEAT
+        hand.turn_number = 6
+        hand.bidder_seat = 1
+        hand.winning_bid = 6
+        hand.bid_type = "regular"
+        hand.contract_type = "suit"
+        hand.trump = "S"
+        hand.revealed_auction_count = len(hand.auction)
+        hand.auction_settled = True
+        hand.hands = [
+            [Card("H", "K"), Card("S", "A")],
+            [],
+            [],
+            [],
+        ]
+        hand.current_trick = TrickState(
+            leader=1, plays=[(1, Card("H", "A")), (2, Card("H", "Q"))]
+        )
+        hand.paused_after_play = True
+        hand.paused_after_trick = False
+        match_row.match_state_json = json.dumps(state.to_dict())
+        session.commit()
+        session.close()
+
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        # Auto-advance attribute should be present (AI seat 2 last played)
+        assert 'data-auto-advance="850"' in resp.text
+        assert "next-controls--auto-advance" in resp.text
+
+    def test_auto_advance_absent_for_trick_result(self, client, app):
+        """paused_after_trick (trick result) does NOT render auto-advance.
+
+        Trick results require manual Next click so the player can see who
+        won the trick before advancing.
+        """
+        link_uuid = _setup_game(client)
+
+        result = get_match_state(app, link_uuid)
+        assert result is not None
+        state, match_row, session = result
+
+        hand = state.current_hand
+        assert hand is not None
+        hand.phase = "trick_play"
+        hand.current_seat = HUMAN_SEAT
+        hand.turn_number = 6
+        hand.bidder_seat = 1
+        hand.winning_bid = 6
+        hand.bid_type = "regular"
+        hand.contract_type = "suit"
+        hand.trump = "S"
+        hand.revealed_auction_count = len(hand.auction)
+        hand.auction_settled = True
+        hand.hands = [
+            [Card("H", "K"), Card("S", "A")],
+            [],
+            [],
+            [],
+        ]
+        hand.completed_tricks = [
+            TrickResult(
+                leader=1,
+                plays=[
+                    (1, Card("D", "A")),
+                    (2, Card("D", "K")),
+                    (3, Card("D", "Q")),
+                    (0, Card("D", "10")),
+                ],
+                winner=1,
+            )
+        ]
+        hand.current_trick = TrickState(leader=1, plays=[(1, Card("H", "A"))])
+        hand.paused_after_trick = True
+        hand.paused_after_play = False
+        match_row.match_state_json = json.dumps(state.to_dict())
+        session.commit()
+        session.close()
+
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        # Manual Next — no auto-advance
+        assert "data-auto-advance" not in resp.text
+        assert "next-controls--auto-advance" not in resp.text
+        assert "Continue to the next trick." in resp.text
+
+    def test_auto_advance_human_card_uses_shorter_delay(self, client, app):
+        """paused_after_play with human last play uses 500ms auto-advance delay.
+
+        When the human just played (not the trick-completing card), the
+        auto-advance delay is shorter (500ms) because no AI card animation
+        is needed — just a brief pause to see the card on the table.
+        """
+        link_uuid = _setup_game(client)
+
+        result = get_match_state(app, link_uuid)
+        assert result is not None
+        state, match_row, session = result
+
+        hand = state.current_hand
+        assert hand is not None
+        hand.phase = "trick_play"
+        hand.current_seat = HUMAN_SEAT
+        hand.turn_number = 6
+        hand.bidder_seat = 1
+        hand.winning_bid = 6
+        hand.bid_type = "regular"
+        hand.contract_type = "suit"
+        hand.trump = "S"
+        hand.revealed_auction_count = len(hand.auction)
+        hand.auction_settled = True
+        hand.hands = [
+            [Card("H", "K"), Card("S", "A")],
+            [],
+            [],
+            [],
+        ]
+        hand.current_trick = TrickState(leader=0, plays=[(0, Card("H", "K"))])
+        hand.paused_after_play = True
+        hand.paused_after_trick = False
+        match_row.match_state_json = json.dumps(state.to_dict())
+        session.commit()
+        session.close()
+
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        # Human card reveal — shorter delay
+        assert 'data-auto-advance="500"' in resp.text
+        assert "next-controls--auto-advance" in resp.text
+
     def test_next_reveals_moon_exchange_and_transitions_to_trick_play(
         self, client, app
     ):

--- a/web/routes.py
+++ b/web/routes.py
@@ -575,6 +575,22 @@ def _build_game_context(
             and last_seat is not None
             and last_seat != HUMAN_SEAT
         )
+
+        # Auto-advance — when paused_after_play (mid-trick reveal), the
+        # client JS auto-triggers the Next endpoint after the animation
+        # completes so the player doesn't have to click Next for every
+        # single AI card.  Manual Next is still required for trick results
+        # (paused_after_trick) and other interstitials (#2442, #2386).
+        if hand.phase == "trick_play" and hand.paused_after_play:
+            is_ai = last_seat is not None and last_seat != HUMAN_SEAT
+            # AI cards: match the CSS animation duration (750ms) + buffer.
+            # Human card: brief pause to see own card on the table.
+            ctx["auto_advance"] = True
+            ctx["auto_advance_delay_ms"] = 850 if is_ai else 500
+        else:
+            ctx["auto_advance"] = False
+            ctx["auto_advance_delay_ms"] = 0
+
         ctx["winning_bid"] = None if _has_hidden_auction(hand) else hand.winning_bid
         ctx["bidder_seat"] = None if _has_hidden_auction(hand) else hand.bidder_seat
         ctx["current_high_bid"] = (
@@ -656,6 +672,8 @@ def _build_game_context(
         ctx["show_bid_panel"] = False
         ctx["last_played_seat"] = None
         ctx["ai_just_played"] = False
+        ctx["auto_advance"] = False
+        ctx["auto_advance_delay_ms"] = 0
 
     return ctx
 

--- a/web/static/game.js
+++ b/web/static/game.js
@@ -648,6 +648,73 @@
         });
     }
 
+    /* ---------------------------------------------------------------
+     * Auto-advance — automatically trigger the Next endpoint after
+     * AI card reveal animations complete.  Reduces per-trick clicks
+     * from 4+ (one per AI card) to 1 (trick result only).
+     * (#2442 latency, #2386 pacing)
+     * --------------------------------------------------------------- */
+
+    var _autoAdvanceTimer = null;
+
+    function cancelAutoAdvance() {
+        if (_autoAdvanceTimer !== null) {
+            clearTimeout(_autoAdvanceTimer);
+            _autoAdvanceTimer = null;
+        }
+    }
+
+    function scheduleAutoAdvance() {
+        cancelAutoAdvance();
+
+        var nextControls = document.querySelector('.next-controls[data-auto-advance]');
+        if (!nextControls) {
+            return;
+        }
+
+        var delayMs = parseInt(nextControls.getAttribute('data-auto-advance'), 10);
+        if (isNaN(delayMs) || delayMs <= 0) {
+            delayMs = 850;
+        }
+
+        var form = nextControls.querySelector('#next-step-form');
+        if (!form) {
+            return;
+        }
+
+        _autoAdvanceTimer = setTimeout(function () {
+            _autoAdvanceTimer = null;
+            // Only auto-advance if the form still exists in the DOM
+            // (HTMX may have swapped it out if the user clicked manually)
+            if (document.body.contains(form)) {
+                htmx.trigger(form, 'submit');
+            }
+        }, delayMs);
+    }
+
+    function attachAutoAdvanceHandler() {
+        // After each HTMX swap on the game board, check if we should
+        // auto-advance the Next step.
+        document.body.addEventListener('htmx:afterSettle', function (event) {
+            var target = event.target;
+            if (!(target instanceof Element) || target.id !== 'game-board') {
+                return;
+            }
+            scheduleAutoAdvance();
+        }, true);
+
+        // Cancel auto-advance if the user navigates away or clicks
+        // something else (e.g., trick history toggle).
+        document.body.addEventListener('htmx:beforeRequest', function (event) {
+            var elt = event.detail && event.detail.elt;
+            // Don't cancel if the auto-advance form itself is firing
+            if (elt && elt.id === 'next-step-form') {
+                return;
+            }
+            cancelAutoAdvance();
+        });
+    }
+
     function initialize() {
         attachDelegatedHandlers();
         attachTabHandlers();
@@ -655,11 +722,15 @@
         attachAuctionLogToggle();
         attachTextSizeToggle();
         attachErrorHandlers();
+        attachAutoAdvanceHandler();
         var form = getCardPlayForm();
         clearCardSelection(form);
         syncCardPlayFormControls(form);
         restoreTrickHistoryState();
         restoreAuctionLogState();
+        // Check for auto-advance on initial page load (e.g., page refresh
+        // while an AI card reveal is pending).
+        scheduleAutoAdvance();
     }
 
     initialize();

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -33,8 +33,8 @@
     /* Team colors — consistent across score, trick count, contract bar */
     --team-human: #66bb6a;
     --team-ai: #42a5f5;
-    /* AI card delay — time before an AI card is revealed (#2330) */
-    --ai-card-delay: 0.8s;
+    /* AI card delay — time before an AI card is revealed (#2330, #2386) */
+    --ai-card-delay: 0.75s;
 }
 
 *,
@@ -266,7 +266,7 @@ main {
 
 /* AI card delay — fade-in animation when AI plays (#2330) */
 .card--ai-delayed {
-    animation: ai-card-reveal var(--ai-card-delay, 0.8s) ease-out both;
+    animation: ai-card-reveal var(--ai-card-delay, 0.75s) ease-out both;
 }
 
 @keyframes ai-card-reveal {
@@ -280,11 +280,22 @@ main {
     }
 }
 
-/* Delay the Next button until the AI card finishes its reveal animation */
-.trick-area--ai-revealing ~ .next-controls {
+/* Delay the Next button until the AI card finishes its reveal animation.
+   When auto-advance is active, the button stays hidden because JS triggers
+   the advance automatically (#2442, #2386). */
+.trick-area--ai-revealing ~ .next-controls:not(.next-controls--auto-advance) {
     opacity: 0;
     pointer-events: none;
-    animation: next-btn-appear 0.3s ease-out var(--ai-card-delay, 0.8s) forwards;
+    animation: next-btn-appear 0.3s ease-out var(--ai-card-delay, 0.75s) forwards;
+}
+
+/* Auto-advancing: hide the Next button entirely — JS auto-submits */
+.next-controls--auto-advance {
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+    height: 0;
+    overflow: hidden;
 }
 
 @keyframes next-btn-appear {

--- a/web/templates/partials/next_controls.html
+++ b/web/templates/partials/next_controls.html
@@ -1,10 +1,17 @@
-{# Unified reveal-step control shown when auction/trick progression is paused. #}
-<div class="next-controls" role="region" aria-label="Continue game progression">
+{# Unified reveal-step control shown when auction/trick progression is paused.
+   When auto_advance is true (mid-trick per-card reveals), JS auto-triggers the
+   Next endpoint after the animation delay so the player doesn't need to click
+   for every AI card (#2442, #2386). #}
+<div class="next-controls{% if auto_advance | default(false) %} next-controls--auto-advance{% endif %}"
+     role="region"
+     aria-label="Continue game progression"
+     {% if auto_advance | default(false) %}data-auto-advance="{{ auto_advance_delay_ms | default(850) }}"{% endif %}>
     {% if next_reason %}
     <p class="next-controls__reason" aria-live="polite">{{ next_reason }}</p>
     {% endif %}
     <div class="next-controls__buttons">
-        <form method="post"
+        <form id="next-step-form"
+              method="post"
               action="/play/{{ link_uuid }}/next"
               hx-post="/play/{{ link_uuid }}/next"
               hx-target="#game-board"


### PR DESCRIPTION
## Plan
N/A — issue-driven UX fix (#2442, #2386)

## Summary
- AI card plays now auto-advance after the CSS animation (750ms) instead of requiring a manual Next click for each AI card
- Reduces per-trick clicks from 4+ (one per AI card) to 1 (trick result only)
- Human card reveals also auto-advance after a brief 500ms pause
- Manual Next preserved for trick results, auction reveals, and other interstitials

## Why
PR #2399 added per-card pacing with manual Next clicks for every AI card. While the server response times are fast (87-933ms per Playwright testing), the high click count per trick made gameplay feel sluggish. This fix preserves the natural card-by-card animation while eliminating the repetitive clicking.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_routes.py -x -q
uv run python -m pytest tests/integration/test_sim_browser_parity.py -x -q
make check-gated
```

## Test Criteria
- **Pass condition:** All hosted_play tests pass (3461+); auto-advance tests verify AI (850ms), human (500ms), and trick-result (no auto-advance) behavior
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_routes.py -k auto_advance -v`
- **Expected result:** 3 auto-advance tests pass — AI card reveals get `data-auto-advance="850"`, human reveals get `data-auto-advance="500"`, trick results do NOT get auto-advance

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_routes.py -k auto_advance` — 3 passed
- [x] `uv run python -m pytest tests/unit/hosted_play/test_routes.py` — 132 passed, 2 skipped
- [x] `uv run python -m pytest tests/integration/test_sim_browser_parity.py` — 27 passed
- [x] `make check-gated` — all checks passed

## Expected impact
- Metrics impact: None (AI play decisions unchanged, only pacing UX)
- Runtime impact: None server-side; client triggers Next automatically after CSS animation

## Risk level
- [x] Medium (web UX — changes click flow for trick play)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git worktree list` (excerpt):
```
Bid-Euchre-steward-brws-author-a   [fix/web-gameplay-pacing]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Issue Linkage
Refs #2442
Refs #2386

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
- [x] Issue linkage uses correct keyword (`Fixes` vs `Refs`) per closure policy