### PR TITLE
fix(test): scope auction assertions to phase and handle AI auto-advance

### DIFF
--- a/tests/browser/test_card_animations.py
+++ b/tests/browser/test_card_animations.py
@@ -82,7 +82,25 @@ def _play_to_trick_boundary(page: Page, timeout_s: float = 120.0) -> bool:
             page.wait_for_timeout(250)
             continue
 
-        # Nothing to do — wait for AI to advance
+        # Handle AI-led trick starts via the auto-advance form.  When it
+        # is the AI's turn to play, the game renders a hidden auto-advance
+        # form instead of a visible Next button.  Submit it directly so the
+        # AI action goes through the browser helper rather than being
+        # bypassed (#2605).
+        auto_submitted = page.evaluate(
+            """() => {
+                const f = document.querySelector(
+                    '.next-controls--auto-advance #next-step-form'
+                );
+                if (f) { f.requestSubmit(); return true; }
+                return false;
+            }"""
+        )
+        if auto_submitted:
+            page.wait_for_timeout(250)
+            continue
+
+        # Nothing to do — wait briefly for HTMX swap
         page.wait_for_timeout(500)
 
     return False
@@ -307,7 +325,6 @@ def test_reduced_motion_disables_slot_fade(
     if animation_name is None:
         pytest.skip("No .card-slot--empty found in current state")
 
-    assert animation_name == "none", (
-        f"Expected animation-name 'none' under reduced-motion, "
-        f"got '{animation_name}'"
-    )
+    assert (
+        animation_name == "none"
+    ), f"Expected animation-name 'none' under reduced-motion, got '{animation_name}'"

--- a/tests/browser/test_mobile.py
+++ b/tests/browser/test_mobile.py
@@ -280,31 +280,40 @@ def test_auction_log_all_bidders_visible_mobile(
             f"The test must reach a four-bidder state before asserting overflow (#2594)."
         )
 
-        # The list container should NOT be scrollable during auction
-        list_el = mobile_page.locator(".action-rail__list")
-        if list_el.count() > 0:
-            scroll_height = list_el.evaluate("el => el.scrollHeight")
-            client_height = list_el.evaluate("el => el.clientHeight")
-            assert scroll_height <= client_height + 2, (
-                f"Auction log list overflows during auction phase: "
-                f"scrollHeight={scroll_height}px, clientHeight={client_height}px. "
-                f"All {item_count} bidder rows should be visible without scrolling (#2591)."
-            )
+        # Overflow and scroll assertions only apply during auction phase.
+        # After _advance_to_four_bidders the game may have transitioned to
+        # trick_play, which repositions the action-rail below the score bar
+        # (different layout).  Detect auction phase by the absence of
+        # #trick-area — only rendered when phase != "auction" (#2601, #2606).
+        in_auction = mobile_page.locator("#trick-area").count() == 0
 
-        # Verify each visible item is within the viewport
-        viewport_height = MOBILE_VIEWPORT["height"]
-        for i in range(item_count):
-            item = items.nth(i)
-            if not item.is_visible():
-                continue
-            box = item.bounding_box()
-            if box is None:
-                continue
-            assert box["y"] + box["height"] <= viewport_height + 5, (
-                f"Auction log item {i} overflows viewport bottom: "
-                f"y={box['y']:.0f} + h={box['height']:.0f} = "
-                f"{box['y'] + box['height']:.0f}px > {viewport_height}px (#2591)"
-            )
+        # The list container should NOT be scrollable during auction
+        if in_auction:
+            list_el = mobile_page.locator(".action-rail__list")
+            if list_el.count() > 0:
+                scroll_height = list_el.evaluate("el => el.scrollHeight")
+                client_height = list_el.evaluate("el => el.clientHeight")
+                assert scroll_height <= client_height + 2, (
+                    f"Auction log list overflows during auction phase: "
+                    f"scrollHeight={scroll_height}px, clientHeight={client_height}px. "
+                    f"All {item_count} bidder rows should be visible without scrolling (#2591)."
+                )
+
+        # Verify each visible item is within the viewport (auction layout only)
+        if in_auction:
+            viewport_height = MOBILE_VIEWPORT["height"]
+            for i in range(item_count):
+                item = items.nth(i)
+                if not item.is_visible():
+                    continue
+                box = item.bounding_box()
+                if box is None:
+                    continue
+                assert box["y"] + box["height"] <= viewport_height + 5, (
+                    f"Auction log item {i} overflows viewport bottom: "
+                    f"y={box['y']:.0f} + h={box['height']:.0f} = "
+                    f"{box['y'] + box['height']:.0f}px > {viewport_height}px (#2591)"
+                )
 
     finally:
         context.close()
@@ -362,16 +371,22 @@ def test_auction_log_all_bidders_visible_mobile_big_text(
             item_count >= 4
         ), f"Expected ≥4 auction log items but found {item_count} (#2594)."
 
+        # Scroll assertion only applies during auction phase — after
+        # _advance_to_four_bidders the game may have transitioned to
+        # trick_play which repositions the action-rail (#2601, #2606).
+        in_auction = mobile_page.locator("#trick-area").count() == 0
+
         # Check the list container is NOT scrollable (big text mode)
-        list_el = mobile_page.locator(".action-rail__list")
-        if list_el.count() > 0:
-            scroll_height = list_el.evaluate("el => el.scrollHeight")
-            client_height = list_el.evaluate("el => el.clientHeight")
-            assert scroll_height <= client_height + 2, (
-                f"Auction log overflows in big text mode: "
-                f"scrollHeight={scroll_height}px, clientHeight={client_height}px. "
-                f"All bidder rows should be visible without scrolling (#2591)."
-            )
+        if in_auction:
+            list_el = mobile_page.locator(".action-rail__list")
+            if list_el.count() > 0:
+                scroll_height = list_el.evaluate("el => el.scrollHeight")
+                client_height = list_el.evaluate("el => el.clientHeight")
+                assert scroll_height <= client_height + 2, (
+                    f"Auction log overflows in big text mode: "
+                    f"scrollHeight={scroll_height}px, clientHeight={client_height}px. "
+                    f"All bidder rows should be visible without scrolling (#2591)."
+                )
 
     finally:
         context.close()


### PR DESCRIPTION
## Summary

- **test_mobile.py:** Guard overflow/scroll assertions behind an auction-phase check — after `_advance_to_four_bidders` the game may transition to trick_play, which repositions the action-rail below the score bar (different layout from the auction center)
- **test_card_animations.py:** Submit the hidden auto-advance form for AI-led trick starts instead of falling through to a 500ms wait loop

## Why

Three convention follow-ups from the review coordinator:
- #2601 (PR #2597): Keep mobile overflow checks in the auction-phase layout
- #2606 (PR #2603): Keep non-scroll assertion scoped to auction phase
- #2605 (PR #2598): Keep AI-led trick starts from bypassing the browser helper

## How

- **Phase detection:** The game board template only renders `#trick-area` when `phase != "auction"` (game_board.html line 119). So `#trick-area` absent → still in auction; present → transitioned to trick play.
- **Auto-advance handling:** When AI leads a trick, the game renders a hidden `.next-controls--auto-advance` form instead of a visible Next button. The helper now detects and submits this form directly via `requestSubmit()`.

## Repro / Validation

```bash
# Tier 2 full validation
make check-gated
# → All checks passed

# Browser tests (not in make check — run separately)
# make browser-smoke
```

## Tests

- `make check-gated` — all checks passed

## Scope

| File | Change |
|------|--------|
| `tests/browser/test_mobile.py` | Guard scroll/overflow assertions with `in_auction` phase check |
| `tests/browser/test_card_animations.py` | Add auto-advance form submission in `_play_to_trick_boundary` |

Refs #2601, Refs #2605, Refs #2606

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
branch: fix/convention-test-fixes-2601-2605-2606
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)