### PR TITLE
fix(web): show contract type suit icon next to high bid (Fixes #2539)

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -591,6 +591,116 @@ class TestBidPanel:
         assert 'onchange="updateBidSubmitState()"' in html
         assert "function updateBidSubmitState" in html
 
+    # -- Contract icon tests (#2539) ----------------------------------------
+
+    @pytest.mark.parametrize(
+        "contract, expected_class, expected_text",
+        [
+            ("S", "suit-icon--spades", "♠"),
+            ("H", "suit-icon--hearts", "♥"),
+            ("D", "suit-icon--diamonds", "♦"),
+            ("C", "suit-icon--clubs", "♣"),
+        ],
+    )
+    def test_high_bid_shows_suit_icon(
+        self, env, contract, expected_class, expected_text
+    ):
+        """Suit contracts (S/H/D/C) render a colored suit icon next to the bid."""
+        tmpl = env.get_template("partials/bid_panel.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=1,
+            auction=[
+                {"seat": 1, "n": 5, "action": "bid", "contract": contract},
+            ],
+            current_high_bid=5,
+            current_high_bid_contract=contract,
+            dealer_seat=0,
+        )
+        assert expected_class in html
+        assert expected_text in html
+
+    def test_high_bid_shows_high_label(self, env):
+        """HIGH contract renders a 'Hi' label."""
+        tmpl = env.get_template("partials/bid_panel.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=1,
+            auction=[
+                {"seat": 1, "n": 5, "action": "bid", "contract": "HIGH"},
+            ],
+            current_high_bid=5,
+            current_high_bid_contract="HIGH",
+            dealer_seat=0,
+        )
+        assert "contract-label" in html
+        assert ">Hi<" in html
+
+    def test_high_bid_shows_low_label(self, env):
+        """LOW contract renders a 'Lo' label."""
+        tmpl = env.get_template("partials/bid_panel.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=1,
+            auction=[
+                {"seat": 1, "n": 5, "action": "bid", "contract": "LOW"},
+            ],
+            current_high_bid=5,
+            current_high_bid_contract="LOW",
+            dealer_seat=0,
+        )
+        assert "contract-label" in html
+        assert ">Lo<" in html
+
+    def test_no_contract_icon_when_no_bid(self, env):
+        """When no bids have been made, no contract icon or label renders."""
+        tmpl = env.get_template("partials/bid_panel.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=0,
+            auction=[],
+            current_high_bid=0,
+            current_high_bid_contract=None,
+            dealer_seat=0,
+        )
+        assert "suit-icon" not in html
+        assert "contract-label" not in html
+
+    def test_no_contract_icon_when_contract_none(self, env):
+        """current_high_bid_contract=None (hidden auction) shows no icon."""
+        tmpl = env.get_template("partials/bid_panel.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=1,
+            auction=[
+                {"seat": 1, "n": 5, "action": "bid", "contract": "H"},
+            ],
+            current_high_bid=5,
+            current_high_bid_contract=None,
+            dealer_seat=0,
+        )
+        # The bid info line should render but without a suit icon
+        assert "Current high bid: 5" in html
+        assert "suit-icon" not in html
+        assert "contract-label" not in html
+
+    def test_contract_icon_absent_when_variable_missing(self, env):
+        """Backward compat: template tolerates missing current_high_bid_contract."""
+        tmpl = env.get_template("partials/bid_panel.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=1,
+            auction=[
+                {"seat": 1, "n": 5, "action": "bid", "contract": "H"},
+            ],
+            current_high_bid=5,
+            dealer_seat=0,
+        )
+        # Should render without error and without icon
+        assert "Current high bid: 5" in html
+        assert "suit-icon" not in html
+        assert "contract-label" not in html
+
 
 # ---------------------------------------------------------------------------
 # hand.html

--- a/web/routes.py
+++ b/web/routes.py
@@ -619,6 +619,18 @@ def _build_game_context(
         ctx["current_high_bid"] = (
             0 if _has_hidden_auction(hand) else hand.current_high_bid
         )
+        # Raw contract value for the current high bid — e.g. "S", "H", "D",
+        # "C", "HIGH", "LOW", or None.  Derived from contract_type + trump.
+        if _has_hidden_auction(hand) or hand.contract_type is None:
+            ctx["current_high_bid_contract"] = None
+        elif hand.contract_type == "suit":
+            ctx["current_high_bid_contract"] = hand.trump  # "S"/"H"/"D"/"C"
+        elif hand.contract_type == "high":
+            ctx["current_high_bid_contract"] = "HIGH"
+        elif hand.contract_type == "low":
+            ctx["current_high_bid_contract"] = "LOW"
+        else:
+            ctx["current_high_bid_contract"] = None
         ctx["auction_settled"] = hand.auction_settled
         ctx["points_team0"] = hand.points_team0
         ctx["points_team1"] = hand.points_team1
@@ -681,6 +693,7 @@ def _build_game_context(
         ctx["winning_bid"] = None
         ctx["bidder_seat"] = None
         ctx["current_high_bid"] = 0
+        ctx["current_high_bid_contract"] = None
         ctx["points_team0"] = 0
         ctx["points_team1"] = 0
         ctx["legal_plays"] = None

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -2834,6 +2834,22 @@ main {
     color: #fff;
 }
 
+/* Contract label for no-trump bids (Hi / Lo) — lightweight neutral style
+   that visually matches the suit icons without adding color rules (#2539). */
+.contract-label {
+    display: inline-block;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0.05em 0.3em;
+    border: 1px solid var(--color-text);
+    border-radius: 3px;
+    vertical-align: middle;
+    margin-left: 0.15rem;
+    color: var(--color-text);
+}
+
 /* Bid type selector option emphasis */
 .bid-controls select option[value="moon"] {
     color: var(--color-moon);

--- a/web/templates/partials/bid_panel.html
+++ b/web/templates/partials/bid_panel.html
@@ -86,6 +86,15 @@
     {% if current_high_bid > 0 %}
     <p class="bid-info" aria-live="polite">
         Current high bid: {{ current_high_bid }}
+        {% set _hbc = current_high_bid_contract|default(None) %}
+        {% if _hbc in ("S", "H", "D", "C") %}
+            {% set contract_suit_map = {"S": "spades", "H": "hearts", "D": "diamonds", "C": "clubs"} %}
+            <span class="suit-icon suit-icon--{{ contract_suit_map[_hbc] }}">{{ suit_symbols[_hbc] }}</span>
+        {% elif _hbc == "HIGH" %}
+            <span class="contract-label">Hi</span>
+        {% elif _hbc == "LOW" %}
+            <span class="contract-label">Lo</span>
+        {% endif %}
         {{ bid_type_labels.get(bid_type|default("regular"), "") }}
         {% if bid_type|default("regular") == "moon" %}
             <span class="bid-type-badge bid-type-badge--moon">Moon</span>


### PR DESCRIPTION
## Summary
- Add contract icon (♠♥♦♣) or Hi/Lo label next to the current high bid display in the bid panel
- Contract icon is hidden during auction reveal (consistent with existing hidden-auction logic)
- Reuses existing `.suit-icon` CSS classes for suit colors; new `.contract-label` class for Hi/Lo

## Why
Players cannot see what contract type (suit or no-trump) the current high bidder chose during the auction. This makes it hard to decide whether to outbid. Showing the contract alongside the bid number gives players the information they need at a glance.

Fixes #2539

## Changes
| File | Change |
|------|--------|
| `web/routes.py` | Derive `current_high_bid_contract` from `contract_type` + `trump` in `_build_game_context` |
| `web/templates/partials/bid_panel.html` | Render suit icon or Hi/Lo label in high bid info line |
| `web/static/style.css` | Add `.contract-label` class for lightweight Hi/Lo styling |
| `tests/unit/hosted_play/test_partials.py` | 9 new tests: all 6 contract types, no-bid, hidden-auction, backward compat |

## Validation

```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/hosted_play/test_partials.py -v -k "TestBidPanel"
# 27 passed (9 new)

uv run python -m pytest tests/unit/hosted_play/test_routes.py --tb=short -x
# 138 passed, 2 skipped

# Tier 2 — full validation
make check-gated
# ✓ All checks passed
```

## Test criteria
- All 6 contract types render correct icon/label (S→♠, H→♥, D→♦, C→♣, HIGH→Hi, LOW→Lo)
- Hearts/diamonds use `--color-red`; spades/clubs use `--color-text` (via existing `.suit-icon` classes)
- No icon rendered when `current_high_bid_contract` is None (hidden auction or no bid)
- Moon/Loner badges still render (no regression — verified by existing tests)
- Template backward-compatible when `current_high_bid_contract` variable is missing

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
branch: fix/web-high-bid-contract-icon-2539
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)