### PR TITLE
fix(web): card-slot empty fade + Playwright trick-boundary smoke (Fixes #2538)

### DIFF
--- a/tests/browser/test_card_animations.py
+++ b/tests/browser/test_card_animations.py
@@ -1,0 +1,311 @@
+"""Card animation smoke tests — trick-boundary layout stability.
+
+Validates that the slot-reset-fade animation on ``.card-slot--empty``
+produces a smooth transition rather than a layout jitter at trick
+boundaries.
+
+Run via::
+
+    make browser-smoke
+
+NOT included in ``make check``.  See UX-3 in
+``plans/sessions/2026-04-06_uiux_wave_plan.md`` §4.3.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Page
+
+from .conftest import enter_game
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _advance_next_steps(page: Page, max_steps: int = 8) -> None:
+    """Click the unified Next button until the board is actionable again."""
+    for _ in range(max_steps):
+        next_button = page.locator("button.btn--next-step")
+        if next_button.count() == 0:
+            return
+        if not next_button.first.is_visible():
+            return
+        next_button.first.click()
+        page.wait_for_timeout(250)
+
+
+def _play_to_trick_boundary(page: Page, timeout_s: float = 120.0) -> bool:
+    """Play actions until a trick boundary is reached or the hand ends.
+
+    Returns True if the game reached a trick boundary or hand result,
+    False if we timed out without reaching one.
+    """
+    import time
+
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        # Check terminal conditions first
+        if page.locator("#match-result").count() > 0:
+            return True
+        if page.locator("#hand-result").count() > 0:
+            return True
+
+        # Advance through any paused states (e.g. trick result)
+        _advance_next_steps(page, max_steps=2)
+
+        # If we see card-slot--empty elements, we are at a trick boundary
+        empty_slots = page.locator(".card-slot--empty")
+        if empty_slots.count() >= 2:
+            # At least 2 empty slots means we are at the start of a new
+            # trick (or post-trick reset).  This is our target state.
+            return True
+
+        # Try to submit a pass bid if in auction
+        pass_btn = page.locator("button.pass-btn")
+        if pass_btn.count() > 0 and pass_btn.is_visible():
+            pass_btn.click()
+            page.wait_for_timeout(250)
+            continue
+
+        # Try to play a legal card if in trick play
+        legal_cards = page.locator(".card--legal")
+        if legal_cards.count() > 0:
+            legal_cards.first.click()
+            page.wait_for_timeout(250)
+            continue
+
+        # Nothing to do — wait for AI to advance
+        page.wait_for_timeout(500)
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.browser
+def test_trick_boundary_no_layout_jitter(
+    page: Page,
+    live_server: str,
+    invite_code: str,
+) -> None:
+    """Assert that card-slot elements do not jitter at trick boundaries.
+
+    Strategy: play into a game, reach a trick boundary where card-slot
+    elements are present, then snapshot their bounding rects.  Click
+    Next to advance, wait 300ms, snapshot again, and verify no element
+    shifted by more than 4px.
+
+    This catches the jitter bug reported in #2538 where empty slots
+    would pop/jump when the trick area was cleared.
+    """
+    enter_game(page, live_server, invite_code, "JitterTester")
+
+    # Start a match with OLSa AI
+    page.click("input[name='model_id'][value='olsa']")
+    page.click("button:has-text('Start Match')")
+
+    # Wait for game board to appear
+    page.wait_for_selector("#game-board", timeout=10000)
+    _advance_next_steps(page)
+
+    # Play until we reach a trick boundary
+    reached = _play_to_trick_boundary(page)
+    if not reached:
+        pytest.skip("Could not reach a trick boundary within timeout")
+
+    # If match/hand is already over, skip the layout check
+    if page.locator("#match-result").count() > 0:
+        pytest.skip("Match ended before trick boundary check")
+    if page.locator("#hand-result").count() > 0:
+        pytest.skip("Hand ended before trick boundary check")
+
+    # Snapshot positions of all card-slot elements in the trick area
+    before_rects = page.evaluate(
+        """
+        () => {
+            const slots = document.querySelectorAll(
+                '#trick-area .card-slot, #trick-area .card-slot--empty'
+            );
+            return Array.from(slots).map(el => {
+                const r = el.getBoundingClientRect();
+                return {
+                    top: r.top,
+                    left: r.left,
+                    width: r.width,
+                    height: r.height,
+                    className: el.className
+                };
+            });
+        }
+        """
+    )
+
+    if not before_rects:
+        pytest.skip("No card-slot elements found in trick area")
+
+    # Click Next if available to trigger the trick-boundary transition
+    next_button = page.locator("button.btn--next-step")
+    if next_button.count() > 0 and next_button.first.is_visible():
+        next_button.first.click()
+
+    # Wait 300ms for the transition to settle
+    page.wait_for_timeout(300)
+
+    # Snapshot positions after the transition
+    after_rects = page.evaluate(
+        """
+        () => {
+            const slots = document.querySelectorAll(
+                '#trick-area .card-slot, #trick-area .card-slot--empty'
+            );
+            return Array.from(slots).map(el => {
+                const r = el.getBoundingClientRect();
+                return {
+                    top: r.top,
+                    left: r.left,
+                    width: r.width,
+                    height: r.height,
+                    className: el.className
+                };
+            });
+        }
+        """
+    )
+
+    # Compare: no slot should have shifted more than 4px in any direction
+    max_shift = 4.0
+    n_compare = min(len(before_rects), len(after_rects))
+    for i in range(n_compare):
+        b = before_rects[i]
+        a = after_rects[i]
+        dy = abs(a["top"] - b["top"])
+        dx = abs(a["left"] - b["left"])
+        dw = abs(a["width"] - b["width"])
+        dh = abs(a["height"] - b["height"])
+
+        assert dy <= max_shift, (
+            f"Card slot {i} ({b['className']}) shifted {dy:.1f}px vertically "
+            f"(max {max_shift}px). Before: top={b['top']:.1f}, "
+            f"After: top={a['top']:.1f}"
+        )
+        assert dx <= max_shift, (
+            f"Card slot {i} ({b['className']}) shifted {dx:.1f}px horizontally "
+            f"(max {max_shift}px). Before: left={b['left']:.1f}, "
+            f"After: left={a['left']:.1f}"
+        )
+        assert dw <= max_shift, (
+            f"Card slot {i} ({b['className']}) width changed by {dw:.1f}px "
+            f"(max {max_shift}px). Before: {b['width']:.1f}, "
+            f"After: {a['width']:.1f}"
+        )
+        assert dh <= max_shift, (
+            f"Card slot {i} ({b['className']}) height changed by {dh:.1f}px "
+            f"(max {max_shift}px). Before: {b['height']:.1f}, "
+            f"After: {a['height']:.1f}"
+        )
+
+
+@pytest.mark.browser
+def test_slot_reset_fade_animation_exists(
+    page: Page,
+    live_server: str,
+    invite_code: str,
+) -> None:
+    """Verify that .card-slot--empty has the slot-reset-fade animation.
+
+    A simpler assertion than the jitter test — just checks the CSS
+    property is correctly applied.
+    """
+    enter_game(page, live_server, invite_code, "FadeCheck")
+
+    page.click("input[name='model_id'][value='olsa']")
+    page.click("button:has-text('Start Match')")
+    page.wait_for_selector("#game-board", timeout=10000)
+    _advance_next_steps(page)
+
+    # Play until we see empty slots
+    reached = _play_to_trick_boundary(page)
+    if not reached:
+        pytest.skip("Could not reach a state with empty slots")
+
+    if page.locator("#match-result").count() > 0:
+        pytest.skip("Match ended before check")
+    if page.locator("#hand-result").count() > 0:
+        pytest.skip("Hand ended before check")
+
+    # Check the computed animation-name on any .card-slot--empty
+    animation_name = page.evaluate(
+        """
+        () => {
+            const slot = document.querySelector('.card-slot--empty');
+            if (!slot) return null;
+            return window.getComputedStyle(slot).animationName;
+        }
+        """
+    )
+
+    if animation_name is None:
+        pytest.skip("No .card-slot--empty found in current state")
+
+    assert animation_name == "slot-reset-fade", (
+        f"Expected animation-name 'slot-reset-fade' on .card-slot--empty, "
+        f"got '{animation_name}'"
+    )
+
+
+@pytest.mark.browser
+def test_reduced_motion_disables_slot_fade(
+    page: Page,
+    live_server: str,
+    invite_code: str,
+) -> None:
+    """Verify prefers-reduced-motion: reduce disables the slot fade.
+
+    Emulates reduced-motion preference and checks that the animation
+    is suppressed.
+    """
+    # Emulate reduced-motion preference
+    page.emulate_media(reduced_motion="reduce")
+
+    enter_game(page, live_server, invite_code, "ReducedMotion")
+
+    page.click("input[name='model_id'][value='olsa']")
+    page.click("button:has-text('Start Match')")
+    page.wait_for_selector("#game-board", timeout=10000)
+    _advance_next_steps(page)
+
+    reached = _play_to_trick_boundary(page)
+    if not reached:
+        pytest.skip("Could not reach a state with empty slots")
+
+    if page.locator("#match-result").count() > 0:
+        pytest.skip("Match ended before check")
+    if page.locator("#hand-result").count() > 0:
+        pytest.skip("Hand ended before check")
+
+    animation_name = page.evaluate(
+        """
+        () => {
+            const slot = document.querySelector('.card-slot--empty');
+            if (!slot) return null;
+            return window.getComputedStyle(slot).animationName;
+        }
+        """
+    )
+
+    if animation_name is None:
+        pytest.skip("No .card-slot--empty found in current state")
+
+    assert animation_name == "none", (
+        f"Expected animation-name 'none' under reduced-motion, "
+        f"got '{animation_name}'"
+    )

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1122,6 +1122,12 @@ main {
 .card-slot--empty {
     border: 2px dashed rgba(255, 255, 255, 0.3);
     border-radius: var(--card-radius);
+    animation: slot-reset-fade 0.2s ease-out both;
+}
+
+@keyframes slot-reset-fade {
+    0%   { opacity: 0.3; transform: scale(0.95); }
+    100% { opacity: 1;   transform: scale(1); }
 }
 
 .seat-label {
@@ -3211,6 +3217,10 @@ main {
     .card--ai-delayed,
     .card--winning.card--ai-delayed,
     .trick-slot--winner .card--ai-delayed {
+        animation: none;
+    }
+
+    .card-slot--empty {
         animation: none;
     }
 }


### PR DESCRIPTION
> ⚠️ **NO AUTO-MERGE** — visible animation behavior change. Operator must visually prove before merge.

## Plan
`plans/sessions/2026-04-06_uiux_wave_plan.md` §4.3 (UX-3)

## Summary
- Add `slot-reset-fade` CSS animation to `.card-slot--empty` so empty trick slots blend in smoothly at trick boundaries (0.2s ease-out fade + scale)
- Disable the animation under `prefers-reduced-motion: reduce`
- Add three Playwright browser smoke tests for trick-boundary layout stability

## Why
Completes the jitter fix chain (UX-1 #2558, UX-2 #2566, UX-3 this PR). Empty card slots previously popped into view abruptly when tricks were cleared, causing perceptible visual jitter. The slot-reset-fade gives them a subtle entry animation that smooths the transition.

## Repro / Validation
**Command(s) run:**
```bash
make check-gated   # ✅ All checks passed
```

**Browser smoke (Playwright tests — run via `make browser-smoke`, NOT in `make check`):**
```bash
uv run python -m pytest tests/browser/test_card_animations.py -v
```

## Test Criteria
- **Pass condition:** `.card-slot--empty` has `animation-name: slot-reset-fade` in computed styles
- **Verification command:** In Playwright or browser devtools, run `getComputedStyle(document.querySelector('.card-slot--empty')).animationName`
- **Expected result:** `"slot-reset-fade"` (normal) or `"none"` (with reduced-motion)

## Tests
- [x] `make check-gated` — all checks passed
- [x] Browser: `tests/browser/test_card_animations.py` — 3 new Playwright tests:
  - `test_trick_boundary_no_layout_jitter` — verifies no card-slot shifts >4px within 300ms
  - `test_slot_reset_fade_animation_exists` — checks animation-name CSS property
  - `test_reduced_motion_disables_slot_fade` — emulates reduced-motion, asserts animation suppressed

## Expected impact
- Metrics impact: None (CSS-only + browser tests)
- Runtime impact: None

## Risk level
- [x] Low (CSS animation + browser tests only)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
```

`git worktree list` (relevant entry):
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a   75f01d87 [fix/web-slot-reset-fade-2538]
```

## How to prove the fix

1. Start the local server: `make web`
2. Navigate to a game in trick play
3. Play through a trick until empty slots appear at a trick boundary
4. Observe: empty slots should fade+scale in smoothly (not pop)
5. In devtools, verify `getComputedStyle(slot).animationName === 'slot-reset-fade'`
6. Toggle reduced-motion in devtools → animation should be `none`

## Scope deviation note

The task packet declared `tests/integration/web/test_card_animations.py` but the test was placed in `tests/browser/test_card_animations.py` instead because that's where the existing Playwright test infrastructure lives (conftest with live_server, invite_code, page fixtures, auto-skip logic). Creating a parallel `tests/integration/web/` directory would duplicate all that infrastructure.

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Issue Linkage
Fixes #2538

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
- [x] Issue linkage uses correct keyword (`Fixes` vs `Refs`) per closure policy