### PR TITLE
feat(web): log glutton counterfactual alongside human card plays

### DIFF
--- a/tests/unit/hosted_play/test_export.py
+++ b/tests/unit/hosted_play/test_export.py
@@ -21,6 +21,7 @@ from tests.unit.hosted_play.conftest import (
     create_test_player,
 )
 from web.export import (
+    OPTIONAL_FIELDS,
     REQUIRED_FIELDS,
     SCHEMA_VERSION,
     decision_to_jsonl,
@@ -48,14 +49,14 @@ class TestSchemaCompliance:
         assert not missing, f"Missing required fields: {missing}"
 
     def test_no_extra_fields(self, db_session):
-        """Output should contain exactly the required fields (no extras)."""
+        """Output should contain exactly required + known optional fields."""
         player = create_test_player(db_session)
         match = create_test_match(db_session, player_id=player.id)
         hand = create_test_hand(db_session, match)
         decision = create_test_decision(db_session, match, hand)
 
         result = decision_to_jsonl(decision, match, hand)
-        extra = set(result.keys()) - REQUIRED_FIELDS
+        extra = set(result.keys()) - REQUIRED_FIELDS - OPTIONAL_FIELDS
         assert not extra, f"Unexpected extra fields: {extra}"
 
     def test_schema_version_is_integer(self, db_session):
@@ -1098,3 +1099,48 @@ class TestValidateReplay:
         assert any(
             "not in dealt hand" in e for e in errors
         ), f"Three copies should be caught, got: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# Glutton counterfactual export tests
+# ---------------------------------------------------------------------------
+
+
+class TestGluttonCounterfactualExport:
+    """Verify glutton_action appears in export when set on Decision rows."""
+
+    def test_glutton_action_included_when_present(self, db_session):
+        """glutton_action field appears in export for decisions that have it."""
+        player = create_test_player(db_session)
+        match = create_test_match(db_session, player_id=player.id)
+        hand = create_test_hand(db_session, match)
+        decision = create_test_decision(
+            db_session,
+            match,
+            hand,
+            phase="play",
+            actor_type="human",
+            decision_source="human",
+            glutton_action_json=json.dumps(3),
+        )
+
+        result = decision_to_jsonl(decision, match, hand)
+        assert "glutton_action" in result
+        assert result["glutton_action"] == 3
+
+    def test_glutton_action_absent_when_null(self, db_session):
+        """glutton_action field is omitted for decisions without it."""
+        player = create_test_player(db_session)
+        match = create_test_match(db_session, player_id=player.id)
+        hand = create_test_hand(db_session, match)
+        decision = create_test_decision(
+            db_session,
+            match,
+            hand,
+            phase="bid",
+            actor_type="human",
+            decision_source="human",
+        )
+
+        result = decision_to_jsonl(decision, match, hand)
+        assert "glutton_action" not in result

--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -1054,6 +1054,142 @@ class TestDecisionLogging:
 
 
 # ---------------------------------------------------------------------------
+# Glutton counterfactual logging (#2468)
+# ---------------------------------------------------------------------------
+
+
+class TestGluttonCounterfactual:
+    """Verify glutton counterfactual is logged alongside human play decisions."""
+
+    def test_human_play_decision_has_glutton_action(self, client, app):
+        """Human play-phase decisions include a glutton_action_json value."""
+        link_uuid = _setup_game(client)
+
+        # Navigate to trick play and play one card
+        for _ in range(20):
+            advance_pending_reveals(client, app, link_uuid)
+            result = get_match_state(app, link_uuid)
+            assert result is not None
+            state, _, session = result
+            session.close()
+
+            hand = state.current_hand
+            if hand is None:
+                break
+
+            if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+                client.post(
+                    f"/play/{link_uuid}/bid",
+                    data={
+                        "turn_number": hand.turn_number,
+                        "bid_n": 0,
+                        "bid_contract": "",
+                    },
+                )
+            elif hand.phase == "trick_play" and hand.current_seat == HUMAN_SEAT:
+                ai_manager = app.state.ai_manager
+                info = ai_manager.get_model_info(state.ai_model)
+                engine = MatchEngine(
+                    bidding_policy=info.bidding_policy,
+                    play_strategy=info.play_strategy,
+                )
+                legal = engine.get_legal_plays(state)
+                client.post(
+                    f"/play/{link_uuid}/play-card",
+                    data={
+                        "turn_number": hand.turn_number,
+                        "card_index": legal[0],
+                    },
+                )
+                break  # played at least one card
+            else:
+                break
+
+        # Query human play decisions
+        session = app.state.session_factory()
+        human_play_decisions = (
+            session.query(Decision)
+            .filter(Decision.actor_type == "human", Decision.phase == "play")
+            .all()
+        )
+        assert (
+            len(human_play_decisions) > 0
+        ), "Expected at least one human play decision"
+
+        for d in human_play_decisions:
+            assert (
+                d.glutton_action_json is not None
+            ), f"Human play decision turn={d.turn_number} missing glutton_action_json"
+            glutton_choice = json.loads(d.glutton_action_json)
+            assert isinstance(
+                glutton_choice, int
+            ), f"glutton_action should be int, got {type(glutton_choice)}"
+
+            # Verify it's a legal play
+            legal = json.loads(d.legal_actions_json)
+            assert (
+                glutton_choice in legal
+            ), f"glutton_action {glutton_choice} not in legal_actions {legal}"
+
+        session.close()
+
+    def test_ai_decisions_no_glutton_action(self, client, app):
+        """AI decisions should NOT have glutton_action_json set."""
+        link_uuid = _setup_game(client)
+
+        # Play a few turns
+        for _ in range(20):
+            advance_pending_reveals(client, app, link_uuid)
+            result = get_match_state(app, link_uuid)
+            assert result is not None
+            state, _, session = result
+            session.close()
+
+            hand = state.current_hand
+            if hand is None:
+                break
+
+            if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+                client.post(
+                    f"/play/{link_uuid}/bid",
+                    data={
+                        "turn_number": hand.turn_number,
+                        "bid_n": 0,
+                        "bid_contract": "",
+                    },
+                )
+            elif hand.phase == "trick_play" and hand.current_seat == HUMAN_SEAT:
+                ai_manager = app.state.ai_manager
+                info = ai_manager.get_model_info(state.ai_model)
+                engine = MatchEngine(
+                    bidding_policy=info.bidding_policy,
+                    play_strategy=info.play_strategy,
+                )
+                legal = engine.get_legal_plays(state)
+                client.post(
+                    f"/play/{link_uuid}/play-card",
+                    data={
+                        "turn_number": hand.turn_number,
+                        "card_index": legal[0],
+                    },
+                )
+                break
+            else:
+                break
+
+        # Query AI decisions — they should NOT have glutton counterfactual
+        session = app.state.session_factory()
+        ai_decisions = session.query(Decision).filter(Decision.actor_type == "ai").all()
+
+        for d in ai_decisions:
+            assert (
+                d.glutton_action_json is None
+            ), f"AI decision turn={d.turn_number} should not have glutton_action_json"
+
+        session.close()
+
+
+# ---------------------------------------------------------------------------
 # Landing page
 # ---------------------------------------------------------------------------
 

--- a/web/db.py
+++ b/web/db.py
@@ -235,6 +235,9 @@ class Decision(Base):
     legal_actions_json = Column(Text, nullable=False)
     chosen_action_json = Column(Text, nullable=False)
     game_state_json = Column(Text, nullable=False)
+    # What the glutton strategy would have played in the same situation.
+    # Only populated for human play-phase decisions (counterfactual logging).
+    glutton_action_json = Column(Text, nullable=True)
     decision_time_ms = Column(
         Integer,
         CheckConstraint("decision_time_ms IS NULL OR decision_time_ms >= 0"),

--- a/web/export.py
+++ b/web/export.py
@@ -55,6 +55,14 @@ REQUIRED_FIELDS: frozenset[str] = frozenset(
     }
 )
 
+# Fields that appear only on certain decision types (e.g. glutton_action
+# on human play decisions).  Tests should accept these as valid extras.
+OPTIONAL_FIELDS: frozenset[str] = frozenset(
+    {
+        "glutton_action",
+    }
+)
+
 
 # ---------------------------------------------------------------------------
 # Export function
@@ -100,7 +108,7 @@ def decision_to_jsonl(
         ts = ts.replace(tzinfo=timezone.utc)
     timestamp = ts.isoformat() if ts is not None else None
 
-    return {
+    result = {
         "schema_version": SCHEMA_VERSION,
         "event": EVENT_TYPE,
         "match_uuid": match_row.match_uuid,
@@ -120,6 +128,12 @@ def decision_to_jsonl(
         "decision_time_ms": decision_row.decision_time_ms,
         "timestamp": timestamp,
     }
+
+    # Include glutton counterfactual when present (human play decisions).
+    if decision_row.glutton_action_json is not None:
+        result["glutton_action"] = json.loads(decision_row.glutton_action_json)
+
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/web/routes.py
+++ b/web/routes.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 from bid_euchre.core.rules import trick_winner
 from bid_euchre.hosted_play.engine import HUMAN_SEAT, MatchEngine, sort_hand_for_display
 from bid_euchre.strategy.bidding import BidAction
+from bid_euchre.strategy.glutton import GluttonStrategy
 
 from .ai_manager import AIManager
 from .cleanup import abandon_player_active_matches
@@ -205,6 +206,32 @@ def _update_match_row(match_row: Match, state) -> None:
         match_row.completed_at = datetime.now(timezone.utc)
 
 
+def _compute_glutton_counterfactual(hand) -> int | None:
+    """Return the card index a fresh GluttonStrategy would play, or None on error.
+
+    Uses a stateless instance so the engine's shared strategy is unaffected.
+    Returns ``None`` if the hand state is unsuitable (missing contract, trick,
+    etc.) so that callers can log without crashing the request.
+    """
+    try:
+        if hand.current_trick is None or hand.contract_type is None:
+            return None
+        glutton = GluttonStrategy(cash_winners_on_lead=True)
+        return glutton.choose_card(
+            hand.hands[HUMAN_SEAT],
+            hand.current_trick.plays,
+            hand.contract_type,
+            hand.trump,
+            HUMAN_SEAT,
+        )
+    except Exception:
+        logger.debug(
+            "glutton counterfactual failed; skipping",
+            exc_info=True,
+        )
+        return None
+
+
 def _log_decision(
     session,
     match_row: Match,
@@ -218,6 +245,7 @@ def _log_decision(
     chosen_action: Any,
     game_state: Any,
     decision_time_ms: int | None = None,
+    glutton_action: Any | None = None,
 ) -> None:
     """Insert a decision row (idempotent — skips if turn already logged)."""
     exists = (
@@ -239,6 +267,9 @@ def _log_decision(
         chosen_action_json=json.dumps(chosen_action),
         game_state_json=json.dumps(game_state),
         decision_time_ms=decision_time_ms,
+        glutton_action_json=json.dumps(glutton_action)
+        if glutton_action is not None
+        else None,
     )
     session.add(decision)
 
@@ -1734,6 +1765,12 @@ async def submit_card(
         # Ensure hand row exists (keyed by deal_id for redeal-safe uniqueness)
         hand_row = _ensure_hand_row(session, match_row, hand, hand.deal_id)
 
+        # Compute glutton counterfactual — what would the glutton strategy
+        # play in the same position?  Uses a fresh instance to avoid
+        # contaminating the engine's shared strategy state.  Purely
+        # observational; does not affect gameplay.  (#2468)
+        glutton_choice = _compute_glutton_counterfactual(hand)
+
         # Log human decision
         _log_decision(
             session,
@@ -1747,6 +1784,7 @@ async def submit_card(
             legal_actions=legal_plays,
             chosen_action=card_index,
             game_state=engine.get_visible_state(state),
+            glutton_action=glutton_choice,
         )
 
         # Apply action — engine auto-advances AI and sets

--- a/web/schema.sql
+++ b/web/schema.sql
@@ -85,6 +85,7 @@ CREATE TABLE IF NOT EXISTS decisions (
     legal_actions_json TEXT NOT NULL,
     chosen_action_json TEXT NOT NULL,
     game_state_json TEXT NOT NULL,
+    glutton_action_json TEXT,
     decision_time_ms INTEGER CHECK (
         decision_time_ms IS NULL OR decision_time_ms >= 0
     ),


### PR DESCRIPTION
## Summary
- Log what GluttonStrategy would have played alongside each human card play decision
- Add `glutton_action_json` nullable column to the Decision table (DB model + reference schema)
- Include glutton counterfactual in JSONL export as an optional field when present
- Purely observational — does not affect gameplay

## Why
Creates a decision-diff dataset for tracking where human play diverges from bot strategy (#2468). This data enables identifying situations where humans consistently outperform or underperform the bot, and provides training data for future strategy improvements.

## Implementation Details
- `_compute_glutton_counterfactual(hand)` uses a fresh `GluttonStrategy(cash_winners_on_lead=True)` instance to avoid contaminating the engine's shared strategy state
- Returns `None` on any error (graceful degradation — never crashes the request)
- Only populated for human play-phase decisions; AI decisions and bid-phase decisions have `NULL`
- JSONL export includes `glutton_action` field only when non-null (backward compatible)

## Repro / Validation
```bash
# Run hosted_play tests including new glutton counterfactual tests
uv run python -m pytest tests/unit/hosted_play/ -x -q

# Run specific counterfactual tests
uv run python -m pytest tests/unit/hosted_play/test_routes.py -k TestGluttonCounterfactual -v

# Run export tests
uv run python -m pytest tests/unit/hosted_play/test_export.py -x -q

# Full validation (3 unrelated cpu_gate test failures pre-existing)
make check-gated
```

## Tests
- `TestGluttonCounterfactual::test_human_play_decision_has_glutton_action` — verifies counterfactual is logged, is an int, and is a legal play
- `TestGluttonCounterfactual::test_ai_decisions_no_glutton_action` — verifies AI decisions don't get counterfactual
- `TestGluttonCounterfactualExport::test_glutton_action_included_when_present` — verifies export includes field
- `TestGluttonCounterfactualExport::test_glutton_action_absent_when_null` — verifies export omits field when null
- Existing `test_no_extra_fields` updated to accept known optional fields

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
branch: feat/glutton-counterfactual
```

## Files changed
- `web/db.py` — Add `glutton_action_json` column to Decision model
- `web/schema.sql` — Add column to reference schema
- `web/routes.py` — Add `_compute_glutton_counterfactual()` helper, wire into play handler
- `web/export.py` — Include `glutton_action` in JSONL export, add `OPTIONAL_FIELDS`
- `tests/unit/hosted_play/test_routes.py` — Add `TestGluttonCounterfactual` class
- `tests/unit/hosted_play/test_export.py` — Add `TestGluttonCounterfactualExport` class

Refs #2468

🤖 Generated with [Claude Code](https://claude.com/claude-code)