### PR TITLE
fix(web): remove mid-trick Next button to eliminate layout jitter (Refs #2538)

### DIFF
--- a/web/routes.py
+++ b/web/routes.py
@@ -577,6 +577,17 @@ def _build_game_context(
     # Fields only available from hand state (not in visible dict)
     if hand is not None:
         show_next = _awaiting_next(hand)
+        # During mid-trick card reveals (paused_after_play), suppress the
+        # visible Next button — auto-advance JS handles progression.
+        # Removing the visible DOM element eliminates the ~87px layout
+        # shift that causes card jitter during AI play sequences (#2538).
+        if (
+            hand.phase == "trick_play"
+            and hand.paused_after_play
+            and not _auction_reveal_active(hand)
+            and not _has_pending_exchange(hand)
+        ):
+            show_next = False
         ctx["show_next"] = show_next
         ctx["next_reason"] = _next_reason(hand)
         # Show "Skip" button when mid-trick per-card pacing is active

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -365,13 +365,17 @@ main {
     margin-left: 1px;
 }
 
-/* "X is winning" text below the trick center during active tricks */
+/* "X is winning" / "X won" text below the trick center.
+   Layout properties (min-height, margin, padding) are shared with
+   .trick-winner to prevent ~12px height shift at trick completion (#2538). */
 .trick-current-winner {
-    font-size: 0.85rem;
+    font-size: 0.9rem;
     font-weight: 500;
     color: #ffd700;
     text-align: center;
-    margin: 0.25rem 0 0;
+    min-height: 1.6rem;
+    margin: 0.3rem 0 0;
+    padding: 0.2rem 0.5rem;
     opacity: 0.9;
 }
 
@@ -948,12 +952,13 @@ main {
 }
 
 .trick-winner {
-    font-size: 1rem;
+    font-size: 0.9rem;
     font-weight: 600;
     color: var(--color-text);
     text-align: center;
-    margin: 0.35rem 0 0;
-    padding: 0.25rem 0.75rem;
+    min-height: 1.6rem;
+    margin: 0.3rem 0 0;
+    padding: 0.2rem 0.5rem;
     border-radius: 4px;
     animation: trick-winner-flash 1.5s ease-out;
 }

--- a/web/templates/partials/game_board.html
+++ b/web/templates/partials/game_board.html
@@ -125,6 +125,25 @@
 
             {% if show_next %}
                 {% include "partials/next_controls.html" %}
+            {% elif auto_advance | default(false) %}
+                {# Hidden auto-advance trigger — no visible button during
+                   mid-trick AI card reveals.  JS auto-submits after the
+                   animation delay.  Eliminating the visible next-controls
+                   prevents the ~87px layout shift that causes card jitter
+                   (#2538). #}
+                <div class="next-controls next-controls--auto-advance"
+                     data-auto-advance="{{ auto_advance_delay_ms | default(850) }}"
+                     aria-hidden="true" hidden>
+                    <form id="next-step-form"
+                          method="post"
+                          action="/play/{{ link_uuid }}/next"
+                          hx-post="/play/{{ link_uuid }}/next"
+                          hx-target="#game-board"
+                          hx-swap="morph:innerHTML"
+                          hx-timeout="15000">
+                        <button type="submit">Next</button>
+                    </form>
+                </div>
             {% endif %}
 
             {# Bid panel — auction phase only, when it's the human's turn #}


### PR DESCRIPTION
## Summary

- **Remove visible Next button during `paused_after_play`** — during AI card reveal sequences, suppress the "Reveal the next card" text and Next button. A hidden auto-advance form preserves the JS auto-submit mechanism.
- **Equalize trick-winner / trick-current-winner layout** — shared `min-height`, `margin`, and `padding` between the two paragraph classes prevents the ~12px height shift at trick completion.

## Why

The analyst investigation (PR #2573, `plans/sessions/2026-04-07_jitter_residual_investigation.md`) identified two root causes of residual card jitter after UX-1/2/3:
- **L1 (~87px):** The `next-controls` div appearing/disappearing during auto-advance causes compass-center height collapse
- **L2 (~12px):** `.trick-current-winner` and `.trick-winner` have different layout dimensions

This PR eliminates both sources. The operator directive is to remove the mid-trick Next button entirely rather than reserve CSS space for it, since auto-advance handles progression.

Refs #2538.

## Changes

| File | Change |
|------|--------|
| `web/routes.py` | Suppress `show_next` during `paused_after_play` trick play |
| `web/templates/partials/game_board.html` | Hidden auto-advance form when `auto_advance=True` but `show_next=False` |
| `web/static/style.css` | Equalize `.trick-current-winner` / `.trick-winner` layout properties |

## Acceptance Criteria

- [x] During AI card plays, no Next button appears — cards auto-advance via hidden form
- [x] "Continue to next trick" button still appears at trick completion (`paused_after_trick`)
- [x] No layout shift when AI plays a card (the ~87px jitter from next-controls is gone)
- [x] 2s pause between AI plays preserved (server-side timing unchanged)
- [x] trick-winner / trick-current-winner height equalized (no ~12px shift)

## Validation

```bash
# Tier 1 — targeted tests (3527 passed)
uv run python -m pytest tests/unit/hosted_play/ -x -q

# Tier 2 — full validation
make check-gated  # ✓ All checks passed
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
branch: fix/remove-mid-trick-next-button
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)