### PR TITLE
fix(web): apply blue outlined styling to Pass button (#2576)

### DIFF
--- a/web/static/css/accessibility.css
+++ b/web/static/css/accessibility.css
@@ -285,35 +285,10 @@ html[data-text-size="large"] .text-size-toggle {
 }
 
 /* --------------------------------------------------------------------------
-   8. Pass Button Styling
+   8. Pass Button Accessibility
    --------------------------------------------------------------------------
-   The pass button is styled as a secondary action distinct from Submit Bid.
+   Core visual styling (.bid-pass, .pass-btn, .pass-btn:hover) lives in
+   style.css alongside other bid-panel rules so it doesn't depend on this
+   file's load order or caching (#2576).  Only accessibility-specific rules
+   (focus ring, touch targets in §3 above) remain here.
    -------------------------------------------------------------------------- */
-
-.bid-pass {
-    margin-top: 0.5rem;
-    /* Full-width container so .pass-btn spans the bid-panel (#2521 item 3). */
-    width: 100%;
-}
-
-.pass-btn {
-    /* Full-width to match Submit Bid, both visually and tap-target wise
-       (#2521 item 3).  Outlined blue to read as a distinct primary action
-       clearly differentiated from the green Submit Bid (#2545). */
-    display: block;
-    width: 100%;
-    padding: 0.6rem 1.25rem;
-    border: 2px solid var(--color-pass-blue, #1565c0);
-    border-radius: 4px;
-    background: transparent;
-    color: var(--color-pass-blue, #1565c0);
-    font-weight: 600;
-    cursor: pointer;
-    font-size: 0.9rem;
-    transition: background 0.15s, color 0.15s;
-}
-
-.pass-btn:hover {
-    background: rgba(21, 101, 192, 0.12);
-    color: #ffffff;
-}

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1359,6 +1359,35 @@ main {
     background: var(--color-surface-light);
 }
 
+/* Pass button — blue outlined, distinct from the green Submit Bid (#2545).
+   Core visual styling lives here so it doesn't depend on accessibility.css
+   load order or caching.  Accessibility-specific rules (focus ring, touch
+   targets) remain in accessibility.css. */
+.bid-pass {
+    margin-top: 0.5rem;
+    /* Full-width container so .pass-btn spans the bid-panel (#2521 item 3). */
+    width: 100%;
+}
+
+.pass-btn {
+    display: block;
+    width: 100%;
+    padding: 0.6rem 1.25rem;
+    border: 2px solid var(--color-pass-blue, #1565c0);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--color-pass-blue, #1565c0);
+    font-weight: 600;
+    cursor: pointer;
+    font-size: 0.9rem;
+    transition: background 0.15s, color 0.15s;
+}
+
+.pass-btn:hover {
+    background: rgba(21, 101, 192, 0.12);
+    color: #ffffff;
+}
+
 .bid-info {
     margin: 0.5rem 0 0;
     font-size: 0.8rem;


### PR DESCRIPTION
## Summary

- Move Pass button visual styling (`.bid-pass`, `.pass-btn`, `.pass-btn:hover`) from `accessibility.css` to `style.css`
- Fixes #2576: Pass button not blue after UX-5 merge

## Why

The `.pass-btn` blue outlined styling lived **only** in `accessibility.css`. If that secondary stylesheet was cached (stale version), failed to load, or loaded out of order, the Pass button would render with no custom styling — the browser's default button appearance.

Moving the core visual rules to `style.css` alongside other bid-panel controls (`.bid-controls button`, `.bid-submit-btn`) makes the styling resilient. Accessibility-specific rules (focus ring in `:focus-visible`, touch targets in `@media (pointer: coarse)`) remain in `accessibility.css` where they belong.

## Repro / Validation

```bash
# Playwright evaluation of computed styles (both with and without accessibility.css)
# borderColor: "rgb(21, 101, 192)"  ← blue (#1565c0)
# color: "rgb(21, 101, 192)"
# backgroundColor: "rgba(0, 0, 0, 0)"  ← transparent
```

Screenshot proof: Pass button renders blue with `style.css` alone (no accessibility.css dependency).

## Tests

```bash
make check-gated  # ✓ All checks passed
```

Browser visual tests (`tests/browser/test_auction_panel_visual.py`) exist but require Playwright installation — not part of `make check`.

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
branch: fix/pass-button-blue
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)