### PR TITLE
fix(web): default to large text (125%) for new users (Refs #2521)

### DIFF
--- a/tests/unit/hosted_play/test_text_size_toggle.py
+++ b/tests/unit/hosted_play/test_text_size_toggle.py
@@ -97,6 +97,14 @@ class TestBaseHtmlFoucPrevention:
         game_js_pos = base_html.find("game.js")
         assert fouc_pos < game_js_pos, "FOUC script must precede game.js"
 
+    def test_fouc_defaults_to_large(self, base_html):
+        """Large text is the default — FOUC script must apply large unless
+        user explicitly opted out (#2521 item 1)."""
+        # The script should check for 'default' opt-out, not 'large' opt-in
+        assert (
+            "!=='default'" in base_html
+        ), "FOUC script should default to large text (check for opt-out, not opt-in)"
+
 
 # ---------------------------------------------------------------------------
 # accessibility.css — large mode rule
@@ -169,3 +177,10 @@ class TestGameJsToggleLogic:
         """Toggle should set/remove data-text-size on documentElement."""
         assert "data-text-size" in game_js
         assert "document.documentElement" in game_js
+
+    def test_large_is_default(self, game_js):
+        """getTextSize should return 'large' when no preference is stored (#2521 item 1)."""
+        # The function should treat missing/null localStorage as 'large'
+        assert (
+            "=== 'default' ? 'default' : 'large'" in game_js
+        ), "getTextSize should default to 'large' when localStorage has no value"

--- a/web/static/game.js
+++ b/web/static/game.js
@@ -374,29 +374,37 @@
     }
 
     /* ---------------------------------------------------------------
-     * Text size toggle — default (100%) and large (125%).
+     * Text size toggle — large (125%) is the DEFAULT (#2521 item 1).
+     * Standard (100%) is opt-in via the toggle button.
      * Persisted in localStorage. The inline <script> in base.html
      * applies the attribute before first paint to avoid FOUC.
+     *
+     * Storage convention:
+     *   - No stored value → large text (default for new users)
+     *   - 'large' → large text (explicit choice)
+     *   - 'default' → standard text (user opted out)
      * --------------------------------------------------------------- */
 
     var TEXT_SIZE_KEY = 'textSize';
 
     function getTextSize() {
         try {
-            return localStorage.getItem(TEXT_SIZE_KEY) || 'default';
+            var stored = localStorage.getItem(TEXT_SIZE_KEY);
+            // No stored preference → large (the default)
+            return stored === 'default' ? 'default' : 'large';
         } catch (_) {
             // localStorage unavailable — fall back to document state
-            return document.documentElement.getAttribute('data-text-size') || 'default';
+            return document.documentElement.getAttribute('data-text-size') ? 'large' : 'large';
         }
     }
 
     function setTextSize(size) {
         try {
             if (size === 'large') {
-                localStorage.setItem(TEXT_SIZE_KEY, 'large');
+                localStorage.removeItem(TEXT_SIZE_KEY);
                 document.documentElement.setAttribute('data-text-size', 'large');
             } else {
-                localStorage.removeItem(TEXT_SIZE_KEY);
+                localStorage.setItem(TEXT_SIZE_KEY, 'default');
                 document.documentElement.removeAttribute('data-text-size');
             }
         } catch (_) {

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -33,9 +33,10 @@
             padding: var(--safe-area-top) var(--safe-area-right) var(--safe-area-bottom) var(--safe-area-left);
         }
     </style>
-    <!-- Apply text size preference before first paint to prevent FOUC -->
+    <!-- Apply text size preference before first paint to prevent FOUC.
+         Large text (125%) is the default — only opt-out if user explicitly chose standard (#2521 item 1). -->
     <script>
-        (function(){try{var s=localStorage.getItem('textSize');if(s==='large'){document.documentElement.setAttribute('data-text-size','large');}}catch(e){}})();
+        (function(){try{var s=localStorage.getItem('textSize');if(s!=='default'){document.documentElement.setAttribute('data-text-size','large');}}catch(e){document.documentElement.setAttribute('data-text-size','large');}})();
     </script>
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     <script src="https://unpkg.com/idiomorph@0.3.0/dist/idiomorph-ext.min.js"></script>


### PR DESCRIPTION
## Summary

- Default the text size to **large (125%)** for new users, completing #2521 item 1
- Users who prefer standard text can opt out via the Aa toggle button
- Added 2 tests verifying the new default-to-large behavior

## Why

Operator review of the mobile experience determined that large text should be the default — text at 100% base is too small on phone screens. Since all font sizes use `rem`, scaling the root `font-size` to 125% propagates cleanly without layout breakage.

## Feasibility Analysis (#2521 Item 1)

Evaluated layout impact of 125% default across all breakpoints:

| Area | Impact | Notes |
|------|--------|-------|
| **Bid form** | ✅ No issues | Flexbox `stretch` layout accommodates wider text |
| **Score bar** | ✅ No issues | `flex-wrap: wrap` handles gracefully |
| **Card area** | ✅ No issues | Card sizes use `px` variables, unaffected by rem scaling |
| **Compass layout** | ✅ No issues | Grid layout with relative gaps |
| **Auction log** | ✅ No issues | Already tested at large text in browser tests |
| **Mobile (375px)** | ✅ No issues | Font sizes already reduced at this breakpoint (0.8–0.85rem) |
| **Mobile (414px)** | ✅ No issues | Tighter padding already applied |
| **Tables/grids** | ✅ No issues | All use flexible layouts |

**Conclusion:** Large text as default is feasible with zero layout regressions. The 125% scale (16px → 20px base) produces comfortable text sizes across all viewports.

## Implementation Details

**Storage convention change:**
- Before: no stored value → standard (100%); `'large'` → large (125%)
- After: no stored value → large (125%); `'default'` → standard (100%)

**Files changed:**
- `web/templates/base.html` — FOUC prevention script defaults to large
- `web/static/game.js` — `getTextSize()`/`setTextSize()` inverted defaults
- `tests/unit/hosted_play/test_text_size_toggle.py` — 2 new tests for default behavior

**Backwards compatibility:**
- Existing users with `textSize=large` in localStorage → still see large text ✅
- Existing users with no stored preference → switch from 100% to 125% (desired) ✅
- Users who toggle to standard → `'default'` stored, persists across sessions ✅

## Repro / Validation

```bash
uv run python -m pytest tests/unit/hosted_play/test_text_size_toggle.py -v
# 22 passed (20 existing + 2 new)
```

Visual: open the game in a fresh browser (no localStorage) — page loads at 125% text. Click Aa → switches to standard. Refresh → stays standard. Clear localStorage → back to large.

## Tests

```bash
make check-gated  # 11,412 passed, 59 skipped, 3 unrelated cpu_gate flaky failures
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
branch: fix/web-large-text-default
```

Refs #2521

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)