### PR TITLE
fix(web): filter test/bot players from leaderboard display

### DIFF
--- a/tests/unit/hosted_play/test_leaderboard.py
+++ b/tests/unit/hosted_play/test_leaderboard.py
@@ -19,12 +19,14 @@ import pytest
 
 from web.db import Hand, Match, Player
 from web.leaderboard import (
+    EXCLUDED_TEST_PLAYERS,
     METRIC_DEFINITIONS,
     PlayerStats,
     compute_ai_stats,
     compute_player_stats,
     format_metric,
     get_leaderboard,
+    is_excluded_test_player,
 )
 
 # ---------------------------------------------------------------------------
@@ -603,6 +605,110 @@ class TestGetLeaderboard:
         assert rankings[0].hands_played == 1
         assert rankings[0].matches_played == 0  # no completed matches yet
         assert rankings[0].games_won == 0
+
+
+# ---------------------------------------------------------------------------
+# Test player exclusion tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsExcludedTestPlayer:
+    """Tests for is_excluded_test_player helper."""
+
+    def test_none_nickname_not_excluded(self):
+        assert is_excluded_test_player(None) is False
+
+    def test_exact_match_excluded(self):
+        for name in EXCLUDED_TEST_PLAYERS:
+            assert is_excluded_test_player(name) is True, f"{name} should be excluded"
+
+    def test_prefix_match_excluded(self):
+        assert is_excluded_test_player("FlexBot-A") is True
+        assert is_excluded_test_player("FlexBot-B") is True
+        assert is_excluded_test_player("FlexBot-C") is True
+        assert is_excluded_test_player("FlexBot-D") is True
+        assert is_excluded_test_player("FlexBot-XYZ") is True
+
+    def test_real_player_not_excluded(self):
+        assert is_excluded_test_player("TESTV2") is False
+        assert is_excluded_test_player("PHIL-TEST") is False
+        assert is_excluded_test_player("CINDY-TEST") is False
+        assert is_excluded_test_player("Alice") is False
+
+    def test_case_sensitive(self):
+        # Exact names are case-sensitive
+        assert is_excluded_test_player("claude") is False
+        assert is_excluded_test_player("CLAUDE") is True
+        assert is_excluded_test_player("test") is False
+        assert is_excluded_test_player("TEST") is True
+
+
+class TestLeaderboardExcludesTestPlayers:
+    """get_leaderboard filters out test/bot accounts."""
+
+    def test_excludes_exact_match_player(self, db_session):
+        # Real player should appear
+        real = _make_player(db_session, nickname="RealPlayer")
+        rmatch = _make_match(db_session, real)
+        _make_hand(db_session, rmatch)
+
+        # Test player should be filtered out
+        test = _make_player(db_session, nickname="QUE-TEST")
+        tmatch = _make_match(db_session, test)
+        _make_hand(db_session, tmatch, hand_number=1)
+
+        db_session.flush()
+        rankings = get_leaderboard(db_session)
+
+        assert len(rankings) == 1
+        assert rankings[0].nickname == "RealPlayer"
+
+    def test_excludes_prefix_match_player(self, db_session):
+        real = _make_player(db_session, nickname="RealPlayer")
+        rmatch = _make_match(db_session, real)
+        _make_hand(db_session, rmatch)
+
+        bot = _make_player(db_session, nickname="FlexBot-A")
+        bmatch = _make_match(db_session, bot)
+        _make_hand(db_session, bmatch, hand_number=1)
+
+        db_session.flush()
+        rankings = get_leaderboard(db_session)
+
+        assert len(rankings) == 1
+        assert rankings[0].nickname == "RealPlayer"
+
+    def test_excludes_multiple_test_players(self, db_session):
+        real = _make_player(db_session, nickname="RealPlayer")
+        rmatch = _make_match(db_session, real)
+        _make_hand(db_session, rmatch)
+
+        for i, name in enumerate(["CLAUDE", "StratBot", "FlexBot-B"], start=1):
+            p = _make_player(db_session, nickname=name)
+            m = _make_match(db_session, p)
+            _make_hand(db_session, m, hand_number=i)
+
+        db_session.flush()
+        rankings = get_leaderboard(db_session)
+
+        assert len(rankings) == 1
+        assert rankings[0].nickname == "RealPlayer"
+
+    def test_test_player_data_still_computable(self, db_session):
+        """Test player data remains in DB — compute_player_stats still works."""
+        test = _make_player(db_session, nickname="QUE-TEST")
+        tmatch = _make_match(db_session, test)
+        _make_hand(db_session, tmatch)
+        db_session.flush()
+
+        # Direct computation still works — data is not deleted
+        stats = compute_player_stats(db_session, test.id)
+        assert stats is not None
+        assert stats.nickname == "QUE-TEST"
+
+        # But leaderboard filters them out
+        rankings = get_leaderboard(db_session)
+        assert len(rankings) == 0
 
 
 # ---------------------------------------------------------------------------

--- a/web/leaderboard.py
+++ b/web/leaderboard.py
@@ -27,6 +27,23 @@ HUMAN_TEAM = 0
 # Match statuses that contribute hands to leaderboard stats.
 _LEADERBOARD_MATCH_STATUSES = ("active", "complete", "abandoned")
 
+# Nicknames excluded from leaderboard display (test/bot accounts).
+# Data remains in the DB — this only hides them from the public ranking.
+EXCLUDED_TEST_PLAYERS: frozenset[str] = frozenset(
+    {
+        "QUE-TEST",
+        "StratBot",
+        "Claude-PW",
+        "CLAUDE",
+        "TEST",
+        "Claude-HTTP",
+        "MEEKS-TEST",
+    }
+)
+
+# Nickname prefixes excluded from leaderboard display.
+_EXCLUDED_PREFIXES: tuple[str, ...] = ("FlexBot",)
+
 
 # ---------------------------------------------------------------------------
 # Metric definitions — display metadata for the leaderboard UI
@@ -229,6 +246,18 @@ class PlayerStats:
 
     # AI indicator (must be last — has default value)
     is_ai: bool = False  # True for AI opponent aggregate entries
+
+
+def is_excluded_test_player(nickname: str | None) -> bool:
+    """Return True if *nickname* belongs to a test/bot account.
+
+    Matches are case-sensitive against the exact list and prefix list.
+    """
+    if nickname is None:
+        return False
+    if nickname in EXCLUDED_TEST_PLAYERS:
+        return True
+    return any(nickname.startswith(p) for p in _EXCLUDED_PREFIXES)
 
 
 def compute_player_stats(session: Session, player_id: int) -> PlayerStats | None:
@@ -528,7 +557,7 @@ def get_leaderboard(
     stats_list: list[PlayerStats] = []
     for player_id, _count in player_hand_counts:
         stats = compute_player_stats(session, player_id)
-        if stats is not None:
+        if stats is not None and not is_excluded_test_player(stats.nickname):
             stats_list.append(stats)
 
     # Add AI opponent aggregate entries


### PR DESCRIPTION
## Summary
- Add `EXCLUDED_TEST_PLAYERS` constant and `is_excluded_test_player()` helper to `web/leaderboard.py`
- Filter test/bot accounts from `get_leaderboard()` results — exact matches (QUE-TEST, StratBot, Claude-PW, CLAUDE, TEST, Claude-HTTP, MEEKS-TEST) and prefix matches (FlexBot-*)
- Data remains in DB — only display is filtered; `compute_player_stats()` still works for test players

## Why
Refs #2494 — Go-live requires hiding test/bot accounts from the public leaderboard while preserving their match data in the database.

## Implementation
**Option A (explicit list)** as recommended in the task packet:
- `EXCLUDED_TEST_PLAYERS` frozenset for exact nickname matches
- `_EXCLUDED_PREFIXES` tuple for prefix matching (FlexBot-*)
- `is_excluded_test_player()` public helper combining both checks
- Filter applied post-computation in `get_leaderboard()` — avoids SQL complexity, clear and auditable

## Scope
- `web/leaderboard.py` — filter logic
- `tests/unit/hosted_play/test_leaderboard.py` — 9 new tests

## Repro / Validation
```bash
uv run python -m pytest tests/unit/hosted_play/test_leaderboard.py -x -v
# 76 tests pass (67 existing + 9 new)
make check-gated  # All checks pass
```

## Tests
- `TestIsExcludedTestPlayer` — 5 tests covering None, exact match, prefix match, real players, case sensitivity
- `TestLeaderboardExcludesTestPlayers` — 4 tests covering exact match filtering, prefix filtering, multiple test players, and data preservation

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
branch: fix/web-leaderboard-filter-test-players
```

## Note for operator
The following players are NOT filtered (per task instructions — check with operator if needed): TESTV2, PHIL-TEST, CINDY-TEST, GO-LIVE-TEST, TEST3

🤖 Generated with [Claude Code](https://claude.com/claude-code)