### PR TITLE
fix(web): card-played CSS cascade — longhand animation + compound winning/ai-delayed rule

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -241,12 +241,20 @@ main {
     cursor: not-allowed;
 }
 
-/* Played card in trick area — slightly smaller, no hover */
+/* Played card in trick area — slightly smaller, no hover.
+   Baseline transitions smooth class-attribute morphs (e.g. card--winning
+   added/removed).  Scoped here — NOT on base .card — per Risk R1:
+   adding opacity transition to all cards would lag hand-card hover. */
 .card--played {
     width: 54px;
     height: 80px;
     font-size: 1rem;
     cursor: default;
+    transition:
+        transform 0.2s ease,
+        box-shadow 0.2s ease,
+        border-color 0.2s ease,
+        opacity 0.2s ease;
 }
 
 .card--played .card__rank {
@@ -264,9 +272,25 @@ main {
     animation: winning-card-pulse 2s ease-in-out infinite;
 }
 
-/* AI card delay — fade-in animation when AI plays (#2330) */
+/* AI card delay — fade-in animation when AI plays (#2330).
+   Declared with longhand animation-name so compound selectors below can
+   extend rather than override (fixes cascade Bug A — #2538). */
 .card--ai-delayed {
-    animation: ai-card-reveal var(--ai-card-delay, 0.75s) ease-out both;
+    animation-name: ai-card-reveal;
+    animation-duration: var(--ai-card-delay, 0.75s);
+    animation-timing-function: ease-out;
+    animation-fill-mode: both;
+}
+
+/* When an AI card is both revealing AND currently winning, compose both
+   animations so the gold pulse starts after the reveal completes. */
+.card--winning.card--ai-delayed {
+    animation-name: ai-card-reveal, winning-card-pulse;
+    animation-duration: var(--ai-card-delay, 0.75s), 2s;
+    animation-timing-function: ease-out, ease-in-out;
+    animation-delay: 0s, var(--ai-card-delay, 0.75s);
+    animation-iteration-count: 1, infinite;
+    animation-fill-mode: both, none;
 }
 
 @keyframes ai-card-reveal {
@@ -937,6 +961,18 @@ main {
     box-shadow: 0 0 10px rgba(76, 175, 80, 0.6);
     border: 2px solid var(--color-legal-glow);
     animation: winner-card-glow 1.5s ease-in-out 2;
+}
+
+/* When the trick-winning card was just played by AI, compose reveal +
+   glow animations.  Specificity 0,2,0 beats .card--ai-delayed 0,1,0
+   so the descendant rule doesn't silently drop the reveal (#2538 R4). */
+.trick-slot--winner .card--ai-delayed {
+    animation-name: ai-card-reveal, winner-card-glow;
+    animation-duration: var(--ai-card-delay, 0.75s), 1.5s;
+    animation-timing-function: ease-out, ease-in-out;
+    animation-delay: 0s, var(--ai-card-delay, 0.75s);
+    animation-iteration-count: 1, 2;
+    animation-fill-mode: both, none;
 }
 
 .last-trick {
@@ -3138,6 +3174,12 @@ main {
     }
 
     .card--winning {
+        animation: none;
+    }
+
+    .card--ai-delayed,
+    .card--winning.card--ai-delayed,
+    .trick-slot--winner .card--ai-delayed {
         animation: none;
     }
 }


### PR DESCRIPTION
> ⚠️ **WARNING: DO NOT AUTO-MERGE** — This PR changes visible UI behavior and
> requires operator visual proving before merge.

## Summary

- Replace `.card--ai-delayed` animation shorthand with longhand properties so compound selectors can extend rather than override (fixes cascade Bug A — #2538)
- Add `.card--winning.card--ai-delayed` compound rule composing reveal + gold pulse animations
- Add `.trick-slot--winner .card--ai-delayed` compound rule (specificity 0,2,0) per Risk R4
- Add baseline transitions to `.card--played` for smooth class-attribute morphs
- Extend `prefers-reduced-motion` to cover new compound selectors

## Why

The CSS `animation` shorthand on `.card--ai-delayed` silently overrides `.card--winning`'s gold pulse animation due to source-order cascade. When an AI plays a trick-winning card, the gold pulse is invisible for ~750ms until `card--ai-delayed` is removed, then snaps on. Converting to longhand properties and adding compound selectors composes both animations correctly.

Refs #2538

## Scope

- `web/static/style.css` (only file changed)

## Acceptance Criteria

- `getComputedStyle` for `animation-name` on card with both `card--winning` and `card--ai-delayed` classes returns `ai-card-reveal, winning-card-pulse`
- Same assertion on card under `.trick-slot--winner` parent returns `ai-card-reveal, winner-card-glow`
- Elements with `.card--played` have non-zero `transition-duration` for opacity
- No regression on `card--legal` hover responsiveness
- Mobile viewport unchanged at 600px media query

## Validation

```bash
make check-gated   # 11,333 passed, 60 skipped; 3 flaky cpu_gate tests (pre-existing, unrelated)
```

All 3,557 web/hosted-play tests pass. The 3 `test_cpu_gate.py` failures are load-sensitive flakes (pass in isolation) and are completely unrelated to this CSS-only change.

## Plan Reference

- `plans/sessions/2026-04-06_card_jitter_investigation.md` §3 Fix 1
- `plans/sessions/2026-04-06_uiux_wave_plan.md` §4.1

## Auto-merge Policy

**NO** — visible animation behavior change (gold pulse becomes visible on new trick lead). Requires operator visual proving.

## Worktree Proof

```
pwd: Bid-Euchre-steward-brws-author-a
branch: fix/web-card-jitter-css-cascade
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)