### PR TITLE
fix(ops): remove broad python -c auto-accept patterns (#2304)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -187,8 +187,6 @@
       "Bash(python -m pytest *)",
       "Bash(python scripts/*)",
       "Bash(python experiments/*)",
-      "Bash(python -c *)",
-      "Bash(python3 -c *)",
       "Bash(sleep *)",
       "Bash(tmux send-keys *)",
       "Bash(tmux capture-pane *)",


### PR DESCRIPTION
## Plan
- `plans/sessions/2026-04-06_overnight_run_plan.md` § 4.4 Wave 2-3 (Packet W2-3, flex-c)

## Summary
- Remove `Bash(python -c *)` and `Bash(python3 -c *)` from `permissions.allow` in `.claude/settings.json`.
- All other narrowings from #2356 (`python -m pytest *`, `python scripts/*`, `python experiments/*`, `tmux send-keys *`, etc.) remain in place.

## Why
Issue #2304 explicitly flags `python -c "<arbitrary code>"` as the exact concern behind narrowing `Bash(python *)`. PR #2356 narrowed `python *` and `tmux *`, but left `Bash(python -c *)` and `Bash(python3 -c *)` in the allow list — so the hole the issue complained about was still open.

Rule `.claude/rules/80_permission_model.md` already documents:

> Patterns that were intentionally excluded:
> - `python *` (too broad — covers `python -c "<arbitrary>"`)

The settings.json directly contradicted that by still auto-accepting `python -c *`. This PR closes that contradiction.

All legitimate in-repo usage of `python -c` goes through `uv run python -c` (verified via grep across `.claude/hooks/`, `scripts/`, `.claude/skills/`, tests, and docs), and `Bash(uv run *)` remains in the allow list — so lanes and hooks are unaffected.

## Repro / Validation
**Command(s) run:**
- `uv run python -c "import json; json.load(open('.claude/settings.json'))"` → `JSON valid`
- `uv run python -m pytest tests/unit/ --co -q` → `10697 tests collected in 5.11s` (no permission prompt — the smoke requested in the task packet)
- `make lint` → ruff passes, exit 0

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** `Bash(python -c *)` and `Bash(python3 -c *)` no longer appear in `.claude/settings.json`, and `uv run python -m pytest` still runs without prompting.
- **Verification command:** `grep -c 'python -c' .claude/settings.json`
- **Expected result:** `0`

## Tests
- [x] `uv run python -m pytest tests/unit/ --co -q` (collection-only smoke — confirms no permission prompt blocks pytest)
- [x] `make lint`
- No new unit tests — this is a permission-list change, not runtime code.

## Expected impact
- Metrics impact: none (config-only).
- Runtime impact: lanes attempting a bare `python -c '...'` (not prefixed with `uv run`) will now see a permission prompt or silent denial. No such usage exists in-repo; all legitimate callers use `uv run python -c`.

## Risk level
- [x] Low (docs/config only; single-line removal)
- [ ] Medium
- [ ] High

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c
```

`git worktree list` (relevant entry):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c  1d84ee6f [fix/narrow-bash-permissions-2304]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Issue Linkage
- Refs #2304 — verification needed in live fleet operations per the reopen comment; orchestrator will confirm lanes stay healthy before closing.

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it — N/A (config removal; smoke is manual pytest invocation)
- [x] PR is focused (one concept — single-file, two-line removal)
- [x] Issue linkage uses `Refs #2304` per tiered closure policy (needs fleet verification)