### PR TITLE
feat(experiments): add Cash-A H2H experiment configs for adversarial evaluation

### DIFF
--- a/experiments/configs/cash_a_h2h_auction.yaml
+++ b/experiments/configs/cash_a_h2h_auction.yaml
@@ -1,0 +1,107 @@
+# Cash-A full-auction head-to-head comparator
+#
+# Purpose
+# -------
+# Measure the real-game competitive impact of `cash_winners_on_lead` when
+# contracts are chosen by the bidder (GBT auction), not forced. Both teams
+# use the identical GBT bidder on all four seats — only the play strategy
+# differs (cash_winners_on_lead True vs False).
+#
+# Design
+# ------
+# Team 0 (seats 0, 2): GluttonStrategy with cash_winners_on_lead=True
+# Team 1 (seats 1, 3): GluttonStrategy with cash_winners_on_lead=False
+# All 4 seats: GBTActionValueBidder (same model, same params)
+#
+# Both seat rotations are included. Pool both directions with sign flip for
+# the final estimate. Since the bidder decides contracts naturally, this
+# captures the weighted impact across the actual contract mix.
+#
+# Relationship to EXP 1 (per-contract)
+# -------------------------------------
+# EXP 1 (`cash_a_h2h_per_contract.yaml`) isolates Cash-A's effect per
+# forced contract type. This experiment (EXP 2) measures the aggregate
+# effect under realistic auction conditions where the GBT bidder selects
+# the contract mix.
+#
+# If EXP 1 shows a signal in suit but not high/low (as predicted by code
+# analysis), EXP 2 should show a diluted version of the suit signal since
+# the GBT bidder selects a mix of contract types.
+#
+# Compute budget
+# --------------
+# 2 matchups × 1 auction scenario × 5,000 deals = 10,000 hands. At
+# ~100 hands/sec for GBT-driven auction runs, this completes in ~100 s.
+#
+# MDE at n=5000 per matchup on net_points (paired SD ≈ 4):
+# ~0.11 net_points/deal at 95% CI.
+#
+# Analysis plan
+# -------------
+# - Primary: paired bootstrap delta on net_points (the real competitive
+#   measure). Pool both matchup directions with sign flip.
+# - Secondary: tricks_won delta, set_rate delta
+# - Facet by contract_type from JSONL logs to see if suit contracts drive
+#   the aggregate signal
+#
+# Depends on
+# ----------
+# - Claim 1 fix (_draw_trump_lead sure-winner-first fallback) from PR #2559
+# - GBT artifact at web/models/training_artifact_gbt_av.json
+# - Code analysis: plans/sessions/2026-04-07_cash_winners_contract_analysis.md
+#
+# Run
+# ---
+#   uv run python experiments/run_experiment.py \
+#     --config experiments/configs/cash_a_h2h_auction.yaml \
+#     --seed 42
+
+experiment_name: cash_a_h2h_auction
+
+parameters:
+  n_per: 5000
+  seed: 42
+  # hand_end records required by
+  # src/bid_euchre/analysis/paired.py::load_paired_data.
+  log_level: hand
+  mode: head_to_head_matrix
+  # Same physical deals across both matchups -> paired bootstrap.
+  pair_deals: true
+
+strategies:
+  # Cash-A ON — the candidate play strategy under evaluation.
+  - name: glutton_cash_on
+    class_name: GluttonStrategy
+    params:
+      cash_winners_on_lead: true
+
+  # Cash-A OFF — the baseline (current production default).
+  - name: glutton_cash_off
+    class_name: GluttonStrategy
+    params:
+      cash_winners_on_lead: false
+
+bidding_policies:
+  # GBT action-value bidder — identical for all seats across both matchups.
+  # Using the shipped web/models artifact (same model Bud Bot uses in the
+  # browser game).
+  - name: gbt_av
+    class_name: GBTActionValueBidder
+    params:
+      artifact_path: web/models/training_artifact_gbt_av.json
+
+matchups:
+  # Cash-A as Team 0 (seats 0, 2)
+  - matchup_id: cash_on_vs_cash_off
+    team0: glutton_cash_on
+    team1: glutton_cash_off
+    seat_bidding_policies: [gbt_av, gbt_av, gbt_av, gbt_av]
+
+  # Seat-swapped: Cash-A as Team 1 (seats 1, 3) — controls for seat bias
+  - matchup_id: cash_off_vs_cash_on
+    team0: glutton_cash_off
+    team1: glutton_cash_on
+    seat_bidding_policies: [gbt_av, gbt_av, gbt_av, gbt_av]
+
+scenarios:
+  - contract_type: null  # Auction mode — GBT bidder decides contract

--- a/experiments/configs/cash_a_h2h_per_contract.yaml
+++ b/experiments/configs/cash_a_h2h_per_contract.yaml
@@ -1,0 +1,111 @@
+# Cash-A per-contract-type head-to-head comparator (bidless)
+#
+# Purpose
+# -------
+# Measure the competitive advantage of `cash_winners_on_lead` per contract
+# type by pitting Cash-A Glutton against baseline Glutton on the same deals
+# with forced (pre-declared) contracts. No bidding policy is used — the
+# contract is fixed per scenario, isolating pure play-strategy differences.
+#
+# Design
+# ------
+# Team 0 (seats 0, 2): GluttonStrategy with cash_winners_on_lead=True
+# Team 1 (seats 1, 3): GluttonStrategy with cash_winners_on_lead=False
+#
+# Both seat rotations are included to control for seat bias. Pool the two
+# matchup directions with sign flip for the final estimate.
+#
+# Expected results (from code analysis in
+# plans/sessions/2026-04-07_cash_winners_contract_analysis.md):
+# - Suit contracts: measurable signal (positive or negative) — Cash-A's
+#   substantive logic (sure-winner cashing, trump drawing, draw-from-top)
+#   only fires in the suit branch.
+# - High and low: near-zero delta — Cash-A degenerates to a weak fallback
+#   that returns the same card the base heuristic selects.
+#
+# Compute budget
+# --------------
+# 2 matchups × 6 scenarios × 5,000 deals = 60,000 hands. At ~5,000
+# hands/sec bidless throughput this completes in ~12 s.
+#
+# MDE at n=5000 per scenario (paired SD ≈ 1.0 on tricks_team0):
+# ~0.055 tricks at 95% CI.
+#
+# Analysis plan
+# -------------
+# - Primary: paired bootstrap delta on tricks_team0 per contract type per
+#   matchup direction
+# - Pool both directions with sign flip to control seat bias
+# - Expected: high/low deltas ≈ 0 (inertness confirmation)
+# - Suit deltas are the real signal — positive = Cash-A helps, negative = hurts
+#
+# Depends on
+# ----------
+# - Claim 1 fix (_draw_trump_lead sure-winner-first fallback) from PR #2559
+# - Code analysis: plans/sessions/2026-04-07_cash_winners_contract_analysis.md
+#
+# Run
+# ---
+#   uv run python experiments/run_experiment.py \
+#     --config experiments/configs/cash_a_h2h_per_contract.yaml \
+#     --seed 42
+
+experiment_name: cash_a_h2h_per_contract
+
+parameters:
+  n_per: 5000
+  seed: 42
+  # hand_end records required by
+  # src/bid_euchre/analysis/paired.py::load_paired_data.
+  log_level: hand
+  mode: head_to_head_matrix
+  # Same physical deals across all scenarios and matchups -> paired
+  # bootstrap analysis on matched (deal_id, seed) keys.
+  pair_deals: true
+
+strategies:
+  # Cash-A ON — the candidate play strategy under evaluation.
+  - name: glutton_cash_on
+    class_name: GluttonStrategy
+    params:
+      cash_winners_on_lead: true
+
+  # Cash-A OFF — the baseline (current production default).
+  - name: glutton_cash_off
+    class_name: GluttonStrategy
+    params:
+      cash_winners_on_lead: false
+
+matchups:
+  # Cash-A as Team 0 (seats 0, 2)
+  - team0: glutton_cash_on
+    team1: glutton_cash_off
+
+  # Seat-swapped: Cash-A as Team 1 (seats 1, 3) — controls for seat bias
+  - team0: glutton_cash_off
+    team1: glutton_cash_on
+
+# Canonical 6-scenario comparison surface.
+# Forced contracts — no bidding policy invoked.
+scenarios:
+  - name: suit_C
+    contract_type: suit
+    trump_suit: C
+
+  - name: suit_D
+    contract_type: suit
+    trump_suit: D
+
+  - name: suit_H
+    contract_type: suit
+    trump_suit: H
+
+  - name: suit_S
+    contract_type: suit
+    trump_suit: S
+
+  - name: high
+    contract_type: high
+
+  - name: low
+    contract_type: low

--- a/plans/sessions/2026-04-07_cash_winners_contract_analysis.md
+++ b/plans/sessions/2026-04-07_cash_winners_contract_analysis.md
@@ -488,3 +488,29 @@ Analysis complete. Delivered:
 3. Prior experiment design critique (self-play flaw)
 4. Two YAML experiment configs for proper adversarial H2H comparison
 5. Recommendation: feature is correctly inert in high/low; needs H2H proof for suit
+
+### Addendum: Committed Experiment Configs (2026-04-07)
+
+The experiment configs proposed in §5 have been committed as runnable YAML files:
+
+- **EXP 1 (bidless per-contract):** `experiments/configs/cash_a_h2h_per_contract.yaml`
+  - 2 matchups × 6 scenarios × 5,000 deals = 60,000 hands (~12s)
+  - Dry-run validated ✅
+- **EXP 2 (auction H2H):** `experiments/configs/cash_a_h2h_auction.yaml`
+  - 2 matchups × 1 scenario × 5,000 deals = 10,000 hands (~100s)
+  - Uses `GBTActionValueBidder` with `web/models/training_artifact_gbt_av.json`
+    (the same model Bud Bot uses in the browser game)
+  - Dry-run validated ✅
+
+Key adaptation from §5 proposal: EXP 2 uses `GBTActionValueBidder` instead
+of `HybridOLSaBidder` because the hybrid artifact (`hybrid_r0.json`) does not
+exist on disk. The GBT bidder is the production bidder and the stronger
+baseline.
+
+Run commands:
+```bash
+uv run python experiments/run_experiment.py \
+  --config experiments/configs/cash_a_h2h_per_contract.yaml --seed 42
+uv run python experiments/run_experiment.py \
+  --config experiments/configs/cash_a_h2h_auction.yaml --seed 42
+```


### PR DESCRIPTION
## Summary

- Add two dry-run-validated YAML experiment configs for head-to-head evaluation of `cash_winners_on_lead`
- **EXP 1** (`cash_a_h2h_per_contract.yaml`): Bidless per-contract H2H — 2 matchups × 6 scenarios × 5k deals = 60k hands (~12s)
- **EXP 2** (`cash_a_h2h_auction.yaml`): GBT auction H2H — 2 matchups × 1 scenario × 5k deals = 10k hands (~100s)
- Update session plan with addendum documenting committed configs and adaptation notes

## Why

The prior Cash-A experiment used **self-play** which cannot detect competitive advantage (both teams use identical logic, so tricks converge to 5.0). These H2H configs pit Cash-A Glutton against baseline Glutton on the same paired deals, enabling proper adversarial measurement.

EXP 1 isolates per-contract-type effects (code analysis predicts suit=signal, high/low=inert). EXP 2 measures aggregate competitive impact under realistic GBT auction conditions.

Refs plans/sessions/2026-04-07_cash_winners_contract_analysis.md

## Repro / Validation

```bash
# Dry-run validation (both pass)
uv run python experiments/run_experiment.py \
  --config experiments/configs/cash_a_h2h_per_contract.yaml --seed 42 --dry-run
uv run python experiments/run_experiment.py \
  --config experiments/configs/cash_a_h2h_auction.yaml --seed 42 --dry-run

# Full runs (~2 min total)
uv run python experiments/run_experiment.py \
  --config experiments/configs/cash_a_h2h_per_contract.yaml --seed 42
uv run python experiments/run_experiment.py \
  --config experiments/configs/cash_a_h2h_auction.yaml --seed 42
```

## Tests

- `make check-gated` ✅
- Both configs pass `--dry-run` validation ✅
- Experiment config validator pre-commit hook ✅

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-analyst
branch: analyst/cash-winners-contract-analysis
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)