### PR TITLE
feat(strategy): Cash-A sure-winners + draw-trump lead fixes (default-off)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ data/_deprecated/
 data/hand_logs/
 data/training/
 data/data/models/
+data/local_smoke/
 
 # Experiment outputs (keep experiment scripts tracked)
 experiments/output/

--- a/src/bid_euchre/strategy/greedy.py
+++ b/src/bid_euchre/strategy/greedy.py
@@ -16,7 +16,13 @@ from .base import Strategy, card_value_for_dump
 # GluttonStrategy or GluttonIsolatedStrategy. See
 # docs/02_agent/STRATEGY_VERSIONING.md for the semver rules and PR
 # changelog template.
-GLUTTON_STRATEGY_VERSION = "0.7.0"
+#
+# Changelog:
+#   0.7.0 — Initial versioned baseline (PR #2529)
+#   0.8.0 — Cash-A: sure-winner lead priority, draw-trump-first,
+#           draw trump from the top (behind ``cash_winners_on_lead``
+#           flag, default False). Category: MINOR.
+GLUTTON_STRATEGY_VERSION = "0.8.0"
 
 
 class GreedyStrategy(Strategy):
@@ -117,9 +123,20 @@ class GluttonStrategy(Strategy):
     # ``docs/02_agent/STRATEGY_VERSIONING.md`` for bump rules.
     VERSION = GLUTTON_STRATEGY_VERSION
 
-    def __init__(self, name: str = "glutton", debug: bool = False):
+    def __init__(
+        self,
+        name: str = "glutton",
+        debug: bool = False,
+        cash_winners_on_lead: bool = False,
+    ):
         super().__init__(name)
         self.debug = debug
+        # Cash-A feature flag. Default ``False`` is deliberate: merging
+        # Cash-A must not change production behavior. The operator will
+        # flip this to ``True`` after a manual proving run. See
+        # plans/sessions/2026-04-06_ai_play_strategy_investigation.md
+        # §"Recommended PR Decomposition" and the Wave 2-A task packet.
+        self.cash_winners_on_lead: bool = cash_winners_on_lead
         self.decision_log: List[dict] = []
         # Double-deck aware tracking (each card exists 0-2 times)
         self._seen_counts: Dict[Card, int] = {}
@@ -239,12 +256,47 @@ class GluttonStrategy(Strategy):
             counts[eff] = counts.get(eff, 0) + 1
         return counts
 
+    def _opponents_might_hold_trump(self, *, seat: int) -> bool:
+        """Return True if at least one opponent might still hold trump.
+
+        Reads ``_void_suits_by_seat`` (populated by ``observe_play``)
+        and treats "not inferred void in trump" as "might still hold
+        trump." Conservative on hand start: before any trump lead has
+        forced a reveal, the helper returns True (assume opponents have
+        trump until proven otherwise). Cash-A, Fix 1b.
+        """
+        if self._trump_suit is None:
+            return False
+        opp_seats = ((seat + 1) % 4, (seat + 3) % 4)
+        return any(
+            self._trump_suit not in self._void_suits_by_seat.get(opp, set())
+            for opp in opp_seats
+        )
+
+    def _draw_trump_lead(self, trump_indices: List[int], hand: List[Card]) -> int:
+        """Lead the highest-ranking trump from the given indices.
+
+        Shared by Cash-A Fix 1b (draw trump first) and Fix 2 (draw
+        trump from the top). ``card_value_for_dump`` already ranks
+        bowers above non-bower trump above non-trump, so ``max``
+        naturally picks RB > LB > A > K > Q > ... > 10.
+        """
+        return max(
+            trump_indices,
+            key=lambda i: card_value_for_dump(
+                hand[i], self._contract_type, self._trump_suit
+            ),
+        )
+
     def _choose_lead(
         self,
         hand: List[Card],
         legal_indices: List[int],
+        player_index: Optional[int] = None,
     ) -> int:
         """Choose which card to lead with human-like heuristics."""
+        if player_index is None:
+            player_index = self._player_index
 
         def card_value(idx: int) -> int:
             return card_value_for_dump(hand[idx], self._contract_type, self._trump_suit)
@@ -279,6 +331,37 @@ class GluttonStrategy(Strategy):
                 )
                 return right_bower_idx
 
+            # 0.5 NEW (Cash-A, Fix 1): Cash established sure winners first.
+            # Gated by ``cash_winners_on_lead`` (default False on both
+            # Glutton classes). Picks the sure winner from the shortest
+            # effective suit to free up length for future leads, breaking
+            # ties on highest card value.
+            if self.cash_winners_on_lead:
+                sure_winner_leads = [
+                    idx
+                    for idx in legal_indices
+                    if self._is_sure_winner(hand[idx], [], hand)
+                ]
+                if sure_winner_leads:
+
+                    def _sure_lead_priority(idx: int) -> Tuple[int, int]:
+                        eff = effective_suit(
+                            hand[idx], self._trump_suit, self._contract_type
+                        )
+                        return (suit_counts.get(eff, 0), -card_value(idx))
+
+                    return min(sure_winner_leads, key=_sure_lead_priority)
+
+            # 0.75 NEW (Cash-A, Fix 1b): Draw opponent trump before
+            # cashing side winners (Defect F). Suit contracts only.
+            # Gated by the same ``cash_winners_on_lead`` flag.
+            if (
+                self.cash_winners_on_lead
+                and trump_indices
+                and self._opponents_might_hold_trump(seat=player_index)
+            ):
+                return self._draw_trump_lead(trump_indices, hand)
+
             # 1. Look for non-trump Aces
             non_trump_aces = [
                 idx
@@ -301,6 +384,13 @@ class GluttonStrategy(Strategy):
             # (trump_count, trump_indices, has_right, has_left computed in Step 0)
             if trump_count >= 4 and trump_indices:
                 if not (has_right and has_left):
+                    # Cash-A, Fix 2: lead highest trump to clear opponents'
+                    # top trump ("draw trump from the top"). Gated by the
+                    # same ``cash_winners_on_lead`` flag so Cash-A can be
+                    # feature-isolated. Previous ``min()`` left master
+                    # trump in hand until tricks 9-10 (#2506).
+                    if self.cash_winners_on_lead:
+                        return self._draw_trump_lead(trump_indices, hand)
                     # Lead lowest trump to draw trump without burning top cards
                     return min(trump_indices, key=card_value)
 
@@ -335,7 +425,29 @@ class GluttonStrategy(Strategy):
                     idx for idx in legal_indices if hand[idx].suit == longest_suit
                 ]
                 if longest_suit_indices:
+                    # Cash-A fallback guard: the longest-suit heuristic
+                    # may skip a sure winner in a short suit. Re-check
+                    # sure winners before falling through when the flag
+                    # is set.
+                    if self.cash_winners_on_lead:
+                        sure_winner_leads = [
+                            idx
+                            for idx in legal_indices
+                            if self._is_sure_winner(hand[idx], [], hand)
+                        ]
+                        if sure_winner_leads:
+                            return max(sure_winner_leads, key=card_value)
                     return select(longest_suit_indices, key=card_value)
+
+            # Cash-A fallback guard for the empty-suit-counts path too.
+            if self.cash_winners_on_lead:
+                sure_winner_leads = [
+                    idx
+                    for idx in legal_indices
+                    if self._is_sure_winner(hand[idx], [], hand)
+                ]
+                if sure_winner_leads:
+                    return max(sure_winner_leads, key=card_value)
 
             # Fallback
             return select(legal_indices, key=card_value)
@@ -482,7 +594,10 @@ class GluttonStrategy(Strategy):
 
         # SPECIAL CASE: When leading, use smart lead selection
         if not plays_so_far:
-            choice = self._choose_lead(hand, legal_indices)
+            # Pass player_index so Cash-A Fix 1b reads the correct seat
+            # even in the shared-instance deployment path where
+            # self._player_index can lag on_hand_start for seats 2/3.
+            choice = self._choose_lead(hand, legal_indices, player_index=player_index)
             if self.debug:
                 self.decision_log.append(
                     {
@@ -673,6 +788,7 @@ class GluttonIsolatedStrategy(Strategy):
         trump_gating: bool = False,
         probabilistic_trump_in: bool = False,
         lead_bower: Optional[bool] = None,
+        cash_winners_on_lead: bool = False,
     ):
         super().__init__(name)
         self.debug = debug
@@ -690,6 +806,11 @@ class GluttonIsolatedStrategy(Strategy):
         # Default lead_bower to smart_leads when not explicitly set,
         # so existing configs with smart_leads=True keep bower leads (#2201).
         self._lead_bower = lead_bower if lead_bower is not None else smart_leads
+        # Cash-A feature flag: defaults False here so the isolated twin
+        # preserves baseline behavior for A/B isolation experiments. See
+        # plans/sessions/2026-04-06_ai_play_strategy_investigation.md
+        # §"Acceptance Criteria" item 1.
+        self.cash_winners_on_lead: bool = cash_winners_on_lead
 
         # Double-deck aware tracking (each card exists 0-2 times)
         self._seen_counts: Dict[Card, int] = {}
@@ -799,12 +920,42 @@ class GluttonIsolatedStrategy(Strategy):
             counts[eff] = counts.get(eff, 0) + 1
         return counts
 
+    def _opponents_might_hold_trump(self, *, seat: int) -> bool:
+        """Return True if at least one opponent might still hold trump.
+
+        Mirror of :meth:`GluttonStrategy._opponents_might_hold_trump`.
+        Cash-A, Fix 1b.
+        """
+        if self._trump_suit is None:
+            return False
+        opp_seats = ((seat + 1) % 4, (seat + 3) % 4)
+        return any(
+            self._trump_suit not in self._void_suits_by_seat.get(opp, set())
+            for opp in opp_seats
+        )
+
+    def _draw_trump_lead(self, trump_indices: List[int], hand: List[Card]) -> int:
+        """Lead the highest-ranking trump from the given indices.
+
+        Mirror of :meth:`GluttonStrategy._draw_trump_lead`. Shared by
+        Cash-A Fix 1b and Fix 2.
+        """
+        return max(
+            trump_indices,
+            key=lambda i: card_value_for_dump(
+                hand[i], self._contract_type, self._trump_suit
+            ),
+        )
+
     def _choose_lead_smart(
         self,
         hand: List[Card],
         legal_indices: List[int],
+        player_index: Optional[int] = None,
     ) -> int:
         """Choose which card to lead with human-like heuristics."""
+        if player_index is None:
+            player_index = self._player_index
 
         def card_value(idx: int) -> int:
             return card_value_for_dump(hand[idx], self._contract_type, self._trump_suit)
@@ -838,6 +989,32 @@ class GluttonIsolatedStrategy(Strategy):
                 )
                 return right_bower_idx
 
+            # 0.5 NEW (Cash-A, Fix 1): Cash established sure winners first.
+            if self.cash_winners_on_lead:
+                sure_winner_leads = [
+                    idx
+                    for idx in legal_indices
+                    if self._is_sure_winner(hand[idx], [], hand)
+                ]
+                if sure_winner_leads:
+
+                    def _sure_lead_priority(idx: int) -> Tuple[int, int]:
+                        eff = effective_suit(
+                            hand[idx], self._trump_suit, self._contract_type
+                        )
+                        return (suit_counts.get(eff, 0), -card_value(idx))
+
+                    return min(sure_winner_leads, key=_sure_lead_priority)
+
+            # 0.75 NEW (Cash-A, Fix 1b): Draw opponent trump before
+            # cashing side winners. Suit contracts only.
+            if (
+                self.cash_winners_on_lead
+                and trump_indices
+                and self._opponents_might_hold_trump(seat=player_index)
+            ):
+                return self._draw_trump_lead(trump_indices, hand)
+
             # 1. Look for non-trump Aces
             non_trump_aces = [
                 idx
@@ -859,6 +1036,9 @@ class GluttonIsolatedStrategy(Strategy):
             # 2. Draw trump if holding >= 4 trumps and NOT holding both bowers
             if trump_count >= 4 and trump_indices:
                 if not (has_right and has_left):
+                    # Cash-A, Fix 2: lead highest trump when flagged on.
+                    if self.cash_winners_on_lead:
+                        return self._draw_trump_lead(trump_indices, hand)
                     return min(trump_indices, key=card_value)
 
             # 3. Lead from longest non-trump suit
@@ -886,7 +1066,27 @@ class GluttonIsolatedStrategy(Strategy):
                     idx for idx in legal_indices if hand[idx].suit == longest_suit
                 ]
                 if longest_suit_indices:
+                    # Cash-A fallback guard in high/low.
+                    if self.cash_winners_on_lead:
+                        sure_winner_leads = [
+                            idx
+                            for idx in legal_indices
+                            if self._is_sure_winner(hand[idx], [], hand)
+                        ]
+                        if sure_winner_leads:
+                            return max(sure_winner_leads, key=card_value)
                     return max(longest_suit_indices, key=card_value)
+
+            # Cash-A fallback guard for the empty-suit-counts path.
+            if self.cash_winners_on_lead:
+                sure_winner_leads = [
+                    idx
+                    for idx in legal_indices
+                    if self._is_sure_winner(hand[idx], [], hand)
+                ]
+                if sure_winner_leads:
+                    return max(sure_winner_leads, key=card_value)
+
             return max(legal_indices, key=card_value)
 
     def _choose_discard_smart(
@@ -994,7 +1194,9 @@ class GluttonIsolatedStrategy(Strategy):
         # LEADING
         if not plays_so_far:
             if self._smart_leads:
-                return self._choose_lead_smart(hand, legal_indices)
+                return self._choose_lead_smart(
+                    hand, legal_indices, player_index=player_index
+                )
             else:
                 # Greedy: highest value card
                 return max(legal_indices, key=card_value)

--- a/tests/unit/test_greedy.py
+++ b/tests/unit/test_greedy.py
@@ -13,6 +13,7 @@ confirm that.
 
 from bid_euchre.core.cards import Card
 from bid_euchre.strategy import GluttonStrategy, GreedyStrategy
+from bid_euchre.strategy.greedy import GluttonIsolatedStrategy
 
 
 class TestBowerValueGreedy:
@@ -193,3 +194,200 @@ class TestSimPathHooksAlreadyCorrect:
         glutton.observe_play(1, led_card, [(1, led_card)], "suit", "H")
         glutton.observe_play(2, off_card, [(1, led_card), (2, off_card)], "suit", "H")
         assert "C" in glutton._void_suits_by_seat[2]
+
+
+class TestCashWinnersOnLead:
+    """Cash-A: sure-winner lead + draw-trump-first + draw trump from the top.
+
+    All behavior is gated by ``cash_winners_on_lead`` which defaults to
+    ``False`` on both ``GluttonStrategy`` and ``GluttonIsolatedStrategy``.
+    Flag-off tests double as baseline regression guards for the operator
+    proving window before the flag flip.
+
+    See plans/sessions/2026-04-06_ai_play_strategy_investigation.md
+    §Recommended PR Decomposition for context.
+    """
+
+    def test_sure_winner_lead_high_contract(self):
+        """Fix 1 (high/low fallback): with flag on, AI leads a short-suit
+        sure winner (A♠ in high) instead of the longest-suit heuristic."""
+        hand = [
+            Card("S", "A"),  # idx 0 - sure winner in high (nothing beats A)
+            Card("C", "K"),  # idx 1 - longest-suit top card under baseline
+            Card("C", "Q"),  # idx 2
+            Card("C", "T"),  # idx 3
+        ]
+
+        # Baseline (flag off, the shipping default): longest-suit heuristic
+        # picks K♣ from the 3-card clubs run, ignoring A♠.
+        baseline = GluttonStrategy()
+        baseline.on_hand_start(hand, "high", None, player_index=0)
+        baseline_choice = baseline.choose_card(hand, [], "high", None, 0)
+        assert hand[baseline_choice] == Card(
+            "C", "K"
+        ), f"Baseline (flag off) should lead K♣, got {hand[baseline_choice]}"
+
+        # Cash-A (flag on): high/low fallback guard spots A♠ sure winner.
+        cash = GluttonStrategy(cash_winners_on_lead=True)
+        cash.on_hand_start(hand, "high", None, player_index=0)
+        cash_choice = cash.choose_card(hand, [], "high", None, 0)
+        assert hand[cash_choice] == Card(
+            "S", "A"
+        ), f"Cash-A (flag on) should lead A♠, got {hand[cash_choice]}"
+
+    def test_sure_winner_lead_low_contract(self):
+        """Fix 1 in low: with flag on, AI leads T♠ (sure winner in low)
+        instead of the longest-suit heuristic."""
+        hand = [
+            Card("S", "T"),  # idx 0 - sure winner in low (nothing beats T)
+            Card("C", "K"),  # idx 1
+            Card("C", "Q"),  # idx 2
+            Card("C", "J"),  # idx 3 - highest club value in low
+        ]
+
+        baseline = GluttonStrategy()
+        baseline.on_hand_start(hand, "low", None, player_index=0)
+        baseline_choice = baseline.choose_card(hand, [], "low", None, 0)
+        assert (
+            hand[baseline_choice] == Card("C", "J")
+        ), f"Baseline (flag off) should lead longest-suit J♣, got {hand[baseline_choice]}"
+
+        cash = GluttonStrategy(cash_winners_on_lead=True)
+        cash.on_hand_start(hand, "low", None, player_index=0)
+        cash_choice = cash.choose_card(hand, [], "low", None, 0)
+        assert hand[cash_choice] == Card(
+            "S", "T"
+        ), f"Cash-A (flag on) should lead sure-winner T♠, got {hand[cash_choice]}"
+
+    def test_draw_trump_first_on_suit(self):
+        """Fix 1b (Defect F): in a suit contract, with flag on, AI draws
+        trump from the top instead of burning a side-suit ace while
+        opponents might still hold trump."""
+        hand = [
+            Card("S", "K"),  # idx 0 - trump K (not a sure winner)
+            Card("H", "A"),  # idx 1 - side-suit ace
+            Card("H", "Q"),  # idx 2 - heart filler
+            Card("D", "T"),  # idx 3 - diamond filler
+        ]
+
+        # Baseline (flag off): non-trump-ace heuristic burns A♥ while
+        # trump is still out. This is the #2506 defect.
+        baseline = GluttonStrategy()
+        baseline.on_hand_start(hand, "suit", "S", player_index=0)
+        baseline_choice = baseline.choose_card(hand, [], "suit", "S", 0)
+        assert hand[baseline_choice] == Card(
+            "H", "A"
+        ), f"Baseline (flag off) should burn A♥, got {hand[baseline_choice]}"
+
+        # Cash-A (flag on): opponents not inferred-void in trump, so Fix
+        # 1b draws trump from the top (highest trump = K♠).
+        cash = GluttonStrategy(cash_winners_on_lead=True)
+        cash.on_hand_start(hand, "suit", "S", player_index=0)
+        cash_choice = cash.choose_card(hand, [], "suit", "S", 0)
+        assert hand[cash_choice] == Card(
+            "S", "K"
+        ), f"Cash-A (flag on) should draw trump K♠, got {hand[cash_choice]}"
+
+    def test_lead_highest_trump_when_drawing(self):
+        """Fix 2: with flag on, the ≥4-trump-no-both-bowers branch leads
+        the highest trump (LB here) instead of the lowest trump."""
+        hand = [
+            Card("S", "T"),  # idx 0 - trump (value 10)
+            Card("S", "Q"),  # idx 1 - trump (value 12)
+            Card("S", "K"),  # idx 2 - trump (value 13)
+            Card("C", "J"),  # idx 3 - LB, effective trump (value 15)
+            Card("D", "T"),  # idx 4 - offsuit filler
+        ]
+
+        # Seed opponent trump voids so Fix 1b is suppressed and Fix 2
+        # (step 2) is the branch under test. The baseline picks the
+        # lowest trump (T♠); Cash-A picks the highest (LB = J♣).
+        def _seed_voids(strategy):
+            strategy._void_suits_by_seat[1].add("S")
+            strategy._void_suits_by_seat[3].add("S")
+
+        baseline = GluttonStrategy()
+        baseline.on_hand_start(hand, "suit", "S", player_index=0)
+        _seed_voids(baseline)
+        baseline_choice = baseline.choose_card(hand, [], "suit", "S", 0)
+        assert (
+            hand[baseline_choice] == Card("S", "T")
+        ), f"Baseline (flag off) should draw lowest trump T♠, got {hand[baseline_choice]}"
+
+        cash = GluttonStrategy(cash_winners_on_lead=True)
+        cash.on_hand_start(hand, "suit", "S", player_index=0)
+        _seed_voids(cash)
+        cash_choice = cash.choose_card(hand, [], "suit", "S", 0)
+        assert (
+            hand[cash_choice] == Card("C", "J")
+        ), f"Cash-A (flag on) should draw highest trump LB (J♣), got {hand[cash_choice]}"
+
+    def test_default_flag_preserves_baseline_behavior(self):
+        """Explicit regression guard: ``GluttonStrategy()`` with no
+        constructor args must behave identically to pre-Cash-A in the
+        scenario Cash-A is designed to change. This protects the
+        operator proving window — merging Cash-A does not change
+        production behavior until the flag is flipped.
+        """
+        hand = [
+            Card("S", "K"),
+            Card("H", "A"),
+            Card("H", "Q"),
+            Card("D", "T"),
+        ]
+
+        default = GluttonStrategy()  # no flag
+        assert default.cash_winners_on_lead is False
+        default.on_hand_start(hand, "suit", "S", player_index=0)
+        default_choice = default.choose_card(hand, [], "suit", "S", 0)
+        # Pre-Cash-A behavior: non-trump ace heuristic leads A♥.
+        assert hand[default_choice] == Card("H", "A"), (
+            "Default GluttonStrategy() must preserve pre-Cash-A lead (A♥) "
+            f"— got {hand[default_choice]}"
+        )
+
+    def test_isolated_strategy_flag_off_by_default(self):
+        """``GluttonIsolatedStrategy`` defaults to flag off so baseline
+        comparison runs are unaffected."""
+        hand = [
+            Card("S", "K"),
+            Card("H", "A"),
+            Card("H", "Q"),
+            Card("D", "T"),
+        ]
+
+        isolated = GluttonIsolatedStrategy(smart_leads=True)
+        assert isolated.cash_winners_on_lead is False
+        isolated.on_hand_start(hand, "suit", "S", player_index=0)
+        choice = isolated.choose_card(hand, [], "suit", "S", 0)
+        # Pre-Cash-A smart-leads: non-trump ace.
+        assert hand[choice] == Card("H", "A"), (
+            "GluttonIsolatedStrategy with smart_leads=True and flag off "
+            f"must preserve baseline lead (A♥) — got {hand[choice]}"
+        )
+
+    def test_isolated_strategy_cash_winners_on_lead_enabled(self):
+        """``GluttonIsolatedStrategy`` with ``cash_winners_on_lead=True``
+        draws trump in the same Defect F scenario as ``GluttonStrategy``."""
+        hand = [
+            Card("S", "K"),
+            Card("H", "A"),
+            Card("H", "Q"),
+            Card("D", "T"),
+        ]
+
+        isolated = GluttonIsolatedStrategy(smart_leads=True, cash_winners_on_lead=True)
+        isolated.on_hand_start(hand, "suit", "S", player_index=0)
+        choice = isolated.choose_card(hand, [], "suit", "S", 0)
+        assert hand[choice] == Card("S", "K"), (
+            "GluttonIsolatedStrategy with cash_winners_on_lead=True must "
+            f"draw trump K♠ — got {hand[choice]}"
+        )
+
+    def test_version_bumped_to_0_8_0(self):
+        """Cash-A bumps GLUTTON_STRATEGY_VERSION from 0.7.0 → 0.8.0."""
+        from bid_euchre.strategy.greedy import GLUTTON_STRATEGY_VERSION
+
+        assert GLUTTON_STRATEGY_VERSION == "0.8.0"
+        assert GluttonStrategy.VERSION == "0.8.0"
+        assert GluttonIsolatedStrategy.VERSION == "0.8.0"


### PR DESCRIPTION
## Summary

Adds three lead-phase fixes to `GluttonStrategy` and `GluttonIsolatedStrategy`,
gated behind a new `cash_winners_on_lead` feature flag that defaults to
**False** on both classes. Default-off is deliberate: merging must not
change production behavior — the operator will flip the flag after a
manual AM proving run.

### Fixes (active only when `cash_winners_on_lead=True`)

- **Fix 1 — sure-winner lead:** When any legal lead is a sure winner
  (`_is_sure_winner` returns True), lead it before falling through to
  longest-suit heuristics. Applied in suit, high, and low branches.
- **Fix 1b — draw trump first:** Before cashing side-suit winners, if
  opponents may still hold trump (via `_void_suits_by_seat` inference),
  lead a trump to draw.
- **Fix 2 — draw trump from the TOP:** When leading trump on a suit
  contract with ≥4 trump (and not both bowers), play the highest trump
  instead of the lowest. Pulls opponent bowers faster.
- **High/low sure-winner fallback guard** added before longest-suit
  fallthrough so a 1-card side ace/ten is cashed rather than losing to a
  failed long-card hope.

All fixes are mirrored between `GluttonStrategy` and `GluttonIsolatedStrategy`
so the paired-twin remains feature-equivalent for future A/B work.

## Strategy Version

| | |
|---|---|
| **Old** | 0.7.0 |
| **New** | 0.8.0 |
| **Category** | MINOR |
| **Behavior delta** | Lead-phase only: sure-winner priority, draw-trump-first, highest-trump-on-draw, high/low fallback guard. Active only when new `cash_winners_on_lead=True` flag is set. Default **False** on both Glutton classes — production behavior is unchanged on merge. |
| **Affected functions** | `GluttonStrategy.__init__`, `GluttonStrategy._choose_lead`, `GluttonStrategy._opponents_might_hold_trump` (new), `GluttonStrategy._draw_trump_lead` (new), `GluttonStrategy.choose_card` (caller update); `GluttonIsolatedStrategy.__init__`, `GluttonIsolatedStrategy._choose_lead_smart`, `GluttonIsolatedStrategy._opponents_might_hold_trump` (new), `GluttonIsolatedStrategy._draw_trump_lead` (new), `GluttonIsolatedStrategy.choose_card` (caller update). |

## Repro / Validation

Exact targeted test command:

\`\`\`bash
uv run python -m pytest tests/unit/test_greedy.py -v
\`\`\`

Expected: **18 passed** (10 pre-existing + 8 new `TestCashWinnersOnLead` cases).

Tier 2 full validation:

\`\`\`bash
make check-gated
\`\`\`

Output: \`✓ All checks passed\`

### Playwright smoke (local, flag=True override)

A LOCAL-ONLY override was applied to \`web/ai_manager.py\` to instantiate both
`OLSa` and `Bud Bot` with `cash_winners_on_lead=True`. A full hand was played
against OLSa Easy via the hosted-play web app. The override was reverted
before commit — only the flag scaffolding ships in this PR.

**Evidence (screenshots, gitignored under `data/local_smoke/cash_a/`):**

- `01_auction.png` — auction phase
- `02_mid_hand.png` — mid-hand (trick 3, spades led)
- `03_post_hand.png` — post-hand summary ("Your Team Made It! Ace bid 3♣ and took 7 tricks.")

**Result:** Hand played through cleanly. Zero ERROR/Traceback entries in
uvicorn log (`/tmp/cash_a_uvicorn.log`, 81 lines, all INFO).

## Tests

- \`uv run python -m pytest tests/unit/test_greedy.py -v\` — 18/18 pass (8 new Cash-A tests)
- \`make check-gated\` — ✓ All checks passed
- Local Playwright smoke (hosted-play full hand, flag=True override) — clean

## Worktree proof

\`\`\`
$ pwd
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
$ git rev-parse --show-toplevel
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
$ git worktree list | grep cash-a
Bid-Euchre-steward-author-b  9961967c [feat/cash-a-sure-winners-glutton]
\`\`\`

## Out of Scope

Deferred per operator no-new-research directive for the 2026-04-06 overnight
run:

- **Paired H2H self-play bootstrap gate** (Cash-A pre-merge statistical proof)
- **New experiment YAML** for Cash-A vs baseline comparison
- **`paired.py` / `stats.py` bootstrap CI** plumbing
- **Cash-B** (follow-trick heuristics) — separate wave

Paired-H2H deferral note: the default-**False** flag makes this PR behavior-
neutral at merge, so statistical proof is correctly deferred to the operator's
manual AM run where `cash_winners_on_lead=True` is flipped on the hosted-play
artifacts and proving is performed in a controlled session.

## Test criteria

- [x] `test_sure_winner_lead_high_contract` proves SxA is led over C♣K/Q/T when flag=True
- [x] `test_sure_winner_lead_low_contract` proves S♠T is led over C♣K/Q/J in low contract when flag=True
- [x] `test_draw_trump_first_on_suit` proves S♠K trump is led over H♥A side winner when flag=True
- [x] `test_lead_highest_trump_when_drawing` proves C♣J(LB) is led over S♠T (lowest trump) when flag=True and opponents might still hold trump
- [x] `test_default_flag_preserves_baseline_behavior` regression guard (flag=False unchanged)
- [x] `test_isolated_strategy_flag_off_by_default` — twin default-off guard
- [x] `test_isolated_strategy_cash_winners_on_lead_enabled` — twin flag-on parity
- [x] `test_version_bumped_to_0_8_0` — version constant assertion
- [x] `make check-gated` clean
- [x] Hosted-play Playwright smoke — zero uvicorn errors

## Related

Refs #2502 #2504 #2506

---

> **Do not auto-merge.** Track A but behavior-affecting. Waits for AM operator proving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)