### PR TITLE
fix(convention): expose greedy package alias and fail on auction overshoot

### DIFF
--- a/src/bid_euchre/strategy/__init__.py
+++ b/src/bid_euchre/strategy/__init__.py
@@ -58,8 +58,9 @@ from .glutton import (
 
 # Backward-compat shim: preserve old bid_euchre.strategy.greedy module path
 # after rename to glutton.py (PR #2604). External code and configs referencing
-# "greedy" will continue to work via sys.modules alias.
+# "greedy" will continue to work via sys.modules alias + package attribute.
 sys.modules[__name__ + ".greedy"] = sys.modules[__name__ + ".glutton"]
+greedy = sys.modules[__name__ + ".glutton"]  # expose as package attribute (#2611)
 
 # Versioning utilities
 from .versioning import collect_versions, compare_versions

--- a/tests/browser/test_mobile.py
+++ b/tests/browser/test_mobile.py
@@ -280,40 +280,39 @@ def test_auction_log_all_bidders_visible_mobile(
             f"The test must reach a four-bidder state before asserting overflow (#2594)."
         )
 
-        # Overflow and scroll assertions only apply during auction phase.
-        # After _advance_to_four_bidders the game may have transitioned to
-        # trick_play, which repositions the action-rail below the score bar
-        # (different layout).  Detect auction phase by the absence of
-        # #trick-area — only rendered when phase != "auction" (#2601, #2606).
-        in_auction = mobile_page.locator("#trick-area").count() == 0
+        # The helper must not overshoot the auction phase — if it does,
+        # the layout assertions below are meaningless (#2612).
+        assert mobile_page.locator("#trick-area").count() == 0, (
+            "Helper _advance_to_four_bidders overshot the auction phase — "
+            "game transitioned to trick_play before auction layout could be "
+            "verified (#2612)."
+        )
 
         # The list container should NOT be scrollable during auction
-        if in_auction:
-            list_el = mobile_page.locator(".action-rail__list")
-            if list_el.count() > 0:
-                scroll_height = list_el.evaluate("el => el.scrollHeight")
-                client_height = list_el.evaluate("el => el.clientHeight")
-                assert scroll_height <= client_height + 2, (
-                    f"Auction log list overflows during auction phase: "
-                    f"scrollHeight={scroll_height}px, clientHeight={client_height}px. "
-                    f"All {item_count} bidder rows should be visible without scrolling (#2591)."
-                )
+        list_el = mobile_page.locator(".action-rail__list")
+        if list_el.count() > 0:
+            scroll_height = list_el.evaluate("el => el.scrollHeight")
+            client_height = list_el.evaluate("el => el.clientHeight")
+            assert scroll_height <= client_height + 2, (
+                f"Auction log list overflows during auction phase: "
+                f"scrollHeight={scroll_height}px, clientHeight={client_height}px. "
+                f"All {item_count} bidder rows should be visible without scrolling (#2591)."
+            )
 
-        # Verify each visible item is within the viewport (auction layout only)
-        if in_auction:
-            viewport_height = MOBILE_VIEWPORT["height"]
-            for i in range(item_count):
-                item = items.nth(i)
-                if not item.is_visible():
-                    continue
-                box = item.bounding_box()
-                if box is None:
-                    continue
-                assert box["y"] + box["height"] <= viewport_height + 5, (
-                    f"Auction log item {i} overflows viewport bottom: "
-                    f"y={box['y']:.0f} + h={box['height']:.0f} = "
-                    f"{box['y'] + box['height']:.0f}px > {viewport_height}px (#2591)"
-                )
+        # Verify each visible item is within the viewport
+        viewport_height = MOBILE_VIEWPORT["height"]
+        for i in range(item_count):
+            item = items.nth(i)
+            if not item.is_visible():
+                continue
+            box = item.bounding_box()
+            if box is None:
+                continue
+            assert box["y"] + box["height"] <= viewport_height + 5, (
+                f"Auction log item {i} overflows viewport bottom: "
+                f"y={box['y']:.0f} + h={box['height']:.0f} = "
+                f"{box['y'] + box['height']:.0f}px > {viewport_height}px (#2591)"
+            )
 
     finally:
         context.close()
@@ -371,22 +370,24 @@ def test_auction_log_all_bidders_visible_mobile_big_text(
             item_count >= 4
         ), f"Expected ≥4 auction log items but found {item_count} (#2594)."
 
-        # Scroll assertion only applies during auction phase — after
-        # _advance_to_four_bidders the game may have transitioned to
-        # trick_play which repositions the action-rail (#2601, #2606).
-        in_auction = mobile_page.locator("#trick-area").count() == 0
+        # The helper must not overshoot the auction phase — if it does,
+        # the layout assertions below are meaningless (#2612).
+        assert mobile_page.locator("#trick-area").count() == 0, (
+            "Helper _advance_to_four_bidders overshot the auction phase — "
+            "game transitioned to trick_play before auction layout could be "
+            "verified (#2612)."
+        )
 
         # Check the list container is NOT scrollable (big text mode)
-        if in_auction:
-            list_el = mobile_page.locator(".action-rail__list")
-            if list_el.count() > 0:
-                scroll_height = list_el.evaluate("el => el.scrollHeight")
-                client_height = list_el.evaluate("el => el.clientHeight")
-                assert scroll_height <= client_height + 2, (
-                    f"Auction log overflows in big text mode: "
-                    f"scrollHeight={scroll_height}px, clientHeight={client_height}px. "
-                    f"All bidder rows should be visible without scrolling (#2591)."
-                )
+        list_el = mobile_page.locator(".action-rail__list")
+        if list_el.count() > 0:
+            scroll_height = list_el.evaluate("el => el.scrollHeight")
+            client_height = list_el.evaluate("el => el.clientHeight")
+            assert scroll_height <= client_height + 2, (
+                f"Auction log overflows in big text mode: "
+                f"scrollHeight={scroll_height}px, clientHeight={client_height}px. "
+                f"All bidder rows should be visible without scrolling (#2591)."
+            )
 
     finally:
         context.close()


### PR DESCRIPTION
## Plan
N/A — convention follow-ups from review coordinator.

## Summary
- Expose `greedy` as a package-level attribute on `bid_euchre.strategy` so attribute access (`strategy.greedy`) works alongside the sys.modules import path shim
- Replace soft `if in_auction:` guards with hard assertions that fail when `_advance_to_four_bidders` overshoots past the auction phase

## Why
Post-merge review findings from PRs #2608 and #2609. The greedy module alias only worked via `import` but not via attribute access. The auction overshoot guard silently skipped assertions instead of failing.

## Repro / Validation
**Command(s) run:**
```bash
make check-gated
uv run python -c "import bid_euchre.strategy as s; assert hasattr(s, 'greedy'); print(s.greedy)"
```

## Test Criteria
- **Pass condition:** `hasattr(bid_euchre.strategy, 'greedy')` returns `True` and the module is the glutton module
- **Verification command:** `uv run python -c "import bid_euchre.strategy as s; assert hasattr(s, 'greedy'); assert s.greedy is s.glutton; print('OK')"`
- **Expected result:** Prints `OK`

## Tests
- [x] `make check-gated` — all checks pass
- [x] `uv run python -m pytest tests/unit/test_greedy.py` — 28 passed

## Worktree Proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: fix/convention-followups-2611-2612
```

Refs #2611, Refs #2612