### PR TITLE
fix(web): hide auction winner line during active auction (#2493)

### DIFF
--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -4226,6 +4226,117 @@ class TestAuctionLogPersistence:
             ), f"Auction entry for {seat_label} missing from page refresh response"
 
 
+class TestAuctionLogPrematureWinner:
+    """Winner line must not appear during active auction (#2493)."""
+
+    def test_no_winner_line_during_active_auction(self, client, app):
+        """When AIs have bid but the human hasn't, 'wins auction' must not show.
+
+        Injects a mid-auction state where seat 2 has the current high bid but
+        the human (seat 0) has not yet bid.  The auction log must show only
+        the revealed bid entries — not the result line (#2493).
+        """
+        link_uuid = _setup_game(client)
+
+        result = get_match_state(app, link_uuid)
+        assert result is not None
+        state, match_row, session = result
+
+        hand = state.current_hand
+        assert hand is not None
+
+        # Inject mid-auction state: 2 AIs have bid, human hasn't yet.
+        hand.phase = "auction"
+        hand.auction = [
+            {
+                "seat": 2,
+                "n": 5,
+                "action": "bid",
+                "contract": "H",
+                "bid_type": "regular",
+            },
+            {"seat": 3, "n": 0, "action": "pass"},
+        ]
+        hand.revealed_auction_count = 2  # both AI actions visible
+        hand.auction_settled = True  # default (not yet set by bid handler)
+        hand.bidder_seat = 2
+        hand.winning_bid = 5
+        hand.current_high_bid = 5
+        hand.contract_type = "suit"
+        hand.trump = "H"
+        hand.current_seat = HUMAN_SEAT  # human's turn to bid
+
+        # Persist injected state
+        ai_manager = app.state.ai_manager
+        info = ai_manager.get_model_info(match_row.ai_model)
+        engine = MatchEngine(
+            bidding_policy=info.bidding_policy,
+            play_strategy=info.play_strategy,
+        )
+        match_row.match_state_json = json.dumps(engine.serialize(state))
+        session.commit()
+        session.close()
+
+        # Render the game board — the result line must NOT appear.
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        assert "wins auction" not in resp.text, (
+            "Winner line shown during active auction (bidder_seat was set "
+            "but the auction is still in progress)"
+        )
+
+    def test_winner_line_appears_after_auction_settles(self, client, app):
+        """After the auction settles, the result line is shown normally."""
+        link_uuid = _setup_game(client)
+
+        result = get_match_state(app, link_uuid)
+        assert result is not None
+        state, match_row, session = result
+
+        hand = state.current_hand
+        assert hand is not None
+
+        # Inject settled-auction state: all 4 bids in, auction complete.
+        hand.phase = "trick_play"
+        hand.auction = [
+            {
+                "seat": 2,
+                "n": 5,
+                "action": "bid",
+                "contract": "H",
+                "bid_type": "regular",
+            },
+            {"seat": 3, "n": 0, "action": "pass"},
+            {"seat": 0, "n": 0, "action": "pass"},
+            {"seat": 1, "n": 0, "action": "pass"},
+        ]
+        hand.revealed_auction_count = 4
+        hand.auction_settled = True
+        hand.bidder_seat = 2
+        hand.winning_bid = 5
+        hand.current_high_bid = 5
+        hand.contract_type = "suit"
+        hand.trump = "H"
+        hand.current_seat = 2
+        hand.current_trick = TrickState(leader=2)
+
+        ai_manager = app.state.ai_manager
+        info = ai_manager.get_model_info(match_row.ai_model)
+        engine = MatchEngine(
+            bidding_policy=info.bidding_policy,
+            play_strategy=info.play_strategy,
+        )
+        match_row.match_state_json = json.dumps(engine.serialize(state))
+        session.commit()
+        session.close()
+
+        resp = client.get(f"/play/{link_uuid}")
+        assert resp.status_code == 200
+        assert (
+            "wins auction" in resp.text
+        ), "Winner line missing after auction is settled and complete"
+
+
 # ===================================================================
 # Onboarding Flow Tests
 # ===================================================================

--- a/web/routes.py
+++ b/web/routes.py
@@ -450,7 +450,14 @@ def _build_action_rail(state) -> list[dict[str, str]]:
         )
 
     # Auction result — shown once the auction is settled and a winner exists.
-    if hand.auction_settled and hand.bidder_seat is not None:
+    # Guard on phase != "auction" so the result line does not appear
+    # prematurely when AIs have bid (setting bidder_seat) but the human
+    # hasn't taken their turn yet (#2493).
+    if (
+        hand.phase != "auction"
+        and hand.auction_settled
+        and hand.bidder_seat is not None
+    ):
         bidder = SEAT_LABELS.get(hand.bidder_seat, f"Seat {hand.bidder_seat}")
         bid_type = hand.bid_type
         if bid_type == "moon":


### PR DESCRIPTION
## Summary
- **Bug:** The "X wins auction" result line appeared in the auction log during an active auction when AI players bid before the human
- **Root cause:** `bidder_seat` is set as soon as any player bids (tracking the current high bidder), and `auction_settled` defaults to `True` — so the condition `auction_settled and bidder_seat is not None` was satisfied even though the auction was still in progress
- **Fix:** Add `hand.phase != "auction"` guard to `_build_action_rail()` so the result line only appears after the auction phase has ended

## Why
When the human is not the first bidder (e.g., when they're the dealer), AI bids set `bidder_seat` before the human gets a chance to bid. The auction log then prematurely showed "X wins auction: Y" even though the human hadn't bid yet, spoiling the auction outcome.

## Repro / Validation
```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/hosted_play/test_routes.py::TestAuctionLogPrematureWinner -xvs

# Tier 2 — full validation
make check-gated
```

## Tests
- `TestAuctionLogPrematureWinner::test_no_winner_line_during_active_auction` — injects mid-auction state with AI bids, verifies "wins auction" does NOT appear
- `TestAuctionLogPrematureWinner::test_winner_line_appears_after_auction_settles` — injects settled post-auction state, verifies "wins auction" DOES appear
- Full hosted_play suite: 3472 passed, 9 skipped
- `make check-gated`: all checks passed

## Worktree proof
```
pwd: Bid-Euchre-steward-brws-author-a
branch: fix/web-auction-log-premature-winner
```

Refs #2493

🤖 Generated with [Claude Code](https://claude.com/claude-code)