### PR TITLE
feat(strategy): add versioning, fingerprinting, and version comparison (#2519)

### DIFF
--- a/experiments/run_experiment.py
+++ b/experiments/run_experiment.py
@@ -55,6 +55,7 @@ from bid_euchre.experiments.meta import get_git_sha, sha256_file, utc_now_iso
 from bid_euchre.logging import GameLogger, LogLevel
 from bid_euchre.sim import simulation
 from bid_euchre.sim.hooks import HandEndEvent, SimulationHooks
+from bid_euchre.strategy.versioning import collect_versions
 
 # Metadata schema version
 META_JSON_SCHEMA_VERSION = (
@@ -1209,6 +1210,7 @@ def main():
         ],
         "strategies": [s.name for s in strategies],
         "bidding_policies": [p.name for p in bidding_policies],
+        "strategy_versions": collect_versions(strategies, bidding_policies),
         "leader_randomized": True,  # Always true with new deal generator
         "common_deals": seed is not None,  # Only true if seed provided
         "pair_deals": pair_deals,  # True = same physical deals across all scenarios

--- a/src/bid_euchre/strategy/__init__.py
+++ b/src/bid_euchre/strategy/__init__.py
@@ -61,6 +61,9 @@ from .glutton import (
 # "greedy" will continue to work via sys.modules alias.
 sys.modules[__name__ + ".greedy"] = sys.modules[__name__ + ".glutton"]
 
+# Versioning utilities
+from .versioning import collect_versions, compare_versions
+
 # Regression strategies - REMOVED: RegressionBidder (legacy pickle path)
 
 __all__ = [
@@ -101,4 +104,7 @@ __all__ = [
     # Legacy functions
     "choose_card_basic",
     "choose_card_greedy",
+    # Versioning
+    "collect_versions",
+    "compare_versions",
 ]

--- a/src/bid_euchre/strategy/base.py
+++ b/src/bid_euchre/strategy/base.py
@@ -2,6 +2,7 @@
 Base strategy class and shared utilities.
 """
 
+import hashlib
 from abc import ABC, abstractmethod
 from typing import List, Optional, Tuple
 
@@ -15,7 +16,16 @@ from ..core.cards import (
 
 
 class Strategy(ABC):
-    """Abstract base class for Bid Euchre strategies."""
+    """Abstract base class for Bid Euchre strategies.
+
+    Subclasses should set a ``VERSION`` class attribute (semver string)
+    that is bumped on every behavioral change.  See
+    ``docs/02_agent/STRATEGY_VERSIONING.md`` for bump rules.
+    """
+
+    # Default version for strategies that have not opted into versioning.
+    # Concrete subclasses override this with their own semver string.
+    VERSION: str = "0.0.0"
 
     def __init__(self, name: str = "unnamed"):
         self.name = name
@@ -114,6 +124,24 @@ class Strategy(ABC):
             trump_suit: Trump suit for "suit" contracts, None otherwise
         """
         pass
+
+    def fingerprint(self) -> str:
+        """Return a short hex digest identifying this strategy's version and config.
+
+        The fingerprint is derived from the class name, ``VERSION``, and the
+        instance ``name``.  Subclasses with extra configuration (feature flags,
+        artifact paths, etc.) should override and include those values.
+
+        Returns:
+            8-character hex digest (first 8 chars of SHA-256).
+        """
+        parts = [
+            type(self).__name__,
+            type(self).VERSION,
+            self.name,
+        ]
+        blob = "|".join(parts).encode()
+        return hashlib.sha256(blob).hexdigest()[:8]
 
     def __str__(self) -> str:
         return f"{self.__class__.__name__}({self.name})"

--- a/src/bid_euchre/strategy/baselines.py
+++ b/src/bid_euchre/strategy/baselines.py
@@ -20,6 +20,11 @@ from ..core.cards import (
 from ..core.rules import get_legal_indices
 from .base import Strategy
 
+# Module-level version constant for baseline strategies. These strategies
+# have been stable since initial commit, so the version stays at 1.0.0
+# unless someone changes their decision logic.
+BASELINES_VERSION = "1.0.0"
+
 
 class BasicStrategy(Strategy):
     """
@@ -27,6 +32,8 @@ class BasicStrategy(Strategy):
 
     Simple rule-based approach with no lookahead or trump consideration.
     """
+
+    VERSION = BASELINES_VERSION
 
     def __init__(self, name: str = "basic"):
         super().__init__(name)
@@ -58,6 +65,8 @@ class RandomLegalStrategy(Strategy):
     - Verification that suit-follow enforcement works
     """
 
+    VERSION = BASELINES_VERSION
+
     def __init__(self, name: str = "random_legal", seed: Optional[int] = None):
         super().__init__(name)
         self.rng = random.Random(seed)
@@ -85,6 +94,8 @@ class AlwaysLowestLegalStrategy(Strategy):
     - Baseline for "passive" play
     - Often does okay at not wasting trump, but loses by never taking initiative
     """
+
+    VERSION = BASELINES_VERSION
 
     def __init__(self, name: str = "always_lowest"):
         super().__init__(name)
@@ -146,6 +157,8 @@ class AlwaysHighestLegalStrategy(Strategy):
     - Wastes trump when a low card would win
     - Sets partner up poorly
     """
+
+    VERSION = BASELINES_VERSION
 
     def __init__(self, name: str = "always_highest"):
         super().__init__(name)

--- a/src/bid_euchre/strategy/bidding.py
+++ b/src/bid_euchre/strategy/bidding.py
@@ -5,6 +5,7 @@ This module provides the canonical interface for bidding in auction games,
 where players bid simultaneously for the right to choose contract and trump.
 """
 
+import hashlib
 import json
 import logging
 import math
@@ -251,7 +252,13 @@ class BiddingPolicy(ABC):
     Abstract base class for bidding policies in auction mode.
 
     Bidding policies decide how to bid based on the current auction state.
+
+    Subclasses should set a ``VERSION`` class attribute (semver string)
+    that is bumped on every behavioral change.
     """
+
+    # Default version for policies that have not opted into versioning.
+    VERSION: str = "0.0.0"
 
     def __init__(self, name: str = "unnamed"):
         self.name = name
@@ -269,6 +276,23 @@ class BiddingPolicy(ABC):
         """
         pass
 
+    def fingerprint(self) -> str:
+        """Return a short hex digest identifying this policy's version and config.
+
+        Subclasses with extra configuration (artifact paths, thresholds, etc.)
+        should override and include those values.
+
+        Returns:
+            8-character hex digest (first 8 chars of SHA-256).
+        """
+        parts = [
+            type(self).__name__,
+            type(self).VERSION,
+            self.name,
+        ]
+        blob = "|".join(parts).encode()
+        return hashlib.sha256(blob).hexdigest()[:8]
+
     def __str__(self) -> str:
         return f"{self.__class__.__name__}({self.name})"
 
@@ -276,10 +300,20 @@ class BiddingPolicy(ABC):
         return str(self)
 
 
+# Module-level version constants for bidding policy families.
+# Heuristic bidders have been stable since initial commit.
+HEURISTIC_BIDDER_VERSION = "1.0.0"
+# Artifact-backed bidders derive behavior from the artifact + thin wrapper
+# logic. Bump this when the wrapper changes (not when the artifact does).
+ARTIFACT_BIDDER_VERSION = "1.0.0"
+
+
 class AlwaysPassBidder(BiddingPolicy):
     """
     Baseline bidder that always passes (n=0).
     """
+
+    VERSION = HEURISTIC_BIDDER_VERSION
 
     def __init__(self, name: str = "always_pass"):
         super().__init__(name)
@@ -297,6 +331,8 @@ class StrictHellRaiser(BiddingPolicy):
     - If current_high_bid >= 10: pass
     - Always bids for "S" (Spades) contract (deterministic choice)
     """
+
+    VERSION = HEURISTIC_BIDDER_VERSION
 
     def __init__(self, name: str = "strict_raiser"):
         super().__init__(name)
@@ -325,6 +361,8 @@ class FixedBidder(BiddingPolicy):
     Otherwise, passes.
     """
 
+    VERSION = HEURISTIC_BIDDER_VERSION
+
     def __init__(self, n: int, contract: str, name: str = "fixed_bidder"):
         super().__init__(name)
         if n < 1 or n > 10:
@@ -352,6 +390,8 @@ class HeuristicSuitBidder(BiddingPolicy):
       - strength >= 300: bid 5
       - strength >= 250: bid 4
       - strength >= 200: bid 3
+
+    .. note:: Not registered in the experiment config registry — internal only.
       - else: pass
     - Complies with strict-increasing rule (only bids if > current_high_bid)
     """
@@ -464,6 +504,8 @@ class RanktheTank(BiddingPolicy):
     Named after the blog post character who bids based on "my hand looks big."
     Serves as the canonical "rankthetank" teacher for imitation learning.
     """
+
+    VERSION = HEURISTIC_BIDDER_VERSION
 
     def __init__(self, name: str = "rankthetank"):
         super().__init__(name)
@@ -579,6 +621,8 @@ class ModeloEspecifico(BiddingPolicy):
     Named after the blog post's "specific model" baseline.
     """
 
+    VERSION = HEURISTIC_BIDDER_VERSION
+
     _DEFAULT_FEATURE_WEIGHTS = {
         "suit": {"bowers": 1.0, "trump_count": 0.5, "offsuit_aces": 0.5},
         "high": {"offsuit_aces": 1.0},
@@ -659,6 +703,8 @@ class ArtifactBidder(BiddingPolicy):
 
     The artifact is loaded and validated at initialization time.
     """
+
+    VERSION = ARTIFACT_BIDDER_VERSION
 
     def __init__(self, artifact_path: str, name: str = None):
         """
@@ -871,6 +917,8 @@ class OLSaBidder(BiddingPolicy):
     For hybrid_olsa_v1, uses the offensive sub-model (bidder's perspective)
     and ignores residual_variance / risk_lambda fields.
     """
+
+    VERSION = ARTIFACT_BIDDER_VERSION
 
     def __init__(self, artifact_path: str, name: str = "olsa"):
         super().__init__(name)
@@ -1130,6 +1178,8 @@ class HybridOLSaBidder(BiddingPolicy):
 
     Artifact format: hybrid_olsa_v1 with payoff_model, residual_variance, risk_lambda.
     """
+
+    VERSION = ARTIFACT_BIDDER_VERSION
 
     # z-cap to prevent numerical overflow in CDF/PDF
     _Z_CAP = 6.0
@@ -2144,6 +2194,8 @@ class ActionValueBidder(BiddingPolicy):
     Artifact schema: action_value_olsa_v1
     """
 
+    VERSION = ARTIFACT_BIDDER_VERSION
+
     def __init__(
         self,
         artifact_path: str,
@@ -2353,6 +2405,8 @@ class GBTActionValueBidder(BiddingPolicy):
 
     Artifact schema: action_value_gbt_v1
     """
+
+    VERSION = ARTIFACT_BIDDER_VERSION
 
     def __init__(
         self,
@@ -2640,6 +2694,8 @@ class FilteredGBTBidder(BiddingPolicy):
       — constructs the inner GBTActionValueBidder automatically.
     """
 
+    VERSION = ARTIFACT_BIDDER_VERSION
+
     def __init__(
         self,
         inner: Optional[GBTActionValueBidder] = None,
@@ -2716,6 +2772,8 @@ class TwoStageActionValueBidder(BiddingPolicy):
 
     Artifact schema: two_stage_action_value_v1
     """
+
+    VERSION = ARTIFACT_BIDDER_VERSION
 
     def __init__(
         self,

--- a/src/bid_euchre/strategy/glutton.py
+++ b/src/bid_euchre/strategy/glutton.py
@@ -9,6 +9,7 @@ These strategies try to win the current trick if possible,
 with variations that add partner awareness and trump conservation.
 """
 
+import hashlib
 from collections import Counter
 from typing import Dict, List, Optional, Set, Tuple
 
@@ -59,6 +60,10 @@ class GreedyStrategy(Strategy):
     - No multi-trick lookahead
     - Myopic (doesn't consider future tricks)
     """
+
+    # GreedyStrategy has been frozen as a reference baseline since the
+    # Glutton fork. Its decision logic never changes, so version is 1.0.0.
+    VERSION = "1.0.0"
 
     def __init__(self, name: str = "greedy"):
         super().__init__(name)
@@ -170,6 +175,22 @@ class GluttonStrategy(Strategy):
         # leader, prefer continuing the same suit on the next lead.
         self._last_won_lead_suit: Optional[str] = None
         self._last_won_lead_seat: Optional[int] = None
+
+    def fingerprint(self) -> str:
+        """Include feature flags in the fingerprint.
+
+        Two ``GluttonStrategy`` instances with different ``cash_winners_on_lead``
+        settings produce different fingerprints even at the same version, because
+        their play behavior differs.
+        """
+        parts = [
+            type(self).__name__,
+            type(self).VERSION,
+            self.name,
+            f"cash_winners_on_lead={self.cash_winners_on_lead}",
+        ]
+        blob = "|".join(parts).encode()
+        return hashlib.sha256(blob).hexdigest()[:8]
 
     def on_hand_start(
         self,
@@ -928,6 +949,27 @@ class GluttonIsolatedStrategy(Strategy):
         # Suit continuity tracking (#2506)
         self._last_won_lead_suit: Optional[str] = None
         self._last_won_lead_seat: Optional[int] = None
+
+    def fingerprint(self) -> str:
+        """Include all feature flags in the fingerprint."""
+        parts = [
+            type(self).__name__,
+            type(self).VERSION,
+            self.name,
+            f"smart_leads={self._smart_leads}",
+            f"smart_discards={self._smart_discards}",
+            f"third_seat_aggression={self._third_seat_aggression}",
+            f"partner_awareness={self._partner_awareness}",
+            f"sure_winner_cover={self._sure_winner_cover}",
+            f"partner_check={self._partner_check}",
+            f"trump_gating={self._trump_gating}",
+            f"probabilistic_trump_in={self._probabilistic_trump_in}",
+            f"lead_bower={self._lead_bower}",
+            f"cash_winners_on_lead={self.cash_winners_on_lead}",
+            f"suit_continuity={self._suit_continuity}",
+        ]
+        blob = "|".join(parts).encode()
+        return hashlib.sha256(blob).hexdigest()[:8]
 
     def on_hand_start(
         self,

--- a/src/bid_euchre/strategy/versioning.py
+++ b/src/bid_euchre/strategy/versioning.py
@@ -1,0 +1,161 @@
+"""
+Strategy versioning utilities.
+
+Provides helpers for collecting, comparing, and serializing strategy
+version metadata from play strategies and bidding policies.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .base import Strategy
+from .bidding import BiddingPolicy
+
+
+def collect_versions(
+    strategies: list[Strategy],
+    bidding_policies: list[BiddingPolicy],
+) -> dict[str, Any]:
+    """Collect version and fingerprint info for all strategies and policies.
+
+    Returns a dict suitable for embedding in ``meta.json`` under a
+    ``strategy_versions`` key.
+
+    Example output::
+
+        {
+            "play_strategies": [
+                {
+                    "name": "glutton",
+                    "class": "GluttonStrategy",
+                    "version": "0.10.0",
+                    "fingerprint": "a1b2c3d4"
+                }
+            ],
+            "bidding_policies": [
+                {
+                    "name": "olsa_H",
+                    "class": "OLSaBidder",
+                    "version": "1.0.0",
+                    "fingerprint": "e5f6a7b8"
+                }
+            ]
+        }
+    """
+    play_entries = []
+    for s in strategies:
+        play_entries.append(
+            {
+                "name": s.name,
+                "class": type(s).__name__,
+                "version": type(s).VERSION,
+                "fingerprint": s.fingerprint(),
+            }
+        )
+
+    bid_entries = []
+    for p in bidding_policies:
+        bid_entries.append(
+            {
+                "name": p.name,
+                "class": type(p).__name__,
+                "version": type(p).VERSION,
+                "fingerprint": p.fingerprint(),
+            }
+        )
+
+    return {
+        "play_strategies": play_entries,
+        "bidding_policies": bid_entries,
+    }
+
+
+def compare_versions(
+    old: dict[str, Any],
+    new: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Compare two ``strategy_versions`` dicts and return a list of diffs.
+
+    Each diff entry contains::
+
+        {
+            "category": "play_strategies" | "bidding_policies",
+            "name": str,
+            "old_version": str | None,
+            "new_version": str | None,
+            "old_fingerprint": str | None,
+            "new_fingerprint": str | None,
+            "change": "added" | "removed" | "version_changed" | "config_changed"
+        }
+
+    ``version_changed`` means the semver string changed.
+    ``config_changed`` means the version is the same but the fingerprint
+    differs (e.g., a feature flag was toggled without a version bump).
+    """
+    diffs: list[dict[str, Any]] = []
+
+    for category in ("play_strategies", "bidding_policies"):
+        old_items = {e["name"]: e for e in old.get(category, [])}
+        new_items = {e["name"]: e for e in new.get(category, [])}
+
+        # Removed
+        for name in sorted(old_items.keys() - new_items.keys()):
+            entry = old_items[name]
+            diffs.append(
+                {
+                    "category": category,
+                    "name": name,
+                    "old_version": entry["version"],
+                    "new_version": None,
+                    "old_fingerprint": entry["fingerprint"],
+                    "new_fingerprint": None,
+                    "change": "removed",
+                }
+            )
+
+        # Added
+        for name in sorted(new_items.keys() - old_items.keys()):
+            entry = new_items[name]
+            diffs.append(
+                {
+                    "category": category,
+                    "name": name,
+                    "old_version": None,
+                    "new_version": entry["version"],
+                    "old_fingerprint": None,
+                    "new_fingerprint": entry["fingerprint"],
+                    "change": "added",
+                }
+            )
+
+        # Changed
+        for name in sorted(old_items.keys() & new_items.keys()):
+            o = old_items[name]
+            n = new_items[name]
+            if o["version"] != n["version"]:
+                diffs.append(
+                    {
+                        "category": category,
+                        "name": name,
+                        "old_version": o["version"],
+                        "new_version": n["version"],
+                        "old_fingerprint": o["fingerprint"],
+                        "new_fingerprint": n["fingerprint"],
+                        "change": "version_changed",
+                    }
+                )
+            elif o["fingerprint"] != n["fingerprint"]:
+                diffs.append(
+                    {
+                        "category": category,
+                        "name": name,
+                        "old_version": o["version"],
+                        "new_version": n["version"],
+                        "old_fingerprint": o["fingerprint"],
+                        "new_fingerprint": n["fingerprint"],
+                        "change": "config_changed",
+                    }
+                )
+
+    return diffs

--- a/tests/unit/test_strategy_versioning.py
+++ b/tests/unit/test_strategy_versioning.py
@@ -1,0 +1,238 @@
+"""Tests for strategy versioning and fingerprinting (#2519).
+
+Verifies:
+- All registered strategies and bidding policies have VERSION > "0.0.0"
+- fingerprint() returns deterministic 8-char hex strings
+- Different configurations produce different fingerprints
+- collect_versions() produces the expected schema
+- compare_versions() detects adds, removes, version changes, config changes
+"""
+
+import re
+
+import pytest
+
+from bid_euchre.experiments.config import (
+    BIDDING_POLICY_REGISTRY,
+    PLAY_STRATEGY_REGISTRY,
+)
+from bid_euchre.strategy import (
+    AlwaysHighestLegalStrategy,
+    AlwaysLowestLegalStrategy,
+    BasicStrategy,
+    GluttonIsolatedStrategy,
+    GluttonStrategy,
+    GreedyStrategy,
+    RandomLegalStrategy,
+)
+from bid_euchre.strategy.base import Strategy
+from bid_euchre.strategy.bidding import (
+    AlwaysPassBidder,
+    BiddingPolicy,
+    StrictHellRaiser,
+)
+from bid_euchre.strategy.versioning import collect_versions, compare_versions
+
+# ── Item 3: VERSION constants ──────────────────────────────────────────
+
+
+class TestVersionConstants:
+    """Every registered strategy and bidding policy has a non-default VERSION."""
+
+    def test_strategy_base_has_version(self):
+        assert hasattr(Strategy, "VERSION")
+        assert Strategy.VERSION == "0.0.0"
+
+    def test_bidding_policy_base_has_version(self):
+        assert hasattr(BiddingPolicy, "VERSION")
+        assert BiddingPolicy.VERSION == "0.0.0"
+
+    @pytest.mark.parametrize(
+        "cls",
+        [
+            BasicStrategy,
+            RandomLegalStrategy,
+            AlwaysLowestLegalStrategy,
+            AlwaysHighestLegalStrategy,
+            GreedyStrategy,
+            GluttonStrategy,
+            GluttonIsolatedStrategy,
+        ],
+    )
+    def test_play_strategy_version_set(self, cls):
+        """Play strategies must have VERSION > '0.0.0'."""
+        assert hasattr(cls, "VERSION")
+        assert cls.VERSION != "0.0.0", f"{cls.__name__}.VERSION is still default"
+        # Validate semver format (relaxed: MAJOR.MINOR.PATCH)
+        assert re.match(
+            r"^\d+\.\d+\.\d+$", cls.VERSION
+        ), f"{cls.__name__}.VERSION = {cls.VERSION!r} is not valid semver"
+
+    @pytest.mark.parametrize(
+        "name,cls",
+        [
+            (name, cls)
+            for name, cls in PLAY_STRATEGY_REGISTRY.items()
+            # ArtifactGreedyStrategy needs artifact_path
+            if name != "ArtifactGreedyStrategy"
+        ],
+    )
+    def test_all_registered_play_strategies_versioned(self, name, cls):
+        """Every class in PLAY_STRATEGY_REGISTRY must have VERSION set."""
+        assert hasattr(cls, "VERSION"), f"{name} missing VERSION"
+        assert cls.VERSION != "0.0.0", f"{name}.VERSION is still default '0.0.0'"
+
+    @pytest.mark.parametrize(
+        "name,cls",
+        list(BIDDING_POLICY_REGISTRY.items()),
+    )
+    def test_all_registered_bidding_policies_versioned(self, name, cls):
+        """Every class in BIDDING_POLICY_REGISTRY must have VERSION set."""
+        assert hasattr(cls, "VERSION"), f"{name} missing VERSION"
+        assert cls.VERSION != "0.0.0", f"{name}.VERSION is still default '0.0.0'"
+
+    def test_glutton_shares_module_version(self):
+        """GluttonStrategy and GluttonIsolatedStrategy share the same VERSION."""
+        assert GluttonStrategy.VERSION == GluttonIsolatedStrategy.VERSION
+
+
+# ── Item 4: fingerprint() method ───────────────────────────────────────
+
+
+class TestFingerprint:
+    """fingerprint() returns deterministic, distinguishing hex digests."""
+
+    def test_strategy_fingerprint_format(self):
+        s = BasicStrategy(name="test")
+        fp = s.fingerprint()
+        assert isinstance(fp, str)
+        assert len(fp) == 8
+        assert re.match(r"^[0-9a-f]{8}$", fp), f"Not hex: {fp}"
+
+    def test_bidding_policy_fingerprint_format(self):
+        b = AlwaysPassBidder(name="test")
+        fp = b.fingerprint()
+        assert isinstance(fp, str)
+        assert len(fp) == 8
+        assert re.match(r"^[0-9a-f]{8}$", fp), f"Not hex: {fp}"
+
+    def test_fingerprint_deterministic(self):
+        s1 = GluttonStrategy(name="g1")
+        s2 = GluttonStrategy(name="g1")
+        assert s1.fingerprint() == s2.fingerprint()
+
+    def test_fingerprint_differs_by_name(self):
+        s1 = GluttonStrategy(name="g1")
+        s2 = GluttonStrategy(name="g2")
+        assert s1.fingerprint() != s2.fingerprint()
+
+    def test_fingerprint_differs_by_class(self):
+        s1 = BasicStrategy(name="test")
+        s2 = GreedyStrategy(name="test")
+        assert s1.fingerprint() != s2.fingerprint()
+
+    def test_glutton_fingerprint_differs_by_feature_flag(self):
+        """Toggling cash_winners_on_lead changes the fingerprint."""
+        s1 = GluttonStrategy(name="g", cash_winners_on_lead=False)
+        s2 = GluttonStrategy(name="g", cash_winners_on_lead=True)
+        assert s1.fingerprint() != s2.fingerprint()
+
+    def test_isolated_fingerprint_differs_by_flags(self):
+        """Toggling smart_leads changes the GluttonIsolated fingerprint."""
+        s1 = GluttonIsolatedStrategy(name="iso", smart_leads=False)
+        s2 = GluttonIsolatedStrategy(name="iso", smart_leads=True)
+        assert s1.fingerprint() != s2.fingerprint()
+
+    def test_bidding_fingerprint_deterministic(self):
+        b1 = StrictHellRaiser(name="sh1")
+        b2 = StrictHellRaiser(name="sh1")
+        assert b1.fingerprint() == b2.fingerprint()
+
+
+# ── Item 5: collect_versions() ─────────────────────────────────────────
+
+
+class TestCollectVersions:
+    """collect_versions() returns the expected dict schema."""
+
+    def test_basic_schema(self):
+        strategies = [GluttonStrategy(name="g1")]
+        policies = [AlwaysPassBidder(name="ap")]
+        result = collect_versions(strategies, policies)
+
+        assert "play_strategies" in result
+        assert "bidding_policies" in result
+        assert len(result["play_strategies"]) == 1
+        assert len(result["bidding_policies"]) == 1
+
+        ps = result["play_strategies"][0]
+        assert ps["name"] == "g1"
+        assert ps["class"] == "GluttonStrategy"
+        assert ps["version"] == GluttonStrategy.VERSION
+        assert len(ps["fingerprint"]) == 8
+
+        bp = result["bidding_policies"][0]
+        assert bp["name"] == "ap"
+        assert bp["class"] == "AlwaysPassBidder"
+        assert bp["version"] == AlwaysPassBidder.VERSION
+        assert len(bp["fingerprint"]) == 8
+
+    def test_empty_lists(self):
+        result = collect_versions([], [])
+        assert result["play_strategies"] == []
+        assert result["bidding_policies"] == []
+
+
+# ── Item 6: compare_versions() ────────────────────────────────────────
+
+
+class TestCompareVersions:
+    """compare_versions() detects adds, removes, and changes."""
+
+    def test_no_diff_on_identical(self):
+        v = collect_versions(
+            [GluttonStrategy(name="g")],
+            [AlwaysPassBidder(name="ap")],
+        )
+        assert compare_versions(v, v) == []
+
+    def test_added_strategy(self):
+        old = collect_versions([], [])
+        new = collect_versions([BasicStrategy(name="b")], [])
+        diffs = compare_versions(old, new)
+        assert len(diffs) == 1
+        assert diffs[0]["change"] == "added"
+        assert diffs[0]["name"] == "b"
+        assert diffs[0]["category"] == "play_strategies"
+
+    def test_removed_policy(self):
+        old = collect_versions([], [AlwaysPassBidder(name="ap")])
+        new = collect_versions([], [])
+        diffs = compare_versions(old, new)
+        assert len(diffs) == 1
+        assert diffs[0]["change"] == "removed"
+        assert diffs[0]["name"] == "ap"
+
+    def test_config_changed(self):
+        """Same version but different fingerprint = config_changed."""
+        old = collect_versions(
+            [GluttonStrategy(name="g", cash_winners_on_lead=False)], []
+        )
+        new = collect_versions(
+            [GluttonStrategy(name="g", cash_winners_on_lead=True)], []
+        )
+        diffs = compare_versions(old, new)
+        assert len(diffs) == 1
+        assert diffs[0]["change"] == "config_changed"
+        assert diffs[0]["old_fingerprint"] != diffs[0]["new_fingerprint"]
+
+    def test_version_changed(self):
+        """Simulate a version bump by patching the version dict."""
+        old = collect_versions([BasicStrategy(name="b")], [])
+        new = collect_versions([BasicStrategy(name="b")], [])
+        # Manually change the version in the new dict to simulate a bump
+        new["play_strategies"][0]["version"] = "2.0.0"
+        new["play_strategies"][0]["fingerprint"] = "deadbeef"
+        diffs = compare_versions(old, new)
+        assert len(diffs) == 1
+        assert diffs[0]["change"] == "version_changed"


### PR DESCRIPTION
## Summary

- Add `VERSION` class attributes to all registered play strategies and bidding policies (items 3 from #2519)
- Add `fingerprint()` method to `Strategy` base and `BiddingPolicy` base — returns 8-char hex digest from class name, version, and config (item 4)
- Log `strategy_versions` dict in experiment `meta.json` via `collect_versions()` (item 5)
- Add `compare_versions()` utility for detecting version/config drift between runs (item 6)

## Why

Strategy versioning is a pre-Cash-A blocker (#2519). Without version tracking, hosted match data and experiment runs lack cohort metadata, making it impossible to identify which AI behavior produced a given result.

## Changes

| File | Change |
|------|--------|
| `src/bid_euchre/strategy/base.py` | Add `VERSION = "0.0.0"` default + `fingerprint()` to `Strategy` |
| `src/bid_euchre/strategy/baselines.py` | Add `BASELINES_VERSION = "1.0.0"` + `VERSION` on all 4 baseline classes |
| `src/bid_euchre/strategy/glutton.py` | Add `VERSION = "1.0.0"` to `GreedyStrategy`, `fingerprint()` overrides on Glutton/Isolated |
| `src/bid_euchre/strategy/bidding.py` | Add `HEURISTIC_BIDDER_VERSION`/`ARTIFACT_BIDDER_VERSION` + `VERSION`/`fingerprint()` on `BiddingPolicy` base + all 13 registered subclasses |
| `src/bid_euchre/strategy/versioning.py` | New module: `collect_versions()` and `compare_versions()` |
| `src/bid_euchre/strategy/__init__.py` | Export `collect_versions`, `compare_versions` |
| `experiments/run_experiment.py` | Add `strategy_versions` key to `meta.json` output |
| `tests/unit/test_strategy_versioning.py` | 45 tests covering all 4 items |

## Repro / Validation

```bash
# Unit tests (Tier 1)
uv run python -m pytest tests/unit/test_strategy_versioning.py -v  # 45 passed

# Full validation (Tier 2)
make check-gated  # ✓ All checks passed
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: feat/strategy-versioning-2519
```

Refs #2519

🤖 Generated with [Claude Code](https://claude.com/claude-code)