### PR TITLE
fix(web): use count-based matching for moon exchange highlights (#2575)

### DIFF
--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -1720,6 +1720,62 @@ class TestPartnerHandReveal:
         # The exchange-received class should appear (for the highlighted cards)
         assert "card--exchange-received" in html
 
+    def test_moon_result_duplicate_card_highlight_count(self, env):
+        """Double-deck: only ONE copy highlighted when one copy exchanged (#2575).
+
+        Partner holds two 10♦ (double-deck), but only one was exchanged.
+        Count-based matching should highlight exactly one, not both.
+        """
+        html = env.get_template("partials/hand_result.html").render(
+            **self._BASE_CTX,
+            partner_exchange_hand=[
+                ["D", "10"],  # copy 1 — should be highlighted (exchanged)
+                ["D", "10"],  # copy 2 — should NOT be highlighted
+                ["S", "K"],
+                ["H", "A"],
+            ],
+            partner_exchange_seat=2,
+        )
+        # Exactly one card--exchange-received occurrence expected
+        count = html.count("card--exchange-received")
+        assert count == 1, (
+            f"Expected 1 highlighted card but found {count}; "
+            "value-based matching highlights all duplicate copies"
+        )
+
+    def test_moon_result_both_copies_highlighted_when_both_exchanged(self, env):
+        """Double-deck: BOTH copies highlighted when both were exchanged (#2575)."""
+        html = env.get_template("partials/hand_result.html").render(
+            link_uuid="abc-123",
+            winning_bid=10,
+            bidder_seat=0,
+            contract_type="suit",
+            trump="S",
+            bid_type="moon",
+            tricks_team0=10,
+            tricks_team1=0,
+            points_team0=20,
+            points_team1=0,
+            score_human=20,
+            score_ai=0,
+            hands_played=1,
+            exchange_given=[["D", "10"], ["D", "10"]],
+            exchange_received=[["S", "A"], ["H", "K"]],
+            partner_exchange_hand=[
+                ["D", "10"],  # copy 1 — should be highlighted
+                ["D", "10"],  # copy 2 — should also be highlighted
+                ["S", "K"],
+                ["H", "A"],
+            ],
+            partner_exchange_seat=2,
+        )
+        # Both copies were exchanged, so both should be highlighted
+        count = html.count("card--exchange-received")
+        assert count == 2, (
+            f"Expected 2 highlighted cards but found {count}; "
+            "both exchanged copies should be highlighted"
+        )
+
     def test_moon_result_shows_sent_cards(self, env):
         """Cards partner sent to mooner (exchange_received) shown as text."""
         html = env.get_template("partials/hand_result.html").render(

--- a/web/templates/partials/hand_result.html
+++ b/web/templates/partials/hand_result.html
@@ -136,11 +136,25 @@
         {% set partner_seat_num = partner_exchange_seat | default(None, true) %}
         {% if hand_bid_type == "moon" and partner_hand %}
             {% set partner_hand_label = seat_labels.get(partner_seat_num, "Partner") if partner_seat_num is not none else partner_seat_label %}
+            {# Build consumable list for count-based matching.  In a double-deck
+               the partner may hold TWO copies of a card; value-based `in` would
+               highlight ALL copies even if only one was exchanged.  #2575 #}
+            {% set exch_ns = namespace(remaining=[]) %}
+            {% for c in exchange_given_cards %}
+                {% set exch_ns.remaining = exch_ns.remaining + [c[0] ~ ":" ~ c[1]] %}
+            {% endfor %}
             <div class="result-partner-hand" aria-label="{{ partner_hand_label }}'s hand after exchange">
                 <p class="result-partner-hand__title"><strong>{{ partner_hand_label }}'s Hand</strong> (after exchange)</p>
                 <div class="result-partner-hand__cards" role="list">
                     {% for card in partner_hand %}
-                        {% set is_received = card in exchange_given_cards %}
+                        {% set card_key = card[0] ~ ":" ~ card[1] %}
+                        {% if card_key in exch_ns.remaining %}
+                            {% set is_received = true %}
+                            {% set _idx = exch_ns.remaining.index(card_key) %}
+                            {% set exch_ns.remaining = exch_ns.remaining[:_idx] + exch_ns.remaining[_idx + 1:] %}
+                        {% else %}
+                            {% set is_received = false %}
+                        {% endif %}
                         {% set disp_suit = card[0] %}
                         {% set bower = card|is_bower(trump | default(None, true), contract_type | default(None, true)) %}
                         <div class="card card--{{ suit_classes.get(disp_suit, 'spades') }} card--exchange{% if is_received %} card--exchange-received{% endif %}{% if bower %} card--bower{% endif %}"


### PR DESCRIPTION
## Summary

- **Bug:** In a double-deck, the partner hand reveal after a moon exchange highlights ALL copies of a card when only one was exchanged. Template used `card in exchange_given_cards` (value-based), which matches every copy.
- **Fix:** Switch to count-based matching via a consumable Jinja2 `namespace` list. Each match decrements the counter so only the correct number of copies get the `card--exchange-received` highlight class.
- **Tests:** Two new tests verify single-copy and both-copy exchange scenarios.

Fixes #2575

## Why

Value-based list membership (`in`) in Jinja2 compares by value, not identity. In a double-deck game (two copies of each card), if the mooner exchanges one 10♦ to their partner who already holds a 10♦, both copies get highlighted — misleading the player about which cards were actually exchanged.

## Changes

| File | Change |
|------|--------|
| `web/templates/partials/hand_result.html` | Replace `card in exchange_given_cards` with consumable `namespace` counter |
| `tests/unit/hosted_play/test_partials.py` | Add `test_moon_result_duplicate_card_highlight_count` and `test_moon_result_both_copies_highlighted_when_both_exchanged` |

## Validation

```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/hosted_play/test_partials.py::TestPartnerHandReveal -xvs
# 7 passed (including 2 new duplicate-handling tests)

# Tier 2 — full validation
make check-gated
# ✓ All checks passed
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
branch: fix/moon-exchange-duplicate-highlight
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)