### PR TITLE
fix(web): force auction log open during auction phase (#2488)

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -2808,7 +2808,7 @@ STATIC_DIR = os.path.join(
 
 
 class TestAuctionLogJsToggle:
-    """Verify game.js resets stale sessionStorage on new-hand auction (#2471)."""
+    """Verify game.js auction log toggle logic (#2471, #2488)."""
 
     @pytest.fixture()
     def game_js(self):
@@ -2822,16 +2822,22 @@ class TestAuctionLogJsToggle:
     def test_save_function_exists(self, game_js):
         assert "function saveAuctionLogState()" in game_js
 
-    def test_new_hand_resets_stale_state(self, game_js):
-        """When previousPhase is non-auction and currentPhase is auction,
-        the JS must clear the stale AUCTION_LOG_KEY so the server-rendered
-        open attribute takes effect (#2471)."""
-        # Find the restoreAuctionLogState function body
+    def test_auction_phase_forces_open(self, game_js):
+        """During auction phase, restoreAuctionLogState must always force
+        the details element open, ignoring stale sessionStorage (#2488)."""
         fn_start = game_js.index("function restoreAuctionLogState()")
         fn_block = game_js[fn_start : fn_start + 1800]
-        # Must contain the new-hand reset logic
-        assert "previousPhase !== 'auction'" in fn_block
+        # Must force open during auction (not just conditionally clear)
+        assert "details.open = true" in fn_block
         assert "sessionStorage.removeItem(AUCTION_LOG_KEY)" in fn_block
+
+    def test_auto_collapse_on_phase_transition(self, game_js):
+        """When transitioning from auction to non-auction, the log should
+        auto-collapse and save the closed state."""
+        fn_start = game_js.index("function restoreAuctionLogState()")
+        fn_block = game_js[fn_start : fn_start + 1800]
+        assert "previousPhase === 'auction'" in fn_block
+        assert "details.open = false" in fn_block
 
     def test_auction_log_keys_defined(self, game_js):
         assert "AUCTION_LOG_KEY" in game_js

--- a/web/static/game.js
+++ b/web/static/game.js
@@ -320,29 +320,22 @@
             var previousPhase = sessionStorage.getItem(AUCTION_LOG_PHASE_KEY);
             sessionStorage.setItem(AUCTION_LOG_PHASE_KEY, currentPhase);
 
+            // During auction phase: always force open.
+            // Server renders <details open> during auction, and JS must
+            // not override that based on stale sessionStorage.  Previous
+            // attempts (#2459, #2475) to selectively clear stale state
+            // still left edge cases where saved '0' closed the log.
+            // The authoritative rule is simple: auction → open.  (#2488)
+            if (currentPhase === 'auction') {
+                details.open = true;
+                sessionStorage.removeItem(AUCTION_LOG_KEY);
+                return;
+            }
+
             // Auto-collapse: transition from auction to non-auction phase
             if (previousPhase === 'auction' && currentPhase !== 'auction') {
                 details.open = false;
                 sessionStorage.setItem(AUCTION_LOG_KEY, '0');
-                return;
-            }
-
-            // During auction phase, default to open (server-rendered)
-            if (currentPhase === 'auction') {
-                // New hand: previous phase was non-auction (e.g. trick_play).
-                // Reset stale saved state so server-rendered `open` takes
-                // effect — the '0' left over from auto-collapse should not
-                // close the log for the brand-new auction.
-                if (previousPhase && previousPhase !== 'auction') {
-                    sessionStorage.removeItem(AUCTION_LOG_KEY);
-                    return;
-                }
-                var saved = sessionStorage.getItem(AUCTION_LOG_KEY);
-                // Only override server default if user explicitly closed it
-                // during *this* auction (not stale from a prior hand).
-                if (saved === '0') {
-                    details.open = false;
-                }
                 return;
             }
 


### PR DESCRIPTION
## Plan
N/A — single bug fix.

## Summary
- Simplify `restoreAuctionLogState()` to unconditionally force the auction log open during auction phase
- Remove the complex sessionStorage-based "was it the user or was it stale state?" conditional logic that caused edge cases across 3 bug reports
- Non-auction phase behavior (persist user toggle) unchanged

## Why
The auction log `<details>` element was still collapsing during auction phase despite two prior fix attempts (#2459, #2475). The root cause is that `restoreAuctionLogState()` would read stale `sessionStorage` values and override the server-rendered `open` attribute. The previous selective-clearing approach had edge cases that were hard to eliminate. The fix is to make the rule unconditional: **auction phase → always open**.

### Root Cause Analysis
The old code had this logic during auction phase:
1. If `previousPhase` transitioned from non-auction → auction: clear stale key ✅
2. Otherwise: read `saved` state, close if `'0'` ❌

Case 2 was supposed to handle "user explicitly closed it during this auction", but it could fire with stale `'0'` values from:
- morph:innerHTML toggle events during DOM reconciliation
- Cross-game sessionStorage persistence
- Same-phase auction→auction edge cases (page refresh during auction)

### Fix
Replace all the conditional logic with a single unconditional rule:
```javascript
if (currentPhase === 'auction') {
    details.open = true;
    sessionStorage.removeItem(AUCTION_LOG_KEY);
    return;
}
```

**Tradeoff:** If a user manually closes the auction log during auction, it will re-open on the next HTMX swap (each bid action). This is acceptable because: (a) during auction, seeing bid history is essential for play decisions, (b) the bug reports consistently say users want it open, (c) simplicity prevents future regressions.

## Repro / Validation
```bash
uv run python -m pytest tests/unit/hosted_play/test_partials.py::TestAuctionLogJsToggle -xvs
uv run python -m pytest tests/unit/hosted_play/ -x -q
make check-gated
```

## Test Criteria
- **Pass condition:** `TestAuctionLogJsToggle::test_auction_phase_forces_open` passes — verifies `details.open = true` and `sessionStorage.removeItem` are present in the auction-phase branch
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_partials.py::TestAuctionLogJsToggle -xvs`
- **Expected result:** 5 passed

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/ -x -q` — 3473 passed, 8 skipped
- [x] `make check-gated` — all checks passed

## Expected impact
- Metrics impact: None
- Runtime impact: None — same number of DOM operations per swap

## Risk level
- [x] Low (single JS function simplification)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git worktree list` (relevant line):
```
Bid-Euchre-steward-brws-author-a [fix/web-auction-log-default-open-v3]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Issue Linkage
Refs #2488

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
- [x] Issue linkage uses correct keyword (`Fixes` vs `Refs`) per closure policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)