### PR TITLE
feat(web): unfilter Claude from leaderboard and post tips comments (#2547)

### DIFF
--- a/tests/unit/hosted_play/test_leaderboard.py
+++ b/tests/unit/hosted_play/test_leaderboard.py
@@ -651,10 +651,20 @@ class TestIsExcludedTestPlayer:
         # below the prefix threshold and is not in the exact list.
         assert is_excluded_test_player("Claude") is False
 
+    def test_stratbot_and_claude_unfiltered(self):
+        """StratBot and CLAUDE were removed from the exclusion list (#2547).
+
+        After renaming StratBot → Claude in the production DB, the player
+        should appear on the public leaderboard.
+        """
+        assert is_excluded_test_player("StratBot") is False
+        assert is_excluded_test_player("CLAUDE") is False
+        assert is_excluded_test_player("Claude") is False
+
     def test_case_sensitive(self):
         # Exact names are case-sensitive
         assert is_excluded_test_player("claude") is False
-        assert is_excluded_test_player("CLAUDE") is True
+        assert is_excluded_test_player("CLAUDE") is False  # removed from list (#2547)
         assert is_excluded_test_player("test") is False
         assert is_excluded_test_player("TEST") is True
 
@@ -699,7 +709,7 @@ class TestLeaderboardExcludesTestPlayers:
         rmatch = _make_match(db_session, real)
         _make_hand(db_session, rmatch)
 
-        for i, name in enumerate(["CLAUDE", "StratBot", "FlexBot-B"], start=1):
+        for i, name in enumerate(["TEST", "TEST3", "FlexBot-B"], start=1):
             p = _make_player(db_session, nickname=name)
             m = _make_match(db_session, p)
             _make_hand(db_session, m, hand_number=i)

--- a/web/leaderboard.py
+++ b/web/leaderboard.py
@@ -35,8 +35,6 @@ _LEADERBOARD_MATCH_STATUSES = ("active", "complete", "abandoned")
 EXCLUDED_TEST_PLAYERS: frozenset[str] = frozenset(
     {
         "QUE-TEST",
-        "StratBot",
-        "CLAUDE",
         "TEST",
         "MEEKS-TEST",
         "TEST3",


### PR DESCRIPTION
## Plan
plans/sessions/2026-04-06_stratbot_tips_plan.md

## Summary
- Remove "StratBot" and "CLAUDE" from `EXCLUDED_TEST_PLAYERS` so the renamed player appears on the public leaderboard
- Keep `"Claude-"` prefix in `_EXCLUDED_PREFIXES` to continue hiding playtest variants (Claude-HTTP, Claude-HYB, etc.)
- Add new test `test_stratbot_and_claude_unfiltered` for the acceptance criteria

## Why
Operator requested (#2547) that the Claude/StratBot player appear on the public leaderboard after being renamed from "StratBot" to "Claude" in production.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/hosted_play/test_leaderboard.py -v
make check-gated
```

**Config (if applicable):** N/A
**Seed (if applicable):** N/A

## Test Criteria
- **Pass condition:** `is_excluded_test_player("Claude")` returns `False`, `is_excluded_test_player("StratBot")` returns `False`, `is_excluded_test_player("Claude-HTTP")` returns `True`, `is_excluded_test_player("TEST3")` returns `True`
- **Verification command:** `uv run python -m pytest tests/unit/hosted_play/test_leaderboard.py -v -k "stratbot_and_claude_unfiltered or claude_playtest or case_sensitive"`
- **Expected result:** 3 tests pass, all green

## Tests
- [x] `uv run python -m pytest tests/unit/hosted_play/test_leaderboard.py -v` — 78 passed
- [x] `make check-gated` — all checks passed

## Expected impact
- Metrics impact: None — display-only change
- Runtime impact: None

## Risk level
- [x] Low (display filter change + tests)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
```

`git worktree list` (relevant line):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b   071cc146 [feat/web-claude-leaderboard-tips]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Issue Linkage
Fixes #2547

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
- [x] Issue linkage uses correct keyword (`Fixes` vs `Refs`) per closure policy

---

## Operator Actions (post-merge)

### 1. Production DB Rename

Run via `render psql bideuchre-db`:
```sql
UPDATE players SET nickname = 'Claude' WHERE nickname = 'StratBot';
```

### 2. Post Tips Comments

Post 3 comments to the comments board as Claude (`link_uuid: f0ada160-74ec-41db-ab4b-ac213a36da47`):

**Tip 1:**
```bash
curl -X POST "https://bideuchre.onrender.com/play/f0ada160-74ec-41db-ab4b-ac213a36da47/comment" \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "text=Don't be afraid to bid 5 or 6 on suit hands. If you've got 3-4 trump and a side ace, go for it! I played 54 games against Bud Bot and made my contract about 74%25 of the time. The points you win when you make it far outweigh the occasional set."
```

**Tip 2:**
```bash
curl -X POST "https://bideuchre.onrender.com/play/f0ada160-74ec-41db-ab4b-ac213a36da47/comment" \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "text=When Bud Bot wins the bid, pay attention to which bowers get played. Lead your off-suit aces early to grab tricks before Bud Bot can trump them. Once you've cashed your sure winners, play low and let your partner help out."
```

**Tip 3:**
```bash
curl -X POST "https://bideuchre.onrender.com/play/f0ada160-74ec-41db-ab4b-ac213a36da47/comment" \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "text=Stick with suit contracts over high or low (no-trump) whenever you can. The bowers give you a massive edge in suit hands that disappears in no-trump. If you're torn between calling hearts vs going low, pick hearts!"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)