### PR TITLE
fix(web): remove Hand Details dropdown from score bar

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -943,7 +943,7 @@ class TestScore:
     """Score bar shows only 'Current Game Score' per #2200 UI cleanup.
 
     Contract, declarer, tricks info removed (shown in contract bar and trick area).
-    Hand details available in collapsed dropdown.
+    Hand details dropdown removed per #2509 (cluttered).
     """
 
     def test_renders_scores(self, env):
@@ -951,48 +951,24 @@ class TestScore:
         html = tmpl.render(
             score_human=15,
             score_ai=-3,
-            hands_played=4,
-            dealer_seat=3,
-            phase="trick_play",
         )
         assert "15" in html
         assert "-3" in html
         assert "Current Game Score" in html
         assert "Your Team:" in html
         assert "Opponent:" in html
-        # Hand details in collapsed dropdown
-        assert "Hand 5" in html
-        assert "Hand Details" in html
 
-    def test_hand_details_in_collapsed_dropdown(self, env):
+    def test_no_hand_details_dropdown(self, env):
+        """Hand details dropdown removed per #2509."""
         tmpl = env.get_template("partials/score.html")
         html = tmpl.render(
             score_human=0,
             score_ai=0,
-            hands_played=0,
-            dealer_seat=0,
-            phase="auction",
         )
-        assert "Hand 1" in html
-        assert "hand-details" in html
-        assert "<details" in html
-        assert "<summary" in html
-
-    def test_dealer_shown_in_hand_details(self, env):
-        """Dealer info moved to collapsed hand details section."""
-        tmpl = env.get_template("partials/score.html")
-        html = tmpl.render(
-            score_human=10,
-            score_ai=5,
-            hands_played=2,
-            dealer_seat=2,
-            phase="trick_play",
-        )
-        assert "Dealer:" in html
-        assert "Ace" in html
-        # AI dealer name with team color class (#2288.4, #2346)
-        # Seat 2 is partner (human team)
-        assert "player-name--human" in html
+        assert "hand-details" not in html
+        assert "<details" not in html
+        assert "<summary" not in html
+        assert "Hand Details" not in html
 
     def test_no_contract_info_in_score_bar(self, env):
         """Contract info removed from score bar (shown in contract bar instead)."""
@@ -1000,9 +976,6 @@ class TestScore:
         html = tmpl.render(
             score_human=10,
             score_ai=5,
-            hands_played=2,
-            dealer_seat=2,
-            phase="trick_play",
         )
         # Contract info should NOT appear in score bar
         assert "contract-info" not in html
@@ -2867,9 +2840,6 @@ class TestAccessibilityScore:
         html = tmpl.render(
             score_human=10,
             score_ai=5,
-            hands_played=2,
-            dealer_seat=0,
-            phase="auction",
         )
         assert 'role="status"' in html
 
@@ -2878,9 +2848,6 @@ class TestAccessibilityScore:
         html = tmpl.render(
             score_human=15,
             score_ai=-3,
-            hands_played=4,
-            dealer_seat=3,
-            phase="auction",
         )
         assert "Current game score: Your Team 15, Opponent -3" in html
 

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1160,25 +1160,6 @@ main {
     color: rgba(255, 255, 255, 0.3);
 }
 
-/* Collapsed hand details dropdown */
-.hand-details {
-    width: 100%;
-    font-size: 0.8rem;
-    color: var(--color-text-muted);
-}
-
-.hand-details__summary {
-    cursor: pointer;
-    font-size: 0.78rem;
-    color: var(--color-text-muted);
-    user-select: none;
-}
-
-.hand-details__content {
-    padding: 0.25rem 0 0 1rem;
-    font-size: 0.78rem;
-    color: var(--color-text-muted);
-}
 
 /* Compact on-board icon legend — quick-glance badge reference */
 .icon-legend {
@@ -2643,18 +2624,6 @@ main {
     .score-bar .score-separator,
     .score-bar .info-separator {
         margin: 0 0.12rem;
-    }
-
-    main {
-        /* Budget extra space for hand-details <details> expansion (#2283) */
-        padding-bottom: 5.5rem;
-    }
-
-    /* Cap hand-details height inside the fixed score footer so it
-       doesn't push content off-screen when expanded (#2283). */
-    .hand-details__content {
-        max-height: 3rem;
-        overflow-y: auto;
     }
 
     #bid-panel {

--- a/web/templates/partials/game_board.html
+++ b/web/templates/partials/game_board.html
@@ -177,7 +177,7 @@
     {# Score bar — outside compass grid, always at bottom #}
     {% include "partials/score.html" %}
 
-    {# Auction log — repositioned below hand details during gameplay.
+    {# Auction log — repositioned below score bar during gameplay.
        During auction it appears in the compass center (see above). #}
     {% if phase != "auction" %}
         {% include "partials/action_rail.html" %}

--- a/web/templates/partials/score.html
+++ b/web/templates/partials/score.html
@@ -1,16 +1,10 @@
 {# Simplified score bar — "Current Game Score" only.
    Contract, declarer, and tricks info removed (shown in contract bar and trick area).
-   Hand details available in a collapsed dropdown.
 
    Context variables:
      - score_human: int — human team's total match score
      - score_ai: int — AI team's total match score
-     - hands_played: int — number of completed hands
-     - dealer_seat: int — seat number of the dealer
-     - phase: str — current hand phase
 #}
-{% set seat_labels = seat_labels | default({0: "You", 1: "Slim", 2: "Ace", 3: "Deuce"}) %}
-
 <div id="score-bar" class="score-bar" role="status" aria-label="Current game score: Your Team {{ score_human }}, Opponent {{ score_ai }}" aria-live="polite">
     <div class="score-section" aria-label="Current game score: Your Team {{ score_human }}, Opponent {{ score_ai }}">
         <span class="score-header">Current Game Score:</span>
@@ -24,15 +18,4 @@
             {{ score_ai }}
         </span>
     </div>
-
-    <details class="hand-details">
-        <summary class="hand-details__summary">Hand Details</summary>
-        <div class="hand-details__content">
-            <span>Hand {{ hands_played + 1 }}</span>
-            <span class="info-separator" aria-hidden="true">&middot;</span>
-            <span>Dealer: {% if dealer_seat != 0 %}<span class="ai-name player-name--{{ 'human' if dealer_seat == 2 else 'ai' }}">{{ seat_labels.get(dealer_seat, "Seat " ~ dealer_seat) }}</span>{% else %}<span class="player-name--human">{{ seat_labels.get(dealer_seat, "Seat " ~ dealer_seat) }}</span>{% endif %}</span>
-            <span class="info-separator" aria-hidden="true">&middot;</span>
-            <span>First to 52 wins &middot; &minus;52 = loss</span>
-        </div>
-    </details>
 </div>


### PR DESCRIPTION
## Plan
N/A — operator-requested UI cleanup.

## Summary
- Remove the Hand Details `<details>` collapsible dropdown from the score bar template
- Remove associated CSS rules (`.hand-details`, `.hand-details__summary`, `.hand-details__content`) and mobile padding/overflow budget
- Update tests: replace hand-details-present assertions with hand-details-absent assertions

## Why
The Hand Details dropdown adds clutter to the game board without enough value for players. Operator requested removal (#2509).

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_partials.py -x -q
make check-gated
```

**Config:** N/A
**Seed:** N/A

## Test Criteria
- **Pass condition:** `score.html` contains no `<details>` or `hand-details` class, CSS has no `.hand-details` rules, tests assert absence
- **Verification command:** `grep -c "hand-details" web/templates/partials/score.html` returns 0; `grep -c "Hand Details" web/templates/partials/score.html` returns 0
- **Expected result:** Both grep commands return 0 (no matches)

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_partials.py` — 243 passed
- [x] `uv run python -m pytest tests/e2e/hosted_play/test_smoke_placeholder.py -k score` — 2 passed
- [x] `make check-gated` — all checks passed

## Expected impact
- Metrics impact: None
- Runtime impact: None (slightly less HTML rendered)

## Risk level
- [x] Low (docs/tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-d   d7128635 [fix/remove-hand-details-dropdown]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Issue Linkage
Fixes #2509

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
- [x] Issue linkage uses correct keyword (`Fixes` vs `Refs`) per closure policy