### PR TITLE
feat(strategy): add GLUTTON_STRATEGY_VERSION + per-match capture in hosted DB

### DIFF
--- a/docs/02_agent/STRATEGY_VERSIONING.md
+++ b/docs/02_agent/STRATEGY_VERSIONING.md
@@ -1,0 +1,49 @@
+# Strategy Versioning
+
+`src/bid_euchre/strategy/greedy.py` is the live hosted-play strategy for
+both OLSa and Bud Bot. `GLUTTON_STRATEGY_VERSION` (exposed as `VERSION`
+on both `GluttonStrategy` and `GluttonIsolatedStrategy`) is the on-disk
+record of which behavior cohort produced any given hosted match.
+
+`web/routes.py` reads `type(engine.play_strategy).VERSION` at match
+creation and stamps it onto `matches.play_strategy_version` (one write
+per match). Pre-versioning rows remain `NULL` — the honest "unknown
+cohort" marker. Full rationale:
+`plans/sessions/2026-04-06_strategy_versioning_plan.md`.
+
+## Semver rules (relaxed MAJOR.MINOR.PATCH)
+
+| Component | Bump when |
+|-----------|-----------|
+| MAJOR | Strategy interface change (rename, signature change, removed flag). |
+| MINOR | New behavioral priority added or removed (e.g., Cash-A). |
+| PATCH | Bug fix that changes play in a narrow class of states. |
+
+Counts toward a bump: changes inside `_choose_lead`, `_choose_discard`,
+`choose_card`, `_is_sure_winner`, `observe_play`, feature-flag defaults,
+or `card_value_for_dump`. Does **not** count: docstrings, comments, log
+lines, ruff cleanups, new helpers that are added but never called.
+
+## PR changelog template
+
+Every PR that touches `src/bid_euchre/strategy/greedy.py`'s decision
+logic must include the following block in its description:
+
+```markdown
+## Strategy Version
+
+| Field | Value |
+|-------|-------|
+| Old version | "0.7.0" |
+| New version | "0.8.0" |
+| Bump category | MINOR (added sure-winner-lead priority) |
+| Behavior delta | <what plays change, in what game states> |
+| Affected functions | `_choose_lead`, `choose_card` |
+| Unaffected functions | `_is_sure_winner` |
+```
+
+## Enforcement
+
+Social / reviewer responsibility for now. A future CI lint that fails
+any PR touching the decision functions without bumping the constant is
+tracked as a deferred enhancement in the plan above (§2.6).

--- a/src/bid_euchre/strategy/greedy.py
+++ b/src/bid_euchre/strategy/greedy.py
@@ -12,6 +12,12 @@ from ..core.cards import Card, cards_that_beat, effective_suit
 from ..core.rules import get_legal_indices, trick_winner
 from .base import Strategy, card_value_for_dump
 
+# Module-level version constant — bump on every behavior change to
+# GluttonStrategy or GluttonIsolatedStrategy. See
+# docs/02_agent/STRATEGY_VERSIONING.md for the semver rules and PR
+# changelog template.
+GLUTTON_STRATEGY_VERSION = "0.7.0"
+
 
 class GreedyStrategy(Strategy):
     """
@@ -103,6 +109,13 @@ class GluttonStrategy(Strategy):
     - Deterministic (no randomness for variety)
     - No multi-trick lookahead beyond "sure winner" logic
     """
+
+    # Version of the play strategy's decision logic. Read polymorphically
+    # via ``type(strategy).VERSION`` by ``web/routes.py`` at match-create
+    # time and stamped onto the ``matches.play_strategy_version`` column
+    # for per-match cohort tracking. See
+    # ``docs/02_agent/STRATEGY_VERSIONING.md`` for bump rules.
+    VERSION = GLUTTON_STRATEGY_VERSION
 
     def __init__(self, name: str = "glutton", debug: bool = False):
         super().__init__(name)
@@ -639,6 +652,12 @@ class GluttonIsolatedStrategy(Strategy):
 
     With all features disabled, this behaves identically to GreedyStrategy.
     """
+
+    # Shares the GluttonStrategy version — the isolated twin runs the
+    # same decision logic paths, just gated by feature flags. Any
+    # behavior change in one class counts as a bump for both. See
+    # ``docs/02_agent/STRATEGY_VERSIONING.md``.
+    VERSION = GLUTTON_STRATEGY_VERSION
 
     def __init__(
         self,

--- a/tests/integration/hosted_play/test_data_capture.py
+++ b/tests/integration/hosted_play/test_data_capture.py
@@ -22,6 +22,7 @@ pytestmark = pytest.mark.integration
 from starlette.testclient import TestClient
 
 from bid_euchre.hosted_play.engine import HUMAN_SEAT, MatchEngine
+from bid_euchre.strategy.greedy import GLUTTON_STRATEGY_VERSION
 from tests.unit.hosted_play.conftest import (
     advance_pending_reveals,
     get_match_state,
@@ -188,6 +189,13 @@ class TestDataCapturePipeline:
             assert match_row.status == "active"
             assert match_row.ai_model == "olsa"
             assert match_row.seed is not None
+
+            # Play strategy version is stamped at match-create time from
+            # type(engine.play_strategy).VERSION — see
+            # docs/02_agent/STRATEGY_VERSIONING.md.  New matches must
+            # record the current GLUTTON_STRATEGY_VERSION so cohort
+            # boundaries are recoverable from the DB alone.
+            assert match_row.play_strategy_version == GLUTTON_STRATEGY_VERSION
 
             # Hand row exists (first hand is dealt on match creation)
             hand_row = session.query(Hand).filter_by(match_id=match_row.id).first()

--- a/tests/unit/hosted_play/test_app.py
+++ b/tests/unit/hosted_play/test_app.py
@@ -459,3 +459,108 @@ class TestOnboardingMigration:
             engine = app.state.engine
             cols = {c["name"] for c in sa_inspect(engine).get_columns("players")}
             assert "onboarding_complete" in cols
+
+
+class TestPlayStrategyVersionMigration:
+    """Tests for the play_strategy_version startup migration (lifespan step 1c).
+
+    The migration in ``web/app.lifespan()`` detects whether the ``matches``
+    table is missing the ``play_strategy_version`` column and, if so,
+    ALTER TABLEs to add it (nullable TEXT).  Pre-versioning rows remain
+    NULL — the honest "unknown cohort" marker per
+    ``docs/02_agent/STRATEGY_VERSIONING.md``.
+    """
+
+    def test_fresh_db_already_has_column(self, tmp_path):
+        """On a brand-new DB, create_tables includes play_strategy_version;
+        migration is a no-op and no errors occur."""
+        app = _make_app(tmp_path)
+        with TestClient(app):
+            engine = app.state.engine
+            cols = {c["name"] for c in sa_inspect(engine).get_columns("matches")}
+            assert "play_strategy_version" in cols
+
+    def test_migration_adds_column_to_legacy_db(self, tmp_path):
+        """Starting the app against a legacy DB (no play_strategy_version
+        column on matches) adds the column via ALTER TABLE."""
+        db_path = tmp_path / "legacy.db"
+        db_url = _create_legacy_db(db_path)
+
+        # Sanity: the legacy fixture must not already have the column
+        pre_engine = create_engine(db_url)
+        pre_cols = {c["name"] for c in sa_inspect(pre_engine).get_columns("matches")}
+        assert "play_strategy_version" not in pre_cols
+        pre_engine.dispose()
+
+        config = make_hosted_play_test_config(tmp_path, database_url=db_url)
+        app = create_app(config=config)
+        with TestClient(app):
+            engine = app.state.engine
+            cols = {c["name"] for c in sa_inspect(engine).get_columns("matches")}
+            assert "play_strategy_version" in cols
+
+    def test_migration_leaves_existing_rows_null(self, tmp_path):
+        """Pre-existing match rows must carry NULL after migration — no
+        fabricated cohort labels."""
+        db_path = tmp_path / "legacy.db"
+        db_url = _create_legacy_db(db_path)
+
+        # Insert a player + a pre-versioning match
+        engine = create_engine(db_url)
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO players (link_uuid, nickname) "
+                    "VALUES ('uuid-legacy', 'Legacy')"
+                )
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO matches ("
+                    "  match_uuid, player_id, ai_model, status, seed,"
+                    "  match_state_json"
+                    ") VALUES ("
+                    "  'legacy-match', "
+                    "  (SELECT id FROM players WHERE link_uuid = 'uuid-legacy'),"
+                    "  'olsa', 'active', 42, '{}'"
+                    ")"
+                )
+            )
+        engine.dispose()
+
+        config = make_hosted_play_test_config(tmp_path, database_url=db_url)
+        app = create_app(config=config)
+        with TestClient(app):
+            session = app.state.session_factory()
+            try:
+                row = session.execute(
+                    text(
+                        "SELECT play_strategy_version FROM matches "
+                        "WHERE match_uuid = 'legacy-match'"
+                    )
+                ).fetchone()
+                assert row is not None
+                assert row[0] is None
+            finally:
+                session.close()
+
+    def test_migration_idempotent_on_second_startup(self, tmp_path):
+        """Running the app twice on the same DB does not fail or duplicate
+        the column (second run is a no-op)."""
+        db_path = tmp_path / "legacy.db"
+        db_url = _create_legacy_db(db_path)
+
+        # First startup — triggers both migrations
+        config1 = make_hosted_play_test_config(tmp_path, database_url=db_url)
+        app1 = create_app(config=config1)
+        with TestClient(app1):
+            pass  # lifespan runs migration
+
+        # Second startup — column already present, migration skipped
+        config2 = make_hosted_play_test_config(tmp_path, database_url=db_url)
+        app2 = create_app(config=config2)
+        with TestClient(app2):
+            engine = app2.state.engine
+            cols = [c["name"] for c in sa_inspect(engine).get_columns("matches")]
+            # Column should exist exactly once (no duplicate)
+            assert cols.count("play_strategy_version") == 1

--- a/tests/unit/hosted_play/test_db.py
+++ b/tests/unit/hosted_play/test_db.py
@@ -72,6 +72,7 @@ class TestSchemaCreation:
             "match_uuid",
             "player_id",
             "ai_model",
+            "play_strategy_version",
             "status",
             "seed",
             "score_human",
@@ -83,6 +84,16 @@ class TestSchemaCreation:
             "completed_at",
         }
         assert expected <= cols
+
+    def test_play_strategy_version_is_nullable(self, engine):
+        """Pre-versioning rows must remain NULL — no NOT NULL constraint."""
+        inspector = inspect(engine)
+        col = next(
+            c
+            for c in inspector.get_columns("matches")
+            if c["name"] == "play_strategy_version"
+        )
+        assert col["nullable"] is True
 
     def test_hands_columns(self, engine):
         inspector = inspect(engine)
@@ -252,6 +263,41 @@ class TestMatchCRUD:
         session.add(match)
         with pytest.raises(Exception):
             session.flush()
+
+    def test_play_strategy_version_round_trip(self, session):
+        """Writing and reading back ``play_strategy_version`` preserves the value."""
+        player = self._make_player(session)
+        match = Match(
+            match_uuid=str(uuid.uuid4()),
+            player_id=player.id,
+            ai_model="heuristic",
+            play_strategy_version="0.7.0",
+            status="active",
+            seed=42,
+            match_state_json="{}",
+        )
+        session.add(match)
+        session.flush()
+
+        fetched = session.query(Match).filter_by(id=match.id).one()
+        assert fetched.play_strategy_version == "0.7.0"
+
+    def test_play_strategy_version_defaults_to_none(self, session):
+        """Omitting ``play_strategy_version`` leaves it NULL (pre-versioning cohort)."""
+        player = self._make_player(session)
+        match = Match(
+            match_uuid=str(uuid.uuid4()),
+            player_id=player.id,
+            ai_model="heuristic",
+            status="active",
+            seed=42,
+            match_state_json="{}",
+        )
+        session.add(match)
+        session.flush()
+
+        fetched = session.query(Match).filter_by(id=match.id).one()
+        assert fetched.play_strategy_version is None
 
 
 # ---------------------------------------------------------------------------

--- a/web/app.py
+++ b/web/app.py
@@ -138,6 +138,17 @@ async def lifespan(app: FastAPI):
             )
         logger.info("Migration: added onboarding_complete column to players")
 
+    # 1c. Migrate: add play_strategy_version column for existing databases.
+    # Rows created before this migration carry NULL as the honest
+    # "unknown cohort" marker — see docs/02_agent/STRATEGY_VERSIONING.md.
+    match_cols = {c["name"] for c in inspector.get_columns("matches")}
+    if "play_strategy_version" not in match_cols:
+        with engine.begin() as conn:
+            conn.execute(
+                text("ALTER TABLE matches " "ADD COLUMN play_strategy_version TEXT")
+            )
+        logger.info("Migration: added play_strategy_version column to matches")
+
     # 2. Auto-seed invite code on fresh database (atomic: skip if another
     #    instance already seeded between our check and insert)
     seed_session = session_factory()

--- a/web/db.py
+++ b/web/db.py
@@ -81,6 +81,12 @@ class Match(Base):
         nullable=False,
     )
     ai_model = Column(String, nullable=False)
+    # Version of the play strategy (src/bid_euchre/strategy/greedy.py's
+    # GLUTTON_STRATEGY_VERSION) active at match-create time. Nullable so
+    # rows written before the versioning infrastructure landed retain an
+    # honest "unknown cohort" marker (NULL) rather than a fabricated value.
+    # See docs/02_agent/STRATEGY_VERSIONING.md.
+    play_strategy_version = Column(String, nullable=True)
     status = Column(
         String,
         CheckConstraint("status IN ('active', 'complete', 'abandoned')"),

--- a/web/routes.py
+++ b/web/routes.py
@@ -1291,10 +1291,21 @@ async def select_ai(
         engine_ms = round((time.monotonic() - t_engine) * 1000, 1)
 
         match_uuid = str(uuid.uuid4())
+        # Stamp the play strategy's version onto the match row for cohort
+        # tracking.  Read polymorphically via ``type(...).VERSION`` so any
+        # future Glutton subclass — or an entirely different strategy —
+        # contributes its own version without extra wiring.  Raises
+        # AttributeError if the strategy forgot to declare VERSION, which
+        # is the correct fail-loud behavior (see
+        # docs/02_agent/STRATEGY_VERSIONING.md).  The attribute is not on
+        # the Strategy base class today, so the static type:ignore is
+        # required until every strategy declares one.
+        play_strategy_version = type(engine.play_strategy).VERSION  # type: ignore[attr-defined]
         match_row = Match(
             match_uuid=match_uuid,
             player_id=player.id,
             ai_model=model_id,
+            play_strategy_version=play_strategy_version,
             status="active",
             seed=seed,
             match_state_json=_serialize_state(engine, state),

--- a/web/schema.sql
+++ b/web/schema.sql
@@ -21,6 +21,11 @@ CREATE TABLE IF NOT EXISTS matches (
     match_uuid TEXT NOT NULL UNIQUE,
     player_id INTEGER NOT NULL REFERENCES players(id) ON DELETE CASCADE,
     ai_model TEXT NOT NULL,
+    -- Version of the play strategy (src/bid_euchre/strategy/greedy.py's
+    -- GLUTTON_STRATEGY_VERSION) active at match-create time. Nullable so
+    -- pre-versioning rows retain an honest "unknown cohort" marker.
+    -- See docs/02_agent/STRATEGY_VERSIONING.md.
+    play_strategy_version TEXT,
     status TEXT NOT NULL CHECK (status IN ('active', 'complete', 'abandoned')),
     seed INTEGER NOT NULL,
     score_human INTEGER NOT NULL DEFAULT 0,


### PR DESCRIPTION
## Summary

PR-1 of the strategy versioning plan — the unblocker for Cash-A.

Adds a provenance constant on `GluttonStrategy` / `GluttonIsolatedStrategy`
and wires the hosted DB to capture which play-strategy cohort produced any
given `Match`. No card-play behavior changes.

- `src/bid_euchre/strategy/greedy.py` — new module-level
  `GLUTTON_STRATEGY_VERSION = "0.7.0"` constant, exposed polymorphically
  as `VERSION` on both Glutton classes. `"0.7.0"` labels the existing
  state (the seven 2026-03-19 → 2026-04-05 edits as one cohort); Cash-A
  will bump it to `"0.8.0"` in the follow-up PR.
- `web/schema.sql` + `web/db.py` — informative + nullable
  `play_strategy_version TEXT` column on `matches`.
- `web/app.py` lifespan — idempotent in-process `ALTER TABLE ADD COLUMN`,
  modeled verbatim on the existing `onboarding_complete` migration at
  lines 118–139. Pre-versioning rows stay `NULL` (the honest "unknown
  cohort" marker).
- `web/routes.py` — reads `type(engine.play_strategy).VERSION`
  polymorphically at match-create time (single insertion point
  immediately before `db.add(match)` in `select_ai`) and stamps it onto
  the new column. Fails loud (`AttributeError`) if a future strategy
  class forgets to declare `VERSION`.
- `docs/02_agent/STRATEGY_VERSIONING.md` — new ≤50 line doc with semver
  rules and the PR changelog template.
- Tests: round-trip in `tests/unit/hosted_play/test_db.py`, migration
  fresh/legacy/leaves-rows-null/idempotency in
  `tests/unit/hosted_play/test_app.py`, and end-to-end capture assertion
  in `tests/integration/hosted_play/test_data_capture.py`.

## Why

`src/bid_euchre/strategy/greedy.py` is the live play strategy for both
OLSa and Bud Bot (`web/ai_manager.py:141,177`). Since the Arc D v2
finalization on 2026-03-19, seven behavioral edits have landed with **no
on-disk record** of which version of the strategy produced any given
hosted-play hand. Cash-A is the next bump on the queue — we want it to
produce a clean cohort boundary in the hosted DB, which requires
landing the versioning infrastructure first.

Per operator directive (2026-04-06): *"Optimize the plan for shortest
path to shipping Cash-A safely, not for research thoroughness."* The
deferred ablation framework lives in §2 of the plan; PR-1 is strictly
the MVP shipping subset.

## Strategy Version

This PR does not bump the strategy version. It adds the constant itself
— `GLUTTON_STRATEGY_VERSION = "0.7.0"` — which labels the pre-Cash-A
state. Cash-A (PR-2) will be the first PR to actually bump from `"0.7.0"`
to `"0.8.0"` using the template introduced in
`docs/02_agent/STRATEGY_VERSIONING.md`.

## Repro / Validation

- **Tier 1 targeted:**
  ```
  uv run python -m pytest tests/unit/hosted_play/ tests/integration/hosted_play/test_data_capture.py tests/unit/test_greedy.py -x
  ```
  → 83 passed (local, pre-rebase re-run confirmed the new
  `TestPlayStrategyVersionMigration` class and the extended
  `test_match_creation_persists_to_db` all pass).

- **Tier 2 full validation:**
  ```
  make check-gated
  ```
  → `✓ All checks passed`.

- **Manual smoke (not run in this worktree — local-only, no Render):**
  ```
  make web
  # create one match via the hosted UI
  sqlite3 <db> "SELECT play_strategy_version FROM matches ORDER BY id DESC LIMIT 1;"
  # expect: 0.7.0
  ```

## Tests

- `tests/unit/hosted_play/test_db.py`
  - `test_matches_columns` — now asserts `play_strategy_version` is in
    the column set.
  - `test_play_strategy_version_is_nullable` — inspector reports the
    column as nullable.
  - `test_play_strategy_version_round_trip` — write `"0.7.0"`, fetch
    back, assert equality.
  - `test_play_strategy_version_defaults_to_none` — omitting the kwarg
    leaves the column NULL.
- `tests/unit/hosted_play/test_app.py::TestPlayStrategyVersionMigration`
  - `test_fresh_db_already_has_column` — new DB already has the column.
  - `test_migration_adds_column_to_legacy_db` — legacy DB gets the
    column ALTERed in.
  - `test_migration_leaves_existing_rows_null` — pre-existing match
    rows carry NULL after migration (no fabricated labels).
  - `test_migration_idempotent_on_second_startup` — running twice does
    not duplicate or fail.
- `tests/integration/hosted_play/test_data_capture.py`
  - `test_match_creation_persists_to_db` now asserts
    `match_row.play_strategy_version == GLUTTON_STRATEGY_VERSION`.

## Acceptance criteria (plan §1.7)

- [x] `GLUTTON_STRATEGY_VERSION = "0.7.0"` exists and is exposed as
      `VERSION` on both Glutton classes.
- [x] `play_strategy_version` column exists in `web/schema.sql`, the ORM
      model, and migrates cleanly on existing DBs via the lifespan
      handler.
- [x] New matches record `"0.7.0"` at match-create time.
- [x] Old matches remain NULL.
- [x] `make check-gated` passes.
- [x] `docs/02_agent/STRATEGY_VERSIONING.md` lands with semver +
      PR template content (≤50 lines).
- [ ] Manual smoke: deferred to a post-merge live check on the hosted
      pilot DB (operator to verify `SELECT play_strategy_version FROM
      matches ORDER BY id DESC LIMIT 1` returns `'0.7.0'` on the next
      new match).

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: feat/strategy-versioning-pr1
base: origin/main @ c4aa8caa
```

Blocks: Cash-A dispatch (per task packet `01783951db28`).