### PR TITLE
fix(web): add remaining test players to leaderboard exclusion list

### DIFF
--- a/tests/unit/hosted_play/test_leaderboard.py
+++ b/tests/unit/hosted_play/test_leaderboard.py
@@ -630,10 +630,9 @@ class TestIsExcludedTestPlayer:
         assert is_excluded_test_player("FlexBot-XYZ") is True
 
     def test_real_player_not_excluded(self):
-        assert is_excluded_test_player("TESTV2") is False
-        assert is_excluded_test_player("PHIL-TEST") is False
-        assert is_excluded_test_player("CINDY-TEST") is False
         assert is_excluded_test_player("Alice") is False
+        assert is_excluded_test_player("Phil") is False
+        assert is_excluded_test_player("Cindy") is False
 
     def test_case_sensitive(self):
         # Exact names are case-sensitive

--- a/web/leaderboard.py
+++ b/web/leaderboard.py
@@ -38,6 +38,11 @@ EXCLUDED_TEST_PLAYERS: frozenset[str] = frozenset(
         "TEST",
         "Claude-HTTP",
         "MEEKS-TEST",
+        "TEST3",
+        "TESTV2",
+        "PHIL-TEST",
+        "CINDY-TEST",
+        "GO-LIVE-TEST",
     }
 )
 


### PR DESCRIPTION
## Summary
- Add TEST3, TESTV2, PHIL-TEST, CINDY-TEST, GO-LIVE-TEST to the `EXCLUDED_TEST_PLAYERS` frozenset in `web/leaderboard.py`
- Update test expectations in `test_leaderboard.py` (previously these names were used as "real player" examples)

## Why
These test/bot accounts created during go-live testing and development appear on the public leaderboard. They should be hidden like the existing test accounts.

## Repro / Validation
```bash
uv run python -m pytest tests/unit/hosted_play/test_leaderboard.py -x -q
# 76 passed
make check-gated
# All checks passed
```

## Tests
- `uv run python -m pytest tests/unit/hosted_play/test_leaderboard.py -x` — 76 passed
- `make check-gated` — all checks passed

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
```

## Scope
- `web/leaderboard.py` — extend `EXCLUDED_TEST_PLAYERS` frozenset
- `tests/unit/hosted_play/test_leaderboard.py` — update test expectations