### PR TITLE
fix(strategy): evaluate capped bid against flag-B filter + canonical artifact path

### DIFF
--- a/experiments/configs/cash_a_h2h_auction.yaml
+++ b/experiments/configs/cash_a_h2h_auction.yaml
@@ -47,7 +47,7 @@
 # Depends on
 # ----------
 # - Claim 1 fix (_draw_trump_lead sure-winner-first fallback) from PR #2559
-# - GBT artifact at web/models/training_artifact_gbt_av.json
+# - GBT artifact at data/artifacts/arc_d_v2/r3/training_artifact_gbt_av.json
 # - Code analysis: plans/sessions/2026-04-07_cash_winners_contract_analysis.md
 #
 # Run
@@ -88,7 +88,7 @@ bidding_policies:
   - name: gbt_av
     class_name: GBTActionValueBidder
     params:
-      artifact_path: web/models/training_artifact_gbt_av.json
+      artifact_path: data/artifacts/arc_d_v2/r3/training_artifact_gbt_av.json
 
 matchups:
   # Cash-A as Team 0 (seats 0, 2)

--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -2684,7 +2684,9 @@ class FilteredGBTBidder(BiddingPolicy):
 
         if self._flag_a and _would_overbid_cap(obs, raw):
             # Cap the bid to current_high_bid + 1, keeping the same contract.
-            return BidAction.bid(obs.current_high_bid + 1, raw.contract)
+            # Do NOT return early — the capped bid must still be evaluated
+            # against flag-B (it could be a same-suit +1 nudge of partner).
+            raw = BidAction.bid(obs.current_high_bid + 1, raw.contract)
 
         if self._flag_b and _would_nudge_partner(obs, raw):
             return BidAction.pass_bid()

--- a/tests/unit/test_bidding.py
+++ b/tests/unit/test_bidding.py
@@ -2241,6 +2241,49 @@ class TestFilteredGBTBidder:
         assert result.n == 5
         assert result.contract == "S"
 
+    def test_both_flags_capped_bid_triggers_flag_b(self):
+        """Both flags on: flag-A caps the bid, capped bid then triggers flag-B.
+
+        Scenario: partner bid 4S, raw bid 7S. Flag-A caps to 5S (high_bid + 1).
+        The capped 5S is partner's 4S + 1 in the same suit -> flag-B fires,
+        returning pass. Before the fix, the early return in flag-A skipped
+        the flag-B evaluation entirely.
+        """
+        transcript = (
+            {
+                "seat": 1,
+                "action": "PASS",
+                "tricks_bid": 0,
+                "contract_type": None,
+                "trump": None,
+            },
+            {
+                "seat": 2,
+                "action": "BID",
+                "tricks_bid": 4,
+                "contract_type": "suit",
+                "trump": "S",
+                "bid_type": "regular",
+            },
+            {
+                "seat": 3,
+                "action": "PASS",
+                "tricks_bid": 0,
+                "contract_type": None,
+                "trump": None,
+            },
+        )
+        obs = _obs(seat=0, dealer_seat=0, current_high_bid=4, transcript=transcript)
+
+        # Raw bid 7S: flag-A caps to 5S (4+1), then flag-B sees 5S is
+        # partner's 4S + 1 in the same suit -> pass.
+        inner = _make_mock_inner(BidAction.bid(7, "S"))
+        bidder = FilteredGBTBidder(inner=inner, flag_a=True, flag_b=True)
+        result = bidder.choose_bid(obs)
+        assert (
+            result.is_pass()
+        ), f"Expected pass (flag-B should fire on capped bid), got {result}"
+
     def test_construction_requires_inner_or_artifact(self):
         """Must provide either inner or artifact_path, not neither."""
         with pytest.raises(ValueError, match="requires either"):


### PR DESCRIPTION
## Summary

- **Fix flag-A/flag-B interaction (#2587):** When `FilteredGBTBidder`'s flag-A caps an overbid, the capped bid now falls through to flag-B evaluation instead of returning early. This ensures a capped bid that is also a same-suit +1 partner nudge is correctly suppressed.
- **Canonical artifact path (#2583):** Updated `cash_a_h2h_auction.yaml` to use `data/artifacts/arc_d_v2/r3/training_artifact_gbt_av.json` instead of the deployment-specific `web/models/` copy.

## Why

Flag-A's early return at line 2687 caused the capped bid to bypass the flag-B predicate entirely. If the capped bid happened to be partner's suit + 1 trick (the exact pattern flag-B detects), the nudge would pass through unchecked. The experiment config used a non-canonical artifact path that doesn't exist in dev checkouts.

## Changes

| File | Change |
|------|--------|
| `src/bid_euchre/strategy/bidding.py` | `return BidAction.bid(...)` → `raw = BidAction.bid(...)` (remove early return) |
| `experiments/configs/cash_a_h2h_auction.yaml` | `web/models/` → `data/artifacts/arc_d_v2/r3/` (canonical path) |
| `tests/unit/test_bidding.py` | New test `test_both_flags_capped_bid_triggers_flag_b` proving the interaction |

## Validation

```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/test_bidding.py -k "FilteredGBT" -v
# 17 passed (including new test)

# Tier 2 — full validation
make check-gated
# 11,411 passed, 3 failed (pre-existing test_cpu_gate.py load-dependent flakes)
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: fix/wave-2a-strategy-convention
```

## Test criteria

The new test `test_both_flags_capped_bid_triggers_flag_b` verifies: when flag-A caps a 7S bid to 5S (high_bid=4, +1) and partner bid 4S, flag-B detects the same-suit +1 nudge and returns pass. This test would fail on the previous code (early return).

Refs #2587, Refs #2583