### PR TITLE
feat(web): show partner hand with exchange highlights at end of moon hand (#2554)

### DIFF
--- a/src/bid_euchre/hosted_play/engine.py
+++ b/src/bid_euchre/hosted_play/engine.py
@@ -520,6 +520,20 @@ class MatchEngine:
         ]
         result["tricks_team0"] = hand.tricks_team0
         result["tricks_team1"] = hand.tricks_team1
+
+        # Reveal partner's full hand at end of moon hands for exchange review.
+        # The partner sits out during trick play so their 10-card post-exchange
+        # hand remains intact in hand.hands[sitting_out_seat].  (#2554)
+        if (
+            hand.phase == "complete"
+            and hand.bid_type == "moon"
+            and hand.sitting_out_seat is not None
+        ):
+            result["partner_exchange_hand"] = [
+                [c.suit, c.rank] for c in hand.hands[hand.sitting_out_seat]
+            ]
+            result["partner_exchange_seat"] = hand.sitting_out_seat
+
         return result
 
     # ------------------------------------------------------------------

--- a/tests/unit/hosted_play/test_engine.py
+++ b/tests/unit/hosted_play/test_engine.py
@@ -2396,6 +2396,122 @@ class TestMoonLonerSerialization:
 
 
 # ---------------------------------------------------------------------------
+# Test: Partner hand reveal at end of moon hand (#2554)
+# ---------------------------------------------------------------------------
+
+
+class TestPartnerHandReveal:
+    """Verify get_visible_state includes partner's hand for completed moon hands."""
+
+    def test_visible_state_includes_partner_hand_on_moon_complete(self) -> None:
+        """partner_exchange_hand present when phase=complete and bid_type=moon."""
+        engine = MatchEngine(
+            bidding_policy=MoonBidder("S"),
+            play_strategy=FirstLegalPlay(),
+        )
+
+        for seed in range(200):
+            state = engine.start_match(seed, "heuristic")
+            # Auto-play to completion
+            for _ in range(500):
+                hand = state.current_hand
+                if hand is None or state.status == "complete":
+                    break
+                if hand.phase == "complete":
+                    break
+                if hand.phase == "redeal":
+                    state = engine.next_hand(state)
+                    continue
+                if hand.phase == "trick_play" and hand.paused_after_play:
+                    state = engine.resume_after_play(state)
+                    continue
+                if hand.phase == "trick_play" and hand.paused_after_trick:
+                    state = engine.resume_ai(state)
+                    continue
+                if hand.current_seat == HUMAN_SEAT:
+                    if hand.phase == "auction":
+                        state = engine.submit_human_bid(state, BidAction.pass_bid())
+                    elif hand.phase == "trick_play":
+                        legal = engine.get_legal_plays(state)
+                        state = engine.submit_human_card(state, legal[0])
+                    elif hand.phase == "moon_exchange":
+                        indices = [0, 1]
+                        state = engine.submit_exchange_selection(state, indices)
+                    else:
+                        state = engine.advance(state)
+                else:
+                    state = engine.advance(state)
+
+            hand = state.current_hand
+            if (
+                hand is not None
+                and hand.phase == "complete"
+                and hand.bid_type == "moon"
+            ):
+                visible = engine.get_visible_state(state)
+                assert "partner_exchange_hand" in visible
+                assert "partner_exchange_seat" in visible
+                assert visible["partner_exchange_seat"] == hand.sitting_out_seat
+                # Partner's hand should have 10 cards (sat out, played nothing)
+                assert len(visible["partner_exchange_hand"]) == 10
+                # Each card should be [suit, rank]
+                for card in visible["partner_exchange_hand"]:
+                    assert len(card) == 2
+                return  # success
+
+        pytest.fail("Could not find a completed moon hand in 200 seeds")
+
+    def test_visible_state_excludes_partner_hand_non_moon(self) -> None:
+        """partner_exchange_hand absent for regular (non-moon) completed hands."""
+        engine = MatchEngine(
+            bidding_policy=FixedBidder(5, "S"),
+            play_strategy=FirstLegalPlay(),
+        )
+
+        for seed in range(200):
+            state = engine.start_match(seed, "heuristic")
+            # Auto-play to completion
+            for _ in range(500):
+                hand = state.current_hand
+                if hand is None or state.status == "complete":
+                    break
+                if hand.phase == "complete":
+                    break
+                if hand.phase == "redeal":
+                    state = engine.next_hand(state)
+                    continue
+                if hand.phase == "trick_play" and hand.paused_after_play:
+                    state = engine.resume_after_play(state)
+                    continue
+                if hand.phase == "trick_play" and hand.paused_after_trick:
+                    state = engine.resume_ai(state)
+                    continue
+                if hand.current_seat == HUMAN_SEAT:
+                    if hand.phase == "auction":
+                        state = engine.submit_human_bid(state, BidAction.pass_bid())
+                    elif hand.phase == "trick_play":
+                        legal = engine.get_legal_plays(state)
+                        state = engine.submit_human_card(state, legal[0])
+                    else:
+                        state = engine.advance(state)
+                else:
+                    state = engine.advance(state)
+
+            hand = state.current_hand
+            if (
+                hand is not None
+                and hand.phase == "complete"
+                and hand.bid_type != "moon"
+            ):
+                visible = engine.get_visible_state(state)
+                assert "partner_exchange_hand" not in visible
+                assert "partner_exchange_seat" not in visible
+                return  # success
+
+        pytest.fail("Could not find a completed non-moon hand in 200 seeds")
+
+
+# ---------------------------------------------------------------------------
 # Test 19: Trick winner display — winning_card in visible state
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -1543,6 +1543,119 @@ class TestHandResult:
 
 
 # ---------------------------------------------------------------------------
+# hand_result.html — Partner hand reveal (#2554)
+# ---------------------------------------------------------------------------
+
+
+class TestPartnerHandReveal:
+    """Tests for the partner hand section in hand_result after moon hands."""
+
+    # Base context shared by all tests in this class
+    _BASE_CTX = dict(
+        link_uuid="abc-123",
+        winning_bid=10,
+        bidder_seat=0,
+        contract_type="suit",
+        trump="S",
+        bid_type="moon",
+        tricks_team0=10,
+        tricks_team1=0,
+        points_team0=20,
+        points_team1=0,
+        score_human=20,
+        score_ai=0,
+        hands_played=1,
+        exchange_given=[["D", "10"], ["C", "J"]],
+        exchange_received=[["S", "A"], ["H", "K"]],
+    )
+
+    def test_moon_result_shows_partner_hand(self, env):
+        """Partner hand section renders with card components when present."""
+        html = env.get_template("partials/hand_result.html").render(
+            **self._BASE_CTX,
+            partner_exchange_hand=[
+                ["S", "K"],
+                ["S", "Q"],
+                ["H", "A"],
+                ["H", "Q"],
+                ["D", "10"],  # received from mooner (in exchange_given)
+                ["D", "A"],
+                ["D", "K"],
+                ["C", "J"],  # received from mooner (in exchange_given)
+                ["C", "A"],
+                ["C", "Q"],
+            ],
+            partner_exchange_seat=2,
+        )
+        assert "result-partner-hand" in html
+        assert "Ace" in html  # seat 2 label
+        assert "'s Hand" in html
+        assert "(after exchange)" in html
+        # Should render card components (not just text)
+        assert "card__rank" in html
+        assert "card__suit" in html
+
+    def test_moon_result_highlights_received_cards(self, env):
+        """Cards matching exchange_given get card--exchange-received CSS class."""
+        html = env.get_template("partials/hand_result.html").render(
+            **self._BASE_CTX,
+            partner_exchange_hand=[
+                ["S", "K"],
+                ["D", "10"],  # matches exchange_given
+                ["C", "J"],  # matches exchange_given
+                ["H", "A"],
+            ],
+            partner_exchange_seat=2,
+        )
+        # The exchange-received class should appear (for the highlighted cards)
+        assert "card--exchange-received" in html
+
+    def test_moon_result_shows_sent_cards(self, env):
+        """Cards partner sent to mooner (exchange_received) shown as text."""
+        html = env.get_template("partials/hand_result.html").render(
+            **self._BASE_CTX,
+            partner_exchange_hand=[
+                ["S", "K"],
+                ["H", "A"],
+                ["D", "10"],
+                ["C", "J"],
+            ],
+            partner_exchange_seat=2,
+        )
+        assert "result-partner-hand__sent" in html
+        assert "Sent to" in html
+        assert "You" in html  # bidder_seat=0 → "You"
+
+    def test_non_moon_no_partner_hand(self, env):
+        """Regular (non-moon) hands do not render partner hand section."""
+        html = env.get_template("partials/hand_result.html").render(
+            winning_bid=6,
+            bidder_seat=0,
+            contract_type="suit",
+            trump="S",
+            tricks_team0=7,
+            tricks_team1=3,
+            points_team0=7,
+            points_team1=3,
+            score_human=7,
+            score_ai=3,
+            hands_played=1,
+        )
+        assert "result-partner-hand" not in html
+
+    def test_partner_hand_missing_graceful(self, env):
+        """Template handles missing partner_exchange_hand gracefully."""
+        html = env.get_template("partials/hand_result.html").render(
+            **self._BASE_CTX,
+            # No partner_exchange_hand or partner_exchange_seat provided
+        )
+        # Should render without error — partner section simply not shown
+        assert "result-partner-hand" not in html
+        # But the exchange summary should still render
+        assert "result-exchange" in html
+
+
+# ---------------------------------------------------------------------------
 # moon_exchange.html
 # ---------------------------------------------------------------------------
 

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -3040,6 +3040,37 @@ main {
     color: var(--color-text-muted);
 }
 
+/* 16d. Partner hand reveal at end of moon hand (#2554) */
+
+.result-partner-hand {
+    margin: 0.75rem auto;
+    max-width: 440px;
+    text-align: center;
+    border: 1px solid rgba(255, 160, 0, 0.25);
+    border-radius: 8px;
+    padding: 0.6rem 0.75rem 0.75rem;
+    background: rgba(255, 160, 0, 0.04);
+}
+
+.result-partner-hand__title {
+    margin: 0 0 0.5rem;
+    font-size: 0.9rem;
+    color: var(--color-text);
+}
+
+.result-partner-hand__cards {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 4px;
+}
+
+.result-partner-hand__sent {
+    margin: 0.5rem 0 0;
+    font-size: 0.82rem;
+    color: var(--color-text-muted);
+}
+
 /* Card text in exchange summaries and trick winner — rank stays default
    (white); suit icon colored via .suit-icon utility where available (#2289).
    Variant classes provide suit coloring for contexts where the suit symbol

--- a/web/templates/partials/hand_result.html
+++ b/web/templates/partials/hand_result.html
@@ -125,6 +125,43 @@
                 </p>
             </div>
         {% endif %}
+
+        {# Partner's full hand after moon exchange — shows which cards the
+           partner received from the mooner (exchange_given from mooner's
+           perspective = cards the partner now holds) and which cards the
+           partner sent to the mooner (exchange_received = no longer in
+           partner's hand).  Only rendered for moon hands at end of hand.
+           Refs #2554. #}
+        {% set partner_hand = partner_exchange_hand | default([], true) %}
+        {% set partner_seat_num = partner_exchange_seat | default(None, true) %}
+        {% if hand_bid_type == "moon" and partner_hand %}
+            {% set partner_hand_label = seat_labels.get(partner_seat_num, "Partner") if partner_seat_num is not none else partner_seat_label %}
+            <div class="result-partner-hand" aria-label="{{ partner_hand_label }}'s hand after exchange">
+                <p class="result-partner-hand__title"><strong>{{ partner_hand_label }}'s Hand</strong> (after exchange)</p>
+                <div class="result-partner-hand__cards" role="list">
+                    {% for card in partner_hand %}
+                        {% set is_received = card in exchange_given_cards %}
+                        {% set disp_suit = card[0] %}
+                        {% set bower = card|is_bower(trump | default(None, true), contract_type | default(None, true)) %}
+                        <div class="card card--{{ suit_classes.get(disp_suit, 'spades') }} card--exchange{% if is_received %} card--exchange-received{% endif %}{% if bower %} card--bower{% endif %}"
+                             role="listitem"
+                             aria-label="{{ card[1]|display_rank }} of {{ suit_classes.get(disp_suit, disp_suit) }}{% if is_received %} (received from mooner){% endif %}{% if bower %} ({{ bower }} bower){% endif %}">
+                            <span class="card__rank" aria-hidden="true">{{ card[1]|display_rank }}</span>
+                            <span class="card__suit" aria-hidden="true">{{ suit_symbols.get(disp_suit, disp_suit) }}</span>
+                            {% if bower %}
+                                <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">{{ "RB" if bower == "right" else "LB" }}</span>
+                            {% endif %}
+                        </div>
+                    {% endfor %}
+                </div>
+                {% if exchange_received_cards %}
+                    <p class="result-partner-hand__sent">
+                        Sent to {{ seat_labels.get(bidder_seat, "Mooner") }}:
+                        {% for card in exchange_received_cards %}<span class="card-text"><span class="suit-icon suit-icon--{{ suit_classes.get(card[0], 'spades') }}">{{ suit_symbols.get(card[0], card[0]) }}</span> {{ card[1]|display_rank }}</span>{% if not loop.last %}, {% endif %}{% endfor %}
+                    </p>
+                {% endif %}
+            </div>
+        {% endif %}
     </div>
 
     <div class="result-scoring" role="table" aria-label="Hand scoring summary">


### PR DESCRIPTION
> ⚠️ **DO NOT AUTO-MERGE** — Visible UI change, needs operator visual proving.

## Summary

- Expose partner's full 10-card post-exchange hand in `get_visible_state()` at end of moon hands
- Render partner hand section in `hand_result.html` with card components and exchange highlights
- Cards received from mooner highlighted with `card--exchange-received` CSS class
- Cards partner sent to mooner shown as text below the hand

## Why

When a moon is bid, the partner's AI exchange decisions are invisible at end of hand. The user wants to evaluate whether the partner AI made good card-selection choices. The partner sits out during trick play, so their 10-card post-exchange hand remains intact and requires no reconstruction. Refs #2554.

## Exchange Perspective

Data is stored from **mooner's perspective**:
- `exchange_given` = cards mooner gave to partner → these are **received** by partner (highlighted)
- `exchange_received` = cards partner sent to mooner → **not in** partner's hand (shown as text)

## Changes

| File | Change |
|------|--------|
| `src/bid_euchre/hosted_play/engine.py` | `get_visible_state()` adds `partner_exchange_hand` and `partner_exchange_seat` when `phase=complete` and `bid_type=moon` |
| `web/templates/partials/hand_result.html` | New partner hand section with card components, exchange highlighting, and "sent to" text |
| `web/static/style.css` | `.result-partner-hand` styles with moon-accent border |
| `tests/unit/hosted_play/test_partials.py` | 5 template tests |
| `tests/unit/hosted_play/test_engine.py` | 2 engine tests |

## Repro / Validation

```bash
# Tier 1 — template tests
uv run python -m pytest tests/unit/hosted_play/test_partials.py -k "TestPartnerHandReveal" -v

# Tier 1 — engine tests
uv run python -m pytest tests/unit/hosted_play/test_engine.py -k "TestPartnerHandReveal" -v

# Tier 2 — full validation
make check-gated
```

All 7 new tests pass. Full `make check-gated` passes (365 engine tests, 256 partial tests, 0 failures).

## Tests

- `test_moon_result_shows_partner_hand` — partner hand renders with card components
- `test_moon_result_highlights_received_cards` — exchange_given cards get highlight CSS class
- `test_moon_result_shows_sent_cards` — exchange_received shown as "sent to" text
- `test_non_moon_no_partner_hand` — regular hands don't render partner section
- `test_partner_hand_missing_graceful` — template handles missing data gracefully
- `test_visible_state_includes_partner_hand_on_moon_complete` — engine returns field for moon complete
- `test_visible_state_excludes_partner_hand_non_moon` — engine excludes field for regular hands

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
Branch: feat/moon-partner-hand-reveal
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)