### PR TITLE
fix(web): force text presentation for suit icons on iOS/mobile (#2505)

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -829,12 +829,14 @@ main {
     flex-wrap: wrap;
 }
 
-/* Lead suit indicator shown next to trick heading */
+/* Lead suit indicator shown next to trick heading.
+   font-variant-emoji: text — same iOS fix as .suit-icon (#2505). */
 .lead-suit {
     display: inline-block;
     margin-left: 0.35rem;
     font-size: 1.1em;
     vertical-align: middle;
+    font-variant-emoji: text;
 }
 
 .lead-suit--hearts,
@@ -3079,6 +3081,7 @@ main {
     font-weight: 700;
     white-space: nowrap;
     color: var(--color-text);
+    font-variant-emoji: text;
 }
 
 .card-text--hearts,
@@ -3095,9 +3098,14 @@ main {
    on dark backgrounds.  Red for hearts/diamonds, white (--color-text) for
    spades/clubs so they render as solid filled shapes, not invisible dark
    outlines (#2329).  Use `suit-icon suit-icon--hearts` (or
-   diamonds/spades/clubs) on a <span> wrapping ♠ ♥ ♦ ♣.  (#2235) */
+   diamonds/spades/clubs) on a <span> wrapping ♠ ♥ ♦ ♣.  (#2235)
+   font-variant-emoji: text forces text presentation on iOS/mobile where
+   suit symbols otherwise render as color emoji — black emoji ♠♣ are
+   invisible on dark backgrounds because CSS color has no effect on emoji
+   glyphs (#2505). */
 .suit-icon {
     white-space: nowrap;
+    font-variant-emoji: text;
 }
 
 .suit-icon--hearts,


### PR DESCRIPTION
## Plan
N/A — bounded CSS fix for #2505

## Summary
- Add `font-variant-emoji: text` to `.suit-icon`, `.lead-suit`, and `.card-text` CSS rules
- Forces text presentation for Unicode suit symbols (♠♣♥♦) so CSS `color` property is respected
- Prevents iOS/mobile color emoji rendering where black suits (♠♣) are invisible on dark backgrounds

## Why
On iOS/mobile devices, Unicode suit symbols can render as **color emoji** instead of text. When rendered as emoji:
- ♥/♦ appear with built-in red coloring → visible on dark backgrounds
- ♠/♣ appear with built-in black coloring → **invisible** on dark backgrounds

The CSS `color` property has **no effect** on emoji glyphs. The existing `color: var(--color-text)` rule for `.suit-icon--spades/.suit-icon--clubs` was correct for text rendering but ineffective when the browser chose emoji presentation. Adding `font-variant-emoji: text` forces the browser to use text glyphs, making CSS `color` take effect.

## Root cause
Related to #2329 (original dark outline fix) and #2441/#2452 (trick.html variant fix). The CSS colors were correct but emoji rendering on iOS bypassed them entirely.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/ -q  # 3484 passed
make check-gated                                      # All checks passed
```

**CSS verification:**
```bash
grep "font-variant-emoji" web/static/style.css
# .suit-icon → font-variant-emoji: text
# .lead-suit → font-variant-emoji: text
# .card-text → font-variant-emoji: text
```

## Test Criteria
- **Pass condition:** All three CSS classes (`.suit-icon`, `.lead-suit`, `.card-text`) include `font-variant-emoji: text`
- **Verification command:** `grep -A2 "font-variant-emoji" web/static/style.css`
- **Expected visual result:** Black suit symbols (♠♣) render as white text (not black emoji) on dark backgrounds in the Cards Played trick log, lead suit indicator, and "won with" text on iOS/mobile

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/ -q` — 3484 passed, 8 skipped
- [x] `make check-gated` — all checks passed

## Expected impact
- Metrics impact: None (CSS-only change)
- Runtime impact: None

## Risk
Low — `font-variant-emoji: text` is widely supported (Chrome 106+, Firefox 108+, Safari 16.4+, Edge 106+). Falls back gracefully to existing behavior on unsupported browsers.

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
branch: fix/web-black-suit-icons-cards-played
```

Refs #2505

🤖 Generated with [Claude Code](https://claude.com/claude-code)