### PR TITLE
fix(web): remove duplicate auction bid log display

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -384,22 +384,6 @@ class TestBidPanel:
         assert "Moon (10)" not in html
         assert "Loner (10)" not in html
 
-    def test_auction_transcript_shows_entries(self, env):
-        tmpl = env.get_template("partials/bid_panel.html")
-        html = tmpl.render(
-            link_uuid="x",
-            turn_number=2,
-            auction=[
-                {"seat": 1, "n": 0, "action": "pass"},
-                {"seat": 2, "n": 3, "action": "bid", "contract": "S"},
-            ],
-            current_high_bid=3,
-            dealer_seat=0,
-        )
-        assert "Pass" in html
-        # Spade symbol in transcript
-        assert "\u2660" in html  # ♠
-
     def test_form_targets_correct_route(self, env):
         tmpl = env.get_template("partials/bid_panel.html")
         html = tmpl.render(
@@ -433,66 +417,6 @@ class TestBidPanel:
             dealer_seat=0,
         )
         assert "Loner (40)" in html
-
-    def test_moon_bid_in_transcript_has_emphasis(self, env):
-        """Moon bids in the auction transcript get CSS class and badge."""
-        tmpl = env.get_template("partials/bid_panel.html")
-        html = tmpl.render(
-            link_uuid="x",
-            turn_number=2,
-            auction=[
-                {
-                    "seat": 1,
-                    "n": 10,
-                    "action": "bid",
-                    "contract": "H",
-                    "bid_type": "moon",
-                },
-            ],
-            current_high_bid=10,
-            dealer_seat=0,
-        )
-        assert "bid--moon" in html
-        assert "bid-type-badge--moon" in html
-        assert "Moon" in html
-
-    def test_loner_bid_in_transcript_has_emphasis(self, env):
-        """Loner bids in the auction transcript get CSS class and badge."""
-        tmpl = env.get_template("partials/bid_panel.html")
-        html = tmpl.render(
-            link_uuid="x",
-            turn_number=2,
-            auction=[
-                {
-                    "seat": 0,
-                    "n": 10,
-                    "action": "bid",
-                    "contract": "S",
-                    "bid_type": "loner",
-                },
-            ],
-            current_high_bid=10,
-            dealer_seat=3,
-        )
-        assert "bid--loner" in html
-        assert "bid-type-badge--loner" in html
-        assert "Loner" in html
-
-    def test_regular_bid_no_emphasis_class(self, env):
-        """Regular bids do not get moon/loner CSS classes."""
-        tmpl = env.get_template("partials/bid_panel.html")
-        html = tmpl.render(
-            link_uuid="x",
-            turn_number=2,
-            auction=[
-                {"seat": 2, "n": 5, "action": "bid", "contract": "D"},
-            ],
-            current_high_bid=5,
-            dealer_seat=0,
-        )
-        assert "bid--moon" not in html
-        assert "bid--loner" not in html
-        assert "bid-type-badge" not in html
 
     def test_current_high_bid_shows_moon_badge(self, env):
         """The current high bid info line shows a moon badge when bid_type is moon."""
@@ -2617,7 +2541,7 @@ class TestAccessibilityBidPanel:
             dealer_seat=0,
         )
         assert 'role="region"' in html
-        assert 'aria-label="Auction panel"' in html
+        assert 'aria-label="Bid controls"' in html
 
     def test_bid_form_has_aria_label(self, env):
         tmpl = env.get_template("partials/bid_panel.html")

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1228,29 +1228,6 @@ main {
     font-size: 1rem;
 }
 
-.auction-transcript {
-    margin-bottom: 1rem;
-    max-height: 160px;
-    overflow-y: auto;
-}
-
-.auction-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 0.85rem;
-}
-
-.auction-table th,
-.auction-table td {
-    padding: 0.25rem 0.5rem;
-    text-align: left;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-}
-
-.auction-table th {
-    color: var(--color-text-muted);
-    font-weight: 600;
-}
 
 .bid-controls {
     display: flex;
@@ -2395,14 +2372,6 @@ main {
         padding: 0.75rem;
     }
 
-    .auction-transcript {
-        max-height: 120px;
-    }
-
-    .auction-table {
-        font-size: 0.8rem;
-    }
-
     /* Score bar — compact single-column */
     .score-bar {
         padding: 0.5rem 0.75rem;
@@ -2579,12 +2548,6 @@ main {
         font-size: 0.85rem;
     }
 
-    .auction-table th,
-    .auction-table td {
-        padding: 0.2rem 0.35rem;
-        font-size: 0.75rem;
-    }
-
     /* Bid recap — compact for small screens */
     .bid-recap {
         font-size: 0.72rem;
@@ -2661,18 +2624,6 @@ main {
         padding: 0.5rem;
         max-height: 170px;
         overflow: auto;
-    }
-
-    .auction-transcript {
-        max-height: 58px;
-        margin-bottom: 0.5rem;
-        overflow-y: auto;
-    }
-
-    .auction-table th,
-    .auction-table td {
-        padding: 0.12rem 0.3rem;
-        font-size: 0.7rem;
     }
 
     .trick-area h3 {

--- a/web/templates/partials/bid_panel.html
+++ b/web/templates/partials/bid_panel.html
@@ -2,63 +2,19 @@
    Context variables:
      - link_uuid: str — player's game link UUID
      - turn_number: int — current turn for idempotency
-     - auction: list[dict] — auction transcript entries
-       Each entry: {seat, n, action, contract? (if action == "bid"), bid_type?}
      - current_high_bid: int — highest bid so far (0 if no bids yet)
      - dealer_seat: int — seat number of the dealer
      - bid_type: str — current winning bid type ("regular", "moon", or "loner")
+
+   Note: Auction bid history is shown by the Auction Log (action_rail.html),
+   not duplicated here. This partial contains only the bid form controls.
 #}
 {% set suit_symbols = {"S": "♠", "H": "♥", "D": "♦", "C": "♣"} %}
-{% set suit_classes = {"S": "spades", "H": "hearts", "D": "diamonds", "C": "clubs"} %}
 {% set seat_labels = seat_labels | default({0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}) %}
 {% set bid_type_labels = {"regular": "", "moon": " Moon", "loner": " Loner"} %}
 
-<div id="bid-panel" role="region" aria-label="Auction panel">
-    <h3 id="auction-heading">Auction</h3>
-
-    {# Show auction transcript so far #}
-    {% if auction %}
-    <div class="auction-transcript" aria-label="Bidding history" aria-live="polite">
-        <table class="auction-table" aria-describedby="auction-heading">
-            <thead>
-                <tr>
-                    <th scope="col">Player</th>
-                    <th scope="col">Bid</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for entry in auction %}
-                {% set entry_bid_type = entry.get("bid_type", "regular") %}
-                <tr{% if entry_bid_type == "moon" %} class="bid--moon"{% elif entry_bid_type == "loner" %} class="bid--loner"{% endif %}>
-                    <td>{% if entry.seat != 0 %}<span class="ai-name player-name--{{ 'human' if entry.seat == 2 else 'ai' }}">{{ seat_labels.get(entry.seat, "Seat " ~ entry.seat) }}</span>{% else %}<span class="player-name--human">{{ seat_labels.get(entry.seat, "Seat " ~ entry.seat) }}</span>{% endif %}</td>
-                    <td>
-                        {% if entry.action == "pass" %}
-                            Pass
-                        {% else %}
-                            {% if entry_bid_type == "moon" %}
-                                <span aria-hidden="true">🌙</span> Moon
-                                <span class="bid-type-badge bid-type-badge--moon">Moon</span>
-                            {% elif entry_bid_type == "loner" %}
-                                <span aria-hidden="true">🃏</span> Loner
-                                <span class="bid-type-badge bid-type-badge--loner">Loner</span>
-                            {% else %}
-                                {{ entry.n }}
-                            {% endif %}
-                            {% if entry.contract in suit_symbols %}
-                                <span class="suit-icon suit-icon--{{ suit_classes.get(entry.contract, 'spades') }}">{{ suit_symbols[entry.contract] }}</span>
-                            {% elif entry.contract == "HIGH" %}
-                                High
-                            {% elif entry.contract == "LOW" %}
-                                Low
-                            {% endif %}
-                        {% endif %}
-                    </td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
-    {% endif %}
+<div id="bid-panel" role="region" aria-label="Bid controls">
+    <h3>Your Bid</h3>
 
     {# Bid form — only shown when it's the human's turn #}
     <form method="post"


### PR DESCRIPTION
## Summary
- Remove the duplicate auction transcript table from `bid_panel.html` — the Auction Log (`action_rail.html`) already shows bid history
- Clean up dead CSS (`.auction-transcript`, `.auction-table` and responsive overrides)
- Remove 4 obsolete tests and update 1 accessibility test to match new aria-label

## Why
During the auction phase, bids were displayed twice: once in the collapsible Auction Log and again in an "Auction" table inside the bid panel. This created visual clutter and confusion.

Fixes #2508

## Repro / Validation
Start a browser game, reach the auction phase. Before this fix, both the Auction Log and an Auction table were visible. After this fix, only the Auction Log shows bid history; the bid panel contains only the bid form controls.

## Tests
```bash
uv run python -m pytest tests/unit/hosted_play/test_partials.py -x -v  # 240 passed
uv run python -m pytest tests/unit/hosted_play/ -x -q                  # 3479 passed
make check-gated                                                       # ✓ All checks passed
```

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
branch: fix/web-duplicate-auction-bid-log
```